### PR TITLE
ui: CSS modules for BarCharts components

### DIFF
--- a/pkg/ui/.storybook/config.tsx
+++ b/pkg/ui/.storybook/config.tsx
@@ -16,6 +16,7 @@ import "nvd3/build/nv.d3.min.css";
 import "react-select/dist/react-select.css";
 import "antd/es/tooltip/style/css";
 import "styl/app.styl";
+import "./styles.css";
 
 const req = require.context("../src/", true, /.stories.tsx$/);
 

--- a/pkg/ui/.storybook/decorators/index.ts
+++ b/pkg/ui/.storybook/decorators/index.ts
@@ -1,0 +1,11 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export * from "./withRouterProvider";

--- a/pkg/ui/.storybook/decorators/withRouterProvider.tsx
+++ b/pkg/ui/.storybook/decorators/withRouterProvider.tsx
@@ -1,0 +1,31 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import {Provider} from "react-redux";
+import {ConnectedRouter, connectRouter} from "connected-react-router";
+import {createMemoryHistory} from "history";
+import { createStore, combineReducers } from "redux";
+import {RenderFunction} from "storybook__react";
+
+const history = createMemoryHistory();
+const routerReducer = connectRouter(history);
+
+const store = createStore(combineReducers({
+  router: routerReducer,
+}));
+
+export const withRouterProvider = (storyFn: RenderFunction) => (
+  <Provider store={store}>
+    <ConnectedRouter history={history}>
+      { storyFn() }
+    </ConnectedRouter>
+  </Provider>
+);

--- a/pkg/ui/.storybook/styles.css
+++ b/pkg/ui/.storybook/styles.css
@@ -1,0 +1,3 @@
+body {
+  min-width: unset;
+}

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -50,7 +50,7 @@
     "@types/assert": "^1.4.0",
     "@types/bytebuffer": "^5.0.33",
     "@types/chai": "^4.1.0",
-    "@types/classnames": "^0.0.32",
+    "@types/classnames": "^2.2.10",
     "@types/combokeys": "^2.4.5",
     "@types/d3": "<4.0.0",
     "@types/d3-dispatch": "^1.0.4",

--- a/pkg/ui/src/interfaces/css-modules.d.ts
+++ b/pkg/ui/src/interfaces/css-modules.d.ts
@@ -1,0 +1,11 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+declare module '*.module.styl'

--- a/pkg/ui/src/views/statements/barCharts.module.styl
+++ b/pkg/ui/src/views/statements/barCharts.module.styl
@@ -1,0 +1,77 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@require '~styl/base/palette.styl'
+@require '~src/components/core/index'
+
+.bar-chart
+  height 14px
+  position relative
+  display flex
+  align-items center
+  flex-direction row
+  > span
+    width 100%
+    display flex
+    align-items center
+    flex-direction row
+
+  &__multiplebars
+    width calc(100% - 75px)
+    border-radius 3px
+    position relative
+    display flex
+    align-items center
+
+  &__label
+    position relative
+    font-family SourceSansPro-Regular
+    font-size 12px
+    line-height 1.83
+    color $adminui-grey-1
+    width 75px
+
+  &__bar
+    display inline-block
+    height 13px
+    border-radius 3px
+
+    &--dev
+      position absolute
+      height 3px
+
+  .count-first-try, .count-total, .count-retry, .count-max-retries
+    border-radius 3px
+    position absolute
+    left 40px
+
+  .count-first-try, .count-total
+    background-color $grey-light
+  .count-retry, .count-max-retries
+    background-color $alert-color
+
+  .rows
+    background-color $grey-light
+    border-radius 3px
+
+  .rows-dev
+    background-color $colors--primary-blue-3
+
+  .bar-chart
+    &__parse, &__plan, &__run, &__overhead, &__overall
+      background-color $colors--neutral-4
+
+  &-red
+    .bar-chart
+      &__parse, &__plan, &__run, &__overhead, &__overall
+        background-color $colors--functional-red-2
+
+  &__parse-dev, &__plan-dev, &__run-dev, &__overhead-dev, &__overall-dev
+    background-color $colors--primary-blue-3

--- a/pkg/ui/src/views/statements/barCharts.stories.tsx
+++ b/pkg/ui/src/views/statements/barCharts.stories.tsx
@@ -1,0 +1,80 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { storiesOf, RenderFunction } from "@storybook/react";
+
+import { countBarChart, latencyBarChart, retryBarChart, rowsBarChart } from "./barCharts";
+import statementsPagePropsFixture from "./statementsPage.fixture";
+
+const { statements } = statementsPagePropsFixture;
+
+const withinColumn = (width = "150px") => (storyFn: RenderFunction) => {
+  const rowStyle = {
+    borderTop: "1px solid #e7ecf3",
+    borderBottom: "1px solid #e7ecf3",
+  };
+
+  const cellStyle = {
+    width: "190px",
+    padding: "10px 20px",
+  };
+
+  return (
+    <table>
+      <tbody>
+      <tr style={rowStyle}>
+        <td style={cellStyle}>
+          <div style={{ width }}>
+            { storyFn() }
+          </div>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  );
+};
+
+storiesOf("BarCharts", module)
+  .add("countBarChart", () => {
+    const chartFactory = countBarChart(statements);
+    return chartFactory(statements[0]);
+  })
+  .add("latencyBarChart", () => {
+    const chartFactory = latencyBarChart(statements);
+    return chartFactory(statements[0]);
+  })
+  .add("retryBarChart", () => {
+    const chartFactory = retryBarChart(statements);
+    return chartFactory(statements[0]);
+  })
+  .add("rowsBarChart", () => {
+    const chartFactory = rowsBarChart(statements);
+    return chartFactory(statements[0]);
+  });
+
+storiesOf("BarCharts/within column (150px)", module)
+  .addDecorator(withinColumn())
+  .add("countBarChart", () => {
+    const chartFactory = countBarChart(statements);
+    return chartFactory(statements[0]);
+  })
+  .add("latencyBarChart", () => {
+    const chartFactory = latencyBarChart(statements);
+    return chartFactory(statements[0]);
+  })
+  .add("retryBarChart", () => {
+    const chartFactory = retryBarChart(statements);
+    return chartFactory(statements[0]);
+  })
+  .add("rowsBarChart", () => {
+    const chartFactory = rowsBarChart(statements);
+    return chartFactory(statements[0]);
+  });

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -24,6 +24,13 @@ type StatementStatistics = protos.cockroach.server.serverpb.StatementsResponse.I
 
 const cx = classNames.bind(styles);
 
