### PR TITLE
geo/geos: change functions in geos_unix.h to return a status string

### DIFF
--- a/pkg/geo/geo_test.go
+++ b/pkg/geo/geo_test.go
@@ -171,30 +171,30 @@ func TestParseGeometry(t *testing.T) {
 	testCases := []struct {
 		wkt         geopb.WKT
 		expected    *Geometry
-		expectedErr bool
+		expectedErr string
 	}{
 		{
 			"POINT(1.0 1.0)",
 			NewGeometry(geopb.EWKB([]byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"))),
-			false,
+			"",
 		},
 		{
 			"invalid",
 			nil,
-			true,
+			"geos error: ParseException: Unknown type: 'INVALID'",
 		},
 		{
 			"",
 			nil,
-			true,
+			"geos error: ParseException: Expected word but encountered end of stream",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(string(tc.wkt), func(t *testing.T) {
 			g, err := ParseGeometry(tc.wkt)
-			if tc.expectedErr {
-				require.Error(t, err)
+			if len(tc.expectedErr) > 0 {
+				require.Equal(t, tc.expectedErr, err.Error())
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, g)
@@ -207,30 +207,30 @@ func TestParseGeography(t *testing.T) {
 	testCases := []struct {
 		wkt         geopb.WKT
 		expected    *Geography
-		expectedErr bool
+		expectedErr string
 	}{
 		{
 			"POINT(1.0 1.0)",
 			NewGeography(geopb.EWKB([]byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"))),
-			false,
+			"",
 		},
 		{
 			"invalid",
 			nil,
-			true,
+			"geos error: ParseException: Unknown type: 'INVALID'",
 		},
 		{
 			"",
 			nil,
-			true,
+			"geos error: ParseException: Expected word but encountered end of stream",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(string(tc.wkt), func(t *testing.T) {
 			g, err := ParseGeography(tc.wkt)
-			if tc.expectedErr {
-				require.Error(t, err)
+			if len(tc.expectedErr) > 0 {
+				require.Equal(t, tc.expectedErr, err.Error())
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, g)

--- a/pkg/geo/geos/geos_unix.h
+++ b/pkg/geo/geos/geos_unix.h
@@ -15,7 +15,7 @@ extern "C" {
 #endif
 
 // Data Types adapted from `capi/geos_c.h.in` in GEOS.
-typedef void *CR_GEOS_Geometry;
+typedef void* CR_GEOS_Geometry;
 
 // NB: Both CR_GEOS_Slice and CR_GEOS_String can contain non-printable
 // data, so neither is necessarily compatible with a NUL character
@@ -27,15 +27,17 @@ typedef void *CR_GEOS_Geometry;
 // can be either a Go or C pointer (which indicates who allocated the
 // memory).
 typedef struct {
-  char *data;
+  char* data;
   size_t len;
 } CR_GEOS_Slice;
 
 // CR_GEOS_String contains a C pointer that needs to be freed.
 typedef struct {
-  char *data;
+  char* data;
   size_t len;
 } CR_GEOS_String;
+
+typedef CR_GEOS_String CR_GEOS_Status;
 
 // CR_GEOS contains all the functions loaded by GEOS.
 typedef struct CR_GEOS CR_GEOS;
@@ -45,16 +47,16 @@ typedef struct CR_GEOS CR_GEOS;
 // must be convertible to a NUL character terminated C string.
 // The CR_GEOS object will be stored in lib.
 // The error returned does not need to be freed (see comment for CR_GEOS_Slice).
-CR_GEOS_Slice CR_GEOS_Init(CR_GEOS_Slice loc, CR_GEOS **lib);
+CR_GEOS_Slice CR_GEOS_Init(CR_GEOS_Slice loc, CR_GEOS** lib);
 
 // CR_GEOS_WKTToWKB converts a given WKT into it's WKB form. The wkt slice must be
 // convertible to a NUL character terminated C string.
-CR_GEOS_String CR_GEOS_WKTToWKB(CR_GEOS *lib, CR_GEOS_Slice wkt);
+CR_GEOS_Status CR_GEOS_WKTToWKB(CR_GEOS* lib, CR_GEOS_Slice wkt, CR_GEOS_String* wkb);
 
 // CR_GEOS_ClipWKBByRect clips a given WKB by the given rectangle.
-CR_GEOS_String CR_GEOS_ClipWKBByRect(
-  CR_GEOS *lib, CR_GEOS_Slice wkb, double xmin, double ymin, double xmax, double ymax);
+CR_GEOS_Status CR_GEOS_ClipWKBByRect(CR_GEOS* lib, CR_GEOS_Slice wkb, double xmin, double ymin,
+                                     double xmax, double ymax, CR_GEOS_String* clipped_wkb);
 
 #ifdef __cplusplus
-} // extern "C"
+}  // extern "C"
 #endif

--- a/pkg/geo/testdata/clip
+++ b/pkg/geo/testdata/clip
@@ -9,3 +9,7 @@ clip xmin=10 ymin=10 xmax=20 ymax=20
 clip xmin=0 ymin=0 xmax=10 ymax=10
 ----
 51 => 51
+
+clip xmin=10 ymin=0 xmax=0 ymax=10
+----
+geos error: IllegalArgumentException: Clipping rectangle must be non-empty


### PR DESCRIPTION
to indicate errors

This required plumbing an error GEOSMessageHandler_r handler into the
GEOSContextHandle_t with a string* to store any errors. Updated the
tests to check the GEOS error strings.

Release note: None