### PR TITLE
sem/builtins: avoid an assertion error on legitimate errors

### DIFF
--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -475,7 +475,7 @@ func parsePrivilegeStr(arg tree.Datum, availOpts pgPrivList) (tree.Datum, error)
 	for _, priv := range privs {
 		d, err := availOpts[priv](false /* withGrantOpt */)
 		if err != nil {
-			return nil, errors.NewAssertionErrorWithWrappedErrf(err,
+			return nil, errors.Wrapf(err,
 				"error checking privilege %q", errors.Safe(priv))
 		}
 		switch d {


### PR DESCRIPTION
Fixes #46035

If there's a retry error or some other legitimate txn error
while checking a privilege, this will come up during the privilege
check and should flow to the client. No need to issue an "internal
error" and a sentry report.

Release note (bug fix): CockroachDB will now avoid producing a severe
"internal error" upon certain privilege check failures via
`pg_catalog` built-in functions.