### PR TITLE
opt: add support for filtering histograms with index constraints

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -874,3 +874,104 @@ select
  │         └── fd: (8)-->(2)
  └── filters
       └── (a:1 = 30) OR (a:1 = 40) [type=bool, outer=(1), constraints=(/1: [/30 - /30] [/40 - /40]; tight)]
+
+# Regression test for #47390. Histograms must be used with index constraints
+# to choose the correct index.
+exec-ddl
+CREATE TABLE xyz (
+  x INT,
+  y INT,
+  z INT,
+  other INT,
+  PRIMARY KEY(x, y),
+  UNIQUE INDEX xyz_x_z_key (x, z),
+  INDEX xyz_x_other_z (x, other DESC)
+)
+----
+
+exec-ddl
+ALTER TABLE xyz INJECT STATISTICS '[
+  {
+    "columns": ["x"],
+    "distinct_count": 5,
+    "null_count": 0,
+    "row_count": 100,
+    "created_at": "2020-01-01 0:00:00.00000+00:00"
+  },
+  {
+    "columns": ["z"],
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 100,
+    "created_at": "2020-01-01 0:00:00.00000+00:00",
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 0, "num_range": 100, "distinct_range": 100, "upper_bound": "1000"}
+    ]
+  },
+  {
+    "columns": ["other"],
+    "distinct_count": 30,
+    "null_count": 0,
+    "row_count": 100,
+    "created_at": "2020-01-01 0:00:00.00000+00:00",
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 10, "num_range": 10, "distinct_range": 10, "upper_bound": "10"},
+      {"num_eq": 20, "num_range": 20, "distinct_range": 20, "upper_bound": "20"},
+      {"num_eq": 20, "num_range": 20, "distinct_range": 20, "upper_bound": "30"}
+    ]
+  }
+]'
+----
+
+opt
+SELECT * FROM xyz WHERE x=1 AND z>990
+----
+index-join xyz
+ ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) other:4(int)
+ ├── stats: [rows=0.18018018, distinct(1)=0.18018018, null(1)=0, distinct(3)=0.18018018, null(3)=0]
+ │   histogram(3)=  0   0   0.18018   0
+ │                <--- 990 --------- 1000
+ ├── key: (2)
+ ├── fd: ()-->(1), (2)-->(3,4), (3)-->(2,4)
+ └── scan xyz@xyz_x_z_key
+      ├── columns: x:1(int!null) y:2(int!null) z:3(int!null)
+      ├── constraint: /1/3: [/1/991 - /1]
+      ├── stats: [rows=0.18018018, distinct(1)=0.18018018, null(1)=0, distinct(3)=0.18018018, null(3)=0]
+      │   histogram(3)=  0   0   0.18018   0
+      │                <--- 990 --------- 1000
+      ├── key: (2)
+      └── fd: ()-->(1), (2)-->(3), (3)-->(2)
+
+opt
+SELECT * FROM xyz WHERE x=1 AND z<990 AND (other=11 OR other=13)
+----
+select
+ ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) other:4(int!null)
+ ├── stats: [rows=0.879991102, distinct(1)=0.879991102, null(1)=0, distinct(3)=0.879991102, null(3)=0, distinct(4)=0.879991102, null(4)=0]
+ │   histogram(3)=  0  0  0.8791 0.00088978
+ │                <--- 0 ---------- 989 ---
+ │   histogram(4)=  0 0.44 0 0.44
+ │                <--- 11 --- 13
+ ├── key: (2)
+ ├── fd: ()-->(1), (2)-->(3,4), (3)-->(2,4)
+ ├── index-join xyz
+ │    ├── columns: x:1(int!null) y:2(int!null) z:3(int) other:4(int)
+ │    ├── stats: [rows=0.888888889]
+ │    ├── key: (2)
+ │    ├── fd: ()-->(1), (2)-->(4), (2)-->(3,4), (1,3)~~>(2,4)
+ │    └── scan xyz@xyz_x_other_z
+ │         ├── columns: x:1(int!null) y:2(int!null) other:4(int!null)
+ │         ├── constraint: /1/-4/2
+ │         │    ├── [/1/13 - /1/13]
+ │         │    └── [/1/11 - /1/11]
+ │         ├── stats: [rows=0.888888889, distinct(1)=0.888888889, null(1)=0, distinct(4)=0.888888889, null(4)=0]
+ │         │   histogram(4)=  0 0.44444 0 0.44444
+ │         │                <---- 11 ------ 13 --
+ │         ├── key: (2)
+ │         └── fd: ()-->(1), (2)-->(4)
+ └── filters
+      └── z:3 < 990 [type=bool, outer=(3), constraints=(/3: (/NULL - /989]; tight)]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -301,7 +301,9 @@ project
            ├── save-table-name: order_status_02_scan_3
            ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar) c_last:6(varchar!null)
            ├── constraint: /3/2/6/4/1: [/2/2/'ANTIBARESE' - /2/2/'ANTIBARESE']
