### PR TITLE
release-19.2: import column selection fixes

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -461,13 +461,13 @@ func importPlanHook(
 			var intoCols []string
 			var isTargetCol = make(map[string]bool)
 			for _, name := range importStmt.IntoCols {
-				var err error
-				if _, err = found.FindActiveColumnByName(name.String()); err != nil {
+				active, err := found.FindActiveColumnsByNames(tree.NameList{name})
+				if err != nil {
 					return errors.Wrap(err, "verifying target columns")
 				}
 
-				isTargetCol[name.String()] = true
-				intoCols = append(intoCols, name.String())
+				isTargetCol[active[0].Name] = true
+				intoCols = append(intoCols, active[0].Name)
 			}
 
 			// IMPORT INTO does not support columns with DEFAULT expressions. Ensure

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1850,11 +1850,11 @@ func TestImportIntoCSV(t *testing.T) {
 			e INT8,
 			f STRING)`
 
-		data = "1,5,e,7,12,teststr"
 		t.Run(data, func(t *testing.T) {
 			sqlDB.Exec(t, createQuery)
 			defer sqlDB.Exec(t, `DROP TABLE t`)
 
+			data = "1"
 			sqlDB.Exec(t, `IMPORT INTO t (a) CSV DATA ($1)`, srv.URL)
 			sqlDB.CheckQueryResults(t, `SELECT * FROM t`,
 				sqlDB.QueryStr(t, `SELECT 1, NULL, NULL, NULL, NULL, 'NULL'`),
@@ -1864,7 +1864,8 @@ func TestImportIntoCSV(t *testing.T) {
 			sqlDB.Exec(t, createQuery)
 			defer sqlDB.Exec(t, `DROP TABLE t`)
 
-			sqlDB.Exec(t, `IMPORT INTO t (a, f) CSV DATA ($1) WITH experimental_direct_ingestion`, srv.URL)
+			data = "1,teststr"
+			sqlDB.Exec(t, `IMPORT INTO t (a, f) CSV DATA ($1)`, srv.URL)
 			sqlDB.CheckQueryResults(t, `SELECT * FROM t`,
 				sqlDB.QueryStr(t, `SELECT 1, NULL, NULL, NULL, NULL, 'teststr'`),
 			)
@@ -1872,6 +1873,8 @@ func TestImportIntoCSV(t *testing.T) {
 		t.Run(data, func(t *testing.T) {
 			sqlDB.Exec(t, createQuery)
 			defer sqlDB.Exec(t, `DROP TABLE t`)
+
+			data = "7,12,teststr"
 			sqlDB.Exec(t, `IMPORT INTO t (d, e, f) CSV DATA ($1)`, srv.URL)
 			sqlDB.CheckQueryResults(t, `SELECT * FROM t`,
 				sqlDB.QueryStr(t, `SELECT NULL, NULL, NULL, 7, 12, 'teststr'`),
@@ -1891,22 +1894,44 @@ func TestImportIntoCSV(t *testing.T) {
 			sqlDB.Exec(t, "INSERT INTO t (a, b) VALUES ($1, $2)", i+1000, v)
 		}
 
-		sqlDB.Exec(t, fmt.Sprintf("IMPORT INTO t (a) CSV DATA (%s)", testFiles.files[0]))
+		data := []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "GET" {
+				_, _ = w.Write([]byte(strings.Join(data, "\n")))
+			}
+		}))
+		defer srv.Close()
+
+		sqlDB.Exec(t, "IMPORT INTO t (a) CSV DATA ($1)", srv.URL)
 
 		var result int
 		numExistingRows := len(insert)
 		// Verify that the target column has been populated.
 		sqlDB.QueryRow(t, `SELECT count(*) FROM t WHERE a IS NOT NULL`).Scan(&result)
-		if expect := numExistingRows + rowsPerFile; result != expect {
+		if expect := numExistingRows + len(data); result != expect {
 			t.Fatalf("expected %d rows, got %d", expect, result)
 		}
 
 		// Verify that the non-target columns have NULLs.
 		sqlDB.QueryRow(t, `SELECT count(*) FROM t WHERE b IS NULL`).Scan(&result)
-		expectedNulls := rowsPerFile
+		expectedNulls := len(data)
 		if result != expectedNulls {
 			t.Fatalf("expected %d rows, got %d", expectedNulls, result)
 		}
+	})
+
+	// Tests IMPORT INTO with a CSV file having more columns when targeted, expected to
+	// get an error indicating the error.
+	t.Run("csv-with-more-than-targeted-columns", func(t *testing.T) {
+		sqlDB.Exec(t, `CREATE TABLE t (a INT PRIMARY KEY, b STRING)`)
+		defer sqlDB.Exec(t, `DROP TABLE t`)
+
+		// Expect an error if attempting to IMPORT INTO with CSV having more columns
+		// than targeted.
+		sqlDB.ExpectErr(
+			t, `row 1: expected 1 fields, got 2`,
+			fmt.Sprintf("IMPORT INTO t (a) CSV DATA (%s)", testFiles.files[0]),
+		)
 	})
 
 	// Tests IMPORT INTO with a target column set which does not include all PKs.
@@ -1941,6 +1966,27 @@ func TestImportIntoCSV(t *testing.T) {
 		sqlDB.ExpectErr(
 			t, fmt.Sprintf("pq: %s: row 1: expected 3 fields, got 2", stripFilenameQuotes),
 			fmt.Sprintf(`IMPORT INTO t (a, b, c) CSV DATA (%s)`, testFiles.files[0]),
+		)
+	})
+
+	// Tests the case where we create table columns in specific order while trying
+	// to import data from csv where columns order is different and import expression
+	// defines in what order columns should be imported to align with table definition
+	t.Run("target-cols-reordered", func(t *testing.T) {
+		sqlDB.Exec(t, "CREATE TABLE t (a INT PRIMARY KEY, b INT, c STRING NOT NULL, d DECIMAL NOT NULL)")
+		defer sqlDB.Exec(t, `DROP TABLE t`)
+
+		const data = "3.14,c is a string,1\n2.73,another string,2"
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "GET" {
+				_, _ = w.Write([]byte(data))
+			}
+		}))
+		defer srv.Close()
+
+		sqlDB.Exec(t, fmt.Sprintf(`IMPORT INTO t (d, c, a) CSV DATA ("%s")`, srv.URL))
+		sqlDB.CheckQueryResults(t, `SELECT * FROM t ORDER BY a`,
+			[][]string{{"1", "NULL", "c is a string", "3.14"}, {"2", "NULL", "another string", "2.73"}},
 		)
 	})
 
@@ -2009,7 +2055,7 @@ func TestImportIntoCSV(t *testing.T) {
 	t.Run("import-into-rejects-interleaved-tables", func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE parent (parent_id INT PRIMARY KEY)`)
 		sqlDB.Exec(t, `CREATE TABLE child (
-				parent_id INT, 
+				parent_id INT,
 				child_id INT,
 				PRIMARY KEY(parent_id, child_id))
 				INTERLEAVE IN PARENT parent(parent_id)`)

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1990,6 +1990,25 @@ func TestImportIntoCSV(t *testing.T) {
 		)
 	})
 
