### PR TITLE
release-20.1: sql: clarify 'SPANS ALL' is EXPLAIN output

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1351,7 +1351,7 @@ func Example_misc_table() {
 	//   render    |             |
 	//    └── scan |             |
 	//             | table       | t@primary
-	//             | spans       | ALL
+	//             | spans       | FULL SCAN
 	// (6 rows)
 }
 

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -455,14 +455,24 @@ func planToString(
 	return buf.String()
 }
 
+func getAttrForSpansAll(hardLimitSet bool) string {
+	if hardLimitSet {
+		return "LIMITED SCAN"
+	}
+	return "FULL SCAN"
+}
+
 // spans implements the planObserver interface.
 func (e *explainer) spans(
-	nodeName, fieldName string, index *sqlbase.IndexDescriptor, spans []roachpb.Span,
+	nodeName, fieldName string,
+	index *sqlbase.IndexDescriptor,
+	spans []roachpb.Span,
+	hardLimitSet bool,
 ) {
 	spanss := sqlbase.PrettySpans(index, spans, 2)
 	if spanss != "" {
 		if spanss == "-" {
-			spanss = "ALL"
+			spanss = getAttrForSpansAll(hardLimitSet)
 		}
 		e.attr(nodeName, fieldName, spanss)
 	}

--- a/pkg/sql/explain_tree.go
+++ b/pkg/sql/explain_tree.go
@@ -69,7 +69,7 @@ func planToTree(ctx context.Context, top *planTop) *roachpb.ExplainTreePlanNode 
 				Value: tree.AsStringWithFlags(expr, sampledLogicalPlanFmtFlags),
 			})
 		},
