### PR TITLE
ui: Graph name in storage tooltips

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
@@ -17,7 +17,6 @@ import {ReactNode} from "react";
 export const CapacityGraphTooltip: React.FunctionComponent<{tooltipSelection: ReactNode}> =
   ({tooltipSelection}) => (<div>
     <dl>
-      <dt>Capacity</dt>
       <dd>
         <p>
           Usage of disk space {tooltipSelection}.
@@ -34,7 +33,6 @@ export const CapacityGraphTooltip: React.FunctionComponent<{tooltipSelection: Re
 export const LogicalBytesGraphTooltip: React.FunctionComponent =
   () => (<div>
     <dl>
-      <dt>Logical Bytes per Store</dt>
       <dd>
         <p>
           Number of logical bytes stored in


### PR DESCRIPTION
Removed Capacity (Overview, Storage dashboards) and Logical Bytes per Store (Replication dashboard) graph name in the metrics graph tooltip for avoiding redundant and potentially confusing

Resolves: #47439

Release note (ui): removed graph names in storage tooltips