### PR TITLE
gcjob: fix zone config gossip update filtering

### DIFF
--- a/pkg/sql/gcjob/gc_job.go
+++ b/pkg/sql/gcjob/gc_job.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -95,7 +96,7 @@ func (r schemaChangeGCResumer) Resume(
 	if err != nil {
 		return err
 	}
-	_, gossipUpdateC := setupConfigWatcher(execCfg)
+	zoneCfgFilter, gossipUpdateC := setupConfigWatcher(execCfg)
 	tableDropTimes, indexDropTimes := getDropTimes(details)
 
 	allTables := getAllTablesWaitingForGC(details, progress)
@@ -125,6 +126,15 @@ func (r schemaChangeGCResumer) Resume(
 			// TTL whenever we get an update on one of the tables/indexes (or the db)
 			// that this job is responsible for, and computing the earliest deadline
 			// from our set of cached TTL values.
+			cfg := execCfg.Gossip.GetSystemConfig()
+			zoneConfigUpdated := false
+			zoneCfgFilter.ForModified(cfg, func(kv roachpb.KeyValue) {
+				zoneConfigUpdated = true
+			})
+			if !zoneConfigUpdated {
+				log.VEventf(ctx, 2, "no zone config updates, continuing")
+				continue
+			}
 			remainingTables := getAllTablesWaitingForGC(details, progress)
 			if len(remainingTables) == 0 {
 				return nil


### PR DESCRIPTION
Previously, in the GC job, we were unintentionally refreshing all the
table descriptors on every system config gossip update. This involved a
round-trip to fetch the table descriptor from KV for every table. This
PR fixes this by using a filter for just the zone configs (which was
already implemented; we just weren't using it correctly), so that we
only refresh the tables on a zone config update.

This PR is intended to be a minimal change to bring about the intended
behavior, and I haven't tried to be more sophisticated in, e.g.,
refreshing the tables only on a zone config update that actually affects
the tables to be dropped.

Closes #47312.

Release note (bug fix): Fixed a bug in the new schema change GC job
implementation causing unnecessary table descriptor lookups whenever any
table was updated.