### PR TITLE
kv: release latches before semi-synchronous intent resolution

### DIFF
--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -740,11 +740,9 @@ func (r *Replica) evaluateProposal(
 
 		// Failed proposals can't have any Result except for what's
 		// whitelisted here.
-		intents := res.Local.DetachEncounteredIntents()
-		endTxns := res.Local.DetachEndTxns(true /* alwaysOnly */)
 		res.Local = result.LocalResult{
-			EncounteredIntents: intents,
-			EndTxns:            endTxns,
+			EncounteredIntents: res.Local.DetachEncounteredIntents(),
+			EndTxns:            res.Local.DetachEndTxns(true /* alwaysOnly */),
 			Metrics:            res.Local.Metrics,
 		}
 		res.Replicated.Reset()

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -65,17 +65,50 @@ func (r *Replica) executeReadOnlyBatch(
 
 	var result result.Result
 	br, result, pErr = r.executeReadOnlyBatchWithServersideRefreshes(ctx, rw, rec, ba, spans)
-	if err := r.handleReadOnlyLocalEvalResult(ctx, ba, result.Local); err != nil {
-		pErr = roachpb.NewError(err)
+
+	// If the request hit a server-side concurrency retry error, immediately
+	// proagate the error. Don't assume ownership of the concurrency guard.
+	if isConcurrencyRetryError(pErr) {
+		return nil, g, pErr
 	}
-	r.updateTimestampCache(ctx, ba, br, pErr)
+
+	// Handle any local (leaseholder-only) side-effects of the request.
+	intents := result.Local.DetachEncounteredIntents()
+	if pErr == nil {
+		pErr = r.handleReadOnlyLocalEvalResult(ctx, ba, result.Local)
+	}
+
+	// Otherwise, update the timestamp cache and release the concurrency guard.
+	ec, g := endCmds{repl: r, g: g}, nil
+	ec.done(ctx, ba, br, pErr)
+
+	// Semi-synchronously process any intents that need resolving here in
+	// order to apply back pressure on the client which generated them. The
+	// resolution is semi-synchronous in that there is a limited number of
+	// outstanding asynchronous resolution tasks allowed after which
+	// further calls will block.
+	if len(intents) > 0 {
+		log.Eventf(ctx, "submitting %d intents to asynchronous processing", len(intents))
+		// We only allow synchronous intent resolution for consistent requests.
+		// Intent resolution is async/best-effort for inconsistent requests.
+		//
+		// An important case where this logic is necessary is for RangeLookup
+		// requests. In their case, synchronous intent resolution can deadlock
+		// if the request originated from the local node which means the local
+		// range descriptor cache has an in-flight RangeLookup request which
+		// prohibits any concurrent requests for the same range. See #17760.
+		allowSyncProcessing := ba.ReadConsistency == roachpb.CONSISTENT
+		if err := r.store.intentResolver.CleanupIntentsAsync(ctx, intents, allowSyncProcessing); err != nil {
+			log.Warning(ctx, err)
+		}
+	}
 
 	if pErr != nil {
 		log.VErrEvent(ctx, 3, pErr.String())
 	} else {
 		log.Event(ctx, "read completed")
 	}
-	return br, g, pErr
+	return br, nil, pErr
 }
 
 // executeReadOnlyBatchWithServersideRefreshes invokes evaluateBatch and retries
@@ -115,22 +148,12 @@ func (r *Replica) executeReadOnlyBatchWithServersideRefreshes(
 
 func (r *Replica) handleReadOnlyLocalEvalResult(
 	ctx context.Context, ba *roachpb.BatchRequest, lResult result.LocalResult,
-) error {
+) *roachpb.Error {
 	// Fields for which no action is taken in this method are zeroed so that
 	// they don't trigger an assertion at the end of the method (which checks
 	// that all fields were handled).
 	{
 		lResult.Reply = nil
-	}
-
-	if lResult.MaybeWatchForMerge {
-		// A merge is (likely) about to be carried out, and this replica needs
-		// to block all traffic until the merge either commits or aborts. See
-		// docs/tech-notes/range-merges.md.
-		if err := r.maybeWatchForMerge(ctx); err != nil {
-			return err
-		}
-		lResult.MaybeWatchForMerge = false
 	}
 
 	if lResult.AcquiredLocks != nil {
@@ -141,20 +164,14 @@ func (r *Replica) handleReadOnlyLocalEvalResult(
 		lResult.AcquiredLocks = nil
 	}
 
-	if intents := lResult.DetachEncounteredIntents(); len(intents) > 0 {
-		log.Eventf(ctx, "submitting %d intents to asynchronous processing", len(intents))
-		// We only allow synchronous intent resolution for consistent requests.
-		// Intent resolution is async/best-effort for inconsistent requests.
-		//
-		// An important case where this logic is necessary is for RangeLookup
-		// requests. In their case, synchronous intent resolution can deadlock
-		// if the request originated from the local node which means the local
-		// range descriptor cache has an in-flight RangeLookup request which
-		// prohibits any concurrent requests for the same range. See #17760.
-		allowSyncProcessing := ba.ReadConsistency == roachpb.CONSISTENT
-		if err := r.store.intentResolver.CleanupIntentsAsync(ctx, intents, allowSyncProcessing); err != nil {
-			log.Warning(ctx, err)
+	if lResult.MaybeWatchForMerge {
+		// A merge is (likely) about to be carried out, and this replica needs
+		// to block all traffic until the merge either commits or aborts. See
+		// docs/tech-notes/range-merges.md.
+		if err := r.maybeWatchForMerge(ctx); err != nil {
+			return roachpb.NewError(err)
 		}
+		lResult.MaybeWatchForMerge = false
 	}
 
 	if !lResult.IsZero() {

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -100,7 +100,17 @@ func (r *Replica) executeReadOnlyBatchWithServersideRefreshes(
 			break
 		}
 	}
-	return br, res, pErr
+
+	if pErr != nil {
+		// Failed read-only batches can't have any Result except for what's
+		// whitelisted here.
+		res.Local = result.LocalResult{
+			EncounteredIntents: res.Local.DetachEncounteredIntents(),
+			Metrics:            res.Local.Metrics,
+		}
+		return nil, res, pErr
+	}
+	return br, res, nil
 }
 
 func (r *Replica) handleReadOnlyLocalEvalResult(

--- a/pkg/kv/kvserver/storagebase/knobs.go
+++ b/pkg/kv/kvserver/storagebase/knobs.go
@@ -25,9 +25,11 @@ type BatchEvalTestingKnobs struct {
 	// to one of the other filters. See #10493
 	// TODO(andrei): Provide guidance on what to use instead for trapping reads.
 	TestingEvalFilter ReplicaCommandFilter
+
 	// NumKeysEvaluatedForRangeIntentResolution is set by the stores to the
 	// number of keys evaluated for range intent resolution.
 	NumKeysEvaluatedForRangeIntentResolution *int64
+
 	// RecoverIndeterminateCommitsOnFailedPushes will propagate indeterminate
 	// commit errors to trigger transaction recovery even if the push that
 	// discovered the indeterminate commit was going to fail. This increases

--- a/pkg/util/quotapool/intpool.go
+++ b/pkg/util/quotapool/intpool.go
@@ -139,6 +139,9 @@ func NewIntPool(name string, capacity uint64, options ...Option) *IntPool {
 // Acquisitions of 0 return immediately with no error, even if the IntPool is
 // closed.
 //
+// Acquisitions of more than 0 from a pool with 0 capacity always returns an
+// ErrNotEnoughQuota.
+//
 // Safe for concurrent use.
 func (p *IntPool) Acquire(ctx context.Context, v uint64) (*IntAlloc, error) {
 	return p.acquireMaybeWait(ctx, v, true /* wait */)
@@ -154,6 +157,10 @@ func (p *IntPool) acquireMaybeWait(ctx context.Context, v uint64, wait bool) (*I
 	// Special case acquisitions of size 0.
 	if v == 0 {
 		return p.newIntAlloc(0), nil
+	}
+	// Special case capacity of 0.
+	if p.Capacity() == 0 {
+		return nil, ErrNotEnoughQuota
 	}
 	// The maximum capacity is math.MaxInt64 so we can always truncate requests
 	// to that value.


### PR DESCRIPTION
Fixes #47187.
Fixes #47186.

This commit addresses the deadlock described in #47187. In that issue, we saw that a single batch deadlocked while performing synchronous intent resolution while continuing to hold latches over the spans that it was trying to resolve. This cascaded into a full workload deadlock because all other requests piled up in the latch manager.

This deadlock was introduced in 0e4fac5. That change made it possible for semi-synchronous intent resolution to begin on the read-write path before a request had released its latches. Specifically, in that issue we saw an EndTxn that hit a TransactionAbortedError run into this bug. This case is now tested in `TestEndTxnWithErrorAndSyncIntentResolution`. Before this commit, the test successfully reproduced the deadlock.

It turns out that this has also been very close to a bug in the read-only path for years. In fact, I believe it was broken or almost broken from the very first commit that introduced this semi-synchronous intent resolution: 9858253. Even in that commit, we see that latches (at the time, the CommandQueue) are held during the call to (poorly named) `processIntentsAsync` in `addReadOnlyCmd`. I believe the saving grace here was that we only seem to populate the Intents field on the LocalResult for INCONSISTENT reads, which don't hold latches and therefore can't create the deadlock. But if that's really the case then I don't understand https://github.com/cockroachdb/cockroach/blob/29c0efdcc5edb5d100449a093b25df107f1df2d6/pkg/kv/kvserver/replica_read.go#L144. Either way, this prevented me from hitting a deadlock here or writing a test for this specific case.

I've tested this with 20 iterations of `cdc/tpcc-1000/rangefeed=true` and it has been stable throughout. I'll spin up another 30 tonight.

Release notes (bug fix): a bug that could cause a workload to stall under heavy load has been fixed. This stall was due to a deadlock that was introduced in an earlier v20.1 release.

Release justification: fixes a high-priority bug in existing functionality. The bug could result in full-workload deadlocks under heavy load.