### PR TITLE
release-19.1: sql: fix casting of negative datums to decimals

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -623,3 +623,15 @@ root                      ·              ·                             ("array
                 └── scan  ·              ·                             (a, b)     ·
 ·                         table          t@primary                     ·          ·
 ·                         spans          ALL                           ·          ·
+
+# Regression test for #47327. The span should have an end value of -1.
+statement ok
+CREATE TABLE t0(c0 DECIMAL UNIQUE); INSERT INTO t0(c0) VALUES(0);
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT t0.c0 FROM t0 WHERE t0.c0 BETWEEN t0.c0 AND INTERVAL '-1'::DECIMAL
+----
+scan  ·       ·                     (c0)  ·
+·     table   t0@t0_c0_key          ·     ·
+·     spans   /!NULL-/-1/PrefixEnd  ·     ·
+·     filter  c0 >= c0              ·     ·

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2720,6 +2720,11 @@ func TimestampToDecimal(ts hlc.Timestamp) *DDecimal {
 	val.Mul(val, big10E10)
 	val.Add(val, big.NewInt(int64(ts.Logical)))
 
+	// val must be positive. If it was set to a negative value above,
+	// transfer the sign to res.Negative.
+	res.Negative = val.Sign() < 0
+	val.Abs(val)
+
 	// Shift 10 decimals to the right, so that the logical
 	// field appears as fractional part.
 	res.Decimal.Exponent = -10
@@ -3185,6 +3190,12 @@ func PerformCast(ctx *EvalContext, d Datum, t coltypes.CastTargetType) (Datum, e
 			return nil, err
 		}
 		if !unset {
+			// dd.Coeff must be positive. If it was set to a negative value
+			// above, transfer the sign to dd.Negative.
+			if dd.Coeff.Sign() < 0 {
+				dd.Negative = true
+				dd.Coeff.Abs(&dd.Coeff)
+			}
 			err = LimitDecimalWidth(&dd.Decimal, typ.Prec, typ.Scale)
 			return &dd, err
 		}

--- a/pkg/sql/sem/tree/testdata/eval/cast
+++ b/pkg/sql/sem/tree/testdata/eval/cast
@@ -977,3 +977,19 @@ eval
 ARRAY['hello','world']::char(2)[]
 ----
 ARRAY['he','wo']
+
+# Test that decimals are correctly cast when the original value is negative.
+eval
+'-2020-10-10'::timestamp::decimal
+----
+-125887824000.000000
+
+eval
+'-2020-10-10-2020 10:10:00.11111111111111111'::timestamptz::decimal
+----
+-125887714199.888889
+
+eval
+'-10'::interval::decimal
+----
+-10.000000000


### PR DESCRIPTION
Backport 1/1 commits from #47483.

/cc @cockroachdb/release

---

Prior to this commit, when negative intervals, timestamps, and timestamptzs
were cast to decimals, the result was incorrect. The problem was due to the
fact that for these negative values, `Decimal.Coeff.neg` was being set to true,
while `Decimal.Negative` was false. As explained in the comment in `decimal.go`,
"Coeff must be positive. If it is negative results may be incorrect and apd
may panic."

This commit fixes the problem by setting `Decimal.Negative` to true and
`Decimal.Coeff.neg` to false when casting negative datums to decimals.

Fixes #47327

Release note (bug fix): Fixed incorrect results that could occur when
casting negative intervals or timestamps to type decimal.
