### PR TITLE
roachtest: bump PredecessorVersion(20.1) to 19.2.6

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1142,7 +1142,7 @@ func PredecessorVersion(buildVersion version.Version) (string, error) {
 	// (see runVersionUpgrade). The same is true for adding a new key to this
 	// map.
 	verMap := map[string]string{
-		"20.1": "19.2.5",
+		"20.1": "19.2.6",
 		"19.2": "19.1.5",
 		"19.1": "2.1.9",
 		"2.2":  "2.1.9",


### PR DESCRIPTION
Release note: Increase predecessor version after 19.2 release