### PR TITLE
sql: skip TestPrimaryKeyChangeWithCancel on short

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -2907,6 +2907,9 @@ ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (v);
 
 func TestPrimaryKeyChangeWithCancel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	if testing.Short() {
+		t.Skip("short flag - #47038")
+	}
 
 	var chunkSize int64 = 100
 	var maxValue = 4000


### PR DESCRIPTION
This test takes exactly 60s for some reason.

Touches #47038

Release note: None