### PR TITLE
release-20.1: sqlmigrations: add migration for 19.2-style schema change jobs

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1350,7 +1350,7 @@ func TestRestoreFailCleanup(t *testing.T) {
 	// Disable GC job so that the final check of crdb_internal.tables is
 	// guaranteed to not be cleaned up. Although this was never observed by a
 	// stress test, it is here for safety.
-	params.Knobs.GCJob = &sql.GCJobTestingKnobs{RunBeforeResume: func() { select {} /* blocks forever */ }}
+	params.Knobs.GCJob = &sql.GCJobTestingKnobs{RunBeforeResume: func(_ int64) error { select {} /* blocks forever */ }}
 
 	const numAccounts = 1000
 	_, _, sqlDB, dir, cleanup := backupRestoreTestSetupWithParams(t, singleNode, numAccounts,
@@ -1394,7 +1394,7 @@ func TestRestoreFailDatabaseCleanup(t *testing.T) {
 	// crdb_internal.tables is guaranteed to not be cleaned up. Although this
 	// was never observed by a stress test, it is here for safety.
 	blockGC := make(chan struct{})
-	params.Knobs.GCJob = &sql.GCJobTestingKnobs{RunBeforeResume: func() { <-blockGC }}
+	params.Knobs.GCJob = &sql.GCJobTestingKnobs{RunBeforeResume: func(_ int64) error { <-blockGC; return nil }}
 
 	const numAccounts = 1000
 	_, _, sqlDB, dir, cleanup := backupRestoreTestSetupWithParams(t, singleNode, numAccounts,

--- a/pkg/ccl/importccl/load_test.go
+++ b/pkg/ccl/importccl/load_test.go
@@ -57,6 +57,9 @@ func TestGetDescriptorFromDB(t *testing.T) {
 	bobDesc := &sqlbase.DatabaseDescriptor{Name: "bob"}
 
 	err := kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		if err := txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
 		batch := txn.NewBatch()
 		batch.Put(sqlbase.NewDatabaseKey("bob").Key(), 9999)
 		batch.Put(sqlbase.NewDeprecatedDatabaseKey("alice").Key(), 10000)

--- a/pkg/ccl/partitionccl/drop_test.go
+++ b/pkg/ccl/partitionccl/drop_test.go
@@ -48,8 +48,9 @@ func TestDropIndexWithZoneConfigCCL(t *testing.T) {
 	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
 		GCJob: &sql.GCJobTestingKnobs{
-			RunBeforeResume: func() {
+			RunBeforeResume: func(_ int64) error {
 				<-asyncNotification
+				return nil
 			},
 		},
 	}

--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -257,9 +257,10 @@ func main() {
 		}
 		if len(pkgs) > 0 {
 			for name, pkg := range pkgs {
-				// 10 minutes total seems OK, but at least a minute per test.
-				duration := (10 * time.Minute) / time.Duration(len(pkgs))
-				minDuration := time.Minute * time.Duration(len(pkg.tests))
+				// 20 minutes total seems OK, but at least 2 minutes per test.
+				// This should be reduced. See #46941.
+				duration := (20 * time.Minute) / time.Duration(len(pkgs))
+				minDuration := (2 * time.Minute) * time.Duration(len(pkg.tests))
 				if duration < minDuration {
 					duration = minDuration
 				}

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -740,7 +739,6 @@ func (j *Job) insert(ctx context.Context, id int64, lease *jobspb.Lease) error {
 }
 
 func (j *Job) adopt(ctx context.Context, oldLease *jobspb.Lease) error {
-	log.Infof(ctx, "job %d: adopting", *j.ID())
 	return j.Update(ctx, func(txn *kv.Txn, md JobMetadata, ju *JobUpdater) error {
 		if !md.Payload.Lease.Equal(oldLease) {
 			return errors.Errorf("current lease %v did not match expected lease %v",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -204,6 +204,7 @@ type Server struct {
 	// shared between the sql.Server and the statusServer.
 	sessionRegistry        *sql.SessionRegistry
 	jobRegistry            *jobs.Registry
+	migMgr                 *sqlmigrations.Manager
 	statsRefresher         *stats.Refresher
 	replicationReporter    *reports.Reporter
 	temporaryObjectCleaner *sql.TemporaryObjectCleaner
@@ -1716,6 +1717,7 @@ func (s *Server) Start(ctx context.Context) error {
 		s.ClusterSettings(),
 		s.jobRegistry,
 	)
+	s.migMgr = migMgr
 
 	// Start garbage collecting system events.
 	s.startSystemLogsGC(ctx)

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -301,6 +301,14 @@ func (ts *TestServer) JobRegistry() interface{} {
 	return nil
 }
 
+// MigrationManager returns the *sqlmigrations.Manager as an interface{}.
+func (ts *TestServer) MigrationManager() interface{} {
+	if ts != nil {
+		return ts.migMgr
+	}
+	return nil
+}
+
 // RPCContext returns the rpc context used by the TestServer.
 func (ts *TestServer) RPCContext() *rpc.Context {
 	if ts != nil {

--- a/pkg/sql/as_of_test.go
+++ b/pkg/sql/as_of_test.go
@@ -33,7 +33,7 @@ func TestAsOfTime(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	params, _ := tests.CreateTestServerParams()
-	params.Knobs.GCJob = &sql.GCJobTestingKnobs{RunBeforeResume: func() { select {} }}
+	params.Knobs.GCJob = &sql.GCJobTestingKnobs{RunBeforeResume: func(_ int64) error { select {} }}
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -287,6 +287,12 @@ func (sc *SchemaChanger) runBackfill(ctx context.Context) error {
 	log.Infof(ctx, "Completed backfill for %q, v=%d, m=%d",
 		tableDesc.Name, tableDesc.Version, sc.mutationID)
 
+	if sc.testingKnobs.RunAfterBackfill != nil {
+		if err := sc.testingKnobs.RunAfterBackfill(*sc.job.ID()); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/sql/gcjob/gc_job.go
+++ b/pkg/sql/gcjob/gc_job.go
@@ -87,7 +87,9 @@ func (r schemaChangeGCResumer) Resume(
 	// TODO(pbardea): Wait for no versions.
 	execCfg := p.ExecCfg()
 	if fn := execCfg.GCJobTestingKnobs.RunBeforeResume; fn != nil {
-		fn()
+		if err := fn(r.jobID); err != nil {
+			return err
+		}
 	}
 	details, progress, err := initDetailsAndProgress(ctx, execCfg, r.jobID)
 	if err != nil {

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -528,7 +528,7 @@ func TestCantLeaseDeletedTable(testingT *testing.T) {
 			},
 		},
 		// Disable GC job.
-		GCJob: &sql.GCJobTestingKnobs{RunBeforeResume: func() { select {} }},
+		GCJob: &sql.GCJobTestingKnobs{RunBeforeResume: func(_ int64) error { select {} }},
 	}
 
 	t := newLeaseTest(testingT, params)
@@ -619,7 +619,7 @@ func TestLeasesOnDeletedTableAreReleasedImmediately(t *testing.T) {
 			},
 		},
 		// Disable GC job.
-		GCJob: &sql.GCJobTestingKnobs{RunBeforeResume: func() { select {} }},
+		GCJob: &sql.GCJobTestingKnobs{RunBeforeResume: func(_ int64) error { select {} }},
 	}
 	s, db, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())

--- a/pkg/sql/schema_change_migrations_test.go
+++ b/pkg/sql/schema_change_migrations_test.go
@@ -1,0 +1,835 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql_test
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/sqlmigrations"
+	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+type BlockState int
+
+// These are the states that we want to block the 19.2 style schema change and
+// ensure that it can be migrated properly when it is in that state.
+const (
+	BeforeBackfill BlockState = iota
+	AfterBackfill
+	AfterReversingMutations // Only used if the job was canceled.
+	WaitingForGC            // Only applies to DROP INDEX, DROP TABLE, TRUNCATE TABLE.
+)
+
+type SchemaChangeType int
+
+const (
+	AddColumn SchemaChangeType = iota
+	DropColumn
+	CreateIndex
+	DropIndex
+	AddConstraint
+	DropConstraint
+	CreateTable
+	DropTable
+	TruncateTable
+)
+
+const setup = `
+CREATE DATABASE t;
+USE t;
+CREATE TABLE test (k INT PRIMARY KEY, v INT, INDEX k_idx (k), CONSTRAINT k_cons CHECK (k > 0));
+INSERT INTO test VALUES (1, 2);
+`
+
+// runsBackfill is a set of schema change types that run a backfill.
+var runsBackfill = map[SchemaChangeType]bool{
+	AddColumn:   true,
+	DropColumn:  true,
+	CreateIndex: true,
+	DropIndex:   true,
+}
+
+func isDeletingTable(schemaChangeType SchemaChangeType) bool {
+	return schemaChangeType == TruncateTable || schemaChangeType == DropTable
+}
+
+func checkBlockedSchemaChange(
+	t *testing.T, runner *sqlutils.SQLRunner, testCase migrationTestCase,
+) {
+	if testCase.blockState == WaitingForGC {
+		// Earlier we turned the 20.1 GC job into a 19.2 schema change job. Delete
+		// the original schema change job which is now succeeded, to avoid having
+		// special cases later, since we rely heavily on the index of the job row in
+		// the jobs table when verifying a job.
+		//
+		// First, though, we have to actually wait for the original job to become
+		// Succeeded.
+		runner.CheckQueryResultsRetry(t,
+			"SELECT count(*) FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE' AND status = 'succeeded'",
+			[][]string{{"1"}},
+		)
+		rows := runner.QueryStr(
+			t,
+			"SELECT * FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE' AND status = 'succeeded'",
+		)
+		jobID, _ := strconv.Atoi(rows[0][0])
+		runner.Exec(t, "DELETE FROM system.jobs WHERE id = $1", jobID)
+	}
+
+	oldVersion := jobutils.GetJobFormatVersion(t, runner)
+	require.Equal(t, jobspb.BaseFormatVersion, oldVersion)
+	expStatus := jobs.StatusRunning
+	if testCase.shouldCancel {
+		expStatus = jobs.StatusReverting
+	}
+	if err := jobutils.VerifySystemJob(t, runner, 0, jobspb.TypeSchemaChange, expStatus, jobs.Record{
+		Description:   testCase.schemaChange.query,
+		Username:      security.RootUser,
+		DescriptorIDs: getTableIDsUnderTest(testCase.schemaChange.kind),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !hadJobInOldVersion(testCase.schemaChange.kind) {
+		// Delete the job if it didn't have a schema change before.
+		rows := runner.QueryStr(t, "SELECT * FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE'")
+		for _, job := range rows {
+			jobID, _ := strconv.Atoi(job[0])
+			runner.Exec(t, "DELETE FROM system.jobs WHERE id = $1", jobID)
+		}
+	}
+}
+
+type schemaChangeRequest struct {
+	kind  SchemaChangeType
+	query string
+}
+
+type migrationTestCase struct {
+	blockState   BlockState
+	shouldCancel bool
+	schemaChange schemaChangeRequest
+}
+
+// testSchemaChangeMigrations tests that a schema change can be migrated after
+// being blocked in a certain state.
+//
+// 1. Create a 20.1 schema change.
+// 2. Block the schema change at a certain point in its execution.
+// 3. Mutate the job descriptor and table descriptor such that it appears as a
+// 19.2 format job. These jobs will not be resumed anymore as 20.1 will refuse
+// to run 19.2 jobs.
+// 4. Verify that the job has been marked as a 19.2 job and is blocked.
+// 5. Run the migration and wait for the migration to complete.
+// 6. Ensure that the schema change completes.
+func testSchemaChangeMigrations(t *testing.T, testCase migrationTestCase) {
+	ctx := context.Background()
+	shouldBlockMigration := false
+	blockFnErrChan := make(chan error, 1)
+	revMigrationDoneCh, signalRevMigrationDone := makeSignal()
+	migrationDoneCh, signalMigrationDone := makeCondSignal(&shouldBlockMigration)
+	runner, sqlDB, tc := setupServerAndStartSchemaChange(
+		t,
+		blockFnErrChan,
+		testCase,
+		signalRevMigrationDone,
+		signalMigrationDone,
+	)
+	defer tc.Stopper().Stop(context.TODO())
+	defer disableGCTTLStrictEnforcement(t, sqlDB)()
+
+	log.Info(ctx, "waiting for all schema changes to block")
+	<-revMigrationDoneCh
+	log.Info(ctx, "all schema changes have blocked")
+
+	close(blockFnErrChan)
+	for err := range blockFnErrChan {
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+	}
+
+	checkBlockedSchemaChange(t, runner, testCase)
+
+	// Start the migrations.
+	log.Info(ctx, "starting job migration")
+	shouldBlockMigration = true
+	migMgr := tc.Server(0).MigrationManager().(*sqlmigrations.Manager)
+	if err := migMgr.StartSchemaChangeJobMigration(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	log.Info(ctx, "waiting for migration to complete")
+	<-migrationDoneCh
+	shouldBlockMigration = false
+
+	// TODO(pbardea): SHOW JOBS WHEN COMPLETE SELECT does not work on some schema
+	// changes when canceling jobs, but querying until there are no jobs works.
+	//runner.Exec(t, "SHOW JOBS WHEN COMPLETE SELECT job_id FROM [SHOW JOBS] WHERE (job_type = 'SCHEMA CHANGE' OR job_type = 'SCHEMA CHANGE GC')")
+	// Wait until there are no more running schema changes.
+	log.Info(ctx, "waiting for new schema change jobs to complete")
+	runner.CheckQueryResultsRetry(t, "SELECT * FROM [SHOW JOBS] WHERE (job_type = 'SCHEMA CHANGE' OR job_type = 'SCHEMA CHANGE GC') AND NOT (status = 'succeeded' OR status = 'canceled')", [][]string{})
+	log.Info(ctx, "done running new schema change jobs")
+
+	verifySchemaChangeJobRan(t, runner, testCase)
+}
+
+func makeCondSignal(shouldSignal *bool) (chan struct{}, func()) {
+	signalCh := make(chan struct{})
+	signalFn := func() {
+		if *shouldSignal {
+			signalCh <- struct{}{}
+		}
+	}
+	return signalCh, signalFn
+}
+
+func makeSignal() (chan struct{}, func()) {
+	alwaysSignal := true
+	return makeCondSignal(&alwaysSignal)
+}
+
+func setupServerAndStartSchemaChange(
+	t *testing.T,
+	errCh chan error,
+	testCase migrationTestCase,
+	revMigrationDone, signalMigrationDone func(),
+) (*sqlutils.SQLRunner, *gosql.DB, serverutils.TestClusterInterface) {
+	clusterSize := 3
+	params, _ := tests.CreateTestServerParams()
+
+	var runner *sqlutils.SQLRunner
+	var kvDB *kv.DB
+	var registry *jobs.Registry
+
+	blockSchemaChanges := false
+
+	migrateJob := func(jobID int64) {
+		if testCase.blockState == WaitingForGC {
+			if err := migrateGCJobToOldFormat(kvDB, registry, jobID, testCase.schemaChange.kind); err != nil {
+				errCh <- err
+			}
+		} else {
+			if err := migrateJobToOldFormat(kvDB, registry, jobID, testCase.schemaChange.kind); err != nil {
+				errCh <- err
+			}
+		}
+	}
+	cancelJob := func(jobID int64) {
+		runner.Exec(t, `CANCEL JOB (
+					SELECT job_id FROM [SHOW JOBS]
+					WHERE
+						job_id = $1
+				)`, jobID)
+	}
+
+	setupTestingKnobs(t, testCase, &params, &blockSchemaChanges, revMigrationDone, signalMigrationDone, migrateJob, cancelJob)
+
+	tc := serverutils.StartTestCluster(t, clusterSize,
+		base.TestClusterArgs{
+			ReplicationMode: base.ReplicationManual,
+			ServerArgs:      params,
+		})
+	sqlDB := tc.ServerConn(0)
+	kvDB = tc.Server(0).DB()
+	runner = sqlutils.MakeSQLRunner(sqlDB)
+	registry = tc.Server(0).JobRegistry().(*jobs.Registry)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if _, err := sqlDB.Exec(setup); err != nil {
+		t.Fatal(err)
+	}
+
+	runner.CheckQueryResultsRetry(t, "SELECT count(*) FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE' AND NOT (status = 'succeeded' OR status = 'canceled')", [][]string{{"0"}})
+	blockSchemaChanges = true
+
+	bg := ctxgroup.WithContext(ctx)
+	bg.Go(func() error {
+		if _, err := sqlDB.ExecContext(ctx, testCase.schemaChange.query); err != nil {
+			cancel()
+			return err
+		}
+		return nil
+	})
+	// TODO(pbardea): Remove this magic 53.
+	if _, err := addImmediateGCZoneConfig(sqlDB, sqlbase.ID(53)); err != nil {
+		t.Fatal(err)
+	}
+	return runner, sqlDB, tc
+}
+
+// migrateJobToOldFormat updates the state of a job and table descriptor from
+// it's 20.1 to its 19.2 representation. There is a separate implementation for
+// GC jobs.
+func migrateJobToOldFormat(
+	kvDB *kv.DB, registry *jobs.Registry, jobID int64, schemaChangeType SchemaChangeType,
+) error {
+	ctx := context.Background()
+
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
+	if schemaChangeType == CreateTable {
+		tableDesc = sqlbase.GetTableDescriptor(kvDB, "t", "new_table")
+	}
+
+	if err := kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		job, err := registry.LoadJobWithTxn(ctx, jobID, txn)
+		if err != nil {
+			return err
+		}
+		return job.WithTxn(txn).Update(ctx, func(txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+			details := job.Details().(jobspb.SchemaChangeDetails)
+			// Explicitly zero out these fields as they will be set to their 0 value
+			// on 19.2 nodes.
+			details.TableID = 0
+			details.MutationID = 0
+			details.FormatVersion = jobspb.BaseFormatVersion
+			if isDeletingTable(schemaChangeType) {
+				details.DroppedTables = []jobspb.DroppedTableDetails{
+					{
+						Name:   tableDesc.Name,
+						ID:     tableDesc.ID,
+						Status: jobspb.Status_DRAINING_NAMES,
+					},
+				}
+			}
+
+			progress := job.Progress()
+			// TODO(pbardea): Probably want to change this to check on block state
+			// being draining names.
+			if isDeletingTable(schemaChangeType) {
+				progress.RunningStatus = string(sql.RunningStatusDrainingNames)
+			}
+
+			md.Payload.Lease = nil
+			md.Payload.Details = jobspb.WrapPayloadDetails(details)
+			md.Progress = &progress
+			ju.UpdatePayload(md.Payload)
+			ju.UpdateProgress(md.Progress)
+			return nil
+		})
+	}); err != nil {
+		return err
+	}
+
+	// Update the table descriptor.
+	tableDesc.Lease = &sqlbase.TableDescriptor_SchemaChangeLease{
+		ExpirationTime: timeutil.Now().UnixNano(),
+		NodeID:         roachpb.NodeID(0),
+	}
+	if schemaChangeType == TruncateTable {
+		tableDesc.DropJobID = jobID
+		// TODO(pbardea): When is drop time populated?
+	}
+
+	// Write the table descriptor back.
+	if err := kvDB.Put(ctx, sqlbase.MakeDescMetadataKey(tableDesc.GetID()), sqlbase.WrapDescriptor(tableDesc)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// migrateGCJobToOldFormat converts a GC job created in 20.1 into a 19.2-style
+// schema change job that is waiting for GC. This involves changing the type of
+// the job details and progress.
+//
+// We could have gone back and set the original schema change job to Running,
+// but then we'd have to update that job from inside the GC job testing knob
+// function, which seems risky since we have no way of controlling that schema
+// change job once it's eligible to be adopted.
+func migrateGCJobToOldFormat(
+	kvDB *kv.DB, registry *jobs.Registry, jobID int64, schemaChangeType SchemaChangeType,
+) error {
+	ctx := context.Background()
+
+	if err := kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		job, err := registry.LoadJobWithTxn(ctx, jobID, txn)
+		if err != nil {
+			return err
+		}
+		return job.WithTxn(txn).Update(ctx, func(txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+			// Replace the details with an entirely new SchemaChangeDetails.
+			details := jobspb.SchemaChangeDetails{
+				FormatVersion: jobspb.BaseFormatVersion,
+			}
+			if isDeletingTable(schemaChangeType) {
+				details.DroppedTables = []jobspb.DroppedTableDetails{
+					{
+						// TODO (lucy): Stop hard-coding these if possible. We can't get
+						// these values from the table descriptor if we're dropping the
+						// table, since at this point the table descriptor would have been
+						// deleted.
+						Name:   "test",
+						ID:     53,
+						Status: jobspb.Status_WAIT_FOR_GC_INTERVAL,
+					},
+				}
+			}
+
+			progress := jobspb.Progress{
+				Details:       jobspb.WrapProgressDetails(jobspb.SchemaChangeProgress{}),
+				RunningStatus: string(sql.RunningStatusWaitingGC),
+			}
+
+			md.Payload.Lease = nil
+			md.Payload.Description = strings.TrimPrefix(md.Payload.Description, "GC for ")
+			md.Payload.Details = jobspb.WrapPayloadDetails(details)
+			md.Progress = &progress
+			ju.UpdatePayload(md.Payload)
+			ju.UpdateProgress(md.Progress)
+			return nil
+		})
+	}); err != nil {
+		return err
+	}
+
+	switch schemaChangeType {
+	case DropTable:
+		// There's no table descriptor to update, so we're done.
+		return nil
+
+	case DropIndex:
+		// Since we write the GC job in a separate transaction from finalizing the
+		// mutations on the table descriptor, there's a chance that we might see the
+		// table descriptor before it's even been updated with the new GCMutations.
+		// This seems like a potential problem. For now, we'll just hackily retry
+		// until the new descriptor appears.
+		// TODO (lucy): Update this after we fix GC job creation.
+		var tableDesc *sql.TableDescriptor
+		for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
+			tableDesc = sqlbase.GetTableDescriptor(kvDB, "t", "test")
+			if l := len(tableDesc.GCMutations); l == 1 {
+				break
+			}
+		}
+
+		// Update the table descriptor.
+		tableDesc.Lease = &sqlbase.TableDescriptor_SchemaChangeLease{
+			ExpirationTime: timeutil.Now().UnixNano(),
+			NodeID:         roachpb.NodeID(0),
+		}
+
+		tableDesc.GCMutations[0].JobID = jobID
+		tableDesc.GCMutations[0].DropTime = timeutil.Now().UnixNano()
+
+		// Write the table descriptor back.
+		if err := kvDB.Put(ctx, sqlbase.MakeDescMetadataKey(tableDesc.GetID()), sqlbase.WrapDescriptor(tableDesc)); err != nil {
+			return err
+		}
+
+	default:
+		return errors.Errorf("invalid schema change type: %d", schemaChangeType)
+	}
+
+	return nil
+}
+
+// Set up server testing args such that knobs are set to block and abandon any
+// given schema change at a certain point. The "blocked" channel will be
+// signaled when the schema change gets abandoned.
+// The runner should only be used inside callback closures.
+func setupTestingKnobs(
+	t *testing.T,
+	testCase migrationTestCase,
+	args *base.TestServerArgs,
+	blockSchemaChanges *bool,
+	revMigrationDone, signalMigrationDone func(),
+	migrateJob, cancelJob func(int64),
+) {
+	numJobs := 1
+	if testCase.schemaChange.kind == CreateTable {
+		numJobs = 2
+	}
+	var (
+		mu                   syncutil.Mutex
+		migratedCount        int
+		doneReverseMigration bool
+		ranCancelCommand     bool
+		hasCanceled          bool
+	)
+
+	blockFn := func(jobID int64) error {
+		mu.Lock()
+		defer mu.Unlock()
+		if !(*blockSchemaChanges) {
+			return nil
+		}
+
+		// In the case we're canceling the job, this blockFn should only be called
+		// after the OnFailOrCancel hook is called. At this point we know that the
+		// job is actually canceled.
+		hasCanceled = true
+
+		if doneReverseMigration {
+			// Already migrated all the jobs that we want to migrate to 19.2.
+			// New jobs created after we migrated the original batch should be allowed
+			// to continue.
+			return nil
+		} else {
+			migrateJob(jobID)
+			migratedCount++
+		}
+
+		if migratedCount == numJobs {
+			doneReverseMigration = true
+			revMigrationDone()
+		}
+
+		// Return a retryable error so that the job doesn't make any progress past
+		// this point. It should not get adopted since it has been marked as a 19.2
+		// job.
+		return jobs.NewRetryJobError("stop this job until cluster upgrade")
+	}
+
+	cancelFn := func(jobID int64) error {
+		mu.Lock()
+		defer mu.Unlock()
+		if hasCanceled {
+			// The job has already been successfully canceled.
+			return nil
+		}
+
+		if !ranCancelCommand {
+			cancelJob(jobID)
+			ranCancelCommand = true
+		}
+
+		// Don't allow the job to progress further than this knob until it has
+		// actually been canceled	.
+		return jobs.NewRetryJobError("retry until canceled")
+	}
+
+	knobs := &sql.SchemaChangerTestingKnobs{}
+	gcKnobs := &sql.GCJobTestingKnobs{}
+
+	shouldCancel := testCase.shouldCancel
+	if shouldCancel {
+		if runsBackfill[testCase.schemaChange.kind] {
+			knobs.RunAfterBackfill = cancelFn
+		} else {
+			knobs.RunBeforeResume = cancelFn
+		}
+	}
+
+	switch testCase.blockState {
+	case BeforeBackfill:
+		if shouldCancel {
+			knobs.RunBeforeOnFailOrCancel = blockFn
+		} else {
+			knobs.RunBeforeResume = blockFn
+		}
+	case AfterBackfill:
+		if shouldCancel {
+			knobs.RunAfterOnFailOrCancel = blockFn
+		} else {
+			knobs.RunAfterBackfill = blockFn
+		}
+	case AfterReversingMutations:
+		if !shouldCancel {
+			t.Fatal("can only block after reversing mutations if the job is expected to be canceled")
+		}
+		knobs.RunAfterBackfill = cancelFn
+		knobs.RunAfterMutationReversal = blockFn
+	case WaitingForGC:
+		if shouldCancel {
+			t.Fatal("cannot block on waiting for GC if the job should also be canceled")
+		}
+		gcKnobs.RunBeforeResume = blockFn
+	}
+
+	args.Knobs.SQLSchemaChanger = knobs
+	args.Knobs.SQLMigrationManager = &sqlmigrations.MigrationManagerTestingKnobs{
+		AfterJobMigration:     signalMigrationDone,
+		AlwaysRunJobMigration: true,
+	}
+	args.Knobs.GCJob = gcKnobs
+}
+
+func getTestName(schemaChange SchemaChangeType, blockState BlockState, shouldCancel bool) string {
+	stateNames := map[BlockState]string{
+		BeforeBackfill:          "before-backfill",
+		AfterBackfill:           "after-backfill",
+		AfterReversingMutations: "after-reversing-mutations",
+		WaitingForGC:            "waiting-for-gc",
+	}
+	schemaChangeName := map[SchemaChangeType]string{
+		AddColumn:      "add-column",
+		DropColumn:     "drop-column",
+		CreateIndex:    "add-index",
+		DropIndex:      "drop-index",
+		AddConstraint:  "add-constraint",
+		DropConstraint: "drop-constraint",
+		CreateTable:    "create-table",
+		TruncateTable:  "truncate-table",
+		DropTable:      "drop-table",
+	}
+
+	testName := fmt.Sprintf("%s-blocked-at-%s", schemaChangeName[schemaChange], stateNames[blockState])
+	if shouldCancel {
+		testName += "-canceled"
+	}
+	return testName
+}
+
+func verifySchemaChangeJobRan(
+	t *testing.T, runner *sqlutils.SQLRunner, testCase migrationTestCase,
+) {
+	expStatus := jobs.StatusSucceeded
+	description := testCase.schemaChange.query
+	if testCase.shouldCancel {
+		expStatus = jobs.StatusCanceled
+	}
+	if testCase.schemaChange.kind == CreateTable {
+		description = "adding table 54"
+	} else {
+		if err := jobutils.VerifySystemJob(t, runner, 0, jobspb.TypeSchemaChange, expStatus, jobs.Record{
+			Description:   description,
+			Username:      security.RootUser,
+			DescriptorIDs: getTableIDsUnderTest(testCase.schemaChange.kind),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Verify that the GC job exists and is in the correct state, if applicable.
+	if testCase.blockState == WaitingForGC {
+		if err := jobutils.VerifySystemJob(t, runner, 0, jobspb.TypeSchemaChangeGC, jobs.StatusSucceeded, jobs.Record{
+			Description:   "GC for " + description,
+			Username:      security.RootUser,
+			DescriptorIDs: getTableIDsUnderTest(testCase.schemaChange.kind),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		// For non-GC jobs, verify that the schema change job format version was
+		// updated.
+		newVersion := jobutils.GetJobFormatVersion(t, runner)
+		require.Equal(t, jobspb.JobResumerFormatVersion, newVersion)
+	}
+
+	var expected [][]string
+	didCancel := testCase.shouldCancel
+	switch testCase.schemaChange.kind {
+	case AddColumn:
+		if didCancel {
+			expected = [][]string{{"1", "2"}}
+		} else {
+			expected = [][]string{{"1", "2", "NULL"}}
+		}
+		rows := runner.QueryStr(t, "SELECT * FROM t.test")
+		require.Equal(t, expected, rows)
+	case DropColumn:
+		if didCancel {
+			expected = [][]string{{"1", "NULL"}}
+		} else {
+			expected = [][]string{{"1"}}
+		}
+		rows := runner.QueryStr(t, "SELECT * FROM t.test")
+		require.Equal(t, expected, rows)
+	case CreateIndex:
+		if didCancel {
+			expected = [][]string{{"primary"}, {"k_idx"}}
+		} else {
+			expected = [][]string{{"primary"}, {"k_idx"}, {"v_idx"}}
+		}
+		rows := runner.QueryStr(t, "SELECT DISTINCT index_name FROM [SHOW INDEXES FROM t.test]")
+		require.Equal(t, expected, rows)
+	case DropIndex:
+		if didCancel {
+			expected = [][]string{{"primary"}, {"k_idx"}}
+		} else {
+			expected = [][]string{{"primary"}}
+		}
+		rows := runner.QueryStr(t, "SELECT DISTINCT index_name FROM [SHOW INDEXES FROM t.test]")
+		require.Equal(t, expected, rows)
+	case AddConstraint:
+		if didCancel {
+			expected = [][]string{{"k_cons"}, {"primary"}}
+		} else {
+			expected = [][]string{{"k_cons"}, {"primary"}, {"v_unq"}}
+		}
+		rows := runner.QueryStr(t, "SELECT constraint_name FROM [SHOW CONSTRAINTS FROM t.test] ORDER BY constraint_name")
+		require.Equal(t, expected, rows)
+	case DropConstraint:
+		if didCancel {
+			expected = [][]string{{"k_cons"}, {"primary"}}
+		} else {
+			expected = [][]string{{"primary"}}
+		}
+		rows := runner.QueryStr(t, "SELECT constraint_name FROM [SHOW CONSTRAINTS FROM t.test] ORDER BY constraint_name")
+		require.Equal(t, expected, rows)
+	case CreateTable:
+		if didCancel {
+			t.Fatal("cannot cancel create table")
+		} else {
+			expected = [][]string{{"new_table"}, {"test"}}
+		}
+		rows := runner.QueryStr(t, "SHOW TABLES FROM t")
+		require.Equal(t, expected, rows)
+	case TruncateTable:
+		if didCancel {
+			expected = [][]string{{"0"}}
+		} else {
+			expected = [][]string{{"0"}}
+		}
+		rows := runner.QueryStr(t, "SELECT count(*) FROM t.test")
+		require.Equal(t, expected, rows)
+	case DropTable:
+		// Canceling after the backfill has no effect.
+		expected = [][]string{}
+		rows := runner.QueryStr(t, "SHOW TABLES FROM t")
+		require.Equal(t, expected, rows)
+	}
+}
+
+func getTableIDsUnderTest(schemaChangeType SchemaChangeType) []sqlbase.ID {
+	tableID := sqlbase.ID(53)
+	if schemaChangeType == CreateTable {
+		tableID = sqlbase.ID(54)
+	}
+	return []sqlbase.ID{tableID}
+}
+
+// Helpers used to determine valid test cases.
+
+// canBlockIfCanceled returns if a certain state (where we want to block the
+// schema change) will be reached given if the job was canceled or not.
+func canBlockIfCanceled(blockState BlockState, shouldCancel bool) bool {
+	// States that are only valid when the job is canceled.
+	if blockState == WaitingForGC {
+		return !shouldCancel
+	}
+	if blockState == AfterReversingMutations {
+		return shouldCancel
+	}
+	return true
+}
+
+// Ensures that the given schema change actually passes through the state where
+// we're proposing to block.
+func validBlockStateForSchemaChange(blockState BlockState, schemaChangeType SchemaChangeType) bool {
+	switch blockState {
+	case AfterBackfill:
+		return runsBackfill[schemaChangeType]
+	case WaitingForGC:
+		return schemaChangeType == DropIndex || schemaChangeType == DropTable
+	}
+	return true
+}
+
+// hasJobInOldVersion returns if a given schema change had a job in 19.2.
+// Therefore these jobs could not be canceled in 19.2
+func hadJobInOldVersion(schemaChangeType SchemaChangeType) bool {
+	return schemaChangeType != CreateTable
+}
+
+func TestMigrateSchemaChanges(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer setTestJobsAdoptInterval()()
+
+	blockStates := []BlockState{
+		BeforeBackfill,
+		AfterBackfill,
+		AfterReversingMutations,
+		WaitingForGC,
+	}
+
+	schemaChanges := []schemaChangeRequest{
+		{
+			CreateTable,
+			"CREATE TABLE t.public.new_table (k INT8, FOREIGN KEY (k) REFERENCES t.public.test (k))",
+		},
+		{
+			AddColumn,
+			"ALTER TABLE t.public.test ADD COLUMN foo INT8",
+		},
+		{
+			DropColumn,
+			"ALTER TABLE t.public.test DROP COLUMN v",
+		},
+		{
+			CreateIndex,
+			"CREATE INDEX v_idx ON t.public.test (v)",
+		},
+		{
+			DropIndex,
+			"DROP INDEX t.public.test@k_idx",
+		},
+		{
+			AddConstraint,
+			"ALTER TABLE t.public.test ADD CONSTRAINT v_unq UNIQUE (v)",
+		},
+		{
+			DropConstraint,
+			"ALTER TABLE t.public.test DROP CONSTRAINT k_cons",
+		},
+		{
+			TruncateTable,
+			"TRUNCATE TABLE t.public.test",
+		},
+		{
+			DropTable,
+			"DROP TABLE t.public.test",
+		},
+	}
+
+	for _, schemaChange := range schemaChanges {
+		for _, blockState := range blockStates {
+			for _, shouldCancel := range []bool{true, false} {
+				blockState := blockState
+				shouldCancel := shouldCancel
+
+				if !canBlockIfCanceled(blockState, shouldCancel) {
+					continue
+				}
+				if !validBlockStateForSchemaChange(blockState, schemaChange.kind) {
+					continue
+				}
+				if shouldCancel && !hadJobInOldVersion(schemaChange.kind) {
+					continue
+				}
+
+				t.Run(getTestName(schemaChange.kind, blockState, shouldCancel), func(t *testing.T) {
+					testCase := migrationTestCase{
+						blockState:   blockState,
+						shouldCancel: shouldCancel,
+						schemaChange: schemaChange,
+					}
+					testSchemaChangeMigrations(t, testCase)
+				})
+			}
+		}
+	}
+}

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -19,6 +19,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -29,13 +31,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sqlmigrations/leasemanager"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/logtags"
 )
 
 var (
@@ -421,6 +425,7 @@ type Manager struct {
 	sqlExecutor  *sql.InternalExecutor
 	testingKnobs MigrationManagerTestingKnobs
 	settings     *cluster.Settings
+	jobRegistry  *jobs.Registry
 }
 
 // NewManager initializes and returns a new Manager object.
@@ -432,6 +437,7 @@ func NewManager(
 	testingKnobs MigrationManagerTestingKnobs,
 	clientID string,
 	settings *cluster.Settings,
+	registry *jobs.Registry,
 ) *Manager {
 	opts := leasemanager.Options{
 		ClientID:      clientID,
@@ -444,6 +450,7 @@ func NewManager(
 		sqlExecutor:  executor,
 		testingKnobs: testingKnobs,
 		settings:     settings,
+		jobRegistry:  registry,
 	}
 }
 
@@ -623,6 +630,520 @@ func (m *Manager) EnsureMigrations(ctx context.Context, bootstrapVersion roachpb
 	}
 
 	return nil
+}
+
+var (
+	schemaChangeJobMigrationName = "upgrade schema change job format"
+	// schemaChangeJobMigrationKey is used for storing the completion status of
+	// the schema change job migration.
+	schemaChangeJobMigrationKey = append(keys.MigrationPrefix, roachpb.RKey(schemaChangeJobMigrationName)...)
+)
+
+// StartSchemaChangeJobMigration starts an async task to run the migration that
+// upgrades 19.2-style jobs to the 20.1 job format, so that the jobs can be
+// adopted by the job registry. The task first waits until the upgrade to 20.1
+// is finalized before running the migration. The migration is retried until
+// it succeeds (on any node).
+func (m *Manager) StartSchemaChangeJobMigration(ctx context.Context) error {
+	return m.stopper.RunAsyncTask(ctx, "run-schema-change-job-migration", func(ctx context.Context) {
+		log.Info(ctx, "starting wait for upgrade finalization before schema change job migration")
+		// First wait for the cluster to finalize the upgrade to 20.1. These values
+		// were chosen to be similar to the retry loop for finalizing the cluster
+		// upgrade.
+		waitRetryOpts := retry.Options{
+			InitialBackoff: 10 * time.Second,
+			MaxBackoff:     10 * time.Second,
+			Closer:         m.stopper.ShouldQuiesce(),
+		}
+		for retry := retry.StartWithCtx(ctx, waitRetryOpts); retry.Next(); {
+			if m.settings.Version.IsActive(ctx, clusterversion.VersionSchemaChangeJob) {
+				break
+			}
+		}
+		select {
+		case <-m.stopper.ShouldQuiesce():
+			return
+		default:
+		}
+		log.VEventf(ctx, 2, "detected upgrade finalization")
+
+		// Check whether this migration has already been completed.
+		if kv, err := m.db.Get(ctx, schemaChangeJobMigrationKey); err != nil {
+			log.Infof(ctx, "error getting record of schema change job migration: %s", err.Error())
+		} else if kv.Exists() {
+			log.Infof(ctx, "schema change job migration already complete")
+			return
+		}
+
+		// Now run the migration. This is retried indefinitely until it finishes.
+		log.Infof(ctx, "starting schema change job migration")
+		r := runner{
+			db:          m.db,
+			sqlExecutor: m.sqlExecutor,
+			settings:    m.settings,
+		}
+		migrationRetryOpts := retry.Options{
+			InitialBackoff: 1 * time.Minute,
+			MaxBackoff:     10 * time.Minute,
+			Closer:         m.stopper.ShouldQuiesce(),
+		}
+		startTime := timeutil.Now().String()
+		for migRetry := retry.Start(migrationRetryOpts); migRetry.Next(); {
+			migrateCtx, _ := m.stopper.WithCancelOnQuiesce(context.Background())
+			migrateCtx = logtags.AddTag(migrateCtx, "schema-change-job-migration", nil)
+			if err := migrateSchemaChangeJobs(migrateCtx, r, m.jobRegistry); err != nil {
+				log.Errorf(ctx, "error attempting running schema change job migration, will retry: %s %s", err.Error(), startTime)
+				continue
+			}
+			log.Infof(ctx, "schema change job migration completed")
+			if err := m.db.Put(ctx, schemaChangeJobMigrationKey, startTime); err != nil {
+				log.Warningf(ctx, "error persisting record of schema change job migration, will retry: %s", err.Error())
+			}
+			break
+		}
+	})
+}
+
+// schemaChangeMigrationKeyForTable returns a key prefixed with
+// schemaChangeJobMigrationKey for a specific table, to store the completion
+// status for adding a new job if the table was being added or needed to drain
+// names.
+func schemaChangeMigrationKeyForTable(tableID sqlbase.ID) roachpb.Key {
+	return encoding.EncodeUint32Ascending(schemaChangeJobMigrationKey, uint32(tableID))
+}
+
+// migrateSchemaChangeJobs runs the schema change job migration. The migration
+// has two steps. In the first step, we scan the jobs table for all
+// non-Succeeded jobs; for each job, it looks up the associated table and uses
+// the table descriptor state to update the job payload appropriately. For jobs
+// that are waiting for GC for dropped tables, indexes, etc., we mark the
+// existing job as completed and create a new GC job. In the second step, we
+// get all the descriptors and all running jobs, and create a new job for all
+// tables that are either in the ADD state or have draining names but which
+// have no running jobs, since tables in those states in 19.2 would have been
+// processed by the schema changer.
+func migrateSchemaChangeJobs(ctx context.Context, r runner, registry *jobs.Registry) error {
+	// Get all jobs that aren't Succeeded and evaluate whether they need a
+	// migration. (Jobs that are canceled in 19.2 could still have in-progress
+	// schema changes.)
+	rows, err := r.sqlExecutor.QueryEx(
+		ctx, "jobs-for-migration", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
+		"SELECT id, payload FROM system.jobs WHERE status != $1", jobs.StatusSucceeded,
+	)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		jobID := int64(tree.MustBeDInt(row[0]))
+		log.VEventf(ctx, 2, "job %d: evaluating for schema change job migration", jobID)
+
+		payload, err := jobs.UnmarshalPayload(row[1])
+		if err != nil {
+			return err
+		}
+		if details := payload.GetSchemaChange(); details == nil ||
+			details.FormatVersion > jobspb.BaseFormatVersion {
+			continue
+		}
+
+		log.Infof(ctx, "job %d: undergoing schema change job migration", jobID)
+
+		if err := r.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			// Read the job again inside the transaction. If the job was already
+			// upgraded, we don't have to do anything else.
+			job, err := registry.LoadJobWithTxn(ctx, jobID, txn)
+			if err != nil {
+				// The job could have been GC'ed in the meantime.
+				if jobs.HasJobNotFoundError(err) {
+					return nil
+				}
+				return err
+			}
+			payload := job.Payload()
+			details := payload.GetSchemaChange()
+			if details.FormatVersion > jobspb.BaseFormatVersion {
+				return nil
+			}
+
+			// Determine whether the job is for dropping a database/table. Note that
+			// DroppedTables is always populated in 19.2 for all jobs that drop
+			// tables.
+			if len(details.DroppedTables) > 0 {
+				return migrateDropTablesOrDatabaseJob(ctx, txn, registry, job)
+			}
+
+			descIDs := job.Payload().DescriptorIDs
+			// All other jobs have exactly 1 associated descriptor ID (for a table),
+			// and correspond to a schema change with a mutation.
+			if len(descIDs) != 1 {
+				return errors.AssertionFailedf(
+					"job %d: could not be migrated due to unexpected descriptor IDs %v", *job.ID(), descIDs)
+			}
+			descID := descIDs[0]
+			tableDesc, err := sqlbase.GetTableDescFromID(ctx, txn, descID)
+			if err != nil {
+				return err
+			}
+			return migrateMutationJobForTable(ctx, txn, registry, job, tableDesc)
+		}); err != nil {
+			return err
+		}
+		log.Infof(ctx, "job %d: completed schema change job migration", jobID)
+	}
+
+	// Finally, we iterate through all table descriptors and jobs, and create jobs
+	// for any tables in the ADD state or that have draining names that don't
+	// already have jobs. We start by getting all descriptors and all running jobs
+	// in a single transaction. Each eligible table then gets a job created for
+	// it, each in a separate transaction; in each of those transactions, we write
+	// a table-specific KV with a key prefixed by schemaChangeJobMigrationKey to
+	// try to prevent more than one such job from being created for the table.
+	//
+	// This process ensures that every table that entered into one of these
+	// intermediate states (being added, or having draining names) in 19.2 will
+	// have a schema change job created for it in 20.1, so that the table can
+	// finish being processed. It's not essential for only one job to be created
+	// for each table, since a redundant schema change job is a no-op, but we make
+	// an effort to do that anyway.
+	//
+	// There are probably more efficient ways to do this part of the migration,
+	// but the current approach seemed like the most straightforward.
+	var allDescs []sqlbase.DescriptorProto
+	jobsForDesc := make(map[sqlbase.ID][]int64)
+	if err := r.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		descs, err := sql.GetAllDescriptors(ctx, txn)
+		if err != nil {
+			return err
+		}
+		allDescs = descs
+
+		// Get all running schema change jobs.
+		rows, err := r.sqlExecutor.QueryEx(
+			ctx, "preexisting-jobs", txn,
+			sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
+			"SELECT id, payload FROM system.jobs WHERE status = $1", jobs.StatusRunning,
+		)
+		if err != nil {
+			return err
+		}
+		for _, row := range rows {
+			jobID := int64(tree.MustBeDInt(row[0]))
+			payload, err := jobs.UnmarshalPayload(row[1])
+			if err != nil {
+				return err
+			}
+			details := payload.GetSchemaChange()
+			if details == nil || details.FormatVersion < jobspb.JobResumerFormatVersion {
+				continue
+			}
+			if details.TableID != sqlbase.InvalidID {
+				jobsForDesc[details.TableID] = append(jobsForDesc[details.TableID], jobID)
+			} else {
+				for _, t := range details.DroppedTables {
+					jobsForDesc[t.ID] = append(jobsForDesc[t.ID], jobID)
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	createSchemaChangeJobForTable := func(txn *kv.Txn, desc *sqlbase.TableDescriptor) error {
+		var description string
+		if desc.Adding() {
+			description = fmt.Sprintf("adding table %d", desc.ID)
+		} else if desc.HasDrainingNames() {
+			description = fmt.Sprintf("draining names for table %d", desc.ID)
+		} else {
+			// This shouldn't be possible, but if it happens, it would be
+			// appropriate to do nothing without returning an error.
+			log.Warningf(
+				ctx,
+				"tried to add job for table %d which is neither being added nor has draining names",
+				desc.ID,
+			)
+			return nil
+		}
+		record := jobs.Record{
+			Description:   description,
+			Username:      security.NodeUser,
+			DescriptorIDs: sqlbase.IDs{desc.ID},
+			Details: jobspb.SchemaChangeDetails{
+				TableID:       desc.ID,
+				FormatVersion: jobspb.JobResumerFormatVersion,
+			},
+			Progress:      jobspb.SchemaChangeProgress{},
+			NonCancelable: true,
+		}
+		job, err := registry.CreateJobWithTxn(ctx, record, txn)
+		if err != nil {
+			return err
+		}
+		log.Infof(ctx, "migration created new job %d: %s", *job.ID(), description)
+		return nil
+	}
+
+	log.Infof(ctx, "evaluating tables for creating jobs")
+	for _, desc := range allDescs {
+		switch desc := desc.(type) {
+		case *sqlbase.TableDescriptor:
+			if len(jobsForDesc[desc.ID]) > 0 {
+				log.VEventf(ctx, 3, "table %d has running jobs, skipping", desc.ID)
+				continue
+			}
+			if !desc.Adding() && !desc.HasDrainingNames() {
+				log.VEventf(ctx, 3,
+					"table %d is not being added and does not have draining names, skipping",
+					desc.ID,
+				)
+				continue
+			}
+
+			if err := r.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+				key := schemaChangeMigrationKeyForTable(desc.ID)
+				startTime := timeutil.Now().String()
+				if kv, err := txn.Get(ctx, key); err != nil {
+					return err
+				} else if kv.Exists() {
+					log.VEventf(ctx, 3, "table %d already processed in migration", desc.ID)
+					return nil
+				}
+				if err := createSchemaChangeJobForTable(txn, desc); err != nil {
+					return err
+				}
+				if err := txn.Put(ctx, key, startTime); err != nil {
+					return err
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+		case *sqlbase.DatabaseDescriptor:
+			// Do nothing.
+		}
+	}
+
+	return nil
+}
+
+// migrateMutationJobForTable handles migrating jobs associated with mutations
+// on a table, each of which is stored in MutationJobs. (This includes adding
+// and dropping columns, indexes, and constraints, as well as primary key
+// changes.) This function also handles jobs for indexes waiting for GC,
+// stored in GCMutations.
+func migrateMutationJobForTable(
+	ctx context.Context,
+	txn *kv.Txn,
+	registry *jobs.Registry,
+	job *jobs.Job,
+	tableDesc *sql.TableDescriptor,
+) error {
+	log.VEventf(ctx, 2, "job %d: undergoing migration as mutation job for table %d", *job.ID(), tableDesc.ID)
+
+	// Check whether the job is for a mutation. There can be multiple mutations
+	// with the same ID that correspond to the same job, but we just need to
+	// look at one, since all the mutations with the same ID get state updates
+	// in the same transaction.
+	for i := range tableDesc.MutationJobs {
+		mutationJob := &tableDesc.MutationJobs[i]
+		if mutationJob.JobID != *job.ID() {
+			continue
+		}
+		log.VEventf(
+			ctx, 2, "job %d: found corresponding mutation %d on table %d",
+			*job.ID(), mutationJob.MutationID, tableDesc.ID,
+		)
+
+		// Update the job details and status based on the table descriptor
+		// state.
+		if err := job.WithTxn(txn).Update(ctx, func(txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+			// Update the job details with the table and mutation IDs.
+			details := md.Payload.GetSchemaChange()
+			details.TableID = tableDesc.ID
+			details.MutationID = mutationJob.MutationID
+			details.FormatVersion = jobspb.JobResumerFormatVersion
+			md.Payload.Details = jobspb.WrapPayloadDetails(*details)
+
+			log.VEventf(ctx, 2, "job %d: updating details to %+v", *job.ID(), details)
+
+			// Also give the job a non-nil expired lease to indicate that the job
+			// is adoptable.
+			md.Payload.Lease = &jobspb.Lease{}
+			ju.UpdatePayload(md.Payload)
+
+			mutation := &tableDesc.Mutations[i]
+			// If the mutation exists on the table descriptor, then the schema
+			// change isn't actually in a terminal state, regardless of what the
+			// job status is. So we force the status to Reverting if there's any
+			// indication that it failed or was canceled, and otherwise force the
+			// state to Running.
+			shouldRevert := md.Status == jobs.StatusFailed || md.Status == jobs.StatusCanceled ||
+				md.Status == jobs.StatusReverting || md.Status == jobs.StatusCancelRequested
+			previousStatus := md.Status
+			if mutation.Rollback || shouldRevert {
+				md.Status = jobs.StatusReverting
+			} else {
+				md.Status = jobs.StatusRunning
+			}
+			log.VEventf(ctx, 2, "job %d: updating status from %s to %s", *job.ID(), previousStatus, md.Status)
+			ju.UpdateStatus(md.Status)
+			return nil
+		}); err != nil {
+			return err
+		}
+		log.Infof(
+			ctx, "job %d: successfully migrated for table %d, mutation %d",
+			*job.ID(), tableDesc.ID, mutationJob.MutationID,
+		)
+		return nil
+	}
+
+	// If not a mutation, check whether the job corresponds to a GCMutation.
+	// This indicates that the job must be in the "waiting for GC TTL" state.
+	// In that case, we mark the job as succeeded and create a new job for GC.
+	for i := range tableDesc.GCMutations {
+		gcMutation := &tableDesc.GCMutations[i]
+		// JobID and dropTime are populated only in 19.2 and earlier versions.
+		if gcMutation.JobID != *job.ID() {
+			continue
+		}
+		log.VEventf(
+			ctx, 2, "job %d: found corresponding index GC mutation for index %d on table %d",
+			*job.ID(), gcMutation.IndexID, tableDesc.ID,
+		)
+		if err := registry.Succeeded(ctx, txn, *job.ID()); err != nil {
+			return err
+		}
+		log.VEventf(ctx, 2, "job %d: marked as succeeded", *job.ID())
+
+		indexGCJobRecord := sql.CreateGCJobRecord(
+			job.Payload().Description,
+			job.Payload().Username,
+			sqlbase.IDs{tableDesc.ID},
+			jobspb.SchemaChangeGCDetails{
+				Indexes: []jobspb.SchemaChangeGCDetails_DroppedIndex{
+					{
+						IndexID:  gcMutation.IndexID,
+						DropTime: gcMutation.DropTime,
+					},
+				},
+				ParentID: tableDesc.GetID(),
+			},
+		)
+		// The new job ID won't be written to GCMutations, which is fine because
+		// we don't read the job ID in 20.1 for anything except this migration.
+		newJob, err := registry.CreateJobWithTxn(ctx, indexGCJobRecord, txn)
+		if err != nil {
+			return err
+		}
+		log.Infof(ctx,
+			"migration marked drop table job %d as successful, created GC job %d",
+			*job.ID(), *newJob.ID(),
+		)
+		return nil
+	}
+
+	// If the job isn't in MutationJobs or GCMutations, it's likely just a
+	// failed or canceled job that was successfully cleaned up. Check for this,
+	// and return an error if this is not the case.
+	status, err := job.CurrentStatus(ctx)
+	if err != nil {
+		return err
+	}
+	if status == jobs.StatusCanceled || status == jobs.StatusFailed {
+		return nil
+	}
+	return errors.Newf(
+		"job %d: no corresponding mutation found on table %d during migration", *job.ID(), tableDesc.ID)
+}
+
+// migrateDropTablesOrDatabaseJob handles migrating any jobs that require
+// dropping a table, including dropping tables, views, sequences, and
+// databases, as well as truncating tables.
+func migrateDropTablesOrDatabaseJob(
+	ctx context.Context, txn *kv.Txn, registry *jobs.Registry, job *jobs.Job,
+) error {
+	payload := job.Payload()
+	details := payload.GetSchemaChange()
+	log.VEventf(ctx, 2,
+		"job %d: undergoing migration as drop table/database job for tables %+v",
+		*job.ID(), details.DroppedTables,
+	)
+
+	if job.Progress().RunningStatus == string(sql.RunningStatusDrainingNames) {
+		// If the job is draining names, the schema change job resumer will handle
+		// it. Just update the job details.
+		if err := job.WithTxn(txn).Update(ctx, func(txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+			details := md.Payload.GetSchemaChange()
+			if len(details.DroppedTables) == 1 {
+				details.TableID = details.DroppedTables[0].ID
+			}
+			details.FormatVersion = jobspb.JobResumerFormatVersion
+			md.Payload.Details = jobspb.WrapPayloadDetails(*details)
+
+			log.VEventf(ctx, 2, "job %d: updating details to %+v", *job.ID(), details)
+
+			// Also give the job a non-nil expired lease to indicate that the job
+			// is adoptable.
+			md.Payload.Lease = &jobspb.Lease{}
+			ju.UpdatePayload(md.Payload)
+			return nil
+		}); err != nil {
+			return err
+		}
+		log.Infof(ctx, "job %d: successfully migrated in draining names state", *job.ID())
+		return nil
+	}
+
+	// Otherwise, the job is in the "waiting for GC TTL" phase. In this case, we
+	// mark the present job as Succeeded and create a new GC job.
+
+	// TODO (lucy/paul): In the case of multiple tables, is it a problem if some
+	// of the tables have already been GC'ed at this point? In 19.2, each table
+	// advances separately through the stages of being dropped, so it should be
+	// possible for some tables to still be draining names while others have
+	// already undergone GC.
+
+	if err := registry.Succeeded(ctx, txn, *job.ID()); err != nil {
+		return err
+	}
+	log.VEventf(ctx, 2, "job %d: marked as succeeded", *job.ID())
+
+	tablesToDrop := make([]jobspb.SchemaChangeGCDetails_DroppedID, len(details.DroppedTables))
+	for i := range details.DroppedTables {
+		tableID := details.DroppedTables[i].ID
+		tablesToDrop[i].ID = details.DroppedTables[i].ID
+		desc, err := sqlbase.GetTableDescFromID(ctx, txn, tableID)
+		if err != nil {
+			return err
+		}
+		tablesToDrop[i].DropTime = desc.DropTime
+	}
+	gcJobRecord := sql.CreateGCJobRecord(
+		job.Payload().Description,
+		job.Payload().Username,
+		job.Payload().DescriptorIDs,
+		jobspb.SchemaChangeGCDetails{
+			Tables:   tablesToDrop,
+			ParentID: details.DroppedDatabaseID,
+		},
+	)
+	// The new job ID won't be written to DropJobID on the table descriptor(s),
+	// which is fine because we don't read the job ID in 20.1 for anything
+	// except this migration.
+	// TODO (lucy): The above is true except for the cleanup loop for orphaned
+	// jobs in the registry, which should be fixed.
+	newJob, err := registry.CreateJobWithTxn(ctx, gcJobRecord, txn)
+	if err != nil {
+		return err
+	}
+	log.Infof(ctx,
+		"migration marked drop database/table job %d as successful, created GC job %d",
+		*job.ID(), *newJob.ID(),
+	)
+	return err
 }
 
 func getCompletedMigrations(ctx context.Context, db db) (map[string]struct{}, error) {

--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -158,7 +159,7 @@ func verifySystemJob(
 	if expectedStatus != statusString {
 		return errors.Errorf("job %d: expected status %v, got %v", offset, expectedStatus, statusString)
 	}
-	if expectedRunningStatus != runningStatusString {
+	if expectedRunningStatus != "" && expectedRunningStatus != runningStatusString {
 		return errors.Errorf("job %d: expected running status %v, got %v",
 			offset, expectedRunningStatus, runningStatusString)
 	}
@@ -189,6 +190,34 @@ func VerifySystemJob(
 	expected jobs.Record,
 ) error {
 	return verifySystemJob(t, db, offset, filterType, string(expectedStatus), "", expected)
+}
+
+// GetJobFormatVersion returns the format version of a schema change job.
+// Will fail the test if the jobID does not reference a schema change job.
+func GetJobFormatVersion(
+	t testing.TB, db *sqlutils.SQLRunner,
+) jobspb.SchemaChangeDetailsFormatVersion {
+	rows := db.QueryStr(t, "SELECT * FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE' AND description <> 'updating privileges' ORDER BY created DESC LIMIT 1")
+	if len(rows) != 1 {
+		t.Fatal("expected exactly one row when checking the format version")
+	}
+	jobID, err := strconv.Atoi(rows[0][0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var payloadBytes []byte
+	db.QueryRow(t, `SELECT payload FROM system.jobs WHERE id = $1`, jobID).Scan(&payloadBytes)
+
+	payload := &jobspb.Payload{}
+	if err := protoutil.Unmarshal(payloadBytes, payload); err != nil {
+		t.Fatal(err)
+	}
+	// Lease is always nil in 19.2.
+	payload.Lease = nil
+
+	details := payload.GetSchemaChange()
+	return details.FormatVersion
 }
 
 // GetJobID gets a particular job's ID.

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -101,6 +101,9 @@ type TestServerInterface interface {
 	// JobRegistry returns the *jobs.Registry as an interface{}.
 	JobRegistry() interface{}
 
+	// MigrationManager returns the *jobs.Registry as an interface{}.
+	MigrationManager() interface{}
+
 	// SetDistSQLSpanResolver changes the SpanResolver used for DistSQL inside the
 	// server's executor. The argument must be a physicalplan.SpanResolver
 	// instance.


### PR DESCRIPTION
Backport 4/4 commits from #46504.

/cc @cockroachdb/release

---

# sqlmigrations: add migration for 19.2-style schema change jobs

This PR adds a migration which upgrades the format of any 19.2 schema
change jobs that remain on a cluster after upgrading to 20.1, so that
those schema changes can run to completion.

For context, note that schema change execution in 19.2 and 20.1 are
mutually incompatible, and 20.1 nodes are forbidden both from initiating
new schema changes before upgrade finalization and from attempting to
run 19.2-style schema changes. Any 19.2 schema changes that linger on
the cluster as a result of being in progress while upgrading the cluster
to have 20.1 binaries must be upgraded to the 20.1 job format before
they can be run in the 20.1 schema change job resumer.

This migration is run inside an async task started in `server.Start()`
after most of the other server state is initialized, and is separate
from the existing startup migrations which must be finished before the
node fully starts up. The migration itself must first wait for the
cluster upgrade to be finalized, to ensure the absence of any 19.2
binaries from the cluster. After upgrade finalization, the migration is
attempted in the background until it finishes successfully. Once any
given job undergoes the migration, it is eligible to be adopted by the
job registry.

The migration has 2 steps: In the first step, we scan all jobs, look up
the table descriptor for each job, and update the job state based on the
schema change-related state on the table descriptor. For jobs that are
waiting for GC for a dropped index, table, etc., we mark the job as
successful and create a GC job. In the second step, we scan all
descriptors and running jobs, and create a new job for each table that
is either being added or has draining names which does not have a
running schema change job. Tables in either of those two states used to
rely on a schema changer in 19.2 to move them out of those intermediate
states, and now require a job in 20.1.

As with the existing startup migrations, we write KVs to the
`system-version/` span to checkpoint the progress of the migration.

Closes #46177.

Release justification: This is needed to support the upgrade path for
the new schema change job.

Release note (general change): Schema changes started in 19.2 will now
be automatically migrated in the background in 20.1 after upgrade
finalization so that they can run to completion.

----

# sql: add schema change migration testing

This commit introduces a testing framework which tests the migration of
schema changes from the 19.2 to the 20.1 format. A test case is created
for each type of schema change so that they can be stressed and
testrace'd individually. For each schema change, the test will:

1. Create a 20.1 schema change.
2. Block the schema change at a certain point in its execution.
3. Mutate the job descriptor and table descriptor such that it appears
as a 19.2 format job. These jobs will not be resumed anymore as 20.1
will refuse to run 19.2 jobs.
4. Verify that the job has been marked as a 19.2 job and is blocked.
5. Run the migration and wait for the migration to complete.
6. Ensure that the schema change completes.

Release justification: testing feature required for release.
Release note: None

----

# testing: increase timeout for CI stress tests

This commit increases the timeout on CI so that make stressrace can
complete. There should be a follow up investigation as to why these
tests take this long to complete.

Release note: None

----

# importccl: set system config trigger in TestGetDescriptorFromDB

The transaction used to write database descriptors in
`TestGetDescriptorFromDB` was missing a call to
`txn.SetSystemConfigTrigger()`. This would be caught by
`CheckEndTxnTrigger` in some cases, in `CreateTestServerParams()`, but
it looks like the error generated by `CheckEndTxnTrigger` to indicate
that the trigger had not been set was consistently being swallowed in
`*txnCommitter.makeTxnCommitExplicitAsync()`, causing the test to pass
anyway. This test started failing with the introduction of the migration
to update schema change jobs, which needs to read all descriptors, and
in doing so somehow causes the error from `CheckEndTxnTrigger` to not be
swallowed anymore. This PR fixes the test.

Release note: None
