### PR TITLE
acceptance: print same cluster.ExternalAddr string that was compared

### DIFF
--- a/pkg/cmd/roachtest/gossip.go
+++ b/pkg/cmd/roachtest/gossip.go
@@ -484,9 +484,8 @@ func runCheckLocalityIPAddress(ctx context.Context, t *test, c *cluster) {
 				if !strings.Contains(advertiseAddress, "localhost") {
 					t.Fatal("Expected connect address to contain localhost")
 				}
-			} else if c.ExternalAddr(ctx, c.Node(nodeID))[0] != advertiseAddress {
-				t.Fatalf("Connection address is %s but expected %s",
-					advertiseAddress, c.ExternalAddr(ctx, c.Node(nodeID))[0])
+			} else if exp := c.ExternalAddr(ctx, c.Node(nodeID))[0]; exp != advertiseAddress {
+				t.Fatalf("Connection address is %s but expected %s", advertiseAddress, exp)
 			}
 		}
 	}


### PR DESCRIPTION
Closes #47674.

The failure mode in that issue is nonsensical. It must be the case that
the string was different during the comparison than during the `t.Fatal`.
Let's just fix this and close the issue.