### PR TITLE
sql: add rule to transform unnest of an array into a Values operator

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -1141,7 +1141,101 @@ SELECT * FROM unnest(array[1,2], array[3,4,5]) AS t(a, b);
 a    b
 1    3  
 2    4  
-NULL 5 
+NULL 5
+
+query I rowsort
+SELECT unnest(ARRAY[1,2,3]) FROM unnest(ARRAY[4,5,6])
+----
+1
+1
+1
+2
+2
+2
+3
+3
+3
+
+query I rowsort
+SELECT unnest(ARRAY[NULL,2,3]) FROM unnest(ARRAY[NULL,NULL,NULL])
+----
+NULL
+NULL
+NULL
+2
+2
+2
+3
+3
+3
+
+query I rowsort
+SELECT unnest(ARRAY[1,2,NULL]) FROM unnest(ARRAY[NULL,NULL,NULL])
+----
+1
+1
+1
+2
+2
+2
+NULL
+NULL
+NULL
+
+query I rowsort
+SELECT unnest(ARRAY[NULL,NULL,NULL]) FROM unnest(ARRAY[NULL,NULL,NULL])
+----
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+
+statement ok
+CREATE TABLE xy (x INT PRIMARY KEY, y INT)
+
+statement ok
+INSERT INTO xy (VALUES (1,1), (2,2), (3,4), (4,8), (5,NULL))
+
+query II rowsort
+SELECT * FROM xy WHERE x IN (SELECT unnest(ARRAY[NULL,x]))
+----
+1  1
+2  2
+3  4
+4  8
+5  NULL
+
+query II rowsort
+SELECT * FROM xy
+WHERE EXISTS
+(SELECT t
+  FROM unnest(ARRAY[NULL,2,NULL,4,5,x])
+  AS f(t)
+  WHERE t=y
+)
+----
+1  1
+2  2
+3  4
+
+query IT rowsort
+SELECT unnest(ARRAY[1,2,3,4]), unnest(ARRAY['one','two'])
+----
+1  one
+2  two
+3  NULL
+4  NULL
+
+query error expected 1 to be of type varbit, found type int
+SELECT unnest(ARRAY[1,2,3::varbit])
+
+query error expected 2 to be of type varbit, found type int
+SELECT unnest(ARRAY[NULL,2,3::varbit])
 
 query error pq: could not determine polymorphic type
 SELECT unnest(NULL, NULL)

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -191,28 +191,28 @@ render                ·                   ·                                   
 query TTTTT
 EXPLAIN (VERBOSE) SELECT generate_series((SELECT unnest(ARRAY[x, y]) FROM xy), z) FROM xz
 ----
-·                                distributed   false                                 ·                     ·
-·                                vectorized    false                                 ·                     ·
-root                             ·             ·                                     (generate_series)     ·
- ├── render                      ·             ·                                     (generate_series)     ·
- │    │                          render 0      generate_series                       ·                     ·
- │    └── project set            ·             ·                                     (z, generate_series)  ·
- │         │                     render 0      generate_series(@S1, @1)              ·                     ·
- │         └── scan              ·             ·                                     (z)                   ·
- │                               table         xz@primary                            ·                     ·
- │                               spans         FULL SCAN                             ·                     ·
- └── subquery                    ·             ·                                     ·                     ·
-      │                          id            @S1                                   ·                     ·
-      │                          original sql  (SELECT unnest(ARRAY[x, y]) FROM xy)  ·                     ·
-      │                          exec mode     one row                               ·                     ·
-      └── max1row                ·             ·                                     (unnest)              ·
-           └── render            ·             ·                                     (unnest)              ·
-                │                render 0      unnest                                ·                     ·
-                └── project set  ·             ·                                     (x, y, unnest)        ·
-                     │           render 0      unnest(ARRAY[@1, @2])                 ·                     ·
-                     └── scan    ·             ·                                     (x, y)                ·
-·                                table         xy@primary                            ·                     ·
-·                                spans         FULL SCAN                             ·                     ·
+·                               distributed   false                                 ·                     ·
+·                               vectorized    false                                 ·                     ·
+root                            ·             ·                                     (generate_series)     ·
+ ├── render                     ·             ·                                     (generate_series)     ·
+ │    │                         render 0      generate_series                       ·                     ·
+ │    └── project set           ·             ·                                     (z, generate_series)  ·
+ │         │                    render 0      generate_series(@S1, @1)              ·                     ·
+ │         └── scan             ·             ·                                     (z)                   ·
+ │                              table         xz@primary                            ·                     ·
+ │                              spans         FULL SCAN                             ·                     ·
+ └── subquery                   ·             ·                                     ·                     ·
+      │                         id            @S1                                   ·                     ·
+      │                         original sql  (SELECT unnest(ARRAY[x, y]) FROM xy)  ·                     ·
+      │                         exec mode     one row                               ·                     ·
+      └── max1row               ·             ·                                     (unnest)              ·
+           └── render           ·             ·                                     (unnest)              ·
+                │               render 0      unnest                                ·                     ·
+                └── apply-join  ·             ·                                     (x, y, unnest)        ·
+                     │          type          inner                                 ·                     ·
+                     └── scan   ·             ·                                     (x, y)                ·
+·                               table         xy@primary                            ·                     ·
+·                               spans         FULL SCAN                             ·                     ·
 
 # Regression test for #24676.
 statement ok

--- a/pkg/sql/opt/memo/testdata/logprops/srfs
+++ b/pkg/sql/opt/memo/testdata/logprops/srfs
@@ -26,34 +26,33 @@ SELECT (SELECT unnest(ARRAY[1,2,y,v]) FROM xy WHERE x = u) FROM uv
 ----
 project
  ├── columns: unnest:7(int)
- ├── side-effects
  ├── prune: (7)
  ├── ensure-distinct-on
  │    ├── columns: rowid:3(int!null) unnest:6(int)
  │    ├── grouping columns: rowid:3(int!null)
  │    ├── error: "more than one row returned by a subquery used as an expression"
- │    ├── side-effects
  │    ├── key: (3)
  │    ├── fd: (3)-->(6)
  │    ├── prune: (6)
  │    ├── left-join-apply
  │    │    ├── columns: u:1(int) v:2(int!null) rowid:3(int!null) x:4(int) y:5(int) unnest:6(int)
- │    │    ├── side-effects
  │    │    ├── fd: (3)-->(1,2)
- │    │    ├── prune: (3)
+ │    │    ├── prune: (3,6)
  │    │    ├── reject-nulls: (4-6)
- │    │    ├── interesting orderings: (+3)
+ │    │    ├── interesting orderings: (+3) (+4)
  │    │    ├── scan uv
  │    │    │    ├── columns: u:1(int) v:2(int!null) rowid:3(int!null)
  │    │    │    ├── key: (3)
  │    │    │    ├── fd: (3)-->(1,2)
  │    │    │    ├── prune: (1-3)
  │    │    │    └── interesting orderings: (+3)
- │    │    ├── project-set
+ │    │    ├── inner-join-apply
  │    │    │    ├── columns: x:4(int!null) y:5(int) unnest:6(int)
  │    │    │    ├── outer: (1,2)
- │    │    │    ├── side-effects
+ │    │    │    ├── cardinality: [0 - 4]
  │    │    │    ├── fd: ()-->(4,5)
+ │    │    │    ├── prune: (6)
+ │    │    │    ├── interesting orderings: (+4)
  │    │    │    ├── select
  │    │    │    │    ├── columns: x:4(int!null) y:5(int)
  │    │    │    │    ├── outer: (1)
