### PR TITLE
sqlmigrations: create GC jobs for failed import/restore jobs from 19.2

### DIFF
--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -803,23 +803,28 @@ func migrateSchemaChangeJobs(ctx context.Context, r runner, registry *jobs.Regis
 
 	// Finally, we iterate through all table descriptors and jobs, and create jobs
 	// for any tables in the ADD state or that have draining names that don't
-	// already have jobs. We start by getting all descriptors and all running jobs
-	// in a single transaction. Each eligible table then gets a job created for
-	// it, each in a separate transaction; in each of those transactions, we write
-	// a table-specific KV with a key prefixed by schemaChangeJobMigrationKey to
-	// try to prevent more than one such job from being created for the table.
+	// already have jobs. We also create a GC job for all tables in the DROP state
+	// with no associated schema change or GC job, which can result from failed
+	// IMPORT and RESTORE jobs whose table data wasn't fully GC'ed.
+	//
+	// We start by getting all descriptors and all running jobs in a single
+	// transaction. Each eligible table then gets a job created for it, each in a
+	// separate transaction; in each of those transactions, we write a table-
+	// specific KV with a key prefixed by schemaChangeJobMigrationKey to try to
+	// prevent more than one such job from being created for the table.
 	//
 	// This process ensures that every table that entered into one of these
-	// intermediate states (being added, or having draining names) in 19.2 will
-	// have a schema change job created for it in 20.1, so that the table can
-	// finish being processed. It's not essential for only one job to be created
-	// for each table, since a redundant schema change job is a no-op, but we make
-	// an effort to do that anyway.
+	// intermediate states (being added/dropped, or having draining names) in 19.2
+	// will have a job created for it in 20.1, so that the table can finish being
+	// processed. It's not essential for only one job to be created for each
+	// table, since a redundant schema change job is a no-op, but we make an
+	// effort to do that anyway.
 	//
 	// There are probably more efficient ways to do this part of the migration,
 	// but the current approach seemed like the most straightforward.
 	var allDescs []sqlbase.DescriptorProto
-	jobsForDesc := make(map[sqlbase.ID][]int64)
+	schemaChangeJobsForDesc := make(map[sqlbase.ID][]int64)
+	gcJobsForDesc := make(map[sqlbase.ID][]int64)
 	if err := r.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		descs, err := sql.GetAllDescriptors(ctx, txn)
 		if err != nil {
@@ -842,15 +847,20 @@ func migrateSchemaChangeJobs(ctx context.Context, r runner, registry *jobs.Regis
 			if err != nil {
 				return err
 			}
-			details := payload.GetSchemaChange()
-			if details == nil || details.FormatVersion < jobspb.JobResumerFormatVersion {
-				continue
-			}
-			if details.TableID != sqlbase.InvalidID {
-				jobsForDesc[details.TableID] = append(jobsForDesc[details.TableID], jobID)
-			} else {
-				for _, t := range details.DroppedTables {
-					jobsForDesc[t.ID] = append(jobsForDesc[t.ID], jobID)
+			if details := payload.GetSchemaChange(); details != nil {
+				if details.FormatVersion < jobspb.JobResumerFormatVersion {
+					continue
+				}
+				if details.TableID != sqlbase.InvalidID {
+					schemaChangeJobsForDesc[details.TableID] = append(schemaChangeJobsForDesc[details.TableID], jobID)
+				} else {
+					for _, t := range details.DroppedTables {
+						schemaChangeJobsForDesc[t.ID] = append(schemaChangeJobsForDesc[t.ID], jobID)
+					}
+				}
+			} else if details := payload.GetSchemaChangeGC(); details != nil {
+				for _, t := range details.Tables {
+					gcJobsForDesc[t.ID] = append(gcJobsForDesc[t.ID], jobID)
 				}
 			}
 		}
@@ -870,7 +880,7 @@ func migrateSchemaChangeJobs(ctx context.Context, r runner, registry *jobs.Regis
 			// appropriate to do nothing without returning an error.
 			log.Warningf(
 				ctx,
-				"tried to add job for table %d which is neither being added nor has draining names",
+				"tried to add schema change job for table %d which is neither being added nor has draining names",
 				desc.ID,
 			)
 			return nil
@@ -890,7 +900,23 @@ func migrateSchemaChangeJobs(ctx context.Context, r runner, registry *jobs.Regis
 		if err != nil {
 			return err
 		}
-		log.Infof(ctx, "migration created new job %d: %s", *job.ID(), description)
+		log.Infof(ctx, "migration created new schema change job %d: %s", *job.ID(), description)
+		return nil
+	}
+
+	createGCJobForTable := func(txn *kv.Txn, desc *sqlbase.TableDescriptor) error {
+		record := sql.CreateGCJobRecord(
+			fmt.Sprintf("table %d", desc.ID),
+			security.NodeUser,
+			sqlbase.IDs{desc.ID},
+			jobspb.SchemaChangeGCDetails{
+				Tables: []jobspb.SchemaChangeGCDetails_DroppedID{{ID: desc.ID, DropTime: desc.DropTime}},
+			})
+		job, err := registry.CreateJobWithTxn(ctx, record, txn)
+		if err != nil {
+			return err
+		}
+		log.Infof(ctx, "migration created new GC job %d for table %d", *job.ID(), desc.ID)
 		return nil
 	}
 
@@ -898,13 +924,16 @@ func migrateSchemaChangeJobs(ctx context.Context, r runner, registry *jobs.Regis
 	for _, desc := range allDescs {
 		switch desc := desc.(type) {
 		case *sqlbase.TableDescriptor:
-			if len(jobsForDesc[desc.ID]) > 0 {
-				log.VEventf(ctx, 3, "table %d has running jobs, skipping", desc.ID)
+			if scJobs := schemaChangeJobsForDesc[desc.ID]; len(scJobs) > 0 {
+				log.VEventf(ctx, 3, "table %d has running schema change jobs %v, skipping", desc.ID, scJobs)
+				continue
+			} else if gcJobs := gcJobsForDesc[desc.ID]; len(gcJobs) > 0 {
+				log.VEventf(ctx, 3, "table %d has running GC jobs %v, skipping", desc.ID, gcJobs)
 				continue
 			}
-			if !desc.Adding() && !desc.HasDrainingNames() {
+			if !desc.Adding() && !desc.Dropped() && !desc.HasDrainingNames() {
 				log.VEventf(ctx, 3,
-					"table %d is not being added and does not have draining names, skipping",
+					"table %d is not being added or dropped and does not have draining names, skipping",
 					desc.ID,
 				)
 				continue
@@ -919,8 +948,18 @@ func migrateSchemaChangeJobs(ctx context.Context, r runner, registry *jobs.Regis
 					log.VEventf(ctx, 3, "table %d already processed in migration", desc.ID)
 					return nil
 				}
-				if err := createSchemaChangeJobForTable(txn, desc); err != nil {
-					return err
+				if desc.Adding() || desc.HasDrainingNames() {
+					if err := createSchemaChangeJobForTable(txn, desc); err != nil {
+						return err
+					}
+				} else if desc.Dropped() {
+					// Note that a table can be both in the DROP state and have draining
+					// names. In that case it was enough to just create a schema change
+					// job, as in the case above, because that job will itself create a
+					// GC job.
+					if err := createGCJobForTable(txn, desc); err != nil {
+						return err
+					}
 				}
 				if err := txn.Put(ctx, key, startTime); err != nil {
 					return err


### PR DESCRIPTION
In 19.2, a failed import or restore job would write a table descriptor
in the DROP state so that the async schema changer could GC the table
data after the original job was finished running. In 20.1 we must now
explicitly queue a GC job to do this. The problem is that there can be
leftover tables whose data had not been fully GC'ed by the time a 20.1
upgrade happens.

This PR updates the schema change job migration to create a GC job for
every table in the DROP state with no running schema change or GC job
associated with it. It is similar to what we're already doing for tables
in the ADD state or which have draining names.

Closes #46818.

Release note (bug fix): As part of migrating to the new schema change
job implementation in 20.1, failed `IMPORT` and `RESTORE` jobs which
left behind table data in 19.2 that had not been completely garbage
collected by the time the cluster was upgraded to 20.1 will now have GC
jobs automatically created for them.