### PR TITLE
workload/schemachange: create new table 90% of the time

### DIFF
--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -458,7 +458,7 @@ func (w *schemaChangeWorker) createSequence(tx *pgx.Tx) (string, error) {
 }
 
 func (w *schemaChangeWorker) createTable(tx *pgx.Tx) (string, error) {
-	tableName, err := w.randTable(tx, 100)
+	tableName, err := w.randTable(tx, 10)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Release note (bug fix): we were using an existing table name 100% of
the time when creating a new table which resulted in no tables created.