### PR TITLE
geogfn: implement Covers using S2

### DIFF
--- a/pkg/geo/geogfn/covers.go
+++ b/pkg/geo/geogfn/covers.go
@@ -1,0 +1,284 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geogfn
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/golang/geo/s2"
+)
+
+// Covers returns whether geography A covers geography B.
+//
+// This calculation is done on the sphere.
+//
+// Due to minor inaccuracies and lack of certain primitives in S2,
+// precision for Covers will be for up to 1cm.
+//
+// Current limitations (which are also limitations in PostGIS):
+// * POLYGON/LINESTRING only works as "contains" - if any point of the LINESTRING
+//   touches the boundary of the polygon, we will return false but should be true - e.g.
+//     SELECT st_covers(
+//       'multipolygon(((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0)), ((1.0 0.0, 2.0 0.0, 2.0 1.0, 1.0 1.0, 1.0 0.0)))',
+//       'linestring(0.0 0.0, 1.0 0.0)'::geography
+//     );
+//
+// * Furthermore, LINESTRINGS that are covered in multiple POLYGONs inside
+//   MULTIPOLYGON but NOT within a single POLYGON in the MULTIPOLYGON
+//   currently return false but should be true, e.g.
+//     SELECT st_covers(
+//       'multipolygon(((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0)), ((1.0 0.0, 2.0 0.0, 2.0 1.0, 1.0 1.0, 1.0 0.0)))',
+//       'linestring(0.0 0.0, 2.0 0.0)'::geography
+//     );
+func Covers(a *geo.Geography, b *geo.Geography) (bool, error) {
+	aRegions, err := a.AsS2()
+	if err != nil {
+		return false, err
+	}
+	bRegions, err := b.AsS2()
+	if err != nil {
+		return false, err
+	}
+
+	// We need to check each region in B is covered by at least
+	// one region of A.
+	bRegionsRemaining := make(map[int]struct{}, len(bRegions))
+	for i := range bRegions {
+		bRegionsRemaining[i] = struct{}{}
+	}
+	for _, aRegion := range aRegions {
+		for bRegionIdx := range bRegionsRemaining {
+			regionCovers, err := regionCovers(aRegion, bRegions[bRegionIdx])
+			if err != nil {
+				return false, err
+			}
+			if regionCovers {
+				delete(bRegionsRemaining, bRegionIdx)
+			}
+		}
+		if len(bRegionsRemaining) == 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// CoveredBy returns whether geography A is covered by geography B.
+// See Covers for limitations.
+func CoveredBy(a *geo.Geography, b *geo.Geography) (bool, error) {
+	return Covers(b, a)
+}
+
+// regionCovers returns whether aRegion completely covers bRegion.
+func regionCovers(aRegion s2.Region, bRegion s2.Region) (bool, error) {
+	switch aRegion := aRegion.(type) {
+	case s2.Point:
+		switch bRegion := bRegion.(type) {
+		case s2.Point:
+			return aRegion.ContainsPoint(bRegion), nil
+		case *s2.Polyline:
+			return false, nil
+		case *s2.Polygon:
+			return false, nil
+		default:
+			return false, fmt.Errorf("unknown s2 type of b: %#v", bRegion)
+		}
+	case *s2.Polyline:
+		switch bRegion := bRegion.(type) {
+		case s2.Point:
+			return polylineCoversPoint(aRegion, bRegion), nil
+		case *s2.Polyline:
+			return polylineCoversPolyline(aRegion, bRegion), nil
+		case *s2.Polygon:
+			return false, nil
+		default:
+			return false, fmt.Errorf("unknown s2 type of b: %#v", bRegion)
+		}
+	case *s2.Polygon:
+		switch bRegion := bRegion.(type) {
+		case s2.Point:
+			return polygonCoversPoint(aRegion, bRegion), nil
+		case *s2.Polyline:
+			return polygonCoversPolyline(aRegion, bRegion), nil
+		case *s2.Polygon:
+			return polygonCoversPolygon(aRegion, bRegion), nil
+		default:
+			return false, fmt.Errorf("unknown s2 type of b: %#v", bRegion)
+		}
+	}
+	return false, fmt.Errorf("unknown s2 type of a: %#v", aRegion)
+}
+
+// polylineCoversPoints returns whether a polyline covers a given point.
+func polylineCoversPoint(a *s2.Polyline, b s2.Point) bool {
+	return a.IntersectsCell(s2.CellFromPoint(b))
+}
+
+// polylineCoversPointsWithIdx returns whether a polyline covers a given point.
+// If true, it will also return an index of the start of the edge where there
+// was an intersection.
+func polylineCoversPointWithIdx(a *s2.Polyline, b s2.Point) (bool, int) {
+	for edgeIdx := 0; edgeIdx < a.NumEdges(); edgeIdx++ {
+		if edgeCoversPoint(a.Edge(edgeIdx), b) {
+			return true, edgeIdx
+		}
+	}
+	return false, -1
+}
+
+// polygonCoversPoints returns whether a polygon covers a given point.
+func polygonCoversPoint(a *s2.Polygon, b s2.Point) bool {
+	// Account for the case where b is on the edge of the polygon.
+	return a.ContainsPoint(b) || a.IntersectsCell(s2.CellFromPoint(b))
+}
+
+// edgeCoversPoint determines whether a given edge contains a point.
+func edgeCoversPoint(e s2.Edge, p s2.Point) bool {
+	return (&s2.Polyline{e.V0, e.V1}).IntersectsCell(s2.CellFromPoint(p))
+}
+
+// polylineCoversPolyline returns whether polyline a covers polyline b.
+func polylineCoversPolyline(a *s2.Polyline, b *s2.Polyline) bool {
+	if polylineCoversPolylineOrdered(a, b) {
+		return true
+	}
+	// Check reverse ordering works as well.
+	reversedB := make([]s2.Point, len(*b))
+	for i, point := range *b {
+		reversedB[len(reversedB)-1-i] = point
+	}
+	newBAsPolyline := s2.Polyline(reversedB)
+	return polylineCoversPolylineOrdered(a, &newBAsPolyline)
+}
+
+// polylineCoversPolylineOrdered returns whether a polyline covers a polyline
+// in the same ordering.
+func polylineCoversPolylineOrdered(a *s2.Polyline, b *s2.Polyline) bool {
+	aCoversStartOfB, aCoverBStart := polylineCoversPointWithIdx(a, (*b)[0])
+	// We must first check that the start of B is contained by A.
+	if !aCoversStartOfB {
+		return false
+	}
+
+	aPoints := *a
+	bPoints := *b
+	// We have found "aIdx" which is the first edge in polyline A
+	// that includes the starting vertex of polyline "B".
+	// Start checking the covering from this edge.
+	aIdx := aCoverBStart
+	bIdx := 0
+
+	aEdge := s2.Edge{V0: aPoints[aIdx], V1: aPoints[aIdx+1]}
+	bEdge := s2.Edge{V0: bPoints[bIdx], V1: bPoints[bIdx+1]}
+	for {
+		aEdgeCoversBStart := edgeCoversPoint(aEdge, bEdge.V0)
+		aEdgeCoversBEnd := edgeCoversPoint(aEdge, bEdge.V1)
+		bEdgeCoversAEnd := edgeCoversPoint(bEdge, aEdge.V1)
+		if aEdgeCoversBStart && aEdgeCoversBEnd {
+			// If the edge A fully covers edge B, check the next edge.
+			bIdx++
+			// We are out of edges in B, and A keeps going or stops at the same point.
+			// This is a covering.
+			if bIdx == len(bPoints)-1 {
+				return true
+			}
+			bEdge = s2.Edge{V0: bPoints[bIdx], V1: bPoints[bIdx+1]}
+			// If A and B end at the same place, we need to move A forward.
+			if bEdgeCoversAEnd {
+				aIdx++
+				if aIdx == len(aPoints)-1 {
+					// At this point, B extends past A. return false.
+					return false
+				}
+				aEdge = s2.Edge{V0: aPoints[aIdx], V1: aPoints[aIdx+1]}
+			}
+			continue
+		}
+
+		if aEdgeCoversBStart {
+			// Edge A doesn't cover the end of B, but it does cover the start.
+			// If B doesn't cover the end of A, we're done.
+			if !bEdgeCoversAEnd {
+				return false
+			}
+			// If the end of edge B covers the end of A, that means that
+			// B is possibly longer than A. If that's the case, truncate B
+			// to be the end of A, and move A forward.
+			bEdge.V0 = aEdge.V1
+			aIdx++
+			if aIdx == len(aPoints)-1 {
+				// At this point, B extends past A. return false.
+				return false
+			}
+			aEdge = s2.Edge{V0: aPoints[aIdx], V1: aPoints[aIdx+1]}
+			continue
+		}
+
+		// Otherwise, we're doomed.
+		// Edge A does not contain edge B.
+		return false
+	}
+}
+
+// polygonCoversPolyline returns whether polygon a covers polyline b.
+func polygonCoversPolyline(a *s2.Polygon, b *s2.Polyline) bool {
+	// Check everything of polyline B is in the interior of polygon A.
+	for _, vertex := range *b {
+		if !polygonCoversPoint(a, vertex) {
+			return false
+		}
+	}
+	// Even if every point of polyline B is inside polygon A, they
+	// may form an edge which goes outside of polygon A and back in
+	// due to holes and concavities.
+	//
+	// As such, check if there are any intersections - if so,
+	// we do not consider it a covering.
+	//
+	// NOTE: this implementation has a limitation where a vertex of the line could
+	// be on the boundary and still technically be "covered" (using GEOS).
+	//
+	// However, PostGIS seems to consider this as non-covering so we can go
+	// with this for now.
+	// i.e. `
+	//   select st_covers(
+	//    'POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))'::geography,
+	//    'LINESTRING(0.0 0.0, 1.0 1.0)'::geography);
+	// ` returns false, but should be true. This requires some more math to resolve.
+	return !polygonIntersectsPolylineEdge(a, b)
+}
+
+// polygonIntersectsPolylineEdge returns whether polygon a intersects with
+// polyline b by edge. It does not return true if the polyline is completely
+// within the polygon.
+func polygonIntersectsPolylineEdge(a *s2.Polygon, b *s2.Polyline) bool {
+	// Avoid using NumEdges / Edge of the Polygon type as it is not O(1).
+	for _, loop := range a.Loops() {
+		for loopEdgeIdx := 0; loopEdgeIdx < loop.NumEdges(); loopEdgeIdx++ {
+			loopEdge := loop.Edge(loopEdgeIdx)
+			crosser := s2.NewChainEdgeCrosser(loopEdge.V0, loopEdge.V1, (*b)[0])
+			for _, nextVertex := range (*b)[1:] {
+				if crosser.ChainCrossingSign(nextVertex) != s2.DoNotCross {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// polygonCoversPolygon returns whether polygon a intersects with polygon b.
+func polygonCoversPolygon(a *s2.Polygon, b *s2.Polygon) bool {
+	// We can rely on Contains here, as if the boundaries of A and B are on top
+	// of each other, it is still considered a containment as well as a covering.
+	return a.Contains(b)
+}

--- a/pkg/geo/geogfn/covers_test.go
+++ b/pkg/geo/geogfn/covers_test.go
@@ -1,0 +1,375 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geogfn
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCovers(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		a        string
+		b        string
+		expected bool
+	}{
+		{
+			"POINT covers the same POINT",
+			"POINT(1.0 1.0)",
+			"POINT(1.0 1.0)",
+			true,
+		},
+		{
+			"POINT does not cover different POINT",
+			"POINT(1.0 1.0)",
+			"POINT(1.0 1.1)",
+			false,
+		},
+		{
+			"POINT does not cover different LINESTRING",
+			"POINT(1.0 1.0)",
+			"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0)",
+			false,
+		},
+		{
+			"POINT does not cover different POLYGON",
+			"POINT(1.0 1.0)",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			false,
+		},
+		{
+			"LINESTRING covers POINT at the start",
+			"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0)",
+			"POINT(1.0 1.0)",
+			true,
+		},
+		{
+			"LINESTRING covers POINT at the middle",
+			"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0)",
+			"POINT(2.0 2.0)",
+			true,
+		},
+		{
+			"LINESTRING covers POINT at the end",
+			"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0)",
+			"POINT(3.0 3.0)",
+			true,
+		},
+		{
+			"LINESTRING covers POINT in between",
+			"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0)",
+			"POINT(1.5 1.5001714)",
+			true,
+		},
+		{
+			"LINESTRING does not cover any POINT out of the way",
+			"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0)",
+			"POINT(2.0 4.0)",
+			false,
+		},
+		{
+			"LINESTRING does not cover longer LINESTRING",
+			"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0)",
+			"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0, 4.0 4.0)",
+			false,
+		},
+		{
+			"LINESTRING does not cover different LINESTRING",
+			"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0)",
+			"LINESTRING(5.0 5.0, 4.0 4.0)",
+			false,
+		},
+		{
+			"LINESTRING covers itself",
+			"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0)",
+			"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0)",
+			true,
+		},
+		{
+			"LINESTRING covers itself in reverse",
+			"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0, 4.0 4.0)",
+			"LINESTRING(4.0 4.0, 3.0 3.0, 2.0 2.0, 1.0 1.0)",
+			true,
+		},
+		{
+			"LINESTRING covers subline of itself",
+			"LINESTRING(0.0 0.0, 1.0 1.0, 2.0 2.0, 3.0 3.0)",
+			"LINESTRING(1.5 1.5001714, 2.0 2.0)",
+			true,
+		},
+		{
+			"LINESTRING does not cover subline of with a tail in b",
+			"LINESTRING(1.0 1.0, 2.0 2.0)",
+			"LINESTRING(1.5 1.5001714, 2.0 2.0, 2.5 2.5)",
+			false,
+		},
+		{
+			"LINESTRING covers subline of itself but veers off",
+			"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0)",
+			"LINESTRING(1.5 1.5001714, 2.0 2.0, 2.5 2.5)",
+			false,
+		},
+		{
+			"LINESTRING covers LINESTRING with subline missing a vertex in A",
+			"LINESTRING(0.999 0.999, 1.0 1.0, 1.01 1.01)",
+			"LINESTRING(0.9995 0.9995, 1.005 1.005)",
+			true,
+		},
+		{
+			"LINESTRING does not cover LINESTRING with subline covering some point in A but B extends past A",
+			"LINESTRING(0.9 0.9, 0.999 0.999, 1.0 1.0)",
+			"LINESTRING(0.999 0.999, 0.9995 0.9995, 1.005 1.005)",
+			false,
+		},
+		{
+			"LINESTRING covers subline of itself from the beginning",
+			"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0)",
+			"LINESTRING(1.0 1.0, 1.5 1.5001714, 2.0 2.0, 2.5 2.5002856, 3.0 3.0)",
+			true,
+		},
+		{
+			"LINESTRING covers subline of itself from the beginning (swapped a and b)",
+			"LINESTRING(1.0 1.0, 1.5 1.5001714, 2.0 2.0, 2.5 2.5002856, 3.0 3.0)",
+			"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0)",
+			true,
+		},
+		{
+			"LINESTRING covers subline of itself from the beginning (reversed)",
+			"LINESTRING(1.0 1.0, 1.5 1.5001714, 2.0 2.0, 2.5 2.5002856, 3.0 3.0)",
+			"LINESTRING(3.0 3.0, 2.0 2.0, 1.0 1.0)",
+			true,
+		},
+		{
+			"LINESTRING covers a substring of itself",
+			"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0)",
+			"LINESTRING(1.0 1.0, 2.0 2.0)",
+			true,
+		},
+		{
+			"LINESTRING covers a substring of itself",
+			"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0)",
+			"LINESTRING(2.0 2.0, 3.0 3.0)",
+			true,
+		},
+		{
+			"LINESTRING covers a substring of itself",
+			"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0, 4.0 4.0)",
+			"LINESTRING(2.0 2.0, 3.0 3.0)",
+			true,
+		},
+		{
+			"LINESTRING does not cover any POLYGON",
+			"POINT(1.0 1.0)",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			false,
+		},
+		{
+			"POLYGON covers POINT inside",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			"POINT(0.5 0.5)",
+			true,
+		},
+		{
+			"POLYGON does not cover POINT outside",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			"POINT(0.5 5.5)",
+			false,
+		},
+		{
+			"POLYGON does not cover POINT in hole",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0), (0.2 0.2, 0.2 0.4, 0.4 0.4, 0.4 0.2, 0.2 0.2))",
+			"POINT(0.3 0.3)",
+			false,
+		},
+		{
+			"POLYGON covers POINT on vertex",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			"POINT(1.0 0.0)",
+			true,
+		},
+		{
+			"POLYGON covers POINT on edge of vertex",
+			"POLYGON((1.0 1.0, 2.0 2.0, 0.0 2.0, 1.0 1.0))",
+			"POINT(1.5 1.5001714)",
+			true,
+		},
+		{
+			"POLYGON covers LINESTRING inside the POLYGON",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			"LINESTRING(0.1 0.1, 0.4 0.4)",
+			true,
+		},
+		{
+			"POLYGON does not cover LINESTRING in hole",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0), (0.2 0.2, 0.2 0.4, 0.4 0.4, 0.4 0.2, 0.2 0.2))",
+			"LINESTRING(0.3 0.3, 0.35 0.35)",
+			false,
+		},
+		{
+			"POLYGON does not cover LINESTRING intersecting with hole",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0), (0.2 0.2, 0.2 0.4, 0.4 0.4, 0.4 0.2, 0.2 0.2))",
+			"LINESTRING(0.3 0.3, 0.55 0.55)",
+			false,
+		},
+		{
+			"POLYGON does not cover LINESTRING intersecting with hole and outside",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0), (0.2 0.2, 0.2 0.4, 0.4 0.4, 0.4 0.2, 0.2 0.2))",
+			"LINESTRING(0.3 0.3, 4.0 4.0)",
+			false,
+		},
+		{
+			"POLYGON does not cover LINESTRING outside the POLYGON",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			"LINESTRING(-1 -1, -2 -2)",
+			false,
+		},
+		{
+			"POLYGON does not cover LINESTRING intersecting the POLYGON",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			"LINESTRING(-0.5 -0.5, 0.5 0.5)",
+			false,
+		},
+		{
+			"POLYGON covers itself",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			true,
+		},
+		{
+			"POLYGON covers a window of itself, intersecting with the edges",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			"POLYGON((0.2 0.2, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.2 0.2))",
+			true,
+		},
+		{
+			"POLYGON covers a nested version of itself",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			"POLYGON((0.1 0.1, 0.2 0.1, 0.2 0.2, 0.1 0.2, 0.1 0.1))",
+			true,
+		},
+		{
+			"POLYGON does not cover POLYGON intersecting",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			"POLYGON((-1.0 0.0, 1.0 0.0, 1.0 1.0, -1.0 1.0, -1.0 0.0))",
+			false,
+		},
+		{
+			"POLYGON does not cover POLYGON totally out of range",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			"POLYGON((3.0 3.0, 4.0 3.0, 4.0 4.0, 3.0 4.0, 3.0 3.0))",
+			false,
+		},
+		{
+			"MULTIPOINT covers single MULTIPOINT",
+			"MULTIPOINT((1.0 1.0), (2.0 2.0))",
+			"MULTIPOINT((2.0 2.0))",
+			true,
+		},
+		{
+			"MULTIPOINT not covered by multiple MULTI POINTs",
+			"MULTIPOINT((1.0 1.0))",
+			"MULTIPOINT((1.0 1.0), (2.0 2.0))",
+			false,
+		},
+		{
+			"MULTILINESTRING covers MULTIPOINTs",
+			"MULTILINESTRING((1.0 1.0, 1.1 1.1), (2.0 2.0, 2.1 2.1))",
+			"MULTIPOINT(2.0 2.0, 2.1 2.1)",
+			true,
+		},
+		{
+			"MULTILINESTRING does not cover all MULTIPOINTs",
+			"MULTILINESTRING((1.0 1.0, 1.1 1.1), (2.0 2.0, 2.1 2.1))",
+			"MULTIPOINT(2.0 2.0, 1.0 1.0, 3.0 3.0)",
+			false,
+		},
+		{
+			"MULTILINESTRING covers all MULTILINESTRING",
+			"MULTILINESTRING((1.0 1.0, 2.0 2.0), (2.0 2.0, 2.1 2.1), (3.0 3.0, 3.1 3.1))",
+			"MULTILINESTRING((1.0 1.0, 1.5 1.5001714), (1.5 1.5001714, 2.0 2.0))",
+			true,
+		},
+		{
+			"MULTILINESTRING does not cover all MULTILINESTRING",
+			"MULTILINESTRING((1.0 1.0, 1.1 1.1), (2.0 2.0, 2.1 2.1), (3.0 3.0, 3.1 3.1))",
+			"MULTILINESTRING((2.0 2.0, 2.1 2.1), (4.0 3.0, 3.1 3.1))",
+			false,
+		},
+		{
+			"MULTIPOLYGON covers MULTIPOINT",
+			"MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5)))",
+			"MULTIPOINT((30 20), (30 30))",
+			true,
+		},
+		{
+			"MULTIPOLYGON does not cover MULTIPOINT",
+			"MULTIPOLYGON (((15 5, 40 10, 10 20, 5 10, 15 5)),((30 20, 45 40, 10 40, 30 20)))",
+			"MULTIPOINT((30 20), (30 30), (45 66))",
+			false,
+		},
+		{
+			"MULTIPOLYGON does not cover MULTIPOINT",
+			"MULTIPOLYGON (((15 5, 40 10, 10 20, 5 10, 15 5)),((30 20, 45 40, 10 40, 30 20)))",
+			"MULTIPOINT((30 20), (30 30), (45 66))",
+			false,
+		},
+		{
+			"MULTIPOLYGON does not cover MULTILINESTRING intersecting at the edge (known edge case *should* return true)",
+			"MULTIPOLYGON (((15 5, 40 10, 10 20, 5 10, 15 5)),((30 20, 45 40, 10 40, 30 20)))",
+			"MULTILINESTRING((45 40, 10 40), (45 40, 10 40, 30 20))",
+			false,
+		},
+		{
+			"MULTIPOLYGON does not cover MULTILINESTRING",
+			"MULTIPOLYGON (((15 5, 40 10, 10 20, 5 10, 15 5)),((30 20, 45 40, 10 40, 30 20)))",
+			"MULTILINESTRING((45 40, 10 40), (45 40, 10 40, 30 11))",
+			false,
+		},
+		{
+			"MULTIPOLYGON covers MULTIPOLYGON",
+			"MULTIPOLYGON (((15 5, 40 10, 10 20, 5 10, 15 5)),((30 20, 45 40, 10 40, 30 20)))",
+			"MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)))",
+			true,
+		},
+		{
+			"MULTIPOLYGON does not cover MULTIPOLYGON",
+			"MULTIPOLYGON (((15 5, 40 10, 10 20, 5 10, 15 5)),((30 20, 45 40, 10 40, 30 20)))",
+			"MULTIPOLYGON (((30 20, 45 40, 15 45, 30 20)))",
+			false,
+		},
+		{
+			"multiple MULTIPOLYGONs required to cover MULTIPOINTS",
+			"MULTIPOLYGON(((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0)), ((1.0 0.0, 2.0 0.0, 2.0 1.0, 1.0 1.0, 1.0 0.0)))",
+			"MULTIPOINT((0.5 0.5), (1.5 0.5))'",
+			true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			a, err := geo.ParseGeography(tc.a)
+			require.NoError(t, err)
+			b, err := geo.ParseGeography(tc.b)
+			require.NoError(t, err)
+
+			covers, err := Covers(a, b)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, covers)
+
+			coveredBy, err := CoveredBy(b, a)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, coveredBy)
+		})
+	}
+}


### PR DESCRIPTION
This commit introduces covers using the primitives available in S2. Most
of the nitty gritty is in comments - but the main thing to note is that
we are introducing a "within 1cm" of accuracy (as intersects is very very
painful in a spheroid), which in geography terms should be good enough^TM
for any application and is line with what S2 provides for it's
primitives.

Note PostGIS has a 0.00001m (0.001cm) tolerance for ST_Intersects.

Release note: None

