### PR TITLE
release-20.1: deps: bump cockroachdb/errors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -406,7 +406,7 @@
 
 [[projects]]
   branch = "v1.2.4-cockroach20.1"
-  digest = "1:f3e110587a7cde6152fe8861a5873ffb552232b8a91ce444075397f4ebabd4cd"
+  digest = "1:b71a73b66891223c46f81a6195774911b79320181b54963196e843e8c3566461"
   name = "github.com/cockroachdb/errors"
   packages = [
     ".",
@@ -429,7 +429,7 @@
     "withstack",
   ]
   pruneopts = "UT"
-  revision = "fcfc812fae48db497f9fb1dbc7b4d4041caa06fa"
+  revision = "ad1964b7f01491050a580f32fa2566ea66518cbd"
 
 [[projects]]
   digest = "1:a44e537b3e080ff297315d166956dba9607f070644a89be78b59af6c54876b64"


### PR DESCRIPTION
* Backport 1/7 commits from #48275

cc @cockroachdb/release 

----

This fixes `errors.IsAny`. There are two calls to this in the source base. None of them are _currently_ affected: the bug was making the function `IsAny` incorrect if the error was decorated, but the two existing calls apply to non-decorated errors. However it was a ticking bomb - an `error.Wrap` in the wrong place would have broken the code without a clear smoking gun.

