### PR TITLE
[WIP] colexec: unify spacing in templates

### DIFF
--- a/pkg/sql/colexec/and_or_projection_tmpl.go
+++ b/pkg/sql/colexec/and_or_projection_tmpl.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 )
 
-// {{ range .}}
+// {{range .}}
 
 type _OP_LOWERProjOp struct {
 	allocator *colmem.Allocator
@@ -135,9 +135,9 @@ func (o *_OP_LOWERProjOp) Next(ctx context.Context) coldata.Batch {
 		knownResult             bool
 		isLeftNull, isRightNull bool
 	)
-	// {{ if _IS_OR_OP }}
+	// {{if _IS_OR_OP}}
 	knownResult = true
-	// {{ end }}
+	// {{end}}
 	leftCol := batch.ColVec(o.leftIdx)
 	leftColVals := leftCol.Bool()
 	var curIdx int
@@ -226,7 +226,7 @@ func (o *_OP_LOWERProjOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-// {{ end }}
+// {{end}}
 
 // {{/*
 // This code snippet decides whether to include the tuple with index i into
@@ -256,7 +256,7 @@ func _ADD_TUPLE_FOR_RIGHT(_L_HAS_NULLS bool) { // */}}
 // This code snippet sets the result of applying a logical operation AND or OR
 // to two boolean vectors while paying attention to null values.
 func _SET_VALUES(_IS_OR_OP bool, _L_HAS_NULLS bool, _R_HAS_NULLS bool) { // */}}
-	// {{ define "setValues" -}}
+	// {{define "setValues" -}}
 	if sel := batch.Selection(); sel != nil {
 		for _, idx := range sel[:origLen] {
 			_SET_SINGLE_VALUE(_IS_OR_OP, _L_HAS_NULLS, _R_HAS_NULLS)
@@ -270,7 +270,7 @@ func _SET_VALUES(_IS_OR_OP bool, _L_HAS_NULLS bool, _R_HAS_NULLS bool) { // */}}
 			_SET_SINGLE_VALUE(_IS_OR_OP, _L_HAS_NULLS, _R_HAS_NULLS)
 		}
 	}
-	// {{ end }}
+	// {{end}}
 	// {{/*
 }
 
@@ -280,23 +280,23 @@ func _SET_VALUES(_IS_OR_OP bool, _L_HAS_NULLS bool, _R_HAS_NULLS bool) { // */}}
 // This code snippet sets the result of applying a logical operation AND or OR
 // to two boolean values which can be null.
 func _SET_SINGLE_VALUE(_IS_OR_OP bool, _L_HAS_NULLS bool, _R_HAS_NULLS bool) { // */}}
-	// {{ define "setSingleValue" -}}
-	// {{ if _L_HAS_NULLS }}
+	// {{define "setSingleValue" -}}
+	// {{if _L_HAS_NULLS}}
 	isLeftNull = leftNulls.NullAt(idx)
-	// {{ else }}
+	// {{else}}
 	isLeftNull = false
-	// {{ end }}
+	// {{end}}
 	leftVal := leftColVals[idx]
 	if !isLeftNull && leftVal == knownResult {
 		outputColVals[idx] = leftVal
 	} else {
-		// {{ if _R_HAS_NULLS }}
+		// {{if _R_HAS_NULLS}}
 		isRightNull = rightNulls.NullAt(idx)
-		// {{ else }}
+		// {{else}}
 		isRightNull = false
-		// {{ end }}
+		// {{end}}
 		rightVal := rightColVals[idx]
-		// {{ if _IS_OR_OP }}
+		// {{if _IS_OR_OP}}
 		// The rules for OR'ing two booleans are:
 		// 1. if at least one of the values is TRUE, then the result is also TRUE
 		// 2. if both values are FALSE, then the result is also FALSE
@@ -312,7 +312,7 @@ func _SET_SINGLE_VALUE(_IS_OR_OP bool, _L_HAS_NULLS bool, _R_HAS_NULLS bool) { /
 			// Rule 3.
 			outputNulls.SetNull(idx)
 		}
-		// {{ else }}
+		// {{else}}
 		// The rules for AND'ing two booleans are:
 		// 1. if at least one of the values is FALSE, then the result is also FALSE
 		// 2. if both values are TRUE, then the result is also TRUE
@@ -328,9 +328,9 @@ func _SET_SINGLE_VALUE(_IS_OR_OP bool, _L_HAS_NULLS bool, _R_HAS_NULLS bool) { /
 			// Rule 3.
 			outputNulls.SetNull(idx)
 		}
-		// {{ end }}
+		// {{end}}
 	}
-	// {{ end }}
+	// {{end}}
 	// {{/*
 }
 

--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -195,11 +195,11 @@ func _FIND_ANY_NOT_NULL(a *anyNotNull_TYPEAgg, nulls *coldata.Nulls, i int, _HAS
 		a.foundNonNullForCurrentGroup = false
 	}
 	var isNull bool
-	// {{ if .HasNulls }}
+	// {{if .HasNulls}}
 	isNull = nulls.NullAt(i)
-	// {{ else }}
+	// {{else}}
 	isNull = false
-	// {{ end }}
+	// {{end}}
 	if !a.foundNonNullForCurrentGroup && !isNull {
 		// If we haven't seen any non-nulls for the current group yet, and the
 		// current value is non-null, then we can pick the current value to be the

--- a/pkg/sql/colexec/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/avg_agg_tmpl.go
@@ -206,16 +206,16 @@ func _ACCUMULATE_AVG(a *_AGG_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS bo
 		// We only need to reset this flag if there are nulls. If there are no
 		// nulls, this will be updated unconditionally below.
 		// */}}
-		// {{ if .HasNulls }}
+		// {{if .HasNulls}}
 		a.scratch.foundNonNullForCurrentGroup = false
-		// {{ end }}
+		// {{end}}
 	}
 	var isNull bool
-	// {{ if .HasNulls }}
+	// {{if .HasNulls}}
 	isNull = nulls.NullAt(i)
-	// {{ else }}
+	// {{else}}
 	isNull = false
-	// {{ end }}
+	// {{end}}
 	if !isNull {
 		_ASSIGN_ADD(a.scratch.curSum, a.scratch.curSum, col[i])
 		a.scratch.curCount++

--- a/pkg/sql/colexec/cast_tmpl.go
+++ b/pkg/sql/colexec/cast_tmpl.go
@@ -75,11 +75,11 @@ func _FROM_TYPE_SLICE(col, i, j interface{}) interface{} {
 
 func cast(fromType, toType *types.T, inputVec, outputVec coldata.Vec, n int, sel []int) {
 	switch typeconv.FromColumnType(fromType) {
-	// {{ range $typ, $overloads := . }}
+	// {{range $typ, $overloads := .}}
 	case coltypes._ALLTYPES:
 		switch typeconv.FromColumnType(toType) {
-		// {{ range $overloads }}
-		// {{ if isCastFuncSet . }}
+		// {{range $overloads}}
+		// {{if isCastFuncSet .}}
 		case coltypes._TOTYPE:
 			inputCol := inputVec._FROMTYPE()
 			outputCol := outputVec._TOTYPE()
@@ -159,11 +159,11 @@ func GetCastOperator(
 		}, nil
 	}
 	switch typeconv.FromColumnType(fromType) {
-	// {{ range $typ, $overloads := . }}
+	// {{range $typ, $overloads := .}}
 	case coltypes._ALLTYPES:
 		switch typeconv.FromColumnType(toType) {
-		// {{ range $overloads }}
-		// {{ if isCastFuncSet . }}
+		// {{range $overloads}}
+		// {{if isCastFuncSet .}}
 		case coltypes._TOTYPE:
 			return &castOp{
 				OneInputNode: NewOneInputNode(input),

--- a/pkg/sql/colexec/execgen/cmd/execgen/data_manipulation_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/data_manipulation_gen.go
@@ -98,7 +98,7 @@ func init() {
 // this file for a list of replacements done.
 func replaceManipulationFuncs(typeIdent string, body string) string {
 	for _, dmri := range dataManipulationReplacementInfos {
-		body = dmri.re.ReplaceAllString(body, fmt.Sprintf("{{ %s.%s }}", typeIdent, dmri.replaceWith))
+		body = dmri.re.ReplaceAllString(body, fmt.Sprintf("{{%s.%s}}", typeIdent, dmri.replaceWith))
 	}
 	return body
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/orderedsynchronizer_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/orderedsynchronizer_gen.go
@@ -41,6 +41,9 @@ func genOrderedSynchronizer(wr io.Writer) error {
 		return err
 	}
 
+	// It doesn't matter that we're passing in all overloads of Equality
+	// comparison operator - we simply need to iterate over all supported
+	// types.
 	return tmpl.Execute(wr, sameTypeComparisonOpToOverloads[tree.EQ])
 }
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads.go
@@ -730,8 +730,8 @@ func getFloatCmpOpCompareFunc(checkLeftNan, checkRightNan bool) compareFunc {
 					{{.Target}} = 1
 				}	else if a == b {
 					{{.Target}} = 0
-				}	else if {{ if .CheckLeftNan }} math.IsNaN(a) {{ else }} false {{ end }} {
-					if {{ if .CheckRightNan }} math.IsNaN(b) {{ else }} false {{ end }} {
+				}	else if {{if .CheckLeftNan}} math.IsNaN(a) {{else}} false {{end}} {
+					if {{if .CheckRightNan}} math.IsNaN(b) {{else}} false {{end}} {
 						{{.Target}} = 0
 					} else {
 						{{.Target}} = -1
@@ -958,11 +958,11 @@ func (c decimalIntCustomizer) getBinOpAssignFunc() assignFunc {
 		buf := strings.Builder{}
 		t := template.Must(template.New("").Parse(`
 			{
-				{{ if .IsDivision }}
+				{{if .IsDivision}}
 				if {{.Right}} == 0 {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
 				}
-				{{ end }}
+				{{end}}
 				tmpDec := &decimalScratch.tmpDec1
 				tmpDec.SetFinite(int64({{.Right}}), 0)
 				if _, err := tree.{{.Ctx}}.{{.Op}}(&{{.Target}}, &{{.Left}}, tmpDec); err != nil {
@@ -1030,14 +1030,14 @@ func (c intDecimalCustomizer) getBinOpAssignFunc() assignFunc {
 			{
 				tmpDec := &decimalScratch.tmpDec1
 				tmpDec.SetFinite(int64({{.Left}}), 0)
-				{{ if .IsDivision }}
+				{{if .IsDivision}}
 				cond, err := tree.{{.Ctx}}.{{.Op}}(&{{.Target}}, tmpDec, &{{.Right}})
 				if cond.DivisionByZero() {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
 				}
-				{{ else }}
+				{{else}}
 				_, err := tree.{{.Ctx}}.{{.Op}}(&{{.Target}}, tmpDec, &{{.Right}})
-				{{ end }}
+				{{end}}
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}

--- a/pkg/sql/colexec/execgen/cmd/execgen/rowstovec_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/rowstovec_gen.go
@@ -63,7 +63,7 @@ func genRowsToVec(wr io.Writer) error {
 	s = strings.Replace(s, "_WIDTH", "{{.Width}}", -1)
 
 	rowsToVecRe := makeFunctionRegex("_ROWS_TO_COL_VEC", 4)
-	s = rowsToVecRe.ReplaceAllString(s, `{{ template "rowsToColVec" . }}`)
+	s = rowsToVecRe.ReplaceAllString(s, `{{template "rowsToColVec" .}}`)
 
 	s = replaceManipulationFuncs(".ExecType", s)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/vec_comparators_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/vec_comparators_gen.go
@@ -39,7 +39,7 @@ func genVecComparators(wr io.Writer) error {
 		return err
 	}
 
-	return tmpl.Execute(wr, sameTypeComparisonOpToOverloads[tree.LT])
+	return tmpl.Execute(wr, sameTypeComparisonOpToOverloads[tree.EQ])
 }
 
 func init() {

--- a/pkg/sql/colexec/execgen/cmd/execgen/vec_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/vec_gen.go
@@ -44,7 +44,10 @@ func genVec(wr io.Writer) error {
 		return err
 	}
 
-	return tmpl.Execute(wr, sameTypeComparisonOpToOverloads[tree.NE])
+	// It doesn't matter that we're passing in all overloads of Equality
+	// comparison operator - we simply need to iterate over all supported
+	// types.
+	return tmpl.Execute(wr, sameTypeComparisonOpToOverloads[tree.EQ])
 }
 func init() {
 	registerGenerator(genVec, "vec.eg.go", vecTmpl)

--- a/pkg/sql/colexec/hash_utils_tmpl.go
+++ b/pkg/sql/colexec/hash_utils_tmpl.go
@@ -76,24 +76,24 @@ func _REHASH_BODY(
 	// {{define "rehashBody" -}}
 	// Early bounds checks.
 	_ = buckets[nKeys-1]
-	// {{ if .HasSel }}
+	// {{if .HasSel}}
 	_ = sel[nKeys-1]
-	// {{ else }}
+	// {{else}}
 	_ = execgen.UNSAFEGET(keys, nKeys-1)
-	// {{ end }}
+	// {{end}}
 	var selIdx int
 	for i := 0; i < nKeys; i++ {
 		cancelChecker.check(ctx)
-		// {{ if .HasSel }}
+		// {{if .HasSel}}
 		selIdx = sel[i]
-		// {{ else }}
+		// {{else}}
 		selIdx = i
-		// {{ end }}
-		// {{ if .HasNulls }}
+		// {{end}}
+		// {{if .HasNulls}}
 		if nulls.NullAt(selIdx) {
 			continue
 		}
-		// {{ end }}
+		// {{end}}
 		v := execgen.UNSAFEGET(keys, selIdx)
 		p := uintptr(buckets[i])
 		_ASSIGN_HASH(p, v)

--- a/pkg/sql/colexec/hashtable_tmpl.go
+++ b/pkg/sql/colexec/hashtable_tmpl.go
@@ -95,7 +95,7 @@ func _CHECK_COL_BODY(
 			// {{else}}
 			probeIdx = int(toCheck)
 			// {{end}}
-			/* {{if .ProbeHasNulls }} */
+			/* {{if .ProbeHasNulls}} */
 			probeIsNull = probeVec.Nulls().NullAt(probeIdx)
 			/* {{end}} */
 
@@ -105,7 +105,7 @@ func _CHECK_COL_BODY(
 			buildIdx = int(keyID - 1)
 			// {{end}}
 
-			/* {{if .BuildHasNulls }} */
+			/* {{if .BuildHasNulls}} */
 			buildIsNull = buildVec.Nulls().NullAt(buildIdx)
 			/* {{end}} */
 

--- a/pkg/sql/colexec/mergejoinbase_tmpl.go
+++ b/pkg/sql/colexec/mergejoinbase_tmpl.go
@@ -98,7 +98,7 @@ func (o *mergeJoinBase) isBufferedGroupFinished(
 	// the same group.
 	for _, colIdx := range input.eqCols[:len(input.eqCols)] {
 		switch typeconv.FromColumnType(&input.sourceTypes[colIdx]) {
-		// {{ range . }}
+		// {{range .}}
 		case _TYPES_T:
 			// We perform this null check on every equality column of the first
 			// buffered tuple regardless of the join type since it is done only once

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -234,11 +234,11 @@ func _ACCUMULATE_MINMAX(a *_AGG_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS
 		a.foundNonNullForCurrentGroup = false
 	}
 	var isNull bool
-	// {{ if .HasNulls }}
+	// {{if .HasNulls}}
 	isNull = nulls.NullAt(i)
-	// {{ else }}
+	// {{else}}
 	isNull = false
-	// {{ end }}
+	// {{end}}
 	if !isNull {
 		if !a.foundNonNullForCurrentGroup {
 			val := execgen.UNSAFEGET(col, i)

--- a/pkg/sql/colexec/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_const_ops_tmpl.go
@@ -83,15 +83,15 @@ func _RET_UNSAFEGET(_, _ interface{}) interface{} {
 
 // */}}
 
-// {{define "projConstOp" }}
+// {{define "projConstOp"}}
 
 type _OP_CONST_NAME struct {
 	projConstOpBase
-	// {{ if _IS_CONST_LEFT }}
+	// {{if _IS_CONST_LEFT}}
 	constArg _L_GO_TYPE
-	// {{ else }}
+	// {{else}}
 	constArg _R_GO_TYPE
-	// {{ end }}
+	// {{end}}
 }
 
 func (p _OP_CONST_NAME) Next(ctx context.Context) coldata.Batch {
@@ -184,7 +184,7 @@ func _SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS bool) { // */}}
 		// {{else}}
 		_ASSIGN(projCol[i], arg, p.constArg)
 		// {{end}}
-		// {{if _HAS_NULLS }}
+		// {{if _HAS_NULLS}}
 	}
 	// {{end}}
 	// {{end}}

--- a/pkg/sql/colexec/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_non_const_ops_tmpl.go
@@ -206,7 +206,7 @@ func _SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS bool) { // */}}
 		arg1 := _L_UNSAFEGET(col1, i)
 		arg2 := _R_UNSAFEGET(col2, i)
 		_ASSIGN(projCol[i], arg1, arg2)
-		// {{if _HAS_NULLS }}
+		// {{if _HAS_NULLS}}
 	}
 	// {{end}}
 	// {{end}}

--- a/pkg/sql/colexec/row_number_tmpl.go
+++ b/pkg/sql/colexec/row_number_tmpl.go
@@ -100,7 +100,7 @@ func (r *_ROW_NUMBER_STRINGOp) Next(ctx context.Context) coldata.Batch {
 
 	// {{if .HasPartition}}
 	partitionCol := batch.ColVec(r.partitionColIdx).Bool()
-	// {{ end }}
+	// {{end}}
 	rowNumberVec := batch.ColVec(r.outputColIdx)
 	if rowNumberVec.MaybeHasNulls() {
 		// We need to make sure that there are no left over null values in the

--- a/pkg/sql/colexec/rowstovec_tmpl.go
+++ b/pkg/sql/colexec/rowstovec_tmpl.go
@@ -104,7 +104,7 @@ func EncDatumRowsToColVec(
 			switch typ.Family() {
 			// {{range .}}
 			case _FAMILY:
-				// {{ if .Widths }}
+				// {{if .Widths}}
 				switch typ.Width() {
 				// {{range .Widths}}
 				case _WIDTH:
@@ -113,7 +113,7 @@ func EncDatumRowsToColVec(
 				default:
 					colexecerror.InternalError(fmt.Sprintf("unsupported width %d for type %s", typ.Width(), typ.String()))
 				}
-				// {{ else }}
+				// {{else}}
 				_ROWS_TO_COL_VEC(rows, vec, columnIdx, typ, alloc)
 				// {{end}}
 			// {{end}}

--- a/pkg/sql/colexec/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/selection_ops_tmpl.go
@@ -357,7 +357,7 @@ func GetSelectionOperator(
 			// {{range $overloads}}
 			case tree._NAME:
 				return &_OP_NAME{selOpBase: selOpBase}, nil
-				// {{end }}
+				// {{end}}
 			default:
 				return nil, errors.Errorf("unhandled comparison operator: %s", cmpOp)
 			}

--- a/pkg/sql/colexec/sort_tmpl.go
+++ b/pkg/sql/colexec/sort_tmpl.go
@@ -86,7 +86,7 @@ func _ASSIGN_LT(_, _, _ string) bool {
 
 func isSorterSupported(t *types.T, dir execinfrapb.Ordering_Column_Direction) bool {
 	switch typeconv.FromColumnType(t) {
-	// {{range $typ, $ := . }} {{/* for each type */}}
+	// {{range $typ, $ := .}} {{/* for each type */}}
 	case _TYPES_T:
 		switch dir {
 		// {{range (index . true).Overloads}} {{/* for each direction */}}
@@ -106,10 +106,10 @@ func newSingleSorter(
 	t *types.T, dir execinfrapb.Ordering_Column_Direction, hasNulls bool,
 ) colSorter {
 	switch typeconv.FromColumnType(t) {
-	// {{range $typ, $ := . }} {{/* for each type */}}
+	// {{range $typ, $ := .}} {{/* for each type */}}
 	case _TYPES_T:
 		switch hasNulls {
-		// {{range $isNull, $ := . }} {{/* for null vs not null */}}
+		// {{range $isNull, $ := .}} {{/* for null vs not null */}}
 		case _ISNULL:
 			switch dir {
 			// {{range .Overloads}} {{/* for each direction */}}
@@ -131,8 +131,8 @@ func newSingleSorter(
 	return nil
 }
 
-// {{range $typ, $ := . }} {{/* for each type */}}
-// {{range . }} {{/* for null vs not null */}}
+// {{range $typ, $ := .}} {{/* for each type */}}
+// {{range .}} {{/* for null vs not null */}}
 // {{range .Overloads}} {{/* for each direction */}}
 
 type sort_TYPE_DIR_HANDLES_NULLSOp struct {
@@ -172,10 +172,10 @@ func (s *sort_TYPE_DIR_HANDLES_NULLSOp) sortPartitions(ctx context.Context, part
 }
 
 func (s *sort_TYPE_DIR_HANDLES_NULLSOp) Less(i, j int) bool {
-	// {{ if eq .Nulls true }}
+	// {{if eq .Nulls true}}
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
-	// {{ if eq .DirString "Asc" }}
+	// {{if eq .DirString "Asc"}}
 	// If ascending, nulls always sort first, so we encode that logic here.
 	if n1 && n2 {
 		return false
@@ -184,7 +184,7 @@ func (s *sort_TYPE_DIR_HANDLES_NULLSOp) Less(i, j int) bool {
 	} else if n2 {
 		return false
 	}
-	// {{ else if eq .DirString "Desc" }}
+	// {{else if eq .DirString "Desc"}}
 	// If descending, nulls always sort last, so we encode that logic here.
 	if n1 && n2 {
 		return false

--- a/pkg/sql/colexec/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/sum_agg_tmpl.go
@@ -194,16 +194,16 @@ func _ACCUMULATE_SUM(a *sum_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS boo
 		// We only need to reset this flag if there are nulls. If there are no
 		// nulls, this will be updated unconditionally below.
 		// */}}
-		// {{ if .HasNulls }}
+		// {{if .HasNulls}}
 		a.scratch.foundNonNullForCurrentGroup = false
-		// {{ end }}
+		// {{end}}
 	}
 	var isNull bool
-	// {{ if .HasNulls }}
+	// {{if .HasNulls}}
 	isNull = nulls.NullAt(i)
-	// {{ else }}
+	// {{else}}
 	isNull = false
-	// {{ end }}
+	// {{end}}
 	if !isNull {
 		_ASSIGN_ADD(a.scratch.curAgg, a.scratch.curAgg, col[i])
 		a.scratch.foundNonNullForCurrentGroup = true

--- a/pkg/sql/colexec/vec_comparators_tmpl.go
+++ b/pkg/sql/colexec/vec_comparators_tmpl.go
@@ -124,7 +124,7 @@ func (c *_TYPEVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 		c.nulls[dstVecIdx].SetNull(dstIdx)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
-		// {{ if eq .LTyp.String "Bytes" }}
+		// {{if eq .LTyp.String "Bytes"}}
 		// Since flat Bytes cannot be set at arbitrary indices (data needs to be
 		// moved around), we use CopySlice to accept the performance hit.
 		// Specifically, this is a performance hit because we are overwriting the
@@ -132,10 +132,10 @@ func (c *_TYPEVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 		// the bytes after that element left or right, depending on how long the
 		// source bytes slice is. Refer to the CopySlice comment for an example.
 		execgen.COPYSLICE(c.vecs[dstVecIdx], c.vecs[srcVecIdx], dstIdx, srcIdx, srcIdx+1)
-		// {{ else }}
+		// {{else}}
 		v := execgen.UNSAFEGET(c.vecs[srcVecIdx], srcIdx)
 		execgen.SET(c.vecs[dstVecIdx], dstIdx, v)
-		// {{ end }}
+		// {{end}}
 	}
 }
 

--- a/pkg/sql/colexec/window_peer_grouper_tmpl.go
+++ b/pkg/sql/colexec/window_peer_grouper_tmpl.go
@@ -99,7 +99,7 @@ type windowPeerGrouperInitFields struct {
 	outputColIdx int
 }
 
-// {{range . }}
+// {{range .}}
 
 type _PEER_GROUPER_STRINGOp struct {
 	windowPeerGrouperInitFields


### PR DESCRIPTION
This commit removes the space after `{{` and before `}}` in templating
directives which unifies the code base (and brings it inline with the
godoc's examples use).

Release note: None