### PR TITLE
sql: fix SCRUB to work on TEMP TABLE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -222,3 +222,11 @@ subtest table_with_on_commit
 
 statement error ON COMMIT can only be used on temporary tables
 CREATE TABLE a (a int) ON COMMIT PRESERVE ROWS
+
+subtest regression_47031
+
+statement ok
+CREATE TEMP TABLE regression_47031(c0 INT)
+
+statement ok
+EXPERIMENTAL SCRUB table regression_47031


### PR DESCRIPTION
Release note (bug fix): Fix a bug where EXPERIMENTAL SCRUB did not work
on temporary tables.