### PR TITLE
release-2.1: sql/sem: properly copy SelectClause.Window in copyNode

### DIFF
--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -1096,7 +1096,7 @@ func (stmt *SelectClause) copyNode() *SelectClause {
 		hCopy := *stmt.Having
 		stmtCopy.Having = &hCopy
 	}
-	stmt.Window = append(Window(nil), stmt.Window...)
+	stmtCopy.Window = append(Window(nil), stmt.Window...)
 	return &stmtCopy
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #47146.

/cc @cockroachdb/release

---

Found while stressing #46793.

The bug was introduced here: https://github.com/cockroachdb/cockroach/commit/fabd5c10c8755c1a30bfdb13dc46604a8c7336a7#diff-2be097dd2faa900531667063b2870a55R1102.
This fix will need to be backported all the way back to v2.1.0.

Release note (bug fix): fix a data race on AST nodes for SELECT
statements that include a WINDOW clause. It is unclear whether this
could have resulted in incorrect results being returned for these
queries.
