### PR TITLE
kv: cleanup a few trace events during replica evaluation

### DIFF
--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -33,7 +33,6 @@ import (
 func (r *Replica) executeReadOnlyBatch(
 	ctx context.Context, ba *roachpb.BatchRequest, st storagepb.LeaseStatus, g *concurrency.Guard,
 ) (br *roachpb.BatchResponse, _ *concurrency.Guard, pErr *roachpb.Error) {
-	log.Event(ctx, "waiting for read lock")
 	r.readOnlyCmdMu.RLock()
 	defer r.readOnlyCmdMu.RUnlock()
 
@@ -121,6 +120,8 @@ func (r *Replica) executeReadOnlyBatchWithServersideRefreshes(
 	ba *roachpb.BatchRequest,
 	latchSpans *spanset.SpanSet,
 ) (br *roachpb.BatchResponse, res result.Result, pErr *roachpb.Error) {
+	log.Event(ctx, "executing read-only batch")
+
 	for retries := 0; ; retries++ {
 		if retries > 0 {
 			log.VEventf(ctx, 2, "server-side retry of batch")

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -316,6 +316,7 @@ func (r *Replica) evaluateWriteBatch(
 	ba *roachpb.BatchRequest,
 	latchSpans *spanset.SpanSet,
 ) (storage.Batch, enginepb.MVCCStats, *roachpb.BatchResponse, result.Result, *roachpb.Error) {
+	log.Event(ctx, "executing read-write batch")
 
 	// If the transaction has been pushed but it can commit at the higher
 	// timestamp, let's evaluate the batch at the bumped timestamp. This will


### PR DESCRIPTION
Removes a useless trace event and adds two helpful ones in.