### PR TITLE
roachtest: temporarily reduce alterpk-tpcc dataset size

### DIFF
--- a/pkg/cmd/roachtest/alterpk.go
+++ b/pkg/cmd/roachtest/alterpk.go
@@ -88,8 +88,7 @@ func registerAlterPK(r *testRegistry) {
 	}
 
 	// runAlterPKTPCC runs a primary key change while the TPCC workload runs.
-	runAlterPKTPCC := func(ctx context.Context, t *test, c *cluster) {
-		const warehouses = 500
+	runAlterPKTPCC := func(ctx context.Context, t *test, c *cluster, warehouses int) {
 		const duration = 10 * time.Minute
 
 		roachNodes, loadNode := setupTest(ctx, t, c)
@@ -170,12 +169,27 @@ func registerAlterPK(r *testRegistry) {
 		Run:        runAlterPKBank,
 	})
 	r.Add(testSpec{
-		Name:  "alterpk-tpcc",
+		Name:  "alterpk-tpcc-250",
 		Owner: OwnerSQLSchema,
 		// Use a 4 node cluster -- 3 nodes will run cockroach, and the last will be the
 		// workload driver node.
 		MinVersion: "v20.1.0",
 		Cluster:    makeClusterSpec(4, cpu(16)),
-		Run:        runAlterPKTPCC,
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runAlterPKTPCC(ctx, t, c, 250 /* warehouses */)
+		},
+	})
+	r.Add(testSpec{
+		// TODO(yuzefovich): investigate #47598 and unskip this configuration.
+		Skip:  "#47598",
+		Name:  "alterpk-tpcc-500",
+		Owner: OwnerSQLSchema,
+		// Use a 4 node cluster -- 3 nodes will run cockroach, and the last will be the
+		// workload driver node.
+		MinVersion: "v20.1.0",
+		Cluster:    makeClusterSpec(4, cpu(16)),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runAlterPKTPCC(ctx, t, c, 500 /* warehouses */)
+		},
 	})
 }


### PR DESCRIPTION
`alterpk-tpcc` now occasionally crashes during 3.3.2.6 expensive check
after the workload has been complete. It is likely that the dataset of
500 warehouses is just too big for the cluster (this needs to be
confirmed though), so for now we will reduce it to 250 warehouses until
we investigate the cause of the crash.

Addresses: #47598.

Release note: None