### PR TITLE
sql: speed up TestPrimaryKeyChangeWithCancel

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -2908,6 +2908,9 @@ ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (v);
 func TestPrimaryKeyChangeWithCancel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	// Decrease the adopt loop interval so that retries happen quickly.
+	defer setTestJobsAdoptInterval()()
+
 	var chunkSize int64 = 100
 	var maxValue = 4000
 	if util.RaceEnabled {


### PR DESCRIPTION
Fixes #47038.

The test was not setting the job adoption interval
to a smaller value.

Release note: None