### PR TITLE
roachtest: add one more version upgrade step

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -47,14 +47,14 @@ func registerAcceptance(r *testRegistry) {
 		{
 			name: "version-upgrade",
 			fn:   runVersionUpgrade,
-			skip: "skipped due to flakiness",
 			// This test doesn't like running on old versions because it upgrades to
 			// the latest released version and then it tries to "head", where head is
 			// the cockroach binary built from the branch on which the test is
 			// running. If that branch corresponds to an older release, then upgrading
 			// to head after 19.2 fails.
 			minVersion: "v19.2.0",
-			timeout:    30 * time.Minute},
+			timeout:    30 * time.Minute,
+		},
 	}
 	tags := []string{"default", "quick"}
 	const numNodes = 4

--- a/pkg/cmd/roachtest/versionupgrade.go
+++ b/pkg/cmd/roachtest/versionupgrade.go
@@ -77,6 +77,7 @@ DROP TABLE test.t;
 }
 
 const (
+	baseVersion = "19.1.5"
 	headVersion = "HEAD"
 )
 
@@ -87,7 +88,6 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster) {
 	// TODO(tbg): revisit as old versions are aged out of this test.
 	c.encryptDefault = false
 
-	const baseVersion = "19.1.5"
 	u := newVersionUpgradeTest(c, versionUpgradeTestFeatures,
 		// Load baseVersion fixture. That fixture's cluster version may be
 		// at the predecessor version, so add a waitForUpgradeStep to make
@@ -119,14 +119,14 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster) {
 		// (automatically).
 		preventAutoUpgradeStep(),
 		// Roll nodes forward.
-		binaryUpgradeStep("HEAD"),
+		binaryUpgradeStep(headVersion),
 		// Roll back again. Note that bad things would happen if the cluster had
 		// ignored our request to not auto-upgrade. The `autoupgrade` roachtest
 		// exercises this in more detail, so here we just rely on things working
 		// as they ought to.
 		binaryUpgradeStep("19.2.1"),
 		// Roll nodes forward, this time allowing them to upgrade.
-		binaryUpgradeStep("HEAD"),
+		binaryUpgradeStep(headVersion),
 		allowAutoUpgradeStep(),
 		waitForUpgradeStep(),
 	)
@@ -358,7 +358,7 @@ func binaryUpgradeStep(newVersion string) versionStep {
 			// compatible).
 			name := checkpointName(newVersion)
 			c.Stop(ctx, nodes)
-			c.Run(ctx, c.All(), "./cockroach-HEAD", "debug", "rocksdb", "--db={store-dir}",
+			c.Run(ctx, c.All(), "./cockroach-" + headVersion, "debug", "rocksdb", "--db={store-dir}",
 				"checkpoint", "--checkpoint_dir={store-dir}/"+name)
 			c.Run(ctx, c.All(), "tar", "-C", "{store-dir}/"+name, "-czf", "{log-dir}/"+name+".tgz", ".")
 			c.Start(ctx, t, nodes, args, startArgsDontEncrypt, roachprodArgOption{"--sequential=false"})

--- a/pkg/cmd/roachtest/versionupgrade.go
+++ b/pkg/cmd/roachtest/versionupgrade.go
@@ -149,7 +149,7 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster) {
 //   mv artifacts/acceptance/version-upgrade/run_1/${i}.logs/checkpoint-*.tgz \
 //     pkg/cmd/roachtest/fixtures/${i}/
 // done
-const createCheckpoints = false
+const createCheckpoints = true
 
 func (u *versionUpgradeTest) run(ctx context.Context, t *test) {
 	if createCheckpoints {


### PR DESCRIPTION
We need to add an intermediate upgrade step to `19.2.5` to prevent the
KV store layer complaining that `HEAD` binary is too new.
This PR also adds some logging that will help debugging test failure
logs.

Fixes CI failure:
https://teamcity.cockroachdb.com/viewLog.html?buildId=1861955&_focus=3423

Release note: none.