### PR TITLE
sql: project away added key columns from output of decorrelation rules

### DIFF
--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -329,7 +329,7 @@
     $private:*
 )
 =>
-(Project
+(Project # Needed to project away any columns added by EnsureKey.
     (Select
         ((OpName $right)
             (InnerJoinApply
@@ -453,35 +453,39 @@
 )
 =>
 (Select
-    # TranslateNonIgnoreAggs is where the actual discriminating CASE
-    # expressions are introduced.
-    (TranslateNonIgnoreAggs
-        (GroupBy
-            (LeftJoinApply
-                $leftWithKey:(EnsureKey $left)
-                # canaryCol might be 0 if no canary is necessary, in which case
-                # this function does nothing.
-                $rightWithCanary:(EnsureCanary
-                    $input
-                    $canaryCol:(EnsureCanaryCol $input $aggregations)
+    (Project # Needed to project away any columns added by EnsureKey.
+        # TranslateNonIgnoreAggs is where the actual discriminating CASE
+        # expressions are introduced.
+        (TranslateNonIgnoreAggs
+            (GroupBy
+                (LeftJoinApply
+                    $leftWithKey:(EnsureKey $left)
+                    # canaryCol might be 0 if no canary is necessary, in which case
+                    # this function does nothing.
+                    $rightWithCanary:(EnsureCanary
+                        $input
+                        $canaryCol:(EnsureCanaryCol $input $aggregations)
+                    )
+                    []
+                    $private
                 )
-                []
-                $private
-            )
-            (AppendAggCols2
-                $translatedAggs:(EnsureAggsCanIgnoreNulls
-                    $rightWithCanary
-                    $aggregations
+                (AppendAggCols2
+                    $translatedAggs:(EnsureAggsCanIgnoreNulls
+                        $rightWithCanary
+                        $aggregations
+                    )
+                    ConstAgg (NonKeyCols $leftWithKey)
+                    AnyNotNullAgg (CanaryColSet $canaryCol)
                 )
-                ConstAgg (NonKeyCols $leftWithKey)
-                AnyNotNullAgg (CanaryColSet $canaryCol)
+                (MakeOrderedGrouping (KeyCols $leftWithKey) (ExtractGroupingOrdering $groupingPrivate))
             )
-            (MakeOrderedGrouping (KeyCols $leftWithKey) (ExtractGroupingOrdering $groupingPrivate))
+            $translatedAggs
+            $rightWithCanary
+            $aggregations
+            $canaryCol
         )
-        $translatedAggs
-        $rightWithCanary
-        $aggregations
-        $canaryCol
+        []
+        (OutputCols2 $left $right)
     )
     $on
 )
@@ -503,15 +507,19 @@
     $private:*
 )
 =>
-(GroupBy
-    (InnerJoinApply
-        $newLeft:(EnsureKey $left)
-        $right
-        $on
-        $private
+(Project # Needed to project away any columns added by EnsureKey.
+    (GroupBy
+        (InnerJoinApply
+            $newLeft:(EnsureKey $left)
+            $right
+            $on
+            $private
+        )
+        (MakeAggCols ConstAgg (NonKeyCols $newLeft))
+        (MakeGrouping (KeyCols $newLeft))
     )
-    (MakeAggCols ConstAgg (NonKeyCols $newLeft))
-    (MakeGrouping (KeyCols $newLeft))
+    []
+    (OutputCols2 $left $right)
 )
 
 # TryDecorrelateLimitOne "pushes down" a Join into a Limit 1 operator, in an
@@ -538,18 +546,22 @@
     $private:*
 )
 =>
-(DistinctOn
-    ((OpName)
-        $newLeft:(EnsureKey $left)
-        $input
-        $on
-        $private
+(Project # Needed to project away any columns added by EnsureKey.
+    (DistinctOn
+        ((OpName)
+            $newLeft:(EnsureKey $left)
+            $input
+            $on
+            $private
+        )
+        (MakeAggCols2
+            ConstAgg (NonKeyCols $newLeft)
+            FirstAgg (OutputCols $input)
+        )
+        (MakeOrderedGrouping (KeyCols $newLeft) $ordering)
     )
-    (MakeAggCols2
-        ConstAgg (NonKeyCols $newLeft)
-        FirstAgg (OutputCols $input)
-    )
-    (MakeOrderedGrouping (KeyCols $newLeft) $ordering)
+    []
+    (OutputCols2 $left $right)
 )
 
 # TryDecorrelateProjectSet "pushes down" an InnerJoinApply operator into a
@@ -672,7 +684,7 @@
     $joinPrivate:*
 )
 =>
-(Project
+(Project # Needed to project away any columns added by EnsureKey.
     (Select
         (Window
             ((OpName)

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -1654,7 +1654,7 @@ TryDecorrelateProject
          └── case:11 [as=r:8, outer=(11)]
 ================================================================================
 TryDecorrelateScalarGroupBy
-  Cost: 2232.67
+  Cost: 2242.68
 ================================================================================
    project
     ├── columns: r:8
@@ -1688,28 +1688,12 @@ TryDecorrelateScalarGroupBy
   - │    │    │    │    │    ├── fd: ()-->(9)
   - │    │    │    │    │    ├── select
   - │    │    │    │    │    │    ├── columns: k:3!null i:4
-  + │    │    │    ├── group-by
-  + │    │    │    │    ├── columns: x:1!null bool_or:10
-  + │    │    │    │    ├── grouping columns: x:1!null
-  + │    │    │    │    ├── key: (1)
-  + │    │    │    │    ├── fd: (1)-->(10)
-  + │    │    │    │    ├── left-join-apply
-  + │    │    │    │    │    ├── columns: x:1!null notnull:9
-  + │    │    │    │    │    ├── key: (1)
-  + │    │    │    │    │    ├── fd: (1)-->(9)
-  + │    │    │    │    │    ├── scan xy
-  + │    │    │    │    │    │    ├── columns: x:1!null
-  + │    │    │    │    │    │    └── key: (1)
-  + │    │    │    │    │    ├── project
-  + │    │    │    │    │    │    ├── columns: notnull:9!null
-    │    │    │    │    │    │    ├── outer: (1)
-    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-    │    │    │    │    │    │    ├── key: ()
+  - │    │    │    │    │    │    ├── outer: (1)
+  - │    │    │    │    │    │    ├── cardinality: [0 - 1]
+  - │    │    │    │    │    │    ├── key: ()
   - │    │    │    │    │    │    ├── fd: ()-->(3,4)
   - │    │    │    │    │    │    ├── scan a
-  + │    │    │    │    │    │    ├── fd: ()-->(9)
-  + │    │    │    │    │    │    ├── select
-    │    │    │    │    │    │    │    ├── columns: k:3!null i:4
+  - │    │    │    │    │    │    │    ├── columns: k:3!null i:4
   - │    │    │    │    │    │    │    ├── key: (3)
   - │    │    │    │    │    │    │    └── fd: (3)-->(4)
   - │    │    │    │    │    │    └── filters
@@ -1717,23 +1701,50 @@ TryDecorrelateScalarGroupBy
   - │    │    │    │    │    │         └── (i:4 = 5) IS NOT false [outer=(4)]
   - │    │    │    │    │    └── projections
   - │    │    │    │    │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
-  + │    │    │    │    │    │    │    ├── outer: (1)
-  + │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-  + │    │    │    │    │    │    │    ├── key: ()
-  + │    │    │    │    │    │    │    ├── fd: ()-->(3,4)
-  + │    │    │    │    │    │    │    ├── scan a
-  + │    │    │    │    │    │    │    │    ├── columns: k:3!null i:4
-  + │    │    │    │    │    │    │    │    ├── key: (3)
-  + │    │    │    │    │    │    │    │    └── fd: (3)-->(4)
-  + │    │    │    │    │    │    │    └── filters
-  + │    │    │    │    │    │    │         ├── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
-  + │    │    │    │    │    │    │         └── (i:4 = 5) IS NOT false [outer=(4)]
-  + │    │    │    │    │    │    └── projections
-  + │    │    │    │    │    │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
-  + │    │    │    │    │    └── filters (true)
-    │    │    │    │    └── aggregations
-    │    │    │    │         └── bool-or [as=bool_or:10, outer=(9)]
-    │    │    │    │              └── notnull:9
+  - │    │    │    │    └── aggregations
+  - │    │    │    │         └── bool-or [as=bool_or:10, outer=(9)]
+  - │    │    │    │              └── notnull:9
+  + │    │    │    ├── project
+  + │    │    │    │    ├── columns: x:1!null bool_or:10
+  + │    │    │    │    ├── key: (1)
+  + │    │    │    │    ├── fd: (1)-->(10)
+  + │    │    │    │    └── group-by
+  + │    │    │    │         ├── columns: x:1!null bool_or:10
+  + │    │    │    │         ├── grouping columns: x:1!null
+  + │    │    │    │         ├── key: (1)
+  + │    │    │    │         ├── fd: (1)-->(10)
+  + │    │    │    │         ├── left-join-apply
+  + │    │    │    │         │    ├── columns: x:1!null notnull:9
+  + │    │    │    │         │    ├── key: (1)
+  + │    │    │    │         │    ├── fd: (1)-->(9)
+  + │    │    │    │         │    ├── scan xy
+  + │    │    │    │         │    │    ├── columns: x:1!null
+  + │    │    │    │         │    │    └── key: (1)
+  + │    │    │    │         │    ├── project
+  + │    │    │    │         │    │    ├── columns: notnull:9!null
+  + │    │    │    │         │    │    ├── outer: (1)
+  + │    │    │    │         │    │    ├── cardinality: [0 - 1]
+  + │    │    │    │         │    │    ├── key: ()
+  + │    │    │    │         │    │    ├── fd: ()-->(9)
+  + │    │    │    │         │    │    ├── select
+  + │    │    │    │         │    │    │    ├── columns: k:3!null i:4
+  + │    │    │    │         │    │    │    ├── outer: (1)
+  + │    │    │    │         │    │    │    ├── cardinality: [0 - 1]
+  + │    │    │    │         │    │    │    ├── key: ()
+  + │    │    │    │         │    │    │    ├── fd: ()-->(3,4)
+  + │    │    │    │         │    │    │    ├── scan a
+  + │    │    │    │         │    │    │    │    ├── columns: k:3!null i:4
+  + │    │    │    │         │    │    │    │    ├── key: (3)
+  + │    │    │    │         │    │    │    │    └── fd: (3)-->(4)
+  + │    │    │    │         │    │    │    └── filters
+  + │    │    │    │         │    │    │         ├── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  + │    │    │    │         │    │    │         └── (i:4 = 5) IS NOT false [outer=(4)]
+  + │    │    │    │         │    │    └── projections
+  + │    │    │    │         │    │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
+  + │    │    │    │         │    └── filters (true)
+  + │    │    │    │         └── aggregations
+  + │    │    │    │              └── bool-or [as=bool_or:10, outer=(9)]
+  + │    │    │    │                   └── notnull:9
     │    │    │    └── filters (true)
     │    │    └── projections
     │    │         └── CASE WHEN bool_or:10 THEN true WHEN bool_or:10 IS NULL THEN false END [as=case:11, outer=(10)]
@@ -1742,7 +1753,7 @@ TryDecorrelateScalarGroupBy
          └── case:11 [as=r:8, outer=(11)]
 ================================================================================
 TryDecorrelateProjectSelect
-  Cost: 2270.13
+  Cost: 2280.14
 ================================================================================
    project
     ├── columns: r:8
@@ -1758,64 +1769,68 @@ TryDecorrelateProjectSelect
     │    │    │    ├── columns: x:1!null bool_or:10
     │    │    │    ├── key: (1)
     │    │    │    ├── fd: (1)-->(10)
-    │    │    │    ├── group-by
+    │    │    │    ├── project
     │    │    │    │    ├── columns: x:1!null bool_or:10
-    │    │    │    │    ├── grouping columns: x:1!null
     │    │    │    │    ├── key: (1)
     │    │    │    │    ├── fd: (1)-->(10)
-  - │    │    │    │    ├── left-join-apply
-  + │    │    │    │    ├── project
-    │    │    │    │    │    ├── columns: x:1!null notnull:9
-  - │    │    │    │    │    ├── key: (1)
-  - │    │    │    │    │    ├── fd: (1)-->(9)
-  - │    │    │    │    │    ├── scan xy
-  - │    │    │    │    │    │    ├── columns: x:1!null
-  - │    │    │    │    │    │    └── key: (1)
-  - │    │    │    │    │    ├── project
-  - │    │    │    │    │    │    ├── columns: notnull:9!null
-  - │    │    │    │    │    │    ├── outer: (1)
-  - │    │    │    │    │    │    ├── cardinality: [0 - 1]
-  - │    │    │    │    │    │    ├── key: ()
-  - │    │    │    │    │    │    ├── fd: ()-->(9)
-  - │    │    │    │    │    │    ├── select
-  - │    │    │    │    │    │    │    ├── columns: k:3!null i:4
-  - │    │    │    │    │    │    │    ├── outer: (1)
-  - │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-  - │    │    │    │    │    │    │    ├── key: ()
-  - │    │    │    │    │    │    │    ├── fd: ()-->(3,4)
-  - │    │    │    │    │    │    │    ├── scan a
-  - │    │    │    │    │    │    │    │    ├── columns: k:3!null i:4
-  - │    │    │    │    │    │    │    │    ├── key: (3)
-  - │    │    │    │    │    │    │    │    └── fd: (3)-->(4)
-  - │    │    │    │    │    │    │    └── filters
-  - │    │    │    │    │    │    │         ├── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
-  - │    │    │    │    │    │    │         └── (i:4 = 5) IS NOT false [outer=(4)]
-  - │    │    │    │    │    │    └── projections
-  - │    │    │    │    │    │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
-  - │    │    │    │    │    └── filters (true)
-  + │    │    │    │    │    └── left-join-apply
-  + │    │    │    │    │         ├── columns: x:1!null k:3 i:4 notnull:9
-  + │    │    │    │    │         ├── key: (1,3)
-  + │    │    │    │    │         ├── fd: (1,3)-->(4,9)
-  + │    │    │    │    │         ├── scan xy
-  + │    │    │    │    │         │    ├── columns: x:1!null
-  + │    │    │    │    │         │    └── key: (1)
-  + │    │    │    │    │         ├── project
-  + │    │    │    │    │         │    ├── columns: notnull:9!null k:3!null i:4
-  + │    │    │    │    │         │    ├── key: (3)
-  + │    │    │    │    │         │    ├── fd: (3)-->(4), (4)-->(9)
-  + │    │    │    │    │         │    ├── scan a
-  + │    │    │    │    │         │    │    ├── columns: k:3!null i:4
-  + │    │    │    │    │         │    │    ├── key: (3)
-  + │    │    │    │    │         │    │    └── fd: (3)-->(4)
-  + │    │    │    │    │         │    └── projections
-  + │    │    │    │    │         │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
-  + │    │    │    │    │         └── filters
-  + │    │    │    │    │              ├── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
-  + │    │    │    │    │              └── (i:4 = 5) IS NOT false [outer=(4)]
-    │    │    │    │    └── aggregations
-    │    │    │    │         └── bool-or [as=bool_or:10, outer=(9)]
-    │    │    │    │              └── notnull:9
+    │    │    │    │    └── group-by
+    │    │    │    │         ├── columns: x:1!null bool_or:10
+    │    │    │    │         ├── grouping columns: x:1!null
+    │    │    │    │         ├── key: (1)
+    │    │    │    │         ├── fd: (1)-->(10)
+  - │    │    │    │         ├── left-join-apply
+  + │    │    │    │         ├── project
+    │    │    │    │         │    ├── columns: x:1!null notnull:9
+  - │    │    │    │         │    ├── key: (1)
+  - │    │    │    │         │    ├── fd: (1)-->(9)
+  - │    │    │    │         │    ├── scan xy
+  - │    │    │    │         │    │    ├── columns: x:1!null
+  - │    │    │    │         │    │    └── key: (1)
+  - │    │    │    │         │    ├── project
+  - │    │    │    │         │    │    ├── columns: notnull:9!null
+  - │    │    │    │         │    │    ├── outer: (1)
+  - │    │    │    │         │    │    ├── cardinality: [0 - 1]
+  - │    │    │    │         │    │    ├── key: ()
+  - │    │    │    │         │    │    ├── fd: ()-->(9)
+  - │    │    │    │         │    │    ├── select
+  - │    │    │    │         │    │    │    ├── columns: k:3!null i:4
+  - │    │    │    │         │    │    │    ├── outer: (1)
+  - │    │    │    │         │    │    │    ├── cardinality: [0 - 1]
+  - │    │    │    │         │    │    │    ├── key: ()
+  - │    │    │    │         │    │    │    ├── fd: ()-->(3,4)
+  - │    │    │    │         │    │    │    ├── scan a
+  - │    │    │    │         │    │    │    │    ├── columns: k:3!null i:4
+  - │    │    │    │         │    │    │    │    ├── key: (3)
+  - │    │    │    │         │    │    │    │    └── fd: (3)-->(4)
+  - │    │    │    │         │    │    │    └── filters
+  - │    │    │    │         │    │    │         ├── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  - │    │    │    │         │    │    │         └── (i:4 = 5) IS NOT false [outer=(4)]
+  - │    │    │    │         │    │    └── projections
+  - │    │    │    │         │    │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
+  - │    │    │    │         │    └── filters (true)
+  + │    │    │    │         │    └── left-join-apply
+  + │    │    │    │         │         ├── columns: x:1!null k:3 i:4 notnull:9
+  + │    │    │    │         │         ├── key: (1,3)
+  + │    │    │    │         │         ├── fd: (1,3)-->(4,9)
+  + │    │    │    │         │         ├── scan xy
+  + │    │    │    │         │         │    ├── columns: x:1!null
+  + │    │    │    │         │         │    └── key: (1)
+  + │    │    │    │         │         ├── project
+  + │    │    │    │         │         │    ├── columns: notnull:9!null k:3!null i:4
+  + │    │    │    │         │         │    ├── key: (3)
+  + │    │    │    │         │         │    ├── fd: (3)-->(4), (4)-->(9)
+  + │    │    │    │         │         │    ├── scan a
+  + │    │    │    │         │         │    │    ├── columns: k:3!null i:4
+  + │    │    │    │         │         │    │    ├── key: (3)
+  + │    │    │    │         │         │    │    └── fd: (3)-->(4)
+  + │    │    │    │         │         │    └── projections
+  + │    │    │    │         │         │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
+  + │    │    │    │         │         └── filters
+  + │    │    │    │         │              ├── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  + │    │    │    │         │              └── (i:4 = 5) IS NOT false [outer=(4)]
+    │    │    │    │         └── aggregations
+    │    │    │    │              └── bool-or [as=bool_or:10, outer=(9)]
+    │    │    │    │                   └── notnull:9
     │    │    │    └── filters (true)
     │    │    └── projections
     │    │         └── CASE WHEN bool_or:10 THEN true WHEN bool_or:10 IS NULL THEN false END [as=case:11, outer=(10)]
@@ -1824,7 +1839,7 @@ TryDecorrelateProjectSelect
          └── case:11 [as=r:8, outer=(11)]
 ================================================================================
 DecorrelateJoin
-  Cost: 2270.13
+  Cost: 2280.14
 ================================================================================
    project
     ├── columns: r:8
@@ -1840,38 +1855,42 @@ DecorrelateJoin
     │    │    │    ├── columns: x:1!null bool_or:10
     │    │    │    ├── key: (1)
     │    │    │    ├── fd: (1)-->(10)
-    │    │    │    ├── group-by
+    │    │    │    ├── project
     │    │    │    │    ├── columns: x:1!null bool_or:10
-    │    │    │    │    ├── grouping columns: x:1!null
     │    │    │    │    ├── key: (1)
     │    │    │    │    ├── fd: (1)-->(10)
-    │    │    │    │    ├── project
-    │    │    │    │    │    ├── columns: x:1!null notnull:9
-  - │    │    │    │    │    └── left-join-apply
-  + │    │    │    │    │    └── left-join (hash)
-    │    │    │    │    │         ├── columns: x:1!null k:3 i:4 notnull:9
-    │    │    │    │    │         ├── key: (1,3)
-  - │    │    │    │    │         ├── fd: (1,3)-->(4,9)
-  + │    │    │    │    │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
-    │    │    │    │    │         ├── scan xy
-    │    │    │    │    │         │    ├── columns: x:1!null
-    │    │    │    │    │         │    └── key: (1)
-    │    │    │    │    │         ├── project
-    │    │    │    │    │         │    ├── columns: notnull:9!null k:3!null i:4
-    │    │    │    │    │         │    ├── key: (3)
-    │    │    │    │    │         │    ├── fd: (3)-->(4), (4)-->(9)
-    │    │    │    │    │         │    ├── scan a
-    │    │    │    │    │         │    │    ├── columns: k:3!null i:4
-    │    │    │    │    │         │    │    ├── key: (3)
-    │    │    │    │    │         │    │    └── fd: (3)-->(4)
-    │    │    │    │    │         │    └── projections
-    │    │    │    │    │         │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
-    │    │    │    │    │         └── filters
-    │    │    │    │    │              ├── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
-    │    │    │    │    │              └── (i:4 = 5) IS NOT false [outer=(4)]
-    │    │    │    │    └── aggregations
-    │    │    │    │         └── bool-or [as=bool_or:10, outer=(9)]
-    │    │    │    │              └── notnull:9
+    │    │    │    │    └── group-by
+    │    │    │    │         ├── columns: x:1!null bool_or:10
+    │    │    │    │         ├── grouping columns: x:1!null
+    │    │    │    │         ├── key: (1)
+    │    │    │    │         ├── fd: (1)-->(10)
+    │    │    │    │         ├── project
+    │    │    │    │         │    ├── columns: x:1!null notnull:9
+  - │    │    │    │         │    └── left-join-apply
+  + │    │    │    │         │    └── left-join (hash)
+    │    │    │    │         │         ├── columns: x:1!null k:3 i:4 notnull:9
+    │    │    │    │         │         ├── key: (1,3)
+  - │    │    │    │         │         ├── fd: (1,3)-->(4,9)
+  + │    │    │    │         │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
+    │    │    │    │         │         ├── scan xy
+    │    │    │    │         │         │    ├── columns: x:1!null
+    │    │    │    │         │         │    └── key: (1)
+    │    │    │    │         │         ├── project
+    │    │    │    │         │         │    ├── columns: notnull:9!null k:3!null i:4
+    │    │    │    │         │         │    ├── key: (3)
+    │    │    │    │         │         │    ├── fd: (3)-->(4), (4)-->(9)
+    │    │    │    │         │         │    ├── scan a
+    │    │    │    │         │         │    │    ├── columns: k:3!null i:4
+    │    │    │    │         │         │    │    ├── key: (3)
+    │    │    │    │         │         │    │    └── fd: (3)-->(4)
+    │    │    │    │         │         │    └── projections
+    │    │    │    │         │         │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
+    │    │    │    │         │         └── filters
+    │    │    │    │         │              ├── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+    │    │    │    │         │              └── (i:4 = 5) IS NOT false [outer=(4)]
+    │    │    │    │         └── aggregations
+    │    │    │    │              └── bool-or [as=bool_or:10, outer=(9)]
+    │    │    │    │                   └── notnull:9
     │    │    │    └── filters (true)
     │    │    └── projections
     │    │         └── CASE WHEN bool_or:10 THEN true WHEN bool_or:10 IS NULL THEN false END [as=case:11, outer=(10)]
@@ -1880,7 +1899,7 @@ DecorrelateJoin
          └── case:11 [as=r:8, outer=(11)]
 ================================================================================
 PushFilterIntoJoinRight
-  Cost: 2268.47
+  Cost: 2278.48
 ================================================================================
    project
     ├── columns: r:8
@@ -1896,50 +1915,54 @@ PushFilterIntoJoinRight
     │    │    │    ├── columns: x:1!null bool_or:10
     │    │    │    ├── key: (1)
     │    │    │    ├── fd: (1)-->(10)
-    │    │    │    ├── group-by
+    │    │    │    ├── project
     │    │    │    │    ├── columns: x:1!null bool_or:10
-    │    │    │    │    ├── grouping columns: x:1!null
     │    │    │    │    ├── key: (1)
     │    │    │    │    ├── fd: (1)-->(10)
-    │    │    │    │    ├── project
-    │    │    │    │    │    ├── columns: x:1!null notnull:9
-    │    │    │    │    │    └── left-join (hash)
-    │    │    │    │    │         ├── columns: x:1!null k:3 i:4 notnull:9
-    │    │    │    │    │         ├── key: (1,3)
-    │    │    │    │    │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
-    │    │    │    │    │         ├── scan xy
-    │    │    │    │    │         │    ├── columns: x:1!null
-    │    │    │    │    │         │    └── key: (1)
-  - │    │    │    │    │         ├── project
-  - │    │    │    │    │         │    ├── columns: notnull:9!null k:3!null i:4
-  + │    │    │    │    │         ├── select
-  + │    │    │    │    │         │    ├── columns: k:3!null i:4 notnull:9!null
-    │    │    │    │    │         │    ├── key: (3)
-    │    │    │    │    │         │    ├── fd: (3)-->(4), (4)-->(9)
-  - │    │    │    │    │         │    ├── scan a
-  - │    │    │    │    │         │    │    ├── columns: k:3!null i:4
-  + │    │    │    │    │         │    ├── project
-  + │    │    │    │    │         │    │    ├── columns: notnull:9!null k:3!null i:4
-    │    │    │    │    │         │    │    ├── key: (3)
-  - │    │    │    │    │         │    │    └── fd: (3)-->(4)
-  - │    │    │    │    │         │    └── projections
-  - │    │    │    │    │         │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
-  + │    │    │    │    │         │    │    ├── fd: (3)-->(4), (4)-->(9)
-  + │    │    │    │    │         │    │    ├── scan a
-  + │    │    │    │    │         │    │    │    ├── columns: k:3!null i:4
-  + │    │    │    │    │         │    │    │    ├── key: (3)
-  + │    │    │    │    │         │    │    │    └── fd: (3)-->(4)
-  + │    │    │    │    │         │    │    └── projections
-  + │    │    │    │    │         │    │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
-  + │    │    │    │    │         │    └── filters
-  + │    │    │    │    │         │         └── (i:4 = 5) IS NOT false [outer=(4)]
-    │    │    │    │    │         └── filters
-  - │    │    │    │    │              ├── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
-  - │    │    │    │    │              └── (i:4 = 5) IS NOT false [outer=(4)]
-  + │    │    │    │    │              └── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
-    │    │    │    │    └── aggregations
-    │    │    │    │         └── bool-or [as=bool_or:10, outer=(9)]
-    │    │    │    │              └── notnull:9
+    │    │    │    │    └── group-by
+    │    │    │    │         ├── columns: x:1!null bool_or:10
+    │    │    │    │         ├── grouping columns: x:1!null
+    │    │    │    │         ├── key: (1)
+    │    │    │    │         ├── fd: (1)-->(10)
+    │    │    │    │         ├── project
+    │    │    │    │         │    ├── columns: x:1!null notnull:9
+    │    │    │    │         │    └── left-join (hash)
+    │    │    │    │         │         ├── columns: x:1!null k:3 i:4 notnull:9
+    │    │    │    │         │         ├── key: (1,3)
+    │    │    │    │         │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
+    │    │    │    │         │         ├── scan xy
+    │    │    │    │         │         │    ├── columns: x:1!null
+    │    │    │    │         │         │    └── key: (1)
+  - │    │    │    │         │         ├── project
+  - │    │    │    │         │         │    ├── columns: notnull:9!null k:3!null i:4
+  + │    │    │    │         │         ├── select
+  + │    │    │    │         │         │    ├── columns: k:3!null i:4 notnull:9!null
+    │    │    │    │         │         │    ├── key: (3)
+    │    │    │    │         │         │    ├── fd: (3)-->(4), (4)-->(9)
+  - │    │    │    │         │         │    ├── scan a
+  - │    │    │    │         │         │    │    ├── columns: k:3!null i:4
+  + │    │    │    │         │         │    ├── project
+  + │    │    │    │         │         │    │    ├── columns: notnull:9!null k:3!null i:4
+    │    │    │    │         │         │    │    ├── key: (3)
+  - │    │    │    │         │         │    │    └── fd: (3)-->(4)
+  - │    │    │    │         │         │    └── projections
+  - │    │    │    │         │         │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
+  + │    │    │    │         │         │    │    ├── fd: (3)-->(4), (4)-->(9)
+  + │    │    │    │         │         │    │    ├── scan a
+  + │    │    │    │         │         │    │    │    ├── columns: k:3!null i:4
+  + │    │    │    │         │         │    │    │    ├── key: (3)
+  + │    │    │    │         │         │    │    │    └── fd: (3)-->(4)
+  + │    │    │    │         │         │    │    └── projections
+  + │    │    │    │         │         │    │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
+  + │    │    │    │         │         │    └── filters
+  + │    │    │    │         │         │         └── (i:4 = 5) IS NOT false [outer=(4)]
+    │    │    │    │         │         └── filters
+  - │    │    │    │         │              ├── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  - │    │    │    │         │              └── (i:4 = 5) IS NOT false [outer=(4)]
+  + │    │    │    │         │              └── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+    │    │    │    │         └── aggregations
+    │    │    │    │              └── bool-or [as=bool_or:10, outer=(9)]
+    │    │    │    │                   └── notnull:9
     │    │    │    └── filters (true)
     │    │    └── projections
     │    │         └── CASE WHEN bool_or:10 THEN true WHEN bool_or:10 IS NULL THEN false END [as=case:11, outer=(10)]
@@ -1948,7 +1971,7 @@ PushFilterIntoJoinRight
          └── case:11 [as=r:8, outer=(11)]
 ================================================================================
 PushSelectIntoProject
-  Cost: 2258.48
+  Cost: 2268.49
 ================================================================================
    project
     ├── columns: r:8
@@ -1964,50 +1987,54 @@ PushSelectIntoProject
     │    │    │    ├── columns: x:1!null bool_or:10
     │    │    │    ├── key: (1)
     │    │    │    ├── fd: (1)-->(10)
-    │    │    │    ├── group-by
+    │    │    │    ├── project
     │    │    │    │    ├── columns: x:1!null bool_or:10
-    │    │    │    │    ├── grouping columns: x:1!null
     │    │    │    │    ├── key: (1)
     │    │    │    │    ├── fd: (1)-->(10)
-    │    │    │    │    ├── project
-    │    │    │    │    │    ├── columns: x:1!null notnull:9
-    │    │    │    │    │    └── left-join (hash)
-    │    │    │    │    │         ├── columns: x:1!null k:3 i:4 notnull:9
-    │    │    │    │    │         ├── key: (1,3)
-    │    │    │    │    │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
-    │    │    │    │    │         ├── scan xy
-    │    │    │    │    │         │    ├── columns: x:1!null
-    │    │    │    │    │         │    └── key: (1)
-    │    │    │    │    │         ├── select
-    │    │    │    │    │         │    ├── columns: k:3!null i:4 notnull:9!null
-    │    │    │    │    │         │    ├── key: (3)
-    │    │    │    │    │         │    ├── fd: (3)-->(4), (4)-->(9)
-    │    │    │    │    │         │    ├── project
-    │    │    │    │    │         │    │    ├── columns: notnull:9!null k:3!null i:4
-    │    │    │    │    │         │    │    ├── key: (3)
-    │    │    │    │    │         │    │    ├── fd: (3)-->(4), (4)-->(9)
-  - │    │    │    │    │         │    │    ├── scan a
-  + │    │    │    │    │         │    │    ├── select
-    │    │    │    │    │         │    │    │    ├── columns: k:3!null i:4
-    │    │    │    │    │         │    │    │    ├── key: (3)
-  - │    │    │    │    │         │    │    │    └── fd: (3)-->(4)
-  + │    │    │    │    │         │    │    │    ├── fd: (3)-->(4)
-  + │    │    │    │    │         │    │    │    ├── scan a
-  + │    │    │    │    │         │    │    │    │    ├── columns: k:3!null i:4
-  + │    │    │    │    │         │    │    │    │    ├── key: (3)
-  + │    │    │    │    │         │    │    │    │    └── fd: (3)-->(4)
-  + │    │    │    │    │         │    │    │    └── filters
-  + │    │    │    │    │         │    │    │         └── (i:4 = 5) IS NOT false [outer=(4)]
-    │    │    │    │    │         │    │    └── projections
-    │    │    │    │    │         │    │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
-  - │    │    │    │    │         │    └── filters
-  - │    │    │    │    │         │         └── (i:4 = 5) IS NOT false [outer=(4)]
-  + │    │    │    │    │         │    └── filters (true)
-    │    │    │    │    │         └── filters
-    │    │    │    │    │              └── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
-    │    │    │    │    └── aggregations
-    │    │    │    │         └── bool-or [as=bool_or:10, outer=(9)]
-    │    │    │    │              └── notnull:9
+    │    │    │    │    └── group-by
+    │    │    │    │         ├── columns: x:1!null bool_or:10
+    │    │    │    │         ├── grouping columns: x:1!null
+    │    │    │    │         ├── key: (1)
+    │    │    │    │         ├── fd: (1)-->(10)
+    │    │    │    │         ├── project
+    │    │    │    │         │    ├── columns: x:1!null notnull:9
+    │    │    │    │         │    └── left-join (hash)
+    │    │    │    │         │         ├── columns: x:1!null k:3 i:4 notnull:9
+    │    │    │    │         │         ├── key: (1,3)
+    │    │    │    │         │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
+    │    │    │    │         │         ├── scan xy
+    │    │    │    │         │         │    ├── columns: x:1!null
+    │    │    │    │         │         │    └── key: (1)
+    │    │    │    │         │         ├── select
+    │    │    │    │         │         │    ├── columns: k:3!null i:4 notnull:9!null
+    │    │    │    │         │         │    ├── key: (3)
+    │    │    │    │         │         │    ├── fd: (3)-->(4), (4)-->(9)
+    │    │    │    │         │         │    ├── project
+    │    │    │    │         │         │    │    ├── columns: notnull:9!null k:3!null i:4
+    │    │    │    │         │         │    │    ├── key: (3)
+    │    │    │    │         │         │    │    ├── fd: (3)-->(4), (4)-->(9)
+  - │    │    │    │         │         │    │    ├── scan a
+  + │    │    │    │         │         │    │    ├── select
+    │    │    │    │         │         │    │    │    ├── columns: k:3!null i:4
+    │    │    │    │         │         │    │    │    ├── key: (3)
+  - │    │    │    │         │         │    │    │    └── fd: (3)-->(4)
+  + │    │    │    │         │         │    │    │    ├── fd: (3)-->(4)
+  + │    │    │    │         │         │    │    │    ├── scan a
+  + │    │    │    │         │         │    │    │    │    ├── columns: k:3!null i:4
+  + │    │    │    │         │         │    │    │    │    ├── key: (3)
+  + │    │    │    │         │         │    │    │    │    └── fd: (3)-->(4)
+  + │    │    │    │         │         │    │    │    └── filters
+  + │    │    │    │         │         │    │    │         └── (i:4 = 5) IS NOT false [outer=(4)]
+    │    │    │    │         │         │    │    └── projections
+    │    │    │    │         │         │    │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
+  - │    │    │    │         │         │    └── filters
+  - │    │    │    │         │         │         └── (i:4 = 5) IS NOT false [outer=(4)]
+  + │    │    │    │         │         │    └── filters (true)
+    │    │    │    │         │         └── filters
+    │    │    │    │         │              └── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+    │    │    │    │         └── aggregations
+    │    │    │    │              └── bool-or [as=bool_or:10, outer=(9)]
+    │    │    │    │                   └── notnull:9
     │    │    │    └── filters (true)
     │    │    └── projections
     │    │         └── CASE WHEN bool_or:10 THEN true WHEN bool_or:10 IS NULL THEN false END [as=case:11, outer=(10)]
@@ -2016,7 +2043,7 @@ PushSelectIntoProject
          └── case:11 [as=r:8, outer=(11)]
 ================================================================================
 EliminateSelect
-  Cost: 2255.14
+  Cost: 2265.15
 ================================================================================
    project
     ├── columns: r:8
@@ -2032,57 +2059,61 @@ EliminateSelect
     │    │    │    ├── columns: x:1!null bool_or:10
     │    │    │    ├── key: (1)
     │    │    │    ├── fd: (1)-->(10)
-    │    │    │    ├── group-by
+    │    │    │    ├── project
     │    │    │    │    ├── columns: x:1!null bool_or:10
-    │    │    │    │    ├── grouping columns: x:1!null
     │    │    │    │    ├── key: (1)
     │    │    │    │    ├── fd: (1)-->(10)
-    │    │    │    │    ├── project
-    │    │    │    │    │    ├── columns: x:1!null notnull:9
-    │    │    │    │    │    └── left-join (hash)
-    │    │    │    │    │         ├── columns: x:1!null k:3 i:4 notnull:9
-    │    │    │    │    │         ├── key: (1,3)
-    │    │    │    │    │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
-    │    │    │    │    │         ├── scan xy
-    │    │    │    │    │         │    ├── columns: x:1!null
-    │    │    │    │    │         │    └── key: (1)
-  - │    │    │    │    │         ├── select
-  - │    │    │    │    │         │    ├── columns: k:3!null i:4 notnull:9!null
-  + │    │    │    │    │         ├── project
-  + │    │    │    │    │         │    ├── columns: notnull:9!null k:3!null i:4
-    │    │    │    │    │         │    ├── key: (3)
-    │    │    │    │    │         │    ├── fd: (3)-->(4), (4)-->(9)
-  - │    │    │    │    │         │    ├── project
-  - │    │    │    │    │         │    │    ├── columns: notnull:9!null k:3!null i:4
-  + │    │    │    │    │         │    ├── select
-  + │    │    │    │    │         │    │    ├── columns: k:3!null i:4
-    │    │    │    │    │         │    │    ├── key: (3)
-  - │    │    │    │    │         │    │    ├── fd: (3)-->(4), (4)-->(9)
-  - │    │    │    │    │         │    │    ├── select
-  + │    │    │    │    │         │    │    ├── fd: (3)-->(4)
-  + │    │    │    │    │         │    │    ├── scan a
-    │    │    │    │    │         │    │    │    ├── columns: k:3!null i:4
-    │    │    │    │    │         │    │    │    ├── key: (3)
-  - │    │    │    │    │         │    │    │    ├── fd: (3)-->(4)
-  - │    │    │    │    │         │    │    │    ├── scan a
-  - │    │    │    │    │         │    │    │    │    ├── columns: k:3!null i:4
-  - │    │    │    │    │         │    │    │    │    ├── key: (3)
-  - │    │    │    │    │         │    │    │    │    └── fd: (3)-->(4)
-  - │    │    │    │    │         │    │    │    └── filters
-  - │    │    │    │    │         │    │    │         └── (i:4 = 5) IS NOT false [outer=(4)]
-  - │    │    │    │    │         │    │    └── projections
-  - │    │    │    │    │         │    │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
-  - │    │    │    │    │         │    └── filters (true)
-  + │    │    │    │    │         │    │    │    └── fd: (3)-->(4)
-  + │    │    │    │    │         │    │    └── filters
-  + │    │    │    │    │         │    │         └── (i:4 = 5) IS NOT false [outer=(4)]
-  + │    │    │    │    │         │    └── projections
-  + │    │    │    │    │         │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
-    │    │    │    │    │         └── filters
-    │    │    │    │    │              └── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
-    │    │    │    │    └── aggregations
-    │    │    │    │         └── bool-or [as=bool_or:10, outer=(9)]
-    │    │    │    │              └── notnull:9
+    │    │    │    │    └── group-by
+    │    │    │    │         ├── columns: x:1!null bool_or:10
+    │    │    │    │         ├── grouping columns: x:1!null
+    │    │    │    │         ├── key: (1)
+    │    │    │    │         ├── fd: (1)-->(10)
+    │    │    │    │         ├── project
+    │    │    │    │         │    ├── columns: x:1!null notnull:9
+    │    │    │    │         │    └── left-join (hash)
+    │    │    │    │         │         ├── columns: x:1!null k:3 i:4 notnull:9
+    │    │    │    │         │         ├── key: (1,3)
+    │    │    │    │         │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
+    │    │    │    │         │         ├── scan xy
+    │    │    │    │         │         │    ├── columns: x:1!null
+    │    │    │    │         │         │    └── key: (1)
+  - │    │    │    │         │         ├── select
+  - │    │    │    │         │         │    ├── columns: k:3!null i:4 notnull:9!null
+  + │    │    │    │         │         ├── project
+  + │    │    │    │         │         │    ├── columns: notnull:9!null k:3!null i:4
+    │    │    │    │         │         │    ├── key: (3)
+    │    │    │    │         │         │    ├── fd: (3)-->(4), (4)-->(9)
+  - │    │    │    │         │         │    ├── project
+  - │    │    │    │         │         │    │    ├── columns: notnull:9!null k:3!null i:4
+  + │    │    │    │         │         │    ├── select
+  + │    │    │    │         │         │    │    ├── columns: k:3!null i:4
+    │    │    │    │         │         │    │    ├── key: (3)
+  - │    │    │    │         │         │    │    ├── fd: (3)-->(4), (4)-->(9)
+  - │    │    │    │         │         │    │    ├── select
+  + │    │    │    │         │         │    │    ├── fd: (3)-->(4)
+  + │    │    │    │         │         │    │    ├── scan a
+    │    │    │    │         │         │    │    │    ├── columns: k:3!null i:4
+    │    │    │    │         │         │    │    │    ├── key: (3)
+  - │    │    │    │         │         │    │    │    ├── fd: (3)-->(4)
+  - │    │    │    │         │         │    │    │    ├── scan a
+  - │    │    │    │         │         │    │    │    │    ├── columns: k:3!null i:4
+  - │    │    │    │         │         │    │    │    │    ├── key: (3)
+  - │    │    │    │         │         │    │    │    │    └── fd: (3)-->(4)
+  - │    │    │    │         │         │    │    │    └── filters
+  - │    │    │    │         │         │    │    │         └── (i:4 = 5) IS NOT false [outer=(4)]
+  - │    │    │    │         │         │    │    └── projections
+  - │    │    │    │         │         │    │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
+  - │    │    │    │         │         │    └── filters (true)
+  + │    │    │    │         │         │    │    │    └── fd: (3)-->(4)
+  + │    │    │    │         │         │    │    └── filters
+  + │    │    │    │         │         │    │         └── (i:4 = 5) IS NOT false [outer=(4)]
+  + │    │    │    │         │         │    └── projections
+  + │    │    │    │         │         │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
+    │    │    │    │         │         └── filters
+    │    │    │    │         │              └── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+    │    │    │    │         └── aggregations
+    │    │    │    │              └── bool-or [as=bool_or:10, outer=(9)]
+    │    │    │    │                   └── notnull:9
     │    │    │    └── filters (true)
     │    │    └── projections
     │    │         └── CASE WHEN bool_or:10 THEN true WHEN bool_or:10 IS NULL THEN false END [as=case:11, outer=(10)]
@@ -2091,6 +2122,73 @@ EliminateSelect
          └── case:11 [as=r:8, outer=(11)]
 ================================================================================
 PruneJoinRightCols
+  Cost: 2265.15
+================================================================================
+   project
+    ├── columns: r:8
+    ├── select
+    │    ├── columns: x:1!null case:11
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(11)
+    │    ├── project
+    │    │    ├── columns: case:11 x:1!null
+    │    │    ├── key: (1)
+    │    │    ├── fd: (1)-->(11)
+    │    │    ├── select
+    │    │    │    ├── columns: x:1!null bool_or:10
+    │    │    │    ├── key: (1)
+    │    │    │    ├── fd: (1)-->(10)
+    │    │    │    ├── project
+    │    │    │    │    ├── columns: x:1!null bool_or:10
+    │    │    │    │    ├── key: (1)
+    │    │    │    │    ├── fd: (1)-->(10)
+    │    │    │    │    └── group-by
+    │    │    │    │         ├── columns: x:1!null bool_or:10
+    │    │    │    │         ├── grouping columns: x:1!null
+    │    │    │    │         ├── key: (1)
+    │    │    │    │         ├── fd: (1)-->(10)
+    │    │    │    │         ├── project
+    │    │    │    │         │    ├── columns: x:1!null notnull:9
+    │    │    │    │         │    └── left-join (hash)
+  - │    │    │    │         │         ├── columns: x:1!null k:3 i:4 notnull:9
+  + │    │    │    │         │         ├── columns: x:1!null k:3 notnull:9
+    │    │    │    │         │         ├── key: (1,3)
+  - │    │    │    │         │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
+  + │    │    │    │         │         ├── fd: (3)-->(9)
+    │    │    │    │         │         ├── scan xy
+    │    │    │    │         │         │    ├── columns: x:1!null
+    │    │    │    │         │         │    └── key: (1)
+    │    │    │    │         │         ├── project
+  - │    │    │    │         │         │    ├── columns: notnull:9!null k:3!null i:4
+  + │    │    │    │         │         │    ├── columns: notnull:9!null k:3!null
+    │    │    │    │         │         │    ├── key: (3)
+  - │    │    │    │         │         │    ├── fd: (3)-->(4), (4)-->(9)
+  + │    │    │    │         │         │    ├── fd: (3)-->(9)
+    │    │    │    │         │         │    ├── select
+    │    │    │    │         │         │    │    ├── columns: k:3!null i:4
+    │    │    │    │         │         │    │    ├── key: (3)
+    │    │    │    │         │         │    │    ├── fd: (3)-->(4)
+    │    │    │    │         │         │    │    ├── scan a
+    │    │    │    │         │         │    │    │    ├── columns: k:3!null i:4
+    │    │    │    │         │         │    │    │    ├── key: (3)
+    │    │    │    │         │         │    │    │    └── fd: (3)-->(4)
+    │    │    │    │         │         │    │    └── filters
+    │    │    │    │         │         │    │         └── (i:4 = 5) IS NOT false [outer=(4)]
+    │    │    │    │         │         │    └── projections
+    │    │    │    │         │         │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
+    │    │    │    │         │         └── filters
+    │    │    │    │         │              └── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+    │    │    │    │         └── aggregations
+    │    │    │    │              └── bool-or [as=bool_or:10, outer=(9)]
+    │    │    │    │                   └── notnull:9
+    │    │    │    └── filters (true)
+    │    │    └── projections
+    │    │         └── CASE WHEN bool_or:10 THEN true WHEN bool_or:10 IS NULL THEN false END [as=case:11, outer=(10)]
+    │    └── filters (true)
+    └── projections
+         └── case:11 [as=r:8, outer=(11)]
+================================================================================
+EliminateGroupByProject
   Cost: 2255.14
 ================================================================================
    project
@@ -2107,45 +2205,70 @@ PruneJoinRightCols
     │    │    │    ├── columns: x:1!null bool_or:10
     │    │    │    ├── key: (1)
     │    │    │    ├── fd: (1)-->(10)
-    │    │    │    ├── group-by
+    │    │    │    ├── project
     │    │    │    │    ├── columns: x:1!null bool_or:10
-    │    │    │    │    ├── grouping columns: x:1!null
     │    │    │    │    ├── key: (1)
     │    │    │    │    ├── fd: (1)-->(10)
-    │    │    │    │    ├── project
-    │    │    │    │    │    ├── columns: x:1!null notnull:9
-    │    │    │    │    │    └── left-join (hash)
-  - │    │    │    │    │         ├── columns: x:1!null k:3 i:4 notnull:9
-  + │    │    │    │    │         ├── columns: x:1!null k:3 notnull:9
-    │    │    │    │    │         ├── key: (1,3)
-  - │    │    │    │    │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
-  + │    │    │    │    │         ├── fd: (3)-->(9)
-    │    │    │    │    │         ├── scan xy
-    │    │    │    │    │         │    ├── columns: x:1!null
-    │    │    │    │    │         │    └── key: (1)
-    │    │    │    │    │         ├── project
-  - │    │    │    │    │         │    ├── columns: notnull:9!null k:3!null i:4
-  + │    │    │    │    │         │    ├── columns: notnull:9!null k:3!null
-    │    │    │    │    │         │    ├── key: (3)
-  - │    │    │    │    │         │    ├── fd: (3)-->(4), (4)-->(9)
-  + │    │    │    │    │         │    ├── fd: (3)-->(9)
-    │    │    │    │    │         │    ├── select
-    │    │    │    │    │         │    │    ├── columns: k:3!null i:4
-    │    │    │    │    │         │    │    ├── key: (3)
-    │    │    │    │    │         │    │    ├── fd: (3)-->(4)
-    │    │    │    │    │         │    │    ├── scan a
-    │    │    │    │    │         │    │    │    ├── columns: k:3!null i:4
-    │    │    │    │    │         │    │    │    ├── key: (3)
-    │    │    │    │    │         │    │    │    └── fd: (3)-->(4)
-    │    │    │    │    │         │    │    └── filters
-    │    │    │    │    │         │    │         └── (i:4 = 5) IS NOT false [outer=(4)]
-    │    │    │    │    │         │    └── projections
-    │    │    │    │    │         │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
-    │    │    │    │    │         └── filters
-    │    │    │    │    │              └── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
-    │    │    │    │    └── aggregations
-    │    │    │    │         └── bool-or [as=bool_or:10, outer=(9)]
-    │    │    │    │              └── notnull:9
+    │    │    │    │    └── group-by
+    │    │    │    │         ├── columns: x:1!null bool_or:10
+    │    │    │    │         ├── grouping columns: x:1!null
+    │    │    │    │         ├── key: (1)
+    │    │    │    │         ├── fd: (1)-->(10)
+  - │    │    │    │         ├── project
+  - │    │    │    │         │    ├── columns: x:1!null notnull:9
+  - │    │    │    │         │    └── left-join (hash)
+  - │    │    │    │         │         ├── columns: x:1!null k:3 notnull:9
+  - │    │    │    │         │         ├── key: (1,3)
+  - │    │    │    │         │         ├── fd: (3)-->(9)
+  - │    │    │    │         │         ├── scan xy
+  - │    │    │    │         │         │    ├── columns: x:1!null
+  - │    │    │    │         │         │    └── key: (1)
+  - │    │    │    │         │         ├── project
+  - │    │    │    │         │         │    ├── columns: notnull:9!null k:3!null
+  - │    │    │    │         │         │    ├── key: (3)
+  - │    │    │    │         │         │    ├── fd: (3)-->(9)
+  - │    │    │    │         │         │    ├── select
+  - │    │    │    │         │         │    │    ├── columns: k:3!null i:4
+  - │    │    │    │         │         │    │    ├── key: (3)
+  - │    │    │    │         │         │    │    ├── fd: (3)-->(4)
+  - │    │    │    │         │         │    │    ├── scan a
+  - │    │    │    │         │         │    │    │    ├── columns: k:3!null i:4
+  - │    │    │    │         │         │    │    │    ├── key: (3)
+  - │    │    │    │         │         │    │    │    └── fd: (3)-->(4)
+  - │    │    │    │         │         │    │    └── filters
+  - │    │    │    │         │         │    │         └── (i:4 = 5) IS NOT false [outer=(4)]
+  - │    │    │    │         │         │    └── projections
+  - │    │    │    │         │         │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
+  - │    │    │    │         │         └── filters
+  - │    │    │    │         │              └── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  + │    │    │    │         ├── left-join (hash)
+  + │    │    │    │         │    ├── columns: x:1!null k:3 notnull:9
+  + │    │    │    │         │    ├── key: (1,3)
+  + │    │    │    │         │    ├── fd: (3)-->(9)
+  + │    │    │    │         │    ├── scan xy
+  + │    │    │    │         │    │    ├── columns: x:1!null
+  + │    │    │    │         │    │    └── key: (1)
+  + │    │    │    │         │    ├── project
+  + │    │    │    │         │    │    ├── columns: notnull:9!null k:3!null
+  + │    │    │    │         │    │    ├── key: (3)
+  + │    │    │    │         │    │    ├── fd: (3)-->(9)
+  + │    │    │    │         │    │    ├── select
+  + │    │    │    │         │    │    │    ├── columns: k:3!null i:4
+  + │    │    │    │         │    │    │    ├── key: (3)
+  + │    │    │    │         │    │    │    ├── fd: (3)-->(4)
+  + │    │    │    │         │    │    │    ├── scan a
+  + │    │    │    │         │    │    │    │    ├── columns: k:3!null i:4
+  + │    │    │    │         │    │    │    │    ├── key: (3)
+  + │    │    │    │         │    │    │    │    └── fd: (3)-->(4)
+  + │    │    │    │         │    │    │    └── filters
+  + │    │    │    │         │    │    │         └── (i:4 = 5) IS NOT false [outer=(4)]
+  + │    │    │    │         │    │    └── projections
+  + │    │    │    │         │    │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
+  + │    │    │    │         │    └── filters
+  + │    │    │    │         │         └── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+    │    │    │    │         └── aggregations
+    │    │    │    │              └── bool-or [as=bool_or:10, outer=(9)]
+    │    │    │    │                   └── notnull:9
     │    │    │    └── filters (true)
     │    │    └── projections
     │    │         └── CASE WHEN bool_or:10 THEN true WHEN bool_or:10 IS NULL THEN false END [as=case:11, outer=(10)]
@@ -2153,7 +2276,7 @@ PruneJoinRightCols
     └── projections
          └── case:11 [as=r:8, outer=(11)]
 ================================================================================
-EliminateGroupByProject
+EliminateProject
   Cost: 2245.13
 ================================================================================
    project
@@ -2170,38 +2293,45 @@ EliminateGroupByProject
     │    │    │    ├── columns: x:1!null bool_or:10
     │    │    │    ├── key: (1)
     │    │    │    ├── fd: (1)-->(10)
-    │    │    │    ├── group-by
+  - │    │    │    ├── project
+  + │    │    │    ├── group-by
     │    │    │    │    ├── columns: x:1!null bool_or:10
-    │    │    │    │    ├── grouping columns: x:1!null
+  + │    │    │    │    ├── grouping columns: x:1!null
     │    │    │    │    ├── key: (1)
     │    │    │    │    ├── fd: (1)-->(10)
-  - │    │    │    │    ├── project
-  - │    │    │    │    │    ├── columns: x:1!null notnull:9
-  - │    │    │    │    │    └── left-join (hash)
-  - │    │    │    │    │         ├── columns: x:1!null k:3 notnull:9
-  - │    │    │    │    │         ├── key: (1,3)
-  - │    │    │    │    │         ├── fd: (3)-->(9)
-  - │    │    │    │    │         ├── scan xy
-  - │    │    │    │    │         │    ├── columns: x:1!null
-  - │    │    │    │    │         │    └── key: (1)
-  - │    │    │    │    │         ├── project
-  - │    │    │    │    │         │    ├── columns: notnull:9!null k:3!null
-  - │    │    │    │    │         │    ├── key: (3)
-  - │    │    │    │    │         │    ├── fd: (3)-->(9)
-  - │    │    │    │    │         │    ├── select
-  - │    │    │    │    │         │    │    ├── columns: k:3!null i:4
-  - │    │    │    │    │         │    │    ├── key: (3)
-  - │    │    │    │    │         │    │    ├── fd: (3)-->(4)
-  - │    │    │    │    │         │    │    ├── scan a
-  - │    │    │    │    │         │    │    │    ├── columns: k:3!null i:4
-  - │    │    │    │    │         │    │    │    ├── key: (3)
-  - │    │    │    │    │         │    │    │    └── fd: (3)-->(4)
-  - │    │    │    │    │         │    │    └── filters
-  - │    │    │    │    │         │    │         └── (i:4 = 5) IS NOT false [outer=(4)]
-  - │    │    │    │    │         │    └── projections
-  - │    │    │    │    │         │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
-  - │    │    │    │    │         └── filters
-  - │    │    │    │    │              └── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  - │    │    │    │    └── group-by
+  - │    │    │    │         ├── columns: x:1!null bool_or:10
+  - │    │    │    │         ├── grouping columns: x:1!null
+  - │    │    │    │         ├── key: (1)
+  - │    │    │    │         ├── fd: (1)-->(10)
+  - │    │    │    │         ├── left-join (hash)
+  - │    │    │    │         │    ├── columns: x:1!null k:3 notnull:9
+  - │    │    │    │         │    ├── key: (1,3)
+  - │    │    │    │         │    ├── fd: (3)-->(9)
+  - │    │    │    │         │    ├── scan xy
+  - │    │    │    │         │    │    ├── columns: x:1!null
+  - │    │    │    │         │    │    └── key: (1)
+  - │    │    │    │         │    ├── project
+  - │    │    │    │         │    │    ├── columns: notnull:9!null k:3!null
+  - │    │    │    │         │    │    ├── key: (3)
+  - │    │    │    │         │    │    ├── fd: (3)-->(9)
+  - │    │    │    │         │    │    ├── select
+  - │    │    │    │         │    │    │    ├── columns: k:3!null i:4
+  - │    │    │    │         │    │    │    ├── key: (3)
+  - │    │    │    │         │    │    │    ├── fd: (3)-->(4)
+  - │    │    │    │         │    │    │    ├── scan a
+  - │    │    │    │         │    │    │    │    ├── columns: k:3!null i:4
+  - │    │    │    │         │    │    │    │    ├── key: (3)
+  - │    │    │    │         │    │    │    │    └── fd: (3)-->(4)
+  - │    │    │    │         │    │    │    └── filters
+  - │    │    │    │         │    │    │         └── (i:4 = 5) IS NOT false [outer=(4)]
+  - │    │    │    │         │    │    └── projections
+  - │    │    │    │         │    │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
+  - │    │    │    │         │    └── filters
+  - │    │    │    │         │         └── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+  - │    │    │    │         └── aggregations
+  - │    │    │    │              └── bool-or [as=bool_or:10, outer=(9)]
+  - │    │    │    │                   └── notnull:9
   + │    │    │    │    ├── left-join (hash)
   + │    │    │    │    │    ├── columns: x:1!null k:3 notnull:9
   + │    │    │    │    │    ├── key: (1,3)
@@ -2227,9 +2357,9 @@ EliminateGroupByProject
   + │    │    │    │    │    │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
   + │    │    │    │    │    └── filters
   + │    │    │    │    │         └── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
-    │    │    │    │    └── aggregations
-    │    │    │    │         └── bool-or [as=bool_or:10, outer=(9)]
-    │    │    │    │              └── notnull:9
+  + │    │    │    │    └── aggregations
+  + │    │    │    │         └── bool-or [as=bool_or:10, outer=(9)]
+  + │    │    │    │              └── notnull:9
     │    │    │    └── filters (true)
     │    │    └── projections
     │    │         └── CASE WHEN bool_or:10 THEN true WHEN bool_or:10 IS NULL THEN false END [as=case:11, outer=(10)]


### PR DESCRIPTION
Previously, several decorrelation rules that use the EnsureKey function
did not project away columns added by EnsureKey.
This patch projects only columns that were in the original input in
order to ensure logical equivalence.

Release note: None