### PR TITLE
sql: make statusServer optional

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -510,7 +510,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		sqlServerOptionalArgs: sqlServerOptionalArgs{
 			rpcContext: rpcContext,
 			distSender: distSender,
-			status: func() (*statusServer, bool) {
+			statusServer: func() (*statusServer, bool) {
 				return sStatus, true
 			},
 			nodeLiveness:           nodeLiveness,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -507,29 +507,31 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	}
 
 	sqlServer, err := newSQLServer(ctx, sqlServerArgs{
-		Config:     &cfg, // NB: s.cfg has a populated AmbientContext.
-		stopper:    stopper,
-		clock:      clock,
-		rpcContext: rpcContext,
-		distSender: distSender,
-		status: func() (*statusServer, bool) {
-			return sStatus, true
+		sqlServerOptionalArgs: sqlServerOptionalArgs{
+			rpcContext: rpcContext,
+			distSender: distSender,
+			status: func() (*statusServer, bool) {
+				return sStatus, true
+			},
+			nodeLiveness:           nodeLiveness,
+			gossip:                 g,
+			nodeDialer:             nodeDialer,
+			grpcServer:             grpcServer.Server,
+			recorder:               recorder,
+			nodeIDContainer:        nodeIDContainer,
+			externalStorage:        externalStorage,
+			externalStorageFromURI: externalStorageFromURI,
+			isMeta1Leaseholder:     node.stores.IsMeta1Leaseholder,
 		},
-		nodeLiveness:             nodeLiveness,
+		Config:                   &cfg, // NB: s.cfg has a populated AmbientContext.
+		stopper:                  stopper,
+		clock:                    clock,
 		protectedtsProvider:      protectedtsProvider,
-		gossip:                   g,
-		nodeDialer:               nodeDialer,
-		grpcServer:               grpcServer.Server,
-		recorder:                 recorder,
 		runtime:                  runtimeSampler,
 		db:                       db,
 		registry:                 registry,
 		circularInternalExecutor: internalExecutor,
-		nodeIDContainer:          nodeIDContainer,
-		externalStorage:          externalStorage,
-		externalStorageFromURI:   externalStorageFromURI,
 		jobRegistry:              jobRegistry,
-		isMeta1Leaseholder:       node.stores.IsMeta1Leaseholder,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/server/server_sql_test.go
+++ b/pkg/server/server_sql_test.go
@@ -126,10 +126,6 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 	clock := hlc.NewClock(hlc.UnixNano, 1)
 	rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
 
-	// Dummy. This thing needs the world and then some.
-	statusServer := &statusServer{
-		sessionRegistry: sql.NewSessionRegistry(),
-	}
 	nl := allErrorsFakeLiveness{}
 
 	ds := ts.DistSender()
@@ -157,14 +153,14 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 	// server to register against (but they'll never get RPCs at the time of
 	// writing): the blob service and DistSQL.
 	dummyRPCServer := rpc.NewServer(rpcContext)
-
+	noStatusServer := func() (*statusServer, bool) { return nil, false }
 	return sqlServerArgs{
 		Config:              &cfg,
 		stopper:             stopper,
 		clock:               clock,
 		rpcContext:          rpcContext,
 		distSender:          ds,
-		status:              statusServer,
+		status:              noStatusServer,
 		nodeLiveness:        nl,
 		protectedtsProvider: protectedTSProvider,
 		gossip:              g,

--- a/pkg/server/server_sql_test.go
+++ b/pkg/server/server_sql_test.go
@@ -12,33 +12,12 @@ package server
 
 import (
 	"context"
-	gosql "database/sql"
-	"net"
-	"net/url"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/gossip"
-	"github.com/cockroachdb/cockroach/pkg/jobs"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/storagepb"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/rpc"
-	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
-	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/server/status"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/metric"
-	"github.com/cockroachdb/cockroach/pkg/util/netutil"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
-	"github.com/cockroachdb/errors"
-	"github.com/stretchr/testify/require"
 )
 
 // TestSQLServer starts up a semi-dedicated SQL server and runs some smoke test
@@ -58,56 +37,8 @@ func TestSQLServer(t *testing.T) {
 	tc := serverutils.StartTestCluster(t, 1, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(ctx)
 
-	n1 := tc.Server(0).(*TestServer)
-	args := testSQLServerArgs(n1)
-
-	const nodeID = 9999
-	args.nodeIDContainer.Set(context.Background(), nodeID)
-
-	s, err := newSQLServer(ctx, args)
-	require.NoError(t, err)
-
-	s.execCfg.DistSQLPlanner.SetNodeDesc(roachpb.NodeDescriptor{
-		NodeID: args.nodeIDContainer.Get(),
-	})
-
-	connManager := netutil.MakeServer(
-		args.stopper,
-		// The SQL server only uses connManager.ServeWith. The both below
-		// are unused.
-		nil, // tlsConfig
-		nil, // handler
-	)
-
-	pgL, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	defer func() { _ = pgL.Close() }()
-
-	const (
-		socketFile = "" // no unix socket
-	)
-	orphanedLeasesTimeThresholdNanos := args.clock.Now().WallTime
-
-	require.NoError(t, s.start(ctx,
-		args.stopper,
-		args.Config.TestingKnobs,
-		connManager,
-		pgL,
-		socketFile,
-		orphanedLeasesTimeThresholdNanos,
-	))
-
-	pgURL, cleanupGoDB := sqlutils.PGUrl(
-		t, pgL.Addr().String(), t.Name() /* prefix */, url.User(security.RootUser))
-
-	db, err := gosql.Open("postgres", pgURL.String())
-	require.NoError(t, err)
-	tc.Stopper().AddCloser(
-		stop.CloserFn(func() {
-			_ = db.Close()
-			cleanupGoDB()
-		}))
-
+	db := serverutils.StartTenant(t, tc.Server(0))
+	defer db.Close()
 	r := sqlutils.MakeSQLRunner(db)
 	r.QueryStr(t, `SELECT 1`)
 	r.Exec(t, `CREATE DATABASE foo`)
@@ -115,90 +46,4 @@ func TestSQLServer(t *testing.T) {
 	r.Exec(t, `INSERT INTO foo.kv VALUES('foo', 'bar')`)
 	t.Log(sqlutils.MatrixToStr(r.QueryStr(t, `SET distsql=off; SELECT * FROM foo.kv`)))
 	t.Log(sqlutils.MatrixToStr(r.QueryStr(t, `SET distsql=auto; SELECT * FROM foo.kv`)))
-}
-
-func testSQLServerArgs(ts *TestServer) sqlServerArgs {
-	st := cluster.MakeTestingClusterSettings()
-	stopper := ts.Stopper()
-
-	cfg := makeTestConfig(st)
-
-	clock := hlc.NewClock(hlc.UnixNano, 1)
-	rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
-
-	nl := allErrorsFakeLiveness{}
-
-	ds := ts.DistSender()
-
-	// Protected timestamps won't be available (at first) in multi-tenant
-	// clusters. TODO(tbg): fail with an error instead of a crash when it's
-	// used. I believe IMPORT INTO is the only use that needs it for correct-
-	// ness, everywhere else we can just not protect the timestamp and continue.
-	var protectedTSProvider protectedts.Provider
-
-	registry := metric.NewRegistry()
-
-	// If we used a dummy gossip, DistSQL and random other things won't work.
-	// Just use the test server's for now.
-	// g := gossip.NewTest(nodeID, nil, nil, stopper, registry, nil)
-	g := ts.Gossip()
-
-	nd := nodedialer.New(rpcContext, gossip.AddressResolver(ts.Gossip()))
-
-	dummyRecorder := &status.MetricsRecorder{}
-
-	var nodeIDContainer base.NodeIDContainer
-
-	// We don't need this for anything except some services that want a gRPC
-	// server to register against (but they'll never get RPCs at the time of
-	// writing): the blob service and DistSQL.
-	dummyRPCServer := rpc.NewServer(rpcContext)
-	noStatusServer := func() (*statusServer, bool) { return nil, false }
-	return sqlServerArgs{
-		sqlServerOptionalArgs: sqlServerOptionalArgs{
-			rpcContext:   rpcContext,
-			distSender:   ds,
-			status:       noStatusServer,
-			nodeLiveness: nl,
-			gossip:       g,
-			nodeDialer:   nd,
-			grpcServer:   dummyRPCServer,
-			recorder:     dummyRecorder,
-			isMeta1Leaseholder: func(timestamp hlc.Timestamp) (bool, error) {
-				return false, errors.New("fake isMeta1Leaseholder")
-			},
-			nodeIDContainer: &nodeIDContainer,
-			externalStorage: func(ctx context.Context, dest roachpb.ExternalStorage) (cloud.ExternalStorage, error) {
-				return nil, errors.New("fake external storage")
-			},
-			externalStorageFromURI: func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
-				return nil, errors.New("fake external uri storage")
-			},
-		},
-		Config:                   &cfg,
-		stopper:                  stopper,
-		clock:                    clock,
-		protectedtsProvider:      protectedTSProvider,
-		runtime:                  &status.RuntimeStatSampler{}, // dummy
-		db:                       ts.DB(),
-		registry:                 registry,
-		circularInternalExecutor: &sql.InternalExecutor{},
-		jobRegistry:              &jobs.Registry{},
-	}
-}
-
-type allErrorsFakeLiveness struct{}
-
-var _ jobs.NodeLiveness = (*allErrorsFakeLiveness)(nil)
-
-func (allErrorsFakeLiveness) Self() (storagepb.Liveness, error) {
-	return storagepb.Liveness{}, errors.New("fake liveness")
-
-}
-func (allErrorsFakeLiveness) GetLivenesses() []storagepb.Liveness {
-	return nil
-}
-
-func (allErrorsFakeLiveness) IsLive(roachpb.NodeID) (bool, error) {
-	return false, errors.New("fake liveness")
 }

--- a/pkg/server/server_sql_test.go
+++ b/pkg/server/server_sql_test.go
@@ -155,33 +155,35 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 	dummyRPCServer := rpc.NewServer(rpcContext)
 	noStatusServer := func() (*statusServer, bool) { return nil, false }
 	return sqlServerArgs{
-		Config:              &cfg,
-		stopper:             stopper,
-		clock:               clock,
-		rpcContext:          rpcContext,
-		distSender:          ds,
-		status:              noStatusServer,
-		nodeLiveness:        nl,
-		protectedtsProvider: protectedTSProvider,
-		gossip:              g,
-		nodeDialer:          nd,
-		grpcServer:          dummyRPCServer,
-		recorder:            dummyRecorder,
-		isMeta1Leaseholder: func(timestamp hlc.Timestamp) (bool, error) {
-			return false, errors.New("fake isMeta1Leaseholder")
+		sqlServerOptionalArgs: sqlServerOptionalArgs{
+			rpcContext:   rpcContext,
+			distSender:   ds,
+			status:       noStatusServer,
+			nodeLiveness: nl,
+			gossip:       g,
+			nodeDialer:   nd,
+			grpcServer:   dummyRPCServer,
+			recorder:     dummyRecorder,
+			isMeta1Leaseholder: func(timestamp hlc.Timestamp) (bool, error) {
+				return false, errors.New("fake isMeta1Leaseholder")
+			},
+			nodeIDContainer: &nodeIDContainer,
+			externalStorage: func(ctx context.Context, dest roachpb.ExternalStorage) (cloud.ExternalStorage, error) {
+				return nil, errors.New("fake external storage")
+			},
+			externalStorageFromURI: func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
+				return nil, errors.New("fake external uri storage")
+			},
 		},
+		Config:                   &cfg,
+		stopper:                  stopper,
+		clock:                    clock,
+		protectedtsProvider:      protectedTSProvider,
 		runtime:                  &status.RuntimeStatSampler{}, // dummy
 		db:                       ts.DB(),
 		registry:                 registry,
 		circularInternalExecutor: &sql.InternalExecutor{},
-		nodeIDContainer:          &nodeIDContainer,
-		externalStorage: func(ctx context.Context, dest roachpb.ExternalStorage) (cloud.ExternalStorage, error) {
-			return nil, errors.New("fake external storage")
-		},
-		externalStorageFromURI: func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
-			return nil, errors.New("fake external uri storage")
-		},
-		jobRegistry: &jobs.Registry{},
+		jobRegistry:              &jobs.Registry{},
 	}
 }
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -13,6 +13,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -26,26 +27,34 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/tscache"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sqlmigrations"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/proto"
@@ -396,6 +405,146 @@ func (ts *TestServer) Start(params base.TestServerArgs) error {
 	ts.Cfg = &ts.Server.cfg
 
 	return ts.Server.Start(context.Background())
+}
+
+type allErrorsFakeLiveness struct{}
+
+var _ jobs.NodeLiveness = (*allErrorsFakeLiveness)(nil)
+
+func (allErrorsFakeLiveness) Self() (storagepb.Liveness, error) {
+	return storagepb.Liveness{}, errors.New("fake liveness")
+
+}
+func (allErrorsFakeLiveness) GetLivenesses() []storagepb.Liveness {
+	return nil
+}
+
+func (allErrorsFakeLiveness) IsLive(roachpb.NodeID) (bool, error) {
+	return false, errors.New("fake liveness")
+}
+
+func testSQLServerArgs(ts *TestServer) sqlServerArgs {
+	st := cluster.MakeTestingClusterSettings()
+	stopper := ts.Stopper()
+
+	cfg := makeTestConfig(st)
+
+	clock := hlc.NewClock(hlc.UnixNano, 1)
+	rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
+
+	nl := allErrorsFakeLiveness{}
+
+	ds := ts.DistSender()
+
+	// Protected timestamps won't be available (at first) in multi-tenant
+	// clusters. TODO(tbg): fail with an error instead of a crash when it's
+	// used. I believe IMPORT INTO is the only use that needs it for correct-
+	// ness, everywhere else we can just not protect the timestamp and continue.
+	var protectedTSProvider protectedts.Provider
+
+	registry := metric.NewRegistry()
+
+	// If we used a dummy gossip, DistSQL and random other things won't work.
+	// Just use the test server's for now.
+	// g := gossip.NewTest(nodeID, nil, nil, stopper, registry, nil)
+	g := ts.Gossip()
+
+	nd := nodedialer.New(rpcContext, gossip.AddressResolver(ts.Gossip()))
+
+	dummyRecorder := &status.MetricsRecorder{}
+
+	var nodeIDContainer base.NodeIDContainer
+
+	// We don't need this for anything except some services that want a gRPC
+	// server to register against (but they'll never get RPCs at the time of
+	// writing): the blob service and DistSQL.
+	dummyRPCServer := rpc.NewServer(rpcContext)
+	noStatusServer := func() (*statusServer, bool) { return nil, false }
+	return sqlServerArgs{
+		sqlServerOptionalArgs: sqlServerOptionalArgs{
+			rpcContext:   rpcContext,
+			distSender:   ds,
+			status:       noStatusServer,
+			nodeLiveness: nl,
+			gossip:       g,
+			nodeDialer:   nd,
+			grpcServer:   dummyRPCServer,
+			recorder:     dummyRecorder,
+			isMeta1Leaseholder: func(timestamp hlc.Timestamp) (bool, error) {
+				return false, errors.New("fake isMeta1Leaseholder")
+			},
+			nodeIDContainer: &nodeIDContainer,
+			externalStorage: func(ctx context.Context, dest roachpb.ExternalStorage) (cloud.ExternalStorage, error) {
+				return nil, errors.New("fake external storage")
+			},
+			externalStorageFromURI: func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
+				return nil, errors.New("fake external uri storage")
+			},
+		},
+		Config:                   &cfg,
+		stopper:                  stopper,
+		clock:                    clock,
+		protectedtsProvider:      protectedTSProvider,
+		runtime:                  &status.RuntimeStatSampler{}, // dummy
+		db:                       ts.DB(),
+		registry:                 registry,
+		circularInternalExecutor: &sql.InternalExecutor{},
+		jobRegistry:              &jobs.Registry{},
+	}
+}
+
+// StartTenant starts a SQL tenant communicating with this TestServer.
+func (ts *TestServer) StartTenant() (addr string, _ error) {
+	ctx := context.Background()
+	args := testSQLServerArgs(ts)
+	const nodeID = 9999
+	args.nodeIDContainer.Set(context.Background(), nodeID)
+	s, err := newSQLServer(ctx, args)
+	if err != nil {
+		return "", err
+	}
+
+	s.execCfg.DistSQLPlanner.SetNodeDesc(roachpb.NodeDescriptor{
+		NodeID: args.nodeIDContainer.Get(),
+	})
+
+	connManager := netutil.MakeServer(
+		args.stopper,
+		// The SQL server only uses connManager.ServeWith. The both below
+		// are unused.
+		nil, // tlsConfig
+		nil, // handler
+	)
+
+	pgL, err := net.Listen("tcp", args.Config.SQLAddr)
+	if err != nil {
+		return "", err
+	}
+	ts.Stopper().RunWorker(ctx, func(ctx context.Context) {
+		<-ts.Stopper().ShouldQuiesce()
+		// NB: we can't do this as a Closer because (*Server).ServeWith is
+		// running in a worker and usually sits on accept(pgL) which unblocks
+		// only when pgL closes. In other words, pgL needs to close when
+		// quiescing starts to allow that worker to shut down.
+		_ = pgL.Close()
+	})
+
+	const (
+		socketFile = "" // no unix socket
+	)
+	orphanedLeasesTimeThresholdNanos := args.clock.Now().WallTime
+
+	if err := s.start(ctx,
+		args.stopper,
+		args.Config.TestingKnobs,
+		connManager,
+		pgL,
+		socketFile,
+		orphanedLeasesTimeThresholdNanos,
+	); err != nil {
+		return "", err
+	}
+	return pgL.Addr().String(), nil
 }
 
 // ExpectedInitialRangeCount returns the expected number of ranges that should

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -464,7 +464,7 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 		sqlServerOptionalArgs: sqlServerOptionalArgs{
 			rpcContext:   rpcContext,
 			distSender:   ds,
-			status:       noStatusServer,
+			statusServer: noStatusServer,
 			nodeLiveness: nl,
 			gossip:       g,
 			nodeDialer:   nd,

--- a/pkg/sql/cancel_queries.go
+++ b/pkg/sql/cancel_queries.go
@@ -44,7 +44,11 @@ func (n *cancelQueriesNode) Next(params runParams) (bool, error) {
 		return true, nil
 	}
 
-	statusServer := params.extendedEvalCtx.StatusServer
+	statusServer, ok := params.extendedEvalCtx.StatusServer()
+	if !ok {
+		return false, pgerror.UnsupportedWithMultiTenancy()
+	}
+
 	queryIDString, ok := tree.AsDString(datum)
 	if !ok {
 		return false, errors.AssertionFailedf("%q: expected *DString, found %T", datum, datum)

--- a/pkg/sql/cancel_sessions.go
+++ b/pkg/sql/cancel_sessions.go
@@ -44,7 +44,10 @@ func (n *cancelSessionsNode) Next(params runParams) (bool, error) {
 		return true, nil
 	}
 
-	statusServer := params.extendedEvalCtx.StatusServer
+	statusServer, ok := params.extendedEvalCtx.StatusServer()
+	if !ok {
+		return false, pgerror.UnsupportedWithMultiTenancy()
+	}
 	sessionIDString, ok := tree.AsDString(datum)
 	if !ok {
 		return false, errors.AssertionFailedf("%q: expected *DString, found %T", datum, datum)

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -910,7 +910,11 @@ var crdbInternalLocalTxnsTable = virtualSchemaTable{
 			return err
 		}
 		req := p.makeSessionsRequest(ctx)
-		response, err := p.extendedEvalCtx.StatusServer.ListLocalSessions(ctx, &req)
+		ss, ok := p.extendedEvalCtx.StatusServer()
+		if !ok {
+			return pgerror.UnsupportedWithMultiTenancy()
+		}
+		response, err := ss.ListLocalSessions(ctx, &req)
 		if err != nil {
 			return err
 		}
@@ -926,7 +930,11 @@ var crdbInternalClusterTxnsTable = virtualSchemaTable{
 			return err
 		}
 		req := p.makeSessionsRequest(ctx)
-		response, err := p.extendedEvalCtx.StatusServer.ListSessions(ctx, &req)
+		ss, ok := p.extendedEvalCtx.StatusServer()
+		if !ok {
+			return pgerror.UnsupportedWithMultiTenancy()
+		}
+		response, err := ss.ListSessions(ctx, &req)
 		if err != nil {
 			return err
 		}
@@ -1028,7 +1036,11 @@ var crdbInternalLocalQueriesTable = virtualSchemaTable{
 	schema:  fmt.Sprintf(queriesSchemaPattern, "node_queries"),
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		req := p.makeSessionsRequest(ctx)
-		response, err := p.extendedEvalCtx.StatusServer.ListLocalSessions(ctx, &req)
+		ss, ok := p.extendedEvalCtx.StatusServer()
+		if !ok {
+			return pgerror.UnsupportedWithMultiTenancy()
+		}
+		response, err := ss.ListLocalSessions(ctx, &req)
 		if err != nil {
 			return err
 		}
@@ -1043,7 +1055,11 @@ var crdbInternalClusterQueriesTable = virtualSchemaTable{
 	schema:  fmt.Sprintf(queriesSchemaPattern, "cluster_queries"),
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		req := p.makeSessionsRequest(ctx)
-		response, err := p.extendedEvalCtx.StatusServer.ListSessions(ctx, &req)
+		ss, ok := p.extendedEvalCtx.StatusServer()
+		if !ok {
+			return pgerror.UnsupportedWithMultiTenancy()
+		}
+		response, err := ss.ListSessions(ctx, &req)
 		if err != nil {
 			return err
 		}
@@ -1147,7 +1163,11 @@ var crdbInternalLocalSessionsTable = virtualSchemaTable{
 	schema:  fmt.Sprintf(sessionsSchemaPattern, "node_sessions"),
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		req := p.makeSessionsRequest(ctx)
-		response, err := p.extendedEvalCtx.StatusServer.ListLocalSessions(ctx, &req)
+		ss, ok := p.extendedEvalCtx.StatusServer()
+		if !ok {
+			return pgerror.UnsupportedWithMultiTenancy()
+		}
+		response, err := ss.ListLocalSessions(ctx, &req)
 		if err != nil {
 			return err
 		}
@@ -1162,7 +1182,11 @@ var crdbInternalClusterSessionsTable = virtualSchemaTable{
 	schema:  fmt.Sprintf(sessionsSchemaPattern, "cluster_sessions"),
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		req := p.makeSessionsRequest(ctx)
-		response, err := p.extendedEvalCtx.StatusServer.ListSessions(ctx, &req)
+		ss, ok := p.extendedEvalCtx.StatusServer()
+		if !ok {
+			return pgerror.UnsupportedWithMultiTenancy()
+		}
+		response, err := ss.ListSessions(ctx, &req)
 		if err != nil {
 			return err
 		}
@@ -3049,8 +3073,11 @@ CREATE TABLE crdb_internal.kv_node_status (
 		if err := p.RequireAdminRole(ctx, "read crdb_internal.kv_node_status"); err != nil {
 			return err
 		}
-
-		response, err := p.ExecCfg().StatusServer.Nodes(ctx, &serverpb.NodesRequest{})
+		ss, ok := p.extendedEvalCtx.StatusServer()
+		if !ok {
+			return pgerror.UnsupportedWithMultiTenancy()
+		}
+		response, err := ss.Nodes(ctx, &serverpb.NodesRequest{})
 		if err != nil {
 			return err
 		}
@@ -3152,8 +3179,11 @@ CREATE TABLE crdb_internal.kv_store_status (
 		if err := p.RequireAdminRole(ctx, "read crdb_internal.kv_store_status"); err != nil {
 			return err
 		}
-
-		response, err := p.ExecCfg().StatusServer.Nodes(ctx, &serverpb.NodesRequest{})
+		ss, ok := p.ExecCfg().StatusServer()
+		if !ok {
+			return pgerror.UnsupportedWithMultiTenancy()
+		}
+		response, err := ss.Nodes(ctx, &serverpb.NodesRequest{})
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -563,7 +563,7 @@ type ExecutorConfig struct {
 	LeaseManager      *LeaseManager
 	Clock             *hlc.Clock
 	DistSQLSrv        *distsql.ServerImpl
-	StatusServer      serverpb.StatusServer
+	StatusServer      func() (serverpb.StatusServer, bool)
 	MetricsRecorder   nodeStatusGenerator
 	SessionRegistry   *SessionRegistry
 	JobRegistry       *jobs.Registry

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -563,20 +563,24 @@ type ExecutorConfig struct {
 	LeaseManager      *LeaseManager
 	Clock             *hlc.Clock
 	DistSQLSrv        *distsql.ServerImpl
-	StatusServer      func() (serverpb.StatusServer, bool)
-	MetricsRecorder   nodeStatusGenerator
-	SessionRegistry   *SessionRegistry
-	JobRegistry       *jobs.Registry
-	VirtualSchemas    *VirtualSchemaHolder
-	DistSQLPlanner    *DistSQLPlanner
-	TableStatsCache   *stats.TableStatisticsCache
-	StatsRefresher    *stats.Refresher
-	ExecLogger        *log.SecondaryLogger
-	AuditLogger       *log.SecondaryLogger
-	SlowQueryLogger   *log.SecondaryLogger
-	AuthLogger        *log.SecondaryLogger
-	InternalExecutor  *InternalExecutor
-	QueryCache        *querycache.C
+	// StatusServer gives access to the Status service.
+	//
+	// In a SQL tenant server, this is not available (returning false) and
+	// pgerror.UnsupportedWithMultiTenancy should be returned.
+	StatusServer     func() (serverpb.StatusServer, bool)
+	MetricsRecorder  nodeStatusGenerator
+	SessionRegistry  *SessionRegistry
+	JobRegistry      *jobs.Registry
+	VirtualSchemas   *VirtualSchemaHolder
+	DistSQLPlanner   *DistSQLPlanner
+	TableStatsCache  *stats.TableStatisticsCache
+	StatsRefresher   *stats.Refresher
+	ExecLogger       *log.SecondaryLogger
+	AuditLogger      *log.SecondaryLogger
+	SlowQueryLogger  *log.SecondaryLogger
+	AuthLogger       *log.SecondaryLogger
+	InternalExecutor *InternalExecutor
+	QueryCache       *querycache.C
 
 	TestingKnobs              ExecutorTestingKnobs
 	PGWireTestingKnobs        *PGWireTestingKnobs

--- a/pkg/sql/pgwire/pgerror/errors.go
+++ b/pkg/sql/pgwire/pgerror/errors.go
@@ -128,6 +128,14 @@ func WrongNumberOfPreparedStatements(n int) error {
 	return err
 }
 
+// UnsupportedWithMultiTenancy returns an error suitable for returning when an
+// operation could not be carried out due to the SQL server running in
+// multi-tenancy mode. In that mode, Gossip and other components of the KV layer
+// are not available.
+func UnsupportedWithMultiTenancy() error {
+	return New(pgcode.Internal, "operation is unsupported in multi-tenancy mode")
+}
+
 var _ fmt.Formatter = &Error{}
 
 // Format implements the fmt.Formatter interface.

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -52,7 +52,7 @@ type extendedEvalContext struct {
 	Tracing *SessionTracing
 
 	// StatusServer gives access to the Status service. Used to cancel queries.
-	StatusServer serverpb.StatusServer
+	StatusServer func() (serverpb.StatusServer, bool)
 
 	// MemMetrics represent the group of metrics to which execution should
 	// contribute.
@@ -332,10 +332,7 @@ func internalExtendedEvalCtx(
 	execCfg *ExecutorConfig,
 	plannerMon *mon.BytesMonitor,
 ) extendedEvalContext {
-	var evalContextTestingKnobs tree.EvalContextTestingKnobs
-	var statusServer serverpb.StatusServer
-	evalContextTestingKnobs = execCfg.EvalContextTestingKnobs
-	statusServer = execCfg.StatusServer
+	evalContextTestingKnobs := execCfg.EvalContextTestingKnobs
 
 	return extendedEvalContext{
 		EvalContext: tree.EvalContext{
@@ -354,7 +351,7 @@ func internalExtendedEvalCtx(
 		SessionMutator:  dataMutator,
 		VirtualSchemas:  execCfg.VirtualSchemas,
 		Tracing:         &SessionTracing{},
-		StatusServer:    statusServer,
+		StatusServer:    execCfg.StatusServer,
 		Tables:          tables,
 		ExecCfg:         execCfg,
 		schemaAccessors: newSchemaInterface(tables, execCfg.VirtualSchemas),

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -51,7 +51,10 @@ type extendedEvalContext struct {
 	// tracing state should be done through the sessionDataMutator.
 	Tracing *SessionTracing
 
-	// StatusServer gives access to the Status service. Used to cancel queries.
+	// StatusServer gives access to the Status service.
+	//
+	// In a SQL tenant server, this is not available (returning false) and
+	// pgerror.UnsupportedWithMultiTenancy should be returned.
 	StatusServer func() (serverpb.StatusServer, bool)
 
 	// MemMetrics represent the group of metrics to which execution should

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -565,10 +565,15 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 				return err
 			}
 
+			ss, ok := params.extendedEvalCtx.StatusServer()
+			if !ok {
+				return pgerror.UnsupportedWithMultiTenancy()
+			}
+
 			// Validate that the result makes sense.
 			if err := validateZoneAttrsAndLocalities(
 				params.ctx,
-				params.extendedEvalCtx.StatusServer.Nodes,
+				ss.Nodes,
 				&newZone,
 			); err != nil {
 				return err

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -364,10 +364,14 @@ type TemporaryObjectCleaner struct {
 	settings                         *cluster.Settings
 	db                               *kv.DB
 	makeSessionBoundInternalExecutor sqlutil.SessionBoundInternalExecutorFactory
-	statusServer                     func() (serverpb.StatusServer, bool)
-	isMeta1LeaseholderFunc           isMeta1LeaseholderFunc
-	testingKnobs                     ExecutorTestingKnobs
-	metrics                          *temporaryObjectCleanerMetrics
+	// statusServer gives access to the Status service.
+	//
+	// In a SQL tenant server, this is not available (returning false) and
+	// pgerror.UnsupportedWithMultiTenancy should be returned.
+	statusServer           func() (serverpb.StatusServer, bool)
+	isMeta1LeaseholderFunc isMeta1LeaseholderFunc
+	testingKnobs           ExecutorTestingKnobs
+	metrics                *temporaryObjectCleanerMetrics
 }
 
 // temporaryObjectCleanerMetrics are the metrics for TemporaryObjectCleaner


### PR DESCRIPTION
SQL depends on the status server to list sessions and nodes. A
pure SQL server (used for multi-tenancy) will not have access to
these.

Wrap the status server in a `(serverpb.StatusServer, bool)` wrapper
that indicates when the status server is not present, and return the
newly introduced `pgerr.UnsupportedWithMultiTenancy()` in such cases.

Over time, we'll have to take stock of the functionality lost that
way and we may have to restore some of it, however at the moment
the focus is on discovering which functionality is affected, and
turning their resolution into work items which can be handed to
the SQL team.

The intention is that looking at the callers of the above error
constructor provides an overview to that end.

Release note: None