### PR TITLE
release-20.1: sql: prevent time-related precision during upgrade from 19.2 -> 20.1

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -68,6 +68,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>19.2-17</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>19.2-18</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -58,6 +58,7 @@ const (
 	VersionSchemaChangeJob
 	VersionSavepoints
 	VersionTimeTZType
+	VersionTimePrecision
 
 	// Add new versions here (step one of two).
 )
@@ -449,6 +450,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// VersionTimeTZType enables the use of the TimeTZ data type.
 		Key:     VersionTimeTZType,
 		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 17},
+	},
+	{
+		// VersionTimePrecision enables the use of precision with time/intervals.
+		Key:     VersionTimePrecision,
+		Version: roachpb.Version{Major: 19, Minor: 2, Unstable: 18},
 	},
 	// Add new versions here (step two of two).
 

--- a/pkg/clusterversion/versionkey_string.go
+++ b/pkg/clusterversion/versionkey_string.go
@@ -34,11 +34,12 @@ func _() {
 	_ = x[VersionSchemaChangeJob-23]
 	_ = x[VersionSavepoints-24]
 	_ = x[VersionTimeTZType-25]
+	_ = x[VersionTimePrecision-26]
 }
 
-const _VersionKey_name = "Version19_1VersionStart19_2VersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDsVersionHashShardedIndexesVersionCreateRolePrivilegeVersionStatementDiagnosticsSystemTablesVersionSchemaChangeJobVersionSavepointsVersionTimeTZType"
+const _VersionKey_name = "Version19_1VersionStart19_2VersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDsVersionHashShardedIndexesVersionCreateRolePrivilegeVersionStatementDiagnosticsSystemTablesVersionSchemaChangeJobVersionSavepointsVersionTimeTZTypeVersionTimePrecision"
 
-var _VersionKey_index = [...]uint16{0, 11, 27, 49, 75, 109, 136, 176, 200, 211, 227, 258, 287, 322, 354, 380, 404, 441, 480, 499, 534, 559, 585, 624, 646, 663, 680}
+var _VersionKey_index = [...]uint16{0, 11, 27, 49, 75, 109, 136, 176, 200, 211, 227, 258, 287, 322, 354, 380, 404, 441, 480, 499, 534, 559, 585, 624, 646, 663, 680, 700}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -145,7 +145,9 @@ func (n *alterTableNode) startExec(params runParams) error {
 					"adding a REFERENCES constraint while also adding a column via ALTER not supported")
 			}
 			version := params.ExecCfg().Settings.Version.ActiveVersionOrEmpty(params.ctx)
