### PR TITLE
sql: update description returned by EXPLAIN ANALYZE (DEBUG)

### DIFF
--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -72,11 +72,11 @@ func setExplainBundleResult(
 			return
 		}
 
-		url := fmt.Sprintf("  %s/_admin/v1/stmtbundle/%d", execCfg.AdminURL(), diagID)
 		text = []string{
-			"Download the bundle from:",
-			url,
-			"or from the Admin UI (Advanced Debug -> Statement Diagnostics).",
+			"Statement diagnostics bundle generated. Download from the Admin UI (Advanced",
+			"Debug -> Statement Diagnostics History) or use the direct link below.",
+			fmt.Sprintf("Admin UI: %s", execCfg.AdminURL()),
+			fmt.Sprintf("Direct link: %s/_admin/v1/stmtbundle/%d", execCfg.AdminURL(), diagID),
 		}
 	}()
 

--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -103,7 +103,7 @@ func TestExplainAnalyzeDebug(t *testing.T) {
 // separated by a space.
 func checkBundle(t *testing.T, text string, expectedFiles ...string) {
 	t.Helper()
-	reg := regexp.MustCompile("http://.*/_admin/v1/stmtbundle/[0-9]*")
+	reg := regexp.MustCompile("http://[a-zA-Z0-9.:]*/_admin/v1/stmtbundle/[0-9]*")
 	url := reg.FindString(text)
 	if url == "" {
 		t.Fatalf("couldn't find URL in response '%s'", text)


### PR DESCRIPTION
Updating the returned text to match the UI wording and to include the "bare" UI
link; example:
```
                                      text
--------------------------------------------------------------------------------
  Statement diagnostics bundle generated. Download from the Admin UI (Advanced
  Debug -> Statement Diagnostics History) or use the direct link below.
  Admin UI: http://127.0.0.1:37023
  Direct link: http://127.0.0.1:37023/_admin/v1/stmtbundle/543551741425713153
```

Release note: None