### PR TITLE
Backport19.2 46285: opt: fix handling of write-only columns during update

### DIFF
--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -332,15 +332,9 @@ CREATE INDEX allidx ON t.test (k, v);
 						afterDefaultInsert = [][]string{{"a", "z", "q"}, {"default", "NULL", "i"}}
 						// The default value of "i" for column "i" is written.
 						afterInsert = [][]string{{"a", "z", "q"}, {"c", "x", "i"}}
-						if useUpsert {
-							// Update is not a noop for column "i".
-							afterUpdate = [][]string{{"a", "u", "q"}, {"c", "x", "i"}}
-							afterPKUpdate = [][]string{{"a", "u", "q"}, {"d", "x", "i"}}
-						} else {
-							// Update is a noop for column "i".
-							afterUpdate = [][]string{{"a", "u", "q"}, {"c", "x", "i"}}
-							afterPKUpdate = [][]string{{"a", "u", "q"}, {"d", "x", "i"}}
-						}
+						// Upsert/update sets column "i" to default value of "i".
+						afterUpdate = [][]string{{"a", "u", "i"}, {"c", "x", "i"}}
+						afterPKUpdate = [][]string{{"a", "u", "i"}, {"d", "x", "i"}}
 						// Delete also deletes column "i".
 						afterDelete = [][]string{{"d", "x", "i"}}
 						afterDeleteKeys = 4
@@ -761,14 +755,20 @@ CREATE INDEX allidx ON t.test (k, v);
 				// Make column "i" and index "foo" live.
 				mTest.makeMutationsActive()
 
-				// The update to column "v" is seen; there is no effect on column "i".
-				mTest.CheckQueryResults(t, starQuery, [][]string{{"a", "u", "q"}, {"b", "y", "r"}, {"c", "x", "NULL"}})
+				if state == sqlbase.DescriptorMutation_DELETE_ONLY {
+					// Mutation column "i" is not updated.
+					mTest.CheckQueryResults(t, starQuery, [][]string{{"a", "u", "q"}, {"b", "y", "r"}, {"c", "x", "NULL"}})
+				} else {
+					// Mutation column "i" is set to its default value (NULL).
+					mTest.CheckQueryResults(t, starQuery, [][]string{{"a", "u", "NULL"}, {"b", "y", "r"}, {"c", "x", "NULL"}})
+				}
+
 				if idxState == sqlbase.DescriptorMutation_DELETE_ONLY {
 					// Index entry for row "a" is deleted.
 					mTest.CheckQueryResults(t, indexQuery, [][]string{{"r"}})
 				} else {
-					// No change in index "foo"
-					mTest.CheckQueryResults(t, indexQuery, [][]string{{"NULL"}, {"q"}, {"r"}})
+					// Index "foo" has NULL "i" value for row "a".
+					mTest.CheckQueryResults(t, indexQuery, [][]string{{"NULL"}, {"NULL"}, {"r"}})
 				}
 
 				// Add index "foo" as a mutation.
@@ -781,19 +781,34 @@ CREATE INDEX allidx ON t.test (k, v);
 				// Make column "i" and index "foo" live.
 				mTest.makeMutationsActive()
 				// Row "b" is deleted.
-				mTest.CheckQueryResults(t, starQuery, [][]string{{"a", "u", "q"}, {"c", "x", "NULL"}})
+				if state == sqlbase.DescriptorMutation_DELETE_ONLY {
+					mTest.CheckQueryResults(t, starQuery, [][]string{{"a", "u", "q"}, {"c", "x", "NULL"}})
+				} else {
+					mTest.CheckQueryResults(t, starQuery, [][]string{{"a", "u", "NULL"}, {"c", "x", "NULL"}})
+				}
+
 				// numKVs is the number of expected key-values. We start with the number
 				// of non-NULL values above.
-				numKVs := 7
+				numKVs := 6
+				if state == sqlbase.DescriptorMutation_DELETE_ONLY {
+					// In DELETE_ONLY case, the "q" value is not set to NULL above.
+					numKVs++
+				}
+
 				if idxState == sqlbase.DescriptorMutation_DELETE_ONLY {
-					// Index entry for row "b" is deleted.
+					// Index entry for row "a" is deleted.
 					mTest.CheckQueryResults(t, indexQuery, [][]string{})
 				} else {
-					// Index entry for row "b" is deleted.
-					mTest.CheckQueryResults(t, indexQuery, [][]string{{"NULL"}, {"q"}})
+					// Index entry for row "a" is deleted.
+					if state == sqlbase.DescriptorMutation_DELETE_ONLY {
+						mTest.CheckQueryResults(t, indexQuery, [][]string{{"NULL"}, {"q"}})
+					} else {
+						mTest.CheckQueryResults(t, indexQuery, [][]string{{"NULL"}, {"NULL"}})
+					}
 					// We have two index values.
 					numKVs += 2
 				}
+
 				// Check that there are no hidden KV values for row "b", and column
 				// "i" for row "b" was deleted. Also check that the index values are
 				// all accounted for.

--- a/pkg/sql/opt/exec/execbuilder/testdata/schema_change_in_txn
+++ b/pkg/sql/opt/exec/execbuilder/testdata/schema_change_in_txn
@@ -1,0 +1,85 @@
+# LogicTest: local
+
+statement ok
+CREATE TABLE t (
+  a INT PRIMARY KEY,
+  b DECIMAL(10,1) NOT NULL DEFAULT(1000.15),
+  c TEXT COLLATE en_US DEFAULT('empty' COLLATE en_US),
+  d DECIMAL(10,2) NOT NULL,
+  e TIME,
+  f DECIMAL AS (a + b + d) STORED,
+  --UNIQUE INDEX t_secondary (c, d), -- Fails due to #46276
+  FAMILY (a, b, c),
+  FAMILY (d, e, f)
+)
+
+statement ok
+INSERT INTO t VALUES (100, 500.5, 'stuff' COLLATE en_US, 600.6, '12:12:12')
+
+# Drop all columns except "a" and perform interesting operations.
+statement ok
+BEGIN;
+--DROP INDEX t_secondary CASCADE;
+ALTER TABLE t DROP COLUMN b, DROP COLUMN c, DROP COLUMN d, DROP COLUMN e, DROP COLUMN f;
+ALTER TABLE t ADD COLUMN g INT NOT NULL DEFAULT(15)
+
+statement ok
+SET tracing = on,kv,results; INSERT INTO t SELECT a + 1 FROM t; SET tracing = off
+
+# Expect default values for b, c, zero value for d, and NULL value for e.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%Scan \/%' OR message LIKE '%Put \/%' OR message LIKE '%Del \/%'
+----
+Scan /Table/53/{1-2}
+CPut /Table/53/1/101/0 -> /TUPLE/2:2:Decimal/1000.2/1:3:Bytes/empty
+CPut /Table/53/1/101/1/1 -> /TUPLE/4:4:Decimal/0.00/2:6:Decimal/1101.2
+
+statement ok
+SET tracing = on,kv,results; UPSERT INTO t SELECT a + 1 FROM t; SET tracing = off
+
+# Expect default values for b, c, zero value for d, and NULL value for e.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%Scan \/%' OR message LIKE '%Put \/%' OR message LIKE '%Del \/%'
+----
+Scan /Table/53/{1-2}
+Scan /Table/53/{1-2}
+Put /Table/53/1/101/0 -> /TUPLE/2:2:Decimal/1000.2/1:3:Bytes/empty
+Put /Table/53/1/101/1/1 -> /TUPLE/4:4:Decimal/0.00/2:6:Decimal/1101.2
+CPut /Table/53/1/102/0 -> /TUPLE/2:2:Decimal/1000.2/1:3:Bytes/empty
+CPut /Table/53/1/102/1/1 -> /TUPLE/4:4:Decimal/0.00/2:6:Decimal/1102.2
+
+statement ok
+SET tracing = on,kv,results; UPDATE t SET a = a + 100; SET tracing = off
+
+# Expect default values for b, c, zero value for d, and NULL value for e.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%Scan \/%' OR message LIKE '%Put \/%' OR message LIKE '%Del \/%'
+----
+Scan /Table/53/{1-2}
+Del /Table/53/1/100/0
+Del /Table/53/1/100/1/1
+CPut /Table/53/1/200/0 -> /TUPLE/2:2:Decimal/1000.2/1:3:Bytes/empty
+CPut /Table/53/1/200/1/1 -> /TUPLE/4:4:Decimal/0.00/2:6:Decimal/1200.2
+Del /Table/53/1/101/0
+Del /Table/53/1/101/1/1
+CPut /Table/53/1/201/0 -> /TUPLE/2:2:Decimal/1000.2/1:3:Bytes/empty
+CPut /Table/53/1/201/1/1 -> /TUPLE/4:4:Decimal/0.00/2:6:Decimal/1201.2
+Del /Table/53/1/102/0
+Del /Table/53/1/102/1/1
+CPut /Table/53/1/202/0 -> /TUPLE/2:2:Decimal/1000.2/1:3:Bytes/empty
+CPut /Table/53/1/202/1/1 -> /TUPLE/4:4:Decimal/0.00/2:6:Decimal/1202.2
+
+statement ok
+DELETE FROM t WHERE a=201
+
+statement ok
+COMMIT
+
+query II
+SELECT * FROM t
+----
+200  15
+202  15

--- a/pkg/sql/opt/memo/testdata/logprops/update
+++ b/pkg/sql/opt/memo/testdata/logprops/update
@@ -25,39 +25,48 @@ update abcde
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) rowid:11(int) e:12(int)
  ├── update-mapping:
  │    ├──  column13:13 => b:2
- │    └──  column14:14 => d:4
+ │    ├──  column15:15 => d:4
+ │    └──  column14:14 => e:6
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: column14:14(int) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null)
+      ├── columns: column15:15(int) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null) column14:14(int!null)
       ├── key: (11)
-      ├── fd: ()-->(7,13), (11)-->(8-10,12), (9)-->(14)
-      ├── prune: (7-14)
+      ├── fd: ()-->(7,13,14), (11)-->(8-10,12), (9)-->(15)
+      ├── prune: (7-15)
       ├── interesting orderings: (+11)
       ├── project
-      │    ├── columns: column13:13(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+      │    ├── columns: column14:14(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null)
       │    ├── key: (11)
-      │    ├── fd: ()-->(7,13), (11)-->(8-10,12)
-      │    ├── prune: (7-13)
+      │    ├── fd: ()-->(7,13,14), (11)-->(8-10,12)
+      │    ├── prune: (7-14)
       │    ├── interesting orderings: (+11)
-      │    ├── select
-      │    │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+      │    ├── project
+      │    │    ├── columns: column13:13(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
       │    │    ├── key: (11)
-      │    │    ├── fd: ()-->(7), (11)-->(8-10,12)
-      │    │    ├── prune: (8-12)
+      │    │    ├── fd: ()-->(7,13), (11)-->(8-10,12)
+      │    │    ├── prune: (7-13)
       │    │    ├── interesting orderings: (+11)
-      │    │    ├── scan abcde
+      │    │    ├── select
       │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
       │    │    │    ├── key: (11)
-      │    │    │    ├── fd: (11)-->(7-10,12)
-      │    │    │    ├── prune: (7-12)
-      │    │    │    └── interesting orderings: (+11)
-      │    │    └── filters
-      │    │         └── eq [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
-      │    │              ├── variable: a [type=int]
-      │    │              └── const: 1 [type=int]
+      │    │    │    ├── fd: ()-->(7), (11)-->(8-10,12)
+      │    │    │    ├── prune: (8-12)
+      │    │    │    ├── interesting orderings: (+11)
+      │    │    │    ├── scan abcde
+      │    │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+      │    │    │    │    ├── key: (11)
+      │    │    │    │    ├── fd: (11)-->(7-10,12)
+      │    │    │    │    ├── prune: (7-12)
+      │    │    │    │    └── interesting orderings: (+11)
+      │    │    │    └── filters
+      │    │    │         └── eq [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+      │    │    │              ├── variable: a [type=int]
+      │    │    │              └── const: 1 [type=int]
+      │    │    └── projections
+      │    │         └── const: 10 [type=int]
       │    └── projections
-      │         └── const: 10 [type=int]
+      │         └── const: 0 [type=int]
       └── projections
            └── plus [type=int, outer=(9,13)]
                 ├── plus [type=int]
@@ -79,40 +88,49 @@ project
       ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) rowid:11(int) e:12(int)
       ├── update-mapping:
       │    ├──  column13:13 => b:2
-      │    └──  column14:14 => d:4
+      │    ├──  column15:15 => d:4
+      │    └──  column14:14 => e:6
       ├── side-effects, mutations
       ├── key: (5)
       ├── fd: ()-->(1,2), (5)-->(3,4), (3)-->(4)
       └── project
-           ├── columns: column14:14(int) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null)
+           ├── columns: column15:15(int) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null) column14:14(int!null)
            ├── key: (11)
-           ├── fd: ()-->(7,13), (11)-->(8-10,12), (9)-->(14)
-           ├── prune: (7-14)
+           ├── fd: ()-->(7,13,14), (11)-->(8-10,12), (9)-->(15)
+           ├── prune: (7-15)
            ├── interesting orderings: (+11)
            ├── project
-           │    ├── columns: column13:13(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+           │    ├── columns: column14:14(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null)
            │    ├── key: (11)
-           │    ├── fd: ()-->(7,13), (11)-->(8-10,12)
-           │    ├── prune: (7-13)
+           │    ├── fd: ()-->(7,13,14), (11)-->(8-10,12)
+           │    ├── prune: (7-14)
            │    ├── interesting orderings: (+11)
-           │    ├── select
-           │    │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+           │    ├── project
+           │    │    ├── columns: column13:13(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
            │    │    ├── key: (11)
-           │    │    ├── fd: ()-->(7), (11)-->(8-10,12)
-           │    │    ├── prune: (8-12)
+           │    │    ├── fd: ()-->(7,13), (11)-->(8-10,12)
+           │    │    ├── prune: (7-13)
            │    │    ├── interesting orderings: (+11)
-           │    │    ├── scan abcde
+           │    │    ├── select
            │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
            │    │    │    ├── key: (11)
-           │    │    │    ├── fd: (11)-->(7-10,12)
-           │    │    │    ├── prune: (7-12)
-           │    │    │    └── interesting orderings: (+11)
-           │    │    └── filters
-           │    │         └── eq [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
-           │    │              ├── variable: a [type=int]
-           │    │              └── const: 1 [type=int]
+           │    │    │    ├── fd: ()-->(7), (11)-->(8-10,12)
+           │    │    │    ├── prune: (8-12)
+           │    │    │    ├── interesting orderings: (+11)
+           │    │    │    ├── scan abcde
+           │    │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+           │    │    │    │    ├── key: (11)
+           │    │    │    │    ├── fd: (11)-->(7-10,12)
+           │    │    │    │    ├── prune: (7-12)
+           │    │    │    │    └── interesting orderings: (+11)
+           │    │    │    └── filters
+           │    │    │         └── eq [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+           │    │    │              ├── variable: a [type=int]
+           │    │    │              └── const: 1 [type=int]
+           │    │    └── projections
+           │    │         └── const: 10 [type=int]
            │    └── projections
-           │         └── const: 10 [type=int]
+           │         └── const: 0 [type=int]
            └── projections
                 └── plus [type=int, outer=(9,13)]
                      ├── plus [type=int]
@@ -136,44 +154,54 @@ project
       ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) rowid:11(int) e:12(int)
       ├── update-mapping:
       │    ├──  column13:13 => b:2
-      │    └──  column14:14 => d:4
+      │    ├──  column15:15 => d:4
+      │    └──  column14:14 => e:6
       ├── cardinality: [0 - 1]
       ├── side-effects, mutations
       ├── key: ()
       ├── fd: ()-->(1-5)
       └── project
-           ├── columns: column14:14(int) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null)
+           ├── columns: column15:15(int) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null) column14:14(int!null)
            ├── cardinality: [0 - 1]
            ├── key: ()
-           ├── fd: ()-->(7-14)
-           ├── prune: (7-14)
+           ├── fd: ()-->(7-15)
+           ├── prune: (7-15)
            ├── interesting orderings: (+11)
            ├── project
-           │    ├── columns: column13:13(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+           │    ├── columns: column14:14(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null)
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
-           │    ├── fd: ()-->(7-13)
-           │    ├── prune: (7-13)
+           │    ├── fd: ()-->(7-14)
+           │    ├── prune: (7-14)
            │    ├── interesting orderings: (+11)
-           │    ├── select
-           │    │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+           │    ├── project
+           │    │    ├── columns: column13:13(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
            │    │    ├── cardinality: [0 - 1]
            │    │    ├── key: ()
-           │    │    ├── fd: ()-->(7-12)
-           │    │    ├── prune: (7-10,12)
+           │    │    ├── fd: ()-->(7-13)
+           │    │    ├── prune: (7-13)
            │    │    ├── interesting orderings: (+11)
-           │    │    ├── scan abcde
+           │    │    ├── select
            │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
-           │    │    │    ├── key: (11)
-           │    │    │    ├── fd: (11)-->(7-10,12)
-           │    │    │    ├── prune: (7-12)
-           │    │    │    └── interesting orderings: (+11)
-           │    │    └── filters
-           │    │         └── eq [type=bool, outer=(11), constraints=(/11: [/1 - /1]; tight), fd=()-->(11)]
-           │    │              ├── variable: rowid [type=int]
-           │    │              └── const: 1 [type=int]
+           │    │    │    ├── cardinality: [0 - 1]
+           │    │    │    ├── key: ()
+           │    │    │    ├── fd: ()-->(7-12)
+           │    │    │    ├── prune: (7-10,12)
+           │    │    │    ├── interesting orderings: (+11)
+           │    │    │    ├── scan abcde
+           │    │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+           │    │    │    │    ├── key: (11)
+           │    │    │    │    ├── fd: (11)-->(7-10,12)
+           │    │    │    │    ├── prune: (7-12)
+           │    │    │    │    └── interesting orderings: (+11)
+           │    │    │    └── filters
+           │    │    │         └── eq [type=bool, outer=(11), constraints=(/11: [/1 - /1]; tight), fd=()-->(11)]
+           │    │    │              ├── variable: rowid [type=int]
+           │    │    │              └── const: 1 [type=int]
+           │    │    └── projections
+           │    │         └── const: 10 [type=int]
            │    └── projections
-           │         └── const: 10 [type=int]
+           │         └── const: 0 [type=int]
            └── projections
                 └── plus [type=int, outer=(9,13)]
                      ├── plus [type=int]
@@ -195,40 +223,49 @@ project
       ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) rowid:11(int) e:12(int)
       ├── update-mapping:
       │    ├──  column13:13 => a:1
-      │    └──  column14:14 => d:4
+      │    ├──  column15:15 => d:4
+      │    └──  column14:14 => e:6
       ├── side-effects, mutations
       ├── key: (5)
       ├── fd: ()-->(1), (2)==(3), (3)==(2), (5)-->(2-4), (2)-->(4)
       └── project
-           ├── columns: column14:14(int) a:7(int!null) b:8(int!null) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null)
+           ├── columns: column15:15(int) a:7(int!null) b:8(int!null) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null) column14:14(int!null)
            ├── key: (11)
-           ├── fd: ()-->(13), (11)-->(7-10,12), (8)==(9), (9)==(8), (8,9)-->(14)
-           ├── prune: (7-14)
+           ├── fd: ()-->(13,14), (11)-->(7-10,12), (8)==(9), (9)==(8), (8,9)-->(15)
+           ├── prune: (7-15)
            ├── interesting orderings: (+11)
            ├── project
-           │    ├── columns: column13:13(int!null) a:7(int!null) b:8(int!null) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+           │    ├── columns: column14:14(int!null) a:7(int!null) b:8(int!null) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null)
            │    ├── key: (11)
-           │    ├── fd: ()-->(13), (11)-->(7-10,12), (8)==(9), (9)==(8)
-           │    ├── prune: (7-13)
+           │    ├── fd: ()-->(13,14), (11)-->(7-10,12), (8)==(9), (9)==(8)
+           │    ├── prune: (7-14)
            │    ├── interesting orderings: (+11)
-           │    ├── select
-           │    │    ├── columns: a:7(int!null) b:8(int!null) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+           │    ├── project
+           │    │    ├── columns: column13:13(int!null) a:7(int!null) b:8(int!null) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
            │    │    ├── key: (11)
-           │    │    ├── fd: (11)-->(7-10,12), (8)==(9), (9)==(8)
-           │    │    ├── prune: (7,10-12)
+           │    │    ├── fd: ()-->(13), (11)-->(7-10,12), (8)==(9), (9)==(8)
+           │    │    ├── prune: (7-13)
            │    │    ├── interesting orderings: (+11)
-           │    │    ├── scan abcde
-           │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+           │    │    ├── select
+           │    │    │    ├── columns: a:7(int!null) b:8(int!null) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
            │    │    │    ├── key: (11)
-           │    │    │    ├── fd: (11)-->(7-10,12)
-           │    │    │    ├── prune: (7-12)
-           │    │    │    └── interesting orderings: (+11)
-           │    │    └── filters
-           │    │         └── eq [type=bool, outer=(8,9), constraints=(/8: (/NULL - ]; /9: (/NULL - ]), fd=(8)==(9), (9)==(8)]
-           │    │              ├── variable: b [type=int]
-           │    │              └── variable: c [type=int]
+           │    │    │    ├── fd: (11)-->(7-10,12), (8)==(9), (9)==(8)
+           │    │    │    ├── prune: (7,10-12)
+           │    │    │    ├── interesting orderings: (+11)
+           │    │    │    ├── scan abcde
+           │    │    │    │    ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+           │    │    │    │    ├── key: (11)
+           │    │    │    │    ├── fd: (11)-->(7-10,12)
+           │    │    │    │    ├── prune: (7-12)
+           │    │    │    │    └── interesting orderings: (+11)
+           │    │    │    └── filters
+           │    │    │         └── eq [type=bool, outer=(8,9), constraints=(/8: (/NULL - ]; /9: (/NULL - ]), fd=(8)==(9), (9)==(8)]
+           │    │    │              ├── variable: b [type=int]
+           │    │    │              └── variable: c [type=int]
+           │    │    └── projections
+           │    │         └── const: 1 [type=int]
            │    └── projections
-           │         └── const: 1 [type=int]
+           │         └── const: 0 [type=int]
            └── projections
                 └── plus [type=int, outer=(8,9)]
                      ├── plus [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -2188,7 +2188,8 @@ upsert mutation
  │    ├──  column3:8 => c:3
  │    └──  column9:9 => d:4
  ├── update-mapping:
- │    └──  upsert_b:17 => b:2
+ │    ├──  upsert_b:17 => b:2
+ │    └──  column9:9 => d:4
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -239,18 +239,9 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 	}
 
 	// Add default columns that were not explicitly specified by name or
-	// implicitly targeted by input columns. This includes columns undergoing
-	// write mutations, if they have a default value.
-	mb.addDefaultColsForInsert()
-
-	// Possibly round DECIMAL-related columns containing insertion values. Do
-	// this before evaluating computed expressions, since those may depend on
-	// the inserted columns.
-	mb.roundDecimalValues(mb.insertOrds, false /* roundComputedCols */)
-
-	// Add any computed columns. This includes columns undergoing write mutations,
-	// if they have a computed value.
-	mb.addComputedColsForInsert()
+	// implicitly targeted by input columns. Also add any computed columns. In
+	// both cases, include columns undergoing mutations in the write-only state.
+	mb.addSynthesizedColsForInsert()
 
 	var returning tree.ReturningExprs
 	if resultsNeeded(ins.Returning) {
@@ -288,8 +279,8 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 			mb.buildInputForUpsert(inScope, mb.getPrimaryKeyColumnNames(), nil /* whereClause */)
 
 			// Add additional columns for computed expressions that may depend on any
-			// updated columns.
-			mb.addComputedColsForUpdate()
+			// updated columns, as well as mutation columns with default values.
+			mb.addSynthesizedColsForUpdate()
 		}
 
 		// Build the final upsert statement, including any returned expressions.
@@ -582,27 +573,28 @@ func (mb *mutationBuilder) buildInputForInsert(inScope *scope, inputRows *tree.S
 	}
 }
 