-		spans: func(nodeName, fieldName string, index *sqlbase.IndexDescriptor, spans []roachpb.Span) {
+		spans: func(nodeName, fieldName string, index *sqlbase.IndexDescriptor, spans []roachpb.Span, hardLimitSet bool) {
 			// TODO(jordan): it's expensive to serialize long span
 			// strings. It's unfortunate that we're still calling
 			// PrettySpans, just to check to see whether the output is - or
@@ -78,7 +78,7 @@ func planToTree(ctx context.Context, top *planTop) *roachpb.ExplainTreePlanNode 
 			spanss := sqlbase.PrettySpans(index, spans, 2)
 			if spanss != "" {
 				if spanss == "-" {
-					spanss = "ALL"
+					spanss = getAttrForSpansAll(hardLimitSet)
 				} else {
 					// Spans contain literal values from the query and thus
 					// cannot be spelled out in the collected plan.

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -222,7 +222,7 @@ SELECT * FROM [EXPLAIN SELECT * FROM child@i] OFFSET 2
 ----
 scan  ·      ·
 ·     table  child@i
-·     spans  ALL
+·     spans  FULL SCAN
 
 query IIII
 SELECT * FROM child@i
@@ -385,7 +385,7 @@ index-join  ·            ·
  │          key columns  y
  └── scan   ·            ·
 ·           table        t@i1
-·           spans        ALL
+·           spans        FULL SCAN
 
 query IIIIT
 SELECT * FROM t@i1
@@ -400,7 +400,7 @@ index-join  ·            ·
  │          key columns  y
  └── scan   ·            ·
 ·           table        t@i2
-·           spans        ALL
+·           spans        FULL SCAN
 
 query IIIIT
 SELECT * FROM t@i2
@@ -415,7 +415,7 @@ index-join  ·            ·
  │          key columns  y
  └── scan   ·            ·
 ·           table        t@i3
-·           spans        ALL
+·           spans        FULL SCAN
 
 query IIIIT
 SELECT * FROM t@i3
@@ -430,7 +430,7 @@ index-join  ·            ·
  │          key columns  y
  └── scan   ·            ·
 ·           table        t@i4
-·           spans        ALL
+·           spans        FULL SCAN
 
 query IIIIT
 SELECT * FROM t@i4
@@ -445,7 +445,7 @@ index-join  ·            ·
  │          key columns  y
  └── scan   ·            ·
 ·           table        t@i5
-·           spans        ALL
+·           spans        FULL SCAN
 
 query IIIIT
 SELECT * FROM t@i5
@@ -460,7 +460,7 @@ index-join  ·            ·
  │          key columns  y
  └── scan   ·            ·
 ·           table        t@i7
-·           spans        ALL
+·           spans        FULL SCAN
 
 query IIIIT
 SELECT * FROM t@i5

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
@@ -25,7 +25,7 @@ group      ·            ·
  │         scalar       ·
  └── scan  ·            ·
 ·          table        small@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 0
@@ -42,7 +42,7 @@ group      ·            ·
  │         scalar       ·
  └── scan  ·            ·
 ·          table        small@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 1000
@@ -68,7 +68,7 @@ group      ·            ·
  │         scalar       ·
  └── scan  ·            ·
 ·          table        small@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 1
@@ -85,7 +85,7 @@ group      ·            ·
  │         scalar       ·
  └── scan  ·            ·
 ·          table        small@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 1000
@@ -114,7 +114,7 @@ group      ·            ·
  │         scalar       ·
  └── scan  ·            ·
 ·          table        large@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 1000000
@@ -131,4 +131,4 @@ group      ·            ·
  │         scalar       ·
  └── scan  ·            ·
 ·          table        large@primary
-·          spans        ALL
+·          spans        FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -33,7 +33,7 @@ group           ·             ·                   (min int, max int, count int
       │         render 3      ('\x01')[bytes]     ·                                                                                                                                                   ·
       └── scan  ·             ·                   ()                                                                                                                                                  ·
 ·               table         kv@primary          ·                                                                                                                                                   ·
-·               spans         ALL                 ·                                                                                                                                                   ·
+·               spans         FULL SCAN           ·                                                                                                                                                   ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT min(v), max(v), count(v), sum_int(1), avg(v), sum(v), stddev(v), variance(v), bool_and(v = 1), bool_and(v = 1), xor_agg(s::bytes) FROM kv
@@ -71,7 +71,7 @@ render               ·            ·                            (min int, max i
            │         render 3     (v)[int]                     ·                                                                                                                                                    ·
            └── scan  ·            ·                            (v int, s string)                                                                                                                                    ·
 ·                    table        kv@primary                   ·                                                                                                                                                    ·
-·                    spans        ALL                          ·                                                                                                                                                    ·
+·                    spans        FULL SCAN                    ·                                                                                                                                                    ·
 
 # Aggregate functions trigger aggregation and computation when there is no source.
 query TTTTT
@@ -125,7 +125,7 @@ render          ·            ·                  (count int, k int)       ·
       │         ordered      +k                 ·                        ·
       └── scan  ·            ·                  (k int)                  +k
 ·               table        kv@primary         ·                        ·
-·               spans        ALL                ·                        ·
+·               spans        FULL SCAN          ·                        ·
 
 # Selecting and grouping on a more complex expression works.
 query TTTTT
@@ -144,7 +144,7 @@ render               ·            ·                           (count int, r in
            │         render 0     ((k)[int] + (v)[int])[int]  ·                              ·
            └── scan  ·            ·                           (k int, v int)                 ·
 ·                    table        kv@primary                  ·                              ·
-·                    spans        ALL                         ·                              ·
+·                    spans        FULL SCAN                   ·                              ·
 
 # Selecting a more complex expression, made up of things which are each grouped, works.
 query TTTTT
@@ -163,7 +163,7 @@ render          ·            ·                                      (count int
       │         ordered      +k                                     ·                                          ·
       └── scan  ·            ·                                      (k int, v int)                             +k
 ·               table        kv@primary                             ·                                          ·
-·               spans        ALL                                    ·                                          ·
+·               spans        FULL SCAN                              ·                                          ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT count(k) FROM kv
@@ -175,7 +175,7 @@ group      ·            ·           (count int)  ·
  │         scalar       ·           ·            ·
  └── scan  ·            ·           (k int)      ·
 ·          table        kv@primary  ·            ·
-·          spans        ALL         ·            ·
+·          spans        FULL SCAN   ·            ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT count(k), sum(k), max(k) FROM kv
@@ -189,7 +189,7 @@ group      ·            ·           (count int, sum decimal, max int)  ·
  │         scalar       ·           ·                                  ·
  └── scan  ·            ·           (k int)                            ·
 ·          table        kv@primary  ·                                  ·
-·          spans        ALL         ·                                  ·
+·          spans        FULL SCAN   ·                                  ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(v), count(DISTINCT v), sum(v), sum(DISTINCT v), min(v), min(DISTINCT v) FROM kv
@@ -206,7 +206,7 @@ group      ·            ·                  (count, count, sum, sum, min, min) 
  │         scalar       ·                  ·                                   ·
  └── scan  ·            ·                  (v)                                 ·
 ·          table        kv@primary         ·                                   ·
-·          spans        ALL                ·                                   ·
+·          spans        FULL SCAN          ·                                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(DISTINCT a.*) FROM kv a, kv b
@@ -222,10 +222,10 @@ group                 ·            ·                             (count)      
            │          type         cross                         ·             ·
            ├── scan   ·            ·                             (k, v, w, s)  ·
            │          table        kv@primary                    ·             ·
-           │          spans        ALL                           ·             ·
+           │          spans        FULL SCAN                     ·             ·
            └── scan   ·            ·                             ()            ·
 ·                     table        kv@primary                    ·             ·
-·                     spans        ALL                           ·             ·
+·                     spans        FULL SCAN                     ·             ·
 
 query TTT
 SELECT tree, field, description FROM [
@@ -244,10 +244,10 @@ render                ·            ·
            │          type         cross
            ├── scan   ·            ·
            │          table        kv@primary
-           │          spans        ALL
+           │          spans        FULL SCAN
            └── scan   ·            ·
 ·                     table        kv@primary
-·                     spans        ALL
+·                     spans        FULL SCAN
 
 query TTT
 SELECT tree, field, description FROM [
@@ -266,10 +266,10 @@ render                ·            ·
            │          type         cross
            ├── scan   ·            ·
            │          table        kv@primary
-           │          spans        ALL
+           │          spans        FULL SCAN
            └── scan   ·            ·
 ·                     table        kv@primary
-·                     spans        ALL
+·                     spans        FULL SCAN
 
 # A useful optimization: naked tuple expansion in GROUP BY clause.
 query TTT
@@ -289,10 +289,10 @@ render                ·            ·
            │          type         cross
            ├── scan   ·            ·
            │          table        kv@primary
-           │          spans        ALL
+           │          spans        FULL SCAN
            └── scan   ·            ·
 ·                     table        kv@primary
-·                     spans        ALL
+·                     spans        FULL SCAN
 
 # Show reuse of renders expression inside an expansion.
 query TTT
@@ -310,10 +310,10 @@ render                ·            ·
            │          type         cross
            ├── scan   ·            ·
            │          table        kv@primary
-           │          spans        ALL
+           │          spans        FULL SCAN
            └── scan   ·            ·
 ·                     table        kv@primary
-·                     spans        ALL
+·                     spans        FULL SCAN
 
 statement ok
 CREATE TABLE abc (
@@ -333,7 +333,7 @@ group      ·            ·                (min char)  ·
  │         scalar       ·                ·           ·
  └── scan  ·            ·                (a char)    ·
 ·          table        abc@primary      ·           ·
-·          spans        ALL              ·           ·
+·          spans        LIMITED SCAN     ·           ·
 ·          limit        1                ·           ·
 
 statement ok
@@ -361,7 +361,7 @@ group      ·            ·                (min int)  ·
  │         scalar       ·                ·          ·
  └── scan  ·            ·                (x int)    ·
 ·          table        xyz@xy           ·          ·
-·          spans        ALL              ·          ·
+·          spans        LIMITED SCAN     ·          ·
 ·          limit        1                ·          ·
 
 query TTTTT
@@ -387,7 +387,7 @@ group         ·            ·                (max int)  ·
  │            scalar       ·                ·          ·
  └── revscan  ·            ·                (x int)    ·
 ·             table        xyz@xy           ·          ·
-·             spans        ALL              ·          ·
+·             spans        LIMITED SCAN     ·          ·
 ·             limit        1                ·          ·
 
 query TTTTT
@@ -591,7 +591,7 @@ sort            ·            ·           (v int, count int)  +count
       │         group by     v           ·                   ·
       └── scan  ·            ·           (k int, v int)      ·
 ·               table        kv@primary  ·                   ·
-·               spans        ALL         ·                   ·
+·               spans        FULL SCAN   ·                   ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT v, count(*) FROM kv GROUP BY v ORDER BY count(*)
@@ -606,7 +606,7 @@ sort            ·            ·             (v int, count int)  +count
       │         group by     v             ·                   ·
       └── scan  ·            ·             (v int)             ·
 ·               table        kv@primary    ·                   ·
-·               spans        ALL           ·                   ·
+·               spans        FULL SCAN     ·                   ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT v, count(1) FROM kv GROUP BY v ORDER BY count(1)
@@ -624,7 +624,7 @@ sort                 ·            ·               (v int, count int)    +count
            │         render 1     (v)[int]        ·                     ·
            └── scan  ·            ·               (v int)               ·
 ·                    table        kv@primary      ·                     ·
-·                    spans        ALL             ·                     ·
+·                    spans        FULL SCAN       ·                     ·
 
 # Check that filters propagate through no-op aggregation.
 query TTTTT
@@ -641,7 +641,7 @@ group           ·            ·               (v, count)    ·
       │         render 1     v               ·             ·
       └── scan  ·            ·               (v)           ·
 ·               table        kv@primary      ·             ·
-·               spans        ALL             ·             ·
+·               spans        FULL SCAN       ·             ·
 ·               filter       v > 10          ·             ·
 
 # Verify that FILTER works.
@@ -673,7 +673,7 @@ render               ·            ·                                      (coun
            │         render 2     v                                      ·                      ·
            └── scan  ·            ·                                      (k, v)                 ·
 ·                    table        filter_test@primary                    ·                      ·
-·                    spans        ALL                                    ·                      ·
+·                    spans        FULL SCAN                              ·                      ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(*) FILTER (WHERE k > 5) FROM filter_test GROUP BY v
@@ -692,7 +692,7 @@ render               ·            ·                                      (coun
            │         render 2     v                                      ·                      ·
            └── scan  ·            ·                                      (k, v)                 ·
 ·                    table        filter_test@primary                    ·                      ·
-·                    spans        ALL                                    ·                      ·
+·                    spans        FULL SCAN                              ·                      ·
 
 # Tests with * inside GROUP BY.
 query TTTTT
@@ -704,7 +704,7 @@ render     ·            ·           (a int)  ·
  │         render 0     (1)[int]    ·        ·
  └── scan  ·            ·           ()       ·
 ·          table        kv@primary  ·        ·
-·          spans        ALL         ·        ·
+·          spans        FULL SCAN   ·        ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT sum(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
@@ -722,10 +722,10 @@ render                ·            ·                                 (sum deci
            │          pred         ((k)[int] >= (d)[decimal])[bool]  ·                     ·
            ├── scan   ·            ·                                 (k int)               ·
            │          table        kv@primary                        ·                     ·
-           │          spans        ALL                               ·                     ·
+           │          spans        FULL SCAN                         ·                     ·
            └── scan   ·            ·                                 (d decimal)           ·
 ·                     table        abc@primary                       ·                     ·
-·                     spans        ALL                               ·                     ·
+·                     spans        FULL SCAN                         ·                     ·
 
 # opt_test is used for tests around the single-row optimization for MIN/MAX.
 statement ok
@@ -779,7 +779,7 @@ group           ·            ·                           (min int)      ·
       │         render 0     ((v)[int] + (1)[int])[int]  ·              ·
       └── scan  ·            ·                           (v int)        ·
 ·               table        opt_test@primary            ·              ·
-·               spans        ALL                         ·              ·
+·               spans        FULL SCAN                   ·              ·
 
 # Verify that we don't use the optimization if there is a GROUP BY.
 query TTTTT
@@ -796,7 +796,7 @@ render          ·            ·                 (min int)         ·
       │         ordered      +k                ·                 ·
       └── scan  ·            ·                 (k int, v int)    +k
 ·               table        opt_test@primary  ·                 ·
-·               spans        ALL               ·                 ·
+·               spans        FULL SCAN         ·                 ·
 
 statement ok
 CREATE TABLE xy(x STRING, y STRING);
@@ -810,7 +810,7 @@ render     ·            ·                                        (r tuple{int,
  │         render 0     (((b)[int], (a)[int]))[tuple{int, int}]  ·                    ·
  └── scan  ·            ·                                        (a int, b int)       ·
 ·          table        ab@primary                               ·                    ·
-·          spans        ALL                                      ·                    ·
+·          spans        FULL SCAN                                ·                    ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT min(y), (b, a) r FROM ab, xy GROUP BY (x, (a, b))
@@ -830,10 +830,10 @@ render                ·            ·                                          
            │          type         cross                                               ·                                                ·
            ├── scan   ·            ·                                                   (a int, b int)                                   ·
            │          table        ab@primary                                          ·                                                ·
-           │          spans        ALL                                                 ·                                                ·
+           │          spans        FULL SCAN                                           ·                                                ·
            └── scan   ·            ·                                                   (x string, y string)                             ·
 ·                     table        xy@primary                                          ·                                                ·
-·                     spans        ALL                                                 ·                                                ·
+·                     spans        FULL SCAN                                           ·                                                ·
 
 # Test that ordering on GROUP BY columns is maintained.
 # TODO(radu): Derive GROUP BY ordering in physicalPropsBuilder.
@@ -966,7 +966,7 @@ render                    ·            ·                                      
                 │         render 1     (v)[int]                                   ·                         ·
                 └── scan  ·            ·                                          (v int, w int)            ·
 ·                         table        kv@primary                                 ·                         ·
-·                         spans        ALL                                        ·                         ·
+·                         spans        FULL SCAN                                  ·                         ·
 
 statement ok
 CREATE TABLE foo(a INT, b CHAR)
@@ -988,7 +988,7 @@ render               ·            ·            (m)             ·
            │         render 1     a            ·               ·
            └── scan  ·            ·            (a)             ·
 ·                    table        foo@primary  ·               ·
-·                    spans        ALL          ·               ·
+·                    spans        FULL SCAN    ·               ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2
@@ -1006,7 +1006,7 @@ render               ·            ·            (m)             ·
            │         render 1     a            ·               ·
            └── scan  ·            ·            (a, b)          ·
 ·                    table        foo@primary  ·               ·
-·                    spans        ALL          ·               ·
+·                    spans        FULL SCAN    ·               ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT array_agg(v) FROM (SELECT * FROM kv ORDER BY v)
@@ -1020,7 +1020,7 @@ group           ·            ·             (array_agg)  ·
       │         order        +v            ·            ·
       └── scan  ·            ·             (v)          ·
 ·               table        kv@primary    ·            ·
-·               spans        ALL           ·            ·
+·               spans        FULL SCAN     ·            ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY s
@@ -1033,7 +1033,7 @@ render          ·            ·           (k)     ·
       │         order        +s          ·       ·
       └── scan  ·            ·           (k, s)  ·
 ·               table        kv@primary  ·       ·
-·               spans        ALL         ·       ·
+·               spans        FULL SCAN   ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT concat_agg(s) FROM (SELECT s FROM kv ORDER BY k)
@@ -1045,7 +1045,7 @@ group      ·            ·              (concat_agg)  ·
  │         scalar       ·              ·             ·
  └── scan  ·            ·              (k, s)        +k
 ·          table        kv@primary     ·             ·
-·          spans        ALL            ·             ·
+·          spans        FULL SCAN      ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT array_agg(k) FROM (SELECT k FROM kv ORDER BY s)
@@ -1059,7 +1059,7 @@ group           ·            ·             (array_agg)  ·
       │         order        +s            ·            ·
       └── scan  ·            ·             (k, s)       ·
 ·               table        kv@primary    ·            ·
-·               spans        ALL           ·            ·
+·               spans        FULL SCAN     ·            ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT string_agg(s, ',') FROM (SELECT s FROM kv ORDER BY k)
@@ -1075,7 +1075,7 @@ group           ·            ·                       (string_agg)     ·
       │         render 2     s                       ·                ·
       └── scan  ·            ·                       (k, s)           +k
 ·               table        kv@primary              ·                ·
-·               spans        ALL                     ·                ·
+·               spans        FULL SCAN               ·                ·
 
 # Verify that we project away all input columns for count(*).
 query TTTTT
@@ -1092,10 +1092,10 @@ group                ·            ·             (count)  ·
            │         equality     (y) = (v)     ·        ·
            ├── scan  ·            ·             (y)      ·
            │         table        xyz@xy        ·        ·
-           │         spans        ALL           ·        ·
+           │         spans        FULL SCAN     ·        ·
            └── scan  ·            ·             (v)      ·
 ·                    table        kv@primary    ·        ·
-·                    spans        ALL           ·        ·
+·                    spans        FULL SCAN     ·        ·
 
 
 # Regression test for #31882: make sure we don't incorrectly advertise an
@@ -1116,7 +1116,7 @@ group      ·            ·             (u, v, s)  ·
  │         ordered      +u,+v         ·          ·
  └── scan  ·            ·             (u, v, w)  +u,+v,+w
 ·          table        uvw@uvw       ·          ·
-·          spans        ALL           ·          ·
+·          spans        FULL SCAN     ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT string_agg(s, ', ') FROM kv
@@ -1131,7 +1131,7 @@ group           ·            ·                       (string_agg)  ·
       │         render 1     s                       ·             ·
       └── scan  ·            ·                       (s)           ·
 ·               table        kv@primary              ·             ·
-·               spans        ALL                     ·             ·
+·               spans        FULL SCAN               ·             ·
 
 statement ok
 CREATE TABLE string_agg_test (
@@ -1165,7 +1165,7 @@ sort                 ·            ·                              (company_id, 
            │         render 2     employee                       ·                                ·
            └── scan  ·            ·                              (company_id, employee)           ·
 ·                    table        string_agg_test@primary        ·                                ·
-·                    spans        ALL                            ·                                ·
+·                    spans        FULL SCAN                      ·                                ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
@@ -1192,7 +1192,7 @@ sort                 ·            ·                             (company_id, s
            │         render 2     company_id                    ·                               ·
            └── scan  ·            ·                             (company_id, employee)          ·
 ·                    table        string_agg_test@primary       ·                               ·
-·                    spans        ALL                           ·                               ·
+·                    spans        FULL SCAN                     ·                               ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
@@ -1219,7 +1219,7 @@ sort                 ·            ·                              (company_id, 
            │         render 2     employee                       ·                                ·
            └── scan  ·            ·                              (company_id, employee)           ·
 ·                    table        string_agg_test@primary        ·                                ·
-·                    spans        ALL                            ·                                ·
+·                    spans        FULL SCAN                      ·                                ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
@@ -1246,4 +1246,4 @@ sort                 ·            ·                             (company_id, s
            │         render 2     company_id                    ·                               ·
            └── scan  ·            ·                             (company_id, employee)          ·
 ·                    table        string_agg_test@primary       ·                               ·
-·                    spans        ALL                           ·                               ·
+·                    spans        FULL SCAN                     ·                               ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/ddl
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ddl
@@ -95,14 +95,14 @@ CREATE TABLE s (k1 INT, k2 INT, v INT, PRIMARY KEY (k1,k2))
 query TTTTT colnames
 EXPLAIN (VERBOSE) ALTER TABLE s SPLIT AT SELECT k1,k2 FROM s ORDER BY k1 LIMIT 3
 ----
-tree       field        description  columns                              ordering
-·          distributed  false        ·                                    ·
-·          vectorized   false        ·                                    ·
-split      ·            ·            (key, pretty, split_enforced_until)  ·
- └── scan  ·            ·            (k1, k2)                             +k1
-·          table        s@primary    ·                                    ·
-·          spans        ALL          ·                                    ·
-·          limit        3            ·                                    ·
+tree       field        description   columns                              ordering
+·          distributed  false         ·                                    ·
+·          vectorized   false         ·                                    ·
+split      ·            ·             (key, pretty, split_enforced_until)  ·
+ └── scan  ·            ·             (k1, k2)                             +k1
+·          table        s@primary     ·                                    ·
+·          spans        LIMITED SCAN  ·                                    ·
+·          limit        3             ·                                    ·
 
 statement ok
 DROP TABLE t; DROP TABLE other

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -65,7 +65,7 @@ tree          field        description
 ·             vectorized   false
 delete range  ·            ·
 ·             from         unindexed
-·             spans        ALL
+·             spans        FULL SCAN
 
 query TTT
 EXPLAIN DELETE FROM unindexed WHERE v = 7 ORDER BY v LIMIT 10
@@ -82,7 +82,7 @@ count                     ·            ·
                 │         count        10
                 └── scan  ·            ·
 ·                         table        unindexed@primary
-·                         spans        ALL
+·                         spans        FULL SCAN
 ·                         filter       v = 7
 
 # Check DELETE with LIMIT clause (MySQL extension)
@@ -101,7 +101,7 @@ count                     ·            ·
                 │         count        10
                 └── scan  ·            ·
 ·                         table        unindexed@primary
-·                         spans        ALL
+·                         spans        FULL SCAN
 ·                         filter       v = 5
 
 # Check fast DELETE.
@@ -161,7 +161,7 @@ count           ·            ·
       │         auto commit  ·
       └── scan  ·            ·
 ·               table        indexed@indexed_value_idx
-·               spans        ALL
+·               spans        LIMITED SCAN
 ·               limit        10
 
 # TODO(andyk): Prune columns so that index-join is not necessary.
@@ -197,4 +197,4 @@ count           ·            ·           ()      ·
       │         auto commit  ·           ·       ·
       └── scan  ·            ·           (a, b)  ·
 ·               table        t38799@foo  ·       ·
-·               spans        ALL         ·       ·
+·               spans        FULL SCAN   ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_union
@@ -14,10 +14,10 @@ EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 union      ·            ·
  ├── scan  ·            ·
  │         table        uniontest@primary
- │         spans        ALL
+ │         spans        FULL SCAN
  └── scan  ·            ·
 ·          table        uniontest@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
@@ -27,10 +27,10 @@ EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
 append     ·            ·
  ├── scan  ·            ·
  │         table        uniontest@primary
- │         spans        ALL
+ │         spans        FULL SCAN
  └── scan  ·            ·
 ·          table        uniontest@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 # Check that EXPLAIN properly releases memory for virtual tables.
 query TTT
@@ -60,12 +60,12 @@ sort                 ·            ·            (a)     +a
       │    │         render 0     a            ·       ·
       │    └── scan  ·            ·            (a, c)  ·
       │              table        abc@primary  ·       ·
-      │              spans        ALL          ·       ·
+      │              spans        FULL SCAN    ·       ·
       └── render     ·            ·            (a)     ·
            │         render 0     a            ·       ·
            └── scan  ·            ·            (a, b)  ·
 ·                    table        abc@primary  ·       ·
-·                    spans        ALL          ·       ·
+·                    spans        FULL SCAN    ·       ·
 
 # Regression test for #32723.
 query TTTTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct
@@ -18,7 +18,7 @@ distinct   ·            ·
  │         order key    y, z
  └── scan  ·            ·
 ·          table        xyz@foo
-·          spans        ALL
+·          spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY z
@@ -30,7 +30,7 @@ distinct   ·            ·
  │         order key    y, z
  └── scan  ·            ·
 ·          table        xyz@foo
-·          spans        ALL
+·          spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y
@@ -44,7 +44,7 @@ sort            ·            ·
       │         order key    y, z
       └── scan  ·            ·
 ·               table        xyz@foo
-·               spans        ALL
+·               spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y, z
@@ -58,7 +58,7 @@ sort            ·            ·
       │         order key    y, z
       └── scan  ·            ·
 ·               table        xyz@foo
-·               spans        ALL
+·               spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT DISTINCT y + z AS r FROM xyz ORDER BY y + z
@@ -73,7 +73,7 @@ distinct             ·            ·
       └── render     ·            ·
            └── scan  ·            ·
 ·                    table        xyz@primary
-·                    spans        ALL
+·                    spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT DISTINCT y AS w, z FROM xyz ORDER BY z
@@ -85,7 +85,7 @@ distinct   ·            ·
  │         order key    w, z
  └── scan  ·            ·
 ·          table        xyz@foo
-·          spans        ALL
+·          spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY y
@@ -98,7 +98,7 @@ sort            ·            ·
       │         distinct on  w
       └── scan  ·            ·
 ·               table        xyz@primary
-·               spans        ALL
+·               spans        FULL SCAN
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT x FROM xyz
@@ -107,7 +107,7 @@ EXPLAIN (VERBOSE) SELECT DISTINCT x FROM xyz
 ·     vectorized   true         ·    ·
 scan  ·            ·            (x)  ·
 ·     table        xyz@primary  ·    ·
-·     spans        ALL          ·    ·
+·     spans        FULL SCAN    ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT x, y, z FROM xyz
@@ -116,23 +116,23 @@ EXPLAIN (VERBOSE) SELECT DISTINCT x, y, z FROM xyz
 ·     vectorized   true         ·          ·
 scan  ·            ·            (x, y, z)  ·
 ·     table        xyz@primary  ·          ·
-·     spans        ALL          ·          ·
+·     spans        FULL SCAN    ·          ·
 
 # Test the case when the DistinctOn operator is projecting away a column.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT z FROM (SELECT y, z FROM xyz WHERE y > 1)
 ----
-·               distributed  false    ·       ·
-·               vectorized   true     ·       ·
-distinct        ·            ·        (z)     ·
- │              distinct on  z        ·       ·
- │              order key    z        ·       ·
- └── render     ·            ·        (z)     +z
-      │         render 0     z        ·       ·
-      └── scan  ·            ·        (y, z)  +z
-·               table        xyz@foo  ·       ·
-·               spans        ALL      ·       ·
-·               filter       y > 1    ·       ·
+·               distributed  false      ·       ·
+·               vectorized   true       ·       ·
+distinct        ·            ·          (z)     ·
+ │              distinct on  z          ·       ·
+ │              order key    z          ·       ·
+ └── render     ·            ·          (z)     +z
+      │         render 0     z          ·       ·
+      └── scan  ·            ·          (y, z)  +z
+·               table        xyz@foo    ·       ·
+·               spans        FULL SCAN  ·       ·
+·               filter       y > 1      ·       ·
 
 statement ok
 CREATE TABLE abcd (
@@ -155,7 +155,7 @@ render     ·            ·                  (z, d, b)  ·
  │         render 2     b                  ·          ·
  └── scan  ·            ·                  (b, d)     +d,+b
 ·          table        abcd@abcd_d_b_key  ·          ·
-·          spans        ALL                ·          ·
+·          spans        FULL SCAN          ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT a, b FROM abcd
@@ -167,7 +167,7 @@ distinct   ·            ·             (a, b)  ·
  │         order key    a, b          ·       ·
  └── scan  ·            ·             (a, b)  +a,+b
 ·          table        abcd@primary  ·       ·
-·          spans        ALL           ·       ·
+·          spans        FULL SCAN     ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT a, b, c FROM abcd
@@ -176,7 +176,7 @@ EXPLAIN (VERBOSE) SELECT DISTINCT a, b, c FROM abcd
 ·     vectorized   true          ·          ·
 scan  ·            ·             (a, b, c)  ·
 ·     table        abcd@primary  ·          ·
-·     spans        ALL           ·          ·
+·     spans        FULL SCAN     ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT a, b, c, d FROM abcd
@@ -185,7 +185,7 @@ EXPLAIN (VERBOSE) SELECT DISTINCT a, b, c, d FROM abcd
 ·     vectorized   true          ·             ·
 scan  ·            ·             (a, b, c, d)  ·
 ·     table        abcd@primary  ·             ·
-·     spans        ALL           ·             ·
+·     spans        FULL SCAN     ·             ·
 
 statement ok
 CREATE TABLE kv (k INT PRIMARY KEY, v INT, UNIQUE INDEX idx(v))
@@ -193,27 +193,27 @@ CREATE TABLE kv (k INT PRIMARY KEY, v INT, UNIQUE INDEX idx(v))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv
 ----
-·          distributed  false   ·    ·
-·          vectorized   true    ·    ·
-distinct   ·            ·       (v)  ·
- │         distinct on  v       ·    ·
- │         order key    v       ·    ·
- └── scan  ·            ·       (v)  +v
-·          table        kv@idx  ·    ·
-·          spans        ALL     ·    ·
+·          distributed  false      ·    ·
+·          vectorized   true       ·    ·
+distinct   ·            ·          (v)  ·
+ │         distinct on  v          ·    ·
+ │         order key    v          ·    ·
+ └── scan  ·            ·          (v)  +v
+·          table        kv@idx     ·    ·
+·          spans        FULL SCAN  ·    ·
 
 # Verify we don't incorrectly elide the distinct node when we only have a weak key (#19343).
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv@idx
 ----
-·          distributed  false   ·    ·
-·          vectorized   true    ·    ·
-distinct   ·            ·       (v)  ·
- │         distinct on  v       ·    ·
- │         order key    v       ·    ·
- └── scan  ·            ·       (v)  +v
-·          table        kv@idx  ·    ·
-·          spans        ALL     ·    ·
+·          distributed  false      ·    ·
+·          vectorized   true       ·    ·
+distinct   ·            ·          (v)  ·
+ │         distinct on  v          ·    ·
+ │         order key    v          ·    ·
+ └── scan  ·            ·          (v)  +v
+·          table        kv@idx     ·    ·
+·          spans        FULL SCAN  ·    ·
 
 # Here we can infer that v is not-NULL so eliding the node is correct.
 query TTTTT
@@ -232,8 +232,8 @@ CREATE TABLE kv2 (k INT PRIMARY KEY, v INT NOT NULL, UNIQUE INDEX idx(v))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv2@idx
 ----
-·     distributed  false    ·    ·
-·     vectorized   true     ·    ·
-scan  ·            ·        (v)  ·
-·     table        kv2@idx  ·    ·
-·     spans        ALL      ·    ·
+·     distributed  false      ·    ·
+·     vectorized   true       ·    ·
+scan  ·            ·          (v)  ·
+·     table        kv2@idx    ·    ·
+·     spans        FULL SCAN  ·    ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -33,7 +33,7 @@ distinct   ·            ·            (x, y, z)  ·
  │         distinct on  x, y, z      ·          ·
  └── scan  ·            ·            (x, y, z)  ·
 ·          table        xyz@primary  ·          ·
-·          spans        ALL          ·          ·
+·          spans        FULL SCAN    ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (z, x, y) x FROM xyz
@@ -46,7 +46,7 @@ render          ·            ·            (x)        ·
       │         distinct on  x, y, z      ·          ·
       └── scan  ·            ·            (x, y, z)  ·
 ·               table        xyz@primary  ·          ·
-·               spans        ALL          ·          ·
+·               spans        FULL SCAN    ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (b, c, a) a, c, b FROM abc
@@ -59,7 +59,7 @@ render     ·            ·            (a, c, b)  ·
  │         render 2     b            ·          ·
  └── scan  ·            ·            (a, b, c)  ·
 ·          table        abc@primary  ·          ·
-·          spans        ALL          ·          ·
+·          spans        FULL SCAN    ·          ·
 
 # Distinct node should be elided since we have a strong key.
 query TTTTT
@@ -69,7 +69,7 @@ EXPLAIN (VERBOSE) SELECT DISTINCT ON (b, c, a) a FROM abc
 ·     vectorized   true         ·    ·
 scan  ·            ·            (a)  ·
 ·     table        abc@primary  ·    ·
-·     spans        ALL          ·    ·
+·     spans        FULL SCAN    ·    ·
 
 # Distinct node should be elided since we have a strong key.
 query TTTTT
@@ -81,7 +81,7 @@ sort       ·            ·            (b)  +b
  │         order        +b           ·    ·
  └── scan  ·            ·            (b)  ·
 ·          table        abc@primary  ·    ·
-·          spans        ALL          ·    ·
+·          spans        FULL SCAN    ·    ·
 
 
 # 2/3 columns
@@ -98,7 +98,7 @@ render          ·            ·            (y, x)  ·
       │         distinct on  x, y         ·       ·
       └── scan  ·            ·            (x, y)  ·
 ·               table        xyz@primary  ·       ·
-·               spans        ALL          ·       ·
+·               spans        FULL SCAN    ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x) x FROM xyz
@@ -111,7 +111,7 @@ render          ·            ·            (x)     ·
       │         distinct on  x, y         ·       ·
       └── scan  ·            ·            (x, y)  ·
 ·               table        xyz@primary  ·       ·
-·               spans        ALL          ·       ·
+·               spans        FULL SCAN    ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x, x, y, x) x, y FROM xyz
@@ -122,7 +122,7 @@ distinct   ·            ·            (x, y)  ·
  │         distinct on  x, y         ·       ·
  └── scan  ·            ·            (x, y)  ·
 ·          table        xyz@primary  ·       ·
-·          spans        ALL          ·       ·
+·          spans        FULL SCAN    ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, x) pk1, x FROM xyz ORDER BY pk1
@@ -137,7 +137,7 @@ render          ·            ·            (pk1, x)  ·
       │         order key    pk1          ·         ·
       └── scan  ·            ·            (x, pk1)  +pk1
 ·               table        xyz@primary  ·         ·
-·               spans        ALL          ·         ·
+·               spans        FULL SCAN    ·         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, c) a, b FROM abc
@@ -152,7 +152,7 @@ render          ·            ·            (a, b)     ·
       │         order key    a            ·          ·
       └── scan  ·            ·            (a, b, c)  +a
 ·               table        abc@primary  ·          ·
-·               spans        ALL          ·          ·
+·               spans        FULL SCAN    ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (c, a) b, c, a FROM abc
@@ -168,7 +168,7 @@ render          ·            ·            (b, c, a)  ·
       │         order key    a            ·          ·
       └── scan  ·            ·            (a, b, c)  +a
 ·               table        abc@primary  ·          ·
-·               spans        ALL          ·          ·
+·               spans        FULL SCAN    ·          ·
 
 
 # 1/3 columns
@@ -185,7 +185,7 @@ distinct   ·            ·            (pk1, pk2)  ·
  │         order key    pk1          ·           ·
  └── scan  ·            ·            (pk1, pk2)  +pk1
 ·          table        xyz@primary  ·           ·
-·          spans        ALL          ·           ·
+·          spans        FULL SCAN    ·           ·
 
 # Ensure the distinctNode advertises an a+ ordering.
 # TODO(radu): set the ordering in the render node to fix this.
@@ -205,7 +205,7 @@ render               ·                ·            (a, c)     +a
            │         already ordered  +a           ·          ·
            └── scan  ·                ·            (a, b, c)  +a
 ·                    table            abc@primary  ·          ·
-·                    spans            ALL          ·          ·
+·                    spans            FULL SCAN    ·          ·
 
 #################
 # With ORDER BY #
@@ -222,7 +222,7 @@ sort            ·            ·            (x)  -x
       │         distinct on  x            ·    ·
       └── scan  ·            ·            (x)  ·
 ·               table        xyz@primary  ·    ·
-·               spans        ALL          ·    ·
+·               spans        FULL SCAN    ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, z) y, z, x FROM xyz ORDER BY z
@@ -240,7 +240,7 @@ render               ·            ·            (y, z, x)  ·
            │         order        +z           ·          ·
            └── scan  ·            ·            (x, y, z)  ·
 ·                    table        xyz@primary  ·          ·
-·                    spans        ALL          ·          ·
+·                    spans        FULL SCAN    ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC, y DESC
@@ -258,7 +258,7 @@ render               ·            ·            (y, z, x)  ·
            │         order        +x,-z,-y     ·          ·
            └── scan  ·            ·            (x, y, z)  ·
 ·                    table        xyz@primary  ·          ·
-·                    spans        ALL          ·          ·
+·                    spans        FULL SCAN    ·          ·
 
 #####################
 # With aggregations #
@@ -276,7 +276,7 @@ group           ·            ·            (max)   ·
       │         render 0     x            ·       ·
       └── scan  ·            ·            (x, y)  ·
 ·               table        xyz@primary  ·       ·
-·               spans        ALL          ·       ·
+·               spans        FULL SCAN    ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(min(a), max(b), min(c)) max(a) FROM abc
@@ -290,7 +290,7 @@ group              ·            ·                (max)      ·
       │            render 0     a                ·          ·
       └── revscan  ·            ·                (a, b, c)  ·
 ·                  table        abc@primary      ·          ·
-·                  spans        ALL              ·          ·
+·                  spans        LIMITED SCAN     ·          ·
 ·                  limit        1                ·          ·
 
 #################
@@ -311,7 +311,7 @@ render          ·            ·            (min)     ·
       │         group by     y            ·         ·
       └── scan  ·            ·            (x, y)    ·
 ·               table        xyz@primary  ·         ·
-·               spans        ALL          ·         ·
+·               spans        FULL SCAN    ·         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(min(x)) min(x) FROM xyz GROUP BY y HAVING min(x) = 1
@@ -330,7 +330,7 @@ render                    ·            ·            (min)     ·
                 │         group by     y            ·         ·
                 └── scan  ·            ·            (x, y)    ·
 ·                         table        xyz@primary  ·         ·
-·                         spans        ALL          ·         ·
+·                         spans        FULL SCAN    ·         ·
 
 #########################
 # With window functions #
@@ -350,7 +350,7 @@ render               ·            ·                                           
            │         render 1     row_number() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                ·
            └── scan  ·            ·                                                                      (y)              ·
 ·                    table        xyz@primary                                                            ·                ·
-·                    spans        ALL                                                                    ·                ·
+·                    spans        FULL SCAN                                                              ·                ·
 
 ###########################
 # With ordinal references #
@@ -365,7 +365,7 @@ distinct   ·            ·            (x, y, z)  ·
  │         distinct on  x            ·          ·
  └── scan  ·            ·            (x, y, z)  ·
 ·          table        xyz@primary  ·          ·
-·          spans        ALL          ·          ·
+·          spans        FULL SCAN    ·          ·
 
 # Distinct node elided because of strong key.
 query TTTTT
@@ -375,7 +375,7 @@ EXPLAIN (VERBOSE) SELECT DISTINCT ON (1,2,3) a, b, c FROM abc
 ·     vectorized   true         ·          ·
 scan  ·            ·            (a, b, c)  ·
 ·     table        abc@primary  ·          ·
-·     spans        ALL          ·          ·
+·     spans        FULL SCAN    ·          ·
 
 #########################
 # With alias references #
@@ -391,7 +391,7 @@ distinct   ·            ·            (y, x)  ·
  │         distinct on  y            ·       ·
  └── scan  ·            ·            (y, x)  ·
 ·          table        xyz@primary  ·       ·
-·          spans        ALL          ·       ·
+·          spans        FULL SCAN    ·       ·
 
 # Ignores the alias.
 query TTTTT
@@ -403,7 +403,7 @@ distinct   ·            ·            (y)  ·
  │         distinct on  y            ·    ·
  └── scan  ·            ·            (y)  ·
 ·          table        xyz@primary  ·    ·
-·          spans        ALL          ·    ·
+·          spans        FULL SCAN    ·    ·
 
 ##################################
 # With nested parentheses/tuples #
@@ -418,7 +418,7 @@ distinct   ·            ·            (x, y)  ·
  │         distinct on  x, y         ·       ·
  └── scan  ·            ·            (x, y)  ·
 ·          table        xyz@primary  ·       ·
-·          spans        ALL          ·       ·
+·          spans        FULL SCAN    ·       ·
 
 ################################
 # Hybrid PK and non-PK queries #
@@ -434,7 +434,7 @@ sort       ·            ·            (x, y, z)  +x,+y
  │         order        +x,+y        ·          ·
  └── scan  ·            ·            (x, y, z)  ·
 ·          table        xyz@primary  ·          ·
-·          spans        ALL          ·          ·
+·          spans        FULL SCAN    ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) pk1 FROM xyz ORDER BY x
@@ -450,7 +450,7 @@ render               ·            ·            (pk1)           ·
            │         order        +x           ·               ·
            └── scan  ·            ·            (x, y, z, pk1)  ·
 ·                    table        xyz@primary  ·               ·
-·                    spans        ALL          ·               ·
+·                    spans        FULL SCAN    ·               ·
 
 # Regression tests for #34112: distinct on constant column.
 query TTTTT
@@ -464,7 +464,7 @@ limit           ·            ·            (x, y)  +y
       │         order        +y           ·       ·
       └── scan  ·            ·            (x, y)  ·
 ·               table        xyz@primary  ·       ·
-·               spans        ALL          ·       ·
+·               spans        FULL SCAN    ·       ·
 ·               filter       x = 1        ·       ·
 
 query TTTTT
@@ -482,5 +482,5 @@ group                     ·            ·             (count)  ·
                 │         order        +y            ·        ·
                 └── scan  ·            ·             (x, y)   ·
 ·                         table        xyz@primary   ·        ·
-·                         spans        ALL           ·        ·
+·                         spans        FULL SCAN     ·        ·
 ·                         filter       x = 1         ·        ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
@@ -73,7 +73,7 @@ distinct   ·            ·            (x, y, z)  ·
  │         distinct on  x, y, z      ·          ·
  └── scan  ·            ·            (x, y, z)  ·
 ·          table        xyz@primary  ·          ·
-·          spans        ALL          ·          ·
+·          spans        FULL SCAN    ·          ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz]
@@ -93,7 +93,7 @@ distinct        ·            ·            (x, y, z)  +x
       │         order        +x           ·          ·
       └── scan  ·            ·            (x, y, z)  ·
 ·               table        xyz@primary  ·          ·
-·               spans        ALL          ·          ·
+·               spans        FULL SCAN    ·          ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz ORDER BY x]
@@ -114,7 +114,7 @@ distinct        ·            ·            (x, y)  +y
       │         order        +y,+x        ·       ·
       └── scan  ·            ·            (x, y)  ·
 ·               table        xyz@primary  ·       ·
-·               spans        ALL          ·       ·
+·               spans        FULL SCAN    ·       ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (y) x, y FROM xyz ORDER BY y, x]
@@ -129,7 +129,7 @@ EXPLAIN (VERBOSE) SELECT DISTINCT ON (a,b,c) a, b, c FROM abc
 ·     vectorized   true         ·          ·
 scan  ·            ·            (a, b, c)  ·
 ·     table        abc@primary  ·          ·
-·     spans        ALL          ·          ·
+·     spans        FULL SCAN    ·          ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (a,b,c) a, b, c FROM abc]
@@ -149,7 +149,7 @@ render          ·            ·            (a, b)     +a,+b
       │         order key    a, b         ·          ·
       └── scan  ·            ·            (a, b, c)  +a,+b,+c
 ·               table        abc@primary  ·          ·
-·               spans        ALL          ·          ·
+·               spans        FULL SCAN    ·          ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (a, b) a, b FROM abc ORDER BY a, b, c]

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
@@ -264,10 +264,10 @@ render           ·                   ·
       │          mergeJoinOrder      +"(pid1=pid1)"
       ├── scan   ·                   ·
       │          table               grandchild2@primary
-      │          spans               ALL
+      │          spans               FULL SCAN
       └── scan   ·                   ·
 ·                table               parent1@primary
-·                spans               ALL
+·                spans               FULL SCAN
 ·                filter              ((((pid1 >= 11) AND (pid1 <= 13)) OR ((pid1 >= 19) AND (pid1 <= 21))) OR ((pid1 >= 31) AND (pid1 <= 33))) OR (pa1 > 0)
 
 # Join on multiple interleaved columns with an overarching ancestor (parent1).
@@ -307,10 +307,10 @@ merge-join  ·                  ·
  │          mergeJoinOrder     +"(pid1=pid1)",+"(cid2=cid2)",+"(cid3=cid3)"
  ├── scan   ·                  ·
  │          table              child2@primary
- │          spans              ALL
+ │          spans              FULL SCAN
  └── scan   ·                  ·
 ·           table              grandchild2@primary
-·           spans              ALL
+·           spans              FULL SCAN
 ·           filter             (((pid1 >= 5) AND (pid1 <= 7)) OR ((cid2 >= 12) AND (cid2 <= 14))) OR ((gcid2 >= 49) AND (gcid2 <= 51))
 
 # Aggregation over parent and child keys.

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
@@ -43,10 +43,10 @@ render           ·               ·                  (a, b)        ·
       │          mergeJoinOrder  +"(a=a)",+"(b=b)"  ·             ·
       ├── scan   ·               ·                  (a, b)        +a,+b
       │          table           data@primary       ·             ·
-      │          spans           ALL                ·             ·
+      │          spans           FULL SCAN          ·             ·
       └── scan   ·               ·                  (a, b)        +a,+b
 ·                table           data@primary       ·             ·
-·                spans           ALL                ·             ·
+·                spans           FULL SCAN          ·             ·
 
 # TODO(radu): enable these tests when joins pass through orderings on equality
 # columns.
@@ -121,10 +121,10 @@ sort            ·            ·                (a, b, c, d)  +b,+a
       │         equality     (a, b) = (c, d)  ·             ·
       ├── scan  ·            ·                (a, b)        ·
       │         table        data@primary     ·             ·
-      │         spans        ALL              ·             ·
+      │         spans        FULL SCAN        ·             ·
       └── scan  ·            ·                (c, d)        ·
 ·               table        data@primary     ·             ·
-·               spans        ALL              ·             ·
+·               spans        FULL SCAN        ·             ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY b,a)]

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
@@ -93,11 +93,11 @@ render           ·                   ·                    (x, str)     ·
       │          mergeJoinOrder      +"(x=y)"             ·            ·
       ├── scan   ·                   ·                    (x)          +x
       │          table               numtosquare@primary  ·            ·
-      │          spans               ALL                  ·            ·
+      │          spans               FULL SCAN            ·            ·
       │          filter              (x % 2) = 0          ·            ·
       └── scan   ·                   ·                    (y, str)     +y
 ·                table               numtostr@primary     ·            ·
-·                spans               ALL                  ·            ·
+·                spans               FULL SCAN            ·            ·
 ·                filter              (y % 2) = 0          ·            ·
 
 query T
@@ -154,7 +154,7 @@ EXPLAIN (VERBOSE) SELECT x FROM (SELECT x, 2*x, x+1 FROM NumToSquare)
 ·     vectorized   true                 ·    ·
 scan  ·            ·                    (x)  ·
 ·     table        numtosquare@primary  ·    ·
-·     spans        ALL                  ·    ·
+·     spans        FULL SCAN            ·    ·
 
 # Verifies that unused renders don't cause us to do rendering instead of a
 # simple projection.
@@ -180,7 +180,7 @@ render               ·            ·                  (y, str, res)  ·
            │         render 2     str                ·              ·
            └── scan  ·            ·                  (y, str)       ·
 ·                    table        numtostr@primary   ·              ·
-·                    spans        ALL                ·              ·
+·                    spans        FULL SCAN          ·              ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT y, str, repeat('test', y) AS res FROM NumToStr ORDER BY res LIMIT 10
@@ -201,7 +201,7 @@ render                    ·            ·                  (y, str, res)  ·
                 │         render 2     str                ·              ·
                 └── scan  ·            ·                  (y, str)       ·
 ·                         table        numtostr@primary   ·              ·
-·                         spans        ALL                ·              ·
+·                         spans        FULL SCAN          ·              ·
 
 # Regression test for #20481.
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_ordinality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_ordinality
@@ -38,7 +38,7 @@ EXPLAIN (VERBOSE) SELECT x, y, z, ordinality FROM xyz WITH ORDINALITY
 ordinality  ·            ·            (x, y, z, "ordinality")  ·
  └── scan   ·            ·            (x, y, z)                ·
 ·           table        xyz@primary  ·                        ·
-·           spans        ALL          ·                        ·
+·           spans        FULL SCAN    ·                        ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT x, y, z, ordinality FROM xyz WITH ORDINALITY]

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -25,7 +25,7 @@ tree       field        description
 render     ·            ·
  └── scan  ·            ·
 ·          table        jobs@jobs_status_created_idx
-·          spans        ALL
+·          spans        FULL SCAN
 
 query TTTTT colnames
 EXPLAIN (PLAN, VERBOSE) SELECT 1 a
@@ -391,13 +391,13 @@ render                                                             ·           
                                │                        │          mergeJoinOrder     +"(username=username)"
                                │                        ├── scan   ·                  ·
                                │                        │          table              users@primary
-                               │                        │          spans              ALL
+                               │                        │          spans              FULL SCAN
                                │                        └── scan   ·                  ·
                                │                                   table              role_options@primary
-                               │                                   spans              ALL
+                               │                                   spans              FULL SCAN
                                └── scan                            ·                  ·
 ·                                                                  table              role_members@role_members_role_idx
-·                                                                  spans              ALL
+·                                                                  spans              FULL SCAN
 
 # EXPLAIN selecting from a sequence.
 statement ok
@@ -455,7 +455,7 @@ EXPLAIN SELECT * FROM t
 ·     vectorized   true
 scan  ·            ·
 ·     table        t@primary
-·     spans        ALL
+·     spans        FULL SCAN
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t
@@ -464,7 +464,7 @@ EXPLAIN (VERBOSE) SELECT * FROM t
 ·     vectorized   true       ·       ·
 scan  ·            ·          (k, v)  ·
 ·     table        t@primary  ·       ·
-·     spans        ALL        ·       ·
+·     spans        FULL SCAN  ·       ·
 
 query TTT
 EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
@@ -492,7 +492,7 @@ lookup-join  ·                      ·
  │           parallel               ·
  └── scan    ·                      ·
 ·            table                  t@primary
-·            spans                  ALL
+·            spans                  FULL SCAN
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE k % 2 = 0
@@ -501,7 +501,7 @@ EXPLAIN (VERBOSE) SELECT * FROM t WHERE k % 2 = 0
 ·     vectorized   false        ·       ·
 scan  ·            ·            (k, v)  ·
 ·     table        t@primary    ·       ·
-·     spans        ALL          ·       ·
+·     spans        FULL SCAN    ·       ·
 ·     filter       (k % 2) = 0  ·       ·
 
 query TTT
@@ -530,7 +530,7 @@ limit            ·            ·
  └── ordinality  ·            ·
       └── scan   ·            ·
 ·                table        t@primary
-·                spans        ALL
+·                spans        LIMITED SCAN
 ·                limit        2
 
 query TTT
@@ -542,7 +542,7 @@ distinct   ·            ·
  │         distinct on  v
  └── scan  ·            ·
 ·          table        t@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 query TTT
 SELECT tree, field, description FROM [EXPLAIN (VERBOSE) SELECT DISTINCT v FROM t LIMIT 1 OFFSET 1]
@@ -557,7 +557,7 @@ limit                ·            ·
            │         distinct on  v
            └── scan  ·            ·
 ·                    table        t@primary
-·                    spans        ALL
+·                    spans        FULL SCAN
 
 statement ok
 CREATE TABLE tc (a INT, b INT, INDEX c(a), FAMILY "primary" (a, b, rowid))
@@ -607,7 +607,7 @@ EXPLAIN (TYPES) SELECT * FROM t
 ·     vectorized   true       ·               ·
 scan  ·            ·          (k int, v int)  ·
 ·     table        t@primary  ·               ·
-·     spans        ALL        ·               ·
+·     spans        FULL SCAN  ·               ·
 
 query TTTTT
 EXPLAIN (TYPES,SYMVARS) SELECT k FROM t
@@ -616,7 +616,7 @@ EXPLAIN (TYPES,SYMVARS) SELECT k FROM t
 ·     vectorized   true       ·        ·
 scan  ·            ·          (k int)  ·
 ·     table        t@primary  ·        ·
-·     spans        ALL        ·        ·
+·     spans        FULL SCAN  ·        ·
 
 query TTTTT
 EXPLAIN (TYPES,VERBOSE) SELECT k FROM t
@@ -625,7 +625,7 @@ EXPLAIN (TYPES,VERBOSE) SELECT k FROM t
 ·     vectorized   true       ·        ·
 scan  ·            ·          (k int)  ·
 ·     table        t@primary  ·        ·
-·     spans        ALL        ·        ·
+·     spans        FULL SCAN  ·        ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM t WHERE v > 123
@@ -634,7 +634,7 @@ EXPLAIN (TYPES) SELECT * FROM t WHERE v > 123
 ·     vectorized   true                           ·               ·
 scan  ·            ·                              (k int, v int)  ·
 ·     table        t@primary                      ·               ·
-·     spans        ALL                            ·               ·
+·     spans        FULL SCAN                      ·               ·
 ·     filter       ((v)[int] > (123)[int])[bool]  ·               ·
 
 query TTTTT
@@ -675,7 +675,7 @@ count                ·            ·                            ()             
            │         render 0     (k)[int]                     ·               ·
            └── scan  ·            ·                            (k int, v int)  ·
 ·                    table        t@primary                    ·               ·
-·                    spans        ALL                          ·               ·
+·                    spans        FULL SCAN                    ·               ·
 ·                    filter       ((v)[int] > (1)[int])[bool]  ·               ·
 
 query TTTTT
@@ -695,7 +695,7 @@ count                ·            ·                              ()           
            │         render 2     ((k)[int] + (1)[int])[int]     ·                            ·
            └── scan  ·            ·                              (k int, v int)               ·
 ·                    table        t@primary                      ·                            ·
-·                    spans        ALL                            ·                            ·
+·                    spans        FULL SCAN                      ·                            ·
 ·                    filter       ((v)[int] > (123)[int])[bool]  ·                            ·
 
 query TTTTT
@@ -718,7 +718,7 @@ EXPLAIN (TYPES) SELECT DISTINCT k FROM t
 ·     vectorized   true       ·        ·
 scan  ·            ·          (k int)  ·
 ·     table        t@primary  ·        ·
-·     spans        ALL        ·        ·
+·     spans        FULL SCAN  ·        ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT v FROM t ORDER BY v
@@ -729,17 +729,17 @@ sort       ·            ·          (v int)  +v
  │         order        +v         ·        ·
  └── scan  ·            ·          (v int)  ·
 ·          table        t@primary  ·        ·
-·          spans        ALL        ·        ·
+·          spans        FULL SCAN  ·        ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT v FROM t LIMIT 1
 ----
-·     distributed  false      ·        ·
-·     vectorized   true       ·        ·
-scan  ·            ·          (v int)  ·
-·     table        t@primary  ·        ·
-·     spans        ALL        ·        ·
-·     limit        1          ·        ·
+·     distributed  false         ·        ·
+·     vectorized   true          ·        ·
+scan  ·            ·             (v int)  ·
+·     table        t@primary     ·        ·
+·     spans        LIMITED SCAN  ·        ·
+·     limit        1             ·        ·
 
 statement ok
 CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
@@ -751,7 +751,7 @@ EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
 ·     vectorized   true                                                                       ·               ·
 scan  ·            ·                                                                          (x int, y int)  ·
 ·     table        tt@primary                                                                 ·               ·
-·     spans        ALL                                                                        ·               ·
+·     spans        FULL SCAN                                                                  ·               ·
 ·     filter       ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]  ·               ·
 
 # TODO(radu): we don't support placeholders with no values.
@@ -1041,4 +1041,4 @@ group      ·            ·
  │         scalar       ·
  └── scan  ·            ·
 ·          table        tc@primary
-·          spans        ALL
+·          spans        FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -50,7 +50,7 @@ render                ·                   ·
            │          filter              (a_y IS NOT NULL) AND (a_x IS NOT NULL)
            └── scan   ·                   ·
 ·                     table               a@primary
-·                     spans               ALL
+·                     spans               FULL SCAN
 
 statement ok
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
@@ -59,7 +59,7 @@ root                                       ·                   ·
  │              │                          label               buffer 1
  │              └── scan                   ·                   ·
  │                                         table               xy@primary
- │                                         spans               ALL
+ │                                         spans               FULL SCAN
  └── postquery                             ·                   ·
       └── error if rows                    ·                   ·
            └── hash-join                   ·                   ·
@@ -71,7 +71,7 @@ root                                       ·                   ·
                 │                          label               buffer 1
                 └── scan                   ·                   ·
 ·                                          table               parent@primary
-·                                          spans               ALL
+·                                          spans               FULL SCAN
 
 statement ok
 CREATE TABLE child_nullable (c INT PRIMARY KEY, p INT REFERENCES parent(p));
@@ -338,7 +338,7 @@ root                                       ·                   ·
  │              └── render                 ·                   ·
  │                   └── scan              ·                   ·
  │                                         table               child@primary
- │                                         spans               ALL
+ │                                         spans               FULL SCAN
  │                                         locking strength    for update
  └── postquery                             ·                   ·
       └── error if rows                    ·                   ·
@@ -351,7 +351,7 @@ root                                       ·                   ·
                 │                          label               buffer 1
                 └── scan                   ·                   ·
 ·                                          table               parent@primary
-·                                          spans               ALL
+·                                          spans               FULL SCAN
 
 query TTT
 EXPLAIN UPDATE child SET p = 4 WHERE c = 10
@@ -399,7 +399,7 @@ root                                                 ·                   ·
  │              └── render                           ·                   ·
  │                   └── scan                        ·                   ·
  │                                                   table               parent@primary
- │                                                   spans               ALL
+ │                                                   spans               FULL SCAN
  │                                                   locking strength    for update
  ├── postquery                                       ·                   ·
  │    └── error if rows                              ·                   ·
@@ -421,7 +421,7 @@ root                                                 ·                   ·
  │                        │                          order key           p
  │                        └── scan                   ·                   ·
  │                                                   table               child@child_auto_index_fk_p_ref_parent
- │                                                   spans               ALL
+ │                                                   spans               FULL SCAN
  └── postquery                                       ·                   ·
       └── error if rows                              ·                   ·
            └── render                                ·                   ·
@@ -442,7 +442,7 @@ root                                                 ·                   ·
                           │                          order key           p
                           └── scan                   ·                   ·
 ·                                                    table               child_nullable@child_nullable_auto_index_fk_p_ref_parent
-·                                                    spans               ALL
+·                                                    spans               FULL SCAN
 
 query TTT
 EXPLAIN UPDATE parent SET p = p+1 WHERE other = 10
@@ -508,7 +508,7 @@ root                                                 ·                   ·
  │              └── render                           ·                   ·
  │                   └── scan                        ·                   ·
  │                                                   table               child@primary
- │                                                   spans               ALL
+ │                                                   spans               FULL SCAN
  │                                                   locking strength    for update
  └── postquery                                       ·                   ·
       └── error if rows                              ·                   ·
@@ -530,7 +530,7 @@ root                                                 ·                   ·
                           │                          order key           c
                           └── scan                   ·                   ·
 ·                                                    table               grandchild@grandchild_auto_index_fk_c_ref_child
-·                                                    spans               ALL
+·                                                    spans               FULL SCAN
 
 # This update shouldn't emit checks for c, since it's unchanged.
 query TTT
@@ -549,7 +549,7 @@ root                                       ·                   ·
  │              └── render                 ·                   ·
  │                   └── scan              ·                   ·
  │                                         table               child@primary
- │                                         spans               ALL
+ │                                         spans               FULL SCAN
  │                                         locking strength    for update
  └── postquery                             ·                   ·
       └── error if rows                    ·                   ·
@@ -562,7 +562,7 @@ root                                       ·                   ·
                 │                          label               buffer 1
                 └── scan                   ·                   ·
 ·                                          table               parent@primary
-·                                          spans               ALL
+·                                          spans               FULL SCAN
 
 query TTT
 EXPLAIN UPDATE child SET p = p
@@ -580,7 +580,7 @@ root                                       ·                   ·
  │              └── render                 ·                   ·
  │                   └── scan              ·                   ·
  │                                         table               child@primary
- │                                         spans               ALL
+ │                                         spans               FULL SCAN
  │                                         locking strength    for update
  └── postquery                             ·                   ·
       └── error if rows                    ·                   ·
@@ -593,7 +593,7 @@ root                                       ·                   ·
                 │                          label               buffer 1
                 └── scan                   ·                   ·
 ·                                          table               parent@primary
-·                                          spans               ALL
+·                                          spans               FULL SCAN
 
 query TTT
 EXPLAIN UPDATE child SET p = p+1, c = c+1
@@ -611,7 +611,7 @@ root                                                 ·                   ·
  │              └── render                           ·                   ·
  │                   └── scan                        ·                   ·
  │                                                   table               child@primary
- │                                                   spans               ALL
+ │                                                   spans               FULL SCAN
  │                                                   locking strength    for update
  ├── postquery                                       ·                   ·
  │    └── error if rows                              ·                   ·
@@ -624,7 +624,7 @@ root                                                 ·                   ·
  │              │                                    label               buffer 1
  │              └── scan                             ·                   ·
  │                                                   table               parent@primary
- │                                                   spans               ALL
+ │                                                   spans               FULL SCAN
  └── postquery                                       ·                   ·
       └── error if rows                              ·                   ·
            └── render                                ·                   ·
@@ -645,7 +645,7 @@ root                                                 ·                   ·
                           │                          order key           c
                           └── scan                   ·                   ·
 ·                                                    table               grandchild@grandchild_auto_index_fk_c_ref_child
-·                                                    spans               ALL
+·                                                    spans               FULL SCAN
 
 # Multiple grandchild tables
 statement ok
@@ -667,7 +667,7 @@ root                                       ·                   ·
  │              └── render                 ·                   ·
  │                   └── scan              ·                   ·
  │                                         table               child@primary
- │                                         spans               ALL
+ │                                         spans               FULL SCAN
  │                                         locking strength    for update
  └── postquery                             ·                   ·
       └── error if rows                    ·                   ·
@@ -680,7 +680,7 @@ root                                       ·                   ·
                 │                          label               buffer 1
                 └── scan                   ·                   ·
 ·                                          table               parent@primary
-·                                          spans               ALL
+·                                          spans               FULL SCAN
 
 statement ok
 CREATE TABLE self (x INT PRIMARY KEY, y INT NOT NULL REFERENCES self(x))
@@ -701,7 +701,7 @@ root                                       ·                   ·
  │              └── render                 ·                   ·
  │                   └── scan              ·                   ·
  │                                         table               self@primary
- │                                         spans               ALL
+ │                                         spans               FULL SCAN
  │                                         locking strength    for update
  └── postquery                             ·                   ·
       └── error if rows                    ·                   ·
@@ -714,7 +714,7 @@ root                                       ·                   ·
                 │                          label               buffer 1
                 └── scan                   ·                   ·
 ·                                          table               self@primary
-·                                          spans               ALL
+·                                          spans               FULL SCAN
 
 query TTT
 EXPLAIN UPDATE self SET x = 3
@@ -732,7 +732,7 @@ root                                                 ·                   ·
  │              └── render                           ·                   ·
  │                   └── scan                        ·                   ·
  │                                                   table               self@primary
- │                                                   spans               ALL
+ │                                                   spans               FULL SCAN
  │                                                   locking strength    for update
  └── postquery                                       ·                   ·
       └── error if rows                              ·                   ·
@@ -754,7 +754,7 @@ root                                                 ·                   ·
                           │                          order key           y
                           └── scan                   ·                   ·
 ·                                                    table               self@self_auto_index_fk_y_ref_self
-·                                                    spans               ALL
+·                                                    spans               FULL SCAN
 
 # Tests for the insert fast path.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -324,7 +324,7 @@ count                          ·            ·
                      │         order        -v
                      └── scan  ·            ·
 ·                              table        select_t@primary
-·                              spans        ALL
+·                              spans        FULL SCAN
 
 # Check that INSERT supports LIMIT (MySQL extension)
 query TTT
@@ -345,7 +345,7 @@ count                ·            ·
            │         render 2     unique_rowid()
            └── scan  ·            ·
 ·                    table        select_t@primary
-·                    spans        ALL
+·                    spans        LIMITED SCAN
 ·                    limit        1
 
 # Check the grouping of LIMIT and ORDER BY
@@ -446,7 +446,7 @@ render                                   ·            ·                      (
                                │         render 2     k || v                 ·                              ·
                                └── scan  ·            ·                      (k, v)                         ·
 ·                                        table        kv@primary             ·                              ·
-·                                        spans        ALL                    ·                              ·
+·                                        spans        FULL SCAN              ·                              ·
 
 # ------------------------------------------------------------------------------
 # Insert rows into table during schema changes.
@@ -538,7 +538,7 @@ root                                          ·             ·                 
                                     │         render 3      unique_rowid()                                       ·                   ·
                                     └── scan  ·             ·                                                    (a, b, c)           ·
 ·                                             table         abc@primary                                          ·                   ·
-·                                             spans         ALL                                                  ·                   ·
+·                                             spans         FULL SCAN                                            ·                   ·
 
 # ------------------------------------------------------------------------------
 # Regression for #35364. This tests behavior that is different between the CBO

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -43,7 +43,7 @@ EXPLAIN SELECT * FROM level4
 ·     vectorized   true
 scan  ·            ·
 ·     table        level4@primary
-·     spans        ALL
+·     spans        FULL SCAN
 
 # The span below ends at the end of the first index of table 53, and is not
 # constraining the value of k2 or k3. This is confusing on first glance because

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -229,7 +229,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '[]';
 ·     vectorized   false      ·       ·
 scan  ·            ·          (a, b)  ·
 ·     table        d@primary  ·       ·
-·     spans        ALL        ·       ·
+·     spans        FULL SCAN  ·       ·
 ·     filter       b @> '[]'  ·       ·
 
 
@@ -240,7 +240,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '{}';
 ·     vectorized   false      ·       ·
 scan  ·            ·          (a, b)  ·
 ·     table        d@primary  ·       ·
-·     spans        ALL        ·       ·
+·     spans        FULL SCAN  ·       ·
 ·     filter       b @> '{}'  ·       ·
 
 
@@ -295,7 +295,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b IS NULL
 ·     vectorized   false      ·       ·
 scan  ·            ·          (a, b)  ·
 ·     table        d@primary  ·       ·
-·     spans        ALL        ·       ·
+·     spans        FULL SCAN  ·       ·
 ·     filter       b IS NULL  ·       ·
 
 query TTT
@@ -305,7 +305,7 @@ EXPLAIN SELECT * from d where b @> '{"a": []}' ORDER BY a;
 ·     vectorized   false
 scan  ·            ·
 ·     table        d@primary
-·     spans        ALL
+·     spans        FULL SCAN
 ·     filter       b @> '{"a": []}'
 
 query TTT
@@ -315,7 +315,7 @@ EXPLAIN SELECT * from d where b @> '{"a": {}}' ORDER BY a;
 ·     vectorized   false
 scan  ·            ·
 ·     table        d@primary
-·     spans        ALL
+·     spans        FULL SCAN
 ·     filter       b @> '{"a": {}}'
 
 # Multi-path contains queries. Should create zigzag joins.
@@ -470,7 +470,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": {}}'
 ·     vectorized   false                      ·       ·
 scan  ·            ·                          (a, b)  ·
 ·     table        d@primary                  ·       ·
-·     spans        ALL                        ·       ·
+·     spans        FULL SCAN                  ·       ·
 ·     filter       b @> '{"a": {}, "b": {}}'  ·       ·
 
 subtest array
@@ -495,7 +495,7 @@ EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[]::INT[]
 ·     vectorized   false         ·       ·
 scan  ·            ·             (a, b)  ·
 ·     table        e@primary     ·       ·
-·     spans        ALL           ·       ·
+·     spans        FULL SCAN     ·       ·
 ·     filter       b @> ARRAY[]  ·       ·
 
 # Test that searching for a NULL element using the inverted index.
@@ -523,7 +523,7 @@ EXPLAIN (VERBOSE) SELECT * from e where b IS NULL
 ·     vectorized   false      ·       ·
 scan  ·            ·          (a, b)  ·
 ·     table        e@primary  ·       ·
-·     spans        ALL        ·       ·
+·     spans        FULL SCAN  ·       ·
 ·     filter       b IS NULL  ·       ·
 
 query TTTTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -19,10 +19,10 @@ render          ·            ·
       │         equality     (x) = (x)
       ├── scan  ·            ·
       │         table        onecolumn@primary
-      │         spans        ALL
+      │         spans        FULL SCAN
       └── scan  ·            ·
 ·               table        twocolumn@primary
-·               spans        ALL
+·               spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
@@ -34,10 +34,10 @@ hash-join  ·            ·
  │         equality     (x) = (y)
  ├── scan  ·            ·
  │         table        twocolumn@primary
- │         spans        ALL
+ │         spans        FULL SCAN
  └── scan  ·            ·
 ·          table        twocolumn@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
@@ -49,10 +49,10 @@ render           ·            ·
       │          type         cross
       ├── scan   ·            ·
       │          table        twocolumn@primary
-      │          spans        ALL
+      │          spans        FULL SCAN
       └── scan   ·            ·
 ·                table        twocolumn@primary
-·                spans        ALL
+·                spans        FULL SCAN
 ·                filter       x = 44
 
 query TTT
@@ -65,10 +65,10 @@ hash-join  ·            ·
  │         equality     (x) = (y)
  ├── scan  ·            ·
  │         table        onecolumn@primary
- │         spans        ALL
+ │         spans        FULL SCAN
  └── scan  ·            ·
 ·          table        twocolumn@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
@@ -80,10 +80,10 @@ hash-join  ·            ·
  │         equality     (x) = (y)
  ├── scan  ·            ·
  │         table        onecolumn@primary
- │         spans        ALL
+ │         spans        FULL SCAN
  └── scan  ·            ·
 ·          table        twocolumn@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM
@@ -105,19 +105,19 @@ limit                ·            ·
       │    │         equality     (x) = (x)
       │    ├── scan  ·            ·
       │    │         table        onecolumn@primary
-      │    │         spans        ALL
+      │    │         spans        FULL SCAN
       │    └── scan  ·            ·
       │              table        twocolumn@primary
-      │              spans        ALL
+      │              spans        FULL SCAN
       └── hash-join  ·            ·
            │         type         inner
            │         equality     (x) = (x)
            ├── scan  ·            ·
            │         table        onecolumn@primary
-           │         spans        ALL
+           │         spans        FULL SCAN
            └── scan  ·            ·
 ·                    table        twocolumn@primary
-·                    spans        ALL
+·                    spans        FULL SCAN
 
 # The following queries verify that only the necessary columns are scanned.
 query TTTTT
@@ -129,10 +129,10 @@ cross-join  ·            ·                  (x, y)  ·
  │          type         cross              ·       ·
  ├── scan   ·            ·                  (x)     ·
  │          table        twocolumn@primary  ·       ·
- │          spans        ALL                ·       ·
+ │          spans        FULL SCAN          ·       ·
  └── scan   ·            ·                  (y)     ·
 ·           table        twocolumn@primary  ·       ·
-·           spans        ALL                ·       ·
+·           spans        FULL SCAN          ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
@@ -146,10 +146,10 @@ render          ·            ·                  (y)        ·
       │         equality     (x) = (x)          ·          ·
       ├── scan  ·            ·                  (x)        ·
       │         table        twocolumn@primary  ·          ·
-      │         spans        ALL                ·          ·
+      │         spans        FULL SCAN          ·          ·
       └── scan  ·            ·                  (x, y)     ·
 ·               table        twocolumn@primary  ·          ·
-·               spans        ALL                ·          ·
+·               spans        FULL SCAN          ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
@@ -163,10 +163,10 @@ render          ·            ·                  (y)        ·
       │         equality     (x) = (x)          ·          ·
       ├── scan  ·            ·                  (x)        ·
       │         table        twocolumn@primary  ·          ·
-      │         spans        ALL                ·          ·
+      │         spans        FULL SCAN          ·          ·
       └── scan  ·            ·                  (x, y)     ·
 ·               table        twocolumn@primary  ·          ·
-·               spans        ALL                ·          ·
+·               spans        FULL SCAN          ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
@@ -180,10 +180,10 @@ render           ·            ·                  (x)     ·
       │          pred         x < y              ·       ·
       ├── scan   ·            ·                  (x)     ·
       │          table        twocolumn@primary  ·       ·
-      │          spans        ALL                ·       ·
+      │          spans        FULL SCAN          ·       ·
       └── scan   ·            ·                  (y)     ·
 ·                table        twocolumn@primary  ·       ·
-·                spans        ALL                ·       ·
+·                spans        FULL SCAN          ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT x, 2 two FROM onecolumn) NATURAL FULL JOIN (SELECT x, y+1 plus1 FROM twocolumn)
@@ -202,13 +202,13 @@ render               ·            ·                  (x, two, plus1)     ·
       │    │         render 1     x                  ·                   ·
       │    └── scan  ·            ·                  (x)                 ·
       │              table        onecolumn@primary  ·                   ·
-      │              spans        ALL                ·                   ·
+      │              spans        FULL SCAN          ·                   ·
       └── render     ·            ·                  (plus1, x)          ·
            │         render 0     y + 1              ·                   ·
            │         render 1     x                  ·                   ·
            └── scan  ·            ·                  (x, y)              ·
 ·                    table        twocolumn@primary  ·                   ·
-·                    spans        ALL                ·                   ·
+·                    spans        FULL SCAN          ·                   ·
 
 # Ensure that the ordering information for the result of joins is sane. (#12037)
 query TTTTT
@@ -417,10 +417,10 @@ merge-join  ·                   ·
  │          mergeJoinOrder      +"(cust=id)"
  ├── scan   ·                   ·
  │          table               cards@cards_auto_index_fk_cust_ref_customers
- │          spans               ALL
+ │          spans               FULL SCAN
  └── scan   ·                   ·
 ·           table               customers@primary
-·           spans               ALL
+·           spans               FULL SCAN
 
 # Tests for filter propagation through joins.
 
@@ -442,10 +442,10 @@ hash-join  ·                   ·
  │         right cols are key  ·
  ├── scan  ·                   ·
  │         table               pairs@primary
- │         spans               ALL
+ │         spans               FULL SCAN
  └── scan  ·                   ·
 ·          table               square@primary
-·          spans               ALL
+·          spans               FULL SCAN
 
 # The filter expression becomes an ON predicate.
 query TTTTT
@@ -467,10 +467,10 @@ render               ·            ·                 (a, b, n, sq)           ·
       │    │         render 2     b                 ·                       ·
       │    └── scan  ·            ·                 (a, b)                  ·
       │              table        pairs@primary     ·                       ·
-      │              spans        ALL               ·                       ·
+      │              spans        FULL SCAN         ·                       ·
       └── scan       ·            ·                 (n, sq)                 ·
 ·                    table        square@primary    ·                       ·
-·                    spans        ALL               ·                       ·
+·                    spans        FULL SCAN         ·                       ·
 
 # Query similar to the one above, but the filter refers to a rendered
 # expression and can't "break through".
@@ -496,10 +496,10 @@ render                     ·            ·               (a, b, n, sq)       ·
                 │          type         cross           ·                   ·
                 ├── scan   ·            ·               (a, b)              ·
                 │          table        pairs@primary   ·                   ·
-                │          spans        ALL             ·                   ·
+                │          spans        FULL SCAN       ·                   ·
                 └── scan   ·            ·               (n, sq)             ·
 ·                          table        square@primary  ·                   ·
-·                          spans        ALL             ·                   ·
+·                          spans        FULL SCAN       ·                   ·
 
 # The filter expression must stay on top of the outer join.
 query TTTTT
@@ -521,10 +521,10 @@ render               ·            ·                 (a, b, n, sq)           ·
       │    │         render 2     b                 ·                       ·
       │    └── scan  ·            ·                 (a, b)                  ·
       │              table        pairs@primary     ·                       ·
-      │              spans        ALL               ·                       ·
+      │              spans        FULL SCAN         ·                       ·
       └── scan       ·            ·                 (n, sq)                 ·
 ·                    table        square@primary    ·                       ·
-·                    spans        ALL               ·                       ·
+·                    spans        FULL SCAN         ·                       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq WHERE pairs.b%2 <> square.sq%2
@@ -547,10 +547,10 @@ render                    ·            ·                    (a, b, n, sq)     
            │    │         render 2     b                    ·                       ·
            │    └── scan  ·            ·                    (a, b)                  ·
            │              table        pairs@primary        ·                       ·
-           │              spans        ALL                  ·                       ·
+           │              spans        FULL SCAN            ·                       ·
            └── scan       ·            ·                    (n, sq)                 ·
 ·                         table        square@primary       ·                       ·
-·                         spans        ALL                  ·                       ·
+·                         spans        FULL SCAN            ·                       ·
 
 # Filter propagation through outer joins.
 
@@ -572,7 +572,7 @@ filter          ·            ·
       │         pred         a > 1
       ├── scan  ·            ·
       │         table        pairs@primary
-      │         spans        ALL
+      │         spans        FULL SCAN
       │         filter       b > 1
       └── scan  ·            ·
 ·               table        square@primary
@@ -605,7 +605,7 @@ render               ·            ·
            │         spans        /2-
            └── scan  ·            ·
 ·                    table        pairs@primary
-·                    spans        ALL
+·                    spans        FULL SCAN
 ·                    filter       a > 1
 
 # The simpler plan for an inner join, to compare.
@@ -624,7 +624,7 @@ hash-join  ·            ·
  │         equality     (b) = (sq)
  ├── scan  ·            ·
  │         table        pairs@primary
- │         spans        ALL
+ │         spans        FULL SCAN
  │         filter       ((a > 1) AND ((a IS NULL) OR (a > 2))) AND ((a IS NULL) OR (a < b))
  └── scan  ·            ·
 ·          table        square@primary
@@ -650,10 +650,10 @@ render          ·            ·                (x)           ·
       │         equality     (x, y) = (x, y)  ·             ·
       ├── scan  ·            ·                (x, y)        ·
       │         table        t1@primary       ·             ·
-      │         spans        ALL              ·             ·
+      │         spans        FULL SCAN        ·             ·
       └── scan  ·            ·                (y, x)        ·
 ·               table        t2@primary       ·             ·
-·               spans        ALL              ·             ·
+·               spans        FULL SCAN        ·             ·
 
 # Tests for merge join ordering information.
 statement ok
@@ -680,10 +680,10 @@ hash-join  ·                   ·                      (a, b, c, d, a, b, c, d)
  │         right cols are key  ·                      ·                         ·
  ├── scan  ·                   ·                      (a, b, c, d)              ·
  │         table               pkba@primary           ·                         ·
- │         spans               ALL                    ·                         ·
+ │         spans               FULL SCAN              ·                         ·
  └── scan  ·                   ·                      (a, b, c, d)              ·
 ·          table               pkbc@primary           ·                         ·
-·          spans               ALL                    ·                         ·
+·          spans               FULL SCAN              ·                         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBA NATURAL JOIN pkBAD
@@ -702,10 +702,10 @@ render          ·                   ·                            (a, b, c, d) 
       │         right cols are key  ·                            ·                         ·
       ├── scan  ·                   ·                            (a, b, c, d)              ·
       │         table               pkba@primary                 ·                         ·
-      │         spans               ALL                          ·                         ·
+      │         spans               FULL SCAN                    ·                         ·
       └── scan  ·                   ·                            (a, b, c, d)              ·
 ·               table               pkbad@primary                ·                         ·
-·               spans               ALL                          ·                         ·
+·               spans               FULL SCAN                    ·                         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAC AS r USING(a, b, c)
@@ -726,10 +726,10 @@ render           ·                   ·                           (a, b, c, d, 
       │          mergeJoinOrder      +"(b=b)",+"(a=a)",+"(c=c)"  ·                         ·
       ├── scan   ·                   ·                           (a, b, c, d)              +b,+a,+c
       │          table               pkbac@primary               ·                         ·
-      │          spans               ALL                         ·                         ·
+      │          spans               FULL SCAN                   ·                         ·
       └── scan   ·                   ·                           (a, b, c, d)              +b,+a,+c
 ·                table               pkbac@primary               ·                         ·
-·                spans               ALL                         ·                         ·
+·                spans               FULL SCAN                   ·                         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a = r.a AND l.b = r.b
@@ -744,10 +744,10 @@ merge-join  ·                   ·                           (a, b, c, d, a, b,
  │          mergeJoinOrder      +"(b=b)",+"(a=a)",+"(c=d)"  ·                         ·
  ├── scan   ·                   ·                           (a, b, c, d)              +b,+a,+c
  │          table               pkbac@primary               ·                         ·
- │          spans               ALL                         ·                         ·
+ │          spans               FULL SCAN                   ·                         ·
  └── scan   ·                   ·                           (a, b, c, d)              +b,+a,+d
 ·           table               pkbad@primary               ·                         ·
-·           spans               ALL                         ·                         ·
+·           spans               FULL SCAN                   ·                         ·
 
 # Tests with joins with merged columns of collated string type.
 statement ok
@@ -770,10 +770,10 @@ render          ·            ·             (s, s, s)  ·
       │         equality     (s) = (s)     ·          ·
       ├── scan  ·            ·             (s)        ·
       │         table        str1@primary  ·          ·
-      │         spans        ALL           ·          ·
+      │         spans        FULL SCAN     ·          ·
       └── scan  ·            ·             (s)        ·
 ·               table        str2@primary  ·          ·
-·               spans        ALL           ·          ·
+·               spans        FULL SCAN     ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 LEFT OUTER JOIN str2 USING(s)
@@ -789,10 +789,10 @@ render          ·            ·             (s, s, s)  ·
       │         equality     (s) = (s)     ·          ·
       ├── scan  ·            ·             (s)        ·
       │         table        str1@primary  ·          ·
-      │         spans        ALL           ·          ·
+      │         spans        FULL SCAN     ·          ·
       └── scan  ·            ·             (s)        ·
 ·               table        str2@primary  ·          ·
-·               spans        ALL           ·          ·
+·               spans        FULL SCAN     ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 RIGHT OUTER JOIN str2 USING(s)
@@ -808,10 +808,10 @@ render          ·            ·               (s, s, s)  ·
       │         equality     (s) = (s)       ·          ·
       ├── scan  ·            ·               (s)        ·
       │         table        str2@primary    ·          ·
-      │         spans        ALL             ·          ·
+      │         spans        FULL SCAN       ·          ·
       └── scan  ·            ·               (s)        ·
 ·               table        str1@primary    ·          ·
-·               spans        ALL             ·          ·
+·               spans        FULL SCAN       ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 FULL OUTER JOIN str2 USING(s)
@@ -827,10 +827,10 @@ render          ·            ·               (s, s, s)  ·
       │         equality     (s) = (s)       ·          ·
       ├── scan  ·            ·               (s)        ·
       │         table        str1@primary    ·          ·
-      │         spans        ALL             ·          ·
+      │         spans        FULL SCAN       ·          ·
       └── scan  ·            ·               (s)        ·
 ·               table        str2@primary    ·          ·
-·               spans        ALL             ·          ·
+·               spans        FULL SCAN       ·          ·
 
 # Verify that we resolve the merged column a to str2.a but use IFNULL for
 # column s which is a collated string.
@@ -849,10 +849,10 @@ render          ·                   ·                (a, s)        ·
       │         right cols are key  ·                ·             ·
       ├── scan  ·                   ·                (a, s)        ·
       │         table               str2@primary     ·             ·
-      │         spans               ALL              ·             ·
+      │         spans               FULL SCAN        ·             ·
       └── scan  ·                   ·                (a, s)        ·
 ·               table               str1@primary     ·             ·
-·               spans               ALL              ·             ·
+·               spans               FULL SCAN        ·             ·
 
 
 statement ok
@@ -942,10 +942,10 @@ filter                ·               ·                  (x, y, u, v)        �
            │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
            ├── scan   ·               ·                  (x, y, u)           +x,+y
            │          table           xyu@primary        ·                   ·
-           │          spans           ALL                ·                   ·
+           │          spans           FULL SCAN          ·                   ·
            └── scan   ·               ·                  (x, y, v)           +x,+y
 ·                     table           xyv@primary        ·                   ·
-·                     spans           ALL                ·                   ·
+·                     spans           FULL SCAN          ·                   ·
 
 # Verify that we transfer constraints between the two sides.
 query TTTTT
@@ -991,7 +991,7 @@ merge-join  ·               ·                  (x, y, u, x, y, v)  ·
  │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
  ├── scan   ·               ·                  (x, y, u)           +x,+y
  │          table           xyu@primary        ·                   ·
- │          spans           ALL                ·                   ·
+ │          spans           FULL SCAN          ·                   ·
  └── scan   ·               ·                  (x, y, v)           +y
 ·           table           xyv@primary        ·                   ·
 ·           spans           /1-/1/10           ·                   ·
@@ -1014,7 +1014,7 @@ render           ·               ·                  (x, y, u, x, y, v)  ·
       │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
       ├── scan   ·               ·                  (x, y, v)           +x,+y
       │          table           xyv@primary        ·                   ·
-      │          spans           ALL                ·                   ·
+      │          spans           FULL SCAN          ·                   ·
       └── scan   ·               ·                  (x, y, u)           +y
 ·                table           xyu@primary        ·                   ·
 ·                spans           /1-/1/10           ·                   ·
@@ -1082,10 +1082,10 @@ filter                ·               ·                  (x, y, u, v)        �
            │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
            ├── scan   ·               ·                  (x, y, u)           +x,+y
            │          table           xyu@primary        ·                   ·
-           │          spans           ALL                ·                   ·
+           │          spans           FULL SCAN          ·                   ·
            └── scan   ·               ·                  (x, y, v)           +x,+y
 ·                     table           xyv@primary        ·                   ·
-·                     spans           ALL                ·                   ·
+·                     spans           FULL SCAN          ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
@@ -1098,7 +1098,7 @@ merge-join  ·               ·                  (x, y, u, x, y, v)  ·
  │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
  ├── scan   ·               ·                  (x, y, u)           +x,+y
  │          table           xyu@primary        ·                   ·
- │          spans           ALL                ·                   ·
+ │          spans           FULL SCAN          ·                   ·
  └── scan   ·               ·                  (x, y, v)           +y
 ·           table           xyv@primary        ·                   ·
 ·           spans           /1-/1/10           ·                   ·
@@ -1121,7 +1121,7 @@ render           ·               ·                  (x, y, u, x, y, v)  ·
       │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
       ├── scan   ·               ·                  (x, y, v)           +x,+y
       │          table           xyv@primary        ·                   ·
-      │          spans           ALL                ·                   ·
+      │          spans           FULL SCAN          ·                   ·
       └── scan   ·               ·                  (x, y, u)           +y
 ·                table           xyu@primary        ·                   ·
 ·                spans           /1-/1/10           ·                   ·
@@ -1146,7 +1146,7 @@ render           ·               ·                  (x, y, u, v)        ·
       │          spans           /1/2/4-            ·                   ·
       └── scan   ·               ·                  (x, y, v)           +x,+y
 ·                table           xyv@primary        ·                   ·
-·                spans           ALL                ·                   ·
+·                spans           FULL SCAN          ·                   ·
 
 
 # Regression test for #20765/27431.
@@ -1275,7 +1275,7 @@ render           ·                   ·
       │          filter              (((a, b) > (1, 2)) OR (((a = 1) AND (b = 2)) AND (c < 6))) OR ((((a = 1) AND (b = 2)) AND (c = 6)) AND (d > 8))
       └── scan   ·                   ·
 ·                table               abg@primary
-·                spans               ALL
+·                spans               FULL SCAN
 
 # Regression tests for mixed-type equality columns (#22514).
 statement ok
@@ -1313,10 +1313,10 @@ render          ·            ·
       │         pred         (b = b) AND (d = d)
       ├── scan  ·            ·
       │         table        foo@primary
-      │         spans        ALL
+      │         spans        FULL SCAN
       └── scan  ·            ·
 ·               table        bar@primary
-·               spans        ALL
+·               spans        FULL SCAN
 
 # b can't be an equality column.
 query TTT
@@ -1339,10 +1339,10 @@ render           ·            ·
       │          pred         b = b
       ├── scan   ·            ·
       │          table        foo@primary
-      │          spans        ALL
+      │          spans        FULL SCAN
       └── scan   ·            ·
 ·                table        bar@primary
-·                spans        ALL
+·                spans        FULL SCAN
 
 # Only a can be an equality column.
 query TTT
@@ -1365,10 +1365,10 @@ render          ·            ·
       │         pred         b = b
       ├── scan  ·            ·
       │         table        foo@primary
-      │         spans        ALL
+      │         spans        FULL SCAN
       └── scan  ·            ·
 ·               table        bar@primary
-·               spans        ALL
+·               spans        FULL SCAN
 
 # Only a and c can be equality columns.
 query TTT
@@ -1390,10 +1390,10 @@ render          ·            ·
       │         pred         b = b
       ├── scan  ·            ·
       │         table        foo@primary
-      │         spans        ALL
+      │         spans        FULL SCAN
       └── scan  ·            ·
 ·               table        bar@primary
-·               spans        ALL
+·               spans        FULL SCAN
 
 # b can't be an equality column.
 query TTT
@@ -1408,10 +1408,10 @@ cross-join  ·            ·
  │          pred         b = b
  ├── scan   ·            ·
  │          table        foo@primary
- │          spans        ALL
+ │          spans        FULL SCAN
  └── scan   ·            ·
 ·           table        bar@primary
-·           spans        ALL
+·           spans        FULL SCAN
 
 # Only a can be an equality column.
 query TTT
@@ -1427,10 +1427,10 @@ hash-join  ·            ·
  │         pred         b = b
  ├── scan  ·            ·
  │         table        foo@primary
- │         spans        ALL
+ │         spans        FULL SCAN
  └── scan  ·            ·
 ·          table        bar@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 query TTT
 SELECT tree, field, description FROM [
@@ -1444,10 +1444,10 @@ cross-join  ·            ·
  │          pred         b = b
  ├── scan   ·            ·
  │          table        foo@primary
- │          spans        ALL
+ │          spans        FULL SCAN
  └── scan   ·            ·
 ·           table        bar@primary
-·           spans        ALL
+·           spans        FULL SCAN
 
 # Only a can be an equality column.
 query TTT
@@ -1463,10 +1463,10 @@ hash-join  ·            ·
  │         pred         b = b
  ├── scan  ·            ·
  │         table        foo@primary
- │         spans        ALL
+ │         spans        FULL SCAN
  └── scan  ·            ·
 ·          table        bar@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 # Only a and c can be equality columns.
 query TTT
@@ -1481,10 +1481,10 @@ render          ·            ·
       │         pred         (b = b) AND (d = d)
       ├── scan  ·            ·
       │         table        foo@primary
-      │         spans        ALL
+      │         spans        FULL SCAN
       └── scan  ·            ·
 ·               table        bar@primary
-·               spans        ALL
+·               spans        FULL SCAN
 
 # Zigzag join tests.
 statement ok
@@ -1624,12 +1624,12 @@ render               ·               ·
       │    │         order           +x
       │    └── scan  ·               ·
       │              table           onecolumn@primary
-      │              spans           ALL
+      │              spans           FULL SCAN
       └── sort       ·               ·
            │         order           +x
            └── scan  ·               ·
 ·                    table           twocolumn@primary
-·                    spans           ALL
+·                    spans           FULL SCAN
 
 # Test that we can force a merge join using the NATURAL syntax.
 query TTT
@@ -1646,12 +1646,12 @@ render               ·               ·
       │    │         order           +x
       │    └── scan  ·               ·
       │              table           onecolumn@primary
-      │              spans           ALL
+      │              spans           FULL SCAN
       └── sort       ·               ·
            │         order           +x
            └── scan  ·               ·
 ·                    table           twocolumn@primary
-·                    spans           ALL
+·                    spans           FULL SCAN
 
 # Test that we can force a merge join using the CROSS syntax.
 query TTT
@@ -1667,12 +1667,12 @@ merge-join      ·               ·
  │    │         order           +x
  │    └── scan  ·               ·
  │              table           onecolumn@primary
- │              spans           ALL
+ │              spans           FULL SCAN
  └── sort       ·               ·
       │         order           +x
       └── scan  ·               ·
 ·               table           twocolumn@primary
-·               spans           ALL
+·               spans           FULL SCAN
 
 statement error LOOKUP can only be used with INNER or LEFT joins
 EXPLAIN SELECT * FROM onecolumn RIGHT LOOKUP JOIN twocolumn USING(x)
@@ -1695,7 +1695,7 @@ hash-join  ·                   ·
  │         right cols are key  ·
  ├── scan  ·                   ·
  │         table               cards@primary
- │         spans               ALL
+ │         spans               FULL SCAN
  └── scan  ·                   ·
 ·          table               customers@primary
-·          spans               ALL
+·          spans               FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/join_order
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join_order
@@ -56,10 +56,10 @@ render                ·                   ·                (a, b, c, d, b, x, 
       │    │          type                cross            ·                         ·
       │    ├── scan   ·                   ·                (b, x)                    ·
       │    │          table               bx@primary       ·                         ·
-      │    │          spans               ALL              ·                         ·
+      │    │          spans               FULL SCAN        ·                         ·
       │    └── scan   ·                   ·                (c, y)                    ·
       │               table               cy@primary       ·                         ·
-      │               spans               ALL              ·                         ·
+      │               spans               FULL SCAN        ·                         ·
       └── scan        ·                   ·                (a, b, c, d)              ·
 ·                     table               abc@primary      ·                         ·
 ·                     spans               /1-/1/#          ·                         ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -41,17 +41,17 @@ limit                     ·            ·            (w)      +w
                 │         order        +w           ·        ·
                 └── scan  ·            ·            (w)      ·
 ·                         table        t@primary    ·        ·
-·                         spans        ALL          ·        ·
+·                         spans        FULL SCAN    ·        ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY k LIMIT 5
 ----
-·     distributed  false      ·       ·
-·     vectorized   true       ·       ·
-scan  ·            ·          (k, v)  +k
-·     table        t@primary  ·       ·
-·     spans        ALL        ·       ·
-·     limit        5          ·       ·
+·     distributed  false         ·       ·
+·     vectorized   true          ·       ·
+scan  ·            ·             (k, v)  +k
+·     table        t@primary     ·       ·
+·     spans        LIMITED SCAN  ·       ·
+·     limit        5             ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY k OFFSET 5
@@ -62,31 +62,31 @@ limit      ·            ·          (k, v)  +k
  │         offset       5          ·       ·
  └── scan  ·            ·          (k, v)  +k
 ·          table        t@primary  ·       ·
-·          spans        ALL        ·       ·
+·          spans        FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY v LIMIT (1+4) OFFSET 1
 ----
-·          distributed  false      ·       ·
-·          vectorized   true       ·       ·
-limit      ·            ·          (k, v)  +v
- │         offset       1          ·       ·
- └── scan  ·            ·          (k, v)  +v
-·          table        t@t_v_idx  ·       ·
-·          spans        ALL        ·       ·
-·          limit        6          ·       ·
+·          distributed  false         ·       ·
+·          vectorized   true          ·       ·
+limit      ·            ·             (k, v)  +v
+ │         offset       1             ·       ·
+ └── scan  ·            ·             (k, v)  +v
+·          table        t@t_v_idx     ·       ·
+·          spans        LIMITED SCAN  ·       ·
+·          limit        6             ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY v DESC LIMIT (1+4) OFFSET 1
 ----
-·             distributed  false      ·       ·
-·             vectorized   true       ·       ·
-limit         ·            ·          (k, v)  -v
- │            offset       1          ·       ·
- └── revscan  ·            ·          (k, v)  -v
-·             table        t@t_v_idx  ·       ·
-·             spans        ALL        ·       ·
-·             limit        6          ·       ·
+·             distributed  false         ·       ·
+·             vectorized   true          ·       ·
+limit         ·            ·             (k, v)  -v
+ │            offset       1             ·       ·
+ └── revscan  ·            ·             (k, v)  -v
+·             table        t@t_v_idx     ·       ·
+·             spans        LIMITED SCAN  ·       ·
+·             limit        6             ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT sum(w) FROM t GROUP BY k, v ORDER BY v DESC LIMIT 10
@@ -107,43 +107,43 @@ render                    ·            ·                (sum)                 
                 │         ordered      +k               ·                       ·
                 └── scan  ·            ·                (k, v, w)               +k
 ·                         table        t@primary        ·                       ·
-·                         spans        ALL              ·                       ·
+·                         spans        FULL SCAN        ·                       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM (SELECT k, v FROM t ORDER BY v LIMIT 4)
 ----
-·          distributed  false      ·       ·
-·          vectorized   true       ·       ·
-render     ·            ·          (k)     ·
- │         render 0     k          ·       ·
- └── scan  ·            ·          (k, v)  ·
-·          table        t@t_v_idx  ·       ·
-·          spans        ALL        ·       ·
-·          limit        4          ·       ·
+·          distributed  false         ·       ·
+·          vectorized   true          ·       ·
+render     ·            ·             (k)     ·
+ │         render 0     k             ·       ·
+ └── scan  ·            ·             (k, v)  ·
+·          table        t@t_v_idx     ·       ·
+·          spans        LIMITED SCAN  ·       ·
+·          limit        4             ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM (SELECT k, v, w FROM t ORDER BY v LIMIT 4)
 ----
-·          distributed  false      ·       ·
-·          vectorized   true       ·       ·
-render     ·            ·          (k)     ·
- │         render 0     k          ·       ·
- └── scan  ·            ·          (k, v)  ·
-·          table        t@t_v_idx  ·       ·
-·          spans        ALL        ·       ·
-·          limit        4          ·       ·
+·          distributed  false         ·       ·
+·          vectorized   true          ·       ·
+render     ·            ·             (k)     ·
+ │         render 0     k             ·       ·
+ └── scan  ·            ·             (k, v)  ·
+·          table        t@t_v_idx     ·       ·
+·          spans        LIMITED SCAN  ·       ·
+·          limit        4             ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM (SELECT k FROM t LIMIT 5) WHERE k != 2
 ----
-·          distributed  false      ·    ·
-·          vectorized   true       ·    ·
-filter     ·            ·          (k)  ·
- │         filter       k != 2     ·    ·
- └── scan  ·            ·          (k)  ·
-·          table        t@t_v_idx  ·    ·
-·          spans        ALL        ·    ·
-·          limit        5          ·    ·
+·          distributed  false         ·    ·
+·          vectorized   true          ·    ·
+filter     ·            ·             (k)  ·
+ │         filter       k != 2        ·    ·
+ └── scan  ·            ·             (k)  ·
+·          table        t@t_v_idx     ·    ·
+·          spans        LIMITED SCAN  ·    ·
+·          limit        5             ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, w FROM t WHERE v >= 1 AND v <= 100 LIMIT 10
@@ -157,7 +157,7 @@ render          ·            ·                        (k, w)     ·
       │         count        10                       ·          ·
       └── scan  ·            ·                        (k, v, w)  ·
 ·               table        t@primary                ·          ·
-·               spans        ALL                      ·          ·
+·               spans        FULL SCAN                ·          ·
 ·               filter       (v >= 1) AND (v <= 100)  ·          ·
 
 query TTTTT
@@ -190,5 +190,5 @@ render               ·            ·                        (k, w)     ·
            │         count        10                       ·          ·
            └── scan  ·            ·                        (k, v, w)  +k
 ·                    table        t@primary                ·          ·
-·                    spans        ALL                      ·          ·
+·                    spans        FULL SCAN                ·          ·
 ·                    filter       (v >= 1) AND (v <= 100)  ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -40,7 +40,7 @@ lookup-join  ·            ·            (a, b, c, d, e, f)  ·
  │           equality     (b) = (f)    ·                   ·
  └── scan    ·            ·            (a, b, c)           ·
 ·            table        abc@primary  ·                   ·
-·            spans        ALL          ·                   ·
+·            spans        FULL SCAN    ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b AND e = c
@@ -56,7 +56,7 @@ lookup-join  ·                      ·                (a, b, c, d, e, f)  ·
  │           parallel               ·                ·                   ·
  └── scan    ·                      ·                (a, b, c)           ·
 ·            table                  abc@primary      ·                   ·
-·            spans                  ALL              ·                   ·
+·            spans                  FULL SCAN        ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b WHERE a > 1 AND e > 1
@@ -101,7 +101,7 @@ lookup-join  ·            ·            (a, b, c, d, e, f)  ·
  │           pred         @1 >= @5     ·                   ·
  └── scan    ·            ·            (a, b, c)           ·
 ·            table        abc@primary  ·                   ·
-·            spans        ALL          ·                   ·
+·            spans        FULL SCAN    ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b AND a >= e
@@ -116,7 +116,7 @@ lookup-join  ·            ·            (a, b, c, d, e, f)  ·
  │           pred         @1 >= @5     ·                   ·
  └── scan    ·            ·            (a, b, c)           ·
 ·            table        abc@primary  ·                   ·
-·            spans        ALL          ·                   ·
+·            spans        FULL SCAN    ·                   ·
 
 # Verify a distsql plan.
 statement ok
@@ -175,7 +175,7 @@ render            ·                      ·                            (a, b, c
       │           parallel               ·                            ·                         ·
       └── scan    ·                      ·                            (a, b, c, d)              ·
 ·                 table                  data@primary                 ·                         ·
-·                 spans                  ALL                          ·                         ·
+·                 spans                  FULL SCAN                    ·                         ·
 ·                 filter                 c = 1                        ·                         ·
 
 query T
@@ -227,7 +227,7 @@ distinct               ·            ·                  (title)                
            │           pred         @2 != @4           ·                             ·
            └── scan    ·            ·                  (title, shelf)                +title
 ·                      table        books@primary      ·                             ·
-·                      spans        ALL                ·                             ·
+·                      spans        FULL SCAN          ·                             ·
 
 statement ok
 CREATE TABLE authors (name STRING, book STRING)
@@ -262,10 +262,10 @@ distinct                  ·            ·                  (name)              
                 │         equality     (book) = (title)   ·                                         ·
                 ├── scan  ·            ·                  (name, book)                              ·
                 │         table        authors@primary    ·                                         ·
-                │         spans        ALL                ·                                         ·
+                │         spans        FULL SCAN          ·                                         ·
                 └── scan  ·            ·                  (title, shelf)                            ·
 ·                         table        books@primary      ·                                         ·
-·                         spans        ALL                ·                                         ·
+·                         spans        FULL SCAN          ·                                         ·
 
 # Verify data placement.
 query TTTI colnames
@@ -295,7 +295,7 @@ render               ·            ·                 (name)               +name
            │         order        +name             ·                    ·
            └── scan  ·            ·                 (name, book)         ·
 ·                    table        authors@primary   ·                    ·
-·                    spans        ALL               ·                    ·
+·                    spans        FULL SCAN         ·                    ·
 
 # Cross joins should not be planned as lookup joins.
 query TTTTT colnames
@@ -315,10 +315,10 @@ render           ·            ·               (title, edition, shelf, title, e
       │          type         cross           ·                                               ·
       ├── scan   ·            ·               (title, edition, shelf)                         ·
       │          table        books2@primary  ·                                               ·
-      │          spans        ALL             ·                                               ·
+      │          spans        FULL SCAN       ·                                               ·
       └── scan   ·            ·               (title, edition, shelf)                         ·
 ·                table        books@primary   ·                                               ·
-·                spans        ALL             ·                                               ·
+·                spans        FULL SCAN       ·                                               ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM authors INNER JOIN books2 ON books2.edition = 1 WHERE books2.title = authors.book]
@@ -381,7 +381,7 @@ render            ·            ·              (a, c)     ·
       │           equality     (a) = (b)      ·          ·
       └── scan    ·            ·              (a)        ·
 ·                 table        small@primary  ·          ·
-·                 spans        ALL            ·          ·
+·                 spans        FULL SCAN      ·          ·
 
 # Lookup join on non-covering secondary index
 query TTTTT
@@ -404,7 +404,7 @@ render                 ·                      ·                (a, d)        �
            │           equality               (a) = (b)        ·             ·
            └── scan    ·                      ·                (a)           ·
 ·                      table                  small@primary    ·             ·
-·                      spans                  ALL              ·             ·
+·                      spans                  FULL SCAN        ·             ·
 
 ############################
 #  LEFT OUTER LOOKUP JOIN  #
@@ -422,7 +422,7 @@ lookup-join  ·            ·              (b, a)  ·
  │           equality     (b) = (a)      ·       ·
  └── scan    ·            ·              (b)     ·
 ·            table        small@primary  ·       ·
-·            spans        ALL            ·       ·
+·            spans        FULL SCAN      ·       ·
 
 # Left join should preserve input order.
 query TTTTT
@@ -440,7 +440,7 @@ render            ·            ·              (a, b)     +a
       │           pred         (@3 % 6) = 0   ·          ·
       └── scan    ·            ·              (a)        +a
 ·                 table        small@primary  ·          ·
-·                 spans        ALL            ·          ·
+·                 spans        FULL SCAN      ·          ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT t1.a, t2.b FROM small t1 LEFT JOIN large t2 ON t1.a = t2.a AND t2.b % 6 = 0 ORDER BY t1.a]
@@ -462,7 +462,7 @@ render            ·            ·              (c, c)     ·
       │           equality     (c) = (b)      ·          ·
       └── scan    ·            ·              (c)        ·
 ·                 table        small@primary  ·          ·
-·                 spans        ALL            ·          ·
+·                 spans        FULL SCAN      ·          ·
 
 # Left join against non-covering secondary index
 query TTTTT
@@ -485,7 +485,7 @@ render                 ·                      ·                (c, d)        �
            │           equality               (c) = (b)        ·             ·
            └── scan    ·                      ·                (c)           ·
 ·                      table                  small@primary    ·             ·
-·                      spans                  ALL              ·             ·
+·                      spans                  FULL SCAN        ·             ·
 
 # Left join with ON filter on covering index
 query TTTTT
@@ -503,7 +503,7 @@ render            ·            ·              (c, c)     ·
       │           pred         @3 < 20        ·          ·
       └── scan    ·            ·              (c)        ·
 ·                 table        small@primary  ·          ·
-·                 spans        ALL            ·          ·
+·                 spans        FULL SCAN      ·          ·
 
 # Left join with ON filter on non-covering index
 # TODO(radu): this doesn't use lookup join yet, the current rules don't cover
@@ -521,11 +521,11 @@ render          ·            ·              (c, d)     ·
       │         equality     (b) = (c)      ·          ·
       ├── scan  ·            ·              (b, d)     ·
       │         table        large@primary  ·          ·
-      │         spans        ALL            ·          ·
+      │         spans        FULL SCAN      ·          ·
       │         filter       d < 30         ·          ·
       └── scan  ·            ·              (c)        ·
 ·               table        small@primary  ·          ·
-·               spans        ALL            ·          ·
+·               spans        FULL SCAN      ·          ·
 
 ###########################################################
 #  LOOKUP JOINS ON IMPLICIT INDEX KEY COLUMNS             #
@@ -554,7 +554,7 @@ render            ·            ·                (a)              ·
       │           equality     (d, a) = (d, a)  ·                ·
       └── scan    ·            ·                (a, d, e)        ·
 ·                 table        t@primary        ·                ·
-·                 spans        ALL              ·                ·
+·                 spans        FULL SCAN        ·                ·
 ·                 filter       e = 5            ·                ·
 
 # Test unique version of same index. (Lookup join should not use column a.)
@@ -580,7 +580,7 @@ render            ·                      ·          (a)              ·
       │           pred                   @1 = @4    ·                ·
       └── scan    ·                      ·          (a, d, e)        ·
 ·                 table                  t@primary  ·                ·
-·                 spans                  ALL        ·                ·
+·                 spans                  FULL SCAN  ·                ·
 ·                 filter                 e = 5      ·                ·
 
 # Test index with first primary key column explicit and the rest implicit.
@@ -603,7 +603,7 @@ render            ·            ·                      (a)                    �
       │           equality     (d, a, b) = (d, a, b)  ·                      ·
       └── scan    ·            ·                      (a, b, d, e)           ·
 ·                 table        t@primary              ·                      ·
-·                 spans        ALL                    ·                      ·
+·                 spans        FULL SCAN              ·                      ·
 ·                 filter       e = 5                  ·                      ·
 
 # Test index with middle primary key column explicit and the rest implicit.
@@ -626,7 +626,7 @@ render            ·            ·                      (a)                    �
       │           equality     (d, b, a) = (d, b, a)  ·                      ·
       └── scan    ·            ·                      (a, b, d, e)           ·
 ·                 table        t@primary              ·                      ·
-·                 spans        ALL                    ·                      ·
+·                 spans        FULL SCAN              ·                      ·
 ·                 filter       e = 5                  ·                      ·
 
 # Test index with last primary key column explicit and the rest implicit.
@@ -650,7 +650,7 @@ render            ·            ·          (a)              ·
       │           pred         @1 = @4    ·                ·
       └── scan    ·            ·          (a, d, e)        ·
 ·                 table        t@primary  ·                ·
-·                 spans        ALL        ·                ·
+·                 spans        FULL SCAN  ·                ·
 ·                 filter       e = 5      ·                ·
 
 query TTTTT
@@ -671,7 +671,7 @@ render            ·            ·            (d, e, f, a, b, c)  ·
       │           equality     (a) = (f)    ·                   ·
       └── scan    ·            ·            (a, b, c)           +a
 ·                 table        abc@primary  ·                   ·
-·                 spans        ALL          ·                   ·
+·                 spans        FULL SCAN    ·                   ·
 
 # Test that we don't get a lookup join if we force a merge join.
 query TTTTT
@@ -685,10 +685,10 @@ merge-join  ·               ·            (d, e, f, a, b, c)  +f
  │          mergeJoinOrder  +"(f=a)"     ·                   ·
  ├── scan   ·               ·            (d, e, f)           +f
  │          table           def@primary  ·                   ·
- │          spans           ALL          ·                   ·
+ │          spans           FULL SCAN    ·                   ·
  └── scan   ·               ·            (a, b, c)           +a
 ·           table           abc@primary  ·                   ·
-·           spans           ALL          ·                   ·
+·           spans           FULL SCAN    ·                   ·
 
 # Test that we don't get a lookup join if we force a hash join.
 query TTTTT
@@ -703,10 +703,10 @@ sort            ·            ·            (d, e, f, a, b, c)  +f
       │         equality     (f) = (a)    ·                   ·
       ├── scan  ·            ·            (d, e, f)           ·
       │         table        def@primary  ·                   ·
-      │         spans        ALL          ·                   ·
+      │         spans        FULL SCAN    ·                   ·
       └── scan  ·            ·            (a, b, c)           ·
 ·               table        abc@primary  ·                   ·
-·               spans        ALL          ·                   ·
+·               spans        FULL SCAN    ·                   ·
 
 # Test lookup semi and anti join.
 query TTTTT
@@ -720,7 +720,7 @@ lookup-join  ·            ·            (a, b, c)  ·
  │           equality     (a) = (f)    ·          ·
  └── scan    ·            ·            (a, b, c)  ·
 ·            table        abc@primary  ·          ·
-·            spans        ALL          ·          ·
+·            spans        FULL SCAN    ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=f)
@@ -733,7 +733,7 @@ lookup-join  ·            ·            (a, b, c)  ·
  │           equality     (a) = (f)    ·          ·
  └── scan    ·            ·            (a, b, c)  ·
 ·            table        abc@primary  ·          ·
-·            spans        ALL          ·          ·
+·            spans        FULL SCAN    ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=f AND c=e)
@@ -748,7 +748,7 @@ lookup-join  ·                      ·                (a, b, c)  ·
  │           parallel               ·                ·          ·
  └── scan    ·                      ·                (a, b, c)  ·
 ·            table                  abc@primary      ·          ·
-·            spans                  ALL              ·          ·
+·            spans                  FULL SCAN        ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=f AND c=e)
@@ -763,7 +763,7 @@ lookup-join  ·                      ·                (a, b, c)  ·
  │           parallel               ·                ·          ·
  └── scan    ·                      ·                (a, b, c)  ·
 ·            table                  abc@primary      ·          ·
-·            spans                  ALL              ·          ·
+·            spans                  FULL SCAN        ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=f AND d+b>1)
@@ -777,7 +777,7 @@ lookup-join  ·            ·              (a, b, c)  ·
  │           pred         (@4 + @2) > 1  ·          ·
  └── scan    ·            ·              (a, b, c)  ·
 ·            table        abc@primary    ·          ·
-·            spans        ALL            ·          ·
+·            spans        FULL SCAN      ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=f AND d+b>1)
@@ -791,7 +791,7 @@ lookup-join  ·            ·              (a, b, c)  ·
  │           pred         (@4 + @2) > 1  ·          ·
  └── scan    ·            ·              (a, b, c)  ·
 ·            table        abc@primary    ·          ·
-·            spans        ALL            ·          ·
+·            spans        FULL SCAN      ·          ·
 
 query T
 SELECT url FROM [ EXPLAIN (DISTSQL)
@@ -838,7 +838,7 @@ group                  ·            ·
            │           equality     (a) = (a)
            └── scan    ·            ·
 ·                      table        b@primary
-·                      spans        ALL
+·                      spans        FULL SCAN
 
 statement ok
 SET tracing = on
@@ -1457,9 +1457,9 @@ limit                                               ·                      ·
                                          │          mergeJoinOrder         +"(l_orderkey=l_orderkey)"
                                          ├── scan   ·                      ·
                                          │          table                  lineitem@primary
-                                         │          spans                  ALL
+                                         │          spans                  FULL SCAN
                                          │          filter                 l_receiptdate > l_commitdate
                                          └── scan   ·                      ·
 ·                                                   table                  lineitem@primary
-·                                                   spans                  ALL
+·                                                   spans                  FULL SCAN
 ·                                                   filter                 l_receiptdate > l_commitdate

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -17,7 +17,7 @@ sort       ·            ·
  │         order        +b
  └── scan  ·            ·
 ·          table        t@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY b DESC
@@ -28,7 +28,7 @@ sort       ·            ·
  │         order        -b
  └── scan  ·            ·
 ·          table        t@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 # TODO(radu): Should set "strategy top 2" on sort node
 query TTT
@@ -42,7 +42,7 @@ limit           ·            ·
       │         order        +b
       └── scan  ·            ·
 ·               table        t@primary
-·               spans        ALL
+·               spans        FULL SCAN
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT c, b FROM t ORDER BY b LIMIT 2
@@ -60,7 +60,7 @@ render                    ·            ·          (c, b)  ·
                 │         distinct on  b, c       ·       ·
                 └── scan  ·            ·          (b, c)  ·
 ·                         table        t@primary  ·       ·
-·                         spans        ALL        ·       ·
+·                         spans        FULL SCAN  ·       ·
 
 query TTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC
@@ -70,7 +70,7 @@ EXPLAIN SELECT b FROM t ORDER BY a DESC
 render        ·            ·
  └── revscan  ·            ·
 ·             table        t@primary
-·             spans        ALL
+·             spans        FULL SCAN
 
 # Check that LIMIT propagates past nosort nodes.
 query TTT
@@ -81,7 +81,7 @@ EXPLAIN SELECT b FROM t ORDER BY a LIMIT 1
 render     ·            ·
  └── scan  ·            ·
 ·          table        t@primary
-·          spans        ALL
+·          spans        LIMITED SCAN
 ·          limit        1
 
 query TTT
@@ -92,7 +92,7 @@ EXPLAIN SELECT b FROM t ORDER BY a DESC, b ASC
 render        ·            ·
  └── revscan  ·            ·
 ·             table        t@primary
-·             spans        ALL
+·             spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b DESC
@@ -102,7 +102,7 @@ EXPLAIN SELECT b FROM t ORDER BY a DESC, b DESC
 render        ·            ·
  └── revscan  ·            ·
 ·             table        t@primary
-·             spans        ALL
+·             spans        FULL SCAN
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY (b, t.*)
@@ -113,7 +113,7 @@ sort       ·            ·          (a, b, c)  +b,+a
  │         order        +b,+a      ·          ·
  └── scan  ·            ·          (a, b, c)  ·
 ·          table        t@primary  ·          ·
-·          spans        ALL        ·          ·
+·          spans        FULL SCAN  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY (b, a), c
@@ -124,7 +124,7 @@ sort       ·            ·          (a, b, c)  +b,+a
  │         order        +b,+a      ·          ·
  └── scan  ·            ·          (a, b, c)  ·
 ·          table        t@primary  ·          ·
-·          spans        ALL        ·          ·
+·          spans        FULL SCAN  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY b, (a, c)
@@ -135,7 +135,7 @@ sort       ·            ·          (a, b, c)  +b,+a
  │         order        +b,+a      ·          ·
  └── scan  ·            ·          (a, b, c)  ·
 ·          table        t@primary  ·          ·
-·          spans        ALL        ·          ·
+·          spans        FULL SCAN  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY (b, (a, c))
@@ -146,7 +146,7 @@ sort       ·            ·          (a, b, c)  +b,+a
  │         order        +b,+a      ·          ·
  └── scan  ·            ·          (a, b, c)  ·
 ·          table        t@primary  ·          ·
-·          spans        ALL        ·          ·
+·          spans        FULL SCAN  ·          ·
 
 # Check that sort is skipped if the ORDER BY clause is constant.
 query TTT
@@ -156,7 +156,7 @@ EXPLAIN SELECT * FROM t ORDER BY 1+2
 ·     vectorized   true
 scan  ·            ·
 ·     table        t@primary
-·     spans        ALL
+·     spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT 1, * FROM t ORDER BY 1
@@ -166,7 +166,7 @@ EXPLAIN SELECT 1, * FROM t ORDER BY 1
 render     ·            ·
  └── scan  ·            ·
 ·          table        t@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM t ORDER BY length('abc')
@@ -175,7 +175,7 @@ EXPLAIN SELECT * FROM t ORDER BY length('abc')
 ·     vectorized   true
 scan  ·            ·
 ·     table        t@primary
-·     spans        ALL
+·     spans        FULL SCAN
 
 # Check that the sort key reuses the existing render.
 query TTTTT
@@ -189,7 +189,7 @@ sort            ·            ·          (r)  +r
       │         render 0     b + 2      ·    ·
       └── scan  ·            ·          (b)  ·
 ·               table        t@primary  ·    ·
-·               spans        ALL        ·    ·
+·               spans        FULL SCAN  ·    ·
 
 # Check that the sort picks up a renamed render properly.
 query TTTTT
@@ -203,7 +203,7 @@ sort            ·            ·          (y)  +y
       │         render 0     b + 2      ·    ·
       └── scan  ·            ·          (b)  ·
 ·               table        t@primary  ·    ·
-·               spans        ALL        ·    ·
+·               spans        FULL SCAN  ·    ·
 
 statement ok
 CREATE TABLE abc (
@@ -258,7 +258,7 @@ EXPLAIN SELECT a, b, c FROM abc ORDER BY b, a, c
 ·     vectorized   true
 scan  ·            ·
 ·     table        abc@ba
-·     spans        ALL
+·     spans        FULL SCAN
 
 # We use the WHERE condition to force the use of the index.
 query TTT
@@ -288,7 +288,7 @@ render          ·            ·
       │         order        +b,+a,+d
       └── scan  ·            ·
 ·               table        abc@primary
-·               spans        ALL
+·               spans        FULL SCAN
 ·               filter       b > 10
 
 query III
@@ -312,7 +312,7 @@ sort       ·            ·            (a, b, c, d)  +b,+a,+c
  │         order        +b,+a,+c     ·             ·
  └── scan  ·            ·            (a, b, c, d)  ·
 ·          table        abc@primary  ·             ·
-·          spans        ALL          ·             ·
+·          spans        FULL SCAN    ·             ·
 ·          filter       b > 10       ·             ·
 
 query TTT
@@ -323,19 +323,19 @@ EXPLAIN SELECT a, b FROM abc ORDER BY b, c
 render     ·            ·
  └── scan  ·            ·
 ·          table        abc@bc
-·          spans        ALL
+·          spans        FULL SCAN
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a, b FROM abc ORDER BY b, c
 ----
-·          distributed  false   ·          ·
-·          vectorized   true    ·          ·
-render     ·            ·       (a, b)     ·
- │         render 0     a       ·          ·
- │         render 1     b       ·          ·
- └── scan  ·            ·       (a, b, c)  +b,+c
-·          table        abc@bc  ·          ·
-·          spans        ALL     ·          ·
+·          distributed  false      ·          ·
+·          vectorized   true       ·          ·
+render     ·            ·          (a, b)     ·
+ │         render 0     a          ·          ·
+ │         render 1     b          ·          ·
+ └── scan  ·            ·          (a, b, c)  +b,+c
+·          table        abc@bc     ·          ·
+·          spans        FULL SCAN  ·          ·
 
 query TTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a
@@ -345,7 +345,7 @@ EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a
 render     ·            ·
  └── scan  ·            ·
 ·          table        abc@bc
-·          spans        ALL
+·          spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a DESC
@@ -355,7 +355,7 @@ EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a DESC
 render     ·            ·
  └── scan  ·            ·
 ·          table        abc@bc
-·          spans        ALL
+·          spans        FULL SCAN
 
 statement ok
 SET tracing = on,kv,results; SELECT b, c FROM abc ORDER BY b, c; SET tracing = off
@@ -405,7 +405,7 @@ EXPLAIN SELECT a FROM abc ORDER BY a DESC
 ·        vectorized   true
 revscan  ·            ·
 ·        table        abc@primary
-·        spans        ALL
+·        spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c
@@ -450,7 +450,7 @@ EXPLAIN (VERBOSE) SELECT * FROM bar ORDER BY baz, id
 ·     vectorized   true       ·          ·
 scan  ·            ·          (id, baz)  +baz,+id
 ·     table        bar@i_bar  ·          ·
-·     spans        ALL        ·          ·
+·     spans        FULL SCAN  ·          ·
 
 statement ok
 CREATE TABLE abcd (
@@ -617,7 +617,7 @@ render                    ·                 ·           (b)                 ·
                 │         render 3          true        ·                   ·
                 └── scan  ·                 ·           (a, b, c)           ·
 ·                         table             t@primary   ·                   ·
-·                         spans             ALL         ·                   ·
+·                         spans             FULL SCAN   ·                   ·
 ·                         locking strength  for update  ·                   ·
 
 statement ok
@@ -675,7 +675,7 @@ render     ·            ·               (block_id, writer_id, block_num, block
  │         render 3     block_id        ·                                           ·
  └── scan  ·            ·               (block_id, writer_id, block_num)            ·
 ·          table        blocks@primary  ·                                           ·
-·          spans        ALL             ·                                           ·
+·          spans        LIMITED SCAN    ·                                           ·
 ·          limit        1               ·                                           ·
 
 statement ok
@@ -698,7 +698,7 @@ render               ·            ·            (b, a)           ·
            │         render 2     b            ·                ·
            └── scan  ·            ·            (a, b)           ·
 ·                    table        foo@primary  ·                ·
-·                    spans        ALL          ·                ·
+·                    spans        FULL SCAN    ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b, a FROM foo ORDER BY @2
@@ -716,7 +716,7 @@ render               ·            ·            (b, a)           ·
            │         render 2     b            ·                ·
            └── scan  ·            ·            (a, b)           ·
 ·                    table        foo@primary  ·                ·
-·                    spans        ALL          ·                ·
+·                    spans        FULL SCAN    ·                ·
 
 # ------------------------------------------------------------------------------
 # Check star expansion in ORDER BY.
@@ -735,7 +735,7 @@ sort       ·            ·
  │         order        +x,+y
  └── scan  ·            ·
 ·          table        a@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 query TTT
 SELECT tree, field, description FROM [
@@ -748,7 +748,7 @@ sort       ·            ·
  │         order        +x,+y
  └── scan  ·            ·
 ·          table        a@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 # ------------------------------------------------------------------------------
 # ORDER BY INDEX test cases.
@@ -767,7 +767,7 @@ render     ·            ·           (v)     ·
  │         render 0     v           ·       ·
  └── scan  ·            ·           (k, v)  +k
 ·          table        kv@primary  ·       ·
-·          spans        ALL         ·       ·
+·          spans        FULL SCAN   ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT v FROM kv ORDER BY PRIMARY KEY kv ASC
@@ -778,7 +778,7 @@ render     ·            ·           (v)     ·
  │         render 0     v           ·       ·
  └── scan  ·            ·           (k, v)  +k
 ·          table        kv@primary  ·       ·
-·          spans        ALL         ·       ·
+·          spans        FULL SCAN   ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT v FROM kv ORDER BY PRIMARY KEY kv DESC
@@ -789,7 +789,7 @@ render        ·            ·           (v)     ·
  │            render 0     v           ·       ·
  └── revscan  ·            ·           (k, v)  -k
 ·             table        kv@primary  ·       ·
-·             spans        ALL         ·       ·
+·             spans        FULL SCAN   ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY v, PRIMARY KEY kv, v-2
@@ -802,51 +802,51 @@ render          ·            ·           (k)     ·
       │         order        +v,+k       ·       ·
       └── scan  ·            ·           (k, v)  ·
 ·               table        kv@primary  ·       ·
-·               spans        ALL         ·       ·
+·               spans        FULL SCAN   ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo
 ----
-·          distributed  false   ·       ·
-·          vectorized   true    ·       ·
-render     ·            ·       (k)     ·
- │         render 0     k       ·       ·
- └── scan  ·            ·       (k, v)  -v,+k
-·          table        kv@foo  ·       ·
-·          spans        ALL     ·       ·
+·          distributed  false      ·       ·
+·          vectorized   true       ·       ·
+render     ·            ·          (k)     ·
+ │         render 0     k          ·       ·
+ └── scan  ·            ·          (k, v)  -v,+k
+·          table        kv@foo     ·       ·
+·          spans        FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo ASC
 ----
-·          distributed  false   ·       ·
-·          vectorized   true    ·       ·
-render     ·            ·       (k)     ·
- │         render 0     k       ·       ·
- └── scan  ·            ·       (k, v)  -v,+k
-·          table        kv@foo  ·       ·
-·          spans        ALL     ·       ·
+·          distributed  false      ·       ·
+·          vectorized   true       ·       ·
+render     ·            ·          (k)     ·
+ │         render 0     k          ·       ·
+ └── scan  ·            ·          (k, v)  -v,+k
+·          table        kv@foo     ·       ·
+·          spans        FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo DESC
 ----
-·             distributed  false   ·       ·
-·             vectorized   true    ·       ·
-render        ·            ·       (k)     ·
- │            render 0     k       ·       ·
- └── revscan  ·            ·       (k, v)  +v,-k
-·             table        kv@foo  ·       ·
-·             spans        ALL     ·       ·
+·             distributed  false      ·       ·
+·             vectorized   true       ·       ·
+render        ·            ·          (k)     ·
+ │            render 0     k          ·       ·
+ └── revscan  ·            ·          (k, v)  +v,-k
+·             table        kv@foo     ·       ·
+·             spans        FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo, k
 ----
-·          distributed  false   ·       ·
-·          vectorized   true    ·       ·
-render     ·            ·       (k)     ·
- │         render 0     k       ·       ·
- └── scan  ·            ·       (k, v)  -v,+k
-·          table        kv@foo  ·       ·
-·          spans        ALL     ·       ·
+·          distributed  false      ·       ·
+·          vectorized   true       ·       ·
+render     ·            ·          (k)     ·
+ │         render 0     k          ·       ·
+ └── scan  ·            ·          (k, v)  -v,+k
+·          table        kv@foo     ·       ·
+·          spans        FULL SCAN  ·       ·
 
 # Check the syntax can be used with joins.
 #
@@ -893,10 +893,10 @@ render           ·                   ·                  (k)           ·
       │          mergeJoinOrder      -"(v=v)",+"(k=k)"  ·             ·
       ├── scan   ·                   ·                  (k, v)        -v,+k
       │          table               kv@foo             ·             ·
-      │          spans               ALL                ·             ·
+      │          spans               FULL SCAN          ·             ·
       └── scan   ·                   ·                  (k, v)        -v,+k
 ·                table               kv@foo             ·             ·
-·                spans               ALL                ·             ·
+·                spans               FULL SCAN          ·             ·
 
 statement ok
 CREATE TABLE xyz (x INT, y INT, z INT, INDEX(z,y))

--- a/pkg/sql/opt/exec/execbuilder/testdata/ordinality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ordinality
@@ -14,7 +14,7 @@ group            ·            ·                (max)           ·
  └── ordinality  ·            ·                ("ordinality")  ·
       └── scan   ·            ·                ()              ·
 ·                table        foo@primary      ·               ·
-·                spans        ALL              ·               ·
+·                spans        FULL SCAN        ·               ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM foo WITH ORDINALITY WHERE ordinality > 1 ORDER BY ordinality
@@ -26,7 +26,7 @@ filter           ·            ·                 (x, "ordinality")  +"ordinalit
  └── ordinality  ·            ·                 (x, "ordinality")  ·
       └── scan   ·            ·                 (x)                ·
 ·                table        foo@primary       ·                  ·
-·                spans        ALL               ·                  ·
+·                spans        FULL SCAN         ·                  ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM foo WITH ORDINALITY WHERE ordinality > 1 ORDER BY ordinality DESC
@@ -40,7 +40,7 @@ sort                  ·            ·                 (x, "ordinality")  -"ordi
       └── ordinality  ·            ·                 (x, "ordinality")  ·
            └── scan   ·            ·                 (x)                ·
 ·                     table        foo@primary       ·                  ·
-·                     spans        ALL               ·                  ·
+·                     spans        FULL SCAN         ·                  ·
 
 # Show that the primary key is used under ordinalityNode.
 query TTTTT
@@ -65,4 +65,4 @@ filter           ·            ·            (x, "ordinality")  ·
  └── ordinality  ·            ·            (x, "ordinality")  ·
       └── scan   ·            ·            (x)                ·
 ·                table        foo@primary  ·                  ·
-·                spans        ALL          ·                  ·
+·                spans        FULL SCAN    ·                  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -15,7 +15,7 @@ EXECUTE change_index
 ·     vectorized   true
 scan  ·            ·
 ·     table        ab@primary
-·     spans        ALL
+·     spans        FULL SCAN
 ·     filter       b = 10
 
 statement ok
@@ -40,7 +40,7 @@ EXECUTE change_index
 ·     vectorized   true
 scan  ·            ·
 ·     table        ab@primary
-·     spans        ALL
+·     spans        FULL SCAN
 ·     filter       b = 10
 
 ## Statistics change: Create statistics and ensure that the plan is recalculated.
@@ -63,10 +63,10 @@ merge-join  ·                   ·
  │          mergeJoinOrder      +"(a=c)"
  ├── scan   ·                   ·
  │          table               ab@primary
- │          spans               ALL
+ │          spans               FULL SCAN
  └── scan   ·                   ·
 ·           table               cd@primary
-·           spans               ALL
+·           spans               FULL SCAN
 
 statement ok
 CREATE STATISTICS s FROM ab
@@ -87,4 +87,4 @@ lookup-join  ·                      ·
  │           parallel               ·
  └── scan    ·                      ·
 ·            table                  ab@primary
-·            spans                  ALL
+·            spans                  FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -61,7 +61,7 @@ render     ·            ·          (r)  ·
  │         render 0     3          ·    ·
  └── scan  ·            ·          ()   ·
 ·          table        t@primary  ·    ·
-·          spans        ALL        ·    ·
+·          spans        FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a + 2 AS r FROM t
@@ -72,7 +72,7 @@ render     ·            ·          (r)  ·
  │         render 0     a + 2      ·    ·
  └── scan  ·            ·          (a)  ·
 ·          table        t@primary  ·    ·
-·          spans        ALL        ·    ·
+·          spans        FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a >= 5 AND b <= 10 AND c < 4 AS r FROM t
@@ -83,7 +83,7 @@ render     ·            ·                                     (r)        ·
  │         render 0     ((a >= 5) AND (b <= 10)) AND (c < 4)  ·          ·
  └── scan  ·            ·                                     (a, b, c)  ·
 ·          table        t@primary                             ·          ·
-·          spans        ALL                                   ·          ·
+·          spans        FULL SCAN                             ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a >= 5 OR b <= 10 OR c < 4 AS r FROM t
@@ -94,7 +94,7 @@ render     ·            ·                                   (r)        ·
  │         render 0     ((a >= 5) OR (b <= 10)) OR (c < 4)  ·          ·
  └── scan  ·            ·                                   (a, b, c)  ·
 ·          table        t@primary                           ·          ·
-·          spans        ALL                                 ·          ·
+·          spans        FULL SCAN                           ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT NOT (a = 5) AS r FROM t
@@ -105,7 +105,7 @@ render     ·            ·          (r)  ·
  │         render 0     a != 5     ·    ·
  └── scan  ·            ·          (a)  ·
 ·          table        t@primary  ·    ·
-·          spans        ALL        ·    ·
+·          spans        FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT NOT (a > 5 AND b >= 10) AS r FROM t
@@ -116,7 +116,7 @@ render     ·            ·                     (r)     ·
  │         render 0     (a <= 5) OR (b < 10)  ·       ·
  └── scan  ·            ·                     (a, b)  ·
 ·          table        t@primary             ·       ·
-·          spans        ALL                   ·       ·
+·          spans        FULL SCAN             ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (a >= 5 AND b <= 10) OR (a <= 10 AND c > 5) AS r FROM t
@@ -127,7 +127,7 @@ render     ·            ·                                                    (
  │         render 0     ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))  ·          ·
  └── scan  ·            ·                                                    (a, b, c)  ·
 ·          table        t@primary                                            ·          ·
-·          spans        ALL                                                  ·          ·
+·          spans        FULL SCAN                                            ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT NOT (a >= 5 OR b <= 10) AND NOT (c >= 10) AS r FROM t
@@ -138,7 +138,7 @@ render     ·            ·                                    (r)        ·
  │         render 0     ((a < 5) AND (b > 10)) AND (c < 10)  ·          ·
  └── scan  ·            ·                                    (a, b, c)  ·
 ·          table        t@primary                            ·          ·
-·          spans        ALL                                  ·          ·
+·          spans        FULL SCAN                            ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, b) = (1, 2)  AS r FROM t
@@ -149,7 +149,7 @@ render     ·            ·                    (r)     ·
  │         render 0     (a = 1) AND (b = 2)  ·       ·
  └── scan  ·            ·                    (a, b)  ·
 ·          table        t@primary            ·       ·
-·          spans        ALL                  ·       ·
+·          spans        FULL SCAN            ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IN (1, 2) AS r FROM t
@@ -160,7 +160,7 @@ render     ·            ·            (r)  ·
  │         render 0     a IN (1, 2)  ·    ·
  └── scan  ·            ·            (a)  ·
 ·          table        t@primary    ·    ·
-·          spans        ALL          ·    ·
+·          spans        FULL SCAN    ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, b) IN ((1, 2), (3, 4)) AS r FROM t
@@ -171,7 +171,7 @@ render     ·            ·                           (r)     ·
  │         render 0     (a, b) IN ((1, 2), (3, 4))  ·       ·
  └── scan  ·            ·                           (a, b)  ·
 ·          table        t@primary                   ·       ·
-·          spans        ALL                         ·       ·
+·          spans        FULL SCAN                   ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, b + c, 5 + d * 2) = (b+c, 8, a - c)  AS r FROM t
@@ -182,7 +182,7 @@ render     ·            ·                                                     
  │         render 0     ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))  ·             ·
  └── scan  ·            ·                                                                (a, b, c, d)  ·
 ·          table        t@primary                                                        ·             ·
-·          spans        ALL                                                              ·             ·
+·          spans        FULL SCAN                                                        ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ((a, b), (c, d)) = ((1, 2), (3, 4))  AS r FROM t
@@ -193,7 +193,7 @@ render     ·            ·                                                (r)  
  │         render 0     (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)  ·             ·
  └── scan  ·            ·                                                (a, b, c, d)  ·
 ·          table        t@primary                                        ·             ·
-·          spans        ALL                                              ·             ·
+·          spans        FULL SCAN                                        ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, (b, 'a'), (c, 'b', 5)) = (9, (a+c, s), (5, s, a)) AS r FROM t
@@ -204,7 +204,7 @@ render     ·            ·                                                     
  │         render 0     (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)  ·             ·
  └── scan  ·            ·                                                                                      (a, b, c, s)  ·
 ·          table        t@primary                                                                              ·             ·
-·          spans        ALL                                                                                    ·             ·
+·          spans        FULL SCAN                                                                              ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS NULL AS r FROM t
@@ -215,7 +215,7 @@ render     ·            ·          (r)  ·
  │         render 0     a IS NULL  ·    ·
  └── scan  ·            ·          (a)  ·
 ·          table        t@primary  ·    ·
-·          spans        ALL        ·    ·
+·          spans        FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS NOT DISTINCT FROM NULL AS r FROM t
@@ -226,7 +226,7 @@ render     ·            ·          (r)  ·
  │         render 0     a IS NULL  ·    ·
  └── scan  ·            ·          (a)  ·
 ·          table        t@primary  ·    ·
-·          spans        ALL        ·    ·
+·          spans        FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS NOT DISTINCT FROM b AS r FROM t
@@ -237,7 +237,7 @@ render     ·            ·                         (r)     ·
  │         render 0     a IS NOT DISTINCT FROM b  ·       ·
  └── scan  ·            ·                         (a, b)  ·
 ·          table        t@primary                 ·       ·
-·          spans        ALL                       ·       ·
+·          spans        FULL SCAN                 ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS NOT NULL AS r FROM t
@@ -248,7 +248,7 @@ render     ·            ·              (r)  ·
  │         render 0     a IS NOT NULL  ·    ·
  └── scan  ·            ·              (a)  ·
 ·          table        t@primary      ·    ·
-·          spans        ALL            ·    ·
+·          spans        FULL SCAN      ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS DISTINCT FROM NULL AS r FROM t
@@ -259,7 +259,7 @@ render     ·            ·              (r)  ·
  │         render 0     a IS NOT NULL  ·    ·
  └── scan  ·            ·              (a)  ·
 ·          table        t@primary      ·    ·
-·          spans        ALL            ·    ·
+·          spans        FULL SCAN      ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS DISTINCT FROM b AS r FROM t
@@ -270,7 +270,7 @@ render     ·            ·                     (r)     ·
  │         render 0     a IS DISTINCT FROM b  ·       ·
  └── scan  ·            ·                     (a, b)  ·
 ·          table        t@primary             ·       ·
-·          spans        ALL                   ·       ·
+·          spans        FULL SCAN             ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT +a + (-b) AS r FROM t
@@ -281,7 +281,7 @@ render     ·            ·          (r)     ·
  │         render 0     a + (-b)   ·       ·
  └── scan  ·            ·          (a, b)  ·
 ·          table        t@primary  ·       ·
-·          spans        ALL        ·       ·
+·          spans        FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END AS r FROM t
@@ -292,7 +292,7 @@ render     ·            ·                                              (r)  ·
  │         render 0     CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END  ·    ·
  └── scan  ·            ·                                              (a)  ·
 ·          table        t@primary                                      ·    ·
-·          spans        ALL                                            ·    ·
+·          spans        FULL SCAN                                      ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE WHEN a = 2 THEN 1 ELSE 2 END AS r FROM t
@@ -303,7 +303,7 @@ render     ·            ·                                  (r)  ·
  │         render 0     CASE WHEN a = 2 THEN 1 ELSE 2 END  ·    ·
  └── scan  ·            ·                                  (a)  ·
 ·          table        t@primary                          ·    ·
-·          spans        ALL                                ·    ·
+·          spans        FULL SCAN                          ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE a + 3 WHEN 5 * b THEN 1 % b WHEN 6 THEN 2 ELSE -1 END AS r FROM t
@@ -314,7 +314,7 @@ render     ·            ·                                                     
  │         render 0     CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END  ·       ·
  └── scan  ·            ·                                                           (a, b)  ·
 ·          table        t@primary                                                   ·       ·
-·          spans        ALL                                                         ·       ·
+·          spans        FULL SCAN                                                   ·       ·
 
 # Tests for CASE with no ELSE statement
 query TTTTT
@@ -326,7 +326,7 @@ render     ·            ·                           (r)  ·
  │         render 0     CASE WHEN a = 2 THEN 1 END  ·    ·
  └── scan  ·            ·                           (a)  ·
 ·          table        t@primary                   ·    ·
-·          spans        ALL                         ·    ·
+·          spans        FULL SCAN                   ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE a WHEN 2 THEN 1 END AS r FROM t
@@ -337,7 +337,7 @@ render     ·            ·                         (r)  ·
  │         render 0     CASE a WHEN 2 THEN 1 END  ·    ·
  └── scan  ·            ·                         (a)  ·
 ·          table        t@primary                 ·    ·
-·          spans        ALL                       ·    ·
+·          spans        FULL SCAN                 ·    ·
 
 # TODO(radu): IS OF not supported yet.
 #query TTTTT
@@ -358,7 +358,7 @@ render     ·            ·          (length)  ·
  │         render 0     length(s)  ·         ·
  └── scan  ·            ·          (s)       ·
 ·          table        t@primary  ·         ·
-·          spans        ALL        ·         ·
+·          spans        FULL SCAN  ·         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j @> '{"a": 1}' AS r FROM t
@@ -369,7 +369,7 @@ render     ·            ·                (r)  ·
  │         render 0     j @> '{"a": 1}'  ·    ·
  └── scan  ·            ·                (j)  ·
 ·          table        t@primary        ·    ·
-·          spans        ALL              ·    ·
+·          spans        FULL SCAN        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT '{"a": 1}' <@ j AS r FROM t
@@ -380,7 +380,7 @@ render     ·            ·                (r)  ·
  │         render 0     j @> '{"a": 1}'  ·    ·
  └── scan  ·            ·                (j)  ·
 ·          table        t@primary        ·    ·
-·          spans        ALL              ·    ·
+·          spans        FULL SCAN        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j->>'a' AS r FROM t
@@ -391,7 +391,7 @@ render     ·            ·          (r)  ·
  │         render 0     j->>'a'    ·    ·
  └── scan  ·            ·          (j)  ·
 ·          table        t@primary  ·    ·
-·          spans        ALL        ·    ·
+·          spans        FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j->'a' AS r FROM t
@@ -402,7 +402,7 @@ render     ·            ·          (r)  ·
  │         render 0     j->'a'     ·    ·
  └── scan  ·            ·          (j)  ·
 ·          table        t@primary  ·    ·
-·          spans        ALL        ·    ·
+·          spans        FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j ? 'a' AS r FROM t
@@ -413,7 +413,7 @@ render     ·            ·          (r)  ·
  │         render 0     j ? 'a'    ·    ·
  └── scan  ·            ·          (j)  ·
 ·          table        t@primary  ·    ·
-·          spans        ALL        ·    ·
+·          spans        FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j ?| ARRAY['a', 'b', 'c'] AS r FROM t
@@ -424,7 +424,7 @@ render     ·            ·                        (r)  ·
  │         render 0     j ?| ARRAY['a','b','c']  ·    ·
  └── scan  ·            ·                        (j)  ·
 ·          table        t@primary                ·    ·
-·          spans        ALL                      ·    ·
+·          spans        FULL SCAN                ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j ?& ARRAY['a', 'b', 'c'] AS r FROM t
@@ -435,7 +435,7 @@ render     ·            ·                        (r)  ·
  │         render 0     j ?& ARRAY['a','b','c']  ·    ·
  └── scan  ·            ·                        (j)  ·
 ·          table        t@primary                ·    ·
-·          spans        ALL                      ·    ·
+·          spans        FULL SCAN                ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j#>ARRAY['a'] AS r FROM t
@@ -446,7 +446,7 @@ render     ·            ·              (r)  ·
  │         render 0     j#>ARRAY['a']  ·    ·
  └── scan  ·            ·              (j)  ·
 ·          table        t@primary      ·    ·
-·          spans        ALL            ·    ·
+·          spans        FULL SCAN      ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j#>>ARRAY['a'] AS r FROM t
@@ -457,7 +457,7 @@ render     ·            ·               (r)  ·
  │         render 0     j#>>ARRAY['a']  ·    ·
  └── scan  ·            ·               (j)  ·
 ·          table        t@primary       ·    ·
-·          spans        ALL             ·    ·
+·          spans        FULL SCAN       ·    ·
 
 
 query TTTTT
@@ -470,7 +470,7 @@ render     ·            ·          (a, b)  ·
  │         render 1     b::FLOAT8  ·       ·
  └── scan  ·            ·          (a, b)  ·
 ·          table        t@primary  ·       ·
-·          spans        ALL        ·       ·
+·          spans        FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CAST(a + b + c AS string) FROM t
@@ -481,7 +481,7 @@ render     ·            ·                      (text)     ·
  │         render 0     (c + (a + b))::STRING  ·          ·
  └── scan  ·            ·                      (a, b, c)  ·
 ·          table        t@primary              ·          ·
-·          spans        ALL                    ·          ·
+·          spans        FULL SCAN              ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT s::VARCHAR(2) FROM t
@@ -492,7 +492,7 @@ render     ·            ·              (s)  ·
  │         render 0     s::VARCHAR(2)  ·    ·
  └── scan  ·            ·              (s)  ·
 ·          table        t@primary      ·    ·
-·          spans        ALL            ·    ·
+·          spans        FULL SCAN      ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT COALESCE(a, b) FROM (VALUES (1, 2), (3, NULL), (NULL, 4), (NULL, NULL)) AS v(a, b)
@@ -543,7 +543,7 @@ render     ·            ·                      (a)        ·
  │         render 0     a                      ·          ·
  └── scan  ·            ·                      (a, b, d)  ·
 ·          table        t@primary              ·          ·
-·          spans        ALL                    ·          ·
+·          spans        FULL SCAN              ·          ·
 ·          filter       (a >= b) AND (a <= d)  ·          ·
 
 query TTTTT
@@ -555,7 +555,7 @@ render     ·            ·                   (a)        ·
  │         render 0     a                   ·          ·
  └── scan  ·            ·                   (a, b, d)  ·
 ·          table        t@primary           ·          ·
-·          spans        ALL                 ·          ·
+·          spans        FULL SCAN           ·          ·
 ·          filter       (a < b) OR (a > d)  ·          ·
 
 query TTTTT
@@ -567,7 +567,7 @@ render     ·            ·                                                   (r
  │         render 0     ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))  ·          ·
  └── scan  ·            ·                                                   (a, b, d)  ·
 ·          table        t@primary                                           ·          ·
-·          spans        ALL                                                 ·          ·
+·          spans        FULL SCAN                                           ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a NOT BETWEEN SYMMETRIC b AND d AS r FROM t
@@ -578,7 +578,7 @@ render     ·            ·                                              (r)    
  │         render 0     ((a < b) OR (a > d)) AND ((a < d) OR (a > b))  ·          ·
  └── scan  ·            ·                                              (a, b, d)  ·
 ·          table        t@primary                                      ·          ·
-·          spans        ALL                                            ·          ·
+·          spans        FULL SCAN                                      ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY[]:::int[] FROM t
@@ -589,7 +589,7 @@ render     ·            ·          ("array")  ·
  │         render 0     ARRAY[]    ·          ·
  └── scan  ·            ·          ()         ·
 ·          table        t@primary  ·          ·
-·          spans        ALL        ·          ·
+·          spans        FULL SCAN  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY[1, 2, 3] FROM t
@@ -600,7 +600,7 @@ render     ·            ·             ("array")  ·
  │         render 0     ARRAY[1,2,3]  ·          ·
  └── scan  ·            ·             ()         ·
 ·          table        t@primary     ·          ·
-·          spans        ALL           ·          ·
+·          spans        FULL SCAN     ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY[a + 1, 2, 3] FROM t
@@ -611,7 +611,7 @@ render     ·            ·                   ("array")  ·
  │         render 0     ARRAY[a + 1, 2, 3]  ·          ·
  └── scan  ·            ·                   (a)        ·
 ·          table        t@primary           ·          ·
-·          spans        ALL                 ·          ·
+·          spans        FULL SCAN           ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 > ANY ARRAY[a + 1, 2, 3] FROM t
@@ -622,7 +622,7 @@ render     ·            ·                           ("?column?")  ·
  │         render 0     1 > ANY ARRAY[a + 1, 2, 3]  ·             ·
  └── scan  ·            ·                           (a)           ·
 ·          table        t@primary                   ·             ·
-·          spans        ALL                         ·             ·
+·          spans        FULL SCAN                   ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 = ANY (1, 2, 3) FROM t
@@ -633,7 +633,7 @@ render     ·            ·          ("?column?")  ·
  │         render 0     true       ·             ·
  └── scan  ·            ·          ()            ·
 ·          table        t@primary  ·             ·
-·          spans        ALL        ·             ·
+·          spans        FULL SCAN  ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 = ANY () FROM t
@@ -644,7 +644,7 @@ render     ·            ·          ("?column?")  ·
  │         render 0     false      ·             ·
  └── scan  ·            ·          ()            ·
 ·          table        t@primary  ·             ·
-·          spans        ALL        ·             ·
+·          spans        FULL SCAN  ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT least(NULL, greatest(NULL, least(1, NULL), 2, 3), greatest(5, 6), a) FROM t
@@ -655,7 +655,7 @@ render     ·            ·                     ("least")  ·
  │         render 0     least(NULL, 3, 6, a)  ·          ·
  └── scan  ·            ·                     (a)        ·
 ·          table        t@primary             ·          ·
-·          spans        ALL                   ·          ·
+·          spans        FULL SCAN             ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pg_attribute WHERE attrelid='t'::regclass
@@ -710,7 +710,7 @@ render     ·            ·                                                 (r1,
  │         render 1     length(upper(concat('a', 'b', s)))::FLOAT8 + 1.0  ·         ·
  └── scan  ·            ·                                                 (s)       ·
 ·          table        t@primary                                         ·         ·
-·          spans        ALL                                               ·         ·
+·          spans        FULL SCAN                                         ·         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY(SELECT generate_series(1,10) ORDER BY 1 DESC)
@@ -750,4 +750,4 @@ root                      ·              ·                             ("array
                 │         order          +b                            ·          ·
                 └── scan  ·              ·                             (a, b)     ·
 ·                         table          t@primary                     ·          ·
-·                         spans          ALL                           ·          ·
+·                         spans          FULL SCAN                     ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -68,7 +68,7 @@ EXPLAIN (VERBOSE) SELECT * FROM [53 AS num_ref_alias]
 ·     vectorized   true             ·          ·
 scan  ·            ·                (p, d, c)  ·
 ·     table        num_ref@primary  ·          ·
-·     spans        ALL              ·          ·
+·     spans        FULL SCAN        ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]
@@ -77,7 +77,7 @@ EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]
 ·     vectorized   true             ·    ·
 scan  ·            ·                (c)  ·
 ·     table        num_ref@primary  ·    ·
-·     spans        ALL              ·    ·
+·     spans        FULL SCAN        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(1,4) AS num_ref_alias]
@@ -86,7 +86,7 @@ EXPLAIN (VERBOSE) SELECT * FROM [53(1,4) AS num_ref_alias]
 ·     vectorized   true             ·       ·
 scan  ·            ·                (p, c)  ·
 ·     table        num_ref@primary  ·       ·
-·     spans        ALL              ·       ·
+·     spans        FULL SCAN        ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(1,3,4) AS num_ref_alias]
@@ -95,7 +95,7 @@ EXPLAIN (VERBOSE) SELECT * FROM [53(1,3,4) AS num_ref_alias]
 ·     vectorized   true             ·          ·
 scan  ·            ·                (p, d, c)  ·
 ·     table        num_ref@primary  ·          ·
-·     spans        ALL              ·          ·
+·     spans        FULL SCAN        ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4,3,1) AS num_ref_alias]
@@ -108,7 +108,7 @@ render     ·            ·                (c, d, p)  ·
  │         render 2     p                ·          ·
  └── scan  ·            ·                (p, d, c)  ·
 ·          table        num_ref@primary  ·          ·
