### PR TITLE
cli/zip: do not ignore close errors

### DIFF
--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -385,7 +385,11 @@ func TestZipRetries(t *testing.T) {
 			t.Fatal(err)
 		}
 		z := newZipper(out)
-		defer z.close()
+		defer func() {
+			if err := z.close(); err != nil {
+				t.Fatal(err)
+			}
+		}()
 
 		sqlURL := url.URL{
 			Scheme:   "postgres",


### PR DESCRIPTION
Fixes #48106

Release note (bug fix): `cockroach debug zip` will now properly report
an error if some error is encountered while writing the end of the
output ZIP file.