### PR TITLE
workload/schemachange: SHOW TABLE has 3 columns now

### DIFF
--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -218,7 +218,7 @@ func (s *schemaChange) initSeqNum(pool *workload.MultiConnPool) (*int64, error) 
 
 	const q = `
 SELECT max(regexp_extract(name, '[0-9]+$')::int)
-  FROM ((SELECT * FROM [SHOW TABLES]) UNION (SELECT * FROM [SHOW SEQUENCES])) AS obj(name)
+  FROM ((SELECT table_name FROM [SHOW TABLES]) UNION (SELECT sequence_name FROM [SHOW SEQUENCES])) AS obj(name)
  WHERE name ~ '^(table|view|seq)[0-9]+$';
 `
 	var max gosql.NullInt64


### PR DESCRIPTION
This breaks the logic of getting the next available sequence number.

Touches #47152.

Release note: none.