### PR TITLE
base: introduce SQLInstanceID (and container)

### DIFF
--- a/pkg/base/node_id.go
+++ b/pkg/base/node_id.go
@@ -81,7 +81,7 @@ func (n *NodeIDContainer) Reset(val roachpb.NodeID) {
 // only one SQL server must be running on behalf of the tenant at any given
 // time. After that, it's likely that we'll allocate these IDs off a counter,
 // so they will be completely unique (per tenant).
-type SQLInstanceID int64
+type SQLInstanceID int32
 
 func (s SQLInstanceID) String() string {
 	return strconv.FormatInt(int64(s), 10)

--- a/pkg/base/node_id.go
+++ b/pkg/base/node_id.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
@@ -66,3 +67,103 @@ func (n *NodeIDContainer) Set(ctx context.Context, val roachpb.NodeID) {
 func (n *NodeIDContainer) Reset(val roachpb.NodeID) {
 	atomic.StoreInt32(&n.nodeID, int32(val))
 }
+
+// A SQLInstanceID is an ephemeral ID assigned to a running instance of the SQL
+// server. This is distinct from a NodeID, which is a long-lived identifier
+// assigned to a node in the KV layer which is unique across all KV nodes in the
+// cluster and persists across restarts. Instead, a SQLInstance is similar to a
+// process ID from the unix world: an integer assigned to the SQL server
+// on process start which is unique across all SQL server processes running
+// on behalf of the tenant, while the SQL server is running.
+//
+// NB: until https://github.com/cockroachdb/cockroach/issues/47899 is addressed,
+// the properties of the SQLInstanceID hold trivially due to the constraint that
+// only one SQL server must be running on behalf of the tenant at any given
+// time. After that, it's likely that we'll allocate these IDs off a counter,
+// so they will be completely unique (per tenant).
+type SQLInstanceID int64
+
+func (s SQLInstanceID) String() string {
+	return strconv.FormatInt(int64(s), 10)
+}
+
+// SQLIDContainer wraps a SQLInstanceID and optionally a NodeID.
+type SQLIDContainer struct {
+	w             errorutil.TenantSQLDeprecatedWrapper // NodeID
+	sqlInstanceID SQLInstanceID
+}
+
+// NewSQLIDContainer sets up an SQLIDContainer wrapping the (positive) SQLInstanceID
+// and a NodeID. See errorutil.TenantSQLDeprecatedWrapper for an explanation of
+// the nodeIDExposed parameter.
+//
+// As a special case, a zero sqlInstanceID in conjunction with
+// nodeIDExposed==true falls back to the NodeID in SQLInstanceID(). This is used
+// in single-tenant deployments.
+func NewSQLIDContainer(
+	sqlInstanceID SQLInstanceID, nodeID *NodeIDContainer, nodeIDExposed bool,
+) *SQLIDContainer {
+	if !nodeIDExposed && sqlInstanceID == 0 {
+		panic("sqlInstanceID must not be zero")
+	}
+	return &SQLIDContainer{
+		w:             errorutil.MakeTenantSQLDeprecatedWrapper(nodeID, nodeIDExposed),
+		sqlInstanceID: sqlInstanceID,
+	}
+}
+
+// OptionalNodeID returns the NodeID and true, if the former is exposed.
+// Otherwise, returns zero and false.
+func (c *SQLIDContainer) OptionalNodeID() (roachpb.NodeID, bool) {
+	v, ok := c.w.Optional()
+	if !ok {
+		return 0, false
+	}
+	return v.(*NodeIDContainer).Get(), true
+}
+
+// OptionalNodeIDErr is like OptionalNodeID, but returns an error (referring to
+// the optionally supplied Github issues) if the ID is not present.
+func (c *SQLIDContainer) OptionalNodeIDErr(issueNos ...int) (roachpb.NodeID, error) {
+	v, err := c.w.OptionalErr(issueNos...)
+	if err != nil {
+		return 0, err
+	}
+	return v.(*NodeIDContainer).Get(), nil
+}
+
+// DeprecatedNodeID returns the NodeID. This call is deprecated: removal of all
+// call sites is the goal, at which point this method will be removed. Calls to
+// this method reflect essential functionality which needs to be reworked in
+// order to enable multi-tenancy.
+func (c *SQLIDContainer) DeprecatedNodeID(issueNo int) roachpb.NodeID {
+	return c.w.Deprecated(issueNo).(*NodeIDContainer).Get()
+}
+
+// SQLInstanceID returns the wrapped SQLInstanceID.
+func (c *SQLIDContainer) SQLInstanceID() SQLInstanceID {
+	if n, ok := c.OptionalNodeID(); ok {
+		return SQLInstanceID(n)
+	}
+	return c.sqlInstanceID
+}
+
+// Get is a temporary method to aid refactoring.
+//
+// TODO(tbg): remove.
+func (c *SQLIDContainer) Get() roachpb.NodeID {
+	// Silence staticcheck.
+	var _ = (*SQLIDContainer)(nil).OptionalNodeID
+	var _ = (*SQLIDContainer)(nil).OptionalNodeIDErr
+	var _ = (*SQLIDContainer)(nil).SQLInstanceID
+	return c.DeprecatedNodeID(-12131415)
+
+}
+
+// TestingIDContainer is an SQLIDContainer with hard-coded SQLInstanceID of 10 and
+// NodeID of 1.
+var TestingIDContainer = func() *SQLIDContainer {
+	var c NodeIDContainer
+	c.Set(context.Background(), 1)
+	return NewSQLIDContainer(10, &c, true /* exposed */)
+}()

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -570,6 +570,11 @@ func backupPlanHook(
 			}
 		}
 
+		nodeID, err := p.ExecCfg().NodeID.OptionalNodeIDErr(47970)
+		if err != nil {
+			return err
+		}
+
 		// if CompleteDbs is lost by a 1.x node, FormatDescriptorTrackingVersion
 		// means that a 2.0 node will disallow `RESTORE DATABASE foo`, but `RESTORE
 		// foo.table1, foo.table2...` will still work. MVCCFilter would be
@@ -588,7 +593,7 @@ func backupPlanHook(
 			IntroducedSpans:    newSpans,
 			FormatVersion:      BackupFormatDescriptorTrackingVersion,
 			BuildInfo:          build.GetInfo(),
-			NodeID:             p.ExecCfg().NodeID.Get(),
+			NodeID:             nodeID,
 			ClusterID:          p.ExecCfg().ClusterID(),
 			Statistics:         tableStatistics,
 			DescriptorCoverage: backupStmt.DescriptorCoverage,

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
@@ -107,7 +108,7 @@ func distChangefeedFlow(
 
 	// Changefeed flows handle transactional consistency themselves.
 	var noTxn *kv.Txn
-	gatewayNodeID := execCfg.NodeID.Get()
+	gatewayNodeID := execCfg.NodeID.DeprecatedNodeID(distsql.MultiTenancyIssueNo)
 	dsp := phs.DistSQLPlanner()
 	evalCtx := phs.ExtendedEvalContext()
 	planCtx := dsp.NewPlanningCtx(ctx, evalCtx, noTxn)

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -252,7 +252,10 @@ func changefeedPlanHook(
 		// the CREATE CHANGEFEED statement. To do this, we create a "canary" sink,
 		// which will be immediately closed, only to check for errors.
 		{
-			nodeID := p.ExtendedEvalContext().NodeID
+			nodeID, err := p.ExtendedEvalContext().NodeID.OptionalNodeIDErr(48274)
+			if err != nil {
+				return err
+			}
 			var nilOracle timestampLowerBoundOracle
 			canarySink, err := getSink(
 				ctx, details.SinkURI, nodeID, details.Opts, details.Targets,

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -734,7 +735,7 @@ func (s *sqlSink) emit(
 	// Generate the message id on the client to match the guaranttees of kafka
 	// (two messages are only guaranteed to keep their order if emitted from the
 	// same producer to the same partition).
-	messageID := builtins.GenerateUniqueInt(roachpb.NodeID(partition))
+	messageID := builtins.GenerateUniqueInt(base.SQLInstanceID(partition))
 	s.rowBuf = append(s.rowBuf, topic, partition, messageID, key, value, resolved)
 	if len(s.rowBuf)/sqlSinkEmitCols >= sqlSinkRowBatchSize {
 		return s.Flush(ctx)

--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -248,7 +248,12 @@ func (sp *csvWriter) Run(ctx context.Context) {
 			}
 			defer es.Close()
 
-			part := fmt.Sprintf("n%d.%d", sp.flowCtx.EvalCtx.NodeID, chunk)
+			nodeID, err := sp.flowCtx.EvalCtx.NodeID.OptionalNodeIDErr(47970)
+			if err != nil {
+				return err
+			}
+
+			part := fmt.Sprintf("n%d.%d", nodeID, chunk)
 			chunk++
 			filename := writer.FileName(sp.spec, part)
 			// Close writer to ensure buffer and any compression footer is flushed.

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -14,6 +14,7 @@ import (
 	"crypto/sha512"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
@@ -204,7 +205,10 @@ func evalExport(
 		}
 
 		if exportStore != nil {
-			exported.Path = fmt.Sprintf("%d.sst", builtins.GenerateUniqueInt(cArgs.EvalCtx.NodeID()))
+			// TODO(dt): don't reach out into a SQL builtin here; this code lives in KV.
+			// Create a unique int differently.
+			nodeID := cArgs.EvalCtx.NodeID()
+			exported.Path = fmt.Sprintf("%d.sst", builtins.GenerateUniqueInt(base.SQLInstanceID(nodeID)))
 			if err := exportStore.WriteFile(ctx, exported.Path, bytes.NewReader(data)); err != nil {
 				return result.Result{}, err
 			}

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -47,6 +47,9 @@ import (
 
 const defaultLeniencySetting = 60 * time.Second
 
+// See https://github.com/cockroachdb/cockroach/issues/47892.
+const multiTenancyIssueNo = 47892
+
 var (
 	nodeLivenessLogLimiter = log.Every(5 * time.Second)
 	// LeniencySetting is the amount of time to defer any attempts to
@@ -255,7 +258,7 @@ func (r *Registry) makeCtx() (context.Context, func()) {
 }
 
 func (r *Registry) makeJobID() int64 {
-	return int64(builtins.GenerateUniqueInt(r.nodeID.Get()))
+	return int64(builtins.GenerateUniqueInt(r.nodeID.DeprecatedNodeID(multiTenancyIssueNo)))
 }
 
 // CreateAndStartJob creates and asynchronously starts a job from record. An
@@ -1026,10 +1029,10 @@ WHERE status IN ($1, $2, $3, $4, $5) ORDER BY created DESC`
 
 			// Don't try to start any more jobs unless we're really live,
 			// otherwise we'd just immediately cancel them.
-			if liveness.NodeID == r.nodeID.Get() {
+			if liveness.NodeID == r.nodeID.DeprecatedNodeID(multiTenancyIssueNo) {
 				if !liveness.IsLive(r.clock.Now().GoTime()) {
 					return errors.Errorf(
-						"trying to adopt jobs on node %d which is not live", r.nodeID.Get())
+						"trying to adopt jobs on node %d which is not live", liveness.NodeID)
 				}
 			}
 		}
@@ -1107,7 +1110,9 @@ WHERE status IN ($1, $2, $3, $4, $5) ORDER BY created DESC`
 		_, runningOnNode := r.mu.jobs[*id]
 		r.mu.Unlock()
 
-		if notLeaseHolder := payload.Lease.NodeID != r.nodeID.Get(); notLeaseHolder {
+		if notLeaseHolder := payload.Lease.NodeID != r.nodeID.DeprecatedNodeID(
+			multiTenancyIssueNo,
+		); notLeaseHolder {
 			// Another node holds the lease on the job, see if we should steal it.
 			if runningOnNode {
 				// If we are currently running a job that another node has the lease on,
@@ -1209,7 +1214,7 @@ WHERE status IN ($1, $2, $3, $4, $5) ORDER BY created DESC`
 }
 
 func (r *Registry) newLease() *jobspb.Lease {
-	nodeID := r.nodeID.Get()
+	nodeID := r.nodeID.DeprecatedNodeID(multiTenancyIssueNo)
 	if nodeID == 0 {
 		panic("jobs.Registry has empty node ID")
 	}

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -100,7 +100,7 @@ type Registry struct {
 	db         *kv.DB
 	ex         sqlutil.InternalExecutor
 	clock      *hlc.Clock
-	nodeID     *base.NodeIDContainer
+	nodeID     *base.SQLIDContainer
 	settings   *cluster.Settings
 	planFn     planHookMaker
 	metrics    Metrics
@@ -178,7 +178,7 @@ func MakeRegistry(
 	nl NodeLiveness,
 	db *kv.DB,
 	ex sqlutil.InternalExecutor,
-	nodeID *base.NodeIDContainer,
+	nodeID *base.SQLIDContainer,
 	settings *cluster.Settings,
 	histogramWindowInterval time.Duration,
 	planFn planHookMaker,

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -258,7 +258,7 @@ func (r *Registry) makeCtx() (context.Context, func()) {
 }
 
 func (r *Registry) makeJobID() int64 {
-	return int64(builtins.GenerateUniqueInt(r.nodeID.DeprecatedNodeID(multiTenancyIssueNo)))
+	return int64(builtins.GenerateUniqueInt(r.nodeID.SQLInstanceID()))
 }
 
 // CreateAndStartJob creates and asynchronously starts a job from record. An

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -84,12 +84,13 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 		const cancelInterval = time.Duration(math.MaxInt64)
 		const adoptInterval = time.Nanosecond
 
+		var c base.NodeIDContainer
+		c.Set(ctx, id)
+		idContainer := base.NewSQLIDContainer(0, &c, true /* exposed */)
 		ac := log.AmbientContext{Tracer: tracing.NewTracer()}
-		nodeID := &base.NodeIDContainer{}
-		nodeID.Reset(id)
 		r := jobs.MakeRegistry(
 			ac, s.Stopper(), clock, nodeLiveness, db, s.InternalExecutor().(sqlutil.InternalExecutor),
-			nodeID, s.ClusterSettings(), server.DefaultHistogramWindowInterval, jobs.FakePHS, "",
+			idContainer, s.ClusterSettings(), server.DefaultHistogramWindowInterval, jobs.FakePHS, "",
 		)
 		if err := r.Start(ctx, s.Stopper(), cancelInterval, adoptInterval); err != nil {
 			t.Fatal(err)

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -55,7 +55,7 @@ func TestRegistryCancelation(t *testing.T) {
 	mClock := hlc.NewManualClock(hlc.UnixNano())
 	clock := hlc.NewClock(mClock.UnixNano, time.Nanosecond)
 	registry := MakeRegistry(
-		log.AmbientContext{}, stopper, clock, nodeLiveness, db, nil /* ex */, FakeNodeID, cluster.NoSettings,
+		log.AmbientContext{}, stopper, clock, nodeLiveness, db, nil /* ex */, base.TestingIDContainer, cluster.NoSettings,
 		histogramWindowInterval, FakePHS, "")
 
 	const cancelInterval = time.Nanosecond

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -684,7 +684,11 @@ func (db *DB) Run(ctx context.Context, b *Batch) error {
 
 // NewTxn creates a new RootTxn.
 func (db *DB) NewTxn(ctx context.Context, debugName string) *Txn {
-	txn := NewTxn(ctx, db, db.ctx.NodeID.Get())
+	// Observed timestamps don't work with multi-tenancy. See:
+	//
+	// https://github.com/cockroachdb/cockroach/issues/48008
+	nodeID, _ := db.ctx.NodeID.OptionalNodeID() // zero if not available
+	txn := NewTxn(ctx, db, nodeID)
 	txn.SetDebugName(debugName)
 	return txn
 }
@@ -698,7 +702,11 @@ func (db *DB) Txn(ctx context.Context, retryable func(context.Context, *Txn) err
 	// TODO(radu): we should open a tracing Span here (we need to figure out how
 	// to use the correct tracer).
 
-	txn := NewTxn(ctx, db, db.ctx.NodeID.Get())
+	// Observed timestamps don't work with multi-tenancy. See:
+	//
+	// https://github.com/cockroachdb/cockroach/issues/48008
+	nodeID, _ := db.ctx.NodeID.OptionalNodeID() // zero if not available
+	txn := NewTxn(ctx, db, nodeID)
 	txn.SetDebugName("unnamed")
 	err := txn.exec(ctx, func(ctx context.Context, txn *Txn) error {
 		return retryable(ctx, txn)

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -182,7 +182,7 @@ type DBContext struct {
 	UserPriority roachpb.UserPriority
 	// NodeID provides the node ID for setting the gateway node and avoiding
 	// clock uncertainty for root transactions started at the gateway.
-	NodeID *base.NodeIDContainer
+	NodeID *base.SQLIDContainer
 	// Stopper is used for async tasks.
 	Stopper *stop.Stopper
 }
@@ -190,10 +190,12 @@ type DBContext struct {
 // DefaultDBContext returns (a copy of) the default options for
 // NewDBWithContext.
 func DefaultDBContext() DBContext {
+	var c base.NodeIDContainer
 	return DBContext{
 		UserPriority: roachpb.NormalUserPriority,
-		NodeID:       &base.NodeIDContainer{},
-		Stopper:      stop.NewStopper(),
+		// TODO(tbg): this is ugly. Force callers to pass in an SQLIDContainer.
+		NodeID:  base.NewSQLIDContainer(0, &c, true /* exposed */),
+		Stopper: stop.NewStopper(),
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -237,6 +237,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// bootstrapped; otherwise a new one is allocated in Node.
 	nodeIDContainer := &base.NodeIDContainer{}
 	cfg.AmbientCtx.AddLogTag("n", nodeIDContainer)
+	const sqlInstanceID = base.SQLInstanceID(0)
+	idContainer := base.NewSQLIDContainer(sqlInstanceID, nodeIDContainer, true /* exposed */)
 
 	ctx := cfg.AmbientCtx.AnnotateCtx(context.Background())
 
@@ -329,7 +331,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	tcsFactory := kvcoord.NewTxnCoordSenderFactory(txnCoordSenderFactoryCfg, distSender)
 
 	dbCtx := kv.DefaultDBContext()
-	dbCtx.NodeID = nodeIDContainer
+	dbCtx.NodeID = idContainer
 	dbCtx.Stopper = stopper
 	db := kv.NewDBWithContext(cfg.AmbientCtx, tcsFactory, clock, dbCtx)
 
@@ -529,7 +531,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			nodeDialer:             nodeDialer,
 			grpcServer:             grpcServer.Server,
 			recorder:               recorder,
-			nodeIDContainer:        nodeIDContainer,
+			nodeIDContainer:        idContainer,
 			externalStorage:        externalStorage,
 			externalStorageFromURI: externalStorageFromURI,
 			isMeta1Leaseholder:     node.stores.IsMeta1Leaseholder,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -400,7 +400,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 			cfg.rpcContext,
 			distSQLServer,
 			cfg.distSender,
-			cfg.gossip.Deprecated(distsql.GossipIssueNo),
+			cfg.gossip.Deprecated(distsql.MultiTenancyIssueNo),
 			cfg.stopper,
 			cfg.nodeLiveness,
 			cfg.nodeDialer,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -118,7 +118,7 @@ type sqlServerOptionalArgs struct {
 	// For the temporaryObjectCleaner.
 	isMeta1Leaseholder func(hlc.Timestamp) (bool, error)
 	// DistSQL, lease management, and others want to know the node they're on.
-	nodeIDContainer *base.NodeIDContainer
+	nodeIDContainer *base.SQLIDContainer
 
 	// Used by backup/restore.
 	externalStorage        cloud.ExternalStorageFactory
@@ -609,7 +609,7 @@ func (s *sqlServer) start(
 		&migrationsExecutor,
 		s.execCfg.Clock,
 		mmKnobs,
-		s.execCfg.NodeID.String(), // TODO(tbg): set yet?
+		s.execCfg.NodeID.SQLInstanceID().String(),
 		s.execCfg.Settings,
 		s.jobRegistry,
 	)

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -528,9 +528,9 @@ func (ts *TestServer) StartTenant() (addr string, _ error) {
 		return "", err
 	}
 
-	s.execCfg.DistSQLPlanner.SetNodeDesc(roachpb.NodeDescriptor{
-		NodeID: args.nodeIDContainer.Get(),
-	})
+	// NB: this should no longer be necessary after #47902. Right now it keeps
+	// the tenant from crashing.
+	s.execCfg.DistSQLPlanner.SetNodeDesc(roachpb.NodeDescriptor{NodeID: -1})
 
 	connManager := netutil.MakeServer(
 		args.stopper,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -473,7 +473,11 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 
 	dummyRecorder := &status.MetricsRecorder{}
 
-	var nodeIDContainer base.NodeIDContainer
+	const fakeNodeID = roachpb.NodeID(9999)
+	var c base.NodeIDContainer
+	c.Set(context.Background(), fakeNodeID)
+	const sqlInstanceID = base.SQLInstanceID(10001)
+	idContainer := base.NewSQLIDContainer(sqlInstanceID, &c, false /* exposed */)
 
 	// We don't need this for anything except some services that want a gRPC
 	// server to register against (but they'll never get RPCs at the time of
@@ -493,7 +497,7 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 			isMeta1Leaseholder: func(timestamp hlc.Timestamp) (bool, error) {
 				return false, errors.New("fake isMeta1Leaseholder")
 			},
-			nodeIDContainer: &nodeIDContainer,
+			nodeIDContainer: idContainer,
 			externalStorage: func(ctx context.Context, dest roachpb.ExternalStorage) (cloud.ExternalStorage, error) {
 				return nil, errors.New("fake external storage")
 			},
@@ -519,8 +523,6 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 func (ts *TestServer) StartTenant() (addr string, _ error) {
 	ctx := context.Background()
 	args := testSQLServerArgs(ts)
-	const nodeID = 9999
-	args.nodeIDContainer.Set(context.Background(), nodeID)
 	s, err := newSQLServer(ctx, args)
 	if err != nil {
 		return "", err

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -116,7 +116,7 @@ func (n *alterIndexNode) startExec(params runParams) error {
 		params.p.txn,
 		EventLogAlterIndex,
 		int32(n.tableDesc.ID),
-		int32(params.extendedEvalCtx.NodeID),
+		int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
 		struct {
 			TableName  string
 			IndexName  string

--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -72,7 +72,7 @@ func (n *alterSequenceNode) startExec(params runParams) error {
 		params.p.txn,
 		EventLogAlterSequence,
 		int32(n.seqDesc.ID),
-		int32(params.extendedEvalCtx.NodeID),
+		int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
 		struct {
 			SequenceName string
 			Statement    string

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -825,7 +825,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 		params.p.txn,
 		EventLogAlterTable,
 		int32(n.tableDesc.ID),
-		int32(params.extendedEvalCtx.NodeID),
+		int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
 		struct {
 			TableName           string
 			Statement           string

--- a/pkg/sql/cluster_wide_id.go
+++ b/pkg/sql/cluster_wide_id.go
@@ -11,7 +11,7 @@
 package sql
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 )
@@ -23,10 +23,10 @@ type ClusterWideID struct {
 	uint128.Uint128
 }
 
-// GenerateClusterWideID takes a timestamp and node ID, and generates a
+// GenerateClusterWideID takes a timestamp and SQLInstanceID, and generates a
 // ClusterWideID.
-func GenerateClusterWideID(timestamp hlc.Timestamp, nodeID roachpb.NodeID) ClusterWideID {
-	loInt := (uint64)(nodeID)
+func GenerateClusterWideID(timestamp hlc.Timestamp, instID base.SQLInstanceID) ClusterWideID {
+	loInt := (uint64)(instID)
 	loInt = loInt | ((uint64)(timestamp.Logical) << 32)
 
 	return ClusterWideID{Uint128: uint128.FromInts((uint64)(timestamp.WallTime), loInt)}

--- a/pkg/sql/colflow/colbatch_scan_test.go
+++ b/pkg/sql/colflow/colbatch_scan_test.go
@@ -74,7 +74,7 @@ func BenchmarkColBatchScan(b *testing.B) {
 				EvalCtx: &evalCtx,
 				Cfg:     &execinfra.ServerConfig{Settings: s.ClusterSettings()},
 				Txn:     kv.NewTxn(ctx, s.DB(), s.NodeID()),
-				NodeID:  s.NodeID(),
+				NodeID:  evalCtx.NodeID,
 			}
 
 			b.SetBytes(int64(numRows * numCols * 8))

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
@@ -213,7 +212,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	ctx := context.Background()
 	defer evalCtx.Stop(ctx)
-	f := &flowinfra.FlowBase{FlowCtx: execinfra.FlowCtx{EvalCtx: &evalCtx, NodeID: roachpb.NodeID(1)}}
+	f := &flowinfra.FlowBase{FlowCtx: execinfra.FlowCtx{EvalCtx: &evalCtx, NodeID: base.TestingIDContainer}}
 	var wg sync.WaitGroup
 	vfc := newVectorizedFlowCreator(&vectorizedFlowCreatorHelper{f: f}, componentCreator, false, &wg, &execinfra.RowChannel{}, nil, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{}, nil)
 
@@ -259,7 +258,7 @@ func TestVectorizedFlowTempDirectory(t *testing.T) {
 						Metrics:         &execinfra.DistSQLMetrics{},
 					},
 					EvalCtx: &evalCtx,
-					NodeID:  roachpb.NodeID(1),
+					NodeID:  base.TestingIDContainer,
 				},
 			},
 		).(*vectorizedFlow)

--- a/pkg/sql/comment_on_column.go
+++ b/pkg/sql/comment_on_column.go
@@ -84,7 +84,7 @@ func (n *commentOnColumnNode) startExec(params runParams) error {
 		params.p.txn,
 		EventLogCommentOnColumn,
 		int32(n.tableDesc.ID),
-		int32(params.extendedEvalCtx.NodeID),
+		int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
 		struct {
 			TableName  string
 			ColumnName string

--- a/pkg/sql/comment_on_database.go
+++ b/pkg/sql/comment_on_database.go
@@ -76,7 +76,7 @@ func (n *commentOnDatabaseNode) startExec(params runParams) error {
 		params.p.txn,
 		EventLogCommentOnDatabase,
 		int32(n.dbDesc.ID),
-		int32(params.extendedEvalCtx.NodeID),
+		int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
 		struct {
 			DatabaseName string
 			Statement    string

--- a/pkg/sql/comment_on_index.go
+++ b/pkg/sql/comment_on_index.go
@@ -59,7 +59,7 @@ func (n *commentOnIndexNode) startExec(params runParams) error {
 		params.p.txn,
 		EventLogCommentOnIndex,
 		int32(n.tableDesc.ID),
-		int32(params.extendedEvalCtx.NodeID),
+		int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
 		struct {
 			TableName string
 			IndexName string

--- a/pkg/sql/comment_on_table.go
+++ b/pkg/sql/comment_on_table.go
@@ -75,7 +75,7 @@ func (n *commentOnTableNode) startExec(params runParams) error {
 		params.p.txn,
 		EventLogCommentOnTable,
 		int32(n.tableDesc.ID),
-		int32(params.extendedEvalCtx.NodeID),
+		int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
 		struct {
 			TableName string
 			Statement string

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1798,11 +1798,11 @@ func stmtHasNoData(stmt tree.Statement) bool {
 	return stmt == nil || stmt.StatementType() != tree.Rows
 }
 
-// generateID generates a unique ID based on the node's ID and its current HLC
-// timestamp. These IDs are either scoped at the query level or at the session
-// level.
+// generateID generates a unique ID based on the SQL instance ID and its current
+// HLC timestamp. These IDs are either scoped at the query level or at the
+// session level.
 func (ex *connExecutor) generateID() ClusterWideID {
-	return GenerateClusterWideID(ex.server.cfg.Clock.Now(), ex.server.cfg.NodeID.Get())
+	return GenerateClusterWideID(ex.server.cfg.Clock.Now(), ex.server.cfg.NodeID.SQLInstanceID())
 }
 
 // commitPrepStmtNamespace deallocates everything in

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -564,6 +564,7 @@ func (s *Server) newConnExecutor(
 		-1 /* increment */, noteworthyMemoryUsageBytes, s.cfg.Settings,
 	)
 
+	nodeIDOrZero, _ := s.cfg.NodeID.OptionalNodeID()
 	ex := &connExecutor{
 		server:      s,
 		metrics:     srvMetrics,
@@ -578,9 +579,9 @@ func (s *Server) newConnExecutor(
 			connCtx: ctx,
 		},
 		transitionCtx: transitionCtx{
-			db:     s.cfg.DB,
-			nodeID: s.cfg.NodeID.Get(),
-			clock:  s.cfg.Clock,
+			db:           s.cfg.DB,
+			nodeIDOrZero: nodeIDOrZero,
+			clock:        s.cfg.Clock,
 			// Future transaction's monitors will inherits from sessionRootMon.
 			connMon:  &sessionRootMon,
 			tracer:   s.cfg.AmbientCtx.Tracer,

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1972,7 +1972,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			TestingKnobs:       ex.server.cfg.EvalContextTestingKnobs,
 			ClusterID:          ex.server.cfg.ClusterID(),
 			ClusterName:        ex.server.cfg.RPCContext.ClusterName(),
-			NodeID:             ex.server.cfg.NodeID.Get(),
+			NodeID:             ex.server.cfg.NodeID,
 			Codec:              ex.server.cfg.Codec,
 			Locality:           ex.server.cfg.Locality,
 			ReCache:            ex.server.reCache,

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -738,8 +738,10 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 
 	ex.sessionTracing.TracePlanCheckStart(ctx)
 	distributePlan := false
-	distributePlan = shouldDistributePlan(
-		ctx, ex.sessionData.DistSQLMode, ex.server.cfg.DistSQLPlanner, planner.curPlan.plan)
+	if _, noMultiTenancy := planner.execCfg.NodeID.OptionalNodeID(); noMultiTenancy {
+		distributePlan = shouldDistributePlan(
+			ctx, ex.sessionData.DistSQLMode, ex.server.cfg.DistSQLPlanner, planner.curPlan.plan)
+	}
 	ex.sessionTracing.TracePlanCheckEnd(ctx, nil, distributePlan)
 
 	if ex.server.cfg.TestingKnobs.BeforeExecute != nil {

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -621,7 +621,7 @@ func (ex *connExecutor) checkTableTwoVersionInvariant(ctx context.Context) error
 
 	// Create a new transaction to retry with a higher timestamp than the
 	// timestamps used in the retry loop above.
-	ex.state.mu.txn = kv.NewTxnWithSteppingEnabled(ctx, ex.transitionCtx.db, ex.transitionCtx.nodeID)
+	ex.state.mu.txn = kv.NewTxnWithSteppingEnabled(ctx, ex.transitionCtx.db, ex.transitionCtx.nodeIDOrZero)
 	if err := ex.state.mu.txn.SetUserPriority(userPriority); err != nil {
 		return err
 	}

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -254,8 +254,7 @@ func startConnExecutor(
 		})
 	db := kv.NewDB(testutils.MakeAmbientCtx(), factory, clock)
 	st := cluster.MakeTestingClusterSettings()
-	nodeID := &base.NodeIDContainer{}
-	nodeID.Set(ctx, 1)
+	nodeID := base.TestingIDContainer
 	distSQLMetrics := execinfra.MakeDistSQLMetrics(time.Hour /* histogramWindow */)
 	cfg := &ExecutorConfig{
 		AmbientCtx:      testutils.MakeAmbientCtx(),

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -116,8 +116,7 @@ CREATE TABLE crdb_internal.node_build_info (
 )`,
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		execCfg := p.ExecCfg()
-		nodeID, _ := execCfg.NodeID.OptionalNodeID()
-		dNodeID := tree.NewDInt(tree.DInt(nodeID))
+		nodeID, _ := execCfg.NodeID.OptionalNodeID() // zero if not available
 
 		info := build.GetInfo()
 		for k, v := range map[string]string{
@@ -129,7 +128,7 @@ CREATE TABLE crdb_internal.node_build_info (
 			"Channel":      info.Channel,
 		} {
 			if err := addRow(
-				dNodeID,
+				tree.NewDInt(tree.DInt(nodeID)),
 				tree.NewDString(k),
 				tree.NewDString(v),
 			); err != nil {
@@ -678,7 +677,7 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 				"cannot access sql statistics from this context")
 		}
 
-		nodeID := tree.NewDInt(tree.DInt(int64(p.execCfg.NodeID.Get())))
+		nodeID, _ := p.execCfg.NodeID.OptionalNodeID() // zero if not available
 
 		// Retrieve the application names and sort them to ensure the
 		// output is deterministic.
@@ -720,7 +719,7 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 					errString = tree.NewDString(s.data.SensitiveInfo.LastErr)
 				}
 				err := addRow(
-					nodeID,
+					tree.NewDInt(tree.DInt(nodeID)),
 					tree.NewDString(appName),
 					tree.NewDString(stmtKey.flags()),
 					tree.NewDString(stmtKey.stmt),
@@ -779,7 +778,7 @@ CREATE TABLE crdb_internal.node_txn_stats (
 				"cannot access sql statistics from this context")
 		}
 
-		nodeID := tree.NewDInt(tree.DInt(int64(p.execCfg.NodeID.Get())))
+		nodeID, _ := p.execCfg.NodeID.OptionalNodeID() // zero if not available
 
 		// Retrieve the application names and sort them to ensure the
 		// output is deterministic.
@@ -795,7 +794,7 @@ CREATE TABLE crdb_internal.node_txn_stats (
 			appStats := sqlStats.getStatsForApplication(appName)
 			txnCount, txnTimeAvg, txnTimeVar, committedCount, implicitCount := appStats.txns.getStats()
 			err := addRow(
-				nodeID,
+				tree.NewDInt(tree.DInt(nodeID)),
 				tree.NewDString(appName),
 				tree.NewDInt(tree.DInt(txnCount)),
 				tree.NewDFloat(tree.DFloat(txnTimeAvg)),

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -116,7 +116,8 @@ CREATE TABLE crdb_internal.node_build_info (
 )`,
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		execCfg := p.ExecCfg()
-		nodeID := tree.NewDInt(tree.DInt(int64(execCfg.NodeID.Get())))
+		nodeID, _ := execCfg.NodeID.OptionalNodeID()
+		dNodeID := tree.NewDInt(tree.DInt(nodeID))
 
 		info := build.GetInfo()
 		for k, v := range map[string]string{
@@ -128,7 +129,7 @@ CREATE TABLE crdb_internal.node_build_info (
 			"Channel":      info.Channel,
 		} {
 			if err := addRow(
-				nodeID,
+				dNodeID,
 				tree.NewDString(k),
 				tree.NewDString(v),
 			); err != nil {

--- a/pkg/sql/create_database.go
+++ b/pkg/sql/create_database.go
@@ -91,7 +91,7 @@ func (n *createDatabaseNode) startExec(params runParams) error {
 			params.p.txn,
 			EventLogCreateDatabase,
 			int32(desc.ID),
-			int32(params.extendedEvalCtx.NodeID),
+			int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
 			struct {
 				DatabaseName string
 				Statement    string

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -411,7 +411,7 @@ func (n *createIndexNode) startExec(params runParams) error {
 		params.p.txn,
 		EventLogCreateIndex,
 		int32(n.tableDesc.ID),
-		int32(params.extendedEvalCtx.NodeID),
+		int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
 		struct {
 			TableName  string
 			IndexName  string

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -144,7 +144,7 @@ func doCreateSequence(
 		params.p.txn,
 		EventLogCreateSequence,
 		int32(desc.ID),
-		int32(params.extendedEvalCtx.NodeID),
+		int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
 		struct {
 			SequenceName string
 			Statement    string

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -461,7 +461,7 @@ func (r *createStatsResumer) Resume(
 			txn,
 			EventLogCreateStatistics,
 			int32(details.Table.ID),
-			int32(evalCtx.NodeID),
+			int32(evalCtx.NodeID.SQLInstanceID()),
 			struct {
 				TableName string
 				Statement string

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -355,7 +355,7 @@ func (n *createTableNode) startExec(params runParams) error {
 		params.p.txn,
 		EventLogCreateTable,
 		int32(desc.ID),
-		int32(params.extendedEvalCtx.NodeID),
+		int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
 		struct {
 			TableName string
 			Statement string

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -207,7 +207,7 @@ func (n *createViewNode) startExec(params runParams) error {
 		params.p.txn,
 		EventLogCreateView,
 		int32(newDesc.ID),
-		int32(params.extendedEvalCtx.NodeID),
+		int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
 		struct {
 			ViewName  string
 			ViewQuery string

--- a/pkg/sql/distsql/inbound_test.go
+++ b/pkg/sql/distsql/inbound_test.go
@@ -56,8 +56,6 @@ func TestOutboxInboundStreamIntegration(t *testing.T) {
 	ctx := context.Background()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
-	ni := base.NodeIDContainer{}
-	ni.Set(ctx, 1)
 	st := cluster.MakeTestingClusterSettings()
 	mt := execinfra.MakeDistSQLMetrics(time.Hour /* histogramWindow */)
 	srv := NewServer(
@@ -66,7 +64,7 @@ func TestOutboxInboundStreamIntegration(t *testing.T) {
 			Settings: st,
 			Stopper:  stopper,
 			Metrics:  &mt,
-			NodeID:   &ni,
+			NodeID:   base.TestingIDContainer,
 		},
 	)
 

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -175,7 +175,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 							ClusterID:      &dsp.rpcCtx.ClusterID,
 							VecFDSemaphore: dsp.distSQLSrv.VecFDSemaphore,
 						},
-						NodeID: -1,
+						NodeID: evalCtx.NodeID,
 					}, spec.Processors, fuseOpt, recv,
 				); err != nil {
 					// Vectorization attempt failed with an error.

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -257,7 +257,7 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 		p.txn,
 		EventLogDropDatabase,
 		int32(n.dbDesc.ID),
-		int32(params.extendedEvalCtx.NodeID),
+		int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
 		struct {
 			DatabaseName         string
 			Statement            string

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -505,7 +505,7 @@ func (p *planner) dropIndexByName(
 		p.txn,
 		EventLogDropIndex,
 		int32(tableDesc.ID),
-		int32(p.extendedEvalCtx.NodeID),
+		int32(p.extendedEvalCtx.NodeID.SQLInstanceID()),
 		struct {
 			TableName           string
 			IndexName           string

--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -82,7 +82,7 @@ func (n *dropSequenceNode) startExec(params runParams) error {
 			params.p.txn,
 			EventLogDropSequence,
 			int32(droppedDesc.ID),
-			int32(params.extendedEvalCtx.NodeID),
+			int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
 			struct {
 				SequenceName string
 				Statement    string

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -125,7 +125,7 @@ func (n *dropTableNode) startExec(params runParams) error {
 			params.p.txn,
 			EventLogDropTable,
 			int32(droppedDesc.ID),
-			int32(params.extendedEvalCtx.NodeID),
+			int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
 			struct {
 				TableName           string
 				Statement           string

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -99,7 +99,7 @@ func (n *dropViewNode) startExec(params runParams) error {
 			params.p.txn,
 			EventLogDropView,
 			int32(droppedDesc.ID),
-			int32(params.extendedEvalCtx.NodeID),
+			int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
 			struct {
 				ViewName            string
 				Statement           string

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -569,7 +569,7 @@ func getMetricMeta(meta metric.Metadata, internal bool) metric.Metadata {
 // NodeInfo contains metadata about the executing node and cluster.
 type NodeInfo struct {
 	ClusterID func() uuid.UUID
-	NodeID    *base.NodeIDContainer
+	NodeID    *base.SQLIDContainer
 	AdminURL  func() *url.URL
 	PGURL     func(*url.Userinfo) (*url.URL, error)
 }

--- a/pkg/sql/execinfra/flow_context.go
+++ b/pkg/sql/execinfra/flow_context.go
@@ -13,9 +13,9 @@
 package execinfra
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -53,7 +53,7 @@ type FlowCtx struct {
 
 	// nodeID is the ID of the node on which the processors using this FlowCtx
 	// run.
-	NodeID roachpb.NodeID
+	NodeID *base.SQLIDContainer
 
 	// TraceKV is true if KV tracing was requested by the session.
 	TraceKV bool

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -88,7 +88,7 @@ type ServerConfig struct {
 	ClusterName string
 
 	// NodeID is the id of the node on which this Server is running.
-	NodeID *base.NodeIDContainer
+	NodeID *base.SQLIDContainer
 
 	// Codec is capable of encoding and decoding sql table keys.
 	Codec keys.SQLCodec

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -204,7 +205,11 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 		}
 		diagram.AddSpans(spans)
 	} else {
-		flows := plan.GenerateFlowSpecs(params.extendedEvalCtx.NodeID)
+		nodeID, err := params.extendedEvalCtx.NodeID.OptionalNodeIDErr(distsql.MultiTenancyIssueNo)
+		if err != nil {
+			return err
+		}
+		flows := plan.GenerateFlowSpecs(nodeID)
 		showInputTypes := n.options.Flags[tree.ExplainFlagTypes]
 		diagram, err = execinfrapb.GeneratePlanDiagram(params.p.stmt.String(), flows, showInputTypes)
 		if err != nil {

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colflow"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
@@ -71,7 +72,11 @@ func (n *explainVecNode) startExec(params runParams) error {
 	}
 
 	distSQLPlanner.FinalizePlan(planCtx, &plan)
-	flows := plan.GenerateFlowSpecs(params.extendedEvalCtx.NodeID)
+	nodeID, err := params.extendedEvalCtx.NodeID.OptionalNodeIDErr(distsql.MultiTenancyIssueNo)
+	if err != nil {
+		return err
+	}
+	flows := plan.GenerateFlowSpecs(nodeID)
 	flowCtx := makeFlowCtx(planCtx, plan, params)
 	flowCtx.Cfg.ClusterID = &distSQLPlanner.rpcCtx.ClusterID
 

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -138,7 +138,7 @@ func storedLeaseExpiration(expiration hlc.Timestamp) tree.DTimestamp {
 // LeaseStore implements the operations for acquiring and releasing leases and
 // publishing a new version of a descriptor. Exported only for testing.
 type LeaseStore struct {
-	nodeIDContainer  *base.NodeIDContainer
+	nodeIDContainer  *base.SQLIDContainer
 	db               *kv.DB
 	clock            *hlc.Clock
 	internalExecutor sqlutil.InternalExecutor
@@ -1426,7 +1426,7 @@ const leaseConcurrencyLimit = 5
 // stopper is used to run async tasks. Can be nil in tests.
 func NewLeaseManager(
 	ambientCtx log.AmbientContext,
-	nodeIDContainer *base.NodeIDContainer,
+	nodeIDContainer *base.SQLIDContainer,
 	db *kv.DB,
 	clock *hlc.Clock,
 	internalExecutor sqlutil.InternalExecutor,

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -228,7 +228,7 @@ func (s LeaseStore) acquire(
 			return err
 		}
 
-		nodeID := s.nodeIDContainer.Get()
+		nodeID := s.nodeIDContainer.SQLInstanceID()
 		if nodeID == 0 {
 			panic("zero nodeID")
 		}
@@ -270,7 +270,7 @@ func (s LeaseStore) release(ctx context.Context, stopper *stop.Stopper, lease *s
 	// NodeUnavailableErrors.
 	for r := retry.Start(retryOptions); r.Next(); {
 		log.VEventf(ctx, 2, "LeaseStore releasing lease %+v", lease)
-		nodeID := s.nodeIDContainer.Get()
+		nodeID := s.nodeIDContainer.SQLInstanceID()
 		if nodeID == 0 {
 			panic("zero nodeID")
 		}
@@ -1920,7 +1920,9 @@ func (m *LeaseManager) DeleteOrphanedLeases(timeThreshold int64) {
 	if m.testingKnobs.DisableDeleteOrphanedLeases {
 		return
 	}
-	nodeID := m.LeaseStore.nodeIDContainer.Get()
+	// TODO(asubiotto): clear up the nodeID naming here and in the table below,
+	// tracked as https://github.com/cockroachdb/cockroach/issues/48271.
+	nodeID := m.LeaseStore.nodeIDContainer.SQLInstanceID()
 	if nodeID == 0 {
 		panic("zero nodeID")
 	}

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -197,8 +197,9 @@ func (t *leaseTest) mustPublish(ctx context.Context, nodeID uint32, descID sqlba
 func (t *leaseTest) node(nodeID uint32) *sql.LeaseManager {
 	mgr := t.nodes[nodeID]
 	if mgr == nil {
-		nc := &base.NodeIDContainer{}
-		nc.Set(context.TODO(), roachpb.NodeID(nodeID))
+		var c base.NodeIDContainer
+		c.Set(context.Background(), roachpb.NodeID(nodeID))
+		nc := base.NewSQLIDContainer(0, &c, true /* exposed*/)
 		// Hack the ExecutorConfig that we pass to the LeaseManager to have a
 		// different node id.
 		cfgCpy := t.server.ExecutorConfig().(sql.ExecutorConfig)

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -295,7 +295,7 @@ func newInternalPlanner(
 	p.extendedEvalCtx.Sequence = p
 	p.extendedEvalCtx.ClusterID = execCfg.ClusterID()
 	p.extendedEvalCtx.ClusterName = execCfg.RPCContext.ClusterName()
-	p.extendedEvalCtx.NodeID = execCfg.NodeID.Get()
+	p.extendedEvalCtx.NodeID = execCfg.NodeID
 	p.extendedEvalCtx.Locality = execCfg.Locality
 
 	p.sessionDataMutator = dataMutator

--- a/pkg/sql/rowexec/index_skip_table_reader_test.go
+++ b/pkg/sql/rowexec/index_skip_table_reader_test.go
@@ -429,7 +429,7 @@ func TestIndexSkipTableReader(t *testing.T) {
 				EvalCtx: &evalCtx,
 				Cfg:     &execinfra.ServerConfig{Settings: s.ClusterSettings()},
 				Txn:     kv.NewTxn(ctx, s.DB(), s.NodeID()),
-				NodeID:  s.NodeID(),
+				NodeID:  evalCtx.NodeID,
 			}
 
 			tr, err := newIndexSkipTableReader(&flowCtx, 0 /* processorID */, &ts, &c.post, nil)
@@ -500,7 +500,7 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 		EvalCtx: &evalCtx,
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		Txn:     kv.NewTxn(ctx, tc.Server(0).DB(), nodeID),
-		NodeID:  nodeID,
+		NodeID:  evalCtx.NodeID,
 	}
 	spec := execinfrapb.IndexSkipTableReaderSpec{
 		Spans: []execinfrapb.TableReaderSpan{{Span: td.PrimaryIndexSpan(keys.SystemSQLCodec)}},
@@ -625,7 +625,7 @@ func BenchmarkIndexScanTableReader(b *testing.B) {
 				EvalCtx: &evalCtx,
 				Cfg:     &execinfra.ServerConfig{Settings: s.ClusterSettings()},
 				Txn:     kv.NewTxn(ctx, s.DB(), s.NodeID()),
-				NodeID:  s.NodeID(),
+				NodeID:  evalCtx.NodeID,
 			}
 
 			b.Run(fmt.Sprintf("TableReader+Distinct-rows=%d-ratio=%d", numRows, valueRatio), func(b *testing.B) {
@@ -662,7 +662,7 @@ func BenchmarkIndexScanTableReader(b *testing.B) {
 				EvalCtx: &evalCtx,
 				Cfg:     &execinfra.ServerConfig{Settings: s.ClusterSettings()},
 				Txn:     kv.NewTxn(ctx, s.DB(), s.NodeID()),
-				NodeID:  s.NodeID(),
+				NodeID:  evalCtx.NodeID,
 			}
 
 			// run the index skip table reader

--- a/pkg/sql/rowexec/interleaved_reader_joiner_test.go
+++ b/pkg/sql/rowexec/interleaved_reader_joiner_test.go
@@ -403,7 +403,7 @@ func TestInterleavedReaderJoiner(t *testing.T) {
 				Cfg:     &execinfra.ServerConfig{Settings: s.ClusterSettings()},
 				// Run in a RootTxn so that there's no txn metadata produced.
 				Txn:    kv.NewTxn(ctx, s.DB(), s.NodeID()),
-				NodeID: s.NodeID(),
+				NodeID: evalCtx.NodeID,
 			}
 
 			out := &distsqlutils.RowBuffer{}
@@ -533,7 +533,7 @@ func TestInterleavedReaderJoinerErrors(t *testing.T) {
 				Cfg:     &execinfra.ServerConfig{Settings: s.ClusterSettings()},
 				// Run in a RootTxn so that there's no txn metadata produced.
 				Txn:    kv.NewTxn(ctx, s.DB(), s.NodeID()),
-				NodeID: s.NodeID(),
+				NodeID: evalCtx.NodeID,
 			}
 
 			out := &distsqlutils.RowBuffer{}
@@ -592,7 +592,7 @@ func TestInterleavedReaderJoinerTrailingMetadata(t *testing.T) {
 		Cfg:     &execinfra.ServerConfig{Settings: s.ClusterSettings()},
 		// Run in a LeafTxn so that txn metadata is produced.
 		Txn:    leafTxn,
-		NodeID: s.NodeID(),
+		NodeID: evalCtx.NodeID,
 	}
 
 	innerJoinSpec := execinfrapb.InterleavedReaderJoinerSpec{

--- a/pkg/sql/rowexec/scrub_tablereader.go
+++ b/pkg/sql/rowexec/scrub_tablereader.go
@@ -68,7 +68,8 @@ func newScrubTableReader(
 	post *execinfrapb.PostProcessSpec,
 	output execinfra.RowReceiver,
 ) (*scrubTableReader, error) {
-	if flowCtx.NodeID == 0 {
+	// NB: we hit this with a zero NodeID (but !ok) with multi-tenancy.
+	if nodeID, ok := flowCtx.NodeID.OptionalNodeID(); nodeID == 0 && ok {
 		return nil, errors.Errorf("attempting to create a tableReader with uninitialized NodeID")
 	}
 	tr := &scrubTableReader{

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -78,7 +78,8 @@ func newTableReader(
 	post *execinfrapb.PostProcessSpec,
 	output execinfra.RowReceiver,
 ) (*tableReader, error) {
-	if flowCtx.NodeID == 0 {
+	// NB: we hit this with a zero NodeID (but !ok) with multi-tenancy.
+	if nodeID, ok := flowCtx.NodeID.OptionalNodeID(); ok && nodeID == 0 {
 		return nil, errors.Errorf("attempting to create a tableReader with uninitialized NodeID")
 	}
 
@@ -275,9 +276,12 @@ func (tr *tableReader) outputStatsToTrace() {
 func (tr *tableReader) generateMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
 	var trailingMeta []execinfrapb.ProducerMetadata
 	if !tr.ignoreMisplannedRanges {
-		ranges := execinfra.MisplannedRanges(ctx, tr.fetcher.GetRangesInfo(), tr.FlowCtx.NodeID)
-		if ranges != nil {
-			trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{Ranges: ranges})
+		nodeID, ok := tr.FlowCtx.NodeID.OptionalNodeID()
+		if ok {
+			ranges := execinfra.MisplannedRanges(ctx, tr.fetcher.GetRangesInfo(), nodeID)
+			if ranges != nil {
+				trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{Ranges: ranges})
+			}
 		}
 	}
 	if tfs := execinfra.GetLeafTxnFinalState(ctx, tr.FlowCtx.Txn); tfs != nil {

--- a/pkg/sql/rowexec/tablereader_test.go
+++ b/pkg/sql/rowexec/tablereader_test.go
@@ -132,7 +132,7 @@ func TestTableReader(t *testing.T) {
 					EvalCtx: &evalCtx,
 					Cfg:     &execinfra.ServerConfig{Settings: s.ClusterSettings()},
 					Txn:     kv.NewTxn(ctx, s.DB(), s.NodeID()),
-					NodeID:  s.NodeID(),
+					NodeID:  evalCtx.NodeID,
 				}
 
 				var out execinfra.RowReceiver
@@ -212,12 +212,12 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 	st := tc.Server(0).ClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
-	nodeID := tc.Server(0).NodeID()
+
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
 		Cfg:     &execinfra.ServerConfig{Settings: st},
-		Txn:     kv.NewTxn(ctx, tc.Server(0).DB(), nodeID),
-		NodeID:  nodeID,
+		Txn:     kv.NewTxn(ctx, tc.Server(0).DB(), tc.Server(0).NodeID()),
+		NodeID:  evalCtx.NodeID,
 	}
 	spec := execinfrapb.TableReaderSpec{
 		Spans: []execinfrapb.TableReaderSpan{{Span: td.PrimaryIndexSpan(keys.SystemSQLCodec)}},
@@ -322,7 +322,7 @@ func TestLimitScans(t *testing.T) {
 		EvalCtx: &evalCtx,
 		Cfg:     &execinfra.ServerConfig{Settings: s.ClusterSettings()},
 		Txn:     kv.NewTxn(ctx, kvDB, s.NodeID()),
-		NodeID:  s.NodeID(),
+		NodeID:  evalCtx.NodeID,
 	}
 	spec := execinfrapb.TableReaderSpec{
 		Table: *tableDesc,
@@ -426,7 +426,7 @@ func BenchmarkTableReader(b *testing.B) {
 			EvalCtx: &evalCtx,
 			Cfg:     &execinfra.ServerConfig{Settings: s.ClusterSettings()},
 			Txn:     kv.NewTxn(ctx, s.DB(), s.NodeID()),
-			NodeID:  s.NodeID(),
+			NodeID:  evalCtx.NodeID,
 		}
 
 		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -72,7 +73,7 @@ type SchemaChanger struct {
 	tableID           sqlbase.ID
 	mutationID        sqlbase.MutationID
 	droppedDatabaseID sqlbase.ID
-	nodeID            roachpb.NodeID
+	sqlInstanceID     base.SQLInstanceID
 	db                *kv.DB
 	leaseMgr          *LeaseManager
 
@@ -96,7 +97,7 @@ type SchemaChanger struct {
 func NewSchemaChangerForTesting(
 	tableID sqlbase.ID,
 	mutationID sqlbase.MutationID,
-	nodeID roachpb.NodeID,
+	sqlInstanceID base.SQLInstanceID,
 	db kv.DB,
 	leaseMgr *LeaseManager,
 	jobRegistry *jobs.Registry,
@@ -104,14 +105,14 @@ func NewSchemaChangerForTesting(
 	settings *cluster.Settings,
 ) SchemaChanger {
 	return SchemaChanger{
-		tableID:     tableID,
-		mutationID:  mutationID,
-		nodeID:      nodeID,
-		db:          &db,
-		leaseMgr:    leaseMgr,
-		jobRegistry: jobRegistry,
-		settings:    settings,
-		execCfg:     execCfg,
+		tableID:       tableID,
+		mutationID:    mutationID,
+		sqlInstanceID: sqlInstanceID,
+		db:            &db,
+		leaseMgr:      leaseMgr,
+		jobRegistry:   jobRegistry,
+		settings:      settings,
+		execCfg:       execCfg,
 	}
 }
 
@@ -959,7 +960,7 @@ func (sc *SchemaChanger) done(ctx context.Context) (*sqlbase.ImmutableTableDescr
 			txn,
 			schemaChangeEventType,
 			int32(sc.tableID),
-			int32(sc.nodeID),
+			int32(sc.sqlInstanceID),
 			struct {
 				MutationID uint32
 			}{uint32(sc.mutationID)},
@@ -1193,7 +1194,7 @@ func (sc *SchemaChanger) maybeReverseMutations(ctx context.Context, causingError
 			txn,
 			EventLogReverseSchemaChange,
 			int32(sc.tableID),
-			int32(sc.nodeID),
+			int32(sc.sqlInstanceID),
 			struct {
 				Error      string
 				MutationID uint32
@@ -1583,7 +1584,7 @@ func (r schemaChangeResumer) Resume(
 			tableID:              tableID,
 			mutationID:           mutationID,
 			droppedDatabaseID:    droppedDatabaseID,
-			nodeID:               p.ExecCfg().NodeID.Get(),
+			sqlInstanceID:        p.ExecCfg().NodeID.SQLInstanceID(),
 			db:                   p.ExecCfg().DB,
 			leaseMgr:             p.ExecCfg().LeaseManager,
 			testingKnobs:         p.ExecCfg().SchemaChangerTestingKnobs,
@@ -1690,7 +1691,7 @@ func (r schemaChangeResumer) OnFailOrCancel(ctx context.Context, phs interface{}
 	sc := SchemaChanger{
 		tableID:              details.TableID,
 		mutationID:           details.MutationID,
-		nodeID:               p.ExecCfg().NodeID.Get(),
+		sqlInstanceID:        p.ExecCfg().NodeID.SQLInstanceID(),
 		db:                   p.ExecCfg().DB,
 		leaseMgr:             p.ExecCfg().LeaseManager,
 		testingKnobs:         p.ExecCfg().SchemaChangerTestingKnobs,

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1541,7 +1541,7 @@ func createSchemaChangeEvalCtx(
 			TestingKnobs:       execCfg.EvalContextTestingKnobs,
 			ClusterID:          execCfg.ClusterID(),
 			ClusterName:        execCfg.RPCContext.ClusterName(),
-			NodeID:             execCfg.NodeID.Get(),
+			NodeID:             execCfg.NodeID,
 			Codec:              execCfg.Codec,
 			Locality:           execCfg.Locality,
 		},

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -87,7 +87,7 @@ func TestSchemaChangeProcess(t *testing.T) {
 	defer s.Stopper().Stop(context.TODO())
 
 	var id = sqlbase.ID(keys.MinNonPredefinedUserDescID + 1 /* skip over DB ID */)
-	var node = roachpb.NodeID(2)
+	var instance = base.SQLInstanceID(2)
 	stopper := stop.NewStopper()
 	cfg := base.NewLeaseManagerConfig()
 	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
@@ -105,7 +105,7 @@ func TestSchemaChangeProcess(t *testing.T) {
 	jobRegistry := s.JobRegistry().(*jobs.Registry)
 	defer stopper.Stop(context.TODO())
 	changer := sql.NewSchemaChangerForTesting(
-		id, 0, node, *kvDB, leaseMgr, jobRegistry, &execCfg, cluster.MakeTestingClusterSettings())
+		id, 0, instance, *kvDB, leaseMgr, jobRegistry, &execCfg, cluster.MakeTestingClusterSettings())
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -140,7 +140,7 @@ INSERT INTO t.test VALUES ('a', 'b'), ('c', 'd');
 	index.ID = tableDesc.NextIndexID
 	tableDesc.NextIndexID++
 	changer = sql.NewSchemaChangerForTesting(
-		id, tableDesc.NextMutationID, node, *kvDB, leaseMgr, jobRegistry,
+		id, tableDesc.NextMutationID, instance, *kvDB, leaseMgr, jobRegistry,
 		&execCfg, cluster.MakeTestingClusterSettings(),
 	)
 	tableDesc.Mutations = append(tableDesc.Mutations, sqlbase.DescriptorMutation{

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2831,7 +2831,7 @@ type EvalContext struct {
 	Settings    *cluster.Settings
 	ClusterID   uuid.UUID
 	ClusterName string
-	NodeID      roachpb.NodeID
+	NodeID      *base.SQLIDContainer
 	Codec       keys.SQLCodec
 
 	// Locality contains the location of the current node as a set of user-defined
@@ -2946,6 +2946,7 @@ func MakeTestingEvalContextWithMon(st *cluster.Settings, monitor *mon.BytesMonit
 		Txn:         &kv.Txn{},
 		SessionData: &sessiondata.SessionData{},
 		Settings:    st,
+		NodeID:      base.TestingIDContainer,
 	}
 	monitor.Start(context.Background(), nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
 	ctx.Mon = monitor

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -47,7 +47,7 @@ func (p *planner) IncrementSequence(ctx context.Context, seqName *tree.TableName
 	seqOpts := descriptor.SequenceOpts
 	var val int64
 	if seqOpts.Virtual {
-		rowid := builtins.GenerateUniqueInt(p.EvalContext().NodeID)
+		rowid := builtins.GenerateUniqueInt(p.EvalContext().NodeID.SQLInstanceID())
 		val = int64(rowid)
 	} else {
 		seqValueKey := keys.TODOSQLCodec.SequenceKey(uint32(descriptor.ID))

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -196,7 +196,7 @@ func (n *setClusterSettingNode) startExec(params runParams) error {
 			txn,
 			EventLogSetClusterSetting,
 			0, /* no target */
-			int32(params.extendedEvalCtx.NodeID),
+			int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
 			EventLogSetClusterSettingDetail{n.name, reportedValue, params.SessionData().User},
 		)
 	}); err != nil {

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -682,7 +682,7 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 			params.p.txn,
 			eventLogType,
 			int32(targetID),
-			int32(params.extendedEvalCtx.NodeID),
+			int32(params.extendedEvalCtx.NodeID.SQLInstanceID()),
 			info,
 		)
 	}

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -136,7 +136,7 @@ func (t *truncateNode) startExec(params runParams) error {
 			p.txn,
 			EventLogTruncateTable,
 			int32(id),
-			int32(p.extendedEvalCtx.NodeID),
+			int32(p.extendedEvalCtx.NodeID.SQLInstanceID()),
 			struct {
 				TableName string
 				Statement string

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -199,7 +199,7 @@ func (ts *txnState) resetForNewSQLTxn(
 	ts.mon.Start(ts.Ctx, tranCtx.connMon, mon.BoundAccount{} /* reserved */)
 	ts.mu.Lock()
 	if txn == nil {
-		ts.mu.txn = kv.NewTxnWithSteppingEnabled(ts.Ctx, tranCtx.db, tranCtx.nodeID)
+		ts.mu.txn = kv.NewTxnWithSteppingEnabled(ts.Ctx, tranCtx.db, tranCtx.nodeIDOrZero)
 		ts.mu.txn.SetDebugName(opName)
 	} else {
 		ts.mu.txn = txn
@@ -399,9 +399,9 @@ type advanceInfo struct {
 
 // transitionCtx is a bag of fields needed by some state machine events.
 type transitionCtx struct {
-	db     *kv.DB
-	nodeID roachpb.NodeID
-	clock  *hlc.Clock
+	db           *kv.DB
+	nodeIDOrZero roachpb.NodeID // zero on SQL tenant servers, see #48008
+	clock        *hlc.Clock
 	// connMon is the connExecutor's monitor. New transactions will create a child
 	// monitor tracking txn-scoped objects.
 	connMon *mon.BytesMonitor

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -211,7 +211,7 @@ func TestTransitions(t *testing.T) {
 	testCon := makeTestContext()
 	tranCtx := transitionCtx{
 		db:             testCon.mockDB,
-		nodeID:         roachpb.NodeID(5),
+		nodeIDOrZero:   roachpb.NodeID(5),
 		clock:          testCon.clock,
 		tracer:         tracing.NewTracer(),
 		connMon:        &testCon.mon,

--- a/pkg/sql/values_test.go
+++ b/pkg/sql/values_test.go
@@ -36,11 +36,9 @@ import (
 func makeTestPlanner() *planner {
 	// Initialize an Executorconfig sufficiently for the purposes of creating a
 	// planner.
-	var nodeID base.NodeIDContainer
-	nodeID.Set(context.TODO(), 1)
 	execCfg := ExecutorConfig{
 		NodeInfo: NodeInfo{
-			NodeID: &nodeID,
+			NodeID: base.TestingIDContainer,
 			ClusterID: func() uuid.UUID {
 				return uuid.MakeV4()
 			},

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -716,7 +716,8 @@ var varGen = map[string]sessionVar{
 	// CockroachDB extension.
 	`node_id`: {
 		Get: func(evalCtx *extendedEvalContext) string {
-			return fmt.Sprintf("%d", evalCtx.NodeID)
+			nodeID, _ := evalCtx.NodeID.OptionalNodeID() // zero if unavailable
+			return fmt.Sprintf("%d", nodeID)
 		},
 	},
 

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -130,7 +130,11 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 		dbCtx.Stopper = ltc.Stopper
 		ltc.DBContext = &dbCtx
 	}
-	ltc.DBContext.NodeID.Set(context.Background(), nodeID)
+	{
+		var c base.NodeIDContainer
+		c.Set(context.Background(), nodeID)
+		ltc.DBContext.NodeID = base.NewSQLIDContainer(0, &c, true /* exposed */)
+	}
 	ltc.DB = kv.NewDBWithContext(cfg.AmbientCtx, factory, ltc.Clock, *ltc.DBContext)
 	transport := kvserver.NewDummyRaftTransport(cfg.Settings)
 	// By default, disable the replica scanner and split queue, which


### PR DESCRIPTION
With the advent of multi-tenancy, SQL servers can optionally be
decoupled from the (and share a) KV backend. As a consequence, the
NodeID may not be available and its use across all components that need
to function in a multi-tenant setup is deprecated. Yet, some components
require a similar unique identifier for the SQL server they're a part
of.

This new identifier is the SQLInstanceID. At the time of writing,
since we're not yet able to start true SQL tenant servers and only
exercise parts of this functionality in unit testing, it is a
randomized integer. It's possible that we'll replace it with
a per-tenant counter in production, putting it truly on par with
the NodeID, to be able to give the simple guarantee that these IDs
are never reused between different incarnations of the SQL process
for a given tenant. (Note that initially, at most one SQL tenant
server will be active per tenant at any given time).

This commit introduces an IDContainer which will aid this process by
wrapping both the NodeID and SQLInstanceID, very similar to the work
carried out for Gossip in #47972. We do not yet audit all of the call
sites to keep the initial diff container. Instead, IDContainer has a
Get() method that makes it a drop-in replacement for the previously used
NodeIDContainer. `Get ` will be removed in a future commit while moving
all callers to either the `Optional{,Err}` or `DeprecatedNodeID`
methods.

Release note: None