### PR TITLE
release-20.1: kvserver: don't quiesce when there's outstanding quota 

### DIFF
--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -29,6 +29,11 @@ func (r *Replica) quiesceLocked() bool {
 		}
 		return false
 	}
+	// Note that we're not calling r.hasPendingProposalQuotaRLocked(). That has
+	// been checked on the leaseholder before deciding to quiesce. There's no
+	// point in checking it followers since the quota is reset when the lease
+	// changes.
+
 	if !r.mu.quiescent {
 		if log.V(3) {
 			log.Infof(ctx, "quiescing %d", r.RangeID)
@@ -161,6 +166,7 @@ type quiescer interface {
 	raftLastIndexLocked() (uint64, error)
 	hasRaftReadyRLocked() bool
 	hasPendingProposalsRLocked() bool
+	hasPendingProposalQuotaRLocked() bool
 	ownsValidLeaseRLocked(ts hlc.Timestamp) bool
 	mergeInProgressRLocked() bool
 	isDestroyedRLocked() (DestroyReason, error)
@@ -179,6 +185,16 @@ func shouldReplicaQuiesce(
 	if q.hasPendingProposalsRLocked() {
 		if log.V(4) {
 			log.Infof(ctx, "not quiescing: proposals pending")
+		}
+		return nil, false
+	}
+	// Don't quiesce if there's outstanding quota - it can lead to deadlock. This
+	// condition is largely subsumed by the upcoming replication state check,
+	// except that the conditions for replica availability are different, and the
+	// timing of releasing quota is unrelated to this function.
+	if q.hasPendingProposalQuotaRLocked() {
+		if log.V(4) {
+			log.Infof(ctx, "not quiescing: replication quota outstanding")
 		}
 		return nil, false
 	}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -9335,6 +9335,7 @@ type testQuiescer struct {
 	mergeInProgress bool
 	isDestroyed     bool
 	livenessMap     IsLiveMap
+	pendingQuota    bool
 }
 
 func (q *testQuiescer) descRLocked() *roachpb.RangeDescriptor {
@@ -9355,6 +9356,10 @@ func (q *testQuiescer) hasRaftReadyRLocked() bool {
 
 func (q *testQuiescer) hasPendingProposalsRLocked() bool {
 	return q.numProposals > 0
+}
+
+func (q *testQuiescer) hasPendingProposalQuotaRLocked() bool {
+	return q.pendingQuota
 }
 
 func (q *testQuiescer) ownsValidLeaseRLocked(ts hlc.Timestamp) bool {
@@ -9430,6 +9435,10 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 	})
 	test(false, func(q *testQuiescer) *testQuiescer {
 		q.numProposals = 1
+		return q
+	})
+	test(false, func(q *testQuiescer) *testQuiescer {
+		q.pendingQuota = true
 		return q
 	})
 	test(false, func(q *testQuiescer) *testQuiescer {

--- a/pkg/util/quotapool/intpool.go
+++ b/pkg/util/quotapool/intpool.go
@@ -294,7 +294,10 @@ func (p *IntPool) Len() int {
 }
 
 // ApproximateQuota will report approximately the amount of quota available in
-// the pool.
+// the pool. It's "approximate" because, if there's an acquisition in progress,
+// this might return an "intermediate" value - one that does not fully reflect
+// the capacity either before that acquisitions started or after it will have
+// finished.
 func (p *IntPool) ApproximateQuota() (q uint64) {
 	p.qp.ApproximateQuota(func(r Resource) {
 		if ia, ok := r.(*intAlloc); ok {
@@ -302,6 +305,11 @@ func (p *IntPool) ApproximateQuota() (q uint64) {
 		}
 	})
 	return q
+}
+
+// Full returns true if no quota is outstanding.
+func (p *IntPool) Full() bool {
+	return p.ApproximateQuota() == p.Capacity()
 }
 
 // Close signals to all ongoing and subsequent acquisitions that the pool is


### PR DESCRIPTION
Backport 1/5 commits from #48082.

/cc @cockroachdb/release

---

See individual commits.
