### PR TITLE
sql: add rule to simplify comparison filters on same vars

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -763,4 +763,3 @@ EXPLAIN (VERBOSE) SELECT t0.c0 FROM t0 WHERE t0.c0 BETWEEN t0.c0 AND INTERVAL '-
 scan  ·            ·                     (c0)  ·
 ·     table        t0@t0_c0_key          ·     ·
 ·     spans        /!NULL-/-1/PrefixEnd  ·     ·
-·     filter       c0 >= c0              ·     ·

--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -22,7 +22,7 @@
 (Join
     $left:*
     $right:*
-    $on:[ ... (FiltersItem (And | True | False | Null)) ... ] & ^(IsFilterFalse $on)
+    $on:[ ... $item:(FiltersItem (And | True | False | Null | Or )) & ^(IsUnsimplifiableOr $item) ... ] & ^(IsFilterFalse $on)
     $private:*
 )
 =>

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -366,3 +366,31 @@
         (Array [] (ArrayType $requestedCol))
     ]
 )
+
+# SimplifySameVarEqualities converts `x = x` and other equality
+# comparisons into `x IS NOT NULL OR NULL`. The `OR NULL` is necessary
+# when x is NULL.
+[SimplifySameVarEqualities, Normalize]
+(Eq | Le | Ge
+    $left:(Variable)
+    $right:(Variable) & (VarsAreSame $left $right)
+)
+=>
+(Or
+    (IsNot $left (Null $typ:(TypeOf $left)))
+    (Null $typ)
+)
+
+# SimplifySameVarInequalities converts `x != x` and other inequality
+# comparisons into `x IS NULL AND NULL`. The `AND NULL` is necessary
+# when x is NULL.
+[SimplifySameVarInequalities, Normalize]
+(Ne | Lt | Gt
+    $left:(Variable)
+    $right:(Variable) & (VarsAreSame $left $right)
+)
+=>
+(And
+    (Is $left (Null $typ:(TypeOf $left)))
+    (Null $typ)
+)

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -8,6 +8,7 @@
 #   - Removes True operands
 #   - Replaces the Filters operator with False if any operand is False or Null
 #   - Flattens nested And operands by merging their conditions into parent
+#   - Simplifies Or operands where one side is a Null to the other side
 #
 # Note that the Null handling behavior is different than the SimplifyAnd rules,
 # because Filters only appears as a Select or Join filter condition, both of
@@ -15,7 +16,7 @@
 [SimplifySelectFilters, Normalize, HighPriority]
 (Select
     $input:*
-    $filters:[ ... (FiltersItem (And | True | False | Null)) ... ] & ^(IsFilterFalse $filters)
+    $filters:[ ... $item:(FiltersItem (And | True | False | Null | Or )) & ^(IsUnsimplifiableOr $item) ... ] & ^(IsFilterFalse $filters)
 )
 =>
 (Select

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -2311,40 +2311,45 @@ project
 
 # With an ordering.
 norm expect=TryDecorrelateScalarGroupBy
-SELECT i, ARRAY(SELECT y FROM xy WHERE xy.y = a.k OR xy.y = NULL ORDER BY y) FROM a
+SELECT i, ARRAY(SELECT y FROM xy WHERE xy.y = a.k OR xy.y IS NULL ORDER BY y) FROM a
 ----
 project
  ├── columns: i:2 array:9
  ├── group-by
- │    ├── columns: k:1!null i:2 y:7 array_agg:10
+ │    ├── columns: k:1!null i:2 canary:10 array_agg:11
  │    ├── grouping columns: k:1!null
  │    ├── internal-ordering: +7
  │    ├── key: (1)
- │    ├── fd: (1)-->(2,7,10)
+ │    ├── fd: (1)-->(2,10,11)
  │    ├── sort
- │    │    ├── columns: k:1!null i:2 y:7
+ │    │    ├── columns: k:1!null i:2 y:7 canary:10
  │    │    ├── fd: (1)-->(2)
  │    │    ├── ordering: +7
  │    │    └── left-join (cross)
- │    │         ├── columns: k:1!null i:2 y:7
+ │    │         ├── columns: k:1!null i:2 y:7 canary:10
  │    │         ├── fd: (1)-->(2)
  │    │         ├── scan a
  │    │         │    ├── columns: k:1!null i:2
  │    │         │    ├── key: (1)
  │    │         │    └── fd: (1)-->(2)
- │    │         ├── scan xy
- │    │         │    └── columns: y:7
+ │    │         ├── project
+ │    │         │    ├── columns: canary:10!null y:7
+ │    │         │    ├── fd: ()-->(10)
+ │    │         │    ├── scan xy
+ │    │         │    │    └── columns: y:7
+ │    │         │    └── projections
+ │    │         │         └── true [as=canary:10]
  │    │         └── filters
- │    │              └── (y:7 = k:1) OR NULL [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ])]
+ │    │              └── (y:7 = k:1) OR (y:7 IS NULL) [outer=(1,7)]
  │    └── aggregations
