### PR TITLE
opt: add SplitDisjunctionAddKey exploration rule for disjunctions

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -139,23 +139,19 @@ WHERE
     OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27))
     AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
 ----
-·               distributed   false                                                                                                       ·                   ·
-·               vectorized    false                                                                                                       ·                   ·
-root            ·             ·                                                                                                           (col0)              ·
- ├── render     ·             ·                                                                                                           (col0)              ·
- │    │         render 0      col0                                                                                                        ·                   ·
- │    └── scan  ·             ·                                                                                                           (col0, col3, col4)  ·
- │              table         tab4@primary                                                                                                ·                   ·
- │              spans         FULL SCAN                                                                                                   ·                   ·
- │              filter        ((col0 <= 0) AND (col4 <= 5.38)) OR ((((col4 = ANY @S1) AND (col3 <= 5)) AND (col3 >= 7)) AND (col3 <= 9))  ·                   ·
- └── subquery   ·             ·                                                                                                           (col0)              ·
-      │         id            @S1                                                                                                         ·                   ·
-      │         original sql  (SELECT col1 FROM tab4 WHERE col1 > 8.27)                                                                   ·                   ·
-      │         exec mode     all rows normalized                                                                                         ·                   ·
-      └── scan  ·             ·                                                                                                           (col1)              ·
-·               table         tab4@primary                                                                                                ·                   ·
-·               spans         FULL SCAN                                                                                                   ·                   ·
-·               filter        col1 > 8.27                                                                                                 ·                   ·
+·                     distributed  false            ·                                  ·
+·                     vectorized   false            ·                                  ·
+render                ·            ·                (col0)                             ·
+ │                    render 0     col0             ·                                  ·
+ └── union            ·            ·                (col0, col3, col4, rowid[hidden])  ·
+      ├── norows      ·            ·                (col0, col3, col4, rowid)          ·
+      └── index-join  ·            ·                (col0, col3, col4, rowid[hidden])  ·
+           │          table        tab4@primary     ·                                  ·
+           │          key columns  rowid            ·                                  ·
+           └── scan   ·            ·                (col0, col4, rowid[hidden])        ·
+·                     table        tab4@idx_tab4_0  ·                                  ·
+·                     spans        /!NULL-/5.38/1   ·                                  ·
+·                     filter       col0 <= 0        ·                                  ·
 
 # ------------------------------------------------------------------------------
 # Correlated subqueries.

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -391,8 +391,11 @@ func (c *CustomFuncs) sharedProps(e opt.Expr) *props.Shared {
 		return &t.Relational().Shared
 	case memo.ScalarPropsExpr:
 		return &t.ScalarProps().Shared
+	default:
+		var p props.Shared
+		memo.BuildSharedProps(e, &p)
+		return &p
 	}
-	panic(errors.AssertionFailedf("no logical properties available for node: %v", e))
 }
 
 // MutationTable returns the table upon which the mutation is applied.

--- a/pkg/sql/opt/xform/rules/select.opt
+++ b/pkg/sql/opt/xform/rules/select.opt
@@ -28,7 +28,7 @@
 =>
 (GenerateInvertedIndexScans $scanPrivate $filters)
 
-# GenerateUnionSelects splits disjunctions (Or expressions) into a Union of two
+# SplitDisjunction splits disjunctions (Or expressions) into a Union of two
 # Select expressions, the first containing the left sub-expression of the Or
 # expression and the second containing the right sub-expression. All other
 # filter items in the original expression are preserved in the new Select
@@ -42,29 +42,9 @@
 # constraints do not need to be duplicated in the left and right scans of the
 # union.
 #
-# Also note that this rule only matches Selects that have strict keys. This is
-# required to prevent the generated Union from de-duplicating rows that have
-# the same selected values. For example, consider the following:
-#
-#     CREATE TABLE t (k INT PRIMARY KEY, a INT, b INT)
-#     INSERT INTO t VALUES (1, 1, 3)
-#     INSERT INTO t VALUES (2, 1, 3)
-#
-# The expected result of the following Select query is 2 rows, with values
-# (1, 3).
-#
-#     SELECT a, b FROM t WHERE a = 1 OR b = 3
-#
-# However, Union de-duplicates all tuples with the same set of values. So, the
-# query below returns only a single row.
-#
-#     SELECT a, b FROM t WHERE a = 1
-#     UNION
-#     SELECT a, b FROM t WHERE b = 3
-#
-# With a key in the output columns, each input row to the Union is guaranteed to
-# be unique, and therefore will not be incorrectly de-duplicated.
-[GenerateUnionSelects, Explore]
+# Also note that this rule only matches Selects that have strict keys. See
+# SplitDisjunctionAddKey which handles Selects that do not have strict keys.
+[SplitDisjunction, Explore]
 (Select
     $input:(Scan
         $scanPrivate:* & (IsCanonicalScan $scanPrivate)
@@ -72,9 +52,9 @@
     $filters:[
         ...
         $item:(FiltersItem (Or $left:* $right:*)) &
-            ^(ColsAreEqual (ExprOuterCols $left) (ExprOuterCols $right)) &
-            (CanMaybeConstrainIndexWithExpr $scanPrivate $left) &
-            (CanMaybeConstrainIndexWithExpr $scanPrivate $right)
+            ^(ColsAreEqual (OuterCols $left) (OuterCols $right)) &
+            (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols $left)) &
+            (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols $right))
         ...
     ]
 )
