### PR TITLE
opt: group disjunctions by columns when generating unions

### DIFF
--- a/pkg/sql/opt/xform/rules/select.opt
+++ b/pkg/sql/opt/xform/rules/select.opt
@@ -51,10 +51,10 @@
     ) & (HasStrictKey $input)
     $filters:[
         ...
-        $item:(FiltersItem (Or $left:* $right:*)) &
-            ^(ColsAreEqual (OuterCols $left) (OuterCols $right)) &
-            (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols $left)) &
-            (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols $right))
+        $item:(FiltersItem $or:(Or)) &
+            (ExprPairSucceeded $pair:(ExprPairForSplitDisjunction $or)) &
+            (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols (ExprPairLeft $pair))) &
+            (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols (ExprPairRight $pair)))
         ...
     ]
 )
@@ -62,17 +62,17 @@
 (Union
     (Select
         $input
-        (ReplaceFiltersItem $filters $item $left)
+        (ReplaceFiltersItem $filters $item (ExprPairLeft $pair))
     )
     (Select
         (Scan $rightScanPrivate:(DuplicateScanPrivate $scanPrivate))
         (MapScanFilterCols
-            (ReplaceFiltersItem $filters $item $right)
+            (ReplaceFiltersItem $filters $item (ExprPairRight $pair))
             $scanPrivate
             $rightScanPrivate
         )
     )
-    (MakeSetPrivateForUnionSelects $scanPrivate $rightScanPrivate)
+    (MakeSetPrivateForSplitDisjunction $scanPrivate $rightScanPrivate)
 )
 
 # SplitDisjunctionAddKey performs a transformation similar to
@@ -112,10 +112,10 @@
     ) & ^(HasStrictKey $input)
     $filters:[
         ...
-        $item:(FiltersItem (Or $left:* $right:*)) &
-            ^(ColsAreEqual (OuterCols $left) (OuterCols $right)) &
-            (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols $left)) &
-            (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols $right))
+        $item:(FiltersItem $or:(Or)) &
+            (ExprPairSucceeded $pair:(ExprPairForSplitDisjunction $or)) &
+            (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols (ExprPairLeft $pair))) &
+            (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols (ExprPairRight $pair)))
         ...
     ]
 )
@@ -124,17 +124,17 @@
     (Union
         (Select
             (Scan $leftScanPrivate:(AddPrimaryKeyColsToScanPrivate $scanPrivate))
-            (ReplaceFiltersItem $filters $item $left)
+            (ReplaceFiltersItem $filters $item (ExprPairLeft $pair))
         )
         (Select
             (Scan $rightScanPrivate:(DuplicateScanPrivate $leftScanPrivate))
             (MapScanFilterCols
-                (ReplaceFiltersItem $filters $item $right)
+                (ReplaceFiltersItem $filters $item (ExprPairRight $pair))
                 $leftScanPrivate
                 $rightScanPrivate
             )
         )
-        (MakeSetPrivateForUnionSelects $leftScanPrivate $rightScanPrivate)
+        (MakeSetPrivateForSplitDisjunction $leftScanPrivate $rightScanPrivate)
     )
     []
     (OutputCols $input)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1449,6 +1449,108 @@ project
            └── filters
                 └── w:8 = 3 [outer=(8), constraints=(/8: [/3 - /3]; tight), fd=()-->(8)]
 