- │         ├── array-agg [as=array_agg:10, outer=(7)]
+ │         ├── array-agg [as=array_agg:11, outer=(7)]
  │         │    └── y:7
  │         ├── const-agg [as=i:2, outer=(2)]
  │         │    └── i:2
- │         └── any-not-null-agg [as=y:7, outer=(7)]
- │              └── y:7
+ │         └── any-not-null-agg [as=canary:10, outer=(10)]
+ │              └── canary:10
  └── projections
-      └── COALESCE(CASE WHEN y:7 IS NOT NULL THEN array_agg:10 END, ARRAY[]) [as=array:9, outer=(7,10)]
+      └── COALESCE(CASE WHEN canary:10 IS NOT NULL THEN array_agg:11 END, ARRAY[]) [as=array:9, outer=(10,11)]
 
 # Nest scalar decorrelation within scalar decorrelation, using IS NULL to force
 # use of left joins.

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -361,7 +361,7 @@ project
  │    ├── scan a
  │    │    └── columns: f:3
  │    └── filters
- │         └── (f:3 + 1.0) = (f:3 + 1.0) [outer=(3)]
+ │         └── (f:3 + 1.0) IS DISTINCT FROM CAST(NULL AS FLOAT8) [outer=(3)]
  └── projections
       └── f:3 + 1.0 [as=expr:6, outer=(3)]
 

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -2060,8 +2060,8 @@ full-join (hash)
  │    └── fd: (6)-->(7-10)
  └── filters
       ├── a.k:1 = a2.k:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-      ├── a.f:3 = a.f:3 [outer=(3), constraints=(/3: (/NULL - ])]
-      └── a2.f:8 = a2.f:8 [outer=(8), constraints=(/8: (/NULL - ])]
+      ├── a.f:3 IS DISTINCT FROM CAST(NULL AS FLOAT8) [outer=(3), constraints=(/3: (/NULL - ]; tight)]
+      └── a2.f:8 IS DISTINCT FROM CAST(NULL AS FLOAT8) [outer=(8), constraints=(/8: (/NULL - ]; tight)]
 
 # Can't simplify: equality conditions have columns from different tables.
 norm expect-not=(SimplifyRightJoinWithFilters,SimplifyLeftJoinWithFilters)

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1797,3 +1797,153 @@ project
  │    └── filters (true)
  └── projections
       └── array:64 [as=array:66, outer=(64)]