@@ -72,13 +71,20 @@ project
  │    │    │    │         └── eq [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
  │    │    │    │              ├── variable: x:4 [type=int]
  │    │    │    │              └── variable: u:1 [type=int]
- │    │    │    └── zip
- │    │    │         └── function: unnest [type=int, outer=(2,5), side-effects]
- │    │    │              └── array: [type=int[]]
- │    │    │                   ├── const: 1 [type=int]
- │    │    │                   ├── const: 2 [type=int]
- │    │    │                   ├── variable: y:5 [type=int]
- │    │    │                   └── variable: v:2 [type=int]
+ │    │    │    ├── values
+ │    │    │    │    ├── columns: unnest:6(int)
+ │    │    │    │    ├── outer: (2,5)
+ │    │    │    │    ├── cardinality: [4 - 4]
+ │    │    │    │    ├── prune: (6)
+ │    │    │    │    ├── tuple [type=tuple{int}]
+ │    │    │    │    │    └── const: 1 [type=int]
+ │    │    │    │    ├── tuple [type=tuple{int}]
+ │    │    │    │    │    └── const: 2 [type=int]
+ │    │    │    │    ├── tuple [type=tuple{int}]
+ │    │    │    │    │    └── variable: y:5 [type=int]
+ │    │    │    │    └── tuple [type=tuple{int}]
+ │    │    │    │         └── variable: v:2 [type=int]
+ │    │    │    └── filters (true)
  │    │    └── filters (true)
  │    └── aggregations
  │         └── const-agg [as=unnest:6, type=int, outer=(6)]

--- a/pkg/sql/opt/memo/testdata/stats/srfs
+++ b/pkg/sql/opt/memo/testdata/stats/srfs
@@ -93,20 +93,24 @@ SELECT unnest(ARRAY[x,y]) FROM xy
 ----
 project
  ├── columns: unnest:3(int)
- ├── side-effects
- ├── stats: [rows=10000, distinct(3)=700, null(3)=100, distinct(1-3)=10000, null(1-3)=199]
- └── project-set
+ ├── stats: [rows=2000, distinct(3)=2, null(3)=0, distinct(1-3)=1982, null(1-3)=20]
+ └── inner-join-apply
       ├── columns: x:1(int!null) y:2(int) unnest:3(int)
-      ├── side-effects
-      ├── stats: [rows=10000, distinct(3)=700, null(3)=100, distinct(1-3)=10000, null(1-3)=199]
+      ├── stats: [rows=2000, distinct(3)=2, null(3)=0, distinct(1-3)=1982, null(1-3)=20]
       ├── fd: (1)-->(2)
       ├── scan xy
       │    ├── columns: x:1(int!null) y:2(int)
       │    ├── stats: [rows=1000, distinct(1,2)=991, null(1,2)=10]
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
-      └── zip
-           └── unnest(ARRAY[x:1, y:2]) [type=int, outer=(1,2), side-effects]
+      ├── values
+      │    ├── columns: unnest:3(int)
+      │    ├── outer: (1,2)
+      │    ├── cardinality: [2 - 2]
+      │    ├── stats: [rows=2, distinct(3)=2, null(3)=0]
+      │    ├── (x:1,) [type=tuple{int}]
+      │    └── (y:2,) [type=tuple{int}]
+      └── filters (true)
 
 opt colstat=3 colstat=4 colstat=(3, 4) colstat=(1, 3) colstat=(2, 4)
 SELECT xy.*, generate_series(x, y), generate_series(0, 1) FROM xy

--- a/pkg/sql/opt/norm/rules/project_set.opt
+++ b/pkg/sql/opt/norm/rules/project_set.opt
@@ -1,0 +1,27 @@
+# =============================================================================
+# project_set.opt contains normalization rules for the ProjectSet operator.
+# =============================================================================
+
+# ConvertZipArraysToValues applies the unnest zip function to array inputs,
+# converting them into a Values operator within an InnerJoinApply. This allows
+# Values and decorrelation rules to fire. It is especially useful in cases where
+# the array contents are passed as a PREPARE parameter, such as:
+#
+#   SELECT * FROM xy WHERE y IN unnest($1)
+#
+# The replace pattern is equivalent to the match pattern because the
+# InnerJoinApply outputs every value in the array for every row in the input,
+# and outputs nulls to pad shorter arrays. It also supports correlation between
+# the array arguments and the input expression.
+[ConvertZipArraysToValues, Normalize]
+(ProjectSet
+    $input:*
+    $zip:* & (CanConstructValuesFromZips $zip)
+)
+=>
+(InnerJoinApply
+        $input
+        (ConstructValuesFromZips $zip)
+        []
+        (EmptyJoinPrivate)
+)

--- a/pkg/sql/opt/norm/testdata/rules/project_set
+++ b/pkg/sql/opt/norm/testdata/rules/project_set
@@ -1,0 +1,199 @@
+exec-ddl
+CREATE TABLE xy (x INT PRIMARY KEY, y INT)
+----
+
+# --------------------------------------------------
+# ConvertZipArraysToValues
+# --------------------------------------------------
+
+# Basic case with single unzip and only constants in array.
+norm expect=ConvertZipArraysToValues
+SELECT unnest(ARRAY[1,2,3])
+----
+values
+ ├── columns: unnest:1!null
+ ├── cardinality: [3 - 3]
+ ├── (1,)
+ ├── (2,)
+ └── (3,)
+
+# Case with subquery in ProjectSet input.
+norm expect=ConvertZipArraysToValues
+SELECT unnest(ARRAY[1,2,3]) FROM unnest(ARRAY[4,5,6])
+----
+inner-join (cross)
+ ├── columns: unnest:2!null
+ ├── cardinality: [9 - 9]
+ ├── values
+ │    ├── cardinality: [3 - 3]
+ │    ├── ()
+ │    ├── ()
+ │    └── ()
+ ├── values
+ │    ├── columns: unnest:2!null
+ │    ├── cardinality: [3 - 3]
+ │    ├── (1,)
+ │    ├── (2,)
+ │    └── (3,)
+ └── filters (true)
+
+# Case with correlated array.
+norm expect=ConvertZipArraysToValues
+SELECT unnest(ARRAY[x,y]) FROM xy
+----
+project
+ ├── columns: unnest:3
+ └── inner-join-apply
+      ├── columns: x:1!null y:2 unnest:3
+      ├── fd: (1)-->(2)
+      ├── scan xy
+      │    ├── columns: x:1!null y:2
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      ├── values
+      │    ├── columns: unnest:3
+      │    ├── outer: (1,2)
+      │    ├── cardinality: [2 - 2]
+      │    ├── (x:1,)
+      │    └── (y:2,)
+      └── filters (true)
+
+# Case with correlated array in a correlated subquery.
+norm expect=ConvertZipArraysToValues
+SELECT * FROM xy
+WHERE EXISTS
+(SELECT t
+  FROM unnest(ARRAY[NULL,2,NULL,4,5,x])
+  AS f(t)
+  WHERE t=y
+)
+----
+semi-join-apply
+ ├── columns: x:1!null y:2!null
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── scan xy
+ │    ├── columns: x:1!null y:2
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ ├── values
+ │    ├── columns: unnest:3
+ │    ├── outer: (1)
+ │    ├── cardinality: [6 - 6]
+ │    ├── (NULL,)
+ │    ├── (2,)
+ │    ├── (NULL,)
+ │    ├── (4,)
+ │    ├── (5,)
+ │    └── (x:1,)
+ └── filters
+      └── unnest:3 = y:2 [outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]), fd=(2)==(3), (3)==(2)]
+
+# Case with multiple arrays of different sizes.
+norm expect=ConvertZipArraysToValues
+SELECT unnest(ARRAY[1,2,3]), unnest(ARRAY[1,2,3,4,5,6,NULL,8,9,10]), unnest(ARRAY[]::INT[])
+----
+values
+ ├── columns: unnest:1 unnest:2 unnest:3
+ ├── cardinality: [10 - 10]
+ ├── (1, 1, NULL)
+ ├── (2, 2, NULL)
+ ├── (3, 3, NULL)
+ ├── (NULL, 4, NULL)
+ ├── (NULL, 5, NULL)
+ ├── (NULL, 6, NULL)
+ ├── (NULL, NULL, NULL)
+ ├── (NULL, 8, NULL)
+ ├── (NULL, 9, NULL)
+ └── (NULL, 10, NULL)
+
+# Case with multiple arrays of different types and different sizes.
+norm expect=ConvertZipArraysToValues
+SELECT unnest(ARRAY['one','two','three']), unnest(ARRAY[1,2,5,6,NULL,8]), unnest(ARRAY[]::BOOL[])
+----
+values
+ ├── columns: unnest:1 unnest:2 unnest:3
+ ├── cardinality: [6 - 6]
+ ├── ('one', 1, NULL)
+ ├── ('two', 2, NULL)
+ ├── ('three', 5, NULL)
+ ├── (NULL, 6, NULL)
+ ├── (NULL, NULL, NULL)
+ └── (NULL, 8, NULL)
+
+# Case with multiple empty arrays.
+norm expect=ConvertZipArraysToValues
+SELECT unnest(ARRAY[]::STRING[]), unnest(ARRAY[]::REAL[]), unnest(ARRAY[]::INT[])
+----
+values
+ ├── columns: unnest:1!null unnest:2!null unnest:3!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-3)
+
+# Case with multiple correlated arrays.
+norm expect=ConvertZipArraysToValues
+SELECT unnest(ARRAY[x,y]), unnest(ARRAY[1,x*100]) FROM xy
+----
+project
+ ├── columns: unnest:3 unnest:4
+ └── inner-join-apply
+      ├── columns: x:1!null y:2 unnest:3 unnest:4
+      ├── fd: (1)-->(2)
+      ├── scan xy
+      │    ├── columns: x:1!null y:2
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      ├── values
+      │    ├── columns: unnest:3 unnest:4
+      │    ├── outer: (1,2)
+      │    ├── cardinality: [2 - 2]
+      │    ├── (x:1, 1)
+      │    └── (y:2, x:1 * 100)
+      └── filters (true)
+
+# No-op case - ConvertZipArraysToValues fires the first time but not the
+# second because the outer zip is over a variable of an array instead of an
+# array.
+norm expect=ConvertZipArraysToValues
+SELECT unnest(x) FROM unnest(ARRAY[[1,2,3],[4,5],[6]]) AS x
+----
+project
+ ├── columns: unnest:2
+ ├── side-effects
+ └── project-set
+      ├── columns: unnest:1!null unnest:2
+      ├── side-effects
+      ├── values
+      │    ├── columns: unnest:1!null
+      │    ├── cardinality: [3 - 3]
+      │    ├── (ARRAY[1,2,3],)
+      │    ├── (ARRAY[4,5],)
+      │    └── (ARRAY[6],)
+      └── zip
+           └── unnest(unnest:1) [outer=(1), side-effects]
+
+# No-op case because array_agg is not an ArrayExpr or ConstExpr with a DArray.
+norm expect-not=ConvertZipArraysToValues
+SELECT unnest((SELECT array_agg(y) FROM xy))
+----
+project-set
+ ├── columns: unnest:4
+ ├── side-effects
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── ()
+ └── zip
+      └── function: unnest [side-effects, subquery]
+           └── subquery
+                └── scalar-group-by
+                     ├── columns: array_agg:3
+                     ├── cardinality: [1 - 1]
+                     ├── key: ()
+                     ├── fd: ()-->(3)
+                     ├── scan xy
+                     │    └── columns: y:2
+                     └── aggregations
+                          └── array-agg [as=array_agg:3, outer=(2)]
+                               └── y:2

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1022,10 +1022,7 @@ values
 # Get account locations of a list of cards.
 #
 # Problems:
