### PR TITLE
release-20.1: sql: ignore soft limits on scan nodes for distsql planning

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_auto_mode
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_auto_mode
@@ -64,10 +64,11 @@ SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT * FROM kv LIMIT 1]
 true
 
 # Soft limit in scan - don't distribute.
+# TODO(yuzefovich): soft limits are currently ignored in scans.
 query B
 SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT * FROM kv UNION SELECT * FROM kv LIMIT 1]
 ----
-false
+true
 
 # Limit after sort - distribute.
 query B

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -243,6 +243,8 @@ func (n *scanNode) limitHint() int64 {
 		}
 	} else {
 		// Like above, read a multiple of the limit when the limit is "soft".
+		// TODO(yuzefovich): shouldn't soft limit already account for the
+		// selectivity of any filter and whatnot?
 		limitHint = n.softLimit * 2
 	}
 	return limitHint


### PR DESCRIPTION
Backport 1/1 commits from #47365.

/cc @cockroachdb/release

---

We have added propagation of soft limits in 20.1 release, and this
causes some of the queries that used to run via DistSQL with
`distsql=auto` to get a "should not distribute" recommendation during
distsql physical planning. However, this can cause an egregious
performance regression on some queries from 19.2 version. In order to
keep the decision whether to distribute scans or not the same, we will
be ignoring the soft limits on scan nodes for now.

Addresses: #47058.

Release note: None
