### PR TITLE
sql: fix panic when SHOW RANGES is called with a virtual table

### DIFF
--- a/pkg/sql/delegate/show_range_for_row.go
+++ b/pkg/sql/delegate/show_range_for_row.go
@@ -33,6 +33,9 @@ func (d *delegator) delegateShowRangeForRow(n *tree.ShowRangeForRow) (tree.State
 	if err := d.catalog.CheckPrivilege(d.ctx, idx.Table(), privilege.SELECT); err != nil {
 		return nil, err
 	}
+	if idx.Table().IsVirtualTable() {
+		return nil, errors.New("SHOW RANGE FOR ROW may not be called on a virtual table")
+	}
 	span := idx.Span()
 	table := idx.Table()
 

--- a/pkg/sql/delegate/show_ranges.go
+++ b/pkg/sql/delegate/show_ranges.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/errors"
 )
 
 // delegateShowRanges implements the SHOW RANGES statement:
@@ -65,6 +66,9 @@ func (d *delegator) delegateShowRanges(n *tree.ShowRanges) (tree.Statement, erro
 	}
 	if err := d.catalog.CheckPrivilege(d.ctx, idx.Table(), privilege.SELECT); err != nil {
 		return nil, err
+	}
+	if idx.Table().IsVirtualTable() {
+		return nil, errors.New("SHOW RANGES may not be called on a virtual table")
 	}
 
 	span := idx.Span()

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -530,3 +530,11 @@ query T
 SELECT crdb_internal.pretty_key(crdb_internal.encode_key(70, 4, (1, )), 0)
 ----
 /70/4/1/0
+
+# Regression test for #44326. SHOW RANGES on a virtual table should cause
+# an error, not a panic.
+query error SHOW RANGES may not be called on a virtual table
+SHOW RANGES FROM TABLE crdb_internal.tables
+
+query error SHOW RANGE FOR ROW may not be called on a virtual table
+SHOW RANGE FROM TABLE crdb_internal.tables FOR ROW (0, 0)


### PR DESCRIPTION
Prior to this commit, calling `SHOW RANGES` or `SHOW RANGE FOR ROW` with
a virtual table caused a panic, since virtual tables have no ranges.
This commit fixes the problem by returning an error instead of a panic.

Fixes #44326

Release note (bug fix): Fixed a panic that could occur when SHOW RANGES
or SHOW RANGE FOR ROW was called with a virtual table.