### PR TITLE
colexec: make projecting operators unset nulls in their output vector

### DIFF
--- a/pkg/sql/colexec/and_or_projection_tmpl.go
+++ b/pkg/sql/colexec/and_or_projection_tmpl.go
@@ -197,6 +197,11 @@ func (o *_OP_LOWERProjOp) Next(ctx context.Context) coldata.Batch {
 	outputCol := batch.ColVec(o.outputIdx)
 	outputColVals := outputCol.Bool()
 	outputNulls := outputCol.Nulls()
+	if outputCol.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputNulls.UnsetNulls()
+	}
 	// This is where we populate the output - do the actual evaluation of the
 	// logical operation.
 	if leftCol.MaybeHasNulls() {

--- a/pkg/sql/colexec/builtin_funcs.go
+++ b/pkg/sql/colexec/builtin_funcs.go
@@ -56,6 +56,11 @@ func (b *defaultBuiltinFuncOperator) Next(ctx context.Context) coldata.Batch {
 
 	sel := batch.Selection()
 	output := batch.ColVec(b.outputIdx)
+	if output.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		output.Nulls().UnsetNulls()
+	}
 	b.allocator.PerformOperation(
 		[]coldata.Vec{output},
 		func() {

--- a/pkg/sql/colexec/const_tmpl.go
+++ b/pkg/sql/colexec/const_tmpl.go
@@ -109,6 +109,11 @@ func (c const_TYPEOp) Next(ctx context.Context) coldata.Batch {
 	}
 	vec := batch.ColVec(c.outputIdx)
 	col := vec._TemplateType()
+	if vec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		vec.Nulls().UnsetNulls()
+	}
 	c.allocator.PerformOperation(
 		[]coldata.Vec{vec},
 		func() {
@@ -163,6 +168,11 @@ func (c constNullOp) Next(ctx context.Context) coldata.Batch {
 
 	col := batch.ColVec(c.outputIdx)
 	nulls := col.Nulls()
+	if col.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		nulls.UnsetNulls()
+	}
 	if sel := batch.Selection(); sel != nil {
 		for _, i := range sel[:n] {
 			nulls.SetNull(i)

--- a/pkg/sql/colexec/is_null_ops.go
+++ b/pkg/sql/colexec/is_null_ops.go
@@ -57,7 +57,13 @@ func (o *isNullProjOp) Next(ctx context.Context) coldata.Batch {
 	}
 	vec := batch.ColVec(o.colIdx)
 	nulls := vec.Nulls()
-	projCol := batch.ColVec(o.outputIdx).Bool()
+	projVec := batch.ColVec(o.outputIdx)
+	projCol := projVec.Bool()
+	if projVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		projVec.Nulls().UnsetNulls()
+	}
 	if nulls.MaybeHasNulls() {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]

--- a/pkg/sql/colexec/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_const_ops_tmpl.go
@@ -110,6 +110,11 @@ func (p _OP_CONST_NAME) Next(ctx context.Context) coldata.Batch {
 	col := vec._L_TYP()
 	// {{end}}
 	projVec := batch.ColVec(p.outputIdx)
+	if projVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		projVec.Nulls().UnsetNulls()
+	}
 	projCol := projVec._RET_TYP()
 	if vec.Nulls().MaybeHasNulls() {
 		_SET_PROJECTION(true)

--- a/pkg/sql/colexec/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_non_const_ops_tmpl.go
@@ -126,6 +126,11 @@ func (p _OP_NAME) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	projVec := batch.ColVec(p.outputIdx)
+	if projVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		projVec.Nulls().UnsetNulls()
+	}
 	projCol := projVec._RET_TYP()
 	vec1 := batch.ColVec(p.col1Idx)
 	vec2 := batch.ColVec(p.col2Idx)

--- a/pkg/sql/colexec/rank_tmpl.go
+++ b/pkg/sql/colexec/rank_tmpl.go
@@ -134,7 +134,13 @@ func (r *_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	partitionCol := batch.ColVec(r.partitionColIdx).Bool()
 	// {{end}}
 	peersCol := batch.ColVec(r.peersColIdx).Bool()
-	rankCol := batch.ColVec(r.outputColIdx).Int64()
+	rankVec := batch.ColVec(r.outputColIdx)
+	if rankVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		rankVec.Nulls().UnsetNulls()
+	}
+	rankCol := rankVec.Int64()
 	sel := batch.Selection()
 	// TODO(yuzefovich): template out sel vs non-sel cases.
 	if sel != nil {

--- a/pkg/sql/colexec/row_number_tmpl.go
+++ b/pkg/sql/colexec/row_number_tmpl.go
@@ -82,7 +82,13 @@ func (r *_ROW_NUMBER_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	// {{ if .HasPartition }}
 	partitionCol := batch.ColVec(r.partitionColIdx).Bool()
 	// {{ end }}
-	rowNumberCol := batch.ColVec(r.outputColIdx).Int64()
+	rowNumberVec := batch.ColVec(r.outputColIdx)
+	if rowNumberVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		rowNumberVec.Nulls().UnsetNulls()
+	}
+	rowNumberCol := rowNumberVec.Int64()
 	sel := batch.Selection()
 	if sel != nil {
 		for i := 0; i < batch.Length(); i++ {

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -285,6 +285,11 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 	projVec := batch.ColVec(pi.outputIdx)
 	projCol := projVec.Bool()
 	projNulls := projVec.Nulls()
+	if projVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		projNulls.UnsetNulls()
+	}
 
 	n := batch.Length()
 

--- a/pkg/sql/colexec/substring_tmpl.go
+++ b/pkg/sql/colexec/substring_tmpl.go
@@ -108,6 +108,11 @@ func (s *substring_StartType_LengthTypeOperator) Next(ctx context.Context) colda
 	startVec := batch.ColVec(s.argumentCols[1])._StartType()
 	lengthVec := batch.ColVec(s.argumentCols[2])._LengthType()
 	outputVec := batch.ColVec(s.outputIdx)
+	if outputVec.MaybeHasNulls() {
+		// We need to make sure that there are no left over null values in the
+		// output vector.
+		outputVec.Nulls().UnsetNulls()
+	}
 	outputCol := outputVec.Bytes()
 	s.allocator.PerformOperation(
 		[]coldata.Vec{outputVec},


### PR DESCRIPTION
This commit adds unsetting of nulls in the output vector of all
projecting operators (those that do not own their output batch and
choose to append the output vector to their input batch) which
previously was omitted.

Release note: None