### PR TITLE
opt: cascades prototype

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -853,7 +853,9 @@ func (ex *connExecutor) execWithDistSQLEngine(
 	}
 
 	var evalCtxFactory func() *extendedEvalContext
-	if len(planner.curPlan.subqueryPlans) != 0 || len(planner.curPlan.postqueryPlans) != 0 {
+	if len(planner.curPlan.subqueryPlans) != 0 ||
+		len(planner.curPlan.cascades) != 0 ||
+		len(planner.curPlan.checkPlans) != 0 {
 		// The factory reuses the same object because the contexts are not used
 		// concurrently.
 		var factoryEvalCtx extendedEvalContext
@@ -890,9 +892,9 @@ func (ex *connExecutor) execWithDistSQLEngine(
 		return recv.bytesRead, recv.rowsRead, recv.commErr
 	}
 
-	if len(planner.curPlan.postqueryPlans) != 0 {
+	if len(planner.curPlan.checkPlans) > 0 || len(planner.curPlan.cascades) > 0 {
 		ex.server.cfg.DistSQLPlanner.PlanAndRunPostqueries(
-			ctx, planner, evalCtxFactory, planner.curPlan.postqueryPlans, recv, distribute,
+			ctx, planner, evalCtxFactory, planner.curPlan.cascades, planner.curPlan.checkPlans, recv, distribute,
 		)
 	}
 

--- a/pkg/sql/explain_tree.go
+++ b/pkg/sql/explain_tree.go
@@ -110,7 +110,8 @@ func planToTree(ctx context.Context, top *planTop) *roachpb.ExplainTreePlanNode 
 	}
 
 	if err := observePlan(
-		ctx, top.plan, top.subqueryPlans, top.postqueryPlans, observer, true /* returnError */, sampledLogicalPlanFmtFlags,
+		ctx, top.plan, top.subqueryPlans, top.cascades, top.checkPlans,
+		observer, true /* returnError */, sampledLogicalPlanFmtFlags,
 	); err != nil {
 		panic(fmt.Sprintf("error while walking plan to save it to statement stats: %s", err.Error()))
 	}

--- a/pkg/sql/explain_tree_test.go
+++ b/pkg/sql/explain_tree_test.go
@@ -67,7 +67,7 @@ func TestPlanToTreeAndPlanToString(t *testing.T) {
 				t.Fatal(err)
 			}
 			if d.Cmd == "plan-string" {
-				return planToString(ctx, p.curPlan.plan, p.curPlan.subqueryPlans, p.curPlan.postqueryPlans)
+				return planToString(ctx, &p.curPlan)
 			}
 			tree := planToTree(ctx, &p.curPlan)
 			treeYaml, err := yaml.Marshal(tree)

--- a/pkg/sql/logictest/testdata/logic_test/cascade_opt
+++ b/pkg/sql/logictest/testdata/logic_test/cascade_opt
@@ -3,6 +3,160 @@
 statement ok
 SET optimizer_foreign_keys = true
 
+# Tests for the experimental opt-driven cascades.
+subtest OptDriven
+
+statement ok
+SET experimental_optimizer_foreign_key_cascades = true
+
+# Single delete cascade.
+statement ok
+CREATE TABLE parent (p INT PRIMARY KEY);
+CREATE TABLE child (
+  c INT PRIMARY KEY,
+  p INT NOT NULL REFERENCES parent(p) ON DELETE CASCADE
+);
+INSERT INTO parent VALUES (1), (2);
+INSERT INTO child VALUES (1, 1), (2, 2), (10, 1), (20, 2);
+
+query II rowsort
+SELECT * FROM child
+----
+1   1
+2   2
+10  1
+20  2
+
+statement ok
+DELETE FROM parent WHERE p >= 2
+
+query II rowsort
+SELECT * FROM child
+----
+1   1
+10  1
+
+statement ok
+DELETE FROM parent WHERE p <= 2
+
+query II
+SELECT * FROM child
+----
+
+statement ok
+DROP TABLE child;
+DROP TABLE parent
+
+
+# Delete cascade with multiple columns and multiple child tables.
+statement ok
+CREATE TABLE parent_multi (pa INT, pb INT, pc INT, UNIQUE INDEX (pa,pb,pc));
+CREATE TABLE child_multi_1 (
+  c INT,
+  a INT,
+  b INT,
+  FOREIGN KEY (a,b,c) REFERENCES parent_multi(pa,pb,pc) ON DELETE CASCADE
+);
+CREATE TABLE child_multi_2 (
+  b INT,
+  c INT,
+  a INT,
+  FOREIGN KEY (a,b,c) REFERENCES parent_multi(pa,pb,pc) ON DELETE CASCADE
+)
+
+statement ok
+INSERT INTO parent_multi VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300), (NULL, NULL, NULL);
+INSERT INTO child_multi_1(a,b,c) VALUES (1, 10, 100), (2, 20, 200), (1, 10, 100), (2, 20, 200), (NULL, NULL, NULL);
+INSERT INTO child_multi_2(a,b,c) VALUES (2, 20, 200), (3, 30, 300)
+
+query III rowsort
+SELECT * FROM parent_multi
+----
+1     10    100
+2     20    200
+3     30    300
+NULL  NULL  NULL
+
+query III rowsort
+SELECT a,b,c FROM child_multi_1
+----
+1     10    100
+2     20    200
+1     10    100
+2     20    200
+NULL  NULL  NULL
+
+query III rowsort
+SELECT a,b,c FROM child_multi_2
+----
+2  20  200
+3  30  300
+
+statement ok
+DELETE FROM parent_multi WHERE pa = 1
+
+query III rowsort
+SELECT * FROM parent_multi
+----
+2     20    200
+3     30    300
+NULL  NULL  NULL
+
+query III rowsort
+SELECT a,b,c FROM child_multi_1
+----
+2     20    200
+2     20    200
+NULL  NULL  NULL
+
+query III rowsort
+SELECT a,b,c FROM child_multi_2
+----
+2  20  200
+3  30  300
+
+statement ok
+DELETE FROM parent_multi WHERE pb = 20
+
+query III rowsort
+SELECT * FROM parent_multi
+----
+3     30    300
+NULL  NULL  NULL
+
+query III rowsort
+SELECT a,b,c FROM child_multi_1
+----
+NULL  NULL  NULL
+
+query III rowsort
+SELECT a,b,c FROM child_multi_2
+----
+3  30  300
+
+# Deleting NULLs should not cause any changes in a child.
+statement ok
+DELETE FROM parent_multi WHERE pa IS NULL
+
+query III rowsort
+SELECT * FROM parent_multi
+----
+3  30  300
+
+query III rowsort
+SELECT a,b,c FROM child_multi_1
+----
+NULL  NULL  NULL
+
+query III rowsort
+SELECT a,b,c FROM child_multi_2
+----
+3  30  300
+
+# TODO(radu): enable when we support Cascades.
+statement ok
+SET experimental_optimizer_foreign_key_cascades = false
+
 subtest AllCascadingActions
 ### A test of all cascading actions in their most basic form.
 # A

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -217,7 +217,7 @@ func (f *stubFactory) RenameColumns(input exec.Node, colNames []string) (exec.No
 }
 
 func (f *stubFactory) ConstructPlan(
-	root exec.Node, subqueries []exec.Subquery, postqueries []exec.Node,
+	root exec.Node, subqueries []exec.Subquery, cascades []exec.Cascade, checks []exec.Node,
 ) (exec.Plan, error) {
 	return struct{}{}, nil
 }

--- a/pkg/sql/opt/exec/execbuilder/cascades.go
+++ b/pkg/sql/opt/exec/execbuilder/cascades.go
@@ -1,0 +1,280 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package execbuilder
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
+)
+
+// cascadeBuilder is a helper that fills in exec.Cascade metadata; it also
+// contains the implementation of exec.Cascade.PlanFn.
+//
+// We walk through a simple example of a cascade to illustrate the flow around
+// executing cascades:
+//
+//   CREATE TABLE parent (p INT PRIMARY KEY);
+//   CREATE TABLE child (
+//     c INT PRIMARY KEY,
+//     p INT NOT NULL REFERENCES parent(p) ON DELETE CASCADE
+//   );
+//
+//   DELETE FROM parent WHERE p > 1;
+//
+// The optimizer expression for this query is:
+//
+//   delete parent
+//    ├── columns: <none>
+//    ├── fetch columns: p:2
+//    ├── input binding: &1
+//    ├── cascades
+//    │    └── fk_p_ref_parent
+//    └── select
+//         ├── columns: p:2!null
+//         ├── scan parent
+//         │    └── columns: p:2!null
+//         └── filters
+//              └── p:2 > 1
+//
+// Note that at this time, the cascading query in the child table was not built.
+// The expression above does contain a reference to a memo.CascadeBuilder which
+// will be invoked to build the query at a later time.
+//
+// When execbuilding the query above, a BufferNode is constructed for the
+// mutation input (binding &1 above) and a cascadeBuilder object is constructed
+// for the cascade.
+//
+// The setupCascade method is called to fill in an exec.Cascade which is passed
+// to ConstructPlan. Note that we still did not build the cascading query; all
+// we did was provide some plumbing and an entry point (through PlanFn) for that
+// to happen later.
+//
+// The plan is constructed and processed by the execution engine. After the
+// plans for the subqueries and the main query are executed, the cascades are
+// processed (in a queue). At this time the PlanFn method is called and the
+// following happens:
+//
+//  1. We set up a new empty memo and add metadata for the columns of the
+//     BufferNode (binding &1).
+//
+//  2. We invoke the memo.CascadeBuilder to optbuild the cascading query. At this
+//     point, the new memo will contain the following expression:
+//
+//      delete child
+//       ├── columns: <none>
+//       ├── fetch columns: c:4 child.p:5
+//       └── semi-join (hash)
+//            ├── columns: c:4!null child.p:5!null
+//            ├── scan child
+//            │    └── columns: c:4!null child.p:5!null
+//            ├── with-scan &1
+//            │    ├── columns: p:6!null
+//            │    └── mapping:
+//            │         └──  parent.p:1 => p:6
+//            └── filters
+//                  └── child.p:5 = p:6
+//
+//    Notes:
+//     - normally, a WithScan can only refer to an ancestor mutation or With
+//       operator. In this case we are creating a reference "out of the void".
+//       This works just fine; we can consider adding a special dummy root
+//       operator but so far it hasn't been necessary;
+//     - the binding &1 column ID has changed: it used to be 2, it is now 1.
+//       This is because we are starting with a fresh memo. We need to take into
+//       account this remapping when referring to the foreign key columns.
+//
+//  3. We optimize the newly built expression.
+//
+//  4. We execbuild the optimizer expression. We have to be careful to set up
+//     the "With" reference before starting.
+//
+// After PlanFn is called, the resulting plan is executed. Note that this plan
+// could itself have more exec.Cascades; these are queued and handled in the
+// same way.
+//
+type cascadeBuilder struct {
+	b              *Builder
+	mutationBuffer exec.BufferNode
+	// mutationBufferCols maps With column IDs from the original memo to buffer
+	// node column ordinals; see builtWithExpr.outputCols.
+	mutationBufferCols opt.ColMap
+
+	// colMeta remembers the metadata of the With columns from the original memo.
+	colMeta []opt.ColumnMeta
+}
+
+// cascadeInputWithID is a special WithID that we use to refer to a cascade
+// input. It should be large enough to never clash with "regular" WithIDs (which
+// are generated sequentially).
+const cascadeInputWithID opt.WithID = 1000000
+
+func makeCascadeBuilder(b *Builder, mutationWithID opt.WithID) (*cascadeBuilder, error) {
+	withExpr := b.findBuiltWithExpr(mutationWithID)
+	if withExpr == nil {
+		return nil, errors.AssertionFailedf("cannot find mutation input withExpr")
+	}
+	cb := &cascadeBuilder{
+		b:                  b,
+		mutationBuffer:     withExpr.bufferNode,
+		mutationBufferCols: withExpr.outputCols,
+	}
+
+	// Remember the column metadata, as we will need to recreate it in the new
+	// memo.
+	md := b.mem.Metadata()
+	cb.colMeta = make([]opt.ColumnMeta, 0, cb.mutationBufferCols.Len())
+	cb.mutationBufferCols.ForEach(func(key, val int) {
+		id := opt.ColumnID(key)
+		cb.colMeta = append(cb.colMeta, *md.ColumnMeta(id))
+	})
+
+	return cb, nil
+}
+
+// setupCascade fills in an exec.Cascade struct for the given cascade.
+func (cb *cascadeBuilder) setupCascade(cascade *memo.FKCascade) exec.Cascade {
+	return exec.Cascade{
+		FKName: cascade.FKName,
+		Buffer: cb.mutationBuffer,
+		PlanFn: func(
+			ctx context.Context,
+			semaCtx *tree.SemaContext,
+			evalCtx *tree.EvalContext,
+			execFactory exec.Factory,
+			bufferRef exec.BufferNode,
+			numBufferedRows int,
+		) (exec.Plan, error) {
+			return cb.planCascade(ctx, semaCtx, evalCtx, execFactory, cascade, bufferRef, numBufferedRows)
+		},
+	}
+}
+
+// planCascade is used to plan a cascade query. It is NOT run while
+// planning the query; it is run by the execution logic (through
+// exec.Cascade.PlanFn) after the main query was executed.
+//
+// See the comment for cascadeBuilder for a detailed explanation of the
+// process.
+func (cb *cascadeBuilder) planCascade(
+	ctx context.Context,
+	semaCtx *tree.SemaContext,
+	evalCtx *tree.EvalContext,
+	execFactory exec.Factory,
+	cascade *memo.FKCascade,
+	bufferRef exec.BufferNode,
+	numBufferedRows int,
+) (exec.Plan, error) {
+	// 1. Set up a brand new memo in which to plan the cascading query.
+	var o xform.Optimizer
+	o.Init(evalCtx, cb.b.catalog)
+	factory := o.Factory()
+	md := factory.Metadata()
+
+	// Set up metadata for the buffer columns.
+
+	// withColRemap is the mapping between the With column IDs in the original
+	// memo and the corresponding column IDs in the new memo.
+	var withColRemap opt.ColMap
+	// bufferColMap is the mapping between the column IDs in the new memo and
+	// the column ordinal in the buffer node.
+	var bufferColMap opt.ColMap
+	var withCols opt.ColSet
+	for i := range cb.colMeta {
+		id := md.AddColumn(cb.colMeta[i].Alias, cb.colMeta[i].Type)
+		withCols.Add(id)
+		ordinal, _ := cb.mutationBufferCols.Get(int(cb.colMeta[i].MetaID))
+		bufferColMap.Set(int(id), ordinal)
+		withColRemap.Set(int(cb.colMeta[i].MetaID), int(id))
+	}
+
+	// Create relational properties for the special WithID input.
+	// TODO(radu): save some more information from the original binding props
+	// (like not-null columns, FDs) and remap them to the new columns.
+	var bindingProps props.Relational
+	bindingProps.Populated = true
+	bindingProps.OutputCols = withCols
+	bindingProps.Cardinality = props.Cardinality{
+		Min: uint32(numBufferedRows),
+		Max: uint32(numBufferedRows),
+	}
+	bindingProps.Stats = props.Statistics{
+		Available: true,
+		RowCount:  float64(numBufferedRows),
+	}
+
+	// Remap the cascade columns.
+	oldVals, err := remapColumns(cascade.OldValues, withColRemap)
+	if err != nil {
+		return nil, err
+	}
+	newVals, err := remapColumns(cascade.NewValues, withColRemap)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. Invoke the memo.CascadeBuilder to build the cascade.
+	relExpr, err := cascade.Builder.Build(
+		ctx,
+		semaCtx,
+		evalCtx,
+		cb.b.catalog,
+		factory,
+		cascadeInputWithID,
+		&bindingProps,
+		oldVals,
+		newVals,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "while building cascade expression")
+	}
+
+	o.Memo().SetRoot(relExpr, &physical.Required{})
+
+	// 3. Optimize the expression.
+	optimizedExpr, err := o.Optimize()
+	if err != nil {
+		return nil, errors.Wrap(err, "while optimizing cascade expression")
+	}
+
+	// 4. Execbuild the optimized expression.
+	eb := New(execFactory, factory.Memo(), cb.b.catalog, optimizedExpr, evalCtx)
+	// TODO(radu): we could allow autocommit for the last cascade (if there are no
+	// checks to run).
+	eb.DisallowAutoCommit()
+	// Set up the With binding.
+	eb.addBuiltWithExpr(cascadeInputWithID, bufferColMap, bufferRef)
+	plan, err := eb.Build()
+	if err != nil {
+		return nil, errors.Wrap(err, "while building cascade plan")
+	}
+	return plan, nil
+}
+
+// Remap columns according to a ColMap.
+func remapColumns(cols opt.ColList, m opt.ColMap) (opt.ColList, error) {
+	res := make(opt.ColList, len(cols))
+	for i := range cols {
+		val, ok := m.Get(int(cols[i]))
+		if !ok {
+			return nil, errors.AssertionFailedf("column %d not in mapping %s\n", cols[i], m.String())
+		}
+		res[i] = opt.ColumnID(val)
+	}
+	return res, nil
+}

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -97,7 +97,7 @@ func (b *Builder) buildInsert(ins *memo.InsertExpr) (execPlan, error) {
 		insertOrds,
 		returnOrds,
 		checkOrds,
-		b.allowAutoCommit && len(ins.Checks) == 0,
+		b.allowAutoCommit && len(ins.Checks) == 0 && len(ins.FKCascades) == 0,
 		disableExecFKs,
 	)
 	if err != nil {
@@ -319,7 +319,7 @@ func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (execPlan, error) {
 		returnColOrds,
 		checkOrds,
 		passthroughCols,
-		b.allowAutoCommit && len(upd.Checks) == 0,
+		b.allowAutoCommit && len(upd.Checks) == 0 && len(upd.FKCascades) == 0,
 		disableExecFKs,
 	)
 	if err != nil {
@@ -394,7 +394,7 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (execPlan, error) {
 		updateColOrds,
 		returnColOrds,
 		checkOrds,
-		b.allowAutoCommit && len(ups.Checks) == 0,
+		b.allowAutoCommit && len(ups.Checks) == 0 && len(ups.FKCascades) == 0,
 		disableExecFKs,
 	)
 	if err != nil {
@@ -445,7 +445,7 @@ func (b *Builder) buildDelete(del *memo.DeleteExpr) (execPlan, error) {
 		tab,
 		fetchColOrds,
 		returnColOrds,
-		b.allowAutoCommit && len(del.Checks) == 0,
+		b.allowAutoCommit && len(del.Checks) == 0 && len(del.FKCascades) == 0,
 		disableExecFKs,
 	)
 	if err != nil {
@@ -453,6 +453,10 @@ func (b *Builder) buildDelete(del *memo.DeleteExpr) (execPlan, error) {
 	}
 
 	if err := b.buildFKChecks(del.Checks); err != nil {
+		return execPlan{}, err
+	}
+
+	if err := b.buildFKCascades(del.WithID, del.FKCascades); err != nil {
 		return execPlan{}, err
 	}
 
@@ -517,7 +521,7 @@ func (b *Builder) buildDeleteRange(del *memo.DeleteExpr) (execPlan, error) {
 		needed,
 		scan.Constraint,
 		maxKeys,
-		b.allowAutoCommit && len(del.Checks) == 0,
+		b.allowAutoCommit && len(del.Checks) == 0 && len(del.FKCascades) == 0,
 	)
 	if err != nil {
 		return execPlan{}, err
@@ -604,7 +608,7 @@ func (b *Builder) buildFKChecks(checks memo.FKChecksExpr) error {
 		if err != nil {
 			return err
 		}
-		b.postqueries = append(b.postqueries, node)
+		b.checks = append(b.checks, node)
 	}
 	return nil
 }
@@ -694,6 +698,20 @@ func mkFKCheckErr(md *opt.Metadata, c *memo.FKChecksItem, keyVals tree.Datums) e
 		pgerror.New(pgcode.ForeignKeyViolation, msg.String()),
 		details.String(),
 	)
+}
+
+func (b *Builder) buildFKCascades(withID opt.WithID, cascades memo.FKCascades) error {
+	if len(cascades) == 0 {
+		return nil
+	}
+	cb, err := makeCascadeBuilder(b, withID)
+	if err != nil {
+		return err
+	}
+	for i := range cascades {
+		b.cascades = append(b.cascades, cb.setupCascade(&cascades[i]))
+	}
+	return nil
 }
 
 // canAutoCommit determines if it is safe to auto commit the mutation contained

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -132,7 +132,7 @@ func (b *Builder) buildExplain(explain *memo.ExplainExpr) (execPlan, error) {
 			return execPlan{}, err
 		}
 
-		plan, err := b.factory.ConstructPlan(input.root, b.subqueries, b.postqueries)
+		plan, err := b.factory.ConstructPlan(input.root, b.subqueries, b.cascades, b.checks)
 		if err != nil {
 			return execPlan{}, err
 		}
@@ -147,10 +147,11 @@ func (b *Builder) buildExplain(explain *memo.ExplainExpr) (execPlan, error) {
 	for i, c := range explain.ColList {
 		ep.outputCols.Set(int(c), i)
 	}
-	// The sub- and postqueries are now owned by the explain node; remove them so
-	// they don't also show up in the final plan.
-	b.subqueries = b.subqueries[:0]
-	b.postqueries = b.postqueries[:0]
+	// The subqueries/cascades/checks are now owned by the explain node;
+	// remove them so they don't also show up in the final plan.
+	b.subqueries = nil
+	b.cascades = nil
+	b.checks = nil
 	return ep, nil
 }
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
@@ -29,7 +29,7 @@ root                                       ·                      ·
  │              │                          label                  buffer 1
  │              └── values                 ·                      ·
  │                                         size                   2 columns, 2 rows
- └── postquery                             ·                      ·
+ └── fk-check                              ·                      ·
       └── error if rows                    ·                      ·
            └── lookup-join                 ·                      ·
                 │                          table                  parent@primary
@@ -60,7 +60,7 @@ root                                       ·                   ·
  │              └── scan                   ·                   ·
  │                                         table               xy@primary
  │                                         spans               FULL SCAN
- └── postquery                             ·                   ·
+ └── fk-check                              ·                   ·
       └── error if rows                    ·                   ·
            └── hash-join                   ·                   ·
                 │                          type                anti
@@ -92,7 +92,7 @@ root                                            ·                      ·
  │              │                               label                  buffer 1
  │              └── values                      ·                      ·
  │                                              size                   2 columns, 2 rows
- └── postquery                                  ·                      ·
+ └── fk-check                                   ·                      ·
       └── error if rows                         ·                      ·
            └── lookup-join                      ·                      ·
                 │                               table                  parent@primary
@@ -132,7 +132,7 @@ root                                            ·                      ·
  │              │                               label                  buffer 1
  │              └── values                      ·                      ·
  │                                              size                   4 columns, 2 rows
- └── postquery                                  ·                      ·
+ └── fk-check                                   ·                      ·
       └── error if rows                         ·                      ·
            └── lookup-join                      ·                      ·
                 │                               table                  multi_col_parent@primary
@@ -176,7 +176,7 @@ root                                            ·                      ·
  │              │                               label                  buffer 1
  │              └── values                      ·                      ·
  │                                              size                   4 columns, 1 row
- ├── postquery                                  ·                      ·
+ ├── fk-check                                   ·                      ·
  │    └── error if rows                         ·                      ·
  │         └── lookup-join                      ·                      ·
  │              │                               table                  multi_ref_parent_a@primary
@@ -189,7 +189,7 @@ root                                            ·                      ·
  │                   └── render                 ·                      ·
  │                        └── scan buffer node  ·                      ·
  │                                              label                  buffer 1
- └── postquery                                  ·                      ·
+ └── fk-check                                   ·                      ·
       └── error if rows                         ·                      ·
            └── lookup-join                      ·                      ·
                 │                               table                  multi_ref_parent_bc@primary
@@ -220,7 +220,7 @@ root                                       ·            ·
  │              └── scan                   ·            ·
  │                                         table        parent@primary
  │                                         spans        /3-/3/#
- ├── postquery                             ·            ·
+ ├── fk-check                              ·            ·
  │    └── error if rows                    ·            ·
  │         └── lookup-join                 ·            ·
  │              │                          table        child@child_auto_index_fk_p_ref_parent
@@ -229,7 +229,7 @@ root                                       ·            ·
  │              └── render                 ·            ·
  │                   └── scan buffer node  ·            ·
  │                                         label        buffer 1
- └── postquery                             ·            ·
+ └── fk-check                              ·            ·
       └── error if rows                    ·            ·
            └── lookup-join                 ·            ·
                 │                          table        child_nullable@child_nullable_auto_index_fk_p_ref_parent
@@ -257,7 +257,7 @@ root                                       ·            ·
  │              └── scan                   ·            ·
  │                                         table        parent@primary
  │                                         spans        /3-/3/#
- ├── postquery                             ·            ·
+ ├── fk-check                              ·            ·
  │    └── error if rows                    ·            ·
  │         └── lookup-join                 ·            ·
  │              │                          table        child@child_auto_index_fk_p_ref_parent
@@ -266,7 +266,7 @@ root                                       ·            ·
  │              └── render                 ·            ·
  │                   └── scan buffer node  ·            ·
  │                                         label        buffer 1
- ├── postquery                             ·            ·
+ ├── fk-check                              ·            ·
  │    └── error if rows                    ·            ·
  │         └── lookup-join                 ·            ·
  │              │                          table        child_nullable@child_nullable_auto_index_fk_p_ref_parent
@@ -275,7 +275,7 @@ root                                       ·            ·
  │              └── render                 ·            ·
  │                   └── scan buffer node  ·            ·
  │                                         label        buffer 1
- └── postquery                             ·            ·
+ └── fk-check                              ·            ·
       └── error if rows                    ·            ·
            └── lookup-join                 ·            ·
                 │                          table        child2@child2_auto_index_fk_p_ref_parent
@@ -311,7 +311,7 @@ root                                  ·            ·
  │              └── scan              ·            ·
  │                                    table        doubleparent@primary
  │                                    spans        /10-/11
- └── postquery                        ·            ·
+ └── fk-check                         ·            ·
       └── error if rows               ·            ·
            └── lookup-join            ·            ·
                 │                     table        doublechild@doublechild_auto_index_fk_p1_ref_doubleparent
@@ -340,7 +340,7 @@ root                                       ·                   ·
  │                                         table               child@primary
  │                                         spans               FULL SCAN
  │                                         locking strength    for update
- └── postquery                             ·                   ·
+ └── fk-check                              ·                   ·
       └── error if rows                    ·                   ·
            └── hash-join                   ·                   ·
                 │                          type                anti
@@ -371,7 +371,7 @@ root                                       ·                      ·
  │                                         table                  child@primary
  │                                         spans                  /10-/10/#
  │                                         locking strength       for update
- └── postquery                             ·                      ·
+ └── fk-check                              ·                      ·
       └── error if rows                    ·                      ·
            └── lookup-join                 ·                      ·
                 │                          table                  parent@primary
@@ -401,7 +401,7 @@ root                                                 ·                   ·
  │                                                   table               parent@primary
  │                                                   spans               FULL SCAN
  │                                                   locking strength    for update
- ├── postquery                                       ·                   ·
+ ├── fk-check                                        ·                   ·
  │    └── error if rows                              ·                   ·
  │         └── render                                ·                   ·
  │              └── hash-join                        ·                   ·
@@ -422,7 +422,7 @@ root                                                 ·                   ·
  │                        └── scan                   ·                   ·
  │                                                   table               child@child_auto_index_fk_p_ref_parent
  │                                                   spans               FULL SCAN
- └── postquery                                       ·                   ·
+ └── fk-check                                        ·                   ·
       └── error if rows                              ·                   ·
            └── render                                ·                   ·
                 └── hash-join                        ·                   ·
@@ -462,7 +462,7 @@ root                                            ·                 ·
  │                                              table             parent@parent_other_key
  │                                              spans             /10-/11
  │                                              locking strength  for update
- ├── postquery                                  ·                 ·
+ ├── fk-check                                   ·                 ·
  │    └── error if rows                         ·                 ·
  │         └── lookup-join                      ·                 ·
  │              │                               table             child@child_auto_index_fk_p_ref_parent
@@ -475,7 +475,7 @@ root                                            ·                 ·
  │                   └── render                 ·                 ·
  │                        └── scan buffer node  ·                 ·
  │                                              label             buffer 1
- └── postquery                                  ·                 ·
+ └── fk-check                                   ·                 ·
       └── error if rows                         ·                 ·
            └── lookup-join                      ·                 ·
                 │                               table             child_nullable@child_nullable_auto_index_fk_p_ref_parent
@@ -510,7 +510,7 @@ root                                                 ·                   ·
  │                                                   table               child@primary
  │                                                   spans               FULL SCAN
  │                                                   locking strength    for update
- └── postquery                                       ·                   ·
+ └── fk-check                                        ·                   ·
       └── error if rows                              ·                   ·
            └── render                                ·                   ·
                 └── hash-join                        ·                   ·
@@ -551,7 +551,7 @@ root                                       ·                   ·
  │                                         table               child@primary
  │                                         spans               FULL SCAN
  │                                         locking strength    for update
- └── postquery                             ·                   ·
+ └── fk-check                              ·                   ·
       └── error if rows                    ·                   ·
            └── hash-join                   ·                   ·
                 │                          type                anti
@@ -582,7 +582,7 @@ root                                       ·                   ·
  │                                         table               child@primary
  │                                         spans               FULL SCAN
  │                                         locking strength    for update
- └── postquery                             ·                   ·
+ └── fk-check                              ·                   ·
       └── error if rows                    ·                   ·
            └── hash-join                   ·                   ·
                 │                          type                anti
@@ -613,7 +613,7 @@ root                                                 ·                   ·
  │                                                   table               child@primary
  │                                                   spans               FULL SCAN
  │                                                   locking strength    for update
- ├── postquery                                       ·                   ·
+ ├── fk-check                                        ·                   ·
  │    └── error if rows                              ·                   ·
  │         └── hash-join                             ·                   ·
  │              │                                    type                anti
@@ -625,7 +625,7 @@ root                                                 ·                   ·
  │              └── scan                             ·                   ·
  │                                                   table               parent@primary
  │                                                   spans               FULL SCAN
- └── postquery                                       ·                   ·
+ └── fk-check                                        ·                   ·
       └── error if rows                              ·                   ·
            └── render                                ·                   ·
                 └── hash-join                        ·                   ·
@@ -669,7 +669,7 @@ root                                       ·                   ·
  │                                         table               child@primary
  │                                         spans               FULL SCAN
  │                                         locking strength    for update
- └── postquery                             ·                   ·
+ └── fk-check                              ·                   ·
       └── error if rows                    ·                   ·
            └── hash-join                   ·                   ·
                 │                          type                anti
@@ -703,7 +703,7 @@ root                                       ·                   ·
  │                                         table               self@primary
  │                                         spans               FULL SCAN
  │                                         locking strength    for update
- └── postquery                             ·                   ·
+ └── fk-check                              ·                   ·
       └── error if rows                    ·                   ·
            └── hash-join                   ·                   ·
                 │                          type                anti
@@ -734,7 +734,7 @@ root                                                 ·                   ·
  │                                                   table               self@primary
  │                                                   spans               FULL SCAN
  │                                                   locking strength    for update
- └── postquery                                       ·                   ·
+ └── fk-check                                        ·                   ·
       └── error if rows                              ·                   ·
            └── render                                ·                   ·
                 └── hash-join                        ·                   ·
@@ -877,3 +877,34 @@ INSERT INTO t46397_parent VALUES (0)
 
 statement ok
 UPSERT INTO t46397_child(c) VALUES (2)
+
+
+# Verify that cascade information shows up in EXPLAIN.
+statement ok
+SET experimental_optimizer_foreign_key_cascades = true
+
+statement ok
+CREATE TABLE cascadeparent (p INT PRIMARY KEY);
+CREATE TABLE cascadechild (
+  c INT PRIMARY KEY,
+  p INT NOT NULL REFERENCES cascadeparent(p) ON DELETE CASCADE
+)
+
+query TTTTT
+EXPLAIN (VERBOSE) DELETE FROM cascadeparent WHERE p > 1
+----
+·                           distributed  false                   ·    ·
+·                           vectorized   false                   ·    ·
+root                        ·            ·                       ()   ·
+ ├── count                  ·            ·                       ()   ·
+ │    └── delete            ·            ·                       ()   ·
+ │         │                from         cascadeparent           ·    ·
+ │         │                strategy     deleter                 ·    ·
+ │         └── buffer node  ·            ·                       (p)  ·
+ │              │           label        buffer 1                ·    ·
+ │              └── scan    ·            ·                       (p)  ·
+ │                          table        cascadeparent@primary   ·    ·
+ │                          spans        /2-                     ·    ·
+ └── fk-cascade             ·            ·                       ·    ·
+·                           fk           fk_p_ref_cascadeparent  ·    ·
+·                           input        buffer 1                ·    ·

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -11,6 +11,8 @@
 package exec
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -295,14 +297,19 @@ type Factory interface {
 	RenameColumns(input Node, colNames []string) (Node, error)
 
 	// ConstructPlan creates a plan enclosing the given plan and (optionally)
-	// subqueries and postqueries.
+	// subqueries, cascades, and checks.
 	//
 	// Subqueries are executed before the root tree, which can refer to subquery
 	// results using tree.Subquery nodes.
 	//
-	// Postqueries are executed after the root tree. They don't return results but
-	// can generate errors (e.g. foreign key check failures).
-	ConstructPlan(root Node, subqueries []Subquery, postqueries []Node) (Plan, error)
+	// Cascades are executed after the root tree. They can return more cascades
+	// and checks which should also be executed.
+	//
+	// Checks are executed after all cascades have been executed. They don't
+	// return results but can generate errors (e.g. foreign key check failures).
+	ConstructPlan(
+		root Node, subqueries []Subquery, cascades []Cascade, checks []Node,
+	) (Plan, error)
 
 	// ConstructExplain returns a node that implements EXPLAIN (OPT), showing
 	// information about the given plan.
@@ -332,7 +339,7 @@ type Factory interface {
 	//
 	// If skipFKChecks is set, foreign keys are not checked as part of the
 	// execution of the insertion. This is used when the FK checks are planned by
-	// the optimizer and are run separately as plan postqueries.
+	// the optimizer and are run separately as plan checks.
 	ConstructInsert(
 		input Node,
 		table cat.Table,
@@ -389,7 +396,7 @@ type Factory interface {
 	//
 	// If skipFKChecks is set, foreign keys are not checked as part of the
 	// execution of the insertion. This is used when the FK checks are planned by
-	// the optimizer and are run separately as plan postqueries.
+	// the optimizer and are run separately as plan checks.
 	ConstructUpdate(
 		input Node,
 		table cat.Table,
@@ -434,7 +441,7 @@ type Factory interface {
 	// If skipFKChecks is set, foreign keys are not checked as part of the
 	// execution of the upsert for the insert half. This is used when the FK
 	// checks are planned by the optimizer and are run separately as plan
-	// postqueries.
+	// checks.
 	ConstructUpsert(
 		input Node,
 		table cat.Table,
@@ -463,7 +470,7 @@ type Factory interface {
 	//
 	// If skipFKChecks is set, foreign keys are not checked as part of the
 	// execution of the delete. This is used when the FK checks are planned
-	// by the optimizer and are run separately as plan postqueries.
+	// by the optimizer and are run separately as plan checks.
 	ConstructDelete(
 		input Node,
 		table cat.Table,
@@ -714,6 +721,39 @@ type RecursiveCTEIterationFn func(bufferRef BufferNode) (Plan, error)
 // a row produced from the left side. The plan is guaranteed to produce the
 // rightColumns passed to ConstructApplyJoin (in order).
 type ApplyJoinPlanRightSideFn func(leftRow tree.Datums) (Plan, error)
+
+// Cascade describes a cascading query. The query uses a BufferNode as an input;
+// it should only be triggered if this buffer is not empty.
+type Cascade struct {
+	// FKName is the name of the foreign key constraint.
+	FKName string
+
+	// Buffer is the Node returned by ConstructBuffer which stores the input to
+	// the mutation.
+	Buffer BufferNode
+
+	// PlanFn builds the cascade query and creates the plan for it.
+	// Note that the generated Plan can in turn contain more cascades (as well as
+	// checks, which should run after all cascades are executed).
+	//
+	// The bufferRef is a reference that can be used with ConstructWithBuffer to
+	// read the mutation input. It is conceptually the same as the Buffer field;
+	// however, we allow the execution engine to provide a different copy or
+	// implementation of the node (e.g. to facilitate early cleanup of the
+	// original plan).
+	//
+	// This method does not mutate any captured state; it is ok to call PlanFn
+	// methods concurrently (provided that they don't use a single non-thread-safe
+	// execFactory).
+	PlanFn func(
+		ctx context.Context,
+		semaCtx *tree.SemaContext,
+		evalCtx *tree.EvalContext,
+		execFactory Factory,
+		bufferRef BufferNode,
+		numBufferedRows int,
+	) (Plan, error)
+}
 
 // InsertFastPathMaxRows is the maximum number of rows for which we can use the
 // insert fast path.

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1060,6 +1060,12 @@ func (f *ExprFmtCtx) formatMutationCommon(tp treeprinter.Node, p *MutationPrivat
 	if p.FKFallback {
 		tp.Childf("fk-fallback")
 	}
+	if len(p.FKCascades) > 0 {
+		c := tp.Childf("cascades")
+		for i := range p.FKCascades {
+			c.Child(p.FKCascades[i].FKName)
+		}
+	}
 }
 
 // ColumnString returns the column in the same format as formatColSimple.

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -484,6 +484,12 @@ func (h *hasher) HashJoinFlags(val JoinFlags) {
 	h.HashUint64(uint64(val))
 }
 
+func (h *hasher) HashFKCascades(val FKCascades) {
+	for i := range val {
+		h.HashUint64(uint64(reflect.ValueOf(val[i].Builder).Pointer()))
+	}
+}
+
 func (h *hasher) HashExplainOptions(val tree.ExplainOptions) {
 	h.HashUint64(uint64(val.Mode))
 	hash := h.hash
@@ -839,6 +845,19 @@ func (h *hasher) IsScanFlagsEqual(l, r ScanFlags) bool {
 
 func (h *hasher) IsJoinFlagsEqual(l, r JoinFlags) bool {
 	return l == r
+}
+
+func (h *hasher) IsFKCascadesEqual(l, r FKCascades) bool {
+	if len(l) != len(r) {
+		return false
+	}
+	for i := range l {
+		// It's sufficient to compare the CascadeBuilder instances.
+		if l[i].Builder != r[i].Builder {
+			return false
+		}
+	}
+	return true
 }
 
 func (h *hasher) IsExplainOptionsEqual(l, r tree.ExplainOptions) bool {

--- a/pkg/sql/opt/ops/mutation.opt
+++ b/pkg/sql/opt/ops/mutation.opt
@@ -134,6 +134,9 @@ define MutationPrivate {
     # is zero.
     WithID WithID
 
+    # FKCascades stores metadata necessary for building cascading queries.
+    FKCascades FKCascades
+
     # FKFallback is true if we need to fall back to the legacy path for FK
     # checks / cascades.
     FKFallback bool

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -74,7 +74,7 @@ func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope
 // buildDelete constructs a Delete operator, possibly wrapped by a Project
 // operator that corresponds to the given RETURNING clause.
 func (mb *mutationBuilder) buildDelete(returning tree.ReturningExprs) {
-	mb.buildFKChecksForDelete()
+	mb.buildFKChecksAndCascadesForDelete()
 
 	private := mb.makeMutationPrivate(returning != nil)
 	mb.outScope.expr = mb.b.factory.ConstructDelete(mb.outScope.expr, mb.checks, private)

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -1,0 +1,156 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package optbuilder
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
+)
+
+// deleteCascadeBuilder is a memo.CascadeBuilder implementation for
+// ON DELETE CASCADE.
+//
+// It provides a method to build the cascading delete in the child table,
+// equivalent to a query like:
+//
+//   DELETE FROM child WHERE fk IN (SELECT fk FROM original_mutation_input)
+//
+// The expression that is built is a semi-join of the table with the mutation
+// input:
+//
+//   delete child
+//    └── semi-join (hash)
+//         ├── columns: c:5!null child.p:6!null
+//         ├── scan child
+//         │    └── columns: c:5!null child.p:6!null
+//         ├── with-scan &1
+//         │    ├── columns: p:7!null
+//         │    └── mapping:
+//         │         └──  parent.p:2 => p:7
+//         └── filters
+//              └── child.p:6 = p:7
+//
+// Note that NULL values in the mutation input don't require any special
+// handling - they will be effectively ignored by the semi-join.
+//
+// See testdata/fk-cascades-delete for more examples.
+//
+type deleteCascadeBuilder struct {
+	mutatedTable cat.Table
+	// fkInboundOrdinal is the ordinal of the inbound foreign key constraint on
+	// the mutated table (can be passed tomutatedTable.InboundForeignKey).
+	fkInboundOrdinal int
+	childTable       cat.Table
+}
+
+var _ memo.CascadeBuilder = &deleteCascadeBuilder{}
+
+func newDeleteCascadeBuilder(
+	mutatedTable cat.Table, fkInboundOrdinal int, childTable cat.Table,
+) *deleteCascadeBuilder {
+	return &deleteCascadeBuilder{
+		mutatedTable:     mutatedTable,
+		fkInboundOrdinal: fkInboundOrdinal,
+		childTable:       childTable,
+	}
+}
+
+// Build is part of the memo.CascadeBuilder interface.
+func (cb *deleteCascadeBuilder) Build(
+	ctx context.Context,
+	semaCtx *tree.SemaContext,
+	evalCtx *tree.EvalContext,
+	catalog cat.Catalog,
+	factoryI interface{},
+	binding opt.WithID,
+	bindingProps *props.Relational,
+	oldValues, newValues opt.ColList,
+) (_ memo.RelExpr, err error) {
+	factory := factoryI.(*norm.Factory)
+	md := factory.Metadata()
+	b := New(ctx, semaCtx, evalCtx, catalog, factory, nil /* stmt */)
+
+	// Enact panic handling similar to Builder.Build().
+	defer func() {
+		if r := recover(); r != nil {
+			if ok, e := errorutil.ShouldCatch(r); ok {
+				err = e
+			} else {
+				panic(r)
+			}
+		}
+	}()
+
+	fk := cb.mutatedTable.InboundForeignKey(cb.fkInboundOrdinal)
+
+	dep := opt.DepByID(fk.OriginTableID())
+	b.checkPrivilege(dep, cb.childTable, privilege.DELETE)
+	b.checkPrivilege(dep, cb.childTable, privilege.SELECT)
+
+	var mb mutationBuilder
+	mb.init(b, "delete", cb.childTable, tree.MakeUnqualifiedTableName(cb.childTable.Name()))
+
+	// Build a semi join of the table with the mutation input. See the comment for
+	// deleteCascadeBuilder.
+
+	mb.outScope = b.buildScan(
+		b.addTable(cb.childTable, &mb.alias),
+		nil, /* ordinals */
+		nil, /* indexFlags */
+		noRowLocking,
+		excludeMutations,
+		b.allocScope(),
+	)
+
+	outCols := make(opt.ColList, len(oldValues))
+	for i := range outCols {
+		c := md.ColumnMeta(oldValues[i])
+		outCols[i] = md.AddColumn(c.Alias, c.Type)
+	}
+
+	mutationInput := factory.ConstructWithScan(&memo.WithScanPrivate{
+		With:         binding,
+		InCols:       oldValues,
+		OutCols:      outCols,
+		BindingProps: bindingProps,
+		ID:           md.NextUniqueID(),
+	})
+
+	on := make(memo.FiltersExpr, len(outCols))
+	for i := range on {
+		tabOrd := fk.OriginColumnOrdinal(cb.childTable, i)
+		on[i] = factory.ConstructFiltersItem(factory.ConstructEq(
+			factory.ConstructVariable(mb.scopeOrdToColID(scopeOrdinal(tabOrd))),
+			factory.ConstructVariable(outCols[i]),
+		))
+	}
+
+	mb.outScope.expr = factory.ConstructSemiJoin(
+		mb.outScope.expr, mutationInput, on, &memo.JoinPrivate{},
+	)
+
+	// Set list of columns that will be fetched by the input expression.
+	// Note that the columns were populated by the scan, but the semi-join returns
+	// the same columns.
+	for i := range mb.outScope.cols {
+		mb.fetchOrds[i] = scopeOrdinal(i)
+	}
+	mb.buildDelete(nil /* returning */)
+	return mb.outScope.expr, nil
+}

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -54,7 +54,7 @@ import (
 type deleteCascadeBuilder struct {
 	mutatedTable cat.Table
 	// fkInboundOrdinal is the ordinal of the inbound foreign key constraint on
-	// the mutated table (can be passed tomutatedTable.InboundForeignKey).
+	// the mutated table (can be passed to mutatedTable.InboundForeignKey).
 	fkInboundOrdinal int
 	childTable       cat.Table
 }

--- a/pkg/sql/opt/optbuilder/testdata/fk-cascades-delete
+++ b/pkg/sql/opt/optbuilder/testdata/fk-cascades-delete
@@ -1,0 +1,178 @@
+exec-ddl
+CREATE TABLE parent (p INT PRIMARY KEY)
+----
+
+exec-ddl
+CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p) ON DELETE CASCADE)
+----
+
+build
+DELETE FROM parent WHERE p > 1
+----
+delete parent
+ ├── columns: <none>
+ ├── fetch columns: p:2
+ ├── input binding: &1
+ ├── cascades
+ │    └── fk_p_ref_parent
+ └── select
+      ├── columns: p:2!null
+      ├── scan parent
+      │    └── columns: p:2!null
+      └── filters
+           └── p:2 > 1
+
+build-cascades
+DELETE FROM parent WHERE p > 1
+----
+root
+ ├── delete parent
+ │    ├── columns: <none>
+ │    ├── fetch columns: p:2
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk_p_ref_parent
+ │    └── select
+ │         ├── columns: p:2!null
+ │         ├── scan parent
+ │         │    └── columns: p:2!null
+ │         └── filters
+ │              └── p:2 > 1
+ └── cascade
+      └── delete child
+           ├── columns: <none>
+           ├── fetch columns: c:5 child.p:6
+           └── semi-join (hash)
+                ├── columns: c:5!null child.p:6!null
+                ├── scan child
+                │    └── columns: c:5!null child.p:6!null
+                ├── with-scan &1
+                │    ├── columns: p:7!null
+                │    └── mapping:
+                │         └──  parent.p:2 => p:7
+                └── filters
+                     └── child.p:6 = p:7
+
+exec-ddl
+CREATE TABLE grandchild (g INT PRIMARY KEY, c INT REFERENCES child(c) ON DELETE CASCADE)
+----
+
+build-cascades
+DELETE FROM parent WHERE p > 1
+----
+root
+ ├── delete parent
+ │    ├── columns: <none>
+ │    ├── fetch columns: p:2
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk_p_ref_parent
+ │    └── select
+ │         ├── columns: p:2!null
+ │         ├── scan parent
+ │         │    └── columns: p:2!null
+ │         └── filters
+ │              └── p:2 > 1
+ └── cascade
+      ├── delete child
+      │    ├── columns: <none>
+      │    ├── fetch columns: c:5 child.p:6
+      │    ├── input binding: &2
+      │    ├── cascades
+      │    │    └── fk_c_ref_child
+      │    └── semi-join (hash)
+      │         ├── columns: c:5!null child.p:6!null
+      │         ├── scan child
+      │         │    └── columns: c:5!null child.p:6!null
+      │         ├── with-scan &1
+      │         │    ├── columns: p:7!null
+      │         │    └── mapping:
+      │         │         └──  parent.p:2 => p:7
+      │         └── filters
+      │              └── child.p:6 = p:7
+      └── cascade
+           └── delete grandchild
+                ├── columns: <none>
+                ├── fetch columns: g:10 grandchild.c:11
+                └── semi-join (hash)
+                     ├── columns: g:10!null grandchild.c:11
+                     ├── scan grandchild
+                     │    └── columns: g:10!null grandchild.c:11
+                     ├── with-scan &2
+                     │    ├── columns: c:12!null
+                     │    └── mapping:
+                     │         └──  child.c:5 => c:12
+                     └── filters
+                          └── grandchild.c:11 = c:12
+
+exec-ddl
+CREATE TABLE self (a INT PRIMARY KEY, b INT REFERENCES self(a) ON DELETE CASCADE)
+----
+
+build-cascades cascade-levels=3
+DELETE FROM self WHERE a=1
+----
+root
+ ├── delete self
+ │    ├── columns: <none>
+ │    ├── fetch columns: a:3 b:4
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk_b_ref_self
+ │    └── select
+ │         ├── columns: a:3!null b:4
+ │         ├── scan self
+ │         │    └── columns: a:3!null b:4
+ │         └── filters
+ │              └── a:3 = 1
+ └── cascade
+      ├── delete self
+      │    ├── columns: <none>
+      │    ├── fetch columns: self.a:7 b:8
+      │    ├── input binding: &2
+      │    ├── cascades
+      │    │    └── fk_b_ref_self
+      │    └── semi-join (hash)
+      │         ├── columns: self.a:7!null b:8
+      │         ├── scan self
+      │         │    └── columns: self.a:7!null b:8
+      │         ├── with-scan &1
+      │         │    ├── columns: a:9!null
+      │         │    └── mapping:
+      │         │         └──  self.a:3 => a:9
+      │         └── filters
+      │              └── b:8 = a:9
+      └── cascade
+           ├── delete self
+           │    ├── columns: <none>
+           │    ├── fetch columns: self.a:12 b:13
+           │    ├── input binding: &3
+           │    ├── cascades
+           │    │    └── fk_b_ref_self
+           │    └── semi-join (hash)
+           │         ├── columns: self.a:12!null b:13
+           │         ├── scan self
+           │         │    └── columns: self.a:12!null b:13
+           │         ├── with-scan &2
+           │         │    ├── columns: a:14!null
+           │         │    └── mapping:
+           │         │         └──  self.a:7 => a:14
+           │         └── filters
+           │              └── b:13 = a:14
+           └── cascade
+                └── delete self
+                     ├── columns: <none>
+                     ├── fetch columns: self.a:17 b:18
+                     ├── input binding: &4
+                     ├── cascades
+                     │    └── fk_b_ref_self
+                     └── semi-join (hash)
+                          ├── columns: self.a:17!null b:18
+                          ├── scan self
+                          │    └── columns: self.a:17!null b:18
+                          ├── with-scan &3
+                          │    ├── columns: a:19!null
+                          │    └── mapping:
+                          │         └──  self.a:12 => a:19
+                          └── filters
+                               └── b:18 = a:19

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-delete
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-delete
@@ -134,22 +134,3 @@ delete doublechild
       │    └── columns: c:4!null p1:5 p2:6
       └── filters
            └── p1:5 = 10
-
-exec-ddl
-CREATE TABLE child_cascade (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p) ON DELETE CASCADE)
-----
-
-# Fall back to the exec-style checks in the presence of CASCADE.
-build
-DELETE FROM parent WHERE p = 1
-----
-delete parent
- ├── columns: <none>
- ├── fetch columns: x:4 parent.p:5 parent.other:6
- ├── fk-fallback
- └── select
-      ├── columns: x:4 parent.p:5!null parent.other:6
-      ├── scan parent
-      │    └── columns: x:4 parent.p:5!null parent.other:6
-      └── filters
-           └── parent.p:5 = 1

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -204,6 +204,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"ScanFlags":           {fullName: "memo.ScanFlags", passByVal: true},
 		"JoinFlags":           {fullName: "memo.JoinFlags", passByVal: true},
 		"WindowFrame":         {fullName: "memo.WindowFrame", passByVal: true},
+		"FKCascades":          {fullName: "memo.FKCascades", passByVal: true},
 		"ExplainOptions":      {fullName: "tree.ExplainOptions", passByVal: true},
 		"StatementType":       {fullName: "tree.StatementType", passByVal: true},
 		"ShowTraceType":       {fullName: "tree.ShowTraceType", passByVal: true},

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
 	"github.com/pmezard/go-difflib/difflib"
@@ -188,6 +189,9 @@ type Flags struct {
 	// File specifies the name of the file to import. This field is only used by
 	// the import command.
 	File string
+
+	// CascadeLevels limits the depth of recursive cascades for build-cascades.
+	CascadeLevels int
 }
 
 // New constructs a new instance of the OptTester for the given SQL statement.
@@ -237,6 +241,11 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 //
 //    Builds an expression tree from a SQL query, fully optimizes it using the
 //    memo, and then outputs the lowest cost tree.
+//
+//  - build-cascades [flags]
+//
+//    Builds a query and then recursively builds cascading queries. Outputs all
+//    unoptimized plans.
 //
 //  - optsteps [flags]
 //
@@ -346,6 +355,9 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 //  - file: used to set the name of the file to be imported. This is used by
 //    the import command.
 //
+//  - cascade-levels: used to limit the depth of recursive cascades for
+//    build-cascades.
+//
 func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 	// Allow testcases to override the flags.
 	for _, a := range d.CmdArgs {
@@ -419,6 +431,55 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 		}
 		ot.postProcess(tb, d, e)
 		return ot.FormatExpr(e)
+
+	case "build-cascades":
+		o := ot.makeOptimizer()
+		o.DisableOptimizations()
+		if err := ot.buildExpr(o.Factory()); err != nil {
+			d.Fatalf(tb, "%+v", err)
+		}
+		e := o.Memo().RootExpr()
+
+		var buildCascades func(e opt.Expr, tp treeprinter.Node, level int)
+		buildCascades = func(e opt.Expr, tp treeprinter.Node, level int) {
+			if ot.Flags.CascadeLevels != 0 && level > ot.Flags.CascadeLevels {
+				return
+			}
+			if opt.IsMutationOp(e) {
+				p := e.Private().(*memo.MutationPrivate)
+
+				for _, c := range p.FKCascades {
+					// We use the same memo to build the cascade. This makes the entire
+					// tree easier to read (e.g. the column IDs won't overlap).
+					cascade, err := c.Builder.Build(
+						context.Background(),
+						&ot.semaCtx,
+						&ot.evalCtx,
+						ot.catalog,
+						o.Factory(),
+						c.WithID,
+						e.Child(0).(memo.RelExpr).Relational(),
+						c.OldValues,
+						c.NewValues,
+					)
+					if err != nil {
+						d.Fatalf(tb, "error building cascade: %+v", err)
+					}
+					n := tp.Child("cascade")
+					n.Child(strings.TrimRight(ot.FormatExpr(cascade), "\n"))
+					buildCascades(cascade, n, level+1)
+				}
+			}
+			for i := 0; i < e.ChildCount(); i++ {
+				buildCascades(e.Child(i), tp, level)
+			}
+		}
+		tp := treeprinter.New()
+		root := tp.Child("root")
+		root.Child(strings.TrimRight(ot.FormatExpr(e), "\n"))
+		buildCascades(e, root, 1)
+
+		return tp.String()
 
 	case "optsteps":
 		result, err := ot.OptSteps()
@@ -696,6 +757,16 @@ func (f *Flags) Set(arg datadriven.CmdArg) error {
 			return fmt.Errorf("file requires one argument")
 		}
 		f.File = arg.Vals[0]
+
+	case "cascade-levels":
+		if len(arg.Vals) != 1 {
+			return fmt.Errorf("cascade-levels requires a single argument")
+		}
+		levels, err := strconv.ParseInt(arg.Vals[0], 10, 64)
+		if err != nil {
+			return errors.Wrap(err, "cascade-levels")
+		}
+		f.CascadeLevels = int(levels)
 
 	default:
 		return fmt.Errorf("unknown argument: %s", arg.Key)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -947,7 +947,7 @@ func (ef *execFactory) ConstructWindow(root exec.Node, wi exec.WindowInfo) (exec
 
 // ConstructPlan is part of the exec.Factory interface.
 func (ef *execFactory) ConstructPlan(
-	root exec.Node, subqueries []exec.Subquery, postqueries []exec.Node,
+	root exec.Node, subqueries []exec.Subquery, cascades []exec.Cascade, checks []exec.Node,
 ) (exec.Plan, error) {
 	// No need to spool at the root.
 	if spool, ok := root.(*spoolNode); ok {
@@ -983,10 +983,11 @@ func (ef *execFactory) ConstructPlan(
 			out.plan = in.Root.(planNode)
 		}
 	}
-	if len(postqueries) > 0 {
-		res.postqueryPlans = make([]postquery, len(postqueries))
-		for i := range res.postqueryPlans {
-			res.postqueryPlans[i].plan = postqueries[i].(planNode)
+	res.cascades = cascades
+	if len(checks) > 0 {
+		res.checkPlans = make([]checkPlan, len(checks))
+		for i := range checks {
+			res.checkPlans[i].plan = checks[i].(planNode)
 		}
 	}
 
@@ -1139,12 +1140,13 @@ func (ef *execFactory) ConstructExplain(
 	switch options.Mode {
 	case tree.ExplainDistSQL:
 		return &explainDistSQLNode{
-			options:        options,
-			plan:           p.plan,
-			subqueryPlans:  p.subqueryPlans,
-			postqueryPlans: p.postqueryPlans,
-			analyze:        analyzeSet,
-			stmtType:       stmtType,
+			options:       options,
+			plan:          p.plan,
+			subqueryPlans: p.subqueryPlans,
+			cascades:      p.cascades,
+			checkPlans:    p.checkPlans,
+			analyze:       analyzeSet,
+			stmtType:      stmtType,
 		}, nil
 
 	case tree.ExplainVec:
@@ -1164,7 +1166,8 @@ func (ef *execFactory) ConstructExplain(
 			options,
 			p.plan,
 			p.subqueryPlans,
-			p.postqueryPlans,
+			p.cascades,
+			p.checkPlans,
 			stmtType,
 		)
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -526,7 +526,7 @@ var varGen = map[string]sessionVar{
 	`experimental_optimizer_foreign_key_cascades`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`experimental_optimizer_foreign_key_cascades`),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
-			b, err := parseBoolVar("optimizer_foreign_key_cascades", s)
+			b, err := parseBoolVar("experimental_optimizer_foreign_key_cascades", s)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Prototype for optimizer-driven cascades; see the accompanying RFC in #48053.

This is split into a few commits for the various areas.

This prototype implements most of the infrastructure in the RFC but only implements ON DELETE CASCADE (for other actions or update cascades it falls back on the legacy path). Moreover, the execution code is incomplete and does not allow the cascade itself to have more checks or cascades. The feature is behind the `experimental_optimizer_foreign_key_cascades` setting (off by default).

Release note: None
