### PR TITLE
opt: fix case where we are not correctly identifying outer columns

### DIFF
--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -217,7 +217,9 @@ func (s *subquery) buildSubquery(desiredTypes []*types.T) {
 	defer func() { s.scope.builder.subquery = outer }()
 	s.scope.builder.subquery = s
 
-	outScope := s.scope.builder.buildStmt(s.Subquery.Select, desiredTypes, s.scope)
+	// We must push() here so that the columns in s.scope are correctly identified
+	// as outer columns.
+	outScope := s.scope.builder.buildStmt(s.Subquery.Select, desiredTypes, s.scope.push())
 	ord := outScope.ordering
 
 	// Treat the subquery result as an anonymous data source (i.e. column names

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -2225,3 +2225,9 @@ build
 SELECT 3::decimal IN (SELECT 1::int)
 ----
 error (22023): unsupported comparison operator: <decimal> IN <tuple{int}>
+
+# Regression test for #47467 - we weren't correctly identifying a.x as an outer column.
+build
+SELECT 1 FROM (VALUES (1)) AS a(x) HAVING (SELECT true FROM (VALUES (a.x)) AS b(y))
+----
+error (42803): subquery uses ungrouped column "x" from outer query


### PR DESCRIPTION
This is a case where a subquery has an outer column but it does not show up in
`subquery.outerCols`. The reason is that the column is defined in the input
scope so at `finishBuildScalarRef` time it doesn't look like an outer column.
The fix is to `push()` the scope when building the subquery.

Fixes #47467.

Release note: None