### PR TITLE
sql: fix renaming of columns involved in hash sharded indexes

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -729,7 +729,9 @@ func (n *alterTableNode) startExec(params runParams) error {
 			}
 
 		case *tree.AlterTableRenameColumn:
-			descChanged, err := params.p.renameColumn(params.ctx, n.tableDesc, &t.Column, &t.NewName)
+			const allowRenameOfShardColumn = false
+			descChanged, err := params.p.renameColumn(params.ctx, n.tableDesc,
+				&t.Column, &t.NewName, allowRenameOfShardColumn)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1985,15 +1985,12 @@ func makeShardColumnDesc(colNames []string, buckets int) (*sqlbase.ColumnDescrip
 //    mod(fnv32(colNames[0]::STRING)+fnv32(colNames[1])+...,buckets)
 //
 func makeHashShardComputeExpr(colNames []string, buckets int) *string {
-	unresolvedName := func(name string) *tree.UnresolvedName {
-		return &tree.UnresolvedName{
-			NumParts: 1,
-			Parts:    tree.NameParts{name},
-		}
-	}
 	unresolvedFunc := func(funcName string) tree.ResolvableFunctionReference {
 		return tree.ResolvableFunctionReference{
-			FunctionReference: unresolvedName(funcName),
+			FunctionReference: &tree.UnresolvedName{
+				NumParts: 1,
+				Parts:    tree.NameParts{funcName},
+			},
 		}
 	}
 	hashedColumnExpr := func(colName string) tree.Expr {
@@ -2012,7 +2009,7 @@ func makeHashShardComputeExpr(colNames []string, buckets int) *string {
 					Exprs: tree.Exprs{
 						&tree.CastExpr{
 							Type: types.String,
-							Expr: unresolvedName(colName),
+							Expr: &tree.ColumnItem{ColumnName: tree.Name(colName)},
 						},
 						tree.NewDString(""),
 					},
@@ -2108,8 +2105,10 @@ func makeShardCheckConstraintDef(
 	return &tree.CheckConstraintTableDef{
 		Expr: &tree.ComparisonExpr{
 			Operator: tree.In,
-			Left:     &tree.UnresolvedName{NumParts: 1, Parts: tree.NameParts{shardCol.Name}},
-			Right:    values,
+			Left: &tree.ColumnItem{
+				ColumnName: tree.Name(shardCol.Name),
+			},
+			Right: values,
 		},
 		Hidden: true,
 	}, nil

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -483,3 +483,86 @@ INSERT INTO sharded_index_with_nulls VALUES (1, NULL);
 
 statement ok
 DROP TABLE sharded_index_with_nulls;
+
+# Test that renaming a column which is a member of a hash sharded index works.
+subtest rename_column
+
+statement ok
+CREATE TABLE rename_column (
+    c0 INT,
+    c1 INT,
+    c2 INT,
+    PRIMARY KEY (c0, c1) USING HASH WITH BUCKET_COUNT = 8,
+    INDEX (c2) USING HASH WITH BUCKET_COUNT = 8,
+    FAMILY "primary" (c0, c1, c2)
+);
+
+statement ok
+INSERT INTO rename_column VALUES (1, 2, 3);
+
+query TT
+SHOW CREATE TABLE rename_column
+----
+rename_column  CREATE TABLE rename_column (
+               c0 INT8 NOT NULL,
+               c1 INT8 NOT NULL,
+               c2 INT8 NULL,
+               CONSTRAINT "primary" PRIMARY KEY (c0 ASC, c1 ASC) USING HASH WITH BUCKET_COUNT = 8,
+               INDEX rename_column_crdb_internal_c2_shard_8_c2_idx (c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
+               FAMILY "primary" (c0, c1, c2, crdb_internal_c0_c1_shard_8, crdb_internal_c2_shard_8)
+)
+
+statement ok
+ALTER TABLE rename_column RENAME c2 TO c3;
+
+# Test mucking with primary key columns.
+statement ok
+ALTER TABLE rename_column RENAME c1 TO c2;
+
+statement ok
+ALTER TABLE rename_column RENAME c0 TO c1;
+
+query TT
+SHOW CREATE TABLE rename_column
+----
+rename_column  CREATE TABLE rename_column (
+               c1 INT8 NOT NULL,
+               c2 INT8 NOT NULL,
+               c3 INT8 NULL,
+               CONSTRAINT "primary" PRIMARY KEY (c1 ASC, c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
+               INDEX rename_column_crdb_internal_c2_shard_8_c2_idx (c3 ASC) USING HASH WITH BUCKET_COUNT = 8,
+               FAMILY "primary" (c1, c2, c3, crdb_internal_c1_c2_shard_8, crdb_internal_c3_shard_8)
+)
+
+query III
+SELECT c3, c2, c1 FROM rename_column
+----
+3 2 1
+
+# Test both at the same time.
+statement ok
+ALTER TABLE rename_column RENAME c1 TO c0, RENAME c2 TO c1, RENAME c3 TO c2;
+
+query TT
+SHOW CREATE TABLE rename_column
+----
+rename_column  CREATE TABLE rename_column (
+               c0 INT8 NOT NULL,
+               c1 INT8 NOT NULL,
+               c2 INT8 NULL,
+               CONSTRAINT "primary" PRIMARY KEY (c0 ASC, c1 ASC) USING HASH WITH BUCKET_COUNT = 8,
+               INDEX rename_column_crdb_internal_c2_shard_8_c2_idx (c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
+               FAMILY "primary" (c0, c1, c2, crdb_internal_c0_c1_shard_8, crdb_internal_c2_shard_8)
+)
+
+query III
+SELECT c2, c1, c0 FROM rename_column
+----
+3 2 1
+
+# Ensure that renaming a shard column fails.
+statement error cannot rename shard column
+ALTER TABLE rename_column RENAME crdb_internal_c2_shard_8 TO foo;
+
+statement ok
+DROP TABLE rename_column;

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2032,6 +2032,10 @@ func (desc *TableDescriptor) validateTableIndexes(columnNames map[string]ColumnI
 			if err := desc.ensureShardedIndexNotComputed(index); err != nil {
 				return err
 			}
+			if _, exists := columnNames[index.Sharded.Name]; !exists {
+				return fmt.Errorf("index %q refers to non-existent shard column %q",
+					index.Name, index.Sharded.Name)
+			}
 		}
 	}
 
@@ -3965,6 +3969,17 @@ func (desc *ImmutableTableDescriptor) DeleteOnlyIndexes() []IndexDescriptor {
 // TableDesc implements the ObjectDescriptor interface.
 func (desc *MutableTableDescriptor) TableDesc() *TableDescriptor {
 	return &desc.TableDescriptor
+}
+
+// IsShardColumn returns true if col corresponds to a non-dropped hash sharded
+// index. This method assumes that col is currently a member of desc.
+func (desc *MutableTableDescriptor) IsShardColumn(col *ColumnDescriptor) bool {
+	for _, idx := range desc.AllNonDropIndexes() {
+		if idx.Sharded.IsSharded && idx.Sharded.Name == col.Name {
+			return true
+		}
+	}
+	return false
 }
 
 // TableDesc implements the ObjectDescriptor interface.

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -596,6 +596,47 @@ func TestValidateTableDesc(t *testing.T) {
 				NextFamilyID: 1,
 				NextIndexID:  3,
 			}},
+		{`index "foo_crdb_internal_bar_shard_5_bar_idx" refers to non-existent shard column "does not exist"`,
+			TableDescriptor{
+				ID:            2,
+				ParentID:      1,
+				Name:          "foo",
+				FormatVersion: FamilyFormatVersion,
+				Columns: []ColumnDescriptor{
+					{ID: 1, Name: "bar"},
+					{ID: 2, Name: "crdb_internal_bar_shard_5"},
+				},
+				Families: []ColumnFamilyDescriptor{
+					{ID: 0, Name: "primary",
+						ColumnIDs:   []ColumnID{1, 2},
+						ColumnNames: []string{"bar", "crdb_internal_bar_shard_5"},
+					},
+				},
+				PrimaryIndex: IndexDescriptor{
+					ID: 1, Name: "primary",
+					Unique:           true,
+					ColumnIDs:        []ColumnID{1},
+					ColumnNames:      []string{"bar"},
+					ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
+					StoreColumnNames: []string{"crdb_internal_bar_shard_5"},
+					StoreColumnIDs:   []ColumnID{2},
+				},
+				Indexes: []IndexDescriptor{
+					{ID: 2, Name: "foo_crdb_internal_bar_shard_5_bar_idx",
+						ColumnIDs:        []ColumnID{2, 1},
+						ColumnNames:      []string{"crdb_internal_bar_shard_5", "bar"},
+						ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC, IndexDescriptor_ASC},
+						Sharded: ShardedDescriptor{
+							IsSharded:    true,
+							Name:         "does not exist",
+							ShardBuckets: 5,
+						},
+					},
+				},
+				NextColumnID: 3,
+				NextFamilyID: 1,
+				NextIndexID:  3,
+			}},
 	}
 	for i, d := range testData {
 		if err := d.desc.ValidateTable(); err == nil {


### PR DESCRIPTION
Prior to this commit, renames in hash sharded indexes were busted in a few
different ways.

1) The column references were using `UnresolvedName` when it should have been
   using `*tree.ColumnItem`. This was going on both in the check constaint and
   in the computed expr.

2) The `ShardedDescriptor` was not being updated to refer to the new name.

Another rough edge in all of this is that we're in deep trouble if we can't
tie the shard column back to the index[es] which are responsible for its
existence. Today this relationship is annoyingly tenuous. In an ideal world
we'd populate the ColumnDescriptor with information to mark it as a sharded
column and, ideally, the sharded descriptor. Furthermore, it's something of a
bummer that we have multiple of the same `ShardedDescriptor`s which each imply
a column but are denormalized into the `IndexDescriptor`.

Given we are where we are however, we really want to keep the name of the
shard column in sync with its source columns. This commit makes sure that
happens when member columns are renamed, the shard column is accordingly
renamed. The commit also disallows the renaming of a shard column as that
would upset the careful name synchronization.

It's worth noting that this is a little bit weird as other auto-generated
names don't change when the members change. For example an index created
with a name in the `CREATE TABLE` statement of a `FAMILY` clause.

Fixes #47087.

Release note (bug fix): In earlier betas, columns which were members of
hash sharded indexes could not be renamed. Indexes created in prior
releases will need to be dropped and recreated to resolve this limitation.