### PR TITLE
sql: add rule to push down agg filter into input of scalar groupby

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -267,31 +267,27 @@ render               ·            ·            (y, z, x)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (max(y)) max(x) FROM xyz
 ----
-·               distributed  false        ·       ·
-·               vectorized   true         ·       ·
-group           ·            ·            (max)   ·
- │              aggregate 0  max(x)       ·       ·
- │              scalar       ·            ·       ·
- └── render     ·            ·            (x)     ·
-      │         render 0     x            ·       ·
-      └── scan  ·            ·            (x, y)  ·
-·               table        xyz@primary  ·       ·
-·               spans        FULL SCAN    ·       ·
+·          distributed  false        ·      ·
+·          vectorized   true         ·      ·
+group      ·            ·            (max)  ·
+ │         aggregate 0  max(x)       ·      ·
+ │         scalar       ·            ·      ·
+ └── scan  ·            ·            (x)    ·
+·          table        xyz@primary  ·      ·
+·          spans        FULL SCAN    ·      ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(min(a), max(b), min(c)) max(a) FROM abc
 ----
-·                  distributed  false            ·          ·
-·                  vectorized   true             ·          ·
-group              ·            ·                (max)      ·
- │                 aggregate 0  any_not_null(a)  ·          ·
- │                 scalar       ·                ·          ·
- └── render        ·            ·                (a)        ·
-      │            render 0     a                ·          ·
-      └── revscan  ·            ·                (a, b, c)  ·
-·                  table        abc@primary      ·          ·
-·                  spans        LIMITED SCAN     ·          ·
-·                  limit        1                ·          ·
+·             distributed  false            ·      ·
+·             vectorized   true             ·      ·
+group         ·            ·                (max)  ·
+ │            aggregate 0  any_not_null(a)  ·      ·
+ │            scalar       ·                ·      ·
+ └── revscan  ·            ·                (a)    ·
+·             table        abc@primary      ·      ·
+·             spans        LIMITED SCAN     ·      ·
+·             limit        1                ·      ·
 
 #################
 # With GROUP BY #

--- a/pkg/sql/opt/norm/rules/groupby.opt
+++ b/pkg/sql/opt/norm/rules/groupby.opt
@@ -223,3 +223,26 @@
     [ (AggregationsItem $agg $aggColID) ]
     $groupingPrivate
 )
+
+# PushAggFilterIntoScalarGroupBy pushes an aggregate function FILTER
+# modifier into the input of the ScalarGroupBy operator. This allows the
+# optimizer to take advantage of an index on the column(s) subject to the
+# FILTER operation. PushAggFilterIntoScalarGroupBy can match any single
+# aggregate function, including those that have multiple input arguments.
+[PushAggFilterIntoScalarGroupBy, Normalize]
+(ScalarGroupBy
+    $input:*
+    $aggregations:[
+        $item:(AggregationsItem
+            (AggFilter $agg:* $condition:*)
+            $aggColID:*
+        )
+    ]
+    $groupingPrivate:*
+)
+=>
+(ScalarGroupBy
+    (Select $input [ (FiltersItem $condition) ])
+    [ (AggregationsItem $agg $aggColID) ]
+    $groupingPrivate
+)

--- a/pkg/sql/opt/norm/rules/prune_cols.opt
+++ b/pkg/sql/opt/norm/rules/prune_cols.opt
@@ -295,7 +295,7 @@
 # PruneGroupByCols discards GroupBy input columns that are never used. Note that
 # UpsertDistinctOn is not included here because its columns are always used.
 [PruneGroupByCols, Normalize]