-·          spans        ALL              ·          ·
+·          spans        FULL SCAN        ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4,3,1) AS num_ref_alias(col1,col2,col3)]
@@ -121,7 +121,7 @@ render     ·            ·                (col1, col2, col3)  ·
  │         render 2     p                ·                   ·
  └── scan  ·            ·                (p, d, c)           ·
 ·          table        num_ref@primary  ·                   ·
-·          spans        ALL              ·                   ·
+·          spans        FULL SCAN        ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4,3,1) AS num_ref_alias]@bc
@@ -134,7 +134,7 @@ render     ·            ·           (c, d, p)  ·
  │         render 2     p           ·          ·
  └── scan  ·            ·           (p, d, c)  ·
 ·          table        num_ref@bc  ·          ·
-·          spans        ALL         ·          ·
+·          spans        FULL SCAN   ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@bc
@@ -143,7 +143,7 @@ EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@bc
 ·     vectorized   true        ·    ·
 scan  ·            ·           (c)  ·
 ·     table        num_ref@bc  ·    ·
-·     spans        ALL         ·    ·
+·     spans        FULL SCAN   ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@bc
@@ -152,7 +152,7 @@ EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@bc
 ·     vectorized   true        ·    ·
 scan  ·            ·           (d)  ·
 ·     table        num_ref@bc  ·    ·