-// addDefaultColsForInsert wraps an Insert input expression with a Project
-// operator containing any default (or nullable) columns that are not yet part
-// of the target column list. This includes mutation columns, since they must
-// always have default or computed values.
-func (mb *mutationBuilder) addDefaultColsForInsert() {
+// addSynthesizedColsForInsert wraps an Insert input expression with a Project
+// operator containing any default (or nullable) columns and any computed
+// columns that are not yet part of the target column list. This includes all
+// write-only mutation columns, since they must always have default or computed
+// values.
+func (mb *mutationBuilder) addSynthesizedColsForInsert() {
+	// Start by adding non-computed columns that have not already been explicitly
+	// specified in the query. Do this before adding computed columns, since those
+	// may depend on non-computed columns.
 	mb.addSynthesizedCols(
 		mb.insertOrds,
-		func(tabCol cat.Column) bool { return !tabCol.IsComputed() },
+		func(colOrd int) bool { return !mb.tab.Column(colOrd).IsComputed() },
 	)
-}
 
-// addComputedColsForInsert wraps an Insert input expression with a Project
-// operator containing computed columns that are not yet part of the target
-// column list. This includes mutation columns, since they must always have
-// default or computed values. This must be done after calling
-// addDefaultColsForInsert, because computed columns can depend on default
-// columns.
-func (mb *mutationBuilder) addComputedColsForInsert() {
+	// Possibly round DECIMAL-related columns containing insertion values (whether
+	// synthesized or not).
+	mb.roundDecimalValues(mb.insertOrds, false /* roundComputedCols */)
+
+	// Now add all computed columns.
 	mb.addSynthesizedCols(
 		mb.insertOrds,
-		func(tabCol cat.Column) bool { return tabCol.IsComputed() },
+		func(colOrd int) bool { return mb.tab.Column(colOrd).IsComputed() },
 	)
 
 	// Possibly round DECIMAL-related computed columns.
@@ -737,9 +729,12 @@ func (mb *mutationBuilder) buildInputForUpsert(
 		mb.outScope.cols[i].table = excludedTableName
 	}
 
-	// Build the right side of the left outer join. Include mutation columns
-	// because they can be used by computed update expressions. Use a different
-	// instance of table metadata so that col IDs do not overlap.
+	// Build the right side of the left outer join. Use a different instance of
+	// table metadata so that col IDs do not overlap.
+	//
+	// NOTE: Include mutation columns, but be careful to never use them for any
+	//       reason other than as "fetch columns". See buildScan comment.
+	// TODO(andyk): Why does execution engine need mutation columns for Insert?
 	fetchScope := mb.b.buildScan(
 		mb.b.addTable(mb.tab, &mb.alias),
 		nil, /* ordinals */

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -225,8 +225,8 @@ func (mb *mutationBuilder) buildInputForUpdate(
 	//
 	//   UPDATE abc SET a=b
 	//
-
-	// FROM
+	// NOTE: Include mutation columns, but be careful to never use them for any
+	//       reason other than as "fetch columns". See buildScan comment.
 	mb.outScope = mb.b.buildScan(
 		mb.b.addTable(mb.tab, &mb.alias),
 		nil, /* ordinals */
@@ -328,6 +328,9 @@ func (mb *mutationBuilder) buildInputForDelete(
 	//
 	//   DELETE FROM abc WHERE a=b
 	//
+	// NOTE: Include mutation columns, but be careful to never use them for any
+	//       reason other than as "fetch columns". See buildScan comment.
+	// TODO(andyk): Why does execution engine need mutation columns for Delete?
 	mb.outScope = mb.b.buildScan(
 		mb.b.addTable(mb.tab, &mb.alias),
 		nil, /* ordinals */
@@ -491,13 +494,23 @@ func (mb *mutationBuilder) replaceDefaultExprs(inRows *tree.Select) (outRows *tr
 	return inRows
 }
 
-// addSynthesizedCols is a helper method for addDefaultAndComputedColsForInsert
-// and addComputedColsForUpdate that scans the list of table columns, looking
+// addSynthesizedCols is a helper method for addSynthesizedColsForInsert
+// and addSynthesizedColsForUpdate that scans the list of table columns, looking
 // for any that do not yet have values provided by the input expression. New
 // columns are synthesized for any missing columns, as long as the addCol
 // callback function returns true for that column.
+//
+// Values are synthesized for columns based on checking these rules, in order:
+//   1. If column is computed, evaluate that expression as its value.
+//   2. If column has a default value specified for it, use that as its value.
+//   3. If column is nullable, use NULL as its value.
+//   4. If column is currently being added or dropped (i.e. a mutation column),
+//      use a default value (0 for INT column, "" for STRING column, etc). Note
+//      that the existing "fetched" value returned by the scan cannot be used,
+//      since it may not have been initialized yet by the backfiller.
+//
 func (mb *mutationBuilder) addSynthesizedCols(
-	scopeOrds []scopeOrdinal, addCol func(tabCol cat.Column) bool,
+	scopeOrds []scopeOrdinal, addCol func(colOrd int) bool,
 ) {
 	var projectionsScope *scope
 
@@ -510,8 +523,7 @@ func (mb *mutationBuilder) addSynthesizedCols(
 		}
 
 		// Invoke addCol to determine whether column should be added.
-		tabCol := mb.tab.Column(i)
-		if !addCol(tabCol) {
+		if !addCol(i) {
 			continue
 		}
 
@@ -522,6 +534,7 @@ func (mb *mutationBuilder) addSynthesizedCols(
 			projectionsScope.appendColumnsFromScope(mb.outScope)
 		}
 		tabColID := mb.tabID.ColumnID(i)
+		tabCol := mb.tab.Column(i)
 		expr := mb.parseDefaultOrComputedExpr(tabColID)
 		texpr := mb.outScope.resolveAndRequireType(expr, tabCol.DatumType())
 		scopeCol := mb.b.addColumn(projectionsScope, "" /* alias */, texpr)
@@ -868,7 +881,19 @@ func (mb *mutationBuilder) parseDefaultOrComputedExpr(colID opt.ColumnID) tree.E
 		exprStr = tabCol.ComputedExprStr()
 	case tabCol.HasDefault():
 		exprStr = tabCol.DefaultExprStr()
+	case tabCol.IsNullable():
+		return tree.DNull
 	default:
+		// Synthesize default value for NOT NULL mutation column so that it can be
+		// set when in the write-only state. This is only used when no other value
+		// is possible (no default value available, NULL not allowed).
+		if cat.IsMutationColumn(mb.tab, ord) {
+			datum, err := tree.NewDefaultDatum(mb.b.evalCtx, tabCol.DatumType())
+			if err != nil {
+				panic(err)
+			}
+			return datum
+		}
 		return tree.DNull
 	}
 

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -365,6 +365,15 @@ func (b *Builder) addTable(tab cat.Table, alias *tree.TableName) *opt.TableMeta 
 // list are projected by the scan. Otherwise, all columns from the table are
 // projected.
 //
+// If scanMutationCols is true, then include columns being added or dropped from
+// the table. These are currently required by the execution engine as "fetch
+// columns", when performing mutation DML statements (INSERT, UPDATE, UPSERT,
+// DELETE).
+//
+// NOTE: Callers must take care that these mutation columns are never used in
+//       any other way, since they may not have been initialized yet by the
+//       backfiller!
+//
 // See Builder.buildStmt for a description of the remaining input and return
 // values.
 func (b *Builder) buildScan(

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1328,7 +1328,7 @@ with &1 (a)
 # Tests with mutations.
 # ------------------------------------------------------------------------------
 
-# Test update that doesn't require mutation column to be recalculated.
+# Mutation columns should be updated.
 build
 UPDATE mutation SET m=1
 ----
@@ -1337,28 +1337,33 @@ update mutation
  ├── fetch columns: m:6(int) n:7(int) o:8(int) p:9(int) q:10(int)
  ├── update-mapping:
  │    ├──  column11:11 => m:1
- │    └──  column12:12 => p:4
- ├── check columns: check1:13(bool)
+ │    ├──  column12:12 => o:3
+ │    └──  column13:13 => p:4
+ ├── check columns: check1:14(bool)
  └── project
-      ├── columns: check1:13(bool) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int) column11:11(int!null) column12:12(int)
+      ├── columns: check1:14(bool) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int) column11:11(int!null) column12:12(int!null) column13:13(int)
       ├── project
-      │    ├── columns: column12:12(int) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int) column11:11(int!null)
+      │    ├── columns: column13:13(int) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int) column11:11(int!null) column12:12(int!null)
       │    ├── project
-      │    │    ├── columns: column11:11(int!null) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
-      │    │    ├── scan mutation
-      │    │    │    └── columns: m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
+      │    │    ├── columns: column12:12(int!null) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int) column11:11(int!null)
+      │    │    ├── project
+      │    │    │    ├── columns: column11:11(int!null) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
+      │    │    │    ├── scan mutation
+      │    │    │    │    └── columns: m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
+      │    │    │    └── projections
+      │    │    │         └── const: 1 [type=int]
       │    │    └── projections
-      │    │         └── const: 1 [type=int]
+      │    │         └── const: 10 [type=int]
       │    └── projections
       │         └── plus [type=int]
-      │              ├── variable: o [type=int]
+      │              ├── variable: column12 [type=int]
       │              └── variable: n [type=int]
       └── projections
            └── gt [type=bool]
                 ├── variable: column11 [type=int]
                 └── const: 0 [type=int]
 
-# Test update that requires computed mutation column to be recalculated.
+# Update column that mutation column depends upon.
 build
 UPDATE mutation SET m=1, n=2
 ----
@@ -1368,22 +1373,27 @@ update mutation
  ├── update-mapping:
  │    ├──  column11:11 => m:1
  │    ├──  column12:12 => n:2
- │    └──  column13:13 => p:4
- ├── check columns: check1:14(bool)
+ │    ├──  column13:13 => o:3
+ │    └──  column14:14 => p:4
+ ├── check columns: check1:15(bool)
  └── project
-      ├── columns: check1:14(bool) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int) column11:11(int!null) column12:12(int!null) column13:13(int)
+      ├── columns: check1:15(bool) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int) column11:11(int!null) column12:12(int!null) column13:13(int!null) column14:14(int)
       ├── project
-      │    ├── columns: column13:13(int) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int) column11:11(int!null) column12:12(int!null)
+      │    ├── columns: column14:14(int) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int) column11:11(int!null) column12:12(int!null) column13:13(int!null)
       │    ├── project
-      │    │    ├── columns: column11:11(int!null) column12:12(int!null) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
-      │    │    ├── scan mutation
-      │    │    │    └── columns: m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
+      │    │    ├── columns: column13:13(int!null) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int) column11:11(int!null) column12:12(int!null)
+      │    │    ├── project
+      │    │    │    ├── columns: column11:11(int!null) column12:12(int!null) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
+      │    │    │    ├── scan mutation
+      │    │    │    │    └── columns: m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
+      │    │    │    └── projections
+      │    │    │         ├── const: 1 [type=int]
+      │    │    │         └── const: 2 [type=int]
       │    │    └── projections
-      │    │         ├── const: 1 [type=int]
-      │    │         └── const: 2 [type=int]
+      │    │         └── const: 10 [type=int]
       │    └── projections
       │         └── plus [type=int]
-      │              ├── variable: o [type=int]
+      │              ├── variable: column13 [type=int]
       │              └── variable: column12 [type=int]
       └── projections
            └── gt [type=bool]
@@ -1399,29 +1409,34 @@ update mutation
  ├── fetch columns: m:6(int) n:7(int) o:8(int) p:9(int) q:10(int)
  ├── update-mapping:
  │    ├──  column11:11 => m:1
- │    └──  column12:12 => p:4
- ├── check columns: check1:13(bool)
+ │    ├──  column12:12 => o:3
+ │    └──  column13:13 => p:4
+ ├── check columns: check1:14(bool)
  └── project
-      ├── columns: check1:13(bool) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int) column11:11(int!null) column12:12(int)
+      ├── columns: check1:14(bool) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int) column11:11(int!null) column12:12(int!null) column13:13(int)
       ├── project
-      │    ├── columns: column12:12(int) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int) column11:11(int!null)
+      │    ├── columns: column13:13(int) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int) column11:11(int!null) column12:12(int!null)
       │    ├── project
-      │    │    ├── columns: column11:11(int!null) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
-      │    │    ├── limit
-      │    │    │    ├── columns: m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
-      │    │    │    ├── internal-ordering: +6,+7
-      │    │    │    ├── sort (segmented)
+      │    │    ├── columns: column12:12(int!null) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int) column11:11(int!null)
+      │    │    ├── project
+      │    │    │    ├── columns: column11:11(int!null) m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
+      │    │    │    ├── limit
       │    │    │    │    ├── columns: m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
-      │    │    │    │    ├── ordering: +6,+7
-      │    │    │    │    └── scan mutation
-      │    │    │    │         ├── columns: m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
-      │    │    │    │         └── ordering: +6
-      │    │    │    └── const: 10 [type=int]
+      │    │    │    │    ├── internal-ordering: +6,+7
+      │    │    │    │    ├── sort (segmented)
+      │    │    │    │    │    ├── columns: m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
+      │    │    │    │    │    ├── ordering: +6,+7
+      │    │    │    │    │    └── scan mutation
+      │    │    │    │    │         ├── columns: m:6(int!null) n:7(int) o:8(int) p:9(int) q:10(int)
+      │    │    │    │    │         └── ordering: +6
+      │    │    │    │    └── const: 10 [type=int]
+      │    │    │    └── projections
+      │    │    │         └── const: 1 [type=int]
       │    │    └── projections
-      │    │         └── const: 1 [type=int]
+      │    │         └── const: 10 [type=int]
       │    └── projections
       │         └── plus [type=int]
-      │              ├── variable: o [type=int]
+      │              ├── variable: column12 [type=int]
       │              └── variable: n [type=int]
       └── projections
            └── gt [type=bool]
@@ -1623,10 +1638,10 @@ update decimals
  ├── update-mapping:
  │    ├──  a:11 => decimals.a:1
  │    ├──  b:12 => decimals.b:2
- │    └──  d:15 => decimals.d:4
- ├── check columns: check1:16(bool) check2:17(bool)
+ │    └──  d:14 => decimals.d:4
+ ├── check columns: check1:15(bool) check2:16(bool)
  └── project
-      ├── columns: check1:16(bool) check2:17(bool) d:15(decimal) decimals.a:5(decimal!null) decimals.b:6(decimal[]) c:7(decimal) decimals.d:8(decimal) a:11(decimal) b:12(decimal[])
+      ├── columns: check1:15(bool) check2:16(bool) d:14(decimal) decimals.a:5(decimal!null) decimals.b:6(decimal[]) c:7(decimal) decimals.d:8(decimal) a:11(decimal) b:12(decimal[])
       ├── project
       │    ├── columns: a:11(decimal) b:12(decimal[]) decimals.a:5(decimal!null) decimals.b:6(decimal[]) c:7(decimal) decimals.d:8(decimal)
       │    ├── scan decimals
@@ -1649,9 +1664,7 @@ update decimals
            │    │    └── const: 0 [type=int]
            │    └── const: 1 [type=decimal]
            └── function: crdb_internal.round_decimal_values [type=decimal]
-                ├── function: crdb_internal.round_decimal_values [type=decimal]
-                │    ├── plus [type=decimal]
-                │    │    ├── variable: a [type=decimal]
-                │    │    └── variable: c [type=decimal]
-                │    └── const: 1 [type=int]
+                ├── plus [type=decimal]
+                │    ├── variable: a [type=decimal]
+                │    └── variable: c [type=decimal]
                 └── const: 1 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -1037,12 +1037,13 @@ upsert mutation
  │    └──  column9:9 => p:4
  ├── update-mapping:
  │    ├──  upsert_m:17 => m:1
- │    └──  upsert_p:20 => p:4
- ├── check columns: check1:21(bool)
+ │    ├──  column8:8 => o:3
+ │    └──  upsert_p:19 => p:4
+ ├── check columns: check1:20(bool)
  └── project
-      ├── columns: check1:21(bool) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int) column16:16(int) upsert_m:17(int) upsert_n:18(int) upsert_o:19(int) upsert_p:20(int)
+      ├── columns: check1:20(bool) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int) column16:16(int) upsert_m:17(int) upsert_n:18(int) upsert_p:19(int)
       ├── project
-      │    ├── columns: upsert_m:17(int) upsert_n:18(int) upsert_o:19(int) upsert_p:20(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int) column16:16(int)
+      │    ├── columns: upsert_m:17(int) upsert_n:18(int) upsert_p:19(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int) column16:16(int)
       │    ├── project
       │    │    ├── columns: column16:16(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int)
       │    │    ├── project
@@ -1076,7 +1077,7 @@ upsert mutation
       │    │    │              └── const: 1 [type=int]
       │    │    └── projections
       │    │         └── plus [type=int]
-      │    │              ├── variable: o [type=int]
+      │    │              ├── variable: column8 [type=int]
       │    │              └── variable: n [type=int]
       │    └── projections
       │         ├── case [type=int]
@@ -1095,14 +1096,6 @@ upsert mutation
       │         │    │    │    └── null [type=unknown]
       │         │    │    └── variable: column2 [type=int]
       │         │    └── variable: n [type=int]
-      │         ├── case [type=int]
-      │         │    ├── true [type=bool]
-      │         │    ├── when [type=int]
-      │         │    │    ├── is [type=bool]
-      │         │    │    │    ├── variable: m [type=int]
-      │         │    │    │    └── null [type=unknown]
-      │         │    │    └── variable: column8 [type=int]
-      │         │    └── variable: o [type=int]
       │         └── case [type=int]
       │              ├── true [type=bool]
       │              ├── when [type=int]
@@ -1359,8 +1352,8 @@ upsert checks
                 ├── variable: upsert_a [type=int]
                 └── const: 0 [type=int]
 
-# Don't directly update mutation columns. However, computed columns do need to
-# be updated. Use explicit target columns.
+# Ensure that mutation columns are set by the insert and update. Use explicit
+# target columns.
 build
 UPSERT INTO mutation (m, n) VALUES (1, 2)
 ----
@@ -1375,66 +1368,45 @@ upsert mutation
  │    └──  column9:9 => p:4
  ├── update-mapping:
  │    ├──  column2:7 => n:2
- │    └──  upsert_p:18 => p:4
- ├── check columns: check1:19(bool)
+ │    ├──  column8:8 => o:3
+ │    └──  column9:9 => p:4
+ ├── check columns: check1:16(bool)
  └── project
-      ├── columns: check1:19(bool) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int) upsert_m:16(int) upsert_o:17(int) upsert_p:18(int)
+      ├── columns: check1:16(bool) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) upsert_m:15(int)
       ├── project
-      │    ├── columns: upsert_m:16(int) upsert_o:17(int) upsert_p:18(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int)
-      │    ├── project
-      │    │    ├── columns: column15:15(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
-      │    │    ├── left-join (hash)
-      │    │    │    ├── columns: column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    ├── columns: upsert_m:15(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    ├── left-join (hash)
+      │    │    ├── columns: column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    ├── project
+      │    │    │    ├── columns: column9:9(int) column1:6(int!null) column2:7(int!null) column8:8(int!null)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column9:9(int) column1:6(int!null) column2:7(int!null) column8:8(int!null)
-      │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column8:8(int!null) column1:6(int!null) column2:7(int!null)
-      │    │    │    │    │    ├── values
-      │    │    │    │    │    │    ├── columns: column1:6(int!null) column2:7(int!null)
-      │    │    │    │    │    │    └── tuple [type=tuple{int, int}]
-      │    │    │    │    │    │         ├── const: 1 [type=int]
-      │    │    │    │    │    │         └── const: 2 [type=int]
-      │    │    │    │    │    └── projections
-      │    │    │    │    │         └── const: 10 [type=int]
+      │    │    │    │    ├── columns: column8:8(int!null) column1:6(int!null) column2:7(int!null)
+      │    │    │    │    ├── values
+      │    │    │    │    │    ├── columns: column1:6(int!null) column2:7(int!null)
+      │    │    │    │    │    └── tuple [type=tuple{int, int}]
+      │    │    │    │    │         ├── const: 1 [type=int]
+      │    │    │    │    │         └── const: 2 [type=int]
       │    │    │    │    └── projections
-      │    │    │    │         └── plus [type=int]
-      │    │    │    │              ├── variable: column8 [type=int]
-      │    │    │    │              └── variable: column2 [type=int]
-      │    │    │    ├── scan mutation
-      │    │    │    │    └── columns: m:10(int!null) n:11(int) o:12(int) p:13(int) q:14(int)
-      │    │    │    └── filters
-      │    │    │         └── eq [type=bool]
-      │    │    │              ├── variable: column1 [type=int]
-      │    │    │              └── variable: m [type=int]
-      │    │    └── projections
-      │    │         └── plus [type=int]
-      │    │              ├── variable: o [type=int]
-      │    │              └── variable: column2 [type=int]
+      │    │    │    │         └── const: 10 [type=int]
+      │    │    │    └── projections
+      │    │    │         └── plus [type=int]
+      │    │    │              ├── variable: column8 [type=int]
+      │    │    │              └── variable: column2 [type=int]
+      │    │    ├── scan mutation
+      │    │    │    └── columns: m:10(int!null) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    └── filters
+      │    │         └── eq [type=bool]
+      │    │              ├── variable: column1 [type=int]
+      │    │              └── variable: m [type=int]
       │    └── projections
-      │         ├── case [type=int]
-      │         │    ├── true [type=bool]
-      │         │    ├── when [type=int]
-      │         │    │    ├── is [type=bool]
-      │         │    │    │    ├── variable: m [type=int]
-      │         │    │    │    └── null [type=unknown]
-      │         │    │    └── variable: column1 [type=int]
-      │         │    └── variable: m [type=int]
-      │         ├── case [type=int]
-      │         │    ├── true [type=bool]
-      │         │    ├── when [type=int]
-      │         │    │    ├── is [type=bool]
-      │         │    │    │    ├── variable: m [type=int]
-      │         │    │    │    └── null [type=unknown]
-      │         │    │    └── variable: column8 [type=int]
-      │         │    └── variable: o [type=int]
       │         └── case [type=int]
       │              ├── true [type=bool]
       │              ├── when [type=int]
       │              │    ├── is [type=bool]
       │              │    │    ├── variable: m [type=int]
       │              │    │    └── null [type=unknown]
-      │              │    └── variable: column9 [type=int]
-      │              └── variable: column15 [type=int]
+      │              │    └── variable: column1 [type=int]
+      │              └── variable: m [type=int]
       └── projections
            └── gt [type=bool]
                 ├── variable: upsert_m [type=int]
@@ -1456,66 +1428,45 @@ upsert mutation
  │    └──  column9:9 => p:4
  ├── update-mapping:
  │    ├──  column2:7 => n:2
- │    └──  upsert_p:18 => p:4
- ├── check columns: check1:19(bool)
+ │    ├──  column8:8 => o:3
+ │    └──  column9:9 => p:4
+ ├── check columns: check1:16(bool)
  └── project
-      ├── columns: check1:19(bool) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int) upsert_m:16(int) upsert_o:17(int) upsert_p:18(int)
+      ├── columns: check1:16(bool) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) upsert_m:15(int)
       ├── project