+# Group sub-expr with the same columns together.
+opt expect=SplitDisjunction
+SELECT k, u, v FROM d WHERE (u = 1 OR v = 2) OR (u = 3 OR v = 4)
+----
+union
+ ├── columns: k:1!null u:2 v:3
+ ├── left columns: k:1!null u:2 v:3
+ ├── right columns: k:5 u:6 v:7
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── index-join d
+ │    ├── columns: k:1!null u:2!null v:3
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── scan d@u
+ │         ├── columns: k:1!null u:2!null
+ │         ├── constraint: /2/1
+ │         │    ├── [/1 - /1]
+ │         │    └── [/3 - /3]
+ │         ├── key: (1)
+ │         └── fd: (1)-->(2)
+ └── index-join d
+      ├── columns: k:5!null u:6 v:7!null
+      ├── key: (5)
+      ├── fd: (5)-->(6,7)
+      └── scan d@v
+           ├── columns: k:5!null v:7!null
+           ├── constraint: /7/5
+           │    ├── [/2 - /2]
+           │    └── [/4 - /4]
+           ├── key: (5)
+           └── fd: (5)-->(7)
+
+# Group sub-expr with the same columns together. Output should have a single union expr.
+opt expect=SplitDisjunction
+SELECT k, u, v FROM d WHERE u = 1 OR u = 3 OR v = 2 OR v = 4 OR u = 5 OR v = 6
+----
+union
+ ├── columns: k:1!null u:2 v:3
+ ├── left columns: k:1!null u:2 v:3
+ ├── right columns: k:5 u:6 v:7
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── index-join d
+ │    ├── columns: k:1!null u:2!null v:3
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── scan d@u
+ │         ├── columns: k:1!null u:2!null
+ │         ├── constraint: /2/1
+ │         │    ├── [/1 - /1]
+ │         │    ├── [/3 - /3]
+ │         │    └── [/5 - /5]
+ │         ├── key: (1)
+ │         └── fd: (1)-->(2)
+ └── index-join d
+      ├── columns: k:5!null u:6 v:7!null
+      ├── key: (5)
+      ├── fd: (5)-->(6,7)
+      └── scan d@v
+           ├── columns: k:5!null v:7!null
+           ├── constraint: /7/5
+           │    ├── [/2 - /2]
+           │    ├── [/4 - /4]
+           │    └── [/6 - /6]
+           ├── key: (5)
+           └── fd: (5)-->(7)
+
+# Group sub-expr with the same columns together. Output should have a single union expr.
+opt expect=SplitDisjunction
+SELECT k, u, v FROM d WHERE (u = 3 OR v = 2) OR (u = 5 OR v = 4) OR v = 6
+----
+union
+ ├── columns: k:1!null u:2 v:3
+ ├── left columns: k:1!null u:2 v:3
+ ├── right columns: k:5 u:6 v:7
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── index-join d
+ │    ├── columns: k:1!null u:2!null v:3
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── scan d@u
+ │         ├── columns: k:1!null u:2!null
+ │         ├── constraint: /2/1
+ │         │    ├── [/3 - /3]
+ │         │    └── [/5 - /5]
+ │         ├── key: (1)
+ │         └── fd: (1)-->(2)
+ └── index-join d
+      ├── columns: k:5!null u:6 v:7!null
+      ├── key: (5)
+      ├── fd: (5)-->(6,7)
+      └── scan d@v
+           ├── columns: k:5!null v:7!null
+           ├── constraint: /7/5
+           │    ├── [/2 - /2]
+           │    ├── [/4 - /4]
+           │    └── [/6 - /6]
+           ├── key: (5)
+           └── fd: (5)-->(7)
+
 # Don't apply when outer columns of both sides of OR do not intersect with index columns.
 opt expect-not=SplitDisjunction
 SELECT k, u, w FROM d WHERE u = 1 OR w = 1
@@ -1955,6 +2057,111 @@ project
                 │         └── fd: ()-->(7)
                 └── filters
                      └── w:8 = 3 [outer=(8), constraints=(/8: [/3 - /3]; tight), fd=()-->(8)]
