### PR TITLE
release-20.1: Revert "storage: constrained span of rangedel in ClearRange to keys in range

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -2856,33 +2856,11 @@ func TestStoreRangeMergeSlowWatcher(t *testing.T) {
 	}
 }
 
-// TestStoreRangeMergeRaftSnapshot sets up a situation which triggers a
-// snapshot that spans both a range merge and split and verifies that the
-// contents of the SSTs that are created for ingestion as a result of the
-// snapshot are what we expect them to be.
-//
-// The test first creates three ranges: [a, b), [b, c), [c, e) and [e, /Max).
-// Keys are inserted at a, b, c and d0 through d9. It then drops traffic to the
-// [a, b) replica on store2 after which the above ranges are iteratively merged
-// together to form [a, e), [e, /Max) then finally split to form
-// [a, d), [d, e), [e, /Max). Once this is all done, the Raft log is truncated
-// to ensure that the replica cannot be caught up with incremental diffs.
-//
-// This set-up allows us to verify that the receiving replica:
-// 1. Creates an SSTs for the user keys in the snapshot with a range del
-// tombstone that is only as wide as the keys that are present in the range.
-// 2. This SST contain all of the user keys that we've inserted.
-// 3. Creates SSTs which correctly clear keys contained in subsumed replicas
-// again with tombstones that are constrained to the keys present in the
-// range.
 func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	// We will be testing the SSTs written on store2's engine.
-	var receivingEng storage.Engine
-	// Used to set the MVCCKey.Timestamp of the manually inserted keys so we
-	// can create keys that are byte-by-byte equal to the ones in the snapshot.
-	keyTimestamps := make(map[string]hlc.Timestamp)
+	var receivingEng, sendingEng storage.Engine
 	ctx := context.Background()
 	storeCfg := kvserver.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableReplicateQueue = true
@@ -2933,48 +2911,41 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		// tombstones and range deletion tombstones.
 		var expectedSSTs [][]byte
 
