### PR TITLE
sql: introduce a default transaction priority setting

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1870,6 +1870,10 @@ func (m *sessionDataMutator) SetDefaultIntSize(size int) {
 	m.data.DefaultIntSize = size
 }
 
+func (m *sessionDataMutator) SetDefaultTransactionPriority(val tree.UserPriority) {
+	m.data.DefaultTxnPriority = int(val)
+}
+
 func (m *sessionDataMutator) SetDefaultReadOnly(val bool) {
 	m.data.DefaultReadOnly = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1618,6 +1618,7 @@ datestyle                                 ISO, MDY            NULL      NULL    
 default_int_size                          8                   NULL      NULL        NULL        string
 default_tablespace                        ·                   NULL      NULL        NULL        string
 default_transaction_isolation             serializable        NULL      NULL        NULL        string
+default_transaction_priority              normal              NULL      NULL        NULL        string
 default_transaction_read_only             off                 NULL      NULL        NULL        string
 distsql                                   off                 NULL      NULL        NULL        string
 enable_implicit_select_for_update         on                  NULL      NULL        NULL        string
@@ -1677,6 +1678,7 @@ datestyle                                 ISO, MDY            NULL  user     NUL
 default_int_size                          8                   NULL  user     NULL      8                   8
 default_tablespace                        ·                   NULL  user     NULL      ·                   ·
 default_transaction_isolation             serializable        NULL  user     NULL      default             default
+default_transaction_priority              normal              NULL  user     NULL      normal              normal
 default_transaction_read_only             off                 NULL  user     NULL      off                 off
 distsql                                   off                 NULL  user     NULL      off                 off
 enable_implicit_select_for_update         on                  NULL  user     NULL      on                  on
@@ -1732,6 +1734,7 @@ datestyle                                 NULL    NULL     NULL     NULL        
 default_int_size                          NULL    NULL     NULL     NULL        NULL
 default_tablespace                        NULL    NULL     NULL     NULL        NULL
 default_transaction_isolation             NULL    NULL     NULL     NULL        NULL
+default_transaction_priority              NULL    NULL     NULL     NULL        NULL
 default_transaction_read_only             NULL    NULL     NULL     NULL        NULL
 distsql                                   NULL    NULL     NULL     NULL        NULL
 enable_implicit_select_for_update         NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1247,4 +1247,3 @@ query I
 EXECUTE tview_prep
 ----
 2
-

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -35,6 +35,7 @@ datestyle                                 ISO, MDY
 default_int_size                          8
 default_tablespace                        ·
 default_transaction_isolation             serializable
+default_transaction_priority              normal
 default_transaction_read_only             off
 distsql                                   off
 enable_implicit_select_for_update         on

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -278,7 +278,7 @@ serializable
 statement ok
 COMMIT
 
-# user priority
+# User priority.
 
 statement error there is no transaction in progress
 SET TRANSACTION PRIORITY LOW
@@ -368,6 +368,151 @@ normal
 
 statement ok
 COMMIT
+
+# Transaction priority can be assigned a default value.
+
+query T
+SHOW DEFAULT_TRANSACTION_PRIORITY
+----
+normal
+
+query T
+SHOW TRANSACTION PRIORITY
+----
+normal
+
+statement ok
+SET DEFAULT_TRANSACTION_PRIORITY TO 'LOW'
+
+query T
+SHOW DEFAULT_TRANSACTION_PRIORITY
+----
+low
+
+query T
+SHOW TRANSACTION PRIORITY
+----
+low
+
+statement ok
+SET DEFAULT_TRANSACTION_PRIORITY TO 'NORMAL'
+
+query T
+SHOW DEFAULT_TRANSACTION_PRIORITY
+----
+normal
+
+query T
+SHOW TRANSACTION PRIORITY
+----
+normal
+
+statement ok
+SET DEFAULT_TRANSACTION_PRIORITY TO 'HIGH'
+
+query T
+SHOW DEFAULT_TRANSACTION_PRIORITY
+----
+high
+
+query T
+SHOW TRANSACTION PRIORITY
+----
+high
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION PRIORITY LOW
+
+query T
+SHOW DEFAULT_TRANSACTION_PRIORITY
+----
+low
+
+query T
+SHOW TRANSACTION PRIORITY
+----
+low
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION PRIORITY NORMAL
+
+query T
+SHOW DEFAULT_TRANSACTION_PRIORITY
+----
+normal
+
+query T
+SHOW TRANSACTION PRIORITY
+----
+normal
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION PRIORITY HIGH
+
+query T
+SHOW DEFAULT_TRANSACTION_PRIORITY
+----
+high
+
+query T
+SHOW TRANSACTION PRIORITY
+----
+high
+
+# Without the priority specified, BEGIN should use the default
+
+statement ok
+BEGIN
+
+query T
+SHOW TRANSACTION PRIORITY
+----
+high
+
+statement ok
+COMMIT
+
+# With the priority specified, BEGIN PRIORITY overrides the default
+
+statement ok
+BEGIN TRANSACTION PRIORITY LOW
+
+query T
+SHOW TRANSACTION PRIORITY
+----
+low
+
+statement ok
+COMMIT
+
+# Even after starting a transaction, the default priority can be overridden
+
+statement ok
+BEGIN
+
+query T
+SHOW TRANSACTION PRIORITY
+----
+high
+
+statement ok
+SET TRANSACTION PRIORITY LOW
+
+query T
+SHOW TRANSACTION PRIORITY
+----
+low
+
+statement ok
+COMMIT
+
+statement ok
+RESET DEFAULT_TRANSACTION_PRIORITY
+
+query T
+SHOW DEFAULT_TRANSACTION_PRIORITY
+----
+normal
 
 # We can specify both isolation level and user priority.
 
@@ -464,7 +609,7 @@ serializable
 statement ok
 COMMIT
 
-# setting user priority without isolation level should not change isolation level.
+# Setting user priority without isolation level should not change isolation level
 
 statement ok
 BEGIN TRANSACTION
@@ -488,9 +633,13 @@ serializable
 statement ok
 COMMIT
 
-# restore default
 statement ok
-SET DEFAULT_TRANSACTION_ISOLATION TO 'SERIALIZABLE'
+RESET DEFAULT_TRANSACTION_ISOLATION
+
+query T
+SHOW DEFAULT_TRANSACTION_ISOLATION
+----
+serializable
 
 # SHOW TRANSACTION STATUS
 
@@ -828,7 +977,7 @@ off
 statement ok
 COMMIT
 
-# BEGIN READ WRITE overwrites READ ONLY default
+# BEGIN READ WRITE overrides READ ONLY default
 statement ok
 BEGIN READ WRITE
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -271,6 +271,18 @@ render                        ·            ·
 ·                             source       ·
 
 query TTT
+SELECT * FROM [EXPLAIN SHOW DEFAULT_TRANSACTION_PRIORITY] WHERE field != 'size'
+----
+·                             distributed  false
+·                             vectorized   false
+render                        ·            ·
+ └── filter                   ·            ·
+      │                       filter       variable = 'default_transaction_priority'
+      └── render              ·            ·
+           └── virtual table  ·            ·
+·                             source       ·
+
+query TTT
 SELECT * FROM [EXPLAIN SHOW TRANSACTION ISOLATION LEVEL] WHERE field != 'size'
 ----
 ·                             distributed  false

--- a/pkg/sql/sem/tree/txn.go
+++ b/pkg/sql/sem/tree/txn.go
@@ -12,6 +12,7 @@ package tree
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -67,6 +68,20 @@ func (up UserPriority) String() string {
 		return fmt.Sprintf("UserPriority(%d)", up)
 	}
 	return userPriorityNames[up]
+}
+
+// UserPriorityFromString converts a string into a UserPriority.
+func UserPriorityFromString(val string) (_ UserPriority, ok bool) {
+	switch strings.ToUpper(val) {
+	case "LOW":
+		return Low, true
+	case "NORMAL":
+		return Normal, true
+	case "HIGH":
+		return High, true
+	default:
+		return 0, false
+	}
 }
 
 // ReadWriteMode holds the read write mode for a transaction.

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -27,6 +27,11 @@ type SessionData struct {
 	// Database indicates the "current" database for the purpose of
 	// resolving names. See searchAndQualifyDatabase() for details.
 	Database string
+	// DefaultTxnPriority indicates the default priority of newly created
+	// transactions.
+	// NOTE: we'd prefer to use tree.UserPriority here, but doing so would
+	// introduce a package dependency cycle.
+	DefaultTxnPriority int
 	// DefaultReadOnly indicates the default read-only status of newly created
 	// transactions.
 	DefaultReadOnly bool


### PR DESCRIPTION
Fixes #47626.

This commit introduces support for a new `default_transaction_priority` session variable along with support for the `SET SESSION CHARACTERISTICS AS TRANSACTION PRIORITY <priority>` statement. These can be used to set the priority that SQL transactions use by default, on a per-session basis. The accepted options for the setting are `LOW`, `NORMAL`, and `HIGH`. The default value is `NORMAL`.

One area where this setting is useful is to give priority to one application's traffic over that of another application. Because this is implemented as a session variable, it can be provided as a session parameter in the PG connection URL.

Release note (sql change): A new default_transaction_priority session variable is now supported, which configures the priority that SQL transactions use by default. The accepted options for the setting are `LOW`, `NORMAL`, and `HIGH`.