### PR TITLE
colexec: some optimizations

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/hash_aggregator_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hash_aggregator_gen.go
@@ -36,6 +36,9 @@ func genHashAggregator(wr io.Writer) error {
 	assignCmpRe := makeFunctionRegex("_ASSIGN_NE", 3)
 	s = assignCmpRe.ReplaceAllString(s, makeTemplateFunctionCall("Global.Assign", 3))
 
+	populateSels := makeFunctionRegex("_POPULATE_SELS", 3)
+	s = populateSels.ReplaceAllString(s, `{{template "populateSels" buildDict "Global" . "BatchHasSelection" $3}}`)
+
 	matchLoop := makeFunctionRegex("_MATCH_LOOP", 8)
 	s = matchLoop.ReplaceAllString(
 		s, `{{template "matchLoop" buildDict "Global" . "LhsMaybeHasNulls" $7 "RhsMaybeHasNulls" $8}}`)

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -28,19 +28,14 @@ import (
 type hashAggregatorState int
 
 const (
-	// hashAggregatorBuffering is the state in which the hashAggregator is
-	// buffering up its inputs.
-	hashAggregatorBuffering hashAggregatorState = iota
-
 	// hashAggregatorAggregating is the state in which the hashAggregator is
-	// performing aggregation on its buffered inputs. After aggregation is done,
-	// the input buffer used in hashAggregatorBuffering phase is reset and ready
-	// to be reused.
-	hashAggregatorAggregating
+	// reading the batches from the input and performing aggregation on them,
+	// one at a time. After the input has been fully exhausted, hashAggregator
+	// transitions to hashAggregatorOutputting state.
+	hashAggregatorAggregating hashAggregatorState = iota
 
 	// hashAggregatorOutputting is the state in which the hashAggregator is
-	// writing its aggregation results to output buffer after it has exhausted all
-	// inputs and finished aggregating.
+	// writing its aggregation results to output buffer after.
 	hashAggregatorOutputting
 
 	// hashAggregatorDone is the state in which the hashAggregator has finished
@@ -50,12 +45,12 @@ const (
 
 // hashAggregator is an operator that performs aggregation based on specified
 // grouping columns. This operator performs aggregation in online fashion. It
-// buffers the input up to batchTupleLimit. Then the aggregator hashes each
-// tuple and groups the tuples with same hash code into same group. Then
-// aggregation function is lazily created for each group. The tuples in that
-// group will be then passed into the aggregation function. After all input is
-// exhausted, the operator begins to write the result into an output buffer. The
-// output row ordering of this operator is arbitrary.
+// reads the input one batch at a time, hashes each tuple from the batch and
+// groups the tuples with same hash code into same group. Then aggregation
+// function is lazily created for each group. The tuples in that group will be
+// then passed into the aggregation function. After the input is exhausted, the
+// operator begins to write the result into an output buffer. The output row
+// ordering of this operator is arbitrary.
 type hashAggregator struct {
 	OneInputNode
 
@@ -75,16 +70,10 @@ type hashAggregator struct {
 	// handle hash collisions.
 	aggFuncMap hashAggFuncMap
 
-	// batchTupleLimit limits the number of tuples the aggregator will buffer
-	// before it starts to perform aggregation.
-	batchTupleLimit int
-
 	// state stores the current state of hashAggregator.
 	state hashAggregatorState
 
 	scratch struct {
-		*appendOnlyBufferedBatch
-
 		// sels stores the intermediate selection vector for each hash code. It
 		// is maintained in such a way that when for a particular hashCode
 		// there are no tuples in the batch, the corresponding int slice is of
@@ -96,8 +85,7 @@ type hashAggregator struct {
 		// in having many int slices), we are using a constant number of such
 		// slices and have a "map" from hashCode to a "slot" in sels that does
 		// the "translation." The key insight here is that we will have at most
-		// batchTupleLimit (plus - possibly - constant excess) different
-		// hashCodes at once.
+		// coldata.BatchSize() different hashCodes at once.
 		sels [][]int
 		// hashCodeForSelsSlot stores the hashCode that corresponds to a slot
 		// in sels slice. For example, if we have tuples with the following
@@ -205,9 +193,6 @@ func NewHashAggregator(
 		groupTypes[i] = typs[colIdx]
 	}
 
-	// We picked value this as the result of our benchmark.
-	tupleLimit := coldata.BatchSize() * 2
-
 	inputPhysTypes, err := typeconv.FromColumnTypes(typs)
 	return &hashAggregator{
 		OneInputNode: NewOneInputNode(input),
@@ -218,9 +203,7 @@ func NewHashAggregator(
 		aggTypes:   aggTyps,
 		aggFuncMap: make(hashAggFuncMap),
 
-		batchTupleLimit: tupleLimit,
-
-		state:          hashAggregatorBuffering,
+		state:          hashAggregatorAggregating,
 		inputTypes:     typs,
 		inputPhysTypes: inputPhysTypes,
 		outputTypes:    outputTypes,
@@ -234,45 +217,29 @@ func (op *hashAggregator) Init() {
 	op.input.Init()
 	op.output.Batch = op.allocator.NewMemBatch(op.outputTypes)
 
-	// We allocate additional coldata.BatchSize for scratch buffer and hashBuffer
-	// to accommodate the case where sometimes number of buffered tuples exceeds
-	// op.batchTupleLimit. This is because we perform checks after appending the
-	// input tuples to the scratch buffer.
-	maxBufferedTuples := op.batchTupleLimit + coldata.BatchSize()
-	op.scratch.appendOnlyBufferedBatch = newAppendOnlyBufferedBatch(
-		op.allocator, op.inputTypes, maxBufferedTuples,
-	)
-	op.scratch.sels = make([][]int, maxBufferedTuples)
-	op.scratch.hashCodeForSelsSlot = make([]uint64, maxBufferedTuples)
-	op.scratch.group = make([]bool, maxBufferedTuples)
+	op.scratch.sels = make([][]int, coldata.BatchSize())
+	op.scratch.hashCodeForSelsSlot = make([]uint64, coldata.BatchSize())
+	op.scratch.group = make([]bool, coldata.BatchSize())
 	// Eventually, op.keyMapping will contain as many tuples as there are
 	// groups in the input, but we don't know that number upfront, so we
 	// allocate it with some reasonably sized constant capacity.
 	op.keyMapping = newAppendOnlyBufferedBatch(
-		op.allocator, op.groupTypes, op.batchTupleLimit,
+		op.allocator, op.groupTypes, coldata.BatchSize(),
 	)
-
-	op.hashBuffer = make([]uint64, maxBufferedTuples)
+	op.hashBuffer = make([]uint64, coldata.BatchSize())
 }
 
 func (op *hashAggregator) Next(ctx context.Context) coldata.Batch {
 	for {
 		switch op.state {
-		case hashAggregatorBuffering:
-			op.scratch.ResetInternalBatch()
-			op.scratch.SetLength(0)
-
-			// Buffering up input batches.
-			if done := op.bufferBatch(ctx); done {
+		case hashAggregatorAggregating:
+			b := op.input.Next(ctx)
+			if b.Length() == 0 {
 				op.state = hashAggregatorOutputting
 				continue
 			}
-
-			op.buildSelectionForEachHashCode(ctx)
-			op.state = hashAggregatorAggregating
-		case hashAggregatorAggregating:
-			op.onlineAgg()
-			op.state = hashAggregatorBuffering
+			op.buildSelectionForEachHashCode(ctx, b)
+			op.onlineAgg(b)
 		case hashAggregatorOutputting:
 			curOutputIdx := 0
 			op.output.ResetInternalBatch()
@@ -338,25 +305,8 @@ func (op *hashAggregator) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-// bufferBatch buffers up batches from input sources until number of tuples
-// reaches batchTupleLimit. It returns true when the hash aggregator has
-// consumed all batches from input.
-func (op *hashAggregator) bufferBatch(ctx context.Context) bool {
-	for op.scratch.Length() < op.batchTupleLimit {
-		b := op.input.Next(ctx)
-		batchSize := b.Length()
-		if batchSize == 0 {
-			break
-		}
-		op.allocator.PerformOperation(op.scratch.ColVecs(), func() {
-			op.scratch.append(b, 0 /* startIdx */, batchSize)
-		})
-	}
-	return op.scratch.Length() == 0
-}
-
-func (op *hashAggregator) buildSelectionForEachHashCode(ctx context.Context) {
-	nKeys := op.scratch.Length()
+func (op *hashAggregator) buildSelectionForEachHashCode(ctx context.Context, b coldata.Batch) {
+	nKeys := b.Length()
 	hashBuffer := op.hashBuffer[:nKeys]
 
 	initHash(hashBuffer, nKeys, defaultInitHashValue)
@@ -365,48 +315,25 @@ func (op *hashAggregator) buildSelectionForEachHashCode(ctx context.Context) {
 		rehash(ctx,
 			hashBuffer,
 			&op.inputTypes[colIdx],
-			op.scratch.ColVec(int(colIdx)),
+			b.ColVec(int(colIdx)),
 			nKeys,
-			nil, /* sel */
+			b.Selection(),
 			op.cancelChecker,
-			op.decimalScratch)
+			op.decimalScratch,
+		)
 	}
 
 	if op.testingKnobs.numOfHashBuckets != 0 {
 		finalizeHash(hashBuffer, nKeys, op.testingKnobs.numOfHashBuckets)
 	}
 
-	// Note: we don't need to reset any of the slices in op.scratch.sels since
-	// they all are of zero length here (see the comment for op.scratch.sels
-	// for context).
-
-	// We can use selIdx to index into op.scratch since op.scratch never has a
-	// a selection vector.
-	op.scratch.hashCodeForSelsSlot = op.scratch.hashCodeForSelsSlot[:0]
-	for selIdx, hashCode := range hashBuffer {
-		selsSlot := -1
-		for slot, hash := range op.scratch.hashCodeForSelsSlot {
-			if hash == hashCode {
-				// We have already seen a tuple with the same hashCode
-				// previously, so we will append into the same sels slot.
-				selsSlot = slot
-				break
-			}
-		}
-		if selsSlot < 0 {
-			// This is the first tuple in hashBuffer with this hashCode, so we
-			// will add this tuple to the next available sels slot.
-			selsSlot = len(op.scratch.hashCodeForSelsSlot)
-			op.scratch.hashCodeForSelsSlot = append(op.scratch.hashCodeForSelsSlot, hashCode)
-		}
-		op.scratch.sels[selsSlot] = append(op.scratch.sels[selsSlot], selIdx)
-	}
+	op.populateSels(b, hashBuffer)
 }
 
 // onlineAgg probes aggFuncMap using the built sels map and lazily creates
 // aggFunctions for each group if it doesn't not exist. Then it calls Compute()
 // on each aggregation function to perform aggregation.
-func (op *hashAggregator) onlineAgg() {
+func (op *hashAggregator) onlineAgg(b coldata.Batch) {
 	for selsSlot, hashCode := range op.scratch.hashCodeForSelsSlot {
 		remaining := op.scratch.sels[selsSlot]
 
@@ -416,16 +343,17 @@ func (op *hashAggregator) onlineAgg() {
 		//          aggregation.
 		if aggFuncs, ok := op.aggFuncMap[hashCode]; ok {
 			for _, aggFunc := range aggFuncs {
-				// We write the selection vector of matched tuples directly into the
-				// selection vector of op.scratch and selection vector of unmatched
-				// tuples into 'remaining'.'remaining' will reuse the underlying memory
-				// allocated for 'sel' to avoid extra allocation and copying.
+				// We write the selection vector of matched tuples directly
+				// into the selection vector of b and selection vector of
+				// unmatched tuples into 'remaining'.'remaining' will reuse the
+				// underlying memory allocated for 'sel' to avoid extra
+				// allocation and copying.
 				anyMatched, remaining = aggFunc.match(
-					remaining, op.scratch, op.groupCols, op.groupTypes, op.keyMapping,
+					remaining, b, op.groupCols, op.groupTypes, op.keyMapping,
 					op.scratch.group[:len(remaining)], false, /* firstDefiniteMatch */
 				)
 				if anyMatched {
-					aggFunc.compute(op.scratch, op.aggCols)
+					aggFunc.compute(b, op.aggCols)
 				}
 			}
 		} else {
@@ -453,7 +381,7 @@ func (op *hashAggregator) onlineAgg() {
 					// .Append() we can use execgen.SET to improve the
 					// performance.
 					op.keyMapping.ColVec(keyIdx).Append(coldata.SliceArgs{
-						Src:         op.scratch.ColVec(int(colIdx)),
+						Src:         b.ColVec(int(colIdx)),
 						ColType:     op.inputPhysTypes[colIdx],
 						DestIdx:     aggFunc.keyIdx,
 						SrcStartIdx: groupStartIdx,
@@ -470,7 +398,7 @@ func (op *hashAggregator) onlineAgg() {
 			// to check if there is any match since 'remaining[0]' will always be
 			// matched.
 			_, remaining = aggFunc.match(
-				remaining, op.scratch, op.groupCols, op.groupTypes, op.keyMapping,
+				remaining, b, op.groupCols, op.groupTypes, op.keyMapping,
 				op.scratch.group[:len(remaining)], true, /* firstDefiniteMatch */
 			)
 
@@ -478,7 +406,7 @@ func (op *hashAggregator) onlineAgg() {
 			// field comment in hashAggregator for more details.
 			op.scratch.group[groupStartIdx] = true
 			aggFunc.init(op.scratch.group, op.output.Batch)
-			aggFunc.compute(op.scratch, op.aggCols)
+			aggFunc.compute(b, op.aggCols)
 			op.scratch.group[groupStartIdx] = false
 		}
 
@@ -496,14 +424,11 @@ func (op *hashAggregator) reset(ctx context.Context) {
 	}
 
 	op.aggFuncMap = hashAggFuncMap{}
-	op.state = hashAggregatorBuffering
+	op.state = hashAggregatorAggregating
 
 	op.output.ResetInternalBatch()
 	op.output.SetLength(0)
 	op.output.pendingOutput = false
-
-	op.scratch.ResetInternalBatch()
-	op.scratch.SetLength(0)
 
 	op.keyMapping.ResetInternalBatch()
 	op.keyMapping.SetLength(0)
@@ -533,7 +458,11 @@ func (v *hashAggFuncs) compute(b coldata.Batch, aggCols [][]uint32) {
 	}
 }
 
-const hashAggFuncsAllocSize = 16
+// hashAggFuncsAllocSize determines the allocation size used by
+// hashAggFuncsAlloc. This number was chosen after running benchmarks of 'sum'
+// aggregation on ints and decimals with varying group sizes (powers of 2 from
+// 1 to 4096).
+const hashAggFuncsAllocSize = 64
 
 // hashAggFuncsAlloc is a utility struct that batches allocations of
 // hashAggFuncs.

--- a/pkg/sql/colexec/hash_aggregator_tmpl.go
+++ b/pkg/sql/colexec/hash_aggregator_tmpl.go
@@ -62,6 +62,50 @@ func _ASSIGN_NE(_, _, _ interface{}) int {
 // */}}
 
 // {{/*
+func _POPULATE_SELS(b coldata.Batch, hashBuffer []uint64, _BATCH_HAS_SELECTION bool) { // */}}
+	// {{define "populateSels" -}}
+	for selIdx, hashCode := range hashBuffer {
+		selsSlot := -1
+		for slot, hash := range op.scratch.hashCodeForSelsSlot {
+			if hash == hashCode {
+				// We have already seen a tuple with the same hashCode
+				// previously, so we will append into the same sels slot.
+				selsSlot = slot
+				break
+			}
+		}
+		if selsSlot < 0 {
+			// This is the first tuple in hashBuffer with this hashCode, so we
+			// will add this tuple to the next available sels slot.
+			selsSlot = len(op.scratch.hashCodeForSelsSlot)
+			op.scratch.hashCodeForSelsSlot = append(op.scratch.hashCodeForSelsSlot, hashCode)
+		}
+		// {{if .BatchHasSelection}}
+		op.scratch.sels[selsSlot] = append(op.scratch.sels[selsSlot], batchSelection[selIdx])
+		// {{else}}
+		op.scratch.sels[selsSlot] = append(op.scratch.sels[selsSlot], selIdx)
+		// {{end}}
+	}
+	// {{end}}
+	// {{/*
+} // */}}
+
+// populateSels populates intermediate selection vectors (stored in
+// op.scratch.sels) for each hash code present in b. hashBuffer must contain
+// the hash codes for all of the tuples in b.
+func (op *hashAggregator) populateSels(b coldata.Batch, hashBuffer []uint64) {
+	// Note: we don't need to reset any of the slices in op.scratch.sels since
+	// they all are of zero length here (see the comment for op.scratch.sels
+	// for context).
+	op.scratch.hashCodeForSelsSlot = op.scratch.hashCodeForSelsSlot[:0]
+	if batchSelection := b.Selection(); batchSelection != nil {
+		_POPULATE_SELS(b, hashBuffer, true)
+	} else {
+		_POPULATE_SELS(b, hashBuffer, false)
+	}
+}
+
+// {{/*
 func _MATCH_LOOP(
 	sel []int,
 	lhs coldata.Vec,

--- a/pkg/sql/colexec/hash_aggregator_tmpl.go
+++ b/pkg/sql/colexec/hash_aggregator_tmpl.go
@@ -194,9 +194,7 @@ func (v hashAggFuncs) match(
 			rhs := b.ColVec(int(colIdx))
 			rhsHasNull := rhs.MaybeHasNulls()
 
-			keyTyp := keyTypes[keyIdx]
-
-			switch typeconv.FromColumnType(&keyTyp) {
+			switch typeconv.FromColumnType(&keyTypes[keyIdx]) {
 			// {{range .}}
 			case _TYPES_T:
 				lhsCol := lhs._TemplateType()
@@ -217,7 +215,7 @@ func (v hashAggFuncs) match(
 				}
 			// {{end}}
 			default:
-				colexecerror.InternalError(fmt.Sprintf("unhandled type %s", &keyTyp))
+				colexecerror.InternalError(fmt.Sprintf("unhandled type %s", keyTypes[keyIdx].String()))
 			}
 		}
 	}

--- a/pkg/sql/colexec/hashtable_tmpl.go
+++ b/pkg/sql/colexec/hashtable_tmpl.go
@@ -286,7 +286,7 @@ func (ht *hashTable) checkColForDistinctTuples(
 		// {{end}}
 		// {{end}}
 	default:
-		colexecerror.InternalError(fmt.Sprintf("unhandled type %s", probeType))
+		colexecerror.InternalError(fmt.Sprintf("unhandled type %s", probeType.Name()))
 	}
 }
 

--- a/pkg/sql/colexec/mergejoinbase_tmpl.go
+++ b/pkg/sql/colexec/mergejoinbase_tmpl.go
@@ -97,9 +97,7 @@ func (o *mergeJoinBase) isBufferedGroupFinished(
 	// Check all equality columns in the first row of batch to make sure we're in
 	// the same group.
 	for _, colIdx := range input.eqCols[:len(input.eqCols)] {
-		typ := input.sourceTypes[colIdx]
-
-		switch typeconv.FromColumnType(&typ) {
+		switch typeconv.FromColumnType(&input.sourceTypes[colIdx]) {
 		// {{ range . }}
 		case _TYPES_T:
 			// We perform this null check on every equality column of the first
@@ -125,7 +123,7 @@ func (o *mergeJoinBase) isBufferedGroupFinished(
 			}
 		// {{end}}
 		default:
-			colexecerror.InternalError(fmt.Sprintf("unhandled type %s", &typ))
+			colexecerror.InternalError(fmt.Sprintf("unhandled type %s", input.sourceTypes[colIdx].String()))
 		}
 	}
 	return false

--- a/pkg/sql/colexec/orderedsynchronizer_tmpl.go
+++ b/pkg/sql/colexec/orderedsynchronizer_tmpl.go
@@ -224,7 +224,7 @@ func (o *OrderedSynchronizer) Init() {
 			o.out_TYPECols = append(o.out_TYPECols, outVec._TYPE())
 		// {{end}}
 		default:
-			colexecerror.InternalError(fmt.Sprintf("unhandled type %s", &o.typs[i]))
+			colexecerror.InternalError(fmt.Sprintf("unhandled type %s", o.typs[i].String()))
 		}
 	}
 	for i := range o.inputs {

--- a/pkg/sql/colexec/vec_comparators_tmpl.go
+++ b/pkg/sql/colexec/vec_comparators_tmpl.go
@@ -151,7 +151,7 @@ func GetVecComparator(t *types.T, numVecs int) vecComparator {
 		}
 		// {{end}}
 	}
-	colexecerror.InternalError(fmt.Sprintf("unhandled type %v", t))
+	colexecerror.InternalError(fmt.Sprintf("unhandled type %s", t.Name()))
 	// This code is unreachable, but the compiler cannot infer that.
 	return nil
 }


### PR DESCRIPTION
**colexec: remove one of the Go maps from hash aggregator**

This commit switches usage of `map` to iteration over `[]uint64` when
building selection vectors in the hash aggregator. This is a lot more
efficient when group sizes are relatively large with moderate hit when
group sizes are small. This hit is reduced in a follow-up commit.

Release note: None

**colexec: more improvements to hash aggregator**

This commit removes the buffering stage of the hash aggregator as well
as removes the "append only" scratch batch that we're currently using.
The removal of buffering stage allows us to have smaller buffers without
sacrificing the performance. The removal of the scratch batch allows to
avoid copying over the data from the input batch and using that input
batch directly. We will be descructively modifying the selection vector
on that batch, but such behavior is acceptable because hash aggregator
owns the output batch, and the input batch will not be propagated
further.

This commit also bumps `hashAggFuncsAllocSize` from 16 to 64 which
gives us minor performance improvement in case of small group sizes.

Release note: None

**colexec: remove some allocations**

In a recent PR (for logical types plumbing) I introduced some
unnecessary allocations for unhandled type case - by taking a pointer
from a value in `[]types.T` slice. This commit fixes that.

Release note: None