### PR TITLE
tree: lift name resolution algorithms in tree to operate on `ObjectNames`

### DIFF
--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -63,7 +63,7 @@ type descriptorResolver struct {
 	objsByName map[sqlbase.ID]map[string]sqlbase.ID
 }
 
-// LookupSchema implements the tree.TableNameTargetResolver interface.
+// LookupSchema implements the tree.ObjectNameTargetResolver interface.
 func (r *descriptorResolver) LookupSchema(
 	_ context.Context, dbName, scName string,
 ) (bool, tree.SchemaMeta, error) {
@@ -76,7 +76,7 @@ func (r *descriptorResolver) LookupSchema(
 	return false, nil, nil
 }
 
-// LookupObject implements the tree.TableNameExistingResolver interface.
+// LookupObject implements the tree.ObjectNameExistingResolver interface.
 func (r *descriptorResolver) LookupObject(
 	_ context.Context, flags tree.ObjectLookupFlags, dbName, scName, obName string,
 ) (bool, tree.NameResolutionResult, error) {
@@ -211,7 +211,7 @@ func descriptorsMatchingTargets(
 
 		switch p := pattern.(type) {
 		case *tree.TableName:
-			found, descI, err := p.ResolveExisting(ctx, resolver, tree.ObjectLookupFlags{}, currentDatabase, searchPath)
+			found, descI, err := tree.ResolveExisting(ctx, p, resolver, tree.ObjectLookupFlags{}, currentDatabase, searchPath)
 			if err != nil {
 				return ret, err
 			}

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -276,8 +276,12 @@ func importPlanHook(
 		var parentID sqlbase.ID
 		if table != nil {
 			// We have a target table, so it might specify a DB in its name.
-			found, descI, err := table.ResolveTarget(ctx,
-				p, p.SessionData().Database, p.SessionData().SearchPath)
+			found, descI, err := tree.ResolveTarget(ctx,
+				table,
+				p,
+				p.SessionData().Database,
+				p.SessionData().SearchPath,
+			)
 			if err != nil {
 				return pgerror.Wrap(err, pgcode.UndefinedTable,
 					"resolving target import name")

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -278,7 +278,7 @@ func (r fkResolver) ObjectLookupFlags(required bool, requireMutable bool) tree.O
 	}
 }
 
-// Implements the tree.TableNameExistingResolver interface.
+// Implements the tree.ObjectNameExistingResolver interface.
 func (r fkResolver) LookupObject(
 	ctx context.Context, lookupFlags tree.ObjectLookupFlags, dbName, scName, obName string,
 ) (found bool, objMeta tree.NameResolutionResult, err error) {
@@ -297,7 +297,7 @@ func (r fkResolver) LookupObject(
 	return false, nil, errors.Errorf("referenced table %q not found in tables being imported (%s)", obName, suggestions)
 }
 
-// Implements the tree.TableNameTargetResolver interface.
+// Implements the tree.ObjectNameTargetResolver interface.
 func (r fkResolver) LookupSchema(
 	ctx context.Context, dbName, scName string,
 ) (found bool, scMeta tree.SchemaMeta, err error) {

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -75,7 +75,7 @@ func doCreateSequence(
 	context string,
 	dbDesc *DatabaseDescriptor,
 	schemaID sqlbase.ID,
-	name *ObjectName,
+	name *TableName,
 	isTemporary bool,
 	opts tree.SequenceOptions,
 	jobDesc string,

--- a/pkg/sql/logical_schema_accessors.go
+++ b/pkg/sql/logical_schema_accessors.go
@@ -74,7 +74,7 @@ func (l *LogicalSchemaAccessor) GetObjectDesc(
 	ctx context.Context,
 	txn *kv.Txn,
 	settings *cluster.Settings,
-	name *ObjectName,
+	name *TableName,
 	flags tree.ObjectLookupFlags,
 ) (ObjectDescriptor, error) {
 	if scEntry, ok := l.vt.getVirtualSchemaEntry(name.Schema()); ok {

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -139,8 +139,9 @@ func (oc *optCatalog) ResolveSchema(
 	oc.tn.ObjectName = ""
 	oc.tn.ObjectNamePrefix = *name
 
-	found, desc, err := oc.tn.ResolveTarget(
+	found, desc, err := tree.ResolveTarget(
 		ctx,
+		&oc.tn,
 		oc.planner,
 		oc.planner.CurrentDatabase(),
 		oc.planner.CurrentSearchPath(),

--- a/pkg/sql/physical_schema_accessors.go
+++ b/pkg/sql/physical_schema_accessors.go
@@ -169,7 +169,7 @@ func (a UncachedPhysicalAccessor) GetObjectDesc(
 	ctx context.Context,
 	txn *kv.Txn,
 	settings *cluster.Settings,
-	name *ObjectName,
+	name *TableName,
 	flags tree.ObjectLookupFlags,
 ) (ObjectDescriptor, error) {
 	// Look up the database ID.
@@ -295,7 +295,7 @@ func (a *CachedPhysicalAccessor) GetObjectDesc(
 	ctx context.Context,
 	txn *kv.Txn,
 	settings *cluster.Settings,
-	name *ObjectName,
+	name *TableName,
 	flags tree.ObjectLookupFlags,
 ) (ObjectDescriptor, error) {
 	if flags.RequireMutable {

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -89,7 +89,7 @@ type PlanHookState interface {
 	ResolveUncachedDatabaseByName(
 		ctx context.Context, dbName string, required bool) (*UncachedDatabaseDescriptor, error)
 	ResolveMutableTableDescriptor(
-		ctx context.Context, tn *ObjectName, required bool, requiredType ResolveRequiredType,
+		ctx context.Context, tn *TableName, required bool, requiredType ResolveRequiredType,
 	) (table *MutableTableDescriptor, err error)
 	ShowCreate(
 		ctx context.Context, dbPrefix string, allDescs []sqlbase.Descriptor, desc *sqlbase.TableDescriptor, ignoreFKs shouldOmitFKClausesFromCreate,

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -35,7 +35,10 @@ import (
 type (
 	// ObjectName is provided for convenience and to make the interface
 	// definitions below more intuitive.
-	ObjectName = tree.TableName
+	ObjectName = tree.ObjectName
+	// TableName is provided for convenience and to make the interface
+	// definitions below more intuitive.
+	TableName = tree.TableName
 	// DatabaseDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	DatabaseDescriptor = sqlbase.DatabaseDescriptor
@@ -90,5 +93,5 @@ type SchemaAccessor interface {
 	// descriptor and that of its parent database. If the object is not
 	// found and flags.required is true, an error is returned, otherwise
 	// a nil reference is returned.
-	GetObjectDesc(ctx context.Context, txn *kv.Txn, settings *cluster.Settings, name *ObjectName, flags tree.ObjectLookupFlags) (ObjectDescriptor, error)
+	GetObjectDesc(ctx context.Context, txn *kv.Txn, settings *cluster.Settings, name *TableName, flags tree.ObjectLookupFlags) (ObjectDescriptor, error)
 }

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -237,9 +237,9 @@ func (c *ColumnItem) Resolve(
 	return r.Resolve(ctx, srcName, srcMeta, -1, colName)
 }
 
-// TableNameTargetResolver is the helper interface to resolve table
+// ObjectNameTargetResolver is the helper interface to resolve table
 // names when the object is not expected to exist.
-type TableNameTargetResolver interface {
+type ObjectNameTargetResolver interface {
 	LookupSchema(ctx context.Context, dbName, scName string) (found bool, scMeta SchemaMeta, err error)
 }
 
@@ -249,11 +249,20 @@ type SchemaMeta interface {
 	SchemaMeta()
 }
 
-// TableNameExistingResolver is the helper interface to resolve table
+// ObjectNameExistingResolver is the helper interface to resolve table
 // names when the object is expected to exist already. The boolean passed
 // is used to specify if a MutableTableDescriptor is to be returned in the
 // result.
-type TableNameExistingResolver interface {
+type ObjectNameExistingResolver interface {
+	// TODO (rohany): The intent is to use whether the object being looked up
+	//  is actually a TableName or TypeName to dispatch descriptor lookup
+	//  appropriately. But because this takes in 3 strings, we lose that
+	//  information. So, there are 3 options:
+	//  * Take in what kind of object we want in the flags.
+	//  * Adjust this method into two methods "LookupTable" and "LookupType".
+	//  * Change this method to take in an ObjectName as well (this option isn't
+	//    very clean because the name resolution algorithms below swap out what
+	//    the dbName, scName while doing resolution).
 	LookupObject(ctx context.Context, flags ObjectLookupFlags, dbName, scName, obName string) (
 		found bool, objMeta NameResolutionResult, err error,
 	)
@@ -265,26 +274,28 @@ type NameResolutionResult interface {
 	NameResolutionResult()
 }
 
-// ResolveExisting performs name resolution for a table name when
-// the target object is expected to exist already.
-func (t *TableName) ResolveExisting(
+// ResolveExisting performs name resolution for an object name when
+// the target object is expected to exist already. It modifies the
+// input object name with the result of the name resolution.
+func ResolveExisting(
 	ctx context.Context,
-	r TableNameExistingResolver,
+	obj ObjectName,
+	r ObjectNameExistingResolver,
 	lookupFlags ObjectLookupFlags,
 	curDb string,
 	searchPath sessiondata.SearchPath,
 ) (bool, NameResolutionResult, error) {
-	if t.ExplicitSchema {
+	if obj.HasExplicitSchema() {
 		// pg_temp can be used as an alias for the current sessions temporary schema.
 		// We must perform this resolution before looking up the object. This
 		// resolution only succeeds if the session already has a temporary schema.
-		scName, err := searchPath.MaybeResolveTemporarySchema(t.Schema())
+		scName, err := searchPath.MaybeResolveTemporarySchema(obj.Schema())
 		if err != nil {
 			return false, nil, err
 		}
-		if t.ExplicitCatalog {
+		if obj.HasExplicitCatalog() {
 			// Already 3 parts: nothing to search. Delegate to the resolver.
-			return r.LookupObject(ctx, lookupFlags, t.Catalog(), scName, t.Table())
+			return r.LookupObject(ctx, lookupFlags, obj.Catalog(), scName, obj.Object())
 		}
 		// Two parts: D.T.
 		// Try to use the current database, and be satisfied if it's sufficient to find the object.
@@ -295,18 +306,18 @@ func (t *TableName) ResolveExisting(
 		// pg_catalog.pg_tables` is meant to show all tables across all
 		// databases when there is no current database set.
 
-		if found, objMeta, err := r.LookupObject(ctx, lookupFlags, curDb, scName, t.Table()); found || err != nil {
+		if found, objMeta, err := r.LookupObject(ctx, lookupFlags, curDb, scName, obj.Object()); found || err != nil {
 			if err == nil {
-				t.CatalogName = Name(curDb)
+				obj.SetCatalog(curDb)
 			}
 			return found, objMeta, err
 		}
 		// No luck so far. Compatibility with CockroachDB v1.1: try D.public.T instead.
-		if found, objMeta, err := r.LookupObject(ctx, lookupFlags, t.Schema(), PublicSchema, t.Table()); found || err != nil {
+		if found, objMeta, err := r.LookupObject(ctx, lookupFlags, obj.Schema(), PublicSchema, obj.Object()); found || err != nil {
 			if err == nil {
-				t.CatalogName = t.SchemaName
-				t.SchemaName = PublicSchemaName
-				t.ExplicitCatalog = true
+				obj.SetCatalog(obj.Schema())
+				obj.SetSchema(PublicSchema)
+				obj.SetExplicitCatalog(true)
 			}
 			return found, objMeta, err
 		}
@@ -317,10 +328,10 @@ func (t *TableName) ResolveExisting(
 	// This is a naked table name. Use the search path.
 	iter := searchPath.Iter()
 	for next, ok := iter.Next(); ok; next, ok = iter.Next() {
-		if found, objMeta, err := r.LookupObject(ctx, lookupFlags, curDb, next, t.Table()); found || err != nil {
+		if found, objMeta, err := r.LookupObject(ctx, lookupFlags, curDb, next, obj.Object()); found || err != nil {
 			if err == nil {
-				t.CatalogName = Name(curDb)
-				t.SchemaName = Name(next)
+				obj.SetCatalog(curDb)
+				obj.SetSchema(next)
 			}
 			return found, objMeta, err
 		}
@@ -328,37 +339,42 @@ func (t *TableName) ResolveExisting(
 	return false, nil, nil
 }
 
-// ResolveTarget performs name resolution for a table name when
-// the target object is not expected to exist already.
-func (t *TableName) ResolveTarget(
-	ctx context.Context, r TableNameTargetResolver, curDb string, searchPath sessiondata.SearchPath,
+// ResolveTarget performs name resolution for an object name when
+// the target object is not expected to exist already. It mutates the
+// input object name with the result of the name resolution.
+func ResolveTarget(
+	ctx context.Context,
+	obj ObjectName,
+	r ObjectNameTargetResolver,
+	curDb string,
+	searchPath sessiondata.SearchPath,
 ) (found bool, scMeta SchemaMeta, err error) {
-	if t.ExplicitSchema {
+	if obj.HasExplicitSchema() {
 		// pg_temp can be used as an alias for the current sessions temporary schema.
 		// We must perform this resolution before looking up the object. This
 		// resolution only succeeds if the session already has a temporary schema.
-		scName, err := searchPath.MaybeResolveTemporarySchema(t.Schema())
+		scName, err := searchPath.MaybeResolveTemporarySchema(obj.Schema())
 		if err != nil {
 			return false, nil, err
 		}
-		if t.ExplicitCatalog {
+		if obj.HasExplicitCatalog() {
 			// Already 3 parts: nothing to do.
-			return r.LookupSchema(ctx, t.Catalog(), scName)
+			return r.LookupSchema(ctx, obj.Catalog(), scName)
 		}
 		// Two parts: D.T.
 		// Try to use the current database, and be satisfied if it's sufficient to find the object.
 		if found, scMeta, err = r.LookupSchema(ctx, curDb, scName); found || err != nil {
 			if err == nil {
-				t.CatalogName = Name(curDb)
+				obj.SetCatalog(curDb)
 			}
 			return found, scMeta, err
 		}
 		// No luck so far. Compatibility with CockroachDB v1.1: use D.public.T instead.
-		if found, scMeta, err = r.LookupSchema(ctx, t.Schema(), PublicSchema); found || err != nil {
+		if found, scMeta, err = r.LookupSchema(ctx, obj.Schema(), PublicSchema); found || err != nil {
 			if err == nil {
-				t.CatalogName = t.SchemaName
-				t.SchemaName = PublicSchemaName
-				t.ExplicitCatalog = true
+				obj.SetCatalog(obj.Schema())
+				obj.SetSchema(PublicSchema)
+				obj.SetExplicitCatalog(true)
 			}
 			return found, scMeta, err
 		}
@@ -372,8 +388,8 @@ func (t *TableName) ResolveTarget(
 	for scName, ok := iter.Next(); ok; scName, ok = iter.Next() {
 		if found, scMeta, err = r.LookupSchema(ctx, curDb, scName); found || err != nil {
 			if err == nil {
-				t.CatalogName = Name(curDb)
-				t.SchemaName = Name(scName)
+				obj.SetCatalog(curDb)
+				obj.SetSchema(scName)
 			}
 			break
 		}
@@ -383,36 +399,36 @@ func (t *TableName) ResolveTarget(
 
 // Resolve is used for table prefixes. This is adequate for table
 // patterns with stars, e.g. AllTablesSelector.
-func (tp *ObjectNamePrefix) Resolve(
-	ctx context.Context, r TableNameTargetResolver, curDb string, searchPath sessiondata.SearchPath,
+func (op *ObjectNamePrefix) Resolve(
+	ctx context.Context, r ObjectNameTargetResolver, curDb string, searchPath sessiondata.SearchPath,
 ) (found bool, scMeta SchemaMeta, err error) {
-	if tp.ExplicitSchema {
+	if op.ExplicitSchema {
 		// pg_temp can be used as an alias for the current sessions temporary schema.
 		// We must perform this resolution before looking up the object. This
 		// resolution only succeeds if the session already has a temporary schema.
-		scName, err := searchPath.MaybeResolveTemporarySchema(tp.Schema())
+		scName, err := searchPath.MaybeResolveTemporarySchema(op.Schema())
 		if err != nil {
 			return false, nil, err
 		}
-		if tp.ExplicitCatalog {
+		if op.ExplicitCatalog {
 			// Catalog name is explicit; nothing to do.
-			return r.LookupSchema(ctx, tp.Catalog(), scName)
+			return r.LookupSchema(ctx, op.Catalog(), scName)
 		}
 		// Try with the current database. This may be empty, because
 		// virtual schemas exist even when the db name is empty
 		// (CockroachDB extension).
 		if found, scMeta, err = r.LookupSchema(ctx, curDb, scName); found || err != nil {
 			if err == nil {
-				tp.CatalogName = Name(curDb)
+				op.CatalogName = Name(curDb)
 			}
 			return found, scMeta, err
 		}
 		// No luck so far. Compatibility with CockroachDB v1.1: use D.public.T instead.
-		if found, scMeta, err = r.LookupSchema(ctx, tp.Schema(), PublicSchema); found || err != nil {
+		if found, scMeta, err = r.LookupSchema(ctx, op.Schema(), PublicSchema); found || err != nil {
 			if err == nil {
-				tp.CatalogName = tp.SchemaName
-				tp.SchemaName = PublicSchemaName
-				tp.ExplicitCatalog = true
+				op.CatalogName = op.SchemaName
+				op.SchemaName = PublicSchemaName
+				op.ExplicitCatalog = true
 			}
 			return found, scMeta, err
 		}
@@ -425,8 +441,8 @@ func (tp *ObjectNamePrefix) Resolve(
 	for scName, ok := iter.Next(); ok; scName, ok = iter.Next() {
 		if found, scMeta, err = r.LookupSchema(ctx, curDb, scName); found || err != nil {
 			if err == nil {
-				tp.CatalogName = Name(curDb)
-				tp.SchemaName = Name(scName)
+				op.CatalogName = Name(curDb)
+				op.SchemaName = Name(scName)
 			}
 			break
 		}

--- a/pkg/sql/sem/tree/name_resolution_test.go
+++ b/pkg/sql/sem/tree/name_resolution_test.go
@@ -794,9 +794,9 @@ func TestResolveTablePatternOrName(t *testing.T) {
 				case *tree.TableName:
 					if tc.expected {
 						flags := tree.ObjectLookupFlags{}
-						found, obMeta, err = tpv.ResolveExisting(ctx, fakeResolver, flags, tc.curDb, tc.searchPath)
+						found, obMeta, err = tree.ResolveExisting(ctx, tpv, fakeResolver, flags, tc.curDb, tc.searchPath)
 					} else {
-						found, scMeta, err = tpv.ResolveTarget(ctx, fakeResolver, tc.curDb, tc.searchPath)
+						found, scMeta, err = tree.ResolveTarget(ctx, tpv, fakeResolver, tc.curDb, tc.searchPath)
 					}
 					scPrefix = tpv.Schema()
 					ctPrefix = tpv.Catalog()

--- a/pkg/sql/sem/tree/object_name.go
+++ b/pkg/sql/sem/tree/object_name.go
@@ -10,6 +10,34 @@
 
 package tree
 
+// ObjectName is an interface for operating on names of qualified objects
+// including the types, tables, views and sequences.
+type ObjectName interface {
+	NodeFormatter
+
+	// Set and retrieve the catalog of the object.
+	Catalog() string
+	SetCatalog(string)
+
+	// Set and retrieve the schema of the object.
+	Schema() string
+	SetSchema(string)
+
+	// Retrieve the unqualified name of the object.
+	Object() string
+
+	// Set and retrieve whether or not the object explicitly defines its catalog.
+	HasExplicitCatalog() bool
+	SetExplicitCatalog(bool)
+
+	// Set and retrieve whether or not the object explicitly defines its schema.
+	HasExplicitSchema() bool
+	SetExplicitSchema(bool)
+}
+
+var _ ObjectName = &TableName{}
+var _ ObjectName = &TypeName{}
+
 // objName is the internal type for a qualified object.
 type objName struct {
 	// ObjectName is the unqualified name for the object
@@ -19,6 +47,11 @@ type objName struct {
 	// ObjectNamePrefix is the path to the object.  This can be modified
 	// further by name resolution, see name_resolution.go.
 	ObjectNamePrefix
+}
+
+// Object implements the ObjectName interface.
+func (o *objName) Object() string {
+	return string(o.ObjectName)
 }
 
 // ObjectNamePrefix corresponds to the path prefix of an object name.
@@ -35,25 +68,55 @@ type ObjectNamePrefix struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (tp *ObjectNamePrefix) Format(ctx *FmtCtx) {
+func (op *ObjectNamePrefix) Format(ctx *FmtCtx) {
 	alwaysFormat := ctx.alwaysFormatTablePrefix()
-	if tp.ExplicitSchema || alwaysFormat {
-		if tp.ExplicitCatalog || alwaysFormat {
-			ctx.FormatNode(&tp.CatalogName)
+	if op.ExplicitSchema || alwaysFormat {
+		if op.ExplicitCatalog || alwaysFormat {
+			ctx.FormatNode(&op.CatalogName)
 			ctx.WriteByte('.')
 		}
-		ctx.FormatNode(&tp.SchemaName)
+		ctx.FormatNode(&op.SchemaName)
 	}
 }
 
-func (tp *ObjectNamePrefix) String() string { return AsString(tp) }
+func (op *ObjectNamePrefix) String() string { return AsString(op) }
 
 // Schema retrieves the unqualified schema name.
-func (tp *ObjectNamePrefix) Schema() string {
-	return string(tp.SchemaName)
+func (op *ObjectNamePrefix) Schema() string {
+	return string(op.SchemaName)
+}
+
+// SetSchema implements the ObjectName interface.
+func (op *ObjectNamePrefix) SetSchema(schema string) {
+	op.SchemaName = Name(schema)
+}
+
+// HasExplicitSchema implements the ObjectName interface.
+func (op *ObjectNamePrefix) HasExplicitSchema() bool {
+	return op.ExplicitSchema
+}
+
+// SetExplicitSchema implements the ObjectName interface.
+func (op *ObjectNamePrefix) SetExplicitSchema(val bool) {
+	op.ExplicitSchema = val
 }
 
 // Catalog retrieves the unqualified catalog name.
-func (tp *ObjectNamePrefix) Catalog() string {
-	return string(tp.CatalogName)
+func (op *ObjectNamePrefix) Catalog() string {
+	return string(op.CatalogName)
+}
+
+// SetCatalog implements the ObjectName interface.
+func (op *ObjectNamePrefix) SetCatalog(catalog string) {
+	op.CatalogName = Name(catalog)
+}
+
+// HasExplicitCatalog implements the ObjectName interface.
+func (op *ObjectNamePrefix) HasExplicitCatalog() bool {
+	return op.ExplicitCatalog
+}
+
+// SetExplicitCatalog implements the ObjectName interface.
+func (op *ObjectNamePrefix) SetExplicitCatalog(val bool) {
+	op.ExplicitCatalog = val
 }

--- a/pkg/sql/serial.go
+++ b/pkg/sql/serial.go
@@ -41,13 +41,13 @@ var virtualSequenceOpts = tree.SequenceOptions{
 
 // processSerialInColumnDef analyzes a column definition and determines
 // whether to use a sequence if the requested type is SERIAL-like.
-// If a sequence must be created, it returns an ObjectName to use
+// If a sequence must be created, it returns an TableName to use
 // to create the new sequence and the DatabaseDescriptor of the
 // parent database where it should be created.
 // The ColumnTableDef is not mutated in-place; instead a new one is returned.
 func (p *planner) processSerialInColumnDef(
-	ctx context.Context, d *tree.ColumnTableDef, tableName *ObjectName,
-) (*tree.ColumnTableDef, *DatabaseDescriptor, *ObjectName, tree.SequenceOptions, error) {
+	ctx context.Context, d *tree.ColumnTableDef, tableName *TableName,
+) (*tree.ColumnTableDef, *DatabaseDescriptor, *TableName, tree.SequenceOptions, error) {
 	if !d.IsSerial {
 		// Column is not SERIAL: nothing to do.
 		return d, nil, nil, nil, nil
@@ -156,7 +156,7 @@ func (p *planner) processSerialInColumnDef(
 // This is currently used by bulk I/O import statements which do not
 // (yet?) support customization of the SERIAL behavior.
 func SimplifySerialInColumnDefWithRowID(
-	ctx context.Context, d *tree.ColumnTableDef, tableName *ObjectName,
+	ctx context.Context, d *tree.ColumnTableDef, tableName *TableName,
 ) error {
 	if !d.IsSerial {
 		// Column is not SERIAL: nothing to do.
@@ -182,7 +182,7 @@ func SimplifySerialInColumnDefWithRowID(
 	return nil
 }
 
-func assertValidSerialColumnDef(d *tree.ColumnTableDef, tableName *ObjectName) error {
+func assertValidSerialColumnDef(d *tree.ColumnTableDef, tableName *TableName) error {
 	if d.HasDefaultExpr() {
 		// SERIAL implies a new default expression, we can't have one to
 		// start with. This is the error produced by pg in such case.


### PR DESCRIPTION
The name resolution algorithms in `tree` were functions defined
on `TableName` objects. However, these algorithms aren't unique
to table name resolution and can be reused for type resolution.
To this end, this PR introduces a new interface `ObjectName`
that both `TypeName` and `TableName` ascribe to, and moves the
name resolution algorithms to operate on `ObjectName`.

Another goal is to use the underlying type of an `ObjectName`
to inform downstream logic about what sort of object is being
resolved. As of this PR, nothing different actually needs to be
done yet because type names can't yet be resolved.

Release note: None