### PR TITLE
release-20.1: cli: add --cert-principal-map to client commands

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
 // Base config defaults.
@@ -267,8 +266,8 @@ func (cfg *Config) AdminURL() *url.URL {
 	}
 }
 
-// GetClientCertPaths returns the paths to the client cert and key.
-func (cfg *Config) GetClientCertPaths(user string) (string, string, error) {
+// getClientCertPaths returns the paths to the client cert and key.
+func (cfg *Config) getClientCertPaths(user string) (string, string, error) {
 	cm, err := cfg.GetCertificateManager()
 	if err != nil {
 		return "", "", err
@@ -276,8 +275,8 @@ func (cfg *Config) GetClientCertPaths(user string) (string, string, error) {
 	return cm.GetClientCertPaths(user)
 }
 
-// GetCACertPath returns the path to the CA certificate.
-func (cfg *Config) GetCACertPath() (string, error) {
+// getCACertPath returns the path to the CA certificate.
+func (cfg *Config) getCACertPath() (string, error) {
 	cm, err := cfg.GetCertificateManager()
 	if err != nil {
 		return "", err
@@ -304,7 +303,7 @@ func (cfg *Config) LoadSecurityOptions(options url.Values, username string) erro
 			// verify-ca and verify-full need a CA certificate.
 			if options.Get("sslrootcert") == "" {
 				// Fetch CA cert. This is required.
-				caCertPath, err := cfg.GetCACertPath()
+				caCertPath, err := cfg.getCACertPath()
 				if err != nil {
 					return wrapError(err)
 				}
@@ -316,7 +315,7 @@ func (cfg *Config) LoadSecurityOptions(options url.Values, username string) erro
 		}
 
 		// Fetch certs, but don't fail, we may be using a password.
-		certPath, keyPath, err := cfg.GetClientCertPaths(username)
+		certPath, keyPath, err := cfg.getClientCertPaths(username)
 		if err == nil {
 			if options.Get("sslcert") == "" {
 				options.Set("sslcert", certPath)
@@ -354,36 +353,6 @@ func (cfg *Config) GetCertificateManager() (*security.CertificateManager, error)
 	return cfg.certificateManager.cm, cfg.certificateManager.err
 }
 
-// InitializeNodeTLSConfigs tries to load client and server-side TLS configs.
-// It also enables the reload-on-SIGHUP functionality on the certificate manager.
-// This should be called early in the life of the server to make sure there are no
-// issues with TLS configs.
-// Returns the certificate manager if successfully created and in secure mode.
-func (cfg *Config) InitializeNodeTLSConfigs(
-	stopper *stop.Stopper,
-) (*security.CertificateManager, error) {
-	if cfg.Insecure {
-		return nil, nil
-	}
-
-	if _, err := cfg.GetServerTLSConfig(); err != nil {
-		return nil, err
-	}
-	if _, err := cfg.GetUIServerTLSConfig(); err != nil {
-		return nil, err
-	}
-	if _, err := cfg.GetClientTLSConfig(); err != nil {
-		return nil, err
-	}
-
-	cm, err := cfg.GetCertificateManager()
-	if err != nil {
-		return nil, err
-	}
-	cm.RegisterSignalHandler(stopper)
-	return cm, nil
-}
-
 // GetClientTLSConfig returns the client TLS config, initializing it if needed.
 // If Insecure is true, return a nil config, otherwise ask the certificate
 // manager for a TLS config using certs for the config.User.
@@ -406,11 +375,11 @@ func (cfg *Config) GetClientTLSConfig() (*tls.Config, error) {
 	return tlsCfg, nil
 }
 
-// GetUIClientTLSConfig returns the client TLS config for Admin UI clients, initializing it if needed.
+// getUIClientTLSConfig returns the client TLS config for Admin UI clients, initializing it if needed.
 // If Insecure is true, return a nil config, otherwise ask the certificate
 // manager for a TLS config configured to talk to the Admin UI.
 // This TLSConfig is **NOT** suitable to talk to the GRPC or SQL servers, use GetClientTLSConfig instead.
-func (cfg *Config) GetUIClientTLSConfig() (*tls.Config, error) {
+func (cfg *Config) getUIClientTLSConfig() (*tls.Config, error) {
 	// Early out.
 	if cfg.Insecure {
 		return nil, nil
@@ -452,6 +421,9 @@ func (cfg *Config) GetServerTLSConfig() (*tls.Config, error) {
 // GetUIServerTLSConfig returns the server TLS config for the Admin UI, initializing it if needed.
 // If Insecure is true, return a nil config, otherwise ask the certificate
 // manager for a server UI TLS config.
+//
+// TODO(peter): This method is only used by `server.NewServer` and
+// `Server.Start`. Move it.
 func (cfg *Config) GetUIServerTLSConfig() (*tls.Config, error) {
 	// Early out.
 	if cfg.Insecure || cfg.DisableTLSForHTTP {
@@ -477,7 +449,7 @@ func (cfg *Config) GetHTTPClient() (http.Client, error) {
 		cfg.httpClient.httpClient.Timeout = 10 * time.Second
 		var transport http.Transport
 		cfg.httpClient.httpClient.Transport = &transport
-		transport.TLSClientConfig, cfg.httpClient.err = cfg.GetUIClientTLSConfig()
+		transport.TLSClientConfig, cfg.httpClient.err = cfg.getUIClientTLSConfig()
 	})
 
 	return cfg.httpClient.httpClient, cfg.httpClient.err

--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -203,9 +203,12 @@ List certificates and keys found in the certificate directory.
 
 // runListCerts loads and lists all certs.
 func runListCerts(cmd *cobra.Command, args []string) error {
-	cm, err := baseCfg.GetCertificateManager()
+	if err := security.SetCertPrincipalMap(certCtx.certPrincipalMap); err != nil {
+		return err
+	}
+	cm, err := security.NewCertificateManager(baseCfg.SSLCertsDir)
 	if err != nil {
-		return errors.Wrap(err, "could not get certificate manager")
+		return errors.Wrap(err, "cannot load certificates")
 	}
 
 	fmt.Fprintf(os.Stdout, "Certificate directory: %s\n", baseCfg.SSLCertsDir)

--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -203,9 +203,6 @@ List certificates and keys found in the certificate directory.
 
 // runListCerts loads and lists all certs.
 func runListCerts(cmd *cobra.Command, args []string) error {
-	if err := security.SetCertPrincipalMap(certCtx.certPrincipalMap); err != nil {
-		return err
-	}
 	cm, err := security.NewCertificateManager(baseCfg.SSLCertsDir)
 	if err != nil {
 		return errors.Wrap(err, "cannot load certificates")

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -77,6 +77,7 @@ func initCLIDefaults() {
 	cliCtx.cmdTimeout = 0 // no timeout
 	cliCtx.clientConnHost = ""
 	cliCtx.clientConnPort = base.DefaultPort
+	cliCtx.certPrincipalMap = nil
 	cliCtx.sqlConnURL = ""
 	cliCtx.sqlConnUser = ""
 	cliCtx.sqlConnPasswd = ""
@@ -171,8 +172,6 @@ func initCLIDefaults() {
 
 	authCtx.validityPeriod = 1 * time.Hour
 
-	certCtx.certPrincipalMap = nil
-
 	initPreFlagsDefaults()
 
 	// Clear the "Changed" state of all the registered command-line flags.
@@ -214,6 +213,9 @@ type cliContext struct {
 
 	// clientConnPort is the port name/number to use to connect to a server.
 	clientConnPort string
+
+	// certPrincipalMap is the cert-principal:db-principal map.
+	certPrincipalMap []string
 
 	// for CLI commands that use the SQL interface, these parameters
 	// determine how to connect to the server.
@@ -395,10 +397,4 @@ var demoCtx struct {
 	simulateLatency           bool
 	transientCluster          *transientCluster
 	insecure                  bool
-}
-
-// certCtx captures the command-line parameters of the `cert` command.
-// Defaults set by InitCLIDefaults() above.
-var certCtx struct {
-	certPrincipalMap []string
 }

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -171,6 +171,8 @@ func initCLIDefaults() {
 
 	authCtx.validityPeriod = 1 * time.Hour
 
+	certCtx.certPrincipalMap = nil
+
 	initPreFlagsDefaults()
 
 	// Clear the "Changed" state of all the registered command-line flags.
@@ -393,4 +395,10 @@ var demoCtx struct {
 	simulateLatency           bool
 	transientCluster          *transientCluster
 	insecure                  bool
+}
+
+// certCtx captures the command-line parameters of the `cert` command.
+// Defaults set by InitCLIDefaults() above.
+var certCtx struct {
+	certPrincipalMap []string
 }

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -240,7 +240,9 @@ func init() {
 
 	// Every command but start will inherit the following setting.
 	AddPersistentPreRunE(cockroachCmd, func(cmd *cobra.Command, _ []string) error {
-		extraClientFlagInit()
+		if err := extraClientFlagInit(); err != nil {
+			return err
+		}
 		return setDefaultStderrVerbosity(cmd, log.Severity_WARNING)
 	})
 
@@ -440,11 +442,10 @@ func init() {
 		f := cmd.Flags()
 		// All certs commands need the certificate directory.
 		StringFlag(f, &baseCfg.SSLCertsDir, cliflags.CertsDir, baseCfg.SSLCertsDir)
+		// All certs commands get the certificate principal map.
+		StringSlice(f, &cliCtx.certPrincipalMap,
+			cliflags.CertPrincipalMap, cliCtx.certPrincipalMap)
 	}
-
-	// The list certs command needs the certificate principal map.
-	StringSlice(listCertsCmd.Flags(), &certCtx.certPrincipalMap,
-		cliflags.CertPrincipalMap, certCtx.certPrincipalMap)
 
 	for _, cmd := range []*cobra.Command{createCACertCmd, createClientCACertCmd} {
 		f := cmd.Flags()
@@ -494,6 +495,9 @@ func init() {
 
 		// Certificate flags.
 		StringFlag(f, &baseCfg.SSLCertsDir, cliflags.CertsDir, baseCfg.SSLCertsDir)
+		// Certificate principal map.
+		StringSlice(f, &cliCtx.certPrincipalMap,
+			cliflags.CertPrincipalMap, cliCtx.certPrincipalMap)
 	}
 
 	// Auth commands.
@@ -875,7 +879,10 @@ func extraServerFlagInit(cmd *cobra.Command) error {
 	return nil
 }
 
-func extraClientFlagInit() {
+func extraClientFlagInit() error {
+	if err := security.SetCertPrincipalMap(cliCtx.certPrincipalMap); err != nil {
+		return err
+	}
 	serverCfg.Addr = net.JoinHostPort(cliCtx.clientConnHost, cliCtx.clientConnPort)
 	serverCfg.AdvertiseAddr = serverCfg.Addr
 	serverCfg.SQLAddr = net.JoinHostPort(cliCtx.clientConnHost, cliCtx.clientConnPort)
@@ -891,6 +898,7 @@ func extraClientFlagInit() {
 	if sqlCtx.debugMode {
 		sqlCtx.echo = true
 	}
+	return nil
 }
 
 func setDefaultStderrVerbosity(cmd *cobra.Command, defaultSeverity log.Severity) error {

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -442,6 +442,10 @@ func init() {
 		StringFlag(f, &baseCfg.SSLCertsDir, cliflags.CertsDir, baseCfg.SSLCertsDir)
 	}
 
+	// The list certs command needs the certificate principal map.
+	StringSlice(listCertsCmd.Flags(), &certCtx.certPrincipalMap,
+		cliflags.CertPrincipalMap, certCtx.certPrincipalMap)
+
 	for _, cmd := range []*cobra.Command{createCACertCmd, createClientCACertCmd} {
 		f := cmd.Flags()
 		// CA certificates have a longer expiration time.

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -799,7 +799,9 @@ func TestServerJoinSettings(t *testing.T) {
 			t.Fatalf("Parse(%#v) got unexpected error: %v", td.args, err)
 		}
 
-		extraClientFlagInit()
+		if err := extraClientFlagInit(); err != nil {
+			t.Fatal(err)
+		}
 
 		var actual []string
 		myHostname, _ := os.Hostname()
@@ -861,7 +863,9 @@ func TestClientConnSettings(t *testing.T) {
 			t.Fatalf("Parse(%#v) got unexpected error: %v", td.args, err)
 		}
 
-		extraClientFlagInit()
+		if err := extraClientFlagInit(); err != nil {
+			t.Fatal(err)
+		}
 		if td.expectedAddr != serverCfg.Addr {
 			t.Errorf("%d. serverCfg.Addr expected '%s', but got '%s'. td.args was '%#v'.",
 				i, td.expectedAddr, serverCfg.Addr, td.args)

--- a/pkg/cli/interactive_tests/test_cert_advisory_validation.tcl
+++ b/pkg/cli/interactive_tests/test_cert_advisory_validation.tcl
@@ -11,7 +11,8 @@ set prompt ":/# "
 eexpect $prompt
 
 # create some cert without an IP address in there.
-set certs_dir "./my-safe-directory"
+set db_dir "logs/db"
+set certs_dir "logs/my-safe-directory"
 send "mkdir -p $certs_dir\r"
 eexpect $prompt
 
@@ -21,7 +22,7 @@ send "$argv cert create-node localhost --certs-dir=$certs_dir --ca-key=$certs_di
 eexpect $prompt
 
 start_test "Check that the server reports a warning if attempting to advertise an IP address not in cert."
-send "$argv start-single-node --certs-dir=$certs_dir --advertise-addr=127.0.0.1\r"
+send "$argv start-single-node --store=$db_dir --certs-dir=$certs_dir --advertise-addr=127.0.0.1\r"
 eexpect "advertise address"
 eexpect "127.0.0.1"
 eexpect "not in node certificate"
@@ -32,7 +33,7 @@ eexpect $prompt
 end_test
 
 start_test "Check that the server reports no warning if the avertise addr is in the cert."
-send "$argv start-single-node --certs-dir=$certs_dir --advertise-addr=localhost\r"
+send "$argv start-single-node --store=$db_dir --certs-dir=$certs_dir --advertise-addr=localhost\r"
 expect {
   "not in node certificate" {
      report "unexpected warning"
@@ -51,13 +52,13 @@ send "COCKROACH_CERT_NODE_USER=foo.bar $argv cert create-node localhost --certs-
 eexpect $prompt
 
 start_test "Check that the server reports an error if the node cert does not contain a node principal."
-send "$argv start-single-node --certs-dir=$certs_dir --advertise-addr=localhost\r"
+send "$argv start-single-node --store=$db_dir --certs-dir=$certs_dir --advertise-addr=localhost\r"
 eexpect "cannot load certificates"
 expect $prompt
 end_test
 
 start_test "Check that the cert principal map can allow the use of non-standard cert principal."
-send "$argv start-single-node --certs-dir=$certs_dir --cert-principal-map=foo.bar:node --advertise-addr=localhost\r"
+send "$argv start-single-node --store=$db_dir --certs-dir=$certs_dir --cert-principal-map=foo.bar:node --advertise-addr=localhost\r"
 eexpect "node starting"
 interrupt
 eexpect "interrupted"
@@ -65,7 +66,7 @@ expect $prompt
 end_test
 
 start_test "Check that the cert principal map can allow the use of a SAN principal."
-send "$argv start-single-node --certs-dir=$certs_dir --cert-principal-map=localhost:node --advertise-addr=localhost\r"
+send "$argv start-single-node --store=$db_dir --certs-dir=$certs_dir --cert-principal-map=localhost:node --advertise-addr=localhost\r"
 eexpect "node starting"
 interrupt
 eexpect "interrupted"
@@ -75,5 +76,25 @@ end_test
 start_test "Check that 'cert list' can utilize cert principal map."
 send "$argv cert list --certs-dir=$certs_dir --cert-principal-map=foo.bar:node\r"
 eexpect "Certificate directory:"
+expect $prompt
+end_test
+
+start_test "Check that 'cert create-client' can utilize cert principal map."
+send "$argv cert create-client root.crdb.io --certs-dir=$certs_dir --ca-key=$certs_dir/ca.key --cert-principal-map=foo.bar:node\r"
+eexpect $prompt
+send "mv $certs_dir/client.root.crdb.io.crt $certs_dir/client.root.crt; mv $certs_dir/client.root.crdb.io.key $certs_dir/client.root.key\r"
+eexpect $prompt
+end_test
+
+start_test "Check that the client commands can use cert principal map."
+system "$argv start-single-node --store=$db_dir --certs-dir=$certs_dir --cert-principal-map=foo.bar:node,root.crdb.io:root --advertise-addr=localhost --background >>expect-cmd.log 2>&1"
+send "$argv sql --certs-dir=$certs_dir --cert-principal-map=foo.bar:node,root.crdb.io:root -e \"select 'hello'\"\r"
+eexpect "hello"
+expect $prompt
+send "$argv node ls --certs-dir=$certs_dir --cert-principal-map=foo.bar:node,root.crdb.io:root\r"
+eexpect "1 row"
+expect $prompt
+send "$argv quit --certs-dir=$certs_dir --cert-principal-map=foo.bar:node,root.crdb.io:root\r"
+eexpect "ok"
 expect $prompt
 end_test

--- a/pkg/cli/interactive_tests/test_cert_advisory_validation.tcl
+++ b/pkg/cli/interactive_tests/test_cert_advisory_validation.tcl
@@ -71,3 +71,9 @@ interrupt
 eexpect "interrupted"
 expect $prompt
 end_test
+
+start_test "Check that 'cert list' can utilize cert principal map."
+send "$argv cert list --certs-dir=$certs_dir --cert-principal-map=foo.bar:node\r"
+eexpect "Certificate directory:"
+expect $prompt
+end_test

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -271,7 +271,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			return nil, err
 		}
 		cm.RegisterSignalHandler(stopper)
-		registry.AddMetricStruct(cm.Metrics())
+		s.registry.AddMetricStruct(cm.Metrics())
 	}
 
 	// Add a dynamic log tag value for the node ID.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -254,11 +254,24 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	}
 
 	// Attempt to load TLS configs right away, failures are permanent.
-	if certMgr, err := cfg.InitializeNodeTLSConfigs(stopper); err != nil {
-		return nil, err
-	} else if certMgr != nil {
-		// The certificate manager is non-nil in secure mode.
-		s.registry.AddMetricStruct(certMgr.Metrics())
+	if !cfg.Insecure {
+		// TODO(peter): Call methods on CertificateManager directly. Need to call
+		// base.wrapError or similar on the resulting error.
+		if _, err := cfg.GetServerTLSConfig(); err != nil {
+			return nil, err
+		}
+		if _, err := cfg.GetUIServerTLSConfig(); err != nil {
+			return nil, err
+		}
+		if _, err := cfg.GetClientTLSConfig(); err != nil {
+			return nil, err
+		}
+		cm, err := cfg.GetCertificateManager()
+		if err != nil {
+			return nil, err
+		}
+		cm.RegisterSignalHandler(stopper)
+		registry.AddMetricStruct(cm.Metrics())
 	}
 
 	// Add a dynamic log tag value for the node ID.


### PR DESCRIPTION
To merge after 20.1 is released.

Backport:
  * 2/2 commits from "cli: add --cert-principal-map to `cert list` command" (#48013)
  * 1/1 commits from "cli: add --cert-principal-map to client commands" (#47449)

Please see individual PRs for details.

/cc @cockroachdb/release
