### PR TITLE
sql: support cascades that have checks

### DIFF
--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -269,7 +269,7 @@ func runPlanInsidePlan(
 	planCtx.stmtType = recv.stmtType
 
 	params.p.extendedEvalCtx.ExecCfg.DistSQLPlanner.PlanAndRun(
-		params.ctx, evalCtx, planCtx, params.p.Txn(), plan.plan, recv,
+		params.ctx, evalCtx, planCtx, params.p.Txn(), plan.main, recv,
 	)()
 	if recv.commErr != nil {
 		return recv.commErr

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -729,7 +729,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 
 	var cols sqlbase.ResultColumns
 	if stmt.AST.StatementType() == tree.Rows {
-		cols = planColumns(planner.curPlan.plan)
+		cols = planColumns(planner.curPlan.main)
 	}
 	if err := ex.initStatementResult(ctx, res, stmt, cols); err != nil {
 		res.SetError(err)
@@ -740,7 +740,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	distributePlan := false
 	if _, noMultiTenancy := planner.execCfg.NodeID.OptionalNodeID(); noMultiTenancy {
 		distributePlan = shouldDistributePlan(
-			ctx, ex.sessionData.DistSQLMode, ex.server.cfg.DistSQLPlanner, planner.curPlan.plan)
+			ctx, ex.sessionData.DistSQLMode, ex.server.cfg.DistSQLPlanner, planner.curPlan.main)
 	}
 	ex.sessionTracing.TracePlanCheckEnd(ctx, nil, distributePlan)
 
@@ -889,7 +889,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 	// We pass in whether or not we wanted to distribute this plan, which tells
 	// the planner whether or not to plan remote table readers.
 	cleanup := ex.server.cfg.DistSQLPlanner.PlanAndRun(
-		ctx, evalCtx, planCtx, planner.txn, planner.curPlan.plan, recv,
+		ctx, evalCtx, planCtx, planner.txn, planner.curPlan.main, recv,
 	)
 	// Note that we're not cleaning up right away because postqueries might
 	// need to have access to the main query tree.

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -898,11 +898,9 @@ func (ex *connExecutor) execWithDistSQLEngine(
 		return recv.bytesRead, recv.rowsRead, recv.commErr
 	}
 
-	if len(planner.curPlan.checkPlans) > 0 || len(planner.curPlan.cascades) > 0 {
-		ex.server.cfg.DistSQLPlanner.PlanAndRunPostqueries(
-			ctx, planner, evalCtxFactory, planner.curPlan.cascades, planner.curPlan.checkPlans, recv, distribute,
-		)
-	}
+	ex.server.cfg.DistSQLPlanner.PlanAndRunCascadesAndChecks(
+		ctx, planner, evalCtxFactory, &planner.curPlan.planComponents, recv, distribute,
+	)
 
 	return recv.bytesRead, recv.rowsRead, recv.commErr
 }

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
@@ -1020,28 +1019,37 @@ func (dsp *DistSQLPlanner) PlanAndRun(
 	return dsp.Run(planCtx, txn, &physPlan, recv, evalCtx, nil /* finishedSetupFn */)
 }
 
-// PlanAndRunPostqueries runs any cascade and check queries.
+// PlanAndRunCascadesAndChecks runs any cascade and check queries.
+//
+// Because cascades can themselves generate more cascades or check queries, this
+// method can append to plan.cascades and plan.checkPlans (and all these plans
+// must be closed later).
 //
 // Returns false if an error was encountered and sets that error in the provided
 // receiver.
-func (dsp *DistSQLPlanner) PlanAndRunPostqueries(
+func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 	ctx context.Context,
 	planner *planner,
 	evalCtxFactory func() *extendedEvalContext,
-	cascades []exec.Cascade,
-	checkPlans []checkPlan,
+	plan *planComponents,
 	recv *DistSQLReceiver,
 	maybeDistribute bool,
 ) bool {
+	if len(plan.cascades) == 0 && len(plan.checkPlans) == 0 {
+		return false
+	}
+
 	prevSteppingMode := planner.Txn().ConfigureStepping(ctx, kv.SteppingEnabled)
 	defer func() { _ = planner.Txn().ConfigureStepping(ctx, prevSteppingMode) }()
 
-	for i := range cascades {
-		cascade := &cascades[i]
-
+	// We treat plan.cascades as a queue.
+	for i := 0; i < len(plan.cascades); i++ {
 		// The original bufferNode is stored in c.Buffer; we can refer to it
 		// directly.
-		buf := cascade.Buffer.(*bufferNode)
+		// TODO(radu): this requires keeping all previous plans "alive" until the
+		// very end. We may want to make copies of the buffer nodes and clean up
+		// everything else.
+		buf := plan.cascades[i].Buffer.(*bufferNode)
 		if buf.bufferedRows.Len() == 0 {
 			// No rows were actually modified.
 			continue
@@ -1057,7 +1065,7 @@ func (dsp *DistSQLPlanner) PlanAndRunPostqueries(
 
 		evalCtx := evalCtxFactory()
 		execFactory := makeExecFactory(planner)
-		cascadePlan, err := cascade.PlanFn(
+		cascadePlan, err := plan.cascades[i].PlanFn(
 			ctx, &planner.semaCtx, &evalCtx.EvalContext, &execFactory, buf, buf.bufferedRows.Len(),
 		)
 		if err != nil {
@@ -1065,16 +1073,22 @@ func (dsp *DistSQLPlanner) PlanAndRunPostqueries(
 			return false
 		}
 		cp := cascadePlan.(*planTop)
+		plan.cascades[i].plan = cp.main
+		if len(cp.subqueryPlans) > 0 {
+			recv.SetError(errors.AssertionFailedf("cascades should not have subqueries"))
+			return false
+		}
+
+		// Queue any new cascades.
 		if len(cp.cascades) > 0 {
 			// TODO(radu): append cascade, effectively making this a queue.
 			recv.SetError(errors.Newf("cascading not implemented yet"))
 			return false
 		}
+
+		// Collect any new checks.
 		if len(cp.checkPlans) > 0 {
-			// TODO(radu): append to checkPlans. But we need to make sure that it will
-			// be properly cleaned up at the end.
-			recv.SetError(errors.Newf("cascades with checks not implemented yet"))
-			return false
+			plan.checkPlans = append(plan.checkPlans, cp.checkPlans...)
 		}
 
 		if err := dsp.planAndRunPostquery(
@@ -1090,7 +1104,7 @@ func (dsp *DistSQLPlanner) PlanAndRunPostqueries(
 		}
 	}
 
-	if len(checkPlans) == 0 {
+	if len(plan.checkPlans) == 0 {
 		return true
 	}
 
@@ -1101,10 +1115,10 @@ func (dsp *DistSQLPlanner) PlanAndRunPostqueries(
 		return false
 	}
 
-	for _, checkPlan := range checkPlans {
+	for i := range plan.checkPlans {
 		if err := dsp.planAndRunPostquery(
 			ctx,
-			checkPlan.plan,
+			plan.checkPlans[i].plan,
 			planner,
 			evalCtxFactory(),
 			recv,

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1079,7 +1079,7 @@ func (dsp *DistSQLPlanner) PlanAndRunPostqueries(
 
 		if err := dsp.planAndRunPostquery(
 			ctx,
-			cp.plan,
+			cp.main,
 			planner,
 			evalCtx,
 			recv,

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -164,7 +164,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 		planCtx.stmtType = recv.stmtType
 
 		execCfg.DistSQLPlanner.PlanAndRun(
-			ctx, evalCtx, planCtx, txn, p.curPlan.plan, recv,
+			ctx, evalCtx, planCtx, txn, p.curPlan.main, recv,
 		)()
 		return rw.Err()
 	})

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -237,12 +237,11 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 			},
 			params.extendedEvalCtx.Tracing,
 		)
-		if !distSQLPlanner.PlanAndRunPostqueries(
+		if !distSQLPlanner.PlanAndRunCascadesAndChecks(
 			planCtx.ctx,
 			params.p,
 			params.extendedEvalCtx.copy,
-			nil, /* cascades */
-			n.plan.checkPlans,
+			&n.plan,
 			recv,
 			true,
 		) {

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -28,11 +27,8 @@ import (
 type explainDistSQLNode struct {
 	optColumnsSlot
 
-	options       *tree.ExplainOptions
-	plan          planNode
-	subqueryPlans []subquery
-	cascades      []exec.Cascade
-	checkPlans    []checkPlan
+	options *tree.ExplainOptions
+	plan    planComponents
 
 	stmtType tree.StatementType
 
@@ -69,14 +65,14 @@ type distSQLExplainable interface {
 
 func (n *explainDistSQLNode) startExec(params runParams) error {
 	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
-	shouldPlanDistribute, recommendation := willDistributePlan(distSQLPlanner, n.plan, params)
+	shouldPlanDistribute, recommendation := willDistributePlan(distSQLPlanner, n.plan.main, params)
 	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx, params.p.txn)
 	planCtx.isLocal = !shouldPlanDistribute
 	planCtx.ignoreClose = true
 	planCtx.planner = params.p
 	planCtx.stmtType = n.stmtType
 
-	if n.analyze && len(n.cascades) > 0 {
+	if n.analyze && len(n.plan.cascades) > 0 {
 		return errors.New("running EXPLAIN ANALYZE (DISTSQL) on this query is " +
 			"unsupported because of the presence of cascades")
 	}
@@ -86,12 +82,12 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 	// original text in the plan.
 	planCtx.noEvalSubqueries = !n.analyze
 
-	if n.analyze && len(n.subqueryPlans) > 0 {
+	if n.analyze && len(n.plan.subqueryPlans) > 0 {
 		outerSubqueries := planCtx.planner.curPlan.subqueryPlans
 		defer func() {
 			planCtx.planner.curPlan.subqueryPlans = outerSubqueries
 		}()
-		planCtx.planner.curPlan.subqueryPlans = n.subqueryPlans
+		planCtx.planner.curPlan.subqueryPlans = n.plan.subqueryPlans
 
 		// Discard rows that are returned.
 		rw := newCallbackResultWriter(func(ctx context.Context, row tree.Datums) error {
@@ -114,7 +110,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 			planCtx.ctx,
 			params.p,
 			params.extendedEvalCtx.copy,
-			n.subqueryPlans,
+			n.plan.subqueryPlans,
 			recv,
 			true,
 		) {
@@ -125,9 +121,9 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 		}
 	}
 
-	plan, err := makePhysicalPlan(planCtx, distSQLPlanner, n.plan)
+	plan, err := makePhysicalPlan(planCtx, distSQLPlanner, n.plan.main)
 	if err != nil {
-		if len(n.subqueryPlans) > 0 {
+		if len(n.plan.subqueryPlans) > 0 {
 			return errors.New("running EXPLAIN (DISTSQL) on this query is " +
 				"unsupported because of the presence of subqueries")
 		}
@@ -217,12 +213,12 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 		}
 	}
 
-	if n.analyze && len(n.checkPlans) > 0 {
+	if n.analyze && len(n.plan.checkPlans) > 0 {
 		outerChecks := planCtx.planner.curPlan.checkPlans
 		defer func() {
 			planCtx.planner.curPlan.checkPlans = outerChecks
 		}()
-		planCtx.planner.curPlan.checkPlans = n.checkPlans
+		planCtx.planner.curPlan.checkPlans = n.plan.checkPlans
 
 		// Discard rows that are returned.
 		rw := newCallbackResultWriter(func(ctx context.Context, row tree.Datums) error {
@@ -246,7 +242,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 			params.p,
 			params.extendedEvalCtx.copy,
 			nil, /* cascades */
-			n.checkPlans,
+			n.plan.checkPlans,
 			recv,
 			true,
 		) {
@@ -280,21 +276,7 @@ func (n *explainDistSQLNode) Next(runParams) (bool, error) {
 
 func (n *explainDistSQLNode) Values() tree.Datums { return n.run.values }
 func (n *explainDistSQLNode) Close(ctx context.Context) {
-	n.plan.Close(ctx)
-	for i := range n.subqueryPlans {
-		// Once a subquery plan has been evaluated, it already closes its plan.
-		if n.subqueryPlans[i].plan != nil {
-			n.subqueryPlans[i].plan.Close(ctx)
-			n.subqueryPlans[i].plan = nil
-		}
-	}
-	for i := range n.checkPlans {
-		// Once a check plan plan has been evaluated, it already closes its plan.
-		if n.checkPlans[i].plan != nil {
-			n.checkPlans[i].plan.Close(ctx)
-			n.checkPlans[i].plan = nil
-		}
-	}
+	n.plan.close(ctx)
 }
 
 // willDistributePlan checks if the given plan will run with distributed

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -43,8 +43,7 @@ const (
 type explainPlanNode struct {
 	explainer explainer
 
-	// plan is the sub-node being explained.
-	plan planNode
+	plan planComponents
 
 	// subqueryPlans contains the subquery plans for the explained query.
 	subqueryPlans []subquery
@@ -63,13 +62,7 @@ type explainPlanNode struct {
 // makeExplainPlanNodeWithPlan instantiates a planNode that EXPLAINs an
 // underlying plan.
 func (p *planner) makeExplainPlanNodeWithPlan(
-	ctx context.Context,
-	opts *tree.ExplainOptions,
-	plan planNode,
-	subqueryPlans []subquery,
-	cascades []exec.Cascade,
-	checkPlans []checkPlan,
-	stmtType tree.StatementType,
+	ctx context.Context, opts *tree.ExplainOptions, plan *planComponents, stmtType tree.StatementType,
 ) (planNode, error) {
 	flags := explainFlags{
 		symbolicVars: opts.Flags[tree.ExplainFlagSymVars],
@@ -114,12 +107,9 @@ func (p *planner) makeExplainPlanNodeWithPlan(
 	}
 
 	node := &explainPlanNode{
-		explainer:     e,
-		plan:          plan,
-		subqueryPlans: subqueryPlans,
-		cascades:      cascades,
-		checkPlans:    checkPlans,
-		stmtType:      stmtType,
+		explainer: e,
+		plan:      *plan,
+		stmtType:  stmtType,
 		run: explainPlanRun{
 			results: p.newContainerValuesNode(columns, 0),
 		},
@@ -134,23 +124,19 @@ type explainPlanRun struct {
 }
 
 func (e *explainPlanNode) startExec(params runParams) error {
-	return populateExplain(
-		params, &e.explainer, e.run.results,
-		e.plan, e.subqueryPlans, e.cascades, e.checkPlans,
-		e.stmtType,
-	)
+	return populateExplain(params, &e.explainer, e.run.results, &e.plan, e.stmtType)
 }
 
 func (e *explainPlanNode) Next(params runParams) (bool, error) { return e.run.results.Next(params) }
 func (e *explainPlanNode) Values() tree.Datums                 { return e.run.results.Values() }
 
 func (e *explainPlanNode) Close(ctx context.Context) {
-	e.plan.Close(ctx)
+	e.plan.main.Close(ctx)
 	for i := range e.subqueryPlans {
-		e.subqueryPlans[i].plan.Close(ctx)
+		e.plan.subqueryPlans[i].plan.Close(ctx)
 	}
 	for i := range e.checkPlans {
-		e.checkPlans[i].plan.Close(ctx)
+		e.plan.checkPlans[i].plan.Close(ctx)
 	}
 	e.run.results.Close(ctx)
 }
@@ -208,26 +194,19 @@ type explainer struct {
 // The subquery plans, if any are known to the planner, are printed
 // at the bottom.
 func populateExplain(
-	params runParams,
-	e *explainer,
-	v *valuesNode,
-	plan planNode,
-	subqueryPlans []subquery,
-	cascades []exec.Cascade,
-	checkPlans []checkPlan,
-	stmtType tree.StatementType,
+	params runParams, e *explainer, v *valuesNode, plan *planComponents, stmtType tree.StatementType,
 ) error {
 	// Determine the "distributed" and "vectorized" values, which we will emit as
 	// special rows.
 	var isDistSQL, isVec bool
 	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
-	isDistSQL, _ = willDistributePlan(distSQLPlanner, plan, params)
+	isDistSQL, _ = willDistributePlan(distSQLPlanner, plan.main, params)
 	outerSubqueries := params.p.curPlan.subqueryPlans
-	planCtx := makeExplainVecPlanningCtx(distSQLPlanner, params, stmtType, subqueryPlans, isDistSQL)
+	planCtx := makeExplainVecPlanningCtx(distSQLPlanner, params, stmtType, plan.subqueryPlans, isDistSQL)
 	defer func() {
 		planCtx.planner.curPlan.subqueryPlans = outerSubqueries
 	}()
-	physicalPlan, err := makePhysicalPlan(planCtx, distSQLPlanner, plan)
+	physicalPlan, err := makePhysicalPlan(planCtx, distSQLPlanner, plan.main)
 	if err == nil {
 		// There might be an issue making the physical plan, but that should not
 		// cause an error or panic, so swallow the error. See #40677 for example.
@@ -296,17 +275,12 @@ func populateExplain(
 		return err
 	}
 
-	e.populateEntries(params.ctx, plan, subqueryPlans, cascades, checkPlans, explainSubqueryFmtFlags)
+	e.populateEntries(params.ctx, plan, explainSubqueryFmtFlags)
 	return e.emitRows(emitRow)
 }
 
 func (e *explainer) populateEntries(
-	ctx context.Context,
-	plan planNode,
-	subqueryPlans []subquery,
-	cascades []exec.Cascade,
-	checkPlans []checkPlan,
-	subqueryFmtFlags tree.FmtFlags,
+	ctx context.Context, plan *planComponents, subqueryFmtFlags tree.FmtFlags,
 ) {
 	e.entries = nil
 	observer := planObserver{
@@ -317,39 +291,34 @@ func (e *explainer) populateEntries(
 		leaveNode: e.leaveNode,
 	}
 	// observePlan never returns an error when returnError is false.
-	_ = observePlan(
-		ctx, plan, subqueryPlans, cascades, checkPlans,
-		observer, false /* returnError */, subqueryFmtFlags,
-	)
+	_ = observePlan(ctx, plan, observer, false /* returnError */, subqueryFmtFlags)
 }
 
 // observePlan walks the plan tree, executing the appropriate functions in the
 // planObserver.
 func observePlan(
 	ctx context.Context,
-	plan planNode,
-	subqueryPlans []subquery,
-	cascades []exec.Cascade,
-	checkPlans []checkPlan,
+	plan *planComponents,
 	observer planObserver,
 	returnError bool,
 	subqueryFmtFlags tree.FmtFlags,
 ) error {
 	// If there are any subqueries, cascades, or checks in the plan, we
 	// enclose everything as children of a virtual "root" node.
-	if len(subqueryPlans) > 0 || len(cascades) > 0 || len(checkPlans) > 0 {
-		if _, err := observer.enterNode(ctx, "root", plan); err != nil && returnError {
+	if len(plan.subqueryPlans) > 0 || len(plan.cascades) > 0 || len(plan.checkPlans) > 0 {
+		if _, err := observer.enterNode(ctx, "root", plan.main); err != nil && returnError {
 			return err
 		}
 	}
 
 	// Explain the main plan.
-	if err := walkPlan(ctx, plan, observer); err != nil && returnError {
+	if err := walkPlan(ctx, plan.main, observer); err != nil && returnError {
 		return err
 	}
 
 	// Explain the subqueries.
-	for i := range subqueryPlans {
+	for i := range plan.subqueryPlans {
+		s := &plan.subqueryPlans[i]
 		if _, err := observer.enterNode(ctx, "subquery", nil /* plan */); err != nil && returnError {
 			return err
 		}
@@ -359,15 +328,15 @@ func observePlan(
 		observer.attr(
 			"subquery",
 			"original sql",
-			tree.AsStringWithFlags(subqueryPlans[i].subquery, subqueryFmtFlags),
+			tree.AsStringWithFlags(s.subquery, subqueryFmtFlags),
 		)
-		observer.attr("subquery", "exec mode", rowexec.SubqueryExecModeNames[subqueryPlans[i].execMode])
-		if subqueryPlans[i].plan != nil {
-			if err := walkPlan(ctx, subqueryPlans[i].plan, observer); err != nil && returnError {
+		observer.attr("subquery", "exec mode", rowexec.SubqueryExecModeNames[s.execMode])
+		if s.plan != nil {
+			if err := walkPlan(ctx, s.plan, observer); err != nil && returnError {
 				return err
 			}
-		} else if subqueryPlans[i].started {
-			observer.expr(observeAlways, "subquery", "result", -1, subqueryPlans[i].result)
+		} else if s.started {
+			observer.expr(observeAlways, "subquery", "result", -1, s.result)
 		}
 		if err := observer.leaveNode("subquery", nil /* plan */); err != nil && returnError {
 			return err
@@ -375,24 +344,24 @@ func observePlan(
 	}
 
 	// Explain the cascades.
-	for i := range cascades {
+	for i := range plan.cascades {
 		if _, err := observer.enterNode(ctx, "fk-cascade", nil); err != nil && returnError {
 			return err
 		}
-		observer.attr("cascade", "fk", cascades[i].FKName)
-		observer.attr("cascade", "input", cascades[i].Buffer.(*bufferNode).label)
+		observer.attr("cascade", "fk", plan.cascades[i].FKName)
+		observer.attr("cascade", "input", plan.cascades[i].Buffer.(*bufferNode).label)
 		if err := observer.leaveNode("cascade", nil); err != nil && returnError {
 			return err
 		}
 	}
 
 	// Explain the checks.
-	for i := range checkPlans {
+	for i := range plan.checkPlans {
 		if _, err := observer.enterNode(ctx, "fk-check", nil /* plan */); err != nil && returnError {
 			return err
 		}
-		if checkPlans[i].plan != nil {
-			if err := walkPlan(ctx, checkPlans[i].plan, observer); err != nil && returnError {
+		if plan.checkPlans[i].plan != nil {
+			if err := walkPlan(ctx, plan.checkPlans[i].plan, observer); err != nil && returnError {
 				return err
 			}
 		}
@@ -401,8 +370,8 @@ func observePlan(
 		}
 	}
 
-	if len(subqueryPlans) > 0 || len(checkPlans) > 0 {
-		if err := observer.leaveNode("root", plan); err != nil && returnError {
+	if len(plan.subqueryPlans) > 0 || len(plan.cascades) > 0 || len(plan.checkPlans) > 0 {
+		if err := observer.leaveNode("root", plan.main); err != nil && returnError {
 			return err
 		}
 	}
@@ -466,9 +435,8 @@ func planToString(ctx context.Context, p *planTop) string {
 		return nil
 	}
 
-	e.populateEntries(
-		ctx, p.plan, p.subqueryPlans, p.cascades, p.checkPlans, explainSubqueryFmtFlags,
-	)
+	e.populateEntries(ctx, &p.planComponents, explainSubqueryFmtFlags)
+
 	// Our emitRow function never returns errors, so neither will emitRows().
 	_ = e.emitRows(emitRow)
 	_ = tw.Flush()

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colflow"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -44,15 +43,6 @@ type explainPlanNode struct {
 	explainer explainer
 
 	plan planComponents
-
-	// subqueryPlans contains the subquery plans for the explained query.
-	subqueryPlans []subquery
-
-	// cascades contains metadata for any cascades.
-	cascades []exec.Cascade
-
-	// checkPlans contains the check plans for the explained query.
-	checkPlans []checkPlan
 
 	stmtType tree.StatementType
 
@@ -132,10 +122,10 @@ func (e *explainPlanNode) Values() tree.Datums                 { return e.run.re
 
 func (e *explainPlanNode) Close(ctx context.Context) {
 	e.plan.main.Close(ctx)
-	for i := range e.subqueryPlans {
+	for i := range e.plan.subqueryPlans {
 		e.plan.subqueryPlans[i].plan.Close(ctx)
 	}
-	for i := range e.checkPlans {
+	for i := range e.plan.checkPlans {
 		e.plan.checkPlans[i].plan.Close(ctx)
 	}
 	e.run.results.Close(ctx)

--- a/pkg/sql/explain_tree.go
+++ b/pkg/sql/explain_tree.go
@@ -110,8 +110,7 @@ func planToTree(ctx context.Context, top *planTop) *roachpb.ExplainTreePlanNode 
 	}
 
 	if err := observePlan(
-		ctx, top.plan, top.subqueryPlans, top.cascades, top.checkPlans,
-		observer, true /* returnError */, sampledLogicalPlanFmtFlags,
+		ctx, &top.planComponents, observer, true /* returnError */, sampledLogicalPlanFmtFlags,
 	); err != nil {
 		panic(fmt.Sprintf("error while walking plan to save it to statement stats: %s", err.Error()))
 	}

--- a/pkg/sql/logictest/testdata/logic_test/cascade_opt
+++ b/pkg/sql/logictest/testdata/logic_test/cascade_opt
@@ -43,10 +43,38 @@ query II
 SELECT * FROM child
 ----
 
+# Delete cascade which itself has a check.
 statement ok
+CREATE TABLE grandchild (
+  g INT PRIMARY KEY,
+  c INT REFERENCES child(c)
+);
+INSERT INTO parent VALUES (1), (2);
+INSERT INTO child VALUES (10, 1), (11, 1), (20, 2), (21, 2);
+INSERT INTO grandchild VALUES (100, 10), (101, 10), (110, 11);
+
+statement ok
+DELETE FROM parent WHERE p = 2
+
+statement error delete on table "child" violates foreign key constraint "fk_c_ref_child" on table "grandchild"\nDETAIL: Key \(c\)\=\(1[01]\) is still referenced from table "grandchild"
+DELETE FROM parent WHERE p = 1
+
+statement ok
+DELETE FROM grandchild WHERE c = 10
+
+statement error delete on table "child" violates foreign key constraint "fk_c_ref_child" on table "grandchild"\nDETAIL: Key \(c\)=\(11\) is still referenced from table "grandchild"
+DELETE FROM parent WHERE p = 1
+
+statement ok
+DELETE FROM grandchild WHERE c = 11
+
+statement ok
+DELETE FROM parent WHERE p = 1
+
+statement ok
+DROP TABLE grandchild;
 DROP TABLE child;
 DROP TABLE parent
-
 
 # Delete cascade with multiple columns and multiple child tables.
 statement ok

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -957,13 +957,13 @@ func (ef *execFactory) ConstructPlan(
 		root = spool.source
 	}
 	res := &planTop{
-		plan: root.(planNode),
 		// TODO(radu): these fields can be modified by planning various opaque
 		// statements. We should have a cleaner way of plumbing these.
 		avoidBuffering:  ef.planner.curPlan.avoidBuffering,
 		auditEvents:     ef.planner.curPlan.auditEvents,
 		instrumentation: ef.planner.curPlan.instrumentation,
 	}
+	res.main = root.(planNode)
 	if len(subqueries) > 0 {
 		res.subqueryPlans = make([]subquery, len(subqueries))
 		for i := range subqueries {
@@ -1143,19 +1143,16 @@ func (ef *execFactory) ConstructExplain(
 	switch options.Mode {
 	case tree.ExplainDistSQL:
 		return &explainDistSQLNode{
-			options:       options,
-			plan:          p.plan,
-			subqueryPlans: p.subqueryPlans,
-			cascades:      p.cascades,
-			checkPlans:    p.checkPlans,
-			analyze:       analyzeSet,
-			stmtType:      stmtType,
+			options:  options,
+			plan:     p.planComponents,
+			analyze:  analyzeSet,
+			stmtType: stmtType,
 		}, nil
 
 	case tree.ExplainVec:
 		return &explainVecNode{
 			options:       options,
-			plan:          p.plan,
+			plan:          p.main,
 			subqueryPlans: p.subqueryPlans,
 			stmtType:      stmtType,
 		}, nil
@@ -1167,10 +1164,7 @@ func (ef *execFactory) ConstructExplain(
 		return ef.planner.makeExplainPlanNodeWithPlan(
 			context.TODO(),
 			options,
-			p.plan,
-			p.subqueryPlans,
-			p.cascades,
-			p.checkPlans,
+			&p.planComponents,
 			stmtType,
 		)
 

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -986,7 +986,12 @@ func (ef *execFactory) ConstructPlan(
 			out.plan = in.Root.(planNode)
 		}
 	}
-	res.cascades = cascades
+	if len(cascades) > 0 {
+		res.cascades = make([]cascadeMetadata, len(cascades))
+		for i := range cascades {
+			res.cascades[i].Cascade = cascades[i]
+		}
+	}
 	if len(checks) > 0 {
 		res.checkPlans = make([]checkPlan, len(checks))
 		for i := range checks {

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -281,8 +281,7 @@ type planTop struct {
 	// stmt is a reference to the current statement (AST and other metadata).
 	stmt *Statement
 
-	// plan is the top-level node of the logical plan.
-	plan planNode
+	planComponents
 
 	// mem/catalog retains the memo and catalog that were used to create the
 	// plan.
@@ -295,16 +294,6 @@ type planTop struct {
 	// This is (currently) used by CREATE VIEW.
 	// TODO(knz): Remove this in favor of a better encapsulated mechanism.
 	deps planDependencies
-
-	// subqueryPlans contains all the sub-query plans.
-	subqueryPlans []subquery
-
-	// cascades contains metadata for all cascades.
-	cascades []exec.Cascade
-
-	// checkPlans contains all the plans for queries that are to be executed after
-	// the main query (for example, foreign key checks).
-	checkPlans []checkPlan
 
 	// auditEvents becomes non-nil if any of the descriptors used by
 	// current statement is causing an auditing event. See exec_log.go.
@@ -326,25 +315,34 @@ type planTop struct {
 	distSQLDiagrams []execinfrapb.FlowDiagram
 }
 
+// planComponents groups together the various components of the entire query
+// plan.
+type planComponents struct {
+	// subqueryPlans contains all the sub-query plans.
+	subqueryPlans []subquery
+
+	// plan for the main query.
+	main planNode
+
+	// cascades contains metadata for all cascades.
+	cascades []exec.Cascade
+
+	// checkPlans contains all the plans for queries that are to be executed after
+	// the main query (for example, foreign key checks).
+	checkPlans []checkPlan
+}
+
 // checkPlan is a query tree that is executed after the main one. It can only
 // return an error (for example, foreign key violation).
 type checkPlan struct {
 	plan planNode
 }
 
-// init resets planTop to point to a given statement; used at the start of the
-// planning process.
-func (p *planTop) init(stmt *Statement, appStats *appStats) {
-	*p = planTop{stmt: stmt}
-	p.instrumentation.init(appStats)
-}
-
-// close ensures that the plan's resources have been deallocated.
-func (p *planTop) close(ctx context.Context) {
-	if p.plan != nil {
-		p.instrumentation.savePlanInfo(ctx, p)
-		p.plan.Close(ctx)
-		p.plan = nil
+// close calls Close on all plan trees.
+func (p *planComponents) close(ctx context.Context) {
+	if p.main != nil {
+		p.main.Close(ctx)
+		p.main = nil
 	}
 
 	for i := range p.subqueryPlans {
@@ -362,6 +360,21 @@ func (p *planTop) close(ctx context.Context) {
 			p.checkPlans[i].plan = nil
 		}
 	}
+}
+
+// init resets planTop to point to a given statement; used at the start of the
+// planning process.
+func (p *planTop) init(stmt *Statement, appStats *appStats) {
+	*p = planTop{stmt: stmt}
+	p.instrumentation.init(appStats)
+}
+
+// close ensures that the plan's resources have been deallocated.
+func (p *planTop) close(ctx context.Context) {
+	if p.main != nil {
+		p.instrumentation.savePlanInfo(ctx, p)
+	}
+	p.planComponents.close(ctx)
 }
 
 // formatOptPlan returns a visual representation of the optimizer plan that was

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -189,7 +189,7 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 		result.flags.Set(planFlagIsDDL)
 	}
 
-	cols := planColumns(result.plan)
+	cols := planColumns(result.main)
 	if stmt.ExpectedTypes != nil {
 		if !stmt.ExpectedTypes.TypesEqual(cols) {
 			return pgerror.New(pgcode.FeatureNotSupported, "cached plan must not change result type")

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -263,7 +263,7 @@ func (sc *SchemaChanger) maybeBackfillCreateTableAs(
 		)
 		defer recv.Release()
 
-		rec, err := sc.distSQLPlanner.checkSupportForNode(localPlanner.curPlan.plan)
+		rec, err := sc.distSQLPlanner.checkSupportForNode(localPlanner.curPlan.main)
 		var planAndRunErr error
 		localPlanner.runWithOptions(resolveFlags{skipCache: true}, func() {
 			// Resolve subqueries before running the queries' physical plan.
@@ -287,7 +287,7 @@ func (sc *SchemaChanger) maybeBackfillCreateTableAs(
 			}}
 
 			PlanAndRunCTAS(ctx, sc.distSQLPlanner, localPlanner,
-				txn, isLocal, localPlanner.curPlan.plan, out, recv)
+				txn, isLocal, localPlanner.curPlan.main, out, recv)
 			if planAndRunErr = rw.Err(); planAndRunErr != nil {
 				return
 			}

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -123,6 +123,6 @@ func (dsp *DistSQLPlanner) Exec(
 	planCtx.planner = p
 	planCtx.stmtType = recv.stmtType
 
-	dsp.PlanAndRun(ctx, evalCtx, planCtx, p.txn, p.curPlan.plan, recv)()
+	dsp.PlanAndRun(ctx, evalCtx, planCtx, p.txn, p.curPlan.main, recv)()
 	return rw.Err()
 }

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -642,7 +642,7 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 		}
 
 	case *explainDistSQLNode:
-		n.plan = v.visit(n.plan)
+		n.plan.main = v.visit(n.plan.main)
 
 	case *explainVecNode:
 		n.plan = v.visit(n.plan)
@@ -666,7 +666,7 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 		n.plan = v.visit(n.plan)
 
 	case *explainPlanNode:
-		n.plan = v.visit(n.plan)
+		n.plan.main = v.visit(n.plan.main)
 
 	case *cancelQueriesNode:
 		n.rows = v.visit(n.rows)


### PR DESCRIPTION
#### sql: group plan components in a structure

This change adds a `planComponents` structure which holds the components of the
plan: subqueries, main query, cascades, checks. This simplifies the explain code
that has to pass these around.

Release note: None

#### sql: support cascades that have checks

This change adds support for running checks that are generated by cascades.

In addition, we now remember the cascade plan trees and we close them as well.

Release note: None
