### PR TITLE
sql: add CREATE TABLE LIKE

### DIFF
--- a/docs/generated/sql/bnf/col_qualification.bnf
+++ b/docs/generated/sql/bnf/col_qualification.bnf
@@ -7,7 +7,7 @@ col_qualification ::=
 	| 'CONSTRAINT' constraint_name 'CHECK' '(' a_expr ')'
 	| 'CONSTRAINT' constraint_name 'DEFAULT' b_expr
 	| 'CONSTRAINT' constraint_name 'REFERENCES' table_name opt_name_parens key_match reference_actions
-	| 'CONSTRAINT' constraint_name 'AS' '(' a_expr ')' 'STORED'
+	| 'CONSTRAINT' constraint_name generated_as '(' a_expr ')' 'STORED'
 	| 'NOT' 'NULL'
 	| 'NULL'
 	| 'UNIQUE'
@@ -16,7 +16,7 @@ col_qualification ::=
 	| 'CHECK' '(' a_expr ')'
 	| 'DEFAULT' b_expr
 	| 'REFERENCES' table_name opt_name_parens key_match reference_actions
-	| 'AS' '(' a_expr ')' 'STORED'
+	| generated_as '(' a_expr ')' 'STORED'
 	| 'COLLATE' collation_name
 	| 'FAMILY' family_name
 	| 'CREATE' 'FAMILY' family_name

--- a/docs/generated/sql/bnf/create_table_stmt.bnf
+++ b/docs/generated/sql/bnf/create_table_stmt.bnf
@@ -1,11 +1,13 @@
 create_table_stmt ::=
-	'CREATE' opt_temp_create_table 'TABLE' table_name '(' column_def ( ( ',' ( column_def | index_def | family_def | table_constraint ) ) )* ')' opt_interleave opt_partition_by
-	| 'CREATE' opt_temp_create_table 'TABLE' table_name '(' index_def ( ( ',' ( column_def | index_def | family_def | table_constraint ) ) )* ')' opt_interleave opt_partition_by
-	| 'CREATE' opt_temp_create_table 'TABLE' table_name '(' family_def ( ( ',' ( column_def | index_def | family_def | table_constraint ) ) )* ')' opt_interleave opt_partition_by
-	| 'CREATE' opt_temp_create_table 'TABLE' table_name '(' table_constraint ( ( ',' ( column_def | index_def | family_def | table_constraint ) ) )* ')' opt_interleave opt_partition_by
+	'CREATE' opt_temp_create_table 'TABLE' table_name '(' column_def ( ( ',' ( column_def | index_def | family_def | table_constraint | 'LIKE' table_name like_table_option_list ) ) )* ')' opt_interleave opt_partition_by
+	| 'CREATE' opt_temp_create_table 'TABLE' table_name '(' index_def ( ( ',' ( column_def | index_def | family_def | table_constraint | 'LIKE' table_name like_table_option_list ) ) )* ')' opt_interleave opt_partition_by
+	| 'CREATE' opt_temp_create_table 'TABLE' table_name '(' family_def ( ( ',' ( column_def | index_def | family_def | table_constraint | 'LIKE' table_name like_table_option_list ) ) )* ')' opt_interleave opt_partition_by
+	| 'CREATE' opt_temp_create_table 'TABLE' table_name '(' table_constraint ( ( ',' ( column_def | index_def | family_def | table_constraint | 'LIKE' table_name like_table_option_list ) ) )* ')' opt_interleave opt_partition_by
+	| 'CREATE' opt_temp_create_table 'TABLE' table_name '(' 'LIKE' table_name like_table_option_list ( ( ',' ( column_def | index_def | family_def | table_constraint | 'LIKE' table_name like_table_option_list ) ) )* ')' opt_interleave opt_partition_by
 	| 'CREATE' opt_temp_create_table 'TABLE' table_name '('  ')' opt_interleave opt_partition_by
