### PR TITLE
roachtest: bump tpchvec slowness threshold

### DIFF
--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -68,7 +68,7 @@ func registerTPCHVec(r *testRegistry) {
 	// the noise.
 	slownessThresholdByVersion := map[crdbVersion]float64{
 		version19_2: 1.5,
-		version20_1: 1.15,
+		version20_1: 1.2,
 	}
 
 	TPCHTables := []string{


### PR DESCRIPTION
This bumps the failure slowness threshold from 15% to 20%.

Fixes: #47118.

Release note: None