### PR TITLE
sql: forbid TIMETZ during mixed 19.2/20.1 node clusters

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -68,6 +68,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>19.2-16</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>19.2-17</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -57,6 +57,7 @@ const (
 	VersionStatementDiagnosticsSystemTables
 	VersionSchemaChangeJob
 	VersionSavepoints
+	VersionTimeTZType
 
 	// Add new versions here (step one of two).
 )
@@ -443,6 +444,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// records.
 		Key:     VersionSavepoints,
 		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 16},
+	},
+	{
+		// VersionTimeTZType enables the use of the TimeTZ data type.
+		Key:     VersionTimeTZType,
+		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 17},
 	},
 	// Add new versions here (step two of two).
 

--- a/pkg/clusterversion/versionkey_string.go
+++ b/pkg/clusterversion/versionkey_string.go
@@ -33,11 +33,12 @@ func _() {
 	_ = x[VersionStatementDiagnosticsSystemTables-22]
 	_ = x[VersionSchemaChangeJob-23]
 	_ = x[VersionSavepoints-24]
+	_ = x[VersionTimeTZType-25]
 }
 
-const _VersionKey_name = "Version19_1VersionStart19_2VersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDsVersionHashShardedIndexesVersionCreateRolePrivilegeVersionStatementDiagnosticsSystemTablesVersionSchemaChangeJobVersionSavepoints"
+const _VersionKey_name = "Version19_1VersionStart19_2VersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDsVersionHashShardedIndexesVersionCreateRolePrivilegeVersionStatementDiagnosticsSystemTablesVersionSchemaChangeJobVersionSavepointsVersionTimeTZType"
 
-var _VersionKey_index = [...]uint16{0, 11, 27, 49, 75, 109, 136, 176, 200, 211, 227, 258, 287, 322, 354, 380, 404, 441, 480, 499, 534, 559, 585, 624, 646, 663}
+var _VersionKey_index = [...]uint16{0, 11, 27, 49, 75, 109, 136, 176, 200, 211, 227, 258, 287, 322, 354, 380, 404, 441, 480, 499, 534, 559, 585, 624, 646, 663, 680}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/sql/logictest/testdata/logic_test/alter_table_mixed_19.2_20.1
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table_mixed_19.2_20.1
@@ -159,3 +159,17 @@ ALTER TABLE t RENAME COLUMN b TO c
 
 statement error schema change cannot be initiated in this version until the version upgrade is finalized
 ALTER TABLE t RENAME TO s
+
+subtest regression_47110
+
+statement error type TIMETZ is not supported until version upgrade is finalized
+CREATE TABLE regression_47110(a TIMETZ)
+
+statement ok
+CREATE TABLE regression_47110(a TIME)
+
+statement error type TIMETZ is not supported until version upgrade is finalized
+ALTER TABLE regression_47110 ADD COLUMN b TIMETZ
+
+statement error type TIMETZ is not supported until version upgrade is finalized
+ALTER TABLE regression_47110 ALTER a SET DATA TYPE timetz


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/47110.

Release note (bug fix): This PR fixes a bug preventing clusters from
creating TIMETZ columns before they accept 20.1 without downgrading.