### PR TITLE
opt: rework apply-join right-side replanning

### DIFF
--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -67,8 +67,8 @@ type joinPredicate struct {
 	rightEqKey bool
 }
 
-// makePredicate constructs a joinPredicate object for joins. The join condition
-// includes equality between usingColumns.
+// makePredicate constructs a joinPredicate object for joins. The equality
+// columns / on condition must be initialized separately.
 func makePredicate(
 	joinType sqlbase.JoinType, left, right sqlbase.ResultColumns,
 ) (*joinPredicate, error) {

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -15,8 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -79,12 +77,9 @@ func (f *stubFactory) ConstructHashJoin(
 func (f *stubFactory) ConstructApplyJoin(
 	joinType sqlbase.JoinType,
 	left exec.Node,
-	leftBoundColMap opt.ColMap,
-	memo *memo.Memo,
-	rightProps *physical.Required,
-	fakeRight exec.Node,
-	right memo.RelExpr,
+	rightColumns sqlbase.ResultColumns,
 	onCond tree.TypedExpr,
+	planRightSideFn exec.ApplyJoinPlanRightSideFn,
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -40,12 +40,6 @@ type Builder struct {
 	// postqueries accumulates check queries that are run after the main query.
 	postqueries []exec.Node
 
-	// nullifyMissingVarExprs, if greater than 0, tells the builder to replace
-	// VariableExprs that have no bindings with DNull. This is useful for apply
-	// join, which needs to be able to create a plan that has outer columns.
-	// The number indicates the depth of apply joins.
-	nullifyMissingVarExprs int
-
 	// nameGen is used to generate names for the tables that will be created for
 	// each relational subexpression when evalCtx.SessionData.SaveTablesPrefix is
 	// non-empty.
@@ -98,11 +92,6 @@ func New(
 		b.allowInsertFastPath = evalCtx.SessionData.InsertFastPath
 	}
 	return b
-}
-
-// DisableTelemetry prevents the execbuilder from updating telemetry counters.
-func (b *Builder) DisableTelemetry() {
-	b.disableTelemetry = true
 }
 
 // Build constructs the execution node tree and returns its root node if no

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -137,9 +137,6 @@ func (b *Builder) indexedVar(
 ) tree.TypedExpr {
 	idx, ok := ctx.ivarMap.Get(int(colID))
 	if !ok {
-		if b.nullifyMissingVarExprs > 0 {
-			return tree.ReType(tree.DNull, md.ColumnMeta(colID).Type)
-		}
 		panic(errors.AssertionFailedf("cannot map variable %d to an indexed var", log.Safe(colID)))
 	}
 	return ctx.ivh.IndexedVarWithType(idx, md.ColumnMeta(colID).Type)

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -14,8 +14,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -99,32 +97,17 @@ type Factory interface {
 	// the data in leftBoundColMap. The apply join can be any kind of join except
 	// for right outer and full outer.
 	//
-	// leftBoundColMap is a map from opt.ColumnID to opt.ColumnOrdinal that maps
-	// a column bound by the left side of the apply join to the column ordinal
-	// in the left side that contains the binding.
-	//
-	// memo, rightProps, and right are the memo, required physical properties, and
-	// RelExpr of the right side of the join that will be repeatedly modified,
-	// re-planned and executed for every row from the left side. The rightProps
-	// always includes a presentation.
-	//
-	// fakeRight is a pre-planned node that is the right side of the join with
-	// all outer columns replaced by NULL. The physical properties of this node
-	// (its output columns, their order and types) are used to pre-determine the
-	// runtime indexes and types for the right side of the apply join, since all
-	// re-plannings of the right hand side will be pinned to output the exact
-	// same output columns in the same order.
+	// To plan the right-hand side, planRightSideFn must be called for each left
+	// row. This function generates a plan (using the same factory) that produces
+	// the rightColumns (in order).
 	//
 	// onCond is the join condition.
 	ConstructApplyJoin(
 		joinType sqlbase.JoinType,
 		left Node,
-		leftBoundColMap opt.ColMap,
-		memo *memo.Memo,
-		rightProps *physical.Required,
-		fakeRight Node,
-		right memo.RelExpr,
+		rightColumns sqlbase.ResultColumns,
 		onCond tree.TypedExpr,
+		planRightSideFn ApplyJoinPlanRightSideFn,
 	) (Node, error)
 
 	// ConstructHashJoin returns a node that runs a hash-join between the results
@@ -682,14 +665,19 @@ type KVOption struct {
 	Value tree.TypedExpr
 }
 
-// InsertFastPathMaxRows is the maximum number of rows for which we can use the
-// insert fast path.
-const InsertFastPathMaxRows = 10000
-
 // RecursiveCTEIterationFn creates a plan for an iteration of WITH RECURSIVE,
 // given the result of the last iteration (as a Buffer that can be used with
 // ConstructScanBuffer).
 type RecursiveCTEIterationFn func(bufferRef Node) (Plan, error)
+
+// ApplyJoinPlanRightSideFn creates a plan for an iteration of ApplyJoin, given
+// a row produced from the left side. The plan is guaranteed to produce the
+// rightColumns passed to ConstructApplyJoin (in order).
+type ApplyJoinPlanRightSideFn func(leftRow tree.Datums) (Plan, error)
+
+// InsertFastPathMaxRows is the maximum number of rows for which we can use the
+// insert fast path.
+const InsertFastPathMaxRows = 10000
 
 // InsertFastPathFKCheck contains information about a foreign key check to be
 // performed by the insert fast-path (see ConstructInsertFastPath). It


### PR DESCRIPTION
This change moves the high-level logic for planning the right side of ApplyJoin
into the execbuilder. This cleans things up significantly, as we don't have to
leak all sorts of optimizer-specific details into the execution code.

As part of this rework, we also remove the dubious first step of planning the
right-hand side using NULL outer values. This step was really only useful for
getting an output column mapping for the left side. We found that we need to
force the right-hand output using a Presentation so it is consistent in each
iteration anyway; so we can just generate an arbitrary Presentation based on
the OutputColumns.

Release note: None