### PR TITLE
base: make in-mem temp storage use disk resource

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -735,31 +735,22 @@ func TempStorageConfigFromEnv(
 	specIdx int,
 ) TempStorageConfig {
 	inMem := parentDir == "" && firstStore.InMemory
-	var monitor mon.BytesMonitor
+	var monitorName string
 	if inMem {
-		monitor = mon.MakeMonitor(
-			"in-mem temp storage",
-			mon.MemoryResource,
-			nil,             /* curCount */
-			nil,             /* maxHist */
-			1024*1024,       /* increment */
-			maxSizeBytes/10, /* noteworthy */
-			st,
-		)
-		monitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(maxSizeBytes))
+		monitorName = "in-mem temp storage"
 	} else {
-		monitor = mon.MakeMonitor(
-			"temp disk storage",
-			mon.DiskResource,
-			nil,             /* curCount */
-			nil,             /* maxHist */
-			1024*1024,       /* increment */
-			maxSizeBytes/10, /* noteworthy */
-			st,
-		)
-		monitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(maxSizeBytes))
+		monitorName = "temp disk storage"
 	}
-
+	monitor := mon.MakeMonitor(
+		monitorName,
+		mon.DiskResource,
+		nil,             /* curCount */
+		nil,             /* maxHist */
+		1024*1024,       /* increment */
+		maxSizeBytes/10, /* noteworthy */
+		st,
+	)
+	monitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(maxSizeBytes))
 	return TempStorageConfig{
 		InMemory: inMem,
 		Mon:      &monitor,

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -153,7 +153,7 @@ func DefaultTestTempStorageConfig(st *cluster.Settings) TempStorageConfig {
 	var maxSizeBytes int64 = DefaultInMemTempStorageMaxSizeBytes
 	monitor := mon.MakeMonitor(
 		"in-mem temp storage",
-		mon.MemoryResource,
+		mon.DiskResource,
 		nil,             /* curCount */
 		nil,             /* maxHist */
 		1024*1024,       /* increment */


### PR DESCRIPTION
Previously, for in-memory temp storage we were creating a memory monitor
that used "memory resource". Whenever we hit that limit, this would
result in "out of memory" error; however, the correct error should be
"disk full", and this commit changes the resource type to "disk
resource".

Addressed: #47206.

Release note: None