### PR TITLE
kvserver,roachtest/hotspotsplits: adjust constants to ensure backpressure

### DIFF
--- a/pkg/cmd/roachtest/hotspotsplits.go
+++ b/pkg/cmd/roachtest/hotspotsplits.go
@@ -42,7 +42,7 @@ func registerHotSpotSplits(r *testRegistry) {
 		m.Go(func() error {
 			t.l.Printf("starting load generator\n")
 
-			const blockSize = 1 << 19 // 512 KB
+			const blockSize = 1 << 18 // 256 KB
 			return c.RunE(ctx, appNode, fmt.Sprintf(
 				"./workload run kv --read-percent=0 --tolerate-errors --concurrency=%d "+
 					"--min-block-bytes=%d --max-block-bytes=%d --duration=%s {pgurl:1-3}",

--- a/pkg/kv/kvserver/replica_backpressure.go
+++ b/pkg/kv/kvserver/replica_backpressure.go
@@ -69,7 +69,7 @@ var backpressureByteTolerance = settings.RegisterByteSizeSetting(
 	"defines the number of bytes above the product of "+
 		"backpressure_range_size_multiplier and the range_max_size at which "+
 		"backpressure will not apply",
-	2<<20 /* 2 MiB */)
+	32<<20 /* 32 MiB */)
 
 // backpressurableSpans contains spans of keys where write backpressuring
 // is permitted. Writes to any keys within these spans may cause a batch


### PR DESCRIPTION
See individual commits. 

Fixes #46957.