### PR TITLE
server: rework cluster version initialization

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -240,12 +240,12 @@ func (tc *testContext) StartWithStoreConfigAndVersion(
 		factory := &testSenderFactory{}
 		cfg.DB = kv.NewDB(cfg.AmbientCtx, factory, cfg.Clock)
 
+		require.NoError(t, WriteClusterVersion(ctx, tc.engine, cv))
 		if err := InitEngine(ctx, tc.engine, roachpb.StoreIdent{
 			ClusterID: uuid.MakeV4(),
 			NodeID:    1,
 			StoreID:   1,
-		},
-			cv); err != nil {
+		}); err != nil {
 			t.Fatal(err)
 		}
 		if err := clusterversion.Initialize(ctx, cv.Version, &cfg.Settings.SV); err != nil {

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 )
 
 func formatKeys(keys []roachpb.Key) string {
@@ -58,8 +59,9 @@ func TestBootstrapCluster(t *testing.T) {
 	ctx := context.Background()
 	e := storage.NewDefaultInMem()
 	defer e.Close()
+	require.NoError(t, kvserver.WriteClusterVersion(ctx, e, clusterversion.TestingClusterVersion))
 	if _, err := bootstrapCluster(
-		ctx, []storage.Engine{e}, clusterversion.TestingClusterVersion, zonepb.DefaultZoneConfigRef(), zonepb.DefaultSystemZoneConfigRef(),
+		ctx, []storage.Engine{e}, zonepb.DefaultZoneConfigRef(), zonepb.DefaultSystemZoneConfigRef(),
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -231,8 +233,9 @@ func TestCorruptedClusterID(t *testing.T) {
 
 	cv := clusterversion.TestingClusterVersion
 
+	require.NoError(t, kvserver.WriteClusterVersion(ctx, e, cv))
 	if _, err := bootstrapCluster(
-		ctx, []storage.Engine{e}, cv, zonepb.DefaultZoneConfigRef(), zonepb.DefaultSystemZoneConfigRef(),
+		ctx, []storage.Engine{e}, zonepb.DefaultZoneConfigRef(), zonepb.DefaultSystemZoneConfigRef(),
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -122,7 +122,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 		storage.DefaultStorageEngine, roachpb.Attributes{}, 50<<20)
 	ltc.Stopper.AddCloser(ltc.Eng)
 
-	ltc.Stores = kvserver.NewStores(ambient, ltc.Clock, clusterversion.TestingBinaryVersion, clusterversion.TestingBinaryMinSupportedVersion)
+	ltc.Stores = kvserver.NewStores(ambient, ltc.Clock)
 
 	factory := initFactory(cfg.Settings, nodeDesc, ambient.Tracer, ltc.Clock, ltc.Latency, ltc.Stores, ltc.Stopper, ltc.Gossip)
 	if ltc.DBContext == nil {
@@ -170,8 +170,11 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	cfg.TimestampCachePageSize = tscache.TestSklPageSize
 	ctx := context.TODO()
 
+	if err := kvserver.WriteClusterVersion(ctx, ltc.Eng, clusterversion.TestingClusterVersion); err != nil {
+		t.Fatalf("unable to write cluster version: %s", err)
+	}
 	if err := kvserver.InitEngine(
-		ctx, ltc.Eng, roachpb.StoreIdent{NodeID: nodeID, StoreID: 1}, clusterversion.TestingClusterVersion,
+		ctx, ltc.Eng, roachpb.StoreIdent{NodeID: nodeID, StoreID: 1},
 	); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)
 	}

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -219,7 +219,7 @@ func StartServer(
 ) (TestServerInterface, *gosql.DB, *kv.DB) {
 	server, err := StartServerRaw(params)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("%+v", err)
 	}
 
 	pgURL, cleanupGoDB := sqlutils.PGUrl(


### PR DESCRIPTION
A central invariant around cluster versions is that when an update
arrives, we need to persist it before exposing it through the version
setting. This was not true during server start time, as described in:

https://github.com/cockroachdb/cockroach/pull/47235#issuecomment-611419920

In short, we were registering the callback to persist to the engines
*after* Gossip had already connected, opening up a window during which
a cluster version bump simply would not be persisted.

In the acceptance/version-upgrade test, this would manifest as nodes
refusing to start because their binary version had proceeded to far
beyond the persisted version. At the time of writing and before this
commit, this would happen in perhaps 1-10% of local runs on a linux
machine (rarely on OSX).

The buggy code was originally written when the startup sequence was a
lot more intricate and we were, as I recall, under pressure to deliver.
Now, with recent refactors around the `initServer`, we're in a
really good place to solve this while also simplifying the whole
story. In this commit,

- persist the cluster version on *all* engines, not just the initialized
  ones; this completely decouples the timing of when the engines get
  initialized from when we can set up the persistence callback and
  makes everything *much simpler*.
- stop opportunistically backfilling the cluster version. It is now
  done once at the beginning, in the right place, without FUD later
  on.
- remove the cluster version persistence from engine initialization.
  Anyone initializing an engine must put a cluster version on it
  first. In a running server, this happens during initServer creation
  time, way before there are any moving parts in the system. In tests,
  extra writes were added as needed.
- set up the callback with Gossip before starting Gossip, and make sure
  (via an assertion) that this property does not rot.
  By setting up the callback before Gossip starts, we make sure there
  isn't a period during which Gossip receives an update but doesn't have
  the callback yet.
- as a result of all of the above, take all knowledge of cluster version
  init away from `*Node` and `*Stores`.

As a last note, we are planning to stop using Gossip for this version
business in 20.1, though this too will be facilitated by this change.

Release note (bug fix): Avoid a condition during rapid version upgrades
where a node would refuse to start, claiming "[a store is] too old for
running version". Before this bug fix, the workaround is to decommission
the node, delete the store directory, and re-add it to the cluster as
a new node.