+interface BarChartOptions {
+  classes?: {
+    root?: string;
+    label?: string;
+  };
+}
+
 export const longToInt = (d: number | Long) => Long.fromValue(FixLong(d)).toInt();
 const clamp = (i: number) => i < 0 ? 0 : i;
 
@@ -89,7 +96,7 @@ const makeBarChart = (
     legendFormatter = formatter;
   }
 
-  return (rows: StatementStatistics[] = []) => {
+  return (rows: StatementStatistics[] = [], options: BarChartOptions = {}) => {
     const getTotal = (d: StatementStatistics) => _.sum(_.map(accessors, ({ value }) => value(d)));
     const getTotalWithStdDev = (d: StatementStatistics) => getTotal(d) + stdDevAccessor.value(d);
 
@@ -142,6 +149,7 @@ const makeBarChart = (
 
       const className = cx("bar-chart", `bar-chart-${type}`, {
         "bar-chart--singleton": rows.length === 0,
+        [options?.classes?.root]: !!options?.classes?.root,
       });
       if (stdDevAccessor) {
         const sd = stdDevAccessor.value(d);
@@ -149,7 +157,7 @@ const makeBarChart = (
         return (
           <div className={ className}>
             <ToolTipWrapper text={ titleText } short>
-              <div className={cx("bar-chart__label")}>{ formatter(getTotal(d)) }</div>
+              <div className={cx("bar-chart__label", options?.classes?.label)}>{ formatter(getTotal(d)) }</div>
               <div className={cx("bar-chart__multiplebars")}>
                 <div
                   key="bar-chart__parse"
@@ -164,7 +172,7 @@ const makeBarChart = (
       } else {
         return (
           <div className={className}>
-            <div className={cx("bar-chart__label")}>{ formatter(getTotal(d)) }</div>
+            <div className={cx("bar-chart__label", options?.classes?.label)}>{ formatter(getTotal(d)) }</div>
             <div
               key="bar-chart__parse"
               className={cx("bar-chart__parse", "bar-chart__bar")}

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -17,10 +17,12 @@ import { stdDevLong } from "src/util/appStats";
 import { FixLong } from "src/util/fixLong";
 import { Duration } from "src/util/format";
 import { ToolTipWrapper } from "src/views/shared/components/toolTip";
-import classNames from "classnames";
+import classNames from "classnames/bind";
 import styles from "./barCharts.module.styl";
 
 type StatementStatistics = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
+
+const cx = classNames.bind(styles);
 
 export const longToInt = (d: number | Long) => Long.fromValue(FixLong(d)).toInt();
 const clamp = (i: number) => i < 0 ? 0 : i;
@@ -46,8 +48,8 @@ const latencyBars = [
   bar("bar-chart__overhead", (d: StatementStatistics) => d.stats.overhead_lat.mean),
 ];
 
-const latencyStdDev = bar(styles[`bar-chart__overall-dev`], (d: StatementStatistics) => stdDevLong(d.stats.service_lat, d.stats.count));
-const rowsStdDev = bar(styles[`rows-dev`], (d: StatementStatistics) => stdDevLong(d.stats.num_rows, d.stats.count));
+const latencyStdDev = bar(cx("bar-chart__overall-dev"), (d: StatementStatistics) => stdDevLong(d.stats.service_lat, d.stats.count));
+const rowsStdDev = bar(cx("rows-dev"), (d: StatementStatistics) => stdDevLong(d.stats.num_rows, d.stats.count));
 
 function bar(name: string, value: (d: StatementStatistics) => number) {
   return { name, value };
@@ -55,18 +57,18 @@ function bar(name: string, value: (d: StatementStatistics) => number) {
 
 function renderNumericStatLegend(count: number | Long, stat: number, sd: number, formatter: (d: number) => string) {
   return (
-    <table className={styles["numeric-stat-legend"]}>
+    <table className={cx("numeric-stat-legend")}>
       <tbody>
         <tr>
           <th>
-            <div className={`${styles["numeric-stat-legend__bar"]} ${styles["numeric-stat-legend__bar--mean"]}`} />
+            <div className={cx("numeric-stat-legend__bar", "numeric-stat-legend__bar--mean")} />
             Mean
           </th>
           <td>{ formatter(stat) }</td>
         </tr>
         <tr>
           <th>
-            <div className={`${styles["numeric-stat-legend__bar"]} ${styles["numeric-stat-legend__bar--dev"]}`} />
+            <div className={cx("numeric-stat-legend__bar", "numeric-stat-legend__bar--dev")} />
             Standard Deviation
           </th>
           <td>{ longToInt(count) < 2 ? "-" : sd ? formatter(sd) : "0" }</td>
@@ -109,7 +111,7 @@ const makeBarChart = (
         return (
           <div
             key={ name + v }
-            className={`${name} ${styles["bar-chart__bar"]}`}
+            className={cx(name, "bar-chart__bar")}
             style={{ width: scale(v) + "%" }}
           />
         );
@@ -125,7 +127,7 @@ const makeBarChart = (
         const stddev = value(d);
         const width = stddev + (stddev > sum ? sum : stddev);
         const left = stddev > sum ? 0 : sum - stddev;
-        const cn = classNames(name, styles["bar-chart__bar"], styles["bar-chart__bar--dev"]);
+        const cn = cx(name, "bar-chart__bar", "bar-chart__bar--dev");
         const style = {
           width: scale(width) + "%",
           left: scale(left) + "%",
@@ -138,8 +140,8 @@ const makeBarChart = (
         );
       };
 
-      const className = classNames(styles["bar-chart"], styles[`bar-chart-${type}`], {
-        [styles["bar-chart--singleton"]]: rows.length === 0,
+      const className = cx("bar-chart", `bar-chart-${type}`, {
+        "bar-chart--singleton": rows.length === 0,
       });
       if (stdDevAccessor) {
         const sd = stdDevAccessor.value(d);
@@ -147,11 +149,11 @@ const makeBarChart = (
         return (
           <div className={ className}>
             <ToolTipWrapper text={ titleText } short>
-              <div className={styles["bar-chart__label"]}>{ formatter(getTotal(d)) }</div>
-              <div className={styles["bar-chart__multiplebars"]}>
+              <div className={cx("bar-chart__label")}>{ formatter(getTotal(d)) }</div>
+              <div className={cx("bar-chart__multiplebars")}>
                 <div
                   key="bar-chart__parse"
-                  className={classNames([styles["bar-chart__parse"], styles["bar-chart__bar"]])}
+                  className={cx("bar-chart__parse", "bar-chart__bar")}
                   style={{ width: scale(getTotal(d)) + "%" }}
                 />
                 { renderStdDev() }
@@ -162,10 +164,10 @@ const makeBarChart = (
       } else {
         return (
           <div className={className}>
-            <div className={styles["bar-chart__label"]}>{ formatter(getTotal(d)) }</div>
+            <div className={cx("bar-chart__label")}>{ formatter(getTotal(d)) }</div>
             <div
               key="bar-chart__parse"
-              className={classNames([styles["bar-chart__parse"], styles["bar-chart__bar"]])}
+              className={cx("bar-chart__parse", "bar-chart__bar")}
               style={{ width: scale(getTotal(d)) + "%" }}
             />
           </div>
@@ -255,15 +257,15 @@ export function latencyBreakdown(s: StatementStatistics) {
       const title = renderNumericStatLegend(s.stats.count, parseMean, parseSd, format);
       return (
         <ToolTipWrapper text={ title } short>
-          <div className={`${styles["bar-chart"]} ${styles["bar-chart--breakdown"]}`}>
-            <div className={styles["bar-chart__label"]}>{ Duration(parseMean * 1e9) }</div>
-            <div className={styles["bar-chart__multiplebars"]}>
+          <div className={cx("bar-chart", "bar-chart--breakdown")}>
+            <div className={cx("bar-chart__label")}>{ Duration(parseMean * 1e9) }</div>
+            <div className={cx("bar-chart__multiplebars")}>
               <div
-                className={`${styles["bar-chart__parse"]} ${styles["bar-chart__bar"]}`}
+                className={cx("bar-chart__parse", "bar-chart__bar")}
                 style={{ width: right + "%", position: "absolute", left: 0 }}
               />
               <div
-                className={`${styles["bar-chart__parse-dev"]} ${styles["bar-chart__bar"]} ${styles["bar-chart__bar--dev"]}`}
+                className={cx("bar-chart__parse-dev", "bar-chart__bar", "bar-chart__bar--dev")}
                 style={{ width: spread + "%", position: "absolute", left: width + "%" }}
               />
             </div>
@@ -280,22 +282,15 @@ export function latencyBreakdown(s: StatementStatistics) {
       const title = renderNumericStatLegend(s.stats.count, planMean, planSd, format);
       return (
         <ToolTipWrapper text={ title } short>
-          <div className={classNames([
-            styles["bar-chart"],
-            styles["bar-chart--breakdown"],
-          ])}>
-            <div className={styles["bar-chart__label"]}>{ Duration(planMean * 1e9) }</div>
-            <div className={styles["bar-chart__multiplebars"]}>
+          <div className={cx("bar-chart", "bar-chart--breakdown")}>
+            <div className={cx("bar-chart__label")}>{ Duration(planMean * 1e9) }</div>
+            <div className={cx("bar-chart__multiplebars")}>
               <div
-                className={classNames(styles[`bar-chart__plan`], styles[`bar-chart__bar`])}
+                className={cx("bar-chart__plan", "bar-chart__bar")}
                 style={{ width: right + "%", position: "absolute", left: left + "%" }}
               />
               <div
-                className={classNames([
-                  styles["bar-chart__plan-dev"],
-                  styles["bar-chart__bar"],
-                  styles["bar-chart__bar--dev"],
-                ])}
+                className={cx("bar-chart__plan-dev", "bar-chart__bar", "bar-chart__bar--dev")}
                 style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
               />
             </div>
@@ -312,22 +307,15 @@ export function latencyBreakdown(s: StatementStatistics) {
       const title = renderNumericStatLegend(s.stats.count, runMean, runSd, format);
       return (
         <ToolTipWrapper text={ title } short>
-          <div className={classNames([
-            styles["bar-chart"],
-            styles["bar-chart--breakdown"],
-          ])}>
-            <div className={styles["bar-chart__label"]}>{ Duration(runMean * 1e9) }</div>
-            <div className={styles["bar-chart__multiplebars"]}>
+          <div className={cx("bar-chart", "bar-chart--breakdown")}>
+            <div className={cx("bar-chart__label")}>{ Duration(runMean * 1e9) }</div>
+            <div className={cx("bar-chart__multiplebars")}>
               <div
-                className={classNames([styles["bar-chart__run"], styles["bar-chart__bar"]])}
+                className={cx("bar-chart__run", "bar-chart__bar")}
                 style={{ width: right + "%", position: "absolute", left: left + "%" }}
               />
               <div
-                className={classNames([
-                  styles["bar-chart__run-dev"],
-                  styles["bar-chart__bar"],
-                  styles["bar-chart__bar--dev"],
-                ])}
+                className={cx("bar-chart__run-dev", "bar-chart__bar", "bar-chart__bar--dev")}
                 style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
               />
             </div>
@@ -344,19 +332,15 @@ export function latencyBreakdown(s: StatementStatistics) {
       const title = renderNumericStatLegend(s.stats.count, overheadMean, overheadSd, format);
       return (
         <ToolTipWrapper text={ title } short>
-          <div className={classNames([styles["bar-chart"], styles["bar-chart--breakdown"]])}>
-            <div className={styles["bar-chart__label"]}>{ Duration(overheadMean * 1e9) }</div>
-            <div className={styles["bar-chart__multiplebars"]}>
+          <div className={cx("bar-chart", "bar-chart--breakdown")}>
+            <div className={cx("bar-chart__label")}>{ Duration(overheadMean * 1e9) }</div>
+            <div className={cx("bar-chart__multiplebars")}>
               <div
-                className={classNames([styles["bar-chart__overhead"], styles["bar-chart__bar"]])}
+                className={cx("bar-chart__overhead", "bar-chart__bar")}
                 style={{ width: right + "%", position: "absolute", left: left + "%" }}
               />
               <div
-                className={classNames([
-                  styles["bar-chart__overhead-dev"],
-                  styles["bar-chart__bar"],
-                  styles["bar-chart__bar--dev"],
-                ])}
+                className={cx("bar-chart__overhead-dev", "bar-chart__bar", "bar-chart__bar--dev")}
                 style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
               />
             </div>
@@ -375,19 +359,15 @@ export function latencyBreakdown(s: StatementStatistics) {
       const title = renderNumericStatLegend(s.stats.count, overallMean, overallSd, format);
       return (
         <ToolTipWrapper text={ title } short>
-          <div className={classNames([styles["bar-chart"], styles["bar-chart--breakdown"]])}>
-            <div className={styles["bar-chart__label"]}>{ Duration(overallMean * 1e9) }</div>
-            <div className={styles["bar-chart__multiplebars"]}>
+          <div className={cx("bar-chart", "bar-chart--breakdown")}>
+            <div className={cx("bar-chart__label")}>{ Duration(overallMean * 1e9) }</div>
+            <div className={cx("bar-chart__multiplebars")}>
               <div
-                className={classNames([styles["bar-chart__parse"], styles["bar-chart__bar"]])}
+                className={cx("bar-chart__parse", "bar-chart__bar")}
                 style={{ width: parse + plan + run + overhead + "%", position: "absolute", left: 0 }}
               />
               <div
-                className={classNames([
-                  styles["bar-chart__overall-dev"],
-                  styles["bar-chart__bar"],
-                  styles["bar-chart__bar--dev"],
-                ])}
+                className={cx("bar-chart__overall-dev", "bar-chart__bar", "bar-chart__bar--dev")}
                 style={{ width: spread + "%", position: "absolute", left: width + "%" }}
               />
             </div>

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -18,6 +18,7 @@ import { FixLong } from "src/util/fixLong";
 import { Duration } from "src/util/format";
 import { ToolTipWrapper } from "src/views/shared/components/toolTip";
 import classNames from "classnames";
+import styles from "./barCharts.module.styl";
 
 type StatementStatistics = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 
@@ -45,8 +46,8 @@ const latencyBars = [
   bar("bar-chart__overhead", (d: StatementStatistics) => d.stats.overhead_lat.mean),
 ];
 
-const latencyStdDev = bar("bar-chart__overall-dev", (d: StatementStatistics) => stdDevLong(d.stats.service_lat, d.stats.count));
-const rowsStdDev = bar("rows-dev", (d: StatementStatistics) => stdDevLong(d.stats.num_rows, d.stats.count));
+const latencyStdDev = bar(styles[`bar-chart__overall-dev`], (d: StatementStatistics) => stdDevLong(d.stats.service_lat, d.stats.count));
+const rowsStdDev = bar(styles[`rows-dev`], (d: StatementStatistics) => stdDevLong(d.stats.num_rows, d.stats.count));
 
 function bar(name: string, value: (d: StatementStatistics) => number) {
   return { name, value };
@@ -54,18 +55,18 @@ function bar(name: string, value: (d: StatementStatistics) => number) {
 
 function renderNumericStatLegend(count: number | Long, stat: number, sd: number, formatter: (d: number) => string) {
   return (
-    <table className="numeric-stat-legend">
+    <table className={styles["numeric-stat-legend"]}>
       <tbody>
         <tr>
           <th>
-            <div className="numeric-stat-legend__bar numeric-stat-legend__bar--mean" />
+            <div className={`${styles["numeric-stat-legend__bar"]} ${styles["numeric-stat-legend__bar--mean"]}`} />
             Mean
           </th>
           <td>{ formatter(stat) }</td>
         </tr>
         <tr>
           <th>
-            <div className="numeric-stat-legend__bar numeric-stat-legend__bar--dev" />
+            <div className={`${styles["numeric-stat-legend__bar"]} ${styles["numeric-stat-legend__bar--dev"]}`} />
             Standard Deviation
           </th>
           <td>{ longToInt(count) < 2 ? "-" : sd ? formatter(sd) : "0" }</td>
@@ -108,7 +109,7 @@ const makeBarChart = (
         return (
           <div
             key={ name + v }
-            className={ name + " bar-chart__bar" }
+            className={`${name} ${styles["bar-chart__bar"]}`}
             style={{ width: scale(v) + "%" }}
           />
         );
@@ -124,7 +125,7 @@ const makeBarChart = (
         const stddev = value(d);
         const width = stddev + (stddev > sum ? sum : stddev);
         const left = stddev > sum ? 0 : sum - stddev;
-        const cn = classNames(name, "bar-chart__bar", "bar-chart__bar--dev");
+        const cn = classNames(name, styles["bar-chart__bar"], styles["bar-chart__bar--dev"]);
         const style = {
           width: scale(width) + "%",
           left: scale(left) + "%",
@@ -137,8 +138,8 @@ const makeBarChart = (
         );
       };
 
-      const className = classNames("bar-chart", `bar-chart-${type}`, {
-        "bar-chart--singleton": rows.length === 0,
+      const className = classNames(styles["bar-chart"], styles[`bar-chart-${type}`], {
+        [styles["bar-chart--singleton"]]: rows.length === 0,
       });
       if (stdDevAccessor) {
         const sd = stdDevAccessor.value(d);
@@ -146,11 +147,11 @@ const makeBarChart = (
         return (
           <div className={ className}>
             <ToolTipWrapper text={ titleText } short>
-              <div className="bar-chart__label">{ formatter(getTotal(d)) }</div>
-              <div className="bar-chart__multiplebars">
+              <div className={styles["bar-chart__label"]}>{ formatter(getTotal(d)) }</div>
+              <div className={styles["bar-chart__multiplebars"]}>
                 <div
                   key="bar-chart__parse"
-                  className="bar-chart__parse bar-chart__bar"
+                  className={classNames([styles["bar-chart__parse"], styles["bar-chart__bar"]])}
                   style={{ width: scale(getTotal(d)) + "%" }}
                 />
                 { renderStdDev() }
@@ -161,10 +162,10 @@ const makeBarChart = (
       } else {
         return (
           <div className={className}>
-            <div className="bar-chart__label">{ formatter(getTotal(d)) }</div>
+            <div className={styles["bar-chart__label"]}>{ formatter(getTotal(d)) }</div>
             <div
               key="bar-chart__parse"
-              className="bar-chart__parse bar-chart__bar"
+              className={classNames([styles["bar-chart__parse"], styles["bar-chart__bar"]])}
               style={{ width: scale(getTotal(d)) + "%" }}
             />
           </div>
@@ -254,15 +255,15 @@ export function latencyBreakdown(s: StatementStatistics) {
       const title = renderNumericStatLegend(s.stats.count, parseMean, parseSd, format);
       return (
         <ToolTipWrapper text={ title } short>
-          <div className="bar-chart bar-chart--breakdown">
-            <div className="bar-chart__label">{ Duration(parseMean * 1e9) }</div>
-            <div className="bar-chart__multiplebars">
+          <div className={`${styles["bar-chart"]} ${styles["bar-chart--breakdown"]}`}>
+            <div className={styles["bar-chart__label"]}>{ Duration(parseMean * 1e9) }</div>
+            <div className={styles["bar-chart__multiplebars"]}>
               <div
-                className="bar-chart__parse bar-chart__bar"
+                className={`${styles["bar-chart__parse"]} ${styles["bar-chart__bar"]}`}
                 style={{ width: right + "%", position: "absolute", left: 0 }}
               />
               <div
-                className="bar-chart__parse-dev bar-chart__bar bar-chart__bar--dev"
+                className={`${styles["bar-chart__parse-dev"]} ${styles["bar-chart__bar"]} ${styles["bar-chart__bar--dev"]}`}
                 style={{ width: spread + "%", position: "absolute", left: width + "%" }}
               />
             </div>
@@ -279,15 +280,22 @@ export function latencyBreakdown(s: StatementStatistics) {
       const title = renderNumericStatLegend(s.stats.count, planMean, planSd, format);
       return (
         <ToolTipWrapper text={ title } short>
-          <div className="bar-chart bar-chart--breakdown">
-            <div className="bar-chart__label">{ Duration(planMean * 1e9) }</div>
-            <div className="bar-chart__multiplebars">
+          <div className={classNames([
+            styles["bar-chart"],
+            styles["bar-chart--breakdown"],
+          ])}>
+            <div className={styles["bar-chart__label"]}>{ Duration(planMean * 1e9) }</div>
+            <div className={styles["bar-chart__multiplebars"]}>
               <div
-                className="bar-chart__plan bar-chart__bar"
+                className={classNames(styles[`bar-chart__plan`], styles[`bar-chart__bar`])}
                 style={{ width: right + "%", position: "absolute", left: left + "%" }}
               />
               <div
-                className="bar-chart__plan-dev bar-chart__bar bar-chart__bar--dev"
+                className={classNames([
+                  styles["bar-chart__plan-dev"],
+                  styles["bar-chart__bar"],
+                  styles["bar-chart__bar--dev"],
+                ])}
                 style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
               />
             </div>
@@ -304,15 +312,22 @@ export function latencyBreakdown(s: StatementStatistics) {
       const title = renderNumericStatLegend(s.stats.count, runMean, runSd, format);
       return (
         <ToolTipWrapper text={ title } short>
-          <div className="bar-chart bar-chart--breakdown">
-            <div className="bar-chart__label">{ Duration(runMean * 1e9) }</div>
-            <div className="bar-chart__multiplebars">
+          <div className={classNames([
+            styles["bar-chart"],
+            styles["bar-chart--breakdown"],
+          ])}>
+            <div className={styles["bar-chart__label"]}>{ Duration(runMean * 1e9) }</div>
+            <div className={styles["bar-chart__multiplebars"]}>
               <div
-                className="bar-chart__run bar-chart__bar"
+                className={classNames([styles["bar-chart__run"], styles["bar-chart__bar"]])}
                 style={{ width: right + "%", position: "absolute", left: left + "%" }}
               />
               <div
-                className="bar-chart__run-dev bar-chart__bar bar-chart__bar--dev"
+                className={classNames([
+                  styles["bar-chart__run-dev"],
+                  styles["bar-chart__bar"],
+                  styles["bar-chart__bar--dev"],
+                ])}
                 style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
               />
             </div>
@@ -329,15 +344,19 @@ export function latencyBreakdown(s: StatementStatistics) {
       const title = renderNumericStatLegend(s.stats.count, overheadMean, overheadSd, format);
       return (
         <ToolTipWrapper text={ title } short>
-          <div className="bar-chart bar-chart--breakdown">
-            <div className="bar-chart__label">{ Duration(overheadMean * 1e9) }</div>
-            <div className="bar-chart__multiplebars">
+          <div className={classNames([styles["bar-chart"], styles["bar-chart--breakdown"]])}>
+            <div className={styles["bar-chart__label"]}>{ Duration(overheadMean * 1e9) }</div>
+            <div className={styles["bar-chart__multiplebars"]}>
               <div
-                className="bar-chart__overhead bar-chart__bar"
+                className={classNames([styles["bar-chart__overhead"], styles["bar-chart__bar"]])}
                 style={{ width: right + "%", position: "absolute", left: left + "%" }}
               />
               <div
-                className="bar-chart__overhead-dev bar-chart__bar bar-chart__bar--dev"
+                className={classNames([
+                  styles["bar-chart__overhead-dev"],
+                  styles["bar-chart__bar"],
+                  styles["bar-chart__bar--dev"],
+                ])}
                 style={{ width: spread + "%", position: "absolute", left: width + left + "%" }}
               />
             </div>
@@ -356,15 +375,19 @@ export function latencyBreakdown(s: StatementStatistics) {
       const title = renderNumericStatLegend(s.stats.count, overallMean, overallSd, format);
       return (
         <ToolTipWrapper text={ title } short>
-          <div className="bar-chart bar-chart--breakdown">
-            <div className="bar-chart__label">{ Duration(overallMean * 1e9) }</div>
-            <div className="bar-chart__multiplebars">
+          <div className={classNames([styles["bar-chart"], styles["bar-chart--breakdown"]])}>
+            <div className={styles["bar-chart__label"]}>{ Duration(overallMean * 1e9) }</div>
+            <div className={styles["bar-chart__multiplebars"]}>
               <div
-                className="bar-chart__parse bar-chart__bar"
+                className={classNames([styles["bar-chart__parse"], styles["bar-chart__bar"]])}
                 style={{ width: parse + plan + run + overhead + "%", position: "absolute", left: 0 }}
               />
               <div
-                className="bar-chart__overall-dev bar-chart__bar bar-chart__bar--dev"
+                className={classNames([
+                  styles["bar-chart__overall-dev"],
+                  styles["bar-chart__bar"],
+                  styles["bar-chart__bar--dev"],
+                ])}
                 style={{ width: spread + "%", position: "absolute", left: width + "%" }}
               />
             </div>

--- a/pkg/ui/src/views/statements/statementsPage.fixture.ts
+++ b/pkg/ui/src/views/statements/statementsPage.fixture.ts
@@ -1,0 +1,397 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { StatementsPageProps } from "./statementsPage";
+import { createMemoryHistory } from "history";
+import Long from "long";
+import * as protos from "src/js/protos";
+import {refreshStatementDiagnosticsRequests, refreshStatements} from "src/redux/apiReducers";
+type IStatementStatistics = protos.cockroach.sql.IStatementStatistics;
+
+const history = createMemoryHistory({ initialEntries: ["/statements"]});
+
+const statementStats: IStatementStatistics = {
+  "count": Long.fromNumber(3),
+  "first_attempt_count": Long.fromNumber(1),
+  "max_retries": Long.fromNumber(10),
+  "num_rows": {
+    "mean": 1,
+    "squared_diffs": 0,
+  },
+  "parse_lat": {
+    "mean": 0,
+    "squared_diffs": 0,
+  },
+  "plan_lat": {
+    "mean": 0.00018,
+    "squared_diffs": 5.4319999999999994e-9,
+  },
+  "run_lat": {
+    "mean": 0.0022536666666666664,
+    "squared_diffs": 0.0000020303526666666667,
+  },
+  "service_lat": {
+    "mean": 0.002496,
+    "squared_diffs": 0.000002308794,
+  },
+  "overhead_lat": {
+    "mean": 0.00006233333333333315,
+    "squared_diffs": 5.786666666666667e-10,
+  },
+  "sensitive_info": {
+    "last_err": "",
+    "most_recent_plan_description": {
+      "name": "root",
+      "children": [
+        {
+          "name": "render",
+          "attrs": [
+            {
+              "key": "render",
+              "value": "COALESCE(a, b)",
+            },
+          ],
+          "children": [
+            {
+              "name": "values",
+              "attrs": [
+                {
+                  "key": "size",
+                  "value": "2 columns, 1 row",
+                },
+                {
+                  "key": "row 0, expr",
+                  "value": "(SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _)",
+                },
+                {
+                  "key": "row 0, expr",
+                  "value": "(SELECT code FROM promo_codes ORDER BY code LIMIT _)",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          "name": "subquery",
+          "attrs": [
+            {
+              "key": "id",
+              "value": "@S1",
+            },
+            {
+              "key": "original sql",
+              "value": "(SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _)",
+            },
+            {
+              "key": "exec mode",
+              "value": "one row",
+            },
+          ],
+          "children": [
+            {
+              "name": "scan",
+              "attrs": [
+                {
+                  "key": "table",
+                  "value": "promo_codes@primary",
+                },
+                {
+                  "key": "spans",
+                  "value": "1 span",
+                },
+                {
+                  "key": "limit",
+                  "value": "1",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          "name": "subquery",
+          "attrs": [
+            {
+              "key": "id",
+              "value": "@S2",
+            },
+            {
+              "key": "original sql",
+              "value": "(SELECT code FROM promo_codes ORDER BY code LIMIT _)",
+            },
+            {
+              "key": "exec mode",
+              "value": "one row",
+            },
+          ],
+          "children": [
+            {
+              "name": "scan",
+              "attrs": [
+                {
+                  "key": "table",
+                  "value": "promo_codes@primary",
+                },
+                {
+                  "key": "spans",
+                  "value": "ALL",
+                },
+                {
+                  "key": "limit",
+                  "value": "1",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
+};
+
+const statementsPagePropsFixture: StatementsPageProps = {
+  history,
+  location: {
+    "pathname": "/statements",
+    "search": "",
+    "hash": "",
+    "state": null,
+  },
+  "match": {
+    "path": "/statements",
+    "url": "/statements",
+    "isExact": true,
+    "params": {},
+  },
+  "statements": [
+    {
+      "label": "SELECT IFNULL(a, b) FROM (SELECT (SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _) AS a, (SELECT code FROM promo_codes ORDER BY code LIMIT _) AS b)",
+      "implicitTxn": true,
+      stats: statementStats,
+    },
+    {
+      "label": "INSERT INTO vehicles VALUES ($1, $2, __more6__)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SELECT IFNULL(a, b) FROM (SELECT (SELECT id FROM users WHERE (city = $1) AND (id > $2) ORDER BY id LIMIT _) AS a, (SELECT id FROM users WHERE city = $1 ORDER BY id LIMIT _) AS b)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "UPSERT INTO vehicle_location_histories VALUES ($1, $2, now(), $3, $4)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "INSERT INTO user_promo_codes VALUES ($1, $2, $3, now(), _)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SELECT city, id FROM vehicles WHERE city = $1",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "INSERT INTO rides VALUES ($1, $2, $2, $3, $4, $5, _, now(), _, $6)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SELECT IFNULL(a, b) FROM (SELECT (SELECT id FROM vehicles WHERE (city = $1) AND (id > $2) ORDER BY id LIMIT _) AS a, (SELECT id FROM vehicles WHERE city = $1 ORDER BY id LIMIT _) AS b)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "UPDATE rides SET end_address = $3, end_time = now() WHERE (city = $1) AND (id = $2)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "INSERT INTO users VALUES ($1, $2, __more3__)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SELECT count(*) FROM user_promo_codes WHERE ((city = $1) AND (user_id = $2)) AND (code = $3)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "INSERT INTO promo_codes VALUES ($1, $2, __more3__)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE users SCATTER FROM (_, _) TO (_, _)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE rides ADD FOREIGN KEY (vehicle_city, vehicle_id) REFERENCES vehicles (city, id)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SHOW database",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE users SPLIT AT VALUES (_, _)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE vehicles SCATTER FROM (_, _) TO (_, _)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE vehicle_location_histories ADD FOREIGN KEY (city, ride_id) REFERENCES rides (city, id)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "CREATE TABLE IF NOT EXISTS user_promo_codes (city VARCHAR NOT NULL, user_id UUID NOT NULL, code VARCHAR NOT NULL, \"timestamp\" TIMESTAMP NULL, usage_count INT8 NULL, PRIMARY KEY (city ASC, user_id ASC, code ASC))",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "INSERT INTO users VALUES ($1, $2, __more3__), (__more40__)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE rides SCATTER FROM (_, _) TO (_, _)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SET CLUSTER SETTING \"cluster.organization\" = $1",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE vehicles ADD FOREIGN KEY (city, owner_id) REFERENCES users (city, id)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "CREATE TABLE IF NOT EXISTS rides (id UUID NOT NULL, city VARCHAR NOT NULL, vehicle_city VARCHAR NULL, rider_id UUID NULL, vehicle_id UUID NULL, start_address VARCHAR NULL, end_address VARCHAR NULL, start_time TIMESTAMP NULL, end_time TIMESTAMP NULL, revenue DECIMAL(10,2) NULL, PRIMARY KEY (city ASC, id ASC), INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC), INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC), CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city))",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "CREATE TABLE IF NOT EXISTS vehicles (id UUID NOT NULL, city VARCHAR NOT NULL, type VARCHAR NULL, owner_id UUID NULL, creation_time TIMESTAMP NULL, status VARCHAR NULL, current_location VARCHAR NULL, ext JSONB NULL, PRIMARY KEY (city ASC, id ASC), INDEX vehicles_auto_index_fk_city_ref_users (city ASC, owner_id ASC))",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "INSERT INTO rides VALUES ($1, $2, __more8__), (__more400__)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE vehicles SPLIT AT VALUES (_, _)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SET sql_safe_updates = _",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "CREATE TABLE IF NOT EXISTS users (id UUID NOT NULL, city VARCHAR NOT NULL, name VARCHAR NULL, address VARCHAR NULL, credit_card VARCHAR NULL, PRIMARY KEY (city ASC, id ASC))",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "CREATE TABLE IF NOT EXISTS vehicle_location_histories (city VARCHAR NOT NULL, ride_id UUID NOT NULL, \"timestamp\" TIMESTAMP NOT NULL, lat FLOAT8 NULL, long FLOAT8 NULL, PRIMARY KEY (city ASC, ride_id ASC, \"timestamp\" ASC))",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SELECT * FROM crdb_internal.node_build_info",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "CREATE DATABASE movr",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SELECT count(*) > _ FROM [SHOW ALL CLUSTER SETTINGS] AS _ (v) WHERE v = _",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SET CLUSTER SETTING \"enterprise.license\" = $1",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE rides ADD FOREIGN KEY (city, rider_id) REFERENCES users (city, id)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE user_promo_codes ADD FOREIGN KEY (city, user_id) REFERENCES users (city, id)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "INSERT INTO promo_codes VALUES ($1, $2, __more3__), (__more900__)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE rides SPLIT AT VALUES (_, _)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SELECT value FROM crdb_internal.node_build_info WHERE field = _",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "INSERT INTO vehicle_location_histories VALUES ($1, $2, __more3__), (__more900__)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "INSERT INTO vehicles VALUES ($1, $2, __more6__), (__more10__)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+  ],
+  "statementsError": null,
+  "apps": [
+    "(internal)",
+    "movr",
+    "$ cockroach demo",
+  ],
+  "totalFingerprints": 95,
+  "lastReset": "2020-04-13 07:22:23",
+  dismissAlertMessage: () => {},
+  refreshStatementDiagnosticsRequests: (() => {}) as (typeof refreshStatementDiagnosticsRequests),
+  refreshStatements: (() => {}) as (typeof refreshStatements),
+};
+
+export default statementsPagePropsFixture;

--- a/pkg/ui/src/views/statements/statementsPage.fixture.ts
+++ b/pkg/ui/src/views/statements/statementsPage.fixture.ts
@@ -18,8 +18,8 @@ type IStatementStatistics = protos.cockroach.sql.IStatementStatistics;
 const history = createMemoryHistory({ initialEntries: ["/statements"]});
 
 const statementStats: IStatementStatistics = {
-  "count": Long.fromNumber(3),
-  "first_attempt_count": Long.fromNumber(1),
+  "count": Long.fromNumber(180000),
+  "first_attempt_count": Long.fromNumber(50000),
   "max_retries": Long.fromNumber(10),
   "num_rows": {
     "mean": 1,

--- a/pkg/ui/src/views/statements/statementsPage.stories.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.stories.tsx
@@ -1,0 +1,22 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+
+import { withRouterProvider } from ".storybook/decorators";
+import { StatementsPage } from "./statementsPage";
+import statementsPagePropsFixture from "./statementsPage.fixture";
+
+storiesOf("StatementsPage", module)
+  .addDecorator(withRouterProvider)
+  .add("with data", () => (
+    <StatementsPage {...statementsPagePropsFixture}/>
+  ));

--- a/pkg/ui/src/views/statements/statementsTable.module.styl
+++ b/pkg/ui/src/views/statements/statementsTable.module.styl
@@ -1,0 +1,62 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@require '~styl/base/palette.styl'
+@require '~src/components/core/index'
+
+.cl-table-link__description
+  font-size $font-size--small
+  line-height 22px
+  color $colors--neutral-1
+  white-space pre-wrap
+  margin-bottom 0
+
+.cl-table-link__statement-tooltip--fixed-width
+  max-width max-content
+  :global(.ant-tooltip-content)
+    max-width 500px
+
+.statements-table__col-time
+  white-space nowrap
+
+.statements-table__col-count--bar-chart
+  width 100px
+
+.statements-table__col-retries--bar-chart
+  width 80px
+
+.numeric-stats-table
+  .bar-chart
+    width 200px
+
+.statements-table__col-rows, .statements-table__col-latency
+  &--bar-chart
+    min-width 150px
+
+.statements-table__col-count, .statements-table__col-retries, .statements-table__col-rows
+  &--bar-chart
+    margin-left 0
+
+    &__label
+      left 0
+      width 40px
+      min-width 40px
+
+.cl-table__col-query-text a
+  font-family RobotoMono-Medium
+  font-size 12px
+  line-height 1.83
+  color $adminui-grey-1
+  width 400px
+  text-decoration none
+  cursor pointer
+  &:hover
+    color $colors--primary-blue-3
+    text-decoration underline

--- a/pkg/ui/src/views/statements/statementsTable.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.tsx
@@ -11,6 +11,7 @@
 import getHighlightedText from "src/util/highlightedText";
 import React from "react";
 import { Link } from "react-router-dom";
+import classNames from "classnames/bind";
 
 import { StatementStatistics } from "src/util/appStats";
 import { FixLong } from "src/util/fixLong";
@@ -23,7 +24,9 @@ import { DiagnosticStatusBadge } from "./diagnostics/diagnosticStatusBadge";
 import { cockroach } from "src/js/protos";
 import IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
 import { ActivateDiagnosticsModalRef } from "./diagnostics/activateDiagnosticsModal";
+import styles from "./statementsTable.module.styl";
 
+const cx = classNames.bind(styles);
 const longToInt = (d: number | Long) => FixLong(d).toInt();
 
 export interface AggregateStatistics {
@@ -151,10 +154,41 @@ export function makeNodesColumns(statements: AggregateStatistics[], nodeNames: {
 
 function makeCommonColumns(statements: AggregateStatistics[])
     : ColumnDescriptor<AggregateStatistics>[] {
-  const countBar = countBarChart(statements);
-  const retryBar = retryBarChart(statements);
-  const rowsBar = rowsBarChart(statements);
-  const latencyBar = latencyBarChart(statements);
+  const countBar = countBarChart(
+    statements,
+    {
+      classes: {
+        root: cx("statements-table__col-count--bar-chart"),
+        label: cx("statements-table__col-count--bar-chart__label"),
+      },
+    },
+  );
+  const retryBar = retryBarChart(
+    statements,
+    {
+      classes: {
+        root: cx("statements-table__col-retries--bar-chart"),
+        label: cx("statements-table__col-retries--bar-chart__label"),
+      },
+    },
+  );
+  const rowsBar = rowsBarChart(
+    statements,
+    {
+      classes: {
+        root: cx("statements-table__col-rows--bar-chart"),
+        label: cx("statements-table__col-rows--bar-chart__label"),
+      },
+    },
+  );
+  const latencyBar = latencyBarChart(
+    statements,
+    {
+      classes: {
+        root: cx("statements-table__col-latency--bar-chart"),
+      },
+    },
+  );
 
   return [
     {

--- a/pkg/ui/webpack.app.js
+++ b/pkg/ui/webpack.app.js
@@ -85,7 +85,29 @@ module.exports = (env, argv) => {
       rules: [
         { test: /\.css$/, use: [ "style-loader", "css-loader" ] },
         {
-          test: /\.styl$/,
+          test: /\.module\.styl$/,
+          use: [
+            "cache-loader",
+            "style-loader",
+            {
+              loader: "css-loader",
+              options: {
+                modules: {
+                  localIdentName: "[local]--[hash:base64:5]",
+                },
+                importLoaders: 1,
+              },
+            },
+            {
+              loader: "stylus-loader",
+              options: {
+                use: [require("nib")()],
+              },
+            },
+          ],
+        },
+        {
+          test: /(?<!\.module)\.styl$/,
           use: [
             "cache-loader",
             "style-loader",

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -2458,9 +2458,10 @@
   version "0.22.7"
   resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.7.tgz#4a92eafedfb2b9f4437d3a4410006d81114c66ce"
 
-"@types/classnames@^0.0.32":
-  version "0.0.32"
-  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-0.0.32.tgz#449abcd9a826807811ef101e58df9f83cfc61713"
+"@types/classnames@^2.2.10":
+  version "2.2.10"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.10.tgz#cc658ca319b6355399efc1f5b9e818f1a24bf999"
+  integrity sha512-1UzDldn9GfYYEsWWnn/P4wkTlkZDH7lDb0wBMGbtIQc9zXEQq7FlKBdZUn6OBqD8sKZZ2RQO2mAjGpXiDGoRmQ==
 
 "@types/combokeys@^2.4.5":
   version "2.4.5"


### PR DESCRIPTION
Depends on: #47417
Depends on: https://github.com/cockroachdb/yarn-vendored/pull/20
Related to: #47527

Current draft is just example for possible styles isolation with CSS modules.
It is required to make components self-contained and easy for extraction.

Before all css files were loaded into
global scope even if file was imported in
some particular module.

Now it is possible to define styles as before
and use old styles without changes, and as a
module, to do this - files has to be named as
someName.module.styl
In webpack config, `style-loader` is defined
two times with different file name matchers
to be able define style loaders with and without
modules.

`barCharts` component is a first candidate to try out css modules.
- all styles related to `barCharts` are copied(!) to `barCharts.module.styl` file,
so in case another component somehow relies on styles defined for barCharts
- it won't be affected.

Storybook is extended with stories related to `barCharts`
