### PR TITLE
colexec: fix TestRouterOutputAddBatch when BatchSize=3

### DIFF
--- a/pkg/sql/colexec/routers_test.go
+++ b/pkg/sql/colexec/routers_test.go
@@ -140,6 +140,10 @@ func TestRouterOutputAddBatch(t *testing.T) {
 	defer cleanup()
 
 	for _, tc := range testCases {
+		if len(tc.selection) == 0 {
+			// No data to work with, probably due to a low coldata.BatchSize.
+			continue
+		}
 		for _, mtc := range memoryTestCases {
 			t.Run(fmt.Sprintf("%s/memoryLimit=%s", tc.name, humanizeutil.IBytes(mtc.bytes)), func(t *testing.T) {
 				// Clear the testAllocator for use.


### PR DESCRIPTION
The QuarterSelection test would use BatchSize/4 elements and expect a spill to
disk. With BatchSize=3, the number of elements would be 0, causing the test to
fail since no disk spill occurred.

Release note: None (testing fix).

Fixes #48088 