### PR TITLE
kvserver/reports: misc improvements

### DIFF
--- a/pkg/kv/kvserver/reports/constraint_stats_report.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report.go
@@ -36,25 +36,19 @@ const replicationConstraintsReportID reportID = 1
 // the cluster's data.
 type ConstraintReport map[ConstraintStatusKey]ConstraintStatus
 
-// ReplicationConstraintStatsReportSaver manages the content and the saving of the report.
+// replicationConstraintStatsReportSaver deals with saving a ConstrainReport to
+// the database. The idea is for it to be used to save new version of the report
+// over and over. It maintains the previously-saved version of the report in
+// order to speed-up the saving of the next one.
 type replicationConstraintStatsReportSaver struct {
 	previousVersion     ConstraintReport
 	lastGenerated       time.Time
 	lastUpdatedRowCount int
-
-	constraints ConstraintReport
 }
 
 // makeReplicationConstraintStatusReportSaver creates a new report saver.
 func makeReplicationConstraintStatusReportSaver() replicationConstraintStatsReportSaver {
-	return replicationConstraintStatsReportSaver{
-		constraints: ConstraintReport{},
-	}
-}
-
-// resetReport resets the report to an empty state.
-func (r *replicationConstraintStatsReportSaver) resetReport() {
-	r.constraints = ConstraintReport{}
+	return replicationConstraintStatsReportSaver{}
 }
 
 // LastUpdatedRowCount is the count of the rows that were touched during the last save.
