### PR TITLE
sql: use rangefeeds for notifications about changes to table descriptors

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -70,6 +70,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>20.1-3</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>20.1-4</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -63,6 +63,7 @@ const (
 	VersionStart20_2
 	VersionGeospatialType
 	VersionEnums
+	VersionRangefeedLeases
 
 	// Add new versions here (step one of two).
 )
@@ -471,6 +472,7 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 1},
 	},
 	{
+
 		// VersionGeospatialType enables the use of Geospatial features.
 		Key:     VersionGeospatialType,
 		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 2},
@@ -479,6 +481,16 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// VersionEnums enables the use of ENUM types.
 		Key:     VersionEnums,
 		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 3},
+	},
+	{
+
+		// VersionRangefeedLeases is the enablement of leases uses rangefeeds.
+		// All nodes with this versions will have rangefeeds enabled on all system
+		// ranges. Once this version is finalized, gossip is not needed in the
+		// schema lease subsystem. Nodes which start with this version finalized
+		// will not pass gossip to the SQL layer.
+		Key:     VersionRangefeedLeases,
+		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 4},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/clusterversion/versionkey_string.go
+++ b/pkg/clusterversion/versionkey_string.go
@@ -39,11 +39,12 @@ func _() {
 	_ = x[VersionStart20_2-28]
 	_ = x[VersionGeospatialType-29]
 	_ = x[VersionEnums-30]
+	_ = x[VersionRangefeedLeases-31]
 }
 
-const _VersionKey_name = "Version19_1VersionStart19_2VersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDsVersionHashShardedIndexesVersionCreateRolePrivilegeVersionStatementDiagnosticsSystemTablesVersionSchemaChangeJobVersionSavepointsVersionTimeTZTypeVersionTimePrecisionVersion20_1VersionStart20_2VersionGeospatialTypeVersionEnums"
+const _VersionKey_name = "Version19_1VersionStart19_2VersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDsVersionHashShardedIndexesVersionCreateRolePrivilegeVersionStatementDiagnosticsSystemTablesVersionSchemaChangeJobVersionSavepointsVersionTimeTZTypeVersionTimePrecisionVersion20_1VersionStart20_2VersionGeospatialTypeVersionEnumsVersionRangefeedLeases"
 
-var _VersionKey_index = [...]uint16{0, 11, 27, 49, 75, 109, 136, 176, 200, 211, 227, 258, 287, 322, 354, 380, 404, 441, 480, 499, 534, 559, 585, 624, 646, 663, 680, 700, 711, 727, 748, 760}
+var _VersionKey_index = [...]uint16{0, 11, 27, 49, 75, 109, 136, 176, 200, 211, 227, 258, 287, 322, 354, 380, 404, 441, 480, 499, 534, 559, 585, 624, 646, 663, 680, 700, 711, 727, 748, 760, 782}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/kv/kvserver/client_rangefeed_test.go
+++ b/pkg/kv/kvserver/client_rangefeed_test.go
@@ -1,0 +1,104 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRangefeedWorksOnSystemRangesUnconditionally ensures that a rangefeed will
+// not return an error when operating on a system span even if the setting is
+// disabled. The test also ensures that an error is received if a rangefeed is
+// run on a user table.
+func TestRangefeedWorksOnSystemRangesUnconditionally(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	// Make sure the rangefeed setting really is disabled.
+	_, err := tc.ServerConn(0).Exec("SET CLUSTER SETTING kv.rangefeed.enabled = false")
+	require.NoError(t, err)
+
+	db := tc.Server(0).DB()
+	ds := tc.Server(0).DistSenderI().(*kvcoord.DistSender)
+
+	t.Run("works on system ranges", func(t *testing.T) {
+		startTS := db.Clock().Now()
+		descTableKey := keys.SystemSQLCodec.TablePrefix(keys.DescriptorTableID)
+		descTableSpan := roachpb.Span{
+			Key:    descTableKey,
+			EndKey: descTableKey.PrefixEnd(),
+		}
+
+		evChan := make(chan *roachpb.RangeFeedEvent)
+		rangefeedErrChan := make(chan error, 1)
+		ctxToCancel, cancel := context.WithCancel(ctx)
+		go func() {
+			rangefeedErrChan <- ds.RangeFeed(ctxToCancel, descTableSpan, startTS, false /* withDiff */, evChan)
+		}()
+
+		// Note: 42 is a system descriptor.
+		const junkDescriptorID = 42
+		require.GreaterOrEqual(t, keys.MaxReservedDescID, junkDescriptorID)
+		junkDescriptorKey := sqlbase.MakeDescMetadataKey(keys.SystemSQLCodec, junkDescriptorID)
+		junkDescriptor := sqlbase.WrapDescriptor(&sqlbase.DatabaseDescriptor{
+			Name: "junk",
+			ID:   junkDescriptorID,
+		})
+		require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			if err := txn.SetSystemConfigTrigger(); err != nil {
+				return err
+			}
+			return txn.Put(ctx, junkDescriptorKey, junkDescriptor)
+		}))
+		after := db.Clock().Now()
+		for {
+			ev := <-evChan
+			if ev.Checkpoint != nil && after.Less(ev.Checkpoint.ResolvedTS) {
+				t.Fatal("expected to see write which occurred before the checkpoint")
+			}
+
+			if ev.Val != nil && ev.Val.Key.Equal(junkDescriptorKey) {
+				var gotProto sqlbase.Descriptor
+				require.NoError(t, ev.Val.Value.GetProto(&gotProto))
+				require.EqualValues(t, junkDescriptor, &gotProto)
+				break
+			}
+		}
+		cancel()
+		// There are several cases that seems like they can happen due
+		// to closed connections. Instead we just expect an error.
+		// The main point is we get an error in a timely manner.
+		require.Error(t, <-rangefeedErrChan)
+	})
+	t.Run("does not work on user ranges", func(t *testing.T) {
+		k := tc.ScratchRange(t)
+		require.NoError(t, tc.WaitForSplitAndInitialization(k))
+		startTS := db.Clock().Now()
+		scratchSpan := roachpb.Span{Key: k, EndKey: k.PrefixEnd()}
+		evChan := make(chan *roachpb.RangeFeedEvent)
+		require.Regexp(t, `rangefeeds require the kv\.rangefeed.enabled setting`,
+			ds.RangeFeed(ctx, scratchSpan, startTS, false /* withDiff */, evChan))
+	})
+}

