### PR TITLE
workload/schemachange: check for tables with no columns

### DIFF
--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
+	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx"
 	"github.com/spf13/pflag"
 )
@@ -421,6 +422,10 @@ func (w *schemaChangeWorker) createIndex(tx *pgx.Tx) (string, error) {
 	columnNames, err := w.tableColumnsShuffled(tx, tableName)
 	if err != nil {
 		return "", err
+	}
+
+	if len(columnNames) <= 0 {
+		return "", errors.Errorf("table %s has no columns", tableName)
 	}
 
 	indexName, err := w.randIndex(tx, tableName, w.existingPct)


### PR DESCRIPTION
Rarely the schemachange workload panics in situations where we try
to select a column from a table without columns. I have not have time
to investigate why this is possible but until then we will throw
an error in such cases. In follow-up PR(s) we will decide which errors
to treat as fatal and which just to log.