@@ -121,41 +115,35 @@ func (k ConstraintStatusKey) Less(other ConstraintStatusKey) bool {
 
 // AddViolation add a constraint that is being violated for a given range. Each call
 // will increase the number of ranges that failed.
-func (r *replicationConstraintStatsReportSaver) AddViolation(
-	z ZoneKey, t ConstraintType, c ConstraintRepr,
-) {
+func (r ConstraintReport) AddViolation(z ZoneKey, t ConstraintType, c ConstraintRepr) {
 	k := ConstraintStatusKey{
 		ZoneKey:       z,
 		ViolationType: t,
 		Constraint:    c,
 	}
-	if _, ok := r.constraints[k]; !ok {
-		r.constraints[k] = ConstraintStatus{}
+	if _, ok := r[k]; !ok {
+		r[k] = ConstraintStatus{}
 	}
-	cRep := r.constraints[k]
+	cRep := r[k]
 	cRep.FailRangeCount++
-	r.constraints[k] = cRep
+	r[k] = cRep
 }
 
-// EnsureEntry us used to add an entry to the report even if there is no violation.
-func (r *replicationConstraintStatsReportSaver) EnsureEntry(
-	z ZoneKey, t ConstraintType, c ConstraintRepr,
-) {
+// ensureEntry us used to add an entry to the report even if there is no violation.
+func (r ConstraintReport) ensureEntry(z ZoneKey, t ConstraintType, c ConstraintRepr) {
 	k := ConstraintStatusKey{
 		ZoneKey:       z,
 		ViolationType: t,
 		Constraint:    c,
 	}
-	if _, ok := r.constraints[k]; !ok {
-		r.constraints[k] = ConstraintStatus{}
+	if _, ok := r[k]; !ok {
+		r[k] = ConstraintStatus{}
 	}
 }
 
-func (r *replicationConstraintStatsReportSaver) ensureEntries(
-	key ZoneKey, zone *zonepb.ZoneConfig,
-) {
+func (r ConstraintReport) ensureEntries(key ZoneKey, zone *zonepb.ZoneConfig) {
 	for _, conjunction := range zone.Constraints {
-		r.EnsureEntry(key, Constraint, ConstraintRepr(conjunction.String()))
+		r.ensureEntry(key, Constraint, ConstraintRepr(conjunction.String()))
 	}
 	for i, sz := range zone.Subzones {
 		szKey := ZoneKey{ZoneID: key.ZoneID, SubzoneID: base.SubzoneIDFromIndex(i)}
@@ -204,11 +192,6 @@ func (r *replicationConstraintStatsReportSaver) loadPreviousVersion(
 	return nil
 }
 
-func (r *replicationConstraintStatsReportSaver) updatePreviousVersion() {
-	r.previousVersion = r.constraints
-	r.constraints = make(ConstraintReport, len(r.previousVersion))
-}
-
 func (r *replicationConstraintStatsReportSaver) updateTimestamp(
 	ctx context.Context, ex sqlutil.InternalExecutor, txn *kv.Txn, reportTS time.Time,
 ) error {
@@ -231,11 +214,17 @@ func (r *replicationConstraintStatsReportSaver) updateTimestamp(
 	return err
 }
 
-// Save the report.
+// Save the report in the database.
 //
+// report should not be used by the caller any more after this call; the callee
+// takes ownership.
 // reportTS is the time that will be set in the updated_at column for every row.
 func (r *replicationConstraintStatsReportSaver) Save(
-	ctx context.Context, reportTS time.Time, db *kv.DB, ex sqlutil.InternalExecutor,
+	ctx context.Context,
+	report ConstraintReport,
+	reportTS time.Time,
+	db *kv.DB,
+	ex sqlutil.InternalExecutor,
 ) error {
 	r.lastUpdatedRowCount = 0
 	if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
@@ -249,7 +238,7 @@ func (r *replicationConstraintStatsReportSaver) Save(
 			return err
 		}
 
-		for k, zoneCons := range r.constraints {
+		for k, zoneCons := range report {
 			if err := r.upsertConstraintStatus(
 				ctx, reportTS, txn, k, zoneCons.FailRangeCount, db, ex,
 			); err != nil {
@@ -258,7 +247,7 @@ func (r *replicationConstraintStatsReportSaver) Save(
 		}
 
 		for key := range r.previousVersion {
-			if _, ok := r.constraints[key]; !ok {
+			if _, ok := report[key]; !ok {
 				_, err := ex.Exec(
 					ctx,
 					"delete-old-replication-constraint-stats",
@@ -284,7 +273,7 @@ func (r *replicationConstraintStatsReportSaver) Save(
 	}
 
 	r.lastGenerated = reportTS
-	r.updatePreviousVersion()
+	r.previousVersion = report
 
 	return nil
 }
@@ -352,7 +341,9 @@ type constraintConformanceVisitor struct {
 	cfg           *config.SystemConfig
 	storeResolver StoreResolver
 
-	report   *replicationConstraintStatsReportSaver
+	// report is the output of the visitor. visit*() methods populate it.
+	// After visiting all the ranges, it can be retrieved with Report().
+	report   ConstraintReport
 	visitErr bool
 
 	// prevZoneKey and prevConstraints maintain state from one range to the next.
@@ -365,15 +356,11 @@ type constraintConformanceVisitor struct {
 var _ rangeVisitor = &constraintConformanceVisitor{}
 
 func makeConstraintConformanceVisitor(
-	ctx context.Context,
-	cfg *config.SystemConfig,
-	storeResolver StoreResolver,
-	saver *replicationConstraintStatsReportSaver,
+	ctx context.Context, cfg *config.SystemConfig, storeResolver StoreResolver,
 ) constraintConformanceVisitor {
 	v := constraintConformanceVisitor{
 		cfg:           cfg,
 		storeResolver: storeResolver,
-		report:        saver,
 	}
 	v.reset(ctx)
 	return v
@@ -384,14 +371,19 @@ func (v *constraintConformanceVisitor) failed() bool {
 	return v.visitErr
 }
 
+// Report returns the ConstraintReport that was populated by previous visit*()
+// calls.
+func (v *constraintConformanceVisitor) Report() ConstraintReport {
+	return v.report
+}
+
 // reset is part of the rangeVisitor interface.
 func (v *constraintConformanceVisitor) reset(ctx context.Context) {
 	*v = constraintConformanceVisitor{
 		cfg:           v.cfg,
 		storeResolver: v.storeResolver,
-		report:        v.report,
+		report:        make(ConstraintReport, len(v.report)),
 	}
-	v.report.resetReport()
 
 	// Iterate through all the zone configs to create report entries for all the
 	// zones that have constraints. Otherwise, just iterating through the ranges

--- a/pkg/kv/kvserver/reports/constraint_stats_report.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report.go
@@ -386,9 +386,11 @@ func (v *constraintConformanceVisitor) failed() bool {
 
 // reset is part of the rangeVisitor interface.
 func (v *constraintConformanceVisitor) reset(ctx context.Context) {
-	v.visitErr = false
-	v.prevZoneKey = ZoneKey{}
-	v.prevConstraints = nil
+	*v = constraintConformanceVisitor{
+		cfg:           v.cfg,
+		storeResolver: v.storeResolver,
+		report:        v.report,
+	}
 	v.report.resetReport()
 
 	// Iterate through all the zone configs to create report entries for all the

--- a/pkg/kv/kvserver/reports/constraint_stats_report.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report.go
@@ -438,9 +438,8 @@ func (v *constraintConformanceVisitor) visitNewZone(
 // visitSameZone is part of the rangeVisitor interface.
 func (v *constraintConformanceVisitor) visitSameZone(
 	ctx context.Context, r *roachpb.RangeDescriptor,
-) (retErr error) {
+) {
 	v.countRange(ctx, r, v.prevZoneKey, v.prevConstraints)
-	return nil
 }
 
 func (v *constraintConformanceVisitor) countRange(

--- a/pkg/kv/kvserver/reports/critical_localities_report.go
+++ b/pkg/kv/kvserver/reports/critical_localities_report.go
@@ -283,6 +283,7 @@ func makeLocalityStatsVisitor(
 		nodeChecker:         nodeChecker,
 		report:              saver,
 	}
+	v.reset(ctx)
 	return v
 }
 
@@ -293,7 +294,13 @@ func (v *criticalLocalitiesVisitor) failed() bool {
 
 // reset is part of the rangeVisitor interface.
 func (v *criticalLocalitiesVisitor) reset(ctx context.Context) {
-	v.visitErr = false
+	*v = criticalLocalitiesVisitor{
+		localityConstraints: v.localityConstraints,
+		cfg:                 v.cfg,
+		storeResolver:       v.storeResolver,
+		nodeChecker:         v.nodeChecker,
+		report:              v.report,
+	}
 	v.report.resetReport()
 }
 

--- a/pkg/kv/kvserver/reports/critical_localities_report.go
+++ b/pkg/kv/kvserver/reports/critical_localities_report.go
@@ -343,6 +343,12 @@ func (v *criticalLocalitiesVisitor) countRange(
 	ctx context.Context, zoneKey ZoneKey, r *roachpb.RangeDescriptor,
 ) error {
 	stores := v.storeResolver(r)
+	// TODO(andrei): We're about to iterate through all the localities in the
+	// cluster and consider each one in relation to the current range. That's
+	// inefficient, since most localities will have nothing to do with the range -
+	// most localities will not have any replica of the range. Such localities are
+	// obviously not critical for the range. We should only iterate through the
+	// localities of the range's replicas.
 	for _, c := range v.localityConstraints {
 		if err := processLocalityForRange(
 			ctx, r, zoneKey, v.report, &c, v.nodeChecker, stores,

--- a/pkg/kv/kvserver/reports/critical_localities_report.go
+++ b/pkg/kv/kvserver/reports/critical_localities_report.go
@@ -47,10 +47,11 @@ type localityStatus struct {
 // applicable zone.
 type LocalityReport map[localityKey]localityStatus
 
-// ReplicationCriticalLocalitiesReportSaver manages the content and the saving
-// of the report.
+// replicationCriticalLocalitiesReportSaver deals with saving a LocalityReport
+// to the database. The idea is for it to be used to save new version of the
+// report over and over. It maintains the previously-saved version of the report
+// in order to speed-up the saving of the next one.
 type replicationCriticalLocalitiesReportSaver struct {
-	localities          LocalityReport
 	previousVersion     LocalityReport
 	lastGenerated       time.Time
 	lastUpdatedRowCount int
@@ -58,14 +59,7 @@ type replicationCriticalLocalitiesReportSaver struct {
 
 // makeReplicationCriticalLocalitiesReportSaver creates a new report saver.
 func makeReplicationCriticalLocalitiesReportSaver() replicationCriticalLocalitiesReportSaver {
-	return replicationCriticalLocalitiesReportSaver{
-		localities: LocalityReport{},
-	}
-}
-
-// resetReport resets the report to an empty state.
-func (r *replicationCriticalLocalitiesReportSaver) resetReport() {
-	r.localities = LocalityReport{}
+	return replicationCriticalLocalitiesReportSaver{}
 }
 
 // LastUpdatedRowCount is the count of the rows that were touched during the last save.
@@ -73,20 +67,21 @@ func (r *replicationCriticalLocalitiesReportSaver) LastUpdatedRowCount() int {
 	return r.lastUpdatedRowCount
 }
 
-// AddCriticalLocality will add locality to the list of the critical localities.
-func (r *replicationCriticalLocalitiesReportSaver) AddCriticalLocality(
-	zKey ZoneKey, loc LocalityRepr,
-) {
+// CountRangeAtRisk increments the number of ranges at-risk for the report entry
+// corresponding to the given zone and locality. In other words, the report will
+// count the respective locality as critical for one more range in the given
+// zone.
+func (r LocalityReport) CountRangeAtRisk(zKey ZoneKey, loc LocalityRepr) {
 	lKey := localityKey{
 		ZoneKey:  zKey,
 		locality: loc,
 	}
-	if _, ok := r.localities[lKey]; !ok {
-		r.localities[lKey] = localityStatus{}
+	if _, ok := r[lKey]; !ok {
+		r[lKey] = localityStatus{}
 	}
-	lStat := r.localities[lKey]
+	lStat := r[lKey]
 	lStat.atRiskRanges++
-	r.localities[lKey] = lStat
+	r[lKey] = lStat
 }
 
 func (r *replicationCriticalLocalitiesReportSaver) loadPreviousVersion(
@@ -129,11 +124,6 @@ func (r *replicationCriticalLocalitiesReportSaver) loadPreviousVersion(
 	return nil
 }
 
-func (r *replicationCriticalLocalitiesReportSaver) updatePreviousVersion() {
-	r.previousVersion = r.localities
-	r.localities = make(LocalityReport, len(r.previousVersion))
-}
-
 func (r *replicationCriticalLocalitiesReportSaver) updateTimestamp(
 	ctx context.Context, ex sqlutil.InternalExecutor, txn *kv.Txn, reportTS time.Time,
 ) error {
@@ -156,11 +146,17 @@ func (r *replicationCriticalLocalitiesReportSaver) updateTimestamp(
 	return err
 }
 
-// Save the report.
+// Save the report to the database.
 //
+// report should not be used by the caller any more after this call; the callee
+// takes ownership.
 // reportTS is the time that will be set in the updated_at column for every row.
 func (r *replicationCriticalLocalitiesReportSaver) Save(
-	ctx context.Context, reportTS time.Time, db *kv.DB, ex sqlutil.InternalExecutor,
+	ctx context.Context,
+	report LocalityReport,
+	reportTS time.Time,
+	db *kv.DB,
+	ex sqlutil.InternalExecutor,
 ) error {
 	r.lastUpdatedRowCount = 0
 	if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
@@ -174,7 +170,7 @@ func (r *replicationCriticalLocalitiesReportSaver) Save(
 			return err
 		}
 
-		for key, status := range r.localities {
+		for key, status := range report {
 			if err := r.upsertLocality(
 				ctx, reportTS, txn, key, status, db, ex,
 			); err != nil {
@@ -183,7 +179,7 @@ func (r *replicationCriticalLocalitiesReportSaver) Save(
 		}
 
 		for key := range r.previousVersion {
-			if _, ok := r.localities[key]; !ok {
+			if _, ok := report[key]; !ok {
 				_, err := ex.Exec(
 					ctx,
 					"delete-old-replication-critical-localities",
@@ -208,7 +204,7 @@ func (r *replicationCriticalLocalitiesReportSaver) Save(
 	}
 
 	r.lastGenerated = reportTS
-	r.updatePreviousVersion()
+	r.previousVersion = report
 
 	return nil
 }
@@ -257,7 +253,9 @@ type criticalLocalitiesVisitor struct {
 	storeResolver       StoreResolver
 	nodeChecker         nodeChecker
 
-	report   *replicationCriticalLocalitiesReportSaver
+	// report is the output of the visitor. visit*() methods populate it.
+	// After visiting all the ranges, it can be retrieved with Report().
+	report   LocalityReport
 	visitErr bool
 
 	// prevZoneKey maintains state from one range to the next. This state can be
@@ -274,14 +272,12 @@ func makeLocalityStatsVisitor(
 	cfg *config.SystemConfig,
 	storeResolver StoreResolver,
 	nodeChecker nodeChecker,
-	saver *replicationCriticalLocalitiesReportSaver,
 ) criticalLocalitiesVisitor {
 	v := criticalLocalitiesVisitor{
 		localityConstraints: localityConstraints,
 		cfg:                 cfg,
 		storeResolver:       storeResolver,
 		nodeChecker:         nodeChecker,
-		report:              saver,
 	}
 	v.reset(ctx)
 	return v
@@ -292,6 +288,12 @@ func (v *criticalLocalitiesVisitor) failed() bool {
 	return v.visitErr
 }
 
+// Report returns the LocalityReport that was populated by previous visit*()
+// calls.
+func (v *criticalLocalitiesVisitor) Report() LocalityReport {
+	return v.report
+}
+
 // reset is part of the rangeVisitor interface.
 func (v *criticalLocalitiesVisitor) reset(ctx context.Context) {
 	*v = criticalLocalitiesVisitor{
@@ -299,9 +301,8 @@ func (v *criticalLocalitiesVisitor) reset(ctx context.Context) {
 		cfg:                 v.cfg,
 		storeResolver:       v.storeResolver,
 		nodeChecker:         v.nodeChecker,
-		report:              v.report,
+		report:              make(LocalityReport, len(v.report)),
 	}
-	v.report.resetReport()
 }
 
 // visitNewZone is part of the rangeVisitor interface.
@@ -372,7 +373,7 @@ func processLocalityForRange(
 	ctx context.Context,
 	r *roachpb.RangeDescriptor,
 	zoneKey ZoneKey,
-	rep *replicationCriticalLocalitiesReportSaver,
+	rep LocalityReport,
 	c *zonepb.ConstraintsConjunction,
 	nodeChecker nodeChecker,
 	storeDescs []roachpb.StoreDescriptor,
@@ -419,7 +420,7 @@ func processLocalityForRange(
 	// If the live nodes outside of the given locality are not enough to
 	// form quorum then this locality is critical.
 	if quorumCount > liveNodeCount-passCount {
-		rep.AddCriticalLocality(zoneKey, loc)
+		rep.CountRangeAtRisk(zoneKey, loc)
 	}
 	return nil
 }

--- a/pkg/kv/kvserver/reports/critical_localities_report.go
+++ b/pkg/kv/kvserver/reports/critical_localities_report.go
@@ -356,24 +356,18 @@ func (v *criticalLocalitiesVisitor) visitNewZone(
 	}
 	v.prevZoneKey = zKey
 
-	return v.countRange(ctx, zKey, r)
+	v.countRange(ctx, zKey, r)
+	return nil
 }
 
 // visitSameZone is part of the rangeVisitor interface.
-func (v *criticalLocalitiesVisitor) visitSameZone(
-	ctx context.Context, r *roachpb.RangeDescriptor,
-) (retErr error) {
-	defer func() {
-		if retErr != nil {
-			v.visitErr = true
-		}
-	}()
-	return v.countRange(ctx, v.prevZoneKey, r)
+func (v *criticalLocalitiesVisitor) visitSameZone(ctx context.Context, r *roachpb.RangeDescriptor) {
+	v.countRange(ctx, v.prevZoneKey, r)
 }
 
 func (v *criticalLocalitiesVisitor) countRange(
 	ctx context.Context, zoneKey ZoneKey, r *roachpb.RangeDescriptor,
-) error {
+) {
 	stores := v.storeResolver(r)
 
 	// Collect all the localities of all the replicas. Note that we collect
@@ -393,13 +387,8 @@ func (v *criticalLocalitiesVisitor) countRange(
 	// Any of the localities of any of the nodes could be critical. We'll check
 	// them one by one.
 	for _, loc := range dedupLocal {
-		if err := processLocalityForRange(
-			ctx, r, zoneKey, v.report, loc, v.nodeChecker, stores,
-		); err != nil {
-			return err
-		}
+		processLocalityForRange(ctx, r, zoneKey, v.report, loc, v.nodeChecker, stores)
 	}
-	return nil
 }
 
 // processLocalityForRange checks a single locality constraint against a
@@ -412,7 +401,7 @@ func processLocalityForRange(
 	loc roachpb.Locality,
 	nodeChecker nodeChecker,
 	storeDescs []roachpb.StoreDescriptor,
-) error {
+) {
 	// Compute the required quorum and the number of live nodes. If the number of
 	// live nodes gets lower than the required quorum then the range is already
 	// unavailable.
@@ -465,5 +454,4 @@ func processLocalityForRange(
 	if quorumCount > liveNodeCount-passCount {
 		rep.CountRangeAtRisk(zoneKey, locStr)
 	}
-	return nil
 }

--- a/pkg/kv/kvserver/reports/critical_localities_report.go
+++ b/pkg/kv/kvserver/reports/critical_localities_report.go
@@ -266,7 +266,7 @@ type criticalLocalitiesVisitor struct {
 
 var _ rangeVisitor = &criticalLocalitiesVisitor{}
 
-func makeLocalityStatsVisitor(
+func makeCriticalLocalitiesVisitor(
 	ctx context.Context,
 	localityConstraints []zonepb.ConstraintsConjunction,
 	cfg *config.SystemConfig,

--- a/pkg/kv/kvserver/reports/critical_localities_report.go
+++ b/pkg/kv/kvserver/reports/critical_localities_report.go
@@ -12,8 +12,6 @@ package reports
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -248,10 +246,10 @@ func (r *replicationCriticalLocalitiesReportSaver) upsertLocality(
 // criticalLocalitiesVisitor is a visitor that, when passed to visitRanges(), builds
 // a LocalityReport.
 type criticalLocalitiesVisitor struct {
-	localityConstraints []zonepb.ConstraintsConjunction
-	cfg                 *config.SystemConfig
-	storeResolver       StoreResolver
-	nodeChecker         nodeChecker
+	allLocalities map[roachpb.NodeID]map[string]roachpb.Locality
+	cfg           *config.SystemConfig
+	storeResolver StoreResolver
+	nodeChecker   nodeChecker
 
 	// report is the output of the visitor. visit*() methods populate it.
 	// After visiting all the ranges, it can be retrieved with Report().
@@ -268,19 +266,45 @@ var _ rangeVisitor = &criticalLocalitiesVisitor{}
 
 func makeCriticalLocalitiesVisitor(
 	ctx context.Context,
-	localityConstraints []zonepb.ConstraintsConjunction,
+	nodeLocalities map[roachpb.NodeID]roachpb.Locality,
 	cfg *config.SystemConfig,
 	storeResolver StoreResolver,
 	nodeChecker nodeChecker,
 ) criticalLocalitiesVisitor {
+	allLocalities := expandLocalities(nodeLocalities)
 	v := criticalLocalitiesVisitor{
-		localityConstraints: localityConstraints,
-		cfg:                 cfg,
-		storeResolver:       storeResolver,
-		nodeChecker:         nodeChecker,
+		allLocalities: allLocalities,
+		cfg:           cfg,
+		storeResolver: storeResolver,
+		nodeChecker:   nodeChecker,
 	}
 	v.reset(ctx)
 	return v
+}
+
+// expandLocalities expands each locality in its input into multiple localities,
+// each at a different level of granularity. For example the locality
+// "region=r1,dc=dc1,az=az1" is expanded into ["region=r1", "region=r1,dc=dc1",
+// "region=r1,dc=dc1,az=az1"].
+// The localities are returned in a format convenient for the
+// criticalLocalitiesVisitor.
+func expandLocalities(
+	nodeLocalities map[roachpb.NodeID]roachpb.Locality,
+) map[roachpb.NodeID]map[string]roachpb.Locality {
+	res := make(map[roachpb.NodeID]map[string]roachpb.Locality)
+	for nid, loc := range nodeLocalities {
+		if len(loc.Tiers) == 0 {
+			res[nid] = nil
+			continue
+		}
+		res[nid] = make(map[string]roachpb.Locality, len(loc.Tiers))
+		for i := range loc.Tiers {
+			partialLoc := roachpb.Locality{Tiers: make([]roachpb.Tier, i+1)}
+			copy(partialLoc.Tiers, loc.Tiers[:i+1])
+			res[nid][partialLoc.String()] = partialLoc
+		}
+	}
+	return res
 }
 
 // failed is part of the rangeVisitor interface.
@@ -297,11 +321,11 @@ func (v *criticalLocalitiesVisitor) Report() LocalityReport {
 // reset is part of the rangeVisitor interface.
 func (v *criticalLocalitiesVisitor) reset(ctx context.Context) {
 	*v = criticalLocalitiesVisitor{
-		localityConstraints: v.localityConstraints,
-		cfg:                 v.cfg,
-		storeResolver:       v.storeResolver,
-		nodeChecker:         v.nodeChecker,
-		report:              make(LocalityReport, len(v.report)),
+		allLocalities: v.allLocalities,
+		cfg:           v.cfg,
+		storeResolver: v.storeResolver,
+		nodeChecker:   v.nodeChecker,
+		report:        make(LocalityReport, len(v.report)),
 	}
 }
 
@@ -351,15 +375,26 @@ func (v *criticalLocalitiesVisitor) countRange(
 	ctx context.Context, zoneKey ZoneKey, r *roachpb.RangeDescriptor,
 ) error {
 	stores := v.storeResolver(r)
-	// TODO(andrei): We're about to iterate through all the localities in the
-	// cluster and consider each one in relation to the current range. That's
-	// inefficient, since most localities will have nothing to do with the range -
-	// most localities will not have any replica of the range. Such localities are
-	// obviously not critical for the range. We should only iterate through the
-	// localities of the range's replicas.
-	for _, c := range v.localityConstraints {
+
+	// Collect all the localities of all the replicas. Note that we collect
+	// "expanded" localities: if a replica has a multi-tier locality like
+	// "region:us-east,dc=new-york", we collect both "region:us-east" and
+	// "region:us-east,dc=new-york".
+	dedupLocal := make(map[string]roachpb.Locality)
+	for _, rep := range r.Replicas().All() {
+		for s, loc := range v.allLocalities[rep.NodeID] {
+			if _, ok := dedupLocal[s]; ok {
+				continue
+			}
+			dedupLocal[s] = loc
+		}
+	}
+
+	// Any of the localities of any of the nodes could be critical. We'll check
+	// them one by one.
+	for _, loc := range dedupLocal {
 		if err := processLocalityForRange(
-			ctx, r, zoneKey, v.report, &c, v.nodeChecker, stores,
+			ctx, r, zoneKey, v.report, loc, v.nodeChecker, stores,
 		); err != nil {
 			return err
 		}
@@ -374,7 +409,7 @@ func processLocalityForRange(
 	r *roachpb.RangeDescriptor,
 	zoneKey ZoneKey,
 	rep LocalityReport,
-	c *zonepb.ConstraintsConjunction,
+	loc roachpb.Locality,
 	nodeChecker nodeChecker,
 	storeDescs []roachpb.StoreDescriptor,
 ) error {
@@ -395,12 +430,20 @@ func processLocalityForRange(
 		}
 	}
 
-	cstrs := make([]string, 0, len(c.Constraints))
-	for _, con := range c.Constraints {
-		cstrs = append(cstrs, fmt.Sprintf("%s=%s", con.Key, con.Value))
+	localityToConstraints := func(loc roachpb.Locality) zonepb.ConstraintsConjunction {
+		c := zonepb.ConstraintsConjunction{
+			Constraints: make([]zonepb.Constraint, 0, len(loc.Tiers)),
+		}
+		for _, tier := range loc.Tiers {
+			c.Constraints = append(c.Constraints, zonepb.Constraint{
+				Type: zonepb.Constraint_REQUIRED, Key: tier.Key, Value: tier.Value,
+			})
+		}
+		return c
 	}
-	loc := LocalityRepr(strings.Join(cstrs, ","))
 
+	locStr := LocalityRepr(loc.String())
+	c := localityToConstraints(loc)
 	passCount := 0
 	for _, storeDesc := range storeDescs {
 		storeHasConstraint := true
@@ -420,7 +463,7 @@ func processLocalityForRange(
 	// If the live nodes outside of the given locality are not enough to
 	// form quorum then this locality is critical.
 	if quorumCount > liveNodeCount-passCount {
-		rep.CountRangeAtRisk(zoneKey, loc)
+		rep.CountRangeAtRisk(zoneKey, locStr)
 	}
 	return nil
 }

--- a/pkg/kv/kvserver/reports/critical_localities_report_test.go
+++ b/pkg/kv/kvserver/reports/critical_localities_report_test.go
@@ -41,14 +41,16 @@ func TestLocalityReport(t *testing.T) {
 	require.ElementsMatch(t, TableData(ctx, "system.reports_meta", con), [][]string{})
 
 	// Add several localities and verify the result
-	r := makeReplicationCriticalLocalitiesReportSaver()
-	r.AddCriticalLocality(MakeZoneKey(1, 3), "region=US")
-	r.AddCriticalLocality(MakeZoneKey(5, 6), "dc=A")
-	r.AddCriticalLocality(MakeZoneKey(7, 8), "dc=B")
-	r.AddCriticalLocality(MakeZoneKey(7, 8), "dc=B")
+	report := make(LocalityReport)
+	report.CountRangeAtRisk(MakeZoneKey(1, 3), "region=US")
+	report.CountRangeAtRisk(MakeZoneKey(5, 6), "dc=A")
+	report.CountRangeAtRisk(MakeZoneKey(7, 8), "dc=B")
+	report.CountRangeAtRisk(MakeZoneKey(7, 8), "dc=B")
 
 	time1 := time.Date(2001, 1, 1, 10, 0, 0, 0, time.UTC)
-	require.NoError(t, r.Save(ctx, time1, db, con))
+	saver := makeReplicationCriticalLocalitiesReportSaver()
+	require.NoError(t, saver.Save(ctx, report, time1, db, con))
+	report = make(LocalityReport)
 
 	require.ElementsMatch(t, TableData(ctx, "system.replication_critical_localities", con), [][]string{
 		{"1", "3", "'region=US'", "2", "1"},
@@ -58,17 +60,18 @@ func TestLocalityReport(t *testing.T) {
 	require.ElementsMatch(t, TableData(ctx, "system.reports_meta", con), [][]string{
 		{"2", "'2001-01-01 10:00:00+00:00'"},
 	})
-	require.Equal(t, 3, r.LastUpdatedRowCount())
+	require.Equal(t, 3, saver.LastUpdatedRowCount())
 
 	// Add new set of localities and verify the old ones are deleted
-	r.AddCriticalLocality(MakeZoneKey(5, 6), "dc=A")
-	r.AddCriticalLocality(MakeZoneKey(5, 6), "dc=A")
-	r.AddCriticalLocality(MakeZoneKey(7, 8), "dc=B")
-	r.AddCriticalLocality(MakeZoneKey(7, 8), "dc=B")
-	r.AddCriticalLocality(MakeZoneKey(15, 6), "dc=A")
+	report.CountRangeAtRisk(MakeZoneKey(5, 6), "dc=A")
+	report.CountRangeAtRisk(MakeZoneKey(5, 6), "dc=A")
+	report.CountRangeAtRisk(MakeZoneKey(7, 8), "dc=B")
+	report.CountRangeAtRisk(MakeZoneKey(7, 8), "dc=B")
+	report.CountRangeAtRisk(MakeZoneKey(15, 6), "dc=A")
 
 	time2 := time.Date(2001, 1, 1, 11, 0, 0, 0, time.UTC)
-	require.NoError(t, r.Save(ctx, time2, db, con))
+	require.NoError(t, saver.Save(ctx, report, time2, db, con))
+	report = make(LocalityReport)
 
 	require.ElementsMatch(t, TableData(ctx, "system.replication_critical_localities", con), [][]string{
 		{"5", "6", "'dc=A'", "2", "2"},
@@ -78,7 +81,7 @@ func TestLocalityReport(t *testing.T) {
 	require.ElementsMatch(t, TableData(ctx, "system.reports_meta", con), [][]string{
 		{"2", "'2001-01-01 11:00:00+00:00'"},
 	})
-	require.Equal(t, 3, r.LastUpdatedRowCount())
+	require.Equal(t, 3, saver.LastUpdatedRowCount())
 
 	time3 := time.Date(2001, 1, 1, 11, 30, 0, 0, time.UTC)
 	// If some other server takes over and does an update.
@@ -99,15 +102,16 @@ func TestLocalityReport(t *testing.T) {
 	require.Equal(t, 1, rows)
 
 	// Add new set of localities and verify the old ones are deleted
-	r.AddCriticalLocality(MakeZoneKey(5, 6), "dc=A")
-	r.AddCriticalLocality(MakeZoneKey(5, 6), "dc=A")
-	r.AddCriticalLocality(MakeZoneKey(5, 6), "dc=A")
-	r.AddCriticalLocality(MakeZoneKey(7, 8), "dc=B")
-	r.AddCriticalLocality(MakeZoneKey(7, 8), "dc=B")
-	r.AddCriticalLocality(MakeZoneKey(15, 6), "dc=A")
+	report.CountRangeAtRisk(MakeZoneKey(5, 6), "dc=A")
+	report.CountRangeAtRisk(MakeZoneKey(5, 6), "dc=A")
+	report.CountRangeAtRisk(MakeZoneKey(5, 6), "dc=A")
+	report.CountRangeAtRisk(MakeZoneKey(7, 8), "dc=B")
+	report.CountRangeAtRisk(MakeZoneKey(7, 8), "dc=B")
+	report.CountRangeAtRisk(MakeZoneKey(15, 6), "dc=A")
 
 	time4 := time.Date(2001, 1, 1, 12, 0, 0, 0, time.UTC)
-	require.NoError(t, r.Save(ctx, time4, db, con))
+	require.NoError(t, saver.Save(ctx, report, time4, db, con))
+	report = make(LocalityReport)
 
 	require.ElementsMatch(t, TableData(ctx, "system.replication_critical_localities", con), [][]string{
 		{"5", "6", "'dc=A'", "2", "3"},
@@ -117,14 +121,14 @@ func TestLocalityReport(t *testing.T) {
 	require.ElementsMatch(t, TableData(ctx, "system.reports_meta", con), [][]string{
 		{"2", "'2001-01-01 12:00:00+00:00'"},
 	})
-	require.Equal(t, 2, r.LastUpdatedRowCount())
+	require.Equal(t, 2, saver.LastUpdatedRowCount())
 
 	// A brand new report (after restart for example) - still works.
-	r = makeReplicationCriticalLocalitiesReportSaver()
-	r.AddCriticalLocality(MakeZoneKey(5, 6), "dc=A")
+	saver = makeReplicationCriticalLocalitiesReportSaver()
+	report.CountRangeAtRisk(MakeZoneKey(5, 6), "dc=A")
 
 	time5 := time.Date(2001, 1, 1, 12, 30, 0, 0, time.UTC)
-	require.NoError(t, r.Save(ctx, time5, db, con))
+	require.NoError(t, saver.Save(ctx, report, time5, db, con))
 
 	require.ElementsMatch(t, TableData(ctx, "system.replication_critical_localities", con), [][]string{
 		{"5", "6", "'dc=A'", "2", "1"},
@@ -132,9 +136,10 @@ func TestLocalityReport(t *testing.T) {
 	require.ElementsMatch(t, TableData(ctx, "system.reports_meta", con), [][]string{
 		{"2", "'2001-01-01 12:30:00+00:00'"},
 	})
-	require.Equal(t, 3, r.LastUpdatedRowCount())
+	require.Equal(t, 3, saver.LastUpdatedRowCount())
 }
 
+// TableData reads a table and returns the rows as strings.
 func TableData(
 	ctx context.Context, tableName string, executor sqlutil.InternalExecutor,
 ) [][]string {

--- a/pkg/kv/kvserver/reports/helpers_test.go
+++ b/pkg/kv/kvserver/reports/helpers_test.go
@@ -1,0 +1,40 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package reports
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/config"
+)
+
+// computeConstraintConformanceReport iterates through all the ranges and
+// generates the constraint conformance report.
+func computeConstraintConformanceReport(
+	ctx context.Context,
+	rangeStore RangeIterator,
+	cfg *config.SystemConfig,
+	storeResolver StoreResolver,
+) (ConstraintReport, error) {
+	v := makeConstraintConformanceVisitor(ctx, cfg, storeResolver)
+	err := visitRanges(ctx, rangeStore, cfg, &v)
+	return v.Report(), err
+}
+
+// computeReplicationStatsReport iterates through all the ranges and generates
+// the replication stats report.
+func computeReplicationStatsReport(
+	ctx context.Context, rangeStore RangeIterator, checker nodeChecker, cfg *config.SystemConfig,
+) (RangeReport, error) {
+	v := makeReplicationStatsVisitor(ctx, cfg, checker)
+	err := visitRanges(ctx, rangeStore, cfg, &v)
+	return v.Report(), err
+}

--- a/pkg/kv/kvserver/reports/replication_stats_report.go
+++ b/pkg/kv/kvserver/reports/replication_stats_report.go
@@ -41,9 +41,11 @@ type zoneRangeStatus struct {
 	overReplicated  int32
 }
 
-// replicationStatsReportSaver manages the content and the saving of the report.
+// replicationStatsReportSaver deals with saving a RangeReport to the database.
+// The idea is for it to be used to save new version of the report over and
+// over. It maintains the previously-saved version of the report in order to
+// speed-up the saving of the next one.
 type replicationStatsReportSaver struct {
-	stats               RangeReport
 	previousVersion     RangeReport
 	lastGenerated       time.Time
 	lastUpdatedRowCount int
@@ -51,14 +53,7 @@ type replicationStatsReportSaver struct {
 
 // makeReplicationStatsReportSaver creates a new report saver.
 func makeReplicationStatsReportSaver() replicationStatsReportSaver {
-	return replicationStatsReportSaver{
-		stats: RangeReport{},
-	}
-}
-
-// resetReport resets the report to an empty state.
-func (r *replicationStatsReportSaver) resetReport() {
-	r.stats = RangeReport{}
+	return replicationStatsReportSaver{}
 }
 
 // LastUpdatedRowCount is the count of the rows that were touched during the last save.
@@ -67,18 +62,19 @@ func (r *replicationStatsReportSaver) LastUpdatedRowCount() int {
 }
 
 // EnsureEntry creates an entry for the given key if there is none.
-func (r *replicationStatsReportSaver) EnsureEntry(zKey ZoneKey) {
-	if _, ok := r.stats[zKey]; !ok {
-		r.stats[zKey] = zoneRangeStatus{}
+func (r RangeReport) EnsureEntry(zKey ZoneKey) {
+	if _, ok := r[zKey]; !ok {
+		r[zKey] = zoneRangeStatus{}
 	}
 }
 
-// AddZoneRangeStatus adds a row to the report.
-func (r *replicationStatsReportSaver) AddZoneRangeStatus(
+// CountRange adds one range's info to the report. If there's no entry in the
+// report for the range's zone, a new one is created.
+func (r RangeReport) CountRange(
 	zKey ZoneKey, unavailable bool, underReplicated bool, overReplicated bool,
 ) {
 	r.EnsureEntry(zKey)
-	rStat := r.stats[zKey]
+	rStat := r[zKey]
 	rStat.numRanges++
 	if unavailable {
 		rStat.unavailable++
@@ -89,7 +85,7 @@ func (r *replicationStatsReportSaver) AddZoneRangeStatus(
 	if overReplicated {
 		rStat.overReplicated++
 	}
-	r.stats[zKey] = rStat
+	r[zKey] = rStat
 }
 
 func (r *replicationStatsReportSaver) loadPreviousVersion(
@@ -137,11 +133,6 @@ func (r *replicationStatsReportSaver) loadPreviousVersion(
 	return nil
 }
 
-func (r *replicationStatsReportSaver) updatePreviousVersion() {
-	r.previousVersion = r.stats
-	r.stats = make(RangeReport, len(r.previousVersion))
-}
-
 func (r *replicationStatsReportSaver) updateTimestamp(
 	ctx context.Context, ex sqlutil.InternalExecutor, txn *kv.Txn, reportTS time.Time,
 ) error {
@@ -164,11 +155,17 @@ func (r *replicationStatsReportSaver) updateTimestamp(
 	return err
 }
 
-// Save the report.
+// Save a report in the database.
 //
+// report should not be used by the caller any more after this call; the callee
+// takes ownership.
 // reportTS is the time that will be set in the updated_at column for every row.
 func (r *replicationStatsReportSaver) Save(
-	ctx context.Context, reportTS time.Time, db *kv.DB, ex sqlutil.InternalExecutor,
+	ctx context.Context,
+	report RangeReport,
+	reportTS time.Time,
+	db *kv.DB,
+	ex sqlutil.InternalExecutor,
 ) error {
 	r.lastUpdatedRowCount = 0
 	if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
@@ -182,14 +179,14 @@ func (r *replicationStatsReportSaver) Save(
 			return err
 		}
 
-		for key, status := range r.stats {
+		for key, status := range report {
 			if err := r.upsertStats(ctx, txn, key, status, ex); err != nil {
 				return err
 			}
 		}
 
 		for key := range r.previousVersion {
-			if _, ok := r.stats[key]; !ok {
+			if _, ok := report[key]; !ok {
 				_, err := ex.Exec(
 					ctx,
 					"delete-old-replication-stats",
@@ -213,7 +210,7 @@ func (r *replicationStatsReportSaver) Save(
 	}
 
 	r.lastGenerated = reportTS
-	r.updatePreviousVersion()
+	r.previousVersion = report
 
 	return nil
 }
@@ -253,7 +250,9 @@ type replicationStatsVisitor struct {
 	cfg         *config.SystemConfig
 	nodeChecker nodeChecker
 
-	report   *replicationStatsReportSaver
+	// report is the output of the visitor. visit*() methods populate it.
+	// After visiting all the ranges, it can be retrieved with Report().
+	report   RangeReport
 	visitErr bool
 
 	// prevZoneKey and prevNumReplicas maintain state from one range to the next.
@@ -266,15 +265,12 @@ type replicationStatsVisitor struct {
 var _ rangeVisitor = &replicationStatsVisitor{}
 
 func makeReplicationStatsVisitor(
-	ctx context.Context,
-	cfg *config.SystemConfig,
-	nodeChecker nodeChecker,
-	saver *replicationStatsReportSaver,
+	ctx context.Context, cfg *config.SystemConfig, nodeChecker nodeChecker,
 ) replicationStatsVisitor {
 	v := replicationStatsVisitor{
 		cfg:         cfg,
 		nodeChecker: nodeChecker,
-		report:      saver,
+		report:      make(RangeReport),
 	}
 	v.reset(ctx)
 	return v
@@ -285,15 +281,19 @@ func (v *replicationStatsVisitor) failed() bool {
 	return v.visitErr
 }
 
+// Report returns the RangeReport that was populated by previous visit*() calls.
+func (v *replicationStatsVisitor) Report() RangeReport {
+	return v.report
+}
+
 // reset is part of the rangeVisitor interface.
 func (v *replicationStatsVisitor) reset(ctx context.Context) {
 	*v = replicationStatsVisitor{
 		cfg:             v.cfg,
 		nodeChecker:     v.nodeChecker,
-		report:          v.report,
 		prevNumReplicas: -1,
+		report:          make(RangeReport, len(v.report)),
 	}
-	v.report.resetReport()
 
 	// Iterate through all the zone configs to create report entries for all the
 	// zones that have constraints. Otherwise, just iterating through the ranges
@@ -410,7 +410,7 @@ func (v *replicationStatsVisitor) countRange(
 	// time if it has many replicas, but sufficiently many of them are on dead
 	// nodes.
 
-	v.report.AddZoneRangeStatus(key, unavailable, underReplicated, overReplicated)
+	v.report.CountRange(key, unavailable, underReplicated, overReplicated)
 }
 
 // zoneChangesReplication determines whether a given zone config changes

--- a/pkg/kv/kvserver/reports/replication_stats_report.go
+++ b/pkg/kv/kvserver/reports/replication_stats_report.go
@@ -183,9 +183,7 @@ func (r *replicationStatsReportSaver) Save(
 		}
 
 		for key, status := range r.stats {
-			if err := r.upsertStats(
-				ctx, reportTS, txn, key, status, db, ex,
-			); err != nil {
+			if err := r.upsertStats(ctx, txn, key, status, ex); err != nil {
 				return err
 			}
 		}
@@ -224,13 +222,7 @@ func (r *replicationStatsReportSaver) Save(
 //
 // existing is used to decide is this is a new data.
 func (r *replicationStatsReportSaver) upsertStats(
-	ctx context.Context,
-	reportTS time.Time,
-	txn *kv.Txn,
-	key ZoneKey,
-	stats zoneRangeStatus,
-	db *kv.DB,
-	ex sqlutil.InternalExecutor,
+	ctx context.Context, txn *kv.Txn, key ZoneKey, stats zoneRangeStatus, ex sqlutil.InternalExecutor,
 ) error {
 	var err error
 	previousStats, hasOldVersion := r.previousVersion[key]

--- a/pkg/kv/kvserver/reports/replication_stats_report.go
+++ b/pkg/kv/kvserver/reports/replication_stats_report.go
@@ -219,8 +219,6 @@ func (r *replicationStatsReportSaver) Save(
 }
 
 // upsertStat upserts a row into system.replication_stats.
-//
-// existing is used to decide is this is a new data.
 func (r *replicationStatsReportSaver) upsertStats(
 	ctx context.Context, txn *kv.Txn, key ZoneKey, stats zoneRangeStatus, ex sqlutil.InternalExecutor,
 ) error {

--- a/pkg/kv/kvserver/reports/replication_stats_report.go
+++ b/pkg/kv/kvserver/reports/replication_stats_report.go
@@ -378,11 +378,8 @@ func (v *replicationStatsVisitor) visitNewZone(
 }
 
 // visitSameZone is part of the rangeVisitor interface.
-func (v *replicationStatsVisitor) visitSameZone(
-	ctx context.Context, r *roachpb.RangeDescriptor,
-) error {
+func (v *replicationStatsVisitor) visitSameZone(ctx context.Context, r *roachpb.RangeDescriptor) {
 	v.countRange(v.prevZoneKey, v.prevNumReplicas, r)
-	return nil
 }
 
 func (v *replicationStatsVisitor) countRange(

--- a/pkg/kv/kvserver/reports/replication_stats_report.go
+++ b/pkg/kv/kvserver/reports/replication_stats_report.go
@@ -287,10 +287,13 @@ func (v *replicationStatsVisitor) failed() bool {
 
 // reset is part of the rangeVisitor interface.
 func (v *replicationStatsVisitor) reset(ctx context.Context) {
-	v.visitErr = false
+	*v = replicationStatsVisitor{
+		cfg:             v.cfg,
+		nodeChecker:     v.nodeChecker,
+		report:          v.report,
+		prevNumReplicas: -1,
+	}
 	v.report.resetReport()
-	v.prevZoneKey = ZoneKey{}
-	v.prevNumReplicas = -1
 
 	// Iterate through all the zone configs to create report entries for all the
 	// zones that have constraints. Otherwise, just iterating through the ranges

--- a/pkg/kv/kvserver/reports/reporter.go
+++ b/pkg/kv/kvserver/reports/reporter.go
@@ -200,7 +200,7 @@ func (stats *Reporter) update(
 	// Create the visitors that we're going to pass to visitRanges() below.
 	constraintConfVisitor := makeConstraintConformanceVisitor(
 		ctx, stats.latestConfig, getStoresFromGossip)
-	localityStatsVisitor := makeLocalityStatsVisitor(
+	localityStatsVisitor := makeCriticalLocalitiesVisitor(
 		ctx, localityConstraints, stats.latestConfig,
 		getStoresFromGossip, isNodeLive)
 	replicationStatsVisitor := makeReplicationStatsVisitor(ctx, stats.latestConfig, isNodeLive)

--- a/pkg/kv/kvserver/reports/reporter.go
+++ b/pkg/kv/kvserver/reports/reporter.go
@@ -234,7 +234,7 @@ func (stats *Reporter) update(
 			return errors.Wrap(err, "failed to save locality report")
 		}
 	}
-	if !localityStatsVisitor.failed() {
+	if !statusVisitor.failed() {
 		if err := statusVisitor.report.Save(
 			ctx, timeutil.Now() /* reportTS */, stats.db, stats.executor,
 		); err != nil {

--- a/pkg/kv/kvserver/reports/reporter.go
+++ b/pkg/kv/kvserver/reports/reporter.go
@@ -511,7 +511,7 @@ type rangeVisitor interface {
 	// to multiple ranges, and so visitSameZone() allows them to efficiently reuse
 	// that state (in particular, not unmarshall ZoneConfigs again).
 	visitNewZone(context.Context, *roachpb.RangeDescriptor) error
-	visitSameZone(context.Context, *roachpb.RangeDescriptor) error
+	visitSameZone(context.Context, *roachpb.RangeDescriptor)
 
 	// failed returns true if an error was encountered by the last visit() call
 	// (and reset( ) wasn't called since).
@@ -586,7 +586,7 @@ func visitRanges(
 		for i, v := range visitors {
 			var err error
 			if sameZoneAsPrevRange {
-				err = v.visitSameZone(ctx, &rd)
+				v.visitSameZone(ctx, &rd)
 			} else {
 				err = v.visitNewZone(ctx, &rd)
 			}

--- a/pkg/kv/kvserver/reports/reporter_test.go
+++ b/pkg/kv/kvserver/reports/reporter_test.go
@@ -661,11 +661,8 @@ func (r *recordingRangeVisitor) visitNewZone(
 	return nil
 }
 
-func (r *recordingRangeVisitor) visitSameZone(
-	_ context.Context, rng *roachpb.RangeDescriptor,
-) error {
+func (r *recordingRangeVisitor) visitSameZone(_ context.Context, rng *roachpb.RangeDescriptor) {
 	r.rngs = append(r.rngs, visitorEntry{newZone: false, rng: *rng})
-	return nil
 }
 
 func (r *recordingRangeVisitor) failed() bool {

--- a/pkg/kv/kvserver/reports/reporter_test.go
+++ b/pkg/kv/kvserver/reports/reporter_test.go
@@ -471,29 +471,6 @@ func (it *erroryRangeIterator) Close(ctx context.Context) {
 	it.iter.Close(ctx)
 }
 
-// computeConstraintConformanceReport iterates through all the ranges and
-// generates the constraint conformance report.
-func computeConstraintConformanceReport(
-	ctx context.Context,
-	rangeStore RangeIterator,
-	cfg *config.SystemConfig,
-	storeResolver StoreResolver,
-) (ConstraintReport, error) {
-	v := makeConstraintConformanceVisitor(ctx, cfg, storeResolver)
-	err := visitRanges(ctx, rangeStore, cfg, &v)
-	return v.Report(), err
-}
-
-// computeReplicationStatsReport iterates through all the ranges and generates
-// the replication stats report.
-func computeReplicationStatsReport(
-	ctx context.Context, rangeStore RangeIterator, checker nodeChecker, cfg *config.SystemConfig,
-) (RangeReport, error) {
-	v := makeReplicationStatsVisitor(ctx, cfg, checker)
-	err := visitRanges(ctx, rangeStore, cfg, &v)
-	return v.Report(), err
-}
-
 func TestZoneChecker(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()

--- a/pkg/kv/kvserver/reports/reporter_test.go
+++ b/pkg/kv/kvserver/reports/reporter_test.go
@@ -423,21 +423,20 @@ func TestRetriableErrorWhenGenerationReport(t *testing.T) {
 	cfg := s.GossipI().(*gossip.Gossip).GetSystemConfig()
 	dummyNodeChecker := func(id roachpb.NodeID) bool { return true }
 
-	saver := makeReplicationStatsReportSaver()
-	v := makeReplicationStatsVisitor(ctx, cfg, dummyNodeChecker, &saver)
+	v := makeReplicationStatsVisitor(ctx, cfg, dummyNodeChecker)
 	realIter := makeMeta2RangeIter(db, 10000 /* batchSize */)
 	require.NoError(t, visitRanges(ctx, &realIter, cfg, &v))
-	expReport := v.report
-	require.Greater(t, len(expReport.stats), 0, "unexpected empty report")
+	expReport := v.Report()
+	require.Greater(t, len(expReport), 0, "unexpected empty report")
 
 	realIter = makeMeta2RangeIter(db, 10000 /* batchSize */)
 	errorIter := erroryRangeIterator{
 		iter:           realIter,
 		injectErrAfter: 3,
 	}
-	v = makeReplicationStatsVisitor(ctx, cfg, func(id roachpb.NodeID) bool { return true }, &saver)
+	v = makeReplicationStatsVisitor(ctx, cfg, func(id roachpb.NodeID) bool { return true })
 	require.NoError(t, visitRanges(ctx, &errorIter, cfg, &v))
-	require.Greater(t, len(v.report.stats), 0, "unexpected empty report")
+	require.Greater(t, len(v.report), 0, "unexpected empty report")
 	require.Equal(t, expReport, v.report)
 }
 
@@ -479,22 +478,20 @@ func computeConstraintConformanceReport(
 	rangeStore RangeIterator,
 	cfg *config.SystemConfig,
 	storeResolver StoreResolver,
-) (*replicationConstraintStatsReportSaver, error) {
-	saver := makeReplicationConstraintStatusReportSaver()
-	v := makeConstraintConformanceVisitor(ctx, cfg, storeResolver, &saver)
+) (ConstraintReport, error) {
+	v := makeConstraintConformanceVisitor(ctx, cfg, storeResolver)
 	err := visitRanges(ctx, rangeStore, cfg, &v)
-	return v.report, err
+	return v.Report(), err
 }
 
 // computeReplicationStatsReport iterates through all the ranges and generates
 // the replication stats report.
 func computeReplicationStatsReport(
 	ctx context.Context, rangeStore RangeIterator, checker nodeChecker, cfg *config.SystemConfig,
-) (*replicationStatsReportSaver, error) {
-	saver := makeReplicationStatsReportSaver()
-	v := makeReplicationStatsVisitor(ctx, cfg, checker, &saver)
+) (RangeReport, error) {
+	v := makeReplicationStatsVisitor(ctx, cfg, checker)
 	err := visitRanges(ctx, rangeStore, cfg, &v)
-	return v.report, err
+	return v.Report(), err
 }
 
 func TestZoneChecker(t *testing.T) {


### PR DESCRIPTION
I'm working on a change to teach the replications reports about joint-consensus states. In the meantime, various things were in my way.
See individual commits; the biggest are "disentangle reports from report savers" and "optimize critical localities report generation".

Release note: None