### PR TITLE
server: fix TestRangeCount

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -65,12 +65,21 @@ const (
 	// defaultAPIEventLimit is the default maximum number of events returned by any
 	// endpoints returning events.
 	defaultAPIEventLimit = 1000
-
-	// Number of empty ranges for table descriptors that aren't actually tables,
-	// e.g. descriptors 17, 18, 19, and 22 which correspond to MetaRangesID,
-	// SystemRangesID, TimeseriesRangesID, and LivenessRangesID in pkg/keys.
-	nonTableDescriptorRangeCount = 4
 )
+
+// Number of empty ranges for table descriptors that aren't actually tables. These
+// cause special cases in range count computations because we split along them anyway,
+// but they're not SQL tables.
+func nonTableDescriptorRangeCount() int64 {
+	// NB: explicitly reference them for IDE usage.
+	return int64(len([]int{
+		keys.MetaRangesID,
+		keys.SystemRangesID,
+		keys.TimeseriesRangesID,
+		keys.LivenessRangesID,
+		keys.PublicSchemaID,
+	}))
+}
 
 // apiServerMessage is the standard body for all HTTP 500 responses.
 var errAdminAPIError = status.Errorf(codes.Internal, "An internal server error "+
@@ -699,7 +708,7 @@ func (s *adminServer) NonTableStats(
 	// ranges, but it may be more trouble than it's worth. In the meantime,
 	// sweeping them under the general-purpose "Internal use" label in
 	// the "Non-Table" section of the Databases page.
-	response.InternalUseStats.RangeCount += nonTableDescriptorRangeCount
+	response.InternalUseStats.RangeCount += nonTableDescriptorRangeCount()
 
 	return &response, nil
 }


### PR DESCRIPTION
Technically fixes a bug but really not one that needs a release note.

The test verifies, or tried to, that the ranges in the system partition
cleanly between "table data" and "rest". There was an unexplained
two-off. The bottom of the rabbit hole reveals:

- tables in the SystemConfigSpan came back as "zero" ranges, so the
  SQL count was missing the SystemConfig range. Ok, add a plus one.
- we burn a tableID on the public schema, which caused another one-off.

It's sort of silly that we split ranges for all of these, but if we
ever change that this test will fail in instructive ways thanks to
all of the debugging I had to put in to reach enlightenment.

cc @celiala not because you should review but because it's a fun blast from the past.

Release note: None