### PR TITLE
sql: fix handling of errors in reversing schema change mutations

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -5811,54 +5811,84 @@ func TestRetriableErrorDuringRollback(t *testing.T) {
 	defer setTestJobsAdoptInterval()()
 	ctx := context.Background()
 
-	onFailOrCancelStarted := false
-	injectedError := false
-	params, _ := tests.CreateTestServerParams()
-	params.Knobs = base.TestingKnobs{
-		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
-			RunBeforeOnFailOrCancel: func(_ int64) error {
-				onFailOrCancelStarted = true
-				return nil
-			},
-			RunBeforeBackfill: func() error {
-				// The first time through the backfiller in OnFailOrCancel, return a
-				// retriable error.
-				if !onFailOrCancelStarted || injectedError {
-					return nil
-				}
-				injectedError = true
-				// Return an artificial context canceled error.
-				return context.Canceled
-			},
-		},
-	}
-	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(ctx)
+	runTest := func(params base.TestServerArgs) {
+		s, sqlDB, kvDB := serverutils.StartServer(t, params)
+		defer s.Stopper().Stop(ctx)
 
-	// Disable strict GC TTL enforcement because we're going to shove a zero-value
-	// TTL into the system with addImmediateGCZoneConfig.
-	defer disableGCTTLStrictEnforcement(t, sqlDB)()
+		// Disable strict GC TTL enforcement because we're going to shove a zero-value
+		// TTL into the system with addImmediateGCZoneConfig.
+		defer disableGCTTLStrictEnforcement(t, sqlDB)()
 
-	_, err := sqlDB.Exec(`
+		_, err := sqlDB.Exec(`
 CREATE DATABASE t;
 CREATE TABLE t.test (k INT PRIMARY KEY, v INT8);
 INSERT INTO t.test VALUES (1, 2), (2, 2);
 `)
-	require.NoError(t, err)
-	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
-	// Add a zone config for the table.
-	_, err = addImmediateGCZoneConfig(sqlDB, tableDesc.ID)
-	require.NoError(t, err)
+		require.NoError(t, err)
+		tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
+		// Add a zone config for the table.
+		_, err = addImmediateGCZoneConfig(sqlDB, tableDesc.ID)
+		require.NoError(t, err)
 
-	// Try to create a unique index which won't be valid and will need a rollback.
-	_, err = sqlDB.Exec(`
+		// Try to create a unique index which won't be valid and will need a rollback.
+		_, err = sqlDB.Exec(`
 CREATE UNIQUE INDEX i ON t.test(v);
 `)
-	require.Error(t, err)
-	require.Regexp(t, "violates unique constraint", err.Error())
-	// Verify that the index was cleaned up.
-	testutils.SucceedsSoon(t, func() error {
-		return checkTableKeyCountExact(ctx, kvDB, 2)
+		require.Regexp(t, "violates unique constraint", err.Error())
+		// Verify that the index was cleaned up.
+		testutils.SucceedsSoon(t, func() error {
+			return checkTableKeyCountExact(ctx, kvDB, 2)
+		})
+	}
+
+	t.Run("error-before-backfill", func(t *testing.T) {
+		onFailOrCancelStarted := false
+		injectedError := false
+		params, _ := tests.CreateTestServerParams()
+		params.Knobs = base.TestingKnobs{
+			SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+				RunBeforeOnFailOrCancel: func(_ int64) error {
+					onFailOrCancelStarted = true
+					return nil
+				},
+				RunBeforeBackfill: func() error {
+					// The first time through the backfiller in OnFailOrCancel, return a
+					// retriable error.
+					if !onFailOrCancelStarted || injectedError {
+						return nil
+					}
+					injectedError = true
+					// Return an artificial context canceled error.
+					return context.Canceled
+				},
+			},
+		}
+		runTest(params)
+	})
+
+	t.Run("error-before-reversing-mutations", func(t *testing.T) {
+		onFailOrCancelStarted := false
+		injectedError := false
+		params, _ := tests.CreateTestServerParams()
+		params.Knobs = base.TestingKnobs{
+			SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+				RunBeforeOnFailOrCancel: func(_ int64) error {
+					onFailOrCancelStarted = true
+					return nil
+				},
+				RunBeforeMutationReversal: func(_ int64) error {
+					// The first time through reversing mutations, return a retriable
+					// error.
+					if !onFailOrCancelStarted || injectedError {
+						return nil
+					}
+					injectedError = true
+					// Return an artificial context canceled error.
+					return context.Canceled
+				},
+			},
+		}
+		runTest(params)
 	})
 }
 
