### PR TITLE
execerror: catch panics from sql/colcontainer package

### DIFF
--- a/pkg/sql/colexec/execerror/error.go
+++ b/pkg/sql/colexec/execerror/error.go
@@ -98,6 +98,7 @@ func CatchVectorizedRuntimeError(operation func()) (retErr error) {
 
 const (
 	colPackagePrefix          = "github.com/cockroachdb/cockroach/pkg/col"
+	colcontainerPackagePrefix = "github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	colexecPackagePrefix      = "github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	colflowsetupPackagePrefix = "github.com/cockroachdb/cockroach/pkg/sql/colflow"
 	execinfraPackagePrefix    = "github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -118,6 +119,7 @@ func isPanicFromVectorizedEngine(panicEmittedFrom string) bool {
 		return false
 	}
 	return strings.HasPrefix(panicEmittedFrom, colPackagePrefix) ||
+		strings.HasPrefix(panicEmittedFrom, colcontainerPackagePrefix) ||
 		strings.HasPrefix(panicEmittedFrom, colexecPackagePrefix) ||
 		strings.HasPrefix(panicEmittedFrom, colflowsetupPackagePrefix) ||
 		strings.HasPrefix(panicEmittedFrom, execinfraPackagePrefix) ||

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1412,6 +1412,10 @@ func TestLint(t *testing.T) {
 			"-nE",
 			fmt.Sprintf(`panic\(.*\)`),
 			"--",
+			// NOTE: if you're adding a new package to the list here because it
+			// uses "panic-catch" error propagation mechanism of the vectorized
+			// engine, don't forget to "register" the newly added package in
+			// sql/colexec/execerror/error.go file.
 			"sql/colexec",
 			"sql/colflow",
 			"sql/colcontainer",


### PR DESCRIPTION
We added a new package `sql/colcontainer` that uses panic-catch
mechanism of error propagation, but we forgot to "register" it with the
catcher, and now this is fixed.

Release note: None