### PR TITLE
opt: exec.Factory cleanup

### DIFF
--- a/pkg/sql/buffer.go
+++ b/pkg/sql/buffer.go
@@ -34,6 +34,9 @@ type bufferNode struct {
 	label string
 }
 
+// BufferNodeMarker is part of the exec.BufferNode interface.
+func (n *bufferNode) BufferNodeMarker() {}
+
 func (n *bufferNode) startExec(params runParams) error {
 	n.bufferedRows = rowcontainer.NewRowContainer(
 		params.EvalContext().Mon.MakeBoundAccount(),

--- a/pkg/sql/join_test.go
+++ b/pkg/sql/join_test.go
@@ -46,7 +46,7 @@ func newTestScanNode(kvDB *kv.DB, tableName string) (*scanNode, error) {
 	}
 	scan.reqOrdering = ordering
 	sb := span.MakeBuilder(desc.TableDesc(), &desc.PrimaryIndex)
-	scan.spans, err = sb.SpansFromConstraint(nil /* constraint */, exec.ColumnOrdinalSet{}, false /* forDelete */)
+	scan.spans, err = sb.SpansFromConstraint(nil /* constraint */, exec.TableColumnOrdinalSet{}, false /* forDelete */)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -344,11 +344,11 @@ func (f *stubFactory) ConstructAlterTableRelocate(
 	return struct{}{}, nil
 }
 
-func (f *stubFactory) ConstructBuffer(value exec.Node, label string) (exec.Node, error) {
-	return struct{}{}, nil
+func (f *stubFactory) ConstructBuffer(value exec.Node, label string) (exec.BufferNode, error) {
+	return struct{ exec.BufferNode }{}, nil
 }
 
-func (f *stubFactory) ConstructScanBuffer(ref exec.Node, label string) (exec.Node, error) {
+func (f *stubFactory) ConstructScanBuffer(ref exec.BufferNode, label string) (exec.Node, error) {
 	return struct{}{}, nil
 }
 

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -33,7 +33,7 @@ func (f *stubFactory) ConstructValues(
 func (f *stubFactory) ConstructScan(
 	table cat.Table,
 	index cat.Index,
-	needed exec.ColumnOrdinalSet,
+	needed exec.TableColumnOrdinalSet,
 	indexConstraint *constraint.Constraint,
 	hardLimit int64,
 	softLimit int64,
@@ -53,7 +53,7 @@ func (f *stubFactory) ConstructFilter(
 }
 
 func (f *stubFactory) ConstructSimpleProject(
-	n exec.Node, cols []exec.ColumnOrdinal, colNames []string, reqOrdering exec.OutputOrdering,
+	n exec.Node, cols []exec.NodeColumnOrdinal, colNames []string, reqOrdering exec.OutputOrdering,
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }
@@ -67,7 +67,7 @@ func (f *stubFactory) ConstructRender(
 func (f *stubFactory) ConstructHashJoin(
 	joinType sqlbase.JoinType,
 	left, right exec.Node,
-	leftEqCols, rightEqCols []exec.ColumnOrdinal,
+	leftEqCols, rightEqCols []exec.NodeColumnOrdinal,
 	leftEqColsAreKey, rightEqColsAreKey bool,
 	extraOnCond tree.TypedExpr,
 ) (exec.Node, error) {
@@ -97,7 +97,7 @@ func (f *stubFactory) ConstructMergeJoin(
 
 func (f *stubFactory) ConstructGroupBy(
 	input exec.Node,
-	groupCols []exec.ColumnOrdinal,
+	groupCols []exec.NodeColumnOrdinal,
 	groupColOrdering sqlbase.ColumnOrdering,
 	aggregations []exec.AggInfo,
 	reqOrdering exec.OutputOrdering,
@@ -113,7 +113,7 @@ func (f *stubFactory) ConstructScalarGroupBy(
 
 func (f *stubFactory) ConstructDistinct(
 	input exec.Node,
-	distinctCols, orderedCols exec.ColumnOrdinalSet,
+	distinctCols, orderedCols exec.NodeColumnOrdinalSet,
 	reqOrdering exec.OutputOrdering,
 	nullsAreDistinct bool,
 	errorOnDup string,
@@ -140,8 +140,8 @@ func (f *stubFactory) ConstructOrdinality(input exec.Node, colName string) (exec
 func (f *stubFactory) ConstructIndexJoin(
 	input exec.Node,
 	table cat.Table,
-	keyCols []exec.ColumnOrdinal,
-	tableCols exec.ColumnOrdinalSet,
+	keyCols []exec.NodeColumnOrdinal,
+	tableCols exec.TableColumnOrdinalSet,
 	reqOrdering exec.OutputOrdering,
 ) (exec.Node, error) {
 	return struct{}{}, nil
@@ -152,9 +152,9 @@ func (f *stubFactory) ConstructLookupJoin(
 	input exec.Node,
 	table cat.Table,
 	index cat.Index,
-	eqCols []exec.ColumnOrdinal,
+	eqCols []exec.NodeColumnOrdinal,
 	eqColsAreKey bool,
-	lookupCols exec.ColumnOrdinalSet,
+	lookupCols exec.TableColumnOrdinalSet,
 	onCond tree.TypedExpr,
 	reqOrdering exec.OutputOrdering,
 ) (exec.Node, error) {
@@ -166,10 +166,10 @@ func (f *stubFactory) ConstructZigzagJoin(
 	leftIndex cat.Index,
 	rightTable cat.Table,
 	rightIndex cat.Index,
-	leftEqCols []exec.ColumnOrdinal,
-	rightEqCols []exec.ColumnOrdinal,
-	leftCols exec.ColumnOrdinalSet,
-	rightCols exec.ColumnOrdinalSet,
+	leftEqCols []exec.NodeColumnOrdinal,
+	rightEqCols []exec.NodeColumnOrdinal,
+	leftCols exec.NodeColumnOrdinalSet,
+	rightCols exec.NodeColumnOrdinalSet,
 	onCond tree.TypedExpr,
 	fixedVals []exec.Node,
 	reqOrdering exec.OutputOrdering,
@@ -226,8 +226,8 @@ func (f *stubFactory) ConstructShowTrace(typ tree.ShowTraceType, compact bool) (
 func (f *stubFactory) ConstructInsert(
 	input exec.Node,
 	table cat.Table,
-	insertCols exec.ColumnOrdinalSet,
-	returnCols exec.ColumnOrdinalSet,
+	insertCols exec.TableColumnOrdinalSet,
+	returnCols exec.TableColumnOrdinalSet,
 	checks exec.CheckOrdinalSet,
 	allowAutoCommit bool,
 	skipFKChecks bool,
@@ -238,8 +238,8 @@ func (f *stubFactory) ConstructInsert(
 func (f *stubFactory) ConstructInsertFastPath(
 	rows [][]tree.TypedExpr,
 	table cat.Table,
-	insertCols exec.ColumnOrdinalSet,
-	returnCols exec.ColumnOrdinalSet,
+	insertCols exec.TableColumnOrdinalSet,
+	returnCols exec.TableColumnOrdinalSet,
 	checkCols exec.CheckOrdinalSet,
 	fkChecks []exec.InsertFastPathFKCheck,
 ) (exec.Node, error) {
@@ -249,9 +249,9 @@ func (f *stubFactory) ConstructInsertFastPath(
 func (f *stubFactory) ConstructUpdate(
 	input exec.Node,
 	table cat.Table,
-	fetchCols exec.ColumnOrdinalSet,
-	updateCols exec.ColumnOrdinalSet,
-	returnCols exec.ColumnOrdinalSet,
+	fetchCols exec.TableColumnOrdinalSet,
+	updateCols exec.TableColumnOrdinalSet,
+	returnCols exec.TableColumnOrdinalSet,
 	checks exec.CheckOrdinalSet,
 	passthrough sqlbase.ResultColumns,
 	allowAutoCommit bool,
@@ -263,11 +263,11 @@ func (f *stubFactory) ConstructUpdate(
 func (f *stubFactory) ConstructUpsert(
 	input exec.Node,
 	table cat.Table,
-	canaryCol exec.ColumnOrdinal,
-	insertCols exec.ColumnOrdinalSet,
-	fetchCols exec.ColumnOrdinalSet,
-	updateCols exec.ColumnOrdinalSet,
-	returnCols exec.ColumnOrdinalSet,
+	canaryCol exec.NodeColumnOrdinal,
+	insertCols exec.TableColumnOrdinalSet,
+	fetchCols exec.TableColumnOrdinalSet,
+	updateCols exec.TableColumnOrdinalSet,
+	returnCols exec.TableColumnOrdinalSet,
 	checks exec.CheckOrdinalSet,
 	allowAutoCommit bool,
 	skipFKChecks bool,
@@ -278,8 +278,8 @@ func (f *stubFactory) ConstructUpsert(
 func (f *stubFactory) ConstructDelete(
 	input exec.Node,
 	table cat.Table,
-	fetchCols exec.ColumnOrdinalSet,
-	returnCols exec.ColumnOrdinalSet,
+	fetchCols exec.TableColumnOrdinalSet,
+	returnCols exec.TableColumnOrdinalSet,
 	allowAutoCommit bool,
 	skipFKChecks bool,
 ) (exec.Node, error) {
@@ -288,7 +288,7 @@ func (f *stubFactory) ConstructDelete(
 
 func (f *stubFactory) ConstructDeleteRange(
 	table cat.Table,
-	needed exec.ColumnOrdinalSet,
+	needed exec.TableColumnOrdinalSet,
 	indexConstraint *constraint.Constraint,
 	maxReturnedKeys int,
 	allowAutoCommit bool,

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -156,10 +156,12 @@ type builtWithExpr struct {
 	// outputCols maps the output ColumnIDs of the With expression to the ordinal
 	// positions they are output to. See execPlan.outputCols for more details.
 	outputCols opt.ColMap
-	bufferNode exec.Node
+	bufferNode exec.BufferNode
 }
 
-func (b *Builder) addBuiltWithExpr(id opt.WithID, outputCols opt.ColMap, bufferNode exec.Node) {
+func (b *Builder) addBuiltWithExpr(
+	id opt.WithID, outputCols opt.ColMap, bufferNode exec.BufferNode,
+) {
 	b.withExprs = append(b.withExprs, builtWithExpr{
 		id:         id,
 		outputCols: outputCols,

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -59,12 +59,13 @@ func (b *Builder) buildMutationInput(
 
 	if p.WithID != 0 {
 		label := fmt.Sprintf("buffer %d", p.WithID)
-		input.root, err = b.factory.ConstructBuffer(input.root, label)
+		bufferNode, err := b.factory.ConstructBuffer(input.root, label)
 		if err != nil {
 			return execPlan{}, err
 		}
 
-		b.addBuiltWithExpr(p.WithID, input.outputCols, input.root)
+		b.addBuiltWithExpr(p.WithID, input.outputCols, bufferNode)
+		input.root = bufferNode
 	}
 	return input, nil
 }

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -177,7 +177,7 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 		}
 
 		out := &fkChecks[i]
-		out.InsertCols = make([]exec.ColumnOrdinal, len(lookupJoin.KeyCols))
+		out.InsertCols = make([]exec.TableColumnOrdinal, len(lookupJoin.KeyCols))
 		findCol := func(cols opt.ColList, col opt.ColumnID) int {
 			res, ok := cols.Find(col)
 			if !ok {
@@ -190,7 +190,7 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 			// column in the mutation input.
 			withColOrd := findCol(withScan.OutCols, keyCol)
 			inputCol := withScan.InCols[withColOrd]
-			out.InsertCols[i] = exec.ColumnOrdinal(findCol(ins.InsertCols, inputCol))
+			out.InsertCols[i] = exec.TableColumnOrdinal(findCol(ins.InsertCols, inputCol))
 		}
 
 		out.ReferencedTable = md.Table(lookupJoin.Table)
@@ -375,9 +375,9 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (execPlan, error) {
 	// Construct the Upsert node.
 	md := b.mem.Metadata()
 	tab := md.Table(ups.Table)
-	canaryCol := exec.ColumnOrdinal(-1)
+	canaryCol := exec.NodeColumnOrdinal(-1)
 	if ups.CanaryCol != 0 {
-		canaryCol = input.getColumnOrdinal(ups.CanaryCol)
+		canaryCol = input.getNodeColumnOrdinal(ups.CanaryCol)
 	}
 	insertColOrds := ordinalSetFromColList(ups.InsertCols)
 	fetchColOrds := ordinalSetFromColList(ups.FetchCols)
@@ -540,7 +540,7 @@ func appendColsWhenPresent(dst, src opt.ColList) opt.ColList {
 // column ID in the given list. This is used with mutation operators, which
 // maintain lists that correspond to the target table, with zero column IDs
 // indicating columns that are not involved in the mutation.
-func ordinalSetFromColList(colList opt.ColList) exec.ColumnOrdinalSet {
+func ordinalSetFromColList(colList opt.ColList) util.FastIntSet {
 	var res util.FastIntSet
 	if colList == nil {
 		return res
@@ -596,7 +596,7 @@ func (b *Builder) buildFKChecks(checks memo.FKChecksExpr) error {
 		mkErr := func(row tree.Datums) error {
 			keyVals := make(tree.Datums, len(c.KeyCols))
 			for i, col := range c.KeyCols {
-				keyVals[i] = row[query.getColumnOrdinal(col)]
+				keyVals[i] = row[query.getNodeColumnOrdinal(col)]
 			}
 			return mkFKCheckErr(md, c, keyVals)
 		}

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -41,7 +41,7 @@ import (
 type execPlan struct {
 	root exec.Node
 
-	// outputCols is a map from opt.ColumnID to exec.ColumnOrdinal. It maps
+	// outputCols is a map from opt.ColumnID to exec.NodeColumnOrdinal. It maps
 	// columns in the output set of a relational expression to indices in the
 	// result columns of the exec.Node.
 	//
@@ -94,21 +94,21 @@ func (ep *execPlan) makeBuildScalarCtx() buildScalarCtx {
 	}
 }
 
-// getColumnOrdinal takes a column that is known to be produced by the execPlan
+// getNodeColumnOrdinal takes a column that is known to be produced by the execPlan
 // and returns the ordinal index of that column in the result columns of the
 // node.
-func (ep *execPlan) getColumnOrdinal(col opt.ColumnID) exec.ColumnOrdinal {
+func (ep *execPlan) getNodeColumnOrdinal(col opt.ColumnID) exec.NodeColumnOrdinal {
 	ord, ok := ep.outputCols.Get(int(col))
 	if !ok {
 		panic(errors.AssertionFailedf("column %d not in input", log.Safe(col)))
 	}
-	return exec.ColumnOrdinal(ord)
+	return exec.NodeColumnOrdinal(ord)
 }
 
-func (ep *execPlan) getColumnOrdinalSet(cols opt.ColSet) exec.ColumnOrdinalSet {
-	var res exec.ColumnOrdinalSet
+func (ep *execPlan) getNodeColumnOrdinalSet(cols opt.ColSet) exec.NodeColumnOrdinalSet {
+	var res exec.NodeColumnOrdinalSet
 	cols.ForEach(func(colID opt.ColumnID) {
-		res.Add(int(ep.getColumnOrdinal(colID)))
+		res.Add(int(ep.getNodeColumnOrdinal(colID)))
 	})
 	return res
 }
@@ -127,7 +127,7 @@ func (ep *execPlan) sqlOrdering(ordering opt.Ordering) sqlbase.ColumnOrdering {
 	}
 	colOrder := make(sqlbase.ColumnOrdering, len(ordering))
 	for i := range ordering {
-		colOrder[i].ColIdx = int(ep.getColumnOrdinal(ordering[i].ID()))
+		colOrder[i].ColIdx = int(ep.getNodeColumnOrdinal(ordering[i].ID()))
 		if ordering[i].Descending() {
 			colOrder[i].Direction = encoding.Descending
 		} else {
@@ -400,9 +400,9 @@ func (b *Builder) constructValues(rows [][]tree.TypedExpr, cols opt.ColList) (ex
 // (starting with outputOrdinalStart).
 func (b *Builder) getColumns(
 	cols opt.ColSet, tableID opt.TableID,
-) (exec.ColumnOrdinalSet, opt.ColMap) {
-	needed := exec.ColumnOrdinalSet{}
-	output := opt.ColMap{}
+) (exec.TableColumnOrdinalSet, opt.ColMap) {
+	var needed exec.TableColumnOrdinalSet
+	var output opt.ColMap
 
 	columnCount := b.mem.Metadata().Table(tableID).DeletableColumnCount()
 	n := 0
@@ -531,11 +531,11 @@ func (b *Builder) applySimpleProject(
 	input execPlan, cols opt.ColSet, providedOrd opt.Ordering,
 ) (execPlan, error) {
 	// We have only pass-through columns.
-	colList := make([]exec.ColumnOrdinal, 0, cols.Len())
+	colList := make([]exec.NodeColumnOrdinal, 0, cols.Len())
 	var res execPlan
 	cols.ForEach(func(i opt.ColumnID) {
 		res.outputCols.Set(int(i), len(colList))
-		colList = append(colList, input.getColumnOrdinal(i))
+		colList = append(colList, input.getNodeColumnOrdinal(i))
 	})
 	var err error
 	res.root, err = b.factory.ConstructSimpleProject(
@@ -785,12 +785,12 @@ func (b *Builder) buildHashJoin(join memo.RelExpr) (execPlan, error) {
 	ep := execPlan{outputCols: outputCols}
 
 	// Convert leftEq/rightEq to ordinals.
-	eqColsBuf := make([]exec.ColumnOrdinal, 2*len(leftEq))
+	eqColsBuf := make([]exec.NodeColumnOrdinal, 2*len(leftEq))
 	leftEqOrdinals := eqColsBuf[:len(leftEq):len(leftEq)]
 	rightEqOrdinals := eqColsBuf[len(leftEq):]
 	for i := range leftEq {
-		leftEqOrdinals[i] = left.getColumnOrdinal(leftEq[i])
-		rightEqOrdinals[i] = right.getColumnOrdinal(rightEq[i])
+		leftEqOrdinals[i] = left.getNodeColumnOrdinal(leftEq[i])
+		rightEqOrdinals[i] = right.getNodeColumnOrdinal(rightEq[i])
 	}
 
 	leftEqColsAreKey := leftExpr.Relational().FuncDeps.ColsAreStrictKey(leftEq.ToSet())
@@ -924,10 +924,10 @@ func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
 
 	var ep execPlan
 	groupingCols := groupBy.Private().(*memo.GroupingPrivate).GroupingCols
-	groupingColIdx := make([]exec.ColumnOrdinal, 0, groupingCols.Len())
+	groupingColIdx := make([]exec.NodeColumnOrdinal, 0, groupingCols.Len())
 	for i, ok := groupingCols.Next(0); ok; i, ok = groupingCols.Next(i + 1) {
 		ep.outputCols.Set(int(i), len(groupingColIdx))
-		groupingColIdx = append(groupingColIdx, input.getColumnOrdinal(i))
+		groupingColIdx = append(groupingColIdx, input.getNodeColumnOrdinal(i))
 	}
 
 	aggregations := *groupBy.Child(1).(*memo.AggregationsExpr)
@@ -936,13 +936,13 @@ func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
 		item := &aggregations[i]
 		agg := item.Agg
 
-		var filterOrd exec.ColumnOrdinal = -1
+		var filterOrd exec.NodeColumnOrdinal = -1
 		if aggFilter, ok := agg.(*memo.AggFilterExpr); ok {
 			filter, ok := aggFilter.Filter.(*memo.VariableExpr)
 			if !ok {
 				return execPlan{}, errors.AssertionFailedf("only VariableOp args supported")
 			}
-			filterOrd = input.getColumnOrdinal(filter.Col)
+			filterOrd = input.getNodeColumnOrdinal(filter.Col)
 			agg = aggFilter.Input
 		}
 
@@ -956,7 +956,7 @@ func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
 
 		// Accumulate variable arguments in argCols and constant arguments in
 		// constArgs. Constant arguments must follow variable arguments.
-		var argCols []exec.ColumnOrdinal
+		var argCols []exec.NodeColumnOrdinal
 		var constArgs tree.Datums
 		for j, n := 0, agg.ChildCount(); j < n; j++ {
 			child := agg.Child(j)
@@ -964,7 +964,7 @@ func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
 				if len(constArgs) != 0 {
 					return execPlan{}, errors.Errorf("constant args must come after variable args")
 				}
-				argCols = append(argCols, input.getColumnOrdinal(variable.Col))
+				argCols = append(argCols, input.getNodeColumnOrdinal(variable.Col))
 			} else {
 				if len(argCols) == 0 {
 					return execPlan{}, errors.Errorf("a constant arg requires at least one variable arg")
@@ -1016,13 +1016,13 @@ func (b *Builder) buildDistinct(distinct memo.RelExpr) (execPlan, error) {
 		return execPlan{}, err
 	}
 
-	distinctCols := input.getColumnOrdinalSet(private.GroupingCols)
-	var orderedCols exec.ColumnOrdinalSet
+	distinctCols := input.getNodeColumnOrdinalSet(private.GroupingCols)
+	var orderedCols exec.NodeColumnOrdinalSet
 	ordering := ordering.StreamingGroupingColOrdering(
 		private, &distinct.RequiredPhysical().Ordering,
 	)
 	for i := range ordering {
-		orderedCols.Add(int(input.getColumnOrdinal(ordering[i].ID())))
+		orderedCols.Add(int(input.getNodeColumnOrdinal(ordering[i].ID())))
 	}
 	ep := execPlan{outputCols: input.outputCols}
 
@@ -1093,7 +1093,7 @@ func (b *Builder) buildGroupByInput(groupBy memo.RelExpr) (execPlan, error) {
 	}
 
 	// The input is producing columns that are not useful; set up a projection.
-	cols := make([]exec.ColumnOrdinal, 0, neededCols.Len())
+	cols := make([]exec.NodeColumnOrdinal, 0, neededCols.Len())
 	var newOutputCols opt.ColMap
 	for colID, ok := neededCols.Next(0); ok; colID, ok = neededCols.Next(colID + 1) {
 		ordinal, ordOk := input.outputCols.Get(int(colID))
@@ -1101,7 +1101,7 @@ func (b *Builder) buildGroupByInput(groupBy memo.RelExpr) (execPlan, error) {
 			panic(errors.AssertionFailedf("needed column not produced by group-by input"))
 		}
 		newOutputCols.Set(int(colID), len(cols))
-		cols = append(cols, exec.ColumnOrdinal(ordinal))
+		cols = append(cols, exec.NodeColumnOrdinal(ordinal))
 	}
 
 	input.outputCols = newOutputCols
@@ -1274,9 +1274,9 @@ func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
 	// TODO(radu): the distsql implementation of index join assumes that the input
 	// starts with the PK columns in order (#40749).
 	pri := tab.Index(cat.PrimaryIndex)
-	keyCols := make([]exec.ColumnOrdinal, pri.KeyColumnCount())
+	keyCols := make([]exec.NodeColumnOrdinal, pri.KeyColumnCount())
 	for i := range keyCols {
-		keyCols[i] = input.getColumnOrdinal(join.Table.ColumnID(pri.Column(i).Ordinal))
+		keyCols[i] = input.getNodeColumnOrdinal(join.Table.ColumnID(pri.Column(i).Ordinal))
 	}
 
 	cols := join.Cols
@@ -1305,9 +1305,9 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 
 	md := b.mem.Metadata()
 
-	keyCols := make([]exec.ColumnOrdinal, len(join.KeyCols))
+	keyCols := make([]exec.NodeColumnOrdinal, len(join.KeyCols))
 	for i, c := range join.KeyCols {
-		keyCols[i] = input.getColumnOrdinal(c)
+		keyCols[i] = input.getNodeColumnOrdinal(c)
 	}
 
 	inputCols := join.Input.Relational().OutputCols
@@ -1368,11 +1368,11 @@ func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
 	leftIndex := leftTable.Index(join.LeftIndex)
 	rightIndex := rightTable.Index(join.RightIndex)
 
-	leftEqCols := make([]exec.ColumnOrdinal, len(join.LeftEqCols))
-	rightEqCols := make([]exec.ColumnOrdinal, len(join.RightEqCols))
+	leftEqCols := make([]exec.NodeColumnOrdinal, len(join.LeftEqCols))
+	rightEqCols := make([]exec.NodeColumnOrdinal, len(join.RightEqCols))
 	for i := range join.LeftEqCols {
-		leftEqCols[i] = exec.ColumnOrdinal(join.LeftTable.ColumnOrdinal(join.LeftEqCols[i]))
-		rightEqCols[i] = exec.ColumnOrdinal(join.RightTable.ColumnOrdinal(join.RightEqCols[i]))
+		leftEqCols[i] = exec.NodeColumnOrdinal(join.LeftTable.ColumnOrdinal(join.LeftEqCols[i]))
+		rightEqCols[i] = exec.NodeColumnOrdinal(join.RightTable.ColumnOrdinal(join.RightEqCols[i]))
 	}
 	leftCols := md.TableMeta(join.LeftTable).IndexColumns(join.LeftIndex).Intersection(join.Cols)
 	rightCols := md.TableMeta(join.RightTable).IndexColumns(join.RightIndex).Intersection(join.Cols)
@@ -1589,13 +1589,13 @@ func (b *Builder) buildWithScan(withScan *memo.WithScanExpr) (execPlan, error) {
 		}
 	} else {
 		// We need a projection.
-		cols := make([]exec.ColumnOrdinal, len(withScan.InCols))
+		cols := make([]exec.NodeColumnOrdinal, len(withScan.InCols))
 		for i := range withScan.InCols {
 			col, ok := e.outputCols.Get(int(withScan.InCols[i]))
 			if !ok {
 				panic(errors.AssertionFailedf("column %d not in input", log.Safe(withScan.InCols[i])))
 			}
-			cols[i] = exec.ColumnOrdinal(col)
+			cols[i] = exec.NodeColumnOrdinal(col)
 			res.outputCols.Set(int(withScan.OutCols[i]), i)
 		}
 		res.root, err = b.factory.ConstructSimpleProject(
@@ -1795,18 +1795,18 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 		}
 	}
 
-	partitionIdxs := make([]exec.ColumnOrdinal, w.Partition.Len())
+	partitionIdxs := make([]exec.NodeColumnOrdinal, w.Partition.Len())
 	partitionExprs := make(tree.Exprs, w.Partition.Len())
 
 	i := 0
 	w.Partition.ForEach(func(col opt.ColumnID) {
 		ordinal, _ := input.outputCols.Get(int(col))
-		partitionIdxs[i] = exec.ColumnOrdinal(ordinal)
+		partitionIdxs[i] = exec.NodeColumnOrdinal(ordinal)
 		partitionExprs[i] = b.indexedVar(&ctx, b.mem.Metadata(), col)
 		i++
 	})
 
-	argIdxs := make([][]exec.ColumnOrdinal, len(w.Windows))
+	argIdxs := make([][]exec.NodeColumnOrdinal, len(w.Windows))
 	filterIdxs := make([]int, len(w.Windows))
 	exprs := make([]*tree.FuncExpr, len(w.Windows))
 
@@ -1820,12 +1820,12 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 		props, _ := builtins.GetBuiltinProperties(name)
 
 		args := make([]tree.TypedExpr, fn.ChildCount())
-		argIdxs[i] = make([]exec.ColumnOrdinal, fn.ChildCount())
+		argIdxs[i] = make([]exec.NodeColumnOrdinal, fn.ChildCount())
 		for j, n := 0, fn.ChildCount(); j < n; j++ {
 			col := fn.Child(j).(*memo.VariableExpr).Col
 			args[j] = b.indexedVar(&ctx, b.mem.Metadata(), col)
 			idx, _ := input.outputCols.Get(int(col))
-			argIdxs[i][j] = exec.ColumnOrdinal(idx)
+			argIdxs[i][j] = exec.NodeColumnOrdinal(idx)
 		}
 
 		frame, err := b.buildFrame(input, item)
@@ -1893,10 +1893,10 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 		outputIdxs[i] = windowStart + i
 	}
 
-	var rangeOffsetColumn exec.ColumnOrdinal
+	var rangeOffsetColumn exec.NodeColumnOrdinal
 	if ord.Empty() {
 		idx, _ := input.outputCols.Get(int(w.RangeOffsetColumn))
-		rangeOffsetColumn = exec.ColumnOrdinal(idx)
+		rangeOffsetColumn = exec.NodeColumnOrdinal(idx)
 	}
 	node, err := b.factory.ConstructWindow(input.root, exec.WindowInfo{
 		Cols:              resultCols,
@@ -1975,7 +1975,7 @@ func (b *Builder) buildOpaque(opaque *memo.OpaqueRelPrivate) (execPlan, error) {
 // the columns (in the same order), returns needProj=false.
 func (b *Builder) needProjection(
 	input execPlan, colList opt.ColList,
-) (_ []exec.ColumnOrdinal, needProj bool) {
+) (_ []exec.NodeColumnOrdinal, needProj bool) {
 	if input.numOutputCols() == len(colList) {
 		identity := true
 		for i, col := range colList {
@@ -1988,10 +1988,10 @@ func (b *Builder) needProjection(
 			return nil, false
 		}
 	}
-	cols := make([]exec.ColumnOrdinal, 0, len(colList))
+	cols := make([]exec.NodeColumnOrdinal, 0, len(colList))
 	for _, col := range colList {
 		if col != 0 {
-			cols = append(cols, input.getColumnOrdinal(col))
+			cols = append(cols, input.getNodeColumnOrdinal(col))
 		}
 	}
 	return cols, true

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1521,7 +1521,7 @@ func (b *Builder) buildRecursiveCTE(rec *memo.RecursiveCTEExpr) (execPlan, error
 		withExprs: b.withExprs[:len(b.withExprs):len(b.withExprs)],
 	}
 
-	fn := func(bufferRef exec.Node) (exec.Plan, error) {
+	fn := func(bufferRef exec.BufferNode) (exec.Plan, error) {
 		// Use a separate builder each time.
 		innerBld := *innerBldTemplate
 		innerBld.addBuiltWithExpr(rec.WithID, initial.outputCols, bufferRef)

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -66,7 +66,7 @@ type Factory interface {
 	ConstructScan(
 		table cat.Table,
 		index cat.Index,
-		needed ColumnOrdinalSet,
+		needed TableColumnOrdinalSet,
 		indexConstraint *constraint.Constraint,
 		hardLimit int64,
 		softLimit int64,
@@ -88,7 +88,7 @@ type Factory interface {
 	// The colNames argument is optional; if it is nil, the names of the
 	// corresponding input columns are kept.
 	ConstructSimpleProject(
-		n Node, cols []ColumnOrdinal, colNames []string, reqOrdering OutputOrdering,
+		n Node, cols []NodeColumnOrdinal, colNames []string, reqOrdering OutputOrdering,
 	) (Node, error)
 
 	// ConstructRender returns a node that applies a projection on the results of
@@ -128,7 +128,7 @@ type Factory interface {
 	ConstructHashJoin(
 		joinType sqlbase.JoinType,
 		left, right Node,
-		leftEqCols, rightEqCols []ColumnOrdinal,
+		leftEqCols, rightEqCols []NodeColumnOrdinal,
 		leftEqColsAreKey, rightEqColsAreKey bool,
 		extraOnCond tree.TypedExpr,
 	) (Node, error)
@@ -155,7 +155,7 @@ type Factory interface {
 	// for each distinct set of values on the set of columns in the ordering).
 	ConstructGroupBy(
 		input Node,
-		groupCols []ColumnOrdinal,
+		groupCols []NodeColumnOrdinal,
 		groupColOrdering sqlbase.ColumnOrdering,
 		aggregations []AggInfo,
 		reqOrdering OutputOrdering,
@@ -173,7 +173,7 @@ type Factory interface {
 	// columns are a contiguous part of the input).
 	ConstructDistinct(
 		input Node,
-		distinctCols, orderedCols ColumnOrdinalSet,
+		distinctCols, orderedCols NodeColumnOrdinalSet,
 		reqOrdering OutputOrdering,
 		nullsAreDistinct bool,
 		errorOnDup string,
@@ -203,8 +203,8 @@ type Factory interface {
 	ConstructIndexJoin(
 		input Node,
 		table cat.Table,
-		keyCols []ColumnOrdinal,
-		tableCols ColumnOrdinalSet,
+		keyCols []NodeColumnOrdinal,
+		tableCols TableColumnOrdinalSet,
 		reqOrdering OutputOrdering,
 	) (Node, error)
 
@@ -221,9 +221,9 @@ type Factory interface {
 		input Node,
 		table cat.Table,
 		index cat.Index,
-		eqCols []ColumnOrdinal,
+		eqCols []NodeColumnOrdinal,
 		eqColsAreKey bool,
-		lookupCols ColumnOrdinalSet,
+		lookupCols TableColumnOrdinalSet,
 		onCond tree.TypedExpr,
 		reqOrdering OutputOrdering,
 	) (Node, error)
@@ -239,10 +239,10 @@ type Factory interface {
 		leftIndex cat.Index,
 		rightTable cat.Table,
 		rightIndex cat.Index,
-		leftEqCols []ColumnOrdinal,
-		rightEqCols []ColumnOrdinal,
-		leftCols ColumnOrdinalSet,
-		rightCols ColumnOrdinalSet,
+		leftEqCols []NodeColumnOrdinal,
+		rightEqCols []NodeColumnOrdinal,
+		leftCols NodeColumnOrdinalSet,
+		rightCols NodeColumnOrdinalSet,
 		onCond tree.TypedExpr,
 		fixedVals []Node,
 		reqOrdering OutputOrdering,
@@ -314,8 +314,8 @@ type Factory interface {
 	ConstructInsert(
 		input Node,
 		table cat.Table,
-		insertCols ColumnOrdinalSet,
-		returnCols ColumnOrdinalSet,
+		insertCols TableColumnOrdinalSet,
+		returnCols TableColumnOrdinalSet,
 		checkCols CheckOrdinalSet,
 		allowAutoCommit bool,
 		skipFKChecks bool,
@@ -337,8 +337,8 @@ type Factory interface {
 	ConstructInsertFastPath(
 		rows [][]tree.TypedExpr,
 		table cat.Table,
-		insertCols ColumnOrdinalSet,
-		returnCols ColumnOrdinalSet,
+		insertCols TableColumnOrdinalSet,
+		returnCols TableColumnOrdinalSet,
 		checkCols CheckOrdinalSet,
 		fkChecks []InsertFastPathFKCheck,
 	) (Node, error)
@@ -371,9 +371,9 @@ type Factory interface {
 	ConstructUpdate(
 		input Node,
 		table cat.Table,
-		fetchCols ColumnOrdinalSet,
-		updateCols ColumnOrdinalSet,
-		returnCols ColumnOrdinalSet,
+		fetchCols TableColumnOrdinalSet,
+		updateCols TableColumnOrdinalSet,
+		returnCols TableColumnOrdinalSet,
 		checks CheckOrdinalSet,
 		passthrough sqlbase.ResultColumns,
 		allowAutoCommit bool,
@@ -416,11 +416,11 @@ type Factory interface {
 	ConstructUpsert(
 		input Node,
 		table cat.Table,
-		canaryCol ColumnOrdinal,
-		insertCols ColumnOrdinalSet,
-		fetchCols ColumnOrdinalSet,
-		updateCols ColumnOrdinalSet,
-		returnCols ColumnOrdinalSet,
+		canaryCol NodeColumnOrdinal,
+		insertCols TableColumnOrdinalSet,
+		fetchCols TableColumnOrdinalSet,
+		updateCols TableColumnOrdinalSet,
+		returnCols TableColumnOrdinalSet,
 		checks CheckOrdinalSet,
 		allowAutoCommit bool,
 		skipFKChecks bool,
@@ -445,8 +445,8 @@ type Factory interface {
 	ConstructDelete(
 		input Node,
 		table cat.Table,
-		fetchCols ColumnOrdinalSet,
-		returnCols ColumnOrdinalSet,
+		fetchCols TableColumnOrdinalSet,
+		returnCols TableColumnOrdinalSet,
 		allowAutoCommit bool,
 		skipFKChecks bool,
 	) (Node, error)
@@ -456,8 +456,13 @@ type Factory interface {
 	// possible when certain conditions hold true (see canUseDeleteRange for more
 	// details). See the comment for ConstructScan for descriptions of the
 	// parameters, since DeleteRange combines Delete + Scan into a single operator.
-	ConstructDeleteRange(table cat.Table, needed ColumnOrdinalSet, indexConstraint *constraint.Constraint,
-		maxReturnedKeys int, allowAutoCommit bool) (Node, error)
+	ConstructDeleteRange(
+		table cat.Table,
+		needed TableColumnOrdinalSet,
+		indexConstraint *constraint.Constraint,
+		maxReturnedKeys int,
+		allowAutoCommit bool,
+	) (Node, error)
 
 	// ConstructCreateTable returns a node that implements a CREATE TABLE
 	// statement.
@@ -591,13 +596,20 @@ const (
 	SubqueryAllRows
 )
 
-// ColumnOrdinal is the 0-based ordinal index of a cat.Table column or a column
-// produced by a Node.
-// TODO(radu): separate these two usages for clarity of the interface.
-type ColumnOrdinal int32
+// TableColumnOrdinal is the 0-based ordinal index of a cat.Table column.
+// It is used when operations involve a table directly (e.g. scans, index/lookup
+// joins, mutations).
+type TableColumnOrdinal int32
 
-// ColumnOrdinalSet contains a set of ColumnOrdinal values as ints.
-type ColumnOrdinalSet = util.FastIntSet
+// TableColumnOrdinalSet contains a set of TableColumnOrdinal values.
+type TableColumnOrdinalSet = util.FastIntSet
+
+// NodeColumnOrdinal is the 0-based ordinal index of a column produced by a
+// Node. It is used when referring to a column in an input to an operator.
+type NodeColumnOrdinal int32
+
+// NodeColumnOrdinalSet contains a set of NodeColumnOrdinal values.
+type NodeColumnOrdinalSet = util.FastIntSet
 
 // CheckOrdinalSet contains the ordinal positions of a set of check constraints
 // taken from the opt.Table.Check collection.
@@ -609,7 +621,7 @@ type AggInfo struct {
 	Builtin    *tree.Overload
 	Distinct   bool
 	ResultType *types.T
-	ArgCols    []ColumnOrdinal
+	ArgCols    []NodeColumnOrdinal
 
 	// ConstArgs is the list of any constant arguments to the aggregate,
 	// for instance, the separator in string_agg.
@@ -617,7 +629,7 @@ type AggInfo struct {
 
 	// Filter is the index of the column, if any, which should be used as the
 	// FILTER condition for the aggregate. If there is no filter, Filter is -1.
-	Filter ColumnOrdinal
+	Filter NodeColumnOrdinal
 }
 
 // WindowInfo represents the information about a window function that must be
@@ -637,13 +649,13 @@ type WindowInfo struct {
 
 	// ArgIdxs is the list of column ordinals each function takes as arguments,
 	// in the same order as Exprs.
-	ArgIdxs [][]ColumnOrdinal
+	ArgIdxs [][]NodeColumnOrdinal
 
 	// FilterIdxs is the list of column indices to use as filters.
 	FilterIdxs []int
 
 	// Partition is the set of input columns to partition on.
-	Partition []ColumnOrdinal
+	Partition []NodeColumnOrdinal
 
 	// Ordering is the set of input columns to order on.
 	Ordering sqlbase.ColumnOrdering
@@ -653,7 +665,7 @@ type WindowInfo struct {
 	// boundary. We store it separately because the ordering might be simplified
 	// (when that single column is in Partition), but the execution still needs
 	// to know the original ordering.
-	RangeOffsetColumn ColumnOrdinal
+	RangeOffsetColumn NodeColumnOrdinal
 }
 
 // ExplainEnvData represents the data that's going to be displayed in EXPLAIN (env).
@@ -695,7 +707,7 @@ type InsertFastPathFKCheck struct {
 	// InsertCols contains the FK columns from the origin table, in the order of
 	// the ReferencedIndex columns. For each, the value in the array indicates the
 	// index of the column in the input table.
-	InsertCols []ColumnOrdinal
+	InsertCols []TableColumnOrdinal
 
 	MatchMethod tree.CompositeKeyMatchMethod
 

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -24,6 +24,13 @@ import (
 // (currently maps to sql.planNode).
 type Node interface{}
 
+// BufferNode is a node returned by ConstructBuffer.
+type BufferNode interface {
+	Node
+
+	BufferNodeMarker()
+}
+
 // Plan represents the plan for a query (currently maps to sql.planTop).
 // For simple queries, the plan is associated with a single Node tree.
 // For queries containing subqueries, the plan is associated with multiple Node
@@ -503,11 +510,11 @@ type Factory interface {
 
 	// ConstructBuffer constructs a node whose input can be referenced from
 	// elsewhere in the query.
-	ConstructBuffer(input Node, label string) (Node, error)
+	ConstructBuffer(input Node, label string) (BufferNode, error)
 
 	// ConstructScanBuffer constructs a node which refers to a node constructed by
 	// ConstructBuffer or passed to RecursiveCTEIterationFn.
-	ConstructScanBuffer(ref Node, label string) (Node, error)
+	ConstructScanBuffer(ref BufferNode, label string) (Node, error)
 
 	// ConstructRecursiveCTE constructs a node that executes a recursive CTE:
 	//   * the initial plan is run first; the results are emitted and also saved
@@ -666,9 +673,8 @@ type KVOption struct {
 }
 
 // RecursiveCTEIterationFn creates a plan for an iteration of WITH RECURSIVE,
-// given the result of the last iteration (as a Buffer that can be used with
-// ConstructScanBuffer).
-type RecursiveCTEIterationFn func(bufferRef Node) (Plan, error)
+// given the result of the last iteration (as a BufferNode).
+type RecursiveCTEIterationFn func(bufferRef BufferNode) (Plan, error)
 
 // ApplyJoinPlanRightSideFn creates a plan for an iteration of ApplyJoin, given
 // a row produced from the left side. The plan is guaranteed to produce the

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -802,7 +802,7 @@ func (ef *execFactory) ConstructMax1Row(input exec.Node, errorText string) (exec
 }
 
 // ConstructBuffer is part of the exec.Factory interface.
-func (ef *execFactory) ConstructBuffer(input exec.Node, label string) (exec.Node, error) {
+func (ef *execFactory) ConstructBuffer(input exec.Node, label string) (exec.BufferNode, error) {
 	return &bufferNode{
 		plan:  input.(planNode),
 		label: label,
@@ -810,7 +810,7 @@ func (ef *execFactory) ConstructBuffer(input exec.Node, label string) (exec.Node
 }
 
 // ConstructScanBuffer is part of the exec.Factory interface.
-func (ef *execFactory) ConstructScanBuffer(ref exec.Node, label string) (exec.Node, error) {
+func (ef *execFactory) ConstructScanBuffer(ref exec.BufferNode, label string) (exec.Node, error) {
 	return &scanBufferNode{
 		buffer: ref.(*bufferNode),
 		label:  label,

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -66,7 +66,7 @@ func (ef *execFactory) ConstructValues(
 func (ef *execFactory) ConstructScan(
 	table cat.Table,
 	index cat.Index,
-	needed exec.ColumnOrdinalSet,
+	needed exec.TableColumnOrdinalSet,
 	indexConstraint *constraint.Constraint,
 	hardLimit int64,
 	softLimit int64,
@@ -136,7 +136,7 @@ func (ef *execFactory) ConstructScan(
 func (ef *execFactory) constructVirtualScan(
 	table cat.Table,
 	index cat.Index,
-	needed exec.ColumnOrdinalSet,
+	needed exec.TableColumnOrdinalSet,
 	indexConstraint *constraint.Constraint,
 	hardLimit int64,
 	softLimit int64,
@@ -170,10 +170,10 @@ func (ef *execFactory) constructVirtualScan(
 	}
 	if needed.Len() != len(columns) {
 		// We are selecting a subset of columns; we need a projection.
-		cols := make([]exec.ColumnOrdinal, 0, needed.Len())
+		cols := make([]exec.NodeColumnOrdinal, 0, needed.Len())
 		colNames := make([]string, len(cols))
 		for ord, ok := needed.Next(0); ok; ord, ok = needed.Next(ord + 1) {
-			cols = append(cols, exec.ColumnOrdinal(ord-1))
+			cols = append(cols, exec.NodeColumnOrdinal(ord-1))
 			colNames = append(colNames, columns[ord-1].Name)
 		}
 		n, err = ef.ConstructSimpleProject(n, cols, colNames, nil /* reqOrdering */)
@@ -234,7 +234,7 @@ func (ef *execFactory) ConstructFilter(
 
 // ConstructSimpleProject is part of the exec.Factory interface.
 func (ef *execFactory) ConstructSimpleProject(
-	n exec.Node, cols []exec.ColumnOrdinal, colNames []string, reqOrdering exec.OutputOrdering,
+	n exec.Node, cols []exec.NodeColumnOrdinal, colNames []string, reqOrdering exec.OutputOrdering,
 ) (exec.Node, error) {
 	// If the top node is already a renderNode, just rearrange the columns. But
 	// we don't want to duplicate a rendering expression (in case it is expensive
@@ -273,7 +273,7 @@ func (ef *execFactory) ConstructSimpleProject(
 	return rb.res, nil
 }
 
-func hasDuplicates(cols []exec.ColumnOrdinal) bool {
+func hasDuplicates(cols []exec.NodeColumnOrdinal) bool {
 	var set util.FastIntSet
 	for _, c := range cols {
 		if set.Contains(int(c)) {
@@ -310,7 +310,7 @@ func (ef *execFactory) RenameColumns(n exec.Node, colNames []string) (exec.Node,
 func (ef *execFactory) ConstructHashJoin(
 	joinType sqlbase.JoinType,
 	left, right exec.Node,
-	leftEqCols, rightEqCols []exec.ColumnOrdinal,
+	leftEqCols, rightEqCols []exec.NodeColumnOrdinal,
 	leftEqColsAreKey, rightEqColsAreKey bool,
 	extraOnCond tree.TypedExpr,
 ) (exec.Node, error) {
@@ -440,7 +440,7 @@ func (ef *execFactory) ConstructScalarGroupBy(
 // ConstructGroupBy is part of the exec.Factory interface.
 func (ef *execFactory) ConstructGroupBy(
 	input exec.Node,
-	groupCols []exec.ColumnOrdinal,
+	groupCols []exec.NodeColumnOrdinal,
 	groupColOrdering sqlbase.ColumnOrdering,
 	aggregations []exec.AggInfo,
 	reqOrdering exec.OutputOrdering,
@@ -524,7 +524,7 @@ func (ef *execFactory) addAggregations(n *groupNode, aggregations []exec.AggInfo
 // ConstructDistinct is part of the exec.Factory interface.
 func (ef *execFactory) ConstructDistinct(
 	input exec.Node,
-	distinctCols, orderedCols exec.ColumnOrdinalSet,
+	distinctCols, orderedCols exec.NodeColumnOrdinalSet,
 	reqOrdering exec.OutputOrdering,
 	nullsAreDistinct bool,
 	errorOnDup string,
@@ -581,8 +581,8 @@ func (ef *execFactory) ConstructOrdinality(input exec.Node, colName string) (exe
 func (ef *execFactory) ConstructIndexJoin(
 	input exec.Node,
 	table cat.Table,
-	keyCols []exec.ColumnOrdinal,
-	tableCols exec.ColumnOrdinalSet,
+	keyCols []exec.NodeColumnOrdinal,
+	tableCols exec.TableColumnOrdinalSet,
 	reqOrdering exec.OutputOrdering,
 ) (exec.Node, error) {
 	tabDesc := table.(*optTable).desc
@@ -622,9 +622,9 @@ func (ef *execFactory) ConstructLookupJoin(
 	input exec.Node,
 	table cat.Table,
 	index cat.Index,
-	eqCols []exec.ColumnOrdinal,
+	eqCols []exec.NodeColumnOrdinal,
 	eqColsAreKey bool,
-	lookupCols exec.ColumnOrdinalSet,
+	lookupCols exec.TableColumnOrdinalSet,
 	onCond tree.TypedExpr,
 	reqOrdering exec.OutputOrdering,
 ) (exec.Node, error) {
@@ -671,7 +671,7 @@ func (ef *execFactory) ConstructLookupJoin(
 func (ef *execFactory) constructScanForZigzag(
 	indexDesc *sqlbase.IndexDescriptor,
 	tableDesc *sqlbase.ImmutableTableDescriptor,
-	cols exec.ColumnOrdinalSet,
+	cols exec.NodeColumnOrdinalSet,
 ) (*scanNode, error) {
 
 	colCfg := scanColumnsConfig{
@@ -699,10 +699,10 @@ func (ef *execFactory) ConstructZigzagJoin(
 	leftIndex cat.Index,
 	rightTable cat.Table,
 	rightIndex cat.Index,
-	leftEqCols []exec.ColumnOrdinal,
-	rightEqCols []exec.ColumnOrdinal,
-	leftCols exec.ColumnOrdinalSet,
-	rightCols exec.ColumnOrdinalSet,
+	leftEqCols []exec.NodeColumnOrdinal,
+	rightEqCols []exec.NodeColumnOrdinal,
+	leftCols exec.NodeColumnOrdinalSet,
+	rightCols exec.NodeColumnOrdinalSet,
 	onCond tree.TypedExpr,
 	fixedVals []exec.Node,
 	reqOrdering exec.OutputOrdering,
@@ -1164,8 +1164,8 @@ func (ef *execFactory) ConstructShowTrace(typ tree.ShowTraceType, compact bool) 
 func (ef *execFactory) ConstructInsert(
 	input exec.Node,
 	table cat.Table,
-	insertColOrdSet exec.ColumnOrdinalSet,
-	returnColOrdSet exec.ColumnOrdinalSet,
+	insertColOrdSet exec.TableColumnOrdinalSet,
+	returnColOrdSet exec.TableColumnOrdinalSet,
 	checkOrdSet exec.CheckOrdinalSet,
 	allowAutoCommit bool,
 	skipFKChecks bool,
@@ -1241,8 +1241,8 @@ func (ef *execFactory) ConstructInsert(
 func (ef *execFactory) ConstructInsertFastPath(
 	rows [][]tree.TypedExpr,
 	table cat.Table,
-	insertColOrdSet exec.ColumnOrdinalSet,
-	returnColOrdSet exec.ColumnOrdinalSet,
+	insertColOrdSet exec.TableColumnOrdinalSet,
+	returnColOrdSet exec.TableColumnOrdinalSet,
 	checkOrdSet exec.CheckOrdinalSet,
 	fkChecks []exec.InsertFastPathFKCheck,
 ) (exec.Node, error) {
@@ -1319,9 +1319,9 @@ func (ef *execFactory) ConstructInsertFastPath(
 func (ef *execFactory) ConstructUpdate(
 	input exec.Node,
 	table cat.Table,
-	fetchColOrdSet exec.ColumnOrdinalSet,
-	updateColOrdSet exec.ColumnOrdinalSet,
-	returnColOrdSet exec.ColumnOrdinalSet,
+	fetchColOrdSet exec.TableColumnOrdinalSet,
+	updateColOrdSet exec.TableColumnOrdinalSet,
+	returnColOrdSet exec.TableColumnOrdinalSet,
 	checks exec.CheckOrdinalSet,
 	passthrough sqlbase.ResultColumns,
 	allowAutoCommit bool,
@@ -1472,11 +1472,11 @@ func (ef *execFactory) makeFkMetadata(
 func (ef *execFactory) ConstructUpsert(
 	input exec.Node,
 	table cat.Table,
-	canaryCol exec.ColumnOrdinal,
-	insertColOrdSet exec.ColumnOrdinalSet,
-	fetchColOrdSet exec.ColumnOrdinalSet,
-	updateColOrdSet exec.ColumnOrdinalSet,
-	returnColOrdSet exec.ColumnOrdinalSet,
+	canaryCol exec.NodeColumnOrdinal,
+	insertColOrdSet exec.TableColumnOrdinalSet,
+	fetchColOrdSet exec.TableColumnOrdinalSet,
+	updateColOrdSet exec.TableColumnOrdinalSet,
+	returnColOrdSet exec.TableColumnOrdinalSet,
 	checks exec.CheckOrdinalSet,
 	allowAutoCommit bool,
 	skipFKChecks bool,
@@ -1595,8 +1595,8 @@ func (ef *execFactory) ConstructUpsert(
 func (ef *execFactory) ConstructDelete(
 	input exec.Node,
 	table cat.Table,
-	fetchColOrdSet exec.ColumnOrdinalSet,
-	returnColOrdSet exec.ColumnOrdinalSet,
+	fetchColOrdSet exec.TableColumnOrdinalSet,
+	returnColOrdSet exec.TableColumnOrdinalSet,
 	allowAutoCommit bool,
 	skipFKChecks bool,
 ) (exec.Node, error) {
@@ -1689,7 +1689,7 @@ func (ef *execFactory) ConstructDelete(
 
 func (ef *execFactory) ConstructDeleteRange(
 	table cat.Table,
-	needed exec.ColumnOrdinalSet,
+	needed exec.TableColumnOrdinalSet,
 	indexConstraint *constraint.Constraint,
 	maxReturnedKeys int,
 	allowAutoCommit bool,
@@ -1933,7 +1933,7 @@ func (rb *renderBuilder) addExpr(expr tree.TypedExpr, colName string) {
 
 // makeColDescList returns a list of table column descriptors. Columns are
 // included if their ordinal position in the table schema is in the cols set.
-func makeColDescList(table cat.Table, cols exec.ColumnOrdinalSet) []sqlbase.ColumnDescriptor {
+func makeColDescList(table cat.Table, cols exec.TableColumnOrdinalSet) []sqlbase.ColumnDescriptor {
 	colDescs := make([]sqlbase.ColumnDescriptor, 0, cols.Len())
 	for i, n := 0, table.DeletableColumnCount(); i < n; i++ {
 		if !cols.Contains(i) {
@@ -1947,7 +1947,7 @@ func makeColDescList(table cat.Table, cols exec.ColumnOrdinalSet) []sqlbase.Colu
 // makeScanColumnsConfig builds a scanColumnsConfig struct by constructing a
 // list of descriptor IDs for columns in the given cols set. Columns are
 // identified by their ordinal position in the table schema.
-func makeScanColumnsConfig(table cat.Table, cols exec.ColumnOrdinalSet) scanColumnsConfig {
+func makeScanColumnsConfig(table cat.Table, cols exec.TableColumnOrdinalSet) scanColumnsConfig {
 	// Set visibility=publicAndNonPublicColumns, since all columns in the "cols"
 	// set should be projected, regardless of whether they're public or non-
 	// public. The caller decides which columns to include (or not include). Note

--- a/pkg/sql/span/span_builder.go
+++ b/pkg/sql/span/span_builder.go
@@ -197,7 +197,7 @@ func (s *Builder) CanSplitSpanIntoSeparateFamilies(
 // TODO (rohany): In future work, there should be a single API to generate spans
 //  from constraints, datums and encdatums.
 func (s *Builder) SpansFromConstraint(
-	c *constraint.Constraint, needed util.FastIntSet, forDelete bool,
+	c *constraint.Constraint, needed exec.TableColumnOrdinalSet, forDelete bool,
 ) (roachpb.Spans, error) {
 	var spans roachpb.Spans
 	var err error
@@ -223,7 +223,7 @@ func (s *Builder) SpansFromConstraint(
 // UnconstrainedSpans returns the full span corresponding to the Builder's
 // table and index.
 func (s *Builder) UnconstrainedSpans(forDelete bool) (roachpb.Spans, error) {
-	return s.SpansFromConstraint(nil, exec.ColumnOrdinalSet{}, forDelete)
+	return s.SpansFromConstraint(nil, exec.TableColumnOrdinalSet{}, forDelete)
 }
 
 // appendSpansFromConstraintSpan converts a constraint.Span to one or more
@@ -232,7 +232,7 @@ func (s *Builder) UnconstrainedSpans(forDelete bool) (roachpb.Spans, error) {
 // scanned. The forDelete parameter indicates whether these spans will be used
 // for row deletion.
 func (s *Builder) appendSpansFromConstraintSpan(
-	appendTo roachpb.Spans, cs *constraint.Span, needed util.FastIntSet, forDelete bool,
+	appendTo roachpb.Spans, cs *constraint.Span, needed exec.TableColumnOrdinalSet, forDelete bool,
 ) (roachpb.Spans, error) {
 	var span roachpb.Span
 	var err error


### PR DESCRIPTION
#### opt: better type safety for buffer nodes in exec.Factory

This change adds an `exec.BufferNode` interface, which makes it more clear where
only such nodes can be used.

Release note: None

#### exec: separate node and table column ordinals in exec.Factory

We use ColumnOrdinal / ColumnOrdinalSet in the factory to refer to either table
column ordinals or node column ordinals. This can be confusing and has led to
bugs in the past. This commit separates the two types.

Release note: None
