### PR TITLE
release-20.1: rowexec: fix error propagation of countRows processor

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -2241,3 +2241,12 @@ CREATE TABLE t45453(c INT)
 query I
 SELECT count(*) FROM t45453 GROUP BY 0 + 0
 ----
+
+# Regression test for #46981 (not propagating an error which occurs when
+# rendering the single output row of countRows aggregate).
+statement ok
+CREATE TABLE t46981_0(c0 INT);
+CREATE VIEW v46981_0(c0) AS SELECT count_rows() FROM t46981_0
+
+statement error parsing regexp: missing argument to repetition operator: `\+`
+SELECT * FROM v46981_0 WHERE '' !~ '+'

--- a/pkg/sql/rowexec/countrows.go
+++ b/pkg/sql/rowexec/countrows.go
@@ -90,8 +90,13 @@ func (ag *countAggregator) Next() (sqlbase.EncDatumRow, *execinfrapb.ProducerMet
 			ret := make(sqlbase.EncDatumRow, 1)
 			ret[0] = sqlbase.EncDatum{Datum: tree.NewDInt(tree.DInt(ag.count))}
 			rendered, _, err := ag.Out.ProcessRow(ag.Ctx, ret)
-			// We're done as soon as we process our one output row.
-			ag.MoveToDraining(err)
+			// We're done as soon as we process our one output row, so we
+			// transition into draining state. We will, however, return non-nil
+			// error (if such occurs during rendering) separately below.
+			ag.MoveToDraining(nil /* err */)
+			if err != nil {
+				return nil, &execinfrapb.ProducerMetadata{Err: err}
+			}
 			return rendered, nil
 		}
 		ag.count++


### PR DESCRIPTION
Backport 1/1 commits from #47036.

/cc @cockroachdb/release

---

Previously, we would incorrectly propagate an error if such occurs
during rendering the single output row of countRows processor - we would
append to trailing meta and then would return `nil, nil` (for `row,
meta`) which would indicate to the consumer that countRows is fully done
(i.e. it has been drained) before it is actually done. This would result
in not propagating the error and is now fixed.

Fixes: #46981.

Release note (bug fix): Previously, instead of returning a parsing error
in queries with `count(*)` CockroachDB could incorrectly return no
output (when the query was executed via row-by-row engine), and this is
now fixed.
