### PR TITLE
logictest: disable gc job; print statement timings

### DIFF
--- a/pkg/sql/gcjob/gc_job.go
+++ b/pkg/sql/gcjob/gc_job.go
@@ -86,6 +86,9 @@ func (r schemaChangeGCResumer) Resume(
 	p := phs.(sql.PlanHookState)
 	// TODO(pbardea): Wait for no versions.
 	execCfg := p.ExecCfg()
+	if execCfg.GCJobTestingKnobs.Disable {
+		return nil
+	}
 	if fn := execCfg.GCJobTestingKnobs.RunBeforeResume; fn != nil {
 		if err := fn(r.jobID); err != nil {
 			return err

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/mutations"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -1140,6 +1141,10 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 				Store: &kvserver.StoreTestingKnobs{
 					// The consistency queue makes a lot of noisy logs during logic tests.
 					DisableConsistencyQueue: true,
+				},
+				GCJob: &sql.GCJobTestingKnobs{
+					// Disable the GC Job for tests, as it's costly.
+					Disable: true,
 				},
 				SQLEvalContext: &tree.EvalContextTestingKnobs{
 					AssertBinaryExprReturnTypes:     true,

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2115,10 +2115,14 @@ func (t *logicTest) execStatement(stmt logicStatement) (bool, error) {
 		t.outf("%s;", stmt.sql)
 	}
 	execSQL, changed := mutations.ApplyString(t.rng, stmt.sql, mutations.ColumnFamilyMutator)
+	n := time.Now()
+	res, err := t.db.Exec(execSQL)
+	if *showSQL {
+		t.outf("%s; -- %s", stmt.sql, time.Since(n))
+	}
 	if changed {
 		t.outf("rewrote:\n%s\n", execSQL)
 	}
-	res, err := t.db.Exec(execSQL)
 	if err == nil {
 		sqlutils.VerifyStatementPrettyRoundtrip(t.t(), stmt.sql)
 	}

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1420,6 +1420,8 @@ func CreateGCJobRecord(
 // dependencies.
 type GCJobTestingKnobs struct {
 	RunBeforeResume func(jobID int64) error
+	// Disable disables the GC Job from running altogether.
+	Disable bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
- Disable the GC job in logic tests, which was using up to 1/6th of the CPU time in a DDL-heavy test
- Print statement timings in -show-sql