-#   1. WITH is not inlined into the query, because it is marked as having side
-#      effects, even though it does not.
-#   2. unnest should be folded into VALUES operator when it operates over
-#      constant ARRAY.
+#   1. Tuple access is not folded with Values operator.
 opt
 WITH CardsToFind AS
 (
@@ -1050,77 +1047,56 @@ GROUP BY AccountName
 ORDER BY sum(Quantity) DESC
 LIMIT 1000
 ----
-sort
+limit
  ├── columns: accountname:8!null quantity:12
+ ├── internal-ordering: -12
  ├── cardinality: [0 - 1000]
- ├── side-effects
  ├── key: (8)
  ├── fd: (8)-->(12)
  ├── ordering: -12
- └── with &1 (cardstofind)
-      ├── columns: accountname:8!null sum:12
-      ├── cardinality: [0 - 1000]
-      ├── side-effects
-      ├── key: (8)
-      ├── fd: (8)-->(12)
-      ├── project
-      │    ├── columns: id:2 quantity:3
-      │    ├── side-effects
-      │    ├── project-set
-      │    │    ├── columns: unnest:1
-      │    │    ├── side-effects
-      │    │    ├── values
-      │    │    │    ├── cardinality: [1 - 1]
-      │    │    │    ├── key: ()
-      │    │    │    └── ()
-      │    │    └── zip
-      │    │         └── unnest(ARRAY[(42948, 3),(24924, 4)]) [side-effects]
-      │    └── projections
-      │         ├── (unnest:1).@1 [as=id:2, outer=(1)]
-      │         └── (unnest:1).@2 [as=quantity:3, outer=(1)]
-      └── limit
-           ├── columns: accountname:8!null sum:12
-           ├── internal-ordering: -12
-           ├── cardinality: [0 - 1000]
-           ├── key: (8)
-           ├── fd: (8)-->(12)
-           ├── sort
-           │    ├── columns: accountname:8!null sum:12
-           │    ├── key: (8)
-           │    ├── fd: (8)-->(12)
-           │    ├── ordering: -12
-           │    ├── limit hint: 1000.00
-           │    └── group-by
-           │         ├── columns: accountname:8!null sum:12
-           │         ├── grouping columns: accountname:8!null
-           │         ├── key: (8)
-           │         ├── fd: (8)-->(12)
-           │         ├── project
-           │         │    ├── columns: quantity:11 accountname:8!null
-           │         │    ├── inner-join (lookup inventorydetails)
-           │         │    │    ├── columns: id:4!null quantity:5 dealerid:6!null cardid:7!null accountname:8!null inventorydetails.quantity:9!null
-           │         │    │    ├── key columns: [6 7 8] = [6 7 8]
-           │         │    │    ├── lookup columns are key
-           │         │    │    ├── fd: (6-8)-->(9), (4)==(7), (7)==(4)
-           │         │    │    ├── inner-join (lookup inventorydetails@inventorydetails_auto_index_inventorydetailscardidkey)
-           │         │    │    │    ├── columns: id:4!null quantity:5 dealerid:6!null cardid:7!null accountname:8!null
-           │         │    │    │    ├── key columns: [4] = [7]
-           │         │    │    │    ├── fd: (4)==(7), (7)==(4)
-           │         │    │    │    ├── with-scan &1 (cardstofind)
-           │         │    │    │    │    ├── columns: id:4 quantity:5
-           │         │    │    │    │    └── mapping:
-           │         │    │    │    │         ├──  id:2 => id:4
-           │         │    │    │    │         └──  quantity:3 => quantity:5
-           │         │    │    │    └── filters
-           │         │    │    │         ├── ((((dealerid:6 = 1) OR (dealerid:6 = 2)) OR (dealerid:6 = 3)) OR (dealerid:6 = 4)) OR (dealerid:6 = 5) [outer=(6), constraints=(/6: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
-           │         │    │    │         └── accountname:8 IN ('account-1', 'account-2', 'account-3') [outer=(8), constraints=(/8: [/'account-1' - /'account-1'] [/'account-2' - /'account-2'] [/'account-3' - /'account-3']; tight)]
-           │         │    │    └── filters (true)
-           │         │    └── projections
-           │         │         └── CASE WHEN quantity:5 < inventorydetails.quantity:9 THEN quantity:5 ELSE inventorydetails.quantity:9 END [as=quantity:11, outer=(5,9)]
-           │         └── aggregations
-           │              └── sum [as=sum:12, outer=(11)]
-           │                   └── quantity:11
-           └── 1000
+ ├── sort
+ │    ├── columns: accountname:8!null sum:12
+ │    ├── key: (8)
+ │    ├── fd: (8)-->(12)
+ │    ├── ordering: -12
+ │    ├── limit hint: 1000.00
+ │    └── group-by
+ │         ├── columns: accountname:8!null sum:12
+ │         ├── grouping columns: accountname:8!null
+ │         ├── key: (8)
+ │         ├── fd: (8)-->(12)
+ │         ├── project
+ │         │    ├── columns: quantity:11 accountname:8!null
+ │         │    ├── inner-join (lookup inventorydetails)
+ │         │    │    ├── columns: id:4!null quantity:5 dealerid:6!null cardid:7!null accountname:8!null inventorydetails.quantity:9!null
+ │         │    │    ├── key columns: [6 7 8] = [6 7 8]
+ │         │    │    ├── lookup columns are key
+ │         │    │    ├── fd: (6-8)-->(9), (4)==(7), (7)==(4)
+ │         │    │    ├── inner-join (lookup inventorydetails@inventorydetails_auto_index_inventorydetailscardidkey)
+ │         │    │    │    ├── columns: id:4!null quantity:5 dealerid:6!null cardid:7!null accountname:8!null
+ │         │    │    │    ├── key columns: [4] = [7]
+ │         │    │    │    ├── fd: (4)==(7), (7)==(4)
+ │         │    │    │    ├── project
+ │         │    │    │    │    ├── columns: id:4 quantity:5
+ │         │    │    │    │    ├── cardinality: [2 - 2]
+ │         │    │    │    │    ├── values
+ │         │    │    │    │    │    ├── columns: unnest:1!null
+ │         │    │    │    │    │    ├── cardinality: [2 - 2]
+ │         │    │    │    │    │    ├── ((42948, 3),)
+ │         │    │    │    │    │    └── ((24924, 4),)
+ │         │    │    │    │    └── projections
+ │         │    │    │    │         ├── (unnest:1).@1 [as=id:4, outer=(1)]
+ │         │    │    │    │         └── (unnest:1).@2 [as=quantity:5, outer=(1)]
+ │         │    │    │    └── filters
+ │         │    │    │         ├── ((((dealerid:6 = 1) OR (dealerid:6 = 2)) OR (dealerid:6 = 3)) OR (dealerid:6 = 4)) OR (dealerid:6 = 5) [outer=(6), constraints=(/6: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
+ │         │    │    │         └── accountname:8 IN ('account-1', 'account-2', 'account-3') [outer=(8), constraints=(/8: [/'account-1' - /'account-1'] [/'account-2' - /'account-2'] [/'account-3' - /'account-3']; tight)]
+ │         │    │    └── filters (true)
+ │         │    └── projections
+ │         │         └── CASE WHEN quantity:5 < inventorydetails.quantity:9 THEN quantity:5 ELSE inventorydetails.quantity:9 END [as=quantity:11, outer=(5,9)]
+ │         └── aggregations
+ │              └── sum [as=sum:12, outer=(11)]
+ │                   └── quantity:11
+ └── 1000
 
 # Get buy/sell volume of a particular card in the last 2 days.
 #
@@ -1432,10 +1408,7 @@ delete inventorydetails
 # transfers.
 #
 # Problems:
-#   1. WITH is not inlined into the query, because it is marked as having side
-#      effects, even though it does not.
-#   2. unnest should be folded into VALUES operator when it operates over
-#      constant ARRAY.
+#   1. Tuple access is not folded with Values operator.
 opt
 WITH Updates AS
 (
@@ -1449,115 +1422,100 @@ SET actualinventory = (SELECT coalesce(sum_INT(quantity), 0)
 FROM Updates
 WHERE ci.cardid = Updates.c AND ci.dealerid = 1
 ----
-with &1 (updates)
+update ci
+ ├── columns: <none>
+ ├── fetch columns: ci.dealerid:13 ci.cardid:14 buyprice:15 sellprice:16 discount:17 desiredinventory:18 actualinventory:19 maxinventory:20 ci.version:21
+ ├── update-mapping:
+ │    └── column31:31 => actualinventory:10
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
- ├── project
- │    ├── columns: c:2 q:3
- │    ├── side-effects
- │    ├── project-set
- │    │    ├── columns: unnest:1
- │    │    ├── side-effects
- │    │    ├── values
- │    │    │    ├── cardinality: [1 - 1]
- │    │    │    ├── key: ()
- │    │    │    └── ()
- │    │    └── zip
- │    │         └── unnest(ARRAY[(42948, 3),(24924, 4)]) [side-effects]
- │    └── projections
- │         ├── (unnest:1).@1 [as=c:2, outer=(1)]
- │         └── (unnest:1).@2 [as=q:3, outer=(1)]
- └── update ci
-      ├── columns: <none>
-      ├── fetch columns: ci.dealerid:13 ci.cardid:14 buyprice:15 sellprice:16 discount:17 desiredinventory:18 actualinventory:19 maxinventory:20 ci.version:21
-      ├── update-mapping:
-      │    └── column31:31 => actualinventory:10
-      ├── cardinality: [0 - 0]
-      ├── side-effects, mutations
-      └── project
-           ├── columns: column31:31 ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23
-           ├── key: (14)
-           ├── fd: ()-->(13), (14)-->(15-23,31), (21)-->(14-20), (14)==(22), (22)==(14)
-           ├── group-by
-           │    ├── columns: ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23 sum_int:29
-           │    ├── grouping columns: ci.cardid:14!null
-           │    ├── key: (14)
-           │    ├── fd: ()-->(13), (14)-->(13,15-23,29), (21)-->(14-20), (14)==(22), (22)==(14)
-           │    ├── left-join (lookup inventorydetails)
-           │    │    ├── columns: ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23 id.dealerid:24 id.cardid:25 quantity:27
-           │    │    ├── key columns: [35 14] = [24 25]
-           │    │    ├── fd: ()-->(13), (14)-->(15-23), (21)-->(14-20), (14)==(22), (22)==(14)
-           │    │    ├── project
-           │    │    │    ├── columns: "project_const_col_@24":35!null ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23
-           │    │    │    ├── key: (14)
-           │    │    │    ├── fd: ()-->(13,35), (14)-->(15-23), (21)-->(14-20), (14)==(22), (22)==(14)
-           │    │    │    ├── distinct-on
-           │    │    │    │    ├── columns: ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23
-           │    │    │    │    ├── grouping columns: ci.cardid:14!null
-           │    │    │    │    ├── key: (14)
-           │    │    │    │    ├── fd: ()-->(13), (14)-->(13,15-23), (21)-->(14-20), (14)==(22), (22)==(14)
-           │    │    │    │    ├── inner-join (lookup cardsinfo)
-           │    │    │    │    │    ├── columns: ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23
-           │    │    │    │    │    ├── key columns: [32 22] = [13 14]
-           │    │    │    │    │    ├── lookup columns are key
-           │    │    │    │    │    ├── fd: ()-->(13), (14)-->(15-21), (21)-->(14-20), (14)==(22), (22)==(14)
-           │    │    │    │    │    ├── project
-           │    │    │    │    │    │    ├── columns: "project_const_col_@13":32!null c:22 q:23
-           │    │    │    │    │    │    ├── fd: ()-->(32)
-           │    │    │    │    │    │    ├── with-scan &1 (updates)
-           │    │    │    │    │    │    │    ├── columns: c:22 q:23
-           │    │    │    │    │    │    │    └── mapping:
-           │    │    │    │    │    │    │         ├──  c:2 => c:22
-           │    │    │    │    │    │    │         └──  q:3 => q:23
-           │    │    │    │    │    │    └── projections
-           │    │    │    │    │    │         └── 1 [as="project_const_col_@13":32]
-           │    │    │    │    │    └── filters (true)
-           │    │    │    │    └── aggregations
-           │    │    │    │         ├── first-agg [as=buyprice:15, outer=(15)]
-           │    │    │    │         │    └── buyprice:15
-           │    │    │    │         ├── first-agg [as=sellprice:16, outer=(16)]
-           │    │    │    │         │    └── sellprice:16
-           │    │    │    │         ├── first-agg [as=discount:17, outer=(17)]
-           │    │    │    │         │    └── discount:17
-           │    │    │    │         ├── first-agg [as=desiredinventory:18, outer=(18)]
-           │    │    │    │         │    └── desiredinventory:18
-           │    │    │    │         ├── first-agg [as=actualinventory:19, outer=(19)]
-           │    │    │    │         │    └── actualinventory:19
-           │    │    │    │         ├── first-agg [as=maxinventory:20, outer=(20)]
-           │    │    │    │         │    └── maxinventory:20
-           │    │    │    │         ├── first-agg [as=ci.version:21, outer=(21)]
-           │    │    │    │         │    └── ci.version:21
-           │    │    │    │         ├── first-agg [as=c:22, outer=(22)]
-           │    │    │    │         │    └── c:22
-           │    │    │    │         ├── first-agg [as=q:23, outer=(23)]
-           │    │    │    │         │    └── q:23
-           │    │    │    │         └── const-agg [as=ci.dealerid:13, outer=(13)]
-           │    │    │    │              └── ci.dealerid:13
-           │    │    │    └── projections
-           │    │    │         └── 1 [as="project_const_col_@24":35]
-           │    │    └── filters (true)
-           │    └── aggregations
-           │         ├── sum-int [as=sum_int:29, outer=(27)]
-           │         │    └── quantity:27
-           │         ├── const-agg [as=ci.dealerid:13, outer=(13)]
-           │         │    └── ci.dealerid:13
-           │         ├── const-agg [as=buyprice:15, outer=(15)]
-           │         │    └── buyprice:15
-           │         ├── const-agg [as=sellprice:16, outer=(16)]
-           │         │    └── sellprice:16
-           │         ├── const-agg [as=discount:17, outer=(17)]
-           │         │    └── discount:17
-           │         ├── const-agg [as=desiredinventory:18, outer=(18)]
-           │         │    └── desiredinventory:18
-           │         ├── const-agg [as=actualinventory:19, outer=(19)]
-           │         │    └── actualinventory:19
-           │         ├── const-agg [as=maxinventory:20, outer=(20)]
-           │         │    └── maxinventory:20
-           │         ├── const-agg [as=ci.version:21, outer=(21)]
-           │         │    └── ci.version:21
-           │         ├── const-agg [as=c:22, outer=(22)]
-           │         │    └── c:22
-           │         └── const-agg [as=q:23, outer=(23)]
-           │              └── q:23
-           └── projections
-                └── COALESCE(sum_int:29, 0) [as=column31:31, outer=(29)]
+ └── project
+      ├── columns: column31:31 ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23
+      ├── key: (14)
+      ├── fd: ()-->(13), (14)-->(15-23,31), (21)-->(14-20), (14)==(22), (22)==(14)
+      ├── group-by
+      │    ├── columns: ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23 sum_int:29
+      │    ├── grouping columns: ci.cardid:14!null
+      │    ├── key: (14)
+      │    ├── fd: ()-->(13), (14)-->(13,15-23,29), (21)-->(14-20), (14)==(22), (22)==(14)
+      │    ├── left-join (lookup inventorydetails)
+      │    │    ├── columns: ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23 id.dealerid:24 id.cardid:25 quantity:27
+      │    │    ├── key columns: [35 14] = [24 25]
+      │    │    ├── fd: ()-->(13), (14)-->(15-23), (21)-->(14-20), (14)==(22), (22)==(14)
+      │    │    ├── project
+      │    │    │    ├── columns: "project_const_col_@24":35!null ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23
+      │    │    │    ├── key: (14)
+      │    │    │    ├── fd: ()-->(13,35), (14)-->(15-23), (21)-->(14-20), (14)==(22), (22)==(14)
+      │    │    │    ├── distinct-on
+      │    │    │    │    ├── columns: ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23
+      │    │    │    │    ├── grouping columns: ci.cardid:14!null
+      │    │    │    │    ├── key: (14)
+      │    │    │    │    ├── fd: ()-->(13), (14)-->(13,15-23), (21)-->(14-20), (14)==(22), (22)==(14)
+      │    │    │    │    ├── inner-join (lookup cardsinfo)
+      │    │    │    │    │    ├── columns: ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23
+      │    │    │    │    │    ├── key columns: [32 22] = [13 14]
+      │    │    │    │    │    ├── lookup columns are key
+      │    │    │    │    │    ├── fd: ()-->(13), (14)-->(15-21), (21)-->(14-20), (14)==(22), (22)==(14)
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: "project_const_col_@13":32!null c:22 q:23
+      │    │    │    │    │    │    ├── cardinality: [2 - 2]
+      │    │    │    │    │    │    ├── fd: ()-->(32)
+      │    │    │    │    │    │    ├── values
+      │    │    │    │    │    │    │    ├── columns: unnest:1!null
+      │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
+      │    │    │    │    │    │    │    ├── ((42948, 3),)
+      │    │    │    │    │    │    │    └── ((24924, 4),)
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         ├── 1 [as="project_const_col_@13":32]
+      │    │    │    │    │    │         ├── (unnest:1).@1 [as=c:22, outer=(1)]
+      │    │    │    │    │    │         └── (unnest:1).@2 [as=q:23, outer=(1)]
+      │    │    │    │    │    └── filters (true)
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── first-agg [as=buyprice:15, outer=(15)]
+      │    │    │    │         │    └── buyprice:15
+      │    │    │    │         ├── first-agg [as=sellprice:16, outer=(16)]
+      │    │    │    │         │    └── sellprice:16
+      │    │    │    │         ├── first-agg [as=discount:17, outer=(17)]
+      │    │    │    │         │    └── discount:17
+      │    │    │    │         ├── first-agg [as=desiredinventory:18, outer=(18)]
+      │    │    │    │         │    └── desiredinventory:18
+      │    │    │    │         ├── first-agg [as=actualinventory:19, outer=(19)]
+      │    │    │    │         │    └── actualinventory:19
+      │    │    │    │         ├── first-agg [as=maxinventory:20, outer=(20)]
+      │    │    │    │         │    └── maxinventory:20
+      │    │    │    │         ├── first-agg [as=ci.version:21, outer=(21)]
+      │    │    │    │         │    └── ci.version:21
+      │    │    │    │         ├── first-agg [as=c:22, outer=(22)]
+      │    │    │    │         │    └── c:22
+      │    │    │    │         ├── first-agg [as=q:23, outer=(23)]
+      │    │    │    │         │    └── q:23
+      │    │    │    │         └── const-agg [as=ci.dealerid:13, outer=(13)]
+      │    │    │    │              └── ci.dealerid:13
+      │    │    │    └── projections
+      │    │    │         └── 1 [as="project_const_col_@24":35]
+      │    │    └── filters (true)
+      │    └── aggregations
+      │         ├── sum-int [as=sum_int:29, outer=(27)]
+      │         │    └── quantity:27
+      │         ├── const-agg [as=ci.dealerid:13, outer=(13)]
+      │         │    └── ci.dealerid:13
+      │         ├── const-agg [as=buyprice:15, outer=(15)]
+      │         │    └── buyprice:15
+      │         ├── const-agg [as=sellprice:16, outer=(16)]
+      │         │    └── sellprice:16
+      │         ├── const-agg [as=discount:17, outer=(17)]
+      │         │    └── discount:17
+      │         ├── const-agg [as=desiredinventory:18, outer=(18)]
+      │         │    └── desiredinventory:18
+      │         ├── const-agg [as=actualinventory:19, outer=(19)]
+      │         │    └── actualinventory:19
+      │         ├── const-agg [as=maxinventory:20, outer=(20)]
+      │         │    └── maxinventory:20
+      │         ├── const-agg [as=ci.version:21, outer=(21)]
+      │         │    └── ci.version:21
+      │         ├── const-agg [as=c:22, outer=(22)]
+      │         │    └── c:22
+      │         └── const-agg [as=q:23, outer=(23)]
+      │              └── q:23
+      └── projections
+           └── COALESCE(sum_int:29, 0) [as=column31:31, outer=(29)]

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1026,10 +1026,7 @@ values
 # Get account locations of a list of cards.
 #
 # Problems:
-#   1. WITH is not inlined into the query, because it is marked as having side
-#      effects, even though it does not.
-#   2. unnest should be folded into VALUES operator when it operates over
-#      constant ARRAY.
+#   1. Tuple access is not folded with Values operator.
 opt
 WITH CardsToFind AS
 (
@@ -1054,77 +1051,56 @@ GROUP BY AccountName
 ORDER BY sum(Quantity) DESC
 LIMIT 1000
 ----
-sort
+limit
  ├── columns: accountname:8!null quantity:14
+ ├── internal-ordering: -14
  ├── cardinality: [0 - 1000]
- ├── side-effects
  ├── key: (8)
  ├── fd: (8)-->(14)
  ├── ordering: -14
- └── with &1 (cardstofind)
-      ├── columns: accountname:8!null sum:14
-      ├── cardinality: [0 - 1000]
-      ├── side-effects
-      ├── key: (8)
-      ├── fd: (8)-->(14)
-      ├── project
-      │    ├── columns: id:2 quantity:3
-      │    ├── side-effects
-      │    ├── project-set
-      │    │    ├── columns: unnest:1
-      │    │    ├── side-effects
-      │    │    ├── values
-      │    │    │    ├── cardinality: [1 - 1]
-      │    │    │    ├── key: ()
-      │    │    │    └── ()
-      │    │    └── zip
-      │    │         └── unnest(ARRAY[(42948, 3),(24924, 4)]) [side-effects]
-      │    └── projections
-      │         ├── (unnest:1).@1 [as=id:2, outer=(1)]
-      │         └── (unnest:1).@2 [as=quantity:3, outer=(1)]
-      └── limit
-           ├── columns: accountname:8!null sum:14
-           ├── internal-ordering: -14
-           ├── cardinality: [0 - 1000]
-           ├── key: (8)
-           ├── fd: (8)-->(14)
-           ├── sort
-           │    ├── columns: accountname:8!null sum:14
-           │    ├── key: (8)
-           │    ├── fd: (8)-->(14)
-           │    ├── ordering: -14
-           │    ├── limit hint: 1000.00
-           │    └── group-by
-           │         ├── columns: accountname:8!null sum:14
-           │         ├── grouping columns: accountname:8!null
-           │         ├── key: (8)
-           │         ├── fd: (8)-->(14)
-           │         ├── project
-           │         │    ├── columns: quantity:13 accountname:8!null
-           │         │    ├── inner-join (lookup inventorydetails)
-           │         │    │    ├── columns: id:4!null quantity:5 dealerid:6!null cardid:7!null accountname:8!null inventorydetails.quantity:9!null
-           │         │    │    ├── key columns: [6 7 8] = [6 7 8]
-           │         │    │    ├── lookup columns are key
-           │         │    │    ├── fd: (6-8)-->(9), (4)==(7), (7)==(4)
-           │         │    │    ├── inner-join (lookup inventorydetails@inventorydetails_auto_index_inventorydetailscardidkey)
-           │         │    │    │    ├── columns: id:4!null quantity:5 dealerid:6!null cardid:7!null accountname:8!null
-           │         │    │    │    ├── key columns: [4] = [7]
-           │         │    │    │    ├── fd: (4)==(7), (7)==(4)
-           │         │    │    │    ├── with-scan &1 (cardstofind)
-           │         │    │    │    │    ├── columns: id:4 quantity:5
-           │         │    │    │    │    └── mapping:
-           │         │    │    │    │         ├──  id:2 => id:4
-           │         │    │    │    │         └──  quantity:3 => quantity:5
-           │         │    │    │    └── filters
-           │         │    │    │         ├── ((((dealerid:6 = 1) OR (dealerid:6 = 2)) OR (dealerid:6 = 3)) OR (dealerid:6 = 4)) OR (dealerid:6 = 5) [outer=(6), constraints=(/6: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
-           │         │    │    │         └── accountname:8 IN ('account-1', 'account-2', 'account-3') [outer=(8), constraints=(/8: [/'account-1' - /'account-1'] [/'account-2' - /'account-2'] [/'account-3' - /'account-3']; tight)]
-           │         │    │    └── filters (true)
-           │         │    └── projections
-           │         │         └── CASE WHEN quantity:5 < inventorydetails.quantity:9 THEN quantity:5 ELSE inventorydetails.quantity:9 END [as=quantity:13, outer=(5,9)]
-           │         └── aggregations
-           │              └── sum [as=sum:14, outer=(13)]
-           │                   └── quantity:13
-           └── 1000
+ ├── sort
+ │    ├── columns: accountname:8!null sum:14
+ │    ├── key: (8)
+ │    ├── fd: (8)-->(14)
+ │    ├── ordering: -14
+ │    ├── limit hint: 1000.00
+ │    └── group-by
+ │         ├── columns: accountname:8!null sum:14
+ │         ├── grouping columns: accountname:8!null
+ │         ├── key: (8)
+ │         ├── fd: (8)-->(14)
+ │         ├── project
+ │         │    ├── columns: quantity:13 accountname:8!null
+ │         │    ├── inner-join (lookup inventorydetails)
+ │         │    │    ├── columns: id:4!null quantity:5 dealerid:6!null cardid:7!null accountname:8!null inventorydetails.quantity:9!null
+ │         │    │    ├── key columns: [6 7 8] = [6 7 8]
+ │         │    │    ├── lookup columns are key
+ │         │    │    ├── fd: (6-8)-->(9), (4)==(7), (7)==(4)
+ │         │    │    ├── inner-join (lookup inventorydetails@inventorydetails_auto_index_inventorydetailscardidkey)
+ │         │    │    │    ├── columns: id:4!null quantity:5 dealerid:6!null cardid:7!null accountname:8!null
+ │         │    │    │    ├── key columns: [4] = [7]
+ │         │    │    │    ├── fd: (4)==(7), (7)==(4)
+ │         │    │    │    ├── project
+ │         │    │    │    │    ├── columns: id:4 quantity:5
+ │         │    │    │    │    ├── cardinality: [2 - 2]
+ │         │    │    │    │    ├── values
+ │         │    │    │    │    │    ├── columns: unnest:1!null
+ │         │    │    │    │    │    ├── cardinality: [2 - 2]
+ │         │    │    │    │    │    ├── ((42948, 3),)
+ │         │    │    │    │    │    └── ((24924, 4),)
+ │         │    │    │    │    └── projections
+ │         │    │    │    │         ├── (unnest:1).@1 [as=id:4, outer=(1)]
+ │         │    │    │    │         └── (unnest:1).@2 [as=quantity:5, outer=(1)]
+ │         │    │    │    └── filters
+ │         │    │    │         ├── ((((dealerid:6 = 1) OR (dealerid:6 = 2)) OR (dealerid:6 = 3)) OR (dealerid:6 = 4)) OR (dealerid:6 = 5) [outer=(6), constraints=(/6: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
+ │         │    │    │         └── accountname:8 IN ('account-1', 'account-2', 'account-3') [outer=(8), constraints=(/8: [/'account-1' - /'account-1'] [/'account-2' - /'account-2'] [/'account-3' - /'account-3']; tight)]
+ │         │    │    └── filters (true)
+ │         │    └── projections
+ │         │         └── CASE WHEN quantity:5 < inventorydetails.quantity:9 THEN quantity:5 ELSE inventorydetails.quantity:9 END [as=quantity:13, outer=(5,9)]
+ │         └── aggregations
+ │              └── sum [as=sum:14, outer=(13)]
+ │                   └── quantity:13
+ └── 1000
 
 # Get buy/sell volume of a particular card in the last 2 days.
 #
@@ -1445,10 +1421,7 @@ delete inventorydetails
 # transfers.
 #
 # Problems:
-#   1. WITH is not inlined into the query, because it is marked as having side
-#      effects, even though it does not.
-#   2. unnest should be folded into VALUES operator when it operates over
-#      constant ARRAY.
+#   1. Tuple access is not folded with Values operator.
 opt
 WITH Updates AS
 (
@@ -1462,137 +1435,122 @@ SET actualinventory = (SELECT coalesce(sum_INT(quantity), 0)
 FROM Updates
 WHERE ci.cardid = Updates.c AND ci.dealerid = 1
 ----
-with &1 (updates)
+update ci
+ ├── columns: <none>
+ ├── fetch columns: ci.dealerid:17 ci.cardid:18 buyprice:19 sellprice:20 discount:21 desiredinventory:22 actualinventory:23 maxinventory:24 ci.version:25 ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29
+ ├── update-mapping:
+ │    ├── column41:41 => actualinventory:10
+ │    ├── discountbuyprice:45 => ci.discountbuyprice:13
+ │    ├── column42:42 => notes:14
+ │    └── column43:43 => oldinventory:15
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
- ├── project
- │    ├── columns: c:2 q:3
- │    ├── side-effects
- │    ├── project-set
- │    │    ├── columns: unnest:1
- │    │    ├── side-effects
- │    │    ├── values
- │    │    │    ├── cardinality: [1 - 1]
- │    │    │    ├── key: ()
- │    │    │    └── ()
- │    │    └── zip
- │    │         └── unnest(ARRAY[(42948, 3),(24924, 4)]) [side-effects]
- │    └── projections
- │         ├── (unnest:1).@1 [as=c:2, outer=(1)]
- │         └── (unnest:1).@2 [as=q:3, outer=(1)]
- └── update ci
-      ├── columns: <none>
-      ├── fetch columns: ci.dealerid:17 ci.cardid:18 buyprice:19 sellprice:20 discount:21 desiredinventory:22 actualinventory:23 maxinventory:24 ci.version:25 ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29
-      ├── update-mapping:
-      │    ├── column41:41 => actualinventory:10
-      │    ├── discountbuyprice:45 => ci.discountbuyprice:13
-      │    ├── column42:42 => notes:14
-      │    └── column43:43 => oldinventory:15
-      ├── cardinality: [0 - 0]
-      ├── side-effects, mutations
-      └── project
-           ├── columns: discountbuyprice:45 column42:42 column43:43!null column41:41 ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31
-           ├── key: (18)
-           ├── fd: ()-->(17,42,43), (18)-->(19-31,41,45), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
-           ├── group-by
-           │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31 sum_int:39
-           │    ├── grouping columns: ci.cardid:18!null
-           │    ├── key: (18)
-           │    ├── fd: ()-->(17), (18)-->(17,19-31,39), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
-           │    ├── left-join (lookup inventorydetails)
-           │    │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31 id.dealerid:32 id.cardid:33 quantity:35
-           │    │    ├── key columns: [49 18] = [32 33]
-           │    │    ├── fd: ()-->(17), (18)-->(19-31), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
-           │    │    ├── project
-           │    │    │    ├── columns: "project_const_col_@32":49!null ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31
-           │    │    │    ├── key: (18)
-           │    │    │    ├── fd: ()-->(17,49), (18)-->(19-31), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
-           │    │    │    ├── distinct-on
-           │    │    │    │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31
-           │    │    │    │    ├── grouping columns: ci.cardid:18!null
-           │    │    │    │    ├── key: (18)
-           │    │    │    │    ├── fd: ()-->(17), (18)-->(17,19-31), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
-           │    │    │    │    ├── inner-join (lookup cardsinfo)
-           │    │    │    │    │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31
-           │    │    │    │    │    ├── key columns: [46 30] = [17 18]
-           │    │    │    │    │    ├── lookup columns are key
-           │    │    │    │    │    ├── fd: ()-->(17), (18)-->(19-29), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
-           │    │    │    │    │    ├── project
-           │    │    │    │    │    │    ├── columns: "project_const_col_@17":46!null c:30 q:31
-           │    │    │    │    │    │    ├── fd: ()-->(46)
-           │    │    │    │    │    │    ├── with-scan &1 (updates)
-           │    │    │    │    │    │    │    ├── columns: c:30 q:31
-           │    │    │    │    │    │    │    └── mapping:
-           │    │    │    │    │    │    │         ├──  c:2 => c:30
-           │    │    │    │    │    │    │         └──  q:3 => q:31
-           │    │    │    │    │    │    └── projections
-           │    │    │    │    │    │         └── 1 [as="project_const_col_@17":46]
-           │    │    │    │    │    └── filters (true)
-           │    │    │    │    └── aggregations
-           │    │    │    │         ├── first-agg [as=buyprice:19, outer=(19)]
-           │    │    │    │         │    └── buyprice:19
-           │    │    │    │         ├── first-agg [as=sellprice:20, outer=(20)]
-           │    │    │    │         │    └── sellprice:20
-           │    │    │    │         ├── first-agg [as=discount:21, outer=(21)]
-           │    │    │    │         │    └── discount:21
-           │    │    │    │         ├── first-agg [as=desiredinventory:22, outer=(22)]
-           │    │    │    │         │    └── desiredinventory:22
-           │    │    │    │         ├── first-agg [as=actualinventory:23, outer=(23)]
-           │    │    │    │         │    └── actualinventory:23
-           │    │    │    │         ├── first-agg [as=maxinventory:24, outer=(24)]
-           │    │    │    │         │    └── maxinventory:24
-           │    │    │    │         ├── first-agg [as=ci.version:25, outer=(25)]
-           │    │    │    │         │    └── ci.version:25
-           │    │    │    │         ├── first-agg [as=ci.discountbuyprice:26, outer=(26)]
-           │    │    │    │         │    └── ci.discountbuyprice:26
-           │    │    │    │         ├── first-agg [as=notes:27, outer=(27)]
-           │    │    │    │         │    └── notes:27
-           │    │    │    │         ├── first-agg [as=oldinventory:28, outer=(28)]
-           │    │    │    │         │    └── oldinventory:28
-           │    │    │    │         ├── first-agg [as=ci.extra:29, outer=(29)]
-           │    │    │    │         │    └── ci.extra:29
-           │    │    │    │         ├── first-agg [as=c:30, outer=(30)]
-           │    │    │    │         │    └── c:30
-           │    │    │    │         ├── first-agg [as=q:31, outer=(31)]
-           │    │    │    │         │    └── q:31
-           │    │    │    │         └── const-agg [as=ci.dealerid:17, outer=(17)]
-           │    │    │    │              └── ci.dealerid:17
-           │    │    │    └── projections
-           │    │    │         └── 1 [as="project_const_col_@32":49]
-           │    │    └── filters (true)
-           │    └── aggregations
-           │         ├── sum-int [as=sum_int:39, outer=(35)]
-           │         │    └── quantity:35
-           │         ├── const-agg [as=ci.dealerid:17, outer=(17)]
-           │         │    └── ci.dealerid:17
-           │         ├── const-agg [as=buyprice:19, outer=(19)]
-           │         │    └── buyprice:19
-           │         ├── const-agg [as=sellprice:20, outer=(20)]
-           │         │    └── sellprice:20
-           │         ├── const-agg [as=discount:21, outer=(21)]
-           │         │    └── discount:21
-           │         ├── const-agg [as=desiredinventory:22, outer=(22)]
-           │         │    └── desiredinventory:22
-           │         ├── const-agg [as=actualinventory:23, outer=(23)]
-           │         │    └── actualinventory:23
-           │         ├── const-agg [as=maxinventory:24, outer=(24)]
-           │         │    └── maxinventory:24
-           │         ├── const-agg [as=ci.version:25, outer=(25)]
-           │         │    └── ci.version:25
-           │         ├── const-agg [as=ci.discountbuyprice:26, outer=(26)]
-           │         │    └── ci.discountbuyprice:26
-           │         ├── const-agg [as=notes:27, outer=(27)]
-           │         │    └── notes:27
-           │         ├── const-agg [as=oldinventory:28, outer=(28)]
-           │         │    └── oldinventory:28
-           │         ├── const-agg [as=ci.extra:29, outer=(29)]
-           │         │    └── ci.extra:29
-           │         ├── const-agg [as=c:30, outer=(30)]
-           │         │    └── c:30
-           │         └── const-agg [as=q:31, outer=(31)]
-           │              └── q:31
-           └── projections
-                ├── crdb_internal.round_decimal_values(buyprice:19 - discount:21, 4) [as=discountbuyprice:45, outer=(19,21)]
-                ├── CAST(NULL AS STRING) [as=column42:42]
-                ├── 0 [as=column43:43]
-                └── COALESCE(sum_int:39, 0) [as=column41:41, outer=(39)]
+ └── project
+      ├── columns: discountbuyprice:45 column42:42 column43:43!null column41:41 ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31
+      ├── key: (18)
+      ├── fd: ()-->(17,42,43), (18)-->(19-31,41,45), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
+      ├── group-by
+      │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31 sum_int:39
+      │    ├── grouping columns: ci.cardid:18!null
+      │    ├── key: (18)
+      │    ├── fd: ()-->(17), (18)-->(17,19-31,39), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
+      │    ├── left-join (lookup inventorydetails)
+      │    │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31 id.dealerid:32 id.cardid:33 quantity:35
+      │    │    ├── key columns: [49 18] = [32 33]
+      │    │    ├── fd: ()-->(17), (18)-->(19-31), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
+      │    │    ├── project
+      │    │    │    ├── columns: "project_const_col_@32":49!null ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31
+      │    │    │    ├── key: (18)
+      │    │    │    ├── fd: ()-->(17,49), (18)-->(19-31), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
+      │    │    │    ├── distinct-on
+      │    │    │    │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31
+      │    │    │    │    ├── grouping columns: ci.cardid:18!null
+      │    │    │    │    ├── key: (18)
+      │    │    │    │    ├── fd: ()-->(17), (18)-->(17,19-31), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
+      │    │    │    │    ├── inner-join (lookup cardsinfo)
+      │    │    │    │    │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31
+      │    │    │    │    │    ├── key columns: [46 30] = [17 18]
+      │    │    │    │    │    ├── lookup columns are key
+      │    │    │    │    │    ├── fd: ()-->(17), (18)-->(19-29), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: "project_const_col_@17":46!null c:30 q:31
+      │    │    │    │    │    │    ├── cardinality: [2 - 2]
+      │    │    │    │    │    │    ├── fd: ()-->(46)
+      │    │    │    │    │    │    ├── values
+      │    │    │    │    │    │    │    ├── columns: unnest:1!null
+      │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
+      │    │    │    │    │    │    │    ├── ((42948, 3),)
+      │    │    │    │    │    │    │    └── ((24924, 4),)
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         ├── 1 [as="project_const_col_@17":46]
+      │    │    │    │    │    │         ├── (unnest:1).@1 [as=c:30, outer=(1)]
+      │    │    │    │    │    │         └── (unnest:1).@2 [as=q:31, outer=(1)]
+      │    │    │    │    │    └── filters (true)
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── first-agg [as=buyprice:19, outer=(19)]
+      │    │    │    │         │    └── buyprice:19
+      │    │    │    │         ├── first-agg [as=sellprice:20, outer=(20)]
+      │    │    │    │         │    └── sellprice:20
+      │    │    │    │         ├── first-agg [as=discount:21, outer=(21)]
+      │    │    │    │         │    └── discount:21
+      │    │    │    │         ├── first-agg [as=desiredinventory:22, outer=(22)]
+      │    │    │    │         │    └── desiredinventory:22
+      │    │    │    │         ├── first-agg [as=actualinventory:23, outer=(23)]
+      │    │    │    │         │    └── actualinventory:23
+      │    │    │    │         ├── first-agg [as=maxinventory:24, outer=(24)]
+      │    │    │    │         │    └── maxinventory:24
+      │    │    │    │         ├── first-agg [as=ci.version:25, outer=(25)]
+      │    │    │    │         │    └── ci.version:25
+      │    │    │    │         ├── first-agg [as=ci.discountbuyprice:26, outer=(26)]
+      │    │    │    │         │    └── ci.discountbuyprice:26
+      │    │    │    │         ├── first-agg [as=notes:27, outer=(27)]
+      │    │    │    │         │    └── notes:27
+      │    │    │    │         ├── first-agg [as=oldinventory:28, outer=(28)]
+      │    │    │    │         │    └── oldinventory:28
+      │    │    │    │         ├── first-agg [as=ci.extra:29, outer=(29)]
+      │    │    │    │         │    └── ci.extra:29
+      │    │    │    │         ├── first-agg [as=c:30, outer=(30)]
+      │    │    │    │         │    └── c:30
+      │    │    │    │         ├── first-agg [as=q:31, outer=(31)]
+      │    │    │    │         │    └── q:31
+      │    │    │    │         └── const-agg [as=ci.dealerid:17, outer=(17)]
+      │    │    │    │              └── ci.dealerid:17
+      │    │    │    └── projections
+      │    │    │         └── 1 [as="project_const_col_@32":49]
+      │    │    └── filters (true)
+      │    └── aggregations
+      │         ├── sum-int [as=sum_int:39, outer=(35)]
+      │         │    └── quantity:35
+      │         ├── const-agg [as=ci.dealerid:17, outer=(17)]
+      │         │    └── ci.dealerid:17
+      │         ├── const-agg [as=buyprice:19, outer=(19)]
+      │         │    └── buyprice:19
+      │         ├── const-agg [as=sellprice:20, outer=(20)]
+      │         │    └── sellprice:20
+      │         ├── const-agg [as=discount:21, outer=(21)]
+      │         │    └── discount:21
+      │         ├── const-agg [as=desiredinventory:22, outer=(22)]
+      │         │    └── desiredinventory:22
+      │         ├── const-agg [as=actualinventory:23, outer=(23)]
+      │         │    └── actualinventory:23
+      │         ├── const-agg [as=maxinventory:24, outer=(24)]
+      │         │    └── maxinventory:24
+      │         ├── const-agg [as=ci.version:25, outer=(25)]
+      │         │    └── ci.version:25
+      │         ├── const-agg [as=ci.discountbuyprice:26, outer=(26)]
+      │         │    └── ci.discountbuyprice:26
+      │         ├── const-agg [as=notes:27, outer=(27)]
+      │         │    └── notes:27
+      │         ├── const-agg [as=oldinventory:28, outer=(28)]
+      │         │    └── oldinventory:28
+      │         ├── const-agg [as=ci.extra:29, outer=(29)]
+      │         │    └── ci.extra:29
+      │         ├── const-agg [as=c:30, outer=(30)]
+      │         │    └── c:30
+      │         └── const-agg [as=q:31, outer=(31)]
+      │              └── q:31
+      └── projections
+           ├── crdb_internal.round_decimal_values(buyprice:19 - discount:21, 4) [as=discountbuyprice:45, outer=(19,21)]
+           ├── CAST(NULL AS STRING) [as=column42:42]
+           ├── 0 [as=column43:43]
+           └── COALESCE(sum_int:39, 0) [as=column41:41, outer=(39)]


### PR DESCRIPTION
Previously, an unnest of an array within the zip of a ProjectSet could
not be unpacked for optimization.

This patch adds a rule to transform a ProjectSet that is zipping unnests
arrays into an InnerJoinApply. The left input of the InnerJoinApply is the
input of the ProjectSet, and the right input is a Values operator with the
values from the arrays in the ProjectSet's zip. Shorter arrays are padded
with nulls.

This allows Values and decorrelation rules to fire. It is especially useful in
cases where the array contents are passed as a PREPARE parameter, such as:
```
SELECT * FROM xy WHERE y IN unnest($1)
```

Fixes #46357

Release note: None