### PR TITLE
release-20.1: cli: disable block profiling by default

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -282,8 +282,11 @@ func initBlockProfile() {
 	// will sample one event per X nanoseconds spent blocking.
 	//
 	// The block profile can be viewed with `pprof http://HOST:PORT/debug/pprof/block`
-	d := envutil.EnvOrDefaultInt64("COCKROACH_BLOCK_PROFILE_RATE",
-		10000000 /* 1 sample per 10 milliseconds spent blocking */)
+	//
+	// The utility of the block profile (aka blocking profile) has diminished
+	// with the advent of the mutex profile. We currently leave the block profile
+	// disabled by default as it has a non-zero performance impact.
+	d := envutil.EnvOrDefaultInt64("COCKROACH_BLOCK_PROFILE_RATE", 0)
 	runtime.SetBlockProfileRate(int(d))
 }
 


### PR DESCRIPTION
Debatable whether this should be backported since it is a small perf change. On the other hand, it should be completely safe.

Backport 1/1 commits from #48133.

/cc @cockroachdb/release

---

Disable block profiles by default as they consume a small but measurable
amount of CPU: 1.5% of CPU in one tpcc experiment. Additionally, block
profiling affects Pebble more than RocksDB as RocksDB's synchronization
primitives are invisible to the Go runtime. This levels the playing
field.

Release note (performance improvement): Disable the Go runtime block
profile by default which results in a small but measurable reduction in
CPU usage. The block profile has diminished in utility with the advent
of mutex contention profiles and is almost never used during performance
investigations.