@@ -85,12 +65,77 @@
         (ReplaceFiltersItem $filters $item $left)
     )
     (Select
-        (Scan $rightScan:(DuplicateScanPrivate $scanPrivate))
+        (Scan $rightScanPrivate:(DuplicateScanPrivate $scanPrivate))
         (MapScanFilterCols
             (ReplaceFiltersItem $filters $item $right)
             $scanPrivate
-            $rightScan
+            $rightScanPrivate
         )
     )
-    (MakeSetPrivateForUnionSelects $scanPrivate $rightScan $scanPrivate)
+    (MakeSetPrivateForUnionSelects $scanPrivate $rightScanPrivate)
+)
+
+# SplitDisjunctionAddKey performs a transformation similar to
+# SplitDisjunction, but it handles the special case when the original Scan
+# does not have a strict key in its ColSet.
+#
+# For this special case, the replace pattern adds primary key columns to the
+# original Scan ColSet. It also adds a Project to remove those columns after the
+# Union operation. Inclusion of the primary keys is required to prevent the
+# generated Union from de-duplicating rows that have the same selected values.
+#
+# To understand why the addition of the primary key columns to the Scans is
+# necessary, consider the following:
+#
+#     CREATE TABLE t (k INT PRIMARY KEY, a INT, b INT)
+#     INSERT INTO t VALUES (1, 1, 3)
+#     INSERT INTO t VALUES (2, 1, 3)
+#     SELECT a, b FROM t WHERE a = 1 OR b = 3
+#
+# The expected result of the Select query is 2 rows, with values (1, 3). Now
+# consider the following query:
+#
+#     SELECT a, b FROM t WHERE a = 1
+#     UNION
+#     SELECT a, b FROM t WHERE b = 3
+#
+# Union de-duplicates all tuples with the same set of values. So, this
+# query returns only a single row.
+#
+# By adding a primary key in the output columns, each input row to the Union is
+# guaranteed to be unique. This prevents incorrect de-duplication and guarantees
+# that the newly generated plan is equivalent to the original plan.
+[SplitDisjunctionAddKey, Explore]
+(Select
+    $input:(Scan
+        $scanPrivate:* & (IsCanonicalScan $scanPrivate)
+    ) & ^(HasStrictKey $input)
+    $filters:[
+        ...
+        $item:(FiltersItem (Or $left:* $right:*)) &
+            ^(ColsAreEqual (OuterCols $left) (OuterCols $right)) &
+            (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols $left)) &
+            (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols $right))
+        ...
+    ]
+)
+=>
+(Project
+    (Union
+        (Select
+            (Scan $leftScanPrivate:(AddPrimaryKeyColsToScanPrivate $scanPrivate))
+            (ReplaceFiltersItem $filters $item $left)
+        )
+        (Select
+            (Scan $rightScanPrivate:(DuplicateScanPrivate $leftScanPrivate))
+            (MapScanFilterCols
+                (ReplaceFiltersItem $filters $item $right)
+                $leftScanPrivate
+                $rightScanPrivate
+            )
+        )
+        (MakeSetPrivateForUnionSelects $leftScanPrivate $rightScanPrivate)
+    )
+    []
+    (OutputCols $input)
 )

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -55,6 +55,17 @@ CREATE TABLE e
 )
 ----
 
+exec-ddl
+CREATE TABLE no_explicit_primary_key
+(
+    k INT,
+    u INT,
+    v INT,
+    INDEX u(u),
+    INDEX v(v)
+)
+----
+
 # --------------------------------------------------
 # GenerateConstrainedScans
 # --------------------------------------------------
@@ -1035,10 +1046,10 @@ project
 
 
 # --------------------------------------------------
-# GenerateUnionSelects
+# SplitDisjunction
 # --------------------------------------------------
 
-opt expect=GenerateUnionSelects
+opt expect=SplitDisjunction
 SELECT k FROM d WHERE u = 1 OR v = 1
 ----
 project
@@ -1069,7 +1080,7 @@ project
                 ├── key: (5)
                 └── fd: ()-->(7)
 
-opt expect=GenerateUnionSelects
+opt expect=SplitDisjunction
 SELECT * FROM d WHERE w = 1 AND (u = 1 OR v = 1)
 ----
 union
@@ -1109,7 +1120,7 @@ union
       └── filters
            └── w:8 = 1 [outer=(8), constraints=(/8: [/1 - /1]; tight), fd=()-->(8)]
 
-opt expect=GenerateUnionSelects
+opt expect=SplitDisjunction
 SELECT k FROM d WHERE (u = 1 OR v = 2) AND (u = 10 OR v = 20)
 ----
 project
