### PR TITLE
sql: allow for uncached resolution of type descriptors 

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -68,6 +68,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>20.1-2</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>20.1-3</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -62,7 +62,7 @@ type descriptorResolver struct {
 	objsByName map[sqlbase.ID]map[string]sqlbase.ID
 }
 
-// LookupSchema implements the tree.TableNameTargetResolver interface.
+// LookupSchema implements the tree.ObjectNameTargetResolver interface.
 func (r *descriptorResolver) LookupSchema(
 	_ context.Context, dbName, scName string,
 ) (bool, tree.SchemaMeta, error) {
@@ -75,7 +75,7 @@ func (r *descriptorResolver) LookupSchema(
 	return false, nil, nil
 }
 
-// LookupObject implements the tree.TableNameExistingResolver interface.
+// LookupObject implements the tree.ObjectNameExistingResolver interface.
 func (r *descriptorResolver) LookupObject(
 	_ context.Context, flags tree.ObjectLookupFlags, dbName, scName, obName string,
 ) (bool, tree.NameResolutionResult, error) {

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -278,7 +278,7 @@ func (r fkResolver) ObjectLookupFlags(required bool, requireMutable bool) tree.O
 	}
 }
 
-// Implements the tree.TableNameExistingResolver interface.
+// Implements the tree.ObjectNameExistingResolver interface.
 func (r fkResolver) LookupObject(
 	ctx context.Context, lookupFlags tree.ObjectLookupFlags, dbName, scName, obName string,
 ) (found bool, objMeta tree.NameResolutionResult, err error) {
@@ -297,7 +297,7 @@ func (r fkResolver) LookupObject(
 	return false, nil, errors.Errorf("referenced table %q not found in tables being imported (%s)", obName, suggestions)
 }
 
-// Implements the tree.TableNameTargetResolver interface.
+// Implements the tree.ObjectNameTargetResolver interface.
 func (r fkResolver) LookupSchema(
 	ctx context.Context, dbName, scName string,
 ) (found bool, scMeta tree.SchemaMeta, err error) {

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -62,6 +62,7 @@ const (
 	Version20_1
 	VersionStart20_2
 	VersionGeospatialType
+	VersionEnums
 
 	// Add new versions here (step one of two).
 )
@@ -473,6 +474,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// VersionGeospatialType enables the use of Geospatial features.
 		Key:     VersionGeospatialType,
 		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 2},
+	},
+	{
+		// VersionEnums enables the use of ENUM types.
+		Key:     VersionEnums,
+		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 3},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/clusterversion/versionkey_string.go
+++ b/pkg/clusterversion/versionkey_string.go
@@ -38,11 +38,12 @@ func _() {
 	_ = x[Version20_1-27]
 	_ = x[VersionStart20_2-28]
 	_ = x[VersionGeospatialType-29]
+	_ = x[VersionEnums-30]
 }
 
-const _VersionKey_name = "Version19_1VersionStart19_2VersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDsVersionHashShardedIndexesVersionCreateRolePrivilegeVersionStatementDiagnosticsSystemTablesVersionSchemaChangeJobVersionSavepointsVersionTimeTZTypeVersionTimePrecisionVersion20_1VersionStart20_2VersionGeospatialType"
+const _VersionKey_name = "Version19_1VersionStart19_2VersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDsVersionHashShardedIndexesVersionCreateRolePrivilegeVersionStatementDiagnosticsSystemTablesVersionSchemaChangeJobVersionSavepointsVersionTimeTZTypeVersionTimePrecisionVersion20_1VersionStart20_2VersionGeospatialTypeVersionEnums"
 
