### PR TITLE
release-20.1: colexec: fix fallback for unsupported join types

### DIFF
--- a/pkg/sql/colexec/hashjoiner.go
+++ b/pkg/sql/colexec/hashjoiner.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
 )
 
 // hashJoinerState represents the state of the hash join columnar operator.
@@ -626,7 +626,7 @@ func makeHashJoinerSpec(
 		rightDistinct = true
 	case sqlbase.JoinType_LEFT_ANTI:
 	default:
-		return spec, errors.Errorf("hash join of type %s not supported", joinType)
+		return spec, errors.AssertionFailedf("hash join of type %s not supported", joinType)
 	}
 
 	left := hashJoinerSourceSpec{

--- a/pkg/sql/colexec/mergejoiner.go
+++ b/pkg/sql/colexec/mergejoiner.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
 	"github.com/marusama/semaphore"
 )
 
@@ -251,10 +252,8 @@ func newMergeJoinOp(
 	case sqlbase.JoinType_LEFT_ANTI:
 		return &mergeJoinLeftAntiOp{base}, err
 	default:
-		execerror.VectorizedInternalPanic("unsupported join type")
+		return nil, errors.AssertionFailedf("merge join of type %s not supported", joinType)
 	}
-	// This code is unreachable, but the compiler cannot infer that.
-	return nil, nil
 }
 
 // Const declarations for the merge joiner cross product (MJCP) zero state.

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -134,3 +134,22 @@ EXPLAIN (VEC) SELECT stddev((t46404_1.c0 > ANY (0, 0))::INT) FROM t46404_0, t464
     └ *colexec.hashJoiner
       ├ *colexec.colBatchScan
       └ *colexec.colBatchScan
+
+statement ok
+CREATE TABLE xyz (
+  x INT,
+  y INT,
+  z TEXT
+)
+
+# Check that we fallback gracefully to row-by-row engine on a join type that
+# we don't support.
+query T
+EXPLAIN (VEC) (SELECT y FROM xyz) EXCEPT ALL (SELECT x AS y FROM xyz) ORDER BY y
+----
+│
+└ Node 1
+  └ *colexec.sortOp
+    └ *rowexec.hashJoiner
+      ├ *colexec.colBatchScan
+      └ *colexec.colBatchScan


### PR DESCRIPTION
Backport 1/1 commits from #47046.

/cc @cockroachdb/release

---

Previously, we didn't check whether the join type is supported by the
vectorized engine in `isSupported` check which would not allow us to
fallback to row engine on such queries, and this is now fixed.

Release note: None
