### PR TITLE
closedts/provider: disable closed timestamp when targetDuration is zero

### DIFF
--- a/pkg/kv/kvserver/closedts/provider/provider.go
+++ b/pkg/kv/kvserver/closedts/provider/provider.go
@@ -131,8 +131,11 @@ func (p *Provider) runCloser(ctx context.Context) {
 	for {
 		closeFraction := closedts.CloseFraction.Get(&p.cfg.Settings.SV)
 		targetDuration := float64(closedts.TargetDuration.Get(&p.cfg.Settings.SV))
-		t.Reset(time.Duration(closeFraction * targetDuration))
-
+		if targetDuration > 0 {
+			t.Reset(time.Duration(closeFraction * targetDuration))
+		} else {
+			t.Stop() // disable closing when the target duration is non-positive
+		}
 		select {
 		case <-p.cfg.Stopper.ShouldQuiesce():
 			return


### PR DESCRIPTION
The comment on the setting says:

```
if nonzero, attempt to provide closed timestamp notifications for timestamps
trailing cluster time by approximately this duration
```

Unfortunately, when the setting was zero (or negative) it would close
with a zero target duration which is just about the opposite of the
intended behavior.

Fixes #47010.

Release note (bug fix): Setting `kv.closed_timestamp.target_duration` to `0`
now disables the closed timestamp as was previously documented.