-(GroupBy | DistinctOn
+(GroupBy | ScalarGroupBy | DistinctOn
     $input:*
     $aggregations:*
     $groupingPrivate:* &

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -66,7 +66,8 @@ CREATE TABLE xyzbs
   z INT NOT NULL,
   b BOOL,
   s TEXT,
-  INDEX (y)
+  INDEX (y),
+  INDEX (s)
 )
 ----
 
@@ -896,21 +897,23 @@ scalar-group-by
  ├── key: ()
  ├── fd: ()-->(4)
  ├── project
- │    ├── columns: column2:2!null column3:3!null s:1!null
+ │    ├── columns: column2:2!null s:1!null
  │    ├── key: (1)
- │    ├── fd: ()-->(2), (1)-->(3)
- │    ├── scan s
+ │    ├── fd: ()-->(2)
+ │    ├── select
  │    │    ├── columns: s:1!null
- │    │    └── key: (1)
+ │    │    ├── key: (1)
+ │    │    ├── scan s
+ │    │    │    ├── columns: s:1!null
+ │    │    │    └── key: (1)
+ │    │    └── filters
+ │    │         └── s:1 > 'a' [outer=(1), constraints=(/1: [/e'a\x00' - ]; tight)]
  │    └── projections
- │         ├── ',' [as=column2:2]
- │         └── s:1 > 'a' [as=column3:3, outer=(1)]
+ │         └── ',' [as=column2:2]
  └── aggregations
-      └── agg-filter [as=string_agg:4, outer=(1-3)]
-           ├── string-agg
-           │    ├── s:1
-           │    └── column2:2
-           └── column3:3
+      └── string-agg [as=string_agg:4, outer=(1,2)]
+           ├── s:1
+           └── column2:2
 
 # GroupBy with key argument.
 norm expect=EliminateAggFilteredDistinctForKeys
@@ -2193,3 +2196,268 @@ scalar-group-by
  └── aggregations
       └── bool-and [as=bool_and:6, outer=(4)]
            └── b:4
+
+# --------------------------------------------------
+# PushAggFilterIntoScalarGroupBy
+# --------------------------------------------------
+
+# SUM case.
+norm expect=PushAggFilterIntoScalarGroupBy
+SELECT sum(y) FILTER (WHERE y < 50) FROM xyzbs
+----
+scalar-group-by
+ ├── columns: sum:7
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7)
+ ├── select
+ │    ├── columns: y:2!null
+ │    ├── scan xyzbs
+ │    │    └── columns: y:2
+ │    └── filters
+ │         └── y:2 < 50 [outer=(2), constraints=(/2: (/NULL - /49]; tight)]
+ └── aggregations
+      └── sum [as=sum:7, outer=(2)]
+           └── y:2
+
+# COUNT case. Expecting an index scan because opt command is used.
+opt expect=PushAggFilterIntoScalarGroupBy
+SELECT count(y) FILTER (WHERE y < 50) FROM xyzbs
+----
+scalar-group-by
+ ├── columns: count:7!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7)
+ ├── scan xyzbs@secondary
+ │    ├── columns: y:2!null
+ │    └── constraint: /2/1: (/NULL - /49]
+ └── aggregations
+      └── count [as=count:7, outer=(2)]
+           └── y:2
+
+# AVG case.
+norm expect=PushAggFilterIntoScalarGroupBy
+SELECT avg(y) FILTER (WHERE y < 50) FROM xyzbs
+----
+scalar-group-by
+ ├── columns: avg:7
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7)
+ ├── select
+ │    ├── columns: y:2!null
+ │    ├── scan xyzbs
+ │    │    └── columns: y:2
+ │    └── filters
+ │         └── y:2 < 50 [outer=(2), constraints=(/2: (/NULL - /49]; tight)]
+ └── aggregations
+      └── avg [as=avg:7, outer=(2)]
+           └── y:2
+
+# MAX case.
+norm expect=PushAggFilterIntoScalarGroupBy
+SELECT max(y) FILTER (WHERE y < 50) FROM xyzbs
+----
+scalar-group-by
+ ├── columns: max:7
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7)
+ ├── select
+ │    ├── columns: y:2!null
+ │    ├── scan xyzbs
+ │    │    └── columns: y:2
+ │    └── filters
+ │         └── y:2 < 50 [outer=(2), constraints=(/2: (/NULL - /49]; tight)]
+ └── aggregations
+      └── max [as=max:7, outer=(2)]
+           └── y:2
+
+# BOOL_AND case.
+norm expect=PushAggFilterIntoScalarGroupBy
+SELECT bool_and(b) FILTER (WHERE b) FROM xyzbs
+----
+scalar-group-by
+ ├── columns: bool_and:6
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(6)
+ ├── select
+ │    ├── columns: b:4!null
+ │    ├── fd: ()-->(4)
+ │    ├── scan xyzbs
+ │    │    └── columns: b:4
+ │    └── filters
+ │         └── b:4 [outer=(4), constraints=(/4: [/true - /true]; tight), fd=()-->(4)]
+ └── aggregations
+      └── bool-and [as=bool_and:6, outer=(4)]
+           └── b:4
+
+# JSON_AGG case.
+norm expect=PushAggFilterIntoScalarGroupBy
+SELECT json_agg(y) FILTER (WHERE y < 50) FROM xyzbs
+----
+scalar-group-by
+ ├── columns: json_agg:7
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7)
+ ├── select
+ │    ├── columns: y:2!null
+ │    ├── scan xyzbs
+ │    │    └── columns: y:2
+ │    └── filters
+ │         └── y:2 < 50 [outer=(2), constraints=(/2: (/NULL - /49]; tight)]
+ └── aggregations
+      └── json-agg [as=json_agg:7, outer=(2)]
+           └── y:2
+
+# CORR case.
+# Multiple input arguments for aggregate function.
+norm expect=PushAggFilterIntoScalarGroupBy
+SELECT corr(y, z) FILTER (WHERE y < 50) FROM xyzbs
+----
+scalar-group-by
+ ├── columns: corr:7
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7)
+ ├── select
+ │    ├── columns: y:2!null z:3!null
+ │    ├── scan xyzbs
+ │    │    └── columns: y:2 z:3!null
+ │    └── filters
+ │         └── y:2 < 50 [outer=(2), constraints=(/2: (/NULL - /49]; tight)]
+ └── aggregations
+      └── corr [as=corr:7, outer=(2,3)]
+           ├── y:2
+           └── z:3
+
+# STRING_AGG case.
+# Multiple input arguments for aggregate function.
+norm expect=PushAggFilterIntoScalarGroupBy
+SELECT string_agg(s, '-') FILTER (WHERE s < 'abc') FROM xyzbs
+----
+scalar-group-by
+ ├── columns: string_agg:8
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(8)
+ ├── project
+ │    ├── columns: column6:6!null s:5!null
+ │    ├── fd: ()-->(6)
+ │    ├── select
+ │    │    ├── columns: s:5!null
+ │    │    ├── scan xyzbs
+ │    │    │    └── columns: s:5
+ │    │    └── filters
+ │    │         └── s:5 < 'abc' [outer=(5), constraints=(/5: (/NULL - /'abc'); tight)]
+ │    └── projections
+ │         └── '-' [as=column6:6]
+ └── aggregations
+      └── string-agg [as=string_agg:8, outer=(5,6)]
+           ├── s:5
+           └── column6:6
+
+# STRING_AGG case with an ORDER BY.
+# Expecting an index scan because opt command is used.
+# Multiple input arguments for aggregate function.
+opt expect=PushAggFilterIntoScalarGroupBy
+SELECT string_agg(s, '-') FILTER (WHERE s < 'abc') FROM (SELECT s FROM xyzbs ORDER BY s)
+----
+scalar-group-by
+ ├── columns: string_agg:8
+ ├── internal-ordering: +5 opt(6)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(8)
+ ├── project
+ │    ├── columns: column6:6!null s:5!null
+ │    ├── fd: ()-->(6)
+ │    ├── ordering: +5 opt(6) [actual: +5]
+ │    ├── scan xyzbs@secondary
+ │    │    ├── columns: s:5!null
+ │    │    ├── constraint: /5/1: (/NULL - /'abc')
+ │    │    └── ordering: +5
+ │    └── projections
+ │         └── '-' [as=column6:6]
+ └── aggregations
+      └── string-agg [as=string_agg:8, outer=(5,6)]
+           ├── s:5
+           └── column6:6
+
+# Case with multiple conditions.
+norm expect=PushAggFilterIntoScalarGroupBy
+SELECT count(y) FILTER (WHERE y < 50 AND z > 5) FROM xyzbs
+----
+scalar-group-by
+ ├── columns: count:7!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7)
+ ├── select
+ │    ├── columns: y:2!null z:3!null
+ │    ├── scan xyzbs
+ │    │    └── columns: y:2 z:3!null
+ │    └── filters
+ │         ├── y:2 < 50 [outer=(2), constraints=(/2: (/NULL - /49]; tight)]
+ │         └── z:3 > 5 [outer=(3), constraints=(/3: [/6 - ]; tight)]
+ └── aggregations
+      └── count [as=count:7, outer=(2)]
+           └── y:2
+
+# No-op case where the same aggregate function is called on different
+# columns.
+norm expect-not=PushAggFilterIntoScalarGroupBy
+SELECT count(y) FILTER (WHERE y < 50), count(z) FILTER (WHERE z > 50) FROM xyzbs
+----
+scalar-group-by
+ ├── columns: count:7!null count:9!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7,9)
+ ├── project
+ │    ├── columns: column6:6 column8:8!null y:2 z:3!null
+ │    ├── fd: (2)-->(6), (3)-->(8)
+ │    ├── scan xyzbs
+ │    │    └── columns: y:2 z:3!null
+ │    └── projections
+ │         ├── y:2 < 50 [as=column6:6, outer=(2)]
+ │         └── z:3 > 50 [as=column8:8, outer=(3)]
+ └── aggregations
+      ├── agg-filter [as=count:7, outer=(2,6)]
+      │    ├── count
+      │    │    └── y:2
+      │    └── column6:6
+      └── agg-filter [as=count:9, outer=(3,8)]
+           ├── count
+           │    └── z:3
+           └── column8:8
+
+# No-op case where different aggregate functions are called on the same
+# column.
+norm expect-not=PushAggFilterIntoScalarGroupBy
+SELECT count(y) FILTER (WHERE y < 50), sum(y) FILTER (WHERE y < 50) FROM xyzbs
+----
+scalar-group-by
+ ├── columns: count:7!null sum:8
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7,8)
+ ├── project
+ │    ├── columns: column6:6 y:2
+ │    ├── fd: (2)-->(6)
+ │    ├── scan xyzbs
+ │    │    └── columns: y:2
+ │    └── projections
+ │         └── y:2 < 50 [as=column6:6, outer=(2)]
+ └── aggregations
+      ├── agg-filter [as=count:7, outer=(2,6)]
+      │    ├── count
+      │    │    └── y:2
+      │    └── column6:6
+      └── agg-filter [as=sum:8, outer=(2,6)]
+           ├── sum
+           │    └── y:2
+           └── column6:6

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -140,9 +140,9 @@ scalar-group-by
  ├── key: ()
  ├── fd: ()-->(6)
  ├── scan abcde