-		// Construct SST #3 as numbered above. We set-up the scenario that
-		// triggered the snapshot so we should be able to predict exactly what
-		// should be in the SST.
-		{
+		// Construct SST #1 through #3 as numbered above, but only ultimately
+		// keep the 3rd one.
+		keyRanges := rditer.MakeReplicatedKeyRanges(inSnap.State.Desc)
+		it := rditer.NewReplicaDataIterator(inSnap.State.Desc, sendingEng, true /* replicatedOnly */, false /* seekEnd */)
+		defer it.Close()
+		// Write a range deletion tombstone to each of the SSTs then put in the
+		// kv entries from the sender of the snapshot.
+		for _, r := range keyRanges {
 			sstFile := &storage.MemFile{}
 			sst := storage.MakeIngestionSSTWriter(sstFile)
-			// Expect the user KeyRange to be [a, d) but we only have keys at
-			// a, b and c so we expect rditer.ConstrainToKeys to restrict the
-			// width of the range del tombstone to [a, c).
-			if err := sst.ClearRange(
-				storage.MakeMVCCMetadataKey(roachpb.Key("a")),
-				storage.MakeMVCCMetadataKey(roachpb.Key("c").Next()),
-			); err != nil {
+			if err := sst.ClearRange(r.Start, r.End); err != nil {
 				return err
 			}
 
-			// Insert keys "a", "b" and "c" with a timestamp that matches the
-			// sender's and has a value of 1.
-			createValFunc := func(key string, val int64) (storage.MVCCKey, roachpb.Value) {
-				k := roachpb.Key(key)
-				mvccKey := storage.MVCCKey{Key: k, Timestamp: keyTimestamps[string(k)]}
-				var v roachpb.Value
-				v.SetInt(val)
-				v.InitChecksum(k)
-				return mvccKey, v
+			// Keep adding kv data to the SST until the the key exceeds the
+			// bounds of the range, then proceed to the next range.
+			for ; ; it.Next() {
+				valid, err := it.Valid()
+				if err != nil {
+					return err
+				}
+				if !valid || r.End.Key.Compare(it.Key().Key) <= 0 {
+					if err := sst.Finish(); err != nil {
+						return err
+					}
+					sst.Close()
+					expectedSSTs = append(expectedSSTs, sstFile.Data())
+					break
+				}
+				if err := sst.Put(it.Key(), it.Value()); err != nil {
+					return err
+				}
 			}
-			k1, v1 := createValFunc("a", int64(1))
-			k2, v2 := createValFunc("b", int64(1))
-			k3, v3 := createValFunc("c", int64(1))
-			if err := sst.Put(k1, v1.RawBytes); err != nil {
-				return err
-			}
-			if err := sst.Put(k2, v2.RawBytes); err != nil {
-				return err
-			}
-			if err := sst.Put(k3, v3.RawBytes); err != nil {
-				return err
-			}
-
-			sst.Close()
-			expectedSSTs = append(expectedSSTs, sstFile.Data())
 		}
+		expectedSSTs = expectedSSTs[2:]
 
 		// Construct SSTs #5 and #6: range-id local keys of subsumed replicas
 		// with RangeIDs 3 and 4.
@@ -3002,12 +2973,16 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		sstFile := &storage.MemFile{}
 		sst := storage.MakeIngestionSSTWriter(sstFile)
 		defer sst.Close()
-		// Expect there to be keys d0 through d9 in the [a, d) user KeyRange
-		// so the range del tombstone should only span exactly these keys.
-		if err := storage.ClearRangeWithHeuristic(receivingEng, &sst, roachpb.Key("d0"), roachpb.Key("d9").Next()); err != nil {
+		desc := roachpb.RangeDescriptor{
+			StartKey: roachpb.RKey("d"),
+			EndKey:   roachpb.RKeyMax,
+		}
+		r := rditer.MakeUserKeyRange(&desc)
+		if err := storage.ClearRangeWithHeuristic(receivingEng, &sst, r.Start.Key, r.End.Key); err != nil {
 			return err
 		}
-		if err := sst.Finish(); err != nil {
+		err := sst.Finish()
+		if err != nil {
 			return err
 		}
 		expectedSSTs = append(expectedSSTs, sstFile.Data())
@@ -3024,7 +2999,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			}
 		}
 		if len(mismatchedSstsIdx) != 0 {
-			return errors.Errorf("actual and expected SST indices %v don't match", mismatchedSstsIdx)
+			return errors.Errorf("SST indices %v don't match", mismatchedSstsIdx)
 		}
 		return nil
 	}
@@ -3038,6 +3013,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 	mtc.Start(t, 3)
 	defer mtc.Stop()
 	store0, store2 := mtc.Store(0), mtc.Store(2)
+	sendingEng = store0.Engine()
 	receivingEng = store2.Engine()
 	distSender := mtc.distSenders[0]
 
@@ -3047,15 +3023,9 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		if _, pErr := kv.SendWrapped(ctx, distSender, adminSplitArgs(key)); pErr != nil {
 			t.Fatal(pErr)
 		}
-		// Manually send the request so we can store the timestamp.
-		ba := roachpb.BatchRequest{}
-		ba.Add(incrementArgs(key, 1))
-		br, pErr := distSender.Send(ctx, ba)
-		if pErr != nil {
+		if _, pErr := kv.SendWrapped(ctx, distSender, incrementArgs(key, 1)); pErr != nil {
 			t.Fatal(pErr)
 		}
-		keyTimestamps[string(key)] = br.Timestamp
-
 		mtc.waitForValues(key, []int64{1, 1, 1})
 	}
 
@@ -3069,13 +3039,6 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			t.Fatal(pErr)
 		}
 		mtc.waitForValues(key, []int64{1, 1, 1})
-	}
-
-	// Split [d, /Max) into [d, e) and [e, /Max) so we can predict the
-	// contents of [a, d) without having to worry about metadata keys that will
-	// now be in [e, /Max) instead.
-	if _, pErr := kv.SendWrapped(ctx, distSender, adminSplitArgs(roachpb.Key("e"))); pErr != nil {
-		t.Fatal(pErr)
 	}
 
 	aRepl0 := store0.LookupReplica(roachpb.RKey("a"))

--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
-	"github.com/pkg/errors"
 )
 
 // KeyRange is a helper struct for the ReplicaDataIterator.
