### PR TITLE
sql: implement virtual index lookup join

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/orms
+++ b/pkg/sql/logictest/testdata/logic_test/orms
@@ -72,8 +72,8 @@ GROUP BY i.relname,
 ORDER BY i.relname
 ----
 name              primary  unique  indkey  column_indexes  column_names  definition
-customers_id_idx  false    false   2       {2,1}           {id,name}     CREATE INDEX customers_id_idx ON test.public.customers USING btree (id ASC)
-primary           true     true    1       {2,1}           {id,name}     CREATE UNIQUE INDEX "primary" ON test.public.customers USING btree (name ASC)
+customers_id_idx  false    false   2       {1,2}           {name,id}     CREATE INDEX customers_id_idx ON test.public.customers USING btree (id ASC)
+primary           true     true    1       {1,2}           {name,id}     CREATE UNIQUE INDEX "primary" ON test.public.customers USING btree (name ASC)
 
 
 query TT colnames
@@ -247,3 +247,20 @@ WHERE
     AND attname = 'a';
 ----
 a  57  true  false  false
+
+# Hibernate query.
+
+query TTTOBIIITTOT
+SELECT * FROM (SELECT n.nspname, c.relname, a.attname, a.atttypid, a.attnotnull OR ((t.typtype = 'd') AND t.typnotnull) AS attnotnull, a.atttypmod, a.attlen, row_number() OVER (PARTITION BY a.attrelid ORDER BY a.attnum) AS attnum, pg_get_expr(def.adbin, def.adrelid) AS adsrc, dsc.description, t.typbasetype, t.typtype FROM pg_catalog.pg_namespace AS n JOIN pg_catalog.pg_class AS c ON (c.relnamespace = n.oid) JOIN pg_catalog.pg_attribute AS a ON (a.attrelid = c.oid) JOIN pg_catalog.pg_type AS t ON (a.atttypid = t.oid) LEFT JOIN pg_catalog.pg_attrdef AS def ON ((a.attrelid = def.adrelid) AND (a.attnum = def.adnum)) LEFT JOIN pg_catalog.pg_description AS dsc ON ((c.oid = dsc.objoid) AND (a.attnum = dsc.objsubid)) LEFT JOIN pg_catalog.pg_class AS dc ON ((dc.oid = dsc.classoid) AND (dc.relname = 'pg_class')) LEFT JOIN pg_catalog.pg_namespace AS dn ON ((dc.relnamespace = dn.oid) AND (dn.nspname = 'pg_catalog')) WHERE (((c.relkind IN ('r', 'v', 'f', 'm')) AND (a.attnum > 0)) AND (NOT a.attisdropped)) AND (n.nspname LIKE 'public')) AS c;
+----
+public  a          id     20  false  -1  8   1  NULL            NULL  0  b
+public  a          name   25  false  -1  -1  2  NULL            NULL  0  b
+public  a          rowid  20  true   -1  8   3  unique_rowid()  NULL  0  b
+public  customers  name   25  true   -1  -1  1  NULL            NULL  0  b
+public  customers  id     20  false  -1  8   2  NULL            NULL  0  b
+public  b          id     20  false  -1  8   1  NULL            NULL  0  b
+public  b          a_id   20  false  -1  8   2  NULL            NULL  0  b
+public  b          rowid  20  true   -1  8   3  unique_rowid()  NULL  0  b
+public  c          a      20  true   -1  8   1  NULL            NULL  0  b
+public  c          b      20  true   -1  8   2  NULL            NULL  0  b
+public  metatest   a      20  true   -1  8   1  NULL            NULL  0  b

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2398,3 +2398,18 @@ select adnum from pg_attrdef WHERE adrelid = 85
 1
 3
 4
+
+# Check virtual table lookup joins.
+statement ok
+CREATE TABLE jt (a INT PRIMARY KEY); INSERT INTO jt VALUES(1); INSERT INTO jt VALUES('jt'::regclass::int)
+
+query ITT
+SELECT a, oid, relname FROM jt INNER LOOKUP JOIN pg_class ON a::oid=oid
+----
+86  86  jt
+
+query ITT
+SELECT a, oid, relname FROM jt LEFT OUTER LOOKUP JOIN pg_class ON a::oid=oid
+----
+1   NULL  NULL
+86  86    jt

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -369,38 +369,29 @@ render                        ·            ·
 query TTT
 EXPLAIN SHOW CONSTRAINTS FROM foo
 ----
