### PR TITLE
kvserver: fix asserts around log truncations

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -43,6 +43,7 @@ func registerAcceptance(r *testRegistry) {
 		{name: "gossip/restart-node-one", fn: runGossipRestartNodeOne},
 		{name: "gossip/locality-address", fn: runCheckLocalityIPAddress},
 		{name: "rapid-restart", fn: runRapidRestart},
+		{name: "many-splits", fn: runManySplits},
 		{name: "status-server", fn: runStatusServer},
 		{
 			name: "version-upgrade",

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2489,6 +2489,7 @@ func (m *monitor) wait(args ...string) error {
 }
 
 func waitForFullReplication(t *test, db *gosql.DB) {
+	t.l.Printf("waiting for up-replication...\n")
 	tStart := timeutil.Now()
 	for ok := false; !ok; time.Sleep(time.Second) {
 		if err := db.QueryRow(

--- a/pkg/cmd/roachtest/many_splits.go
+++ b/pkg/cmd/roachtest/many_splits.go
@@ -1,0 +1,44 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+// runManySplits attempts to create 2000 tiny ranges on a 4-node cluster using
+// left-to-right splits and check the cluster is still live afterwards.
+func runManySplits(ctx context.Context, t *test, c *cluster) {
+	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
+	c.Put(ctx, cockroach, "./cockroach")
+	c.Start(ctx, t, args)
+
+	db := c.Conn(ctx, 1)
+	defer db.Close()
+
+	// Wait for upreplication then create many ranges.
+	waitForFullReplication(t, db)
+
+	m := newMonitor(ctx, c, c.All())
+	m.Go(func(ctx context.Context) error {
+		const numRanges = 2000
+		t.l.Printf("creating %d ranges...", numRanges)
+		if _, err := db.ExecContext(ctx, fmt.Sprintf(`
+			CREATE TABLE t(x, PRIMARY KEY(x)) AS TABLE generate_series(1,%[1]d);
+            ALTER TABLE t SPLIT AT TABLE generate_series(1,%[1]d);
+		`, numRanges)); err != nil {
+			return err
+		}
+		return nil
+	})
+	m.Wait()
+}

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -462,21 +462,50 @@ func computeTruncateDecision(input truncateDecisionInput) truncateDecision {
 		decision.ChosenVia = truncatableIndexChosenViaFirstIndex
 	}
 
-	// Invariants: NewFirstIndex >= FirstIndex
-	//             NewFirstIndex <= LastIndex (if != 10)
-	//             NewFirstIndex <= CommitIndex (if != 10)
+	// We've inherited the unfortunate semantics for {First,Last}Index from
+	// raft.Storage. Specifically, both {First,Last}Index are inclusive, so
+	// there's no way to represent an empty log. The way we've initialized
+	// repl.FirstIndex is to set it to the first index in the possibly-empty log
+	// (TruncatedState.Index + 1), and allowing LastIndex to fall behind it when
+	// the log is empty (TruncatedState.Index). The initialization is done when
+	// minting a new replica from either the truncated state of incoming
+	// snapshot, or using the default initial log index. This makes for the
+	// confusing situation where FirstIndex > LastIndex. We can detect this
+	// special empty log case by comparing checking if
+	// `FirstIndex == LastIndex + 1` (`logEmpty` below). Similar to this, we can
+	// have the case that `FirstIndex = CommitIndex + 1` when there are no
+	// committed entries (which we check for in `noCommittedEntries` below).
+	// Having done that (i.e. if the raft log is not empty, and there are
+	// committed entries), we can assert on the following invariants:
 	//
-	// For uninit'ed replicas we can have NewFirstIndex > input.LastIndex, more
-	// specifically NewFirstIndex = input.LastIndex + 1. NewFirstIndex is set to
-	// TruncatedState.Index + 1, and for an unit'ed replica, input.LastIndex is
-	// simply 10. This is what informs the `input.LastIndex == 10` conditional
-	// below. The same reasoning holds for NewFirstIndex and
-	// decision.CommitIndex.
-	valid := (decision.NewFirstIndex >= input.FirstIndex) &&
-		(decision.NewFirstIndex <= input.LastIndex || input.LastIndex == 10) &&
-		(decision.NewFirstIndex <= decision.CommitIndex || decision.CommitIndex == 10)
+	//         FirstIndex    <= LastIndex                                    (0)
+	//         NewFirstIndex >= FirstIndex                                   (1)
+	//         NewFirstIndex <= LastIndex                                    (2)
+	//         NewFirstIndex <= CommitIndex                                  (3)
+	//
+	// (1) asserts that we're not regressing our FirstIndex
+	// (2) asserts that our we don't truncate past the last index we can
+	//     truncate away, and
+	// (3) is similar to (2) in that we assert that we're not truncating past
+	//     the last known CommitIndex.
+	//
+	// TODO(irfansharif): We should consider cleaning up this mess around
+	// {First,Last,Commit}Index by using a sentinel value to represent an empty
+	// log (like we do with `invalidLastTerm`). It'd be extra nice if we could
+	// safeguard access by relying on the type system to force callers to
+	// consider the empty case. Something like
+	// https://github.com/nvanbenschoten/optional could help us emulate an
+	// `option<uint64>` type if we care enough.
+	logEmpty := input.FirstIndex == input.LastIndex+1
+	noCommittedEntries := input.FirstIndex == input.RaftStatus.Commit+1
+
+	logIndexValid := logEmpty ||
+		(decision.NewFirstIndex >= input.FirstIndex) && (decision.NewFirstIndex <= input.LastIndex)
+	commitIndexValid := noCommittedEntries ||
+		(decision.NewFirstIndex <= decision.CommitIndex)
+	valid := logIndexValid && commitIndexValid
 	if !valid {
-		err := fmt.Sprintf("invalid truncation decision; output = %d, input: [%d, %d], commit idx = %d",
+		err := fmt.Sprintf("invalid truncation decision: output = %d, input: [%d, %d], commit idx = %d",
 			decision.NewFirstIndex, input.FirstIndex, input.LastIndex, decision.CommitIndex)
 		panic(err)
 	}


### PR DESCRIPTION
Fixes #43605.

Re-work (again) the invariants around log truncations to accommodate log
truncations of new replicas without any log entries. Previously we
assumed that a replica's FirstIndex (oldest raft entry index) was
strictly less than or equal to a replica's LastIndex (latest raft entry
index). This, for unfortunate reasons, is not always true. Reproducing
the comment below:

```
// We've inherited the unfortunate semantics for {First,Last}Index from
// raft.Storage. Specifically, both {First,Last}Index are inclusive, so
// there's no way to represent an empty log. The way we've initialized
// repl.FirstIndex is to set it to the first index in the possibly-empty log
// (TruncatedState.Index + 1), and allowing LastIndex to fall behind it when
// the log is empty (TruncatedState.Index). The initialization is done when
// minting a new replica from either the truncated state of incoming
// snapshot, or using the default initial log index. This makes for the
// confusing situation where FirstIndex > LastIndex. We can detect this
// special empty log case by comparing checking if
// `FirstIndex == LastIndex + 1`. Having done that (i.e. if the raft log is
// not empty), we can assert on the following invariants:
//
//              FirstIndex    <= LastIndex                              (0)
//              NewFirstIndex >= FirstIndex                             (1)
//              NewFirstIndex <= LastIndex                              (2)
//              NewFirstIndex <= CommitIndex                            (3)
//
// (1) asserts that we're not regressing our FirstIndex
// (2) asserts that our we don't truncate past the last index we can
//     truncate away, and
// (3) is similar to (2) in that we assert that we're not truncating past
//     the last known CommitIndex.
```

We additionally include Raphael's test that was able to shake out the
panic observed in #43605 much more efficiently.

Release note: Critical bug fix that would cause panics out in the wild.
