### PR TITLE
geo/geogfn: implement PostGIS compatible Area/Length/Perimeter

### DIFF
--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -256,8 +256,8 @@ func (g *Geography) AsS2() ([]s2.Region, error) {
 	if err != nil {
 		return nil, err
 	}
-	// TODO(otan): convert by reading from S2 directly.
-	return s2RegionsFromGeom(geomRepr), nil
+	// TODO(otan): convert by reading from EWKB to S2 directly.
+	return S2RegionsFromGeom(geomRepr), nil
 }
 
 // isLinearRingCCW returns whether a given linear ring is counter clock wise.
@@ -302,9 +302,9 @@ func isLinearRingCCW(linearRing *geom.LinearRing) bool {
 	return areaSign > 0
 }
 
-// s2RegionsFromGeom converts an geom representation of an object
+// S2RegionsFromGeom converts an geom representation of an object
 // to s2 regions.
-func s2RegionsFromGeom(geomRepr geom.T) []s2.Region {
+func S2RegionsFromGeom(geomRepr geom.T) []s2.Region {
 	var regions []s2.Region
 	switch repr := geomRepr.(type) {
 	case *geom.Point:
@@ -343,19 +343,19 @@ func s2RegionsFromGeom(geomRepr geom.T) []s2.Region {
 		}
 	case *geom.GeometryCollection:
 		for _, geom := range repr.Geoms() {
-			regions = append(regions, s2RegionsFromGeom(geom)...)
+			regions = append(regions, S2RegionsFromGeom(geom)...)
 		}
 	case *geom.MultiPoint:
 		for i := 0; i < repr.NumPoints(); i++ {
-			regions = append(regions, s2RegionsFromGeom(repr.Point(i))...)
+			regions = append(regions, S2RegionsFromGeom(repr.Point(i))...)
 		}
 	case *geom.MultiLineString:
 		for i := 0; i < repr.NumLineStrings(); i++ {
-			regions = append(regions, s2RegionsFromGeom(repr.LineString(i))...)
+			regions = append(regions, S2RegionsFromGeom(repr.LineString(i))...)
 		}
 	case *geom.MultiPolygon:
 		for i := 0; i < repr.NumPolygons(); i++ {
-			regions = append(regions, s2RegionsFromGeom(repr.Polygon(i))...)
+			regions = append(regions, S2RegionsFromGeom(repr.Polygon(i))...)
 		}
 	}
 	return regions

--- a/pkg/geo/geogfn/unary_operators.go
+++ b/pkg/geo/geogfn/unary_operators.go
@@ -1,0 +1,122 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geogfn
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/cockroachdb/cockroach/pkg/geo/geographiclib"
+	"github.com/cockroachdb/errors"
+	"github.com/golang/geo/s2"
+	"github.com/twpayne/go-geom"
+)
+
+// Area returns the area of a given Geography.
+func Area(g *geo.Geography, useSphereOrSpheroid useSphereOrSpheroid) (float64, error) {
+	regions, err := g.AsS2()
+	if err != nil {
+		return 0, err
+	}
+	spheroid := geographiclib.WGS84Spheroid
+
+	var totalArea float64
+	for _, region := range regions {
+		switch region := region.(type) {
+		case s2.Point, *s2.Polyline:
+		case *s2.Polygon:
+			if useSphereOrSpheroid == UseSpheroid {
+				for _, loop := range region.Loops() {
+					points := loop.Vertices()
+					area, _ := spheroid.AreaAndPerimeter(points[:len(points)-1])
+					totalArea += float64(loop.Sign()) * area
+				}
+			} else {
+				totalArea += region.Area()
+			}
+		default:
+			return 0, errors.Newf("unknown type: %T", region)
+		}
+	}
+	if useSphereOrSpheroid == UseSphere {
+		totalArea *= spheroid.SphereRadius * spheroid.SphereRadius
+	}
+	return totalArea, nil
+}
+
+// Perimeter returns the perimeter of a given Geography.
+func Perimeter(g *geo.Geography, useSphereOrSpheroid useSphereOrSpheroid) (float64, error) {
+	gt, err := g.AsGeomT()
+	if err != nil {
+		return 0, err
+	}
+	// This check mirrors PostGIS behavior, where GeometryCollections
+	// of LineStrings include the length for perimeters.
+	switch gt.(type) {
+	case *geom.Polygon, *geom.MultiPolygon, *geom.GeometryCollection:
+	default:
+		return 0, nil
+	}
+	return length(geo.S2RegionsFromGeom(gt), useSphereOrSpheroid)
+}
+
+// Length returns length of a given Geography.
+func Length(g *geo.Geography, useSphereOrSpheroid useSphereOrSpheroid) (float64, error) {
+	gt, err := g.AsGeomT()
+	if err != nil {
+		return 0, err
+	}
+	// This check mirrors PostGIS behavior, where GeometryCollections
+	// of Polygons include the perimeters for polygons.
+	switch gt.(type) {
+	case *geom.LineString, *geom.MultiLineString, *geom.GeometryCollection:
+	default:
+		return 0, nil
+	}
+	return length(geo.S2RegionsFromGeom(gt), useSphereOrSpheroid)
+}
+
+// length returns the sum of the lengtsh and perimeters in the shapes of the Geography.
+// In OGC parlance, length returns both LineString lengths _and_ Polygon perimeters.
+func length(regions []s2.Region, useSphereOrSpheroid useSphereOrSpheroid) (float64, error) {
+	spheroid := geographiclib.WGS84Spheroid
+
+	var totalLength float64
+	for _, region := range regions {
+		switch region := region.(type) {
+		case s2.Point:
+		case *s2.Polyline:
+			if useSphereOrSpheroid == UseSpheroid {
+				totalLength += spheroid.InverseBatch((*region))
+			} else {
+				for edgeIdx := 0; edgeIdx < region.NumEdges(); edgeIdx++ {
+					edge := region.Edge(edgeIdx)
+					totalLength += s2.ChordAngleBetweenPoints(edge.V0, edge.V1).Angle().Radians()
+				}
+			}
+		case *s2.Polygon:
+			for _, loop := range region.Loops() {
+				if useSphereOrSpheroid == UseSpheroid {
+					totalLength += spheroid.InverseBatch(loop.Vertices())
+				} else {
+					for edgeIdx := 0; edgeIdx < loop.NumEdges(); edgeIdx++ {
+						edge := loop.Edge(edgeIdx)
+						totalLength += s2.ChordAngleBetweenPoints(edge.V0, edge.V1).Angle().Radians()
+					}
+				}
+			}
+		default:
+			return 0, errors.Newf("unknown type: %T", region)
+		}
+	}
+	if useSphereOrSpheroid == UseSphere {
+		totalLength *= spheroid.SphereRadius
+	}
+	return totalLength, nil
+}

--- a/pkg/geo/geogfn/unary_operators_test.go
+++ b/pkg/geo/geogfn/unary_operators_test.go
@@ -1,0 +1,195 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geogfn
+
+import (
+	"math"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/stretchr/testify/require"
+)
+
+type unaryOperatorExpectedResult struct {
+	expectedArea      float64
+	expectedLength    float64
+	expectedPerimeter float64
+}
+
+var unaryOperatorTestCases = []struct {
+	wkt      string
+	sphere   unaryOperatorExpectedResult
+	spheroid unaryOperatorExpectedResult
+}{
+	{
+		wkt: "POINT(1.0 1.0)",
+	},
+	{
+		wkt: "LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0)",
+		sphere: unaryOperatorExpectedResult{
+			expectedLength: 314403.4167139704,
+		},
+		spheroid: unaryOperatorExpectedResult{
+			expectedLength: 313705.47851796006,
+		},
+	},
+	{
+		wkt: "POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 0.0))",
+		sphere: unaryOperatorExpectedResult{
+			expectedArea:      6182486746.455541,
+			expectedPerimeter: 379639.75723776827,
+		},
+		spheroid: unaryOperatorExpectedResult{
+			expectedArea:      6154854786.721433,
+			expectedPerimeter: 378793.4476424126,
+		},
+	},
+	{
+		wkt: "POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 0.0), (0.1 0.1, 0.2 0.1, 0.2 0.2, 0.1 0.1))",
+		sphere: unaryOperatorExpectedResult{
+			expectedArea:      6120665080.445181,
+			expectedPerimeter: 417604.087288779,
+		},
+		spheroid: unaryOperatorExpectedResult{
+			expectedArea:      6093309483.796953,
+			expectedPerimeter: 416673.1281208417,
+		},
+	},
+	{
+		wkt: "MULTIPOINT((1.0 1.0), (2.0 2.0))",
+	},
+	{
+		wkt: "MULTILINESTRING((1.0 1.0, 2.0 2.0, 3.0 3.0), (6.0 6.0, 7.0 6.0))",
+		sphere: unaryOperatorExpectedResult{
+			expectedLength: 424989.34283080546,
+		},
+		spheroid: unaryOperatorExpectedResult{
+			expectedLength: 424419.1832424484,
+		},
+	},
+	{
+		wkt: "MULTIPOLYGON(((3.0 3.0, 4.0 3.0, 4.0 4.0, 3.0 3.0)), ((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 0.0), (0.1 0.1, 0.2 0.1, 0.2 0.2, 0.1 0.1)))",
+		sphere: unaryOperatorExpectedResult{
+			expectedArea:      12294677441.341661,
+			expectedPerimeter: 796947.8473004946,
+		},
+		spheroid: unaryOperatorExpectedResult{
+			expectedArea:      12240009431.86529,
+			expectedPerimeter: 795178.6592721482,
+		},
+	},
+	{
+		wkt: "GEOMETRYCOLLECTION (POINT (40 10),LINESTRING (10 10, 20 20, 10 40),POLYGON ((40 40, 20 45, 45 30, 40 40)))",
+		sphere: unaryOperatorExpectedResult{
+			expectedArea:      691570576619.521,
+			expectedLength:    9637039.459995955,
+			expectedPerimeter: 9637039.459995955,
+		},
+		spheroid: unaryOperatorExpectedResult{
+			expectedArea:      691638769184.1753,
+			expectedLength:    9632838.874863794,
+			expectedPerimeter: 9632838.874863794,
+		},
+	},
+}
+
+func TestArea(t *testing.T) {
+	for _, tc := range unaryOperatorTestCases {
+		t.Run(tc.wkt, func(t *testing.T) {
+			g, err := geo.ParseGeography(tc.wkt)
+			require.NoError(t, err)
+
+			for _, subTC := range []struct {
+				desc                string
+				useSphereOrSpheroid useSphereOrSpheroid
+				expected            float64
+			}{
+				{"sphere", UseSphere, tc.sphere.expectedArea},
+				{"spheroid", UseSpheroid, tc.spheroid.expectedArea},
+			} {
+				t.Run(subTC.desc, func(t *testing.T) {
+					ret, err := Area(g, subTC.useSphereOrSpheroid)
+					require.NoError(t, err)
+					require.LessOrEqualf(
+						t,
+						math.Abs(ret-subTC.expected),
+						0.1, // allow 0.1m^2 difference.
+						"expected %f, found %f",
+						subTC.expected,
+						ret,
+					)
+				})
+			}
+		})
+	}
+}
+
+func TestPerimeter(t *testing.T) {
+	for _, tc := range unaryOperatorTestCases {
+		t.Run(tc.wkt, func(t *testing.T) {
+			g, err := geo.ParseGeography(tc.wkt)
+			require.NoError(t, err)
+
+			for _, subTC := range []struct {
+				desc                string
+				useSphereOrSpheroid useSphereOrSpheroid
+				expected            float64
+			}{
+				{"sphere", UseSphere, tc.sphere.expectedPerimeter},
+				{"spheroid", UseSpheroid, tc.spheroid.expectedPerimeter},
+			} {
+				t.Run(subTC.desc, func(t *testing.T) {
+					ret, err := Perimeter(g, subTC.useSphereOrSpheroid)
+					require.NoError(t, err)
+					require.LessOrEqualf(
+						t,
+						math.Abs(ret-subTC.expected),
+						0.01, // allow 0.01m difference.
+						"expected %f, found %f",
+						subTC.expected,
+						ret,
+					)
+				})
+			}
+		})
+	}
+}
+
+func TestLength(t *testing.T) {
+	for _, tc := range unaryOperatorTestCases {
+		t.Run(tc.wkt, func(t *testing.T) {
+			g, err := geo.ParseGeography(tc.wkt)
+			require.NoError(t, err)
+
+			for _, subTC := range []struct {
+				desc                string
+				useSphereOrSpheroid useSphereOrSpheroid
+				expected            float64
+			}{
+				{"sphere", UseSphere, tc.sphere.expectedLength},
+				{"spheroid", UseSpheroid, tc.spheroid.expectedLength},
+			} {
+				t.Run(subTC.desc, func(t *testing.T) {
+					ret, err := Length(g, subTC.useSphereOrSpheroid)
+					require.NoError(t, err)
+					require.LessOrEqualf(
+						t,
+						math.Abs(ret-subTC.expected),
+						0.01, // allow 0.01m difference
+						"expected %f, found %f",
+						subTC.expected,
+						ret,
+					)
+				})
+			}
+		})
+	}
+}

--- a/pkg/geo/geographiclib/geographiclib.cc
+++ b/pkg/geo/geographiclib/geographiclib.cc
@@ -1,0 +1,27 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "geodesic.h"
+#include "geographiclib.h"
+
+void CR_GEOGRAPHICLIB_InverseBatch(
+  struct geod_geodesic* spheroid,
+  double lats[],
+  double lngs[],
+  int len,
+  double *result
+) {
+  *result = 0;
+  for (int i = 0; i < len - 1; i++) {
+    double s12, az1, az2;
+    geod_inverse(spheroid, lats[i], lngs[i], lats[i+1], lngs[i+1], &s12, &az1, &az2);
+    *result += s12;
+  }
+}

--- a/pkg/geo/geographiclib/geographiclib.go
+++ b/pkg/geo/geographiclib/geographiclib.go
@@ -15,6 +15,7 @@ package geographiclib
 // #cgo LDFLAGS: -lm
 //
 // #include "geodesic.h"
+// #include "geographiclib.h"
 import "C"
 
 import "github.com/golang/geo/s2"
@@ -61,4 +62,50 @@ func (s *Spheroid) Inverse(a, b s2.LatLng) (s12, az1, az2 float64) {
 		&retAZ2,
 	)
 	return float64(retS12), float64(retAZ1), float64(retAZ2)
+}
+
+// InverseBatch computes the sum of the length of the lines represented
+// by the line of points.
+// This is intended for use for LineStrings. LinearRings/Polygons should use "AreaAndPerimeter".
+// Returns the sum of the s12 (distance in meters) units.
+func (s *Spheroid) InverseBatch(points []s2.Point) float64 {
+	lats := make([]C.double, len(points))
+	lngs := make([]C.double, len(points))
+	for i, p := range points {
+		latlng := s2.LatLngFromPoint(p)
+		lats[i] = C.double(latlng.Lat.Degrees())
+		lngs[i] = C.double(latlng.Lng.Degrees())
+	}
+	var result C.double
+	C.CR_GEOGRAPHICLIB_InverseBatch(
+		&s.cRepr,
+		&lats[0],
+		&lngs[0],
+		C.int(len(points)),
+		&result,
+	)
+	return float64(result)
+}
+
+// AreaAndPerimeter computes the area and perimeter of a polygon on a given spheroid.
+// The points must never be duplicated (i.e. do not include the "final" point of a Polygon LinearRing).
+// Area is in meter^2, Perimeter is in meters.
+func (s *Spheroid) AreaAndPerimeter(points []s2.Point) (area float64, perimeter float64) {
+	lats := make([]C.double, len(points))
+	lngs := make([]C.double, len(points))
+	for i, p := range points {
+		latlng := s2.LatLngFromPoint(p)
+		lats[i] = C.double(latlng.Lat.Degrees())
+		lngs[i] = C.double(latlng.Lng.Degrees())
+	}
+	var areaDouble, perimeterDouble C.double
+	C.geod_polygonarea(
+		&s.cRepr,
+		&lats[0],
+		&lngs[0],
+		C.int(len(points)),
+		&areaDouble,
+		&perimeterDouble,
+	)
+	return float64(areaDouble), float64(perimeterDouble)
 }

