### PR TITLE
sql: add a framework for lazy generation of virtual table rows

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
@@ -153,3 +153,10 @@ RANGE default  ALTER RANGE default CONFIGURE ZONE USING
                num_replicas = 3,
                constraints = '[]',
                lease_preferences = '[]'
+
+# This test checks that generator backed tables do not concurrently
+# access transactions. It does this by scanning two virtual tables at a time.
+# If the background generator functions were performing work when not allowed
+# to, the background generators would conflict with an error.
+statement ok
+SELECT a.* FROM crdb_internal.partitions AS a JOIN crdb_internal.partitions AS b ON a.table_id = b.table_id

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -74,7 +74,7 @@ type virtualSchemaTable struct {
 	// generator, if non-nil, is a function that is used when creating a
 	// virtualTableNode. This function returns a virtualTableGenerator function
 	// which generates the next row of the virtual table when called.
-	generator func(ctx context.Context, p *planner, db *DatabaseDescriptor) (virtualTableGenerator, error)
+	generator func(ctx context.Context, p *planner, db *DatabaseDescriptor) (virtualTableGenerator, cleanupFunc, error)
 }
 
 // virtualSchemaView represents a view within a virtualSchema
@@ -264,11 +264,11 @@ func (e virtualDefEntry) getPlanInfo() (sqlbase.ResultColumns, virtualTableConst
 			}
 
 			if def.generator != nil {
-				next, err := def.generator(ctx, p, dbDesc)
+				next, cleanup, err := def.generator(ctx, p, dbDesc)
 				if err != nil {
 					return nil, err
 				}
-				return p.newContainerVirtualTableNode(columns, 0, next), nil
+				return p.newContainerVirtualTableNode(columns, 0, next, cleanup), nil
 			}
 			v := p.newContainerValuesNode(columns, 0)
 

