### PR TITLE
vendor: remove uneeded twpayne deps

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1589,30 +1589,17 @@
   version = "v1.4.0"
 
 [[projects]]
-  digest = "1:661aa35409435cec194eb640ec712cf1e9b483d988d587a8b91847293e715f59"
+  digest = "1:5d6d51379802fc1da79c497786851fe41a65695307d8b54e80edaf26da8f00d0"
   name = "github.com/twpayne/go-geom"
   packages = [
     ".",
     "encoding/ewkb",
     "encoding/ewkbhex",
-    "encoding/geojson",
-    "encoding/kml",
-    "encoding/wkb",
     "encoding/wkbcommon",
-    "encoding/wkbhex",
-    "encoding/wkt",
   ]
   pruneopts = "UT"
   revision = "6e58c69044b13f84504654b4741390b92a70a402"
   version = "v1.0.6"
-
-[[projects]]
-  digest = "1:43e0db2b113d1aee4bb68745598c135511976a44fb380ebd701cd0c14a77c303"
-  name = "github.com/twpayne/go-kml"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "324bc36063aba8d64871e9cebc45b8753ff9de9e"
-  version = "v1.5.0"
 
 [[projects]]
   branch = "master"
@@ -2177,11 +2164,6 @@
     "github.com/twpayne/go-geom",
     "github.com/twpayne/go-geom/encoding/ewkb",
     "github.com/twpayne/go-geom/encoding/ewkbhex",
-    "github.com/twpayne/go-geom/encoding/geojson",
-    "github.com/twpayne/go-geom/encoding/kml",
-    "github.com/twpayne/go-geom/encoding/wkb",
-    "github.com/twpayne/go-geom/encoding/wkbhex",
-    "github.com/twpayne/go-geom/encoding/wkt",
     "github.com/wadey/gocovmerge",
     "go.etcd.io/etcd/raft",
     "go.etcd.io/etcd/raft/confchange",


### PR DESCRIPTION
The deps stopped being needed after
https://github.com/cockroachdb/cockroach/pull/47171 but we didn't catch
the leak because of
https://github.com/cockroachdb/cockroach/issues/47363

Release note: None