### PR TITLE
release-20.1: schemachange: more informative dependent job descriptions

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -393,7 +393,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				return pgerror.DangerousStatementf("ALTER TABLE DROP COLUMN will remove all data in that column")
 			}
 
-			col, dropped, err := n.tableDesc.FindColumnByName(t.Column)
+			colToDrop, dropped, err := n.tableDesc.FindColumnByName(t.Column)
 			if err != nil {
 				if t.IfExists {
 					// Noop.
@@ -406,19 +406,19 @@ func (n *alterTableNode) startExec(params runParams) error {
 			}
 
 			// If the dropped column uses a sequence, remove references to it from that sequence.
-			if len(col.UsesSequenceIds) > 0 {
-				if err := params.p.removeSequenceDependencies(params.ctx, n.tableDesc, col); err != nil {
+			if len(colToDrop.UsesSequenceIds) > 0 {
+				if err := params.p.removeSequenceDependencies(params.ctx, n.tableDesc, colToDrop); err != nil {
 					return err
 				}
 			}
 
 			// You can't remove a column that owns a sequence that is depended on
 			// by another column
-			if err := params.p.canRemoveAllColumnOwnedSequences(params.ctx, n.tableDesc, col, t.DropBehavior); err != nil {
+			if err := params.p.canRemoveAllColumnOwnedSequences(params.ctx, n.tableDesc, colToDrop, t.DropBehavior); err != nil {
 				return err
 			}
 
-			if err := params.p.dropSequencesOwnedByCol(params.ctx, col); err != nil {
+			if err := params.p.dropSequencesOwnedByCol(params.ctx, colToDrop); err != nil {
 				return err
 			}
 
@@ -427,7 +427,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			for _, ref := range n.tableDesc.DependedOnBy {
 				found := false
 				for _, colID := range ref.ColumnIDs {
-					if colID == col.ID {
+					if colID == colToDrop.ID {
 						found = true
 						break
 					}
@@ -447,15 +447,17 @@ func (n *alterTableNode) startExec(params runParams) error {
 				if err != nil {
 					return err
 				}
-				droppedViews, err = params.p.removeDependentView(params.ctx, n.tableDesc, viewDesc)
+				jobDesc := fmt.Sprintf("removing view %q dependent on column %q which is being dropped",
+					viewDesc.Name, colToDrop.ColName())
+				droppedViews, err = params.p.removeDependentView(params.ctx, n.tableDesc, viewDesc, jobDesc)
 				if err != nil {
 					return err
 				}
 			}
 
-			if n.tableDesc.PrimaryIndex.ContainsColumnID(col.ID) {
+			if n.tableDesc.PrimaryIndex.ContainsColumnID(colToDrop.ID) {
 				return pgerror.Newf(pgcode.InvalidColumnReference,
-					"column %q is referenced by the primary key", col.Name)
+					"column %q is referenced by the primary key", colToDrop.Name)
 			}
 			for _, idx := range n.tableDesc.AllNonDropIndexes() {
 				// We automatically drop indexes on that column that only
@@ -481,7 +483,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 
 				// Analyze the index.
 				for _, id := range idx.ColumnIDs {
-					if id == col.ID {
+					if id == colToDrop.ID {
 						containsThisColumn = true
 					} else {
 						containsOnlyThisColumn = false
@@ -496,7 +498,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 						// sufficient reason to reject the DROP.
 						continue
 					}
-					if id == col.ID {
+					if id == colToDrop.ID {
 						containsThisColumn = true
 					}
 				}
@@ -504,7 +506,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				// loop below is for the new encoding (where the STORING columns are
 				// always in the value part of a KV).
 				for _, id := range idx.StoreColumnIDs {
-					if id == col.ID {
+					if id == colToDrop.ID {
 						containsThisColumn = true
 					}
 				}
@@ -512,16 +514,18 @@ func (n *alterTableNode) startExec(params runParams) error {
 				// Perform the DROP.
 				if containsThisColumn {
 					if containsOnlyThisColumn || t.DropBehavior == tree.DropCascade {
+						jobDesc := fmt.Sprintf("removing index %q dependent on column %q which is being"+
+							" dropped; full details: %s", idx.Name, colToDrop.ColName(),
+							tree.AsStringWithFQNames(n.n, params.Ann()))
 						if err := params.p.dropIndexByName(
 							params.ctx, tn, tree.UnrestrictedName(idx.Name), n.tableDesc, false,
-							t.DropBehavior, ignoreIdxConstraint,
-							tree.AsStringWithFQNames(n.n, params.Ann()),
+							t.DropBehavior, ignoreIdxConstraint, jobDesc,
 						); err != nil {
 							return err
 						}
 					} else {
 						return pgerror.Newf(pgcode.InvalidColumnReference,
-							"column %q is referenced by existing index %q", col.Name, idx.Name)
+							"column %q is referenced by existing index %q", colToDrop.Name, idx.Name)
 					}
 				}
 			}
@@ -532,7 +536,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			// indexes in the same way, FKs will have to be dropped separately here.
 			validChecks := n.tableDesc.Checks[:0]
 			for _, check := range n.tableDesc.AllActiveAndInactiveChecks() {
-				if used, err := check.UsesColumn(n.tableDesc.TableDesc(), col.ID); err != nil {
+				if used, err := check.UsesColumn(n.tableDesc.TableDesc(), colToDrop.ID); err != nil {
 					return err
 				} else if used {
 					if check.Validity == sqlbase.ConstraintValidity_Validating {
@@ -552,14 +556,14 @@ func (n *alterTableNode) startExec(params runParams) error {
 			if err != nil {
 				return err
 			}
-			if err := params.p.removeColumnComment(params.ctx, n.tableDesc.ID, col.ID); err != nil {
+			if err := params.p.removeColumnComment(params.ctx, n.tableDesc.ID, colToDrop.ID); err != nil {
 				return err
 			}
 
 			found := false
 			for i := range n.tableDesc.Columns {
-				if n.tableDesc.Columns[i].ID == col.ID {
-					n.tableDesc.AddColumnMutation(col, sqlbase.DescriptorMutation_DROP)
+				if n.tableDesc.Columns[i].ID == colToDrop.ID {
+					n.tableDesc.AddColumnMutation(colToDrop, sqlbase.DescriptorMutation_DROP)
 					// Use [:i:i] to prevent reuse of existing slice, or outstanding refs
 					// to ColumnDescriptors may unexpectedly change.
 					n.tableDesc.Columns = append(n.tableDesc.Columns[:i:i], n.tableDesc.Columns[i+1:]...)

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -409,7 +409,9 @@ func (p *planner) dropIndexByName(
 			if err != nil {
 				return err
 			}
-			cascadedViews, err := p.removeDependentView(ctx, tableDesc, viewDesc)
+			viewJobDesc := fmt.Sprintf("removing view %q dependent on index %q which is being dropped",
+				viewDesc.Name, idx.Name)
+			cascadedViews, err := p.removeDependentView(ctx, tableDesc, viewDesc, viewJobDesc)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -164,14 +164,13 @@ func (p *planner) canRemoveDependentViewGeneric(
 // Returns the names of any additional views that were also dropped
 // due to `cascade` behavior.
 func (p *planner) removeDependentView(
-	ctx context.Context, tableDesc, viewDesc *sqlbase.MutableTableDescriptor,
+	ctx context.Context, tableDesc, viewDesc *sqlbase.MutableTableDescriptor, jobDesc string,
 ) ([]string, error) {
 	// In the table whose index is being removed, filter out all back-references
 	// that refer to the view that's being removed.
 	tableDesc.DependedOnBy = removeMatchingReferences(tableDesc.DependedOnBy, viewDesc.ID)
 	// Then proceed to actually drop the view and log an event for it.
-	// TODO (lucy): Have more consistent/informative names for dependent jobs.
-	return p.dropViewImpl(ctx, viewDesc, true /* queueJob */, "dropping dependent view", tree.DropCascade)
+	return p.dropViewImpl(ctx, viewDesc, true /* queueJob */, jobDesc, tree.DropCascade)
 }
 
 // dropViewImpl does the work of dropping a view (and views that depend on it
@@ -199,7 +198,7 @@ func (p *planner) dropViewImpl(
 			continue
 		}
 		dependencyDesc.DependedOnBy = removeMatchingReferences(dependencyDesc.DependedOnBy, viewDesc.ID)
-		// TODO (lucy): Have more consistent/informative names for dependent jobs.
+		// TODO (lucy): have more consistent/informative names for dependent jobs.
 		if err := p.writeSchemaChange(
 			ctx, dependencyDesc, sqlbase.InvalidMutationID, "removing references for view",
 		); err != nil {

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -29,7 +29,7 @@ ReadyForQuery
 ----
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
-{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":482,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":484,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -12,6 +12,7 @@ package sql
 
 import (
 	"context"
+	"fmt"
 	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -473,9 +474,10 @@ func (p *planner) dropSequencesOwnedByCol(
 		if err != nil {
 			return err
 		}
-		// TODO (lucy): Have more consistent/informative names for dependent jobs.
+		jobDesc := fmt.Sprintf("removing sequence %q dependent on column %q which is being dropped",
+			seqDesc.Name, col.ColName())
 		if err := p.dropSequenceImpl(
-			ctx, seqDesc, true /* queueJob */, "dropping dependent sequence", tree.DropRestrict,
+			ctx, seqDesc, true /* queueJob */, jobDesc, tree.DropRestrict,
 		); err != nil {
 			return err
 		}
@@ -535,9 +537,10 @@ func (p *planner) removeSequenceDependencies(
 				seqDesc.DependedOnBy[refTableIdx+1:]...)
 		}
 
-		// TODO (lucy): Have more consistent/informative names for dependent jobs.
+		jobDesc := fmt.Sprintf("removing sequence %q dependent on column %q which is being dropped",
+			seqDesc.Name, col.ColName())
 		if err := p.writeSchemaChange(
-			ctx, seqDesc, sqlbase.InvalidMutationID, "removing sequence dependency",
+			ctx, seqDesc, sqlbase.InvalidMutationID, jobDesc,
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
Backport 1/1 commits from #48163.

/cc @cockroachdb/release

---

`DROP xxx` statements have cascading effects of causing sequences, indexes
and views being dropped as well. We should name the jobs that execute them
accordingly so that it is clear to users that they are connected to the
inital `DROP` statement.

Fixes #35051.

Release note (bug fix): Better distinguish between the delete jobs for
columns and dependent jobs for deleting indices, views and sequences. In the
current state clients were confused why more than 1 job was created from
a `DROP COLUMN` statement.
