### PR TITLE
storage: populate remaining Pebble EnvStats

### DIFF
--- a/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/baseccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl/enginepbccl"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -26,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
 )
 
@@ -218,15 +220,22 @@ func TestPebbleEncryption(t *testing.T) {
 			Opts: opts,
 		})
 	require.NoError(t, err)
-	// Only exercising the stats code paths and not checking the returned values.
-	// TODO(sbhola): Make this better once stats are complete. Also ensure that we are
-	// not returning the secret data keys by mistake.
+	// TODO(sbhola): Ensure that we are not returning the secret data keys by mistake.
 	r, err := db.GetEncryptionRegistries()
 	require.NoError(t, err)
 	t.Logf("FileRegistry:\n%s\n\n", r.FileRegistry)
 	t.Logf("KeyRegistry:\n%s\n\n", r.KeyRegistry)
+
 	stats, err := db.GetEnvStats()
 	require.NoError(t, err)
+	// Opening the DB should've created OPTIONS, CURRENT, MANIFEST and the
+	// WAL, all under the active key.
+	require.Equal(t, uint64(4), stats.TotalFiles)
+	require.Equal(t, uint64(4), stats.ActiveKeyFiles)
+	var s enginepbccl.EncryptionStatus
+	require.NoError(t, proto.UnmarshalText(string(stats.EncryptionStatus), &s))
+	require.Equal(t, "16.key", s.ActiveStoreKey.Source)
+	require.Equal(t, int32(enginepbccl.EncryptionType_AES128_CTR), stats.EncryptionType)
 	t.Logf("EnvStats:\n%+v\n\n", *stats)
 
 	batch := db.NewWriteOnlyBatch()
@@ -258,5 +267,14 @@ func TestPebbleEncryption(t *testing.T) {
 	val, err = db.Get(storage.MVCCKey{Key: roachpb.Key("a")})
 	require.NoError(t, err)
 	require.Equal(t, "a", string(val))
+
+	// Flushing should've created a new sstable under the active key.
+	stats, err = db.GetEnvStats()
+	require.NoError(t, err)
+	require.Equal(t, uint64(5), stats.TotalFiles)
+	require.Equal(t, uint64(5), stats.ActiveKeyFiles)
+	require.Equal(t, stats.TotalBytes, stats.ActiveKeyBytes)
+	t.Logf("EnvStats:\n%+v\n\n", *stats)
+
 	db.Close()
 }

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -18,6 +18,8 @@ import (
 	"io/ioutil"
 	"os"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -28,11 +30,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/bloom"
 	"github.com/cockroachdb/pebble/vfs"
-	"github.com/pkg/errors"
 )
 
 // MVCCKeyCompare compares cockroach keys, including the MVCC timestamps.
@@ -806,14 +808,28 @@ func (p *Pebble) GetEnvStats() (*EnvStats, error) {
 		return nil, err
 	}
 	fr := p.fileRegistry.getRegistryCopy()
-	if fr != nil {
-		stats.TotalFiles = uint64(len(fr.Files))
-	}
 	activeKeyID, err := p.statsHandler.GetActiveDataKeyID()
 	if err != nil {
 		return nil, err
 	}
-	for _, entry := range fr.Files {
+
+	m := p.db.Metrics()
+	stats.TotalFiles = 3 /* CURRENT, MANIFEST, OPTIONS */
+	stats.TotalFiles += uint64(m.WAL.Files + m.Table.ZombieCount + m.WAL.ObsoleteFiles)
+	stats.TotalBytes = m.WAL.Size + m.Table.ZombieSize
+	for _, l := range m.Levels {
+		stats.TotalFiles += uint64(l.NumFiles)
+		stats.TotalBytes += l.Size
+	}
+
+	sstSizes := make(map[pebble.FileNum]uint64)
+	for _, ssts := range p.db.SSTables() {
+		for _, sst := range ssts {
+			sstSizes[sst.FileNum] = sst.Size
+		}
+	}
+
+	for filePath, entry := range fr.Files {
 		keyID, err := p.statsHandler.GetKeyIDFromSettings(entry.EncryptionSettings)
 		if err != nil {
 			return nil, err
@@ -821,9 +837,21 @@ func (p *Pebble) GetEnvStats() (*EnvStats, error) {
 		if len(keyID) == 0 {
 			keyID = "plain"
 		}
-		if keyID == activeKeyID {
-			stats.ActiveKeyFiles++
+		if keyID != activeKeyID {
+			continue
 		}
+		stats.ActiveKeyFiles++
+
+		filename := p.fs.PathBase(filePath)
+		numStr := strings.TrimSuffix(filename, ".sst")
+		if len(numStr) == len(filename) {
+			continue // not a sstable
+		}
+		u, err := strconv.ParseUint(numStr, 10, 64)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parsing filename %q", errors.Safe(filename))
+		}
+		stats.ActiveKeyBytes += sstSizes[pebble.FileNum(u)]
 	}
 	return stats, nil
 }


### PR DESCRIPTION
Populate a couple of remaining EnvStats that were unpopulated or
incomplete for Pebble Engines.

Completes #39673.

Release note: None