### PR TITLE
acceptance: bump flyway versions

### DIFF
--- a/pkg/acceptance/compose/flyway/docker-compose.yml
+++ b/pkg/acceptance/compose/flyway/docker-compose.yml
@@ -2,13 +2,13 @@ version: '3'
 services:
   cockroach:
     image: ubuntu:xenial-20170214
-    command: /cockroach/cockroach start --insecure --listen-addr cockroach
+    command: /cockroach/cockroach start-single-node --insecure --listen-addr cockroach
     volumes:
       - ../../../../cockroach-linux-2.6.32-gnu-amd64:/cockroach/cockroach
   flyway:
     depends_on:
       - cockroach
-    image: boxfuse/flyway:6.0.0-beta
+    image: flyway/flyway:6
     volumes:
       - ./sql:/sql
     command: migrate -user=root -url=jdbc:postgresql://cockroach:26257/defaultdb -locations=filesystem:/sql


### PR DESCRIPTION
The flyway test has been failing stress. Bump its version to see if
that helps?

Release note: None