### PR TITLE
release-20.1: backport temporary schema cleanup shutdown races

### DIFF
--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -162,7 +162,11 @@ func WithMaxAttempts(ctx context.Context, opts Options, n int, fn func() error) 
 		}
 	}
 	if err == nil {
-		err = errors.Wrap(ctx.Err(), "did not run function")
+		if ctx.Err() != nil {
+			err = errors.Wrap(ctx.Err(), "did not run function due to context completion")
+		} else {
+			err = errors.New("did not run function due to closed opts.Closer")
+		}
 	}
 	return err
 }


### PR DESCRIPTION
Backport:
  * 1/1 commits from "sql: pass stopper.ShouldQuiesce() to retryFunc for TemporaryObjectCleaner" (#47048)
  * 1/1 commits from "retry: fix retry.WithMaxAttempt to deal with opt.Closer properly" (#47063)
  * 1/1 commits from "sql: early exit temp schema cleaner if no temp schemas found" (#47064)

Please see individual PRs for details.

/cc @cockroachdb/release
