### PR TITLE
cli/zip: avoid buffering SQL data in RAM

### DIFF
--- a/pkg/cli/testdata/zip/partial1
+++ b/pkg/cli/testdata/zip/partial1
@@ -89,33 +89,47 @@ writing: debug/nodes/1/ranges/31.json
 writing: debug/nodes/1/ranges/32.json
 writing: debug/nodes/2/status.json
 using SQL connection URL for node 2: postgresql://...
-retrieving SQL data for crdb_internal.feature_usage... writing: debug/nodes/2/crdb_internal.feature_usage.txt.err.txt
+retrieving SQL data for crdb_internal.feature_usage... writing: debug/nodes/2/crdb_internal.feature_usage.txt
+writing: debug/nodes/2/crdb_internal.feature_usage.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for crdb_internal.gossip_alerts... writing: debug/nodes/2/crdb_internal.gossip_alerts.txt.err.txt
+retrieving SQL data for crdb_internal.gossip_alerts... writing: debug/nodes/2/crdb_internal.gossip_alerts.txt
+writing: debug/nodes/2/crdb_internal.gossip_alerts.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for crdb_internal.gossip_liveness... writing: debug/nodes/2/crdb_internal.gossip_liveness.txt.err.txt
+retrieving SQL data for crdb_internal.gossip_liveness... writing: debug/nodes/2/crdb_internal.gossip_liveness.txt
+writing: debug/nodes/2/crdb_internal.gossip_liveness.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for crdb_internal.gossip_network... writing: debug/nodes/2/crdb_internal.gossip_network.txt.err.txt
+retrieving SQL data for crdb_internal.gossip_network... writing: debug/nodes/2/crdb_internal.gossip_network.txt
+writing: debug/nodes/2/crdb_internal.gossip_network.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for crdb_internal.gossip_nodes... writing: debug/nodes/2/crdb_internal.gossip_nodes.txt.err.txt
+retrieving SQL data for crdb_internal.gossip_nodes... writing: debug/nodes/2/crdb_internal.gossip_nodes.txt
+writing: debug/nodes/2/crdb_internal.gossip_nodes.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for crdb_internal.leases... writing: debug/nodes/2/crdb_internal.leases.txt.err.txt
+retrieving SQL data for crdb_internal.leases... writing: debug/nodes/2/crdb_internal.leases.txt
+writing: debug/nodes/2/crdb_internal.leases.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for crdb_internal.node_build_info... writing: debug/nodes/2/crdb_internal.node_build_info.txt.err.txt
+retrieving SQL data for crdb_internal.node_build_info... writing: debug/nodes/2/crdb_internal.node_build_info.txt
+writing: debug/nodes/2/crdb_internal.node_build_info.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for crdb_internal.node_metrics... writing: debug/nodes/2/crdb_internal.node_metrics.txt.err.txt
+retrieving SQL data for crdb_internal.node_metrics... writing: debug/nodes/2/crdb_internal.node_metrics.txt
+writing: debug/nodes/2/crdb_internal.node_metrics.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/2/crdb_internal.node_queries.txt.err.txt
+retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/2/crdb_internal.node_queries.txt
+writing: debug/nodes/2/crdb_internal.node_queries.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/2/crdb_internal.node_runtime_info.txt.err.txt
+retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/2/crdb_internal.node_runtime_info.txt
+writing: debug/nodes/2/crdb_internal.node_runtime_info.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for crdb_internal.node_sessions... writing: debug/nodes/2/crdb_internal.node_sessions.txt.err.txt
+retrieving SQL data for crdb_internal.node_sessions... writing: debug/nodes/2/crdb_internal.node_sessions.txt
+writing: debug/nodes/2/crdb_internal.node_sessions.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for crdb_internal.node_statement_statistics... writing: debug/nodes/2/crdb_internal.node_statement_statistics.txt.err.txt
+retrieving SQL data for crdb_internal.node_statement_statistics... writing: debug/nodes/2/crdb_internal.node_statement_statistics.txt
+writing: debug/nodes/2/crdb_internal.node_statement_statistics.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for crdb_internal.node_transactions... writing: debug/nodes/2/crdb_internal.node_transactions.txt.err.txt
+retrieving SQL data for crdb_internal.node_transactions... writing: debug/nodes/2/crdb_internal.node_transactions.txt
+writing: debug/nodes/2/crdb_internal.node_transactions.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for crdb_internal.node_txn_stats... writing: debug/nodes/2/crdb_internal.node_txn_stats.txt.err.txt
+retrieving SQL data for crdb_internal.node_txn_stats... writing: debug/nodes/2/crdb_internal.node_txn_stats.txt
+writing: debug/nodes/2/crdb_internal.node_txn_stats.txt.err.txt
   ^- resulted in ...
 requesting data for debug/nodes/2/details... writing: debug/nodes/2/details.json.err.txt
   ^- resulted in ...

