### PR TITLE
kvserver: garbage collect uninitialized replica eventually

### DIFF
--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -160,6 +160,19 @@ func (s *Store) EnqueueRaftUpdateCheck(rangeID roachpb.RangeID) {
 	s.enqueueRaftUpdateCheck(rangeID)
 }
 
+// VisitReplicas invokes the visitor on the Store's Replicas until the visitor returns false.
+// Replicas which are added to the Store after iteration begins may or may not be observed.
+func (s *Store) VisitReplicas(visitor func(*Replica) bool) {
+	v := newStoreReplicaVisitor(s)
+	v.Visit(visitor)
+}
+
+// InOrder tells the visitor to visit replicas in increasing RangeID order.
+func (rs *storeReplicaVisitor) InOrder() *storeReplicaVisitor {
+	rs.ordered = true
+	return rs
+}
+
 func manualQueue(s *Store, q queueImpl, repl *Replica) error {
 	cfg := s.Gossip().GetSystemConfig()
 	if cfg == nil {

--- a/pkg/kv/kvserver/queue_helpers_testutil.go
+++ b/pkg/kv/kvserver/queue_helpers_testutil.go
@@ -34,10 +34,12 @@ func forceScanAndProcess(s *Store, q *baseQueue) error {
 		return errors.Errorf("system config not available in gossip")
 	}
 
-	newStoreReplicaVisitor(s).Visit(func(repl *Replica) bool {
-		q.maybeAdd(context.Background(), repl, s.cfg.Clock.Now())
-		return true
-	})
+	newStoreReplicaVisitor(s).
+		includeUninitialized().
+		Visit(func(repl *Replica) bool {
+			q.maybeAdd(context.Background(), repl, s.cfg.Clock.Now())
+			return true
+		})
 
 	q.DrainQueue(s.stopper)
 	return nil

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -196,7 +196,8 @@ type Replica struct {
 
 	// creatingReplica is set when a replica is created as uninitialized
 	// via a raft message.
-	creatingReplica *roachpb.ReplicaDescriptor
+	creatingReplica  *roachpb.ReplicaDescriptor
+	createdTimestamp hlc.Timestamp
 
 	// Held in read mode during read-only commands. Held in exclusive mode to
 	// prevent read-only commands from executing. Acquired before the embedded
@@ -355,6 +356,11 @@ type Replica struct {
 		// Used to determine whether a replica is new enough that we shouldn't
 		// penalize it for being slightly behind. These field gets cleared out once
 		// we know that the replica has caught up.
+		//
+		// Note that the replica considers itself to be the lastReplicaAdded when it
+		// is uninitialized. This timestamp is used to determine whether an
+		// uninitialized Replica is likely garbage needing to be collected by the
+		// replicaGCQueue.
 		lastReplicaAdded     roachpb.ReplicaID
 		lastReplicaAddedTime time.Time
 		// initialMaxClosed is the initial maxClosed timestamp for the replica as known

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -44,6 +44,19 @@ const (
 	// learned about its promotion but that state shouldn't last long so we
 	// also treat idle replicas in that state as suspect.
 	ReplicaGCQueueSuspectTimeout = 1 * time.Second
+
+	// ReplicaGCQueueUninitializedTimeout is the amount of time from creation
+	// after which an uninitialized Replica should be processed by the queue.
+	// Uninitialized replicas exist while a replica is in the process of receiving
+	// a snapshot. Uninitialized replicas can be orphaned in cases where the
+	// snapshot fails. In some cases those uninitialized replicas will receive
+	// a ReplicaTooOldError in response to a heartbeat but this is not guaranteed.
+	// Furthermore, uninitialized replicas will not campaign and thus will not
+	// be considered suspect.
+	//
+	// This value is chosen conservatively as no snapshot should take this long.
+	// If it does, then it will fail, but that's fine.
+	ReplicaGCQueueUninitializedTimeout = 60 * time.Minute
 )
 
 // Priorities for the replica GC queue.
@@ -89,6 +102,35 @@ type replicaGCQueue struct {
 	*baseQueue
 	metrics ReplicaGCQueueMetrics
 	db      *kv.DB
+	cfg     replicaGCQueueConfig
+}
+
+// replicaGCQueueConfig controls the timeouts used by the queue. It primarily
+// exists so that it can be overridden by testing knobs.
+type replicaGCQueueConfig struct {
+	inactivityThreshold          time.Duration
+	suspectTimeout               time.Duration
+	uninitializedTimeout         time.Duration
+	uninitializedTimeoutOverride func() time.Duration
+}
+
+func makeReplicaGCQueueConfig(knobs *StoreTestingKnobs) replicaGCQueueConfig {
+	cfg := replicaGCQueueConfig{
+		inactivityThreshold:  ReplicaGCQueueInactivityThreshold,
+		suspectTimeout:       ReplicaGCQueueSuspectTimeout,
+		uninitializedTimeout: ReplicaGCQueueUninitializedTimeout,
+	}
+	if knobs != nil {
+		cfg.uninitializedTimeoutOverride = knobs.ReplicaGCQueueUninitializedTimeout
+	}
+	return cfg
+}
+
+func (c replicaGCQueueConfig) getUninitializedTimeout() time.Duration {
+	if c.uninitializedTimeoutOverride != nil {
+		return c.uninitializedTimeoutOverride()
+	}
+	return c.uninitializedTimeout
 }
 
 // newReplicaGCQueue returns a new instance of replicaGCQueue.
@@ -96,21 +138,24 @@ func newReplicaGCQueue(store *Store, db *kv.DB, gossip *gossip.Gossip) *replicaG
 	rgcq := &replicaGCQueue{
 		metrics: makeReplicaGCQueueMetrics(),
 		db:      db,
+		cfg:     makeReplicaGCQueueConfig(store.TestingKnobs()),
 	}
+
 	store.metrics.registry.AddMetricStruct(&rgcq.metrics)
 	rgcq.baseQueue = newBaseQueue(
 		"replicaGC", rgcq, store, gossip,
 		queueConfig{
-			maxSize:                  defaultQueueMaxSize,
-			needsLease:               false,
-			needsRaftInitialized:     true,
-			needsSystemConfig:        false,
-			acceptsUnsplitRanges:     true,
-			processDestroyedReplicas: true,
-			successes:                store.metrics.ReplicaGCQueueSuccesses,
-			failures:                 store.metrics.ReplicaGCQueueFailures,
-			pending:                  store.metrics.ReplicaGCQueuePending,
-			processingNanos:          store.metrics.ReplicaGCQueueProcessingNanos,
+			maxSize:                      defaultQueueMaxSize,
+			needsLease:                   false,
+			needsRaftInitialized:         true,
+			needsSystemConfig:            false,
+			acceptsUnsplitRanges:         true,
+			processDestroyedReplicas:     true,
+			processUninitializedReplicas: true,
+			successes:                    store.metrics.ReplicaGCQueueSuccesses,
+			failures:                     store.metrics.ReplicaGCQueueFailures,
+			pending:                      store.metrics.ReplicaGCQueuePending,
+			processingNanos:              store.metrics.ReplicaGCQueueProcessingNanos,
 		},
 	)
 	return rgcq
@@ -125,33 +170,50 @@ func newReplicaGCQueue(store *Store, db *kv.DB, gossip *gossip.Gossip) *replicaG
 func (rgcq *replicaGCQueue) shouldQueue(
 	ctx context.Context, now hlc.Timestamp, repl *Replica, _ *config.SystemConfig,
 ) (shouldQ bool, prio float64) {
-
 	lastCheck, err := repl.GetLastReplicaGCTimestamp(ctx)
 	if err != nil {
 		log.Errorf(ctx, "could not read last replica GC timestamp: %+v", err)
 		return false, 0
 	}
+	desc := repl.Desc()
 	replDesc, currentMember := repl.Desc().GetReplicaDescriptor(repl.store.StoreID())
-	if !currentMember {
+	if !currentMember && desc.IsInitialized() {
+		// TODO(ajwerner): This case should not happen as of 19.2. Validate that
+		// and remove it.
 		return true, replicaGCPriorityRemoved
 	}
 
 	lastActivity := hlc.Timestamp{
 		WallTime: repl.store.startedAt,
 	}
-
 	if lease, _ := repl.GetLease(); lease.ProposedTS != nil {
 		lastActivity.Forward(*lease.ProposedTS)
 	}
+	if !desc.IsInitialized() {
+		// The replicaID for an uninitialized replica will be the current
+		// replica's ID.
+		replicaID, addedAt := repl.LastReplicaAdded()
+		if replicaID != repl.ReplicaID() {
+			log.Fatalf(ctx, "uninitialized replica did not have itself as the"+
+				" last replica added: %v %v %v", replicaID, addedAt, repl)
+		}
+		lastActivity.Forward(hlc.Timestamp{
+			WallTime: addedAt.UnixNano(),
+		})
+	}
 
-	// It is critical to think of the replica as suspect if it is a learner as
-	// it both shouldn't be a learner for long but will never become a candidate.
-	// It is less critical to consider joint configuration members as suspect
-	// but in cases where a replica is removed but only ever hears about the
-	// command which sets it to VOTER_OUTGOING we would conservatively wait
-	// 10 days before removing the node. Finally we consider replicas which are
-	// VOTER_INCOMING as suspect because no replica should stay in that state for
-	// too long and being conservative here doesn't seem worthwhile.
+	// If a replica has not been initialized we should consider it as suspect if
+	// it has not had recent activity. We expect replicas to become initialized
+	// via a snapshot soon after they are constructed. If not, the uninitialized
+	// replica may become orphaned and will be leaked. It is critical to think of
+	// the replica as suspect if it is a learner as it both shouldn't be a learner
+	// for long but will never become a candidate. It is less critical to consider
+	// joint configuration members as suspect but in cases where a replica is
+	// removed but only ever hears about the command which sets it to
+	// VOTER_OUTGOING we would conservatively wait 10 days before removing the
+	// node. We consider replicas which are VOTER_INCOMING as suspect because no
+	// replica should stay in that state for too long and being conservative here
+	// doesn't seem worthwhile.
 	isSuspect := replDesc.GetType() != roachpb.VOTER_FULL
 	if raftStatus := repl.RaftStatus(); raftStatus != nil {
 		isSuspect = isSuspect ||
@@ -169,32 +231,37 @@ func (rgcq *replicaGCQueue) shouldQueue(
 			}
 		}
 	}
-	return replicaGCShouldQueueImpl(now, lastCheck, lastActivity, isSuspect)
+	return replicaGCShouldQueueImpl(rgcq.cfg, now, lastCheck, lastActivity,
+		isSuspect, desc.IsInitialized())
 }
 
 func replicaGCShouldQueueImpl(
-	now, lastCheck, lastActivity hlc.Timestamp, isSuspect bool,
+	cfg replicaGCQueueConfig,
+	now, lastCheck, lastActivity hlc.Timestamp,
+	isSuspect, isInitialized bool,
 ) (bool, float64) {
-	timeout := ReplicaGCQueueInactivityThreshold
+	timeout := cfg.inactivityThreshold
 	priority := replicaGCPriorityDefault
 
 	if isSuspect {
 		// If the range is suspect (which happens if its former replica set
 		// ignores it), let it expire much earlier.
-		timeout = ReplicaGCQueueSuspectTimeout
+		timeout = cfg.suspectTimeout
 		priority = replicaGCPrioritySuspect
-	} else if now.Less(lastCheck.Add(ReplicaGCQueueInactivityThreshold.Nanoseconds(), 0)) {
-		// Return false immediately if the previous check was less than the
-		// check interval in the past. Note that we don't do this if the
-		// replica is in candidate state, in which case we want to be more
-		// aggressive - a failed rebalance attempt could have checked this
-		// range, and candidate state suggests that a retry succeeded. See
-		// #7489.
+	} else if !isInitialized {
+		timeout = cfg.getUninitializedTimeout()
+		priority = replicaGCPrioritySuspect
+	}
+	if !isSuspect && now.Less(lastCheck.Add(timeout.Nanoseconds(), 0)) {
+		// Return false immediately if the previous check was less than the check
+		// interval in the past. Note that we don't do this if the replica is in
+		// candidate state(suspect), in which case we want to be more aggressive.
+		// A failed rebalance attempt could have checked this range, and candidate
+		// state suggests that a retry succeeded. See #7489.
 		return false, 0
 	}
 
 	shouldQ := lastActivity.Add(timeout.Nanoseconds(), 0).Less(now)
-
 	if !shouldQ {
 		return false, 0
 	}
@@ -206,7 +273,7 @@ func replicaGCShouldQueueImpl(
 // still a member of the range.
 func (rgcq *replicaGCQueue) process(
 	ctx context.Context, repl *Replica, _ *config.SystemConfig,
-) error {
+) (err error) {
 	// Note that the Replicas field of desc is probably out of date, so
 	// we should only use `desc` for its static fields like RangeID and
 	// StartKey (and avoid rng.GetReplica() for the same reason).
@@ -299,10 +366,7 @@ func (rgcq *replicaGCQueue) process(
 		// we pass in the NextReplicaID to detect situations in which the
 		// replica became "non-gc'able" in the meantime by checking (with raftMu
 		// held throughout) whether the replicaID is still smaller than the
-		// NextReplicaID. Given non-zero replica IDs don't change, this is only
-		// possible if we currently think we're processing a pre-emptive snapshot
-		// but discover in RemoveReplica that this range has since been added and
-		// knows that.
+		// NextReplicaID. Given replica IDs don't change, this is not possible.
 		if err := repl.store.RemoveReplica(ctx, repl, nextReplicaID, RemoveOptions{
 			DestroyData: true,
 		}); err != nil {

--- a/pkg/kv/kvserver/replica_gc_queue_test.go
+++ b/pkg/kv/kvserver/replica_gc_queue_test.go
@@ -31,13 +31,16 @@ func TestReplicaGCShouldQueue(t *testing.T) {
 		bTS     = ts(base)
 		cTS     = ts(base + ReplicaGCQueueSuspectTimeout)
 		cTSnext = ts(base + ReplicaGCQueueSuspectTimeout + 1)
+		uTSprev = ts(base + ReplicaGCQueueUninitializedTimeout - 1)
+		uTS     = ts(base + ReplicaGCQueueUninitializedTimeout)
+		uTSnext = ts(base + ReplicaGCQueueUninitializedTimeout + 1)
 		iTSprev = ts(base + ReplicaGCQueueInactivityThreshold - 1)
 		iTS     = ts(base + ReplicaGCQueueInactivityThreshold)
 	)
-
+	cfg := makeReplicaGCQueueConfig(nil)
 	for i, test := range []struct {
 		now, lastCheck, lastActivity hlc.Timestamp
-		isCandidate                  bool
+		isCandidate, isInitialized   bool
 
 		shouldQ  bool
 		priority float64
@@ -45,23 +48,29 @@ func TestReplicaGCShouldQueue(t *testing.T) {
 		// Test outcomes when range is in candidate state.
 
 		// All timestamps current: candidacy plays no role.
-		{now: z, lastCheck: z, lastActivity: z, isCandidate: true, shouldQ: false, priority: 0},
+		{now: z, lastCheck: z, lastActivity: z, isCandidate: true, isInitialized: true, shouldQ: false, priority: 0},
 		// Threshold: no action taken.
-		{now: cTS, lastCheck: z, lastActivity: bTS, isCandidate: true, shouldQ: false, priority: 0},
+		{now: cTS, lastCheck: z, lastActivity: bTS, isCandidate: true, isInitialized: true, shouldQ: false, priority: 0},
 		// Queue with priority.
-		{now: cTSnext, lastCheck: z, lastActivity: bTS, isCandidate: true, shouldQ: true, priority: 1},
+		{now: cTSnext, lastCheck: z, lastActivity: bTS, isCandidate: true, isInitialized: true, shouldQ: true, priority: 1},
 		// Last processed recently: candidate still gets processed eagerly.
-		{now: cTSnext, lastCheck: bTS, lastActivity: z, isCandidate: true, shouldQ: true, priority: 1},
+		{now: cTSnext, lastCheck: bTS, lastActivity: z, isCandidate: true, isInitialized: true, shouldQ: true, priority: 1},
 		// Last processed recently: non-candidate stays put.
-		{now: cTSnext, lastCheck: bTS, lastActivity: z, isCandidate: false, shouldQ: false, priority: 0},
+		{now: cTSnext, lastCheck: bTS, lastActivity: z, isCandidate: false, isInitialized: true, shouldQ: false, priority: 0},
 		// Still no effect until iTS reached.
-		{now: iTSprev, lastCheck: bTS, lastActivity: z, isCandidate: false, shouldQ: false, priority: 0},
-		{now: iTS, lastCheck: bTS, lastActivity: z, isCandidate: true, shouldQ: true, priority: 1},
+		{now: iTSprev, lastCheck: bTS, lastActivity: z, isCandidate: false, isInitialized: true, shouldQ: false, priority: 0},
+		{now: iTS, lastCheck: bTS, lastActivity: z, isCandidate: true, isInitialized: true, shouldQ: true, priority: 1},
 		// Verify again that candidacy increases priority.
-		{now: iTS, lastCheck: bTS, lastActivity: z, isCandidate: false, shouldQ: true, priority: 0},
+		{now: iTS, lastCheck: bTS, lastActivity: z, isCandidate: false, isInitialized: true, shouldQ: true, priority: 0},
+		// Verify that uninitialized replicas will get cleaned up after lastActivity is old enough.
+		{now: uTS, lastCheck: z, lastActivity: bTS, isCandidate: false, isInitialized: false, shouldQ: false, priority: 0},
+		{now: uTSnext, lastCheck: z, lastActivity: bTS, isCandidate: false, isInitialized: false, shouldQ: true, priority: 1},
+		// Verify that uninitialized replicas aren't cleaned up if lastCheck was too recent.
+		{now: uTSprev, lastCheck: bTS, lastActivity: z, isCandidate: false, isInitialized: false, shouldQ: false, priority: 0},
+		{now: uTS, lastCheck: bTS, lastActivity: z, isCandidate: false, isInitialized: false, shouldQ: true, priority: 1},
 	} {
 		if sq, pr := replicaGCShouldQueueImpl(
-			test.now, test.lastCheck, test.lastActivity, test.isCandidate,
+			cfg, test.now, test.lastCheck, test.lastActivity, test.isCandidate, test.isInitialized,
 		); sq != test.shouldQ || pr != test.priority {
 			t.Errorf("%d: %+v: got (%t,%f)", i, test, sq, pr)
 		}

--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -200,6 +200,9 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 		// our state that was tracking it. This is unrelated to managing proposal
 		// quota, but this is a convenient place to do so.
 		if rep.ReplicaID == r.mu.lastReplicaAdded && progress.Match >= commitIndex {
+			if !r.isInitializedRLocked() {
+				panic("here")
+			}
 			r.mu.lastReplicaAdded = 0
 			r.mu.lastReplicaAddedTime = time.Time{}
 		}

--- a/pkg/kv/kvserver/split_trigger_helper.go
+++ b/pkg/kv/kvserver/split_trigger_helper.go
@@ -37,7 +37,7 @@ func (rd *replicaMsgAppDropper) ShouldDrop(startKey roachpb.RKey) (fmt.Stringer,
 	if lhsRepl == nil {
 		return nil, false
 	}
-	lhsRepl.store.gcQueue.AddAsync(context.Background(), lhsRepl, replicaGCPriorityDefault)
+	lhsRepl.store.replicaGCQueue.AddAsync(context.Background(), lhsRepl, replicaGCPriorityDefault)
 	return lhsRepl, true
 }
 

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -235,6 +235,8 @@ type StoreTestingKnobs struct {
 	// RangeFeedPushTxnsAge overrides the default value for
 	// rangefeed.Config.PushTxnsAge.
 	RangeFeedPushTxnsAge time.Duration
+	// ReplicaGCQueueSuspectTimeout overrides the constant of the same name.
+	ReplicaGCQueueUninitializedTimeout func() time.Duration
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
We recently saw an abandoned "leaked" uninitialized replica on a 19.2 node.
The unfortunate truth is in that version we aren't sure of its replica ID and
thus can't remove it. In 20.1 and later we can remove uninitialized replicas
(see #44615). Much of the time, uninitialized replicas are removed either
because the range is re-added to the store at a higher replica ID or because
the node receives a ReplicaTooOldError which leads to the removal.

The replicaGCQueue is the obvious tool to remove "leaked" uninitialized
replicas. This commit has to do some work to allow that queue the opportunity
to interact with uninitialized replicas.

There are at least two cases where such replicas can certainly come to exist
The first is when a split is rapidly followed by a removal of both the LHS and
RHS but the LHS never processes the split because it receives a
ReplicaTooOldError. The second is when a snapshot to add a learner fails but
the learner never discovers that it has been removed.

Release note (bug fix): Garbage collect abandoned, uninitialized replicas rather than leaking them until the process restarts.