### PR TITLE
roachtest: fix sqlalchemy roachtest

### DIFF
--- a/pkg/cmd/roachtest/sqlalchemy.go
+++ b/pkg/cmd/roachtest/sqlalchemy.go
@@ -95,7 +95,8 @@ func registerSQLAlchemy(r *testRegistry) {
 			c,
 			node,
 			"install pytest",
-			`sudo pip3 install --upgrade --force-reinstall setuptools pytest pytest-xdist psycopg2`,
+			// Unpin pytest once sqlalchemy rel_1_3_16 is released (https://github.com/sqlalchemy/sqlalchemy/issues/5201)
+			`sudo pip3 install --upgrade --force-reinstall setuptools pytest==5.3.5 pytest-xdist psycopg2`,
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/sqlalchemy_blacklist.go
+++ b/pkg/cmd/roachtest/sqlalchemy_blacklist.go
@@ -160,5 +160,6 @@ var sqlAlchemyBlacklist = blacklist{
 var sqlAlchemyIgnoreList20_1 = sqlAlchemyIgnoreList
 
 var sqlAlchemyIgnoreList = blacklist{
-	"test/dialect/test_suite.py::TableDDLTest_cockroachdb+psycopg2_9_5_0::test_create_table": "flaky",
+	"test/dialect/test_suite.py::ExceptionTest_cockroachdb+psycopg2_9_5_0::test_integrity_error": "passes, but can't parse result",
+	"test/dialect/test_suite.py::TableDDLTest_cockroachdb+psycopg2_9_5_0::test_create_table":     "flaky",
 }


### PR DESCRIPTION
This test was failing because an upstream change made the test
incompatible with the latest version of pytest.

It is fixed by pinning the version of pytest that gets installed. The
ignore list is also updated to deal with a test result parsing issue.

fixes #45989

Release note: None