### PR TITLE
sqlbase: avoid decode/encode in Fingerprint

### DIFF
--- a/pkg/cmd/roachtest/alterpk.go
+++ b/pkg/cmd/roachtest/alterpk.go
@@ -180,8 +180,6 @@ func registerAlterPK(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		// TODO(yuzefovich): investigate #47598 and unskip this configuration.
-		Skip:  "#47598",
 		Name:  "alterpk-tpcc-500",
 		Owner: OwnerSQLSchema,
 		// Use a 4 node cluster -- 3 nodes will run cockroach, and the last will be the

--- a/pkg/sql/sqlbase/encoded_datum.go
+++ b/pkg/sql/sqlbase/encoded_datum.go
@@ -279,15 +279,21 @@ func (ed *EncDatum) Encode(
 // fingerprints of a set of datums are appended together, the resulting
 // fingerprint will uniquely identify the set.
 func (ed *EncDatum) Fingerprint(typ *types.T, a *DatumAlloc, appendTo []byte) ([]byte, error) {
-	if err := ed.EnsureDecoded(typ, a); err != nil {
-		return nil, err
-	}
+	// Note: we don't ed.EnsureDecoded on top of this method, because the default
+	// case uses ed.Encode, which has a fast path if the encoded bytes are already
+	// the right encoding.
 	switch typ.Family() {
 	case types.JsonFamily:
+		if err := ed.EnsureDecoded(typ, a); err != nil {
+			return nil, err
+		}
 		// We must use value encodings without a column ID even if the EncDatum already
 		// is encoded with the value encoding so that the hashes are indeed unique.
 		return EncodeTableValue(appendTo, ColumnID(encoding.NoColumnID), ed.Datum, a.scratch)
 	case types.ArrayFamily:
+		if err := ed.EnsureDecoded(typ, a); err != nil {
+			return nil, err
+		}
 		// Arrays may contain composite data, so we cannot just value
 		// encode an array (that would give same-valued composite
 		// datums a different encoding).


### PR DESCRIPTION
The Fingerprint method introduced in
b08d8f449a979457e8c60781ca56b4c90f112433 added an unnecessary
decode/encode cycle that didn't exist before, if the input Datum was
already in ASCENDING_KEY encoding.

This commit restores the original behavior.

We should probably backport this to release-20.1.

Release note: None