### PR TITLE
release-20.1: logictest: fix error matching in vectorize_types test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize_types
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_types
@@ -79,7 +79,7 @@ INSERT INTO skip_unneeded_cols VALUES ('63616665-6630-3064-6465-616462656562', 1
 statement ok
 SET vectorize=experimental_always
 
-statement error pq: unable to vectorize execution plan: unhandled type int\[\]
+statement error .*(unhandled|unsupported) type int\[\]
 SELECT _unsupported1 FROM skip_unneeded_cols
 
 query IBB


### PR DESCRIPTION
Backport 1/1 commits from #47130.

/cc @cockroachdb/release

---

Vectorized engine will emit slightly different error for unsupported
type depending on whether the query runs locally or in distributed
fashion. We added `fakedist-vec` config to `vectorize_types` logic test
recently, so we need to make error matching more flexible in there.

Fixes: #47111.

Release note: None
