### PR TITLE
internal/sqlsmith: clean up dependencies

### DIFF
--- a/pkg/internal/sqlsmith/bulkio.go
+++ b/pkg/internal/sqlsmith/bulkio.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"time"
 
-	_ "github.com/cockroachdb/cockroach/pkg/ccl" // ccl init hooks to enable Bulk IO
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"

--- a/pkg/internal/sqlsmith/main_test.go
+++ b/pkg/internal/sqlsmith/main_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"testing"
 
+	_ "github.com/cockroachdb/cockroach/pkg/ccl" // ccl init hooks to enable Bulk IO
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"


### PR DESCRIPTION
This commit moves `ccl` hook in `internal/sqlsmith` package for
a regular file into a `_test` file. This change, for example, reduces
the size of `smithcmp` binary from 180MB to 59 MB.

Release note: None