- │    ├── columns: a:1!null b:2 c:3
+ │    ├── columns: a:1!null b:2
  │    ├── key: (1)
- │    ├── fd: (1)-->(2,3), (2,3)~~>(1)
+ │    ├── fd: (1)-->(2)
  │    └── ordering: +1
  └── aggregations
       └── array-agg [as=array_agg:6, outer=(2)]

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -1195,12 +1195,8 @@ scalar-group-by
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(5)
- ├── project
- │    ├── columns: column6:6 i:2
- │    ├── scan a
- │    │    └── columns: i:2 s:4
- │    └── projections
- │         └── s:4 || 'foo' [as=column6:6, outer=(4)]
+ ├── scan a
+ │    └── columns: i:2
  └── aggregations
       └── sum [as=sum:5, outer=(2)]
            └── i:2
@@ -1231,9 +1227,9 @@ scalar-group-by
  ├── key: ()
  ├── fd: ()-->(5,6)
  ├── scan a
- │    ├── columns: k:1!null i:2 f:3
+ │    ├── columns: k:1!null i:2
  │    ├── key: (1)
- │    └── fd: (1)-->(2,3)
+ │    └── fd: (1)-->(2)
  └── aggregations
       ├── min [as=min:5, outer=(2)]
       │    └── i:2