+
+# Group sub-expr with the same columns together.
+opt expect=SplitDisjunctionAddKey
+SELECT u, v FROM d WHERE (u = 1 OR v = 2) OR (u = 3 OR v = 4)
+----
+project
+ ├── columns: u:2 v:3
+ └── union
+      ├── columns: k:1!null u:2 v:3
+      ├── left columns: k:1!null u:2 v:3
+      ├── right columns: k:5 u:6 v:7
+      ├── key: (1-3)
+      ├── index-join d
+      │    ├── columns: k:1!null u:2!null v:3
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,3)
+      │    └── scan d@u
+      │         ├── columns: k:1!null u:2!null
+      │         ├── constraint: /2/1
+      │         │    ├── [/1 - /1]
+      │         │    └── [/3 - /3]
+      │         ├── key: (1)
+      │         └── fd: (1)-->(2)
+      └── index-join d
+           ├── columns: k:5!null u:6 v:7!null
+           ├── key: (5)
+           ├── fd: (5)-->(6,7)
+           └── scan d@v
+                ├── columns: k:5!null v:7!null
+                ├── constraint: /7/5
+                │    ├── [/2 - /2]
+                │    └── [/4 - /4]
+                ├── key: (5)
+                └── fd: (5)-->(7)
+
+# Group sub-expr with the same columns together. Output should have a single union expr.
+opt expect=SplitDisjunctionAddKey
+SELECT u, v FROM d WHERE u = 1 OR u = 3 OR v = 2 OR v = 4 OR u = 5 OR v = 6
+----
+project
+ ├── columns: u:2 v:3
+ └── union
+      ├── columns: k:1!null u:2 v:3
+      ├── left columns: k:1!null u:2 v:3
+      ├── right columns: k:5 u:6 v:7
+      ├── key: (1-3)
+      ├── index-join d
+      │    ├── columns: k:1!null u:2!null v:3
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,3)
+      │    └── scan d@u
+      │         ├── columns: k:1!null u:2!null
+      │         ├── constraint: /2/1
+      │         │    ├── [/1 - /1]
+      │         │    ├── [/3 - /3]
+      │         │    └── [/5 - /5]
+      │         ├── key: (1)
+      │         └── fd: (1)-->(2)
+      └── index-join d
+           ├── columns: k:5!null u:6 v:7!null
+           ├── key: (5)
+           ├── fd: (5)-->(6,7)
+           └── scan d@v
+                ├── columns: k:5!null v:7!null
+                ├── constraint: /7/5
+                │    ├── [/2 - /2]
+                │    ├── [/4 - /4]
+                │    └── [/6 - /6]
+                ├── key: (5)
+                └── fd: (5)-->(7)
+
+# Group sub-expr with the same columns together. Output should have a single union expr.
+opt expect=SplitDisjunctionAddKey
+SELECT u, v FROM d WHERE (u = 3 OR v = 2) OR (u = 5 OR v = 4) OR v = 6
+----
+project
+ ├── columns: u:2 v:3
+ └── union
+      ├── columns: k:1!null u:2 v:3
+      ├── left columns: k:1!null u:2 v:3
+      ├── right columns: k:5 u:6 v:7
+      ├── key: (1-3)
+      ├── index-join d
+      │    ├── columns: k:1!null u:2!null v:3
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,3)
+      │    └── scan d@u
+      │         ├── columns: k:1!null u:2!null
+      │         ├── constraint: /2/1
+      │         │    ├── [/3 - /3]
+      │         │    └── [/5 - /5]
+      │         ├── key: (1)
+      │         └── fd: (1)-->(2)
+      └── index-join d
+           ├── columns: k:5!null u:6 v:7!null
+           ├── key: (5)
+           ├── fd: (5)-->(6,7)
+           └── scan d@v
+                ├── columns: k:5!null v:7!null
+                ├── constraint: /7/5
+                │    ├── [/2 - /2]
+                │    ├── [/4 - /4]
+                │    └── [/6 - /6]
+                ├── key: (5)
+                └── fd: (5)-->(7)
 
 # Don't apply when outer columns of both sides of OR do not intersect with index columns.
 opt expect-not=SplitDisjunctionAddKey


### PR DESCRIPTION
#### opt: group disjunctions by columns when generating unions

This commit more intelligently splits disjunctions into a Union of
Selects. Before this commit, GenerateUnionSelects(AddKey) would blindly
try to split the top-level OrExpr by its left and right expressions.
Now, sub-expressions of all adjacent OrExprs are grouped by their
columns.

Prior to this commit, complex disjunctions could result in a query plan
with many more Unions than necessary, like the one below.

```
  SELECT k, u, v FROM d
  WHERE u = 1 OR u = 3 OR v = 2 OR v = 4 OR u = 5 OR v = 6

  union
   ├── union
   │    ├── union
   │    │    ├── union
   │    │    │    ├── scan d@u
   │    │    │    └── scan d@v
   │    │    └── scan d@v
   │    └── scan d@u
   └── scan d@v
```

Now the same query results in the optimal plan:

```
   union
    ├── scan d@u
    └── scan d@v
```

In addition, before this commit the following query would not result in
a Union expression at all.

```
  SELECT k, u, v FROM d WHERE (u = 3 OR v = 2) OR (v = 4 OR u = 5) OR v = 6

  select
   ├── scan d@u
   └── filters
```

Release note (performance improvement): The query optimizer is now
smarter when splitting disjunctions into unions by grouping disjunctions
based on the columns referenced.

#### opt: group disjunctions before column check when generating unions

This commit changes the pattern for the GenerateUnionSelects(AddKey)
rule such that "interesting" left and right expression groupings are
generated before evaluating if those expression groupings have ColSets
that are not equal.

Prior to this commit, the rule would only match if the ColSets of the
left and right side of the top-level Or were not equal.

Consider the query below.

```
  SELECT * FROM t WHERE (a = 1 OR b = 2) OR (a = 3 OR b = 4)
```

Because the middle "OR" is top-level, the columns on the left and right
are both "a" and "b". Therefore, this rule would not match in this case,
despite the fact that there is an "interesting" way split these
disjunctions such two separate index scans are constrained:

```
  a = 1 OR a = 3
  b = 2 OR b = 4
```

Now, this "interesting" grouping is determined before the check for
ColSet inequality, and the rule is applied, resulting in the optimal
query plan:

```
  union
   ├── scan t@a
   └── scan t@b
```

Release note (performance improvement): The query optimizer now attempts
to split disjunctions into unions in more cases, leading to faster query
plans.