-·                                                      distributed         false
-·                                                      vectorized          false
-render                                                 ·                   ·
- └── sort                                              ·                   ·
-      │                                                order               +conname
-      └── render                                       ·                   ·
-           └── hash-join                               ·                   ·
-                │                                      type                inner
-                │                                      equality            (oid) = (relnamespace)
-                ├── filter                             ·                   ·
-                │    │                                 filter              nspname = 'public'
-                │    └── render                        ·                   ·
-                │         └── virtual table            ·                   ·
-                │                                      source              pg_namespace@primary
-                └── merge-join                         ·                   ·
-                     │                                 type                inner
-                     │                                 equality            (conrelid) = (oid)
-                     │                                 left cols are key   ·
-                     │                                 right cols are key  ·
-                     │                                 mergeJoinOrder      +"(conrelid=oid)"
-                     ├── sort                          ·                   ·
-                     │    │                            order               +conrelid
-                     │    └── render                   ·                   ·
-                     │         └── virtual table       ·                   ·
-                     │                                 source              pg_constraint@pg_constraint_conrelid_idx
-                     └── filter                        ·                   ·
-                          │                            filter              relname = 'foo'
-                          └── sort                     ·                   ·
-                               │                       order               +oid
-                               └── render              ·                   ·
-                                    └── virtual table  ·                   ·
-·                                                      source              pg_class@pg_class_oid_idx
+·                                                 distributed  false
+·                                                 vectorized   false
+render                                            ·            ·
+ └── sort                                         ·            ·
+      │                                           order        +conname
+      └── render                                  ·            ·
+           └── hash-join                          ·            ·
+                │                                 type         inner
+                │                                 equality     (oid) = (relnamespace)
+                ├── filter                        ·            ·
+                │    │                            filter       nspname = 'public'
+                │    └── render                   ·            ·
+                │         └── virtual table       ·            ·
+                │                                 source       pg_namespace@primary
+                └── virtual-table-lookup-join     ·            ·
+                     │                            table        pg_constraint@pg_constraint_conrelid_idx
+                     │                            type         inner
+                     │                            equality     (oid) = (conrelid)
+                     └── filter                   ·            ·
+                          │                       filter       relname = 'foo'
+                          └── render              ·            ·
+                               └── virtual table  ·            ·
+·                                                 source       pg_class@primary
 
 query TTT
 EXPLAIN SHOW USERS

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -55,3 +55,100 @@ filter              ·            ·
  └── virtual table  ·            ·
 ·                   source       tables@tables_table_name_idx
 ·                   constraint   /4: [/'blah' - /'blah']
