### PR TITLE
geomfn: implement the majority of the indexed geom builtins

### DIFF
--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -102,6 +102,15 @@ func ParseGeometry(str string) (*Geometry, error) {
 	return NewGeometry(ewkb), nil
 }
 
+// MustParseGeometry behaves as ParseGeometry, but panics if there is an error.
+func MustParseGeometry(str string) *Geometry {
+	g, err := ParseGeometry(str)
+	if err != nil {
+		panic(err)
+	}
+	return g
+}
+
 // AsGeography converts a given Geometry to it's Geography form.
 func (g *Geometry) AsGeography() (*Geography, error) {
 	if g.SRID() != 0 {

--- a/pkg/geo/geomfn/binary_predicates.go
+++ b/pkg/geo/geomfn/binary_predicates.go
@@ -1,0 +1,61 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/cockroachdb/cockroach/pkg/geo/geos"
+)
+
+// Covers returns whether geometry A covers geometry B.
+func Covers(a *geo.Geometry, b *geo.Geometry) (bool, error) {
+	return geos.Covers(a.EWKB(), b.EWKB())
+}
+
+// CoveredBy returns whether geometry A is covered by geometry B.
+func CoveredBy(a *geo.Geometry, b *geo.Geometry) (bool, error) {
+	return geos.CoveredBy(a.EWKB(), b.EWKB())
+}
+
+// Contains returns whether geometry A contains geometry B.
+func Contains(a *geo.Geometry, b *geo.Geometry) (bool, error) {
+	return geos.Contains(a.EWKB(), b.EWKB())
+}
+
+// Crosses returns whether geometry A crosses geometry B.
+func Crosses(a *geo.Geometry, b *geo.Geometry) (bool, error) {
+	return geos.Crosses(a.EWKB(), b.EWKB())
+}
+
+// Equals returns whether geometry A equals geometry B.
+func Equals(a *geo.Geometry, b *geo.Geometry) (bool, error) {
+	return geos.Equals(a.EWKB(), b.EWKB())
+}
+
+// Intersects returns whether geometry A intersects geometry B.
+func Intersects(a *geo.Geometry, b *geo.Geometry) (bool, error) {
+	return geos.Intersects(a.EWKB(), b.EWKB())
+}
+
+// Overlaps returns whether geometry A overlaps geometry B.
+func Overlaps(a *geo.Geometry, b *geo.Geometry) (bool, error) {
+	return geos.Overlaps(a.EWKB(), b.EWKB())
+}
+
+// Touches returns whether geometry A touches geometry B.
+func Touches(a *geo.Geometry, b *geo.Geometry) (bool, error) {
+	return geos.Touches(a.EWKB(), b.EWKB())
+}
+
+// Within returns whether geometry A is within geometry B.
+func Within(a *geo.Geometry, b *geo.Geometry) (bool, error) {
+	return geos.Within(a.EWKB(), b.EWKB())
+}

--- a/pkg/geo/geomfn/binary_predicates_test.go
+++ b/pkg/geo/geomfn/binary_predicates_test.go
@@ -1,0 +1,215 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	leftRect             = geo.MustParseGeometry("POLYGON((-1.0 0.0, 0.0 0.0, 0.0 1.0, -1.0 1.0, -1.0 0.0))")
+	leftRectPoint        = geo.MustParseGeometry("POINT(-0.5 -0.5)")
+	rightRect            = geo.MustParseGeometry("POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))")
+	rightRectPoint       = geo.MustParseGeometry("POINT(0.5 0.5)")
+	overlappingRightRect = geo.MustParseGeometry("POLYGON((-0.1 0.0, 1.0 0.0, 1.0 1.0, -0.1 1.0, -0.1 0.0))")
+	middleLine           = geo.MustParseGeometry("LINESTRING(-0.5 0.5, 0.5 0.5)")
+)
+
+func TestCovers(t *testing.T) {
+	testCases := []struct {
+		a        *geo.Geometry
+		b        *geo.Geometry
+		expected bool
+	}{
+		{rightRect, rightRectPoint, true},
+		{rightRectPoint, rightRect, false},
+		{leftRect, rightRect, false},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("tc:%d", i), func(t *testing.T) {
+			g, err := Covers(tc.a, tc.b)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, g)
+		})
+	}
+}
+
+func TestCoveredBy(t *testing.T) {
+	testCases := []struct {
+		a        *geo.Geometry
+		b        *geo.Geometry
+		expected bool
+	}{
+		{rightRect, rightRectPoint, false},
+		{rightRectPoint, rightRect, true},
+		{leftRect, rightRect, false},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("tc:%d", i), func(t *testing.T) {
+			g, err := CoveredBy(tc.a, tc.b)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, g)
+		})
+	}
+}
+
+func TestContains(t *testing.T) {
+	testCases := []struct {
+		a        *geo.Geometry
+		b        *geo.Geometry
+		expected bool
+	}{
+		{rightRect, rightRectPoint, true},
+		{rightRectPoint, rightRect, false},
+		{leftRect, rightRect, false},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("tc:%d", i), func(t *testing.T) {
+			g, err := Contains(tc.a, tc.b)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, g)
+		})
+	}
+}
+
+func TestCrosses(t *testing.T) {
+	testCases := []struct {
+		a        *geo.Geometry
+		b        *geo.Geometry
+		expected bool
+	}{
+		{rightRect, rightRectPoint, false},
+		{rightRectPoint, rightRect, false},
+		{leftRect, rightRect, false},
+		{leftRect, middleLine, true},
+		{rightRect, middleLine, true},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("tc:%d", i), func(t *testing.T) {
+			g, err := Crosses(tc.a, tc.b)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, g)
+		})
+	}
+}
+
+func TestEquals(t *testing.T) {
+	testCases := []struct {
+		a        *geo.Geometry
+		b        *geo.Geometry
+		expected bool
+	}{
+		{rightRect, rightRectPoint, false},
+		{rightRectPoint, rightRect, false},
+		{leftRect, rightRect, false},
+		{leftRect, geo.MustParseGeometry("POLYGON((0.0 0.0, 0.0 1.0, -1.0 1.0, -1.0 0.0, 0.0 0.0))"), true},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("tc:%d", i), func(t *testing.T) {
+			g, err := Equals(tc.a, tc.b)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, g)
+		})
+	}
+}
+
+func TestIntersects(t *testing.T) {
+	testCases := []struct {
+		a        *geo.Geometry
+		b        *geo.Geometry
+		expected bool
+	}{
+		{rightRect, leftRectPoint, false},
+		{rightRect, rightRectPoint, true},
+		{rightRectPoint, rightRect, true},
+		{leftRect, rightRect, true},
+		{leftRect, middleLine, true},
+		{rightRect, middleLine, true},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("tc:%d", i), func(t *testing.T) {
+			g, err := Intersects(tc.a, tc.b)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, g)
+		})
+	}
+}
+
+func TestOverlaps(t *testing.T) {
+	testCases := []struct {
+		a        *geo.Geometry
+		b        *geo.Geometry
+		expected bool
+	}{
+		{rightRect, rightRectPoint, false},
+		{rightRectPoint, rightRect, false},
+		{leftRect, rightRect, false},
+		{leftRect, overlappingRightRect, true},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("tc:%d", i), func(t *testing.T) {
+			g, err := Overlaps(tc.a, tc.b)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, g)
+		})
+	}
+}
+
+func TestTouches(t *testing.T) {
+	testCases := []struct {
+		a        *geo.Geometry
+		b        *geo.Geometry
+		expected bool
+	}{
+		{rightRect, rightRectPoint, false},
+		{rightRectPoint, rightRect, false},
+		{leftRect, rightRect, true},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("tc:%d", i), func(t *testing.T) {
+			g, err := Touches(tc.a, tc.b)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, g)
+		})
+	}
+}
+
+func TestWithin(t *testing.T) {
+	testCases := []struct {
+		a        *geo.Geometry
+		b        *geo.Geometry
+		expected bool
+	}{
+		{rightRect, rightRectPoint, false},
+		{rightRectPoint, rightRect, true},
+		{leftRect, rightRect, false},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("tc:%d", i), func(t *testing.T) {
+			g, err := Within(tc.a, tc.b)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, g)
+		})
+	}
+}

