### PR TITLE
release-19.2: deps: bump cockroachdb/errors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -376,7 +376,8 @@
   revision = "edce558372380347c6fef147e62f5559a9f8413d"
 
 [[projects]]
-  digest = "1:35ff61e02c035785971ac6ec04d54428307a986412e5d0aea86b8b7f45677d09"
+  branch = "v1.2.4-cockroach20.1"
+  digest = "1:f4441cc580b6f69ff82a4130589b43cf4b14883e9f090db66f9c4ad337b41ee4"
   name = "github.com/cockroachdb/errors"
   packages = [
     ".",
@@ -399,8 +400,7 @@
     "withstack",
   ]
   pruneopts = "UT"
-  revision = "7ba395ace80575c71104187a222f77bf23c19326"
-  version = "v1.2.3"
+  revision = "5f3a6d1e1cf5d5d6212d56dc3833d6d57c7545e4"
 
 [[projects]]
   digest = "1:cd936a7edd1897083994b6d397f9c975a5a8dc58e845f0cf3d1e5cf4717b918b"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,6 +37,10 @@ ignored = [
   revision = "470f45bf29f4147d6fbd7dfd0a02a848e49f5bf4"
 
 [[constraint]]
+  name = "github.com/cockroachdb/errors"
+  branch = "v1.2.4-cockroach20.1"
+
+[[constraint]]
   name = "go.etcd.io/etcd"
   # The last time this was bumped forward, it was for a targeted fix of #40207,
   # which temporarily prevented us from being compatible with etcd's HEAD. The

--- a/pkg/util/errorutil/error_test.go
+++ b/pkg/util/errorutil/error_test.go
@@ -39,7 +39,7 @@ func TestUnexpectedWithIssueErrorf(t *testing.T) {
 	}
 
 	// Check that the issue number is present in the safe details.
-	exp = "safe details: issue #%d\n    -- arg 1: 1234"
+	exp = "4 safe details enclosed"
 	if !strings.Contains(safeMsg, exp) {
 		t.Errorf("expected substring in error\n%s\ngot:\n%s", exp, safeMsg)
 	}

--- a/pkg/util/grpcutil/grpc_util.go
+++ b/pkg/util/grpcutil/grpc_util.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
@@ -77,13 +77,11 @@ func IsClosedConnection(err error) bool {
 // TODO(bdarnell): Replace this with a cleaner mechanism when/if
 // https://github.com/grpc/grpc-go/issues/1443 is resolved.
 func RequestDidNotStart(err error) bool {
-	if _, ok := err.(connectionNotReadyError); ok {
+	if errors.HasType(err, connectionNotReadyError{}) ||
+		errors.HasType(err, (*netutil.InitialHeartbeatFailedError)(nil)) {
 		return true
 	}
-	if _, ok := err.(*netutil.InitialHeartbeatFailedError); ok {
-		return true
-	}
-	s, ok := status.FromError(err)
+	s, ok := status.FromError(errors.Cause(err))
 	if !ok {
 		// This is a non-gRPC error; assume nothing.
 		return false

--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -178,12 +178,11 @@ var _ error = (*InitialHeartbeatFailedError)(nil)
 var _ fmt.Formatter = (*InitialHeartbeatFailedError)(nil)
 var _ errors.Formatter = (*InitialHeartbeatFailedError)(nil)
 
-// Note: Error is not a causer. If this is changed to implement
-// Cause()/Unwrap(), change the type assertions in package cli and
-// elsewhere to use errors.As() or equivalent.
-
 // Error implements error.
 func (e *InitialHeartbeatFailedError) Error() string { return fmt.Sprintf("%v", e) }
+
+// Cause implements causer.
+func (e *InitialHeartbeatFailedError) Cause() error { return e.WrappedErr }
 
 // Format implements fmt.Formatter.
 func (e *InitialHeartbeatFailedError) Format(s fmt.State, verb rune) { errors.FormatError(e, s, verb) }


### PR DESCRIPTION
Fixes #48247.
Fixes #47738.

This picks up a few bug fixes, in particular `errors.Cause()` should be equivalent to `errors.UnwrapAll()` (for compatibility with pkg/errors). This is what caused the regression when #47691 was merged.