@@ -1142,8 +1153,44 @@ project
                 ├── v:7 = 2 [outer=(7), constraints=(/7: [/2 - /2]; tight), fd=()-->(7)]
                 └── u:6 = 10 [outer=(6), constraints=(/6: [/10 - /10]; tight), fd=()-->(6)]
 
+opt expect=SplitDisjunction
+SELECT count(k) FROM d WHERE u = 1 OR v = 1
+----
+scalar-group-by
+ ├── columns: count:5!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(5)
+ ├── union
+ │    ├── columns: k:1!null u:2 v:3
+ │    ├── left columns: k:1!null u:2 v:3
+ │    ├── right columns: k:6 u:7 v:8
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── index-join d
+ │    │    ├── columns: k:1!null u:2!null v:3
+ │    │    ├── key: (1)
+ │    │    ├── fd: ()-->(2), (1)-->(3)
+ │    │    └── scan d@u
+ │    │         ├── columns: k:1!null u:2!null
+ │    │         ├── constraint: /2/1: [/1 - /1]
+ │    │         ├── key: (1)
+ │    │         └── fd: ()-->(2)
+ │    └── index-join d
+ │         ├── columns: k:6!null u:7 v:8!null
+ │         ├── key: (6)
+ │         ├── fd: ()-->(8), (6)-->(7)
+ │         └── scan d@v
+ │              ├── columns: k:6!null v:8!null
+ │              ├── constraint: /8/6: [/1 - /1]
+ │              ├── key: (6)
+ │              └── fd: ()-->(8)
+ └── aggregations
+      └── count [as=count:5, outer=(1)]
+           └── k:1
+
 # Don't expand INs to many ORs.
-opt expect=GenerateUnionSelects
+opt expect=SplitDisjunction
 SELECT k FROM d WHERE u IN (1, 2, 3, 4) OR v IN (5, 6, 7, 8)
 ----
 project
@@ -1175,7 +1222,7 @@ project
                 └── fd: (5)-->(7)
 
 # Uncorrelated subquery.
-opt expect=GenerateUnionSelects
+opt expect=SplitDisjunction
 SELECT k FROM d WHERE (u = 1 OR v = 1) AND EXISTS (SELECT u, v FROM a)
 ----
 project
@@ -1229,7 +1276,7 @@ project
                                └── fd: ()-->(6,7)
 
 # Correlated subquery.
-opt expect=GenerateUnionSelects
+opt expect=SplitDisjunction
 SELECT k FROM d WHERE (u = 1 OR v = 1) AND EXISTS (SELECT * FROM a WHERE a.u = d.u)
 ----
 project
@@ -1279,7 +1326,7 @@ project
                 └── a.u:6 = d.u:2 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
 
 # Correlated subquery with references to outer columns not in the scan columns.
-opt expect=GenerateUnionSelects
+opt expect=SplitDisjunction
 SELECT k FROM d WHERE (u = 1 OR v = 1) AND EXISTS (SELECT * FROM a WHERE a.u = d.w)
 ----
 project
@@ -1329,7 +1376,7 @@ project
                 └── a.u:6 = w:4 [outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ]), fd=(4)==(6), (6)==(4)]
 
 # Apply when outer columns of both sides of OR are a subset of index columns.
-opt expect=GenerateUnionSelects
+opt expect=SplitDisjunction
 SELECT k, u, v FROM e WHERE u = 1 OR v = 1
 ----
 union
@@ -1358,7 +1405,7 @@ union
            └── fd: ()-->(7)
 
 # Apply when outer columns of both sides of OR are a superset of index columns.
-opt expect=GenerateUnionSelects
+opt expect=SplitDisjunction
 SELECT k, u, v FROM d WHERE (u = 1 AND w = 2) OR (v = 1 AND w = 3)
 ----
 project
@@ -1403,7 +1450,7 @@ project
                 └── w:8 = 3 [outer=(8), constraints=(/8: [/3 - /3]; tight), fd=()-->(8)]
 
 # Don't apply when outer columns of both sides of OR do not intersect with index columns.
-opt expect-not=GenerateUnionSelects
+opt expect-not=SplitDisjunction
 SELECT k, u, w FROM d WHERE u = 1 OR w = 1
 ----
 select
@@ -1418,18 +1465,37 @@ select
       └── (u:2 = 1) OR (w:4 = 1) [outer=(2,4)]
 
 # Don't apply to queries without strict keys.
-opt expect-not=GenerateUnionSelects
+opt expect-not=SplitDisjunction
 SELECT u, v FROM d WHERE u = 1 OR v = 1
 ----
-select
+project
  ├── columns: u:2 v:3
