### PR TITLE
sql: execute multiple levels of cascades

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -141,17 +141,10 @@ const ReorderJoinsLimitClusterSettingName = "sql.defaults.reorder_joins_limit"
 
 // ReorderJoinsLimitClusterValue controls the cluster default for the maximum
 // number of joins reordered.
-var ReorderJoinsLimitClusterValue = settings.RegisterValidatedIntSetting(
+var ReorderJoinsLimitClusterValue = settings.RegisterNonNegativeIntSetting(
 	ReorderJoinsLimitClusterSettingName,
 	"default number of joins to reorder",
 	opt.DefaultJoinOrderLimit,
-	func(v int64) error {
-		if v < 0 {
-			return pgerror.Newf(pgcode.InvalidParameterValue,
-				"cannot set sql.defaults.reorder_joins_limit to a negative value: %d", v)
-		}
-		return nil
-	},
 )
 
 var requireExplicitPrimaryKeysClusterMode = settings.RegisterBoolSetting(
@@ -188,6 +181,12 @@ var optDrivenFKCascadesClusterMode = settings.RegisterBoolSetting(
 	"sql.defaults.experimental_optimizer_foreign_key_cascades.enabled",
 	"default value for experimental_optimizer_foreign_key_cascades session setting; enables optimizer-driven foreign key cascades by default",
 	false,
+)
+
+var optDrivenFKCascadesClusterLimit = settings.RegisterNonNegativeIntSetting(
+	"sql.defaults.foreign_key_cascades_limit",
+	"default value for foreign_key_cascades_limit session setting; limits the number of cascading operations that run as part of a single query",
+	10000,
 )
 
 // optUseHistogramsClusterMode controls the cluster default for whether
@@ -1957,6 +1956,10 @@ func (m *sessionDataMutator) SetOptimizerFKChecks(val bool) {
 
 func (m *sessionDataMutator) SetOptimizerFKCascades(val bool) {
 	m.data.OptimizerFKCascades = val
+}
+
+func (m *sessionDataMutator) SetOptimizerFKCascadesLimit(val int) {
+	m.data.OptimizerFKCascadesLimit = val
 }
 
 func (m *sessionDataMutator) SetOptimizerUseHistograms(val bool) {

--- a/pkg/sql/logictest/testdata/logic_test/cascade_opt
+++ b/pkg/sql/logictest/testdata/logic_test/cascade_opt
@@ -72,6 +72,44 @@ statement ok
 DELETE FROM parent WHERE p = 1
 
 statement ok
+DROP TABLE grandchild
+
+# Delete cascade which itself has a cascade.
+statement ok
+CREATE TABLE grandchild (
+  g INT PRIMARY KEY,
+  c INT REFERENCES child(c) ON DELETE CASCADE
+);
+INSERT INTO parent VALUES (1), (2);
+INSERT INTO child VALUES (10, 1), (11, 1), (20, 2), (21, 2);
+INSERT INTO grandchild VALUES (100, 10), (101, 10), (110, 11), (200, 20)
+
+statement ok
+DELETE FROM parent WHERE p = 1
+
+query II rowsort
+SELECT * FROM child
+----
+20  2
+21  2
+
+query II rowsort
+SELECT * FROM grandchild
+----
+200  20
+
+statement ok
+DELETE FROM parent WHERE p = 2
+
+query II
+SELECT * FROM child
+----
+
+query II
+SELECT * FROM grandchild
+----
+
+statement ok
 DROP TABLE grandchild;
 DROP TABLE child;
 DROP TABLE parent
@@ -181,9 +219,56 @@ SELECT a,b,c FROM child_multi_2
 ----
 3  30  300
 
+statement ok
+DROP TABLE child_multi_1;
+DROP TABLE child_multi_2;
+DROP TABLE parent_multi
+
+# Self-referencing cascade.
+statement ok
+CREATE TABLE self (a INT PRIMARY KEY, b INT REFERENCES self(a) ON DELETE CASCADE)
+
+statement ok
+INSERT INTO self VALUES (1, NULL);
+INSERT INTO self SELECT x, x-1 FROM generate_series(2, 10) AS g(x)
+
+statement ok
+DELETE FROM self WHERE a = 4
+
+query II rowsort
+SELECT * FROM self
+----
+1   NULL
+2   1
+3   2
+
+statement ok
+DELETE FROM self WHERE a = 1
+
+query II
+SELECT * FROM self
+----
+
+# Test cascade limit setting.
+statement ok
+INSERT INTO self VALUES (1, NULL);
+INSERT INTO self SELECT x, x-1 FROM generate_series(2, 20) AS g(x)
+
+statement ok
+SET foreign_key_cascades_limit = 10
+
+statement error cascades limit \(10\) reached
+DELETE FROM self WHERE a = 1
+
+statement ok
+RESET foreign_key_cascades_limit
+
 # TODO(radu): enable when we support Cascades.
 statement ok
 SET experimental_optimizer_foreign_key_cascades = false
+
+statement ok
+DROP TABLE self
 
 subtest AllCascadingActions
 ### A test of all cascading actions in their most basic form.

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1678,6 +1678,7 @@ experimental_optimizer_foreign_key_cascades  off                 NULL      NULL 
 experimental_serial_normalization            rowid               NULL      NULL        NULL        string
 extra_float_digits                           0                   NULL      NULL        NULL        string
 force_savepoint_restart                      off                 NULL      NULL        NULL        string
+foreign_key_cascades_limit                   10000               NULL      NULL        NULL        string
 idle_in_transaction_session_timeout          0                   NULL      NULL        NULL        string
 integer_datetimes                            on                  NULL      NULL        NULL        string
 intervalstyle                                postgres            NULL      NULL        NULL        string
@@ -1741,6 +1742,7 @@ experimental_optimizer_foreign_key_cascades  off                 NULL  user     
 experimental_serial_normalization            rowid               NULL  user     NULL      rowid               rowid
 extra_float_digits                           0                   NULL  user     NULL      0                   2
 force_savepoint_restart                      off                 NULL  user     NULL      off                 off
+foreign_key_cascades_limit                   10000               NULL  user     NULL      10000               10000
 idle_in_transaction_session_timeout          0                   NULL  user     NULL      0                   0
 integer_datetimes                            on                  NULL  user     NULL      on                  on
 intervalstyle                                postgres            NULL  user     NULL      postgres            postgres
@@ -1800,6 +1802,7 @@ experimental_optimizer_foreign_key_cascades  NULL    NULL     NULL     NULL     
 experimental_serial_normalization            NULL    NULL     NULL     NULL        NULL
 extra_float_digits                           NULL    NULL     NULL     NULL        NULL
 force_savepoint_restart                      NULL    NULL     NULL     NULL        NULL
+foreign_key_cascades_limit                   NULL    NULL     NULL     NULL        NULL
 idle_in_transaction_session_timeout          NULL    NULL     NULL     NULL        NULL
 integer_datetimes                            NULL    NULL     NULL     NULL        NULL
 intervalstyle                                NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -47,6 +47,7 @@ experimental_optimizer_foreign_key_cascades  off
 experimental_serial_normalization            rowid
 extra_float_digits                           0
 force_savepoint_restart                      off
+foreign_key_cascades_limit                   10000
 idle_in_transaction_session_timeout          0
 integer_datetimes                            on
 intervalstyle                                postgres

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -47,6 +47,9 @@ type SessionData struct {
 	// OptimizerFKCascades indicates whether we should use the new paths to plan foreign
 	// key cascades in the optimizer.
 	OptimizerFKCascades bool
+	// OptimizerFKCascadesLimit is the maximum number of cascading operations that
+	// are run for a single query.
+	OptimizerFKCascadesLimit int
 	// OptimizerUseHistograms indicates whether we should use histograms for
 	// cardinality estimation in the optimizer.
 	OptimizerUseHistograms bool

--- a/pkg/sql/sqltelemetry/exec.go
+++ b/pkg/sql/sqltelemetry/exec.go
@@ -29,3 +29,7 @@ var VecExecCounter = telemetry.GetCounterOnce("sql.exec.query.is-vectorized")
 func VecModeCounter(mode string) telemetry.Counter {
 	return telemetry.GetCounter(fmt.Sprintf("sql.exec.vectorized-setting.%s", mode))
 }
+
+// CascadesLimitReached is to be incremented whenever the limit of foreign key
+// cascade for a single query is exceeded.
+var CascadesLimitReached = telemetry.GetCounterOnce("sql.exec.cascade-limit-reached")

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -542,6 +542,29 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`foreign_key_cascades_limit`: {
+		GetStringVal: makeIntGetStringValFn(`foreign_key_cascades_limit`),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			b, err := strconv.ParseInt(s, 10, 64)
+			if err != nil {
+				return err
+			}
+			if b < 0 {
+				return pgerror.Newf(pgcode.InvalidParameterValue,
+					"cannot set foreign_key_cascades_limit to a negative value: %d", b)
+			}
+			m.SetOptimizerFKCascadesLimit(int(b))
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return strconv.FormatInt(int64(evalCtx.SessionData.OptimizerFKCascadesLimit), 10)
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return strconv.FormatInt(optDrivenFKCascadesClusterLimit.Get(sv), 10)
+		},
+	},
+
+	// CockroachDB extension.
 	`optimizer_use_histograms`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_histograms`),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {


### PR DESCRIPTION
Support executing FK cascades that themselves have cascades: we simply append
the cascade to our existing list (which acts as a queue).

Because each cascade has a plan that uses some amount of unaccounted memory, we
add a configurable limit on the number of cascades that can run as part of a
single query. We also add a telemetry counter so we can keep track if users are
hitting this.

Release note: None