### PR TITLE
colexec, coldata: fix compiler warnings in template files

### DIFF
--- a/pkg/ccl/importccl/read_import_workload.go
+++ b/pkg/ccl/importccl/read_import_workload.go
@@ -138,7 +138,8 @@ func (w *workloadReader) readFiles(
 		}
 		gen := meta.New()
 		if f, ok := gen.(workload.Flagser); ok {
-			if err := f.Flags().Parse(conf.Flags); err != nil {
+			flags := f.Flags()
+			if err := flags.Parse(conf.Flags); err != nil {
 				return errors.Wrapf(err, `parsing parameters %s`, strings.Join(conf.Flags, ` `))
 			}
 		}

--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -127,7 +127,8 @@ func TestAllRegisteredSetup(t *testing.T) {
 		case `roachmart`:
 			// TODO(dan): It'd be nice to test this with the default flags. For now,
 			// this is better than nothing.
-			if err := gen.(workload.Flagser).Flags().Parse([]string{
+			flags := gen.(workload.Flagser).Flags()
+			if err := flags.Parse([]string{
 				`--users=10`, `--orders=100`, `--partition=false`,
 			}); err != nil {
 				t.Fatal(err)

--- a/pkg/col/coldata/unknown_vec.go
+++ b/pkg/col/coldata/unknown_vec.go
@@ -71,7 +71,7 @@ func (u unknown) SetCol(interface{}) {
 	panic("Vec is of unknown type and should not be accessed")
 }
 
-func (u unknown) _TemplateType() []interface{} {
+func (u unknown) TemplateType() []interface{} {
 	panic("Vec is of unknown type and should not be accessed")
 }
 

--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -90,7 +90,7 @@ type Vec interface {
 
 	// TemplateType returns an []interface{} and is used for operator templates.
 	// Do not call this from normal code - it'll always panic.
-	_TemplateType() []interface{}
+	TemplateType() []interface{}
 
 	// Append uses SliceArgs to append elements of a source Vec into this Vec.
 	// It is logically equivalent to:
@@ -226,7 +226,7 @@ func (m *memColumn) Col() interface{} {
 	return m.col
 }
 
-func (m *memColumn) _TemplateType() []interface{} {
+func (m *memColumn) TemplateType() []interface{} {
 	panic("don't call this from non template code")
 }
 

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -55,8 +55,8 @@ func (m *memColumn) Append(args SliceArgs) {
 	switch args.ColType {
 	// {{range .}}
 	case _TYPES_T:
-		fromCol := args.Src._TemplateType()
-		toCol := m._TemplateType()
+		fromCol := args.Src.TemplateType()
+		toCol := m.TemplateType()
 		// NOTE: it is unfortunate that we always append whole slice without paying
 		// attention to whether the values are NULL. However, if we do start paying
 		// attention, the performance suffers dramatically, so we choose to copy
@@ -153,8 +153,8 @@ func (m *memColumn) Copy(args CopySliceArgs) {
 	switch args.ColType {
 	// {{range .}}
 	case _TYPES_T:
-		fromCol := args.Src._TemplateType()
-		toCol := m._TemplateType()
+		fromCol := args.Src.TemplateType()
+		toCol := m.TemplateType()
 		if args.Sel != nil {
 			sel := args.Sel
 			if args.SelOnDest {
@@ -177,7 +177,7 @@ func (m *memColumn) Window(colType coltypes.T, start int, end int) Vec {
 	switch colType {
 	// {{range .}}
 	case _TYPES_T:
-		col := m._TemplateType()
+		col := m.TemplateType()
 		return &memColumn{
 			t:     colType,
 			col:   execgen.WINDOW(col, start, end),
@@ -195,7 +195,7 @@ func SetValueAt(v Vec, elem interface{}, rowIdx int, colType coltypes.T) {
 	switch colType {
 	// {{range .}}
 	case _TYPES_T:
-		target := v._TemplateType()
+		target := v.TemplateType()
 		newVal := elem.(_GOTYPE)
 		execgen.SET(target, rowIdx, newVal)
 	// {{end}}
@@ -210,7 +210,7 @@ func GetValueAt(v Vec, rowIdx int, colType coltypes.T) interface{} {
 	switch colType {
 	// {{range .}}
 	case _TYPES_T:
-		target := v._TemplateType()
+		target := v.TemplateType()
 		return execgen.UNSAFEGET(target, rowIdx)
 	// {{end}}
 	default:

--- a/pkg/sql/colexec/and_or_projection_tmpl.go
+++ b/pkg/sql/colexec/and_or_projection_tmpl.go
@@ -131,10 +131,12 @@ func (o *_OP_LOWERProjOp) Next(ctx context.Context) coldata.Batch {
 	//
 	// knownResult indicates the boolean value which if present on the left side
 	// fully determines the result of the logical operation.
+	var (
+		knownResult             bool
+		isLeftNull, isRightNull bool
+	)
 	// {{ if _IS_OR_OP }}
-	knownResult := true
-	// {{ else }}
-	knownResult := false
+	knownResult = true
 	// {{ end }}
 	leftCol := batch.ColVec(o.leftIdx)
 	leftColVals := leftCol.Bool()
@@ -234,9 +236,9 @@ func (o *_OP_LOWERProjOp) Next(ctx context.Context) coldata.Batch {
 func _ADD_TUPLE_FOR_RIGHT(_L_HAS_NULLS bool) { // */}}
 	// {{define "addTupleForRight" -}}
 	// {{if _L_HAS_NULLS}}
-	isLeftNull := leftNulls.NullAt(i)
+	isLeftNull = leftNulls.NullAt(i)
 	// {{else}}
-	isLeftNull := false
+	isLeftNull = false
 	// {{end}}
 	if isLeftNull || leftColVals[i] != knownResult {
 		// We add the tuple into the selection vector if the left value is NULL or
@@ -280,18 +282,18 @@ func _SET_VALUES(_IS_OR_OP bool, _L_HAS_NULLS bool, _R_HAS_NULLS bool) { // */}}
 func _SET_SINGLE_VALUE(_IS_OR_OP bool, _L_HAS_NULLS bool, _R_HAS_NULLS bool) { // */}}
 	// {{ define "setSingleValue" -}}
 	// {{ if _L_HAS_NULLS }}
-	isLeftNull := leftNulls.NullAt(idx)
+	isLeftNull = leftNulls.NullAt(idx)
 	// {{ else }}
-	isLeftNull := false
+	isLeftNull = false
 	// {{ end }}
 	leftVal := leftColVals[idx]
 	if !isLeftNull && leftVal == knownResult {
 		outputColVals[idx] = leftVal
 	} else {
 		// {{ if _R_HAS_NULLS }}
-		isRightNull := rightNulls.NullAt(idx)
+		isRightNull = rightNulls.NullAt(idx)
 		// {{ else }}
-		isRightNull := false
+		isRightNull = false
 		// {{ end }}
 		rightVal := rightColVals[idx]
 		// {{ if _IS_OR_OP }}

--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -90,7 +90,7 @@ type anyNotNull_TYPEAgg struct {
 func (a *anyNotNull_TYPEAgg) Init(groups []bool, vec coldata.Vec) {
 	a.groups = groups
 	a.vec = vec
-	a.col = vec._TemplateType()
+	a.col = vec.TemplateType()
 	a.nulls = vec.Nulls()
 	a.Reset()
 }
@@ -131,7 +131,7 @@ func (a *anyNotNull_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 		return
 	}
 	vec, sel := b.ColVec(int(inputIdxs[0])), b.Selection()
-	col, nulls := vec._TemplateType(), vec.Nulls()
+	col, nulls := vec.TemplateType(), vec.Nulls()
 
 	a.allocator.PerformOperation(
 		[]coldata.Vec{a.vec},

--- a/pkg/sql/colexec/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/avg_agg_tmpl.go
@@ -97,7 +97,7 @@ var _ aggregateFunc = &avg_TYPEAgg{}
 
 func (a *avg_TYPEAgg) Init(groups []bool, v coldata.Vec) {
 	a.groups = groups
-	a.scratch.vec = v._TemplateType()
+	a.scratch.vec = v.TemplateType()
 	a.scratch.nulls = v.Nulls()
 	a.Reset()
 }
@@ -141,7 +141,7 @@ func (a *avg_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 		return
 	}
 	vec, sel := b.ColVec(int(inputIdxs[0])), b.Selection()
-	col, nulls := vec._TemplateType(), vec.Nulls()
+	col, nulls := vec.TemplateType(), vec.Nulls()
 	if nulls.MaybeHasNulls() {
 		if sel != nil {
 			sel = sel[:inputLen]

--- a/pkg/sql/colexec/const_tmpl.go
+++ b/pkg/sql/colexec/const_tmpl.go
@@ -108,7 +108,7 @@ func (c const_TYPEOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(c.outputIdx)
-	col := vec._TemplateType()
+	col := vec.TemplateType()
 	if vec.MaybeHasNulls() {
 		// We need to make sure that there are no left over null values in the
 		// output vector.

--- a/pkg/sql/colexec/distinct_tmpl.go
+++ b/pkg/sql/colexec/distinct_tmpl.go
@@ -236,7 +236,7 @@ func (p *sortedDistinct_TYPEOp) Next(ctx context.Context) coldata.Batch {
 	if vec.MaybeHasNulls() {
 		nulls = vec.Nulls()
 	}
-	col := vec._TemplateType()
+	col := vec.TemplateType()
 
 	// We always output the first row.
 	lastVal := p.lastVal
@@ -311,7 +311,7 @@ func (p partitioner_TYPE) partitionWithOrder(
 		nulls = colVec.Nulls()
 	}
 
-	col := colVec._TemplateType()
+	col := colVec.TemplateType()
 	col = execgen.SLICE(col, 0, n)
 	outputCol = outputCol[:n]
 	outputCol[0] = true
@@ -336,7 +336,7 @@ func (p partitioner_TYPE) partition(colVec coldata.Vec, outputCol []bool, n int)
 		nulls = colVec.Nulls()
 	}
 
-	col := colVec._TemplateType()
+	col := colVec.TemplateType()
 	col = execgen.SLICE(col, 0, n)
 	outputCol = outputCol[:n]
 	outputCol[0] = true

--- a/pkg/sql/colexec/execgen/cmd/execgen/any_not_null_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/any_not_null_agg_gen.go
@@ -33,7 +33,7 @@ func genAnyNotNullAgg(wr io.Writer) error {
 	s = strings.Replace(s, "_GOTYPE", "{{.LTyp.GoTypeName}}", -1)
 	s = strings.Replace(s, "_TYPES_T", "coltypes.{{.LTyp}}", -1)
 	s = strings.Replace(s, "_TYPE", "{{.LTyp}}", -1)
-	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "TemplateType", "{{.LTyp}}", -1)
 
 	findAnyNotNull := makeFunctionRegex("_FIND_ANY_NOT_NULL", 4)
 	s = findAnyNotNull.ReplaceAllString(s, `{{template "findAnyNotNull" buildDict "Global" . "LTyp" .LTyp "HasNulls" $4}}`)

--- a/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
@@ -69,7 +69,7 @@ func genAvgAgg(wr io.Writer) error {
 	s = strings.Replace(s, "_GOTYPE", "{{.Type.GoTypeName}}", -1)
 	s = strings.Replace(s, "_TYPES_T", "coltypes.{{.Type}}", -1)
 	s = strings.Replace(s, "_TYPE", "{{.Type}}", -1)
-	s = strings.Replace(s, "_TemplateType", "{{.Type}}", -1)
+	s = strings.Replace(s, "TemplateType", "{{.Type}}", -1)
 
 	assignDivRe := makeFunctionRegex("_ASSIGN_DIV_INT64", 3)
 	s = assignDivRe.ReplaceAllString(s, makeTemplateFunctionCall("AssignDivInt64", 3))

--- a/pkg/sql/colexec/execgen/cmd/execgen/const_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/const_gen.go
@@ -33,7 +33,7 @@ func genConstOps(wr io.Writer) error {
 	s = strings.Replace(s, "_GOTYPE", "{{.GoTypeName}}", -1)
 	s = strings.Replace(s, "_TYPES_T", "coltypes.{{.}}", -1)
 	s = strings.Replace(s, "_TYPE", "{{.}}", -1)
-	s = strings.Replace(s, "_TemplateType", "{{.}}", -1)
+	s = strings.Replace(s, "TemplateType", "{{.}}", -1)
 	s = replaceManipulationFuncs("", s)
 
 	// Now, generate the op, from the template.

--- a/pkg/sql/colexec/execgen/cmd/execgen/distinct_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/distinct_gen.go
@@ -34,7 +34,7 @@ func genDistinctOps(wr io.Writer) error {
 	s = strings.Replace(s, "_GOTYPESLICE", "{{.LTyp.GoTypeSliceName}}", -1)
 	s = strings.Replace(s, "_TYPES_T", "coltypes.{{.LTyp}}", -1)
 	s = strings.Replace(s, "_TYPE", "{{.LTyp}}", -1)
-	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "TemplateType", "{{.LTyp}}", -1)
 
 	assignNeRe := makeFunctionRegex("_ASSIGN_NE", 3)
 	s = assignNeRe.ReplaceAllString(s, makeTemplateFunctionCall("Global.Assign", 3))

--- a/pkg/sql/colexec/execgen/cmd/execgen/hash_aggregator_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hash_aggregator_gen.go
@@ -29,7 +29,7 @@ func genHashAggregator(wr io.Writer) error {
 
 	s := string(t)
 
-	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "TemplateType", "{{.LTyp}}", -1)
 	s = strings.Replace(s, "_TYPES_T", "coltypes.{{.LTyp}}", -1)
 	s = replaceManipulationFuncs(".Global.LTyp", s)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/hash_utils_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hash_utils_gen.go
@@ -29,7 +29,7 @@ func genHashUtils(wr io.Writer) error {
 
 	s = strings.Replace(s, "_TYPES_T", "coltypes.{{.LTyp}}", -1)
 	s = strings.Replace(s, "_TYPE", "{{.LTyp}}", -1)
-	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "TemplateType", "{{.LTyp}}", -1)
 
 	assignHash := makeFunctionRegex("_ASSIGN_HASH", 2)
 	s = assignHash.ReplaceAllString(s, makeTemplateFunctionCall("Global.UnaryAssign", 2))

--- a/pkg/sql/colexec/execgen/cmd/execgen/mergejoinbase_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/mergejoinbase_gen.go
@@ -32,7 +32,7 @@ func genMergeJoinBase(wr io.Writer) error {
 	// Replace the template variables.
 	s = strings.Replace(s, "_GOTYPE", "{{.LTyp.GoTypeName}}", -1)
 	s = strings.Replace(s, "_TYPES_T", "coltypes.{{.LTyp}}", -1)
-	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "TemplateType", "{{.LTyp}}", -1)
 
 	assignEqRe := makeFunctionRegex("_ASSIGN_EQ", 3)
 	s = assignEqRe.ReplaceAllString(s, makeTemplateFunctionCall("Assign", 3))

--- a/pkg/sql/colexec/execgen/cmd/execgen/mergejoiner_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/mergejoiner_gen.go
@@ -64,7 +64,7 @@ func genMergeJoinOps(wr io.Writer, jti joinTypeInfo) error {
 	s = strings.Replace(s, "_GOTYPESLICE", "{{.LTyp.GoTypeSliceName}}", -1)
 	s = strings.Replace(s, "_GOTYPE", "{{.LTyp.GoTypeName}}", -1)
 	s = strings.Replace(s, "_TYPES_T", "coltypes.{{.LTyp}}", -1)
-	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "TemplateType", "{{.LTyp}}", -1)
 	s = strings.Replace(s, "_L_SEL_IND", "{{$sel.LSelString}}", -1)
 	s = strings.Replace(s, "_R_SEL_IND", "{{$sel.RSelString}}", -1)
 	s = strings.Replace(s, "_IS_L_SEL", "{{$sel.IsLSel}}", -1)

--- a/pkg/sql/colexec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/projection_ops_gen.go
@@ -79,11 +79,13 @@ func replaceProjConstTmplVariables(tmpl string, isConstLeft bool) string {
 		tmpl = strings.Replace(tmpl, "_CONST_SIDE", "L", -1)
 		tmpl = strings.Replace(tmpl, "_IS_CONST_LEFT", "true", -1)
 		tmpl = strings.Replace(tmpl, "_OP_CONST_NAME", "proj{{.Name}}{{.LTyp}}Const{{.RTyp}}Op", -1)
+		tmpl = strings.Replace(tmpl, "_NON_CONST_GOTYPESLICE", "{{.RTyp.GoTypeSliceName}}", -1)
 		tmpl = replaceManipulationFuncs(".RTyp", tmpl)
 	} else {
 		tmpl = strings.Replace(tmpl, "_CONST_SIDE", "R", -1)
 		tmpl = strings.Replace(tmpl, "_IS_CONST_LEFT", "false", -1)
 		tmpl = strings.Replace(tmpl, "_OP_CONST_NAME", "proj{{.Name}}{{.LTyp}}{{.RTyp}}ConstOp", -1)
+		tmpl = strings.Replace(tmpl, "_NON_CONST_GOTYPESLICE", "{{.LTyp.GoTypeSliceName}}", -1)
 		tmpl = replaceManipulationFuncs(".LTyp", tmpl)
 	}
 	return replaceProjTmplVariables(tmpl)

--- a/pkg/sql/colexec/execgen/cmd/execgen/rowstovec_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/rowstovec_gen.go
@@ -57,7 +57,7 @@ func genRowsToVec(wr io.Writer) error {
 	s := string(f)
 
 	// Replace the template variables.
-	s = strings.Replace(s, "_TemplateType", "{{.ExecType.String}}", -1)
+	s = strings.Replace(s, "TemplateType", "{{.ExecType.String}}", -1)
 	s = strings.Replace(s, "_GOTYPE", "{{.ExecType.GoTypeName}}", -1)
 	s = strings.Replace(s, "_FAMILY", "types.{{.Family}}", -1)
 	s = strings.Replace(s, "_WIDTH", "{{.Width}}", -1)

--- a/pkg/sql/colexec/execgen/cmd/execgen/select_in_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/select_in_gen.go
@@ -33,7 +33,7 @@ func genSelectIn(wr io.Writer) error {
 	s = assignEq.ReplaceAllString(s, makeTemplateFunctionCall("Assign", 3))
 	s = strings.Replace(s, "_GOTYPE", "{{.LGoType}}", -1)
 	s = strings.Replace(s, "_TYPE", "{{.LTyp}}", -1)
-	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "TemplateType", "{{.LTyp}}", -1)
 
 	s = replaceManipulationFuncs(".LTyp", s)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/sort_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/sort_gen.go
@@ -52,7 +52,7 @@ func genSortOps(wr io.Writer) error {
 	s = strings.Replace(s, "_TYPE", "{{$typ}}", -1)
 	s = strings.Replace(s, "_DIR_ENUM", "{{.Dir}}", -1)
 	s = strings.Replace(s, "_DIR", "{{.DirString}}", -1)
-	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "TemplateType", "{{.LTyp}}", -1)
 	s = strings.Replace(s, "_ISNULL", "{{$isNull}}", -1)
 	s = strings.Replace(s, "_HANDLES_NULLS", "{{if .Nulls}}WithNulls{{else}}{{end}}", -1)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/sum_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/sum_agg_gen.go
@@ -32,7 +32,7 @@ func genSumAgg(wr io.Writer) error {
 	s = strings.Replace(s, "_GOTYPE", "{{.LTyp.GoTypeName}}", -1)
 	s = strings.Replace(s, "_TYPES_T", "coltypes.{{.LTyp}}", -1)
 	s = strings.Replace(s, "_TYPE", "{{.LTyp}}", -1)
-	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "TemplateType", "{{.LTyp}}", -1)
 
 	assignAddRe := makeFunctionRegex("_ASSIGN_ADD", 3)
 	s = assignAddRe.ReplaceAllString(s, makeTemplateFunctionCall("Global.Assign", 3))

--- a/pkg/sql/colexec/execgen/cmd/execgen/values_differ_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/values_differ_gen.go
@@ -33,7 +33,7 @@ func genValuesDiffer(wr io.Writer) error {
 	s = strings.Replace(s, "_GOTYPE", "{{.LTyp.GoTypeName}}", -1)
 	s = strings.Replace(s, "_TYPES_T", "coltypes.{{.LTyp}}", -1)
 	s = strings.Replace(s, "_TYPE", "{{.LTyp}}", -1)
-	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "TemplateType", "{{.LTyp}}", -1)
 
 	assignNeRe := makeFunctionRegex("_ASSIGN_NE", 3)
 	s = assignNeRe.ReplaceAllString(s, makeTemplateFunctionCall("Assign", 3))

--- a/pkg/sql/colexec/execgen/cmd/execgen/vec_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/vec_gen.go
@@ -32,7 +32,7 @@ func genVec(wr io.Writer) error {
 	// Replace the template variables.
 	s = strings.Replace(s, "_GOTYPE", "{{.LTyp.GoTypeName}}", -1)
 	s = strings.Replace(s, "_TYPES_T", "coltypes.{{.LTyp}}", -1)
-	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "TemplateType", "{{.LTyp}}", -1)
 	s = replaceManipulationFuncs(".LTyp", s)
 
 	copyWithSel := makeFunctionRegex("_COPY_WITH_SEL", 6)

--- a/pkg/sql/colexec/hash_aggregator_tmpl.go
+++ b/pkg/sql/colexec/hash_aggregator_tmpl.go
@@ -155,8 +155,8 @@ func (v hashAggFuncs) match(
 			switch typeconv.FromColumnType(&keyTyp) {
 			// {{range .}}
 			case _TYPES_T:
-				lhsCol := lhs._TemplateType()
-				rhsCol := rhs._TemplateType()
+				lhsCol := lhs.TemplateType()
+				rhsCol := rhs.TemplateType()
 				if lhsHasNull {
 					lhsNull := lhs.Nulls().NullAt(v.keyIdx)
 					if rhsHasNull {

--- a/pkg/sql/colexec/hash_utils_tmpl.go
+++ b/pkg/sql/colexec/hash_utils_tmpl.go
@@ -81,12 +81,13 @@ func _REHASH_BODY(
 	// {{ else }}
 	_ = execgen.UNSAFEGET(keys, nKeys-1)
 	// {{ end }}
+	var selIdx int
 	for i := 0; i < nKeys; i++ {
 		cancelChecker.check(ctx)
 		// {{ if .HasSel }}
-		selIdx := sel[i]
+		selIdx = sel[i]
 		// {{ else }}
-		selIdx := i
+		selIdx = i
 		// {{ end }}
 		// {{ if .HasNulls }}
 		if nulls.NullAt(selIdx) {
@@ -121,7 +122,7 @@ func rehash(
 	switch typeconv.FromColumnType(t) {
 	// {{range $hashType := .}}
 	case _TYPES_T:
-		keys, nulls := col._TemplateType(), col.Nulls()
+		keys, nulls := col.TemplateType(), col.Nulls()
 		if col.MaybeHasNulls() {
 			if sel != nil {
 				_REHASH_BODY(ctx, buckets, keys, nulls, nKeys, sel, true, true)

--- a/pkg/sql/colexec/hashtable_tmpl.go
+++ b/pkg/sql/colexec/hashtable_tmpl.go
@@ -74,8 +74,10 @@ func _CHECK_COL_BODY(
 	_USE_BUILD_SEL bool,
 ) { // */}}
 	// {{define "checkColBody" -}}
-	probeIsNull := false
-	buildIsNull := false
+	var (
+		probeIdx, buildIdx       int
+		probeIsNull, buildIsNull bool
+	)
 	// Early bounds check.
 	_ = ht.probeScratch.toCheck[nToCheck-1]
 	for i := uint64(0); i < nToCheck; i++ {
@@ -89,18 +91,18 @@ func _CHECK_COL_BODY(
 			// found.
 
 			// {{if .UseProbeSel}}
-			probeIdx := probeSel[toCheck]
+			probeIdx = probeSel[toCheck]
 			// {{else}}
-			probeIdx := int(toCheck)
+			probeIdx = int(toCheck)
 			// {{end}}
 			/* {{if .ProbeHasNulls }} */
 			probeIsNull = probeVec.Nulls().NullAt(probeIdx)
 			/* {{end}} */
 
 			// {{if .UseBuildSel}}
-			buildIdx := buildSel[keyID-1]
+			buildIdx = buildSel[keyID-1]
 			// {{else}}
-			buildIdx := int(keyID - 1)
+			buildIdx = int(keyID - 1)
 			// {{end}}
 
 			/* {{if .BuildHasNulls }} */

--- a/pkg/sql/colexec/mergejoinbase_tmpl.go
+++ b/pkg/sql/colexec/mergejoinbase_tmpl.go
@@ -110,13 +110,13 @@ func (o *mergeJoinBase) isBufferedGroupFinished(
 			if bufferedGroup.firstTuple[colIdx].Nulls().NullAt(0) {
 				return true
 			}
-			bufferedCol := bufferedGroup.firstTuple[colIdx]._TemplateType()
+			bufferedCol := bufferedGroup.firstTuple[colIdx].TemplateType()
 			prevVal := execgen.UNSAFEGET(bufferedCol, 0)
 			var curVal _GOTYPE
 			if batch.ColVec(int(colIdx)).MaybeHasNulls() && batch.ColVec(int(colIdx)).Nulls().NullAt(tupleToLookAtIdx) {
 				return true
 			}
-			col := batch.ColVec(int(colIdx))._TemplateType()
+			col := batch.ColVec(int(colIdx)).TemplateType()
 			curVal = execgen.UNSAFEGET(col, tupleToLookAtIdx)
 			var match bool
 			_ASSIGN_EQ(match, prevVal, curVal)

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -123,8 +123,8 @@ func _PROBE_SWITCH(
 	switch colType {
 	// {{range $mjOverload := $.Global.MJOverloads }}
 	case _TYPES_T:
-		lKeys := lVec._TemplateType()
-		rKeys := rVec._TemplateType()
+		lKeys := lVec.TemplateType()
+		rKeys := rVec.TemplateType()
 		var lGroup, rGroup group
 		for o.groups.nextGroupInCol(&lGroup, &rGroup) {
 			curLIdx := lGroup.rowStartIdx
@@ -634,9 +634,9 @@ func _LEFT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool)
 	case _TYPES_T:
 		var srcCol _GOTYPESLICE
 		if src != nil {
-			srcCol = src._TemplateType()
+			srcCol = src.TemplateType()
 		}
-		outCol := out._TemplateType()
+		outCol := out.TemplateType()
 		var val _GOTYPE
 		var srcStartIdx int
 
@@ -826,8 +826,8 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) buildLeftBufferedGroup(
 					switch colType {
 					// {{ range $.MJOverloads }}
 					case _TYPES_T:
-						srcCol := src._TemplateType()
-						outCol := out._TemplateType()
+						srcCol := src.TemplateType()
+						outCol := out.TemplateType()
 						var val _GOTYPE
 						// Loop over every row in the group.
 						for ; o.builderState.left.curSrcStartIdx < batchLength; o.builderState.left.curSrcStartIdx++ {
@@ -921,9 +921,9 @@ func _RIGHT_SWITCH(_JOIN_TYPE joinTypeInfo, _HAS_SELECTION bool, _HAS_NULLS bool
 	case _TYPES_T:
 		var srcCol _GOTYPESLICE
 		if src != nil {
-			srcCol = src._TemplateType()
+			srcCol = src.TemplateType()
 		}
-		outCol := out._TemplateType()
+		outCol := out.TemplateType()
 
 		// Loop over every group.
 		for ; o.builderState.right.groupsIdx < len(rightGroups); o.builderState.right.groupsIdx++ {
@@ -1123,8 +1123,8 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) buildRightBufferedGroup(
 						switch colType {
 						// {{range $.MJOverloads }}
 						case _TYPES_T:
-							srcCol := src._TemplateType()
-							outCol := out._TemplateType()
+							srcCol := src.TemplateType()
+							outCol := out.TemplateType()
 
 							// Optimization in the case that group length is 1, use assign
 							// instead of copy.

--- a/pkg/sql/colexec/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_const_ops_tmpl.go
@@ -66,6 +66,9 @@ var _ duration.Duration
 // Dummy import to pull in "coltypes" package.
 var _ coltypes.T
 
+// _NON_CONST_GOTYPESLICE is a template Go type slice variable.
+type _NON_CONST_GOTYPESLICE interface{}
+
 // _ASSIGN is the template function for assigning the first input to the result
 // of computation an operation on the second and the third inputs.
 func _ASSIGN(_, _, _ interface{}) {
@@ -104,10 +107,11 @@ func (p _OP_CONST_NAME) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
+	var col _NON_CONST_GOTYPESLICE
 	// {{if _IS_CONST_LEFT}}
-	col := vec._R_TYP()
+	col = vec._R_TYP()
 	// {{else}}
-	col := vec._L_TYP()
+	col = vec._L_TYP()
 	// {{end}}
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -225,10 +229,14 @@ func GetProjection_CONST_SIDEConstOperator(
 		colIdx:       colIdx,
 		outputIdx:    outputIdx,
 	}
+	var (
+		c   interface{}
+		err error
+	)
 	// {{if _IS_CONST_LEFT}}
-	c, err := getDatumToPhysicalFn(leftType)(constArg)
+	c, err = getDatumToPhysicalFn(leftType)(constArg)
 	// {{else}}
-	c, err := getDatumToPhysicalFn(rightType)(constArg)
+	c, err = getDatumToPhysicalFn(rightType)(constArg)
 	// {{end}}
 	if err != nil {
 		return nil, err

--- a/pkg/sql/colexec/rowstovec_tmpl.go
+++ b/pkg/sql/colexec/rowstovec_tmpl.go
@@ -59,7 +59,7 @@ func _ROWS_TO_COL_VEC(
 	rows sqlbase.EncDatumRows, vec coldata.Vec, columnIdx int, alloc *sqlbase.DatumAlloc,
 ) error { // */}}
 	// {{define "rowsToColVec" -}}
-	col := vec._TemplateType()
+	col := vec.TemplateType()
 	datumToPhysicalFn := getDatumToPhysicalFn(typ)
 	for i := range rows {
 		row := rows[i]

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -210,7 +210,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 		}
 
 		vec := batch.ColVec(si.colIdx)
-		col := vec._TemplateType()
+		col := vec.TemplateType()
 		var idx int
 		n := batch.Length()
 
@@ -280,7 +280,7 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 	}
 
 	vec := batch.ColVec(pi.colIdx)
-	col := vec._TemplateType()
+	col := vec.TemplateType()
 
 	projVec := batch.ColVec(pi.outputIdx)
 	projCol := projVec.Bool()

--- a/pkg/sql/colexec/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/selection_ops_tmpl.go
@@ -85,9 +85,9 @@ func _SEL_CONST_LOOP(_HAS_NULLS bool) { // */}}
 			arg := execgen.UNSAFEGET(col, i)
 			_ASSIGN_CMP(cmp, arg, p.constArg)
 			// {{if _HAS_NULLS}}
-			isNull := nulls.NullAt(i)
+			isNull = nulls.NullAt(i)
 			// {{else}}
-			isNull := false
+			isNull = false
 			// {{end}}
 			if cmp && !isNull {
 				sel[idx] = i
@@ -103,9 +103,9 @@ func _SEL_CONST_LOOP(_HAS_NULLS bool) { // */}}
 			arg := execgen.UNSAFEGET(col, i)
 			_ASSIGN_CMP(cmp, arg, p.constArg)
 			// {{if _HAS_NULLS}}
-			isNull := nulls.NullAt(i)
+			isNull = nulls.NullAt(i)
 			// {{else}}
-			isNull := false
+			isNull = false
 			// {{end}}
 			if cmp && !isNull {
 				sel[idx] = i
@@ -131,9 +131,9 @@ func _SEL_LOOP(_HAS_NULLS bool) { // */}}
 			arg2 := _R_UNSAFEGET(col2, i)
 			_ASSIGN_CMP(cmp, arg1, arg2)
 			// {{if _HAS_NULLS}}
-			isNull := nulls.NullAt(i)
+			isNull = nulls.NullAt(i)
 			// {{else}}
-			isNull := false
+			isNull = false
 			// {{end}}
 			if cmp && !isNull {
 				sel[idx] = i
@@ -157,9 +157,9 @@ func _SEL_LOOP(_HAS_NULLS bool) { // */}}
 			arg2 := _R_UNSAFEGET(col2, i)
 			_ASSIGN_CMP(cmp, arg1, arg2)
 			// {{if _HAS_NULLS}}
-			isNull := nulls.NullAt(i)
+			isNull = nulls.NullAt(i)
 			// {{else}}
-			isNull := false
+			isNull = false
 			// {{end}}
 			if cmp && !isNull {
 				sel[idx] = i
@@ -201,6 +201,7 @@ func (p *_OP_CONST_NAME) Next(ctx context.Context) coldata.Batch {
 	// However, the scratch is not used in all of the selection operators, so
 	// we add this to go around "unused" error.
 	_ = decimalScratch
+	var isNull bool
 	for {
 		batch := p.input.Next(ctx)
 		if batch.Length() == 0 {
@@ -242,6 +243,7 @@ func (p *_OP_NAME) Next(ctx context.Context) coldata.Batch {
 	// However, the scratch is not used in all of the selection operators, so
 	// we add this to go around "unused" error.
 	_ = decimalScratch
+	var isNull bool
 	for {
 		batch := p.input.Next(ctx)
 		if batch.Length() == 0 {

--- a/pkg/sql/colexec/sort_tmpl.go
+++ b/pkg/sql/colexec/sort_tmpl.go
@@ -143,7 +143,7 @@ type sort_TYPE_DIR_HANDLES_NULLSOp struct {
 }
 
 func (s *sort_TYPE_DIR_HANDLES_NULLSOp) init(col coldata.Vec, order []int) {
-	s.sortCol = col._TemplateType()
+	s.sortCol = col.TemplateType()
 	s.nulls = col.Nulls()
 	s.order = order
 }

--- a/pkg/sql/colexec/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/sum_agg_tmpl.go
@@ -90,7 +90,7 @@ var _ aggregateFunc = &sum_TYPEAgg{}
 
 func (a *sum_TYPEAgg) Init(groups []bool, v coldata.Vec) {
 	a.groups = groups
-	a.scratch.vec = v._TemplateType()
+	a.scratch.vec = v.TemplateType()
 	a.scratch.nulls = v.Nulls()
 	a.Reset()
 }
@@ -132,7 +132,7 @@ func (a *sum_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 		return
 	}
 	vec, sel := b.ColVec(int(inputIdxs[0])), b.Selection()
-	col, nulls := vec._TemplateType(), vec.Nulls()
+	col, nulls := vec.TemplateType(), vec.Nulls()
 	if nulls.MaybeHasNulls() {
 		if sel != nil {
 			sel = sel[:inputLen]

--- a/pkg/sql/colexec/values_differ_tmpl.go
+++ b/pkg/sql/colexec/values_differ_tmpl.go
@@ -75,8 +75,8 @@ func valuesDiffer(
 	switch typeconv.FromColumnType(t) {
 	// {{range .}}
 	case _TYPES_T:
-		aCol := aColVec._TemplateType()
-		bCol := bColVec._TemplateType()
+		aCol := aColVec.TemplateType()
+		bCol := bColVec.TemplateType()
 		aNulls := aColVec.Nulls()
 		bNulls := bColVec.Nulls()
 		aNull := aNulls.MaybeHasNulls() && aNulls.NullAt(aValueIdx)

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -411,7 +411,8 @@ func FromFlags(meta Meta, flags ...string) Generator {
 		if !ok {
 			panic(fmt.Sprintf(`generator %s does not accept flags: %v`, meta.Name, flags))
 		}
-		if err := f.Flags().Parse(flags); err != nil {
+		flagsStruct := f.Flags()
+		if err := flagsStruct.Parse(flags); err != nil {
 			panic(fmt.Sprintf(`generator %s parsing flags %v: %v`, meta.Name, flags, err))
 		}
 	}


### PR DESCRIPTION
This commit fixes all compiler warnings that I see in Goland. To get
there it does the following:
1. renames `Vec._TemplateType` to `Vec.TemplateType` so that the method
is considered exported
2. pulls out declaration of local variables outside of templated `if`
blocks
3. breaks up the chained function call to parse flags in `pkg/workload`
and a few other places so that there is an allocation of a struct and we
can call a method on it that has a pointer receiver. It shouldn't matter
for the performance though.

Release note: None