### PR TITLE
sql: add rule to fold tuple access with Values operator

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/tuple
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tuple
@@ -151,12 +151,10 @@ FROM (
   SELECT ((1,'2',true) AS e,f,g) AS x
 )
 ----
-·            distributed    false                                                                                            ·                                            ·
-·            vectorized     false                                                                                            ·                                            ·
-render       ·              ·                                                                                                (e int, f string, g bool)                    ·
- │           render 0       (((x)[tuple{int AS e, string AS f, bool AS g}]).e)[int]                                          ·                                            ·
- │           render 1       (((x)[tuple{int AS e, string AS f, bool AS g}]).f)[string]                                       ·                                            ·
- │           render 2       (((x)[tuple{int AS e, string AS f, bool AS g}]).g)[bool]                                         ·                                            ·
- └── values  ·              ·                                                                                                (x tuple{int AS e, string AS f, bool AS g})  ·
-·            size           1 column, 1 row                                                                                  ·                                            ·
-·            row 0, expr 0  ((((1)[int], ('2')[string], (true)[bool]) AS e, f, g))[tuple{int AS e, string AS f, bool AS g}]  ·                                            ·
+·       distributed    false             ·                          ·
+·       vectorized     false             ·                          ·
+values  ·              ·                 (e int, f string, g bool)  ·
+·       size           3 columns, 1 row  ·                          ·
+·       row 0, expr 0  (1)[int]          ·                          ·
+·       row 0, expr 1  ('2')[string]     ·                          ·
+·       row 0, expr 2  (true)[bool]      ·                          ·

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -11,6 +11,7 @@
 package norm
 
 import (
+	"fmt"
 	"math"
 	"sort"
 
@@ -280,6 +281,11 @@ func (c *CustomFuncs) HasNoCols(input memo.RelExpr) bool {
 	return input.Relational().OutputCols.Empty()
 }
 
+// HasOneCol returns true if the input expression has exactly one output column.
+func (c *CustomFuncs) HasOneCol(input memo.RelExpr) bool {
+	return input.Relational().OutputCols.Len() == 1
+}
+
 // HasZeroRows returns true if the input expression never returns any rows.
 func (c *CustomFuncs) HasZeroRows(input memo.RelExpr) bool {
 	return input.Relational().Cardinality.IsZero()
@@ -385,6 +391,12 @@ func (c *CustomFuncs) AddColToSet(set opt.ColSet, col opt.ColumnID) opt.ColSet {
 	newSet := set.Copy()
 	newSet.Add(col)
 	return newSet
+}
+
+// SingleColFromSet returns the single column in s. Panics if s does not contain
+// exactly one column.
+func (c *CustomFuncs) SingleColFromSet(s opt.ColSet) opt.ColumnID {
+	return s.SingleColumn()
 }
 
 // sharedProps returns the shared logical properties for the given expression.
@@ -1142,6 +1154,172 @@ func (c *CustomFuncs) ProjectExtraCol(
 	return c.f.ConstructProject(in, projections, in.Relational().OutputCols)
 }
 
+// CanUnnestTuplesFromValues returns true if the Values operator has a single
+// column containing tuples that can be unfolded into multiple columns.
+//
+// This is the case if:
+//
+// 	1. The Values operator has exactly one output column.
+//
+// 	2. The single output column is of type tuple.
+//
+// 	3. There is at least one row.
+//
+// 	4. All tuples in the single column are either TupleExpr's or ConstExpr's
+//     that wrap DTuples, as opposed to dynamically generated tuples.
+//
+func (c *CustomFuncs) CanUnnestTuplesFromValues(expr memo.RelExpr) bool {
+	values := expr.(*memo.ValuesExpr)
+	if !c.HasOneCol(expr) {
+		return false
+	}
+	colTypeFam := c.mem.Metadata().ColumnMeta(values.Cols[0]).Type.Family()
+	if colTypeFam != types.TupleFamily {
+		return false
+	}
+	if len(values.Rows) < 1 {
+		return false
+	}
+	for _, row := range values.Rows {
+		if !c.IsStaticTuple(row.(*memo.TupleExpr).Elems[0]) {
+			return false
+		}
+	}
+	return true
+}
+
+// OnlyTupleColumnsAccessed ensures that the input ProjectionsExpr contains no
+// direct references to the tuple represented by the given ColumnID.
+func (c *CustomFuncs) OnlyTupleColumnsAccessed(
+	projections memo.ProjectionsExpr, tupleCol opt.ColumnID,
+) bool {
+	var check func(expr opt.Expr) bool
+	check = func(expr opt.Expr) bool {
+		switch t := expr.(type) {
+		case *memo.ColumnAccessExpr:
+			switch t.Input.(type) {
+			case *memo.VariableExpr:
+				return true
+			}
+
+		case *memo.VariableExpr:
+			return t.Col != tupleCol
+		}
+		for i, n := 0, expr.ChildCount(); i < n; i++ {
+			if !check(expr.Child(i)) {
+				return false
+			}
+		}
+		return true
+	}
+
+	for i := range projections {
+		if !check(projections[i].Element) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// MakeColsForUnnestTuples takes in the ColumnID of a tuple column and adds new
+// columns to metadata corresponding to each field in the tuple. A ColList
+// containing these new columns is returned.
+func (c *CustomFuncs) MakeColsForUnnestTuples(tupleColID opt.ColumnID) opt.ColList {
+	mem := c.mem.Metadata()
+	tupleType := c.mem.Metadata().ColumnMeta(tupleColID).Type
+
+	// Create a new column for each position in the tuple. Add it to outColIDs.
+	tupleLen := len(tupleType.TupleContents())
+	tupleAlias := mem.ColumnMeta(tupleColID).Alias
+	outColIDs := make(opt.ColList, tupleLen)
+	for i := 0; i < tupleLen; i++ {
+		newAlias := fmt.Sprintf("%s_%d", tupleAlias, i+1)
+		newColID := mem.AddColumn(newAlias, &tupleType.TupleContents()[i])
+		outColIDs[i] = newColID
+	}
+	return outColIDs
+}
+
+// UnnestTuplesFromValues takes in a Values operator that has a single column
+// of tuples and a ColList corresponding to each tuple field. It returns a new
+// Values operator with the tuple expanded out into the Values rows.
+// For example, these rows:
+//
+//   ((1, 2),)
+//   ((3, 4),)
+//
+// would be unnested as:
+//
+//   (1, 2)
+//   (3, 4)
+//
+func (c *CustomFuncs) UnnestTuplesFromValues(
+	expr memo.RelExpr, valuesCols opt.ColList,
+) memo.RelExpr {
+	values := expr.(*memo.ValuesExpr)
+	tupleColID := values.Cols[0]
+	tupleType := c.mem.Metadata().ColumnMeta(tupleColID).Type
+	outTuples := make(memo.ScalarListExpr, len(values.Rows))
+
+	// Pull the inner tuples out of the single column of the Values operator and
+	// put them into a ScalarListExpr to be used in the new Values operator.
+	for i, row := range values.Rows {
+		outerTuple := row.(*memo.TupleExpr)
+		switch t := outerTuple.Elems[0].(type) {
+		case *memo.TupleExpr:
+			outTuples[i] = t
+
+		case *memo.ConstExpr:
+			dTuple := t.Value.(*tree.DTuple)
+			tupleVals := make(memo.ScalarListExpr, len(dTuple.D))
+			for i, v := range dTuple.D {
+				val := c.f.ConstructConstVal(v, &tupleType.TupleContents()[i])
+				tupleVals[i] = val
+			}
+			outTuples[i] = c.f.ConstructTuple(tupleVals, tupleType)
+
+		default:
+			panic(errors.AssertionFailedf("unhandled input op: %T", t))
+		}
+	}
+
+	// Return new ValuesExpr with new tuples.
+	valuesPrivate := &memo.ValuesPrivate{Cols: valuesCols, ID: c.mem.Metadata().NextUniqueID()}
+	return c.f.ConstructValues(outTuples, valuesPrivate)
+}
+
+// FoldTupleColumnAccess constructs a new ProjectionsExpr from the old one with
+// any ColumnAccess operators that refer to the original tuple column (oldColID)
+// replaced by new columns from the output of the given ValuesExpr.
+func (c *CustomFuncs) FoldTupleColumnAccess(
+	projections memo.ProjectionsExpr, valuesCols opt.ColList, oldColID opt.ColumnID,
+) memo.ProjectionsExpr {
+	newProjections := make(memo.ProjectionsExpr, len(projections))
+
+	// Recursively traverses a ProjectionsItem element and replaces references to
+	// positions in the tuple rows with one of the newly constructed columns.
+	var replace ReplaceFunc
+	replace = func(nd opt.Expr) opt.Expr {
+		if colAccess, ok := nd.(*memo.ColumnAccessExpr); ok {
+			if variable, ok := colAccess.Input.(*memo.VariableExpr); ok {
+				// Skip past references to columns other than the input tuple column.
+				if variable.Col == oldColID {
+					return c.f.ConstructVariable(valuesCols[int(colAccess.Idx)])
+				}
+			}
+		}
+		return c.f.Replace(nd, replace)
+	}
+
+	// Construct and return a new ProjectionsExpr using the new ColumnIDs.
+	for i, projection := range projections {
+		newProjections[i] = c.f.ConstructProjectionsItem(
+			replace(projection.Element).(opt.ScalarExpr), projection.Col)
+	}
+	return newProjections
+}
+
 // ----------------------------------------------------------------------
 //
 // Select Rules
@@ -1398,7 +1576,7 @@ func (c *CustomFuncs) CanConstructValuesFromZips(zip memo.ZipExpr) bool {
 			// Unnest has more than one argument.
 			return false
 		}
-		if !c.IsArray(fn.Args[0]) {
+		if !c.IsStaticArray(fn.Args[0]) {
 			// Unnest argument is not an ArrayExpr or ConstExpr wrapping a DArray.
 			return false
 		}
@@ -1447,6 +1625,7 @@ func (c *CustomFuncs) ConstructValuesFromZips(zip memo.ZipExpr) memo.RelExpr {
 			for j, val := range t.Elems {
 				addValToOutRows(val, j, i)
 			}
+
 		case *memo.ConstExpr:
 			dArray := t.Value.(*tree.DArray)
 			for j, elem := range dArray.Array {
@@ -1974,9 +2153,20 @@ func (c *CustomFuncs) IsConstArray(scalar opt.ScalarExpr) bool {
 	return false
 }
 
-// IsArray returns true if the expression is either a constant array or a normal
-// array.
-func (c *CustomFuncs) IsArray(scalar opt.ScalarExpr) bool {
+// IsStaticArray returns true if the expression is either a ConstExpr that
+// wraps a DArray or an ArrayExpr. The complete set of expressions within a
+// static array can be determined during planning:
+//
+//   ARRAY[1,2]
+//   ARRAY[x,y]
+//
+// By contrast, expressions within a dynamic array can only be determined at
+// run-time:
+//
+//   SELECT (SELECT array_agg(x) FROM xy)
+//
+// Here, the length of the array is only known at run-time.
+func (c *CustomFuncs) IsStaticArray(scalar opt.ScalarExpr) bool {
 	if _, ok := scalar.(*memo.ArrayExpr); ok {
 		return true
 	}
@@ -2170,6 +2360,33 @@ func (c *CustomFuncs) VarsAreSame(left, right opt.ScalarExpr) bool {
 	lv := left.(*memo.VariableExpr)
 	rv := right.(*memo.VariableExpr)
 	return lv.Col == rv.Col
+}
+
+// IsStaticTuple returns true if the given ScalarExpr is either a TupleExpr or a
+// ConstExpr wrapping a DTuple. Expressions within a static tuple can be
+// determined during planning:
+//
+//   (1, 2)
+//   (x, y)
+//
+// By contrast, expressions within a dynamic tuple can only be determined at
+// run-time:
+//
+//   SELECT (SELECT (x, y) FROM xy)
+//
+// Here, if there are 0 rows in xy, the tuple value will be NULL. Or, if there
+// is more than one row in xy, a dynamic error will be raised.
+func (c *CustomFuncs) IsStaticTuple(expr opt.ScalarExpr) bool {
+	switch t := expr.(type) {
+	case *memo.TupleExpr:
+		return true
+
+	case *memo.ConstExpr:
+		if _, ok := t.Value.(*tree.DTuple); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // ----------------------------------------------------------------------

--- a/pkg/sql/opt/norm/rules/project.opt
+++ b/pkg/sql/opt/norm/rules/project.opt
@@ -49,3 +49,33 @@ $input
 )
 =>
 (MergeProjectWithValues $projections $passthrough $input)
+
+# FoldTupleAccessIntoValues replaces a Values with a single column that
+# references a column of tuples with a new Values that has a column for each
+# tuple index. This works as long as the surrounding Project does not reference
+# the original tuple column itself, since then it would be invalid to eliminate
+# that reference. However, references to fields within the tuple are allowed,
+# and are translated to the new unnested Values columns.
+#
+# This rule simplifies access to the Values operator in hopes of allowing other
+# rules to fire.
+#
+# Example:
+#
+#   SELECT (tup).@1, (tup).@2 FROM (VALUES ((1,2)), ((3,4))) AS v(tup)
+#   =>
+#   SELECT tup_1, tup_2 FROM (VALUES (1, 2), (3, 4)) AS v(tup_1, tup_2)
+#
+[FoldTupleAccessIntoValues, Normalize]
+(Project
+    $input:(Values) & (CanUnnestTuplesFromValues $input)
+    $projections:* &
+        (OnlyTupleColumnsAccessed $projections $col:(SingleColFromSet (OutputCols $input)))
+    $passthrough:* & (ColsAreEmpty $passthrough)
+)
+=>
+(Project
+    (UnnestTuplesFromValues $input $tuplecols:(MakeColsForUnnestTuples $col))
+    (FoldTupleColumnAccess $projections $tuplecols $col)
+    $passthrough
+)

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -216,3 +216,334 @@ project
  └── projections
       ├── column1:1 + 1 [as="?column?":3, outer=(1)]
       └── 3 [as="?column?":4]
+
+# --------------------------------------------------
+# FoldTupleAccessIntoValues
+# --------------------------------------------------
+
+# Simple case with VALUES.
+norm expect=FoldTupleAccessIntoValues
+SELECT (tup).@1, (tup).@2 FROM (VALUES ((1,2)), ((3,4))) AS v(tup)
+----
+project
+ ├── columns: "?column?":2!null "?column?":3!null
+ ├── cardinality: [2 - 2]
+ ├── values
+ │    ├── columns: column1_1:4!null column1_2:5!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── (1, 2)
+ │    └── (3, 4)
+ └── projections
+      ├── column1_1:4 [as="?column?":2, outer=(4)]
+      └── column1_2:5 [as="?column?":3, outer=(5)]
+
+# Simple case with unnest.
+norm expect=FoldTupleAccessIntoValues
+SELECT (Tuples).@1, (Tuples).@2 FROM unnest(ARRAY[(1,2),(3,4)]) AS Tuples
+----
+project
+ ├── columns: "?column?":2!null "?column?":3!null
+ ├── cardinality: [2 - 2]
+ ├── values
+ │    ├── columns: unnest_1:4!null unnest_2:5!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── (1, 2)
+ │    └── (3, 4)
+ └── projections
+      ├── unnest_1:4 [as="?column?":2, outer=(4)]
+      └── unnest_2:5 [as="?column?":3, outer=(5)]
+
+# Case with tuples containing multiple types.
+norm expect=FoldTupleAccessIntoValues
+SELECT (tup).@1, (tup).@2, (tup).@3 FROM (VALUES ((1,'2',3.0)), ((4,'5',NULL::DECIMAL))) AS v(tup)
+----
+project
+ ├── columns: "?column?":2!null "?column?":3!null "?column?":4
+ ├── cardinality: [2 - 2]
+ ├── values
+ │    ├── columns: column1_1:5!null column1_2:6!null column1_3:7
+ │    ├── cardinality: [2 - 2]
+ │    ├── (1, '2', 3.0)
+ │    └── (4, '5', NULL)
+ └── projections
+      ├── column1_1:5 [as="?column?":2, outer=(5)]
+      ├── column1_2:6 [as="?column?":3, outer=(6)]
+      └── column1_3:7 [as="?column?":4, outer=(7)]
+
+# Case with one tuple field referenced zero times, one field referenced once,
+# and one field referenced twice.
+norm expect=FoldTupleAccessIntoValues
+SELECT (tup).@2, (tup).@3, ARRAY[(tup).@3] FROM (VALUES ((1,2,3))) AS v(tup)
+----
+values
+ ├── columns: "?column?":2!null "?column?":3!null array:4!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(2-4)
+ └── (2, 3, ARRAY[3])
+
+# Case with tuples of empty tuples.
+norm expect=FoldTupleAccessIntoValues
+SELECT (Tuples).@1, (Tuples).@2 FROM unnest(ARRAY[((),()),((),())]) AS Tuples
+----
+project
+ ├── columns: "?column?":2!null "?column?":3!null
+ ├── cardinality: [2 - 2]
+ ├── values
+ │    ├── columns: unnest_1:4!null unnest_2:5!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── ((), ())
+ │    └── ((), ())
+ └── projections
+      ├── unnest_1:4 [as="?column?":2, outer=(4)]
+      └── unnest_2:5 [as="?column?":3, outer=(5)]
+
+# Case with subquery projection.
+norm expect=FoldTupleAccessIntoValues
+SELECT (SELECT (tup).@1 * x FROM b) FROM (VALUES ((1,2)), ((3,4))) AS v(tup)
+----
+project
+ ├── columns: "?column?":5
+ ├── cardinality: [1 - ]
+ ├── ensure-distinct-on
+ │    ├── columns: "?column?":4 rownum:8!null
+ │    ├── grouping columns: rownum:8!null
+ │    ├── error: "more than one row returned by a subquery used as an expression"
+ │    ├── cardinality: [1 - ]
+ │    ├── key: (8)
+ │    ├── fd: (8)-->(4)
+ │    ├── left-join-apply
+ │    │    ├── columns: "?column?":4 column1_1:6!null rownum:8!null
+ │    │    ├── cardinality: [2 - ]
+ │    │    ├── fd: (8)-->(6)
+ │    │    ├── ordinality
+ │    │    │    ├── columns: column1_1:6!null rownum:8!null
+ │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    ├── key: (8)
+ │    │    │    ├── fd: (8)-->(6)
+ │    │    │    └── values
+ │    │    │         ├── columns: column1_1:6!null
+ │    │    │         ├── cardinality: [2 - 2]
+ │    │    │         ├── (1,)
+ │    │    │         └── (3,)
+ │    │    ├── project
+ │    │    │    ├── columns: "?column?":4
+ │    │    │    ├── outer: (6)
+ │    │    │    ├── scan b
+ │    │    │    │    ├── columns: x:2!null
+ │    │    │    │    └── key: (2)
+ │    │    │    └── projections
+ │    │    │         └── x:2 * column1_1:6 [as="?column?":4, outer=(2,6)]
+ │    │    └── filters (true)
+ │    └── aggregations
+ │         └── const-agg [as="?column?":4, outer=(4)]
+ │              └── "?column?":4
+ └── projections
+      └── "?column?":4 [as="?column?":5, outer=(4)]
+
+# Case where columns are unnested and then pruned away because the surrounding
+# project only references an outer column.
+norm expect=FoldTupleAccessIntoValues
+SELECT (SELECT ((x).@1) FROM (VALUES ((5,6)),((7,8)))) FROM (VALUES ((1,2)), ((3,4))) v(x);
+----
+project
+ ├── columns: "?column?":6!null
+ ├── cardinality: [1 - 4]
+ ├── ensure-distinct-on
+ │    ├── columns: "?column?":3!null rownum:9!null
+ │    ├── grouping columns: rownum:9!null
+ │    ├── error: "more than one row returned by a subquery used as an expression"
+ │    ├── cardinality: [1 - 4]
+ │    ├── key: (9)
+ │    ├── fd: (9)-->(3)
+ │    ├── project
+ │    │    ├── columns: "?column?":3!null rownum:9!null
+ │    │    ├── cardinality: [4 - 4]
+ │    │    ├── fd: (9)-->(3)
+ │    │    ├── inner-join (cross)
+ │    │    │    ├── columns: column1_1:7!null rownum:9!null
+ │    │    │    ├── cardinality: [4 - 4]
+ │    │    │    ├── fd: (9)-->(7)
+ │    │    │    ├── ordinality
+ │    │    │    │    ├── columns: column1_1:7!null rownum:9!null
+ │    │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    │    ├── key: (9)
+ │    │    │    │    ├── fd: (9)-->(7)
+ │    │    │    │    └── values
+ │    │    │    │         ├── columns: column1_1:7!null
+ │    │    │    │         ├── cardinality: [2 - 2]
+ │    │    │    │         ├── (1,)
+ │    │    │    │         └── (3,)
+ │    │    │    ├── values
+ │    │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    │    ├── ()
+ │    │    │    │    └── ()
+ │    │    │    └── filters (true)
+ │    │    └── projections
+ │    │         └── column1_1:7 [as="?column?":3, outer=(7)]
+ │    └── aggregations
+ │         └── const-agg [as="?column?":3, outer=(3)]
+ │              └── "?column?":3
+ └── projections
+      └── "?column?":3 [as="?column?":6, outer=(3)]
+
+# Case with named tuple access.
+norm expect=FoldTupleAccessIntoValues
+SELECT (tup).a, (tup).b
+FROM (VALUES
+        (((1,2) AS a,b)),
+        (((3,4) AS a,b))
+     ) v(tup)
+----
+project
+ ├── columns: a:2!null b:3!null
+ ├── cardinality: [2 - 2]
+ ├── values
+ │    ├── columns: column1_1:4!null column1_2:5!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── ((1, 2) AS a, b)
+ │    └── ((3, 4) AS a, b)
+ └── projections
+      ├── column1_1:4 [as=a:2, outer=(4)]
+      └── column1_2:5 [as=b:3, outer=(5)]
+
+# Case with wildcard tuple access on a named tuple.
+norm expect=FoldTupleAccessIntoValues
+SELECT (tup).*
+FROM (VALUES
+        (((1,2) AS a,b)),
+        (((3,4) AS a,b))
+     ) v(tup)
+----
+project
+ ├── columns: a:2!null b:3!null
+ ├── cardinality: [2 - 2]
+ ├── values
+ │    ├── columns: column1_1:4!null column1_2:5!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── ((1, 2) AS a, b)
+ │    └── ((3, 4) AS a, b)
+ └── projections
+      ├── column1_1:4 [as=a:2, outer=(4)]
+      └── column1_2:5 [as=b:3, outer=(5)]
+
+# Case with wildcard tuple access on an unnamed tuple.
+norm expect=FoldTupleAccessIntoValues
+SELECT (tup).*
+FROM (VALUES
+        ((1,2)),
+        ((3,4))
+     ) v(tup)
+----
+project
+ ├── columns: "?column?":2!null "?column?":3!null
+ ├── cardinality: [2 - 2]
+ ├── values
+ │    ├── columns: column1_1:4!null column1_2:5!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── (1, 2)
+ │    └── (3, 4)
+ └── projections
+      ├── column1_1:4 [as="?column?":2, outer=(4)]
+      └── column1_2:5 [as="?column?":3, outer=(5)]
+
+# No-op case because the Values operator has more than one column.
+norm expect-not=FoldTupleAccessIntoValues
+SELECT (col1).@1, (col2).@1 FROM (VALUES ((1,2),(3,4)), ((5,6),(7,8))) AS v(col1, col2)
+----
+project
+ ├── columns: "?column?":3 "?column?":4
+ ├── cardinality: [2 - 2]
+ ├── values
+ │    ├── columns: column1:1 column2:2
+ │    ├── cardinality: [2 - 2]
+ │    ├── ((1, 2), (3, 4))
+ │    └── ((5, 6), (7, 8))
+ └── projections
+      ├── (column1:1).@1 [as="?column?":3, outer=(1)]
+      └── (column2:2).@1 [as="?column?":4, outer=(2)]
+
+# No-op case because the single column in Values is not of type tuple.
+norm expect-not=FoldTupleAccessIntoValues
+SELECT col[1], col[2] FROM unnest(ARRAY[[1,2],[3,4]]) AS col
+----
+project
+ ├── columns: col:2 col:3
+ ├── cardinality: [2 - 2]
+ ├── values
+ │    ├── columns: unnest:1!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── (ARRAY[1,2],)
+ │    └── (ARRAY[3,4],)
+ └── projections
+      ├── unnest:1[1] [as=col:2, outer=(1)]
+      └── unnest:1[2] [as=col:3, outer=(1)]
+
+# No-op case because one of the tuple rows in Values can only be determined at
+# run-time. Put dynamic tuple expression at end of list to ensure that all rows
+# are checked.
+norm expect-not=FoldTupleAccessIntoValues
+SELECT (tup).@1, (tup).@2 FROM (VALUES ((3,4)), ((SELECT (x, z) FROM b))) AS v(tup)
+----
+project
+ ├── columns: "?column?":5 "?column?":6
+ ├── cardinality: [2 - 2]
+ ├── values
+ │    ├── columns: column1:4
+ │    ├── cardinality: [2 - 2]
+ │    ├── ((3, 4),)
+ │    └── tuple
+ │         └── subquery
+ │              └── max1-row
+ │                   ├── columns: "?column?":3
+ │                   ├── error: "more than one row returned by a subquery used as an expression"
+ │                   ├── cardinality: [0 - 1]
+ │                   ├── key: ()
+ │                   ├── fd: ()-->(3)
+ │                   └── project
+ │                        ├── columns: "?column?":3
+ │                        ├── scan b
+ │                        │    ├── columns: x:1!null z:2
+ │                        │    ├── key: (1)
+ │                        │    └── fd: (1)-->(2)
+ │                        └── projections
+ │                             └── (x:1, z:2) [as="?column?":3, outer=(1,2)]
+ └── projections
+      ├── (column1:4).@1 [as="?column?":5, outer=(4)]
+      └── (column1:4).@2 [as="?column?":6, outer=(4)]
+
+# No-op case because the tuple itself is referenced rather than just its fields.
+norm expect-not=FoldTupleAccessIntoValues
+SELECT (tup).@1, (tup).@2, ARRAY[tup] FROM (VALUES ((1,2)), ((3,4))) AS v(tup)
+----
+project
+ ├── columns: "?column?":2 "?column?":3 array:4
+ ├── cardinality: [2 - 2]
+ ├── values
+ │    ├── columns: column1:1
+ │    ├── cardinality: [2 - 2]
+ │    ├── ((1, 2),)
+ │    └── ((3, 4),)
+ └── projections
+      ├── (column1:1).@1 [as="?column?":2, outer=(1)]
+      ├── (column1:1).@2 [as="?column?":3, outer=(1)]
+      └── ARRAY[column1:1] [as=array:4, outer=(1)]
+
+# No-op case because the tuple itself is referenced. Make sure that a reference
+# inside the input of a ColumnAccess is detected.
+norm expect-not=FoldTupleAccessIntoValues
+SELECT (least(tup, (1,2))).a FROM (VALUES (((1,2) AS a,b), ((3,4) AS a,b))) v(tup)
+----
+project
+ ├── columns: a:3
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(3)
+ ├── values
+ │    ├── columns: column1:1
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    └── (((1, 2) AS a, b),)
+ └── projections
+      └── (least(column1:1, (1, 2))).a [as=a:3, outer=(1)]

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1048,54 +1048,54 @@ ORDER BY sum(Quantity) DESC
 LIMIT 1000
 ----
 limit
- ├── columns: accountname:8!null quantity:12
- ├── internal-ordering: -12
+ ├── columns: accountname:10!null quantity:14!null
+ ├── internal-ordering: -14
  ├── cardinality: [0 - 1000]
- ├── key: (8)
- ├── fd: (8)-->(12)
- ├── ordering: -12
+ ├── key: (10)
+ ├── fd: (10)-->(14)
+ ├── ordering: -14
  ├── sort
- │    ├── columns: accountname:8!null sum:12
- │    ├── key: (8)
- │    ├── fd: (8)-->(12)
- │    ├── ordering: -12
+ │    ├── columns: accountname:10!null sum:14!null
+ │    ├── key: (10)
+ │    ├── fd: (10)-->(14)
+ │    ├── ordering: -14
  │    ├── limit hint: 1000.00
  │    └── group-by
- │         ├── columns: accountname:8!null sum:12
- │         ├── grouping columns: accountname:8!null
- │         ├── key: (8)
- │         ├── fd: (8)-->(12)
+ │         ├── columns: accountname:10!null sum:14!null
+ │         ├── grouping columns: accountname:10!null
+ │         ├── key: (10)
+ │         ├── fd: (10)-->(14)
  │         ├── project
- │         │    ├── columns: quantity:11 accountname:8!null
+ │         │    ├── columns: quantity:13!null accountname:10!null
  │         │    ├── inner-join (lookup inventorydetails)
- │         │    │    ├── columns: id:4!null quantity:5 dealerid:6!null cardid:7!null accountname:8!null inventorydetails.quantity:9!null
- │         │    │    ├── key columns: [6 7 8] = [6 7 8]
+ │         │    │    ├── columns: id:6!null quantity:7!null dealerid:8!null cardid:9!null accountname:10!null inventorydetails.quantity:11!null
+ │         │    │    ├── key columns: [8 9 10] = [8 9 10]
  │         │    │    ├── lookup columns are key
- │         │    │    ├── fd: (6-8)-->(9), (4)==(7), (7)==(4)
+ │         │    │    ├── fd: (8-10)-->(11), (6)==(9), (9)==(6)
  │         │    │    ├── inner-join (lookup inventorydetails@inventorydetails_auto_index_inventorydetailscardidkey)
- │         │    │    │    ├── columns: id:4!null quantity:5 dealerid:6!null cardid:7!null accountname:8!null
- │         │    │    │    ├── key columns: [4] = [7]
- │         │    │    │    ├── fd: (4)==(7), (7)==(4)
+ │         │    │    │    ├── columns: id:6!null quantity:7!null dealerid:8!null cardid:9!null accountname:10!null
+ │         │    │    │    ├── key columns: [6] = [9]
+ │         │    │    │    ├── fd: (6)==(9), (9)==(6)
  │         │    │    │    ├── project
- │         │    │    │    │    ├── columns: id:4 quantity:5
+ │         │    │    │    │    ├── columns: id:6!null quantity:7!null
  │         │    │    │    │    ├── cardinality: [2 - 2]
  │         │    │    │    │    ├── values
- │         │    │    │    │    │    ├── columns: unnest:1!null
+ │         │    │    │    │    │    ├── columns: unnest_1:4!null unnest_2:5!null
  │         │    │    │    │    │    ├── cardinality: [2 - 2]
- │         │    │    │    │    │    ├── ((42948, 3),)
- │         │    │    │    │    │    └── ((24924, 4),)
+ │         │    │    │    │    │    ├── (42948, 3)
+ │         │    │    │    │    │    └── (24924, 4)
  │         │    │    │    │    └── projections
- │         │    │    │    │         ├── (unnest:1).@1 [as=id:4, outer=(1)]
- │         │    │    │    │         └── (unnest:1).@2 [as=quantity:5, outer=(1)]
+ │         │    │    │    │         ├── unnest_1:4 [as=id:6, outer=(4)]
+ │         │    │    │    │         └── unnest_2:5 [as=quantity:7, outer=(5)]
  │         │    │    │    └── filters
- │         │    │    │         ├── ((((dealerid:6 = 1) OR (dealerid:6 = 2)) OR (dealerid:6 = 3)) OR (dealerid:6 = 4)) OR (dealerid:6 = 5) [outer=(6), constraints=(/6: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
- │         │    │    │         └── accountname:8 IN ('account-1', 'account-2', 'account-3') [outer=(8), constraints=(/8: [/'account-1' - /'account-1'] [/'account-2' - /'account-2'] [/'account-3' - /'account-3']; tight)]
+ │         │    │    │         ├── ((((dealerid:8 = 1) OR (dealerid:8 = 2)) OR (dealerid:8 = 3)) OR (dealerid:8 = 4)) OR (dealerid:8 = 5) [outer=(8), constraints=(/8: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
+ │         │    │    │         └── accountname:10 IN ('account-1', 'account-2', 'account-3') [outer=(10), constraints=(/10: [/'account-1' - /'account-1'] [/'account-2' - /'account-2'] [/'account-3' - /'account-3']; tight)]
  │         │    │    └── filters (true)
  │         │    └── projections
- │         │         └── CASE WHEN quantity:5 < inventorydetails.quantity:9 THEN quantity:5 ELSE inventorydetails.quantity:9 END [as=quantity:11, outer=(5,9)]
+ │         │         └── CASE WHEN quantity:7 < inventorydetails.quantity:11 THEN quantity:7 ELSE inventorydetails.quantity:11 END [as=quantity:13, outer=(7,11)]
  │         └── aggregations
- │              └── sum [as=sum:12, outer=(11)]
- │                   └── quantity:11
+ │              └── sum [as=sum:14, outer=(13)]
+ │                   └── quantity:13
  └── 1000
 
 # Get buy/sell volume of a particular card in the last 2 days.
@@ -1424,98 +1424,98 @@ WHERE ci.cardid = Updates.c AND ci.dealerid = 1
 ----
 update ci
  ├── columns: <none>
- ├── fetch columns: ci.dealerid:13 ci.cardid:14 buyprice:15 sellprice:16 discount:17 desiredinventory:18 actualinventory:19 maxinventory:20 ci.version:21
+ ├── fetch columns: ci.dealerid:15 ci.cardid:16 buyprice:17 sellprice:18 discount:19 desiredinventory:20 actualinventory:21 maxinventory:22 ci.version:23
  ├── update-mapping:
- │    └── column31:31 => actualinventory:10
+ │    └── column33:33 => actualinventory:12
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: column31:31 ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23
-      ├── key: (14)
-      ├── fd: ()-->(13), (14)-->(15-23,31), (21)-->(14-20), (14)==(22), (22)==(14)
+      ├── columns: column33:33 ci.dealerid:15!null ci.cardid:16!null buyprice:17!null sellprice:18!null discount:19!null desiredinventory:20!null actualinventory:21!null maxinventory:22!null ci.version:23!null c:24!null q:25!null
+      ├── key: (16)
+      ├── fd: ()-->(15), (16)-->(17-25,33), (23)-->(16-22), (16)==(24), (24)==(16)
       ├── group-by
-      │    ├── columns: ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23 sum_int:29
-      │    ├── grouping columns: ci.cardid:14!null
-      │    ├── key: (14)
-      │    ├── fd: ()-->(13), (14)-->(13,15-23,29), (21)-->(14-20), (14)==(22), (22)==(14)
+      │    ├── columns: ci.dealerid:15!null ci.cardid:16!null buyprice:17!null sellprice:18!null discount:19!null desiredinventory:20!null actualinventory:21!null maxinventory:22!null ci.version:23!null c:24!null q:25!null sum_int:31
+      │    ├── grouping columns: ci.cardid:16!null
+      │    ├── key: (16)
+      │    ├── fd: ()-->(15), (16)-->(15,17-25,31), (23)-->(16-22), (16)==(24), (24)==(16)
       │    ├── left-join (lookup inventorydetails)
-      │    │    ├── columns: ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23 id.dealerid:24 id.cardid:25 quantity:27
-      │    │    ├── key columns: [35 14] = [24 25]
-      │    │    ├── fd: ()-->(13), (14)-->(15-23), (21)-->(14-20), (14)==(22), (22)==(14)
+      │    │    ├── columns: ci.dealerid:15!null ci.cardid:16!null buyprice:17!null sellprice:18!null discount:19!null desiredinventory:20!null actualinventory:21!null maxinventory:22!null ci.version:23!null c:24!null q:25!null id.dealerid:26 id.cardid:27 quantity:29
+      │    │    ├── key columns: [37 16] = [26 27]
+      │    │    ├── fd: ()-->(15), (16)-->(17-25), (23)-->(16-22), (16)==(24), (24)==(16)
       │    │    ├── project
-      │    │    │    ├── columns: "project_const_col_@24":35!null ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23
-      │    │    │    ├── key: (14)
-      │    │    │    ├── fd: ()-->(13,35), (14)-->(15-23), (21)-->(14-20), (14)==(22), (22)==(14)
+      │    │    │    ├── columns: "project_const_col_@26":37!null ci.dealerid:15!null ci.cardid:16!null buyprice:17!null sellprice:18!null discount:19!null desiredinventory:20!null actualinventory:21!null maxinventory:22!null ci.version:23!null c:24!null q:25!null
+      │    │    │    ├── key: (16)
+      │    │    │    ├── fd: ()-->(15,37), (16)-->(17-25), (23)-->(16-22), (16)==(24), (24)==(16)
       │    │    │    ├── distinct-on
-      │    │    │    │    ├── columns: ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23
-      │    │    │    │    ├── grouping columns: ci.cardid:14!null
-      │    │    │    │    ├── key: (14)
-      │    │    │    │    ├── fd: ()-->(13), (14)-->(13,15-23), (21)-->(14-20), (14)==(22), (22)==(14)
+      │    │    │    │    ├── columns: ci.dealerid:15!null ci.cardid:16!null buyprice:17!null sellprice:18!null discount:19!null desiredinventory:20!null actualinventory:21!null maxinventory:22!null ci.version:23!null c:24!null q:25!null
+      │    │    │    │    ├── grouping columns: ci.cardid:16!null
+      │    │    │    │    ├── key: (16)
+      │    │    │    │    ├── fd: ()-->(15), (16)-->(15,17-25), (23)-->(16-22), (16)==(24), (24)==(16)
       │    │    │    │    ├── inner-join (lookup cardsinfo)
-      │    │    │    │    │    ├── columns: ci.dealerid:13!null ci.cardid:14!null buyprice:15!null sellprice:16!null discount:17!null desiredinventory:18!null actualinventory:19!null maxinventory:20!null ci.version:21!null c:22!null q:23
-      │    │    │    │    │    ├── key columns: [32 22] = [13 14]
+      │    │    │    │    │    ├── columns: ci.dealerid:15!null ci.cardid:16!null buyprice:17!null sellprice:18!null discount:19!null desiredinventory:20!null actualinventory:21!null maxinventory:22!null ci.version:23!null c:24!null q:25!null
+      │    │    │    │    │    ├── key columns: [34 24] = [15 16]
       │    │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │    ├── fd: ()-->(13), (14)-->(15-21), (21)-->(14-20), (14)==(22), (22)==(14)
+      │    │    │    │    │    ├── fd: ()-->(15), (16)-->(17-23), (23)-->(16-22), (16)==(24), (24)==(16)
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: "project_const_col_@13":32!null c:22 q:23
+      │    │    │    │    │    │    ├── columns: "project_const_col_@15":34!null c:24!null q:25!null
       │    │    │    │    │    │    ├── cardinality: [2 - 2]
-      │    │    │    │    │    │    ├── fd: ()-->(32)
+      │    │    │    │    │    │    ├── fd: ()-->(34)
       │    │    │    │    │    │    ├── values
-      │    │    │    │    │    │    │    ├── columns: unnest:1!null
+      │    │    │    │    │    │    │    ├── columns: unnest_1:4!null unnest_2:5!null
       │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
-      │    │    │    │    │    │    │    ├── ((42948, 3),)
-      │    │    │    │    │    │    │    └── ((24924, 4),)
+      │    │    │    │    │    │    │    ├── (42948, 3)
+      │    │    │    │    │    │    │    └── (24924, 4)
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         ├── 1 [as="project_const_col_@13":32]
-      │    │    │    │    │    │         ├── (unnest:1).@1 [as=c:22, outer=(1)]
-      │    │    │    │    │    │         └── (unnest:1).@2 [as=q:23, outer=(1)]
+      │    │    │    │    │    │         ├── 1 [as="project_const_col_@15":34]
+      │    │    │    │    │    │         ├── unnest_1:4 [as=c:24, outer=(4)]
+      │    │    │    │    │    │         └── unnest_2:5 [as=q:25, outer=(5)]
       │    │    │    │    │    └── filters (true)
       │    │    │    │    └── aggregations
-      │    │    │    │         ├── first-agg [as=buyprice:15, outer=(15)]
-      │    │    │    │         │    └── buyprice:15
-      │    │    │    │         ├── first-agg [as=sellprice:16, outer=(16)]
-      │    │    │    │         │    └── sellprice:16
-      │    │    │    │         ├── first-agg [as=discount:17, outer=(17)]
-      │    │    │    │         │    └── discount:17
-      │    │    │    │         ├── first-agg [as=desiredinventory:18, outer=(18)]
-      │    │    │    │         │    └── desiredinventory:18
-      │    │    │    │         ├── first-agg [as=actualinventory:19, outer=(19)]
-      │    │    │    │         │    └── actualinventory:19
-      │    │    │    │         ├── first-agg [as=maxinventory:20, outer=(20)]
-      │    │    │    │         │    └── maxinventory:20
-      │    │    │    │         ├── first-agg [as=ci.version:21, outer=(21)]
-      │    │    │    │         │    └── ci.version:21
-      │    │    │    │         ├── first-agg [as=c:22, outer=(22)]
-      │    │    │    │         │    └── c:22
-      │    │    │    │         ├── first-agg [as=q:23, outer=(23)]
-      │    │    │    │         │    └── q:23
-      │    │    │    │         └── const-agg [as=ci.dealerid:13, outer=(13)]
-      │    │    │    │              └── ci.dealerid:13
+      │    │    │    │         ├── first-agg [as=buyprice:17, outer=(17)]
+      │    │    │    │         │    └── buyprice:17
+      │    │    │    │         ├── first-agg [as=sellprice:18, outer=(18)]
+      │    │    │    │         │    └── sellprice:18
+      │    │    │    │         ├── first-agg [as=discount:19, outer=(19)]
+      │    │    │    │         │    └── discount:19
+      │    │    │    │         ├── first-agg [as=desiredinventory:20, outer=(20)]
+      │    │    │    │         │    └── desiredinventory:20
+      │    │    │    │         ├── first-agg [as=actualinventory:21, outer=(21)]
+      │    │    │    │         │    └── actualinventory:21
+      │    │    │    │         ├── first-agg [as=maxinventory:22, outer=(22)]
+      │    │    │    │         │    └── maxinventory:22
+      │    │    │    │         ├── first-agg [as=ci.version:23, outer=(23)]
+      │    │    │    │         │    └── ci.version:23
+      │    │    │    │         ├── first-agg [as=c:24, outer=(24)]
+      │    │    │    │         │    └── c:24
+      │    │    │    │         ├── first-agg [as=q:25, outer=(25)]
+      │    │    │    │         │    └── q:25
+      │    │    │    │         └── const-agg [as=ci.dealerid:15, outer=(15)]
+      │    │    │    │              └── ci.dealerid:15
       │    │    │    └── projections
-      │    │    │         └── 1 [as="project_const_col_@24":35]
+      │    │    │         └── 1 [as="project_const_col_@26":37]
       │    │    └── filters (true)
       │    └── aggregations
-      │         ├── sum-int [as=sum_int:29, outer=(27)]
-      │         │    └── quantity:27
-      │         ├── const-agg [as=ci.dealerid:13, outer=(13)]
-      │         │    └── ci.dealerid:13
-      │         ├── const-agg [as=buyprice:15, outer=(15)]
-      │         │    └── buyprice:15
-      │         ├── const-agg [as=sellprice:16, outer=(16)]
-      │         │    └── sellprice:16
-      │         ├── const-agg [as=discount:17, outer=(17)]
-      │         │    └── discount:17
-      │         ├── const-agg [as=desiredinventory:18, outer=(18)]
-      │         │    └── desiredinventory:18
-      │         ├── const-agg [as=actualinventory:19, outer=(19)]
-      │         │    └── actualinventory:19
-      │         ├── const-agg [as=maxinventory:20, outer=(20)]
-      │         │    └── maxinventory:20
-      │         ├── const-agg [as=ci.version:21, outer=(21)]
-      │         │    └── ci.version:21
-      │         ├── const-agg [as=c:22, outer=(22)]
-      │         │    └── c:22
-      │         └── const-agg [as=q:23, outer=(23)]
-      │              └── q:23
+      │         ├── sum-int [as=sum_int:31, outer=(29)]
+      │         │    └── quantity:29
+      │         ├── const-agg [as=ci.dealerid:15, outer=(15)]
+      │         │    └── ci.dealerid:15
+      │         ├── const-agg [as=buyprice:17, outer=(17)]
+      │         │    └── buyprice:17
+      │         ├── const-agg [as=sellprice:18, outer=(18)]
+      │         │    └── sellprice:18
+      │         ├── const-agg [as=discount:19, outer=(19)]
+      │         │    └── discount:19
+      │         ├── const-agg [as=desiredinventory:20, outer=(20)]
+      │         │    └── desiredinventory:20
+      │         ├── const-agg [as=actualinventory:21, outer=(21)]
+      │         │    └── actualinventory:21
+      │         ├── const-agg [as=maxinventory:22, outer=(22)]
+      │         │    └── maxinventory:22
+      │         ├── const-agg [as=ci.version:23, outer=(23)]
+      │         │    └── ci.version:23
+      │         ├── const-agg [as=c:24, outer=(24)]
+      │         │    └── c:24
+      │         └── const-agg [as=q:25, outer=(25)]
+      │              └── q:25
       └── projections
-           └── COALESCE(sum_int:29, 0) [as=column31:31, outer=(29)]
+           └── COALESCE(sum_int:31, 0) [as=column33:33, outer=(31)]

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1052,54 +1052,54 @@ ORDER BY sum(Quantity) DESC
 LIMIT 1000
 ----
 limit
- ├── columns: accountname:8!null quantity:14
- ├── internal-ordering: -14
+ ├── columns: accountname:10!null quantity:16!null
+ ├── internal-ordering: -16
  ├── cardinality: [0 - 1000]
- ├── key: (8)
- ├── fd: (8)-->(14)
- ├── ordering: -14
+ ├── key: (10)
+ ├── fd: (10)-->(16)
+ ├── ordering: -16
  ├── sort
- │    ├── columns: accountname:8!null sum:14
- │    ├── key: (8)
- │    ├── fd: (8)-->(14)
- │    ├── ordering: -14
+ │    ├── columns: accountname:10!null sum:16!null
+ │    ├── key: (10)
+ │    ├── fd: (10)-->(16)
+ │    ├── ordering: -16
  │    ├── limit hint: 1000.00
  │    └── group-by
- │         ├── columns: accountname:8!null sum:14
- │         ├── grouping columns: accountname:8!null
- │         ├── key: (8)
- │         ├── fd: (8)-->(14)
+ │         ├── columns: accountname:10!null sum:16!null
+ │         ├── grouping columns: accountname:10!null
+ │         ├── key: (10)
+ │         ├── fd: (10)-->(16)
  │         ├── project
- │         │    ├── columns: quantity:13 accountname:8!null
+ │         │    ├── columns: quantity:15!null accountname:10!null
  │         │    ├── inner-join (lookup inventorydetails)
- │         │    │    ├── columns: id:4!null quantity:5 dealerid:6!null cardid:7!null accountname:8!null inventorydetails.quantity:9!null
- │         │    │    ├── key columns: [6 7 8] = [6 7 8]
+ │         │    │    ├── columns: id:6!null quantity:7!null dealerid:8!null cardid:9!null accountname:10!null inventorydetails.quantity:11!null
+ │         │    │    ├── key columns: [8 9 10] = [8 9 10]
  │         │    │    ├── lookup columns are key
- │         │    │    ├── fd: (6-8)-->(9), (4)==(7), (7)==(4)
+ │         │    │    ├── fd: (8-10)-->(11), (6)==(9), (9)==(6)
  │         │    │    ├── inner-join (lookup inventorydetails@inventorydetails_auto_index_inventorydetailscardidkey)
- │         │    │    │    ├── columns: id:4!null quantity:5 dealerid:6!null cardid:7!null accountname:8!null
- │         │    │    │    ├── key columns: [4] = [7]
- │         │    │    │    ├── fd: (4)==(7), (7)==(4)
+ │         │    │    │    ├── columns: id:6!null quantity:7!null dealerid:8!null cardid:9!null accountname:10!null
+ │         │    │    │    ├── key columns: [6] = [9]
+ │         │    │    │    ├── fd: (6)==(9), (9)==(6)
  │         │    │    │    ├── project
- │         │    │    │    │    ├── columns: id:4 quantity:5
+ │         │    │    │    │    ├── columns: id:6!null quantity:7!null
  │         │    │    │    │    ├── cardinality: [2 - 2]
  │         │    │    │    │    ├── values
- │         │    │    │    │    │    ├── columns: unnest:1!null
+ │         │    │    │    │    │    ├── columns: unnest_1:4!null unnest_2:5!null
  │         │    │    │    │    │    ├── cardinality: [2 - 2]
- │         │    │    │    │    │    ├── ((42948, 3),)
- │         │    │    │    │    │    └── ((24924, 4),)
+ │         │    │    │    │    │    ├── (42948, 3)
+ │         │    │    │    │    │    └── (24924, 4)
  │         │    │    │    │    └── projections
- │         │    │    │    │         ├── (unnest:1).@1 [as=id:4, outer=(1)]
- │         │    │    │    │         └── (unnest:1).@2 [as=quantity:5, outer=(1)]
+ │         │    │    │    │         ├── unnest_1:4 [as=id:6, outer=(4)]
+ │         │    │    │    │         └── unnest_2:5 [as=quantity:7, outer=(5)]
  │         │    │    │    └── filters
- │         │    │    │         ├── ((((dealerid:6 = 1) OR (dealerid:6 = 2)) OR (dealerid:6 = 3)) OR (dealerid:6 = 4)) OR (dealerid:6 = 5) [outer=(6), constraints=(/6: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
- │         │    │    │         └── accountname:8 IN ('account-1', 'account-2', 'account-3') [outer=(8), constraints=(/8: [/'account-1' - /'account-1'] [/'account-2' - /'account-2'] [/'account-3' - /'account-3']; tight)]
+ │         │    │    │         ├── ((((dealerid:8 = 1) OR (dealerid:8 = 2)) OR (dealerid:8 = 3)) OR (dealerid:8 = 4)) OR (dealerid:8 = 5) [outer=(8), constraints=(/8: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
+ │         │    │    │         └── accountname:10 IN ('account-1', 'account-2', 'account-3') [outer=(10), constraints=(/10: [/'account-1' - /'account-1'] [/'account-2' - /'account-2'] [/'account-3' - /'account-3']; tight)]
  │         │    │    └── filters (true)
  │         │    └── projections
- │         │         └── CASE WHEN quantity:5 < inventorydetails.quantity:9 THEN quantity:5 ELSE inventorydetails.quantity:9 END [as=quantity:13, outer=(5,9)]
+ │         │         └── CASE WHEN quantity:7 < inventorydetails.quantity:11 THEN quantity:7 ELSE inventorydetails.quantity:11 END [as=quantity:15, outer=(7,11)]
  │         └── aggregations
- │              └── sum [as=sum:14, outer=(13)]
- │                   └── quantity:13
+ │              └── sum [as=sum:16, outer=(15)]
+ │                   └── quantity:15
  └── 1000
 
 # Get buy/sell volume of a particular card in the last 2 days.
@@ -1437,120 +1437,120 @@ WHERE ci.cardid = Updates.c AND ci.dealerid = 1
 ----
 update ci
  ├── columns: <none>
- ├── fetch columns: ci.dealerid:17 ci.cardid:18 buyprice:19 sellprice:20 discount:21 desiredinventory:22 actualinventory:23 maxinventory:24 ci.version:25 ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29
+ ├── fetch columns: ci.dealerid:19 ci.cardid:20 buyprice:21 sellprice:22 discount:23 desiredinventory:24 actualinventory:25 maxinventory:26 ci.version:27 ci.discountbuyprice:28 notes:29 oldinventory:30 ci.extra:31
  ├── update-mapping:
- │    ├── column41:41 => actualinventory:10
- │    ├── discountbuyprice:45 => ci.discountbuyprice:13
- │    ├── column42:42 => notes:14
- │    └── column43:43 => oldinventory:15
+ │    ├── column43:43 => actualinventory:12
+ │    ├── discountbuyprice:47 => ci.discountbuyprice:15
+ │    ├── column44:44 => notes:16
+ │    └── column45:45 => oldinventory:17
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: discountbuyprice:45 column42:42 column43:43!null column41:41 ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31
-      ├── key: (18)
-      ├── fd: ()-->(17,42,43), (18)-->(19-31,41,45), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
+      ├── columns: discountbuyprice:47 column44:44 column45:45!null column43:43 ci.dealerid:19!null ci.cardid:20!null buyprice:21!null sellprice:22!null discount:23!null desiredinventory:24!null actualinventory:25!null maxinventory:26!null ci.version:27!null ci.discountbuyprice:28 notes:29 oldinventory:30 ci.extra:31 c:32!null q:33!null
+      ├── key: (20)
+      ├── fd: ()-->(19,44,45), (20)-->(21-33,43,47), (27)-->(20-26,28-31), (20)==(32), (32)==(20)
       ├── group-by
-      │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31 sum_int:39
-      │    ├── grouping columns: ci.cardid:18!null
-      │    ├── key: (18)
-      │    ├── fd: ()-->(17), (18)-->(17,19-31,39), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
+      │    ├── columns: ci.dealerid:19!null ci.cardid:20!null buyprice:21!null sellprice:22!null discount:23!null desiredinventory:24!null actualinventory:25!null maxinventory:26!null ci.version:27!null ci.discountbuyprice:28 notes:29 oldinventory:30 ci.extra:31 c:32!null q:33!null sum_int:41
+      │    ├── grouping columns: ci.cardid:20!null
+      │    ├── key: (20)
+      │    ├── fd: ()-->(19), (20)-->(19,21-33,41), (27)-->(20-26,28-31), (20)==(32), (32)==(20)
       │    ├── left-join (lookup inventorydetails)
-      │    │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31 id.dealerid:32 id.cardid:33 quantity:35
-      │    │    ├── key columns: [49 18] = [32 33]
-      │    │    ├── fd: ()-->(17), (18)-->(19-31), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
+      │    │    ├── columns: ci.dealerid:19!null ci.cardid:20!null buyprice:21!null sellprice:22!null discount:23!null desiredinventory:24!null actualinventory:25!null maxinventory:26!null ci.version:27!null ci.discountbuyprice:28 notes:29 oldinventory:30 ci.extra:31 c:32!null q:33!null id.dealerid:34 id.cardid:35 quantity:37
+      │    │    ├── key columns: [51 20] = [34 35]
+      │    │    ├── fd: ()-->(19), (20)-->(21-33), (27)-->(20-26,28-31), (20)==(32), (32)==(20)
       │    │    ├── project
-      │    │    │    ├── columns: "project_const_col_@32":49!null ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31
-      │    │    │    ├── key: (18)
-      │    │    │    ├── fd: ()-->(17,49), (18)-->(19-31), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
+      │    │    │    ├── columns: "project_const_col_@34":51!null ci.dealerid:19!null ci.cardid:20!null buyprice:21!null sellprice:22!null discount:23!null desiredinventory:24!null actualinventory:25!null maxinventory:26!null ci.version:27!null ci.discountbuyprice:28 notes:29 oldinventory:30 ci.extra:31 c:32!null q:33!null
+      │    │    │    ├── key: (20)
+      │    │    │    ├── fd: ()-->(19,51), (20)-->(21-33), (27)-->(20-26,28-31), (20)==(32), (32)==(20)
       │    │    │    ├── distinct-on
-      │    │    │    │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31
-      │    │    │    │    ├── grouping columns: ci.cardid:18!null
-      │    │    │    │    ├── key: (18)
-      │    │    │    │    ├── fd: ()-->(17), (18)-->(17,19-31), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
+      │    │    │    │    ├── columns: ci.dealerid:19!null ci.cardid:20!null buyprice:21!null sellprice:22!null discount:23!null desiredinventory:24!null actualinventory:25!null maxinventory:26!null ci.version:27!null ci.discountbuyprice:28 notes:29 oldinventory:30 ci.extra:31 c:32!null q:33!null
+      │    │    │    │    ├── grouping columns: ci.cardid:20!null
+      │    │    │    │    ├── key: (20)
+      │    │    │    │    ├── fd: ()-->(19), (20)-->(19,21-33), (27)-->(20-26,28-31), (20)==(32), (32)==(20)
       │    │    │    │    ├── inner-join (lookup cardsinfo)
-      │    │    │    │    │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null ci.discountbuyprice:26 notes:27 oldinventory:28 ci.extra:29 c:30!null q:31
-      │    │    │    │    │    ├── key columns: [46 30] = [17 18]
+      │    │    │    │    │    ├── columns: ci.dealerid:19!null ci.cardid:20!null buyprice:21!null sellprice:22!null discount:23!null desiredinventory:24!null actualinventory:25!null maxinventory:26!null ci.version:27!null ci.discountbuyprice:28 notes:29 oldinventory:30 ci.extra:31 c:32!null q:33!null
+      │    │    │    │    │    ├── key columns: [48 32] = [19 20]
       │    │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │    ├── fd: ()-->(17), (18)-->(19-29), (25)-->(18-24,26-29), (18)==(30), (30)==(18)
+      │    │    │    │    │    ├── fd: ()-->(19), (20)-->(21-31), (27)-->(20-26,28-31), (20)==(32), (32)==(20)
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: "project_const_col_@17":46!null c:30 q:31
+      │    │    │    │    │    │    ├── columns: "project_const_col_@19":48!null c:32!null q:33!null
       │    │    │    │    │    │    ├── cardinality: [2 - 2]
-      │    │    │    │    │    │    ├── fd: ()-->(46)
+      │    │    │    │    │    │    ├── fd: ()-->(48)
       │    │    │    │    │    │    ├── values
-      │    │    │    │    │    │    │    ├── columns: unnest:1!null
+      │    │    │    │    │    │    │    ├── columns: unnest_1:4!null unnest_2:5!null
       │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
-      │    │    │    │    │    │    │    ├── ((42948, 3),)
-      │    │    │    │    │    │    │    └── ((24924, 4),)
+      │    │    │    │    │    │    │    ├── (42948, 3)
+      │    │    │    │    │    │    │    └── (24924, 4)
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         ├── 1 [as="project_const_col_@17":46]
-      │    │    │    │    │    │         ├── (unnest:1).@1 [as=c:30, outer=(1)]
-      │    │    │    │    │    │         └── (unnest:1).@2 [as=q:31, outer=(1)]
+      │    │    │    │    │    │         ├── 1 [as="project_const_col_@19":48]
+      │    │    │    │    │    │         ├── unnest_1:4 [as=c:32, outer=(4)]
+      │    │    │    │    │    │         └── unnest_2:5 [as=q:33, outer=(5)]
       │    │    │    │    │    └── filters (true)
       │    │    │    │    └── aggregations
-      │    │    │    │         ├── first-agg [as=buyprice:19, outer=(19)]
-      │    │    │    │         │    └── buyprice:19
-      │    │    │    │         ├── first-agg [as=sellprice:20, outer=(20)]
-      │    │    │    │         │    └── sellprice:20
-      │    │    │    │         ├── first-agg [as=discount:21, outer=(21)]
-      │    │    │    │         │    └── discount:21
-      │    │    │    │         ├── first-agg [as=desiredinventory:22, outer=(22)]
-      │    │    │    │         │    └── desiredinventory:22
-      │    │    │    │         ├── first-agg [as=actualinventory:23, outer=(23)]
-      │    │    │    │         │    └── actualinventory:23
-      │    │    │    │         ├── first-agg [as=maxinventory:24, outer=(24)]
-      │    │    │    │         │    └── maxinventory:24
-      │    │    │    │         ├── first-agg [as=ci.version:25, outer=(25)]
-      │    │    │    │         │    └── ci.version:25
-      │    │    │    │         ├── first-agg [as=ci.discountbuyprice:26, outer=(26)]
-      │    │    │    │         │    └── ci.discountbuyprice:26
-      │    │    │    │         ├── first-agg [as=notes:27, outer=(27)]
-      │    │    │    │         │    └── notes:27
-      │    │    │    │         ├── first-agg [as=oldinventory:28, outer=(28)]
-      │    │    │    │         │    └── oldinventory:28
-      │    │    │    │         ├── first-agg [as=ci.extra:29, outer=(29)]
-      │    │    │    │         │    └── ci.extra:29
-      │    │    │    │         ├── first-agg [as=c:30, outer=(30)]
-      │    │    │    │         │    └── c:30
-      │    │    │    │         ├── first-agg [as=q:31, outer=(31)]
-      │    │    │    │         │    └── q:31
-      │    │    │    │         └── const-agg [as=ci.dealerid:17, outer=(17)]
-      │    │    │    │              └── ci.dealerid:17
+      │    │    │    │         ├── first-agg [as=buyprice:21, outer=(21)]
+      │    │    │    │         │    └── buyprice:21
+      │    │    │    │         ├── first-agg [as=sellprice:22, outer=(22)]
+      │    │    │    │         │    └── sellprice:22
+      │    │    │    │         ├── first-agg [as=discount:23, outer=(23)]
+      │    │    │    │         │    └── discount:23
+      │    │    │    │         ├── first-agg [as=desiredinventory:24, outer=(24)]
+      │    │    │    │         │    └── desiredinventory:24
+      │    │    │    │         ├── first-agg [as=actualinventory:25, outer=(25)]
+      │    │    │    │         │    └── actualinventory:25
+      │    │    │    │         ├── first-agg [as=maxinventory:26, outer=(26)]
+      │    │    │    │         │    └── maxinventory:26
+      │    │    │    │         ├── first-agg [as=ci.version:27, outer=(27)]
+      │    │    │    │         │    └── ci.version:27
+      │    │    │    │         ├── first-agg [as=ci.discountbuyprice:28, outer=(28)]
+      │    │    │    │         │    └── ci.discountbuyprice:28
+      │    │    │    │         ├── first-agg [as=notes:29, outer=(29)]
+      │    │    │    │         │    └── notes:29
+      │    │    │    │         ├── first-agg [as=oldinventory:30, outer=(30)]
+      │    │    │    │         │    └── oldinventory:30
+      │    │    │    │         ├── first-agg [as=ci.extra:31, outer=(31)]
+      │    │    │    │         │    └── ci.extra:31
+      │    │    │    │         ├── first-agg [as=c:32, outer=(32)]
+      │    │    │    │         │    └── c:32
+      │    │    │    │         ├── first-agg [as=q:33, outer=(33)]
+      │    │    │    │         │    └── q:33
+      │    │    │    │         └── const-agg [as=ci.dealerid:19, outer=(19)]
+      │    │    │    │              └── ci.dealerid:19
       │    │    │    └── projections
-      │    │    │         └── 1 [as="project_const_col_@32":49]
+      │    │    │         └── 1 [as="project_const_col_@34":51]
       │    │    └── filters (true)
       │    └── aggregations
-      │         ├── sum-int [as=sum_int:39, outer=(35)]
-      │         │    └── quantity:35
-      │         ├── const-agg [as=ci.dealerid:17, outer=(17)]
-      │         │    └── ci.dealerid:17
-      │         ├── const-agg [as=buyprice:19, outer=(19)]
-      │         │    └── buyprice:19
-      │         ├── const-agg [as=sellprice:20, outer=(20)]
-      │         │    └── sellprice:20
-      │         ├── const-agg [as=discount:21, outer=(21)]
-      │         │    └── discount:21
-      │         ├── const-agg [as=desiredinventory:22, outer=(22)]
-      │         │    └── desiredinventory:22
-      │         ├── const-agg [as=actualinventory:23, outer=(23)]
-      │         │    └── actualinventory:23
-      │         ├── const-agg [as=maxinventory:24, outer=(24)]
-      │         │    └── maxinventory:24
-      │         ├── const-agg [as=ci.version:25, outer=(25)]
-      │         │    └── ci.version:25
-      │         ├── const-agg [as=ci.discountbuyprice:26, outer=(26)]
-      │         │    └── ci.discountbuyprice:26
-      │         ├── const-agg [as=notes:27, outer=(27)]
-      │         │    └── notes:27
-      │         ├── const-agg [as=oldinventory:28, outer=(28)]
-      │         │    └── oldinventory:28
-      │         ├── const-agg [as=ci.extra:29, outer=(29)]
-      │         │    └── ci.extra:29
-      │         ├── const-agg [as=c:30, outer=(30)]
-      │         │    └── c:30
-      │         └── const-agg [as=q:31, outer=(31)]
-      │              └── q:31
+      │         ├── sum-int [as=sum_int:41, outer=(37)]
+      │         │    └── quantity:37
+      │         ├── const-agg [as=ci.dealerid:19, outer=(19)]
+      │         │    └── ci.dealerid:19
+      │         ├── const-agg [as=buyprice:21, outer=(21)]
+      │         │    └── buyprice:21
+      │         ├── const-agg [as=sellprice:22, outer=(22)]
+      │         │    └── sellprice:22
+      │         ├── const-agg [as=discount:23, outer=(23)]
+      │         │    └── discount:23
+      │         ├── const-agg [as=desiredinventory:24, outer=(24)]
+      │         │    └── desiredinventory:24
+      │         ├── const-agg [as=actualinventory:25, outer=(25)]
+      │         │    └── actualinventory:25
+      │         ├── const-agg [as=maxinventory:26, outer=(26)]
+      │         │    └── maxinventory:26
+      │         ├── const-agg [as=ci.version:27, outer=(27)]
+      │         │    └── ci.version:27
+      │         ├── const-agg [as=ci.discountbuyprice:28, outer=(28)]
+      │         │    └── ci.discountbuyprice:28
+      │         ├── const-agg [as=notes:29, outer=(29)]
+      │         │    └── notes:29
+      │         ├── const-agg [as=oldinventory:30, outer=(30)]
+      │         │    └── oldinventory:30
+      │         ├── const-agg [as=ci.extra:31, outer=(31)]
+      │         │    └── ci.extra:31
+      │         ├── const-agg [as=c:32, outer=(32)]
+      │         │    └── c:32
+      │         └── const-agg [as=q:33, outer=(33)]
+      │              └── q:33
       └── projections
-           ├── crdb_internal.round_decimal_values(buyprice:19 - discount:21, 4) [as=discountbuyprice:45, outer=(19,21)]
-           ├── CAST(NULL AS STRING) [as=column42:42]
-           ├── 0 [as=column43:43]
-           └── COALESCE(sum_int:39, 0) [as=column41:41, outer=(39)]
+           ├── crdb_internal.round_decimal_values(buyprice:21 - discount:23, 4) [as=discountbuyprice:47, outer=(21,23)]
+           ├── CAST(NULL AS STRING) [as=column44:44]
+           ├── 0 [as=column45:45]
+           └── COALESCE(sum_int:41, 0) [as=column43:43, outer=(41)]


### PR DESCRIPTION
Previously, the optimizer didn't fold tuple access operators over an input
Values operator.

This patch adds a rule that constructs a new Values operator with columns
for each field in the inner tuple of the original Values. It replaces the
surrounding Project operator with a new one that references the new
columns and takes the new Values as input. Example:
```
SELECT (tup).@1, (tup).@2 FROM (VALUES ((1,2)), ((3,4))) AS v(tup)
=>
SELECT tup_1, tup_2 FROM (VALUES (1, 2), (3, 4)) AS v(tup_1, tup_2)
```
Fixes #48044

Release note: None