### PR TITLE
hlc: improve scalability of the HLC

### DIFF
--- a/pkg/kv/kvserver/store_merge.go
+++ b/pkg/kv/kvserver/store_merge.go
@@ -103,7 +103,7 @@ func (s *Store) MergeRange(
 		// invariant that our clock is always greater than or equal to any
 		// timestamps in the timestamp cache. For a full discussion, see the comment
 		// on TestStoreRangeMergeTimestampCacheCausality.
-		_ = s.Clock().Update(freezeStart)
+		s.Clock().Update(freezeStart)
 		setTimestampCacheLowWaterMark(s.tsCache, &rightDesc, freezeStart)
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1211,6 +1211,7 @@ func (s *Server) startMonitoringForwardClockJumps(ctx context.Context) error {
 	})
 
 	if err := s.clock.StartMonitoringForwardClockJumps(
+		ctx,
 		forwardJumpCheckEnabled,
 		time.NewTicker,
 		nil, /* tick callback */

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -309,7 +309,7 @@ func runPlanInsidePlan(
 		params.extendedEvalCtx.ExecCfg.LeaseHolderCache,
 		params.p.Txn(),
 		func(ts hlc.Timestamp) {
-			_ = params.extendedEvalCtx.ExecCfg.Clock.Update(ts)
+			params.extendedEvalCtx.ExecCfg.Clock.Update(ts)
 		},
 		params.p.extendedEvalCtx.Tracing,
 	)

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -860,7 +860,7 @@ func (sc *SchemaChanger) distBackfill(
 				sc.leaseHolderCache,
 				nil, /* txn - the flow does not run wholly in a txn */
 				func(ts hlc.Timestamp) {
-					_ = sc.clock.Update(ts)
+					sc.clock.Update(ts)
 				},
 				evalCtx.Tracing,
 			)

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -829,7 +829,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 		ex.server.cfg.RangeDescriptorCache, ex.server.cfg.LeaseHolderCache,
 		planner.txn,
 		func(ts hlc.Timestamp) {
-			_ = ex.server.cfg.Clock.Update(ts)
+			ex.server.cfg.Clock.Update(ts)
 		},
 		&ex.sessionTracing,
 	)

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -247,7 +247,7 @@ func (dsp *DistSQLPlanner) planAndRunCreateStats(
 		evalCtx.ExecCfg.LeaseHolderCache,
 		txn,
 		func(ts hlc.Timestamp) {
-			_ = evalCtx.ExecCfg.Clock.Update(ts)
+			evalCtx.ExecCfg.Clock.Update(ts)
 		},
 		evalCtx.Tracing,
 	)

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -141,7 +141,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 			execCfg.LeaseHolderCache,
 			txn,
 			func(ts hlc.Timestamp) {
-				_ = execCfg.Clock.Update(ts)
+				execCfg.Clock.Update(ts)
 			},
 			p.ExtendedEvalContext().Tracing,
 		)

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -98,7 +98,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 			execCfg.LeaseHolderCache,
 			params.p.txn,
 			func(ts hlc.Timestamp) {
-				_ = execCfg.Clock.Update(ts)
+				execCfg.Clock.Update(ts)
 			},
 			params.extendedEvalCtx.Tracing,
 		)
@@ -172,7 +172,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 			execCfg.LeaseHolderCache,
 			newParams.p.txn,
 			func(ts hlc.Timestamp) {
-				_ = execCfg.Clock.Update(ts)
+				execCfg.Clock.Update(ts)
 			},
 			newParams.extendedEvalCtx.Tracing,
 		)