-var _VersionKey_index = [...]uint16{0, 11, 27, 49, 75, 109, 136, 176, 200, 211, 227, 258, 287, 322, 354, 380, 404, 441, 480, 499, 534, 559, 585, 624, 646, 663, 680, 700, 711, 727, 748}
+var _VersionKey_index = [...]uint16{0, 11, 27, 49, 75, 109, 136, 176, 200, 211, 227, 258, 287, 322, 354, 380, 404, 441, 480, 499, 534, 559, 585, 624, 646, 663, 680, 700, 711, 727, 748, 760}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -129,7 +129,12 @@ func (n *alterTableNode) startExec(params runParams) error {
 	descriptorChanged := false
 	origNumMutations := len(n.tableDesc.Mutations)
 	var droppedViews []string
-	tn := params.p.ResolvedName(n.n.Table)
+	resolved := params.p.ResolvedName(n.n.Table)
+	tn, ok := resolved.(*tree.TableName)
+	if !ok {
+		return errors.AssertionFailedf(
+			"%q was not resolved as a table but is %T", resolved, resolved)
+	}
 
 	for i, cmd := range n.n.Cmds {
 		telemetry.Inc(cmd.TelemetryCounter())

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -223,8 +223,15 @@ func (p *planner) MemberOfWithAdminOption(
 
 	// Lookup table version.
 	objDesc, err := p.PhysicalSchemaAccessor().GetObjectDesc(
-		ctx, p.txn, p.ExecCfg().Settings, p.ExecCfg().Codec, &roleMembersTableName,
-		p.ObjectLookupFlags(true /*required*/, false /*requireMutable*/))
+		ctx,
+		p.txn,
+		p.ExecCfg().Settings,
+		p.ExecCfg().Codec,
+		roleMembersTableName.Catalog(),
+		roleMembersTableName.Schema(),
+		roleMembersTableName.Table(),
+		p.ObjectLookupFlags(true /*required*/, false /*requireMutable*/),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -116,7 +116,7 @@ func newCopyMachine(
 	}()
 	c.parsingEvalCtx = c.p.EvalContext()
 
-	tableDesc, err := ResolveExistingObject(ctx, &c.p, &n.Table, tree.ObjectLookupFlagsWithRequired(), ResolveRequireTableDesc)
+	tableDesc, err := ResolveExistingTableObject(ctx, &c.p, &n.Table, tree.ObjectLookupFlagsWithRequired(), ResolveRequireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -77,7 +77,7 @@ func doCreateSequence(
 	context string,
 	dbDesc *DatabaseDescriptor,
 	schemaID sqlbase.ID,
-	name *ObjectName,
+	name *TableName,
 	isTemporary bool,
 	opts tree.SequenceOptions,
 	jobDesc string,

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -193,10 +193,16 @@ func getTableCreateParams(
 		tKey = sqlbase.NewTableKey(dbID, schemaID, tableName)
 	}
 
-	exists, _, err := sqlbase.LookupObjectID(params.ctx, params.p.txn, params.ExecCfg().Codec, dbID, schemaID, tableName)
+	exists, id, err := sqlbase.LookupObjectID(
+		params.ctx, params.p.txn, params.ExecCfg().Codec, dbID, schemaID, tableName)
 	if err == nil && exists {
+		// Try and see what kind of object we collided with.
+		desc, err := getDescriptorByID(params.ctx, params.p.txn, params.ExecCfg().Codec, id)
+		if err != nil {
+			return nil, 0, err
+		}
 		// Still return data in this case.
-		return tKey, schemaID, sqlbase.NewRelationAlreadyExistsError(tableName)
+		return tKey, schemaID, makeObjectAlreadyExistsError(desc, tableName)
 	} else if err != nil {
 		return nil, 0, err
 	}
@@ -622,7 +628,7 @@ func ResolveFK(
 		originCols[i] = col
 	}
 
-	target, err := ResolveMutableExistingObject(ctx, sc, &d.Table, true /*required*/, ResolveRequireTableDesc)
+	target, err := ResolveMutableExistingTableObject(ctx, sc, &d.Table, true /*required*/, ResolveRequireTableDesc)
 	if err != nil {
 		return err
 	}
@@ -897,7 +903,7 @@ func addInterleave(
 			7854, "unsupported shorthand %s", interleave.DropBehavior)
 	}
 
-	parentTable, err := ResolveExistingObject(
+	parentTable, err := ResolveExistingTableObject(
 		ctx, vt, &interleave.Parent, tree.ObjectLookupFlagsWithRequired(), ResolveRequireTableDesc,
 	)
 	if err != nil {
@@ -1970,6 +1976,18 @@ func replaceLikeTableOpts(n *tree.CreateTable, params runParams) (tree.TableDefs
 		newDefs = append(newDefs, defs...)
 	}
 	return newDefs, nil
+}
+
+func makeObjectAlreadyExistsError(collidingObject sqlbase.DescriptorProto, name string) error {
+	switch collidingObject.(type) {
+	case *TableDescriptor:
+		return sqlbase.NewRelationAlreadyExistsError(name)
+	case *TypeDescriptor:
+		return sqlbase.NewTypeAlreadyExistsError(name)
+	case *DatabaseDescriptor:
+		return sqlbase.NewDatabaseAlreadyExistsError(name)
+	}
+	return nil
 }
 
 // dummyColumnItem is used in MakeCheckConstraint to construct an expression

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -13,7 +13,13 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
 )
@@ -26,12 +32,110 @@ type createTypeNode struct {
 var _ planNode = &createTypeNode{n: nil}
 
 func (p *planner) CreateType(ctx context.Context, n *tree.CreateType) (planNode, error) {
-	return nil, unimplemented.NewWithIssue(24873, "CREATE TYPE")
+	return &createTypeNode{n: n}, nil
 }
 
 func (n *createTypeNode) startExec(params runParams) error {
-	return errors.AssertionFailedf(
-		"should not be calling startExec on CREATE TYPE node",
+	switch n.n.Variety {
+	case tree.Enum:
+		return params.p.createEnum(params, n.n)
+	default:
+		return unimplemented.NewWithIssue(25123, "CREATE TYPE")
+	}
+}
+
+func resolveNewTypeName(
+	params runParams, name *tree.UnresolvedObjectName,
+) (*tree.TypeName, *DatabaseDescriptor, error) {
+	// Resolve the target schema and database.
+	db, prefix, err := params.p.ResolveUncachedDatabase(params.ctx, name)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := params.p.CheckPrivilege(params.ctx, db, privilege.CREATE); err != nil {
+		return nil, nil, err
+	}
+
+	// Disallow type creation in the system database.
+	if db.ID == keys.SystemDatabaseID {
+		return nil, nil, errors.New("cannot create a type in the system database")
+	}
+
+	typename := tree.NewUnqualifiedTypeName(tree.Name(name.Object()))
+	typename.ObjectNamePrefix = prefix
+	return typename, db, nil
+}
+
+// getCreateTypeParams performs some initial validation on the input new
+// TypeName and returns the key for the new type descriptor, the ID of the
+// new type, the parent database and parent schema id.
+func getCreateTypeParams(
+	params runParams, name *tree.TypeName, db *DatabaseDescriptor,
+) (sqlbase.DescriptorKey, sqlbase.ID, error) {
+	// TODO (rohany): This should be named object key.
+	typeKey := sqlbase.MakePublicTableNameKey(params.ctx, params.ExecCfg().Settings, db.ID, name.Type())
+	// As of now, we can only create types in the public schema.
+	schemaID := sqlbase.ID(keys.PublicSchemaID)
+	exists, collided, err := sqlbase.LookupObjectID(
+		params.ctx, params.p.txn, params.ExecCfg().Codec, db.ID, schemaID, name.Type())
+	if err == nil && exists {
+		// Try and see what kind of object we collided with.
+		desc, err := getDescriptorByID(params.ctx, params.p.txn, params.ExecCfg().Codec, collided)
+		if err != nil {
+			return nil, 0, err
+		}
+		return nil, 0, makeObjectAlreadyExistsError(desc, name.String())
+	}
+	if err != nil {
+		return nil, 0, err
+	}
+	id, err := GenerateUniqueDescID(params.ctx, params.extendedEvalCtx.ExecCfg.DB)
+	if err != nil {
+		return nil, 0, err
+	}
+	return typeKey, id, nil
+}
+
+func (p *planner) createEnum(params runParams, n *tree.CreateType) error {
+	// Make sure that all nodes in the cluster are able to recognize ENUM types.
+	if !p.ExecCfg().Settings.Version.IsActive(params.ctx, clusterversion.VersionEnums) {
+		return pgerror.Newf(pgcode.FeatureNotSupported,
+			"not all nodes are the correct version for ENUM type creation")
+	}
+
+	if len(n.EnumLabels) > 0 {
+		return unimplemented.NewWithIssue(24873, "CREATE TYPE")
+	}
+
+	// Resolve the desired new type name.
+	typeName, db, err := resolveNewTypeName(params, n.TypeName)
+	if err != nil {
+		return err
+	}
+	n.TypeName.SetAnnotation(&p.semaCtx.Annotations, typeName)
+
+	// Generate a key in the namespace table and a new id for this type.
+	typeKey, id, err := getCreateTypeParams(params, typeName, db)
+	if err != nil {
+		return err
+	}
+
+	// TODO (rohany): We need to generate an oid for this type!
+	typeDesc := &sqlbase.TypeDescriptor{
+		ParentID:       db.ID,
+		ParentSchemaID: keys.PublicSchemaID,
+		Name:           typeName.Type(),
+		ID:             id,
+		Kind:           sqlbase.TypeDescriptor_ENUM,
+	}
+	return p.createDescriptorWithID(
+		params.ctx,
+		typeKey.Key(params.ExecCfg().Codec),
+		id,
+		typeDesc,
+		params.EvalContext().Settings,
+		tree.AsStringWithFQNames(n, params.Ann()),
 	)
 }
 

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -101,11 +101,16 @@ func getDatabaseID(
 func getDatabaseDescByID(
 	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, id sqlbase.ID,
 ) (*sqlbase.DatabaseDescriptor, error) {
-	desc := &sqlbase.DatabaseDescriptor{}
-	if err := getDescriptorByID(ctx, txn, codec, id, desc); err != nil {
+	desc, err := getDescriptorByID(ctx, txn, codec, id)
+	if err != nil {
 		return nil, err
 	}
-	return desc, nil
+	db, ok := desc.(*sqlbase.DatabaseDescriptor)
+	if !ok {
+		return nil, pgerror.Newf(pgcode.WrongObjectType,
+			"%q is not a database", desc.String())
+	}
+	return db, nil
 }
 
 // MustGetDatabaseDescByID looks up the database descriptor given its ID,

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1367,7 +1367,7 @@ https://www.postgresql.org/docs/9.5/infoschema-tables.html`,
 				addRow func(...tree.Datum) error) (bool, error) {
 				// This index is on the TABLE_NAME column.
 				name := tree.MustBeDString(constraint)
-				desc, err := ResolveExistingObject(ctx, p, tree.NewUnqualifiedTableName(tree.Name(name)),
+				desc, err := ResolveExistingTableObject(ctx, p, tree.NewUnqualifiedTableName(tree.Name(name)),
 					tree.ObjectLookupFlags{}, ResolveAnyDescType)
 				if err != nil || desc == nil {
 					return false, err

--- a/pkg/sql/logical_schema_accessors.go
+++ b/pkg/sql/logical_schema_accessors.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/errors"
 )
 
 // This file provides reference implementations of the schema accessor
@@ -30,6 +31,8 @@ import (
 type LogicalSchemaAccessor struct {
 	SchemaAccessor
 	vt VirtualTabler
+	// Used to avoid allocations.
+	tn TableName
 }
 
 var _ SchemaAccessor = &LogicalSchemaAccessor{}
@@ -77,28 +80,36 @@ func (l *LogicalSchemaAccessor) GetObjectDesc(
 	txn *kv.Txn,
 	settings *cluster.Settings,
 	codec keys.SQLCodec,
-	name *ObjectName,
+	db, schema, object string,
 	flags tree.ObjectLookupFlags,
 ) (ObjectDescriptor, error) {
-	if scEntry, ok := l.vt.getVirtualSchemaEntry(name.Schema()); ok {
-		tableName := name.Table()
-		if t, ok := scEntry.defs[tableName]; ok {
-			if flags.RequireMutable {
-				return sqlbase.NewMutableExistingTableDescriptor(*t.desc), nil
+	switch flags.DesiredObjectKind {
+	case tree.TypeObject:
+		return (UncachedPhysicalAccessor{}).GetObjectDesc(ctx, txn, settings, codec, db, schema, object, flags)
+	case tree.TableObject:
+		l.tn = tree.MakeTableNameWithSchema(tree.Name(db), tree.Name(schema), tree.Name(object))
+		if scEntry, ok := l.vt.getVirtualSchemaEntry(l.tn.Schema()); ok {
+			tableName := l.tn.Table()
+			if t, ok := scEntry.defs[tableName]; ok {
+				if flags.RequireMutable {
+					return sqlbase.NewMutableExistingTableDescriptor(*t.desc), nil
+				}
+				return sqlbase.NewImmutableTableDescriptor(*t.desc), nil
 			}
-			return sqlbase.NewImmutableTableDescriptor(*t.desc), nil
-		}
-		if _, ok := scEntry.allTableNames[tableName]; ok {
-			return nil, unimplemented.Newf(name.Schema()+"."+tableName,
-				"virtual schema table not implemented: %s.%s", name.Schema(), tableName)
+			if _, ok := scEntry.allTableNames[tableName]; ok {
+				return nil, unimplemented.Newf(l.tn.Schema()+"."+tableName,
+					"virtual schema table not implemented: %s.%s", l.tn.Schema(), tableName)
+			}
+
+			if flags.Required {
+				return nil, sqlbase.NewUndefinedRelationError(&l.tn)
+			}
+			return nil, nil
 		}
 
-		if flags.Required {
-			return nil, sqlbase.NewUndefinedRelationError(name)
-		}
-		return nil, nil
+		// Fallthrough.
+		return l.SchemaAccessor.GetObjectDesc(ctx, txn, settings, codec, db, schema, object, flags)
+	default:
+		return nil, errors.AssertionFailedf("unknown desired object kind %d", flags.DesiredObjectKind)
 	}
-
-	// Fallthrough.
-	return l.SchemaAccessor.GetObjectDesc(ctx, txn, settings, codec, name, flags)
 }

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -6,3 +6,31 @@ DROP TYPE mytype
 
 statement error pq: unimplemented: DROP TYPE
 DROP TYPE IF EXISTS mytype
+
+statement ok
+CREATE TYPE t AS ENUM ()
+
+statement error pq: relation "t" does not exist
+SELECT * FROM t
+
+statement error pq: type "t" already exists
+CREATE TABLE t (x INT)
+
+statement error pq: type "t" already exists
+CREATE TYPE t AS ENUM ()
+
+statement ok
+CREATE TABLE torename (x INT)
+
+statement error pq: type "t" already exists
+ALTER TABLE torename RENAME TO t
+
+statement ok
+CREATE DATABASE db2;
+CREATE TYPE db2.t AS ENUM ()
+
+statement error pq: relation "db2.t" does not exist
+SELECT * FROM db2.t
+
+statement error pq: type "db2.public.t" already exists
+CREATE TYPE db2.t AS ENUM ()

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -174,7 +174,7 @@ func (oc *optCatalog) ResolveDataSource(
 	}
 
 	oc.tn = *name
-	desc, err := ResolveExistingObject(ctx, oc.planner, &oc.tn, tree.ObjectLookupFlagsWithRequired(), ResolveAnyDescType)
+	desc, err := ResolveExistingTableObject(ctx, oc.planner, &oc.tn, tree.ObjectLookupFlagsWithRequired(), ResolveAnyDescType)
 	if err != nil {
 		return nil, cat.DataSourceName{}, err
 	}

--- a/pkg/sql/physical_schema_accessors.go
+++ b/pkg/sql/physical_schema_accessors.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 )
 
 // This file provides reference implementations of the schema accessor
@@ -41,7 +42,10 @@ import (
 
 // UncachedPhysicalAccessor implements direct access to DB descriptors,
 // without any kind of caching.
-type UncachedPhysicalAccessor struct{}
+type UncachedPhysicalAccessor struct {
+	// Used to avoid allocations.
+	tn TableName
+}
 
 var _ SchemaAccessor = UncachedPhysicalAccessor{}
 
@@ -70,12 +74,7 @@ func (a UncachedPhysicalAccessor) GetDatabaseDesc(
 		return nil, nil
 	}
 
-	desc = &sqlbase.DatabaseDescriptor{}
-	if err := getDescriptorByID(ctx, txn, codec, descID, desc); err != nil {
-		return nil, err
-	}
-
-	return desc, nil
+	return getDatabaseDescByID(ctx, txn, codec, descID)
 }
 
 // IsValidSchema implements the SchemaAccessor interface.
@@ -176,23 +175,24 @@ func (a UncachedPhysicalAccessor) GetObjectDesc(
 	txn *kv.Txn,
 	settings *cluster.Settings,
 	codec keys.SQLCodec,
-	name *ObjectName,
+	db, schema, object string,
 	flags tree.ObjectLookupFlags,
 ) (ObjectDescriptor, error) {
 	// Look up the database ID.
-	dbID, err := getDatabaseID(ctx, txn, codec, name.Catalog(), flags.Required)
+	dbID, err := getDatabaseID(ctx, txn, codec, db, flags.Required)
 	if err != nil || dbID == sqlbase.InvalidID {
 		// dbID can still be invalid if required is false and the database is not found.
 		return nil, err
 	}
 
-	ok, schemaID, err := a.IsValidSchema(ctx, txn, codec, dbID, name.Schema())
+	ok, schemaID, err := a.IsValidSchema(ctx, txn, codec, dbID, schema)
 	if err != nil {
 		return nil, err
 	}
 	if !ok {
 		if flags.Required {
-			return nil, sqlbase.NewUnsupportedSchemaUsageError(tree.ErrString(name))
+			a.tn = tree.MakeTableNameWithSchema(tree.Name(db), tree.Name(schema), tree.Name(object))
+			return nil, sqlbase.NewUnsupportedSchemaUsageError(tree.ErrString(&a.tn))
 		}
 		return nil, nil
 	}
@@ -201,61 +201,68 @@ func (a UncachedPhysicalAccessor) GetObjectDesc(
 	// Note: we can only bypass name to ID resolution. The desc
 	// lookup below must still go through KV because system descriptors
 	// can be modified on a running cluster.
-	descID := sqlbase.LookupSystemTableDescriptorID(ctx, settings, dbID, name.Table())
+	descID := sqlbase.LookupSystemTableDescriptorID(ctx, settings, dbID, object)
 	if descID == sqlbase.InvalidID {
 		var found bool
-		found, descID, err = sqlbase.LookupObjectID(ctx, txn, codec, dbID, schemaID, name.Table())
+		found, descID, err = sqlbase.LookupObjectID(ctx, txn, codec, dbID, schemaID, object)
 		if err != nil {
 			return nil, err
 		}
 		if !found {
 			// KV name resolution failed.
 			if flags.Required {
-				return nil, sqlbase.NewUndefinedRelationError(name)
+				a.tn = tree.MakeTableNameWithSchema(tree.Name(db), tree.Name(schema), tree.Name(object))
+				return nil, sqlbase.NewUndefinedObjectError(&a.tn, flags.DesiredObjectKind)
 			}
 			return nil, nil
 		}
 	}
 
-	// Look up the table using the discovered database descriptor.
-	desc := &sqlbase.TableDescriptor{}
-	err = getDescriptorByID(ctx, txn, codec, descID, desc)
+	// Look up the object using the discovered database descriptor.
+	rawDesc, err := getDescriptorByID(ctx, txn, codec, descID)
 	if err != nil {
 		return nil, err
 	}
-
-	// We have a descriptor, allow it to be in the PUBLIC or ADD state. Possibly
-	// OFFLINE if the relevant flag is set.
-	acceptableStates := map[sqlbase.TableDescriptor_State]bool{
-		sqlbase.TableDescriptor_ADD:     true,
-		sqlbase.TableDescriptor_PUBLIC:  true,
-		sqlbase.TableDescriptor_OFFLINE: flags.IncludeOffline,
-	}
-	if acceptableStates[desc.State] {
-		// Immediately after a RENAME an old name still points to the
-		// descriptor during the drain phase for the name. Do not
-		// return a descriptor during draining.
-		//
-		// The second or condition ensures that clusters < 20.1 access the
-		// system.namespace_deprecated table when selecting from system.namespace.
-		// As this table can not be renamed by users, it is okay that the first
-		// check fails.
-		if desc.Name == name.Table() ||
-			name.Table() == sqlbase.NamespaceTableName && name.Catalog() == sqlbase.SystemDB.Name {
-			if flags.RequireMutable {
-				return sqlbase.NewMutableExistingTableDescriptor(*desc), nil
-			}
-			return sqlbase.NewImmutableTableDescriptor(*desc), nil
+	switch desc := rawDesc.(type) {
+	case *sqlbase.TableDescriptor:
+		// We have a descriptor, allow it to be in the PUBLIC or ADD state. Possibly
+		// OFFLINE if the relevant flag is set.
+		acceptableStates := map[sqlbase.TableDescriptor_State]bool{
+			sqlbase.TableDescriptor_ADD:     true,
+			sqlbase.TableDescriptor_PUBLIC:  true,
+			sqlbase.TableDescriptor_OFFLINE: flags.IncludeOffline,
 		}
+		if acceptableStates[desc.State] {
+			// Immediately after a RENAME an old name still points to the
+			// descriptor during the drain phase for the name. Do not
+			// return a descriptor during draining.
+			//
+			// The second or condition ensures that clusters < 20.1 access the
+			// system.namespace_deprecated table when selecting from system.namespace.
+			// As this table can not be renamed by users, it is okay that the first
+			// check fails.
+			if desc.Name == object ||
+				object == sqlbase.NamespaceTableName && db == sqlbase.SystemDB.Name {
+				if flags.RequireMutable {
+					return sqlbase.NewMutableExistingTableDescriptor(*desc), nil
+				}
+				return sqlbase.NewImmutableTableDescriptor(*desc), nil
+			}
+		}
+		return nil, nil
+	case *sqlbase.TypeDescriptor:
+		return desc, nil
+	default:
+		return nil, nil
 	}
-
-	return nil, nil
 }
 
 // CachedPhysicalAccessor adds a cache on top of any SchemaAccessor.
 type CachedPhysicalAccessor struct {
 	SchemaAccessor
 	tc *TableCollection
+	// Used to avoid allocations.
+	tn TableName
 }
 
 var _ SchemaAccessor = &CachedPhysicalAccessor{}
@@ -307,21 +314,29 @@ func (a *CachedPhysicalAccessor) GetObjectDesc(
 	txn *kv.Txn,
 	settings *cluster.Settings,
 	codec keys.SQLCodec,
-	name *ObjectName,
+	db, schema, object string,
 	flags tree.ObjectLookupFlags,
 ) (ObjectDescriptor, error) {
-	if flags.RequireMutable {
-		table, err := a.tc.getMutableTableDescriptor(ctx, txn, name, flags)
+	switch flags.DesiredObjectKind {
+	case tree.TypeObject:
+		return nil, errors.AssertionFailedf("accesses to type descriptors aren't cached")
+	case tree.TableObject:
+		a.tn = tree.MakeTableNameWithSchema(tree.Name(db), tree.Name(schema), tree.Name(object))
+		if flags.RequireMutable {
+			table, err := a.tc.getMutableTableDescriptor(ctx, txn, &a.tn, flags)
+			if table == nil {
+				// return nil interface.
+				return nil, err
+			}
+			return table, err
+		}
+		table, err := a.tc.getTableVersion(ctx, txn, &a.tn, flags)
 		if table == nil {
 			// return nil interface.
 			return nil, err
 		}
 		return table, err
+	default:
+		return nil, errors.AssertionFailedf("unknown desired object kind %d", flags.DesiredObjectKind)
 	}
-	table, err := a.tc.getTableVersion(ctx, txn, name, flags)
-	if table == nil {
-		// return nil interface.
-		return nil, err
-	}
-	return table, err
 }

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -89,7 +89,7 @@ type PlanHookState interface {
 	ResolveUncachedDatabaseByName(
 		ctx context.Context, dbName string, required bool) (*UncachedDatabaseDescriptor, error)
 	ResolveMutableTableDescriptor(
-		ctx context.Context, tn *ObjectName, required bool, requiredType ResolveRequiredType,
+		ctx context.Context, tn *TableName, required bool, requiredType ResolveRequiredType,
 	) (table *MutableTableDescriptor, err error)
 	ShowCreate(
 		ctx context.Context, dbPrefix string, allDescs []sqlbase.Descriptor, desc *sqlbase.TableDescriptor, ignoreFKs shouldOmitFKClausesFromCreate,

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -441,7 +441,7 @@ func (p *planner) ParseQualifiedTableName(sql string) (*tree.TableName, error) {
 
 // ResolveTableName implements the tree.EvalDatabase interface.
 func (p *planner) ResolveTableName(ctx context.Context, tn *tree.TableName) (tree.ID, error) {
-	desc, err := ResolveExistingObject(ctx, p, tn, tree.ObjectLookupFlagsWithRequired(), ResolveAnyDescType)
+	desc, err := ResolveExistingTableObject(ctx, p, tn, tree.ObjectLookupFlagsWithRequired(), ResolveAnyDescType)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -112,7 +112,9 @@ func (n *renameDatabaseNode) startExec(params runParams) error {
 				p.txn,
 				p.ExecCfg().Settings,
 				p.ExecCfg().Codec,
-				&tbNames[i],
+				tbNames[i].Catalog(),
+				tbNames[i].Schema(),
+				tbNames[i].Table(),
 				tree.ObjectLookupFlags{CommonLookupFlags: lookupFlags},
 			)
 			if err != nil {

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -34,9 +34,9 @@ import (
 // reference implementations of these interfaces.
 
 type (
-	// ObjectName is provided for convenience and to make the interface
+	// TableName is provided for convenience and to make the interface
 	// definitions below more intuitive.
-	ObjectName = tree.TableName
+	TableName = tree.TableName
 	// DatabaseDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	DatabaseDescriptor = sqlbase.DatabaseDescriptor
@@ -52,6 +52,9 @@ type (
 	// TableDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	TableDescriptor = sqlbase.TableDescriptor
+	// TypeDescriptor is provided for convenience and to make the
+	// interface definitions below more intuitive.
+	TypeDescriptor = sqlbase.TypeDescriptor
 	// ViewDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	ViewDescriptor = sqlbase.TableDescriptor
@@ -67,8 +70,13 @@ type (
 type ObjectDescriptor interface {
 	tree.NameResolutionResult
 
-	// TableDesc returns the underlying table descriptor.
+	// TableDesc returns the underlying table descriptor, or nil if the
+	// descriptor is not a table backed object.
 	TableDesc() *TableDescriptor
+
+	// TypeDesc returns the underlying type descriptor, or nil if the
+	// descriptor is not a type backed object.
+	TypeDesc() *TypeDescriptor
 }
 
 // SchemaAccessor provides access to database descriptors.
@@ -91,5 +99,5 @@ type SchemaAccessor interface {
 	// descriptor and that of its parent database. If the object is not
 	// found and flags.required is true, an error is returned, otherwise
 	// a nil reference is returned.
-	GetObjectDesc(ctx context.Context, txn *kv.Txn, settings *cluster.Settings, codec keys.SQLCodec, name *ObjectName, flags tree.ObjectLookupFlags) (ObjectDescriptor, error)
+	GetObjectDesc(ctx context.Context, txn *kv.Txn, settings *cluster.Settings, codec keys.SQLCodec, db, schema, object string, flags tree.ObjectLookupFlags) (ObjectDescriptor, error)
 }

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -92,9 +92,11 @@ func (n *scrubNode) startExec(params runParams) error {
 		if err != nil {
 			return err
 		}
-		if err := n.startScrubTable(
-			params.ctx, params.p, tableDesc, params.p.ResolvedName(n.n.Table),
-		); err != nil {
+		tn, ok := params.p.ResolvedName(n.n.Table).(*tree.TableName)
+		if !ok {
+			return errors.AssertionFailedf("%q was not resolved as a table", n.n.Table)
+		}
+		if err := n.startScrubTable(params.ctx, params.p, tableDesc, tn); err != nil {
 			return err
 		}
 	case tree.ScrubDatabase:
@@ -173,8 +175,16 @@ func (n *scrubNode) startScrubDatabase(ctx context.Context, p *planner, name *tr
 
 	for i := range tbNames {
 		tableName := &tbNames[i]
-		objDesc, err := p.LogicalSchemaAccessor().GetObjectDesc(ctx, p.txn, p.ExecCfg().Settings,
-			p.ExecCfg().Codec, tableName, p.ObjectLookupFlags(true /*required*/, false /*requireMutable*/))
+		objDesc, err := p.LogicalSchemaAccessor().GetObjectDesc(
+			ctx,
+			p.txn,
+			p.ExecCfg().Settings,
+			p.ExecCfg().Codec,
+			tableName.Catalog(),
+			tableName.Schema(),
+			tableName.Table(),
+			p.ObjectLookupFlags(true /*required*/, false /*requireMutable*/),
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/sem/tree/table_name.go
+++ b/pkg/sql/sem/tree/table_name.go
@@ -40,6 +40,8 @@ func (t *TableName) Format(ctx *FmtCtx) {
 }
 func (t *TableName) String() string { return AsString(t) }
 
+func (t *TableName) objectName() {}
+
 // FQString renders the table name in full, not omitting the prefix
 // schema and catalog names. Suitable for logging, etc.
 func (t *TableName) FQString() string {
@@ -61,25 +63,6 @@ func (t *TableName) Table() string {
 // the ExplicitSchema/ExplicitCatalog flags).
 func (t *TableName) Equals(other *TableName) bool {
 	return *t == *other
-}
-
-// ToUnresolvedObjectName converts the table name to an unresolved object name.
-// Schema and catalog are included if indicated by the ExplicitSchema and
-// ExplicitCatalog flags.
-func (t *TableName) ToUnresolvedObjectName() *UnresolvedObjectName {
-	u := &UnresolvedObjectName{}
-
-	u.NumParts = 1
-	u.Parts[0] = string(t.ObjectName)
-	if t.ExplicitSchema {
-		u.Parts[u.NumParts] = string(t.SchemaName)
-		u.NumParts++
-	}
-	if t.ExplicitCatalog {
-		u.Parts[u.NumParts] = string(t.CatalogName)
-		u.NumParts++
-	}
-	return u
 }
 
 // tableExpr implements the TableExpr interface.

--- a/pkg/sql/sem/tree/type_name.go
+++ b/pkg/sql/sem/tree/type_name.go
@@ -62,6 +62,8 @@ func (t *TypeName) FQString() string {
 	return ctx.CloseAndGetString()
 }
 
+func (t *TypeName) objectName() {}
+
 // NewUnqualifiedTypeName returns a new base type name.
 func NewUnqualifiedTypeName(typ Name) *TypeName {
 	return &TypeName{objName{

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -36,7 +36,7 @@ func (p *planner) IncrementSequence(ctx context.Context, seqName *tree.TableName
 		return 0, readOnlyError("nextval()")
 	}
 
-	descriptor, err := ResolveExistingObject(ctx, p, seqName, tree.ObjectLookupFlagsWithRequired(), ResolveRequireSequenceDesc)
+	descriptor, err := ResolveExistingTableObject(ctx, p, seqName, tree.ObjectLookupFlagsWithRequired(), ResolveRequireSequenceDesc)
 	if err != nil {
 		return 0, err
 	}
@@ -94,7 +94,7 @@ func boundsExceededError(descriptor *sqlbase.ImmutableTableDescriptor) error {
 func (p *planner) GetLatestValueInSessionForSequence(
 	ctx context.Context, seqName *tree.TableName,
 ) (int64, error) {
-	descriptor, err := ResolveExistingObject(ctx, p, seqName, tree.ObjectLookupFlagsWithRequired(), ResolveRequireSequenceDesc)
+	descriptor, err := ResolveExistingTableObject(ctx, p, seqName, tree.ObjectLookupFlagsWithRequired(), ResolveRequireSequenceDesc)
 	if err != nil {
 		return 0, err
 	}
@@ -117,7 +117,7 @@ func (p *planner) SetSequenceValue(
 		return readOnlyError("setval()")
 	}
 
-	descriptor, err := ResolveExistingObject(ctx, p, seqName, tree.ObjectLookupFlagsWithRequired(), ResolveRequireSequenceDesc)
+	descriptor, err := ResolveExistingTableObject(ctx, p, seqName, tree.ObjectLookupFlagsWithRequired(), ResolveRequireSequenceDesc)
 	if err != nil {
 		return err
 	}
@@ -432,7 +432,7 @@ func maybeAddSequenceDependencies(
 			}
 		} else {
 			// This is only executed via IMPORT which uses its own resolver.
-			seqDesc, err = ResolveMutableExistingObject(ctx, sc, &tn, true /*required*/, ResolveRequireSequenceDesc)
+			seqDesc, err = ResolveMutableExistingTableObject(ctx, sc, &tn, true /*required*/, ResolveRequireSequenceDesc)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/serial.go
+++ b/pkg/sql/serial.go
@@ -41,13 +41,13 @@ var virtualSequenceOpts = tree.SequenceOptions{
 
 // processSerialInColumnDef analyzes a column definition and determines
 // whether to use a sequence if the requested type is SERIAL-like.
-// If a sequence must be created, it returns an ObjectName to use
+// If a sequence must be created, it returns an TableName to use
 // to create the new sequence and the DatabaseDescriptor of the
 // parent database where it should be created.
 // The ColumnTableDef is not mutated in-place; instead a new one is returned.
 func (p *planner) processSerialInColumnDef(
-	ctx context.Context, d *tree.ColumnTableDef, tableName *ObjectName,
-) (*tree.ColumnTableDef, *DatabaseDescriptor, *ObjectName, tree.SequenceOptions, error) {
+	ctx context.Context, d *tree.ColumnTableDef, tableName *TableName,
+) (*tree.ColumnTableDef, *DatabaseDescriptor, *TableName, tree.SequenceOptions, error) {
 	if !d.IsSerial {
 		// Column is not SERIAL: nothing to do.
 		return d, nil, nil, nil, nil
@@ -163,7 +163,7 @@ func (p *planner) processSerialInColumnDef(
 // This is currently used by bulk I/O import statements which do not
 // (yet?) support customization of the SERIAL behavior.
 func SimplifySerialInColumnDefWithRowID(
-	ctx context.Context, d *tree.ColumnTableDef, tableName *ObjectName,
+	ctx context.Context, d *tree.ColumnTableDef, tableName *TableName,
 ) error {
 	if !d.IsSerial {
 		// Column is not SERIAL: nothing to do.
@@ -189,7 +189,7 @@ func SimplifySerialInColumnDefWithRowID(
 	return nil
 }
 
-func assertValidSerialColumnDef(d *tree.ColumnTableDef, tableName *ObjectName) error {
+func assertValidSerialColumnDef(d *tree.ColumnTableDef, tableName *TableName) error {
 	if d.HasDefaultExpr() {
 		// SERIAL implies a new default expression, we can't have one to
 		// start with. This is the error produced by pg in such case.

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -4038,9 +4038,29 @@ func (desc *MutableTableDescriptor) IsShardColumn(col *ColumnDescriptor) bool {
 	return false
 }
 
+// TypeDesc implements the ObjectDescriptor interface.
+func (desc *MutableTableDescriptor) TypeDesc() *TypeDescriptor {
+	return nil
+}
+
 // TableDesc implements the ObjectDescriptor interface.
 func (desc *ImmutableTableDescriptor) TableDesc() *TableDescriptor {
 	return &desc.TableDescriptor
+}
+
+// TypeDesc implements the ObjectDescriptor interface.
+func (desc *ImmutableTableDescriptor) TypeDesc() *TypeDescriptor {
+	return nil
+}
+
+// TableDesc implements the ObjectDescriptor interface.
+func (desc *TypeDescriptor) TableDesc() *TableDescriptor {
+	return nil
+}
+
+// TypeDesc implements the ObjectDescriptor interface.
+func (desc *TypeDescriptor) TypeDesc() *TypeDescriptor {
+	return desc
 }
 
 // GetAuditMode implements the DescriptorProto interface.

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -234,7 +234,16 @@ func (tc *TableCollection) getMutableTableDescriptor(
 	}
 
 	phyAccessor := UncachedPhysicalAccessor{}
-	obj, err := phyAccessor.GetObjectDesc(ctx, txn, tc.settings, tc.codec(), tn, flags)
+	obj, err := phyAccessor.GetObjectDesc(
+		ctx,
+		txn,
+		tc.settings,
+		tc.codec(),
+		tn.Catalog(),
+		tn.Schema(),
+		tn.Table(),
+		flags,
+	)
 	if obj == nil {
 		return nil, err
 	}
@@ -295,11 +304,24 @@ func (tc *TableCollection) getTableVersion(
 
 	readTableFromStore := func() (*sqlbase.ImmutableTableDescriptor, error) {
 		phyAccessor := UncachedPhysicalAccessor{}
-		obj, err := phyAccessor.GetObjectDesc(ctx, txn, tc.settings, tc.codec(), tn, flags)
+		obj, err := phyAccessor.GetObjectDesc(
+			ctx,
+			txn,
+			tc.settings,
+			tc.codec(),
+			tn.Catalog(),
+			tn.Schema(),
+			tn.Table(),
+			flags,
+		)
 		if obj == nil {
 			return nil, err
 		}
-		return obj.(*sqlbase.ImmutableTableDescriptor), err
+		tbl, ok := obj.(*sqlbase.ImmutableTableDescriptor)
+		if !ok {
+			return nil, err
+		}
+		return tbl, err
 	}
 
 	refuseFurtherLookup, dbID, err := tc.getUncommittedDatabaseID(tn.Catalog(), flags.Required)

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -232,7 +232,9 @@ func cleanupSchemaObjects(
 			txn,
 			settings,
 			codec,
-			&tbName,
+			tbName.Catalog(),
+			tbName.Schema(),
+			tbName.Object(),
 			tree.ObjectLookupFlagsWithRequired(),
 		)
 		if err != nil {

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -250,7 +250,7 @@ func (p *planner) resolveTableForZone(
 		p.runWithOptions(resolveFlags{skipCache: true}, func() {
 			flags := tree.ObjectLookupFlagsWithRequired()
 			flags.IncludeOffline = true
-			immutRes, err = ResolveExistingObject(ctx, p, &zs.TableOrIndex.Table, flags, ResolveAnyDescType)
+			immutRes, err = ResolveExistingTableObject(ctx, p, &zs.TableOrIndex.Table, flags, ResolveAnyDescType)
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR adds the ability to create a type (but not really use it
anywhere). It adjusts the name resolution paths to be able to handle
the requested kind of descriptor, and disallows paths that want
table descriptors from accidentally accessing a type descriptor.
Upon type creation it performs similar logic to table creation
to write entries in the namespace and descriptor tables.

It additionally renames a variety of name resolution methods
to be more clear about what kind of object is being accessed.

Release note: None