### PR TITLE
acceptance: retry harder during go download in ComposeGSS

### DIFF
--- a/pkg/acceptance/compose/gss/psql/Dockerfile
+++ b/pkg/acceptance/compose/gss/psql/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
   git \
   krb5-user
 
-RUN curl --retry 5 https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar xz -C /usr/local
+RUN curl --retry 10 --retry-connrefused https://dl.google.com/go/go1.13.10.linux-amd64.tar.gz | tar xz -C /usr/local
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 


### PR DESCRIPTION
This has been failing recently. Not sure what's going on, but let's retry
harder and also bump the go version while we're here. If this doesn't
end up working, it probably makes sense to consider something like using
a Go docker image to pre-build the test binary (which would avoid using
curl and thus may be more resilient) and dump it into the postgres image.

Release note: None