### PR TITLE
geo/geos: clarify semantics of CR_GEOS_Slice and CR_GEOS_String

### DIFF
--- a/pkg/geo/geos/geos_unix.h
+++ b/pkg/geo/geos/geos_unix.h
@@ -17,13 +17,21 @@ extern "C" {
 // Data Types adapted from `capi/geos_c.h.in` in GEOS.
 typedef void *CR_GEOS_Geometry;
 
-// CR_GEOS_Slice is a wrapper around a Go slice.
+// NB: Both CR_GEOS_Slice and CR_GEOS_String can contain non-printable
+// data, so neither is necessarily compatible with a NUL character
+// terminated C string. Functions that need data that does not contain
+// the NUL character, so that they can convert to a NUL terminated C
+// string, must document that additional constraint in their interface.
+
+// CR_GEOS_Slice contains data that does not need to be freed. It
+// can be either a Go or C pointer (which indicates who allocated the
+// memory).
 typedef struct {
   char *data;
   size_t len;
 } CR_GEOS_Slice;
 
-// CR_GEOS_String is a wrapper around a Go string.
+// CR_GEOS_String contains a C pointer that needs to be freed.
 typedef struct {
   char *data;
   size_t len;
@@ -33,13 +41,15 @@ typedef struct {
 typedef struct CR_GEOS CR_GEOS;
 
 // CR_GEOS_Init initializes the provided GEOSLib with GEOS using dlopen/dlsym.
-// Returns a string containing an error if an error was found.
+// Returns a string containing an error if an error was found. The loc slice
+// must be convertible to a NUL character terminated C string.
 // The CR_GEOS object will be stored in lib.
-// The error returned does not need to be freed.
-char *CR_GEOS_Init(CR_GEOS_String loc, CR_GEOS **lib);
+// The error returned does not need to be freed (see comment for CR_GEOS_Slice).
+CR_GEOS_Slice CR_GEOS_Init(CR_GEOS_Slice loc, CR_GEOS **lib);
 
-// CR_GEOS_WKTToWKB converts a given WKT into it's WKB form.
-CR_GEOS_String CR_GEOS_WKTToWKB(CR_GEOS *lib, CR_GEOS_String wkt);
+// CR_GEOS_WKTToWKB converts a given WKT into it's WKB form. The wkt slice must be
+// convertible to a NUL character terminated C string.
+CR_GEOS_String CR_GEOS_WKTToWKB(CR_GEOS *lib, CR_GEOS_Slice wkt);
 
 // CR_GEOS_ClipWKBByRect clips a given WKB by the given rectangle.
 CR_GEOS_String CR_GEOS_ClipWKBByRect(


### PR DESCRIPTION
and fix current uses.

Also changed CR_GEOS_Init to return a CR_GEOS_Slice instead of
a char* error so it can be meaningfully handled in Go code.

Release note: None