--- a/pkg/geo/geographiclib/geographiclib.h
+++ b/pkg/geo/geographiclib/geographiclib.h
@@ -1,0 +1,30 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+#include "geodesic.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// CR_GEOGRAPHICLIB_InverseBatch computes the sum of the length of the lines
+// represented by an array of lat/lngs using Inverse from GeographicLib.
+// It is batched in C++ to reduce the cgo overheads.
+void CR_GEOGRAPHICLIB_InverseBatch(
+  struct geod_geodesic* spheroid,
+  double lats[],
+  double lngs[],
+  int len,
+  double *result
+);
+
+#if defined(__cplusplus)
+}
+#endif

--- a/pkg/geo/geographiclib/geographiclib_test.go
+++ b/pkg/geo/geographiclib/geographiclib_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"github.com/golang/geo/s2"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInverse(t *testing.T) {
@@ -37,10 +37,67 @@ func TestInverse(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			s12, az1, az2 := WGS84Spheroid.Inverse(tc.a, tc.b)
-			assert.Equal(t, tc.s12, s12)
-			assert.Equal(t, tc.az1, az1)
-			assert.Equal(t, tc.az2, az2)
+			s12, az1, az2 := tc.spheroid.Inverse(tc.a, tc.b)
+			require.Equal(t, tc.s12, s12)
+			require.Equal(t, tc.az1, az1)
+			require.Equal(t, tc.az2, az2)
+		})
+	}
+}
+
+func TestInverseBatch(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		spheroid Spheroid
+		points   []s2.Point
+		sum      float64
+	}{
+		{
+			desc:     "WKT from Wikipedia",
+			spheroid: WGS84Spheroid,
+			points: []s2.Point{
+				s2.PointFromLatLng(s2.LatLngFromDegrees(40, 40)),
+				s2.PointFromLatLng(s2.LatLngFromDegrees(45, 20)),
+				s2.PointFromLatLng(s2.LatLngFromDegrees(30, 45)),
+			},
+			sum: 4.477956179118822e+06,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			sum := tc.spheroid.InverseBatch(tc.points)
+			require.Equal(t, tc.sum, sum)
+		})
+	}
+}
+
+func TestAreaAndPerimeter(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		spheroid  Spheroid
+		points    []s2.Point
+		area      float64
+		perimeter float64
+	}{
+		{
+			desc:     "WKT from Wikipedia",
+			spheroid: WGS84Spheroid,
+			points: []s2.Point{
+				s2.PointFromLatLng(s2.LatLngFromDegrees(40, 40)),
+				s2.PointFromLatLng(s2.LatLngFromDegrees(45, 20)),
+				s2.PointFromLatLng(s2.LatLngFromDegrees(30, 45)),
+			},
+			area:      6.91638769184179e+11,
+			perimeter: 5.6770339842410665e+06,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			area, perimeter := tc.spheroid.AreaAndPerimeter(tc.points)
+			require.Equal(t, tc.area, area)
+			require.Equal(t, tc.perimeter, perimeter)
 		})
 	}
 }


### PR DESCRIPTION
This commit implements Area, Length and Perimeter that is compatible
with PostGIS. There is a GEOMETRYCOLLECTION related bug with PostGIS,
where the Length of a Polygon includes the perimeter, and the Perimeter
of a LineString includes it's length, which seems like a bug. We've
copied it here for compatibility.

Release note: None

