### PR TITLE
build: add prototool lint configuration

### DIFF
--- a/prototool.yaml
+++ b/prototool.yaml
@@ -1,0 +1,32 @@
+excludes:
+  - pkg/ui/node_modules
+protoc:
+  version: 3.8.0
+  includes:
+   - pkg
+   - vendor/github.com/gogo/protobuf
+   - vendor/github.com/cockroachdb/errors
+   - vendor/go.etcd.io
+   - vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis
+   - vendor/github.com
+lint:
+  group: uber2
+  ignores:
+    - id: FILE_OPTIONS_REQUIRE_PHP_NAMESPACE
+      files:
+        - pkg
+    - id: FILE_OPTIONS_REQUIRE_JAVA_PACKAGE
+      files:
+        - pkg
+    - id: FILE_OPTIONS_REQUIRE_JAVA_MULTIPLE_FILES
+      files:
+        - pkg
+    - id: FILE_OPTIONS_REQUIRE_JAVA_OUTER_CLASSNAME
+      files:
+        - pkg
+    - id: FILE_OPTIONS_REQUIRE_CSHARP_NAMESPACE
+      files:
+        - pkg
+    - id: FILE_OPTIONS_REQUIRE_OBJC_CLASS_PREFIX
+      files:
+        - pkg


### PR DESCRIPTION
Add a lint configuration for [prototool](https://github.com/uber/prototool#prototool).

I'm not sure if prototool is the best thing to use anymore now that there is [buf](https://github.com/bufbuild/buf), but I couldn't figure out how to get buf to understand our wacky include path setup. Both of these tools expect that protobufs are all pathed from the PWD properly, and ours are not, but prototool has flexibility for specifying this whereas buf does not. Buf allows you to specify "roots", but the roots can't overlap, and each root has to be an include root and not just a directory from which many protos with different roots live...

You can run this with `prototool lint pkg`. Here's what it turned up:

```
pkg/acceptance/cluster/testconfig.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/acceptance/cluster/testconfig.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.acceptance.cluster".
pkg/acceptance/cluster/testconfig.proto:13:1:Expected "clusterpb" for option "go_package" but was "cluster".
pkg/acceptance/cluster/testconfig.proto:23:3:Enum field "INIT_COMMAND" is expected to have the prefix "INIT_MODE_".
pkg/acceptance/cluster/testconfig.proto:23:3:Zero value enum field "INIT_COMMAND" is expected to have the name "INIT_MODE_INVALID".
pkg/acceptance/cluster/testconfig.proto:27:3:Enum field "INIT_BOOTSTRAP_NODE_ZERO" is expected to have the prefix "INIT_MODE_".
pkg/acceptance/cluster/testconfig.proto:31:3:Enum field "INIT_NONE" is expected to have the prefix "INIT_MODE_".
pkg/acceptance/cluster/testconfig.proto:45:1:Message "TestConfig" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/blobs/blobspb/blobs.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.blobs".
pkg/blobs/blobspb/blobs.proto:21:1:Message "GetRequest" is a request for RPC "GetStream" and should be defined in the file after the RPC.
pkg/blobs/blobspb/blobs.proto:26:1:Message "GetResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/blobs/blobspb/blobs.proto:32:1:Message "PutRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/blobs/blobspb/blobs.proto:38:1:Message "PutResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/blobs/blobspb/blobs.proto:42:1:Message "GlobRequest" is a request for RPC "List" and should be defined in the file after the RPC.
pkg/blobs/blobspb/blobs.proto:47:1:Message "GlobResponse" is a response for RPC "List" and should be defined in the file after the RPC.
pkg/blobs/blobspb/blobs.proto:53:1:Message "DeleteRequest" is a request for RPC "Delete" and should be defined in the file after the RPC.
pkg/blobs/blobspb/blobs.proto:58:1:Message "DeleteResponse" is a response for RPC "Delete" and should be defined in the file after the RPC.
pkg/blobs/blobspb/blobs.proto:63:1:Message "StatRequest" is a request for RPC "Stat" and should be defined in the file after the RPC.
pkg/blobs/blobspb/blobs.proto:68:1:Message "BlobStat" is a response for RPC "Stat" and should be defined in the file after the RPC.
pkg/blobs/blobspb/blobs.proto:73:1:Message "StreamChunk" is a request for RPC "PutStream" and should be defined in the file after the RPC.
pkg/blobs/blobspb/blobs.proto:73:1:Message "StreamChunk" is a response for RPC "GetStream" and should be defined in the file after the RPC.
pkg/blobs/blobspb/blobs.proto:78:1:Message "StreamResponse" is a response for RPC "PutStream" and should be defined in the file after the RPC.
pkg/blobs/blobspb/blobs.proto:84:1:Service name "Blob" must end with "API".
pkg/blobs/blobspb/blobs.proto:84:1:Expected filename to be "blob.proto" for file containing service "Blob" but was "blobs.proto".
pkg/blobs/blobspb/blobs.proto:85:3:Name of request type "GlobRequest" should be "ListRequest".
pkg/blobs/blobspb/blobs.proto:85:3:Name of response type "GlobResponse" should be "ListResponse".
pkg/blobs/blobspb/blobs.proto:85:3:RPC "List" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/blobs/blobspb/blobs.proto:86:3:RPC "Delete" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/blobs/blobspb/blobs.proto:87:3:Name of response type "BlobStat" should be "StatResponse".
pkg/blobs/blobspb/blobs.proto:87:3:RPC "Stat" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/blobs/blobspb/blobs.proto:88:3:Name of request type "GetRequest" should be "GetStreamRequest".
pkg/blobs/blobspb/blobs.proto:88:3:Name of response type "StreamChunk" should be "GetStreamResponse".
pkg/blobs/blobspb/blobs.proto:88:3:RPC "GetStream" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/blobs/blobspb/blobs.proto:89:3:Name of request type "StreamChunk" should be "PutStreamRequest".
pkg/blobs/blobspb/blobs.proto:89:3:Name of response type "StreamResponse" should be "PutStreamResponse".
pkg/blobs/blobspb/blobs.proto:89:3:Message "StreamChunk" is already used as a request or response type in an RPC and all request and response types must be unique.
pkg/blobs/blobspb/blobs.proto:89:3:RPC "PutStream" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/build/info.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/build/info.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.build".
pkg/build/info.proto:13:1:Expected "buildpb" for option "go_package" but was "build".
pkg/ccl/backupccl/backup.proto:10:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.ccl.backupccl".
pkg/ccl/backupccl/backup.proto:11:1:Expected "backupcclpb" for option "go_package" but was "backupccl".
pkg/ccl/backupccl/backup.proto:21:1:Enum "MVCCFilter" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ccl/backupccl/backup.proto:22:3:Field name "Latest" must be UPPER_SNAKE_CASE.
pkg/ccl/backupccl/backup.proto:22:3:Enum field "Latest" is expected to have the prefix "MVCC_FILTER_".
pkg/ccl/backupccl/backup.proto:22:3:Zero value enum field "Latest" is expected to have the name "MVCC_FILTER_INVALID".
pkg/ccl/backupccl/backup.proto:23:3:Field name "All" must be UPPER_SNAKE_CASE.
pkg/ccl/backupccl/backup.proto:23:3:Enum field "All" is expected to have the prefix "MVCC_FILTER_".
pkg/ccl/backupccl/backup.proto:28:3:The name "data_size" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/ccl/backupccl/backup.proto:31:3:"RowCount" cannot have reserved field numbers, use the deprecated field option instead.
pkg/ccl/backupccl/backup.proto:31:15:Inline comments are not allowed on reserved, only comment above the type.
pkg/ccl/backupccl/backup.proto:46:5:"BackupManifest.File" cannot have reserved field numbers, use the deprecated field option instead.
pkg/ccl/backupccl/backup.proto:48:5:"BackupManifest.File" cannot have reserved field numbers, use the deprecated field option instead.
pkg/ccl/backupccl/backup.proto:58:3:Message "DescriptorRevision" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ccl/backupccl/backup.proto:60:5:Field name "ID" must be lower_snake_case.
pkg/ccl/backupccl/backup.proto:92:3:"BackupManifest" cannot have reserved field numbers, use the deprecated field option instead.
pkg/ccl/backupccl/backup.proto:117:1:Message "BackupPartitionDescriptor" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ccl/backupccl/backup.proto:129:3:Enum "Scheme" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ccl/backupccl/backup.proto:130:5:Enum field "AES256GCM" is expected to have the prefix "SCHEME_".
pkg/ccl/backupccl/backup.proto:130:5:Zero value enum field "AES256GCM" is expected to have the name "SCHEME_INVALID".
pkg/ccl/baseccl/encryption_options.proto:10:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.ccl.baseccl".
pkg/ccl/baseccl/encryption_options.proto:11:1:Expected "basecclpb" for option "go_package" but was "baseccl".
pkg/ccl/baseccl/encryption_options.proto:15:1:Enum "EncryptionKeySource" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ccl/baseccl/encryption_options.proto:17:3:Field name "KeyFiles" must be UPPER_SNAKE_CASE.
pkg/ccl/baseccl/encryption_options.proto:17:3:Enum field "KeyFiles" is expected to have the prefix "ENCRYPTION_KEY_SOURCE_".
pkg/ccl/baseccl/encryption_options.proto:17:3:Zero value enum field "KeyFiles" is expected to have the name "ENCRYPTION_KEY_SOURCE_INVALID".
pkg/ccl/baseccl/encryption_options.proto:35:3:The name "data_key_rotation_period" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.proto:10:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.ccl.storageccl.engineccl.enginepbccl".
pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.proto:11:1:Expected "enginepbcclpb" for option "go_package" but was "enginepbccl".
pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.proto:15:1:Enum "EncryptionType" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.proto:17:3:Field name "Plaintext" must be UPPER_SNAKE_CASE.
pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.proto:17:3:Enum field "Plaintext" is expected to have the prefix "ENCRYPTION_TYPE_".
pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.proto:17:3:Zero value enum field "Plaintext" is expected to have the name "ENCRYPTION_TYPE_INVALID".
pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.proto:19:3:Enum field "AES128_CTR" is expected to have the prefix "ENCRYPTION_TYPE_".
pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.proto:20:3:Enum field "AES192_CTR" is expected to have the prefix "ENCRYPTION_TYPE_".
pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.proto:21:3:Enum field "AES256_CTR" is expected to have the prefix "ENCRYPTION_TYPE_".
pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.proto:27:1:The name "DataKeysRegistry" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.proto:31:3:The name "data_keys" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.proto:34:3:The name "active_data_key_id" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.proto:75:23:Inline comments are not allowed on fields, only comment above the type.
pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.proto:76:23:Inline comments are not allowed on fields, only comment above the type.
pkg/ccl/storageccl/engineccl/enginepbccl/stats.proto:10:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.ccl.storageccl.engineccl.enginepbccl".
pkg/ccl/storageccl/engineccl/enginepbccl/stats.proto:11:1:Expected "enginepbcclpb" for option "go_package" but was "enginepbccl".
pkg/ccl/storageccl/engineccl/enginepbccl/stats.proto:21:3:The name "active_data_key" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/ccl/utilccl/licenseccl/license.proto:10:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.ccl.utilccl.licenseccl".
pkg/ccl/utilccl/licenseccl/license.proto:11:1:Expected "licensecclpb" for option "go_package" but was "licenseccl".
pkg/ccl/utilccl/licenseccl/license.proto:15:1:Message "License" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ccl/utilccl/licenseccl/license.proto:21:5:Enum "Type" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ccl/utilccl/licenseccl/license.proto:22:7:Field name "NonCommercial" must be UPPER_SNAKE_CASE.
pkg/ccl/utilccl/licenseccl/license.proto:22:7:Enum field "NonCommercial" is expected to have the prefix "TYPE_".
pkg/ccl/utilccl/licenseccl/license.proto:22:7:Zero value enum field "NonCommercial" is expected to have the name "TYPE_INVALID".
pkg/ccl/utilccl/licenseccl/license.proto:23:7:Field name "Enterprise" must be UPPER_SNAKE_CASE.
pkg/ccl/utilccl/licenseccl/license.proto:23:7:Enum field "Enterprise" is expected to have the prefix "TYPE_".
pkg/ccl/utilccl/licenseccl/license.proto:24:7:Field name "Evaluation" must be UPPER_SNAKE_CASE.
pkg/ccl/utilccl/licenseccl/license.proto:24:7:Enum field "Evaluation" is expected to have the prefix "TYPE_".
pkg/cli/systembench/systembenchpb/ping.proto:1:1:File option "go_package" is required.
pkg/cli/systembench/systembenchpb/ping.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/cli/systembench/systembenchpb/ping.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "systembench".
pkg/cli/systembench/systembenchpb/ping.proto:14:1:Message "PingRequest" is a request for RPC "Ping" and should be defined in the file after the RPC.
pkg/cli/systembench/systembenchpb/ping.proto:18:1:Message "PingResponse" is a response for RPC "Ping" and should be defined in the file after the RPC.
pkg/cli/systembench/systembenchpb/ping.proto:22:1:Service "Pinger" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/cli/systembench/systembenchpb/ping.proto:22:1:Service name "Pinger" must end with "API".
pkg/cli/systembench/systembenchpb/ping.proto:22:1:Expected filename to be "pinger.proto" for file containing service "Pinger" but was "ping.proto".
pkg/cli/systembench/systembenchpb/ping.proto:23:3:RPC "Ping" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/clusterversion/cluster_version.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.base".
pkg/clusterversion/cluster_version.proto:13:1:Expected "basepb" for option "go_package" but was "clusterversion".
pkg/clusterversion/cluster_version.proto:24:3:"ClusterVersion" cannot have reserved field numbers, use the deprecated field option instead.
pkg/config/system.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/config/system.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.config".
pkg/config/system.proto:13:1:Expected "configpb" for option "go_package" but was "config".
pkg/config/system.proto:18:1:Message "SystemConfigEntries" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/config/zonepb/zone.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/config/zonepb/zone.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.config.zonepb".
pkg/config/zonepb/zone.proto:13:1:Expected "zonepbpb" for option "go_package" but was "zonepb".
pkg/config/zonepb/zone.proto:39:3:Enum "Type" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/config/zonepb/zone.proto:41:5:Enum field "DEPRECATED_POSITIVE" is expected to have the prefix "TYPE_".
pkg/config/zonepb/zone.proto:41:5:Zero value enum field "DEPRECATED_POSITIVE" is expected to have the name "TYPE_INVALID".
pkg/config/zonepb/zone.proto:44:5:Enum field "REQUIRED" is expected to have the prefix "TYPE_".
pkg/config/zonepb/zone.proto:46:5:Enum field "PROHIBITED" is expected to have the prefix "TYPE_".
pkg/config/zonepb/zone.proto:88:3:"ZoneConfig" cannot have reserved field numbers, use the deprecated field option instead.
pkg/config/zonepb/zone.proto:138:1:Message "Subzone" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/config/zonepb/zone.proto:155:1:Message "SubzoneSpan" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/gossip/gossip.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.gossip".
pkg/gossip/gossip.proto:13:1:Expected "gossippb" for option "go_package" but was "gossip".
pkg/gossip/gossip.proto:22:1:Message "BootstrapInfo" is not a request or response of any service in this file and should be in a separate file.
pkg/gossip/gossip.proto:30:1:Message "Request" is a request for RPC "Gossip" and should be defined in the file after the RPC.
pkg/gossip/gossip.proto:49:1:Message "Response" is a response for RPC "Gossip" and should be defined in the file after the RPC.
pkg/gossip/gossip.proto:68:1:Message "ConnStatus" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/gossip/gossip.proto:68:1:Message "ConnStatus" is not a request or response of any service in this file and should be in a separate file.
pkg/gossip/gossip.proto:77:1:Message "MetricSnap" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/gossip/gossip.proto:77:1:Message "MetricSnap" is not a request or response of any service in this file and should be in a separate file.
pkg/gossip/gossip.proto:87:1:Message "OutgoingConnStatus" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/gossip/gossip.proto:87:1:Message "OutgoingConnStatus" is not a request or response of any service in this file and should be in a separate file.
pkg/gossip/gossip.proto:94:1:Message "ClientStatus" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/gossip/gossip.proto:94:1:Message "ClientStatus" is not a request or response of any service in this file and should be in a separate file.
pkg/gossip/gossip.proto:101:1:Message "ServerStatus" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/gossip/gossip.proto:101:1:Message "ServerStatus" is not a request or response of any service in this file and should be in a separate file.
pkg/gossip/gossip.proto:113:1:Message "Connectivity" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/gossip/gossip.proto:113:1:Message "Connectivity" is not a request or response of any service in this file and should be in a separate file.
pkg/gossip/gossip.proto:116:3:Message "Conn" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/gossip/gossip.proto:129:1:Message "InfoStatus" is not a request or response of any service in this file and should be in a separate file.
pkg/gossip/gossip.proto:138:1:Message "Info" is not a request or response of any service in this file and should be in a separate file.
pkg/gossip/gossip.proto:154:1:Service "Gossip" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/gossip/gossip.proto:154:1:Service name "Gossip" must end with "API".
pkg/gossip/gossip.proto:155:3:Name of request type "Request" should be "GossipRequest".
pkg/gossip/gossip.proto:155:3:Name of response type "Response" should be "GossipResponse".
pkg/gossip/gossip.proto:155:3:RPC "Gossip" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.jobs.jobspb".
pkg/jobs/jobspb/jobs.proto:13:1:Expected "jobspbpb" for option "go_package" but was "jobspb".
pkg/jobs/jobspb/jobs.proto:23:1:Message "Lease" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:35:1:Message "BackupDetails" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:60:1:Message "BackupProgress" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:64:1:Message "RestoreDetails" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:65:3:Message "TableRewrite" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:75:3:Message "BackupLocalityInfo" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:78:3:"RestoreDetails" cannot have reserved field numbers, use the deprecated field option instead.
pkg/jobs/jobspb/jobs.proto:99:1:Message "RestoreProgress" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:103:1:Message "ImportDetails" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:104:3:Message "Table" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:110:5:"ImportDetails.Table" cannot have reserved field numbers, use the deprecated field option instead.
pkg/jobs/jobspb/jobs.proto:152:1:Message "ImportProgress" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:164:34:Inline comments are not allowed on fields, only comment above the type.
pkg/jobs/jobspb/jobs.proto:167:1:Message "ResumeSpanList" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:171:1:Enum "Status" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:172:3:Enum field "DRAINING_NAMES" is expected to have the prefix "STATUS_".
pkg/jobs/jobspb/jobs.proto:172:3:Zero value enum field "DRAINING_NAMES" is expected to have the name "STATUS_INVALID".
pkg/jobs/jobspb/jobs.proto:173:3:Enum field "WAIT_FOR_GC_INTERVAL" is expected to have the prefix "STATUS_".
pkg/jobs/jobspb/jobs.proto:174:3:Enum field "ROCKSDB_COMPACTION" is expected to have the prefix "STATUS_".
pkg/jobs/jobspb/jobs.proto:175:3:Enum field "DONE" is expected to have the prefix "STATUS_".
pkg/jobs/jobspb/jobs.proto:178:1:Message "DroppedTableDetails" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:180:3:Field name "ID" must be lower_snake_case.
pkg/jobs/jobspb/jobs.proto:199:3:Message "DroppedIndex" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:205:3:Message "DroppedID" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:223:1:Message "SchemaChangeDetails" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:224:3:"SchemaChangeDetails" cannot have reserved field numbers, use the deprecated field option instead.
pkg/jobs/jobspb/jobs.proto:234:3:The name "dropped_database_id" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/jobs/jobspb/jobs.proto:247:1:Message "SchemaChangeProgress" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:251:1:Message "SchemaChangeGCProgress" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:252:3:Enum "Status" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:254:5:Enum field "WAITING_FOR_GC" is expected to have the prefix "STATUS_".
pkg/jobs/jobspb/jobs.proto:254:5:Zero value enum field "WAITING_FOR_GC" is expected to have the name "STATUS_INVALID".
pkg/jobs/jobspb/jobs.proto:256:5:Enum field "DELETING" is expected to have the prefix "STATUS_".
pkg/jobs/jobspb/jobs.proto:259:5:Enum field "DELETED" is expected to have the prefix "STATUS_".
pkg/jobs/jobspb/jobs.proto:262:3:Message "IndexProgress" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:268:3:Message "TableProgress" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:281:1:Message "ChangefeedTarget" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:287:1:Message "ChangefeedDetails" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:314:3:"ChangefeedDetails" cannot have reserved field numbers, use the deprecated field option instead.
pkg/jobs/jobspb/jobs.proto:317:1:Message "ResolvedSpan" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:323:1:Message "ChangefeedProgress" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:324:3:"ChangefeedProgress" cannot have reserved field numbers, use the deprecated field option instead.
pkg/jobs/jobspb/jobs.proto:348:3:Message "ColStat" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:368:1:Message "CreateStatsProgress" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:372:1:Message "Payload" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:382:3:"Payload" cannot have reserved field numbers, use the deprecated field option instead.
pkg/jobs/jobspb/jobs.proto:387:3:"Payload" cannot have reserved field numbers, use the deprecated field option instead.
pkg/jobs/jobspb/jobs.proto:406:5:Field name "schemaChange" must be lower_snake_case.
pkg/jobs/jobspb/jobs.proto:409:5:Field name "createStats" must be lower_snake_case.
pkg/jobs/jobspb/jobs.proto:410:5:Field name "schemaChangeGC" must be lower_snake_case.
pkg/jobs/jobspb/jobs.proto:414:1:Message "Progress" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:425:5:Field name "schemaChange" must be lower_snake_case.
pkg/jobs/jobspb/jobs.proto:428:5:Field name "createStats" must be lower_snake_case.
pkg/jobs/jobspb/jobs.proto:429:5:Field name "schemaChangeGC" must be lower_snake_case.
pkg/jobs/jobspb/jobs.proto:433:1:Enum "Type" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/jobs/jobspb/jobs.proto:437:3:Enum field "UNSPECIFIED" is expected to have the prefix "TYPE_".
pkg/jobs/jobspb/jobs.proto:437:3:Zero value enum field "UNSPECIFIED" is expected to have the name "TYPE_INVALID".
pkg/jobs/jobspb/jobs.proto:438:3:Enum field "BACKUP" is expected to have the prefix "TYPE_".
pkg/jobs/jobspb/jobs.proto:439:3:Enum field "RESTORE" is expected to have the prefix "TYPE_".
pkg/jobs/jobspb/jobs.proto:440:3:Enum field "SCHEMA_CHANGE" is expected to have the prefix "TYPE_".
pkg/jobs/jobspb/jobs.proto:441:3:Enum field "IMPORT" is expected to have the prefix "TYPE_".
pkg/jobs/jobspb/jobs.proto:442:3:Enum field "CHANGEFEED" is expected to have the prefix "TYPE_".
pkg/jobs/jobspb/jobs.proto:443:3:Enum field "CREATE_STATS" is expected to have the prefix "TYPE_".
pkg/jobs/jobspb/jobs.proto:444:3:Enum field "AUTO_CREATE_STATS" is expected to have the prefix "TYPE_".
pkg/jobs/jobspb/jobs.proto:445:3:Enum field "SCHEMA_CHANGE_GC" is expected to have the prefix "TYPE_".
pkg/jobs/jobspb/jobs.proto:448:1:Message "Job" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvnemesis/operations.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.kv.kvnemesis".
pkg/kv/kvnemesis/operations.proto:13:1:Expected "kvnemesispb" for option "go_package" but was "kvnemesis".
pkg/kv/kvnemesis/operations.proto:21:1:Message "BatchOperation" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvnemesis/operations.proto:26:1:Enum "ClosureTxnType" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvnemesis/operations.proto:27:3:Field name "Commit" must be UPPER_SNAKE_CASE.
pkg/kv/kvnemesis/operations.proto:27:3:Enum field "Commit" is expected to have the prefix "CLOSURE_TXN_TYPE_".
pkg/kv/kvnemesis/operations.proto:27:3:Zero value enum field "Commit" is expected to have the name "CLOSURE_TXN_TYPE_INVALID".
pkg/kv/kvnemesis/operations.proto:28:3:Field name "Rollback" must be UPPER_SNAKE_CASE.
pkg/kv/kvnemesis/operations.proto:28:3:Enum field "Rollback" is expected to have the prefix "CLOSURE_TXN_TYPE_".
pkg/kv/kvnemesis/operations.proto:32:1:Message "ClosureTxnOperation" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvnemesis/operations.proto:41:1:Message "GetOperation" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvnemesis/operations.proto:46:1:Message "PutOperation" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvnemesis/operations.proto:52:1:Message "SplitOperation" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvnemesis/operations.proto:57:1:Message "MergeOperation" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvnemesis/operations.proto:62:1:Message "ChangeReplicasOperation" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvnemesis/operations.proto:68:1:Message "Operation" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvnemesis/operations.proto:87:1:Enum "ResultType" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvnemesis/operations.proto:88:3:Field name "Unknown" must be UPPER_SNAKE_CASE.
pkg/kv/kvnemesis/operations.proto:88:3:Enum field "Unknown" is expected to have the prefix "RESULT_TYPE_".
pkg/kv/kvnemesis/operations.proto:88:3:Zero value enum field "Unknown" is expected to have the name "RESULT_TYPE_INVALID".
pkg/kv/kvnemesis/operations.proto:89:3:Field name "NoError" must be UPPER_SNAKE_CASE.
pkg/kv/kvnemesis/operations.proto:89:3:Enum field "NoError" is expected to have the prefix "RESULT_TYPE_".
pkg/kv/kvnemesis/operations.proto:90:3:Field name "Error" must be UPPER_SNAKE_CASE.
pkg/kv/kvnemesis/operations.proto:90:3:Enum field "Error" is expected to have the prefix "RESULT_TYPE_".
pkg/kv/kvnemesis/operations.proto:91:3:Field name "Value" must be UPPER_SNAKE_CASE.
pkg/kv/kvnemesis/operations.proto:91:3:Enum field "Value" is expected to have the prefix "RESULT_TYPE_".
pkg/kv/kvnemesis/operations.proto:94:1:Message "Result" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvnemesis/operations.proto:101:1:Message "Step" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/api.proto:1:1:Multiple packages in directory: cockroach.kv.kvserver, cockroach.storage.
pkg/kv/kvserver/api.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.kv.kvserver".
pkg/kv/kvserver/api.proto:13:1:Expected "kvserverpb" for option "go_package" but was "kvserver".
pkg/kv/kvserver/api.proto:41:1:Message "CollectChecksumResponse" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/api.proto:66:1:Message "WaitForApplicationResponse" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/api.proto:69:1:Message "WaitForReplicaInitRequest" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/api.proto:75:1:Message "WaitForReplicaInitResponse" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/closedts/ctpb/entry.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.kv.kvserver.ctupdate".
pkg/kv/kvserver/closedts/ctpb/entry.proto:13:1:Expected "ctupdatepb" for option "go_package" but was "ctpb".
pkg/kv/kvserver/closedts/ctpb/entry.proto:59:12:Field name "Requested" must be lower_snake_case.
pkg/kv/kvserver/closedts/ctpb/service.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.kv.kvserver.ctupdate".
pkg/kv/kvserver/closedts/ctpb/service.proto:13:1:Expected "ctupdatepb" for option "go_package" but was "ctpb".
pkg/kv/kvserver/closedts/ctpb/service.proto:20:1:Service "ClosedTimestamp" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/closedts/ctpb/service.proto:20:1:Service name "ClosedTimestamp" must end with "API".
pkg/kv/kvserver/closedts/ctpb/service.proto:20:1:Expected filename to be "closed_timestamp.proto" for file containing service "ClosedTimestamp" but was "service.proto".
pkg/kv/kvserver/closedts/ctpb/service.proto:21:5:Name of request type "Reaction" should be "GetRequest".
pkg/kv/kvserver/closedts/ctpb/service.proto:21:5:Name of response type "Entry" should be "GetResponse".
pkg/kv/kvserver/closedts/ctpb/service.proto:21:5:Request type "Reaction" should be defined in the same file as the corresponding service.
pkg/kv/kvserver/closedts/ctpb/service.proto:21:5:Response type "Entry" should be defined in the same file as the corresponding service.
pkg/kv/kvserver/closedts/ctpb/service.proto:21:5:RPC "Get" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/concurrency/lock/locking.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.kv.kvserver.concurrency.lock".
pkg/kv/kvserver/concurrency/lock/locking.proto:13:1:Expected "lockpb" for option "go_package" but was "lock".
pkg/kv/kvserver/concurrency/lock/locking.proto:76:3:Field name "None" must be UPPER_SNAKE_CASE.
pkg/kv/kvserver/concurrency/lock/locking.proto:76:3:Enum field "None" is expected to have the prefix "STRENGTH_".
pkg/kv/kvserver/concurrency/lock/locking.proto:76:3:Zero value enum field "None" is expected to have the name "STRENGTH_INVALID".
pkg/kv/kvserver/concurrency/lock/locking.proto:88:3:Field name "Shared" must be UPPER_SNAKE_CASE.
pkg/kv/kvserver/concurrency/lock/locking.proto:88:3:Enum field "Shared" is expected to have the prefix "STRENGTH_".
pkg/kv/kvserver/concurrency/lock/locking.proto:130:3:Field name "Upgrade" must be UPPER_SNAKE_CASE.
pkg/kv/kvserver/concurrency/lock/locking.proto:130:3:Enum field "Upgrade" is expected to have the prefix "STRENGTH_".
pkg/kv/kvserver/concurrency/lock/locking.proto:137:3:Field name "Exclusive" must be UPPER_SNAKE_CASE.
pkg/kv/kvserver/concurrency/lock/locking.proto:137:3:Enum field "Exclusive" is expected to have the prefix "STRENGTH_".
pkg/kv/kvserver/concurrency/lock/locking.proto:153:3:Field name "Replicated" must be UPPER_SNAKE_CASE.
pkg/kv/kvserver/concurrency/lock/locking.proto:153:3:Enum field "Replicated" is expected to have the prefix "DURABILITY_".
pkg/kv/kvserver/concurrency/lock/locking.proto:153:3:Zero value enum field "Replicated" is expected to have the name "DURABILITY_INVALID".
pkg/kv/kvserver/concurrency/lock/locking.proto:162:3:Field name "Unreplicated" must be UPPER_SNAKE_CASE.
pkg/kv/kvserver/concurrency/lock/locking.proto:162:3:Enum field "Unreplicated" is expected to have the prefix "DURABILITY_".
pkg/kv/kvserver/protectedts/ptpb/protectedts.proto:13:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.protectedts".
pkg/kv/kvserver/protectedts/ptpb/protectedts.proto:14:1:Expected "protectedtspb" for option "go_package" but was "ptpb".
pkg/kv/kvserver/protectedts/ptpb/protectedts.proto:50:3:Enum field "PROTECT_AFTER" is expected to have the prefix "PROTECTION_MODE_".
pkg/kv/kvserver/protectedts/ptpb/protectedts.proto:50:3:Zero value enum field "PROTECT_AFTER" is expected to have the name "PROTECTION_MODE_INVALID".
pkg/kv/kvserver/protectedts/ptpb/protectedts.proto:72:1:The name "Metadata" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/kv/kvserver/protectedts/ptpb/protectedts.proto:128:3:The name "metadata" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/kv/kvserver/protectedts/ptstorage/storage.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.protectedts".
pkg/kv/kvserver/protectedts/ptstorage/storage.proto:13:1:Expected "protectedtspb" for option "go_package" but was "ptstorage".
pkg/kv/kvserver/raft.proto:1:1:Multiple packages in directory: cockroach.kv.kvserver, cockroach.storage.
pkg/kv/kvserver/raft.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/kv/kvserver/raft.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.kv.kvserver".
pkg/kv/kvserver/raft.proto:13:1:Expected "kvserverpb" for option "go_package" but was "kvserver".
pkg/kv/kvserver/raft.proto:83:1:Message "RaftMessageRequestBatch" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/raft.proto:87:1:Message "RaftMessageResponseUnion" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/raft.proto:113:3:Enum "Priority" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/raft.proto:114:5:Enum field "UNKNOWN" is expected to have the prefix "PRIORITY_".
pkg/kv/kvserver/raft.proto:114:5:Zero value enum field "UNKNOWN" is expected to have the name "PRIORITY_INVALID".
pkg/kv/kvserver/raft.proto:118:5:Enum field "RECOVERY" is expected to have the prefix "PRIORITY_".
pkg/kv/kvserver/raft.proto:120:5:Enum field "REBALANCE" is expected to have the prefix "PRIORITY_".
pkg/kv/kvserver/raft.proto:123:3:Enum "Strategy" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/raft.proto:128:5:Enum field "KV_BATCH" is expected to have the prefix "STRATEGY_".
pkg/kv/kvserver/raft.proto:128:5:Zero value enum field "KV_BATCH" is expected to have the name "STRATEGY_INVALID".
pkg/kv/kvserver/raft.proto:131:3:Enum "Type" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/raft.proto:132:5:Enum field "RAFT" is expected to have the prefix "TYPE_".
pkg/kv/kvserver/raft.proto:132:5:Zero value enum field "RAFT" is expected to have the name "TYPE_INVALID".
pkg/kv/kvserver/raft.proto:133:5:Enum field "LEARNER" is expected to have the prefix "TYPE_".
pkg/kv/kvserver/raft.proto:134:5:"SnapshotRequest.Type" cannot have reserved field numbers, use the deprecated field option instead.
pkg/kv/kvserver/raft.proto:137:3:Message "Header" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/raft.proto:138:5:"SnapshotRequest.Header" cannot have reserved field numbers, use the deprecated field option instead.
pkg/kv/kvserver/raft.proto:192:1:Message "SnapshotResponse" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/raft.proto:193:3:Enum "Status" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/raft.proto:194:5:Enum field "UNKNOWN" is expected to have the prefix "STATUS_".
pkg/kv/kvserver/raft.proto:194:5:Zero value enum field "UNKNOWN" is expected to have the name "STATUS_INVALID".
pkg/kv/kvserver/raft.proto:195:5:Enum field "ACCEPTED" is expected to have the prefix "STATUS_".
pkg/kv/kvserver/raft.proto:196:5:Enum field "APPLIED" is expected to have the prefix "STATUS_".
pkg/kv/kvserver/raft.proto:197:5:Enum field "ERROR" is expected to have the prefix "STATUS_".
pkg/kv/kvserver/raft.proto:198:5:Enum field "DECLINED" is expected to have the prefix "STATUS_".
pkg/kv/kvserver/raft.proto:202:3:"SnapshotResponse" cannot have reserved field numbers, use the deprecated field option instead.
pkg/kv/kvserver/storage_services.proto:1:1:Multiple packages in directory: cockroach.kv.kvserver, cockroach.storage.
pkg/kv/kvserver/storage_services.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/kv/kvserver/storage_services.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.storage".
pkg/kv/kvserver/storage_services.proto:12:28:Inline comments are not allowed on packages, only comment above the type.
pkg/kv/kvserver/storage_services.proto:13:1:Expected "storagepb" for option "go_package" but was "kvserver".
pkg/kv/kvserver/storage_services.proto:19:1:Service "MultiRaft" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/storage_services.proto:19:1:Service name "MultiRaft" must end with "API".
pkg/kv/kvserver/storage_services.proto:19:1:Multiple services defined in this file and there should be only one service per file.
pkg/kv/kvserver/storage_services.proto:20:5:Name of request type "cockroach.kv.kvserver.RaftMessageRequestBatch" should be "RaftMessageBatchRequest".
pkg/kv/kvserver/storage_services.proto:20:5:Name of response type "cockroach.kv.kvserver.RaftMessageResponse" should be "RaftMessageBatchResponse".
pkg/kv/kvserver/storage_services.proto:20:5:Request type "cockroach.kv.kvserver.RaftMessageRequestBatch" should be defined in the same file as the corresponding service.
pkg/kv/kvserver/storage_services.proto:20:5:Response type "cockroach.kv.kvserver.RaftMessageResponse" should be defined in the same file as the corresponding service.
pkg/kv/kvserver/storage_services.proto:20:5:RPC "RaftMessageBatch" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/storage_services.proto:21:5:Name of request type "cockroach.kv.kvserver.SnapshotRequest" should be "RaftSnapshotRequest".
pkg/kv/kvserver/storage_services.proto:21:5:Name of response type "cockroach.kv.kvserver.SnapshotResponse" should be "RaftSnapshotResponse".
pkg/kv/kvserver/storage_services.proto:21:5:Request type "cockroach.kv.kvserver.SnapshotRequest" should be defined in the same file as the corresponding service.
pkg/kv/kvserver/storage_services.proto:21:5:Response type "cockroach.kv.kvserver.SnapshotResponse" should be defined in the same file as the corresponding service.
pkg/kv/kvserver/storage_services.proto:21:5:RPC "RaftSnapshot" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/storage_services.proto:24:1:Service "PerReplica" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/storage_services.proto:24:1:Service name "PerReplica" must end with "API".
pkg/kv/kvserver/storage_services.proto:24:1:Multiple services defined in this file and there should be only one service per file.
pkg/kv/kvserver/storage_services.proto:25:5:Name of request type "cockroach.kv.kvserver.CollectChecksumRequest" should be "CollectChecksumRequest".
pkg/kv/kvserver/storage_services.proto:25:5:Name of response type "cockroach.kv.kvserver.CollectChecksumResponse" should be "CollectChecksumResponse".
pkg/kv/kvserver/storage_services.proto:25:5:Request type "cockroach.kv.kvserver.CollectChecksumRequest" should be defined in the same file as the corresponding service.
pkg/kv/kvserver/storage_services.proto:25:5:Response type "cockroach.kv.kvserver.CollectChecksumResponse" should be defined in the same file as the corresponding service.
pkg/kv/kvserver/storage_services.proto:25:5:RPC "CollectChecksum" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/storage_services.proto:26:5:Name of request type "cockroach.kv.kvserver.WaitForApplicationRequest" should be "WaitForApplicationRequest".
pkg/kv/kvserver/storage_services.proto:26:5:Name of response type "cockroach.kv.kvserver.WaitForApplicationResponse" should be "WaitForApplicationResponse".
pkg/kv/kvserver/storage_services.proto:26:5:Request type "cockroach.kv.kvserver.WaitForApplicationRequest" should be defined in the same file as the corresponding service.
pkg/kv/kvserver/storage_services.proto:26:5:Response type "cockroach.kv.kvserver.WaitForApplicationResponse" should be defined in the same file as the corresponding service.
pkg/kv/kvserver/storage_services.proto:26:5:RPC "WaitForApplication" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/storage_services.proto:27:5:Name of request type "cockroach.kv.kvserver.WaitForReplicaInitRequest" should be "WaitForReplicaInitRequest".
pkg/kv/kvserver/storage_services.proto:27:5:Name of response type "cockroach.kv.kvserver.WaitForReplicaInitResponse" should be "WaitForReplicaInitResponse".
pkg/kv/kvserver/storage_services.proto:27:5:Request type "cockroach.kv.kvserver.WaitForReplicaInitRequest" should be defined in the same file as the corresponding service.
pkg/kv/kvserver/storage_services.proto:27:5:Response type "cockroach.kv.kvserver.WaitForReplicaInitResponse" should be defined in the same file as the corresponding service.
pkg/kv/kvserver/storage_services.proto:27:5:RPC "WaitForReplicaInit" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/storagepb/lease_status.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.kv.kvserver.storagepb".
pkg/kv/kvserver/storagepb/lease_status.proto:13:1:Expected "storagepbpb" for option "go_package" but was "storagepb".
pkg/kv/kvserver/storagepb/lease_status.proto:21:1:Enum "LeaseState" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/storagepb/lease_status.proto:23:3:Enum field "ERROR" is expected to have the prefix "LEASE_STATE_".
pkg/kv/kvserver/storagepb/lease_status.proto:23:3:Zero value enum field "ERROR" is expected to have the name "LEASE_STATE_INVALID".
pkg/kv/kvserver/storagepb/lease_status.proto:25:3:Enum field "VALID" is expected to have the prefix "LEASE_STATE_".
pkg/kv/kvserver/storagepb/lease_status.proto:46:3:Enum field "STASIS" is expected to have the prefix "LEASE_STATE_".
pkg/kv/kvserver/storagepb/lease_status.proto:52:3:Enum field "EXPIRED" is expected to have the prefix "LEASE_STATE_".
pkg/kv/kvserver/storagepb/lease_status.proto:59:3:Enum field "PROSCRIBED" is expected to have the prefix "LEASE_STATE_".
pkg/kv/kvserver/storagepb/liveness.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.kv.kvserver.storagepb".
pkg/kv/kvserver/storagepb/liveness.proto:13:1:Expected "storagepbpb" for option "go_package" but was "storagepb".
pkg/kv/kvserver/storagepb/liveness.proto:51:3:Enum field "UNKNOWN" is expected to have the prefix "NODE_LIVENESS_STATUS_".
pkg/kv/kvserver/storagepb/liveness.proto:51:3:Zero value enum field "UNKNOWN" is expected to have the name "NODE_LIVENESS_STATUS_INVALID".
pkg/kv/kvserver/storagepb/liveness.proto:53:3:Enum field "DEAD" is expected to have the prefix "NODE_LIVENESS_STATUS_".
pkg/kv/kvserver/storagepb/liveness.proto:57:3:Enum field "UNAVAILABLE" is expected to have the prefix "NODE_LIVENESS_STATUS_".
pkg/kv/kvserver/storagepb/liveness.proto:59:3:Enum field "LIVE" is expected to have the prefix "NODE_LIVENESS_STATUS_".
pkg/kv/kvserver/storagepb/liveness.proto:61:3:Enum field "DECOMMISSIONING" is expected to have the prefix "NODE_LIVENESS_STATUS_".
pkg/kv/kvserver/storagepb/liveness.proto:64:3:Enum field "DECOMMISSIONED" is expected to have the prefix "NODE_LIVENESS_STATUS_".
pkg/kv/kvserver/storagepb/log.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.kv.kvserver.storagepb".
pkg/kv/kvserver/storagepb/log.proto:13:1:Expected "storagepbpb" for option "go_package" but was "storagepb".
pkg/kv/kvserver/storagepb/log.proto:19:1:Enum "RangeLogEventType" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/storagepb/log.proto:23:3:Field name "split" must be UPPER_SNAKE_CASE.
pkg/kv/kvserver/storagepb/log.proto:23:3:Enum field "split" is expected to have the prefix "RANGE_LOG_EVENT_TYPE_".
pkg/kv/kvserver/storagepb/log.proto:23:3:Zero value enum field "split" is expected to have the name "RANGE_LOG_EVENT_TYPE_INVALID".
pkg/kv/kvserver/storagepb/log.proto:25:3:Field name "merge" must be UPPER_SNAKE_CASE.
pkg/kv/kvserver/storagepb/log.proto:25:3:Enum field "merge" is expected to have the prefix "RANGE_LOG_EVENT_TYPE_".
pkg/kv/kvserver/storagepb/log.proto:27:3:Field name "add" must be UPPER_SNAKE_CASE.
pkg/kv/kvserver/storagepb/log.proto:27:3:Enum field "add" is expected to have the prefix "RANGE_LOG_EVENT_TYPE_".
pkg/kv/kvserver/storagepb/log.proto:29:3:Field name "remove" must be UPPER_SNAKE_CASE.
pkg/kv/kvserver/storagepb/log.proto:29:3:Enum field "remove" is expected to have the prefix "RANGE_LOG_EVENT_TYPE_".
pkg/kv/kvserver/storagepb/log.proto:32:1:Message "RangeLogEvent" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/storagepb/log.proto:33:3:Message "Info" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/kv/kvserver/storagepb/log.proto:46:3:Field "timestamp" of type "google.protobuf.Timestamp" must be "time" or end in "_time".
pkg/kv/kvserver/storagepb/proposer_kv.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.kv.kvserver.storagepb".
pkg/kv/kvserver/storagepb/proposer_kv.proto:13:1:Expected "storagepbpb" for option "go_package" but was "storagepb".
pkg/kv/kvserver/storagepb/proposer_kv.proto:137:53:Inline comments are not allowed on fields, only comment above the type.
pkg/kv/kvserver/storagepb/proposer_kv.proto:155:5:The name "data" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/kv/kvserver/storagepb/proposer_kv.proto:170:3:"ReplicatedEvalResult" cannot have reserved field numbers, use the deprecated field option instead.
pkg/kv/kvserver/storagepb/proposer_kv.proto:178:3:The name "data" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/kv/kvserver/storagepb/proposer_kv.proto:254:3:"RaftCommand" cannot have reserved field numbers, use the deprecated field option instead.
pkg/kv/kvserver/storagepb/proposer_kv.proto:274:3:The name "trace_data" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/kv/kvserver/storagepb/proposer_kv.proto:276:3:"RaftCommand" cannot have reserved field numbers, use the deprecated field option instead.
pkg/kv/kvserver/storagepb/state.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.kv.kvserver.storagepb".
pkg/kv/kvserver/storagepb/state.proto:13:1:Expected "storagepbpb" for option "go_package" but was "storagepb".
pkg/kv/kvserver/storagepb/state.proto:72:3:"ReplicaState" cannot have reserved field numbers, use the deprecated field option instead.
pkg/kv/kvserver/storagepb/state.proto:84:3:"RangeInfo" cannot have reserved field numbers, use the deprecated field option instead.
pkg/kv/kvserver/storagepb/state.proto:84:15:Inline comments are not allowed on reserved, only comment above the type.
pkg/kv/kvserver/storagepb/state.proto:99:3:"RangeInfo" cannot have reserved field numbers, use the deprecated field option instead.
pkg/kv/kvserver/storagepb/state.proto:100:3:Message "CTEntry" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:1:1:Multiple packages in directory: cockroach.roachpb, cockroach.sql.
pkg/roachpb/api.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.roachpb".
pkg/roachpb/api.proto:13:1:Expected "roachpbpb" for option "go_package" but was "roachpb".
pkg/roachpb/api.proto:27:1:Enum "ReadConsistencyType" is in the same file as a service and should be in a separate file.
pkg/roachpb/api.proto:32:3:Enum field "CONSISTENT" is expected to have the prefix "READ_CONSISTENCY_TYPE_".
pkg/roachpb/api.proto:32:3:Zero value enum field "CONSISTENT" is expected to have the name "READ_CONSISTENCY_TYPE_INVALID".
pkg/roachpb/api.proto:38:3:Enum field "READ_UNCOMMITTED" is expected to have the prefix "READ_CONSISTENCY_TYPE_".
pkg/roachpb/api.proto:42:3:Enum field "INCONSISTENT" is expected to have the prefix "READ_CONSISTENCY_TYPE_".
pkg/roachpb/api.proto:47:1:Message "RangeInfo" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:53:1:Message "RequestHeader" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:56:3:"RequestHeader" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:71:1:Message "ResponseHeader" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:72:3:Enum "ResumeReason" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:75:5:Enum field "RESUME_UNKNOWN" is expected to have the prefix "RESUME_REASON_".
pkg/roachpb/api.proto:75:5:Zero value enum field "RESUME_UNKNOWN" is expected to have the name "RESUME_REASON_INVALID".
pkg/roachpb/api.proto:78:5:Enum field "RESUME_KEY_LIMIT" is expected to have the prefix "RESUME_REASON_".
pkg/roachpb/api.proto:119:1:Message "GetRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:127:1:Message "GetResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:136:1:Message "PutRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:152:1:Message "PutResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:162:1:Message "ConditionalPutRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:185:1:Message "ConditionalPutResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:195:1:Message "InitPutRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:205:3:Field name "failOnTombstones" must be lower_snake_case.
pkg/roachpb/api.proto:209:1:Message "InitPutResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:219:1:Message "IncrementRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:229:1:Message "IncrementResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:235:1:Message "DeleteRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:242:1:Message "DeleteResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:251:1:Message "DeleteRangeRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:255:3:"DeleteRangeRequest" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:274:1:Message "DeleteRangeResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:294:1:Message "ClearRangeRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:301:1:Message "ClearRangeResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:309:1:Message "RevertRangeRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:322:1:Message "RevertRangeResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:328:1:Enum "ScanFormat" is in the same file as a service and should be in a separate file.
pkg/roachpb/api.proto:332:3:Enum field "KEY_VALUES" is expected to have the prefix "SCAN_FORMAT_".
pkg/roachpb/api.proto:332:3:Zero value enum field "KEY_VALUES" is expected to have the name "SCAN_FORMAT_INVALID".
pkg/roachpb/api.proto:335:3:Enum field "BATCH_RESPONSE" is expected to have the prefix "SCAN_FORMAT_".
pkg/roachpb/api.proto:342:1:Message "ScanRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:345:3:"ScanRequest" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:368:1:Message "ScanResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:389:1:Message "ReverseScanRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:392:3:"ReverseScanRequest" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:415:1:Message "ReverseScanResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:434:1:Enum "ChecksumMode" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:434:1:Enum "ChecksumMode" is in the same file as a service and should be in a separate file.
pkg/roachpb/api.proto:448:5:Enum field "CHECK_VIA_QUEUE" is expected to have the prefix "CHECKSUM_MODE_".
pkg/roachpb/api.proto:448:5:Zero value enum field "CHECK_VIA_QUEUE" is expected to have the name "CHECKSUM_MODE_INVALID".
pkg/roachpb/api.proto:451:5:Enum field "CHECK_FULL" is expected to have the prefix "CHECKSUM_MODE_".
pkg/roachpb/api.proto:458:5:Enum field "CHECK_STATS" is expected to have the prefix "CHECKSUM_MODE_".
pkg/roachpb/api.proto:465:1:Message "CheckConsistencyRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:489:1:Message "CheckConsistencyResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:492:3:Enum "Status" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:494:5:Enum field "RANGE_INDETERMINATE" is expected to have the prefix "STATUS_".
pkg/roachpb/api.proto:494:5:Zero value enum field "RANGE_INDETERMINATE" is expected to have the name "STATUS_INVALID".
pkg/roachpb/api.proto:496:5:Enum field "RANGE_INCONSISTENT" is expected to have the prefix "STATUS_".
pkg/roachpb/api.proto:498:5:Enum field "RANGE_CONSISTENT" is expected to have the prefix "STATUS_".
pkg/roachpb/api.proto:502:5:Enum field "RANGE_CONSISTENT_STATS_ESTIMATED" is expected to have the prefix "STATUS_".
pkg/roachpb/api.proto:507:5:Enum field "RANGE_CONSISTENT_STATS_INCORRECT" is expected to have the prefix "STATUS_".
pkg/roachpb/api.proto:510:3:Message "Result" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:540:1:Message "RecomputeStatsRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:551:1:Message "RecomputeStatsResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:560:1:Message "EndTxnRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:626:3:"EndTxnRequest" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:635:1:Message "EndTxnResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:637:3:"EndTxnResponse" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:638:3:"EndTxnResponse" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:674:1:Message "AdminSplitRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:679:3:"AdminSplitRequest" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:685:1:Message "AdminSplitResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:695:1:Message "AdminUnsplitRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:703:1:Message "AdminUnsplitResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:717:1:Message "AdminMergeRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:725:1:Message "AdminMergeResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:733:1:Message "AdminTransferLeaseRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:740:1:Message "AdminTransferLeaseResponse" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:740:1:Message "AdminTransferLeaseResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:745:1:Message "ReplicationChange" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:755:1:Message "AdminChangeReplicasRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:784:1:Message "AdminChangeReplicasResponse" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:784:1:Message "AdminChangeReplicasResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:793:1:Message "AdminRelocateRangeRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:801:1:Message "AdminRelocateRangeResponse" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:801:1:Message "AdminRelocateRangeResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:810:1:Message "HeartbeatTxnRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:821:1:Message "HeartbeatTxnResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:827:1:Message "GCRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:832:3:Message "GCKey" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:842:3:"GCRequest" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:846:1:Message "GCResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:851:1:Enum "PushTxnType" is in the same file as a service and should be in a separate file.
pkg/roachpb/api.proto:855:3:Enum field "PUSH_TIMESTAMP" is expected to have the prefix "PUSH_TXN_TYPE_".
pkg/roachpb/api.proto:855:3:Zero value enum field "PUSH_TIMESTAMP" is expected to have the name "PUSH_TXN_TYPE_INVALID".
pkg/roachpb/api.proto:857:3:Enum field "PUSH_ABORT" is expected to have the prefix "PUSH_TXN_TYPE_".
pkg/roachpb/api.proto:860:3:Enum field "PUSH_TOUCH" is expected to have the prefix "PUSH_TXN_TYPE_".
pkg/roachpb/api.proto:862:3:"PushTxnType" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:878:1:Message "PushTxnRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:906:3:"PushTxnRequest" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:914:1:Message "PushTxnResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:929:1:Message "RecoverTxnRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:944:1:Message "RecoverTxnResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:955:1:Message "QueryTxnRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:969:1:Message "QueryTxnResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:982:1:Message "QueryIntentRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1014:1:Message "QueryIntentResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1024:1:Message "ResolveIntentRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1044:1:Message "ResolveIntentResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1052:1:Message "ResolveIntentRangeRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1076:1:Message "ResolveIntentRangeResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1083:1:Message "MergeRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1091:1:Message "MergeResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1100:1:Message "TruncateLogRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1116:1:Message "TruncateLogResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1123:1:Message "RequestLeaseRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1149:1:Message "TransferLeaseRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1163:1:Message "LeaseInfoRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1169:1:Message "LeaseInfoResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1178:1:Message "RequestLeaseResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1186:1:Message "ComputeChecksumRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1193:3:"ComputeChecksumRequest" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:1212:1:Message "ComputeChecksumResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1222:1:Enum "ExternalStorageProvider" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:1222:1:Enum "ExternalStorageProvider" is in the same file as a service and should be in a separate file.
pkg/roachpb/api.proto:1223:3:Field name "Unknown" must be UPPER_SNAKE_CASE.
pkg/roachpb/api.proto:1223:3:Enum field "Unknown" is expected to have the prefix "EXTERNAL_STORAGE_PROVIDER_".
pkg/roachpb/api.proto:1223:3:Zero value enum field "Unknown" is expected to have the name "EXTERNAL_STORAGE_PROVIDER_INVALID".
pkg/roachpb/api.proto:1224:3:Field name "LocalFile" must be UPPER_SNAKE_CASE.
pkg/roachpb/api.proto:1224:3:Enum field "LocalFile" is expected to have the prefix "EXTERNAL_STORAGE_PROVIDER_".
pkg/roachpb/api.proto:1225:3:Field name "Http" must be UPPER_SNAKE_CASE.
pkg/roachpb/api.proto:1225:3:Enum field "Http" is expected to have the prefix "EXTERNAL_STORAGE_PROVIDER_".
pkg/roachpb/api.proto:1226:3:Enum field "S3" is expected to have the prefix "EXTERNAL_STORAGE_PROVIDER_".
pkg/roachpb/api.proto:1227:3:Field name "GoogleCloud" must be UPPER_SNAKE_CASE.
pkg/roachpb/api.proto:1227:3:Enum field "GoogleCloud" is expected to have the prefix "EXTERNAL_STORAGE_PROVIDER_".
pkg/roachpb/api.proto:1228:3:Field name "Azure" must be UPPER_SNAKE_CASE.
pkg/roachpb/api.proto:1228:3:Enum field "Azure" is expected to have the prefix "EXTERNAL_STORAGE_PROVIDER_".
pkg/roachpb/api.proto:1229:3:Field name "Workload" must be UPPER_SNAKE_CASE.
pkg/roachpb/api.proto:1229:3:Enum field "Workload" is expected to have the prefix "EXTERNAL_STORAGE_PROVIDER_".
pkg/roachpb/api.proto:1232:1:Message "ExternalStorage" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:1232:1:Message "ExternalStorage" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1237:3:Message "LocalFilePath" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:1243:3:Message "Http" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:1246:5:Field name "baseUri" must be lower_snake_case.
pkg/roachpb/api.proto:1248:3:Message "S3" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:1261:3:Message "GCS" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:1274:3:Message "Azure" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:1283:3:Message "Workload" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:1294:3:Field name "LocalFile" must be lower_snake_case.
pkg/roachpb/api.proto:1295:3:Field name "HttpPath" must be lower_snake_case.
pkg/roachpb/api.proto:1296:3:Field name "GoogleCloudConfig" must be lower_snake_case.
pkg/roachpb/api.proto:1297:3:Field name "S3Config" must be lower_snake_case.
pkg/roachpb/api.proto:1298:3:Field name "AzureConfig" must be lower_snake_case.
pkg/roachpb/api.proto:1299:3:Field name "WorkloadConfig" must be lower_snake_case.
pkg/roachpb/api.proto:1304:1:Message "WriteBatchRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1310:3:The name "data_span" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/roachpb/api.proto:1312:3:The name "data" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/roachpb/api.proto:1316:1:Message "WriteBatchResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1320:1:Enum "MVCCFilter" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:1320:1:Enum "MVCCFilter" is in the same file as a service and should be in a separate file.
pkg/roachpb/api.proto:1321:3:Field name "Latest" must be UPPER_SNAKE_CASE.
pkg/roachpb/api.proto:1321:3:Enum field "Latest" is expected to have the prefix "MVCC_FILTER_".
pkg/roachpb/api.proto:1321:3:Zero value enum field "Latest" is expected to have the name "MVCC_FILTER_INVALID".
pkg/roachpb/api.proto:1322:3:Field name "All" must be UPPER_SNAKE_CASE.
pkg/roachpb/api.proto:1322:3:Enum field "All" is expected to have the prefix "MVCC_FILTER_".
pkg/roachpb/api.proto:1325:1:Message "FileEncryptionOptions" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:1325:1:Message "FileEncryptionOptions" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1333:1:Message "ExportRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1381:1:Message "BulkOpSummary" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1383:3:The name "data_size" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/roachpb/api.proto:1396:3:"BulkOpSummary" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:1404:1:Message "ExportResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1410:5:"ExportResponse.File" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:1411:5:"ExportResponse.File" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:1427:1:Message "ImportRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1430:3:Message "File" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:1435:5:"ImportRequest.File" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:1443:3:The name "data_span" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/roachpb/api.proto:1447:3:"ImportRequest" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:1448:3:Message "TableRekey" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:1468:1:Message "ImportResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1470:3:"ImportResponse" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:1478:1:Message "AdminScatterRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1486:1:Message "AdminScatterResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1489:3:Message "Range" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:1491:5:"AdminScatterResponse.Range" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:1499:1:Message "AdminVerifyProtectedTimestampRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1525:1:Message "AdminVerifyProtectedTimestampResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1535:1:Message "AddSSTableRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1539:3:The name "data" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/roachpb/api.proto:1561:1:Message "AddSSTableResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1573:1:Message "RefreshRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1577:3:"RefreshRequest" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:1585:1:Message "RefreshResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1592:1:Message "RefreshRangeRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1596:3:"RefreshRangeRequest" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:1604:1:Message "RefreshRangeResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1618:1:Message "SubsumeRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1632:1:Message "SubsumeResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1635:3:"SubsumeResponse" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:1661:1:Message "RangeStatsRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1668:1:Message "RangeStatsResponse" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1687:1:Message "RequestUnion" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1734:3:"RequestUnion" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:1739:1:Message "ResponseUnion" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1785:3:"ResponseUnion" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:1790:1:Message "Header" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:1931:3:"Header" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:1938:1:Message "BatchRequest" is a request for RPC "Batch" and should be defined in the file after the RPC.
pkg/roachpb/api.proto:1949:1:Message "BatchResponse" is a response for RPC "Batch" and should be defined in the file after the RPC.
pkg/roachpb/api.proto:1952:3:Message "Header" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:1953:5:"BatchResponse.Header" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/api.proto:1969:5:Field name "Timestamp" must be lower_snake_case.
pkg/roachpb/api.proto:1988:1:Message "RangeFeedRequest" is a request for RPC "RangeFeed" and should be defined in the file after the RPC.
pkg/roachpb/api.proto:1998:1:Message "RangeFeedValue" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:2015:1:Message "RangeFeedCheckpoint" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:2025:1:Message "RangeFeedError" is not a request or response of any service in this file and should be in a separate file.
pkg/roachpb/api.proto:2031:1:Message "RangeFeedEvent" is a response for RPC "RangeFeed" and should be defined in the file after the RPC.
pkg/roachpb/api.proto:2040:1:Service name "Internal" must end with "API".
pkg/roachpb/api.proto:2040:1:Expected filename to be "internal.proto" for file containing service "Internal" but was "api.proto".
pkg/roachpb/api.proto:2041:3:RPC "Batch" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/api.proto:2042:3:Name of response type "RangeFeedEvent" should be "RangeFeedResponse".
pkg/roachpb/api.proto:2042:3:RPC "RangeFeed" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/app_stats.proto:1:1:Multiple packages in directory: cockroach.roachpb, cockroach.sql.
pkg/roachpb/app_stats.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/roachpb/app_stats.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql".
pkg/roachpb/app_stats.proto:13:1:Expected "sqlpb" for option "go_package" but was "roachpb".
pkg/roachpb/app_stats.proto:88:1:Message "SensitiveInfo" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/app_stats.proto:98:12:Field "most_recent_plan_timestamp" of type "google.protobuf.Timestamp" must be "time" or end in "_time".
pkg/roachpb/app_stats.proto:114:1:Message "StatementStatisticsKey" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/app_stats.proto:117:12:Field name "distSQL" must be lower_snake_case.
pkg/roachpb/app_stats.proto:135:3:Message "Attr" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/data.proto:1:1:Multiple packages in directory: cockroach.roachpb, cockroach.sql.
pkg/roachpb/data.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.roachpb".
pkg/roachpb/data.proto:13:1:Expected "roachpbpb" for option "go_package" but was "roachpb".
pkg/roachpb/data.proto:29:3:"Span" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/data.proto:47:3:Enum field "UNKNOWN" is expected to have the prefix "VALUE_TYPE_".
pkg/roachpb/data.proto:47:3:Zero value enum field "UNKNOWN" is expected to have the name "VALUE_TYPE_INVALID".
pkg/roachpb/data.proto:48:3:"ValueType" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/data.proto:49:3:Enum field "INT" is expected to have the prefix "VALUE_TYPE_".
pkg/roachpb/data.proto:50:3:Enum field "FLOAT" is expected to have the prefix "VALUE_TYPE_".
pkg/roachpb/data.proto:51:3:Enum field "BYTES" is expected to have the prefix "VALUE_TYPE_".
pkg/roachpb/data.proto:52:3:Enum field "DELIMITED_BYTES" is expected to have the prefix "VALUE_TYPE_".
pkg/roachpb/data.proto:53:3:Enum field "TIME" is expected to have the prefix "VALUE_TYPE_".
pkg/roachpb/data.proto:54:3:Enum field "DECIMAL" is expected to have the prefix "VALUE_TYPE_".
pkg/roachpb/data.proto:55:3:Enum field "DELIMITED_DECIMAL" is expected to have the prefix "VALUE_TYPE_".
pkg/roachpb/data.proto:56:3:Enum field "DURATION" is expected to have the prefix "VALUE_TYPE_".
pkg/roachpb/data.proto:57:3:Enum field "TIMETZ" is expected to have the prefix "VALUE_TYPE_".
pkg/roachpb/data.proto:61:3:Enum field "TUPLE" is expected to have the prefix "VALUE_TYPE_".
pkg/roachpb/data.proto:63:3:Enum field "BITARRAY" is expected to have the prefix "VALUE_TYPE_".
pkg/roachpb/data.proto:66:3:Enum field "TIMESERIES" is expected to have the prefix "VALUE_TYPE_".
pkg/roachpb/data.proto:123:3:"SplitTrigger" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/data.proto:139:3:"MergeTrigger" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/data.proto:158:3:Enum field "ADD_REPLICA" is expected to have the prefix "REPLICA_CHANGE_TYPE_".
pkg/roachpb/data.proto:158:3:Zero value enum field "ADD_REPLICA" is expected to have the name "REPLICA_CHANGE_TYPE_INVALID".
pkg/roachpb/data.proto:159:3:Enum field "REMOVE_REPLICA" is expected to have the prefix "REPLICA_CHANGE_TYPE_".
pkg/roachpb/data.proto:266:3:Enum field "PENDING" is expected to have the prefix "TRANSACTION_STATUS_".
pkg/roachpb/data.proto:266:3:Zero value enum field "PENDING" is expected to have the name "TRANSACTION_STATUS_INVALID".
pkg/roachpb/data.proto:276:3:Enum field "STAGING" is expected to have the prefix "TRANSACTION_STATUS_".
pkg/roachpb/data.proto:282:3:Enum field "COMMITTED" is expected to have the prefix "TRANSACTION_STATUS_".
pkg/roachpb/data.proto:287:3:Enum field "ABORTED" is expected to have the prefix "TRANSACTION_STATUS_".
pkg/roachpb/data.proto:290:1:Message "ObservedTimestamp" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/data.proto:512:3:"Transaction" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/data.proto:541:3:"TransactionRecord" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/data.proto:559:5:"Intent.SingleKeySpan" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/data.proto:665:3:"LeafTxnInputState" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/data.proto:698:3:"LeafTxnFinalState" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/data.proto:707:3:"LeafTxnFinalState" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/data.proto:708:3:"LeafTxnFinalState" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/data.proto:714:3:"LeafTxnFinalState" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/errors.proto:1:1:Multiple packages in directory: cockroach.roachpb, cockroach.sql.
pkg/roachpb/errors.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/roachpb/errors.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.roachpb".
pkg/roachpb/errors.proto:13:1:Expected "roachpbpb" for option "go_package" but was "roachpb".
pkg/roachpb/errors.proto:119:3:Enum field "ABORT_REASON_UNKNOWN" is expected to have the prefix "TRANSACTION_ABORTED_REASON_".
pkg/roachpb/errors.proto:119:3:Zero value enum field "ABORT_REASON_UNKNOWN" is expected to have the name "TRANSACTION_ABORTED_REASON_INVALID".
pkg/roachpb/errors.proto:127:3:Enum field "ABORT_REASON_ABORTED_RECORD_FOUND" is expected to have the prefix "TRANSACTION_ABORTED_REASON_".
pkg/roachpb/errors.proto:133:3:Enum field "ABORT_REASON_CLIENT_REJECT" is expected to have the prefix "TRANSACTION_ABORTED_REASON_".
pkg/roachpb/errors.proto:137:3:Enum field "ABORT_REASON_PUSHER_ABORTED" is expected to have the prefix "TRANSACTION_ABORTED_REASON_".
pkg/roachpb/errors.proto:142:3:Enum field "ABORT_REASON_ABORT_SPAN" is expected to have the prefix "TRANSACTION_ABORTED_REASON_".
pkg/roachpb/errors.proto:151:3:Enum field "ABORT_REASON_ALREADY_COMMITTED_OR_ROLLED_BACK_POSSIBLE_REPLAY" is expected to have the prefix "TRANSACTION_ABORTED_REASON_".
pkg/roachpb/errors.proto:163:3:Enum field "ABORT_REASON_NEW_LEASE_PREVENTS_TXN" is expected to have the prefix "TRANSACTION_ABORTED_REASON_".
pkg/roachpb/errors.proto:174:3:Enum field "ABORT_REASON_TIMESTAMP_CACHE_REJECTED" is expected to have the prefix "TRANSACTION_ABORTED_REASON_".
pkg/roachpb/errors.proto:176:3:"TransactionAbortedReason" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/errors.proto:209:3:Enum field "RETRY_REASON_UNKNOWN" is expected to have the prefix "TRANSACTION_RETRY_REASON_".
pkg/roachpb/errors.proto:209:3:Zero value enum field "RETRY_REASON_UNKNOWN" is expected to have the name "TRANSACTION_RETRY_REASON_INVALID".
pkg/roachpb/errors.proto:211:3:Enum field "RETRY_WRITE_TOO_OLD" is expected to have the prefix "TRANSACTION_RETRY_REASON_".
pkg/roachpb/errors.proto:213:3:Enum field "RETRY_SERIALIZABLE" is expected to have the prefix "TRANSACTION_RETRY_REASON_".
pkg/roachpb/errors.proto:215:3:Enum field "RETRY_ASYNC_WRITE_FAILURE" is expected to have the prefix "TRANSACTION_RETRY_REASON_".
pkg/roachpb/errors.proto:217:3:Enum field "RETRY_COMMIT_DEADLINE_EXCEEDED" is expected to have the prefix "TRANSACTION_RETRY_REASON_".
pkg/roachpb/errors.proto:243:5:Zero value enum field "REASON_UNKNOWN" is expected to have the name "REASON_INVALID".
pkg/roachpb/errors.proto:247:5:"TransactionStatusError.Reason" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/errors.proto:261:3:"WriteIntentError" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/errors.proto:309:3:"SendError" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/errors.proto:343:1:Message "ReplicaTooOldError" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/errors.proto:374:12:Field name "pErr" must be lower_snake_case.
pkg/roachpb/errors.proto:433:12:Field name "Timestamp" must be lower_snake_case.
pkg/roachpb/errors.proto:434:12:Field name "Threshold" must be lower_snake_case.
pkg/roachpb/errors.proto:466:5:Zero value enum field "REASON_REPLICA_REMOVED" is expected to have the name "REASON_INVALID".
pkg/roachpb/errors.proto:498:3:"ErrorDetail" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/errors.proto:545:3:Enum field "NONE" is expected to have the prefix "TRANSACTION_RESTART_".
pkg/roachpb/errors.proto:545:3:Zero value enum field "NONE" is expected to have the name "TRANSACTION_RESTART_INVALID".
pkg/roachpb/errors.proto:550:3:Enum field "BACKOFF" is expected to have the prefix "TRANSACTION_RESTART_".
pkg/roachpb/errors.proto:554:3:Enum field "IMMEDIATE" is expected to have the prefix "TRANSACTION_RESTART_".
pkg/roachpb/errors.proto:600:3:"Error" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/internal.proto:1:1:Multiple packages in directory: cockroach.roachpb, cockroach.sql.
pkg/roachpb/internal.proto:12:1:Syntax should be proto3 but was "proto2".
pkg/roachpb/internal.proto:13:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.roachpb".
pkg/roachpb/internal.proto:14:1:Expected "roachpbpb" for option "go_package" but was "roachpb".
pkg/roachpb/internal.proto:54:1:The name "InternalTimeSeriesData" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/roachpb/internal_raft.proto:1:1:Multiple packages in directory: cockroach.roachpb, cockroach.sql.
pkg/roachpb/internal_raft.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/roachpb/internal_raft.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.roachpb".
pkg/roachpb/internal_raft.proto:13:1:Expected "roachpbpb" for option "go_package" but was "roachpb".
pkg/roachpb/internal_raft.proto:39:1:The name "RaftSnapshotData" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/roachpb/internal_raft.proto:40:3:Message "KeyValue" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/internal_raft.proto:45:12:Field name "KV" must be lower_snake_case.
pkg/roachpb/internal_raft.proto:50:3:"RaftSnapshotData" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/io-formats.proto:1:1:File name should be lower_snake_case.proto.
pkg/roachpb/io-formats.proto:1:1:Multiple packages in directory: cockroach.roachpb, cockroach.sql.
pkg/roachpb/io-formats.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/roachpb/io-formats.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.roachpb".
pkg/roachpb/io-formats.proto:13:1:Expected "roachpbpb" for option "go_package" but was "roachpb".
pkg/roachpb/io-formats.proto:18:1:Message "IOFileFormat" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/io-formats.proto:19:3:Enum "FileFormat" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/io-formats.proto:20:5:Field name "Unknown" must be UPPER_SNAKE_CASE.
pkg/roachpb/io-formats.proto:20:5:Enum field "Unknown" is expected to have the prefix "FILE_FORMAT_".
pkg/roachpb/io-formats.proto:20:5:Zero value enum field "Unknown" is expected to have the name "FILE_FORMAT_INVALID".
pkg/roachpb/io-formats.proto:21:5:Enum field "CSV" is expected to have the prefix "FILE_FORMAT_".
pkg/roachpb/io-formats.proto:22:5:Field name "MysqlOutfile" must be UPPER_SNAKE_CASE.
pkg/roachpb/io-formats.proto:22:5:Enum field "MysqlOutfile" is expected to have the prefix "FILE_FORMAT_".
pkg/roachpb/io-formats.proto:23:5:Field name "Mysqldump" must be UPPER_SNAKE_CASE.
pkg/roachpb/io-formats.proto:23:5:Enum field "Mysqldump" is expected to have the prefix "FILE_FORMAT_".
pkg/roachpb/io-formats.proto:24:5:Field name "PgCopy" must be UPPER_SNAKE_CASE.
pkg/roachpb/io-formats.proto:24:5:Enum field "PgCopy" is expected to have the prefix "FILE_FORMAT_".
pkg/roachpb/io-formats.proto:25:5:Field name "PgDump" must be UPPER_SNAKE_CASE.
pkg/roachpb/io-formats.proto:25:5:Enum field "PgDump" is expected to have the prefix "FILE_FORMAT_".
pkg/roachpb/io-formats.proto:26:5:Field name "Avro" must be UPPER_SNAKE_CASE.
pkg/roachpb/io-formats.proto:26:5:Enum field "Avro" is expected to have the prefix "FILE_FORMAT_".
pkg/roachpb/io-formats.proto:36:3:Enum "Compression" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/io-formats.proto:37:5:Field name "Auto" must be UPPER_SNAKE_CASE.
pkg/roachpb/io-formats.proto:37:5:Enum field "Auto" is expected to have the prefix "COMPRESSION_".
pkg/roachpb/io-formats.proto:37:5:Zero value enum field "Auto" is expected to have the name "COMPRESSION_INVALID".
pkg/roachpb/io-formats.proto:38:5:Field name "None" must be UPPER_SNAKE_CASE.
pkg/roachpb/io-formats.proto:38:5:Enum field "None" is expected to have the prefix "COMPRESSION_".
pkg/roachpb/io-formats.proto:39:5:Field name "Gzip" must be UPPER_SNAKE_CASE.
pkg/roachpb/io-formats.proto:39:5:Enum field "Gzip" is expected to have the prefix "COMPRESSION_".
pkg/roachpb/io-formats.proto:40:5:Field name "Bzip" must be UPPER_SNAKE_CASE.
pkg/roachpb/io-formats.proto:40:5:Enum field "Bzip" is expected to have the prefix "COMPRESSION_".
pkg/roachpb/io-formats.proto:65:3:Enum "Enclose" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/io-formats.proto:66:5:Field name "Never" must be UPPER_SNAKE_CASE.
pkg/roachpb/io-formats.proto:66:5:Enum field "Never" is expected to have the prefix "ENCLOSE_".
pkg/roachpb/io-formats.proto:66:5:Zero value enum field "Never" is expected to have the name "ENCLOSE_INVALID".
pkg/roachpb/io-formats.proto:67:5:Field name "Always" must be UPPER_SNAKE_CASE.
pkg/roachpb/io-formats.proto:67:5:Enum field "Always" is expected to have the prefix "ENCLOSE_".
pkg/roachpb/io-formats.proto:68:5:Field name "Optional" must be UPPER_SNAKE_CASE.
pkg/roachpb/io-formats.proto:68:5:Enum field "Optional" is expected to have the prefix "ENCLOSE_".
pkg/roachpb/io-formats.proto:87:3:"MySQLOutfileOptions" cannot have reserved field numbers, use the deprecated field option instead.
pkg/roachpb/io-formats.proto:97:12:Field name "maxRowSize" must be lower_snake_case.
pkg/roachpb/io-formats.proto:103:12:Field name "maxRowSize" must be lower_snake_case.
pkg/roachpb/io-formats.proto:106:1:Message "AvroOptions" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/io-formats.proto:107:3:Enum "Format" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/roachpb/io-formats.proto:109:5:Enum field "OCF" is expected to have the prefix "FORMAT_".
pkg/roachpb/io-formats.proto:109:5:Zero value enum field "OCF" is expected to have the name "FORMAT_INVALID".
pkg/roachpb/io-formats.proto:111:5:Enum field "BIN_RECORDS" is expected to have the prefix "FORMAT_".
pkg/roachpb/io-formats.proto:113:5:Enum field "JSON_RECORDS" is expected to have the prefix "FORMAT_".
pkg/roachpb/io-formats.proto:125:12:Field name "schemaJSON" must be lower_snake_case.
pkg/roachpb/metadata.proto:1:1:Multiple packages in directory: cockroach.roachpb, cockroach.sql.
pkg/roachpb/metadata.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/roachpb/metadata.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.roachpb".
pkg/roachpb/metadata.proto:13:1:Expected "roachpbpb" for option "go_package" but was "roachpb".
pkg/roachpb/metadata.proto:64:3:Enum field "VOTER_FULL" is expected to have the prefix "REPLICA_TYPE_".
pkg/roachpb/metadata.proto:64:3:Zero value enum field "VOTER_FULL" is expected to have the name "REPLICA_TYPE_INVALID".
pkg/roachpb/metadata.proto:69:3:Enum field "VOTER_INCOMING" is expected to have the prefix "REPLICA_TYPE_".
pkg/roachpb/metadata.proto:75:3:Enum field "VOTER_OUTGOING" is expected to have the prefix "REPLICA_TYPE_".
pkg/roachpb/metadata.proto:81:3:Enum field "VOTER_DEMOTING" is expected to have the prefix "REPLICA_TYPE_".
pkg/roachpb/metadata.proto:89:3:Enum field "LEARNER" is expected to have the prefix "REPLICA_TYPE_".
pkg/roachpb/metadata.proto:273:12:Field name "pMax" must be lower_snake_case.
pkg/roachpb/metadata.proto:319:12:Field name "ServerVersion" must be lower_snake_case.
pkg/roachpb/metadata.proto:373:1:Message "Version" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/rpc/heartbeat.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/rpc/heartbeat.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.rpc".
pkg/rpc/heartbeat.proto:13:1:Expected "rpcpb" for option "go_package" but was "rpc".
pkg/rpc/heartbeat.proto:26:1:Message "RemoteOffset" is not a request or response of any service in this file and should be in a separate file.
pkg/rpc/heartbeat.proto:39:1:Message "PingRequest" is a request for RPC "Ping" and should be defined in the file after the RPC.
pkg/rpc/heartbeat.proto:39:1:Message "PingRequest" is a request for RPC "PingStream" and should be defined in the file after the RPC.
pkg/rpc/heartbeat.proto:61:1:Message "PingResponse" is a response for RPC "Ping" and should be defined in the file after the RPC.
pkg/rpc/heartbeat.proto:61:1:Message "PingResponse" is a response for RPC "PingStream" and should be defined in the file after the RPC.
pkg/rpc/heartbeat.proto:72:1:Service "Heartbeat" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/rpc/heartbeat.proto:72:1:Service name "Heartbeat" must end with "API".
pkg/rpc/heartbeat.proto:72:1:Multiple services defined in this file and there should be only one service per file.
pkg/rpc/heartbeat.proto:73:3:RPC "Ping" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/rpc/heartbeat.proto:75:1:Service "TestingHeartbeatStream" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/rpc/heartbeat.proto:75:1:Service name "TestingHeartbeatStream" must end with "API".
pkg/rpc/heartbeat.proto:75:1:Multiple services defined in this file and there should be only one service per file.
pkg/rpc/heartbeat.proto:76:3:Name of request type "PingRequest" should be "PingStreamRequest".
pkg/rpc/heartbeat.proto:76:3:Name of response type "PingResponse" should be "PingStreamResponse".
pkg/rpc/heartbeat.proto:76:3:Message "PingRequest" is already used as a request or response type in an RPC and all request and response types must be unique.
pkg/rpc/heartbeat.proto:76:3:Message "PingResponse" is already used as a request or response type in an RPC and all request and response types must be unique.
pkg/rpc/heartbeat.proto:76:3:RPC "PingStream" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/diagnosticspb/diagnostics.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.server.diagnosticspb".
pkg/server/diagnosticspb/diagnostics.proto:13:1:Expected "diagnosticspbpb" for option "go_package" but was "diagnosticspb".
pkg/server/diagnosticspb/diagnostics.proto:22:1:Message "DiagnosticReport" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/diagnosticspb/diagnostics.proto:36:1:Message "NodeInfo" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/diagnosticspb/diagnostics.proto:51:1:Message "StoreInfo" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/diagnosticspb/diagnostics.proto:67:1:Message "CPUInfo" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/diagnosticspb/diagnostics.proto:68:21:Inline comments are not allowed on fields, only comment above the type.
pkg/server/diagnosticspb/diagnostics.proto:69:22:Inline comments are not allowed on fields, only comment above the type.
pkg/server/diagnosticspb/diagnostics.proto:70:21:Inline comments are not allowed on fields, only comment above the type.
pkg/server/diagnosticspb/diagnostics.proto:71:21:Inline comments are not allowed on fields, only comment above the type.
pkg/server/diagnosticspb/diagnostics.proto:72:19:Inline comments are not allowed on fields, only comment above the type.
pkg/server/diagnosticspb/diagnostics.proto:73:33:Inline comments are not allowed on fields, only comment above the type.
pkg/server/diagnosticspb/diagnostics.proto:76:1:Message "HardwareInfo" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/diagnosticspb/diagnostics.proto:85:1:Message "OSInfo" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/diagnosticspb/diagnostics.proto:91:1:Message "MemInfo" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/diagnosticspb/diagnostics.proto:96:1:Message "TopologyInfo" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.server.serverpb".
pkg/server/serverpb/admin.proto:13:1:Expected "serverpbpb" for option "go_package" but was "serverpb".
pkg/server/serverpb/admin.proto:31:1:Enum "ZoneConfigurationLevel" is in the same file as a service and should be in a separate file.
pkg/server/serverpb/admin.proto:32:3:Enum field "UNKNOWN" is expected to have the prefix "ZONE_CONFIGURATION_LEVEL_".
pkg/server/serverpb/admin.proto:32:3:Zero value enum field "UNKNOWN" is expected to have the name "ZONE_CONFIGURATION_LEVEL_INVALID".
pkg/server/serverpb/admin.proto:34:3:Enum field "CLUSTER" is expected to have the prefix "ZONE_CONFIGURATION_LEVEL_".
pkg/server/serverpb/admin.proto:36:3:Enum field "DATABASE" is expected to have the prefix "ZONE_CONFIGURATION_LEVEL_".
pkg/server/serverpb/admin.proto:36:3:The name "DATABASE" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:38:3:Enum field "TABLE" is expected to have the prefix "ZONE_CONFIGURATION_LEVEL_".
pkg/server/serverpb/admin.proto:42:1:The name "DatabasesRequest" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:42:1:Message "DatabasesRequest" is a request for RPC "Databases" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:46:1:The name "DatabasesResponse" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:46:1:Message "DatabasesResponse" is a response for RPC "Databases" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:47:12:The name "databases" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:52:1:The name "DatabaseDetailsRequest" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:52:1:Message "DatabaseDetailsRequest" is a request for RPC "DatabaseDetails" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:54:3:The name "database" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:59:1:The name "DatabaseDetailsResponse" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:59:1:Message "DatabaseDetailsResponse" is a response for RPC "DatabaseDetails" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:60:3:Message "Grant" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:85:1:Message "TableDetailsRequest" is a request for RPC "TableDetails" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:87:3:The name "database" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:95:1:Message "TableDetailsResponse" is a response for RPC "TableDetails" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:105:3:Message "Column" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:125:3:Message "Index" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:176:1:Message "TableStatsRequest" is a request for RPC "TableStats" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:178:3:The name "database" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:185:1:Message "TableStatsResponse" is a response for RPC "TableStats" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:218:1:Message "NonTableStatsRequest" is a request for RPC "NonTableStats" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:224:1:Message "NonTableStatsResponse" is a response for RPC "NonTableStats" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:232:1:Message "UsersRequest" is a request for RPC "Users" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:236:1:Message "UsersResponse" is a response for RPC "Users" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:248:1:Message "EventsRequest" is a request for RPC "Events" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:266:1:Message "EventsResponse" is a response for RPC "Events" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:267:3:Message "Event" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:269:5:Field "timestamp" of type "google.protobuf.Timestamp" must be "time" or end in "_time".
pkg/server/serverpb/admin.proto:292:1:The name "SetUIDataRequest" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:292:1:Message "SetUIDataRequest" is a request for RPC "SetUIData" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:299:1:The name "SetUIDataResponse" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:299:1:Message "SetUIDataResponse" is a response for RPC "SetUIData" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:304:1:The name "GetUIDataRequest" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:304:1:Message "GetUIDataRequest" is a request for RPC "GetUIData" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:310:1:The name "GetUIDataResponse" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:310:1:Message "GetUIDataResponse" is a response for RPC "GetUIData" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:311:3:Message "Value" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:316:5:Field "last_updated" of type "google.protobuf.Timestamp" must be "time" or end in "_time".
pkg/server/serverpb/admin.proto:325:1:Message "ClusterRequest" is a request for RPC "Cluster" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:329:1:Message "ClusterResponse" is a response for RPC "Cluster" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:341:1:Message "DrainRequest" is a request for RPC "Drain" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:355:3:"DrainRequest" cannot have reserved field numbers, use the deprecated field option instead.
pkg/server/serverpb/admin.proto:370:1:Message "DrainResponse" is a response for RPC "Drain" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:437:1:Message "DecommissionStatusRequest" is a request for RPC "DecommissionStatus" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:446:1:Message "DecommissionRequest" is a request for RPC "Decommission" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:453:1:Message "DecommissionStatusResponse" is a response for RPC "Decommission" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:453:1:Message "DecommissionStatusResponse" is a response for RPC "DecommissionStatus" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:454:3:Message "Status" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:468:1:Message "SettingsRequest" is a request for RPC "Settings" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:482:1:Message "SettingsResponse" is a response for RPC "Settings" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:483:4:Message "Value" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:509:1:Message "HealthRequest" is a request for RPC "Health" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:518:1:Message "HealthResponse" is a response for RPC "Health" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:522:1:Message "LivenessRequest" is a request for RPC "Liveness" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:526:1:Message "LivenessResponse" is a response for RPC "Liveness" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:535:1:Message "JobsRequest" is a request for RPC "Jobs" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:542:1:Message "JobsResponse" is a response for RPC "Jobs" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:543:3:Message "Job" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:554:5:Field "created" of type "google.protobuf.Timestamp" must be "time" or end in "_time".
pkg/server/serverpb/admin.proto:555:5:Field "started" of type "google.protobuf.Timestamp" must be "time" or end in "_time".
pkg/server/serverpb/admin.proto:556:5:Field "finished" of type "google.protobuf.Timestamp" must be "time" or end in "_time".
pkg/server/serverpb/admin.proto:557:5:Field "modified" of type "google.protobuf.Timestamp" must be "time" or end in "_time".
pkg/server/serverpb/admin.proto:562:5:Field "highwater_timestamp" of type "google.protobuf.Timestamp" must be "time" or end in "_time".
pkg/server/serverpb/admin.proto:574:1:Message "LocationsRequest" is a request for RPC "Locations" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:578:1:Message "LocationsResponse" is a response for RPC "Locations" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:579:3:Message "Location" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:590:1:Message "RangeLogRequest" is a request for RPC "RangeLog" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:603:1:Message "RangeLogResponse" is a response for RPC "RangeLog" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:614:3:Message "Event" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:618:3:"RangeLogResponse" cannot have reserved field numbers, use the deprecated field option instead.
pkg/server/serverpb/admin.proto:618:15:Inline comments are not allowed on reserved, only comment above the type.
pkg/server/serverpb/admin.proto:623:1:Message "QueryPlanRequest" is a request for RPC "QueryPlan" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:630:1:Message "QueryPlanResponse" is a response for RPC "QueryPlan" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:634:1:The name "DataDistributionRequest" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:634:1:Message "DataDistributionRequest" is a request for RPC "DataDistribution" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:637:1:The name "DataDistributionResponse" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:637:1:Message "DataDistributionResponse" is a response for RPC "DataDistribution" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:638:3:Message "ZoneConfig" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:645:5:"DataDistributionResponse.ZoneConfig" cannot have reserved field numbers, use the deprecated field option instead.
pkg/server/serverpb/admin.proto:651:3:Message "TableInfo" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:655:5:Field "dropped_at" of type "google.protobuf.Timestamp" must be "time" or end in "_time".
pkg/server/serverpb/admin.proto:658:3:Message "DatabaseInfo" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:658:3:The name "DatabaseInfo" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:664:3:The name "database_info" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:666:3:"DataDistributionResponse" cannot have reserved field numbers, use the deprecated field option instead.
pkg/server/serverpb/admin.proto:673:1:The name "MetricMetadataRequest" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:673:1:Message "MetricMetadataRequest" is a request for RPC "AllMetricMetadata" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:677:1:The name "MetricMetadataResponse" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:677:1:Message "MetricMetadataResponse" is a response for RPC "AllMetricMetadata" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:678:3:The name "metadata" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:681:1:Message "EnqueueRangeRequest" is a request for RPC "EnqueueRange" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:697:1:Message "EnqueueRangeResponse" is a response for RPC "EnqueueRange" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:698:3:Message "Details" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:710:1:Message "ChartCatalogRequest" is a request for RPC "ChartCatalog" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:714:1:Message "ChartCatalogResponse" is a response for RPC "ChartCatalog" and should be defined in the file after the RPC.
pkg/server/serverpb/admin.proto:720:1:Service name "Admin" must end with "API".
pkg/server/serverpb/admin.proto:722:3:RPC "Users" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:729:3:The name "Databases" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:729:3:RPC "Databases" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:736:3:The name "DatabaseDetails" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:736:3:RPC "DatabaseDetails" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:743:3:RPC "TableDetails" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:750:3:RPC "TableStats" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:757:3:RPC "NonTableStats" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:771:3:RPC "Events" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:792:3:The name "SetUIData" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:807:3:The name "GetUIData" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:873:3:Name of response type "DecommissionStatusResponse" should be "DecommissionResponse".
pkg/server/serverpb/admin.proto:879:3:Message "DecommissionStatusResponse" is already used as a request or response type in an RPC and all request and response types must be unique.
pkg/server/serverpb/admin.proto:886:3:RPC "RangeLog" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:895:3:The name "DataDistribution" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:895:3:RPC "DataDistribution" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:902:3:The name "AllMetricMetadata" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/admin.proto:902:3:Name of request type "MetricMetadataRequest" should be "AllMetricMetadataRequest".
pkg/server/serverpb/admin.proto:902:3:Name of response type "MetricMetadataResponse" should be "AllMetricMetadataResponse".
pkg/server/serverpb/admin.proto:902:3:RPC "AllMetricMetadata" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/admin.proto:909:3:RPC "ChartCatalog" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/authentication.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.server.serverpb".
pkg/server/serverpb/authentication.proto:13:1:Expected "serverpbpb" for option "go_package" but was "serverpb".
pkg/server/serverpb/authentication.proto:19:1:Message "UserLoginRequest" is a request for RPC "UserLogin" and should be defined in the file after the RPC.
pkg/server/serverpb/authentication.proto:29:1:Message "UserLoginResponse" is a response for RPC "UserLogin" and should be defined in the file after the RPC.
pkg/server/serverpb/authentication.proto:36:1:Message "UserLogoutRequest" is a request for RPC "UserLogout" and should be defined in the file after the RPC.
pkg/server/serverpb/authentication.proto:40:1:Message "UserLogoutResponse" is a response for RPC "UserLogout" and should be defined in the file after the RPC.
pkg/server/serverpb/authentication.proto:46:1:Message "SessionCookie" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/authentication.proto:60:1:Service name "LogIn" must end with "API".
pkg/server/serverpb/authentication.proto:60:1:Multiple services defined in this file and there should be only one service per file.
pkg/server/serverpb/authentication.proto:70:1:Service "LogOut" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/authentication.proto:70:1:Service name "LogOut" must end with "API".
pkg/server/serverpb/authentication.proto:70:1:Multiple services defined in this file and there should be only one service per file.
pkg/server/serverpb/init.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.server.serverpb".
pkg/server/serverpb/init.proto:13:1:Expected "serverpbpb" for option "go_package" but was "serverpb".
pkg/server/serverpb/init.proto:15:1:Message "BootstrapRequest" is a request for RPC "Bootstrap" and should be defined in the file after the RPC.
pkg/server/serverpb/init.proto:18:1:Message "BootstrapResponse" is a response for RPC "Bootstrap" and should be defined in the file after the RPC.
pkg/server/serverpb/init.proto:21:1:Service "Init" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/init.proto:21:1:Service name "Init" must end with "API".
pkg/server/serverpb/status.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.server.serverpb".
pkg/server/serverpb/status.proto:13:1:Expected "serverpbpb" for option "go_package" but was "serverpb".
pkg/server/serverpb/status.proto:38:1:Message "CertificatesRequest" is a request for RPC "Certificates" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:44:1:Message "CertificateDetails" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:44:1:Message "CertificateDetails" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:48:5:Enum field "CA" is expected to have the prefix "CERTIFICATE_TYPE_".
pkg/server/serverpb/status.proto:48:5:Zero value enum field "CA" is expected to have the name "CERTIFICATE_TYPE_INVALID".
pkg/server/serverpb/status.proto:49:5:Enum field "NODE" is expected to have the prefix "CERTIFICATE_TYPE_".
pkg/server/serverpb/status.proto:50:5:Enum field "CLIENT_CA" is expected to have the prefix "CERTIFICATE_TYPE_".
pkg/server/serverpb/status.proto:51:5:Enum field "CLIENT" is expected to have the prefix "CERTIFICATE_TYPE_".
pkg/server/serverpb/status.proto:52:5:Enum field "UI_CA" is expected to have the prefix "CERTIFICATE_TYPE_".
pkg/server/serverpb/status.proto:53:5:Enum field "UI" is expected to have the prefix "CERTIFICATE_TYPE_".
pkg/server/serverpb/status.proto:56:3:Message "Fields" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:73:3:The name "data" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/status.proto:77:1:Message "CertificatesResponse" is a response for RPC "Certificates" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:83:1:Message "DetailsRequest" is a request for RPC "Details" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:87:3:"DetailsRequest" cannot have reserved field numbers, use the deprecated field option instead.
pkg/server/serverpb/status.proto:91:1:Message "SystemInfo" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:99:1:Message "DetailsResponse" is a response for RPC "Details" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:111:1:Message "NodesRequest" is a request for RPC "Nodes" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:113:1:Message "NodesResponse" is a response for RPC "Nodes" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:122:1:Message "NodeRequest" is a request for RPC "Node" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:130:1:Message "RaftState" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:131:3:Message "Progress" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:152:1:Message "RangeProblems" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:152:1:Message "RangeProblems" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:170:1:Message "RangeStatistics" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:170:1:Message "RangeStatistics" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:177:1:Message "PrettySpan" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:177:1:Message "PrettySpan" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:184:1:Message "RangeInfo" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:184:1:Message "RangeInfo" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:209:1:Message "RangesRequest" is a request for RPC "Ranges" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:220:1:Message "RangesResponse" is a response for RPC "Ranges" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:224:1:Message "GossipRequest" is a request for RPC "Gossip" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:230:1:Message "EngineStatsInfo" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:230:1:Message "EngineStatsInfo" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:240:1:Message "EngineStatsRequest" is a request for RPC "EngineStats" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:246:1:Message "EngineStatsResponse" is a response for RPC "EngineStats" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:250:1:Message "TraceEvent" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:250:1:Message "TraceEvent" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:256:1:Message "AllocatorDryRun" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:256:1:Message "AllocatorDryRun" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:265:1:Message "AllocatorRangeRequest" is a request for RPC "AllocatorRange" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:269:1:Message "AllocatorRangeResponse" is a response for RPC "AllocatorRange" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:280:1:Message "AllocatorRequest" is a request for RPC "Allocator" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:289:1:Message "AllocatorResponse" is a response for RPC "Allocator" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:291:1:Message "JSONResponse" is a response for RPC "Metrics" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:291:1:Message "JSONResponse" is a response for RPC "Metrics" and should be defined in the file after the request "MetricsRequest".
pkg/server/serverpb/status.proto:291:1:Message "JSONResponse" is a response for RPC "Profile" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:291:1:Message "JSONResponse" is a response for RPC "Profile" and should be defined in the file after the request "ProfileRequest".
pkg/server/serverpb/status.proto:291:1:Message "JSONResponse" is a response for RPC "Stacks" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:291:1:Message "JSONResponse" is a response for RPC "Stacks" and should be defined in the file after the request "StacksRequest".
pkg/server/serverpb/status.proto:291:24:The name "data" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/status.proto:293:1:Message "LogsRequest" is a request for RPC "Logs" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:304:1:Message "LogEntriesResponse" is a response for RPC "LogFile" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:304:1:Message "LogEntriesResponse" is a response for RPC "LogFile" and should be defined in the file after the request "LogFileRequest".
pkg/server/serverpb/status.proto:304:1:Message "LogEntriesResponse" is a response for RPC "Logs" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:309:1:Message "LogFilesListRequest" is a request for RPC "LogFilesList" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:315:1:Message "LogFilesListResponse" is a response for RPC "LogFilesList" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:320:1:Message "LogFileRequest" is a request for RPC "LogFile" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:327:1:Enum "StacksType" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:327:1:Enum "StacksType" is in the same file as a service and should be in a separate file.
pkg/server/serverpb/status.proto:328:3:Enum field "GOROUTINE_STACKS" is expected to have the prefix "STACKS_TYPE_".
pkg/server/serverpb/status.proto:328:3:Zero value enum field "GOROUTINE_STACKS" is expected to have the name "STACKS_TYPE_INVALID".
pkg/server/serverpb/status.proto:329:3:Enum field "THREAD_STACKS" is expected to have the prefix "STACKS_TYPE_".
pkg/server/serverpb/status.proto:332:1:Message "StacksRequest" is a request for RPC "Stacks" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:343:1:Enum "FileType" is in the same file as a service and should be in a separate file.
pkg/server/serverpb/status.proto:344:3:Enum field "HEAP" is expected to have the prefix "FILE_TYPE_".
pkg/server/serverpb/status.proto:344:3:Zero value enum field "HEAP" is expected to have the name "FILE_TYPE_INVALID".
pkg/server/serverpb/status.proto:345:3:Enum field "GOROUTINES" is expected to have the prefix "FILE_TYPE_".
pkg/server/serverpb/status.proto:348:1:Message "File" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:348:1:Message "File" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:355:1:Message "GetFilesRequest" is a request for RPC "GetFiles" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:370:1:Message "GetFilesResponse" is a response for RPC "GetFiles" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:374:1:Message "ProfileRequest" is a request for RPC "Profile" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:379:3:Enum "Type" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:379:15:Enum field "HEAP" is expected to have the prefix "TYPE_".
pkg/server/serverpb/status.proto:379:15:Zero value enum field "HEAP" is expected to have the name "TYPE_INVALID".
pkg/server/serverpb/status.proto:384:1:Message "MetricsRequest" is a request for RPC "Metrics" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:390:1:Message "RaftRangeNode" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:390:1:Message "RaftRangeNode" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:399:1:Message "RaftRangeError" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:399:1:Message "RaftRangeError" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:401:1:Message "RaftRangeStatus" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:401:1:Message "RaftRangeStatus" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:411:1:Message "RaftDebugRequest" is a request for RPC "RaftDebug" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:419:1:Message "RaftDebugResponse" is a response for RPC "RaftDebug" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:429:1:Message "TxnInfo" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:437:3:Field "start" of type "google.protobuf.Timestamp" must be "time" or end in "_time".
pkg/server/serverpb/status.proto:446:1:Message "ActiveQuery" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:459:3:Field "start" of type "google.protobuf.Timestamp" must be "time" or end in "_time".
pkg/server/serverpb/status.proto:466:5:Enum field "PREPARING" is expected to have the prefix "PHASE_".
pkg/server/serverpb/status.proto:466:5:Zero value enum field "PREPARING" is expected to have the name "PHASE_INVALID".
pkg/server/serverpb/status.proto:467:5:Enum field "EXECUTING" is expected to have the prefix "PHASE_".
pkg/server/serverpb/status.proto:476:1:Message "ListSessionsRequest" is a request for RPC "ListLocalSessions" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:476:1:Message "ListSessionsRequest" is a request for RPC "ListSessions" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:482:1:Message "Session" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:498:3:Field "start" of type "google.protobuf.Timestamp" must be "time" or end in "_time".
pkg/server/serverpb/status.proto:521:1:Message "ListSessionsError" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:533:1:Message "ListSessionsResponse" is a response for RPC "ListLocalSessions" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:533:1:Message "ListSessionsResponse" is a response for RPC "ListSessions" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:541:1:Message "CancelQueryRequest" is a request for RPC "CancelQuery" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:557:1:Message "CancelQueryResponse" is a response for RPC "CancelQuery" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:564:1:Message "CancelSessionRequest" is a request for RPC "CancelSession" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:575:1:Message "CancelSessionResponse" is a response for RPC "CancelSession" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:580:1:Message "SpanStatsRequest" is a request for RPC "SpanStats" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:589:1:Message "SpanStatsResponse" is a response for RPC "SpanStats" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:596:1:Message "ProblemRangesRequest" is a request for RPC "ProblemRanges" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:601:1:Message "ProblemRangesResponse" is a response for RPC "ProblemRanges" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:602:3:Message "NodeProblems" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:645:3:"ProblemRangesResponse" cannot have reserved field numbers, use the deprecated field option instead.
pkg/server/serverpb/status.proto:659:1:Message "HotRangesRequest" is a request for RPC "HotRanges" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:664:1:Message "HotRangesResponse" is a response for RPC "HotRanges" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:665:3:Message "HotRange" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:669:3:Message "StoreResponse" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:677:3:Message "NodeResponse" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:694:1:Message "RangeRequest" is a request for RPC "Range" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:698:1:Message "RangeResponse" is a response for RPC "Range" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:699:3:Message "NodeResponse" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:720:3:"RangeResponse" cannot have reserved field numbers, use the deprecated field option instead.
pkg/server/serverpb/status.proto:720:15:Inline comments are not allowed on reserved, only comment above the type.
pkg/server/serverpb/status.proto:724:1:Message "DiagnosticsRequest" is a request for RPC "Diagnostics" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:730:1:Message "StoresRequest" is a request for RPC "Stores" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:736:1:Message "StoreDetails" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:736:1:Message "StoreDetails" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:761:1:Message "StoresResponse" is a response for RPC "Stores" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:765:1:Message "StatementsRequest" is a request for RPC "Statements" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:769:1:Message "StatementsResponse" is a response for RPC "Statements" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:770:3:Message "ExtendedStatementStatisticsKey" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:771:5:The name "key_data" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/server/serverpb/status.proto:776:3:Message "CollectedStatementStatistics" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:783:3:Field "last_reset" of type "google.protobuf.Timestamp" must be "time" or end in "_time".
pkg/server/serverpb/status.proto:789:1:Message "StatementDiagnosticsReport" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:789:1:Message "StatementDiagnosticsReport" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:795:3:Field "requested_at" of type "google.protobuf.Timestamp" must be "time" or end in "_time".
pkg/server/serverpb/status.proto:799:1:Message "CreateStatementDiagnosticsReportRequest" is a request for RPC "CreateStatementDiagnosticsReport" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:803:1:Message "CreateStatementDiagnosticsReportResponse" is a response for RPC "CreateStatementDiagnosticsReport" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:807:1:Message "StatementDiagnosticsReportsRequest" is a request for RPC "StatementDiagnosticsRequests" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:809:1:Message "StatementDiagnosticsReportsResponse" is a response for RPC "StatementDiagnosticsRequests" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:813:1:Message "StatementDiagnostics" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:813:1:Message "StatementDiagnostics" is not a request or response of any service in this file and should be in a separate file.
pkg/server/serverpb/status.proto:816:3:Field "collected_at" of type "google.protobuf.Timestamp" must be "time" or end in "_time".
pkg/server/serverpb/status.proto:821:1:Message "StatementDiagnosticsRequest" is a request for RPC "StatementDiagnostics" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:825:1:Message "StatementDiagnosticsResponse" is a response for RPC "StatementDiagnostics" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:829:1:Message "JobRegistryStatusRequest" is a request for RPC "JobRegistryStatus" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:833:1:Message "JobRegistryStatusResponse" is a response for RPC "JobRegistryStatus" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:839:3:Message "Job" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:845:1:Message "JobStatusRequest" is a request for RPC "JobStatus" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:849:1:Message "JobStatusResponse" is a response for RPC "JobStatus" and should be defined in the file after the RPC.
pkg/server/serverpb/status.proto:853:1:Service "Status" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:853:1:Service name "Status" must end with "API".
pkg/server/serverpb/status.proto:854:3:RPC "Certificates" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:859:3:RPC "Details" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:864:3:RPC "Nodes" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:869:3:Name of response type "server.status.statuspb.NodeStatus" should be "NodeResponse".
pkg/server/serverpb/status.proto:869:3:Response type "server.status.statuspb.NodeStatus" should be defined in the same file as the corresponding service.
pkg/server/serverpb/status.proto:869:3:RPC "Node" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:874:3:RPC "RaftDebug" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:879:3:RPC "Ranges" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:884:3:Name of response type "gossip.InfoStatus" should be "GossipResponse".
pkg/server/serverpb/status.proto:884:3:Response type "gossip.InfoStatus" should be defined in the same file as the corresponding service.
pkg/server/serverpb/status.proto:884:3:RPC "Gossip" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:889:3:RPC "EngineStats" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:894:3:RPC "Allocator" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:899:3:RPC "AllocatorRange" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:904:3:RPC "ListSessions" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:909:3:Name of request type "ListSessionsRequest" should be "ListLocalSessionsRequest".
pkg/server/serverpb/status.proto:909:3:Name of response type "ListSessionsResponse" should be "ListLocalSessionsResponse".
pkg/server/serverpb/status.proto:909:3:Message "ListSessionsRequest" is already used as a request or response type in an RPC and all request and response types must be unique.
pkg/server/serverpb/status.proto:909:3:Message "ListSessionsResponse" is already used as a request or response type in an RPC and all request and response types must be unique.
pkg/server/serverpb/status.proto:909:3:RPC "ListLocalSessions" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:914:3:RPC "CancelQuery" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:919:3:RPC "CancelSession" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:936:3:Name of response type "JSONResponse" should be "StacksResponse".
pkg/server/serverpb/status.proto:936:3:RPC "Stacks" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:941:3:Name of response type "JSONResponse" should be "ProfileResponse".
pkg/server/serverpb/status.proto:941:3:Message "JSONResponse" is already used as a request or response type in an RPC and all request and response types must be unique.
pkg/server/serverpb/status.proto:941:3:RPC "Profile" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:946:3:Name of response type "JSONResponse" should be "MetricsResponse".
pkg/server/serverpb/status.proto:946:3:Message "JSONResponse" is already used as a request or response type in an RPC and all request and response types must be unique.
pkg/server/serverpb/status.proto:946:3:RPC "Metrics" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:951:3:RPC "GetFiles" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:956:3:RPC "LogFilesList" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:961:3:Name of response type "LogEntriesResponse" should be "LogFileResponse".
pkg/server/serverpb/status.proto:961:3:RPC "LogFile" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:966:3:Name of response type "LogEntriesResponse" should be "LogsResponse".
pkg/server/serverpb/status.proto:966:3:Message "LogEntriesResponse" is already used as a request or response type in an RPC and all request and response types must be unique.
pkg/server/serverpb/status.proto:966:3:RPC "Logs" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:971:3:RPC "ProblemRanges" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:976:3:RPC "HotRanges" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:981:3:RPC "Range" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:986:3:Name of response type "cockroach.server.diagnosticspb.DiagnosticReport" should be "DiagnosticsResponse".
pkg/server/serverpb/status.proto:986:3:Response type "cockroach.server.diagnosticspb.DiagnosticReport" should be defined in the same file as the corresponding service.
pkg/server/serverpb/status.proto:986:3:RPC "Diagnostics" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:992:3:RPC "Stores" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:997:3:RPC "Statements" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:1002:3:RPC "CreateStatementDiagnosticsReport" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:1008:3:Name of request type "StatementDiagnosticsReportsRequest" should be "StatementDiagnosticsRequestsRequest".
pkg/server/serverpb/status.proto:1008:3:Name of response type "StatementDiagnosticsReportsResponse" should be "StatementDiagnosticsRequestsResponse".
pkg/server/serverpb/status.proto:1008:3:RPC "StatementDiagnosticsRequests" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:1013:3:RPC "StatementDiagnostics" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:1018:3:RPC "JobRegistryStatus" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/serverpb/status.proto:1023:3:RPC "JobStatus" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/status/statuspb/status.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.server.status.statuspb".
pkg/server/status/statuspb/status.proto:13:1:Expected "statuspbpb" for option "go_package" but was "statuspb".
pkg/server/status/statuspb/status.proto:45:3:Message "NetworkActivity" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/status/statuspb/status.proto:46:25:Inline comments are not allowed on fields, only comment above the type.
pkg/server/status/statuspb/status.proto:47:25:Inline comments are not allowed on fields, only comment above the type.
pkg/server/status/statuspb/status.proto:48:25:Inline comments are not allowed on fields, only comment above the type.
pkg/server/status/statuspb/status.proto:75:3:Enum "Category" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/server/status/statuspb/status.proto:76:5:Enum field "METRICS" is expected to have the prefix "CATEGORY_".
pkg/server/status/statuspb/status.proto:76:5:Zero value enum field "METRICS" is expected to have the name "CATEGORY_INVALID".
pkg/server/status/statuspb/status.proto:77:5:Enum field "NETWORK" is expected to have the prefix "CATEGORY_".
pkg/sql/colexec/execpb/stats.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.execpb".
pkg/sql/colexec/execpb/stats.proto:13:1:Expected "execpbpb" for option "go_package" but was "execpb".
pkg/sql/colexec/execpb/stats.proto:23:3:Field "time" of type "google.protobuf.Duration" must be "duration" or end in "_duration".
pkg/sql/execinfrapb/api.proto:13:1:Syntax should be proto3 but was "proto2".
pkg/sql/execinfrapb/api.proto:17:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.distsqlrun".
pkg/sql/execinfrapb/api.proto:18:1:Expected "distsqlrunpb" for option "go_package" but was "execinfrapb".
pkg/sql/execinfrapb/api.proto:27:1:Message "SetupFlowRequest" is a request for RPC "SetupFlow" and should be defined in the file after the RPC.
pkg/sql/execinfrapb/api.proto:28:3:"SetupFlowRequest" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/execinfrapb/api.proto:44:12:Field name "evalContext" must be lower_snake_case.
pkg/sql/execinfrapb/api.proto:46:12:Field name "TraceKV" must be lower_snake_case.
pkg/sql/execinfrapb/api.proto:51:1:Message "FlowSpec" is not a request or response of any service in this file and should be in a separate file.
pkg/sql/execinfrapb/api.proto:63:1:Message "EvalContext" is not a request or response of any service in this file and should be in a separate file.
pkg/sql/execinfrapb/api.proto:64:12:Field name "stmtTimestampNanos" must be lower_snake_case.
pkg/sql/execinfrapb/api.proto:65:12:Field name "txnTimestampNanos" must be lower_snake_case.
pkg/sql/execinfrapb/api.proto:66:3:"EvalContext" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/execinfrapb/api.proto:70:12:The name "database" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/sql/execinfrapb/api.proto:82:1:Enum "BytesEncodeFormat" is in the same file as a service and should be in a separate file.
pkg/sql/execinfrapb/api.proto:83:3:Enum field "HEX" is expected to have the prefix "BYTES_ENCODE_FORMAT_".
pkg/sql/execinfrapb/api.proto:83:3:Zero value enum field "HEX" is expected to have the name "BYTES_ENCODE_FORMAT_INVALID".
pkg/sql/execinfrapb/api.proto:84:3:Enum field "ESCAPE" is expected to have the prefix "BYTES_ENCODE_FORMAT_".
pkg/sql/execinfrapb/api.proto:85:3:Enum field "BASE64" is expected to have the prefix "BYTES_ENCODE_FORMAT_".
pkg/sql/execinfrapb/api.proto:89:1:Message "SequenceState" is not a request or response of any service in this file and should be in a separate file.
pkg/sql/execinfrapb/api.proto:102:1:Message "SimpleResponse" is a response for RPC "SetupFlow" and should be defined in the file after the RPC.
pkg/sql/execinfrapb/api.proto:108:1:Message "ConsumerSignal" is a request for RPC "RunSyncFlow" and should be defined in the file after the RPC.
pkg/sql/execinfrapb/api.proto:108:1:Message "ConsumerSignal" is a response for RPC "FlowStream" and should be defined in the file after the RPC.
pkg/sql/execinfrapb/api.proto:124:1:Message "DrainRequest" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/api.proto:124:1:Message "DrainRequest" is not a request or response of any service in this file and should be in a separate file.
pkg/sql/execinfrapb/api.proto:131:1:Message "ConsumerHandshake" is not a request or response of any service in this file and should be in a separate file.
pkg/sql/execinfrapb/api.proto:144:12:Field "consumer_schedule_deadline" of type "google.protobuf.Timestamp" must be "time" or end in "_time".
pkg/sql/execinfrapb/api.proto:153:1:Service "DistSQL" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/api.proto:153:1:Service name "DistSQL" must end with "API".
pkg/sql/execinfrapb/api.proto:153:1:Expected filename to be "dist_sql.proto" for file containing service "DistSQL" but was "api.proto".
pkg/sql/execinfrapb/api.proto:157:3:Name of request type "ConsumerSignal" should be "RunSyncFlowRequest".
pkg/sql/execinfrapb/api.proto:157:3:Name of response type "ProducerMessage" should be "RunSyncFlowResponse".
pkg/sql/execinfrapb/api.proto:157:3:Response type "ProducerMessage" should be defined in the same file as the corresponding service.
pkg/sql/execinfrapb/api.proto:161:3:Name of response type "SimpleResponse" should be "SetupFlowResponse".
pkg/sql/execinfrapb/api.proto:173:3:Name of request type "ProducerMessage" should be "FlowStreamRequest".
pkg/sql/execinfrapb/api.proto:173:3:Name of response type "ConsumerSignal" should be "FlowStreamResponse".
pkg/sql/execinfrapb/api.proto:173:3:Request type "ProducerMessage" should be defined in the same file as the corresponding service.
pkg/sql/execinfrapb/api.proto:173:3:Message "ConsumerSignal" is already used as a request or response type in an RPC and all request and response types must be unique.
pkg/sql/execinfrapb/api.proto:173:3:Message "ProducerMessage" is already used as a request or response type in an RPC and all request and response types must be unique.
pkg/sql/execinfrapb/data.proto:15:1:Syntax should be proto3 but was "proto2".
pkg/sql/execinfrapb/data.proto:19:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.distsqlrun".
pkg/sql/execinfrapb/data.proto:20:1:Expected "distsqlrunpb" for option "go_package" but was "execinfrapb".
pkg/sql/execinfrapb/data.proto:37:3:"Error" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/execinfrapb/data.proto:44:1:Message "Expression" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/data.proto:62:3:Message "Column" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/data.proto:67:7:Enum field "ASC" is expected to have the prefix "DIRECTION_".
pkg/sql/execinfrapb/data.proto:67:7:Zero value enum field "ASC" is expected to have the name "DIRECTION_INVALID".
pkg/sql/execinfrapb/data.proto:68:7:Enum field "DESC" is expected to have the prefix "DIRECTION_".
pkg/sql/execinfrapb/data.proto:79:3:Enum "Type" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/data.proto:81:5:Enum field "LOCAL" is expected to have the prefix "TYPE_".
pkg/sql/execinfrapb/data.proto:81:5:Zero value enum field "LOCAL" is expected to have the name "TYPE_INVALID".
pkg/sql/execinfrapb/data.proto:83:5:Enum field "REMOTE" is expected to have the prefix "TYPE_".
pkg/sql/execinfrapb/data.proto:88:5:Enum field "SYNC_RESPONSE" is expected to have the prefix "TYPE_".
pkg/sql/execinfrapb/data.proto:108:3:"StreamEndpointSpec" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/execinfrapb/data.proto:114:3:Enum "Type" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/data.proto:116:5:Enum field "UNORDERED" is expected to have the prefix "TYPE_".
pkg/sql/execinfrapb/data.proto:116:5:Zero value enum field "UNORDERED" is expected to have the name "TYPE_INVALID".
pkg/sql/execinfrapb/data.proto:120:5:Enum field "ORDERED" is expected to have the prefix "TYPE_".
pkg/sql/execinfrapb/data.proto:135:3:Enum "Type" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/data.proto:137:5:Enum field "PASS_THROUGH" is expected to have the prefix "TYPE_".
pkg/sql/execinfrapb/data.proto:137:5:Zero value enum field "PASS_THROUGH" is expected to have the name "TYPE_INVALID".
pkg/sql/execinfrapb/data.proto:139:5:Enum field "MIRROR" is expected to have the prefix "TYPE_".
pkg/sql/execinfrapb/data.proto:142:5:Enum field "BY_HASH" is expected to have the prefix "TYPE_".
pkg/sql/execinfrapb/data.proto:145:5:Enum field "BY_RANGE" is expected to have the prefix "TYPE_".
pkg/sql/execinfrapb/data.proto:154:3:Message "RangeRouterSpec" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/data.proto:155:5:Message "ColumnEncoding" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/data.proto:191:1:Message "DatumInfo" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/data.proto:210:1:The name "ProducerData" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/sql/execinfrapb/data.proto:220:12:The name "metadata" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/sql/execinfrapb/data.proto:223:1:Message "ProducerMessage" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/data.proto:235:12:The name "data" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/sql/execinfrapb/data.proto:242:1:The name "RemoteProducerMetadata" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/sql/execinfrapb/data.proto:243:3:Message "RangeInfos" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/data.proto:246:3:Message "TraceData" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/data.proto:246:3:The name "TraceData" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/sql/execinfrapb/data.proto:261:3:Message "SamplerProgress" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/data.proto:269:3:Message "BulkProcessorProgress" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/data.proto:284:5:The name "trace_data" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/sql/execinfrapb/data.proto:291:3:"RemoteProducerMetadata" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/execinfrapb/processors.proto:15:1:Syntax should be proto3 but was "proto2".
pkg/sql/execinfrapb/processors.proto:19:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.distsqlrun".
pkg/sql/execinfrapb/processors.proto:20:1:Expected "distsqlrunpb" for option "go_package" but was "execinfrapb".
pkg/sql/execinfrapb/processors.proto:77:1:Message "ProcessorCoreUnion" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/processors.proto:81:12:Field name "tableReader" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:82:12:Field name "joinReader" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:86:12:Field name "mergeJoiner" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:87:12:Field name "hashJoiner" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:90:12:Field name "readImport" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:91:3:"ProcessorCoreUnion" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/execinfrapb/processors.proto:92:12:Field name "CSVWriter" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:93:12:Field name "Sampler" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:94:12:Field name "SampleAggregator" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:95:12:Field name "interleavedReaderJoiner" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:96:12:Field name "metadataTestSender" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:96:12:The name "metadataTestSender" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/sql/execinfrapb/processors.proto:97:12:Field name "metadataTestReceiver" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:97:12:The name "metadataTestReceiver" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/sql/execinfrapb/processors.proto:98:12:Field name "zigzagJoiner" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:99:12:Field name "projectSet" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:101:12:Field name "localPlanNode" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:102:12:Field name "changeAggregator" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:103:12:Field name "changeFrontier" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:105:12:Field name "bulkRowWriter" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:107:3:"ProcessorCoreUnion" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/execinfrapb/processors.proto:124:12:Field name "RowSourceIdx" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:125:12:Field name "NumInputs" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:126:12:Field name "Name" must be lower_snake_case.
pkg/sql/execinfrapb/processors.proto:129:1:Message "MetadataTestSenderSpec" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/processors.proto:129:1:The name "MetadataTestSenderSpec" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/sql/execinfrapb/processors.proto:134:1:Message "MetadataTestReceiverSpec" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/processors.proto:134:1:The name "MetadataTestReceiverSpec" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/sql/execinfrapb/processors_base.proto:15:1:Syntax should be proto3 but was "proto2".
pkg/sql/execinfrapb/processors_base.proto:19:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.distsqlrun".
pkg/sql/execinfrapb/processors_base.proto:20:1:Expected "distsqlrunpb" for option "go_package" but was "execinfrapb".
pkg/sql/execinfrapb/processors_base.proto:61:1:Message "Columns" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/processors_base.proto:65:1:Message "TableReaderSpan" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/processors_bulk_io.proto:15:1:Syntax should be proto3 but was "proto2".
pkg/sql/execinfrapb/processors_bulk_io.proto:19:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.distsqlrun".
pkg/sql/execinfrapb/processors_bulk_io.proto:20:1:Expected "distsqlrunpb" for option "go_package" but was "execinfrapb".
pkg/sql/execinfrapb/processors_bulk_io.proto:38:3:Enum "Type" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/processors_bulk_io.proto:39:5:Field name "Invalid" must be UPPER_SNAKE_CASE.
pkg/sql/execinfrapb/processors_bulk_io.proto:39:5:Enum field "Invalid" is expected to have the prefix "TYPE_".
pkg/sql/execinfrapb/processors_bulk_io.proto:39:5:Zero value enum field "Invalid" is expected to have the name "TYPE_INVALID".
pkg/sql/execinfrapb/processors_bulk_io.proto:40:5:Field name "Column" must be UPPER_SNAKE_CASE.
pkg/sql/execinfrapb/processors_bulk_io.proto:40:5:Enum field "Column" is expected to have the prefix "TYPE_".
pkg/sql/execinfrapb/processors_bulk_io.proto:41:5:Field name "Index" must be UPPER_SNAKE_CASE.
pkg/sql/execinfrapb/processors_bulk_io.proto:41:5:Enum field "Index" is expected to have the prefix "TYPE_".
pkg/sql/execinfrapb/processors_bulk_io.proto:65:12:Field name "readAsOf" must be lower_snake_case.
pkg/sql/execinfrapb/processors_bulk_io.proto:79:1:Message "ReadImportDataSpec" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/processors_bulk_io.proto:79:1:The name "ReadImportDataSpec" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/sql/execinfrapb/processors_bulk_io.proto:80:3:"ReadImportDataSpec" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/execinfrapb/processors_bulk_io.proto:84:3:"ReadImportDataSpec" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/execinfrapb/processors_bulk_io.proto:86:3:Message "ImportTable" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/processors_bulk_io.proto:92:14:Field name "targetCols" must be lower_snake_case.
pkg/sql/execinfrapb/processors_bulk_io.proto:119:3:"ReadImportDataSpec" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/execinfrapb/processors_bulk_io.proto:120:3:"ReadImportDataSpec" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/execinfrapb/processors_bulk_io.proto:125:12:Field name "walltimeNanos" must be lower_snake_case.
pkg/sql/execinfrapb/processors_bulk_io.proto:127:3:"ReadImportDataSpec" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/execinfrapb/processors_bulk_io.proto:130:12:Field name "readerParallelism" must be lower_snake_case.
pkg/sql/execinfrapb/processors_bulk_io.proto:137:1:Enum "FileCompression" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/processors_bulk_io.proto:138:3:Field name "None" must be UPPER_SNAKE_CASE.
pkg/sql/execinfrapb/processors_bulk_io.proto:138:3:Enum field "None" is expected to have the prefix "FILE_COMPRESSION_".
pkg/sql/execinfrapb/processors_bulk_io.proto:138:3:Zero value enum field "None" is expected to have the name "FILE_COMPRESSION_INVALID".
pkg/sql/execinfrapb/processors_bulk_io.proto:139:3:Field name "Gzip" must be UPPER_SNAKE_CASE.
pkg/sql/execinfrapb/processors_bulk_io.proto:139:3:Enum field "Gzip" is expected to have the prefix "FILE_COMPRESSION_".
pkg/sql/execinfrapb/processors_changefeeds.proto:15:1:Syntax should be proto3 but was "proto2".
pkg/sql/execinfrapb/processors_changefeeds.proto:19:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.distsqlrun".
pkg/sql/execinfrapb/processors_changefeeds.proto:20:1:Expected "distsqlrunpb" for option "go_package" but was "execinfrapb".
pkg/sql/execinfrapb/processors_changefeeds.proto:30:3:Message "Watch" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/processors_sql.proto:15:1:Syntax should be proto3 but was "proto2".
pkg/sql/execinfrapb/processors_sql.proto:19:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.distsqlrun".
pkg/sql/execinfrapb/processors_sql.proto:20:1:Expected "distsqlrunpb" for option "go_package" but was "execinfrapb".
pkg/sql/execinfrapb/processors_sql.proto:47:3:Enum field "PUBLIC" is expected to have the prefix "SCAN_VISIBILITY_".
pkg/sql/execinfrapb/processors_sql.proto:47:3:Zero value enum field "PUBLIC" is expected to have the name "SCAN_VISIBILITY_INVALID".
pkg/sql/execinfrapb/processors_sql.proto:48:3:Enum field "PUBLIC_AND_NOT_PUBLIC" is expected to have the prefix "SCAN_VISIBILITY_".
pkg/sql/execinfrapb/processors_sql.proto:223:3:"JoinReaderSpec" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/execinfrapb/processors_sql.proto:265:1:Message "DistinctSpec" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/processors_sql.proto:465:5:Enum field "ANY_NOT_NULL" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:465:5:Zero value enum field "ANY_NOT_NULL" is expected to have the name "FUNC_INVALID".
pkg/sql/execinfrapb/processors_sql.proto:466:5:Enum field "AVG" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:467:5:Enum field "BOOL_AND" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:468:5:Enum field "BOOL_OR" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:469:5:Enum field "CONCAT_AGG" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:470:5:Enum field "COUNT" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:471:5:Enum field "MAX" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:472:5:Enum field "MIN" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:473:5:Enum field "STDDEV" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:474:5:Enum field "SUM" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:475:5:Enum field "SUM_INT" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:476:5:Enum field "VARIANCE" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:477:5:Enum field "XOR_AGG" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:478:5:Enum field "COUNT_ROWS" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:479:5:Enum field "SQRDIFF" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:480:5:Enum field "FINAL_VARIANCE" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:481:5:Enum field "FINAL_STDDEV" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:482:5:Enum field "ARRAY_AGG" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:483:5:Enum field "JSON_AGG" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:485:5:Enum field "JSONB_AGG" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:486:5:Enum field "STRING_AGG" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:487:5:Enum field "BIT_AND" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:488:5:Enum field "BIT_OR" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:489:5:Enum field "CORR" is expected to have the prefix "FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:492:3:Enum "Type" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/processors_sql.proto:496:5:Enum field "AUTO" is expected to have the prefix "TYPE_".
pkg/sql/execinfrapb/processors_sql.proto:496:5:Zero value enum field "AUTO" is expected to have the name "TYPE_INVALID".
pkg/sql/execinfrapb/processors_sql.proto:499:5:Enum field "SCALAR" is expected to have the prefix "TYPE_".
pkg/sql/execinfrapb/processors_sql.proto:502:5:Enum field "NON_SCALAR" is expected to have the prefix "TYPE_".
pkg/sql/execinfrapb/processors_sql.proto:505:3:Message "Aggregation" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/processors_sql.proto:530:5:"AggregatorSpec.Aggregation" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/execinfrapb/processors_sql.proto:560:3:Message "Table" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/processors_sql.proto:650:3:Enum "WindowFunc" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/processors_sql.proto:652:5:Enum field "ROW_NUMBER" is expected to have the prefix "WINDOW_FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:652:5:Zero value enum field "ROW_NUMBER" is expected to have the name "WINDOW_FUNC_INVALID".
pkg/sql/execinfrapb/processors_sql.proto:653:5:Enum field "RANK" is expected to have the prefix "WINDOW_FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:654:5:Enum field "DENSE_RANK" is expected to have the prefix "WINDOW_FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:655:5:Enum field "PERCENT_RANK" is expected to have the prefix "WINDOW_FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:656:5:Enum field "CUME_DIST" is expected to have the prefix "WINDOW_FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:657:5:Enum field "NTILE" is expected to have the prefix "WINDOW_FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:658:5:Enum field "LAG" is expected to have the prefix "WINDOW_FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:659:5:Enum field "LEAD" is expected to have the prefix "WINDOW_FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:660:5:Enum field "FIRST_VALUE" is expected to have the prefix "WINDOW_FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:661:5:Enum field "LAST_VALUE" is expected to have the prefix "WINDOW_FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:662:5:Enum field "NTH_VALUE" is expected to have the prefix "WINDOW_FUNC_".
pkg/sql/execinfrapb/processors_sql.proto:670:14:Field name "aggregateFunc" must be lower_snake_case.
pkg/sql/execinfrapb/processors_sql.proto:671:14:Field name "windowFunc" must be lower_snake_case.
pkg/sql/execinfrapb/processors_sql.proto:679:7:Enum field "RANGE" is expected to have the prefix "MODE_".
pkg/sql/execinfrapb/processors_sql.proto:679:7:Zero value enum field "RANGE" is expected to have the name "MODE_INVALID".
pkg/sql/execinfrapb/processors_sql.proto:681:7:Enum field "ROWS" is expected to have the prefix "MODE_".
pkg/sql/execinfrapb/processors_sql.proto:684:7:Enum field "GROUPS" is expected to have the prefix "MODE_".
pkg/sql/execinfrapb/processors_sql.proto:689:7:Enum field "UNBOUNDED_PRECEDING" is expected to have the prefix "BOUND_TYPE_".
pkg/sql/execinfrapb/processors_sql.proto:689:7:Zero value enum field "UNBOUNDED_PRECEDING" is expected to have the name "BOUND_TYPE_INVALID".
pkg/sql/execinfrapb/processors_sql.proto:690:7:Enum field "UNBOUNDED_FOLLOWING" is expected to have the prefix "BOUND_TYPE_".
pkg/sql/execinfrapb/processors_sql.proto:692:7:Enum field "OFFSET_PRECEDING" is expected to have the prefix "BOUND_TYPE_".
pkg/sql/execinfrapb/processors_sql.proto:693:7:Enum field "OFFSET_FOLLOWING" is expected to have the prefix "BOUND_TYPE_".
pkg/sql/execinfrapb/processors_sql.proto:694:7:Enum field "CURRENT_ROW" is expected to have the prefix "BOUND_TYPE_".
pkg/sql/execinfrapb/processors_sql.proto:699:7:Enum field "NO_EXCLUSION" is expected to have the prefix "EXCLUSION_".
pkg/sql/execinfrapb/processors_sql.proto:699:7:Zero value enum field "NO_EXCLUSION" is expected to have the name "EXCLUSION_INVALID".
pkg/sql/execinfrapb/processors_sql.proto:700:7:Enum field "EXCLUDE_CURRENT_ROW" is expected to have the prefix "EXCLUSION_".
pkg/sql/execinfrapb/processors_sql.proto:701:7:Enum field "EXCLUDE_GROUP" is expected to have the prefix "EXCLUSION_".
pkg/sql/execinfrapb/processors_sql.proto:702:7:Enum field "EXCLUDE_TIES" is expected to have the prefix "EXCLUSION_".
pkg/sql/execinfrapb/processors_sql.proto:707:16:Field name "boundType" must be lower_snake_case.
pkg/sql/execinfrapb/processors_sql.proto:734:14:Field name "argsIdxs" must be lower_snake_case.
pkg/sql/execinfrapb/processors_sql.proto:743:14:Field name "filterColIdx" must be lower_snake_case.
pkg/sql/execinfrapb/processors_sql.proto:746:14:Field name "outputColIdx" must be lower_snake_case.
pkg/sql/execinfrapb/processors_sql.proto:748:5:"WindowerSpec.WindowFn" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/execinfrapb/processors_sql.proto:752:12:Field name "partitionBy" must be lower_snake_case.
pkg/sql/execinfrapb/processors_sql.proto:754:12:Field name "windowFns" must be lower_snake_case.
pkg/sql/execinfrapb/processors_table_stats.proto:15:1:Syntax should be proto3 but was "proto2".
pkg/sql/execinfrapb/processors_table_stats.proto:19:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.distsqlrun".
pkg/sql/execinfrapb/processors_table_stats.proto:20:1:Expected "distsqlrunpb" for option "go_package" but was "execinfrapb".
pkg/sql/execinfrapb/processors_table_stats.proto:25:1:Enum "SketchType" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/execinfrapb/processors_table_stats.proto:29:3:Enum field "HLL_PLUS_PLUS_V1" is expected to have the prefix "SKETCH_TYPE_".
pkg/sql/execinfrapb/processors_table_stats.proto:29:3:Zero value enum field "HLL_PLUS_PLUS_V1" is expected to have the name "SKETCH_TYPE_INVALID".
pkg/sql/execinfrapb/processors_table_stats.proto:133:3:"SampleAggregatorSpec" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/flowinfra/stats.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.distsqlrun".
pkg/sql/flowinfra/stats.proto:13:1:Expected "distsqlrunpb" for option "go_package" but was "flowinfra".
pkg/sql/pgwire/pgerror/errors.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.pgerror".
pkg/sql/pgwire/pgerror/errors.proto:13:1:Expected "pgerrorpb" for option "go_package" but was "pgerror".
pkg/sql/pgwire/pgerror/errors.proto:27:3:Message "Source" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/pgwire/pgerror/errors.proto:53:3:Message "SafeDetail" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/rowexec/stats.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.distsqlrun".
pkg/sql/rowexec/stats.proto:13:1:Expected "distsqlrunpb" for option "go_package" but was "rowexec".
pkg/sql/rowexec/stats.proto:23:3:Field "stall_time" of type "google.protobuf.Duration" must be "duration" or end in "_duration".
pkg/sql/rowexec/stats.proto:37:3:"JoinReaderStats" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/rowflow/stats.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.distsqlrun".
pkg/sql/rowflow/stats.proto:13:1:Expected "distsqlrunpb" for option "go_package" but was "rowflow".
pkg/sql/sqlbase/encoded_datum.proto:14:1:Syntax should be proto3 but was "proto2".
pkg/sql/sqlbase/encoded_datum.proto:15:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.sqlbase".
pkg/sql/sqlbase/encoded_datum.proto:16:1:Expected "sqlbasepb" for option "go_package" but was "sqlbase".
pkg/sql/sqlbase/encoded_datum.proto:24:5:Enum field "ASCENDING_KEY" is expected to have the prefix "DATUM_ENCODING_".
pkg/sql/sqlbase/encoded_datum.proto:24:5:Zero value enum field "ASCENDING_KEY" is expected to have the name "DATUM_ENCODING_INVALID".
pkg/sql/sqlbase/encoded_datum.proto:27:5:Enum field "DESCENDING_KEY" is expected to have the prefix "DATUM_ENCODING_".
pkg/sql/sqlbase/encoded_datum.proto:29:5:Enum field "VALUE" is expected to have the prefix "DATUM_ENCODING_".
pkg/sql/sqlbase/join_type.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/sql/sqlbase/join_type.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.sqlbase".
pkg/sql/sqlbase/join_type.proto:13:1:Expected "sqlbasepb" for option "go_package" but was "sqlbase".
pkg/sql/sqlbase/join_type.proto:18:3:Enum field "INNER" is expected to have the prefix "JOIN_TYPE_".
pkg/sql/sqlbase/join_type.proto:18:3:Zero value enum field "INNER" is expected to have the name "JOIN_TYPE_INVALID".
pkg/sql/sqlbase/join_type.proto:19:3:Enum field "LEFT_OUTER" is expected to have the prefix "JOIN_TYPE_".
pkg/sql/sqlbase/join_type.proto:20:3:Enum field "RIGHT_OUTER" is expected to have the prefix "JOIN_TYPE_".
pkg/sql/sqlbase/join_type.proto:21:3:Enum field "FULL_OUTER" is expected to have the prefix "JOIN_TYPE_".
pkg/sql/sqlbase/join_type.proto:25:3:Enum field "LEFT_SEMI" is expected to have the prefix "JOIN_TYPE_".
pkg/sql/sqlbase/join_type.proto:30:3:Enum field "LEFT_ANTI" is expected to have the prefix "JOIN_TYPE_".
pkg/sql/sqlbase/join_type.proto:51:3:Enum field "INTERSECT_ALL" is expected to have the prefix "JOIN_TYPE_".
pkg/sql/sqlbase/join_type.proto:77:3:Enum field "EXCEPT_ALL" is expected to have the prefix "JOIN_TYPE_".
pkg/sql/sqlbase/locking.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/sql/sqlbase/locking.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.sqlbase".
pkg/sql/sqlbase/locking.proto:13:1:Expected "sqlbasepb" for option "go_package" but was "sqlbase".
pkg/sql/sqlbase/locking.proto:57:3:Enum field "FOR_NONE" is expected to have the prefix "SCAN_LOCKING_STRENGTH_".
pkg/sql/sqlbase/locking.proto:57:3:Zero value enum field "FOR_NONE" is expected to have the name "SCAN_LOCKING_STRENGTH_INVALID".
pkg/sql/sqlbase/locking.proto:74:3:Enum field "FOR_KEY_SHARE" is expected to have the prefix "SCAN_LOCKING_STRENGTH_".
pkg/sql/sqlbase/locking.proto:85:3:Enum field "FOR_SHARE" is expected to have the prefix "SCAN_LOCKING_STRENGTH_".
pkg/sql/sqlbase/locking.proto:100:3:Enum field "FOR_NO_KEY_UPDATE" is expected to have the prefix "SCAN_LOCKING_STRENGTH_".
pkg/sql/sqlbase/locking.proto:116:3:Enum field "FOR_UPDATE" is expected to have the prefix "SCAN_LOCKING_STRENGTH_".
pkg/sql/sqlbase/locking.proto:123:3:Enum field "BLOCK" is expected to have the prefix "SCAN_LOCKING_WAIT_POLICY_".
pkg/sql/sqlbase/locking.proto:123:3:Zero value enum field "BLOCK" is expected to have the name "SCAN_LOCKING_WAIT_POLICY_INVALID".
pkg/sql/sqlbase/locking.proto:129:3:Enum field "SKIP" is expected to have the prefix "SCAN_LOCKING_WAIT_POLICY_".
pkg/sql/sqlbase/locking.proto:135:3:Enum field "ERROR" is expected to have the prefix "SCAN_LOCKING_WAIT_POLICY_".
pkg/sql/sqlbase/privilege.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/sql/sqlbase/privilege.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.sqlbase".
pkg/sql/sqlbase/privilege.proto:13:1:Expected "sqlbasepb" for option "go_package" but was "sqlbase".
pkg/sql/sqlbase/structured.proto:12:1:Syntax should be proto3 but was "proto2".
pkg/sql/sqlbase/structured.proto:13:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.sqlbase".
pkg/sql/sqlbase/structured.proto:14:1:Expected "sqlbasepb" for option "go_package" but was "sqlbase".
pkg/sql/sqlbase/structured.proto:20:1:Enum "ConstraintValidity" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/sqlbase/structured.proto:22:3:Field name "Validated" must be UPPER_SNAKE_CASE.
pkg/sql/sqlbase/structured.proto:22:3:Enum field "Validated" is expected to have the prefix "CONSTRAINT_VALIDITY_".
pkg/sql/sqlbase/structured.proto:22:3:Zero value enum field "Validated" is expected to have the name "CONSTRAINT_VALIDITY_INVALID".
pkg/sql/sqlbase/structured.proto:25:3:Field name "Unvalidated" must be UPPER_SNAKE_CASE.
pkg/sql/sqlbase/structured.proto:25:3:Enum field "Unvalidated" is expected to have the prefix "CONSTRAINT_VALIDITY_".
pkg/sql/sqlbase/structured.proto:28:3:Field name "Validating" must be UPPER_SNAKE_CASE.
pkg/sql/sqlbase/structured.proto:28:3:Enum field "Validating" is expected to have the prefix "CONSTRAINT_VALIDITY_".
pkg/sql/sqlbase/structured.proto:30:3:Field name "Dropping" must be UPPER_SNAKE_CASE.
pkg/sql/sqlbase/structured.proto:30:3:Enum field "Dropping" is expected to have the prefix "CONSTRAINT_VALIDITY_".
pkg/sql/sqlbase/structured.proto:33:1:Message "ForeignKeyReference" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/sqlbase/structured.proto:35:3:Enum "Action" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/sqlbase/structured.proto:37:5:Enum field "NO_ACTION" is expected to have the prefix "ACTION_".
pkg/sql/sqlbase/structured.proto:37:5:Zero value enum field "NO_ACTION" is expected to have the name "ACTION_INVALID".
pkg/sql/sqlbase/structured.proto:38:5:Enum field "RESTRICT" is expected to have the prefix "ACTION_".
pkg/sql/sqlbase/structured.proto:39:5:Enum field "SET_NULL" is expected to have the prefix "ACTION_".
pkg/sql/sqlbase/structured.proto:40:5:Enum field "SET_DEFAULT" is expected to have the prefix "ACTION_".
pkg/sql/sqlbase/structured.proto:41:5:Enum field "CASCADE" is expected to have the prefix "ACTION_".
pkg/sql/sqlbase/structured.proto:47:5:Enum field "SIMPLE" is expected to have the prefix "MATCH_".
pkg/sql/sqlbase/structured.proto:47:5:Zero value enum field "SIMPLE" is expected to have the name "MATCH_INVALID".
pkg/sql/sqlbase/structured.proto:48:5:Enum field "FULL" is expected to have the prefix "MATCH_".
pkg/sql/sqlbase/structured.proto:49:5:Enum field "PARTIAL" is expected to have the prefix "MATCH_".
pkg/sql/sqlbase/structured.proto:49:18:Inline comments are not allowed on enum values, only comment above the type.
pkg/sql/sqlbase/structured.proto:108:3:"ForeignKeyConstraint" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/sqlbase/structured.proto:111:1:Message "ColumnDescriptor" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/sqlbase/structured.proto:118:3:"ColumnDescriptor" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/sqlbase/structured.proto:122:3:"ColumnDescriptor" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/sqlbase/structured.proto:124:3:"ColumnDescriptor" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/sqlbase/structured.proto:179:3:Message "Ancestor" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/sqlbase/structured.proto:332:5:Enum field "ASC" is expected to have the prefix "DIRECTION_".
pkg/sql/sqlbase/structured.proto:332:5:Zero value enum field "ASC" is expected to have the name "DIRECTION_INVALID".
pkg/sql/sqlbase/structured.proto:333:5:Enum field "DESC" is expected to have the prefix "DIRECTION_".
pkg/sql/sqlbase/structured.proto:338:5:Enum field "FORWARD" is expected to have the prefix "TYPE_".
pkg/sql/sqlbase/structured.proto:338:5:Zero value enum field "FORWARD" is expected to have the name "TYPE_INVALID".
pkg/sql/sqlbase/structured.proto:339:5:Enum field "INVERTED" is expected to have the prefix "TYPE_".
pkg/sql/sqlbase/structured.proto:453:3:Enum "ConstraintType" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/sqlbase/structured.proto:454:5:Enum field "CHECK" is expected to have the prefix "CONSTRAINT_TYPE_".
pkg/sql/sqlbase/structured.proto:454:5:Zero value enum field "CHECK" is expected to have the name "CONSTRAINT_TYPE_INVALID".
pkg/sql/sqlbase/structured.proto:455:5:Enum field "FOREIGN_KEY" is expected to have the prefix "CONSTRAINT_TYPE_".
pkg/sql/sqlbase/structured.proto:460:5:Enum field "NOT_NULL" is expected to have the prefix "CONSTRAINT_TYPE_".
pkg/sql/sqlbase/structured.proto:467:3:"ConstraintToUpdate" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/sqlbase/structured.proto:500:5:Field name "primaryKeySwap" must be lower_snake_case.
pkg/sql/sqlbase/structured.proto:507:5:Enum field "UNKNOWN" is expected to have the prefix "STATE_".
pkg/sql/sqlbase/structured.proto:507:5:Zero value enum field "UNKNOWN" is expected to have the name "STATE_INVALID".
pkg/sql/sqlbase/structured.proto:519:5:Enum field "DELETE_ONLY" is expected to have the prefix "STATE_".
pkg/sql/sqlbase/structured.proto:531:5:Enum field "DELETE_AND_WRITE_ONLY" is expected to have the prefix "STATE_".
pkg/sql/sqlbase/structured.proto:538:5:Enum field "NONE" is expected to have the prefix "DIRECTION_".
pkg/sql/sqlbase/structured.proto:538:5:Zero value enum field "NONE" is expected to have the name "DIRECTION_INVALID".
pkg/sql/sqlbase/structured.proto:540:5:Enum field "ADD" is expected to have the prefix "DIRECTION_".
pkg/sql/sqlbase/structured.proto:542:5:Enum field "DROP" is expected to have the prefix "DIRECTION_".
pkg/sql/sqlbase/structured.proto:552:3:"DescriptorMutation" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/sqlbase/structured.proto:599:3:"TableDescriptor" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/sqlbase/structured.proto:654:3:"TableDescriptor" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/sqlbase/structured.proto:663:5:Enum field "PUBLIC" is expected to have the prefix "STATE_".
pkg/sql/sqlbase/structured.proto:663:5:Zero value enum field "PUBLIC" is expected to have the name "STATE_INVALID".
pkg/sql/sqlbase/structured.proto:665:5:Enum field "ADD" is expected to have the prefix "STATE_".
pkg/sql/sqlbase/structured.proto:667:5:Enum field "DROP" is expected to have the prefix "STATE_".
pkg/sql/sqlbase/structured.proto:669:5:Enum field "OFFLINE" is expected to have the prefix "STATE_".
pkg/sql/sqlbase/structured.proto:674:3:Message "CheckConstraint" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/sqlbase/structured.proto:679:5:"TableDescriptor.CheckConstraint" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/sqlbase/structured.proto:794:12:Field name "dependsOn" must be lower_snake_case.
pkg/sql/sqlbase/structured.proto:797:3:Message "Reference" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/sqlbase/structured.proto:815:12:Field name "dependedOnBy" must be lower_snake_case.
pkg/sql/sqlbase/structured.proto:818:3:Message "MutationJob" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/sqlbase/structured.proto:832:12:Field name "mutationJobs" must be lower_snake_case.
pkg/sql/sqlbase/structured.proto:834:3:Message "SequenceOpts" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/sqlbase/structured.proto:847:5:Message "SequenceOwner" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/sqlbase/structured.proto:874:3:Message "Replacement" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/sqlbase/structured.proto:894:5:Enum field "DISABLED" is expected to have the prefix "AUDIT_MODE_".
pkg/sql/sqlbase/structured.proto:894:5:Zero value enum field "DISABLED" is expected to have the name "AUDIT_MODE_INVALID".
pkg/sql/sqlbase/structured.proto:895:5:Enum field "READWRITE" is expected to have the prefix "AUDIT_MODE_".
pkg/sql/sqlbase/structured.proto:903:3:Message "GCDescriptorMutation" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/sqlbase/structured.proto:956:1:The name "DatabaseDescriptor" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/sql/sqlbase/structured.proto:972:5:The name "database" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/sql/stats/histogram.proto:16:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.stats".
pkg/sql/stats/histogram.proto:17:1:Expected "statspb" for option "go_package" but was "stats".
pkg/sql/stats/histogram.proto:23:1:The name "HistogramData" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/sql/stats/histogram.proto:24:3:Message "Bucket" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/sql/stats/table_statistic.proto:16:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.stats".
pkg/sql/stats/table_statistic.proto:17:1:Expected "statspb" for option "go_package" but was "stats".
pkg/sql/stats/table_statistic.proto:41:3:Field "created_at" of type "google.protobuf.Timestamp" must be "time" or end in "_time".
pkg/sql/stats/table_statistic.proto:49:3:The name "histogram_data" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/sql/types/types.proto:12:1:Syntax should be proto3 but was "proto2".
pkg/sql/types/types.proto:13:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.sql.sem.types".
pkg/sql/types/types.proto:14:1:Expected "typespb" for option "go_package" but was "types".
pkg/sql/types/types.proto:30:5:Field name "BoolFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:30:5:Enum field "BoolFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:30:5:Zero value enum field "BoolFamily" is expected to have the name "FAMILY_INVALID".
pkg/sql/types/types.proto:43:5:Field name "IntFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:43:5:Enum field "IntFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:55:5:Field name "FloatFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:55:5:Enum field "FloatFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:69:5:Field name "DecimalFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:69:5:Enum field "DecimalFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:80:5:Field name "DateFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:80:5:Enum field "DateFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:96:5:Field name "TimestampFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:96:5:Enum field "TimestampFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:107:5:Field name "IntervalFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:107:5:Enum field "IntervalFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:126:5:Field name "StringFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:126:5:Enum field "StringFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:136:5:Field name "BytesFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:136:5:Enum field "BytesFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:151:5:Field name "TimestampTZFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:151:5:Enum field "TimestampTZFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:166:5:Field name "CollatedStringFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:166:5:Enum field "CollatedStringFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:169:5:"Family" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/types/types.proto:186:5:Field name "OidFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:186:5:Enum field "OidFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:197:5:Field name "UnknownFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:197:5:Enum field "UnknownFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:210:5:Field name "UuidFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:210:5:Enum field "UuidFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:210:5:The name "UuidFamily" contains the outlawed name "uuid". UUIDs in Protobuf are named ID instead of UUID..
pkg/sql/types/types.proto:238:5:Field name "ArrayFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:238:5:Enum field "ArrayFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:249:5:Field name "INetFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:249:5:Enum field "INetFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:264:5:Field name "TimeFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:264:5:Enum field "TimeFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:277:5:Field name "JsonFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:277:5:Enum field "JsonFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:291:5:Field name "TimeTZFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:291:5:Enum field "TimeTZFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:309:5:Field name "TupleFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:309:5:Enum field "TupleFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:325:5:Field name "BitFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:325:5:Enum field "BitFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:336:5:Field name "AnyFamily" must be UPPER_SNAKE_CASE.
pkg/sql/types/types.proto:336:5:Enum field "AnyFamily" is expected to have the prefix "FAMILY_".
pkg/sql/types/types.proto:339:5:"Family" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/types/types.proto:342:5:"Family" cannot have reserved field numbers, use the deprecated field option instead.
pkg/sql/types/types.proto:351:3:Enum field "UNSET" is expected to have the prefix "INTERVAL_DURATION_TYPE_".
pkg/sql/types/types.proto:351:3:Zero value enum field "UNSET" is expected to have the name "INTERVAL_DURATION_TYPE_INVALID".
pkg/sql/types/types.proto:353:3:Enum field "YEAR" is expected to have the prefix "INTERVAL_DURATION_TYPE_".
pkg/sql/types/types.proto:354:3:Enum field "MONTH" is expected to have the prefix "INTERVAL_DURATION_TYPE_".
pkg/sql/types/types.proto:355:3:Enum field "DAY" is expected to have the prefix "INTERVAL_DURATION_TYPE_".
pkg/sql/types/types.proto:356:3:Enum field "HOUR" is expected to have the prefix "INTERVAL_DURATION_TYPE_".
pkg/sql/types/types.proto:357:3:Enum field "MINUTE" is expected to have the prefix "INTERVAL_DURATION_TYPE_".
pkg/sql/types/types.proto:359:3:Enum field "SECOND" is expected to have the prefix "INTERVAL_DURATION_TYPE_".
pkg/sql/types/types.proto:365:3:Enum field "MILLISECOND" is expected to have the prefix "INTERVAL_DURATION_TYPE_".
pkg/sqlmigrations/leasemanager/lease.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/sqlmigrations/leasemanager/lease.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.client".
pkg/sqlmigrations/leasemanager/lease.proto:13:1:Expected "clientpb" for option "go_package" but was "leasemanager".
pkg/sqlmigrations/leasemanager/lease.proto:18:1:Message "LeaseVal" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/storage/enginepb/engine.proto:1:1:File option "go_package" set in some files in directory but not in others.
pkg/storage/enginepb/engine.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.storage.enginepb".
pkg/storage/enginepb/engine.proto:13:1:Expected "enginepbpb" for option "go_package" but was "enginepb".
pkg/storage/enginepb/engine.proto:25:3:Field name "EngineTypeDefault" must be UPPER_SNAKE_CASE.
pkg/storage/enginepb/engine.proto:25:3:Enum field "EngineTypeDefault" is expected to have the prefix "ENGINE_TYPE_".
pkg/storage/enginepb/engine.proto:25:3:Zero value enum field "EngineTypeDefault" is expected to have the name "ENGINE_TYPE_INVALID".
pkg/storage/enginepb/engine.proto:27:3:Field name "EngineTypeRocksDB" must be UPPER_SNAKE_CASE.
pkg/storage/enginepb/engine.proto:27:3:Enum field "EngineTypeRocksDB" is expected to have the prefix "ENGINE_TYPE_".
pkg/storage/enginepb/engine.proto:29:3:Field name "EngineTypePebble" must be UPPER_SNAKE_CASE.
pkg/storage/enginepb/engine.proto:29:3:Enum field "EngineTypePebble" is expected to have the prefix "ENGINE_TYPE_".
pkg/storage/enginepb/engine.proto:32:3:Field name "EngineTypeTeePebbleRocksDB" must be UPPER_SNAKE_CASE.
pkg/storage/enginepb/engine.proto:32:3:Enum field "EngineTypeTeePebbleRocksDB" is expected to have the prefix "ENGINE_TYPE_".
pkg/storage/enginepb/file_registry.proto:1:1:File option "go_package" set in some files in directory but not in others.
pkg/storage/enginepb/file_registry.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.storage.enginepb".
pkg/storage/enginepb/file_registry.proto:13:1:Expected "enginepbpb" for option "go_package" but was "enginepb".
pkg/storage/enginepb/file_registry.proto:17:1:Enum "RegistryVersion" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/storage/enginepb/file_registry.proto:19:3:Field name "Base" must be UPPER_SNAKE_CASE.
pkg/storage/enginepb/file_registry.proto:19:3:Enum field "Base" is expected to have the prefix "REGISTRY_VERSION_".
pkg/storage/enginepb/file_registry.proto:19:3:Zero value enum field "Base" is expected to have the name "REGISTRY_VERSION_INVALID".
pkg/storage/enginepb/file_registry.proto:26:3:Field name "Plaintext" must be UPPER_SNAKE_CASE.
pkg/storage/enginepb/file_registry.proto:26:3:Enum field "Plaintext" is expected to have the prefix "ENV_TYPE_".
pkg/storage/enginepb/file_registry.proto:26:3:Zero value enum field "Plaintext" is expected to have the name "ENV_TYPE_INVALID".
pkg/storage/enginepb/file_registry.proto:29:3:Field name "Store" must be UPPER_SNAKE_CASE.
pkg/storage/enginepb/file_registry.proto:29:3:Enum field "Store" is expected to have the prefix "ENV_TYPE_".
pkg/storage/enginepb/file_registry.proto:32:3:Field name "Data" must be UPPER_SNAKE_CASE.
pkg/storage/enginepb/file_registry.proto:32:3:Enum field "Data" is expected to have the prefix "ENV_TYPE_".
pkg/storage/enginepb/file_registry.proto:32:3:The name "Data" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/storage/enginepb/file_registry.proto:47:1:Message "FileEntry" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/storage/enginepb/mvcc.proto:1:1:File option "go_package" set in some files in directory but not in others.
pkg/storage/enginepb/mvcc.proto:12:1:Syntax should be proto3 but was "proto2".
pkg/storage/enginepb/mvcc.proto:13:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.storage.enginepb".
pkg/storage/enginepb/mvcc.proto:14:1:Expected "enginepbpb" for option "go_package" but was "enginepb".
pkg/storage/enginepb/mvcc.proto:23:1:The name "MVCCMetadata" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/storage/enginepb/mvcc.proto:86:1:The name "MVCCMetadataSubsetForMergeSerialization" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/storage/enginepb/mvcc3.proto:1:1:File option "go_package" set in some files in directory but not in others.
pkg/storage/enginepb/mvcc3.proto:1:1:File option "go_package" is required.
pkg/storage/enginepb/mvcc3.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.storage.enginepb".
pkg/storage/enginepb/mvcc3.proto:28:3:"TxnMeta" cannot have reserved field numbers, use the deprecated field option instead.
pkg/storage/enginepb/mvcc3.proto:33:18:Inline comments are not allowed on fields, only comment above the type.
pkg/storage/enginepb/mvcc3.proto:116:3:"TxnMeta" cannot have reserved field numbers, use the deprecated field option instead.
pkg/storage/enginepb/mvcc3.proto:158:34:Inline comments are not allowed on fields, only comment above the type.
pkg/storage/enginepb/rocksdb.proto:1:1:File option "go_package" set in some files in directory but not in others.
pkg/storage/enginepb/rocksdb.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.storage.enginepb".
pkg/storage/enginepb/rocksdb.proto:13:1:Expected "enginepbpb" for option "go_package" but was "enginepb".
pkg/storage/enginepb/rocksdb.proto:36:1:The name "HistogramData" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/ts/catalog/chart_catalog.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/ts/catalog/chart_catalog.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.ts.catalog".
pkg/ts/catalog/chart_catalog.proto:13:1:Expected "catalogpb" for option "go_package" but was "catalog".
pkg/ts/catalog/chart_catalog.proto:25:3:Enum field "UNSET_UNITS" is expected to have the prefix "AXIS_UNITS_".
pkg/ts/catalog/chart_catalog.proto:25:3:Zero value enum field "UNSET_UNITS" is expected to have the name "AXIS_UNITS_INVALID".
pkg/ts/catalog/chart_catalog.proto:27:3:Enum field "COUNT" is expected to have the prefix "AXIS_UNITS_".
pkg/ts/catalog/chart_catalog.proto:29:3:Enum field "BYTES" is expected to have the prefix "AXIS_UNITS_".
pkg/ts/catalog/chart_catalog.proto:31:3:Enum field "DURATION" is expected to have the prefix "AXIS_UNITS_".
pkg/ts/catalog/chart_catalog.proto:39:3:Enum field "UNSET_AGG" is expected to have the prefix "DESCRIBE_AGGREGATOR_".
pkg/ts/catalog/chart_catalog.proto:39:3:Zero value enum field "UNSET_AGG" is expected to have the name "DESCRIBE_AGGREGATOR_INVALID".
pkg/ts/catalog/chart_catalog.proto:41:3:Enum field "AVG" is expected to have the prefix "DESCRIBE_AGGREGATOR_".
pkg/ts/catalog/chart_catalog.proto:43:3:Enum field "SUM" is expected to have the prefix "DESCRIBE_AGGREGATOR_".
pkg/ts/catalog/chart_catalog.proto:45:3:Enum field "MAX" is expected to have the prefix "DESCRIBE_AGGREGATOR_".
pkg/ts/catalog/chart_catalog.proto:47:3:Enum field "MIN" is expected to have the prefix "DESCRIBE_AGGREGATOR_".
pkg/ts/catalog/chart_catalog.proto:56:3:Enum field "UNSET_DER" is expected to have the prefix "DESCRIBE_DERIVATIVE_".
pkg/ts/catalog/chart_catalog.proto:56:3:Zero value enum field "UNSET_DER" is expected to have the name "DESCRIBE_DERIVATIVE_INVALID".
pkg/ts/catalog/chart_catalog.proto:58:3:Enum field "NONE" is expected to have the prefix "DESCRIBE_DERIVATIVE_".
pkg/ts/catalog/chart_catalog.proto:60:3:Enum field "DERIVATIVE" is expected to have the prefix "DESCRIBE_DERIVATIVE_".
pkg/ts/catalog/chart_catalog.proto:64:3:Enum field "NON_NEGATIVE_DERIVATIVE" is expected to have the prefix "DESCRIBE_DERIVATIVE_".
pkg/ts/catalog/chart_catalog.proto:75:12:Field name "axisLabel" must be lower_snake_case.
pkg/ts/catalog/chart_catalog.proto:78:12:Field name "preferredUnits" must be lower_snake_case.
pkg/ts/catalog/chart_catalog.proto:82:12:Field name "metricType" must be lower_snake_case.
pkg/ts/catalog/chart_catalog.proto:92:12:Field name "longTitle" must be lower_snake_case.
pkg/ts/catalog/chart_catalog.proto:94:12:Field name "collectionTitle" must be lower_snake_case.
pkg/ts/catalog/chart_catalog.proto:104:12:Field name "axisLabel" must be lower_snake_case.
pkg/ts/catalog/chart_catalog.proto:118:12:Field name "longTitle" must be lower_snake_case.
pkg/ts/catalog/chart_catalog.proto:120:12:Field name "collectionTitle" must be lower_snake_case.
pkg/ts/tspb/timeseries.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/ts/tspb/timeseries.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.ts.tspb".
pkg/ts/tspb/timeseries.proto:13:1:Expected "tspbpb" for option "go_package" but was "tspb".
pkg/ts/tspb/timeseries.proto:20:1:The name "TimeSeriesDatapoint" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/ts/tspb/timeseries.proto:20:1:Message "TimeSeriesDatapoint" is not a request or response of any service in this file and should be in a separate file.
pkg/ts/tspb/timeseries.proto:32:1:The name "TimeSeriesData" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/ts/tspb/timeseries.proto:32:1:Message "TimeSeriesData" is a response for RPC "Dump" and should be defined in the file after the RPC.
pkg/ts/tspb/timeseries.proto:32:1:Message "TimeSeriesData" is a response for RPC "Dump" and should be defined in the file after the request "DumpRequest".
pkg/ts/tspb/timeseries.proto:39:12:The name "datapoints" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/ts/tspb/timeseries.proto:49:1:Enum "TimeSeriesQueryAggregator" is in the same file as a service and should be in a separate file.
pkg/ts/tspb/timeseries.proto:51:3:Enum field "AVG" is expected to have the prefix "TIME_SERIES_QUERY_AGGREGATOR_".
pkg/ts/tspb/timeseries.proto:53:3:Enum field "SUM" is expected to have the prefix "TIME_SERIES_QUERY_AGGREGATOR_".
pkg/ts/tspb/timeseries.proto:55:3:Enum field "MAX" is expected to have the prefix "TIME_SERIES_QUERY_AGGREGATOR_".
pkg/ts/tspb/timeseries.proto:57:3:Enum field "MIN" is expected to have the prefix "TIME_SERIES_QUERY_AGGREGATOR_".
pkg/ts/tspb/timeseries.proto:61:3:Enum field "FIRST" is expected to have the prefix "TIME_SERIES_QUERY_AGGREGATOR_".
pkg/ts/tspb/timeseries.proto:65:3:Enum field "LAST" is expected to have the prefix "TIME_SERIES_QUERY_AGGREGATOR_".
pkg/ts/tspb/timeseries.proto:67:3:Enum field "VARIANCE" is expected to have the prefix "TIME_SERIES_QUERY_AGGREGATOR_".
pkg/ts/tspb/timeseries.proto:72:1:Enum "TimeSeriesQueryDerivative" is in the same file as a service and should be in a separate file.
pkg/ts/tspb/timeseries.proto:74:3:Enum field "NONE" is expected to have the prefix "TIME_SERIES_QUERY_DERIVATIVE_".
pkg/ts/tspb/timeseries.proto:74:3:Zero value enum field "NONE" is expected to have the name "TIME_SERIES_QUERY_DERIVATIVE_INVALID".
pkg/ts/tspb/timeseries.proto:76:3:Enum field "DERIVATIVE" is expected to have the prefix "TIME_SERIES_QUERY_DERIVATIVE_".
pkg/ts/tspb/timeseries.proto:80:3:Enum field "NON_NEGATIVE_DERIVATIVE" is expected to have the prefix "TIME_SERIES_QUERY_DERIVATIVE_".
pkg/ts/tspb/timeseries.proto:85:1:Message "Query" is not a request or response of any service in this file and should be in a separate file.
pkg/ts/tspb/timeseries.proto:106:1:Message "TimeSeriesQueryRequest" is a request for RPC "Query" and should be defined in the file after the RPC.
pkg/ts/tspb/timeseries.proto:124:1:Message "TimeSeriesQueryResponse" is a response for RPC "Query" and should be defined in the file after the RPC.
pkg/ts/tspb/timeseries.proto:128:14:The name "datapoints" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/ts/tspb/timeseries.proto:137:1:Message "DumpRequest" is a request for RPC "Dump" and should be defined in the file after the RPC.
pkg/ts/tspb/timeseries.proto:141:1:Service name "TimeSeries" must end with "API".
pkg/ts/tspb/timeseries.proto:141:1:Expected filename to be "time_series.proto" for file containing service "TimeSeries" but was "timeseries.proto".
pkg/ts/tspb/timeseries.proto:143:3:Name of request type "TimeSeriesQueryRequest" should be "QueryRequest".
pkg/ts/tspb/timeseries.proto:143:3:Name of response type "TimeSeriesQueryResponse" should be "QueryResponse".
pkg/ts/tspb/timeseries.proto:143:3:RPC "Query" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ts/tspb/timeseries.proto:154:3:Name of response type "TimeSeriesData" should be "DumpResponse".
pkg/ui/node_modules/protobufjs/google/api/annotations.proto:1:1:File option "go_package" is required.
pkg/ui/node_modules/protobufjs/google/api/annotations.proto:3:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "google.api".
pkg/ui/node_modules/protobufjs/google/protobuf/api.proto:1:1:File option "go_package" is required.
pkg/ui/node_modules/protobufjs/google/protobuf/api.proto:3:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "google.protobuf".
pkg/ui/node_modules/protobufjs/google/protobuf/api.proto:8:1:Message "Api" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/api.proto:19:1:Message "Method" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/api.proto:30:1:Message "Mixin" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:1:1:File option "go_package" is required.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:1:1:Syntax should be proto3 but was "proto2".
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:3:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "google.protobuf".
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:5:1:Message "FileDescriptorSet" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:10:1:Message "FileDescriptorProto" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:26:1:Message "DescriptorProto" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:39:5:Message "ExtensionRange" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:45:5:Message "ReservedRange" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:52:1:Message "FieldDescriptorProto" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:65:5:Enum "Type" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:87:5:Enum "Label" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:95:1:Message "OneofDescriptorProto" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:101:1:Message "EnumDescriptorProto" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:108:1:Message "EnumValueDescriptorProto" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:115:1:Message "ServiceDescriptorProto" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:122:1:Message "MethodDescriptorProto" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:132:1:Message "FileOptions" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:150:5:Enum "OptimizeMode" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:152:9:Enum field "SPEED" is expected to have the prefix "OPTIMIZE_MODE_".
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:153:9:Enum field "CODE_SIZE" is expected to have the prefix "OPTIMIZE_MODE_".
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:154:9:Enum field "LITE_RUNTIME" is expected to have the prefix "OPTIMIZE_MODE_".
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:159:5:"FileOptions" cannot have reserved field numbers, use the deprecated field option instead.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:162:1:Message "MessageOptions" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:172:5:"MessageOptions" cannot have reserved field numbers, use the deprecated field option instead.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:175:1:Message "FieldOptions" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:185:5:Enum "CType" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:187:9:Enum field "STRING" is expected to have the prefix "C_TYPE_".
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:187:9:Zero value enum field "STRING" is expected to have the name "C_TYPE_INVALID".
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:188:9:Enum field "CORD" is expected to have the prefix "C_TYPE_".
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:189:9:Enum field "STRING_PIECE" is expected to have the prefix "C_TYPE_".
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:192:5:Enum "JSType" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:194:9:Enum field "JS_NORMAL" is expected to have the prefix "JS_TYPE_".
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:194:9:Zero value enum field "JS_NORMAL" is expected to have the name "JS_TYPE_INVALID".
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:195:9:Enum field "JS_STRING" is expected to have the prefix "JS_TYPE_".
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:196:9:Enum field "JS_NUMBER" is expected to have the prefix "JS_TYPE_".
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:201:5:"FieldOptions" cannot have reserved field numbers, use the deprecated field option instead.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:204:1:Message "OneofOptions" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:211:1:Message "EnumOptions" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:220:1:Message "EnumValueOptions" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:228:1:Message "ServiceOptions" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:236:1:Message "MethodOptions" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:244:1:Message "UninterpretedOption" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:254:5:Message "NamePart" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:261:1:Message "SourceCodeInfo" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:265:5:Message "Location" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:275:1:Message "GeneratedCodeInfo" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/descriptor.proto:279:5:Message "Annotation" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/ui/node_modules/protobufjs/google/protobuf/field_mask.proto:1:1:File option "go_package" is required.
pkg/ui/node_modules/protobufjs/google/protobuf/field_mask.proto:3:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "google.protobuf".
pkg/ui/node_modules/protobufjs/google/protobuf/field_mask.proto:5:1:Message "FieldMask" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/util/hlc/legacy_timestamp.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/util/hlc/legacy_timestamp.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.util.hlc".
pkg/util/hlc/legacy_timestamp.proto:13:1:Expected "hlcpb" for option "go_package" but was "hlc".
pkg/util/hlc/timestamp.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.util.hlc".
pkg/util/hlc/timestamp.proto:13:1:Expected "hlcpb" for option "go_package" but was "hlc".
pkg/util/log/log.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.util.log".
pkg/util/log/log.proto:13:1:Expected "logpb" for option "go_package" but was "log".
pkg/util/log/log.proto:17:1:Enum "Severity" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/util/log/log.proto:18:3:Enum field "UNKNOWN" is expected to have the prefix "SEVERITY_".
pkg/util/log/log.proto:18:3:Zero value enum field "UNKNOWN" is expected to have the name "SEVERITY_INVALID".
pkg/util/log/log.proto:19:3:Enum field "INFO" is expected to have the prefix "SEVERITY_".
pkg/util/log/log.proto:20:3:Enum field "WARNING" is expected to have the prefix "SEVERITY_".
pkg/util/log/log.proto:21:3:Enum field "ERROR" is expected to have the prefix "SEVERITY_".
pkg/util/log/log.proto:22:3:Enum field "FATAL" is expected to have the prefix "SEVERITY_".
pkg/util/log/log.proto:25:3:Enum field "NONE" is expected to have the prefix "SEVERITY_".
pkg/util/log/log.proto:30:3:Enum field "DEFAULT" is expected to have the prefix "SEVERITY_".
pkg/util/log/log.proto:50:3:"FileDetails" cannot have reserved field numbers, use the deprecated field option instead.
pkg/util/log/log.proto:55:1:Message "FileInfo" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/util/metric/metric.proto:12:1:Syntax should be proto3 but was "proto2".
pkg/util/metric/metric.proto:13:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.util.metric".
pkg/util/metric/metric.proto:14:1:Expected "metricpb" for option "go_package" but was "metric".
pkg/util/metric/metric.proto:25:1:Message "LabelPair" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/util/metric/metric.proto:33:3:Enum field "UNSET" is expected to have the prefix "UNIT_".
pkg/util/metric/metric.proto:33:3:Zero value enum field "UNSET" is expected to have the name "UNIT_INVALID".
pkg/util/metric/metric.proto:35:3:Enum field "BYTES" is expected to have the prefix "UNIT_".
pkg/util/metric/metric.proto:37:3:Enum field "CONST" is expected to have the prefix "UNIT_".
pkg/util/metric/metric.proto:39:3:Enum field "COUNT" is expected to have the prefix "UNIT_".
pkg/util/metric/metric.proto:41:3:Enum field "NANOSECONDS" is expected to have the prefix "UNIT_".
pkg/util/metric/metric.proto:43:3:Enum field "PERCENT" is expected to have the prefix "UNIT_".
pkg/util/metric/metric.proto:45:3:Enum field "SECONDS" is expected to have the prefix "UNIT_".
pkg/util/metric/metric.proto:48:3:Enum field "TIMESTAMP_NS" is expected to have the prefix "UNIT_".
pkg/util/metric/metric.proto:51:3:Enum field "TIMESTAMP_SEC" is expected to have the prefix "UNIT_".
pkg/util/metric/metric.proto:57:1:The name "Metadata" contains the outlawed name "data". Data is a decorator and all types on Protobuf are data, consider merging this information into a higher-level type, or if you must have such a type, Use "Info" instead..
pkg/util/metric/metric.proto:62:12:Field name "metricType" must be lower_snake_case.
pkg/util/protoutil/clone.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.util.protoutil".
pkg/util/protoutil/clone.proto:13:1:Expected "protoutilpb" for option "go_package" but was "protoutil".
pkg/util/protoutil/clone.proto:17:1:Message "RecursiveAndUncloneable" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/util/protoutil/clone.proto:19:5:The name "uuid" contains the outlawed name "uuid". UUIDs in Protobuf are named ID instead of UUID..
pkg/util/tracing/recorded_span.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.util.tracing".
pkg/util/tracing/recorded_span.proto:13:1:Expected "tracingpb" for option "go_package" but was "tracing".
pkg/util/tracing/recorded_span.proto:25:3:Message "Field" needs a comment with a complete sentence that starts on the first line of the comment.
pkg/util/unresolved_addr.proto:11:1:Syntax should be proto3 but was "proto2".
pkg/util/unresolved_addr.proto:12:1:Package should be of the form "package.vMAJORVERSION" or "packagevMAJORVERSIONbetaBETAVERSION" with versions >=1 but was "cockroach.util".
pkg/util/unresolved_addr.proto:13:1:Expected "utilpb" for option "go_package" but was "util".
pkg/util/unresolved_addr.proto:18:1:Message "UnresolvedAddr" needs a comment with a complete sentence that starts on the first line of the comment.
```