### PR TITLE
logictest: give larger disk limit to clusters in big tests

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -150,7 +150,14 @@ var (
 // DefaultTestStoreSpec that is in-memory.
 // It has a maximum size of 100MiB.
 func DefaultTestTempStorageConfig(st *cluster.Settings) TempStorageConfig {
-	var maxSizeBytes int64 = DefaultInMemTempStorageMaxSizeBytes
+	return DefaultTestTempStorageConfigWithSize(st, DefaultInMemTempStorageMaxSizeBytes)
+}
+
+// DefaultTestTempStorageConfigWithSize is the associated temp storage for
+// DefaultTestStoreSpec that is in-memory with the customized maximum size.
+func DefaultTestTempStorageConfigWithSize(
+	st *cluster.Settings, maxSizeBytes int64,
+) TempStorageConfig {
 	monitor := mon.MakeMonitor(
 		"in-mem temp storage",
 		mon.DiskResource,

--- a/pkg/ccl/logictestccl/logic_test.go
+++ b/pkg/ccl/logictestccl/logic_test.go
@@ -18,5 +18,5 @@ import (
 
 func TestCCLLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	logictest.RunLogicTest(t, "testdata/logic_test/[^.]*")
+	logictest.RunLogicTest(t, logictest.TestServerArgs{}, "testdata/logic_test/[^.]*")
 }

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1162,7 +1162,7 @@ func (t *logicTest) setUser(user string) func() {
 	return cleanupFunc
 }
 
-func (t *logicTest) setup(cfg testClusterConfig) {
+func (t *logicTest) setup(cfg testClusterConfig, serverArgs TestServerArgs) {
 	t.cfg = cfg
 	// TODO(pmattis): Add a flag to make it easy to run the tests against a local
 	// MySQL or Postgres instance.
@@ -1170,11 +1170,18 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 	// it installs detects a transaction that doesn't have
 	// modifiedSystemConfigSpan set even though it should, for
 	// "testdata/rename_table". Figure out what's up with that.
+	var tempStorageConfig base.TempStorageConfig
+	if serverArgs.tempStorageDiskLimit == 0 {
+		tempStorageConfig = base.DefaultTestTempStorageConfig(cluster.MakeTestingClusterSettings())
+	} else {
+		tempStorageConfig = base.DefaultTestTempStorageConfigWithSize(cluster.MakeTestingClusterSettings(), serverArgs.tempStorageDiskLimit)
+	}
 	params := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			// Specify a fixed memory limit (some test cases verify OOM conditions; we
 			// don't want those to take long on large machines).
 			SQLMemoryPoolSize: 192 * 1024 * 1024,
+			TempStorageConfig: tempStorageConfig,
 			Knobs: base.TestingKnobs{
 				Store: &kvserver.StoreTestingKnobs{
 					// The consistency queue makes a lot of noisy logs during logic tests.
@@ -2535,9 +2542,18 @@ var skipLogicTests = envutil.EnvOrDefaultBool("COCKROACH_LOGIC_TESTS_SKIP", fals
 var logicTestsConfigExclude = envutil.EnvOrDefaultString("COCKROACH_LOGIC_TESTS_SKIP_CONFIG", "")
 var logicTestsConfigFilter = envutil.EnvOrDefaultString("COCKROACH_LOGIC_TESTS_CONFIG", "")
 
+// TestServerArgs contains the parameters that callers of RunLogicTest might
+// want to specify for the test clusters to be created with.
+type TestServerArgs struct {
+	// tempStorageDiskLimit determines the limit for the temp storage (that is
+	// actually in-memory). If it is unset, then the default limit of 100MB
+	// will be used.
+	tempStorageDiskLimit int64
+}
+
 // RunLogicTest is the main entry point for the logic test. The globs parameter
 // specifies the default sets of files to run.
-func RunLogicTest(t *testing.T, globs ...string) {
+func RunLogicTest(t *testing.T, serverArgs TestServerArgs, globs ...string) {
 	// Note: there is special code in teamcity-trigger/main.go to run this package
 	// with less concurrency in the nightly stress runs. If you see problems
 	// please make adjustments there.
@@ -2665,7 +2681,7 @@ func RunLogicTest(t *testing.T, globs ...string) {
 					if *printErrorSummary {
 						defer lt.printErrorSummary()
 					}
-					lt.setup(cfg)
+					lt.setup(cfg, serverArgs)
 					lt.runFile(path, cfg)
 
 					progress.Lock()

--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -29,7 +29,7 @@ import (
 // See the comments in logic.go for more details.
 func TestLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	RunLogicTest(t, "testdata/logic_test/[^.]*")
+	RunLogicTest(t, TestServerArgs{}, "testdata/logic_test/[^.]*")
 }
 
 // TestSqlLiteLogic runs the supported SqlLite logic tests. See the comments
@@ -105,5 +105,10 @@ func runSQLLiteLogicTest(t *testing.T, globs ...string) {
 		prefixedGlobs[i] = logicTestPath + glob
 	}
 
-	RunLogicTest(t, prefixedGlobs...)
+	// SQLLite logic tests can be very disk (with '-disk' configs) intensive,
+	// so we give them larger temp storage limit than other logic tests get.
+	serverArgs := TestServerArgs{
+		tempStorageDiskLimit: 512 << 20, // 512 MiB
+	}
+	RunLogicTest(t, serverArgs, prefixedGlobs...)
 }

--- a/pkg/sql/opt/exec/execbuilder/builder_test.go
+++ b/pkg/sql/opt/exec/execbuilder/builder_test.go
@@ -27,5 +27,5 @@ import (
 func TestExecBuild(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
-	logictest.RunLogicTest(t, "testdata/[^.]*")
+	logictest.RunLogicTest(t, logictest.TestServerArgs{}, "testdata/[^.]*")
 }


### PR DESCRIPTION
This commit adds an option to specify the temp storage limit for
test clusters created to run the logic tests and uses that option to
increase the limit when running the big test (sqllitelogic).

Fixes: #48283.

Release note: None