@@ -1333,6 +1329,25 @@ distinct-on
  └── aggregations
       └── first-agg [as=f:3, outer=(3)]
            └── f:3
+
+# Scalar GroupBy case.
+norm expect=PruneGroupByCols
+SELECT icnt FROM (SELECT COUNT(i+1) AS icnt, COUNT(k+1) FROM a);
+----
+scalar-group-by
+ ├── columns: icnt:6!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(6)
+ ├── project
+ │    ├── columns: column5:5
+ │    ├── scan a
+ │    │    └── columns: i:2
+ │    └── projections
+ │         └── i:2 + 1 [as=column5:5, outer=(2)]
+ └── aggregations
+      └── count [as=count:6, outer=(5)]
+           └── column5:5
 
 # --------------------------------------------------
 # PruneValuesCols

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -1330,9 +1330,9 @@ distinct-on
       └── first-agg [as=f:3, outer=(3)]
            └── f:3
 
-# Scalar GroupBy case.
+# ScalarGroupBy case.
 norm expect=PruneGroupByCols
-SELECT icnt FROM (SELECT COUNT(i+1) AS icnt, COUNT(k+1) FROM a);
+SELECT icnt FROM (SELECT count(i+1) AS icnt, count(k+1) FROM a);
 ----
 scalar-group-by
  ├── columns: icnt:6!null

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -429,13 +429,9 @@ select
  │    ├── key: ()
  │    ├── fd: ()-->(5,6)
  │    ├── inner-join (cross)
