### PR TITLE
cli: deprecate 'cockroach quit'

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1387,7 +1387,7 @@ Available Commands:
   start-single-node start a single-node cluster
   init              initialize a cluster
   cert              create ca, node, and client certs
-  quit              drain and shut down a node
+  quit              drain and shut down a node (DEPRECATED)
 
   sql               open a sql shell
   auth-session      log in and out of HTTP sessions

--- a/pkg/cli/quit.go
+++ b/pkg/cli/quit.go
@@ -32,24 +32,18 @@ import (
 // quitCmd command shuts down the node server.
 var quitCmd = &cobra.Command{
 	Use:   "quit",
-	Short: "drain and shut down a node\n",
+	Short: "drain and shut down a node (DEPRECATED)\n",
 	Long: `
-Shut down the server. The first stage is drain, where the server
-stops accepting client connections, then stops extant
-connections, and finally pushes range leases onto other nodes,
-subject to various timeout parameters configurable via
-cluster settings. After the first stage completes,
-the server process is shut down.
-
-See also 'cockroach node drain' to drain a server
-without stopping the server process.
-`,
+This command is deprecated.
+Instead, use 'cockroach node drain' to stop all activity on a server
+then use a process manager or orchestration layer to terminate the process.`,
 	Args: cobra.NoArgs,
 	RunE: MaybeDecorateGRPCError(runQuit),
 }
 
 // runQuit accesses the quit shutdown path.
 func runQuit(cmd *cobra.Command, args []string) (err error) {
+	fmt.Fprintf(stderr, "warning: %s\n", strings.ReplaceAll(strings.TrimSpace(cmd.Long), "\n", " "))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 


### PR DESCRIPTION
tldr: `cockroach quit` marked deprecated in 20.2, will be removed in 21.1

Fixes  #47608

With the advent of `cockroach node drain`, better support for
signal-based termination (eg Ctrl+C) and the move towards emphasizing
orchestration and service managers, there is much less need for
`cockroach quit` overall.

Also it has confusing semantics because it does not guarantee the
server process has terminated when `quit` terminates.

Release note (cli change): The command `cockroach quit` is now
deprecated. Deployments are encouraged to use the new `cockroach node
drain` command instead, followed by process termination using
their standard service/process manager or orchestration tool.