### PR TITLE
server: ignore SRV results with port 0 for --join list lookups

### DIFF
--- a/pkg/gossip/resolver/resolver.go
+++ b/pkg/gossip/resolver/resolver.go
@@ -53,7 +53,6 @@ func SRV(name string) ([]string, error) {
 	}
 
 	if name == "" {
-		// nolint:returnerrcheck
 		return nil, nil
 	}
 
@@ -67,9 +66,11 @@ func SRV(name string) ([]string, error) {
 		return nil, errors.Wrapf(err, "failed to lookup SRV record for %q", name)
 	}
 
-	var addrs = make([]string, len(recs))
-	for i, r := range recs {
-		addrs[i] = net.JoinHostPort(r.Target, fmt.Sprintf("%d", r.Port))
+	addrs := []string{}
+	for _, r := range recs {
+		if r.Port != 0 {
+			addrs = append(addrs, net.JoinHostPort(r.Target, fmt.Sprintf("%d", r.Port)))
+		}
 	}
 
 	return addrs, nil

--- a/pkg/gossip/resolver/resolver_test.go
+++ b/pkg/gossip/resolver/resolver_test.go
@@ -108,6 +108,7 @@ func TestSRV(t *testing.T) {
 		srvs := []*net.SRV{
 			{Target: "node1", Port: 26222},
 			{Target: "node2", Port: 35222},
+			{Target: "node3", Port: 0},
 		}
 
 		return "cluster", srvs, nil


### PR DESCRIPTION
This introduces two changes to the current implementation of SRV record support in the join list:

1. In the real world it is possible to get an SRV result with port 0 which does not make practical sense and leads to unnecessary attempts to open a connection to that port. Now SRV
records with port 0 are ignored.

2. We did SRV resolution for records of "hostname:port", but I propose to immediately treat them as a host address and skip SRV lookup as SRV request does not use that format and works
with tuples of (hostname, port, protocol). This also creates a way to opt-out from SRV resolution via adding port numbers to hostnames.