### PR TITLE
server: fix an invalid error unwrap

### DIFF
--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -15,7 +15,7 @@ import (
 	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/rpc"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -98,6 +98,6 @@ func (s *grpcServer) waitingForInitError(methodName string) error {
 // IsWaitingForInit checks whether the provided error is because the node is
 // still waiting for initialization.
 func IsWaitingForInit(err error) bool {
-	s, ok := grpcstatus.FromError(errors.Cause(err))
+	s, ok := grpcstatus.FromError(errors.UnwrapAll(err))
 	return ok && s.Code() == codes.Unavailable && strings.Contains(err.Error(), "node waiting for init")
 }


### PR DESCRIPTION
Found via #47691

The call to `errors.Cause()` can return `nil` if the error was not
wrapped. It's wrapped always (by accident) in the 20.1 tree, but
that's not guaranteed/enforced.

Release note: None