-			if !isTypeSupportedInVersion(version, d.Type) {
+			if supported, err := isTypeSupportedInVersion(version, d.Type); err != nil {
+				return err
+			} else if !supported {
 				return pgerror.Newf(
 					pgcode.FeatureNotSupported,
 					"type %s is not supported until version upgrade is finalized",
@@ -879,7 +881,9 @@ func applyColumnMutation(
 		typ := t.ToType
 
 		version := params.ExecCfg().Settings.Version.ActiveVersionOrEmpty(params.ctx)
-		if !isTypeSupportedInVersion(version, typ) {
+		if supported, err := isTypeSupportedInVersion(version, typ); err != nil {
+			return err
+		} else if !supported {
 			return pgerror.Newf(
 				pgcode.FeatureNotSupported,
 				"type %s is not supported until version upgrade is finalized",

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -119,12 +119,27 @@ var minimumTypeUsageVersions = map[types.Family]clusterversion.VersionKey{
 }
 
 // isTypeSupportedInVersion returns whether a given type is supported in the given version.
-func isTypeSupportedInVersion(v clusterversion.ClusterVersion, t *types.T) bool {
+func isTypeSupportedInVersion(v clusterversion.ClusterVersion, t *types.T) (bool, error) {
+	switch t.Family() {
+	case types.TimeFamily, types.TimestampFamily, types.TimestampTZFamily, types.TimeTZFamily:
+		if t.Precision() != 6 && !v.IsActive(clusterversion.VersionTimePrecision) {
+			return false, nil
+		}
+	case types.IntervalFamily:
+		itm, err := t.IntervalTypeMetadata()
+		if err != nil {
+			return false, err
+		}
+		if (t.Precision() != 6 || itm.DurationField != types.IntervalDurationField{}) &&
+			!v.IsActive(clusterversion.VersionTimePrecision) {
+			return false, nil
+		}
+	}
 	minVersion, ok := minimumTypeUsageVersions[t.Family()]
 	if !ok {
-		return true
+		return true, nil
 	}
-	return v.IsActive(minVersion)
+	return v.IsActive(minVersion), nil
 }
 
 // ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
@@ -1253,7 +1268,9 @@ func MakeTableDesc(
 					)
 				}
 			}
-			if !isTypeSupportedInVersion(version, d.Type) {
+			if supported, err := isTypeSupportedInVersion(version, d.Type); err != nil {
+				return desc, err
+			} else if !supported {
 				return desc, pgerror.Newf(
 					pgcode.FeatureNotSupported,
 					"type %s is not supported until version upgrade is finalized",

--- a/pkg/sql/create_table_test.go
+++ b/pkg/sql/create_table_test.go
@@ -1,0 +1,88 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsTypeSupportedInVersion(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		v clusterversion.VersionKey
+		t *types.T
+
+		ok bool
+	}{
+		{clusterversion.Version19_2, types.Time, true},
+		{clusterversion.Version19_2, types.Timestamp, true},
+		{clusterversion.Version19_2, types.Interval, true},
+
+		{clusterversion.Version19_2, types.TimeTZ, false},
+		{clusterversion.VersionTimeTZType, types.TimeTZ, true},
+
+		{clusterversion.Version19_2, types.MakeTime(0), false},
+		{clusterversion.Version19_2, types.MakeTimeTZ(0), false},
+		{clusterversion.VersionTimeTZType, types.MakeTimeTZ(0), false},
+		{clusterversion.Version19_2, types.MakeTimestamp(0), false},
+		{clusterversion.Version19_2, types.MakeTimestampTZ(0), false},
+		{
+			clusterversion.Version19_2,
+			types.MakeInterval(types.IntervalTypeMetadata{Precision: 3, PrecisionIsSet: true}),
+			false,
+		},
+		{
+			clusterversion.Version19_2,
+			types.MakeInterval(
+				types.IntervalTypeMetadata{
+					DurationField: types.IntervalDurationField{DurationType: types.IntervalDurationType_SECOND},
+				},
+			),
+			false,
+		},
+		{clusterversion.VersionTimePrecision, types.MakeTime(0), true},
+		{clusterversion.VersionTimePrecision, types.MakeTimeTZ(0), true},
+		{clusterversion.VersionTimePrecision, types.MakeTimestamp(0), true},
+		{clusterversion.VersionTimePrecision, types.MakeTimestampTZ(0), true},
+		{
+			clusterversion.VersionTimePrecision,
+			types.MakeInterval(types.IntervalTypeMetadata{Precision: 3, PrecisionIsSet: true}),
+			true,
+		},
+		{
+			clusterversion.VersionTimePrecision,
+			types.MakeInterval(
+				types.IntervalTypeMetadata{
+					DurationField: types.IntervalDurationField{DurationType: types.IntervalDurationType_SECOND},
+				},
+			),
+			true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s:%s", tc.v, tc.t.SQLString()), func(t *testing.T) {
+			ok, err := isTypeSupportedInVersion(
+				clusterversion.ClusterVersion{Version: clusterversion.VersionByKey(tc.v)},
+				tc.t,
+			)
+			require.NoError(t, err)
+			require.Equal(t, tc.ok, ok)
+		})
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/alter_table_mixed_19.2_20.1
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table_mixed_19.2_20.1
@@ -154,13 +154,13 @@ subtest non_backfill_schema_changes
 statement ok
 CREATE TABLE IF NOT EXISTS t (a INT PRIMARY KEY, b INT, INDEX (b), FAMILY (a, b))
 
+subtest regression_47110
+
 statement error schema change cannot be initiated in this version until the version upgrade is finalized
 ALTER TABLE t RENAME COLUMN b TO c
 
 statement error schema change cannot be initiated in this version until the version upgrade is finalized
 ALTER TABLE t RENAME TO s
-
-subtest regression_47110
 
 statement error type TIMETZ is not supported until version upgrade is finalized
 CREATE TABLE regression_47110(a TIMETZ)
@@ -173,3 +173,34 @@ ALTER TABLE regression_47110 ADD COLUMN b TIMETZ
 
 statement error type TIMETZ is not supported until version upgrade is finalized
 ALTER TABLE regression_47110 ALTER a SET DATA TYPE timetz
+
+# test precision as well
+
+# default statements ok
+statement ok
+CREATE TABLE regression_47110_tt(tt_ok TIMESTAMP)
+
+statement ok
+CREATE TABLE regression_47110_ttz(ttz_ok TIMESTAMPTZ)
+
+statement ok
+CREATE TABLE regression_47110_t(ttz_ok TIME)
+
+statement ok
+CREATE TABLE regression_47110_interval_ok(interval_ok INTERVAL)
+
+# but precision is not ok
+statement error type TIMESTAMP\(3\) is not supported until version upgrade is finalized
+CREATE TABLE regression_47110_not_ok(tt_not_ok TIMESTAMP(3))
+
+statement error type TIMESTAMPTZ\(3\) is not supported until version upgrade is finalized
+CREATE TABLE regression_47110_not_ok(ttz_not_ok TIMESTAMPTZ(3))
+
+statement error type TIME\(3\) is not supported until version upgrade is finalized
+CREATE TABLE regression_47110_not_ok(t_not_ok TIME(3))
+
+statement error type INTERVAL\(3\) is not supported until version upgrade is finalized
+CREATE TABLE regression_47110_not_ok(interval_not_ok INTERVAL(3))
+
+statement error type INTERVAL DAY is not supported until version upgrade is finalized
+CREATE TABLE regression_47110_not_ok(interval_not_ok INTERVAL DAY)


### PR DESCRIPTION
Backport 1/1 commits from #47425.

/cc @cockroachdb/release

---

The intention is to backport this if we think this change is important.

Release note (sql change): We previously allowed mixed type 20.1/19.2
upgrades to add time precision. However, the 19.2 would disrespect the
precision component and we documented that. To make this cleaner, we
instead only allow precision to be specified in time-related types when
the version upgrade is complete.