+	// Tests that we can import into the table even if the table has columns named with
+	// reserved keywords.
+	t.Run("cols-named-with-reserved-keywords", func(t *testing.T) {
+		sqlDB.Exec(t, `CREATE TABLE t ("select" INT PRIMARY KEY, "from" INT, "Some-c,ol-'Name'" STRING NOT NULL)`)
+		defer sqlDB.Exec(t, `DROP TABLE t`)
+
+		const data = "today,1,2"
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "GET" {
+				_, _ = w.Write([]byte(data))
+			}
+		}))
+		defer srv.Close()
+
+		sqlDB.Exec(t, fmt.Sprintf(
+			`IMPORT INTO t ("Some-c,ol-'Name'", "select", "from") CSV DATA ("%s")`, srv.URL))
+		sqlDB.CheckQueryResults(t, `SELECT * FROM t`, [][]string{{"1", "2", "today"}})
+	})
+
 	// Tests behvior when the existing table being imported into has fewer columns
 	// in its schema then the source CSV file.
 	t.Run("fewer-table-cols-than-csv", func(t *testing.T) {

--- a/pkg/ccl/importccl/read_import_csv.go
+++ b/pkg/ccl/importccl/read_import_csv.go
@@ -49,12 +49,16 @@ func newCSVInputReader(
 	targetCols tree.NameList,
 	evalCtx *tree.EvalContext,
 ) *csvInputReader {
+	expectedLen := len(targetCols)
+	if len(targetCols) == 0 {
+		expectedLen = len(tableDesc.VisibleColumns())
+	}
 	return &csvInputReader{
 		evalCtx:      evalCtx,
 		opts:         opts,
 		walltime:     walltime,
 		kvCh:         kvCh,
-		expectedCols: len(tableDesc.VisibleColumns()),
+		expectedCols: expectedLen,
 		tableDesc:    tableDesc,
 		targetCols:   targetCols,
 		recordCh:     make(chan csvRecord),
@@ -144,6 +148,7 @@ func (c *csvInputReader) readFile(
 		if uint32(i) <= c.opts.Skip {
 			continue
 		}
+
 		if len(record) == c.expectedCols {
 			// Expected number of columns.
 		} else if len(record) == c.expectedCols+1 && record[c.expectedCols] == "" {

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -247,7 +247,7 @@ func NewDatumRowConverter(
 	}
 
 	c.IsTargetCol = make(map[int]struct{})
-	for i, col := range immutDesc.VisibleColumns() {
+	for i, col := range targetColDescriptors {
 		if _, ok := isTargetColID[col.ID]; !ok {
 			continue
 		}
@@ -274,7 +274,7 @@ func NewDatumRowConverter(
 	c.cols = cols
 	c.defaultExprs = defaultExprs
 
-	c.VisibleCols = immutDesc.VisibleColumns()
+	c.VisibleCols = targetColDescriptors
 	c.VisibleColTypes = make([]*types.T, len(c.VisibleCols))
 	for i := range c.VisibleCols {
 		c.VisibleColTypes[i] = c.VisibleCols[i].DatumType()


### PR DESCRIPTION
Backport:
  * 1/1 commits from "importccl: fix target columns order" (#45747)
  * 1/1 commits from " importccl: Correctly resolve column names when importing." (#45944)

Please see individual PRs for details.

/cc @cockroachdb/release
