### PR TITLE
sql: skip TestScrubFKConstraintFKNulls

### DIFF
--- a/pkg/sql/scrub_test.go
+++ b/pkg/sql/scrub_test.go
@@ -511,6 +511,7 @@ func TestScrubFKConstraintFKMissing(t *testing.T) {
 // constraint in this test with corrupted KVs.
 func TestScrubFKConstraintFKNulls(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("#47546")
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.TODO())
 


### PR DESCRIPTION
This test is causing a lot of flakes on master and should be skipped for
now while we investigate.

See #47546 for the test failures.

Release note: None