### PR TITLE
cli/zip: makes it possible to include/exclude specific nodes

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1144,4 +1144,20 @@ Addresses for network benchmark.`,
 		Description: `
 Latency or throughput mode.`,
 	}
+
+	ZipNodes = FlagInfo{
+		Name: "nodes",
+		Description: `
+List of nodes to include. Can be specified as a comma-delimited
+list of node IDs or ranges of node IDs, for example: 5,10-20,23.
+The default is to include all nodes.`,
+	}
+
+	ZipExcludeNodes = FlagInfo{
+		Name: "exclude-nodes",
+		Description: `
+List of nodes to exclude. Can be specified as a comma-delimited
+list of node IDs or ranges of node IDs, for example: 5,10-20,23.
+The default is to not exclude any node.`,
+	}
 )

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -91,6 +91,8 @@ func initCLIDefaults() {
 	sqlCtx.debugMode = false
 	sqlCtx.echo = false
 
+	zipCtx.nodes = nodeSelection{}
+
 	dumpCtx.dumpMode = dumpBoth
 	dumpCtx.asOf = ""
 	dumpCtx.dumpAll = false
@@ -265,6 +267,12 @@ var sqlCtx = struct {
 	// more verbose (sets echo).
 	debugMode bool
 }{cliContext: &cliCtx}
+
+// zipCtx captures the command-line parameters of the `zip` command.
+// Defaults set by InitCLIDefaults() above.
+var zipCtx struct {
+	nodes nodeSelection
+}
 
 // dumpCtx captures the command-line parameters of the `dump` command.
 // Defaults set by InitCLIDefaults() above.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -552,6 +552,13 @@ func init() {
 		}
 	}
 
+	// Zip command.
+	{
+		f := debugZipCmd.Flags()
+		VarFlag(f, &zipCtx.nodes.inclusive, cliflags.ZipNodes)
+		VarFlag(f, &zipCtx.nodes.exclusive, cliflags.ZipExcludeNodes)
+	}
+
 	// Decommission command.
 	VarFlag(decommissionNodeCmd.Flags(), &nodeCtx.nodeDecommissionWait, cliflags.Wait)
 

--- a/pkg/cli/testdata/zip/partial1_excluded
+++ b/pkg/cli/testdata/zip/partial1_excluded
@@ -1,0 +1,183 @@
+zip
+----
+debug zip /dev/null --exclude-nodes=2
+establishing RPC connection to ...
+retrieving the node status to get the SQL address...
+using SQL address: ...
+using SQL connection URL: postgresql://...
+writing /dev/null
+requesting data for debug/events... writing: debug/events.json
+requesting data for debug/rangelog... writing: debug/rangelog.json
+requesting data for debug/liveness... writing: debug/liveness.json
+requesting data for debug/settings... writing: debug/settings.json
+requesting data for debug/reports/problemranges... writing: debug/reports/problemranges.json
+retrieving SQL data for crdb_internal.cluster_queries... writing: debug/crdb_internal.cluster_queries.txt
+retrieving SQL data for crdb_internal.cluster_sessions... writing: debug/crdb_internal.cluster_sessions.txt
+retrieving SQL data for crdb_internal.cluster_settings... writing: debug/crdb_internal.cluster_settings.txt
+retrieving SQL data for crdb_internal.cluster_transactions... writing: debug/crdb_internal.cluster_transactions.txt
+retrieving SQL data for crdb_internal.jobs... writing: debug/crdb_internal.jobs.txt
+retrieving SQL data for system.jobs... writing: debug/system.jobs.txt
+retrieving SQL data for system.descriptor... writing: debug/system.descriptor.txt
+retrieving SQL data for system.namespace... writing: debug/system.namespace.txt
+retrieving SQL data for system.namespace2... writing: debug/system.namespace2.txt
+retrieving SQL data for crdb_internal.kv_node_status... writing: debug/crdb_internal.kv_node_status.txt
+retrieving SQL data for crdb_internal.kv_store_status... writing: debug/crdb_internal.kv_store_status.txt
+retrieving SQL data for crdb_internal.schema_changes... writing: debug/crdb_internal.schema_changes.txt
+retrieving SQL data for crdb_internal.partitions... writing: debug/crdb_internal.partitions.txt
+retrieving SQL data for crdb_internal.zones... writing: debug/crdb_internal.zones.txt
+requesting nodes... writing: debug/nodes.json
+requesting liveness... writing: debug/liveness.json
+writing: debug/nodes/1/status.json
+using SQL connection URL for node 1: postgresql://...
+retrieving SQL data for crdb_internal.feature_usage... writing: debug/nodes/1/crdb_internal.feature_usage.txt
+retrieving SQL data for crdb_internal.gossip_alerts... writing: debug/nodes/1/crdb_internal.gossip_alerts.txt
+retrieving SQL data for crdb_internal.gossip_liveness... writing: debug/nodes/1/crdb_internal.gossip_liveness.txt
+retrieving SQL data for crdb_internal.gossip_network... writing: debug/nodes/1/crdb_internal.gossip_network.txt
+retrieving SQL data for crdb_internal.gossip_nodes... writing: debug/nodes/1/crdb_internal.gossip_nodes.txt
+retrieving SQL data for crdb_internal.leases... writing: debug/nodes/1/crdb_internal.leases.txt
+retrieving SQL data for crdb_internal.node_build_info... writing: debug/nodes/1/crdb_internal.node_build_info.txt
+retrieving SQL data for crdb_internal.node_metrics... writing: debug/nodes/1/crdb_internal.node_metrics.txt
+retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/1/crdb_internal.node_queries.txt
+retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/1/crdb_internal.node_runtime_info.txt
+retrieving SQL data for crdb_internal.node_sessions... writing: debug/nodes/1/crdb_internal.node_sessions.txt
+retrieving SQL data for crdb_internal.node_statement_statistics... writing: debug/nodes/1/crdb_internal.node_statement_statistics.txt
+retrieving SQL data for crdb_internal.node_transactions... writing: debug/nodes/1/crdb_internal.node_transactions.txt
+retrieving SQL data for crdb_internal.node_txn_stats... writing: debug/nodes/1/crdb_internal.node_txn_stats.txt
+requesting data for debug/nodes/1/details... writing: debug/nodes/1/details.json
+requesting data for debug/nodes/1/gossip... writing: debug/nodes/1/gossip.json
+requesting data for debug/nodes/1/enginestats... writing: debug/nodes/1/enginestats.json
+requesting stacks for node 1... writing: debug/nodes/1/stacks.txt
+requesting threads for node 1... writing: debug/nodes/1/threads.txt
+requesting heap profile for node 1... writing: debug/nodes/1/heap.pprof
+requesting heap files for node 1... writing: debug/nodes/1/heapprof.err.txt
+  ^- resulted in ...
+requesting goroutine files for node 1... writing: debug/nodes/1/goroutines.err.txt
+  ^- resulted in ...
+requesting log file ...
+requesting ranges... 32 found
+writing: debug/nodes/1/ranges/1.json
+writing: debug/nodes/1/ranges/2.json
+writing: debug/nodes/1/ranges/3.json
+writing: debug/nodes/1/ranges/4.json
+writing: debug/nodes/1/ranges/5.json
+writing: debug/nodes/1/ranges/6.json
+writing: debug/nodes/1/ranges/7.json
+writing: debug/nodes/1/ranges/8.json
+writing: debug/nodes/1/ranges/9.json
+writing: debug/nodes/1/ranges/10.json
+writing: debug/nodes/1/ranges/11.json
+writing: debug/nodes/1/ranges/12.json
+writing: debug/nodes/1/ranges/13.json
+writing: debug/nodes/1/ranges/14.json
+writing: debug/nodes/1/ranges/15.json
+writing: debug/nodes/1/ranges/16.json
+writing: debug/nodes/1/ranges/17.json
+writing: debug/nodes/1/ranges/18.json
+writing: debug/nodes/1/ranges/19.json
+writing: debug/nodes/1/ranges/20.json
+writing: debug/nodes/1/ranges/21.json
+writing: debug/nodes/1/ranges/22.json
+writing: debug/nodes/1/ranges/23.json
+writing: debug/nodes/1/ranges/24.json
+writing: debug/nodes/1/ranges/25.json
+writing: debug/nodes/1/ranges/26.json
+writing: debug/nodes/1/ranges/27.json
+writing: debug/nodes/1/ranges/28.json
+writing: debug/nodes/1/ranges/29.json
+writing: debug/nodes/1/ranges/30.json
+writing: debug/nodes/1/ranges/31.json
+writing: debug/nodes/1/ranges/32.json
+writing: debug/nodes/2.skipped
+writing: debug/nodes/3/status.json
+using SQL connection URL for node 3: postgresql://...
+retrieving SQL data for crdb_internal.feature_usage... writing: debug/nodes/3/crdb_internal.feature_usage.txt
+retrieving SQL data for crdb_internal.gossip_alerts... writing: debug/nodes/3/crdb_internal.gossip_alerts.txt
+retrieving SQL data for crdb_internal.gossip_liveness... writing: debug/nodes/3/crdb_internal.gossip_liveness.txt
+retrieving SQL data for crdb_internal.gossip_network... writing: debug/nodes/3/crdb_internal.gossip_network.txt
+retrieving SQL data for crdb_internal.gossip_nodes... writing: debug/nodes/3/crdb_internal.gossip_nodes.txt
+retrieving SQL data for crdb_internal.leases... writing: debug/nodes/3/crdb_internal.leases.txt
+retrieving SQL data for crdb_internal.node_build_info... writing: debug/nodes/3/crdb_internal.node_build_info.txt
+retrieving SQL data for crdb_internal.node_metrics... writing: debug/nodes/3/crdb_internal.node_metrics.txt
+retrieving SQL data for crdb_internal.node_queries... writing: debug/nodes/3/crdb_internal.node_queries.txt
+retrieving SQL data for crdb_internal.node_runtime_info... writing: debug/nodes/3/crdb_internal.node_runtime_info.txt
+retrieving SQL data for crdb_internal.node_sessions... writing: debug/nodes/3/crdb_internal.node_sessions.txt
+retrieving SQL data for crdb_internal.node_statement_statistics... writing: debug/nodes/3/crdb_internal.node_statement_statistics.txt
+retrieving SQL data for crdb_internal.node_transactions... writing: debug/nodes/3/crdb_internal.node_transactions.txt
+retrieving SQL data for crdb_internal.node_txn_stats... writing: debug/nodes/3/crdb_internal.node_txn_stats.txt
+requesting data for debug/nodes/3/details... writing: debug/nodes/3/details.json
+requesting data for debug/nodes/3/gossip... writing: debug/nodes/3/gossip.json
+requesting data for debug/nodes/3/enginestats... writing: debug/nodes/3/enginestats.json
+requesting stacks for node 3... writing: debug/nodes/3/stacks.txt
+requesting threads for node 3... writing: debug/nodes/3/threads.txt
+requesting heap profile for node 3... writing: debug/nodes/3/heap.pprof
+requesting heap files for node 3... writing: debug/nodes/3/heapprof.err.txt
+  ^- resulted in ...
+requesting goroutine files for node 3... writing: debug/nodes/3/goroutines.err.txt
+  ^- resulted in ...
+requesting log file ...
+requesting ranges... 32 found
+writing: debug/nodes/3/ranges/1.json
+writing: debug/nodes/3/ranges/2.json
+writing: debug/nodes/3/ranges/3.json
+writing: debug/nodes/3/ranges/4.json
+writing: debug/nodes/3/ranges/5.json
+writing: debug/nodes/3/ranges/6.json
+writing: debug/nodes/3/ranges/7.json
+writing: debug/nodes/3/ranges/8.json
+writing: debug/nodes/3/ranges/9.json
+writing: debug/nodes/3/ranges/10.json
+writing: debug/nodes/3/ranges/11.json
+writing: debug/nodes/3/ranges/12.json
+writing: debug/nodes/3/ranges/13.json
+writing: debug/nodes/3/ranges/14.json
+writing: debug/nodes/3/ranges/15.json
+writing: debug/nodes/3/ranges/16.json
+writing: debug/nodes/3/ranges/17.json
+writing: debug/nodes/3/ranges/18.json
+writing: debug/nodes/3/ranges/19.json
+writing: debug/nodes/3/ranges/20.json
+writing: debug/nodes/3/ranges/21.json
+writing: debug/nodes/3/ranges/22.json
+writing: debug/nodes/3/ranges/23.json
+writing: debug/nodes/3/ranges/24.json
+writing: debug/nodes/3/ranges/25.json
+writing: debug/nodes/3/ranges/26.json
+writing: debug/nodes/3/ranges/27.json
+writing: debug/nodes/3/ranges/28.json
+writing: debug/nodes/3/ranges/29.json
+writing: debug/nodes/3/ranges/30.json
+writing: debug/nodes/3/ranges/31.json
+writing: debug/nodes/3/ranges/32.json
+requesting list of SQL databases... 3 found
+requesting database details for defaultdb... writing: debug/schema/defaultdb@details.json
+0 tables found
+requesting database details for postgres... writing: debug/schema/postgres@details.json
+0 tables found
+requesting database details for system... writing: debug/schema/system@details.json
+26 tables found
+requesting table details for system.comments... writing: debug/schema/system/comments.json
+requesting table details for system.descriptor... writing: debug/schema/system/descriptor.json
+requesting table details for system.eventlog... writing: debug/schema/system/eventlog.json
+requesting table details for system.jobs... writing: debug/schema/system/jobs.json
+requesting table details for system.lease... writing: debug/schema/system/lease.json
+requesting table details for system.locations... writing: debug/schema/system/locations.json
+requesting table details for system.namespace... writing: debug/schema/system/namespace.json
+requesting table details for system.namespace2... writing: debug/schema/system/namespace2.json
+requesting table details for system.protected_ts_meta... writing: debug/schema/system/protected_ts_meta.json
+requesting table details for system.protected_ts_records... writing: debug/schema/system/protected_ts_records.json
+requesting table details for system.rangelog... writing: debug/schema/system/rangelog.json
+requesting table details for system.replication_constraint_stats... writing: debug/schema/system/replication_constraint_stats.json
+requesting table details for system.replication_critical_localities... writing: debug/schema/system/replication_critical_localities.json
+requesting table details for system.replication_stats... writing: debug/schema/system/replication_stats.json
+requesting table details for system.reports_meta... writing: debug/schema/system/reports_meta.json
+requesting table details for system.role_members... writing: debug/schema/system/role_members.json
+requesting table details for system.role_options... writing: debug/schema/system/role_options.json
+requesting table details for system.settings... writing: debug/schema/system/settings.json
+requesting table details for system.statement_bundle_chunks... writing: debug/schema/system/statement_bundle_chunks.json
+requesting table details for system.statement_diagnostics... writing: debug/schema/system/statement_diagnostics.json
+requesting table details for system.statement_diagnostics_requests... writing: debug/schema/system/statement_diagnostics_requests.json
+requesting table details for system.table_statistics... writing: debug/schema/system/table_statistics.json
+requesting table details for system.ui... writing: debug/schema/system/ui.json
+requesting table details for system.users... writing: debug/schema/system/users.json
+requesting table details for system.web_sessions... writing: debug/schema/system/web_sessions.json
+requesting table details for system.zones... writing: debug/schema/system/zones.json

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -375,6 +376,7 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 
 		for _, node := range nodeList {
 			nodeID := node.Desc.NodeID
+
 			liveness := livenessByNodeID[nodeID]
 			if liveness == storagepb.NodeLivenessStatus_DECOMMISSIONED {
 				// Decommissioned + process terminated. Let's not waste time
@@ -392,6 +394,15 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 
 			id := fmt.Sprintf("%d", nodeID)
 			prefix := fmt.Sprintf("%s/%s", nodesPrefix, id)
+
+			if !zipCtx.nodes.isIncluded(nodeID) {
+				if err := z.createRaw(prefix+".skipped",
+					[]byte(fmt.Sprintf("skipping excluded node %d\n", nodeID))); err != nil {
+					return err
+				}
+				continue
+			}
+
 			// Don't use sqlConn because that's only for is the node `debug
 			// zip` was pointed at, but here we want to connect to nodes
 			// individually to grab node- local SQL tables. Try to guess by
