### PR TITLE
release-20.1: use StartableJobs for GC and index drop jobs created at the end of the schema changer job

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -735,20 +735,6 @@ ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (x)
 statement ok
 ROLLBACK
 
-# Ensure that we cannot cancel the index cleanup jobs spawned by
-# a primary key change.
-statement ok
-DROP TABLE IF EXISTS t;
-CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL);
-ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (y)
-
-statement error pq: job [0-9]*: not cancelable
-CANCEL JOB (
-  SELECT job_id FROM [SHOW JOBS] WHERE
-  description = 'CLEANUP JOB for ''ALTER TABLE test.public.t ALTER PRIMARY KEY USING COLUMNS (y)''' AND
-  status = 'running'
-)
-
 # Ensure that starting a primary key change that does not
 # enqueue any mutations doesn't start a job.
 # TODO (rohany): This test might become obselete when #44923 is fixed.

--- a/pkg/sql/logictest/testdata/logic_test/drop_database
+++ b/pkg/sql/logictest/testdata/logic_test/drop_database
@@ -34,12 +34,8 @@ postgres
 system
 test
 
-# The "updating privileges" clause in the SELECT statement is for excluding jobs
-# run by an unrelated startup migration.
-# TODO (lucy): Update this if/when we decide to change how these jobs queued by
-# the startup migration are handled.
 query TT
-SELECT job_type, status FROM [SHOW JOBS] WHERE description != 'updating privileges'
+SELECT job_type, status FROM [SHOW JOBS]
 ----
 SCHEMA CHANGE       succeeded
 SCHEMA CHANGE GC    running
@@ -251,3 +247,15 @@ DROP DATABASE defaultdb; DROP DATABASE postgres
 
 statement ok
 CREATE DATABASE defaultdb; CREATE DATABASE postgres
+
+# Test that an empty database doesn't get a GC job.
+statement ok
+CREATE DATABASE empty
+
+statement ok
+DROP DATABASE empty
+
+query TT
+SELECT job_type, status FROM [SHOW JOBS] WHERE description LIKE '%empty%'
+----
+SCHEMA CHANGE       succeeded

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -373,22 +373,8 @@ func startGCJob(
 	details jobspb.SchemaChangeGCDetails,
 ) error {
 	var sj *jobs.StartableJob
-	descriptorIDs := make([]sqlbase.ID, 0)
-	if len(details.Indexes) > 0 {
-		if len(descriptorIDs) == 0 {
-			descriptorIDs = []sqlbase.ID{details.ParentID}
-		}
-	} else if len(details.Tables) > 0 {
-		for _, table := range details.Tables {
-			descriptorIDs = append(descriptorIDs, table.ID)
-		}
-	} else {
-		// Nothing to GC.
-		return nil
-	}
-
+	jobRecord := CreateGCJobRecord(schemaChangeDescription, username, details)
 	if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		jobRecord := CreateGCJobRecord(schemaChangeDescription, username, descriptorIDs, details)
 		var err error
 		if sj, err = jobRegistry.CreateStartableJobWithTxn(ctx, jobRecord, txn, nil /* resultCh */); err != nil {
 			return err
@@ -401,16 +387,6 @@ func startGCJob(
 		return err
 	}
 	return nil
-}
-
-func (sc *SchemaChanger) startGCJob(
-	ctx context.Context, details jobspb.SchemaChangeGCDetails, isRollback bool,
-) error {
-	description := sc.job.Payload().Description
-	if isRollback {
-		description = "ROLLBACK of " + description
-	}
-	return startGCJob(ctx, sc.db, sc.jobRegistry, sc.job.Payload().Username, description, details)
 }
 
 // Execute the entire schema change in steps.
@@ -464,7 +440,9 @@ func (sc *SchemaChanger) exec(ctx context.Context) error {
 				},
 			},
 		}
-		if err := sc.startGCJob(ctx, gcDetails, false /* isRollback */); err != nil {
+		if err := startGCJob(
+			ctx, sc.db, sc.jobRegistry, sc.job.Payload().Username, sc.job.Payload().Description, gcDetails,
+		); err != nil {
 			return err
 		}
 	}
@@ -799,9 +777,11 @@ func (sc *SchemaChanger) done(ctx context.Context) (*sqlbase.ImmutableTableDescr
 		}
 	}
 
+	var indexGCJobs []*jobs.StartableJob
 	update := func(txn *kv.Txn, descs map[sqlbase.ID]*sqlbase.MutableTableDescriptor) error {
 		// Reset vars here because update function can be called multiple times in a retry.
 		isRollback = false
+		indexGCJobs = nil
 
 		i := 0
 		scDesc, ok := descs[sc.tableID]
@@ -837,9 +817,18 @@ func (sc *SchemaChanger) done(ctx context.Context) (*sqlbase.ImmutableTableDescr
 						},
 						ParentID: sc.tableID,
 					}
