### PR TITLE
schemachange: categorize error as unimplemented

### DIFF
--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2333,7 +2333,8 @@ func checkColumnsValidForInvertedIndex(
 	tableDesc *MutableTableDescriptor, indexColNames []string,
 ) error {
 	if len((indexColNames)) > 1 {
-		return errors.New("indexing more than one column with an inverted index is not supported")
+		return unimplemented.NewWithIssue(48100,
+			"indexing more than one column with an inverted index is not supported")
 	}
 	invalidColumns := make([]ColumnDescriptor, 0, len(indexColNames))
 	for _, indexCol := range indexColNames {


### PR DESCRIPTION
We currently only support inverted indexes for a single column. Instead
of returning an uncategorized error we return an unimplemented error.

Touches #47430.
Touches #48100.

Release note: none.