### PR TITLE
ccl/storageccl,storage: fix retrieval of Pebble encryption info

### DIFF
--- a/pkg/ccl/storageccl/engineccl/encrypted_fs.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs.go
@@ -219,12 +219,12 @@ func (e *encryptionStatsHandler) GetEncryptionStatus() ([]byte, error) {
 	if k != nil {
 		s.ActiveDataKey = k.Info
 	}
-	return []byte(s.String()), nil
+	return protoutil.Marshal(&s)
 }
 
 func (e *encryptionStatsHandler) GetDataKeysRegistry() ([]byte, error) {
 	r := e.dataKM.getScrubbedRegistry()
-	return []byte(r.String()), nil
+	return protoutil.Marshal(r)
 }
 
 func (e *encryptionStatsHandler) GetActiveDataKeyID() (string, error) {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -801,7 +801,10 @@ func (p *Pebble) GetEncryptionRegistries() (*EncryptionRegistries, error) {
 		}
 	}
 	if p.fileRegistry != nil {
-		rv.FileRegistry = []byte(p.fileRegistry.getRegistryCopy().String())
+		rv.FileRegistry, err = protoutil.Marshal(p.fileRegistry.getRegistryCopy())
+		if err != nil {
+			return nil, err
+		}
 	}
 	return rv, nil
 }


### PR DESCRIPTION
Pebble encryption-at-rest was returning certain status info in the text
proto format rather than the binary format which was incompatible with
`debug encryption-status` and the Admin UI encryption status
expectations.

Release note (bug fix): Fix `debug encryption-status` and the Admin UI
display of encryption status when using Pebble.