### PR TITLE
kvserver: gossip on aborted system config transactions following failure

### DIFF
--- a/pkg/kv/kvserver/batcheval/eval_context.go
+++ b/pkg/kv/kvserver/batcheval/eval_context.go
@@ -180,7 +180,7 @@ func (m *mockEvalCtxImpl) Desc() *roachpb.RangeDescriptor {
 	return m.MockEvalCtx.Desc
 }
 func (m *mockEvalCtxImpl) ContainsKey(key roachpb.Key) bool {
-	panic("unimplemented")
+	return false
 }
 func (m *mockEvalCtxImpl) GetMVCCStats() enginepb.MVCCStats {
 	return m.Stats

--- a/pkg/kv/kvserver/batcheval/result/result.go
+++ b/pkg/kv/kvserver/batcheval/result/result.go
@@ -57,6 +57,8 @@ type LocalResult struct {
 	GossipFirstRange bool
 	// Call MaybeGossipSystemConfig.
 	MaybeGossipSystemConfig bool
+	// Call MaybeGossipSystemConfigIfHaveFailure
+	MaybeGossipSystemConfigIfHaveFailure bool
 	// Call MaybeAddToSplitQueue.
 	MaybeAddToSplitQueue bool
 	// Call MaybeGossipNodeLiveness with the specified Span, if set.
@@ -80,6 +82,7 @@ func (lResult *LocalResult) IsZero() bool {
 		lResult.EndTxns == nil &&
 		!lResult.GossipFirstRange &&
 		!lResult.MaybeGossipSystemConfig &&
+		!lResult.MaybeGossipSystemConfigIfHaveFailure &&
 		lResult.MaybeGossipNodeLiveness == nil &&
 		!lResult.MaybeWatchForMerge &&
 		lResult.Metrics == nil
@@ -92,12 +95,14 @@ func (lResult *LocalResult) String() string {
 	return fmt.Sprintf("LocalResult (reply: %v, "+
 		"#encountered intents: %d, #acquired locks: %d, #resolved locks: %d"+
 		"#updated txns: %d #end txns: %d, "+
-		"GossipFirstRange:%t MaybeGossipSystemConfig:%t MaybeAddToSplitQueue:%t "+
+		"GossipFirstRange:%t MaybeGossipSystemConfig:%t "+
+		"MaybeGossipSystemConfigIfHaveFailure:%t MaybeAddToSplitQueue:%t "+
 		"MaybeGossipNodeLiveness:%s MaybeWatchForMerge:%t",
 		lResult.Reply,
 		len(lResult.EncounteredIntents), len(lResult.AcquiredLocks), len(lResult.ResolvedLocks),
 		len(lResult.UpdatedTxns), len(lResult.EndTxns),
-		lResult.GossipFirstRange, lResult.MaybeGossipSystemConfig, lResult.MaybeAddToSplitQueue,
+		lResult.GossipFirstRange, lResult.MaybeGossipSystemConfig,
+		lResult.MaybeGossipSystemConfigIfHaveFailure, lResult.MaybeAddToSplitQueue,
 		lResult.MaybeGossipNodeLiveness, lResult.MaybeWatchForMerge)
 }
 
@@ -332,6 +337,7 @@ func (p *Result) MergeAndDestroy(q Result) error {
 
 	coalesceBool(&p.Local.GossipFirstRange, &q.Local.GossipFirstRange)
 	coalesceBool(&p.Local.MaybeGossipSystemConfig, &q.Local.MaybeGossipSystemConfig)
+	coalesceBool(&p.Local.MaybeGossipSystemConfigIfHaveFailure, &q.Local.MaybeGossipSystemConfigIfHaveFailure)
 	coalesceBool(&p.Local.MaybeAddToSplitQueue, &q.Local.MaybeAddToSplitQueue)
 	coalesceBool(&p.Local.MaybeWatchForMerge, &q.Local.MaybeWatchForMerge)
 

--- a/pkg/kv/kvserver/replica_gossip.go
+++ b/pkg/kv/kvserver/replica_gossip.go
@@ -95,6 +95,7 @@ func (r *Replica) MaybeGossipSystemConfig(ctx context.Context) error {
 	if err != nil {
 		if err == errSystemConfigIntent {
 			log.VEventf(ctx, 2, "not gossiping system config because intents were found on SystemConfigSpan")
+			r.markSystemConfigGossipFailed()
 			return nil
 		}
 		return errors.Wrap(err, "could not load SystemConfig span")
@@ -103,6 +104,9 @@ func (r *Replica) MaybeGossipSystemConfig(ctx context.Context) error {
 	if gossipedCfg := r.store.Gossip().GetSystemConfig(); gossipedCfg != nil && gossipedCfg.Equal(loadedCfg) &&
 		r.store.Gossip().InfoOriginatedHere(gossip.KeySystemConfig) {
 		log.VEventf(ctx, 2, "not gossiping unchanged system config")
+		// Clear the failure bit if all intents have been resolved but there's
+		// nothing new to gossip.
+		r.markSystemConfigGossipSuccess()
 		return nil
 	}
 
@@ -110,7 +114,21 @@ func (r *Replica) MaybeGossipSystemConfig(ctx context.Context) error {
 	if err := r.store.Gossip().AddInfoProto(gossip.KeySystemConfig, loadedCfg, 0); err != nil {
 		return errors.Wrap(err, "failed to gossip system config")
 	}
+	r.markSystemConfigGossipSuccess()
 	return nil
+}
+
+// MaybeGossipSystemConfigIfHaveFailure is a trigger to gossip the system config
+// due to an abort of a transaction keyed in the system config span. It will
+// call MaybeGossipSystemConfig if failureToGossipSystemConfig is true.
+func (r *Replica) MaybeGossipSystemConfigIfHaveFailure(ctx context.Context) error {
+	r.mu.RLock()
+	failed := r.mu.failureToGossipSystemConfig
+	r.mu.RUnlock()
+	if !failed {
+		return nil
+	}
+	return r.MaybeGossipSystemConfig(ctx)
 }
 
 // MaybeGossipNodeLiveness gossips information for all node liveness

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -667,6 +667,13 @@ func (r *Replica) handleReadWriteLocalEvalResult(ctx context.Context, lResult re
 		lResult.MaybeGossipSystemConfig = false
 	}
 
+	if lResult.MaybeGossipSystemConfigIfHaveFailure {
+		if err := r.MaybeGossipSystemConfigIfHaveFailure(ctx); err != nil {
+			log.Error(ctx, err)
+		}
+		lResult.MaybeGossipSystemConfigIfHaveFailure = false
+	}
+
 	if lResult.MaybeGossipNodeLiveness != nil {
 		if err := r.MaybeGossipNodeLiveness(ctx, *lResult.MaybeGossipNodeLiveness); err != nil {
 			log.Error(ctx, err)


### PR DESCRIPTION
This PR adds a new behavior to the Replica to track when a failure to gossip
occurs due to an existing intent on the range. The SQL layer degrades quite
poorly in the face of failure to gossip on writes to the system config. The
expectation had been that failures to gossip due to intents were likely to
be rectified soon as those intents were likely to be turned into committed
values and to lead to a new gossip event. Unfortunately there are cases where
no values will be committed until gossip occurs. What will happen in those
cases is the intents will be removed due to aborts.

Fixes #47304

Release note (bug fix): Fix bug where concurrent schema change interactions
could lead to schema changes being blocked for minutes.