### PR TITLE
*: fix bad require.Error() usage

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -3058,7 +3058,7 @@ func TestTxnCoordSenderRetriesAcrossEndTxn(t *testing.T) {
 				return nil
 			})
 
-			require.Error(t, txn.CommitInBatch(ctx, b), "injected")
+			require.Regexp(t, "injected", txn.CommitInBatch(ctx, b))
 			err = kvclientutils.CheckPushResult(
 				ctx, db, *origTxn, kvclientutils.ExpectAborted, tc.txnRecExpectation)
 			require.NoError(t, err)

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -1977,7 +1977,7 @@ func TestConcurrentTxnRequestsProhibited(t *testing.T) {
 		})
 		return g.Wait()
 	})
-	require.Error(t, err, "concurrent txn use detected")
+	require.Regexp(t, "concurrent txn use detected", err)
 }
 
 // TestTxnRequestTxnTimestamp verifies response txn timestamp is

--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -168,7 +168,7 @@ func TestLostUpdate(t *testing.T) {
 		b.Put(key, newVal)
 		err = txn.Run(ctx, b)
 		if firstAttempt {
-			require.Error(t, err, "RETRY_WRITE_TOO_OLD")
+			require.Regexp(t, "RETRY_WRITE_TOO_OLD", err)
 			firstAttempt = false
 			return err
 		}
@@ -671,7 +671,7 @@ func TestTxnLeavesIntentBehindAfterWriteTooOldError(t *testing.T) {
 	intentVal := []byte("test")
 	err = txn.Put(ctx, key, intentVal)
 	require.IsType(t, &roachpb.TransactionRetryWithProtoRefreshError{}, err)
-	require.Error(t, err, "WriteTooOld")
+	require.Regexp(t, "WriteTooOld", err)
 
 	// Check that the intent was left behind.
 	b := kv.Batch{}

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -438,5 +438,5 @@ func TestTimestampCacheErrorAfterLeaseTransfer(t *testing.T) {
 	require.NoError(t, tc.TransferRangeLease(rangeDesc, tc.Target(1)))
 
 	err = txn.Commit(ctx)
-	require.Error(t, err, "TransactionAbortedError(ABORT_REASON_NEW_LEASE_PREVENTS_TXN)")
+	require.Regexp(t, `TransactionAbortedError\(ABORT_REASON_NEW_LEASE_PREVENTS_TXN\)`, err)
 }

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -4301,7 +4301,7 @@ func TestEndTxnWithErrorAndSyncIntentResolution(t *testing.T) {
 	args.Sequence = 2
 
 	_, pErr := tc.SendWrappedWith(h, &args)
-	require.Error(t, pErr.GetDetail(), "TransactionAbortedError(ABORT_REASON_ABORTED_RECORD_FOUND)")
+	require.Regexp(t, `TransactionAbortedError\(ABORT_REASON_ABORTED_RECORD_FOUND\)`, pErr)
 	require.NotNil(t, pErr.GetTxn())
 	require.Equal(t, txn.ID, pErr.GetTxn().ID)
 }
@@ -4429,8 +4429,9 @@ func TestRPCRetryProtectionInTxn(t *testing.T) {
 		if pErr == nil {
 			t.Fatalf("expected error, got nil")
 		}
-		require.Error(t, pErr.GetDetail(),
-			"TransactionAbortedError(ABORT_REASON_ALREADY_COMMITTED_OR_ROLLED_BACK_POSSIBLE_REPLAY)")
+		require.Regexp(t,
+			`TransactionAbortedError\(ABORT_REASON_ALREADY_COMMITTED_OR_ROLLED_BACK_POSSIBLE_REPLAY\)`,
+			pErr)
 	})
 }
 

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -503,6 +503,6 @@ func TestAnchoringErrorNoTrigger(t *testing.T) {
 			}),
 		clock)
 	txn := NewTxn(ctx, db, 0 /* gatewayNodeID */)
-	require.Error(t, txn.SetSystemConfigTrigger(), "unimplemented")
+	require.EqualError(t, txn.SetSystemConfigTrigger(), "unimplemented")
 	require.False(t, txn.systemConfigTrigger)
 }

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -344,7 +344,7 @@ func TestOutboxInbox(t *testing.T) {
 			// If the stream context gets canceled, GRPC should take care of closing
 			// and cleaning up the stream. The Inbox stream handler should have
 			// received the context cancellation and returned.
-			require.Error(t, streamHandlerErr, "context canceled")
+			require.Regexp(t, "context canceled", streamHandlerErr)
 			// The Inbox propagates this cancellation on its host.
 			require.True(t, testutils.IsError(readerErr, "context canceled"), readerErr)
 
@@ -355,7 +355,7 @@ func TestOutboxInbox(t *testing.T) {
 		case readerCtxCancel:
 			// If the reader context gets canceled, the Inbox should have returned
 			// from the stream handler.
-			require.Error(t, streamHandlerErr, "context canceled")
+			require.Regexp(t, "context canceled", streamHandlerErr)
 			// The Inbox should propagate this error upwards.
 			require.True(t, testutils.IsError(readerErr, "context canceled"), readerErr)
 

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -2081,7 +2081,7 @@ func TestLeaseAcquisitionByNameDoesntBlock(t *testing.T) {
 
 	require.NoError(t, <-schemaCh)
 	_, err = db.Exec("SELECT * from t.test")
-	require.Error(t, err, `pq: relation "t.test" does not exist`)
+	require.Regexp(t, `pq: relation "t\.test" does not exist`, err)
 	close(schemaUnblock)
 
 	// Wait for the schema change to finish.

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -612,7 +612,7 @@ BEGIN;
 
 	// Continue the txn in a new request, which is not retriable.
 	_, err = sqlDB.Exec("INSERT INTO t.public.test(k, v, t) VALUES (4, 'hooly', cluster_logical_timestamp())")
-	require.Error(t, err, "RETRY_REASON_UNKNOWN - injected err")
+	require.Regexp(t, "RETRY_REASON_UNKNOWN - injected err", err)
 }
 
 // Test that aborted txn are only retried once.


### PR DESCRIPTION
We had a bunch of callsites that misunderstood the string argument of
require.Error(t, err, msg), thinking that it's a substring to be
searched in the error. It is not; it's a message to display when err is
nil. A lot of the callsites were mine.
Switched to require.Regexp() and require.EqualError().

Release note: None