### PR TITLE
u:i Ant Design styles isolation with custom namespace

### DIFF
--- a/pkg/ui/.babelrc
+++ b/pkg/ui/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": ["@babel/preset-env", "@babel/preset-react"],
   "plugins": [
-    ["import", { "libraryName": "antd", "style": "css" }]
+    ["import", { "libraryName": "antd", "style": "css", "libraryDirectory": "es" }]
   ]
 }

--- a/pkg/ui/.storybook/config.tsx
+++ b/pkg/ui/.storybook/config.tsx
@@ -12,9 +12,6 @@ import React from "react";
 import { configure, addDecorator } from "@storybook/react";
 
 // Import global styles here
-import "nvd3/build/nv.d3.min.css";
-import "react-select/dist/react-select.css";
-import "antd/es/tooltip/style/css";
 import "styl/app.styl";
 
 const req = require.context("../src/", true, /.stories.tsx$/);

--- a/pkg/ui/.storybook/decorators/index.ts
+++ b/pkg/ui/.storybook/decorators/index.ts
@@ -1,0 +1,11 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export * from "./withRouterProvider";

--- a/pkg/ui/.storybook/decorators/withRouterProvider.tsx
+++ b/pkg/ui/.storybook/decorators/withRouterProvider.tsx
@@ -1,0 +1,31 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import {Provider} from "react-redux";
+import {ConnectedRouter, connectRouter} from "connected-react-router";
+import {createMemoryHistory} from "history";
+import { createStore, combineReducers } from "redux";
+import {RenderFunction} from "storybook__react";
+
+const history = createMemoryHistory();
+const routerReducer = connectRouter(history);
+
+const store = createStore(combineReducers({
+  router: routerReducer,
+}));
+
+export const withRouterProvider = (storyFn: RenderFunction) => (
+  <Provider store={store}>
+    <ConnectedRouter history={history}>
+      { storyFn() }
+    </ConnectedRouter>
+  </Provider>
+);

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -104,6 +104,8 @@
     "karma-sinon": "^1.0.5",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^2.0.13",
+    "less": "^3.11.1",
+    "less-loader": "^5.0.0",
     "mocha": "^6.2.1",
     "nib": "^1.1.2",
     "prop-types": "^15.5.10",

--- a/pkg/ui/src/components/pagination/pagination.tsx
+++ b/pkg/ui/src/components/pagination/pagination.tsx
@@ -10,7 +10,7 @@
 
 import { Icon, Pagination } from "antd";
 import * as React from "react";
-import { getMatchParamByName } from "oss/src/util/query";
+import { getMatchParamByName } from "src/util/query";
 import { match } from "react-router";
 
 export interface PaginationSettings {

--- a/pkg/ui/src/interfaces/css-modules.d.ts
+++ b/pkg/ui/src/interfaces/css-modules.d.ts
@@ -1,0 +1,1 @@
+declare module "*.module.styl";

--- a/pkg/ui/src/util/constants.ts
+++ b/pkg/ui/src/util/constants.ts
@@ -20,3 +20,6 @@ export const statementAttr = "statement";
 export const tableNameAttr = "table_name";
 
 export const REMOTE_DEBUGGING_ERROR_TEXT = "This information is not available due to the current value of the 'server.remote_debugging.mode' setting.";
+
+// Has to be the same as defined in ~styl/ant-custom.css and ~styl/ant-custom.less
+export const ANT_DESIGN_PREFIX = "crl-ant";

--- a/pkg/ui/src/views/app/components/Search/index.tsx
+++ b/pkg/ui/src/views/app/components/Search/index.tsx
@@ -8,11 +8,15 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { Button, Form, Input } from "antd";
+import React from "react";
+import { Button, Form, Input, ConfigProvider } from "antd";
 import { InputProps } from "antd/lib/input";
+import { ANT_DESIGN_PREFIX } from "src/util/constants";
 import CancelIcon from "assets/cancel.svg";
 import SearchIcon from "assets/search.svg";
-import React from "react";
+import "antd/es/input/style";
+import "antd/es/form/style";
+import "antd/es/button/style";
 import styles from  "./search.module.styl";
 
 interface ISearchProps {
@@ -89,19 +93,21 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
     const { value, submitted } = this.state;
     const className = submitted ? styles._submitted : "";
     return (
-      <Form onSubmit={this.onSubmit} className={styles._searchForm}>
-        <Form.Item>
-          <Input
-            className={className}
-            placeholder="Search Statement"
-            onChange={this.onChange}
-            prefix={<img className={styles._prefixIcon} src={SearchIcon} />}
-            suffix={this.renderSuffix()}
-            value={value}
-            {...this.props}
-         />
-        </Form.Item>
-      </Form>
+      <ConfigProvider prefixCls={ANT_DESIGN_PREFIX}>
+        <Form onSubmit={this.onSubmit} className={styles._searchForm}>
+          <Form.Item>
+            <Input
+              className={className}
+              placeholder="Search Statement"
+              onChange={this.onChange}
+              prefix={<img className={styles._prefixIcon} src={SearchIcon} />}
+              suffix={this.renderSuffix()}
+              value={value}
+              {...this.props}
+           />
+          </Form.Item>
+        </Form>
+      </ConfigProvider>
     );
   }
 }

--- a/pkg/ui/src/views/app/components/Search/index.tsx
+++ b/pkg/ui/src/views/app/components/Search/index.tsx
@@ -13,7 +13,7 @@ import { InputProps } from "antd/lib/input";
 import CancelIcon from "assets/cancel.svg";
 import SearchIcon from "assets/search.svg";
 import React from "react";