@@ -25,10 +24,10 @@ type KeyRange struct {
 
 // ReplicaDataIterator provides a complete iteration over all key / value
 // rows in a range, including all system-local metadata and user data.
-// The ranges KeyRange slice specifies the key ranges which comprise
+// The ranges keyRange slice specifies the key ranges which comprise
 // all of the range's data.
 //
-// A ReplicaDataIterator provides a subset of the storage.Iterator interface.
+// A ReplicaDataIterator provides a subset of the engine.Iterator interface.
 //
 // TODO(tschottdorf): the API is awkward. By default, ReplicaDataIterator uses
 // a byte allocator which needs to be reset manually using `ResetAllocator`.
@@ -49,32 +48,6 @@ func MakeAllKeyRanges(d *roachpb.RangeDescriptor) []KeyRange {
 		MakeRangeLocalKeyRange(d),
 		MakeUserKeyRange(d),
 	}
-}
-
-// ConstrainToKeys returns a Span constrained to the keys present in the given Range.
-// Returns (span, true) if the Range is contains no keys, otherwise (span, false).
-func ConstrainToKeys(
-	reader storage.Reader, span roachpb.Span,
-) (_ roachpb.Span, empty bool, _ error) {
-	it := reader.NewIterator(storage.IterOptions{LowerBound: span.Key, UpperBound: span.EndKey})
-	defer it.Close()
-	it.SeekGE(storage.MakeMVCCMetadataKey(span.Key))
-	if valid, err := it.Valid(); err != nil {
-		return roachpb.Span{}, true, errors.Wrapf(err, "unexpected error when constraining non-empty span")
-	} else if !valid {
-		return roachpb.Span{}, true, nil
-	}
-	startKey := it.Key().Key
-
-	it.SeekLT(storage.MakeMVCCMetadataKey(span.EndKey))
-	if valid, err := it.Valid(); err != nil {
-		return roachpb.Span{}, true, errors.Wrapf(err, "unexpected error when constraining non-empty span")
-	} else if !valid {
-		return roachpb.Span{}, true, nil
-	}
-	endKey := it.Key().Key.Next()
-
-	return roachpb.Span{Key: startKey, EndKey: endKey}, false, nil
 }
 
 // MakeReplicatedKeyRanges returns all key ranges that are fully Raft

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"github.com/stretchr/testify/require"
 )
 
 func fakePrevKey(k []byte) roachpb.Key {
@@ -265,67 +264,4 @@ func TestReplicaDataIterator(t *testing.T) {
 			verifyRDIter(t, test.desc, eng, false /* replicatedOnly */, test.keys)
 		})
 	}
