### PR TITLE
release-19.2: kvserver: don't quiesce when there's outstanding quota 

### DIFF
--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -379,6 +379,20 @@ func (r *Replica) hasPendingProposalsRLocked() bool {
 	return r.numPendingProposalsRLocked() > 0
 }
 
+// hasPendingProposalQuotaRLocked is part of the quiescer interface. It returns
+// true if there are any commands that haven't completed replicating that are
+// tracked by this node's quota pool (i.e. commands that haven't been acked by
+// all live replicas).
+// We can't quiesce while there's outstanding quota because the respective quota
+// would not be released while quiesced, and it might prevent the range from
+// unquiescing (leading to deadlock). See #46699.
+func (r *Replica) hasPendingProposalQuotaRLocked() bool {
+	if r.mu.proposalQuota == nil {
+		return true
+	}
+	return !r.mu.proposalQuota.Full()
+}
+
 var errRemoved = errors.New("replica removed")
 
 // stepRaftGroup calls Step on the replica's RawNode with the provided request's

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -9083,6 +9083,7 @@ type testQuiescer struct {
 	mergeInProgress bool
 	isDestroyed     bool
 	livenessMap     IsLiveMap
+	pendingQuota    bool
 }
 
 func (q *testQuiescer) descRLocked() *roachpb.RangeDescriptor {
@@ -9103,6 +9104,10 @@ func (q *testQuiescer) hasRaftReadyRLocked() bool {
 
 func (q *testQuiescer) hasPendingProposalsRLocked() bool {
 	return q.numProposals > 0
+}
+
+func (q *testQuiescer) hasPendingProposalQuotaRLocked() bool {
+	return q.pendingQuota
 }
 
 func (q *testQuiescer) ownsValidLeaseRLocked(ts hlc.Timestamp) bool {
@@ -9178,6 +9183,10 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 	})
 	test(false, func(q *testQuiescer) *testQuiescer {
 		q.numProposals = 1
+		return q
+	})
+	test(false, func(q *testQuiescer) *testQuiescer {
+		q.pendingQuota = true
 		return q
 	})
 	test(false, func(q *testQuiescer) *testQuiescer {

--- a/pkg/util/quotapool/intpool.go
+++ b/pkg/util/quotapool/intpool.go
@@ -212,7 +212,10 @@ func (p *IntPool) Len() int {
 }
 
 // ApproximateQuota will report approximately the amount of quota available in
-// the pool.
+// the pool. It's "approximate" because, if there's an acquisition in progress,
+// this might return an "intermediate" value - one that does not fully reflect
+// the capacity either before that acquisitions started or after it will have
+// finished.
 func (p *IntPool) ApproximateQuota() (q uint64) {
 	p.qp.ApproximateQuota(func(r Resource) {
 		if ia, ok := r.(*intAlloc); ok {
@@ -220,6 +223,11 @@ func (p *IntPool) ApproximateQuota() (q uint64) {
 		}
 	})
 	return q
+}
+
+// Full returns true if no quota is outstanding.
+func (p *IntPool) Full() bool {
+	return p.ApproximateQuota() == p.Capacity()
 }
 
 // Close signals to all ongoing and subsequent acquisitions that the pool is


### PR DESCRIPTION
Backport 1/5 commits from #48082.

/cc @cockroachdb/release

---

See individual commits.
