### PR TITLE
sql/mutations: remove @index hints for postgres

### DIFF
--- a/pkg/sql/mutations/mutations.go
+++ b/pkg/sql/mutations/mutations.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"math/rand"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -507,6 +508,8 @@ Loop:
 	}
 }
 
+var postgresMutatorAtIndex = regexp.MustCompile(`@[\[\]\w]+`)
+
 func postgresMutator(rng *rand.Rand, q string) string {
 	q, _ = ApplyString(rng, q, postgresStatementMutator)
 
@@ -521,6 +524,7 @@ func postgresMutator(rng *rand.Rand, q string) string {
 	} {
 		q = strings.Replace(q, from, to, -1)
 	}
+	q = postgresMutatorAtIndex.ReplaceAllString(q, "")
 	return q
 }
 


### PR DESCRIPTION
Postgres doesn't support this syntax. Although a regex isn't great,
we don't have a general purpose SQL walker that can do this, so it's
good enough for now. I didn't see any other use of @ in formatting,
so I believe this won't break any postgres queries.

Release note: None