### PR TITLE
geo/geogfn: implement geography intersects using S2

### DIFF
--- a/pkg/geo/geogfn/intersects.go
+++ b/pkg/geo/geogfn/intersects.go
@@ -1,0 +1,130 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geogfn
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/golang/geo/s2"
+)
+
+// Intersects returns whether geography A intersects geography B.
+// This calculation is done on the sphere.
+// Precision of intersect measurements is up to 1cm.
+func Intersects(a *geo.Geography, b *geo.Geography) (bool, error) {
+	aRegions, err := a.AsS2()
+	if err != nil {
+		return false, err
+	}
+	bRegions, err := b.AsS2()
+	if err != nil {
+		return false, err
+	}
+	// If any of aRegions intersects any of bRegions, return true.
+	for _, aRegion := range aRegions {
+		for _, bRegion := range bRegions {
+			intersects, err := singleRegionIntersects(aRegion, bRegion)
+			if err != nil {
+				return false, err
+			}
+			if intersects {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// singleRegionIntersects returns true if aRegion intersects bRegion.
+func singleRegionIntersects(aRegion s2.Region, bRegion s2.Region) (bool, error) {
+	switch aRegion := aRegion.(type) {
+	case s2.Point:
+		switch bRegion := bRegion.(type) {
+		case s2.Point:
+			return aRegion.IntersectsCell(s2.CellFromPoint(bRegion)), nil
+		case *s2.Polyline:
+			return bRegion.IntersectsCell(s2.CellFromPoint(aRegion)), nil
+		case *s2.Polygon:
+			return bRegion.IntersectsCell(s2.CellFromPoint(aRegion)), nil
+		default:
+			return false, fmt.Errorf("unknown s2 type of b: %#v", bRegion)
+		}
+	case *s2.Polyline:
+		switch bRegion := bRegion.(type) {
+		case s2.Point:
+			return aRegion.IntersectsCell(s2.CellFromPoint(bRegion)), nil
+		case *s2.Polyline:
+			return polylineIntersectsPolyline(aRegion, bRegion), nil
+		case *s2.Polygon:
+			return polygonIntersectsPolyline(bRegion, aRegion), nil
+		default:
+			return false, fmt.Errorf("unknown s2 type of b: %#v", bRegion)
+		}
+	case *s2.Polygon:
+		switch bRegion := bRegion.(type) {
+		case s2.Point:
+			return aRegion.IntersectsCell(s2.CellFromPoint(bRegion)), nil
+		case *s2.Polyline:
+			return polygonIntersectsPolyline(aRegion, bRegion), nil
+		case *s2.Polygon:
+			return aRegion.Intersects(bRegion), nil
+		default:
+			return false, fmt.Errorf("unknown s2 type of b: %#v", bRegion)
+		}
+	}
+	return false, fmt.Errorf("unknown s2 type of a: %#v", aRegion)
+}
+
+// polylineIntersectsPolyline returns whether polyline a intersects with
+// polyline b.
+func polylineIntersectsPolyline(a *s2.Polyline, b *s2.Polyline) bool {
+	for aEdgeIdx := 0; aEdgeIdx < a.NumEdges(); aEdgeIdx++ {
+		edge := a.Edge(aEdgeIdx)
+		crosser := s2.NewChainEdgeCrosser(edge.V0, edge.V1, (*b)[0])
+		for _, nextVertex := range (*b)[1:] {
+			crossing := crosser.ChainCrossingSign(nextVertex)
+			if crossing != s2.DoNotCross {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// polygonIntersectsPolyline returns whether polygon a intersects with
+// polyline b.
+func polygonIntersectsPolyline(a *s2.Polygon, b *s2.Polyline) bool {
+	// Check if the polygon contains any vertex of the line b.
+	for _, vertex := range *b {
+		if a.IntersectsCell(s2.CellFromPoint(vertex)) {
+			return true
+		}
+	}
+	// Here the polygon does not contain any vertex of the polyline.
+	// The polyline can intersect the polygon if a line goes through the polygon
+	// with both vertexes that are not in the interior of the polygon.
+	// This technique works for holes touching, or holes touching the exterior
+	// as the point in which the holes touch is considered an intersection.
+	for _, loop := range a.Loops() {
+		for loopEdgeIdx := 0; loopEdgeIdx < loop.NumEdges(); loopEdgeIdx++ {
+			loopEdge := loop.Edge(loopEdgeIdx)
+			crosser := s2.NewChainEdgeCrosser(loopEdge.V0, loopEdge.V1, (*b)[0])
+			for _, nextVertex := range (*b)[1:] {
+				crossing := crosser.ChainCrossingSign(nextVertex)
+				if crossing != s2.DoNotCross {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/pkg/geo/geogfn/intersects_test.go
+++ b/pkg/geo/geogfn/intersects_test.go
@@ -1,0 +1,280 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geogfn
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntersects(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		a        string
+		b        string
+		expected bool
+	}{
+		{
+			"POINTs which are the same intersect",
+			"POINT(1.0 1.0)",
+			"POINT(1.0 1.0)",
+			true,
+		},
+		{
+			"POINTs which are different do not intersect",
+			"POINT(1.0 1.0)",
+			"POINT(1.0 1.1)",
+			false,
+		},
+		{
+			"POINTs intersect with a vertex on a LINESTRING",
+			"POINT(2.0 2.0)",
+			"LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0)",
+			true,
+		},
+		{
+			"POINTs intersect with a point along the LINESTRING",
+			"POINT(1.5 1.5001714)",
+			"LINESTRING(0.0 0.0, 1.0 1.0, 2.0 2.0, 3.0 3.0)",
+			true,
+		},
+		{
+			"POINTs do not intersect with point outside the LINESTRING",
+			"POINT(1.5 1.6001714)",
+			"LINESTRING(0.0 0.0, 1.0 1.0, 2.0 2.0, 3.0 3.0)",
+			false,
+		},
+		{
+			"POINTs intersect with vertex along a POLYGON",
+			"POLYGON((1.0 1.0, 2.0 2.0, 0.0 2.0, 1.0 1.0))",
+			"POINT(2.0 2.0)",
+			true,
+		},
+		{
+			"POINTs intersect with edge along a POLYGON",
+			"POLYGON((1.0 1.0, 2.0 2.0, 0.0 2.0, 1.0 1.0))",
+			"POINT(1.5 1.5001714)",
+			true,
+		},
+		{
+			"POINTs intersect inside a POLYGON",
+			"POLYGON((1.0 1.0, 2.0 2.0, 0.0 2.0, 1.0 1.0))",
+			"POINT(1.5 1.9)",
+			true,
+		},
+		{
+			"POINTs do not intersect with any hole inside the polygon",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0), (0.2 0.2, 0.2 0.4, 0.4 0.4, 0.4 0.2, 0.2 0.2))",
+			"POINT(0.3 0.3)",
+			false,
+		},
+		{
+			"LINESTRING intersects itself",
+			"LINESTRING(2.0 2.0, 3.0 3.0)",
+			"LINESTRING(2.0 2.0, 3.0 3.0)",
+			true,
+		},
+		{
+			"LINESTRING intersects LINESTRING at ends",
+			"LINESTRING(1.0 1.0, 1.5 1.5, 2.0 2.0)",
+			"LINESTRING(2.0 2.0, 3.0 3.0)",
+			true,
+		},
+		{
+			"LINESTRING intersects LINESTRING subline not at vertex",
+			"LINESTRING(1.0 1.0, 2.0 2.0)",
+			"LINESTRING(1.5499860 1.5501575, 3.0 3.0)",
+			true,
+		},
+		{
+			"LINESTRING intersects LINESTRING with subline completely inside LINESTRING",
+			"LINESTRING(1.0 1.0, 2.0 2.0)",
+			"LINESTRING(1.5499860 1.5501575, 1.5 1.5001714)",
+			true,
+		},
+		{
+			"LINESTRING intersects LINESTRING at some edge",
+			"LINESTRING(1.0 1.0, 1.5 1.5, 2.0 2.0)",
+			"LINESTRING(1.0 2.0, 2.0 1.0)",
+			true,
+		},
+		{
+			"LINESTRING does not intersect LINESTRING",
+			"LINESTRING(1.0 1.0, 1.5 1.5, 2.0 2.0)",
+			"LINESTRING(1.0 2.0, 1.0 4.0)",
+			false,
+		},
+		{
+			"LINESTRING intersects POLYGON at a vertex",
+			"LINESTRING(1.0 1.0, 1.5 1.5, 2.0 2.0)",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			true,
+		},
+		{
+			"LINESTRING contained within POLYGON",
+			"LINESTRING(0.2 0.2, 0.4 0.4)",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			true,
+		},
+		{
+			"LINESTRING intersects POLYGON at an edge",
+			"LINESTRING(-0.5 0.5, 0.5 0.5)",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			true,
+		},
+		{
+			"LINESTRING intersects POLYGON through the whole thing",
+			"LINESTRING(-0.5 0.5, 1.5 0.5)",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			true,
+		},
+		{
+			"LINESTRING missing the POLYGON does not intersect",
+			"LINESTRING(-0.5 0.5, -1.5 -1.5)",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			false,
+		},
+		{
+			"LINESTRING does not intersect POLYGON if contained within the hole",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0), (0.2 0.2, 0.2 0.4, 0.4 0.4, 0.4 0.2, 0.2 0.2))",
+			"LINESTRING(0.3 0.3, 0.35 0.35)",
+			false,
+		},
+		{
+			"LINESTRING intersects POLYGON through the hole",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0), (0.2 0.2, 0.2 0.4, 0.4 0.4, 0.4 0.2, 0.2 0.2))",
+			"LINESTRING(0.3 0.3, 0.5 0.5)",
+			true,
+		},
+		{
+			"LINESTRING intersects POLYGON through touching holes",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0), (0.3 0.3, 0.4 0.2, 0.5 0.3, 0.4 0.4, 0.3 0.3), (0.5 0.3, 0.6 0.2, 0.7 0.3, 0.6 0.4, 0.5 0.3))",
+			"LINESTRING(0.4 0.3, 0.6 0.3)",
+			true,
+		},
+		{
+			"POLYGON intersects itself",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			true,
+		},
+		{
+			"POLYGON intersects a window of itself (with edges touches)",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			"POLYGON((0.2 0.2, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.2 0.2))",
+			true,
+		},
+		{
+			"POLYGON intersects a nested version of itself",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			"POLYGON((0.1 0.1, 0.2 0.1, 0.2 0.2, 0.1 0.2, 0.1 0.1))",
+			true,
+		},
+		{
+			"POLYGON intersects POLYGON intersecting",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			"POLYGON((-1.0 0.0, 1.0 0.0, 1.0 1.0, -1.0 1.0, -1.0 0.0))",
+			true,
+		},
+		{
+			"POLYGON does not intersect POLYGON totally out of range",
+			"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
+			"POLYGON((3.0 3.0, 4.0 3.0, 4.0 4.0, 3.0 4.0, 3.0 3.0))",
+			false,
+		},
+		{
+			"MULTIPOINT intersects single MULTIPOINT",
+			"MULTIPOINT((1.0 1.0), (2.0 2.0))",
+			"MULTIPOINT((2.0 2.0))",
+			true,
+		},
+		{
+			"MULTILINESTRING intersects one of the MULTIPOINTs",
+			"MULTILINESTRING((1.0 1.0, 1.1 1.1), (2.0 2.0, 2.1 2.1))",
+			"MULTIPOINT((4.0 5.0), (66.0 66.0), (2.1 2.1))",
+			true,
+		},
+		{
+			"MULTILINESTRING does not intersect with MULTIPOINTS out of the range",
+			"MULTILINESTRING((1.0 1.0, 1.1 1.1), (2.0 2.0, 2.1 2.1))",
+			"MULTIPOINT((55.0 55.0), (66.0 66.0))",
+			false,
+		},
+		{
+			"MULTILINESTRING intersects MULTILINESTRING",
+			"MULTILINESTRING((1.0 1.0, 2.0 2.0), (2.0 2.0, 2.1 2.1), (3.0 3.0, 3.1 3.1))",
+			"MULTILINESTRING((0.0 0.5001714, -1.0 -1.0), (1.5 1.5001714, 2.0 2.0))",
+			true,
+		},
+		{
+			"MULTILINESTRING does not intersect all MULTILINESTRING",
+			"MULTILINESTRING((1.0 1.0, 1.1 1.1), (2.0 2.0, 2.1 2.1), (3.0 3.0, 3.1 3.1))",
+			"MULTILINESTRING((25.0 25.0, 25.1 25.1), (4.0 3.0, 3.12 3.12))",
+			false,
+		},
+		{
+			"MULTIPOLYGON intersects MULTIPOINT",
+			"MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5)))",
+			"MULTIPOINT((30 20), (30 30))",
+			true,
+		},
+		{
+			"MULTIPOLYGON does not intersect MULTIPOINT",
+			"MULTIPOLYGON (((15 5, 40 10, 10 20, 5 10, 15 5)),((30 20, 45 40, 10 40, 30 20)))",
+			"MULTIPOINT((30 -20), (-30 30), (45 66))",
+			false,
+		},
+		{
+			"MULTIPOLYGON intersects MULTILINESTRING",
+			"MULTIPOLYGON (((15 5, 40 10, 10 20, 5 10, 15 5)),((30 20, 45 40, 10 40, 30 20)))",
+			"MULTILINESTRING((65 40, 60 40), (45 40, 10 40, 30 20))",
+			true,
+		},
+		{
+			"MULTIPOLYGON does not intersect MULTILINESTRING",
+			"MULTIPOLYGON (((15 5, 40 10, 10 20, 5 10, 15 5)),((30 20, 45 40, 10 40, 30 20)))",
+			"MULTILINESTRING((45 41, 60 80), (-45 -40, -10 -40))",
+			false,
+		},
+		{
+			"MULTIPOLYGON intersects MULTIPOLYGON",
+			"MULTIPOLYGON (((15 5, 40 10, 10 20, 5 10, 15 5)),((30 20, 45 40, 10 40, 30 20)))",
+			"MULTIPOLYGON (((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0)), ((30 20, 45 40, 10 40, 30 20)))",
+			true,
+		},
+		{
+			"MULTIPOLYGON does not intersect MULTIPOLYGON",
+			"MULTIPOLYGON (((15 5, 40 10, 10 20, 5 10, 15 5)),((30 20, 45 40, 10 40, 30 20)))",
+			"MULTIPOLYGON (((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0)))",
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			a, err := geo.ParseGeography(tc.a)
+			require.NoError(t, err)
+			b, err := geo.ParseGeography(tc.b)
+			require.NoError(t, err)
+
+			intersects, err := Intersects(a, b)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, intersects)
+
+			// Relationships should be reciprocal.
+			intersects, err = Intersects(b, a)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, intersects)
+		})
+	}
+}


### PR DESCRIPTION
This commits adds the intersect geography functionality, which uses the
S2 library to do the heavy lifting. Some of the edge crossings we've had
to implement ourselves but should be straightforward.

We have a 1cm precision for this (PostGIS is 0.001cm) which is line with
the S2 library, but that should be good enough for geospatial use cases.

Release note: None