### PR TITLE
release-20.1: ui: do not report errors for ranges with untrusted raft log size

### DIFF
--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -58,6 +58,7 @@ func (r *Replica) Metrics(
 	desc := r.mu.state.Desc
 	zone := r.mu.zone
 	raftLogSize := r.mu.raftLogSize
+	raftLogSizeTrusted := r.mu.raftLogSizeTrusted
 	r.mu.RUnlock()
 
 	r.store.unquiescedReplicas.Lock()
@@ -82,6 +83,7 @@ func (r *Replica) Metrics(
 		latchInfoLocal,
 		latchInfoGlobal,
 		raftLogSize,
+		raftLogSizeTrusted,
 	)
 }
 
@@ -101,6 +103,7 @@ func calcReplicaMetrics(
 	latchInfoLocal storagepb.LatchManagerInfo,
 	latchInfoGlobal storagepb.LatchManagerInfo,
 	raftLogSize int64,
+	raftLogSizeTrusted bool,
 ) ReplicaMetrics {
 	var m ReplicaMetrics
 
@@ -129,7 +132,8 @@ func calcReplicaMetrics(
 	m.LatchInfoGlobal = latchInfoGlobal
 
 	const raftLogTooLargeMultiple = 4
-	m.RaftLogTooLarge = raftLogSize > (raftLogTooLargeMultiple * raftCfg.RaftLogTruncationThreshold)
+	m.RaftLogTooLarge = raftLogSize > (raftLogTooLargeMultiple*raftCfg.RaftLogTruncationThreshold) &&
+		raftLogSizeTrusted
 
 	return m
 }

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -8705,7 +8705,7 @@ func TestReplicaMetrics(t *testing.T) {
 				context.Background(), hlc.Timestamp{}, &cfg.RaftConfig, zoneConfig,
 				c.liveness, 0, &c.desc, c.raftStatus, storagepb.LeaseStatus{},
 				c.storeID, c.expected.Quiescent, c.expected.Ticking,
-				storagepb.LatchManagerInfo{}, storagepb.LatchManagerInfo{}, c.raftLogSize)
+				storagepb.LatchManagerInfo{}, storagepb.LatchManagerInfo{}, c.raftLogSize, true)
 			if c.expected != metrics {
 				t.Fatalf("unexpected metrics:\n%s", pretty.Diff(c.expected, metrics))
 			}

--- a/pkg/ui/src/views/reports/containers/range/rangeTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/rangeTable.tsx
@@ -66,7 +66,6 @@ const rangeTableDisplayList: RangeTableRow[] = [
   { variable: "commit", display: "Commit", compareToLeader: true },
   { variable: "lastIndex", display: "Last Index", compareToLeader: true },
   { variable: "logSize", display: "Log Size", compareToLeader: false },
-  { variable: "logSizeTrusted", display: "Log Size Trusted?", compareToLeader: false },
   { variable: "leaseHolderQPS", display: "Lease Holder QPS", compareToLeader: false },
   { variable: "keysWrittenPS", display: "Average Keys Written Per Second", compareToLeader: false },
   { variable: "approxProposalQuota", display: "Approx Proposal Quota", compareToLeader: false },
@@ -153,11 +152,18 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
     };
   }
 
-  contentBytes(bytes: Long): RangeTableCellContent {
+  contentBytes(bytes: Long, className: string = null, toolTip: string = null): RangeTableCellContent {
     const humanized = Bytes(bytes.toNumber());
+    if (_.isNull(className)) {
+      return {
+        value: [humanized],
+        title: [humanized, bytes.toString()],
+      };
+    }
     return {
       value: [humanized],
-      title: [humanized, bytes.toString()],
+      title: [humanized, bytes.toString(), toolTip],
+      className: [className],
     };
   }
 
@@ -499,8 +505,14 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
         applied: this.contentIf(!dormant, () => this.createContent(FixLong(info.raft_state.applied))),
         commit: this.contentIf(!dormant, () => this.createContent(FixLong(info.raft_state.hard_state.commit))),
         lastIndex: this.createContent(FixLong(info.state.last_index)),
-        logSize: this.contentBytes(FixLong(info.state.raft_log_size)),
-        logSizeTrusted: this.createContent(info.state.raft_log_size_trusted.toString()),
+        logSize: this.contentBytes(
+          FixLong(info.state.raft_log_size),
+          info.state.raft_log_size_trusted ? "" : "range-table__cell--dormant",
+          "Log size is known to not be correct. This isn't an error condition. " +
+            "The log size will became exact the next time it is recomputed. " +
+            "This replica does not perform log truncation (because the log might already " +
+            "be truncated sufficiently).",
+        ),
         leaseHolderQPS: leaseHolder ? this.createContent(info.stats.queries_per_second.toFixed(4)) : rangeTableEmptyContent,
         keysWrittenPS: this.createContent(info.stats.writes_per_second.toFixed(4)),
         approxProposalQuota: raftLeader ? this.createContent(FixLong(info.state.approximate_proposal_quota)) : rangeTableEmptyContent,


### PR DESCRIPTION
Backport 1/1 commits from #48032.

/cc @cockroachdb/release

---

Previousuly a raft log size that exceeded several times the truncation
threshold will result in a "Raft too large" reported for each replica even
though the Log Size is set to not be trusted.
This lead to confusion from the customers as it seemed as if there is a problem.
With this fix, the "Raft too large" is only reported if the raft log size is trusted.
In the cases that it isn't trusted, the raft log size is now displayed grayed for each replica.
This PR also removes the "Log Size Trusted?" from the range report and instead
the grayed log size is used to indicate untrusted log size.

Fixes #47569

Release note (admin ui change): Fixed a bug where "Raft log too large" was reported incorrectly for replicas for which the raft log size is not to be trusted.
