### PR TITLE
sql: allow rules to be disabled during opsteps execution

### DIFF
--- a/pkg/sql/opt/testutils/opttester/forcing_opt.go
+++ b/pkg/sql/opt/testutils/opttester/forcing_opt.go
@@ -74,6 +74,9 @@ func newForcingOptimizer(
 		if fo.remaining == 0 {
 			return false
 		}
+		if tester.Flags.DisableRules.Contains(int(ruleName)) {
+			return false
+		}
 		fo.remaining--
 		fo.lastMatched = ruleName
 		return true


### PR DESCRIPTION
Previously, optsteps would ignore rules in the DisableRules
set. This allowed supposedly disabled rules to execute
unexpectedly.
This patch prevents the opsteps optimizer from applying a
matched rule that is in the DisabledRules set.

Release note: None