### PR TITLE
opt: use 4 space indentation for .opt files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,11 @@ charset = utf-8
 # with tabs but still set indent_size to control the github web viewer.
 indent_size=2
 
+# Override default spacing rules for .opt files.
+[*.opt]
+indent_style = space
+indent_size = 4
+
 # Makefiles are broken without using actual tabs for indentation.
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
4 space indentation has been the standard for .opt files since the
beginning. This commit just makes that the default using the
.editorconfig file.

Release note: None