### PR TITLE
sql: collect multi-column stats on index prefixes

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -56,6 +56,7 @@
 <tr><td><code>sql.stats.automatic_collection.fraction_stale_rows</code></td><td>float</td><td><code>0.2</code></td><td>target fraction of stale rows per table that will trigger a statistics refresh</td></tr>
 <tr><td><code>sql.stats.automatic_collection.min_stale_rows</code></td><td>integer</td><td><code>500</code></td><td>target minimum number of stale rows per table that will trigger a statistics refresh</td></tr>
 <tr><td><code>sql.stats.histogram_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>histogram collection mode</td></tr>
+<tr><td><code>sql.stats.multi_column_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>multi-column statistics collection mode</td></tr>
 <tr><td><code>sql.stats.post_events.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if set, an event is logged for every CREATE STATISTICS job</td></tr>
 <tr><td><code>sql.temp_object_cleaner.cleanup_interval</code></td><td>duration</td><td><code>30m0s</code></td><td>how often to clean up orphaned temporary objects</td></tr>
 <tr><td><code>sql.trace.log_statement_execute</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable logging of executed statements</td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
@@ -23,6 +23,8 @@ SELECT statistics_name, column_names, row_count, distinct_count, null_count
 FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
+__auto__         {a,b,c}       1000       1000            0
+__auto__         {a,b}         1000       100             0
 __auto__         {a}           1000       10              0
 __auto__         {b}           1000       10              0
 __auto__         {c}           1000       10              0
@@ -42,6 +44,8 @@ SELECT statistics_name, column_names, row_count, distinct_count, null_count
 FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
+__auto__         {a,b,c}       1000       1000            0
+__auto__         {a,b}         1000       100             0
 __auto__         {a}           1000       10              0
 __auto__         {b}           1000       10              0
 __auto__         {c}           1000       10              0
@@ -60,6 +64,10 @@ SELECT statistics_name, column_names, row_count, distinct_count, null_count
 FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
+__auto__         {a,b,c}       1000       1000            0
+__auto__         {a,b,c}       1000       1000            0
+__auto__         {a,b}         1000       100             0
+__auto__         {a,b}         1000       100             0
 __auto__         {a}           1000       10              0
 __auto__         {a}           1000       10              0
 __auto__         {b}           1000       10              0
@@ -81,6 +89,12 @@ SELECT statistics_name, column_names, row_count, distinct_count, null_count
 FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
+__auto__         {a,b,c}       1000       1000            0
+__auto__         {a,b,c}       1000       1000            0
+__auto__         {a,b,c}       1050       1050            0
+__auto__         {a,b}         1000       100             0
+__auto__         {a,b}         1000       100             0
+__auto__         {a,b}         1050       110             0
 __auto__         {a}           1000       10              0
 __auto__         {a}           1000       10              0
 __auto__         {a}           1050       11              0
@@ -103,6 +117,14 @@ SELECT statistics_name, column_names, row_count, distinct_count, null_count
 FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
+__auto__         {a,b,c}       1000       1000            0
+__auto__         {a,b,c}       1000       1000            0
+__auto__         {a,b,c}       1050       1050            0
+__auto__         {a,b,c}       550        550             0
+__auto__         {a,b}         1000       100             0
+__auto__         {a,b}         1000       100             0
+__auto__         {a,b}         1050       110             0
+__auto__         {a,b}         550        110             0
 __auto__         {a}           1000       10              0
 __auto__         {a}           1000       10              0
 __auto__         {a}           1050       11              0

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -169,6 +169,10 @@ s2               {a}           256        4               0
 # Test default column statistics
 #
 
+# Disable multi-column stats to start.
+statement ok
+SET CLUSTER SETTING sql.stats.multi_column_collection.enabled = false
+
 statement ok
 CREATE STATISTICS s3 FROM data
 
@@ -186,9 +190,14 @@ column_names  row_count  distinct_count  null_count  has_histogram
 {d}           256        4               0           false
 {e}           256        2               0           true
 
-# Add indexes, including duplicate index on column c.
+
+# Re-enable multi-column stats.
 statement ok
