### PR TITLE
cli: add --geo-libs flag for geospatial library location

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1050,6 +1050,12 @@ Start with an empty database: avoid pre-loading a default dataset in
 the demo shell.`,
 	}
 
+	GeoLibsDir = FlagInfo{
+		Name: "geo-libs",
+		Description: `
+The location where all libraries for Geospatial operations is located.`,
+	}
+
 	Global = FlagInfo{
 		Name: "global",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -127,6 +127,7 @@ func initCLIDefaults() {
 	startCtx.listeningURLFile = ""
 	startCtx.pidFile = ""
 	startCtx.inBackground = false
+	startCtx.geoLibsDir = "/usr/local/lib"
 
 	quitCtx.serverDecommission = false
 	quitCtx.drainWait = 10 * time.Minute
@@ -167,6 +168,7 @@ func initCLIDefaults() {
 	demoCtx.disableLicenseAcquisition = false
 	demoCtx.transientCluster = nil
 	demoCtx.insecure = false
+	demoCtx.geoLibsDir = "/usr/local/lib"
 
 	authCtx.validityPeriod = 1 * time.Hour
 
@@ -325,6 +327,9 @@ var startCtx struct {
 
 	// logging settings specific to file logging.
 	logDir log.DirName
+
+	// geoLibsDir is used to specify locations of the GEOS library.
+	geoLibsDir string
 }
 
 // quitCtx captures the command-line parameters of the `quit` and
@@ -392,4 +397,5 @@ var demoCtx struct {
 	simulateLatency           bool
 	transientCluster          *transientCluster
 	insecure                  bool
+	geoLibsDir                string
 }

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -18,10 +18,12 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
+	"github.com/cockroachdb/cockroach/pkg/geo/geos"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/errors"
@@ -259,6 +261,13 @@ func runDemo(cmd *cobra.Command, gen workload.Generator) (err error) {
 
 	if err := checkTzDatabaseAvailability(ctx); err != nil {
 		return err
+	}
+
+	loc, err := geos.EnsureInit(geos.EnsureInitErrorDisplayPrivate, demoCtx.geoLibsDir)
+	if err != nil {
+		log.Infof(ctx, "could not initialize GEOS - geospatial functions may not be available: %v", err)
+	} else {
+		log.Infof(ctx, "GEOS initialized at %s", loc)
 	}
 
 	c, err := setupTransientCluster(ctx, cmd, gen)

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -363,6 +363,7 @@ func init() {
 		StringFlag(f, &startCtx.listeningURLFile, cliflags.ListeningURLFile, startCtx.listeningURLFile)
 
 		StringFlag(f, &startCtx.pidFile, cliflags.PIDFile, startCtx.pidFile)
+		StringFlag(f, &startCtx.geoLibsDir, cliflags.GeoLibsDir, startCtx.geoLibsDir)
 
 		// Use a separate variable to store the value of ServerInsecure.
 		// We share the default with the ClientInsecure flag.
@@ -657,6 +658,7 @@ func init() {
 	// The --empty flag is only valid for the top level demo command,
 	// so we use the regular flag set.
 	BoolFlag(demoCmd.Flags(), &demoCtx.useEmptyDatabase, cliflags.UseEmptyDatabase, demoCtx.useEmptyDatabase)
+	StringFlag(demoFlags, &demoCtx.geoLibsDir, cliflags.GeoLibsDir, demoCtx.geoLibsDir)
 
 	// sqlfmt command.
 	fmtFlags := sqlfmtCmd.Flags()

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
+	"github.com/cockroachdb/cockroach/pkg/geo/geos"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -659,6 +660,15 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 			// the time this function gets called.
 			log.Warningf(ctx, msg)
 		}
+	}
+
+	// Set up the Geospatial library.
+	// We need to make sure this happens before any queries involving geospatial data is executed.
+	loc, err := geos.EnsureInit(geos.EnsureInitErrorDisplayPrivate, demoCtx.geoLibsDir)
+	if err != nil {
+		log.Infof(ctx, "could not initialize GEOS - geospatial functions may not be available: %v", err)
+	} else {
+		log.Infof(ctx, "GEOS initialized at %s", loc)
 	}
 
 	// Beyond this point, the configuration is set and the server is

--- a/pkg/geo/geos/geos_unix_test.go
+++ b/pkg/geo/geos/geos_unix_test.go
@@ -21,34 +21,35 @@ import (
 
 func TestInitGEOS(t *testing.T) {
 	t.Run("test no initGEOS paths", func(t *testing.T) {
-		_, err := initGEOS([]string{})
+		_, _, err := initGEOS([]string{})
 		require.Error(t, err)
 	})
 
 	t.Run("test invalid initGEOS paths", func(t *testing.T) {
-		_, err := initGEOS([]string{"/invalid/path"})
+		_, _, err := initGEOS([]string{"/invalid/path"})
 		require.Error(t, err)
 	})
 
 	t.Run("test valid initGEOS paths", func(t *testing.T) {
-		ret, err := initGEOS(defaultGEOSLocations)
+		ret, loc, err := initGEOS(findGEOSLocations(""))
 		require.NoError(t, err)
+		require.NotEmpty(t, loc)
 		require.NotNil(t, ret)
 	})
 }
 
 func TestEnsureInit(t *testing.T) {
 	// Fetch at least once.
-	_, err := ensureInit(EnsureInitErrorDisplayPublic)
+	_, err := ensureInit(EnsureInitErrorDisplayPublic, "")
 	require.NoError(t, err)
 
 	fakeErr := errors.Newf("contain path info do not display me")
 	defer func() { geosOnce.err = nil }()
 
 	geosOnce.err = fakeErr
-	_, err = ensureInit(EnsureInitErrorDisplayPrivate)
+	_, err = ensureInit(EnsureInitErrorDisplayPrivate, "")
 	require.Contains(t, err.Error(), fakeErr.Error())
 
-	_, err = ensureInit(EnsureInitErrorDisplayPublic)
+	_, err = ensureInit(EnsureInitErrorDisplayPublic, "")
 	require.Equal(t, errors.Newf("geos: this operation is not available").Error(), err.Error())
 }

--- a/pkg/geo/geos/geos_windows.go
+++ b/pkg/geo/geos/geos_windows.go
@@ -17,8 +17,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 )
 
-func EnsureInit(errDisplay EnsureInitErrorDisplay) error {
-	return nil
+func EnsureInit(errDisplay EnsureInitErrorDisplay, flagGEOSLocationValue string) (string, error) {
+	return "", nil
 }
 
 func WKTToEWKB(wkt geopb.WKT, srid geopb.SRID) (geopb.EWKB, error) {

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/blobs/blobspb"
-	"github.com/cockroachdb/cockroach/pkg/geo/geos"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -547,10 +546,6 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 		cfg.isMeta1Leaseholder,
 		sqlExecutorTestingKnobs,
 	)
-
-	if err := geos.EnsureInit(geos.EnsureInitErrorDisplayPrivate); err != nil {
-		log.Infof(ctx, "could not initialize GEOS - geospatial functions may not be available: %v", err)
-	}
 
 	return &sqlServer{
 		pgServer:                pgServer,


### PR DESCRIPTION
Add a flag to the CLI (--geo-libs) which contains the libraries with
geospatial capabilities we need (e.g. GEOS, maybe PROJ4/SFCGAL later).
This is used by GEOS in addition to looking at parenting directories.

Also log the directory which GEOS was initialized.

Release note: None