### PR TITLE
release-20.1: sql: fix handling of errors in schema change rollbacks

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -547,9 +547,11 @@ func (sc *SchemaChanger) handlePermanentSchemaChangeError(
 	ctx context.Context, err error, evalCtx *extendedEvalContext,
 ) error {
 	if rollbackErr := sc.rollbackSchemaChange(ctx, err); rollbackErr != nil {
-		// Note: the "err" object is captured by rollbackSchemaChange(), so
-		// it does not simply disappear.
-		return errors.Wrap(rollbackErr, "while rolling back schema change")
+		// From now on, the returned error will be a secondary error of the returned
+		// error, so we'll record the original error now.
+		secondary := errors.Wrap(err, "original error when rolling back mutations")
+		sqltelemetry.RecordError(ctx, secondary, &sc.settings.SV)
+		return errors.WithSecondaryError(rollbackErr, secondary)
 	}
 
 	// TODO (lucy): This is almost the same as in exec(), maybe refactor.
@@ -634,20 +636,7 @@ func (sc *SchemaChanger) initJobRunningStatus(ctx context.Context) error {
 func (sc *SchemaChanger) rollbackSchemaChange(ctx context.Context, err error) error {
 	log.Warningf(ctx, "reversing schema change %d due to irrecoverable error: %s", *sc.job.ID(), err)
 	if errReverse := sc.maybeReverseMutations(ctx, err); errReverse != nil {
-		// Although the backfill did hit an integrity constraint violation
-		// and made a decision to reverse the mutations,
-		// maybeReverseMutations() failed. If exec() is called again the entire
-		// schema change will be retried.
-
-		// Note: we capture the original error as "secondary" to ensure it
-		// does not fully disappear.
-		// However, since it is not in the main causal chain any more,
-		// it will become invisible to further telemetry. So before
-		// we relegate it to a secondary, go through the recording motions.
-		// This ensures that any important error gets reported to Sentry, etc.
-		secondary := errors.Wrap(err, "original error when reversing mutations")
-		sqltelemetry.RecordError(ctx, secondary, &sc.settings.SV)
-		return errors.WithSecondaryError(errReverse, secondary)
+		return err
 	}
 
 	if fn := sc.testingKnobs.RunAfterMutationReversal; fn != nil {
@@ -658,20 +647,7 @@ func (sc *SchemaChanger) rollbackSchemaChange(ctx context.Context, err error) er
 
 	// After this point the schema change has been reversed and any retry
 	// of the schema change will act upon the reversed schema change.
-	if errPurge := sc.runStateMachineAndBackfill(ctx); errPurge != nil {
-		// Don't return this error because we do want the caller to know
-		// that an integrity constraint was violated with the original
-		// schema change. The reversed schema change will be
-		// retried via the async schema change manager.
-
-		// Since the errors are going to disappear, do the recording
-		// motions on them. This ensures that any assertion failure or
-		// other important error underneath gets recorded properly.
-		log.Warningf(ctx, "error purging mutation: %+v\nwhile handling error: %+v", errPurge, err)
-		sqltelemetry.RecordError(ctx, err, &sc.settings.SV)
-		sqltelemetry.RecordError(ctx, errPurge, &sc.settings.SV)
-	}
-	return nil
+	return sc.runStateMachineAndBackfill(ctx)
 }
 
 // RunStateMachineBeforeBackfill moves the state machine forward
@@ -1722,12 +1698,36 @@ func (r schemaChangeResumer) OnFailOrCancel(ctx context.Context, phs interface{}
 			// We check for this case so that we can just return the error without
 			// wrapping it in a retry error.
 			return rollbackErr
-		default:
-			// Always retry when we get any other error. Otherwise we risk leaving the
-			// in-progress schema change state on the table descriptor indefinitely.
-			// Note that, in theory, this could mean retrying the job forever even for
-			// an error we can't recover from, if there's a bug.
+		case !isPermanentSchemaChangeError(rollbackErr):
+			// Check if the error is on a whitelist of errors we should retry on, and
+			// have the job registry retry.
 			return jobs.NewRetryJobError(rollbackErr.Error())
+		default:
+			// All other errors lead to a failed job.
+			//
+			// TODO (lucy): We have a problem where some schema change rollbacks will
+			// never succeed because the backfiller can't handle rolling back schema
+			// changes that involve dropping a column; see #46541. (This is probably
+			// not the only bug that could cause rollbacks to fail.) For historical
+			// context: This was the case in 19.2 and probably earlier versions as
+			// well, and in those earlier versions, the old async schema changer would
+			// keep retrying the rollback and failing in the background because the
+			// mutation would still be left on the table descriptor. In the present
+			// schema change job, we return an error immediately and put the job in a
+			// terminal state instead of retrying indefinitely, basically to make the
+			// behavior similar to 19.2: If the rollback fails, we end up returning
+			// immediately (instead of retrying and blocking indefinitely), and the
+			// table descriptor is left in a bad state with some mutations that we
+			// can't clean up.
+			//
+			// Ultimately, this is untenable, and we should figure out some better way
+			// of dealing with failed rollbacks. Part of the solution is just making
+			// rollbacks (especially of dropped columns) more robust, but part of it
+			// will likely involve some sort of medium-term solution for cleaning up
+			// mutations that we can't make any progress on (see #47456). In the long
+			// term we'll hopefully be rethinking what it even means to "roll back" a
+			// (transactional) schema change.
+			return rollbackErr
 		}
 	}
 

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -5800,3 +5800,113 @@ ALTER TABLE t.public.test DROP COLUMN v;
 		{"1", "2"},
 	}, rows)
 }