-·     spans        ALL         ·    ·
+·     spans        FULL SCAN   ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@bc
@@ -161,7 +161,7 @@ EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@bc
 ·     vectorized   true        ·    ·
 scan  ·            ·           (p)  ·
 ·     table        num_ref@bc  ·    ·
-·     spans        ALL         ·    ·
+·     spans        FULL SCAN   ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@[1]
@@ -170,7 +170,7 @@ EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@[1]
 ·     vectorized   true             ·    ·
 scan  ·            ·                (p)  ·
 ·     table        num_ref@primary  ·    ·
-·     spans        ALL              ·    ·
+·     spans        FULL SCAN        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@[2]
@@ -179,7 +179,7 @@ EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@[2]
 ·     vectorized   true        ·    ·
 scan  ·            ·           (p)  ·
 ·     table        num_ref@bc  ·    ·
-·     spans        ALL         ·    ·
+·     spans        FULL SCAN   ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@[1]
@@ -188,7 +188,7 @@ EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@[1]
 ·     vectorized   true             ·    ·
 scan  ·            ·                (d)  ·
 ·     table        num_ref@primary  ·    ·
-·     spans        ALL              ·    ·
+·     spans        FULL SCAN        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@[2]
@@ -197,7 +197,7 @@ EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@[2]
 ·     vectorized   true        ·    ·
 scan  ·            ·           (d)  ·
 ·     table        num_ref@bc  ·    ·
