### PR TITLE
serverpb: introduce OptionalStatusServer

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -543,6 +543,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		runtime:                  runtimeSampler,
 		db:                       db,
 		registry:                 registry,
+		sessionRegistry:          sessionRegistry,
 		circularInternalExecutor: internalExecutor,
 		jobRegistry:              jobRegistry,
 	})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -523,7 +523,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		sqlServerOptionalArgs: sqlServerOptionalArgs{
 			rpcContext: rpcContext,
 			distSender: distSender,
-			statusServer: func() (*statusServer, bool) {
+			statusServer: func() (serverpb.StatusServer, bool) {
 				return sStatus, true
 			},
 			nodeLiveness:           nodeLiveness,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -550,6 +550,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
+	sStatus.setStmtDiagnosticsRequester(sqlServer.execCfg.StmtDiagnosticsRecorder)
 	debugServer := debug.NewServer(st, sqlServer.pgServer.HBADebugFn())
 	node.InitLogger(sqlServer.execCfg)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -521,11 +521,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	sqlServer, err := newSQLServer(ctx, sqlServerArgs{
 		sqlServerOptionalArgs: sqlServerOptionalArgs{
-			rpcContext: rpcContext,
-			distSender: distSender,
-			statusServer: func() (serverpb.StatusServer, bool) {
-				return sStatus, true
-			},
+			rpcContext:             rpcContext,
+			distSender:             distSender,
+			statusServer:           serverpb.MakeOptionalStatusServer(sStatus),
 			nodeLiveness:           nodeLiveness,
 			gossip:                 gossip.MakeDeprecatedGossip(g, true /* exposed */),
 			nodeDialer:             nodeDialer,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -99,10 +99,7 @@ type sqlServerOptionalArgs struct {
 	// for debugging and DistSQL planning purposes.
 	distSender *kvcoord.DistSender
 	// statusServer gives access to the Status service.
-	//
-	// In a SQL tenant server, this is not available (returning false) and
-	// pgerror.UnsupportedWithMultiTenancy should be returned.
-	statusServer func() (serverpb.StatusServer, bool)
+	statusServer serverpb.OptionalStatusServer
 	// Narrowed down version of *NodeLiveness.
 	nodeLiveness interface {
 		jobs.NodeLiveness                    // jobs uses this
@@ -376,7 +373,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 		LeaseManager:            leaseMgr,
 		Clock:                   cfg.clock,
 		DistSQLSrv:              distSQLServer,
-		StatusServer:            func() (serverpb.StatusServer, bool) { return cfg.statusServer() },
+		StatusServer:            cfg.statusServer,
 		SessionRegistry:         cfg.sessionRegistry,
 		JobRegistry:             jobRegistry,
 		VirtualSchemas:          virtualSchemas,
@@ -537,9 +534,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 		cfg.db,
 		cfg.registry,
 		distSQLServer.ServerConfig.SessionBoundInternalExecutorFactory,
-		func() (serverpb.StatusServer, bool) {
-			return cfg.statusServer()
-		},
+		cfg.statusServer,
 		cfg.isMeta1Leaseholder,
 		sqlExecutorTestingKnobs,
 	)

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -527,9 +527,6 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 		cfg.gossip.Deprecated(47893),
 		cfg.Settings,
 	)
-	if statusServer, ok := cfg.statusServer(); ok {
-		statusServer.setStmtDiagnosticsRequester(stmtDiagnosticsRegistry)
-	}
 	execCfg.StmtDiagnosticsRecorder = stmtDiagnosticsRegistry
 
 	leaseMgr.RefreshLeases(cfg.stopper, cfg.db, cfg.gossip.Deprecated(47150))

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -102,7 +102,7 @@ type sqlServerOptionalArgs struct {
 	//
 	// In a SQL tenant server, this is not available (returning false) and
 	// pgerror.UnsupportedWithMultiTenancy should be returned.
-	statusServer func() (*statusServer, bool)
+	statusServer func() (serverpb.StatusServer, bool)
 	// Narrowed down version of *NodeLiveness.
 	nodeLiveness interface {
 		jobs.NodeLiveness                    // jobs uses this

--- a/pkg/server/serverpb/status.go
+++ b/pkg/server/serverpb/status.go
@@ -1,0 +1,41 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package serverpb
+
+import "github.com/cockroachdb/cockroach/pkg/util/errorutil"
+
+// OptionalStatusServer is a StatusServer that is only optionally present inside
+// the SQL subsystem. In practice, it is present on the system tenant, and not
+// present on "regular" tenants.
+type OptionalStatusServer struct {
+	w errorutil.TenantSQLDeprecatedWrapper // stores serverpb.StatusServer
+}
+
+// MakeOptionalStatusServer initializes and returns an OptionalStatusServer. The
+// provided server will be returned via OptionalErr() if and only if it is not
+// nil.
+func MakeOptionalStatusServer(s StatusServer) OptionalStatusServer {
+	return OptionalStatusServer{
+		// Return the status server from OptionalErr() only if one was provided.
+		// We don't have any calls to .Deprecated().
+		w: errorutil.MakeTenantSQLDeprecatedWrapper(s, s != nil /* exposed */),
+	}
+}
+
+// OptionalErr returns the wrapped StatusServer, if it is available. If it is
+// not, an error referring to the optionally supplied issues is returned.
+func (s *OptionalStatusServer) OptionalErr(issueNos ...int) (StatusServer, error) {
+	v, err := s.w.OptionalErr(issueNos...)
+	if err != nil {
+		return nil, err
+	}
+	return v.(StatusServer), nil
+}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -479,7 +479,7 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 	// server to register against (but they'll never get RPCs at the time of
 	// writing): the blob service and DistSQL.
 	dummyRPCServer := rpc.NewServer(rpcContext)
-	noStatusServer := func() (*statusServer, bool) { return nil, false }
+	noStatusServer := func() (serverpb.StatusServer, bool) { return nil, false }
 	return sqlServerArgs{
 		sqlServerOptionalArgs: sqlServerOptionalArgs{
 			rpcContext:   rpcContext,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -479,7 +479,7 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 	// server to register against (but they'll never get RPCs at the time of
 	// writing): the blob service and DistSQL.
 	dummyRPCServer := rpc.NewServer(rpcContext)
-	noStatusServer := func() (serverpb.StatusServer, bool) { return nil, false }
+	noStatusServer := serverpb.MakeOptionalStatusServer(nil)
 	return sqlServerArgs{
 		sqlServerOptionalArgs: sqlServerOptionalArgs{
 			rpcContext:   rpcContext,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -508,6 +508,7 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 		runtime:                  status.NewRuntimeStatSampler(context.Background(), clock),
 		db:                       ts.DB(),
 		registry:                 registry,
+		sessionRegistry:          sql.NewSessionRegistry(),
 		circularInternalExecutor: circularInternalExecutor,
 		jobRegistry:              &jobs.Registry{},
 	}

--- a/pkg/sql/cancel_queries.go
+++ b/pkg/sql/cancel_queries.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -45,9 +44,9 @@ func (n *cancelQueriesNode) Next(params runParams) (bool, error) {
 		return true, nil
 	}
 
-	statusServer, ok := params.extendedEvalCtx.StatusServer()
-	if !ok {
-		return false, errorutil.UnsupportedWithMultiTenancy()
+	statusServer, err := params.extendedEvalCtx.StatusServer.OptionalErr(47895)
+	if err != nil {
+		return false, err
 	}
 
 	queryIDString, ok := tree.AsDString(datum)

--- a/pkg/sql/cancel_sessions.go
+++ b/pkg/sql/cancel_sessions.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -45,9 +44,9 @@ func (n *cancelSessionsNode) Next(params runParams) (bool, error) {
 		return true, nil
 	}
 
-	statusServer, ok := params.extendedEvalCtx.StatusServer()
-	if !ok {
-		return false, errorutil.UnsupportedWithMultiTenancy()
+	statusServer, err := params.extendedEvalCtx.StatusServer.OptionalErr(47895)
+	if err != nil {
+		return false, err
 	}
 	sessionIDString, ok := tree.AsDString(datum)
 	if !ok {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -41,7 +41,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -926,9 +925,9 @@ var crdbInternalLocalTxnsTable = virtualSchemaTable{
 			return err
 		}
 		req := p.makeSessionsRequest(ctx)
-		ss, ok := p.extendedEvalCtx.StatusServer()
-		if !ok {
-			return errorutil.UnsupportedWithMultiTenancy()
+		ss, err := p.extendedEvalCtx.StatusServer.OptionalErr()
+		if err != nil {
+			return err
 		}
 		response, err := ss.ListLocalSessions(ctx, &req)
 		if err != nil {
@@ -946,9 +945,9 @@ var crdbInternalClusterTxnsTable = virtualSchemaTable{
 			return err
 		}
 		req := p.makeSessionsRequest(ctx)
-		ss, ok := p.extendedEvalCtx.StatusServer()
-		if !ok {
-			return errorutil.UnsupportedWithMultiTenancy()
+		ss, err := p.extendedEvalCtx.StatusServer.OptionalErr()
+		if err != nil {
+			return err
 		}
 		response, err := ss.ListSessions(ctx, &req)
 		if err != nil {
@@ -1056,9 +1055,9 @@ var crdbInternalLocalQueriesTable = virtualSchemaTable{
 	schema:  fmt.Sprintf(queriesSchemaPattern, "node_queries"),
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		req := p.makeSessionsRequest(ctx)
-		ss, ok := p.extendedEvalCtx.StatusServer()
-		if !ok {
-			return errorutil.UnsupportedWithMultiTenancy()
+		ss, err := p.extendedEvalCtx.StatusServer.OptionalErr()
+		if err != nil {
+			return err
 		}
 		response, err := ss.ListLocalSessions(ctx, &req)
 		if err != nil {
@@ -1075,9 +1074,9 @@ var crdbInternalClusterQueriesTable = virtualSchemaTable{
 	schema:  fmt.Sprintf(queriesSchemaPattern, "cluster_queries"),
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		req := p.makeSessionsRequest(ctx)
-		ss, ok := p.extendedEvalCtx.StatusServer()
-		if !ok {
-			return errorutil.UnsupportedWithMultiTenancy()
+		ss, err := p.extendedEvalCtx.StatusServer.OptionalErr()
+		if err != nil {
+			return err
 		}
 		response, err := ss.ListSessions(ctx, &req)
 		if err != nil {
@@ -1187,9 +1186,9 @@ var crdbInternalLocalSessionsTable = virtualSchemaTable{
 	schema:  fmt.Sprintf(sessionsSchemaPattern, "node_sessions"),
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		req := p.makeSessionsRequest(ctx)
-		ss, ok := p.extendedEvalCtx.StatusServer()
-		if !ok {
-			return errorutil.UnsupportedWithMultiTenancy()
+		ss, err := p.extendedEvalCtx.StatusServer.OptionalErr()
+		if err != nil {
+			return err
 		}
 		response, err := ss.ListLocalSessions(ctx, &req)
 		if err != nil {
@@ -1206,9 +1205,9 @@ var crdbInternalClusterSessionsTable = virtualSchemaTable{
 	schema:  fmt.Sprintf(sessionsSchemaPattern, "cluster_sessions"),
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		req := p.makeSessionsRequest(ctx)
-		ss, ok := p.extendedEvalCtx.StatusServer()
-		if !ok {
-			return errorutil.UnsupportedWithMultiTenancy()
+		ss, err := p.extendedEvalCtx.StatusServer.OptionalErr()
+		if err != nil {
+			return err
 		}
 		response, err := ss.ListSessions(ctx, &req)
 		if err != nil {
@@ -3070,9 +3069,9 @@ CREATE TABLE crdb_internal.kv_node_status (
 		if err := p.RequireAdminRole(ctx, "read crdb_internal.kv_node_status"); err != nil {
 			return err
 		}
-		ss, ok := p.extendedEvalCtx.StatusServer()
-		if !ok {
-			return errorutil.UnsupportedWithMultiTenancy()
+		ss, err := p.extendedEvalCtx.StatusServer.OptionalErr()
+		if err != nil {
+			return err
 		}
 		response, err := ss.Nodes(ctx, &serverpb.NodesRequest{})
 		if err != nil {
@@ -3184,9 +3183,9 @@ CREATE TABLE crdb_internal.kv_store_status (
 		if err := p.RequireAdminRole(ctx, "read crdb_internal.kv_store_status"); err != nil {
 			return err
 		}
-		ss, ok := p.ExecCfg().StatusServer()
-		if !ok {
-			return errorutil.UnsupportedWithMultiTenancy()
+		ss, err := p.ExecCfg().StatusServer.OptionalErr()
+		if err != nil {
+			return err
 		}
 		response, err := ss.Nodes(ctx, &serverpb.NodesRequest{})
 		if err != nil {

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -108,9 +107,9 @@ func (dsp *DistSQLPlanner) setupAllNodesPlanning(
 ) (*PlanningCtx, []roachpb.NodeID, error) {
 	planCtx := dsp.NewPlanningCtx(ctx, evalCtx, nil /* txn */)
 
-	ss, ok := execCfg.StatusServer()
-	if !ok {
-		return nil, nil, errorutil.UnsupportedWithMultiTenancy()
+	ss, err := execCfg.StatusServer.OptionalErr(47900)
+	if err != nil {
+		return nil, nil, err
 	}
 	resp, err := ss.Nodes(ctx, &serverpb.NodesRequest{})
 	if err != nil {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -597,10 +597,7 @@ type ExecutorConfig struct {
 	Clock             *hlc.Clock
 	DistSQLSrv        *distsql.ServerImpl
 	// StatusServer gives access to the Status service.
-	//
-	// In a SQL tenant server, this is not available (returning false) and
-	// pgerror.UnsupportedWithMultiTenancy should be returned.
-	StatusServer     func() (serverpb.StatusServer, bool)
+	StatusServer     serverpb.OptionalStatusServer
 	MetricsRecorder  nodeStatusGenerator
 	SessionRegistry  *SessionRegistry
 	JobRegistry      *jobs.Registry

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
+	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
@@ -634,7 +635,7 @@ type ExecutorConfig struct {
 	ProtectedTimestampProvider protectedts.Provider
 
 	// StmtDiagnosticsRecorder deals with recording statement diagnostics.
-	StmtDiagnosticsRecorder StmtDiagnosticsRecorder
+	StmtDiagnosticsRecorder *stmtdiagnostics.Registry
 }
 
 // Organization returns the value of cluster.organization.

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -52,10 +52,7 @@ type extendedEvalContext struct {
 	Tracing *SessionTracing
 
 	// StatusServer gives access to the Status service.
-	//
-	// In a SQL tenant server, this is not available (returning false) and
-	// pgerror.UnsupportedWithMultiTenancy should be returned.
-	StatusServer func() (serverpb.StatusServer, bool)
+	StatusServer serverpb.OptionalStatusServer
 
 	// MemMetrics represent the group of metrics to which execution should
 	// contribute.

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/proto"
@@ -566,9 +565,9 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 				return err
 			}
 
-			ss, ok := params.extendedEvalCtx.StatusServer()
-			if !ok {
-				return errorutil.UnsupportedWithMultiTenancy()
+			ss, err := params.extendedEvalCtx.StatusServer.OptionalErr()
+			if err != nil {
+				return err
 			}
 
 			// Validate that the result makes sense.

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -41,7 +40,7 @@ func TestDiagnosticsRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	// Ask to trace a particular query.
-	registry := s.ExecutorConfig().(sql.ExecutorConfig).StmtDiagnosticsRecorder.(*stmtdiagnostics.Registry)
+	registry := s.ExecutorConfig().(sql.ExecutorConfig).StmtDiagnosticsRecorder
 	reqID, err := registry.InsertRequestInternal(ctx, "INSERT INTO test VALUES (_)")
 	require.NoError(t, err)
 	reqRow := db.QueryRow(
@@ -108,7 +107,7 @@ func TestDiagnosticsRequestDifferentNode(t *testing.T) {
 	require.NoError(t, err)
 
 	// Ask to trace a particular query using node 0.
-	registry := tc.Server(0).ExecutorConfig().(sql.ExecutorConfig).StmtDiagnosticsRecorder.(*stmtdiagnostics.Registry)
+	registry := tc.Server(0).ExecutorConfig().(sql.ExecutorConfig).StmtDiagnosticsRecorder
 	reqID, err := registry.InsertRequestInternal(ctx, "INSERT INTO test VALUES (_)")
 	require.NoError(t, err)
 	reqRow := db0.QueryRow(


### PR DESCRIPTION
Wrap StatusServer in an option type for use in SQL, replacing
an earlier more ad-hoc (and less comprehensible) wrapper.

Release note: None