### PR TITLE
release-20.1: backupccl: stop including system db as complete in full cluster backup

### DIFF
--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -572,7 +572,10 @@ func fullClusterTargets(
 	for _, desc := range allDescs {
 		if dbDesc := desc.GetDatabase(); dbDesc != nil {
 			fullClusterDescs = append(fullClusterDescs, desc)
-			fullClusterDBs = append(fullClusterDBs, dbDesc)
+			if dbDesc.ID != sqlbase.SystemDB.ID {
+				// The only database that isn't being fully backed up is the system DB.
+				fullClusterDBs = append(fullClusterDBs, dbDesc)
+			}
 		}
 		if tableDesc := desc.Table(hlc.Timestamp{}); tableDesc != nil {
 			if tableDesc.ParentID == sqlbase.SystemDB.ID {


### PR DESCRIPTION
Backport 1/1 commits from #47092.

/cc @cockroachdb/release

---

When we perform a full-cluster backup we were including the system
database as a "complete database", however full cluster backup only
backs up a subset of the tables in the system table.

This led to bugs around taking several backups with revision history
since we would look for changes in all table descriptors for system
tables, but we should have only been looking for differences in system
tables that were backed up.

Fixes #47050.

Release justification: fixes release blocker.
Release note (bug fix): in some cases where system tables have changed,
incremental, full-cluster BACKUPs with revision history were sometimes
incorrectly disallowed.
