### PR TITLE
release-19.2: c-deps/rocksdb: fix correctness issue with snapshots and delete range

### DIFF
--- a/c-deps/cryptopp-rebuild
+++ b/c-deps/cryptopp-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing cryptopp configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-3
+3-19.2

--- a/c-deps/jemalloc-rebuild
+++ b/c-deps/jemalloc-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing jemalloc configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-4
+4-19.2

--- a/c-deps/krb5-rebuild
+++ b/c-deps/krb5-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing krb5 configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-1
+1-19.2

--- a/c-deps/libedit-rebuild
+++ b/c-deps/libedit-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing libedit configure flags. Search for "BUILD
 ARTIFACT CACHING" in the top-level Makefile for rationale.
 
-1
+1-19.2

--- a/c-deps/libroach-rebuild
+++ b/c-deps/libroach-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing libroach CMake flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-3
+3-19.2

--- a/c-deps/protobuf-rebuild
+++ b/c-deps/protobuf-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing protobuf CMake flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-5
+5-19.2

--- a/c-deps/rocksdb-rebuild
+++ b/c-deps/rocksdb-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing rocksdb CMake flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-13
+13-19.2

--- a/c-deps/snappy-rebuild
+++ b/c-deps/snappy-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing snappy configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-6
+6-19.2


### PR DESCRIPTION
Fix a bug where RocksDB allowed a range deletion added after a snapshot
was created to incorrectly affect reads from the snapshot if the range
deletion was present in an immutable memtable.

Release note (bug fix): Fix a bug that could lead to data corruption or
data loss if a replica was both the source of a snapshot and was being
concurrently removed from the range and certain specific conditions
exist inside RocksDB. This scenario is rare, but possible.