### PR TITLE
roachtest: bump tpccbench/nodes=3/cpu=16 AWS warehouse estimate

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -340,8 +340,8 @@ func registerTPCC(r *testRegistry) {
 		Nodes: 3,
 		CPUs:  16,
 
-		LoadWarehouses: gceOrAws(cloud, 2000, 2500),
-		EstimatedMax:   gceOrAws(cloud, 1600, 2350),
+		LoadWarehouses: gceOrAws(cloud, 2000, 3000),
+		EstimatedMax:   gceOrAws(cloud, 1600, 2500),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes: 12,


### PR DESCRIPTION
Bump the estimated warehouse count to 2500 and the load
warehouse count to 3000.

I saw this pass 5 times today while loading 3500 warehouses,
so I'm now less concerned about the disk usage.