### PR TITLE
roachprod: fix command kind for `roachprod run`

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1238,7 +1238,7 @@ var runCmd = &cobra.Command{
 		if len(title) > 30 {
 			title = title[:27] + "..."
 		}
-		return c.Run(os.Stdout, os.Stderr, c.Nodes, install.CockroachCmd, title, cmd)
+		return c.Run(os.Stdout, os.Stderr, c.Nodes, install.OtherCmd, title, cmd)
 	}),
 }
 


### PR DESCRIPTION
It was previously an `install.CockroachCmd`, and it should be
`install.OtherCmd`, as we can run arbitrary other commands through it.
This came up in #46960, where failures of the running process (with an
exit code of 255) were captured as SSH errors, instead of just a failure
of the running process.

Release note: None.