### PR TITLE
builtins: implement swathe of I/O functions for Geometry/Geography

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -666,6 +666,38 @@ has no relationship with the commit order of concurrent transactions.</p>
 <tbody>
 <tr><td><a name="st_area"></a><code>st_area(geometry_a: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the area of geometry_a</p>
 </span></td></tr>
+<tr><td><a name="st_asbinary"></a><code>st_asbinary(geography: geography) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns the WKB representation of a given Geography.</p>
+</span></td></tr>
+<tr><td><a name="st_asbinary"></a><code>st_asbinary(geometry: geometry) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns the WKB representation of a given Geometry.</p>
+</span></td></tr>
+<tr><td><a name="st_asewkb"></a><code>st_asewkb(geography: geography) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns the EWKB representation of a given Geography.</p>
+</span></td></tr>
+<tr><td><a name="st_asewkb"></a><code>st_asewkb(geometry: geometry) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns the EWKB representation of a given Geometry.</p>
+</span></td></tr>
+<tr><td><a name="st_asewkt"></a><code>st_asewkt(geography: geography) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the EWKT representation of a given Geography.</p>
+</span></td></tr>
+<tr><td><a name="st_asewkt"></a><code>st_asewkt(geometry: geometry) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the EWKT representation of a given Geometry.</p>
+</span></td></tr>
+<tr><td><a name="st_asgeojson"></a><code>st_asgeojson(geography: geography) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the GeoJSON representation of a given Geography.</p>
+</span></td></tr>
+<tr><td><a name="st_asgeojson"></a><code>st_asgeojson(geometry: geometry) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the GeoJSON representation of a given Geometry.</p>
+</span></td></tr>
+<tr><td><a name="st_ashexewkb"></a><code>st_ashexewkb(geography: geography) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the EWKB representation in hex of a given Geography.</p>
+</span></td></tr>
+<tr><td><a name="st_ashexewkb"></a><code>st_ashexewkb(geometry: geometry) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the EWKB representation in hex of a given Geometry.</p>
+</span></td></tr>
+<tr><td><a name="st_ashexwkb"></a><code>st_ashexwkb(geography: geography) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the WKB representation in hex of a given Geography.</p>
+</span></td></tr>
+<tr><td><a name="st_ashexwkb"></a><code>st_ashexwkb(geometry: geometry) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the WKB representation in hex of a given Geometry.</p>
+</span></td></tr>
+<tr><td><a name="st_askml"></a><code>st_askml(geography: geography) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the KML representation of a given Geography.</p>
+</span></td></tr>
+<tr><td><a name="st_askml"></a><code>st_askml(geometry: geometry) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the KML representation of a given Geometry.</p>
+</span></td></tr>
+<tr><td><a name="st_astext"></a><code>st_astext(geography: geography) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the WKT representation of a given Geography.</p>
+</span></td></tr>
+<tr><td><a name="st_astext"></a><code>st_astext(geometry: geometry) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the WKT representation of a given Geometry.</p>
+</span></td></tr>
 <tr><td><a name="st_contains"></a><code>st_contains(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if no points of geometry_b lie in the exterior of geometry_a, and there is at least one point in the interior of geometry_b that lies in the interior of geometry_a.</p>
 <p>This function uses the GEOS module.</p>
 <p>This function will automatically use any available index.</p>
@@ -685,6 +717,46 @@ has no relationship with the commit order of concurrent transactions.</p>
 <tr><td><a name="st_equals"></a><code>st_equals(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_a is spatially equal to geometry_b, i.e. ST_Within(geometry_a, geometry_b) = ST_Within(geometry_b, geometry_a) = true.</p>
 <p>This function uses the GEOS module.</p>
 <p>This function will automatically use any available index.</p>
+</span></td></tr>
+<tr><td><a name="st_geogfromewkb"></a><code>st_geogfromewkb(val: <a href="bytes.html">bytes</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns the Geography from an EWKB representation.</p>
+</span></td></tr>
+<tr><td><a name="st_geogfromewkt"></a><code>st_geogfromewkt(val: <a href="string.html">string</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns the Geography from an EWKT representation.</p>
+</span></td></tr>
+<tr><td><a name="st_geogfromgeojson"></a><code>st_geogfromgeojson(val: <a href="string.html">string</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns the Geography from an GeoJSON representation.</p>
+</span></td></tr>
+<tr><td><a name="st_geogfromgeojson"></a><code>st_geogfromgeojson(val: jsonb) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns the Geography from an GeoJSON representation.</p>
+</span></td></tr>
+<tr><td><a name="st_geogfromtext"></a><code>st_geogfromtext(str: <a href="string.html">string</a>, srid: <a href="int.html">int</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns the Geography from a WKT or EWKT representation with an SRID. If the SRID is present in both the EWKT and the argument, the argument value is used.</p>
+</span></td></tr>
+<tr><td><a name="st_geogfromtext"></a><code>st_geogfromtext(val: <a href="string.html">string</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns the Geography from a WKT or EWKT representation.</p>
+</span></td></tr>
+<tr><td><a name="st_geogfromwkb"></a><code>st_geogfromwkb(bytes: <a href="bytes.html">bytes</a>, srid: <a href="int.html">int</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns the Geography from a WKB representation with the given SRID set.</p>
+</span></td></tr>
+<tr><td><a name="st_geogfromwkb"></a><code>st_geogfromwkb(val: <a href="bytes.html">bytes</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns the Geography from a WKB representation.</p>
+</span></td></tr>
+<tr><td><a name="st_geographyfromtext"></a><code>st_geographyfromtext(str: <a href="string.html">string</a>, srid: <a href="int.html">int</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns the Geography from a WKT or EWKT representation with an SRID. If the SRID is present in both the EWKT and the argument, the argument value is used.</p>
+</span></td></tr>
+<tr><td><a name="st_geographyfromtext"></a><code>st_geographyfromtext(val: <a href="string.html">string</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns the Geography from a WKT or EWKT representation.</p>
+</span></td></tr>
+<tr><td><a name="st_geometryfromtext"></a><code>st_geometryfromtext(str: <a href="string.html">string</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation with an SRID. If the SRID is present in both the EWKT and the argument, the argument value is used.</p>
+</span></td></tr>
+<tr><td><a name="st_geometryfromtext"></a><code>st_geometryfromtext(val: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation.</p>
+</span></td></tr>
+<tr><td><a name="st_geomfromewkb"></a><code>st_geomfromewkb(val: <a href="bytes.html">bytes</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from an EWKB representation.</p>
+</span></td></tr>
+<tr><td><a name="st_geomfromewkt"></a><code>st_geomfromewkt(val: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from an EWKT representation.</p>
+</span></td></tr>
+<tr><td><a name="st_geomfromgeojson"></a><code>st_geomfromgeojson(val: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from an GeoJSON representation.</p>
+</span></td></tr>
+<tr><td><a name="st_geomfromgeojson"></a><code>st_geomfromgeojson(val: jsonb) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from an GeoJSON representation.</p>
+</span></td></tr>
+<tr><td><a name="st_geomfromtext"></a><code>st_geomfromtext(str: <a href="string.html">string</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation with an SRID. If the SRID is present in both the EWKT and the argument, the argument value is used.</p>
+</span></td></tr>
+<tr><td><a name="st_geomfromtext"></a><code>st_geomfromtext(val: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation.</p>
+</span></td></tr>
+<tr><td><a name="st_geomfromwkb"></a><code>st_geomfromwkb(bytes: <a href="bytes.html">bytes</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKB representation with the given SRID set.</p>
+</span></td></tr>
+<tr><td><a name="st_geomfromwkb"></a><code>st_geomfromwkb(val: <a href="bytes.html">bytes</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKB representation.</p>
 </span></td></tr>
 <tr><td><a name="st_intersects"></a><code>st_intersects(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_a shares any portion of space with geometry_b.</p>
 <p>This function uses the GEOS module.</p>

--- a/pkg/geo/encode_test.go
+++ b/pkg/geo/encode_test.go
@@ -28,7 +28,7 @@ func TestEWKBToWKT(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(string(tc.ewkt), func(t *testing.T) {
-			ewkb, err := ParseEWKT(tc.ewkt, geopb.DefaultGeometrySRID)
+			ewkb, err := ParseEWKT(tc.ewkt, geopb.DefaultGeometrySRID, DefaultSRIDIsHint)
 			require.NoError(t, err)
 			encoded, err := EWKBToWKT(ewkb)
 			require.NoError(t, err)
@@ -48,7 +48,7 @@ func TestEWKBToEWKT(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(string(tc.ewkt), func(t *testing.T) {
-			ewkb, err := ParseEWKT(tc.ewkt, geopb.DefaultGeometrySRID)
+			ewkb, err := ParseEWKT(tc.ewkt, geopb.DefaultGeometrySRID, DefaultSRIDIsHint)
 			require.NoError(t, err)
 			encoded, err := EWKBToEWKT(ewkb)
 			require.NoError(t, err)
@@ -68,7 +68,7 @@ func TestEWKBToWKB(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(string(tc.ewkt), func(t *testing.T) {
-			ewkb, err := ParseEWKT(tc.ewkt, geopb.DefaultGeometrySRID)
+			ewkb, err := ParseEWKT(tc.ewkt, geopb.DefaultGeometrySRID, DefaultSRIDIsHint)
 			require.NoError(t, err)
 			encoded, err := EWKBToWKB(ewkb)
 			require.NoError(t, err)
@@ -88,7 +88,7 @@ func TestEWKBToGeoJSON(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(string(tc.ewkt), func(t *testing.T) {
-			ewkb, err := ParseEWKT(tc.ewkt, geopb.DefaultGeometrySRID)
+			ewkb, err := ParseEWKT(tc.ewkt, geopb.DefaultGeometrySRID, DefaultSRIDIsHint)
 			require.NoError(t, err)
 			encoded, err := EWKBToGeoJSON(ewkb)
 			require.NoError(t, err)
@@ -108,7 +108,7 @@ func TestEWKBToWKBHex(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(string(tc.ewkt), func(t *testing.T) {
-			ewkb, err := ParseEWKT(tc.ewkt, geopb.DefaultGeometrySRID)
+			ewkb, err := ParseEWKT(tc.ewkt, geopb.DefaultGeometrySRID, DefaultSRIDIsHint)
 			require.NoError(t, err)
 			encoded, err := EWKBToWKBHex(ewkb)
 			require.NoError(t, err)
@@ -130,7 +130,7 @@ func TestEWKBToKML(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(string(tc.ewkt), func(t *testing.T) {
-			ewkb, err := ParseEWKT(tc.ewkt, geopb.DefaultGeometrySRID)
+			ewkb, err := ParseEWKT(tc.ewkt, geopb.DefaultGeometrySRID, DefaultSRIDIsHint)
 			require.NoError(t, err)
 			encoded, err := EWKBToKML(ewkb)
 			require.NoError(t, err)

--- a/pkg/geo/parse_test.go
+++ b/pkg/geo/parse_test.go
@@ -17,6 +17,110 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestParseWKB(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		b             []byte
+		defaultSRID   geopb.SRID
+		expected      geopb.EWKB
+		expectedError string
+	}{
+		{
+			"EWKB should make this error",
+			[]byte("\x01\x01\x00\x00\x20\x11\x0F\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),
+			4326,
+			[]byte(""),
+			"wkb: unknown type: 536870913",
+		},
+		{
+			"Normal WKB should take the SRID",
+			[]byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),
+			4326,
+			[]byte("\x01\x01\x00\x00\x20\xe6\x10\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),
+			"",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ret, err := ParseWKB(tc.b, tc.defaultSRID)
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.EqualError(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, ret)
+			}
+		})
+	}
+}
+
+func TestParseEWKB(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		b           []byte
+		defaultSRID geopb.SRID
+		overwrite   defaultSRIDOverwriteSetting
+		expected    geopb.EWKB
+	}{
+		{
+			"SRID 4326 is hint; EWKB has 3857",
+			[]byte("\x01\x01\x00\x00\x20\x11\x0F\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),
+			4326,
+			DefaultSRIDIsHint,
+			[]byte("\x01\x01\x00\x00\x20\x11\x0F\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),
+		},
+		{
+			"Overwrite SRID 3857 with 4326",
+			[]byte("\x01\x01\x00\x00\x20\x11\x0F\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),
+			4326,
+			DefaultSRIDShouldOverwrite,
+			[]byte("\x01\x01\x00\x00\x20\xe6\x10\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ret, err := ParseEWKB(tc.b, tc.defaultSRID, tc.overwrite)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, ret)
+		})
+	}
+}
+
+func TestParseEWKT(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		wkt         geopb.EWKT
+		defaultSRID geopb.SRID
+		overwrite   defaultSRIDOverwriteSetting
+		expected    geopb.EWKB
+	}{
+		{
+			"SRID 4326 is hint; EWKT has 3857",
+			"SRID=3857;POINT(1.0 1.0)",
+			4326,
+			DefaultSRIDIsHint,
+			[]byte("\x01\x01\x00\x00\x20\x11\x0F\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),
+		},
+		{
+			"Overwrite SRID 3857 with 4326",
+			"SRID=3857;POINT(1.0 1.0)",
+			4326,
+			DefaultSRIDShouldOverwrite,
+			[]byte("\x01\x01\x00\x00\x20\xe6\x10\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ret, err := ParseEWKT(tc.wkt, tc.defaultSRID, tc.overwrite)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, ret)
+		})
+	}
+}
+
 func TestParseGeometry(t *testing.T) {
 	testCases := []struct {
 		str          string

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -81,7 +81,105 @@ SELECT NULL::geometry, NULL::geography
 ----
 NULL  NULL
 
-subtest binary_predicates
+subtest parse_and_unparse
+
+statement ok
+CREATE TABLE parse_test (
+  id SERIAL PRIMARY KEY,
+  geom GEOMETRY,
+  geog GEOGRAPHY
+)
+
+statement ok
+INSERT INTO parse_test (geom, geog) VALUES
+  (ST_GeomFromText('POINT(1.0 2.0)'), ST_GeogFromText('POINT(1.0 2.0)')),
+  (ST_GeomFromText('SRID=4326;POINT(1.0 2.0)'), ST_GeogFromText('SRID=4326;POINT(1.0 2.0)')),
+  (ST_GeomFromText('SRID=4326;POINT(1.0 2.0)', 3857), ST_GeogFromText('SRID=4326;POINT(1.0 2.0)', 3857)),
+  (ST_GeometryFromText('POINT(1.0 2.0)'), ST_GeographyFromText('POINT(1.0 2.0)')),
+  (ST_GeometryFromText('SRID=4326;POINT(1.0 2.0)'), ST_GeographyFromText('POINT(1.0 2.0)', 3857)),
+  (ST_GeometryFromText('SRID=4326;POINT(1.0 2.0)', 3857), ST_GeographyFromText('SRID=4326;POINT(1.0 2.0)', 3857)),
+  (ST_GeomFromEWKT('SRID=3857;POINT(1.0 2.0)'), ST_GeogFromEWKT('SRID=3857;POINT(1.0 2.0)')),
+  (ST_GeomFromGeoJSON('{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}'), ST_GeogFromGeoJSON('{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}')),
+  (ST_GeomFromGeoJSON('{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}'::jsonb), ST_GeogFromGeoJSON('{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}'::jsonb)),
+  (ST_GeomFromWKB(decode('0101000000000000000000F03F000000000000F03F', 'hex')), ST_GeogFromWKB(decode('0101000000000000000000F03F000000000000F03F', 'hex'))),
+  (ST_GeomFromWKB(decode('0101000000000000000000F03F000000000000F03F', 'hex'), 3857), ST_GeogFromWKB(decode('0101000000000000000000F03F000000000000F03F', 'hex'), 3857)),
+  (ST_GeomFromEWKB(decode('0101000000000000000000F03F000000000000F03F', 'hex')), ST_GeogFromEWKB(decode('0101000000000000000000F03F000000000000F03F', 'hex')))
+
+query TTTTTTTT
+SELECT
+  ST_AsText(geom),
+  ST_AsEWKT(geom),
+  ST_AsBinary(geom),
+  ST_AsEWKB(geom),
+  ST_AsHexWKB(geom),
+  ST_AsHexEWKB(geom),
+  ST_AsKML(geom),
+  ST_AsGeoJSON(geom)
+FROM parse_test ORDER BY id ASC
+----
+POINT (1 2)                                    POINT (1 2)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
+POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
+POINT (1 2)                                    SRID=3857;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 17 15 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020110F0000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
+POINT (1 2)                                    POINT (1 2)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
+POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
+POINT (1 2)                                    SRID=3857;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 17 15 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020110F0000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
+POINT (1 2)                                    SRID=3857;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 17 15 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020110F0000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
+POINT (1 2)                                    POINT (1 2)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
+POINT (1 2)                                    POINT (1 2)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
+POINT (1 1)                                    POINT (1 1)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  0101000000000000000000F03F000000000000F03F  0101000000000000000000F03F000000000000F03F  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,1</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":null}
+POINT (1 1)                                    SRID=3857;POINT (1 1)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 32 17 15 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  0101000000000000000000F03F000000000000F03F  0101000020110F0000000000000000F03F000000000000F03F  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,1</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":null}
+POINT (1 1)                                    POINT (1 1)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  0101000000000000000000F03F000000000000F03F  0101000000000000000000F03F000000000000F03F  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,1</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":null}
+
+query TTTTTTTT
+SELECT
+  ST_AsText(geog),
+  ST_AsEWKT(geog),
+  ST_AsBinary(geog),
+  ST_AsEWKB(geog),
+  ST_AsHexWKB(geog),
+  ST_AsHexEWKB(geog),
+  ST_AsKML(geog),
+  ST_AsGeoJSON(geog)
+FROM parse_test ORDER BY id ASC
+----
+POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
+POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
+POINT (1 2)                                    SRID=3857;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 17 15 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020110F0000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
+POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
+POINT (1 2)                                    SRID=3857;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 17 15 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020110F0000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
+POINT (1 2)                                    SRID=3857;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 17 15 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020110F0000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
+POINT (1 2)                                    SRID=3857;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 17 15 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020110F0000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
+POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
+POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
+POINT (1 1)                                    SRID=4326;POINT (1 1)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  0101000000000000000000F03F000000000000F03F  0101000020E6100000000000000000F03F000000000000F03F  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,1</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":null}
+POINT (1 1)                                    SRID=3857;POINT (1 1)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 32 17 15 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  0101000000000000000000F03F000000000000F03F  0101000020110F0000000000000000F03F000000000000F03F  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,1</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":null}
+POINT (1 1)                                    SRID=4326;POINT (1 1)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  0101000000000000000000F03F000000000000F03F  0101000020E6100000000000000000F03F000000000000F03F  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,1</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":null}
+
+subtest geom_binary_predicates
 
 statement ok
 CREATE TABLE geom_binary_predicates_test (

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4184,6 +4184,19 @@ func setProps(props tree.FunctionProperties, d builtinDefinition) builtinDefinit
 	return d
 }
 
+func jsonOverload1(
+	f func(*tree.EvalContext, json.JSON) (tree.Datum, error), returnType *types.T, info string,
+) tree.Overload {
+	return tree.Overload{
+		Types:      tree.ArgTypes{{"val", types.Jsonb}},
+		ReturnType: tree.FixedReturnType(returnType),
+		Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+			return f(evalCtx, tree.MustBeDJSON(args[0]).JSON)
+		},
+		Info: info,
+	}
+}
+
 func stringOverload1(
 	f func(*tree.EvalContext, string) (tree.Datum, error), returnType *types.T, info string,
 ) tree.Overload {

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -11,12 +11,15 @@
 package builtins
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/geo"
 	"github.com/cockroachdb/cockroach/pkg/geo/geomfn"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/errors"
 )
 
@@ -40,7 +43,414 @@ func (ib infoBuilder) String() string {
 	return sb.String()
 }
 
+// geometryFromText is the builtin for ST_GeomFromText/ST_GeometryFromText.
+var geometryFromText = makeBuiltin(
+	defProps(),
+	stringOverload1(
+		func(_ *tree.EvalContext, s string) (tree.Datum, error) {
+			g, err := geo.ParseEWKT(geopb.EWKT(s), geopb.DefaultGeometrySRID, geo.DefaultSRIDIsHint)
+			if err != nil {
+				return nil, err
+			}
+			return tree.NewDGeometry(geo.NewGeometry(g)), nil
+		},
+		types.Geometry,
+		infoBuilder{info: "Returns the Geometry from a WKT or EWKT representation."}.String(),
+	),
+	tree.Overload{
+		Types:      tree.ArgTypes{{"str", types.String}, {"srid", types.Int}},
+		ReturnType: tree.FixedReturnType(types.Geometry),
+		Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+			s := string(tree.MustBeDString(args[0]))
+			srid := geopb.SRID(tree.MustBeDInt(args[1]))
+			g, err := geo.ParseEWKT(geopb.EWKT(s), srid, geo.DefaultSRIDShouldOverwrite)
+			if err != nil {
+				return nil, err
+			}
+			return tree.NewDGeometry(geo.NewGeometry(g)), nil
+		},
+		Info: infoBuilder{
+			info: `Returns the Geometry from a WKT or EWKT representation with an SRID. If the SRID is present in both the EWKT and the argument, the argument value is used.`,
+		}.String(),
+	},
+)
+
+// geographyFromText is the builtin for ST_GeomFromText/ST_GeographyFromText.
+var geographyFromText = makeBuiltin(
+	defProps(),
+	stringOverload1(
+		func(_ *tree.EvalContext, s string) (tree.Datum, error) {
+			g, err := geo.ParseEWKT(geopb.EWKT(s), geopb.DefaultGeographySRID, geo.DefaultSRIDIsHint)
+			if err != nil {
+				return nil, err
+			}
+			return tree.NewDGeography(geo.NewGeography(g)), nil
+		},
+		types.Geography,
+		infoBuilder{info: "Returns the Geography from a WKT or EWKT representation."}.String(),
+	),
+	tree.Overload{
+		Types:      tree.ArgTypes{{"str", types.String}, {"srid", types.Int}},
+		ReturnType: tree.FixedReturnType(types.Geography),
+		Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+			s := string(tree.MustBeDString(args[0]))
+			srid := geopb.SRID(tree.MustBeDInt(args[1]))
+			g, err := geo.ParseEWKT(geopb.EWKT(s), srid, geo.DefaultSRIDShouldOverwrite)
+			if err != nil {
+				return nil, err
+			}
+			return tree.NewDGeography(geo.NewGeography(g)), nil
+		},
+		Info: infoBuilder{
+			info: `Returns the Geography from a WKT or EWKT representation with an SRID. If the SRID is present in both the EWKT and the argument, the argument value is used.`,
+		}.String(),
+	},
+)
+
 var geoBuiltins = map[string]builtinDefinition{
+	//
+	// Input (Geometry)
+	//
+
+	"st_geomfromtext":     geometryFromText,
+	"st_geometryfromtext": geometryFromText,
+	"st_geomfromewkt": makeBuiltin(
+		defProps(),
+		stringOverload1(
+			func(_ *tree.EvalContext, s string) (tree.Datum, error) {
+				g, err := geo.ParseEWKT(geopb.EWKT(s), geopb.DefaultGeometrySRID, geo.DefaultSRIDIsHint)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(geo.NewGeometry(g)), nil
+			},
+			types.Geometry,
+			infoBuilder{info: "Returns the Geometry from an EWKT representation."}.String(),
+		),
+	),
+	"st_geomfromwkb": makeBuiltin(
+		defProps(),
+		bytesOverload1(
+			func(_ *tree.EvalContext, s string) (tree.Datum, error) {
+				g, err := geo.ParseWKB([]byte(s), geopb.DefaultGeometrySRID)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(geo.NewGeometry(g)), nil
+			},
+			types.Geometry,
+			infoBuilder{info: "Returns the Geometry from a WKB representation."}.String(),
+		),
+		tree.Overload{
+			Types:      tree.ArgTypes{{"bytes", types.Bytes}, {"srid", types.Int}},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				b := string(tree.MustBeDBytes(args[0]))
+				srid := geopb.SRID(tree.MustBeDInt(args[1]))
+				g, err := geo.ParseWKB(geopb.WKB(b), srid)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(geo.NewGeometry(g)), nil
+			},
+			Info: infoBuilder{
+				info: `Returns the Geometry from a WKB representation with the given SRID set.`,
+			}.String(),
+		},
+	),
+	"st_geomfromewkb": makeBuiltin(
+		defProps(),
+		bytesOverload1(
+			func(_ *tree.EvalContext, s string) (tree.Datum, error) {
+				g, err := geo.ParseEWKB([]byte(s), geopb.DefaultGeometrySRID, geo.DefaultSRIDIsHint)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(geo.NewGeometry(g)), nil
+			},
+			types.Geometry,
+			infoBuilder{info: "Returns the Geometry from an EWKB representation."}.String(),
+		),
+	),
+	"st_geomfromgeojson": makeBuiltin(
+		defProps(),
+		stringOverload1(
+			func(_ *tree.EvalContext, s string) (tree.Datum, error) {
+				g, err := geo.ParseGeoJSON([]byte(s), geopb.DefaultGeometrySRID)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(geo.NewGeometry(g)), nil
+			},
+			types.Geometry,
+			infoBuilder{info: "Returns the Geometry from an GeoJSON representation."}.String(),
+		),
+		jsonOverload1(
+			func(_ *tree.EvalContext, s json.JSON) (tree.Datum, error) {
+				// TODO(otan): optimize to not string it first.
+				asString, err := s.AsText()
+				if err != nil {
+					return nil, err
+				}
+				g, err := geo.ParseGeoJSON([]byte(*asString), geopb.DefaultGeometrySRID)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(geo.NewGeometry(g)), nil
+			},
+			types.Geometry,
+			infoBuilder{info: "Returns the Geometry from an GeoJSON representation."}.String(),
+		),
+	),
+
+	//
+	// Input (Geography)
+	//
+
+	"st_geogfromtext":      geographyFromText,
+	"st_geographyfromtext": geographyFromText,
+	"st_geogfromewkt": makeBuiltin(
+		defProps(),
+		stringOverload1(
+			func(_ *tree.EvalContext, s string) (tree.Datum, error) {
+				g, err := geo.ParseEWKT(geopb.EWKT(s), geopb.DefaultGeographySRID, geo.DefaultSRIDIsHint)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeography(geo.NewGeography(g)), nil
+			},
+			types.Geography,
+			infoBuilder{info: "Returns the Geography from an EWKT representation."}.String(),
+		),
+	),
+	"st_geogfromwkb": makeBuiltin(
+		defProps(),
+		bytesOverload1(
+			func(_ *tree.EvalContext, s string) (tree.Datum, error) {
+				g, err := geo.ParseWKB([]byte(s), geopb.DefaultGeographySRID)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeography(geo.NewGeography(g)), nil
+			},
+			types.Geography,
+			infoBuilder{info: "Returns the Geography from a WKB representation."}.String(),
+		),
+		tree.Overload{
+			Types:      tree.ArgTypes{{"bytes", types.Bytes}, {"srid", types.Int}},
+			ReturnType: tree.FixedReturnType(types.Geography),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				b := string(tree.MustBeDBytes(args[0]))
+				srid := geopb.SRID(tree.MustBeDInt(args[1]))
+				g, err := geo.ParseWKB(geopb.WKB(b), srid)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeography(geo.NewGeography(g)), nil
+			},
+			Info: infoBuilder{
+				info: `Returns the Geography from a WKB representation with the given SRID set.`,
+			}.String(),
+		},
+	),
+	"st_geogfromewkb": makeBuiltin(
+		defProps(),
+		bytesOverload1(
+			func(_ *tree.EvalContext, s string) (tree.Datum, error) {
+				g, err := geo.ParseEWKB([]byte(s), geopb.DefaultGeographySRID, geo.DefaultSRIDIsHint)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeography(geo.NewGeography(g)), nil
+			},
+			types.Geography,
+			infoBuilder{info: "Returns the Geography from an EWKB representation."}.String(),
+		),
+	),
+	"st_geogfromgeojson": makeBuiltin(
+		defProps(),
+		stringOverload1(
+			func(_ *tree.EvalContext, s string) (tree.Datum, error) {
+				g, err := geo.ParseGeoJSON([]byte(s), geopb.DefaultGeographySRID)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeography(geo.NewGeography(g)), nil
+			},
+			types.Geography,
+			infoBuilder{info: "Returns the Geography from an GeoJSON representation."}.String(),
+		),
+		jsonOverload1(
+			func(_ *tree.EvalContext, s json.JSON) (tree.Datum, error) {
+				// TODO(otan): optimize to not string it first.
+				asString, err := s.AsText()
+				if err != nil {
+					return nil, err
+				}
+				g, err := geo.ParseGeoJSON([]byte(*asString), geopb.DefaultGeographySRID)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeography(geo.NewGeography(g)), nil
+			},
+			types.Geography,
+			infoBuilder{info: "Returns the Geography from an GeoJSON representation."}.String(),
+		),
+	),
+
+	//
+	// Output
+	//
+
+	"st_astext": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				wkt, err := geo.EWKBToWKT(g.Geometry.EWKB())
+				return tree.NewDString(string(wkt)), err
+			},
+			types.String,
+			infoBuilder{info: "Returns the WKT representation of a given Geometry."},
+		),
+		geographyOverload1(
+			func(_ *tree.EvalContext, g *tree.DGeography) (tree.Datum, error) {
+				wkt, err := geo.EWKBToWKT(g.Geography.EWKB())
+				return tree.NewDString(string(wkt)), err
+			},
+			types.String,
+			infoBuilder{info: "Returns the WKT representation of a given Geography."},
+		),
+	),
+	"st_asewkt": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				ewkt, err := geo.EWKBToEWKT(g.Geometry.EWKB())
+				return tree.NewDString(string(ewkt)), err
+			},
+			types.String,
+			infoBuilder{info: "Returns the EWKT representation of a given Geometry."},
+		),
+		geographyOverload1(
+			func(_ *tree.EvalContext, g *tree.DGeography) (tree.Datum, error) {
+				ewkt, err := geo.EWKBToEWKT(g.Geography.EWKB())
+				return tree.NewDString(string(ewkt)), err
+			},
+			types.String,
+			infoBuilder{info: "Returns the EWKT representation of a given Geography."},
+		),
+	),
+	"st_asbinary": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				wkb, err := geo.EWKBToWKB(g.Geometry.EWKB())
+				return tree.NewDBytes(tree.DBytes(wkb)), err
+			},
+			types.Bytes,
+			infoBuilder{info: "Returns the WKB representation of a given Geometry."},
+		),
+		geographyOverload1(
+			func(_ *tree.EvalContext, g *tree.DGeography) (tree.Datum, error) {
+				wkb, err := geo.EWKBToWKB(g.Geography.EWKB())
+				return tree.NewDBytes(tree.DBytes(wkb)), err
+			},
+			types.Bytes,
+			infoBuilder{info: "Returns the WKB representation of a given Geography."},
+		),
+	),
+	"st_asewkb": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				return tree.NewDBytes(tree.DBytes(g.EWKB())), nil
+			},
+			types.Bytes,
+			infoBuilder{info: "Returns the EWKB representation of a given Geometry."},
+		),
+		geographyOverload1(
+			func(_ *tree.EvalContext, g *tree.DGeography) (tree.Datum, error) {
+				return tree.NewDBytes(tree.DBytes(g.EWKB())), nil
+			},
+			types.Bytes,
+			infoBuilder{info: "Returns the EWKB representation of a given Geography."},
+		),
+	),
+	"st_ashexwkb": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				hexwkb, err := geo.EWKBToWKBHex(g.Geometry.EWKB())
+				return tree.NewDString(hexwkb), err
+			},
+			types.String,
+			infoBuilder{info: "Returns the WKB representation in hex of a given Geometry."},
+		),
+		geographyOverload1(
+			func(_ *tree.EvalContext, g *tree.DGeography) (tree.Datum, error) {
+				hexwkb, err := geo.EWKBToWKBHex(g.Geography.EWKB())
+				return tree.NewDString(hexwkb), err
+			},
+			types.String,
+			infoBuilder{info: "Returns the WKB representation in hex of a given Geography."},
+		),
+	),
+	"st_ashexewkb": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				return tree.NewDString(strings.ToUpper(fmt.Sprintf("%x", g.EWKB()))), nil
+			},
+			types.String,
+			infoBuilder{info: "Returns the EWKB representation in hex of a given Geometry."},
+		),
+		geographyOverload1(
+			func(_ *tree.EvalContext, g *tree.DGeography) (tree.Datum, error) {
+				return tree.NewDString(strings.ToUpper(fmt.Sprintf("%x", g.EWKB()))), nil
+			},
+			types.String,
+			infoBuilder{info: "Returns the EWKB representation in hex of a given Geography."},
+		),
+	),
+	"st_askml": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				kml, err := geo.EWKBToKML(g.Geometry.EWKB())
+				return tree.NewDString(kml), err
+			},
+			types.String,
+			infoBuilder{info: "Returns the KML representation of a given Geometry."},
+		),
+		geographyOverload1(
+			func(_ *tree.EvalContext, g *tree.DGeography) (tree.Datum, error) {
+				kml, err := geo.EWKBToKML(g.Geography.EWKB())
+				return tree.NewDString(kml), err
+			},
+			types.String,
+			infoBuilder{info: "Returns the KML representation of a given Geography."},
+		),
+	),
+	"st_asgeojson": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				geojson, err := geo.EWKBToGeoJSON(g.Geometry.EWKB())
+				return tree.NewDString(string(geojson)), err
+			},
+			types.String,
+			infoBuilder{info: "Returns the GeoJSON representation of a given Geometry."},
+		),
+		geographyOverload1(
+			func(_ *tree.EvalContext, g *tree.DGeography) (tree.Datum, error) {
+				geojson, err := geo.EWKBToGeoJSON(g.Geography.EWKB())
+				return tree.NewDString(string(geojson)), err
+			},
+			types.String,
+			infoBuilder{info: "Returns the GeoJSON representation of a given Geography."},
+		),
+	),
+
 	//
 	// Unary functions.
 	//
@@ -62,6 +472,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	//
 	// Binary Predicates
 	//
+
 	"st_covers": makeBuiltin(
 		defProps(),
 		geometryOverload2BinaryPredicate(
@@ -165,6 +576,44 @@ var geoBuiltins = map[string]builtinDefinition{
 			},
 		),
 	),
+}
+
+// geometryOverload1 hides the boilerplate for builtins operating on one geometry.
+func geometryOverload1(
+	f func(*tree.EvalContext, *tree.DGeometry) (tree.Datum, error),
+	returnType *types.T,
+	ib infoBuilder,
+) tree.Overload {
+	return tree.Overload{
+		Types: tree.ArgTypes{
+			{"geometry", types.Geometry},
+		},
+		ReturnType: tree.FixedReturnType(returnType),
+		Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+			a := args[0].(*tree.DGeometry)
+			return f(ctx, a)
+		},
+		Info: ib.String(),
+	}
+}
+
+// geographyOverload1 hides the boilerplate for builtins operating on one geography.
+func geographyOverload1(
+	f func(*tree.EvalContext, *tree.DGeography) (tree.Datum, error),
+	returnType *types.T,
+	ib infoBuilder,
+) tree.Overload {
+	return tree.Overload{
+		Types: tree.ArgTypes{
+			{"geography", types.Geography},
+		},
+		ReturnType: tree.FixedReturnType(returnType),
+		Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+			a := args[0].(*tree.DGeography)
+			return f(ctx, a)
+		},
+		Info: ib.String(),
+	}
 }
 
 // geometryOverload2 hides the boilerplate for builtins operating on two geometries.

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -892,7 +892,7 @@ func TestLint(t *testing.T) {
 
 		if err := stream.ForEach(stream.Sequence(
 			filter,
-			stream.GrepNot(`(json|jsonpb|yaml|xml|protoutil|toml|Codec|ewkb)\.Unmarshal\(`),
+			stream.GrepNot(`(json|jsonpb|yaml|xml|protoutil|toml|Codec|ewkb|wkb)\.Unmarshal\(`),
 		), func(s string) {
 			t.Errorf("\n%s <- forbidden; use 'protoutil.Unmarshal' instead", s)
 		}); err != nil {


### PR DESCRIPTION
The main weirdness here is that ST_Geo*fromText can take EWKT and an
SRID and the SRID always overwrites the EWKT value. As such, minor
changes were made to the parser in the geo package.

Release note (sql change): We have added new functionality for the
following functions:
* ST_GeomFromText, ST_GeometryFromText
* ST_GeogFromText, ST_GeographyFromText
* ST_GeomFromWKB
* ST_GeomFromEWKB
* ST_GeomFromEWKT
* ST_GeomFromGeoJSON
* ST_GeogFromWKB
* ST_GeogFromEWKB
* ST_GeogFromEWKT
* ST_GeogFromGeoJSON
* ST_AsText
* ST_AsBinary
* ST_AsEWKB
* ST_AsEWKT
* ST_AsKML
* ST_AsGeoJSON