-·     spans        ALL         ·    ·
+·     spans        FULL SCAN   ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@[1]
@@ -206,7 +206,7 @@ EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@[1]
 ·     vectorized   true             ·    ·
 scan  ·            ·                (c)  ·
 ·     table        num_ref@primary  ·    ·
-·     spans        ALL              ·    ·
+·     spans        FULL SCAN        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@[2]
@@ -215,7 +215,7 @@ EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@[2]
 ·     vectorized   true        ·    ·
 scan  ·            ·           (c)  ·
 ·     table        num_ref@bc  ·    ·
-·     spans        ALL         ·    ·
+·     spans        FULL SCAN   ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [54(1,3) AS num_ref_alias]
@@ -224,7 +224,7 @@ EXPLAIN (VERBOSE) SELECT * FROM [54(1,3) AS num_ref_alias]
 ·     vectorized   true                    ·    ·
 scan  ·            ·                       (a)  ·
 ·     table        num_ref_hidden@primary  ·    ·
-·     spans        ALL                     ·    ·
+·     spans        FULL SCAN               ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [54(3) AS num_ref_alias]
@@ -233,7 +233,7 @@ EXPLAIN (VERBOSE) SELECT * FROM [54(3) AS num_ref_alias]
 ·     vectorized   true                    ·   ·
 scan  ·            ·                       ()  ·
 ·     table        num_ref_hidden@primary  ·   ·
