### PR TITLE
opt: corrects function doc for canMaybeConstrainIndex

### DIFF
--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -983,13 +983,16 @@ func (c *CustomFuncs) allInvIndexConstraints(
 	return constraints, true
 }
 
-// canMaybeConstrainIndex performs two checks that can quickly rule out the
-// possibility that the given index can be constrained by the specified filter:
+// canMaybeConstrainIndex returns true if we should try to constrain a given
+// index by the given filter. It returns false if it is impossible for the
+// filter can constrain the scan.
 //
-//   1. If the filter does not reference the first index column, then no
-//      constraint can be generated.
-//   2. If none of the filter's constraints start with the first index column,
-//      then no constraint can be generated.
+// If any of the three following statements are true, then it is
+// possible that the index can be constrained:
+//
+//   1. The filter references the first index column.
+//   2. The constraints are not tight (see props.Scalar.TightConstraints).
+//   3. Any of the filter's constraints start with the first index column.
 //
 func (c *CustomFuncs) canMaybeConstrainIndex(
 	filters memo.FiltersExpr, tabID opt.TableID, indexOrd int,


### PR DESCRIPTION
#### opt: corrects function doc for canMaybeConstrainIndex

This commit corrects a the function documentation for
canMaybeConstrainIndex.

Prior to this change, it did not mention a third check, for tight filter
constraints, that is performed to determinte the possibility that an
index could be constrained by a filer.

Also, the documentation now correctly maps to the logic of the function.
Previously it falsly claimed that if any of the checks were false then
the function would return false. Now it correctly states that if any of
the checks are true, then the fucntion returns true.

Release note: None

