### PR TITLE
[DNM]roachtest: mixed version upgrade test for schema changes

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -44,6 +44,12 @@ func registerAcceptance(r *testRegistry) {
 		{name: "gossip/locality-address", fn: runCheckLocalityIPAddress},
 		{name: "rapid-restart", fn: runRapidRestart},
 		{name: "many-splits", fn: runManySplits},
+		{
+			name:       "mixed-version-schemachange",
+			fn:         runMixedVersionSchemaChange,
+			minVersion: "v19.2.5",
+			timeout:    30 * time.Minute,
+		},
 		{name: "status-server", fn: runStatusServer},
 		{
 			name: "version-upgrade",

--- a/pkg/cmd/roachtest/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/mixed_version_schemachange.go
@@ -1,0 +1,97 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+const predecessorVersion = "19.2.5"
+
+func runMixedVersionSchemaChange(ctx context.Context, t *test, c *cluster) {
+	var numFeatureRuns int
+	testFeaturesStep := func(ctx context.Context, t *test, u *versionUpgradeTest) {
+		numFeatureRuns++
+		t.l.Printf("Feature test run: %d", numFeatureRuns)
+		loadNode := u.c.All().randNode()[0]
+		u.c.Run(ctx, u.c.Node(loadNode), "./workload init schemachange")
+		runCmd := []string{
+			"./workload run",
+			"schemachange --concurrency 2 --max-ops 10 --verbose=1",
+			fmt.Sprintf("{pgurl:1-%d}", u.c.spec.NodeCount),
+		}
+		t.l.Printf("running workload %s", strings.Join(runCmd, " "))
+
+		err := u.c.RunE(ctx, u.c.Node(loadNode), runCmd...)
+		if err != nil {
+			t.l.Printf("--- FAILi:\n%s\n%v", strings.Join(runCmd, " "), err)
+			c.t.Fatal(err)
+		}
+	}
+	u := newVersionUpgradeTest(c,
+		uploadAndStartFromCheckpointFixture(c.All(), predecessorVersion),
+		waitForUpgradeStep(c.All()),
+
+		// NB: at this point, cluster and binary version equal predecessorVersion,
+		// and auto-upgrades are on.
+
+		// We use an empty string for the version below, which means to use the
+		// main ./cockroach binary (i.e. the one being tested in this run).
+		// We upgrade into this version more capriciously to ensure better
+		// coverage by first rolling the cluster into the new version with
+		// auto-upgrade disabled, then rolling back, and then rolling forward
+		// and finalizing on the auto-upgrade path.
+		preventAutoUpgradeStep(1),
+		testFeaturesStep,
+
+		// Roll nodes forward.
+		binaryUpgradeStep(c.Node(3), ""),
+		preventDeadlock(3),
+		testFeaturesStep,
+		binaryUpgradeStep(c.Node(2), ""),
+		testFeaturesStep,
+		binaryUpgradeStep(c.Node(1), ""),
+		testFeaturesStep,
+		binaryUpgradeStep(c.Node(4), ""),
+		testFeaturesStep,
+
+		// Roll back again. Note that bad things would happen if the cluster had
+		// ignored our request to not auto-upgrade. The `autoupgrade` roachtest
+		// exercises this in more detail, so here we just rely on things working
+		// as they ought to.
+		binaryUpgradeStep(c.Node(2), predecessorVersion),
+		testFeaturesStep,
+		binaryUpgradeStep(c.Node(4), predecessorVersion),
+		testFeaturesStep,
+		binaryUpgradeStep(c.Node(3), predecessorVersion),
+		testFeaturesStep,
+		binaryUpgradeStep(c.Node(1), predecessorVersion),
+		testFeaturesStep,
+
+		// Roll nodes forward.
+		binaryUpgradeStep(c.Node(4), ""),
+		testFeaturesStep,
+		binaryUpgradeStep(c.Node(3), ""),
+		testFeaturesStep,
+		binaryUpgradeStep(c.Node(1), ""),
+		testFeaturesStep,
+		binaryUpgradeStep(c.Node(2), ""),
+		testFeaturesStep,
+
+		allowAutoUpgradeStep(1),
+		waitForUpgradeStep(c.All()),
+		testFeaturesStep,
+	)
+
+	u.run(ctx, t)
+}

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -64,7 +64,7 @@ type schemaChange struct {
 	concurrency     int
 	maxOpsPerWorker int
 	existingPct     int
-	verbose         bool
+	verbose         int
 	dryRun          bool
 }
 
@@ -83,7 +83,7 @@ var schemaChangeMeta = workload.Meta{
 			`Number of operations to execute in a single transaction`)
 		s.flags.IntVar(&s.existingPct, `existing-pct`, defaultExistingPct,
 			`Percentage of times to use existing name`)
-		s.flags.BoolVarP(&s.verbose, `verbose`, `v`, true, ``)
+		s.flags.IntVarP(&s.verbose, `verbose`, `v`, 0, ``)
 		s.flags.BoolVarP(&s.dryRun, `dry-run`, `n`, false, ``)
 		return s
 	},
@@ -218,7 +218,7 @@ func (s *schemaChange) initSeqNum(pool *workload.MultiConnPool) (*int64, error) 
 
 	const q = `
 SELECT max(regexp_extract(name, '[0-9]+$')::int)
-  FROM ((SELECT * FROM [SHOW TABLES]) UNION (SELECT * FROM [SHOW SEQUENCES])) AS obj(name)
+  FROM ((SELECT table_name FROM [SHOW TABLES]) UNION (SELECT sequence_name FROM [SHOW SEQUENCES])) AS obj(name)
  WHERE name ~ '^(table|view|seq)[0-9]+$';
 `
 	var max gosql.NullInt64
@@ -233,7 +233,7 @@ SELECT max(regexp_extract(name, '[0-9]+$')::int)
 }
 
 type schemaChangeWorker struct {
-	verbose         bool
+	verbose         int
 	dryRun          bool
 	maxOpsPerWorker int
 	existingPct     int
@@ -249,14 +249,15 @@ func (w *schemaChangeWorker) runInTxn(tx *pgx.Tx) (string, error) {
 	// Run between 1 and maxOpsPerWorker schema change operations.
 	n := 1 + w.rng.Intn(w.maxOpsPerWorker)
 	for i := 0; i < n; i++ {
-		op, err := w.randOp(tx)
+		op, noops, err := w.randOp(tx)
 		if err != nil {
-			return log.String(), err
+			return noops, errors.Wrap(err, "randOp")
 		}
+		log.WriteString(noops)
 		log.WriteString(fmt.Sprintf("  %s;\n", op))
 		if !w.dryRun {
 			if _, err := tx.Exec(op); err != nil {
-				return log.String(), err
+				return log.String(), errors.Wrapf(err, "%s failed", op)
 			}
 		}
 	}
@@ -267,27 +268,32 @@ func (w *schemaChangeWorker) run(_ context.Context) error {
 	start := timeutil.Now()
 	tx, err := w.pool.Get().Begin()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "cannot get a connection and begin a txn")
 	}
 
 	var histBin string
 	log, err := w.runInTxn(tx)
 	elapsed := timeutil.Since(start)
 	if err != nil {
-		_ = tx.Rollback()
+		rbkErr := tx.Rollback()
+		if rbkErr != nil {
+			w.hists.Get("rbk").Record(elapsed)
+			err = errors.Wrapf(err, "ROLLBACK: %v", rbkErr)
+		}
 		log = log + "ROLLBACK;\n"
 		histBin = "err"
 		// TODO(spaskob): should we log the ROLLBACK error as well?
 	} else {
 		log = log + "COMMIT;\n"
 		if err = tx.Commit(); err != nil {
-			histBin = "err"
+			histBin = "cmt_err"
+			err = errors.Wrap(err, "COMMIT")
 		} else {
 			histBin = "ok"
 		}
 	}
 	w.hists.Get(histBin).Record(elapsed)
-	if w.verbose {
+	if w.verbose >= 1 {
 		fmt.Print("BEGIN\n")
 		fmt.Print(log)
 		if err != nil {
@@ -298,7 +304,8 @@ func (w *schemaChangeWorker) run(_ context.Context) error {
 	return nil
 }
 
-func (w *schemaChangeWorker) randOp(tx *pgx.Tx) (string, error) {
+func (w *schemaChangeWorker) randOp(tx *pgx.Tx) (string, string, error) {
+	var log strings.Builder
 	for {
 		var stmt string
 		var err error
@@ -379,12 +386,12 @@ func (w *schemaChangeWorker) randOp(tx *pgx.Tx) (string, error) {
 
 		// TODO(spaskob): use more fine-grained error reporting.
 		if stmt == "" || err == pgx.ErrNoRows {
-			if w.verbose {
-				fmt.Printf("NOOP: %s -> %v\n", op, err)
+			if w.verbose >= 2 {
+				log.WriteString(fmt.Sprintf("NOOP: %s -> %v\n", op, err))
 			}
 			continue
 		}
-		return stmt, err
+		return stmt, log.String(), err
 	}
 }
 


### PR DESCRIPTION
This PR is for illustration puposes only. It shows the differeces between this test
and `acceptance/version-upgrade` so that we can glean what th right abstraction are
to be shared by these tests. Also the test has some in-efficiencies: for example
the new binary is copied to all nodes every time a single node  is upgraded.

Release note: none.