### PR TITLE
opt: fix constant columns bug in zig-zag join rule

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/zigzag_join
+++ b/pkg/sql/logictest/testdata/logic_test/zigzag_join
@@ -59,6 +59,11 @@ CREATE INDEX a_idx_2 ON a(a);
 CREATE INDEX b_idx_2 ON a(b);
 SELECT n,a,b FROM a WHERE a = 4 AND b = 1;
 
+# Regression test for 48003 ("non-values node passed as fixed value to zigzag
+# join" error).
+statement ok
+SELECT n FROM a WHERE b = 1 AND (((a < 1) AND (a > 1)) OR (a >= 2 AND a <= 2))
+
 # ------------------------------------------------------------------------------
 # Zigzag join tests on inverted indexes.
 # ------------------------------------------------------------------------------

--- a/pkg/sql/opt/constraint/constraint_set.go
+++ b/pkg/sql/opt/constraint/constraint_set.go
@@ -289,6 +289,29 @@ func (s *Set) ExtractConstCols(evalCtx *tree.EvalContext) opt.ColSet {
 	return res
 }
 
+// ExtractValueForConstCol extracts the value for a constant column returned
+// by ExtractConstCols.
+func (s *Set) ExtractValueForConstCol(evalCtx *tree.EvalContext, col opt.ColumnID) tree.Datum {
+	if s == Unconstrained || s == Contradiction {
+		return nil
+	}
+	for i := 0; i < s.Length(); i++ {
+		c := s.Constraint(i)
+		colOrd := -1
+		for j := 0; j < c.Columns.Count(); j++ {
+			if c.Columns.Get(j).ID() == col {
+				colOrd = j
+				break
+			}
+		}
+		// The column must be part of the constraint's "exact prefix".
+		if colOrd != -1 && c.ExactPrefix(evalCtx) > colOrd {
+			return c.Spans.Get(0).StartKey().Value(colOrd)
+		}
+	}
+	return nil
+}
+
 // IsSingleColumnConstValue returns true if the Set contains a single constraint
 // on a single column which allows for a single constant value. On success,
 // returns the column and the constant value.

--- a/pkg/sql/opt/constraint/constraint_set_test.go
+++ b/pkg/sql/opt/constraint/constraint_set_test.go
@@ -270,53 +270,52 @@ func TestExtractCols(t *testing.T) {
 }
 
 func TestExtractConstCols(t *testing.T) {
+	type vals map[opt.ColumnID]string
 	type testCase struct {
 		constraints []string
-		expected    opt.ColSet
+		expected    vals
 	}
 
-	cols := opt.MakeColSet
-
 	cases := []testCase{
-		{[]string{`/1: [/10 - /10]`}, cols(1)},
-		{[]string{`/-1: [/10 - /10]`}, cols(1)},
-		{[]string{`/1: [/10 - /11]`}, cols()},
-		{[]string{`/1: [/10 - ]`}, cols()},
-		{[]string{`/1/2: [/10/2 - /10/4]`}, cols(1)},
-		{[]string{`/1/-2: [/10/4 - /10/2]`}, cols(1)},
-		{[]string{`/1/2: [/10/2 - /10/2]`}, cols(1, 2)},
-		{[]string{`/1/2: [/10/2 - /12/2]`}, cols()},
-		{[]string{`/1/2: [/9/2 - /9/2] [/10/2 - /12/2]`}, cols()},
-		{[]string{`/1: [/10 - /10] [/12 - /12]`}, cols()},
+		{[]string{`/1: [/10 - /10]`}, vals{1: "10"}},
+		{[]string{`/-1: [/10 - /10]`}, vals{1: "10"}},
+		{[]string{`/1: [/10 - /11]`}, vals{}},
+		{[]string{`/1: [/10 - ]`}, vals{}},
+		{[]string{`/1/2: [/10/2 - /10/4]`}, vals{1: "10"}},
+		{[]string{`/1/-2: [/10/4 - /10/2]`}, vals{1: "10"}},
+		{[]string{`/1/2: [/10/2 - /10/2]`}, vals{1: "10", 2: "2"}},
+		{[]string{`/1/2: [/10/2 - /12/2]`}, vals{}},
+		{[]string{`/1/2: [/9/2 - /9/2] [/10/2 - /12/2]`}, vals{}},
+		{[]string{`/1: [/10 - /10] [/12 - /12]`}, vals{}},
 		{
 			[]string{
 				`/1: [/10 - /10]`,
 				`/2: [/8 - /8]`,
 				`/-3: [/13 - /7]`,
 			},
-			cols(1, 2),
+			vals{1: "10", 2: "8"},
 		},
 		{
 			[]string{
 				`/1/2: [/10/4 - /10/5] [/12/4 - /12/5]`,
 				`/2: [/4 - /4]`,
 			},
-			cols(2),
+			vals{2: "4"},
 		},
-		{[]string{`/1: [/10 - /11)`}, cols()},
+		{[]string{`/1: [/10 - /11)`}, vals{}},
 		// TODO(justin): column 1 here is constant but we don't infer it as such.
 		{
 			[]string{
 				`/2/1: [/900/4 - /900/4] [/1000/4 - /1000/4] [/1100/4 - /1100/4] [/1400/4 - /1400/4] [/1500/4 - /1500/4]`,
 			},
-			cols(),
+			vals{},
 		},
 		{
 			[]string{
 				`/1: [/2 - /3]`,
 				`/2/1: [/10/3 - /11/1]`,
 			},
-			cols(),
+			vals{},
 		},
 	}
 
@@ -328,9 +327,23 @@ func TestExtractConstCols(t *testing.T) {
 			cs = cs.Intersect(evalCtx, SingleConstraint(&constraint))
 		}
 		cols := cs.ExtractConstCols(evalCtx)
-		if !tc.expected.Equals(cols) {
-			t.Errorf("expected constant columns from %s to be %s, was %s", cs, tc.expected, cols)
+		var expCols opt.ColSet
+		for col := range tc.expected {
+			expCols.Add(col)
 		}
+		if !expCols.Equals(cols) {
+			t.Errorf("%s: expected constant columns be %s, was %s", cs, expCols, cols)
+		}
+		cols.ForEach(func(col opt.ColumnID) {
+			val := cs.ExtractValueForConstCol(evalCtx, col)
+			if val == nil {
+				t.Errorf("%s: no const value for column %d", cs, col)
+				return
+			}
+			if actual, expected := val.String(), tc.expected[col]; actual != expected {
+				t.Errorf("%s: expected value %s for column %d, got %s", cs, expected, col, actual)
+			}
+		})
 	}
 }
 

