### PR TITLE
server: make SRV resolution for join list non-fatal

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -565,7 +565,7 @@ func runStart(cmd *cobra.Command, args []string, disableReplication bool) error 
 	// Initialize the node's configuration from startup parameters.
 	// This also reads the part of the configuration that comes from
 	// environment variables.
-	if err := serverCfg.InitNode(); err != nil {
+	if err := serverCfg.InitNode(ctx); err != nil {
 		return errors.Wrap(err, "failed to initialize node")
 	}
 

--- a/pkg/gossip/resolver/resolver.go
+++ b/pkg/gossip/resolver/resolver.go
@@ -11,12 +11,14 @@
 package resolver
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/pkg/errors"
 )
@@ -45,7 +47,7 @@ func NewResolver(address string) (Resolver, error) {
 }
 
 // SRV returns a slice of addresses from SRV record lookup
-func SRV(name string) ([]string, error) {
+func SRV(ctx context.Context, name string) ([]string, error) {
 	// Ignore port
 	name, _, err := netutil.SplitHostPort(name, base.DefaultPort)
 	if err != nil {
@@ -64,7 +66,11 @@ func SRV(name string) ([]string, error) {
 			return nil, nil
 		}
 
-		return nil, errors.Wrapf(err, "failed to lookup SRV record for %q", name)
+		if log.V(1) {
+			log.Infof(context.TODO(), "failed to lookup SRV record for %q: %v", name, err)
+		}
+
+		return nil, nil
 	}
 
 	var addrs = make([]string, len(recs))

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -585,7 +585,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 
 // InitNode parses node attributes and initializes the gossip bootstrap
 // resolvers.
-func (cfg *Config) InitNode() error {
+func (cfg *Config) InitNode(ctx context.Context) error {
 	cfg.readEnvironmentVariables()
 
 	// Initialize attributes.
@@ -596,7 +596,7 @@ func (cfg *Config) InitNode() error {
 	cfg.Config.HistogramWindowInterval = cfg.HistogramWindowInterval()
 
 	// Get the gossip bootstrap resolvers.
-	resolvers, err := cfg.parseGossipBootstrapResolvers()
+	resolvers, err := cfg.parseGossipBootstrapResolvers(ctx)
 	if err != nil {
 		return err
 	}
@@ -647,10 +647,10 @@ func (cfg *Config) readEnvironmentVariables() {
 }
 
 // parseGossipBootstrapResolvers parses list of gossip bootstrap resolvers.
-func (cfg *Config) parseGossipBootstrapResolvers() ([]resolver.Resolver, error) {
+func (cfg *Config) parseGossipBootstrapResolvers(ctx context.Context) ([]resolver.Resolver, error) {
 	var bootstrapResolvers []resolver.Resolver
 	for _, address := range cfg.JoinList {
-		srvAddrs, err := resolver.SRV(address)
+		srvAddrs, err := resolver.SRV(ctx, address)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -37,7 +37,7 @@ func TestParseInitNodeAttributes(t *testing.T) {
 		t.Fatalf("Failed to initialize stores: %s", err)
 	}
 	defer engines.Close()
-	if err := cfg.InitNode(); err != nil {
+	if err := cfg.InitNode(context.TODO()); err != nil {
 		t.Fatalf("Failed to initialize node: %s", err)
 	}
 
@@ -58,7 +58,7 @@ func TestParseJoinUsingAddrs(t *testing.T) {
 		t.Fatalf("Failed to initialize stores: %s", err)
 	}
 	defer engines.Close()
-	if err := cfg.InitNode(); err != nil {
+	if err := cfg.InitNode(context.TODO()); err != nil {
 		t.Fatalf("Failed to initialize node: %s", err)
 	}
 	r1, err := resolver.NewResolver("localhost:12345")

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -384,8 +384,10 @@ func (ts *TestServer) Start(params base.TestServerArgs) error {
 		ts.Cfg.DefaultZoneConfig.NumReplicas = proto.Int32(1)
 	}
 
+	ctx := context.Background()
+
 	// Needs to be called before NewServer to ensure resolvers are initialized.
-	if err := ts.Cfg.InitNode(); err != nil {
+	if err := ts.Cfg.InitNode(ctx); err != nil {
 		return err
 	}
 
@@ -406,7 +408,7 @@ func (ts *TestServer) Start(params base.TestServerArgs) error {
 	// Our context must be shared with our server.
 	ts.Cfg = &ts.Server.cfg
 
-	return ts.Server.Start(context.Background())
+	return ts.Server.Start(ctx)
 }
 
 type allErrorsFakeLiveness struct{}


### PR DESCRIPTION
Currently, any other failure to do an SRV lookup for the join list than the "host not found" error would cause the resolution to stop. In case of that happening for all records, the node won't be unable to start.

Actually, it is recommended to ignore errors from SRV lookups and continue with regular A lookup
(https://tools.ietf.org/html/rfc2782). This PR makes that change.

Fixes #47550

Release note (bug fix): makes SRV resolution non-fatal for join list records to align with the standard and improve reliability of node startup.