### PR TITLE
release-20.1: sql: populate Oid on type upgrade 

### DIFF
--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1722,11 +1722,10 @@ func (t *T) upgradeType() error {
 		if t.Width() != 0 {
 			return errors.AssertionFailedf("name type cannot have non-zero width: %d", t.Width())
 		}
+	}
 
-	default:
-		if t.InternalType.Oid == 0 {
-			t.InternalType.Oid = familyToOid[t.Family()]
-		}
+	if t.InternalType.Oid == 0 {
+		t.InternalType.Oid = familyToOid[t.Family()]
 	}
 
 	// Clear the deprecated visible types, since they are now handled by the


### PR DESCRIPTION
Backport 1/1 commits from #47234.

/cc @cockroachdb/release

---

When types are unmarshalled, the types are upgraded and the Oid of the
internal type should be set. In 19.1, timestamps received an Oid and
they were populated by the default case in upgradeTypes. However,
a case to handle timestamps was added, but the Oids were no longer
set (as they didn't need to be anymore). However, this meant that
default case was not triggered anymore, so the Oid was no longer
set. This commit also sets the Oid in the timestamp case.

Fixes #44453.

Release note (bug fix): Restoring a backup from 2.1 to 20.1 with a
timestamp column would result in incomplete type data. This would
crash commands such as SHOW COLUMNS FROM <new_table>. This is now
fixed.
