### PR TITLE
ui: CSS modules for Statements filter section

### DIFF
--- a/pkg/ui/.storybook/decorators/withBackground.tsx
+++ b/pkg/ui/.storybook/decorators/withBackground.tsx
@@ -8,5 +8,11 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export * from "./withRouterProvider";
-export * from "./withBackground";
+import React from "react";
+import {RenderFunction} from "storybook__react";
+
+export const withBackgroundFactory = (backgroundColor = "#F5F7FA") => (storyFn: RenderFunction) => (
+  <div style={{backgroundColor}}>
+    {storyFn()}
+  </div>
+);

--- a/pkg/ui/src/views/app/components/Search/index.tsx
+++ b/pkg/ui/src/views/app/components/Search/index.tsx
@@ -13,7 +13,8 @@ import { InputProps } from "antd/lib/input";
 import CancelIcon from "assets/cancel.svg";
 import SearchIcon from "assets/search.svg";
 import React from "react";
-import "./search.styl";
+import classNames from "classnames/bind";
+import styles from "./search.module.styl";
 
 interface ISearchProps {
   onSubmit: (value: string) => void;
@@ -28,6 +29,8 @@ interface ISearchState {
 }
 
 type TSearchProps = ISearchProps & InputProps;
+
+const cx = classNames.bind(styles);
 
 export class Search extends React.Component<TSearchProps, ISearchState> {
   state = {
@@ -62,16 +65,24 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
     const { value, submitted } = this.state;
     if (value.length > 0) {
       if (submitted) {
-        return <Button onClick={this.onClear} type="default" className="_clear-search"><img className="_suffix-icon" src={CancelIcon} /></Button>;
+        return (
+          <Button
+            onClick={this.onClear}
+            type="default"
+            className={cx("_clear-search")}
+          >
+            <img className={cx("_suffix-icon")} src={CancelIcon} />
+          </Button>
+        );
       }
-      return <Button type="default" htmlType="submit" className="_submit-search">Enter</Button>;
+      return <Button type="default" htmlType="submit" className={cx("_submit-search")}>Enter</Button>;
     }
     return null;
   }
 
   render() {
     const { value, submitted } = this.state;
-    const className = submitted ? "_submitted" : "";
+    const className = submitted ? cx("_submitted") : "";
 
     /*
       current antdesign (3.25.3) has Input.d.ts incompatible with latest @types/react
@@ -82,13 +93,13 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
     const MyInput = Input as any;
 
     return (
-      <Form onSubmit={this.onSubmit} className="_search-form">
+      <Form onSubmit={this.onSubmit} className={cx("_search-form")}>
         <Form.Item>
           <MyInput
             className={className}
             placeholder="Search Statement"
             onChange={this.onChange}
-            prefix={<img className="_prefix-icon" src={SearchIcon} />}
+            prefix={<img className={cx("_prefix-icon")} src={SearchIcon} />}
             suffix={this.renderSuffix()}
             value={value}
             {...this.props}

--- a/pkg/ui/src/views/app/components/Search/search.module.styl
+++ b/pkg/ui/src/views/app/components/Search/search.module.styl
@@ -14,12 +14,13 @@
 ._search-form
   width 280px
   height 40px
-  .ant-input-affix-wrapper
+  :global(.ant-input-affix-wrapper)
+    height 40px
     &:hover
-      .ant-input:not(.ant-input-disabled)
+      :global(.ant-input:not(.ant-input-disabled))
         border-color $adminui-blue-1-base
         border-right-width 2px !important
-  .ant-btn
+  :global(.ant-btn)
     margin 0
     padding 0
     width auto
@@ -44,7 +45,7 @@
     line-height 0px !important
     &:hover
       color $adminui-grey-2
-  .ant-input
+  :global(.ant-input)
     font-size 14px
     font-family $font-family--base
     color $adminui-grey-1
@@ -60,6 +61,6 @@
       padding-left 35px
       padding-right 60px
   ._submitted
-    .ant-input
+    :global(.ant-input)
       &:not(:first-child)
         padding-right 40px

--- a/pkg/ui/src/views/app/components/Search/search.stories.tsx
+++ b/pkg/ui/src/views/app/components/Search/search.stories.tsx
@@ -8,5 +8,15 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export * from "./withRouterProvider";
-export * from "./withBackground";
+import React from "react";
+import { storiesOf } from "@storybook/react";
+
+import { Search } from "./index";
+
+storiesOf("Search", module)
+  .add("empty", () => (
+    <Search defaultValue="" onSubmit={() => {}} value="" />
+  ))
+  .add("with search text", () => (
+    <Search defaultValue="select * from" onSubmit={() => {}} value="select * from" />
+  ));

--- a/pkg/ui/src/views/cluster/components/range/index.tsx
+++ b/pkg/ui/src/views/cluster/components/range/index.tsx
@@ -164,7 +164,7 @@ class RangeSelect extends React.Component<RangeSelectProps, RangeSelectState> {
       onClick={this.handleOptionButtonOnClick(option)}
       ghost
     >
-      <span className="dropdown__range-title">{this.props.selected.title !== "Custom" && option.value === "Custom" ? "--" : option.timeLabel}</span>
+      <span className="range__range-title">{this.props.selected.title !== "Custom" && option.value === "Custom" ? "--" : option.timeLabel}</span>
       <span className="__option-label">{option.value === "Custom" ? "Custom date range" : option.value}</span>
     </Button>
   )

--- a/pkg/ui/src/views/cluster/components/range/range.styl
+++ b/pkg/ui/src/views/cluster/components/range/range.styl
@@ -230,3 +230,17 @@
                 border 1px solid $colors--neutral-5
                 &:hover
                   background $background-color
+
+.range__range-title
+  display flex
+  justify-content center
+  align-items center
+  background $colors--neutral-3
+  width 34px
+  text-align center
+  border-radius 3px
+  color $colors--neutral-7
+  font-size 12px
+  line-height 24px
+  letter-spacing 0.1px
+  font-family $font-family--bold

--- a/pkg/ui/src/views/reports/containers/network/filter/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/filter/index.tsx
@@ -20,6 +20,7 @@ interface IFilterProps {
   deselectFilterByKey: (key: string) => void;
   sort: NetworkSort[];
   filter: NetworkFilter;
+  dropDownClassName?: string;
 }
 
 interface IFilterState {
@@ -106,6 +107,7 @@ export class Filter extends React.Component<IFilterProps, IFilterState> {
 
   render() {
     const { opened, width } = this.state;
+    const { dropDownClassName } = this.props;
     const containerLeft = this.rangeContainer.current ? this.rangeContainer.current.getBoundingClientRect().left : 0;
     const left = width >= (containerLeft + 240) ? 0 : width - (containerLeft + 240);
     return (
@@ -114,7 +116,7 @@ export class Filter extends React.Component<IFilterProps, IFilterState> {
           title="Filter"
           options={[]}
           selected=""
-          className={classNames({ "dropdown__focused": opened })}
+          className={classNames({ "dropdown__focused": opened }, dropDownClassName)}
           content={
             <div ref={this.rangeContainer} className="Range">
               <div className="click-zone" onClick={() => this.setState({ opened: !opened })}/>

--- a/pkg/ui/src/views/reports/containers/network/sort/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/sort/index.tsx
@@ -68,8 +68,15 @@ class Sort extends React.Component<ISortProps & RouteComponentProps, {}> {
           options={this.getSortValues(sort)}
           selected={this.pageView()}
           onChange={this.navigateTo}
+          className="Sort-latency__dropdown--spacing"
         />
-        <Filter sort={sort} onChangeFilter={onChangeFilter} deselectFilterByKey={deselectFilterByKey} filter={filter} />
+        <Filter
+          sort={sort}
+          onChangeFilter={onChangeFilter}
+          deselectFilterByKey={deselectFilterByKey}
+          filter={filter}
+          dropDownClassName="Sort-latency__dropdown--spacing"
+        />
         <Divider type="vertical" style={{ height: "100%" }} />
         <Checkbox disabled={!nodeId || nodeId === "cluster"} checked={collapsed} onChange={this.onChange}>Collapse Nodes</Checkbox>
       </div>

--- a/pkg/ui/src/views/reports/containers/network/sort/sort.styl
+++ b/pkg/ui/src/views/reports/containers/network/sort/sort.styl
@@ -12,6 +12,6 @@
   display flex
   align-items center
   padding 0 24px
-  .dropdown
-    margin-right 24px
-  
+
+.Sort-latency__dropdown--spacing
+  margin-right 24px

--- a/pkg/ui/src/views/shared/components/dropdown/dropdown.module.styl
+++ b/pkg/ui/src/views/shared/components/dropdown/dropdown.module.styl
@@ -28,14 +28,14 @@ $dropdown-hover-color = darken($background-color, 2.5%)
   display flex
   align-items center
 
-  .Select
+  :global(.Select)
     position initial
 
-  .Select-menu-outer
+  :global(.Select-menu-outer)
     top calc(100% + 8px)
     padding 8px 0
 
-  .Select-option
+  :global(.Select-option)
     font-size 14px
     line-height 22px
     font-family $font-family--base
@@ -45,7 +45,7 @@ $dropdown-hover-color = darken($background-color, 2.5%)
       color $colors--primary-blue-3 !important
       background-color transparent
 
-  .dropdown__title, .Select-value-label
+  .dropdown__title, :global(.Select-value-label)
     color $adminui-grey-1 !important
     font-family SourceSansPro-SemiBold
     font-size 14px
@@ -53,7 +53,7 @@ $dropdown-hover-color = darken($background-color, 2.5%)
     letter-spacing 0.1px
 
   &:hover
-    .Select-arrow-zone
+    :global(.Select-arrow-zone)
       path
         fill $colors--neutral-5
 
@@ -74,7 +74,7 @@ $dropdown-hover-color = darken($background-color, 2.5%)
       border 1px solid $colors--primary-blue-3 
       box-shadow 0px 0px 3px 2px $colors--primary-blue-1
 
-  .Select-arrow-zone
+  :global(.Select-arrow-zone)
     color $adminui-blue-1-base
     .caret-down
       display flex
@@ -163,7 +163,7 @@ $dropdown-hover-color = darken($background-color, 2.5%)
       &:hover
         background-color $dropdown-hover-color
 .dropdown.full-size
-  .Select-menu-outer, .Select-menu
+  :global(.Select-menu-outer), :global(.Select-menu)
     max-height 450px
 
 // NOTE: react-select styles can be found in styl/shame.styl

--- a/pkg/ui/src/views/shared/components/dropdown/index.tsx
+++ b/pkg/ui/src/views/shared/components/dropdown/index.tsx
@@ -8,12 +8,12 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import classNames from "classnames";
+import classNames from "classnames/bind";
 import Select from "react-select";
 import React from "react";
 import _ from "lodash";
 
-import "./dropdown.styl";
+import styles from "./dropdown.module.styl";
 
 import {leftArrow, rightArrow} from "src/views/shared/components/icons";
 import { trustIcon } from "src/util/trust";
@@ -45,7 +45,17 @@ interface DropdownOwnProps {
   type?: "primary" | "secondary";
 }
 
-export const arrowRenderer = ({ isOpen }: { isOpen: boolean }) => <span className={classNames("caret-down", { "active": isOpen })}><CaretDown /></span>;
+const cx = classNames.bind(styles);
+
+export const arrowRenderer = ({ isOpen }: { isOpen: boolean }) =>
+  <span
+    className={cx(
+      "caret-down",
+      { active: isOpen },
+    )}
+  >
+    <CaretDown />
+  </span>;
 
 /**
  * Dropdown component that uses the URL query string for state.
@@ -85,20 +95,27 @@ export default class Dropdown extends React.Component<DropdownOwnProps, {}> {
   render() {
     const { selected, options, onChange, onArrowClick, disabledArrows, content, isTimeRange, type = "secondary" } = this.props;
 
-    const className = classNames(
+    const className = cx(
       "dropdown",
       `dropdown--type-${type}`,
-      isTimeRange ? "_range" : "",
-      { "dropdown--side-arrows": !_.isNil(onArrowClick), "dropdown__focused": this.state.is_focused },
+      {
+        "_range": isTimeRange,
+        "dropdown--side-arrows": !_.isNil(onArrowClick),
+        "dropdown__focused": this.state.is_focused,
+      },
       this.props.className,
     );
-    const leftClassName = classNames(
+    const leftClassName = cx(
       "dropdown__side-arrow",
-      { "dropdown__side-arrow--disabled": _.includes(disabledArrows, ArrowDirection.LEFT) },
+      {
+        "dropdown__side-arrow--disabled": _.includes(disabledArrows, ArrowDirection.LEFT),
+      },
     );
-    const rightClassName = classNames(
+    const rightClassName = cx(
       "dropdown__side-arrow",
-      { "dropdown__side-arrow--disabled": _.includes(disabledArrows, ArrowDirection.RIGHT) },
+      {
+        "dropdown__side-arrow--disabled": _.includes(disabledArrows, ArrowDirection.RIGHT),
+      },
     );
 
     return <div className={className} onClick={this.triggerSelectClick} ref={this.dropdownRef}>
@@ -109,12 +126,15 @@ export default class Dropdown extends React.Component<DropdownOwnProps, {}> {
         onClick={() => this.props.onArrowClick(ArrowDirection.LEFT)}>
       </span>
       <span
-        className={isTimeRange ? "dropdown__range-title" : "dropdown__title"}
+        className={cx({
+          "dropdown__range-title": isTimeRange,
+          "dropdown__title": !isTimeRange,
+        })}
         ref={this.titleRef}>
           {this.props.title}{this.props.title && !isTimeRange ? ":" : ""}
       </span>
       {content ? content : <Select
-        className="dropdown__select"
+        className={cx("dropdown__select")}
         arrowRenderer={arrowRenderer}
         clearable={false}
         searchable={false}

--- a/pkg/ui/src/views/shared/components/pageconfig/index.tsx
+++ b/pkg/ui/src/views/shared/components/pageconfig/index.tsx
@@ -8,22 +8,25 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import classnames from "classnames";
+import classnames from "classnames/bind";
 import React from "react";
+import styles from "./pageConfig.module.styl";
 
 export interface PageConfigProps {
   layout?: "list" | "spread";
   children?: React.ReactNode;
 }
 
+const cx = classnames.bind(styles);
+
 export function PageConfig(props: PageConfigProps) {
-  const classes = classnames({
+  const classes = cx({
     "page-config__list": props.layout !== "spread",
     "page-config__spread": props.layout === "spread",
   });
 
   return (
-    <div className="page-config">
+    <div className={cx("page-config")}>
       <ul className={ classes }>
         { props.children }
       </ul>
@@ -37,7 +40,7 @@ export interface PageConfigItemProps {
 
 export function PageConfigItem(props: PageConfigItemProps) {
   return (
-    <li className="page-config__item">
+    <li className={cx("page-config__item")}>
       { props.children }
     </li>
   );

--- a/pkg/ui/src/views/shared/components/pageconfig/pageConfig.module.styl
+++ b/pkg/ui/src/views/shared/components/pageconfig/pageConfig.module.styl
@@ -1,0 +1,46 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@require '~styl/base/palette.styl'
+@require '~styl/base/layout-vars.styl'
+
+.page-config
+  padding-left 24px
+  // Stick to the top.
+  position sticky
+  position -webkit-sticky
+  top 0
+  // We want 10px of spacing above and below this div when
+  // it's fixed during scrolling, but not when the page
+  // is scrolled to the top. This combination of padding
+  // and negative margins achieves that.
+  padding-bottom 10px
+  padding-top 10px
+  margin-bottom -10px
+  margin-top -10px
+
+  z-index $z-index-page-config
+  background-color $background-color
+
+  &__list
+    display flex
+    justify-content flex-start
+    align-items center
+
+    .page-config__item
+      margin-right 24px
+
+  &__spread
+    display flex
+    justify-content space-between
+    align-items center
+
+  &__item
+    list-style none

--- a/pkg/ui/src/views/statements/statementsPage.stories.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.stories.tsx
@@ -11,12 +11,13 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 
-import { withRouterProvider } from ".storybook/decorators";
+import {withBackgroundFactory, withRouterProvider} from ".storybook/decorators";
 import { StatementsPage } from "./statementsPage";
 import statementsPagePropsFixture from "./statementsPage.fixture";
 
 storiesOf("StatementsPage", module)
   .addDecorator(withRouterProvider)
+  .addDecorator(withBackgroundFactory())
   .add("with data", () => (
     <StatementsPage {...statementsPagePropsFixture}/>
   ));


### PR DESCRIPTION
Depends on #47606
Related to #47527

This change refactors following components to
use CSS modules instead of styles defined as
global:
- Dropdown
- Search
- PageConfig

Release note: None