--- a/pkg/geo/geomfn/geomfn.go
+++ b/pkg/geo/geomfn/geomfn.go
@@ -1,0 +1,12 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package geomfn contains functions that are used for geometry-based builtins.
+package geomfn

--- a/pkg/geo/geos/geos_unix.go
+++ b/pkg/geo/geos/geos_unix.go
@@ -198,3 +198,120 @@ func ClipEWKBByRect(
 	}
 	return cStringToSafeGoBytes(cEWKB), nil
 }
+
+// Covers returns whether the EWKB provided by A covers the EWKB provided by B.
+func Covers(a geopb.EWKB, b geopb.EWKB) (bool, error) {
+	g, err := ensureInit(EnsureInitErrorDisplayPrivate)
+	if err != nil {
+		return false, err
+	}
+	var ret C.char
+	if err := statusToError(C.CR_GEOS_Covers(g, goToCSlice(a), goToCSlice(b), &ret)); err != nil {
+		return false, err
+	}
+	return ret == 1, nil
+}
+
+// CoveredBy returns whether the EWKB provided by A is covered by the EWKB provided by B.
+func CoveredBy(a geopb.EWKB, b geopb.EWKB) (bool, error) {
+	g, err := ensureInit(EnsureInitErrorDisplayPrivate)
+	if err != nil {
+		return false, err
+	}
+	var ret C.char
+	if err := statusToError(C.CR_GEOS_CoveredBy(g, goToCSlice(a), goToCSlice(b), &ret)); err != nil {
+		return false, err
+	}
+	return ret == 1, nil
+}
+
+// Contains returns whether the EWKB provided by A contains the EWKB provided by B.
+func Contains(a geopb.EWKB, b geopb.EWKB) (bool, error) {
+	g, err := ensureInit(EnsureInitErrorDisplayPrivate)
+	if err != nil {
+		return false, err
+	}
+	var ret C.char
+	if err := statusToError(C.CR_GEOS_Contains(g, goToCSlice(a), goToCSlice(b), &ret)); err != nil {
+		return false, err
+	}
+	return ret == 1, nil
+}
+
+// Crosses returns whether the EWKB provided by A crosses the EWKB provided by B.
+func Crosses(a geopb.EWKB, b geopb.EWKB) (bool, error) {
+	g, err := ensureInit(EnsureInitErrorDisplayPrivate)
+	if err != nil {
+		return false, err
+	}
+	var ret C.char
+	if err := statusToError(C.CR_GEOS_Crosses(g, goToCSlice(a), goToCSlice(b), &ret)); err != nil {
+		return false, err
+	}
+	return ret == 1, nil
+}
+
+// Equals returns whether the EWKB provided by A equals the EWKB provided by B.
+func Equals(a geopb.EWKB, b geopb.EWKB) (bool, error) {
+	g, err := ensureInit(EnsureInitErrorDisplayPrivate)
+	if err != nil {
+		return false, err
+	}
+	var ret C.char
+	if err := statusToError(C.CR_GEOS_Equals(g, goToCSlice(a), goToCSlice(b), &ret)); err != nil {
+		return false, err
+	}
+	return ret == 1, nil
+}
+
+// Intersects returns whether the EWKB provided by A intersects the EWKB provided by B.
+func Intersects(a geopb.EWKB, b geopb.EWKB) (bool, error) {
+	g, err := ensureInit(EnsureInitErrorDisplayPrivate)
+	if err != nil {
+		return false, err
+	}
+	var ret C.char
+	if err := statusToError(C.CR_GEOS_Intersects(g, goToCSlice(a), goToCSlice(b), &ret)); err != nil {
+		return false, err
+	}
+	return ret == 1, nil
+}
+
+// Overlaps returns whether the EWKB provided by A overlaps the EWKB provided by B.
+func Overlaps(a geopb.EWKB, b geopb.EWKB) (bool, error) {
+	g, err := ensureInit(EnsureInitErrorDisplayPrivate)
+	if err != nil {
+		return false, err
+	}
+	var ret C.char
+	if err := statusToError(C.CR_GEOS_Overlaps(g, goToCSlice(a), goToCSlice(b), &ret)); err != nil {
+		return false, err
+	}
+	return ret == 1, nil
+}
+
+// Touches returns whether the EWKB provided by A touches the EWKB provided by B.
+func Touches(a geopb.EWKB, b geopb.EWKB) (bool, error) {
+	g, err := ensureInit(EnsureInitErrorDisplayPrivate)
+	if err != nil {
+		return false, err
+	}
+	var ret C.char
+	if err := statusToError(C.CR_GEOS_Touches(g, goToCSlice(a), goToCSlice(b), &ret)); err != nil {
+		return false, err
+	}
+	return ret == 1, nil
+}
+
+// Within returns whether the EWKB provided by A is within the EWKB provided by B.
+func Within(a geopb.EWKB, b geopb.EWKB) (bool, error) {
+	g, err := ensureInit(EnsureInitErrorDisplayPrivate)
+	if err != nil {
+		return false, err
+	}
+	var ret C.char
+	if err := statusToError(C.CR_GEOS_Within(g, goToCSlice(a), goToCSlice(b), &ret)); err != nil {
+		return false, err
+	}
+	return ret == 1, nil
+}

