### PR TITLE
col*: support json type in vectorized engine using datum

### DIFF
--- a/pkg/ccl/importccl/read_import_workload.go
+++ b/pkg/ccl/importccl/read_import_workload.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -224,7 +225,7 @@ func (w *WorkloadKVConverter) Worker(ctx context.Context, evalCtx *tree.EvalCont
 	}
 	var alloc sqlbase.DatumAlloc
 	var a bufalloc.ByteAllocator
-	cb := coldata.NewMemBatchWithSize(nil, 0)
+	cb := coldata.NewMemBatchWithSize(nil /* types */, 0 /* size */, colmem.NewExtendedColumnFactory(evalCtx))
 
 	for {
 		batchIdx := int(atomic.AddInt64(&w.batchIdxAtomic, 1))

--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/workloadccl"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -188,7 +189,7 @@ func hashTableInitialData(
 	h hash.Hash, data workload.BatchedTuples, a *bufalloc.ByteAllocator,
 ) error {
 	var scratch [8]byte
-	b := coldata.NewMemBatchWithSize(nil, 0)
+	b := coldata.NewMemBatchWithSize(nil /* types */, 0 /* size */, colmem.NewExtendedColumnFactory(nil /* evalCtx */))
 	for batchIdx := 0; batchIdx < data.NumBatches; batchIdx++ {
 		*a = (*a)[:0]
 		data.FillBatch(batchIdx, b, a)

--- a/pkg/col/coldata/batch_test.go
+++ b/pkg/col/coldata/batch_test.go
@@ -18,10 +18,21 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes/typeconv"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/assert"
 )
+
+var columnFactory = colmem.NewExtendedColumnFactory(nil /* evalCtx */)
+
+func newTestMemBatch(types []types.T) coldata.Batch {
+	return coldata.NewMemBatch(types, columnFactory)
+}
+
+func newTestMemBatchWithSize(types []types.T, n int) coldata.Batch {
+	return coldata.NewMemBatchWithSize(types, n, columnFactory)
+}
 
 func TestBatchReset(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -32,7 +43,7 @@ func TestBatchReset(t *testing.T) {
 		// reallocated.
 		vecsBefore := b.ColVecs()
 		ptrBefore := (*reflect.SliceHeader)(unsafe.Pointer(&vecsBefore))
-		b.Reset(typs, n)
+		b.Reset(typs, n, columnFactory)
 		vecsAfter := b.ColVecs()
 		ptrAfter := (*reflect.SliceHeader)(unsafe.Pointer(&vecsAfter))
 		assert.Equal(t, shouldReuse, ptrBefore.Data == ptrAfter.Data)
@@ -76,37 +87,37 @@ func TestBatchReset(t *testing.T) {
 	var b coldata.Batch
 
 	// Simple case, reuse
-	b = coldata.NewMemBatch(typsInt)
+	b = newTestMemBatch(typsInt)
 	resetAndCheck(b, typsInt, 1, true)
 
 	// Types don't match, don't reuse
-	b = coldata.NewMemBatch(typsInt)
+	b = newTestMemBatch(typsInt)
 	resetAndCheck(b, typsBytes, 1, false)
 
 	// Columns are a prefix, reuse
-	b = coldata.NewMemBatch(typsIntBytes)
+	b = newTestMemBatch(typsIntBytes)
 	resetAndCheck(b, typsInt, 1, true)
 
 	// Exact length, reuse
-	b = coldata.NewMemBatchWithSize(typsInt, 1)
+	b = newTestMemBatchWithSize(typsInt, 1)
 	resetAndCheck(b, typsInt, 1, true)
 
 	// Insufficient capacity, don't reuse
-	b = coldata.NewMemBatchWithSize(typsInt, 1)
+	b = newTestMemBatchWithSize(typsInt, 1)
 	resetAndCheck(b, typsInt, 2, false)
 
 	// Selection vector gets reset
-	b = coldata.NewMemBatchWithSize(typsInt, 1)
+	b = newTestMemBatchWithSize(typsInt, 1)
 	b.SetSelection(true)
 	b.Selection()[0] = 7
 	resetAndCheck(b, typsInt, 1, true)
 
 	// Nulls gets reset
-	b = coldata.NewMemBatchWithSize(typsInt, 1)
+	b = newTestMemBatchWithSize(typsInt, 1)
 	b.ColVec(0).Nulls().SetNull(0)
 	resetAndCheck(b, typsInt, 1, true)
 
 	// Bytes columns use a different impl than everything else
-	b = coldata.NewMemBatch(typsBytes)
+	b = newTestMemBatch(typsBytes)
 	resetAndCheck(b, typsBytes, 1, true)
 }

--- a/pkg/col/coldata/bytes_test.go
+++ b/pkg/col/coldata/bytes_test.go
@@ -418,7 +418,7 @@ func TestBytes(t *testing.T) {
 // TestAppendBytesWithLastNull makes sure that Append handles correctly the
 // case when the last element of Bytes vector is NULL.
 func TestAppendBytesWithLastNull(t *testing.T) {
-	src := NewMemColumn(types.Bytes, 4)
+	src := NewMemColumn(types.Bytes, 4, StandardVectorizedColumnFactory)
 	sel := []int{0, 2, 3}
 	src.Bytes().Set(0, []byte("zero"))
 	src.Nulls().SetNull(1)
@@ -431,8 +431,8 @@ func TestAppendBytesWithLastNull(t *testing.T) {
 		SrcStartIdx: 0,
 		SrcEndIdx:   len(sel),
 	}
-	dest := NewMemColumn(types.Bytes, 3)
-	expected := NewMemColumn(types.Bytes, 3)
+	dest := NewMemColumn(types.Bytes, 3, StandardVectorizedColumnFactory)
+	expected := NewMemColumn(types.Bytes, 3, StandardVectorizedColumnFactory)
 	for _, withSel := range []bool{false, true} {
 		t.Run(fmt.Sprintf("AppendBytesWithLastNull/sel=%t", withSel), func(t *testing.T) {
 			expected.Nulls().UnsetNulls()

--- a/pkg/col/coldata/datum_container.go
+++ b/pkg/col/coldata/datum_container.go
@@ -1,0 +1,37 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package coldata
+
+import "github.com/cockroachdb/cockroach/pkg/sql/types"
+
+// DatumContainerElem is abstract type for elements inside DatumContainer, this
+// type in reality should be tree.Datum. However, in order te avoid pulling in
+// pkg/sql/sem/tree package into the coldata package, we have to rely on duck
+// typing and runtime cast instead.
+type DatumContainerElem interface{}
+
+// DatumContainer is the interface for a specialized vector that operates on
+// tree.Datum for vectorized engine. In order to avoid import tree package the
+// implementation of DatumContainer lives in pkg/sql/colmem/datum_vec.go.
+type DatumContainer interface {
+	Get(i int) DatumContainerElem
+	Set(i int, v DatumContainerElem)
+	Slice(start, end int) DatumContainer
+	CopySlice(src DatumContainer, destIdx, srcStartIdx, srcEndIdx int)
+	AppendSlice(src DatumContainer, destIdx, srcStartIdx, srcEndIdx int)
+	AppendVal(v DatumContainerElem)
+	SetLength(l int)
+	MarshalAt(i int) ([]byte, error)
+	UnmarshalTo(i int, b []byte) error
+	SetType(t *types.T)
+	Len() int
+	Cap() int
+}

--- a/pkg/col/coldata/nulls_test.go
+++ b/pkg/col/coldata/nulls_test.go
@@ -224,7 +224,7 @@ func TestSetAndUnsetNulls(t *testing.T) {
 func TestNullsSet(t *testing.T) {
 	args := SliceArgs{
 		// Neither type nor the length here matter.
-		Src: NewMemColumn(types.Bool, 0),
+		Src: NewMemColumn(types.Bool, 0, StandardVectorizedColumnFactory),
 	}
 	for _, withSel := range []bool{false, true} {
 		t.Run(fmt.Sprintf("WithSel=%t", withSel), func(t *testing.T) {

--- a/pkg/col/coldata/testutils.go
+++ b/pkg/col/coldata/testutils.go
@@ -12,6 +12,7 @@ package coldata
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/stretchr/testify/require"
@@ -91,6 +92,18 @@ func AssertEquivalentBatches(t testingT, expected, actual Batch) {
 			for i := range expectedInterval {
 				if expectedInterval[i].Compare(resultInterval[i]) != 0 {
 					t.Fatalf("Interval mismatch at index %d:\nexpected:\n%sactual:\n%s", i, expectedInterval[i], resultInterval[i])
+				}
+			}
+		} else if typ == coltypes.Datum {
+			// Cannot use require.Equal for this type.
+			expectedDatum := expectedVec.Datum().Slice(0 /* start */, expected.Length())
+			resultDatum := actualVec.Datum().Slice(0 /* start */, actual.Length())
+			require.Equal(t, expectedDatum.Len(), resultDatum.Len())
+			for i := 0; i < expectedDatum.Len(); i++ {
+				expected := expectedDatum.Get(i).(fmt.Stringer).String()
+				actual := resultDatum.Get(i).(fmt.Stringer).String()
+				if expected != actual {
+					t.Fatalf("Datum mismatch at index %d:\nexpected:\n%sactual:\n%s", i, expectedDatum.Get(i), resultDatum.Get(i))
 				}
 			}
 		} else {

--- a/pkg/col/coldata/unknown_vec.go
+++ b/pkg/col/coldata/unknown_vec.go
@@ -63,6 +63,10 @@ func (u unknown) Interval() []duration.Duration {
 	panic("Vec is of unknown type and should not be accessed")
 }
 
+func (u unknown) Datum() DatumContainer {
+	panic("Vec is of unknown type and should not be accessed")
+}
+
 func (u unknown) Col() interface{} {
 	panic("Vec is of unknown type and should not be accessed")
 }

--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -21,8 +21,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
-// column is an interface that represents a raw array of a Go native type.
-type column interface{}
+// Column is an interface that represents a raw array of a Go native type.
+type Column interface{}
 
 // SliceArgs represents the arguments passed in to Vec.Append and Nulls.set.
 type SliceArgs struct {
@@ -81,11 +81,13 @@ type Vec interface {
 	Timestamp() []time.Time
 	// Interval returns a duration.Duration slice.
 	Interval() []duration.Duration
+	// Datum returns a vector of Datums.
+	Datum() DatumContainer
 
 	// Col returns the raw, typeless backing storage for this Vec.
 	Col() interface{}
 
-	// SetCol sets the member column (in the case of mutable columns).
+	// SetCol sets the member Column (in the case of mutable columns).
 	SetCol(interface{})
 
 	// TemplateType returns an []interface{} and is used for operator templates.
@@ -114,14 +116,14 @@ type Vec interface {
 	// behavior).
 	Window(colType coltypes.T, start int, end int) Vec
 
-	// MaybeHasNulls returns true if the column possibly has any null values, and
-	// returns false if the column definitely has no null values.
+	// MaybeHasNulls returns true if the Column possibly has any null values, and
+	// returns false if the Column definitely has no null values.
 	MaybeHasNulls() bool
 
-	// Nulls returns the nulls vector for the column.
+	// Nulls returns the nulls vector for the Column.
 	Nulls() *Nulls
 
-	// SetNulls sets the nulls vector for this column.
+	// SetNulls sets the nulls vector for this Column.
 	SetNulls(*Nulls)
 
 	// Length returns the length of the slice that is underlying this Vec.
@@ -144,37 +146,61 @@ var _ Vec = &memColumn{}
 // a generic interface{} to the proper type when requested.
 type memColumn struct {
 	t     coltypes.T
-	col   column
+	col   Column
 	nulls Nulls
 }
 
-// NewMemColumn returns a new memColumn, initialized with a length.
-func NewMemColumn(t *types.T, n int) Vec {
-	nulls := NewNulls(n)
+// ColumnFactory is an interface that can construct columns for memBatches.
+type ColumnFactory interface {
+	ConstructColumn(t coltypes.T, n int) Column
+}
 
-	switch t := typeconv.FromColumnType(t); t {
+type defaultColumnFactory struct{}
+
+// StandardVectorizedColumnFactory is a factory that produce all vectorized
+// types beside datum types.
+var StandardVectorizedColumnFactory ColumnFactory = &defaultColumnFactory{}
+
+func (cf *defaultColumnFactory) ConstructColumn(t coltypes.T, n int) Column {
+	switch t {
 	case coltypes.Bool:
-		return &memColumn{t: t, col: make([]bool, n), nulls: nulls}
+		return make([]bool, n)
 	case coltypes.Bytes:
-		return &memColumn{t: t, col: NewBytes(n), nulls: nulls}
+		return NewBytes(n)
 	case coltypes.Int16:
-		return &memColumn{t: t, col: make([]int16, n), nulls: nulls}
+		return make([]int16, n)
 	case coltypes.Int32:
-		return &memColumn{t: t, col: make([]int32, n), nulls: nulls}
+		return make([]int32, n)
 	case coltypes.Int64:
-		return &memColumn{t: t, col: make([]int64, n), nulls: nulls}
+		return make([]int64, n)
 	case coltypes.Float64:
-		return &memColumn{t: t, col: make([]float64, n), nulls: nulls}
+		return make([]float64, n)
 	case coltypes.Decimal:
-		return &memColumn{t: t, col: make([]apd.Decimal, n), nulls: nulls}
+		return make([]apd.Decimal, n)
 	case coltypes.Timestamp:
-		return &memColumn{t: t, col: make([]time.Time, n), nulls: nulls}
+		return make([]time.Time, n)
 	case coltypes.Interval:
-		return &memColumn{t: t, col: make([]duration.Duration, n), nulls: nulls}
+		return make([]duration.Duration, n)
 	case coltypes.Unhandled:
-		return unknown{}
+		return nil
 	default:
 		panic(fmt.Sprintf("unhandled type %s", t))
+	}
+}
+
+// NewMemColumn returns a new memColumn, initialized with a length
+// using the given column factory.
+func NewMemColumn(t *types.T, n int, factory ColumnFactory) Vec {
+	nulls := NewNulls(n)
+
+	coltyps := typeconv.FromColumnType(t)
+	if coltyps == coltypes.Unhandled {
+		return unknown{}
+	}
+	return &memColumn{
+		t:     coltyps,
+		col:   factory.ConstructColumn(coltyps, n),
+		nulls: nulls,
 	}
 }
 
@@ -222,6 +248,10 @@ func (m *memColumn) Interval() []duration.Duration {
 	return m.col.([]duration.Duration)
 }
 
+func (m *memColumn) Datum() DatumContainer {
+	return m.col.(DatumContainer)
+}
+
 func (m *memColumn) Col() interface{} {
 	return m.col
 }
@@ -262,6 +292,8 @@ func (m *memColumn) Length() int {
 		return len(m.col.([]time.Time))
 	case coltypes.Interval:
 		return len(m.col.([]duration.Duration))
+	case coltypes.Datum:
+		return m.col.(DatumContainer).Len()
 	default:
 		panic(fmt.Sprintf("unhandled type %s", m.t))
 	}
@@ -287,6 +319,8 @@ func (m *memColumn) SetLength(l int) {
 		m.col = m.col.([]time.Time)[:l]
 	case coltypes.Interval:
 		m.col = m.col.([]duration.Duration)[:l]
+	case coltypes.Datum:
+		m.col.(DatumContainer).SetLength(l)
 	default:
 		panic(fmt.Sprintf("unhandled type %s", m.t))
 	}
@@ -312,6 +346,8 @@ func (m *memColumn) Capacity() int {
 		return cap(m.col.([]time.Time))
 	case coltypes.Interval:
 		return cap(m.col.([]duration.Duration))
+	case coltypes.Datum:
+		return m.col.(DatumContainer).Cap()
 	default:
 		panic(fmt.Sprintf("unhandled type %s", m.t))
 	}

--- a/pkg/col/coldatatestutils/utils.go
+++ b/pkg/col/coldatatestutils/utils.go
@@ -20,8 +20,10 @@ import (
 // the underlying capacity might be different (a new batch is created only with
 // capacity original.Length()).
 // NOTE: memory accounting is not performed.
-func CopyBatch(original coldata.Batch, typs []types.T) coldata.Batch {
-	b := coldata.NewMemBatchWithSize(typs, original.Length())
+func CopyBatch(
+	original coldata.Batch, typs []types.T, columnFactory coldata.ColumnFactory,
+) coldata.Batch {
+	b := coldata.NewMemBatchWithSize(typs, original.Length(), columnFactory)
 	b.SetLength(original.Length())
 	for colIdx, col := range original.ColVecs() {
 		b.ColVec(colIdx).Copy(coldata.CopySliceArgs{

--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -104,7 +104,8 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 		}
 
 		physType := typeconv.FromColumnType(&typ)
-		if physType == coltypes.Bool || physType == coltypes.Decimal || physType == coltypes.Timestamp || physType == coltypes.Interval {
+		if physType == coltypes.Bool || physType == coltypes.Decimal || physType == coltypes.Timestamp || physType == coltypes.Interval ||
+			physType == coltypes.Datum {
 			var data *array.Data
 			switch physType {
 			case coltypes.Bool:
@@ -144,6 +145,16 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 					binary.LittleEndian.PutUint64(scratchIntervalBytes[sizeOfInt64:sizeOfInt64*2], uint64(months))
 					binary.LittleEndian.PutUint64(scratchIntervalBytes[sizeOfInt64*2:sizeOfInt64*3], uint64(days))
 					c.builders.binaryBuilder.Append(scratchIntervalBytes)
+				}
+				data = c.builders.binaryBuilder.NewBinaryArray().Data()
+			case coltypes.Datum:
+				datums := vec.Datum().Slice(0, n)
+				for idx := 0; idx < n; idx++ {
+					b, err := datums.MarshalAt(idx)
+					if err != nil {
+						return nil, err
+					}
+					c.builders.binaryBuilder.Append(b)
 				}
 				data = c.builders.binaryBuilder.NewBinaryArray().Data()
 			default:
@@ -329,6 +340,28 @@ func (c *ArrowBatchConverter) ArrowToBatch(data []*array.Data, b coldata.Batch) 
 					int64(binary.LittleEndian.Uint64(intervalBytes[sizeOfInt64:sizeOfInt64*2])),
 					int64(binary.LittleEndian.Uint64(intervalBytes[sizeOfInt64*2:sizeOfInt64*3])),
 				)
+				if err != nil {
+					return err
+				}
+			}
+			arr = bytesArr
+		case coltypes.Datum:
+			// TODO(azhng): this serialization is quite inefficient - improve
+			//  it.
+			bytesArr := array.NewBinaryData(d)
+			bytes := bytesArr.ValueBytes()
+			if bytes == nil {
+				// All bytes values are empty, so the representation is solely with the
+				// offsets slice, so create an empty slice so that the conversion
+				// corresponds.
+				bytes = make([]byte, 0)
+			}
+			offsets := bytesArr.ValueOffsets()
+			vecArr := vec.Datum()
+			// TODO(azhng): extends unmarshaling support to more than json.
+			vecArr.SetType(types.Jsonb)
+			for i := 0; i < len(offsets)-1; i++ {
+				err := vecArr.UnmarshalTo(i, bytes[offsets[i]:offsets[i+1]])
 				if err != nil {
 					return err
 				}

--- a/pkg/col/colserde/arrowbatchconverter_test.go
+++ b/pkg/col/colserde/arrowbatchconverter_test.go
@@ -61,11 +61,11 @@ func TestArrowBatchConverterRandom(t *testing.T) {
 
 	// Make a copy of the original batch because the converter modifies and casts
 	// data without copying for performance reasons.
-	expected := coldatatestutils.CopyBatch(b, typs)
+	expected := coldatatestutils.CopyBatch(b, typs, testColumnFactory)
 
 	arrowData, err := c.BatchToArrow(b)
 	require.NoError(t, err)
-	actual := coldata.NewMemBatchWithSize(typs, b.Length())
+	actual := coldata.NewMemBatchWithSize(typs, b.Length(), testColumnFactory)
 	require.NoError(t, c.ArrowToBatch(arrowData, actual))
 
 	coldata.AssertEquivalentBatches(t, expected, actual)
@@ -95,7 +95,7 @@ func roundTripBatch(
 	if err := r.Deserialize(&arrowDataOut, buf.Bytes()); err != nil {
 		return nil, err
 	}
-	actual := coldata.NewMemBatchWithSize(typs, b.Length())
+	actual := coldata.NewMemBatchWithSize(typs, b.Length(), testColumnFactory)
 	if err := c.ArrowToBatch(arrowDataOut, actual); err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func TestRecordBatchRoundtripThroughBytes(t *testing.T) {
 
 		// Make a copy of the original batch because the converter modifies and
 		// casts data without copying for performance reasons.
-		expected := coldatatestutils.CopyBatch(b, typs)
+		expected := coldatatestutils.CopyBatch(b, typs, testColumnFactory)
 		actual, err := roundTripBatch(b, c, r, typs)
 		require.NoError(t, err)
 
@@ -214,7 +214,7 @@ func BenchmarkArrowBatchConverter(b *testing.B) {
 			data, err := c.BatchToArrow(batch)
 			require.NoError(b, err)
 			testPrefix := fmt.Sprintf("%s/nullFraction=%0.2f", typ.String(), nullFraction)
-			result := coldata.NewMemBatch([]types.T{typ})
+			result := coldata.NewMemBatch([]types.T{typ}, testColumnFactory)
 			b.Run(testPrefix+"/ArrowToBatch", func(b *testing.B) {
 				b.SetBytes(numBytes[typIdx])
 				for i := 0; i < b.N; i++ {

--- a/pkg/col/colserde/file.go
+++ b/pkg/col/colserde/file.go
@@ -379,6 +379,11 @@ func schema(fb *flatbuffers.Builder, typs []types.T) flatbuffers.UOffsetT {
 			arrowserde.BinaryStart(fb)
 			fbTypOffset = arrowserde.BinaryEnd(fb)
 			fbTyp = arrowserde.TypeInterval
+		case coltypes.Datum:
+			// Datums are marshaled into bytes, so we use binary headers.
+			arrowserde.BinaryStart(fb)
+			fbTypOffset = arrowserde.BinaryEnd(fb)
+			fbTyp = arrowserde.TypeUtf8
 		default:
 			panic(errors.Errorf(`don't know how to map %s`, &typ))
 		}

--- a/pkg/col/colserde/file_test.go
+++ b/pkg/col/colserde/file_test.go
@@ -33,7 +33,7 @@ func TestFileRoundtrip(t *testing.T) {
 	t.Run(`mem`, func(t *testing.T) {
 		// Make a copy of the original batch because the converter modifies and
 		// casts data without copying for performance reasons.
-		original := coldatatestutils.CopyBatch(b, typs)
+		original := coldatatestutils.CopyBatch(b, typs, testColumnFactory)
 
 		var buf bytes.Buffer
 		s, err := colserde.NewFileSerializer(&buf, typs)
@@ -46,7 +46,7 @@ func TestFileRoundtrip(t *testing.T) {
 		// buffer.
 		for i := 0; i < 2; i++ {
 			func() {
-				roundtrip := coldata.NewMemBatchWithSize(typs, b.Length())
+				roundtrip := coldata.NewMemBatchWithSize(typs, b.Length(), testColumnFactory)
 				d, err := colserde.NewFileDeserializerFromBytes(typs, buf.Bytes())
 				require.NoError(t, err)
 				defer func() { require.NoError(t, d.Close()) }()
@@ -66,7 +66,7 @@ func TestFileRoundtrip(t *testing.T) {
 
 		// Make a copy of the original batch because the converter modifies and
 		// casts data without copying for performance reasons.
-		original := coldatatestutils.CopyBatch(b, typs)
+		original := coldatatestutils.CopyBatch(b, typs, testColumnFactory)
 
 		f, err := os.Create(path)
 		require.NoError(t, err)
@@ -82,7 +82,7 @@ func TestFileRoundtrip(t *testing.T) {
 		// file.
 		for i := 0; i < 2; i++ {
 			func() {
-				roundtrip := coldata.NewMemBatchWithSize(typs, b.Length())
+				roundtrip := coldata.NewMemBatchWithSize(typs, b.Length(), testColumnFactory)
 				d, err := colserde.NewFileDeserializerFromPath(typs, path)
 				require.NoError(t, err)
 				defer func() { require.NoError(t, d.Close()) }()
@@ -108,7 +108,7 @@ func TestFileIndexing(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 0; i < numInts; i++ {
-		b := coldata.NewMemBatchWithSize(typs, batchSize)
+		b := coldata.NewMemBatchWithSize(typs, batchSize, testColumnFactory)
 		b.SetLength(batchSize)
 		b.ColVec(0).Int64()[0] = int64(i)
 		require.NoError(t, s.AppendBatch(b))
@@ -121,7 +121,7 @@ func TestFileIndexing(t *testing.T) {
 	require.Equal(t, typs, d.Typs())
 	require.Equal(t, numInts, d.NumBatches())
 	for batchIdx := numInts - 1; batchIdx >= 0; batchIdx-- {
-		b := coldata.NewMemBatchWithSize(typs, batchSize)
+		b := coldata.NewMemBatchWithSize(typs, batchSize, testColumnFactory)
 		require.NoError(t, d.GetBatch(batchIdx, b))
 		require.Equal(t, batchSize, b.Length())
 		require.Equal(t, 1, b.Width())

--- a/pkg/col/colserde/main_test.go
+++ b/pkg/col/colserde/main_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -31,6 +32,8 @@ var (
 	// and a memory account bound to it for use in tests.
 	testMemMonitor *mon.BytesMonitor
 	testMemAcc     *mon.BoundAccount
+
+	testColumnFactory coldata.ColumnFactory
 )
 
 func TestMain(m *testing.M) {
@@ -41,7 +44,8 @@ func TestMain(m *testing.M) {
 		defer testMemMonitor.Stop(ctx)
 		memAcc := testMemMonitor.MakeBoundAccount()
 		testMemAcc = &memAcc
-		testAllocator = colmem.NewAllocator(ctx, testMemAcc)
+		testColumnFactory = colmem.NewExtendedColumnFactory(nil /* evalCtx */)
+		testAllocator = colmem.NewAllocator(ctx, testMemAcc, testColumnFactory)
 		defer testMemAcc.Close(ctx)
 		return m.Run()
 	}())

--- a/pkg/col/colserde/record_batch.go
+++ b/pkg/col/colserde/record_batch.go
@@ -38,7 +38,7 @@ func numBuffersForType(t coltypes.T) int {
 	// null bitmap and one for the values.
 	numBuffers := 2
 	switch t {
-	case coltypes.Bytes, coltypes.Decimal, coltypes.Timestamp, coltypes.Interval:
+	case coltypes.Bytes, coltypes.Decimal, coltypes.Timestamp, coltypes.Interval, coltypes.Datum:
 		// This type has an extra offsets buffer.
 		numBuffers = 3
 	}

--- a/pkg/col/colserde/record_batch_test.go
+++ b/pkg/col/colserde/record_batch_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -176,6 +177,15 @@ func randomDataFromType(rng *rand.Rand, t *types.T, n int, nullProbability float
 			binary.LittleEndian.PutUint64(data[i][0:sizeOfInt64], rng.Uint64())
 			binary.LittleEndian.PutUint64(data[i][sizeOfInt64:sizeOfInt64*2], rng.Uint64())
 			binary.LittleEndian.PutUint64(data[i][sizeOfInt64*2:sizeOfInt64*3], rng.Uint64())
+		}
+		builder.(*array.BinaryBuilder).AppendValues(data, valid)
+	case coltypes.Datum:
+		builder = array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
+		data := make([][]byte, n)
+		for i := range data {
+			v := rng.Float64() * math.MaxFloat64
+			j, _ := json.FromFloat64(v)
+			data[i], _ = json.EncodeJSON(data[i], j)
 		}
 		builder.(*array.BinaryBuilder).AppendValues(data, valid)
 	default:

--- a/pkg/col/coltypes/t_string.go
+++ b/pkg/col/coltypes/t_string.go
@@ -17,12 +17,13 @@ func _() {
 	_ = x[Float64-6]
 	_ = x[Timestamp-7]
 	_ = x[Interval-8]
-	_ = x[Unhandled-9]
+	_ = x[Datum-9]
+	_ = x[Unhandled-10]
 }
 
-const _T_name = "BoolBytesDecimalInt16Int32Int64Float64TimestampIntervalUnhandled"
+const _T_name = "BoolBytesDecimalInt16Int32Int64Float64TimestampIntervalDatumUnhandled"
 
-var _T_index = [...]uint8{0, 4, 9, 16, 21, 26, 31, 38, 47, 55, 64}
+var _T_index = [...]uint8{0, 4, 9, 16, 21, 26, 31, 38, 47, 55, 60, 69}
 
 func (i T) String() string {
 	if i < 0 || i >= T(len(_T_index)-1) {

--- a/pkg/col/coltypes/typeconv/typeconv.go
+++ b/pkg/col/coltypes/typeconv/typeconv.go
@@ -36,6 +36,7 @@ var AllSupportedSQLTypes = []types.T{
 	*types.Timestamp,
 	*types.TimestampTZ,
 	*types.Interval,
+	*types.Jsonb,
 }
 
 // FromColumnType returns the T that corresponds to the input ColumnType.
@@ -69,6 +70,8 @@ func FromColumnType(ct *types.T) coltypes.T {
 		return coltypes.Timestamp
 	case types.IntervalFamily:
 		return coltypes.Interval
+	case types.JsonFamily:
+		return coltypes.Datum
 	}
 	return coltypes.Unhandled
 }
@@ -109,6 +112,8 @@ func UnsafeToSQLType(t coltypes.T) (*types.T, error) {
 		return types.Timestamp, nil
 	case coltypes.Interval:
 		return types.Interval, nil
+	case coltypes.Datum:
+		return types.Jsonb, nil
 	default:
 		return nil, errors.Errorf("unsupported coltype %s", t)
 	}

--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -68,7 +68,7 @@ func TestDiskQueue(t *testing.T) {
 						BatchSize:  1 + rng.Intn(coldata.BatchSize()),
 						Nulls:      true,
 						BatchAccumulator: func(b coldata.Batch, typs []types.T) {
-							batches = append(batches, coldatatestutils.CopyBatch(b, typs))
+							batches = append(batches, coldatatestutils.CopyBatch(b, typs, testColumnFactory))
 						},
 					})
 					typs := op.Typs()
@@ -124,7 +124,7 @@ func TestDiskQueue(t *testing.T) {
 					}
 					for i := 0; i < numReadIterations; i++ {
 						batchIdx := 0
-						b := coldata.NewMemBatch(typs)
+						b := coldata.NewMemBatch(typs, testColumnFactory)
 						for batchIdx < len(batches) {
 							if ok, err := q.Dequeue(ctx, b); !ok {
 								t.Fatal("queue incorrectly considered empty")
@@ -217,7 +217,7 @@ func BenchmarkDiskQueue(b *testing.B) {
 				break
 			}
 		}
-		dequeuedBatch := coldata.NewMemBatch(typs)
+		dequeuedBatch := coldata.NewMemBatch(typs, testColumnFactory)
 		for dequeuedBatch.Length() != 0 {
 			if _, err := q.Dequeue(ctx, dequeuedBatch); err != nil {
 				b.Fatal(err)

--- a/pkg/sql/colcontainer/partitionedqueue_test.go
+++ b/pkg/sql/colcontainer/partitionedqueue_test.go
@@ -106,7 +106,8 @@ func TestPartitionedDiskQueue(t *testing.T) {
 	queueCfg.FS = countingFS
 
 	t.Run("ReopenReadPartition", func(t *testing.T) {
-		p := colcontainer.NewPartitionedDiskQueue(typs, queueCfg, sem, colcontainer.PartitionerStrategyDefault, testDiskAcc)
+		p := colcontainer.NewPartitionedDiskQueue(typs, queueCfg, sem,
+			colcontainer.PartitionerStrategyDefault, testDiskAcc)
 
 		countingFS.assertOpenFDs(t, sem, 0, 0)
 		require.NoError(t, p.Enqueue(ctx, 0, batch))

--- a/pkg/sql/colencoding/value_encoding_test.go
+++ b/pkg/sql/colencoding/value_encoding_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes/typeconv"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -26,6 +27,7 @@ import (
 
 func TestDecodeTableValueToCol(t *testing.T) {
 	rng, _ := randutil.NewPseudoRand()
+	var da sqlbase.DatumAlloc
 	var buf []byte
 	var scratch []byte
 	nCols := 1000
@@ -47,14 +49,15 @@ func TestDecodeTableValueToCol(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	batch := coldata.NewMemBatchWithSize(typs, 1)
+	columnFactory := colmem.NewExtendedColumnFactory(nil /* evalCtx */)
+	batch := coldata.NewMemBatchWithSize(typs, 1 /* size */, columnFactory)
 	for i := 0; i < nCols; i++ {
 		typeOffset, dataOffset, _, typ, err := encoding.DecodeValueTag(buf)
 		fmt.Println(typ)
 		if err != nil {
 			t.Fatal(err)
 		}
-		buf, err = DecodeTableValueToCol(batch.ColVec(i), 0 /* rowIdx */, typ,
+		buf, err = DecodeTableValueToCol(da, batch.ColVec(i), 0 /* rowIdx */, typ,
 			dataOffset, &typs[i], buf[typeOffset:])
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/sql/colexec/aggregator_test.go
+++ b/pkg/sql/colexec/aggregator_test.go
@@ -472,6 +472,35 @@ func TestAggregatorMultiFunc(t *testing.T) {
 				{0}, {1}, {2}, {3}, {3},
 			},
 		},
+		{
+			aggFns: []execinfrapb.AggregatorSpec_Func{
+				execinfrapb.AggregatorSpec_ANY_NOT_NULL,
+				execinfrapb.AggregatorSpec_SUM_INT,
+			},
+			input: tuples{
+				{`{"id": null}`, -1},
+				{`{"id": 0, "data": "s1"}`, 1},
+				{`{"id": 0, "data": "s1"}`, 2},
+				{`{"id": 1, "data": "s2"}`, 10},
+				{`{"id": 1, "data": "s2"}`, 11},
+				{`{"id": 2, "data": "s3"}`, 100},
+				{`{"id": 2, "data": "s3"}`, 101},
+				{`{"id": 2, "data": "s4"}`, 102},
+			},
+			expected: tuples{
+				{`{"id": null}`, -1},
+				{`{"id": 0, "data": "s1"}`, 3},
+				{`{"id": 1, "data": "s2"}`, 21},
+				{`{"id": 2, "data": "s3"}`, 201},
+				{`{"id": 2, "data": "s4"}`, 102},
+			},
+			typs:      []types.T{*types.Jsonb, *types.Int},
+			name:      "GroupOnJsonColumns",
+			groupCols: []uint32{0},
+			aggCols: [][]uint32{
+				{0}, {1},
+			},
+		},
 	}
 
 	for _, agg := range aggTypes {

--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -1071,7 +1071,9 @@ func (rf *cFetcher) processValueSingle(
 				return prettyKey, "", nil
 			}
 			typ := &table.cols[idx].Type
-			err := colencoding.UnmarshalColumnValueToCol(rf.machine.colvecs[idx], rf.machine.rowIdx, typ, val)
+			err := colencoding.UnmarshalColumnValueToCol(
+				table.da, rf.machine.colvecs[idx], rf.machine.rowIdx, typ, val,
+			)
 			if err != nil {
 				return "", "", err
 			}
@@ -1161,8 +1163,9 @@ func (rf *cFetcher) processValueBytes(
 		vec := rf.machine.colvecs[idx]
 
 		valTyp := &table.cols[idx].Type
-		valueBytes, err = colencoding.DecodeTableValueToCol(vec, rf.machine.rowIdx, typ, dataOffset, valTyp,
-			valueBytes)
+		valueBytes, err = colencoding.DecodeTableValueToCol(
+			table.da, vec, rf.machine.rowIdx, typ, dataOffset, valTyp, valueBytes,
+		)
 		if err != nil {
 			return "", "", err
 		}

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -157,12 +157,35 @@ func TestDistinct(t *testing.T) {
 				{0, "11"},
 			},
 		},
+		{
+			distinctCols: []uint32{0},
+			typs:         []types.T{*types.Jsonb, *types.String},
+			tuples: tuples{
+				{`{"id": 1}`, "a"},
+				{`{"id": 2}`, "b"},
+				{`{"id": 3}`, "c"},
+				{`{"id": null}`, "d"},
+				{`{"id": 5}`, "e"},
+				{`{"id": 6}`, "f"},
+				{`{"id": 1}`, "1"},
+				{`{"id": 2}`, "2"},
+				{`{"id": 3}`, "3"},
+			},
+			expected: tuples{
+				{`{"id": 1}`, "a"},
+				{`{"id": 2}`, "b"},
+				{`{"id": 3}`, "c"},
+				{`{"id": null}`, "d"},
+				{`{"id": 5}`, "e"},
+				{`{"id": 6}`, "f"},
+			},
+		},
 	}
 
 	for _, tc := range tcs {
 		for _, numOfBuckets := range []uint64{1, 3, 5, hashTableNumBuckets} {
 			t.Run(fmt.Sprintf("unordered/numOfBuckets=%d", numOfBuckets), func(t *testing.T) {
-				runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier,
+				runTestsWithTyps(t, []tuples{tc.tuples}, [][]types.T{tc.typs}, tc.expected, orderedVerifier,
 					func(input []colexecbase.Operator) (colexecbase.Operator, error) {
 						return NewUnorderedDistinct(
 							testAllocator, input[0], tc.distinctCols, tc.typs,

--- a/pkg/sql/colexec/distinct_tmpl.go
+++ b/pkg/sql/colexec/distinct_tmpl.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
@@ -112,6 +113,9 @@ var _ duration.Duration
 
 // Dummy import to pull in "tree" package.
 var _ tree.Datum
+
+// Dummy import to pull in "colmem" package.
+var _ colmem.ContextWrappedDatum
 
 // Dummy import to pull in "math" package.
 var _ = math.MaxInt64

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads.go
@@ -567,6 +567,12 @@ type timestampCustomizer struct{}
 // operators.
 type intervalCustomizer struct{}
 
+// TODO(azhng): support JSON binary operators.
+// datumCustomizer is necessary since tree.Datum doesn't have infix operators,
+// support for binary or comparison operators, hash functions, and also doesn't
+// have normal variable-set semantics.
+type datumCustomizer struct{}
+
 // timestampIntervalCustomizer supports mixed type expression with a timestamp
 // left-hand side and an interval right-hand side.
 type timestampIntervalCustomizer struct{}
@@ -1143,6 +1149,21 @@ func (c intervalCustomizer) getBinOpAssignFunc() assignFunc {
 	}
 }
 
+func (c datumCustomizer) getCmpOpCompareFunc() compareFunc {
+	return func(target, l, r string) string {
+		return fmt.Sprintf(`
+			%s = %s.(*colmem.ContextWrappedDatum).CompareElem(%s)
+		`, target, l, r)
+	}
+}
+
+func (c datumCustomizer) getHashAssignFunc() assignFunc {
+	return func(op overload, target, v, _ string) string {
+		return fmt.Sprintf("b := []byte(%[1]s.(tree.Datum).String())", v) +
+			fmt.Sprintf(hashByteSliceString, target, "b")
+	}
+}
+
 func (c timestampIntervalCustomizer) getBinOpAssignFunc() assignFunc {
 	return func(op overload, target, l, r string) string {
 		switch op.BinOp {
@@ -1283,6 +1304,7 @@ func registerTypeCustomizers() {
 	registerTypeCustomizer(coltypePair{coltypes.Decimal, coltypes.Decimal}, decimalCustomizer{})
 	registerTypeCustomizer(coltypePair{coltypes.Timestamp, coltypes.Timestamp}, timestampCustomizer{})
 	registerTypeCustomizer(coltypePair{coltypes.Interval, coltypes.Interval}, intervalCustomizer{})
+	registerTypeCustomizer(coltypePair{coltypes.Datum, coltypes.Datum}, datumCustomizer{})
 	for _, leftFloatType := range coltypes.FloatTypes {
 		for _, rightFloatType := range coltypes.FloatTypes {
 			registerTypeCustomizer(coltypePair{leftFloatType, rightFloatType}, floatCustomizer{width: 64})

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_test_utils_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_test_utils_gen.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )

--- a/pkg/sql/colexec/external_hash_joiner.go
+++ b/pkg/sql/colexec/external_hash_joiner.go
@@ -292,13 +292,15 @@ func newExternalHashJoiner(
 		partitionedDiskQueueSemaphore = nil
 	}
 	leftPartitioner := colcontainer.NewPartitionedDiskQueue(
-		spec.left.sourceTypes, diskQueueCfg, partitionedDiskQueueSemaphore, colcontainer.PartitionerStrategyDefault, diskAcc,
+		spec.left.sourceTypes, diskQueueCfg, partitionedDiskQueueSemaphore,
+		colcontainer.PartitionerStrategyDefault, diskAcc,
 	)
 	leftJoinerInput := newPartitionerToOperator(
 		unlimitedAllocator, spec.left.sourceTypes, leftPartitioner, 0, /* partitionIdx */
 	)
 	rightPartitioner := colcontainer.NewPartitionedDiskQueue(
-		spec.right.sourceTypes, diskQueueCfg, partitionedDiskQueueSemaphore, colcontainer.PartitionerStrategyDefault, diskAcc,
+		spec.right.sourceTypes, diskQueueCfg, partitionedDiskQueueSemaphore,
+		colcontainer.PartitionerStrategyDefault, diskAcc,
 	)
 	rightJoinerInput := newPartitionerToOperator(
 		unlimitedAllocator, spec.right.sourceTypes, rightPartitioner, 0, /* partitionIdx */

--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -231,7 +231,8 @@ func newExternalSorter(
 		inMemSorter:        inMemSorter,
 		inMemSorterInput:   inputPartitioner.(*inputPartitioningOperator),
 		partitionerCreator: func() colcontainer.PartitionedQueue {
-			return colcontainer.NewPartitionedDiskQueue(inputTypes, diskQueueCfg, partitionedDiskQueueSemaphore, colcontainer.PartitionerStrategyCloseOnNewPartition, diskAcc)
+			return colcontainer.NewPartitionedDiskQueue(inputTypes, diskQueueCfg,
+				partitionedDiskQueueSemaphore, colcontainer.PartitionerStrategyCloseOnNewPartition, diskAcc)
 		},
 		inputTypes:          inputTypes,
 		ordering:            ordering,

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -70,9 +70,10 @@ func TestExternalSort(t *testing.T) {
 			for _, tc := range tcs {
 				t.Run(fmt.Sprintf("spillForced=%t/%s", spillForced, tc.description), func(t *testing.T) {
 					var semsToCheck []semaphore.Semaphore
-					runTests(
+					runTestsWithTyps(
 						t,
 						[]tuples{tc.tuples},
+						[][]types.T{tc.typs},
 						tc.expected,
 						orderedVerifier,
 						func(input []colexecbase.Operator) (colexecbase.Operator, error) {

--- a/pkg/sql/colexec/hash_aggregator_tmpl.go
+++ b/pkg/sql/colexec/hash_aggregator_tmpl.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
@@ -45,6 +46,9 @@ var _ bytes.Buffer
 
 // Dummy import to pull in "tree" package.
 var _ tree.Operator
+
+// Dummy import to pull in "colmem" package.
+var _ colmem.ContextWrappedDatum
 
 // Dummy import to pull in "math" package.
 var _ int = math.MaxInt16

--- a/pkg/sql/colexec/hash_utils_tmpl.go
+++ b/pkg/sql/colexec/hash_utils_tmpl.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
@@ -50,6 +51,9 @@ var _ = math.MaxInt64
 
 // Dummy import to pull in "coltypes" package.
 var _ coltypes.T
+
+// Dummy import to pull in "tree" package.
+var _ tree.Datum
 
 // _GOTYPESLICE is a template Go type slice variable.
 type _GOTYPESLICE interface{}

--- a/pkg/sql/colexec/hashtable_tmpl.go
+++ b/pkg/sql/colexec/hashtable_tmpl.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
@@ -46,6 +47,9 @@ var _ bytes.Buffer
 
 // Dummy import to pull in "math" package.
 var _ = math.MaxInt64
+
+// Dummy import to pull in "colmem" package.
+var _ colmem.ContextWrappedDatum
 
 // _ASSIGN_NE is the template equality function for assigning the first input
 // to the result of the the second input != the third input.

--- a/pkg/sql/colexec/main_test.go
+++ b/pkg/sql/colexec/main_test.go
@@ -41,6 +41,8 @@ var (
 	// and a disk account bound to it for use in tests.
 	testDiskMonitor *mon.BytesMonitor
 	testDiskAcc     *mon.BoundAccount
+
+	testColumnFactory coldata.ColumnFactory
 )
 
 func TestMain(m *testing.M) {
@@ -51,7 +53,8 @@ func TestMain(m *testing.M) {
 		defer testMemMonitor.Stop(ctx)
 		memAcc := testMemMonitor.MakeBoundAccount()
 		testMemAcc = &memAcc
-		testAllocator = colmem.NewAllocator(ctx, testMemAcc)
+		testColumnFactory = colmem.NewExtendedColumnFactory(nil /* evalCtx */)
+		testAllocator = colmem.NewAllocator(ctx, testMemAcc, testColumnFactory)
 		defer testMemAcc.Close(ctx)
 
 		testDiskMonitor = execinfra.NewTestDiskMonitor(ctx, cluster.MakeTestingClusterSettings())

--- a/pkg/sql/colexec/mergejoinbase_tmpl.go
+++ b/pkg/sql/colexec/mergejoinbase_tmpl.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
@@ -58,6 +59,9 @@ var _ duration.Duration
 
 // Dummy import to pull in "math" package.
 var _ = math.MaxInt64
+
+// Dummy import to pull in "colmem" package.
+var _ colmem.ContextWrappedDatum
 
 // _TYPES_T is the template type variable for coltypes.T. It will be replaced by
 // coltypes.Foo for each type Foo in the coltypes.T type.

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -2087,7 +2087,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 
 				benchMemAccount.Clear(ctx)
 				base, err := newMergeJoinBase(
-					colmem.NewAllocator(ctx, &benchMemAccount), defaultMemoryLimit, queueCfg, colexecbase.NewTestingSemaphore(mjFDLimit),
+					colmem.NewAllocator(ctx, &benchMemAccount, testColumnFactory), defaultMemoryLimit, queueCfg, colexecbase.NewTestingSemaphore(mjFDLimit),
 					sqlbase.InnerJoin, leftSource, rightSource, sourceTypes, sourceTypes,
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
@@ -2118,7 +2118,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 
 				benchMemAccount.Clear(ctx)
 				base, err := newMergeJoinBase(
-					colmem.NewAllocator(ctx, &benchMemAccount), defaultMemoryLimit, queueCfg, colexecbase.NewTestingSemaphore(mjFDLimit),
+					colmem.NewAllocator(ctx, &benchMemAccount, testColumnFactory), defaultMemoryLimit, queueCfg, colexecbase.NewTestingSemaphore(mjFDLimit),
 					sqlbase.InnerJoin, leftSource, rightSource, sourceTypes, sourceTypes,
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
@@ -2151,7 +2151,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 
 				benchMemAccount.Clear(ctx)
 				base, err := newMergeJoinBase(
-					colmem.NewAllocator(ctx, &benchMemAccount), defaultMemoryLimit, queueCfg, colexecbase.NewTestingSemaphore(mjFDLimit),
+					colmem.NewAllocator(ctx, &benchMemAccount, testColumnFactory), defaultMemoryLimit, queueCfg, colexecbase.NewTestingSemaphore(mjFDLimit),
 					sqlbase.InnerJoin, leftSource, rightSource, sourceTypes, sourceTypes,
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
@@ -59,6 +60,9 @@ var _ duration.Duration
 
 // Dummy import to pull in "math" package.
 var _ = math.MaxInt64
+
+// Dummy import to pull in "colmem" package.
+var _ colmem.ContextWrappedDatum
 
 // _TYPES_T is the template type variable for coltypes.T. It will be replaced by
 // coltypes.Foo for each type Foo in the coltypes.T type.

--- a/pkg/sql/colexec/projection_ops_test.go
+++ b/pkg/sql/colexec/projection_ops_test.go
@@ -235,8 +235,9 @@ func TestRandomComparisons(t *testing.T) {
 	lDatums := make([]tree.Datum, numTuples)
 	rDatums := make([]tree.Datum, numTuples)
 	for _, typ := range types.Scalar {
-		if typ.Family() == types.DateFamily {
+		if typ.Family() == types.DateFamily || typ.Family() == types.JsonFamily {
 			// TODO(jordan): #40354 tracks failure to compare infinite dates.
+			// TODO(azhng): #43123 eventually support json comparison.
 			continue
 		}
 		if typeconv.FromColumnType(typ) == coltypes.Unhandled {

--- a/pkg/sql/colexec/routers_test.go
+++ b/pkg/sql/colexec/routers_test.go
@@ -477,7 +477,7 @@ func TestRouterOutputRandom(t *testing.T) {
 				go func() {
 					for {
 						b := o.Next(ctx)
-						actual.Add(coldatatestutils.CopyBatch(b, typs), typs)
+						actual.Add(coldatatestutils.CopyBatch(b, typs, testColumnFactory), typs)
 						if b.Length() == 0 {
 							wg.Done()
 							return
@@ -842,7 +842,7 @@ func TestHashRouterRandom(t *testing.T) {
 					defer acc.Close(ctx)
 					diskAcc := testDiskMonitor.MakeBoundAccount()
 					defer diskAcc.Close(ctx)
-					allocator := colmem.NewAllocator(ctx, &acc)
+					allocator := colmem.NewAllocator(ctx, &acc, testColumnFactory)
 					op := newRouterOutputOpWithBlockedThresholdAndBatchSize(allocator, typs, unblockEventsChan, memoryLimitPerOutput, queueCfg, colexecbase.NewTestingSemaphore(len(outputs)*2), blockedThreshold, outputSize, &diskAcc)
 					outputs[i] = op
 					outputsAsOps[i] = op
@@ -943,7 +943,7 @@ func BenchmarkHashRouter(b *testing.B) {
 				diskAccounts := make([]*mon.BoundAccount, numOutputs)
 				for i := range allocators {
 					acc := testMemMonitor.MakeBoundAccount()
-					allocators[i] = colmem.NewAllocator(ctx, &acc)
+					allocators[i] = colmem.NewAllocator(ctx, &acc, testColumnFactory)
 					defer acc.Close(ctx)
 					diskAcc := testDiskMonitor.MakeBoundAccount()
 					diskAccounts[i] = &diskAcc

--- a/pkg/sql/colexec/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/selection_ops_tmpl.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
@@ -64,6 +65,9 @@ var _ duration.Duration
 
 // Dummy import to pull in "coltypes" package.
 var _ coltypes.T
+
+// Dummy import to pull in "colmem" package.
+var _ colmem.ContextWrappedDatum
 
 // _ASSIGN_CMP is the template function for assigning the result of comparing
 // the second input to the third input into the first input.

--- a/pkg/sql/colexec/sort_test.go
+++ b/pkg/sql/colexec/sort_test.go
@@ -132,15 +132,64 @@ func init() {
 			typs:    []types.T{*types.Int, *types.Int, *types.Int},
 			ordCols: []execinfrapb.Ordering_Column{{ColIdx: 0}, {ColIdx: 1}, {ColIdx: 2}},
 		},
+
+		{
+			tuples: tuples{
+				{
+					`{
+						"int_val": 3,
+						"str_val": "string value 1"
+					}`,
+				},
+				{
+					`{
+						"int_val": 2,
+						"str_val": "string value 2"
+					}`,
+				},
+				{
+					`{
+						"int_val": 1,
+						"str_val": "string value 3"
+					}`,
+				},
+				{nil},
+			},
+			expected: tuples{
+				{nil},
+				{
+					`
+					{
+						"int_val": 1,
+						"str_val": "string value 3"
+					}`,
+				},
+				{
+					`{
+						"int_val": 2,
+						"str_val": "string value 2"
+					}`,
+				},
+				{
+					`{
+						"int_val": 3,
+						"str_val": "string value 1"
+					}`,
+				},
+			},
+			typs:    []types.T{*types.Jsonb},
+			ordCols: []execinfrapb.Ordering_Column{{ColIdx: 0}},
+		},
 	}
 }
 
 func TestSort(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	for _, tc := range sortAllTestCases {
-		runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier, func(input []colexecbase.Operator) (colexecbase.Operator, error) {
-			return NewSorter(testAllocator, input[0], tc.typs, tc.ordCols)
-		})
+		runTestsWithTyps(t, []tuples{tc.tuples}, [][]types.T{tc.typs}, tc.expected, orderedVerifier,
+			func(input []colexecbase.Operator) (colexecbase.Operator, error) {
+				return NewSorter(testAllocator, input[0], tc.typs, tc.ordCols)
+			})
 	}
 }
 

--- a/pkg/sql/colexec/sort_tmpl.go
+++ b/pkg/sql/colexec/sort_tmpl.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -62,6 +63,9 @@ var _ tree.Datum
 
 // Dummy import to pull in "math" package.
 var _ = math.MaxInt64
+
+// Dummy import to pull in "colmem" package.
+var _ colmem.ContextWrappedDatum
 
 // _GOTYPESLICE is the template Go type slice variable for this operator. It
 // will be replaced by the Go slice representation for each type in coltypes.T, for

--- a/pkg/sql/colexec/spilling_queue_test.go
+++ b/pkg/sql/colexec/spilling_queue_test.go
@@ -64,7 +64,7 @@ func TestSpillingQueue(t *testing.T) {
 					BatchSize:  1 + rng.Intn(coldata.BatchSize()),
 					Nulls:      true,
 					BatchAccumulator: func(b coldata.Batch, typs []types.T) {
-						batches = append(batches, coldatatestutils.CopyBatch(b, typs))
+						batches = append(batches, coldatatestutils.CopyBatch(b, typs, testColumnFactory))
 					},
 				})
 				typs := op.Typs()

--- a/pkg/sql/colexec/utils.go
+++ b/pkg/sql/colexec/utils.go
@@ -323,6 +323,14 @@ func getDatumToPhysicalFn(ct *types.T) func(tree.Datum) (interface{}, error) {
 			}
 			return d.Duration, nil
 		}
+	case types.JsonFamily:
+		return func(datum tree.Datum) (interface{}, error) {
+			j, ok := datum.(*tree.DJSON)
+			if !ok {
+				return nil, errors.Errorf("expected *tree.DJSON, found %s", reflect.TypeOf(datum))
+			}
+			return j, nil
+		}
 	}
 	// It would probably be more correct to return an error here, rather than a
 	// function which always returns an error. But since the function tends to be

--- a/pkg/sql/colexec/values_differ_tmpl.go
+++ b/pkg/sql/colexec/values_differ_tmpl.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
@@ -48,6 +49,9 @@ var _ tree.Datum
 
 // Dummy import to pull in "math" package.
 var _ = math.MaxInt64
+
+// Dummy import to pull in "colmem" package.
+var _ colmem.ContextWrappedDatum
 
 // _GOTYPE is the template Go type variable for this operator. It will be
 // replaced by the Go type equivalent for each type in coltypes.T, for example

--- a/pkg/sql/colexec/vec_comparators_tmpl.go
+++ b/pkg/sql/colexec/vec_comparators_tmpl.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
@@ -63,6 +64,9 @@ var _ = math.MaxInt64
 
 // Dummy import to pull in "coltypes" package.
 var _ coltypes.T
+
+// Dummy import to pull in "colmem" package.
+var _ colmem.ContextWrappedDatum
 
 // _COMPARE is the template equality function for assigning the first input
 // to the result of comparing second and third inputs.

--- a/pkg/sql/colexec/vec_elem_to_datum.go
+++ b/pkg/sql/colexec/vec_elem_to_datum.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -90,6 +91,8 @@ func PhysicalTypeColElemToDatum(
 		return da.NewDTimestampTZ(tree.DTimestampTZ{Time: col.Timestamp()[rowIdx]})
 	case types.IntervalFamily:
 		return da.NewDInterval(tree.DInterval{Duration: col.Interval()[rowIdx]})
+	case types.JsonFamily:
+		return col.Datum().Get(rowIdx).(*colmem.ContextWrappedDatum).Datum
 	default:
 		colexecerror.InternalError(fmt.Sprintf("Unsupported column type %s", ct.String()))
 		// This code is unreachable, but the compiler cannot infer that.

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -219,18 +219,19 @@ func TestOutboxInbox(t *testing.T) {
 		inputMemAcc := testMemMonitor.MakeBoundAccount()
 		defer inputMemAcc.Close(ctx)
 		input := coldatatestutils.NewRandomDataOp(
-			colmem.NewAllocator(ctx, &inputMemAcc), rng, args,
+			colmem.NewAllocator(ctx, &inputMemAcc, testColumnFactory), rng, args,
 		)
 
 		outboxMemAcc := testMemMonitor.MakeBoundAccount()
 		defer outboxMemAcc.Close(ctx)
-		outbox, err := NewOutbox(colmem.NewAllocator(ctx, &outboxMemAcc), input, typs, nil /* metadataSource */, nil /* toClose */)
+		outbox, err :=
+			NewOutbox(colmem.NewAllocator(ctx, &outboxMemAcc, testColumnFactory), input, typs, nil /* metadataSource */, nil /* toClose */)
 		require.NoError(t, err)
 
 		inboxMemAcc := testMemMonitor.MakeBoundAccount()
 		defer inboxMemAcc.Close(ctx)
 		inbox, err := NewInbox(
-			colmem.NewAllocator(ctx, &inboxMemAcc), typs, execinfrapb.StreamID(0),
+			colmem.NewAllocator(ctx, &inboxMemAcc, testColumnFactory), typs, execinfrapb.StreamID(0),
 		)
 		require.NoError(t, err)
 
@@ -269,7 +270,7 @@ func TestOutboxInbox(t *testing.T) {
 		deselectorMemAcc := testMemMonitor.MakeBoundAccount()
 		defer deselectorMemAcc.Close(ctx)
 		inputBatches := colexec.NewDeselectorOp(
-			colmem.NewAllocator(ctx, &deselectorMemAcc), inputBuffer, typs,
+			colmem.NewAllocator(ctx, &deselectorMemAcc, testColumnFactory), inputBuffer, typs,
 		)
 		inputBatches.Init()
 		outputBatches := colexecbase.NewBatchBuffer()
@@ -462,7 +463,7 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 
 			outboxMemAcc := testMemMonitor.MakeBoundAccount()
 			defer outboxMemAcc.Close(ctx)
-			outbox, err := NewOutbox(colmem.NewAllocator(ctx, &outboxMemAcc), input, typs, []execinfrapb.MetadataSource{
+			outbox, err := NewOutbox(colmem.NewAllocator(ctx, &outboxMemAcc, testColumnFactory), input, typs, []execinfrapb.MetadataSource{
 				execinfrapb.CallbackMetadataSource{
 					DrainMetaCb: func(context.Context) []execinfrapb.ProducerMetadata {
 						return []execinfrapb.ProducerMetadata{{Err: errors.New(expectedMeta)}}
@@ -474,7 +475,7 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 			inboxMemAcc := testMemMonitor.MakeBoundAccount()
 			defer inboxMemAcc.Close(ctx)
 			inbox, err := NewInbox(
-				colmem.NewAllocator(ctx, &inboxMemAcc),
+				colmem.NewAllocator(ctx, &inboxMemAcc, testColumnFactory),
 				typs, execinfrapb.StreamID(0),
 			)
 			require.NoError(t, err)
@@ -536,13 +537,14 @@ func BenchmarkOutboxInbox(b *testing.B) {
 
 	outboxMemAcc := testMemMonitor.MakeBoundAccount()
 	defer outboxMemAcc.Close(ctx)
-	outbox, err := NewOutbox(colmem.NewAllocator(ctx, &outboxMemAcc), input, typs, nil /* metadataSources */, nil /* toClose */)
+	outbox, err :=
+		NewOutbox(colmem.NewAllocator(ctx, &outboxMemAcc, testColumnFactory), input, typs, nil /* metadataSources */, nil /* toClose */)
 	require.NoError(b, err)
 
 	inboxMemAcc := testMemMonitor.MakeBoundAccount()
 	defer inboxMemAcc.Close(ctx)
 	inbox, err := NewInbox(
-		colmem.NewAllocator(ctx, &inboxMemAcc), typs, execinfrapb.StreamID(0),
+		colmem.NewAllocator(ctx, &inboxMemAcc, testColumnFactory), typs, execinfrapb.StreamID(0),
 	)
 	require.NoError(b, err)
 
@@ -600,7 +602,8 @@ func TestOutboxStreamIDPropagation(t *testing.T) {
 
 	outboxMemAcc := testMemMonitor.MakeBoundAccount()
 	defer outboxMemAcc.Close(ctx)
-	outbox, err := NewOutbox(colmem.NewAllocator(ctx, &outboxMemAcc), input, typs, nil /* metadataSources */, nil /* toClose */)
+	outbox, err :=
+		NewOutbox(colmem.NewAllocator(ctx, &outboxMemAcc, testColumnFactory), input, typs, nil /* metadataSources */, nil /* toClose */)
 	require.NoError(t, err)
 
 	outboxDone := make(chan struct{})

--- a/pkg/sql/colflow/colrpc/inbox_test.go
+++ b/pkg/sql/colflow/colrpc/inbox_test.go
@@ -224,7 +224,7 @@ func TestInboxShutdown(t *testing.T) {
 					inboxMemAccount := testMemMonitor.MakeBoundAccount()
 					defer inboxMemAccount.Close(inboxCtx)
 					inbox, err := NewInbox(
-						colmem.NewAllocator(inboxCtx, &inboxMemAccount),
+						colmem.NewAllocator(inboxCtx, &inboxMemAccount, testColumnFactory),
 						typs, execinfrapb.StreamID(0),
 					)
 					require.NoError(t, err)

--- a/pkg/sql/colflow/colrpc/main_test.go
+++ b/pkg/sql/colflow/colrpc/main_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -30,6 +31,8 @@ var (
 	// and a memory account bound to it for use in tests.
 	testMemMonitor *mon.BytesMonitor
 	testMemAcc     *mon.BoundAccount
+
+	testColumnFactory coldata.ColumnFactory
 )
 
 func TestMain(m *testing.M) {
@@ -40,7 +43,8 @@ func TestMain(m *testing.M) {
 		defer testMemMonitor.Stop(ctx)
 		memAcc := testMemMonitor.MakeBoundAccount()
 		testMemAcc = &memAcc
-		testAllocator = colmem.NewAllocator(ctx, testMemAcc)
+		testColumnFactory = colmem.NewExtendedColumnFactory(nil /* evalCtx */)
+		testAllocator = colmem.NewAllocator(ctx, testMemAcc, testColumnFactory)
 		defer testMemAcc.Close(ctx)
 		return m.Run()
 	}())

--- a/pkg/sql/colflow/colrpc/outbox_test.go
+++ b/pkg/sql/colflow/colrpc/outbox_test.go
@@ -54,7 +54,7 @@ func TestOutboxCatchesPanics(t *testing.T) {
 	inboxMemAccount := testMemMonitor.MakeBoundAccount()
 	defer inboxMemAccount.Close(ctx)
 	inbox, err := NewInbox(
-		colmem.NewAllocator(ctx, &inboxMemAccount), typs, execinfrapb.StreamID(0),
+		colmem.NewAllocator(ctx, &inboxMemAccount, testColumnFactory), typs, execinfrapb.StreamID(0),
 	)
 	require.NoError(t, err)
 
@@ -108,7 +108,7 @@ func TestOutboxDrainsMetadataSources(t *testing.T) {
 		outboxMemAccount := testMemMonitor.MakeBoundAccount()
 		defer outboxMemAccount.Close(ctx)
 		outbox, sourceDrained, err := newOutboxWithMetaSources(
-			colmem.NewAllocator(ctx, &outboxMemAccount),
+			colmem.NewAllocator(ctx, &outboxMemAccount, testColumnFactory),
 		)
 		require.NoError(t, err)
 

--- a/pkg/sql/colflow/main_test.go
+++ b/pkg/sql/colflow/main_test.go
@@ -55,7 +55,8 @@ func TestMain(m *testing.M) {
 		defer testMemMonitor.Stop(ctx)
 		memAcc := testMemMonitor.MakeBoundAccount()
 		testMemAcc = &memAcc
-		testAllocator = colmem.NewAllocator(ctx, testMemAcc)
+		columnFactory := colmem.NewExtendedColumnFactory(nil /* evalCtx */)
+		testAllocator = colmem.NewAllocator(ctx, testMemAcc, columnFactory)
 		defer testMemAcc.Close(ctx)
 
 		testDiskMonitor = execinfra.NewTestDiskMonitor(ctx, cluster.MakeTestingClusterSettings())

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -601,9 +601,10 @@ func (s *vectorizedFlowCreator) setupRemoteOutputStream(
 	stream *execinfrapb.StreamEndpointSpec,
 	metadataSourcesQueue []execinfrapb.MetadataSource,
 	toClose []colexec.IdempotentCloser,
+	columnFactory coldata.ColumnFactory,
 ) (execinfra.OpNode, error) {
 	outbox, err := s.remoteComponentCreator.newOutbox(
-		colmem.NewAllocator(ctx, s.newStreamingMemAccount(flowCtx)),
+		colmem.NewAllocator(ctx, s.newStreamingMemAccount(flowCtx), columnFactory),
 		op, outputTyps, metadataSourcesQueue, toClose,
 	)
 	if err != nil {
@@ -645,6 +646,7 @@ func (s *vectorizedFlowCreator) setupRouter(
 	output *execinfrapb.OutputRouterSpec,
 	metadataSourcesQueue []execinfrapb.MetadataSource,
 	toClose []colexec.IdempotentCloser,
+	columnFactory coldata.ColumnFactory,
 ) error {
 	if output.Type != execinfrapb.OutputRouterSpec_BY_HASH {
 		return errors.Errorf("vectorized output router type %s unsupported", output.Type)
@@ -661,7 +663,7 @@ func (s *vectorizedFlowCreator) setupRouter(
 	allocators := make([]*colmem.Allocator, len(output.Streams))
 	for i := range allocators {
 		acc := hashRouterMemMonitor.MakeBoundAccount()
-		allocators[i] = colmem.NewAllocator(ctx, &acc)
+		allocators[i] = colmem.NewAllocator(ctx, &acc, columnFactory)
 		s.accounts = append(s.accounts, &acc)
 	}
 	limit := execinfra.GetWorkMemLimit(flowCtx.Cfg)
@@ -689,7 +691,7 @@ func (s *vectorizedFlowCreator) setupRouter(
 			return errors.Errorf("unexpected sync response output when setting up router")
 		case execinfrapb.StreamEndpointSpec_REMOTE:
 			if _, err := s.setupRemoteOutputStream(
-				ctx, flowCtx, op, outputTyps, stream, metadataSourcesQueue, toClose,
+				ctx, flowCtx, op, outputTyps, stream, metadataSourcesQueue, toClose, columnFactory,
 			); err != nil {
 				return err
 			}
@@ -736,6 +738,7 @@ func (s *vectorizedFlowCreator) setupInput(
 	flowCtx *execinfra.FlowCtx,
 	input execinfrapb.InputSyncSpec,
 	opt flowinfra.FuseOpt,
+	columnFactory coldata.ColumnFactory,
 ) (op colexecbase.Operator, _ []execinfrapb.MetadataSource, _ error) {
 	inputStreamOps := make([]colexecbase.Operator, 0, len(input.Streams))
 	metaSources := make([]execinfrapb.MetadataSource, 0, len(input.Streams))
@@ -755,7 +758,7 @@ func (s *vectorizedFlowCreator) setupInput(
 				return nil, nil, err
 			}
 			inbox, err := s.remoteComponentCreator.newInbox(
-				colmem.NewAllocator(ctx, s.newStreamingMemAccount(flowCtx)),
+				colmem.NewAllocator(ctx, s.newStreamingMemAccount(flowCtx), columnFactory),
 				input.ColumnTypes, inputStream.StreamID,
 			)
 			if err != nil {
@@ -794,7 +797,7 @@ func (s *vectorizedFlowCreator) setupInput(
 		if input.Type == execinfrapb.InputSyncSpec_ORDERED {
 			var err error
 			op, err = colexec.NewOrderedSynchronizer(
-				colmem.NewAllocator(ctx, s.newStreamingMemAccount(flowCtx)),
+				colmem.NewAllocator(ctx, s.newStreamingMemAccount(flowCtx), columnFactory),
 				inputStreamOps, input.ColumnTypes, execinfrapb.ConvertToColumnOrdering(input.Ordering),
 			)
 			if err != nil {
@@ -839,6 +842,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 	opOutputTypes []types.T,
 	metadataSourcesQueue []execinfrapb.MetadataSource,
 	toClose []colexec.IdempotentCloser,
+	columnFactory coldata.ColumnFactory,
 ) error {
 	output := &pspec.Output[0]
 	if output.Type != execinfrapb.OutputRouterSpec_PASS_THROUGH {
@@ -852,6 +856,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 			// further appends without overwriting.
 			metadataSourcesQueue,
 			toClose,
+			columnFactory,
 		)
 	}
 
@@ -887,7 +892,8 @@ func (s *vectorizedFlowCreator) setupOutput(
 				},
 			)
 		}
-		outbox, err := s.setupRemoteOutputStream(ctx, flowCtx, op, opOutputTypes, outputStream, metadataSourcesQueue, toClose)
+		outbox, err :=
+			s.setupRemoteOutputStream(ctx, flowCtx, op, opOutputTypes, outputStream, metadataSourcesQueue, toClose, columnFactory)
 		if err != nil {
 			return err
 		}
@@ -947,6 +953,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 	opt flowinfra.FuseOpt,
 ) (leaves []execinfra.OpNode, err error) {
 	streamIDToSpecIdx := make(map[execinfrapb.StreamID]int)
+	columnFactory := colmem.NewExtendedColumnFactory(flowCtx.NewEvalCtx())
 	// queue is a queue of indices into processorSpecs, for topologically
 	// ordered processing.
 	queue := make([]int, 0, len(processorSpecs))
@@ -989,7 +996,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 		toClose := make([]colexec.IdempotentCloser, 0, 1)
 		inputs = inputs[:0]
 		for i := range pspec.Input {
-			input, metadataSources, err := s.setupInput(ctx, flowCtx, pspec.Input[i], opt)
+			input, metadataSources, err := s.setupInput(ctx, flowCtx, pspec.Input[i], opt, columnFactory)
 			if err != nil {
 				return nil, err
 			}
@@ -1052,7 +1059,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 			return nil, err
 		}
 		if err = s.setupOutput(
-			ctx, flowCtx, pspec, op, result.ColumnTypes, metadataSourcesQueue, toClose,
+			ctx, flowCtx, pspec, op, result.ColumnTypes, metadataSourcesQueue, toClose, columnFactory,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -136,6 +136,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 				defer cancelRemote()
 				st := cluster.MakeTestingClusterSettings()
 				evalCtx := tree.MakeTestingEvalContext(st)
+				columnFactory := colmem.NewExtendedColumnFactory(&evalCtx)
 				defer evalCtx.Stop(ctxLocal)
 				flowCtx := &execinfra.FlowCtx{
 					EvalCtx: &evalCtx,
@@ -173,7 +174,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 				for i := range allocators {
 					acc := testMemMonitor.MakeBoundAccount()
 					defer acc.Close(ctxRemote)
-					allocators[i] = colmem.NewAllocator(ctxRemote, &acc)
+					allocators[i] = colmem.NewAllocator(ctxRemote, &acc, columnFactory)
 					diskAcc := testDiskMonitor.MakeBoundAccount()
 					diskAccounts[i] = &diskAcc
 					defer diskAcc.Close(ctxRemote)
@@ -186,7 +187,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					inboxMemAccount := testMemMonitor.MakeBoundAccount()
 					defer inboxMemAccount.Close(ctxLocal)
 					inbox, err := colrpc.NewInbox(
-						colmem.NewAllocator(ctxLocal, &inboxMemAccount), typs, execinfrapb.StreamID(streamID),
+						colmem.NewAllocator(ctxLocal, &inboxMemAccount, columnFactory), typs, execinfrapb.StreamID(streamID),
 					)
 					require.NoError(t, err)
 					inboxes = append(inboxes, inbox)
@@ -214,18 +215,19 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					idToClosed.Lock()
 					idToClosed.mapping[id] = false
 					idToClosed.Unlock()
-					outbox, err := colrpc.NewOutbox(colmem.NewAllocator(ctx, outboxMemAcc), outboxInput, typs, append(outboxMetadataSources,
-						execinfrapb.CallbackMetadataSource{
+					outbox, err := colrpc.NewOutbox(colmem.NewAllocator(ctx, outboxMemAcc, columnFactory), outboxInput, typs,
+						append(outboxMetadataSources, execinfrapb.CallbackMetadataSource{
 							DrainMetaCb: func(ctx context.Context) []execinfrapb.ProducerMetadata {
 								return []execinfrapb.ProducerMetadata{{Err: errors.Errorf("%d", id)}}
 							},
 						},
-					), []colexec.IdempotentCloser{callbackCloser{closeCb: func() error {
-						idToClosed.Lock()
-						idToClosed.mapping[id] = true
-						idToClosed.Unlock()
-						return nil
-					}}})
+						), []colexec.IdempotentCloser{callbackCloser{closeCb: func() error {
+							idToClosed.Lock()
+							idToClosed.mapping[id] = true
+							idToClosed.Unlock()
+							return nil
+						}}})
+
 					require.NoError(t, err)
 					wg.Add(1)
 					go func(id int) {
@@ -264,7 +266,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					} else {
 						sourceMemAccount := testMemMonitor.MakeBoundAccount()
 						defer sourceMemAccount.Close(ctxRemote)
-						remoteAllocator := colmem.NewAllocator(ctxRemote, &sourceMemAccount)
+						remoteAllocator := colmem.NewAllocator(ctxRemote, &sourceMemAccount, columnFactory)
 						batch := remoteAllocator.NewMemBatch(typs)
 						batch.SetLength(coldata.BatchSize())
 						runOutboxInbox(ctxRemote, cancelRemote, &outboxMemAccount, colexecbase.NewRepeatableBatchSource(remoteAllocator, batch, typs), inboxes[i], streamID, outboxMetadataSources)
@@ -279,7 +281,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					inboxMemAccount := testMemMonitor.MakeBoundAccount()
 					defer inboxMemAccount.Close(ctxAnotherRemote)
 					inbox, err := colrpc.NewInbox(
-						colmem.NewAllocator(ctxAnotherRemote, &inboxMemAccount),
+						colmem.NewAllocator(ctxAnotherRemote, &inboxMemAccount, columnFactory),
 						typs, execinfrapb.StreamID(streamID),
 					)
 					require.NoError(t, err)

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -32,8 +33,9 @@ import (
 //
 // In the future this can also be used to pool coldata.Vec allocations.
 type Allocator struct {
-	ctx context.Context
-	acc *mon.BoundAccount
+	ctx     context.Context
+	acc     *mon.BoundAccount
+	factory coldata.ColumnFactory
 }
 
 func selVectorSize(capacity int) int64 {
@@ -78,8 +80,14 @@ func GetProportionalBatchMemSize(b coldata.Batch, length int64) int64 {
 }
 
 // NewAllocator constructs a new Allocator instance.
-func NewAllocator(ctx context.Context, acc *mon.BoundAccount) *Allocator {
-	return &Allocator{ctx: ctx, acc: acc}
+func NewAllocator(
+	ctx context.Context, acc *mon.BoundAccount, factory coldata.ColumnFactory,
+) *Allocator {
+	return &Allocator{
+		ctx:     ctx,
+		acc:     acc,
+		factory: factory,
+	}
 }
 
 // NewMemBatch allocates a new in-memory coldata.Batch.
@@ -94,7 +102,7 @@ func (a *Allocator) NewMemBatchWithSize(typs []types.T, size int) coldata.Batch 
 	if err := a.acc.Grow(a.ctx, estimatedMemoryUsage); err != nil {
 		colexecerror.InternalError(err)
 	}
-	return coldata.NewMemBatchWithSize(typs, size)
+	return coldata.NewMemBatchWithSize(typs, size, a.factory)
 }
 
 // NewMemBatchNoCols creates a "skeleton" of new in-memory coldata.Batch. It
@@ -159,7 +167,7 @@ func (a *Allocator) NewMemColumn(t *types.T, n int) coldata.Vec {
 	if err := a.acc.Grow(a.ctx, estimatedMemoryUsage); err != nil {
 		colexecerror.InternalError(err)
 	}
-	return coldata.NewMemColumn(t, n)
+	return coldata.NewMemColumn(t, n, a.factory)
 }
 
 // MaybeAppendColumn might append a newly allocated coldata.Vec of the given
@@ -251,6 +259,9 @@ const (
 	sizeOfFloat64  = int(unsafe.Sizeof(float64(0)))
 	sizeOfTime     = int(unsafe.Sizeof(time.Time{}))
 	sizeOfDuration = int(unsafe.Sizeof(duration.Duration{}))
+	// Since we currently only support JSON using datum, we use tree.DJSON struct
+	// to estimate the size of datum.
+	sizeOfDatum = int(unsafe.Sizeof(tree.DJSON{}))
 )
 
 // SizeOfBatchSizeSelVector is the size (in bytes) of a selection vector of
@@ -300,6 +311,8 @@ func EstimateBatchSizeBytes(vecTypes []coltypes.T, batchLength int) int {
 			acc += sizeOfTime
 		case coltypes.Interval:
 			acc += sizeOfDuration
+		case coltypes.Datum:
+			acc += sizeOfDatum
 		case coltypes.Unhandled:
 			// Placeholder coldata.Vecs of unknown types are allowed.
 		default:

--- a/pkg/sql/colmem/datum_vec.go
+++ b/pkg/sql/colmem/datum_vec.go
@@ -1,0 +1,234 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colmem
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+)
+
+// DatumVec is a vector of tree.Datum of the same type.
+// NOTE: currently vectorized engine only support JSON through datum types.
+// this is due to the difficulties of consolidating logical type systems and
+// physical type systems used in the vectorized engine.
+type DatumVec struct {
+	// typ is the type of the tree.Datum that DatumVec stores.
+	typ *types.T
+
+	// data is the underlying data stored in DatumVec.
+	data []tree.Datum
+
+	// evalCtx is required for most of the tree.Datum interfaces.
+	evalCtx *tree.EvalContext
+
+	da sqlbase.DatumAlloc
+}
+
+var _ coldata.DatumContainer = &DatumVec{}
+
+// ContextWrappedDatum wraps a tree.Datum with tree.EvalContext. This is the
+// struct that DatumVec.Get() returns. The wrapped tree.EvalContext is used for
+// calling tree.Datum interfaces and this avoided us to plumb down
+// tree.EvalContext everywhere into vectorized engine.
+type ContextWrappedDatum struct {
+	tree.Datum
+	evalCtx *tree.EvalContext
+}
+
+var _ coldata.DatumContainerElem = &ContextWrappedDatum{}
+
+// CompareElem returns the comparison between cd and other value. The other is
+// assumed to be tree.Datum.
+func (cd *ContextWrappedDatum) CompareElem(otherElem interface{}) int {
+	var other tree.Datum
+	if otherElem == nil {
+		other = tree.DNull
+	} else {
+		other = otherElem.(tree.Datum)
+	}
+	unwrapped := other
+	if ou, ok := other.(*ContextWrappedDatum); ok {
+		unwrapped = ou.Datum
+	}
+	return cd.Datum.Compare(cd.evalCtx, unwrapped)
+}
+
+// NewDatumVec returns a DatumVec struct with capacity of n.
+func NewDatumVec(n int, evalCtx *tree.EvalContext) coldata.DatumContainer {
+	return &DatumVec{
+		// TODO(azhng): we hard code the DatumVec type to Json due to the type
+		//  system restrictions, see struct definition note for details.
+		typ:     types.Jsonb,
+		data:    make([]tree.Datum, n),
+		evalCtx: evalCtx,
+	}
+}
+
+// Get returns *ContextWrappedDatum which wraps the ith tree.Datum in DatumVec
+// and the evalCtx stored inside DatumVec.
+func (dv *DatumVec) Get(i int) coldata.DatumContainerElem {
+	v := dv.data[i]
+	if v == nil {
+		v = tree.DNull
+	}
+	return &ContextWrappedDatum{
+		Datum:   v,
+		evalCtx: dv.evalCtx,
+	}
+}
+
+// Set sets ith element of DatumVec to given tree.Datum v.
+func (dv *DatumVec) Set(i int, v coldata.DatumContainerElem) {
+	datum, evalCtx := unwrapContainerElemAsDatum(v)
+	dv.ensureValidDatum(datum)
+	dv.data[i] = datum
+	if dv.evalCtx == nil {
+		dv.evalCtx = evalCtx
+	}
+}
+
+// Slice creates a "window" into the receiver. It behaves similarly to
+// Golang's slice.
+func (dv *DatumVec) Slice(start, end int) coldata.DatumContainer {
+	return &DatumVec{
+		typ:  dv.typ,
+		data: dv.data[start:end],
+	}
+}
+
+// CopySlice copies srcStartIdx inclusive and srcEndIdx exclusive tree.Datum
+// values from src into the receiver starting at destIdx.
+func (dv *DatumVec) CopySlice(src coldata.DatumContainer, destIdx, srcStartIdx, srcEndIdx int) {
+	castSrc := src.(*DatumVec)
+	dv.ensureValidDatumType(castSrc.typ)
+	copy(dv.data[destIdx:], castSrc.data[srcStartIdx:srcEndIdx])
+	dv.evalCtx = castSrc.evalCtx
+}
+
+// AppendSlice appends srcStartIdx inclusive and srcEndIdx exclusive tree.Datum
+// values from src into the receiver starting at destIdx.
+func (dv *DatumVec) AppendSlice(src coldata.DatumContainer, destIdx, srcStartIdx, srcEndIdx int) {
+	castSrc := src.(*DatumVec)
+	dv.ensureValidDatumType(castSrc.typ)
+	dv.data = append(dv.data[:destIdx], castSrc.data[srcStartIdx:srcEndIdx]...)
+	dv.evalCtx = castSrc.evalCtx
+}
+
+// AppendVal appends the given tree.Datum value to the end of the receiver.
+func (dv *DatumVec) AppendVal(v coldata.DatumContainerElem) {
+	datum, evalCtx := unwrapContainerElemAsDatum(v)
+	dv.ensureValidDatum(datum)
+	dv.data = append(dv.data, datum)
+	if dv.evalCtx == nil {
+		dv.evalCtx = evalCtx
+	}
+}
+
+// SetLength sets the length of this DatumVec.
+func (dv *DatumVec) SetLength(l int) {
+	dv.data = dv.data[:l]
+}
+
+// Len returns how many tree.Datum the DatumVec contains.
+func (dv *DatumVec) Len() int {
+	return len(dv.data)
+}
+
+// Cap returns the capacity of DatumVec.
+func (dv *DatumVec) Cap() int {
+	return cap(dv.data)
+}
+
+// MarshalAt returns the marshaled byte of datum at i.
+func (dv *DatumVec) MarshalAt(i int) ([]byte, error) {
+	datum := dv.data[i]
+	// Append/Copy will copy/append values to dv.data regardless if it is nil.
+	if datum == nil {
+		datum = tree.DNull
+	}
+	switch dv.typ {
+	case types.Jsonb:
+		var bytes, scratch []byte
+		b, err := sqlbase.EncodeTableValue(bytes, sqlbase.ColumnID(encoding.NoColumnID), datum, scratch)
+		if err != nil {
+			return nil, err
+		}
+		return b, nil
+	default:
+		colexecerror.InternalError(fmt.Sprintf("unsupported type %v", dv.typ))
+		// Unreachable code, but compiler cannot detect that.
+		return nil, nil
+	}
+}
+
+// UnmarshalTo unmarshals the byte to datum and set it at i.
+func (dv *DatumVec) UnmarshalTo(i int, b []byte) error {
+	switch dv.typ.Family() {
+	case types.JsonFamily:
+		datum, _, err := sqlbase.DecodeTableValue(&dv.da, dv.typ, b)
+		if err != nil {
+			return err
+		}
+		dv.data[i] = datum
+		return nil
+	default:
+		return fmt.Errorf("unsupported type for DatumVec %v", dv.typ)
+	}
+}
+
+// SetType sets the type of DatumVec.
+func (dv *DatumVec) SetType(t *types.T) {
+	dv.typ = t
+}
+
+// ensureValidDatum ensures that the given datum has the same type as *types.T
+// associated with the receiver if it is not null.
+func (dv *DatumVec) ensureValidDatum(datum tree.Datum) {
+	if datum != tree.DNull {
+		dv.ensureValidDatumType(datum.ResolvedType())
+	}
+}
+
+// ensureValidDatumType ensures that the given *types.T is same as the *types.T
+// associated with the receiver if it is not null.
+func (dv *DatumVec) ensureValidDatumType(typ *types.T) {
+	if !dv.typ.Equal(*typ) {
+		panic(
+			fmt.Sprintf("cannot use value of type %v on a DatumVec of type: %v",
+				typ, dv.typ,
+			),
+		)
+	}
+}
+
+// unwrapContainerElemAsDatum unwraps the datum and  if it is wrapped inside
+// ContextWrappedDatum. This is to prevent us from recursively wrapping datums.
+func unwrapContainerElemAsDatum(v coldata.DatumContainerElem) (tree.Datum, *tree.EvalContext) {
+	if v == nil {
+		return tree.DNull, nil
+	}
+	if datum, ok := v.(*ContextWrappedDatum); ok {
+		return datum.Datum, datum.evalCtx
+	} else if datum, ok := v.(tree.Datum); ok {
+		return datum, nil
+	}
+	colexecerror.InternalError(
+		fmt.Sprintf("unexpected value: %v", v))
+
+	// Unreachable code, but compiler can't detect that.
+	return nil, nil
+}

--- a/pkg/sql/colmem/datum_vec_test.go
+++ b/pkg/sql/colmem/datum_vec_test.go
@@ -1,0 +1,146 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colmem
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextWrappedDatum(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	evalCtx := &tree.EvalContext{}
+
+	var d1 *ContextWrappedDatum
+	var d2 tree.Datum
+	d1 = &ContextWrappedDatum{
+		Datum:   &tree.DJSON{JSON: json.FromString("string")},
+		evalCtx: evalCtx,
+	}
+	d2 = &tree.DJSON{JSON: json.FromString("string")}
+
+	// ContextWrappedDatum can be compared with regular datum.
+	require.Equal(t, 0 /* expected */, d1.CompareElem(d2))
+
+	d2 = &ContextWrappedDatum{
+		Datum:   d2,
+		evalCtx: nil,
+	}
+
+	// ContextWrappedDatum can be compared with another ContextWrappedDatum.
+	require.Equal(t, 0 /* expected */, d1.CompareElem(d2))
+
+	// ContextWrappedDatum implicitly views nil as tree.DNull.
+	require.Equal(t, d1.CompareElem(tree.DNull) /* expected */, d1.CompareElem(nil /* other */))
+
+	// ContextWrappedDatum panics if compared with incompatible type.
+	d2 = tree.NewDString("s")
+	require.Panics(t,
+		func() { d1.CompareElem(d2) },
+		"Different datum type should cause panic when compared",
+	)
+
+	d2 = &ContextWrappedDatum{Datum: d2}
+	require.Panics(t,
+		func() { d1.CompareElem(d2) },
+		"Different datum type should cause panic when compared",
+	)
+}
+
+func TestDatumVec(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	evalCtx := &tree.EvalContext{}
+
+	dv1 := NewDatumVec(0 /* n */, evalCtx)
+
+	var expected coldata.DatumContainerElem
+	expected = tree.NewDJSON(json.FromString("str1"))
+	dv1.AppendVal(expected)
+	require.Equal(t, 0, /* expected */
+		fetchContextWrappedDatum(dv1, 0 /* idx */).Compare(evalCtx, expected.(tree.Datum)))
+
+	expected = tree.NewDJSON(json.FromString("str2"))
+	dv1.AppendVal(expected)
+	require.Equal(t, 0, /* expected */
+		fetchContextWrappedDatum(dv1, 1 /* idx */).Compare(evalCtx, expected.(tree.Datum)))
+	require.Equal(t, 2, dv1.Len())
+
+	invalidDatum, _ := tree.ParseDInt("10")
+	require.Panics(
+		t,
+		func() { dv1.Set(0 /* i */, invalidDatum) },
+		"should not be able to set datum of different type",
+	)
+
+	dv1 = NewDatumVec(0 /* n */, evalCtx)
+	dv2 := NewDatumVec(0 /* n */, evalCtx)
+
+	dv1.AppendVal(tree.NewDJSON(json.FromString("str1")))
+	dv1.AppendVal(tree.NewDJSON(json.FromString("str2")))
+
+	// Truncating dv1.
+	require.Equal(t, 2 /* expected */, dv1.Len())
+	dv1.AppendSlice(dv2, 0 /* destIdx */, 0 /* srcStartIdx */, 0 /* srcEndIdx */)
+	require.Equal(t, 0 /* expected */, dv1.Len())
+
+	dv1.AppendVal(tree.NewDJSON(json.FromString("dv1 str")))
+	dv2.AppendVal(tree.NewDJSON(json.FromString("dv2 str")))
+	// Try appending dv2 to dv1 3 times. The first time will overwrite the
+	// current present value in dv1.
+	for i := 0; i < 3; i++ {
+		dv1.AppendSlice(dv2, i, 0 /* srcStartIdx */, dv2.Len())
+		require.Equal(t, i+1, dv1.Len())
+		for j := 0; j <= i; j++ {
+			require.Equal(t, 0, /* expected */
+				fetchContextWrappedDatum(dv1, j).Compare(evalCtx, tree.NewDJSON(json.FromString("dv2 str"))))
+		}
+	}
+
+	dv2 = NewDatumVec(0 /* n */, evalCtx)
+	dv2.AppendVal(tree.NewDJSON(json.FromString("dv2 str1")))
+	dv2.AppendVal(tree.NewDJSON(json.FromString("dv2 str2")))
+	dv2.AppendVal(nil /* v */)
+	dv2.AppendVal(tree.NewDJSON(json.FromString("dv2 str3")))
+
+	dv1.AppendSlice(dv2, 1 /* destIdx */, 1 /* srcStartIdx */, 3 /* srcEndIdx */)
+	require.Equal(t, 3 /* expected */, dv1.Len())
+	require.Equal(t, 0, /* expected */
+		fetchContextWrappedDatum(dv1, 0 /* idx */).Compare(evalCtx, tree.NewDJSON(json.FromString("dv2 str"))))
+	require.Equal(t, 0, /* expected */
+		fetchContextWrappedDatum(dv1, 1 /* idx */).Compare(evalCtx, tree.NewDJSON(json.FromString("dv2 str2"))))
+	require.Equal(t, 0, /* expected */
+		fetchContextWrappedDatum(dv1, 2 /* idx */).Compare(evalCtx, tree.DNull))
+
+	dv2 = NewDatumVec(0 /* n */, evalCtx)
+	dv2.AppendVal(tree.NewDJSON(json.FromString("string0")))
+	dv2.AppendVal(nil /* v */)
+	dv2.AppendVal(tree.NewDJSON(json.FromString("string2")))
+
+	dv1.CopySlice(dv2, 0 /* destIdx */, 0 /* srcStartIdx */, 3 /* srcEndIdx */)
+	require.Equal(t, 3 /* expected */, dv1.Len())
+	require.Equal(t, 0, /* expected */
+		fetchContextWrappedDatum(dv1, 0 /* idx */).Compare(evalCtx, tree.NewDJSON(json.FromString("string0"))))
+	require.Equal(t, 0, /* expected */
+		fetchContextWrappedDatum(dv1, 1 /* idx */).Compare(evalCtx, tree.DNull))
+	require.Equal(t, 0, /* expected */
+		fetchContextWrappedDatum(dv1, 2 /* idx */).Compare(evalCtx, tree.NewDJSON(json.FromString("string2"))))
+}
+
+func fetchContextWrappedDatum(vec coldata.DatumContainer, idx int) tree.Datum {
+	return vec.Get(idx).(tree.Datum)
+}

--- a/pkg/sql/colmem/extended_column_factory.go
+++ b/pkg/sql/colmem/extended_column_factory.go
@@ -1,0 +1,39 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colmem
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// extendedColumnFactory stores an evalCtx which can be used to construct
+// DatumVec later. This is to prevent plumbing evalCtx to all vectorized
+// operators as well as avoiding introducing dependency from coldata to tree
+// package.
+type extendedColumnFactory struct {
+	evalCtx *tree.EvalContext
+}
+
+var _ coldata.ColumnFactory = &extendedColumnFactory{}
+
+// NewExtendedColumnFactory returns an extendedColumnFactory instance.
+func NewExtendedColumnFactory(evalCtx *tree.EvalContext) coldata.ColumnFactory {
+	return &extendedColumnFactory{evalCtx: evalCtx}
+}
+
+func (cf *extendedColumnFactory) ConstructColumn(t coltypes.T, n int) coldata.Column {
+	if t == coltypes.Datum {
+		return NewDatumVec(n, cf.evalCtx)
+	}
+	return coldata.StandardVectorizedColumnFactory.ConstructColumn(t, n)
+}

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -99,7 +99,8 @@ func verifyColOperator(args verifyColOperatorArgs) error {
 
 	acc := evalCtx.Mon.MakeBoundAccount()
 	defer acc.Close(ctx)
-	testAllocator := colmem.NewAllocator(ctx, &acc)
+	columnFactory := colmem.NewExtendedColumnFactory(&evalCtx)
+	testAllocator := colmem.NewAllocator(ctx, &acc, columnFactory)
 	columnarizers := make([]colexecbase.Operator, len(args.inputs))
 	for i, input := range inputsColOp {
 		c, err := colexec.NewColumnarizer(ctx, testAllocator, flowCtx, int32(i)+1, input)

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -165,7 +165,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
 ----
 ·           distributed  false                        ·       ·
-·           vectorized   false                        ·       ·
+·           vectorized   true                         ·       ·
 index-join  ·            ·                            (a, b)  ·
  │          table        d@primary                    ·       ·
  │          key columns  a                            ·       ·
@@ -177,7 +177,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": {"b": [1]}}'
 ----
 ·           distributed  false                                    ·       ·
-·           vectorized   false                                    ·       ·
+·           vectorized   true                                     ·       ·
 index-join  ·            ·                                        (a, b)  ·
  │          table        d@primary                                ·       ·
  │          key columns  a                                        ·       ·
@@ -189,7 +189,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": [[2]]}}';
 ----
 ·           distributed  false                                            ·       ·
-·           vectorized   false                                            ·       ·
+·           vectorized   true                                             ·       ·
 index-join  ·            ·                                                (a, b)  ·
  │          table        d@primary                                        ·       ·
  │          key columns  a                                                ·       ·
@@ -201,7 +201,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b":true}}';
 ----
 ·           distributed  false                         ·       ·
-·           vectorized   false                         ·       ·
+·           vectorized   true                          ·       ·
 index-join  ·            ·                             (a, b)  ·
  │          table        d@primary                     ·       ·
  │          key columns  a                             ·       ·
@@ -213,7 +213,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'[1]'
 ----
 ·           distributed  false                    ·       ·
-·           vectorized   false                    ·       ·
+·           vectorized   true                     ·       ·
 index-join  ·            ·                        (a, b)  ·
  │          table        d@primary                ·       ·
  │          key columns  a                        ·       ·
@@ -225,7 +225,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'[{"a": {"b": [1]}}]'
 ----
 ·           distributed  false                                            ·       ·
-·           vectorized   false                                            ·       ·
+·           vectorized   true                                             ·       ·
 index-join  ·            ·                                                (a, b)  ·
  │          table        d@primary                                        ·       ·
  │          key columns  a                                                ·       ·
@@ -259,7 +259,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b->'a' = '"b"'
 ----
 ·           distributed  false                        ·       ·
-·           vectorized   false                        ·       ·
+·           vectorized   true                         ·       ·
 index-join  ·            ·                            (a, b)  ·
  │          table        d@primary                    ·       ·
  │          key columns  a                            ·       ·
@@ -271,7 +271,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b->'a'->'c' = '"b"'
 ----
 ·           distributed  false                                ·       ·
-·           vectorized   false                                ·       ·
+·           vectorized   true                                 ·       ·
 index-join  ·            ·                                    (a, b)  ·
  │          table        d@primary                            ·       ·
  │          key columns  a                                    ·       ·
@@ -290,7 +290,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where '"b"' = b->'a'
 ----
 ·           distributed  false                        ·       ·
-·           vectorized   false                        ·       ·
+·           vectorized   true                         ·       ·
 index-join  ·            ·                            (a, b)  ·
  │          table        d@primary                    ·       ·
  │          key columns  a                            ·       ·
@@ -303,7 +303,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b IS NULL
 ----
 ·     distributed  false      ·       ·
-·     vectorized   false      ·       ·
+·     vectorized   true       ·       ·
 scan  ·            ·          (a, b)  ·
 ·     table        d@primary  ·       ·
 ·     spans        FULL SCAN  ·       ·
@@ -464,7 +464,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": 2}'
 ----
 ·                distributed  false                     ·       ·
-·                vectorized   false                     ·       ·
+·                vectorized   true                      ·       ·
 filter           ·            ·                         (a, b)  ·
  │               filter       b @> '{"a": {}, "b": 2}'  ·       ·
  └── index-join  ·            ·                         (a, b)  ·

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -217,7 +217,7 @@ func TestEval(t *testing.T) {
 								return coldata.ZeroBatch
 							}
 							// It doesn't matter what types we create the input batch with.
-							batch := coldata.NewMemBatch(inputTyps)
+							batch := coldata.NewMemBatch(inputTyps, coldata.StandardVectorizedColumnFactory)
 							batch.SetLength(1)
 							batchesReturned++
 							return batch

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -637,6 +637,8 @@ func init() {
 		}
 	}
 
+	a := seedTypes
+	_ = a
 	for _, typ := range types.OidToType {
 		// Don't include un-encodable types.
 		encTyp, err := datumTypeToArrayElementEncodingType(typ)

--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -144,7 +144,7 @@ func (b *bank) Tables() []workload.Table {
 				if rowEnd > b.rows {
 					rowEnd = b.rows
 				}
-				cb.Reset(bankTypes, rowEnd-rowBegin)
+				cb.Reset(bankTypes, rowEnd-rowBegin, coldata.StandardVectorizedColumnFactory)
 				idCol := cb.ColVec(0).Int64()
 				balanceCol := cb.ColVec(1).Int64()
 				payloadCol := cb.ColVec(2).Bytes()

--- a/pkg/workload/bench_test.go
+++ b/pkg/workload/bench_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/bank"
@@ -47,7 +48,7 @@ func benchmarkInitialData(b *testing.B, gen workload.Generator) {
 	for i := 0; i < b.N; i++ {
 		// Share the Batch and ByteAllocator across tables but not across benchmark
 		// iterations.
-		cb := coldata.NewMemBatch(nil)
+		cb := coldata.NewMemBatch(nil /* types */, colmem.NewExtendedColumnFactory(nil /* evalCtx */))
 		var a bufalloc.ByteAllocator
 		for _, table := range tables {
 			for rowIdx := 0; rowIdx < table.InitialRows.NumBatches; rowIdx++ {

--- a/pkg/workload/bulkingest/bulkingest.go
+++ b/pkg/workload/bulkingest/bulkingest.go
@@ -149,7 +149,7 @@ func (w *bulkingest) Tables() []workload.Table {
 					a = ab % w.aCount
 				}
 
-				cb.Reset(bulkingestTypes, w.cCount)
+				cb.Reset(bulkingestTypes, w.cCount, coldata.StandardVectorizedColumnFactory)
 				aCol := cb.ColVec(0).Int64()
 				bCol := cb.ColVec(1).Int64()
 				cCol := cb.ColVec(2).Int64()

--- a/pkg/workload/csv.go
+++ b/pkg/workload/csv.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding/csv"
 	"github.com/pkg/errors"
@@ -39,7 +40,7 @@ const (
 func WriteCSVRows(
 	ctx context.Context, w io.Writer, table Table, rowStart, rowEnd int, sizeBytesLimit int64,
 ) (rowBatchIdx int, err error) {
-	cb := coldata.NewMemBatchWithSize(nil, 0)
+	cb := coldata.NewMemBatchWithSize(nil /* types */, 0 /* size */, colmem.NewExtendedColumnFactory(nil /* evalCtx */))
 	var a bufalloc.ByteAllocator
 
 	bytesWrittenW := &bytesWrittenWriter{w: w}
@@ -91,7 +92,7 @@ type csvRowsReader struct {
 
 func (r *csvRowsReader) Read(p []byte) (n int, err error) {
 	if r.cb == nil {
-		r.cb = coldata.NewMemBatchWithSize(nil, 0)
+		r.cb = coldata.NewMemBatchWithSize(nil /* types */, 0 /* size */, colmem.NewExtendedColumnFactory(nil /* evalCtx */))
 	}
 
 	for {

--- a/pkg/workload/csv_test.go
+++ b/pkg/workload/csv_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -79,7 +80,7 @@ func BenchmarkWriteCSVRows(b *testing.B) {
 
 	var batches []coldata.Batch
 	for _, table := range tpcc.FromWarehouses(1).Tables() {
-		cb := coldata.NewMemBatch(nil)
+		cb := coldata.NewMemBatch(nil /* types */, colmem.NewExtendedColumnFactory(nil /* evalCtx */))
 		var a bufalloc.ByteAllocator
 		table.InitialRows.FillBatch(0, cb, &a)
 		batches = append(batches, cb)
@@ -129,7 +130,7 @@ func TestCSVRowsReader(t *testing.T) {
 func BenchmarkCSVRowsReader(b *testing.B) {
 	var batches []coldata.Batch
 	for _, table := range tpcc.FromWarehouses(1).Tables() {
-		cb := coldata.NewMemBatch(nil)
+		cb := coldata.NewMemBatch(nil /* types */, colmem.NewExtendedColumnFactory(nil /* evalCtx */))
 		var a bufalloc.ByteAllocator
 		table.InitialRows.FillBatch(0, cb, &a)
 		batches = append(batches, cb)

--- a/pkg/workload/interleavedpartitioned/interleavedpartitioned.go
+++ b/pkg/workload/interleavedpartitioned/interleavedpartitioned.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -831,7 +832,7 @@ func (w *interleavedPartitioned) childInitialRowBatchFunc(
 		nowString := timeutil.Now().UTC().Format(time.RFC3339)
 		rng := rand.New(rand.NewSource(int64(sessionRowIdx) + rngFactor))
 
-		cb.Reset(childTypes, nPerBatch)
+		cb.Reset(childTypes, nPerBatch, colmem.NewExtendedColumnFactory(nil /* evalCtx */))
 		sessionIDCol := cb.ColVec(0).Bytes()
 		idCol := cb.ColVec(1).Bytes()
 		valueCol := cb.ColVec(2).Bytes()
@@ -868,7 +869,7 @@ func (w *interleavedPartitioned) deviceInitialRowBatch(
 	sessionID := randomSessionID(sessionRNG, `east`, w.initEastPercent)
 	nowString := timeutil.Now().UTC().Format(time.RFC3339)
 
-	cb.Reset(deviceTypes, w.devicesPerSession)
+	cb.Reset(deviceTypes, w.devicesPerSession, colmem.NewExtendedColumnFactory(nil /* evalCtx */))
 	sessionIDCol := cb.ColVec(0).Bytes()
 	idCol := cb.ColVec(1).Bytes()
 	deviceIDCol := cb.ColVec(2).Bytes()
@@ -908,7 +909,7 @@ func (w *interleavedPartitioned) queryInitialRowBatch(
 	sessionID := randomSessionID(sessionRNG, `east`, w.initEastPercent)
 	nowString := timeutil.Now().UTC().Format(time.RFC3339)
 
-	cb.Reset(queryTypes, w.queriesPerSession)
+	cb.Reset(queryTypes, w.queriesPerSession, colmem.NewExtendedColumnFactory(nil /* evalCtx */))
 	sessionIDCol := cb.ColVec(0).Bytes()
 	idCol := cb.ColVec(1).Bytes()
 	createdCol := cb.ColVec(2).Bytes()

--- a/pkg/workload/tpcc/generate.go
+++ b/pkg/workload/tpcc/generate.go
@@ -81,7 +81,7 @@ func (w *tpcc) tpccItemInitialRowBatch(rowIdx int, cb coldata.Batch, a *bufalloc
 
 	iID := rowIdx + 1
 
-	cb.Reset(itemTypes, 1)
+	cb.Reset(itemTypes, 1, coldata.StandardVectorizedColumnFactory)
 	cb.ColVec(0).Int64()[0] = int64(iID)
 	cb.ColVec(1).Int64()[0] = randInt(l.rng.Rand, 1, 10000)                             // im_id: "Image ID associated to Item"
 	cb.ColVec(2).Bytes().Set(0, randAStringInitialDataOnly(&l.rng, &ao, a, 14, 24))     // name
@@ -125,7 +125,7 @@ func (w *tpcc) tpccWarehouseInitialRowBatch(
 
 	wID := rowIdx // warehouse ids are 0-indexed. every other table is 1-indexed
 
-	cb.Reset(warehouseTypes, 1)
+	cb.Reset(warehouseTypes, 1, coldata.StandardVectorizedColumnFactory)
 	cb.ColVec(0).Int64()[0] = int64(wID)
 	cb.ColVec(1).Bytes().Set(0, []byte(strconv.FormatInt(randInt(l.rng.Rand, 6, 10), 10)))  // name
 	cb.ColVec(2).Bytes().Set(0, []byte(strconv.FormatInt(randInt(l.rng.Rand, 10, 20), 10))) // street_1
@@ -183,7 +183,7 @@ func (w *tpcc) tpccStockInitialRowBatch(rowIdx int, cb coldata.Batch, a *bufallo
 	sID := (rowIdx % numStockPerWarehouse) + 1
 	wID := (rowIdx / numStockPerWarehouse)
 
-	cb.Reset(stockTypes, 1)
+	cb.Reset(stockTypes, 1, coldata.StandardVectorizedColumnFactory)
 	cb.ColVec(0).Int64()[0] = int64(sID)
 	cb.ColVec(1).Int64()[0] = int64(wID)
 	cb.ColVec(2).Int64()[0] = randInt(l.rng.Rand, 10, 100)                           // quantity
@@ -257,7 +257,7 @@ func (w *tpcc) tpccDistrictInitialRowBatch(
 	dID := (rowIdx % numDistrictsPerWarehouse) + 1
 	wID := (rowIdx / numDistrictsPerWarehouse)
 
-	cb.Reset(districtTypes, 1)
+	cb.Reset(districtTypes, 1, coldata.StandardVectorizedColumnFactory)
 	cb.ColVec(0).Int64()[0] = int64(dID)
 	cb.ColVec(1).Int64()[0] = int64(wID)
 	cb.ColVec(2).Bytes().Set(0, randAStringInitialDataOnly(&l.rng, &ao, a, 6, 10))  // name
@@ -347,7 +347,7 @@ func (w *tpcc) tpccCustomerInitialRowBatch(
 		lastName = w.randCLast(l.rng.Rand, a)
 	}
 
-	cb.Reset(customerTypes, 1)
+	cb.Reset(customerTypes, 1, coldata.StandardVectorizedColumnFactory)
 	cb.ColVec(0).Int64()[0] = int64(cID)
 	cb.ColVec(1).Int64()[0] = int64(dID)
 	cb.ColVec(2).Int64()[0] = int64(wID)
@@ -439,7 +439,7 @@ func (w *tpcc) tpccHistoryInitialRowBatch(rowIdx int, cb coldata.Batch, a *bufal
 	dID := ((rowIdx / numCustomersPerDistrict) % numDistrictsPerWarehouse) + 1
 	wID := (rowIdx / numCustomersPerWarehouse)
 
-	cb.Reset(historyTypes, 1)
+	cb.Reset(historyTypes, 1, coldata.StandardVectorizedColumnFactory)
 	cb.ColVec(0).Bytes().Set(0, rowID)
 	cb.ColVec(1).Int64()[0] = int64(cID)
 	cb.ColVec(2).Int64()[0] = int64(dID)
@@ -520,7 +520,7 @@ func (w *tpcc) tpccOrderInitialRowBatch(rowIdx int, cb coldata.Batch, a *bufallo
 		carrierID = randInt(l.rng.Rand, 1, 10)
 	}
 
-	cb.Reset(orderTypes, 1)
+	cb.Reset(orderTypes, 1, coldata.StandardVectorizedColumnFactory)
 	cb.ColVec(0).Int64()[0] = int64(oID)
 	cb.ColVec(1).Int64()[0] = int64(dID)
 	cb.ColVec(2).Int64()[0] = int64(wID)
@@ -570,7 +570,7 @@ func (w *tpcc) tpccNewOrderInitialRowBatch(
 	dID := ((rowIdx / numNewOrdersPerDistrict) % numDistrictsPerWarehouse) + 1
 	wID := (rowIdx / numNewOrdersPerWarehouse)
 
-	cb.Reset(newOrderTypes, 1)
+	cb.Reset(newOrderTypes, 1, coldata.StandardVectorizedColumnFactory)
 	cb.ColVec(0).Int64()[0] = int64(oID)
 	cb.ColVec(1).Int64()[0] = int64(dID)
 	cb.ColVec(2).Int64()[0] = int64(wID)
@@ -615,7 +615,7 @@ func (w *tpcc) tpccOrderLineInitialRowBatch(
 	wID := (orderRowIdx / numOrdersPerWarehouse)
 
 	ao := aCharsOffset(l.rng.Intn(len(aCharsAlphabet)))
-	cb.Reset(orderLineTypes, numOrderLines)
+	cb.Reset(orderLineTypes, numOrderLines, coldata.StandardVectorizedColumnFactory)
 	olOIDCol := cb.ColVec(0).Int64()
 	olDIDCol := cb.ColVec(1).Int64()
 	olWIDCol := cb.ColVec(2).Int64()

--- a/pkg/workload/tpch/generate.go
+++ b/pkg/workload/tpch/generate.go
@@ -67,7 +67,7 @@ func (w *tpch) tpchRegionInitialRowBatch(
 	rng.Seed(w.seed + uint64(batchIdx))
 
 	regionKey := batchIdx
-	cb.Reset(regionTypes, 1)
+	cb.Reset(regionTypes, 1, coldata.StandardVectorizedColumnFactory)
 	cb.ColVec(0).Int16()[0] = int16(regionKey)                       // r_regionkey
 	cb.ColVec(1).Bytes().Set(0, []byte(regionNames[regionKey]))      // r_name
 	cb.ColVec(2).Bytes().Set(0, w.textPool.randString(rng, 31, 115)) // r_comment
@@ -90,7 +90,7 @@ func (w *tpch) tpchNationInitialRowBatch(
 
 	nationKey := batchIdx
 	nation := nations[nationKey]
-	cb.Reset(nationTypes, 1)
+	cb.Reset(nationTypes, 1, coldata.StandardVectorizedColumnFactory)
 	cb.ColVec(0).Int16()[0] = int16(nationKey)                       // n_nationkey
 	cb.ColVec(1).Bytes().Set(0, []byte(nation.name))                 // n_name
 	cb.ColVec(2).Int16()[0] = int16(nation.regionKey)                // n_regionkey
@@ -117,7 +117,7 @@ func (w *tpch) tpchSupplierInitialRowBatch(
 
 	suppKey := int64(batchIdx) + 1
 	nationKey := int16(randInt(rng, 0, 24))
-	cb.Reset(supplierTypes, 1)
+	cb.Reset(supplierTypes, 1, coldata.StandardVectorizedColumnFactory)
 	cb.ColVec(0).Int64()[0] = suppKey                                        // s_suppkey
 	cb.ColVec(1).Bytes().Set(0, supplierName(a, suppKey))                    // s_name
 	cb.ColVec(2).Bytes().Set(0, randVString(rng, a, 10, 40))                 // s_address
@@ -151,7 +151,7 @@ func (w *tpch) tpchPartInitialRowBatch(batchIdx int, cb coldata.Batch, a *bufall
 	rng.Seed(w.seed + uint64(batchIdx))
 
 	partKey := batchIdx + 1
-	cb.Reset(partTypes, 1)
+	cb.Reset(partTypes, 1, coldata.StandardVectorizedColumnFactory)
 
 	// P_PARTKEY unique within [SF * 200,000].
 	cb.ColVec(0).Int64()[0] = int64(partKey)
@@ -192,7 +192,7 @@ func (w *tpch) tpchPartSuppInitialRowBatch(
 	rng.Seed(w.seed + uint64(batchIdx))
 
 	partKey := batchIdx + 1
-	cb.Reset(partSuppTypes, numPartSuppPerPart)
+	cb.Reset(partSuppTypes, numPartSuppPerPart, coldata.StandardVectorizedColumnFactory)
 
 	// P_PARTKEY unique within [SF * 200,000].
 	partKeyCol := cb.ColVec(0).Int64()
@@ -239,7 +239,7 @@ func (w *tpch) tpchCustomerInitialRowBatch(
 	rng.Seed(w.seed + uint64(batchIdx))
 
 	custKey := int64(batchIdx) + 1
-	cb.Reset(customerTypes, 1)
+	cb.Reset(customerTypes, 1, coldata.StandardVectorizedColumnFactory)
 
 	// C_CUSTKEY unique within [SF * 150,000].
 	cb.ColVec(0).Int64()[0] = custKey
@@ -371,7 +371,7 @@ func (w *tpch) tpchOrdersInitialRowBatch(
 	defer w.localsPool.Put(l)
 	rng := l.rng
 
-	cb.Reset(ordersTypes, numOrderPerCustomer)
+	cb.Reset(ordersTypes, numOrderPerCustomer, coldata.StandardVectorizedColumnFactory)
 
 	orderKeyCol := cb.ColVec(0).Int64()
 	custKeyCol := cb.ColVec(1).Int64()
@@ -450,7 +450,7 @@ func (w *tpch) tpchLineItemInitialRowBatch(
 	defer w.localsPool.Put(l)
 	rng := l.rng
 
-	cb.Reset(lineItemTypes, numOrderPerCustomer*7)
+	cb.Reset(lineItemTypes, numOrderPerCustomer*7, coldata.StandardVectorizedColumnFactory)
 
 	orderKeyCol := cb.ColVec(0).Int64()
 	partKeyCol := cb.ColVec(1).Int64()

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes/typeconv"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
@@ -226,7 +227,7 @@ func TypedTuples(count int, typs []types.T, fn func(int) []interface{}) BatchedT
 				}
 			})
 
-			cb.Reset(typs, 1)
+			cb.Reset(typs, 1, coldata.StandardVectorizedColumnFactory)
 			for colIdx, col := range cb.ColVecs() {
 				switch d := row[colIdx].(type) {
 				case nil:
@@ -257,7 +258,7 @@ func TypedTuples(count int, typs []types.T, fn func(int) []interface{}) BatchedT
 // heavy. In performance-critical code, FillBatch should be used directly,
 // instead.
 func (b BatchedTuples) BatchRows(batchIdx int) [][]interface{} {
-	cb := coldata.NewMemBatchWithSize(nil, 0)
+	cb := coldata.NewMemBatchWithSize(nil, 0, colmem.NewExtendedColumnFactory(nil /* evalCtx */))
 	var a bufalloc.ByteAllocator
 	b.FillBatch(batchIdx, cb, &a)
 	return ColBatchToRows(cb)


### PR DESCRIPTION
Previously, when vectorized engine encounters an unsupported data type it falls
back to row execution engine. We introduce new DatumVec in order to use
tree.Datum to support all data types. This PR only introduces support for JSON
types and overloads for datum comparison.

Since we do not want to introduce dependency from `coldata` to `tree` package,
the implementation of DatumVec actually lives in `colmem` package to implement
an interface declared in `coldata` package.


Release note (sql change): vectorized engine now supports JSON columns.

Addresses  #45612. 
