### PR TITLE
retry: fix retry.WithMaxAttempt to deal with opt.Closer properly

### DIFF
--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -162,7 +162,11 @@ func WithMaxAttempts(ctx context.Context, opts Options, n int, fn func() error) 
 		}
 	}
 	if err == nil {
-		err = errors.Wrap(ctx.Err(), "did not run function")
+		if ctx.Err() != nil {
+			err = errors.Wrap(ctx.Err(), "did not run function due to context completion")
+		} else {
+			err = errors.New("did not run function due to closed opts.Closer")
+		}
 	}
 	return err
 }


### PR DESCRIPTION
In `beac4a53e0e2e2236eb5957f67abc1bf476ad1b6`, we introduced
stopper.ShouldQuiesce() to the retry.Closer so that server shutdowns
also shut down in-process retries to the temp schema cleaner.

However, when stopper.ShouldQuiesce() is called, the error that gets
wrapped in `errors.Wrap` is nil (as ctx.Err() is nil), and as such we
return with no error set. This causes potentially bugs afterwards as
users of the functions expected errors when this happens and not to
continue silently.

This PR bridges that gap by always wrapping an error around cases where
WithMaxAttempt is aborted by a context attempt.

Resolves https://github.com/cockroachdb/cockroach/issues/47057.

Release note: None.