### PR TITLE
opt: fix star expansion of un-labeled tuples

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -1087,8 +1087,8 @@ query II colnames
 SELECT (unnest(ARRAY[(1,2),(3,4)])).*
 ----
 ?column?  ?column?
-1         1
-3         3
+1         2
+3         4
 
 query T colnames
 SELECT * FROM unnest(ARRAY[(1,2),(3,4)])

--- a/pkg/sql/opt/optbuilder/testdata/project
+++ b/pkg/sql/opt/optbuilder/testdata/project
@@ -229,3 +229,17 @@ project
  │    └── columns: k:1!null v:2
  └── projections
       └── ((v:2, v:2, v:2) AS a, b, c) [as=x:3]
+
+# Regression test for #48179. Star expansion of un-labeled tuple must project
+# all columns from the tuple.
+build
+SELECT (b).* FROM (VALUES (((1, 2)))) as a(b)
+----
+project
+ ├── columns: "?column?":2 "?column?":3
+ ├── values
+ │    ├── columns: column1:1
+ │    └── ((1, 2),)
+ └── projections
+      ├── (column1:1).@1 [as="?column?":2]
+      └── (column1:1).@2 [as="?column?":3]


### PR DESCRIPTION
Prior to this commit, there was a bug with star expansion of
un-labeled tuples in which only the first column of the tuple
was projected. This was happening because the name "?column?"
was being passed to `NewTypedColumnAccessExpr` for all columns in
the tuple, which made it impossible to determine that they were
actually different expressions. This commit fixes the issue by
ensuring that an empty column name is always passed to
`NewTypedColumnAccessExpr` when the tuple elements are unlabeled.
This signals that the tuple index should be used instead of the
name.

Fixes #48179

Release note (bug fix): Fixed a bug in which (tuple).* was only
expanded to the first column in the tuple and the remaining
elements were dropped.