### PR TITLE
release-20.1: vendor: bump pebble to b46a83e31ff105cf3ffa3dcc67c4e9223b6b2f0a

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -463,8 +463,8 @@
   revision = "eb05cc24525fa45bcdbaaeec3e431a82099f9ad4"
 
 [[projects]]
-  branch = "master"
-  digest = "1:2a55164a97ace26d520ad3a5494789627e0511db321c74dd62f0f03eeca91604"
+  branch = "crl-release-20.1"
+  digest = "1:da6aafa8c3148636600ca6d3e0518381bff7314a22d49212040a1ed4d6417206"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -490,7 +490,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "de7fc1b547d5c7f390ae3a8162289f2dc7efab6a"
+  revision = "b46a83e31ff105cf3ffa3dcc67c4e9223b6b2f0a"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -127,7 +127,7 @@ ignored = [
 
 [[constraint]]
   name = "github.com/cockroachdb/pebble"
-  branch = "master"
+  branch = "crl-release-20.1"
 
 # github.com/lib/pq has a newer revision that has notices, which we want
 [[override]]


### PR DESCRIPTION
* bloom: fix hash() to be compatible with RocksDB
* db: add ParseHooks.NewCache

Pin the vendored version of Pebble to Pebble's crl-release-20.1 branch.

Release note (bug fix): Fix an incompatibility between Pebble and
RocksDB bloom filters that could result in keys disappearing or
reappearing when switching storage engines.