### PR TITLE
colexec: clean up some window functions

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/rank_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/rank_gen.go
@@ -69,10 +69,12 @@ func genRankOps(wr io.Writer) error {
 
 	s = strings.Replace(s, "_RANK_STRING", "{{.String}}", -1)
 
+	computeRankRe := makeFunctionRegex("_COMPUTE_RANK", 0)
+	s = computeRankRe.ReplaceAllString(s, `{{template "computeRank" buildDict "Global" . "HasPartition" .HasPartition}}`)
 	updateRankRe := makeFunctionRegex("_UPDATE_RANK", 0)
-	s = updateRankRe.ReplaceAllString(s, makeTemplateFunctionCall("UpdateRank", 0))
+	s = updateRankRe.ReplaceAllString(s, makeTemplateFunctionCall("Global.UpdateRank", 0))
 	updateRankIncrementRe := makeFunctionRegex("_UPDATE_RANK_INCREMENT", 0)
-	s = updateRankIncrementRe.ReplaceAllString(s, makeTemplateFunctionCall("UpdateRankIncrement", 0))
+	s = updateRankIncrementRe.ReplaceAllString(s, makeTemplateFunctionCall("Global.UpdateRankIncrement", 0))
 
 	// Now, generate the op, from the template.
 	tmpl, err := template.New("rank_op").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)

--- a/pkg/sql/colexec/execgen/cmd/execgen/row_number_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/row_number_gen.go
@@ -34,6 +34,9 @@ func genRowNumberOp(wr io.Writer) error {
 
 	s = strings.Replace(s, "_ROW_NUMBER_STRING", "{{.String}}", -1)
 
+	computeRowNumberRe := makeFunctionRegex("_COMPUTE_ROW_NUMBER", 0)
+	s = computeRowNumberRe.ReplaceAllString(s, `{{template "computeRowNumber" buildDict "HasPartition" .HasPartition}}`)
+
 	// Now, generate the op, from the template.
 	tmpl, err := template.New("row_number_op").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
 	if err != nil {

--- a/pkg/sql/colexec/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/relative_rank_tmpl.go
@@ -423,12 +423,14 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 			r.scratch = r.allocator.NewMemBatchWithSize(r.inputTypes, n)
 			r.allocator.PerformOperation(r.scratch.ColVecs(), func() {
 				for colIdx, vec := range r.scratch.ColVecs() {
-					vec.Append(
-						coldata.SliceArgs{
-							ColType:   typeconv.FromColumnType(&r.inputTypes[colIdx]),
-							Src:       batch.ColVec(colIdx),
-							Sel:       sel,
-							SrcEndIdx: n,
+					vec.Copy(
+						coldata.CopySliceArgs{
+							SliceArgs: coldata.SliceArgs{
+								ColType:   typeconv.FromColumnType(&r.inputTypes[colIdx]),
+								Src:       batch.ColVec(colIdx),
+								Sel:       sel,
+								SrcEndIdx: n,
+							},
 						},
 					)
 				}
@@ -510,13 +512,15 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 
 			r.output.ResetInternalBatch()
 			// First, we copy over the buffered up columns.
-			r.allocator.PerformOperation(r.output.ColVecs()[:r.outputColIdx], func() {
-				for colIdx, vec := range r.output.ColVecs()[:r.outputColIdx] {
-					vec.Append(
-						coldata.SliceArgs{
-							ColType:   typeconv.FromColumnType(&r.inputTypes[colIdx]),
-							Src:       r.scratch.ColVec(colIdx),
-							SrcEndIdx: n,
+			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
+				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {
+					vec.Copy(
+						coldata.CopySliceArgs{
+							SliceArgs: coldata.SliceArgs{
+								ColType:   typeconv.FromColumnType(&r.inputTypes[colIdx]),
+								Src:       r.scratch.ColVec(colIdx),
+								SrcEndIdx: n,
+							},
 						},
 					)
 				}

--- a/pkg/sql/colexec/window_functions_test.go
+++ b/pkg/sql/colexec/window_functions_test.go
@@ -75,9 +75,19 @@ func TestWindowFunctions(t *testing.T) {
 		flowCtx.Cfg.TestingKnobs.ForceDiskSpill = spillForced
 		for _, tc := range []windowFnTestCase{
 			// With PARTITION BY, no ORDER BY.
-			//
-			// Without ORDER BY, the output of row_number is non-deterministic, so we
-			// skip such a case for rowNumberFn.
+			{
+				tuples:   tuples{{1}, {1}, {1}, {2}, {2}, {3}},
+				expected: tuples{{1, 1}, {1, 2}, {1, 3}, {2, 1}, {2, 2}, {3, 1}},
+				windowerSpec: execinfrapb.WindowerSpec{
+					PartitionBy: []uint32{0},
+					WindowFns: []execinfrapb.WindowerSpec_WindowFn{
+						{
+							Func:         execinfrapb.WindowerSpec_Func{WindowFunc: &rowNumberFn},
+							OutputColIdx: 1,
+						},
+					},
+				},
+			},
 			{
 				tuples:   tuples{{3}, {1}, {2}, {nil}, {1}, {nil}, {3}},
 				expected: tuples{{nil, 1}, {nil, 1}, {1, 1}, {1, 1}, {2, 1}, {3, 1}, {3, 1}},


### PR DESCRIPTION
**colexec: fix row number window function in unused code path**

This commit fixes a bug with `row_number` window function when it has
`PARTITION BY` clause when the selection vector is present on the batch.
When a new partition is encountered, we need to reset the running
`rowNumber` variable to 0 and then increment it by 1 to get the first
row's correct row number in the new partition. Previously, we were
incorrectly resetting it to 1 and then incrementing (this would result
in all partitions except for the first one to not have a row with row
number 1). This is now fixed and the code has been improved.

However, currently this code path could not be triggered because:
1. we need to have PARTITION BY clause
2. the only way we handle PARTITION BY clause right now is by planning
a sort in front of the window function
3. the sort will perform "deselection" on its input batches.

Nonetheless, it is good idea to fix it.

Release note: None

**colexec: clean up rank and dense rank templates**

This commit cleans up `rank_tmpl` file to factor out sel vs non-sel
cases to remove the repetition.

Release note: None