### PR TITLE
ui: Tooltips for storage metrics

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
@@ -20,7 +20,7 @@ export const CapacityGraphTooltip: React.FunctionComponent<{tooltipSelection: Re
       <dt>Capacity</dt>
       <dd>
         <p>
-          Usage of disk space {tooltipSelection}.
+          {`Usage of disk space across all ${tooltipSelection} / on node <node>.`}
         </p>
         <p>
           <Anchor href={docsURL.howAreCapacityMetricsCalculated}>
@@ -37,13 +37,11 @@ export const LogicalBytesGraphTooltip: React.FunctionComponent =
       <dt>Logical Bytes per Store</dt>
       <dd>
         <p>
-          Number of logical bytes stored in
-          {" "}
+          {"Number of logical bytes stored in "}
           <Anchor href={docsURL.keyValuePairs}>
             key-value pairs
           </Anchor>
-          {" "}
-          on each node.
+          {" on each node."}
         </p>
         <p>
           This includes historical and deleted data.

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
@@ -14,6 +14,8 @@ import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
 import { GraphDashboardProps, nodeDisplayName, storeIDsForNode } from "./dashboardUtils";
+import { Anchor } from "src/components";
+import { howAreCapacityMetricsCalculated } from "src/util/docs";
 
 // TODO(vilterp): tooltips
 
@@ -138,6 +140,14 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Available Disk Capacity"
       sources={storeSources}
+      tooltip={(
+        <div>
+          <p>Free disk space available to CockroachDB</p>
+          <Anchor href={howAreCapacityMetricsCalculated}>
+            How is this metric calculated?
+          </Anchor>
+        </div>
+      )}
     >
       <Axis units={AxisUnits.Bytes} label="capacity">
         {nodeIDs.map((nid) => (

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -91,11 +91,10 @@ export default function (props: GraphDashboardProps) {
       tooltip={<CapacityGraphTooltip tooltipSelection={tooltipSelection}/>}
     >
       <Axis units={AxisUnits.Bytes} label="capacity">
-        <Metric name="cr.store.capacity" title="Capacity" />
+        <Metric name="cr.store.capacity" title="Max" />
         <Metric name="cr.store.capacity.available" title="Available" />
         <Metric name="cr.store.capacity.used" title="Used" />
       </Axis>
     </LineGraph>,
-
   ];
 }

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -27,7 +27,7 @@ export default function (props: GraphDashboardProps) {
       tooltip={<CapacityGraphTooltip tooltipSelection={tooltipSelection} />}
     >
       <Axis units={AxisUnits.Bytes} label="capacity">
-        <Metric name="cr.store.capacity" title="Capacity" />
+        <Metric name="cr.store.capacity" title="Max" />
         <Metric name="cr.store.capacity.available" title="Available" />
         <Metric name="cr.store.capacity.used" title="Used" />
       </Axis>
@@ -37,7 +37,7 @@ export default function (props: GraphDashboardProps) {
       title="Live Bytes"
       sources={storeSources}
       tooltip={
-        `Amount of data that can be read by applications and CockroachDB ${tooltipSelection}`
+        `Amount of data that can be read by applications and CockroachDB across all ${tooltipSelection} / on node <node>.`
       }
     >
       <Axis units={AxisUnits.Bytes} label="live bytes">

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
@@ -27,6 +27,8 @@ import {
   SummaryStatMessage,
   SummaryMetricsAggregator,
 } from "src/views/shared/components/summaryBar";
+import { Tooltip, Anchor } from "src/components";
+import { howAreCapacityMetricsCalculated } from "src/util/docs";
 
 interface ClusterSummaryProps {
   nodeSources: string[];
@@ -77,15 +79,31 @@ export default function(props: ClusterSummaryProps) {
   // Capacity math used in the summary status section.
   const { capacityUsed, capacityUsable } = props.nodesSummary.nodeSums;
   const capacityPercent = capacityUsable !== 0 ? (capacityUsed / capacityUsable) : null;
-
   return (
     <div>
       <SummaryBar>
         <SummaryLabel>Summary</SummaryLabel>
         <ClusterNodeTotals {...props}/>
-        <SummaryStat title="Capacity Used" value={capacityPercent} format={formatPercentage}>
-          <SummaryStatMessage message={`You are using ${Bytes(capacityUsed)} of ${Bytes(capacityUsable)}
-                                        usable storage capacity across all nodes.`} />
+        <SummaryStat title={
+          <Tooltip
+            placement="left"
+            title={(
+              <>
+                <p>Percentage of total usable disk space in use by CockroachDB data.</p>
+                <Anchor
+                  href={howAreCapacityMetricsCalculated}
+                >
+                  How is this metric calculated?
+                </Anchor>
+              </>
+            )}
+          >
+            Capacity Used
+          </Tooltip>
+        } value={capacityPercent} format={formatPercentage}>
+          <SummaryStatMessage
+            message={`You are using ${Bytes(capacityUsed)} of ${Bytes(capacityUsable)} usable disk capacity across all nodes.`}
+          />
         </SummaryStat>
         <SummaryStat title="Unavailable ranges" value={props.nodesSummary.nodeSums.unavailableRanges} />
         <SummaryMetricStat


### PR DESCRIPTION
Updated tooltips for storage metrics.
Added tooltip in `Storage Metrics Page` to `Capacity Used` in sidebar.

Resolves: #47429

Release note(ui): storage metrics page updates