### PR TITLE
release-20.1: opt: fix in-place modification of window definition in optbuilder

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -567,3 +567,24 @@ SELECT * FROM v1
 1  1  false
 2  2  true
 3  3  true
+
+# Regression test for #47704: the columns inside PARITION BY and ORDER BY were
+# losing their qualification.
+statement ok
+CREATE TABLE a47704 (foo UUID);
+CREATE TABLE b47704 (foo UUID)
+
+statement ok
+CREATE VIEW v47704 AS
+  SELECT first_value(a47704.foo) OVER (PARTITION BY a47704.foo ORDER BY a47704.foo)
+  FROM a47704 JOIN b47704 ON a47704.foo = b47704.foo
+
+# Verify that the descriptor did not "lose" the column qualification inside
+# PARITION BY and ORDER BY.
+query T
+SELECT create_statement FROM [ SHOW CREATE VIEW v47704 ]
+----
+CREATE VIEW v47704 (first_value) AS SELECT first_value(a47704.foo) OVER (PARTITION BY a47704.foo ORDER BY a47704.foo) FROM test.public.a47704 JOIN test.public.b47704 ON a47704.foo = b47704.foo
+
+statement ok
+SELECT * FROM v47704

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -801,13 +801,13 @@ const (
 // OverrideWindowDef implements the logic to have a base window definition which
 // then gets augmented by a different window definition.
 func OverrideWindowDef(base *WindowDef, override WindowDef) (WindowDef, error) {
-	// referencedSpec.Partitions is always used.
+	// base.Partitions is always used.
 	if len(override.Partitions) > 0 {
 		return WindowDef{}, pgerror.Newf(pgcode.Windowing, "cannot override PARTITION BY clause of window %q", base.Name)
 	}
 	override.Partitions = base.Partitions
 
-	// referencedSpec.OrderBy is used if set.
+	// base.OrderBy is used if set.
 	if len(base.OrderBy) > 0 {
 		if len(override.OrderBy) > 0 {
 			return WindowDef{}, pgerror.Newf(pgcode.Windowing, "cannot override ORDER BY clause of window %q", base.Name)


### PR DESCRIPTION
Backport 1/1 commits from #47709. Planning to merge this for 20.1.1, after 20.1.0 is released.

/cc @cockroachdb/release

---

The optbuilder code which handles window functions inadvertently modifies the
`WindowDef` in place. This leads to loss of qualification in the PARTITION BY
and ORDER BY columns (which get replaced with `*scopeColumn`s). This is a
problem for views where the query stored in the descriptor could be invalid
without the qualification.

This change fixes this by making copies as necessary.

Fixes #47704.

Release note (bug fix): fixed case where PARTITION BY and ORDER BY columns in
window specifications were losing qualifications when used inside views.
