### PR TITLE
rowexec: release buckets from hash aggregator eagerly

### DIFF
--- a/pkg/cmd/roachtest/alterpk.go
+++ b/pkg/cmd/roachtest/alterpk.go
@@ -89,8 +89,7 @@ func registerAlterPK(r *testRegistry) {
 
 	// runAlterPKTPCC runs a primary key change while the TPCC workload runs.
 	runAlterPKTPCC := func(ctx context.Context, t *test, c *cluster) {
-		// TODO(yuzefovich): increase this back to 500 once #47205 is resolved.
-		const warehouses = 100
+		const warehouses = 500
 		const duration = 10 * time.Minute
 
 		roachNodes, loadNode := setupTest(ctx, t, c)


### PR DESCRIPTION
**rowexec: release buckets from hash aggregator eagerly**

This commit makes hash aggregator release the memory under buckets
eagerly (once we're done with the bucket) so that it is returned to the
system. This can matter a lot when we have large number of buckets (on
the order of 100k). Previously, this would happen only on the flow
shutdown, once we're losing the references to `hashAggregator`
processor. But it was problematic - we "released" the associated memory
from the memory accounting, yet we were holding the references still.
With this commit we will reduce the memory footprint and we'll be a lot
closer to what our memory accounting thinks we're using.

Fixes: #47205.

Release note: None

**roachtest: bump number of warehouses in alterpk-tpcc**

Release note: None