### PR TITLE
keys,sqlbase: move PublicSchemaID to sqlbase

### DIFF
--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -338,7 +338,7 @@ func allocateDescriptorRewrites(
 				// This would fail the CPut later anyway, but this yields a prettier error.
 				// TODO (rohany): Use keys.PublicSchemaID for now, revisit this once we
 				//  support user defined schemas.
-				if err := CheckObjectExists(ctx, txn, p.ExecCfg().Codec, parentID, keys.PublicSchemaID, table.Name); err != nil {
+				if err := CheckObjectExists(ctx, txn, p.ExecCfg().Codec, parentID, sqlbase.PublicSchemaID, table.Name); err != nil {
 					return err
 				}
 
@@ -405,7 +405,7 @@ func allocateDescriptorRewrites(
 				}
 
 				// See if there is an existing type with the same name.
-				found, id, err := sqlbase.LookupObjectID(ctx, txn, p.ExecCfg().Codec, parentID, keys.PublicSchemaID, typ.Name)
+				found, id, err := sqlbase.LookupObjectID(ctx, txn, p.ExecCfg().Codec, parentID, sqlbase.PublicSchemaID, typ.Name)
 				if err != nil {
 					return err
 				}
@@ -423,7 +423,7 @@ func allocateDescriptorRewrites(
 
 					// Ensure that there isn't a collision with the array type name.
 					arrTyp := typesByID[typ.ArrayTypeID]
-					if err := CheckObjectExists(ctx, txn, p.ExecCfg().Codec, parentID, keys.PublicSchemaID, arrTyp.Name); err != nil {
+					if err := CheckObjectExists(ctx, txn, p.ExecCfg().Codec, parentID, sqlbase.PublicSchemaID, arrTyp.Name); err != nil {
 						return errors.Wrapf(err, "name collision for %q's array type", typ.Name)
 					}
 					// Create the rewrite entry for the array type as well.

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -862,7 +862,7 @@ func prepareNewTableDescsForIngestion(
 	for _, i := range importTables {
 		// TODO (rohany): Use keys.PublicSchemaID for now, revisit this once we
 		//  support user defined schemas.
-		if err := backupccl.CheckObjectExists(ctx, txn, p.ExecCfg().Codec, parentID, keys.PublicSchemaID, i.Desc.Name); err != nil {
+		if err := backupccl.CheckObjectExists(ctx, txn, p.ExecCfg().Codec, parentID, sqlbase.PublicSchemaID, i.Desc.Name); err != nil {
 			return nil, err
 		}
 		tableDescs = append(tableDescs, i.Desc)

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -159,7 +159,7 @@ func MakeSimpleTableDescriptor(
 		st,
 		create,
 		parentID,
-		keys.PublicSchemaID,
+		sqlbase.PublicSchemaID,
 		tableID,
 		hlc.Timestamp{WallTime: walltime},
 		sqlbase.NewDefaultPrivilegeDescriptor(),

--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -210,7 +210,7 @@ func Load(
 			var txn *kv.Txn
 			// At this point the CREATE statements in the loaded SQL do not
 			// use the SERIAL type so we need not process SERIAL types here.
-			desc, err := sql.MakeTableDesc(ctx, txn, nil /* vt */, st, s, dbDesc.GetID(), keys.PublicSchemaID,
+			desc, err := sql.MakeTableDesc(ctx, txn, nil /* vt */, st, s, dbDesc.GetID(), sqlbase.PublicSchemaID,
 				0 /* table ID */, ts, privs, affected, nil, evalCtx, evalCtx.SessionData, false /* temporary */)
 			if err != nil {
 				return backupccl.BackupManifest{}, errors.Wrap(err, "make table desc")

--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -17,7 +17,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -408,7 +407,7 @@ func mysqlTableToCockroach(
 				seqName,
 				opts,
 				parentID,
-				keys.PublicSchemaID,
+				sqlbase.PublicSchemaID,
 				id,
 				time,
 				priv,
@@ -420,7 +419,7 @@ func mysqlTableToCockroach(
 				seqName,
 				opts,
 				parentID,
-				keys.PublicSchemaID,
+				sqlbase.PublicSchemaID,
 				id,
 				time,
 				priv,

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -240,7 +240,7 @@ func readPostgresCreateTable(
 					name,
 					seq.Options,
 					parentID,
-					keys.PublicSchemaID,
+					sqlbase.PublicSchemaID,
 					id,
 					hlc.Timestamp{WallTime: walltime},
 					sqlbase.NewDefaultPrivilegeDescriptor(),

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -55,7 +55,7 @@ func descForTable(
 			name,
 			tree.SequenceOptions{},
 			parent,
-			keys.PublicSchemaID,
+			sqlbase.PublicSchemaID,
 			id-1,
 			ts,
 			priv,

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -298,7 +298,7 @@ func DecodeKeyIntoZoneIDAndSuffix(key roachpb.RKey) (id SystemTenantObjectID, ke
 	if !ok {
 		// Not in the structured data namespace.
 		objectID = keys.RootNamespaceID
-	} else if objectID <= keys.MaxSystemConfigDescID || isPseudoTableID(uint32(objectID)) {
+	} else if objectID <= keys.MaxSystemConfigDescID {
 		// For now, you cannot set the zone config on gossiped tables. The only
 		// way to set a zone config on these tables is to modify config for the
 		// system database as a whole. This is largely because all the

--- a/pkg/config/system_test.go
+++ b/pkg/config/system_test.go
@@ -571,12 +571,6 @@ func TestGetZoneConfigForKey(t *testing.T) {
 		{tkey(keys.LocationsTableID), keys.LocationsTableID},
 		{tkey(keys.NamespaceTableID), keys.NamespaceTableID},
 
-		// Pseudo-tables should refer to the SystemDatabaseID.
-		{tkey(keys.MetaRangesID), keys.SystemDatabaseID},
-		{tkey(keys.SystemRangesID), keys.SystemDatabaseID},
-		{tkey(keys.TimeseriesRangesID), keys.SystemDatabaseID},
-		{tkey(keys.LivenessRangesID), keys.SystemDatabaseID},
-
 		// User tables should refer to themselves.
 		{tkey(keys.MinUserDescID), keys.MinUserDescID},
 		{tkey(keys.MinUserDescID + 22), keys.MinUserDescID + 22},

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -367,7 +367,11 @@ const (
 	ReplicationCriticalLocalitiesTableID = 26
 	ReplicationStatsTableID              = 27
 	ReportsMetaTableID                   = 28
-	PublicSchemaID                       = 29 // pseudo
+
+	// PublicSchemaID is a constant ID used to indicate the public schema. No
+	// descriptor is actually stored with this ID.
+	PublicSchemaID = 29 // pseudo
+
 	// New NamespaceTableID for cluster version >= 20.1
 	// Ensures that NamespaceTable does not get gossiped again
 	NamespaceTableID                    = 30
@@ -405,7 +409,6 @@ var PseudoTableIDs = []uint32{
 	SystemRangesID,
 	TimeseriesRangesID,
 	LivenessRangesID,
-	PublicSchemaID,
 	TenantsRangesID,
 }
 

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -77,7 +77,7 @@ func nonTableDescriptorRangeCount() int64 {
 		keys.SystemRangesID,
 		keys.TimeseriesRangesID,
 		keys.LivenessRangesID,
-		keys.PublicSchemaID,
+		sqlbase.PublicSchemaID,
 		keys.TenantsRangesID,
 	}))
 }

--- a/pkg/sql/catalog/catalogkv/catalogkv.go
+++ b/pkg/sql/catalog/catalogkv/catalogkv.go
@@ -65,7 +65,7 @@ func ResolveSchemaID(
 	// Try to use the system name resolution bypass. Avoids a hotspot by explicitly
 	// checking for public schema.
 	if scName == tree.PublicSchema {
-		return true, keys.PublicSchemaID, nil
+		return true, sqlbase.PublicSchemaID, nil
 	}
 
 	sKey := sqlbase.NewSchemaKey(dbID, scName)

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -228,7 +228,7 @@ func (tc *Collection) ResolveSchemaID(
 ) (bool, sqlbase.ID, error) {
 	// Fast path public schema, as it is always found.
 	if schemaName == tree.PublicSchema {
-		return true, keys.PublicSchemaID, nil
+		return true, sqlbase.PublicSchemaID, nil
 	}
 
 	type schemaCacheKey struct {

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -274,7 +274,7 @@ CREATE TEMP TABLE t2 (temp int);
 		tableDesc := sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "defaultdb", tableName)
 		lease := leaseManager.tableNames.get(
 			tableDesc.ParentID,
-			sqlbase.ID(keys.PublicSchemaID),
+			sqlbase.ID(sqlbase.PublicSchemaID),
 			tableName,
 			s.Clock().Now(),
 		)

--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -242,7 +242,7 @@ var requiredTypeNames = [...]string{
 }
 
 var staticSchemaIDMap = map[sqlbase.ID]string{
-	keys.PublicSchemaID:         tree.PublicSchema,
+	sqlbase.PublicSchemaID:      tree.PublicSchema,
 	sqlbase.PgCatalogID:         sessiondata.PgCatalogName,
 	sqlbase.InformationSchemaID: sessiondata.InformationSchemaName,
 	sqlbase.CrdbInternalID:      sessiondata.CRDBInternalSchemaName,
@@ -345,7 +345,7 @@ func GetForDatabase(
 	// TODO(solon): This can be removed in 20.2, when this is always written.
 	// In 20.1, in a migrating state, it may be not included yet.
 	ret := make(map[sqlbase.ID]string, len(kvs)+1)
-	ret[sqlbase.ID(keys.PublicSchemaID)] = tree.PublicSchema
+	ret[sqlbase.ID(sqlbase.PublicSchemaID)] = tree.PublicSchema
 
 	for _, kv := range kvs {
 		id := sqlbase.ID(kv.ValueInt())

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -158,7 +158,7 @@ func getTableCreateParams(
 	params runParams, dbID sqlbase.ID, isTemporary bool, tableName string,
 ) (sqlbase.DescriptorKey, sqlbase.ID, error) {
 	// By default, all tables are created in the `public` schema.
-	schemaID := sqlbase.ID(keys.PublicSchemaID)
+	schemaID := sqlbase.ID(sqlbase.PublicSchemaID)
 	tKey := sqlbase.MakePublicTableNameKey(params.ctx,
 		params.ExecCfg().Settings, dbID, tableName)
 	if isTemporary {

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -80,7 +80,7 @@ func getCreateTypeParams(
 	// TODO (rohany): This should be named object key.
 	typeKey := sqlbase.MakePublicTableNameKey(params.ctx, params.ExecCfg().Settings, db.GetID(), name.Type())
 	// As of now, we can only create types in the public schema.
-	schemaID := sqlbase.ID(keys.PublicSchemaID)
+	schemaID := sqlbase.ID(sqlbase.PublicSchemaID)
 	exists, collided, err := sqlbase.LookupObjectID(
 		params.ctx, params.p.txn, params.ExecCfg().Codec, db.GetID(), schemaID, name.Type())
 	if err == nil && exists {
@@ -117,7 +117,7 @@ func (p *planner) createArrayType(
 	// Postgres starts off trying to create the type as _<typename>. It then
 	// continues adding "_" to the front of the name until it doesn't find
 	// a collision.
-	schemaID := sqlbase.ID(keys.PublicSchemaID)
+	schemaID := sqlbase.ID(sqlbase.PublicSchemaID)
 	arrayTypeName := "_" + typ.Type()
 	var arrayTypeKey sqlbase.DescriptorKey
 	for {
@@ -170,7 +170,7 @@ func (p *planner) createArrayType(
 		Name:           arrayTypeName,
 		ID:             id,
 		ParentID:       db.GetID(),
-		ParentSchemaID: keys.PublicSchemaID,
+		ParentSchemaID: sqlbase.PublicSchemaID,
 		Kind:           sqlbase.TypeDescriptor_ALIAS,
 		Alias:          types.MakeArray(elemTyp),
 	})
@@ -244,7 +244,7 @@ func (p *planner) createEnum(params runParams, n *tree.CreateType) error {
 		Name:           typeName.Type(),
 		ID:             id,
 		ParentID:       db.GetID(),
-		ParentSchemaID: keys.PublicSchemaID,
+		ParentSchemaID: sqlbase.PublicSchemaID,
 		Kind:           sqlbase.TypeDescriptor_ENUM,
 		EnumMembers:    members,
 	})

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -14,7 +14,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -90,7 +89,7 @@ func (p *planner) createDatabase(
 	// be created in every database in >= 20.2.
 	if shouldCreatePublicSchema {
 		// Every database must be initialized with the public schema.
-		if err := p.createSchemaWithID(ctx, sqlbase.NewPublicSchemaKey(id).Key(p.ExecCfg().Codec), keys.PublicSchemaID); err != nil {
+		if err := p.createSchemaWithID(ctx, sqlbase.NewPublicSchemaKey(id).Key(p.ExecCfg().Codec), sqlbase.PublicSchemaID); err != nil {
 			return nil, true, err
 		}
 	}

--- a/pkg/sql/namespace_test.go
+++ b/pkg/sql/namespace_test.go
@@ -130,7 +130,7 @@ func TestNamespaceTableSemantics(t *testing.T) {
 	desc := sqlbase.InitTableDescriptor(
 		sqlbase.ID(idCounter),
 		dbID,
-		keys.PublicSchemaID,
+		sqlbase.PublicSchemaID,
 		"rel",
 		hlc.Timestamp{},
 		&sqlbase.PrivilegeDescriptor{},

--- a/pkg/sql/sqlbase/constants.go
+++ b/pkg/sql/sqlbase/constants.go
@@ -13,6 +13,7 @@ package sqlbase
 import (
 	"math"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 )
 
@@ -45,6 +46,10 @@ const InternalAppNamePrefix = ReportableAppNamePrefix + "internal"
 // RepotableAppNamePrefix; in particular the application name with
 // DelegatedAppNamePrefix should be scrubbed in reporting.
 const DelegatedAppNamePrefix = "$$ "
+
+// PublicSchemaID is a constant descriptor ID used to refer to the public schema
+// in all databases.
+const PublicSchemaID = keys.PublicSchemaID // pseudo
 
 // Oid for virtual database and table.
 const (

--- a/pkg/sql/sqlbase/metadata.go
+++ b/pkg/sql/sqlbase/metadata.go
@@ -148,7 +148,7 @@ func (ms MetadataSchema) GetInitialValues() ([]roachpb.KeyValue, []roachpb.RKey)
 			// Initializing a database. Databases must be initialized with
 			// the public schema, as all tables are scoped under the public schema.
 			publicSchemaValue := roachpb.Value{}
-			publicSchemaValue.SetInt(int64(keys.PublicSchemaID))
+			publicSchemaValue.SetInt(int64(PublicSchemaID))
 			ret = append(
 				ret,
 				roachpb.KeyValue{

--- a/pkg/sql/sqlbase/namespace.go
+++ b/pkg/sql/sqlbase/namespace.go
@@ -97,7 +97,7 @@ func RemoveObjectNamespaceEntry(
 func RemovePublicTableNamespaceEntry(
 	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, parentID ID, name string,
 ) error {
-	return RemoveObjectNamespaceEntry(ctx, txn, codec, parentID, keys.PublicSchemaID, name, false /* KVTrace */)
+	return RemoveObjectNamespaceEntry(ctx, txn, codec, parentID, PublicSchemaID, name, false /* KVTrace */)
 }
 
 // RemoveSchemaNamespaceEntry is a wrapper around RemoveObjectNamespaceEntry
@@ -143,7 +143,7 @@ func MakeObjectNameKey(
 func MakePublicTableNameKey(
 	ctx context.Context, settings *cluster.Settings, parentID ID, name string,
 ) DescriptorKey {
-	return MakeObjectNameKey(ctx, settings, parentID, keys.PublicSchemaID, name)
+	return MakeObjectNameKey(ctx, settings, parentID, PublicSchemaID, name)
 }
 
 // MakeDatabaseNameKey is a wrapper around MakeObjectNameKey for databases.
@@ -193,7 +193,7 @@ func LookupObjectID(
 	// valid temporary schema.
 	// - If this session explicitly accesses `pg_temp.t`, it should fail -- but
 	// without this check, `pg_temp.t` will return the permanent table instead.
-	if parentSchemaID != keys.PublicSchemaID && parentSchemaID != keys.RootNamespaceID {
+	if parentSchemaID != PublicSchemaID && parentSchemaID != keys.RootNamespaceID {
 		return false, InvalidID, nil
 	}
 
@@ -218,7 +218,7 @@ func LookupObjectID(
 func LookupPublicTableID(
 	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, parentID ID, name string,
 ) (bool, ID, error) {
-	return LookupObjectID(ctx, txn, codec, parentID, keys.PublicSchemaID, name)
+	return LookupObjectID(ctx, txn, codec, parentID, PublicSchemaID, name)
 }
 
 // LookupDatabaseID is  a wrapper around LookupObjectID for databases.

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -722,7 +722,7 @@ func (desc *TableDescriptor) IsVirtualTable() bool {
 func (desc *TableDescriptor) GetParentSchemaID() ID {
 	parentSchemaID := desc.GetUnexposedParentSchemaID()
 	if parentSchemaID == InvalidID {
-		parentSchemaID = keys.PublicSchemaID
+		parentSchemaID = PublicSchemaID
 	}
 	return parentSchemaID
 }
@@ -4444,7 +4444,7 @@ type TableKey struct {
 
 // NewPublicTableKey returns a new TableKey scoped under the public schema.
 func NewPublicTableKey(parentID ID, name string) TableKey {
-	return TableKey{parentID: parentID, parentSchemaID: keys.PublicSchemaID, name: name}
+	return TableKey{parentID: parentID, parentSchemaID: PublicSchemaID, name: name}
 }
 
 // NewTableKey returns a new TableKey

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -426,7 +426,7 @@ var (
 		Name:                    NamespaceTableName,
 		ID:                      keys.DeprecatedNamespaceTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "parentID", ID: 1, Type: types.Int},
@@ -470,7 +470,7 @@ var (
 		Name:                    "namespace2",
 		ID:                      keys.NamespaceTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "parentID", ID: 1, Type: types.Int},
@@ -505,7 +505,7 @@ var (
 		ID:                      keys.DescriptorTableID,
 		Privileges:              NewCustomSuperuserPrivilegeDescriptor(SystemAllowedPrivileges[keys.DescriptorTableID]),
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "id", ID: 1, Type: types.Int},
@@ -534,7 +534,7 @@ var (
 		Name:                    "users",
 		ID:                      keys.UsersTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "username", ID: 1, Type: types.String},
@@ -560,7 +560,7 @@ var (
 		Name:                    "zones",
 		ID:                      keys.ZonesTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "id", ID: 1, Type: types.Int},
@@ -594,7 +594,7 @@ var (
 		Name:                    "settings",
 		ID:                      keys.SettingsTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "name", ID: 1, Type: types.String},
@@ -624,7 +624,7 @@ var (
 		Name:                    "descriptor_id_seq",
 		ID:                      keys.DescIDSequenceID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: SequenceColumnName, ID: SequenceColumnID, Type: types.Int},
@@ -657,7 +657,7 @@ var (
 		Name:                    "tenants",
 		ID:                      keys.TenantsTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "id", ID: 1, Type: types.Int},
@@ -696,7 +696,7 @@ var (
 		Name:                    "lease",
 		ID:                      keys.LeaseTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "descID", ID: 1, Type: types.Int},
@@ -731,7 +731,7 @@ var (
 		Name:                    "eventlog",
 		ID:                      keys.EventLogTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "timestamp", ID: 1, Type: types.Timestamp},
@@ -772,7 +772,7 @@ var (
 		Name:                    "rangelog",
 		ID:                      keys.RangeEventTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "timestamp", ID: 1, Type: types.Timestamp},
@@ -813,7 +813,7 @@ var (
 		Name:                    "ui",
 		ID:                      keys.UITableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "key", ID: 1, Type: types.String},
@@ -842,7 +842,7 @@ var (
 		Name:                    "jobs",
 		ID:                      keys.JobsTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "id", ID: 1, Type: types.Int, DefaultExpr: &uniqueRowIDString},
@@ -909,7 +909,7 @@ var (
 		Name:                    "web_sessions",
 		ID:                      keys.WebSessionsTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "id", ID: 1, Type: types.Int, DefaultExpr: &uniqueRowIDString},
@@ -974,7 +974,7 @@ var (
 		Name:                    "table_statistics",
 		ID:                      keys.TableStatisticsTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "tableID", ID: 1, Type: types.Int},
@@ -1029,7 +1029,7 @@ var (
 		Name:                    "locations",
 		ID:                      keys.LocationsTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "localityKey", ID: 1, Type: types.String},
@@ -1067,7 +1067,7 @@ var (
 		Name:                    "role_members",
 		ID:                      keys.RoleMembersTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "role", ID: 1, Type: types.String},
@@ -1133,7 +1133,7 @@ var (
 		Name:                    "comments",
 		ID:                      keys.CommentsTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "type", ID: 1, Type: types.Int},
@@ -1166,7 +1166,7 @@ var (
 		Name:                    "reports_meta",
 		ID:                      keys.ReportsMetaTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "id", ID: 1, Type: types.Int},
@@ -1207,7 +1207,7 @@ var (
 		Name:                    "replication_constraint_stats",
 		ID:                      keys.ReplicationConstraintStatsTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "zone_id", ID: 1, Type: types.Int},
@@ -1260,7 +1260,7 @@ var (
 		Name:                    "replication_critical_localities",
 		ID:                      keys.ReplicationCriticalLocalitiesTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "zone_id", ID: 1, Type: types.Int},
@@ -1310,7 +1310,7 @@ var (
 		Name:                    "replication_stats",
 		ID:                      keys.ReplicationStatsTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "zone_id", ID: 1, Type: types.Int},
@@ -1358,7 +1358,7 @@ var (
 		Name:                    "protected_ts_meta",
 		ID:                      keys.ProtectedTimestampsMetaTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{
@@ -1409,7 +1409,7 @@ var (
 		Name:                    "protected_ts_records",
 		ID:                      keys.ProtectedTimestampsRecordsTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "id", ID: 1, Type: types.Uuid},
@@ -1451,7 +1451,7 @@ var (
 		Name:                    "role_options",
 		ID:                      keys.RoleOptionsTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "username", ID: 1, Type: types.String},
@@ -1487,7 +1487,7 @@ var (
 		Name:                    "statement_bundle_chunks",
 		ID:                      keys.StatementBundleChunksTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "id", ID: 1, Type: types.Int, DefaultExpr: &uniqueRowIDString},
@@ -1516,7 +1516,7 @@ var (
 		Name:                    "statement_diagnostics_requests",
 		ID:                      keys.StatementDiagnosticsRequestsTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "id", ID: 1, Type: types.Int, DefaultExpr: &uniqueRowIDString, Nullable: false},
@@ -1560,7 +1560,7 @@ var (
 		Name:                    "statement_diagnostics",
 		ID:                      keys.StatementDiagnosticsTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "id", ID: 1, Type: types.Int, DefaultExpr: &uniqueRowIDString, Nullable: false},
@@ -1594,7 +1594,7 @@ var (
 		Name:                    "scheduled_jobs",
 		ID:                      keys.ScheduledJobsTableID,
 		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
+		UnexposedParentSchemaID: PublicSchemaID,
 		Version:                 1,
 		Columns: []ColumnDescriptor{
 			{Name: "schedule_id", ID: 1, Type: types.Int, DefaultExpr: &uniqueRowIDString, Nullable: false},

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -13,7 +13,6 @@ package sql
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -47,7 +46,7 @@ func CreateTestTableDescriptor(
 			nil, /* vs */
 			st,
 			n,
-			parentID, keys.PublicSchemaID, id,
+			parentID, sqlbase.PublicSchemaID, id,
 			hlc.Timestamp{}, /* creationTime */
 			privileges,
 			nil, /* affected */
@@ -61,7 +60,7 @@ func CreateTestTableDescriptor(
 		desc, err := MakeSequenceTableDesc(
 			n.Name.Table(),
 			n.Options,
-			parentID, keys.PublicSchemaID, id,
+			parentID, sqlbase.PublicSchemaID, id,
 			hlc.Timestamp{}, /* creationTime */
 			privileges,
 			false, /* temporary */

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -943,7 +943,7 @@ func (m *Manager) migrateSystemNamespace(
 					// Also create a 'public' schema for this database.
 					schemaKey := sqlbase.NewSchemaKey(id, "public")
 					log.VEventf(ctx, 2, "Migrating system.namespace entry for database %s", name)
-					if err := txn.Put(ctx, schemaKey.Key(r.codec), keys.PublicSchemaID); err != nil {
+					if err := txn.Put(ctx, schemaKey.Key(r.codec), sqlbase.PublicSchemaID); err != nil {
 						return err
 					}
 				} else {
@@ -955,7 +955,7 @@ func (m *Manager) migrateSystemNamespace(
 						// deprecated ID.
 						continue
 					}
-					tableKey := sqlbase.NewTableKey(parentID, keys.PublicSchemaID, name)
+					tableKey := sqlbase.NewTableKey(parentID, sqlbase.PublicSchemaID, name)
 					log.VEventf(ctx, 2, "Migrating system.namespace entry for table %s", name)
 					if err := txn.Put(ctx, tableKey.Key(r.codec), id); err != nil {
 						return err


### PR DESCRIPTION
The PublicSchemaID was introduced during the work for temp tables and the
associated migration of the namespace table. The chosen constantly was
erroneously put into the `PseudoTableIDs` which is used to create split
points and control zone configs for low-level constructs like meta ranges,
liveness range, timeseries, etc.

This commit also fixed non-sense I introduced in #39638 while trying to
enable real system tables to have their own zone configs (as opposed to
just being controlled by the system zone config). All of the pseudo-table
ids had corresponding filters below.

This change should get backported as far back as 19.1.

Release note (bug fix): Fix bug where an extra split was created in the
keyspace which does not correspond to user data.