-import "./search.styl";
+import styles from  "./search.module.styl";
 
 interface ISearchProps {
   onSubmit: (value: string) => void;
@@ -62,33 +62,40 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
     const { value, submitted } = this.state;
     if (value.length > 0) {
       if (submitted) {
-        return <Button onClick={this.onClear} type="default" className="_clear-search"><img className="_suffix-icon" src={CancelIcon} /></Button>;
+        return (
+          <Button
+            onClick={this.onClear}
+            type="default"
+            className={styles._clearSearch}
+          >
+            <img className={styles._suffixIcon} src={CancelIcon} />
+          </Button>
+        );
       }
-      return <Button type="default" htmlType="submit" className="_submit-search">Enter</Button>;
+      return (
+        <Button
+          type="default"
+          htmlType="submit"
+          className={styles._submitSearch}
+        >
+          Enter
+        </Button>
+      );
     }
     return null;
   }
 
   render() {
     const { value, submitted } = this.state;
-    const className = submitted ? "_submitted" : "";
-
-    /*
-      current antdesign (3.25.3) has Input.d.ts incompatible with latest @types/react
-      temporary fix, remove as soon antd can be updated
-    */
-
-    // tslint:disable-next-line: variable-name
-    const MyInput = Input as any;
-
+    const className = submitted ? styles._submitted : "";
     return (
-      <Form onSubmit={this.onSubmit} className="_search-form">
+      <Form onSubmit={this.onSubmit} className={styles._searchForm}>
         <Form.Item>
-          <MyInput
+          <Input
             className={className}
             placeholder="Search Statement"
             onChange={this.onChange}
-            prefix={<img className="_prefix-icon" src={SearchIcon} />}
+            prefix={<img className={styles._prefixIcon} src={SearchIcon} />}
             suffix={this.renderSuffix()}
             value={value}
             {...this.props}

--- a/pkg/ui/src/views/app/components/Search/search.module.styl
+++ b/pkg/ui/src/views/app/components/Search/search.module.styl
@@ -14,12 +14,13 @@
 ._search-form
   width 280px
   height 40px
-  .ant-input-affix-wrapper
+  :global(.ant-input-affix-wrapper)
+    height 40px
     &:hover
-      .ant-input:not(.ant-input-disabled)
+      :global(.ant-input:not(.ant-input-disabled))
         border-color $adminui-blue-1-base
         border-right-width 2px !important
-  .ant-btn
+  :global(.ant-btn)
     margin 0
     padding 0
     width auto
@@ -44,7 +45,7 @@
     line-height 0px !important
     &:hover
       color $adminui-grey-2
-  .ant-input
+  :global(.ant-input)
     font-size 14px
     font-family $font-family--base
     color $adminui-grey-1
@@ -60,6 +61,6 @@
       padding-left 35px
       padding-right 60px
   ._submitted
-    .ant-input
+    :global(.ant-input)
       &:not(:first-child)
         padding-right 40px

--- a/pkg/ui/src/views/app/components/Search/search.module.styl
+++ b/pkg/ui/src/views/app/components/Search/search.module.styl
@@ -10,17 +10,18 @@
 
 @require '~styl/base/palette.styl'
 @require "~src/components/core/index.styl"
+@require "~styl/ant-custom.styl"
 
 ._search-form
   width 280px
   height 40px
-  :global(.ant-input-affix-wrapper)
+  :global(.{$ant-prefix}-input-affix-wrapper)
     height 40px
     &:hover
-      :global(.ant-input:not(.ant-input-disabled))
+      :global(.{$ant-prefix}-input:not(.{$ant-prefix}-input-disabled))
         border-color $adminui-blue-1-base
         border-right-width 2px !important
-  :global(.ant-btn)
+  :global(.{$ant-prefix}-btn)
     margin 0
     padding 0
     width auto
@@ -45,7 +46,7 @@
     line-height 0px !important
     &:hover
       color $adminui-grey-2
-  :global(.ant-input)
+  :global(.{$ant-prefix}-input)
     font-size 14px
     font-family $font-family--base
     color $adminui-grey-1
@@ -61,6 +62,6 @@
       padding-left 35px
       padding-right 60px
   ._submitted
-    :global(.ant-input)
+    :global(.{$ant-prefix}-input)
       &:not(:first-child)
         padding-right 40px

--- a/pkg/ui/src/views/app/components/empty/index.tsx
+++ b/pkg/ui/src/views/app/components/empty/index.tsx
@@ -11,7 +11,7 @@
 import React from "react";
 import heroBannerLp from "assets/heroBannerLp.png";
 import "./styles.styl";
-import { Button } from "oss/src/components/button";
+import { Button } from "src/components/button";
 
 export interface IEmptyProps {
   title?: string;

--- a/pkg/ui/src/views/app/containers/layout/layout.styl
+++ b/pkg/ui/src/views/app/containers/layout/layout.styl
@@ -27,40 +27,6 @@ $subnav-background  = $background-color
     display table
     clear both
 
-.page-config
-  padding-left 24px
-  // Stick to the top.
-  position sticky
-  position -webkit-sticky
-  top 0
-  // We want 10px of spacing above and below this div when
-  // it's fixed during scrolling, but not when the page
-  // is scrolled to the top. This combination of padding
-  // and negative margins achieves that.
-  padding-bottom 10px
-  padding-top 10px
-  margin-bottom -10px
-  margin-top -10px
-
-  z-index $z-index-page-config
-  background-color $background-color
-
-  &__list
-    display flex
-    justify-content flex-start
-    align-items center
-
-    .page-config__item
-      margin-right 24px
-
-  &__spread
-    display flex
-    justify-content space-between
-    align-items center
-
-  &__item
-    list-style none
-
 .l-columns
   display flex
   margin 0 -5px

--- a/pkg/ui/src/views/shared/components/pageconfig/index.tsx
+++ b/pkg/ui/src/views/shared/components/pageconfig/index.tsx
@@ -10,6 +10,7 @@
 
 import classnames from "classnames";
 import React from "react";
+import styles from "./pageConfig.module.styl";
 
 export interface PageConfigProps {
   layout?: "list" | "spread";
@@ -18,12 +19,14 @@ export interface PageConfigProps {
 
 export function PageConfig(props: PageConfigProps) {
   const classes = classnames({
-    "page-config__list": props.layout !== "spread",
-    "page-config__spread": props.layout === "spread",
+    [styles.pageConfig__list]: props.layout !== "spread",
+    [styles.pageConfig__spread]: props.layout === "spread",
   });
 
+  console.log(styles)
+
   return (
-    <div className="page-config">
+    <div className={styles.pageConfig}>
       <ul className={ classes }>
         { props.children }
       </ul>
@@ -37,7 +40,7 @@ export interface PageConfigItemProps {
 
 export function PageConfigItem(props: PageConfigItemProps) {
   return (
-    <li className="page-config__item">
+    <li className={styles.pageConfig__item}>
       { props.children }
     </li>
   );

--- a/pkg/ui/src/views/shared/components/pageconfig/index.tsx
+++ b/pkg/ui/src/views/shared/components/pageconfig/index.tsx
@@ -23,8 +23,6 @@ export function PageConfig(props: PageConfigProps) {
     [styles.pageConfig__spread]: props.layout === "spread",
   });
 
-  console.log(styles)
-
   return (
     <div className={styles.pageConfig}>
       <ul className={ classes }>

--- a/pkg/ui/src/views/shared/components/pageconfig/pageConfig.module.styl
+++ b/pkg/ui/src/views/shared/components/pageconfig/pageConfig.module.styl
@@ -1,0 +1,37 @@
+
+@require '~styl/base/palette.styl'
+@require '~styl/base/layout-vars.styl'
+
+.page-config
+  padding-left 24px
+  // Stick to the top.
+  position sticky
+  position -webkit-sticky
+  top 0
+  // We want 10px of spacing above and below this div when
+  // it's fixed during scrolling, but not when the page
+  // is scrolled to the top. This combination of padding
+  // and negative margins achieves that.
+  padding-bottom 10px
+  padding-top 10px
+  margin-bottom -10px
+  margin-top -10px
+
+  z-index $z-index-page-config
+  background-color $background-color
+
+.page-config__list
+  display flex
+  justify-content flex-start
+  align-items center
+
+  .page-config__item
+    margin-right 24px
+
+.page-config__spread
+  display flex
+  justify-content space-between
+  align-items center
+
+.page-config__item
+  list-style none

--- a/pkg/ui/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/index.tsx
@@ -14,7 +14,7 @@ import map from "lodash/map";
 import isUndefined from "lodash/isUndefined";
 import times from "lodash/times";
 
-import getHighlightedText from "oss/src/util/highlightedText";
+import getHighlightedText from "src/util/highlightedText";
 import { DrawerComponent } from "../drawer";
 import { trackTableSort } from "src/util/analytics";
 

--- a/pkg/ui/src/views/statements/barCharts.module.styl
+++ b/pkg/ui/src/views/statements/barCharts.module.styl
@@ -1,0 +1,98 @@
+@require '~styl/base/palette.styl'
+@require '~src/components/core/index'
+
+.bar-chart
+  height 14px
+  position relative
+  display flex
+  align-items center
+  flex-direction row
+  > span
+    width 100%
+    display flex
+    align-items center
+    flex-direction row
+
+  &__multiplebars
+    width calc(100% - 75px)
+    border-radius 3px
+    position relative
+    display flex
+    align-items center
+
+  &__label
+    position relative
+    font-family SourceSansPro-Regular
+    font-size 12px
+    line-height 1.83
+    color $adminui-grey-1
+    width 75px
+
+  &__bar
+    display inline-block
+    height 13px
+    border-radius 3px
+
+    &--dev
+      position absolute
+      height 3px
+
+  .count-first-try, .count-total, .count-retry, .count-max-retries
+    border-radius 3px
+    position absolute
+    left 40px
+
+  .count-first-try, .count-total
+    background-color $grey-light
+  .count-retry, .count-max-retries
+    background-color $alert-color
+
+  .rows
+    background-color $grey-light
+    border-radius 3px
+
+  .rows-dev
+    background-color $colors--primary-blue-3
+
+  .bar-chart
+    &__parse, &__plan, &__run, &__overhead, &__overall
+      background-color $colors--neutral-4
+
+  &-red
+    .bar-chart
+    &__parse, &__plan, &__run, &__overhead, &__overall
+      background-color $colors--functional-red-2
+
+  &__parse-dev, &__plan-dev, &__run-dev, &__overhead-dev, &__overall-dev
+    background-color $colors--primary-blue-3
+
+.numeric-stat-legend
+  white-space nowrap
+  width 282px
+  font-family SourceSansPro-SemiBold
+  font-size 12px
+  line-height 1.67
+  letter-spacing 0.3px
+  color $adminui-grey-1
+  font-weight 600
+
+  th
+    position relative
+    display flex
+    align-items center
+
+  td
+    text-align right
+
+.numeric-stat-legend__bar
+  width 41px
+  border-radius 10px
+  margin-right 14px
+
+.numeric-stat-legend__bar--mean
+  height 13px
+  background-color $grey-light
+
+.numeric-stat-legend__bar--dev
+  height 3px
+  background-color $colors--primary-blue-3

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -18,6 +18,7 @@ import { FixLong } from "src/util/fixLong";
 import { Duration } from "src/util/format";
 import { ToolTipWrapper } from "src/views/shared/components/toolTip";
 import classNames from "classnames";
+import styles from './barCharts.module.styl';
 
 type StatementStatistics = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 
@@ -108,7 +109,7 @@ const makeBarChart = (
         return (
           <div
             key={ name + v }
-            className={ name + " bar-chart__bar" }
+            className={ name + ` ${styles.bar}` " bar-chart__bar" }
             style={{ width: scale(v) + "%" }}
           />
         );

--- a/pkg/ui/src/views/statements/barCharts.tsx
+++ b/pkg/ui/src/views/statements/barCharts.tsx
@@ -18,7 +18,7 @@ import { FixLong } from "src/util/fixLong";
 import { Duration } from "src/util/format";
 import { ToolTipWrapper } from "src/views/shared/components/toolTip";
 import classNames from "classnames";
-import styles from './barCharts.module.styl';
+import styles from "./barCharts.module.styl";
 
 type StatementStatistics = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 
@@ -109,7 +109,7 @@ const makeBarChart = (
         return (
           <div
             key={ name + v }
-            className={ name + ` ${styles.bar}` " bar-chart__bar" }
+            className={ name + ` ${styles["bar-chart__bar"]}` }
             style={{ width: scale(v) + "%" }}
           />
         );

--- a/pkg/ui/src/views/statements/statements.module.styl
+++ b/pkg/ui/src/views/statements/statements.module.styl
@@ -12,6 +12,15 @@
 @require '~src/views/shared/util/table.styl'
 @require '~src/components/core/index'
 
+.root
+  background $colors--neutral-1
+
+.section
+  composes section from '~src/views/app/containers/layout/layout.styl'
+
+.base-heading
+  composes baseHeading from '~styl/base/typography.styl'
+
 .statements-table
   &__col-query-text
     font-family $font-family--monospace

--- a/pkg/ui/src/views/statements/statements.module.styl
+++ b/pkg/ui/src/views/statements/statements.module.styl
@@ -125,14 +125,14 @@
     display flex
     align-items center
     flex-direction row
-    
+
   &__multiplebars
     width calc(100% - 75px)
     border-radius 3px
     position relative
     display flex
     align-items center
-  
+
   &__label
     position relative
     font-family SourceSansPro-Regular
@@ -170,7 +170,7 @@
   .bar-chart
     &__parse, &__plan, &__run, &__overhead, &__overall
       background-color $colors--neutral-4
-  
+
   &-red
     .bar-chart
       &__parse, &__plan, &__run, &__overhead, &__overall

--- a/pkg/ui/src/views/statements/statementsPage.fixture.ts
+++ b/pkg/ui/src/views/statements/statementsPage.fixture.ts
@@ -1,0 +1,397 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { StatementsPageProps } from "./statementsPage";
+import { createMemoryHistory } from "history";
+import Long from "long";
+import * as protos from "src/js/protos";
+import {refreshStatementDiagnosticsRequests, refreshStatements} from "src/redux/apiReducers";
+type IStatementStatistics = protos.cockroach.sql.IStatementStatistics;
+
+const history = createMemoryHistory({ initialEntries: ["/statements"]});
+
+const statementStats: IStatementStatistics = {
+  "count": Long.fromNumber(3),
+  "first_attempt_count": Long.fromNumber(1),
+  "max_retries": Long.fromNumber(10),
+  "num_rows": {
+    "mean": 1,
+    "squared_diffs": 0,
+  },
+  "parse_lat": {
+    "mean": 0,
+    "squared_diffs": 0,
+  },
+  "plan_lat": {
+    "mean": 0.00018,
+    "squared_diffs": 5.4319999999999994e-9,
+  },
+  "run_lat": {
+    "mean": 0.0022536666666666664,
+    "squared_diffs": 0.0000020303526666666667,
+  },
+  "service_lat": {
+    "mean": 0.002496,
+    "squared_diffs": 0.000002308794,
+  },
+  "overhead_lat": {
+    "mean": 0.00006233333333333315,
+    "squared_diffs": 5.786666666666667e-10,
+  },
+  "sensitive_info": {
+    "last_err": "",
+    "most_recent_plan_description": {
+      "name": "root",
+      "children": [
+        {
+          "name": "render",
+          "attrs": [
+            {
+              "key": "render",
+              "value": "COALESCE(a, b)",
+            },
+          ],
+          "children": [
+            {
+              "name": "values",
+              "attrs": [
+                {
+                  "key": "size",
+                  "value": "2 columns, 1 row",
+                },
+                {
+                  "key": "row 0, expr",
+                  "value": "(SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _)",
+                },
+                {
+                  "key": "row 0, expr",
+                  "value": "(SELECT code FROM promo_codes ORDER BY code LIMIT _)",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          "name": "subquery",
+          "attrs": [
+            {
+              "key": "id",
+              "value": "@S1",
+            },
+            {
+              "key": "original sql",
+              "value": "(SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _)",
+            },
+            {
+              "key": "exec mode",
+              "value": "one row",
+            },
+          ],
+          "children": [
+            {
+              "name": "scan",
+              "attrs": [
+                {
+                  "key": "table",
+                  "value": "promo_codes@primary",
+                },
+                {
+                  "key": "spans",
+                  "value": "1 span",
+                },
+                {
+                  "key": "limit",
+                  "value": "1",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          "name": "subquery",
+          "attrs": [
+            {
+              "key": "id",
+              "value": "@S2",
+            },
+            {
+              "key": "original sql",
+              "value": "(SELECT code FROM promo_codes ORDER BY code LIMIT _)",
+            },
+            {
+              "key": "exec mode",
+              "value": "one row",
+            },
+          ],
+          "children": [
+            {
+              "name": "scan",
+              "attrs": [
+                {
+                  "key": "table",
+                  "value": "promo_codes@primary",
+                },
+                {
+                  "key": "spans",
+                  "value": "ALL",
+                },
+                {
+                  "key": "limit",
+                  "value": "1",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
+};
+
+const statementsPagePropsFixture: StatementsPageProps = {
+  history,
+  location: {
+    "pathname": "/statements",
+    "search": "",
+    "hash": "",
+    "state": null,
+  },
+  "match": {
+    "path": "/statements",
+    "url": "/statements",
+    "isExact": true,
+    "params": {},
+  },
+  "statements": [
+    {
+      "label": "SELECT IFNULL(a, b) FROM (SELECT (SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _) AS a, (SELECT code FROM promo_codes ORDER BY code LIMIT _) AS b)",
+      "implicitTxn": true,
+      stats: statementStats,
+    },
+    {
+      "label": "INSERT INTO vehicles VALUES ($1, $2, __more6__)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SELECT IFNULL(a, b) FROM (SELECT (SELECT id FROM users WHERE (city = $1) AND (id > $2) ORDER BY id LIMIT _) AS a, (SELECT id FROM users WHERE city = $1 ORDER BY id LIMIT _) AS b)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "UPSERT INTO vehicle_location_histories VALUES ($1, $2, now(), $3, $4)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "INSERT INTO user_promo_codes VALUES ($1, $2, $3, now(), _)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SELECT city, id FROM vehicles WHERE city = $1",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "INSERT INTO rides VALUES ($1, $2, $2, $3, $4, $5, _, now(), _, $6)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SELECT IFNULL(a, b) FROM (SELECT (SELECT id FROM vehicles WHERE (city = $1) AND (id > $2) ORDER BY id LIMIT _) AS a, (SELECT id FROM vehicles WHERE city = $1 ORDER BY id LIMIT _) AS b)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "UPDATE rides SET end_address = $3, end_time = now() WHERE (city = $1) AND (id = $2)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "INSERT INTO users VALUES ($1, $2, __more3__)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SELECT count(*) FROM user_promo_codes WHERE ((city = $1) AND (user_id = $2)) AND (code = $3)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "INSERT INTO promo_codes VALUES ($1, $2, __more3__)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE users SCATTER FROM (_, _) TO (_, _)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE rides ADD FOREIGN KEY (vehicle_city, vehicle_id) REFERENCES vehicles (city, id)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SHOW database",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE users SPLIT AT VALUES (_, _)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE vehicles SCATTER FROM (_, _) TO (_, _)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE vehicle_location_histories ADD FOREIGN KEY (city, ride_id) REFERENCES rides (city, id)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "CREATE TABLE IF NOT EXISTS user_promo_codes (city VARCHAR NOT NULL, user_id UUID NOT NULL, code VARCHAR NOT NULL, \"timestamp\" TIMESTAMP NULL, usage_count INT8 NULL, PRIMARY KEY (city ASC, user_id ASC, code ASC))",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "INSERT INTO users VALUES ($1, $2, __more3__), (__more40__)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE rides SCATTER FROM (_, _) TO (_, _)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SET CLUSTER SETTING \"cluster.organization\" = $1",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE vehicles ADD FOREIGN KEY (city, owner_id) REFERENCES users (city, id)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "CREATE TABLE IF NOT EXISTS rides (id UUID NOT NULL, city VARCHAR NOT NULL, vehicle_city VARCHAR NULL, rider_id UUID NULL, vehicle_id UUID NULL, start_address VARCHAR NULL, end_address VARCHAR NULL, start_time TIMESTAMP NULL, end_time TIMESTAMP NULL, revenue DECIMAL(10,2) NULL, PRIMARY KEY (city ASC, id ASC), INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC), INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC), CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city))",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "CREATE TABLE IF NOT EXISTS vehicles (id UUID NOT NULL, city VARCHAR NOT NULL, type VARCHAR NULL, owner_id UUID NULL, creation_time TIMESTAMP NULL, status VARCHAR NULL, current_location VARCHAR NULL, ext JSONB NULL, PRIMARY KEY (city ASC, id ASC), INDEX vehicles_auto_index_fk_city_ref_users (city ASC, owner_id ASC))",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "INSERT INTO rides VALUES ($1, $2, __more8__), (__more400__)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE vehicles SPLIT AT VALUES (_, _)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SET sql_safe_updates = _",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "CREATE TABLE IF NOT EXISTS users (id UUID NOT NULL, city VARCHAR NOT NULL, name VARCHAR NULL, address VARCHAR NULL, credit_card VARCHAR NULL, PRIMARY KEY (city ASC, id ASC))",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "CREATE TABLE IF NOT EXISTS vehicle_location_histories (city VARCHAR NOT NULL, ride_id UUID NOT NULL, \"timestamp\" TIMESTAMP NOT NULL, lat FLOAT8 NULL, long FLOAT8 NULL, PRIMARY KEY (city ASC, ride_id ASC, \"timestamp\" ASC))",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SELECT * FROM crdb_internal.node_build_info",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "CREATE DATABASE movr",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SELECT count(*) > _ FROM [SHOW ALL CLUSTER SETTINGS] AS _ (v) WHERE v = _",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SET CLUSTER SETTING \"enterprise.license\" = $1",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE rides ADD FOREIGN KEY (city, rider_id) REFERENCES users (city, id)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE user_promo_codes ADD FOREIGN KEY (city, user_id) REFERENCES users (city, id)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "INSERT INTO promo_codes VALUES ($1, $2, __more3__), (__more900__)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "ALTER TABLE rides SPLIT AT VALUES (_, _)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "SELECT value FROM crdb_internal.node_build_info WHERE field = _",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "INSERT INTO vehicle_location_histories VALUES ($1, $2, __more3__), (__more900__)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+    {
+      "label": "INSERT INTO vehicles VALUES ($1, $2, __more6__), (__more10__)",
+      "implicitTxn": true,
+      "stats": statementStats,
+    },
+  ],
+  "statementsError": null,
+  "apps": [
+    "(internal)",
+    "movr",
+    "$ cockroach demo",
+  ],
+  "totalFingerprints": 95,
+  "lastReset": "2020-04-13 07:22:23",
+  dismissAlertMessage: () => {},
+  refreshStatementDiagnosticsRequests: (() => {}) as (typeof refreshStatementDiagnosticsRequests),
+  refreshStatements: (() => {}) as (typeof refreshStatements),
+};
+
+export default statementsPagePropsFixture;

--- a/pkg/ui/src/views/statements/statementsPage.fixture.ts
+++ b/pkg/ui/src/views/statements/statementsPage.fixture.ts
@@ -18,8 +18,8 @@ type IStatementStatistics = protos.cockroach.sql.IStatementStatistics;
 const history = createMemoryHistory({ initialEntries: ["/statements"]});
 
 const statementStats: IStatementStatistics = {
-  "count": Long.fromNumber(3),
-  "first_attempt_count": Long.fromNumber(1),
+  "count": Long.fromNumber(13000000),
+  "first_attempt_count": Long.fromNumber(13000),
   "max_retries": Long.fromNumber(10),
   "num_rows": {
     "mean": 1,

--- a/pkg/ui/src/views/statements/statementsPage.stories.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.stories.tsx
@@ -1,0 +1,22 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+
+import { withRouterProvider } from ".storybook/decorators";
+import { StatementsPage } from "./statementsPage";
+import statementsPagePropsFixture from "./statementsPage.fixture";
+
+storiesOf("StatementsPage", module)
+  .addDecorator(withRouterProvider)
+  .add("with data", () => (
+    <StatementsPage {...statementsPagePropsFixture}/>
+  ));

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -36,7 +36,6 @@ import Empty from "../app/components/empty";
 import { Search } from "../app/components/Search";
 import { AggregateStatistics, makeStatementsColumns, StatementsSortedTable } from "./statementsTable";
 import ActivateDiagnosticsModal, { ActivateDiagnosticsModalRef } from "src/views/statements/diagnostics/activateDiagnosticsModal";
-import "./statements.styl";
 import {
   selectLastDiagnosticsReportPerStatement,
 } from "src/redux/statements/statementsSelectors";
@@ -44,7 +43,8 @@ import { createStatementDiagnosticsAlertLocalSetting } from "src/redux/alerts";
 import { getMatchParamByName } from "src/util/query";
 import { trackPaginate, trackSearch } from "src/util/analytics";
 
-import "./statements.styl";
+import styles from "./statements.module.styl";
+
 import { ISortedTablePagination } from "../shared/components/sortedtable";
 
 type ICollectedStatementStatistics = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
@@ -199,16 +199,16 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
     switch (type) {
       case "jump-prev":
         return (
-          <div className="_pg-jump">
+          <div className={styles._pgJump}>
             <Icon type="left" />
-            <span className="_jump-dots">•••</span>
+            <span className={styles._jumpDots}>•••</span>
           </div>
         );
       case "jump-next":
         return (
-          <div className="_pg-jump">
+          <div className={styles._pgJump}>
             <Icon type="right" />
-            <span className="_jump-dots">•••</span>
+            <span className={styles._jumpDots}>•••</span>
           </div>
         );
       default:
@@ -255,12 +255,12 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
             />
           </PageConfigItem>
         </PageConfig>
-        <section className="cl-table-container">
-          <div className="cl-table-statistic">
-            <h4 className="cl-count-title">
+        <section className={styles.clTableContainer}>
+          <div className={styles.clTableStatistic}>
+            <h4 className={styles.clCountTitle}>
               {paginationPageCount({ ...pagination, total: this.filteredStatementsData().length }, "statements", match, appAttr, search)}
             </h4>
-            <h4 className="last-cleared-title">
+            <h4 className={styles.lastClearedTitle}>
               {this.renderLastCleared()}
             </h4>
           </div>
@@ -272,9 +272,9 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
             />
           )}
           {(data.length > 0 || search.length > 0) && (
-            <div className="cl-table-wrapper">
+            <div className={styles.clTableWrapper}>
               <StatementsSortedTable
-                className="statements-table"
+                className={styles.statementsTable}
                 data={data}
                 columns={
                   makeStatementsColumns(
@@ -309,11 +309,11 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
     const { match } = this.props;
     const app = getMatchParamByName(match, appAttr);
     return (
-      <React.Fragment>
+      <div className={styles.root}>
         <Helmet title={app ? `${app} App | Statements` : "Statements"} />
 
-        <section className="section">
-          <h1 className="base-heading">Statements</h1>
+        <section className={styles.section}>
+          <h1 className={styles.baseHeading}>Statements</h1>
         </section>
 
         <Loading
@@ -322,7 +322,7 @@ export class StatementsPage extends React.Component<StatementsPageProps, Stateme
           render={this.renderStatements}
         />
         <ActivateDiagnosticsModal ref={this.activateDiagnosticsRef} />
-      </React.Fragment>
+      </div>
     );
   }
 }

--- a/pkg/ui/src/views/statements/statementsTable.module.styl
+++ b/pkg/ui/src/views/statements/statementsTable.module.styl
@@ -1,3 +1,29 @@
 
+@require '~styl/base/palette.styl'
+@require '~src/views/shared/util/table.styl'
+@require '~src/components/core/index'
+
 .cl-table-link__tooltip
   composes clTableLink__tooltip from '~src/views/shared/components/sortabletable/sortabletable.styl'
+
+.cl-table-link__description
+  composes clTableLink__description from '~src/views/shared/components/sortabletable/sortabletable.styl'
+
+.cl-table__col-query-text a
+  font-family RobotoMono-Medium
+  font-size 12px
+  line-height 1.83
+  color $adminui-grey-1
+  width 400px
+  text-decoration none
+  cursor pointer
+  &:hover
+    color $colors--primary-blue-3
+    text-decoration underline
+  ._text-bold
+    font-family RobotoMono-Bold
+
+.cl-table-link__statement-tooltip--fixed-width
+  max-width max-content
+  .ant-tooltip-content
+    max-width 500px

--- a/pkg/ui/src/views/statements/statementsTable.module.styl
+++ b/pkg/ui/src/views/statements/statementsTable.module.styl
@@ -1,0 +1,3 @@
+
+.cl-table-link__tooltip
+  composes clTableLink__tooltip from '~src/views/shared/components/sortabletable/sortabletable.styl'

--- a/pkg/ui/src/views/statements/statementsTable.stories.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.stories.tsx
@@ -15,7 +15,7 @@ import { withRouterProvider } from ".storybook/decorators";
 import {makeStatementsColumns, StatementsSortedTable} from "./statementsTable";
 import statementsPagePropsFixture from "./statementsPage.fixture";
 
-const { statements } = statementsPagePropsFixture
+const { statements } = statementsPagePropsFixture;
 
 storiesOf("StatementsTable", module)
   .addDecorator(withRouterProvider)

--- a/pkg/ui/src/views/statements/statementsTable.stories.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.stories.tsx
@@ -1,0 +1,31 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+
+import { withRouterProvider } from ".storybook/decorators";
+import {makeStatementsColumns, StatementsSortedTable} from "./statementsTable";
+import statementsPagePropsFixture from "./statementsPage.fixture";
+
+const { statements } = statementsPagePropsFixture
+
+storiesOf("StatementsTable", module)
+  .addDecorator(withRouterProvider)
+  .add("with data", () => (
+    <StatementsSortedTable
+      columns={makeStatementsColumns(statements, "App")}
+      data={statements}
+      sortSetting={{
+        sortKey: 3,
+        ascending: false,
+      }}
+    />
+  ));

--- a/pkg/ui/src/views/statements/statementsTable.stories.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.stories.tsx
@@ -25,7 +25,7 @@ storiesOf("StatementsTable", module)
       data={statements}
       sortSetting={{
         sortKey: 3,
-        ascending: false,
+        ascending: true,
       }}
     />
   ));

--- a/pkg/ui/src/views/statements/statementsTable.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.tsx
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import getHighlightedText from "oss/src/util/highlightedText";
+import getHighlightedText from "src/util/highlightedText";
 import React from "react";
 import { Link } from "react-router-dom";
 

--- a/pkg/ui/src/views/statements/statementsTable.tsx
+++ b/pkg/ui/src/views/statements/statementsTable.tsx
@@ -18,11 +18,11 @@ import { StatementSummary, summarize } from "src/util/sql/summarize";
 import { ColumnDescriptor, SortedTable } from "src/views/shared/components/sortedtable";
 import { countBarChart, latencyBarChart, retryBarChart, rowsBarChart } from "./barCharts";
 import { Anchor, Tooltip } from "src/components";
-import "./statements.styl";
 import { DiagnosticStatusBadge } from "./diagnostics/diagnosticStatusBadge";
 import { cockroach } from "src/js/protos";
 import IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
 import { ActivateDiagnosticsModalRef } from "./diagnostics/activateDiagnosticsModal";
+import styles from "./statementsTable.module.styl";
 
 const longToInt = (d: number | Long) => FixLong(d).toInt();
 
@@ -43,7 +43,7 @@ function StatementLink(props: { statement: string, app: string, implicitTxn: boo
   const base = props.app && props.app.length > 0 ? `/statements/${props.app}/${props.implicitTxn}` : `/statement/${props.implicitTxn}`;
   return (
     <Link to={ `${base}/${encodeURIComponent(props.statement)}` }>
-      <div className="cl-table-link__tooltip">
+      <div className={styles.clTableLink__tooltip}>
         <Tooltip
           placement="bottom"
           title={<pre className="cl-table-link__description">

--- a/pkg/ui/styl/ant-custom.less
+++ b/pkg/ui/styl/ant-custom.less
@@ -1,0 +1,1 @@
+@ant-prefix: crl-ant;

--- a/pkg/ui/styl/ant-custom.styl
+++ b/pkg/ui/styl/ant-custom.styl
@@ -1,0 +1,1 @@
+$ant-prefix = "crl-ant"

--- a/pkg/ui/styl/app.styl
+++ b/pkg/ui/styl/app.styl
@@ -13,6 +13,7 @@
 @require 'base/layout-vars.styl'
 @require 'base/palette.styl'
 @require 'base/typography.styl'
+@require 'utils/fonts.styl'
 @require 'base/reset.styl'
 
 @require 'pages/reports.styl'

--- a/pkg/ui/styl/base/typography.styl
+++ b/pkg/ui/styl/base/typography.styl
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-@require 'utils/fonts.styl'
 @require "~src/components/core/index.styl"
 
 // Using the same strategy as sassline: establish the root size (rems) as 1/2
@@ -19,7 +18,7 @@ html
 
 body
   line-height $line-height--small
-  font-size $font-base-size
+  font-size $font-size--medium
   font-family Lato-Regular
   font-weight $font-weight--light
 
@@ -35,15 +34,3 @@ h2.base-heading
 code
   font-family $font-family--monospace
 
-font-face('Lato-Light')
-font-face('Lato-Bold')
-font-face('Lato-Regular')
-font-face('Lato-Medium')
-font-face('RobotoMono-Bold')
-font-face('RobotoMono-Regular')
-font-face('RobotoMono-Medium')
-font-face('Inconsolata-Regular')
-font-face('SourceSansPro-Bold')
-font-face('SourceSansPro-Regular')
-font-face('SourceSansPro-SemiBold')
-font-face('SFMono-Semibold')

--- a/pkg/ui/styl/utils/fonts.styl
+++ b/pkg/ui/styl/utils/fonts.styl
@@ -21,3 +21,17 @@ font-face($family, $style='normal')
     font-weight normal
     font-style $style
     text-rendering optimizeLegibility
+
+
+font-face('Lato-Light')
+font-face('Lato-Bold')
+font-face('Lato-Regular')
+font-face('Lato-Medium')
+font-face('RobotoMono-Bold')
+font-face('RobotoMono-Regular')
+font-face('RobotoMono-Medium')
+font-face('Inconsolata-Regular')
+font-face('SourceSansPro-Bold')
+font-face('SourceSansPro-Regular')
+font-face('SourceSansPro-SemiBold')
+font-face('SFMono-Semibold')

--- a/pkg/ui/webpack.app.js
+++ b/pkg/ui/webpack.app.js
@@ -65,7 +65,7 @@ module.exports = (env, argv) => {
 
     resolve: {
       // Add resolvable extensions.
-      extensions: [".ts", ".tsx", ".js", ".json", ".styl", ".css"],
+      extensions: [".ts", ".tsx", ".js", ".json", ".styl", ".css", ".less"],
       // First check for local modules, then for third-party modules from
       // node_modules.
       //
@@ -152,6 +152,23 @@ module.exports = (env, argv) => {
           loader: "source-map-loader",
           include: localRoots,
           exclude: /\/node_modules/,
+        },
+        {
+          use: [
+            "cache-loader",
+            "style-loader",
+            "css-loader",
+            {
+              loader: "less-loader",
+              options: {
+                javascriptEnabled: true,
+                modifyVars: {
+                  "hack": `true; @import "~styl/ant-custom.less";`,
+                },
+              },
+            },
+          ],
+          test: /\.less$/,
         },
       ],
     },

--- a/pkg/ui/webpack.app.js
+++ b/pkg/ui/webpack.app.js
@@ -85,7 +85,30 @@ module.exports = (env, argv) => {
       rules: [
         { test: /\.css$/, use: [ "style-loader", "css-loader" ] },
         {
-          test: /\.styl$/,
+          test: /\.module\.styl$/,
+          use: [
+            "cache-loader",
+            "style-loader",
+            {
+              loader: "css-loader",
+              options: {
+                modules: {
+                  localIdentName: "[local]--[hash:base64:5]",
+                },
+                importLoaders: 1,
+                localsConvention: "dashesOnly",
+              },
+            },
+            {
+              loader: "stylus-loader",
+              options: {
+                use: [require("nib")()],
+              },
+            },
+          ],
+        },
+        {
+          test: /(?<!\.module)\.styl$/,
           use: [
             "cache-loader",
             "style-loader",

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -5017,6 +5017,11 @@ clone@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.2.tgz#260b7a99ebb1edfe247538175f783243cb19d149"
 
+clone@^2.1.1, clone@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -6344,7 +6349,7 @@ enzyme@^3.3.0:
     raf "^3.4.0"
     rst-selector-parser "^2.2.3"
 
-errno@^0.1.3, errno@~0.1.7:
+errno@^0.1.1, errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
   integrity sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==
@@ -7902,6 +7907,11 @@ ignore@^3.3.5:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.8.tgz#3f8e9c35d38708a3a7e0e9abb6c73e7ee7707b2b"
 
+image-size@~0.5.0:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
+  integrity sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=
+
 immer@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
@@ -8843,6 +8853,32 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
+less-loader@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/less-loader/-/less-loader-5.0.0.tgz#498dde3a6c6c4f887458ee9ed3f086a12ad1b466"
+  integrity sha512-bquCU89mO/yWLaUq0Clk7qCsKhsF/TZpJUzETRvJa9KSVEL9SO3ovCvdEHISBhrC81OwC8QSVX7E0bzElZj9cg==
+  dependencies:
+    clone "^2.1.1"
+    loader-utils "^1.1.0"
+    pify "^4.0.1"
+
+less@^3.11.1:
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/less/-/less-3.11.1.tgz#c6bf08e39e02404fe6b307a3dfffafdc55bd36e2"
+  integrity sha512-tlWX341RECuTOvoDIvtFqXsKj072hm3+9ymRBe76/mD6O5ZZecnlAOVDlWAleF2+aohFrxNidXhv2773f6kY7g==
+  dependencies:
+    clone "^2.1.2"
+    tslib "^1.10.0"
+  optionalDependencies:
+    errno "^0.1.1"
+    graceful-fs "^4.1.2"
+    image-size "~0.5.0"
+    mime "^1.4.1"
+    mkdirp "^0.5.0"
+    promise "^7.1.1"
+    request "^2.83.0"
+    source-map "~0.6.0"
+
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
@@ -9362,7 +9398,7 @@ mime-types@~2.1.17, mime-types@~2.1.24:
   dependencies:
     mime-db "1.40.0"
 
-mime@1.6.0, mime@^1.5.0:
+mime@1.6.0, mime@^1.4.1, mime@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
@@ -12143,6 +12179,32 @@ request-progress@3.0.0:
   dependencies:
     throttleit "^1.0.0"
 
+request@^2.83.0:
+  version "2.88.2"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
+  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.3"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.5.0"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -13529,6 +13591,11 @@ ts-loader@^6.2.1:
     loader-utils "^1.0.2"
     micromatch "^4.0.0"
     semver "^6.0.0"
+
+tslib@^1.10.0:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
+  integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
 tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"


### PR DESCRIPTION
References to #47527
Depends on https://github.com/cockroachdb/yarn-vendored/pull/19
Depends on #47417

Initially, Ant Design styles were imported by
babel-import plugin. This approach has following
disadvantages:
- global styles are loaded by Ant Design so it might affect existing styles
- it is not possible to simulate modular behavior for components

Current changes change the way Ant Design styles are
loaded and imported by components.
- Ant Design styles are loaded as before to avoid breaking styles
for existing components
- Added less-loader to load Ant design styles (.less) and then modify
class-prefixes to own `crl-ant` prefix. It creates namespace which doesn't
affect global and design styles.
To override default ant prefix with custom, following changes are needed:
- modify ant design variables in Less files - specify source with new
variables in `webpack` configuration for `less-loader`
- Use `ConfigProvider` to override class names in ant components so they
have the same prefix as defined in less styles.

As result components which have to use `isolated` (with custom namespace)
ant styles - should manually import less styles for components and wrap
component with `ConfigProvider` component.

Release note: None