### PR TITLE
deps: upgrade cockroachdb/errors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -405,7 +405,8 @@
   revision = "aca09668cb243672cb82f3cbeec73b3871e13cc9"
 
 [[projects]]
-  digest = "1:7cfbe9c31d82a7044c86f36c24354363da85cc0a69ee7f2a20908a620d7e9b8a"
+  branch = "v1.2.4-cockroach20.1"
+  digest = "1:f4441cc580b6f69ff82a4130589b43cf4b14883e9f090db66f9c4ad337b41ee4"
   name = "github.com/cockroachdb/errors"
   packages = [
     ".",
@@ -428,8 +429,7 @@
     "withstack",
   ]
   pruneopts = "UT"
-  revision = "9e21257b06ad938e53c24c52b393076a51b61540"
-  version = "v1.2.4"
+  revision = "5f3a6d1e1cf5d5d6212d56dc3833d6d57c7545e4"
 
 [[projects]]
   digest = "1:a44e537b3e080ff297315d166956dba9607f070644a89be78b59af6c54876b64"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -76,6 +76,10 @@ ignored = [
   branch = "master"
 
 [[constraint]]
+  name = "github.com/cockroachdb/errors"
+  branch = "v1.2.4-cockroach20.1"
+
+[[constraint]]
   name = "vitess.io/vitess"
   source = "https://github.com/cockroachdb/vitess"
   branch = "no-flag-names-parens"

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -173,14 +173,9 @@ func TestClusterMonitor(t *testing.T) {
 			time.Sleep(30 * time.Millisecond)
 			return execCmd(ctx, logger, "/bin/bash", "-c", "echo hi && notthere")
 		})
-		expectedErr := regexp.QuoteMeta(`/bin/bash -c echo hi && notthere returned:
-stderr:
-/bin/bash: notthere: command not found
-
-stdout:
-hi
-: exit status 127`)
+		expectedErr := regexp.QuoteMeta(`exit status 127`)
 		if err := m.wait("sleep", "100"); !testutils.IsError(err, expectedErr) {
+			t.Logf("error details: %+v", err)
 			t.Error(err)
 		}
 	})
@@ -202,6 +197,7 @@ hi
 		})
 		expectedErr := regexp.QuoteMeta(`Goexit() was called`)
 		if err := m.wait("sleep", "100"); !testutils.IsError(err, expectedErr) {
+			t.Logf("error details: %+v", err)
 			t.Error(err)
 		}
 	})

--- a/pkg/cmd/roachtest/disk_full.go
+++ b/pkg/cmd/roachtest/disk_full.go
@@ -68,7 +68,7 @@ func registerDiskFull(r *testRegistry) {
 					m.ExpectDeath()
 					if err := c.StartE(ctx, c.Node(n)); err == nil {
 						t.Fatalf("node successfully started unexpectedly")
-					} else if strings.Contains(err.Error(), "a panic has occurred") {
+					} else if strings.Contains(GetStderr(err), "a panic has occurred") {
 						t.Fatal(err)
 					}
 				}

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -130,7 +130,7 @@ func (hc *HealthChecker) Runner(ctx context.Context) (err error) {
 
 		if elapsed := timeutil.Since(tBegin); elapsed > 10*time.Second {
 			err := errors.Errorf("health check against node %d took %s", nodeIdx, elapsed)
-			logger.Printf(err.Error() + "\n")
+			logger.Printf("%+v", err)
 			// TODO(tschottdorf): see method comment.
 			// return err
 		}

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -281,7 +281,7 @@ func (r *testRunner) Run(
 				l,
 			); err != nil {
 				// A worker returned an error. Let's shut down.
-				msg := fmt.Sprintf("Worker %d returned with error. Quiescing. Error: %s", i, err)
+				msg := fmt.Sprintf("Worker %d returned with error. Quiescing. Error: %+v", i, err)
 				shout(ctx, l, lopt.stdout, msg)
 				errs.AddErr(err)
 				// Quiesce the stopper. This will cause all workers to not pick up more
@@ -479,7 +479,7 @@ func (r *testRunner) runWorker(
 		if err != nil || t.Failed() {
 			failureMsg := fmt.Sprintf("%s (%d) - ", testToRun.spec.Name, testToRun.runNum)
 			if err != nil {
-				failureMsg += err.Error()
+				failureMsg += fmt.Sprintf("%+v", err)
 			} else {
 				failureMsg += t.FailureMsg()
 			}

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -865,10 +865,5 @@ var _ ErrorDetailInterface = &IndeterminateCommitError{}
 
 // IsRangeNotFoundError returns true if err contains a *RangeNotFoundError.
 func IsRangeNotFoundError(err error) bool {
-	// TODO(ajwerner): adopt errors.IsType once the pull request to add it merges.
-	_, isRangeNotFound := errors.If(err, func(err error) (interface{}, bool) {
-		_, isRangeNotFound := err.(*RangeNotFoundError)
-		return err, isRangeNotFound
-	})
-	return isRangeNotFound
+	return errors.HasType(err, (*RangeNotFoundError)(nil))
 }

--- a/pkg/util/errorutil/error_test.go
+++ b/pkg/util/errorutil/error_test.go
@@ -39,7 +39,7 @@ func TestUnexpectedWithIssueErrorf(t *testing.T) {
 	}
 
 	// Check that the issue number is present in the safe details.
-	exp = "safe details: issue #%d\n    -- arg 1: 1234"
+	exp = "4 safe details enclosed"
 	if !strings.Contains(safeMsg, exp) {
 		t.Errorf("expected substring in error\n%s\ngot:\n%s", exp, safeMsg)
 	}

--- a/pkg/util/grpcutil/grpc_util.go
+++ b/pkg/util/grpcutil/grpc_util.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
@@ -77,13 +77,11 @@ func IsClosedConnection(err error) bool {
 // TODO(bdarnell): Replace this with a cleaner mechanism when/if
 // https://github.com/grpc/grpc-go/issues/1443 is resolved.
 func RequestDidNotStart(err error) bool {
-	if _, ok := err.(connectionNotReadyError); ok {
+	if errors.HasType(err, connectionNotReadyError{}) ||
+		errors.HasType(err, (*netutil.InitialHeartbeatFailedError)(nil)) {
 		return true
 	}
-	if _, ok := err.(*netutil.InitialHeartbeatFailedError); ok {
-		return true
-	}
-	s, ok := status.FromError(err)
+	s, ok := status.FromError(errors.Cause(err))
 	if !ok {
 		// This is a non-gRPC error; assume nothing.
 		return false

--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -178,12 +178,11 @@ var _ error = (*InitialHeartbeatFailedError)(nil)
 var _ fmt.Formatter = (*InitialHeartbeatFailedError)(nil)
 var _ errors.Formatter = (*InitialHeartbeatFailedError)(nil)
 
-// Note: Error is not a causer. If this is changed to implement
-// Cause()/Unwrap(), change the type assertions in package cli and
-// elsewhere to use errors.As() or equivalent.
-
 // Error implements error.
 func (e *InitialHeartbeatFailedError) Error() string { return fmt.Sprintf("%v", e) }
+
+// Cause implements causer.
+func (e *InitialHeartbeatFailedError) Cause() error { return e.WrappedErr }
 
 // Format implements fmt.Formatter.
 func (e *InitialHeartbeatFailedError) Format(s fmt.State, verb rune) { errors.FormatError(e, s, verb) }


### PR DESCRIPTION
This picks up all the incremental improvements without
the upgrade from raven-go to sentry-go.

Release note: None