### PR TITLE
compose: have cockroach use the "postgres" database

### DIFF
--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -41,24 +41,24 @@ func TestCompare(t *testing.T) {
 		init []string
 	}{
 		"postgres": {
-			addr: "postgresql://postgres@postgres:5432/",
+			addr: "postgresql://postgres@postgres:5432/postgres",
 			init: []string{
 				"drop schema if exists public cascade",
 				"create schema public",
 			},
 		},
 		"cockroach1": {
-			addr: "postgresql://root@cockroach1:26257/?sslmode=disable",
+			addr: "postgresql://root@cockroach1:26257/postgres?sslmode=disable",
 			init: []string{
-				"drop database if exists defaultdb",
-				"create database defaultdb",
+				"drop database if exists postgres",
+				"create database postgres",
 			},
 		},
 		"cockroach2": {
-			addr: "postgresql://root@cockroach2:26257/?sslmode=disable",
+			addr: "postgresql://root@cockroach2:26257/postgres?sslmode=disable",
 			init: []string{
-				"drop database if exists defaultdb",
-				"create database defaultdb",
+				"drop database if exists postgres",
+				"create database postgres",
 			},
 		},
 	}


### PR DESCRIPTION
This is needed because postgres can't do cross-database queries. So,
we'll just use the default "postgres" database since it exists at startup,
and have cockroach create and use a database of the same name.

You can't connect to a database that doesn't exist in postgres, so having
postgres connect to the "defaultdb" database that cockroach uses would
require changing something to first create that before it connected,
and the current stuff isn't designed to do that. (There's probably a
way to do it in the docker image, but this is just as easy.)

Release note: None