- │    │    ├── columns: x:1!null y:2 u:3!null v:4!null
- │    │    ├── key: (1,3)
- │    │    ├── fd: (1)-->(2), (3)-->(4)
+ │    │    ├── columns: u:3!null v:4!null
+ │    │    ├── fd: (3)-->(4)
  │    │    ├── scan xy
- │    │    │    ├── columns: x:1!null y:2
- │    │    │    ├── key: (1)
- │    │    │    └── fd: (1)-->(2)
  │    │    ├── select
  │    │    │    ├── columns: u:3!null v:4!null
  │    │    │    ├── key: (3)
@@ -721,22 +717,20 @@ select
  │    ├── key: ()
  │    ├── fd: ()-->(6)
  │    ├── inner-join-apply
- │    │    ├── columns: x:1!null y:2 u:3!null v:4 z:5
+ │    │    ├── columns: x:1!null u:3!null z:5
  │    │    ├── key: (1,3)
- │    │    ├── fd: (1)-->(2), (1,3)-->(4,5)
+ │    │    ├── fd: (1,3)-->(5)
  │    │    ├── scan xy
- │    │    │    ├── columns: x:1!null y:2
- │    │    │    ├── key: (1)
- │    │    │    └── fd: (1)-->(2)
+ │    │    │    ├── columns: x:1!null
+ │    │    │    └── key: (1)
  │    │    ├── left-join-apply
- │    │    │    ├── columns: u:3!null v:4 z:5
+ │    │    │    ├── columns: u:3!null z:5
  │    │    │    ├── outer: (1)
  │    │    │    ├── key: (3)
- │    │    │    ├── fd: (3)-->(4,5)
+ │    │    │    ├── fd: (3)-->(5)
  │    │    │    ├── scan uv
- │    │    │    │    ├── columns: u:3!null v:4
- │    │    │    │    ├── key: (3)
- │    │    │    │    └── fd: (3)-->(4)
+ │    │    │    │    ├── columns: u:3!null
+ │    │    │    │    └── key: (3)
  │    │    │    ├── values
  │    │    │    │    ├── columns: z:5
  │    │    │    │    ├── outer: (1,3)

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -80,20 +80,15 @@ scalar-group-by
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(6)
- ├── project
- │    ├── columns: column5:5!null a:1!null
- │    ├── key: (1)
- │    ├── fd: (1)-->(5)
- │    ├── scan abc
- │    │    ├── columns: a:1!null
- │    │    └── key: (1)
- │    └── projections
- │         └── a:1 > 'a' [as=column5:5, outer=(1)]
+ ├── scan abc
+ │    ├── columns: a:1!null
+ │    ├── constraint: /1: [/e'a\x00' - ]
+ │    ├── limit: 1
+ │    ├── key: ()
+ │    └── fd: ()-->(1)
  └── aggregations
-      └── agg-filter [as=min:6, outer=(1,5)]
-           ├── min
-           │    └── a:1
-           └── column5:5
+      └── const-agg [as=min:6, outer=(1)]
+           └── a:1
 
 opt
 SELECT min(b) FROM abc
@@ -664,20 +659,15 @@ scalar-group-by
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(6)
- ├── project
- │    ├── columns: column5:5!null a:1!null
- │    ├── key: (1)
- │    ├── fd: (1)-->(5)
- │    ├── scan abc
- │    │    ├── columns: a:1!null
- │    │    └── key: (1)
- │    └── projections
- │         └── a:1 > 'a' [as=column5:5, outer=(1)]
+ ├── scan abc,rev
+ │    ├── columns: a:1!null
+ │    ├── constraint: /1: [/e'a\x00' - ]
+ │    ├── limit: 1(rev)
+ │    ├── key: ()
+ │    └── fd: ()-->(1)
  └── aggregations
-      └── agg-filter [as=max:6, outer=(1,5)]
-           ├── max
-           │    └── a:1
-           └── column5:5
+      └── const-agg [as=max:6, outer=(1)]
+           └── a:1
 
 opt
 SELECT max(b) FROM abc


### PR DESCRIPTION
Previously, the optimizer could not take advantage of an index on
a column with a command like the following:

  SELECT COUNT(y) FILTER (WHERE y < 50) FROM xy

To address this, PushAggFilterIntoScalarGroupBy pushes the
filter from the aggregate function and into the input of
the ScalarGroupBy.

Fixes #46903

Release note: None