### PR TITLE
interval/generic: disable checkptr instrumentation of leafToNode

### DIFF
--- a/pkg/kv/kvserver/concurrency/lockstate_interval_btree.go
+++ b/pkg/kv/kvserver/concurrency/lockstate_interval_btree.go
@@ -109,6 +109,7 @@ type node struct {
 	children [maxItems + 1]*node
 }
 
+//go:nocheckptr casts a ptr to a smaller struct to a ptr to a larger struct.
 func leafToNode(ln *leafNode) *node {
 	return (*node)(unsafe.Pointer(ln))
 }

--- a/pkg/kv/kvserver/spanlatch/latch_interval_btree.go
+++ b/pkg/kv/kvserver/spanlatch/latch_interval_btree.go
@@ -109,6 +109,7 @@ type node struct {
 	children [maxItems + 1]*node
 }
 
+//go:nocheckptr casts a ptr to a smaller struct to a ptr to a larger struct.
 func leafToNode(ln *leafNode) *node {
 	return (*node)(unsafe.Pointer(ln))
 }

--- a/pkg/util/interval/generic/example_interval_btree.go
+++ b/pkg/util/interval/generic/example_interval_btree.go
@@ -109,6 +109,7 @@ type node struct {
 	children [maxItems + 1]*node
 }
 
+//go:nocheckptr casts a ptr to a smaller struct to a ptr to a larger struct.
 func leafToNode(ln *leafNode) *node {
 	return (*node)(unsafe.Pointer(ln))
 }

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl.go
@@ -109,6 +109,7 @@ type node struct {
 	children [maxItems + 1]*node
 }
 
+//go:nocheckptr casts a ptr to a smaller struct to a ptr to a larger struct.
 func leafToNode(ln *leafNode) *node {
 	return (*node)(unsafe.Pointer(ln))
 }


### PR DESCRIPTION
Fixes #47684.

Go1.14 introduced and enabled `checkptr` instrumentation by default for race and msan builds. This was triggering a memory violation warning in the btree implementation due to a deliberate type safety violation - we were casting a pointer of a smaller struct to a pointer of a larger struct. The check was firing for a legitimate reason, but one we already knew about, and there was already a mechanism in place to keep this safe (see `leafNode.leaf`).

This unsafe cast is important to keep this btree implementation running fast. It avoids dynamic dispatch on node accesses and allows significantly more of the implementation to be inlined, all while allowing us to optimize the memory footprint of the tree (remember, at any time > 1/2 of the nodes in a balanced tree are leaf nodes). So we don't want to change it. Instead, we simply disable checkptr instrumentation for this specific case using the `//go:nocheckptr` annotation.

Note that I was going to extend the comment, but it's generally not standard form to have comments for annotations extend past a single line. Given that anyone interested in the annotation will already be reading this file and understand the `node`/`leafNode` behavior anyway, I think this is fine.

Also, I looked to see whether we needed to make a similar change in Pebble and was sad to find https://github.com/cockroachdb/pebble/commit/d99331e4d41506aca41f977e451cf4de57208911. The memory will live on, even if the code's time has come to an end.