- ├── scan d
- │    └── columns: u:2 v:3
- └── filters
-      └── (u:2 = 1) OR (v:3 = 1) [outer=(2,3)]
+ └── union
+      ├── columns: k:1!null u:2 v:3
+      ├── left columns: k:1!null u:2 v:3
+      ├── right columns: k:5 u:6 v:7
+      ├── key: (1-3)
+      ├── index-join d
+      │    ├── columns: k:1!null u:2!null v:3
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2), (1)-->(3)
+      │    └── scan d@u
+      │         ├── columns: k:1!null u:2!null
+      │         ├── constraint: /2/1: [/1 - /1]
+      │         ├── key: (1)
+      │         └── fd: ()-->(2)
+      └── index-join d
+           ├── columns: k:5!null u:6 v:7!null
+           ├── key: (5)
+           ├── fd: ()-->(7), (5)-->(6)
+           └── scan d@v
+                ├── columns: k:5!null v:7!null
+                ├── constraint: /7/5: [/1 - /1]
+                ├── key: (5)
+                └── fd: ()-->(7)
 
 # Don't apply to disjunctions with identical colsets on the left and right.
-opt expect-not=GenerateUnionSelects
+opt expect-not=SplitDisjunction
 SELECT k FROM d WHERE u = 1 OR u = 5
 ----
 project
@@ -1443,23 +1509,526 @@ project
       ├── key: (1)
       └── fd: (1)-->(2)
 
-# Verifies that flags are copied to the duplicated scan. By forcing a single
-# index, the generated expression with a UNION has a higher cost and is not
-# part of the final expression.
-opt
-SELECT k FROM d@primary WHERE u = 1 OR v = 1
+# Verifies that flags are copied to the duplicated scan.
+opt expect=SplitDisjunction
+SELECT k FROM a@{NO_INDEX_JOIN} WHERE u = 1 OR v = 1
 ----
 project
  ├── columns: k:1!null
  ├── key: (1)
- └── select
+ └── union
       ├── columns: k:1!null u:2 v:3
+      ├── left columns: k:1!null u:2 v:3
+      ├── right columns: k:4 u:5 v:6
       ├── key: (1)
-      ├── fd: (1)-->(2,3)
-      ├── scan d
-      │    ├── columns: k:1!null u:2 v:3
-      │    ├── flags: force-index=primary
+      ├── fd: (1)-->(2,3), (3)~~>(1,2)
+      ├── scan a@u
+      │    ├── columns: k:1!null u:2!null v:3
+      │    ├── constraint: /2/1: [/1 - /1]
+      │    ├── flags: no-index-join
       │    ├── key: (1)
