### PR TITLE
release-19.2: cli: Support cluster name flags in all non-sql client commands

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -374,7 +374,8 @@ func init() {
 		// 'start' will check that the flag is properly defined.
 		VarFlag(f, &serverCfg.JoinList, cliflags.Join)
 		VarFlag(f, clusterNameSetter{&baseCfg.ClusterName}, cliflags.ClusterName)
-		BoolFlag(f, &baseCfg.DisableClusterNameVerification, cliflags.DisableClusterNameVerification, false)
+		BoolFlag(f, &baseCfg.DisableClusterNameVerification,
+			cliflags.DisableClusterNameVerification, baseCfg.DisableClusterNameVerification)
 		if cmd == startSingleNodeCmd {
 			// Even though all server flags are supported for
 			// 'start-single-node', we intend that command to be used by
@@ -460,6 +461,7 @@ func init() {
 		debugZipCmd,
 		dumpCmd,
 		genHAProxyCmd,
+		initCmd,
 		quitCmd,
 		sqlShellCmd,
 		/* StartCmds are covered above */
@@ -468,7 +470,6 @@ func init() {
 	clientCmds = append(clientCmds, authCmds...)
 	clientCmds = append(clientCmds, nodeCmds...)
 	clientCmds = append(clientCmds, systemBenchCmds...)
-	clientCmds = append(clientCmds, initCmd)
 	for _, cmd := range clientCmds {
 		f := cmd.PersistentFlags()
 		VarFlag(f, addrSetter{&cliCtx.clientConnHost, &cliCtx.clientConnPort}, cliflags.ClientHost)
@@ -580,14 +581,18 @@ func init() {
 		}
 	}
 
-	// Make the other non-SQL client commands also recognize --url in
-	// strict SSL mode.
+	// Make the non-SQL client commands also recognize --url in strict SSL mode
+	// and ensure they can connect to clusters that use a cluster-name.
 	for _, cmd := range clientCmds {
 		if f := flagSetForCmd(cmd).Lookup(cliflags.URL.Name); f != nil {
 			// --url already registered above, nothing to do.
 			continue
 		}
-		VarFlag(cmd.PersistentFlags(), urlParser{cmd, &cliCtx, true /* strictSSL */}, cliflags.URL)
+		f := cmd.PersistentFlags()
+		VarFlag(f, urlParser{cmd, &cliCtx, true /* strictSSL */}, cliflags.URL)
+		VarFlag(f, clusterNameSetter{&baseCfg.ClusterName}, cliflags.ClusterName)
+		BoolFlag(f, &baseCfg.DisableClusterNameVerification,
+			cliflags.DisableClusterNameVerification, baseCfg.DisableClusterNameVerification)
 	}
 
 	// Commands that print tables.

--- a/pkg/cli/interactive_tests/test_cluster_name.tcl
+++ b/pkg/cli/interactive_tests/test_cluster_name.tcl
@@ -1,0 +1,36 @@
+#! /usr/bin/env expect -f
+#
+source [file join [file dirnam $argv0] common.tcl]
+
+# Start a server with a --join flag so the init command is required
+# (even though we have no intention of starting a second node).  Note that unlike other
+# expect-based tests, this one doesn't use a fifo for --pid_file
+# because we don't want reads from that fifo to change the outcome.
+system "$argv start --insecure --pid-file=server_pid -s=path=logs/db --listen-addr=localhost --background --join=localhost:26258 --cluster-name=foo >>logs/expect-cmd.log 2>&1"
+
+start_test "Check that the server has informed us and the log file that it was ready before forking off in the background"
+system "grep -q 'initial startup completed' logs/db/logs/cockroach.log"
+system "grep -q 'will now attempt to join a running cluster, or wait' logs/db/logs/cockroach.log"
+end_test
+
+start_test "Check that init works with a cluster-name provided"
+system "$argv init --insecure --host=localhost --cluster-name=foo"
+end_test
+
+start_test "Check that decommission works with a cluster-name provided"
+send "$argv node decommission 1 --insecure --host=localhost --wait=none --cluster-name=foo\r"
+end_test
+
+start_test "Check that recommission works with cluster name verification disabled"
+send "$argv node recommission 1 --insecure --host=localhost --disable-cluster-name-verification\r"
+end_test
+
+start_test "Check that debug commands work with a cluster name provided"
+send "$argv debug gossip-values --insecure --host=localhost --cluster-name=foo\r"
+end_test
+
+start_test "Check that quit works with a cluster-name provided"
+send "$argv quit --insecure --host=localhost --wait=none --cluster-name=foo\r"
+end_test
+
+stop_server $argv


### PR DESCRIPTION
Backport 1/1 commits from #48000.

/cc @cockroachdb/release 

---

Release note (cli change): Client commands such as init and quit now
support the --cluster-name and --disable-cluster-name-verification flags
in order to support running them on clusters that have been configured
to use a cluster name. Previously it was impossible to run such
commands against nodes configured with the --cluster-name flag.