### PR TITLE
release-20.1: sql: fix TRUNCATE for temporary tables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -209,3 +209,21 @@ subtest table_with_on_commit
 
 statement error ON COMMIT can only be used on temporary tables
 CREATE TABLE a (a int) ON COMMIT PRESERVE ROWS
+
+subtest regression_47030
+
+statement ok
+CREATE TEMP TABLE regression_47030(c0 INT); INSERT INTO regression_47030 VALUES (1);
+
+query I
+SELECT * FROM regression_47030
+----
+1
+
+statement ok
+TRUNCATE regression_47030; INSERT INTO regression_47030 VALUES (2)
+
+query I
+SELECT * FROM regression_47030
+----
+2

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -189,8 +189,19 @@ func (p *planner) truncateTable(
 	//
 	// TODO(vivek): Fix properly along with #12123.
 	zoneKey := config.MakeZoneKey(uint32(tableDesc.ID))
-	nameKey := sqlbase.MakePublicTableNameKey(ctx, p.ExecCfg().Settings, tableDesc.ParentID, tableDesc.GetName()).Key()
-	key := sqlbase.MakePublicTableNameKey(ctx, p.ExecCfg().Settings, newTableDesc.ParentID, newTableDesc.Name).Key()
+	nameKey := sqlbase.MakeObjectNameKey(
+		ctx,
+		p.ExecCfg().Settings,
+		tableDesc.ParentID,
+		tableDesc.GetParentSchemaID(),
+		tableDesc.GetName(),
+	).Key()
+	key := sqlbase.MakeObjectNameKey(
+		ctx, p.ExecCfg().Settings,
+		newTableDesc.ParentID,
+		newTableDesc.GetParentSchemaID(),
+		newTableDesc.Name,
+	).Key()
 
 	b := &kv.Batch{}
 	// Use CPut because we want to remove a specific name -> id map.


### PR DESCRIPTION
Backport 1/1 commits from #47482.

/cc @cockroachdb/release

Not planning on pushing this until the clearance has been given.

---

Resolves https://github.com/cockroachdb/cockroach/issues/47030

Release note (bug fix): TRUNCATE can now run on temporary tables,
fixing a bug in 20.1.0 where temporary tables could not be truncated,
resulting in an error `unexpected value: nil`.
