### PR TITLE
roachtest: mixed-version schema change test

### DIFF
--- a/pkg/cmd/roachtest/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/mixed_version_schemachange.go
@@ -1,0 +1,119 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+func registerSchemaChangeMixedVersions(r *testRegistry) {
+	r.Add(testSpec{
+		Name:    "schemachange/mixed-versions",
+		Owner:   OwnerSQLSchema,
+		Cluster: makeClusterSpec(4),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			predV, err := PredecessorVersion(r.buildVersion)
+			if err != nil {
+				t.Fatal(err)
+			}
+			maxOps := 100
+			if local {
+				maxOps = 10
+			}
+			runSchemaChangeMixedVersions(ctx, t, c, maxOps, predV)
+		},
+	})
+}
+
+func uploadAndInitSchemaChangeWorkload() versionStep {
+	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
+		// Stage workload on all nodes as the load node to run workload is chosen
+		// randomly.
+		u.c.Put(ctx, workload, "./workload", u.c.All())
+		u.c.Run(ctx, u.c.All(), "./workload init schemachange")
+	}
+}
+
+func runSchemaChangeWorkloadStep(maxOps int) versionStep {
+	var numFeatureRuns int
+	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
+		numFeatureRuns++
+		t.l.Printf("Workload step run: %d", numFeatureRuns)
+		loadNode := u.c.All().randNode()[0]
+		runCmd := []string{
+			"./workload run",
+			fmt.Sprintf("schemachange --concurrency 2 --max-ops %d --verbose=1", maxOps),
+			fmt.Sprintf("{pgurl:1-%d}", u.c.spec.NodeCount),
+		}
+		u.c.Run(ctx, u.c.Node(loadNode), runCmd...)
+	}
+}
+
+func runSchemaChangeMixedVersions(
+	ctx context.Context, t *test, c *cluster, maxOps int, predecessorVersion string,
+) {
+	// An empty string will lead to the cockroach binary specified by flag
+	// `cockroach` to be used.
+	const mainVersion = ""
+	schemaChangeStep := runSchemaChangeWorkloadStep(maxOps)
+
+	u := newVersionUpgradeTest(c,
+		uploadAndStartFromCheckpointFixture(c.All(), predecessorVersion),
+		uploadAndInitSchemaChangeWorkload(),
+		waitForUpgradeStep(c.All()),
+
+		// NB: at this point, cluster and binary version equal predecessorVersion,
+		// and auto-upgrades are on.
+
+		preventAutoUpgradeStep(1),
+		schemaChangeStep,
+
+		// Roll the nodes into the new version one by one, while repeatedly running
+		// schema changes. We use an empty string for the version below, which means
+		// use the main ./cockroach binary (i.e. the one being tested in this run).
+		binaryUpgradeStep(c.Node(3), mainVersion),
+		schemaChangeStep,
+		binaryUpgradeStep(c.Node(2), mainVersion),
+		schemaChangeStep,
+		binaryUpgradeStep(c.Node(1), mainVersion),
+		schemaChangeStep,
+		binaryUpgradeStep(c.Node(4), mainVersion),
+		schemaChangeStep,
+
+		// Roll back again, which ought to be fine because the cluster upgrade was
+		// not finalized.
+		binaryUpgradeStep(c.Node(2), predecessorVersion),
+		schemaChangeStep,
+		binaryUpgradeStep(c.Node(4), predecessorVersion),
+		schemaChangeStep,
+		binaryUpgradeStep(c.Node(3), predecessorVersion),
+		schemaChangeStep,
+		binaryUpgradeStep(c.Node(1), predecessorVersion),
+		schemaChangeStep,
+
+		// Roll nodes forward and finalize upgrade.
+		binaryUpgradeStep(c.Node(4), mainVersion),
+		schemaChangeStep,
+		binaryUpgradeStep(c.Node(3), mainVersion),
+		schemaChangeStep,
+		binaryUpgradeStep(c.Node(1), mainVersion),
+		schemaChangeStep,
+		binaryUpgradeStep(c.Node(2), mainVersion),
+		schemaChangeStep,
+
+		allowAutoUpgradeStep(1),
+		waitForUpgradeStep(c.All()),
+		schemaChangeStep,
+	)
+
+	u.run(ctx, t)
+}

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -75,6 +75,7 @@ func registerTests(r *testRegistry) {
 	registerSchemaChangeIndexTPCC1000(r)
 	registerSchemaChangeDuringTPCC1000(r)
 	registerSchemaChangeInvertedIndex(r)
+	registerSchemaChangeMixedVersions(r)
 	registerScrubAllChecksTPCC(r)
 	registerScrubIndexOnlyTPCC(r)
 	registerSecondaryIndexesMultiVersionCluster(r)

--- a/pkg/cmd/roachtest/versionupgrade.go
+++ b/pkg/cmd/roachtest/versionupgrade.go
@@ -95,6 +95,7 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster, predecessorVers
 	}
 
 	testFeaturesStep := versionUpgradeTestFeatures.step(c.All())
