### PR TITLE
util/tracing: rationalize the span's use of logtags

### DIFF
--- a/pkg/util/tracing/helpers_test.go
+++ b/pkg/util/tracing/helpers_test.go
@@ -1,0 +1,141 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tracing
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+)
+
+type mockTracer struct {
+	spans []*mockSpan
+}
+
+var _ opentracing.Tracer = &mockTracer{}
+
+func (m *mockTracer) clear() {
+	m.spans = nil
+}
+
+// expectSingleStartWithTags checks that there's been a single call to
+// StartSpan() since the last clear(), and that the call specified the given tag
+// names (amongst possibly more tags).
+func (m *mockTracer) expectSingleSpanWithTags(tagNames ...string) error {
+	if len(m.spans) != 1 {
+		return errors.Newf("expected 1 StartSpan() call, had: %d", len(m.spans))
+	}
+	s := m.spans[0]
+	for _, t := range tagNames {
+		if _, ok := s.tags[t]; !ok {
+			return errors.Newf("missing tag: %s", t)
+		}
+	}
+	return nil
+}
+
+func (m *mockTracer) StartSpan(
+	operationName string, opts ...opentracing.StartSpanOption,
+) opentracing.Span {
+	var opt opentracing.StartSpanOptions
+	for _, o := range opts {
+		o.Apply(&opt)
+	}
+	s := &mockSpan{
+		tags: make(opentracing.Tags),
+	}
+	if opt.Tags != nil {
+		s.tags = opt.Tags
+	}
+	m.spans = append(m.spans, s)
+	return s
+}
+
+func (m *mockTracer) Inject(
+	sm opentracing.SpanContext, format interface{}, carrier interface{},
+) error {
+	panic("unimplemented")
+}
+
+func (m *mockTracer) Extract(
+	format interface{}, carrier interface{},
+) (opentracing.SpanContext, error) {
+	panic("unimplemented")
+}
+
+type mockTracerManager struct{}
+
+var _ shadowTracerManager = &mockTracerManager{}
+
+func (m *mockTracerManager) Name() string {
+	return "mock"
+}
+
+func (m *mockTracerManager) Close(tr opentracing.Tracer) {}
+
+type mockSpan struct {
+	tags opentracing.Tags
+}
+
+var _ opentracing.Span = &mockSpan{}
+
+func (m *mockSpan) Finish() {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) FinishWithOptions(opts opentracing.FinishOptions) {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) Context() opentracing.SpanContext {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) SetOperationName(operationName string) opentracing.Span {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) SetTag(key string, value interface{}) opentracing.Span {
+	m.tags[key] = value
+	return m
+}
+
+func (m *mockSpan) LogFields(fields ...log.Field) {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) LogKV(alternatingKeyValues ...interface{}) {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) SetBaggageItem(restrictedKey, value string) opentracing.Span {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) BaggageItem(restrictedKey string) string {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) Tracer() opentracing.Tracer {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) LogEvent(event string) {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) LogEventWithPayload(event string, payload interface{}) {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) Log(data opentracing.LogData) {
+	panic("unimplemented")
+}

--- a/pkg/util/tracing/shadow.go
+++ b/pkg/util/tracing/shadow.go
@@ -76,7 +76,7 @@ func (st *shadowTracer) Close() {
 // The Shadow span will have a parent if parentShadowCtx is not nil.
 // parentType is ignored if parentShadowCtx is nil.
 //
-// The tags from s are copied to the Shadow span.
+// The tags (including logTags) from s are copied to the Shadow span.
 func linkShadowSpan(
 	s *span,
 	shadowTr *shadowTracer,
@@ -87,14 +87,8 @@ func linkShadowSpan(
 	var opts []opentracing.StartSpanOption
 	// Replicate the options, using the lightstep context in the reference.
 	opts = append(opts, opentracing.StartTime(s.startTime))
-	if s.startTags != nil {
-		startTags := make(opentracing.Tags)
-		tags := s.startTags.Get()
-		for i := range tags {
-			tag := &tags[i]
-			startTags[tag.Key()] = tag.Value()
-		}
-		opts = append(opts, startTags)
+	if s.logTags != nil {
+		opts = append(opts, LogTags(s.logTags))
 	}
 	if s.mu.tags != nil {
 		opts = append(opts, s.mu.tags)

--- a/pkg/util/tracing/tags.go
+++ b/pkg/util/tracing/tags.go
@@ -23,6 +23,10 @@ type logTagsOption logtags.Buffer
 var _ opentracing.StartSpanOption = &logTagsOption{}
 
 // Apply is part of the opentracing.StartSpanOption interface.
+//
+// Note that our tracer does not call Apply() for this options. Instead, it
+// recognizes it as a special case and treats it more efficiently, avoiding
+// allocations for each tag. The Apply() is still used by shadow tracers.
 func (lt *logTagsOption) Apply(o *opentracing.StartSpanOptions) {
 	if lt == nil {
 		return
@@ -40,7 +44,8 @@ func (lt *logTagsOption) Apply(o *opentracing.StartSpanOptions) {
 }
 
 // LogTags returns a StartSpanOption that sets the span tags to the given log
-// tags.
+// tags. When applied, the returned option will apply any logtag name->span tag
+// name remapping that has been registered via RegisterTagRemapping.
 func LogTags(tags *logtags.Buffer) opentracing.StartSpanOption {
 	return (*logTagsOption)(tags)
 }


### PR DESCRIPTION
Before this patch, the handling of logtags in tracing was a bit chaotic,
and also suboptimal for performance. Depending on exactly how a span was
created, the logtags were or weren't going through the process of
remapping log tag names to span tag names (e.g. turning "n:1" ->
"node:1"). Similarly, a shadow span was or wasn't getting its tags
remapped depending on the phases of the moon.

This patch clears the water. It makes it so that a span's log tags are
never remapped, and a shadow span's tags are always remapped.
tracer.StartSpan(..., LogTagsFromContext(ctx)) should now be more
efficient, since the respective tags continue to be stored as a
logtags.Buffer, and not normalized. This is done by having our tracer
recognize the logTagsOption as a special case.

Fixes #47243

Release note: None