### PR TITLE
release-20.1: sem/builtins: avoid an assertion error on legitimate errors

### DIFF
--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -473,7 +473,7 @@ func parsePrivilegeStr(arg tree.Datum, availOpts pgPrivList) (tree.Datum, error)
 	for _, priv := range privs {
 		d, err := availOpts[priv](false /* withGrantOpt */)
 		if err != nil {
-			return nil, errors.NewAssertionErrorWithWrappedErrf(err,
+			return nil, errors.Wrapf(err,
 				"error checking privilege %q", errors.Safe(priv))
 		}
 		switch d {


### PR DESCRIPTION
Backport 1/1 commits from #48216.

/cc @cockroachdb/release

---
(planning to hold off merging this until 20.1 is out)