-           ├── stats: [rows=3, distinct(1)=2.99851499, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=2.99196484, null(4)=0, distinct(6)=1, null(6)=0]
+           ├── stats: [rows=2.853, distinct(1)=2.85165693, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=2.84573236, null(4)=0, distinct(6)=1, null(6)=0]
+           │   histogram(3)=  0 2.853
+           │                <---- 2 -
            ├── key: (1)
            ├── fd: ()-->(2,3,6), (1)-->(4)
            └── ordering: +4 opt(2,3,6) [actual: +4]

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -541,11 +541,6 @@ CREATE VIEW GlobalCardsView AS
 # --------------------------------------------------
 
 # Find all cards that have been modified in the last 5 seconds.
-#
-# Problems:
-#   1. The wrong index is selected because of mismatched row estimates. The
-#      CardsInfoVersionIndex should be used instead.
-#
 opt format=show-stats
 SELECT
   Id, Name, Rarity, SetName, Number, IsFoil, BuyPrice, SellPrice,
@@ -564,21 +559,21 @@ project
       ├── stats: [rows=1, distinct(1)=0.00184973785, null(1)=0, distinct(8)=0.00184973785, null(8)=0]
       ├── key: (8)
       ├── fd: ()-->(7), (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(9-15), (15)-->(8-14), (1)==(8), (8)==(1)
-      ├── select
+      ├── index-join cardsinfo
       │    ├── columns: dealerid:7!null cardid:8!null buyprice:9!null sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null version:15!null
       │    ├── stats: [rows=0.00184973785, distinct(7)=0.00184973785, null(7)=0, distinct(8)=0.00184973785, null(8)=0, distinct(9)=0.00184973785, null(9)=0, distinct(10)=0.00184973785, null(10)=0, distinct(11)=0.00184973785, null(11)=0, distinct(12)=0.00184973785, null(12)=0, distinct(13)=0.00184973785, null(13)=0, distinct(14)=0.00184973785, null(14)=0, distinct(15)=0.00184973785, null(15)=0]
       │    │   histogram(15)=  0                0                 0.0018497           0
       │    │                 <--- 1584421773604892000.0000000000 ----------- 1584421778604892000
       │    ├── key: (8)
       │    ├── fd: ()-->(7), (8)-->(9-15), (15)-->(8-14)
-      │    ├── scan cardsinfo
-      │    │    ├── columns: dealerid:7!null cardid:8!null buyprice:9!null sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null version:15!null
-      │    │    ├── constraint: /7/8: [/1 - /1]
-      │    │    ├── stats: [rows=58333.3333, distinct(7)=1, null(7)=0]
-      │    │    ├── key: (8)
-      │    │    └── fd: ()-->(7), (8)-->(9-15), (15)-->(8-14)
-      │    └── filters
-      │         └── version:15 > 1584421773604892000.0000000000 [outer=(15), constraints=(/15: (/1584421773604892000.0000000000 - ]; tight)]
+      │    └── scan cardsinfo@cardsinfoversionindex
+      │         ├── columns: dealerid:7!null cardid:8!null version:15!null
+      │         ├── constraint: /7/15: (/1/1584421773604892000.0000000000 - /1]
+      │         ├── stats: [rows=0.00184973785, distinct(7)=0.00184973785, null(7)=0, distinct(15)=0.00184973785, null(15)=0]
+      │         │   histogram(15)=  0                0                 0.0018497           0
+      │         │                 <--- 1584421773604892000.0000000000 ----------- 1584421778604892000
+      │         ├── key: (8)
+      │         └── fd: ()-->(7), (8)-->(15), (15)-->(8)
       └── filters (true)
 
 # Get version of last card that was changed.

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -549,11 +549,6 @@ CREATE VIEW GlobalCardsView AS
 # --------------------------------------------------
 
 # Find all cards that have been modified in the last 5 seconds.
-#
-# Problems:
-#   1. The wrong index is selected because of mismatched row estimates. The
-#      CardsInfoVersionIndex should be used instead.
-#
 opt format=show-stats
 SELECT
   Id, Name, Rarity, SetName, Number, IsFoil, BuyPrice, SellPrice,
@@ -572,20 +567,19 @@ project
       ├── stats: [rows=0.3325, distinct(1)=5.83333167e-06, null(1)=0, distinct(8)=5.83333167e-06, null(8)=0]
       ├── key: (8)
       ├── fd: ()-->(7), (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(9-15), (15)-->(8-14), (1)==(8), (8)==(1)
-      ├── select
+      ├── index-join cardsinfo
       │    ├── columns: dealerid:7!null cardid:8!null buyprice:9!null sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null version:15!null
       │    ├── stats: [rows=5.83333333e-06, distinct(7)=5.83333333e-06, null(7)=0, distinct(8)=5.83333167e-06, null(8)=0, distinct(9)=5.83333333e-06, null(9)=0, distinct(10)=5.83333333e-06, null(10)=0, distinct(11)=5.83333333e-06, null(11)=0, distinct(12)=5.83333333e-06, null(12)=0, distinct(13)=5.83333333e-06, null(13)=0, distinct(14)=5.83333333e-06, null(14)=0, distinct(15)=5.83333333e-06, null(15)=0]
       │    │   histogram(15)=
       │    ├── key: (8)
       │    ├── fd: ()-->(7), (8)-->(9-15), (15)-->(8-14)
-      │    ├── scan cardsinfo
-      │    │    ├── columns: dealerid:7!null cardid:8!null buyprice:9!null sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null version:15!null
-      │    │    ├── constraint: /7/8: [/1 - /1]
-      │    │    ├── stats: [rows=58333.3333, distinct(7)=1, null(7)=0]
-      │    │    ├── key: (8)
-      │    │    └── fd: ()-->(7), (8)-->(9-15), (15)-->(8-14)
-      │    └── filters
-      │         └── version:15 > 1584421773604892000.0000000000 [outer=(15), constraints=(/15: (/1584421773604892000.0000000000 - ]; tight)]
+      │    └── scan cardsinfo@cardsinfoversionindex
+      │         ├── columns: dealerid:7!null cardid:8!null version:15!null
+      │         ├── constraint: /7/15: (/1/1584421773604892000.0000000000 - /1]
+      │         ├── stats: [rows=5.83333333e-06, distinct(7)=5.83333333e-06, null(7)=0, distinct(15)=5.83333333e-06, null(15)=0]
+      │         │   histogram(15)=
+      │         ├── key: (8)
+      │         └── fd: ()-->(7), (8)-->(15), (15)-->(8)
       └── filters (true)
 
 # Get version of last card that was changed.


### PR DESCRIPTION
Prior to this commit, we only supported filtering histograms with constraints
on a single, ascending column matching the column of the histogram. This was
problematic, because it meant that any index constraint involving multiple
columns or descending columns could not be used. This led to inconsistencies
in cost estimation between `Select` and `Scan` operations, causing suboptimal
plan selection.

This commit fixes the problem by adding support for filtering with any index
constraint in which the histogram column is part of the exact prefix or the
first column after the exact prefix. It supports descending columns too by
adding support for iterating over the histogram in reverse order.

Fixes #47390

Release note (performance improvement): Histograms are now used by the
optimizer to estimate the cost of index scans with multiple constrained
columns or descending columns. This enables better query plan selection in
some cases.