### PR TITLE
colexec: fix planning of projections with mixed-widths ints

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads.go
@@ -1348,6 +1348,8 @@ func registerBinOpOutputTypes() {
 		// Use an output type of the same width when input widths are the same.
 		binOpOutputTypes[binOp][coltypePair{coltypes.Decimal, coltypes.Decimal}] = coltypes.Decimal
 		binOpOutputTypes[binOp][coltypePair{coltypes.Float64, coltypes.Float64}] = coltypes.Float64
+		// Note: keep output type of binary operations on integers of different
+		// widths in line with planning in colexec/execplan.go.
 		binOpOutputTypes[binOp][coltypePair{coltypes.Int16, coltypes.Int16}] = coltypes.Int16
 		binOpOutputTypes[binOp][coltypePair{coltypes.Int32, coltypes.Int32}] = coltypes.Int32
 		binOpOutputTypes[binOp][coltypePair{coltypes.Int64, coltypes.Int64}] = coltypes.Int64

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_types
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_types
@@ -150,3 +150,12 @@ query I
 SELECT * FROM t46714_0 ORDER BY c0 + c0
 ----
 0
+
+# Regression test for #47131 (mismatched expected logical and actual physical
+# integer types on mixed-width integer binary expressions).
+statement ok
+CREATE TABLE t47131_0(c0 INT2 UNIQUE); INSERT INTO t47131_0 VALUES(1)
+
+query I
+SELECT * FROM t47131_0 WHERE (t47131_0.c0 + t47131_0.c0::INT4) = 0
+----


### PR DESCRIPTION
This commit fixes two bugs with the recent refactor of the way we handle
planning of projections of INT2 and/or INT4:
1. when we have INT2 + INT4, we actually output INT8. This was the
   previous behavior that I mistakenly changed
2. I used incorrect method to check for the equivalence of types to
   decide whether a cast is needed.

These issues are now fixed. Hopefully smaller integers will not bite us
in the future.

Fixes: #47131.

Release note: None