### PR TITLE
sql: rationalize the initialization of session variables

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1997,7 +1997,15 @@ func (m *sessionDataMutator) SetLocation(loc *time.Location) {
 }
 
 func (m *sessionDataMutator) SetReadOnly(val bool) {
-	m.setCurTxnReadOnly(val)
+	// The read-only state is special; it's set as a session variable (SET
+	// transaction_read_only=<>), but it represents per-txn state, not
+	// per-session. There's no field for it in the SessionData struct. Instead, we
+	// call into the connEx, which modifies its TxnState.
+	// NOTE(andrei): I couldn't find good documentation on transaction_read_only,
+	// but I've tested its behavior in Postgres 11.
+	if m.setCurTxnReadOnly != nil {
+		m.setCurTxnReadOnly(val)
+	}
 }
 
 func (m *sessionDataMutator) SetStmtTimeout(timeout time.Duration) {

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"context"
 	"math"
+	"strings"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -110,7 +111,6 @@ func (ie *InternalExecutor) initConnEx(
 	ctx context.Context,
 	txn *kv.Txn,
 	sd *sessiondata.SessionData,
-	sdMut sessionDataMutator,
 	syncCallback func([]resWithPos),
 	errCallback func(error),
 ) (*StmtBuf, *sync.WaitGroup, error) {
@@ -120,23 +120,41 @@ func (ie *InternalExecutor) initConnEx(
 		lastDelivered: -1,
 	}
 
+	// When the connEx is serving an internal executor, it can inherit the
+	// application name from an outer session. This happens e.g. during ::regproc
+	// casts and built-in functions that use SQL internally. In that case, we do
+	// not want to record statistics against the outer application name directly;
+	// instead we want to use a separate bucket. However we will still want to
+	// have separate buckets for different applications so that we can measure
+	// their respective "pressure" on internal queries. Hence the choice here to
+	// add the delegate prefix to the current app name.
+	var appStatsBucketName string
+	if !strings.HasPrefix(sd.ApplicationName, sqlbase.InternalAppNamePrefix) {
+		appStatsBucketName = sqlbase.DelegatedAppNamePrefix + sd.ApplicationName
+	} else {
+		// If this is already an "internal app", don't put more prefix.
+		appStatsBucketName = sd.ApplicationName
+	}
+	appStats := ie.s.sqlStats.getStatsForApplication(appStatsBucketName)
+
 	stmtBuf := NewStmtBuf()
 	var ex *connExecutor
-	var err error
 	if txn == nil {
-		ex, err = ie.s.newConnExecutor(
+		ex = ie.s.newConnExecutor(
 			ctx,
-			sd, &sdMut,
+			sd,
+			nil, /* sdDefaults */
 			stmtBuf,
 			clientComm,
 			ie.memMetrics,
 			&ie.s.InternalMetrics,
-			dontResetSessionDataToDefaults,
+			appStats,
 		)
 	} else {
-		ex, err = ie.s.newConnExecutorWithTxn(
+		ex = ie.s.newConnExecutorWithTxn(
 			ctx,
-			sd, &sdMut,
+			sd,
+			nil, /* sdDefaults */
 			stmtBuf,
 			clientComm,
 			ie.mon,
@@ -144,11 +162,8 @@ func (ie *InternalExecutor) initConnEx(
 			&ie.s.InternalMetrics,
 			txn,
 			ie.tcModifier,
-			dontResetSessionDataToDefaults,
+			appStats,
 		)
-	}
-	if err != nil {
-		return nil, nil, err
 	}
 	ex.executorType = executorTypeInternal
 
@@ -371,7 +386,6 @@ func (ie *InternalExecutor) execInternal(
 	if sd.ApplicationName == "" {
 		sd.ApplicationName = sqlbase.InternalAppNamePrefix + "-" + opName
 	}
-	sdMutator := ie.s.makeSessionDataMutator(sd, nil /* defaults */)
 
 	defer func() {
 		// We wrap errors with the opName, but not if they're retriable - in that
@@ -424,7 +438,7 @@ func (ie *InternalExecutor) execInternal(
 		}
 		resCh <- result{err: err}
 	}
-	stmtBuf, wg, err := ie.initConnEx(ctx, txn, sd, sdMutator, syncCallback, errCallback)
+	stmtBuf, wg, err := ie.initConnEx(ctx, txn, sd, syncCallback, errCallback)
 	if err != nil {
 		return result{}, err
 	}


### PR DESCRIPTION
Before this patch, the initialization of session variables was hard to
trace: a pgwire connection was providing "default values", which were
making their way to the initial values of a connExecutor's session vars
by a resetSessionVars() call hidden in the connEx initialization. Also
the respective initialization was hackily aware of whether it's an
internal executor being created, in which case it was doing some other
stuff.

This patch lifts the responsibility for initializing the vars. The
connEx constructor now takes initialized vars, and separately their
default values. Besides being saner, this also allows the creation of an
executor with initialized session vars, but with different default
values.

Release note: None