### PR TITLE
sql: move more name resolution methods to UnresolvedObjectName

### DIFF
--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -30,10 +30,12 @@ type createSequenceNode struct {
 }
 
 func (p *planner) CreateSequence(ctx context.Context, n *tree.CreateSequence) (planNode, error) {
-	dbDesc, err := p.ResolveUncachedDatabase(ctx, &n.Name)
+	un := n.Name.ToUnresolvedObjectName()
+	dbDesc, prefix, err := p.ResolveUncachedDatabase(ctx, un)
 	if err != nil {
 		return nil, err
 	}
+	n.Name.ObjectNamePrefix = prefix
 
 	if err := p.CheckPrivilege(ctx, dbDesc, privilege.CREATE); err != nil {
 		return nil, err

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -83,17 +83,21 @@ func (n *renameTableNode) startExec(params runParams) error {
 	newTn := n.newTn
 	tableDesc := n.tableDesc
 
-	prevDbDesc, err := p.ResolveUncachedDatabase(ctx, oldTn)
+	oldUn := oldTn.ToUnresolvedObjectName()
+	prevDbDesc, prefix, err := p.ResolveUncachedDatabase(ctx, oldUn)
 	if err != nil {
 		return err
 	}
+	oldTn.ObjectNamePrefix = prefix
 
 	// Check if target database exists.
 	// We also look at uncached descriptors here.
-	targetDbDesc, err := p.ResolveUncachedDatabase(ctx, newTn)
+	newUn := newTn.ToUnresolvedObjectName()
+	targetDbDesc, prefix, err := p.ResolveUncachedDatabase(ctx, newUn)
 	if err != nil {
 		return err
 	}
+	newTn.ObjectNamePrefix = prefix
 
 	if err := p.CheckPrivilege(ctx, targetDbDesc, privilege.CREATE); err != nil {
 		return err

--- a/pkg/sql/serial.go
+++ b/pkg/sql/serial.go
@@ -111,10 +111,13 @@ func (p *planner) processSerialInColumnDef(
 	// Here and below we skip the cache because name resolution using
 	// the cache does not work (well) if the txn retries and the
 	// descriptor was written already in an early txn attempt.
-	dbDesc, err := p.ResolveUncachedDatabase(ctx, seqName)
+	un := seqName.ToUnresolvedObjectName()
+	dbDesc, prefix, err := p.ResolveUncachedDatabase(ctx, un)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
+	seqName.ObjectNamePrefix = prefix
+
 	// Now skip over all names that are already taken.
 	nameBase := seqName.ObjectName
 	for i := 0; ; i++ {


### PR DESCRIPTION
More work for #34240.

This PR moves some more name resolution methods to operate on
UnresolvedObjectName.

Release note: None