### PR TITLE
release-20.1: sql: allow global access for some pg_catalog tables

### DIFF
--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -89,7 +89,7 @@ func (n *DropRoleNode) startExec(params runParams) error {
 	// Now check whether the user still has permission on any object in the database.
 
 	// First check all the databases.
-	if err := forEachDatabaseDesc(params.ctx, params.p, nil, /*nil prefix = all databases*/
+	if err := forEachDatabaseDesc(params.ctx, params.p, nil /*nil prefix = all databases*/, true, /* requiresPrivileges */
 		func(db *sqlbase.DatabaseDescriptor) error {
 			for _, u := range db.GetPrivileges().Users {
 				if _, ok := userNames[u.User]; ok {

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -964,16 +964,17 @@ var informationSchemaSchemataTable = virtualSchemaTable{
 https://www.postgresql.org/docs/9.5/infoschema-schemata.html`,
 	schema: vtable.InformationSchemaSchemata,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return forEachDatabaseDesc(ctx, p, dbContext, func(db *sqlbase.DatabaseDescriptor) error {
-			return forEachSchemaName(ctx, p, db, func(sc string) error {
-				return addRow(
-					tree.NewDString(db.Name), // catalog_name
-					tree.NewDString(sc),      // schema_name
-					tree.DNull,               // default_character_set_name
-					tree.DNull,               // sql_path
-				)
+		return forEachDatabaseDesc(ctx, p, dbContext, true, /* requiresPrivileges */
+			func(db *sqlbase.DatabaseDescriptor) error {
+				return forEachSchemaName(ctx, p, db, func(sc string) error {
+					return addRow(
+						tree.NewDString(db.Name), // catalog_name
+						tree.NewDString(sc),      // schema_name
+						tree.DNull,               // default_character_set_name
+						tree.DNull,               // sql_path
+					)
+				})
 			})
-		})
 	},
 }
 
@@ -990,30 +991,31 @@ CREATE TABLE information_schema.schema_privileges (
 	IS_GRANTABLE    STRING
 )`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return forEachDatabaseDesc(ctx, p, dbContext, func(db *sqlbase.DatabaseDescriptor) error {
-			return forEachSchemaName(ctx, p, db, func(scName string) error {
-				privs := db.Privileges.Show()
-				dbNameStr := tree.NewDString(db.Name)
-				scNameStr := tree.NewDString(scName)
-				// TODO(knz): This should filter for the current user, see
-				// https://github.com/cockroachdb/cockroach/issues/35572
-				for _, u := range privs {
-					userNameStr := tree.NewDString(u.User)
-					for _, priv := range u.Privileges {
-						if err := addRow(
-							userNameStr,           // grantee
-							dbNameStr,             // table_catalog
-							scNameStr,             // table_schema
-							tree.NewDString(priv), // privilege_type
-							tree.DNull,            // is_grantable
-						); err != nil {
-							return err
+		return forEachDatabaseDesc(ctx, p, dbContext, true, /* requiresPrivileges */
+			func(db *sqlbase.DatabaseDescriptor) error {
+				return forEachSchemaName(ctx, p, db, func(scName string) error {
+					privs := db.Privileges.Show()
+					dbNameStr := tree.NewDString(db.Name)
+					scNameStr := tree.NewDString(scName)
+					// TODO(knz): This should filter for the current user, see
+					// https://github.com/cockroachdb/cockroach/issues/35572
+					for _, u := range privs {
+						userNameStr := tree.NewDString(u.User)
+						for _, priv := range u.Privileges {
+							if err := addRow(
+								userNameStr,           // grantee
+								dbNameStr,             // table_catalog
+								scNameStr,             // table_schema
+								tree.NewDString(priv), // privilege_type
+								tree.DNull,            // is_grantable
+							); err != nil {
+								return err
+							}
 						}
 					}
-				}
-				return nil
+					return nil
+				})
 			})
-		})
 	},
 }
 
@@ -1273,23 +1275,24 @@ CREATE TABLE information_schema.user_privileges (
 	IS_GRANTABLE   STRING
 )`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return forEachDatabaseDesc(ctx, p, dbContext, func(dbDesc *DatabaseDescriptor) error {
-			dbNameStr := tree.NewDString(dbDesc.Name)
-			for _, u := range []string{security.RootUser, sqlbase.AdminRole} {
-				grantee := tree.NewDString(u)
-				for _, p := range privilege.List(privilege.ByValue[:]).SortedNames() {
-					if err := addRow(
-						grantee,            // grantee
-						dbNameStr,          // table_catalog
-						tree.NewDString(p), // privilege_type
-						tree.DNull,         // is_grantable
-					); err != nil {
-						return err
+		return forEachDatabaseDesc(ctx, p, dbContext, true, /* requiresPrivileges */
+			func(dbDesc *DatabaseDescriptor) error {
+				dbNameStr := tree.NewDString(dbDesc.Name)
+				for _, u := range []string{security.RootUser, sqlbase.AdminRole} {
+					grantee := tree.NewDString(u)
+					for _, p := range privilege.List(privilege.ByValue[:]).SortedNames() {
+						if err := addRow(
+							grantee,            // grantee
+							dbNameStr,          // table_catalog
+							tree.NewDString(p), // privilege_type
+							tree.DNull,         // is_grantable
+						); err != nil {
+							return err
+						}
 					}
 				}
-			}
-			return nil
-		})
+				return nil
+			})
 	},
 }
 
@@ -1463,23 +1466,35 @@ func forEachSchemaName(
 
 // forEachDatabaseDesc calls a function for the given DatabaseDescriptor, or if
 // it is nil, retrieves all database descriptors and iterates through them in
-// lexicographical order with respect to their name. The function is only called
-// if the user has privileges on the database.
+// lexicographical order with respect to their name. If privileges are required,
+// the function is only called if the user has privileges on the database.
 func forEachDatabaseDesc(
 	ctx context.Context,
 	p *planner,
 	dbContext *DatabaseDescriptor,
+	requiresPrivileges bool,
 	fn func(*sqlbase.DatabaseDescriptor) error,
 ) error {
 	var dbDescs []*sqlbase.DatabaseDescriptor
-	dbDescs, err := p.Tables().getAllDatabaseDescriptors(ctx, p.txn)
-	if err != nil {
-		return err
+	if dbContext == nil {
+		allDbDescs, err := p.Tables().getAllDatabaseDescriptors(ctx, p.txn)
+		if err != nil {
+			return err
+		}
+		dbDescs = allDbDescs
+	} else {
+		// We can't just use dbContext here because we need to fetch the descriptor
+		// with privileges from kv.
+		fetchedDbDesc, err := getDatabaseDescriptorsFromIDs(ctx, p.txn, []sqlbase.ID{dbContext.ID})
+		if err != nil {
+			return err
+		}
+		dbDescs = fetchedDbDesc
 	}
 
 	// Ignore databases that the user cannot see.
 	for _, dbDesc := range dbDescs {
-		if (dbContext == nil || dbContext.ID == dbDesc.ID) && userCanSeeDatabase(ctx, p, dbDesc) {
+		if !requiresPrivileges || userCanSeeDatabase(ctx, p, dbDesc) {
 			if err := fn(dbDesc); err != nil {
 				return err
 			}

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -730,6 +730,18 @@ WHERE collname='en-US'
 oid         collname  collnamespace  collowner  collencoding  collcollate  collctype
 3903121477  en-US     1307062959     NULL       6             NULL         NULL
 
+user testuser
+
+# Should be globally visible
+query OT colnames
+SELECT oid, collname FROM pg_collation
+WHERE collname='en-US'
+----
+oid         collname
+3903121477  en-US
+
+user root
+
 ## pg_catalog.pg_constraint
 ##
 ## These order of this virtual table is non-deterministic, so all queries must
@@ -1266,6 +1278,19 @@ oid   typname        typndims  typcollation  typdefaultbin  typdefault  typacl
 4089  regnamespace   0         0             NULL           NULL        NULL
 4090  _regnamespace  0         0             NULL           NULL        NULL
 
+user testuser
+
+# Should be globally visible
+query OTOIBT colnames
+SELECT oid, typname, typowner, typlen, typbyval, typtype
+FROM pg_catalog.pg_type WHERE typname = 'uuid'
+ORDER BY oid
+----
+oid    typname  typowner  typlen  typbyval  typtype
+2950   uuid     NULL      16      true      b
+
+user root
+
 ## pg_catalog.pg_proc
 
 query TOOOTTO colnames
@@ -1338,6 +1363,19 @@ WHERE proname='json_extract_path'
 ----
 proname            provariadic  pronargs  prorettype  proargtypes  proargmodes
 json_extract_path  25           2         3802        3802 25      {i,v}
+
+user testuser
+
+# Should be globally visible
+query TOIOTT colnames
+SELECT proname, provariadic, pronargs, prorettype, proargtypes, proargmodes
+FROM pg_catalog.pg_proc
+WHERE proname='json_extract_path'
+----
+proname            provariadic  pronargs  prorettype  proargtypes  proargmodes
+json_extract_path  25           2         3802        3802 25      {i,v}
+
+user root
 
 ## pg_catalog.pg_range
 query IIIIII colnames

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -774,7 +774,7 @@ CREATE TABLE pg_catalog.pg_collation (
 )`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
-		return forEachDatabaseDesc(ctx, p, dbContext, func(db *DatabaseDescriptor) error {
+		return forEachDatabaseDesc(ctx, p, dbContext, false /* requiresPrivileges */, func(db *DatabaseDescriptor) error {
 			namespaceOid := h.NamespaceOid(db, pgCatalogName)
 			for _, tag := range collate.Supported() {
 				collName := tag.String()
@@ -1076,26 +1076,27 @@ CREATE TABLE pg_catalog.pg_database (
 	datacl STRING[]
 )`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return forEachDatabaseDesc(ctx, p, nil /*all databases*/, func(db *sqlbase.DatabaseDescriptor) error {
-			return addRow(
-				defaultOid(db.ID),      // oid
-				tree.NewDName(db.Name), // datname
-				tree.DNull,             // datdba
-				// If there is a change in encoding value for the database we must update
-				// the definitions of getdatabaseencoding within pg_builtin.
-				builtins.DatEncodingUTFId,  // encoding
-				builtins.DatEncodingEnUTF8, // datcollate
-				builtins.DatEncodingEnUTF8, // datctype
-				tree.DBoolFalse,            // datistemplate
-				tree.DBoolTrue,             // datallowconn
-				negOneVal,                  // datconnlimit
-				oidZero,                    // datlastsysoid
-				tree.DNull,                 // datfrozenxid
-				tree.DNull,                 // datminmxid
-				oidZero,                    // dattablespace
-				tree.DNull,                 // datacl
-			)
-		})
+		return forEachDatabaseDesc(ctx, p, nil /*all databases*/, true, /* requiresPrivileges */
+			func(db *sqlbase.DatabaseDescriptor) error {
+				return addRow(
+					defaultOid(db.ID),      // oid
+					tree.NewDName(db.Name), // datname
+					tree.DNull,             // datdba
+					// If there is a change in encoding value for the database we must update
+					// the definitions of getdatabaseencoding within pg_builtin.
+					builtins.DatEncodingUTFId,  // encoding
+					builtins.DatEncodingEnUTF8, // datcollate
+					builtins.DatEncodingEnUTF8, // datctype
+					tree.DBoolFalse,            // datistemplate
+					tree.DBoolTrue,             // datallowconn
+					negOneVal,                  // datconnlimit
+					oidZero,                    // datlastsysoid
+					tree.DNull,                 // datfrozenxid
+					tree.DNull,                 // datminmxid
+					oidZero,                    // dattablespace
+					tree.DNull,                 // datacl
+				)
+			})
 	},
 }
 
@@ -1727,16 +1728,17 @@ CREATE TABLE pg_catalog.pg_namespace (
 )`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
-		return forEachDatabaseDesc(ctx, p, dbContext, func(db *sqlbase.DatabaseDescriptor) error {
-			return forEachSchemaName(ctx, p, db, func(s string) error {
-				return addRow(
-					h.NamespaceOid(db, s), // oid
-					tree.NewDString(s),    // nspname
-					tree.DNull,            // nspowner
-					tree.DNull,            // nspacl
-				)
+		return forEachDatabaseDesc(ctx, p, dbContext, true, /* requiresPrivileges */
+			func(db *sqlbase.DatabaseDescriptor) error {
+				return forEachSchemaName(ctx, p, db, func(s string) error {
+					return addRow(
+						h.NamespaceOid(db, s), // oid
+						tree.NewDString(s),    // nspname
+						tree.DNull,            // nspowner
+						tree.DNull,            // nspacl
+					)
+				})
 			})
-		})
 	},
 }
 
@@ -1975,123 +1977,124 @@ CREATE TABLE pg_catalog.pg_proc (
 )`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
-		return forEachDatabaseDesc(ctx, p, dbContext, func(db *DatabaseDescriptor) error {
-			nspOid := h.NamespaceOid(db, pgCatalogName)
-			for _, name := range builtins.AllBuiltinNames {
-				// parser.Builtins contains duplicate uppercase and lowercase keys.
-				// Only return the lowercase ones for compatibility with postgres.
-				var first rune
-				for _, c := range name {
-					first = c
-					break
-				}
-				if unicode.IsUpper(first) {
-					continue
-				}
-				props, overloads := builtins.GetBuiltinProperties(name)
-				isAggregate := props.Class == tree.AggregateClass
-				isWindow := props.Class == tree.WindowClass
-				for _, builtin := range overloads {
-					dName := tree.NewDName(name)
-					dSrc := tree.NewDString(name)
-
-					var retType tree.Datum
-					isRetSet := false
-					if fixedRetType := builtin.FixedReturnType(); fixedRetType != nil {
-						var retOid oid.Oid
-						if fixedRetType.Family() == types.TupleFamily && builtin.Generator != nil {
-							isRetSet = true
-							// Functions returning tables with zero, or more than one
-							// columns are marked to return "anyelement"
-							// (e.g. `unnest`)
-							retOid = oid.T_anyelement
-							if len(fixedRetType.TupleContents()) == 1 {
-								// Functions returning tables with exactly one column
-								// are marked to return the type of that column
-								// (e.g. `generate_series`).
-								retOid = fixedRetType.TupleContents()[0].Oid()
-							}
-						} else {
-							retOid = fixedRetType.Oid()
-						}
-						retType = tree.NewDOid(tree.DInt(retOid))
+		return forEachDatabaseDesc(ctx, p, dbContext, false, /* requiresPrivileges */
+			func(db *DatabaseDescriptor) error {
+				nspOid := h.NamespaceOid(db, pgCatalogName)
+				for _, name := range builtins.AllBuiltinNames {
+					// parser.Builtins contains duplicate uppercase and lowercase keys.
+					// Only return the lowercase ones for compatibility with postgres.
+					var first rune
+					for _, c := range name {
+						first = c
+						break
 					}
+					if unicode.IsUpper(first) {
+						continue
+					}
+					props, overloads := builtins.GetBuiltinProperties(name)
+					isAggregate := props.Class == tree.AggregateClass
+					isWindow := props.Class == tree.WindowClass
+					for _, builtin := range overloads {
+						dName := tree.NewDName(name)
+						dSrc := tree.NewDString(name)
 
-					argTypes := builtin.Types
-					dArgTypes := tree.NewDArray(types.Oid)
-					for _, argType := range argTypes.Types() {
-						if err := dArgTypes.Append(tree.NewDOid(tree.DInt(argType.Oid()))); err != nil {
+						var retType tree.Datum
+						isRetSet := false
+						if fixedRetType := builtin.FixedReturnType(); fixedRetType != nil {
+							var retOid oid.Oid
+							if fixedRetType.Family() == types.TupleFamily && builtin.Generator != nil {
+								isRetSet = true
+								// Functions returning tables with zero, or more than one
+								// columns are marked to return "anyelement"
+								// (e.g. `unnest`)
+								retOid = oid.T_anyelement
+								if len(fixedRetType.TupleContents()) == 1 {
+									// Functions returning tables with exactly one column
+									// are marked to return the type of that column
+									// (e.g. `generate_series`).
+									retOid = fixedRetType.TupleContents()[0].Oid()
+								}
+							} else {
+								retOid = fixedRetType.Oid()
+							}
+							retType = tree.NewDOid(tree.DInt(retOid))
+						}
+
+						argTypes := builtin.Types
+						dArgTypes := tree.NewDArray(types.Oid)
+						for _, argType := range argTypes.Types() {
+							if err := dArgTypes.Append(tree.NewDOid(tree.DInt(argType.Oid()))); err != nil {
+								return err
+							}
+						}
+
+						var argmodes tree.Datum
+						var variadicType tree.Datum
+						switch v := argTypes.(type) {
+						case tree.VariadicType:
+							if len(v.FixedTypes) == 0 {
+								argmodes = proArgModeVariadic
+							} else {
+								ary := tree.NewDArray(types.String)
+								for range v.FixedTypes {
+									if err := ary.Append(tree.NewDString("i")); err != nil {
+										return err
+									}
+								}
+								if err := ary.Append(tree.NewDString("v")); err != nil {
+									return err
+								}
+								argmodes = ary
+							}
+							variadicType = tree.NewDOid(tree.DInt(v.VarType.Oid()))
+						case tree.HomogeneousType:
+							argmodes = proArgModeVariadic
+							argType := types.Any
+							oid := argType.Oid()
+							variadicType = tree.NewDOid(tree.DInt(oid))
+						default:
+							argmodes = tree.DNull
+							variadicType = oidZero
+						}
+						err := addRow(
+							h.BuiltinOid(name, &builtin),            // oid
+							dName,                                   // proname
+							nspOid,                                  // pronamespace
+							tree.DNull,                              // proowner
+							oidZero,                                 // prolang
+							tree.DNull,                              // procost
+							tree.DNull,                              // prorows
+							variadicType,                            // provariadic
+							tree.DNull,                              // protransform
+							tree.MakeDBool(tree.DBool(isAggregate)), // proisagg
+							tree.MakeDBool(tree.DBool(isWindow)),    // proiswindow
+							tree.DBoolFalse,                         // prosecdef
+							tree.MakeDBool(tree.DBool(!props.Impure)), // proleakproof
+							tree.DBoolFalse,                      // proisstrict
+							tree.MakeDBool(tree.DBool(isRetSet)), // proretset
+							tree.DNull,                           // provolatile
+							tree.DNull,                           // proparallel
+							tree.NewDInt(tree.DInt(builtin.Types.Length())), // pronargs
+							tree.NewDInt(tree.DInt(0)),                      // pronargdefaults
+							retType,                                         // prorettype
+							tree.NewDOidVectorFromDArray(dArgTypes),         // proargtypes
+							tree.DNull,                                      // proallargtypes
+							argmodes,                                        // proargmodes
+							tree.DNull,                                      // proargnames
+							tree.DNull,                                      // proargdefaults
+							tree.DNull,                                      // protrftypes
+							dSrc,                                            // prosrc
+							tree.DNull,                                      // probin
+							tree.DNull,                                      // proconfig
+							tree.DNull,                                      // proacl
+						)
+						if err != nil {
 							return err
 						}
 					}
-
-					var argmodes tree.Datum
-					var variadicType tree.Datum
-					switch v := argTypes.(type) {
-					case tree.VariadicType:
-						if len(v.FixedTypes) == 0 {
-							argmodes = proArgModeVariadic
-						} else {
-							ary := tree.NewDArray(types.String)
-							for range v.FixedTypes {
-								if err := ary.Append(tree.NewDString("i")); err != nil {
-									return err
-								}
-							}
-							if err := ary.Append(tree.NewDString("v")); err != nil {
-								return err
-							}
-							argmodes = ary
-						}
-						variadicType = tree.NewDOid(tree.DInt(v.VarType.Oid()))
-					case tree.HomogeneousType:
-						argmodes = proArgModeVariadic
-						argType := types.Any
-						oid := argType.Oid()
-						variadicType = tree.NewDOid(tree.DInt(oid))
-					default:
-						argmodes = tree.DNull
-						variadicType = oidZero
-					}
-					err := addRow(
-						h.BuiltinOid(name, &builtin),            // oid
-						dName,                                   // proname
-						nspOid,                                  // pronamespace
-						tree.DNull,                              // proowner
-						oidZero,                                 // prolang
-						tree.DNull,                              // procost
-						tree.DNull,                              // prorows
-						variadicType,                            // provariadic
-						tree.DNull,                              // protransform
-						tree.MakeDBool(tree.DBool(isAggregate)), // proisagg
-						tree.MakeDBool(tree.DBool(isWindow)),    // proiswindow
-						tree.DBoolFalse,                         // prosecdef
-						tree.MakeDBool(tree.DBool(!props.Impure)), // proleakproof
-						tree.DBoolFalse,                      // proisstrict
-						tree.MakeDBool(tree.DBool(isRetSet)), // proretset
-						tree.DNull,                           // provolatile
-						tree.DNull,                           // proparallel
-						tree.NewDInt(tree.DInt(builtin.Types.Length())), // pronargs
-						tree.NewDInt(tree.DInt(0)),                      // pronargdefaults
-						retType,                                         // prorettype
-						tree.NewDOidVectorFromDArray(dArgTypes),         // proargtypes
-						tree.DNull,                                      // proallargtypes
-						argmodes,                                        // proargmodes
-						tree.DNull,                                      // proargnames
-						tree.DNull,                                      // proargdefaults
-						tree.DNull,                                      // protrftypes
-						dSrc,                                            // prosrc
-						tree.DNull,                                      // probin
-						tree.DNull,                                      // proconfig
-						tree.DNull,                                      // proacl
-					)
-					if err != nil {
-						return err
-					}
 				}
-			}
-			return nil
-		})
+				return nil
+			})
 	},
 }
 
@@ -2507,82 +2510,83 @@ CREATE TABLE pg_catalog.pg_type (
 )`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
-		return forEachDatabaseDesc(ctx, p, dbContext, func(db *DatabaseDescriptor) error {
-			nspOid := h.NamespaceOid(db, pgCatalogName)
+		return forEachDatabaseDesc(ctx, p, dbContext, false, /* requiresPrivileges */
+			func(db *DatabaseDescriptor) error {
+				nspOid := h.NamespaceOid(db, pgCatalogName)
 
-			for o, typ := range types.OidToType {
-				cat := typCategory(typ)
-				typType := typTypeBase
-				typElem := oidZero
-				typArray := oidZero
-				builtinPrefix := builtins.PGIOBuiltinPrefix(typ)
-				if typ.Family() == types.ArrayFamily {
-					switch typ.Oid() {
-					case oid.T_int2vector:
-						// IntVector needs a special case because it's a special snowflake
-						// type that behaves in some ways like a scalar type and in others
-						// like an array type.
-						typElem = tree.NewDOid(tree.DInt(oid.T_int2))
-						typArray = tree.NewDOid(tree.DInt(oid.T__int2vector))
-					case oid.T_oidvector:
-						// Same story as above for OidVector.
-						typElem = tree.NewDOid(tree.DInt(oid.T_oid))
-						typArray = tree.NewDOid(tree.DInt(oid.T__oidvector))
-					case oid.T_anyarray:
-						// AnyArray does not use a prefix or element type.
-					default:
-						builtinPrefix = "array_"
-						typElem = tree.NewDOid(tree.DInt(typ.ArrayContents().Oid()))
+				for o, typ := range types.OidToType {
+					cat := typCategory(typ)
+					typType := typTypeBase
+					typElem := oidZero
+					typArray := oidZero
+					builtinPrefix := builtins.PGIOBuiltinPrefix(typ)
+					if typ.Family() == types.ArrayFamily {
+						switch typ.Oid() {
+						case oid.T_int2vector:
+							// IntVector needs a special case because it's a special snowflake
+							// type that behaves in some ways like a scalar type and in others
+							// like an array type.
+							typElem = tree.NewDOid(tree.DInt(oid.T_int2))
+							typArray = tree.NewDOid(tree.DInt(oid.T__int2vector))
+						case oid.T_oidvector:
+							// Same story as above for OidVector.
+							typElem = tree.NewDOid(tree.DInt(oid.T_oid))
+							typArray = tree.NewDOid(tree.DInt(oid.T__oidvector))
+						case oid.T_anyarray:
+							// AnyArray does not use a prefix or element type.
+						default:
+							builtinPrefix = "array_"
+							typElem = tree.NewDOid(tree.DInt(typ.ArrayContents().Oid()))
+						}
+					} else {
+						typArray = tree.NewDOid(tree.DInt(types.MakeArray(typ).Oid()))
 					}
-				} else {
-					typArray = tree.NewDOid(tree.DInt(types.MakeArray(typ).Oid()))
-				}
-				if cat == typCategoryPseudo {
-					typType = typTypePseudo
-				}
-				typname := typ.PGName()
+					if cat == typCategoryPseudo {
+						typType = typTypePseudo
+					}
+					typname := typ.PGName()
 
-				if err := addRow(
-					tree.NewDOid(tree.DInt(o)), // oid
-					tree.NewDName(typname),     // typname
-					nspOid,                     // typnamespace
-					tree.DNull,                 // typowner
-					typLen(typ),                // typlen
-					typByVal(typ),              // typbyval
-					typType,                    // typtype
-					cat,                        // typcategory
-					tree.DBoolFalse,            // typispreferred
-					tree.DBoolTrue,             // typisdefined
-					typDelim,                   // typdelim
-					oidZero,                    // typrelid
-					typElem,                    // typelem
-					typArray,                   // typarray
+					if err := addRow(
+						tree.NewDOid(tree.DInt(o)), // oid
+						tree.NewDName(typname),     // typname
+						nspOid,                     // typnamespace
+						tree.DNull,                 // typowner
+						typLen(typ),                // typlen
+						typByVal(typ),              // typbyval
+						typType,                    // typtype
+						cat,                        // typcategory
+						tree.DBoolFalse,            // typispreferred
+						tree.DBoolTrue,             // typisdefined
+						typDelim,                   // typdelim
+						oidZero,                    // typrelid
+						typElem,                    // typelem
+						typArray,                   // typarray
 
-					// regproc references
-					h.RegProc(builtinPrefix+"in"),   // typinput
-					h.RegProc(builtinPrefix+"out"),  // typoutput
-					h.RegProc(builtinPrefix+"recv"), // typreceive
-					h.RegProc(builtinPrefix+"send"), // typsend
-					oidZero,                         // typmodin
-					oidZero,                         // typmodout
-					oidZero,                         // typanalyze
+						// regproc references
+						h.RegProc(builtinPrefix+"in"),   // typinput
+						h.RegProc(builtinPrefix+"out"),  // typoutput
+						h.RegProc(builtinPrefix+"recv"), // typreceive
+						h.RegProc(builtinPrefix+"send"), // typsend
+						oidZero,                         // typmodin
+						oidZero,                         // typmodout
+						oidZero,                         // typanalyze
 
-					tree.DNull,      // typalign
-					tree.DNull,      // typstorage
-					tree.DBoolFalse, // typnotnull
-					oidZero,         // typbasetype
-					negOneVal,       // typtypmod
-					zeroVal,         // typndims
-					typColl(typ, h), // typcollation
-					tree.DNull,      // typdefaultbin
-					tree.DNull,      // typdefault
-					tree.DNull,      // typacl
-				); err != nil {
-					return err
+						tree.DNull,      // typalign
+						tree.DNull,      // typstorage
+						tree.DBoolFalse, // typnotnull
+						oidZero,         // typbasetype
+						negOneVal,       // typtypmod
+						zeroVal,         // typndims
+						typColl(typ, h), // typcollation
+						tree.DNull,      // typdefaultbin
+						tree.DNull,      // typdefault
+						tree.DNull,      // typacl
+					); err != nil {
+						return err
+					}
 				}
-			}
-			return nil
-		})
+				return nil
+			})
 	},
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #47996.

/cc @cockroachdb/release

---

pg_collation, pg_proc, and pg_type were all
limiting the output to only include rows if the user had any privileges
on the database. In Postgres, this is not required.

Some tables in information_schema still do require the privilege check,
as well as pg_database and pg_namespace.

This commit also includes a small improvement to avoid fetching all
database descriptors unless they are all needed.

fixes #43177

Release note (sql change): The pg_collation, pg_proc, and pg_type tables
in pg_catalog no longer require privileges on any database in order for the
data to be visible.