--- a/pkg/cli/testdata/zip/unavailable
+++ b/pkg/cli/testdata/zip/unavailable
@@ -17,25 +17,35 @@ retrieving SQL data for crdb_internal.cluster_queries... writing: debug/crdb_int
 retrieving SQL data for crdb_internal.cluster_sessions... writing: debug/crdb_internal.cluster_sessions.txt
 retrieving SQL data for crdb_internal.cluster_settings... writing: debug/crdb_internal.cluster_settings.txt
 retrieving SQL data for crdb_internal.cluster_transactions... writing: debug/crdb_internal.cluster_transactions.txt
-retrieving SQL data for crdb_internal.jobs... writing: debug/crdb_internal.jobs.txt.err.txt
+retrieving SQL data for crdb_internal.jobs... writing: debug/crdb_internal.jobs.txt
+writing: debug/crdb_internal.jobs.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for system.jobs... writing: debug/system.jobs.txt.err.txt
+retrieving SQL data for system.jobs... writing: debug/system.jobs.txt
+writing: debug/system.jobs.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for system.descriptor... writing: debug/system.descriptor.txt.err.txt
+retrieving SQL data for system.descriptor... writing: debug/system.descriptor.txt
+writing: debug/system.descriptor.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for system.namespace... writing: debug/system.namespace.txt.err.txt
+retrieving SQL data for system.namespace... writing: debug/system.namespace.txt
+writing: debug/system.namespace.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for system.namespace2... writing: debug/system.namespace2.txt.err.txt
+retrieving SQL data for system.namespace2... writing: debug/system.namespace2.txt
+writing: debug/system.namespace2.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for crdb_internal.kv_node_status... writing: debug/crdb_internal.kv_node_status.txt.err.txt
+retrieving SQL data for crdb_internal.kv_node_status... writing: debug/crdb_internal.kv_node_status.txt
+writing: debug/crdb_internal.kv_node_status.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for crdb_internal.kv_store_status... writing: debug/crdb_internal.kv_store_status.txt.err.txt
+retrieving SQL data for crdb_internal.kv_store_status... writing: debug/crdb_internal.kv_store_status.txt
+writing: debug/crdb_internal.kv_store_status.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for crdb_internal.schema_changes... writing: debug/crdb_internal.schema_changes.txt.err.txt
+retrieving SQL data for crdb_internal.schema_changes... writing: debug/crdb_internal.schema_changes.txt
+writing: debug/crdb_internal.schema_changes.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for crdb_internal.partitions... writing: debug/crdb_internal.partitions.txt.err.txt
+retrieving SQL data for crdb_internal.partitions... writing: debug/crdb_internal.partitions.txt
+writing: debug/crdb_internal.partitions.txt.err.txt
   ^- resulted in ...
-retrieving SQL data for crdb_internal.zones... writing: debug/crdb_internal.zones.txt.err.txt
+retrieving SQL data for crdb_internal.zones... writing: debug/crdb_internal.zones.txt
+writing: debug/crdb_internal.zones.txt.err.txt
   ^- resulted in ...
 requesting nodes... writing: debug/nodes.json.err.txt
   ^- resulted in ...


### PR DESCRIPTION
Fixes #47594 

Previously, `cockroach debug zip` would fetch all SQL rows in RAM:

- a first time into an array of strings, to determine the maximum
  table width in the "pretty" ASCII-art formatter,
- then a second time in a `bytes.Buffer`,

before being eventually streamed out into the output ZIP file.

This was causing problems when extracting very large `system` tables,
for example out of runaway job, event log or range log tables.

This patch fixes it by switching to a streaming SQL row renderer (TSV)
and avoiding the intermediate byte buffer.

A side benefit is that the TSV format is arguably much more easy to
scan to the human eye when the tables are very wide.

Release note (backward-incompatible change): The copy of system and
`crdb_internal` tables extracted by `cockroach debug zip` is now
written using the TSV format (inside the ZIP file), instead of an
ASCII-art table as previously.

Release note (bug fix): `cockroach debug zip` can now successfully
avoid out-of-memory errors when extracting very large `system` or
`crdb_internal` tables.