### PR TITLE
geo: order linear rings correctly when converting to S2

### DIFF
--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -182,6 +182,48 @@ func (g *Geography) AsS2() ([]s2.Region, error) {
 	return s2RegionsFromGeom(geomRepr), nil
 }
 
+// isLinearRingCCW returns whether a given linear ring is counter clock wise.
+// See 2.07 of http://www.faqs.org/faqs/graphics/algorithms-faq/.
+// "Find the lowest vertex (or, if  there is more than one vertex with the same lowest coordinate,
+//  the rightmost of those vertices) and then take the cross product of the edges fore and aft of it."
+func isLinearRingCCW(linearRing *geom.LinearRing) bool {
+	smallestIdx := 0
+	smallest := linearRing.Coord(0)
+
+	for pointIdx := 1; pointIdx < linearRing.NumCoords()-1; pointIdx++ {
+		curr := linearRing.Coord(pointIdx)
+		if curr.Y() < smallest.Y() || (curr.Y() == smallest.Y() && curr.X() > smallest.X()) {
+			smallestIdx = pointIdx
+			smallest = curr
+		}
+	}
+
+	// prevIdx is the previous point. If we are at the 0th point, the last coordinate
+	// is also the 0th point, so take the second last point.
+	// Note we don't have to apply this for "nextIdx" as we cap the search above at the
+	// second last vertex.
+	prevIdx := smallestIdx - 1
+	if smallestIdx == 0 {
+		prevIdx = linearRing.NumCoords() - 2
+	}
+	a := linearRing.Coord(prevIdx)
+	b := smallest
+	c := linearRing.Coord(smallestIdx + 1)
+
+	// We could do the cross product, but we are only interested in the sign.
+	// To find the sign, reorganize into the orientation matrix:
+	//  1 x_a y_a
+	//  1 x_b y_b
+	//  1 x_c y_c
+	// and find the determinant.
+	// https://en.wikipedia.org/wiki/Curve_orientation#Orientation_of_a_simple_polygon
+	areaSign := a.X()*b.Y() - a.Y()*b.X() +
+		a.Y()*c.X() - a.X()*c.Y() +
+		b.X()*c.Y() - c.X()*b.Y()
+	// Note having an area sign of 0 means it is a flat polygon, which is invalid.
+	return areaSign > 0
+}
+
 // s2RegionsFromGeom converts an geom representation of an object
 // to s2 regions.
 func s2RegionsFromGeom(geomRepr geom.T) []s2.Region {
@@ -202,15 +244,15 @@ func s2RegionsFromGeom(geomRepr geom.T) []s2.Region {
 		}
 	case *geom.Polygon:
 		loops := make([]*s2.Loop, repr.NumLinearRings())
-		// The first ring is a "shell", which is represented as CCW.
-		// Following rings are "holes", which are CW. For S2, they are CCW and automatically figured out.
+		// All loops must be oriented CCW for S2.
 		for ringIdx := 0; ringIdx < repr.NumLinearRings(); ringIdx++ {
 			linearRing := repr.LinearRing(ringIdx)
 			points := make([]s2.Point, linearRing.NumCoords())
+			isCCW := isLinearRingCCW(linearRing)
 			for pointIdx := 0; pointIdx < linearRing.NumCoords(); pointIdx++ {
 				p := linearRing.Coord(pointIdx)
 				pt := s2.PointFromLatLng(s2.LatLngFromDegrees(p.Y(), p.X()))
-				if ringIdx == 0 {
+				if isCCW {
 					points[pointIdx] = pt
 				} else {
 					points[len(points)-pointIdx-1] = pt

--- a/pkg/geo/geo_test.go
+++ b/pkg/geo/geo_test.go
@@ -64,6 +64,81 @@ func TestGeographyAsS2(t *testing.T) {
 			},
 		},
 		{
+			`POLYGON(
+				(0.0 0.0, 0.5 0.0, 0.75 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0),
+				(0.2 0.2, 0.2 0.4, 0.4 0.4, 0.4 0.2, 0.2 0.2)
+			)`,
+			[]s2.Region{
+				s2.PolygonFromLoops([]*s2.Loop{
+					s2.LoopFromPoints([]s2.Point{
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.0, 0.0)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.0, 0.5)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.0, 0.75)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.0, 1.0)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(1.0, 1.0)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(1.0, 0.0)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.0, 0.0)),
+					}),
+					s2.LoopFromPoints([]s2.Point{
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.2, 0.2)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.2, 0.4)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.4, 0.4)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.4, 0.2)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.2, 0.2)),
+					}),
+				}),
+			},
+		},
+		{
+			`POLYGON(
+				(0.0 0.0, 0.0 1.0, 1.0 1.0, 1.0 0.0, 0.0 0.0),
+				(0.2 0.2, 0.2 0.4, 0.4 0.4, 0.4 0.2, 0.2 0.2)
+			)`,
+			[]s2.Region{
+				s2.PolygonFromLoops([]*s2.Loop{
+					s2.LoopFromPoints([]s2.Point{
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.0, 0.0)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.0, 1.0)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(1.0, 1.0)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(1.0, 0.0)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.0, 0.0)),
+					}),
+					s2.LoopFromPoints([]s2.Point{
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.2, 0.2)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.2, 0.4)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.4, 0.4)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.4, 0.2)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.2, 0.2)),
+					}),
+				}),
+			},
+		},
+		{
+			`POLYGON(
+				(0.0 0.0, 0.0 0.5, 0.0 1.0, 1.0 1.0, 1.0 0.0, 0.0 0.0),
+				(0.2 0.2, 0.2 0.4, 0.4 0.4, 0.4 0.2, 0.2 0.2)
+			)`,
+			[]s2.Region{
+				s2.PolygonFromLoops([]*s2.Loop{
+					s2.LoopFromPoints([]s2.Point{
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.0, 0.0)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.0, 1.0)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(1.0, 1.0)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(1.0, 0.0)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.5, 0.0)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.0, 0.0)),
+					}),
+					s2.LoopFromPoints([]s2.Point{
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.2, 0.2)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.2, 0.4)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.4, 0.4)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.4, 0.2)),
+						s2.PointFromLatLng(s2.LatLngFromDegrees(0.2, 0.2)),
+					}),
+				}),
+			},
+		},
+		{
 			`GEOMETRYCOLLECTION(POINT(1.0 2.0), POLYGON(
 				(0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0),
 				(0.2 0.2, 0.2 0.4, 0.4 0.4, 0.4 0.2, 0.2 0.2)


### PR DESCRIPTION
We falsely assumed all WKTs we were given would be CCW. Some could be
CW, as is the case with ESRI shape files. Since S2 requires CCW, we now
check the linear ring is CCW with math.

Note that the geoindex tests still have an invalid result as the WKT for
New York State is invalid.

Release note: None