-·     spans        ALL                     ·   ·
+·     spans        FULL SCAN               ·   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT rowid FROM [54(3) AS num_ref_alias]
@@ -242,7 +242,7 @@ EXPLAIN (VERBOSE) SELECT rowid FROM [54(3) AS num_ref_alias]
 ·     vectorized   true                    ·                ·
 scan  ·            ·                       (rowid[hidden])  ·
 ·     table        num_ref_hidden@primary  ·                ·
-·     spans        ALL                     ·                ·
+·     spans        FULL SCAN               ·                ·
 
 query error pq: \[666\(1\) AS num_ref_alias\]: relation \"\[666\]\" does not exist
 EXPLAIN (VERBOSE) SELECT * FROM [666(1) AS num_ref_alias]
@@ -287,7 +287,7 @@ EXPLAIN (VERBOSE) SELECT * FROM a WHERE y > 10
 ·     vectorized   true       ·       ·
 scan  ·            ·          (x, y)  ·
 ·     table        a@primary  ·       ·
-·     spans        ALL        ·       ·
+·     spans        FULL SCAN  ·       ·
 ·     filter       y > 10     ·       ·
 
 query TTTTT
@@ -318,7 +318,7 @@ render     ·            ·          (r)  ·
  │         render 0     x + 1      ·    ·
  └── scan  ·            ·          (x)  ·
 ·          table        a@primary  ·    ·
-·          spans        ALL        ·    ·
+·          spans        FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x AS a, x + 1 AS b, y, y + 1 AS c, x + y AS d FROM a
@@ -333,7 +333,7 @@ render     ·            ·          (a, b, y, c, d)  ·
  │         render 4     x + y      ·                ·
  └── scan  ·            ·          (x, y)           ·
 ·          table        a@primary  ·                ·
-·          spans        ALL        ·                ·
+·          spans        FULL SCAN  ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u * v + v AS r FROM (SELECT x + 3, y + 10 FROM a) AS foo(u, v)
@@ -347,7 +347,7 @@ render          ·            ·                                       (r)      
       │         render 1     y + 10                                  ·                         ·
       └── scan  ·            ·                                       (x, y)                    ·
 ·               table        a@primary                               ·                         ·
-·               spans        ALL                                     ·                         ·
+·               spans        FULL SCAN                               ·                         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x, x, y, x FROM a
@@ -361,7 +361,7 @@ render     ·            ·          (x, x, y, x)  ·
  │         render 3     x          ·             ·
  └── scan  ·            ·          (x, y)        ·
 ·          table        a@primary  ·             ·
-·          spans        ALL        ·             ·
+·          spans        FULL SCAN  ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x + 1 AS a, x + y AS b FROM a WHERE x + y > 20
@@ -373,7 +373,7 @@ render     ·            ·             (a, b)  ·
  │         render 1     x + y         ·       ·
  └── scan  ·            ·             (x, y)  ·
 ·          table        a@primary     ·       ·
-·          spans        ALL           ·       ·
+·          spans        FULL SCAN     ·       ·
 ·          filter       (x + y) > 20  ·       ·
 
 statement ok
@@ -392,7 +392,7 @@ EXPLAIN (VERBOSE) SELECT * FROM b
 ·     vectorized   true       ·       ·
 scan  ·            ·          (x, y)  ·
 ·     table        b@primary  ·       ·
-·     spans        ALL        ·       ·
+·     spans        FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x, y, rowid FROM b WHERE rowid > 0
@@ -526,7 +526,7 @@ EXPLAIN SELECT a FROM t14601 ORDER BY a
 ·     vectorized   true
 scan  ·            ·
 ·     table        t14601@i14601
-·     spans        ALL
+·     spans        FULL SCAN
 
 # Updates were broken too.
 
@@ -550,7 +550,7 @@ EXPLAIN SELECT a, b FROM t14601a ORDER BY a
 ·     vectorized   true
 scan  ·            ·
 ·     table        t14601a@i14601a
-·     spans        ALL
+·     spans        FULL SCAN
 
 statement ok
 DROP index i14601a
@@ -565,7 +565,7 @@ EXPLAIN SELECT a, b FROM t14601a ORDER BY a
 ·     vectorized   true
 scan  ·            ·
 ·     table        t14601a@i14601a
-·     spans        ALL
+·     spans        FULL SCAN
 
 statement ok
 DROP TABLE t; DROP TABLE t14601; DROP TABLE t14601a
@@ -603,7 +603,7 @@ render     ·            ·               (a)  ·
  │         render 0     1               ·    ·
  └── scan  ·            ·               ()   ·
 ·          table        nocols@primary  ·    ·
-·          spans        ALL             ·    ·
+·          spans        FULL SCAN       ·    ·
 
 statement ok
 DROP TABLE nocols
@@ -627,7 +627,7 @@ EXPLAIN (TYPES) SELECT a, b FROM coll ORDER BY a, b
 ·     vectorized   false         ·                              ·
 scan  ·            ·             (a collatedstring{da}, b int)  +a,+b
 ·     table        coll@primary  ·                              ·
-·     spans        ALL           ·                              ·
+·     spans        FULL SCAN     ·                              ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT b, a FROM coll ORDER BY b, a
@@ -639,7 +639,7 @@ render     ·            ·                        (b int, a collatedstring{da})
  │         render 1     (a)[collatedstring{da}]  ·                              ·
  └── scan  ·            ·                        (a collatedstring{da}, b int)  +b,+a
 ·          table        coll@coll_b_a_idx        ·                              ·
-·          spans        ALL                      ·                              ·
+·          spans        FULL SCAN                ·                              ·
 
 statement ok
 DROP TABLE coll
@@ -662,7 +662,7 @@ EXPLAIN (TYPES) SELECT b FROM computed ORDER BY b
 ·     vectorized   true                     ·           ·
 scan  ·            ·                        (b string)  +b
 ·     table        computed@computed_b_idx  ·           ·
-·     spans        ALL                      ·           ·
+·     spans        FULL SCAN                ·           ·
 
 statement ok
 DROP TABLE computed
@@ -833,7 +833,7 @@ EXPLAIN (TYPES) SELECT * FROM dec2 WHERE isnan(d)
 ·     vectorized   false                        ·            ·
 scan  ·            ·                            (d decimal)  ·
 ·     table        dec2@primary                 ·            ·
-·     spans        ALL                          ·            ·
+·     spans        FULL SCAN                    ·            ·
 ·     filter       (isnan((d)[decimal]))[bool]  ·            ·
 
 statement ok
@@ -873,7 +873,7 @@ EXPLAIN (TYPES) SELECT * FROM flt WHERE isnan(f)
 ·     vectorized   false                      ·          ·
 scan  ·            ·                          (f float)  ·
 ·     table        flt@primary                ·          ·
-·     spans        ALL                        ·          ·
+·     spans        FULL SCAN                  ·          ·
 ·     filter       (isnan((f)[float]))[bool]  ·          ·
 
 statement ok
@@ -1137,7 +1137,7 @@ render     ·            ·             ("?column?")  ·
  │         render 0     a + (b + c)   ·             ·
  └── scan  ·            ·             (a, b, c)     +a
 ·          table        abcd@primary  ·             ·
-·          spans        ALL           ·             ·
+·          spans        FULL SCAN     ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a + x FROM (SELECT a, b, a + b + c AS x FROM abcd) ORDER BY b
@@ -1153,7 +1153,7 @@ render               ·            ·                  ("?column?")     ·
            │         render 1     b                  ·                ·
            └── scan  ·            ·                  (a, b, c)        ·
 ·                    table        abcd@primary       ·                ·
-·                    spans        ALL                ·                ·
+·                    spans        FULL SCAN          ·                ·
 
 
 query TTTTT
@@ -1165,7 +1165,7 @@ render        ·            ·                  ("?column?")  ·
  │            render 0     a + (c + (a + b))  ·             ·
  └── revscan  ·            ·                  (a, b, c)     -a,-b
 ·             table        abcd@primary       ·             ·
-·             spans        ALL                ·             ·
+·             spans        FULL SCAN          ·             ·
 
 # Ensure that filter nodes (and filtered scan nodes) get populated with the correct ordering.
 query TTTTT
@@ -1175,7 +1175,7 @@ EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a > b ORDER BY a
 ·     vectorized   true          ·             ·
 scan  ·            ·             (a, b, c, d)  +a
 ·     table        abcd@primary  ·             ·
-·     spans        ALL           ·             ·
+·     spans        FULL SCAN     ·             ·
 ·     filter       a > b         ·             ·
 
 query TTTTT
@@ -1187,7 +1187,7 @@ sort       ·            ·             (a, b, c, d)  -a,-b
  │         order        -a,-b         ·             ·
  └── scan  ·            ·             (a, b, c, d)  ·
 ·          table        abcd@primary  ·             ·
-·          spans        ALL           ·             ·
+·          spans        FULL SCAN     ·             ·
 ·          filter       a > b         ·             ·
 
 query TTTTT
@@ -1199,7 +1199,7 @@ filter     ·            ·             (a, b)  +a
  │         filter       a > b         ·       ·
  └── scan  ·            ·             (a, b)  +a
 ·          table        abcd@primary  ·       ·
-·          spans        ALL           ·       ·
+·          spans        LIMITED SCAN  ·       ·
 ·          limit        10            ·       ·
 
 query TTTTT
@@ -1214,7 +1214,7 @@ render          ·            ·                    (a, x)     ·
       │         filter       (c + (a + b)) > 100  ·          ·
       └── scan  ·            ·                    (a, b, c)  +a
 ·               table        abcd@primary         ·          ·
-·               spans        ALL                  ·          ·
+·               spans        LIMITED SCAN         ·          ·
 ·               limit        10                   ·          ·
 
 statement ok
@@ -1230,7 +1230,7 @@ filter     ·            ·                  (x, y, z)  +x,+z
  │         filter       y = 1              ·          ·
  └── scan  ·            ·                  (x, y, z)  +x,+y,+z
 ·          table        xyz@xyz_x_y_z_idx  ·          ·
-·          spans        ALL                ·          ·
+·          spans        LIMITED SCAN       ·          ·
 ·          limit        10                 ·          ·
 
 # ------------------------------------------------------
@@ -1517,7 +1517,7 @@ render                         ·            ·
                      │         equality     (y) = (y)
                      ├── scan  ·            ·
                      │         table        e@primary
-                     │         spans        ALL
+                     │         spans        FULL SCAN
                      └── scan  ·            ·
 ·                              table        s@primary
-·                              spans        ALL
+·                              spans        FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -20,7 +20,7 @@ EXPLAIN SELECT * FROM t FOR UPDATE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for update
 
 query TTT
@@ -30,7 +30,7 @@ EXPLAIN SELECT * FROM t FOR NO KEY UPDATE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for no key update
 
 query TTT
@@ -40,7 +40,7 @@ EXPLAIN SELECT * FROM t FOR SHARE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for share
 
 query TTT
@@ -50,7 +50,7 @@ EXPLAIN SELECT * FROM t FOR KEY SHARE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for key share
 
 query TTT
@@ -60,7 +60,7 @@ EXPLAIN SELECT * FROM t FOR KEY SHARE FOR SHARE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for share
 
 query TTT
@@ -70,7 +70,7 @@ EXPLAIN SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for no key update
 
 query TTT
@@ -80,7 +80,7 @@ EXPLAIN SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for update
 
 query TTT
@@ -90,7 +90,7 @@ EXPLAIN SELECT * FROM t FOR UPDATE OF t
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for update
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
@@ -104,7 +104,7 @@ EXPLAIN SELECT 1 FROM t FOR UPDATE OF t
 render     ·                 ·
  └── scan  ·                 ·
 ·          table             t@primary
-·          spans             ALL
+·          spans             FULL SCAN
 ·          locking strength  for update
 
 query TTT
@@ -212,7 +212,7 @@ EXPLAIN SELECT * FROM t AS t2 FOR UPDATE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for update
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
@@ -225,7 +225,7 @@ EXPLAIN SELECT * FROM t AS t2 FOR UPDATE OF t2
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for update
 
 # ------------------------------------------------------------------------------
@@ -240,7 +240,7 @@ EXPLAIN SELECT * FROM [53 AS t] FOR UPDATE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for update
 
 query TTT
@@ -250,7 +250,7 @@ EXPLAIN SELECT * FROM [53 AS t] FOR UPDATE OF t
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for update
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
@@ -267,7 +267,7 @@ EXPLAIN SELECT * FROM v FOR UPDATE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for update
 
 query TTT
@@ -277,7 +277,7 @@ EXPLAIN SELECT * FROM v FOR UPDATE OF v
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for update
 
 query error pgcode 42P01 relation "v2" in FOR UPDATE clause not found in FROM clause
@@ -300,7 +300,7 @@ EXPLAIN SELECT * FROM v AS v2 FOR UPDATE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for update
 
 query error pgcode 42P01 relation "v" in FOR UPDATE clause not found in FROM clause
@@ -313,7 +313,7 @@ EXPLAIN SELECT * FROM v AS v2 FOR UPDATE OF v2
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for update
 
 # ------------------------------------------------------------------------------
@@ -331,7 +331,7 @@ EXPLAIN SELECT * FROM (SELECT a FROM t) FOR UPDATE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for update
 
 query TTT
@@ -341,7 +341,7 @@ EXPLAIN SELECT * FROM (SELECT a FROM t FOR UPDATE)
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for update
 
 query TTT
@@ -351,7 +351,7 @@ EXPLAIN SELECT * FROM (SELECT a FROM t FOR NO KEY UPDATE) FOR KEY SHARE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for no key update
 
 query TTT
@@ -361,7 +361,7 @@ EXPLAIN SELECT * FROM (SELECT a FROM t FOR KEY SHARE) FOR NO KEY UPDATE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for no key update
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
@@ -374,7 +374,7 @@ EXPLAIN SELECT * FROM (SELECT a FROM t FOR UPDATE OF t)
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for update
 
 query TTT
@@ -384,7 +384,7 @@ EXPLAIN SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for update
 
 query TTT
@@ -394,7 +394,7 @@ EXPLAIN SELECT * FROM (SELECT a FROM t FOR UPDATE) AS r
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for update
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
@@ -407,7 +407,7 @@ EXPLAIN SELECT * FROM (SELECT a FROM t FOR UPDATE OF t) AS r
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
-·     spans             ALL
+·     spans             FULL SCAN
 ·     locking strength  for update
 
 query TTT
@@ -425,7 +425,7 @@ root                 ·             ·
       └── max1row    ·             ·
            └── scan  ·             ·
 ·                    table         t@primary
-·                    spans         ALL
+·                    spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT (SELECT a FROM t FOR UPDATE)
@@ -442,7 +442,7 @@ root                 ·                 ·
       └── max1row    ·                 ·
            └── scan  ·                 ·
 ·                    table             t@primary
-·                    spans             ALL
+·                    spans             FULL SCAN
 ·                    locking strength  for update
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
@@ -463,7 +463,7 @@ root                 ·                 ·
       └── max1row    ·                 ·
            └── scan  ·                 ·
 ·                    table             t@primary
-·                    spans             ALL
+·                    spans             FULL SCAN
 ·                    locking strength  for update
 
 query TTT
@@ -481,7 +481,7 @@ root                 ·             ·
       └── max1row    ·             ·
            └── scan  ·             ·
 ·                    table         t@primary
-·                    spans         ALL
+·                    spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT (SELECT a FROM t FOR UPDATE) AS r
@@ -498,7 +498,7 @@ root                 ·                 ·
       └── max1row    ·                 ·
            └── scan  ·                 ·
 ·                    table             t@primary
-·                    spans             ALL
+·                    spans             FULL SCAN
 ·                    locking strength  for update
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
@@ -519,7 +519,7 @@ root                 ·                 ·
       └── max1row    ·                 ·
            └── scan  ·                 ·
 ·                    table             t@primary
-·                    spans             ALL
+·                    spans             FULL SCAN
 ·                    locking strength  for update
 
 query TTT
@@ -535,11 +535,11 @@ merge-join  ·                   ·
  │          mergeJoinOrder      +"(a=a)"
  ├── scan   ·                   ·
  │          table               t@primary
- │          spans               ALL
+ │          spans               FULL SCAN
  │          locking strength    for update
  └── scan   ·                   ·
 ·           table               t@primary
-·           spans               ALL
+·           spans               FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM t WHERE a IN (SELECT a FROM t FOR UPDATE)
@@ -554,10 +554,10 @@ merge-join  ·                   ·
  │          mergeJoinOrder      +"(a=a)"
  ├── scan   ·                   ·
  │          table               t@primary
- │          spans               ALL
+ │          spans               FULL SCAN
  └── scan   ·                   ·
 ·           table               t@primary
-·           spans               ALL
+·           spans               FULL SCAN
 ·           locking strength    for update
 
 query TTT
@@ -573,11 +573,11 @@ merge-join  ·                   ·
  │          mergeJoinOrder      +"(a=a)"
  ├── scan   ·                   ·
  │          table               t@primary
- │          spans               ALL
+ │          spans               FULL SCAN
  │          locking strength    for update
  └── scan   ·                   ·
 ·           table               t@primary
-·           spans               ALL
+·           spans               FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM t WHERE a IN (SELECT a FROM t FOR UPDATE OF t)
@@ -592,10 +592,10 @@ merge-join  ·                   ·
  │          mergeJoinOrder      +"(a=a)"
  ├── scan   ·                   ·
  │          table               t@primary
- │          spans               ALL
+ │          spans               FULL SCAN
  └── scan   ·                   ·
 ·           table               t@primary
-·           spans               ALL
+·           spans               FULL SCAN
 ·           locking strength    for update
 
 # ------------------------------------------------------------------------------
@@ -617,7 +617,7 @@ EXPLAIN SELECT * FROM [SELECT a FROM t] FOR UPDATE
 render     ·            ·
  └── scan  ·            ·
 ·          table        t@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 query TTT
 EXPLAIN WITH cte AS (SELECT a FROM t) SELECT * FROM cte FOR UPDATE
@@ -627,7 +627,7 @@ EXPLAIN WITH cte AS (SELECT a FROM t) SELECT * FROM cte FOR UPDATE
 render     ·            ·
  └── scan  ·            ·
 ·          table        t@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM [SELECT a FROM t FOR UPDATE]
@@ -645,7 +645,7 @@ root                   ·                 ·
            │           label             buffer 1
            └── scan    ·                 ·
 ·                      table             t@primary
-·                      spans             ALL
+·                      spans             FULL SCAN
 ·                      locking strength  for update
 
 query TTT
@@ -664,7 +664,7 @@ root                   ·                 ·
            │           label             buffer 1 (cte)
            └── scan    ·                 ·
 ·                      table             t@primary
-·                      spans             ALL
+·                      spans             FULL SCAN
 ·                      locking strength  for update
 
 # Verify that the unused CTE doesn't get eliminated.
@@ -678,7 +678,7 @@ SELECT c FROM u
 root                   ·                 ·
  ├── scan              ·                 ·
  │                     table             u@primary
- │                     spans             ALL
+ │                     spans             FULL SCAN
  └── subquery          ·                 ·
       │                id                @S1
       │                original sql      SELECT a FROM t FOR UPDATE
@@ -687,7 +687,7 @@ root                   ·                 ·
            │           label             buffer 1 (sfu)
            └── scan    ·                 ·
 ·                      table             t@primary
-·                      spans             ALL
+·                      spans             FULL SCAN
 ·                      locking strength  for update
 
 # ------------------------------------------------------------------------------
@@ -708,11 +708,11 @@ render           ·                   ·
       │          mergeJoinOrder      +"(a=a)"
       ├── scan   ·                   ·
       │          table               t@primary
