### PR TITLE
roachprod: increase fd limit on aws and gcp clusters from 64Ki to 1Mi

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/support.go
+++ b/pkg/cmd/roachprod/vm/aws/support.go
@@ -96,7 +96,7 @@ sudo service sshd restart
 # increase the default maximum number of open file descriptors for
 # root and non-root users. Load generators running a lot of concurrent
 # workers bump into this often.
-sudo sh -c 'echo "root - nofile 65536\n* - nofile 65536" > /etc/security/limits.d/10-roachprod-nofiles.conf'
+sudo sh -c 'echo "root - nofile 1048576\n* - nofile 1048576" > /etc/security/limits.d/10-roachprod-nofiles.conf'
 
 # Enable core dumps
 cat <<EOF > /etc/security/limits.d/core_unlimited.conf

--- a/pkg/cmd/roachprod/vm/gce/utils.go
+++ b/pkg/cmd/roachprod/vm/gce/utils.go
@@ -84,7 +84,7 @@ sudo service sshd restart
 # increase the default maximum number of open file descriptors for
 # root and non-root users. Load generators running a lot of concurrent
 # workers bump into this often.
-sudo sh -c 'echo "root - nofile 65536\n* - nofile 65536" > /etc/security/limits.d/10-roachprod-nofiles.conf'
+sudo sh -c 'echo "root - nofile 1048576\n* - nofile 1048576" > /etc/security/limits.d/10-roachprod-nofiles.conf'
 
 # Send TCP keepalives every minute since GCE will terminate idle connections
 # after 10m. Note that keepalives still need to be requested by the application


### PR DESCRIPTION
Given we've increased it, why not increase it dramatically.

Release note: None