### PR TITLE
sql: fix explain output for subqueries/postqueries

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -518,7 +518,7 @@ root                                          ·             ·                 
  │    │                                       order         +z                                                   ·                   ·
  │    └── scan buffer node                    ·             ·                                                    (z)                 ·
  │                                            label         buffer 1                                             ·                   ·
- └── subquery                                 ·             ·                                                    (z)                 +z
+ └── subquery                                 ·             ·                                                    ·                   ·
       │                                       id            @S1                                                  ·                   ·
       │                                       original sql  INSERT INTO xyz SELECT a, b, c FROM abc RETURNING z  ·                   ·
       │                                       exec mode     all rows                                             ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -721,7 +721,7 @@ root                          ·              ·                                
  ├── values                   ·              ·                                                ("array")          ·
  │                            size           1 column, 1 row                                  ·                  ·
  │                            row 0, expr 0  ARRAY @S1                                        ·                  ·
- └── subquery                 ·              ·                                                ("array")          ·
+ └── subquery                 ·              ·                                                ·                  ·
       │                       id             @S1                                              ·                  ·
       │                       original sql   (SELECT generate_series(1, 10) ORDER BY 1 DESC)  ·                  ·
       │                       exec mode      all rows                                         ·                  ·
@@ -740,7 +740,7 @@ root                      ·              ·                             ("array
  ├── values               ·              ·                             ("array")  ·
  │                        size           1 column, 1 row               ·          ·
  │                        row 0, expr 0  ARRAY @S1                     ·          ·
- └── subquery             ·              ·                             ("array")  ·
+ └── subquery             ·              ·                             ·          ·
       │                   id             @S1                           ·          ·
       │                   original sql   (SELECT a FROM t ORDER BY b)  ·          ·
       │                   exec mode      all rows                      ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -201,7 +201,7 @@ root                             ·             ·                              
  │         └── scan              ·             ·                                     (z)                   ·
  │                               table         xz@primary                            ·                     ·
  │                               spans         FULL SCAN                             ·                     ·
- └── subquery                    ·             ·                                     (generate_series)     ·
+ └── subquery                    ·             ·                                     ·                     ·
       │                          id            @S1                                   ·                     ·
       │                          original sql  (SELECT unnest(ARRAY[x, y]) FROM xy)  ·                     ·
       │                          exec mode     one row                               ·                     ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -52,7 +52,7 @@ root                         ·             ·                                  
  │                           table         abc@primary                                                                  ·               ·
  │                           spans         FULL SCAN                                                                    ·               ·
  │                           filter        a = @S2                                                                      ·               ·
- ├── subquery                ·             ·                                                                            (a, b, c)       ·
+ ├── subquery                ·             ·                                                                            ·               ·
  │    │                      id            @S1                                                                          ·               ·
  │    │                      original sql  EXISTS (SELECT * FROM abc WHERE c = (a + 3))                                 ·               ·
  │    │                      exec mode     exists                                                                       ·               ·
@@ -62,7 +62,7 @@ root                         ·             ·                                  
  │                           table         abc@primary                                                                  ·               ·
  │                           spans         FULL SCAN                                                                    ·               ·
  │                           filter        c = (a + 3)                                                                  ·               ·
- └── subquery                ·             ·                                                                            (a, b, c)       ·
+ └── subquery                ·             ·                                                                            ·               ·
       │                      id            @S2                                                                          ·               ·
       │                      original sql  (SELECT max(a) FROM abc WHERE EXISTS (SELECT * FROM abc WHERE c = (a + 3)))  ·               ·
       │                      exec mode     one row                                                                      ·               ·
@@ -241,7 +241,7 @@ root            ·              ·                  ("array")  ·
  ├── values     ·              ·                  ("array")  ·
  │              size           1 column, 1 row    ·          ·
  │              row 0, expr 0  ARRAY @S1          ·          ·
- └── subquery   ·              ·                  ("array")  ·
+ └── subquery   ·              ·                  ·          ·
       │         id             @S1                ·          ·
       │         original sql   (SELECT x FROM b)  ·          ·
       │         exec mode      all rows           ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -346,7 +346,7 @@ root                                          ·                 ·             
  │    │                                       order             +a                                ·                         ·
  │    └── scan buffer node                    ·                 ·                                 (a)                       ·
  │                                            label             buffer 1                          ·                         ·
- └── subquery                                 ·                 ·                                 (a)                       +a
+ └── subquery                                 ·                 ·                                 ·                         ·
       │                                       id                @S1                               ·                         ·
       │                                       original sql      UPDATE abc SET a = c RETURNING a  ·                         ·
       │                                       exec mode         all rows                          ·                         ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -356,7 +356,7 @@ root                                               ·             ·            
  │    │                                            order         +z                                                   ·                            ·
  │    └── scan buffer node                         ·             ·                                                    (z)                          ·
  │                                                 label         buffer 1                                             ·                            ·
- └── subquery                                      ·             ·                                                    (z)                          +z
+ └── subquery                                      ·             ·                                                    ·                            ·
       │                                            id            @S1                                                  ·                            ·
       │                                            original sql  UPSERT INTO xyz SELECT a, b, c FROM abc RETURNING z  ·                            ·
       │                                            exec mode     all rows                                             ·                            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -420,7 +420,7 @@ root                 ·             ·                                          
  │         └── scan  ·             ·                                                                          (v, w)        ·
  │                   table         kv@primary                                                                 ·             ·
  │                   spans         FULL SCAN                                                                  ·             ·
- └── subquery        ·             ·                                                                          (avg)         ·
+ └── subquery        ·             ·                                                                          ·             ·
       │              id            @S1                                                                        ·             ·
       │              original sql  (SELECT count(*) FROM kv)                                                  ·             ·
       │              exec mode     one row                                                                    ·             ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -19,7 +19,7 @@ root                        ·             ·                (a, a)  ·
  │    │                     label         buffer 1 (t)     ·       ·
  │    └── scan buffer node  ·             ·                (a)     ·
  │                          label         buffer 1 (t)     ·       ·
- └── subquery               ·             ·                (a, a)  ·
+ └── subquery               ·             ·                ·       ·
       │                     id            @S1              ·       ·
       │                     original sql  SELECT a FROM y  ·       ·
       │                     exec mode     all rows         ·       ·
@@ -50,7 +50,7 @@ EXPLAIN (VERBOSE)
 root                                       ·              ·                                     (a)                 ·
  ├── scan buffer node                      ·              ·                                     (a)                 ·
  │                                         label          buffer 1 (t)                          ·                   ·
- └── subquery                              ·              ·                                     (a)                 ·
+ └── subquery                              ·              ·                                     ·                   ·
       │                                    id             @S1                                   ·                   ·
       │                                    original sql   INSERT INTO x VALUES (1) RETURNING a  ·                   ·
       │                                    exec mode      all rows                              ·                   ·

--- a/pkg/sql/testdata/explain_tree
+++ b/pkg/sql/testdata/explain_tree
@@ -232,7 +232,7 @@ root                                                                            
  │    └── scan                                                                     (id int, title string)
  │                   table         movies@primary
  │                   spans         FULL SCAN
- └── subquery                                                                      (movie_id int, title string, name string)
+ └── subquery
       │              id            @S1
       │              original sql  (SELECT name FROM t.actors WHERE name = 'Foo')
       │              exec mode     one row


### PR DESCRIPTION
#### sql: fix explain output for subqueries/postqueries

The code was passing the main plan to `enterNode` which resulted in that
metadata being shown for the `subquery / postquery` rows. Changing the explain
code to correctly handle a `nil` plan and using that instead so no metadata is
shown.

Release note (bug fix): removed redundant metadata information for subqueries
and postqueries in EXPLAIN (VERBOSE) output.