@@ -721,4 +732,88 @@ func dumpTableDataForZip(
 		break
 	}
 	return nil
+}
+
+type nodeSelection struct {
+	inclusive     rangeSelection
+	exclusive     rangeSelection
+	includedCache map[int]struct{}
+	excludedCache map[int]struct{}
+}
+
+func (n *nodeSelection) isIncluded(nodeID roachpb.NodeID) bool {
+	// Avoid recomputing the maps on every call.
+	if n.includedCache == nil {
+		n.includedCache = n.inclusive.items()
+	}
+	if n.excludedCache == nil {
+		n.excludedCache = n.exclusive.items()
+	}
+
+	// If the included cache is empty, then we're assuming the node is included.
+	isIncluded := true
+	if len(n.includedCache) > 0 {
+		_, isIncluded = n.includedCache[int(nodeID)]
+	}
+	// Then filter out excluded IDs.
+	if _, excluded := n.excludedCache[int(nodeID)]; excluded {
+		isIncluded = false
+	}
+	return isIncluded
+}
+
+type rangeSelection struct {
+	input  string
+	ranges []vrange
+}
+
+type vrange struct {
+	a, b int
+}
+
+func (r *rangeSelection) String() string { return r.input }
+
+func (r *rangeSelection) Type() string {
+	return "a-b,c,d-e,..."
+}
+
+func (r *rangeSelection) Set(v string) error {
+	r.input = v
+	for _, rs := range strings.Split(v, ",") {
+		var thisRange vrange
+		if strings.Contains(rs, "-") {
+			ab := strings.SplitN(rs, "-", 2)
+			a, err := strconv.Atoi(ab[0])
+			if err != nil {
+				return err
+			}
+			b, err := strconv.Atoi(ab[1])
+			if err != nil {
+				return err
+			}
+			if b < a {
+				return errors.New("invalid range")
+			}
+			thisRange = vrange{a, b}
+		} else {
+			a, err := strconv.Atoi(rs)
+			if err != nil {
+				return err
+			}
+			thisRange = vrange{a, a}
+		}
+		r.ranges = append(r.ranges, thisRange)
+	}
+	return nil
+}
+
+// items returns the values selected by the range selection
+func (r *rangeSelection) items() map[int]struct{} {
+	s := map[int]struct{}{}
+	for _, vr := range r.ranges {
+		for i := vr.a; i <= vr.b; i++ {
+			s[i] = struct{}{}
+		}
+	}
+	return s
 }

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -315,8 +315,20 @@ func TestPartialZip(t *testing.T) {
 			return out
 		})
 