-					if err := sc.startGCJob(ctx, indexGCDetails, isRollback); err != nil {
+
+					description := sc.job.Payload().Description
+					if isRollback {
+						description = "ROLLBACK of " + description
+					}
+					gcJobRecord := CreateGCJobRecord(description, sc.job.Payload().Username, indexGCDetails)
+					indexGCJob, err := sc.jobRegistry.CreateStartableJobWithTxn(ctx, gcJobRecord, txn, nil /* resultsCh */)
+					if err != nil {
 						return err
 					}
+					log.VEventf(ctx, 2, "created index GC job %d", *indexGCJob.ID())
+					indexGCJobs = append(indexGCJobs, indexGCJob)
 				}
 			}
 			if constraint := mutation.GetConstraint(); constraint != nil &&
@@ -921,10 +910,15 @@ func (sc *SchemaChanger) done(ctx context.Context) (*sqlbase.ImmutableTableDescr
 						Progress:      jobspb.SchemaChangeProgress{},
 						NonCancelable: true,
 					}
+					// TODO (lucy): We should be able to create a StartableJob and start
+					// it after calling PublishMultiple() to finalize the mutations,
+					// as with the indexGCJob. That will allow us to start the job
+					// immediately without having to wait for the registry to adopt it.
 					job, err := sc.jobRegistry.CreateJobWithTxn(ctx, jobRecord, txn)
 					if err != nil {
 						return err
 					}
+					log.VEventf(ctx, 2, "created job %d to drop previous indexes", *job.ID())
 					scDesc.MutationJobs = append(scDesc.MutationJobs, sqlbase.TableDescriptor_MutationJob{
 						MutationID: mutationID,
 						JobID:      *job.ID(),
@@ -973,7 +967,18 @@ func (sc *SchemaChanger) done(ctx context.Context) (*sqlbase.ImmutableTableDescr
 		)
 	})
 	if err != nil {
+		for _, job := range indexGCJobs {
+			if rollbackErr := job.CleanupOnRollback(ctx); rollbackErr != nil {
+				log.Warningf(ctx, "failed to cleanup job: %v", rollbackErr)
+			}
+		}
 		return nil, err
+	}
+	for _, job := range indexGCJobs {
+		if _, err := job.Start(ctx); err != nil {
+			log.Warningf(ctx, "starting GC job %d failed with error: %v", *job.ID(), err)
+		}
+		log.VEventf(ctx, 2, "started GC job %d", *job.ID())
 	}
 	return descs[sc.tableID], nil
 }
@@ -1379,14 +1384,21 @@ func (sc *SchemaChanger) reverseMutation(
 	return mutation, columns
 }
 
