### PR TITLE
util/log: fix lying comment

### DIFF
--- a/pkg/util/log/exit_override.go
+++ b/pkg/util/log/exit_override.go
@@ -21,8 +21,11 @@ import (
 // if true, suppresses the stack trace, which is useful for test
 // callers wishing to keep the logs reasonably clean.
 //
-// Call with a nil function to undo.
+// Use ResetExitFunc() to reset.
 func SetExitFunc(hideStack bool, f func(int)) {
+	if f == nil {
+		panic("nil exit func invalid")
+	}
 	setExitErrFunc(hideStack, func(x int, err error) { f(x) })
 }
 


### PR DESCRIPTION
SetExitFunc() claimed that a nil function was a way to reset it. It
wasn't; it'd lead to a crash.

Release note: None