### PR TITLE
sql: gate Geospatial features under version gate

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -68,6 +68,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>20.1-1</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>20.1-2</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -61,6 +61,7 @@ const (
 	VersionTimePrecision
 	Version20_1
 	VersionStart20_2
+	VersionGeospatialType
 
 	// Add new versions here (step one of two).
 )
@@ -467,6 +468,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// VersionStart20_2 demarcates work towards CockroachDB v20.2.
 		Key:     VersionStart20_2,
 		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 1},
+	},
+	{
+		// VersionGeospatialType enables the use of Geospatial features.
+		Key:     VersionGeospatialType,
+		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 2},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/clusterversion/versionkey_string.go
+++ b/pkg/clusterversion/versionkey_string.go
@@ -37,11 +37,12 @@ func _() {
 	_ = x[VersionTimePrecision-26]
 	_ = x[Version20_1-27]
 	_ = x[VersionStart20_2-28]
+	_ = x[VersionGeospatialType-29]
 }
 
-const _VersionKey_name = "Version19_1VersionStart19_2VersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDsVersionHashShardedIndexesVersionCreateRolePrivilegeVersionStatementDiagnosticsSystemTablesVersionSchemaChangeJobVersionSavepointsVersionTimeTZTypeVersionTimePrecisionVersion20_1VersionStart20_2"
+const _VersionKey_name = "Version19_1VersionStart19_2VersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDsVersionHashShardedIndexesVersionCreateRolePrivilegeVersionStatementDiagnosticsSystemTablesVersionSchemaChangeJobVersionSavepointsVersionTimeTZTypeVersionTimePrecisionVersion20_1VersionStart20_2VersionGeospatialType"
 
-var _VersionKey_index = [...]uint16{0, 11, 27, 49, 75, 109, 136, 176, 200, 211, 227, 258, 287, 322, 354, 380, 404, 441, 480, 499, 534, 559, 585, 624, 646, 663, 680, 700, 711, 727}
+var _VersionKey_index = [...]uint16{0, 11, 27, 49, 75, 109, 136, 176, 200, 211, 227, 258, 287, 322, 354, 380, 404, 441, 480, 499, 534, 559, 585, 624, 646, 663, 680, 700, 711, 727, 748}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -115,7 +115,9 @@ var storageParamExpectedTypes = map[string]storageParamType{
 // minimumTypeUsageVersions defines the minimum version needed for a new
 // data type.
 var minimumTypeUsageVersions = map[types.Family]clusterversion.VersionKey{
-	types.TimeTZFamily: clusterversion.VersionTimeTZType,
+	types.TimeTZFamily:    clusterversion.VersionTimeTZType,
+	types.GeographyFamily: clusterversion.VersionGeospatialType,
+	types.GeometryFamily:  clusterversion.VersionGeospatialType,
 }
 
 // isTypeSupportedInVersion returns whether a given type is supported in the given version.

--- a/pkg/sql/logictest/testdata/logic_test/alter_table_mixed_19.2_20.1
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table_mixed_19.2_20.1
@@ -204,3 +204,16 @@ CREATE TABLE regression_47110_not_ok(interval_not_ok INTERVAL(3))
 
 statement error type INTERVAL DAY is not supported until version upgrade is finalized
 CREATE TABLE regression_47110_not_ok(interval_not_ok INTERVAL DAY)
+
+# TODO(otan): move this to mixed 20.1-20.2 tests when available.
+statement error type GEOMETRY is not supported until version upgrade is finalized
+CREATE TABLE geo_test(a GEOMETRY)
+
+statement error type GEOGRAPHY.* is not supported until version upgrade is finalized
+CREATE TABLE geo_test(a GEOGRAPHY)
+
+statement error type GEOMETRY is not supported until version upgrade is finalized
+ALTER TABLE t ADD COLUMN geo GEOMETRY
+
+statement error type GEOGRAPHY.* is not supported until version upgrade is finalized
+ALTER TABLE t ADD COLUMN geo GEOGRAPHY


### PR DESCRIPTION
Prevent the creation of Geospatial types until a version upgrade is
complete. Re-using the 19.2-20.1 mixed cluster tests for now to test
this.

Resolves #47242.

Release note: None