### PR TITLE
sql: validate index columns prior to creating index

### DIFF
--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -114,6 +114,11 @@ func (p *planner) setupFamilyAndConstraintForShard(
 func MakeIndexDescriptor(
 	params runParams, n *tree.CreateIndex, tableDesc *sqlbase.MutableTableDescriptor,
 ) (*sqlbase.IndexDescriptor, error) {
+	// Ensure that the columns we want to index exist before trying to create the
+	// index.
+	if err := validateIndexColumnsExist(tableDesc, n.Columns); err != nil {
+		return nil, err
+	}
 	indexDesc := sqlbase.IndexDescriptor{
 		Name:              string(n.Name),
 		Unique:            n.Unique,
@@ -177,6 +182,23 @@ func MakeIndexDescriptor(
 		return nil, err
 	}
 	return &indexDesc, nil
+}
+
+// validateIndexColumnsExists validates that the columns for an index exist
+// in the table and are not being dropped prior to attempting to add the index.
+func validateIndexColumnsExist(
+	desc *sqlbase.MutableTableDescriptor, columns tree.IndexElemList,
+) error {
+	for _, column := range columns {
+		_, dropping, err := desc.FindColumnByName(column.Column)
+		if err != nil {
+			return err
+		}
+		if dropping {
+			return sqlbase.NewUndefinedColumnError(string(column.Column))
+		}
+	}
+	return nil
 }
 
 // ReadingOwnWrites implements the planNodeReadingOwnWrites interface.

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -877,7 +877,7 @@ CREATE TABLE t.test (a STRING PRIMARY KEY, b STRING, c STRING, INDEX foo (c));
 	mt.makeMutationsActive()
 	// Add column DROP mutation "b"
 	mt.writeColumnMutation("b", sqlbase.DescriptorMutation{Direction: sqlbase.DescriptorMutation_DROP})
-	if _, err := sqlDB.Exec(`CREATE INDEX bar ON t.test (b)`); !testutils.IsError(err, `index "bar" contains unknown column "b"`) {
+	if _, err := sqlDB.Exec(`CREATE INDEX bar ON t.test (b)`); !testutils.IsError(err, `column "b" does not exist`) {
 		t.Fatal(err)
 	}
 	// Make "b" live.

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -17,7 +17,7 @@ CREATE INDEX foo ON t (b)
 statement error duplicate index name: \"foo\"
 CREATE INDEX foo ON t (a)
 
-statement error index \"bar\" contains unknown column \"c\"
+statement error column "c" does not exist
 CREATE INDEX bar ON t (c)
 
 statement error index \"bar\" contains duplicate column \"b\"
@@ -188,3 +188,22 @@ create_index_concurrently_tbl  CREATE TABLE create_index_concurrently_tbl (
 
 statement ok
 DROP TABLE create_index_concurrently_tbl
+
+# Test that creating an index on a column which is currently being dropped
+# causes an error.
+subtest create_index_on_dropping_column
+
+statement ok
+CREATE TABLE create_idx_drop_column (c0 INT PRIMARY KEY, c1 INT);
+
+statement ok
+begin; ALTER TABLE create_idx_drop_column DROP COLUMN c1;
+
+statement error column "c1" does not exist
+CREATE INDEX idx_create_idx_drop_column ON create_idx_drop_column (c1);
+
+statement ok
+ROLLBACK;
+
+statement ok
+DROP TABLE create_idx_drop_column;

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -475,3 +475,38 @@ CREATE TABLE t (x INT, y INT, PRIMARY KEY (x, y) USING HASH WITH BUCKET_COUNT = 
 
 statement error pq: interleaved indexes cannot also be hash sharded
 CREATE INDEX ON parent (x) USING HASH WITH BUCKET_COUNT = 10 INTERLEAVE IN PARENT parent(x)
+
+statement ok
+DROP TABLE parent;
+
+# This test ensures that the appropriate error is returned when trying to create
+# a hash sharded index with a column which does not exist.
+subtest column_does_not_exist
+
+statement ok
+CREATE TABLE t0();
+
+statement error column "c0" does not exist
+CREATE INDEX ON t0 (c0) USING HASH WITH BUCKET_COUNT = 8;
+
+statement ok
+DROP TABLE t0;
+
+# Test that creating an index on a column which is currently being dropped
+# causes an error.
+subtest create_hash_index_on_dropping_column
+
+statement ok
+CREATE TABLE create_idx_drop_column (c0 INT PRIMARY KEY, c1 INT);
+
+statement ok
+begin; ALTER TABLE create_idx_drop_column DROP COLUMN c1;
+
+statement error column "c1" does not exist
+CREATE INDEX idx_create_idx_drop_column ON create_idx_drop_column (c1) USING HASH WITH BUCKET_COUNT = 8;
+
+statement ok
+ROLLBACK;
+
+statement ok
+DROP TABLE create_idx_drop_column;

--- a/pkg/sql/opt/exec/execbuilder/testdata/ddl
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ddl
@@ -141,7 +141,7 @@ CREATE INDEX foo ON t (b)
 statement error duplicate index name: \"foo\"
 CREATE INDEX foo ON t (a)
 
-statement error index \"bar\" contains unknown column \"c\"
+statement error column "c" does not exist
 CREATE INDEX bar ON t (c)
 
 statement error index \"bar\" contains duplicate column \"b\"


### PR DESCRIPTION
Prior to this change, index creation would not validate the state of the index
until after the table descriptor had been updated. This was somewhat unfortunate
because it lead to an error in sqlbase which did not have an error code and did
not match up with postgres. This was more unfortunate because it led to an
assertion failure in the hash sharded index creation code.

Fixes #47037.

Before:

```
root@127.0.0.1:45631/movr> CREATE TABLE t1();
CREATE TABLE

root@localhost:26257/defaultdb> CREATE INDEX ON t1(c0);
ERROR: index "t1_c0_idx" contains unknown column "c0"

root@localhost:26257/defaultdb> CREATE INDEX ON t1(c0) USING HASH WITH BUCKET_COUNT = 8;
ERROR: internal error: could not find column family for the first column in the index column set
SQLSTATE: XX000
DETAIL: stack trace:
/go/src/github.com/cockroachdb/cockroach/pkg/sql/create_index.go:66: setupFamilyAndConstraintForShard()
...
```

After:
```
root@127.0.0.1:45631/movr> CREATE TABLE t1();
CREATE TABLE

root@127.0.0.1:45631/movr> CREATE INDEX ON t1(c0);
ERROR: column "c0" does not exist
SQLSTATE: 42703

root@127.0.0.1:45631/movr> CREATE INDEX ON t1(c0) USING HASH WITH BUCKET_COUNT = 8;
ERROR: column "c0" does not exist
SQLSTATE: 42703
```

Postgres:
```
postgres=# CREATE INDEX ON t1(c0);
ERROR:  42703: column "c0" does not exist
LOCATION:  ComputeIndexAttrs, indexcmds.c:1086
```

Release note (bug fix): Return proper error for index creation statements
using a column which does not exist.