@@ -225,7 +225,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 			execCfg.LeaseHolderCache,
 			params.p.txn,
 			func(ts hlc.Timestamp) {
-				_ = execCfg.Clock.Update(ts)
+				execCfg.Clock.Update(ts)
 			},
 			params.extendedEvalCtx.Tracing,
 		)

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -253,7 +253,7 @@ func (sc *SchemaChanger) maybeBackfillCreateTableAs(
 			sc.execCfg.LeaseHolderCache,
 			txn,
 			func(ts hlc.Timestamp) {
-				_ = sc.clock.Update(ts)
+				sc.clock.Update(ts)
 			},
 			// Make a session tracing object on-the-fly. This is OK
 			// because it sets "enabled: false" and thus none of the

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -469,7 +469,7 @@ func scrubRunDistSQL(
 		p.ExecCfg().LeaseHolderCache,
 		p.txn,
 		func(ts hlc.Timestamp) {
-			_ = p.ExecCfg().Clock.Update(ts)
+			p.ExecCfg().Clock.Update(ts)
 		},
 		p.extendedEvalCtx.Tracing,
 	)

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -111,7 +111,7 @@ func (dsp *DistSQLPlanner) Exec(
 		execCfg.LeaseHolderCache,
 		p.txn,
 		func(ts hlc.Timestamp) {
-			_ = execCfg.Clock.Update(ts)
+			execCfg.Clock.Update(ts)
 		},
 		p.ExtendedEvalContext().Tracing,
 	)

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -56,20 +56,24 @@ type Clock struct {
 	// TODO(tamird): make this dynamic in the distant future.
 	maxOffset time.Duration
 
+	// lastPhysicalTime reports the last measured physical time. This
+	// is used to detect clock jumps. The field is accessed atomically.
+	// This field isn't part of the mutex below to prevent
+	// a second mutex acquisition in Now()
+	lastPhysicalTime int64
+
+	// monotonicityErrorsCount indicate how often this clock was
+	// observed to jump backwards. The field is accessed atomically.
+	monotonicityErrorsCount int32
+
+	// forwardClockJumpCheckEnabled specifies whether to panic on forward
+	// clock jumps. If set to 1, then jumps will cause panic. If set to 0,
+	// the check is disabled. The field is accessed atomically.
+	forwardClockJumpCheckEnabled int32
+
 	mu struct {
 		syncutil.Mutex
 		timestamp Timestamp
-
-		// monotonicityErrorsCount indicate how often this clock was
-		// observed to jump backwards.
-		monotonicityErrorsCount int32
-		// lastPhysicalTime reports the last measured physical time. This
-		// is used to detect clock jumps.
-		lastPhysicalTime int64
-
-		// forwardClockJumpCheckEnabled specifies whether to panic on forward
-		// clock jumps
-		forwardClockJumpCheckEnabled bool
 
 		// isMonitoringForwardClockJumps is a flag to ensure that only one jump monitoring
 		// goroutine is running per clock
@@ -162,6 +166,7 @@ func (c *Clock) toleratedForwardClockJump() time.Duration {
 // tickCallback is called whenever maxForwardClockJumpCh or a ticker tick is
 // processed
 func (c *Clock) StartMonitoringForwardClockJumps(
+	ctx context.Context,
 	forwardClockJumpCheckEnabledCh <-chan bool,
 	tickerFn func(d time.Duration) *time.Ticker,
 	tickCallback func(),
@@ -192,11 +197,11 @@ func (c *Clock) StartMonitoringForwardClockJumps(
 					// jumps. Otherwise the gap between the previous call to
 					// Now() and the time of the first tick would look like a
 					// forward jump.
-					c.getPhysicalClockAndCheck()
+					c.getPhysicalClockAndCheck(ctx)
 				}
 				c.setForwardJumpCheckEnabled(forwardClockJumpEnabled)
 			case <-ticker.C:
-				c.getPhysicalClockAndCheck()
+				c.getPhysicalClockAndCheck(ctx)
 			}
 
 			if tickCallback != nil {
@@ -217,39 +222,50 @@ func (c *Clock) MaxOffset() time.Duration {
 
 // getPhysicalClockAndCheck locks mu in order to access the physical clock, check for
 // time jumps and update the internal jump checking state.
-func (c *Clock) getPhysicalClockAndCheck() int64 {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.getPhysicalClockAndCheckLocked()
+func (c *Clock) getPhysicalClockAndCheck(ctx context.Context) int64 {
+	oldTime := atomic.LoadInt64(&c.lastPhysicalTime)
+	newTime := c.physicalClock()
+	lastPhysTime := oldTime
+	for {
+		atomic.CompareAndSwapInt64(&c.lastPhysicalTime, lastPhysTime, newTime)
+		lastPhysTime = atomic.LoadInt64(&c.lastPhysicalTime)
+		if lastPhysTime >= newTime {
+			// Either we did a successful update or someone else updated to a
+			// later time than ours. Either way - we are done.
+			break
+		}
+		// Someone else did an update to an earlier time than what we got in newTime.
+		// So try one more time to update.
+	}
+	c.checkPhysicalClock(ctx, oldTime, newTime)
+	return newTime
 }
 
-// getPhysicalClockAndCheckLocked returns the current physical clock and checks for
-// time jumps.
-func (c *Clock) getPhysicalClockAndCheckLocked() int64 {
-	newTime := c.physicalClock()
-
-	if c.mu.lastPhysicalTime != 0 {
-		interval := c.mu.lastPhysicalTime - newTime
-		if interval > int64(c.maxOffset/10) {
-			c.mu.monotonicityErrorsCount++
-			log.Warningf(context.TODO(), "backward time jump detected (%f seconds)", float64(-interval)/1e9)
-		}
-
-		if c.mu.forwardClockJumpCheckEnabled {
-			toleratedForwardClockJump := c.toleratedForwardClockJump()
-			if int64(toleratedForwardClockJump) <= -interval {
-				log.Fatalf(
-					context.TODO(),
-					"detected forward time jump of %f seconds is not allowed with tolerance of %f seconds",
-					float64(-interval)/1e9,
-					float64(toleratedForwardClockJump)/1e9,
-				)
-			}
-		}
+// checkPhysicalClock checks for time jumps.
+// oldTime is the lastPhysicalTime before the call to get a new time.
+// newTime is the result of the call to get a new time.
+func (c *Clock) checkPhysicalClock(ctx context.Context, oldTime, newTime int64) {
+	if oldTime == 0 {
+		return
 	}
 
-	c.mu.lastPhysicalTime = newTime
-	return newTime
+	interval := oldTime - newTime
+	if interval > int64(c.maxOffset/10) {
+		atomic.AddInt32(&c.monotonicityErrorsCount, 1)
+		log.Warningf(ctx, "backward time jump detected (%f seconds)", float64(-interval)/1e9)
+	}
+
+	if atomic.LoadInt32(&c.forwardClockJumpCheckEnabled) != 0 {
+		toleratedForwardClockJump := c.toleratedForwardClockJump()
+		if int64(toleratedForwardClockJump) <= -interval {
+			log.Fatalf(
+				ctx,
+				"detected forward time jump of %f seconds is not allowed with tolerance of %f seconds",
+				float64(-interval)/1e9,
+				float64(toleratedForwardClockJump)/1e9,
+			)
+		}
+	}
 }
 
 // Now returns a timestamp associated with an event from
@@ -258,9 +274,10 @@ func (c *Clock) getPhysicalClockAndCheckLocked() int64 {
 // of Update, which is passed a timestamp received from
 // another member of the distributed network.
 func (c *Clock) Now() Timestamp {
+	physicalClock := c.getPhysicalClockAndCheck(context.TODO())
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if physicalClock := c.getPhysicalClockAndCheckLocked(); c.mu.timestamp.WallTime >= physicalClock {
+	if c.mu.timestamp.WallTime >= physicalClock {
 		// The wall time is ahead, so the logical clock ticks.
 		c.mu.timestamp.Logical++
 	} else {
@@ -303,89 +320,60 @@ func (c *Clock) PhysicalTime() time.Time {
 
 // Update takes a hybrid timestamp, usually originating from an event
 // received from another member of a distributed system. The clock is
-// updated and the clock's updated hybrid timestamp is returned. If
-// the remote timestamp exceeds the wall clock time by more than the
-// maximum clock offset, the update is still processed, but a warning
-// is logged. To receive an error response instead of forcing the
+// updated to reflect the later of the two. The update does not check
+// the maximum clock offset. To receive an error response instead of forcing the
 // update in case the remote timestamp is too far into the future, use
 // UpdateAndCheckMaxOffset() instead.
-func (c *Clock) Update(rt Timestamp) Timestamp {
+func (c *Clock) Update(rt Timestamp) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	updateT, err := c.updateLocked(rt, true)
-	if err != nil {
-		log.Warningf(context.TODO(), "%s - updating anyway", err)
-	}
-	return updateT
-}
 
-func (c *Clock) updateLocked(rt Timestamp, updateIfMaxOffsetExceeded bool) (Timestamp, error) {
-	var err error
-	physicalClock := c.getPhysicalClockAndCheckLocked()
-
-	if physicalClock > c.mu.timestamp.WallTime && physicalClock > rt.WallTime {
-		// Our physical clock is ahead of both wall times. It is used
-		// as the new wall time and the logical clock is reset.
-		c.mu.timestamp.WallTime = physicalClock
-		c.mu.timestamp.Logical = 0
-		return c.mu.timestamp, nil
-	}
-
-	offset := time.Duration(rt.WallTime - physicalClock)
-	if c.maxOffset > 0 && offset > c.maxOffset {
-		err = fmt.Errorf("remote wall time is too far ahead (%s) to be trustworthy", offset)
-		if !updateIfMaxOffsetExceeded {
-			return Timestamp{}, err
-		}
-	}
-
-	// In the remaining cases, our physical clock plays no role
-	// as it is behind the local or remote wall times. Instead,
-	// the logical clock comes into play.
+	// There is nothing to do if the remote wall time is behind ours. We just keep ours.
 	if rt.WallTime > c.mu.timestamp.WallTime {
 		// The remote clock is ahead of ours, and we update
 		// our own logical clock with theirs.
 		c.mu.timestamp.WallTime = rt.WallTime
-		c.mu.timestamp.Logical = rt.Logical + 1
-	} else if c.mu.timestamp.WallTime > rt.WallTime {
-		// Our wall time is larger, so it remains but we tick
-		// the logical clock.
-		c.mu.timestamp.Logical++
-	} else {
+		c.mu.timestamp.Logical = rt.Logical
+	} else if rt.WallTime == c.mu.timestamp.WallTime {
 		// Both wall times are equal, and the larger logical
 		// clock is used for the update.
 		if rt.Logical > c.mu.timestamp.Logical {
 			c.mu.timestamp.Logical = rt.Logical
 		}
-		c.mu.timestamp.Logical++
 	}
 
 	c.enforceWallTimeWithinBoundLocked()
-	return c.mu.timestamp, err
 }
 
-// UpdateAndCheckMaxOffset is similar to Update, except it returns an
-// error instead of logging a warning and updating the clock's
-// timestamp, in the event that the supplied remote timestamp exceeds
+// UpdateAndCheckMaxOffset is like Update, but also takes the wall time into account and
+// returns an error in the event that the supplied remote timestamp exceeds
 // the wall clock time by more than the maximum clock offset.
-func (c *Clock) UpdateAndCheckMaxOffset(rt Timestamp) (Timestamp, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.updateLocked(rt, false)
-}
+func (c *Clock) UpdateAndCheckMaxOffset(ctx context.Context, rt Timestamp) error {
+	var err error
+	physicalClock := c.getPhysicalClockAndCheck(ctx)
 
-// lastPhysicalTime returns the last physical time
-func (c *Clock) lastPhysicalTime() int64 {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.mu.lastPhysicalTime
+	offset := time.Duration(rt.WallTime - physicalClock)
+	if c.maxOffset > 0 && offset > c.maxOffset {
+		err = fmt.Errorf("remote wall time is too far ahead (%s) to be trustworthy", offset)
+		return err
+	}
+
+	if physicalClock > rt.WallTime {
+		c.Update(Timestamp{WallTime: physicalClock})
+	} else {
+		c.Update(rt)
+	}
+
+	return nil
 }
 
 // setForwardJumpCheckEnabled atomically sets forwardClockJumpCheckEnabled
 func (c *Clock) setForwardJumpCheckEnabled(forwardJumpCheckEnabled bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.mu.forwardClockJumpCheckEnabled = forwardJumpCheckEnabled
+	if forwardJumpCheckEnabled {
+		atomic.StoreInt32(&c.forwardClockJumpCheckEnabled, 1)
+	} else {
+		atomic.StoreInt32(&c.forwardClockJumpCheckEnabled, 0)
+	}
 }
 
 // setMonitoringClockJump atomically sets isMonitoringForwardClockJumps to true and

--- a/pkg/util/hlc/hlc_test.go
+++ b/pkg/util/hlc/hlc_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -185,7 +186,7 @@ func TestHLCPhysicalClockJump(t *testing.T) {
 			isFatal:    false,
 		},
 	}
-
+	ctx := context.Background()
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			a := assert.New(t)
@@ -199,6 +200,7 @@ func TestHLCPhysicalClockJump(t *testing.T) {
 			defer close(forwardJumpCheckEnabledCh)
 
 			if err := c.StartMonitoringForwardClockJumps(
+				ctx,
 				forwardJumpCheckEnabledCh,
 				func(d time.Duration) *time.Ticker {
 					tickerDuration = d
@@ -216,6 +218,7 @@ func TestHLCPhysicalClockJump(t *testing.T) {
 			}
 
 			if err := c.StartMonitoringForwardClockJumps(
+				ctx,
 				forwardJumpCheckEnabledCh,
 				time.NewTicker,
 				nil, /* tick callback */
@@ -248,7 +251,7 @@ func TestHLCPhysicalClockJump(t *testing.T) {
 			// This should not fatal as tickerCh has ticked
 			a.Equal(false, fatal)
 			// After ticker ticks, last physical time should be equal to physical now
-			lastPhysicalTime := c.lastPhysicalTime()
+			lastPhysicalTime := c.lastPhysicalTime
 			physicalNow := c.PhysicalNow()
 			a.Equal(lastPhysicalTime, physicalNow)
 
@@ -326,7 +329,8 @@ func TestHLCClock(t *testing.T) {
 			fallthrough
 		default:
 			previous := c.Now()
-			current = c.Update(*step.input)
+			c.Update(*step.input)
+			current = c.Now()
 			if current == previous {
 				t.Errorf("%d: clock not updated", i)
 			}
@@ -361,9 +365,7 @@ func TestHLCMonotonicityCheck(t *testing.T) {
 	secondTime := c.Now()
 
 	{
-		c.mu.Lock()
-		errCount := c.mu.monotonicityErrorsCount
-		c.mu.Unlock()
+		errCount := atomic.LoadInt32(&c.monotonicityErrorsCount)
 
 		if errCount != 1 {
 			t.Fatalf("clock backward jump was not detected by the monotonicity checker (from %s to %s)", firstTime, secondTime)
@@ -374,9 +376,7 @@ func TestHLCMonotonicityCheck(t *testing.T) {
 	thirdTime := c.Now()
 
 	{
-		c.mu.Lock()
-		errCount := c.mu.monotonicityErrorsCount
-		c.mu.Unlock()
+		errCount := atomic.LoadInt32(&c.monotonicityErrorsCount)
 
 		if errCount != 1 {
 			t.Fatalf("clock backward jump below threshold was incorrectly detected by the monotonicity checker (from %s to %s)", secondTime, thirdTime)
@@ -469,6 +469,7 @@ func TestHLCEnforceWallTimeWithinBoundsInUpdate(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			a := assert.New(t)
@@ -476,7 +477,7 @@ func TestHLCEnforceWallTimeWithinBoundsInUpdate(t *testing.T) {
 			c := NewClock(m.UnixNano, time.Nanosecond)
 			c.mu.wallTimeUpperBound = test.wallTimeUpperBound
 			fatal = false
-			_, err := c.updateLocked(Timestamp{WallTime: test.messageWallTime}, true)
+			err := c.UpdateAndCheckMaxOffset(ctx, Timestamp{WallTime: test.messageWallTime})
 			a.Nil(err)
 			a.Equal(test.isFatal, fatal)
 		})
@@ -573,7 +574,8 @@ func TestLateStartForwardClockJump(t *testing.T) {
 	ticked := func() {
 		tickedCh <- struct{}{}
 	}
-	if err := c.StartMonitoringForwardClockJumps(activeCh, time.NewTicker, ticked); err != nil {
+	ctx := context.Background()
+	if err := c.StartMonitoringForwardClockJumps(ctx, activeCh, time.NewTicker, ticked); err != nil {
 		t.Fatal(err)
 	}
 	<-tickedCh


### PR DESCRIPTION
Previously HLC was calling Now() within a mutex.
This was a bottleneck in case multiple callers had to get time
simultaneously. To address this, this patch moves the calls to Now()
outside of the mutex but keeps in place the existing check.

Previosuly HLC was also calling Now() when receiving a hybrid timestamp
update. Calling Now() can be postponed until a client reads the HLC clock
if the client does not need to check the max offset. This is now fixed
so Now() is called only in case that the max offset has to be checked.

Release note: None