+	schemaChangeStep := runSchemaChangeWorkloadStep(10 /* maxOps */)
 
 	// The steps below start a cluster at predecessorVersion (from a fixture),
 	// then start an upgrade that is rolled back, and finally start and finalize
@@ -109,6 +110,7 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster, predecessorVers
 		//
 		// See the comment on createCheckpoints for details on fixtures.
 		uploadAndStartFromCheckpointFixture(c.All(), predecessorVersion),
+		uploadAndInitSchemaChangeWorkload(),
 		waitForUpgradeStep(c.All()),
 		testFeaturesStep,
 
@@ -125,19 +127,25 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster, predecessorVers
 		// Roll nodes forward.
 		binaryUpgradeStep(c.All(), ""),
 		testFeaturesStep,
+		// Run a quick schemachange workload in between each upgrade.
+		// The maxOps is 10 to keep the test runtime under 1-2 minutes.
+		schemaChangeStep,
 		// Roll back again. Note that bad things would happen if the cluster had
 		// ignored our request to not auto-upgrade. The `autoupgrade` roachtest
 		// exercises this in more detail, so here we just rely on things working
 		// as they ought to.
 		binaryUpgradeStep(c.All(), predecessorVersion),
 		testFeaturesStep,
+		schemaChangeStep,
 		// Roll nodes forward, this time allowing them to upgrade, and waiting
 		// for it to happen.
 		binaryUpgradeStep(c.All(), ""),
 		allowAutoUpgradeStep(1),
 		testFeaturesStep,
+		schemaChangeStep,
 		waitForUpgradeStep(c.All()),
 		testFeaturesStep,
+		schemaChangeStep,
 	)
 
 	u.run(ctx, t)

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -877,14 +877,15 @@ FROM [SHOW COLUMNS FROM "%s"];
 		columnNames = append(columnNames, name)
 	}
 	if rows.Err() != nil {
-		return nil, err
-	}
-	if len(columnNames) <= 0 {
-		return nil, errors.Errorf("table %s has no columns", tableName)
+		return nil, rows.Err()
 	}
 
 	w.rng.Shuffle(len(columnNames), func(i, j int) {
 		columnNames[i], columnNames[j] = columnNames[j], columnNames[i]
 	})
+
+	if len(columnNames) <= 0 {
+		return nil, errors.Errorf("table %s has no columns", tableName)
+	}
 	return columnNames, nil
 }

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -64,7 +64,7 @@ type schemaChange struct {
 	concurrency     int
 	maxOpsPerWorker int
 	existingPct     int
-	verbose         bool
+	verbose         int
 	dryRun          bool
 }
 
@@ -83,7 +83,7 @@ var schemaChangeMeta = workload.Meta{
 			`Number of operations to execute in a single transaction`)
 		s.flags.IntVar(&s.existingPct, `existing-pct`, defaultExistingPct,
 			`Percentage of times to use existing name`)
-		s.flags.BoolVarP(&s.verbose, `verbose`, `v`, true, ``)
+		s.flags.IntVarP(&s.verbose, `verbose`, `v`, 0, ``)
 		s.flags.BoolVarP(&s.dryRun, `dry-run`, `n`, false, ``)
 		return s
 	},
