### PR TITLE
cli/dump: dump all databases with a single command

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -240,6 +240,12 @@ Dumps the data as of the specified timestamp. Formats supported are the same
 as the timestamp type.`,
 	}
 
+	DumpAll = FlagInfo{
+		Name: "dump-all",
+		Description: `
+Dumps all databases, for each non-system database provides dump of all available tables.`,
+	}
+
 	Execute = FlagInfo{
 		Name:      "execute",
 		Shorthand: "e",

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -93,6 +93,7 @@ func initCLIDefaults() {
 
 	dumpCtx.dumpMode = dumpBoth
 	dumpCtx.asOf = ""
+	dumpCtx.dumpAll = false
 
 	debugCtx.startKey = storage.NilKey
 	debugCtx.endKey = storage.MVCCKeyMax
@@ -273,6 +274,9 @@ var dumpCtx struct {
 
 	// asOf determines the time stamp at which the dump should be taken.
 	asOf string
+
+	// dumpAll determines whenever we going to dump all databases
+	dumpAll bool
 }
 
 // authCtx captures the command-line parameters of the `auth-session`

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -584,6 +584,7 @@ func init() {
 
 	VarFlag(dumpCmd.Flags(), &dumpCtx.dumpMode, cliflags.DumpMode)
 	StringFlag(dumpCmd.Flags(), &dumpCtx.asOf, cliflags.DumpTime, dumpCtx.asOf)
+	BoolFlag(dumpCmd.Flags(), &dumpCtx.dumpAll, cliflags.DumpAll, dumpCtx.dumpAll)
 
 	// Commands that establish a SQL connection.
 	sqlCmds := []*cobra.Command{sqlShellCmd, dumpCmd, demoCmd}


### PR DESCRIPTION
Fixes #28615.

This commit enables to dump all databases with a single command. New
flag is added to the `dump` command, namely `--all` which scans for all
available non-system databases and dump theirs content.

Signed-off-by: Artem Barger <bartem@il.ibm.com>

Release note (feature): enable to dump all databases with a single
command