### PR TITLE
opt: add rule to fold remappings of ValuesExpr columns

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/groupby
+++ b/pkg/sql/opt/memo/testdata/stats/groupby
@@ -483,28 +483,20 @@ project
  │    │    ├── stats: [rows=1.29289322, distinct(4)=1.29289322, null(4)=1, distinct(5)=1.29289322, null(5)=0]
  │    │    ├── key: (4)
  │    │    ├── fd: (4)-->(5)
- │    │    ├── project
+ │    │    ├── select
  │    │    │    ├── columns: a:3(bool!null) b:4(int)
  │    │    │    ├── cardinality: [0 - 3]
- │    │    │    ├── stats: [rows=1.5, distinct(4)=1.29289322, null(4)=1]
+ │    │    │    ├── stats: [rows=1.5, distinct(3)=1, null(3)=0, distinct(4)=1.29289322, null(4)=1]
  │    │    │    ├── fd: ()-->(3)
- │    │    │    ├── select
- │    │    │    │    ├── columns: column1:1(bool!null) column2:2(int)
- │    │    │    │    ├── cardinality: [0 - 3]
- │    │    │    │    ├── stats: [rows=1.5, distinct(1)=1, null(1)=0, distinct(2)=1.29289322, null(2)=1]
- │    │    │    │    ├── fd: ()-->(1)
- │    │    │    │    ├── values
- │    │    │    │    │    ├── columns: column1:1(bool!null) column2:2(int)
- │    │    │    │    │    ├── cardinality: [3 - 3]
- │    │    │    │    │    ├── stats: [rows=3, distinct(1)=2, null(1)=0, distinct(2)=2, null(2)=2]
- │    │    │    │    │    ├── (true, NULL) [type=tuple{bool, int}]
- │    │    │    │    │    ├── (false, NULL) [type=tuple{bool, int}]
- │    │    │    │    │    └── (true, 5) [type=tuple{bool, int}]
- │    │    │    │    └── filters
- │    │    │    │         └── column1:1 [type=bool, outer=(1), constraints=(/1: [/true - /true]; tight), fd=()-->(1)]
- │    │    │    └── projections
- │    │    │         ├── column1:1 [as=a:3, type=bool, outer=(1)]
- │    │    │         └── column2:2 [as=b:4, type=int, outer=(2)]
+ │    │    │    ├── values
+ │    │    │    │    ├── columns: a:3(bool!null) b:4(int)
+ │    │    │    │    ├── cardinality: [3 - 3]
+ │    │    │    │    ├── stats: [rows=3, distinct(3)=2, null(3)=0, distinct(4)=2, null(4)=2]
+ │    │    │    │    ├── (true, NULL) [type=tuple{bool, int}]
+ │    │    │    │    ├── (false, NULL) [type=tuple{bool, int}]
+ │    │    │    │    └── (true, 5) [type=tuple{bool, int}]
+ │    │    │    └── filters
+ │    │    │         └── a:3 [type=bool, outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
  │    │    └── aggregations
  │    │         └── bool-or [as=bool_or:5, type=bool, outer=(3)]
  │    │              └── a:3 [type=bool]

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -1313,11 +1313,151 @@ func (c *CustomFuncs) FoldTupleColumnAccess(
 	}
 
 	// Construct and return a new ProjectionsExpr using the new ColumnIDs.
-	for i, projection := range projections {
+	for i := range projections {
+		projection := &projections[i]
 		newProjections[i] = c.f.ConstructProjectionsItem(
 			replace(projection.Element).(opt.ScalarExpr), projection.Col)
 	}
 	return newProjections
+}
+
+// CanPushColumnRemappingIntoValues returns true if there is at least one
+// ProjectionsItem for which the following conditions hold:
+//
+// 1. The ProjectionsItem remaps an output column from the given ValuesExpr.
+//
+// 2. The Values output column being remapped is not in the passthrough set.
+//
+func (c *CustomFuncs) CanPushColumnRemappingIntoValues(
+	projections memo.ProjectionsExpr, passthrough opt.ColSet, values memo.RelExpr,
+) bool {
+	outputCols := values.(*memo.ValuesExpr).Relational().OutputCols
+	for i := range projections {
+		if variable, ok := projections[i].Element.(*memo.VariableExpr); ok {
+			if !passthrough.Contains(variable.Col) && outputCols.Contains(variable.Col) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// PushColumnRemappingIntoValues folds ProjectionsItems into the passthrough set
+// if all they do is remap output columns from the ValuesExpr input. The Values
+// output columns are replaced by the corresponding columns from the folded
+// ProjectionsItems.
+//
+// Example:
+// project
+//  ├── columns: x:2!null
+//  ├── values
+//  │    ├── columns: column1:1!null
+//  │    ├── cardinality: [2 - 2]
+//  │    ├── (1,)
+//  │    └── (2,)
+//  └── projections
+//       └── column1:1 [as=x:2, outer=(1)]
+// =>
+// project
+//  ├── columns: x:2!null
+//  └── values
+//       ├── columns: x:2!null
+//       ├── cardinality: [2 - 2]
+//       ├── (1,)
+//       └── (2,)
+//
+// This allows other rules to fire. In the above example, EliminateProject can
+// now remove the Project altogether.
+func (c *CustomFuncs) PushColumnRemappingIntoValues(
+	oldInput memo.RelExpr, oldProjections memo.ProjectionsExpr, oldPassthrough opt.ColSet,
+) memo.RelExpr {
+	oldValues := oldInput.(*memo.ValuesExpr)
+	oldValuesCols := oldValues.Relational().OutputCols
+	newPassthrough := oldPassthrough.Copy()
+	replacementCols := make(map[opt.ColumnID]opt.ColumnID)
+	var newProjections memo.ProjectionsExpr
+
+	// Construct the new ProjectionsExpr and passthrough columns. Keep track of
+	// which Values columns are to be replaced.
+	for i := range oldProjections {
+		oldItem := &oldProjections[i]
+
+		// A column can be replaced if the following conditions hold:
+		// 1. The current ProjectionsItem contains a VariableExpr.
+		// 2. The VariableExpr references a column from the ValuesExpr.
+		// 3. The column has not already been assigned a replacement.
+		// 4. The column is not a passthrough column.
+		if v, ok := oldItem.Element.(*memo.VariableExpr); ok {
+			if targetCol := v.Col; oldValuesCols.Contains(targetCol) {
+				if replacementCols[targetCol] == 0 {
+					if !newPassthrough.Contains(targetCol) {
+						// The conditions for column replacement have been met. Map the old
+						// Values output column to its replacement and add the replacement
+						// to newPassthrough so it will become a passthrough column.
+						// Continue so that no corresponding ProjectionsItem is added to
+						// newProjections.
+						replacementCols[targetCol] = oldItem.Col
+						newPassthrough.Add(oldItem.Col)
+						continue
+					}
+				}
+			}
+		}
+		// The current ProjectionsItem cannot be folded into newPassthrough because
+		// the above conditions do not hold. Simply add it to newProjections. Later,
+		// every ProjectionsItem will be recursively traversed and any references to
+		// columns that are in replacementCols will be replaced.
+		newProjections = append(newProjections, *oldItem)
+	}
+
+	// Recursively traverses a ProjectionsItem element and replaces references to
+	// old ValuesExpr columns with the replacement columns. This ensures that any
+	// remaining references to old columns are replaced. For example:
+	//
+	//   WITH t AS (SELECT x, x FROM (VALUES (1)) f(x)) SELECT * FROM t;
+	//
+	// The "x" column of the Values operator will be mapped to the first column of
+	// t. This first column will become a passthrough column. Now, the remaining
+	// reference to "x" in the second column of t needs to be replaced by the new
+	// passthrough column.
+	var replace ReplaceFunc
+	replace = func(nd opt.Expr) opt.Expr {
+		switch t := nd.(type) {
+		case *memo.VariableExpr:
+			if replaceCol := replacementCols[t.Col]; replaceCol != 0 {
+				return c.f.ConstructVariable(replaceCol)
+			}
+		}
+		return c.f.Replace(nd, replace)
+	}
+
+	// Traverse each element in newProjections and replace col references as
+	// dictated by replacementCols.
+	for i := range newProjections {
+		item := &newProjections[i]
+		newProjections[i] = c.f.ConstructProjectionsItem(
+			replace(item.Element).(opt.ScalarExpr), item.Col)
+	}
+
+	// Replace all columns in newValuesColList that have been remapped by the old
+	// ProjectionsExpr.
+	oldValuesColList := oldValues.Cols
+	newValuesColList := make(opt.ColList, len(oldValuesColList))
+	for i := range newValuesColList {
+		if replaceCol := replacementCols[oldValuesColList[i]]; replaceCol != 0 {
+			newValuesColList[i] = replaceCol
+		} else {
+			newValuesColList[i] = oldValuesColList[i]
+		}
+	}
+
+	// Construct a new ValuesExpr with the replaced cols.
+	newValues := c.f.ConstructValues(
+		oldValues.Rows,
+		&memo.ValuesPrivate{Cols: newValuesColList, ID: c.f.Metadata().NextUniqueID()})
+
+	// Construct and return a new ProjectExpr with the new ValuesExpr as input.
+	return c.f.ConstructProject(newValues, newProjections, newPassthrough)
 }
 
 // ----------------------------------------------------------------------

--- a/pkg/sql/opt/norm/rules/project.opt
+++ b/pkg/sql/opt/norm/rules/project.opt
@@ -62,6 +62,47 @@ $input
 =>
 (MergeProjectWithValues $projections $passthrough $input)
 
+# PushColumnRemappingIntoValues folds ProjectionsItems into the passthrough set
+# if they simply remap Values output columns that are not already in
+# passthrough. The Values output columns are replaced with the corresponding
+# columns projected by the folded ProjectionsItems.
+#
+# Example:
+#
+# project
+#  ├── columns: x:2!null
+#  ├── values
+#  │    ├── columns: column1:1!null
+#  │    ├── cardinality: [2 - 2]
+#  │    ├── (1,)
+#  │    └── (2,)
+#  └── projections
+#       └── column1:1 [as=x:2, outer=(1)]
+# =>
+# project
+#  ├── columns: x:2!null
+#  └── values
+#       ├── columns: x:2!null
+#       ├── cardinality: [2 - 2]
+#       ├── (1,)
+#       └── (2,)
+#
+# This allows other rules to fire. In the example above, the project would now
+# be removed by EliminateProject.
+[PushColumnRemappingIntoValues, Normalize]
+(Project
+    $input:(Values)
+    $projections:*
+    $passthrough:* &
+        (CanPushColumnRemappingIntoValues
+            $projections
+            $passthrough
+            $input
+        )
+)
+=>
+(PushColumnRemappingIntoValues $input $projections $passthrough)
+
 # FoldTupleAccessIntoValues replaces a Values with a single column that
 # references a column of tuples with a new Values that has a column for each
 # tuple index. This works as long as the surrounding Project does not reference

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -221,54 +221,35 @@ project
 # FoldTupleAccessIntoValues
 # --------------------------------------------------
 
-# Simple case with VALUES.
+# Simple case with VALUES operator.
 norm expect=FoldTupleAccessIntoValues
 SELECT (tup).@1, (tup).@2 FROM (VALUES ((1,2)), ((3,4))) AS v(tup)
 ----
-project
+values
  ├── columns: "?column?":2!null "?column?":3!null
  ├── cardinality: [2 - 2]
- ├── values
- │    ├── columns: column1_1:4!null column1_2:5!null
- │    ├── cardinality: [2 - 2]
- │    ├── (1, 2)
- │    └── (3, 4)
- └── projections
-      ├── column1_1:4 [as="?column?":2, outer=(4)]
-      └── column1_2:5 [as="?column?":3, outer=(5)]
+ ├── (1, 2)
+ └── (3, 4)
 
-# Simple case with unnest.
+# Simple case with unnest function.
 norm expect=FoldTupleAccessIntoValues
 SELECT (Tuples).@1, (Tuples).@2 FROM unnest(ARRAY[(1,2),(3,4)]) AS Tuples
 ----
-project
+values
  ├── columns: "?column?":2!null "?column?":3!null
  ├── cardinality: [2 - 2]
- ├── values
- │    ├── columns: unnest_1:4!null unnest_2:5!null
- │    ├── cardinality: [2 - 2]
- │    ├── (1, 2)
- │    └── (3, 4)
- └── projections
-      ├── unnest_1:4 [as="?column?":2, outer=(4)]
-      └── unnest_2:5 [as="?column?":3, outer=(5)]
+ ├── (1, 2)
+ └── (3, 4)
 
 # Case with tuples containing multiple types.
 norm expect=FoldTupleAccessIntoValues
 SELECT (tup).@1, (tup).@2, (tup).@3 FROM (VALUES ((1,'2',3.0)), ((4,'5',NULL::DECIMAL))) AS v(tup)
 ----
-project
+values
  ├── columns: "?column?":2!null "?column?":3!null "?column?":4
  ├── cardinality: [2 - 2]
- ├── values
- │    ├── columns: column1_1:5!null column1_2:6!null column1_3:7
- │    ├── cardinality: [2 - 2]
- │    ├── (1, '2', 3.0)
- │    └── (4, '5', NULL)
- └── projections
-      ├── column1_1:5 [as="?column?":2, outer=(5)]
-      ├── column1_2:6 [as="?column?":3, outer=(6)]
-      └── column1_3:7 [as="?column?":4, outer=(7)]
+ ├── (1, '2', 3.0)
+ └── (4, '5', NULL)
 
 # Case with one tuple field referenced zero times, one field referenced once,
 # and one field referenced twice.
@@ -286,17 +267,11 @@ values
 norm expect=FoldTupleAccessIntoValues
 SELECT (Tuples).@1, (Tuples).@2 FROM unnest(ARRAY[((),()),((),())]) AS Tuples
 ----
-project
+values
  ├── columns: "?column?":2!null "?column?":3!null
  ├── cardinality: [2 - 2]
- ├── values
- │    ├── columns: unnest_1:4!null unnest_2:5!null
- │    ├── cardinality: [2 - 2]
- │    ├── ((), ())
- │    └── ((), ())
- └── projections
-      ├── unnest_1:4 [as="?column?":2, outer=(4)]
-      └── unnest_2:5 [as="?column?":3, outer=(5)]
+ ├── ((), ())
+ └── ((), ())
 
 # Case with subquery projection.
 norm expect=FoldTupleAccessIntoValues
@@ -395,17 +370,11 @@ FROM (VALUES
         (((3,4) AS a,b))
      ) v(tup)
 ----
-project
+values
  ├── columns: a:2!null b:3!null
  ├── cardinality: [2 - 2]
- ├── values
- │    ├── columns: column1_1:4!null column1_2:5!null
- │    ├── cardinality: [2 - 2]
- │    ├── ((1, 2) AS a, b)
- │    └── ((3, 4) AS a, b)
- └── projections
-      ├── column1_1:4 [as=a:2, outer=(4)]
-      └── column1_2:5 [as=b:3, outer=(5)]
+ ├── ((1, 2) AS a, b)
+ └── ((3, 4) AS a, b)
 
 # Case with wildcard tuple access on a named tuple.
 norm expect=FoldTupleAccessIntoValues
@@ -415,17 +384,11 @@ FROM (VALUES
         (((3,4) AS a,b))
      ) v(tup)
 ----
-project
+values
  ├── columns: a:2!null b:3!null
  ├── cardinality: [2 - 2]
- ├── values
- │    ├── columns: column1_1:4!null column1_2:5!null
- │    ├── cardinality: [2 - 2]
- │    ├── ((1, 2) AS a, b)
- │    └── ((3, 4) AS a, b)
- └── projections
-      ├── column1_1:4 [as=a:2, outer=(4)]
-      └── column1_2:5 [as=b:3, outer=(5)]
+ ├── ((1, 2) AS a, b)
+ └── ((3, 4) AS a, b)
 
 # Case with wildcard tuple access on an unnamed tuple.
 norm expect=FoldTupleAccessIntoValues
@@ -435,17 +398,11 @@ FROM (VALUES
         ((3,4))
      ) v(tup)
 ----
-project
+values
  ├── columns: "?column?":2!null "?column?":3!null
  ├── cardinality: [2 - 2]
- ├── values
- │    ├── columns: column1_1:4!null column1_2:5!null
- │    ├── cardinality: [2 - 2]
- │    ├── (1, 2)
- │    └── (3, 4)
- └── projections
-      ├── column1_1:4 [as="?column?":2, outer=(4)]
-      └── column1_2:5 [as="?column?":3, outer=(5)]
+ ├── (1, 2)
+ └── (3, 4)
 
 # No-op case because the Values operator has more than one column.
 norm expect-not=FoldTupleAccessIntoValues
@@ -547,3 +504,271 @@ project
  │    └── (((1, 2) AS a, b),)
  └── projections
       └── (least(column1:1, (1, 2))).a [as=a:3, outer=(1)]
+
+# --------------------------------------------------
+# PushColumnRemappingIntoValues
+# --------------------------------------------------
+
+# With clause case. This works because InlineWith creates a simple remapping
+# projection on the Values output column.
+norm expect=PushColumnRemappingIntoValues
+WITH a AS (SELECT x FROM (VALUES (1), (2)) f(x)) SELECT x FROM a
+----
+values
+ ├── columns: x:2!null
+ ├── cardinality: [2 - 2]
+ ├── (1,)
+ └── (2,)
+
+# Multiplication by one case. This works because after FoldMultOne and
+# EliminateCast fire, the x*1 projection does no more than rename its input
+# column.
+norm expect=PushColumnRemappingIntoValues
+SELECT x*1 FROM (VALUES (1), (2)) f(x)
+----
+values
+ ├── columns: "?column?":2!null
+ ├── cardinality: [2 - 2]
+ ├── (1,)
+ └── (2,)
+
+# Tuple access case. This works because FoldTupleAccessIntoValues creates new
+# columns that reference the tuple fields, and so the surrounding Project that
+# references those fields becomes a remapping of the new columns.
+norm expect=PushColumnRemappingIntoValues
+SELECT (tup).@1, (tup).@2 FROM (VALUES ((1,2)), ((3,4))) AS v(tup)
+----
+values
+ ├── columns: "?column?":2!null "?column?":3!null
+ ├── cardinality: [2 - 2]
+ ├── (1, 2)
+ └── (3, 4)
+
+# Case with multiple remappings of the same column.
+norm expect=PushColumnRemappingIntoValues
+WITH a AS (SELECT x, x FROM (VALUES (1), (2)) f(x)) SELECT * FROM a
+----
+project
+ ├── columns: x:2!null x:3!null
+ ├── cardinality: [2 - 2]
+ ├── fd: (2)==(3), (3)==(2)
+ ├── values
+ │    ├── columns: x:2!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── (1,)
+ │    └── (2,)
+ └── projections
+      └── x:2 [as=x:3, outer=(2)]
+
+# Case with a projection on a column only determined at run-time.
+norm expect=PushColumnRemappingIntoValues
+WITH a AS (SELECT v FROM (VALUES (1), ((SELECT z FROM b WHERE z=1))) f(v)) SELECT v FROM a
+----
+values
+ ├── columns: v:4
+ ├── cardinality: [2 - 2]
+ ├── (1,)
+ └── tuple
+      └── subquery
+           └── max1-row
+                ├── columns: z:2!null
+                ├── error: "more than one row returned by a subquery used as an expression"
+                ├── cardinality: [0 - 1]
+                ├── key: ()
+                ├── fd: ()-->(2)
+                └── select
+                     ├── columns: z:2!null
+                     ├── fd: ()-->(2)
+                     ├── scan b
+                     │    └── columns: z:2
+                     └── filters
+                          └── z:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+
+# Case with a non-VariableExpr reference to a remapped column.
+norm expect=PushColumnRemappingIntoValues
+SELECT x*1, x+1 FROM (VALUES (1), (2)) f(x)
+----
+project
+ ├── columns: "?column?":2!null "?column?":3!null
+ ├── cardinality: [2 - 2]
+ ├── fd: (2)-->(3)
+ ├── values
+ │    ├── columns: "?column?":2!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── (1,)
+ │    └── (2,)
+ └── projections
+      └── "?column?":2 + 1 [as="?column?":3, outer=(2)]
+
+# Case with a subquery reference to a remapped column.
+norm expect=PushColumnRemappingIntoValues
+SELECT
+    x*1,
+    (SELECT * FROM (Values (1), (2), (3), (4)) WHERE x=12)
+FROM
+    (VALUES (11), (12)) f(x)
+----
+project
+ ├── columns: "?column?":3!null "?column?":4
+ ├── cardinality: [1 - 8]
+ ├── ensure-distinct-on
+ │    ├── columns: column1:2 "?column?":3!null rownum:5!null
+ │    ├── grouping columns: rownum:5!null
+ │    ├── error: "more than one row returned by a subquery used as an expression"
+ │    ├── cardinality: [1 - 8]
+ │    ├── key: (5)
+ │    ├── fd: (5)-->(2,3)
+ │    ├── left-join (cross)
+ │    │    ├── columns: column1:2 "?column?":3!null rownum:5!null
+ │    │    ├── cardinality: [2 - 8]
+ │    │    ├── fd: (5)-->(3)
+ │    │    ├── ordinality
+ │    │    │    ├── columns: "?column?":3!null rownum:5!null
+ │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    ├── key: (5)
+ │    │    │    ├── fd: (5)-->(3)
+ │    │    │    └── values
+ │    │    │         ├── columns: "?column?":3!null
+ │    │    │         ├── cardinality: [2 - 2]
+ │    │    │         ├── (11,)
+ │    │    │         └── (12,)
+ │    │    ├── values
+ │    │    │    ├── columns: column1:2!null
+ │    │    │    ├── cardinality: [4 - 4]
+ │    │    │    ├── (1,)
+ │    │    │    ├── (2,)
+ │    │    │    ├── (3,)
+ │    │    │    └── (4,)
+ │    │    └── filters
+ │    │         └── "?column?":3 = 12 [outer=(3), constraints=(/3: [/12 - /12]; tight), fd=()-->(3)]
+ │    └── aggregations
+ │         ├── const-agg [as=column1:2, outer=(2)]
+ │         │    └── column1:2
+ │         └── const-agg [as="?column?":3, outer=(3)]
+ │              └── "?column?":3
+ └── projections
+      └── column1:2 [as="?column?":4, outer=(2)]
+
+# PushColumnRemappingIntoValues should only fold one projection into the
+# passthrough columns because all the projections refer to the same column.
+norm expect=PushColumnRemappingIntoValues
+SELECT x*1*1, x*1 FROM (VALUES (1), (2)) v(x)
+----
+project
+ ├── columns: "?column?":2!null "?column?":3!null
+ ├── cardinality: [2 - 2]
+ ├── fd: (2)==(3), (3)==(2)
+ ├── values
+ │    ├── columns: "?column?":2!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── (1,)
+ │    └── (2,)
+ └── projections
+      └── "?column?":2 [as="?column?":3, outer=(2)]
+
+# Case with only one column that can be replaced (The z*1 column can replace the
+# original z column).
+norm expect=PushColumnRemappingIntoValues
+SELECT x, x*1, y, y*1, z*1 FROM (VALUES (1,2,3), (2,3,6)) v(x,y,z)
+----
+project
+ ├── columns: x:1!null "?column?":4!null y:2!null "?column?":5!null "?column?":6!null
+ ├── cardinality: [2 - 2]
+ ├── fd: (1)==(4), (4)==(1), (2)==(5), (5)==(2)
+ ├── values
+ │    ├── columns: column1:1!null column2:2!null "?column?":6!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── (1, 2, 3)
+ │    └── (2, 3, 6)
+ └── projections
+      ├── column1:1 [as="?column?":4, outer=(1)]
+      └── column2:2 [as="?column?":5, outer=(2)]
+
+# No-op case because no columns from the input ValuesExpr are being remapped.
+norm expect-not=PushColumnRemappingIntoValues
+SELECT (SELECT x FROM (VALUES (1), (2)) f(x)) FROM (VALUES (2), (3))
+----
+project
+ ├── columns: x:3
+ ├── cardinality: [2 - 2]
+ ├── fd: ()-->(3)
+ ├── values
+ │    ├── cardinality: [2 - 2]
+ │    ├── ()
+ │    └── ()
+ └── projections
+      └── subquery [as=x:3, subquery]
+           └── max1-row
+                ├── columns: column1:2!null
+                ├── error: "more than one row returned by a subquery used as an expression"
+                ├── cardinality: [1 - 1]
+                ├── key: ()
+                ├── fd: ()-->(2)
+                └── values
+                     ├── columns: column1:2!null
+                     ├── cardinality: [2 - 2]
+                     ├── (1,)
+                     └── (2,)
+
+# No-op case because a passthrough column is being remapped.
+norm expect-not=PushColumnRemappingIntoValues
+SELECT x, x*1 FROM (VALUES (1), (2)) v(x)
+----
+project
+ ├── columns: x:1!null "?column?":2!null
+ ├── cardinality: [2 - 2]
+ ├── fd: (1)==(2), (2)==(1)
+ ├── values
+ │    ├── columns: column1:1!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── (1,)
+ │    └── (2,)
+ └── projections
+      └── column1:1 [as="?column?":2, outer=(1)]
+
+# No-op case because the Project is on a Scan rather than a Values operator.
+norm expect-not=PushColumnRemappingIntoValues
+WITH t AS (SELECT * FROM a) SELECT x FROM t
+----
+project
+ ├── columns: x:5!null
+ ├── key: (5)
+ ├── scan a
+ │    ├── columns: a.x:1!null
+ │    └── key: (1)
+ └── projections
+      └── a.x:1 [as=x:5, outer=(1)]
+
+# No-op case with no projections on the Project surrounding the Values operator.
+# A Project with no projections is created when PruneUnionAllCols fires, and is
+# then removed by EliminateProject.
+norm expect-not=PushColumnRemappingIntoValues
+WITH a AS
+(
+  SELECT * FROM (VALUES (1,2)) AS f(x,y)
+  UNION ALL (VALUES (3,4))
+)
+SELECT x FROM a
+----
+project
+ ├── columns: x:7!null
+ ├── cardinality: [2 - 2]
+ ├── union-all
+ │    ├── columns: x:5!null
+ │    ├── left columns: column1:1
+ │    ├── right columns: column1:3
+ │    ├── cardinality: [2 - 2]
+ │    ├── values
+ │    │    ├── columns: column1:1!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1)
+ │    │    └── (1,)
+ │    └── values
+ │         ├── columns: column1:3!null
+ │         ├── cardinality: [1 - 1]
+ │         ├── key: ()
+ │         ├── fd: ()-->(3)
+ │         └── (3,)
+ └── projections
+      └── x:5 [as=x:7, outer=(5)]

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -754,21 +754,13 @@ with &1 (foo)
 norm expect=InlineWith
 WITH foo AS NOT MATERIALIZED (SELECT 1/0) SELECT * FROM foo
 ----
-project
+values
  ├── columns: "?column?":2
  ├── cardinality: [1 - 1]
  ├── side-effects
  ├── key: ()
  ├── fd: ()-->(2)
- ├── values
- │    ├── columns: "?column?":1
- │    ├── cardinality: [1 - 1]
- │    ├── side-effects
- │    ├── key: ()
- │    ├── fd: ()-->(1)
- │    └── (1 / 0,)
- └── projections
-      └── "?column?":1 [as="?column?":2, outer=(1)]
+ └── (1 / 0,)
 
 # Original CTE is not inlined, adding "NOT MATERIALIZED" should force the inline.
 norm expect=InlineWith

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1076,17 +1076,11 @@ limit
  │         │    │    │    ├── columns: id:6!null quantity:7!null dealerid:8!null cardid:9!null accountname:10!null
  │         │    │    │    ├── key columns: [6] = [9]
  │         │    │    │    ├── fd: (6)==(9), (9)==(6)
- │         │    │    │    ├── project
+ │         │    │    │    ├── values
  │         │    │    │    │    ├── columns: id:6!null quantity:7!null
  │         │    │    │    │    ├── cardinality: [2 - 2]
- │         │    │    │    │    ├── values
- │         │    │    │    │    │    ├── columns: unnest_1:4!null unnest_2:5!null
- │         │    │    │    │    │    ├── cardinality: [2 - 2]
- │         │    │    │    │    │    ├── (42948, 3)
- │         │    │    │    │    │    └── (24924, 4)
- │         │    │    │    │    └── projections
- │         │    │    │    │         ├── unnest_1:4 [as=id:6, outer=(4)]
- │         │    │    │    │         └── unnest_2:5 [as=quantity:7, outer=(5)]
+ │         │    │    │    │    ├── (42948, 3)
+ │         │    │    │    │    └── (24924, 4)
  │         │    │    │    └── filters
  │         │    │    │         ├── ((((dealerid:8 = 1) OR (dealerid:8 = 2)) OR (dealerid:8 = 3)) OR (dealerid:8 = 4)) OR (dealerid:8 = 5) [outer=(8), constraints=(/8: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
  │         │    │    │         └── accountname:10 IN ('account-1', 'account-2', 'account-3') [outer=(10), constraints=(/10: [/'account-1' - /'account-1'] [/'account-2' - /'account-2'] [/'account-3' - /'account-3']; tight)]
@@ -1461,14 +1455,12 @@ update ci
       │    │    │    │    │    │    ├── cardinality: [2 - 2]
       │    │    │    │    │    │    ├── fd: ()-->(34)
       │    │    │    │    │    │    ├── values
-      │    │    │    │    │    │    │    ├── columns: unnest_1:4!null unnest_2:5!null
+      │    │    │    │    │    │    │    ├── columns: c:24!null q:25!null
       │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
       │    │    │    │    │    │    │    ├── (42948, 3)
       │    │    │    │    │    │    │    └── (24924, 4)
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         ├── 1 [as="project_const_col_@15":34]
-      │    │    │    │    │    │         ├── unnest_1:4 [as=c:24, outer=(4)]
-      │    │    │    │    │    │         └── unnest_2:5 [as=q:25, outer=(5)]
+      │    │    │    │    │    │         └── 1 [as="project_const_col_@15":34]
       │    │    │    │    │    └── filters (true)
       │    │    │    │    └── aggregations
       │    │    │    │         ├── first-agg [as=buyprice:17, outer=(17)]

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1080,17 +1080,11 @@ limit
  │         │    │    │    ├── columns: id:6!null quantity:7!null dealerid:8!null cardid:9!null accountname:10!null
  │         │    │    │    ├── key columns: [6] = [9]
  │         │    │    │    ├── fd: (6)==(9), (9)==(6)
- │         │    │    │    ├── project
+ │         │    │    │    ├── values
  │         │    │    │    │    ├── columns: id:6!null quantity:7!null
  │         │    │    │    │    ├── cardinality: [2 - 2]
- │         │    │    │    │    ├── values
- │         │    │    │    │    │    ├── columns: unnest_1:4!null unnest_2:5!null
- │         │    │    │    │    │    ├── cardinality: [2 - 2]
- │         │    │    │    │    │    ├── (42948, 3)
- │         │    │    │    │    │    └── (24924, 4)
- │         │    │    │    │    └── projections
- │         │    │    │    │         ├── unnest_1:4 [as=id:6, outer=(4)]
- │         │    │    │    │         └── unnest_2:5 [as=quantity:7, outer=(5)]
+ │         │    │    │    │    ├── (42948, 3)
+ │         │    │    │    │    └── (24924, 4)
  │         │    │    │    └── filters
  │         │    │    │         ├── ((((dealerid:8 = 1) OR (dealerid:8 = 2)) OR (dealerid:8 = 3)) OR (dealerid:8 = 4)) OR (dealerid:8 = 5) [outer=(8), constraints=(/8: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]; tight)]
  │         │    │    │         └── accountname:10 IN ('account-1', 'account-2', 'account-3') [outer=(10), constraints=(/10: [/'account-1' - /'account-1'] [/'account-2' - /'account-2'] [/'account-3' - /'account-3']; tight)]
@@ -1477,14 +1471,12 @@ update ci
       │    │    │    │    │    │    ├── cardinality: [2 - 2]
       │    │    │    │    │    │    ├── fd: ()-->(48)
       │    │    │    │    │    │    ├── values
-      │    │    │    │    │    │    │    ├── columns: unnest_1:4!null unnest_2:5!null
+      │    │    │    │    │    │    │    ├── columns: c:32!null q:33!null
       │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
       │    │    │    │    │    │    │    ├── (42948, 3)
       │    │    │    │    │    │    │    └── (24924, 4)
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         ├── 1 [as="project_const_col_@19":48]
-      │    │    │    │    │    │         ├── unnest_1:4 [as=c:32, outer=(4)]
-      │    │    │    │    │    │         └── unnest_2:5 [as=q:33, outer=(5)]
+      │    │    │    │    │    │         └── 1 [as="project_const_col_@19":48]
       │    │    │    │    │    └── filters (true)
       │    │    │    │    └── aggregations
       │    │    │    │         ├── first-agg [as=buyprice:21, outer=(21)]


### PR DESCRIPTION
Previously, the optimizer had no rule to fold projected remappings of columns
from a ValuesExpr.

This patch adds a rule that folds any ProjectionsItems into the passthrough
set if:

1. The projection does nothing but remap a colum from the input.

2. The column being remapped is not itself in the passthrough set.

The Values output columns are replaced by the corresponding columns
projected by the folded ProjectionsItems so that logical equivalency is
preserved.

Example:
```
project
 ├── columns: x:2!null
 ├── values
 │    ├── columns: column1:1!null
 │    ├── cardinality: [2 - 2]
 │    ├── (1,)
 │    └── (2,)
 └── projections
      └── column1:1 [as=x:2, outer=(1)]
  =>
project
 ├── columns: x:2!null
 └── values
      ├── columns: x:2!null
      ├── cardinality: [2 - 2]
      ├── (1,)
      └── (2,)
```
In this example, the project can now be removed altogether.

Fixes: #48083

Release note: None