-CREATE INDEX ON data (c DESC, b ASC); CREATE INDEX ON data (b DESC)
+SET CLUSTER SETTING sql.stats.multi_column_collection.enabled = true
+
+# Add indexes, including duplicate index on column c and columns (a, b).
+statement ok
+CREATE INDEX ON data (c DESC, b ASC); CREATE INDEX ON data (b DESC, a);
 
 statement ok
 CREATE STATISTICS s4 FROM data
@@ -201,7 +210,12 @@ WHERE statistics_name = 's4'
 ----
 column_names  row_count  distinct_count  null_count
 {a}           256        4               0
+{a,b}         256        16              0
+{a,b,c}       256        64              0
+{a,b,c,d}     256        256             0
 {c}           256        4               0
+{c,d}         256        16              0
+{c,b}         256        16              0
 {b}           256        4               0
 {d}           256        4               0
 {e}           256        2               0
@@ -221,6 +235,9 @@ WHERE statistics_name = 's5'
 ----
 column_names  row_count  distinct_count  null_count
 {a}           256        4               0
+{a,b}         256        16              0
+{a,b,c}       256        64              0
+{a,b,c,d}     256        256             0
 {b}           256        4               0
 {c}           256        4               0
 {d}           256        4               0
@@ -263,6 +280,30 @@ default_stat2    {rowid}       1          1               0
 default_stat2    {y}           1          1               1
 default_stat2    {x}           1          1               1
 
+# Add a few more rows.
+statement ok
+INSERT INTO simple VALUES (DEFAULT, DEFAULT);
+INSERT INTO simple VALUES (0, DEFAULT);
+INSERT INTO simple VALUES (DEFAULT, 0);
+INSERT INTO simple VALUES (0, 1);
+
+# Add an index.
+statement ok
+CREATE INDEX ON simple (x, y)
+
+statement ok
+CREATE STATISTICS default_stat3 FROM simple
+
+query TTIII colnames
+SELECT statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE simple]
+----
+statistics_name  column_names  row_count  distinct_count  null_count
+default_stat3    {rowid}       5          5               0
+default_stat3    {y}           5          3               3
+default_stat3    {x}           5          2               3
+default_stat3    {x,y}         5          4               4
+
 #
 # Test numeric references
 #
@@ -275,6 +316,11 @@ SELECT statistics_name, column_names, row_count, distinct_count, null_count
 FROM [SHOW STATISTICS FOR TABLE data]
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
+s4               {c,d}         256        16              0
+s4               {c,b}         256        16              0
+s5               {a,b}         256        16              0
+s5               {a,b,c}       256        64              0
+s5               {a,b,c,d}     256        256             0
 s5               {b}           256        4               0
 s5               {c}           256        4               0
 s5               {d}           256        4               0
@@ -292,6 +338,9 @@ WHERE statistics_name = '__auto__'
 ----
 column_names  row_count  distinct_count  null_count
 {a}           256        4               0
+{a,b}         256        16              0
+{a,b,c}       256        64              0
+{a,b,c,d}     256        256             0
 {b}           256        4               0
 {c}           256        4               0
 {d}           256        4               0
@@ -302,7 +351,7 @@ column_names  row_count  distinct_count  null_count
 #
 
 statement ok
-DROP INDEX data@data_b_idx
+DROP INDEX data@data_b_a_idx
 
 statement ok
 CREATE STATISTICS __auto__ FROM [53];
@@ -318,6 +367,21 @@ SELECT statistics_name, column_names
 FROM [SHOW STATISTICS FOR TABLE data] ORDER BY statistics_name, column_names::STRING
 ----
 statistics_name  column_names
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a,b}
 __auto__         {a}
 __auto__         {a}
 __auto__         {a}
@@ -343,6 +407,8 @@ __auto__         {e}
 __auto__         {e}
 __auto__         {e}
 __auto__         {e}
+s4               {c,b}
+s4               {c,d}
 
 statement ok
 CREATE STATISTICS s7 ON a FROM [53]
@@ -352,6 +418,21 @@ SELECT statistics_name, column_names
 FROM [SHOW STATISTICS FOR TABLE data] ORDER BY statistics_name, column_names::STRING
 ----
 statistics_name  column_names
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a,b}
 __auto__         {a}
 __auto__         {a}
 __auto__         {a}
