### PR TITLE
sql: allow global access for some pg_catalog tables

### DIFF
--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -89,7 +89,7 @@ func (n *DropRoleNode) startExec(params runParams) error {
 	// Now check whether the user still has permission on any object in the database.
 
 	// First check all the databases.
-	if err := forEachDatabaseDesc(params.ctx, params.p, nil, /*nil prefix = all databases*/
+	if err := forEachDatabaseDesc(params.ctx, params.p, nil /*nil prefix = all databases*/, true, /* requiresPrivileges */
 		func(db *sqlbase.DatabaseDescriptor) error {
 			for _, u := range db.GetPrivileges().Users {
 				if _, ok := userNames[u.User]; ok {

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -732,6 +732,18 @@ WHERE collname='en-US'
 oid         collname  collnamespace  collowner  collencoding  collcollate  collctype
 3903121477  en-US     1307062959     NULL       6             NULL         NULL
 
+user testuser
+
+# Should be globally visible
+query OT colnames
+SELECT oid, collname FROM pg_collation
+WHERE collname='en-US'
+----
+oid         collname
+3903121477  en-US
+
+user root
+
 ## pg_catalog.pg_constraint
 ##
 ## These order of this virtual table is non-deterministic, so all queries must
@@ -1288,6 +1300,19 @@ oid    typname        typndims  typcollation  typdefaultbin  typdefault  typacl
 90002  geography      0         0             NULL           NULL        NULL
 90003  _geography     0         0             NULL           NULL        NULL
 
+user testuser
+
+# Should be globally visible
+query OTOIBT colnames
+SELECT oid, typname, typowner, typlen, typbyval, typtype
+FROM pg_catalog.pg_type WHERE typname = 'uuid'
+ORDER BY oid
+----
+oid    typname  typowner  typlen  typbyval  typtype
+2950   uuid     NULL      16      true      b
+
+user root
+
 ## pg_catalog.pg_proc
 
 query TOOOTTO colnames
@@ -1380,6 +1405,19 @@ WHERE proname='json_extract_path'
 ----
 proname            provariadic  pronargs  prorettype  proargtypes  proargmodes
 json_extract_path  25           2         3802        3802 25      {i,v}
+
+user testuser
+
+# Should be globally visible
+query TOIOTT colnames
+SELECT proname, provariadic, pronargs, prorettype, proargtypes, proargmodes
+FROM pg_catalog.pg_proc
+WHERE proname='json_extract_path'
+----
+proname            provariadic  pronargs  prorettype  proargtypes  proargmodes
+json_extract_path  25           2         3802        3802 25      {i,v}
+
+user root
 
 ## pg_catalog.pg_range
 query IIIIII colnames


### PR DESCRIPTION
pg_collation, pg_proc, and pg_type were all
limiting the output to only include rows if the user had any privileges
on the database. In Postgres, this is not required.

Some tables in information_schema still do require the privilege check,
as well as pg_database and pg_namespace.

This commit also includes a small improvement to avoid fetching all
database descriptors unless they are all needed.

fixes #43177

Release note (sql change): The pg_collation, pg_proc, and pg_type tables
in pg_catalog no longer require privileges on any database in order for the
data to be visible.