### PR TITLE
release-20.1: ui: link to download explain analyze (debug) output

### DIFF
--- a/pkg/ui/src/util/analytics/index.ts
+++ b/pkg/ui/src/util/analytics/index.ts
@@ -20,3 +20,4 @@ export { default as trackNetworkSort } from "./trackNetworkSort";
 export { default as trackCollapseNodes } from "./trackCollapseNodes";
 export { default as trackTimeScaleSelected } from "./trackTimeScaleSelected";
 export { default as trackTimeFrameChange } from "./trackTimeFrameChange";
+export { default as trackDownloadDiagnosticsBundle } from "./trackDownloadDiagnosticsBundle";

--- a/pkg/ui/src/util/analytics/trackDownloadDiagnosticsBundle.spec.ts
+++ b/pkg/ui/src/util/analytics/trackDownloadDiagnosticsBundle.spec.ts
@@ -1,0 +1,54 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get, isString } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackDownloadDiagnosticsBundle";
+
+const sandbox = createSandbox();
+
+describe("trackDownloadDiagnosticsBundle", () => {
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)("some statement");
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send the right event", () => {
+    const spy = sandbox.spy();
+    const expected = "Diagnostics Bundle Download";
+
+    track(spy)("whatever");
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(isString(event));
+    assert.isTrue(event === expected);
+  });
+
+  it("should send the correct payload", () => {
+    const spy = sandbox.spy();
+    const statement = "SELECT blah from blah-blah";
+
+    track(spy)(statement);
+
+    const sent = spy.getCall(0).args[0];
+    const fingerprint = get(sent, "properties.fingerprint");
+
+    assert.isTrue(isString(fingerprint));
+    assert.isTrue(fingerprint === statement);
+  });
+});

--- a/pkg/ui/src/util/analytics/trackDownloadDiagnosticsBundle.ts
+++ b/pkg/ui/src/util/analytics/trackDownloadDiagnosticsBundle.ts
@@ -1,0 +1,25 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (statement: string) => {
+  fn({
+    event: "Diagnostics Bundle Download",
+    properties: {
+      fingerprint: statement,
+    },
+  });
+};
+
+export default function trackDownloadDiagnosticsBundle (statement: string) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(statement);
+}