--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -24,20 +24,136 @@ import (
 // nil). If there is an error, then return (nil, error).
 type virtualTableGenerator func() (tree.Datums, error)
 
+// cleanupFunc is a function to cleanup resources created by the generator.
+type cleanupFunc func()
+
+// rowPusher is an interface for lazy generators to push rows into
+// and then suspend until the next row has been requested.
+type rowPusher interface {
+	// pushRow pushes the input row to the receiver of the generator. It doesn't
+	// mutate the input row. It will block until the the data has been received
+	// and more data has been requested. Once pushRow returns, the caller is free
+	// to mutate the slice passed as input. The caller is not allowed to perform
+	// operations on a transaction while blocked on a call to pushRow.
+	// If pushRow returns an error, the caller must immediately return the error.
+	pushRow(...tree.Datum) error
+}
+
+// funcRowPusher implements rowPusher on functions.
+type funcRowPusher func(...tree.Datum) error
+
+func (f funcRowPusher) pushRow(datums ...tree.Datum) error {
+	return f(datums...)
+}
+
+type virtualTableGeneratorResponse struct {
+	datums tree.Datums
+	err    error
+}
+
+// setupGenerator takes in a worker that generates rows eagerly and transforms
+// it into a lazy row generator. It returns two functions:
+// * next: A handle that can be called to generate a row from the worker. Next
+//   cannot be called once cleanup has been called.
+// * cleanup: Performs all cleanup. This function must be called exactly once
+//   to ensure that resources are cleaned up.
+func setupGenerator(
+	ctx context.Context, worker func(pusher rowPusher) error,
+) (next virtualTableGenerator, cleanup cleanupFunc) {
+	var cancel func()
+	ctx, cancel = context.WithCancel(ctx)
+	cleanup = cancel
+
+	// comm is the channel to manage communication between the row receiver
+	// and the generator. The row receiver notifies the worker to begin
+	// computation through comm, and the generator places rows to consume
+	// back into comm.
+	comm := make(chan virtualTableGeneratorResponse)
+
+	addRow := func(datums ...tree.Datum) error {
+		select {
+		case <-ctx.Done():
+			return sqlbase.QueryCanceledError
+		case comm <- virtualTableGeneratorResponse{datums: datums}:
+		}
+
+		// Block until the next call to cleanup() or next(). This allows us to
+		// avoid issues with concurrent transaction usage if the worker is using
+		// a transaction. Otherwise, worker could proceed running operations after
+		// a call to next() has returned. That could result in the main operator
+		// chain using the transaction while the worker is also running. This
+		// makes it so that the worker can only run while next() is being called,
+		// which effectively gives ownership of the transaction usage over to the
+		// worker, and then back to the next() caller after it is done.
+		select {
+		case <-ctx.Done():
+			return sqlbase.QueryCanceledError
+		case <-comm:
+		}
+		return nil
+	}
+
+	go func() {
+		// We wait until a call to next before starting the worker. This prevents
+		// concurrent transaction usage during the startup phase. We also have to
+		// wait on done here if cleanup is called before any calls to next() to
+		// avoid leaking this goroutine. Lastly, we check if the context has
+		// been canceled before any rows are even requested.
+		select {
+		case <-ctx.Done():
+			return
+		case <-comm:
+		}
+		err := worker(funcRowPusher(addRow))
+		// If the query was canceled, next() will already return a
+		// QueryCanceledError, so just exit here.
+		if err == sqlbase.QueryCanceledError {
+			return
+		}
+
+		// Notify that we are done sending rows.
+		select {
+		case <-ctx.Done():
+			return
+		case comm <- virtualTableGeneratorResponse{err: err}:
+		}
+	}()
+
+	next = func() (tree.Datums, error) {
+		// Notify the worker to begin computing a row.
+		select {
+		case comm <- virtualTableGeneratorResponse{}:
+		case <-ctx.Done():
+			return nil, sqlbase.QueryCanceledError
+		}
+
+		// Wait for the row to be sent.
+		select {
+		case <-ctx.Done():
+			return nil, sqlbase.QueryCanceledError
+		case resp := <-comm:
+			return resp.datums, resp.err
+		}
+	}
+	return next, cleanup
+}
+
 // virtualTableNode is a planNode that constructs its rows by repeatedly
 // invoking a virtualTableGenerator function.
 type virtualTableNode struct {
 	columns    sqlbase.ResultColumns
 	next       virtualTableGenerator
+	cleanup    func()
 	currentRow tree.Datums
 }
 
 func (p *planner) newContainerVirtualTableNode(
-	columns sqlbase.ResultColumns, capacity int, next virtualTableGenerator,
+	columns sqlbase.ResultColumns, capacity int, next virtualTableGenerator, cleanup func(),
 ) *virtualTableNode {
 	return &virtualTableNode{
 		columns: columns,
 		next:    next,
+		cleanup: cleanup,
 	}
 }
 
@@ -59,4 +175,7 @@ func (n *virtualTableNode) Values() tree.Datums {
 }
 
 func (n *virtualTableNode) Close(ctx context.Context) {
+	if n.cleanup != nil {
+		n.cleanup()
+	}
 }

--- a/pkg/sql/virtual_table_test.go
+++ b/pkg/sql/virtual_table_test.go
@@ -1,0 +1,146 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVirtualTableGenerators(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	t.Run("test cleanup", func(t *testing.T) {
+		ctx := context.Background()
+		worker := func(pusher rowPusher) error {
+			if err := pusher.pushRow(tree.NewDInt(1)); err != nil {
+				return err
+			}
+			if err := pusher.pushRow(tree.NewDInt(2)); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		next, cleanup := setupGenerator(ctx, worker)
+		d, err := next()
+		if err != nil {
+			t.Fatal(err)
+		}
+		require.Equal(t, tree.Datums{tree.NewDInt(1)}, d)
+
+		// Check that we can safely cleanup in the middle of execution.
+		cleanup()
+	})
+
+	t.Run("test worker error", func(t *testing.T) {
+		// Test that if the worker returns an error we catch it.
+		ctx := context.Background()
+		worker := func(pusher rowPusher) error {
+			if err := pusher.pushRow(tree.NewDInt(1)); err != nil {
+				return err
+			}
+			if err := pusher.pushRow(tree.NewDInt(2)); err != nil {
+				return err
+			}
+			return errors.New("dummy error")
+		}
+		next, cleanup := setupGenerator(ctx, worker)
+		_, err := next()
+		require.NoError(t, err)
+		_, err = next()
+		require.NoError(t, err)
+		_, err = next()
+		require.Error(t, err)
+		cleanup()
+	})
+
+	t.Run("test no next", func(t *testing.T) {
+		ctx := context.Background()
+		// Test we don't leak anything if we call cleanup before next.
+		worker := func(pusher rowPusher) error {
+			return nil
+		}
+		_, cleanup := setupGenerator(ctx, worker)
+		cleanup()
+	})
+
+	t.Run("test context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		// Test cancellation before asking for any rows.
+		worker := func(pusher rowPusher) error {
+			if err := pusher.pushRow(tree.NewDInt(1)); err != nil {
+				return err
+			}
+			if err := pusher.pushRow(tree.NewDInt(2)); err != nil {
+				return err
+			}
+			return nil
+		}
+		next, cleanup := setupGenerator(ctx, worker)
+		cancel()
+		_, err := next()
+		// There is a small chance that we race and don't return
+		// a query canceled here. So, only check the error if
+		// it is non-nil.
+		if err != nil {
+			require.Equal(t, sqlbase.QueryCanceledError, err)
+		}
+		cleanup()
+
+		// Test cancellation after asking for a row.
+		ctx, cancel = context.WithCancel(context.Background())
+		next, cleanup = setupGenerator(ctx, worker)
+		row, err := next()
+		require.NoError(t, err)
+		require.Equal(t, tree.Datums{tree.NewDInt(1)}, row)
+		cancel()
+		_, err = next()
+		require.Equal(t, sqlbase.QueryCanceledError, err)
+		cleanup()
+
+		// Test cancellation after asking for all the rows.
+		ctx, cancel = context.WithCancel(context.Background())
+		next, cleanup = setupGenerator(ctx, worker)
+		_, err = next()
+		require.NoError(t, err)
+		_, err = next()
+		require.NoError(t, err)
+		cancel()
+		cleanup()
+	})
+}
+
+func BenchmarkVirtualTableGenerators(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	ctx := context.Background()
+	worker := func(pusher rowPusher) error {
+		for {
+			if err := pusher.pushRow(tree.NewDInt(tree.DInt(1))); err != nil {
+				return err
+			}
+		}
+	}
+	b.Run("bench read", func(b *testing.B) {
+		next, cleanup := setupGenerator(ctx, worker)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := next()
+			require.NoError(b, err)
+		}
+		cleanup()
+	})
+}


### PR DESCRIPTION
This PR adds a framework for lazily generating rows for virtual
tables. It also ports some virtual table generators that loop
over all table descriptors to use this framework.

Release note: None