### PR TITLE
schemachange: categorize error as unimplemented

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -755,7 +755,7 @@ statement ok
 DROP TABLE IF EXISTS t;
 CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL, FAMILY (x), FAMILY (y))
 
-statement error pq: primary key of table t dropped without subsequent addition of new primary key
+statement error pq: unimplemented: primary key of table t dropped without subsequent addition of new primary key
 ALTER TABLE t DROP CONSTRAINT "primary"
 
 statement error pq: multiple primary keys for table "t" are not allowed
@@ -916,7 +916,7 @@ ALTER TABLE t1 DROP CONSTRAINT "primary"
 statement ok
 INSERT INTO t2 VALUES (1)
 
-statement error pq: primary key of table t1 dropped without subsequent addition of new primary key
+statement error pq: unimplemented: primary key of table t1 dropped without subsequent addition of new primary key
 COMMIT
 
 query I

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -856,7 +857,7 @@ func (tc *TableCollection) validatePrimaryKeys() error {
 	for i := range modifiedTables {
 		table := tc.getUncommittedTableByID(modifiedTables[i].id).MutableTableDescriptor
 		if !table.HasPrimaryKey() {
-			return errors.Errorf(
+			return unimplemented.NewWithIssuef(48026,
 				"primary key of table %s dropped without subsequent addition of new primary key",
 				table.Name,
 			)


### PR DESCRIPTION
When dropping a primary key inside a txn without subsequently adding a
new one the txn will fail at commit with error:
```
primary key of table <table_name> dropped without subsequent addition of
new primary key.
```
Instead of returning an uncategorized error we return an unimplemented
error.

Touches #47430.
Touches #48026.

Release note: none.