--- a/pkg/kv/kvserver/gossip_test.go
+++ b/pkg/kv/kvserver/gossip_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -211,10 +212,10 @@ func TestGossipAfterAbortOfSystemConfigTransactionAfterFailureDueToIntents(t *te
 	txB := db.NewTxn(ctx, "b")
 
 	require.NoError(t, txA.SetSystemConfigTrigger())
-	require.NoError(t, txA.Put(ctx, keys.SystemSQLCodec.DescMetadataKey(1000), "foo"))
+	require.NoError(t, txA.Put(ctx, keys.SystemSQLCodec.DescMetadataKey(1000), &sqlbase.Descriptor{}))
 
 	require.NoError(t, txB.SetSystemConfigTrigger())
-	require.NoError(t, txB.Put(ctx, keys.SystemSQLCodec.DescMetadataKey(2000), "bar"))
+	require.NoError(t, txB.Put(ctx, keys.SystemSQLCodec.DescMetadataKey(2000), &sqlbase.Descriptor{}))
 
 	const someTime = 10 * time.Millisecond
 	clearNotifictions := func(ch <-chan struct{}) {

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -130,7 +130,7 @@ func (i iteratorWithCloser) Close() {
 func (r *Replica) RangeFeed(
 	args *roachpb.RangeFeedRequest, stream roachpb.Internal_RangeFeedServer,
 ) *roachpb.Error {
-	if !RangefeedEnabled.Get(&r.store.cfg.Settings.SV) {
+	if !r.isSystemRangeRLocked() && !RangefeedEnabled.Get(&r.store.cfg.Settings.SV) {
 		return roachpb.NewErrorf("rangefeeds require the kv.rangefeed.enabled setting. See %s",
 			base.DocsURL(`change-data-capture.html#enable-rangefeeds-to-reduce-latency`))
 	}

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -572,7 +572,7 @@ func (r *Replica) evaluateWriteBatchWrapper(
 func (r *Replica) newBatchedEngine(spans *spanset.SpanSet) (storage.Batch, *storage.OpLoggerBatch) {
 	batch := r.store.Engine().NewBatch()
 	var opLogger *storage.OpLoggerBatch
-	if RangefeedEnabled.Get(&r.store.cfg.Settings.SV) {
+	if r.isSystemRange() || RangefeedEnabled.Get(&r.store.cfg.Settings.SV) {
 		// TODO(nvanbenschoten): once we get rid of the RangefeedEnabled
 		// cluster setting we'll need a way to turn this on when any
 		// replica (not just the leaseholder) wants it and off when no

--- a/pkg/kv/kvserver/storagebase/base.go
+++ b/pkg/kv/kvserver/storagebase/base.go
@@ -101,6 +101,12 @@ type ReplicaApplyFilter func(args ApplyFilterArgs) (int, *roachpb.Error)
 // been processed. This filter is invoked only by the command proposer.
 type ReplicaResponseFilter func(context.Context, roachpb.BatchRequest, *roachpb.BatchResponse) *roachpb.Error
 
+// ReplicaRangefeedFilter is used in unit tests to modify the request, inject
+// responses, or return errors from rangefeeds.
+type ReplicaRangefeedFilter func(
+	args *roachpb.RangeFeedRequest, stream roachpb.Internal_RangeFeedServer,
+) *roachpb.Error
+
 // ContainsKey returns whether this range contains the specified key.
 func ContainsKey(desc *roachpb.RangeDescriptor, key roachpb.Key) bool {
 	if bytes.HasPrefix(key, keys.LocalRangeIDPrefix) {

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2299,6 +2299,13 @@ func (s *Store) Descriptor(useCached bool) (*roachpb.StoreDescriptor, error) {
 func (s *Store) RangeFeed(
 	args *roachpb.RangeFeedRequest, stream roachpb.Internal_RangeFeedServer,
 ) *roachpb.Error {
+
+	if filter := s.TestingKnobs().TestingRangefeedFilter; filter != nil {
+		if pErr := filter(args, stream); pErr != nil {
+			return pErr
+		}
+	}
+
 	if err := verifyKeys(args.Span.Key, args.Span.EndKey, true); err != nil {
 		return roachpb.NewError(err)
 	}

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -62,6 +62,11 @@ type StoreTestingKnobs struct {
 	// error returned to the client, or to simulate network failures.
 	TestingResponseFilter storagebase.ReplicaResponseFilter
 
+	// TestingRangefeedFilter is called before a replica processes a rangefeed
+	// in order for unit tests to modify the request, error returned to the client
+	// or data.
+	TestingRangefeedFilter storagebase.ReplicaRangefeedFilter
+
 	// A hack to manipulate the clock before sending a batch request to a replica.
 	// TODO(kaneda): This hook is not encouraged to use. Get rid of it once
 	// we make TestServer take a ManualClock.

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -535,9 +535,6 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 	)
 	execCfg.StmtDiagnosticsRecorder = stmtDiagnosticsRegistry
 
-	leaseMgr.RefreshLeases(cfg.stopper, cfg.db, cfg.gossip)
-	leaseMgr.PeriodicallyRefreshSomeLeases()
-
 	temporaryObjectCleaner := sql.NewTemporaryObjectCleaner(
 		cfg.Settings,
 		cfg.db,
@@ -592,6 +589,9 @@ func (s *sqlServer) start(
 	if migrationManagerTestingKnobs := knobs.SQLMigrationManager; migrationManagerTestingKnobs != nil {
 		mmKnobs = *migrationManagerTestingKnobs.(*sqlmigrations.MigrationManagerTestingKnobs)
 	}
+
+	s.leaseMgr.RefreshLeases(stopper, s.execCfg.DB, s.execCfg.Gossip)
+	s.leaseMgr.PeriodicallyRefreshSomeLeases()
 	migrationsExecutor := sql.MakeInternalExecutor(
 		ctx, s.pgServer.SQLServer, s.internalMemMetrics, s.execCfg.Settings)
 	migrationsExecutor.SetSessionData(

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -590,8 +590,9 @@ func (s *sqlServer) start(
 		mmKnobs = *migrationManagerTestingKnobs.(*sqlmigrations.MigrationManagerTestingKnobs)
 	}
 
-	s.leaseMgr.RefreshLeases(stopper, s.execCfg.DB, s.execCfg.Gossip)
-	s.leaseMgr.PeriodicallyRefreshSomeLeases()
+	s.leaseMgr.RefreshLeases(ctx, stopper, s.execCfg.DB, s.execCfg.Gossip)
+	s.leaseMgr.PeriodicallyRefreshSomeLeases(ctx)
+
 	migrationsExecutor := sql.MakeInternalExecutor(
 		ctx, s.pgServer.SQLServer, s.internalMemMetrics, s.execCfg.Settings)
 	migrationsExecutor.SetSessionData(

--- a/pkg/sql/lease_internal_test.go
+++ b/pkg/sql/lease_internal_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -123,7 +122,7 @@ func TestPurgeOldVersions(t *testing.T) {
 	serverParams := base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			SQLLeaseManager: &LeaseManagerTestingKnobs{
-				GossipUpdateEvent: func(cfg *config.SystemConfig) error {
+				TestingTableUpdateEvent: func(t *sqlbase.TableDescriptor) error {
 					gossipSem <- struct{}{}
 					<-gossipSem
 					return nil


### PR DESCRIPTION
This PR comes in several commits:

1) Enable rangefeeds unconditionally on system ranges
  * this is going to need to some modification to work with tenant system spans
2) Add a cluster version for the above functionality
3) Add the basic (messy) implementation of rangefeed based lease manager notifications
4) Add some testing knobs
5) Clean up 3 in a number of ways, add some more testing, fix a synchronization issue.
6) Updates a test to not break a new assertion that values in the descriptor table actually be descriptors

Relates to but does not fully resolve #47150. Another PR will follow-up and disable the gossip of the descriptors table and lift the enforcement of the system config transaction anchor. 
