### PR TITLE
roachtest: bump PredecessorVersion(20.1) to 19.1.5

### DIFF
--- a/pkg/cmd/roachtest/autoupgrade.go
+++ b/pkg/cmd/roachtest/autoupgrade.go
@@ -26,6 +26,10 @@ import (
 //
 // NB: if you're interested in mixed-version testing, don't look at this test
 // but check out acceptance/version-upgrade.
+//
+// NOTE: DO NOT USE THIS TEST AS A TEMPLATE FOR MIXED-VERSION TESTING.
+// You want to look at versionupgrade.go, which has a test harness you
+// can use.
 func registerAutoUpgrade(r *testRegistry) {
 	runAutoUpgrade := func(ctx context.Context, t *test, c *cluster, oldVersion string) {
 		nodes := c.spec.NodeCount

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1136,8 +1136,13 @@ func PredecessorVersion(buildVersion version.Version) (string, error) {
 
 	buildVersionMajorMinor := fmt.Sprintf("%d.%d", buildVersion.Major(), buildVersion.Minor())
 
+	// NB: you can update the values in this map to point at newer patch
+	// releases. You will need to run acceptance/version-upgrade with the
+	// checkpoint option enabled to create the missing store directory fixture
+	// (see runVersionUpgrade). The same is true for adding a new key to this
+	// map.
 	verMap := map[string]string{
-		"20.1": "19.2.1",
+		"20.1": "19.2.5",
 		"19.2": "19.1.5",
 		"19.1": "2.1.9",
 		"2.2":  "2.1.9",

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -238,6 +238,8 @@ func registerTPCC(r *testRegistry) {
 		},
 	})
 	mixedHeadroomSpec := makeClusterSpec(5, cpu(16))
+
+	// TODO(tbg): rewrite and extend this using the harness in versionupgrade.go.
 	r.Add(testSpec{
 		// mixed-headroom is similar to w=headroom, but with an additional node
 		// and on a mixed version cluster. It simulates a real production

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -22,6 +22,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+// TODO(tbg): remove this test. Use the harness in versionupgrade.go
+// to make a much better one, much more easily.
 func registerVersion(r *testRegistry) {
 	runVersion := func(ctx context.Context, t *test, c *cluster, version string) {
 		nodes := c.spec.NodeCount - 1

--- a/pkg/cmd/roachtest/versionupgrade.go
+++ b/pkg/cmd/roachtest/versionupgrade.go
@@ -79,7 +79,7 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster, predecessorVers
 	c.encryptDefault = false
 
 	// Set the bool within to true to create a new fixture for this test. This
-	// is necessary after every release. For example, when day `master` becomes
+	// is necessary after every release. For example, the day `master` becomes
 	// the 20.2 release, this test will fail because it is missing a fixture for
 	// 20.1; run the test (on 20.1) with the bool flipped to create the fixture.
 	// Check it in (instructions are on the 'checkpointer' struct) and off we


### PR DESCRIPTION
See #47362.

Release note: None