### PR TITLE
release-20.1: ui: update code for warning about full scan

### DIFF
--- a/pkg/ui/src/views/statements/planView.spec.tsx
+++ b/pkg/ui/src/views/statements/planView.spec.tsx
@@ -344,7 +344,7 @@ describe("flattenAttributes", () => {
       );
     });
   });
-  describe("when attribute key/value is `spans ALL`", () => {
+  describe("when attribute key/value is `spans FULL SCAN`", () => {
     it("sets warn to true", () => {
       const testAttrs: IAttr[] = [
         {
@@ -353,7 +353,7 @@ describe("flattenAttributes", () => {
         },
         {
           key: "spans",
-          value: "ALL",
+          value: "FULL SCAN",
         },
       ];
       const expectedTestAttrs: FlatPlanNodeAttribute[] = [
@@ -364,7 +364,7 @@ describe("flattenAttributes", () => {
         },
         {
           key: "spans",
-          values: ["ALL"],
+          values: ["FULL SCAN"],
           warn: true,
         },
       ];

--- a/pkg/ui/src/views/statements/planView.tsx
+++ b/pkg/ui/src/views/statements/planView.tsx
@@ -151,7 +151,10 @@ export function flattenAttributes(attrs: IAttr[]|null): FlatPlanNodeAttribute[] 
 }
 
 function warnForAttribute(attr: IAttr): boolean {
-  if (attr.key === "spans" && attr.value === "ALL") {
+  // TODO(yuzefovich): 'spans ALL' is pre-20.1 attribute (and it might show up
+  // during an upgrade), so we should remove the check for it after 20.2
+  // release.
+  if (attr.key === "spans" && (attr.value === "FULL SCAN" || attr.value === "ALL")) {
     return true;
   }
   return false;


### PR DESCRIPTION
Backport 1/1 commits from #47767.

/cc @cockroachdb/release

---

We recently made a change to the output of `EXPLAIN` to print
`spans | FULL SCAN` instead of `spans | ALL`. However, ui uses that
information to decide whether to display a warning to the user, and that
has not been updated accordingly. This commit fixes that.

See #46708.

Release note: None