+
+// TestRetriableErrorDuringRollback tests that a retriable error while rolling
+// back a schema change causes the rollback to retry and succeed.
+func TestRetriableErrorDuringRollback(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer setTestJobsAdoptInterval()()
+	ctx := context.Background()
+
+	onFailOrCancelStarted := false
+	injectedError := false
+	params, _ := tests.CreateTestServerParams()
+	params.Knobs = base.TestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			RunBeforeOnFailOrCancel: func(_ int64) error {
+				onFailOrCancelStarted = true
+				return nil
+			},
+			RunBeforeBackfill: func() error {
+				// The first time through the backfiller in OnFailOrCancel, return a
+				// retriable error.
+				if !onFailOrCancelStarted || injectedError {
+					return nil
+				}
+				injectedError = true
+				// Return an artificial context canceled error.
+				return context.Canceled
+			},
+		},
+	}
+	s, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	// Disable strict GC TTL enforcement because we're going to shove a zero-value
+	// TTL into the system with addImmediateGCZoneConfig.
+	defer disableGCTTLStrictEnforcement(t, sqlDB)()
+
+	_, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (k INT PRIMARY KEY, v INT8);
+INSERT INTO t.test VALUES (1, 2), (2, 2);
+`)
+	require.NoError(t, err)
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
+	// Add a zone config for the table.
+	_, err = addImmediateGCZoneConfig(sqlDB, tableDesc.ID)
+	require.NoError(t, err)
+
+	// Try to create a unique index which won't be valid and will need a rollback.
+	_, err = sqlDB.Exec(`
+CREATE UNIQUE INDEX i ON t.test(v);
+`)
+	require.Error(t, err)
+	require.Regexp(t, "violates unique constraint", err.Error())
+	// Verify that the index was cleaned up.
+	testutils.SucceedsSoon(t, func() error {
+		return checkTableKeyCountExact(ctx, kvDB, 2)
+	})
+}
+
+// TestPermanentErrorDuringRollback tests that a permanent error while rolling
+// back a schema change causes the job to fail, and that the appropriate error
+// is displayed in the jobs table.
+func TestPermanentErrorDuringRollback(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer setTestJobsAdoptInterval()()
+	ctx := context.Background()
+
+	onFailOrCancelStarted := false
+	injectedError := false
+	params, _ := tests.CreateTestServerParams()
+	params.Knobs = base.TestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			RunBeforeOnFailOrCancel: func(_ int64) error {
+				onFailOrCancelStarted = true
+				return nil
+			},
+			RunBeforeBackfill: func() error {
+				// The first time through the backfiller in OnFailOrCancel, return a
+				// permanent error.
+				if !onFailOrCancelStarted || injectedError {
+					return nil
+				}
+				injectedError = true
+				// Any error not on the whitelist of retriable errors is considered permanent.
+				return errors.New("permanent error")
+			},
+		},
+	}
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	_, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (k INT PRIMARY KEY, v INT8);
+INSERT INTO t.test VALUES (1, 2), (2, 2);
+`)
+	require.NoError(t, err)
+
+	// Try to create a unique index which won't be valid and will need a rollback.
+	_, err = sqlDB.Exec(`
+CREATE UNIQUE INDEX i ON t.test(v);
+`)
+	require.Error(t, err)
+	require.Regexp(t, "violates unique constraint", err.Error())
+
+	var jobErr string
+	row := sqlDB.QueryRow("SELECT error FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE'")
+	require.NoError(t, row.Scan(&jobErr))
+	require.Regexp(t, "cannot be reverted, manual cleanup may be required", jobErr)
+}


### PR DESCRIPTION
Backport 1/1 commits from #47446.

/cc @cockroachdb/release

---

This PR does two main things to fix error handling for a schema change
being rolled back in the job's `OnFailOrCancel` hook: (1) errors from
`runStateMachineAndBackfill` (acting on the reversed schema change) are
now returned instead of being logged and swallowed; and (2) we now
return the error and cause the the job to fail permanently when we
encounter any error that isn't one of the specific whitelisted
"retriable" errors for the schema changer. Transient "retriable" errors
in the schema changer now correctly lead to retries (which are handled
by the job registry).

The reason for implementing (2) in addition to (1) was that I discovered
some pre-existing instances of erroneous behavior in 19.2 and earlier
versions where the "expected" behavior was that we would never be able
to clean up a failed schema change due to inadequacies in the schema
changer and backfiller. (One notable example is that because the
column backfiller can't recover previous values, if a DROP COLUMN schema
change is being rolled back, trying to backfill a default value on a
column with constraints won't work in general.) Given this, it seemed
best to just return a result to the client right away instead of
pointlessly retrying and blocking indefinitely. This seemed like the
best quick fix that isn't a regression from 19.2 and that somewhat
reproduces the existing behavior.

This change also required a few changes to testing: There's now a
sentinel for job retry errors used with the errors package, and a few
testing knobs in the schema change job migration tests that were relying
on the old erroneous behavior have now been corrected.

See https://github.com/cockroachdb/cockroach/issues/46541#issuecomment-613023680 for an example of a schema change that can't be successfully rolled back.
Closes #47324.

Release note (bug fix): Fixed a bug introduced with the new schema
change job implementation in beta.3 that caused errors when rolling back
a schema change to be swallowed.
