### PR TITLE
roachtest: deflake acceptance/version-upgrade

### DIFF
--- a/pkg/cmd/roachtest/versionupgrade.go
+++ b/pkg/cmd/roachtest/versionupgrade.go
@@ -112,18 +112,6 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster, predecessorVers
 		waitForUpgradeStep(c.All()),
 		testFeaturesStep,
 
-		// Work around a bug in <= 20.1 that exists at the time of writing. The
-		// bug would sometimes cause the cluster version (predecessorVersion)
-		// to not be persisted on the engines. In that case, moving to the next
-		// version would fail. For details, see:
-		//
-		// https://github.com/cockroachdb/cockroach/pull/47358
-		//
-		// TODO(tbg): remove this when we stop running this test against 20.1
-		// or any earlier release. Or, make sure the <=20.1 fixtures all have
-		// the bumped cluster version on all stores.
-		binaryUpgradeStep(c.All(), predecessorVersion),
-
 		// NB: at this point, cluster and binary version equal predecessorVersion,
 		// and auto-upgrades are on.
 


### PR DESCRIPTION
Remove a workaround that wasn't necessary any more (since I regenerated
the fixtures last week) but which caused flakes of its own because it
was re-uploading the binary for predecessorVersion while processes were
running using that binary (resulting in occasional 'text file busy' on
linux).

Closes #44732.
Touches #47024.

Release note: None