--- a/pkg/ui/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/src/views/reports/containers/debug/index.tsx
@@ -116,6 +116,11 @@ export default function Debug() {
           url="#/data-distribution"
           note="View the distribution of table data across nodes and verify zone configuration."
         />
+        <DebugPanelLink
+          name="Statement Diagnostics History"
+          url="#/reports/statements/diagnosticshistory"
+          note="View the history of statement diagnostics requests"
+        />
         <PanelTitle>Configuration</PanelTitle>
         <DebugPanelLink
           name="Cluster Settings"
@@ -178,13 +183,6 @@ export default function Debug() {
           />
           <DebugTableLink name="Raft Messages" url="#/raft/messages/all" />
           <DebugTableLink name="Raft for all ranges" url="#/raft/ranges" />
-        </DebugTableRow>
-        <DebugTableRow title="Statements">
-          <DebugTableLink
-            name="Statement diagnostics history"
-            url="#/reports/statements/diagnosticshistory"
-            note="#/reports/statements/diagnosticshistory"
-          />
         </DebugTableRow>
       </DebugTable>
       <DebugTable heading="Tracing and Profiling Endpoints (local node only)">

--- a/pkg/ui/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
+++ b/pkg/ui/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
@@ -39,6 +39,7 @@ import {
   sortByRequestedAtField,
   sortByStatementFingerprintField,
 } from "src/views/statements/diagnostics";
+import { trackDownloadDiagnosticsBundle } from "src/util/analytics";
 
 type StatementDiagnosticsHistoryViewProps = MapStateToProps & MapDispatchToProps;
 
@@ -85,20 +86,22 @@ class StatementDiagnosticsHistoryView extends React.Component<StatementDiagnosti
         if (record.completed) {
           return (
             <div className="crl-statements-diagnostics-view__actions-column cell--show-on-hover nodes-table__link">
-              <Button
-                onClick={() => this.getStatementDiagnostics(record.statement_diagnostics_id)}
-                size="small"
-                type="flat"
-                iconPosition="left"
-                icon={() => (
-                  <span
-                    className="crl-statements-diagnostics-view__icon"
-                    dangerouslySetInnerHTML={ trustIcon(DownloadIcon) }
-                  />
-                )}
-              >
-                Download
-              </Button>
+              <a href={`_admin/v1/stmtbundle/${record.statement_diagnostics_id}`}
+                 onClick={() => trackDownloadDiagnosticsBundle(record.statement_fingerprint)}>
+                <Button
+                  size="small"
+                  type="flat"
+                  iconPosition="left"
+                  icon={() => (
+                    <span
+                      className="crl-statements-diagnostics-view__icon"
+                      dangerouslySetInnerHTML={ trustIcon(DownloadIcon) }
+                    />
+                  )}
+                >
+                  Bundle (.zip)
+                </Button>
+              </a>
             </div>
           );
         }

--- a/pkg/ui/src/views/statements/diagnostics/diagnosticsView.styl
+++ b/pkg/ui/src/views/statements/diagnostics/diagnosticsView.styl
@@ -34,27 +34,7 @@
     display flex
     flex-direction row
     flex-wrap nowrap
-
-  &__vertical-line
-    width 1px
-    min-height 100%
-    border-left 1px solid $colors--neutral-3
-    margin 0 $spacing-x-small
-
-  &__icon
-    display inline-block
-    color inherit
-    font-style normal
-    line-height 0
-    text-align center
-    text-transform none
-    vertical-align -0.125em
-    margin-right $spacing-x-small
-
-  &__actions-column
-    display flex
-    flex-direction row
-    flex-wrap nowrap
+    justify-content flex-end
 
   &__vertical-line
     width 1px

--- a/pkg/ui/src/views/statements/diagnostics/diagnosticsView.tsx
+++ b/pkg/ui/src/views/statements/diagnostics/diagnosticsView.tsx
@@ -43,7 +43,7 @@ import StatementDiagnosticsRequest = cockroach.server.serverpb.StatementDiagnost
 import { getDiagnosticsStatus, sortByCompletedField, sortByRequestedAtField } from "./diagnosticsUtils";
 import { statementDiagnostics } from "src/util/docs";
 import { createStatementDiagnosticsAlertLocalSetting } from "oss/src/redux/alerts";
-import { trackActivateDiagnostics } from "src/util/analytics";
+import { trackActivateDiagnostics, trackDownloadDiagnosticsBundle } from "src/util/analytics";
 
 interface DiagnosticsViewOwnProps {
   statementFingerprint?: string;
@@ -93,20 +93,22 @@ export class DiagnosticsView extends React.Component<DiagnosticsViewProps, Diagn
         if (record.completed) {
           return (
             <div className="crl-statements-diagnostics-view__actions-column">
-              <Button
-                onClick={() => this.getStatementDiagnostics(record.statement_diagnostics_id)}
-                size="small"
-                type="flat"
-                iconPosition="left"
-                icon={() => (
-                  <span
-                    className="crl-statements-diagnostics-view__icon"
-                    dangerouslySetInnerHTML={ trustIcon(DownloadIcon) }
-                  />
-                )}
-              >
-                Download
-              </Button>
+              <a href={`_admin/v1/stmtbundle/${record.statement_diagnostics_id}`}
+                 onClick={() => trackDownloadDiagnosticsBundle(record.statement_fingerprint)}>
+                <Button
+                  size="small"
+                  type="flat"
+                  iconPosition="left"
+                  icon={() => (
+                    <span
+                      className="crl-statements-diagnostics-view__icon"
+                      dangerouslySetInnerHTML={ trustIcon(DownloadIcon) }
+                    />
+                  )}
+                >
+                  Bundle (.zip)
+                </Button>
+              </a>
             </div>
           );
         }


### PR DESCRIPTION
Backport 1/1 commits from #46790.

/cc @cockroachdb/release

---

This commit modifies the link for downloading the output
of a statement diagnostics activation. It now points to
the bundle zip file of all diagnostics.

The link is constructed using the statement diagnostics ID
which was already present in the object retrieved from the
database.

Triggering `explain analyze (debug)` via SQL also
creates a diagnostics request which will be shown on the
statements page and have the trace and bundle available
for download. (see #46759)

Promoted the Statement Diagnostics History page to the Reports
section in Advanced Debug.

Added telemetry for tracking of bundle downloads as per
#45625

![Screen Shot 2020-04-02 at 11 33 38 AM](https://user-images.githubusercontent.com/986307/78277548-b79a6000-74e2-11ea-91e9-b462aeaaff54.png)

Release justification: low-risk ui-only additive change to
a new feature.

Release note (admin ui change): The download link for statement 
diagnostics has changed and now points to the bundle zip file.