@@ -376,6 +457,8 @@ __auto__         {e}
 __auto__         {e}
 __auto__         {e}
 __auto__         {e}
+s4               {c,b}
+s4               {c,d}
 s7               {a}
 
 statement ok
@@ -387,6 +470,21 @@ SELECT statistics_name, column_names
 FROM [SHOW STATISTICS FOR TABLE data] ORDER BY statistics_name, column_names::STRING
 ----
 statistics_name  column_names
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a,b}
 __auto__         {a}
 __auto__         {a}
 __auto__         {a}
@@ -411,6 +509,8 @@ __auto__         {e}
 __auto__         {e}
 __auto__         {e}
 __auto__         {e}
+s4               {c,b}
+s4               {c,d}
 s8               {a}
 
 # Regression test for #33195.

--- a/pkg/sql/rowexec/sampler_test.go
+++ b/pkg/sql/rowexec/sampler_test.go
@@ -189,9 +189,12 @@ func TestSamplerSketch(t *testing.T) {
 		{-1, 1},
 		{-1, 3},
 		{1, -1},
+		{2, 8},
+		{-1, 1},
+		{-1, -1},
 	}
-	cardinalities := []int{3, 9}
-	numNulls := []int{2, 1}
+	cardinalities := []int{3, 9, 12}
+	numNulls := []int{4, 2, 5}
 
 	rows := sqlbase.GenEncDatumRowsInt(inputRows)
 	in := distsqlutils.NewRowBuffer(sqlbase.TwoIntCols, rows, distsqlutils.RowBufferArgs{})
@@ -226,6 +229,10 @@ func TestSamplerSketch(t *testing.T) {
 				SketchType: execinfrapb.SketchType_HLL_PLUS_PLUS_V1,
 				Columns:    []uint32{1},
 			},
+			{
+				SketchType: execinfrapb.SketchType_HLL_PLUS_PLUS_V1,
+				Columns:    []uint32{0, 1},
+			},
 		},
 	}
 	p, err := newSamplerProcessor(&flowCtx, 0 /* processorID */, spec, in, &execinfrapb.PostProcessSpec{}, out)
@@ -249,9 +256,9 @@ func TestSamplerSketch(t *testing.T) {
 		rows = append(rows, row)
 	}
 
-	// We expect one sampled row and two sketch rows.
-	if len(rows) != 3 {
-		t.Fatalf("expected 3 rows, got %v\n", rows.String(outTypes))
+	// We expect one sampled row and three sketch rows.
+	if len(rows) != 4 {
+		t.Fatalf("expected 4 rows, got %v\n", rows.String(outTypes))
 	}
 	rows = rows[1:]
 

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -43,6 +43,14 @@ var AutomaticStatisticsClusterMode = settings.RegisterPublicBoolSetting(
 	true,
 )
 
+// MultiColumnStatisticsClusterMode controls the cluster setting for enabling
+// automatic collection of multi-column statistics.
+var MultiColumnStatisticsClusterMode = settings.RegisterPublicBoolSetting(
+	"sql.stats.multi_column_collection.enabled",
+	"multi-column statistics collection mode",
+	true,
+)
+
 // AutomaticStatisticsMaxIdleTime controls the maximum fraction of time that
 // the sampler processors will be idle when scanning large tables for automatic
 // statistics (in high load scenarios). This value can be tuned to trade off


### PR DESCRIPTION
Prior to this commit, only single-column statistics were supported
and collected. This commit adds support for collecting multi-column
statistics, and by default collects stats on all prefixes of each
index (in addition to all the single column statistics that were already
collected). For example, if there is an index on (a, b, c), we now
collect stats on (a, b) and (a, b, c) in addition to stats on each
individual column.

A new cluster setting `sql.stats.multi_column_collection.enabled`
controls this feature. It is currently enabled by default, but automatic
collection of multi-column stats can be disabled by setting it to false.

Note that we do not yet make full use of these statistics in the
optimizer. That change will come in a future PR.

Informs #34422

Release note (sql change): Added support for collection of multi-
column statistics. By default, statistics are now collected on all
prefixes of each index, in addition to 100 other individual columns.
This feature can be disabled by setting the cluster setting
sql.stats.multi_column_collection.enabled to false.