### PR TITLE
opt: smarter SplitDisjunction(AddKey) rules

### DIFF
--- a/pkg/sql/opt/xform/rules/select.opt
+++ b/pkg/sql/opt/xform/rules/select.opt
@@ -49,10 +49,7 @@
     $input:(Scan
         $scanPrivate:* & (IsCanonicalScan $scanPrivate)
     ) & (HasStrictKey $input)
-    $filters:* &
-        (ExprPairSucceeded $pair:(ExprPairForSplitDisjunction $filters)) &
-        (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols (ExprPairLeft $pair))) &
-        (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols (ExprPairRight $pair)))
+    $filters:* & (ExprPairSucceeded $pair:(ExprPairForSplitDisjunction $scanPrivate $filters))
 )
 =>
 (DistinctOn
@@ -112,10 +109,7 @@
     $input:(Scan
         $scanPrivate:* & (IsCanonicalScan $scanPrivate)
     ) & ^(HasStrictKey $input)
-    $filters:* &
-        (ExprPairSucceeded $pair:(ExprPairForSplitDisjunction $filters)) &
-        (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols (ExprPairLeft $pair))) &
-        (CanMaybeConstrainIndexWithCols $scanPrivate (OuterCols (ExprPairRight $pair)))
+    $filters:* & (ExprPairSucceeded $pair:(ExprPairForSplitDisjunction $scanPrivate $filters))
 )
 =>
 (Project

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1843,6 +1843,61 @@ project
            └── const-agg [as=w:4, outer=(4)]
                 └── w:4
 
+# Find the first disjunction in the filters that have columns on the left and
+# right that constrain a scan.
+opt expect=SplitDisjunction
+SELECT k FROM d WHERE (u = 1 OR w = 2) AND (u = 3 OR v = 4)
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── distinct-on
+      ├── columns: k:1!null u:2 v:3 w:4
+      ├── grouping columns: k:1!null
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      ├── union-all
+      │    ├── columns: k:1!null u:2 v:3 w:4
+      │    ├── left columns: k:1!null u:2 v:3 w:4
+      │    ├── right columns: k:5 u:6 v:7 w:8
+      │    ├── select
+      │    │    ├── columns: k:1!null u:2!null v:3 w:4!null
+      │    │    ├── key: (1)
+      │    │    ├── fd: ()-->(2,4), (1)-->(3)
+      │    │    ├── index-join d
+      │    │    │    ├── columns: k:1!null u:2 v:3 w:4
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: ()-->(2), (1)-->(3,4)
+      │    │    │    └── scan d@u
+      │    │    │         ├── columns: k:1!null u:2!null
+      │    │    │         ├── constraint: /2/1: [/3 - /3]
+      │    │    │         ├── key: (1)
+      │    │    │         └── fd: ()-->(2)
+      │    │    └── filters
+      │    │         └── w:4 = 2 [outer=(4), constraints=(/4: [/2 - /2]; tight), fd=()-->(4)]
+      │    └── select
+      │         ├── columns: k:5!null u:6 v:7!null w:8
+      │         ├── key: (5)
+      │         ├── fd: ()-->(7), (5)-->(6,8)
+      │         ├── index-join d
+      │         │    ├── columns: k:5!null u:6 v:7 w:8
+      │         │    ├── key: (5)
+      │         │    ├── fd: ()-->(7), (5)-->(6,8)
+      │         │    └── scan d@v
+      │         │         ├── columns: k:5!null v:7!null
+      │         │         ├── constraint: /7/5: [/4 - /4]
+      │         │         ├── key: (5)
+      │         │         └── fd: ()-->(7)
+      │         └── filters
+      │              └── (u:6 = 1) OR (w:8 = 2) [outer=(6,8)]
+      └── aggregations
+           ├── const-agg [as=u:2, outer=(2)]
+           │    └── u:2
+           ├── const-agg [as=v:3, outer=(3)]
+           │    └── v:3
+           └── const-agg [as=w:4, outer=(4)]
+                └── w:4
+
 # Don't apply when outer columns of both sides of OR do not intersect with index columns.
 opt expect-not=SplitDisjunction
 SELECT k, u, w FROM d WHERE u = 1 OR w = 1
@@ -2798,6 +2853,62 @@ project
            │         │         └── fd: ()-->(7)
            │         └── filters
            │              └── (w:8 = 1) OR (w:8 = 2) [outer=(8), constraints=(/8: [/1 - /1] [/2 - /2]; tight)]
+           └── aggregations
+                ├── const-agg [as=u:2, outer=(2)]
+                │    └── u:2
+                ├── const-agg [as=v:3, outer=(3)]
+                │    └── v:3
+                └── const-agg [as=w:4, outer=(4)]
+                     └── w:4
+
+# Find the first disjunction in the filters that have columns on the left and
+# right that constrain a scan.
+opt expect=SplitDisjunctionAddKey
+SELECT u, v FROM d WHERE (u = 1 OR w = 2) AND (u = 3 OR v = 4)
+----
+project
+ ├── columns: u:2 v:3
+ └── project
+      ├── columns: u:2 v:3 w:4
+      └── distinct-on
+           ├── columns: k:1!null u:2 v:3 w:4
+           ├── grouping columns: k:1!null
+           ├── key: (1)
+           ├── fd: (1)-->(2-4)
+           ├── union-all
+           │    ├── columns: k:1!null u:2 v:3 w:4
+           │    ├── left columns: k:1!null u:2 v:3 w:4
+           │    ├── right columns: k:5 u:6 v:7 w:8
+           │    ├── select
+           │    │    ├── columns: k:1!null u:2!null v:3 w:4!null
+           │    │    ├── key: (1)
+           │    │    ├── fd: ()-->(2,4), (1)-->(3)
+           │    │    ├── index-join d
+           │    │    │    ├── columns: k:1!null u:2 v:3 w:4
+           │    │    │    ├── key: (1)
+           │    │    │    ├── fd: ()-->(2), (1)-->(3,4)
+           │    │    │    └── scan d@u
+           │    │    │         ├── columns: k:1!null u:2!null
+           │    │    │         ├── constraint: /2/1: [/3 - /3]
+           │    │    │         ├── key: (1)
+           │    │    │         └── fd: ()-->(2)
+           │    │    └── filters
+           │    │         └── w:4 = 2 [outer=(4), constraints=(/4: [/2 - /2]; tight), fd=()-->(4)]
+           │    └── select
+           │         ├── columns: k:5!null u:6 v:7!null w:8
+           │         ├── key: (5)
+           │         ├── fd: ()-->(7), (5)-->(6,8)
+           │         ├── index-join d
+           │         │    ├── columns: k:5!null u:6 v:7 w:8
+           │         │    ├── key: (5)
+           │         │    ├── fd: ()-->(7), (5)-->(6,8)
+           │         │    └── scan d@v
+           │         │         ├── columns: k:5!null v:7!null
+           │         │         ├── constraint: /7/5: [/4 - /4]
+           │         │         ├── key: (5)
+           │         │         └── fd: ()-->(7)
+           │         └── filters
+           │              └── (u:6 = 1) OR (w:8 = 2) [outer=(6,8)]
            └── aggregations
                 ├── const-agg [as=u:2, outer=(2)]
                 │    └── u:2


### PR DESCRIPTION
Previously, SplitDisjunction(AddKey) would find the first disjunction
that could be split into two expressions with unequal columns. The rule
would then only match if these two expressions looked likely to
constrain an index scan. This was limiting, because if this first
disjunction found was not likely to constrain and index scan, other
disjunctions in the filters would not be searched.

For example, consider the following query where an index exists on a and
another on b, but there is no index on c.

```
SELECT * FROM t WHERE (a = 1 OR c = 3) AND (a = 1 OR b = 2)
```

The first disjunction with unequal columns on the left and right is `a =
1 OR c = 3`.
This is the first disjunction found. However, no index
exists on c, so the SplitDisjunction rule would not apply, and this query
would not be optimized into a UnionAll over two index scans.

This commit makes the search for a qualifying disjunction more
thoughtful. It now finds the first disjunction with unequal columns on
each side AND where those columns are likely to constrain an index scan.

Release note (performance improvement): The query optimizer can now
split disjunctions in more complex expressions into a union over two
index scans.