-// CreateGCJobRecord creates the job record for a GC job setting some properties
-// which are common for all GC job.
+// CreateGCJobRecord creates the job record for a GC job, setting some
+// properties which are common for all GC jobs.
 func CreateGCJobRecord(
-	originalDescription string,
-	username string,
-	descriptorIDs sqlbase.IDs,
-	details jobspb.SchemaChangeGCDetails,
+	originalDescription string, username string, details jobspb.SchemaChangeGCDetails,
 ) jobs.Record {
+	descriptorIDs := make([]sqlbase.ID, 0)
+	if len(details.Indexes) > 0 {
+		if len(descriptorIDs) == 0 {
+			descriptorIDs = []sqlbase.ID{details.ParentID}
+		}
+	} else {
+		for _, table := range details.Tables {
+			descriptorIDs = append(descriptorIDs, table.ID)
+		}
+	}
 	return jobs.Record{
 		Description:   fmt.Sprintf("GC for %s", originalDescription),
 		Username:      username,
@@ -1605,6 +1617,12 @@ func (r schemaChangeResumer) Resume(
 				return err
 			}
 		}
+		return nil
+	}
+
+	// For an empty database, the zone config for it was already GC'ed and there's
+	// nothing left to do.
+	if details.DroppedDatabaseID != sqlbase.InvalidID && len(details.DroppedTables) == 0 {
 		return nil
 	}
 

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -405,10 +405,12 @@ func runSchemaChangeWithOperations(
 	wg.Wait() // for schema change to complete.
 
 	// Verify the number of keys left behind in the table to validate schema
-	// change operations.
-	if err := checkTableKeyCount(ctx, kvDB, keyMultiple, maxValue+numInserts); err != nil {
-		t.Fatal(err)
-	}
+	// change operations. This is wrapped in SucceedsSoon to handle cases where
+	// dropped indexes are expected to be GC'ed immediately after the schema
+	// change completes.
+	testutils.SucceedsSoon(t, func() error {
+		return checkTableKeyCount(ctx, kvDB, keyMultiple, maxValue+numInserts)
+	})
 	if err := sqlutils.RunScrub(sqlDB, "t", "test"); err != nil {
 		t.Fatal(err)
 	}
@@ -2494,6 +2496,13 @@ CREATE TABLE t.test (k INT NOT NULL, v INT);
 `); err != nil {
 		t.Fatal(err)
 	}
+	// GC the old indexes to be dropped after the PK change immediately.
+	defer disableGCTTLStrictEnforcement(t, sqlDB)()
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
+	if _, err := addImmediateGCZoneConfig(sqlDB, tableDesc.ID); err != nil {
+		t.Fatal(err)
+	}
+
 	// Bulk insert.
 	if err := bulkInsertIntoTable(sqlDB, maxValue); err != nil {
 		t.Fatal(err)
@@ -2505,7 +2514,7 @@ CREATE TABLE t.test (k INT NOT NULL, v INT);
 		kvDB,
 		"ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (k)",
 		maxValue,
-		2,
+		1,
 		initBackfillNotification(),
 		// We don't let runSchemaChangeWithOperations use UPSERT statements, because
 		// way in which runSchemaChangeWithOperations uses them assumes that k is already
@@ -2989,14 +2998,68 @@ CREATE TABLE t.test (k INT NOT NULL, v INT);
 	})
 }
 
+// TestPrimaryKeyDropIndexNotCancelable tests that the job to drop indexes after
+// a primary key change is not cancelable.
+func TestPrimaryKeyDropIndexNotCancelable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	var db *gosql.DB
+	shouldAttemptCancel := true
+	hasAttemptedCancel := make(chan struct{})
+	params, _ := tests.CreateTestServerParams()
+	params.Knobs = base.TestingKnobs{
+		GCJob: &sql.GCJobTestingKnobs{
+			RunBeforeResume: func(jobID int64) error {
+				if !shouldAttemptCancel {
+					return nil
+				}
+				_, err := db.Exec(`CANCEL JOB ($1)`, jobID)
+				require.Regexp(t, "not cancelable", err)
+				shouldAttemptCancel = false
+				close(hasAttemptedCancel)
+				return nil
+			},
+		},
+	}
+	s, sqlDB, kvDB := serverutils.StartServer(t, params)
+	db = sqlDB
+	defer s.Stopper().Stop(ctx)
+
+	_, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (k INT NOT NULL, v INT);
+`)
+	require.NoError(t, err)
+
+	_, err = sqlDB.Exec(`ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (k)`)
+	require.NoError(t, err)
+
+	// Wait until the testing knob has notified that canceling the job has been
+	// attempted before continuing.
+	<-hasAttemptedCancel
+
+	sqlRun := sqlutils.MakeSQLRunner(sqlDB)
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
+	testutils.SucceedsSoon(t, func() error {
+		return jobutils.VerifySystemJob(t, sqlRun, 1, jobspb.TypeSchemaChange, jobs.StatusSucceeded, jobs.Record{
+			Description:   "CLEANUP JOB for 'ALTER TABLE t.public.test ALTER PRIMARY KEY USING COLUMNS (k)'",
+			Username:      security.RootUser,
+			DescriptorIDs: sqlbase.IDs{tableDesc.ID},
+		})
+	})
+}
+
 // TestMultiplePrimaryKeyChanges ensures that we can run many primary key
-// changes back to back. We cannot run this in a logic test because we need the
-// job that drops old indexes to finish so that the following primary key change
-// occurs quickly.
+// changes back to back. We cannot run this in a logic test because we need to
+// set a low job registry adopt interval, so that each successive schema change
+// can run immediately without waiting too long for a retry due to being second
+// in line after the mutation to drop indexes for the previous primary key
+// change.
 func TestMultiplePrimaryKeyChanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	// Adopt the job to drop old indexes quickly.
+	// Decrease the adopt loop interval so that retries happen quickly.
 	defer setTestJobsAdoptInterval()()
 
 	ctx := context.Background()

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -918,7 +918,6 @@ func migrateSchemaChangeJobs(ctx context.Context, r runner, registry *jobs.Regis
 		record := sql.CreateGCJobRecord(
 			fmt.Sprintf("table %d", desc.ID),
 			security.NodeUser,
-			sqlbase.IDs{desc.ID},
 			jobspb.SchemaChangeGCDetails{
 				Tables: []jobspb.SchemaChangeGCDetails_DroppedID{{ID: desc.ID, DropTime: desc.DropTime}},
 			})
@@ -1079,7 +1078,6 @@ func migrateMutationJobForTable(
 		indexGCJobRecord := sql.CreateGCJobRecord(
 			job.Payload().Description,
 			job.Payload().Username,
-			sqlbase.IDs{tableDesc.ID},
 			jobspb.SchemaChangeGCDetails{
 				Indexes: []jobspb.SchemaChangeGCDetails_DroppedIndex{
 					{
@@ -1181,7 +1179,6 @@ func migrateDropTablesOrDatabaseJob(
 	gcJobRecord := sql.CreateGCJobRecord(
 		job.Payload().Description,
 		job.Payload().Username,
-		job.Payload().DescriptorIDs,
 		jobspb.SchemaChangeGCDetails{
 			Tables:   tablesToDrop,
 			ParentID: details.DroppedDatabaseID,


### PR DESCRIPTION
Backport:
  * 1/1 commits from "sql: wait to start index GC job until schema changer is done" (#46929)
  * 1/1 commits from "sql: start index drop job for primary key changes immediately" (#47624)

Please see individual PRs for details.

/cc @cockroachdb/release