-}
-
-func TestConstrainToKeysEmptyRange(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	eng := storage.NewDefaultInMem()
-	defer eng.Close()
-
-	span, empty, err := ConstrainToKeys(eng, roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")})
-	require.NoError(t, err)
-	require.True(t, empty)
-	require.Equal(t, roachpb.Span{}, span)
-}
-
-func TestConstrainToKeysNonEmptyRange(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	eng := storage.NewDefaultInMem()
-	defer eng.Close()
-
-	originalSpan := roachpb.Span{
-		Key:    roachpb.Key("b"),
-		EndKey: roachpb.Key("q"),
-	}
-
-	// Insert a single key, d, and expect [d, d.Next()).
-	err := storage.MVCCPut(context.Background(), eng, nil, roachpb.Key("d"), hlc.Timestamp{}, roachpb.MakeValueFromString("value"), nil)
-	require.NoError(t, err)
-	span, empty, err := ConstrainToKeys(eng, originalSpan)
-	require.NoError(t, err)
-	require.False(t, empty)
-	require.Equal(t, roachpb.Key("d"), span.Key)
-	require.Equal(t, roachpb.Key("d").Next(), span.EndKey)
-
-	// Insert a second key, h, and expect [d, h.Next()).
-	err = storage.MVCCPut(context.Background(), eng, nil, roachpb.Key("h"), hlc.Timestamp{}, roachpb.MakeValueFromString("value"), nil)
-	require.NoError(t, err)
-	span, empty, err = ConstrainToKeys(eng, originalSpan)
-	require.NoError(t, err)
-	require.False(t, empty)
-	require.Equal(t, roachpb.Key("d"), span.Key)
-	require.Equal(t, roachpb.Key("h").Next(), span.EndKey)
-
-	// Insert a third key, c, and expect [c, h.Next()).
-	err = storage.MVCCPut(context.Background(), eng, nil, roachpb.Key("c"), hlc.Timestamp{}, roachpb.MakeValueFromString("value"), nil)
-	require.NoError(t, err)
-	span, empty, err = ConstrainToKeys(eng, originalSpan)
-	require.NoError(t, err)
-	require.False(t, empty)
-	require.Equal(t, roachpb.Key("c"), span.Key)
-	require.Equal(t, roachpb.Key("h").Next(), span.EndKey)
-
-	// Insert a key before the start key and beyond the end key of the original
-	// span. Expect the constrained span to remain unchanged.
-	err = storage.MVCCPut(context.Background(), eng, nil, roachpb.Key("a"), hlc.Timestamp{}, roachpb.MakeValueFromString("value"), nil)
-	require.NoError(t, err)
-	err = storage.MVCCPut(context.Background(), eng, nil, roachpb.Key("z"), hlc.Timestamp{}, roachpb.MakeValueFromString("value"), nil)
-	require.NoError(t, err)
-	span, empty, err = ConstrainToKeys(eng, originalSpan)
-	require.NoError(t, err)
-	require.False(t, empty)
-	require.Equal(t, roachpb.Key("c"), span.Key)
-	require.Equal(t, roachpb.Key("h").Next(), span.EndKey)
 }

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -1740,11 +1740,8 @@ func execChangeReplicasTxn(
 // three SSTs from them for direct ingestion: one for the replicated range-ID
 // local keys, one for the range local keys, and one for the user keys. The
 // reason it creates three separate SSTs is to prevent overlaps with the
-// memtable and existing SSTs in RocksDB. These SST files are created lazily,
-// so in the case where the keyspace is empty, no file will be created. Each
-// of the SSTs has a range deletion tombstone written to it to delete the
-// existing data in the range, however if the keyspace is empty, then the
-// tombstone will be omitted.
+// memtable and existing SSTs in RocksDB. Each of the SSTs also has a range
+// deletion tombstone to delete the existing data in the range.
 //
 // Applying the snapshot: After the recipient has received the message
 // indicating it has all the data, it hands it all to

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -577,10 +577,10 @@ func snapshot(
 // They are managed by the caller, including cleaning up obsolete on-disk
 // payloads in case the log tail is replaced.
 //
-// NOTE: This method takes a storage.Writer because reads are unnecessary when
+// NOTE: This method takes a engine.Writer because reads are unnecessary when
 // prevLastIndex is 0 and prevLastTerm is invalidLastTerm. In the case where
 // reading is necessary (I.E. entries are getting overwritten or deleted), a
-// storage.ReadWriter must be passed in.
+// engine.ReadWriter must be passed in.
 func (r *Replica) append(
 	ctx context.Context,
 	writer storage.Writer,
@@ -606,11 +606,11 @@ func (r *Replica) append(
 		if ent.Index > prevLastIndex {
 			err = storage.MVCCBlindPut(ctx, writer, &diff, key, hlc.Timestamp{}, value, nil /* txn */)
 		} else {
-			// We type assert `writer` to also be an storage.ReadWriter only in
+			// We type assert `writer` to also be an engine.ReadWriter only in
 			// the case where we're replacing existing entries.
 			eng, ok := writer.(storage.ReadWriter)
 			if !ok {
-				panic("expected writer to be a storage.ReadWriter when overwriting log entries")
+				panic("expected writer to be a engine.ReadWriter when overwriting log entries")
 			}
 			err = storage.MVCCPut(ctx, eng, &diff, key, hlc.Timestamp{}, value, nil /* txn */)
 		}
@@ -623,11 +623,11 @@ func (r *Replica) append(
 	lastTerm := entries[len(entries)-1].Term
 	// Delete any previously appended log entries which never committed.
 	if prevLastIndex > 0 {
-		// We type assert `writer` to also be an storage.ReadWriter only in the
+		// We type assert `writer` to also be an engine.ReadWriter only in the
 		// case where we're deleting existing entries.
 		eng, ok := writer.(storage.ReadWriter)
 		if !ok {
-			panic("expected writer to be a storage.ReadWriter when deleting log entries")
+			panic("expected writer to be a engine.ReadWriter when deleting log entries")
 		}
 		for i := lastIndex + 1; i <= prevLastIndex; i++ {
 			// Note that the caller is in charge of deleting any sideloaded payloads
@@ -1066,21 +1066,14 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 			subsumedReplSSTFile := &storage.MemFile{}
 			subsumedReplSST := storage.MakeIngestionSSTWriter(subsumedReplSSTFile)
 			defer subsumedReplSST.Close()
-			unconstrainedSpan := roachpb.Span{Key: keyRanges[i].End.Key, EndKey: totalKeyRanges[i].End.Key}
-			span, empty, err := rditer.ConstrainToKeys(r.Engine(), unconstrainedSpan)
-			if err != nil {
-				return errors.Wrapf(err, "error constraining width of range deletion tombstone")
-			}
-			if !empty {
-				if err := storage.ClearRangeWithHeuristic(
-					r.store.Engine(),
-					&subsumedReplSST,
-					span.Key,
-					span.EndKey,
-				); err != nil {
-					subsumedReplSST.Close()
-					return err
-				}
+			if err := storage.ClearRangeWithHeuristic(
+				r.store.Engine(),
+				&subsumedReplSST,
+				keyRanges[i].End.Key,
+				totalKeyRanges[i].End.Key,
+			); err != nil {
+				subsumedReplSST.Close()
+				return err
 			}
 			if err := subsumedReplSST.Finish(); err != nil {
 				return err

--- a/pkg/kv/kvserver/replica_sst_snapshot_storage.go
+++ b/pkg/kv/kvserver/replica_sst_snapshot_storage.go
@@ -93,6 +93,7 @@ func (s *SSTSnapshotStorageScratch) NewFile(
 ) (*SSTSnapshotStorageFile, error) {
 	id := len(s.ssts)
 	filename := s.filename(id)
+	s.ssts = append(s.ssts, filename)
 	f := &SSTSnapshotStorageFile{
 		scratch:   s,
 		filename:  filename,
@@ -164,7 +165,6 @@ func (f *SSTSnapshotStorageFile) openFile() error {
 	}
 	f.file = file
 	f.created = true
-	f.scratch.ssts = append(f.scratch.ssts, f.filename)
 	return nil
 }
 

--- a/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
+++ b/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
@@ -18,8 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/stretchr/testify/require"
@@ -53,8 +51,8 @@ func TestSSTSnapshotStorage(t *testing.T) {
 		require.NoError(t, f.Close())
 	}()
 
-	// The files are lazily created and also lazily added to the SSTs() slice.
-	require.Equal(t, len(scratch.SSTs()), 0)
+	// Check that even though the files aren't created, they are still recorded in SSTs().
+	require.Equal(t, len(scratch.SSTs()), 1)
 
 	// Check that the storage lazily creates the files on write.
 	for _, fileName := range scratch.SSTs() {
@@ -66,8 +64,6 @@ func TestSSTSnapshotStorage(t *testing.T) {
 
 	_, err = f.Write([]byte("foo"))
 	require.NoError(t, err)
-	// After the SST file has been written to, it should be recorded in SSTs().
-	require.Equal(t, len(scratch.SSTs()), 1)
 
 	// After writing to files, check that they have been flushed to disk.
 	for _, fileName := range scratch.SSTs() {
@@ -105,10 +101,9 @@ func TestSSTSnapshotStorage(t *testing.T) {
 	}
 }
 
-// TestMultiSSTWriterInitSST tests that multiSSTWriter lazily creates each of
-// the SST files associated with the three replicated key ranges and if the
-// ranges are non-empty, writes a range deletion tombstone to each file that
-// spans only the keys in the range.
+// TestMultiSSTWriterInitSST tests that multiSSTWriter initializes each of the
+// SST files associated with the three replicated key ranges by writing a range
+// deletion tombstone that spans the entire range of each respectively.
 func TestMultiSSTWriterInitSST(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -121,70 +116,45 @@ func TestMultiSSTWriterInitSST(t *testing.T) {
 	defer cleanup()
 	defer eng.Close()
 
-	testutils.RunTrueAndFalse(t, "insertKeys", func(t *testing.T, insertKeys bool) {
-		desc := roachpb.RangeDescriptor{
-			StartKey: roachpb.RKey("d"),
-			EndKey:   roachpb.RKeyMax,
-		}
-		keyRanges := rditer.MakeReplicatedKeyRanges(&desc)
-		ts := hlc.Timestamp{}
-		sstSnapshotStorage := NewSSTSnapshotStorage(eng, testLimiter)
-		var scratch *SSTSnapshotStorageScratch
+	sstSnapshotStorage := NewSSTSnapshotStorage(eng, testLimiter)
+	scratch := sstSnapshotStorage.NewScratchSpace(testRangeID, testSnapUUID)
+	desc := roachpb.RangeDescriptor{
+		StartKey: roachpb.RKey("d"),
+		EndKey:   roachpb.RKeyMax,
+	}
+	keyRanges := rditer.MakeReplicatedKeyRanges(&desc)
 
-		if insertKeys {
-			// Expect a SST file to be created for a range only if that range contains
-			// at least one key. So we insert a key that falls within each of the
-			// three types of replicated key ranges and check to see if the number of
-			// SST files created matches what we expect.
-			insertedKeys := make([]roachpb.Key, len(keyRanges))
-			for i, kr := range keyRanges {
-				insertedKeys[i] = kr.Start.Key
-			}
-			for numberOfPuts := 1; numberOfPuts < len(keyRanges)+1; numberOfPuts++ {
-				err := storage.MVCCPut(ctx, eng, nil, insertedKeys[numberOfPuts-1], ts, roachpb.MakeValueFromString("value"), nil)
-				require.NoError(t, err)
-				scratch = sstSnapshotStorage.NewScratchSpace(testRangeID, testSnapUUID)
-				msstw, err := newMultiSSTWriter(ctx, scratch, keyRanges, 0, eng)
-				require.NoError(t, err)
-				err = msstw.Finish(ctx)
-				require.NoError(t, err)
-				require.Equal(t, numberOfPuts, len(msstw.scratch.SSTs()))
-			}
+	msstw, err := newMultiSSTWriter(ctx, scratch, keyRanges, 0)
+	require.NoError(t, err)
+	err = msstw.Finish(ctx)
+	require.NoError(t, err)
 
-			var actualSSTs [][]byte
-			fileNames := scratch.SSTs()
-			for _, file := range fileNames {
-				sst, err := eng.ReadFile(file)
-				require.NoError(t, err)
-				actualSSTs = append(actualSSTs, sst)
-			}
-			// Construct an SST file for each of the key ranges and write a rangedel
-			// tombstone that spans [insertedKey, insertedKey.Next()
-			var expectedSSTs [][]byte
-			for i := range keyRanges {
-				func() {
-					sstFile := &storage.MemFile{}
-					sst := storage.MakeIngestionSSTWriter(sstFile)
-					defer sst.Close()
-					err := sst.ClearRange(storage.MakeMVCCMetadataKey(insertedKeys[i]), storage.MakeMVCCMetadataKey(insertedKeys[i].Next()))
-					require.NoError(t, err)
-					err = sst.Finish()
-					require.NoError(t, err)
-					expectedSSTs = append(expectedSSTs, sstFile.Data())
-				}()
-			}
+	var actualSSTs [][]byte
+	fileNames := msstw.scratch.SSTs()
+	for _, file := range fileNames {
+		sst, err := eng.ReadFile(file)
+		require.NoError(t, err)
+		actualSSTs = append(actualSSTs, sst)
+	}
 
-			for i := range fileNames {
-				require.Equal(t, actualSSTs[i], expectedSSTs[i])
-			}
-		} else {
-			// Without any inserted keys, we expect no SSTs to be created.
-			scratch = sstSnapshotStorage.NewScratchSpace(testRangeID, testSnapUUID)
-			msstw, err := newMultiSSTWriter(ctx, scratch, keyRanges, 0, eng)
+	// Construct an SST file for each of the key ranges and write a rangedel
+	// tombstone that spans from Start to End.
+	var expectedSSTs [][]byte
+	for _, r := range keyRanges {
+		func() {
+			sstFile := &storage.MemFile{}
+			sst := storage.MakeIngestionSSTWriter(sstFile)
+			defer sst.Close()
+			err := sst.ClearRange(r.Start, r.End)
 			require.NoError(t, err)
-			err = msstw.Finish(ctx)
+			err = sst.Finish()
 			require.NoError(t, err)
-			require.Equal(t, 0, len(msstw.scratch.SSTs()))
-		}
-	})
+			expectedSSTs = append(expectedSSTs, sstFile.Data())
+		}()
+	}
+
+	require.Equal(t, len(actualSSTs), len(expectedSSTs))
+	for i := range fileNames {
+		require.Equal(t, actualSSTs[i], expectedSSTs[i])
+	}
 }

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -107,10 +107,6 @@ type kvBatchSnapshotStrategy struct {
 	sstChunkSize int64
 	// Only used on the receiver side.
 	scratch *SSTSnapshotStorageScratch
-	// Used when initializing SST files to scan for the first and last keys in
-	// each of the replicated key ranges in order to restrict the width of the
-	// range del tombstone to keys present in each range.
-	reader storage.Reader
 }
 
 // multiSSTWriter is a wrapper around RocksDBSstFileWriter and
@@ -124,9 +120,6 @@ type multiSSTWriter struct {
 	// The approximate size of the SST chunk to buffer in memory on the receiver
 	// before flushing to disk.
 	sstChunkSize int64
-	// Used to scan for the minimum and maximum keys in each of the replicated
-	// key ranges to restrict range deletion tombstone width.
-	reader storage.Reader
 }
 
 func newMultiSSTWriter(
@@ -134,13 +127,11 @@ func newMultiSSTWriter(
 	scratch *SSTSnapshotStorageScratch,
 	keyRanges []rditer.KeyRange,
 	sstChunkSize int64,
-	reader storage.Reader,
 ) (multiSSTWriter, error) {
 	msstw := multiSSTWriter{
 		scratch:      scratch,
 		keyRanges:    keyRanges,
 		sstChunkSize: sstChunkSize,
-		reader:       reader,
 	}
 	if err := msstw.initSST(ctx); err != nil {
 		return msstw, err
@@ -149,55 +140,26 @@ func newMultiSSTWriter(
 }
 
 func (msstw *multiSSTWriter) initSST(ctx context.Context) error {
-	span := roachpb.Span{
-		Key:    msstw.keyRanges[msstw.currRange].Start.Key,
-		EndKey: msstw.keyRanges[msstw.currRange].End.Key,
-	}
-	// Check if the range contains any keys. If the range is empty, skip
-	// creating the file since this may lead to the ingestion of an empty SST
-	// file.
-	span, empty, err := rditer.ConstrainToKeys(msstw.reader, span)
+	newSSTFile, err := msstw.scratch.NewFile(ctx, msstw.sstChunkSize)
 	if err != nil {
-		return errors.Wrap(err, "failed to constrain span to keys in range")
+		return errors.Wrap(err, "failed to create new sst file")
 	}
-	if empty {
-		return nil
-	}
-	if err := msstw.maybeCreateNewFile(ctx); err != nil {
-		return err
-	}
-	if err := msstw.currSST.ClearRange(storage.MakeMVCCMetadataKey(span.Key), storage.MakeMVCCMetadataKey(span.EndKey)); err != nil {
+	newSST := storage.MakeIngestionSSTWriter(newSSTFile)
+	msstw.currSST = newSST
+	if err := msstw.currSST.ClearRange(msstw.keyRanges[msstw.currRange].Start, msstw.keyRanges[msstw.currRange].End); err != nil {
 		msstw.currSST.Close()
 		return errors.Wrap(err, "failed to clear range on sst file writer")
 	}
 	return nil
 }
 
-// maybeCreateNewFile creates a new file if the current SST file is closed.
-// If the current SST file is open then this is a no-op. maybeCreateNewFile is
-// idempotent.
-func (msstw *multiSSTWriter) maybeCreateNewFile(ctx context.Context) error {
-	// The file has already been created so avoiding creating twice.
-	if !msstw.currSST.Closed() {
-		return nil
-	}
-	newSSTFile, err := msstw.scratch.NewFile(ctx, msstw.sstChunkSize)
-	if err != nil {
-		return errors.Wrap(err, "failed to create new sst file")
-	}
-	msstw.currSST = storage.MakeIngestionSSTWriter(newSSTFile)
-	return nil
-}
-
 func (msstw *multiSSTWriter) finalizeSST(ctx context.Context) error {
-	if !msstw.currSST.Closed() {
-		err := msstw.currSST.Finish()
-		if err != nil {
-			return errors.Wrap(err, "failed to finish sst")
-		}
-		msstw.currSST.Close()
+	err := msstw.currSST.Finish()
+	if err != nil {
+		return errors.Wrap(err, "failed to finish sst")
 	}
 	msstw.currRange++
+	msstw.currSST.Close()
 	return nil
 }
 
@@ -214,9 +176,6 @@ func (msstw *multiSSTWriter) Put(ctx context.Context, key storage.MVCCKey, value
 	}
 	if msstw.keyRanges[msstw.currRange].Start.Key.Compare(key.Key) > 0 {
 		return crdberrors.AssertionFailedf("client error: expected %s to fall in one of %s", key.Key, msstw.keyRanges)
-	}
-	if err := msstw.maybeCreateNewFile(ctx); err != nil {
-		return errors.Wrap(err, "failed to create SST file for Put")
 	}
 	if err := msstw.currSST.Put(key, value); err != nil {
 		return errors.Wrap(err, "failed to put in sst")
@@ -241,7 +200,6 @@ func (msstw *multiSSTWriter) Finish(ctx context.Context) error {
 	return nil
 }
 
-// Close is idempotent.
 func (msstw *multiSSTWriter) Close() {
 	msstw.currSST.Close()
 }
@@ -262,7 +220,7 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 	// At the moment we'll write at most three SSTs.
 	// TODO(jeffreyxiao): Re-evaluate as the default range size grows.
 	keyRanges := rditer.MakeReplicatedKeyRanges(header.State.Desc)
-	msstw, err := newMultiSSTWriter(ctx, kvSS.scratch, keyRanges, kvSS.sstChunkSize, kvSS.reader)
+	msstw, err := newMultiSSTWriter(ctx, kvSS.scratch, keyRanges, kvSS.sstChunkSize)
 	if err != nil {
 		return noSnap, err
 	}
@@ -304,8 +262,8 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 		if req.Final {
 			// We finished receiving all batches and log entries. It's possible that
 			// we did not receive any key-value pairs for some of the key ranges, but
-			// we must still construct SSTs with range deletion tombstones for
-			// non-empty ranges in order to remove the data.
+			// we must still construct SSTs with range deletion tombstones to remove
+			// the data.
 			if err := msstw.Finish(ctx); err != nil {
 				return noSnap, err
 			}
@@ -818,7 +776,6 @@ func (s *Store) receiveSnapshot(
 			raftCfg:      &s.cfg.RaftConfig,
 			scratch:      s.sstSnapshotStorage.NewScratchSpace(header.State.Desc.RangeID, snapUUID),
 			sstChunkSize: snapshotSSTWriteSyncRate.Get(&s.cfg.Settings.SV),
-			reader:       s.Engine(),
 		}
 		defer ss.Close(ctx)
 	default:


### PR DESCRIPTION
Backport 1/1 commits from #47284.

/cc @cockroachdb/release

---

This reverts commit 37a1bd1705065df1f67f8606458f065336d08c67. See the discussion in https://github.com/cockroachdb/cockroach/issues/44048#issuecomment-610071732 for why that change is deemed unsafe.

Release justification: reverts a change that we no longer believe is safe and could cause extremely high-priority bugs like replica data inconsistency.
