### PR TITLE
geos: fix windows compliation for EnsureInit* changes

### DIFF
--- a/pkg/geo/geos/geos.go
+++ b/pkg/geo/geos/geos.go
@@ -13,3 +13,16 @@
 // at init time.
 // Operations will error if the GEOS library was not found.
 package geos
+
+// EnsureInitErrorDisplay is used to control the error message displayed by
+// EnsureInit.
+type EnsureInitErrorDisplay int
+
+const (
+	// EnsureInitErrorDisplayPrivate displays the full error message, including
+	// path info. It is intended for log messages.
+	EnsureInitErrorDisplayPrivate EnsureInitErrorDisplay = iota
+	// EnsureInitErrorDisplayPublic displays a redacted error message, excluding
+	// path info. It is intended for errors to display for the client.
+	EnsureInitErrorDisplayPublic
+)

--- a/pkg/geo/geos/geos_unix.go
+++ b/pkg/geo/geos/geos_unix.go
@@ -42,19 +42,6 @@ var geosOnce struct {
 	once sync.Once
 }
 
-// EnsureInitErrorDisplay is used to control the error message displayed by
-// EnsureInit.
-type EnsureInitErrorDisplay int
-
-const (
-	// EnsureInitErrorDisplayPrivate displays the full error message, including
-	// path info. It is intended for log messages.
-	EnsureInitErrorDisplayPrivate EnsureInitErrorDisplay = iota
-	// EnsureInitErrorDisplayPublic displays a redacted error message, excluding
-	// path info. It is intended for errors to display for the client.
-	EnsureInitErrorDisplayPublic
-)
-
 // EnsureInit attempts to start GEOS if it has not been opened already
 // and returns an error if the CR_GEOS  is not valid.
 func EnsureInit(errDisplay EnsureInitErrorDisplay) error {

--- a/pkg/geo/geos/geos_windows.go
+++ b/pkg/geo/geos/geos_windows.go
@@ -17,6 +17,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 )
 
+func EnsureInit(errDisplay EnsureInitErrorDisplay) error {
+	return nil
+}
+
 func WKTToWKB(wkt geopb.WKT) (geopb.WKB, error) {
 	return nil, unimplemented.NewWithIssue(46876, "operation not supported on Windows")
 }


### PR DESCRIPTION
A previous commit broke the build on windows because of EnsureInit. We
add the EnsureInit behavior on Windows to not return an error in an
effort to reduce log spam.

Release note: None