### PR TITLE
util/protoutil: add missing newline symbol

### DIFF
--- a/pkg/util/protoutil/randnullability.go
+++ b/pkg/util/protoutil/randnullability.go
@@ -85,7 +85,7 @@ func RandomZeroInsertingVisitor(v reflect.Value) {
 		}
 		actual, loaded := insertZero.LoadOrStore(key, flipCoin())
 		if !loaded {
-			fmt.Printf("inserting null for (%v).%v: %t", typ, typ.Field(i).Name, actual)
+			fmt.Printf("inserting null for (%v).%v: %t\n", typ, typ.Field(i).Name, actual)
 		}
 		if b := actual.(bool); b {
 			hookInsertZero(v, i)


### PR DESCRIPTION
In a recent PR (#47583) I changed one "logging" function call from `log.Infof` to
`fmt.Printf`. While the discussion whether it is a sound decision is out
of scope for this commit, the change is missing a newline symbol which
messes up the output parsing and is now fixed.

Release note: None