### PR TITLE
Avoid adding sql mem metrics twice

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -469,8 +469,8 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 	execCfg.StatsRefresher = statsRefresher
 
 	// Set up internal memory metrics for use by internal SQL executors.
+	// Don't add them to the registry now because it will be added as part of pgServer metrics.
 	sqlMemMetrics := sql.MakeMemMetrics("sql", cfg.HistogramWindowInterval())
-	cfg.registry.AddMetricStruct(sqlMemMetrics)
 	pgServer := pgwire.MakeServer(
 		cfg.AmbientCtx,
 		cfg.Config.Config,


### PR DESCRIPTION
SQL memory metrics are registered twice and they are also reported
twice by metrics exporters. This is specially strange on Prometheus
histograms, where buckets are duplicated:

```
sql_mem_sql_txn_max_bucket{le="+Inf"} 0.0
sql_mem_sql_txn_max_sum 0.0
sql_mem_sql_txn_max_count 0.0
sql_mem_sql_txn_max_bucket{le="+Inf"} 0.0
sql_mem_sql_txn_max_sum 0.0
sql_mem_sql_txn_max_count 0.0
```

Release note (bug fix): Remove duplicated SQL memory metrics.