### PR TITLE
release-20.1: ui: Refactor usage of `latency parse`

### DIFF
--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -39,13 +39,13 @@ const rowsBars = [
 ];
 
 const latencyBars = [
-  bar("bar-chart__latency--parse", (d: StatementStatistics) => d.stats.parse_lat.mean),
-  bar("bar-chart__latency--plan", (d: StatementStatistics) => d.stats.plan_lat.mean),
-  bar("bar-chart__latency--run", (d: StatementStatistics) => d.stats.run_lat.mean),
-  bar("bar-chart__latency--overhead", (d: StatementStatistics) => d.stats.overhead_lat.mean),
+  bar("bar-chart__parse", (d: StatementStatistics) => d.stats.parse_lat.mean),
+  bar("bar-chart__plan", (d: StatementStatistics) => d.stats.plan_lat.mean),
+  bar("bar-chart__run", (d: StatementStatistics) => d.stats.run_lat.mean),
+  bar("bar-chart__overhead", (d: StatementStatistics) => d.stats.overhead_lat.mean),
 ];
 
-const latencyStdDev = bar("bar-chart__latency--overall-dev", (d: StatementStatistics) => stdDevLong(d.stats.service_lat, d.stats.count));
+const latencyStdDev = bar("bar-chart__overall-dev", (d: StatementStatistics) => stdDevLong(d.stats.service_lat, d.stats.count));
 const rowsStdDev = bar("rows-dev", (d: StatementStatistics) => stdDevLong(d.stats.num_rows, d.stats.count));
 
 function bar(name: string, value: (d: StatementStatistics) => number) {
@@ -149,8 +149,8 @@ const makeBarChart = (
               <div className="bar-chart__label">{ formatter(getTotal(d)) }</div>
               <div className="bar-chart__multiplebars">
                 <div
-                  key="bar-chart__latency--parse"
-                  className="bar-chart__latency--parse bar-chart__bar"
+                  key="bar-chart__parse"
+                  className="bar-chart__parse bar-chart__bar"
                   style={{ width: scale(getTotal(d)) + "%" }}
                 />
                 { renderStdDev() }
@@ -163,8 +163,8 @@ const makeBarChart = (
           <div className={className}>
             <div className="bar-chart__label">{ formatter(getTotal(d)) }</div>
             <div
-              key="bar-chart__latency--parse"
-              className="bar-chart__latency--parse bar-chart__bar"
+              key="bar-chart__parse"
+              className="bar-chart__parse bar-chart__bar"
               style={{ width: scale(getTotal(d)) + "%" }}
             />
           </div>
@@ -258,11 +258,11 @@ export function latencyBreakdown(s: StatementStatistics) {
             <div className="bar-chart__label">{ Duration(parseMean * 1e9) }</div>
             <div className="bar-chart__multiplebars">
               <div
-                className="bar-chart__latency--parse bar-chart__bar"
+                className="bar-chart__parse bar-chart__bar"
                 style={{ width: right + "%", position: "absolute", left: 0 }}
               />
               <div
-                className="bar-chart__latency--parse-dev bar-chart__bar bar-chart__bar--dev"
+                className="bar-chart__parse-dev bar-chart__bar bar-chart__bar--dev"
                 style={{ width: spread + "%", position: "absolute", left: width + "%" }}
               />
             </div>
@@ -283,11 +283,11 @@ export function latencyBreakdown(s: StatementStatistics) {
             <div className="bar-chart__label">{ Duration(planMean * 1e9) }</div>
             <div className="bar-chart__multiplebars">
               <div
-                className="bar-chart__latency--plan bar-chart__bar"
+                className="bar-chart__plan bar-chart__bar"
                 style={{ width: right + "%", position: "absolute", left: left + "%" }}
               />
               <div
-                className="bar-chart__latency--plan-dev bar-chart__bar bar-chart__bar--dev"
+                className="bar-chart__plan-dev bar-chart__bar bar-chart__bar--dev"
                 style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
               />
             </div>
@@ -308,11 +308,11 @@ export function latencyBreakdown(s: StatementStatistics) {
             <div className="bar-chart__label">{ Duration(runMean * 1e9) }</div>
             <div className="bar-chart__multiplebars">
               <div
-                className="bar-chart__latency--run bar-chart__bar"
+                className="bar-chart__run bar-chart__bar"
                 style={{ width: right + "%", position: "absolute", left: left + "%" }}
               />
               <div
-                className="bar-chart__latency--run-dev bar-chart__bar bar-chart__bar--dev"
+                className="bar-chart__run-dev bar-chart__bar bar-chart__bar--dev"
                 style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
               />
             </div>
@@ -333,11 +333,11 @@ export function latencyBreakdown(s: StatementStatistics) {
             <div className="bar-chart__label">{ Duration(overheadMean * 1e9) }</div>
             <div className="bar-chart__multiplebars">
               <div
-                className="bar-chart__latency--overhead bar-chart__bar"
+                className="bar-chart__overhead bar-chart__bar"
                 style={{ width: right + "%", position: "absolute", left: left + "%" }}
               />
               <div
-                className="bar-chart__latency--overhead-dev bar-chart__bar bar-chart__bar--dev"
+                className="bar-chart__overhead-dev bar-chart__bar bar-chart__bar--dev"
                 style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
               />
             </div>
@@ -360,11 +360,11 @@ export function latencyBreakdown(s: StatementStatistics) {
             <div className="bar-chart__label">{ Duration(overallMean * 1e9) }</div>
             <div className="bar-chart__multiplebars">
               <div
-                className="bar-chart__latency--parse bar-chart__bar"
+                className="bar-chart__parse bar-chart__bar"
                 style={{ width: parse + plan + run + overhead + "%", position: "absolute", left: 0 }}
               />
               <div
-                className="bar-chart__latency--overall-dev bar-chart__bar bar-chart__bar--dev"
+                className="bar-chart__overall-dev bar-chart__bar bar-chart__bar--dev"
                 style={{ width: spread + "%", position: "absolute", left: width + "%" }}
               />
             </div>

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -17,6 +17,7 @@ import { stdDevLong } from "src/util/appStats";
 import { FixLong } from "src/util/fixLong";
 import { Duration } from "src/util/format";
 import { ToolTipWrapper } from "src/views/shared/components/toolTip";
+import classNames from "classnames";
 
 type StatementStatistics = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 
@@ -38,13 +39,13 @@ const rowsBars = [
 ];
 
 const latencyBars = [
-  bar("latency-parse", (d: StatementStatistics) => d.stats.parse_lat.mean),
-  bar("latency-plan", (d: StatementStatistics) => d.stats.plan_lat.mean),
-  bar("latency-run", (d: StatementStatistics) => d.stats.run_lat.mean),
-  bar("latency-overhead", (d: StatementStatistics) => d.stats.overhead_lat.mean),
+  bar("bar-chart__latency--parse", (d: StatementStatistics) => d.stats.parse_lat.mean),
+  bar("bar-chart__latency--plan", (d: StatementStatistics) => d.stats.plan_lat.mean),
+  bar("bar-chart__latency--run", (d: StatementStatistics) => d.stats.run_lat.mean),
+  bar("bar-chart__latency--overhead", (d: StatementStatistics) => d.stats.overhead_lat.mean),
 ];
 
-const latencyStdDev = bar("latency-overall-dev", (d: StatementStatistics) => stdDevLong(d.stats.service_lat, d.stats.count));
+const latencyStdDev = bar("bar-chart__latency--overall-dev", (d: StatementStatistics) => stdDevLong(d.stats.service_lat, d.stats.count));
 const rowsStdDev = bar("rows-dev", (d: StatementStatistics) => stdDevLong(d.stats.num_rows, d.stats.count));
 
 function bar(name: string, value: (d: StatementStatistics) => number) {
@@ -74,25 +75,20 @@ function renderNumericStatLegend(count: number | Long, stat: number, sd: number,
   );
 }
 
-function makeBarChart(
+const makeBarChart = (
+  type: "grey" | "red",
   accessors: { name: string, value: (d: StatementStatistics) => number }[],
   formatter: (d: number) => string = (x) => `${x}`,
   stdDevAccessor?: { name: string, value: (d: StatementStatistics) => number },
   legendFormatter?: (d: number) => string,
-) {
+) => {
   if (!legendFormatter) {
     legendFormatter = formatter;
   }
 
-  return function barChart(rows: StatementStatistics[] = []) {
-    function getTotal(d: StatementStatistics) {
-      return _.sum(_.map(accessors, ({ value }) => value(d)));
-    }
-
-    function getTotalWithStdDev(d: StatementStatistics) {
-      const mean = getTotal(d);
-      return mean + stdDevAccessor.value(d);
-    }
+  return (rows: StatementStatistics[] = []) => {
+    const getTotal = (d: StatementStatistics) => _.sum(_.map(accessors, ({ value }) => value(d)));
+    const getTotalWithStdDev = (d: StatementStatistics) => getTotal(d) + stdDevAccessor.value(d);
 
     const extent = d3.extent(rows, stdDevAccessor ? getTotalWithStdDev : getTotal);
 
@@ -100,13 +96,13 @@ function makeBarChart(
       .domain([0, extent[1]])
       .range([0, 100]);
 
-    return function renderBarChart(d: StatementStatistics) {
+    return (d: StatementStatistics) => {
       if (rows.length === 0) {
         scale.domain([0, getTotal(d)]);
       }
 
       let sum = 0;
-      accessors.map(({ name, value }) => {
+      _.map(accessors, ({ name, value }) => {
         const v = value(d);
         sum += v;
         return (
@@ -118,7 +114,7 @@ function makeBarChart(
         );
       });
 
-      function renderStdDev() {
+      const renderStdDev = () => {
         if (!stdDevAccessor) {
           return null;
         }
@@ -128,27 +124,33 @@ function makeBarChart(
         const stddev = value(d);
         const width = stddev + (stddev > sum ? sum : stddev);
         const left = stddev > sum ? 0 : sum - stddev;
-
+        const cn = classNames(name, "bar-chart__bar", "bar-chart__bar--dev");
+        const style = {
+          width: scale(width) + "%",
+          left: scale(left) + "%",
+        };
         return (
           <div
-            className={ name + " bar-chart__bar bar-chart__bar--dev" }
-            style={{ width: scale(width) + "%", left: scale(left) + "%" }}
+            className={cn}
+            style={style}
           />
         );
-      }
+      };
 
+      const className = classNames("bar-chart", `bar-chart-${type}`, {
+        "bar-chart--singleton": rows.length === 0,
+      });
       if (stdDevAccessor) {
         const sd = stdDevAccessor.value(d);
         const titleText = renderNumericStatLegend(rows.length, sum, sd, legendFormatter);
-
         return (
-          <div className={ "bar-chart" + (rows.length === 0 ? " bar-chart--singleton" : "") }>
+          <div className={ className}>
             <ToolTipWrapper text={ titleText } short>
-              <div className="label">{ formatter(getTotal(d)) }</div>
+              <div className="bar-chart__label">{ formatter(getTotal(d)) }</div>
               <div className="bar-chart__multiplebars">
                 <div
-                  key="latency-parse"
-                  className="latency-parse bar-chart__bar"
+                  key="bar-chart__latency--parse"
+                  className="bar-chart__latency--parse bar-chart__bar"
                   style={{ width: scale(getTotal(d)) + "%" }}
                 />
                 { renderStdDev() }
@@ -158,11 +160,11 @@ function makeBarChart(
         );
       } else {
         return (
-          <div className={ "bar-chart" + (rows.length === 0 ? " bar-chart--singleton" : "") }>
-            <div className="label">{ formatter(getTotal(d)) }</div>
+          <div className={className}>
+            <div className="bar-chart__label">{ formatter(getTotal(d)) }</div>
             <div
-              key="latency-parse"
-              className="latency-parse bar-chart__bar"
+              key="bar-chart__latency--parse"
+              className="bar-chart__latency--parse bar-chart__bar"
               style={{ width: scale(getTotal(d)) + "%" }}
             />
           </div>
@@ -170,7 +172,7 @@ function makeBarChart(
       }
     };
   };
-}
+};
 
 const SCALE_FACTORS: { factor: number, key: string }[] = [
   { factor: 1000000000, key: "b" },
@@ -189,10 +191,10 @@ export function approximify(value: number) {
   return "" + Math.round(value);
 }
 
-export const countBarChart = makeBarChart(countBars, approximify);
-export const retryBarChart = makeBarChart(retryBars, approximify);
-export const rowsBarChart = makeBarChart(rowsBars, approximify, rowsStdDev, formatTwoPlaces);
-export const latencyBarChart = makeBarChart(latencyBars, v => Duration(v * 1e9), latencyStdDev);
+export const countBarChart = makeBarChart("grey", countBars, approximify);
+export const retryBarChart = makeBarChart("red", retryBars, approximify);
+export const rowsBarChart = makeBarChart("grey", rowsBars, approximify, rowsStdDev, formatTwoPlaces);
+export const latencyBarChart = makeBarChart("grey", latencyBars, v => Duration(v * 1e9), latencyStdDev);
 
 export function rowsBreakdown(s: StatementStatistics) {
   const mean = s.stats.num_rows.mean;
@@ -253,14 +255,14 @@ export function latencyBreakdown(s: StatementStatistics) {
       return (
         <ToolTipWrapper text={ title } short>
           <div className="bar-chart bar-chart--breakdown">
-            <div className="label">{ Duration(parseMean * 1e9) }</div>
+            <div className="bar-chart__label">{ Duration(parseMean * 1e9) }</div>
             <div className="bar-chart__multiplebars">
               <div
-                className="latency-parse bar-chart__bar"
+                className="bar-chart__latency--parse bar-chart__bar"
                 style={{ width: right + "%", position: "absolute", left: 0 }}
               />
               <div
-                className="latency-parse-dev bar-chart__bar bar-chart__bar--dev"
+                className="bar-chart__latency--parse-dev bar-chart__bar bar-chart__bar--dev"
                 style={{ width: spread + "%", position: "absolute", left: width + "%" }}
               />
             </div>
@@ -278,14 +280,14 @@ export function latencyBreakdown(s: StatementStatistics) {
       return (
         <ToolTipWrapper text={ title } short>
           <div className="bar-chart bar-chart--breakdown">
-            <div className="label">{ Duration(planMean * 1e9) }</div>
+            <div className="bar-chart__label">{ Duration(planMean * 1e9) }</div>
             <div className="bar-chart__multiplebars">
               <div
-                className="latency-plan bar-chart__bar"
+                className="bar-chart__latency--plan bar-chart__bar"
                 style={{ width: right + "%", position: "absolute", left: left + "%" }}
               />
               <div
-                className="latency-plan-dev bar-chart__bar bar-chart__bar--dev"
+                className="bar-chart__latency--plan-dev bar-chart__bar bar-chart__bar--dev"
                 style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
               />
             </div>
@@ -303,14 +305,14 @@ export function latencyBreakdown(s: StatementStatistics) {
       return (
         <ToolTipWrapper text={ title } short>
           <div className="bar-chart bar-chart--breakdown">
-            <div className="label">{ Duration(runMean * 1e9) }</div>
+            <div className="bar-chart__label">{ Duration(runMean * 1e9) }</div>
             <div className="bar-chart__multiplebars">
               <div
-                className="latency-run bar-chart__bar"
+                className="bar-chart__latency--run bar-chart__bar"
                 style={{ width: right + "%", position: "absolute", left: left + "%" }}
               />
               <div
-                className="latency-run-dev bar-chart__bar bar-chart__bar--dev"
+                className="bar-chart__latency--run-dev bar-chart__bar bar-chart__bar--dev"
                 style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
               />
             </div>
@@ -328,14 +330,14 @@ export function latencyBreakdown(s: StatementStatistics) {
       return (
         <ToolTipWrapper text={ title } short>
           <div className="bar-chart bar-chart--breakdown">
-            <div className="label">{ Duration(overheadMean * 1e9) }</div>
+            <div className="bar-chart__label">{ Duration(overheadMean * 1e9) }</div>
             <div className="bar-chart__multiplebars">
               <div
-                className="latency-overhead bar-chart__bar"
+                className="bar-chart__latency--overhead bar-chart__bar"
                 style={{ width: right + "%", position: "absolute", left: left + "%" }}
               />
               <div
-                className="latency-overhead-dev bar-chart__bar bar-chart__bar--dev"
+                className="bar-chart__latency--overhead-dev bar-chart__bar bar-chart__bar--dev"
                 style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
               />
             </div>
@@ -355,14 +357,14 @@ export function latencyBreakdown(s: StatementStatistics) {
       return (
         <ToolTipWrapper text={ title } short>
           <div className="bar-chart bar-chart--breakdown">
-            <div className="label">{ Duration(overallMean * 1e9) }</div>
+            <div className="bar-chart__label">{ Duration(overallMean * 1e9) }</div>
             <div className="bar-chart__multiplebars">
               <div
-                className="latency-parse bar-chart__bar"
+                className="bar-chart__latency--parse bar-chart__bar"
                 style={{ width: parse + plan + run + overhead + "%", position: "absolute", left: 0 }}
               />
               <div
-                className="latency-overall-dev bar-chart__bar bar-chart__bar--dev"
+                className="bar-chart__latency--overall-dev bar-chart__bar bar-chart__bar--dev"
                 style={{ width: spread + "%", position: "absolute", left: width + "%" }}
               />
             </div>

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -99,9 +99,10 @@
   .bar-chart
     margin-left 0
 
-    .label
+    &__label
       left 0
       width 40px
+      min-width 40px
 
 .bar-chart
   height 14px
@@ -122,7 +123,7 @@
     display flex
     align-items center
   
-  .label
+  &__label
     position relative
     font-family SourceSansPro-Regular
     font-size 12px
@@ -154,16 +155,20 @@
     border-radius 3px
 
   .rows-dev
-    background-color $blue
+    background-color $colors--primary-blue-3
 
-  .latency-parse, .latency-plan, .latency-run, .latency-overhead, .latency-overall
-    background-color $grey-light
+  &-grey
+    .bar-chart__latency
+      &--parse, &--plan, &--run, &--overhead, &--overall
+        background-color $colors--neutral-4
+  &-red
+    .bar-chart__latency
+      &--parse, &--plan, &--run, &--overhead, &--overall
+        background-color $colors--functional-red-2
 
-  .latency-parse-dev, .latency-plan-dev, .latency-run-dev, .latency-overhead-dev
-    background-color $blue
-
-  .latency-overall-dev
-    background-color $blue
+  &__latency
+    &--parse-dev, &--plan-dev, &--run-dev, &--overhead-dev, &--overall-dev
+      background-color $colors--primary-blue-3
 
 .numeric-stats-table
   @extend $table-base
@@ -204,7 +209,7 @@
 
     &--dev
       height 3px
-      background-color $blue
+      background-color $colors--primary-blue-3
 
 $plan-node-line-color = #DADADA                                 // connecting line: light gray
 $plan-node-warning-color = #b26000                              // dark orange
@@ -411,7 +416,7 @@ $plan-node-attribute-key-color = #37a806                        // light green
   text-decoration none
   cursor pointer
   &:hover
-    color $blue
+    color $colors--primary-blue-3
     text-decoration underline
   ._text-bold
     font-family RobotoMono-Bold

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -157,17 +157,16 @@
   .rows-dev
     background-color $colors--primary-blue-3
 
-  &-grey
-    .bar-chart__latency
-      &--parse, &--plan, &--run, &--overhead, &--overall
-        background-color $colors--neutral-4
+  .bar-chart
+    &__parse, &__plan, &__run, &__overhead, &__overall
+      background-color $colors--neutral-4
+  
   &-red
-    .bar-chart__latency
-      &--parse, &--plan, &--run, &--overhead, &--overall
+    .bar-chart
+      &__parse, &__plan, &__run, &__overhead, &__overall
         background-color $colors--functional-red-2
 
-  &__latency
-    &--parse-dev, &--plan-dev, &--run-dev, &--overhead-dev, &--overall-dev
+  &__parse-dev, &__plan-dev, &__run-dev, &__overhead-dev, &__overall-dev
       background-color $colors--primary-blue-3
 
 .numeric-stats-table


### PR DESCRIPTION
Backport 2/2 commits from #46574.

/cc @cockroachdb/release

---

Fixed `Retries` bar chart
Refactored code,
changed `latency-parse` class names for more clear

Resolves: #46445

Release justification: bug fixes and low-risk updates to new functionality

Release note (ui): fix and clean up code of barcharts on statements page
