### PR TITLE
sql: add a new cockroach specific pgcode

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -819,7 +819,7 @@ BEGIN
 statement ok
 ALTER TABLE t DROP CONSTRAINT "primary"
 
-statement error pq: requested table does not have a primary key
+statement error pgcode 55C02 requested table does not have a primary key
 INSERT INTO t VALUES (1, 1)
 
 statement ok
@@ -831,7 +831,7 @@ BEGIN
 statement ok
 ALTER TABLE t DROP CONSTRAINT "primary"
 
-statement error pq: requested table does not have a primary key
+statement error pgcode 55C02 pq: requested table does not have a primary key
 DELETE FROM t WHERE x = 1
 
 statement ok
@@ -843,7 +843,7 @@ BEGIN
 statement ok
 ALTER TABLE t DROP CONSTRAINT "primary"
 
-statement error pq: requested table does not have a primary key
+statement error pgcode 55C02 pq: requested table does not have a primary key
 UPDATE t SET x = 1 WHERE y = 1
 
 statement ok
@@ -855,7 +855,7 @@ BEGIN
 statement ok
 ALTER TABLE t DROP CONSTRAINT "primary"
 
-statement error pq: requested table does not have a primary key
+statement error pgcode 55C02 pq: requested table does not have a primary key
 SELECT * FROM t
 
 statement ok
@@ -870,7 +870,7 @@ BEGIN
 statement ok
 ALTER TABLE t DROP CONSTRAINT "primary"
 
-statement error pq: requested table does not have a primary key
+statement error pgcode 55C02 pq: requested table does not have a primary key
 CREATE INDEX ON t(x)
 
 statement ok
@@ -882,7 +882,7 @@ BEGIN
 statement ok
 ALTER TABLE t DROP CONSTRAINT "primary"
 
-statement error pq: requested table does not have a primary key
+statement error pgcode 55C02 pq: requested table does not have a primary key
 ALTER TABLE t ADD COLUMN z INT
 
 statement ok
@@ -894,7 +894,7 @@ BEGIN
 statement ok
 ALTER TABLE t DROP CONSTRAINT "primary"
 
-statement error pq: requested table does not have a primary key
+statement error pgcode 55C02 pq: requested table does not have a primary key
 ALTER TABLE t ADD COLUMN z INT, ADD PRIMARY KEY (x)
 
 statement ok

--- a/pkg/sql/pgwire/pgcode/codes.go
+++ b/pkg/sql/pgwire/pgcode/codes.go
@@ -345,6 +345,10 @@ const (
 	// precedes the hlc timestamp of the relevant DDL transaction.
 	SchemaChangeOccurred = "55C01"
 
+	// NoPrimaryKey signals that a table descriptor is invalid because the table
+	// does not have a primary key.
+	NoPrimaryKey = "55C02"
+
 	// Class 58C - System errors related to CockroachDB node problems.
 
 	// RangeUnavailable signals that some data from the cluster cannot be

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -50,7 +50,8 @@ type SchemaResolver interface {
 
 var _ SchemaResolver = &planner{}
 
-var errNoPrimaryKey = errors.New("requested table does not have a primary key")
+var errNoPrimaryKey = pgerror.Newf(pgcode.NoPrimaryKey,
+	"requested table does not have a primary key")
 
 // ResolveUncachedDatabaseByName looks up a database name from the store.
 func (p *planner) ResolveUncachedDatabaseByName(


### PR DESCRIPTION
All cockroach tables need to have a primary key however
inside a txn a user can drop the primary key and then
attempt another operation on the table. This should return
a no primary key error.

Here is an example:

```
statement ok
BEGIN;
  ALTER TABLE t DROP CONSTRAINT primary;
  INSERT INTO t VALUES (1, 1)
COMMIT;
ERROR: requested table does not have a primary key
SQLSTATE: 55C02
```

Touches #47430.

Release note (bug fix): return a proper error cockroach specific error code
for trying to modify a table without a primary key instead of the
generic `XXUUU` error code.