### PR TITLE
smithcmp: add test timeout option

### DIFF
--- a/pkg/cmd/smithcmp/tpch.toml
+++ b/pkg/cmd/smithcmp/tpch.toml
@@ -3,7 +3,7 @@
 
 smither = "postgres"
 seed = -1
-timeoutsecs = 120
+stmttimeoutsecs = 120
 
 sql = [
 """


### PR DESCRIPTION
Previously, "smithing" would run indefinitely until it is canceled
explicitly or we hit an error. Now an additional `timeoutmins` option is
accepted (which by default is 15 minutes). Statement timeout option has
been renamed from `timeoutsecs` to `stmttimeoutsecs`.

Addresses: #46500.

Release note: None