### PR TITLE
release-19.2: rowexec: release buckets from hash aggregator eagerly

### DIFF
--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -385,6 +385,8 @@ func (ag *hashAggregator) close() {
 				ag.buckets[bucket].close(ag.Ctx)
 			}
 		}
+		// Make sure to release any remaining memory under 'buckets'.
+		ag.buckets = nil
 		// Note that we should be closing accounts only after closing all the
 		// buckets since the latter might be releasing some precisely tracked
 		// memory, and if we were to close the accounts first, there would be
@@ -632,7 +634,23 @@ func (ag *hashAggregator) emitRow() (
 	bucket := ag.bucketsIter[0]
 	ag.bucketsIter = ag.bucketsIter[1:]
 
-	return ag.getAggResults(ag.buckets[bucket])
+	// Once we get the results from the bucket, we can delete it from the map.
+	// This will allow us to return the memory to the system before the hash
+	// aggregator is fully done (which matters when we have many buckets).
+	// NOTE: accounting for the memory under aggregate builtins in the bucket
+	// is updated in getAggResults (the bucket will be closed), however, we
+	// choose to not reduce our estimate of the map's internal footprint
+	// because it is error-prone to estimate the new footprint (we don't
+	// whether and when Go runtime will release some of the underlying memory).
+	// This behavior is ok, though, since actual usage of buckets will be lower
+	// than what we accounted for - in the worst case, the query might hit a
+	// memory budget limit and error out when it might actually be within the
+	// limit. However, we might be under accounting memory usage in other
+	// places, so having some over accounting here might be actually beneficial
+	// as a defensive mechanism against OOM crashes.
+	state, row, meta := ag.getAggResults(ag.buckets[bucket])
+	delete(ag.buckets, bucket)
+	return state, row, meta
 }
 
 // emitRow constructs an output row from an accumulated bucket and returns it.


### PR DESCRIPTION
Backport 1/2 commits from #47466.

/cc @cockroachdb/release

---

**rowexec: release buckets from hash aggregator eagerly**

This commit makes hash aggregator release the memory under buckets
eagerly (once we're done with the bucket) so that it is returned to the
system. This can matter a lot when we have large number of buckets (on
the order of 100k). Previously, this would happen only on the flow
shutdown, once we're losing the references to `hashAggregator`
processor. But it was problematic - we "released" the associated memory
from the memory accounting, yet we were holding the references still.
With this commit we will reduce the memory footprint and we'll be a lot
closer to what our memory accounting thinks we're using.

Fixes: #47205.

Release note (bug fix): Previously, CockroachDB was incorrectly
releasing memory used by hash aggregation (we were releasing the correct
amount from the internal memory accounting system but, by mistake, were
keeping the references to the actual memory for some time which
prohibited the memory to be garbage collected). This could lead to
a crash (which was more likely when hash aggregation had to store on the
order of 100k of groups) and is now fixed.