+
+# --------------------------------------------------
+# SimplifySameVarEqualities
+# --------------------------------------------------
+
+norm expect=(SimplifySameVarEqualities,SimplifySelectFilters)
+SELECT k FROM a WHERE k = k
+----
+scan a
+ ├── columns: k:1!null
+ └── key: (1)
+
+norm expect=(SimplifySameVarEqualities,SimplifySelectFilters)
+SELECT k FROM a WHERE k >= k
+----
+scan a
+ ├── columns: k:1!null
+ └── key: (1)
+
+norm expect=(SimplifySameVarEqualities,SimplifySelectFilters)
+SELECT k FROM a WHERE k <= k
+----
+scan a
+ ├── columns: k:1!null
+ └── key: (1)
+
+norm expect=(SimplifySameVarEqualities,SimplifyJoinFilters)
+SELECT a.k FROM a FULL OUTER JOIN xy ON a.k = a.k
+----
+full-join (cross)
+ ├── columns: k:1
+ ├── scan a
+ │    ├── columns: k:1!null
+ │    └── key: (1)
+ ├── scan xy
+ └── filters
+      └── k:1 IS DISTINCT FROM CAST(NULL AS INT8) [outer=(1), constraints=(/1: (/NULL - ]; tight)]
+
+norm expect=(SimplifySameVarEqualities,SimplifyJoinFilters)
+SELECT a.k FROM a FULL OUTER JOIN xy ON a.k >= a.k
+----
+full-join (cross)
+ ├── columns: k:1
+ ├── scan a
+ │    ├── columns: k:1!null
+ │    └── key: (1)
+ ├── scan xy
+ └── filters
+      └── k:1 IS DISTINCT FROM CAST(NULL AS INT8) [outer=(1), constraints=(/1: (/NULL - ]; tight)]
+
+norm expect=(SimplifySameVarEqualities,SimplifyJoinFilters)
+SELECT a.k FROM a FULL OUTER JOIN xy ON a.k <= a.k
+----
+full-join (cross)
+ ├── columns: k:1
+ ├── scan a
+ │    ├── columns: k:1!null
+ │    └── key: (1)
+ ├── scan xy
+ └── filters
+      └── k:1 IS DISTINCT FROM CAST(NULL AS INT8) [outer=(1), constraints=(/1: (/NULL - ]; tight)]
+
+norm expect=SimplifySameVarEqualities
+SELECT k = k FROM a
+----
+project
+ ├── columns: "?column?":7
+ ├── scan a
+ │    ├── columns: k:1!null
+ │    └── key: (1)
+ └── projections
+      └── (k:1 IS DISTINCT FROM CAST(NULL AS INT8)) OR CAST(NULL AS INT8) [as="?column?":7, outer=(1)]
+
+# --------------------------------------------------
+# SimplifySameVarInequalities
+# --------------------------------------------------
+
+norm expect=(SimplifySameVarInequalities,SimplifySelectFilters)
+SELECT k FROM a WHERE k != k
+----
+values
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1)
+
+norm expect=(SimplifySameVarInequalities,SimplifySelectFilters)
+SELECT k FROM a WHERE k > k
+----
+values
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1)
+
+norm expect=(SimplifySameVarInequalities,SimplifySelectFilters)
+SELECT k FROM a WHERE k < k
+----
+values
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1)
+
+norm expect=(SimplifySameVarInequalities,SimplifyJoinFilters)
+SELECT a.k FROM a FULL OUTER JOIN xy ON a.k != a.k
+----
+full-join (cross)
+ ├── columns: k:1
+ ├── scan a
+ │    ├── columns: k:1!null
+ │    └── key: (1)
+ ├── scan xy
+ └── filters
+      └── false
+
+norm expect=(SimplifySameVarInequalities,SimplifyJoinFilters)
+SELECT a.k FROM a FULL OUTER JOIN xy ON a.k > a.k
+----
+full-join (cross)
+ ├── columns: k:1
+ ├── scan a
+ │    ├── columns: k:1!null
+ │    └── key: (1)
+ ├── scan xy
+ └── filters
+      └── false
+
+norm expect=(SimplifySameVarInequalities,SimplifyJoinFilters)
+SELECT a.k FROM a FULL OUTER JOIN xy ON a.k < a.k
+----
+full-join (cross)
+ ├── columns: k:1
+ ├── scan a
+ │    ├── columns: k:1!null
+ │    └── key: (1)
+ ├── scan xy
+ └── filters
+      └── false
+
+norm expect=SimplifySameVarInequalities
+SELECT k != k FROM a
+----
+project
+ ├── columns: "?column?":7
+ ├── scan a
+ │    ├── columns: k:1!null
+ │    └── key: (1)
+ └── projections
+      └── (k:1 IS NOT DISTINCT FROM CAST(NULL AS INT8)) AND CAST(NULL AS INT8) [as="?column?":7, outer=(1)]

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -46,6 +46,48 @@ values
  ├── key: ()
  └── fd: ()-->(1-7)
 
+norm expect=SimplifyJoinFilters
+SELECT * FROM a INNER JOIN xy ON x=1 OR NULL
+----
+inner-join (cross)
+ ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6!null y:7
+ ├── key: (1)
+ ├── fd: ()-->(6,7), (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── select
+ │    ├── columns: x:6!null y:7
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(6,7)
+ │    ├── scan xy
+ │    │    ├── columns: x:6!null y:7
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(7)
+ │    └── filters
+ │         └── x:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+ └── filters (true)
+
+norm expect-not=SimplifyJoinFilters
+SELECT * FROM a INNER JOIN xy ON x=1 OR k=1
+----
+inner-join (cross)
+ ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6!null y:7
+ ├── key: (1,6)
+ ├── fd: (1)-->(2-5), (6)-->(7)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── scan xy
+ │    ├── columns: x:6!null y:7
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
+ └── filters
+      └── (x:6 = 1) OR (k:1 = 1) [outer=(1,6)]
+
 norm expect=SimplifySelectFilters
 SELECT * FROM a WHERE i=1 AND Null
 ----
@@ -72,6 +114,35 @@ select
       ├── i:2 = 2 [outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
       ├── f:3 = 3.5 [outer=(3), constraints=(/3: [/3.5 - /3.5]; tight), fd=()-->(3)]
       └── s:4 = 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+
+norm expect=SimplifySelectFilters
+SELECT * FROM a WHERE k=1 OR NULL
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── k:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+
+norm expect-not=SimplifySelectFilters
+SELECT * FROM a WHERE k=1 OR i=2
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── (k:1 = 1) OR (i:2 = 2) [outer=(1,2)]
 
 norm expect=SimplifyJoinFilters
 SELECT * FROM a INNER JOIN xy ON (k=x AND i=y) AND true AND (f=3.5 AND s='foo')


### PR DESCRIPTION
Add rules for SELECT WHERE and JOIN ON filters that simplifies comparisons
on same variables to their filter equivalent.

Fixes #47717

Release note: None