### PR TITLE
opt: split disjunctions with an inverted index

### DIFF
--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -27,7 +27,9 @@ CREATE TABLE c
 (
     k INT PRIMARY KEY,
     a INT[],
-    INVERTED INDEX inv_idx(a)
+    u INT,
+    INVERTED INDEX inv_idx(a),
+    INDEX u(u)
 )
 ----
 
@@ -1221,6 +1223,62 @@ project
                 ├── key: (5)
                 └── fd: (5)-->(7)
 
+# Split and constrain with an inverted index on JSONB on one side.
+opt expect=SplitDisjunction
+SELECT k FROM b WHERE k = 1 OR j @> '{"foo": "bar"}'
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── union
+      ├── columns: k:1!null j:4
+      ├── left columns: k:1!null j:4
+      ├── right columns: k:5 j:8
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── scan b
+      │    ├── columns: k:1!null j:4
+      │    ├── constraint: /1: [/1 - /1]
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    └── fd: ()-->(1,4)
+      └── index-join b
+           ├── columns: k:5!null j:8
+           ├── key: (5)
+           ├── fd: (5)-->(8)
+           └── scan b@inv_idx
+                ├── columns: k:5!null
+                ├── constraint: /8/5: [/'{"foo": "bar"}' - /'{"foo": "bar"}']
+                └── key: (5)
+
+# Split and constrain with an inverted index on an array on one side.
+opt expect=SplitDisjunction
+SELECT k FROM c WHERE k = 1 OR a @> ARRAY[2]
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── union
+      ├── columns: k:1!null a:2
+      ├── left columns: k:1!null a:2
+      ├── right columns: k:4 a:5
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── scan c
+      │    ├── columns: k:1!null a:2
+      │    ├── constraint: /1: [/1 - /1]
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    └── fd: ()-->(1,2)
+      └── index-join c
+           ├── columns: k:4!null a:5
+           ├── key: (4)
+           ├── fd: (4)-->(5)
+           └── scan c@inv_idx
+                ├── columns: k:4!null
+                ├── constraint: /5/4: [/ARRAY[2] - /ARRAY[2]]
+                └── key: (4)
+
 # Uncorrelated subquery.
 opt expect=SplitDisjunction
 SELECT k FROM d WHERE (u = 1 OR v = 1) AND EXISTS (SELECT u, v FROM a)
@@ -1809,6 +1867,64 @@ project
                 ├── constraint: /7/5: [/5 - /8]
                 ├── key: (5)
                 └── fd: (5)-->(7)
+
+# Split and constrain with an inverted index on JSONB on one side.
+opt expect=SplitDisjunctionAddKey
+SELECT u, j FROM b WHERE u = 1 OR j @> '{"foo": "bar"}'
+----
+project
+ ├── columns: u:2 j:4
+ └── union
+      ├── columns: k:1!null u:2 j:4
+      ├── left columns: k:1!null u:2 j:4
+      ├── right columns: k:5 u:6 j:8
+      ├── key: (1,2,4)
+      ├── index-join b
+      │    ├── columns: k:1!null u:2!null j:4
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2), (1)-->(4)
+      │    └── scan b@u
+      │         ├── columns: k:1!null u:2!null
+      │         ├── constraint: /2/1: [/1 - /1]
+      │         ├── key: (1)
+      │         └── fd: ()-->(2)
+      └── index-join b
+           ├── columns: k:5!null u:6 j:8
+           ├── key: (5)
+           ├── fd: (5)-->(6,8)
+           └── scan b@inv_idx
+                ├── columns: k:5!null
+                ├── constraint: /8/5: [/'{"foo": "bar"}' - /'{"foo": "bar"}']
+                └── key: (5)
+
+# Split and constrain with an inverted index on an array on one side.
+opt expect=SplitDisjunctionAddKey
+SELECT u, a FROM c WHERE u = 1 OR a @> ARRAY[2]
+----
+project
+ ├── columns: u:3 a:2
+ └── union
+      ├── columns: k:1!null a:2 u:3
+      ├── left columns: k:1!null a:2 u:3
+      ├── right columns: k:4 a:5 u:6
+      ├── key: (1-3)
+      ├── index-join c
+      │    ├── columns: k:1!null a:2 u:3!null
+      │    ├── key: (1)
+      │    ├── fd: ()-->(3), (1)-->(2)
+      │    └── scan c@u
+      │         ├── columns: k:1!null u:3!null
+      │         ├── constraint: /3/1: [/1 - /1]
+      │         ├── key: (1)
+      │         └── fd: ()-->(3)
+      └── index-join c
+           ├── columns: k:4!null a:5 u:6
+           ├── key: (4)
+           ├── fd: (4)-->(5,6)
+           └── scan c@inv_idx
+                ├── columns: k:4!null
+                ├── constraint: /5/4: [/ARRAY[2] - /ARRAY[2]]
+                └── key: (4)
 
 # Uncorrelated subquery.
 opt expect=SplitDisjunctionAddKey


### PR DESCRIPTION
This commit expands query optimization for disjunctions to support
utilizing constrained inverted index scans.

Prior to this commit, splitting disjunctions into a union of multiple
constrained scans was not supported for a query like below:

```
SELECT * FROM t WHERE a = 1 OR b @> '{"f": "g"}'
```

Now, the resulting query plan is:

```
  distinct-on
   └── union-all
        ├── index-join t
        │    └── scan t@a
        │         └── constraint: /2/1: [/1 - /1]
        └── index-join t
             └── scan t@j
                  └── constraint: /7/5: [/'{"f": "g"}' - /'{"f": "g"}']
```

Release note (performance improvement): Query optimization for
disjunctions was extended to support scans over inverted indexes.