+	// Now do it again and exclude the down node explicitly.
+	out, err = c.RunWithCapture("debug zip " + os.DevNull + " --exclude-nodes=2")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out = eraseNonDeterministicZipOutput(out)
+	datadriven.RunTest(t, "testdata/zip/partial1_excluded",
+		func(t *testing.T, td *datadriven.TestData) string {
+			return out
+		})
+
 	// Now mark the stopped node as decommissioned, and check that zip
-	// skips over it.
+	// skips over it automatically.
 	s := tc.Server(0)
 	conn, err := s.RPCContext().GRPCDialNode(s.ServingRPCAddr(), s.NodeID(),
 		rpc.DefaultClass).Connect(context.Background())
@@ -513,5 +525,44 @@ func TestToHex(t *testing.T) {
 	}
 	if err = r.Close(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestNodeRangeSelection(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Avoid leaking configuration changes after the tests end.
+	defer initCLIDefaults()
+
+	testData := []struct {
+		args         []string
+		wantIncluded []int
+		wantExcluded []int
+	}{
+		{[]string{""}, []int{1, 200, 3}, nil},
+		{[]string{"--nodes=1"}, []int{1}, []int{2, 3, 100}},
+		{[]string{"--nodes=1,3"}, []int{1, 3}, []int{2, 4, 100}},
+		{[]string{"--nodes=1-3"}, []int{1, 2, 3}, []int{4, 100}},
+		{[]string{"--nodes=1-3,5"}, []int{1, 2, 3, 5}, []int{4, 100}},
+		{[]string{"--nodes=1-3,5,10-20"}, []int{2, 5, 15}, []int{7}},
+		{[]string{"--nodes=1,1-2"}, []int{1, 2}, []int{3, 100}},
+		{[]string{"--nodes=1-3", "--exclude-nodes=2"}, []int{1, 3}, []int{2, 4, 100}},
+		{[]string{"--nodes=1,3", "--exclude-nodes=3"}, []int{1}, []int{2, 3, 4, 100}},
+		{[]string{"--exclude-nodes=2-7"}, []int{1, 8, 9, 10}, []int{2, 3, 4, 5, 6, 7}},
+	}
+
+	f := debugZipCmd.Flags()
+	for _, tc := range testData {
+		initCLIDefaults()
+		if err := f.Parse(tc.args); err != nil {
+			t.Fatalf("Parse(%#v) got unexpected error: %v", tc.args, err)
+		}
+
+		for _, wantIncluded := range tc.wantIncluded {
+			assert.True(t, zipCtx.nodes.isIncluded(roachpb.NodeID(wantIncluded)))
+		}
+		for _, wantExcluded := range tc.wantExcluded {
+			assert.False(t, zipCtx.nodes.isIncluded(roachpb.NodeID(wantExcluded)))
+		}
 	}
 }


### PR DESCRIPTION
Fixes #42953 

Release note (cli change): `cockroach debug zip` now supports two
command-line parameters `--nodes` and `--exclude-nodes`. When
specified, they control which nodes are inspected when gathering the
data. This makes it possible to focus on a group of nodes of interest
in a large cluster, or to exclude nodes that `debug zip` would have
trouble reaching otherwise. Both flags accept a list of individual
node IDs or ranges of node IDs, e.g. `--nodes=1,10,13-15`.