### PR TITLE
sql: validate column name prior to adding or renaming a column

### DIFF
--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -917,7 +917,7 @@ CREATE TABLE t.test (a STRING PRIMARY KEY, b STRING, c STRING, INDEX foo (c));
 	// "b" is being added.
 	mt.writeColumnMutation("b", sqlbase.DescriptorMutation{Direction: sqlbase.DescriptorMutation_ADD})
 	if _, err := sqlDB.Exec(`ALTER TABLE t.test ADD b CHAR`); !testutils.IsError(err,
-		`duplicate: column "b" in the middle of being added, not yet public`) {
+		`pq: duplicate: column "b" in the middle of being added, not yet public`) {
 		t.Fatal(err)
 	}
 	if _, err := sqlDB.Exec(`ALTER TABLE t.test DROP b`); !testutils.IsError(err, `column "b" in the middle of being added, try again later`) {

--- a/pkg/sql/logictest/testdata/logic_test/alter_table_mixed_19.2_20.1
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table_mixed_19.2_20.1
@@ -58,7 +58,7 @@ statement ok
 ALTER TABLE t ADD COLUMN IF NOT EXISTS b INT
 
 # Errors during validation should still occur.
-statement error duplicate column name
+statement error pq: column "b" of relation "t" already exists
 ALTER TABLE t ADD COLUMN b INT
 
 query TT

--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -9,7 +9,7 @@ CREATE DATABASE a
 statement ok
 CREATE DATABASE IF NOT EXISTS a
 
-statement error empty database name
+statement error pgcode 42601 empty database name
 CREATE DATABASE ""
 
 query T colnames
@@ -140,7 +140,7 @@ DROP DATABASE b2 CASCADE;
   DROP DATABASE b5 CASCADE;
   DROP DATABASE b6 CASCADE
 
-statement error empty database name
+statement error pgcode 42601 empty database name
 DROP DATABASE ""
 
 query T colnames

--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -17,10 +17,10 @@ uid name  title
 1  tom   cat
 2  jerry rat
 
-statement error column name "name" already exists
+statement error pq: column "name" of relation "users" already exists
 ALTER TABLE users RENAME COLUMN title TO name
 
-statement error empty column name
+statement error pgcode 42601 empty column name
 ALTER TABLE users RENAME COLUMN title TO ""
 
 statement error pgcode 42703 column "ttle" does not exist

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -83,10 +83,10 @@ SELECT * FROM kv
 5 6
 7 8
 
-statement error empty database name
+statement error pgcode 42601 empty database name
 ALTER DATABASE "" RENAME TO u
 
-statement error empty database name
+statement error pgcode 42601 empty database name
 ALTER DATABASE u RENAME TO ""
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/rename_index
+++ b/pkg/sql/logictest/testdata/logic_test/rename_index
@@ -45,7 +45,7 @@ users_dupe  bar         false       2             name         ASC        false 
 statement error index name "bar" already exists
 ALTER INDEX users@foo RENAME TO bar
 
-statement error empty index name
+statement error pgcode 42601 empty index name
 ALTER INDEX users@foo RENAME TO ""
 
 statement error index "ffo" does not exist

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -119,6 +119,11 @@ func NewUndefinedColumnError(name string) error {
 	return pgerror.Newf(pgcode.UndefinedColumn, "column %q does not exist", name)
 }
 
+// NewColumnAlreadyExistsError creates an error for a preexisting column.
+func NewColumnAlreadyExistsError(name, relation string) error {
+	return pgerror.Newf(pgcode.DuplicateColumn, "column %q of relation %q already exists", name, relation)
+}
+
 // NewDatabaseAlreadyExistsError creates an error for a preexisting database.
 func NewDatabaseAlreadyExistsError(name string) error {
 	return pgerror.Newf(pgcode.DuplicateDatabase, "database %q already exists", name)

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -215,7 +215,7 @@ var ErrMissingPrimaryKey = errors.New("table must contain a primary key")
 
 func validateName(name, typ string) error {
 	if len(name) == 0 {
-		return fmt.Errorf("empty %s name", typ)
+		return pgerror.Newf(pgcode.Syntax, "empty %s name", typ)
 	}
 	// TODO(pmattis): Do we want to be more restrictive than this?
 	return nil
@@ -1796,13 +1796,15 @@ func (desc *TableDescriptor) ValidateTable() error {
 			return errors.AssertionFailedf("invalid column ID %d", errors.Safe(column.ID))
 		}
 
-		if _, ok := columnNames[column.Name]; ok {
+		if _, columnNameExists := columnNames[column.Name]; columnNameExists {
 			for i := range desc.Columns {
 				if desc.Columns[i].Name == column.Name {
-					return fmt.Errorf("duplicate column name: %q", column.Name)
+					return pgerror.Newf(pgcode.DuplicateColumn,
+						"duplicate column name: %q", column.Name)
 				}
 			}
-			return fmt.Errorf("duplicate: column %q in the middle of being added, not yet public", column.Name)
+			return pgerror.Newf(pgcode.DuplicateColumn,
+				"duplicate: column %q in the middle of being added, not yet public", column.Name)
 		}
 		columnNames[column.Name] = column.ID
 
@@ -2574,6 +2576,19 @@ func (desc *MutableTableDescriptor) FindActiveOrNewColumnByName(
 		}
 	}
 	return nil, NewUndefinedColumnError(string(name))
+}
+
+// FindColumnMutationByName finds the mutation on the specified column.
+func (desc *TableDescriptor) FindColumnMutationByName(name tree.Name) *DescriptorMutation {
+	for i := range desc.Mutations {
+		m := &desc.Mutations[i]
+		if c := m.GetColumn(); c != nil {
+			if c.Name == string(name) {
+				return m
+			}
+		}
+	}
+	return nil
 }
 
 // ColumnIdxMap returns a map from Column ID to the ordinal position of that


### PR DESCRIPTION
Prior to this change, add or renaming a column would not validate that
the column name does not exist until after the table descriptor had been
updated.  This lead to an error in sqlbase which did not have an error
code and did not match up with postgres. This PR categorizes such errors
as `pgcode.DuplicateColumn`. Also empty column name error is categorized
as `pgcode.Syntax` error.

Touches #47430.

Before:
```
root@:26257/defaultdb> CREATE TABLE t (col1 INT, col1 FLOAT);
ERROR: duplicate column name: "col1"
root@:26257/defaultdb> CREATE TABLE t (col1 INT, col2 FLOAT);
CREATE TABLE
root@:26257/defaultdb> ALTER TABLE t ADD COLUMN col2 INT;
ERROR: duplicate column name: "col2"
root@:26257/defaultdb> ALTER TABLE t RENAME COLUMN col2 TO col1;
ERROR: column name "col1" already exists
```

After:
```
root@:26257/defaultdb> CREATE TABLE t (col1 INT, col1 FLOAT);
ERROR: duplicate column name: "col1"
SQLSTATE: 42701
root@:26257/defaultdb> CREATE TABLE t (col1 INT, col2 FLOAT);
CREATE TABLE
root@:26257/defaultdb> ALTER TABLE t ADD COLUMN col2 INT;
ERROR: column "col2" of relation "t" already exists
SQLSTATE: 42701
root@:26257/defaultdb> ALTER TABLE t RENAME COLUMN col2 TO col1;
ERROR: column "col1" of relation "t" already exists
SQLSTATE: 42701
```

Postgres:
```
spas-> CREATE TABLE t (col1 INT, col2 FLOAT);
ERROR:  42601: syntax error at or near "ERROR"
LINE 1: ERROR: column "col1" of relation "t" already exists
        ^
LOCATION:  scanner_yyerror, scan.l:1127
spas=> CREATE TABLE t (col1 INT, col2 FLOAT);
CREATE TABLE
spas=> drop table t;
DROP TABLE
spas=> CREATE TABLE t (col1 INT, col1 FLOAT);
ERROR:  42701: column "col1" specified more than once
LOCATION:  MergeAttributes, tablecmds.c:1742
spas=> CREATE TABLE t (col1 INT, col2 FLOAT);
CREATE TABLE
spas=> ALTER TABLE t ADD COLUMN col2 INT;
ERROR:  42701: column "col2" of relation "t" already exists
LOCATION:  check_for_column_name_collision, tablecmds.c:5568
spas=> ALTER TABLE t RENAME COLUMN col2 to col1;
ERROR:  42701: column "col1" of relation "t" already exists
LOCATION:  check_for_column_name_collision, tablecmds.c:5568
```

Release note (bug fix): Return proper error for trying to ADD or RENAME
a column with an existing name.