### PR TITLE
sql: refactors around name resolution for tables

### DIFF
--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -63,7 +63,7 @@ type descriptorResolver struct {
 	objsByName map[sqlbase.ID]map[string]sqlbase.ID
 }
 
-// LookupSchema implements the tree.TableNameTargetResolver interface.
+// LookupSchema implements the tree.ObjectNameTargetResolver interface.
 func (r *descriptorResolver) LookupSchema(
 	_ context.Context, dbName, scName string,
 ) (bool, tree.SchemaMeta, error) {
@@ -76,7 +76,7 @@ func (r *descriptorResolver) LookupSchema(
 	return false, nil, nil
 }
 
-// LookupObject implements the tree.TableNameExistingResolver interface.
+// LookupObject implements the tree.ObjectNameExistingResolver interface.
 func (r *descriptorResolver) LookupObject(
 	_ context.Context, flags tree.ObjectLookupFlags, dbName, scName, obName string,
 ) (bool, tree.NameResolutionResult, error) {
@@ -211,7 +211,7 @@ func descriptorsMatchingTargets(
 
 		switch p := pattern.(type) {
 		case *tree.TableName:
-			found, descI, err := p.ResolveExisting(ctx, resolver, tree.ObjectLookupFlags{}, currentDatabase, searchPath)
+			found, descI, err := tree.ResolveExisting(ctx, p, resolver, tree.ObjectLookupFlags{}, currentDatabase, searchPath)
 			if err != nil {
 				return ret, err
 			}

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -276,8 +276,7 @@ func importPlanHook(
 		var parentID sqlbase.ID
 		if table != nil {
 			// We have a target table, so it might specify a DB in its name.
-			found, descI, err := table.ResolveTarget(ctx,
-				p, p.SessionData().Database, p.SessionData().SearchPath)
+			found, descI, err := tree.ResolveTarget(ctx, table, p, p.SessionData().Database, p.SessionData().SearchPath)
 			if err != nil {
 				return pgerror.Wrap(err, pgcode.UndefinedTable,
 					"resolving target import name")

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -278,7 +278,7 @@ func (r fkResolver) ObjectLookupFlags(required bool, requireMutable bool) tree.O
 	}
 }
 
-// Implements the tree.TableNameExistingResolver interface.
+// Implements the tree.ObjectNameExistingResolver interface.
 func (r fkResolver) LookupObject(
 	ctx context.Context, lookupFlags tree.ObjectLookupFlags, dbName, scName, obName string,
 ) (found bool, objMeta tree.NameResolutionResult, err error) {
@@ -297,7 +297,7 @@ func (r fkResolver) LookupObject(
 	return false, nil, errors.Errorf("referenced table %q not found in tables being imported (%s)", obName, suggestions)
 }
 
-// Implements the tree.TableNameTargetResolver interface.
+// Implements the tree.ObjectNameTargetResolver interface.
 func (r fkResolver) LookupSchema(
 	ctx context.Context, dbName, scName string,
 ) (found bool, scMeta tree.SchemaMeta, err error) {

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -116,7 +116,7 @@ func newCopyMachine(
 	}()
 	c.parsingEvalCtx = c.p.EvalContext()
 
-	tableDesc, err := ResolveExistingObject(ctx, &c.p, &n.Table, tree.ObjectLookupFlagsWithRequired(), ResolveRequireTableDesc)
+	tableDesc, err := ResolveExistingTableObject(ctx, &c.p, &n.Table, tree.ObjectLookupFlagsWithRequired(), ResolveRequireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -75,7 +75,7 @@ func doCreateSequence(
 	context string,
 	dbDesc *DatabaseDescriptor,
 	schemaID sqlbase.ID,
-	name *ObjectName,
+	name *TableName,
 	isTemporary bool,
 	opts tree.SequenceOptions,
 	jobDesc string,

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -628,7 +628,7 @@ func ResolveFK(
 		originColumnIDs[i] = col.ID
 	}
 
-	target, err := ResolveMutableExistingObject(ctx, sc, &d.Table, true /*required*/, ResolveRequireTableDesc)
+	target, err := ResolveMutableExistingTableObject(ctx, sc, &d.Table, true /*required*/, ResolveRequireTableDesc)
 	if err != nil {
 		return err
 	}
@@ -897,7 +897,7 @@ func addInterleave(
 			7854, "unsupported shorthand %s", interleave.DropBehavior)
 	}
 
-	parentTable, err := ResolveExistingObject(
+	parentTable, err := ResolveExistingTableObject(
 		ctx, vt, &interleave.Parent, tree.ObjectLookupFlagsWithRequired(), ResolveRequireTableDesc,
 	)
 	if err != nil {

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -139,8 +139,9 @@ func (oc *optCatalog) ResolveSchema(
 	oc.tn.TableName = ""
 	oc.tn.TableNamePrefix = *name
 
-	found, desc, err := oc.tn.ResolveTarget(
+	found, desc, err := tree.ResolveTarget(
 		ctx,
+		&oc.tn,
 		oc.planner,
 		oc.planner.CurrentDatabase(),
 		oc.planner.CurrentSearchPath(),
@@ -177,7 +178,7 @@ func (oc *optCatalog) ResolveDataSource(
 	}
 
 	oc.tn = *name
-	desc, err := ResolveExistingObject(ctx, oc.planner, &oc.tn, tree.ObjectLookupFlagsWithRequired(), ResolveAnyDescType)
+	desc, err := ResolveExistingTableObject(ctx, oc.planner, &oc.tn, tree.ObjectLookupFlagsWithRequired(), ResolveAnyDescType)
 	if err != nil {
 		return nil, cat.DataSourceName{}, err
 	}

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -89,7 +89,7 @@ type PlanHookState interface {
 	ResolveUncachedDatabaseByName(
 		ctx context.Context, dbName string, required bool) (*UncachedDatabaseDescriptor, error)
 	ResolveMutableTableDescriptor(
-		ctx context.Context, tn *ObjectName, required bool, requiredType ResolveRequiredType,
+		ctx context.Context, tn *TableName, required bool, requiredType ResolveRequiredType,
 	) (table *MutableTableDescriptor, err error)
 	ShowCreate(
 		ctx context.Context, dbPrefix string, allDescs []sqlbase.Descriptor, desc *sqlbase.TableDescriptor, ignoreFKs shouldOmitFKClausesFromCreate,

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -439,7 +439,7 @@ func (p *planner) ParseQualifiedTableName(sql string) (*tree.TableName, error) {
 
 // ResolveTableName implements the tree.EvalDatabase interface.
 func (p *planner) ResolveTableName(ctx context.Context, tn *tree.TableName) (tree.ID, error) {
-	desc, err := ResolveExistingObject(ctx, p, tn, tree.ObjectLookupFlagsWithRequired(), ResolveAnyDescType)
+	desc, err := ResolveExistingTableObject(ctx, p, tn, tree.ObjectLookupFlagsWithRequired(), ResolveAnyDescType)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -35,7 +35,13 @@ import (
 type (
 	// ObjectName is provided for convenience and to make the interface
 	// definitions below more intuitive.
-	ObjectName = tree.TableName
+	ObjectName = tree.ObjectName
+	// TableName is provided for convenience and to make the interface
+	// definitions below more intuitive.
+	TableName = tree.TableName
+	// TypeName is provided for convenience and to make the interface
+	// definitions below more intuitive.
+	TypeName = tree.TypeName
 	// DatabaseDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	DatabaseDescriptor = sqlbase.DatabaseDescriptor
@@ -90,5 +96,5 @@ type SchemaAccessor interface {
 	// descriptor and that of its parent database. If the object is not
 	// found and flags.required is true, an error is returned, otherwise
 	// a nil reference is returned.
-	GetObjectDesc(ctx context.Context, txn *kv.Txn, settings *cluster.Settings, name *ObjectName, flags tree.ObjectLookupFlags) (ObjectDescriptor, error)
+	GetObjectDesc(ctx context.Context, txn *kv.Txn, settings *cluster.Settings, name ObjectName, flags tree.ObjectLookupFlags) (ObjectDescriptor, error)
 }

--- a/pkg/sql/sem/tree/name_resolution_test.go
+++ b/pkg/sql/sem/tree/name_resolution_test.go
@@ -794,9 +794,9 @@ func TestResolveTablePatternOrName(t *testing.T) {
 				case *tree.TableName:
 					if tc.expected {
 						flags := tree.ObjectLookupFlags{}
-						found, obMeta, err = tpv.ResolveExisting(ctx, fakeResolver, flags, tc.curDb, tc.searchPath)
+						found, obMeta, err = tree.ResolveExisting(ctx, tpv, fakeResolver, flags, tc.curDb, tc.searchPath)
 					} else {
-						found, scMeta, err = tpv.ResolveTarget(ctx, fakeResolver, tc.curDb, tc.searchPath)
+						found, scMeta, err = tree.ResolveTarget(ctx, tpv, fakeResolver, tc.curDb, tc.searchPath)
 					}
 					scPrefix = tpv.Schema()
 					ctPrefix = tpv.Catalog()

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -35,7 +35,7 @@ func (p *planner) IncrementSequence(ctx context.Context, seqName *tree.TableName
 		return 0, readOnlyError("nextval()")
 	}
 
-	descriptor, err := ResolveExistingObject(ctx, p, seqName, tree.ObjectLookupFlagsWithRequired(), ResolveRequireSequenceDesc)
+	descriptor, err := ResolveExistingTableObject(ctx, p, seqName, tree.ObjectLookupFlagsWithRequired(), ResolveRequireSequenceDesc)
 	if err != nil {
 		return 0, err
 	}
@@ -93,7 +93,7 @@ func boundsExceededError(descriptor *sqlbase.ImmutableTableDescriptor) error {
 func (p *planner) GetLatestValueInSessionForSequence(
 	ctx context.Context, seqName *tree.TableName,
 ) (int64, error) {
-	descriptor, err := ResolveExistingObject(ctx, p, seqName, tree.ObjectLookupFlagsWithRequired(), ResolveRequireSequenceDesc)
+	descriptor, err := ResolveExistingTableObject(ctx, p, seqName, tree.ObjectLookupFlagsWithRequired(), ResolveRequireSequenceDesc)
 	if err != nil {
 		return 0, err
 	}
@@ -116,7 +116,7 @@ func (p *planner) SetSequenceValue(
 		return readOnlyError("setval()")
 	}
 
-	descriptor, err := ResolveExistingObject(ctx, p, seqName, tree.ObjectLookupFlagsWithRequired(), ResolveRequireSequenceDesc)
+	descriptor, err := ResolveExistingTableObject(ctx, p, seqName, tree.ObjectLookupFlagsWithRequired(), ResolveRequireSequenceDesc)
 	if err != nil {
 		return err
 	}
@@ -431,7 +431,7 @@ func maybeAddSequenceDependencies(
 			}
 		} else {
 			// This is only executed via IMPORT which uses its own resolver.
-			seqDesc, err = ResolveMutableExistingObject(ctx, sc, &tn, true /*required*/, ResolveRequireSequenceDesc)
+			seqDesc, err = ResolveMutableExistingTableObject(ctx, sc, &tn, true /*required*/, ResolveRequireSequenceDesc)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/serial.go
+++ b/pkg/sql/serial.go
@@ -41,13 +41,13 @@ var virtualSequenceOpts = tree.SequenceOptions{
 
 // processSerialInColumnDef analyzes a column definition and determines
 // whether to use a sequence if the requested type is SERIAL-like.
-// If a sequence must be created, it returns an ObjectName to use
+// If a sequence must be created, it returns an TableName to use
 // to create the new sequence and the DatabaseDescriptor of the
 // parent database where it should be created.
 // The ColumnTableDef is not mutated in-place; instead a new one is returned.
 func (p *planner) processSerialInColumnDef(
-	ctx context.Context, d *tree.ColumnTableDef, tableName *ObjectName,
-) (*tree.ColumnTableDef, *DatabaseDescriptor, *ObjectName, tree.SequenceOptions, error) {
+	ctx context.Context, d *tree.ColumnTableDef, tableName *TableName,
+) (*tree.ColumnTableDef, *DatabaseDescriptor, *TableName, tree.SequenceOptions, error) {
 	if !d.IsSerial {
 		// Column is not SERIAL: nothing to do.
 		return d, nil, nil, nil, nil
@@ -156,7 +156,7 @@ func (p *planner) processSerialInColumnDef(
 // This is currently used by bulk I/O import statements which do not
 // (yet?) support customization of the SERIAL behavior.
 func SimplifySerialInColumnDefWithRowID(
-	ctx context.Context, d *tree.ColumnTableDef, tableName *ObjectName,
+	ctx context.Context, d *tree.ColumnTableDef, tableName *TableName,
 ) error {
 	if !d.IsSerial {
 		// Column is not SERIAL: nothing to do.
@@ -182,7 +182,7 @@ func SimplifySerialInColumnDefWithRowID(
 	return nil
 }
 
-func assertValidSerialColumnDef(d *tree.ColumnTableDef, tableName *ObjectName) error {
+func assertValidSerialColumnDef(d *tree.ColumnTableDef, tableName *TableName) error {
 	if d.HasDefaultExpr() {
 		// SERIAL implies a new default expression, we can't have one to
 		// start with. This is the error produced by pg in such case.

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -244,7 +244,7 @@ func (p *planner) resolveTableForZone(
 		p.runWithOptions(resolveFlags{skipCache: true}, func() {
 			flags := tree.ObjectLookupFlagsWithRequired()
 			flags.IncludeOffline = true
-			immutRes, err = ResolveExistingObject(ctx, p, &zs.TableOrIndex.Table, flags, ResolveAnyDescType)
+			immutRes, err = ResolveExistingTableObject(ctx, p, &zs.TableOrIndex.Table, flags, ResolveAnyDescType)
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR includes some refactoring around name resolution
on table names to prepare for type resolution. It introduces
a new type `TypeName` for qualified typenames and a new
interface `ObjectName` that both `TypeName` and `TableName`
implement. It then plumbs this new interface through the
resolution methods in `tree` and `sql` so that a majority
of the resolution logic can be shared across table and
type names. Lastly, it refactors some existing method
names to be clearer that they are accessing `TableDescriptor`
backed data.

Release note: None