### PR TITLE
sql: SHOW SAVEPOINT STATUS is unsupported as statement source

### DIFF
--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 )
 
 // Certain statements (most SHOW variants) are just syntactic sugar for a more
@@ -107,6 +108,9 @@ func TryDelegate(
 
 	case *tree.ShowTransactionStatus:
 		return d.delegateShowVar(&tree.ShowVar{Name: "transaction_status"})
+
+	case *tree.ShowSavepointStatus:
+		return nil, unimplemented.NewWithIssue(47333, "cannot use SHOW SAVEPOINT STATUS as a statement source")
 
 	default:
 		return nil, nil

--- a/pkg/sql/logictest/testdata/logic_test/statement_source
+++ b/pkg/sql/logictest/testdata/logic_test/statement_source
@@ -88,3 +88,8 @@ query III
 SELECT * FROM [INSERT INTO b VALUES(2,3) RETURNING b] JOIN [INSERT INTO b VALUES(4,5) RETURNING b, a] ON true;
 ----
 3 5 4
+
+subtest unsupported_47333
+
+query error unimplemented: cannot use SHOW SAVEPOINT STATUS as a statement source
+SELECT * FROM [SHOW SAVEPOINT STATUS]


### PR DESCRIPTION
Informs #47333

For now, SHOW SAVEPOINT STATUS can only be used as top-level
statement. This patch ensures that an attempt to use it as statement
source reports a useful error.

Release note: None