### PR TITLE
release-20.1: sql, tracing: save traces in Jaeger format

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1040,6 +1040,14 @@
   version = "v3.6.2"
 
 [[projects]]
+  digest = "1:ddcd5a47f37b0a26a3c9eb898ee7bd8109b944d79877e0001f3401f1c61ec0ac"
+  name = "github.com/jaegertracing/jaeger"
+  packages = ["model/json"]
+  pruneopts = "UT"
+  revision = "3b34ac6bcdeb22e09a81c6244bfeed20503a383b"
+  version = "v1.17.1"
+
+[[projects]]
   digest = "1:dcb3e2ad17349c0cc89ffc16692d05195e6a67b4924fe81760fba9a307a7271d"
   name = "github.com/jmank88/nuts"
   packages = ["."]
@@ -2084,6 +2092,7 @@
     "github.com/jackc/pgx",
     "github.com/jackc/pgx/pgproto3",
     "github.com/jackc/pgx/pgtype",
+    "github.com/jaegertracing/jaeger/model/json",
     "github.com/kevinburke/go-bindata/go-bindata",
     "github.com/kisielk/errcheck",
     "github.com/kisielk/gotool",

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1005,6 +1005,8 @@ func (n *Node) setupSpanForIncomingRPC(
 				opName, n.storeCfg.AmbientCtx.LogTags(), tracing.NonRecordableSpan,
 			)
 			ctx = opentracing.ContextWithSpan(ctx, newSpan)
+		} else {
+			grpcSpan.SetTag("node", n.Descriptor.NodeID)
 		}
 	}
 