-      │    └── fd: (1)-->(2,3)
+      │    └── fd: ()-->(2), (1)-->(3), (3)~~>(1)
+      └── scan a@v
+           ├── columns: k:4!null u:5 v:6!null
+           ├── constraint: /6: [/1 - /1]
+           ├── flags: no-index-join
+           ├── cardinality: [0 - 1]
+           ├── key: ()
+           └── fd: ()-->(4-6)
+
+# --------------------------------------------------
+# SplitDisjunctionAddKey
+# --------------------------------------------------
+
+opt expect=SplitDisjunctionAddKey
+SELECT u, v FROM d WHERE u = 1 OR v = 1
+----
+project
+ ├── columns: u:2 v:3
+ └── union
+      ├── columns: k:1!null u:2 v:3
+      ├── left columns: k:1!null u:2 v:3
+      ├── right columns: k:5 u:6 v:7
+      ├── key: (1-3)
+      ├── index-join d
+      │    ├── columns: k:1!null u:2!null v:3
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2), (1)-->(3)
+      │    └── scan d@u
+      │         ├── columns: k:1!null u:2!null
+      │         ├── constraint: /2/1: [/1 - /1]
+      │         ├── key: (1)
+      │         └── fd: ()-->(2)
+      └── index-join d
+           ├── columns: k:5!null u:6 v:7!null
+           ├── key: (5)
+           ├── fd: ()-->(7), (5)-->(6)
+           └── scan d@v
+                ├── columns: k:5!null v:7!null
+                ├── constraint: /7/5: [/1 - /1]
+                ├── key: (5)
+                └── fd: ()-->(7)
+
+opt expect=SplitDisjunctionAddKey
+SELECT u, v, w FROM d WHERE w = 1 AND (u = 1 OR v = 1)
+----
+project
+ ├── columns: u:2 v:3 w:4!null
+ ├── fd: ()-->(4)
+ └── union
+      ├── columns: k:1!null u:2 v:3 w:4!null
+      ├── left columns: k:1!null u:2 v:3 w:4!null
+      ├── right columns: k:5 u:6 v:7 w:8
+      ├── key: (1-4)
+      ├── select
+      │    ├── columns: k:1!null u:2!null v:3 w:4!null
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2,4), (1)-->(3)
+      │    ├── index-join d
+      │    │    ├── columns: k:1!null u:2 v:3 w:4
+      │    │    ├── key: (1)
+      │    │    ├── fd: ()-->(2), (1)-->(3,4)
+      │    │    └── scan d@u
+      │    │         ├── columns: k:1!null u:2!null
+      │    │         ├── constraint: /2/1: [/1 - /1]
+      │    │         ├── key: (1)
+      │    │         └── fd: ()-->(2)
+      │    └── filters
+      │         └── w:4 = 1 [outer=(4), constraints=(/4: [/1 - /1]; tight), fd=()-->(4)]
+      └── select
+           ├── columns: k:5!null u:6 v:7!null w:8!null
+           ├── key: (5)
+           ├── fd: ()-->(7,8), (5)-->(6)
+           ├── index-join d
+           │    ├── columns: k:5!null u:6 v:7 w:8
+           │    ├── key: (5)
+           │    ├── fd: ()-->(7), (5)-->(6,8)
+           │    └── scan d@v
+           │         ├── columns: k:5!null v:7!null
+           │         ├── constraint: /7/5: [/1 - /1]
+           │         ├── key: (5)
+           │         └── fd: ()-->(7)
+           └── filters
+                └── w:8 = 1 [outer=(8), constraints=(/8: [/1 - /1]; tight), fd=()-->(8)]
+
+opt expect=SplitDisjunctionAddKey
+SELECT u, v FROM d WHERE (u = 1 OR v = 2) AND (u = 10 OR v = 20)
+----
+project
+ ├── columns: u:2 v:3
+ └── union
+      ├── columns: k:1!null u:2!null v:3!null
+      ├── left columns: k:1!null u:2!null v:3!null
+      ├── right columns: k:5 u:6 v:7
+      ├── key: (1-3)
+      ├── inner-join (zigzag d@u d@v)
+      │    ├── columns: k:1!null u:2!null v:3!null
+      │    ├── eq columns: [1] = [1]
+      │    ├── left fixed columns: [2] = [1]
+      │    ├── right fixed columns: [3] = [20]
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2,3)
+      │    └── filters
+      │         ├── u:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+      │         └── v:3 = 20 [outer=(3), constraints=(/3: [/20 - /20]; tight), fd=()-->(3)]
+      └── inner-join (zigzag d@u d@v)
+           ├── columns: k:5!null u:6!null v:7!null
+           ├── eq columns: [5] = [5]
+           ├── left fixed columns: [6] = [10]
+           ├── right fixed columns: [7] = [2]
+           ├── key: (5)
+           ├── fd: ()-->(6,7)
+           └── filters
+                ├── v:7 = 2 [outer=(7), constraints=(/7: [/2 - /2]; tight), fd=()-->(7)]
+                └── u:6 = 10 [outer=(6), constraints=(/6: [/10 - /10]; tight), fd=()-->(6)]
+
+opt expect=SplitDisjunctionAddKey
+SELECT count(*) FROM d WHERE u = 1 OR v = 1
+----
+scalar-group-by
+ ├── columns: count:5!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(5)
+ ├── project
+ │    ├── columns: u:2 v:3
+ │    └── union
+ │         ├── columns: k:1!null u:2 v:3
+ │         ├── left columns: k:1!null u:2 v:3
+ │         ├── right columns: k:6 u:7 v:8
+ │         ├── key: (1-3)
+ │         ├── index-join d
+ │         │    ├── columns: k:1!null u:2!null v:3
+ │         │    ├── key: (1)
+ │         │    ├── fd: ()-->(2), (1)-->(3)
+ │         │    └── scan d@u
+ │         │         ├── columns: k:1!null u:2!null
+ │         │         ├── constraint: /2/1: [/1 - /1]
+ │         │         ├── key: (1)
+ │         │         └── fd: ()-->(2)
+ │         └── index-join d
+ │              ├── columns: k:6!null u:7 v:8!null
+ │              ├── key: (6)
+ │              ├── fd: ()-->(8), (6)-->(7)
+ │              └── scan d@v
+ │                   ├── columns: k:6!null v:8!null
+ │                   ├── constraint: /8/6: [/1 - /1]
+ │                   ├── key: (6)
+ │                   └── fd: ()-->(8)
+ └── aggregations
+      └── count-rows [as=count_rows:5]
+
+# Don't expand INs to many ORs.
+opt expect=SplitDisjunctionAddKey
+SELECT u, v FROM d WHERE u IN (1, 2, 3, 4) OR v IN (5, 6, 7, 8)
+----
+project
+ ├── columns: u:2 v:3
+ └── union
+      ├── columns: k:1!null u:2 v:3
+      ├── left columns: k:1!null u:2 v:3
+      ├── right columns: k:5 u:6 v:7
+      ├── key: (1-3)
+      ├── index-join d
+      │    ├── columns: k:1!null u:2!null v:3
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,3)
+      │    └── scan d@u
+      │         ├── columns: k:1!null u:2!null
+      │         ├── constraint: /2/1: [/1 - /4]
+      │         ├── key: (1)
+      │         └── fd: (1)-->(2)
+      └── index-join d
+           ├── columns: k:5!null u:6 v:7!null
+           ├── key: (5)
+           ├── fd: (5)-->(6,7)
+           └── scan d@v
+                ├── columns: k:5!null v:7!null
+                ├── constraint: /7/5: [/5 - /8]
+                ├── key: (5)
+                └── fd: (5)-->(7)
+
+# Uncorrelated subquery.
+opt expect=SplitDisjunctionAddKey
+SELECT u, v FROM d WHERE (u = 1 OR v = 1) AND EXISTS (SELECT u, v FROM a)
+----
+project
+ ├── columns: u:2 v:3
+ └── union
+      ├── columns: d.k:1!null d.u:2 d.v:3
+      ├── left columns: d.k:1!null d.u:2 d.v:3
+      ├── right columns: d.k:8 d.u:9 d.v:10
+      ├── key: (1-3)
+      ├── index-join d
+      │    ├── columns: d.k:1!null d.u:2!null d.v:3
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2), (1)-->(3)
+      │    └── select
+      │         ├── columns: d.k:1!null d.u:2!null
+      │         ├── key: (1)
+      │         ├── fd: ()-->(2)
+      │         ├── scan d@u
+      │         │    ├── columns: d.k:1!null d.u:2!null
+      │         │    ├── constraint: /2/1: [/1 - /1]
+      │         │    ├── key: (1)
+      │         │    └── fd: ()-->(2)
+      │         └── filters
+      │              └── exists [subquery]
+      │                   └── scan a
+      │                        ├── columns: a.u:6 a.v:7
+      │                        ├── limit: 1
+      │                        ├── key: ()
+      │                        └── fd: ()-->(6,7)
+      └── index-join d
+           ├── columns: d.k:8!null d.u:9 d.v:10!null
+           ├── key: (8)
+           ├── fd: ()-->(10), (8)-->(9)
+           └── select
+                ├── columns: d.k:8!null d.v:10!null
+                ├── key: (8)
+                ├── fd: ()-->(10)
+                ├── scan d@v
+                │    ├── columns: d.k:8!null d.v:10!null
+                │    ├── constraint: /10/8: [/1 - /1]
+                │    ├── key: (8)
+                │    └── fd: ()-->(10)
+                └── filters
+                     └── exists [subquery]
+                          └── scan a
+                               ├── columns: a.u:6 a.v:7
+                               ├── limit: 1
+                               ├── key: ()
+                               └── fd: ()-->(6,7)
+
+# Correlated subquery.
+opt expect=SplitDisjunctionAddKey
+SELECT u, v FROM d WHERE (u = 1 OR v = 1) AND EXISTS (SELECT * FROM a WHERE a.u = d.u)
+----
+project
+ ├── columns: u:2 v:3
+ └── inner-join (hash)
+      ├── columns: d.u:2!null d.v:3 a.u:6!null
+      ├── fd: (2)==(6), (6)==(2)
+      ├── project
+      │    ├── columns: d.u:2 d.v:3
+      │    └── union
+      │         ├── columns: d.k:1!null d.u:2 d.v:3
+      │         ├── left columns: d.k:1!null d.u:2 d.v:3
+      │         ├── right columns: d.k:8 d.u:9 d.v:10
+      │         ├── key: (1-3)
+      │         ├── index-join d
+      │         │    ├── columns: d.k:1!null d.u:2!null d.v:3
+      │         │    ├── key: (1)
+      │         │    ├── fd: ()-->(2), (1)-->(3)
+      │         │    └── scan d@u
+      │         │         ├── columns: d.k:1!null d.u:2!null
+      │         │         ├── constraint: /2/1: [/1 - /1]
+      │         │         ├── key: (1)
+      │         │         └── fd: ()-->(2)
+      │         └── index-join d
+      │              ├── columns: d.k:8!null d.u:9 d.v:10!null
+      │              ├── key: (8)
+      │              ├── fd: ()-->(10), (8)-->(9)
+      │              └── scan d@v
+      │                   ├── columns: d.k:8!null d.v:10!null
+      │                   ├── constraint: /10/8: [/1 - /1]
+      │                   ├── key: (8)
+      │                   └── fd: ()-->(10)
+      ├── distinct-on
+      │    ├── columns: a.u:6
+      │    ├── grouping columns: a.u:6
+      │    ├── internal-ordering: +6
+      │    ├── key: (6)
+      │    └── scan a@u
+      │         ├── columns: a.u:6
+      │         └── ordering: +6
       └── filters
