### PR TITLE
roachtest: assert against bogus return from pgurls

### DIFF
--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -148,7 +148,14 @@ func (c *SyncedCluster) GetInternalIP(index int) (string, error) {
 			"GetInternalIP: failed to execute hostname on %s:%d:\n(stdout) %s\n(stderr) %s",
 			c.Name, index, stdout.String(), stderr.String())
 	}
-	return strings.TrimSpace(stdout.String()), nil
+	ip := strings.TrimSpace(stdout.String())
+	if ip == "" {
+		return "", errors.Errorf(
+			"empty internal IP returned, stdout:\n%s\nstderr:\n%s",
+			stdout.String(), stderr.String(),
+		)
+	}
+	return ip, nil
 }
 
 // Start TODO(peter): document

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1436,9 +1436,15 @@ var pgurlCmd = &cobra.Command{
 
 		var urls []string
 		for i, ip := range ips {
+			if ip == "" {
+				return errors.Errorf("empty ip: %v", ips)
+			}
 			urls = append(urls, c.Impl.NodeURL(c, ip, c.Impl.NodePort(c, nodes[i])))
 		}
 		fmt.Println(strings.Join(urls, " "))
+		if len(urls) != len(nodes) {
+			return errors.Errorf("have nodes %v, but urls %v from ips %v", nodes, urls, ips)
+		}
 		return nil
 	}),
 }

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2126,8 +2126,20 @@ func (c *cluster) pgURL(ctx context.Context, node nodeListOption, external bool)
 		c.t.Fatal(errors.Wrapf(cmd.err, "failed to get pgurl for nodes: %s", nodes))
 	}
 	urls := strings.Split(strings.TrimSpace(cmd.stdout), " ")
+	if len(urls) != len(node) {
+		c.t.Fatalf(
+			"pgurl for nodes %v got urls %v from stdout:\n%s\nstderr:\n%s",
+			node, urls, cmd.stdout, cmd.stderr,
+		)
+	}
 	for i := range urls {
 		urls[i] = strings.Trim(urls[i], "'")
+		if urls[i] == "" {
+			c.t.Fatalf(
+				"pgurl for nodes %s empty: %v from\nstdout:\n%s\nstderr:\n%s",
+				urls, node, cmd.stdout, cmd.stderr,
+			)
+		}
 	}
 	return urls
 }


### PR DESCRIPTION
See https://github.com/cockroachdb/cockroach/issues/48091.

Apparently `c.InternalAddr` can return an empty addr:

https://github.com/cockroachdb/cockroach/blob/26b9716f3d1b30cb8456fc8f1de1bad78c4d26fa/pkg/cmd/roachtest/cluster.go#L2112-L2134

I have no idea how this can happen despite a bit of sleuthing, but
apparently it does, so the low cost way to home in on the problem
is to sprinkle some assertions.

Release note: None