@@ -5870,46 +5900,76 @@ func TestPermanentErrorDuringRollback(t *testing.T) {
 	defer setTestJobsAdoptInterval()()
 	ctx := context.Background()
 
-	onFailOrCancelStarted := false
-	injectedError := false
-	params, _ := tests.CreateTestServerParams()
-	params.Knobs = base.TestingKnobs{
-		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
-			RunBeforeOnFailOrCancel: func(_ int64) error {
-				onFailOrCancelStarted = true
-				return nil
-			},
-			RunBeforeBackfill: func() error {
-				// The first time through the backfiller in OnFailOrCancel, return a
-				// permanent error.
-				if !onFailOrCancelStarted || injectedError {
-					return nil
-				}
-				injectedError = true
-				// Any error not on the whitelist of retriable errors is considered permanent.
-				return errors.New("permanent error")
-			},
-		},
-	}
-	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(ctx)
+	runTest := func(params base.TestServerArgs) {
+		s, sqlDB, _ := serverutils.StartServer(t, params)
+		defer s.Stopper().Stop(ctx)
 
-	_, err := sqlDB.Exec(`
+		_, err := sqlDB.Exec(`
 CREATE DATABASE t;
 CREATE TABLE t.test (k INT PRIMARY KEY, v INT8);
 INSERT INTO t.test VALUES (1, 2), (2, 2);
 `)
-	require.NoError(t, err)
+		require.NoError(t, err)
 
-	// Try to create a unique index which won't be valid and will need a rollback.
-	_, err = sqlDB.Exec(`
+		// Try to create a unique index which won't be valid and will need a rollback.
+		_, err = sqlDB.Exec(`
 CREATE UNIQUE INDEX i ON t.test(v);
 `)
-	require.Error(t, err)
-	require.Regexp(t, "violates unique constraint", err.Error())
+		require.Regexp(t, "violates unique constraint", err.Error())
 
-	var jobErr string
-	row := sqlDB.QueryRow("SELECT error FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE'")
-	require.NoError(t, row.Scan(&jobErr))
-	require.Regexp(t, "cannot be reverted, manual cleanup may be required", jobErr)
+		var jobErr string
+		row := sqlDB.QueryRow("SELECT error FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE'")
+		require.NoError(t, row.Scan(&jobErr))
+		require.Regexp(t, "cannot be reverted, manual cleanup may be required: permanent error", jobErr)
+	}
+
+	t.Run("error-before-backfill", func(t *testing.T) {
+		onFailOrCancelStarted := false
+		injectedError := false
+		params, _ := tests.CreateTestServerParams()
+		params.Knobs = base.TestingKnobs{
+			SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+				RunBeforeOnFailOrCancel: func(_ int64) error {
+					onFailOrCancelStarted = true
+					return nil
+				},
+				RunBeforeBackfill: func() error {
+					// The first time through the backfiller in OnFailOrCancel, return a
+					// permanent error.
+					if !onFailOrCancelStarted || injectedError {
+						return nil
+					}
+					injectedError = true
+					// Any error not on the whitelist of retriable errors is considered permanent.
+					return errors.New("permanent error")
+				},
+			},
+		}
+		runTest(params)
+	})
+
+	t.Run("error-before-reversing-mutations", func(t *testing.T) {
+		onFailOrCancelStarted := false
+		injectedError := false
+		params, _ := tests.CreateTestServerParams()
+		params.Knobs = base.TestingKnobs{
+			SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+				RunBeforeOnFailOrCancel: func(_ int64) error {
+					onFailOrCancelStarted = true
+					return nil
+				},
+				RunBeforeBackfill: func() error {
+					// The first time through reversing mutations, return a permanent
+					// error.
+					if !onFailOrCancelStarted || injectedError {
+						return nil
+					}
+					injectedError = true
+					// Any error not on the whitelist of retriable errors is considered permanent.
+					return errors.New("permanent error")
+				},
+			},
+		}
+		runTest(params)
+	})
 }


### PR DESCRIPTION
As part of fixing error handling for rolling back schema changes in
general, a bug was introduced: When an error was returned from reversing
the direction of mutations, instead of returning that error, we would
instead return the original resumer error. This would prevent some
retriable errors from producing retries, and could lead to failed jobs
that weren't cleaned up even though they could have been; fixing these
problems was the point of the original PR. This patch replaces the wrong
error with the right error.

A new schema change testing knob has been added to inject errors for
testing.

See #47446 for the original error handling fix.
Closes #47532.

Release note (bug fix): Fixed a bug causing some schema change rollbacks
to fail permanently even on transient errors.