### PR TITLE
geo/geos: fix error not returning on EnsureInit if no paths are input

### DIFF
--- a/pkg/geo/geos/geos_unix.go
+++ b/pkg/geo/geos/geos_unix.go
@@ -111,7 +111,10 @@ func initGEOS(locs []string) (*C.CR_GEOS, error) {
 			),
 		)
 	}
-	return nil, errors.Wrap(err, "geos: could not find location to init GEOS")
+	if err != nil {
+		return nil, errors.Wrap(err, "geos: error during GEOS init")
+	}
+	return nil, errors.Newf("geos: no locations to init GEOS")
 }
 
 // goToCSlice returns a CR_GEOS_Slice from a given Go byte slice.

--- a/pkg/geo/geos/geos_unix_test.go
+++ b/pkg/geo/geos/geos_unix_test.go
@@ -20,6 +20,11 @@ import (
 )
 
 func TestInitGEOS(t *testing.T) {
+	t.Run("test no initGEOS paths", func(t *testing.T) {
+		_, err := initGEOS([]string{})
+		require.Error(t, err)
+	})
+
 	t.Run("test invalid initGEOS paths", func(t *testing.T) {
 		_, err := initGEOS([]string{"/invalid/path"})
 		require.Error(t, err)


### PR DESCRIPTION
Whilst the more broad change is in another PR (#47759), we are currently
not returning an error at all if no GEOS locations are found. This is
causing issues with sqlsmith roachtests, and should make it in whilst
the discussion with the other thread is ongoing.

Refs: #47932

Release note: None