--- a/pkg/sql/opt/memo/extract.go
+++ b/pkg/sql/opt/memo/extract.go
@@ -294,3 +294,20 @@ func ExtractConstColumns(
 	}
 	return fixedCols
 }
+
+// ExtractValueForConstColumn returns the constant value of a column returned by
+// ExtractConstColumns.
+func ExtractValueForConstColumn(
+	on FiltersExpr, mem *Memo, evalCtx *tree.EvalContext, col opt.ColumnID,
+) tree.Datum {
+	for i := range on {
+		scalar := on[i]
+		scalarProps := scalar.ScalarProps()
+		if scalarProps.Constraints != nil {
+			if val := scalarProps.Constraints.ExtractValueForConstCol(evalCtx, col); val != nil {
+				return val
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1756,6 +1756,20 @@ memo (optimized, ~13KB, required=[presentation: q:2,r:3])
  ├── G16: (variable r)
  └── G17: (const 2)
 
+# Case where the fixed columns are extracted from a complicated expression.
+opt
+SELECT q,r FROM pqr WHERE q = 1 AND ((r < 1 AND r > 1) OR (r >= 2 AND r <= 2))
+----
+inner-join (zigzag pqr@q pqr@r)
+ ├── columns: q:2!null r:3!null
+ ├── eq columns: [1] = [1]
+ ├── left fixed columns: [2] = [1]
+ ├── right fixed columns: [3] = [2]
+ ├── fd: ()-->(2,3)
+ └── filters
+      ├── q:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+      └── ((r:3 < 1) AND (r:3 > 1)) OR ((r:3 >= 2) AND (r:3 <= 2)) [outer=(3), constraints=(/3: [/2 - /2]), fd=()-->(3)]
+
 # Nested zigzag case - zigzag join needs to be wrapped in a lookup join to
 # satisfy required columns.
 opt


### PR DESCRIPTION
This is a fix for a regression introduced by #47412.

We were using `ExtractConstCols` to get the list of possible fixed
columns, and later we were using `findConstantFilter` to get the values.
The latter has more restrictive semantics so we wouldn't always find
the value we need.

The fix is to use logic consistent with `ExtractConstCols`, which is
now added as `ExtractValueForConstColumn`. The zig-zag join code now
also verifies that we fill in all the columns so we get a better error
earlier.

Fixes #48003.

Release note (bug fix): Fixed "non-values node passed as fixed value
to zigzag join" internal error.