### PR TITLE
backupccl,sql: do not include comments in SHOW BACKUP SCHEMAS

### DIFF
--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -237,7 +237,11 @@ func backupShowerDefault(
 							tree.MakeDBool(manifest.DescriptorCoverage == tree.AllDescriptors),
 						}
 						if showSchemas {
-							schema, err := p.ShowCreate(ctx, dbName, manifest.Descriptors, table, sql.OmitMissingFKClausesFromCreate)
+							displayOptions := sql.ShowCreateDisplayOptions{
+								FKDisplayMode:  sql.OmitMissingFKClausesFromCreate,
+								IgnoreComments: true,
+							}
+							schema, err := p.ShowCreate(ctx, dbName, manifest.Descriptors, table, displayOptions)
 							if err != nil {
 								continue
 							}

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -26,8 +26,11 @@ func TestShowBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const numAccounts = 11
-	_, tc, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
+	_, tc, sqlDB, tempDir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
+	kvDB := tc.Server(0).DB()
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, initNone)
 	defer cleanupFn()
+	defer cleanupEmptyCluster()
 
 	const full, inc, inc2 = localFoo + "/full", localFoo + "/inc", localFoo + "/inc2"
 
@@ -104,14 +107,14 @@ func TestShowBackup(t *testing.T) {
 	details1Key := roachpb.Key(sqlbase.MakeIndexKeyPrefix(keys.SystemSQLCodec, details1Desc, details1Desc.PrimaryIndex.ID))
 	details2Key := roachpb.Key(sqlbase.MakeIndexKeyPrefix(keys.SystemSQLCodec, details2Desc, details2Desc.PrimaryIndex.ID))
 
-	sqlDB.CheckQueryResults(t, fmt.Sprintf(`SHOW BACKUP RANGES '%s'`, details), [][]string{
+	sqlDBRestore.CheckQueryResults(t, fmt.Sprintf(`SHOW BACKUP RANGES '%s'`, details), [][]string{
 		{"/Table/56/1", "/Table/56/2", string(details1Key), string(details1Key.PrefixEnd())},
 		{"/Table/57/1", "/Table/57/2", string(details2Key), string(details2Key.PrefixEnd())},
 	})
 
 	var showFiles = fmt.Sprintf(`SELECT start_pretty, end_pretty, size_bytes, rows
 		FROM [SHOW BACKUP FILES '%s']`, details)
-	sqlDB.CheckQueryResults(t, showFiles, [][]string{
+	sqlDBRestore.CheckQueryResults(t, showFiles, [][]string{
 		{"/Table/56/1/1", "/Table/56/1/42", "369", "41"},
 		{"/Table/56/1/42", "/Table/56/2", "531", "59"},
 	})
@@ -135,27 +138,30 @@ func TestShowBackup(t *testing.T) {
 	{
 		viewTableSeq := localFoo + "/tableviewseq"
 		sqlDB.Exec(t, `CREATE TABLE data.tableA (a int primary key, b int, INDEX tableA_b_idx (b ASC))`)
-		sqlDB.Exec(t, `COMMENT ON TABLE data.tableA IS 'table'`)
-		sqlDB.Exec(t, `COMMENT ON COLUMN data.tableA.a IS 'column'`)
-		sqlDB.Exec(t, `COMMENT ON INDEX data.tableA_b_idx IS 'index'`)
 		sqlDB.Exec(t, `CREATE VIEW data.viewA AS SELECT a from data.tableA`)
 		sqlDB.Exec(t, `CREATE SEQUENCE data.seqA START 1 INCREMENT 2 MAXVALUE 20`)
 		sqlDB.Exec(t, `BACKUP data.tableA, data.viewA, data.seqA TO $1;`, viewTableSeq)
 
+		// Create tables with the same ID as data.tableA to ensure that comments
+		// from different tables in the restoring cluster don't appear.
+		tableA := sqlbase.GetTableDescriptor(kvDB, keys.SystemSQLCodec, "data", "tablea")
+		for i := keys.MinUserDescID; i < int(tableA.ID); i++ {
+			tableName := fmt.Sprintf("foo%d", i)
+			sqlDBRestore.Exec(t, fmt.Sprintf("CREATE TABLE %s ();", tableName))
+			sqlDBRestore.Exec(t, fmt.Sprintf("COMMENT ON TABLE %s IS 'table comment'", tableName))
+		}
+
 		expectedCreateTable := `CREATE TABLE tablea (
-	a INT8 NOT NULL,
-	b INT8 NULL,
-	CONSTRAINT "primary" PRIMARY KEY (a ASC),
-	INDEX tablea_b_idx (b ASC),
-	FAMILY "primary" (a, b)
-);
-COMMENT ON TABLE tablea IS 'table';
-COMMENT ON COLUMN tablea.a IS 'column';
-COMMENT ON INDEX tablea_b_idx IS 'index'`
+		a INT8 NOT NULL,
+		b INT8 NULL,
+		CONSTRAINT "primary" PRIMARY KEY (a ASC),
+		INDEX tablea_b_idx (b ASC),
+		FAMILY "primary" (a, b)
+	)`
 		expectedCreateView := `CREATE VIEW viewa (a) AS SELECT a FROM data.public.tablea`
 		expectedCreateSeq := `CREATE SEQUENCE seqa MINVALUE 1 MAXVALUE 20 INCREMENT 2 START 1`
 
-		showBackupRows = sqlDB.QueryStr(t, fmt.Sprintf(`SHOW BACKUP SCHEMAS '%s'`, viewTableSeq))
+		showBackupRows = sqlDBRestore.QueryStr(t, fmt.Sprintf(`SHOW BACKUP SCHEMAS '%s'`, viewTableSeq))
 		expected = []string{
 			expectedCreateTable,
 			expectedCreateView,
@@ -196,7 +202,7 @@ COMMENT ON INDEX tablea_b_idx IS 'index'`
 				FAMILY "primary" (a, b)
 			)`
 
-		showBackupRows = sqlDB.QueryStr(t, fmt.Sprintf(`SHOW BACKUP SCHEMAS '%s'`, includedFK))
+		showBackupRows = sqlDBRestore.QueryStr(t, fmt.Sprintf(`SHOW BACKUP SCHEMAS '%s'`, includedFK))
 		createStmtSameDB := showBackupRows[1][7]
 		if !eqWhitespace(createStmtSameDB, wantSameDB) {
 			t.Fatalf("mismatched create statement: %s, want %s", createStmtSameDB, wantSameDB)
@@ -222,7 +228,7 @@ COMMENT ON INDEX tablea_b_idx IS 'index'`
 				FAMILY "primary" (a, b)
 			)`
 
-		showBackupRows = sqlDB.QueryStr(t, fmt.Sprintf(`SHOW BACKUP SCHEMAS '%s'`, missingFK))
+		showBackupRows = sqlDBRestore.QueryStr(t, fmt.Sprintf(`SHOW BACKUP SCHEMAS '%s'`, missingFK))
 		createStmt := showBackupRows[0][7]
 		if !eqWhitespace(createStmt, want) {
 			t.Fatalf("mismatched create statement: %s, want %s", createStmt, want)
@@ -233,7 +239,7 @@ COMMENT ON INDEX tablea_b_idx IS 'index'`
 		full_cluster := localFoo + "/full_cluster"
 		sqlDB.Exec(t, `BACKUP TO $1;`, full_cluster)
 
-		showBackupRows = sqlDB.QueryStr(t, fmt.Sprintf(`SHOW BACKUP '%s'`, full_cluster))
+		showBackupRows = sqlDBRestore.QueryStr(t, fmt.Sprintf(`SHOW BACKUP '%s'`, full_cluster))
 		is_full_cluster := showBackupRows[0][6]
 		if !eqWhitespace(is_full_cluster, "true") {
 			t.Fatal("expected show backup to indicate that backup was full cluster")
@@ -242,7 +248,7 @@ COMMENT ON INDEX tablea_b_idx IS 'index'`
 		full_cluster_inc := localFoo + "/full_cluster_inc"
 		sqlDB.Exec(t, `BACKUP TO $1 INCREMENTAL FROM $2;`, full_cluster_inc, full_cluster)
 
-		showBackupRows = sqlDB.QueryStr(t, fmt.Sprintf(`SHOW BACKUP '%s'`, full_cluster))
+		showBackupRows = sqlDBRestore.QueryStr(t, fmt.Sprintf(`SHOW BACKUP '%s'`, full_cluster))
 		is_full_cluster = showBackupRows[0][6]
 		if !eqWhitespace(is_full_cluster, "true") {
 			t.Fatal("expected show backup to indicate that backup was full cluster")
@@ -267,7 +273,7 @@ COMMENT ON INDEX tablea_b_idx IS 'index'`
 
 		want := `GRANT ALL ON top_secret TO admin; GRANT SELECT, UPDATE ON top_secret TO agent_bond; GRANT INSERT ON top_secret TO agents; GRANT ALL ON top_secret TO m; GRANT ALL ON top_secret TO root; `
 
-		showBackupRows := sqlDB.QueryStr(t, fmt.Sprintf(`SHOW BACKUP '%s' WITH privileges`, showPrivs))
+		showBackupRows := sqlDBRestore.QueryStr(t, fmt.Sprintf(`SHOW BACKUP '%s' WITH privileges`, showPrivs))
 		privs := showBackupRows[0][7]
 		if !eqWhitespace(privs, want) {
 			t.Fatalf("mismatched privileges: %s, want %s", privs, want)

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1423,7 +1423,10 @@ CREATE TABLE crdb_internal.create_statements (
 		} else {
 			descType = typeTable
 			tn := (*tree.Name)(&table.Name)
-			createNofk, err = ShowCreateTable(ctx, p, tn, contextName, table, lookup, OmitFKClausesFromCreate)
+			displayOptions := ShowCreateDisplayOptions{
+				FKDisplayMode: OmitFKClausesFromCreate,
+			}
+			createNofk, err = ShowCreateTable(ctx, p, tn, contextName, table, lookup, displayOptions)
 			if err != nil {
 				return err
 			}
@@ -1431,7 +1434,8 @@ CREATE TABLE crdb_internal.create_statements (
 				validateStmts); err != nil {
 				return err
 			}
-			stmt, err = ShowCreateTable(ctx, p, tn, contextName, table, lookup, IncludeFkClausesInCreate)
+			displayOptions.FKDisplayMode = IncludeFkClausesInCreate
+			stmt, err = ShowCreateTable(ctx, p, tn, contextName, table, lookup, displayOptions)
 		}
 		if err != nil {
 			return err

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -92,7 +92,7 @@ type PlanHookState interface {
 		ctx context.Context, tn *TableName, required bool, requiredType ResolveRequiredType,
 	) (table *MutableTableDescriptor, err error)
 	ShowCreate(
-		ctx context.Context, dbPrefix string, allDescs []sqlbase.Descriptor, desc *sqlbase.TableDescriptor, ignoreFKs shouldOmitFKClausesFromCreate,
+		ctx context.Context, dbPrefix string, allDescs []sqlbase.Descriptor, desc *sqlbase.TableDescriptor, displayOptions ShowCreateDisplayOptions,
 	) (string, error)
 }
 

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -37,6 +37,19 @@ const (
 	OmitMissingFKClausesFromCreate
 )
 
+// ShowCreateDisplayOptions is a container struct holding the options that
+// ShowCreate uses to determine how much information should be included in the
+// CREATE statement.
+type ShowCreateDisplayOptions struct {
+	FKDisplayMode shouldOmitFKClausesFromCreate
+	// Comment resolution requires looking up table data from system.comments
+	// table. This is sometimes not possible. For example, in the context of a
+	// SHOW BACKUP which may resolve the create statement, there is no mechanism
+	// to read any table data from the backup (nor is there a guarantee that the
+	// system.comments table is included in the backup at all).
+	IgnoreComments bool
+}
+
 // ShowCreateTable returns a valid SQL representation of the CREATE
 // TABLE statement used to create the given table.
 //
@@ -52,7 +65,7 @@ func ShowCreateTable(
 	dbPrefix string,
 	desc *sqlbase.TableDescriptor,
 	lCtx simpleSchemaResolver,
-	fkDisplayMode shouldOmitFKClausesFromCreate,
+	displayOptions ShowCreateDisplayOptions,
 ) (string, error) {
 	a := &sqlbase.DatumAlloc{}
 
@@ -88,7 +101,7 @@ func ShowCreateTable(
 	}
 	// TODO (lucy): Possibly include FKs in the mutations list here, or else
 	// exclude check mutations below, for consistency.
-	if fkDisplayMode != OmitFKClausesFromCreate {
+	if displayOptions.FKDisplayMode != OmitFKClausesFromCreate {
 		for i := range desc.OutboundFKs {
 			fkCtx := tree.NewFmtCtx(tree.FmtSimple)
 			fk := &desc.OutboundFKs[i]
@@ -96,9 +109,9 @@ func ShowCreateTable(
 			fkCtx.FormatNameP(&fk.Name)
 			fkCtx.WriteString(" ")
 			if err := showForeignKeyConstraint(&fkCtx.Buffer, dbPrefix, desc, fk, lCtx); err != nil {
-				if fkDisplayMode == OmitMissingFKClausesFromCreate {
+				if displayOptions.FKDisplayMode == OmitMissingFKClausesFromCreate {
 					continue
-				} else { // When fkDisplayMode == IncludeFkClausesInCreate.
+				} else { // When FKDisplayMode == IncludeFkClausesInCreate.
 					return "", err
 				}
 			}
@@ -114,7 +127,7 @@ func ShowCreateTable(
 		// Initialize to false if Interleave has no ancestors, indicating that the
 		// index is not interleaved at all.
 		includeInterleaveClause := len(idx.Interleave.Ancestors) == 0
-		if fkDisplayMode != OmitFKClausesFromCreate {
+		if displayOptions.FKDisplayMode != OmitFKClausesFromCreate {
 			// The caller is instructing us to not omit FK clauses from inside the CREATE.
 			// (i.e. the caller does not want them as separate DDL.)
 			// Since we're including FK clauses, we need to also include the PARTITION and INTERLEAVE
@@ -156,8 +169,10 @@ func ShowCreateTable(
 		return "", err
 	}
 
-	if err := showComments(desc, selectComment(ctx, p, desc.ID), &f.Buffer); err != nil {
-		return "", err
+	if !displayOptions.IgnoreComments {
+		if err := showComments(desc, selectComment(ctx, p, desc.ID), &f.Buffer); err != nil {
+			return "", err
+		}
 	}
 
 	return f.CloseAndGetString(), nil
@@ -188,7 +203,7 @@ func (p *planner) ShowCreate(
 	dbPrefix string,
 	allDescs []sqlbase.Descriptor,
 	desc *sqlbase.TableDescriptor,
-	ignoreFKs shouldOmitFKClausesFromCreate,
+	displayOptions ShowCreateDisplayOptions,
 ) (string, error) {
 	var stmt string
 	var err error
@@ -199,7 +214,7 @@ func (p *planner) ShowCreate(
 		stmt, err = ShowCreateSequence(ctx, tn, desc)
 	} else {
 		lCtx := newInternalLookupCtxFromDescriptors(allDescs, nil /* want all tables */)
-		stmt, err = ShowCreateTable(ctx, p, tn, dbPrefix, desc, lCtx, ignoreFKs)
+		stmt, err = ShowCreateTable(ctx, p, tn, dbPrefix, desc, lCtx, displayOptions)
 	}
 
 	return stmt, err


### PR DESCRIPTION
SHOW BACKUP SCHEMAS shows all of the tables in the backup and the SHOW
CREATE TABLE statement of the associated table, using ShowCreate.
ShowCreate includes the comments on the table, but this requires reading
table data from outside the lookup scope of ShowCreate. To show the
comments on a particular table, the comments need to be read from the
system.comments table, which poses 2 difficulties:

1. The system.comments data may not be present in the backup at all.
2. There currently is no way to read this data from a backup even if it
were included.

To address this, the display options for ShowCreate were expanded to
include a flag indicating whether or not comments should be ignored.

Previously, the SHOW BACKUP testing structure did not exercise that
SHOW BACKUP may be run on a different cluster than the one issuing the
backup. This commit updates the testing to ensure that the SHOW BACKUP
commands are run on a new cluster to ensure that the command does not
reference data outside of the BACKUP file.

Release note (bug fix): SHOW BACKUP SCHEMAS no longer shows
table comments as they may be inaccurate.