--- a/pkg/geo/geos/geos_unix.h
+++ b/pkg/geo/geos/geos_unix.h
@@ -59,6 +59,20 @@ CR_GEOS_Status CR_GEOS_WKTToEWKB(CR_GEOS* lib, CR_GEOS_Slice wkt, int srid, CR_G
 CR_GEOS_Status CR_GEOS_ClipEWKBByRect(CR_GEOS* lib, CR_GEOS_Slice wkb, double xmin, double ymin,
                                       double xmax, double ymax, CR_GEOS_String* clippedEWKB);
 
+//
+// Binary predicates.
+//
+
+CR_GEOS_Status CR_GEOS_Covers(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char *ret);
+CR_GEOS_Status CR_GEOS_CoveredBy(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char *ret);
+CR_GEOS_Status CR_GEOS_Contains(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char *ret);
+CR_GEOS_Status CR_GEOS_Crosses(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char *ret);
+CR_GEOS_Status CR_GEOS_Equals(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char *ret);
+CR_GEOS_Status CR_GEOS_Intersects(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char *ret);
+CR_GEOS_Status CR_GEOS_Overlaps(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char *ret);
+CR_GEOS_Status CR_GEOS_Touches(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char *ret);
+CR_GEOS_Status CR_GEOS_Within(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char *ret);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/pkg/geo/geos/geos_windows.go
+++ b/pkg/geo/geos/geos_windows.go
@@ -30,3 +30,39 @@ func ClipEWKBByRect(
 ) (geopb.EWKB, error) {
 	return nil, unimplemented.NewWithIssue(46876, "operation not supported on Windows")
 }
+
+func Covers(a geopb.EWKB, b geopb.EWKB) (bool, error) {
+	return false, unimplemented.NewWithIssue(46876, "operation not supported on Windows")
+}
+
+func CoveredBy(a geopb.EWKB, b geopb.EWKB) (bool, error) {
+	return false, unimplemented.NewWithIssue(46876, "operation not supported on Windows")
+}
+
+func Contains(a geopb.EWKB, b geopb.EWKB) (bool, error) {
+	return false, unimplemented.NewWithIssue(46876, "operation not supported on Windows")
+}
+
+func Crosses(a geopb.EWKB, b geopb.EWKB) (bool, error) {
+	return false, unimplemented.NewWithIssue(46876, "operation not supported on Windows")
+}
+
+func Equals(a geopb.EWKB, b geopb.EWKB) (bool, error) {
+	return false, unimplemented.NewWithIssue(46876, "operation not supported on Windows")
+}
+
+func Intersects(a geopb.EWKB, b geopb.EWKB) (bool, error) {
+	return false, unimplemented.NewWithIssue(46876, "operation not supported on Windows")
+}
+
+func Overlaps(a geopb.EWKB, b geopb.EWKB) (bool, error) {
+	return false, unimplemented.NewWithIssue(46876, "operation not supported on Windows")
+}
+
+func Touches(a geopb.EWKB, b geopb.EWKB) (bool, error) {
+	return false, unimplemented.NewWithIssue(46876, "operation not supported on Windows")
+}
+
+func Within(a geopb.EWKB, b geopb.EWKB) (bool, error) {
+	return false, unimplemented.NewWithIssue(46876, "operation not supported on Windows")
+}


### PR DESCRIPTION
This commit adds builtins for the majority of geometry indexed backed
functions by calling into GEOS. The missing ones are `DWithin` and
`DFullyWithin`, which are not backed by GEOS.

Added some basic unit tests that don't do too much as this should be
tested by GEOS. We have not linked this to the builtins yet.

Release note: None