-      │          spans               ALL
+      │          spans               FULL SCAN
       │          locking strength    for update
       └── scan   ·                   ·
 ·                table               u@primary
-·                spans               ALL
+·                spans               FULL SCAN
 ·                locking strength    for update
 
 query TTT
@@ -729,11 +729,11 @@ render           ·                   ·
       │          mergeJoinOrder      +"(a=a)"
       ├── scan   ·                   ·
       │          table               t@primary
-      │          spans               ALL
+      │          spans               FULL SCAN
       │          locking strength    for update
       └── scan   ·                   ·
 ·                table               u@primary
-·                spans               ALL
+·                spans               FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM t JOIN u USING (a) FOR UPDATE OF u
@@ -749,10 +749,10 @@ render           ·                   ·
       │          mergeJoinOrder      +"(a=a)"
       ├── scan   ·                   ·
       │          table               t@primary
-      │          spans               ALL
+      │          spans               FULL SCAN
       └── scan   ·                   ·
 ·                table               u@primary
-·                spans               ALL
+·                spans               FULL SCAN
 ·                locking strength    for update
 
 query TTT
@@ -769,11 +769,11 @@ render           ·                   ·
       │          mergeJoinOrder      +"(a=a)"
       ├── scan   ·                   ·
       │          table               t@primary
-      │          spans               ALL
+      │          spans               FULL SCAN
       │          locking strength    for update
       └── scan   ·                   ·
 ·                table               u@primary
-·                spans               ALL
+·                spans               FULL SCAN
 ·                locking strength    for update
 
 query TTT
@@ -790,11 +790,11 @@ render           ·                   ·
       │          mergeJoinOrder      +"(a=a)"
       ├── scan   ·                   ·
       │          table               t@primary
-      │          spans               ALL
+      │          spans               FULL SCAN
       │          locking strength    for update
       └── scan   ·                   ·
 ·                table               u@primary
-·                spans               ALL
+·                spans               FULL SCAN
 ·                locking strength    for share
 
 query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
@@ -814,11 +814,11 @@ render           ·                   ·
       │          mergeJoinOrder      +"(a=a)"
       ├── scan   ·                   ·
       │          table               t@primary
-      │          spans               ALL
+      │          spans               FULL SCAN
       │          locking strength    for update
       └── scan   ·                   ·
 ·                table               u@primary
-·                spans               ALL
+·                spans               FULL SCAN
 ·                locking strength    for share
 
 query TTT
@@ -835,11 +835,11 @@ render           ·                   ·
       │          mergeJoinOrder      +"(a=a)"
       ├── scan   ·                   ·
       │          table               t@primary
-      │          spans               ALL
+      │          spans               FULL SCAN
       │          locking strength    for update
       └── scan   ·                   ·
 ·                table               u@primary
-·                spans               ALL
+·                spans               FULL SCAN
 ·                locking strength    for update
 
 query TTT
@@ -856,11 +856,11 @@ render           ·                   ·
       │          mergeJoinOrder      +"(a=a)"
       ├── scan   ·                   ·
       │          table               t@primary
-      │          spans               ALL
+      │          spans               FULL SCAN
       │          locking strength    for no key update
       └── scan   ·                   ·
 ·                table               u@primary
-·                spans               ALL
+·                spans               FULL SCAN
 ·                locking strength    for key share
 
 query TTT
@@ -877,11 +877,11 @@ render           ·                   ·
       │          mergeJoinOrder      +"(a=a)"
       ├── scan   ·                   ·
       │          table               t@primary
-      │          spans               ALL
+      │          spans               FULL SCAN
       │          locking strength    for no key update
       └── scan   ·                   ·
 ·                table               u@primary
-·                spans               ALL
+·                spans               FULL SCAN
 ·                locking strength    for update
 
 # ------------------------------------------------------------------------------
@@ -902,11 +902,11 @@ render           ·                   ·
       │          mergeJoinOrder      +"(a=a)"
       ├── scan   ·                   ·
       │          table               t@primary
-      │          spans               ALL
+      │          spans               FULL SCAN
       │          locking strength    for update
       └── scan   ·                   ·
 ·                table               u@primary
-·                spans               ALL
+·                spans               FULL SCAN
 ·                locking strength    for update
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
@@ -932,11 +932,11 @@ render           ·                   ·
       │          mergeJoinOrder      +"(a=a)"
       ├── scan   ·                   ·
       │          table               t@primary
-      │          spans               ALL
+      │          spans               FULL SCAN
       │          locking strength    for update
       └── scan   ·                   ·
 ·                table               u@primary
-·                spans               ALL
+·                spans               FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF u2
@@ -952,10 +952,10 @@ render           ·                   ·
       │          mergeJoinOrder      +"(a=a)"
       ├── scan   ·                   ·
       │          table               t@primary
-      │          spans               ALL
+      │          spans               FULL SCAN
       └── scan   ·                   ·
 ·                table               u@primary
-·                spans               ALL
+·                spans               FULL SCAN
 ·                locking strength    for update
 
 query TTT
@@ -972,11 +972,11 @@ render           ·                   ·
       │          mergeJoinOrder      +"(a=a)"
       ├── scan   ·                   ·
       │          table               t@primary
-      │          spans               ALL
+      │          spans               FULL SCAN
       │          locking strength    for update
       └── scan   ·                   ·
 ·                table               u@primary
-·                spans               ALL
+·                spans               FULL SCAN
 ·                locking strength    for update
 
 # Postgres doesn't support applying locking clauses to joins. The following
@@ -997,11 +997,11 @@ render           ·                   ·
       │          mergeJoinOrder      +"(a=a)"
       ├── scan   ·                   ·
       │          table               t@primary
-      │          spans               ALL
+      │          spans               FULL SCAN
       │          locking strength    for update
       └── scan   ·                   ·
 ·                table               u@primary
-·                spans               ALL
+·                spans               FULL SCAN
 ·                locking strength    for update
 
 query error pgcode 42P01 relation "t" in FOR UPDATE clause not found in FROM clause
@@ -1027,11 +1027,11 @@ render           ·                   ·
       │          mergeJoinOrder      +"(a=a)"
       ├── scan   ·                   ·
       │          table               t@primary
-      │          spans               ALL
+      │          spans               FULL SCAN
       │          locking strength    for update
       └── scan   ·                   ·
 ·                table               u@primary
-·                spans               ALL
+·                spans               FULL SCAN
 ·                locking strength    for update
 
 # ------------------------------------------------------------------------------
@@ -1047,11 +1047,11 @@ cross-join  ·                 ·
  │          type              cross
  ├── scan   ·                 ·
  │          table             t@primary
- │          spans             ALL
+ │          spans             FULL SCAN
  │          locking strength  for update
  └── scan   ·                 ·
 ·           table             u@primary
-·           spans             ALL
+·           spans             FULL SCAN
 ·           locking strength  for update
 
 query TTT
@@ -1063,11 +1063,11 @@ cross-join  ·                 ·
  │          type              cross
  ├── scan   ·                 ·
  │          table             t@primary
- │          spans             ALL
+ │          spans             FULL SCAN
  │          locking strength  for update
  └── scan   ·                 ·
 ·           table             u@primary
-·           spans             ALL
+·           spans             FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM t, u FOR SHARE OF t FOR UPDATE OF u
@@ -1078,11 +1078,11 @@ cross-join  ·                 ·
  │          type              cross
  ├── scan   ·                 ·
  │          table             t@primary
- │          spans             ALL
+ │          spans             FULL SCAN
  │          locking strength  for share
  └── scan   ·                 ·
 ·           table             u@primary
-·           spans             ALL
+·           spans             FULL SCAN
 ·           locking strength  for update
 
 query TTT
@@ -1094,11 +1094,11 @@ cross-join  ·                 ·
  │          type              cross
  ├── scan   ·                 ·
  │          table             t@primary
- │          spans             ALL
+ │          spans             FULL SCAN
  │          locking strength  for update
  └── scan   ·                 ·
 ·           table             u@primary
-·           spans             ALL
+·           spans             FULL SCAN
 ·           locking strength  for update
 
 query error pgcode 42P01 relation "u" in FOR UPDATE clause not found in FROM clause
@@ -1113,8 +1113,8 @@ cross-join  ·                 ·
  │          type              cross
  ├── scan   ·                 ·
  │          table             t@primary
- │          spans             ALL
+ │          spans             FULL SCAN
  └── scan   ·                 ·
 ·           table             u@primary
-·           spans             ALL
+·           spans             FULL SCAN
 ·           locking strength  for update

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -475,7 +475,7 @@ render     ·            ·          (a)     ·
  │         render 0     a          ·       ·
  └── scan  ·            ·          (a, c)  ·
 ·          table        t@primary  ·       ·
-·          spans        ALL        ·       ·
+·          spans        FULL SCAN  ·       ·
 ·          filter       c > 1      ·       ·
 
 query TTTTT
@@ -499,7 +499,7 @@ render     ·            ·          (a)     ·
  │         render 0     a          ·       ·
  └── scan  ·            ·          (a, c)  ·
 ·          table        t@primary  ·       ·
-·          spans        ALL        ·       ·
+·          spans        FULL SCAN  ·       ·
 ·          filter       c > 1      ·       ·
 
 query TTTTT
@@ -511,7 +511,7 @@ render     ·            ·          (a)     ·
  │         render 0     a          ·       ·
  └── scan  ·            ·          (a, c)  ·
 ·          table        t@primary  ·       ·
-·          spans        ALL        ·       ·
+·          spans        FULL SCAN  ·       ·
 ·          filter       c < 1      ·       ·
 
 query TTTTT
@@ -634,7 +634,7 @@ render     ·            ·                  (i, s)  ·
  │         render 1     s                  ·       ·
  └── scan  ·            ·                  (s, i)  ·
 ·          table        ab@primary         ·       ·
-·          spans        ALL                ·       ·
+·          spans        FULL SCAN          ·       ·
 ·          filter       (i, s) < (1, 'c')  ·       ·
 
 statement ok
@@ -668,12 +668,12 @@ abz  abz_c_b_key  false  3  a  ASC   false  true
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM abz ORDER BY a DESC LIMIT 1
 ----
-·     distributed  false        ·    ·
-·     vectorized   true         ·    ·
-scan  ·            ·            (a)  ·
-·     table        abz@primary  ·    ·
-·     spans        ALL          ·    ·
-·     limit        1            ·    ·
+·     distributed  false         ·    ·
+·     vectorized   true          ·    ·
+scan  ·            ·             (a)  ·
+·     table        abz@primary   ·    ·
+·     spans        LIMITED SCAN  ·    ·
+·     limit        1             ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT c FROM abz ORDER BY c DESC LIMIT 1
@@ -682,7 +682,7 @@ EXPLAIN (VERBOSE) SELECT c FROM abz ORDER BY c DESC LIMIT 1
 ·     vectorized   true             ·    ·
 scan  ·            ·                (c)  ·
 ·     table        abz@abz_c_b_key  ·    ·
-·     spans        ALL              ·    ·
+·     spans        LIMITED SCAN     ·    ·
 ·     limit        1                ·    ·
 
 # Issue #14426: verify we don't have an internal filter that contains "a IN ()"
@@ -703,7 +703,7 @@ render     ·            ·                                      (k)        ·
  │         render 0     k                                      ·          ·
  └── scan  ·            ·                                      (k, a, b)  ·
 ·          table        tab0@primary                           ·          ·
-·          spans        ALL                                    ·          ·
+·          spans        FULL SCAN                              ·          ·
 ·          filter       ((a IN (6,)) AND (a > 6)) OR (b >= 4)  ·          ·
 
 # Check that no extraneous rows are fetched due to excessive batching (#15910)
@@ -994,7 +994,7 @@ EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM NULL
 ·     vectorized   true           ·       ·
 scan  ·            ·              (x, y)  ·
 ·     table        xy@primary     ·       ·
-·     spans        ALL            ·       ·
+·     spans        FULL SCAN      ·       ·
 ·     filter       y IS NOT NULL  ·       ·
 
 query TTTTT
@@ -1004,7 +1004,7 @@ EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM 4
 ·     vectorized   false                 ·       ·
 scan  ·            ·                     (x, y)  ·
 ·     table        xy@primary            ·       ·
-·     spans        ALL                   ·       ·
+·     spans        FULL SCAN             ·       ·
 ·     filter       y IS DISTINCT FROM 4  ·       ·
 
 # Regression tests for #22670.
@@ -1115,7 +1115,7 @@ sort       ·            ·                 (a, b, c, d)  -c
  │         order        -c                ·             ·
  └── scan  ·            ·                 (a, b, c, d)  ·
 ·          table        noncover@primary  ·             ·
-·          spans        ALL               ·             ·
+·          spans        FULL SCAN         ·             ·
 ·          filter       c > 0             ·             ·
 
 query TTTTT
@@ -1127,7 +1127,7 @@ sort       ·            ·                 (a, b, c, d)  +c
  │         order        +c                ·             ·
  └── scan  ·            ·                 (a, b, c, d)  ·
 ·          table        noncover@primary  ·             ·
-·          spans        ALL               ·             ·
+·          spans        FULL SCAN         ·             ·
 ·          filter       c > 0             ·             ·
 
 query TTTTT
@@ -1137,7 +1137,7 @@ EXPLAIN (VERBOSE) SELECT * FROM noncover WHERE c > 0 AND d = 8
 ·     vectorized   true                 ·             ·
 scan  ·            ·                    (a, b, c, d)  ·
 ·     table        noncover@primary     ·             ·
-·     spans        ALL                  ·             ·
+·     spans        FULL SCAN            ·             ·
 ·     filter       (c > 0) AND (d = 8)  ·             ·
 
 # The following testcases verify that when we have a small limit, we prefer an
@@ -1152,7 +1152,7 @@ sort       ·            ·
  │         order        +c
  └── scan  ·            ·
 ·          table        noncover@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM noncover ORDER BY c LIMIT 5
@@ -1164,7 +1164,7 @@ index-join  ·            ·
  │          key columns  a
  └── scan   ·            ·
 ·           table        noncover@c
-·           spans        ALL
+·           spans        LIMITED SCAN
 ·           limit        5
 
 query TTT
@@ -1180,7 +1180,7 @@ limit           ·            ·
       │         order        +c
       └── scan  ·            ·
 ·               table        noncover@primary
-·               spans        ALL
+·               spans        FULL SCAN
 
 # TODO(radu): need to prefer the order-matching index when OFFSET is present.
 query TTT
@@ -1197,7 +1197,7 @@ limit            ·            ·
       │          key columns  a
       └── scan   ·            ·
 ·                table        noncover@c
-·                spans        ALL
+·                spans        LIMITED SCAN
 ·                limit        10
 
 query TTT
@@ -1213,7 +1213,7 @@ limit           ·            ·
       │         order        +c
       └── scan  ·            ·
 ·               table        noncover@primary
-·               spans        ALL
+·               spans        FULL SCAN
 
 # ------------------------------------------------------------------------------
 # These tests verify that while we are joining an index with the table, we

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
@@ -92,7 +92,7 @@ filter           ·            ·
       │          key columns  a
       └── scan   ·            ·
 ·                table        abcd@b
-·                spans        ALL
+·                spans        FULL SCAN
 
 # Force index b, reverse scan.
 query TTT
@@ -107,7 +107,7 @@ filter             ·            ·
       │            key columns  a
       └── revscan  ·            ·
 ·                  table        abcd@b
-·                  spans        ALL
+·                  spans        FULL SCAN
 
 # Force index b, allowing reverse scan.
 query TTT
@@ -120,7 +120,7 @@ index-join    ·            ·
  │            key columns  a
  └── revscan  ·            ·
 ·             table        abcd@b
-·             spans        ALL
+·             spans        LIMITED SCAN
 ·             limit        5
 
 # Force index b, reverse scan.
@@ -134,7 +134,7 @@ index-join    ·            ·
  │            key columns  a
  └── revscan  ·            ·
 ·             table        abcd@b
-·             spans        ALL
+·             spans        LIMITED SCAN
 ·             limit        5
 
 
@@ -153,7 +153,7 @@ limit                 ·            ·
            │          key columns  a
            └── scan   ·            ·
 ·                     table        abcd@b
-·                     spans        ALL
+·                     spans        FULL SCAN
 
 # Force index cd
 query TTT
@@ -168,7 +168,7 @@ filter           ·            ·
       │          key columns  a
       └── scan   ·            ·
 ·                table        abcd@cd
-·                spans        ALL
+·                spans        FULL SCAN
 
 # Force index bcd
 query TTT
@@ -178,7 +178,7 @@ EXPLAIN SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 ·     vectorized   true
 scan  ·            ·
 ·     table        abcd@bcd
-·     spans        ALL
+·     spans        FULL SCAN
 ·     filter       (a >= 20) AND (a <= 30)
 
 # Force index b (covering)
@@ -190,7 +190,7 @@ EXPLAIN SELECT b FROM abcd@b WHERE a >= 20 AND a <= 30
 render     ·            ·
  └── scan  ·            ·
 ·          table        abcd@b
-·          spans        ALL
+·          spans        FULL SCAN
 ·          filter       (a >= 20) AND (a <= 30)
 
 # Force index b (non-covering due to WHERE clause)
@@ -207,7 +207,7 @@ render                ·            ·
            │          key columns  a
            └── scan   ·            ·
 ·                     table        abcd@b
-·                     spans        ALL
+·                     spans        FULL SCAN
 
 # No hint, should be using index cd
 query TTT
@@ -227,7 +227,7 @@ EXPLAIN SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 ·     vectorized   true
 scan  ·            ·
 ·     table        abcd@primary
-·     spans        ALL
+·     spans        FULL SCAN
 ·     filter       (c >= 20) AND (c < 40)
 
 # Force index b
@@ -243,7 +243,7 @@ filter           ·            ·
       │          key columns  a
       └── scan   ·            ·
 ·                table        abcd@b
-·                spans        ALL
+·                spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b} WHERE a >= 20 AND a <= 30
@@ -257,7 +257,7 @@ filter           ·            ·
       │          key columns  a
       └── scan   ·            ·
 ·                table        abcd@b
-·                spans        ALL
+·                spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd WHERE c = 10
@@ -278,7 +278,7 @@ EXPLAIN SELECT b, c, d FROM abcd@{NO_INDEX_JOIN} WHERE c = 10
 ·     vectorized   true
 scan  ·            ·
 ·     table        abcd@primary
-·     spans        ALL
+·     spans        FULL SCAN
 ·     filter       c = 10
 
 query TTT
@@ -288,7 +288,7 @@ EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=bcd} WHERE c = 10
 ·     vectorized   true
 scan  ·            ·
 ·     table        abcd@bcd
-·     spans        ALL
+·     spans        FULL SCAN
 ·     filter       c = 10
 
 query TTT
@@ -298,5 +298,5 @@ EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=primary} WHERE c = 10
 ·     vectorized   true
 scan  ·            ·
 ·     table        abcd@primary
-·     spans        ALL
+·     spans        FULL SCAN
 ·     filter       c = 10

--- a/pkg/sql/opt/exec/execbuilder/testdata/spool
+++ b/pkg/sql/opt/exec/execbuilder/testdata/spool
@@ -31,7 +31,7 @@ root                                ·             ·
                           │         strategy      inserter
                           └── scan  ·             ·
 ·                                   table         t2@primary
-·                                   spans         ALL
+·                                   spans         FULL SCAN
 
 query TTT
 EXPLAIN WITH a AS (DELETE FROM t RETURNING x)
@@ -57,7 +57,7 @@ root                                ·             ·
                           │         strategy      deleter
                           └── scan  ·             ·
 ·                                   table         t@primary
-·                                   spans         ALL
+·                                   spans         FULL SCAN
 
 
 query TTT
@@ -86,7 +86,7 @@ root                                     ·                 ·
                           └── render     ·                 ·
                                └── scan  ·                 ·
 ·                                        table             t@primary
-·                                        spans             ALL
+·                                        spans             FULL SCAN
 ·                                        locking strength  for update
 
 query TTT
@@ -138,7 +138,7 @@ root                                ·             ·
                           │         strategy      inserter
                           └── scan  ·             ·
 ·                                   table         t2@primary
-·                                   spans         ALL
+·                                   spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM [DELETE FROM t RETURNING x] LIMIT 1
@@ -163,7 +163,7 @@ root                                ·             ·
                           │         strategy      deleter
                           └── scan  ·             ·
 ·                                   table         t@primary
-·                                   spans         ALL
+·                                   spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM [UPDATE t SET x = x + 1 RETURNING x] LIMIT 1
@@ -190,7 +190,7 @@ root                                     ·                 ·
                           └── render     ·                 ·
                                └── scan  ·                 ·
 ·                                        table             t@primary
-·                                        spans             ALL
+·                                        spans             FULL SCAN
 ·                                        locking strength  for update
 
 query TTT
@@ -243,7 +243,7 @@ root                                ·             ·
                           │         strategy      inserter
                           └── scan  ·             ·
 ·                                   table         t2@primary
-·                                   spans         ALL
+·                                   spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x], t
@@ -257,7 +257,7 @@ root                                ·             ·
  │    │                             label         buffer 1
  │    └── scan                      ·             ·
  │                                  table         t@primary
- │                                  spans         ALL
+ │                                  spans         FULL SCAN
  └── subquery                       ·             ·
       │                             id            @S1
       │                             original sql  INSERT INTO t SELECT * FROM t2 RETURNING x
@@ -271,7 +271,7 @@ root                                ·             ·
                           │         strategy      inserter
                           └── scan  ·             ·
 ·                                   table         t2@primary
-·                                   spans         ALL
+·                                   spans         FULL SCAN
 
 # Check that if a spool is already added at some level, then it is not added
 # again at levels below.
@@ -301,7 +301,7 @@ root                                                 ·             ·
  │                        │                          strategy      inserter
  │                        └── scan                   ·             ·
  │                                                   table         t2@primary
- │                                                   spans         ALL
+ │                                                   spans         FULL SCAN
  └── subquery                                        ·             ·
       │                                              id            @S2
       │                                              original sql  INSERT INTO t SELECT x + 1 FROM a RETURNING x
@@ -339,7 +339,7 @@ root                                ·             ·
                           │         strategy      inserter
                           └── scan  ·             ·
 ·                                   table         t2@primary
-·                                   spans         ALL
+·                                   spans         FULL SCAN
 
 # Check that no spool is used for a top-level INSERT, but
 # sub-INSERTs still get a spool.
@@ -369,7 +369,7 @@ root                                  ·             ·
                           │           strategy      inserter
                           └── scan    ·             ·
 ·                                     table         t2@primary
-·                                     spans         ALL
+·                                     spans         FULL SCAN
 
 # Check that simple computations using RETURNING get their spool pulled up.
 query TTT
@@ -398,7 +398,7 @@ root                                     ·             ·
                                │         strategy      inserter
                                └── scan  ·             ·
 ·                                        table         t2@primary
-·                                        spans         ALL
+·                                        spans         FULL SCAN
 
 # Check that a pulled up spool gets elided at the top level.
 query TTT
@@ -425,4 +425,4 @@ root                                     ·             ·
                                │         strategy      inserter
                                └── scan  ·             ·
 ·                                        table         t2@primary
-·                                        spans         ALL
+·                                        spans         FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -71,14 +71,14 @@ render                        ·            ·                      (a, b, gener
       │    │                  type         cross                  ·                                         ·
       │    ├── scan           ·            ·                      (b)                                       ·
       │    │                  table        u@primary              ·                                         ·
-      │    │                  spans        ALL                    ·                                         ·
+      │    │                  spans        FULL SCAN              ·                                         ·
       │    └── project set    ·            ·                      (generate_series, generate_series)        ·
       │         │             render 0     generate_series(1, 2)  ·                                         ·
       │         │             render 1     generate_series(3, 4)  ·                                         ·
       │         └── emptyrow  ·            ·                      ()                                        ·
       └── scan                ·            ·                      (a)                                       ·
 ·                             table        t@primary              ·                                         ·
-·                             spans        ALL                    ·                                         ·
+·                             spans        FULL SCAN              ·                                         ·
 
 subtest correlated_SRFs
 
@@ -96,7 +96,7 @@ sort              ·            ·                            (a, generate_serie
       │           render 0     generate_series(@1, @1 + 1)  ·                     ·
       └── scan    ·            ·                            (a)                   ·
 ·                 table        data@primary                 ·                     ·
-·                 spans        ALL                          ·                     ·
+·                 spans        FULL SCAN                    ·                     ·
 
 statement ok
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
@@ -133,10 +133,10 @@ render                          ·                   ·                         
                      │          pred                y < z                                                  ·                                                ·
                      ├── scan   ·                   ·                                                      (x, y)                                           +x
                      │          table               xy@primary                                             ·                                                ·
-                     │          spans               ALL                                                    ·                                                ·
+                     │          spans               FULL SCAN                                              ·                                                ·
                      └── scan   ·                   ·                                                      (x, z)                                           +x
 ·                               table               xz@primary                                             ·                                                ·
-·                               spans               ALL                                                    ·                                                ·
+·                               spans               FULL SCAN                                              ·                                                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT generate_series(x, z) FROM xz WHERE z < ANY(SELECT generate_series(x, y) FROM xy)
@@ -152,12 +152,12 @@ render                      ·            ·                        (generate_se
            │                pred         z < generate_series      ·                        ·
            ├── scan         ·            ·                        (x, z)                   ·
            │                table        xz@primary               ·                        ·
-           │                spans        ALL                      ·                        ·
+           │                spans        FULL SCAN                ·                        ·
            └── project set  ·            ·                        (x, y, generate_series)  ·
                 │           render 0     generate_series(@1, @2)  ·                        ·
                 └── scan    ·            ·                        (x, y)                   ·
 ·                           table        xy@primary               ·                        ·
-·                           spans        ALL                      ·                        ·
+·                           spans        FULL SCAN                ·                        ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT generate_subscripts(ARRAY[0, x, 1, 2]), generate_series(x, y), unnest(ARRAY[0, x, y, z]), y, z
@@ -183,10 +183,10 @@ render                ·                   ·                                   
            │          mergeJoinOrder      +"(x=x)"                                 ·                                                           ·
            ├── scan   ·                   ·                                        (x, y)                                                      +x
            │          table               xy@primary                               ·                                                           ·
-           │          spans               ALL                                      ·                                                           ·
+           │          spans               FULL SCAN                                ·                                                           ·
            └── scan   ·                   ·                                        (x, z)                                                      +x
 ·                     table               xz@primary                               ·                                                           ·
-·                     spans               ALL                                      ·                                                           ·
+·                     spans               FULL SCAN                                ·                                                           ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT generate_series((SELECT unnest(ARRAY[x, y]) FROM xy), z) FROM xz
@@ -200,7 +200,7 @@ root                             ·             ·                              
  │         │                     render 0      generate_series(@S1, @1)              ·                     ·
  │         └── scan              ·             ·                                     (z)                   ·
  │                               table         xz@primary                            ·                     ·
- │                               spans         ALL                                   ·                     ·
+ │                               spans         FULL SCAN                             ·                     ·
  └── subquery                    ·             ·                                     (generate_series)     ·
       │                          id            @S1                                   ·                     ·
       │                          original sql  (SELECT unnest(ARRAY[x, y]) FROM xy)  ·                     ·
@@ -212,7 +212,7 @@ root                             ·             ·                              
                      │           render 0      unnest(ARRAY[@1, @2])                 ·                     ·
                      └── scan    ·             ·                                     (x, y)                ·
 ·                                table         xy@primary                            ·                     ·
-·                                spans         ALL                                   ·                     ·
+·                                spans         FULL SCAN                             ·                     ·
 
 # Regression test for #24676.
 statement ok
@@ -240,7 +240,7 @@ render                ·            ·                         (group_name, json
            │          type         left outer                ·                                         ·
            └── scan   ·            ·                         (data)                                    ·
 ·                     table        groups@primary            ·                                         ·
-·                     spans        ALL                       ·                                         ·
+·                     spans        FULL SCAN                 ·                                         ·
 
 # Regression test for #32162.
 query TTTTT
@@ -307,7 +307,7 @@ limit                                 ·            ·                          
                           │           render 0     unnest(@6)                 ·                                                                                        ·
                           └── scan    ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          ·
 ·                                     table        articles@primary           ·                                                                                        ·
-·                                     spans        ALL                        ·                                                                                        ·
+·                                     spans        FULL SCAN                  ·                                                                                        ·
 
 # Regression test for #32723.
 query TTTTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -39,7 +39,7 @@ root            ·             ·
       │         exec mode     exists
       └── scan  ·             ·
 ·               table         abc@primary
-·               spans         ALL
+·               spans         LIMITED SCAN
 ·               limit         1
 
 query TTTTT
@@ -50,7 +50,7 @@ EXPLAIN (VERBOSE) SELECT * FROM abc WHERE a = (SELECT max(a) FROM abc WHERE EXIS
 root                         ·             ·                                                                            (a, b, c)       ·
  ├── scan                    ·             ·                                                                            (a, b, c)       ·
  │                           table         abc@primary                                                                  ·               ·
- │                           spans         ALL                                                                          ·               ·
+ │                           spans         FULL SCAN                                                                    ·               ·
  │                           filter        a = @S2                                                                      ·               ·
  ├── subquery                ·             ·                                                                            (a, b, c)       ·
  │    │                      id            @S1                                                                          ·               ·
@@ -60,7 +60,7 @@ root                         ·             ·                                  
  │         │                 count         1                                                                            ·               ·
  │         └── scan          ·             ·                                                                            (a, b, c)       ·
  │                           table         abc@primary                                                                  ·               ·
- │                           spans         ALL                                                                          ·               ·
+ │                           spans         FULL SCAN                                                                    ·               ·
  │                           filter        c = (a + 3)                                                                  ·               ·
  └── subquery                ·             ·                                                                            (a, b, c)       ·
       │                      id            @S2                                                                          ·               ·
@@ -73,7 +73,7 @@ root                         ·             ·                                  
                 │            count         1                                                                            ·               ·
                 └── revscan  ·             ·                                                                            (a)             -a
 ·                            table         abc@primary                                                                  ·               ·
-·                            spans         ALL                                                                          ·               ·
+·                            spans         FULL SCAN                                                                    ·               ·
 ·                            filter        @S1                                                                          ·               ·
 
 # IN expression transformed into semi-join.
@@ -90,10 +90,10 @@ merge-join  ·                   ·            (a)  ·
  │          mergeJoinOrder      +"(a=a)"     ·    ·
  ├── scan   ·                   ·            (a)  +a
  │          table               abc@primary  ·    ·
- │          spans               ALL          ·    ·
+ │          spans               FULL SCAN    ·    ·
  └── scan   ·                   ·            (a)  +a
 ·           table               abc@primary  ·    ·
-·           spans               ALL          ·    ·
+·           spans               FULL SCAN    ·    ·
 
 query TTT
 EXPLAIN SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS moo (moo1, moo2, moo3) ORDER BY moo2) as foo (foo1) ORDER BY foo1
@@ -146,7 +146,7 @@ root            ·             ·                                               
  │    │         render 0      col0                                                                                                        ·                   ·
  │    └── scan  ·             ·                                                                                                           (col0, col3, col4)  ·
  │              table         tab4@primary                                                                                                ·                   ·
- │              spans         ALL                                                                                                         ·                   ·
+ │              spans         FULL SCAN                                                                                                   ·                   ·
  │              filter        ((col0 <= 0) AND (col4 <= 5.38)) OR ((((col4 = ANY @S1) AND (col3 <= 5)) AND (col3 >= 7)) AND (col3 <= 9))  ·                   ·
  └── subquery   ·             ·                                                                                                           (col0)              ·
       │         id            @S1                                                                                                         ·                   ·
@@ -154,7 +154,7 @@ root            ·             ·                                               
       │         exec mode     all rows normalized                                                                                         ·                   ·
       └── scan  ·             ·                                                                                                           (col1)              ·
 ·               table         tab4@primary                                                                                                ·                   ·
-·               spans         ALL                                                                                                         ·                   ·
+·               spans         FULL SCAN                                                                                                   ·                   ·
 ·               filter        col1 > 8.27                                                                                                 ·                   ·
 
 # ------------------------------------------------------------------------------
@@ -177,10 +177,10 @@ merge-join  ·                   ·          (x, y)  ·
  │          mergeJoinOrder      +"(x=x)"   ·       ·
  ├── scan   ·                   ·          (x, y)  +x
  │          table               a@primary  ·       ·
- │          spans               ALL        ·       ·
+ │          spans               FULL SCAN  ·       ·
  └── scan   ·                   ·          (x)     +x
 ·           table               b@primary  ·       ·
-·           spans               ALL        ·       ·
+·           spans               FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE b.x-1 = a.x)
@@ -193,12 +193,12 @@ hash-join       ·                  ·                (x, y)     ·
  │              left cols are key  ·                ·          ·
  ├── scan       ·                  ·                (x, y)     ·
  │              table              a@primary        ·          ·
- │              spans              ALL              ·          ·
+ │              spans              FULL SCAN        ·          ·
  └── render     ·                  ·                (column5)  ·
       │         render 0           x - 1            ·          ·
       └── scan  ·                  ·                (x)        ·
 ·               table              b@primary        ·          ·
-·               spans              ALL              ·          ·
+·               spans              FULL SCAN        ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM b WHERE b.x = a.x)
@@ -213,10 +213,10 @@ merge-join  ·                   ·          (x, y)  ·
  │          mergeJoinOrder      +"(x=x)"   ·       ·
  ├── scan   ·                   ·          (x, y)  +x
  │          table               a@primary  ·       ·
- │          spans               ALL        ·       ·
+ │          spans               FULL SCAN  ·       ·
  └── scan   ·                   ·          (x)     +x
 ·           table               b@primary  ·       ·
-·           spans               ALL        ·       ·
+·           spans               FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM b WHERE NOT EXISTS(SELECT * FROM a WHERE x-1 = b.x)
@@ -229,12 +229,12 @@ hash-join       ·                  ·                (x, z)     ·
  │              left cols are key  ·                ·          ·
  ├── scan       ·                  ·                (x, z)     ·
  │              table              b@primary        ·          ·
- │              spans              ALL              ·          ·
+ │              spans              FULL SCAN        ·          ·
  └── render     ·                  ·                (column5)  ·
       │         render 0           x - 1            ·          ·
       └── scan  ·                  ·                (x)        ·
 ·               table              a@primary        ·          ·
-·               spans              ALL              ·          ·
+·               spans              FULL SCAN        ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY(SELECT x FROM b)
@@ -251,7 +251,7 @@ root            ·              ·                  ("array")  ·
       │         exec mode      all rows           ·          ·
       └── scan  ·              ·                  (x)        ·
 ·               table          b@primary          ·          ·
-·               spans          ALL                ·          ·
+·               spans          FULL SCAN          ·          ·
 
 # Case where the plan has an apply join.
 query TTTTT
@@ -264,7 +264,7 @@ apply-join  ·            ·            (a, b, c)  ·
  │          pred         column1 = a  ·          ·
  └── scan   ·            ·            (a, b, c)  ·
 ·           table        abc@primary  ·          ·
-·           spans        ALL          ·          ·
+·           spans        FULL SCAN    ·          ·
 
 # Case where the EXISTS subquery still has outer columns in the subquery
 # (regression test for #28816).

--- a/pkg/sql/opt/exec/execbuilder/testdata/tuple
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tuple
@@ -128,7 +128,7 @@ render     ·            ·                                                     
  │         render 0     ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]  ·                                        ·
  └── scan  ·            ·                                                                                   (v int)                                  ·
 ·          table        kv@primary                                                                          ·                                        ·
-·          spans        ALL                                                                                 ·                                        ·
+·          spans        FULL SCAN                                                                           ·                                        ·
 
 query TTTTT
 EXPLAIN (VERBOSE, TYPES) SELECT (x).a, (x).b, (x).c FROM (SELECT (row(v,v,v) AS a,b,c) AS x FROM kv)
@@ -143,7 +143,7 @@ render          ·            ·                                                
       │         render 0     ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]  ·                                        ·
       └── scan  ·            ·                                                                                   (v int)                                  ·
 ·               table        kv@primary                                                                          ·                                        ·