-	| 'CREATE' opt_temp_create_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name '(' column_def ( ( ',' ( column_def | index_def | family_def | table_constraint ) ) )* ')' opt_interleave opt_partition_by
-	| 'CREATE' opt_temp_create_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name '(' index_def ( ( ',' ( column_def | index_def | family_def | table_constraint ) ) )* ')' opt_interleave opt_partition_by
-	| 'CREATE' opt_temp_create_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name '(' family_def ( ( ',' ( column_def | index_def | family_def | table_constraint ) ) )* ')' opt_interleave opt_partition_by
-	| 'CREATE' opt_temp_create_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name '(' table_constraint ( ( ',' ( column_def | index_def | family_def | table_constraint ) ) )* ')' opt_interleave opt_partition_by
+	| 'CREATE' opt_temp_create_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name '(' column_def ( ( ',' ( column_def | index_def | family_def | table_constraint | 'LIKE' table_name like_table_option_list ) ) )* ')' opt_interleave opt_partition_by
+	| 'CREATE' opt_temp_create_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name '(' index_def ( ( ',' ( column_def | index_def | family_def | table_constraint | 'LIKE' table_name like_table_option_list ) ) )* ')' opt_interleave opt_partition_by
+	| 'CREATE' opt_temp_create_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name '(' family_def ( ( ',' ( column_def | index_def | family_def | table_constraint | 'LIKE' table_name like_table_option_list ) ) )* ')' opt_interleave opt_partition_by
+	| 'CREATE' opt_temp_create_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name '(' table_constraint ( ( ',' ( column_def | index_def | family_def | table_constraint | 'LIKE' table_name like_table_option_list ) ) )* ')' opt_interleave opt_partition_by
+	| 'CREATE' opt_temp_create_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name '(' 'LIKE' table_name like_table_option_list ( ( ',' ( column_def | index_def | family_def | table_constraint | 'LIKE' table_name like_table_option_list ) ) )* ')' opt_interleave opt_partition_by
 	| 'CREATE' opt_temp_create_table 'TABLE' 'IF' 'NOT' 'EXISTS' table_name '('  ')' opt_interleave opt_partition_by

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -618,6 +618,7 @@ unreserved_keyword ::=
 	| 'ADMIN'
 	| 'AGGREGATE'
 	| 'ALTER'
+	| 'ALWAYS'
 	| 'AT'
 	| 'AUTOMATIC'
 	| 'AUTHORIZATION'
@@ -639,6 +640,7 @@ unreserved_keyword ::=
 	| 'CLUSTER'
 	| 'COLUMNS'
 	| 'COMMENT'
+	| 'COMMENTS'
 	| 'COMMIT'
 	| 'COMMITTED'
 	| 'COMPACT'
@@ -663,6 +665,7 @@ unreserved_keyword ::=
 	| 'DEALLOCATE'
 	| 'DECLARE'
 	| 'DELETE'
+	| 'DEFAULTS'
 	| 'DEFERRED'
 	| 'DISCARD'
 	| 'DOMAIN'
@@ -672,6 +675,7 @@ unreserved_keyword ::=
 	| 'ENUM'
 	| 'ESCAPE'
 	| 'EXCLUDE'
+	| 'EXCLUDING'
 	| 'EXECUTE'
 	| 'EXPERIMENTAL'
 	| 'EXPERIMENTAL_AUDIT'
@@ -690,6 +694,7 @@ unreserved_keyword ::=
 	| 'FOLLOWING'
 	| 'FORCE_INDEX'
 	| 'FUNCTION'
+	| 'GENERATED'
 	| 'GEOMETRYCOLLECTION'
 	| 'GLOBAL'
 	| 'GRANTS'
@@ -698,9 +703,11 @@ unreserved_keyword ::=
 	| 'HIGH'
 	| 'HISTOGRAM'
 	| 'HOUR'
+	| 'IDENTITY'
 	| 'IMMEDIATE'
 	| 'IMPORT'
 	| 'INCLUDE'
+	| 'INCLUDING'
 	| 'INCREMENT'
 	| 'INCREMENTAL'
 	| 'INDEXES'
@@ -846,6 +853,7 @@ unreserved_keyword ::=
 	| 'START'
 	| 'STATISTICS'
 	| 'STDIN'
+	| 'STORAGE'
 	| 'STORE'
 	| 'STORED'
 	| 'STORING'
@@ -1125,6 +1133,7 @@ table_elem ::=
 	| index_def
 	| family_def
 	| table_constraint
+	| 'LIKE' table_name like_table_option_list
 
 insert_column_item ::=
 	column_name
@@ -1531,6 +1540,9 @@ table_constraint ::=
 	'CONSTRAINT' constraint_name constraint_elem
 	| constraint_elem
 
+like_table_option_list ::=
+	(  ) ( ( 'INCLUDING' like_table_option | 'EXCLUDING' like_table_option ) )*
+
 column_name ::=
 	name
 
@@ -1860,6 +1872,13 @@ constraint_elem ::=
 	| 'UNIQUE' '(' index_params ')' opt_storing opt_interleave opt_partition_by
 	| 'PRIMARY' 'KEY' '(' index_params ')' opt_hash_sharded opt_interleave
 	| 'FOREIGN' 'KEY' '(' name_list ')' 'REFERENCES' table_name opt_column_list key_match reference_actions
