### PR TITLE
server: remove stale comment

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1604,27 +1604,6 @@ func (s *Server) startListenRPCAndSQL(
 		log.Eventf(ctx, "listening on sql port %s", s.cfg.SQLAddr)
 	}
 
-	// The following code is a specialization of util/net.go's ListenAndServe
-	// which adds pgwire support. A single port is used to serve all protocols
-	// (pg, http, h2) via the following construction:
-	//
-	// non-TLS case:
-	// net.Listen -> cmux.New
-	//               |
-	//               -  -> pgwire.Match -> pgwire.Server.ServeConn
-	//               -  -> cmux.Any -> grpc.(*Server).Serve
-	//
-	// TLS case:
-	// net.Listen -> cmux.New
-	//               |
-	//               -  -> pgwire.Match -> pgwire.Server.ServeConn
-	//               -  -> cmux.Any -> grpc.(*Server).Serve
-	//
-	// Note that the difference between the TLS and non-TLS cases exists due to
-	// Go's lack of an h2c (HTTP2 Clear Text) implementation. See inline comments
-	// in util.ListenAndServe for an explanation of how h2c is implemented there
-	// and here.
-
 	// serveOnMux is used to ensure that the mux gets listened on eventually,
 	// either via the returned startRPCServer() or upon stopping.
 	var serveOnMux sync.Once


### PR DESCRIPTION
- util.ListenAndServe and the inline comments are gone as of 41b83f8
- the TLS and non-TLS cases are identical since 7017b82
- Go supports h2c now (https://godoc.org/golang.org/x/net/http2/h2c)

Release note: None