### PR TITLE
builtins: fix ST_Geo[gm]FromGeoJSON(null:::jsonb)

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -263,3 +263,10 @@ Square overlapping left and right square  Point middle of Right Square          
 Square overlapping left and right square  Square (left)                             false  false  false  false  false  true   true   false  false
 Square overlapping left and right square  Square (right)                            true   false  true   false  false  true   false  false  false
 Square overlapping left and right square  Square overlapping left and right square  true   true   true   false  true   true   false  false  true
+
+subtest regression_48093
+
+query TT
+SELECT st_geogfromgeojson('null':::jsonb), st_geomfromgeojson('null':::jsonb)
+----
+NULL  NULL

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -192,6 +192,9 @@ var geoBuiltins = map[string]builtinDefinition{
 				if err != nil {
 					return nil, err
 				}
+				if asString == nil {
+					return tree.DNull, nil
+				}
 				g, err := geo.ParseGeoJSON([]byte(*asString), geopb.DefaultGeometrySRID)
 				if err != nil {
 					return nil, err
@@ -286,6 +289,9 @@ var geoBuiltins = map[string]builtinDefinition{
 				asString, err := s.AsText()
 				if err != nil {
 					return nil, err
+				}
+				if asString == nil {
+					return tree.DNull, nil
 				}
 				g, err := geo.ParseGeoJSON([]byte(*asString), geopb.DefaultGeographySRID)
 				if err != nil {


### PR DESCRIPTION
Fix a bug where annotating jsonb to a null and using it in the
*FromGeoJSON functions will break. This is because `AsText` can return a
nil value.

Release note: None