### PR TITLE
colserde: remove batch reset logic from ArrowBatchConverter

### DIFF
--- a/pkg/col/colserde/file_test.go
+++ b/pkg/col/colserde/file_test.go
@@ -46,7 +46,7 @@ func TestFileRoundtrip(t *testing.T) {
 		// buffer.
 		for i := 0; i < 2; i++ {
 			func() {
-				roundtrip := coldata.NewMemBatchWithSize(nil, 0)
+				roundtrip := coldata.NewMemBatchWithSize(typs, b.Length())
 				d, err := colserde.NewFileDeserializerFromBytes(typs, buf.Bytes())
 				require.NoError(t, err)
 				defer func() { require.NoError(t, d.Close()) }()
@@ -82,7 +82,7 @@ func TestFileRoundtrip(t *testing.T) {
 		// file.
 		for i := 0; i < 2; i++ {
 			func() {
-				roundtrip := coldata.NewMemBatchWithSize(nil, 0)
+				roundtrip := coldata.NewMemBatchWithSize(typs, b.Length())
 				d, err := colserde.NewFileDeserializerFromPath(typs, path)
 				require.NoError(t, err)
 				defer func() { require.NoError(t, d.Close()) }()
@@ -101,14 +101,15 @@ func TestFileIndexing(t *testing.T) {
 
 	const numInts = 10
 	typs := []types.T{*types.Int}
+	batchSize := 1
 
 	var buf bytes.Buffer
 	s, err := colserde.NewFileSerializer(&buf, typs)
 	require.NoError(t, err)
 
 	for i := 0; i < numInts; i++ {
-		b := coldata.NewMemBatchWithSize(typs, 1)
-		b.SetLength(1)
+		b := coldata.NewMemBatchWithSize(typs, batchSize)
+		b.SetLength(batchSize)
 		b.ColVec(0).Int64()[0] = int64(i)
 		require.NoError(t, s.AppendBatch(b))
 	}
@@ -120,9 +121,9 @@ func TestFileIndexing(t *testing.T) {
 	require.Equal(t, typs, d.Typs())
 	require.Equal(t, numInts, d.NumBatches())
 	for batchIdx := numInts - 1; batchIdx >= 0; batchIdx-- {
-		b := coldata.NewMemBatchWithSize(nil, 0)
+		b := coldata.NewMemBatchWithSize(typs, batchSize)
 		require.NoError(t, d.GetBatch(batchIdx, b))
-		require.Equal(t, 1, b.Length())
+		require.Equal(t, batchSize, b.Length())
 		require.Equal(t, 1, b.Width())
 		require.Equal(t, coltypes.Int64, b.ColVec(0).Type())
 		require.Equal(t, int64(batchIdx), b.ColVec(0).Int64()[0])

--- a/pkg/sql/colexec/external_hash_joiner.go
+++ b/pkg/sql/colexec/external_hash_joiner.go
@@ -207,10 +207,7 @@ type externalHashJoiner struct {
 	// recursively repartition another partition because the latter was too big
 	// to join.
 	numRepartitions int
-	// scratch and recursiveScratch are helper structs. Note that batches in
-	// scratch are fully-allocated whereas batches in recursiveScratch are
-	// simply "skeletons". The latter are intended to be used to dequeue into
-	// from colcontainer.PartitionedQueues.
+	// scratch and recursiveScratch are helper structs.
 	scratch, recursiveScratch struct {
 		// Input sources can have different schemas, so when distributing tuples
 		// (i.e. copying them into scratch batch to be spilled) we might need two
@@ -399,7 +396,7 @@ func newExternalHashJoiner(
 		ehj.memState.maxRightPartitionSizeToJoin = externalHJMinimalMaxRightPartitionSize
 	}
 	ehj.scratch.leftBatch = unlimitedAllocator.NewMemBatch(spec.left.sourceTypes)
-	ehj.recursiveScratch.leftBatch = unlimitedAllocator.NewMemBatchNoCols(spec.left.sourceTypes, 0 /* size */)
+	ehj.recursiveScratch.leftBatch = unlimitedAllocator.NewMemBatch(spec.left.sourceTypes)
 	sameSourcesSchema := len(spec.left.sourceTypes) == len(spec.right.sourceTypes)
 	for i, leftType := range spec.left.sourceTypes {
 		if i < len(spec.right.sourceTypes) && !leftType.Identical(&spec.right.sourceTypes[i]) {
@@ -413,7 +410,7 @@ func newExternalHashJoiner(
 		ehj.recursiveScratch.rightBatch = ehj.recursiveScratch.leftBatch
 	} else {
 		ehj.scratch.rightBatch = unlimitedAllocator.NewMemBatch(spec.right.sourceTypes)
-		ehj.recursiveScratch.rightBatch = unlimitedAllocator.NewMemBatchNoCols(spec.right.sourceTypes, 0 /* size */)
+		ehj.recursiveScratch.rightBatch = unlimitedAllocator.NewMemBatch(spec.right.sourceTypes)
 	}
 	ehj.testingKnobs.numForcedRepartitions = numForcedRepartitions
 	ehj.testingKnobs.delegateFDAcquisitions = delegateFDAcquisitions

--- a/pkg/sql/colexec/spilling_queue.go
+++ b/pkg/sql/colexec/spilling_queue.go
@@ -99,7 +99,7 @@ func newSpillingQueue(
 		items:              make([]coldata.Batch, itemsLen),
 		diskQueueCfg:       cfg,
 		fdSemaphore:        fdSemaphore,
-		dequeueScratch:     unlimitedAllocator.NewMemBatchWithSize(typs, 0 /* size */),
+		dequeueScratch:     unlimitedAllocator.NewMemBatchWithSize(typs, coldata.BatchSize()),
 		diskAcc:            diskAcc,
 	}
 }

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -82,7 +82,7 @@ func TestSupportedSQLTypesIntegration(t *testing.T) {
 			require.NoError(t, err)
 			r, err := colserde.NewRecordBatchSerializer(typs)
 			require.NoError(t, err)
-			arrowOp := newArrowTestOperator(columnarizer, c, r)
+			arrowOp := newArrowTestOperator(columnarizer, c, r, typs)
 
 			output := distsqlutils.NewRowBuffer(typs, nil /* rows */, distsqlutils.RowBufferArgs{})
 			materializer, err := NewMaterializer(
@@ -125,17 +125,23 @@ type arrowTestOperator struct {
 
 	c *colserde.ArrowBatchConverter
 	r *colserde.RecordBatchSerializer
+
+	typs []types.T
 }
 
 var _ colexecbase.Operator = &arrowTestOperator{}
 
 func newArrowTestOperator(
-	input colexecbase.Operator, c *colserde.ArrowBatchConverter, r *colserde.RecordBatchSerializer,
+	input colexecbase.Operator,
+	c *colserde.ArrowBatchConverter,
+	r *colserde.RecordBatchSerializer,
+	typs []types.T,
 ) colexecbase.Operator {
 	return &arrowTestOperator{
 		OneInputNode: NewOneInputNode(input),
 		c:            c,
 		r:            r,
+		typs:         typs,
 	}
 }
 
@@ -159,7 +165,7 @@ func (a *arrowTestOperator) Next(ctx context.Context) coldata.Batch {
 	if err := a.r.Deserialize(&arrowDataOut, buf.Bytes()); err != nil {
 		colexecerror.InternalError(err)
 	}
-	batchOut := testAllocator.NewMemBatchWithSize(nil, 0)
+	batchOut := testAllocator.NewMemBatchWithSize(a.typs, coldata.BatchSize())
 	if err := a.c.ArrowToBatch(arrowDataOut, batchOut); err != nil {
 		colexecerror.InternalError(err)
 	}

--- a/pkg/sql/colexec/utils.go
+++ b/pkg/sql/colexec/utils.go
@@ -94,7 +94,7 @@ func newPartitionerToOperator(
 	return &partitionerToOperator{
 		partitioner:  partitioner,
 		partitionIdx: partitionIdx,
-		batch:        allocator.NewMemBatchNoCols(types, 0 /* size */),
+		batch:        allocator.NewMemBatch(types),
 	}
 }
 


### PR DESCRIPTION
Previously, the ArrowBatchCoverter resets the input batch when performing
translation from Arrow to Batch. However, this creates issue this Reset
can potentially perform allocation and it is not tracked by allocator.

Now ArrowBatchConverter no longer performs this reset and it is expecting
the input batch will have the correct schema and capacity.

Release note: None

Closes #43964