### PR TITLE
colexec: fix type management in execplan

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1524,6 +1524,41 @@ func TestLint(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("TestVectorizedTypeSchemaCopy", func(t *testing.T) {
+		t.Parallel()
+		cmd, stderr, filter, err := dirCmd(
+			pkgDir,
+			"git",
+			"grep",
+			"-nE",
+			// We prohibit appending to the type schema and require allocating
+			// a new slice. See the comment in execplan.go file.
+			fmt.Sprintf(`(yps|ypes) = append\(`),
+			"--",
+			"sql/colexec/execplan.go",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := stream.ForEach(filter, func(s string) {
+			t.Errorf("\n%s <- forbidden; allocate a new []types.T slice", s)
+		}); err != nil {
+			t.Error(err)
+		}
+
+		if err := cmd.Wait(); err != nil {
+			if out := stderr.String(); len(out) > 0 {
+				t.Fatalf("err=%s, stderr=%s", err, out)
+			}
+		}
+	})
+
 	// RoachVet is expensive memory-wise and thus should not run with t.Parallel().
 	// RoachVet includes all of the passes of `go vet` plus first-party additions.
 	// See pkg/cmd/roachvet.


### PR DESCRIPTION
This commit fixes the column type management in `execplan.go` by
requiring that we allocate new `[]types.T` slice whenever a projecting
operator wants to append a column to the passed-in type schema. Previous
behavior could result in "type schema corruption" (when it was captured
by `batchSchemaPrefixEnforcer` and possibly in other places), and this
is now fixed. The requirement is enforced by a linter rule that
prohibits code lines that have `yps = append(` or `ypes = append(`
inside (this is not perfect, but it should be good enough).

Fixes: #47889.

Release note (bug fix): Previously, CockroachDB could return an internal
error when performing a query with CASE, AND, OR operators in some cases
when it was executed via the vectorized engine, and this has been fixed.