--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -39,7 +39,7 @@ func TestExplainAnalyzeDebug(t *testing.T) {
 	r := sqlutils.MakeSQLRunner(godb)
 	r.Exec(t, "CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT UNIQUE)")
 
-	base := "statement.txt trace.json trace.txt env.sql"
+	base := "statement.txt trace.json trace.txt trace-jaeger.json env.sql"
 	plans := "schema.sql opt.txt opt-v.txt opt-vv.txt plan.txt"
 
 	t.Run("basic", func(t *testing.T) {

--- a/pkg/util/tracing/helpers_test.go
+++ b/pkg/util/tracing/helpers_test.go
@@ -87,9 +87,7 @@ type mockSpan struct {
 
 var _ opentracing.Span = &mockSpan{}
 
-func (m *mockSpan) Finish() {
-	panic("unimplemented")
-}
+func (m *mockSpan) Finish() {}
 
 func (m *mockSpan) FinishWithOptions(opts opentracing.FinishOptions) {
 	panic("unimplemented")

--- a/pkg/util/tracing/helpers_test.go
+++ b/pkg/util/tracing/helpers_test.go
@@ -1,0 +1,141 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tracing
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+)
+
+type mockTracer struct {
+	spans []*mockSpan
+}
+
+var _ opentracing.Tracer = &mockTracer{}
+
+func (m *mockTracer) clear() {
+	m.spans = nil
+}
+
+// expectSingleStartWithTags checks that there's been a single call to
+// StartSpan() since the last clear(), and that the call specified the given tag
+// names (amongst possibly more tags).
+func (m *mockTracer) expectSingleSpanWithTags(tagNames ...string) error {
+	if len(m.spans) != 1 {
+		return errors.Newf("expected 1 StartSpan() call, had: %d", len(m.spans))
+	}
+	s := m.spans[0]
+	for _, t := range tagNames {
+		if _, ok := s.tags[t]; !ok {
+			return errors.Newf("missing tag: %s", t)
+		}
+	}
+	return nil
+}
+
+func (m *mockTracer) StartSpan(
+	operationName string, opts ...opentracing.StartSpanOption,
+) opentracing.Span {
+	var opt opentracing.StartSpanOptions
+	for _, o := range opts {
+		o.Apply(&opt)
+	}
+	s := &mockSpan{
+		tags: make(opentracing.Tags),
+	}
+	if opt.Tags != nil {
+		s.tags = opt.Tags
+	}
+	m.spans = append(m.spans, s)
+	return s
+}
+
+func (m *mockTracer) Inject(
+	sm opentracing.SpanContext, format interface{}, carrier interface{},
+) error {
+	panic("unimplemented")
+}
+
+func (m *mockTracer) Extract(
+	format interface{}, carrier interface{},
+) (opentracing.SpanContext, error) {
+	panic("unimplemented")
+}
+
+type mockTracerManager struct{}
+
+var _ shadowTracerManager = &mockTracerManager{}
+
+func (m *mockTracerManager) Name() string {
+	return "mock"
+}
+
+func (m *mockTracerManager) Close(tr opentracing.Tracer) {}
+
+type mockSpan struct {
+	tags opentracing.Tags
+}
+
+var _ opentracing.Span = &mockSpan{}
+
+func (m *mockSpan) Finish() {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) FinishWithOptions(opts opentracing.FinishOptions) {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) Context() opentracing.SpanContext {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) SetOperationName(operationName string) opentracing.Span {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) SetTag(key string, value interface{}) opentracing.Span {
+	m.tags[key] = value
+	return m
+}
+
+func (m *mockSpan) LogFields(fields ...log.Field) {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) LogKV(alternatingKeyValues ...interface{}) {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) SetBaggageItem(restrictedKey, value string) opentracing.Span {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) BaggageItem(restrictedKey string) string {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) Tracer() opentracing.Tracer {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) LogEvent(event string) {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) LogEventWithPayload(event string, payload interface{}) {
+	panic("unimplemented")
+}
+
+func (m *mockSpan) Log(data opentracing.LogData) {
+	panic("unimplemented")
+}

--- a/pkg/util/tracing/recorded_span.pb.go
+++ b/pkg/util/tracing/recorded_span.pb.go
@@ -39,7 +39,7 @@ func (m *LogRecord) Reset()         { *m = LogRecord{} }
 func (m *LogRecord) String() string { return proto.CompactTextString(m) }
 func (*LogRecord) ProtoMessage()    {}
 func (*LogRecord) Descriptor() ([]byte, []int) {
-	return fileDescriptor_recorded_span_2278c97c583fd31c, []int{0}
+	return fileDescriptor_recorded_span_ec83bd4619f89f60, []int{0}
 }
 func (m *LogRecord) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -73,7 +73,7 @@ func (m *LogRecord_Field) Reset()         { *m = LogRecord_Field{} }
 func (m *LogRecord_Field) String() string { return proto.CompactTextString(m) }
 func (*LogRecord_Field) ProtoMessage()    {}
 func (*LogRecord_Field) Descriptor() ([]byte, []int) {
-	return fileDescriptor_recorded_span_2278c97c583fd31c, []int{0, 0}
+	return fileDescriptor_recorded_span_ec83bd4619f89f60, []int{0, 0}
 }
 func (m *LogRecord_Field) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -117,7 +117,11 @@ type RecordedSpan struct {
 	Tags map[string]string `protobuf:"bytes,6,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// Time when the span was started.
 	StartTime time.Time `protobuf:"bytes,7,opt,name=start_time,json=startTime,proto3,stdtime" json:"start_time"`
-	// Duration in nanoseconds; 0 if the span is not finished.
+	// Duration is the span's duration, measured from start to Finish().
+	//
+	// A spans whose recording is collected before it's finished will have the
+	// duration set as the time of collection - start_time. Such a span will have
+	// an "unfinished" tag.
 	Duration time.Duration `protobuf:"bytes,8,opt,name=duration,proto3,stdduration" json:"duration"`
 	// Events logged in the span.
 	Logs []LogRecord `protobuf:"bytes,9,rep,name=logs,proto3" json:"logs"`
@@ -128,7 +132,7 @@ type RecordedSpan struct {
 func (m *RecordedSpan) Reset()      { *m = RecordedSpan{} }
 func (*RecordedSpan) ProtoMessage() {}
 func (*RecordedSpan) Descriptor() ([]byte, []int) {
-	return fileDescriptor_recorded_span_2278c97c583fd31c, []int{1}
+	return fileDescriptor_recorded_span_ec83bd4619f89f60, []int{1}
 }
 func (m *RecordedSpan) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -171,7 +175,7 @@ func (m *NormalizedSpan) Reset()         { *m = NormalizedSpan{} }
 func (m *NormalizedSpan) String() string { return proto.CompactTextString(m) }
 func (*NormalizedSpan) ProtoMessage()    {}
 func (*NormalizedSpan) Descriptor() ([]byte, []int) {
-	return fileDescriptor_recorded_span_2278c97c583fd31c, []int{2}
+	return fileDescriptor_recorded_span_ec83bd4619f89f60, []int{2}
 }
 func (m *NormalizedSpan) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1765,10 +1769,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("util/tracing/recorded_span.proto", fileDescriptor_recorded_span_2278c97c583fd31c)
+	proto.RegisterFile("util/tracing/recorded_span.proto", fileDescriptor_recorded_span_ec83bd4619f89f60)
 }
 
-var fileDescriptor_recorded_span_2278c97c583fd31c = []byte{
+var fileDescriptor_recorded_span_ec83bd4619f89f60 = []byte{
 	// 623 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x53, 0xcd, 0x6e, 0xd3, 0x4c,
 	0x14, 0x8d, 0x13, 0xe7, 0xef, 0x36, 0xaa, 0xaa, 0x51, 0xf5, 0xc9, 0xb5, 0x3e, 0xd9, 0xa5, 0x48,

--- a/pkg/util/tracing/recorded_span.proto
+++ b/pkg/util/tracing/recorded_span.proto
@@ -52,7 +52,11 @@ message RecordedSpan {
   // Time when the span was started.
   google.protobuf.Timestamp start_time = 7 [(gogoproto.nullable) = false,
                                             (gogoproto.stdtime) = true];
-  // Duration in nanoseconds; 0 if the span is not finished.
+  // Duration is the span's duration, measured from start to Finish().
+  //
+  // A spans whose recording is collected before it's finished will have the
+  // duration set as the time of collection - start_time. Such a span will have
+  // an "unfinished" tag.
   google.protobuf.Duration duration = 8 [(gogoproto.nullable) = false,
                                          (gogoproto.stdduration) = true];
 

--- a/pkg/util/tracing/shadow.go
+++ b/pkg/util/tracing/shadow.go
@@ -76,7 +76,7 @@ func (st *shadowTracer) Close() {
 // The Shadow span will have a parent if parentShadowCtx is not nil.
 // parentType is ignored if parentShadowCtx is nil.
 //
-// The tags from s are copied to the Shadow span.
+// The tags (including logTags) from s are copied to the Shadow span.
 func linkShadowSpan(
 	s *span,
 	shadowTr *shadowTracer,
@@ -87,14 +87,8 @@ func linkShadowSpan(
 	var opts []opentracing.StartSpanOption
 	// Replicate the options, using the lightstep context in the reference.
 	opts = append(opts, opentracing.StartTime(s.startTime))
-	if s.startTags != nil {
-		startTags := make(opentracing.Tags)
-		tags := s.startTags.Get()
-		for i := range tags {
-			tag := &tags[i]
-			startTags[tag.Key()] = tag.Value()
-		}
-		opts = append(opts, startTags)
+	if s.logTags != nil {
+		opts = append(opts, LogTags(s.logTags))
 	}
 	if s.mu.tags != nil {
 		opts = append(opts, s.mu.tags)

--- a/pkg/util/tracing/tags.go
+++ b/pkg/util/tracing/tags.go
@@ -23,6 +23,10 @@ type logTagsOption logtags.Buffer
 var _ opentracing.StartSpanOption = &logTagsOption{}
 
 // Apply is part of the opentracing.StartSpanOption interface.
+//
+// Note that our tracer does not call Apply() for this options. Instead, it
+// recognizes it as a special case and treats it more efficiently, avoiding
+// allocations for each tag. The Apply() is still used by shadow tracers.
 func (lt *logTagsOption) Apply(o *opentracing.StartSpanOptions) {
 	if lt == nil {
 		return
@@ -40,7 +44,8 @@ func (lt *logTagsOption) Apply(o *opentracing.StartSpanOptions) {
 }
 
 // LogTags returns a StartSpanOption that sets the span tags to the given log
-// tags.
+// tags. When applied, the returned option will apply any logtag name->span tag
+// name remapping that has been registered via RegisterTagRemapping.
 func LogTags(tags *logtags.Buffer) opentracing.StartSpanOption {
 	return (*logTagsOption)(tags)
 }

--- a/pkg/util/tracing/tags.go
+++ b/pkg/util/tracing/tags.go
@@ -24,9 +24,12 @@ var _ opentracing.StartSpanOption = &logTagsOption{}
 
 // Apply is part of the opentracing.StartSpanOption interface.
 //
+// The tags in the buffer go through the log tag -> span tag remapping (see
+// tagName()).
+//
 // Note that our tracer does not call Apply() for this options. Instead, it
 // recognizes it as a special case and treats it more efficiently, avoiding
-// allocations for each tag. The Apply() is still used by shadow tracers.
+// allocations for each tag. Apply() is still used by shadow tracers.
 func (lt *logTagsOption) Apply(o *opentracing.StartSpanOptions) {
 	if lt == nil {
 		return

--- a/pkg/util/tracing/tags_test.go
+++ b/pkg/util/tracing/tags_test.go
@@ -26,12 +26,11 @@ func TestLogTags(t *testing.T) {
 	l = l.Add("tag2", "val2")
 	sp1 := tr.StartSpan("foo", Recordable, LogTags(l))
 	StartRecording(sp1, SingleNodeRecording)
-
+	sp1.Finish()
 	require.NoError(t, TestingCheckRecordedSpans(GetRecording(sp1), `
 		span foo:
 		  tags: tag1=val1 tag2=val2
 	`))
-
 	require.NoError(t, shadowTracer.expectSingleSpanWithTags("tag1", "tag2"))
 	shadowTracer.clear()
 
@@ -40,7 +39,7 @@ func TestLogTags(t *testing.T) {
 
 	sp2 := tr.StartSpan("bar", Recordable, LogTags(l))
 	StartRecording(sp2, SingleNodeRecording)
-
+	sp2.Finish()
 	require.NoError(t, TestingCheckRecordedSpans(GetRecording(sp2), `
 		span bar:
 			tags: one=val1 two=val2
@@ -50,6 +49,7 @@ func TestLogTags(t *testing.T) {
 
 	sp3 := tr.StartRootSpan("baz", l, RecordableSpan)
 	StartRecording(sp3, SingleNodeRecording)
+	sp3.Finish()
 	require.NoError(t, TestingCheckRecordedSpans(GetRecording(sp3), `
 		span baz:
 			tags: one=val1 two=val2

--- a/pkg/util/tracing/tracer_span.go
+++ b/pkg/util/tracing/tracer_span.go
@@ -12,9 +12,11 @@ package tracing
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -24,6 +26,7 @@ import (
 	"github.com/cockroachdb/logtags"
 	proto "github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
+	jaegerjson "github.com/jaegertracing/jaeger/model/json"
 	opentracing "github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
@@ -409,6 +412,125 @@ func (r Recording) visitSpan(sp RecordedSpan, depth int) []traceLogData {
 	}
 
 	return mergedLogs
+}
+
+// ToJaegerJSON returns the trace as a JSON that can be imported into Jaeger for
+// visualization.
+//
+// The format is described here: https://github.com/jaegertracing/jaeger-ui/issues/381#issuecomment-494150826
+//
+// The statement is passed in so it can be included in the trace.
+func (r Recording) ToJaegerJSON(stmt string) (string, error) {
+	if len(r) == 0 {
+		return "", nil
+	}
+
+	cpy := make(Recording, len(r))
+	copy(cpy, r)
+	r = cpy
+	tagsCopy := make(map[string]string)
+	for k, v := range r[0].Tags {
+		tagsCopy[k] = v
+	}
+	tagsCopy["statement"] = stmt
+	r[0].Tags = tagsCopy
+
+	toJaegerSpanID := func(spanID uint64) jaegerjson.SpanID {
+		return jaegerjson.SpanID(strconv.FormatUint(spanID, 10))
+	}
+
+	// Each span in Jaeger belongs to a "process" that generated it. Spans
+	// belonging to different colors are colored differently in Jaeger. We're
+	// going to map our different nodes to different processes.
+	processes := make(map[jaegerjson.ProcessID]jaegerjson.Process)
+	// getProcessID figures out what "process" a span belongs to. It looks for an
+	// "node: <node id>" tag. The processes map is populated with an entry for every
+	// node present in the trace.
+	getProcessID := func(sp RecordedSpan) jaegerjson.ProcessID {
+		node := "unknown node"
+		for k, v := range sp.Tags {
+			if k == "node" {
+				node = fmt.Sprintf("node %s", v)
+				break
+			}
+		}
+		pid := jaegerjson.ProcessID(node)
+		if _, ok := processes[pid]; !ok {
+			processes[pid] = jaegerjson.Process{
+				ServiceName: node,
+				Tags:        nil,
+			}
+		}
+		return pid
+	}
+
+	var t jaegerjson.Trace
+	t.TraceID = jaegerjson.TraceID(strconv.FormatUint(r[0].TraceID, 10))
+	t.Processes = processes
+
+	for _, sp := range r {
+		var s jaegerjson.Span
+
+		s.TraceID = t.TraceID
+		s.Duration = uint64(sp.Duration.Microseconds())
+		s.StartTime = uint64(sp.StartTime.UnixNano() / 1000)
+		s.SpanID = toJaegerSpanID(sp.SpanID)
+		s.OperationName = sp.Operation
+		s.ProcessID = getProcessID(sp)
+
+		if sp.ParentSpanID != 0 {
+			s.References = []jaegerjson.Reference{{
+				RefType: jaegerjson.ChildOf,
+				TraceID: s.TraceID,
+				SpanID:  toJaegerSpanID(sp.ParentSpanID),
+			}}
+		}
+
+		for k, v := range sp.Tags {
+			s.Tags = append(s.Tags, jaegerjson.KeyValue{
+				Key:   k,
+				Value: v,
+				Type:  "STRING",
+			})
+		}
+		for _, l := range sp.Logs {
+			jl := jaegerjson.Log{Timestamp: uint64(l.Time.UnixNano() / 1000)}
+			for _, field := range l.Fields {
+				jl.Fields = append(jl.Fields, jaegerjson.KeyValue{
+					Key:   field.Key,
+					Value: field.Value,
+					Type:  "STRING",
+				})
+			}
+			s.Logs = append(s.Logs, jl)
+		}
+		t.Spans = append(t.Spans, s)
+	}
+
+	data := TraceCollection{
+		Data: []jaegerjson.Trace{t},
+		// Add a comment that will show-up at the top of the JSON file, is someone opens the file.
+		// NOTE: This comment is scarce on newlines because they appear as \n in the
+		// generated file doing more harm than good.
+		Comment: fmt.Sprintf(`This is a trace for SQL statement: %s
+This trace can be imported into Jaeger for visualization. From the Jaeger Search screen, select JSON File.
+Jaeger can be started using docker with: docker run -d --name jaeger -p 16686:16686 jaegertracing/all-in-one:1.17
+The UI can then be accessed at http://localhost:16686/search`,
+			stmt),
+	}
+	json, err := json.MarshalIndent(data, "" /* prefix */, "\t" /* indent */)
+	if err != nil {
+		return "", err
+	}
+	return string(json), nil
+}
+
+// TraceCollection is the format accepted by the Jaegar upload feature, as per
+// https://github.com/jaegertracing/jaeger-ui/issues/381#issuecomment-494150826
+type TraceCollection struct {
+	// Comment is a dummy field we use to put instructions on how to load the trace.
+	Comment string             `json:"_comment"`
+	Data    []jaegerjson.Trace `json:"data"`
 }
 
 // ImportRemoteSpans adds RecordedSpan data to the recording of the given span;

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -60,8 +60,10 @@ func TestTracerRecording(t *testing.T) {
 
 	if err := TestingCheckRecordedSpans(GetRecording(s1), `
 		span a:
+			tags: unfinished=
 			x: 2
 		span b:
+			tags: unfinished=
 			x: 3
 	`); err != nil {
 		t.Fatal(err)
@@ -69,8 +71,10 @@ func TestTracerRecording(t *testing.T) {
 
 	if err := TestingCheckRecordedSpans(GetRecording(s2), `
 		span a:
+			tags: unfinished=
 			x: 2
 		span b:
+			tags: unfinished=
 			x: 3
 	`); err != nil {
 		t.Fatal(err)
@@ -84,11 +88,12 @@ func TestTracerRecording(t *testing.T) {
 
 	if err := TestingCheckRecordedSpans(GetRecording(s1), `
 		span a:
+			tags: unfinished=
 			x: 2
 		span b:
 			x: 3
 		span c:
-			tags: tag=val
+			tags: tag=val unfinished=
 			x: 4
 	`); err != nil {
 		t.Fatal(err)
@@ -96,6 +101,7 @@ func TestTracerRecording(t *testing.T) {
 	s3.Finish()
 	if err := TestingCheckRecordedSpans(GetRecording(s1), `
 		span a:
+      tags: unfinished=
 			x: 2
 		span b:
 			x: 3
@@ -115,6 +121,7 @@ func TestTracerRecording(t *testing.T) {
 	s3.LogKV("x", 5)
 	if err := TestingCheckRecordedSpans(GetRecording(s3), `
 		span a:
+			tags: unfinished=
 			x: 2
 		span b:
 			x: 3
@@ -230,6 +237,7 @@ func TestTracerInjectExtract(t *testing.T) {
 		t.Errorf("TraceID doesn't match: parent %d child %d", trace1, trace2)
 	}
 	s2.LogKV("x", 1)
+	s2.Finish()
 
 	// Verify that recording was started automatically.
 	rec := GetRecording(s2)
@@ -243,7 +251,7 @@ func TestTracerInjectExtract(t *testing.T) {
 
 	if err := TestingCheckRecordedSpans(GetRecording(s1), `
 		span a:
-			tags: sb=1
+			tags: sb=1 unfinished=
 	`); err != nil {
 		t.Fatal(err)
 	}
@@ -251,6 +259,7 @@ func TestTracerInjectExtract(t *testing.T) {
 	if err := ImportRemoteSpans(s1, rec); err != nil {
 		t.Fatal(err)
 	}
+	s1.Finish()
 
 	if err := TestingCheckRecordedSpans(GetRecording(s1), `
 		span a:


### PR DESCRIPTION
Backport 4/4 commits from #47303.

/cc @cockroachdb/release

---

This patch adds a new file to a statement diagnostics bundle:
trace-jaeger.json. This file can be manually imported in Jaeger, which
will the display the trace.
This is in addition to our own JSON format, and to a human-readable
format, which also remain in the bundle.

A source file with the structure of the respective JSON is copied over
from the Jaeger source code.

No longer shall we live in darkness.

Release note (general change): Statement diagnostics zip bundles now
contain a representation of the statement trace that can be imported
into Jaeger for visualization.
