### PR TITLE
release-20.1: colexec: set min size of partition to join using in-mem hash joiner

### DIFF
--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -540,8 +540,8 @@ RESTORE tpch.* FROM 'gs://cockroach-fixtures/workload/tpch/scalefactor=1/backup'
 		if runConfig.stressDiskSpilling {
 			// In order to stress the disk spilling of the vectorized
 			// engine, we will set workmem limit to a random value in range
-			// [100KiB, 1000KiB).
-			workmemInKiB := 100 + rng.Intn(900)
+			// [16KiB, 256KiB).
+			workmemInKiB := 16 + rng.Intn(240)
 			workmem := fmt.Sprintf("%dKiB", workmemInKiB)
 			t.Status(fmt.Sprintf("setting workmem='%s'", workmem))
 			if _, err := conn.Exec(fmt.Sprintf("SET CLUSTER SETTING sql.distsql.temp_storage.workmem='%s'", workmem)); err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #47083.

/cc @cockroachdb/release

Fixes: #46810.

---

We are computing `maxRightPartitionSizeToJoin` variable of the external
hash joiner by subtracting preallocated buffers of disk queues from the
provided memory limit. However, when the memory limit is very low, this
value can end up being negative. As a result, we will be recursively
repartitioning both inputs until each partition contains exactly one
tuple, and only then we transition to sort + merge phase on those single
tuple partitions. This could create millions of temporary files which
could crash the machine that CockroachDB is running on. Now this is
fixed by requiring a minimal value for this variable (set to `64KiB`).

This commit additionally adjusts `tpchvec` roachtest to use lower range
of values for random `workmem` settings to allow spotting such
regressions sooner.

Release note: None
