### PR TITLE
geo: add encoding functionality to different formats

### DIFF
--- a/pkg/geo/encode.go
+++ b/pkg/geo/encode.go
@@ -1,0 +1,101 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geo
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
+	"github.com/twpayne/go-geom/encoding/ewkb"
+	"github.com/twpayne/go-geom/encoding/geojson"
+	"github.com/twpayne/go-geom/encoding/kml"
+	"github.com/twpayne/go-geom/encoding/wkb"
+	"github.com/twpayne/go-geom/encoding/wkbhex"
+	"github.com/twpayne/go-geom/encoding/wkt"
+)
+
+// EWKBToWKT transforms a given EWKB to WKT.
+func EWKBToWKT(b geopb.EWKB) (geopb.WKT, error) {
+	t, err := ewkb.Unmarshal([]byte(b))
+	if err != nil {
+		return "", err
+	}
+	ret, err := wkt.Marshal(t)
+	return geopb.WKT(ret), err
+}
+
+// EWKBToEWKT transforms a given EWKB to EWKT.
+func EWKBToEWKT(b geopb.EWKB) (geopb.EWKT, error) {
+	t, err := ewkb.Unmarshal([]byte(b))
+	if err != nil {
+		return "", err
+	}
+	ret, err := wkt.Marshal(t)
+	if err != nil {
+		return "", err
+	}
+	if t.SRID() != 0 {
+		ret = fmt.Sprintf("SRID=%d;%s", t.SRID(), ret)
+	}
+	return geopb.EWKT(ret), err
+}
+
+// EWKBToWKB transforms a given EWKB to WKB.
+func EWKBToWKB(b geopb.EWKB) (geopb.WKB, error) {
+	t, err := ewkb.Unmarshal([]byte(b))
+	if err != nil {
+		return nil, err
+	}
+	ret, err := wkb.Marshal(t, ewkbEncodingFormat)
+	return geopb.WKB(ret), err
+}
+
+// EWKBToGeoJSON transforms a given EWKB to GeoJSON.
+func EWKBToGeoJSON(b geopb.EWKB) ([]byte, error) {
+	t, err := ewkb.Unmarshal([]byte(b))
+	if err != nil {
+		return nil, err
+	}
+	f := geojson.Feature{
+		// TODO(otan): add features once we have spatial_ref_sys.
+		Geometry: t,
+	}
+	return f.MarshalJSON()
+}
+
+// EWKBToWKBHex transforms a given EWKB to WKBHex.
+func EWKBToWKBHex(b geopb.EWKB) (string, error) {
+	t, err := ewkb.Unmarshal([]byte(b))
+	if err != nil {
+		return "", err
+	}
+	ret, err := wkbhex.Encode(t, ewkbEncodingFormat)
+	return strings.ToUpper(ret), err
+}
+
+// EWKBToKML transforms a given EWKB to KML.
+func EWKBToKML(b geopb.EWKB) (string, error) {
+	t, err := ewkb.Unmarshal([]byte(b))
+	if err != nil {
+		return "", err
+	}
+	kmlElement, err := kml.Encode(t)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := kmlElement.Write(&buf); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/pkg/geo/encode_test.go
+++ b/pkg/geo/encode_test.go
@@ -1,0 +1,140 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geo
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEWKBToWKT(t *testing.T) {
+	testCases := []struct {
+		ewkt     geopb.EWKT
+		expected geopb.WKT
+	}{
+		{"POINT(1.0 1.0)", "POINT (1 1)"},
+		{"SRID=4;POINT(1.0 1.0)", "POINT (1 1)"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(string(tc.ewkt), func(t *testing.T) {
+			ewkb, err := ParseEWKT(tc.ewkt, geopb.DefaultGeometrySRID)
+			require.NoError(t, err)
+			encoded, err := EWKBToWKT(ewkb)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, encoded)
+		})
+	}
+}
+
+func TestEWKBToEWKT(t *testing.T) {
+	testCases := []struct {
+		ewkt     geopb.EWKT
+		expected geopb.EWKT
+	}{
+		{"POINT(1.0 1.0)", "POINT (1 1)"},
+		{"SRID=4;POINT(1.0 1.0)", "SRID=4;POINT (1 1)"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(string(tc.ewkt), func(t *testing.T) {
+			ewkb, err := ParseEWKT(tc.ewkt, geopb.DefaultGeometrySRID)
+			require.NoError(t, err)
+			encoded, err := EWKBToEWKT(ewkb)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, encoded)
+		})
+	}
+}
+
+func TestEWKBToWKB(t *testing.T) {
+	testCases := []struct {
+		ewkt     geopb.EWKT
+		expected geopb.WKB
+	}{
+		{"POINT(1.0 1.0)", []byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f")},
+		{"SRID=4;POINT(1.0 1.0)", []byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f")},
+	}
+
+	for _, tc := range testCases {
+		t.Run(string(tc.ewkt), func(t *testing.T) {
+			ewkb, err := ParseEWKT(tc.ewkt, geopb.DefaultGeometrySRID)
+			require.NoError(t, err)
+			encoded, err := EWKBToWKB(ewkb)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, encoded)
+		})
+	}
+}
+
+func TestEWKBToGeoJSON(t *testing.T) {
+	testCases := []struct {
+		ewkt     geopb.EWKT
+		expected string
+	}{
+		{"POINT(1.0 1.0)", `{"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":null}`},
+		{"SRID=4;POINT(1.0 1.0)", `{"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":null}`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(string(tc.ewkt), func(t *testing.T) {
+			ewkb, err := ParseEWKT(tc.ewkt, geopb.DefaultGeometrySRID)
+			require.NoError(t, err)
+			encoded, err := EWKBToGeoJSON(ewkb)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, string(encoded))
+		})
+	}
+}
+
+func TestEWKBToWKBHex(t *testing.T) {
+	testCases := []struct {
+		ewkt     geopb.EWKT
+		expected string
+	}{
+		{"POINT(1.0 1.0)", "0101000000000000000000F03F000000000000F03F"},
+		{"SRID=4;POINT(1.0 1.0)", "0101000000000000000000F03F000000000000F03F"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(string(tc.ewkt), func(t *testing.T) {
+			ewkb, err := ParseEWKT(tc.ewkt, geopb.DefaultGeometrySRID)
+			require.NoError(t, err)
+			encoded, err := EWKBToWKBHex(ewkb)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, encoded)
+		})
+	}
+}
+
+func TestEWKBToKML(t *testing.T) {
+	testCases := []struct {
+		ewkt     geopb.EWKT
+		expected string
+	}{
+		{"POINT(1.0 1.0)", `<?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,1</coordinates></Point>`},
+		{"SRID=4;POINT(1.0 1.0)", `<?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,1</coordinates></Point>`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(string(tc.ewkt), func(t *testing.T) {
+			ewkb, err := ParseEWKT(tc.ewkt, geopb.DefaultGeometrySRID)
+			require.NoError(t, err)
+			encoded, err := EWKBToKML(ewkb)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, encoded)
+		})
+	}
+}

--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -20,12 +20,6 @@ import (
 	"github.com/golang/geo/s2"
 	"github.com/twpayne/go-geom"
 	"github.com/twpayne/go-geom/encoding/ewkb"
-	// Force imports until they are used.
-	_ "github.com/twpayne/go-geom/encoding/geojson"
-	_ "github.com/twpayne/go-geom/encoding/kml"
-	_ "github.com/twpayne/go-geom/encoding/wkb"
-	_ "github.com/twpayne/go-geom/encoding/wkbhex"
-	_ "github.com/twpayne/go-geom/encoding/wkt"
 )
 
 var ewkbEncodingFormat = binary.LittleEndian
@@ -147,7 +141,6 @@ func NewGeographyFromUnvalidatedEWKB(ewkb geopb.UnvalidatedEWKB) (*Geography, er
 }
 
 // ParseGeography parses a Geography from a given text.
-// TODO(otan): when we have our own WKT parser, move this to geo.
 func ParseGeography(str string) (*Geography, error) {
 	// TODO(otan): set SRID of EWKB to 4326.
 	ewkb, err := parseAmbiguousTextToEWKB(str, geopb.DefaultGeographySRID)

--- a/pkg/geo/geopb/types.go
+++ b/pkg/geo/geopb/types.go
@@ -33,6 +33,9 @@ type SRID int32
 // WKT is the Well Known Text form of a spatial object.
 type WKT string
 
+// EWKT is the Extended Well Known Text form of a spatial object.
+type EWKT string
+
 // WKB is the Well Known Bytes form of a spatial object.
 type WKB []byte
 

--- a/pkg/geo/parse_test.go
+++ b/pkg/geo/parse_test.go
@@ -55,6 +55,12 @@ func TestParseGeometry(t *testing.T) {
 			0,
 		},
 		{
+			`{ "type": "Feature", "geometry": { "type": "Point", "coordinates": [1.0, 1.0] }, "properties": { "name": "┳━┳ ヽ(ಠل͜ಠ)ﾉ" } }`,
+			NewGeometry(geopb.EWKB([]byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"))),
+			"",
+			0,
+		},
+		{
 			"invalid",
 			nil,
 			"geos error: ParseException: Unknown type: 'INVALID'",
@@ -138,6 +144,12 @@ func TestParseGeography(t *testing.T) {
 			NewGeography(geopb.EWKB([]byte("\x01\x01\x00\x00\x20\x11\x0F\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"))),
 			"",
 			3857,
+		},
+		{
+			`{ "type": "Feature", "geometry": { "type": "Point", "coordinates": [1.0, 1.0] }, "properties": { "name": "┳━┳ ヽ(ಠل͜ಠ)ﾉ" } }`,
+			NewGeography(geopb.EWKB([]byte("\x01\x01\x00\x00\x20\xe6\x10\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"))),
+			"",
+			4326,
 		},
 		{
 			"invalid",

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -854,7 +854,7 @@ func TestLint(t *testing.T) {
 
 		if err := stream.ForEach(stream.Sequence(
 			filter,
-			stream.GrepNot(`(json|yaml|protoutil|xml|\.Field|ewkb|wkb)\.Marshal\(`),
+			stream.GrepNot(`(json|yaml|protoutil|xml|\.Field|ewkb|wkb|wkt)\.Marshal\(`),
 		), func(s string) {
 			t.Errorf("\n%s <- forbidden; use 'protoutil.Marshal' instead", s)
 		}); err != nil {
@@ -1393,8 +1393,6 @@ func TestLint(t *testing.T) {
 				stream.GrepNot(`pkg/sql/opt/optgen/exprgen/custom_funcs.go:.* func .* is unused`),
 				// Using deprecated method to COPY.
 				stream.GrepNot(`pkg/cli/nodelocal.go:.* stmt.Exec is deprecated: .*`),
-				// Geospatial code is in-progress.
-				stream.GrepNot("pkg/geo/geopb/types.go:.* type WKB is unused .*"),
 			), func(s string) {
 				t.Errorf("\n%s", s)
 			}); err != nil {


### PR DESCRIPTION
This commit adds encoding for KML, GeoJSON, WKT, WKB and WKBHex. Note EWKB
and EWKBHex is already provided by the identity function and String()
respectively. These will be plugged in at a later date.

Release note: None