### PR TITLE
roachtest: enable auto stats in cdc test

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -87,14 +87,6 @@ func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
 		nodes: kafkaNode,
 	}
 
-	// Workaround for #35947. The optimizer currently plans a bad query for TPCC
-	// when it has stats, so disable stats for now.
-	if _, err := db.Exec(
-		`SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false`,
-	); err != nil && !strings.Contains(err.Error(), "unknown cluster setting") {
-		t.Fatal(err)
-	}
-
 	var sinkURI string
 	if args.cloudStorageSink {
 		ts := timeutil.Now().Format(`20060102150405`)


### PR DESCRIPTION
Automatic collection of stats has been disabled about a year ago due to
a limitation of the optimizer (issue 35947) which has been fixed. This
commit removes the override of the setting.

Release note: None