### PR TITLE
vendor: bump pebble to b976c257531658d4b96577393866c42d7b4ca801

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -464,7 +464,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f75d5bc93783656eeeeceeb15cfc4db3a87e3e4f4d16bd1c5c5e0bb17031321e"
+  digest = "1:8811c5677b1fe11167d12da96e3cd11ccac7d012b365cabaf8852fc2492983b4"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -490,7 +490,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "d9c9d49c3cf01cc4801dc06f092956684c8fa4be"
+  revision = "b976c257531658d4b96577393866c42d7b4ca801"
 
 [[projects]]
   branch = "master"

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -56,11 +56,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/tool"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/kr/pretty"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -1241,8 +1241,33 @@ process that has failed and cannot restart.
 	RunE: usageAndErr,
 }
 
+// mvccValueFormatter is an fmt.Formatter for MVCC values.
+type mvccValueFormatter struct {
+	kv  storage.MVCCKeyValue
+	err error
+}
+
+// Format implements the fmt.Formatter interface.
+func (m mvccValueFormatter) Format(f fmt.State, c rune) {
+	if m.err != nil {
+		errors.FormatError(m.err, f, c)
+		return
+	}
+	fmt.Fprint(f, kvserver.SprintKeyValue(m.kv, false /* printKey */))
+}
+
 func init() {
 	DebugCmd.AddCommand(debugCmds...)
+
+	// Note: we hook up FormatValue here in order to avoid a circular dependency
+	// between kvserver and storage.
+	storage.MVCCComparer.FormatValue = func(key, value []byte) fmt.Formatter {
+		decoded, err := storage.DecodeMVCCKey(key)
+		if err != nil {
+			return mvccValueFormatter{err: err}
+		}
+		return mvccValueFormatter{kv: storage.MVCCKeyValue{Key: decoded, Value: value}}
+	}
 
 	pebbleTool := tool.New()
 	// To be able to read Cockroach-written RocksDB manifests/SSTables, comparator

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -92,7 +92,7 @@ var MVCCComparer = &pebble.Comparer{
 		return pebble.DefaultComparer.AbbreviatedKey(key)
 	},
 
-	Format: func(k []byte) fmt.Formatter {
+	FormatKey: func(k []byte) fmt.Formatter {
 		decoded, err := DecodeMVCCKey(k)
 		if err != nil {
 			return mvccKeyFormatter{err: err}


### PR DESCRIPTION
* internal/manifest: Fix merge skew with Formatter -> FormatKey change
* internal/manifest: Introduce L0SubLevels data structure
* *: introduce Comparer.FormatValue
* *: rename base.Formatter to base.FormatKey
* tool: enhance `sstable check` to catch bloom filter problems
* tool: add db properties subcommand
* tool: fix sstable panic

Enabled pretty-printing of values in `debug pebble` commands by hooking
up `MVCCComparer.FormatValue`.

Release note: None