### PR TITLE
release-2.1: c-deps/rocksdb: fix correctness issue with snapshots and delete range

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -551,7 +551,7 @@ $(ROCKSDB_DIR)/Makefile: $(C_DEPS_DIR)/rocksdb-rebuild | bin/.submodules-initial
 	  $(if $(findstring release,$(BUILDTYPE)),-DPORTABLE=ON) -DWITH_GFLAGS=OFF \
 	  -DSNAPPY_LIBRARIES=$(LIBSNAPPY) -DSNAPPY_INCLUDE_DIR="$(SNAPPY_SRC_DIR);$(SNAPPY_DIR)" -DWITH_SNAPPY=ON \
 	  $(if $(use-stdmalloc),,-DJEMALLOC_LIBRARIES=$(LIBJEMALLOC) -DJEMALLOC_INCLUDE_DIR=$(JEMALLOC_DIR)/include -DWITH_JEMALLOC=ON) \
-	  -DCMAKE_BUILD_TYPE=$(if $(ENABLE_ROCKSDB_ASSERTIONS),Debug,Release)
+	  -DCMAKE_BUILD_TYPE=$(if $(ENABLE_ROCKSDB_ASSERTIONS),Debug,Release) -DFAIL_ON_WARNINGS=0
 
 $(SNAPPY_DIR)/Makefile: $(C_DEPS_DIR)/snappy-rebuild | bin/.submodules-initialized
 	rm -rf $(SNAPPY_DIR)

--- a/c-deps/cryptopp-rebuild
+++ b/c-deps/cryptopp-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing cryptopp configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-3
+3-2.1

--- a/c-deps/jemalloc-rebuild
+++ b/c-deps/jemalloc-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing jemalloc configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-4
+4-2.1

--- a/c-deps/libroach-rebuild
+++ b/c-deps/libroach-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing libroach CMake flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-3
+3-2.1

--- a/c-deps/protobuf-rebuild
+++ b/c-deps/protobuf-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing protobuf CMake flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-5
+5-2.1

--- a/c-deps/rocksdb-rebuild
+++ b/c-deps/rocksdb-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing rocksdb CMake flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-10
+10-2.1

--- a/c-deps/snappy-rebuild
+++ b/c-deps/snappy-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing snappy configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-6
+6-2.1


### PR DESCRIPTION
The optimization to skip sstables and swaths of keys within an sstable
covered by a range tombstone has correctness issues when used with
snapshot reads. This optimization isn't present in later versions of
RocksDB, so disable it rather than trying to fix.

Release note (bug fix): Fix a bug that could lead to data corruption or
data loss if a replica was both the source of a snapshot and was being
concurrently removed from the range. This scenario is rare, but
possible.