### PR TITLE
workload/schemachange: classify schema change errors

### DIFF
--- a/pkg/cmd/roachtest/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/mixed_version_schemachange.go
@@ -33,7 +33,7 @@ func registerSchemaChangeMixedVersions(r *testRegistry) {
 				maxOps = 10
 				concurrency = 2
 			}
-			runSchemaChangeMixedVersions(ctx, t, c, maxOps, r.buildVersion)
+			runSchemaChangeMixedVersions(ctx, t, c, maxOps, concurrency, r.buildVersion)
 		},
 	})
 }
@@ -69,7 +69,12 @@ func runSchemaChangeWorkloadStep(loadNode, maxOps, concurrency int) versionStep 
 }
 
 func runSchemaChangeMixedVersions(
-	ctx context.Context, t *test, c *cluster, maxOps int, buildVersion version.Version,
+	ctx context.Context,
+	t *test,
+	c *cluster,
+	maxOps int,
+	concurrency int,
+	buildVersion version.Version,
 ) {
 	predecessorVersion, err := PredecessorVersion(buildVersion)
 	if err != nil {

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -78,6 +78,7 @@ func registerTests(r *testRegistry) {
 	registerSchemaChangeDuringTPCC1000(r)
 	registerSchemaChangeInvertedIndex(r)
 	registerSchemaChangeMixedVersions(r)
+	registerSchemaChangeRandomLoad(r)
 	registerScrubAllChecksTPCC(r)
 	registerScrubIndexOnlyTPCC(r)
 	registerSecondaryIndexesMultiVersionCluster(r)

--- a/pkg/cmd/roachtest/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/schemachange_random_load.go
@@ -1,0 +1,60 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+func registerSchemaChangeRandomLoad(r *testRegistry) {
+	r.Add(testSpec{
+		Name:    "schemachange/random-load",
+		Owner:   OwnerSQLSchema,
+		Cluster: makeClusterSpec(3),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			maxOps := 5000
+			concurrency := 20
+			if local {
+				maxOps = 1000
+				concurrency = 2
+			}
+			runSchemaChangeRandomLoad(ctx, t, c, maxOps, concurrency)
+		},
+		Skip: "deadlocks because of pgx bug",
+	})
+}
+
+func runSchemaChangeRandomLoad(ctx context.Context, t *test, c *cluster, maxOps, concurrency int) {
+	loadNode := c.Node(1)
+	roachNodes := c.Range(1, c.spec.NodeCount)
+	t.Status("copying binaries")
+	c.Put(ctx, cockroach, "./cockroach", roachNodes)
+	c.Put(ctx, workload, "./workload", loadNode)
+
+	t.Status("starting cockroach nodes")
+	c.Start(ctx, t, roachNodes)
+	c.Run(ctx, loadNode, "./workload init schemachange")
+
+	runCmd := []string{
+		"./workload run schemachange --verbose=1",
+		// The workload is still in development and occasionally discovers schema
+		// change errors so for now we don't fail on them but only on panics, server
+		// crashes, deadlocks, etc.
+		// TODO(spaskob): remove when https://github.com/cockroachdb/cockroach/issues/47430
+		// is closed.
+		"--tolerate-errors=true",
+		fmt.Sprintf("--max-ops %d", maxOps),
+		fmt.Sprintf("--concurrency %d", concurrency),
+	}
+	t.Status("running schemachange workload")
+	c.Run(ctx, loadNode, runCmd...)
+}

--- a/pkg/cmd/roachtest/versionupgrade.go
+++ b/pkg/cmd/roachtest/versionupgrade.go
@@ -99,7 +99,7 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster, buildVersion ve
 	}
 
 	testFeaturesStep := versionUpgradeTestFeatures.step(c.All())
-	schemaChangeStep := runSchemaChangeWorkloadStep(10 /* maxOps */)
+	schemaChangeStep := runSchemaChangeWorkloadStep(c.All().randNode()[0], 10 /* maxOps */, 2 /* concurrency */)
 
 	// The steps below start a cluster at predecessorVersion (from a fixture),
 	// then start an upgrade that is rolled back, and finally start and finalize

--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -231,7 +231,7 @@ func workerRun(
 		}
 
 		if err := workFn(ctx); err != nil {
-			if errors.Is(err, ctx.Err()) {
+			if ctx.Err() != nil && errors.Is(err, ctx.Err()) {
 				return
 			}
 			errCh <- err

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -244,63 +244,107 @@ type schemaChangeWorker struct {
 	seqNum          *int64
 }
 
-func (w *schemaChangeWorker) runInTxn(tx *pgx.Tx) (string, error) {
+// handleOpError returns an error if the op error is considered serious and
+// we should terminate the workload.
+func handleOpError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if pgErr := (pgx.PgError{}); errors.As(err, &pgErr) {
+		sqlstate := pgErr.SQLState()
+		class := sqlstate[0:2]
+		switch class {
+		case "09":
+			return errors.Wrap(err, "Class 09 - Triggered Action Exception")
+		case "XX":
+			return errors.Wrap(err, "Class XX - Internal Error")
+		}
+	} else {
+		return errors.Wrapf(err, "unexpected error %v", err)
+	}
+	return nil
+}
+
+var (
+	errRunInTxnFatalSentinel = errors.New("fatal error when running txn")
+	errRunInTxnRbkSentinel   = errors.New("txn needs to rollback")
+)
+
+func (w *schemaChangeWorker) runInTxn(tx *pgx.Tx, opsNum int) (string, error) {
 	var log strings.Builder
-	// Run between 1 and maxOpsPerWorker schema change operations.
-	n := 1 + w.rng.Intn(w.maxOpsPerWorker)
-	for i := 0; i < n; i++ {
+	for i := 0; i < opsNum; i++ {
 		op, noops, err := w.randOp(tx)
 		if err != nil {
-			return noops, errors.Wrap(err, "randOp")
+			return noops, errors.Mark(
+				errors.Wrap(err, "could not generate a random operation"),
+				errRunInTxnFatalSentinel,
+			)
 		}
-		log.WriteString(noops)
+		if w.verbose >= 2 {
+			// Print the failed attempts to produce a random operation.
+			log.WriteString(noops)
+		}
 		log.WriteString(fmt.Sprintf("  %s;\n", op))
 		if !w.dryRun {
-			if _, err := tx.Exec(op); err != nil {
-				return log.String(), errors.Wrapf(err, "%s failed", op)
+			histBin := "opOk"
+			start := timeutil.Now()
+			if _, err = tx.Exec(op); err != nil {
+				histBin = "txnRbk"
+				log.WriteString(fmt.Sprintf("***FAIL: %v\n", err))
+				log.WriteString("ROLLBACK;\n")
+				return log.String(), errors.Mark(err, errRunInTxnRbkSentinel)
 			}
+			elapsed := timeutil.Since(start)
+			w.hists.Get(histBin).Record(elapsed)
 		}
 	}
 	return log.String(), nil
 }
 
 func (w *schemaChangeWorker) run(_ context.Context) error {
-	start := timeutil.Now()
 	tx, err := w.pool.Get().Begin()
 	if err != nil {
 		return errors.Wrap(err, "cannot get a connection and begin a txn")
 	}
+	opsNum := 1 + w.rng.Intn(w.maxOpsPerWorker)
 
-	var histBin string
-	log, err := w.runInTxn(tx)
-	elapsed := timeutil.Since(start)
+	// Run between 1 and maxOpsPerWorker schema change operations.
+	start := timeutil.Now()
+	logs, err := w.runInTxn(tx, opsNum)
+	logs = "BEGIN\n" + logs
+	defer func() {
+		if w.verbose >= 1 {
+			fmt.Print(logs)
+		}
+	}()
+
 	if err != nil {
-		rbkErr := tx.Rollback()
-		if rbkErr != nil {
-			w.hists.Get("rbk").Record(elapsed)
-			err = errors.Wrapf(err, "ROLLBACK: %v", rbkErr)
+		// Rollback in all cases to release the txn object and its conn pool.
+		if rbkErr := tx.Rollback(); rbkErr != nil {
+			return errors.Wrapf(err, "Could not rollback %v", rbkErr)
 		}
-		log = log + "ROLLBACK;\n"
-		histBin = "err"
-		// TODO(spaskob): should we log the ROLLBACK error as well?
-	} else {
-		log = log + "COMMIT;\n"
-		if err = tx.Commit(); err != nil {
-			histBin = "cmt_err"
-			err = errors.Wrap(err, "COMMIT")
-		} else {
-			histBin = "ok"
-		}
-	}
-	w.hists.Get(histBin).Record(elapsed)
-	if w.verbose >= 1 {
-		fmt.Print("BEGIN\n")
-		fmt.Print(log)
-		if err != nil {
-			fmt.Printf("%v\n", err)
+		switch {
+		case errors.Is(err, errRunInTxnFatalSentinel):
+			return err
+		case errors.Is(err, errRunInTxnRbkSentinel):
+			if seriousErr := handleOpError(err); seriousErr != nil {
+				return seriousErr
+			}
+			return nil
+		default:
+			return errors.Wrapf(err, "Unexpected error")
 		}
 	}
-	// TODO(spaskob): what to do with the error instead dropping it?
+
+	// If there were no errors commit the txn.
+	histBin := "txnOk"
+	cmtErrMsg := ""
+	if err = tx.Commit(); err != nil {
+		histBin = "txnCmtErr"
+		cmtErrMsg = fmt.Sprintf("***FAIL: %v", err)
+	}
+	w.hists.Get(histBin).Record(timeutil.Since(start))
+	logs = logs + fmt.Sprintf("COMMIT;  %s\n", cmtErrMsg)
 	return nil
 }
 
@@ -391,9 +435,7 @@ func (w *schemaChangeWorker) randOp(tx *pgx.Tx) (string, string, error) {
 
 		// TODO(spaskob): use more fine-grained error reporting.
 		if stmt == "" || errors.Is(err, pgx.ErrNoRows) {
-			if w.verbose >= 2 {
-				log.WriteString(fmt.Sprintf("NOOP: %s -> %v\n", op, err))
-			}
+			log.WriteString(fmt.Sprintf("NOOP: %s -> %v\n", op, err))
 			continue
 		}
 		return stmt, log.String(), err


### PR DESCRIPTION
Previously this workload will not fail even when a schema change
operation returns an error. Now we extract the SQLSTATE code from
the error and if it is of class `09`, i.e. Triggered Action Exception
or `XX`, i.e. Internal Error we abort the workload and report the error.
Also previously we aborted the txn at the first operation error, now
we continue unless the error is one of the classes above.
We also add a roachtest `schemachange/random-load` that runs
the workload and fails if unclassified errors are encountered.

Fixes #23286.

Release note: none.