### PR TITLE
kvcoord: add 'have been waiting' warning to DistSender

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -3479,3 +3479,29 @@ func TestEvictionTokenCoalesce(t *testing.T) {
 	go putFn("c", "c")
 	batchWaitGroup.Wait()
 }
+
+func TestDistSenderSlowLogMessage(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	const (
+		dur      = 8158 * time.Millisecond
+		attempts = 120
+	)
+	desc := &roachpb.RangeDescriptor{RangeID: 9, StartKey: roachpb.RKey("x")}
+	{
+		exp := `have been waiting 8.16s (120 attempts) for RPC to` +
+			` r9:{-} [<no replicas>, next=0, gen=0?]: boom`
+		act := slowRangeRPCWarningStr(
+			dur,
+			120,
+			desc,
+			roachpb.NewError(errors.New("boom")))
+
+		require.Equal(t, exp, act)
+	}
+
+	{
+		exp := `slow RPC finished after 8.16s (120 attempts)`
+		act := slowRangeRPCReturnWarningStr(dur, attempts)
+		require.Equal(t, exp, act)
+	}
+}

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -624,6 +624,7 @@ var charts = []sectionDescription{
 		Organization: [][]string{
 			{KVTransactionLayer, "Requests", "Slow"},
 			{ReplicationLayer, "Requests", "Slow"},
+			{DistributionLayer, "Requests", "Slow"},
 		},
 		Charts: []chartDescription{
 			{
@@ -643,6 +644,12 @@ var charts = []sectionDescription{
 				Downsampler: DescribeAggregator_MAX,
 				Percentiles: false,
 				Metrics:     []string{"requests.slow.raft"},
+			},
+			{
+				Title:       "Stuck sending RPCs to range",
+				Downsampler: DescribeAggregator_MAX,
+				Percentiles: false,
+				Metrics:     []string{"requests.slow.distsender"},
 			},
 		},
 	},

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/requests.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/requests.tsx
@@ -25,6 +25,12 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
+    <LineGraph title="Slow DistSender RPCs" sources={storeSources}>
+      <Axis label="proposals">
+        <Metric name="cr.node.requests.slow.distsender" title="Slow DistSender RPCs" downsampleMax />
+      </Axis>
+    </LineGraph>,
+
     <LineGraph title="Slow Lease Acquisitions" sources={storeSources}>
       <Axis label="lease acquisitions">
         <Metric name="cr.store.requests.slow.lease" title="Slow Lease Acquisitions" downsampleMax />


### PR DESCRIPTION
We already have these at the Range level, but it looks like we might
have seen a case in which requests spent all of their time in
DistSender, without ever showing up on the ranges. This could be an
infinite retry loop related to descriptor caching, though this is pure
speculation. Either way, it will be helpful to see what error these
requests are stuck retrying on should the problem occur again.

No release note since this is out in the weeds.

Release note: None