### PR TITLE
logictest: add 3node-tenant configuration 

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -143,7 +143,7 @@ type sqlServerArgs struct {
 	protectedtsProvider protectedts.Provider
 	// DistSQLCfg holds on to this to check for node CPU utilization in
 	// samplerProcessor.
-	runtime *status.RuntimeStatSampler
+	runtime execinfra.RuntimeStats
 
 	// SQL uses KV, both for non-DistSQL and DistSQL execution.
 	db *kv.DB

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -33,6 +33,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptprovider"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/tscache"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -423,6 +425,14 @@ func (allErrorsFakeLiveness) IsLive(roachpb.NodeID) (bool, error) {
 	return false, errors.New("fake liveness")
 }
 
+type dummyProtectedTSProvider struct {
+	protectedts.Provider
+}
+
+func (d dummyProtectedTSProvider) Protect(context.Context, *kv.Txn, *ptpb.Record) error {
+	return errors.New("fake protectedts.Provider")
+}
+
 func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 	st := cluster.MakeTestingClusterSettings()
 	stopper := ts.Stopper()
@@ -436,11 +446,21 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 
 	ds := ts.DistSender()
 
+	circularInternalExecutor := &sql.InternalExecutor{}
 	// Protected timestamps won't be available (at first) in multi-tenant
-	// clusters. TODO(tbg): fail with an error instead of a crash when it's
-	// used. I believe IMPORT INTO is the only use that needs it for correct-
-	// ness, everywhere else we can just not protect the timestamp and continue.
+	// clusters.
 	var protectedTSProvider protectedts.Provider
+	{
+		pp, err := ptprovider.New(ptprovider.Config{
+			DB:               ts.DB(),
+			InternalExecutor: circularInternalExecutor,
+			Settings:         st,
+		})
+		if err != nil {
+			panic(err)
+		}
+		protectedTSProvider = dummyProtectedTSProvider{pp}
+	}
 
 	registry := metric.NewRegistry()
 
@@ -488,7 +508,7 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 		runtime:                  status.NewRuntimeStatSampler(context.Background(), clock),
 		db:                       ts.DB(),
 		registry:                 registry,
-		circularInternalExecutor: &sql.InternalExecutor{},
+		circularInternalExecutor: circularInternalExecutor,
 		jobRegistry:              &jobs.Registry{},
 	}
 }

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -485,7 +485,7 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 		stopper:                  stopper,
 		clock:                    clock,
 		protectedtsProvider:      protectedTSProvider,
-		runtime:                  &status.RuntimeStatSampler{}, // dummy
+		runtime:                  status.NewRuntimeStatSampler(context.Background(), clock),
 		db:                       ts.DB(),
 		registry:                 registry,
 		circularInternalExecutor: &sql.InternalExecutor{},

--- a/pkg/sql/logictest/testdata/logic_test/tenant_unsupported
+++ b/pkg/sql/logictest/testdata/logic_test/tenant_unsupported
@@ -1,0 +1,70 @@
+# This file documents operations that are unsupported when running a SQL tenant
+# server.
+# TODO(tbg): file an issue detailing which ones are Phase 2 blockers.
+# LogicTest: 3node-tenant
+
+statement ok
+CREATE TABLE kv (k STRING PRIMARY KEY, v STRING)
+
+statement ok
+INSERT INTO kv VALUES ('foo', 'bar')
+
+# This isn't actually using DistSQL since it fails during planning (node liveness
+# and friends are missing). The work to do here for Phase 2 is to not even try
+# DistSQL on tenant SQL servers.
+query I
+SET distsql = on; SELECT count(*) FROM kv
+----
+1
+
+# This works, but jobs itself will need work as it relies on node liveness and
+# having a NodeID.
+query I
+SELECT job_id FROM [ SHOW JOBS ] WHERE job_id = 0
+----
+
+# Temp tables work, but the TemporaryObjectCleaner needs some work as it
+# relies on the status server.
+statement ok
+SET experimental_enable_temp_tables = true
+
+statement ok
+CREATE TEMP TABLE users (id UUID, city STRING, CONSTRAINT "primary" PRIMARY KEY (id ASC, city ASC))
+
+statement error pgcode XX000 operation is unsupported
+ALTER TABLE kv CONFIGURE ZONE USING num_replicas = 123
+
+# Missing status server
+
+statement error pgcode XX000 operation is unsupported
+SHOW SESSIONS
+
+statement error pgcode XX000 operation is unsupported
+SHOW QUERIES
+
+statement error pgcode XX000 operation is unsupported
+CANCEL QUERY ''
+
+statement error pgcode XX000 operation is unsupported
+CANCEL SESSION ''
+
+statement error pgcode XX000 operation is unsupported
+SELECT * FROM crdb_internal.node_transactions
+
+statement error pgcode XX000 operation is unsupported
+SELECT * FROM crdb_internal.node_sessions
+
+statement error pgcode XX000 operation is unsupported
+SELECT * FROM crdb_internal.node_queries
+
+statement error pgcode XX000 operation is unsupported
+SELECT * FROM crdb_internal.cluster_sessions
+
+statement error pgcode XX000 operation is unsupported
+SELECT * FROM crdb_internal.cluster_queries
+
+statement error pgcode XX000 operation is unsupported
+SELECT * FROM crdb_internal.kv_store_status
+
+statement error pgcode XX000 operation is unsupported
+SELECT * FROM crdb_internal.kv_node_status


### PR DESCRIPTION
In this configuration, the `*gosql.DB`s used by the test are started
against a SQL tenant server pointed at one of the TestServers.

The goal is to make this a default config over time that skips only
those test files which are known to test functionality not available
in a multi-tenancy setup.

For now, it's exercised by a newly added logic test that tests some
of the expected errors.

cc @nvanbenschoten @andreimatei 

Release note: None