### PR TITLE
Make `roachprod run` report errors as COMMAND_PROBLEM

### DIFF
--- a/pkg/cmd/roachprod/errors/errors.go
+++ b/pkg/cmd/roachprod/errors/errors.go
@@ -29,15 +29,11 @@ type Error interface {
 // Exit codes for the errors
 const (
 	cmdExitCode          = 20
-	cockroachExitCode    = 30
 	sshExitCode          = 10
 	unclassifiedExitCode = 1
 )
 
-// Cmd wraps errors that result from a non-cockroach command run against
-// the cluster.
-//
-// For errors coming from a cockroach command, use Cockroach.
+// Cmd wraps errors that result from a command run against the cluster.
 type Cmd struct {
 	Err error
 }
@@ -59,32 +55,6 @@ func (e Cmd) Format(s fmt.State, verb rune) {
 
 // Unwrap the wrapped the non-cockroach command error.
 func (e Cmd) Unwrap() error {
-	return e.Err
-}
-
-// Cockroach wraps errors that result from a cockroach command run against the cluster.
-//
-// For non-cockroach commands, use Cmd.
-type Cockroach struct {
-	Err error
-}
-
-func (e Cockroach) Error() string {
-	return fmt.Sprintf("DEAD_ROACH_PROBLEM: %s", e.Err.Error())
-}
-
-// ExitCode gives the process exit code to return for cockroach errors.
-func (e Cockroach) ExitCode() int {
-	return cockroachExitCode
-}
-
-// Format passes formatting responsibilities to cockroachdb/errors
-func (e Cockroach) Format(s fmt.State, verb rune) {
-	errors.FormatError(e, s, verb)
-}
-
-// Unwrap the wrapped cockroach error.
-func (e Cockroach) Unwrap() error {
 	return e.Err
 }
 
@@ -149,23 +119,6 @@ func ClassifyCmdError(err error) Error {
 			return SSH{err}
 		}
 		return Cmd{err}
-	}
-
-	return Unclassified{err}
-}
-
-// ClassifyCockroachError classifies an error received while executing a
-// cockroach command remotely over an ssh connection to the right Error type.
-func ClassifyCockroachError(err error) Error {
-	if err == nil {
-		return nil
-	}
-
-	if exitErr, ok := asExitError(err); ok {
-		if exitErr.ExitCode() == 255 {
-			return SSH{err}
-		}
-		return Cockroach{err}
 	}
 
 	return Unclassified{err}

--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -82,26 +82,6 @@ type SyncedCluster struct {
 	DebugDir string
 }
 
-// CmdKind is the kind of command passed to SyncedCluster.Run().
-type CmdKind int
-
-// The kinds of commands passed to SyncedCluster.Run().
-const (
-	// A cockroach command is passed.
-	CockroachCmd CmdKind = iota
-
-	// A non-classified command is passed.
-	OtherCmd
-)
-
-func (ck CmdKind) classifyError(err error) rperrors.Error {
-	if ck == CockroachCmd {
-		return rperrors.ClassifyCockroachError(err)
-	}
-
-	return rperrors.ClassifyCmdError(err)
-}
-
 func (c *SyncedCluster) host(index int) string {
 	return c.VMs[index-1]
 }
@@ -466,12 +446,9 @@ done
 // stdout: Where stdout messages are written
 // stderr: Where stderr messages are written
 // nodes: The cluster nodes where the command will be run.
-// cmdKind: Which type of command is being run? This allows refined error reporting.
 // title: A description of the command being run that is output to the logs.
 // cmd: The command to run.
-func (c *SyncedCluster) Run(
-	stdout, stderr io.Writer, nodes []int, cmdKind CmdKind, title, cmd string,
-) error {
+func (c *SyncedCluster) Run(stdout, stderr io.Writer, nodes []int, title, cmd string) error {
 	// Stream output if we're running the command on only 1 node.
 	stream := len(nodes) == 1
 	var display string
@@ -520,7 +497,7 @@ func (c *SyncedCluster) Run(
 			if errors[i] != nil {
 				detailMsg := fmt.Sprintf("Node %d. Command with error:\n```\n%s\n```\n", nodes[i], cmd)
 				err = crdberrors.WithDetail(errors[i], detailMsg)
-				err = cmdKind.classifyError(err)
+				err = rperrors.ClassifyCmdError(err)
 				errors[i] = err
 			}
 			return nil, nil
@@ -531,7 +508,7 @@ func (c *SyncedCluster) Run(
 		if err != nil {
 			detailMsg := fmt.Sprintf("Node %d. Command with error:\n```\n%s\n```\n", nodes[i], cmd)
 			err = crdberrors.WithDetail(err, detailMsg)
-			err = cmdKind.classifyError(err)
+			err = rperrors.ClassifyCmdError(err)
 			errors[i] = err
 			msg += fmt.Sprintf("\n%v", err)
 		}

--- a/pkg/cmd/roachprod/install/install.go
+++ b/pkg/cmd/roachprod/install/install.go
@@ -163,7 +163,7 @@ func SortedCmds() []string {
 func Install(c *SyncedCluster, args []string) error {
 	do := func(title, cmd string) error {
 		var buf bytes.Buffer
-		err := c.Run(&buf, &buf, c.Nodes, OtherCmd, "installing "+title, cmd)
+		err := c.Run(&buf, &buf, c.Nodes, "installing "+title, cmd)
 		if err != nil {
 			fmt.Print(buf.String())
 		}

--- a/pkg/cmd/roachprod/install/staging.go
+++ b/pkg/cmd/roachprod/install/staging.go
@@ -64,8 +64,7 @@ func StageRemoteBinary(c *SyncedCluster, applicationName, binaryPath, SHA, arch 
 		`curl -sfSL -o %s "%s" && chmod 755 ./%s`, applicationName, binURL, applicationName,
 	)
 	return c.Run(
-		os.Stdout, os.Stderr, c.Nodes, OtherCmd,
-		fmt.Sprintf("staging binary (%s)", applicationName), cmdStr,
+		os.Stdout, os.Stderr, c.Nodes, fmt.Sprintf("staging binary (%s)", applicationName), cmdStr,
 	)
 }
 
@@ -96,6 +95,6 @@ mv ${tmpdir}/cockroach ./cockroach && \
 chmod 755 ./cockroach
 `, binURL)
 	return c.Run(
-		os.Stdout, os.Stderr, c.Nodes, OtherCmd, "staging cockroach release binary", cmdStr,
+		os.Stdout, os.Stderr, c.Nodes, "staging cockroach release binary", cmdStr,
 	)
 }

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1186,7 +1186,7 @@ the 'zfs rollback' command:
 			return fmt.Errorf("unknown filesystem %q", fs)
 		}
 
-		err = c.Run(os.Stdout, os.Stderr, c.Nodes, install.OtherCmd, "reformatting", fmt.Sprintf(`
+		err = c.Run(os.Stdout, os.Stderr, c.Nodes, "reformatting", fmt.Sprintf(`
 set -euo pipefail
 if sudo zpool list -Ho name 2>/dev/null | grep ^data1$; then
   sudo zpool destroy -f data1
@@ -1228,7 +1228,7 @@ var runCmd = &cobra.Command{
 		if len(title) > 30 {
 			title = title[:27] + "..."
 		}
-		return c.Run(os.Stdout, os.Stderr, c.Nodes, install.CockroachCmd, title, cmd)
+		return c.Run(os.Stdout, os.Stderr, c.Nodes, title, cmd)
 	}),
 }
 

--- a/pkg/cmd/roachtest/rapid_restart.go
+++ b/pkg/cmd/roachtest/rapid_restart.go
@@ -80,7 +80,7 @@ func runRapidRestart(ctx context.Context, t *test, c *cluster) {
 				case -1:
 					// Received SIGINT before setting up our own signal handlers or
 					// SIGKILL.
-				case 30:
+				case 20:
 					// Exit code from a SIGINT received by our signal handlers.
 				default:
 					t.Fatalf("unexpected exit status %d", status)


### PR DESCRIPTION
Before:

Errors from a remote ssh command during `roachprod run` were reported as
DEAD_ROACH_PROBLEM.

Why Change?

Most commands run via `roachprod run` are not cockroach commands. Instead
of roachprod trying to figure out if the problem is from cockroach or a
different command, let the calling program decide how to classify and
handle the error.

Now:

When a remote command run over ssh results in an error being returned,
`roachprod run` will report COMMAND_PROBLEM in its output and its
corresponding exit code.

Fixes: #47202

Release note: None