### PR TITLE
sql: add telemetry for statement diagnostics

### DIFF
--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -243,6 +243,7 @@ func TestCBOReportUsage(t *testing.T) {
 	sqlDB.Exec(t, `EXPLAIN SELECT * FROM x`)
 	sqlDB.Exec(t, `EXPLAIN (distsql) SELECT * FROM x`)
 	sqlDB.Exec(t, `EXPLAIN ANALYZE SELECT * FROM x`)
+	sqlDB.Exec(t, `EXPLAIN ANALYZE (DEBUG) SELECT * FROM x`)
 	sqlDB.Exec(t, `EXPLAIN (opt) SELECT * FROM x`)
 	sqlDB.Exec(t, `EXPLAIN (opt, verbose) SELECT * FROM x`)
 	// Do joins different numbers of times to disambiguate them in the expected,
@@ -312,6 +313,7 @@ func TestCBOReportUsage(t *testing.T) {
 		"sql.plan.stats.created":                1,
 		"sql.plan.explain":                      1,
 		"sql.plan.explain-analyze":              1,
+		"sql.plan.explain-analyze-debug":        1,
 		"sql.plan.explain-opt":                  1,
 		"sql.plan.explain-opt-verbose":          1,
 		"sql.plan.explain-distsql":              1,

--- a/pkg/sql/sqltelemetry/diagnostics.go
+++ b/pkg/sql/sqltelemetry/diagnostics.go
@@ -1,0 +1,20 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqltelemetry
+
+import "github.com/cockroachdb/cockroach/pkg/server/telemetry"
+
+// StatementDiagnosticsCollectedCounter is to be incremented whenever a query is
+// run with diagnostic collection (as a result of a user request through the
+// UI). This does not include diagnostics collected through
+// EXPLAIN ANALYZE (DEBUG), which has a separate counter.
+// distributed across multiple nodes.
+var StatementDiagnosticsCollectedCounter = telemetry.GetCounterOnce("sql.diagnostics.collected")

--- a/pkg/sql/sqltelemetry/planning.go
+++ b/pkg/sql/sqltelemetry/planning.go
@@ -94,6 +94,10 @@ var ExplainDistSQLUseCounter = telemetry.GetCounterOnce("sql.plan.explain-distsq
 // ExplainAnalyzeUseCounter is to be incremented whenever EXPLAIN ANALYZE is run.
 var ExplainAnalyzeUseCounter = telemetry.GetCounterOnce("sql.plan.explain-analyze")
 
+// ExplainAnalyzeDebugUseCounter is to be incremented whenever
+// EXPLAIN ANALYZE (DEBUG) is run.
+var ExplainAnalyzeDebugUseCounter = telemetry.GetCounterOnce("sql.plan.explain-analyze-debug")
+
 // ExplainOptUseCounter is to be incremented whenever EXPLAIN (OPT) is run.
 var ExplainOptUseCounter = telemetry.GetCounterOnce("sql.plan.explain-opt")
 


### PR DESCRIPTION
Add two telemetry counters for statement diagnostics - one when triggered via
the UI, one for EXPLAIN ANALYZE (DEBUG).

Release note: None