### PR TITLE
ui: CSS modules for Table components

### DIFF
--- a/pkg/ui/src/util/highlightedText.module.styl
+++ b/pkg/ui/src/util/highlightedText.module.styl
@@ -1,0 +1,13 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+._text-bold
+  color #87beff
+  font-family RobotoMono-Bold

--- a/pkg/ui/src/util/highlightedText.tsx
+++ b/pkg/ui/src/util/highlightedText.tsx
@@ -9,6 +9,10 @@
 // licenses/APL.txt.
 
 import React from "react";
+import classNames from "classnames/bind";
+import styles from "./highlightedText.module.styl";
+
+const cx = classNames.bind(styles);
 
 export default function getHighlightedText(text: string, highlight: string, isOriginalText?: boolean) {
   if (!highlight || highlight.length === 0) {
@@ -25,7 +29,7 @@ export default function getHighlightedText(text: string, highlight: string, isOr
   return parts.map((part, i) => {
     if (search.includes(part.toLowerCase())) {
       return (
-        <span key={i} className="_text-bold">
+        <span key={i} className={cx("_text-bold")}>
           {`${part}`}
         </span>
       );

--- a/pkg/ui/src/views/databases/containers/databases/nonTableSummary.tsx
+++ b/pkg/ui/src/views/databases/containers/databases/nonTableSummary.tsx
@@ -18,6 +18,7 @@ import { Bytes } from "src/util/format";
 import Loading from "src/views/shared/components/loading";
 import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 import { NonTableStatsResponseMessage } from "src/util/api";
+import "src/views/shared/components/sortabletable/sortabletable.styl";
 
 interface TimeSeriesSummaryProps {
   nonTableStats: protos.cockroach.server.serverpb.NonTableStatsResponse;

--- a/pkg/ui/src/views/shared/components/drawer/drawer.module.styl
+++ b/pkg/ui/src/views/shared/components/drawer/drawer.module.styl
@@ -1,0 +1,82 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+.__actions
+  button, a
+    width auto
+    color #f6f6f6
+    font-size 12px
+    font-family Lato-Bold
+    line-height 2
+    letter-spacing 0.1px
+    &:hover
+      color #5f6c87
+
+.drawer--preset-black
+  display flex
+  align-items center
+  /* width */
+  ::-webkit-scrollbar {
+    width 7px
+  }
+
+  /* Track */
+  ::-webkit-scrollbar-track {
+    background transparent
+    border-radius 10px
+  }
+
+  /* Handle */
+  ::-webkit-scrollbar-thumb {
+    background #5f6c87
+    border-radius 10px
+  }
+
+  /* Handle on hover */
+  ::-webkit-scrollbar-thumb:hover {
+    background #5f6c87ad
+  }
+  :global(.ant-divider)
+    width 1px
+    background #5f6c87
+    margin: 0 15px
+    height 14px
+  .__actions
+    button, a
+      width auto
+      color #f6f6f6
+      font-size 12px
+      font-family Lato-Bold
+      line-height 2
+      letter-spacing 0.1px
+      &:hover
+        color #5f6c87
+  :global(.ant-drawer-content)
+    overflow auto
+  :global(.ant-drawer-mask)
+    background-color transparent
+  :global(.ant-drawer-content-wrapper)
+    padding-left 80px
+    box-shadow none !important
+  :global(.ant-drawer-content)
+    background #242a35
+  :global(.ant-drawer-header)
+    padding 15px 0
+    margin 0 24px
+    background transparent
+    border-bottom: 1px solid #5f6c87;
+  :global(.ant-drawer-body)
+    padding 15px 20px
+    margin 0 4px
+    height 190px
+    overflow-x hidde
+    overflow-y auto
+
+

--- a/pkg/ui/src/views/shared/components/drawer/index.tsx
+++ b/pkg/ui/src/views/shared/components/drawer/index.tsx
@@ -11,6 +11,10 @@
 import React from "react";
 import { Drawer, Button, Divider } from "antd";
 import { Link } from "react-router-dom";
+import classNames from "classnames/bind";
+import styles from "./drawer.module.styl";
+
+const cx = classNames.bind(styles);
 
 interface IDrawerProps {
   visible: boolean;
@@ -32,7 +36,7 @@ const openDetails = (data: any) => {
 export const DrawerComponent = ({ visible, onClose, children, data, details, ...props }: IDrawerProps) => (
   <Drawer
     title={
-      <div className="__actions">
+      <div className={cx("__actions")}>
         <Button type="default" ghost block onClick={onClose}>
           Close
         </Button>
@@ -48,7 +52,7 @@ export const DrawerComponent = ({ visible, onClose, children, data, details, ...
     closable={false}
     onClose={onClose}
     visible={visible}
-    className="drawer--preset-black"
+    className={cx("drawer--preset-black")}
     // getContainer={false}
     {...props}
   >

--- a/pkg/ui/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/index.tsx
@@ -10,11 +10,11 @@
 
 import React from "react";
 import classNames from "classnames";
-import getHighlightedText from "src/util/highlightedText";
 import map from "lodash/map";
 import isUndefined from "lodash/isUndefined";
 import times from "lodash/times";
 
+import getHighlightedText from "src/util/highlightedText";
 import { DrawerComponent } from "../drawer";
 import { trackTableSort } from "src/util/analytics";
 

--- a/pkg/ui/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/index.tsx
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 import React from "react";
-import classNames from "classnames";
+import classNames from "classnames/bind";
 import map from "lodash/map";
 import isUndefined from "lodash/isUndefined";
 import times from "lodash/times";
@@ -18,11 +18,12 @@ import getHighlightedText from "src/util/highlightedText";
 import { DrawerComponent } from "../drawer";
 import { trackTableSort } from "src/util/analytics";
 
-import "./sortabletable.styl";
+import styles from "./sortabletable.module.styl";
 import { Spin, Icon } from "antd";
 import SpinIcon from "src/components/icon/spin";
 import { Empty, IEmptyProps } from "src/components/empty";
 
+const cx = classNames.bind(styles);
 /**
  * SortableColumn describes the contents a single column of a
  * sortable table.
@@ -151,7 +152,7 @@ export class SortableTable extends React.Component<TableProps> {
   expansionControl(expanded: boolean) {
     const content = expanded ? "▼" : "▶";
     return (
-      <td className="sort-table__cell sort-table__cell__expansion-control">
+      <td className={cx("sort-table__cell", "sort-table__cell__expansion-control")}>
         <div>
           {content}
         </div>
@@ -161,7 +162,7 @@ export class SortableTable extends React.Component<TableProps> {
 
   renderRow = (rowIndex: number) => {
     const { columns, expandableConfig, drawer, firstCellBordered } = this.props;
-    const classes = classNames(
+    const classes = cx(
       "sort-table__row",
       "sort-table__row--body",
       this.state.activeIndex === rowIndex ? "drawer-active" : "",
@@ -187,7 +188,15 @@ export class SortableTable extends React.Component<TableProps> {
         {expandableConfig ? this.expansionControl(expanded) : null}
         {map(columns, (c: SortableColumn, colIndex: number) => {
           return (
-            <td className={classNames("sort-table__cell", { "sort-table__cell--header": firstCellBordered && colIndex === 0 }, c.className)} key={colIndex}>
+            <td
+              className={cx(
+                "sort-table__cell",
+                {
+                  "sort-table__cell--header": firstCellBordered && colIndex === 0,
+                },
+                c.className,
+              )}
+              key={colIndex}>
               {c.cell(rowIndex)}
             </td>
           );
@@ -196,7 +205,7 @@ export class SortableTable extends React.Component<TableProps> {
       </tr>,
     ];
     if (expandableConfig && expandableConfig.rowIsExpanded(rowIndex)) {
-      const expandedAreaClasses = classNames(
+      const expandedAreaClasses = cx(
         "sort-table__row",
         "sort-table__row--body",
         "sort-table__row--expanded-area",
@@ -208,7 +217,7 @@ export class SortableTable extends React.Component<TableProps> {
         <tr className={expandedAreaClasses} key={output.length + 2} >
           <td />
           <td
-            className="sort-table__cell"
+            className={cx("sort-table__cell")}
             colSpan={columns.length}
           >
             {expandableConfig.expandedContent(rowIndex)}
@@ -253,39 +262,39 @@ export class SortableTable extends React.Component<TableProps> {
       return <Empty {...emptyProps}/>;
     }
     return (
-      <div className="cl-table-wrapper">
-        <table className={classNames("sort-table", className)}>
+      <div className={cx("cl-table-wrapper")}>
+        <table className={cx("sort-table", className)}>
           <thead>
-            <tr className="sort-table__row sort-table__row--header">
-              {expandableConfig ? <th className="sort-table__cell" /> : null}
+            <tr className={cx("sort-table__row", "sort-table__row--header")}>
+              {expandableConfig ? <th className={cx("sort-table__cell")} /> : null}
               {map(columns, (c: SortableColumn, colIndex: number) => {
-                const classes = ["sort-table__cell"];
+                const classes = [cx("sort-table__cell")];
                 const style = {
                   textAlign: c.titleAlign,
                 };
                 let onClick: (e: any) => void = undefined;
 
                 if (!isUndefined(c.sortKey)) {
-                  classes.push("sort-table__cell--sortable");
+                  classes.push(cx("sort-table__cell--sortable"));
                   onClick = () => {
                     trackTableSort(className, c, sortSetting);
                     this.clickSort(c.sortKey);
                   };
                   if (c.sortKey === sortSetting.sortKey) {
                     if (sortSetting.ascending) {
-                      classes.push(" sort-table__cell--ascending");
+                      classes.push(cx("sort-table__cell--ascending"));
                     } else {
-                      classes.push("sort-table__cell--descending");
+                      classes.push(cx("sort-table__cell--descending"));
                     }
                   }
                 }
                 if (firstCellBordered && colIndex === 0) {
-                  classes.push("sort-table__cell--header");
+                  classes.push(cx("sort-table__cell--header"));
                 }
                 return (
                   <th className={classNames(classes)} key={colIndex} onClick={onClick} style={style}>
                     {c.title}
-                    {!isUndefined(c.sortKey) && <span className="sortable__actions" />}
+                    {!isUndefined(c.sortKey) && <span className={cx("sortable__actions")} />}
                   </th>
                 );
               })}
@@ -296,18 +305,18 @@ export class SortableTable extends React.Component<TableProps> {
           </tbody>
         </table>
         {loading && (
-          <div className="table__loading">
-            <Spin className="table__loading--spin" indicator={<Icon component={SpinIcon} spin />} />
-            {loadingLabel && <span className="table__loading--label">{loadingLabel}</span>}
+          <div className={cx("table__loading")}>
+            <Spin className={cx("table__loading--spin")} indicator={<Icon component={SpinIcon} spin />} />
+            {loadingLabel && <span className={cx("table__loading--label")}>{loadingLabel}</span>}
           </div>
         )}
         {drawer && (
           <DrawerComponent visible={visible} onClose={this.onClose} data={drawerData} details>
-            <span className="drawer__content">{getHighlightedText(drawerData.statement, drawerData.search, true)}</span>
+            <span className={cx("drawer__content")}>{getHighlightedText(drawerData.statement, drawerData.search, true)}</span>
           </DrawerComponent>
         )}
         {count === 0 && (
-          <div className="table__no-results">
+          <div className={cx("table__no-results")}>
             {renderNoResult}
           </div>
         )}

--- a/pkg/ui/src/views/shared/components/sortabletable/sortabletable.module.styl
+++ b/pkg/ui/src/views/shared/components/sortabletable/sortabletable.module.styl
@@ -1,0 +1,11 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@import "sortabletable.styl"

--- a/pkg/ui/src/views/shared/components/sortabletable/sortabletable.spec.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/sortabletable.spec.tsx
@@ -13,9 +13,13 @@ import _ from "lodash";
 import { assert } from "chai";
 import { shallow } from "enzyme";
 import * as sinon from "sinon";
+import classNames from "classnames/bind";
+import styles from "./sortabletable.module.styl";
 
 import "src/enzymeInit";
 import { SortableTable, SortableColumn, SortSetting } from "src/views/shared/components/sortabletable";
+
+const cx = classNames.bind(styles);
 
 const columns: SortableColumn[] = [
   {
@@ -48,7 +52,7 @@ describe("<SortableTable>", () => {
       const wrapper = makeTable(1);
       assert.lengthOf(wrapper.find("table"), 1, "one table");
       assert.lengthOf(wrapper.find("thead").find("tr"), 1, "one header row");
-      assert.lengthOf(wrapper.find("tr.sort-table__row--header"), 1, "column header row");
+      assert.lengthOf(wrapper.find(`tr.${cx("sort-table__row--header")}`), 1, "column header row");
       assert.lengthOf(wrapper.find("tbody"), 1, "tbody element");
     });
 
@@ -58,10 +62,10 @@ describe("<SortableTable>", () => {
 
       // Verify header structure.
       assert.equal(wrapper.find("tbody").find("tr").length, rowCount, "correct number of rows");
-      const headers = wrapper.find("tr.sort-table__row--header");
+      const headers = wrapper.find(`tr.${cx("sort-table__row--header")}`);
       _.each(columns, (c, index) => {
         const header = headers.childAt(index);
-        assert.isTrue(header.is(".sort-table__cell"), "header is correct class.");
+        assert.isTrue(header.is(`.${cx("sort-table__cell")}`), "header is correct class.");
         assert.equal(header.text(), c.title, "header has correct title.");
       });
 
@@ -76,27 +80,27 @@ describe("<SortableTable>", () => {
       });
 
       // Nothing is sorted.
-      assert.lengthOf(wrapper.find("th.sort-table__cell--ascending"), 0, "expected zero sorted columns.");
-      assert.lengthOf(wrapper.find("th.sort-table__cell--descending"), 0, "expected zero sorted columns.");
+      assert.lengthOf(wrapper.find(`th.${cx("sort-table__cell--ascending")}`), 0, "expected zero sorted columns.");
+      assert.lengthOf(wrapper.find(`th.${cx("sort-table__cell--descending")}`), 0, "expected zero sorted columns.");
     });
 
     it("renders sorted column correctly.", () => {
       // ascending = false.
       let wrapper = makeTable(1, { sortKey: 1, ascending: false });
 
-      let sortHeader = wrapper.find("th.sort-table__cell--descending");
+      let sortHeader = wrapper.find(`th.${cx("sort-table__cell--descending")}`);
       assert.lengthOf(sortHeader, 1, "only a single column is sorted descending.");
       assert.equal(sortHeader.text(), columns[0].title, "first column should be sorted.");
-      sortHeader = wrapper.find("th.sort-table__cell--ascending");
+      sortHeader = wrapper.find(`th.${cx("sort-table__cell--ascending")}`);
       assert.lengthOf(sortHeader, 0, "no columns are sorted ascending.");
 
       // ascending = true
       wrapper = makeTable(1, { sortKey: 2, ascending: true });
 
-      sortHeader = wrapper.find("th.sort-table__cell--ascending");
+      sortHeader = wrapper.find(`th.${cx("sort-table__cell--ascending")}`);
       assert.lengthOf(sortHeader, 1, "only a single column is sorted ascending.");
       assert.equal(sortHeader.text(), columns[1].title, "second column should be sorted.");
-      sortHeader = wrapper.find("th.sort-table__cell--descending");
+      sortHeader = wrapper.find(`th.${cx("sort-table__cell--descending")}`);
       assert.lengthOf(sortHeader, 0, "no columns are sorted descending.");
     });
   });
@@ -105,7 +109,7 @@ describe("<SortableTable>", () => {
     it("sorts descending on initial click.", () => {
       const spy = sinon.spy();
       const wrapper = makeTable(1, undefined, spy);
-      wrapper.find("th.sort-table__cell--sortable").first().simulate("click");
+      wrapper.find(`th.${cx("sort-table__cell")}`).first().simulate("click");
       assert.isTrue(spy.calledOnce);
       assert.isTrue(spy.calledWith({
         sortKey: 1,
@@ -118,7 +122,7 @@ describe("<SortableTable>", () => {
       const spy = sinon.spy();
       const wrapper = makeTable(1, {sortKey: 2, ascending: true}, spy);
 
-      wrapper.find("th.sort-table__cell--sortable").first().simulate("click");
+      wrapper.find(`th.${cx("sort-table__cell")}`).first().simulate("click");
       assert.isTrue(spy.calledOnce);
       assert.isTrue(spy.calledWith({
         sortKey: 1,
@@ -130,7 +134,7 @@ describe("<SortableTable>", () => {
       const spy = sinon.spy();
       const wrapper = makeTable(1, {sortKey: 1, ascending: false}, spy);
 
-      wrapper.find("th.sort-table__cell--sortable").first().simulate("click");
+      wrapper.find(`th.${cx("sort-table__cell")}`).first().simulate("click");
       assert.isTrue(spy.calledOnce);
       assert.isTrue( spy.calledWith({
         sortKey: 1,
@@ -142,7 +146,7 @@ describe("<SortableTable>", () => {
       const spy = sinon.spy();
       const wrapper = makeTable(1, {sortKey: 1, ascending: true}, spy);
 
-      wrapper.find("th.sort-table__cell--sortable").first().simulate("click");
+      wrapper.find(`th.${cx("sort-table__cell")}`).first().simulate("click");
       assert.isTrue(spy.calledOnce);
       assert.isTrue( spy.calledWith({
         sortKey: null,
@@ -155,7 +159,7 @@ describe("<SortableTable>", () => {
       const spy = sinon.spy();
       const wrapper = makeTable(1, {sortKey: 1, ascending: true}, spy);
 
-      wrapper.find("thead th.sort-table__cell").last().simulate("click");
+      wrapper.find(`thead th.${cx("sort-table__cell")}`).last().simulate("click");
       assert.isTrue(spy.notCalled);
     });
   });

--- a/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
+++ b/pkg/ui/src/views/shared/components/sortabletable/sortabletable.styl
@@ -136,3 +136,9 @@
     line-height 22px
     letter-spacing $letter-spacing--compact
     color $colors--neutral-6
+
+.drawer__content
+  color #f6f6f6
+  font-family RobotoMono-Regular
+  font-size 12px
+  line-height 24px

--- a/pkg/ui/src/views/shared/components/sortedtable/sortedtable.spec.tsx
+++ b/pkg/ui/src/views/shared/components/sortedtable/sortedtable.spec.tsx
@@ -13,10 +13,14 @@ import _ from "lodash";
 import { assert } from "chai";
 import { mount } from "enzyme";
 import * as sinon from "sinon";
+import classNames from "classnames/bind";
 
 import "src/enzymeInit";
 import { SortedTable, ColumnDescriptor, ISortedTablePagination } from "src/views/shared/components/sortedtable";
 import { SortSetting } from "src/views/shared/components/sortabletable";
+import styles from "../sortabletable/sortabletable.module.styl";
+
+const cx = classNames.bind(styles);
 
 class TestRow {
   constructor(public name: string, public value: number) { }
@@ -67,14 +71,14 @@ describe("<SortedTable>", function() {
     const wrapper = makeTable([new TestRow("test", 1)]);
     assert.lengthOf(wrapper.find("table"), 1, "one table");
     assert.lengthOf(wrapper.find("thead").find("tr"), 1, "one header row");
-    assert.lengthOf(wrapper.find("tr.sort-table__row--header"), 1, "column header row");
+    assert.lengthOf(wrapper.find(`tr.${cx("sort-table__row--header")}`), 1, "column header row");
     assert.lengthOf(wrapper.find("tbody"), 1, "tbody element");
   });
 
   it("correctly uses onChangeSortSetting", function() {
     const spy = sinon.spy();
     const wrapper = makeTable([new TestRow("test", 1)], undefined, spy);
-    wrapper.find("th.sort-table__cell--sortable").first().simulate("click");
+    wrapper.find(`th.${cx("sort-table__cell")}`).first().simulate("click");
     assert.isTrue(spy.calledOnce);
     assert.deepEqual(spy.getCall(0).args[0], {
       sortKey: 0,
@@ -110,30 +114,30 @@ describe("<SortedTable>", function() {
       const wrapper = makeExpandableTable([new TestRow("test", 1)], undefined);
       assert.lengthOf(wrapper.find("table"), 1, "one table");
       assert.lengthOf(wrapper.find("thead").find("tr"), 1, "one header row");
-      assert.lengthOf(wrapper.find("tr.sort-table__row--header"), 1, "column header row");
+      assert.lengthOf(wrapper.find(`tr.${cx("sort-table__row--header")}`), 1, "column header row");
       assert.lengthOf(wrapper.find("tbody"), 1, "tbody element");
       assert.lengthOf(wrapper.find("tbody tr"), 1, "one body row");
       assert.lengthOf(wrapper.find("tbody td"), 3, "two body cells plus one expansion control cell");
-      assert.lengthOf(wrapper.find("td.sort-table__cell__expansion-control"), 1, "one expansion control cell");
+      assert.lengthOf(wrapper.find(`td.${cx("sort-table__cell__expansion-control")}`), 1, "one expansion control cell");
     });
 
     it("expands and collapses the clicked row", function() {
       const wrapper = makeExpandableTable([new TestRow("test", 1)], undefined);
-      assert.lengthOf(wrapper.find(".sort-table__row--expanded-area"), 0, "nothing expanded yet");
-      wrapper.find(".sort-table__cell__expansion-control").simulate("click");
+      assert.lengthOf(wrapper.find(`.${cx("sort-table__row--expanded-area")}`), 0, "nothing expanded yet");
+      wrapper.find(`.${cx("sort-table__cell__expansion-control")}`).simulate("click");
       const expandedArea = wrapper.find(".sort-table__row--expanded-area");
       assert.lengthOf(expandedArea, 1, "row is expanded");
       assert.lengthOf(expandedArea.children(), 2, "expanded row contains placeholder and content area");
       assert.isTrue(expandedArea.contains(<td />));
       assert.isTrue(expandedArea.contains(
-        <td className="sort-table__cell" colSpan={2}>
+        <td className={cx("sort-table__cell")} colSpan={2}>
           <div>
             test=1
           </div>
         </td>,
       ));
-      wrapper.find(".sort-table__cell__expansion-control").simulate("click");
-      assert.lengthOf(wrapper.find(".sort-table__row--expanded-area"), 0, "row collapsed again");
+      wrapper.find(`.${cx("sort-table__cell__expansion-control")}`).simulate("click");
+      assert.lengthOf(wrapper.find(`.${cx("sort-table__row--expanded-area")}`), 0, "row collapsed again");
     });
   });
 

--- a/pkg/ui/src/views/statements/planView/index.ts
+++ b/pkg/ui/src/views/statements/planView/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2019 The Cockroach Authors.
+// Copyright 2020 The Cockroach Authors.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -8,14 +8,4 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-@require nib
-
-@require 'base/layout-vars.styl'
-@require 'base/palette.styl'
-@require 'base/typography.styl'
-@require 'utils/fonts.styl'
-@require 'base/reset.styl'
-
-@require 'pages/reports.styl'
-
-@require 'shame.styl'
+export * from "./planView";

--- a/pkg/ui/src/views/statements/planView/planView.fixtures.tsx
+++ b/pkg/ui/src/views/statements/planView/planView.fixtures.tsx
@@ -1,0 +1,192 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {cockroach} from "src/js/protos";
+import IExplainTreePlanNode = cockroach.sql.IExplainTreePlanNode;
+
+export const logicalPlan: IExplainTreePlanNode = {
+  "name": "root",
+  "attrs": [],
+  "children": [
+    {
+      "name": "count",
+      "attrs": [],
+      "children": [
+        {
+          "name": "upsert",
+          "attrs": [
+            {
+              "key": "into",
+              "value": "vehicle_location_histories(city, ride_id, timestamp, lat, long)",
+            },
+            {
+              "key": "strategy",
+              "value": "opt upserter",
+            },
+          ],
+          "children": [
+            {
+              "name": "buffer node",
+              "attrs": [
+                {
+                  "key": "label",
+                  "value": "buffer 1",
+                },
+              ],
+              "children": [
+                {
+                  "name": "row source to plan node",
+                  "attrs": [],
+                  "children": [
+                    {
+                      "name": "render",
+                      "attrs": [
+                        {
+                          "key": "render",
+                          "value": "column1",
+                        },
+                        {
+                          "key": "render",
+                          "value": "column2",
+                        },
+                        {
+                          "key": "render",
+                          "value": "column3",
+                        },
+                        {
+                          "key": "render",
+                          "value": "column4",
+                        },
+                        {
+                          "key": "render",
+                          "value": "column5",
+                        },
+                        {
+                          "key": "render",
+                          "value": "column4",
+                        },
+                        {
+                          "key": "render",
+                          "value": "column5",
+                        },
+                      ],
+                      "children": [
+                        {
+                          "name": "values",
+                          "attrs": [
+                            {
+                              "key": "size",
+                              "value": "5 columns, 1 row",
+                            },
+                            {
+                              "key": "row 0, expr",
+                              "value": "_",
+                            },
+                            {
+                              "key": "row 0, expr",
+                              "value": "_",
+                            },
+                            {
+                              "key": "row 0, expr",
+                              "value": "now()",
+                            },
+                            {
+                              "key": "row 0, expr",
+                              "value": "_",
+                            },
+                            {
+                              "key": "row 0, expr",
+                              "value": "_",
+                            },
+                          ],
+                          "children": [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      "name": "postquery",
+      "attrs": [],
+      "children": [
+        {
+          "name": "error if rows",
+          "attrs": [],
+          "children": [
+            {
+              "name": "row source to plan node",
+              "attrs": [],
+              "children": [
+                {
+                  "name": "lookup-join",
+                  "attrs": [
+                    {
+                      "key": "table",
+                      "value": "rides@primary",
+                    },
+                    {
+                      "key": "type",
+                      "value": "anti",
+                    },
+                    {
+                      "key": "equality",
+                      "value": "(column1, column2) = (city, id)",
+                    },
+                    {
+                      "key": "equality cols are key",
+                      "value": "",
+                    },
+                    {
+                      "key": "parallel",
+                      "value": "",
+                    },
+                  ],
+                  "children": [
+                    {
+                      "name": "render",
+                      "attrs": [
+                        {
+                          "key": "render",
+                          "value": "column1",
+                        },
+                        {
+                          "key": "render",
+                          "value": "column2",
+                        },
+                      ],
+                      "children": [
+                        {
+                          "name": "scan buffer node",
+                          "children": [],
+                          "attrs": [
+                            {
+                              "key": "label",
+                              "value": "buffer 1",
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/pkg/ui/src/views/statements/planView/planView.module.styl
+++ b/pkg/ui/src/views/statements/planView/planView.module.styl
@@ -1,0 +1,199 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@require '~styl/base/palette.styl'
+@require '~src/views/shared/util/table.styl'
+@require '~src/components/core/index'
+
+.base-heading
+  composes base-heading from '~styl/base/typography.styl'
+
+.plan-view-table
+  @extend $table-base
+  .plan-view-table__cell
+    padding 0
+  .summary--card__title
+    font-family SourceSansPro-Regular
+    line-height 1.6
+    letter-spacing -0.2px
+    color $popover-color
+    font-size 16px
+    display inline-block
+    margin-bottom 10px
+    padding 0
+    text-transform none
+  &__row
+    &--body
+      border-top none
+      &:hover
+        background-color $adminui-white
+  &__tooltip
+    .hover-tooltip__text
+      width 520px
+      margin-left 15px
+
+.plan-view-table
+  &__tooltip
+    width 36px  // Reserve space for 10px padding around centered 16px icon
+    height 16px
+    display inline-block
+
+    // Overrides to let the tooltip sit inside a table header.
+    text-transform none
+    font-weight normal
+    white-space normal
+    letter-spacing normal
+    font-size 14px
+
+  &__tooltip-hover-area
+    width 100%
+    padding 0px 10px
+
+  &__info-icon
+    width 16px
+    height 16px
+    border-radius 50%
+    border 1px solid $tooltip-color
+    font-size 12px
+    line-height 14px  // Visual tweak to vertically center the "i"
+    text-align center
+    color $tooltip-color
+
+  .hover-tooltip--hovered &__info-icon
+    border-color $body-color
+    color $body-color
+
+.plan-view
+  color $body-color
+  position relative
+
+  .plan-view-container
+    height 100%
+    max-height 100%
+    overflow hidden
+
+    .plan-view-container-scroll
+      max-height 400px
+      overflow-y scroll
+
+    .plan-view-container-directions
+      text-align center
+      cursor pointer
+      text-transform uppercase
+      color $main-blue-color
+      font-size smaller
+
+  .node-icon
+    margin 0 10px 0 0
+    color $grey-light
+  .warning-icon
+    margin 0 4px 0 4px
+    position relative
+    top 3px
+    path
+      fill $colors--functional-orange-4
+
+  .warn
+    position relative
+    left -5px
+    color $colors--functional-orange-4
+    background-color $plan-node-warning-background-color
+    border-radius 2px
+    padding 2px
+
+  .nodeDetails
+    position relative
+    padding 6px 0
+    border 1px solid transparent
+    b
+      font-family SourceSansPro-SemiBold
+      font-size 12px
+      font-weight 600
+      line-height 1.67
+      letter-spacing 0.3px
+      color $text-color
+
+  .nodeAttributes
+    color $adminui-grey-2
+    padding 7px 16px 0px 18px
+    margin-left 3px
+    border-left 1px solid $grey-light
+    font-family RobotoMono-Medium
+    font-size 12px
+    font-weight 500
+    line-height 1.83
+
+    .nodeAttributeKey
+      color $colors--primary-green-3
+
+  ul
+    padding 0
+    margin 0
+    li
+      padding 0
+      margin 0
+      position relative
+      list-style-type none
+
+      // vertical line, to previous node (above)
+      &:not(:first-child):after
+        content ''
+        width 1px
+        height 19px
+        background-color $grey-light
+        position absolute
+        top -10px
+        left 4px
+
+      ul
+        padding-left 27px
+        position relative
+        &:last-child
+          &:before
+            content ''
+            width 28px
+            height 29px
+            position absolute
+            border-left 1px solid $grey-light
+            border-bottom 1px solid $grey-light
+            top -10px
+            left 4px
+            border-bottom-left-radius 10px
+          li
+            &:before
+              content none
+            &:first-child:after
+              content none
+        li
+          // first node: horizontal line, to parent
+          .nodeDetails
+            margin-left 12px
+          &:not(:first-child):after
+            left 16px
+          &:last-child
+            .nodeAttributes
+              border-color transparent
+          &:first-child
+            &:after
+              content ''
+              height 1px
+              width 27px
+              background-color $grey-light
+              position absolute
+              top 18px
+              left -22px
+          &:before
+            content ''
+            width 1px
+            height 100%
+            background-color $grey-light
+            position absolute
+            top -10px
+            left -23px

--- a/pkg/ui/src/views/statements/planView/planView.spec.tsx
+++ b/pkg/ui/src/views/statements/planView/planView.spec.tsx
@@ -11,7 +11,12 @@
 import { assert } from "chai";
 
 import { cockroach } from "src/js/protos";
-import { FlatPlanNode, FlatPlanNodeAttribute, flattenTree, flattenAttributes } from "src/views/statements/planView";
+import {
+  FlatPlanNode,
+  FlatPlanNodeAttribute,
+  flattenTree,
+  flattenAttributes,
+} from "src/views/statements/planView";
 import IAttr = cockroach.sql.ExplainTreePlanNode.IAttr;
 import IExplainTreePlanNode = cockroach.sql.IExplainTreePlanNode;
 

--- a/pkg/ui/src/views/statements/planView/planView.stories.tsx
+++ b/pkg/ui/src/views/statements/planView/planView.stories.tsx
@@ -1,0 +1,22 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { PlanView } from "./planView";
+import {logicalPlan} from "./planView.fixtures";
+
+storiesOf("PlanView", module)
+  .add("default", () => (
+    <PlanView
+      title="Logical Plan"
+      plan={logicalPlan}
+    />),
+  );

--- a/pkg/ui/src/views/statements/planView/planView.tsx
+++ b/pkg/ui/src/views/statements/planView/planView.tsx
@@ -12,17 +12,18 @@ import _ from "lodash";
 import React, { Fragment } from "react";
 import { cockroach } from "src/js/protos";
 import { ToolTipWrapper } from "src/views/shared/components/toolTip";
+import styles from "./planView.module.styl";
 
 import IAttr = cockroach.sql.ExplainTreePlanNode.IAttr;
 import IExplainTreePlanNode = cockroach.sql.IExplainTreePlanNode;
 
 const WARNING_ICON = (
-  <svg className="warning-icon" width="17" height="17" viewBox="0 0 24 22" xmlns="http://www.w3.org/2000/svg">
+  <svg className={styles["warning-icon"]} width="17" height="17" viewBox="0 0 24 22" xmlns="http://www.w3.org/2000/svg">
     <path fill-rule="evenodd" clip-rule="evenodd" d="M15.7798 2.18656L23.4186 15.5005C25.0821 18.4005 22.9761 21.9972 19.6387 21.9972H4.3619C1.02395 21.9972 -1.08272 18.4009 0.582041 15.5005M0.582041 15.5005L8.21987 2.18656C9.89189 -0.728869 14.1077 -0.728837 15.7798 2.18656M13.4002 7.07075C13.4002 6.47901 12.863 5.99932 12.2002 5.99932C11.5375 5.99932 11.0002 6.47901 11.0002 7.07075V13.4993C11.0002 14.0911 11.5375 14.5707 12.2002 14.5707C12.863 14.5707 13.4002 14.0911 13.4002 13.4993V7.07075ZM13.5717 17.2774C13.5717 16.5709 12.996 15.9981 12.286 15.9981C11.5759 15.9981 11.0002 16.5709 11.0002 17.2774V17.2902C11.0002 17.9967 11.5759 18.5695 12.286 18.5695C12.996 18.5695 13.5717 17.9967 13.5717 17.2902V17.2774Z"/>
   </svg>
 );
 const NODE_ICON = (
-  <span className="node-icon">&#x26AC;</span>
+  <span className={styles["node-icon"]}>&#x26AC;</span>
 );
 
 // FlatPlanNodeAttribute contains a flattened representation of IAttr[].
@@ -203,9 +204,9 @@ class PlanNodeDetails extends React.Component<PlanNodeDetailProps> {
       keyClassName = "";
     }
     return (
-      <div key={attr.key} className={attrClassName}>
+      <div key={attr.key} className={styles[attrClassName]}>
         {attr.warn && WARNING_ICON}
-        <span className={keyClassName}>{attr.key}</span>
+        <span className={styles[keyClassName]}>{attr.key}</span>
         {this.renderAttributeValues(attr.values)}
       </div>
     );
@@ -215,7 +216,7 @@ class PlanNodeDetails extends React.Component<PlanNodeDetailProps> {
     const node = this.props.node;
     if (node.attrs && node.attrs.length > 0) {
       return (
-        <div className="nodeAttributes">
+        <div className={styles[`nodeAttributes`]}>
           {node.attrs.map( (attr) => this.renderAttribute(attr))}
         </div>
       );
@@ -225,7 +226,7 @@ class PlanNodeDetails extends React.Component<PlanNodeDetailProps> {
   render() {
     const node = this.props.node;
     return (
-      <div className="nodeDetails">
+      <div className={styles[`nodeDetails`]}>
         {NODE_ICON} <b>{_.capitalize(node.name)}</b>
         {this.renderNodeDetails()}
       </div>
@@ -326,16 +327,16 @@ export class PlanView extends React.Component<PlanViewProps, PlanViewState> {
     );
 
     return (
-      <table className="plan-view-table">
+      <table className={styles["plan-view-table"]}>
         <thead>
-        <tr className="plan-view-table__row--header">
-          <th className="plan-view-table__cell">
-            <h2 className="base-heading summary--card__title">{this.props.title}</h2>
-            <div className="plan-view-table__tooltip">
+        <tr className={styles["plan-view-table__row--header"]}>
+          <th className={styles["plan-view-table__cell"]}>
+            <h2 className={`${styles["base-heading"]} ${styles["summary--card__title"]}`}>{this.props.title}</h2>
+            <div className={styles["plan-view-table__tooltip"]}>
               <ToolTipWrapper
                 text={lastSampledHelpText}>
-                <div className="plan-view-table__tooltip-hover-area">
-                  <div className="plan-view-table__info-icon">i</div>
+                <div className={styles["plan-view-table__tooltip-hover-area"]}>
+                  <div className={styles["plan-view-table__info-icon"]}>i</div>
                 </div>
               </ToolTipWrapper>
             </div>
@@ -343,9 +344,9 @@ export class PlanView extends React.Component<PlanViewProps, PlanViewState> {
         </tr>
         </thead>
         <tbody>
-        <tr className="plan-view-table__row--body">
-          <td className="plan-view plan-view-table__cell" style={{ textAlign: "left" }}>
-            <div className="plan-view-container">
+        <tr className={styles["plan-view-table__row--body"]}>
+          <td className={`${styles["plan-view"]} ${styles["plan-view-table__cell"]}`} style={{ textAlign: "left" }}>
+            <div className={styles["plan-view-container"]}>
               <div
                 id="plan-view-inner-container"
                 ref={this.innerContainer}

--- a/pkg/ui/src/views/statements/planView/planView.tsx
+++ b/pkg/ui/src/views/statements/planView/planView.tsx
@@ -10,6 +10,7 @@
 
 import _ from "lodash";
 import React, { Fragment } from "react";
+import classNames from "classnames/bind";
 import { cockroach } from "src/js/protos";
 import { ToolTipWrapper } from "src/views/shared/components/toolTip";
 import styles from "./planView.module.styl";
@@ -17,13 +18,15 @@ import styles from "./planView.module.styl";
 import IAttr = cockroach.sql.ExplainTreePlanNode.IAttr;
 import IExplainTreePlanNode = cockroach.sql.IExplainTreePlanNode;
 
+const cx = classNames.bind(styles);
+
 const WARNING_ICON = (
-  <svg className={styles["warning-icon"]} width="17" height="17" viewBox="0 0 24 22" xmlns="http://www.w3.org/2000/svg">
+  <svg className={cx("warning-icon")} width="17" height="17" viewBox="0 0 24 22" xmlns="http://www.w3.org/2000/svg">
     <path fill-rule="evenodd" clip-rule="evenodd" d="M15.7798 2.18656L23.4186 15.5005C25.0821 18.4005 22.9761 21.9972 19.6387 21.9972H4.3619C1.02395 21.9972 -1.08272 18.4009 0.582041 15.5005M0.582041 15.5005L8.21987 2.18656C9.89189 -0.728869 14.1077 -0.728837 15.7798 2.18656M13.4002 7.07075C13.4002 6.47901 12.863 5.99932 12.2002 5.99932C11.5375 5.99932 11.0002 6.47901 11.0002 7.07075V13.4993C11.0002 14.0911 11.5375 14.5707 12.2002 14.5707C12.863 14.5707 13.4002 14.0911 13.4002 13.4993V7.07075ZM13.5717 17.2774C13.5717 16.5709 12.996 15.9981 12.286 15.9981C11.5759 15.9981 11.0002 16.5709 11.0002 17.2774V17.2902C11.0002 17.9967 11.5759 18.5695 12.286 18.5695C12.996 18.5695 13.5717 17.9967 13.5717 17.2902V17.2774Z"/>
   </svg>
 );
 const NODE_ICON = (
-  <span className={styles["node-icon"]}>&#x26AC;</span>
+  <span className={cx("node-icon")}>&#x26AC;</span>
 );
 
 // FlatPlanNodeAttribute contains a flattened representation of IAttr[].
@@ -204,9 +207,9 @@ class PlanNodeDetails extends React.Component<PlanNodeDetailProps> {
       keyClassName = "";
     }
     return (
-      <div key={attr.key} className={styles[attrClassName]}>
+      <div key={attr.key} className={cx(attrClassName)}>
         {attr.warn && WARNING_ICON}
-        <span className={styles[keyClassName]}>{attr.key}</span>
+        <span className={cx(keyClassName)}>{attr.key}</span>
         {this.renderAttributeValues(attr.values)}
       </div>
     );
@@ -216,7 +219,7 @@ class PlanNodeDetails extends React.Component<PlanNodeDetailProps> {
     const node = this.props.node;
     if (node.attrs && node.attrs.length > 0) {
       return (
-        <div className={styles[`nodeAttributes`]}>
+        <div className={cx("nodeAttributes")}>
           {node.attrs.map( (attr) => this.renderAttribute(attr))}
         </div>
       );
@@ -226,7 +229,7 @@ class PlanNodeDetails extends React.Component<PlanNodeDetailProps> {
   render() {
     const node = this.props.node;
     return (
-      <div className={styles[`nodeDetails`]}>
+      <div className={cx("nodeDetails")}>
         {NODE_ICON} <b>{_.capitalize(node.name)}</b>
         {this.renderNodeDetails()}
       </div>
@@ -327,16 +330,16 @@ export class PlanView extends React.Component<PlanViewProps, PlanViewState> {
     );
 
     return (
-      <table className={styles["plan-view-table"]}>
+      <table className={cx("plan-view-table")}>
         <thead>
-        <tr className={styles["plan-view-table__row--header"]}>
-          <th className={styles["plan-view-table__cell"]}>
-            <h2 className={`${styles["base-heading"]} ${styles["summary--card__title"]}`}>{this.props.title}</h2>
-            <div className={styles["plan-view-table__tooltip"]}>
+        <tr className={cx("plan-view-table__row--header")}>
+          <th className={cx("plan-view-table__cell")}>
+            <h2 className={cx("base-heading", "summary--card__title")}>{this.props.title}</h2>
+            <div className={cx("plan-view-table__tooltip")}>
               <ToolTipWrapper
                 text={lastSampledHelpText}>
-                <div className={styles["plan-view-table__tooltip-hover-area"]}>
-                  <div className={styles["plan-view-table__info-icon"]}>i</div>
+                <div className={cx("plan-view-table__tooltip-hover-area")}>
+                  <div className={cx("plan-view-table__info-icon")}>i</div>
                 </div>
               </ToolTipWrapper>
             </div>
@@ -344,9 +347,9 @@ export class PlanView extends React.Component<PlanViewProps, PlanViewState> {
         </tr>
         </thead>
         <tbody>
-        <tr className={styles["plan-view-table__row--body"]}>
-          <td className={`${styles["plan-view"]} ${styles["plan-view-table__cell"]}`} style={{ textAlign: "left" }}>
-            <div className={styles["plan-view-container"]}>
+        <tr className={cx("plan-view-table__row--body")}>
+          <td className={cx("plan-view", "plan-view-table__cell")} style={{ textAlign: "left" }}>
+            <div className={cx("plan-view-container")}>
               <div
                 id="plan-view-inner-container"
                 ref={this.innerContainer}

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -406,8 +406,6 @@ $plan-node-warning-background-color = rgba(209, 135, 55, 0.06)  // light orange
   &:hover
     color $colors--primary-blue-3
     text-decoration underline
-  ._text-bold
-    font-family RobotoMono-Bold
 
 .cl-table-link__statement-tooltip--fixed-width
   max-width max-content

--- a/pkg/ui/src/views/statements/statementsPage.module.styl
+++ b/pkg/ui/src/views/statements/statementsPage.module.styl
@@ -1,0 +1,71 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+._pg-jump
+  width 32px
+  height 24px
+  position relative
+  justify-content center
+  align-items center
+  ._jump-dots
+    position absolute
+    top 50%
+    left 50%
+    transform: translate(-50%, -50%)
+    color $colors--neutral-5
+    font-size 14px
+    letter-spacing 1.5px
+  .anticon
+    position absolute
+    top 50%
+    left 50%
+    transform: translate(-50%, -50%)
+    display none
+    font-size 10px
+    color #3a7ce1
+  &:hover
+    ._jump-dots
+      display none
+    .anticon
+      display block
+
+.cl-table-statistic
+  display flex
+  justify-content space-between
+  align-items center
+  margin-bottom 7px
+
+.cl-count-title, .last-cleared-title
+  font-family SourceSansPro-Regular
+  font-size 14px
+  padding 0px
+  margin 0px
+  color $placeholder
+  line-height 1.57
+  letter-spacing 0.1px
+  .label
+    font-family $font-family--bold
+    color $colors--neutral-7
+
+.section
+  flex 0 0 auto
+  padding 12px 24px
+  max-width $max-window-width
+  clearfix()
+
+  &--heading
+    padding-top 0
+    padding-bottom 0
+
+  &--container
+    padding 0 24px 0 0
+
+.base-heading
+  composes base-heading from '~styl/base/typography.styl'

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -17,6 +17,7 @@ import Helmet from "react-helmet";
 import { connect } from "react-redux";
 import { createSelector } from "reselect";
 import { RouteComponentProps, withRouter } from "react-router-dom";
+import classNames from "classnames/bind";
 import { paginationPageCount } from "src/components/pagination/pagination";
 import * as protos from "src/js/protos";
 import { refreshStatementDiagnosticsRequests, refreshStatements } from "src/redux/apiReducers";
@@ -35,17 +36,19 @@ import { SortSetting } from "src/views/shared/components/sortabletable";
 import { Search } from "../app/components/Search";
 import { AggregateStatistics, makeStatementsColumns, StatementsSortedTable } from "./statementsTable";
 import ActivateDiagnosticsModal, { ActivateDiagnosticsModalRef } from "src/views/statements/diagnostics/activateDiagnosticsModal";
-import "./statements.styl";
 import {
   selectLastDiagnosticsReportPerStatement,
 } from "src/redux/statements/statementsSelectors";
 import { createStatementDiagnosticsAlertLocalSetting } from "src/redux/alerts";
 import { getMatchParamByName } from "src/util/query";
 import { trackPaginate, trackSearch } from "src/util/analytics";
-
-import "./statements.styl";
 import { ISortedTablePagination } from "../shared/components/sortedtable";
 import { statementsTable } from "src/util/docs";
+import styles from "./statementsPage.module.styl";
+import sortableTableStyles from "src/views/shared/components/sortabletable/sortabletable.module.styl";
+
+const cx = classNames.bind(styles);
+const sortableTableCx = classNames.bind(sortableTableStyles);
 
 type ICollectedStatementStatistics = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 
@@ -199,16 +202,16 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
     switch (type) {
       case "jump-prev":
         return (
-          <div className="_pg-jump">
+          <div className={cx("_pg-jump")}>
             <Icon type="left" />
-            <span className="_jump-dots">•••</span>
+            <span className={cx("_jump-dots")}>•••</span>
           </div>
         );
       case "jump-next":
         return (
-          <div className="_pg-jump">
+          <div className={cx("_pg-jump")}>
             <Icon type="right" />
-            <span className="_jump-dots">•••</span>
+            <span className={cx("_jump-dots")}>•••</span>
           </div>
         );
       default:
@@ -223,8 +226,8 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
 
   noStatementResult = () => (
     <>
-      <h3 className="table__no-results--title">There are no SQL statements that match your search or filter since this page was last cleared.</h3>
-      <p className="table__no-results--description">
+      <h3 className={sortableTableCx("table__no-results--title")}>There are no SQL statements that match your search or filter since this page was last cleared.</h3>
+      <p className={sortableTableCx("table__no-results--description")}>
         <span>Statements are cleared every hour by default, or according to your configuration.</span>
         <a href={statementsTable} target="_blank">Learn more</a>
       </p>
@@ -258,12 +261,12 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
             />
           </PageConfigItem>
         </PageConfig>
-        <section className="cl-table-container">
-          <div className="cl-table-statistic">
-            <h4 className="cl-count-title">
+        <section className={sortableTableCx("cl-table-container")}>
+          <div className={cx("cl-table-statistic")}>
+            <h4 className={cx("cl-count-title")}>
               {paginationPageCount({ ...pagination, total: this.filteredStatementsData().length }, "statements", match, appAttr, search)}
             </h4>
-            <h4 className="last-cleared-title">
+            <h4 className={cx("last-cleared-title")}>
               {this.renderLastCleared()}
             </h4>
           </div>
@@ -311,8 +314,8 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
       <React.Fragment>
         <Helmet title={app ? `${app} App | Statements` : "Statements"} />
 
-        <section className="section">
-          <h1 className="base-heading">Statements</h1>
+        <section className={cx("section")}>
+          <h1 className={cx("base-heading")}>Statements</h1>
         </section>
 
         <Loading

--- a/pkg/ui/src/views/statements/statementsTable.module.styl
+++ b/pkg/ui/src/views/statements/statementsTable.module.styl
@@ -11,18 +11,6 @@
 @require '~styl/base/palette.styl'
 @require '~src/components/core/index'
 
-.cl-table-link__description
-  font-size $font-size--small
-  line-height 22px
-  color $colors--neutral-1
-  white-space pre-wrap
-  margin-bottom 0
-
-.cl-table-link__statement-tooltip--fixed-width
-  max-width max-content
-  :global(.ant-tooltip-content)
-    max-width 500px
-
 .statements-table__col-time
   white-space nowrap
 

--- a/pkg/ui/src/views/statements/statementsTable.stories.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.stories.tsx
@@ -1,0 +1,43 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import {makeStatementsColumns, StatementsSortedTable} from "./statementsTable";
+import statementsPagePropsFixture from "src/views/statements/statementsPage.fixture";
+import {withRouterProvider} from ".storybook/decorators";
+
+const { statements } = statementsPagePropsFixture;
+
+storiesOf("StatementsSortedTable", module)
+  .addDecorator(withRouterProvider)
+  .add("with data", () => (
+    <StatementsSortedTable
+      className="statements-table"
+      data={statements}
+      columns={
+        makeStatementsColumns(
+          statements,
+          "(internal)",
+        )
+      }
+      sortSetting={{
+        ascending: false,
+        sortKey: 3,
+      }}
+      pagination={{
+        pageSize: 20,
+        current: 1,
+      }}
+    />
+  ))
+  .add("empty table", () => (
+    <StatementsSortedTable />
+  ));

--- a/pkg/ui/src/views/statements/statementsTable.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.tsx
@@ -59,13 +59,13 @@ export function makeStatementsColumns(
   const columns: ColumnDescriptor<AggregateStatistics>[] = [
     {
       title: StatementTableTitle.statements,
-      className: "cl-table__col-query-text",
+      className: cx("cl-table__col-query-text"),
       cell: StatementTableCell.statements(search, selectedApp),
       sort: (stmt) => stmt.label,
     },
     {
       title: StatementTableTitle.txtType,
-      className: "statements-table__col-time",
+      className: cx("statements-table__col-time"),
       cell: (stmt) => (stmt.implicitTxn ? "Implicit" : "Explicit"),
       sort: (stmt) => (stmt.implicitTxn ? "Implicit" : "Explicit"),
     },
@@ -142,25 +142,25 @@ function makeCommonColumns(statements: AggregateStatistics[])
   return [
     {
       title: StatementTableTitle.retries,
-      className: "statements-table__col-retries",
+      className: cx("statements-table__col-retries"),
       cell: retryBar,
       sort: (stmt) => (longToInt(stmt.stats.count) - longToInt(stmt.stats.first_attempt_count)),
     },
     {
       title: StatementTableTitle.executionCount,
-      className: "statements-table__col-count",
+      className: cx("statements-table__col-count"),
       cell: countBar,
       sort: (stmt) => FixLong(stmt.stats.count).toInt(),
     },
     {
       title: StatementTableTitle.rowsAffected,
-      className: "statements-table__col-rows",
+      className: cx("statements-table__col-rows"),
       cell: rowsBar,
       sort: (stmt) => stmt.stats.num_rows.mean,
     },
     {
       title: StatementTableTitle.latency,
-      className: "statements-table__col-latency",
+      className: cx("statements-table__col-latency"),
       cell: latencyBar,
       sort: (stmt) => stmt.stats.service_lat.mean,
     },

--- a/pkg/ui/src/views/statements/statementsTableContent.module.styl
+++ b/pkg/ui/src/views/statements/statementsTableContent.module.styl
@@ -1,0 +1,46 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@require '~styl/base/palette.styl'
+@require '~src/components/core/index'
+
+.cl-table-link__description
+  font-size $font-size--small
+  line-height 22px
+  color $colors--neutral-1
+  white-space pre-wrap
+  margin-bottom 0
+
+.cl-table-link__statement-tooltip--fixed-width
+  max-width max-content
+  :global(.ant-tooltip-content)
+    max-width 500px
+
+.tooltip__table--title
+  font-family $font-family--base
+  font-weight 600
+  font-size $font-size--small
+  line-height $line-height--small
+  letter-spacing 0.3px
+  color $colors--neutral-0
+  a
+    color $colors--neutral-0
+    text-decoration underline
+    &:hover
+      opacity 0.7
+      color $colors--neutral-0
+  code
+    font-family $font-family--monospace
+    line-height $line-height--medium
+    color $colors--neutral-8
+    background $colors--neutral-4
+    border-radius 3px
+    padding 2px 5px
+

--- a/pkg/ui/src/views/statements/statementsTableContent.tsx
+++ b/pkg/ui/src/views/statements/statementsTableContent.tsx
@@ -10,6 +10,7 @@
 
 import React from "react";
 import { Link } from "react-router-dom";
+import classNames from "classnames/bind";
 import { Anchor, Tooltip } from "src/components";
 import { statementDiagnostics, statementsRetries, statementsSql, statementsTimeInterval, transactionalPipelining } from "src/util/docs";
 import getHighlightedText from "src/util/highlightedText";
@@ -17,15 +18,18 @@ import { summarize } from "src/util/sql/summarize";
 import { ActivateDiagnosticsModalRef } from "./diagnostics/activateDiagnosticsModal";
 import { DiagnosticStatusBadge } from "./diagnostics/diagnosticStatusBadge";
 import { shortStatement } from "./statementsTable";
+import styles from "./statementsTableContent.module.styl";
 
 export type NodeNames = { [nodeId: string]: string };
+
+const cx = classNames.bind(styles);
 
 export const StatementTableTitle = {
   statements: (
     <Tooltip
       placement="bottom"
       title={
-        <div className="tooltip__table--title">
+        <div className={cx("tooltip__table--title")}>
           <p>
             {"SQL statement "}
             <Anchor
@@ -48,7 +52,7 @@ export const StatementTableTitle = {
     <Tooltip
       placement="bottom"
       title={
-        <div className="tooltip__table--title">
+        <div className={cx("tooltip__table--title")}>
           <p>
             {"Type of transaction (implicit or explicit). Explicit transactions refer to statements that are wrapped by "}
             <code>BEGIN</code>
@@ -76,7 +80,7 @@ export const StatementTableTitle = {
     <Tooltip
       placement="bottom"
       title={
-        <div className="tooltip__table--title">
+        <div className={cx("tooltip__table--title")}>
           <p>
             {"Option to activate "}
             <Anchor
@@ -98,7 +102,7 @@ export const StatementTableTitle = {
     <Tooltip
       placement="bottom"
       title={
-        <div className="tooltip__table--title">
+        <div className={cx("tooltip__table--title")}>
           <p>
             {"Cumulative number of "}
             <Anchor
@@ -119,7 +123,7 @@ export const StatementTableTitle = {
     <Tooltip
       placement="bottom"
       title={
-        <div className="tooltip__table--title">
+        <div className={cx("tooltip__table--title")}>
           <p>
             {"Cumulative number of executions of statements with this fingerprint within the last hour or specified "}
             <Anchor
@@ -149,7 +153,7 @@ export const StatementTableTitle = {
     <Tooltip
       placement="bottom"
       title={
-        <div className="tooltip__table--title">
+        <div className={cx("tooltip__table--title")}>
           <p>
             {"Average number of rows returned while executing statements with this fingerprint within the last hour or specified "}
             <Anchor
@@ -172,7 +176,7 @@ export const StatementTableTitle = {
     <Tooltip
       placement="bottom"
       title={
-        <div className="tooltip__table--title">
+        <div className={cx("tooltip__table--title")}>
           <p>
             Average service latency of statements with this fingerprint within the last hour or specified time interval.
           </p>
@@ -216,13 +220,13 @@ export const StatementLink = (props: { statement: string, app: string, implicitT
   const base = props.app && props.app.length > 0 ? `/statements/${props.app}/${props.implicitTxn}` : `/statement/${props.implicitTxn}`;
   return (
     <Link to={ `${base}/${encodeURIComponent(props.statement)}` }>
-      <div className="cl-table-link__tooltip">
+      <div>
         <Tooltip
           placement="bottom"
-          title={<pre className="cl-table-link__description">
+          title={<pre className={cx("cl-table-link__description")}>
             { getHighlightedText(props.statement, props.search) }
           </pre>}
-          overlayClassName="cl-table-link__statement-tooltip--fixed-width"
+          overlayClassName={cx("cl-table-link__statement-tooltip--fixed-width")}
         >
           <div className="cl-table-link__tooltip-hover-area">
             { getHighlightedText(shortStatement(summary, props.statement), props.search, true) }

--- a/pkg/ui/styl/base/typography.styl
+++ b/pkg/ui/styl/base/typography.styl
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-@require 'utils/fonts.styl'
 @require "~src/components/core/index.styl"
 
 // Using the same strategy as sassline: establish the root size (rems) as 1/2
@@ -34,16 +33,3 @@ h2.base-heading
 
 code
   font-family $font-family--monospace
-
-font-face('Lato-Light')
-font-face('Lato-Bold')
-font-face('Lato-Regular')
-font-face('Lato-Medium')
-font-face('RobotoMono-Bold')
-font-face('RobotoMono-Regular')
-font-face('RobotoMono-Medium')
-font-face('Inconsolata-Regular')
-font-face('SourceSansPro-Bold')
-font-face('SourceSansPro-Regular')
-font-face('SourceSansPro-SemiBold')
-font-face('SFMono-Semibold')

--- a/pkg/ui/styl/utils/fonts.styl
+++ b/pkg/ui/styl/utils/fonts.styl
@@ -21,3 +21,16 @@ font-face($family, $style='normal')
     font-weight normal
     font-style $style
     text-rendering optimizeLegibility
+
+font-face('Lato-Light')
+font-face('Lato-Bold')
+font-face('Lato-Regular')
+font-face('Lato-Medium')
+font-face('RobotoMono-Bold')
+font-face('RobotoMono-Regular')
+font-face('RobotoMono-Medium')
+font-face('Inconsolata-Regular')
+font-face('SourceSansPro-Bold')
+font-face('SourceSansPro-Regular')
+font-face('SourceSansPro-SemiBold')
+font-face('SFMono-Semibold')


### PR DESCRIPTION
Depends on #47513
Related to #47527

This change refactors components to use CSS modules and
incorporate all required styles without any external
dependencies and prevent styles altering from outside.
It affects several components which tightly
coupled with StatementsTable and couldn't be changed
separately.

Following component are changed:
- HighlightedText
- Drawer
- StatementsTable
- SortableTable

Note, that `StatementsTable#makeCommonColumns` function
is refactored to provide custom styles from parent to
child components via props instead of overriding styles.

Storybook is extended to show some components as independent
units or in context of `StatementTable` component (if it is
only the way components work).

Release note: None