-           └── (u:2 = 1) OR (v:3 = 1) [outer=(2,3)]
+           └── a.u:6 = d.u:2 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+
+# Correlated subquery with references to outer columns not in the scan columns.
+opt expect=SplitDisjunctionAddKey
+SELECT u, v FROM d WHERE (u = 1 OR v = 1) AND EXISTS (SELECT * FROM a WHERE a.u = d.w)
+----
+project
+ ├── columns: u:2 v:3
+ └── project
+      ├── columns: d.u:2 d.v:3 w:4
+      └── inner-join (hash)
+           ├── columns: d.u:2 d.v:3 w:4!null a.u:6!null
+           ├── fd: (4)==(6), (6)==(4)
+           ├── project
+           │    ├── columns: d.u:2 d.v:3 w:4
+           │    └── union
+           │         ├── columns: d.k:1!null d.u:2 d.v:3 w:4
+           │         ├── left columns: d.k:1!null d.u:2 d.v:3 w:4
+           │         ├── right columns: d.k:8 d.u:9 d.v:10 w:11
+           │         ├── key: (1-4)
+           │         ├── index-join d
+           │         │    ├── columns: d.k:1!null d.u:2!null d.v:3 w:4
+           │         │    ├── key: (1)
+           │         │    ├── fd: ()-->(2), (1)-->(3,4)
+           │         │    └── scan d@u
+           │         │         ├── columns: d.k:1!null d.u:2!null
+           │         │         ├── constraint: /2/1: [/1 - /1]
+           │         │         ├── key: (1)
+           │         │         └── fd: ()-->(2)
+           │         └── index-join d
+           │              ├── columns: d.k:8!null d.u:9 d.v:10!null w:11
+           │              ├── key: (8)
+           │              ├── fd: ()-->(10), (8)-->(9,11)
+           │              └── scan d@v
+           │                   ├── columns: d.k:8!null d.v:10!null
+           │                   ├── constraint: /10/8: [/1 - /1]
+           │                   ├── key: (8)
+           │                   └── fd: ()-->(10)
+           ├── distinct-on
+           │    ├── columns: a.u:6
+           │    ├── grouping columns: a.u:6
+           │    ├── internal-ordering: +6
+           │    ├── key: (6)
+           │    └── scan a@u
+           │         ├── columns: a.u:6
+           │         └── ordering: +6
+           └── filters
+                └── a.u:6 = w:4 [outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ]), fd=(4)==(6), (6)==(4)]
+
+# Use rowid when there is no explicit primary key.
+opt expect=SplitDisjunctionAddKey
+SELECT u, v FROM no_explicit_primary_key WHERE u = 1 OR v = 5
+----
+project
+ ├── columns: u:2 v:3
+ └── union
+      ├── columns: u:2 v:3 rowid:4!null
+      ├── left columns: u:2 v:3 rowid:4!null
+      ├── right columns: u:6 v:7 rowid:8
+      ├── key: (2-4)
+      ├── index-join no_explicit_primary_key
+      │    ├── columns: u:2!null v:3 rowid:4!null
+      │    ├── key: (4)
+      │    ├── fd: ()-->(2), (4)-->(3)
+      │    └── scan no_explicit_primary_key@u
+      │         ├── columns: u:2!null rowid:4!null
+      │         ├── constraint: /2/4: [/1 - /1]
+      │         ├── key: (4)
+      │         └── fd: ()-->(2)
+      └── index-join no_explicit_primary_key
+           ├── columns: u:6 v:7!null rowid:8!null
+           ├── key: (8)
+           ├── fd: ()-->(7), (8)-->(6)
+           └── scan no_explicit_primary_key@v
+                ├── columns: v:7!null rowid:8!null
+                ├── constraint: /7/8: [/5 - /5]
+                ├── key: (8)
+                └── fd: ()-->(7)
+
+# Apply when outer columns of both sides of OR are a subset of index columns.
+opt expect=SplitDisjunctionAddKey
+SELECT u, v FROM e WHERE u = 1 OR v = 1
+----
+project
+ ├── columns: u:2 v:3
+ └── union
+      ├── columns: k:1!null u:2 v:3
+      ├── left columns: k:1!null u:2 v:3
+      ├── right columns: k:5 u:6 v:7
+      ├── key: (1-3)
+      ├── index-join e
+      │    ├── columns: k:1!null u:2!null v:3
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2), (1)-->(3)
+      │    └── scan e@uw
+      │         ├── columns: k:1!null u:2!null
+      │         ├── constraint: /2/4/1: [/1 - /1]
+      │         ├── key: (1)
+      │         └── fd: ()-->(2)
+      └── index-join e
+           ├── columns: k:5!null u:6 v:7!null
+           ├── key: (5)
+           ├── fd: ()-->(7), (5)-->(6)
+           └── scan e@vw
+                ├── columns: k:5!null v:7!null
+                ├── constraint: /7/8/5: [/1 - /1]
+                ├── key: (5)
+                └── fd: ()-->(7)
+
+# Apply when outer columns of both sides of OR are a superset of index columns.
+opt expect=SplitDisjunctionAddKey
+SELECT u, v FROM d WHERE (u = 1 AND w = 2) OR (v = 1 AND w = 3)
+----
+project
+ ├── columns: u:2 v:3
+ └── project
+      ├── columns: u:2 v:3 w:4!null
+      └── union
+           ├── columns: k:1!null u:2 v:3 w:4!null
+           ├── left columns: k:1!null u:2 v:3 w:4!null
+           ├── right columns: k:5 u:6 v:7 w:8
+           ├── key: (1-4)
+           ├── select
+           │    ├── columns: k:1!null u:2!null v:3 w:4!null
+           │    ├── key: (1)
+           │    ├── fd: ()-->(2,4), (1)-->(3)
+           │    ├── index-join d
+           │    │    ├── columns: k:1!null u:2 v:3 w:4
+           │    │    ├── key: (1)
+           │    │    ├── fd: ()-->(2), (1)-->(3,4)
+           │    │    └── scan d@u
+           │    │         ├── columns: k:1!null u:2!null
+           │    │         ├── constraint: /2/1: [/1 - /1]
+           │    │         ├── key: (1)
+           │    │         └── fd: ()-->(2)
+           │    └── filters
+           │         └── w:4 = 2 [outer=(4), constraints=(/4: [/2 - /2]; tight), fd=()-->(4)]
+           └── select
+                ├── columns: k:5!null u:6 v:7!null w:8!null
+                ├── key: (5)
+                ├── fd: ()-->(7,8), (5)-->(6)
+                ├── index-join d
+                │    ├── columns: k:5!null u:6 v:7 w:8
+                │    ├── key: (5)
+                │    ├── fd: ()-->(7), (5)-->(6,8)
+                │    └── scan d@v
+                │         ├── columns: k:5!null v:7!null
+                │         ├── constraint: /7/5: [/1 - /1]
+                │         ├── key: (5)
+                │         └── fd: ()-->(7)
+                └── filters
+                     └── w:8 = 3 [outer=(8), constraints=(/8: [/3 - /3]; tight), fd=()-->(8)]
+
+# Don't apply when outer columns of both sides of OR do not intersect with index columns.
+opt expect-not=SplitDisjunctionAddKey
+SELECT u, w FROM d WHERE u = 1 OR w = 1
+----
+select
+ ├── columns: u:2 w:4
+ ├── scan d
+ │    └── columns: u:2 w:4
+ └── filters
+      └── (u:2 = 1) OR (w:4 = 1) [outer=(2,4)]
+
+# Don't apply to queries with strict keys.
+opt expect-not=SplitDisjunctionAddKey
+SELECT k, u, v FROM d WHERE u = 1 OR v = 1
+----
+union
+ ├── columns: k:1!null u:2 v:3
+ ├── left columns: k:1!null u:2 v:3
+ ├── right columns: k:5 u:6 v:7
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── index-join d
+ │    ├── columns: k:1!null u:2!null v:3
+ │    ├── key: (1)
+ │    ├── fd: ()-->(2), (1)-->(3)
+ │    └── scan d@u
+ │         ├── columns: k:1!null u:2!null
+ │         ├── constraint: /2/1: [/1 - /1]
+ │         ├── key: (1)
+ │         └── fd: ()-->(2)
+ └── index-join d
+      ├── columns: k:5!null u:6 v:7!null
+      ├── key: (5)
+      ├── fd: ()-->(7), (5)-->(6)
+      └── scan d@v
+           ├── columns: k:5!null v:7!null
+           ├── constraint: /7/5: [/1 - /1]
+           ├── key: (5)
+           └── fd: ()-->(7)
+
+# Don't apply to disjunctions with identical colsets on the left and right.
+opt expect-not=SplitDisjunctionAddKey
+SELECT u FROM d WHERE u = 1 OR u = 5
+----
+scan d@u
+ ├── columns: u:2!null
+ └── constraint: /2/1
+      ├── [/1 - /1]
+      └── [/5 - /5]
+
+# Verifies that flags are copied to the duplicated scan.
+opt expect=SplitDisjunctionAddKey
+SELECT u, v FROM a@{NO_INDEX_JOIN} WHERE u = 1 OR v = 1
+----
+project
+ ├── columns: u:2 v:3
+ ├── lax-key: (2,3)
+ ├── fd: (3)~~>(2)
+ └── union
+      ├── columns: k:1!null u:2 v:3
+      ├── left columns: k:1!null u:2 v:3
+      ├── right columns: k:4 u:5 v:6
+      ├── key: (1-3)
+      ├── scan a@u
+      │    ├── columns: k:1!null u:2!null v:3
+      │    ├── constraint: /2/1: [/1 - /1]
+      │    ├── flags: no-index-join
+      │    ├── key: (1)
+      │    └── fd: ()-->(2), (1)-->(3), (3)~~>(1)
+      └── scan a@v
+           ├── columns: k:4!null u:5 v:6!null
+           ├── constraint: /6: [/1 - /1]
+           ├── flags: no-index-join
+           ├── cardinality: [0 - 1]
+           ├── key: ()
+           └── fd: ()-->(4-6)


### PR DESCRIPTION
This commit adds a new exploration rule that can produce better query
plans for disjunctions (e.g. a = 1 OR b = 2). It is similar to
SplitDisjunction, but handles the special case when the selected
columns of a query do not contain a strict key.

Consider the query below, where a and b are not primary keys.

  SELECT a, b FROM t WHERE a = 1 OR b = 2

Before this commit, this disjunction would not be optimized into a UNION
of two SELECT expressions, because the SplitDisjunction exploration
rule only applies when the output columns contain a strict key.

Release note (performance improvement): Query optimization for
disjunctions was extended to support queries which do not select strict
keys.
