### PR TITLE
release-19.2: colexec: fix cfetcher with interleaved tables with NULL in key

### DIFF
--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -169,6 +169,11 @@ func decodeTableKeyToCol(
 		vec.Nulls().SetNull(idx)
 		return key, nil
 	}
+	// We might have read a NULL value in the interleaved child table which
+	// would update the nulls vector, so we need to explicitly unset the null
+	// value here.
+	vec.Nulls().UnsetNull(idx)
+
 	var rkey []byte
 	var err error
 	switch valType.Family() {

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1107,3 +1107,16 @@ query I
 SELECT count(*) FROM t46183 WHERE y->'y' = to_jsonb('hello')
 ----
 1
+
+# Regression test for #47029 (not resetting nulls vector when cfetcher read a
+# NULL value in the interleaved table).
+statement ok
+CREATE TABLE t47029_0(c0 INT);
+CREATE TABLE t47029_1(c0 INT);
+INSERT INTO t47029_0(c0) VALUES(0);
+INSERT INTO t47029_1(c0) VALUES(NULL);
+CREATE INDEX ON t47029_1(c0) INTERLEAVE IN PARENT t47029_0(c0)
+
+query I
+SELECT * FROM t47029_0 WHERE (t47029_0.rowid > 0) IS NULL
+----


### PR DESCRIPTION
Backport 1/1 commits from #47035.

/cc @cockroachdb/release

---

Previously `cFetcher` could decode an interleaved table's `NULL` value
which would set the NULL in the corresponding column vector but would
not unset the null while it should have.

Fixes: #47029.

Release note (bug fix): Previously, CockroachDB could incorrectly
consider non-NULL value from an interleaved parent table to be NULL when
the interleaved child has NULL value in the row with the corresponding
index key, and now this has been fixed.
