### PR TITLE
opt: check for overlapping output columns in sub-exprs

### DIFF
--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -58,8 +58,8 @@
 # the LHS, we only commute a SemiJoin into an InnerJoin when the On conditions
 # are only composed of equalities.
 #
-# Note: We only consier the columns of the RHS that are used in the On conditions
-# (B* in the example above). And so we can be certain that
+# Note: We only consider the columns of the RHS that are used in the On
+# conditions (B* in the example above). And so we can be certain that
 # ((Distinct(RHS*) InnerJoin LHS) will have at most 1 matching row for each row
 # in the LHS if the On conditions are simple equalities.
 #


### PR DESCRIPTION
This commit adds a check, run during testrace, that panics if a
relational expression's left and right sub-expressions have overlapping
column IDs. This will help identify incorrect normalization and
exploration rules.

To verify that the check works correctly, I created the following
exploration rule.

  [FailCheckExpr, Explore]
  (Select $input:* $filters:*)
  =>
  (InnerJoin $input $input $filters)

When running a test query like "SELECT * FROM t WHERE k = 1",
"make testrace" panics.

Release note: None
