### PR TITLE
geo/geos: fix compile error with Make

### DIFF
--- a/pkg/geo/geos/geos_unix.go
+++ b/pkg/geo/geos/geos_unix.go
@@ -93,17 +93,17 @@ func initCRGEOS(locs []string) *C.CR_GEOS {
 // goToCString returns a CR_GEOS_Slice from a given Go string.
 func goToCString(str string) C.CR_GEOS_String {
 	if len(str) == 0 {
-		return C.CR_GEOS_Slice{data: nil, len: 0}
+		return C.CR_GEOS_String{data: nil, len: 0}
 	}
 	b := []byte(str)
-	return C.CR_GEOS_Slice{
+	return C.CR_GEOS_String{
 		data: (*C.char)(unsafe.Pointer(&b[0])),
 		len:  C.size_t(len(b)),
 	}
 }
 
-// cSliceToGo converts a CR_GEOS_Slice to go bytes.
-func cSliceToUnsafeGoBytes(s C.CR_GEOS_Slice) []byte {
+// cStringToUnsafeGoBytes converts a CR_GEOS_String to go bytes.
+func cStringToUnsafeGoBytes(s C.CR_GEOS_String) []byte {
 	if s.data == nil {
 		return nil
 	}
@@ -123,7 +123,7 @@ func WKTToWKB(wkt geopb.WKT) (geopb.WKB, error) {
 	if cWKB.data == nil {
 		return nil, errors.Newf("error decoding WKT: %s", wkt)
 	}
-	unsafeWKB := cSliceToUnsafeGoBytes(cWKB)
+	unsafeWKB := cStringToUnsafeGoBytes(cWKB)
 	wkb := make([]byte, len(unsafeWKB))
 	copy(wkb, unsafeWKB)
 	defer C.free(unsafe.Pointer(cWKB.data))

--- a/pkg/geo/geos/geos_unix.h
+++ b/pkg/geo/geos/geos_unix.h
@@ -23,7 +23,8 @@ typedef struct {
   size_t len;
 } CR_GEOS_Slice;
 
-// CR_GEOS_String is a wrapper around a Go string.
+// CR_GEOS_String is a wrapper around a Go string. The data it
+// contains must be freed via a call to free().
 typedef struct {
   char *data;
   size_t len;


### PR DESCRIPTION
We've used CSlice where we should have used CString in various places.
This only came out when compiling with Make.

Release note: None