+
+like_table_option ::=
+	'CONSTRAINTS'
+	| 'DEFAULTS'
+	| 'GENERATED'
+	| 'INDEXES'
+	| 'ALL'
 
 const_typename ::=
 	numeric
@@ -2364,7 +2383,7 @@ col_qualification_elem ::=
 	| 'CHECK' '(' a_expr ')'
 	| 'DEFAULT' b_expr
 	| 'REFERENCES' table_name opt_name_parens key_match reference_actions
-	| 'AS' '(' a_expr ')' 'STORED'
+	| generated_as '(' a_expr ')' 'STORED'
 
 family_name ::=
 	name
@@ -2468,6 +2487,9 @@ create_as_params ::=
 opt_name_parens ::=
 	'(' name ')'
 	| 
+
+generated_as ::=
+	'AS'
 
 reference_action ::=
 	'NO' 'ACTION'

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -125,7 +125,7 @@ func avroFieldMetadataToColDesc(metadata string) (*sqlbase.ColumnDescriptor, err
 		return nil, err
 	}
 	def := parsed.AST.(*tree.AlterTable).Cmds[0].(*tree.AlterTableAddColumn).ColumnDef
-	col, _, _, err := sqlbase.MakeColumnDefDescs(def, &tree.SemaContext{})
+	col, _, _, err := sqlbase.MakeColumnDefDescs(def, &tree.SemaContext{}, &tree.EvalContext{})
 	return col, err
 }
 

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -293,7 +293,7 @@ func runParse(
 		return nil, errors.Wrap(err, "inline")
 	}
 	b, err := g.ExtractProduction(topStmt, descend, nosplit, match, exclude)