-·               spans        ALL                                                                                 ·                                        ·
+·               spans        FULL SCAN                                                                           ·                                        ·
 
 query TTTTT
 EXPLAIN (VERBOSE, TYPES) SELECT (x).e, (x).f, (x).g

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -14,10 +14,10 @@ EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 union      ·            ·
  ├── scan  ·            ·
  │         table        uniontest@primary
- │         spans        ALL
+ │         spans        FULL SCAN
  └── scan  ·            ·
 ·          table        uniontest@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 query TTT
 EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
@@ -27,10 +27,10 @@ EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
 append     ·            ·
  ├── scan  ·            ·
  │         table        uniontest@primary
- │         spans        ALL
+ │         spans        FULL SCAN
  └── scan  ·            ·
 ·          table        uniontest@primary
-·          spans        ALL
+·          spans        FULL SCAN
 
 # Check that EXPLAIN properly releases memory for virtual tables.
 query TTT
@@ -60,12 +60,12 @@ sort                 ·            ·            (a)     +a
       │    │         render 0     a            ·       ·
       │    └── scan  ·            ·            (a, c)  ·
       │              table        abc@primary  ·       ·
-      │              spans        ALL          ·       ·
+      │              spans        FULL SCAN    ·       ·
       └── render     ·            ·            (a)     ·
            │         render 0     a            ·       ·
            └── scan  ·            ·            (a, b)  ·
 ·                    table        abc@primary  ·       ·
-·                    spans        ALL          ·       ·
+·                    spans        FULL SCAN    ·       ·
 
 # Regression test for #32723.
 query TTTTT
@@ -125,11 +125,11 @@ render               ·            ·                  ("?column?")  ·
  └── append          ·            ·                  ()            ·
       ├── scan       ·            ·                  ()            ·
       │              table        uniontest@primary  ·             ·
-      │              spans        ALL                ·             ·
+      │              spans        FULL SCAN          ·             ·
       └── render     ·            ·                  ()            ·
            └── scan  ·            ·                  (k)           ·
 ·                    table        uniontest@primary  ·             ·
-·                    spans        ALL                ·             ·
+·                    spans        FULL SCAN          ·             ·
 ·                    filter       k > 3              ·             ·
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -112,7 +112,7 @@ count                ·                 ·
       └── render     ·                 ·
            └── scan  ·                 ·
 ·                    table             xyz@primary
-·                    spans             ALL
+·                    spans             FULL SCAN
 ·                    locking strength  for update
 
 query TTTTT
@@ -134,7 +134,7 @@ count                ·                 ·            ()                        
            │         render 4          2            ·                            ·
            └── scan  ·                 ·            (x, y, z)                    ·
 ·                    table             xyz@primary  ·                            ·
-·                    spans             ALL          ·                            ·
+·                    spans             FULL SCAN    ·                            ·
 ·                    locking strength  for update   ·                            ·
 
 query TTTTT
@@ -156,7 +156,7 @@ count                ·                 ·            ()               ·
            │         render 4          x            ·                ·
            └── scan  ·                 ·            (x, y, z)        ·
 ·                    table             xyz@primary  ·                ·
-·                    spans             ALL          ·                ·
+·                    spans             FULL SCAN    ·                ·
 ·                    locking strength  for update   ·                ·
 
 query TTTTT
@@ -183,7 +183,7 @@ count                     ·                 ·            ()                   
                 │         render 3          z            ·                            ·
                 └── scan  ·                 ·            (x, y, z)                    ·
 ·                         table             xyz@primary  ·                            ·
-·                         spans             ALL          ·                            ·
+·                         spans             FULL SCAN    ·                            ·
 ·                         locking strength  for update   ·                            ·
 
 statement ok
@@ -247,7 +247,7 @@ count                          ·            ·
                      │         order        -v
                      └── scan  ·            ·
 ·                              table        kv@primary
-·                              spans        ALL
+·                              spans        FULL SCAN
 
 # Use case for UPDATE ... ORDER BY: renumbering a PK without unique violation.
 query TTT
@@ -296,7 +296,7 @@ count                ·                 ·
            │         render 3          c + 1
            └── scan  ·                 ·
 ·                    table             tu@primary
-·                    spans             ALL
+·                    spans             FULL SCAN
 ·                    locking strength  for update
 
 statement ok
@@ -368,7 +368,7 @@ root                                          ·                 ·             
                                     │         render 4          c                                 ·                         ·
                                     └── scan  ·                 ·                                 (a, b, c, rowid[hidden])  ·
 ·                                             table             abc@primary                       ·                         ·
-·                                             spans             ALL                               ·                         ·
+·                                             spans             FULL SCAN                         ·                         ·
 ·                                             locking strength  for update                        ·                         ·
 
 # ------------------------------------------------------------------------------
@@ -422,7 +422,7 @@ count                           ·            ·               ()               
                      │          key columns  a               ·                   ·
                      └── scan   ·            ·               (a, b)              ·
 ·                               table        t38799@foo      ·                   ·
-·                               spans        ALL             ·                   ·
+·                               spans        FULL SCAN       ·                   ·
 
 # ------------------------------------------------------------------------------
 # Test without implicit SELECT FOR UPDATE.
@@ -478,7 +478,7 @@ count                ·                 ·
       └── render     ·                 ·
            └── scan  ·                 ·
 ·                    table             kv@primary
-·                    spans             ALL
+·                    spans             FULL SCAN
 ·                    locking strength  for update
 
 statement ok
@@ -580,7 +580,7 @@ count                ·            ·
       └── render     ·            ·
            └── scan  ·            ·
 ·                    table        kv@primary
-·                    spans        ALL
+·                    spans        FULL SCAN
 
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (1, 2)
@@ -601,7 +601,7 @@ count                ·            ·            ()                           ·
            │         render 4     2            ·                            ·
            └── scan  ·            ·            (x, y, z)                    ·
 ·                    table        xyz@primary  ·                            ·
-·                    spans        ALL          ·                            ·
+·                    spans        FULL SCAN    ·                            ·
 
 query TTT
 EXPLAIN UPDATE kv SET v = v - 1 WHERE k < 3 LIMIT 1
@@ -675,7 +675,7 @@ count                ·            ·
       └── render     ·            ·
            └── scan  ·            ·
 ·                    table        tu@primary
-·                    spans        ALL
+·                    spans        FULL SCAN
 
 # Reset for rest of test.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_from
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_from
@@ -24,10 +24,10 @@ count                      ·                   ·
                 │          mergeJoinOrder      +"(a=a)"
                 ├── scan   ·                   ·
                 │          table               abc@primary
-                │          spans               ALL
+                │          spans               FULL SCAN
                 └── scan   ·                   ·
 ·                          table               abc@primary
-·                          spans               ALL
+·                          spans               FULL SCAN
 
 # Update from another table.
 statement ok
@@ -53,10 +53,10 @@ count                          ·                  ·
                      │         left cols are key  ·
                      ├── scan  ·                  ·
                      │         table              abc@primary
-                     │         spans              ALL
+                     │         spans              FULL SCAN
                      └── scan  ·                  ·
 ·                              table              new_abc@primary
-·                              spans              ALL
+·                              spans              FULL SCAN
 
 # Returning old values.
 query TTT
@@ -88,10 +88,10 @@ render                          ·                   ·
                      │          mergeJoinOrder      +"(a=a)"
                      ├── scan   ·                   ·
                      │          table               abc@primary
-                     │          spans               ALL
+                     │          spans               FULL SCAN
                      └── scan   ·                   ·
 ·                               table               abc@primary
-·                               spans               ALL
+·                               spans               FULL SCAN
 
 # Check if RETURNING * returns everything
 query TTTTT
@@ -122,10 +122,10 @@ run                        ·                   ·            (a, b, c, a, b, c)
                 │          mergeJoinOrder      +"(a=a)"     ·                                       ·
                 ├── scan   ·                   ·            (a, b, c)                               +a
                 │          table               abc@primary  ·                                       ·
-                │          spans               ALL          ·                                       ·
+                │          spans               FULL SCAN    ·                                       ·
                 └── scan   ·                   ·            (a, b, c)                               +a
 ·                          table               abc@primary  ·                                       ·
-·                          spans               ALL          ·                                       ·
+·                          spans               FULL SCAN    ·                                       ·
 
 # Update values of table from values expression
 query TTT
@@ -177,17 +177,17 @@ count                               ·                   ·
                      │              equality            (a) = (a)
                      ├── scan       ·                   ·
                      │              table               ab@primary
-                     │              spans               ALL
+                     │              spans               FULL SCAN
                      └── hash-join  ·                   ·
                           │         type                inner
                           │         equality            (a) = (a)
                           │         right cols are key  ·
                           ├── scan  ·                   ·
                           │         table               ac@primary
-                          │         spans               ALL
+                          │         spans               FULL SCAN
                           └── scan  ·                   ·
 ·                                   table               abc@primary
-·                                   spans               ALL
+·                                   spans               FULL SCAN
 
 # Make sure UPDATE ... FROM works with LATERAL.
 query TTT
@@ -218,14 +218,14 @@ run                                 ·                   ·
                      │              equality            (a) = (a)
                      ├── scan       ·                   ·
                      │              table               ab@primary
-                     │              spans               ALL
+                     │              spans               FULL SCAN
                      └── hash-join  ·                   ·
                           │         type                inner
                           │         equality            (a) = (a)
                           │         right cols are key  ·
                           ├── scan  ·                   ·
                           │         table               ac@primary
-                          │         spans               ALL
+                          │         spans               FULL SCAN
                           └── scan  ·                   ·
 ·                                   table               abc@primary
-·                                   spans               ALL
+·                                   spans               FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -29,7 +29,7 @@ count                          ·            ·
                      │         order        -v
                      └── scan  ·            ·
 ·                              table        kv@primary
-·                              spans        ALL
+·                              spans        FULL SCAN
 
 # Use explicit target columns (which can use blind KV Put).
 query TTT
@@ -54,7 +54,7 @@ count                          ·            ·
                      │         order        -v
                      └── scan  ·            ·
 ·                              table        kv@primary
-·                              spans        ALL
+·                              spans        FULL SCAN
 
 # Add RETURNING clause (should still use blind KV Put).
 query TTT
@@ -79,7 +79,7 @@ run                            ·            ·
                      │         order        -v
                      └── scan  ·            ·
 ·                              table        kv@primary
-·                              spans        ALL
+·                              spans        FULL SCAN
 
 # Use subset of explicit target columns (which cannot use blind KV Put).
 query TTT
@@ -117,7 +117,7 @@ count                                         ·                      ·
                                     │         order                  -v
                                     └── scan  ·                      ·
 ·                                             table                  kv@primary
-·                                             spans                  ALL
+·                                             spans                  FULL SCAN
 
 # Use Upsert with indexed table, default columns, computed columns, and check
 # columns.
@@ -384,7 +384,7 @@ root                                               ·             ·            
                                          │         render 3      c                                                    ·                            ·
                                          └── scan  ·             ·                                                    (a, b, c)                    ·
 ·                                                  table         abc@primary                                          ·                            ·
-·                                                  spans         ALL                                                  ·                            ·
+·                                                  spans         FULL SCAN                                            ·                            ·
 
 # ------------------------------------------------------------------------------
 # Regression for #35364. This tests behavior that is different between the CBO

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -69,7 +69,7 @@ render               ·            ·                                           
            │         render 0     1                                                                   ·                      ·
            └── scan  ·            ·                                                                   ()                     ·
 ·                    table        kv@primary                                                          ·                      ·
-·                    spans        ALL                                                                 ·                      ·
+·                    spans        FULL SCAN                                                           ·                      ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT nth_value(1, 2) OVER () FROM kv
@@ -86,7 +86,7 @@ render               ·            ·                                           
            │         render 1     2                                                                           ·                                                ·
            └── scan  ·            ·                                                                           ()                                               ·
 ·                    table        kv@primary                                                                  ·                                                ·
-·                    spans        ALL                                                                         ·                                                ·
+·                    spans        FULL SCAN                                                                   ·                                                ·
 
 statement error column "v" must appear in the GROUP BY clause or be used in an aggregate function
 EXPLAIN (VERBOSE) SELECT max(v) OVER (), min(v) FROM kv ORDER BY 1
@@ -103,7 +103,7 @@ render                    ·            ·
            └── window     ·            ·
                 └── scan  ·            ·
 ·                         table        kv@primary
-·                         spans        ALL
+·                         spans        FULL SCAN
 
 query TTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
@@ -126,7 +126,7 @@ render                    ·            ·                                      
                 │         render 4     (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
                 └── scan  ·            ·                                                                                                                   (k int, v int, d decimal)                                    ·
 ·                         table        kv@primary                                                                                                          ·                                                            ·
-·                         spans        ALL                                                                                                                 ·                                                            ·
+·                         spans        FULL SCAN                                                                                                           ·                                                            ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
@@ -150,7 +150,7 @@ render                         ·            ·                                 
                      │         render 3     (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
                      └── scan  ·            ·                                                                                                                   (k int, v int, d decimal)                                    ·
 ·                              table        kv@primary                                                                                                          ·                                                            ·
-·                              spans        ALL                                                                                                                 ·                                                            ·
+·                              spans        FULL SCAN                                                                                                           ·                                                            ·
 
 query TTTTT
 EXPLAIN (TYPES,NONORMALIZE) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY k
@@ -167,7 +167,7 @@ sort                 ·            ·                                           
            │         render 3     (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                          ·
            └── scan  ·            ·                                                                                                                 (k int, v int, d decimal)                  ·
 ·                    table        kv@primary                                                                                                        ·                                          ·
-·                    spans        ALL                                                                                                               ·                                          ·
+·                    spans        FULL SCAN                                                                                                         ·                                          ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
@@ -191,7 +191,7 @@ render                         ·            ·                                 
                      │         render 3     (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
                      └── scan  ·            ·                                                                                                                   (k int, v int, d decimal)                                    ·
 ·                              table        kv@primary                                                                                                          ·                                                            ·
-·                              spans        ALL                                                                                                                 ·                                                            ·
+·                              spans        FULL SCAN                                                                                                           ·                                                            ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT max(k), max(k) + stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY variance(d) OVER (PARTITION BY v, 100)
@@ -220,7 +220,7 @@ render                              ·            ·                            
                           │         group by     v, d                                                                                                                ·                                                              ·
                           └── scan  ·            ·                                                                                                                   (k int, v int, d decimal)                                      ·
 ·                                   table        kv@primary                                                                                                          ·                                                              ·
-·                                   spans        ALL                                                                                                                 ·                                                              ·
+·                                   spans        FULL SCAN                                                                                                           ·                                                              ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT max(k), stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY 1
@@ -242,7 +242,7 @@ sort                      ·            ·                                      
                 │         group by     v, d                                                                                                              ·                                            ·
                 └── scan  ·            ·                                                                                                                 (k int, v int, d decimal)                    ·
 ·                         table        kv@primary                                                                                                        ·                                            ·
-·                         spans        ALL                                                                                                               ·                                            ·
+·                         spans        FULL SCAN                                                                                                         ·                                            ·
 
 # Partition
 
@@ -271,7 +271,7 @@ render                         ·            ·                                 
                      │         render 2     2                                                                          ·                                                       ·
                      └── scan  ·            ·                                                                          ()                                                      ·
 ·                              table        kv@primary                                                                 ·                                                       ·
-·                              spans        ALL                                                                        ·                                                       ·
+·                              spans        FULL SCAN                                                                  ·                                                       ·
 
 # Ordering
 
@@ -287,7 +287,7 @@ sort            ·            ·                                                
       │         render 2     rank() OVER (ORDER BY @1 ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·             ·
       └── scan  ·            ·                                                                                (k, v)        ·
 ·               table        kv@primary                                                                       ·             ·
-·               spans        ALL                                                                              ·             ·
+·               spans        FULL SCAN                                                                        ·             ·
 
 
 # Frames
@@ -304,7 +304,7 @@ render          ·            ·                                                
       │         render 1     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
       └── scan  ·            ·                                                                 (k)       ·
 ·               table        kv@primary                                                        ·         ·
-·               spans        ALL                                                               ·         ·
+·               spans        FULL SCAN                                                         ·         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) FROM kv
@@ -318,7 +318,7 @@ render          ·            ·                                                
       │         render 1     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)  ·         ·
       └── scan  ·            ·                                                                         (k)       ·
 ·               table        kv@primary                                                                ·         ·
-·               spans        ALL                                                                       ·         ·
+·               spans        FULL SCAN                                                                 ·         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM kv
@@ -332,7 +332,7 @@ render          ·            ·                                                
       │         render 1     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
       └── scan  ·            ·                                                                 (k)       ·
 ·               table        kv@primary                                                        ·         ·
-·               spans        ALL                                                               ·         ·
+·               spans        FULL SCAN                                                         ·         ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
@@ -395,7 +395,7 @@ render               ·            ·                                           
            │         render 8     avg(@1) OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW)                                    ·                                                                ·
            └── scan  ·            ·                                                                                          (k)                                                              ·
 ·                    table        kv@primary                                                                                 ·                                                                ·
-·                    spans        ALL                                                                                        ·                                                                ·
+·                    spans        FULL SCAN                                                                                  ·                                                                ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
@@ -419,7 +419,7 @@ root                 ·             ·                                          
  │         │         render 2      avg(@1) OVER (PARTITION BY @2 ROWS BETWEEN @S1 PRECEDING AND 1 FOLLOWING)  ·             ·
  │         └── scan  ·             ·                                                                          (v, w)        ·
  │                   table         kv@primary                                                                 ·             ·
- │                   spans         ALL                                                                        ·             ·
+ │                   spans         FULL SCAN                                                                  ·             ·
  └── subquery        ·             ·                                                                          (avg)         ·
       │              id            @S1                                                                        ·             ·
       │              original sql  (SELECT count(*) FROM kv)                                                  ·             ·
@@ -429,7 +429,7 @@ root                 ·             ·                                          
            │         scalar        ·                                                                          ·             ·
            └── scan  ·             ·                                                                          ()            ·
 ·                    table         kv@primary                                                                 ·             ·
-·                    spans         ALL                                                                        ·             ·
+·                    spans         FULL SCAN                                                                  ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
@@ -459,4 +459,4 @@ render          ·            ·                                                
       │         render 4     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                      ·                        ·
       └── scan  ·            ·                                                                                     (k)                      ·
 ·               table        kv@primary                                                                            ·                        ·
-·               spans        ALL                                                                                   ·                        ·
+·               spans        FULL SCAN                                                                             ·                        ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -27,7 +27,7 @@ root                        ·             ·                (a, a)  ·
            │                label         buffer 1 (t)     ·       ·
            └── scan         ·             ·                (a)     ·
 ·                           table         y@primary        ·       ·
-·                           spans         ALL              ·       ·
+·                           spans         FULL SCAN        ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
@@ -39,7 +39,7 @@ render     ·            ·          (a)  ·
  │         render 0     a          ·    ·
  └── scan  ·            ·          (a)  ·
 ·          table        y@primary  ·    ·
-·          spans        ALL        ·    ·
+·          spans        FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
@@ -88,10 +88,10 @@ cross-join  ·            ·                   (col)  ·
  │          type         cross               ·      ·
  ├── scan   ·            ·                   ()     ·
  │          table        table39010@primary  ·      ·
- │          spans        ALL                 ·      ·
+ │          spans        FULL SCAN           ·      ·
  └── scan   ·            ·                   (col)  ·
 ·           table        table39010@primary  ·      ·
-·           spans        ALL                 ·      ·
+·           spans        FULL SCAN           ·      ·
 
 query TTTTT
 EXPLAIN (VERBOSE)

--- a/pkg/sql/testdata/explain_tree
+++ b/pkg/sql/testdata/explain_tree
@@ -30,7 +30,7 @@ render                               (cid int, date date, value decimal)
  │         render 2  (@2)[decimal]
  └── scan                            (cid int, value decimal, date date)
            table     orders@primary
-           spans     ALL
+           spans     FULL SCAN
 
 plan-tree
 SELECT cid, date, value FROM t.orders
@@ -49,7 +49,7 @@ children:
   - key: table
     value: orders@primary
   - key: spans
-    value: ALL
+    value: FULL SCAN
   children: []
 
 plan-string
@@ -73,7 +73,7 @@ render                                                                          
                      │         render 1     (@2)[decimal]
                      └── scan                                                          (cid int, value decimal, date date)
                                table        orders@primary
-                               spans        ALL
+                               spans        FULL SCAN
                                filter       ((@3)[date] > ('2015-01-01')[date])[bool]
 
 plan-tree
@@ -121,7 +121,7 @@ children:
           - key: table
             value: orders@primary
           - key: spans
-            value: ALL
+            value: FULL SCAN
           - key: filter
             value: date > _
           children: []
@@ -131,7 +131,7 @@ SELECT value FROM (SELECT cid, date, value FROM t.orders)
 ----
 scan                         (value decimal)
       table  orders@primary
-      spans  ALL
+      spans  FULL SCAN
 
 plan-tree
 SELECT value FROM (SELECT cid, date, value FROM t.orders)
@@ -141,7 +141,7 @@ attrs:
 - key: table
   value: orders@primary
 - key: spans
-  value: ALL
+  value: FULL SCAN
 children: []
 
 plan-string
@@ -157,12 +157,12 @@ render                                                    (cid int, date date, v
       │              right cols are key
       ├── scan                                            (cid int, value decimal, date date)
       │              table               orders@primary
-      │              spans               ALL
+      │              spans               FULL SCAN
       └── distinct                                        (date date)
            │         distinct on         date
            └── scan                                       (date date)
                      table               orders@primary
-                     spans               ALL
+                     spans               FULL SCAN
 
 plan-tree
 SELECT cid, date, value FROM t.orders WHERE date IN (SELECT date FROM t.orders)
@@ -190,7 +190,7 @@ children:
     - key: table
       value: orders@primary
     - key: spans
-      value: ALL
+      value: FULL SCAN
     children: []
   - name: distinct
     attrs:
@@ -202,7 +202,7 @@ children:
       - key: table
         value: orders@primary
       - key: spans
-        value: ALL
+        value: FULL SCAN
       children: []
 
 exec
@@ -231,7 +231,7 @@ root                                                                            
  │    │              render 2      (@S1)[string]
  │    └── scan                                                                     (id int, title string)
  │                   table         movies@primary
- │                   spans         ALL
+ │                   spans         FULL SCAN
  └── subquery                                                                      (movie_id int, title string, name string)
       │              id            @S1
       │              original sql  (SELECT name FROM t.actors WHERE name = 'Foo')
@@ -239,7 +239,7 @@ root                                                                            
       └── max1row                                                                  (name string)
            └── scan                                                                (name string)
                      table         actors@primary
-                     spans         ALL
+                     spans         FULL SCAN
                      filter        ((@1)[string] = ('Foo')[string])[bool]
 
 plan-tree
@@ -262,7 +262,7 @@ children:
     - key: table
       value: movies@primary
     - key: spans
-      value: ALL
+      value: FULL SCAN
     children: []
 - name: subquery
   attrs:
@@ -281,7 +281,7 @@ children:
       - key: table
         value: actors@primary
       - key: spans
-        value: ALL
+        value: FULL SCAN
       - key: filter
         value: name = _
       children: []


### PR DESCRIPTION
Backport 1/1 commits from #46708.

/cc @cockroachdb/release

---

Release justification: UX improvement of explain output.

Fixes: #44403.

Release note (sql change): CockroachDB will now be more verbose about
full scans when executing `EXPLAIN`, previously, we would output
`SPANS | ALL`, now it will be `SPANS | FULL SCAN` or (if there is
a limit) `SPANS | LIMITED SCAN`.
