### PR TITLE
opt: never remove hard limits from scans

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -161,3 +161,16 @@ SELECT * FROM (select * from generate_series(1,10) a LIMIT 5) OFFSET 3
 query I
 SELECT * FROM (select * from generate_series(1,10) a LIMIT 5) OFFSET 6
 ----
+
+# Regression test for #47283: scan with both hard limit and soft limit.
+statement ok
+CREATE TABLE t_47283(k INT PRIMARY KEY, a INT)
+
+statement ok
+INSERT INTO t_47283 VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)
+
+# This should return no results; if it does, we incorrectly removed the hard
+# limit in the scan.
+query II
+SELECT * FROM (SELECT * FROM t_47283 ORDER BY k LIMIT 4) WHERE a > 5 LIMIT 1
+----

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -482,16 +482,6 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 	softLimit := int64(math.Ceil(scan.RequiredPhysical().LimitHint))
 	hardLimit := scan.HardLimit.RowCount()
 
-	// At most one of hardLimit and softLimit may be defined at the same time.
-	//
-	// TODO(celine): Determine the more optimal course of action if there are
-	// competing hard and soft limits. It is currently unclear what course to
-	// take in the case of, for example, a small soft limit and a large hard
-	// limit, but always taking the soft limit is almost certainly suboptimal.
-	if softLimit != 0 {
-		hardLimit = 0
-	}
-
 	locking := scan.Locking
 	if b.forceForUpdateLocking {
 		locking = forUpdateLocking

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -192,3 +192,22 @@ render               ·            ·                        (k, w)     ·
 ·                    table        t@primary                ·          ·
 ·                    spans        FULL SCAN                ·          ·
 ·                    filter       (v >= 1) AND (v <= 100)  ·          ·
+
+# Regression test for #47283: scan with both hard limit and soft limit.
+statement ok
+CREATE TABLE t_47283(k INT PRIMARY KEY, a INT)
+
+# The scan should have a hard limit.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM t_47283 ORDER BY k LIMIT 4) WHERE a > 5 LIMIT 1
+----
+·               distributed  false            ·       ·
+·               vectorized   true             ·       ·
+limit           ·            ·                (k, a)  ·
+ │              count        1                ·       ·
+ └── filter     ·            ·                (k, a)  ·
+      │         filter       a > 5            ·       ·
+      └── scan  ·            ·                (k, a)  ·
+·               table        t_47283@primary  ·       ·
+·               spans        LIMITED SCAN     ·       ·
+·               limit        4                ·       ·

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -50,12 +50,10 @@ type Factory interface {
 	//   - Only the given set of needed columns are part of the result.
 	//   - If indexConstraint is not nil, the scan is restricted to the spans in
 	//     in the constraint.
-	//   - If hardLimit > 0, then only up to hardLimit rows can be returned from
-	//     the scan. If hardLimit > 0, softLimit must be 0.
+	//   - If hardLimit > 0, then the scan returns only up to hardLimit rows.
 	//   - If softLimit > 0, then the scan may be required to return up to all
-	//     of its rows, but can be optimized under the assumption that only
-	//     softLimit rows will be needed. If softLimit > 0, then hardLimit must
-	//     be 0.
+	//     of its rows (or up to the hardLimit if it is set), but can be optimized
+	//     under the assumption that only softLimit rows will be needed.
 	//   - If maxResults > 0, the scan is guaranteed to return at most maxResults
 	//     rows.
 	//   - If locking is provided, the scan should use the specified row-level


### PR DESCRIPTION
When we have both a hard limit and a soft limit, the execbuilder
removes the hard limit (which is not correct in general).

This change relaxes `exec.Factory.ConstructScan` to allow both a hard
limit and a soft limit to be set at the same time. The scanNode built
by ConstructScan already supports this.

Fixes #47283.

Release note (bug fix): fixes some cases where limits were applied
incorrectly when pushed down into scans (resulting in some queries
returning more results than they should).