### PR TITLE
vendor: bump pebble to de7fc1b547d5c7f390ae3a8162289f2dc7efab6a 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -464,7 +464,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:72cd3a6421449aeb9b90ac2d284695178adb9372f89f82b088dca4c7b9602c31"
+  digest = "1:2a55164a97ace26d520ad3a5494789627e0511db321c74dd62f0f03eeca91604"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -490,7 +490,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "74d69792cb150369fb7a799be862524ad2b39d51"
+  revision = "de7fc1b547d5c7f390ae3a8162289f2dc7efab6a"
 
 [[projects]]
   branch = "master"

--- a/pkg/storage/sst_iterator.go
+++ b/pkg/storage/sst_iterator.go
@@ -84,7 +84,10 @@ func (r *sstIterator) SeekGE(key MVCCKey) {
 	}
 	if r.iter == nil {
 		// Iterator creation happens on the first Seek as it involves I/O.
-		r.iter = r.sst.NewIter(nil /* lower */, nil /* upper */)
+		r.iter, r.err = r.sst.NewIter(nil /* lower */, nil /* upper */)
+		if r.err != nil {
+			return
+		}
 	}
 	var iKey *sstable.InternalKey
 	iKey, r.value = r.iter.SeekGE(EncodeKey(key))


### PR DESCRIPTION
* internal/record: don't return partial records (again)
* vfs: match RocksDB WAL preallocation semantics
* sstable: unref cache handle on error in EstimateDiskUsage
* internal/metamorphic: add error rate
* db: unlock manifest on ingest error
* internal/metamorphic: add trace flag
* db: clear err before absolute positioning
* db: fix Iterator.Close documentation
* sstable: add error return value to NewIter, NewCompactionIter
* sstable: remove unused blockIter.err
* internal/lint: prohibit usage of "errors" and fmt.Errorf
* *: remove remaining uses of errors.New and fmt.Errorf

Release note: Fix a backwards incompatibility between RocksDB and Pebble
that prevented RocksDB from opening a Pebble created WAL file under
certain conditions.