### PR TITLE
rowexec: change lookup join batch size to be specified in bytes

### DIFF
--- a/pkg/sql/rowexec/joinreader_strategies.go
+++ b/pkg/sql/rowexec/joinreader_strategies.go
@@ -29,6 +29,8 @@ type defaultSpanGenerator struct {
 
 	indexKeyRow          sqlbase.EncDatumRow
 	keyToInputRowIndices map[string][]int
+
+	scratchSpans roachpb.Spans
 }
 
 // Generate spans for a given row.
@@ -69,7 +71,7 @@ func (g *defaultSpanGenerator) generateSpans(rows []sqlbase.EncDatumRow) (roachp
 	}
 	// We maintain a map from index key to the corresponding input rows so we can
 	// join the index results to the inputs.
-	var spans roachpb.Spans
+	g.scratchSpans = g.scratchSpans[:0]
 	for i, inputRow := range rows {
 		if g.hasNullLookupColumn(inputRow) {
 			continue
@@ -80,15 +82,18 @@ func (g *defaultSpanGenerator) generateSpans(rows []sqlbase.EncDatumRow) (roachp
 		}
 		inputRowIndices := g.keyToInputRowIndices[string(generatedSpan.Key)]
 		if inputRowIndices == nil {
-			spans = g.spanBuilder.MaybeSplitSpanIntoSeparateFamilies(
-				spans, generatedSpan, len(g.lookupCols), containsNull)
+			g.scratchSpans = g.spanBuilder.MaybeSplitSpanIntoSeparateFamilies(
+				g.scratchSpans, generatedSpan, len(g.lookupCols), containsNull)
 		}
 		g.keyToInputRowIndices[string(generatedSpan.Key)] = append(inputRowIndices, i)
 	}
-	return spans, nil
+	return g.scratchSpans, nil
 }
 
 type joinReaderStrategy interface {
+	// getLookupRowsBatchSizeHint returns the size in bytes of the batch of lookup
+	// rows.
+	getLookupRowsBatchSizeHint() int64
 	// processLookupRows consumes the rows the joinReader has buffered and should
 	// return the lookup spans.
 	processLookupRows(rows []sqlbase.EncDatumRow) (roachpb.Spans, error)
@@ -139,6 +144,15 @@ type joinReaderNoOrderingStrategy struct {
 		matchingInputRowIndices       []int
 		lookedUpRow                   sqlbase.EncDatumRow
 	}
+}
+
+// getLookupRowsBatchSizeHint returns the batch size for the join reader no
+// ordering strategy. This number was chosen by running TPCH queries 7, 9, 10,
+// and 11 with varying batch sizes and choosing the smallest batch size that
+// offered a significant performance improvement. Larger batch sizes offered
+// small to no marginal improvements.
+func (s *joinReaderNoOrderingStrategy) getLookupRowsBatchSizeHint() int64 {
+	return 2 << 20 /* 2 MiB */
 }
 
 func (s *joinReaderNoOrderingStrategy) processLookupRows(
@@ -292,6 +306,12 @@ type joinReaderOrderingStrategy struct {
 		// match means that there's no need to output an outer or anti join row.
 		seenMatch bool
 	}
+}
+
+func (s *joinReaderOrderingStrategy) getLookupRowsBatchSizeHint() int64 {
+	// TODO(asubiotto): Eventually we might want to adjust this batch size
+	//  dynamically based on whether the result row container spilled or not.
+	return 10 << 10 /* 10 KiB */
 }
 
 func (s *joinReaderOrderingStrategy) processLookupRows(

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -451,7 +451,7 @@ func TestJoinReader(t *testing.T) {
 					}
 
 					// Set a lower batch size to force multiple batches.
-					jr.(*joinReader).SetBatchSize(3 /* batchSize */)
+					jr.(*joinReader).SetBatchSizeBytes(int64(encRows[0].Size() * 3))
 
 					jr.Run(ctx)
 

--- a/pkg/sql/rowexec/utils_test.go
+++ b/pkg/sql/rowexec/utils_test.go
@@ -60,7 +60,7 @@ func runProcessorTest(
 	switch pt := p.(type) {
 	case *joinReader:
 		// Reduce batch size to exercise batching logic.
-		pt.SetBatchSize(2 /* batchSize */)
+		pt.SetBatchSizeBytes(2 * int64(inputRows[0].Size()))
 	case *indexJoiner:
 		//	Reduce batch size to exercise batching logic.
 		pt.SetBatchSize(2 /* batchSize */)


### PR DESCRIPTION
The previous batch size of 100 rows was overly defensive in order to protect
against result memory blowup. Since the addition of TargetBytes to the roachpb
API, a result will no longer take more than 10MiB. Having a higher batch size
allows us to amortize the lookup cost.

The concern with a larger batch size is no longer whether the results will
cause a memory blowup, but whether the results need to be spilled to disk.
A variation of TPCH Q10 which has a lookup join with a ratio of 8 result bytes
per lookup byte to determine that 6MiB was a good default batch size. However,
since this ratio changes based on the query and lookup columns, we eventually
will want to make this lookup batch size dynamic.

With the new default of 6MiB, the TPCH Q10 variation shows a 15% improvement
on local lookups (2.8s v 3.3s) and an 88% improvement (11s vs 97s) with an
artificial 150ms latency injected into kvfetcher fetches.

Release note (performance improvement): lookup join performance has been
improved.

Closes #39471