### PR TITLE
kvclient: relax already-committed assertion

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -801,7 +801,7 @@ func (tc *TxnCoordSender) updateStateLocked(
 				// Finding out about our transaction being committed indicates a serious
 				// bug. Requests are not supposed to be sent on transactions after they
 				// are committed.
-				log.Fatalf(ctx, "transaction unexpectedly committed: %s. ba: %s. txn: %s.", pErr, ba, errTxn)
+				log.Errorf(ctx, "transaction unexpectedly committed: %s. ba: %s. txn: %s.", pErr, ba, errTxn)
 			}
 			// We only expect TransactionAbortedError to carry an aborted txn. In
 			// particular, the heartbeater doesn't like running when the transaction


### PR DESCRIPTION
The assertion we've added yesterday fires sometimes for rollbacks. I
think this is caused by context timeouts triggering a rollback, racing
with an in-flight commit. This patch just turns the fatal into an
errorf. I want to do something better; this is just temporary.

Fixes #48191
Fixes #48188
Fixes #48200
Fixes #48201
Fixes #48197

Release note: None