### PR TITLE
opt: add containment-type constraints

### DIFF
--- a/pkg/sql/opt/constraint/spans_test.go
+++ b/pkg/sql/opt/constraint/spans_test.go
@@ -93,10 +93,10 @@ func TestSpansSortAndMerge(t *testing.T) {
 
 		// Calculate via constraints.
 		var c Constraint
-		c.InitSingleSpan(keyCtx, spans.Get(0))
+		c.InitSingleSpan(keyCtx, spans.Get(0), Equality)
 		for i := 1; i < spans.Count(); i++ {
 			var d Constraint
-			d.InitSingleSpan(keyCtx, spans.Get(i))
+			d.InitSingleSpan(keyCtx, spans.Get(i), Equality)
 			c.UnionWith(evalCtx, &d)
 		}
 		expected := c.Spans.String()

--- a/pkg/sql/opt/constraint/testutils.go
+++ b/pkg/sql/opt/constraint/testutils.go
@@ -32,9 +32,13 @@ func ParseConstraint(evalCtx *tree.EvalContext, str string) Constraint {
 	for _, v := range parseIntPath(s[0]) {
 		cols = append(cols, opt.OrderingColumn(v))
 	}
+	spans := strings.TrimPrefix(s[1], "⊇ ")
 	var c Constraint
 	c.Columns.Init(cols)
-	c.Spans = parseSpans(evalCtx, s[1])
+	c.Spans = parseSpans(evalCtx, spans)
+	if len(spans) != len(s[1]) {
+		c.Type = Containment
+	}
 	return c
 }
 


### PR DESCRIPTION
This is a proof-of-concept showing how we might add support in
constraints for containment-type operators, like `@>`.

It is not finished. Proper logic for set intersect and union is missing.

Release note: None