### PR TITLE
opt: index constraints generation improvements

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -1313,7 +1313,6 @@ render           ·                   ·
       ├── scan   ·                   ·
       │          table               abcdef@primary
       │          spans               /1/2/6/9-
-      │          filter              (((a, b) > (1, 2)) OR (((a = 1) AND (b = 2)) AND (c < 6))) OR ((((a = 1) AND (b = 2)) AND (c = 6)) AND (d > 8))
       └── scan   ·                   ·
 ·                table               abg@primary
 ·                spans               FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1351,7 +1351,6 @@ scan  ·            ·
 statement ok
 SET CLUSTER SETTING sql.parallel_scans.enabled = true
 
-# TODO(radu): fix this testcase after #31614 is resolved. There should be no filter left.
 query TTT
 EXPLAIN SELECT * FROM b WHERE (a = 10 AND b = 10) OR (a = 20 AND b = 20)
 ----
@@ -1361,7 +1360,6 @@ scan  ·            ·
 ·     table        b@primary
 ·     spans        /10/10-/10/10/# /20/20-/20/20/#
 ·     parallel     ·
-·     filter       ((a = 10) AND (b = 10)) OR ((a = 20) AND (b = 20))
 
 # This one isn't parallelizable because it's not a point lookup - only part of
 # the primary key is specified.
@@ -1450,7 +1448,6 @@ render     ·            ·
  └── scan  ·            ·
 ·          table        b@b_c_d_key
 ·          spans        /NULL/1-/NULL/2 /10/10-/10/11
-·          filter       ((c = 10) AND (d = 10)) OR ((c IS NULL) AND (d < 2))
 
 statement ok
 DROP INDEX b_b_idx

--- a/pkg/sql/opt/idxconstraint/testdata/misc
+++ b/pkg/sql/opt/idxconstraint/testdata/misc
@@ -144,7 +144,6 @@ index-constraints vars=(int, int, int) index=(@1, @2, @3)
 [/2/4/5 - /2/4/5]
 [/2/6/7 - /2/6/7]
 [/3 - /3]
-Remaining filter: ((@1 = 1) OR ((@1 = 2) AND ((@2, @3) IN ((4, 5), (6, 7))))) OR (@1 = 3)
 
 # Tests with inner OR.
 
@@ -158,7 +157,6 @@ index-constraints vars=(int, int, int) index=(@1, @2, @3)
 ----
 [/1/2 - /1/2]
 [/1/3/4 - /1/3/4]
-Remaining filter: (@2 = 2) OR ((@2 = 3) AND (@3 = 4))
 
 index-constraints vars=(int, int) index=(@1, @2)
 @1 >= 1 AND (@2 = 2 OR @2 = 3)
@@ -191,7 +189,6 @@ index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4) nonormalize
 @1 = 1 AND @2 = 2 AND @3 = 3 AND @4 IN (4,5,6)
 ----
 [/1/2/3/4 - /1/2/3/6]
-Remaining filter: true
 
 index-constraints vars=(int, int) index=(@1, @2)
 (@1 = 1) AND (@2 > 5) AND (@2 < 1)

--- a/pkg/sql/opt/idxconstraint/testdata/multi-column
+++ b/pkg/sql/opt/idxconstraint/testdata/multi-column
@@ -111,6 +111,20 @@ index-constraints vars=(int, int) index=(@1, @2)
 [/1/3 - /1]
 
 index-constraints vars=(int, int) index=(@1, @2)
+(@1 = 0 AND @2 = 0) OR (@1 = 10 AND @2 = 10)
+----
+[/0/0 - /0/0]
+[/10/10 - /10/10]
+
+# Note: columns 2 and 3 are not null so that (@2, @3) <= (15, 25) generates a
+# tight span.
+index-constraints vars=(int, int, int) index=(@1, @2 not null, @3 not null)
+(@1 = 1) OR (@1 = 2 AND (@2, @3) >= (10, 20) AND (@2, @3) <= (15, 25))
+----
+[/1 - /1]
+[/2/10/20 - /2/15/25]
+
+index-constraints vars=(int, int) index=(@1, @2)
 @1 >= 1 AND @1 <= 5 AND @2 != 2
 ----
 (/1/NULL - /5]

--- a/pkg/sql/opt/idxconstraint/testdata/strings
+++ b/pkg/sql/opt/idxconstraint/testdata/strings
@@ -87,4 +87,3 @@ index-constraints vars=(string, string) index=(@1, @2)
 ----
 [/'eu' - /'us')
 [/'us'/'cali' - /'us'/'cali']
-Remaining filter: (((@1 = 'us') AND (@2 = 'cali')) OR (@1 = 'eu')) OR ((@1 > 'eu') AND (@1 < 'us'))


### PR DESCRIPTION
This change makes the following improvements to the index constraints
code:
 - Or is now explicitly treated as a binary op
 - And is no longer treated as a non-binary op; instead we "unnest"
   them and  collect all the conjunctions.
 - we do a better job of detecting tightness of conjunctions

Fixes #31614.

Release note (performance improvement): improved execution plans by
removing unnecessary remaining filters in some cases where the filters
are reflected by an index constraint.