### PR TITLE
roachtest: fix one-off in version-upgrade

### DIFF
--- a/pkg/cmd/roachtest/versionupgrade.go
+++ b/pkg/cmd/roachtest/versionupgrade.go
@@ -396,7 +396,7 @@ func waitForUpgradeStep() versionStep {
 		newVersion := u.binaryVersion(ctx, t, 1).String()
 		t.l.Printf("%s: waiting for cluster to auto-upgrade\n", newVersion)
 
-		for i := 1; i < c.spec.NodeCount; i++ {
+		for i := 1; i <= c.spec.NodeCount; i++ {
 			err := retry.ForDuration(30*time.Second, func() error {
 				db := u.conn(ctx, t, i)
 


### PR DESCRIPTION
We weren't checking whether n4 had actually upgraded.

Fixes the failure
https://github.com/cockroachdb/cockroach/issues/44732#issuecomment-610454808
(but there are others, so not closing).

Release note: None