### PR TITLE
cli/interactive_tests: deflake test_demo_partitioning

### DIFF
--- a/pkg/cli/interactive_tests/test_demo_partitioning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_partitioning.tcl
@@ -15,7 +15,7 @@ expect {
   # can fail in various ways (i.e. not just a timeout).
   # So instead we use the specific error message shouted by `cockroach demo` when license
   # acquisition fails.
-  "license acquisition was unsuccessful" {
+  "unable to acquire a license for this demo" {
       # The license server is unreachable. There's not much we can test here.
       # Simply ignore the test.
       report "License server could not be reached - skipping with no error"


### PR DESCRIPTION
Fixes #45717

This test uses the license server, which sometimes is not available.

There is a check on whether the server is available at the beginning
of the test, however the particular string that was used has been
recently updaded. This patch updates the test.

Release note: None