### PR TITLE
util/log,*: enforce literal strings in non-formatting log calls

### DIFF
--- a/pkg/acceptance/cluster/docker.go
+++ b/pkg/acceptance/cluster/docker.go
@@ -299,7 +299,7 @@ func (c *Container) Wait(ctx context.Context, condition container.WaitCondition)
 
 		out := io.MultiWriter(cmdLog, os.Stderr)
 		if err := c.Logs(ctx, out); err != nil {
-			log.Warning(ctx, err)
+			log.Warningf(ctx, "%v", err)
 		}
 
 		if exitCode := waitOKBody.StatusCode; exitCode != 0 {
@@ -351,7 +351,7 @@ func (c *Container) Inspect(ctx context.Context) (types.ContainerJSON, error) {
 func (c *Container) Addr(ctx context.Context, port nat.Port) *net.TCPAddr {
 	containerInfo, err := c.Inspect(ctx)
 	if err != nil {
-		log.Error(ctx, err)
+		log.Errorf(ctx, "%v", err)
 		return nil
 	}
 	bindings, ok := containerInfo.NetworkSettings.Ports[port]
@@ -360,7 +360,7 @@ func (c *Container) Addr(ctx context.Context, port nat.Port) *net.TCPAddr {
 	}
 	portNum, err := strconv.Atoi(bindings[0].HostPort)
 	if err != nil {
-		log.Error(ctx, err)
+		log.Errorf(ctx, "%v", err)
 		return nil
 	}
 	return &net.TCPAddr{

--- a/pkg/acceptance/cluster/docker.go
+++ b/pkg/acceptance/cluster/docker.go
@@ -305,7 +305,7 @@ func (c *Container) Wait(ctx context.Context, condition container.WaitCondition)
 		if exitCode := waitOKBody.StatusCode; exitCode != 0 {
 			err = errors.Errorf("non-zero exit code: %d", exitCode)
 			fmt.Fprintln(out, err.Error())
-			log.Shout(ctx, log.Severity_INFO, "command left-over files in ", c.cluster.volumesDir)
+			log.Shoutf(ctx, log.Severity_INFO, "command left-over files in %s", c.cluster.volumesDir)
 		}
 
 		return err

--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -864,7 +864,7 @@ func (l *DockerCluster) ExecCLI(ctx context.Context, i int, cmd []string) (strin
 func (l *DockerCluster) Cleanup(ctx context.Context, preserveLogs bool) {
 	volumes, err := ioutil.ReadDir(l.volumesDir)
 	if err != nil {
-		log.Warning(ctx, err)
+		log.Warningf(ctx, "%v", err)
 		return
 	}
 	for _, v := range volumes {
@@ -872,7 +872,7 @@ func (l *DockerCluster) Cleanup(ctx context.Context, preserveLogs bool) {
 			continue
 		}
 		if err := os.RemoveAll(filepath.Join(l.volumesDir, v.Name())); err != nil {
-			log.Warning(ctx, err)
+			log.Warningf(ctx, "%v", err)
 		}
 	}
 }

--- a/pkg/base/addr_validation.go
+++ b/pkg/base/addr_validation.go
@@ -286,7 +286,7 @@ func (cfg *Config) CheckCertificateAddrs(ctx context.Context) {
 	// with the provided certificate.
 	certInfo := cm.NodeCert()
 	if certInfo.Error != nil {
-		log.Shout(ctx, log.Severity_ERROR,
+		log.Shoutf(ctx, log.Severity_ERROR,
 			"invalid node certificate: %v", certInfo.Error)
 	} else {
 		cert := certInfo.ParsedCertificates[0]
@@ -313,11 +313,11 @@ func (cfg *Config) CheckCertificateAddrs(ctx context.Context) {
 			fmt.Fprintf(&msg, "advertise SQL address %q not in node certificate (%s)\n", host, addrInfo)
 		}
 		if msg.Len() > 0 {
-			log.Shout(ctx, log.Severity_WARNING,
-				fmt.Sprintf("%s"+
+			log.Shoutf(ctx, log.Severity_WARNING,
+				"%s"+
 					"Secure client connections are likely to fail.\n"+
 					"Consider extending the node certificate or tweak --listen-addr/--advertise-addr/--sql-addr/--advertise-sql-addr.",
-					msg.String()))
+				msg.String())
 		}
 	}
 
@@ -331,7 +331,7 @@ func (cfg *Config) CheckCertificateAddrs(ctx context.Context) {
 		certInfo = cm.NodeCert()
 	}
 	if certInfo.Error != nil {
-		log.Shout(ctx, log.Severity_ERROR,
+		log.Shoutf(ctx, log.Severity_ERROR,
 			"invalid UI certificate: %v", certInfo.Error)
 	} else {
 		cert := certInfo.ParsedCertificates[0]

--- a/pkg/ccl/changefeedccl/cdctest/nemeses.go
+++ b/pkg/ccl/changefeedccl/cdctest/nemeses.go
@@ -637,7 +637,7 @@ func noteFeedMessage(a fsm.Args) error {
 		if err != nil {
 			return err
 		}
-		log.Info(a.Ctx, string(m.Resolved))
+		log.Infof(a.Ctx, "%v", string(m.Resolved))
 		return ns.v.NoteResolved(m.Partition, ts)
 	}
 	ts, _, err := ParseJSONValueTimestamps(m.Value)

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -271,13 +271,13 @@ type kafkaLogAdapter struct {
 var _ sarama.StdLogger = (*kafkaLogAdapter)(nil)
 
 func (l *kafkaLogAdapter) Print(v ...interface{}) {
-	log.InfoDepth(l.ctx, 1, v...)
+	log.InfofDepth(l.ctx, 1, "", v...)
 }
 func (l *kafkaLogAdapter) Printf(format string, v ...interface{}) {
 	log.InfofDepth(l.ctx, 1, format, v...)
 }
 func (l *kafkaLogAdapter) Println(v ...interface{}) {
-	log.InfoDepth(l.ctx, 1, v...)
+	log.InfofDepth(l.ctx, 1, "", v...)
 }
 
 func init() {

--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -384,7 +384,7 @@ func writeSST(
 	}
 
 	filename := fmt.Sprintf("load-%d.sst", rand.Int63())
-	log.Info(ctx, "writesst ", filename)
+	log.Infof(ctx, "writesst %s", filename)
 
 	sstFile := &storage.MemFile{}
 	sst := storage.MakeBackupSSTWriter(sstFile)

--- a/pkg/ccl/importccl/read_import_base.go
+++ b/pkg/ccl/importccl/read_import_base.go
@@ -393,7 +393,7 @@ type importFileContext struct {
 // handleCorruptRow reports an error encountered while processing a row
 // in an input file.
 func handleCorruptRow(ctx context.Context, fileCtx *importFileContext, err error) error {
-	log.Error(ctx, err)
+	log.Errorf(ctx, "%v", err)
 
 	if rowErr, isRowErr := err.(*importRowError); isRowErr && fileCtx.rejected != nil {
 		fileCtx.rejected <- rowErr.row + "\n"

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -863,7 +863,7 @@ func runTimeSeriesDump(cmd *cobra.Command, args []string) error {
 	tsClient := tspb.NewTimeSeriesClient(conn)
 	stream, err := tsClient.Dump(context.Background(), &tspb.DumpRequest{})
 	if err != nil {
-		log.Fatal(context.Background(), err)
+		log.Fatalf(context.Background(), "%v", err)
 	}
 
 	var name, source string

--- a/pkg/cli/demo_cluster.go
+++ b/pkg/cli/demo_cluster.go
@@ -433,18 +433,17 @@ func maybeWarnMemSize(ctx context.Context) {
 		requestedMem := (demoCtx.cacheSize + demoCtx.sqlPoolMemorySize) * int64(demoCtx.nodes)
 		maxRecommendedMem := int64(.75 * float64(maxMemory))
 		if requestedMem > maxRecommendedMem {
-			log.Shout(
+			log.Shoutf(
 				ctx,
 				log.Severity_WARNING,
-				fmt.Sprintf(`HIGH MEMORY USAGE
+				`HIGH MEMORY USAGE
 The sum of --max-sql-memory (%s) and --cache (%s) multiplied by the
 number of nodes (%d) results in potentially high memory usage on your
 device.
 This server is running at increased risk of memory-related failures.`,
-					demoNodeSQLMemSizeValue,
-					demoNodeCacheSizeValue,
-					demoCtx.nodes,
-				),
+				demoNodeSQLMemSizeValue,
+				demoNodeCacheSizeValue,
+				demoCtx.nodes,
 			)
 		}
 	}

--- a/pkg/cli/error.go
+++ b/pkg/cli/error.go
@@ -354,11 +354,11 @@ func maybeShoutError(
 }
 
 func checkAndMaybeShout(err error) error {
-	return checkAndMaybeShoutTo(err, log.Shout)
+	return checkAndMaybeShoutTo(err, log.Shoutf)
 }
 
 func checkAndMaybeShoutTo(
-	err error, logger func(context.Context, log.Severity, ...interface{}),
+	err error, logger func(context.Context, log.Severity, string, ...interface{}),
 ) error {
 	if err == nil {
 		return nil
@@ -370,6 +370,6 @@ func checkAndMaybeShoutTo(
 		severity = ec.severity
 		cause = ec.cause
 	}
-	logger(context.Background(), severity, cause)
+	logger(context.Background(), severity, "%v", cause)
 	return err
 }

--- a/pkg/cli/error_test.go
+++ b/pkg/cli/error_test.go
@@ -109,7 +109,7 @@ type logger struct {
 	Err      error
 }
 
-func (l *logger) Log(_ context.Context, sev log.Severity, args ...interface{}) {
+func (l *logger) Log(_ context.Context, sev log.Severity, msg string, args ...interface{}) {
 	require.Equal(l.TB, 1, len(args), "expected to log one item")
 	err, ok := args[0].(error)
 	require.True(l.TB, ok, "expected to log an error")

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -448,7 +448,7 @@ func (c *sqlConn) Close() {
 	if c.conn != nil {
 		err := c.conn.Close()
 		if err != nil && err != driver.ErrBadConn {
-			log.Info(context.TODO(), err)
+			log.Infof(context.TODO(), "%v", err)
 		}
 		c.conn = nil
 	}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -648,20 +648,20 @@ func runStart(cmd *cobra.Command, args []string, disableReplication bool) error 
 	// DelayedBoostrapFn will be called if the boostrap process is
 	// taking a bit long.
 	serverCfg.DelayedBootstrapFn = func() {
-		msg := `The server appears to be unable to contact the other nodes in the cluster. Please try:
+		const msg = `The server appears to be unable to contact the other nodes in the cluster. Please try:
 
 - starting the other nodes, if you haven't already;
 - double-checking that the '--join' and '--listen'/'--advertise' flags are set up correctly;
 - running the 'cockroach init' command if you are trying to initialize a new cluster.
 
-If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.html") + "."
-
+If problems persist, please see %s.`
+		docLink := base.DocsURL("cluster-setup-troubleshooting.html")
 		if !startCtx.inBackground {
-			log.Shout(context.Background(), log.Severity_WARNING, msg)
+			log.Shoutf(context.Background(), log.Severity_WARNING, msg, docLink)
 		} else {
 			// Don't shout to stderr since the server will have detached by
 			// the time this function gets called.
-			log.Warningf(ctx, "%s", msg)
+			log.Warningf(ctx, msg, docLink)
 		}
 	}
 
@@ -1020,8 +1020,9 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 	case sig := <-signalCh:
 		// This new signal is not welcome, as it interferes with the graceful
 		// shutdown process.
-		log.Shout(shutdownCtx, log.Severity_ERROR, fmt.Sprintf(
-			"received signal '%s' during shutdown, initiating hard shutdown%s", sig, hardShutdownHint))
+		log.Shoutf(shutdownCtx, log.Severity_ERROR,
+			"received signal '%s' during shutdown, initiating hard shutdown%s",
+			log.Safe(sig), log.Safe(hardShutdownHint))
 		handleSignalDuringShutdown(sig)
 		panic("unreachable")
 
@@ -1047,12 +1048,12 @@ func hintServerCmdFlags(ctx context.Context, cmd *cobra.Command) {
 
 	if !listenAddrSpecified && !advAddrSpecified {
 		host, _, _ := net.SplitHostPort(serverCfg.AdvertiseAddr)
-		log.Shout(ctx, log.Severity_WARNING,
+		log.Shoutf(ctx, log.Severity_WARNING,
 			"neither --listen-addr nor --advertise-addr was specified.\n"+
-				"The server will advertise "+fmt.Sprintf("%q", host)+" to other nodes, is this routable?\n\n"+
+				"The server will advertise %q to other nodes, is this routable?\n\n"+
 				"Consider using:\n"+
 				"- for local-only servers:  --listen-addr=localhost\n"+
-				"- for multi-node clusters: --advertise-addr=<host/IP addr>\n")
+				"- for multi-node clusters: --advertise-addr=<host/IP addr>\n", host)
 	}
 }
 
@@ -1082,7 +1083,7 @@ func checkTzDatabaseAvailability(ctx context.Context) error {
 		if envutil.EnvOrDefaultBool("COCKROACH_INCONSISTENT_TIME_ZONES", false) {
 			// The user tells us they really know what they want.
 			reportedErr := &formattedError{err: reportedErr}
-			log.Shout(ctx, log.Severity_WARNING, reportedErr.Error())
+			log.Shoutf(ctx, log.Severity_WARNING, "%v", reportedErr)
 		} else {
 			// Prevent a successful start.
 			//
@@ -1131,9 +1132,9 @@ func maybeWarnMemorySizes(ctx context.Context) {
 		requestedMem := serverCfg.CacheSize + serverCfg.SQLMemoryPoolSize
 		maxRecommendedMem := int64(.75 * float64(maxMemory))
 		if requestedMem > maxRecommendedMem {
-			log.Shout(ctx, log.Severity_WARNING, fmt.Sprintf(
+			log.Shoutf(ctx, log.Severity_WARNING,
 				"the sum of --max-sql-memory (%s) and --cache (%s) is larger than 75%% of total RAM (%s).\nThis server is running at increased risk of memory-related failures.",
-				sqlSizeValue, cacheSizeValue, humanizeutil.IBytes(maxRecommendedMem)))
+				sqlSizeValue, cacheSizeValue, humanizeutil.IBytes(maxRecommendedMem))
 		}
 	}
 }
@@ -1251,13 +1252,14 @@ func setupAndInitializeLoggingAndProfiling(
 		if addr == "" {
 			addr = "<all your IP addresses>"
 		}
-		log.Shout(context.Background(), log.Severity_WARNING,
+		log.Shoutf(context.Background(), log.Severity_WARNING,
 			"RUNNING IN INSECURE MODE!\n\n"+
-				"- Your cluster is open for any client that can access "+addr+".\n"+
+				"- Your cluster is open for any client that can access %s.\n"+
 				"- Any user, even root, can log in without providing a password.\n"+
 				"- Any user, connecting as root, can read or write any data in your cluster.\n"+
 				"- There is no network encryption nor authentication, and thus no confidentiality.\n\n"+
-				"Check out how to secure your cluster: "+base.DocsURL("secure-a-cluster.html"))
+				"Check out how to secure your cluster: %s",
+			addr, log.Safe(base.DocsURL("secure-a-cluster.html")))
 	}
 
 	maybeWarnMemorySizes(ctx)

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -119,7 +119,7 @@ var maxSizePerProfile = envutil.EnvOrDefaultInt64(
 func gcProfiles(dir, prefix string, maxSize int64) {
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
-		log.Warning(context.Background(), err)
+		log.Warningf(context.Background(), "%v", err)
 		return
 	}
 	var sum int64
@@ -142,7 +142,7 @@ func gcProfiles(dir, prefix string, maxSize int64) {
 			continue
 		}
 		if err := os.Remove(filepath.Join(dir, f.Name())); err != nil {
-			log.Info(context.Background(), err)
+			log.Infof(context.Background(), "%v", err)
 		}
 	}
 }

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -661,7 +661,7 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 		} else {
 			// Don't shout to stderr since the server will have detached by
 			// the time this function gets called.
-			log.Warning(ctx, msg)
+			log.Warningf(ctx, "%s", msg)
 		}
 	}
 
@@ -1123,7 +1123,7 @@ func maybeWarnMemorySizes(ctx context.Context) {
 		} else {
 			fmt.Fprintf(&buf, "  If you have a dedicated server a reasonable setting is 25%% of physical memory.")
 		}
-		log.Warning(ctx, buf.String())
+		log.Warningf(ctx, "%s", buf.String())
 	}
 
 	// Check that the total suggested "max" memory is well below the available memory.
@@ -1265,7 +1265,7 @@ func setupAndInitializeLoggingAndProfiling(
 	// We log build information to stdout (for the short summary), but also
 	// to stderr to coincide with the full logs.
 	info := build.GetInfo()
-	log.Info(ctx, info.Short())
+	log.Infof(ctx, "%s", info.Short())
 
 	initMemProfile(ctx, outputDirectory)
 	initCPUProfile(ctx, outputDirectory)

--- a/pkg/cli/syncbench/syncbench.go
+++ b/pkg/cli/syncbench/syncbench.go
@@ -87,28 +87,28 @@ func (w *worker) run(wg *sync.WaitGroup) {
 		if w.logOnly {
 			block := randBlock(300, 400)
 			if err := b.LogData(block); err != nil {
-				log.Fatal(ctx, err)
+				log.Fatalf(ctx, "%v", err)
 			}
 		} else {
 			for j := 0; j < 5; j++ {
 				block := randBlock(60, 80)
 				key := encoding.EncodeUint32Ascending(buf, rand.Uint32())
 				if err := b.Put(storage.MakeMVCCMetadataKey(key), block); err != nil {
-					log.Fatal(ctx, err)
+					log.Fatalf(ctx, "%v", err)
 				}
 				buf = key[:0]
 			}
 		}
 		bytes := uint64(b.Len())
 		if err := b.Commit(true); err != nil {
-			log.Fatal(ctx, err)
+			log.Fatalf(ctx, "%v", err)
 		}
 		atomic.AddUint64(&numOps, 1)
 		atomic.AddUint64(&numBytes, bytes)
 		elapsed := clampLatency(timeutil.Since(start), minLatency, maxLatency)
 		w.latency.Lock()
 		if err := w.latency.Current.RecordValue(elapsed.Nanoseconds()); err != nil {
-			log.Fatal(ctx, err)
+			log.Fatalf(ctx, "%v", err)
 		}
 		w.latency.Unlock()
 	}

--- a/pkg/clusterversion/setting.go
+++ b/pkg/clusterversion/setting.go
@@ -145,7 +145,7 @@ func (cv *clusterVersionSetting) activeVersionOrEmpty(
 	}
 	var curVer ClusterVersion
 	if err := protoutil.Unmarshal(encoded.([]byte), &curVer); err != nil {
-		log.Fatal(ctx, err)
+		log.Fatalf(ctx, "%v", err)
 	}
 	return curVer
 }

--- a/pkg/cmd/allocsim/main.go
+++ b/pkg/cmd/allocsim/main.go
@@ -170,7 +170,7 @@ func (a *allocSim) runWithConfig(config Configuration) {
 func (a *allocSim) setup() {
 	db := a.Nodes[0].DB()
 	if _, err := db.Exec("CREATE DATABASE IF NOT EXISTS allocsim"); err != nil {
-		log.Fatal(context.Background(), err)
+		log.Fatalf(context.Background(), "%v", err)
 	}
 
 	blocks := `
@@ -182,7 +182,7 @@ CREATE TABLE IF NOT EXISTS blocks (
 )
 `
 	if _, err := db.Exec(blocks); err != nil {
-		log.Fatal(context.Background(), err)
+		log.Fatalf(context.Background(), "%v", err)
 	}
 }
 
@@ -190,7 +190,7 @@ func (a *allocSim) maybeLogError(err error) {
 	if localcluster.IsUnavailableError(err) {
 		return
 	}
-	log.Error(context.Background(), err)
+	log.Errorf(context.Background(), "%v", err)
 	atomic.AddUint64(&a.stats.errors, 1)
 }
 
@@ -251,11 +251,11 @@ func (a *allocSim) rangeInfo() allocStats {
 				NodeId: fmt.Sprintf("local"),
 			})
 			if err != nil {
-				log.Fatal(context.Background(), err)
+				log.Fatalf(context.Background(), "%v", err)
 			}
 			var metrics map[string]interface{}
 			if err := json.Unmarshal(resp.Data, &metrics); err != nil {
-				log.Fatal(context.Background(), err)
+				log.Fatalf(context.Background(), "%v", err)
 			}
 			stores := metrics["stores"].(map[string]interface{})
 			for _, v := range stores {
@@ -420,7 +420,7 @@ func main() {
 		var err error
 		config, err = loadConfig(*configFile)
 		if err != nil {
-			log.Fatal(context.Background(), err)
+			log.Fatalf(context.Background(), "%v", err)
 		}
 	}
 
@@ -479,11 +479,11 @@ func main() {
 			// set up tc rules on the loopback device.
 			tcController = tc.NewController("lo")
 			if err := tcController.Init(); err != nil {
-				log.Fatal(context.Background(), err)
+				log.Fatalf(context.Background(), "%v", err)
 			}
 			defer func() {
 				if err := tcController.CleanUp(); err != nil {
-					log.Error(context.Background(), err)
+					log.Errorf(context.Background(), "%v", err)
 				}
 			}()
 		}
@@ -495,7 +495,7 @@ func main() {
 							if err := tcController.AddLatency(
 								perNodeCfg[srcNodeIdx].Addr, perNodeCfg[dstNodeIdx].Addr, time.Duration(outgoing.Latency/2),
 							); err != nil {
-								log.Fatal(context.Background(), err)
+								log.Fatalf(context.Background(), "%v", err)
 							}
 						}
 					}
@@ -542,7 +542,7 @@ func main() {
 	c.UpdateZoneConfig(1, 1<<20)
 	_, err := c.Nodes[0].DB().Exec("SET CLUSTER SETTING kv.raft_log.disable_synchronization_unsafe = true")
 	if err != nil {
-		log.Fatal(context.Background(), err)
+		log.Fatalf(context.Background(), "%v", err)
 	}
 	if len(config.Localities) != 0 {
 		a.runWithConfig(config)

--- a/pkg/cmd/gossipsim/main.go
+++ b/pkg/cmd/gossipsim/main.go
@@ -182,7 +182,7 @@ func outputDotFile(
 		quiescent = false
 		nodeID, err := strconv.Atoi(strings.Split(key, ":")[0])
 		if err != nil {
-			log.Fatal(context.TODO(), err)
+			log.Fatalf(context.TODO(), "%v", err)
 		}
 		outgoingMap.addEdge(roachpb.NodeID(nodeID), e)
 		delete(edgeSet, key)

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1165,7 +1165,7 @@ func (f *clusterFactory) newCluster(
 	logPath := filepath.Join(f.artifactsDir, runnerLogsDir, "cluster-create", name+".log")
 	l, err := rootLogger(logPath, teeOpt)
 	if err != nil {
-		log.Fatal(ctx, err)
+		log.Fatalf(ctx, "%v", err)
 	}
 
 	success := false

--- a/pkg/cmd/zerosum/main.go
+++ b/pkg/cmd/zerosum/main.go
@@ -110,7 +110,7 @@ func (z *zeroSum) run(workers, monkeys int) {
 func (z *zeroSum) setup() uint32 {
 	db := z.Nodes[0].DB()
 	if _, err := db.Exec("CREATE DATABASE IF NOT EXISTS zerosum"); err != nil {
-		log.Fatal(context.Background(), err)
+		log.Fatalf(context.Background(), "%v", err)
 	}
 
 	accounts := `
@@ -120,7 +120,7 @@ CREATE TABLE IF NOT EXISTS accounts (
 )
 `
 	if _, err := db.Exec(accounts); err != nil {
-		log.Fatal(context.Background(), err)
+		log.Fatalf(context.Background(), "%v", err)
 	}
 
 	tableIDQuery := `
@@ -130,7 +130,7 @@ SELECT tables.id FROM system.namespace tables
 `
 	var tableID uint32
 	if err := db.QueryRow(tableIDQuery, "zerosum", "accounts").Scan(&tableID); err != nil {
-		log.Fatal(context.Background(), err)
+		log.Fatalf(context.Background(), "%v", err)
 	}
 	return tableID
 }
@@ -150,7 +150,7 @@ func (z *zeroSum) maybeLogError(err error) {
 	if localcluster.IsUnavailableError(err) || strings.Contains(err.Error(), "range is frozen") {
 		return
 	}
-	log.Error(context.Background(), err)
+	log.Errorf(context.Background(), "%v", err)
 	atomic.AddUint64(&z.stats.errors, 1)
 }
 
@@ -181,7 +181,7 @@ func (z *zeroSum) worker() {
 				var id uint64
 				var balance int64
 				if err = rows.Scan(&id, &balance); err != nil {
-					log.Fatal(context.Background(), err)
+					log.Fatalf(context.Background(), "%v", err)
 				}
 				switch id {
 				case from:

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -473,7 +473,7 @@ func (g *Gossip) SetStorage(storage Storage) error {
 	// Persist merged addresses.
 	if numAddrs := len(g.bootstrapInfo.Addresses); numAddrs > len(storedBI.Addresses) {
 		if err := g.storage.WriteBootstrapInfo(&g.bootstrapInfo); err != nil {
-			log.Error(ctx, err)
+			log.Errorf(ctx, "%v", err)
 		}
 	}
 
@@ -756,12 +756,12 @@ func (g *Gossip) maybeCleanupBootstrapAddressesLocked() {
 		}
 		return nil
 	}, true /* deleteExpired */); err != nil {
-		log.Error(ctx, err)
+		log.Errorf(ctx, "%v", err)
 		return
 	}
 
 	if err := g.storage.WriteBootstrapInfo(&g.bootstrapInfo); err != nil {
-		log.Error(ctx, err)
+		log.Errorf(ctx, "%v", err)
 	}
 }
 
@@ -804,7 +804,7 @@ func (g *Gossip) updateNodeAddress(key string, content roachpb.Value) {
 	ctx := g.AnnotateCtx(context.TODO())
 	var desc roachpb.NodeDescriptor
 	if err := content.GetProto(&desc); err != nil {
-		log.Error(ctx, err)
+		log.Errorf(ctx, "%v", err)
 		return
 	}
 	if log.V(1) {
@@ -856,7 +856,7 @@ func (g *Gossip) updateNodeAddress(key string, content roachpb.Value) {
 	added := g.maybeAddBootstrapAddressLocked(desc.Address, desc.NodeID)
 	if added && g.storage != nil {
 		if err := g.storage.WriteBootstrapInfo(&g.bootstrapInfo); err != nil {
-			log.Error(ctx, err)
+			log.Errorf(ctx, "%v", err)
 		}
 	}
 }
@@ -871,7 +871,7 @@ func (g *Gossip) updateStoreMap(key string, content roachpb.Value) {
 	ctx := g.AnnotateCtx(context.TODO())
 	var desc roachpb.StoreDescriptor
 	if err := content.GetProto(&desc); err != nil {
-		log.Error(ctx, err)
+		log.Errorf(ctx, "%v", err)
 		return
 	}
 
@@ -912,7 +912,7 @@ func (g *Gossip) updateClients() {
 	g.mu.RUnlock()
 
 	if err := g.AddInfo(MakeGossipClientsKey(nodeID), buf.Bytes(), 2*defaultClientsInterval); err != nil {
-		log.Error(g.AnnotateCtx(context.Background()), err)
+		log.Errorf(g.AnnotateCtx(context.Background()), "%v", err)
 	}
 }
 

--- a/pkg/gossip/infostore.go
+++ b/pkg/gossip/infostore.go
@@ -251,8 +251,8 @@ func (is *infoStore) addInfo(key string, i *Info) error {
 		i.OrigStamp = monotonicUnixNano()
 		if highWaterStamp, ok := is.highWaterStamps[i.NodeID]; ok && highWaterStamp >= i.OrigStamp {
 			// Report both timestamps in the crash.
-			log.Fatal(context.Background(),
-				log.Safe(fmt.Sprintf("high water stamp %d >= %d", highWaterStamp, i.OrigStamp)))
+			log.Fatalf(context.Background(),
+				"high water stamp %d >= %d", log.Safe(highWaterStamp), log.Safe(i.OrigStamp))
 		}
 	}
 	// Update info map.

--- a/pkg/gossip/simulation/network.go
+++ b/pkg/gossip/simulation/network.go
@@ -81,7 +81,7 @@ func NewNetwork(
 	var err error
 	n.tlsConfig, err = n.RPCContext.GetServerTLSConfig()
 	if err != nil {
-		log.Fatal(context.TODO(), err)
+		log.Fatalf(context.TODO(), "%v", err)
 	}
 
 	// Ensure that tests using this test context and restart/shut down
@@ -92,7 +92,7 @@ func NewNetwork(
 	for i := 0; i < nodeCount; i++ {
 		node, err := n.CreateNode(defaultZoneConfig)
 		if err != nil {
-			log.Fatal(context.TODO(), err)
+			log.Fatalf(context.TODO(), "%v", err)
 		}
 		// Build a resolver for each instance or we'll get data races.
 		if createResolvers {
@@ -180,14 +180,14 @@ func (n *Network) SimulateNetwork(simCallback func(cycle int, network *Network) 
 			encoding.EncodeUint64Ascending(nil, uint64(cycle)),
 			time.Hour,
 		); err != nil {
-			log.Fatal(context.TODO(), err)
+			log.Fatalf(context.TODO(), "%v", err)
 		}
 		if err := nodes[0].Gossip.AddInfo(
 			gossip.KeyClusterID,
 			encoding.EncodeUint64Ascending(nil, uint64(cycle)),
 			0*time.Second,
 		); err != nil {
-			log.Fatal(context.TODO(), err)
+			log.Fatalf(context.TODO(), "%v", err)
 		}
 		// Every node gossips every cycle.
 		for _, node := range nodes {
@@ -196,7 +196,7 @@ func (n *Network) SimulateNetwork(simCallback func(cycle int, network *Network) 
 				encoding.EncodeUint64Ascending(nil, uint64(cycle)),
 				time.Hour,
 			); err != nil {
-				log.Fatal(context.TODO(), err)
+				log.Fatalf(context.TODO(), "%v", err)
 			}
 			node.Gossip.SimulationCycle()
 		}
@@ -223,7 +223,7 @@ func (n *Network) Start() {
 	n.started = true
 	for _, node := range n.Nodes {
 		if err := n.StartNode(node); err != nil {
-			log.Fatal(context.TODO(), err)
+			log.Fatalf(context.TODO(), "%v", err)
 		}
 	}
 }

--- a/pkg/internal/client/requestbatcher/batcher.go
+++ b/pkg/internal/client/requestbatcher/batcher.go
@@ -312,7 +312,7 @@ func (b *RequestBatcher) sendBatch(ctx context.Context, ba *batch) {
 					if prevResps != nil {
 						prevResp := prevResps[i]
 						if cErr := roachpb.CombineResponses(prevResp, resp); cErr != nil {
-							log.Fatal(ctx, cErr)
+							log.Fatalf(ctx, "%v", cErr)
 						}
 						resp = prevResp
 					}

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -973,7 +973,7 @@ func (r *Registry) adoptionDisabled(ctx context.Context) bool {
 	if r.preventAdoptionFile != "" {
 		if _, err := os.Stat(r.preventAdoptionFile); err != nil {
 			if !os.IsNotExist(err) {
-				log.Warning(ctx, "error checking if job adoption is currently disabled", err)
+				log.Warningf(ctx, "error checking if job adoption is currently disabled: %v", err)
 			}
 			return false
 		}

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -271,13 +271,13 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Ke
 		// minimizes impact on other adders (e.g. causing extra SST splitting).
 		if b.flushCounts.total == 1 {
 			if splitAt, err := keys.EnsureSafeSplitKey(start); err != nil {
-				log.Warning(ctx, err)
+				log.Warningf(ctx, "%v", err)
 			} else {
 				// NB: Passing 'hour' here is technically illegal until 19.2 is
 				// active, but the value will be ignored before that, and we don't
 				// have access to the cluster version here.
 				if err := b.db.SplitAndScatter(ctx, splitAt, hour); err != nil {
-					log.Warning(ctx, err)
+					log.Warningf(ctx, "%v", err)
 				}
 			}
 		}
@@ -319,7 +319,7 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Ke
 		if b.splitAfter != nil {
 			if splitAfter := b.splitAfter(); b.flushedToCurrentRange > splitAfter && nextKey != nil {
 				if splitAt, err := keys.EnsureSafeSplitKey(nextKey); err != nil {
-					log.Warning(ctx, err)
+					log.Warningf(ctx, "%v", err)
 				} else {
 					beforeSplit := timeutil.Now()
 

--- a/pkg/kv/kvclient/kvcoord/transport.go
+++ b/pkg/kv/kvclient/kvcoord/transport.go
@@ -202,7 +202,7 @@ func (gt *grpcTransport) sendBatch(
 	if reply != nil && !rpc.IsLocal(iface) {
 		for i := range reply.Responses {
 			if err := reply.Responses[i].GetInner().Verify(ba.Requests[i].GetInner()); err != nil {
-				log.Error(ctx, err)
+				log.Errorf(ctx, "%v", err)
 			}
 		}
 		// Import the remotely collected spans, if any.

--- a/pkg/kv/kvclient/kvcoord/transport.go
+++ b/pkg/kv/kvclient/kvcoord/transport.go
@@ -337,7 +337,7 @@ func (s *senderTransport) SendNext(
 	defer cleanup()
 
 	ba.Replica = s.replica
-	log.Event(ctx, ba.String())
+	log.Eventf(ctx, "%v", ba.String())
 	br, pErr := s.sender.Send(ctx, ba)
 	if br == nil {
 		br = &roachpb.BatchResponse{}
@@ -347,7 +347,7 @@ func (s *senderTransport) SendNext(
 	}
 	br.Error = pErr
 	if pErr != nil {
-		log.Event(ctx, "error: "+pErr.String())
+		log.Eventf(ctx, "error: %v", pErr.String())
 	}
 
 	// Import the remotely collected spans, if any.

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
@@ -397,7 +397,7 @@ func (h *txnHeartbeater) abortTxnAsyncLocked(ctx context.Context) {
 			}
 		},
 	); err != nil {
-		log.Warning(ctx, err)
+		log.Warningf(ctx, "%v", err)
 	}
 }
 

--- a/pkg/kv/kvnemesis/kvnemesis.go
+++ b/pkg/kv/kvnemesis/kvnemesis.go
@@ -75,7 +75,7 @@ func RunNemesis(
 			fmt.Fprintf(&buf, "\n  before: %s", step.Before)
 			step.format(&buf, formatCtx{indent: `  ` + workerName + ` OP  `})
 			fmt.Fprintf(&buf, "\n  after: %s", step.After)
-			log.Info(ctx, buf.String())
+			log.Infof(ctx, "%v", buf.String())
 			stepsByWorker[workerIdx] = append(stepsByWorker[workerIdx], step)
 		}
 		return nil

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -608,7 +608,7 @@ func (l *leaseTransferTest) sendRead(storeIdx int) *roachpb.Error {
 		getArgs(l.leftKey),
 	)
 	if pErr != nil {
-		log.Warning(context.TODO(), pErr)
+		log.Warningf(context.TODO(), "%v", pErr)
 	}
 	return pErr
 }

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1193,7 +1193,7 @@ func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 				if err := stopper.RunAsyncTask(ctx, "force split", func(_ context.Context) {
 					store.SetSplitQueueActive(true)
 					if err := store.ForceSplitScanAndProcess(); err != nil {
-						log.Fatal(ctx, err)
+						log.Fatalf(ctx, "%v", err)
 					}
 				}); err != nil {
 					t.Fatal(err)

--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -973,7 +973,7 @@ func (m *multiTestContext) addStore(idx int) {
 	m.nodeLivenesses[idx].StartHeartbeat(ctx, stopper, m.engines[idx:idx+1], func(ctx context.Context) {
 		now := clock.Now()
 		if err := store.WriteLastUpTimestamp(ctx, now); err != nil {
-			log.Warning(ctx, err)
+			log.Warningf(ctx, "%v", err)
 		}
 		ran.Do(func() {
 			close(ran.ch)
@@ -1070,7 +1070,7 @@ func (m *multiTestContext) restartStoreWithoutHeartbeat(i int) {
 	cfg.NodeLiveness.StartHeartbeat(ctx, stopper, m.engines[i:i+1], func(ctx context.Context) {
 		now := m.clocks[i].Now()
 		if err := store.WriteLastUpTimestamp(ctx, now); err != nil {
-			log.Warning(ctx, err)
+			log.Warningf(ctx, "%v", err)
 		}
 	})
 }
@@ -1196,7 +1196,7 @@ func (m *multiTestContext) changeReplicas(
 		// is lost. We could make a this into a roachpb.Error but it seems overkill
 		// for this one usage.
 		if testutils.IsError(err, "snapshot failed: .*|descriptor changed") {
-			log.Info(ctx, err)
+			log.Infof(ctx, "%v", err)
 			continue
 		}
 		return 0, err

--- a/pkg/kv/kvserver/closedts/minprop/tracker.go
+++ b/pkg/kv/kvserver/closedts/minprop/tracker.go
@@ -282,7 +282,8 @@ func (t *Tracker) Track(ctx context.Context) (hlc.Timestamp, closedts.ReleaseFun
 		calls++
 		if calls != 1 {
 			if lai != 0 || rangeID != 0 || calls > 2 {
-				log.Fatal(ctx, log.Safe(fmt.Sprintf("command released %d times, this time with arguments (%d, %d)", calls, rangeID, lai)))
+				log.Fatalf(ctx, "command released %d times, this time with arguments (%d, %d)",
+					log.Safe(calls), log.Safe(rangeID), log.Safe(lai))
 			}
 			return
 		}

--- a/pkg/kv/kvserver/compactor/compactor.go
+++ b/pkg/kv/kvserver/compactor/compactor.go
@@ -325,7 +325,7 @@ func (c *Compactor) fetchSuggestions(
 				log.Infof(ctx, "purging suggested compaction for range %s - %s that contains live data",
 					sc.StartKey, sc.EndKey)
 				if err := delBatch.Clear(kv.Key); err != nil {
-					log.Fatal(ctx, err) // should never happen on a batch
+					log.Fatalf(ctx, "%v", err) // should never happen on a batch
 				}
 				c.Metrics.BytesSkipped.Inc(sc.Bytes)
 			} else {
@@ -403,7 +403,7 @@ func (c *Compactor) processCompaction(
 		}
 		key := keys.StoreSuggestedCompactionKey(sc.StartKey, sc.EndKey)
 		if err := delBatch.Clear(storage.MVCCKey{Key: key}); err != nil {
-			log.Fatal(ctx, err) // should never happen on a batch
+			log.Fatalf(ctx, "%v", err) // should never happen on a batch
 		}
 	}
 

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -258,7 +258,7 @@ func (m *managerImpl) HandleWriterIntentError(
 		intent := &t.Intents[i]
 		added, err := m.lt.AddDiscoveredLock(intent, g.ltg)
 		if err != nil {
-			log.Fatal(ctx, errors.HandleAsAssertionFailure(err))
+			log.Fatalf(ctx, "%v", errors.HandleAsAssertionFailure(err))
 		}
 		if !added {
 			wait = true
@@ -305,14 +305,14 @@ func (m *managerImpl) HandleTransactionPushError(
 // OnLockAcquired implements the LockManager interface.
 func (m *managerImpl) OnLockAcquired(ctx context.Context, acq *roachpb.LockAcquisition) {
 	if err := m.lt.AcquireLock(&acq.Txn, acq.Key, lock.Exclusive, acq.Durability); err != nil {
-		log.Fatal(ctx, errors.HandleAsAssertionFailure(err))
+		log.Fatalf(ctx, "%v", errors.HandleAsAssertionFailure(err))
 	}
 }
 
 // OnLockUpdated implements the LockManager interface.
 func (m *managerImpl) OnLockUpdated(ctx context.Context, up *roachpb.LockUpdate) {
 	if err := m.lt.UpdateLocks(up); err != nil {
-		log.Fatal(ctx, errors.HandleAsAssertionFailure(err))
+		log.Fatalf(ctx, "%v", errors.HandleAsAssertionFailure(err))
 	}
 }
 

--- a/pkg/kv/kvserver/consistency_queue.go
+++ b/pkg/kv/kvserver/consistency_queue.go
@@ -132,8 +132,9 @@ func (q *consistencyQueue) process(
 		if !shouldQuiesce || !grpcutil.IsClosedConnection(pErr.GoError()) {
 			// Suppress noisy errors about closed GRPC connections when the
 			// server is quiescing.
-			log.Error(ctx, pErr.GoError())
-			return pErr.GoError()
+			err := pErr.GoError()
+			log.Errorf(ctx, "%v", err)
+			return err
 		}
 		return nil
 	}

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -506,7 +506,7 @@ func processAbortSpan(
 		return nil
 	})
 	if err != nil {
-		log.Warning(ctx, err)
+		log.Warningf(ctx, "%v", err)
 	}
 }
 

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -159,7 +159,7 @@ func runGCOld(
 								// safe to continue because we bumped the GC
 								// thresholds. We may leave some inconsistent history
 								// behind, but nobody can read it.
-								log.Warning(ctx, err)
+								log.Warningf(ctx, "%v", err)
 								return
 							}
 						}

--- a/pkg/kv/kvserver/gc_queue.go
+++ b/pkg/kv/kvserver/gc_queue.go
@@ -380,7 +380,7 @@ func (r *replicaGCer) send(ctx context.Context, req roachpb.GCRequest) error {
 	ba.Add(&req)
 
 	if _, pErr := r.repl.Send(ctx, ba); pErr != nil {
-		log.VErrEvent(ctx, 2, pErr.String())
+		log.VErrEventf(ctx, 2, "%v", pErr.String())
 		return pErr.GoError()
 	}
 	return nil

--- a/pkg/kv/kvserver/intentresolver/intent_resolver.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver.go
@@ -437,7 +437,7 @@ func (ir *IntentResolver) CleanupIntentsAsync(
 				return err
 			})
 		if err != nil && ir.every.ShouldLog() {
-			log.Warning(ctx, err)
+			log.Warningf(ctx, "%v", err)
 		}
 	})
 }

--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -342,7 +342,7 @@ func (mq *mergeQueue) process(
 	}
 	if testingAggressiveConsistencyChecks {
 		if err := mq.store.consistencyQueue.process(ctx, lhsRepl, sysCfg); err != nil {
-			log.Warning(ctx, err)
+			log.Warningf(ctx, "%v", err)
 		}
 	}
 	return nil

--- a/pkg/kv/kvserver/node_liveness.go
+++ b/pkg/kv/kvserver/node_liveness.go
@@ -967,7 +967,7 @@ func shouldReplaceLiveness(old, new storagepb.Liveness) bool {
 func (nl *NodeLiveness) livenessGossipUpdate(key string, content roachpb.Value) {
 	var liveness storagepb.Liveness
 	if err := content.GetProto(&liveness); err != nil {
-		log.Error(context.TODO(), err)
+		log.Errorf(context.TODO(), "%v", err)
 		return
 	}
 

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -1089,7 +1089,7 @@ func (bq *baseQueue) finishProcessingReplica(
 
 		// If not a benign or purgatory error, log.
 		if !benign {
-			log.Error(ctx, err)
+			log.Errorf(ctx, "%v", err)
 		}
 	}
 
@@ -1114,7 +1114,7 @@ func (bq *baseQueue) addToPurgatoryLocked(
 	}
 
 	if log.V(1) {
-		log.Info(ctx, errors.Wrap(purgErr, "purgatory"))
+		log.Infof(ctx, "purgatory: %v", purgErr)
 	}
 
 	if _, found := bq.mu.replicas[repl.GetRangeID()]; found {

--- a/pkg/kv/kvserver/queue_helpers_testutil.go
+++ b/pkg/kv/kvserver/queue_helpers_testutil.go
@@ -45,7 +45,7 @@ func forceScanAndProcess(s *Store, q *baseQueue) error {
 
 func mustForceScanAndProcess(ctx context.Context, s *Store, q *baseQueue) {
 	if err := forceScanAndProcess(s, q); err != nil {
-		log.Fatal(ctx, err)
+		log.Fatalf(ctx, "%v", err)
 	}
 }
 

--- a/pkg/kv/kvserver/raft.go
+++ b/pkg/kv/kvserver/raft.go
@@ -290,6 +290,6 @@ func traceProposals(r *Replica, ids []storagebase.CmdIDKey, event string) {
 	}
 	r.mu.RUnlock()
 	for _, ctx := range ctxs {
-		log.Event(ctx, event)
+		log.Eventf(ctx, "%v", event)
 	}
 }

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -528,7 +528,7 @@ func (rlq *raftLogQueue) shouldQueue(
 ) (shouldQ bool, priority float64) {
 	decision, err := newTruncateDecision(ctx, r)
 	if err != nil {
-		log.Warning(ctx, err)
+		log.Warningf(ctx, "%v", err)
 		return false, 0
 	}
 

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -604,9 +604,9 @@ func (rlq *raftLogQueue) process(ctx context.Context, r *Replica, _ *config.Syst
 	// Can and should the raft logs be truncated?
 	if decision.ShouldTruncate() {
 		if n := decision.NumNewRaftSnapshots(); log.V(1) || n > 0 && rlq.logSnapshots.ShouldProcess(timeutil.Now()) {
-			log.Info(ctx, decision.String())
+			log.Infof(ctx, "%v", log.Safe(decision.String()))
 		} else {
-			log.VEvent(ctx, 1, decision.String())
+			log.VEventf(ctx, 1, "%v", log.Safe(decision.String()))
 		}
 		b := &kv.Batch{}
 		b.AddRawRequest(&roachpb.TruncateLogRequest{

--- a/pkg/kv/kvserver/raft_snapshot_queue.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue.go
@@ -123,7 +123,7 @@ func (rq *raftSnapshotQueue) processRaftSnapshot(
 			// bail for now and try again later.
 			err := errors.Errorf(
 				"skipping snapshot; replica is likely a learner in the process of being added: %s", repDesc)
-			log.Info(ctx, err)
+			log.Infof(ctx, "%v", err)
 			// TODO(dan): This is super brittle and non-obvious. In the common case,
 			// this check avoids duplicate work, but in rare cases, we send the
 			// learner snap at an index before the one raft wanted here. The raft

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -235,7 +235,7 @@ func (r *registration) outputLoop(ctx context.Context) error {
 	if r.catchupIter != nil {
 		if err := r.runCatchupScan(); err != nil {
 			err = errors.Wrap(err, "catch-up scan failed")
-			log.Error(ctx, err)
+			log.Errorf(ctx, "%v", err)
 			return err
 		}
 	}

--- a/pkg/kv/kvserver/rangefeed/task.go
+++ b/pkg/kv/kvserver/rangefeed/task.go
@@ -57,7 +57,7 @@ func (s *initResolvedTSScan) Run(ctx context.Context) {
 	defer s.Cancel()
 	if err := s.iterateAndConsume(ctx); err != nil {
 		err = errors.Wrap(err, "initial resolved timestamp scan failed")
-		log.Error(ctx, err)
+		log.Errorf(ctx, "%v", err)
 		s.p.StopWithErr(roachpb.NewError(err))
 	} else {
 		// Inform the processor that its resolved timestamp can be initialized.
@@ -160,7 +160,7 @@ func newTxnPushAttempt(
 func (a *txnPushAttempt) Run(ctx context.Context) {
 	defer a.Cancel()
 	if err := a.pushOldTxns(ctx); err != nil {
-		log.Error(ctx, errors.Wrap(err, "pushing old intents failed"))
+		log.Errorf(ctx, "pushing old intents failed: %v", err)
 	}
 }
 

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1029,18 +1029,17 @@ func (r *Replica) State() storagepb.RangeInfo {
 func (r *Replica) assertStateLocked(ctx context.Context, reader storage.Reader) {
 	diskState, err := r.mu.stateLoader.Load(ctx, reader, r.mu.state.Desc)
 	if err != nil {
-		log.Fatal(ctx, err)
+		log.Fatalf(ctx, "%v", err)
 	}
 	if !diskState.Equal(r.mu.state) {
 		// The roundabout way of printing here is to expose this information in sentry.io.
 		//
 		// TODO(dt): expose properly once #15892 is addressed.
-		log.Errorf(ctx, "on-disk and in-memory state diverged:\n%s", pretty.Diff(diskState, r.mu.state))
+		log.Errorf(ctx, "on-disk and in-memory state diverged:\n%s",
+			pretty.Diff(diskState, r.mu.state))
 		r.mu.state.Desc, diskState.Desc = nil, nil
-		log.Fatal(ctx, log.Safe(
-			fmt.Sprintf("on-disk and in-memory state diverged: %s",
-				pretty.Diff(diskState, r.mu.state)),
-		))
+		log.Fatalf(ctx, "on-disk and in-memory state diverged: %s",
+			log.Safe(pretty.Diff(diskState, r.mu.state)))
 	}
 }
 

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -995,7 +995,7 @@ func (sm *replicaStateMachine) ApplySideEffects(
 	// error will lead to replica removal.
 	sm.r.prepareLocalResult(ctx, cmd)
 	if log.ExpensiveLogEnabled(ctx, 2) {
-		log.VEvent(ctx, 2, cmd.localResult.String())
+		log.VEventf(ctx, 2, "%v", cmd.localResult.String())
 	}
 
 	// Handle the ReplicatedEvalResult, executing any side effects of the last

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -1649,14 +1649,14 @@ func execChangeReplicasTxn(
 			},
 		})
 		if err := txn.Run(ctx, b); err != nil {
-			log.Event(ctx, err.Error())
+			log.Eventf(ctx, "%v", err)
 			return err
 		}
 
 		returnDesc = crt.Desc
 		return nil
 	}); err != nil {
-		log.Event(ctx, err.Error())
+		log.Eventf(ctx, "%v", err)
 		// NB: desc may not be the descriptor we actually compared against, but
 		// either way this gives a good idea of what happened which is all it's
 		// supposed to do.

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2023,7 +2023,7 @@ func (s *Store) AdminRelocateRange(
 	// about them.
 	newDesc, err := maybeLeaveAtomicChangeReplicasAndRemoveLearners(ctx, s, &rangeDesc)
 	if err != nil {
-		log.Warning(ctx, err)
+		log.Warningf(ctx, "%v", err)
 		return err
 	}
 	rangeDesc = *newDesc
@@ -2117,7 +2117,7 @@ func (s *Store) AdminRelocateRange(
 						return returnErr
 					}
 					if every.ShouldLog() {
-						log.Info(ctx, returnErr)
+						log.Infof(ctx, "%v", returnErr)
 					}
 					success = false
 					break

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -167,7 +167,7 @@ func (r *Replica) CheckConsistency(
 		}
 
 		if isQueue {
-			log.Error(ctx, buf.String())
+			log.Errorf(ctx, "%v", buf.String())
 		}
 		res.Detail += buf.String()
 	} else {

--- a/pkg/kv/kvserver/replica_corruption.go
+++ b/pkg/kv/kvserver/replica_corruption.go
@@ -71,7 +71,7 @@ A file preventing this node from restarting was placed at:
 `, r, path)
 
 	if err := ioutil.WriteFile(path, []byte(preventStartupMsg), 0644); err != nil {
-		log.Warning(ctx, err)
+		log.Warningf(ctx, "%v", err)
 	}
 
 	log.FatalfDepth(ctx, 1, "replica is corrupted: %s", cErr)

--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -345,7 +345,7 @@ func evaluateBatch(
 					errors.Safe(ba.Header.MaxSpanRequestKeys),
 					errors.Safe(ba.Summary()), errors.Safe(index))
 				if sentryIssue46720Limiter.Allow() {
-					log.Error(ctx, err)
+					log.Errorf(ctx, "%v", err)
 					errorutil.SendReport(ctx, &rec.ClusterSettings().SV, err)
 				}
 				return nil, mergedResult, roachpb.NewError(err)

--- a/pkg/kv/kvserver/replica_gossip.go
+++ b/pkg/kv/kvserver/replica_gossip.go
@@ -211,7 +211,7 @@ func (r *Replica) loadSystemConfig(ctx context.Context) (*config.SystemConfigEnt
 		// locked), so disallow synchronous processing (which blocks that mutex
 		// for too long and is a potential deadlock).
 		if err := r.store.intentResolver.CleanupIntentsAsync(ctx, intents, false /* allowSync */); err != nil {
-			log.Warning(ctx, err)
+			log.Warningf(ctx, "%v", err)
 		}
 		return nil, errSystemConfigIntent
 	}

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -42,7 +42,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/kr/pretty"
 	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
 	"golang.org/x/time/rate"
 )
 
@@ -276,7 +275,7 @@ A file preventing this node from restarting was placed at:
 `, r, auxDir, path)
 
 			if err := ioutil.WriteFile(path, []byte(preventStartupMsg), 0644); err != nil {
-				log.Warning(ctx, err)
+				log.Warningf(ctx, "%v", err)
 			}
 
 			if p := r.store.cfg.TestingKnobs.ConsistencyTestingKnobs.OnBadChecksumFatal; p != nil {
@@ -289,7 +288,7 @@ A file preventing this node from restarting was placed at:
 
 	}); err != nil {
 		defer snap.Close()
-		log.Error(ctx, errors.Wrapf(err, "could not run async checksum computation (ID = %s)", cc.ChecksumID))
+		log.Errorf(ctx, "could not run async checksum computation (ID = %s): %v", cc.ChecksumID, err)
 		// Set checksum to nil.
 		r.computeChecksumDone(ctx, cc.ChecksumID, nil, nil)
 	}
@@ -446,10 +445,10 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease, pe
 	// range lease that is only reacquired extremely infrequently.
 	if iAmTheLeaseHolder {
 		if err := r.MaybeGossipSystemConfig(ctx); err != nil {
-			log.Error(ctx, err)
+			log.Errorf(ctx, "%v", err)
 		}
 		if err := r.MaybeGossipNodeLiveness(ctx, keys.NodeLivenessSpan); err != nil {
-			log.Error(ctx, err)
+			log.Errorf(ctx, "%v", err)
 		}
 
 		// Emit an MLAI on the leaseholder replica, as follower will be looking
@@ -662,21 +661,21 @@ func (r *Replica) handleReadWriteLocalEvalResult(ctx context.Context, lResult re
 
 	if lResult.MaybeGossipSystemConfig {
 		if err := r.MaybeGossipSystemConfig(ctx); err != nil {
-			log.Error(ctx, err)
+			log.Errorf(ctx, "%v", err)
 		}
 		lResult.MaybeGossipSystemConfig = false
 	}
 
 	if lResult.MaybeGossipSystemConfigIfHaveFailure {
 		if err := r.MaybeGossipSystemConfigIfHaveFailure(ctx); err != nil {
-			log.Error(ctx, err)
+			log.Errorf(ctx, "%v", err)
 		}
 		lResult.MaybeGossipSystemConfigIfHaveFailure = false
 	}
 
 	if lResult.MaybeGossipNodeLiveness != nil {
 		if err := r.MaybeGossipNodeLiveness(ctx, *lResult.MaybeGossipNodeLiveness); err != nil {
-			log.Error(ctx, err)
+			log.Errorf(ctx, "%v", err)
 		}
 		lResult.MaybeGossipNodeLiveness = nil
 	}

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -264,7 +264,7 @@ func (r *Replica) propose(ctx context.Context, p *ProposalData) (index int64, pE
 		for _, rDesc := range crt.Removed() {
 			if rDesc.ReplicaID == replID {
 				msg := fmt.Sprintf("received invalid ChangeReplicasTrigger %s to remove self (leaseholder)", crt)
-				log.Error(p.ctx, msg)
+				log.Errorf(p.ctx, "%v", msg)
 				return 0, roachpb.NewErrorf("%s: %s", r, msg)
 			}
 		}

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1167,7 +1167,7 @@ func (r *Replica) sendRaftMessage(ctx context.Context, msg raftpb.Message) {
 			raftGroup.ReportUnreachable(msg.To)
 			return true, nil
 		}); err != nil && err != errRemoved {
-			log.Fatal(ctx, err)
+			log.Fatalf(ctx, "%v", err)
 		}
 	}
 }
@@ -1210,7 +1210,7 @@ func (r *Replica) reportSnapshotStatus(ctx context.Context, to roachpb.ReplicaID
 		raftGroup.ReportSnapshot(uint64(to), snapStatus)
 		return true, nil
 	}); err != nil && err != errRemoved {
-		log.Fatal(ctx, err)
+		log.Fatalf(ctx, "%v", err)
 	}
 }
 

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -336,7 +336,7 @@ func (p *pendingLeaseRequest) requestLeaseAsync(
 				if status.Lease.OwnedBy(nextLeaseHolder.StoreID) &&
 					p.repl.store.StoreID() == nextLeaseHolder.StoreID {
 					if err = p.repl.store.cfg.NodeLiveness.Heartbeat(ctx, status.Liveness); err != nil {
-						log.Error(ctx, err)
+						log.Errorf(ctx, "%v", err)
 					}
 				} else if status.Liveness.Epoch == status.Lease.Epoch {
 					// If not owner, increment epoch if necessary to invalidate lease.
@@ -347,7 +347,7 @@ func (p *pendingLeaseRequest) requestLeaseAsync(
 						err = errors.Errorf("not incrementing epoch on n%d because next leaseholder (n%d) not live (err = %v)",
 							status.Liveness.NodeID, nextLeaseHolder.NodeID, liveErr)
 						if log.V(1) {
-							log.Info(ctx, err)
+							log.Infof(ctx, "%v", err)
 						}
 					} else if err = p.repl.store.cfg.NodeLiveness.IncrementEpoch(ctx, status.Liveness); err != nil {
 						// If we get ErrEpochAlreadyIncremented, someone else beat
@@ -380,7 +380,7 @@ func (p *pendingLeaseRequest) requestLeaseAsync(
 						//
 						// https://github.com/cockroachdb/cockroach/issues/35986
 						if err != ErrEpochAlreadyIncremented {
-							log.Error(ctx, err)
+							log.Errorf(ctx, "%v", err)
 						}
 					}
 				}

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -99,7 +99,7 @@ func (r *Replica) executeReadOnlyBatch(
 		// prohibits any concurrent requests for the same range. See #17760.
 		allowSyncProcessing := ba.ReadConsistency == roachpb.CONSISTENT
 		if err := r.store.intentResolver.CleanupIntentsAsync(ctx, intents, allowSyncProcessing); err != nil {
-			log.Warning(ctx, err)
+			log.Warningf(ctx, "%v", err)
 		}
 	}
 

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -104,7 +104,7 @@ func (r *Replica) executeReadOnlyBatch(
 	}
 
 	if pErr != nil {
-		log.VErrEvent(ctx, 3, pErr.String())
+		log.VErrEventf(ctx, 3, "%v", pErr.String())
 	} else {
 		log.Event(ctx, "read completed")
 	}

--- a/pkg/kv/kvserver/replica_sideload.go
+++ b/pkg/kv/kvserver/replica_sideload.go
@@ -214,7 +214,7 @@ func assertSideloadedRaftCommandInlined(ctx context.Context, ent *raftpb.Entry) 
 	var command storagepb.RaftCommand
 	_, data := DecodeRaftCommand(ent.Data)
 	if err := protoutil.Unmarshal(data, &command); err != nil {
-		log.Fatal(ctx, err)
+		log.Fatalf(ctx, "%v", err)
 	}
 
 	if len(command.ReplicatedEvalResult.AddSSTable.Data) == 0 {

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -190,14 +190,14 @@ func (r *Replica) executeWriteBatch(
 				if err := r.store.intentResolver.CleanupIntentsAsync(
 					ctx, propResult.EncounteredIntents, true, /* allowSync */
 				); err != nil {
-					log.Warning(ctx, err)
+					log.Warningf(ctx, "%v", err)
 				}
 			}
 			if len(propResult.EndTxns) > 0 {
 				if err := r.store.intentResolver.CleanupTxnIntentsAsync(
 					ctx, r.RangeID, propResult.EndTxns, true, /* allowSync */
 				); err != nil {
-					log.Warning(ctx, err)
+					log.Warningf(ctx, "%v", err)
 				}
 			}
 			return propResult.Reply, nil, propResult.Err

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -205,8 +205,9 @@ func (r *Replica) executeWriteBatch(
 			slowTimer.Read = true
 			r.store.metrics.SlowRaftRequests.Inc(1)
 
-			log.Error(ctx, rangeUnavailableMessage(r.Desc(), r.store.cfg.NodeLiveness.GetIsLiveMap(),
-				r.RaftStatus(), ba, timeutil.Since(startPropTime)))
+			log.Errorf(ctx, "range unavailable: %v",
+				rangeUnavailableMessage(r.Desc(), r.store.cfg.NodeLiveness.GetIsLiveMap(),
+					r.RaftStatus(), ba, timeutil.Since(startPropTime)))
 		case <-ctxDone:
 			// If our context was canceled, return an AmbiguousResultError,
 			// which indicates to the caller that the command may have executed.

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -277,7 +277,7 @@ func (rq *replicateQueue) process(
 				// declined reservation or the remote node being unavailable. In either
 				// case we don't want to wait another scanner cycle before reconsidering
 				// the range.
-				log.Info(ctx, err)
+				log.Infof(ctx, "%v", err)
 				break
 			}
 
@@ -287,7 +287,7 @@ func (rq *replicateQueue) process(
 
 			if testingAggressiveConsistencyChecks {
 				if err := rq.store.consistencyQueue.process(ctx, repl, sysCfg); err != nil {
-					log.Warning(ctx, err)
+					log.Warningf(ctx, "%v", err)
 				}
 			}
 

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -137,7 +137,7 @@ func testReplicateQueueRebalanceInner(t *testing.T, atomic bool) {
 			if c < minReplicas {
 				err := errors.Errorf(
 					"not balanced (want at least %d replicas on all stores): %d", minReplicas, counts)
-				log.Info(context.Background(), err)
+				log.Infof(context.Background(), "%v", err)
 				return err
 			}
 		}

--- a/pkg/kv/kvserver/spanset/spanset.go
+++ b/pkg/kv/kvserver/spanset/spanset.go
@@ -201,7 +201,7 @@ func (s *SpanSet) MaxProtectedTimestamp() hlc.Timestamp {
 // only the span boundaries are checked.
 func (s *SpanSet) AssertAllowed(access SpanAccess, span roachpb.Span) {
 	if err := s.CheckAllowed(access, span); err != nil {
-		log.Fatal(context.TODO(), err)
+		log.Fatalf(context.TODO(), "%v", err)
 	}
 }
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1185,7 +1185,7 @@ func (s *Store) SetDraining(drain bool, reporter func(int, string)) {
 					}
 					err = errors.Errorf("waiting for %d replicas to transfer their lease away", numRemaining)
 					if everySecond.ShouldLog() {
-						log.Info(ctx, err)
+						log.Infof(ctx, "%v", err)
 					}
 				}
 				if err == nil {

--- a/pkg/kv/kvserver/store_pool.go
+++ b/pkg/kv/kvserver/store_pool.go
@@ -340,7 +340,7 @@ func (sp *StorePool) storeGossipUpdate(_ string, content roachpb.Value) {
 	var storeDesc roachpb.StoreDescriptor
 	if err := content.GetProto(&storeDesc); err != nil {
 		ctx := sp.AnnotateCtx(context.TODO())
-		log.Error(ctx, err)
+		log.Errorf(ctx, "%v", err)
 		return
 	}
 

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -357,7 +357,7 @@ func (s *Store) HandleRaftResponse(ctx context.Context, resp *RaftMessageRespons
 				if replErr != nil {
 					// RangeNotFoundErrors are expected here; nothing else is.
 					if _, ok := replErr.(*roachpb.RangeNotFoundError); !ok {
-						log.Error(ctx, replErr)
+						log.Errorf(ctx, "%v", replErr)
 					}
 					return nil
 				}
@@ -398,7 +398,7 @@ func (s *Store) HandleRaftResponse(ctx context.Context, resp *RaftMessageRespons
 				if replErr != nil {
 					// RangeNotFoundErrors are expected here; nothing else is.
 					if _, ok := replErr.(*roachpb.RangeNotFoundError); !ok {
-						log.Error(ctx, replErr)
+						log.Errorf(ctx, "%v", replErr)
 					}
 					return nil
 				}
@@ -536,7 +536,7 @@ func (s *Store) processTick(ctx context.Context, rangeID roachpb.RangeID) bool {
 	r := (*Replica)(value)
 	exists, err := r.tick(livenessMap)
 	if err != nil {
-		log.Error(ctx, err)
+		log.Errorf(ctx, "%v", err)
 	}
 	s.metrics.RaftTickingDurationNanos.Inc(timeutil.Since(start).Nanoseconds())
 	return exists // ready

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -645,8 +645,7 @@ func (s *Store) checkSnapshotOverlapLocked(
 		exReplica, err := s.GetReplica(exRange.Desc().RangeID)
 		msg := IntersectingSnapshotMsg
 		if err != nil {
-			log.Warning(ctx, errors.Wrapf(
-				err, "unable to look up overlapping replica on %s", exReplica))
+			log.Warningf(ctx, "unable to look up overlapping replica on %s: %v", exReplica, err)
 		} else {
 			inactive := func(r *Replica) bool {
 				if r.RaftStatus() == nil {

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -56,7 +56,7 @@ func splitPreApply(
 		// We handle this below.
 		rightRepl = nil
 	} else if err != nil {
-		log.Fatal(ctx, errors.Wrap(err, "failed to get RHS replica"))
+		log.Fatalf(ctx, "failed to get RHS replica: %v", err)
 	}
 	// Check to see if we know that the RHS has already been removed from this
 	// store at the replica ID implied by the split.
@@ -113,7 +113,7 @@ func splitPreApply(
 	// Term and Vote). This is the common case.
 	rsl := stateloader.Make(split.RightDesc.RangeID)
 	if err := rsl.SynthesizeRaftState(ctx, readWriter); err != nil {
-		log.Fatal(ctx, err)
+		log.Fatalf(ctx, "%v", err)
 	}
 
 	// The initialMaxClosed is assigned to the RHS replica to ensure that
@@ -233,7 +233,7 @@ func prepareRightReplicaForSplit(
 	err = rightRepl.loadRaftMuLockedReplicaMuLocked(&split.RightDesc)
 	rightRepl.mu.Unlock()
 	if err != nil {
-		log.Fatal(ctx, err)
+		log.Fatalf(ctx, "%v", err)
 	}
 
 	// Copy the minLeaseProposedTS from the LHS and grab the RHS's lease.

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -81,7 +81,7 @@ func (s *Store) TestSender() kv.Sender {
 		// that.
 		key, err := keys.Addr(ba.Requests[0].GetInner().Header().Key)
 		if err != nil {
-			log.Fatal(context.TODO(), err)
+			log.Fatalf(context.TODO(), "%v", err)
 		}
 
 		ba.RangeID = roachpb.RangeID(1)
@@ -549,7 +549,7 @@ func createReplica(s *Store, rangeID roachpb.RangeID, start, end roachpb.RKey) *
 	}
 	r, err := newReplica(context.Background(), desc, s, 1)
 	if err != nil {
-		log.Fatal(context.Background(), err)
+		log.Fatalf(context.Background(), "%v", err)
 	}
 	return r
 }

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -233,7 +233,7 @@ func (txn *Txn) TestingSetPriority(priority enginepb.TxnPriority) {
 	// non-randomized, priority for the transaction.
 	txn.mu.userPriority = roachpb.UserPriority(-priority)
 	if err := txn.mu.sender.SetUserPriority(txn.mu.userPriority); err != nil {
-		log.Fatal(context.TODO(), err)
+		log.Fatalf(context.TODO(), "%+v", err)
 	}
 	txn.mu.Unlock()
 }

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -575,7 +575,7 @@ func TestHeartbeatHealthTransport(t *testing.T) {
 	if err := stopper.RunAsyncTask(ctx, "busyloop-closer", func(ctx context.Context) {
 		for {
 			if _, err := closeConns(); err != nil {
-				log.Warning(ctx, err)
+				log.Warningf(ctx, "%v", err)
 			}
 			select {
 			case <-done:

--- a/pkg/rpc/heartbeat.go
+++ b/pkg/rpc/heartbeat.go
@@ -72,7 +72,7 @@ func checkClusterName(clusterName string, peerName string) error {
 			err = errors.Errorf(
 				"local cluster name %q does not match peer cluster name %q", clusterName, peerName)
 		}
-		log.Shout(context.Background(), log.Severity_ERROR, err)
+		log.Shoutf(context.Background(), log.Severity_ERROR, "%v", err)
 		return err
 	}
 	return nil

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -176,7 +176,7 @@ func (s *authenticationServer) UserLogout(
 		return nil, apiInternalError(ctx, err)
 	} else if n == 0 {
 		err := errors.Newf("session with id %d nonexistent", sessionID)
-		log.Info(ctx, err)
+		log.Infof(ctx, "%v", err)
 		return nil, err
 	}
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -576,7 +576,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 	log.Infof(ctx, "%d storage engine%s initialized",
 		len(engines), util.Pluralize(int64(len(engines))))
 	for _, s := range details {
-		log.Info(ctx, s)
+		log.Infof(ctx, "%v", s)
 	}
 	enginesCopy := engines
 	engines = nil

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -401,7 +401,7 @@ func (cfg *Config) Report(ctx context.Context) {
 	} else {
 		log.Infof(ctx, "system total memory: %s", humanizeutil.IBytes(memSize))
 	}
-	log.Info(ctx, "server configuration:\n", cfg)
+	log.Infof(ctx, "server configuration:\n%s", cfg)
 }
 
 // Engines is a container of engines, allowing convenient closing.

--- a/pkg/server/debug/logspy.go
+++ b/pkg/server/debug/logspy.go
@@ -153,7 +153,7 @@ func (spy *logSpy) handleDebugLogSpy(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if err := spy.run(ctx, w, opts); err != nil {
 		// This is likely a broken HTTP connection, so nothing too unexpected.
-		log.Info(ctx, err)
+		log.Infof(ctx, "%v", err)
 	}
 }
 

--- a/pkg/server/heapprofiler/heapprofiler.go
+++ b/pkg/server/heapprofiler/heapprofiler.go
@@ -126,7 +126,7 @@ func (o *HeapProfiler) gcProfiles(ctx context.Context, dir, prefix string) {
 	maxCount := maxProfiles.Get(&o.st.SV)
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
-		log.Warning(ctx, err)
+		log.Warningf(ctx, "%v", err)
 		return
 	}
 
@@ -154,7 +154,7 @@ func (o *HeapProfiler) gcProfiles(ctx context.Context, dir, prefix string) {
 			continue
 		}
 		if err := os.Remove(filepath.Join(dir, f.Name())); err != nil {
-			log.Info(ctx, err)
+			log.Infof(ctx, "%v", err)
 		}
 	}
 }

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -509,7 +509,7 @@ func (n *Node) SetHLCUpperBound(ctx context.Context, hlcUpperBound int64) error 
 func (n *Node) addStore(store *kvserver.Store) {
 	cv, err := store.GetClusterVersion(context.TODO())
 	if err != nil {
-		log.Fatal(context.TODO(), err)
+		log.Fatalf(context.TODO(), "%v", err)
 	}
 	if cv == (clusterversion.ClusterVersion{}) {
 		// The store should have had a version written to it during the store
@@ -636,7 +636,7 @@ func (n *Node) gossipStores(ctx context.Context) {
 	if err := n.stores.VisitStores(func(s *kvserver.Store) error {
 		return s.GossipStore(ctx, false /* useCached */)
 	}); err != nil {
-		log.Warning(ctx, err)
+		log.Warningf(ctx, "%v", err)
 	}
 }
 
@@ -744,7 +744,7 @@ func (n *Node) writeNodeStatus(ctx context.Context, alertTTL time.Duration) erro
 				numNodes++
 				return nil
 			}); err != nil {
-				log.Warning(ctx, err)
+				log.Warningf(ctx, "%v", err)
 			}
 			if numNodes > 1 {
 				// Avoid this warning on single-node clusters, which require special UX.

--- a/pkg/server/node_engine_health.go
+++ b/pkg/server/node_engine_health.go
@@ -12,7 +12,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -54,7 +53,7 @@ func (n *Node) startAssertEngineHealth(ctx context.Context, engines []storage.En
 
 func guaranteedExitFatal(ctx context.Context, msg string, args ...interface{}) {
 	// NB: log.Shout sets up a timer that guarantees process termination.
-	log.Shout(ctx, log.Severity_FATAL, fmt.Sprintf(msg, args...))
+	log.Shoutf(ctx, log.Severity_FATAL, msg, args...)
 }
 
 func (n *Node) assertEngineHealth(

--- a/pkg/server/node_engine_health.go
+++ b/pkg/server/node_engine_health.go
@@ -76,7 +76,7 @@ func (n *Node) assertEngineHealth(
 			})
 			defer t.Stop()
 			if err := storage.WriteSyncNoop(ctx, eng); err != nil {
-				log.Fatal(ctx, err)
+				log.Fatalf(ctx, "%v", err)
 			}
 		}()
 	}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1038,7 +1038,7 @@ func (s *statusServer) Nodes(
 	b := &kv.Batch{}
 	b.Scan(startKey, endKey)
 	if err := s.db.Run(ctx, b); err != nil {
-		log.Error(ctx, err)
+		log.Errorf(ctx, "%v", err)
 		return nil, grpcstatus.Errorf(codes.Internal, err.Error())
 	}
 	rows := b.Results[0].Rows
@@ -1048,7 +1048,7 @@ func (s *statusServer) Nodes(
 	}
 	for i, row := range rows {
 		if err := row.ValueProto(&resp.Nodes[i]); err != nil {
-			log.Error(ctx, err)
+			log.Errorf(ctx, "%v", err)
 			return nil, grpcstatus.Errorf(codes.Internal, err.Error())
 		}
 	}
@@ -1107,14 +1107,14 @@ func (s *statusServer) Node(
 	b := &kv.Batch{}
 	b.Get(key)
 	if err := s.db.Run(ctx, b); err != nil {
-		log.Error(ctx, err)
+		log.Errorf(ctx, "%v", err)
 		return nil, grpcstatus.Errorf(codes.Internal, err.Error())
 	}
 
 	var nodeStatus statuspb.NodeStatus
 	if err := b.Results[0].Rows[0].ValueProto(&nodeStatus); err != nil {
 		err = errors.Errorf("could not unmarshal NodeStatus from %s: %s", key, err)
-		log.Error(ctx, err)
+		log.Errorf(ctx, "%v", err)
 		return nil, grpcstatus.Errorf(codes.Internal, err.Error())
 	}
 	return &nodeStatus, nil
@@ -1239,7 +1239,7 @@ func (s *statusServer) handleVars(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set(httputil.ContentTypeHeader, httputil.PlaintextContentType)
 	err := s.metricSource.PrintAsText(w)
 	if err != nil {
-		log.Error(r.Context(), err)
+		log.Errorf(r.Context(), "%v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 	telemetry.Inc(telemetryPrometheusVars)

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -380,7 +380,7 @@ func (mr *MetricsRecorder) getNetworkActivity(
 			address, err := mr.gossip.GetNodeIDAddress(nodeID)
 			if err != nil {
 				if entry.IsLive {
-					log.Warning(ctx, err.Error())
+					log.Warningf(ctx, "%v", err)
 				}
 				continue
 			}

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -427,7 +427,7 @@ func (mr *MetricsRecorder) GenerateNodeStatus(ctx context.Context) *statuspb.Nod
 
 	systemMemory, _, err := GetTotalMemoryWithoutLogging()
 	if err != nil {
-		log.Error(ctx, "could not get total system memory:", err)
+		log.Errorf(ctx, "could not get total system memory: %v", err)
 	}
 
 	// Generate a node status with no store data.
@@ -563,7 +563,7 @@ func eachRecordableValue(reg *metric.Registry, fn func(string, float64)) {
 		} else {
 			val, err := extractValue(mtr)
 			if err != nil {
-				log.Warning(context.TODO(), err)
+				log.Warningf(context.TODO(), "%v", err)
 				return
 			}
 			fn(name, val)

--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -226,7 +226,7 @@ func (s *Server) checkForUpdates(ctx context.Context) bool {
 
 	err = decoder.Decode(&r)
 	if err != nil && err != io.EOF {
-		log.Warning(ctx, "Error decoding updates info: ", err)
+		log.Warningf(ctx, "Error decoding updates info: %v", err)
 		return false
 	}
 
@@ -341,7 +341,7 @@ func (s *Server) getReportingInfo(
 		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		"SELECT id, config FROM system.zones",
 	); err != nil {
-		log.Warning(ctx, err)
+		log.Warningf(ctx, "%v", err)
 	} else {
 		info.ZoneConfigs = make(map[int64]zonepb.ZoneConfig)
 		for _, row := range datums {
@@ -436,7 +436,7 @@ func (s *Server) ReportDiagnostics(ctx context.Context) {
 
 	b, err := protoutil.Marshal(report)
 	if err != nil {
-		log.Warning(ctx, err)
+		log.Warningf(ctx, "%v", err)
 		return
 	}
 
@@ -447,7 +447,7 @@ func (s *Server) ReportDiagnostics(ctx context.Context) {
 		if log.V(2) {
 			// This is probably going to be relatively common in production
 			// environments where network access is usually curtailed.
-			log.Warning(ctx, "failed to report node usage metrics: ", err)
+			log.Warningf(ctx, "failed to report node usage metrics: %v", err)
 		}
 		return
 	}

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -394,7 +394,6 @@ func dumpStmtStats(ctx context.Context, appName string, stats map[stmtKey]*stmtS
 		return
 	}
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "Statistics for %q:\n", appName)
 	for key, s := range stats {
 		s.Lock()
 		json, err := json.Marshal(s.data)
@@ -405,7 +404,7 @@ func dumpStmtStats(ctx context.Context, appName string, stats map[stmtKey]*stmtS
 		}
 		fmt.Fprintf(&buf, "%q: %s\n", key.String(), json)
 	}
-	log.Info(ctx, buf.String())
+	log.Infof(ctx, "Statistics for %q:\n%s", appName, buf.String())
 }
 
 func scrubStmtStatKey(vt VirtualTabler, key string) (string, bool) {

--- a/pkg/sql/colexec/external_hash_joiner.go
+++ b/pkg/sql/colexec/external_hash_joiner.go
@@ -534,9 +534,9 @@ StateChanged:
 		case externalHJRecursivePartitioning:
 			hj.numRepartitions++
 			if log.V(2) && hj.numRepartitions%10 == 0 {
-				log.Info(ctx, fmt.Sprintf(
+				log.Infof(ctx,
 					"external hash joiner is performing %d'th repartition", hj.numRepartitions,
-				))
+				)
 			}
 			// In order to use a different hash function when repartitioning, we need
 			// to increase the seed value of the tuple distributor.
@@ -636,10 +636,10 @@ StateChanged:
 					// join strategy.
 					hj.diskBackedSortMerge.Init()
 					if log.V(2) {
-						log.Info(ctx, fmt.Sprintf(
+						log.Infof(ctx,
 							"external hash joiner will join %d partitions using sort + merge join",
 							len(hj.partitionsToJoinUsingSortMerge),
-						))
+						)
 					}
 					hj.state = externalHJSortMergeNewPartition
 					continue

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2112,7 +2112,7 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 					advInfo.txnEvent.String()+ //the event is included like this so that it doesn't get sanitized
 					" generated even though res.Err() has been set to: %s",
 				res.Err())
-			log.Error(ex.Ctx(), err)
+			log.Errorf(ex.Ctx(), "%v", err)
 			errorutil.SendReport(ex.Ctx(), &ex.server.cfg.Settings.SV, err)
 			return advanceInfo{}, err
 		}

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -794,8 +794,8 @@ func (ex *connExecutor) closeWrapper(ctx context.Context, recovered interface{})
 			cutStmt = cutStmt[:panicLogOutputCutoffChars] + " [...]"
 		}
 
-		log.Shout(ctx, log.Severity_ERROR,
-			fmt.Sprintf("a SQL panic has occurred while executing %q: %s", cutStmt, recovered))
+		log.Shoutf(ctx, log.Severity_ERROR,
+			"a SQL panic has occurred while executing %q: %s", cutStmt, recovered)
 
 		ex.close(ctx, panicClose)
 

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -216,7 +216,7 @@ func TestPortalsDestroyedOnTxnFinish(t *testing.T) {
 func mustParseOne(s string) parser.Statement {
 	stmts, err := parser.Parse(s)
 	if err != nil {
-		log.Fatal(context.TODO(), err)
+		log.Fatalf(context.TODO(), "%v", err)
 	}
 	return stmts[0]
 }

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -980,7 +980,7 @@ func populateTransactionsTable(
 		}
 	}
 	for _, rpcErr := range response.Errors {
-		log.Warning(ctx, rpcErr.Message)
+		log.Warningf(ctx, "%v", rpcErr.Message)
 		if rpcErr.NodeID != 0 {
 			// Add a row with this node ID, the error for the txn string,
 			// and nulls for all other columns.
@@ -1138,7 +1138,7 @@ func populateQueriesTable(
 	}
 
 	for _, rpcErr := range response.Errors {
-		log.Warning(ctx, rpcErr.Message)
+		log.Warningf(ctx, "%v", rpcErr.Message)
 		if rpcErr.NodeID != 0 {
 			// Add a row with this node ID, the error for query, and
 			// nulls for all other columns.
@@ -1276,7 +1276,7 @@ func populateSessionsTable(
 	}
 
 	for _, rpcErr := range response.Errors {
-		log.Warning(ctx, rpcErr.Message)
+		log.Warningf(ctx, "%v", rpcErr.Message)
 		if rpcErr.NodeID != 0 {
 			// Add a row with this node ID, error in active queries, and nulls
 			// for all other columns.

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -171,7 +171,7 @@ func (ds *ServerImpl) setupFlow(
 			"version mismatch in flow request: %d; this node accepts %d through %d",
 			req.Version, execinfra.MinAcceptedVersion, execinfra.Version,
 		)
-		log.Warning(ctx, err)
+		log.Warningf(ctx, "%v", err)
 		return ctx, nil, err
 	}
 	nodeID := ds.ServerConfig.NodeID.Get()
@@ -566,7 +566,7 @@ func (ds *ServerImpl) FlowStream(stream execinfrapb.DistSQL_FlowStreamServer) er
 		// flowStreamInt may return an error during normal operation (e.g. a flow
 		// was canceled as part of a graceful teardown). Log this error at the INFO
 		// level behind a verbose flag for visibility.
-		log.Info(ctx, err)
+		log.Infof(ctx, "%v", err)
 	}
 	return err
 }

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -703,9 +703,9 @@ func (h *distSQLNodeHealth) check(ctx context.Context, nodeID roachpb.NodeID) er
 	}
 
 	if drainingInfo.Draining {
-		errMsg := fmt.Sprintf("not using n%d because it is draining", nodeID)
-		log.VEvent(ctx, 1, errMsg)
-		return errors.New(errMsg)
+		err := errors.Newf("not using n%d because it is draining", log.Safe(nodeID))
+		log.VEventf(ctx, 1, "%v", err)
+		return err
 	}
 
 	return nil

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2421,7 +2421,7 @@ func (dsp *DistSQLPlanner) createPlanForNode(
 
 	if dsp.shouldPlanTestMetadata() {
 		if err := plan.CheckLastStagePost(); err != nil {
-			log.Fatal(planCtx.ctx, err)
+			log.Fatalf(planCtx.ctx, "%v", err)
 		}
 		plan.AddNoGroupingStageWithCoreFunc(
 			func(_ int, _ *physicalplan.Processor) execinfrapb.ProcessorCoreUnion {

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2745,7 +2745,7 @@ func (t *logicTest) Error(args ...interface{}) {
 	if *showSQL {
 		t.outf("\t-- FAIL")
 	}
-	log.Error(context.Background(), "\n", fmt.Sprint(args...))
+	log.Errorf(context.Background(), "\n%s", fmt.Sprint(args...))
 	t.t().Error("\n", fmt.Sprint(args...))
 	t.failures++
 }
@@ -2770,7 +2770,7 @@ func (t *logicTest) Fatal(args ...interface{}) {
 	if *showSQL {
 		fmt.Println()
 	}
-	log.Error(context.Background(), args...)
+	log.Errorf(context.Background(), "", args...)
 	t.t().Logf("\n%s:%d: error while processing", t.curPath, t.curLineNo)
 	t.t().Fatal(args...)
 }
@@ -2781,7 +2781,7 @@ func (t *logicTest) Fatalf(format string, args ...interface{}) {
 	if *showSQL {
 		fmt.Println()
 	}
-	log.Error(context.Background(), args...)
+	log.Errorf(context.Background(), format, args...)
 	t.t().Logf("\n%s:%d: error while processing", t.curPath, t.curLineNo)
 	t.t().Fatalf(format, args...)
 }

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2770,7 +2770,7 @@ func (t *logicTest) Fatal(args ...interface{}) {
 	if *showSQL {
 		fmt.Println()
 	}
-	log.Errorf(context.Background(), "", args...)
+	log.Errorf(context.Background(), "%s", fmt.Sprint(args...))
 	t.t().Logf("\n%s:%d: error while processing", t.curPath, t.curLineNo)
 	t.t().Fatal(args...)
 }

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -266,7 +266,7 @@ func (opc *optPlanningCtx) reset() {
 
 func (opc *optPlanningCtx) log(ctx context.Context, msg string) {
 	if log.VDepth(1, 1) {
-		log.InfofDepth(ctx, 1, "%s: %s", msg, opc.p.stmt)
+		log.InfofDepth(ctx, 1, "%s: %s", log.Safe(msg), opc.p.stmt)
 	} else {
 		log.Event(ctx, msg)
 	}

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -123,7 +123,7 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 	kvsToRows := func(kvs []roachpb.KeyValue) []rowWithMVCCMetadata {
 		t.Helper()
 		for _, kv := range kvs {
-			log.Info(ctx, kv.Key, kv.Value.Timestamp, kv.Value.PrettyPrint())
+			log.Infof(ctx, "%v %v %v", kv.Key, kv.Value.Timestamp, kv.Value.PrettyPrint())
 		}
 
 		if err := rf.StartScanFrom(ctx, &row.SpanKVFetcher{KVs: kvs}); err != nil {

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -299,14 +299,14 @@ func (f *txnKVFetcher) fetch(ctx context.Context) error {
 	copy(f.requestSpans, f.spans)
 
 	if log.ExpensiveLogEnabled(ctx, 2) {
-		buf := bytes.NewBufferString("Scan ")
+		var buf bytes.Buffer
 		for i, span := range f.spans {
 			if i != 0 {
 				buf.WriteString(", ")
 			}
 			buf.WriteString(span.String())
 		}
-		log.VEvent(ctx, 2, buf.String())
+		log.VEventf(ctx, 2, "Scan %s", buf.String())
 	}
 
 	// Reset spans in preparation for adding resume-spans below.

--- a/pkg/sql/rowcontainer/disk_row_container.go
+++ b/pkg/sql/rowcontainer/disk_row_container.go
@@ -283,7 +283,7 @@ var _ RowIterator = &diskRowIterator{}
 
 func (d *DiskRowContainer) newIterator(ctx context.Context) diskRowIterator {
 	if err := d.bufferedRows.Flush(); err != nil {
-		log.Fatal(ctx, err)
+		log.Fatalf(ctx, "%v", err)
 	}
 	return diskRowIterator{rowContainer: d, SortedDiskMapIterator: d.diskMap.NewIterator()}
 }

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -506,7 +506,7 @@ func (tc *TableCollection) releaseTableLeases(ctx context.Context, tables []IDVe
 		if !shouldRelease(l.ID) {
 			filteredLeases = append(filteredLeases, l)
 		} else if err := tc.leaseMgr.Release(l); err != nil {
-			log.Warning(ctx, err)
+			log.Warningf(ctx, "%v", err)
 		}
 	}
 	tc.leasedTables = filteredLeases
@@ -517,7 +517,7 @@ func (tc *TableCollection) releaseLeases(ctx context.Context) {
 		log.VEventf(ctx, 2, "releasing %d tables", len(tc.leasedTables))
 		for _, table := range tc.leasedTables {
 			if err := tc.leaseMgr.Release(table); err != nil {
-				log.Warning(ctx, err)
+				log.Warningf(ctx, "%v", err)
 			}
 		}
 		tc.leasedTables = tc.leasedTables[:0]

--- a/pkg/storage/disk_map.go
+++ b/pkg/storage/disk_map.go
@@ -162,7 +162,7 @@ func (r *rocksDBMap) Clear() error {
 // Close implements the SortedDiskMap interface.
 func (r *rocksDBMap) Close(ctx context.Context) {
 	if err := r.Clear(); err != nil {
-		log.Error(ctx, err)
+		log.Errorf(ctx, "%v", err)
 	}
 }
 
@@ -362,7 +362,7 @@ func (r *pebbleMap) Clear() error {
 // Close implements the SortedDiskMap interface.
 func (r *pebbleMap) Close(ctx context.Context) {
 	if err := r.Clear(); err != nil {
-		log.Error(ctx, err)
+		log.Errorf(ctx, "%v", err)
 	}
 }
 

--- a/pkg/storage/rocksdb.go
+++ b/pkg/storage/rocksdb.go
@@ -740,7 +740,7 @@ func (r *RocksDB) Close() {
 		}
 		// Remove the temporary directory when the engine is in-memory.
 		if err := os.RemoveAll(r.auxDir); err != nil {
-			log.Warning(context.TODO(), err)
+			log.Warningf(context.TODO(), "%v", err)
 		}
 	} else {
 		log.Infof(context.TODO(), "closing rocksdb instance at %q", r.cfg.Dir)

--- a/pkg/storage/rocksdb.go
+++ b/pkg/storage/rocksdb.go
@@ -115,13 +115,13 @@ func rocksDBLog(usePrimaryLog C.bool, sevLvl C.int, s *C.char, n C.int) {
 	ctx := logtags.AddTag(context.Background(), "rocksdb", nil)
 	switch sev {
 	case log.Severity_WARNING:
-		log.Warning(ctx, C.GoStringN(s, n))
+		log.Warningf(ctx, "%v", C.GoStringN(s, n))
 	case log.Severity_ERROR:
-		log.Error(ctx, C.GoStringN(s, n))
+		log.Errorf(ctx, "%v", C.GoStringN(s, n))
 	case log.Severity_FATAL:
-		log.Fatal(ctx, C.GoStringN(s, n))
+		log.Fatalf(ctx, "%v", C.GoStringN(s, n))
 	default:
-		log.Info(ctx, C.GoStringN(s, n))
+		log.Infof(ctx, "%v", C.GoStringN(s, n))
 	}
 }
 

--- a/pkg/storage/temp_engine.go
+++ b/pkg/storage/temp_engine.go
@@ -111,7 +111,7 @@ type pebbleTempEngine struct {
 func (r *pebbleTempEngine) Close() {
 	err := r.db.Close()
 	if err != nil {
-		log.Fatal(context.TODO(), err)
+		log.Fatalf(context.TODO(), "%v", err)
 	}
 }
 

--- a/pkg/testutils/lint/passes/fmtsafe/functions.go
+++ b/pkg/testutils/lint/passes/fmtsafe/functions.go
@@ -35,6 +35,15 @@ var requireConstMsg = map[string]bool{
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented.NewWithIssueDetail": true,
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire.newAdminShutdownErr": true,
+
+	"github.com/cockroachdb/cockroach/pkg/util/log.Info":      true,
+	"github.com/cockroachdb/cockroach/pkg/util/log.Warning":   true,
+	"github.com/cockroachdb/cockroach/pkg/util/log.Error":     true,
+	"github.com/cockroachdb/cockroach/pkg/util/log.Event":     true,
+	"github.com/cockroachdb/cockroach/pkg/util/log.VEvent":    true,
+	"github.com/cockroachdb/cockroach/pkg/util/log.VErrEvent": true,
+
+	"(*github.com/cockroachdb/cockroach/pkg/sql.optPlanningCtx).log": true,
 }
 
 // requireConstFmt records functions for which the string arg

--- a/pkg/testutils/lint/passes/fmtsafe/functions.go
+++ b/pkg/testutils/lint/passes/fmtsafe/functions.go
@@ -36,6 +36,7 @@ var requireConstMsg = map[string]bool{
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire.newAdminShutdownErr": true,
 
+	"github.com/cockroachdb/cockroach/pkg/util/log.Shout":     true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.Info":      true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.Warning":   true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.Error":     true,
@@ -57,6 +58,7 @@ var requireConstFmt = map[string]bool{
 	"(*log.Logger).Panicf": true,
 	"(*log.Logger).Printf": true,
 
+	"github.com/cockroachdb/cockroach/pkg/util/log.Shoutf":          true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.Infof":           true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.Warningf":        true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.Errorf":          true,
@@ -118,6 +120,7 @@ var requireConstFmt = map[string]bool{
 	"(*github.com/cockroachdb/cockroach/pkg/sql/logictest.logicTest).Fatalf": true,
 
 	"(*github.com/cockroachdb/cockroach/pkg/server.adminServer).serverErrorf": true,
+	"github.com/cockroachdb/cockroach/pkg/server.guaranteedExitFatal":         true,
 
 	"(*github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl.kafkaLogAdapter).Printf": true,
 

--- a/pkg/testutils/lint/passes/fmtsafe/testdata/src/a/a.go
+++ b/pkg/testutils/lint/passes/fmtsafe/testdata/src/a/a.go
@@ -64,7 +64,7 @@ func init() {
 type myLogger struct{}
 
 func (m myLogger) Info(args ...interface{}) {
-	log.Error(context.Background(), args...)
+	log.Errorf(context.Background(), "", args...)
 }
 
 func (m myLogger) Infof(_ string, args ...interface{}) {

--- a/pkg/testutils/lint/passes/fmtsafe/testdata/src/github.com/cockroachdb/cockroach/pkg/util/log/log.go
+++ b/pkg/testutils/lint/passes/fmtsafe/testdata/src/github.com/cockroachdb/cockroach/pkg/util/log/log.go
@@ -19,6 +19,6 @@ func Errorf(ctx context.Context, format string, args ...interface{}) {
 	fmt.Println(fmt.Sprintf(format, args...))
 }
 
-func Error(ctx context.Context, msg ...interface{}) {
-	fmt.Println(msg...)
+func Error(ctx context.Context, msg string) {
+	fmt.Println(msg)
 }

--- a/pkg/testutils/soon.go
+++ b/pkg/testutils/soon.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/pkg/errors"
 )
 
 // DefaultSucceedsSoonDuration is the maximum amount of time unittests
@@ -47,7 +46,7 @@ func SucceedsSoonError(fn func() error) error {
 	wrappedFn := func() error {
 		err := fn()
 		if timeutil.Since(tBegin) > 3*time.Second && err != nil {
-			log.InfoDepth(context.Background(), 4, errors.Wrap(err, "SucceedsSoon"))
+			log.InfofDepth(context.Background(), 4, "SucceedsSoon: %v", err)
 		}
 		return err
 	}

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -788,7 +788,7 @@ func (tc *TestCluster) WaitForFullReplication() error {
 				if err := s.ComputeMetrics(context.TODO(), 0); err != nil {
 					// This can sometimes fail since ComputeMetrics calls
 					// updateReplicationGauges which needs the system config gossiped.
-					log.Info(context.TODO(), err)
+					log.Infof(context.TODO(), "%v", err)
 					notReplicated = true
 					return nil
 				}

--- a/pkg/ts/db.go
+++ b/pkg/ts/db.go
@@ -194,7 +194,7 @@ func (p *poller) poll() {
 			log.Warningf(ctx, "error writing time series data: %s", err)
 		}
 	}); err != nil {
-		log.Warning(bgCtx, err)
+		log.Warningf(bgCtx, "%v", err)
 	}
 }
 

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -143,7 +143,7 @@ func Handler(cfg Config) http.Handler {
 		}); err != nil {
 			err = errors.Wrap(err, "templating index.html")
 			http.Error(w, err.Error(), 500)
-			log.Error(r.Context(), err)
+			log.Errorf(r.Context(), "%v", err)
 		}
 	})
 }

--- a/pkg/util/cache/cache.go
+++ b/pkg/util/cache/cache.go
@@ -559,13 +559,13 @@ func (ic *IntervalCache) doGet(i interval.Interface) bool {
 
 func (ic *IntervalCache) add(e *Entry) {
 	if err := ic.tree.Insert(e, false); err != nil {
-		log.Error(context.TODO(), err)
+		log.Errorf(context.TODO(), "%v", err)
 	}
 }
 
 func (ic *IntervalCache) del(e *Entry) {
 	if err := ic.tree.Delete(e, false); err != nil {
-		log.Error(context.TODO(), err)
+		log.Errorf(context.TODO(), "%v", err)
 	}
 }
 

--- a/pkg/util/encoding/csv/example_test.go
+++ b/pkg/util/encoding/csv/example_test.go
@@ -40,7 +40,7 @@ Ken,Thompson,ken
 			break
 		}
 		if err != nil {
-			log.Fatal(ctx, err)
+			log.Fatalf(ctx, "%v", err)
 		}
 
 		fmt.Println(record)
@@ -68,7 +68,7 @@ Ken;Thompson;ken
 
 	records, err := r.ReadAll()
 	if err != nil {
-		log.Fatal(ctx, err)
+		log.Fatalf(ctx, "%v", err)
 	}
 
 	fmt.Print(records)
@@ -87,7 +87,7 @@ Ken,Thompson,ken
 
 	records, err := r.ReadAll()
 	if err != nil {
-		log.Fatal(ctx, err)
+		log.Fatalf(ctx, "%v", err)
 	}
 
 	fmt.Print(records)
@@ -116,7 +116,7 @@ func ExampleWriter() {
 	w.Flush()
 
 	if err := w.Error(); err != nil {
-		log.Fatal(ctx, err)
+		log.Fatalf(ctx, "%v", err)
 	}
 	// Output:
 	// first_name,last_name,username

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -536,7 +536,7 @@ func TestRollover(t *testing.T) {
 		t.Fatalf("info has initial error: %v", err)
 	}
 	fname0 := info.file.Name()
-	Info(context.Background(), strings.Repeat("x", int(LogFileMaxSize))) // force a rollover
+	Infof(context.Background(), "%s", strings.Repeat("x", int(LogFileMaxSize))) // force a rollover
 	if err != nil {
 		t.Fatalf("info has error after big write: %v", err)
 	}

--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -530,7 +530,7 @@ func SendReport(
 	eventID, ch := raven.DefaultClient.Capture(packet, tags)
 	select {
 	case <-ch:
-		Shout(ctx, Severity_ERROR, "Reported as error "+eventID)
+		Shoutf(ctx, Severity_ERROR, "Reported as error %v", eventID)
 	case <-time.After(10 * time.Second):
 		Shout(ctx, Severity_ERROR, "Time out trying to submit crash report")
 	}

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -46,7 +46,12 @@ func logDepth(ctx context.Context, depth int, sev Severity, format string, args 
 
 // Shout logs to the specified severity's log, and also to the real
 // stderr if logging is currently redirected to a file.
-func Shout(ctx context.Context, sev Severity, args ...interface{}) {
+func Shout(ctx context.Context, sev Severity, msg string) {
+	Shoutf(ctx, sev, msg)
+}
+
+// Shoutf is like Shout but uses formatting.
+func Shoutf(ctx context.Context, sev Severity, format string, args ...interface{}) {
 	if sev == Severity_FATAL {
 		// Fatal error handling later already tries to exit even if I/O should
 		// block, but crash reporting might also be in the way.
@@ -57,9 +62,9 @@ func Shout(ctx context.Context, sev Severity, args ...interface{}) {
 	}
 	if mainLog.stderrRedirected() {
 		fmt.Fprintf(OrigStderr, "*\n* %s: %s\n*\n", sev.String(),
-			strings.Replace(MakeMessage(ctx, "", args), "\n", "\n* ", -1))
+			strings.Replace(MakeMessage(ctx, format, args), "\n", "\n* ", -1))
 	}
-	logDepth(ctx, 1, sev, "", args)
+	logDepth(ctx, 1, sev, format, args)
 }
 
 // Infof logs to the INFO log.

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -72,19 +72,9 @@ func Infof(ctx context.Context, format string, args ...interface{}) {
 
 // Info logs to the INFO log.
 // It extracts log tags from the context and logs them along with the given
-// message. Arguments are handled in the manner of fmt.Print; a newline is
-// appended.
-func Info(ctx context.Context, args ...interface{}) {
-	logDepth(ctx, 1, Severity_INFO, "", args)
-}
-
-// InfoDepth logs to the INFO log, offsetting the caller's stack frame by
-// 'depth'.
-// It extracts log tags from the context and logs them along with the given
-// message. Arguments are handled in the manner of fmt.Print; a newline is
-// appended.
-func InfoDepth(ctx context.Context, depth int, args ...interface{}) {
-	logDepth(ctx, depth+1, Severity_INFO, "", args)
+// message.
+func Info(ctx context.Context, msg string) {
+	logDepth(ctx, 1, Severity_INFO, msg, nil)
 }
 
 // InfofDepth logs to the INFO log, offsetting the caller's stack frame by
@@ -106,10 +96,9 @@ func Warningf(ctx context.Context, format string, args ...interface{}) {
 
 // Warning logs to the WARNING and INFO logs.
 // It extracts log tags from the context and logs them along with the given
-// message. Arguments are handled in the manner of fmt.Print; a newline is
-// appended.
-func Warning(ctx context.Context, args ...interface{}) {
-	logDepth(ctx, 1, Severity_WARNING, "", args)
+// message.
+func Warning(ctx context.Context, msg string) {
+	logDepth(ctx, 1, Severity_WARNING, msg, nil)
 }
 
 // WarningfDepth logs to the WARNING and INFO logs, offsetting the caller's
@@ -131,10 +120,9 @@ func Errorf(ctx context.Context, format string, args ...interface{}) {
 
 // Error logs to the ERROR, WARNING, and INFO logs.
 // It extracts log tags from the context and logs them along with the given
-// message. Arguments are handled in the manner of fmt.Print; a newline is
-// appended.
-func Error(ctx context.Context, args ...interface{}) {
-	logDepth(ctx, 1, Severity_ERROR, "", args)
+// message.
+func Error(ctx context.Context, msg string) {
+	logDepth(ctx, 1, Severity_ERROR, msg, nil)
 }
 
 // ErrorfDepth logs to the ERROR, WARNING, and INFO logs, offsetting the
@@ -158,10 +146,9 @@ func Fatalf(ctx context.Context, format string, args ...interface{}) {
 // Fatal logs to the INFO, WARNING, ERROR, and FATAL logs, including a stack
 // trace of all running goroutines, then calls os.Exit(255).
 // It extracts log tags from the context and logs them along with the given
-// message. Arguments are handled in the manner of fmt.Print; a newline is
-// appended.
-func Fatal(ctx context.Context, args ...interface{}) {
-	logDepth(ctx, 1, Severity_FATAL, "", args)
+// message.
+func Fatal(ctx context.Context, msg string) {
+	logDepth(ctx, 1, Severity_FATAL, msg, nil)
 }
 
 // FatalfDepth logs to the INFO, WARNING, ERROR, and FATAL logs (offsetting the

--- a/pkg/util/log/log_flush.go
+++ b/pkg/util/log/log_flush.go
@@ -12,7 +12,6 @@ package log
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"time"
 
@@ -155,9 +154,9 @@ func (l *loggerT) flushAndSync(doSync bool) {
 	// If we can't sync within this duration, exit the process.
 	t := time.AfterFunc(maxSyncDuration, func() {
 		// NB: the disk-stall-detected roachtest matches on this message.
-		Shout(context.Background(), Severity_FATAL, fmt.Sprintf(
+		Shoutf(context.Background(), Severity_FATAL,
 			"disk stall detected: unable to sync log files within %s", maxSyncDuration,
-		))
+		)
 	})
 	defer t.Stop()
 

--- a/pkg/util/metric/graphite_exporter.go
+++ b/pkg/util/metric/graphite_exporter.go
@@ -60,7 +60,7 @@ func (ge *GraphiteExporter) Push(ctx context.Context, endpoint string) error {
 		Timeout:       10 * time.Second,
 		ErrorHandling: graphite.AbortOnError,
 		Logger: loggerFunc(func(args ...interface{}) {
-			log.InfoDepth(ctx, 1, args...)
+			log.InfofDepth(ctx, 1, "", args...)
 		}),
 	}); err != nil {
 		return err

--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -100,7 +100,7 @@ func MakeServer(stopper *stop.Stopper, tlsConfig *tls.Config, handler http.Handl
 	// net/http.(*Server).Serve/http2.ConfigureServer are not thread safe with
 	// respect to net/http.(*Server).TLSConfig, so we call it synchronously here.
 	if err := http2.ConfigureServer(server.Server, nil); err != nil {
-		log.Fatal(ctx, err)
+		log.Fatalf(ctx, "%v", err)
 	}
 
 	stopper.RunWorker(ctx, func(context.Context) {
@@ -163,7 +163,7 @@ func IsClosedConnection(err error) bool {
 // cmux.ErrListenerClosed, or the net package's errClosed.
 func FatalIfUnexpected(err error) {
 	if err != nil && !IsClosedConnection(err) {
-		log.Fatal(context.TODO(), err)
+		log.Fatalf(context.TODO(), "%v", err)
 	}
 }
 

--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -300,7 +300,7 @@ func startPProfEndPoint(ctx context.Context) {
 	go func() {
 		err := http.ListenAndServe(":"+strconv.Itoa(*pprofport), nil)
 		if err != nil {
-			log.Error(ctx, err)
+			log.Errorf(ctx, "%v", err)
 		}
 	}()
 }
@@ -442,7 +442,7 @@ func runRun(gen workload.Generator, urls []string, dbName string) error {
 			formatter.outputError(err)
 			if *tolerateErrors {
 				if everySecond.ShouldLog() {
-					log.Error(ctx, err)
+					log.Errorf(ctx, "%v", err)
 				}
 				continue
 			}


### PR DESCRIPTION
This patch changes the logging interface and the `fmtsafe` linter to enforce that uses of the non-formatting log functions (`log.Info`, `log.Warning` etc) always uses a literal string.

This makes it possible to assume that the argument to those functions
is PII-free and can be collected in PII-free logs and telemetry.

