### PR TITLE
opt: optimize SplitDisjunction exploration rule

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -632,3 +632,24 @@ SELECT * FROM t38878 WHERE (k1 = 'd' AND k2 = 'x') OR k1 = 'b' OR (k1 > 'b' AND 
 b  v  2
 c  w  3
 d  x  4
+
+# Regression test for #47976 (optimizer OOM and timeouts with many ORs).
+statement ok
+CREATE TABLE t47976 (
+  k INT PRIMARY KEY,
+  a INT,
+  b FLOAT,
+  c INT,
+  INDEX (a),
+  INDEX (b),
+  INDEX (c)
+)
+
+statement ok
+SELECT k FROM t47976 WHERE
+  (a >= 6 OR b < 8 OR c IN (23, 27, 53)) AND
+  (a = 1 OR b >= 12 OR c IS NULL) AND
+  (a < 1 OR b = 6.8 OR c = 12) AND
+  (a > 4 OR b <= 5.23 OR c IN (1, 2, 3)) AND
+  (a = 12 OR b = 15.23 OR c = 14) AND
+  (a > 58 OR b < 0 OR c >= 13)

--- a/pkg/sql/opt/xform/rules/select.opt
+++ b/pkg/sql/opt/xform/rules/select.opt
@@ -49,26 +49,22 @@
     $input:(Scan
         $scanPrivate:* & (IsCanonicalScan $scanPrivate)
     ) & (HasStrictKey $input)
-    $filters:[
-        ...
-        $item:(FiltersItem $or:(Or)) &
-            (ExprPairSucceeded $pair:(ExprPairForSplitDisjunction $or)) &
-            (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols (ExprPairLeft $pair))) &
-            (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols (ExprPairRight $pair)))
-        ...
-    ]
+    $filters:* &
+        (ExprPairSucceeded $pair:(ExprPairForSplitDisjunction $filters)) &
+        (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols (ExprPairLeft $pair))) &
+        (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols (ExprPairRight $pair)))
 )
 =>
 (DistinctOn
     (UnionAll
         (Select
             $input
-            (ReplaceFiltersItem $filters $item (ExprPairLeft $pair))
+            (ReplaceFiltersItem $filters (ExprPairFiltersItemToReplace $pair) (ExprPairLeft $pair))
         )
         (Select
             (Scan $rightScanPrivate:(DuplicateScanPrivate $scanPrivate))
             (MapScanFilterCols
-                (ReplaceFiltersItem $filters $item (ExprPairRight $pair))
+                (ReplaceFiltersItem $filters (ExprPairFiltersItemToReplace $pair) (ExprPairRight $pair))
                 $scanPrivate
                 $rightScanPrivate
             )
@@ -116,14 +112,10 @@
     $input:(Scan
         $scanPrivate:* & (IsCanonicalScan $scanPrivate)
     ) & ^(HasStrictKey $input)
-    $filters:[
-        ...
-        $item:(FiltersItem $or:(Or)) &
-            (ExprPairSucceeded $pair:(ExprPairForSplitDisjunction $or)) &
-            (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols (ExprPairLeft $pair))) &
-            (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols (ExprPairRight $pair)))
-        ...
-    ]
+    $filters:* &
+        (ExprPairSucceeded $pair:(ExprPairForSplitDisjunction $filters)) &
+        (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols (ExprPairLeft $pair))) &
+        (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols (ExprPairRight $pair)))
 )
 =>
 (Project
@@ -131,12 +123,12 @@
         (UnionAll
             (Select
                 $leftScan:(Scan $leftScanPrivate:(AddPrimaryKeyColsToScanPrivate $scanPrivate))
-                (ReplaceFiltersItem $filters $item (ExprPairLeft $pair))
+                (ReplaceFiltersItem $filters (ExprPairFiltersItemToReplace $pair) (ExprPairLeft $pair))
             )
             (Select
                 (Scan $rightScanPrivate:(DuplicateScanPrivate $leftScanPrivate))
                 (MapScanFilterCols
-                    (ReplaceFiltersItem $filters $item (ExprPairRight $pair))
+                    (ReplaceFiltersItem $filters (ExprPairFiltersItemToReplace $pair) (ExprPairRight $pair))
                     $leftScanPrivate
                     $rightScanPrivate
                 )

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1788,6 +1788,61 @@ distinct-on
       └── const-agg [as=v:3, outer=(3)]
            └── v:3
 
+# Find the first disjunction in the filters that have different column sets on
+# the left and right.
+opt expect=SplitDisjunction
+SELECT k FROM d WHERE (w = 1 OR w = 2) AND (u = 3 OR v = 4)
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── distinct-on
+      ├── columns: k:1!null u:2 v:3 w:4!null
+      ├── grouping columns: k:1!null
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      ├── union-all
+      │    ├── columns: k:1!null u:2 v:3 w:4!null
+      │    ├── left columns: k:1!null u:2 v:3 w:4!null
+      │    ├── right columns: k:5 u:6 v:7 w:8
+      │    ├── select
+      │    │    ├── columns: k:1!null u:2!null v:3 w:4!null
+      │    │    ├── key: (1)
+      │    │    ├── fd: ()-->(2), (1)-->(3,4)
+      │    │    ├── index-join d
+      │    │    │    ├── columns: k:1!null u:2 v:3 w:4
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: ()-->(2), (1)-->(3,4)
+      │    │    │    └── scan d@u
+      │    │    │         ├── columns: k:1!null u:2!null
+      │    │    │         ├── constraint: /2/1: [/3 - /3]
+      │    │    │         ├── key: (1)
+      │    │    │         └── fd: ()-->(2)
+      │    │    └── filters
+      │    │         └── (w:4 = 1) OR (w:4 = 2) [outer=(4), constraints=(/4: [/1 - /1] [/2 - /2]; tight)]
+      │    └── select
+      │         ├── columns: k:5!null u:6 v:7!null w:8!null
+      │         ├── key: (5)
+      │         ├── fd: ()-->(7), (5)-->(6,8)
+      │         ├── index-join d
+      │         │    ├── columns: k:5!null u:6 v:7 w:8
+      │         │    ├── key: (5)
+      │         │    ├── fd: ()-->(7), (5)-->(6,8)
+      │         │    └── scan d@v
+      │         │         ├── columns: k:5!null v:7!null
+      │         │         ├── constraint: /7/5: [/4 - /4]
+      │         │         ├── key: (5)
+      │         │         └── fd: ()-->(7)
+      │         └── filters
+      │              └── (w:8 = 1) OR (w:8 = 2) [outer=(8), constraints=(/8: [/1 - /1] [/2 - /2]; tight)]
+      └── aggregations
+           ├── const-agg [as=u:2, outer=(2)]
+           │    └── u:2
+           ├── const-agg [as=v:3, outer=(3)]
+           │    └── v:3
+           └── const-agg [as=w:4, outer=(4)]
+                └── w:4
+
 # Don't apply when outer columns of both sides of OR do not intersect with index columns.
 opt expect-not=SplitDisjunction
 SELECT k, u, w FROM d WHERE u = 1 OR w = 1
@@ -2694,6 +2749,62 @@ project
            │    └── u:2
            └── const-agg [as=v:3, outer=(3)]
                 └── v:3
+
+# Find the first disjunction in the filters that have different column sets on
+# the left and right.
+opt expect=SplitDisjunctionAddKey
+SELECT u, v FROM d WHERE (w = 1 OR w = 2) AND (u = 3 OR v = 4)
+----
+project
+ ├── columns: u:2 v:3
+ └── project
+      ├── columns: u:2 v:3 w:4!null
+      └── distinct-on
+           ├── columns: k:1!null u:2 v:3 w:4!null
+           ├── grouping columns: k:1!null
+           ├── key: (1)
+           ├── fd: (1)-->(2-4)
+           ├── union-all
+           │    ├── columns: k:1!null u:2 v:3 w:4!null
+           │    ├── left columns: k:1!null u:2 v:3 w:4!null
+           │    ├── right columns: k:5 u:6 v:7 w:8
+           │    ├── select
+           │    │    ├── columns: k:1!null u:2!null v:3 w:4!null
+           │    │    ├── key: (1)
+           │    │    ├── fd: ()-->(2), (1)-->(3,4)
+           │    │    ├── index-join d
+           │    │    │    ├── columns: k:1!null u:2 v:3 w:4
+           │    │    │    ├── key: (1)
+           │    │    │    ├── fd: ()-->(2), (1)-->(3,4)
+           │    │    │    └── scan d@u
+           │    │    │         ├── columns: k:1!null u:2!null
+           │    │    │         ├── constraint: /2/1: [/3 - /3]
+           │    │    │         ├── key: (1)
+           │    │    │         └── fd: ()-->(2)
+           │    │    └── filters
+           │    │         └── (w:4 = 1) OR (w:4 = 2) [outer=(4), constraints=(/4: [/1 - /1] [/2 - /2]; tight)]
+           │    └── select
+           │         ├── columns: k:5!null u:6 v:7!null w:8!null
+           │         ├── key: (5)
+           │         ├── fd: ()-->(7), (5)-->(6,8)
+           │         ├── index-join d
+           │         │    ├── columns: k:5!null u:6 v:7 w:8
+           │         │    ├── key: (5)
+           │         │    ├── fd: ()-->(7), (5)-->(6,8)
+           │         │    └── scan d@v
+           │         │         ├── columns: k:5!null v:7!null
+           │         │         ├── constraint: /7/5: [/4 - /4]
+           │         │         ├── key: (5)
+           │         │         └── fd: ()-->(7)
+           │         └── filters
+           │              └── (w:8 = 1) OR (w:8 = 2) [outer=(8), constraints=(/8: [/1 - /1] [/2 - /2]; tight)]
+           └── aggregations
+                ├── const-agg [as=u:2, outer=(2)]
+                │    └── u:2
+                ├── const-agg [as=v:3, outer=(3)]
+                │    └── v:3
+                └── const-agg [as=w:4, outer=(4)]
+                     └── w:4
 
 # Don't apply when outer columns of both sides of OR do not intersect with index columns.
 opt expect-not=SplitDisjunctionAddKey


### PR DESCRIPTION
Previously, the SplitDisjunction and SplitDisjunctionAddKey exploration
rules would match all disjunctions in the filters. Because these rules
are recursively applied to their resulting trees, the amount of
computation would explode when applying these rules to complex filters
with many disjunctions. In some examples from SQLite logic tests, the
optimizer can take minutes to create a query plan.

This commit changes the behavior of these rules to match only the first
"interesting disjunction" in the list of filters. An "interesting
disjunction" is one where the column sets on the left and the right side
of the disjunction are not equal. (These rules, which attempt to utilize
two indexes to satisfy a disjunction, are pointless for non-interesting
disjunctions because splitting them would result in a union of two scans
over the same index.)

Fixes #47976

Release note (performance improvement): The query optimizer is now more
efficient when generating plans for queries with many OR expressions.