-	b = bytes.Replace(b, []byte("IDENT"), []byte("identifier"), -1)
+	b = bytes.Replace(b, []byte("'IDENT'"), []byte("'identifier'"), -1)
 	b = bytes.Replace(b, []byte("_LA"), []byte(""), -1)
 	return b, err
 }

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -142,7 +142,8 @@ func (p *planner) AlterPrimaryKey(
 	if alterPKNode.Sharded != nil {
 		shardCol, newColumn, err := setupShardedIndex(
 			ctx,
-			p.EvalContext().Settings,
+			p.EvalContext(),
+			&p.semaCtx,
 			p.SessionData().HashShardedIndexesEnabled,
 			&alterPKNode.Columns,
 			alterPKNode.Sharded.ShardBuckets,

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -175,7 +175,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			d = newDef
 			incTelemetryForNewColumn(d)
 
-			col, idx, expr, err := sqlbase.MakeColumnDefDescs(d, &params.p.semaCtx)
+			col, idx, expr, err := sqlbase.MakeColumnDefDescs(d, &params.p.semaCtx, params.EvalContext())
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -201,7 +201,7 @@ CREATE TABLE t.test (k INT);
 		t.Fatal(err)
 	}
 	colDef := alterCmd.AST.(*tree.AlterTable).Cmds[0].(*tree.AlterTableAddColumn).ColumnDef
-	col, _, _, err := sqlbase.MakeColumnDefDescs(colDef, nil)
+	col, _, _, err := sqlbase.MakeColumnDefDescs(colDef, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1282,7 +1282,7 @@ func MakeTableDesc(
 				if n.Interleave != nil {
 					return desc, pgerror.New(pgcode.FeatureNotSupported, "interleaved indexes cannot also be hash sharded")
 				}
-				buckets, err := tree.EvalShardBucketCount(d.PrimaryKey.ShardBuckets)
+				buckets, err := sqlbase.EvalShardBucketCount(semaCtx, evalCtx, d.PrimaryKey.ShardBuckets)
 				if err != nil {
 					return desc, err
 				}
@@ -1302,7 +1302,7 @@ func MakeTableDesc(
 				n.Defs = append(n.Defs, checkConstraint)
 				columnDefaultExprs = append(columnDefaultExprs, nil)
 			}
-			col, idx, expr, err := sqlbase.MakeColumnDefDescs(d, semaCtx)
+			col, idx, expr, err := sqlbase.MakeColumnDefDescs(d, semaCtx, evalCtx)
 			if err != nil {
 				return desc, err
 			}
@@ -1364,7 +1364,8 @@ func MakeTableDesc(
 		}
 		shardCol, newColumn, err := setupShardedIndex(
 			ctx,
-			st,
+			evalCtx,
+			semaCtx,
 			sessionData.HashShardedIndexesEnabled,
 			&d.Columns,
 			d.Sharded.ShardBuckets,
@@ -1375,7 +1376,7 @@ func MakeTableDesc(
 			return err
 		}
 		if newColumn {
-			buckets, err := tree.EvalShardBucketCount(d.Sharded.ShardBuckets)
+			buckets, err := sqlbase.EvalShardBucketCount(semaCtx, evalCtx, d.Sharded.ShardBuckets)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1391,7 +1391,7 @@ func MakeTableDesc(
 	}
 	for _, def := range n.Defs {
 		switch d := def.(type) {
-		case *tree.ColumnTableDef:
+		case *tree.ColumnTableDef, *tree.LikeTableDef:
 			// pass, handled above.
 
 		case *tree.IndexTableDef:
@@ -1614,7 +1614,7 @@ func MakeTableDesc(
 		case *tree.ColumnTableDef:
 			// Check after all ResolveFK calls.
 
-		case *tree.IndexTableDef, *tree.UniqueConstraintTableDef, *tree.FamilyTableDef:
+		case *tree.IndexTableDef, *tree.UniqueConstraintTableDef, *tree.FamilyTableDef, *tree.LikeTableDef:
 			// Pass, handled above.
 
 		case *tree.CheckConstraintTableDef:
@@ -1720,6 +1720,18 @@ func makeTableDesc(
 			createStmt = &newCreateStmt
 		}
 	}
+	newDefs, err := replaceLikeTableOpts(n, params)
+	if err != nil {
+		return ret, err
+	}
+
+	if newDefs != nil {
+		// If we found any LIKE table defs, we actually modified the list of
+		// defs during iteration, so we re-assign the resultant list back to
+		// n.Defs.
+		n.Defs = newDefs
+	}
+
 	for i, def := range n.Defs {
 		d, ok := def.(*tree.ColumnTableDef)
 		if !ok {
@@ -1778,6 +1790,139 @@ func makeTableDesc(
 		)
 	})
 	return ret, err
+}
+
+// replaceLikeTableOps processes the TableDefs in the input CreateTableNode,
+// searching for LikeTableDefs. If any are found, each LikeTableDef will be
+// replaced in the output tree.TableDefs (which will be a copy of the input
+// node's TableDefs) by an equivalent set of TableDefs pulled from the
+// LikeTableDef's target table.
+// If no LikeTableDefs are found, the output tree.TableDefs will be nil.
+func replaceLikeTableOpts(n *tree.CreateTable, params runParams) (tree.TableDefs, error) {
+	var newDefs tree.TableDefs
+	for i, def := range n.Defs {
+		d, ok := def.(*tree.LikeTableDef)
+		if !ok {
+			if newDefs != nil {
+				newDefs = append(newDefs, def)
+			}
+			continue
+		}
+		// We're definitely going to be editing n.Defs now, so make a copy of it.
+		if newDefs == nil {
+			newDefs = make(tree.TableDefs, 0, len(n.Defs))
+			newDefs = append(newDefs, n.Defs[:i]...)
+		}
+		td, err := params.p.ResolveMutableTableDescriptor(params.ctx, &d.Name, true, ResolveRequireTableDesc)
+		if err != nil {
+			return nil, err
+		}
+		opts := tree.LikeTableOpt(0)
+		// Process ons / offs.
+		for _, opt := range d.Options {
+			if opt.Excluded {
+				opts &^= opt.Opt
+			} else {
+				opts |= opt.Opt
+			}
+		}
+
+		defs := make(tree.TableDefs, 0)
+		// Add all columns. Columns are always added.
+		for i := range td.Columns {
+			c := &td.Columns[i]
+			if c.Hidden {
+				// Hidden columns automatically get added by the system; we don't need
+				// to add them ourselves here.
+				continue
+			}
+			def := tree.ColumnTableDef{
+				Name: tree.Name(c.Name),
+				Type: c.DatumType(),
+			}
+			if c.Nullable {
+				def.Nullable.Nullability = tree.Null
+			} else {
+				def.Nullable.Nullability = tree.NotNull
+			}
+			if c.DefaultExpr != nil {
+				if opts.Has(tree.LikeTableOptDefaults) {
+					def.DefaultExpr.Expr, err = parser.ParseExpr(*c.DefaultExpr)
+					if err != nil {
+						return nil, err
+					}
+				}
+			}
+			if c.ComputeExpr != nil {
+				if opts.Has(tree.LikeTableOptGenerated) {
+					def.Computed.Computed = true
+					def.Computed.Expr, err = parser.ParseExpr(*c.ComputeExpr)
+					if err != nil {
+						return nil, err
+					}
+				}
+			}
+			defs = append(defs, &def)
+		}
+		if opts.Has(tree.LikeTableOptConstraints) {
+			for _, c := range td.Checks {
+				def := tree.CheckConstraintTableDef{
+					Name:   tree.Name(c.Name),
+					Hidden: c.Hidden,
+				}
+				def.Expr, err = parser.ParseExpr(c.Expr)
+				if err != nil {
+					return nil, err
+				}
+				defs = append(defs, &def)
+			}
+		}
+		if opts.Has(tree.LikeTableOptIndexes) {
+			for _, idx := range td.AllNonDropIndexes() {
+				indexDef := tree.IndexTableDef{
+					Name:     tree.Name(idx.Name),
+					Inverted: idx.Type == sqlbase.IndexDescriptor_INVERTED,
+					Storing:  make(tree.NameList, 0, len(idx.StoreColumnNames)),
+					Columns:  make(tree.IndexElemList, 0, len(idx.ColumnNames)),
+				}
+				columnNames := idx.ColumnNames
+				if idx.IsSharded() {
+					indexDef.Sharded = &tree.ShardedIndexDef{
+						ShardBuckets: tree.NewDInt(tree.DInt(idx.Sharded.ShardBuckets)),
+					}
+					columnNames = idx.Sharded.ColumnNames
+				}
+				for i, name := range columnNames {
+					elem := tree.IndexElem{
+						Column:    tree.Name(name),
+						Direction: tree.Ascending,
+					}
+					if idx.ColumnDirections[i] == sqlbase.IndexDescriptor_DESC {
+						elem.Direction = tree.Descending
+					}
+					indexDef.Columns = append(indexDef.Columns, elem)
+				}
+				for _, name := range idx.StoreColumnNames {
+					indexDef.Storing = append(indexDef.Storing, tree.Name(name))
+				}
+				var def tree.TableDef = &indexDef
+				if idx.Unique {
+					isPK := idx.ID == td.PrimaryIndex.ID
+					if isPK && td.IsPrimaryIndexDefaultRowID() {
+						continue
+					}
+
+					def = &tree.UniqueConstraintTableDef{
+						IndexTableDef: indexDef,
+						PrimaryKey:    isPK,
+					}
+				}
+				defs = append(defs, def)
+			}
+		}
+		newDefs = append(newDefs, defs...)
+	}
+	return newDefs, nil
 }
 
 // dummyColumnItem is used in MakeCheckConstraint to construct an expression

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -102,6 +102,7 @@ func (n *createViewNode) startExec(params runParams) error {
 		params.creationTimeForNewTableDescriptor(),
 		privs,
 		&params.p.semaCtx,
+		params.EvalContext(),
 		isTemporary,
 	)
 	if err != nil {
@@ -188,6 +189,7 @@ func makeViewTableDesc(
 	creationTime hlc.Timestamp,
 	privileges *sqlbase.PrivilegeDescriptor,
 	semaCtx *tree.SemaContext,
+	evalCtx *tree.EvalContext,
 	temporary bool,
 ) (sqlbase.MutableTableDescriptor, error) {
 	desc := InitTableDescriptor(
@@ -204,7 +206,7 @@ func makeViewTableDesc(
 		columnTableDef := tree.ColumnTableDef{Name: tree.Name(colRes.Name), Type: colRes.Typ}
 		// The new types in the CREATE VIEW column specs never use
 		// SERIAL so we need not process SERIAL types here.
-		col, _, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, semaCtx)
+		col, _, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, semaCtx, evalCtx)
 		if err != nil {
 			return desc, err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -110,3 +110,209 @@ WHERE feature_name IN (
 ----
 sql.schema.inverted_index
 sql.schema.hash_sharded_index
+
+subtest like_table
+
+# Test the CREATE TABLE LIKE functionality.
+
+statement ok
+CREATE TABLE like_table (
+  a INT CHECK (a > 3),
+  b STRING DEFAULT 'foo' NOT NULL,
+  c DECIMAL AS (a+3) STORED,
+  h INT,
+  j JSON,
+  PRIMARY KEY (a, b),
+  UNIQUE INDEX foo (b DESC, c),
+  INDEX (c) STORING (j),
+  INVERTED INDEX (j)
+)
+
+statement ok
+CREATE TABLE like_none (LIKE like_table)
+
+query TT
+SHOW CREATE TABLE like_none
+----
+like_none  CREATE TABLE like_none (
+           a INT8 NOT NULL,
+           b STRING NOT NULL,
+           c DECIMAL NULL,
+           h INT8 NULL,
+           j JSONB NULL,
+           FAMILY "primary" (a, b, c, h, j, rowid)
+)
+
+statement ok
+CREATE TABLE like_constraints (LIKE like_table INCLUDING CONSTRAINTS)
+
+query TT
+SHOW CREATE TABLE like_constraints
+----
+like_constraints  CREATE TABLE like_constraints (
+                  a INT8 NOT NULL,
+                  b STRING NOT NULL,
+                  c DECIMAL NULL,
+                  h INT8 NULL,
+                  j JSONB NULL,
+                  FAMILY "primary" (a, b, c, h, j, rowid),
+                  CONSTRAINT check_a CHECK (a > 3)
+)
+
+statement ok
+CREATE TABLE like_indexes (LIKE like_table INCLUDING INDEXES)
+
+query TT
+SHOW CREATE TABLE like_indexes
+----
+like_indexes  CREATE TABLE like_indexes (
+              a INT8 NOT NULL,
+              b STRING NOT NULL,
+              c DECIMAL NULL,
+              h INT8 NULL,
+              j JSONB NULL,
+              CONSTRAINT "primary" PRIMARY KEY (a ASC, b ASC),
+              UNIQUE INDEX foo (b DESC, c ASC),
+              INDEX like_table_c_idx (c ASC) STORING (j),
+              INVERTED INDEX like_table_j_idx (j),
+              FAMILY "primary" (a, b, c, h, j)
+)
+
+# INCLUDING GENERATED adds "generated columns", aka stored columns.
+statement ok
+CREATE TABLE like_generated (LIKE like_table INCLUDING GENERATED)
+
+query TT
+SHOW CREATE TABLE like_generated
+----
+like_generated  CREATE TABLE like_generated (
+                a INT8 NOT NULL,
+                b STRING NOT NULL,
+                c DECIMAL NULL AS (a + 3) STORED,
+                h INT8 NULL,
+                j JSONB NULL,
+                FAMILY "primary" (a, b, c, h, j, rowid)
+)
+
+statement ok
+CREATE TABLE like_defaults (LIKE like_table INCLUDING DEFAULTS)
+
+query TT
+SHOW CREATE TABLE like_defaults
+----
+like_defaults  CREATE TABLE like_defaults (
+               a INT8 NOT NULL,
+               b STRING NOT NULL DEFAULT 'foo':::STRING,
+               c DECIMAL NULL,
+               h INT8 NULL,
+               j JSONB NULL,
+               FAMILY "primary" (a, b, c, h, j, rowid)
+)
+
+statement ok
+CREATE TABLE like_all (LIKE like_table INCLUDING ALL)
+
+query TT
+SHOW CREATE TABLE like_all
+----
+like_all  CREATE TABLE like_all (
+          a INT8 NOT NULL,
+          b STRING NOT NULL DEFAULT 'foo':::STRING,
+          c DECIMAL NULL AS (a + 3) STORED,
+          h INT8 NULL,
+          j JSONB NULL,
+          CONSTRAINT "primary" PRIMARY KEY (a ASC, b ASC),
+          UNIQUE INDEX foo (b DESC, c ASC),
+          INDEX like_table_c_idx (c ASC) STORING (j),
+          INVERTED INDEX like_table_j_idx (j),
+          FAMILY "primary" (a, b, c, h, j),
+          CONSTRAINT check_a CHECK (a > 3)
+)
+
+statement ok
+CREATE TABLE like_mixed (LIKE like_table INCLUDING ALL EXCLUDING GENERATED EXCLUDING CONSTRAINTS INCLUDING GENERATED)
+
+# We expect that this table will be missing the check constraint from the first
+# table, but will include everything else.
+query TT
+SHOW CREATE TABLE like_mixed
+----
+like_mixed  CREATE TABLE like_mixed (
+            a INT8 NOT NULL,
+            b STRING NOT NULL DEFAULT 'foo':::STRING,
+            c DECIMAL NULL AS (a + 3) STORED,
+            h INT8 NULL,
+            j JSONB NULL,
+            CONSTRAINT "primary" PRIMARY KEY (a ASC, b ASC),
+            UNIQUE INDEX foo (b DESC, c ASC),
+            INDEX like_table_c_idx (c ASC) STORING (j),
+            INVERTED INDEX like_table_j_idx (j),
+            FAMILY "primary" (a, b, c, h, j)
+)
+
+statement ok
+CREATE TABLE like_no_pk_table (
+  a INT, b INT
+)
+
+statement ok
+CREATE TABLE like_no_pk_rowid_hidden (LIKE like_no_pk_table INCLUDING INDEXES)
+
+query TT
+SHOW CREATE TABLE like_no_pk_rowid_hidden
+----
+like_no_pk_rowid_hidden  CREATE TABLE like_no_pk_rowid_hidden (
+                         a INT8 NULL,
+                         b INT8 NULL,
+                         FAMILY "primary" (a, b, rowid)
+)
+
+statement error duplicate column name
+CREATE TABLE duplicate_column (LIKE like_table, c DECIMAL)
+
+statement ok
+CREATE TABLE other_table (blah INT)
+
+# Test that mixing normal specifiers and LIKE specifiers works as expected. We
+# expect that the column ordering depends on the order of the LIKE specifiers.
+statement ok
+CREATE TABLE like_more_specifiers (LIKE like_table, z DECIMAL, INDEX(a,blah,z), LIKE other_table)
+
+query TT
+SHOW CREATE TABLE like_more_specifiers
+----
+like_more_specifiers  CREATE TABLE like_more_specifiers (
+                      a INT8 NOT NULL,
+                      b STRING NOT NULL,
+                      c DECIMAL NULL,
+                      h INT8 NULL,
+                      j JSONB NULL,
+                      z DECIMAL NULL,
+                      blah INT8 NULL,
+                      INDEX like_more_specifiers_a_blah_z_idx (a ASC, blah ASC, z ASC),
+                      FAMILY "primary" (a, b, c, h, j, z, blah, rowid)
+)
+
+statement ok
+CREATE TABLE like_hash_base (a INT, INDEX (a) USING HASH WITH BUCKET_COUNT=4)
+
+statement ok
+CREATE TABLE like_hash (LIKE like_hash_base INCLUDING INDEXES)
+
+query TT
+SHOW CREATE TABLE like_hash
+----
+like_hash  CREATE TABLE like_hash (
+           a INT8 NULL,
+           INDEX like_hash_base_crdb_internal_a_shard_4_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
+           FAMILY "primary" (a, crdb_internal_a_shard_4, rowid)
+)
+
+statement error unimplemented
+CREATE TABLE error (LIKE like_hash_base INCLUDING COMMENTS)
+
+statement error unimplemented
+CREATE TABLE error (LIKE like_hash_base INCLUDING STATISTICS)
+
+statement error unimplemented
+CREATE TABLE error (LIKE like_hash_base INCLUDING STORAGE)

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -14,11 +14,17 @@ sharded_primary  CREATE TABLE sharded_primary (
                  FAMILY "primary" (crdb_internal_a_shard_10, a)
 )
 
-statement error pgcode 22023 BUCKET_COUNT must be a strictly positive integer value
+statement error pgcode 22023 BUCKET_COUNT must be an integer greater than 1
 CREATE TABLE invalid_bucket_count (k INT PRIMARY KEY USING HASH WITH BUCKET_COUNT=-1)
 
-statement error pgcode 22003 BUCKET_COUNT must be a strictly positive integer value
+statement error pgcode 22023 BUCKET_COUNT must be an integer greater than 1
+CREATE TABLE invalid_bucket_count (k INT PRIMARY KEY USING HASH WITH BUCKET_COUNT=1)
+
+statement error expected BUCKET_COUNT expression to have type int, but '2.32' has type decimal
 CREATE TABLE fractional_bucket_count (k INT PRIMARY KEY USING HASH WITH BUCKET_COUNT=2.32)
+
+statement error variable sub-expressions are not allowed in BUCKET_COUNT
+CREATE TABLE invalid_bucket_count (k INT PRIMARY KEY USING HASH WITH BUCKET_COUNT=(SELECT 1))
 
 # Ensure that this is round-tripable
 statement ok

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -287,6 +287,11 @@ func TestParse(t *testing.T) {
 		{`CREATE TABLE a (b STRING[] COLLATE de)`},
 		{`CREATE TABLE a (b STRING(3)[] COLLATE de)`},
 
+		{`CREATE TABLE a (LIKE b)`},
+		{`CREATE TABLE a (LIKE b, c INT8)`},
+		{`CREATE TABLE a (LIKE b EXCLUDING INDEXES INCLUDING INDEXES)`},
+		{`CREATE TABLE a (LIKE b INCLUDING ALL EXCLUDING INDEXES, c INT8)`},
+
 		{`CREATE VIEW a AS SELECT * FROM b`},
 		{`EXPLAIN CREATE VIEW a AS SELECT * FROM b`},
 		{`CREATE VIEW a AS SELECT b.* FROM b LIMIT 5`},
@@ -3201,8 +3206,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`CREATE TABLE a(x INT[1][2])`, 32552, ``, ``},
 		{`CREATE TABLE a(x INT ARRAY[1][2])`, 32552, ``, ``},
 
-		{`CREATE TABLE a(LIKE b)`, 30840, ``, ``},
-
 		{`CREATE TABLE a(b INT8) WITH OIDS`, 0, `create table with oids`, ``},
 
 		{`CREATE TABLE a AS SELECT b WITH NO DATA`, 0, `create table as with no data`, ``},
@@ -3218,6 +3221,11 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`CREATE TABLE a(b INT8, FOREIGN KEY (b) REFERENCES c(x) DEFERRABLE INITIALLY IMMEDIATE)`, 31632, `initially immediate`, ``},
 		{`CREATE TABLE a(b INT8, UNIQUE (b) DEFERRABLE)`, 31632, `deferrable`, ``},
 		{`CREATE TABLE a(b INT8, CHECK (b > 0) DEFERRABLE)`, 31632, `deferrable`, ``},
+
+		{`CREATE TABLE a (LIKE b INCLUDING COMMENTS)`, 47071, `like table`, ``},
+		{`CREATE TABLE a (LIKE b INCLUDING IDENTITY)`, 47071, `like table`, ``},
+		{`CREATE TABLE a (LIKE b INCLUDING STATISTICS)`, 47071, `like table`, ``},
+		{`CREATE TABLE a (LIKE b INCLUDING STORAGE)`, 47071, `like table`, ``},
 
 		{`CREATE TEMP TABLE a (a int) ON COMMIT DROP`, 46556, `drop`, ``},
 		{`CREATE TEMP TABLE a (a int) ON COMMIT DELETE ROWS`, 46556, `delete rows`, ``},

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -1544,6 +1544,20 @@ func (node *FamilyTableDef) doc(p *PrettyCfg) pretty.Doc {
 	return pretty.ConcatSpace(d, p.bracket("(", p.Doc(&node.Columns), ")"))
 }
 
+func (node *LikeTableDef) doc(p *PrettyCfg) pretty.Doc {
+	d := pretty.Keyword("LIKE")
+	d = pretty.ConcatSpace(d, p.Doc(&node.Name))
+	for _, opt := range node.Options {
+		word := "INCLUDING"
+		if opt.Excluded {
+			word = "EXCLUDING"
+		}
+		d = pretty.ConcatSpace(d, pretty.Keyword(word))
+		d = pretty.ConcatSpace(d, pretty.Keyword(opt.Opt.String()))
+	}
+	return d
+}
+
 func (node *IndexElem) doc(p *PrettyCfg) pretty.Doc {
 	d := p.Doc(&node.Column)
 	if node.Direction != DefaultDirection {

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -163,6 +163,7 @@ func (v virtualSchemaView) initVirtualTableDesc(
 		hlc.Timestamp{}, /* creationTime */
 		publicSelectPrivileges,
 		nil,   /* semaCtx */
+		nil,   /* evalCtx */
 		false, /* temporary */
 	)
 	return mutDesc.TableDescriptor, err


### PR DESCRIPTION
Closes #30840.

CREATE TABLE LIKE allows the user to create a table based on the schema
of a different table. Different combinations of INCLUDING specifiers
allow the user to customize which bits of the different table should be
copied into the new table.

By default, CREATE TABLE a (LIKE b) will include all of the columns of b
into a, including their nullability, and nothing else.

This commit adds the specifiers:

- INCLUDING CONSTRAINTS adds all CHECK constraints from the source
- INCLUDING DEFAULTS adds all DEFAULT column expressions from the source
- INCLUDING GENERATED adds all computed column expressions from the source
- INCLUDING INDEXES adds all indexes from the source table
- INCLUDING ALL includes all of the above specifiers.

Column families, interleavings, partitioning and foreign key constraints
cannot be preserved from the old table and will have to be recreated
manually in the new table if the user wishes.

In addition, users can exclude specifiers using the EXCLUDING keyword.
This is useful to include ALL and then remove things that aren't wanted.
The most recent INCLUDING/EXCLUDING for a given specifier wins.

LIKE specifiers can also be mixed with ordinary CREATE TABLE specifiers.

For example:

```
CREATE TABLE a (a INT PRIMARY KEY, b INT NOT NULL DEFAULT 3 CHECK (b > 0), INDEX(b))

CREATE TABLE dest (LIKE a INCLUDING ALL EXCLUDING CONSTRAINTS, c INT, INDEX(b,c))
```

The dest table will get all of the indexes and defaults and so on from
a, but not its check constraints, because `EXCLUDING CONSTRAINTS` was
specified after `INCLUDING ALL`.

Also includes `sql: slightly improve hash sharded index creation`

- improve type checking of bucket count for sharded indexes
- return an error if a user happens to name a column the same thing as
  one of the hidden columns for hash sharded indexes.

Release note (sql change): small UX improvements to hash sharded index
creation

Release note (sql change): add CREATE TABLE LIKE specifiers. See commit
message for more detailed examples and documentation.