-      │    ├── columns: upsert_m:16(int) upsert_o:17(int) upsert_p:18(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int)
-      │    ├── project
-      │    │    ├── columns: column15:15(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
-      │    │    ├── left-join (hash)
-      │    │    │    ├── columns: column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    ├── columns: upsert_m:15(int) column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    ├── left-join (hash)
+      │    │    ├── columns: column1:6(int!null) column2:7(int!null) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    ├── project
+      │    │    │    ├── columns: column9:9(int) column1:6(int!null) column2:7(int!null) column8:8(int!null)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column9:9(int) column1:6(int!null) column2:7(int!null) column8:8(int!null)
-      │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column8:8(int!null) column1:6(int!null) column2:7(int!null)
-      │    │    │    │    │    ├── values
-      │    │    │    │    │    │    ├── columns: column1:6(int!null) column2:7(int!null)
-      │    │    │    │    │    │    └── tuple [type=tuple{int, int}]
-      │    │    │    │    │    │         ├── const: 1 [type=int]
-      │    │    │    │    │    │         └── const: 2 [type=int]
-      │    │    │    │    │    └── projections
-      │    │    │    │    │         └── const: 10 [type=int]
+      │    │    │    │    ├── columns: column8:8(int!null) column1:6(int!null) column2:7(int!null)
+      │    │    │    │    ├── values
+      │    │    │    │    │    ├── columns: column1:6(int!null) column2:7(int!null)
+      │    │    │    │    │    └── tuple [type=tuple{int, int}]
+      │    │    │    │    │         ├── const: 1 [type=int]
+      │    │    │    │    │         └── const: 2 [type=int]
       │    │    │    │    └── projections
-      │    │    │    │         └── plus [type=int]
-      │    │    │    │              ├── variable: column8 [type=int]
-      │    │    │    │              └── variable: column2 [type=int]
-      │    │    │    ├── scan mutation
-      │    │    │    │    └── columns: m:10(int!null) n:11(int) o:12(int) p:13(int) q:14(int)
-      │    │    │    └── filters
-      │    │    │         └── eq [type=bool]
-      │    │    │              ├── variable: column1 [type=int]
-      │    │    │              └── variable: m [type=int]
-      │    │    └── projections
-      │    │         └── plus [type=int]
-      │    │              ├── variable: o [type=int]
-      │    │              └── variable: column2 [type=int]
+      │    │    │    │         └── const: 10 [type=int]
+      │    │    │    └── projections
+      │    │    │         └── plus [type=int]
+      │    │    │              ├── variable: column8 [type=int]
+      │    │    │              └── variable: column2 [type=int]
+      │    │    ├── scan mutation
+      │    │    │    └── columns: m:10(int!null) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    └── filters
+      │    │         └── eq [type=bool]
+      │    │              ├── variable: column1 [type=int]
+      │    │              └── variable: m [type=int]
       │    └── projections
-      │         ├── case [type=int]
-      │         │    ├── true [type=bool]
-      │         │    ├── when [type=int]
-      │         │    │    ├── is [type=bool]
-      │         │    │    │    ├── variable: m [type=int]
-      │         │    │    │    └── null [type=unknown]
-      │         │    │    └── variable: column1 [type=int]
-      │         │    └── variable: m [type=int]
-      │         ├── case [type=int]
-      │         │    ├── true [type=bool]
-      │         │    ├── when [type=int]
-      │         │    │    ├── is [type=bool]
-      │         │    │    │    ├── variable: m [type=int]
-      │         │    │    │    └── null [type=unknown]
-      │         │    │    └── variable: column8 [type=int]
-      │         │    └── variable: o [type=int]
       │         └── case [type=int]
       │              ├── true [type=bool]
       │              ├── when [type=int]
       │              │    ├── is [type=bool]
       │              │    │    ├── variable: m [type=int]
       │              │    │    └── null [type=unknown]
-      │              │    └── variable: column9 [type=int]
-      │              └── variable: column15 [type=int]
+      │              │    └── variable: column1 [type=int]
+      │              └── variable: m [type=int]
       └── projections
            └── gt [type=bool]
                 ├── variable: upsert_m [type=int]
@@ -1883,17 +1834,17 @@ upsert decimals
  ├── fetch columns: decimals.a:13(decimal) decimals.b:14(decimal[]) decimals.c:15(decimal) decimals.d:16(decimal)
  ├── insert-mapping:
  │    ├──  a:8 => decimals.a:1
- │    ├──  b:9 => decimals.b:2
+ │    ├──  b:17 => decimals.b:2
  │    ├──  c:10 => decimals.c:3
  │    └──  d:12 => decimals.d:4
  ├── update-mapping:
- │    ├──  b:9 => decimals.b:2
- │    └──  upsert_d:21 => decimals.d:4
- ├── check columns: check1:22(bool) check2:23(bool)
+ │    ├──  b:17 => decimals.b:2
+ │    └──  upsert_d:22 => decimals.d:4
+ ├── check columns: check1:23(bool) check2:24(bool)
  └── project
-      ├── columns: check1:22(bool) check2:23(bool) a:8(decimal) b:9(decimal[]) c:10(decimal) d:12(decimal) decimals.a:13(decimal) decimals.b:14(decimal[]) decimals.c:15(decimal) decimals.d:16(decimal) upsert_d:21(decimal)
+      ├── columns: check1:23(bool) check2:24(bool) a:8(decimal) c:10(decimal) d:12(decimal) decimals.a:13(decimal) decimals.b:14(decimal[]) decimals.c:15(decimal) decimals.d:16(decimal) b:17(decimal[]) upsert_d:22(decimal)
       ├── project
-      │    ├── columns: upsert_a:19(decimal) upsert_d:21(decimal) a:8(decimal) b:9(decimal[]) c:10(decimal) d:12(decimal) decimals.a:13(decimal) decimals.b:14(decimal[]) decimals.c:15(decimal) decimals.d:16(decimal)
+      │    ├── columns: upsert_a:20(decimal) upsert_d:22(decimal) b:17(decimal[]) a:8(decimal) c:10(decimal) d:12(decimal) decimals.a:13(decimal) decimals.b:14(decimal[]) decimals.c:15(decimal) decimals.d:16(decimal)
       │    ├── left-join (lookup decimals)
       │    │    ├── columns: a:8(decimal) b:9(decimal[]) c:10(decimal) d:12(decimal) decimals.a:13(decimal) decimals.b:14(decimal[]) decimals.c:15(decimal) decimals.d:16(decimal)
       │    │    ├── key columns: [8] = [13]
@@ -1928,18 +1879,21 @@ upsert decimals
       │         │    │    │    └── null [type=unknown]
       │         │    │    └── variable: a [type=decimal]
       │         │    └── variable: decimals.a [type=decimal]
-      │         └── case [type=decimal]
-      │              ├── true [type=bool]
-      │              ├── when [type=decimal]
-      │              │    ├── is [type=bool]
-      │              │    │    ├── variable: decimals.a [type=decimal]
-      │              │    │    └── null [type=unknown]
-      │              │    └── variable: d [type=decimal]
-      │              └── function: crdb_internal.round_decimal_values [type=decimal]
-      │                   ├── plus [type=decimal]
-      │                   │    ├── variable: decimals.a [type=decimal]
-      │                   │    └── variable: decimals.c [type=decimal]
-      │                   └── const: 1 [type=int]
+      │         ├── case [type=decimal]
+      │         │    ├── true [type=bool]
+      │         │    ├── when [type=decimal]
+      │         │    │    ├── is [type=bool]
+      │         │    │    │    ├── variable: decimals.a [type=decimal]
+      │         │    │    │    └── null [type=unknown]
+      │         │    │    └── variable: d [type=decimal]
+      │         │    └── function: crdb_internal.round_decimal_values [type=decimal]
+      │         │         ├── plus [type=decimal]
+      │         │         │    ├── variable: decimals.a [type=decimal]
+      │         │         │    └── variable: decimals.c [type=decimal]
+      │         │         └── const: 1 [type=int]
+      │         └── function: crdb_internal.round_decimal_values [type=decimal[]]
+      │              ├── variable: b [type=decimal[]]
+      │              └── const: 1 [type=int]
       └── projections
            ├── eq [type=bool]
            │    ├── variable: upsert_a [type=decimal]

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -111,10 +111,6 @@ func (b *Builder) buildUpdate(upd *tree.Update, inScope *scope) (outScope *scope
 	// Build each of the SET expressions.
 	mb.addUpdateCols(upd.Exprs)
 
-	// Add additional columns for computed expressions that may depend on the
-	// updated columns.
-	mb.addComputedColsForUpdate()
-
 	// Build the final update statement, including any returned expressions.
 	if resultsNeeded(upd.Returning) {
 		mb.buildUpdate(*upd.Returning.(*tree.ReturningExprs))
@@ -284,20 +280,15 @@ func (mb *mutationBuilder) addUpdateCols(exprs tree.UpdateExprs) {
 	mb.b.constructProjectForScope(mb.outScope, projectionsScope)
 	mb.outScope = projectionsScope
 
-	// Possibly round DECIMAL-related columns that were updated. Do this
-	// before evaluating computed expressions, since those may depend on the
-	// inserted columns.
-	mb.roundDecimalValues(mb.updateOrds, false /* roundComputedCols */)
-
-	// Add additional columns for computed expressions that may depend on any
+	// Add additional columns for computed expressions that may depend on the
 	// updated columns.
-	mb.addComputedColsForUpdate()
+	mb.addSynthesizedColsForUpdate()
 }
 
 // addComputedColsForUpdate wraps an Update input expression with a Project
 // operator containing any computed columns that need to be updated. This
 // includes write-only mutation columns that are computed.
-func (mb *mutationBuilder) addComputedColsForUpdate() {
+func (mb *mutationBuilder) addSynthesizedColsForUpdate() {
 	// Allow mutation columns to be referenced by other computed mutation
 	// columns (otherwise the scope will raise an error if a mutation column
 	// is referenced). These do not need to be set back to true again because
@@ -306,13 +297,30 @@ func (mb *mutationBuilder) addComputedColsForUpdate() {
 		mb.outScope.cols[i].mutation = false
 	}
 
+	// Add non-computed columns that are being dropped or added (mutated) to the
+	// table. These are not visible to queries, and will always be updated to
+	// their default values. This is necessary because they may not yet have been
+	// set by the backfiller.
+	mb.addSynthesizedCols(
+		mb.updateOrds,
+		func(colOrd int) bool {
+			return !mb.tab.Column(colOrd).IsComputed() && cat.IsMutationColumn(mb.tab, colOrd)
+		},
+	)
+
+	// Possibly round DECIMAL-related columns containing update values. Do
+	// this before evaluating computed expressions, since those may depend on
+	// the inserted columns.
+	mb.roundDecimalValues(mb.updateOrds, false /* roundComputedCols */)
+
 	// Disambiguate names so that references in the computed expression refer to
 	// the correct columns.
 	mb.disambiguateColumns()
 
+	// Add all computed columns in case their values have changed.
 	mb.addSynthesizedCols(
 		mb.updateOrds,
-		func(tabCol cat.Column) bool { return tabCol.IsComputed() },
+		func(colOrd int) bool { return mb.tab.Column(colOrd).IsComputed() },
 	)
 
 	// Possibly round DECIMAL-related computed columns.

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1,0 +1,1469 @@
+# =============================================================================
+# This schema is based on a business buying/selling online trading cards. This
+# file simulates queries taking place while schema changes are *not* taking
+# place. See the trading-mutation file for the same queries running against
+# tables with simulated schema changes in progress.
+# =============================================================================
+
+# --------------------------------------------------
+# Schema Definitions
+# --------------------------------------------------
+
+# Cards is the catalog of all cards that can be traded.
+exec-ddl
+CREATE TABLE Cards
+(
+  id INT NOT NULL,
+  name VARCHAR(128) NOT NULL,
+  rarity VARCHAR(1) NULL,
+  setname VARCHAR(5) NULL,
+  number INT NOT NULL,
+  isfoil BIT NOT NULL,
+  CONSTRAINT CardsPrimaryKey PRIMARY KEY
+  (
+    id ASC
+  ),
+  CONSTRAINT CardsNameSetNumber UNIQUE
+  (
+    name ASC,
+    setname ASC,
+    number ASC
+  )
+)
+----
+
+exec-ddl
+ALTER TABLE Cards INJECT STATISTICS '[
+  {
+    "columns": ["id"],
+    "distinct_count": 57000,
+    "null_count": 0,
+    "row_count": 57000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["name"],
+    "distinct_count": 39000,
+    "null_count": 0,
+    "row_count": 57000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["setname"],
+    "distinct_count": 162,
+    "null_count": 0,
+    "row_count": 57000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["number"],
+    "distinct_count": 829,
+    "null_count": 0,
+    "row_count": 57000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["name", "setname"],
+    "distinct_count": 56700,
+    "null_count": 0,
+    "row_count": 57000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["name", "setname", "number"],
+    "distinct_count": 57000,
+    "null_count": 0,
+    "row_count": 57000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  }
+]'
+----
+
+# CardsInfo tracks current inventory of each card, as well as current buy/sell
+# price. It is partitioned on dealerid, which represents multiple licensees
+# (dealers) using the trading software.
+exec-ddl
+CREATE TABLE CardsInfo
+(
+  dealerid OID NOT NULL,
+  cardid INT NOT NULL,
+  buyprice DECIMAL(10,4) NOT NULL,
+  sellprice DECIMAL(10,4) NOT NULL,
+  discount DECIMAL(10,4) NOT NULL,
+  desiredinventory INT NOT NULL,
+  actualinventory INT NOT NULL,
+  maxinventory INT NOT NULL,
+  version DECIMAL NOT NULL DEFAULT (cluster_logical_timestamp()),
+  CONSTRAINT CardsInfoPrimaryKey PRIMARY KEY
+  (
+    dealerid ASC,
+    cardid ASC
+  ),
+  CONSTRAINT CardsInfoCardIdKey FOREIGN KEY (cardid)
+  REFERENCES Cards (id),
+  UNIQUE INDEX CardsInfoVersionIndex (dealerid ASC, version ASC)
+)
+----
+
+exec-ddl
+ALTER TABLE CardsInfo INJECT STATISTICS '[
+  {
+    "columns": ["dealerid"],
+    "distinct_count": 12,
+    "null_count": 0,
+    "row_count": 700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["cardid"],
+    "distinct_count": 57000,
+    "null_count": 0,
+    "row_count": 700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["version"],
+    "distinct_count": 700000,
+    "null_count": 0,
+    "row_count": 700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00",
+    "histo_col_type": "decimal",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "1426741777604892000"},
+      {"num_eq": 0, "num_range": 350000, "distinct_range": 350000, "upper_bound": "1584421693935036000"}
+    ]
+  },
+  {
+    "columns": ["dealerid", "cardid"],
+    "distinct_count": 700000,
+    "null_count": 0,
+    "row_count": 700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "version"],
+    "distinct_count": 700000,
+    "null_count": 0,
+    "row_count": 700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  }
+]'
+----
+
+# InventoryDetails stores the quantity and location of all the cards.
+exec-ddl
+CREATE TABLE InventoryDetails
+(
+  dealerid OID NOT NULL,
+  cardid INT NOT NULL,
+  accountname VARCHAR(128) NOT NULL,
+  quantity INT NOT NULL,
+  version DECIMAL NOT NULL DEFAULT (cluster_logical_timestamp()),
+  CONSTRAINT InventoryDetailsPrimaryKey PRIMARY KEY
+  (
+    dealerid ASC,
+    cardid ASC,
+    accountname ASC
+  ),
+  CONSTRAINT InventoryDetailsCardIdKey FOREIGN KEY (cardid)
+  REFERENCES Cards (id)
+)
+----
+
+exec-ddl
+ALTER TABLE InventoryDetails INJECT STATISTICS '[
+  {
+    "columns": ["dealerid"],
+    "distinct_count": 12,
+    "null_count": 0,
+    "row_count": 1700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["cardid"],
+    "distinct_count": 50000,
+    "null_count": 0,
+    "row_count": 1700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["accountname"],
+    "distinct_count": 150,
+    "null_count": 0,
+    "row_count": 1700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "cardid"],
+    "distinct_count": 250000,
+    "null_count": 0,
+    "row_count": 1700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "cardid", "accountname"],
+    "distinct_count": 170000,
+    "null_count": 0,
+    "row_count": 1700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  }
+]'
+----
+
+# Transactions records all buy/sell trading activity.
+#
+# NOTE: The TransactionsOpIndex is meant to be a partial index, only containing
+#       non-NULL values. The operationid column is for idempotency, and
+#       older values get set to NULL after X hours to save space. 99%+ of values
+#       are NULL.
+exec-ddl
+CREATE TABLE Transactions
+(
+  dealerid OID NOT NULL,
+  isbuy BOOL NOT NULL,
+  date TIMESTAMPTZ NOT NULL,
+  accountname VARCHAR(128) NOT NULL,
+  customername VARCHAR(128) NOT NULL,
+  operationid UUID,
+  version DECIMAL NOT NULL DEFAULT (cluster_logical_timestamp()),
+  CONSTRAINT TransactionsPrimaryKey PRIMARY KEY
+  (
+    dealerid ASC,
+    isbuy ASC,
+    date ASC
+  ),
+  UNIQUE INDEX TransactionsOpIndex (dealerid ASC, operationid ASC)
+  --WHERE operationid IS NOT NULL
+)
+----
+
+exec-ddl
+ALTER TABLE Transactions INJECT STATISTICS '[
+  {
+    "columns": ["dealerid"],
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 20000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["isbuy"],
+    "distinct_count": 2,
+    "null_count": 0,
+    "row_count": 20000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["date"],
+    "distinct_count": 20000000,
+    "null_count": 0,
+    "row_count": 20000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["operationid"],
+    "distinct_count": 4000,
+    "null_count": 19996000,
+    "row_count": 20000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "isbuy"],
+    "distinct_count": 15,
+    "null_count": 0,
+    "row_count": 20000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "isbuy", "date"],
+    "distinct_count": 20000000,
+    "null_count": 0,
+    "row_count": 20000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  }
+]'
+----
+
+# TransactionDetails records line items of each Transaction.
+exec-ddl
+CREATE TABLE TransactionDetails
+(
+  dealerid OID NOT NULL,
+  isbuy BOOL NOT NULL,
+  transactiondate TIMESTAMPTZ NOT NULL,
+  cardid INT NOT NULL,
+  quantity INT NOT NULL,
+  sellprice DECIMAL(10,4) NOT NULL,
+  buyprice DECIMAL(10,4) NOT NULL,
+  version DECIMAL NOT NULL DEFAULT (cluster_logical_timestamp()),
+  CONSTRAINT DetailsPrimaryKey PRIMARY KEY
+  (
+    dealerid ASC,
+    isbuy ASC,
+    transactiondate ASC,
+    cardid ASC,
+    quantity ASC
+  ),
+  CONSTRAINT DetailsDealerDateKey FOREIGN KEY (dealerid, isbuy, transactiondate)
+  REFERENCES Transactions (dealerid, isbuy, date),
+  CONSTRAINT DetailsCardIdKey FOREIGN KEY (cardid)
+  REFERENCES Cards (id),
+  INDEX DetailsCardIdIndex (dealerid ASC, isbuy ASC, cardid ASC)
+)
+----
+
+exec-ddl
+ALTER TABLE TransactionDetails INJECT STATISTICS '[
+  {
+    "columns": ["dealerid"],
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 180000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["isbuy"],
+    "distinct_count": 2,
+    "null_count": 0,
+    "row_count": 180000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["transactiondate"],
+    "distinct_count": 180000000,
+    "null_count": 0,
+    "row_count": 180000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["cardid"],
+    "distinct_count": 57000,
+    "null_count": 0,
+    "row_count": 180000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "isbuy"],
+    "distinct_count": 15,
+    "null_count": 0,
+    "row_count": 180000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "isbuy", "transactiondate"],
+    "distinct_count": 20000000,
+    "null_count": 0,
+    "row_count": 180000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "isbuy", "transactiondate", "cardid"],
+    "distinct_count": 180000000,
+    "null_count": 0,
+    "row_count": 180000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "isbuy", "transactiondate", "cardid", "quantity"],
+    "distinct_count": 180000000,
+    "null_count": 0,
+    "row_count": 180000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "isbuy", "cardid"],
+    "distinct_count": 350000,
+    "null_count": 0,
+    "row_count": 180000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  }
+]'
+----
+
+# PriceDetails records price history for each card.
+exec-ddl
+CREATE TABLE PriceDetails
+(
+    dealerid OID NOT NULL,
+    cardid INT NOT NULL,
+    pricedate TIMESTAMPTZ NOT NULL,
+    pricedby VARCHAR(128) NOT NULL,
+    buyprice DECIMAL(10,4) NOT NULL,
+    sellprice DECIMAL(10,4) NOT NULL,
+    discount DECIMAL(10,4) NOT NULL,
+    version DECIMAL NOT NULL,
+    CONSTRAINT PriceDetailsPrimaryKey PRIMARY KEY
+    (
+        dealerid ASC,
+        cardid ASC,
+        pricedate ASC
+    ),
+    CONSTRAINT PriceDetailsCardIdKey FOREIGN KEY (cardid)
+    REFERENCES Cards (id)
+)
+----
+
+exec-ddl
+ALTER TABLE PriceDetails INJECT STATISTICS '[
+  {
+    "columns": ["dealerid"],
+    "distinct_count": 2,
+    "null_count": 0,
+    "row_count": 40000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["cardid"],
+    "distinct_count": 57000,
+    "null_count": 0,
+    "row_count": 40000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["pricedate"],
+    "distinct_count": 40000000,
+    "null_count": 0,
+    "row_count": 40000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "cardid"],
+    "distinct_count": 90000,
+    "null_count": 0,
+    "row_count": 40000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "cardid", "pricedate"],
+    "distinct_count": 40000000,
+    "null_count": 0,
+    "row_count": 40000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  }
+]'
+----
+
+# NOTE: These views should not be checking for the constant dealerid = 1.
+# Instead, the dealerid should be derived from the current user, like this:
+#
+#   dealerid = (SELECT oid FROM pg_roles WHERE rolname = current_user);
+#
+# However, the optimizer and execution engine are not smart enough to do a good
+# job with this. The following needs to be done:
+#
+#   1. Optimizer needs access to key information about pg_roles so that it can
+#      infer that there will be at most one row that matches the predicate.
+#   2. Optimizer needs to replace "current_user" with constant after the query
+#      is prepared, as if it were a parameter.
+#   3. Execution engine should allow "push down" into virtual tables, or else
+#      this query will need to enumerate every user and role in order to find
+#      the requested rolname.
+#
+
+exec-ddl
+CREATE VIEW CardsView AS
+    SELECT  id AS Id, name AS Name, rarity AS Rarity, setname AS SetName, number AS Number, isfoil AS IsFoil,
+            buyprice AS BuyPrice, sellprice AS SellPrice, discount AS Discount,
+            desiredinventory AS DesiredInventory, actualinventory AS ActualInventory,
+            maxinventory AS MaxInventory, version AS Version
+    FROM Cards
+    JOIN CardsInfo
+    ON id = cardid
+    WHERE dealerid = 1
+----
+
+exec-ddl
+CREATE VIEW TransactionsView AS
+    SELECT
+      date AS Date, accountname AS AccountName, customername AS CustomerName,
+      isbuy AS IsBuy, operationid AS OperationId
+    FROM Transactions
+    WHERE dealerid = 1
+----
+
+exec-ddl
+CREATE VIEW TransactionDetailsView AS
+    SELECT  isbuy AS IsBuy, transactiondate AS TransactionDate, cardid AS CardId, quantity AS Quantity,
+            sellprice AS SellPrice, buyprice AS BuyPrice
+    FROM TransactionDetails
+    WHERE dealerid = 1
+----
+
+exec-ddl
+CREATE VIEW PriceDetailsView AS
+    SELECT  cardid AS CardId, pricedate AS PriceDate, pricedby AS PricedBy, buyprice AS BuyPrice,
+            sellprice AS SellPrice,
+            (
+                CASE
+                    WHEN dealerid <> 1
+                    THEN 0::DECIMAL(10,4)
+                    ELSE discount
+                END
+            ) AS Discount
+    FROM PriceDetails
+    WHERE dealerid = 1
+----
+
+exec-ddl
+CREATE VIEW GlobalInventoryView AS
+    SELECT cardid, min(buyprice) AS BuyPrice, max(sellprice) AS SellPrice, max(discount) AS Discount,
+        sum(desiredinventory) AS DesiredInventory,
+        sum
+        (
+            CASE
+                WHEN dealerid = 2 AND actualinventory > 24 THEN 24
+                WHEN dealerid <> 1 AND actualinventory > maxinventory THEN maxinventory
+                ELSE actualinventory
+            END
+        ) AS ActualInventory,
+        sum(maxinventory) AS MaxInventory,
+        max(version) AS Version
+    FROM CardsInfo
+    INNER JOIN Cards
+    ON cardid = id
+    WHERE (dealerid = 1 OR dealerid = 2 OR dealerid = 3 OR dealerid = 4)
+    GROUP BY cardid
+----
+
+exec-ddl
+CREATE VIEW GlobalCardsView AS
+    SELECT c.id AS Id, c.name AS Name, c.rarity AS Rarity, c.setname AS SetName, c.number AS Number, c.isfoil AS IsFoil,
+            inv.BuyPrice, inv.SellPrice, inv.Discount, inv.DesiredInventory, inv.ActualInventory,
+            inv.MaxInventory, inv.Version
+    FROM Cards c
+    INNER JOIN GlobalInventoryView inv
+    ON c.id = inv.cardid
+----
+
+# --------------------------------------------------
+# SELECT Queries
+# --------------------------------------------------
+
+# Find all cards that have been modified in the last 5 seconds.
+#
+# Problems:
+#   1. The wrong index is selected because of mismatched row estimates. The
+#      CardsInfoVersionIndex should be used instead.
+#
+opt format=show-stats
+SELECT
+  Id, Name, Rarity, SetName, Number, IsFoil, BuyPrice, SellPrice,
+  DesiredInventory, ActualInventory, Version, Discount, MaxInventory
+FROM CardsView WHERE Version > 1584421773604892000.0000000000
+----
+project
+ ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null buyprice:9!null sellprice:10!null desiredinventory:12!null actualinventory:13!null version:15!null discount:11!null maxinventory:14!null
+ ├── stats: [rows=0.3325]
+ ├── key: (15)
+ ├── fd: (1)-->(2-6,9-15), (2,4,5)~~>(1,3,6), (15)-->(1-6,9-14)
+ └── inner-join (lookup cards)
+      ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null dealerid:7!null cardid:8!null buyprice:9!null sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null version:15!null
+      ├── key columns: [8] = [1]
+      ├── lookup columns are key
+      ├── stats: [rows=0.3325, distinct(1)=5.83333167e-06, null(1)=0, distinct(8)=5.83333167e-06, null(8)=0]
+      ├── key: (8)
+      ├── fd: ()-->(7), (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(9-15), (15)-->(8-14), (1)==(8), (8)==(1)
+      ├── select
+      │    ├── columns: dealerid:7!null cardid:8!null buyprice:9!null sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null version:15!null
+      │    ├── stats: [rows=5.83333333e-06, distinct(7)=5.83333333e-06, null(7)=0, distinct(8)=5.83333167e-06, null(8)=0, distinct(9)=5.83333333e-06, null(9)=0, distinct(10)=5.83333333e-06, null(10)=0, distinct(11)=5.83333333e-06, null(11)=0, distinct(12)=5.83333333e-06, null(12)=0, distinct(13)=5.83333333e-06, null(13)=0, distinct(14)=5.83333333e-06, null(14)=0, distinct(15)=5.83333333e-06, null(15)=0]
+      │    │   histogram(15)=
+      │    ├── key: (8)
+      │    ├── fd: ()-->(7), (8)-->(9-15), (15)-->(8-14)
+      │    ├── scan cardsinfo
+      │    │    ├── columns: dealerid:7!null cardid:8!null buyprice:9!null sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null version:15!null
+      │    │    ├── constraint: /7/8: [/1 - /1]
+      │    │    ├── stats: [rows=58333.3333, distinct(7)=1, null(7)=0]
+      │    │    ├── key: (8)
+      │    │    └── fd: ()-->(7), (8)-->(9-15), (15)-->(8-14)
+      │    └── filters
+      │         └── version:15 > 1584421773604892000.0000000000 [outer=(15), constraints=(/15: (/1584421773604892000.0000000000 - ]; tight)]
+      └── filters (true)
+
+# Get version of last card that was changed.
+#
+# Problems:
+#   1. CardsView is actually a join between Cards and CardsInfo tables. But the
+#      optimizer is missing join elimination rules. If those were available, we
+#      could eliminate the join to Cards (because of FK).
+#   2. InnerJoin can be pushed below GroupBy, which would put the GroupBy as the
+#      input of the ScalarGroupBy.
+#   3. ScalarGroupBy Max of a GroupBy Max is just ScalarGroupBy Max. Those two
+#      would then be collapsed into one.
+#   4. Furthermore, the join with the second Cards table could be eliminated,
+#      just as with #1.
+#
+opt format=show-stats
+SELECT coalesce(max(Version), 0) FROM GlobalCardsView
+----
+project
+ ├── columns: coalesce:31
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── key: ()
+ ├── fd: ()-->(31)
+ ├── scalar-group-by
+ │    ├── columns: max:30
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(30)
+ │    ├── inner-join (hash)
+ │    │    ├── columns: c.id:1!null cardid:8!null max:29!null
+ │    │    ├── stats: [rows=56607.9417, distinct(1)=56607.9417, null(1)=0, distinct(8)=56607.9417, null(8)=0]
+ │    │    ├── key: (8)
+ │    │    ├── fd: (8)-->(29), (1)==(8), (8)==(1)
+ │    │    ├── scan c@cardsnamesetnumber
+ │    │    │    ├── columns: c.id:1!null
+ │    │    │    ├── stats: [rows=57000, distinct(1)=57000, null(1)=0]
+ │    │    │    └── key: (1)
+ │    │    ├── group-by
+ │    │    │    ├── columns: cardid:8!null max:29!null
+ │    │    │    ├── grouping columns: cardid:8!null
+ │    │    │    ├── stats: [rows=56607.9417, distinct(8)=56607.9417, null(8)=0, distinct(29)=56607.9417, null(29)=0]
+ │    │    │    ├── key: (8)
+ │    │    │    ├── fd: (8)-->(29)
+ │    │    │    ├── inner-join (hash)
+ │    │    │    │    ├── columns: dealerid:7!null cardid:8!null version:15!null cards.id:16!null
+ │    │    │    │    ├── stats: [rows=233333.333, distinct(8)=56607.9417, null(8)=0, distinct(16)=56607.9417, null(16)=0]
+ │    │    │    │    ├── key: (7,16)
+ │    │    │    │    ├── fd: (7,8)-->(15), (7,15)-->(8), (8)==(16), (16)==(8)
+ │    │    │    │    ├── scan cardsinfo@cardsinfoversionindex
+ │    │    │    │    │    ├── columns: dealerid:7!null cardid:8!null version:15!null
+ │    │    │    │    │    ├── constraint: /7/15: [/1 - /4]
+ │    │    │    │    │    ├── stats: [rows=233333.333, distinct(7)=4, null(7)=0, distinct(8)=56607.9417, null(8)=0, distinct(15)=233333.333, null(15)=0]
+ │    │    │    │    │    ├── key: (7,8)
+ │    │    │    │    │    └── fd: (7,8)-->(15), (7,15)-->(8)
+ │    │    │    │    ├── scan cards@cardsnamesetnumber
+ │    │    │    │    │    ├── columns: cards.id:16!null
+ │    │    │    │    │    ├── stats: [rows=57000, distinct(16)=57000, null(16)=0]
+ │    │    │    │    │    └── key: (16)
+ │    │    │    │    └── filters
+ │    │    │    │         └── cardid:8 = cards.id:16 [outer=(8,16), constraints=(/8: (/NULL - ]; /16: (/NULL - ]), fd=(8)==(16), (16)==(8)]
+ │    │    │    └── aggregations
+ │    │    │         └── max [as=max:29, outer=(15)]
+ │    │    │              └── version:15
+ │    │    └── filters
+ │    │         └── c.id:1 = cardid:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+ │    └── aggregations
+ │         └── max [as=max:30, outer=(29)]
+ │              └── max:29
+ └── projections
+      └── COALESCE(max:30, 0) [as=coalesce:31, outer=(30)]
+
+# Show last 20 transactions for a particular card.
+#
+# Problems:
+#   1. Wrong join-type is selected (hash instead of lookup). This is because
+#      "NOT IsBuy" needs to be mapped to "IsBuy = FALSE".
+#   2. Index join should be applied after join between TransactionsView and
+#      TransactionDetailsView.
+#
+opt format=show-stats
+SELECT
+  d.IsBuy, TransactionDate, CardId, Quantity, SellPrice, BuyPrice,
+  t.IsBuy AS IsBuy2, Date, AccountName, CustomerName
+FROM TransactionDetailsView d
+INNER JOIN TransactionsView t
+ON t.Date = d.TransactionDate
+WHERE (d.CardId = 21953) AND NOT d.IsBuy AND NOT t.IsBuy
+ORDER BY TransactionDate DESC
+LIMIT 20
+----
+project
+ ├── columns: isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null sellprice:6!null buyprice:7!null isbuy2:10!null date:11!null accountname:12!null customername:13!null
+ ├── cardinality: [0 - 20]
+ ├── stats: [rows=20]
+ ├── key: (5,11)
+ ├── fd: ()-->(2,4,10), (3,5)-->(6,7), (11)-->(12,13), (3)==(11), (11)==(3)
+ ├── ordering: -(3|11) opt(2,4,10) [actual: -3]
+ └── limit
+      ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null sellprice:6!null buyprice:7!null transactions.dealerid:9!null transactions.isbuy:10!null date:11!null accountname:12!null customername:13!null
+      ├── internal-ordering: -(3|11) opt(1,2,4,9,10)
+      ├── cardinality: [0 - 20]
+      ├── stats: [rows=20]
+      ├── key: (5,11)
+      ├── fd: ()-->(1,2,4,9,10), (3,5)-->(6,7), (11)-->(12,13), (3)==(11), (11)==(3)
+      ├── ordering: -(3|11) opt(1,2,4,9,10) [actual: -3]
+      ├── sort
+      │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null sellprice:6!null buyprice:7!null transactions.dealerid:9!null transactions.isbuy:10!null date:11!null accountname:12!null customername:13!null
+      │    ├── stats: [rows=157.894737, distinct(3)=157.894737, null(3)=0, distinct(11)=157.894737, null(11)=0]
+      │    ├── key: (5,11)
+      │    ├── fd: ()-->(1,2,4,9,10), (3,5)-->(6,7), (11)-->(12,13), (3)==(11), (11)==(3)
+      │    ├── ordering: -(3|11) opt(1,2,4,9,10) [actual: -3]
+      │    ├── limit hint: 20.00
+      │    └── inner-join (hash)
+      │         ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null sellprice:6!null buyprice:7!null transactions.dealerid:9!null transactions.isbuy:10!null date:11!null accountname:12!null customername:13!null
+      │         ├── stats: [rows=157.894737, distinct(3)=157.894737, null(3)=0, distinct(11)=157.894737, null(11)=0]
+      │         ├── key: (5,11)
+      │         ├── fd: ()-->(1,2,4,9,10), (3,5)-->(6,7), (11)-->(12,13), (3)==(11), (11)==(3)
+      │         ├── scan transactions
+      │         │    ├── columns: transactions.dealerid:9!null transactions.isbuy:10!null date:11!null accountname:12!null customername:13!null
+      │         │    ├── constraint: /9/10/11: [/1/false - /1/false]
+      │         │    ├── stats: [rows=1000000, distinct(9)=1, null(9)=0, distinct(10)=1, null(10)=0, distinct(11)=1000000, null(11)=0, distinct(12)=802526.122, null(12)=0, distinct(13)=802526.122, null(13)=0]
+      │         │    ├── key: (11)
+      │         │    └── fd: ()-->(9,10), (11)-->(12,13)
+      │         ├── index-join transactiondetails
+      │         │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null sellprice:6!null buyprice:7!null
+      │         │    ├── stats: [rows=157.894737, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=157.894737, null(3)=0, distinct(4)=1, null(4)=0, distinct(5)=157.894114, null(5)=0, distinct(6)=157.894114, null(6)=0, distinct(7)=157.894114, null(7)=0]
+      │         │    ├── key: (3,5)
+      │         │    ├── fd: ()-->(1,2,4), (3,5)-->(6,7)
+      │         │    └── scan transactiondetails@detailscardidindex
+      │         │         ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null
+      │         │         ├── constraint: /1/2/4/3/5: [/1/false/21953 - /1/false/21953]
+      │         │         ├── stats: [rows=157.894737, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(4)=1, null(4)=0]
+      │         │         ├── key: (3,5)
+      │         │         └── fd: ()-->(1,2,4)
+      │         └── filters
+      │              └── date:11 = transactiondate:3 [outer=(3,11), constraints=(/3: (/NULL - ]; /11: (/NULL - ]), fd=(3)==(11), (11)==(3)]
+      └── 20
+
+# Show last 20 prices for a card.
+opt format=show-stats
+SELECT CardId, PriceDate, PricedBy, BuyPrice, SellPrice
+FROM PriceDetailsView
+WHERE CardId = 12345
+ORDER BY PriceDate DESC
+LIMIT 10
+----
+project
+ ├── columns: cardid:2!null pricedate:3!null pricedby:4!null buyprice:5!null sellprice:6!null
+ ├── cardinality: [0 - 10]
+ ├── stats: [rows=10]
+ ├── key: (3)
+ ├── fd: ()-->(2), (3)-->(4-6)
+ ├── ordering: -3 opt(2) [actual: -3]
+ └── scan pricedetails,rev
+      ├── columns: dealerid:1!null cardid:2!null pricedate:3!null pricedby:4!null buyprice:5!null sellprice:6!null
+      ├── constraint: /1/2/3: [/1/12345 - /1/12345]
+      ├── limit: 10(rev)
+      ├── stats: [rows=10]
+      ├── key: (3)
+      ├── fd: ()-->(1,2), (3)-->(4-6)
+      └── ordering: -3 opt(1,2) [actual: -3]
+
+# Show next page of 50 cards.
+#
+# Problems:
+#   1. This query will not compile, due to #46180.
+#   2. The TransactionDate comparisons should be the last 2 days from the
+#      current timestamp. However, the current timestamp is not treated as a
+#      constant as it should be.
+#   3. Missing rule to push "LIMIT 50" into GroupBy->LeftJoin complex. This
+#      would need to be an exploration rule since it involves an ordering.
+#      Or we could push down the "limit hint" into GroupBy->LeftJoin.
+#   4. Wrong join-type (probably due to #3 above). Should be LookupJoin.
+#
+#opt format=show-stats
+#SELECT
+#  Id, Name, Rarity, SetName, Number, IsFoil, BuyPrice, SellPrice,
+#  DesiredInventory, ActualInventory, Version, Discount, MaxInventory, Value AS TwoDaySales
+#FROM
+#(
+#  SELECT *,
+#    coalesce((
+#      SELECT sum(Quantity)
+#      FROM TransactionDetailsView d
+#      WHERE
+#        d.CardId = c.Id AND
+#        d.IsBuy = FALSE AND
+#        d.TransactionDate BETWEEN '2020-03-01'::TIMESTAMPTZ - INTERVAL '2 days' AND '2020-03-01'::TIMESTAMPTZ
+#      ), 0) AS Value
+#  FROM CardsView c
+#) AS c
+#WHERE (Name, SetName, Number) > ('Shock', '7E', 248)
+#ORDER BY Name, SetName, Number
+#LIMIT 50
+#----
+
+# Daily transaction query.
+#
+# Problems:
+#   1. CardsView is actually a join between Cards and CardsInfo tables. But the
+#      optimizer is missing join elimination rules. If those were available, we
+#      could eliminate the join to Cards (because of FK).
+#   2. Inequality predicate terms (accountname / customername) are too
+#      selective.
+#   3. The Date comparisons should be the last 7 days from the current
+#      timestamp. However, the current timestamp is not treated as a constant as
+#      it should be.
+#
+opt format=show-stats
+SELECT
+  extract(day from d.TransactionDate),
+  sum(d.SellPrice * d.Quantity) AS TotalSell,
+  sum(d.BuyPrice * d.Quantity) AS TotalBuy,
+  sum((d.SellPrice - d.BuyPrice) * d.Quantity) AS TotalProfit
+FROM TransactionDetailsView d, TransactionsView t, CardsView c
+WHERE
+  d.TransactionDate = t.Date AND
+  c.Id = d.CardId AND
+  NOT d.IsBuy AND
+  NOT t.IsBuy AND
+  t.Date BETWEEN '2020-03-01'::TIMESTAMPTZ - INTERVAL '7 days' AND '2020-03-01'::TIMESTAMPTZ AND
+  t.AccountName <> 'someaccount' AND
+  t.customername <> 'somecustomer'
+GROUP BY extract(day from d.TransactionDate)
+ORDER BY extract(day from d.TransactionDate)
+----
+group-by
+ ├── columns: extract:37 totalsell:32!null totalbuy:34!null totalprofit:36!null
+ ├── grouping columns: column37:37
+ ├── stats: [rows=12345.679, distinct(37)=12345.679, null(37)=0]
+ ├── key: (37)
+ ├── fd: (37)-->(32,34,36)
+ ├── ordering: +37
+ ├── sort
+ │    ├── columns: column31:31!null column33:33!null column35:35!null column37:37
+ │    ├── stats: [rows=12634.4671, distinct(37)=12345.679, null(37)=0]
+ │    ├── ordering: +37
+ │    └── project
+ │         ├── columns: column31:31!null column33:33!null column35:35!null column37:37
+ │         ├── stats: [rows=12634.4671, distinct(37)=12345.679, null(37)=0]
+ │         ├── inner-join (hash)
+ │         │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:9!null transactions.isbuy:10!null date:11!null accountname:12!null customername:13!null id:16!null cardsinfo.dealerid:22!null cardsinfo.cardid:23!null
+ │         │    ├── stats: [rows=12634.4671, distinct(3)=12345.679, null(3)=0, distinct(4)=12634.4671, null(4)=0, distinct(11)=12345.679, null(11)=0, distinct(16)=12634.4671, null(16)=0]
+ │         │    ├── key: (5,11,23)
+ │         │    ├── fd: ()-->(1,2,9,10,22), (3-5)-->(6,7), (11)-->(12,13), (16)==(4,23), (23)==(4,16), (3)==(11), (11)==(3), (4)==(16,23)
+ │         │    ├── scan cardsinfo@cardsinfoversionindex
+ │         │    │    ├── columns: cardsinfo.dealerid:22!null cardsinfo.cardid:23!null
+ │         │    │    ├── constraint: /22/30: [/1 - /1]
+ │         │    │    ├── stats: [rows=58333.3333, distinct(22)=1, null(22)=0, distinct(23)=37420.3552, null(23)=0]
+ │         │    │    ├── key: (23)
+ │         │    │    └── fd: ()-->(22)
+ │         │    ├── inner-join (hash)
+ │         │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:9!null transactions.isbuy:10!null date:11!null accountname:12!null customername:13!null id:16!null
+ │         │    │    ├── stats: [rows=12345.679, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=12345.679, null(3)=0, distinct(4)=12345.679, null(4)=0, distinct(5)=12267.872, null(5)=0, distinct(6)=12267.872, null(6)=0, distinct(7)=12267.872, null(7)=0, distinct(9)=1, null(9)=0, distinct(10)=1, null(10)=0, distinct(11)=12345.679, null(11)=0, distinct(12)=7803.95639, null(12)=0, distinct(13)=7803.95639, null(13)=0, distinct(16)=12345.679, null(16)=0]
+ │         │    │    ├── key: (5,11,16)
+ │         │    │    ├── fd: ()-->(1,2,9,10), (11)-->(12,13), (3-5)-->(6,7), (3)==(11), (11)==(3), (4)==(16), (16)==(4)
+ │         │    │    ├── scan cards@cardsnamesetnumber
+ │         │    │    │    ├── columns: id:16!null
+ │         │    │    │    ├── stats: [rows=57000, distinct(16)=57000, null(16)=0]
+ │         │    │    │    └── key: (16)
+ │         │    │    ├── inner-join (hash)
+ │         │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:9!null transactions.isbuy:10!null date:11!null accountname:12!null customername:13!null
+ │         │    │    │    ├── stats: [rows=12345.679, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=12345.679, null(3)=0, distinct(4)=11100.2211, null(4)=0, distinct(5)=12267.8812, null(5)=0, distinct(6)=12267.8812, null(6)=0, distinct(7)=12267.8812, null(7)=0, distinct(9)=1, null(9)=0, distinct(10)=1, null(10)=0, distinct(11)=12345.679, null(11)=0, distinct(12)=7803.95979, null(12)=0, distinct(13)=7803.95979, null(13)=0]
+ │         │    │    │    ├── key: (4,5,11)
+ │         │    │    │    ├── fd: ()-->(1,2,9,10), (11)-->(12,13), (3-5)-->(6,7), (3)==(11), (11)==(3)
+ │         │    │    │    ├── scan transactiondetails
+ │         │    │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null
+ │         │    │    │    │    ├── constraint: /1/2/3/4/5: [/1/false/'2020-02-23 00:00:00+00:00' - /1/false/'2020-03-01 00:00:00+00:00']
+ │         │    │    │    │    ├── stats: [rows=1000000, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1000000, null(3)=0, distinct(4)=56999.9987, null(4)=0, distinct(5)=975366.793, null(5)=0, distinct(6)=975366.793, null(6)=0, distinct(7)=975366.793, null(7)=0]
+ │         │    │    │    │    ├── key: (3-5)
+ │         │    │    │    │    └── fd: ()-->(1,2), (3-5)-->(6,7)
+ │         │    │    │    ├── select
+ │         │    │    │    │    ├── columns: transactions.dealerid:9!null transactions.isbuy:10!null date:11!null accountname:12!null customername:13!null
+ │         │    │    │    │    ├── stats: [rows=12345.679, distinct(9)=1, null(9)=0, distinct(10)=1, null(10)=0, distinct(11)=12345.679, null(11)=0, distinct(12)=12345.679, null(12)=0, distinct(13)=12345.679, null(13)=0]
+ │         │    │    │    │    ├── key: (11)
+ │         │    │    │    │    ├── fd: ()-->(9,10), (11)-->(12,13)
+ │         │    │    │    │    ├── scan transactions
+ │         │    │    │    │    │    ├── columns: transactions.dealerid:9!null transactions.isbuy:10!null date:11!null accountname:12!null customername:13!null
+ │         │    │    │    │    │    ├── constraint: /9/10/11: [/1/false/'2020-02-23 00:00:00+00:00' - /1/false/'2020-03-01 00:00:00+00:00']
+ │         │    │    │    │    │    ├── stats: [rows=111111.111, distinct(9)=1, null(9)=0, distinct(10)=1, null(10)=0, distinct(11)=111111.111, null(11)=0]
+ │         │    │    │    │    │    ├── key: (11)
+ │         │    │    │    │    │    └── fd: ()-->(9,10), (11)-->(12,13)
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         ├── accountname:12 != 'someaccount' [outer=(12), constraints=(/12: (/NULL - /'someaccount') [/e'someaccount\x00' - ]; tight)]
+ │         │    │    │    │         └── customername:13 != 'somecustomer' [outer=(13), constraints=(/13: (/NULL - /'somecustomer') [/e'somecustomer\x00' - ]; tight)]
+ │         │    │    │    └── filters
+ │         │    │    │         └── transactiondate:3 = date:11 [outer=(3,11), constraints=(/3: (/NULL - ]; /11: (/NULL - ]), fd=(3)==(11), (11)==(3)]
+ │         │    │    └── filters
+ │         │    │         └── id:16 = transactiondetails.cardid:4 [outer=(4,16), constraints=(/4: (/NULL - ]; /16: (/NULL - ]), fd=(4)==(16), (16)==(4)]
+ │         │    └── filters
+ │         │         └── id:16 = cardsinfo.cardid:23 [outer=(16,23), constraints=(/16: (/NULL - ]; /23: (/NULL - ]), fd=(16)==(23), (23)==(16)]
+ │         └── projections
+ │              ├── transactiondetails.sellprice:6 * quantity:5 [as=column31:31, outer=(5,6)]
+ │              ├── transactiondetails.buyprice:7 * quantity:5 [as=column33:33, outer=(5,7)]
+ │              ├── quantity:5 * (transactiondetails.sellprice:6 - transactiondetails.buyprice:7) [as=column35:35, outer=(5-7)]
+ │              └── extract('day', transactiondate:3) [as=column37:37, outer=(3)]
+ └── aggregations
+      ├── sum [as=sum:32, outer=(31)]
+      │    └── column31:31
+      ├── sum [as=sum:34, outer=(33)]
+      │    └── column33:33
+      └── sum [as=sum:36, outer=(35)]
+           └── column35:35
+
+# Check if transaction was already inserted, for idempotency.
+#
+# Problems:
+#   1. Missing rule to transform AnyOp into ExistsOp when both the scalar
+#      inclusion value and subquery column are non-NULL.
+#
+# NOTE: This looks awkward, but it's adapted from stored procedure code.
+opt
+SELECT
+(
+  '70F03EB1-4F58-4C26-B72D-C524A9D537DD'::UUID IN
+  (
+    SELECT coalesce(OperationId, '00000000-0000-0000-0000-000000000000'::UUID)
+    FROM TransactionsView
+    WHERE IsBuy = FALSE
+  )
+) AS AlreadyInserted
+----
+values
+ ├── columns: alreadyinserted:9
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(9)
+ └── tuple
+      └── any: eq
+           ├── project
+           │    ├── columns: coalesce:8
+           │    ├── scan transactions
+           │    │    ├── columns: dealerid:1!null isbuy:2!null operationid:6
+           │    │    ├── constraint: /1/2/3: [/1/false - /1/false]
+           │    │    ├── lax-key: (6)
+           │    │    └── fd: ()-->(1,2)
+           │    └── projections
+           │         └── COALESCE(operationid:6, '00000000-0000-0000-0000-000000000000') [as=coalesce:8, outer=(6)]
+           └── '70f03eb1-4f58-4c26-b72d-c524a9d537dd'
+
+# Get account locations of a list of cards.
+#
+# Problems:
+#   1. WITH is not inlined into the query, because it is marked as having side
+#      effects, even though it does not.
+#   2. unnest should be folded into VALUES operator when it operates over
+#      constant ARRAY.
+opt
+WITH CardsToFind AS
+(
+  SELECT (IdAndQuantity).@1 AS Id, (IdAndQuantity).@2 AS Quantity
+  FROM unnest(ARRAY[(42948, 3), (24924, 4)]) AS IdAndQuantity
+)
+SELECT AccountName, sum(Quantity) AS Quantity
+FROM
+(
+    SELECT Id, AccountName, (CASE WHEN needed.Quantity < have.Quantity THEN needed.Quantity ELSE have.Quantity END) Quantity
+    FROM CardsToFind AS needed
+    INNER JOIN LATERAL
+    (
+        SELECT AccountName, Quantity
+        FROM InventoryDetails
+        WHERE (dealerid = 1 OR dealerid = 2 OR dealerid = 3 OR dealerid = 4 OR dealerid = 5) AND
+            CardId = Id AND AccountName = ANY ARRAY['account-1', 'account-2', 'account-3']
+    ) AS have
+    ON TRUE
+) AS allData
+GROUP BY AccountName
+ORDER BY sum(Quantity) DESC
+LIMIT 1000
+----
+sort
+ ├── columns: accountname:8!null quantity:12
+ ├── cardinality: [0 - 1000]
+ ├── side-effects
+ ├── key: (8)
+ ├── fd: (8)-->(12)
+ ├── ordering: -12
+ └── with &1 (cardstofind)
+      ├── columns: accountname:8!null sum:12
+      ├── cardinality: [0 - 1000]
+      ├── side-effects
+      ├── key: (8)
+      ├── fd: (8)-->(12)
+      ├── project
+      │    ├── columns: id:2 quantity:3
+      │    ├── side-effects
+      │    ├── project-set
+      │    │    ├── columns: unnest:1
+      │    │    ├── side-effects
+      │    │    ├── values
+      │    │    │    ├── cardinality: [1 - 1]
+      │    │    │    ├── key: ()
+      │    │    │    └── ()
+      │    │    └── zip
+      │    │         └── unnest(ARRAY[(42948, 3),(24924, 4)]) [side-effects]
+      │    └── projections
+      │         ├── (unnest:1).@1 [as=id:2, outer=(1)]
+      │         └── (unnest:1).@2 [as=quantity:3, outer=(1)]
+      └── limit
+           ├── columns: accountname:8!null sum:12
+           ├── internal-ordering: -12
+           ├── cardinality: [0 - 1000]
+           ├── key: (8)
+           ├── fd: (8)-->(12)
+           ├── sort
+           │    ├── columns: accountname:8!null sum:12
+           │    ├── key: (8)
+           │    ├── fd: (8)-->(12)
+           │    ├── ordering: -12
+           │    ├── limit hint: 1000.00
+           │    └── group-by
+           │         ├── columns: accountname:8!null sum:12
+           │         ├── grouping columns: accountname:8!null
+           │         ├── key: (8)
+           │         ├── fd: (8)-->(12)
+           │         ├── project
+           │         │    ├── columns: quantity:11 accountname:8!null
+           │         │    ├── inner-join (lookup inventorydetails)
+           │         │    │    ├── columns: id:4!null quantity:5 dealerid:6!null cardid:7!null accountname:8!null inventorydetails.quantity:9!null
+           │         │    │    ├── key columns: [6 7 8] = [6 7 8]
+           │         │    │    ├── lookup columns are key
+           │         │    │    ├── fd: (6-8)-->(9), (4)==(7), (7)==(4)
+           │         │    │    ├── inner-join (lookup inventorydetails@inventorydetails_auto_index_inventorydetailscardidkey)
+           │         │    │    │    ├── columns: id:4!null quantity:5 dealerid:6!null cardid:7!null accountname:8!null
+           │         │    │    │    ├── key columns: [4] = [7]
+           │         │    │    │    ├── fd: (4)==(7), (7)==(4)
+           │         │    │    │    ├── with-scan &1 (cardstofind)
+           │         │    │    │    │    ├── columns: id:4 quantity:5
+           │         │    │    │    │    └── mapping:
+           │         │    │    │    │         ├──  id:2 => id:4
+           │         │    │    │    │         └──  quantity:3 => quantity:5
+           │         │    │    │    └── filters
+           │         │    │    │         ├── ((((dealerid:6 = 1) OR (dealerid:6 = 2)) OR (dealerid:6 = 3)) OR (dealerid:6 = 4)) OR (dealerid:6 = 5) [outer=(6), constraints=(/6: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
+           │         │    │    │         └── accountname:8 IN ('account-1', 'account-2', 'account-3') [outer=(8), constraints=(/8: [/'account-1' - /'account-1'] [/'account-2' - /'account-2'] [/'account-3' - /'account-3']; tight)]
+           │         │    │    └── filters (true)
+           │         │    └── projections
+           │         │         └── CASE WHEN quantity:5 < inventorydetails.quantity:9 THEN quantity:5 ELSE inventorydetails.quantity:9 END [as=quantity:11, outer=(5,9)]
+           │         └── aggregations
+           │              └── sum [as=sum:12, outer=(11)]
+           │                   └── quantity:11
+           └── 1000
+
+# Get buy/sell volume of a particular card in the last 2 days.
+#
+# Problems:
+#   1. Multiple duplicate predicates. Scan is already constraining CardId,
+#      IsBuy, and TransactionDate. But filters still contain those checks.
+#
+opt
+SELECT coalesce((
+    SELECT sum(Quantity) AS Volume
+    FROM
+    (
+        SELECT d.Quantity
+        FROM TransactionDetails d
+        INNER JOIN Transactions t
+        ON d.dealerid = t.dealerid AND d.isbuy = t.isbuy AND d.transactiondate = t.date
+        WHERE
+          (d.dealerid = 1 OR d.dealerid = 2 OR d.dealerid = 3 OR d.dealerid = 4 OR d.dealerid = 5) AND
+          d.isbuy IN (TRUE, FALSE) AND
+          d.cardid = 19483 AND
+          d.transactiondate BETWEEN '2020-03-01'::TIMESTAMPTZ - INTERVAL '2 days' AND '2020-03-01'::TIMESTAMPTZ
+        ORDER BY TransactionDate DESC
+        LIMIT 100
+    ) t
+), 0)
+----
+values
+ ├── columns: coalesce:17
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(17)
+ └── tuple
+      └── coalesce
+           ├── subquery
+           │    └── scalar-group-by
+           │         ├── columns: sum:16
+           │         ├── cardinality: [1 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(16)
+           │         ├── limit
+           │         │    ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null t.dealerid:9!null t.isbuy:10!null date:11!null
+           │         │    ├── internal-ordering: -(3|11) opt(4)
+           │         │    ├── cardinality: [0 - 100]
+           │         │    ├── key: (5,9-11)
+           │         │    ├── fd: ()-->(4), (1)==(9), (9)==(1), (2)==(10), (10)==(2), (3)==(11), (11)==(3)
+           │         │    ├── sort
+           │         │    │    ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null t.dealerid:9!null t.isbuy:10!null date:11!null
+           │         │    │    ├── key: (5,9-11)
+           │         │    │    ├── fd: ()-->(4), (1)==(9), (9)==(1), (2)==(10), (10)==(2), (3)==(11), (11)==(3)
+           │         │    │    ├── ordering: -(3|11) opt(4) [actual: -3]
+           │         │    │    ├── limit hint: 100.00
+           │         │    │    └── inner-join (lookup transactions)
+           │         │    │         ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null t.dealerid:9!null t.isbuy:10!null date:11!null
+           │         │    │         ├── key columns: [1 2 3] = [9 10 11]
+           │         │    │         ├── lookup columns are key
+           │         │    │         ├── key: (5,9-11)
+           │         │    │         ├── fd: ()-->(4), (1)==(9), (9)==(1), (2)==(10), (10)==(2), (3)==(11), (11)==(3)
+           │         │    │         ├── select
+           │         │    │         │    ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null
+           │         │    │         │    ├── key: (1-3,5)
+           │         │    │         │    ├── fd: ()-->(4)
+           │         │    │         │    ├── scan d@transactiondetails_auto_index_detailscardidkey
+           │         │    │         │    │    ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null
+           │         │    │         │    │    ├── constraint: /4/1/2/3/5
+           │         │    │         │    │    │    ├── [/19483/1/false/'2020-02-28 00:00:00+00:00' - /19483/1/false/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    │    ├── [/19483/1/true/'2020-02-28 00:00:00+00:00' - /19483/1/true/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    │    ├── [/19483/2/false/'2020-02-28 00:00:00+00:00' - /19483/2/false/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    │    ├── [/19483/2/true/'2020-02-28 00:00:00+00:00' - /19483/2/true/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    │    ├── [/19483/3/false/'2020-02-28 00:00:00+00:00' - /19483/3/false/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    │    ├── [/19483/3/true/'2020-02-28 00:00:00+00:00' - /19483/3/true/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    │    ├── [/19483/4/false/'2020-02-28 00:00:00+00:00' - /19483/4/false/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    │    ├── [/19483/4/true/'2020-02-28 00:00:00+00:00' - /19483/4/true/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    │    ├── [/19483/5/false/'2020-02-28 00:00:00+00:00' - /19483/5/false/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    │    └── [/19483/5/true/'2020-02-28 00:00:00+00:00' - /19483/5/true/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    ├── key: (1-3,5)
+           │         │    │         │    │    └── fd: ()-->(4)
+           │         │    │         │    └── filters
+           │         │    │         │         └── ((((d.dealerid:1 = 1) OR (d.dealerid:1 = 2)) OR (d.dealerid:1 = 3)) OR (d.dealerid:1 = 4)) OR (d.dealerid:1 = 5) [outer=(1), constraints=(/1: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
+           │         │    │         └── filters
+           │         │    │              ├── (date:11 >= '2020-02-28 00:00:00+00:00') AND (date:11 <= '2020-03-01 00:00:00+00:00') [outer=(11), constraints=(/11: [/'2020-02-28 00:00:00+00:00' - /'2020-03-01 00:00:00+00:00']; tight)]
+           │         │    │              ├── ((((t.dealerid:9 = 1) OR (t.dealerid:9 = 2)) OR (t.dealerid:9 = 3)) OR (t.dealerid:9 = 4)) OR (t.dealerid:9 = 5) [outer=(9), constraints=(/9: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
+           │         │    │              └── t.isbuy:10 IN (false, true) [outer=(10), constraints=(/10: [/false - /false] [/true - /true]; tight)]
+           │         │    └── 100
+           │         └── aggregations
+           │              └── sum [as=sum:16, outer=(5)]
+           │                   └── quantity:5
+           └── 0
+
+# --------------------------------------------------
+# INSERT/UPDATE/DELETE/UPSERT Queries
+# --------------------------------------------------
+
+# Insert buy or sell transaction.
+opt
+INSERT INTO Transactions (dealerid, isbuy, date, accountname, customername, operationid)
+VALUES (1, FALSE, '2020-03-01', 'the-account', 'the-customer', '70F03EB1-4F58-4C26-B72D-C524A9D537DD')
+----
+insert transactions
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:8 => dealerid:1
+ │    ├── column2:9 => isbuy:2
+ │    ├── column3:10 => date:3
+ │    ├── column4:11 => accountname:4
+ │    ├── column5:12 => customername:5
+ │    ├── column6:13 => operationid:6
+ │    └── column14:14 => version:7
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── values
+      ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null column6:13!null column14:14
+      ├── cardinality: [1 - 1]
+      ├── side-effects
+      ├── key: ()
+      ├── fd: ()-->(8-14)
+      └── (1, false, '2020-03-01 00:00:00+00:00', 'the-account', 'the-customer', '70f03eb1-4f58-4c26-b72d-c524a9d537dd', cluster_logical_timestamp())
+
+# Upsert buy or sell transaction.
+opt
+UPSERT INTO Transactions (dealerid, isbuy, date, accountname, customername, operationid)
+VALUES (1, FALSE, '2020-03-01', 'the-account', 'the-customer', '70F03EB1-4F58-4C26-B72D-C524A9D537DD')
+----
+upsert transactions
+ ├── columns: <none>
+ ├── canary column: 15
+ ├── fetch columns: dealerid:15 isbuy:16 date:17 accountname:18 customername:19 operationid:20 version:21
+ ├── insert-mapping:
+ │    ├── column1:8 => dealerid:1
+ │    ├── column2:9 => isbuy:2
+ │    ├── column3:10 => date:3
+ │    ├── column4:11 => accountname:4
+ │    ├── column5:12 => customername:5
+ │    ├── column6:13 => operationid:6
+ │    └── column14:14 => version:7
+ ├── update-mapping:
+ │    ├── column4:11 => accountname:4
+ │    ├── column5:12 => customername:5
+ │    └── column6:13 => operationid:6
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── left-join (cross)
+      ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null column6:13!null column14:14 dealerid:15 isbuy:16 date:17 accountname:18 customername:19 operationid:20 version:21
+      ├── cardinality: [1 - 1]
+      ├── side-effects
+      ├── key: ()
+      ├── fd: ()-->(8-21)
+      ├── values
+      │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null column6:13!null column14:14
+      │    ├── cardinality: [1 - 1]
+      │    ├── side-effects
+      │    ├── key: ()
+      │    ├── fd: ()-->(8-14)
+      │    └── (1, false, '2020-03-01 00:00:00+00:00', 'the-account', 'the-customer', '70f03eb1-4f58-4c26-b72d-c524a9d537dd', cluster_logical_timestamp())
+      ├── scan transactions
+      │    ├── columns: dealerid:15!null isbuy:16!null date:17!null accountname:18!null customername:19!null operationid:20 version:21!null
+      │    ├── constraint: /15/16/17: [/1/false/'2020-03-01 00:00:00+00:00' - /1/false/'2020-03-01 00:00:00+00:00']
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    └── fd: ()-->(15-21)
+      └── filters (true)
+
+# Insert structured data (c=CardId, q=Quantity, s=SellPrice, b=BuyPrice)
+# represented as JSON into TransactionDetails table.
+#
+# Problems:
+#   1. WITH is not inlined into the query, because it is marked as having side
+#      effects, even though it does not.
+#   2. jsonb_array_elements should be folded into VALUES operator when it
+#      operates over constant JSON.
+#
+opt
+WITH updates AS (SELECT jsonb_array_elements('[
+    {"c": 49833, "q": 4, "s": 2.89, "b": 2.29},
+    {"c": 29483, "q": 2, "s": 18.93, "b": 17.59}
+  ]'::JSONB
+) AS Detail)
+UPSERT INTO TransactionDetails
+(dealerid, isbuy, transactiondate, cardid, quantity, sellprice, buyprice)
+SELECT
+  1, FALSE, current_timestamp(), (Detail->'c')::TEXT::INT, (Detail->'q')::TEXT::INT,
+  (Detail->'s')::TEXT::DECIMAL(10,4), (Detail->'b')::TEXT::DECIMAL(10,4)
+FROM updates
+----
+with &1 (updates)
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ ├── project-set
+ │    ├── columns: jsonb_array_elements:1
+ │    ├── side-effects
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── ()
+ │    └── zip
+ │         └── jsonb_array_elements('[{"b": 2.29, "c": 49833, "q": 4, "s": 2.89}, {"b": 17.59, "c": 29483, "q": 2, "s": 18.93}]') [side-effects]
+ └── upsert transactiondetails
+      ├── columns: <none>
+      ├── canary column: 21
+      ├── fetch columns: transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondate:23 cardid:24 quantity:25 transactiondetails.sellprice:26 transactiondetails.buyprice:27 transactiondetails.version:28
+      ├── insert-mapping:
+      │    ├── "?column?":11 => transactiondetails.dealerid:2
+      │    ├── bool:12 => transactiondetails.isbuy:3
+      │    ├── current_timestamp:13 => transactiondate:4
+      │    ├── int8:14 => cardid:5
+      │    ├── int8:15 => quantity:6
+      │    ├── sellprice:29 => transactiondetails.sellprice:7
+      │    ├── buyprice:30 => transactiondetails.buyprice:8
+      │    └── column18:18 => transactiondetails.version:9
+      ├── update-mapping:
+      │    ├── sellprice:29 => transactiondetails.sellprice:7
+      │    └── buyprice:30 => transactiondetails.buyprice:8
+      ├── input binding: &2
+      ├── cardinality: [0 - 0]
+      ├── side-effects, mutations
+      ├── project
+      │    ├── columns: upsert_dealerid:31 upsert_isbuy:32 upsert_transactiondate:33 upsert_cardid:34 sellprice:29 buyprice:30 "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15 column18:18 transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondate:23 cardid:24 quantity:25 transactiondetails.sellprice:26 transactiondetails.buyprice:27 transactiondetails.version:28
+      │    ├── side-effects
+      │    ├── lax-key: (13-15,21-25)
+      │    ├── fd: ()-->(11,12), (13-15)~~>(18), (21-25)-->(26-28), (21)-->(31), (21,22)-->(32), (13,21,23)-->(33), (14,21,24)-->(34), (13-15,21-25)~~>(18,29,30)
+      │    ├── left-join (lookup transactiondetails)
+      │    │    ├── columns: "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15 column18:18 sellprice:19 buyprice:20 transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondate:23 cardid:24 quantity:25 transactiondetails.sellprice:26 transactiondetails.buyprice:27 transactiondetails.version:28
+      │    │    ├── key columns: [11 12 13 14 15] = [21 22 23 24 25]
+      │    │    ├── lookup columns are key
+      │    │    ├── side-effects
+      │    │    ├── lax-key: (13-15,21-25)
+      │    │    ├── fd: ()-->(11,12), (13-15)~~>(18-20), (21-25)-->(26-28)
+      │    │    ├── upsert-distinct-on
+      │    │    │    ├── columns: "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15 column18:18 sellprice:19 buyprice:20
+      │    │    │    ├── grouping columns: current_timestamp:13 int8:14 int8:15
+      │    │    │    ├── error-on-dup
+      │    │    │    ├── side-effects
+      │    │    │    ├── lax-key: (13-15)
+      │    │    │    ├── fd: ()-->(11,12), (13-15)~~>(11,12,18-20)
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: sellprice:19 buyprice:20 column18:18 "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15
+      │    │    │    │    ├── side-effects
+      │    │    │    │    ├── fd: ()-->(11,12)
+      │    │    │    │    ├── with-scan &1 (updates)
+      │    │    │    │    │    ├── columns: detail:10
+      │    │    │    │    │    └── mapping:
+      │    │    │    │    │         └──  jsonb_array_elements:1 => detail:10
+      │    │    │    │    └── projections
+      │    │    │    │         ├── crdb_internal.round_decimal_values((detail:10->'s')::STRING::DECIMAL(10,4), 4) [as=sellprice:19, outer=(10)]
+      │    │    │    │         ├── crdb_internal.round_decimal_values((detail:10->'b')::STRING::DECIMAL(10,4), 4) [as=buyprice:20, outer=(10)]
+      │    │    │    │         ├── cluster_logical_timestamp() [as=column18:18, side-effects]
+      │    │    │    │         ├── 1 [as="?column?":11]
+      │    │    │    │         ├── false [as=bool:12]
+      │    │    │    │         ├── current_timestamp() [as=current_timestamp:13, side-effects]
+      │    │    │    │         ├── (detail:10->'c')::STRING::INT8 [as=int8:14, outer=(10)]
+      │    │    │    │         └── (detail:10->'q')::STRING::INT8 [as=int8:15, outer=(10)]
+      │    │    │    └── aggregations
+      │    │    │         ├── first-agg [as=sellprice:19, outer=(19)]
+      │    │    │         │    └── sellprice:19
+      │    │    │         ├── first-agg [as=buyprice:20, outer=(20)]
+      │    │    │         │    └── buyprice:20
+      │    │    │         ├── first-agg [as=column18:18, outer=(18)]
+      │    │    │         │    └── column18:18
+      │    │    │         ├── const-agg [as="?column?":11, outer=(11)]
+      │    │    │         │    └── "?column?":11
+      │    │    │         └── const-agg [as=bool:12, outer=(12)]
+      │    │    │              └── bool:12
+      │    │    └── filters (true)
+      │    └── projections
+      │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN "?column?":11 ELSE transactiondetails.dealerid:21 END [as=upsert_dealerid:31, outer=(11,21)]
+      │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN bool:12 ELSE transactiondetails.isbuy:22 END [as=upsert_isbuy:32, outer=(12,21,22)]
+      │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN current_timestamp:13 ELSE transactiondate:23 END [as=upsert_transactiondate:33, outer=(13,21,23)]
+      │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN int8:14 ELSE cardid:24 END [as=upsert_cardid:34, outer=(14,21,24)]
+      │         ├── crdb_internal.round_decimal_values(sellprice:19, 4) [as=sellprice:29, outer=(19)]
+      │         └── crdb_internal.round_decimal_values(buyprice:20, 4) [as=buyprice:30, outer=(20)]
+      └── f-k-checks
+           ├── f-k-checks-item: transactiondetails(dealerid,isbuy,transactiondate) -> transactions(dealerid,isbuy,date)
+           │    └── anti-join (lookup transactions)
+           │         ├── columns: upsert_dealerid:37 upsert_isbuy:38 upsert_transactiondate:39
+           │         ├── key columns: [37 38 39] = [40 41 42]
+           │         ├── lookup columns are key
+           │         ├── with-scan &2
+           │         │    ├── columns: upsert_dealerid:37 upsert_isbuy:38 upsert_transactiondate:39
+           │         │    └── mapping:
+           │         │         ├──  upsert_dealerid:31 => upsert_dealerid:37
+           │         │         ├──  upsert_isbuy:32 => upsert_isbuy:38
+           │         │         └──  upsert_transactiondate:33 => upsert_transactiondate:39
+           │         └── filters (true)
+           └── f-k-checks-item: transactiondetails(cardid) -> cards(id)
+                └── anti-join (lookup cards)
+                     ├── columns: upsert_cardid:47
+                     ├── key columns: [47] = [48]
+                     ├── lookup columns are key
+                     ├── with-scan &2
+                     │    ├── columns: upsert_cardid:47
+                     │    └── mapping:
+                     │         └──  upsert_cardid:34 => upsert_cardid:47
+                     └── filters (true)
+
+# Delete inventory detail rows to reflect card transfers.
+opt
+DELETE FROM InventoryDetails
+WHERE dealerid = 1 AND accountname = 'some-account' AND cardid = ANY ARRAY[29483, 1793, 294]
+----
+delete inventorydetails
+ ├── columns: <none>
+ ├── fetch columns: dealerid:6 cardid:7 accountname:8
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── scan inventorydetails@inventorydetails_auto_index_inventorydetailscardidkey
+      ├── columns: dealerid:6!null cardid:7!null accountname:8!null
+      ├── constraint: /7/6/8
+      │    ├── [/294/1/'some-account' - /294/1/'some-account']
+      │    ├── [/1793/1/'some-account' - /1793/1/'some-account']
+      │    └── [/29483/1/'some-account' - /29483/1/'some-account']
+      ├── cardinality: [0 - 3]
+      ├── key: (7)
+      └── fd: ()-->(6,8)
+
+# Update CardsInfo inventory numbers (by CardId, Quantity) to reflect card
+# transfers.
+#
+# Problems:
+#   1. WITH is not inlined into the query, because it is marked as having side
+#      effects, even though it does not.
+#   2. unnest should be folded into VALUES operator when it operates over
+#      constant ARRAY.
+opt
+WITH Updates AS
+(
+  SELECT (Detail).@1 AS c, (Detail).@2 AS q
+  FROM unnest(ARRAY[(42948, 3), (24924, 4)]) AS Detail
+)
+UPDATE CardsInfo ci
+SET actualinventory = (SELECT coalesce(sum_INT(quantity), 0)
+                       FROM InventoryDetails id
+                       WHERE dealerid = 1 AND id.cardid = ci.cardid)
+FROM Updates
+WHERE ci.cardid = Updates.c AND ci.dealerid = 1
+----
+with &1 (updates)
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ ├── project
+ │    ├── columns: c:2 q:3
+ │    ├── side-effects
+ │    ├── project-set
+ │    │    ├── columns: unnest:1
+ │    │    ├── side-effects
+ │    │    ├── values
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    └── ()
+ │    │    └── zip
+ │    │         └── unnest(ARRAY[(42948, 3),(24924, 4)]) [side-effects]
+ │    └── projections
+ │         ├── (unnest:1).@1 [as=c:2, outer=(1)]
+ │         └── (unnest:1).@2 [as=q:3, outer=(1)]
+ └── update ci
+      ├── columns: <none>
+      ├── fetch columns: ci.dealerid:13 ci.cardid:14 buyprice:15 sellprice:16 discount:17 desiredinventory:18 actualinventory:19 maxinventory:20 ci.version:21
+      ├── update-mapping:
+      │    └── column31:31 => actualinventory:10
+      ├── cardinality: [0 - 0]
+      ├── side-effects, mutations
+      └── project
+           ├── columns: column31:31 ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23
+           ├── key: (14)
+           ├── fd: ()-->(13), (14)-->(15-23,31), (21)-->(14-20), (14)==(22), (22)==(14)
+           ├── group-by
+           │    ├── columns: ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23 sum_int:29
+           │    ├── grouping columns: ci.cardid:14!null
+           │    ├── key: (14)
+           │    ├── fd: ()-->(13), (14)-->(13,15-23,29), (21)-->(14-20), (14)==(22), (22)==(14)
+           │    ├── left-join (lookup inventorydetails)
+           │    │    ├── columns: ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23 id.dealerid:24 id.cardid:25 quantity:27
+           │    │    ├── key columns: [35 14] = [24 25]
+           │    │    ├── fd: ()-->(13), (14)-->(15-23), (21)-->(14-20), (14)==(22), (22)==(14)
+           │    │    ├── project
+           │    │    │    ├── columns: "project_const_col_@24":35!null ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23
+           │    │    │    ├── key: (14)
+           │    │    │    ├── fd: ()-->(13,35), (14)-->(15-23), (21)-->(14-20), (14)==(22), (22)==(14)
+           │    │    │    ├── distinct-on
+           │    │    │    │    ├── columns: ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23
+           │    │    │    │    ├── grouping columns: ci.cardid:14!null
+           │    │    │    │    ├── key: (14)
+           │    │    │    │    ├── fd: ()-->(13), (14)-->(13,15-23), (21)-->(14-20), (14)==(22), (22)==(14)
+           │    │    │    │    ├── inner-join (lookup cardsinfo)
+           │    │    │    │    │    ├── columns: ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23
+           │    │    │    │    │    ├── key columns: [32 22] = [13 14]
+           │    │    │    │    │    ├── lookup columns are key
+           │    │    │    │    │    ├── fd: ()-->(13), (14)-->(15-21), (21)-->(14-20), (14)==(22), (22)==(14)
+           │    │    │    │    │    ├── project
+           │    │    │    │    │    │    ├── columns: "project_const_col_@13":32!null c:22 q:23
+           │    │    │    │    │    │    ├── fd: ()-->(32)
+           │    │    │    │    │    │    ├── with-scan &1 (updates)
+           │    │    │    │    │    │    │    ├── columns: c:22 q:23
+           │    │    │    │    │    │    │    └── mapping:
+           │    │    │    │    │    │    │         ├──  c:2 => c:22
+           │    │    │    │    │    │    │         └──  q:3 => q:23
+           │    │    │    │    │    │    └── projections
+           │    │    │    │    │    │         └── 1 [as="project_const_col_@13":32]
+           │    │    │    │    │    └── filters (true)
+           │    │    │    │    └── aggregations
+           │    │    │    │         ├── first-agg [as=buyprice:15, outer=(15)]
+           │    │    │    │         │    └── buyprice:15
+           │    │    │    │         ├── first-agg [as=sellprice:16, outer=(16)]
+           │    │    │    │         │    └── sellprice:16
+           │    │    │    │         ├── first-agg [as=discount:17, outer=(17)]
+           │    │    │    │         │    └── discount:17
+           │    │    │    │         ├── first-agg [as=desiredinventory:18, outer=(18)]
+           │    │    │    │         │    └── desiredinventory:18
+           │    │    │    │         ├── first-agg [as=actualinventory:19, outer=(19)]
+           │    │    │    │         │    └── actualinventory:19
+           │    │    │    │         ├── first-agg [as=maxinventory:20, outer=(20)]
+           │    │    │    │         │    └── maxinventory:20
+           │    │    │    │         ├── first-agg [as=ci.version:21, outer=(21)]
+           │    │    │    │         │    └── ci.version:21
+           │    │    │    │         ├── first-agg [as=c:22, outer=(22)]
+           │    │    │    │         │    └── c:22
+           │    │    │    │         ├── first-agg [as=q:23, outer=(23)]
+           │    │    │    │         │    └── q:23
+           │    │    │    │         └── const-agg [as=ci.dealerid:13, outer=(13)]
+           │    │    │    │              └── ci.dealerid:13
+           │    │    │    └── projections
+           │    │    │         └── 1 [as="project_const_col_@24":35]
+           │    │    └── filters (true)
+           │    └── aggregations
+           │         ├── sum-int [as=sum_int:29, outer=(27)]
+           │         │    └── quantity:27
+           │         ├── const-agg [as=ci.dealerid:13, outer=(13)]
+           │         │    └── ci.dealerid:13
+           │         ├── const-agg [as=buyprice:15, outer=(15)]
+           │         │    └── buyprice:15
+           │         ├── const-agg [as=sellprice:16, outer=(16)]
+           │         │    └── sellprice:16
+           │         ├── const-agg [as=discount:17, outer=(17)]
+           │         │    └── discount:17
+           │         ├── const-agg [as=desiredinventory:18, outer=(18)]
+           │         │    └── desiredinventory:18
+           │         ├── const-agg [as=actualinventory:19, outer=(19)]
+           │         │    └── actualinventory:19
+           │         ├── const-agg [as=maxinventory:20, outer=(20)]
+           │         │    └── maxinventory:20
+           │         ├── const-agg [as=ci.version:21, outer=(21)]
+           │         │    └── ci.version:21
+           │         ├── const-agg [as=c:22, outer=(22)]
+           │         │    └── c:22
+           │         └── const-agg [as=q:23, outer=(23)]
+           │              └── q:23
+           └── projections
+                └── COALESCE(sum_int:29, 0) [as=column31:31, outer=(29)]

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1,0 +1,1605 @@
+# =============================================================================
+# This schema is based on a business buying/selling online trading cards. This
+# file simulates queries taking place while schema changes *are* taking place.
+# Compare with the trading file to see differences.
+# =============================================================================
+
+# --------------------------------------------------
+# Schema Definitions
+# --------------------------------------------------
+
+# Cards is the catalog of all cards that can be traded.
+exec-ddl
+CREATE TABLE Cards
+(
+  id INT NOT NULL,
+  name VARCHAR(128) NOT NULL,
+  rarity VARCHAR(1) NULL,
+  setname VARCHAR(5) NULL,
+  number INT NOT NULL,
+  isfoil BIT NOT NULL,
+  CONSTRAINT CardsPrimaryKey PRIMARY KEY
+  (
+    id ASC
+  ),
+  CONSTRAINT CardsNameSetNumber UNIQUE
+  (
+    name ASC,
+    setname ASC,
+    number ASC
+  )
+)
+----
+
+exec-ddl
+ALTER TABLE Cards INJECT STATISTICS '[
+  {
+    "columns": ["id"],
+    "distinct_count": 57000,
+    "null_count": 0,
+    "row_count": 57000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["name"],
+    "distinct_count": 39000,
+    "null_count": 0,
+    "row_count": 57000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["setname"],
+    "distinct_count": 162,
+    "null_count": 0,
+    "row_count": 57000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["number"],
+    "distinct_count": 829,
+    "null_count": 0,
+    "row_count": 57000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["name", "setname"],
+    "distinct_count": 56700,
+    "null_count": 0,
+    "row_count": 57000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["name", "setname", "number"],
+    "distinct_count": 57000,
+    "null_count": 0,
+    "row_count": 57000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  }
+]'
+----
+
+# CardsInfo tracks current inventory of each card, as well as current buy/sell
+# price. It is partitioned on dealerid, which represents multiple licensees
+# (dealers) using the trading software.
+exec-ddl
+CREATE TABLE CardsInfo
+(
+  dealerid OID NOT NULL,
+  cardid INT NOT NULL,
+  buyprice DECIMAL(10,4) NOT NULL,
+  sellprice DECIMAL(10,4) NOT NULL,
+  discount DECIMAL(10,4) NOT NULL,
+  desiredinventory INT NOT NULL,
+  actualinventory INT NOT NULL,
+  maxinventory INT NOT NULL,
+  version DECIMAL NOT NULL DEFAULT (cluster_logical_timestamp()),
+  "discountbuyprice:write-only" DECIMAL(10,4) AS (buyprice - discount) STORED,
+  "notes:write-only" TEXT,
+  "oldinventory:write-only" INT NOT NULL,
+  "extra:delete-only" TEXT NOT NULL,
+  CONSTRAINT CardsInfoPrimaryKey PRIMARY KEY
+  (
+    dealerid ASC,
+    cardid ASC
+  ),
+  CONSTRAINT CardsInfoCardIdKey FOREIGN KEY (cardid)
+  REFERENCES Cards (id),
+  UNIQUE INDEX CardsInfoVersionIndex (dealerid ASC, version ASC)
+)
+----
+
+exec-ddl
+ALTER TABLE CardsInfo INJECT STATISTICS '[
+  {
+    "columns": ["dealerid"],
+    "distinct_count": 12,
+    "null_count": 0,
+    "row_count": 700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["cardid"],
+    "distinct_count": 57000,
+    "null_count": 0,
+    "row_count": 700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["version"],
+    "distinct_count": 700000,
+    "null_count": 0,
+    "row_count": 700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00",
+    "histo_col_type": "decimal",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "1426741777604892000"},
+      {"num_eq": 0, "num_range": 350000, "distinct_range": 350000, "upper_bound": "1584421693935036000"}
+    ]
+  },
+  {
+    "columns": ["dealerid", "cardid"],
+    "distinct_count": 700000,
+    "null_count": 0,
+    "row_count": 700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "version"],
+    "distinct_count": 700000,
+    "null_count": 0,
+    "row_count": 700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  }
+]'
+----
+
+# InventoryDetails stores the quantity and location of all the cards.
+exec-ddl
+CREATE TABLE InventoryDetails
+(
+  dealerid OID NOT NULL,
+  cardid INT NOT NULL,
+  accountname VARCHAR(128) NOT NULL,
+  quantity INT NOT NULL,
+  version DECIMAL NOT NULL DEFAULT (cluster_logical_timestamp()),
+  "lastchange:write-only" INT,
+  "extra:delete-only" DECIMAL(10,0) NOT NULL,
+  CONSTRAINT InventoryDetailsPrimaryKey PRIMARY KEY
+  (
+    dealerid ASC,
+    cardid ASC,
+    accountname ASC
+  ),
+  CONSTRAINT InventoryDetailsCardIdKey FOREIGN KEY (cardid)
+  REFERENCES Cards (id)
+)
+----
+
+exec-ddl
+ALTER TABLE InventoryDetails INJECT STATISTICS '[
+  {
+    "columns": ["dealerid"],
+    "distinct_count": 12,
+    "null_count": 0,
+    "row_count": 1700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["cardid"],
+    "distinct_count": 50000,
+    "null_count": 0,
+    "row_count": 1700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["accountname"],
+    "distinct_count": 150,
+    "null_count": 0,
+    "row_count": 1700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "cardid"],
+    "distinct_count": 250000,
+    "null_count": 0,
+    "row_count": 1700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "cardid", "accountname"],
+    "distinct_count": 170000,
+    "null_count": 0,
+    "row_count": 1700000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  }
+]'
+----
+
+# Transactions records all buy/sell trading activity.
+#
+# NOTE: The TransactionsOpIndex is meant to be a partial index, only containing
+#       non-NULL values. The operationid column is for idempotency, and
+#       older values get set to NULL after X hours to save space. 99%+ of values
+#       are NULL.
+exec-ddl
+CREATE TABLE Transactions
+(
+  dealerid OID NOT NULL,
+  isbuy BOOL NOT NULL,
+  date TIMESTAMPTZ NOT NULL,
+  accountname VARCHAR(128) NOT NULL,
+  customername VARCHAR(128) NOT NULL,
+  operationid UUID,
+  version DECIMAL NOT NULL DEFAULT (cluster_logical_timestamp()),
+  "olddate:write-only" TIMESTAMP NOT NULL,
+  "extra:delete-only" TEXT AS ('a:' || accountname) STORED,
+  CONSTRAINT TransactionsPrimaryKey PRIMARY KEY
+  (
+    dealerid ASC,
+    isbuy ASC,
+    date ASC
+  ),
+  UNIQUE INDEX TransactionsOpIndex (dealerid ASC, operationid ASC)
+  --WHERE operationid IS NOT NULL
+)
+----
+
+exec-ddl
+ALTER TABLE Transactions INJECT STATISTICS '[
+  {
+    "columns": ["dealerid"],
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 20000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["isbuy"],
+    "distinct_count": 2,
+    "null_count": 0,
+    "row_count": 20000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["date"],
+    "distinct_count": 20000000,
+    "null_count": 0,
+    "row_count": 20000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["operationid"],
+    "distinct_count": 4000,
+    "null_count": 19996000,
+    "row_count": 20000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "isbuy"],
+    "distinct_count": 15,
+    "null_count": 0,
+    "row_count": 20000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "isbuy", "date"],
+    "distinct_count": 20000000,
+    "null_count": 0,
+    "row_count": 20000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  }
+]'
+----
+
+# TransactionDetails records line items of each Transaction.
+exec-ddl
+CREATE TABLE TransactionDetails
+(
+  dealerid OID NOT NULL,
+  isbuy BOOL NOT NULL,
+  transactiondate TIMESTAMPTZ NOT NULL,
+  cardid INT NOT NULL,
+  quantity INT NOT NULL,
+  sellprice DECIMAL(10,4) NOT NULL,
+  buyprice DECIMAL(10,4) NOT NULL,
+  version DECIMAL NOT NULL DEFAULT (cluster_logical_timestamp()),
+  "discount:write-only" DECIMAL(10,4) DEFAULT(0.00001),
+  "extra:delete-only" TEXT NOT NULL,
+  CONSTRAINT DetailsPrimaryKey PRIMARY KEY
+  (
+    dealerid ASC,
+    isbuy ASC,
+    transactiondate ASC,
+    cardid ASC,
+    quantity ASC
+  ),
+  CONSTRAINT DetailsDealerDateKey FOREIGN KEY (dealerid, isbuy, transactiondate)
+  REFERENCES Transactions (dealerid, isbuy, date),
+  CONSTRAINT DetailsCardIdKey FOREIGN KEY (cardid)
+  REFERENCES Cards (id),
+  INDEX DetailsCardIdIndex (dealerid ASC, isbuy ASC, cardid ASC)
+)
+----
+
+exec-ddl
+ALTER TABLE TransactionDetails INJECT STATISTICS '[
+  {
+    "columns": ["dealerid"],
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 180000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["isbuy"],
+    "distinct_count": 2,
+    "null_count": 0,
+    "row_count": 180000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["transactiondate"],
+    "distinct_count": 180000000,
+    "null_count": 0,
+    "row_count": 180000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["cardid"],
+    "distinct_count": 57000,
+    "null_count": 0,
+    "row_count": 180000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "isbuy"],
+    "distinct_count": 15,
+    "null_count": 0,
+    "row_count": 180000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "isbuy", "transactiondate"],
+    "distinct_count": 20000000,
+    "null_count": 0,
+    "row_count": 180000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "isbuy", "transactiondate", "cardid"],
+    "distinct_count": 180000000,
+    "null_count": 0,
+    "row_count": 180000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "isbuy", "transactiondate", "cardid", "quantity"],
+    "distinct_count": 180000000,
+    "null_count": 0,
+    "row_count": 180000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "isbuy", "cardid"],
+    "distinct_count": 350000,
+    "null_count": 0,
+    "row_count": 180000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  }
+]'
+----
+
+# PriceDetails records price history for each card.
+exec-ddl
+CREATE TABLE PriceDetails
+(
+    dealerid OID NOT NULL,
+    cardid INT NOT NULL,
+    pricedate TIMESTAMPTZ NOT NULL,
+    pricedby VARCHAR(128) NOT NULL,
+    buyprice DECIMAL(10,4) NOT NULL,
+    sellprice DECIMAL(10,4) NOT NULL,
+    discount DECIMAL(10,4) NOT NULL,
+    version DECIMAL NOT NULL,
+    CONSTRAINT PriceDetailsPrimaryKey PRIMARY KEY
+    (
+        dealerid ASC,
+        cardid ASC,
+        pricedate ASC
+    ),
+    CONSTRAINT PriceDetailsCardIdKey FOREIGN KEY (cardid)
+    REFERENCES Cards (id)
+)
+----
+
+exec-ddl
+ALTER TABLE PriceDetails INJECT STATISTICS '[
+  {
+    "columns": ["dealerid"],
+    "distinct_count": 2,
+    "null_count": 0,
+    "row_count": 40000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["cardid"],
+    "distinct_count": 57000,
+    "null_count": 0,
+    "row_count": 40000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["pricedate"],
+    "distinct_count": 40000000,
+    "null_count": 0,
+    "row_count": 40000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "cardid"],
+    "distinct_count": 90000,
+    "null_count": 0,
+    "row_count": 40000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["dealerid", "cardid", "pricedate"],
+    "distinct_count": 40000000,
+    "null_count": 0,
+    "row_count": 40000000,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  }
+]'
+----
+
+# NOTE: These views should not be checking for the constant dealerid = 1.
+# Instead, the dealerid should be derived from the current user, like this:
+#
+#   dealerid = (SELECT oid FROM pg_roles WHERE rolname = current_user);
+#
+# However, the optimizer and execution engine are not smart enough to do a good
+# job with this. The following needs to be done:
+#
+#   1. Optimizer needs access to key information about pg_roles so that it can
+#      infer that there will be at most one row that matches the predicate.
+#   2. Optimizer needs to replace "current_user" with constant after the query
+#      is prepared, as if it were a parameter.
+#   3. Execution engine should allow "push down" into virtual tables, or else
+#      this query will need to enumerate every user and role in order to find
+#      the requested rolname.
+#
+
+exec-ddl
+CREATE VIEW CardsView AS
+    SELECT  id AS Id, name AS Name, rarity AS Rarity, setname AS SetName, number AS Number, isfoil AS IsFoil,
+            buyprice AS BuyPrice, sellprice AS SellPrice, discount AS Discount,
+            desiredinventory AS DesiredInventory, actualinventory AS ActualInventory,
+            maxinventory AS MaxInventory, version AS Version
+    FROM Cards
+    JOIN CardsInfo
+    ON id = cardid
+    WHERE dealerid = 1
+----
+
+exec-ddl
+CREATE VIEW TransactionsView AS
+    SELECT
+      date AS Date, accountname AS AccountName, customername AS CustomerName,
+      isbuy AS IsBuy, operationid AS OperationId
+    FROM Transactions
+    WHERE dealerid = 1
+----
+
+exec-ddl
+CREATE VIEW TransactionDetailsView AS
+    SELECT  isbuy AS IsBuy, transactiondate AS TransactionDate, cardid AS CardId, quantity AS Quantity,
+            sellprice AS SellPrice, buyprice AS BuyPrice
+    FROM TransactionDetails
+    WHERE dealerid = 1
+----
+
+exec-ddl
+CREATE VIEW PriceDetailsView AS
+    SELECT  cardid AS CardId, pricedate AS PriceDate, pricedby AS PricedBy, buyprice AS BuyPrice,
+            sellprice AS SellPrice,
+            (
+                CASE
+                    WHEN dealerid <> 1
+                    THEN 0::DECIMAL(10,4)
+                    ELSE discount
+                END
+            ) AS Discount
+    FROM PriceDetails
+    WHERE dealerid = 1
+----
+
+exec-ddl
+CREATE VIEW GlobalInventoryView AS
+    SELECT cardid, min(buyprice) AS BuyPrice, max(sellprice) AS SellPrice, max(discount) AS Discount,
+        sum(desiredinventory) AS DesiredInventory,
+        sum
+        (
+            CASE
+                WHEN dealerid = 2 AND actualinventory > 24 THEN 24
+                WHEN dealerid <> 1 AND actualinventory > maxinventory THEN maxinventory
+                ELSE actualinventory
+            END
+        ) AS ActualInventory,
+        sum(maxinventory) AS MaxInventory,
+        max(version) AS Version
+    FROM CardsInfo
+    INNER JOIN Cards
+    ON cardid = id
+    WHERE (dealerid = 1 OR dealerid = 2 OR dealerid = 3 OR dealerid = 4)
+    GROUP BY cardid
+----
+
+exec-ddl
+CREATE VIEW GlobalCardsView AS
+    SELECT c.id AS Id, c.name AS Name, c.rarity AS Rarity, c.setname AS SetName, c.number AS Number, c.isfoil AS IsFoil,
+            inv.BuyPrice, inv.SellPrice, inv.Discount, inv.DesiredInventory, inv.ActualInventory,
+            inv.MaxInventory, inv.Version
+    FROM Cards c
+    INNER JOIN GlobalInventoryView inv
+    ON c.id = inv.cardid
+----
+
+# --------------------------------------------------
+# SELECT Queries
+# --------------------------------------------------
+
+# Find all cards that have been modified in the last 5 seconds.
+#
+# Problems:
+#   1. The wrong index is selected because of mismatched row estimates. The
+#      CardsInfoVersionIndex should be used instead.
+#
+opt format=show-stats
+SELECT
+  Id, Name, Rarity, SetName, Number, IsFoil, BuyPrice, SellPrice,
+  DesiredInventory, ActualInventory, Version, Discount, MaxInventory
+FROM CardsView WHERE Version > 1584421773604892000.0000000000
+----
+project
+ ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null buyprice:9!null sellprice:10!null desiredinventory:12!null actualinventory:13!null version:15!null discount:11!null maxinventory:14!null
+ ├── stats: [rows=0.3325]
+ ├── key: (15)
+ ├── fd: (1)-->(2-6,9-15), (2,4,5)~~>(1,3,6), (15)-->(1-6,9-14)
+ └── inner-join (lookup cards)
+      ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null dealerid:7!null cardid:8!null buyprice:9!null sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null version:15!null
+      ├── key columns: [8] = [1]
+      ├── lookup columns are key
+      ├── stats: [rows=0.3325, distinct(1)=5.83333167e-06, null(1)=0, distinct(8)=5.83333167e-06, null(8)=0]
+      ├── key: (8)
+      ├── fd: ()-->(7), (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(9-15), (15)-->(8-14), (1)==(8), (8)==(1)
+      ├── select
+      │    ├── columns: dealerid:7!null cardid:8!null buyprice:9!null sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null version:15!null
+      │    ├── stats: [rows=5.83333333e-06, distinct(7)=5.83333333e-06, null(7)=0, distinct(8)=5.83333167e-06, null(8)=0, distinct(9)=5.83333333e-06, null(9)=0, distinct(10)=5.83333333e-06, null(10)=0, distinct(11)=5.83333333e-06, null(11)=0, distinct(12)=5.83333333e-06, null(12)=0, distinct(13)=5.83333333e-06, null(13)=0, distinct(14)=5.83333333e-06, null(14)=0, distinct(15)=5.83333333e-06, null(15)=0]
+      │    │   histogram(15)=
+      │    ├── key: (8)
+      │    ├── fd: ()-->(7), (8)-->(9-15), (15)-->(8-14)
+      │    ├── scan cardsinfo
+      │    │    ├── columns: dealerid:7!null cardid:8!null buyprice:9!null sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null version:15!null
+      │    │    ├── constraint: /7/8: [/1 - /1]
+      │    │    ├── stats: [rows=58333.3333, distinct(7)=1, null(7)=0]
+      │    │    ├── key: (8)
+      │    │    └── fd: ()-->(7), (8)-->(9-15), (15)-->(8-14)
+      │    └── filters
+      │         └── version:15 > 1584421773604892000.0000000000 [outer=(15), constraints=(/15: (/1584421773604892000.0000000000 - ]; tight)]
+      └── filters (true)
+
+# Get version of last card that was changed.
+#
+# Problems:
+#   1. CardsView is actually a join between Cards and CardsInfo tables. But the
+#      optimizer is missing join elimination rules. If those were available, we
+#      could eliminate the join to Cards (because of FK).
+#   2. InnerJoin can be pushed below GroupBy, which would put the GroupBy as the
+#      input of the ScalarGroupBy.
+#   3. ScalarGroupBy Max of a GroupBy Max is just ScalarGroupBy Max. Those two
+#      would then be collapsed into one.
+#   4. Furthermore, the join with the second Cards table could be eliminated,
+#      just as with #1.
+#
+opt format=show-stats
+SELECT coalesce(max(Version), 0) FROM GlobalCardsView
+----
+project
+ ├── columns: coalesce:35
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── key: ()
+ ├── fd: ()-->(35)
+ ├── scalar-group-by
+ │    ├── columns: max:34
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(34)
+ │    ├── inner-join (hash)
+ │    │    ├── columns: c.id:1!null cardid:8!null max:33!null
+ │    │    ├── stats: [rows=56607.9417, distinct(1)=56607.9417, null(1)=0, distinct(8)=56607.9417, null(8)=0]
+ │    │    ├── key: (8)
+ │    │    ├── fd: (8)-->(33), (1)==(8), (8)==(1)
+ │    │    ├── scan c@cardsnamesetnumber
+ │    │    │    ├── columns: c.id:1!null
+ │    │    │    ├── stats: [rows=57000, distinct(1)=57000, null(1)=0]
+ │    │    │    └── key: (1)
+ │    │    ├── group-by
+ │    │    │    ├── columns: cardid:8!null max:33!null
+ │    │    │    ├── grouping columns: cardid:8!null
+ │    │    │    ├── stats: [rows=56607.9417, distinct(8)=56607.9417, null(8)=0, distinct(33)=56607.9417, null(33)=0]
+ │    │    │    ├── key: (8)
+ │    │    │    ├── fd: (8)-->(33)
+ │    │    │    ├── inner-join (hash)
+ │    │    │    │    ├── columns: dealerid:7!null cardid:8!null version:15!null cards.id:20!null
+ │    │    │    │    ├── stats: [rows=233333.333, distinct(8)=56607.9417, null(8)=0, distinct(20)=56607.9417, null(20)=0]
+ │    │    │    │    ├── key: (7,20)
+ │    │    │    │    ├── fd: (7,8)-->(15), (7,15)-->(8), (8)==(20), (20)==(8)
+ │    │    │    │    ├── scan cardsinfo@cardsinfoversionindex
+ │    │    │    │    │    ├── columns: dealerid:7!null cardid:8!null version:15!null
+ │    │    │    │    │    ├── constraint: /7/15: [/1 - /4]
+ │    │    │    │    │    ├── stats: [rows=233333.333, distinct(7)=4, null(7)=0, distinct(8)=56607.9417, null(8)=0, distinct(15)=233333.333, null(15)=0]
+ │    │    │    │    │    ├── key: (7,8)
+ │    │    │    │    │    └── fd: (7,8)-->(15), (7,15)-->(8)
+ │    │    │    │    ├── scan cards@cardsnamesetnumber
+ │    │    │    │    │    ├── columns: cards.id:20!null
+ │    │    │    │    │    ├── stats: [rows=57000, distinct(20)=57000, null(20)=0]
+ │    │    │    │    │    └── key: (20)
+ │    │    │    │    └── filters
+ │    │    │    │         └── cardid:8 = cards.id:20 [outer=(8,20), constraints=(/8: (/NULL - ]; /20: (/NULL - ]), fd=(8)==(20), (20)==(8)]
+ │    │    │    └── aggregations
+ │    │    │         └── max [as=max:33, outer=(15)]
+ │    │    │              └── version:15
+ │    │    └── filters
+ │    │         └── c.id:1 = cardid:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+ │    └── aggregations
+ │         └── max [as=max:34, outer=(33)]
+ │              └── max:33
+ └── projections
+      └── COALESCE(max:34, 0) [as=coalesce:35, outer=(34)]
+
+# Show last 20 transactions for a particular card.
+#
+# Problems:
+#   1. Wrong join-type is selected (hash instead of lookup). This is because
+#      "NOT IsBuy" needs to be mapped to "IsBuy = FALSE".
+#   2. Index join should be applied after join between TransactionsView and
+#      TransactionDetailsView.
+#
+opt format=show-stats
+SELECT
+  d.IsBuy, TransactionDate, CardId, Quantity, SellPrice, BuyPrice,
+  t.IsBuy AS IsBuy2, Date, AccountName, CustomerName
+FROM TransactionDetailsView d
+INNER JOIN TransactionsView t
+ON t.Date = d.TransactionDate
+WHERE (d.CardId = 21953) AND NOT d.IsBuy AND NOT t.IsBuy
+ORDER BY TransactionDate DESC
+LIMIT 20
+----
+project
+ ├── columns: isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null sellprice:6!null buyprice:7!null isbuy2:12!null date:13!null accountname:14!null customername:15!null
+ ├── cardinality: [0 - 20]
+ ├── stats: [rows=20]
+ ├── key: (5,13)
+ ├── fd: ()-->(2,4,12), (3,5)-->(6,7), (13)-->(14,15), (3)==(13), (13)==(3)
+ ├── ordering: -(3|13) opt(2,4,12) [actual: -3]
+ └── limit
+      ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null sellprice:6!null buyprice:7!null transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null
+      ├── internal-ordering: -(3|13) opt(1,2,4,11,12)
+      ├── cardinality: [0 - 20]
+      ├── stats: [rows=20]
+      ├── key: (5,13)
+      ├── fd: ()-->(1,2,4,11,12), (3,5)-->(6,7), (13)-->(14,15), (3)==(13), (13)==(3)
+      ├── ordering: -(3|13) opt(1,2,4,11,12) [actual: -3]
+      ├── sort
+      │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null sellprice:6!null buyprice:7!null transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null
+      │    ├── stats: [rows=157.894737, distinct(3)=157.894737, null(3)=0, distinct(13)=157.894737, null(13)=0]
+      │    ├── key: (5,13)
+      │    ├── fd: ()-->(1,2,4,11,12), (3,5)-->(6,7), (13)-->(14,15), (3)==(13), (13)==(3)
+      │    ├── ordering: -(3|13) opt(1,2,4,11,12) [actual: -3]
+      │    ├── limit hint: 20.00
+      │    └── inner-join (hash)
+      │         ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null sellprice:6!null buyprice:7!null transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null
+      │         ├── stats: [rows=157.894737, distinct(3)=157.894737, null(3)=0, distinct(13)=157.894737, null(13)=0]
+      │         ├── key: (5,13)
+      │         ├── fd: ()-->(1,2,4,11,12), (3,5)-->(6,7), (13)-->(14,15), (3)==(13), (13)==(3)
+      │         ├── scan transactions
+      │         │    ├── columns: transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null
+      │         │    ├── constraint: /11/12/13: [/1/false - /1/false]
+      │         │    ├── stats: [rows=1000000, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=1000000, null(13)=0, distinct(14)=802526.122, null(14)=0, distinct(15)=802526.122, null(15)=0]
+      │         │    ├── key: (13)
+      │         │    └── fd: ()-->(11,12), (13)-->(14,15)
+      │         ├── index-join transactiondetails
+      │         │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null sellprice:6!null buyprice:7!null
+      │         │    ├── stats: [rows=157.894737, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=157.894737, null(3)=0, distinct(4)=1, null(4)=0, distinct(5)=157.894114, null(5)=0, distinct(6)=157.894114, null(6)=0, distinct(7)=157.894114, null(7)=0]
+      │         │    ├── key: (3,5)
+      │         │    ├── fd: ()-->(1,2,4), (3,5)-->(6,7)
+      │         │    └── scan transactiondetails@detailscardidindex
+      │         │         ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null
+      │         │         ├── constraint: /1/2/4/3/5: [/1/false/21953 - /1/false/21953]
+      │         │         ├── stats: [rows=157.894737, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(4)=1, null(4)=0]
+      │         │         ├── key: (3,5)
+      │         │         └── fd: ()-->(1,2,4)
+      │         └── filters
+      │              └── date:13 = transactiondate:3 [outer=(3,13), constraints=(/3: (/NULL - ]; /13: (/NULL - ]), fd=(3)==(13), (13)==(3)]
+      └── 20
+
+# Show last 20 prices for a card.
+opt format=show-stats
+SELECT CardId, PriceDate, PricedBy, BuyPrice, SellPrice
+FROM PriceDetailsView
+WHERE CardId = 12345
+ORDER BY PriceDate DESC
+LIMIT 10
+----
+project
+ ├── columns: cardid:2!null pricedate:3!null pricedby:4!null buyprice:5!null sellprice:6!null
+ ├── cardinality: [0 - 10]
+ ├── stats: [rows=10]
+ ├── key: (3)
+ ├── fd: ()-->(2), (3)-->(4-6)
+ ├── ordering: -3 opt(2) [actual: -3]
+ └── scan pricedetails,rev
+      ├── columns: dealerid:1!null cardid:2!null pricedate:3!null pricedby:4!null buyprice:5!null sellprice:6!null
+      ├── constraint: /1/2/3: [/1/12345 - /1/12345]
+      ├── limit: 10(rev)
+      ├── stats: [rows=10]
+      ├── key: (3)
+      ├── fd: ()-->(1,2), (3)-->(4-6)
+      └── ordering: -3 opt(1,2) [actual: -3]
+
+# Show next page of 50 cards.
+#
+# Problems:
+#   1. The TransactionDate comparisons should be the last 2 days from the
+#      current timestamp. However, the current timestamp is not treated as a
+#      constant as it should be.
+#   2. Missing rule to push "LIMIT 50" into GroupBy->LeftJoin complex. This
+#      would need to be an exploration rule since it involves an ordering.
+#      Or we could push down the "limit hint" into GroupBy->LeftJoin.
+#   3. Wrong join-type (probably due to #3 above). Should be LookupJoin.
+#
+opt format=show-stats
+SELECT
+  Id, Name, Rarity, SetName, Number, IsFoil, BuyPrice, SellPrice,
+  DesiredInventory, ActualInventory, Version, Discount, MaxInventory, Value AS TwoDaySales
+FROM
+(
+  SELECT *,
+    coalesce((
+      SELECT sum(Quantity)
+      FROM TransactionDetailsView d
+      WHERE
+        d.CardId = c.Id AND
+        d.IsBuy = FALSE AND
+        d.TransactionDate BETWEEN '2020-03-01'::TIMESTAMPTZ - INTERVAL '2 days' AND '2020-03-01'::TIMESTAMPTZ
+      ), 0) AS Value
+  FROM CardsView c
+) AS c
+WHERE (Name, SetName, Number) > ('Shock', '7E', 248)
+ORDER BY Name, SetName, Number
+LIMIT 50
+----
+project
+ ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null buyprice:9!null sellprice:10!null desiredinventory:12!null actualinventory:13!null version:15!null discount:11!null maxinventory:14!null twodaysales:31
+ ├── cardinality: [0 - 50]
+ ├── stats: [rows=50]
+ ├── key: (15,31)
+ ├── fd: (1)-->(2-6,9-15), (2,4,5)~~>(1,3,6), (15)-->(1-6,9-14)
+ ├── ordering: +2,+4,+5
+ ├── limit
+ │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.cardid:8!null cardsinfo.buyprice:9!null cardsinfo.sellprice:10!null cardsinfo.discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null cardsinfo.version:15!null sum:30
+ │    ├── internal-ordering: +2,+4,+5
+ │    ├── cardinality: [0 - 50]
+ │    ├── stats: [rows=50]
+ │    ├── key: (8)
+ │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(1-6,9-15,30), (15)-->(8-14), (1)==(8), (8)==(1)
+ │    ├── ordering: +2,+4,+5
+ │    ├── sort
+ │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.cardid:8!null cardsinfo.buyprice:9!null cardsinfo.sellprice:10!null cardsinfo.discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null cardsinfo.version:15!null sum:30
+ │    │    ├── stats: [rows=19000, distinct(8)=19000, null(8)=0]
+ │    │    ├── key: (8)
+ │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(1-6,9-15,30), (15)-->(8-14), (1)==(8), (8)==(1)
+ │    │    ├── ordering: +2,+4,+5
+ │    │    ├── limit hint: 50.00
+ │    │    └── group-by
+ │    │         ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.cardid:8!null cardsinfo.buyprice:9!null cardsinfo.sellprice:10!null cardsinfo.discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null cardsinfo.version:15!null sum:30
+ │    │         ├── grouping columns: cardsinfo.cardid:8!null
+ │    │         ├── stats: [rows=19000, distinct(8)=19000, null(8)=0]
+ │    │         ├── key: (8)
+ │    │         ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(1-6,9-15,30), (15)-->(8-14), (1)==(8), (8)==(1)
+ │    │         ├── right-join (hash)
+ │    │         │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:7!null cardsinfo.cardid:8!null cardsinfo.buyprice:9!null cardsinfo.sellprice:10!null cardsinfo.discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null cardsinfo.version:15!null transactiondetails.dealerid:20 isbuy:21 transactiondate:22 transactiondetails.cardid:23 quantity:24
+ │    │         │    ├── stats: [rows=519622.136, distinct(8)=19000, null(8)=0, distinct(23)=19000, null(23)=0]
+ │    │         │    ├── key: (8,22-24)
+ │    │         │    ├── fd: ()-->(7), (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(9-15), (15)-->(8-14), (1)==(8), (8)==(1), (8,22-24)-->(20,21)
+ │    │         │    ├── scan transactiondetails
+ │    │         │    │    ├── columns: transactiondetails.dealerid:20!null isbuy:21!null transactiondate:22!null transactiondetails.cardid:23!null quantity:24!null
+ │    │         │    │    ├── constraint: /20/21/22/23/24: [/1/false/'2020-02-28 00:00:00+00:00' - /1/false/'2020-03-01 00:00:00+00:00']
+ │    │         │    │    ├── stats: [rows=1000000, distinct(20)=1, null(20)=0, distinct(21)=1, null(21)=0, distinct(22)=1000000, null(22)=0, distinct(23)=56999.9987, null(23)=0]
+ │    │         │    │    ├── key: (22-24)
+ │    │         │    │    └── fd: ()-->(20,21)
+ │    │         │    ├── inner-join (hash)
+ │    │         │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:7!null cardsinfo.cardid:8!null cardsinfo.buyprice:9!null cardsinfo.sellprice:10!null cardsinfo.discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null cardsinfo.version:15!null
+ │    │         │    │    ├── stats: [rows=29618.4611, distinct(1)=19000, null(1)=0, distinct(2)=11668.1409, null(2)=0, distinct(5)=829, null(5)=0, distinct(6)=5572.85686, null(6)=0, distinct(7)=1, null(7)=0, distinct(8)=19000, null(8)=0, distinct(9)=21037.9959, null(9)=0, distinct(10)=21037.9959, null(10)=0, distinct(11)=21037.9959, null(11)=0, distinct(12)=21037.9959, null(12)=0, distinct(13)=21037.9959, null(13)=0, distinct(14)=21037.9959, null(14)=0, distinct(15)=23225.5851, null(15)=0]
+ │    │         │    │    ├── key: (8)
+ │    │         │    │    ├── fd: ()-->(7), (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(9-15), (15)-->(8-14), (1)==(8), (8)==(1)
+ │    │         │    │    ├── scan cardsinfo
+ │    │         │    │    │    ├── columns: cardsinfo.dealerid:7!null cardsinfo.cardid:8!null cardsinfo.buyprice:9!null cardsinfo.sellprice:10!null cardsinfo.discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null cardsinfo.version:15!null
+ │    │         │    │    │    ├── constraint: /7/8: [/1 - /1]
+ │    │         │    │    │    ├── stats: [rows=58333.3333, distinct(7)=1, null(7)=0, distinct(8)=37420.3552, null(8)=0, distinct(9)=40676.7278, null(9)=0, distinct(10)=40676.7278, null(10)=0, distinct(11)=40676.7278, null(11)=0, distinct(12)=40676.7278, null(12)=0, distinct(13)=40676.7278, null(13)=0, distinct(14)=40676.7278, null(14)=0, distinct(15)=58333.3333, null(15)=0]
+ │    │         │    │    │    ├── key: (8)
+ │    │         │    │    │    └── fd: ()-->(7), (8)-->(9-15), (15)-->(8-14)
+ │    │         │    │    ├── index-join cards
+ │    │         │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
+ │    │         │    │    │    ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0, distinct(5)=829, null(5)=0, distinct(6)=5601.15328, null(6)=0]
+ │    │         │    │    │    ├── key: (1)
+ │    │         │    │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6)
+ │    │         │    │    │    └── scan cards@cardsnamesetnumber
+ │    │         │    │    │         ├── columns: id:1!null name:2!null setname:4 number:5!null
+ │    │         │    │    │         ├── constraint: /2/4/5: [/'Shock'/'7E'/249 - ]
+ │    │         │    │    │         ├── stats: [rows=2111.11111, distinct(2)=2111.11111, null(2)=0, distinct(4)=54, null(4)=0, distinct(5)=276.333333, null(5)=0]
+ │    │         │    │    │         ├── key: (1)
+ │    │         │    │    │         └── fd: (1)-->(2,4,5), (2,4,5)~~>(1)
+ │    │         │    │    └── filters
+ │    │         │    │         └── id:1 = cardsinfo.cardid:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+ │    │         │    └── filters
+ │    │         │         └── transactiondetails.cardid:23 = id:1 [outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ]), fd=(1)==(23), (23)==(1)]
+ │    │         └── aggregations
+ │    │              ├── sum [as=sum:30, outer=(24)]
+ │    │              │    └── quantity:24
+ │    │              ├── const-agg [as=id:1, outer=(1)]
+ │    │              │    └── id:1
+ │    │              ├── const-agg [as=name:2, outer=(2)]
+ │    │              │    └── name:2
+ │    │              ├── const-agg [as=rarity:3, outer=(3)]
+ │    │              │    └── rarity:3
+ │    │              ├── const-agg [as=setname:4, outer=(4)]
+ │    │              │    └── setname:4
+ │    │              ├── const-agg [as=number:5, outer=(5)]
+ │    │              │    └── number:5
+ │    │              ├── const-agg [as=isfoil:6, outer=(6)]
+ │    │              │    └── isfoil:6
+ │    │              ├── const-agg [as=cardsinfo.buyprice:9, outer=(9)]
+ │    │              │    └── cardsinfo.buyprice:9
+ │    │              ├── const-agg [as=cardsinfo.sellprice:10, outer=(10)]
+ │    │              │    └── cardsinfo.sellprice:10
+ │    │              ├── const-agg [as=cardsinfo.discount:11, outer=(11)]
+ │    │              │    └── cardsinfo.discount:11
+ │    │              ├── const-agg [as=desiredinventory:12, outer=(12)]
+ │    │              │    └── desiredinventory:12
+ │    │              ├── const-agg [as=actualinventory:13, outer=(13)]
+ │    │              │    └── actualinventory:13
+ │    │              ├── const-agg [as=maxinventory:14, outer=(14)]
+ │    │              │    └── maxinventory:14
+ │    │              └── const-agg [as=cardsinfo.version:15, outer=(15)]
+ │    │                   └── cardsinfo.version:15
+ │    └── 50
+ └── projections
+      └── COALESCE(sum:30, 0) [as=value:31, outer=(30)]
+
+# Daily transaction query.
+#
+# Problems:
+#   1. CardsView is actually a join between Cards and CardsInfo tables. But the
+#      optimizer is missing join elimination rules. If those were available, we
+#      could eliminate the join to Cards (because of FK).
+#   2. Inequality predicate terms (accountname / customername) are too
+#      selective.
+#   3. The Date comparisons should be the last 7 days from the current
+#      timestamp. However, the current timestamp is not treated as a constant as
+#      it should be.
+#
+opt format=show-stats
+SELECT
+  extract(day from d.TransactionDate),
+  sum(d.SellPrice * d.Quantity) AS TotalSell,
+  sum(d.BuyPrice * d.Quantity) AS TotalBuy,
+  sum((d.SellPrice - d.BuyPrice) * d.Quantity) AS TotalProfit
+FROM TransactionDetailsView d, TransactionsView t, CardsView c
+WHERE
+  d.TransactionDate = t.Date AND
+  c.Id = d.CardId AND
+  NOT d.IsBuy AND
+  NOT t.IsBuy AND
+  t.Date BETWEEN '2020-03-01'::TIMESTAMPTZ - INTERVAL '7 days' AND '2020-03-01'::TIMESTAMPTZ AND
+  t.AccountName <> 'someaccount' AND
+  t.customername <> 'somecustomer'
+GROUP BY extract(day from d.TransactionDate)
+ORDER BY extract(day from d.TransactionDate)
+----
+group-by
+ ├── columns: extract:45 totalsell:40!null totalbuy:42!null totalprofit:44!null
+ ├── grouping columns: column45:45
+ ├── stats: [rows=12345.679, distinct(45)=12345.679, null(45)=0]
+ ├── key: (45)
+ ├── fd: (45)-->(40,42,44)
+ ├── ordering: +45
+ ├── sort
+ │    ├── columns: column39:39!null column41:41!null column43:43!null column45:45
+ │    ├── stats: [rows=12634.4671, distinct(45)=12345.679, null(45)=0]
+ │    ├── ordering: +45
+ │    └── project
+ │         ├── columns: column39:39!null column41:41!null column43:43!null column45:45
+ │         ├── stats: [rows=12634.4671, distinct(45)=12345.679, null(45)=0]
+ │         ├── inner-join (hash)
+ │         │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null id:20!null cardsinfo.dealerid:26!null cardsinfo.cardid:27!null
+ │         │    ├── stats: [rows=12634.4671, distinct(3)=12345.679, null(3)=0, distinct(4)=12634.4671, null(4)=0, distinct(13)=12345.679, null(13)=0, distinct(20)=12634.4671, null(20)=0]
+ │         │    ├── key: (5,13,27)
+ │         │    ├── fd: ()-->(1,2,11,12,26), (3-5)-->(6,7), (13)-->(14,15), (20)==(4,27), (27)==(4,20), (3)==(13), (13)==(3), (4)==(20,27)
+ │         │    ├── scan cardsinfo@cardsinfoversionindex
+ │         │    │    ├── columns: cardsinfo.dealerid:26!null cardsinfo.cardid:27!null
+ │         │    │    ├── constraint: /26/34: [/1 - /1]
+ │         │    │    ├── stats: [rows=58333.3333, distinct(26)=1, null(26)=0, distinct(27)=37420.3552, null(27)=0]
+ │         │    │    ├── key: (27)
+ │         │    │    └── fd: ()-->(26)
+ │         │    ├── inner-join (hash)
+ │         │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null id:20!null
+ │         │    │    ├── stats: [rows=12345.679, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=12345.679, null(3)=0, distinct(4)=12345.679, null(4)=0, distinct(5)=12267.872, null(5)=0, distinct(6)=12267.872, null(6)=0, distinct(7)=12267.872, null(7)=0, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=12345.679, null(13)=0, distinct(14)=7803.95639, null(14)=0, distinct(15)=7803.95639, null(15)=0, distinct(20)=12345.679, null(20)=0]
+ │         │    │    ├── key: (5,13,20)
+ │         │    │    ├── fd: ()-->(1,2,11,12), (13)-->(14,15), (3-5)-->(6,7), (3)==(13), (13)==(3), (4)==(20), (20)==(4)
+ │         │    │    ├── scan cards@cardsnamesetnumber
+ │         │    │    │    ├── columns: id:20!null
+ │         │    │    │    ├── stats: [rows=57000, distinct(20)=57000, null(20)=0]
+ │         │    │    │    └── key: (20)
+ │         │    │    ├── inner-join (hash)
+ │         │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null
+ │         │    │    │    ├── stats: [rows=12345.679, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=12345.679, null(3)=0, distinct(4)=11100.2211, null(4)=0, distinct(5)=12267.8812, null(5)=0, distinct(6)=12267.8812, null(6)=0, distinct(7)=12267.8812, null(7)=0, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=12345.679, null(13)=0, distinct(14)=7803.95979, null(14)=0, distinct(15)=7803.95979, null(15)=0]
+ │         │    │    │    ├── key: (4,5,13)
+ │         │    │    │    ├── fd: ()-->(1,2,11,12), (13)-->(14,15), (3-5)-->(6,7), (3)==(13), (13)==(3)
+ │         │    │    │    ├── scan transactiondetails
+ │         │    │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null
+ │         │    │    │    │    ├── constraint: /1/2/3/4/5: [/1/false/'2020-02-23 00:00:00+00:00' - /1/false/'2020-03-01 00:00:00+00:00']
+ │         │    │    │    │    ├── stats: [rows=1000000, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1000000, null(3)=0, distinct(4)=56999.9987, null(4)=0, distinct(5)=975366.793, null(5)=0, distinct(6)=975366.793, null(6)=0, distinct(7)=975366.793, null(7)=0]
+ │         │    │    │    │    ├── key: (3-5)
+ │         │    │    │    │    └── fd: ()-->(1,2), (3-5)-->(6,7)
+ │         │    │    │    ├── select
+ │         │    │    │    │    ├── columns: transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null
+ │         │    │    │    │    ├── stats: [rows=12345.679, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=12345.679, null(13)=0, distinct(14)=12345.679, null(14)=0, distinct(15)=12345.679, null(15)=0]
+ │         │    │    │    │    ├── key: (13)
+ │         │    │    │    │    ├── fd: ()-->(11,12), (13)-->(14,15)
+ │         │    │    │    │    ├── scan transactions
+ │         │    │    │    │    │    ├── columns: transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null
+ │         │    │    │    │    │    ├── constraint: /11/12/13: [/1/false/'2020-02-23 00:00:00+00:00' - /1/false/'2020-03-01 00:00:00+00:00']
+ │         │    │    │    │    │    ├── stats: [rows=111111.111, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=111111.111, null(13)=0]
+ │         │    │    │    │    │    ├── key: (13)
+ │         │    │    │    │    │    └── fd: ()-->(11,12), (13)-->(14,15)
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         ├── accountname:14 != 'someaccount' [outer=(14), constraints=(/14: (/NULL - /'someaccount') [/e'someaccount\x00' - ]; tight)]
+ │         │    │    │    │         └── customername:15 != 'somecustomer' [outer=(15), constraints=(/15: (/NULL - /'somecustomer') [/e'somecustomer\x00' - ]; tight)]
+ │         │    │    │    └── filters
+ │         │    │    │         └── transactiondate:3 = date:13 [outer=(3,13), constraints=(/3: (/NULL - ]; /13: (/NULL - ]), fd=(3)==(13), (13)==(3)]
+ │         │    │    └── filters
+ │         │    │         └── id:20 = transactiondetails.cardid:4 [outer=(4,20), constraints=(/4: (/NULL - ]; /20: (/NULL - ]), fd=(4)==(20), (20)==(4)]
+ │         │    └── filters
+ │         │         └── id:20 = cardsinfo.cardid:27 [outer=(20,27), constraints=(/20: (/NULL - ]; /27: (/NULL - ]), fd=(20)==(27), (27)==(20)]
+ │         └── projections
+ │              ├── transactiondetails.sellprice:6 * quantity:5 [as=column39:39, outer=(5,6)]
+ │              ├── transactiondetails.buyprice:7 * quantity:5 [as=column41:41, outer=(5,7)]
+ │              ├── quantity:5 * (transactiondetails.sellprice:6 - transactiondetails.buyprice:7) [as=column43:43, outer=(5-7)]
+ │              └── extract('day', transactiondate:3) [as=column45:45, outer=(3)]
+ └── aggregations
+      ├── sum [as=sum:40, outer=(39)]
+      │    └── column39:39
+      ├── sum [as=sum:42, outer=(41)]
+      │    └── column41:41
+      └── sum [as=sum:44, outer=(43)]
+           └── column43:43
+
+# Check if transaction was already inserted, for idempotency.
+#
+# Problems:
+#   1. Missing rule to transform AnyOp into ExistsOp when both the scalar
+#      inclusion value and subquery column are non-NULL.
+#
+# NOTE: This looks awkward, but it's adapted from stored procedure code.
+opt
+SELECT
+(
+  '70F03EB1-4F58-4C26-B72D-C524A9D537DD'::UUID IN
+  (
+    SELECT coalesce(OperationId, '00000000-0000-0000-0000-000000000000'::UUID)
+    FROM TransactionsView
+    WHERE IsBuy = FALSE
+  )
+) AS AlreadyInserted
+----
+values
+ ├── columns: alreadyinserted:11
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(11)
+ └── tuple
+      └── any: eq
+           ├── project
+           │    ├── columns: coalesce:10
+           │    ├── scan transactions
+           │    │    ├── columns: dealerid:1!null isbuy:2!null operationid:6
+           │    │    ├── constraint: /1/2/3: [/1/false - /1/false]
+           │    │    ├── lax-key: (6)
+           │    │    └── fd: ()-->(1,2)
+           │    └── projections
+           │         └── COALESCE(operationid:6, '00000000-0000-0000-0000-000000000000') [as=coalesce:10, outer=(6)]
+           └── '70f03eb1-4f58-4c26-b72d-c524a9d537dd'
+
+# Get account locations of a list of cards.
+#
+# Problems:
+#   1. WITH is not inlined into the query, because it is marked as having side
+#      effects, even though it does not.
+#   2. unnest should be folded into VALUES operator when it operates over
+#      constant ARRAY.
+opt
+WITH CardsToFind AS
+(
+  SELECT (IdAndQuantity).@1 AS Id, (IdAndQuantity).@2 AS Quantity
+  FROM unnest(ARRAY[(42948, 3), (24924, 4)]) AS IdAndQuantity
+)
+SELECT AccountName, sum(Quantity) AS Quantity
+FROM
+(
+    SELECT Id, AccountName, (CASE WHEN needed.Quantity < have.Quantity THEN needed.Quantity ELSE have.Quantity END) Quantity
+    FROM CardsToFind AS needed
+    INNER JOIN LATERAL
+    (
+        SELECT AccountName, Quantity
+        FROM InventoryDetails
+        WHERE (dealerid = 1 OR dealerid = 2 OR dealerid = 3 OR dealerid = 4 OR dealerid = 5) AND
+            CardId = Id AND AccountName = ANY ARRAY['account-1', 'account-2', 'account-3']
+    ) AS have
+    ON TRUE
+) AS allData
+GROUP BY AccountName
+ORDER BY sum(Quantity) DESC
+LIMIT 1000
+----
+sort
+ ├── columns: accountname:8!null quantity:14
+ ├── cardinality: [0 - 1000]
+ ├── side-effects
+ ├── key: (8)
+ ├── fd: (8)-->(14)
+ ├── ordering: -14
+ └── with &1 (cardstofind)
+      ├── columns: accountname:8!null sum:14
+      ├── cardinality: [0 - 1000]
+      ├── side-effects
+      ├── key: (8)
+      ├── fd: (8)-->(14)
+      ├── project
+      │    ├── columns: id:2 quantity:3
+      │    ├── side-effects
+      │    ├── project-set
+      │    │    ├── columns: unnest:1
+      │    │    ├── side-effects
+      │    │    ├── values
+      │    │    │    ├── cardinality: [1 - 1]
+      │    │    │    ├── key: ()
+      │    │    │    └── ()
+      │    │    └── zip
+      │    │         └── unnest(ARRAY[(42948, 3),(24924, 4)]) [side-effects]
+      │    └── projections
+      │         ├── (unnest:1).@1 [as=id:2, outer=(1)]
+      │         └── (unnest:1).@2 [as=quantity:3, outer=(1)]
+      └── limit
+           ├── columns: accountname:8!null sum:14
+           ├── internal-ordering: -14
+           ├── cardinality: [0 - 1000]
+           ├── key: (8)
+           ├── fd: (8)-->(14)
+           ├── sort
+           │    ├── columns: accountname:8!null sum:14
+           │    ├── key: (8)
+           │    ├── fd: (8)-->(14)
+           │    ├── ordering: -14
+           │    ├── limit hint: 1000.00
+           │    └── group-by
+           │         ├── columns: accountname:8!null sum:14
+           │         ├── grouping columns: accountname:8!null
+           │         ├── key: (8)
+           │         ├── fd: (8)-->(14)
+           │         ├── project
+           │         │    ├── columns: quantity:13 accountname:8!null
+           │         │    ├── inner-join (lookup inventorydetails)
+           │         │    │    ├── columns: id:4!null quantity:5 dealerid:6!null cardid:7!null accountname:8!null inventorydetails.quantity:9!null
+           │         │    │    ├── key columns: [6 7 8] = [6 7 8]
+           │         │    │    ├── lookup columns are key
+           │         │    │    ├── fd: (6-8)-->(9), (4)==(7), (7)==(4)
+           │         │    │    ├── inner-join (lookup inventorydetails@inventorydetails_auto_index_inventorydetailscardidkey)
+           │         │    │    │    ├── columns: id:4!null quantity:5 dealerid:6!null cardid:7!null accountname:8!null
+           │         │    │    │    ├── key columns: [4] = [7]
+           │         │    │    │    ├── fd: (4)==(7), (7)==(4)
+           │         │    │    │    ├── with-scan &1 (cardstofind)
+           │         │    │    │    │    ├── columns: id:4 quantity:5
+           │         │    │    │    │    └── mapping:
+           │         │    │    │    │         ├──  id:2 => id:4
+           │         │    │    │    │         └──  quantity:3 => quantity:5
+           │         │    │    │    └── filters
+           │         │    │    │         ├── ((((dealerid:6 = 1) OR (dealerid:6 = 2)) OR (dealerid:6 = 3)) OR (dealerid:6 = 4)) OR (dealerid:6 = 5) [outer=(6), constraints=(/6: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
+           │         │    │    │         └── accountname:8 IN ('account-1', 'account-2', 'account-3') [outer=(8), constraints=(/8: [/'account-1' - /'account-1'] [/'account-2' - /'account-2'] [/'account-3' - /'account-3']; tight)]
+           │         │    │    └── filters (true)
+           │         │    └── projections
+           │         │         └── CASE WHEN quantity:5 < inventorydetails.quantity:9 THEN quantity:5 ELSE inventorydetails.quantity:9 END [as=quantity:13, outer=(5,9)]
+           │         └── aggregations
+           │              └── sum [as=sum:14, outer=(13)]
+           │                   └── quantity:13
+           └── 1000
+
+# Get buy/sell volume of a particular card in the last 2 days.
+#
+# Problems:
+#   1. Multiple duplicate predicates. Scan is already constraining CardId,
+#      IsBuy, and TransactionDate. But filters still contain those checks.
+#
+opt
+SELECT coalesce((
+    SELECT sum(Quantity) AS Volume
+    FROM
+    (
+        SELECT d.Quantity
+        FROM TransactionDetails d
+        INNER JOIN Transactions t
+        ON d.dealerid = t.dealerid AND d.isbuy = t.isbuy AND d.transactiondate = t.date
+        WHERE
+          (d.dealerid = 1 OR d.dealerid = 2 OR d.dealerid = 3 OR d.dealerid = 4 OR d.dealerid = 5) AND
+          d.isbuy IN (TRUE, FALSE) AND
+          d.cardid = 19483 AND
+          d.transactiondate BETWEEN '2020-03-01'::TIMESTAMPTZ - INTERVAL '2 days' AND '2020-03-01'::TIMESTAMPTZ
+        ORDER BY TransactionDate DESC
+        LIMIT 100
+    ) t
+), 0)
+----
+values
+ ├── columns: coalesce:21
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(21)
+ └── tuple
+      └── coalesce
+           ├── subquery
+           │    └── scalar-group-by
+           │         ├── columns: sum:20
+           │         ├── cardinality: [1 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(20)
+           │         ├── limit
+           │         │    ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null t.dealerid:11!null t.isbuy:12!null date:13!null
+           │         │    ├── internal-ordering: -(3|13) opt(4)
+           │         │    ├── cardinality: [0 - 100]
+           │         │    ├── key: (5,11-13)
+           │         │    ├── fd: ()-->(4), (1)==(11), (11)==(1), (2)==(12), (12)==(2), (3)==(13), (13)==(3)
+           │         │    ├── sort
+           │         │    │    ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null t.dealerid:11!null t.isbuy:12!null date:13!null
+           │         │    │    ├── key: (5,11-13)
+           │         │    │    ├── fd: ()-->(4), (1)==(11), (11)==(1), (2)==(12), (12)==(2), (3)==(13), (13)==(3)
+           │         │    │    ├── ordering: -(3|13) opt(4) [actual: -3]
+           │         │    │    ├── limit hint: 100.00
+           │         │    │    └── inner-join (lookup transactions)
+           │         │    │         ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null t.dealerid:11!null t.isbuy:12!null date:13!null
+           │         │    │         ├── key columns: [1 2 3] = [11 12 13]
+           │         │    │         ├── lookup columns are key
+           │         │    │         ├── key: (5,11-13)
+           │         │    │         ├── fd: ()-->(4), (1)==(11), (11)==(1), (2)==(12), (12)==(2), (3)==(13), (13)==(3)
+           │         │    │         ├── select
+           │         │    │         │    ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null
+           │         │    │         │    ├── key: (1-3,5)
+           │         │    │         │    ├── fd: ()-->(4)
+           │         │    │         │    ├── scan d@transactiondetails_auto_index_detailscardidkey
+           │         │    │         │    │    ├── columns: d.dealerid:1!null d.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null
+           │         │    │         │    │    ├── constraint: /4/1/2/3/5
+           │         │    │         │    │    │    ├── [/19483/1/false/'2020-02-28 00:00:00+00:00' - /19483/1/false/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    │    ├── [/19483/1/true/'2020-02-28 00:00:00+00:00' - /19483/1/true/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    │    ├── [/19483/2/false/'2020-02-28 00:00:00+00:00' - /19483/2/false/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    │    ├── [/19483/2/true/'2020-02-28 00:00:00+00:00' - /19483/2/true/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    │    ├── [/19483/3/false/'2020-02-28 00:00:00+00:00' - /19483/3/false/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    │    ├── [/19483/3/true/'2020-02-28 00:00:00+00:00' - /19483/3/true/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    │    ├── [/19483/4/false/'2020-02-28 00:00:00+00:00' - /19483/4/false/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    │    ├── [/19483/4/true/'2020-02-28 00:00:00+00:00' - /19483/4/true/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    │    ├── [/19483/5/false/'2020-02-28 00:00:00+00:00' - /19483/5/false/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    │    └── [/19483/5/true/'2020-02-28 00:00:00+00:00' - /19483/5/true/'2020-03-01 00:00:00+00:00']
+           │         │    │         │    │    ├── key: (1-3,5)
+           │         │    │         │    │    └── fd: ()-->(4)
+           │         │    │         │    └── filters
+           │         │    │         │         └── ((((d.dealerid:1 = 1) OR (d.dealerid:1 = 2)) OR (d.dealerid:1 = 3)) OR (d.dealerid:1 = 4)) OR (d.dealerid:1 = 5) [outer=(1), constraints=(/1: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
+           │         │    │         └── filters
+           │         │    │              ├── (date:13 >= '2020-02-28 00:00:00+00:00') AND (date:13 <= '2020-03-01 00:00:00+00:00') [outer=(13), constraints=(/13: [/'2020-02-28 00:00:00+00:00' - /'2020-03-01 00:00:00+00:00']; tight)]
+           │         │    │              ├── ((((t.dealerid:11 = 1) OR (t.dealerid:11 = 2)) OR (t.dealerid:11 = 3)) OR (t.dealerid:11 = 4)) OR (t.dealerid:11 = 5) [outer=(11), constraints=(/11: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
+           │         │    │              └── t.isbuy:12 IN (false, true) [outer=(12), constraints=(/12: [/false - /false] [/true - /true]; tight)]
+           │         │    └── 100
+           │         └── aggregations
+           │              └── sum [as=sum:20, outer=(5)]
+           │                   └── quantity:5
+           └── 0
+
+# --------------------------------------------------
+# INSERT/UPDATE/DELETE/UPSERT Queries
+# --------------------------------------------------
+
+# Insert buy or sell transaction.
+opt
+INSERT INTO Transactions (dealerid, isbuy, date, accountname, customername, operationid)
+VALUES (1, FALSE, '2020-03-01', 'the-account', 'the-customer', '70F03EB1-4F58-4C26-B72D-C524A9D537DD')
+----
+insert transactions
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:10 => dealerid:1
+ │    ├── column2:11 => isbuy:2
+ │    ├── column3:12 => date:3
+ │    ├── column4:13 => accountname:4
+ │    ├── column5:14 => customername:5
+ │    ├── column6:15 => operationid:6
+ │    ├── column16:16 => version:7
+ │    └── column17:17 => olddate:8
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── values
+      ├── columns: column1:10!null column2:11!null column3:12!null column4:13!null column5:14!null column6:15!null column16:16 column17:17!null
+      ├── cardinality: [1 - 1]
+      ├── side-effects
+      ├── key: ()
+      ├── fd: ()-->(10-17)
+      └── (1, false, '2020-03-01 00:00:00+00:00', 'the-account', 'the-customer', '70f03eb1-4f58-4c26-b72d-c524a9d537dd', cluster_logical_timestamp(), '0001-01-01 00:00:00+00:00')
+
+# Upsert buy or sell transaction.
+opt
+UPSERT INTO Transactions (dealerid, isbuy, date, accountname, customername, operationid)
+VALUES (1, FALSE, '2020-03-01', 'the-account', 'the-customer', '70F03EB1-4F58-4C26-B72D-C524A9D537DD')
+----
+upsert transactions
+ ├── columns: <none>
+ ├── canary column: 18
+ ├── fetch columns: dealerid:18 isbuy:19 date:20 accountname:21 customername:22 operationid:23 version:24 olddate:25 extra:26
+ ├── insert-mapping:
+ │    ├── column1:10 => dealerid:1
+ │    ├── column2:11 => isbuy:2
+ │    ├── column3:12 => date:3
+ │    ├── column4:13 => accountname:4
+ │    ├── column5:14 => customername:5
+ │    ├── column6:15 => operationid:6
+ │    ├── column16:16 => version:7
+ │    └── column17:17 => olddate:8
+ ├── update-mapping:
+ │    ├── column4:13 => accountname:4
+ │    ├── column5:14 => customername:5
+ │    ├── column6:15 => operationid:6
+ │    └── column17:17 => olddate:8
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── left-join (cross)
+      ├── columns: column1:10!null column2:11!null column3:12!null column4:13!null column5:14!null column6:15!null column16:16 column17:17!null dealerid:18 isbuy:19 date:20 accountname:21 customername:22 operationid:23 version:24 olddate:25 extra:26
+      ├── cardinality: [1 - 1]
+      ├── side-effects
+      ├── key: ()
+      ├── fd: ()-->(10-26)
+      ├── values
+      │    ├── columns: column1:10!null column2:11!null column3:12!null column4:13!null column5:14!null column6:15!null column16:16 column17:17!null
+      │    ├── cardinality: [1 - 1]
+      │    ├── side-effects
+      │    ├── key: ()
+      │    ├── fd: ()-->(10-17)
+      │    └── (1, false, '2020-03-01 00:00:00+00:00', 'the-account', 'the-customer', '70f03eb1-4f58-4c26-b72d-c524a9d537dd', cluster_logical_timestamp(), '0001-01-01 00:00:00+00:00')
+      ├── scan transactions
+      │    ├── columns: dealerid:18!null isbuy:19!null date:20!null accountname:21!null customername:22!null operationid:23 version:24!null olddate:25 extra:26
+      │    ├── constraint: /18/19/20: [/1/false/'2020-03-01 00:00:00+00:00' - /1/false/'2020-03-01 00:00:00+00:00']
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    └── fd: ()-->(18-26)
+      └── filters (true)
+
+# Insert structured data (c=CardId, q=Quantity, s=SellPrice, b=BuyPrice)
+# represented as JSON into TransactionDetails table.
+#
+# Problems:
+#   1. WITH is not inlined into the query, because it is marked as having side
+#      effects, even though it does not.
+#   2. jsonb_array_elements should be folded into VALUES operator when it
+#      operates over constant JSON.
+#
+opt
+WITH updates AS (SELECT jsonb_array_elements('[
+    {"c": 49833, "q": 4, "s": 2.89, "b": 2.29},
+    {"c": 29483, "q": 2, "s": 18.93, "b": 17.59}
+  ]'::JSONB
+) AS Detail)
+UPSERT INTO TransactionDetails
+(dealerid, isbuy, transactiondate, cardid, quantity, sellprice, buyprice)
+SELECT
+  1, FALSE, current_timestamp(), (Detail->'c')::TEXT::INT, (Detail->'q')::TEXT::INT,
+  (Detail->'s')::TEXT::DECIMAL(10,4), (Detail->'b')::TEXT::DECIMAL(10,4)
+FROM updates
+----
+with &1 (updates)
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ ├── project-set
+ │    ├── columns: jsonb_array_elements:1
+ │    ├── side-effects
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── ()
+ │    └── zip
+ │         └── jsonb_array_elements('[{"b": 2.29, "c": 49833, "q": 4, "s": 2.89}, {"b": 17.59, "c": 29483, "q": 2, "s": 18.93}]') [side-effects]
+ └── upsert transactiondetails
+      ├── columns: <none>
+      ├── canary column: 25
+      ├── fetch columns: transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondate:27 cardid:28 quantity:29 transactiondetails.sellprice:30 transactiondetails.buyprice:31 transactiondetails.version:32 transactiondetails.discount:33 transactiondetails.extra:34
+      ├── insert-mapping:
+      │    ├── "?column?":13 => transactiondetails.dealerid:2
+      │    ├── bool:14 => transactiondetails.isbuy:3
+      │    ├── current_timestamp:15 => transactiondate:4
+      │    ├── int8:16 => cardid:5
+      │    ├── int8:17 => quantity:6
+      │    ├── sellprice:35 => transactiondetails.sellprice:7
+      │    ├── buyprice:36 => transactiondetails.buyprice:8
+      │    ├── column20:20 => transactiondetails.version:9
+      │    └── discount:24 => transactiondetails.discount:10
+      ├── update-mapping:
+      │    ├── sellprice:35 => transactiondetails.sellprice:7
+      │    ├── buyprice:36 => transactiondetails.buyprice:8
+      │    └── upsert_discount:44 => transactiondetails.discount:10
+      ├── input binding: &2
+      ├── cardinality: [0 - 0]
+      ├── side-effects, mutations
+      ├── project
+      │    ├── columns: upsert_dealerid:38 upsert_isbuy:39 upsert_transactiondate:40 upsert_cardid:41 upsert_discount:44 sellprice:35 buyprice:36 "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17 column20:20 discount:24 transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondate:27 cardid:28 quantity:29 transactiondetails.sellprice:30 transactiondetails.buyprice:31 transactiondetails.version:32 transactiondetails.discount:33 transactiondetails.extra:34
+      │    ├── side-effects
+      │    ├── lax-key: (15-17,25-29)
+      │    ├── fd: ()-->(13,14,24), (15-17)~~>(20), (25-29)-->(30-34), (25)-->(38), (25,26)-->(39), (15,25,27)-->(40), (16,25,28)-->(41), (15-17,25-29)~~>(20,35,36,44)
+      │    ├── left-join (lookup transactiondetails)
+      │    │    ├── columns: "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17 column20:20 sellprice:22 buyprice:23 discount:24 transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondate:27 cardid:28 quantity:29 transactiondetails.sellprice:30 transactiondetails.buyprice:31 transactiondetails.version:32 transactiondetails.discount:33 transactiondetails.extra:34
+      │    │    ├── key columns: [13 14 15 16 17] = [25 26 27 28 29]
+      │    │    ├── lookup columns are key
+      │    │    ├── side-effects
+      │    │    ├── lax-key: (15-17,25-29)
+      │    │    ├── fd: ()-->(13,14,24), (15-17)~~>(20,22,23), (25-29)-->(30-34)
+      │    │    ├── upsert-distinct-on
+      │    │    │    ├── columns: "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17 column20:20 sellprice:22 buyprice:23 discount:24
+      │    │    │    ├── grouping columns: current_timestamp:15 int8:16 int8:17
+      │    │    │    ├── error-on-dup
+      │    │    │    ├── side-effects
+      │    │    │    ├── lax-key: (15-17)
+      │    │    │    ├── fd: ()-->(13,14,24), (15-17)~~>(13,14,20,22-24)
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: sellprice:22 buyprice:23 discount:24 column20:20 "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17
+      │    │    │    │    ├── side-effects
+      │    │    │    │    ├── fd: ()-->(13,14,24)
+      │    │    │    │    ├── with-scan &1 (updates)
+      │    │    │    │    │    ├── columns: detail:12
+      │    │    │    │    │    └── mapping:
+      │    │    │    │    │         └──  jsonb_array_elements:1 => detail:12
+      │    │    │    │    └── projections
+      │    │    │    │         ├── crdb_internal.round_decimal_values((detail:12->'s')::STRING::DECIMAL(10,4), 4) [as=sellprice:22, outer=(12)]
+      │    │    │    │         ├── crdb_internal.round_decimal_values((detail:12->'b')::STRING::DECIMAL(10,4), 4) [as=buyprice:23, outer=(12)]
+      │    │    │    │         ├── crdb_internal.round_decimal_values(0.00001, 4) [as=discount:24]
+      │    │    │    │         ├── cluster_logical_timestamp() [as=column20:20, side-effects]
+      │    │    │    │         ├── 1 [as="?column?":13]
+      │    │    │    │         ├── false [as=bool:14]
+      │    │    │    │         ├── current_timestamp() [as=current_timestamp:15, side-effects]
+      │    │    │    │         ├── (detail:12->'c')::STRING::INT8 [as=int8:16, outer=(12)]
+      │    │    │    │         └── (detail:12->'q')::STRING::INT8 [as=int8:17, outer=(12)]
+      │    │    │    └── aggregations
+      │    │    │         ├── first-agg [as=sellprice:22, outer=(22)]
+      │    │    │         │    └── sellprice:22
+      │    │    │         ├── first-agg [as=buyprice:23, outer=(23)]
+      │    │    │         │    └── buyprice:23
+      │    │    │         ├── first-agg [as=column20:20, outer=(20)]
+      │    │    │         │    └── column20:20
+      │    │    │         ├── first-agg [as=discount:24, outer=(24)]
+      │    │    │         │    └── discount:24
+      │    │    │         ├── const-agg [as="?column?":13, outer=(13)]
+      │    │    │         │    └── "?column?":13
+      │    │    │         └── const-agg [as=bool:14, outer=(14)]
+      │    │    │              └── bool:14
+      │    │    └── filters (true)
+      │    └── projections
+      │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN "?column?":13 ELSE transactiondetails.dealerid:25 END [as=upsert_dealerid:38, outer=(13,25)]
+      │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN bool:14 ELSE transactiondetails.isbuy:26 END [as=upsert_isbuy:39, outer=(14,25,26)]
+      │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN current_timestamp:15 ELSE transactiondate:27 END [as=upsert_transactiondate:40, outer=(15,25,27)]
+      │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN int8:16 ELSE cardid:28 END [as=upsert_cardid:41, outer=(16,25,28)]
+      │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN discount:24 ELSE crdb_internal.round_decimal_values(discount:24, 4) END [as=upsert_discount:44, outer=(24,25)]
+      │         ├── crdb_internal.round_decimal_values(sellprice:22, 4) [as=sellprice:35, outer=(22)]
+      │         └── crdb_internal.round_decimal_values(buyprice:23, 4) [as=buyprice:36, outer=(23)]
+      └── f-k-checks
+           ├── f-k-checks-item: transactiondetails(dealerid,isbuy,transactiondate) -> transactions(dealerid,isbuy,date)
+           │    └── anti-join (lookup transactions)
+           │         ├── columns: upsert_dealerid:45 upsert_isbuy:46 upsert_transactiondate:47
+           │         ├── key columns: [45 46 47] = [48 49 50]
+           │         ├── lookup columns are key
+           │         ├── with-scan &2
+           │         │    ├── columns: upsert_dealerid:45 upsert_isbuy:46 upsert_transactiondate:47
+           │         │    └── mapping:
+           │         │         ├──  upsert_dealerid:38 => upsert_dealerid:45
+           │         │         ├──  upsert_isbuy:39 => upsert_isbuy:46
+           │         │         └──  upsert_transactiondate:40 => upsert_transactiondate:47
+           │         └── filters (true)
+           └── f-k-checks-item: transactiondetails(cardid) -> cards(id)
+                └── anti-join (lookup cards)
+                     ├── columns: upsert_cardid:57
+                     ├── key columns: [57] = [58]
+                     ├── lookup columns are key
+                     ├── with-scan &2
+                     │    ├── columns: upsert_cardid:57
+                     │    └── mapping:
+                     │         └──  upsert_cardid:41 => upsert_cardid:57
+                     └── filters (true)
+
+# Delete inventory detail rows to reflect card transfers.
+opt
+DELETE FROM InventoryDetails
+WHERE dealerid = 1 AND accountname = 'some-account' AND cardid = ANY ARRAY[29483, 1793, 294]
+----
+delete inventorydetails
+ ├── columns: <none>
+ ├── fetch columns: dealerid:8 cardid:9 accountname:10
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── scan inventorydetails@inventorydetails_auto_index_inventorydetailscardidkey
+      ├── columns: dealerid:8!null cardid:9!null accountname:10!null
+      ├── constraint: /9/8/10
+      │    ├── [/294/1/'some-account' - /294/1/'some-account']
+      │    ├── [/1793/1/'some-account' - /1793/1/'some-account']
+      │    └── [/29483/1/'some-account' - /29483/1/'some-account']
+      ├── cardinality: [0 - 3]
+      ├── key: (9)
+      └── fd: ()-->(8,10)
+
+# Update CardsInfo inventory numbers (by CardId, Quantity) to reflect card
+# transfers.
+#
+# Problems:
+#   1. WITH is not inlined into the query, because it is marked as having side
+#      effects, even though it does not.
+#   2. unnest should be folded into VALUES operator when it operates over
+#      constant ARRAY.
+opt
+WITH Updates AS
+(
+  SELECT (Detail).@1 AS c, (Detail).@2 AS q
+  FROM unnest(ARRAY[(42948, 3), (24924, 4)]) AS Detail
+)
+UPDATE CardsInfo ci
+SET actualinventory = (SELECT coalesce(sum_INT(quantity), 0)
+                       FROM InventoryDetails id
+                       WHERE dealerid = 1 AND id.cardid = ci.cardid)
+FROM Updates
+WHERE ci.cardid = Updates.c AND ci.dealerid = 1
+----
+with &1 (updates)
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ ├── project
+ │    ├── columns: c:2 q:3
+ │    ├── side-effects
+ │    ├── project-set
+ │    │    ├── columns: unnest:1
+ │    │    ├── side-effects
+ │    │    ├── values
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    └── ()
+ │    │    └── zip
+ │    │         └── unnest(ARRAY[(42948, 3),(24924, 4)]) [side-effects]
+ │    └── projections
+ │         ├── (unnest:1).@1 [as=c:2, outer=(1)]
+ │         └── (unnest:1).@2 [as=q:3, outer=(1)]
+ └── update ci
+      ├── columns: <none>
+      ├── fetch columns: ci.dealerid:17 ci.cardid:18 buyprice:19 sellprice:20 discount:21 desiredinventory:22 actualinventory:23 maxinventory:24 ci.version:25 ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29
+      ├── update-mapping:
+      │    ├── column41:41 => actualinventory:10
+      │    ├── discountbuyprice:45 => ci.discountbuyprice:13
+      │    ├── column42:42 => notes:14
+      │    └── column43:43 => oldinventory:15
+      ├── cardinality: [0 - 0]
+      ├── side-effects, mutations
+      └── project
+           ├── columns: discountbuyprice:45 column42:42 column43:43!null column41:41 ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31
+           ├── key: (18)
+           ├── fd: ()-->(17,42,43), (18)-->(19-31,41,45), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
+           ├── group-by
+           │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31 sum_int:39
+           │    ├── grouping columns: ci.cardid:18!null
+           │    ├── key: (18)
+           │    ├── fd: ()-->(17), (18)-->(17,19-31,39), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
+           │    ├── left-join (lookup inventorydetails)
+           │    │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31 id.dealerid:32 id.cardid:33 quantity:35
+           │    │    ├── key columns: [49 18] = [32 33]
+           │    │    ├── fd: ()-->(17), (18)-->(19-31), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
+           │    │    ├── project
+           │    │    │    ├── columns: "project_const_col_@32":49!null ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31
+           │    │    │    ├── key: (18)
+           │    │    │    ├── fd: ()-->(17,49), (18)-->(19-31), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
+           │    │    │    ├── distinct-on
+           │    │    │    │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31
+           │    │    │    │    ├── grouping columns: ci.cardid:18!null
+           │    │    │    │    ├── key: (18)
+           │    │    │    │    ├── fd: ()-->(17), (18)-->(17,19-31), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
+           │    │    │    │    ├── inner-join (lookup cardsinfo)
+           │    │    │    │    │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31
+           │    │    │    │    │    ├── key columns: [46 30] = [17 18]
+           │    │    │    │    │    ├── lookup columns are key
+           │    │    │    │    │    ├── fd: ()-->(17), (18)-->(19-29), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
+           │    │    │    │    │    ├── project
+           │    │    │    │    │    │    ├── columns: "project_const_col_@17":46!null c:30 q:31
+           │    │    │    │    │    │    ├── fd: ()-->(46)
+           │    │    │    │    │    │    ├── with-scan &1 (updates)
+           │    │    │    │    │    │    │    ├── columns: c:30 q:31
+           │    │    │    │    │    │    │    └── mapping:
+           │    │    │    │    │    │    │         ├──  c:2 => c:30
+           │    │    │    │    │    │    │         └──  q:3 => q:31
+           │    │    │    │    │    │    └── projections
+           │    │    │    │    │    │         └── 1 [as="project_const_col_@17":46]
+           │    │    │    │    │    └── filters (true)
+           │    │    │    │    └── aggregations
+           │    │    │    │         ├── first-agg [as=buyprice:19, outer=(19)]
+           │    │    │    │         │    └── buyprice:19
+           │    │    │    │         ├── first-agg [as=sellprice:20, outer=(20)]
+           │    │    │    │         │    └── sellprice:20
+           │    │    │    │         ├── first-agg [as=discount:21, outer=(21)]
+           │    │    │    │         │    └── discount:21
+           │    │    │    │         ├── first-agg [as=desiredinventory:22, outer=(22)]
+           │    │    │    │         │    └── desiredinventory:22
+           │    │    │    │         ├── first-agg [as=actualinventory:23, outer=(23)]
+           │    │    │    │         │    └── actualinventory:23
+           │    │    │    │         ├── first-agg [as=maxinventory:24, outer=(24)]
+           │    │    │    │         │    └── maxinventory:24
+           │    │    │    │         ├── first-agg [as=ci.version:25, outer=(25)]
+           │    │    │    │         │    └── ci.version:25
+           │    │    │    │         ├── first-agg [as=ci.discountbuyprice:26, outer=(26)]
+           │    │    │    │         │    └── ci.discountbuyprice:26
+           │    │    │    │         ├── first-agg [as=notes:27, outer=(27)]
+           │    │    │    │         │    └── notes:27
+           │    │    │    │         ├── first-agg [as=oldinventory:28, outer=(28)]
+           │    │    │    │         │    └── oldinventory:28
+           │    │    │    │         ├── first-agg [as=ci.extra:29, outer=(29)]
+           │    │    │    │         │    └── ci.extra:29
+           │    │    │    │         ├── first-agg [as=c:30, outer=(30)]
+           │    │    │    │         │    └── c:30
+           │    │    │    │         ├── first-agg [as=q:31, outer=(31)]
+           │    │    │    │         │    └── q:31
+           │    │    │    │         └── const-agg [as=ci.dealerid:17, outer=(17)]
+           │    │    │    │              └── ci.dealerid:17
+           │    │    │    └── projections
+           │    │    │         └── 1 [as="project_const_col_@32":49]
+           │    │    └── filters (true)
+           │    └── aggregations
+           │         ├── sum-int [as=sum_int:39, outer=(35)]
+           │         │    └── quantity:35
+           │         ├── const-agg [as=ci.dealerid:17, outer=(17)]
+           │         │    └── ci.dealerid:17
+           │         ├── const-agg [as=buyprice:19, outer=(19)]
+           │         │    └── buyprice:19
+           │         ├── const-agg [as=sellprice:20, outer=(20)]
+           │         │    └── sellprice:20
+           │         ├── const-agg [as=discount:21, outer=(21)]
+           │         │    └── discount:21
+           │         ├── const-agg [as=desiredinventory:22, outer=(22)]
+           │         │    └── desiredinventory:22
+           │         ├── const-agg [as=actualinventory:23, outer=(23)]
+           │         │    └── actualinventory:23
+           │         ├── const-agg [as=maxinventory:24, outer=(24)]
+           │         │    └── maxinventory:24
+           │         ├── const-agg [as=ci.version:25, outer=(25)]
+           │         │    └── ci.version:25
+           │         ├── const-agg [as=ci.discountbuyprice:26, outer=(26)]
+           │         │    └── ci.discountbuyprice:26
+           │         ├── const-agg [as=notes:27, outer=(27)]
+           │         │    └── notes:27
+           │         ├── const-agg [as=oldinventory:28, outer=(28)]
+           │         │    └── oldinventory:28
+           │         ├── const-agg [as=ci.extra:29, outer=(29)]
+           │         │    └── ci.extra:29
+           │         ├── const-agg [as=c:30, outer=(30)]
+           │         │    └── c:30
+           │         └── const-agg [as=q:31, outer=(31)]
+           │              └── q:31
+           └── projections
+                ├── crdb_internal.round_decimal_values(buyprice:19 - discount:21, 4) [as=discountbuyprice:45, outer=(19,21)]
+                ├── CAST(NULL AS STRING) [as=column42:42]
+                ├── 0 [as=column43:43]
+                └── COALESCE(sum_int:39, 0) [as=column41:41, outer=(39)]

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -961,7 +961,7 @@ func (rf *Fetcher) processValueSingle(
 	if rf.traceKV || table.neededCols.Contains(int(colID)) {
 		if idx, ok := table.colIdxMap[colID]; ok {
 			if rf.traceKV {
-				prettyKey = fmt.Sprintf("%s/%s", prettyKey, table.desc.Columns[idx].Name)
+				prettyKey = fmt.Sprintf("%s/%s", prettyKey, table.desc.DeletableColumns()[idx].Name)
 			}
 			if len(kv.Value.RawBytes) == 0 {
 				return prettyKey, "", nil
@@ -1036,7 +1036,7 @@ func (rf *Fetcher) processValueBytes(
 		idx := table.colIdxMap[colID]
 
 		if rf.traceKV {
-			prettyKey = fmt.Sprintf("%s/%s", prettyKey, table.desc.Columns[idx].Name)
+			prettyKey = fmt.Sprintf("%s/%s", prettyKey, table.desc.DeletableColumns()[idx].Name)
 		}
 
 		var encValue sqlbase.EncDatum

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -824,6 +824,7 @@ func (d *DFloat) Next(_ *EvalContext) (Datum, bool) {
 	return NewDFloat(DFloat(math.Nextafter(f, math.Inf(+1)))), true
 }
 
+var dZeroFloat = NewDFloat(0.0)
 var dPosInfFloat = NewDFloat(DFloat(math.Inf(+1)))
 var dNegInfFloat = NewDFloat(DFloat(math.Inf(-1)))
 var dNaNFloat = NewDFloat(DFloat(math.NaN()))
@@ -989,6 +990,7 @@ func (d *DDecimal) Next(_ *EvalContext) (Datum, bool) {
 	return nil, false
 }
 
+var dZeroDecimal = &DDecimal{Decimal: apd.Decimal{}}
 var dPosInfDecimal = &DDecimal{Decimal: apd.Decimal{Form: apd.Infinite, Negative: false}}
 var dNaNDecimal = &DDecimal{Decimal: apd.Decimal{Form: apd.NaN}}
 
@@ -1780,10 +1782,12 @@ func (d *DDate) Compare(ctx *EvalContext, other Datum) int {
 }
 
 var (
-	dMaxDate  = NewDDate(pgdate.PosInfDate)
-	dMinDate  = NewDDate(pgdate.NegInfDate)
-	dLowDate  = NewDDate(pgdate.LowDate)
-	dHighDate = NewDDate(pgdate.HighDate)
+	epochDate, _ = pgdate.MakeDateFromPGEpoch(0)
+	dEpochDate   = NewDDate(epochDate)
+	dMaxDate     = NewDDate(pgdate.PosInfDate)
+	dMinDate     = NewDDate(pgdate.NegInfDate)
+	dLowDate     = NewDDate(pgdate.LowDate)
+	dHighDate    = NewDDate(pgdate.HighDate)
 )
 
 // Prev implements the Datum interface.
@@ -1971,6 +1975,8 @@ func MakeDTimestamp(t time.Time, precision time.Duration) *DTimestamp {
 	return &DTimestamp{Time: t.Round(precision)}
 }
 
+var dMinTimestamp = &DTimestamp{}
+
 // time.Time formats.
 const (
 	// TimestampOutputFormat is used to output all timestamps.
@@ -2152,6 +2158,8 @@ func ParseDTimestampTZ(
 	}
 	return MakeDTimestampTZ(t, precision), nil
 }
+
+var dMinTimestampTZ = &DTimestampTZ{}
 
 // AsDTimestampTZ attempts to retrieve a DTimestampTZ from an Expr, returning a
 // DTimestampTZ and a flag signifying whether the assertion was successful. The
@@ -2432,8 +2440,9 @@ func (d *DInterval) IsMin(_ *EvalContext) bool {
 }
 
 var (
-	dMaxInterval = &DInterval{duration.MakeDuration(math.MaxInt64, math.MaxInt64, math.MaxInt64)}
-	dMinInterval = &DInterval{duration.MakeDuration(math.MinInt64, math.MinInt64, math.MinInt64)}
+	dZeroInterval = &DInterval{}
+	dMaxInterval  = &DInterval{duration.MakeDuration(math.MaxInt64, math.MaxInt64, math.MaxInt64)}
+	dMinInterval  = &DInterval{duration.MakeDuration(math.MinInt64, math.MinInt64, math.MinInt64)}
 )
 
 // Max implements the Datum interface.
@@ -2504,6 +2513,8 @@ func MakeDJSON(d interface{}) (Datum, error) {
 	}
 	return &DJSON{j}, nil
 }
+
+var dNullJSON = NewDJSON(json.NullJSONValue)
 
 // AsDJSON attempts to retrieve a *DJSON from an Expr, returning a *DJSON and
 // a flag signifying whether the assertion was successful. The function should
@@ -3674,6 +3685,64 @@ func NewDOidVectorFromDArray(d *DArray) Datum {
 	*ret = *d
 	ret.customOid = oid.T_oidvector
 	return ret
+}
+
+// NewDefaultDatum returns a default non-NULL datum value for the given type.
+// This is used when updating non-NULL columns that are being added or dropped
+// from a table, and there is no user-defined DEFAULT value available.
+func NewDefaultDatum(evalCtx *EvalContext, t *types.T) (d Datum, err error) {
+	switch t.Family() {
+	case types.BoolFamily:
+		return DBoolFalse, nil
+	case types.IntFamily:
+		return DZero, nil
+	case types.FloatFamily:
+		return dZeroFloat, nil
+	case types.DecimalFamily:
+		return dZeroDecimal, nil
+	case types.DateFamily:
+		return dEpochDate, nil
+	case types.TimestampFamily:
+		return dMinTimestamp, nil
+	case types.IntervalFamily:
+		return dZeroInterval, nil
+	case types.StringFamily:
+		return dEmptyString, nil
+	case types.BytesFamily:
+		return dEmptyBytes, nil
+	case types.TimestampTZFamily:
+		return dMinTimestampTZ, nil
+	case types.CollatedStringFamily:
+		return NewDCollatedString("", t.Locale(), &evalCtx.CollationEnv)
+	case types.OidFamily:
+		return NewDOidWithName(DInt(t.Oid()), t, t.SQLStandardName()), nil
+	case types.UnknownFamily:
+		return DNull, nil
+	case types.UuidFamily:
+		return dMinUUID, nil
+	case types.ArrayFamily:
+		return NewDArray(t.ArrayContents()), nil
+	case types.INetFamily:
+		return dMinIPAddr, nil
+	case types.TimeFamily:
+		return dTimeMin, nil
+	case types.JsonFamily:
+		return dNullJSON, nil
+	case types.TupleFamily:
+		contents := t.TupleContents()
+		datums := make([]Datum, len(contents))
+		for i, subT := range contents {
+			datums[i], err = NewDefaultDatum(evalCtx, &subT)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return NewDTuple(t, datums...), nil
+	case types.BitFamily:
+		return bitArrayZero, nil
+	default:
+		return nil, errors.AssertionFailedf("unhandled type %v", t.SQLString())
+	}
 }
 
 // DatumTypeSize returns a lower bound on the total size of a Datum

--- a/pkg/sql/sem/tree/datum_test.go
+++ b/pkg/sql/sem/tree/datum_test.go
@@ -703,3 +703,63 @@ func TestAllTypesAsJSON(t *testing.T) {
 		}
 	}
 }
+
+// Test default values of many different datum types.
+func TestNewDefaultDatum(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	defer evalCtx.Stop(context.Background())
+
+	testCases := []struct {
+		t        *types.T
+		expected string
+	}{
+		{t: types.Bool, expected: "false"},
+		{t: types.Int, expected: "0:::INT8"},
+		{t: types.Int2, expected: "0:::INT8"},
+		{t: types.Int4, expected: "0:::INT8"},
+		{t: types.Float, expected: "0.0:::FLOAT8"},
+		{t: types.Float4, expected: "0.0:::FLOAT8"},
+		{t: types.Decimal, expected: "0:::DECIMAL"},
+		{t: types.MakeDecimal(10, 5), expected: "0:::DECIMAL"},
+		{t: types.Date, expected: "'2000-01-01':::DATE"},
+		{t: types.Timestamp, expected: "'0001-01-01 00:00:00+00:00':::TIMESTAMP"},
+		{t: types.Interval, expected: "'00:00:00':::INTERVAL"},
+		{t: types.String, expected: "'':::STRING"},
+		{t: types.MakeChar(3), expected: "'':::STRING"},
+		{t: types.Bytes, expected: "'\\x':::BYTES"},
+		{t: types.TimestampTZ, expected: "'0001-01-01 00:00:00+00:00':::TIMESTAMPTZ"},
+		{t: types.MakeCollatedString(types.MakeVarChar(10), "de"), expected: "'' COLLATE de"},
+		{t: types.MakeCollatedString(types.VarChar, "en_US"), expected: "'' COLLATE en_US"},
+		{t: types.Oid, expected: "26:::OID"},
+		{t: types.RegClass, expected: "crdb_internal.create_regclass(2205,'regclass'):::REGCLASS"},
+		{t: types.Unknown, expected: "NULL"},
+		{t: types.Uuid, expected: "'00000000-0000-0000-0000-000000000000':::UUID"},
+		{t: types.MakeArray(types.Int), expected: "ARRAY[]:::INT8[]"},
+		{t: types.MakeArray(types.MakeArray(types.String)), expected: "ARRAY[]:::STRING[][]"},
+		{t: types.OidVector, expected: "ARRAY[]:::OID[]"},
+		{t: types.INet, expected: "'0.0.0.0/0':::INET"},
+		{t: types.Time, expected: "'00:00:00':::TIME"},
+		{t: types.Jsonb, expected: "'null':::JSONB"},
+		{t: types.MakeTuple([]types.T{}), expected: "()"},
+		{t: types.MakeTuple([]types.T{*types.Int, *types.MakeChar(1)}), expected: "(0:::INT8, '':::STRING)"},
+		{t: types.MakeTuple([]types.T{*types.OidVector, *types.MakeTuple([]types.T{*types.Float})}), expected: "(ARRAY[]:::OID[], (0.0:::FLOAT8,))"},
+		{t: types.VarBit, expected: "B''"},
+		{t: types.MakeBit(5), expected: "B''"},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("#%d %s", i, tc.t.SQLString()), func(t *testing.T) {
+			datum, err := tree.NewDefaultDatum(evalCtx, tc.t)
+			if err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+
+			actual := tree.AsStringWithFlags(datum, tree.FmtCheckEquivalence)
+			if actual != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A column in the write-only state has either been recently added or dropped
from a table. If recently added, then it's currently being backfilled, and
therefore may still have a NULL value. If NULL, then it's not valid to use
this value during an UPDATE or UPSERT. However, this is what the previous
code was doing; when a column value was updated, it would mistakenly
incorporate the NULL value into the update.

The fix is to *always* write the default or computed value of a column
during an UPDATE or UPSERT of a write-only column. Here are the rules:

  1. If column is computed, evaluate that expression as its value.
  2. If column has a default value specified for it, use that as its value.
  3. If column is nullable, use NULL as its value.
  4. If column is currently being added or dropped (i.e. a mutation column),
     use a default value (0 for INT column, "" for STRING column, etc).

One side effect of doing this is that NOT NULL columns can now be dropped
without triggering null constraint violations when other transactions try
to insert rows during the dropping process. Also, other transactions can
observe the default values if they SELECT a column that is dropped at just
the right time.

Fixes #42459

Release justification: Fix for high-severity bug in existing functionality.
This bug can result in NULL values being written to NOT NULL columns. It
can also trigger unexpected errors during INSERT/UPDATE/UPSERT statements
when schema changes are taking place.

Release note (sql change): Columns in the process of being added or removed
to a table are now always set to their default or computed value if another
transaction concurrently inserts, updates, or upserts a row. This fixes an
issue where a column being backfilled would not get properly set by
concurrent transactions.