### PR TITLE
opt: allow multiple expect[-not] options in rules

### DIFF
--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -630,16 +630,18 @@ func (f *Flags) Set(arg datadriven.CmdArg) error {
 		f.ExploreTraceSkipNoop = true
 
 	case "expect":
-		var err error
-		if f.ExpectedRules, err = ruleNamesToRuleSet(arg.Vals); err != nil {
+		ruleset, err := ruleNamesToRuleSet(arg.Vals)
+		if err != nil {
 			return err
 		}
+		f.ExpectedRules.UnionWith(ruleset)
 
 	case "expect-not":
-		var err error
-		if f.UnexpectedRules, err = ruleNamesToRuleSet(arg.Vals); err != nil {
+		ruleset, err := ruleNamesToRuleSet(arg.Vals)
+		if err != nil {
 			return err
 		}
+		f.UnexpectedRules.UnionWith(ruleset)
 
 	case "colstat":
 		if len(arg.Vals) == 0 {


### PR DESCRIPTION
Previously only the last was used, now they are merged.

Release note: None