### PR TITLE
sql: inject tenant ID in sqlServerArgs, pass through ExecutorConfig

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -87,14 +87,14 @@ type tableAndIndex struct {
 // spansForAllTableIndexes returns non-overlapping spans for every index and
 // table passed in. They would normally overlap if any of them are interleaved.
 func spansForAllTableIndexes(
-	tables []*sqlbase.TableDescriptor, revs []BackupManifest_DescriptorRevision,
+	codec keys.SQLCodec, tables []*sqlbase.TableDescriptor, revs []BackupManifest_DescriptorRevision,
 ) []roachpb.Span {
 
 	added := make(map[tableAndIndex]bool, len(tables))
 	sstIntervalTree := interval.NewTree(interval.ExclusiveOverlapper)
 	for _, table := range tables {
 		for _, index := range table.AllNonDropIndexes() {
-			if err := sstIntervalTree.Insert(intervalSpan(table.IndexSpan(index.ID)), false); err != nil {
+			if err := sstIntervalTree.Insert(intervalSpan(table.IndexSpan(codec, index.ID)), false); err != nil {
 				panic(errors.NewAssertionErrorWithWrappedErrf(err, "IndexSpan"))
 			}
 			added[tableAndIndex{tableID: table.ID, indexID: index.ID}] = true
@@ -108,7 +108,7 @@ func spansForAllTableIndexes(
 			for _, idx := range tbl.AllNonDropIndexes() {
 				key := tableAndIndex{tableID: tbl.ID, indexID: idx.ID}
 				if !added[key] {
-					if err := sstIntervalTree.Insert(intervalSpan(tbl.IndexSpan(idx.ID)), false); err != nil {
+					if err := sstIntervalTree.Insert(intervalSpan(tbl.IndexSpan(codec, idx.ID)), false); err != nil {
 						panic(errors.NewAssertionErrorWithWrappedErrf(err, "IndexSpan"))
 					}
 					added[key] = true
@@ -528,7 +528,7 @@ func backupPlanHook(
 			}
 		}
 
-		spans := spansForAllTableIndexes(tables, revs)
+		spans := spansForAllTableIndexes(p.ExecCfg().Codec, tables, revs)
 
 		if len(prevBackups) > 0 {
 			tablesInPrev := make(map[sqlbase.ID]struct{})

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1046,7 +1046,7 @@ func TestBackupRestoreResume(t *testing.T) {
 
 	t.Run("backup", func(t *testing.T) {
 		sqlDB := sqlutils.MakeSQLRunner(outerDB.DB)
-		backupStartKey := backupTableDesc.PrimaryIndexSpan().Key
+		backupStartKey := backupTableDesc.PrimaryIndexSpan(keys.SystemSQLCodec).Key
 		backupEndKey, err := sqlbase.TestingMakePrimaryIndexKey(backupTableDesc, numAccounts/2)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -904,7 +904,7 @@ func createImportingTables(
 
 	// We get the spans of the restoring tables _as they appear in the backup_,
 	// that is, in the 'old' keyspace, before we reassign the table IDs.
-	spans := spansForAllTableIndexes(tables, nil)
+	spans := spansForAllTableIndexes(p.ExecCfg().Codec, tables, nil)
 
 	log.Eventf(ctx, "starting restore for %d tables", len(tables))
 

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -100,8 +101,8 @@ func TestShowBackup(t *testing.T) {
 
 	details1Desc := sqlbase.GetTableDescriptor(tc.Server(0).DB(), "data", "details1")
 	details2Desc := sqlbase.GetTableDescriptor(tc.Server(0).DB(), "data", "details2")
-	details1Key := roachpb.Key(sqlbase.MakeIndexKeyPrefix(details1Desc, details1Desc.PrimaryIndex.ID))
-	details2Key := roachpb.Key(sqlbase.MakeIndexKeyPrefix(details2Desc, details2Desc.PrimaryIndex.ID))
+	details1Key := roachpb.Key(sqlbase.MakeIndexKeyPrefix(keys.SystemSQLCodec, details1Desc, details1Desc.PrimaryIndex.ID))
+	details2Key := roachpb.Key(sqlbase.MakeIndexKeyPrefix(keys.SystemSQLCodec, details2Desc, details2Desc.PrimaryIndex.ID))
 
 	sqlDB.CheckQueryResults(t, fmt.Sprintf(`SHOW BACKUP RANGES '%s'`, details), [][]string{
 		{"/Table/56/1", "/Table/56/2", string(details1Key), string(details1Key.PrefixEnd())},

--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvfeed"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -184,7 +185,7 @@ func createBenchmarkChangefeed(
 	database, table string,
 ) (*benchSink, func() error, error) {
 	tableDesc := sqlbase.GetTableDescriptor(s.DB(), database, table)
-	spans := []roachpb.Span{tableDesc.PrimaryIndexSpan()}
+	spans := []roachpb.Span{tableDesc.PrimaryIndexSpan(keys.SystemSQLCodec)}
 	details := jobspb.ChangefeedDetails{
 		Targets: jobspb.ChangefeedTargets{tableDesc.ID: jobspb.ChangefeedTarget{
 			StatementTimeName: tableDesc.Name,
@@ -232,7 +233,8 @@ func createBenchmarkChangefeed(
 		NeedsInitialScan: needsInitialScan,
 	}
 
-	rowsFn := kvsToRows(s.LeaseManager().(*sql.LeaseManager), details, buf.Get)
+	rowsFn := kvsToRows(s.ExecutorConfig().(sql.ExecutorConfig).Codec,
+		s.LeaseManager().(*sql.LeaseManager), details, buf.Get)
 	sf := span.MakeFrontier(spans...)
 	tickFn := emitEntries(s.ClusterSettings(), details, hlc.Timestamp{}, sf,
 		encoder, sink, rowsFn, TestingKnobs{}, metrics)

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -54,12 +54,13 @@ type emitEntry struct {
 // returns a closure that may be repeatedly called to advance the changefeed.
 // The returned closure is not threadsafe.
 func kvsToRows(
+	codec keys.SQLCodec,
 	leaseMgr *sql.LeaseManager,
 	details jobspb.ChangefeedDetails,
 	inputFn func(context.Context) (kvfeed.Event, error),
 ) func(context.Context) ([]emitEntry, error) {
 	_, withDiff := details.Opts[changefeedbase.OptDiff]
-	rfCache := newRowFetcherCache(leaseMgr)
+	rfCache := newRowFetcherCache(codec, leaseMgr)
 
 	var kvs row.SpanKVFetcher
 	appendEmitEntryForKV := func(

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -205,7 +205,7 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 	_, withDiff := ca.spec.Feed.Opts[changefeedbase.OptDiff]
 	kvfeedCfg := makeKVFeedCfg(ca.flowCtx.Cfg, leaseMgr, ca.kvFeedMemMon, ca.spec,
 		spans, withDiff, buf, metrics)
-	rowsFn := kvsToRows(leaseMgr, ca.spec.Feed, buf.Get)
+	rowsFn := kvsToRows(ca.flowCtx.Codec(), leaseMgr, ca.spec.Feed, buf.Get)
 	ca.tickFn = emitEntries(ca.flowCtx.Cfg.Settings, ca.spec.Feed,
 		kvfeedCfg.InitialHighWater, sf, ca.encoder, ca.sink, rowsFn, knobs, metrics)
 	ca.startKVFeed(ctx, kvfeedCfg)

--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -27,14 +27,16 @@ import (
 // StartScanFrom can be used to turn that key (or all the keys making up the
 // column families of one row) into a row.
 type rowFetcherCache struct {
+	codec    keys.SQLCodec
 	leaseMgr *sql.LeaseManager
 	fetchers map[*sqlbase.ImmutableTableDescriptor]*row.Fetcher
 
 	a sqlbase.DatumAlloc
 }
 
-func newRowFetcherCache(leaseMgr *sql.LeaseManager) *rowFetcherCache {
+func newRowFetcherCache(codec keys.SQLCodec, leaseMgr *sql.LeaseManager) *rowFetcherCache {
 	return &rowFetcherCache{
+		codec:    codec,
 		leaseMgr: leaseMgr,
 		fetchers: make(map[*sqlbase.ImmutableTableDescriptor]*row.Fetcher),
 	}
@@ -44,7 +46,7 @@ func (c *rowFetcherCache) TableDescForKey(
 	ctx context.Context, key roachpb.Key, ts hlc.Timestamp,
 ) (*sqlbase.ImmutableTableDescriptor, error) {
 	var tableDesc *sqlbase.ImmutableTableDescriptor
-	key, err := keys.TODOSQLCodec.StripTenantPrefix(key)
+	key, err := c.codec.StripTenantPrefix(key)
 	if err != nil {
 		return nil, err
 	}
@@ -103,13 +105,14 @@ func (c *rowFetcherCache) RowFetcherForTableDesc(
 
 	var rf row.Fetcher
 	if err := rf.Init(
+		c.codec,
 		false, /* reverse */
 		sqlbase.ScanLockingStrength_FOR_NONE,
 		false, /* returnRangeInfo */
 		false, /* isCheck */
 		&c.a,
 		row.FetcherTableArgs{
-			Spans:            tableDesc.AllIndexSpans(),
+			Spans:            tableDesc.AllIndexSpans(c.codec),
 			Desc:             tableDesc,
 			Index:            &tableDesc.PrimaryIndex,
 			ColIdxMap:        colIdxMap,

--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -113,6 +113,7 @@ func Load(
 	evalCtx := &tree.EvalContext{}
 	evalCtx.SetTxnTimestamp(curTime)
 	evalCtx.SetStmtTimestamp(curTime)
+	evalCtx.Codec = keys.TODOSQLCodec
 
 	blobClientFactory := blobs.TestBlobServiceClient(writeToDir)
 	conf, err := cloud.ExternalStorageConfFromURI(uri)
@@ -223,7 +224,7 @@ func Load(
 			}
 
 			ri, err = row.MakeInserter(
-				ctx, nil, tableDesc, tableDesc.Columns, row.SkipFKs, nil /* fkTables */, &sqlbase.DatumAlloc{},
+				ctx, nil, evalCtx.Codec, tableDesc, tableDesc.Columns, row.SkipFKs, nil /* fkTables */, &sqlbase.DatumAlloc{},
 			)
 			if err != nil {
 				return backupccl.BackupManifest{}, errors.Wrap(err, "make row inserter")

--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
@@ -332,7 +331,7 @@ func readMysqlCreateTable(
 	if match != "" && !found {
 		return nil, errors.Errorf("table %q not found in file (found tables: %s)", match, strings.Join(names, ", "))
 	}
-	if err := addDelayedFKs(ctx, fkDefs, fks.resolver, evalCtx.Settings); err != nil {
+	if err := addDelayedFKs(ctx, fkDefs, fks.resolver, evalCtx); err != nil {
 		return nil, err
 	}
 	return ret, nil
@@ -540,11 +539,11 @@ type delayedFK struct {
 }
 
 func addDelayedFKs(
-	ctx context.Context, defs []delayedFK, resolver fkResolver, settings *cluster.Settings,
+	ctx context.Context, defs []delayedFK, resolver fkResolver, evalCtx *tree.EvalContext,
 ) error {
 	for _, def := range defs {
 		if err := sql.ResolveFK(
-			ctx, nil, resolver, def.tbl, def.def, map[sqlbase.ID]*sqlbase.MutableTableDescriptor{}, sql.NewTable, tree.ValidationDefault, settings,
+			ctx, nil, resolver, def.tbl, def.def, map[sqlbase.ID]*sqlbase.MutableTableDescriptor{}, sql.NewTable, tree.ValidationDefault, evalCtx,
 		); err != nil {
 			return err
 		}

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -275,7 +275,7 @@ func readPostgresCreateTable(
 				}
 				for _, constraint := range constraints {
 					if err := sql.ResolveFK(
-						evalCtx.Ctx(), nil /* txn */, fks.resolver, desc, constraint, backrefs, sql.NewTable, tree.ValidationDefault, p.ExecCfg().Settings,
+						evalCtx.Ctx(), nil /* txn */, fks.resolver, desc, constraint, backrefs, sql.NewTable, tree.ValidationDefault, evalCtx,
 					); err != nil {
 						return nil, err
 					}

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -85,6 +85,7 @@ var testEvalCtx = &tree.EvalContext{
 	},
 	StmtTimestamp: timeutil.Unix(100000000, 0),
 	Settings:      cluster.MakeTestingClusterSettings(),
+	Codec:         keys.SystemSQLCodec,
 }
 
 // Value generator represents a value of some data at specified row/col.

--- a/pkg/ccl/partitionccl/drop_test.go
+++ b/pkg/ccl/partitionccl/drop_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/gcjob"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -71,7 +72,7 @@ func TestDropIndexWithZoneConfigCCL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	indexSpan := tableDesc.IndexSpan(indexDesc.ID)
+	indexSpan := tableDesc.IndexSpan(keys.SystemSQLCodec, indexDesc.ID)
 	tests.CheckKeyCount(t, kvDB, indexSpan, numRows)
 
 	// Set zone configs on the primary index, secondary index, and one partition

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1252,7 +1252,7 @@ func TestSelectPartitionExprs(t *testing.T) {
 		{`p33p44,p335p445,p33dp44d`, `((a, b) = (3, 3)) OR ((a, b) = (4, 4))`},
 	}
 
-	evalCtx := &tree.EvalContext{}
+	evalCtx := &tree.EvalContext{Codec: keys.SystemSQLCodec}
 	for _, test := range tests {
 		t.Run(test.partitions, func(t *testing.T) {
 			var partNames tree.NameList
@@ -1332,7 +1332,7 @@ func TestRepartitioning(t *testing.T) {
 					repartition.WriteString(`PARTITION BY NOTHING`)
 				} else {
 					if err := sql.ShowCreatePartitioning(
-						&sqlbase.DatumAlloc{}, test.new.parsed.tableDesc, testIndex,
+						&sqlbase.DatumAlloc{}, keys.SystemSQLCodec, test.new.parsed.tableDesc, testIndex,
 						&testIndex.Partitioning, &repartition, 0 /* indent */, 0, /* colOffset */
 					); err != nil {
 						t.Fatalf("%+v", err)

--- a/pkg/ccl/partitionccl/zone_test.go
+++ b/pkg/ccl/partitionccl/zone_test.go
@@ -289,7 +289,7 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 			clusterID := uuid.MakeV4()
 			hasNewSubzones := false
 			spans, err := sql.GenerateSubzoneSpans(
-				cluster.NoSettings, clusterID, test.parsed.tableDesc, test.parsed.subzones, hasNewSubzones)
+				cluster.NoSettings, clusterID, keys.SystemSQLCodec, test.parsed.tableDesc, test.parsed.subzones, hasNewSubzones)
 			if err != nil {
 				t.Fatalf("generating subzone spans: %+v", err)
 			}

--- a/pkg/ccl/storageccl/bench_test.go
+++ b/pkg/ccl/storageccl/bench_test.go
@@ -178,7 +178,7 @@ func BenchmarkImport(b *testing.B) {
 					if tableDesc == nil || tableDesc.ParentID == keys.SystemDatabaseID {
 						b.Fatalf("bad table descriptor: %+v", tableDesc)
 					}
-					oldStartKey = sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIndex.ID)
+					oldStartKey = sqlbase.MakeIndexKeyPrefix(keys.SystemSQLCodec, tableDesc, tableDesc.PrimaryIndex.ID)
 					newDesc := *tableDesc
 					newDesc.ID = id
 					newDescBytes, err := protoutil.Marshal(sqlbase.WrapDescriptor(&newDesc))

--- a/pkg/ccl/storageccl/key_rewriter_test.go
+++ b/pkg/ccl/storageccl/key_rewriter_test.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -76,7 +77,7 @@ func TestKeyRewriter(t *testing.T) {
 	}
 
 	t.Run("normal", func(t *testing.T) {
-		key := sqlbase.MakeIndexKeyPrefix(&sqlbase.NamespaceTable, desc.PrimaryIndex.ID)
+		key := sqlbase.MakeIndexKeyPrefix(keys.SystemSQLCodec, &sqlbase.NamespaceTable, desc.PrimaryIndex.ID)
 		newKey, ok, err := kr.RewriteKey(key, notSpan)
 		if err != nil {
 			t.Fatal(err)
@@ -94,7 +95,7 @@ func TestKeyRewriter(t *testing.T) {
 	})
 
 	t.Run("prefix end", func(t *testing.T) {
-		key := roachpb.Key(sqlbase.MakeIndexKeyPrefix(&sqlbase.NamespaceTable, desc.PrimaryIndex.ID)).PrefixEnd()
+		key := roachpb.Key(sqlbase.MakeIndexKeyPrefix(keys.SystemSQLCodec, &sqlbase.NamespaceTable, desc.PrimaryIndex.ID)).PrefixEnd()
 		newKey, ok, err := kr.RewriteKey(key, notSpan)
 		if err != nil {
 			t.Fatal(err)
@@ -123,7 +124,7 @@ func TestKeyRewriter(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		key := sqlbase.MakeIndexKeyPrefix(&sqlbase.NamespaceTable, desc.PrimaryIndex.ID)
+		key := sqlbase.MakeIndexKeyPrefix(keys.SystemSQLCodec, &sqlbase.NamespaceTable, desc.PrimaryIndex.ID)
 		newKey, ok, err := newKr.RewriteKey(key, notSpan)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/keys/spans.go
+++ b/pkg/keys/spans.go
@@ -34,6 +34,9 @@ var (
 	NodeLivenessSpan = roachpb.Span{Key: NodeLivenessPrefix, EndKey: NodeLivenessKeyMax}
 
 	// SystemConfigSpan is the range of system objects which will be gossiped.
+	//
+	// TODO(nvanbenschoten): references to this span need to be prefixed by
+	// tenant ID. This is tracked in #48184.
 	SystemConfigSpan = roachpb.Span{Key: SystemConfigSplitKey, EndKey: SystemConfigTableDataMax}
 
 	// NoSplitSpans describes the ranges that should never be split.

--- a/pkg/kv/kvserver/reports/constraint_stats_report_test.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report_test.go
@@ -857,8 +857,8 @@ func generateTableZone(t table, tableDesc sqlbase.TableDescriptor) (*zonepb.Zone
 	if tableZone != nil {
 		var err error
 		tableZone.SubzoneSpans, err = sql.GenerateSubzoneSpans(
-			nil, uuid.UUID{} /* clusterID */, &tableDesc, tableZone.Subzones,
-			false /* hasNewSubzones */)
+			nil, uuid.UUID{} /* clusterID */, keys.SystemSQLCodec,
+			&tableDesc, tableZone.Subzones, false /* hasNewSubzones */)
 		if err != nil {
 			return nil, errors.Wrap(err, "error generating subzone spans")
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -537,13 +537,14 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		Config:                   &cfg, // NB: s.cfg has a populated AmbientContext.
 		stopper:                  stopper,
 		clock:                    clock,
-		protectedtsProvider:      protectedtsProvider,
 		runtime:                  runtimeSampler,
+		tenantID:                 roachpb.SystemTenantID,
 		db:                       db,
 		registry:                 registry,
 		sessionRegistry:          sessionRegistry,
 		circularInternalExecutor: internalExecutor,
 		jobRegistry:              jobRegistry,
+		protectedtsProvider:      protectedtsProvider,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/server/settingsworker.go
+++ b/pkg/server/settingsworker.go
@@ -31,7 +31,8 @@ func (s *Server) refreshSettings() {
 	tbl := &sqlbase.SettingsTable
 
 	a := &sqlbase.DatumAlloc{}
-	settingsTablePrefix := keys.TODOSQLCodec.TablePrefix(uint32(tbl.ID))
+	codec := keys.TODOSQLCodec
+	settingsTablePrefix := codec.TablePrefix(uint32(tbl.ID))
 	colIdxMap := row.ColIDtoRowIndexFromCols(tbl.Columns)
 
 	processKV := func(ctx context.Context, kv roachpb.KeyValue, u settings.Updater) error {
@@ -44,7 +45,7 @@ func (s *Server) refreshSettings() {
 		{
 			types := []types.T{tbl.Columns[0].Type}
 			nameRow := make([]sqlbase.EncDatum, 1)
-			_, matches, _, err := sqlbase.DecodeIndexKey(tbl, &tbl.PrimaryIndex, types, nameRow, nil, kv.Key)
+			_, matches, _, err := sqlbase.DecodeIndexKey(codec, tbl, &tbl.PrimaryIndex, types, nameRow, nil, kv.Key)
 			if err != nil {
 				return errors.Wrap(err, "failed to decode key")
 			}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -504,13 +504,14 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 		Config:                   &cfg,
 		stopper:                  stopper,
 		clock:                    clock,
-		protectedtsProvider:      protectedTSProvider,
 		runtime:                  status.NewRuntimeStatSampler(context.Background(), clock),
+		tenantID:                 roachpb.SystemTenantID,
 		db:                       ts.DB(),
 		registry:                 registry,
 		sessionRegistry:          sql.NewSessionRegistry(),
 		circularInternalExecutor: circularInternalExecutor,
 		jobRegistry:              &jobs.Registry{},
+		protectedtsProvider:      protectedTSProvider,
 	}
 }
 

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -202,7 +202,8 @@ func (n *alterTableNode) startExec(params runParams) error {
 			// We're checking to see if a user is trying add a non-nullable column without a default to a
 			// non empty table by scanning the primary index span with a limit of 1 to see if any key exists.
 			if !col.Nullable && (col.DefaultExpr == nil && !col.IsComputed()) {
-				kvs, err := params.p.txn.Scan(params.ctx, n.tableDesc.PrimaryIndexSpan().Key, n.tableDesc.PrimaryIndexSpan().EndKey, 1)
+				span := n.tableDesc.PrimaryIndexSpan(params.ExecCfg().Codec)
+				kvs, err := params.p.txn.Scan(params.ctx, span.Key, span.EndKey, 1)
 				if err != nil {
 					return err
 				}
@@ -342,7 +343,8 @@ func (n *alterTableNode) startExec(params runParams) error {
 					// Check whether the table is empty, and pass the result to resolveFK(). If
 					// the table is empty, then resolveFK will automatically add the necessary
 					// index for a fk constraint if the index does not exist.
-					kvs, scanErr := params.p.txn.Scan(params.ctx, n.tableDesc.PrimaryIndexSpan().Key, n.tableDesc.PrimaryIndexSpan().EndKey, 1)
+					span := n.tableDesc.PrimaryIndexSpan(params.ExecCfg().Codec)
+					kvs, scanErr := params.p.txn.Scan(params.ctx, span.Key, span.EndKey, 1)
 					if scanErr != nil {
 						err = scanErr
 						return

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -119,7 +119,7 @@ func (sc *SchemaChanger) makeFixedTimestampRunner(readAsOf hlc.Timestamp) histor
 	runner := func(ctx context.Context, retryable scTxnFn) error {
 		return sc.fixedTimestampTxn(ctx, readAsOf, func(ctx context.Context, txn *kv.Txn) error {
 			// We need to re-create the evalCtx since the txn may retry.
-			evalCtx := createSchemaChangeEvalCtx(ctx, readAsOf, sc.ieFactory)
+			evalCtx := createSchemaChangeEvalCtx(ctx, sc.execCfg, readAsOf, sc.ieFactory)
 			return retryable(ctx, txn, &evalCtx)
 		})
 	}
@@ -185,7 +185,7 @@ func (sc *SchemaChanger) runBackfill(ctx context.Context) error {
 					needColumnBackfill = true
 				}
 			case *sqlbase.DescriptorMutation_Index:
-				addedIndexSpans = append(addedIndexSpans, tableDesc.IndexSpan(t.Index.ID))
+				addedIndexSpans = append(addedIndexSpans, tableDesc.IndexSpan(sc.execCfg.Codec, t.Index.ID))
 			case *sqlbase.DescriptorMutation_Constraint:
 				switch t.Constraint.ConstraintType {
 				case sqlbase.ConstraintToUpdate_CHECK:
@@ -628,7 +628,15 @@ func (sc *SchemaChanger) truncateIndexes(
 				}
 
 				rd, err := row.MakeDeleter(
-					ctx, txn, tableDesc, nil, nil, row.SkipFKs, nil /* *tree.EvalContext */, alloc,
+					ctx,
+					txn,
+					sc.execCfg.Codec,
+					tableDesc,
+					nil,
+					nil,
+					row.SkipFKs,
+					nil, /* *tree.EvalContext */
+					alloc,
 				)
 				if err != nil {
 					return err
@@ -852,7 +860,7 @@ func (sc *SchemaChanger) distBackfill(
 				return nil
 			}
 			cbw := metadataCallbackWriter{rowResultWriter: &errOnlyResultWriter{}, fn: metaFn}
-			evalCtx := createSchemaChangeEvalCtx(ctx, txn.ReadTimestamp(), sc.ieFactory)
+			evalCtx := createSchemaChangeEvalCtx(ctx, sc.execCfg, txn.ReadTimestamp(), sc.ieFactory)
 			recv := MakeDistSQLReceiver(
 				ctx,
 				&cbw,
@@ -1060,8 +1068,9 @@ func (sc *SchemaChanger) validateInvertedIndexes(
 			// distributed execution and avoid bypassing the SQL decoding
 			start := timeutil.Now()
 			var idxLen int64
-			key := tableDesc.IndexSpan(idx.ID).Key
-			endKey := tableDesc.IndexSpan(idx.ID).EndKey
+			span := tableDesc.IndexSpan(sc.execCfg.Codec, idx.ID)
+			key := span.Key
+			endKey := span.EndKey
 			if err := runHistoricalTxn(ctx, func(ctx context.Context, txn *kv.Txn, _ *extendedEvalContext) error {
 				for {
 					kvs, err := txn.Scan(ctx, key, endKey, 1000000)
@@ -1354,7 +1363,7 @@ func runSchemaChangesInTxn(
 				doneColumnBackfill = true
 
 			case *sqlbase.DescriptorMutation_Index:
-				if err := indexBackfillInTxn(ctx, planner.Txn(), immutDesc, traceKV); err != nil {
+				if err := indexBackfillInTxn(ctx, planner.Txn(), planner.EvalContext(), immutDesc, traceKV); err != nil {
 					return err
 				}
 
@@ -1416,7 +1425,7 @@ func runSchemaChangesInTxn(
 
 			case *sqlbase.DescriptorMutation_Index:
 				if err := indexTruncateInTxn(
-					ctx, planner.Txn(), planner.ExecCfg(), immutDesc, t.Index, traceKV,
+					ctx, planner.Txn(), planner.ExecCfg(), planner.EvalContext(), immutDesc, t.Index, traceKV,
 				); err != nil {
 					return err
 				}
@@ -1687,7 +1696,7 @@ func columnBackfillInTxn(
 		}
 		otherTableDescs = append(otherTableDescs, t.ImmutableTableDescriptor)
 	}
-	sp := tableDesc.PrimaryIndexSpan()
+	sp := tableDesc.PrimaryIndexSpan(evalCtx.Codec)
 	for sp.Key != nil {
 		var err error
 		sp.Key, err = backfiller.RunColumnBackfillChunk(ctx,
@@ -1706,13 +1715,17 @@ func columnBackfillInTxn(
 // It operates entirely on the current goroutine and is thus able to
 // reuse an existing kv.Txn safely.
 func indexBackfillInTxn(
-	ctx context.Context, txn *kv.Txn, tableDesc *sqlbase.ImmutableTableDescriptor, traceKV bool,
+	ctx context.Context,
+	txn *kv.Txn,
+	evalCtx *tree.EvalContext,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
+	traceKV bool,
 ) error {
 	var backfiller backfill.IndexBackfiller
-	if err := backfiller.Init(tableDesc); err != nil {
+	if err := backfiller.Init(evalCtx, tableDesc); err != nil {
 		return err
 	}
-	sp := tableDesc.PrimaryIndexSpan()
+	sp := tableDesc.PrimaryIndexSpan(evalCtx.Codec)
 	for sp.Key != nil {
 		var err error
 		sp.Key, err = backfiller.RunIndexBackfillChunk(ctx,
@@ -1731,6 +1744,7 @@ func indexTruncateInTxn(
 	ctx context.Context,
 	txn *kv.Txn,
 	execCfg *ExecutorConfig,
+	evalCtx *tree.EvalContext,
 	tableDesc *sqlbase.ImmutableTableDescriptor,
 	idx *sqlbase.IndexDescriptor,
 	traceKV bool,
@@ -1739,13 +1753,13 @@ func indexTruncateInTxn(
 	var sp roachpb.Span
 	for done := false; !done; done = sp.Key == nil {
 		rd, err := row.MakeDeleter(
-			ctx, txn, tableDesc, nil, nil, row.SkipFKs, nil /* *tree.EvalContext */, alloc,
+			ctx, txn, execCfg.Codec, tableDesc, nil, nil, row.SkipFKs, evalCtx, alloc,
 		)
 		if err != nil {
 			return err
 		}
 		td := tableDeleter{rd: rd, alloc: alloc}
-		if err := td.init(ctx, txn, nil /* *tree.EvalContext */); err != nil {
+		if err := td.init(ctx, txn, evalCtx); err != nil {
 			return err
 		}
 		sp, err = td.deleteIndex(

--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -245,6 +245,7 @@ type cFetcher struct {
 // non-primary index, tables.ValNeededForCol can only refer to columns in the
 // index.
 func (rf *cFetcher) Init(
+	codec keys.SQLCodec,
 	allocator *colmem.Allocator,
 	reverse bool,
 	lockStr sqlbase.ScanLockingStrength,
@@ -323,7 +324,7 @@ func (rf *cFetcher) Init(
 	}
 	sort.Ints(table.neededColsList)
 
-	table.knownPrefixLength = len(sqlbase.MakeIndexKeyPrefix(table.desc.TableDesc(), table.index.ID))
+	table.knownPrefixLength = len(sqlbase.MakeIndexKeyPrefix(codec, table.desc.TableDesc(), table.index.ID))
 
 	var indexColumnIDs []sqlbase.ColumnID
 	indexColumnIDs, table.indexColumnDirs = table.index.FullColumnIDs()

--- a/pkg/sql/colflow/colbatch_scan_test.go
+++ b/pkg/sql/colflow/colbatch_scan_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -56,7 +57,9 @@ func BenchmarkColBatchScan(b *testing.B) {
 				Core: execinfrapb.ProcessorCoreUnion{
 					TableReader: &execinfrapb.TableReaderSpec{
 						Table: *tableDesc,
-						Spans: []execinfrapb.TableReaderSpan{{Span: tableDesc.PrimaryIndexSpan()}},
+						Spans: []execinfrapb.TableReaderSpan{
+							{Span: tableDesc.PrimaryIndexSpan(keys.SystemSQLCodec)},
+						},
 					}},
 				Post: execinfrapb.PostProcessSpec{
 					Projection:    true,

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1972,6 +1972,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			ClusterID:          ex.server.cfg.ClusterID(),
 			ClusterName:        ex.server.cfg.RPCContext.ClusterName(),
 			NodeID:             ex.server.cfg.NodeID.Get(),
+			Codec:              ex.server.cfg.Codec,
 			Locality:           ex.server.cfg.Locality,
 			ReCache:            ex.server.reCache,
 			InternalExecutor:   &ie,

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -266,6 +267,7 @@ func startConnExecutor(
 			NodeID:    nodeID,
 			ClusterID: func() uuid.UUID { return uuid.UUID{} },
 		},
+		Codec: keys.SystemSQLCodec,
 		DistSQLPlanner: NewDistSQLPlanner(
 			ctx, execinfra.Version, st, roachpb.NodeDescriptor{NodeID: 1},
 			nil, /* rpcCtx */

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2895,7 +2895,7 @@ func addPartitioningRows(
 				buf.WriteString(`, `)
 			}
 			tuple, _, err := sqlbase.DecodePartitionTuple(
-				&datumAlloc, table, index, partitioning, values, fakePrefixDatums,
+				&datumAlloc, p.ExecCfg().Codec, table, index, partitioning, values, fakePrefixDatums,
 			)
 			if err != nil {
 				return err
@@ -2946,7 +2946,7 @@ func addPartitioningRows(
 	for _, r := range partitioning.Range {
 		var buf bytes.Buffer
 		fromTuple, _, err := sqlbase.DecodePartitionTuple(
-			&datumAlloc, table, index, partitioning, r.FromInclusive, fakePrefixDatums,
+			&datumAlloc, p.ExecCfg().Codec, table, index, partitioning, r.FromInclusive, fakePrefixDatums,
 		)
 		if err != nil {
 			return err
@@ -2954,7 +2954,7 @@ func addPartitioningRows(
 		buf.WriteString(fromTuple.String())
 		buf.WriteString(" TO ")
 		toTuple, _, err := sqlbase.DecodePartitionTuple(
-			&datumAlloc, table, index, partitioning, r.ToExclusive, fakePrefixDatums,
+			&datumAlloc, p.ExecCfg().Codec, table, index, partitioning, r.ToExclusive, fakePrefixDatums,
 		)
 		if err != nil {
 			return err

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -126,7 +126,7 @@ func doCreateSequence(
 	}
 
 	// Initialize the sequence value.
-	seqValueKey := keys.TODOSQLCodec.SequenceKey(uint32(id))
+	seqValueKey := params.ExecCfg().Codec.SequenceKey(uint32(id))
 	b := &kv.Batch{}
 	b.Inc(seqValueKey, desc.SequenceOpts.Start-desc.SequenceOpts.Increment)
 	if err := params.p.txn.Run(params.ctx, b); err != nil {

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -184,6 +184,7 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 		}
 	}
 	if err := d.fetcher.Init(
+		params.ExecCfg().Codec,
 		false, /* reverse */
 		// TODO(nvanbenschoten): it might make sense to use a FOR_UPDATE locking
 		// strength here. Consider hooking this in to the same knob that will

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -92,8 +92,7 @@ func maybeCreateDeleteFastNode(
 	}
 
 	// Check whether the source plan is "simple": that it contains no remaining
-	// filtering, limiting, sorting, etc. Note that this logic must be kept in
-	// sync with the logic for setting scanNode.isDeleteSource (see doExpandPlan.)
+	// filtering, limiting, sorting, etc.
 	// TODO(dt): We could probably be smarter when presented with an
 	// index-join, but this goes away anyway once we push-down more of
 	// SQL.

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -297,6 +297,7 @@ func (ds *ServerImpl) setupFlow(
 			ClusterID:   ds.ServerConfig.ClusterID.Get(),
 			ClusterName: ds.ServerConfig.ClusterName,
 			NodeID:      nodeID,
+			Codec:       ds.ServerConfig.Codec,
 			ReCache:     ds.regexpCache,
 			Mon:         &monitor,
 			// Most processors will override this Context with their own context in

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -446,7 +446,7 @@ func (dsp *DistSQLPlanner) checkSupportForNode(node planNode) (distRecommendatio
 			rec = rec.compose(shouldDistribute)
 		}
 		// Check if we are doing a full scan.
-		if len(n.spans) == 1 && n.spans[0].EqualValue(n.desc.IndexSpan(n.index.ID)) {
+		if n.isFull {
 			rec = rec.compose(shouldDistribute)
 		}
 		return rec, nil

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -188,7 +188,7 @@ func presplitTableBoundaries(
 ) error {
 	expirationTime := cfg.DB.Clock().Now().Add(time.Hour.Nanoseconds(), 0)
 	for _, tbl := range tables {
-		for _, span := range tbl.Desc.AllIndexSpans() {
+		for _, span := range tbl.Desc.AllIndexSpans(cfg.Codec) {
 			if err := cfg.DB.AdminSplit(ctx, span.Key, span.Key, expirationTime); err != nil {
 				return err
 			}

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -87,6 +87,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 	if err != nil {
 		return PhysicalPlan{}, err
 	}
+	scan.isFull = true
 
 	p, err := dsp.createTableReaders(planCtx, &scan, nil /* overrideResultColumns */)
 	if err != nil {

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -82,7 +82,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 	if err != nil {
 		return PhysicalPlan{}, err
 	}
-	sb := span.MakeBuilder(desc.TableDesc(), scan.index)
+	sb := span.MakeBuilder(planCtx.planner.ExecCfg().Codec, desc.TableDesc(), scan.index)
 	scan.spans, err = sb.UnconstrainedSpans()
 	if err != nil {
 		return PhysicalPlan{}, err

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -83,7 +83,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 		return PhysicalPlan{}, err
 	}
 	sb := span.MakeBuilder(desc.TableDesc(), scan.index)
-	scan.spans, err = sb.UnconstrainedSpans(scan.isDeleteSource)
+	scan.spans, err = sb.UnconstrainedSpans()
 	if err != nil {
 		return PhysicalPlan{}, err
 	}

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -362,7 +362,7 @@ func (p *planner) initiateDropTable(
 
 	// Unsplit all manually split ranges in the table so they can be
 	// automatically merged by the merge queue.
-	ranges, err := ScanMetaKVs(ctx, p.txn, tableDesc.TableSpan())
+	ranges, err := ScanMetaKVs(ctx, p.txn, tableDesc.TableSpan(p.ExecCfg().Codec))
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
@@ -586,6 +587,7 @@ type nodeStatusGenerator interface {
 type ExecutorConfig struct {
 	Settings *cluster.Settings
 	NodeInfo
+	Codec             keys.SQLCodec
 	DefaultZoneConfig *zonepb.ZoneConfig
 	Locality          roachpb.Locality
 	AmbientCtx        log.AmbientContext

--- a/pkg/sql/execinfra/flow_context.go
+++ b/pkg/sql/execinfra/flow_context.go
@@ -13,6 +13,7 @@
 package execinfra
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -80,4 +81,9 @@ func (ctx *FlowCtx) TestingKnobs() TestingKnobs {
 // Stopper returns the stopper for this flowCtx.
 func (ctx *FlowCtx) Stopper() *stop.Stopper {
 	return ctx.Cfg.Stopper
+}
+
+// Codec returns the SQL codec for this flowCtx.
+func (ctx *FlowCtx) Codec() keys.SQLCodec {
+	return ctx.EvalCtx.Codec
 }

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/diskmap"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
@@ -83,6 +84,15 @@ type ServerConfig struct {
 	Settings     *cluster.Settings
 	RuntimeStats RuntimeStats
 
+	ClusterID   *base.ClusterIDContainer
+	ClusterName string
+
+	// NodeID is the id of the node on which this Server is running.
+	NodeID *base.NodeIDContainer
+
+	// Codec is capable of encoding and decoding sql table keys.
+	Codec keys.SQLCodec
+
 	// DB is a handle to the cluster.
 	DB *kv.DB
 	// Executor can be used to run "internal queries". Note that Flows also have
@@ -123,11 +133,6 @@ type ServerConfig struct {
 	DiskMonitor *mon.BytesMonitor
 
 	Metrics *DistSQLMetrics
-
-	// NodeID is the id of the node on which this Server is running.
-	NodeID      *base.NodeIDContainer
-	ClusterID   *base.ClusterIDContainer
-	ClusterName string
 
 	// JobRegistry manages jobs being used by this Server.
 	JobRegistry *jobs.Registry

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/storagebase"
@@ -67,7 +68,7 @@ func TestClusterFlow(t *testing.T) {
 	desc := sqlbase.GetTableDescriptor(kvDB, "test", "t")
 	makeIndexSpan := func(start, end int) execinfrapb.TableReaderSpan {
 		var span roachpb.Span
-		prefix := roachpb.Key(sqlbase.MakeIndexKeyPrefix(desc, desc.Indexes[0].ID))
+		prefix := roachpb.Key(sqlbase.MakeIndexKeyPrefix(keys.SystemSQLCodec, desc, desc.Indexes[0].ID))
 		span.Key = append(prefix, encoding.EncodeVarintAscending(nil, int64(start))...)
 		span.EndKey = append(span.EndKey, prefix...)
 		span.EndKey = append(span.EndKey, encoding.EncodeVarintAscending(nil, int64(end))...)

--- a/pkg/sql/flowinfra/server_test.go
+++ b/pkg/sql/flowinfra/server_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -53,7 +54,7 @@ func TestServer(t *testing.T) {
 		Table:    *td,
 		IndexIdx: 0,
 		Reverse:  false,
-		Spans:    []execinfrapb.TableReaderSpan{{Span: td.PrimaryIndexSpan()}},
+		Spans:    []execinfrapb.TableReaderSpan{{Span: td.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 	}
 	post := execinfrapb.PostProcessSpec{
 		Filter:        execinfrapb.Expression{Expr: "@1 != 2"}, // a != 2

--- a/pkg/sql/gcjob/table_garbage_collection.go
+++ b/pkg/sql/gcjob/table_garbage_collection.go
@@ -57,7 +57,7 @@ func gcTables(
 		}
 
 		// First, delete all the table data.
-		if err := clearTableData(ctx, execCfg.DB, execCfg.DistSender, table); err != nil {
+		if err := clearTableData(ctx, execCfg.DB, execCfg.DistSender, execCfg.Codec, table); err != nil {
 			return false, errors.Wrapf(err, "clearing data for table %d", table.ID)
 		}
 
@@ -75,7 +75,11 @@ func gcTables(
 
 // clearTableData deletes all of the data in the specified table.
 func clearTableData(
-	ctx context.Context, db *kv.DB, distSender *kvcoord.DistSender, table *sqlbase.TableDescriptor,
+	ctx context.Context,
+	db *kv.DB,
+	distSender *kvcoord.DistSender,
+	codec keys.SQLCodec,
+	table *sqlbase.TableDescriptor,
 ) error {
 	// If DropTime isn't set, assume this drop request is from a version
 	// 1.1 server and invoke legacy code that uses DeleteRange and range GC.
@@ -84,11 +88,11 @@ func clearTableData(
 	// cleaned up.
 	if table.DropTime == 0 || table.IsInterleaved() {
 		log.Infof(ctx, "clearing data in chunks for table %d", table.ID)
-		return sql.ClearTableDataInChunks(ctx, table, db, false /* traceKV */)
+		return sql.ClearTableDataInChunks(ctx, db, codec, table, false /* traceKV */)
 	}
 	log.Infof(ctx, "clearing data for table %d", table.ID)
 
-	tableKey := roachpb.RKey(keys.TODOSQLCodec.TablePrefix(uint32(table.ID)))
+	tableKey := roachpb.RKey(codec.TablePrefix(uint32(table.ID)))
 	tableSpan := roachpb.RSpan{Key: tableKey, EndKey: tableKey.PrefixEnd()}
 
 	// ClearRange requests lays down RocksDB range deletion tombstones that have

--- a/pkg/sql/join_test.go
+++ b/pkg/sql/join_test.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/span"
@@ -45,7 +46,7 @@ func newTestScanNode(kvDB *kv.DB, tableName string) (*scanNode, error) {
 		}
 	}
 	scan.reqOrdering = ordering
-	sb := span.MakeBuilder(desc.TableDesc(), &desc.PrimaryIndex)
+	sb := span.MakeBuilder(keys.SystemSQLCodec, desc.TableDesc(), &desc.PrimaryIndex)
 	scan.spans, err = sb.SpansFromConstraint(nil /* constraint */, exec.TableColumnOrdinalSet{}, false /* forDelete */)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -1086,7 +1086,7 @@ INSERT INTO t.kv VALUES ('a', 'b');
 		t.Fatal(err)
 	}
 
-	tableSpan := tableDesc.TableSpan()
+	tableSpan := tableDesc.TableSpan(keys.SystemSQLCodec)
 	tests.CheckKeyCount(t, kvDB, tableSpan, 4)
 
 	// Allow async schema change waiting for GC to complete (when dropping an

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -90,7 +90,7 @@ func (ef *execFactory) ConstructScan(
 	scan := ef.planner.Scan()
 	colCfg := makeScanColumnsConfig(table, needed)
 
-	sb := span.MakeBuilder(tabDesc.TableDesc(), indexDesc)
+	sb := span.MakeBuilder(ef.planner.ExecCfg().Codec, tabDesc.TableDesc(), indexDesc)
 
 	// initTable checks that the current user has the correct privilege to access
 	// the table. However, the privilege has already been checked in optbuilder,
@@ -120,7 +120,9 @@ func (ef *execFactory) ConstructScan(
 	if err != nil {
 		return nil, err
 	}
-	scan.isFull = len(scan.spans) == 1 && scan.spans[0].EqualValue(scan.desc.IndexSpan(scan.index.ID))
+	scan.isFull = len(scan.spans) == 1 && scan.spans[0].EqualValue(
+		scan.desc.IndexSpan(ef.planner.ExecCfg().Codec, scan.index.ID),
+	)
 	for i := range reqOrdering {
 		if reqOrdering[i].ColIdx >= len(colCfg.wantedColumns) {
 			return nil, errors.Errorf("invalid reqOrdering: %v", reqOrdering)
@@ -1227,7 +1229,7 @@ func (ef *execFactory) ConstructInsert(
 	}
 	// Create the table inserter, which does the bulk of the work.
 	ri, err := row.MakeInserter(
-		ctx, ef.planner.txn, tabDesc, colDescs, checkFKs, fkTables, &ef.planner.alloc,
+		ctx, ef.planner.txn, ef.planner.ExecCfg().Codec, tabDesc, colDescs, checkFKs, fkTables, &ef.planner.alloc,
 	)
 	if err != nil {
 		return nil, err
@@ -1292,7 +1294,7 @@ func (ef *execFactory) ConstructInsertFastPath(
 
 	// Create the table inserter, which does the bulk of the work.
 	ri, err := row.MakeInserter(
-		ctx, ef.planner.txn, tabDesc, colDescs, row.SkipFKs, nil /* fkTables */, &ef.planner.alloc,
+		ctx, ef.planner.txn, ef.planner.ExecCfg().Codec, tabDesc, colDescs, row.SkipFKs, nil /* fkTables */, &ef.planner.alloc,
 	)
 	if err != nil {
 		return nil, err
@@ -1396,6 +1398,7 @@ func (ef *execFactory) ConstructUpdate(
 	ru, err := row.MakeUpdater(
 		ctx,
 		ef.planner.txn,
+		ef.planner.ExecCfg().Codec,
 		tabDesc,
 		fkTables,
 		updateColDescs,
@@ -1542,7 +1545,14 @@ func (ef *execFactory) ConstructUpsert(
 
 	// Create the table inserter, which does the bulk of the insert-related work.
 	ri, err := row.MakeInserter(
-		ctx, ef.planner.txn, tabDesc, insertColDescs, checkFKs, fkTables, &ef.planner.alloc,
+		ctx,
+		ef.planner.txn,
+		ef.planner.ExecCfg().Codec,
+		tabDesc,
+		insertColDescs,
+		checkFKs,
+		fkTables,
+		&ef.planner.alloc,
 	)
 	if err != nil {
 		return nil, err
@@ -1552,6 +1562,7 @@ func (ef *execFactory) ConstructUpsert(
 	ru, err := row.MakeUpdater(
 		ctx,
 		ef.planner.txn,
+		ef.planner.ExecCfg().Codec,
 		tabDesc,
 		fkTables,
 		updateColDescs,
@@ -1669,6 +1680,7 @@ func (ef *execFactory) ConstructDelete(
 	rd, err := row.MakeDeleter(
 		ctx,
 		ef.planner.txn,
+		ef.planner.ExecCfg().Codec,
 		tabDesc,
 		fkTables,
 		fetchColDescs,
@@ -1729,7 +1741,7 @@ func (ef *execFactory) ConstructDeleteRange(
 ) (exec.Node, error) {
 	tabDesc := table.(*optTable).desc
 	indexDesc := &tabDesc.PrimaryIndex
-	sb := span.MakeBuilder(tabDesc.TableDesc(), indexDesc)
+	sb := span.MakeBuilder(ef.planner.ExecCfg().Codec, tabDesc.TableDesc(), indexDesc)
 
 	if err := ef.planner.maybeSetSystemConfig(tabDesc.GetID()); err != nil {
 		return nil, err

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -120,6 +120,7 @@ func (ef *execFactory) ConstructScan(
 	if err != nil {
 		return nil, err
 	}
+	scan.isFull = len(scan.spans) == 1 && scan.spans[0].EqualValue(scan.desc.IndexSpan(scan.index.ID))
 	for i := range reqOrdering {
 		if reqOrdering[i].ColIdx >= len(colCfg.wantedColumns) {
 			return nil, errors.Errorf("invalid reqOrdering: %v", reqOrdering)

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -29,7 +29,7 @@ ReadyForQuery
 ----
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
-{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":490,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":496,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 

--- a/pkg/sql/physicalplan/fake_span_resolver_test.go
+++ b/pkg/sql/physicalplan/fake_span_resolver_test.go
@@ -56,7 +56,7 @@ func TestFakeSpanResolver(t *testing.T) {
 	tableDesc := sqlbase.GetTableDescriptor(db, "test", "t")
 	primIdxValDirs := sqlbase.IndexKeyValDirs(&tableDesc.PrimaryIndex)
 
-	span := tableDesc.PrimaryIndexSpan()
+	span := tableDesc.PrimaryIndexSpan(keys.SystemSQLCodec)
 
 	// Make sure we see all the nodes. It will not always happen (due to
 	// randomness) but it should happen most of the time.

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -341,6 +341,7 @@ func internalExtendedEvalCtx(
 			TxnReadOnly:      false,
 			TxnImplicit:      true,
 			Settings:         execCfg.Settings,
+			Codec:            execCfg.Codec,
 			Context:          ctx,
 			Mon:              plannerMon,
 			TestingKnobs:     evalContextTestingKnobs,

--- a/pkg/sql/relocate.go
+++ b/pkg/sql/relocate.go
@@ -112,7 +112,7 @@ func (n *relocateNode) Next(params runParams) (bool, error) {
 	// TODO(a-robinson): Get the lastRangeStartKey via the ReturnRangeInfo option
 	// on the BatchRequest Header. We can't do this until v2.2 because admin
 	// requests don't respect the option on versions earlier than v2.1.
-	rowKey, err := getRowKey(n.tableDesc, n.index, data[1:])
+	rowKey, err := getRowKey(params.ExecCfg().Codec, n.tableDesc, n.index, data[1:])
 	if err != nil {
 		return false, err
 	}

--- a/pkg/sql/revert.go
+++ b/pkg/sql/revert.go
@@ -31,6 +31,7 @@ const RevertTableDefaultBatchSize = 500000
 func RevertTables(
 	ctx context.Context,
 	db *kv.DB,
+	execCfg *ExecutorConfig,
 	tables []*sqlbase.TableDescriptor,
 	targetTime hlc.Timestamp,
 	batchSize int64,
@@ -64,7 +65,7 @@ func RevertTables(
 				}
 			}
 		}
-		spans = append(spans, tables[i].TableSpan())
+		spans = append(spans, tables[i].TableSpan(execCfg.Codec))
 	}
 
 	for i := range tables {

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -95,7 +95,7 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 			valNeededForCol.Add(colIdx)
 		}
 		args = append(args, row.FetcherTableArgs{
-			Spans:            desc.AllIndexSpans(),
+			Spans:            desc.AllIndexSpans(keys.SystemSQLCodec),
 			Desc:             desc,
 			Index:            &desc.PrimaryIndex,
 			ColIdxMap:        colIdxMap,
@@ -106,6 +106,7 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 	}
 	var rf row.Fetcher
 	if err := rf.Init(
+		keys.SystemSQLCodec,
 		false, /* reverse */
 		sqlbase.ScanLockingStrength_FOR_NONE,
 		false, /* returnRangeInfo */

--- a/pkg/sql/row/fk_existence_base.go
+++ b/pkg/sql/row/fk_existence_base.go
@@ -13,6 +13,7 @@ package row
 import (
 	"sort"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -118,6 +119,7 @@ type fkExistenceCheckBaseHelper struct {
 //   sql, sqlbase, row. The proliferation is annoying.
 func makeFkExistenceCheckBaseHelper(
 	txn *kv.Txn,
+	codec keys.SQLCodec,
 	otherTables FkTableMetadata,
 	ref *sqlbase.ForeignKeyConstraint,
 	searchIdx *sqlbase.IndexDescriptor,
@@ -147,6 +149,7 @@ func makeFkExistenceCheckBaseHelper(
 	}
 	rf := &Fetcher{}
 	if err := rf.Init(
+		codec,
 		false, /* reverse */
 		sqlbase.ScanLockingStrength_FOR_NONE,
 		false, /* returnRangeInfo */
@@ -168,7 +171,7 @@ func makeFkExistenceCheckBaseHelper(
 		ids:           ids,
 		prefixLen:     len(ref.OriginColumnIDs),
 		valuesScratch: make(tree.Datums, len(ref.OriginColumnIDs)),
-		spanBuilder:   span.MakeBuilder(searchTable.TableDesc(), searchIdx),
+		spanBuilder:   span.MakeBuilder(codec, searchTable.TableDesc(), searchIdx),
 	}, nil
 }
 

--- a/pkg/sql/row/fk_existence_delete.go
+++ b/pkg/sql/row/fk_existence_delete.go
@@ -13,6 +13,7 @@ package row
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -36,6 +37,7 @@ type fkExistenceCheckForDelete struct {
 func makeFkExistenceCheckHelperForDelete(
 	ctx context.Context,
 	txn *kv.Txn,
+	codec keys.SQLCodec,
 	table *sqlbase.ImmutableTableDescriptor,
 	otherTables FkTableMetadata,
 	colMap map[sqlbase.ColumnID]int,
@@ -83,7 +85,7 @@ func makeFkExistenceCheckHelperForDelete(
 			return fkExistenceCheckForDelete{}, errors.NewAssertionErrorWithWrappedErrf(
 				err, "failed to find a suitable index on table %d for deletion", ref.ReferencedTableID)
 		}
-		fk, err := makeFkExistenceCheckBaseHelper(txn, otherTables, fakeRef, searchIdx, mutatedIdx, colMap, alloc,
+		fk, err := makeFkExistenceCheckBaseHelper(txn, codec, otherTables, fakeRef, searchIdx, mutatedIdx, colMap, alloc,
 			CheckDeletes)
 		if err == errSkipUnusedFK {
 			continue

--- a/pkg/sql/row/fk_existence_insert.go
+++ b/pkg/sql/row/fk_existence_insert.go
@@ -13,6 +13,7 @@ package row
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -45,6 +46,7 @@ type fkExistenceCheckForInsert struct {
 func makeFkExistenceCheckHelperForInsert(
 	ctx context.Context,
 	txn *kv.Txn,
+	codec keys.SQLCodec,
 	table *sqlbase.ImmutableTableDescriptor,
 	otherTables FkTableMetadata,
 	colMap map[sqlbase.ColumnID]int,
@@ -75,7 +77,7 @@ func makeFkExistenceCheckHelperForInsert(
 			return h, errors.NewAssertionErrorWithWrappedErrf(err,
 				"failed to find suitable search index for fk %q", ref.Name)
 		}
-		fk, err := makeFkExistenceCheckBaseHelper(txn, otherTables, ref, searchIdx, mutatedIdx, colMap, alloc, CheckInserts)
+		fk, err := makeFkExistenceCheckBaseHelper(txn, codec, otherTables, ref, searchIdx, mutatedIdx, colMap, alloc, CheckInserts)
 		if err == errSkipUnusedFK {
 			continue
 		}

--- a/pkg/sql/row/fk_existence_update.go
+++ b/pkg/sql/row/fk_existence_update.go
@@ -13,6 +13,7 @@ package row
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -64,6 +65,7 @@ type fkExistenceCheckForUpdate struct {
 func makeFkExistenceCheckHelperForUpdate(
 	ctx context.Context,
 	txn *kv.Txn,
+	codec keys.SQLCodec,
 	table *sqlbase.ImmutableTableDescriptor,
 	otherTables FkTableMetadata,
 	updateCols []sqlbase.ColumnDescriptor,
@@ -76,13 +78,13 @@ func makeFkExistenceCheckHelperForUpdate(
 
 	// Instantiate a helper for the referencing tables.
 	var err error
-	if ret.inbound, err = makeFkExistenceCheckHelperForDelete(ctx, txn, table, otherTables, colMap,
+	if ret.inbound, err = makeFkExistenceCheckHelperForDelete(ctx, txn, codec, table, otherTables, colMap,
 		alloc); err != nil {
 		return ret, err
 	}
 
 	// Instantiate a helper for the referenced table(s).
-	ret.outbound, err = makeFkExistenceCheckHelperForInsert(ctx, txn, table, otherTables, colMap, alloc)
+	ret.outbound, err = makeFkExistenceCheckHelperForInsert(ctx, txn, codec, table, otherTables, colMap, alloc)
 	ret.outbound.checker = ret.inbound.checker
 
 	// We need *some* KV batch checker to perform the checks. It doesn't

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -42,6 +43,7 @@ type Inserter struct {
 func MakeInserter(
 	ctx context.Context,
 	txn *kv.Txn,
+	codec keys.SQLCodec,
 	tableDesc *sqlbase.ImmutableTableDescriptor,
 	insertCols []sqlbase.ColumnDescriptor,
 	checkFKs checkFKConstraints,
@@ -49,7 +51,7 @@ func MakeInserter(
 	alloc *sqlbase.DatumAlloc,
 ) (Inserter, error) {
 	ri := Inserter{
-		Helper:                newRowHelper(tableDesc, tableDesc.WritableIndexes()),
+		Helper:                newRowHelper(codec, tableDesc, tableDesc.WritableIndexes()),
 		InsertCols:            insertCols,
 		InsertColIDtoRowIndex: ColIDtoRowIndexFromCols(insertCols),
 		marshaled:             make([]roachpb.Value, len(insertCols)),
@@ -63,7 +65,7 @@ func MakeInserter(
 
 	if checkFKs == CheckFKs {
 		var err error
-		if ri.Fks, err = makeFkExistenceCheckHelperForInsert(ctx, txn, tableDesc, fkTables,
+		if ri.Fks, err = makeFkExistenceCheckHelperForInsert(ctx, txn, codec, tableDesc, fkTables,
 			ri.InsertColIDtoRowIndex, alloc); err != nil {
 			return ri, err
 		}

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -277,6 +277,7 @@ func NewDatumRowConverter(
 	ri, err := MakeInserter(
 		ctx,
 		nil, /* txn */
+		evalCtx.Codec,
 		immutDesc,
 		cols,
 		SkipFKs,

--- a/pkg/sql/rowexec/index_skip_table_reader.go
+++ b/pkg/sql/rowexec/index_skip_table_reader.go
@@ -125,6 +125,7 @@ func newIndexSkipTableReader(
 	}
 
 	if err := t.fetcher.Init(
+		flowCtx.Codec(),
 		t.reverse,
 		spec.LockingStrength,
 		true,  /* returnRangeInfo */

--- a/pkg/sql/rowexec/index_skip_table_reader_test.go
+++ b/pkg/sql/rowexec/index_skip_table_reader_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -168,7 +169,7 @@ func TestIndexSkipTableReader(t *testing.T) {
 
 	makeIndexSpan := func(td *sqlbase.TableDescriptor, start, end int) execinfrapb.TableReaderSpan {
 		var span roachpb.Span
-		prefix := roachpb.Key(sqlbase.MakeIndexKeyPrefix(td, td.PrimaryIndex.ID))
+		prefix := roachpb.Key(sqlbase.MakeIndexKeyPrefix(keys.SystemSQLCodec, td, td.PrimaryIndex.ID))
 		span.Key = append(prefix, encoding.EncodeVarintAscending(nil, int64(start))...)
 		span.EndKey = append(span.EndKey, prefix...)
 		span.EndKey = append(span.EndKey, encoding.EncodeVarintAscending(nil, int64(end))...)
@@ -187,7 +188,7 @@ func TestIndexSkipTableReader(t *testing.T) {
 			desc:      "SimpleForward",
 			tableDesc: td1,
 			spec: execinfrapb.IndexSkipTableReaderSpec{
-				Spans: []execinfrapb.TableReaderSpan{{Span: td1.PrimaryIndexSpan()}},
+				Spans: []execinfrapb.TableReaderSpan{{Span: td1.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 			},
 			post: execinfrapb.PostProcessSpec{
 				Projection:    true,
@@ -200,7 +201,7 @@ func TestIndexSkipTableReader(t *testing.T) {
 			desc:      "InterleavedParent",
 			tableDesc: td5,
 			spec: execinfrapb.IndexSkipTableReaderSpec{
-				Spans: []execinfrapb.TableReaderSpan{{Span: td5.PrimaryIndexSpan()}},
+				Spans: []execinfrapb.TableReaderSpan{{Span: td5.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 			},
 			post: execinfrapb.PostProcessSpec{
 				Projection:    true,
@@ -213,7 +214,7 @@ func TestIndexSkipTableReader(t *testing.T) {
 			desc:      "InterleavedChild",
 			tableDesc: td6,
 			spec: execinfrapb.IndexSkipTableReaderSpec{
-				Spans: []execinfrapb.TableReaderSpan{{Span: td6.PrimaryIndexSpan()}},
+				Spans: []execinfrapb.TableReaderSpan{{Span: td6.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 			},
 			post: execinfrapb.PostProcessSpec{
 				Projection:    true,
@@ -253,7 +254,7 @@ func TestIndexSkipTableReader(t *testing.T) {
 			desc:      "Filter",
 			tableDesc: td1,
 			spec: execinfrapb.IndexSkipTableReaderSpec{
-				Spans: []execinfrapb.TableReaderSpan{{Span: td1.PrimaryIndexSpan()}},
+				Spans: []execinfrapb.TableReaderSpan{{Span: td1.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 			},
 			post: execinfrapb.PostProcessSpec{
 				Filter:        execinfrapb.Expression{Expr: "@1 > 3 AND @1 < 7"},
@@ -267,7 +268,7 @@ func TestIndexSkipTableReader(t *testing.T) {
 			desc:      "MultipleOutputCols",
 			tableDesc: td2,
 			spec: execinfrapb.IndexSkipTableReaderSpec{
-				Spans: []execinfrapb.TableReaderSpan{{Span: td2.PrimaryIndexSpan()}},
+				Spans: []execinfrapb.TableReaderSpan{{Span: td2.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 			},
 			post: execinfrapb.PostProcessSpec{
 				Projection:    true,
@@ -280,7 +281,7 @@ func TestIndexSkipTableReader(t *testing.T) {
 			desc:      "Nulls",
 			tableDesc: td3,
 			spec: execinfrapb.IndexSkipTableReaderSpec{
-				Spans: []execinfrapb.TableReaderSpan{{Span: td3.PrimaryIndexSpan()}},
+				Spans: []execinfrapb.TableReaderSpan{{Span: td3.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 			},
 			post: execinfrapb.PostProcessSpec{
 				Projection:    true,
@@ -293,7 +294,7 @@ func TestIndexSkipTableReader(t *testing.T) {
 			desc:      "SecondaryIdx",
 			tableDesc: td4,
 			spec: execinfrapb.IndexSkipTableReaderSpec{
-				Spans:    []execinfrapb.TableReaderSpan{{Span: td4.IndexSpan(2)}},
+				Spans:    []execinfrapb.TableReaderSpan{{Span: td4.IndexSpan(keys.SystemSQLCodec, 2)}},
 				IndexIdx: 1,
 			},
 			post: execinfrapb.PostProcessSpec{
@@ -307,7 +308,7 @@ func TestIndexSkipTableReader(t *testing.T) {
 			desc:      "SimpleReverse",
 			tableDesc: td1,
 			spec: execinfrapb.IndexSkipTableReaderSpec{
-				Spans:   []execinfrapb.TableReaderSpan{{Span: td1.PrimaryIndexSpan()}},
+				Spans:   []execinfrapb.TableReaderSpan{{Span: td1.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 				Reverse: true,
 			},
 			post: execinfrapb.PostProcessSpec{
@@ -350,7 +351,7 @@ func TestIndexSkipTableReader(t *testing.T) {
 			desc:      "InterleavedParentReverse",
 			tableDesc: td5,
 			spec: execinfrapb.IndexSkipTableReaderSpec{
-				Spans:   []execinfrapb.TableReaderSpan{{Span: td5.PrimaryIndexSpan()}},
+				Spans:   []execinfrapb.TableReaderSpan{{Span: td5.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 				Reverse: true,
 			},
 			post: execinfrapb.PostProcessSpec{
@@ -378,7 +379,7 @@ func TestIndexSkipTableReader(t *testing.T) {
 			desc:      "InterleavedChildReverse",
 			tableDesc: td6,
 			spec: execinfrapb.IndexSkipTableReaderSpec{
-				Spans:   []execinfrapb.TableReaderSpan{{Span: td6.PrimaryIndexSpan()}},
+				Spans:   []execinfrapb.TableReaderSpan{{Span: td6.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 				Reverse: true,
 			},
 			post: execinfrapb.PostProcessSpec{
@@ -392,7 +393,7 @@ func TestIndexSkipTableReader(t *testing.T) {
 			desc:      "IndexMultipleNulls",
 			tableDesc: td7,
 			spec: execinfrapb.IndexSkipTableReaderSpec{
-				Spans:    []execinfrapb.TableReaderSpan{{Span: td7.IndexSpan(2)}},
+				Spans:    []execinfrapb.TableReaderSpan{{Span: td7.IndexSpan(keys.SystemSQLCodec, 2)}},
 				IndexIdx: 1,
 			},
 			post: execinfrapb.PostProcessSpec{
@@ -406,7 +407,7 @@ func TestIndexSkipTableReader(t *testing.T) {
 			desc:      "IndexAllNulls",
 			tableDesc: td7,
 			spec: execinfrapb.IndexSkipTableReaderSpec{
-				Spans:    []execinfrapb.TableReaderSpan{{Span: td7.IndexSpan(3)}},
+				Spans:    []execinfrapb.TableReaderSpan{{Span: td7.IndexSpan(keys.SystemSQLCodec, 3)}},
 				IndexIdx: 2,
 			},
 			post: execinfrapb.PostProcessSpec{
@@ -502,7 +503,7 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 		NodeID:  nodeID,
 	}
 	spec := execinfrapb.IndexSkipTableReaderSpec{
-		Spans: []execinfrapb.TableReaderSpan{{Span: td.PrimaryIndexSpan()}},
+		Spans: []execinfrapb.TableReaderSpan{{Span: td.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 		Table: *td,
 	}
 	post := execinfrapb.PostProcessSpec{
@@ -630,7 +631,7 @@ func BenchmarkIndexScanTableReader(b *testing.B) {
 			b.Run(fmt.Sprintf("TableReader+Distinct-rows=%d-ratio=%d", numRows, valueRatio), func(b *testing.B) {
 				spec := execinfrapb.TableReaderSpec{
 					Table: *tableDesc,
-					Spans: []execinfrapb.TableReaderSpan{{Span: tableDesc.PrimaryIndexSpan()}},
+					Spans: []execinfrapb.TableReaderSpan{{Span: tableDesc.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 				}
 				post := execinfrapb.PostProcessSpec{
 					Projection:    true,
@@ -668,7 +669,7 @@ func BenchmarkIndexScanTableReader(b *testing.B) {
 			b.Run(fmt.Sprintf("IndexSkipTableReader-rows=%d-ratio=%d", numRows, valueRatio), func(b *testing.B) {
 				spec := execinfrapb.IndexSkipTableReaderSpec{
 					Table: *tableDesc,
-					Spans: []execinfrapb.TableReaderSpan{{Span: tableDesc.PrimaryIndexSpan()}},
+					Spans: []execinfrapb.TableReaderSpan{{Span: tableDesc.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 				}
 				post := execinfrapb.PostProcessSpec{
 					OutputColumns: []uint32{0},

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -78,7 +78,7 @@ func newIndexBackfiller(
 	}
 	ib.backfiller.chunks = ib
 
-	if err := ib.IndexBackfiller.Init(ib.desc); err != nil {
+	if err := ib.IndexBackfiller.Init(flowCtx.NewEvalCtx(), ib.desc); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/rowexec/indexjoiner.go
+++ b/pkg/sql/rowexec/indexjoiner.go
@@ -99,6 +99,7 @@ func newIndexJoiner(
 	}
 	var fetcher row.Fetcher
 	if _, _, err := initRowFetcher(
+		flowCtx,
 		&fetcher,
 		&ij.desc,
 		0, /* primary index */
@@ -122,7 +123,7 @@ func newIndexJoiner(
 		ij.fetcher = &fetcher
 	}
 
-	ij.spanBuilder = span.MakeBuilder(&spec.Table, &spec.Table.PrimaryIndex)
+	ij.spanBuilder = span.MakeBuilder(flowCtx.Codec(), &spec.Table, &spec.Table.PrimaryIndex)
 	ij.spanBuilder.SetNeededColumns(ij.Out.NeededColumns())
 
 	return ij, nil

--- a/pkg/sql/rowexec/interleaved_reader_joiner.go
+++ b/pkg/sql/rowexec/interleaved_reader_joiner.go
@@ -367,7 +367,7 @@ func newInterleavedReaderJoiner(
 	}
 
 	if err := irj.initRowFetcher(
-		spec.Tables, tables, spec.Reverse, spec.LockingStrength, &irj.alloc,
+		flowCtx, spec.Tables, tables, spec.Reverse, spec.LockingStrength, &irj.alloc,
 	); err != nil {
 		return nil, err
 	}
@@ -400,6 +400,7 @@ func newInterleavedReaderJoiner(
 }
 
 func (irj *interleavedReaderJoiner) initRowFetcher(
+	flowCtx *execinfra.FlowCtx,
 	tables []execinfrapb.InterleavedReaderJoinerSpec_Table,
 	tableInfos []tableInfo,
 	reverseScan bool,
@@ -427,6 +428,7 @@ func (irj *interleavedReaderJoiner) initRowFetcher(
 	}
 
 	return irj.fetcher.Init(
+		flowCtx.Codec(),
 		reverseScan,
 		lockStr,
 		true, /* returnRangeInfo */

--- a/pkg/sql/rowexec/interleaved_reader_joiner_test.go
+++ b/pkg/sql/rowexec/interleaved_reader_joiner_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -35,7 +36,7 @@ import (
 // min and max are inclusive bounds on the root table's ID.
 // If min and/or max is -1, then no bound is used for that endpoint.
 func makeSpanWithRootBound(desc *sqlbase.TableDescriptor, min int, max int) roachpb.Span {
-	keyPrefix := sqlbase.MakeIndexKeyPrefix(desc, desc.PrimaryIndex.ID)
+	keyPrefix := sqlbase.MakeIndexKeyPrefix(keys.SystemSQLCodec, desc, desc.PrimaryIndex.ID)
 
 	startKey := roachpb.Key(append([]byte(nil), keyPrefix...))
 	if min != -1 {
@@ -132,12 +133,12 @@ func TestInterleavedReaderJoiner(t *testing.T) {
 			{
 				Desc:     *pd,
 				Ordering: execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}}},
-				Spans:    []execinfrapb.TableReaderSpan{{Span: pd.PrimaryIndexSpan()}},
+				Spans:    []execinfrapb.TableReaderSpan{{Span: pd.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 			},
 			{
 				Desc:     *cd1,
 				Ordering: execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}}},
-				Spans:    []execinfrapb.TableReaderSpan{{Span: cd1.PrimaryIndexSpan()}},
+				Spans:    []execinfrapb.TableReaderSpan{{Span: cd1.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 			},
 		},
 		Type: sqlbase.InnerJoin,
@@ -150,10 +151,10 @@ func TestInterleavedReaderJoiner(t *testing.T) {
 
 	pdCd2Spec := copySpec(pdCd1Spec)
 	pdCd2Spec.Tables[1].Desc = *cd2
-	pdCd2Spec.Tables[1].Spans = []execinfrapb.TableReaderSpan{{Span: cd2.PrimaryIndexSpan()}}
+	pdCd2Spec.Tables[1].Spans = []execinfrapb.TableReaderSpan{{Span: cd2.PrimaryIndexSpan(keys.SystemSQLCodec)}}
 	pdCd3Spec := copySpec(pdCd1Spec)
 	pdCd3Spec.Tables[1].Desc = *cd3
-	pdCd3Spec.Tables[1].Spans = []execinfrapb.TableReaderSpan{{Span: cd3.PrimaryIndexSpan()}}
+	pdCd3Spec.Tables[1].Spans = []execinfrapb.TableReaderSpan{{Span: cd3.PrimaryIndexSpan(keys.SystemSQLCodec)}}
 
 	testCases := []struct {
 		spec     execinfrapb.InterleavedReaderJoinerSpec
@@ -476,12 +477,12 @@ func TestInterleavedReaderJoinerErrors(t *testing.T) {
 					{
 						Desc:     *pd,
 						Ordering: execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}}},
-						Spans:    []execinfrapb.TableReaderSpan{{Span: pd.PrimaryIndexSpan()}},
+						Spans:    []execinfrapb.TableReaderSpan{{Span: pd.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 					},
 					{
 						Desc:     *cd,
 						Ordering: execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_DESC}}},
-						Spans:    []execinfrapb.TableReaderSpan{{Span: cd.PrimaryIndexSpan()}},
+						Spans:    []execinfrapb.TableReaderSpan{{Span: cd.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 					},
 				},
 				Type: sqlbase.InnerJoin,
@@ -495,7 +496,7 @@ func TestInterleavedReaderJoinerErrors(t *testing.T) {
 					{
 						Desc:     *pd,
 						Ordering: execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}}},
-						Spans:    []execinfrapb.TableReaderSpan{{Span: pd.PrimaryIndexSpan()}},
+						Spans:    []execinfrapb.TableReaderSpan{{Span: pd.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 					},
 				},
 				Type: sqlbase.InnerJoin,
@@ -509,12 +510,12 @@ func TestInterleavedReaderJoinerErrors(t *testing.T) {
 					{
 						Desc:     *cd,
 						Ordering: execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}}},
-						Spans:    []execinfrapb.TableReaderSpan{{Span: pd.PrimaryIndexSpan()}},
+						Spans:    []execinfrapb.TableReaderSpan{{Span: pd.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 					},
 					{
 						Desc:     *gcd,
 						Ordering: execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}}},
-						Spans:    []execinfrapb.TableReaderSpan{{Span: gcd.PrimaryIndexSpan()}},
+						Spans:    []execinfrapb.TableReaderSpan{{Span: gcd.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 					},
 				},
 				Type: sqlbase.InnerJoin,
@@ -599,12 +600,12 @@ func TestInterleavedReaderJoinerTrailingMetadata(t *testing.T) {
 			{
 				Desc:     *pd,
 				Ordering: execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}}},
-				Spans:    []execinfrapb.TableReaderSpan{{Span: pd.PrimaryIndexSpan()}},
+				Spans:    []execinfrapb.TableReaderSpan{{Span: pd.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 			},
 			{
 				Desc:     *cd,
 				Ordering: execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}}},
-				Spans:    []execinfrapb.TableReaderSpan{{Span: cd.PrimaryIndexSpan()}},
+				Spans:    []execinfrapb.TableReaderSpan{{Span: cd.PrimaryIndexSpan(keys.SystemSQLCodec)}},
 			},
 		},
 		Type: sqlbase.InnerJoin,

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -205,7 +205,7 @@ func newJoinReader(
 
 	var fetcher row.Fetcher
 	_, _, err = initRowFetcher(
-		&fetcher, &jr.desc, int(spec.IndexIdx), jr.colIdxMap, false, /* reverse */
+		flowCtx, &fetcher, &jr.desc, int(spec.IndexIdx), jr.colIdxMap, false, /* reverse */
 		neededRightCols, false /* isCheck */, &jr.alloc, spec.Visibility, spec.LockingStrength,
 	)
 	if err != nil {
@@ -219,7 +219,7 @@ func newJoinReader(
 		jr.fetcher = &fetcher
 	}
 
-	jr.spanBuilder = span.MakeBuilder(&jr.desc, jr.index)
+	jr.spanBuilder = span.MakeBuilder(flowCtx.Codec(), &jr.desc, jr.index)
 	jr.spanBuilder.SetNeededColumns(jr.neededRightCols())
 
 	ctx := flowCtx.EvalCtx.Ctx()

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -53,6 +54,7 @@ type rowFetcher interface {
 
 // initRowFetcher initializes the fetcher.
 func initRowFetcher(
+	flowCtx *execinfra.FlowCtx,
 	fetcher *row.Fetcher,
 	desc *sqlbase.TableDescriptor,
 	indexIdx int,
@@ -83,7 +85,13 @@ func initRowFetcher(
 		ValNeededForCol:  valNeededForCol,
 	}
 	if err := fetcher.Init(
-		reverseScan, lockStr, true /* returnRangeInfo */, isCheck, alloc, tableArgs,
+		flowCtx.Codec(),
+		reverseScan,
+		lockStr,
+		true, /* returnRangeInfo */
+		isCheck,
+		alloc,
+		tableArgs,
 	); err != nil {
 		return nil, false, err
 	}

--- a/pkg/sql/rowexec/scrub_tablereader.go
+++ b/pkg/sql/rowexec/scrub_tablereader.go
@@ -121,8 +121,8 @@ func newScrubTableReader(
 
 	var fetcher row.Fetcher
 	if _, _, err := initRowFetcher(
-		&fetcher, &tr.tableDesc, int(spec.IndexIdx), tr.tableDesc.ColumnIdxMap(), spec.Reverse,
-		neededColumns, true /* isCheck */, &tr.alloc,
+		flowCtx, &fetcher, &tr.tableDesc, int(spec.IndexIdx), tr.tableDesc.ColumnIdxMap(),
+		spec.Reverse, neededColumns, true /* isCheck */, &tr.alloc,
 		execinfrapb.ScanVisibility_PUBLIC, spec.LockingStrength,
 	); err != nil {
 		return nil, err

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -116,7 +116,7 @@ func newTableReader(
 	var fetcher row.Fetcher
 	columnIdxMap := spec.Table.ColumnIdxMapWithMutations(returnMutations)
 	if _, _, err := initRowFetcher(
-		&fetcher, &spec.Table, int(spec.IndexIdx), columnIdxMap, spec.Reverse,
+		flowCtx, &fetcher, &spec.Table, int(spec.IndexIdx), columnIdxMap, spec.Reverse,
 		neededColumns, spec.IsCheck, &tr.alloc, spec.Visibility, spec.LockingStrength,
 	); err != nil {
 		return nil, err

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -320,7 +320,7 @@ func newZigzagJoiner(
 				return nil, err
 			}
 		}
-		if err := z.setupInfo(spec, i, colOffset); err != nil {
+		if err := z.setupInfo(flowCtx, spec, i, colOffset); err != nil {
 			return nil, err
 		}
 		colOffset += len(z.infos[i].table.Columns)
@@ -393,7 +393,7 @@ type zigzagJoinerInfo struct {
 // to process. It is the number of columns in the tables of all previous sides
 // of the join.
 func (z *zigzagJoiner) setupInfo(
-	spec *execinfrapb.ZigzagJoinerSpec, side int, colOffset int,
+	flowCtx *execinfra.FlowCtx, spec *execinfrapb.ZigzagJoinerSpec, side int, colOffset int,
 ) error {
 	z.side = side
 	info := z.infos[side]
@@ -438,11 +438,12 @@ func (z *zigzagJoiner) setupInfo(
 	// Setup the RowContainers.
 	info.container.Reset()
 
-	info.spanBuilder = span.MakeBuilder(info.table, info.index)
+	info.spanBuilder = span.MakeBuilder(flowCtx.Codec(), info.table, info.index)
 
 	// Setup the Fetcher.
 	_, _, err := initRowFetcher(
-		&(info.fetcher),
+		flowCtx,
+		&info.fetcher,
 		info.table,
 		int(indexOrdinal),
 		info.table.ColumnIdxMap(),
@@ -459,7 +460,7 @@ func (z *zigzagJoiner) setupInfo(
 		return err
 	}
 
-	info.prefix = sqlbase.MakeIndexKeyPrefix(info.table, info.index.ID)
+	info.prefix = sqlbase.MakeIndexKeyPrefix(flowCtx.Codec(), info.table, info.index.ID)
 	span, err := z.produceSpanFromBaseRow()
 
 	if err != nil {

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -109,9 +109,6 @@ type scanNode struct {
 	// scan is guaranteed to return.
 	maxResults uint64
 
-	// Indicates if this scan is the source for a delete node.
-	isDeleteSource bool
-
 	// estimatedRowCount is the estimated number of rows that this scanNode will
 	// output. When there are no statistics to make the estimation, it will be
 	// set to zero.

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -99,6 +99,10 @@ type scanNode struct {
 	// Should be set to true if sqlbase.ParallelScans is true.
 	parallelScansEnabled bool
 
+	// Is this a full scan of an index?
+	isFull bool
+
+	// Is this a scan of a secondary index?
 	isSecondaryIndex bool
 
 	// Indicates if this scanNode will do a physical data check. This is

--- a/pkg/sql/scatter.go
+++ b/pkg/sql/scatter.go
@@ -40,7 +40,7 @@ func (p *planner) Scatter(ctx context.Context, n *tree.Scatter) (planNode, error
 	var span roachpb.Span
 	if n.From == nil {
 		// No FROM/TO specified; the span is the entire table/index.
-		span = tableDesc.IndexSpan(index.ID)
+		span = tableDesc.IndexSpan(p.ExecCfg().Codec, index.ID)
 	} else {
 		switch {
 		case len(n.From) == 0:
@@ -91,11 +91,11 @@ func (p *planner) Scatter(ctx context.Context, n *tree.Scatter) (planNode, error
 			}
 		}
 
-		span.Key, err = getRowKey(tableDesc.TableDesc(), index, fromVals)
+		span.Key, err = getRowKey(p.ExecCfg().Codec, tableDesc.TableDesc(), index, fromVals)
 		if err != nil {
 			return nil, err
 		}
-		span.EndKey, err = getRowKey(tableDesc.TableDesc(), index, toVals)
+		span.EndKey, err = getRowKey(p.ExecCfg().Codec, tableDesc.TableDesc(), index, toVals)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -113,7 +113,7 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 	}
 	scan.index = scan.specifiedIndex
 	sb := span.MakeBuilder(o.tableDesc.TableDesc(), o.indexDesc)
-	scan.spans, err = sb.UnconstrainedSpans(false /* forDelete */)
+	scan.spans, err = sb.UnconstrainedSpans()
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -117,6 +117,7 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 	if err != nil {
 		return err
 	}
+	scan.isFull = true
 
 	planCtx := params.extendedEvalCtx.DistSQLPlanner.NewPlanningCtx(ctx, params.extendedEvalCtx, params.p.txn)
 	physPlan, err := params.extendedEvalCtx.DistSQLPlanner.createScrubPhysicalCheck(

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -112,7 +112,7 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 		return err
 	}
 	scan.index = scan.specifiedIndex
-	sb := span.MakeBuilder(o.tableDesc.TableDesc(), o.indexDesc)
+	sb := span.MakeBuilder(params.ExecCfg().Codec, o.tableDesc.TableDesc(), o.indexDesc)
 	scan.spans, err = sb.UnconstrainedSpans()
 	if err != nil {
 		return err

--- a/pkg/sql/scrub_test.go
+++ b/pkg/sql/scrub_test.go
@@ -64,7 +64,7 @@ INSERT INTO t."tEst" VALUES (10, 20);
 	// Construct the secondary index key that is currently in the
 	// database.
 	secondaryIndexKey, err := sqlbase.EncodeSecondaryIndex(
-		tableDesc, secondaryIndex, colIDtoRowIndex, values, true /* includeEmpty */)
+		keys.SystemSQLCodec, tableDesc, secondaryIndex, colIDtoRowIndex, values, true /* includeEmpty */)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -132,7 +132,7 @@ CREATE INDEX secondary ON t.test (v);
 	// Construct datums and secondary k/v for our row values (k, v).
 	values := []tree.Datum{tree.NewDInt(10), tree.NewDInt(314)}
 	secondaryIndex, err := sqlbase.EncodeSecondaryIndex(
-		tableDesc, secondaryIndexDesc, colIDtoRowIndex, values, true /* includeEmpty */)
+		keys.SystemSQLCodec, tableDesc, secondaryIndexDesc, colIDtoRowIndex, values, true /* includeEmpty */)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -226,7 +226,7 @@ INSERT INTO t.test VALUES (10, 20, 1337);
 	// Generate the existing secondary index key.
 	values := []tree.Datum{tree.NewDInt(10), tree.NewDInt(20), tree.NewDInt(1337)}
 	secondaryIndex, err := sqlbase.EncodeSecondaryIndex(
-		tableDesc, secondaryIndexDesc, colIDtoRowIndex, values, true /* includeEmpty */)
+		keys.SystemSQLCodec, tableDesc, secondaryIndexDesc, colIDtoRowIndex, values, true /* includeEmpty */)
 
 	if len(secondaryIndex) != 1 {
 		t.Fatalf("expected 1 index entry, got %d. got %#v", len(secondaryIndex), secondaryIndex)
@@ -243,7 +243,7 @@ INSERT INTO t.test VALUES (10, 20, 1337);
 	// Generate a secondary index k/v that has a different value.
 	values = []tree.Datum{tree.NewDInt(10), tree.NewDInt(20), tree.NewDInt(314)}
 	secondaryIndex, err = sqlbase.EncodeSecondaryIndex(
-		tableDesc, secondaryIndexDesc, colIDtoRowIndex, values, true /* includeEmpty */)
+		keys.SystemSQLCodec, tableDesc, secondaryIndexDesc, colIDtoRowIndex, values, true /* includeEmpty */)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -342,7 +342,8 @@ INSERT INTO t.test VALUES (10, 2);
 
 	// Create the primary index key.
 	values := []tree.Datum{tree.NewDInt(10), tree.NewDInt(2)}
-	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIndex.ID)
+	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(
+		keys.SystemSQLCodec, tableDesc, tableDesc.PrimaryIndex.ID)
 	primaryIndexKey, _, err := sqlbase.EncodeIndexKey(
 		tableDesc, &tableDesc.PrimaryIndex, colIDtoRowIndex, values, primaryIndexKeyPrefix)
 	if err != nil {
@@ -444,7 +445,7 @@ func TestScrubFKConstraintFKMissing(t *testing.T) {
 	// Construct the secondary index key entry as it exists in the
 	// database.
 	secondaryIndexKey, err := sqlbase.EncodeSecondaryIndex(
-		tableDesc, secondaryIndex, colIDtoRowIndex, values, true /* includeEmpty */)
+		keys.SystemSQLCodec, tableDesc, secondaryIndex, colIDtoRowIndex, values, true /* includeEmpty */)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -464,7 +465,7 @@ func TestScrubFKConstraintFKMissing(t *testing.T) {
 
 	// Construct the new secondary index key that will be inserted.
 	secondaryIndexKey, err = sqlbase.EncodeSecondaryIndex(
-		tableDesc, secondaryIndex, colIDtoRowIndex, values, true /* includeEmpty */)
+		keys.SystemSQLCodec, tableDesc, secondaryIndex, colIDtoRowIndex, values, true /* includeEmpty */)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -578,7 +579,8 @@ INSERT INTO t.test VALUES (217, 314);
 	colIDtoRowIndex[tableDesc.Columns[1].ID] = 1
 
 	// Create the primary index key
-	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIndex.ID)
+	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(
+		keys.SystemSQLCodec, tableDesc, tableDesc.PrimaryIndex.ID)
 	primaryIndexKey, _, err := sqlbase.EncodeIndexKey(
 		tableDesc, &tableDesc.PrimaryIndex, colIDtoRowIndex, values, primaryIndexKeyPrefix)
 	if err != nil {
@@ -659,7 +661,8 @@ INSERT INTO t.test VALUES (217, 314, 1337);
 	colIDtoRowIndex[tableDesc.Columns[2].ID] = 2
 
 	// Create the primary index key
-	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIndex.ID)
+	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(
+		keys.SystemSQLCodec, tableDesc, tableDesc.PrimaryIndex.ID)
 	primaryIndexKey, _, err := sqlbase.EncodeIndexKey(
 		tableDesc, &tableDesc.PrimaryIndex, colIDtoRowIndex, values, primaryIndexKeyPrefix)
 	if err != nil {
@@ -762,7 +765,8 @@ CREATE TABLE t.test (
 	colIDtoRowIndex[tableDesc.Columns[1].ID] = 1
 
 	// Create the primary index key
-	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIndex.ID)
+	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(
+		keys.SystemSQLCodec, tableDesc, tableDesc.PrimaryIndex.ID)
 	primaryIndexKey, _, err := sqlbase.EncodeIndexKey(
 		tableDesc, &tableDesc.PrimaryIndex, colIDtoRowIndex, values, primaryIndexKeyPrefix)
 	if err != nil {
@@ -865,7 +869,8 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v1 INT, v2 INT);
 	colIDtoRowIndex[tableDesc.Columns[2].ID] = 2
 
 	// Create the primary index key
-	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIndex.ID)
+	primaryIndexKeyPrefix := sqlbase.MakeIndexKeyPrefix(
+		keys.SystemSQLCodec, tableDesc, tableDesc.PrimaryIndex.ID)
 	primaryIndexKey, _, err := sqlbase.EncodeIndexKey(
 		tableDesc, &tableDesc.PrimaryIndex, colIDtoRowIndex, values, primaryIndexKeyPrefix)
 	if err != nil {

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2864,7 +2864,7 @@ may increase either contention or retry errors, or both.`,
 				}
 
 				if indexDesc.ID == tableDesc.PrimaryIndex.ID {
-					keyPrefix := sqlbase.MakeIndexKeyPrefix(tableDesc, indexDesc.ID)
+					keyPrefix := sqlbase.MakeIndexKeyPrefix(ctx.Codec, tableDesc, indexDesc.ID)
 					res, _, err := sqlbase.EncodeIndexKey(tableDesc, indexDesc, colMap, datums, keyPrefix)
 					if err != nil {
 						return nil, err
@@ -2872,7 +2872,7 @@ may increase either contention or retry errors, or both.`,
 					return tree.NewDBytes(tree.DBytes(res)), err
 				}
 				// We have a secondary index.
-				res, err := sqlbase.EncodeSecondaryIndex(tableDesc, indexDesc, colMap, datums, true /* includeEmpty */)
+				res, err := sqlbase.EncodeSecondaryIndex(ctx.Codec, tableDesc, indexDesc, colMap, datums, true /* includeEmpty */)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -2829,8 +2830,9 @@ type EvalContext struct {
 
 	Settings    *cluster.Settings
 	ClusterID   uuid.UUID
-	NodeID      roachpb.NodeID
 	ClusterName string
+	NodeID      roachpb.NodeID
+	Codec       keys.SQLCodec
 
 	// Locality contains the location of the current node as a set of user-defined
 	// key/value pairs, ordered from most inclusive to least inclusive. If there
@@ -2940,6 +2942,7 @@ func MakeTestingEvalContext(st *cluster.Settings) EvalContext {
 // EvalContext so do not start or close the memory monitor.
 func MakeTestingEvalContextWithMon(st *cluster.Settings, monitor *mon.BytesMonitor) EvalContext {
 	ctx := EvalContext{
+		Codec:       keys.SystemSQLCodec,
 		Txn:         &kv.Txn{},
 		SessionData: &sessiondata.SessionData{},
 		Settings:    st,

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -840,7 +840,7 @@ func writeZoneConfig(
 	if len(zone.Subzones) > 0 {
 		st := execCfg.Settings
 		zone.SubzoneSpans, err = GenerateSubzoneSpans(
-			st, execCfg.ClusterID(), table, zone.Subzones, hasNewSubzones)
+			st, execCfg.ClusterID(), execCfg.Codec, table, zone.Subzones, hasNewSubzones)
 		if err != nil {
 			return 0, err
 		}

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -136,7 +136,7 @@ func ShowCreateTable(
 				}
 			}
 			if err := ShowCreatePartitioning(
-				a, desc, idx, &idx.Partitioning, &f.Buffer, 1 /* indent */, 0, /* colOffset */
+				a, p.ExecCfg().Codec, desc, idx, &idx.Partitioning, &f.Buffer, 1 /* indent */, 0, /* colOffset */
 			); err != nil {
 				return "", err
 			}
@@ -151,7 +151,7 @@ func ShowCreateTable(
 		return "", err
 	}
 	if err := ShowCreatePartitioning(
-		a, desc, &desc.PrimaryIndex, &desc.PrimaryIndex.Partitioning, &f.Buffer, 0 /* indent */, 0, /* colOffset */
+		a, p.ExecCfg().Codec, desc, &desc.PrimaryIndex, &desc.PrimaryIndex.Partitioning, &f.Buffer, 0 /* indent */, 0, /* colOffset */
 	); err != nil {
 		return "", err
 	}

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -282,6 +282,7 @@ func showCreateInterleave(
 // index, if applicable.
 func ShowCreatePartitioning(
 	a *sqlbase.DatumAlloc,
+	codec keys.SQLCodec,
 	tableDesc *sqlbase.TableDescriptor,
 	idxDesc *sqlbase.IndexDescriptor,
 	partDesc *sqlbase.PartitioningDescriptor,
@@ -334,7 +335,7 @@ func ShowCreatePartitioning(
 				buf.WriteString(`, `)
 			}
 			tuple, _, err := sqlbase.DecodePartitionTuple(
-				a, tableDesc, idxDesc, partDesc, values, fakePrefixDatums)
+				a, codec, tableDesc, idxDesc, partDesc, values, fakePrefixDatums)
 			if err != nil {
 				return err
 			}
@@ -342,7 +343,7 @@ func ShowCreatePartitioning(
 		}
 		buf.WriteString(`)`)
 		if err := ShowCreatePartitioning(
-			a, tableDesc, idxDesc, &part.Subpartitioning, buf, indent+1,
+			a, codec, tableDesc, idxDesc, &part.Subpartitioning, buf, indent+1,
 			colOffset+int(partDesc.NumColumns),
 		); err != nil {
 			return err
@@ -358,14 +359,14 @@ func ShowCreatePartitioning(
 		buf.WriteString(part.Name)
 		buf.WriteString(" VALUES FROM ")
 		fromTuple, _, err := sqlbase.DecodePartitionTuple(
-			a, tableDesc, idxDesc, partDesc, part.FromInclusive, fakePrefixDatums)
+			a, codec, tableDesc, idxDesc, partDesc, part.FromInclusive, fakePrefixDatums)
 		if err != nil {
 			return err
 		}
 		buf.WriteString(fromTuple.String())
 		buf.WriteString(" TO ")
 		toTuple, _, err := sqlbase.DecodePartitionTuple(
-			a, tableDesc, idxDesc, partDesc, part.ToExclusive, fakePrefixDatums)
+			a, codec, tableDesc, idxDesc, partDesc, part.ToExclusive, fakePrefixDatums)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/span/span_builder.go
+++ b/pkg/sql/span/span_builder.go
@@ -219,8 +219,8 @@ func (s *Builder) SpansFromConstraint(
 
 // UnconstrainedSpans returns the full span corresponding to the Builder's
 // table and index.
-func (s *Builder) UnconstrainedSpans(forDelete bool) (roachpb.Spans, error) {
-	return s.SpansFromConstraint(nil, exec.TableColumnOrdinalSet{}, forDelete)
+func (s *Builder) UnconstrainedSpans() (roachpb.Spans, error) {
+	return s.SpansFromConstraint(nil, exec.TableColumnOrdinalSet{}, false /* forDelete */)
 }
 
 // appendSpansFromConstraintSpan converts a constraint.Span to one or more

--- a/pkg/sql/span_builder_test.go
+++ b/pkg/sql/span_builder_test.go
@@ -31,6 +31,7 @@ func TestSpanBuilderCanSplitSpan(t *testing.T) {
 	params, _ := tests.CreateTestServerParams()
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
+	execCfg := s.ExecutorConfig().(ExecutorConfig)
 	tcs := []struct {
 		sql               string
 		index             string
@@ -101,7 +102,7 @@ func TestSpanBuilderCanSplitSpan(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			builder := span.MakeBuilder(desc, idx)
+			builder := span.MakeBuilder(execCfg.Codec, desc, idx)
 			if res := builder.CanSplitSpanIntoSeparateFamilies(
 				tc.numNeededFamilies, tc.prefixLen, tc.containsNull); res != tc.canSplit {
 				t.Errorf("expected result to be %v, but found %v", tc.canSplit, res)

--- a/pkg/sql/sqlbase/partition.go
+++ b/pkg/sql/sqlbase/partition.go
@@ -13,6 +13,7 @@ package sqlbase
 import (
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -102,6 +103,7 @@ func (t *PartitionTuple) String() string {
 // partitioning and MINVALUE/MAXVALUE.
 func DecodePartitionTuple(
 	a *DatumAlloc,
+	codec keys.SQLCodec,
 	tableDesc *TableDescriptor,
 	idxDesc *IndexDescriptor,
 	partDesc *PartitioningDescriptor,
@@ -161,7 +163,7 @@ func DecodePartitionTuple(
 		colMap[idxDesc.ColumnIDs[i]] = i
 	}
 
-	indexKeyPrefix := MakeIndexKeyPrefix(tableDesc, idxDesc.ID)
+	indexKeyPrefix := MakeIndexKeyPrefix(codec, tableDesc, idxDesc.ID)
 	key, _, err := EncodePartialIndexKey(
 		tableDesc, idxDesc, len(allDatums), colMap, allDatums, indexKeyPrefix)
 	if err != nil {

--- a/pkg/sql/sqlbase/table_test.go
+++ b/pkg/sql/sqlbase/table_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -101,7 +102,7 @@ func makeTableDescForTest(test indexKeyTest) (TableDescriptor, map[ColumnID]int)
 }
 
 func decodeIndex(
-	tableDesc *TableDescriptor, index *IndexDescriptor, key []byte,
+	codec keys.SQLCodec, tableDesc *TableDescriptor, index *IndexDescriptor, key []byte,
 ) ([]tree.Datum, error) {
 	types, err := GetColumnTypes(tableDesc, index.ColumnIDs)
 	if err != nil {
@@ -109,7 +110,7 @@ func decodeIndex(
 	}
 	values := make([]EncDatum, len(index.ColumnIDs))
 	colDirs := index.ColumnDirections
-	_, ok, _, err := DecodeIndexKey(tableDesc, index, types, values, colDirs, key)
+	_, ok, _, err := DecodeIndexKey(codec, tableDesc, index, types, values, colDirs, key)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,8 @@ func TestIndexKey(t *testing.T) {
 
 		testValues := append(test.primaryValues, test.secondaryValues...)
 
-		primaryKeyPrefix := MakeIndexKeyPrefix(&tableDesc, tableDesc.PrimaryIndex.ID)
+		codec := keys.SystemSQLCodec
+		primaryKeyPrefix := MakeIndexKeyPrefix(codec, &tableDesc, tableDesc.PrimaryIndex.ID)
 		primaryKey, _, err := EncodeIndexKey(
 			&tableDesc, &tableDesc.PrimaryIndex, colMap, testValues, primaryKeyPrefix)
 		if err != nil {
@@ -224,7 +226,7 @@ func TestIndexKey(t *testing.T) {
 		primaryIndexKV := kv.KeyValue{Key: primaryKey, Value: &primaryValue}
 
 		secondaryIndexEntry, err := EncodeSecondaryIndex(
-			&tableDesc, &tableDesc.Indexes[0], colMap, testValues, true /* includeEmpty */)
+			codec, &tableDesc, &tableDesc.Indexes[0], colMap, testValues, true /* includeEmpty */)
 		if len(secondaryIndexEntry) != 1 {
 			t.Fatalf("expected 1 index entry, got %d. got %#v", len(secondaryIndexEntry), secondaryIndexEntry)
 		}
@@ -237,7 +239,7 @@ func TestIndexKey(t *testing.T) {
 		}
 
 		checkEntry := func(index *IndexDescriptor, entry kv.KeyValue) {
-			values, err := decodeIndex(&tableDesc, index, entry.Key)
+			values, err := decodeIndex(codec, &tableDesc, index, entry.Key)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -249,7 +251,7 @@ func TestIndexKey(t *testing.T) {
 				}
 			}
 
-			indexID, _, err := DecodeIndexKeyPrefix(&tableDesc, entry.Key)
+			indexID, _, err := DecodeIndexKeyPrefix(codec, &tableDesc, entry.Key)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -257,7 +259,7 @@ func TestIndexKey(t *testing.T) {
 				t.Errorf("%d", i)
 			}
 
-			extracted, err := ExtractIndexKey(&a, &tableDesc, entry)
+			extracted, err := ExtractIndexKey(&a, codec, &tableDesc, entry)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -666,7 +668,7 @@ func TestIndexKeyEquivSignature(t *testing.T) {
 			tc.table.indexKeyArgs.primaryValues = tc.table.values
 			// Setup descriptors and form an index key.
 			desc, colMap := makeTableDescForTest(tc.table.indexKeyArgs)
-			primaryKeyPrefix := MakeIndexKeyPrefix(&desc, desc.PrimaryIndex.ID)
+			primaryKeyPrefix := MakeIndexKeyPrefix(keys.SystemSQLCodec, &desc, desc.PrimaryIndex.ID)
 			primaryKey, _, err := EncodeIndexKey(
 				&desc, &desc.PrimaryIndex, colMap, tc.table.values, primaryKeyPrefix)
 			if err != nil {
@@ -807,7 +809,7 @@ func TestEquivSignature(t *testing.T) {
 
 				// Setup descriptors and form an index key.
 				desc, colMap := makeTableDescForTest(table.indexKeyArgs)
-				primaryKeyPrefix := MakeIndexKeyPrefix(&desc, desc.PrimaryIndex.ID)
+				primaryKeyPrefix := MakeIndexKeyPrefix(keys.SystemSQLCodec, &desc, desc.PrimaryIndex.ID)
 				primaryKey, _, err := EncodeIndexKey(
 					&desc, &desc.PrimaryIndex, colMap, table.values, primaryKeyPrefix)
 				if err != nil {
@@ -1055,12 +1057,14 @@ func TestAdjustStartKeyForInterleave(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			actual, err := AdjustStartKeyForInterleave(tc.index, EncodeTestKey(t, kvDB, ShortToLongKeyFmt(tc.input)))
+			codec := keys.SystemSQLCodec
+			actual := EncodeTestKey(t, kvDB, codec, ShortToLongKeyFmt(tc.input))
+			actual, err := AdjustStartKeyForInterleave(codec, tc.index, actual)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			expected := EncodeTestKey(t, kvDB, ShortToLongKeyFmt(tc.expected))
+			expected := EncodeTestKey(t, kvDB, codec, ShortToLongKeyFmt(tc.expected))
 			if !expected.Equal(actual) {
 				t.Errorf("expected tightened start key %s, got %s", expected, actual)
 			}
@@ -1475,12 +1479,14 @@ func TestAdjustEndKeyForInterleave(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			actual, err := AdjustEndKeyForInterleave(tc.table, tc.index, EncodeTestKey(t, kvDB, ShortToLongKeyFmt(tc.input)), tc.inclusive)
+			codec := keys.SystemSQLCodec
+			actual := EncodeTestKey(t, kvDB, codec, ShortToLongKeyFmt(tc.input))
+			actual, err := AdjustEndKeyForInterleave(codec, tc.table, tc.index, actual, tc.inclusive)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			expected := EncodeTestKey(t, kvDB, ShortToLongKeyFmt(tc.expected))
+			expected := EncodeTestKey(t, kvDB, codec, ShortToLongKeyFmt(tc.expected))
 			if !expected.Equal(actual) {
 				t.Errorf("expected tightened end key %s, got %s", expected, actual)
 			}

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/geo"
 	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -964,7 +965,7 @@ func TestingMakePrimaryIndexKey(desc *TableDescriptor, vals ...interface{}) (roa
 		colIDToRowIndex[index.ColumnIDs[i]] = i
 	}
 
-	keyPrefix := MakeIndexKeyPrefix(desc, index.ID)
+	keyPrefix := MakeIndexKeyPrefix(keys.SystemSQLCodec, desc, index.ID)
 	key, _, err := EncodeIndexKey(desc, index, colIDToRowIndex, datums, keyPrefix)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/sqlbase/utils_test.go
+++ b/pkg/sql/sqlbase/utils_test.go
@@ -43,8 +43,8 @@ var tableNames = map[string]bool{
 //    - 'd' first byte - decimal (ascending)
 //    - NULLASC, NULLDESC, NOTNULLASC, NOTNULLDESC
 //    - PrefixEnd
-func EncodeTestKey(tb testing.TB, kvDB *kv.DB, keyStr string) roachpb.Key {
-	key := keys.SystemSQLCodec.TenantPrefix()
+func EncodeTestKey(tb testing.TB, kvDB *kv.DB, codec keys.SQLCodec, keyStr string) roachpb.Key {
+	key := codec.TenantPrefix()
 	tokens := strings.Split(keyStr, "/")
 	if tokens[0] != "" {
 		panic("missing '/' token at the beginning of long format")

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -956,7 +956,7 @@ func (p *planner) createOrUpdateSchemaChangeJob(
 	if jobExists {
 		spanList = job.Details().(jobspb.SchemaChangeDetails).ResumeSpanList
 	}
-	span := tableDesc.PrimaryIndexSpan()
+	span := tableDesc.PrimaryIndexSpan(p.ExecCfg().Codec)
 	for i := len(tableDesc.ClusterVersion.Mutations) + len(spanList); i < len(tableDesc.Mutations); i++ {
 		spanList = append(spanList,
 			jobspb.ResumeSpanList{

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -160,7 +160,9 @@ func (tu *optTableUpserter) init(
 		evalCtx.Mon.MakeBoundAccount(), sqlbase.ColTypeInfoFromColDescs(tu.ri.InsertCols), 0,
 	)
 
-	tu.indexKeyPrefix = sqlbase.MakeIndexKeyPrefix(tableDesc.TableDesc(), tableDesc.PrimaryIndex.ID)
+	tu.indexKeyPrefix = sqlbase.MakeIndexKeyPrefix(
+		evalCtx.Codec, tableDesc.TableDesc(), tableDesc.PrimaryIndex.ID,
+	)
 
 	if tu.collectRows {
 		tu.resultRow = make(tree.Datums, len(tu.returnCols))

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -406,7 +407,11 @@ func reassignComments(
 // can even eliminate the need to use a transaction for each chunk at a later
 // stage if it proves inefficient).
 func ClearTableDataInChunks(
-	ctx context.Context, tableDesc *sqlbase.TableDescriptor, db *kv.DB, traceKV bool,
+	ctx context.Context,
+	db *kv.DB,
+	codec keys.SQLCodec,
+	tableDesc *sqlbase.TableDescriptor,
+	traceKV bool,
 ) error {
 	const chunkSize = TableTruncateChunkSize
 	var resume roachpb.Span
@@ -420,6 +425,7 @@ func ClearTableDataInChunks(
 			rd, err := row.MakeDeleter(
 				ctx,
 				txn,
+				codec,
 				sqlbase.NewImmutableTableDescriptor(*tableDesc),
 				nil,
 				nil,

--- a/pkg/sql/unsplit.go
+++ b/pkg/sql/unsplit.go
@@ -43,7 +43,7 @@ func (n *unsplitNode) Next(params runParams) (bool, error) {
 	}
 
 	row := n.rows.Values()
-	rowKey, err := getRowKey(n.tableDesc, n.index, row)
+	rowKey, err := getRowKey(params.ExecCfg().Codec, n.tableDesc, n.index, row)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Fixes #47903.
Informs #48123.

Also known as "the grand plumbing", this change replaces a few instances of `TODOSQLCodec` in `pkg/sql/sqlbase/index_encoding.go` and watches the house of cards fall apart. It then glues the world back together, this time using a properly injected tenant-bound SQLCodec to encode and decode all SQL table keys.

A tenant ID field is added to `sqlServerArgs`. This is used to construct a tenant-bound `keys.SQLCodec` during server creation. This codec morally lives on the `sql.ExecutorConfig`. In practice, it is also copied onto `tree.EvalContext` and `execinfra.ServerConfig` to help carry it around. SQL code is adapted to use this codec whenever it needs to encode or decode keys.

If all tests pass after this refactor, there is a good chance it got things right. This is because any use of an uninitialized SQLCodec will panic immediately when the codec is first used. This was helpful in ensuring that it was properly plumbed everywhere.