### PR TITLE
sql: improve UPDATE on inverted indexes

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -150,6 +150,17 @@ INSERT INTO f VALUES(2, NULL)
 ----
 CPut /Table/55/1/2/0 -> /TUPLE/
 
+# Test that updating a row that edits inverted index entries doesn't delete and
+# re-put things that exist both in the old and in the new value.
+# This case adds 15 and removes 1, so we should just see those commands.
+query T kvtrace
+UPDATE f SET b = ARRAY[0,15,7,10] WHERE a = 0
+----
+Scan /Table/55/1/0{-/#}
+Put /Table/55/1/0/0 -> /TUPLE/
+Del /Table/55/2/1/0/0
+InitPut /Table/55/2/15/0/0 -> /BYTES/
+
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
 ----

--- a/pkg/util/unique/unique.go
+++ b/pkg/util/unique/unique.go
@@ -12,6 +12,7 @@ package unique
 
 import (
 	"bytes"
+	"reflect"
 	"sort"
 )
 
@@ -39,4 +40,71 @@ func UniquifyByteSlices(slices [][]byte) [][]byte {
 	}
 	slices = slices[:lastUniqueIdx+1]
 	return slices
+}
+
+// UniquifyAcrossSlices removes elements from both slices that are duplicated
+// across both of the slices. For example, inputs [1,2,3], [2,3,4] would remove
+// 2 and 3 from both lists.
+// It assumes that both slices are pre-sorted using the same comparison metric
+// as cmpFunc provides, and also already free of duplicates internally. It
+// returns the slices, which will have also been sorted as a side effect.
+// cmpFunc compares the lth index of left to the rth index of right. It must
+// return less than 0 if the left element is less than the right element, 0 if
+// equal, and greater than 0 otherwise.
+// setLeft sets the ith index of left to the jth index of left.
+// setRight sets the ith index of right to the jth index of right.
+// The function returns the new lengths of both input slices, whose elements
+// will have been mutated, but whose lengths must be set the new lengths by
+// the caller.
+func UniquifyAcrossSlices(
+	left interface{},
+	right interface{},
+	cmpFunc func(l, r int) int,
+	setLeft func(i, j int),
+	setRight func(i, j int),
+) (leftLen, rightLen int) {
+	leftSlice := reflect.ValueOf(left)
+	rightSlice := reflect.ValueOf(right)
+
+	lLen := leftSlice.Len()
+	rLen := rightSlice.Len()
+
+	var lIn, lOut int
+	var rIn, rOut int
+
+	// Remove entries that are duplicated across both entry lists.
+	// This loop walks through both lists using a merge strategy. Two pointers per
+	// list are maintained. One is the "input pointer", which is always the ith
+	// element of the input list. One is the "output pointer", which is the index
+	// after the most recent unique element in the list. Every time we bump the
+	// input pointer, we also set the element at the output pointer to that at
+	// the input pointer, so we don't have to use extra space - we're
+	// deduplicating in-place.
+	for rIn < rLen || lIn < lLen {
+		var cmp int
+		if lIn == lLen {
+			cmp = 1
+		} else if rIn == rLen {
+			cmp = -1
+		} else {
+			cmp = cmpFunc(lIn, rIn)
+		}
+		if cmp < 0 {
+			setLeft(lOut, lIn)
+			lIn++
+			lOut++
+		} else if cmp > 0 {
+			setRight(rOut, rIn)
+			rIn++
+			rOut++
+		} else {
+			// Elements are identical - we want to remove them from the list. So
+			// we increment our input indices without touching our output indices.
+			// Next time through the loop, we'll shift the next element back to
+			// the last output index which is now lagging behind the input index.
+			lIn++
+			rIn++
+		}
+	}
+	return lOut, rOut
 }

--- a/pkg/util/unique/unique_test.go
+++ b/pkg/util/unique/unique_test.go
@@ -13,6 +13,7 @@ package unique
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 )
 
@@ -62,6 +63,101 @@ func TestUniquifyByteSlices(t *testing.T) {
 			}
 			if got := UniquifyByteSlices(input); !reflect.DeepEqual(got, expected) {
 				t.Errorf("UniquifyByteSlices() = %v, expected %v", got, expected)
+			}
+		})
+	}
+}
+
+type uasTestCase = struct {
+	left          []int
+	right         []int
+	expectedLeft  []int
+	expectedRight []int
+}
+
+func TestUniquifyAcrossSlices(t *testing.T) {
+	tests := []uasTestCase{
+		{
+			left:          []int{0, 5, 7, 10},
+			right:         []int{1, 5, 7, 11},
+			expectedLeft:  []int{0, 10},
+			expectedRight: []int{1, 11},
+		},
+		{
+			left:          []int{0, 5, 7, 10},
+			right:         []int{},
+			expectedLeft:  []int{0, 5, 7, 10},
+			expectedRight: []int{},
+		},
+		{
+			left:          []int{},
+			right:         []int{},
+			expectedLeft:  []int{},
+			expectedRight: []int{},
+		},
+		{
+			left:          []int{3, 5, 7},
+			right:         []int{7},
+			expectedLeft:  []int{3, 5},
+			expectedRight: []int{},
+		},
+		{
+			left:          []int{3, 5, 7},
+			right:         []int{8},
+			expectedLeft:  []int{3, 5, 7},
+			expectedRight: []int{8},
+		},
+		{
+			left:          []int{1, 2, 3},
+			right:         []int{1, 2, 3},
+			expectedLeft:  []int{},
+			expectedRight: []int{},
+		},
+	}
+
+	origTests := tests
+	for _, test := range origTests {
+		// For each test case, add a flipped test case.
+		rightCopy := make([]int, len(test.right))
+		leftCopy := make([]int, len(test.left))
+		for i := range rightCopy {
+			rightCopy[i] = test.right[i]
+		}
+		for i := range leftCopy {
+			leftCopy[i] = test.left[i]
+		}
+		tests = append(tests, uasTestCase{
+			left:          rightCopy,
+			right:         leftCopy,
+			expectedLeft:  test.expectedRight,
+			expectedRight: test.expectedLeft,
+		})
+	}
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			leftLen, rightLen := UniquifyAcrossSlices(tt.left, tt.right,
+				func(l, r int) int {
+					if tt.left[l] < tt.right[r] {
+						return -1
+					} else if tt.left[l] == tt.right[r] {
+						return 0
+					}
+					return 1
+				},
+				func(i, j int) {
+					tt.left[i] = tt.left[j]
+				},
+				func(i, j int) {
+					tt.right[i] = tt.right[j]
+				},
+			)
+			left := tt.left[:leftLen]
+			right := tt.right[:rightLen]
+			if !reflect.DeepEqual(left, tt.expectedLeft) {
+				t.Errorf("expected %v, got %v", tt.expectedLeft, left)
+			}
+			if !reflect.DeepEqual(right, tt.expectedRight) {
+				t.Errorf("expected %v, got %v", tt.expectedRight, right)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #47338.

Previously, updating a table that had an inverted index on one of the
columns would always delete all of the keys for the old row, and then
re-add all of the keys for the new row, even if there were some keys
that didn't change in the update.

For example, updating an inverted indexed array column with value
`[0,1]` to `[0,2]` would delete the key for `0` and `1`, and add the key
for `0` and `2`, instead of just deleting `1` and adding `2`.

Release note (performance improvement): improve performance of UPDATE on
tables with inverted indexed columns.