### PR TITLE
release-20.1: pgwire: ensure the conn is always closed even in tests

### DIFF
--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -212,6 +212,8 @@ func (c *conn) serveImpl(
 	authOpt authOptions,
 	stopper *stop.Stopper,
 ) {
+	defer func() { _ = c.conn.Close() }()
+
 	ctx = logtags.AddTag(ctx, "user", c.sessionArgs.User)
 
 	inTestWithoutSQL := sqlServer == nil
@@ -220,7 +222,6 @@ func (c *conn) serveImpl(
 		authLogger = sqlServer.GetExecutorConfig().AuthLogger
 		sessionStart := timeutil.Now()
 		defer func() {
-			_ = c.conn.Close()
 			if c.authLogEnabled() {
 				authLogger.Logf(ctx, "session terminated; duration: %s", timeutil.Now().Sub(sessionStart))
 			}


### PR DESCRIPTION
Backport 1/1 commits from #47700.

/cc @cockroachdb/release

---

Fixes #47464
