### PR TITLE
sql: refactors and renames of table name related structs

### DIFF
--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -242,7 +242,7 @@ func descriptorsMatchingTargets(
 			}
 
 		case *tree.AllTablesSelector:
-			found, descI, err := p.TableNamePrefix.Resolve(ctx, resolver, currentDatabase, searchPath)
+			found, descI, err := p.ObjectNamePrefix.Resolve(ctx, resolver, currentDatabase, searchPath)
 			if err != nil {
 				return ret, err
 			}

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -618,7 +618,7 @@ func importPlanHook(
 
 				var match string
 				if table != nil {
-					match = table.TableName.String()
+					match = table.ObjectName.String()
 				}
 
 				fks := fkHandler{skip: skipFKs, allowed: true, resolver: make(fkResolver)}
@@ -636,7 +636,7 @@ func importPlanHook(
 					return err
 				}
 				if tableDescs == nil && table != nil {
-					return errors.Errorf("table definition not found for %q", table.TableName.String())
+					return errors.Errorf("table definition not found for %q", table.ObjectName.String())
 				}
 			} else {
 				if table == nil {
@@ -658,10 +658,10 @@ func importPlanHook(
 						return err
 					}
 
-					if table.TableName != create.Table.TableName {
+					if table.ObjectName != create.Table.ObjectName {
 						return errors.Errorf(
 							"importing table %s, but file specifies a schema for table %s",
-							table.TableName, create.Table.TableName,
+							table.ObjectName, create.Table.ObjectName,
 						)
 					}
 				}

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -131,7 +131,7 @@ func MakeSimpleTableDescriptor(
 				continue
 			}
 			// Strip the schema/db prefix.
-			def.Table = tree.MakeUnqualifiedTableName(def.Table.TableName)
+			def.Table = tree.MakeUnqualifiedTableName(def.Table.ObjectName)
 
 		default:
 			return nil, unimplemented.Newf(fmt.Sprintf("import.%T", def), "unsupported table definition: %s", tree.AsString(def))

--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -758,7 +758,7 @@ func dumpTableData(w io.Writer, conn *sqlConn, clusterTS string, bmd basicMetada
 }
 
 func writeInserts(w io.Writer, tmd tableMetadata, inserts []string) {
-	fmt.Fprintf(w, "\nINSERT INTO %s (%s) VALUES", &tmd.name.TableName, tmd.columnNames)
+	fmt.Fprintf(w, "\nINSERT INTO %s (%s) VALUES", &tmd.name.ObjectName, tmd.columnNames)
 	for idx, values := range inserts {
 		if idx > 0 {
 			fmt.Fprint(w, ",")

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2437,7 +2437,7 @@ CREATE TABLE crdb_internal.zones (
 				if p.CheckAnyPrivilege(ctx, database) != nil {
 					continue
 				}
-			} else if zoneSpecifier.TableOrIndex.Table.TableName != "" {
+			} else if zoneSpecifier.TableOrIndex.Table.ObjectName != "" {
 				table, err = sqlbase.GetTableDescFromID(ctx, p.txn, sqlbase.ID(id))
 				if err != nil {
 					return err

--- a/pkg/sql/delegate/show_partitions.go
+++ b/pkg/sql/delegate/show_partitions.go
@@ -110,7 +110,7 @@ func (d *delegator) delegateShowPartitions(n *tree.ShowPartitions) (tree.Stateme
 	tn := n.Index.Table
 
 	// Throw a more descriptive error if the user did not use the index hint syntax.
-	if tn.TableName == "" {
+	if tn.ObjectName == "" {
 		err := errors.New("no table specified")
 		err = pgerror.WithCandidateCode(err, pgcode.InvalidParameterValue)
 		err = errors.WithHint(err, "Specify a table using the hint syntax of table@index")

--- a/pkg/sql/delegate/show_tables.go
+++ b/pkg/sql/delegate/show_tables.go
@@ -25,7 +25,7 @@ import (
 //          mysql only returns tables you have privileges on.
 func (d *delegator) delegateShowTables(n *tree.ShowTables) (tree.Statement, error) {
 	flags := cat.Flags{AvoidDescriptorCaches: true}
-	_, name, err := d.catalog.ResolveSchema(d.ctx, flags, &n.TableNamePrefix)
+	_, name, err := d.catalog.ResolveSchema(d.ctx, flags, &n.ObjectNamePrefix)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -42,9 +42,9 @@ import (
 // databases.
 type StableID uint64
 
-// SchemaName is an alias for tree.TableNamePrefix, since it consists of the
+// SchemaName is an alias for tree.ObjectNamePrefix, since it consists of the
 // catalog + schema name.
-type SchemaName = tree.TableNamePrefix
+type SchemaName = tree.ObjectNamePrefix
 
 // Flags allows controlling aspects of some Catalog operations.
 type Flags struct {

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -37,7 +37,7 @@ func ExpandDataSourceGlob(
 		return []DataSourceName{name}, nil
 
 	case *tree.AllTablesSelector:
-		schema, _, err := catalog.ResolveSchema(ctx, flags, &p.TableNamePrefix)
+		schema, _, err := catalog.ResolveSchema(ctx, flags, &p.ObjectNamePrefix)
 		if err != nil {
 			return nil, err
 		}
@@ -53,7 +53,7 @@ func ExpandDataSourceGlob(
 func ResolveTableIndex(
 	ctx context.Context, catalog Catalog, flags Flags, name *tree.TableIndexName,
 ) (Index, DataSourceName, error) {
-	if name.Table.TableName != "" {
+	if name.Table.ObjectName != "" {
 		ds, tn, err := catalog.ResolveDataSource(ctx, flags, &name.Table)
 		if err != nil {
 			return nil, DataSourceName{}, err
@@ -61,7 +61,7 @@ func ResolveTableIndex(
 		table, ok := ds.(Table)
 		if !ok {
 			return nil, DataSourceName{}, pgerror.Newf(
-				pgcode.WrongObjectType, "%q is not a table", name.Table.TableName,
+				pgcode.WrongObjectType, "%q is not a table", name.Table.ObjectName,
 			)
 		}
 		if name.Index == "" {
@@ -79,7 +79,7 @@ func ResolveTableIndex(
 	}
 
 	// We have to search for a table that has an index with the given name.
-	schema, _, err := catalog.ResolveSchema(ctx, flags, &name.Table.TableNamePrefix)
+	schema, _, err := catalog.ResolveSchema(ctx, flags, &name.Table.ObjectNamePrefix)
 	if err != nil {
 		return nil, DataSourceName{}, err
 	}

--- a/pkg/sql/opt/cat/utils_test.go
+++ b/pkg/sql/opt/cat/utils_test.go
@@ -46,17 +46,17 @@ func TestExpandDataSourceGlob(t *testing.T) {
 			expected: `error: no data source matches prefix: "t.public.z"`,
 		},
 		{
-			pattern:  &tree.AllTablesSelector{TableNamePrefix: tree.TableNamePrefix{}},
+			pattern:  &tree.AllTablesSelector{ObjectNamePrefix: tree.ObjectNamePrefix{}},
 			expected: `[t.public.a t.public.b t.public.c]`,
 		},
 		{
-			pattern: &tree.AllTablesSelector{TableNamePrefix: tree.TableNamePrefix{
+			pattern: &tree.AllTablesSelector{ObjectNamePrefix: tree.ObjectNamePrefix{
 				SchemaName: "t", ExplicitSchema: true,
 			}},
 			expected: `[t.public.a t.public.b t.public.c]`,
 		},
 		{
-			pattern: &tree.AllTablesSelector{TableNamePrefix: tree.TableNamePrefix{
+			pattern: &tree.AllTablesSelector{ObjectNamePrefix: tree.ObjectNamePrefix{
 				SchemaName: "z", ExplicitSchema: true,
 			}},
 			expected: `error: target database or schema does not exist`,

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -622,7 +622,7 @@ func mkFKCheckErr(md *opt.Metadata, c *memo.FKChecksItem, keyVals tree.Datums) e
 		//   DETAIL: Key (child_p)=(2) is not present in table "parent".
 		fk := origin.Table.OutboundForeignKey(c.FKOrdinal)
 		fmt.Fprintf(&msg, "%s on table ", c.OpName)
-		lex.EncodeEscapedSQLIdent(&msg, string(origin.Alias.TableName))
+		lex.EncodeEscapedSQLIdent(&msg, string(origin.Alias.ObjectName))
 		msg.WriteString(" violates foreign key constraint ")
 		lex.EncodeEscapedSQLIdent(&msg, fk.Name())
 
@@ -653,7 +653,7 @@ func mkFKCheckErr(md *opt.Metadata, c *memo.FKChecksItem, keyVals tree.Datums) e
 			details.WriteString("MATCH FULL does not allow mixing of null and nonnull key values.")
 		} else {
 			details.WriteString(") is not present in table ")
-			lex.EncodeEscapedSQLIdent(&details, string(referenced.Alias.TableName))
+			lex.EncodeEscapedSQLIdent(&details, string(referenced.Alias.ObjectName))
 			details.WriteByte('.')
 		}
 	} else {
@@ -663,11 +663,11 @@ func mkFKCheckErr(md *opt.Metadata, c *memo.FKChecksItem, keyVals tree.Datums) e
 		//   DETAIL: Key (p)=(1) is still referenced from table "child".
 		fk := referenced.Table.InboundForeignKey(c.FKOrdinal)
 		fmt.Fprintf(&msg, "%s on table ", c.OpName)
-		lex.EncodeEscapedSQLIdent(&msg, string(referenced.Alias.TableName))
+		lex.EncodeEscapedSQLIdent(&msg, string(referenced.Alias.ObjectName))
 		msg.WriteString(" violates foreign key constraint ")
 		lex.EncodeEscapedSQLIdent(&msg, fk.Name())
 		msg.WriteString(" on table ")
-		lex.EncodeEscapedSQLIdent(&msg, string(origin.Alias.TableName))
+		lex.EncodeEscapedSQLIdent(&msg, string(origin.Alias.ObjectName))
 
 		details.WriteString("Key (")
 		for i := 0; i < fk.ColumnCount(); i++ {
@@ -685,7 +685,7 @@ func mkFKCheckErr(md *opt.Metadata, c *memo.FKChecksItem, keyVals tree.Datums) e
 			details.WriteString(d.String())
 		}
 		details.WriteString(") is still referenced from table ")
-		lex.EncodeEscapedSQLIdent(&details, string(origin.Alias.TableName))
+		lex.EncodeEscapedSQLIdent(&details, string(origin.Alias.ObjectName))
 		details.WriteByte('.')
 	}
 

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -926,7 +926,7 @@ func (f *ExprFmtCtx) formatScalarPrivate(scalar opt.ScalarExpr) {
 		//
 		// TODO(radu): maybe flip these if we are deleting from the parent (i.e.
 		// FKOutbound=false)?
-		fmt.Fprintf(f.Buffer, ": %s(", origin.Alias.TableName)
+		fmt.Fprintf(f.Buffer, ": %s(", origin.Alias.ObjectName)
 		for i := 0; i < fk.ColumnCount(); i++ {
 			if i > 0 {
 				f.Buffer.WriteByte(',')
@@ -934,7 +934,7 @@ func (f *ExprFmtCtx) formatScalarPrivate(scalar opt.ScalarExpr) {
 			col := origin.Table.Column(fk.OriginColumnOrdinal(origin.Table, i))
 			f.Buffer.WriteString(string(col.ColName()))
 		}
-		fmt.Fprintf(f.Buffer, ") -> %s(", referenced.Alias.TableName)
+		fmt.Fprintf(f.Buffer, ") -> %s(", referenced.Alias.ObjectName)
 		for i := 0; i < fk.ColumnCount(); i++ {
 			if i > 0 {
 				f.Buffer.WriteByte(',')

--- a/pkg/sql/opt/norm/fold_constants.go
+++ b/pkg/sql/opt/norm/fold_constants.go
@@ -125,7 +125,7 @@ func (c *CustomFuncs) foldStringToRegclassCast(
 
 	c.mem.Metadata().AddDependency(opt.DepByName(&resName), ds, privilege.SELECT)
 
-	regclassOid := tree.NewDOidWithName(tree.DInt(ds.PostgresDescriptorID()), types.RegClass, string(tn.TableName))
+	regclassOid := tree.NewDOidWithName(tree.DInt(ds.PostgresDescriptorID()), types.RegClass, string(tn.ObjectName))
 	return c.f.ConstructConstVal(regclassOid, typ), nil
 
 }

--- a/pkg/sql/opt/optbuilder/create_table.go
+++ b/pkg/sql/opt/optbuilder/create_table.go
@@ -40,11 +40,11 @@ func (b *Builder) buildCreateTable(ct *tree.CreateTable, inScope *scope) (outSco
 		// resolved correctly.
 		// TODO(solon): Once it is possible to drop schemas, it will no longer be
 		// safe to set the schema name to `public`, as it may have been dropped.
-		ct.Table.TableNamePrefix.SchemaName = tree.PublicSchemaName
+		ct.Table.ObjectNamePrefix.SchemaName = tree.PublicSchemaName
 		ct.Temporary = true
 	}
 	sch, resName := b.resolveSchemaForCreate(&ct.Table)
-	ct.Table.TableNamePrefix = resName
+	ct.Table.ObjectNamePrefix = resName
 	schID := b.factory.Metadata().AddSchema(sch)
 
 	// HoistConstraints normalizes any column constraints in the CreateTable AST

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -144,7 +144,7 @@ func (b *Builder) validateJoinTableNames(leftScope, rightScope *scope) {
 			rightName := &rightScope.cols[right].table
 
 			// Must match all name parts.
-			if leftName.TableName != rightName.TableName ||
+			if leftName.ObjectName != rightName.ObjectName ||
 				leftName.SchemaName != rightName.SchemaName ||
 				leftName.CatalogName != rightName.CatalogName {
 				continue
@@ -153,7 +153,7 @@ func (b *Builder) validateJoinTableNames(leftScope, rightScope *scope) {
 			panic(pgerror.Newf(
 				pgcode.DuplicateAlias,
 				"source name %q specified more than once (missing AS clause)",
-				tree.ErrString(&leftName.TableName),
+				tree.ErrString(&leftName.ObjectName),
 			))
 		}
 	}
@@ -170,7 +170,7 @@ func (b *Builder) findJoinColsToValidate(scope *scope) util.FastIntSet {
 		// associated table name. At worst, the USING/NATURAL
 		// detection code or expression analysis for ON will detect an
 		// ambiguity later.
-		if scope.cols[i].table.TableName == "" {
+		if scope.cols[i].table.ObjectName == "" {
 			continue
 		}
 

--- a/pkg/sql/opt/optbuilder/locking.go
+++ b/pkg/sql/opt/optbuilder/locking.go
@@ -138,7 +138,7 @@ func (lm lockingSpec) filter(alias tree.Name) lockingSpec {
 		} else {
 			// If targets are specified, the clause affects only those tables.
 			for _, target := range li.Targets {
-				if target.TableName == alias {
+				if target.ObjectName == alias {
 					updateRet(li, len1)
 					break
 				}

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -535,7 +535,7 @@ func (s *scope) removeHiddenCols() {
 // isAnonymousTable returns true if the table name of the first column
 // in this scope is empty.
 func (s *scope) isAnonymousTable() bool {
-	return len(s.cols) > 0 && s.cols[0].table.TableName == ""
+	return len(s.cols) > 0 && s.cols[0].table.ObjectName == ""
 }
 
 // setTableAlias qualifies the names of all columns in this scope with the
@@ -703,7 +703,7 @@ func (s *scope) FindSourceProvidingColumn(
 				continue
 			}
 
-			if col.table.TableName == "" && !col.hidden {
+			if col.table.ObjectName == "" && !col.hidden {
 				if candidateFromAnonSource != nil {
 					moreThanOneCandidateFromAnonSource = true
 					break
@@ -808,7 +808,7 @@ func (s *scope) FindSourceMatchingName(
 // - a request for "kv" is matched by a source named "db1.public.kv"
 // - a request for "public.kv" is not matched by a source named just "kv"
 func sourceNameMatches(srcName tree.TableName, toFind tree.TableName) bool {
-	if srcName.TableName != toFind.TableName {
+	if srcName.ObjectName != toFind.ObjectName {
 		return false
 	}
 	if toFind.ExplicitSchema {
@@ -1418,7 +1418,7 @@ func (s *scope) newAmbiguousColumnError(
 	for i := range s.cols {
 		col := &s.cols[i]
 		if col.name == n && (allowHidden || !col.hidden) {
-			if col.table.TableName == "" && !col.hidden {
+			if col.table.ObjectName == "" && !col.hidden {
 				if moreThanOneCandidateFromAnonSource {
 					// Only print first anonymous source, since other(s) are identical.
 					fmtCandidate(col.table)
@@ -1451,7 +1451,7 @@ func newAmbiguousSourceError(tn *tree.TableName) error {
 	}
 	return pgerror.Newf(pgcode.AmbiguousAlias,
 		"ambiguous source name: %q (within database %q)",
-		tree.ErrString(&tn.TableName), tree.ErrString(&tn.CatalogName))
+		tree.ErrString(&tn.ObjectName), tree.ErrString(&tn.CatalogName))
 }
 
 func (s *scope) String() string {

--- a/pkg/sql/opt/optbuilder/scope_column.go
+++ b/pkg/sql/opt/optbuilder/scope_column.go
@@ -103,7 +103,7 @@ func (c *scopeColumn) Format(ctx *tree.FmtCtx) {
 		return
 	}
 
-	if ctx.HasFlags(tree.FmtShowTableAliases) && c.table.TableName != "" {
+	if ctx.HasFlags(tree.FmtShowTableAliases) && c.table.ObjectName != "" {
 		if c.table.ExplicitSchema && c.table.SchemaName != "" {
 			if c.table.ExplicitCatalog && c.table.CatalogName != "" {
 				ctx.FormatNode(&c.table.CatalogName)
@@ -113,7 +113,7 @@ func (c *scopeColumn) Format(ctx *tree.FmtCtx) {
 			ctx.WriteByte('.')
 		}
 
-		ctx.FormatNode(&c.table.TableName)
+		ctx.FormatNode(&c.table.ObjectName)
 		ctx.WriteByte('.')
 	}
 	ctx.FormatNode(&c.name)

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -106,7 +106,7 @@ func (b *Builder) buildDataSource(
 		}
 
 		priv := privilege.SELECT
-		locking = locking.filter(tn.TableName)
+		locking = locking.filter(tn.ObjectName)
 		if locking.isSet() {
 			// SELECT ... FOR [KEY] UPDATE/SHARE requires UPDATE privileges.
 			priv = privilege.UPDATE
@@ -1291,7 +1291,7 @@ func (b *Builder) validateLockingInFrom(
 			// columns to be small enough that doing so is likely not worth it.
 			found := false
 			for _, col := range fromScope.cols {
-				if target.TableName == col.table.TableName {
+				if target.ObjectName == col.table.ObjectName {
 					found = true
 					break
 				}
@@ -1300,7 +1300,7 @@ func (b *Builder) validateLockingInFrom(
 				panic(pgerror.Newf(
 					pgcode.UndefinedTable,
 					"relation %q in %s clause not found in FROM clause",
-					target.TableName, li.Strength,
+					target.ObjectName, li.Strength,
 				))
 			}
 		}

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -457,7 +457,7 @@ func resolveTemporaryStatus(name *tree.TableName, explicitTemp bool) bool {
 // CREATE privilege, then resolveSchemaForCreate raises an error.
 func (b *Builder) resolveSchemaForCreate(name *tree.TableName) (cat.Schema, cat.SchemaName) {
 	flags := cat.Flags{AvoidDescriptorCaches: true}
-	sch, resName, err := b.catalog.ResolveSchema(b.ctx, flags, &name.TableNamePrefix)
+	sch, resName, err := b.catalog.ResolveSchema(b.ctx, flags, &name.ObjectNamePrefix)
 	if err != nil {
 		// Remap invalid schema name error text so that it references the catalog
 		// object that could not be created.

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -164,7 +164,7 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 			if def.Unique {
 				tab.addIndex(
 					&tree.IndexTableDef{
-						Name:    tree.Name(fmt.Sprintf("%s_%s_key", stmt.Table.TableName, def.Name)),
+						Name:    tree.Name(fmt.Sprintf("%s_%s_key", stmt.Table.ObjectName, def.Name)),
 						Columns: tree.IndexElemList{{Column: def.Name}},
 					},
 					uniqueIndex,
@@ -277,7 +277,7 @@ func (tc *Catalog) resolveFK(tab *Table, d *tree.ForeignKeyConstraintTableDef) {
 	}
 
 	var targetTable *Table
-	if d.Table.TableName == tab.Name() {
+	if d.Table.ObjectName == tab.Name() {
 		targetTable = tab
 	} else {
 		targetTable = tc.Table(&d.Table)

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -495,7 +495,7 @@ func (tv *View) Equals(other cat.Object) bool {
 
 // Name is part of the cat.DataSource interface.
 func (tv *View) Name() tree.Name {
-	return tv.ViewName.TableName
+	return tv.ViewName.ObjectName
 }
 
 // fqName is part of the dataSource interface.
@@ -581,7 +581,7 @@ func (tt *Table) Equals(other cat.Object) bool {
 
 // Name is part of the cat.DataSource interface.
 func (tt *Table) Name() tree.Name {
-	return tt.TabName.TableName
+	return tt.TabName.ObjectName
 }
 
 // fqName is part of the dataSource interface.
@@ -1146,7 +1146,7 @@ func (ts *Sequence) Equals(other cat.Object) bool {
 
 // Name is part of the cat.DataSource interface.
 func (ts *Sequence) Name() tree.Name {
-	return ts.SeqName.TableName
+	return ts.SeqName.ObjectName
 }
 
 // fqName is part of the dataSource interface.

--- a/pkg/sql/opt/testutils/testcat/vtable.go
+++ b/pkg/sql/opt/testutils/testcat/vtable.go
@@ -49,7 +49,7 @@ func init() {
 		ct.Table.ExplicitCatalog = true
 
 		name := ct.Table
-		informationSchemaMap[name.TableName.String()] = ct
+		informationSchemaMap[name.ObjectName.String()] = ct
 	}
 }
 
@@ -58,7 +58,7 @@ func init() {
 func resolveVTable(name *tree.TableName) (*tree.CreateTable, bool) {
 	switch name.SchemaName {
 	case "information_schema":
-		schema, ok := informationSchemaMap[name.TableName.String()]
+		schema, ok := informationSchemaMap[name.ObjectName.String()]
 		return schema, ok
 	}
 

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -136,8 +136,8 @@ func (oc *optCatalog) ResolveSchema(
 	// assumes that a data source object is being resolved, which is not the case
 	// for ResolveSchema. Therefore, call ResolveTarget directly and produce a
 	// more general error.
-	oc.tn.TableName = ""
-	oc.tn.TableNamePrefix = *name
+	oc.tn.ObjectName = ""
+	oc.tn.ObjectNamePrefix = *name
 
 	found, desc, err := oc.tn.ResolveTarget(
 		ctx,
@@ -161,8 +161,8 @@ func (oc *optCatalog) ResolveSchema(
 	return &optSchema{
 		planner: oc.planner,
 		desc:    desc.(*DatabaseDescriptor),
-		name:    oc.tn.TableNamePrefix,
-	}, oc.tn.TableNamePrefix, nil
+		name:    oc.tn.ObjectNamePrefix,
+	}, oc.tn.ObjectNamePrefix, nil
 }
 
 // ResolveDataSource is part of the cat.Catalog interface.
@@ -1338,7 +1338,7 @@ func (ot *optVirtualTable) Equals(other cat.Object) bool {
 
 // Name is part of the cat.Table interface.
 func (ot *optVirtualTable) Name() tree.Name {
-	return ot.name.TableName
+	return ot.name.ObjectName
 }
 
 // IsVirtualTable is part of the cat.Table interface.

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3867,7 +3867,7 @@ show_sessions_stmt:
 show_tables_stmt:
   SHOW TABLES FROM name '.' name with_comment
   {
-    $$.val = &tree.ShowTables{TableNamePrefix:tree.TableNamePrefix{
+    $$.val = &tree.ShowTables{ObjectNamePrefix:tree.ObjectNamePrefix{
         CatalogName: tree.Name($4),
         ExplicitCatalog: true,
         SchemaName: tree.Name($6),
@@ -3877,7 +3877,7 @@ show_tables_stmt:
   }
 | SHOW TABLES FROM name with_comment
   {
-    $$.val = &tree.ShowTables{TableNamePrefix:tree.TableNamePrefix{
+    $$.val = &tree.ShowTables{ObjectNamePrefix:tree.ObjectNamePrefix{
         // Note: the schema name may be interpreted as database name,
         // see name_resolution.go.
         SchemaName: tree.Name($4),
@@ -9555,10 +9555,10 @@ table_index_name:
   }
 | standalone_index_name
   {
-    // Treat it as a table name, then pluck out the TableName.
+    // Treat it as a table name, then pluck out the ObjectName.
     name := $1.unresolvedObjectName().ToTableName()
-    indexName := tree.UnrestrictedName(name.TableName)
-    name.TableName = ""
+    indexName := tree.UnrestrictedName(name.ObjectName)
+    name.ObjectName = ""
     $$.val = tree.TableIndexName{
         Table: name,
         Index: indexName,

--- a/pkg/sql/physical_schema_accessors.go
+++ b/pkg/sql/physical_schema_accessors.go
@@ -95,7 +95,7 @@ func (a UncachedPhysicalAccessor) GetObjectNames(
 	if !ok {
 		if flags.Required {
 			tn := tree.MakeTableNameWithSchema(tree.Name(dbDesc.Name), tree.Name(scName), "")
-			return nil, sqlbase.NewUnsupportedSchemaUsageError(tree.ErrString(&tn.TableNamePrefix))
+			return nil, sqlbase.NewUnsupportedSchemaUsageError(tree.ErrString(&tn.ObjectNamePrefix))
 		}
 		return nil, nil
 	}

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -240,7 +240,7 @@ func ResolveTargetObject(
 	}
 	if tn.Schema() != tree.PublicSchema {
 		return nil, pgerror.Newf(pgcode.InvalidName,
-			"schema cannot be modified: %q", tree.ErrString(&tn.TableNamePrefix))
+			"schema cannot be modified: %q", tree.ErrString(&tn.ObjectNamePrefix))
 	}
 	return descI.(*DatabaseDescriptor), nil
 }
@@ -487,7 +487,7 @@ func expandIndexName(
 	// references the table name.
 
 	// Look up the table prefix.
-	found, _, err := tn.TableNamePrefix.Resolve(ctx, sc, sc.CurrentDatabase(), sc.CurrentSearchPath())
+	found, _, err := tn.ObjectNamePrefix.Resolve(ctx, sc, sc.CurrentDatabase(), sc.CurrentSearchPath())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -694,7 +694,7 @@ func (l *internalLookupCtx) getParentAsTableName(
 	return parentName, nil
 }
 
-// getTableAsTableName returns a TableName object fot a given TableDescriptor.
+// getTableAsTableName returns a TableName object for a given TableDescriptor.
 func (l *internalLookupCtx) getTableAsTableName(
 	table *sqlbase.TableDescriptor, dbPrefix string,
 ) (tree.TableName, error) {

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1114,7 +1114,7 @@ SELECT description
 			} else {
 				pred = fmt.Sprintf(
 					"table_catalog = '%s' AND table_schema = '%s' AND table_name = '%s'",
-					tn.CatalogName, tn.SchemaName, tn.TableName)
+					tn.CatalogName, tn.SchemaName, tn.ObjectName)
 			}
 
 			return parsePrivilegeStr(args[1], pgPrivList{
@@ -1168,7 +1168,7 @@ SELECT description
 			} else {
 				pred = fmt.Sprintf(
 					"table_catalog = '%s' AND table_schema = '%s' AND table_name = '%s'",
-					tn.CatalogName, tn.SchemaName, tn.TableName)
+					tn.CatalogName, tn.SchemaName, tn.ObjectName)
 
 				// Verify that the column exists in the table.
 				var colPred string
@@ -1190,7 +1190,7 @@ SELECT description
 					fmt.Sprintf(`
 					SELECT attname FROM pg_attribute
 					 WHERE attrelid = '%s.%s.%s'::REGCLASS AND %s`,
-						tn.CatalogName, tn.SchemaName, tn.TableName, colPred), colArg,
+						tn.CatalogName, tn.SchemaName, tn.ObjectName, colPred), colArg,
 				); err != nil {
 					return nil, err
 				} else if r == nil {
@@ -1462,7 +1462,7 @@ SELECT description
 					ctx.Txn,
 					`SELECT sequence_name FROM information_schema.sequences `+
 						`WHERE sequence_catalog = $1 AND sequence_schema = $2 AND sequence_name = $3`,
-					tn.CatalogName, tn.SchemaName, tn.TableName); err != nil {
+					tn.CatalogName, tn.SchemaName, tn.ObjectName); err != nil {
 					return nil, err
 				} else if r == nil {
 					return nil, pgerror.Newf(pgcode.WrongObjectType,
@@ -1471,7 +1471,7 @@ SELECT description
 
 				pred = fmt.Sprintf(
 					"table_catalog = '%s' AND table_schema = '%s' AND table_name = '%s'",
-					tn.CatalogName, tn.SchemaName, tn.TableName)
+					tn.CatalogName, tn.SchemaName, tn.ObjectName)
 			}
 
 			return parsePrivilegeStr(args[1], pgPrivList{
@@ -1547,7 +1547,7 @@ SELECT description
 			} else {
 				pred = fmt.Sprintf(
 					"table_catalog = '%s' AND table_schema = '%s' AND table_name = '%s'",
-					tn.CatalogName, tn.SchemaName, tn.TableName)
+					tn.CatalogName, tn.SchemaName, tn.ObjectName)
 			}
 
 			return parsePrivilegeStr(args[1], pgPrivList{

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3925,7 +3925,7 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 				return &DOid{
 					semanticType: t,
 					DInt:         DInt(id),
-					name:         tn.TableName.String(),
+					name:         tn.ObjectName.String(),
 				}, nil
 			default:
 				return queryOid(ctx, t, NewDString(s))

--- a/pkg/sql/sem/tree/name_part.go
+++ b/pkg/sql/sem/tree/name_part.go
@@ -218,7 +218,7 @@ type UnresolvedObjectName struct {
 	// (the number of parts specified) is populated in NumParts above.
 	Parts [3]string
 
-	// UnresolvedObjectName cam be annotated with a *TableName.
+	// UnresolvedObjectName can be annotated with a *TableName.
 	AnnotatedNode
 }
 
@@ -306,9 +306,9 @@ func (u *UnresolvedObjectName) String() string { return AsString(u) }
 // would only figure that out during name resolution. This method is temporary,
 // while we change all the code paths to only use TableName after resolution.
 func (u *UnresolvedObjectName) ToTableName() TableName {
-	return TableName{tblName{
-		TableName: Name(u.Parts[0]),
-		TableNamePrefix: TableNamePrefix{
+	return TableName{objName{
+		ObjectName: Name(u.Parts[0]),
+		ObjectNamePrefix: ObjectNamePrefix{
 			SchemaName:      Name(u.Parts[1]),
 			CatalogName:     Name(u.Parts[2]),
 			ExplicitSchema:  u.NumParts >= 2,

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -56,7 +56,7 @@ func classifyTablePattern(n *UnresolvedName) (TablePattern, error) {
 
 	// Construct the result.
 	if n.Star {
-		return &AllTablesSelector{makeTableNamePrefixFromUnresolvedName(n)}, nil
+		return &AllTablesSelector{makeObjectNamePrefixFromUnresolvedName(n)}, nil
 	}
 	tb := makeTableNameFromUnresolvedName(n)
 	return &tb, nil
@@ -383,7 +383,7 @@ func (t *TableName) ResolveTarget(
 
 // Resolve is used for table prefixes. This is adequate for table
 // patterns with stars, e.g. AllTablesSelector.
-func (tp *TableNamePrefix) Resolve(
+func (tp *ObjectNamePrefix) Resolve(
 	ctx context.Context, r TableNameTargetResolver, curDb string, searchPath sessiondata.SearchPath,
 ) (found bool, scMeta SchemaMeta, err error) {
 	if tp.ExplicitSchema {

--- a/pkg/sql/sem/tree/name_resolution_test.go
+++ b/pkg/sql/sem/tree/name_resolution_test.go
@@ -228,7 +228,7 @@ func (f *fakeSource) FindSourceMatchingName(
 	var columns colsRes
 	for i := range f.knownTables {
 		t := &f.knownTables[i]
-		if t.srcName.TableName != tn.TableName {
+		if t.srcName.ObjectName != tn.ObjectName {
 			continue
 		}
 		if tn.ExplicitSchema {
@@ -788,7 +788,7 @@ func TestResolveTablePatternOrName(t *testing.T) {
 				ctx := context.Background()
 				switch tpv := tp.(type) {
 				case *tree.AllTablesSelector:
-					found, scMeta, err = tpv.TableNamePrefix.Resolve(ctx, fakeResolver, tc.curDb, tc.searchPath)
+					found, scMeta, err = tpv.ObjectNamePrefix.Resolve(ctx, fakeResolver, tc.curDb, tc.searchPath)
 					scPrefix = tpv.Schema()
 					ctPrefix = tpv.Catalog()
 				case *tree.TableName:
@@ -840,11 +840,11 @@ func TestResolveTablePatternOrName(t *testing.T) {
 			}
 			switch tpv := tp.(type) {
 			case *tree.AllTablesSelector:
-				tpv.TableNamePrefix.ExplicitCatalog = true
-				tpv.TableNamePrefix.ExplicitSchema = true
+				tpv.ObjectNamePrefix.ExplicitCatalog = true
+				tpv.ObjectNamePrefix.ExplicitSchema = true
 			case *tree.TableName:
-				tpv.TableNamePrefix.ExplicitCatalog = true
-				tpv.TableNamePrefix.ExplicitSchema = true
+				tpv.ObjectNamePrefix.ExplicitCatalog = true
+				tpv.ObjectNamePrefix.ExplicitSchema = true
 			}
 			if out := tp.String(); tc.expanded != out {
 				t.Errorf("%s: expected full %s, but found %s", t.Name(), tc.expanded, out)

--- a/pkg/sql/sem/tree/object_name.go
+++ b/pkg/sql/sem/tree/object_name.go
@@ -1,0 +1,59 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree
+
+// objName is the internal type for a qualified object.
+type objName struct {
+	// ObjectName is the unqualified name for the object
+	// (table/view/sequence/function/type).
+	ObjectName Name
+
+	// ObjectNamePrefix is the path to the object.  This can be modified
+	// further by name resolution, see name_resolution.go.
+	ObjectNamePrefix
+}
+
+// ObjectNamePrefix corresponds to the path prefix of an object name.
+type ObjectNamePrefix struct {
+	CatalogName Name
+	SchemaName  Name
+
+	// ExplicitCatalog is true iff the catalog was explicitly specified
+	// or it needs to be rendered during pretty-printing.
+	ExplicitCatalog bool
+	// ExplicitSchema is true iff the schema was explicitly specified
+	// or it needs to be rendered during pretty-printing.
+	ExplicitSchema bool
+}
+
+// Format implements the NodeFormatter interface.
+func (tp *ObjectNamePrefix) Format(ctx *FmtCtx) {
+	alwaysFormat := ctx.alwaysFormatTablePrefix()
+	if tp.ExplicitSchema || alwaysFormat {
+		if tp.ExplicitCatalog || alwaysFormat {
+			ctx.FormatNode(&tp.CatalogName)
+			ctx.WriteByte('.')
+		}
+		ctx.FormatNode(&tp.SchemaName)
+	}
+}
+
+func (tp *ObjectNamePrefix) String() string { return AsString(tp) }
+
+// Schema retrieves the unqualified schema name.
+func (tp *ObjectNamePrefix) Schema() string {
+	return string(tp.SchemaName)
+}
+
+// Catalog retrieves the unqualified catalog name.
+func (tp *ObjectNamePrefix) Catalog() string {
+	return string(tp.CatalogName)
+}

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -293,7 +293,7 @@ func (node *ShowSequences) Format(ctx *FmtCtx) {
 
 // ShowTables represents a SHOW TABLES statement.
 type ShowTables struct {
-	TableNamePrefix
+	ObjectNamePrefix
 	WithComment bool
 }
 
@@ -302,7 +302,7 @@ func (node *ShowTables) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW TABLES")
 	if node.ExplicitSchema {
 		ctx.WriteString(" FROM ")
-		ctx.FormatNode(&node.TableNamePrefix)
+		ctx.FormatNode(&node.ObjectNamePrefix)
 	}
 
 	if node.WithComment {

--- a/pkg/sql/sem/tree/table_pattern.go
+++ b/pkg/sql/sem/tree/table_pattern.go
@@ -52,12 +52,12 @@ func (t *TableName) NormalizeTablePattern() (TablePattern, error) { return t, ni
 // AllTablesSelector corresponds to a selection of all
 // tables in a database, e.g. when used with GRANT.
 type AllTablesSelector struct {
-	TableNamePrefix
+	ObjectNamePrefix
 }
 
 // Format implements the NodeFormatter interface.
 func (at *AllTablesSelector) Format(ctx *FmtCtx) {
-	at.TableNamePrefix.Format(ctx)
+	at.ObjectNamePrefix.Format(ctx)
 	if at.ExplicitSchema || ctx.alwaysFormatTablePrefix() {
 		ctx.WriteByte('.')
 	}

--- a/pkg/sql/sem/tree/type_name.go
+++ b/pkg/sql/sem/tree/type_name.go
@@ -1,0 +1,63 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree
+
+// TypeName corresponds to the name of a type in a CREATE TYPE statement,
+// in an expression, or column type etc.
+//
+// Users of this struct should not construct it directly, and
+// instead use the constructors below.
+type TypeName struct {
+	objName
+}
+
+// Satisfy the linter.
+var _ = (*TypeName).Type
+var _ = (*TypeName).FQString
+var _ = NewUnqualifiedTypeName
+
+// Type returns the unqualified name of this TypeName.
+func (t *TypeName) Type() string {
+	return string(t.ObjectName)
+}
+
+// Format implements the NodeFormatter interface.
+func (t *TypeName) Format(ctx *FmtCtx) {
+	t.ObjectNamePrefix.Format(ctx)
+	if t.ExplicitSchema || ctx.alwaysFormatTablePrefix() {
+		ctx.WriteByte('.')
+	}
+	ctx.FormatNode(&t.ObjectName)
+}
+
+// String implements the Stringer interface.
+func (t *TypeName) String() string {
+	return AsString(t)
+}
+
+// FQString renders the type name in full, not omitting the prefix
+// schema and catalog names. Suitable for logging, etc.
+func (t *TypeName) FQString() string {
+	ctx := NewFmtCtx(FmtSimple)
+	ctx.FormatNode(&t.CatalogName)
+	ctx.WriteByte('.')
+	ctx.FormatNode(&t.SchemaName)
+	ctx.WriteByte('.')
+	ctx.FormatNode(&t.ObjectName)
+	return ctx.CloseAndGetString()
+}
+
+// NewUnqualifiedTypeName returns a new base type name.
+func NewUnqualifiedTypeName(typ Name) *TypeName {
+	return &TypeName{objName{
+		ObjectName: typ,
+	}}
+}

--- a/pkg/sql/serial.go
+++ b/pkg/sql/serial.go
@@ -116,10 +116,10 @@ func (p *planner) processSerialInColumnDef(
 		return nil, nil, nil, nil, err
 	}
 	// Now skip over all names that are already taken.
-	nameBase := seqName.TableName
+	nameBase := seqName.ObjectName
 	for i := 0; ; i++ {
 		if i > 0 {
-			seqName.TableName = tree.Name(fmt.Sprintf("%s%d", nameBase, i))
+			seqName.ObjectName = tree.Name(fmt.Sprintf("%s%d", nameBase, i))
 		}
 		res, err := p.ResolveUncachedTableDescriptor(ctx, seqName, false /*required*/, ResolveAnyDescType)
 		if err != nil {

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -202,7 +202,7 @@ func checkPrivilegeForSetZoneConfig(ctx context.Context, p *planner, zs tree.Zon
 	}
 	tableDesc, err := p.resolveTableForZone(ctx, &zs)
 	if err != nil {
-		if zs.TargetsIndex() && zs.TableOrIndex.Table.TableName == "" {
+		if zs.TargetsIndex() && zs.TableOrIndex.Table.ObjectName == "" {
 			err = errors.WithHint(err, "try specifying the index as <tablename>@<indexname>")
 		}
 		return err

--- a/pkg/sql/show_zone_config.go
+++ b/pkg/sql/show_zone_config.go
@@ -95,7 +95,7 @@ func getShowZoneConfigRow(
 		return nil, err
 	}
 
-	if zoneSpecifier.TableOrIndex.Table.TableName != "" {
+	if zoneSpecifier.TableOrIndex.Table.ObjectName != "" {
 		if err = p.CheckAnyPrivilege(ctx, tblDesc); err != nil {
 			return nil, err
 		}
@@ -249,9 +249,9 @@ func generateZoneConfigIntrospectionValues(
 		if zs.Database != "" {
 			values[databaseNameCol] = tree.NewDString(string(zs.Database))
 		}
-		if zs.TableOrIndex.Table.TableName != "" {
+		if zs.TableOrIndex.Table.ObjectName != "" {
 			values[databaseNameCol] = tree.NewDString(string(zs.TableOrIndex.Table.CatalogName))
-			values[tableNameCol] = tree.NewDString(string(zs.TableOrIndex.Table.TableName))
+			values[tableNameCol] = tree.NewDString(string(zs.TableOrIndex.Table.ObjectName))
 		}
 		if zs.TableOrIndex.Index != "" {
 			values[indexNameCol] = tree.NewDString(string(zs.TableOrIndex.Index))

--- a/pkg/sql/sqlbase/column_resolver.go
+++ b/pkg/sql/sqlbase/column_resolver.go
@@ -72,7 +72,7 @@ func ProcessTargetColumns(
 // - a request for "kv" is matched by a source named "db1.public.kv"
 // - a request for "public.kv" is not matched by a source named just "kv"
 func sourceNameMatches(srcName *tree.TableName, toFind tree.TableName) bool {
-	if srcName.TableName != toFind.TableName {
+	if srcName.ObjectName != toFind.ObjectName {
 		return false
 	}
 	if toFind.ExplicitSchema {

--- a/pkg/sql/sqlbase/data_source.go
+++ b/pkg/sql/sqlbase/data_source.go
@@ -146,7 +146,7 @@ var AnonymousTable = tree.TableName{}
 // NewSourceInfoForSingleTable creates a simple DataSourceInfo
 // which maps the same tableAlias to all columns.
 func NewSourceInfoForSingleTable(tn tree.TableName, columns ResultColumns) *DataSourceInfo {
-	if tn.TableName != "" && tn.SchemaName != "" {
+	if tn.ObjectName != "" && tn.SchemaName != "" {
 		// When we're not looking at an unqualified table, we make sure that
 		// the table name in the data source struct is fully qualified. This
 		// ensures that queries like this are valid:
@@ -168,7 +168,7 @@ type varFormatter struct {
 
 // Format implements the NodeFormatter interface.
 func (c *varFormatter) Format(ctx *tree.FmtCtx) {
-	if ctx.HasFlags(tree.FmtShowTableAliases) && c.TableName.TableName != "" {
+	if ctx.HasFlags(tree.FmtShowTableAliases) && c.TableName.ObjectName != "" {
 		// This logic is different from (*TableName).Format() with
 		// FmtAlwaysQualify, because FmtShowTableAliases only wants to
 		// prefixes the table names for vars in expressions, not table
@@ -182,7 +182,7 @@ func (c *varFormatter) Format(ctx *tree.FmtCtx) {
 			ctx.WriteByte('.')
 		}
 
-		ctx.FormatNode(&c.TableName.TableName)
+		ctx.FormatNode(&c.TableName.ObjectName)
 		ctx.WriteByte('.')
 	}
 	ctx.FormatNode(&c.ColumnName)

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -1248,7 +1248,7 @@ func IndexStoringMutator(rng *rand.Rand, stmts []tree.Statement) ([]tree.Stateme
 			if ast.Inverted {
 				continue
 			}
-			tableInfo, ok := tables[ast.Table.TableName]
+			tableInfo, ok := tables[ast.Table.ObjectName]
 			if !ok {
 				continue
 			}
@@ -1264,7 +1264,7 @@ func IndexStoringMutator(rng *rand.Rand, stmts []tree.Statement) ([]tree.Stateme
 		case *tree.CreateTable:
 			// Write down this table for later.
 			tableInfo := getTableInfoFromCreateStatement(ast)
-			tables[ast.Table.TableName] = tableInfo
+			tables[ast.Table.ObjectName] = tableInfo
 			for _, def := range ast.Defs {
 				var idx *tree.IndexTableDef
 				switch defType := def.(type) {

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -335,7 +335,7 @@ func (tc *TableCollection) getTableVersion(
 	// system.users. For now we're sticking to disabling caching of
 	// all system descriptors except the role-members-table.
 	avoidCache := flags.AvoidCached || testDisableTableLeases ||
-		(tn.Catalog() == sqlbase.SystemDB.Name && tn.TableName.String() != sqlbase.RoleMembersTable.Name)
+		(tn.Catalog() == sqlbase.SystemDB.Name && tn.ObjectName.String() != sqlbase.RoleMembersTable.Name)
 
 	if refuseFurtherLookup, table, err := tc.getUncommittedTable(
 		dbID,
@@ -663,7 +663,7 @@ func (tc *TableCollection) getUncommittedTable(
 		// transaction has already committed and this transaction is seeing the
 		// effect of it.
 		for _, drain := range mutTbl.DrainingNames {
-			if drain.Name == string(tn.TableName) &&
+			if drain.Name == string(tn.ObjectName) &&
 				drain.ParentID == dbID &&
 				drain.ParentSchemaID == schemaID {
 				// Table name has gone away.


### PR DESCRIPTION
This PR introduces a new `TypeName` type which is similar
to `TableName`. In order to better share properties between
these types, this PR also refactors the names of the base
types `tblName` and `TableNamePrefix` to be more general,
rather than just being fixed to tables.

In particular we perform the following:
* Rename `tblName` to `objName`
* Rename `TableNamePrefix` to `ObjectNamePrefix`
* Move the above two types into their own file `object_name.go`
* Add a new `TypeName` type for representing qualified type names.

Release note: None