### PR TITLE
release-20.1: jobs: use system.jobs instead of SHOW JOBS to poll jobs

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -294,12 +294,15 @@ func (r *Registry) Run(ctx context.Context, ex sqlutil.InternalExecutor, jobs []
 		if i > 0 {
 			buf.WriteString(",")
 		}
-		buf.WriteString(fmt.Sprintf(" (%d)", id))
+		buf.WriteString(fmt.Sprintf(" %d", id))
 	}
 	// Manually retry instead of using SHOW JOBS WHEN COMPLETE so we have greater
-	// control over retries.
+	// control over retries. Also, avoiding SHOW JOBS prevents us from having to
+	// populate the crdb_internal.jobs vtable.
 	query := fmt.Sprintf(
-		"SELECT count(*) FROM [SHOW JOBS VALUES %s] WHERE finished IS NULL", buf.String())
+		`SELECT count(*) FROM system.jobs WHERE id IN (%s)
+       AND (status != 'succeeded' AND status != 'failed' AND status != 'canceled')`,
+		buf.String())
 	for r := retry.StartWithCtx(ctx, retry.Options{
 		InitialBackoff: 10 * time.Millisecond,
 		MaxBackoff:     1 * time.Second,


### PR DESCRIPTION
Backport 1/1 commits from #47786.

/cc @cockroachdb/release

---

Previously, the jobs registry would check for unfinished jobs using SHOW
JOBS. This causes the crdb_internal.jobs vtable to be materialized,
which loads all rows from system.jobs and deserializes their payloads.

This work can be skipped by requesting individual rows from system.jobs
directly.

In the case of ORM test suites that frequently create and drop tables
repeatedly, populating the crdb_internal.jobs table was using a lot of
memory and time.

Release note: None
