### PR TITLE
build: Upgrade builder image git version

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20200326-092324
+version=20200421-180956
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -266,6 +266,12 @@ RUN curl -fsSL "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-b
   ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
   rm -rf awscli-bundle.zip awscli-bundle
 
+# git - Upgrade to a more modern version
+RUN apt-get install -y python-software-properties software-properties-common && \
+    add-apt-repository ppa:git-core/ppa -y && \
+    apt-get update && \
+    apt-get install -y git
+
 ENV PATH /opt/backtrace/bin:$PATH
 
 RUN apt-get purge -y \


### PR DESCRIPTION
The version of git on the builder image is long in the tooth.  This change
updates the builder's build script to install an updated version of git
(current 2.26.2 as of this change).

Release note: None