### PR TITLE
sql: add infrastructure for unresolved types

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1570,6 +1570,7 @@ case_expr ::=
 
 simple_typename ::=
 	general_type_name
+	| complex_type_name
 	| const_typename
 	| bit_with_length
 	| character_with_length
@@ -1906,6 +1907,10 @@ case_default ::=
 
 general_type_name ::=
 	type_function_name_no_crdb_extra
+
+complex_type_name ::=
+	general_type_name '.' unrestricted_name
+	| general_type_name '.' unrestricted_name '.' unrestricted_name
 
 const_typename ::=
 	numeric

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -178,7 +178,7 @@ func (regclassRewriter) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Exp
 			if len(t.Exprs) > 0 {
 				switch e := t.Exprs[0].(type) {
 				case *tree.CastExpr:
-					if e.Type.Oid() == oid.T_regclass {
+					if typ, ok := tree.GetStaticallyKnownType(e.Type); ok && typ.Oid() == oid.T_regclass {
 						// tree.Visitor says we should make a copy, but since copyNode is unexported
 						// and there's no planner here, I think it's safe to directly modify the
 						// statement here.

--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/cockroachdb/errors"
@@ -523,8 +524,12 @@ func constructTableMetadata(rows *sqlRows, md basicMetadata) (tableMetadata, err
 		if err != nil {
 			return tableMetadata{}, fmt.Errorf("type %s is not a valid CockroachDB type", typ)
 		}
-		coltyp := stmt.AST.(*tree.AlterTable).Cmds[0].(*tree.AlterTableAlterColumnType).ToType
+		ref := stmt.AST.(*tree.AlterTable).Cmds[0].(*tree.AlterTableAlterColumnType).ToType
 
+		coltyp, ok := tree.GetStaticallyKnownType(ref)
+		if !ok {
+			return tableMetadata{}, unimplemented.NewWithIssue(47765, "user defined types are unsupported")
+		}
 		coltypes[name] = coltyp
 		if colnames.Len() > 0 {
 			colnames.WriteString(", ")

--- a/pkg/internal/sqlsmith/alter.go
+++ b/pkg/internal/sqlsmith/alter.go
@@ -268,7 +268,8 @@ func makeCreateIndex(s *Smither) (tree.Statement, bool) {
 		}
 		seen[col.Name] = true
 		// If this is the first column and it's invertable (i.e., JSONB), make an inverted index.
-		if len(cols) == 0 && sqlbase.ColumnTypeIsInvertedIndexable(col.Type) {
+		if len(cols) == 0 &&
+			sqlbase.ColumnTypeIsInvertedIndexable(tree.MustBeStaticallyKnownType(col.Type)) {
 			inverted = true
 			unique = false
 			cols = append(cols, tree.IndexElem{
@@ -276,7 +277,7 @@ func makeCreateIndex(s *Smither) (tree.Statement, bool) {
 			})
 			break
 		}
-		if sqlbase.ColumnTypeIsIndexable(col.Type) {
+		if sqlbase.ColumnTypeIsIndexable(tree.MustBeStaticallyKnownType(col.Type)) {
 			cols = append(cols, tree.IndexElem{
 				Column:    col.Name,
 				Direction: s.randDirection(),

--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -79,7 +79,7 @@ func (s *Smither) tableExpr(table *tableRef, name *tree.TableName) (tree.TableEx
 	refs := make(colRefs, len(table.Columns))
 	for i, c := range table.Columns {
 		refs[i] = &colRef{
-			typ: c.Type,
+			typ: tree.MustBeStaticallyKnownType(c.Type),
 			item: tree.NewColumnItem(
 				name,
 				c.Name,
@@ -289,16 +289,16 @@ func makeMergeJoinExpr(s *Smither, _ colRefs, forJoin bool) (tree.TableExpr, col
 					if rightColElem.Direction != leftColElem.Direction {
 						break
 					}
-					if !rightCol.Type.Equivalent(leftCol.Type) {
+					if !tree.MustBeStaticallyKnownType(rightCol.Type).Equivalent(tree.MustBeStaticallyKnownType(leftCol.Type)) {
 						break
 					}
 					cols = append(cols, [2]colRef{
 						{
-							typ:  leftCol.Type,
+							typ:  tree.MustBeStaticallyKnownType(leftCol.Type),
 							item: tree.NewColumnItem(leftAliasName, leftColElem.Column),
 						},
 						{
-							typ:  rightCol.Type,
+							typ:  tree.MustBeStaticallyKnownType(rightCol.Type),
 							item: tree.NewColumnItem(rightAliasName, rightColElem.Column),
 						},
 					})
@@ -946,7 +946,7 @@ func (s *Smither) makeInsert(refs colRefs) (*tree.Insert, *tableRef, bool) {
 				continue
 			}
 			if unnamed || c.Nullable.Nullability == tree.NotNull || s.coin() {
-				desiredTypes = append(desiredTypes, c.Type)
+				desiredTypes = append(desiredTypes, tree.MustBeStaticallyKnownType(c.Type))
 				names = append(names, c.Name)
 			}
 		}
@@ -1130,7 +1130,7 @@ func (s *Smither) makeReturning(table *tableRef) (*tree.ReturningExprs, colRefs)
 	refs := make(colRefs, len(table.Columns))
 	for i, c := range table.Columns {
 		refs[i] = &colRef{
-			typ:  c.Type,
+			typ:  tree.MustBeStaticallyKnownType(c.Type),
 			item: &tree.ColumnItem{ColumnName: c.Name},
 		}
 	}

--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -104,7 +104,7 @@ func (s *Smither) getRandTableIndex(
 	defer s.lock.RUnlock()
 	for _, col := range idx.Columns {
 		refs = append(refs, &colRef{
-			typ:  s.columns[table][col.Column].Type,
+			typ:  tree.MustBeStaticallyKnownType(s.columns[table][col.Column].Type),
 			item: tree.NewColumnItem(&alias, col.Column),
 		})
 	}

--- a/pkg/internal/sqlsmith/type.go
+++ b/pkg/internal/sqlsmith/type.go
@@ -14,17 +14,18 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 )
 
 func typeFromName(name string) *types.T {
-	typ, err := parser.ParseType(name)
+	typRef, err := parser.ParseType(name)
 	if err != nil {
 		panic(errors.AssertionFailedf("failed to parse type: %v", name))
 	}
-	return typ
+	return tree.MustBeStaticallyKnownType(typRef)
 }
 
 // pickAnyType returns a concrete type if typ is types.Any or types.AnyArray,

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -146,13 +146,17 @@ func (n *alterTableNode) startExec(params runParams) error {
 					"adding a REFERENCES constraint while also adding a column via ALTER not supported")
 			}
 			version := params.ExecCfg().Settings.Version.ActiveVersionOrEmpty(params.ctx)
-			if supported, err := isTypeSupportedInVersion(version, d.Type); err != nil {
+			toType, err := tree.ResolveType(d.Type, params.p.semaCtx.GetTypeResolver())
+			if err != nil {
+				return err
+			}
+			if supported, err := isTypeSupportedInVersion(version, toType); err != nil {
 				return err
 			} else if !supported {
 				return pgerror.Newf(
 					pgcode.FeatureNotSupported,
 					"type %s is not supported until version upgrade is finalized",
-					d.Type.SQLString(),
+					toType.SQLString(),
 				)
 			}
 
@@ -892,7 +896,10 @@ func applyColumnMutation(
 ) error {
 	switch t := mut.(type) {
 	case *tree.AlterTableAlterColumnType:
-		typ := t.ToType
+		typ, err := tree.ResolveType(t.ToType, params.p.semaCtx.GetTypeResolver())
+		if err != nil {
+			return err
+		}
 
 		version := params.ExecCfg().Settings.Version.ActiveVersionOrEmpty(params.ctx)
 		if supported, err := isTypeSupportedInVersion(version, typ); err != nil {
@@ -914,7 +921,7 @@ func applyColumnMutation(
 			}
 		}
 
-		err := sqlbase.ValidateColumnDefType(typ)
+		err = sqlbase.ValidateColumnDefType(typ)
 		if err != nil {
 			return err
 		}
@@ -1159,7 +1166,7 @@ func injectTableStats(
 	// Insert each statistic.
 	for i := range jsonStats {
 		s := &jsonStats[i]
-		h, err := s.GetHistogram(params.EvalContext())
+		h, err := s.GetHistogram(&params.p.semaCtx, params.EvalContext())
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -1619,14 +1619,14 @@ func planProjectionOperators(
 		// We can't use planProjectionOperators because it will reject planning a constNullOp without knowing
 		// the post typechecking "type" of the NULL.
 		if expr.ResolvedType() == types.Unknown {
-			op, resultIdx, typs, internalMemUsed, err = planTypedMaybeNullProjectionOperators(ctx, evalCtx, expr, t.Type, columnTypes, input, acc)
+			op, resultIdx, typs, internalMemUsed, err = planTypedMaybeNullProjectionOperators(ctx, evalCtx, expr, t.ResolvedType(), columnTypes, input, acc)
 		} else {
 			op, resultIdx, typs, internalMemUsed, err = planProjectionOperators(ctx, evalCtx, expr, columnTypes, input, acc)
 		}
 		if err != nil {
 			return nil, 0, nil, internalMemUsed, err
 		}
-		op, resultIdx, typs, err = planCastOperator(ctx, acc, typs, op, resultIdx, expr.ResolvedType(), t.Type)
+		op, resultIdx, typs, err = planCastOperator(ctx, acc, typs, op, resultIdx, expr.ResolvedType(), t.ResolvedType())
 		return op, resultIdx, typs, internalMemUsed, err
 	case *tree.FuncExpr:
 		var (

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -329,7 +329,11 @@ func (ex *connExecutor) execStmtInOpenState(
 			}
 			typeHints = make(tree.PlaceholderTypes, stmt.NumPlaceholders)
 			for i, t := range s.Types {
-				typeHints[i] = t
+				resolved, err := tree.ResolveType(t, ex.planner.semaCtx.GetTypeResolver())
+				if err != nil {
+					return makeErrEvent(err)
+				}
+				typeHints[i] = resolved
 			}
 		}
 		if _, err := ex.addPreparedStmt(

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -157,7 +157,7 @@ func (ex *connExecutor) prepare(
 	// preparation.
 	stmt.Prepared = prepared
 
-	if err := tree.ProcessPlaceholderAnnotations(stmt.AST, placeholderHints); err != nil {
+	if err := tree.ProcessPlaceholderAnnotations(&ex.planner.semaCtx, stmt.AST, placeholderHints); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -219,7 +219,9 @@ func (v *distSQLExprCheckVisitor) VisitPre(expr tree.Expr) (recurse bool, newExp
 		v.err = newQueryNotSupportedError("OID expressions are not supported by distsql")
 		return false, expr
 	case *tree.CastExpr:
-		if t.Type.Family() == types.OidFamily {
+		// TODO (rohany): I'm not sure why this CastExpr doesn't have a type
+		//  annotation at this stage of processing...
+		if typ, ok := tree.GetStaticallyKnownType(t.Type); ok && typ.Family() == types.OidFamily {
 			v.err = newQueryNotSupportedErrorf("cast to %s is not supported by distsql", t.Type)
 			return false, expr
 		}

--- a/pkg/sql/mutations/mutations.go
+++ b/pkg/sql/mutations/mutations.go
@@ -203,11 +203,12 @@ func statisticsMutator(
 			}
 			n := rng.Intn(10)
 			seen := map[string]bool{}
+			colType := tree.MustBeStaticallyKnownType(col.Type)
 			h := stats.HistogramData{
-				ColumnType: *col.Type,
+				ColumnType: *colType,
 			}
 			for i := 0; i < n; i++ {
-				upper := sqlbase.RandDatumWithNullChance(rng, col.Type, 0)
+				upper := sqlbase.RandDatumWithNullChance(rng, colType, 0)
 				if upper == tree.DNull {
 					continue
 				}
@@ -417,7 +418,9 @@ func foreignKeyMutator(
 				fkCol := fkCols[len(usingCols)]
 				found := false
 				for refI, refCol := range availCols {
-					if fkCol.Type.Equivalent(refCol.Type) {
+					fkColType := tree.MustBeStaticallyKnownType(fkCol.Type)
+					refColType := tree.MustBeStaticallyKnownType(refCol.Type)
+					if fkColType.Equivalent(refColType) {
 						usingCols = append(usingCols, refCol)
 						availCols = append(availCols[:refI], availCols[refI+1:]...)
 						found = true

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -317,7 +317,7 @@ func (b *Builder) buildCast(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Ty
 	if err != nil {
 		return nil, err
 	}
-	return tree.NewTypedCastExpr(input, cast.Typ)
+	return tree.NewTypedCastExpr(input, cast.Typ), nil
 }
 
 func (b *Builder) buildCoalesce(

--- a/pkg/sql/opt/norm/fold_constants.go
+++ b/pkg/sql/opt/norm/fold_constants.go
@@ -145,10 +145,7 @@ func (c *CustomFuncs) FoldCast(input opt.ScalarExpr, typ *types.T) opt.ScalarExp
 	}
 
 	datum := memo.ExtractConstDatum(input)
-	texpr, err := tree.NewTypedCastExpr(datum, typ)
-	if err != nil {
-		return nil
-	}
+	texpr := tree.NewTypedCastExpr(datum, typ)
 
 	result, err := texpr.Eval(c.f.evalCtx)
 	if err != nil {

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -251,7 +251,7 @@ func (b *Builder) buildScalar(
 	case *tree.CastExpr:
 		texpr := t.Expr.(tree.TypedExpr)
 		arg := b.buildScalar(texpr, inScope, nil, nil, colRefs)
-		out = b.factory.ConstructCast(arg, t.Type)
+		out = b.factory.ConstructCast(arg, t.ResolvedType())
 
 	case *tree.CoalesceExpr:
 		args := make(memo.ScalarListExpr, len(t.Exprs))
@@ -387,7 +387,7 @@ func (b *Builder) buildScalar(
 		actualType := t.Expr.(tree.TypedExpr).ResolvedType()
 
 		found := false
-		for _, typ := range t.Types {
+		for _, typ := range t.ResolvedTypes() {
 			if actualType.Equivalent(typ) {
 				found = true
 				break

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -456,11 +456,7 @@ func (s *scope) resolveAndRequireType(expr tree.Expr, desired *types.T) tree.Typ
 // and can be cast to any other type.
 func (s *scope) ensureNullType(texpr tree.TypedExpr, desired *types.T) tree.TypedExpr {
 	if desired.Family() != types.AnyFamily && texpr.ResolvedType().Family() == types.UnknownFamily {
-		var err error
-		texpr, err = tree.NewTypedCastExpr(texpr, desired)
-		if err != nil {
-			panic(err)
-		}
+		texpr = tree.NewTypedCastExpr(texpr, desired)
 	}
 	return texpr
 }

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -382,10 +382,10 @@ func (tt *Table) addColumn(def *tree.ColumnTableDef) {
 	col := &Column{
 		Ordinal:  tt.ColumnCount(),
 		Name:     string(def.Name),
-		Type:     def.Type,
+		Type:     tree.MustBeStaticallyKnownType(def.Type),
 		Nullable: nullable,
 	}
-	col.ColType = *def.Type
+	col.ColType = *tree.MustBeStaticallyKnownType(def.Type)
 
 	// Look for name suffixes indicating this is a mutation column.
 	if name, ok := extractWriteOnlyColumn(def); ok {

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -39,6 +39,7 @@ const (
 
 // Catalog implements the cat.Catalog interface for testing purposes.
 type Catalog struct {
+	tree.TypeReferenceResolver
 	testSchema Schema
 	counter    int
 }
@@ -993,10 +994,11 @@ func (ts *TableStat) Histogram() []cat.HistogramBucket {
 	if ts.js.HistogramColumnType == "" || ts.js.HistogramBuckets == nil {
 		return nil
 	}
-	colType, err := parser.ParseType(ts.js.HistogramColumnType)
+	colTypeRef, err := parser.ParseType(ts.js.HistogramColumnType)
 	if err != nil {
 		panic(err)
 	}
+	colType := tree.MustBeStaticallyKnownType(colTypeRef)
 	histogram := make([]cat.HistogramBucket, len(ts.js.HistogramBuckets))
 	for i := range histogram {
 		bucket := &ts.js.HistogramBuckets[i]

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -37,6 +37,7 @@ import (
 // only include what the optimizer needs, and certain common lookups are cached
 // for faster performance.
 type optCatalog struct {
+	tree.TypeReferenceResolver
 	// planner needs to be set via a call to init before calling other methods.
 	planner *planner
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -517,6 +517,12 @@ func (u *sqlSymUnion) geoFigure() geopb.Shape {
 func newNameFromStr(s string) *tree.Name {
     return (*tree.Name)(&s)
 }
+func (u *sqlSymUnion) typeReference() tree.ResolvableTypeReference {
+    return u.val.(tree.ResolvableTypeReference)
+}
+func (u *sqlSymUnion) typeReferences() []tree.ResolvableTypeReference {
+    return u.val.([]tree.ResolvableTypeReference)
+}
 %}
 
 // NB: the %token definitions must come before the %type definitions in this
@@ -972,7 +978,7 @@ func newNameFromStr(s string) *tree.Name {
 %type <tree.Expr> having_clause
 %type <tree.Expr> array_expr
 %type <tree.Expr> interval_value
-%type <[]*types.T> type_list prep_type_clause
+%type <[]tree.ResolvableTypeReference> type_list prep_type_clause
 %type <tree.Exprs> array_expr_list
 %type <*tree.Tuple> row labeled_row
 %type <tree.Expr> case_expr case_arg case_default
@@ -998,7 +1004,8 @@ func newNameFromStr(s string) *tree.Name {
 %type <str> explain_option_name
 %type <[]string> explain_option_list opt_enum_val_list enum_val_list
 
-%type <*types.T> typename simple_typename const_typename
+%type <tree.ResolvableTypeReference> typename simple_typename cast_target
+%type <*types.T> const_typename
 %type <bool> opt_timezone
 %type <*types.T> numeric opt_numeric_modifiers
 %type <*types.T> opt_float
@@ -1007,7 +1014,6 @@ func newNameFromStr(s string) *tree.Name {
 %type <*types.T> bit_with_length bit_without_length
 %type <*types.T> character_base
 %type <*types.T> geo_shape
-%type <*types.T> cast_target
 %type <*types.T> const_geo
 %type <str> extract_arg
 %type <bool> opt_varying
@@ -1030,7 +1036,8 @@ func newNameFromStr(s string) *tree.Name {
 %type <str> unreserved_keyword type_func_name_keyword type_func_name_no_crdb_extra_keyword type_func_name_crdb_extra_keyword
 %type <str> col_name_keyword reserved_keyword cockroachdb_extra_reserved_keyword extra_var_value
 
-%type <str> complex_type_name general_type_name
+%type <tree.ResolvableTypeReference> complex_type_name
+%type <str> general_type_name
 
 %type <tree.ConstraintTableDef> table_constraint constraint_elem create_as_constraint_def create_as_constraint_elem
 %type <tree.TableDef> index_def
@@ -1723,7 +1730,7 @@ alter_table_cmd:
   {
     $$.val = &tree.AlterTableAlterColumnType{
       Column: tree.Name($3),
-      ToType: $6.colType(),
+      ToType: $6.typeReference(),
       Collation: $7,
       Using: $8.expr(),
     }
@@ -2840,7 +2847,7 @@ prepare_stmt:
   {
     $$.val = &tree.Prepare{
       Name: tree.Name($2),
-      Types: $3.colTypes(),
+      Types: $3.typeReferences(),
       Statement: $5.stmt(),
     }
   }
@@ -2849,7 +2856,7 @@ prepare_stmt:
     /* SKIP DOC */
     $$.val = &tree.Prepare{
       Name: tree.Name($2),
-      Types: $3.colTypes(),
+      Types: $3.typeReferences(),
       Statement: &tree.CannedOptPlan{Plan: $7},
     }
   }
@@ -2858,11 +2865,11 @@ prepare_stmt:
 prep_type_clause:
   '(' type_list ')'
   {
-    $$.val = $2.colTypes();
+    $$.val = $2.typeReferences();
   }
 | /* EMPTY */
   {
-    $$.val = []*types.T(nil)
+    $$.val = []tree.ResolvableTypeReference(nil)
   }
 
 // %Help: EXECUTE - execute a statement prepared previously
@@ -4735,8 +4742,8 @@ range_partition:
 column_def:
   column_name typename col_qual_list
   {
-    typ := $2.colType()
-    tableDef, err := tree.NewColumnTableDef(tree.Name($1), typ, types.IsSerialType(typ), $3.colQuals())
+    typ := $2.typeReference()
+    tableDef, err := tree.NewColumnTableDef(tree.Name($1), typ, tree.IsReferenceSerialType(typ), $3.colQuals())
     if err != nil {
       return setErr(sqllex, err)
     }
@@ -5252,7 +5259,7 @@ sequence_option_list:
 | sequence_option_list sequence_option_elem  { $$.val = append($1.seqOpts(), $2.seqOpt()) }
 
 sequence_option_elem:
-  AS typename                  { return unimplementedWithIssueDetail(sqllex, 25110, $2.colType().SQLString()) }
+  AS typename                  { return unimplementedWithIssueDetail(sqllex, 25110, $2.typeReference().SQLString()) }
 | CYCLE                        { /* SKIP DOC */
                                  $$.val = tree.SequenceOption{Name: tree.SeqOptCycle} }
 | NO CYCLE                     { $$.val = tree.SequenceOption{Name: tree.SeqOptNoCycle} }
@@ -7369,12 +7376,12 @@ typename:
   {
     if bounds := $2.int32s(); bounds != nil {
       var err error
-      $$.val, err = arrayOf($1.colType(), bounds)
+      $$.val, err = arrayOf($1.typeReference(), bounds)
       if err != nil {
         return setErr(sqllex, err)
       }
     } else {
-      $$.val = $1.colType()
+      $$.val = $1.typeReference()
     }
   }
   // SQL standard syntax, currently only one-dimensional
@@ -7382,7 +7389,7 @@ typename:
 | simple_typename ARRAY '[' ICONST ']' {
     /* SKIP DOC */
     var err error
-    $$.val, err = arrayOf($1.colType(), nil)
+    $$.val, err = arrayOf($1.typeReference(), nil)
     if err != nil {
       return setErr(sqllex, err)
     }
@@ -7390,7 +7397,7 @@ typename:
 | simple_typename ARRAY '[' ICONST ']' '[' error { return unimplementedWithIssue(sqllex, 32552) }
 | simple_typename ARRAY {
     var err error
-    $$.val, err = arrayOf($1.colType(), nil)
+    $$.val, err = arrayOf($1.typeReference(), nil)
     if err != nil {
       return setErr(sqllex, err)
     }
@@ -7399,7 +7406,7 @@ typename:
 cast_target:
   typename
   {
-    $$.val = $1.colType()
+    $$.val = $1.typeReference()
   }
 
 opt_array_bounds:
@@ -7430,11 +7437,17 @@ general_type_name:
 complex_type_name:
   general_type_name '.' unrestricted_name
   {
-    return unimplemented(sqllex, "qualified types")
+    aIdx := sqllex.(*lexer).NewAnnotation()
+    res, err := tree.NewUnresolvedObjectName(2, [3]string{$3, $1}, aIdx)
+    if err != nil { return setErr(sqllex, err) }
+    $$.val = res
   }
 | general_type_name '.' unrestricted_name '.' unrestricted_name
   {
-    return unimplemented(sqllex, "qualified types")
+    aIdx := sqllex.(*lexer).NewAnnotation()
+    res, err := tree.NewUnresolvedObjectName(3, [3]string{$5, $3, $1}, aIdx)
+    if err != nil { return setErr(sqllex, err) }
+    $$.val = res
   }
 
 simple_typename:
@@ -7456,16 +7469,20 @@ simple_typename:
           $$.val = &types.Serial8Type
         }
     } else {
+      // Check the the type is one of our "non-keyword" type names.
+      // Otherwise, package it up as a type reference for later.
       var ok bool
+      var err error
       var unimp int
       $$.val, ok, unimp = types.TypeForNonKeywordTypeName($1)
       if !ok {
         switch unimp {
           case 0:
-            // Note: we can only report an unimplemented error for specific
-            // known type names. Anything else may return sensitive info.
-            sqllex.Error(fmt.Sprintf("type %q does not exist", $1))
-            return 1
+            // In this case, we don't think this type is one of our
+            // known unsupported types, so make a type reference for it.
+            aIdx := sqllex.(*lexer).NewAnnotation()
+            $$.val, err = tree.NewUnresolvedObjectName(1, [3]string{$1}, aIdx)
+            if err != nil { return setErr(sqllex, err) }
           case -1:
             return unimplemented(sqllex, "type name " + $1)
           default:
@@ -7476,7 +7493,7 @@ simple_typename:
   }
 | complex_type_name
   {
-    return unimplemented(sqllex, "qualified types")
+    $$.val = $1.typeReference()
   }
 | const_typename
 | bit_with_length
@@ -7957,11 +7974,11 @@ a_expr:
   c_expr
 | a_expr TYPECAST cast_target
   {
-    $$.val = &tree.CastExpr{Expr: $1.expr(), Type: $3.colType(), SyntaxMode: tree.CastShort}
+    $$.val = &tree.CastExpr{Expr: $1.expr(), Type: $3.typeReference(), SyntaxMode: tree.CastShort}
   }
 | a_expr TYPEANNOTATE typename
   {
-    $$.val = &tree.AnnotateTypeExpr{Expr: $1.expr(), Type: $3.colType(), SyntaxMode: tree.AnnotateShort}
+    $$.val = &tree.AnnotateTypeExpr{Expr: $1.expr(), Type: $3.typeReference(), SyntaxMode: tree.AnnotateShort}
   }
 | a_expr COLLATE collation_name
   {
@@ -8266,11 +8283,11 @@ a_expr:
   }
 | a_expr IS OF '(' type_list ')' %prec IS
   {
-    $$.val = &tree.IsOfTypeExpr{Expr: $1.expr(), Types: $5.colTypes()}
+    $$.val = &tree.IsOfTypeExpr{Expr: $1.expr(), Types: $5.typeReferences()}
   }
 | a_expr IS NOT OF '(' type_list ')' %prec IS
   {
-    $$.val = &tree.IsOfTypeExpr{Not: true, Expr: $1.expr(), Types: $6.colTypes()}
+    $$.val = &tree.IsOfTypeExpr{Not: true, Expr: $1.expr(), Types: $6.typeReferences()}
   }
 | a_expr BETWEEN opt_asymmetric b_expr AND a_expr %prec BETWEEN
   {
@@ -8332,11 +8349,11 @@ b_expr:
   c_expr
 | b_expr TYPECAST cast_target
   {
-    $$.val = &tree.CastExpr{Expr: $1.expr(), Type: $3.colType(), SyntaxMode: tree.CastShort}
+    $$.val = &tree.CastExpr{Expr: $1.expr(), Type: $3.typeReference(), SyntaxMode: tree.CastShort}
   }
 | b_expr TYPEANNOTATE typename
   {
-    $$.val = &tree.AnnotateTypeExpr{Expr: $1.expr(), Type: $3.colType(), SyntaxMode: tree.AnnotateShort}
+    $$.val = &tree.AnnotateTypeExpr{Expr: $1.expr(), Type: $3.typeReference(), SyntaxMode: tree.AnnotateShort}
   }
 | '+' b_expr %prec UMINUS
   {
@@ -8436,11 +8453,11 @@ b_expr:
   }
 | b_expr IS OF '(' type_list ')' %prec IS
   {
-    $$.val = &tree.IsOfTypeExpr{Expr: $1.expr(), Types: $5.colTypes()}
+    $$.val = &tree.IsOfTypeExpr{Expr: $1.expr(), Types: $5.typeReferences()}
   }
 | b_expr IS NOT OF '(' type_list ')' %prec IS
   {
-    $$.val = &tree.IsOfTypeExpr{Not: true, Expr: $1.expr(), Types: $6.colTypes()}
+    $$.val = &tree.IsOfTypeExpr{Not: true, Expr: $1.expr(), Types: $6.typeReferences()}
   }
 
 // Productions that can be used in both a_expr and b_expr.
@@ -8654,14 +8671,23 @@ typed_literal:
           $$.val = &tree.CastExpr{Expr: tree.NewStrVal($2), Type: &types.Serial8Type, SyntaxMode: tree.CastPrepend}
         }
       } else {
-        typ, ok, unimp := types.TypeForNonKeywordTypeName(typName)
+        // Check the the type is one of our "non-keyword" type names.
+        // Otherwise, package it up as a type reference for later.
+        // However, if the type name is one of our known unsupported
+        // types, return an unimplemented error message.
+        var typ tree.ResolvableTypeReference
+        var ok bool
+        var err error
+        var unimp int
+        typ, ok, unimp = types.TypeForNonKeywordTypeName(typName)
         if !ok {
           switch unimp {
             case 0:
-              // Note: we can only report an unimplemented error for specific
-              // known type names. Anything else may return PII.
-              sqllex.Error(fmt.Sprintf("type %q does not exist", typName))
-              return 1
+              // In this case, we don't think this type is one of our
+              // known unsupported types, so make a type reference for it.
+              aIdx := sqllex.(*lexer).NewAnnotation()
+              typ, err = name.ToUnresolvedObjectName(aIdx)
+              if err != nil { return setErr(sqllex, err) }
             case -1:
               return unimplemented(sqllex, "type name " + typName)
             default:
@@ -8671,7 +8697,10 @@ typed_literal:
       $$.val = &tree.CastExpr{Expr: tree.NewStrVal($2), Type: typ, SyntaxMode: tree.CastPrepend}
       }
     } else {
-      return unimplemented(sqllex, "generic-type-name prepended casts")
+      aIdx := sqllex.(*lexer).NewAnnotation()
+      res, err := name.ToUnresolvedObjectName(aIdx)
+      if err != nil { return setErr(sqllex, err) }
+      $$.val = &tree.CastExpr{Expr: tree.NewStrVal($2), Type: res, SyntaxMode: tree.CastPrepend}
     }
   }
 | const_typename SCONST
@@ -8763,11 +8792,11 @@ func_expr_common_subexpr:
   }
 | CAST '(' a_expr AS cast_target ')'
   {
-    $$.val = &tree.CastExpr{Expr: $3.expr(), Type: $5.colType(), SyntaxMode: tree.CastExplicit}
+    $$.val = &tree.CastExpr{Expr: $3.expr(), Type: $5.typeReference(), SyntaxMode: tree.CastExplicit}
   }
 | ANNOTATE_TYPE '(' a_expr ',' typename ')'
   {
-    $$.val = &tree.AnnotateTypeExpr{Expr: $3.expr(), Type: $5.colType(), SyntaxMode: tree.AnnotateExplicit}
+    $$.val = &tree.AnnotateTypeExpr{Expr: $3.expr(), Type: $5.typeReference(), SyntaxMode: tree.AnnotateExplicit}
   }
 | IF '(' a_expr ',' a_expr ',' a_expr ')'
   {
@@ -9282,11 +9311,11 @@ expr_list:
 type_list:
   typename
   {
-    $$.val = []*types.T{$1.colType()}
+    $$.val = []tree.ResolvableTypeReference{$1.typeReference()}
   }
 | type_list ',' typename
   {
-    $$.val = append($1.colTypes(), $3.colType())
+    $$.val = append($1.typeReferences(), $3.typeReference())
   }
 
 array_expr:

--- a/pkg/sql/physicalplan/expression.go
+++ b/pkg/sql/physicalplan/expression.go
@@ -130,10 +130,7 @@ func (e *evalAndReplaceSubqueryVisitor) VisitPre(expr tree.Expr) (bool, tree.Exp
 		}
 		var newExpr tree.Expr = val
 		if _, isTuple := val.(*tree.DTuple); !isTuple && expr.ResolvedType().Family() != types.UnknownFamily {
-			newExpr = &tree.CastExpr{
-				Expr: val,
-				Type: expr.ResolvedType(),
-			}
+			newExpr = tree.NewTypedCastExpr(val, expr.ResolvedType())
 		}
 		return false, newExpr
 	default:

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -423,7 +423,11 @@ func (p *planner) DistSQLPlanner() *DistSQLPlanner {
 // ParseType implements the tree.EvalPlanner interface.
 // We define this here to break the dependency from eval.go to the parser.
 func (p *planner) ParseType(sql string) (*types.T, error) {
-	return parser.ParseType(sql)
+	ref, err := parser.ParseType(sql)
+	if err != nil {
+		return nil, err
+	}
+	return tree.ResolveType(ref, p.semaCtx.GetTypeResolver())
 }
 
 // ParseQualifiedTableName implements the tree.EvalDatabase interface.

--- a/pkg/sql/schemachange/alter_column_type.go
+++ b/pkg/sql/schemachange/alter_column_type.go
@@ -228,10 +228,9 @@ func ClassifyConversion(oldType *types.T, newType *types.T) (ColumnConversionKin
 	}
 
 	// Cook up a cast expression using the placeholder.
-	if cast, err := tree.NewTypedCastExpr(fromPlaceholder, newType); err == nil {
-		if _, err := cast.TypeCheck(&ctx, nil); err == nil {
-			return ColumnConversionGeneral, nil
-		}
+	cast := tree.NewTypedCastExpr(fromPlaceholder, newType)
+	if _, err := cast.TypeCheck(&ctx, nil); err == nil {
+		return ColumnConversionGeneral, nil
 	}
 
 	return ColumnConversionImpossible,

--- a/pkg/sql/schemachange/alter_column_type_test.go
+++ b/pkg/sql/schemachange/alter_column_type_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -40,7 +41,7 @@ func TestColumnConversions(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		return t
+		return tree.MustBeStaticallyKnownType(t)
 	}
 
 	// columnConversionInfo is where we document conversions that

--- a/pkg/sql/sem/tree/alter_table.go
+++ b/pkg/sql/sem/tree/alter_table.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
 // AlterTable represents an ALTER TABLE statement.
@@ -200,7 +199,7 @@ func (node *AlterTableAddConstraint) Format(ctx *FmtCtx) {
 type AlterTableAlterColumnType struct {
 	Collation string
 	Column    Name
-	ToType    *types.T
+	ToType    ResolvableTypeReference
 	Using     Expr
 }
 

--- a/pkg/sql/sem/tree/col_name.go
+++ b/pkg/sql/sem/tree/col_name.go
@@ -86,7 +86,10 @@ func ComputeColNameInternal(sp sessiondata.SearchPath, target Expr) (int, string
 			return 0, "", err
 		}
 		if strength <= 1 {
-			return 1, computeCastName(e.Type), nil
+			if typ, ok := GetStaticallyKnownType(e.Type); ok {
+				return 0, computeCastName(typ), nil
+			}
+			return 1, e.Type.SQLString(), nil
 		}
 		return strength, s, nil
 
@@ -97,7 +100,10 @@ func ComputeColNameInternal(sp sessiondata.SearchPath, target Expr) (int, string
 			return 0, "", err
 		}
 		if strength <= 1 {
-			return 1, computeCastName(e.Type), nil
+			if typ, ok := GetStaticallyKnownType(e.Type); ok {
+				return 0, computeCastName(typ), nil
+			}
+			return 1, e.Type.SQLString(), nil
 		}
 		return strength, s, nil
 

--- a/pkg/sql/sem/tree/col_types_test.go
+++ b/pkg/sql/sem/tree/col_types_test.go
@@ -85,9 +85,10 @@ func TestParseColumnType(t *testing.T) {
 			if !ok2 {
 				t.Fatalf("%d: expected tree.ColumnTableDef, but got %T", i, createTable.Defs[0])
 			}
-			if !reflect.DeepEqual(d.expectedType, columnDef.Type) {
+			colType := tree.MustBeStaticallyKnownType(columnDef.Type)
+			if !reflect.DeepEqual(d.expectedType, colType) {
 				t.Fatalf("%d: expected %s, but got %s",
-					i, d.expectedType.DebugString(), columnDef.Type.DebugString())
+					i, d.expectedType.DebugString(), colType.DebugString())
 			}
 		})
 	}
@@ -124,8 +125,9 @@ func TestParseColumnTypeAliases(t *testing.T) {
 			if !ok2 {
 				t.Fatalf("%d: expected tree.ColumnTableDef, but got %T", i, createTable.Defs[0])
 			}
-			if !reflect.DeepEqual(*d.expectedType, *columnDef.Type) {
-				t.Fatalf("%d: expected %s, but got %s", i, d.expectedType.DebugString(), columnDef.Type.DebugString())
+			colType := tree.MustBeStaticallyKnownType(columnDef.Type)
+			if !reflect.DeepEqual(*d.expectedType, *colType) {
+				t.Fatalf("%d: expected %s, but got %s", i, d.expectedType.DebugString(), colType.DebugString())
 			}
 		})
 	}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3322,7 +3322,7 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 		return d, nil
 	}
 	d = UnwrapDatum(ctx, d)
-	return PerformCast(ctx, d, expr.Type)
+	return PerformCast(ctx, d, expr.ResolvedType())
 }
 
 // PerformCast performs a cast from the provided Datum to the specified
@@ -4253,7 +4253,7 @@ func (expr *IsOfTypeExpr) Eval(ctx *EvalContext) (Datum, error) {
 	}
 	datumTyp := d.ResolvedType()
 
-	for _, t := range expr.Types {
+	for _, t := range expr.ResolvedTypes() {
 		if datumTyp.Equivalent(t) {
 			return MakeDBool(DBool(!expr.Not)), nil
 		}
@@ -4602,7 +4602,7 @@ func (t *Placeholder) Eval(ctx *EvalContext) (Datum, error) {
 		// type for the placeholder. In this case, we cast the expression to
 		// the desired type.
 		// TODO(jordan): introduce a restriction on what casts are allowed here.
-		cast := &CastExpr{Expr: e, Type: typ}
+		cast := NewTypedCastExpr(e, typ)
 		return cast.Eval(ctx)
 	}
 	return e.Eval(ctx)

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -598,12 +598,24 @@ func (node *RangeCond) TypedTo() TypedExpr {
 type IsOfTypeExpr struct {
 	Not   bool
 	Expr  Expr
-	Types []*types.T
+	Types []ResolvableTypeReference
+
+	resolvedTypes []*types.T
 
 	typeAnnotation
 }
 
 func (*IsOfTypeExpr) operatorExpr() {}
+
+// ResolvedTypes returns a slice of resolved types corresponding
+// to the Types slice of unresolved types. It may only be accessed
+// after typechecking.
+func (node *IsOfTypeExpr) ResolvedTypes() []*types.T {
+	if node.resolvedTypes == nil {
+		panic("ResolvedTypes called on an IsOfTypeExpr before typechecking")
+	}
+	return node.resolvedTypes
+}
 
 // Format implements the NodeFormatter interface.
 func (node *IsOfTypeExpr) Format(ctx *FmtCtx) {
@@ -1422,7 +1434,7 @@ const (
 // CastExpr represents a CAST(expr AS type) expression.
 type CastExpr struct {
 	Expr Expr
-	Type *types.T
+	Type ResolvableTypeReference
 
 	typeAnnotation
 	SyntaxMode castSyntaxMode
@@ -1433,7 +1445,7 @@ func (node *CastExpr) Format(ctx *FmtCtx) {
 	switch node.SyntaxMode {
 	case CastPrepend:
 		// This is a special case for things like INTERVAL '1s'. These only work
-		// with string constats; if the underlying expression was changed, we fall
+		// with string constants; if the underlying expression was changed, we fall
 		// back to the short syntax.
 		if _, ok := node.Expr.(*StrVal); ok {
 			ctx.WriteString(node.Type.SQLString())
@@ -1450,19 +1462,19 @@ func (node *CastExpr) Format(ctx *FmtCtx) {
 		ctx.WriteString("CAST(")
 		ctx.FormatNode(node.Expr)
 		ctx.WriteString(" AS ")
-		if node.Type.Family() == types.CollatedStringFamily {
+		if typ, ok := GetStaticallyKnownType(node.Type); ok && typ.Family() == types.CollatedStringFamily {
 			// Need to write closing parentheses before COLLATE clause, so create
 			// equivalent string type without the locale.
 			strTyp := types.MakeScalar(
 				types.StringFamily,
-				node.Type.Oid(),
-				node.Type.Precision(),
-				node.Type.Width(),
+				typ.Oid(),
+				typ.Precision(),
+				typ.Width(),
 				"", /* locale */
 			)
 			ctx.WriteString(strTyp.SQLString())
 			ctx.WriteString(") COLLATE ")
-			lex.EncodeLocaleName(&ctx.Buffer, node.Type.Locale())
+			lex.EncodeLocaleName(&ctx.Buffer, typ.Locale())
 		} else {
 			ctx.WriteString(node.Type.SQLString())
 			ctx.WriteByte(')')
@@ -1471,10 +1483,10 @@ func (node *CastExpr) Format(ctx *FmtCtx) {
 }
 
 // NewTypedCastExpr returns a new CastExpr that is verified to be well-typed.
-func NewTypedCastExpr(expr TypedExpr, typ *types.T) (*CastExpr, error) {
+func NewTypedCastExpr(expr TypedExpr, typ *types.T) *CastExpr {
 	node := &CastExpr{Expr: expr, Type: typ, SyntaxMode: CastShort}
 	node.typ = typ
-	return node, nil
+	return node
 }
 
 type castInfo struct {
@@ -1595,7 +1607,7 @@ const (
 // AnnotateTypeExpr represents a ANNOTATE_TYPE(expr, type) expression.
 type AnnotateTypeExpr struct {
 	Expr Expr
-	Type *types.T
+	Type ResolvableTypeReference
 
 	SyntaxMode annotateSyntaxMode
 }
@@ -1604,11 +1616,13 @@ type AnnotateTypeExpr struct {
 func (node *AnnotateTypeExpr) Format(ctx *FmtCtx) {
 	if ctx.HasFlags(FmtPGAttrdefAdbin) {
 		ctx.FormatNode(node.Expr)
-		switch node.Type.Family() {
-		case types.StringFamily, types.CollatedStringFamily:
-			// Postgres formats strings using a cast afterward. Let's do the same.
-			ctx.WriteString("::")
-			ctx.WriteString(node.Type.SQLString())
+		if typ, ok := GetStaticallyKnownType(node.Type); ok {
+			switch typ.Family() {
+			case types.StringFamily, types.CollatedStringFamily:
+				// Postgres formats strings using a cast afterward. Let's do the same.
+				ctx.WriteString("::")
+				ctx.WriteString(node.Type.SQLString())
+			}
 		}
 		return
 	}

--- a/pkg/sql/sem/tree/name_part.go
+++ b/pkg/sql/sem/tree/name_part.go
@@ -10,7 +10,11 @@
 
 package tree
 
-import "github.com/cockroachdb/cockroach/pkg/sql/lex"
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/lex"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+)
 
 // A Name is an SQL identifier.
 //
@@ -200,4 +204,16 @@ func MakeUnresolvedName(args ...string) UnresolvedName {
 		n.Parts[i] = args[len(args)-1-i]
 	}
 	return n
+}
+
+// ToUnresolvedObjectName converts an UnresolvedName to an UnresolvedObjectName.
+func (u *UnresolvedName) ToUnresolvedObjectName(idx AnnotationIdx) (*UnresolvedObjectName, error) {
+	if u.NumParts == 4 {
+		return nil, pgerror.Newf(pgcode.Syntax, "improper qualified name (too many dotted names): %s", u)
+	}
+	return NewUnresolvedObjectName(
+		u.NumParts,
+		[3]string{u.Parts[0], u.Parts[1], u.Parts[2]},
+		idx,
+	)
 }

--- a/pkg/sql/sem/tree/prepare.go
+++ b/pkg/sql/sem/tree/prepare.go
@@ -10,15 +10,12 @@
 
 package tree
 
-import (
-	"github.com/cockroachdb/cockroach/pkg/sql/lex"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
-)
+import "github.com/cockroachdb/cockroach/pkg/sql/lex"
 
 // Prepare represents a PREPARE statement.
 type Prepare struct {
 	Name      Name
-	Types     []*types.T
+	Types     []ResolvableTypeReference
 	Statement Statement
 }
 

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -986,10 +986,12 @@ func (node *CastExpr) doc(p *PrettyCfg) pretty.Doc {
 		}
 		fallthrough
 	case CastShort:
-		switch node.Type.Family() {
-		case types.JsonFamily:
-			if sv, ok := node.Expr.(*StrVal); ok && p.JSONFmt {
-				return p.jsonCast(sv, "::", node.Type)
+		if typ, ok := GetStaticallyKnownType(node.Type); ok {
+			switch typ.Family() {
+			case types.JsonFamily:
+				if sv, ok := node.Expr.(*StrVal); ok && p.JSONFmt {
+					return p.jsonCast(sv, "::", typ)
+				}
 			}
 		}
 		return pretty.Fold(pretty.Concat,
@@ -998,15 +1000,15 @@ func (node *CastExpr) doc(p *PrettyCfg) pretty.Doc {
 			typ,
 		)
 	default:
-		if node.Type.Family() == types.CollatedStringFamily {
+		if nTyp, ok := GetStaticallyKnownType(node.Type); ok && nTyp.Family() == types.CollatedStringFamily {
 			// COLLATE clause needs to go after CAST expression, so create
 			// equivalent string type without the locale to get name of string
 			// type without the COLLATE.
 			strTyp := types.MakeScalar(
 				types.StringFamily,
-				node.Type.Oid(),
-				node.Type.Precision(),
-				node.Type.Width(),
+				nTyp.Oid(),
+				nTyp.Precision(),
+				nTyp.Width(),
 				"", /* locale */
 			)
 			typ = pretty.Text(strTyp.SQLString())
@@ -1027,11 +1029,11 @@ func (node *CastExpr) doc(p *PrettyCfg) pretty.Doc {
 			),
 		)
 
-		if node.Type.Family() == types.CollatedStringFamily {
+		if nTyp, ok := GetStaticallyKnownType(node.Type); ok && nTyp.Family() == types.CollatedStringFamily {
 			ret = pretty.Fold(pretty.ConcatSpace,
 				ret,
 				pretty.Keyword("COLLATE"),
-				pretty.Text(node.Type.Locale()))
+				pretty.Text(nTyp.Locale()))
 		}
 		return ret
 	}
@@ -2159,10 +2161,12 @@ func (node *Execute) docTable(p *PrettyCfg) []pretty.TableRow {
 
 func (node *AnnotateTypeExpr) doc(p *PrettyCfg) pretty.Doc {
 	if node.SyntaxMode == AnnotateShort {
-		switch node.Type.Family() {
-		case types.JsonFamily:
-			if sv, ok := node.Expr.(*StrVal); ok && p.JSONFmt {
-				return p.jsonCast(sv, ":::", node.Type)
+		if typ, ok := GetStaticallyKnownType(node.Type); ok {
+			switch typ.Family() {
+			case types.JsonFamily:
+				if sv, ok := node.Expr.(*StrVal); ok && p.JSONFmt {
+					return p.jsonCast(sv, ":::", typ)
+				}
 			}
 		}
 	}

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -49,6 +49,9 @@ type SemaContext struct {
 	// already.
 	SearchPath sessiondata.SearchPath
 
+	// TypeResolver manages resolving type names into *types.T's.
+	TypeResolver TypeReferenceResolver
+
 	// AsOfTimestamp denotes the explicit AS OF SYSTEM TIME timestamp for the
 	// query, if any. If the query is not an AS OF SYSTEM TIME query,
 	// AsOfTimestamp is nil.
@@ -210,6 +213,14 @@ func (sc *SemaContext) GetLocation() *time.Location {
 // GetRelativeParseTime implements ParseTimeContext.
 func (sc *SemaContext) GetRelativeParseTime() time.Time {
 	return timeutil.Now().In(sc.GetLocation())
+}
+
+// GetTypeResolver returns the TypeReferenceResolver.
+func (sc *SemaContext) GetTypeResolver() TypeReferenceResolver {
+	if sc == nil {
+		return nil
+	}
+	return sc.TypeResolver
 }
 
 func placeholderTypeAmbiguityError(idx PlaceholderIdx) error {
@@ -434,20 +445,24 @@ func (expr *CastExpr) TypeCheck(ctx *SemaContext, _ *types.T) (TypedExpr, error)
 	// types.Any is passed to the child of the cast. There are two
 	// exceptions, described below.
 	desired := types.Any
+	exprType, err := ResolveType(expr.Type, ctx.GetTypeResolver())
+	if err != nil {
+		return nil, err
+	}
 	switch {
 	case isConstant(expr.Expr):
-		if canConstantBecome(expr.Expr.(Constant), expr.Type) {
+		if canConstantBecome(expr.Expr.(Constant), exprType) {
 			// If a Constant is subject to a cast which it can naturally become (which
 			// is in its resolvable type set), we desire the cast's type for the Constant,
 			// which will result in the CastExpr becoming an identity cast.
-			desired = expr.Type
+			desired = exprType
 
 			// If the type doesn't have any possible parameters (like length,
 			// precision), the CastExpr becomes a no-op and can be elided.
-			switch expr.Type.Family() {
+			switch exprType.Family() {
 			case types.BoolFamily, types.DateFamily, types.TimeFamily, types.TimestampFamily, types.TimestampTZFamily,
 				types.IntervalFamily, types.BytesFamily:
-				return expr.Expr.TypeCheck(ctx, expr.Type)
+				return expr.Expr.TypeCheck(ctx, exprType)
 			}
 		}
 	case ctx.isUnresolvedPlaceholder(expr.Expr):
@@ -461,8 +476,8 @@ func (expr *CastExpr) TypeCheck(ctx *SemaContext, _ *types.T) (TypedExpr, error)
 		// types.Any. If we're going to cast to another array type, which is a
 		// common pattern in SQL (select array[]::int[]), use the cast type as the
 		// the desired type.
-		if expr.Type.Family() == types.ArrayFamily {
-			desired = expr.Type
+		if exprType.Family() == types.ArrayFamily {
+			desired = exprType
 		}
 	}
 
@@ -473,14 +488,14 @@ func (expr *CastExpr) TypeCheck(ctx *SemaContext, _ *types.T) (TypedExpr, error)
 
 	castFrom := typedSubExpr.ResolvedType()
 
-	if ok, c := isCastDeepValid(castFrom, expr.Type); ok {
+	if ok, c := isCastDeepValid(castFrom, exprType); ok {
 		telemetry.Inc(c)
 		expr.Expr = typedSubExpr
-		expr.typ = expr.Type
+		expr.typ = exprType
 		return expr, nil
 	}
 
-	return nil, pgerror.Newf(pgcode.CannotCoerce, "invalid cast: %s -> %s", castFrom, expr.Type)
+	return nil, pgerror.Newf(pgcode.CannotCoerce, "invalid cast: %s -> %s", castFrom, exprType)
 }
 
 // TypeCheck implements the Expr interface.
@@ -517,8 +532,20 @@ func (expr *IndirectionExpr) TypeCheck(ctx *SemaContext, desired *types.T) (Type
 
 // TypeCheck implements the Expr interface.
 func (expr *AnnotateTypeExpr) TypeCheck(ctx *SemaContext, desired *types.T) (TypedExpr, error) {
-	subExpr, err := typeCheckAndRequire(ctx, expr.Expr, expr.Type,
-		fmt.Sprintf("type annotation for %v as %s, found", expr.Expr, expr.Type))
+	annotateType, err := ResolveType(expr.Type, ctx.GetTypeResolver())
+	if err != nil {
+		return nil, err
+	}
+	subExpr, err := typeCheckAndRequire(
+		ctx,
+		expr.Expr,
+		annotateType,
+		fmt.Sprintf(
+			"type annotation for %v as %s, found",
+			expr.Expr,
+			annotateType,
+		),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -872,11 +899,7 @@ func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired *types.T) (TypedExpr, 
 
 					// Cast the expression to a string so the execution engine will find
 					// the correct overload.
-					e, err := NewTypedCastExpr(typedSubExprs[i], types.String)
-					if err != nil {
-						return nil, err
-					}
-					typedSubExprs[i] = e
+					typedSubExprs[i] = NewTypedCastExpr(typedSubExprs[i], types.String)
 				}
 			}
 		}
@@ -1042,6 +1065,14 @@ func (expr *IsOfTypeExpr) TypeCheck(ctx *SemaContext, desired *types.T) (TypedEx
 	exprTyped, err := expr.Expr.TypeCheck(ctx, types.Any)
 	if err != nil {
 		return nil, err
+	}
+	expr.resolvedTypes = make([]*types.T, len(expr.Types))
+	for i := range expr.Types {
+		typ, err := ResolveType(expr.Types[i], ctx.GetTypeResolver())
+		if err != nil {
+			return nil, err
+		}
+		expr.resolvedTypes[i] = typ
 	}
 	expr.Expr = exprTyped
 	expr.typ = types.Bool
@@ -2179,6 +2210,7 @@ type placeholderAnnotationVisitor struct {
 	types PlaceholderTypes
 	state []annotationState
 	err   error
+	ctx   *SemaContext
 	// errIdx stores the placeholder to which err applies. Used to select the
 	// error for the smallest index.
 	errIdx PlaceholderIdx
@@ -2222,15 +2254,20 @@ func (v *placeholderAnnotationVisitor) VisitPre(expr Expr) (recurse bool, newExp
 	switch t := expr.(type) {
 	case *AnnotateTypeExpr:
 		if arg, ok := t.Expr.(*Placeholder); ok {
+			tType, err := ResolveType(t.Type, v.ctx.GetTypeResolver())
+			if err != nil {
+				v.setErr(arg.Idx, err)
+				return false, expr
+			}
 			switch v.state[arg.Idx] {
 			case noType, typeFromCast, conflictingCasts:
 				// An annotation overrides casts.
-				v.types[arg.Idx] = t.Type
+				v.types[arg.Idx] = tType
 				v.state[arg.Idx] = typeFromAnnotation
 
 			case typeFromAnnotation:
 				// Verify that the annotations are consistent.
-				if !t.Type.Equivalent(v.types[arg.Idx]) {
+				if !tType.Equivalent(v.types[arg.Idx]) {
 					v.setErr(arg.Idx, pgerror.Newf(
 						pgcode.DatatypeMismatch,
 						"multiple conflicting type annotations around %s",
@@ -2240,7 +2277,7 @@ func (v *placeholderAnnotationVisitor) VisitPre(expr Expr) (recurse bool, newExp
 
 			case typeFromHint:
 				// Verify that the annotation is consistent with the type hint.
-				if prevType := v.types[arg.Idx]; !t.Type.Equivalent(prevType) {
+				if prevType := v.types[arg.Idx]; !tType.Equivalent(prevType) {
 					v.setErr(arg.Idx, pgerror.Newf(
 						pgcode.DatatypeMismatch,
 						"type annotation around %s conflicts with specified type %s",
@@ -2256,14 +2293,19 @@ func (v *placeholderAnnotationVisitor) VisitPre(expr Expr) (recurse bool, newExp
 
 	case *CastExpr:
 		if arg, ok := t.Expr.(*Placeholder); ok {
+			tType, err := ResolveType(t.Type, v.ctx.GetTypeResolver())
+			if err != nil {
+				v.setErr(arg.Idx, err)
+				return false, expr
+			}
 			switch v.state[arg.Idx] {
 			case noType:
-				v.types[arg.Idx] = t.Type
+				v.types[arg.Idx] = tType
 				v.state[arg.Idx] = typeFromCast
 
 			case typeFromCast:
 				// Verify that the casts are consistent.
-				if !t.Type.Equivalent(v.types[arg.Idx]) {
+				if !tType.Equivalent(v.types[arg.Idx]) {
 					v.state[arg.Idx] = conflictingCasts
 					v.types[arg.Idx] = nil
 				}
@@ -2327,10 +2369,13 @@ func (*placeholderAnnotationVisitor) VisitPost(expr Expr) Expr { return expr }
 // placeholders in the statement and is populated accordingly.
 //
 // TODO(nvanbenschoten): Can this visitor and map be preallocated (like normalizeVisitor)?
-func ProcessPlaceholderAnnotations(stmt Statement, typeHints PlaceholderTypes) error {
+func ProcessPlaceholderAnnotations(
+	semaCtx *SemaContext, stmt Statement, typeHints PlaceholderTypes,
+) error {
 	v := placeholderAnnotationVisitor{
 		types: typeHints,
 		state: make([]annotationState, len(typeHints)),
+		ctx:   semaCtx,
 	}
 
 	for placeholder := range typeHints {

--- a/pkg/sql/sem/tree/type_check_internal_test.go
+++ b/pkg/sql/sem/tree/type_check_internal_test.go
@@ -357,6 +357,7 @@ func TestProcessPlaceholderAnnotations(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	intType := types.Int
 	boolType := types.Bool
+	semaCtx := tree.MakeSemaContext()
 
 	testData := []struct {
 		initArgs  tree.PlaceholderTypes
@@ -519,7 +520,7 @@ func TestProcessPlaceholderAnnotations(t *testing.T) {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			args := d.initArgs
 			stmt := &tree.ValuesClause{Rows: []tree.Exprs{d.stmtExprs}}
-			if err := tree.ProcessPlaceholderAnnotations(stmt, args); err != nil {
+			if err := tree.ProcessPlaceholderAnnotations(&semaCtx, stmt, args); err != nil {
 				t.Errorf("%d: unexpected error returned from ProcessPlaceholderAnnotations: %v", i, err)
 			} else if !reflect.DeepEqual(args, d.desired) {
 				t.Errorf(
@@ -535,6 +536,7 @@ func TestProcessPlaceholderAnnotationsError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	intType := types.Int
 	floatType := types.Float
+	semaCtx := tree.MakeSemaContext()
 
 	testData := []struct {
 		initArgs  tree.PlaceholderTypes
@@ -604,7 +606,7 @@ func TestProcessPlaceholderAnnotationsError(t *testing.T) {
 	for i, d := range testData {
 		args := d.initArgs
 		stmt := &tree.ValuesClause{Rows: []tree.Exprs{d.stmtExprs}}
-		if err := tree.ProcessPlaceholderAnnotations(stmt, args); !testutils.IsError(err, d.expected) {
+		if err := tree.ProcessPlaceholderAnnotations(&semaCtx, stmt, args); !testutils.IsError(err, d.expected) {
 			t.Errorf("%d: expected '%s', got '%v'", i, d.expected, err)
 		}
 	}

--- a/pkg/sql/sem/tree/type_name.go
+++ b/pkg/sql/sem/tree/type_name.go
@@ -10,6 +10,13 @@
 
 package tree
 
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
+)
+
 // TypeName corresponds to the name of a type in a CREATE TYPE statement,
 // in an expression, or column type etc.
 //
@@ -60,4 +67,115 @@ func NewUnqualifiedTypeName(typ Name) *TypeName {
 	return &TypeName{objName{
 		ObjectName: typ,
 	}}
+}
+
+// TypeReferenceResolver is the interface that will provide the ability
+// to actually look up type metadata and transform references into
+// *types.T's. In practice, this will probably be implemented by
+// the planner, but for now it is a dummy interface.
+type TypeReferenceResolver interface {
+	// In the future this will take a context.
+	ResolveType(name *UnresolvedObjectName) (*types.T, error)
+}
+
+// ResolvableTypeReference represents a type that is possibly unknown
+// until type-checking/type name resolution is performed.
+type ResolvableTypeReference interface {
+	SQLString() string
+}
+
+var _ ResolvableTypeReference = &UnresolvedObjectName{}
+var _ ResolvableTypeReference = &ArrayTypeReference{}
+var _ ResolvableTypeReference = &types.T{}
+
+// ResolveType converts a ResolvableTypeReference into a *types.T.
+func ResolveType(ref ResolvableTypeReference, resolver TypeReferenceResolver) (*types.T, error) {
+	switch t := ref.(type) {
+	case *types.T:
+		return t, nil
+	case *ArrayTypeReference:
+		typ, err := ResolveType(t.ElementType, resolver)
+		if err != nil {
+			return nil, err
+		}
+		return types.MakeArray(typ), nil
+	case *UnresolvedObjectName:
+		if resolver == nil {
+			// If we don't have a resolver, we can't actually resolve this
+			// name into a type.
+			return nil, pgerror.Newf(pgcode.UndefinedObject, "type %q does not exist", t)
+		}
+		return resolver.ResolveType(t)
+	default:
+		return nil, errors.AssertionFailedf("unknown resolvable type reference type %s", t)
+	}
+}
+
+// GetStaticallyKnownType possibly promotes a ResolvableTypeReference into a
+// *types.T if the reference is a statically known type. It is only safe to
+// access the returned type if ok is true.
+func GetStaticallyKnownType(ref ResolvableTypeReference) (typ *types.T, ok bool) {
+	typ, ok = ref.(*types.T)
+	return typ, ok
+}
+
+// MustBeStaticallyKnownType does the same thing as GetStaticallyKnownType but panics
+// in the case that the reference is not statically known. This function
+// is intended to be used in tests or in cases where it is not possible
+// to have any unresolved type references.
+func MustBeStaticallyKnownType(ref ResolvableTypeReference) *types.T {
+	if typ, ok := ref.(*types.T); ok {
+		return typ
+	}
+	panic(errors.AssertionFailedf("type reference was not a statically known type"))
+}
+
+// ArrayTypeReference represents an array of possibly unknown type references.
+type ArrayTypeReference struct {
+	ElementType ResolvableTypeReference
+}
+
+// SQLString implements the ResolvableTypeReference interface.
+func (node *ArrayTypeReference) SQLString() string {
+	var ctx FmtCtx
+	if typ, ok := GetStaticallyKnownType(node.ElementType); ok {
+		ctx.WriteString(types.MakeArray(typ).SQLString())
+	} else {
+		ctx.WriteString(node.ElementType.SQLString())
+		ctx.WriteString("[]")
+	}
+	return ctx.String()
+}
+
+// SQLString implements the ResolvableTypeReference interface.
+func (name *UnresolvedObjectName) SQLString() string {
+	return name.String()
+}
+
+// IsReferenceSerialType returns whether the input reference is a known
+// serial type. It should only be used during parsing.
+func IsReferenceSerialType(ref ResolvableTypeReference) bool {
+	if typ, ok := GetStaticallyKnownType(ref); ok {
+		return types.IsSerialType(typ)
+	}
+	return false
+}
+
+// TestingMapTypeResolver is a fake type resolver for testing purposes.
+type TestingMapTypeResolver struct {
+	typeMap map[string]*types.T
+}
+
+// ResolveType implements the TypeReferenceResolver interface.
+func (dtr *TestingMapTypeResolver) ResolveType(name *UnresolvedObjectName) (*types.T, error) {
+	typ, ok := dtr.typeMap[name.String()]
+	if !ok {
+		return nil, errors.Newf("type %q does not exist", name)
+	}
+	return typ, nil
+}
+
+// MakeTestingMapTypeResolver creates a TestingMapTypeResolver from a map.
+func MakeTestingMapTypeResolver(typeMap map[string]*types.T) TypeReferenceResolver {
+	return &TestingMapTypeResolver{typeMap: typeMap}
 }

--- a/pkg/sql/serial.go
+++ b/pkg/sql/serial.go
@@ -88,8 +88,12 @@ func (p *planner) processSerialInColumnDef(
 	// Clear the IsSerial bit now that it's been remapped.
 	newSpec.IsSerial = false
 
+	defType, err := tree.ResolveType(d.Type, p.semaCtx.GetTypeResolver())
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
 	telemetry.Inc(sqltelemetry.SerialColumnNormalizationCounter(
-		d.Type.Name(), serialNormalizationMode.String()))
+		defType.Name(), serialNormalizationMode.String()))
 
 	if serialNormalizationMode == sessiondata.SerialUsesRowID {
 		// We're not constructing a sequence for this SERIAL column.

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -1326,7 +1326,7 @@ func randIndexTableDefFromCols(
 
 	indexElemList := make(tree.IndexElemList, 0, len(cols))
 	for i := range cols {
-		semType := cols[i].Type.Family()
+		semType := tree.MustBeStaticallyKnownType(cols[i].Type).Family()
 		if MustBeValueEncoded(semType) {
 			continue
 		}

--- a/pkg/sql/stats/json.go
+++ b/pkg/sql/stats/json.go
@@ -95,12 +95,18 @@ func (js *JSONStatistic) DecodeAndSetHistogram(datum tree.Datum) error {
 }
 
 // GetHistogram converts the json histogram into HistogramData.
-func (js *JSONStatistic) GetHistogram(evalCtx *tree.EvalContext) (*HistogramData, error) {
+func (js *JSONStatistic) GetHistogram(
+	semaCtx *tree.SemaContext, evalCtx *tree.EvalContext,
+) (*HistogramData, error) {
 	if len(js.HistogramBuckets) == 0 {
 		return nil, nil
 	}
 	h := &HistogramData{}
-	colType, err := parser.ParseType(js.HistogramColumnType)
+	colTypeRef, err := parser.ParseType(js.HistogramColumnType)
+	if err != nil {
+		return nil, err
+	}
+	colType, err := tree.ResolveType(colTypeRef, semaCtx.GetTypeResolver())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR extends our type system to unresolved/unknown types
before and after type checking. This work is part of the larger project
to add ENUM types to CockroachDB. The idea is to an indirection
to `*types.T` during parsing called a `ResolvableTypeReference`.
Wherever we are unsure whether a type is statically known or not
we have to use this type reference. The typechecking phase then
removes all of these unknown type references by attempting to
resolve each one before proceeding in typechecking. This intuiton
is enforced by ensuring that no values that ascribe to the
`TypedExpr` interface contain `ResolvableTypeReferences`.

A large amount of this commit is propogating this information
through to the rest of the SQL system, where most places expect
`*types.T` we have to teach it to now handle type references and
to resolve them.

Release note: None