+
+# Lookup joins into virtual indexes.
+
+query TTT
+EXPLAIN SELECT * FROM pg_constraint INNER LOOKUP JOIN pg_class on conrelid=pg_class.oid
+----
+·                          distributed  false
+·                          vectorized   false
+virtual-table-lookup-join  ·            ·
+ │                         table        pg_class@pg_class_oid_idx
+ │                         type         inner
+ │                         equality     (conrelid) = (oid)
+ └── virtual table         ·            ·
+·                          source       pg_constraint@primary
+
+query TTT
+EXPLAIN SELECT * FROM pg_constraint LEFT LOOKUP JOIN pg_class on conrelid=pg_class.oid
+----
+·                          distributed  false
+·                          vectorized   false
+virtual-table-lookup-join  ·            ·
+ │                         table        pg_class@pg_class_oid_idx
+ │                         type         left outer
+ │                         equality     (conrelid) = (oid)
+ └── virtual table         ·            ·
+·                          source       pg_constraint@primary
+
+# Can't lookup into a vtable with no index.
+query error could not produce
+EXPLAIN SELECT * FROM pg_constraint INNER LOOKUP JOIN pg_index on true
+
+# Test that a gnarly ORM query from ActiveRecord uses lookup joins for speed.
+
+query TTT
+EXPLAIN SELECT
+        t2.oid::REGCLASS AS to_table,
+        a1.attname AS column,
+        a2.attname AS primary_key,
+        c.conname AS name,
+        c.confupdtype AS on_update,
+        c.confdeltype AS on_delete,
+        c.convalidated AS valid
+FROM
+        pg_constraint AS c
+        JOIN pg_class AS t1 ON c.conrelid = t1.oid
+        JOIN pg_class AS t2 ON c.confrelid = t2.oid
+        JOIN pg_attribute AS a1 ON
+                        (a1.attnum = c.conkey[1]) AND (a1.attrelid = t1.oid)
+        JOIN pg_attribute AS a2 ON
+                        (a2.attnum = c.confkey[1]) AND (a2.attrelid = t2.oid)
+        JOIN pg_namespace AS t3 ON c.connamespace = t3.oid
+WHERE
+        ((c.contype = 'f') AND (t1.oid = 'b'::regclass))
+        AND (t3.nspname = ANY (current_schemas(false)))
+ORDER BY
+        c.conname
+----
+·                                                                          distributed  false
+·                                                                          vectorized   false
+render                                                                     ·            ·
+ └── sort                                                                  ·            ·
+      │                                                                    order        +conname
+      └── render                                                           ·            ·
+           └── hash-join                                                   ·            ·
+                │                                                          type         inner
+                │                                                          equality     (oid) = (connamespace)
+                ├── filter                                                 ·            ·
+                │    │                                                     filter       nspname = ANY ARRAY['public']
+                │    └── render                                            ·            ·
+                │         └── virtual table                                ·            ·
+                │                                                          source       pg_namespace@primary
+                └── virtual-table-lookup-join                              ·            ·
+                     │                                                     table        pg_attribute@pg_attribute_attrelid_idx
+                     │                                                     type         inner
+                     │                                                     equality     (oid) = (attrelid)
+                     │                                                     pred         column131 = attnum
+                     └── render                                            ·            ·
+                          └── virtual-table-lookup-join                    ·            ·
+                               │                                           table        pg_attribute@pg_attribute_attrelid_idx
+                               │                                           type         inner
+                               │                                           equality     (oid) = (attrelid)
+                               │                                           pred         (column108 = attnum) AND (attrelid = 'b'::REGCLASS)
+                               └── render                                  ·            ·
+                                    └── virtual-table-lookup-join          ·            ·
+                                         │                                 table        pg_class@pg_class_oid_idx
+                                         │                                 type         inner
+                                         │                                 equality     (conrelid) = (oid)
+                                         │                                 pred         oid = 'b'::REGCLASS
+                                         └── virtual-table-lookup-join     ·            ·
+                                              │                            table        pg_class@pg_class_oid_idx
+                                              │                            type         inner
+                                              │                            equality     (confrelid) = (oid)
+                                              └── filter                   ·            ·
+                                                   │                       filter       (conrelid = 'b'::REGCLASS) AND (contype = 'f')
+                                                   └── render              ·            ·
+                                                        └── virtual table  ·            ·
+·                                                                          source       pg_constraint@primary

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -1318,9 +1318,6 @@ func (c *CustomFuncs) GenerateLookupJoins(
 		return
 	}
 	md := c.e.mem.Metadata()
