### PR TITLE
roachtest: rename rebalance-{leases,replicas}-by-load to rebalance/by-load/{leases,replicas}

### DIFF
--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -125,7 +125,7 @@ func registerRebalanceLoad(r *testRegistry) {
 	concurrency := 128
 
 	r.Add(testSpec{
-		Name:       `rebalance-leases-by-load`,
+		Name:       `rebalance/by-load/leases`,
 		Owner:      OwnerKV,
 		Cluster:    makeClusterSpec(4), // the last node is just used to generate load
 		MinVersion: "v2.1.0",
@@ -138,7 +138,7 @@ func registerRebalanceLoad(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:       `rebalance-replicas-by-load`,
+		Name:       `rebalance/by-load/replicas`,
 		Owner:      OwnerKV,
 		Cluster:    makeClusterSpec(7), // the last node is just used to generate load
 		MinVersion: "v2.1.0",


### PR DESCRIPTION
Rename the tests so their artifacts get grouped together.