### PR TITLE
sql: categorize dropping unique index error

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -387,10 +387,10 @@ orders      fk_product_ref_products  FOREIGN KEY      FOREIGN KEY (product) REFE
 orders      primary                  PRIMARY KEY      PRIMARY KEY (id ASC, shipment ASC)                                                    true
 orders      valid_customer           FOREIGN KEY      FOREIGN KEY (customer) REFERENCES customers(id)                                       true
 
-statement error "products_upc_key" is referenced by foreign key from table "delivery"
+statement error pq: index "products_upc_key" is in use as unique constraint
 DROP INDEX products@products_upc_key
 
-statement error "products_upc_key" is referenced by foreign key from table "delivery"
+statement error pq: index "products_upc_key" is in use as unique constraint
 DROP INDEX products@products_upc_key RESTRICT
 
 statement error "products_upc_key" is referenced by foreign key from table "delivery"
@@ -478,7 +478,7 @@ CREATE TABLE grandchild (id INT PRIMARY KEY, parent_id INT REFERENCES child (par
 statement error pgcode 23503 foreign key violation
 INSERT INTO grandchild VALUES (1, 1)
 
-statement error "child_parent_id_key" is referenced by foreign key from table "grandchild"
+statement error pq: index "child_parent_id_key" is in use as unique constraint
 DROP INDEX child@child_parent_id_key
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/fk_opt
+++ b/pkg/sql/logictest/testdata/logic_test/fk_opt
@@ -656,10 +656,10 @@ orders      fk_product_ref_products  FOREIGN KEY      FOREIGN KEY (product) REFE
 orders      primary                  PRIMARY KEY      PRIMARY KEY (id ASC, shipment ASC)                                                    true
 orders      valid_customer           FOREIGN KEY      FOREIGN KEY (customer) REFERENCES customers(id)                                       true
 
-statement error "products_upc_key" is referenced by foreign key from table "delivery"
+statement error pq: index "products_upc_key" is in use as unique constraint
 DROP INDEX products@products_upc_key
 
-statement error "products_upc_key" is referenced by foreign key from table "delivery"
+statement error pq: index "products_upc_key" is in use as unique constraint
 DROP INDEX products@products_upc_key RESTRICT
 
 statement error "products_upc_key" is referenced by foreign key from table "delivery"
@@ -747,7 +747,7 @@ CREATE TABLE grandchild (id INT PRIMARY KEY, parent_id INT REFERENCES child (par
 statement error pgcode 23503 foreign key
 INSERT INTO grandchild VALUES (1, 1)
 
-statement error "child_parent_id_key" is referenced by foreign key from table "grandchild"
+statement error pq: index "child_parent_id_key" is in use as unique constraint
 DROP INDEX child@child_parent_id_key
 
 statement ok

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -1,5 +1,7 @@
+# Test notices work as expected by creating a VIEW on a TEMP TABLE.
+
 send
-Parse {"Query": "SELECT crdb_internal.notice('hello')"}
+Parse {"Query": "CREATE TABLE t(x INT, y INT, INDEX (x), INDEX (y))"}
 Bind
 Execute
 Sync
@@ -10,9 +12,25 @@ ReadyForQuery
 ----
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
-{"Type":"DataRow","Values":[{"text":"0"}]}
-{"Severity":"NOTICE","Code":"00000","Message":"hello","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"notice.go","Line":32,"Routine":"crdbInternalSendNotice","UnknownFields":null}
-{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+
+send
+Parse {"Query": "DROP INDEX t@t_x_idx"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":488,"Routine":"dropIndexByName","UnknownFields":null}
+{"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # Disable notices and assert now it is not sent.
@@ -32,7 +50,7 @@ ReadyForQuery
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 send
-Parse {"Query": "SELECT crdb_internal.notice('goodbye')"}
+Parse {"Query": "DROP INDEX t@t_y_idx"}
 Bind
 Execute
 Sync
@@ -43,6 +61,5 @@ ReadyForQuery
 ----
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
-{"Type":"DataRow","Values":[{"text":"0"}]}
-{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 {"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
Prior to this change, drop an UNIQUE index would return an uncategorized
pgerror `XXUUU`.

Touches #47430.

Before:

```
CREATE TABLE tbl (col1 int, col2 int);
ALTER TABLE tbl ADD CONSTRAINT col2_unq UNIQUE(col2);
DROP INDEX col2_unq;
ERROR: index "col2_unq" is in use as unique constraint
HINT: use CASCADE if you really want to drop it.
```

After:
```
ERROR: index "col2_unq" is in use as unique constraint (use CASCADE if you really want to drop it)
SQLSTATE: 2BP01
```

Postgres:
```
ERROR:  2BP01: cannot drop index col2_unq because constraint col2_unq on table tbl requires it
HINT:  You can drop constraint col2_unq on table tbl instead.
LOCATION:  findDependentObjects, dependency.c:633
```

Release note (bug fix): Return proper pg error from drop index
statements when dropping UNIQUE indices.