### PR TITLE
util/log: type the Level argument to vmodule functions as own type

### DIFF
--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -104,7 +104,7 @@ const (
 
 // vLevel returns the vmodule log level at which logs from the given executor
 // should be written to the logs.
-func (s executorType) vLevel() int32 { return int32(s) + 2 }
+func (s executorType) vLevel() log.Level { return log.Level(s) + 2 }
 
 var logLabels = []string{"exec", "exec-internal"}
 

--- a/pkg/util/grpcutil/log.go
+++ b/pkg/util/grpcutil/log.go
@@ -141,7 +141,7 @@ func (severity *logger) V(i int) bool {
 	if i > math.MaxInt32 {
 		i = math.MaxInt32
 	}
-	return log.VDepth(int32(i) /* level */, 1 /* depth */)
+	return log.VDepth(log.Level(i) /* level */, 1 /* depth */)
 }
 
 // https://github.com/grpc/grpc-go/blob/v1.7.0/clientconn.go#L937

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -354,7 +354,7 @@ func TestVmoduleOff(t *testing.T) {
 	_ = SetVModule("notthisfile=2")
 	defer func() { _ = SetVModule("") }()
 	for i := 1; i <= 3; i++ {
-		if V(int32(i)) {
+		if V(Level(i)) {
 			t.Errorf("V enabled for %d", i)
 		}
 	}

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -181,7 +181,7 @@ func FatalfDepth(ctx context.Context, depth int, format string, args ...interfac
 //
 // TODO(andrei): Audit uses of V() and see which ones should actually use the
 // newer ExpensiveLogEnabled().
-func V(level int32) bool {
+func V(level Level) bool {
 	return VDepth(level, 1)
 }
 
@@ -205,7 +205,7 @@ func V(level int32) bool {
 //   log.VEventf(ctx, 2, msg)
 // }
 //
-func ExpensiveLogEnabled(ctx context.Context, level int32) bool {
+func ExpensiveLogEnabled(ctx context.Context, level Level) bool {
 	if sp := opentracing.SpanFromContext(ctx); sp != nil {
 		if tracing.IsRecording(sp) {
 			return true

--- a/pkg/util/log/trace.go
+++ b/pkg/util/log/trace.go
@@ -162,7 +162,7 @@ func Eventf(ctx context.Context, format string, args ...interface{}) {
 }
 
 func vEventf(
-	ctx context.Context, isErr bool, depth int, level int32, format string, args ...interface{},
+	ctx context.Context, isErr bool, depth int, level Level, format string, args ...interface{},
 ) {
 	if VDepth(level, 1+depth) {
 		// Log the message (which also logs an event).
@@ -179,41 +179,41 @@ func vEventf(
 // VEvent either logs a message to the log files (which also outputs to the
 // active trace or event log) or to the trace/event log alone, depending on
 // whether the specified verbosity level is active.
-func VEvent(ctx context.Context, level int32, msg string) {
+func VEvent(ctx context.Context, level Level, msg string) {
 	vEventf(ctx, false /* isErr */, 1, level, msg)
 }
 
 // VEventf either logs a message to the log files (which also outputs to the
 // active trace or event log) or to the trace/event log alone, depending on
 // whether the specified verbosity level is active.
-func VEventf(ctx context.Context, level int32, format string, args ...interface{}) {
+func VEventf(ctx context.Context, level Level, format string, args ...interface{}) {
 	vEventf(ctx, false /* isErr */, 1, level, format, args...)
 }
 
 // VEventfDepth performs the same as VEventf but checks the verbosity level
 // at the given depth in the call stack.
-func VEventfDepth(ctx context.Context, depth int, level int32, format string, args ...interface{}) {
+func VEventfDepth(ctx context.Context, depth int, level Level, format string, args ...interface{}) {
 	vEventf(ctx, false /* isErr */, 1+depth, level, format, args...)
 }
 
 // VErrEvent either logs an error message to the log files (which also outputs
 // to the active trace or event log) or to the trace/event log alone, depending
 // on whether the specified verbosity level is active.
-func VErrEvent(ctx context.Context, level int32, msg string) {
+func VErrEvent(ctx context.Context, level Level, msg string) {
 	vEventf(ctx, true /* isErr */, 1, level, msg)
 }
 
 // VErrEventf either logs an error message to the log files (which also outputs
 // to the active trace or event log) or to the trace/event log alone, depending
 // on whether the specified verbosity level is active.
-func VErrEventf(ctx context.Context, level int32, format string, args ...interface{}) {
+func VErrEventf(ctx context.Context, level Level, format string, args ...interface{}) {
 	vEventf(ctx, true /* isErr */, 1, level, format, args...)
 }
 
 // VErrEventfDepth performs the same as VErrEventf but checks the verbosity
 // level at the given depth in the call stack.
 func VErrEventfDepth(
-	ctx context.Context, depth int, level int32, format string, args ...interface{},
+	ctx context.Context, depth int, level Level, format string, args ...interface{},
 ) {
 	vEventf(ctx, true /* isErr */, 1+depth, level, format, args...)
 }

--- a/pkg/util/log/trace_test.go
+++ b/pkg/util/log/trace_test.go
@@ -55,8 +55,8 @@ func compareTraces(expected, actual events) bool {
 
 // noLogV returns a verbosity level that will not result in VEvents and
 // VErrEvents being logged.
-func noLogV() int32 {
-	return int32(logging.vmoduleConfig.verbosity.get() + 1)
+func noLogV() Level {
+	return logging.vmoduleConfig.verbosity.get() + 1
 }
 
 func TestTrace(t *testing.T) {

--- a/pkg/util/log/vmodule.go
+++ b/pkg/util/log/vmodule.go
@@ -31,7 +31,7 @@ type vmoduleConfig struct {
 
 	// V logging level, the value of the --verbosity flag. Updated with
 	// atomics.
-	verbosity level
+	verbosity Level
 
 	mu struct {
 		// These flags are modified only under lock.
@@ -39,7 +39,7 @@ type vmoduleConfig struct {
 
 		// vmap is a cache of the V Level for each V() call site, identified by PC.
 		// It is wiped whenever the vmodule flag changes state.
-		vmap map[uintptr]level
+		vmap map[uintptr]Level
 
 		// filterLength stores the length of the vmodule filter
 		// chain. If greater than zero, it means vmodule is enabled. It is
@@ -67,16 +67,16 @@ func SetVModule(value string) error {
 
 // VDepth reports whether verbosity at the call site is at least the requested
 // level.
-func VDepth(l int32, depth int) bool {
+func VDepth(l Level, depth int) bool {
 	return logging.vmoduleConfig.vDepth(l, depth+1)
 }
 
-func (c *vmoduleConfig) vDepth(l int32, depth int) bool {
+func (c *vmoduleConfig) vDepth(l Level, depth int) bool {
 	// This function tries hard to be cheap unless there's work to do.
 	// The fast path is three atomic loads and compares.
 
 	// Here is a cheap but safe test to see if V logging is enabled globally.
-	if c.verbosity.get() >= level(l) {
+	if c.verbosity.get() >= l {
 		return true
 	}
 
@@ -108,14 +108,14 @@ func (c *vmoduleConfig) vDepth(l int32, depth int) bool {
 		}
 		c.mu.Unlock()
 		c.pcsPool.Put(poolObj)
-		return v >= level(l)
+		return v >= l
 	}
 	return false
 }
 
 // setVState sets a consistent state for V logging.
 // l.mu is held.
-func (c *vmoduleConfig) setVState(verbosity level, filter []modulePat, setFilter bool) {
+func (c *vmoduleConfig) setVState(verbosity Level, filter []modulePat, setFilter bool) {
 	// Turn verbosity off so V will not fire while we are in transition.
 	c.verbosity.set(0)
 	// Ditto for filter length.
@@ -124,7 +124,7 @@ func (c *vmoduleConfig) setVState(verbosity level, filter []modulePat, setFilter
 	// Set the new filters and wipe the pc->Level map if the filter has changed.
 	if setFilter {
 		c.mu.vmodule.filter = filter
-		c.mu.vmap = make(map[uintptr]level)
+		c.mu.vmap = make(map[uintptr]Level)
 	}
 
 	// Things are consistent now, so enable filtering and verbosity.
@@ -140,7 +140,7 @@ func (c *vmoduleConfig) setVState(verbosity level, filter []modulePat, setFilter
 // general than the *? matching used in C++.
 //
 // c.mu is held.
-func (c *vmoduleConfig) setV(pc [1]uintptr) level {
+func (c *vmoduleConfig) setV(pc [1]uintptr) Level {
 	frame, _ := runtime.CallersFrames(pc[:]).Next()
 	file := frame.File
 	// The file is something like /a/b/c/d.go. We want just the d.
@@ -170,7 +170,7 @@ type moduleSpec struct {
 type modulePat struct {
 	pattern string
 	literal bool // The pattern is a literal string
-	level   level
+	level   Level
 }
 
 // match reports whether the file matches the pattern. It uses a string
@@ -223,7 +223,7 @@ func (m *moduleSpec) Set(value string) error {
 			continue // Ignore. It's harmless but no point in paying the overhead.
 		}
 		// TODO: check syntax of filter?
-		filter = append(filter, modulePat{pattern, isLiteral(pattern), level(v)})
+		filter = append(filter, modulePat{pattern, isLiteral(pattern), Level(v)})
 	}
 
 	logging.vmoduleConfig.mu.Lock()
@@ -250,31 +250,31 @@ func isLiteral(pattern string) bool {
 // Level specifies a level of verbosity for V logs. *Level implements
 // flag.Value; the --verbosity flag is of type Level and should be modified
 // only through the flag.Value interface.
-type level int32
+type Level int32
 
 // get returns the value of the Level.
-func (l *level) get() level {
-	return level(atomic.LoadInt32((*int32)(l)))
+func (l *Level) get() Level {
+	return Level(atomic.LoadInt32((*int32)(l)))
 }
 
 // set sets the value of the Level.
-func (l *level) set(val level) {
+func (l *Level) set(val Level) {
 	atomic.StoreInt32((*int32)(l), int32(val))
 }
 
 // String is part of the flag.Value interface.
-func (l *level) String() string {
+func (l *Level) String() string {
 	return strconv.FormatInt(int64(*l), 10)
 }
 
 // Set is part of the flag.Value interface.
-func (l *level) Set(value string) error {
+func (l *Level) Set(value string) error {
 	v, err := strconv.Atoi(value)
 	if err != nil {
 		return err
 	}
 	logging.vmoduleConfig.mu.Lock()
 	defer logging.vmoduleConfig.mu.Unlock()
-	logging.vmoduleConfig.setVState(level(v), logging.vmoduleConfig.mu.vmodule.filter, false)
+	logging.vmoduleConfig.setVState(Level(v), logging.vmoduleConfig.mu.vmodule.filter, false)
 	return nil
 }


### PR DESCRIPTION
Fixes #40972.

Previously the "level" argument was a plain `int32`.
This had been *intended* from the start (#1052) to be a specialized,
exported Go type. Somehow the initial implementation stopped short of
actually exporting the type. This patch completes that work (from 2015!)

Release note: None