### PR TITLE
release-19.1: c-deps/rocksdb: fix correctness issue with snapshots and delete range

### DIFF
--- a/c-deps/cryptopp-rebuild
+++ b/c-deps/cryptopp-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing cryptopp configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-3
+3-19.1

--- a/c-deps/jemalloc-rebuild
+++ b/c-deps/jemalloc-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing jemalloc configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-4
+4-19.1

--- a/c-deps/krb5-rebuild
+++ b/c-deps/krb5-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing krb5 configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-1
+1-19.1

--- a/c-deps/libroach-rebuild
+++ b/c-deps/libroach-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing libroach CMake flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-3
+3-19.1

--- a/c-deps/protobuf-rebuild
+++ b/c-deps/protobuf-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing protobuf CMake flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-5
+5-19.1

--- a/c-deps/rocksdb-rebuild
+++ b/c-deps/rocksdb-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing rocksdb CMake flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-13
+13-19.1

--- a/c-deps/snappy-rebuild
+++ b/c-deps/snappy-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing snappy configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-6
+6-19.1


### PR DESCRIPTION
The optimization to skip sstables and swaths of keys within an sstable
covered by a range tombstone has correctness issues when used with
snapshot reads. This optimization isn't present in later versions of
RocksDB, so disable it rather than trying to fix.

Release note (bug fix): Fix a bug that could lead to data corruption or
data loss if a replica was both the source of a snapshot and was being
concurrently removed from the range. This scenario is rare, but
possible.