@@ -233,7 +233,7 @@ SELECT max(regexp_extract(name, '[0-9]+$')::int)
 }
 
 type schemaChangeWorker struct {
-	verbose         bool
+	verbose         int
 	dryRun          bool
 	maxOpsPerWorker int
 	existingPct     int
@@ -249,14 +249,15 @@ func (w *schemaChangeWorker) runInTxn(tx *pgx.Tx) (string, error) {
 	// Run between 1 and maxOpsPerWorker schema change operations.
 	n := 1 + w.rng.Intn(w.maxOpsPerWorker)
 	for i := 0; i < n; i++ {
-		op, err := w.randOp(tx)
+		op, noops, err := w.randOp(tx)
 		if err != nil {
-			return log.String(), err
+			return noops, errors.Wrap(err, "randOp")
 		}
+		log.WriteString(noops)
 		log.WriteString(fmt.Sprintf("  %s;\n", op))
 		if !w.dryRun {
 			if _, err := tx.Exec(op); err != nil {
-				return log.String(), err
+				return log.String(), errors.Wrapf(err, "%s failed", op)
 			}
 		}
 	}
@@ -267,27 +268,32 @@ func (w *schemaChangeWorker) run(_ context.Context) error {
 	start := timeutil.Now()
 	tx, err := w.pool.Get().Begin()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "cannot get a connection and begin a txn")
 	}
 
 	var histBin string
 	log, err := w.runInTxn(tx)
 	elapsed := timeutil.Since(start)
 	if err != nil {
-		_ = tx.Rollback()
+		rbkErr := tx.Rollback()
+		if rbkErr != nil {
+			w.hists.Get("rbk").Record(elapsed)
+			err = errors.Wrapf(err, "ROLLBACK: %v", rbkErr)
+		}
 		log = log + "ROLLBACK;\n"
 		histBin = "err"
 		// TODO(spaskob): should we log the ROLLBACK error as well?
 	} else {
 		log = log + "COMMIT;\n"
 		if err = tx.Commit(); err != nil {
-			histBin = "err"
+			histBin = "cmt_err"
+			err = errors.Wrap(err, "COMMIT")
 		} else {
 			histBin = "ok"
 		}
 	}
 	w.hists.Get(histBin).Record(elapsed)
-	if w.verbose {
+	if w.verbose >= 1 {
 		fmt.Print("BEGIN\n")
 		fmt.Print(log)
 		if err != nil {
@@ -298,7 +304,13 @@ func (w *schemaChangeWorker) run(_ context.Context) error {
 	return nil
 }
 
-func (w *schemaChangeWorker) randOp(tx *pgx.Tx) (string, error) {
+// randOp attempts to produce a random schema change operation. It returns a
+// triple `(randOp, log, error)`. On success `randOp` is the random schema
+// change constructed. Constructing a random schema change may require a few
+// stochastic attempts and if verbosity is >= 2 the unsuccessful attempts are
+// recorded in `log` to help with debugging of the workload.
+func (w *schemaChangeWorker) randOp(tx *pgx.Tx) (string, string, error) {
+	var log strings.Builder
 	for {
 		var stmt string
 		var err error
@@ -379,12 +391,12 @@ func (w *schemaChangeWorker) randOp(tx *pgx.Tx) (string, error) {
 
 		// TODO(spaskob): use more fine-grained error reporting.
 		if stmt == "" || err == pgx.ErrNoRows {
-			if w.verbose {
-				fmt.Printf("NOOP: %s -> %v\n", op, err)
+			if w.verbose >= 2 {
+				log.WriteString(fmt.Sprintf("NOOP: %s -> %v\n", op, err))
 			}
 			continue
 		}
-		return stmt, err
+		return stmt, log.String(), err
 	}
 }
 

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -436,10 +436,6 @@ func (w *schemaChangeWorker) createIndex(tx *pgx.Tx) (string, error) {
 		return "", err
 	}
 
-	if len(columnNames) <= 0 {
-		return "", errors.Errorf("table %s has no columns", tableName)
-	}
-
 	indexName, err := w.randIndex(tx, tableName, w.existingPct)
 	if err != nil {
 		return "", err
@@ -863,7 +859,7 @@ ORDER BY random()
 func (w *schemaChangeWorker) tableColumnsShuffled(tx *pgx.Tx, tableName string) ([]string, error) {
 	q := fmt.Sprintf(`
 SELECT column_name
-  FROM [SHOW COLUMNS FROM "%s"];
+FROM [SHOW COLUMNS FROM "%s"];
 `, tableName)
 
 	rows, err := tx.Query(q)
@@ -882,6 +878,9 @@ SELECT column_name
 	}
 	if rows.Err() != nil {
 		return nil, err
+	}
+	if len(columnNames) <= 0 {
+		return nil, errors.Errorf("table %s has no columns", tableName)
 	}
 
 	w.rng.Shuffle(len(columnNames), func(i, j int) {


### PR DESCRIPTION
roachtest: add new mixed version schema change test

This test performs a rolling upgrade, downgrade and upgrade again
from predecessor version of `HEAD` to `HEAD` while running the
`schemachange` workload in between each upgrade/downgrade of a node.

Closes #47152.

Release note: none