### PR TITLE
opt: removes unnecessary loop in index constraint test

### DIFF
--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -133,10 +133,6 @@ func TestIndexConstraints(t *testing.T) {
 					d.Fatalf(t, "%v", err)
 				}
 
-				varNames := make([]string, len(varTypes))
-				for i := range varNames {
-					varNames[i] = fmt.Sprintf("@%d", i+1)
-				}
 				var ic idxconstraint.Instance
 				ic.Init(filters, optionalFilters, indexCols, notNullCols, invertedIndex, &evalCtx, &f)
 				result := ic.Constraint()


### PR DESCRIPTION
This commit removes an unnecessary loop in
`idxconstraint/index_constraints_test.go`. It appears to be
a forgotten remnant from a previous version of the tests.

Release note: None