### PR TITLE
opt: factor check constraints into Scan FDs

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/catalog
+++ b/pkg/sql/opt/exec/execbuilder/testdata/catalog
@@ -33,7 +33,7 @@ CREATE TABLE abcdef (
     c INT DEFAULT (10),
     d INT AS (abcdef.b + c + 1) STORED,
     e INT AS (a) STORED,
-    f INT CHECK (test.abcdef.f > 2),
+    f INT NOT NULL CHECK (test.abcdef.f > 2),
     FAMILY "primary" (a, b, c, d, e, f, rowid)
 )
 
@@ -46,7 +46,7 @@ TABLE abcdef
  ├── c int default (10:::INT8)
  ├── d int as ((b + c) + 1) stored
  ├── e int as (a) stored
- ├── f int
+ ├── f int not null
  ├── rowid int not null default (unique_rowid()) [hidden]
  ├── CHECK (f > 2)
  └── INDEX primary

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -326,10 +326,10 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		if t.IsCanonical() {
 			// For the canonical scan, show the expressions attached to the TableMeta.
 			tab := md.TableMeta(t.Table)
-			if len(tab.Constraints) > 0 {
+			if tab.Constraints != nil {
 				c := tp.Childf("check constraint expressions")
-				for i := 0; i < len(tab.Constraints); i++ {
-					f.formatExpr(tab.Constraints[i], c)
+				for i := 0; i < tab.Constraints.ChildCount(); i++ {
+					f.formatExpr(tab.Constraints.Child(i), c)
 				}
 			}
 			if len(tab.ComputedCols) > 0 {

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -101,6 +101,9 @@ func (b *logicalPropsBuilder) buildScanProps(scan *ScanExpr, rel *props.Relation
 		if scan.Constraint != nil {
 			rel.FuncDeps.AddConstants(scan.Constraint.ExtractConstCols(b.evalCtx))
 		}
+		if tabMeta := md.TableMeta(scan.Table); tabMeta.Constraints != nil {
+			b.addFiltersToFuncDep(*tabMeta.Constraints.(*FiltersExpr), &rel.FuncDeps)
+		}
 		rel.FuncDeps.MakeNotNull(rel.NotNullCols)
 		rel.FuncDeps.ProjectCols(rel.OutputCols)
 	}

--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -210,3 +210,28 @@ scan a
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-4)
  └── interesting orderings: (+1) (-3,+4,+1)
+
+exec-ddl
+CREATE TABLE kab (
+  k INT8 PRIMARY KEY,
+  a INT8 NOT NULL,
+  b INT8 NOT NULL CHECK (b = 0),
+  INDEX ba (b, a)
+)
+----
+
+# Verify that check constraints are factored into Scan FDs (namely
+# that b:3 shows up as constant).
+build
+SELECT * FROM kab
+----
+scan kab
+ ├── columns: k:1(int!null) a:2(int!null) b:3(int!null)
+ ├── check constraint expressions
+ │    └── eq [type=bool, outer=(3), constraints=(/3: [/0 - /0]; tight), fd=()-->(3)]
+ │         ├── variable: b:3 [type=int]
+ │         └── const: 0 [type=int]
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2)
+ ├── prune: (1-3)
+ └── interesting orderings: (+1) (+3,+2,+1)

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -523,10 +523,11 @@ func (b *Builder) buildScan(
 		if locking.isSet() {
 			private.Locking = locking.get()
 		}
-		outScope.expr = b.factory.ConstructScan(&private)
 
 		b.addCheckConstraintsForTable(tabMeta)
 		b.addComputedColsForTable(tabMeta)
+
+		outScope.expr = b.factory.ConstructScan(&private)
 
 		if b.trackViewDeps {
 			dep := opt.ViewDep{DataSource: tab}

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -543,17 +543,42 @@ func (b *Builder) buildScan(
 	return outScope
 }
 
-// addCheckConstraintsForTable finds all the check constraints that apply to the
-// table and adds them to the table metadata. To do this, the scalar expression
-// of the check constraints are built here.
+// addCheckConstraintsForTable extracts filters from the check constraints that
+// apply to the table and adds them to the table metadata (see
+// TableMeta.Constraints). To do this, the scalar expressions of the check
+// constraints are built here.
 func (b *Builder) addCheckConstraintsForTable(tabMeta *opt.TableMeta) {
-	// Find all the check constraints that apply to the table and add them
-	// to the table meta data. To do this, we must build them into scalar
-	// expressions.
-	var tableScope *scope
 	tab := tabMeta.Table
-	for i, n := 0, tab.CheckCount(); i < n; i++ {
-		checkConstraint := tab.Check(i)
+
+	// Check if we have any validated check constraints. Only validated
+	// constraints are known to hold on existing table data.
+	numChecks := tab.CheckCount()
+	chkIdx := 0
+	for ; chkIdx < numChecks; chkIdx++ {
+		if tab.Check(chkIdx).Validated {
+			break
+		}
+	}
+	if chkIdx == numChecks {
+		return
+	}
+
+	// Create a scope that can be used for building the scalar expressions.
+	tableScope := b.allocScope()
+	tableScope.appendColumnsFromTable(tabMeta, &tabMeta.Alias)
+
+	// Find the non-nullable table columns.
+	var notNullCols opt.ColSet
+	for i := 0; i < tab.ColumnCount(); i++ {
+		if !tab.Column(i).IsNullable() {
+			notNullCols.Add(tabMeta.MetaID.ColumnID(i))
+		}
+	}
+
+	var filters memo.FiltersExpr
+	// Skip to the first validated constraint we found above.
+	for ; chkIdx < numChecks; chkIdx++ {
+		checkConstraint := tab.Check(chkIdx)
 
 		// Only add validated check constraints to the table's metadata.
 		if !checkConstraint.Validated {
@@ -564,15 +589,17 @@ func (b *Builder) addCheckConstraintsForTable(tabMeta *opt.TableMeta) {
 			panic(err)
 		}
 
-		if tableScope == nil {
-			tableScope = b.allocScope()
-			tableScope.appendColumnsFromTable(tabMeta, &tabMeta.Alias)
+		texpr := tableScope.resolveAndRequireType(expr, types.Bool)
+		condition := b.buildScalar(texpr, tableScope, nil, nil, nil)
+		// Check constraints that are guaranteed to not evaluate to NULL
+		// are the only ones converted into filters. This is because a NULL
+		// constraint is interpreted as passing, whereas a NULL filter is not.
+		if memo.ExprIsNeverNull(condition, notNullCols) {
+			filters = append(filters, b.factory.ConstructFiltersItem(condition))
 		}
-
-		if texpr := tableScope.resolveAndRequireType(expr, types.Bool); texpr != nil {
-			scalar := b.buildScalar(texpr, tableScope, nil, nil, nil)
-			tabMeta.AddConstraint(scalar)
-		}
+	}
+	if len(filters) > 0 {
+		tabMeta.SetConstraints(&filters)
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -14,7 +14,7 @@ CREATE TABLE tab54 (x INT, y INT)
 ----
 
 exec-ddl
-CREATE TABLE tab55 (a INT PRIMARY KEY, b INT, CONSTRAINT foo CHECK (a+b < 10))
+CREATE TABLE tab55 (a INT PRIMARY KEY, b INT NOT NULL, CONSTRAINT foo CHECK (a+b < 10))
 ----
 
 # SELECT with no table.

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1492,7 +1492,6 @@ update checks
       │    │    ├── scan checks
       │    │    │    ├── columns: a:5!null b:6 c:7 d:8
       │    │    │    ├── check constraint expressions
-      │    │    │    │    ├── b:6 < d:8
       │    │    │    │    └── a:5 > 0
       │    │    │    └── computed column expressions
       │    │    │         └── d:8
@@ -1527,7 +1526,6 @@ update checks
       │    │    ├── scan checks
       │    │    │    ├── columns: a:5!null b:6 c:7 d:8
       │    │    │    ├── check constraint expressions
-      │    │    │    │    ├── b:6 < d:8
       │    │    │    │    └── a:5 > 0
       │    │    │    └── computed column expressions
       │    │    │         └── d:8
@@ -1560,7 +1558,6 @@ update checks
       │    │    ├── scan checks
       │    │    │    ├── columns: a:5!null b:6 c:7 d:8
       │    │    │    ├── check constraint expressions
-      │    │    │    │    ├── b:6 < d:8
       │    │    │    │    └── a:5 > 0
       │    │    │    └── computed column expressions
       │    │    │         └── d:8
@@ -1594,7 +1591,6 @@ update checks
       │    │    ├── scan checks
       │    │    │    ├── columns: checks.a:5!null checks.b:6 checks.c:7 checks.d:8
       │    │    │    ├── check constraint expressions
-      │    │    │    │    ├── checks.b:6 < checks.d:8
       │    │    │    │    └── checks.a:5 > 0
       │    │    │    └── computed column expressions
       │    │    │         └── checks.d:8
@@ -1642,9 +1638,6 @@ update decimals
       │    ├── columns: a:11 b:12 decimals.a:5!null decimals.b:6 c:7 decimals.d:8
       │    ├── scan decimals
       │    │    ├── columns: decimals.a:5!null decimals.b:6 c:7 decimals.d:8
-      │    │    ├── check constraint expressions
-      │    │    │    ├── decimals.a:5 = round(decimals.a:5)
-      │    │    │    └── decimals.b:6[0] > 1
       │    │    └── computed column expressions
       │    │         └── decimals.d:8
       │    │              └── decimals.a:5 + c:7

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -1159,7 +1159,6 @@ upsert checks
       │    │    ├── scan checks
       │    │    │    ├── columns: a:9!null b:10 c:11 d:12
       │    │    │    ├── check constraint expressions
-      │    │    │    │    ├── b:10 < d:12
       │    │    │    │    └── a:9 > 0
       │    │    │    └── computed column expressions
       │    │    │         └── d:12
@@ -1348,7 +1347,6 @@ upsert checks
       │    │    │    │    ├── scan checks
       │    │    │    │    │    ├── columns: a:9!null b:10 c:11 d:12
       │    │    │    │    │    ├── check constraint expressions
-      │    │    │    │    │    │    ├── b:10 < d:12
       │    │    │    │    │    │    └── a:9 > 0
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── d:12
@@ -1406,7 +1404,6 @@ insert checks
       │    │         │    ├── scan checks
       │    │         │    │    ├── columns: a:9!null b:10 c:11 d:12
       │    │         │    │    ├── check constraint expressions
-      │    │         │    │    │    ├── b:10 < d:12
       │    │         │    │    │    └── a:9 > 0
       │    │         │    │    └── computed column expressions
       │    │         │    │         └── d:12
@@ -1475,7 +1472,6 @@ upsert checks
       │    │    │    ├── scan checks
       │    │    │    │    ├── columns: a:9!null b:10 c:11 d:12
       │    │    │    │    ├── check constraint expressions
-      │    │    │    │    │    ├── b:10 < d:12
       │    │    │    │    │    └── a:9 > 0
       │    │    │    │    └── computed column expressions
       │    │    │    │         └── d:12
@@ -1550,7 +1546,6 @@ upsert checks
       │    │    │    │    ├── scan checks
       │    │    │    │    │    ├── columns: checks.a:11!null checks.b:12 checks.c:13 d:14
       │    │    │    │    │    ├── check constraint expressions
-      │    │    │    │    │    │    ├── checks.b:12 < d:14
       │    │    │    │    │    │    └── checks.a:11 > 0
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── d:14

--- a/pkg/sql/opt/testutils/opttester/memo_groups.go
+++ b/pkg/sql/opt/testutils/opttester/memo_groups.go
@@ -137,8 +137,8 @@ func (g *memoGroups) depthFirstSearch(
 		if scan, ok := expr.(*memo.ScanExpr); ok {
 			md := scan.Memo().Metadata()
 			meta := md.TableMeta(scan.Table)
-			for i := 0; i < len(meta.Constraints); i++ {
-				if r := g.depthFirstSearch(meta.Constraints[i], target, visited, nextPath); r != nil {
+			if meta.Constraints != nil {
+				if r := g.depthFirstSearch(meta.Constraints, target, visited, nextPath); r != nil {
 					return r
 				}
 			}

--- a/pkg/sql/opt/testutils/opttester/testdata/opt_steps
+++ b/pkg/sql/opt/testutils/opttester/testdata/opt_steps
@@ -157,7 +157,7 @@ Initial expression
    ├── scan orders
    │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
    │    ├── check constraint expressions
-   │    │    └── in [type=bool]
+   │    │    └── in [type=bool, outer=(3), constraints=(/3: [/'cancelled' - /'cancelled'] [/'complete' - /'complete'] [/'open' - /'open']; tight)]
    │    │         ├── variable: status:3 [type=string]
    │    │         └── tuple [type=tuple{string, string, string}]
    │    │              ├── const: 'open' [type=string]
@@ -184,7 +184,7 @@ NormalizeInConst
     ├── scan orders
     │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
     │    ├── check constraint expressions
-    │    │    └── in [type=bool]
+    │    │    └── in [type=bool, outer=(3), constraints=(/3: [/'cancelled' - /'cancelled'] [/'complete' - /'complete'] [/'open' - /'open']; tight)]
     │    │         ├── variable: status:3 [type=string]
     │    │         └── tuple [type=tuple{string, string, string}]
   - │    │              ├── const: 'open' [type=string]
@@ -223,7 +223,7 @@ CommuteLeftJoin (higher cost)
     ├── scan orders
     │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
     │    ├── check constraint expressions
-    │    │    └── in [type=bool]
+    │    │    └── in [type=bool, outer=(3), constraints=(/3: [/'cancelled' - /'cancelled'] [/'complete' - /'complete'] [/'open' - /'open']; tight)]
     │    │         ├── variable: status:3 [type=string]
     │    │         └── tuple [type=tuple{string, string, string}]
     │    │              ├── const: 'cancelled' [type=string]
@@ -255,7 +255,7 @@ GenerateLookupJoins (higher cost)
     ├── scan orders
     │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
     │    ├── check constraint expressions
-    │    │    └── in [type=bool]
+    │    │    └── in [type=bool, outer=(3), constraints=(/3: [/'cancelled' - /'cancelled'] [/'complete' - /'complete'] [/'open' - /'open']; tight)]
     │    │         ├── variable: status:3 [type=string]
     │    │         └── tuple [type=tuple{string, string, string}]
     │    │              ├── const: 'cancelled' [type=string]
@@ -293,7 +293,7 @@ GenerateMergeJoins (higher cost)
   + ├── sort
     │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
   - │    ├── check constraint expressions
-  - │    │    └── in [type=bool]
+  - │    │    └── in [type=bool, outer=(3), constraints=(/3: [/'cancelled' - /'cancelled'] [/'complete' - /'complete'] [/'open' - /'open']; tight)]
   - │    │         ├── variable: status:3 [type=string]
   - │    │         └── tuple [type=tuple{string, string, string}]
   - │    │              ├── const: 'cancelled' [type=string]
@@ -306,7 +306,7 @@ GenerateMergeJoins (higher cost)
   + │    └── scan orders
   + │         ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
   + │         ├── check constraint expressions
-  + │         │    └── in [type=bool]
+  + │         │    └── in [type=bool, outer=(3), constraints=(/3: [/'cancelled' - /'cancelled'] [/'complete' - /'complete'] [/'open' - /'open']; tight)]
   + │         │         ├── variable: status:3 [type=string]
   + │         │         └── tuple [type=tuple{string, string, string}]
   + │         │              ├── const: 'cancelled' [type=string]
@@ -326,7 +326,7 @@ Final best expression
    ├── scan orders
    │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
    │    ├── check constraint expressions
-   │    │    └── in [type=bool]
+   │    │    └── in [type=bool, outer=(3), constraints=(/3: [/'cancelled' - /'cancelled'] [/'complete' - /'complete'] [/'open' - /'open']; tight)]
    │    │         ├── variable: status:3 [type=string]
    │    │         └── tuple [type=tuple{string, string, string}]
    │    │              ├── const: 'cancelled' [type=string]

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -2038,3 +2038,39 @@ distinct-on
       │    └── projections
       │         └── 1 [as="project_const_col_@5":8]
       └── filters (true)
+
+# Regression test for #47041: factor check constraints into the (canonical)
+# scan FDs; otherwise operators above won't always be able to remap a provided
+# ordering.
+exec-ddl
+CREATE TABLE t47041 (
+  k INT8 PRIMARY KEY,
+  a INT8 NOT NULL,
+  b INT8 NOT NULL CHECK (b = 0),
+  INDEX ba (b, a)
+)
+----
+
+opt
+SELECT 1 FROM t47041 WHERE a > 1 AND k > 0 GROUP BY b, a ORDER BY b
+----
+project
+ ├── columns: "?column?":4!null
+ ├── fd: ()-->(4)
+ ├── distinct-on
+ │    ├── columns: a:2!null
+ │    ├── grouping columns: a:2!null
+ │    ├── key: (2)
+ │    └── select
+ │         ├── columns: k:1!null a:2!null
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2)
+ │         ├── scan t47041@ba
+ │         │    ├── columns: k:1!null a:2!null
+ │         │    ├── constraint: /3/2/1: [/0/2/1 - /0]
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(2)
+ │         └── filters
+ │              └── k:1 > 0 [outer=(1)]
+ └── projections
+      └── 1 [as="?column?":4]


### PR DESCRIPTION
#### opt: build check constraint filters upfront

We use check constraint filters to try to improve index constraint generation. We
build all check constraints as scalars and store them in the TableMeta; then we
create the FiltersExpr in GenerateConstrainedScans.

With this change, we now create the filters upfront. This will allow other uses
for the filters (like better FD generation for Scans).

Release note: None

#### opt: factor check constraints into Scan FDs

The provided orderings logic has a fragility: if a child operator is "smarter"
about FDs than a parent operator, the parent operator might not be able to
calculate a provided ordering (the child ordering would seem incomplete). This
can happen when that child operator was created during exploration.

This change fixes an instance of this where the canonical scan doesn't take the
check constraints into account, but a constrained scan indirectly does (when the
checks are incorporated into the constraint). The fix is to take into account
the check constraints when calculating the Scan's FDs (which seems like a good
thing to do regardless of this issue).

Here's an example (simplified from #47041):
```
CREATE TABLE t (
  k INT8 PRIMARY KEY,
  a INT8 NOT NULL,
  b INT8 NOT NULL CHECK (b = 0),
  INDEX ba (b, a)
)
SELECT 1 FROM t WHERE a > 1 AND k > 0 GROUP BY b, a ORDER BY b
```

The optimized tree for this statement is a Project on top of DistinctOn on top
of a constrained Scan. DistinctOn requires `+b,+a` from its input (because it's
a streaming aggregation). The input provided ordering is just `+a` because the
constrained scan knows that `b` is constant. But the Select does not know that
`b` is constant, so DistinctOn does not realize that `+a` is not needed to
satisfy the required ordering. When we try to project away column `a`, we don't
know what to do with the `+a` ordering.

Fixes #47041.

Release note (bug fix): fixed an internal "no output column equivalent to X"
error in some very rare cases.
