### PR TITLE
sql: validate index name prior to creating index

### DIFF
--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -120,6 +120,11 @@ func MakeIndexDescriptor(
 	if err := validateIndexColumnsExist(tableDesc, n.Columns); err != nil {
 		return nil, err
 	}
+
+	// Ensure that the index name does not exist before trying to create the index.
+	if err := tableDesc.ValidateIndexNameIsUnique(string(n.Name)); err != nil {
+		return nil, err
+	}
 	indexDesc := sqlbase.IndexDescriptor{
 		Name:              string(n.Name),
 		Unique:            n.Unique,

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -829,9 +829,15 @@ func addIndexForFK(
 	constraintName string,
 	ts FKTableState,
 ) (sqlbase.IndexID, error) {
+	autoIndexName := sqlbase.GenerateUniqueConstraintName(
+		fmt.Sprintf("%s_auto_index_%s", tbl.Name, constraintName),
+		func(name string) bool {
+			return tbl.ValidateIndexNameIsUnique(name) != nil
+		},
+	)
 	// No existing index for the referencing columns found, so we add one.
 	idx := sqlbase.IndexDescriptor{
-		Name:             fmt.Sprintf("%s_auto_index_%s", tbl.Name, constraintName),
+		Name:             autoIndexName,
 		ColumnNames:      make([]string, len(srcCols)),
 		ColumnDirections: make([]sqlbase.IndexDescriptor_Direction, len(srcCols)),
 	}

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -870,7 +870,7 @@ CREATE TABLE t.test (a STRING PRIMARY KEY, b STRING, c STRING, INDEX foo (c));
 	// "foo" is being added.
 	mt.writeIndexMutation("foo", sqlbase.DescriptorMutation{Direction: sqlbase.DescriptorMutation_ADD})
 	if _, err := sqlDB.Exec(`CREATE INDEX foo ON t.test (c)`); !testutils.IsError(err,
-		`duplicate: index "foo" in the middle of being added, not yet public`) {
+		`relation "foo" already exists`) {
 		t.Fatal(err)
 	}
 	// Make "foo" live.

--- a/pkg/sql/logictest/testdata/logic_test/alter_table_mixed_19.2_20.1
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table_mixed_19.2_20.1
@@ -89,7 +89,7 @@ statement ok
 CREATE INDEX IF NOT EXISTS t_b_idx ON t (b)
 
 # Errors during validation should still occur.
-statement error duplicate index name
+statement error pq: relation "t_b_idx" already exists
 CREATE INDEX t_b_idx ON t (b)
 
 query TT

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -14,7 +14,7 @@ user root
 statement ok
 CREATE INDEX foo ON t (b)
 
-statement error duplicate index name: \"foo\"
+statement error relation \"foo\" already exists
 CREATE INDEX foo ON t (a)
 
 statement error column "c" does not exist

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -2478,8 +2478,8 @@ CREATE INDEX child_name_collision_auto_index_fk_id ON child_name_collision (othe
 # Testing the unusual case where an index already exists that has the same name
 # as the index to be auto-generated when adding a fk constraint to an empty
 # table (but the existing index is not on the referencing column), in which
-# case the ALTER TABLE will fail due to the name collision.
-statement error duplicate index name: "child_name_collision_auto_index_fk_id"
+# case the ALTER TABLE will choose another unique name for the index.
+statement ok
 ALTER TABLE child_name_collision ADD CONSTRAINT fk_id FOREIGN KEY (parent_id) references parent_name_collision
 
 subtest auto_add_fk_duplicate_cols_error

--- a/pkg/sql/logictest/testdata/logic_test/fk_opt
+++ b/pkg/sql/logictest/testdata/logic_test/fk_opt
@@ -2722,8 +2722,8 @@ CREATE INDEX child_name_collision_auto_index_fk_id ON child_name_collision (othe
 # Testing the unusual case where an index already exists that has the same name
 # as the index to be auto-generated when adding a fk constraint to an empty
 # table (but the existing index is not on the referencing column), in which
-# case the ALTER TABLE will fail due to the name collision.
-statement error duplicate index name: "child_name_collision_auto_index_fk_id"
+# case the ALTER TABLE will create another name for the index.
+statement ok
 ALTER TABLE child_name_collision ADD CONSTRAINT fk_id FOREIGN KEY (parent_id) references parent_name_collision
 
 subtest auto_add_fk_duplicate_cols_error

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -167,8 +167,8 @@ CREATE INDEX child_name_collision_auto_index_fk_id ON child_name_collision (othe
 # Testing the unusual case where an index already exists that has the same name
 # as the index to be auto-generated when adding a fk constraint to an empty
 # table (but the existing index is not on the referencing column), in which
-# case the ALTER TABLE will fail due to the name collision.
-statement error duplicate index name: "child_name_collision_auto_index_fk_id"
+# case the ALTER TABLE generate another unique name for the index.
+statement ok
 ALTER TABLE child_name_collision ADD CONSTRAINT fk_id FOREIGN KEY (parent_id) references parent_name_collision
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/ddl
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ddl
@@ -138,7 +138,7 @@ user root
 statement ok
 CREATE INDEX foo ON t (b)
 
-statement error duplicate index name: \"foo\"
+statement error relation \"foo\" already exists
 CREATE INDEX foo ON t (a)
 
 statement error column "c" does not exist

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1713,6 +1713,16 @@ func (desc *TableDescriptor) validateCrossReferences(ctx context.Context, txn *k
 	return nil
 }
 
+// ValidateIndexNameIsUnique validates that the index name does not exist.
+func (desc *TableDescriptor) ValidateIndexNameIsUnique(indexName string) error {
+	for _, index := range desc.AllNonDropIndexes() {
+		if indexName == index.Name {
+			return NewRelationAlreadyExistsError(indexName)
+		}
+	}
+	return nil
+}
+
 // ValidateTable validates that the table descriptor is well formed. Checks
 // include validating the table, column and index names, verifying that column
 // names and index names are unique and verifying that column IDs and index IDs
@@ -1979,13 +1989,16 @@ func (desc *TableDescriptor) validateTableIndexes(columnNames map[string]ColumnI
 			return fmt.Errorf("invalid index ID %d", index.ID)
 		}
 
-		if _, ok := indexNames[index.Name]; ok {
+		if _, indexNameExists := indexNames[index.Name]; indexNameExists {
 			for i := range desc.Indexes {
 				if desc.Indexes[i].Name == index.Name {
-					return fmt.Errorf("duplicate index name: %q", index.Name)
+					// This error should be caught in MakeIndexDescriptor.
+					return errors.HandleAsAssertionFailure(fmt.Errorf("duplicate index name: %q", index.Name))
 				}
 			}
-			return fmt.Errorf("duplicate: index %q in the middle of being added, not yet public", index.Name)
+			// This error should be caught in MakeIndexDescriptor.
+			return errors.HandleAsAssertionFailure(fmt.Errorf(
+				"duplicate: index %q in the middle of being added, not yet public", index.Name))
 		}
 		indexNames[index.Name] = struct{}{}
 


### PR DESCRIPTION
Prior to this change, index creation would not validate the name of the
index until after the table descriptor had been updated. This lead to an
error in sqlbase which did not have an error code and did not match up
with postgres.

Touches #47430.

Before:

```
root@:26257/defaultdb> CREATE TABLE t (col1 int, col2 int);
CREATE TABLE

Time: 41.895671ms

root@:26257/defaultdb> CREATE INDEX col1_ind ON t (col1);
CREATE INDEX

Time: 485.49071ms

root@:26257/defaultdb> CREATE INDEX col1_ind ON t (col2);
ERROR: duplicate index name: "col1_ind"
```

After:
```
root@:26257/defaultdb> CREATE TABLE t (col1 int, col2 int);
CREATE TABLE

Time: 41.895671ms

root@:26257/defaultdb> CREATE INDEX col1_ind ON t (col1);
CREATE INDEX

Time: 485.49071ms

root@:26257/defaultdb> CREATE INDEX col1_ind ON t (col2);
ERROR: relation "col1_ind" already exists
SQLSTATE: 42P07
```

Postgres:
```
=> CREATE TABLE t (col1 int, col2 int);
CREATE TABLE
=> CREATE INDEX col1_ind ON t (col1);
CREATE INDEX
=> CREATE INDEX col1_ind ON t (col2);
ERROR:  42P07: relation "col1_ind" already exists
LOCATION:  index_create, index.c:821
```

Release note (bug fix): Return proper error for index creation statements
using an existing index name.