-	if md.Table(scanPrivate.Table).IsVirtualTable() {
-		return
-	}
 	inputProps := input.Relational()
 
 	leftEq, rightEq := memo.ExtractJoinEqualityColumns(inputProps.OutputCols, scanPrivate.Cols, on)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -648,6 +648,9 @@ func (ef *execFactory) ConstructLookupJoin(
 	onCond tree.TypedExpr,
 	reqOrdering exec.OutputOrdering,
 ) (exec.Node, error) {
+	if table.IsVirtualTable() {
+		return ef.constructVirtualTableLookupJoin(joinType, input, table, index, eqCols, lookupCols, onCond)
+	}
 	tabDesc := table.(*optTable).desc
 	indexDesc := index.(*optIndex).desc
 	colCfg := makeScanColumnsConfig(table, lookupCols)
@@ -683,6 +686,75 @@ func (ef *execFactory) ConstructLookupJoin(
 	n.columns = make(sqlbase.ResultColumns, 0, len(inputCols)+len(scanCols))
 	n.columns = append(n.columns, inputCols...)
 	n.columns = append(n.columns, scanCols...)
+	return n, nil
+}
+
+func (ef *execFactory) constructVirtualTableLookupJoin(
+	joinType sqlbase.JoinType,
+	input exec.Node,
+	table cat.Table,
+	index cat.Index,
+	eqCols []exec.NodeColumnOrdinal,
+	lookupCols exec.TableColumnOrdinalSet,
+	onCond tree.TypedExpr,
+) (exec.Node, error) {
+	tn := &table.(*optVirtualTable).name
+	virtual, err := ef.planner.getVirtualTabler().getVirtualTableEntry(tn)
+	if err != nil {
+		return nil, err
+	}
+	if len(eqCols) > 1 {
+		return nil, errors.AssertionFailedf("vtable indexes with more than one column aren't supported yet")
+	}
+	// Check for explicit use of the dummy column.
+	if lookupCols.Contains(0) {
+		return nil, errors.Errorf("use of %s column not allowed.", table.Column(0).ColName())
+	}
+	indexDesc := index.(*optVirtualIndex).desc
+	tableDesc := table.(*optVirtualTable).desc
+	// Build the result columns.
+	inputCols := planColumns(input.(planNode))
+
+	if onCond == tree.DBoolTrue {
+		onCond = nil
+	}
+
+	var tableScan scanNode
+	// Set up a scanNode that we won't actually use, just to get the needed
+	// column analysis.
+	colCfg := makeScanColumnsConfig(table, lookupCols)
+	if err := tableScan.initTable(context.TODO(), ef.planner, tableDesc, nil, colCfg); err != nil {
+		return nil, err
+	}
+	tableScan.index = indexDesc
+	tableScan.isSecondaryIndex = true
+	vtableCols := sqlbase.ResultColumnsFromColDescs(tableDesc.ID, tableDesc.Columns)
+	projectedVtableCols := planColumns(&tableScan)
+	outputCols := make(sqlbase.ResultColumns, 0, len(inputCols)+len(projectedVtableCols))
+	outputCols = append(outputCols, inputCols...)
+	outputCols = append(outputCols, projectedVtableCols...)
+	// joinType is either INNER or LEFT_OUTER.
+	pred, err := makePredicate(joinType, inputCols, projectedVtableCols)
+	if err != nil {
+		return nil, err
+	}
+	pred.onCond = pred.iVarHelper.Rebind(
+		onCond, false /* alsoReset */, false, /* normalizeToNonNil */
+	)
+	n := &vTableLookupJoinNode{
+		input:             input.(planNode),
+		joinType:          joinType,
+		virtualTableEntry: virtual,
+		dbName:            tn.Catalog(),
+		table:             tableDesc.TableDesc(),
+		index:             indexDesc,
+		eqCol:             int(eqCols[0]),
+		inputCols:         inputCols,
+		vtableCols:        vtableCols,
+		lookupCols:        lookupCols,
+		columns:           outputCols,
+		pred:              pred,
+	}
 	return n, nil
 }
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1024,14 +1024,18 @@ func makeAllRelationsVirtualTableWithDescriptorIDIndex(
 				populate: func(ctx context.Context, constraint tree.Datum, p *planner, db *DatabaseDescriptor,
 					addRow func(...tree.Datum) error) (bool, error) {
 					var id sqlbase.ID
-					switch t := constraint.(type) {
+					d := tree.UnwrapDatum(p.EvalContext(), constraint)
+					if d == tree.DNull {
+						return false, nil
+					}
+					switch t := d.(type) {
 					case *tree.DOid:
 						id = sqlbase.ID(t.DInt)
 					case *tree.DInt:
 						id = sqlbase.ID(*t)
 					default:
 						return false, errors.AssertionFailedf("unexpected type %T for table id column in virtual table %s",
-							constraint, schemaDef)
+							d, schemaDef)
 					}
 					table, err := p.LookupTableByID(ctx, id)
 					if err != nil {

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -3007,7 +3007,7 @@ CREATE TABLE pg_catalog.pg_aggregate (
 								}
 							}
 						}
-						regprocForZeroOid := oidZero.AsRegProc("-")
+						regprocForZeroOid := tree.NewDOidWithName(tree.DInt(0), types.RegProc, "-")
 						err := addRow(
 							h.BuiltinOid(name, &overload).AsRegProc(name), // aggfnoid
 							aggregateKind,     // aggkind

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -89,6 +89,8 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.columns
 	case *zigzagJoinNode:
 		return n.columns
+	case *vTableLookupJoinNode:
+		return n.columns
 
 	// Nodes with a fixed schema.
 	case *scrubNode:


### PR DESCRIPTION
This commit adds the capability to plan inner lookup joins into virtual
tables with indexes. This should be a big boon to certain complex,
chained joins that tend to come up from ORMs querying database metadata.

Closes #48178.

Release note (performance improvement): the optimizer and execution
engine can now plan lookup joins into virtual indexes, avoiding full
scans against virtual tables.