### PR TITLE
release-20.1: sql: do not try to create histograms on array columns

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -204,9 +204,10 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 			columnIDs[i] = columns[i].ID
 		}
 		colStats = []jobspb.CreateStatsDetails_ColStat{{ColumnIDs: columnIDs, HasHistogram: false}}
-		if len(columnIDs) == 1 {
+		if len(columnIDs) == 1 && columns[0].Type.Family() != types.ArrayFamily {
 			// By default, create histograms on all explicitly requested column stats
-			// with a single column.
+			// with a single column. (We cannot create histograms on array columns
+			// because we do not support key encoding arrays.)
 			colStats[0].HasHistogram = true
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -486,3 +486,22 @@ FROM [SHOW STATISTICS FOR TABLE arr] ORDER BY statistics_name, column_names::STR
 statistics_name  column_names  row_count  distinct_count  null_count
 arr_stats        {rowid}       4          4               0
 arr_stats        {x}           4          3               1
+
+# Regression test for #46964. Do not try to create a histogram on the array column.
+statement ok
+CREATE STATISTICS arr_stats_x ON x FROM arr
+
+query TTIIIB colnames
+SELECT
+  statistics_name,
+  column_names,
+  row_count,
+  distinct_count,
+  null_count,
+  histogram_id IS NOT NULL AS has_histogram
+FROM [SHOW STATISTICS FOR TABLE arr]
+ORDER BY statistics_name, column_names::STRING
+----
+statistics_name  column_names  row_count  distinct_count  null_count  has_histogram
+arr_stats        {rowid}       4          4               0           true
+arr_stats_x      {x}           4          3               1           false


### PR DESCRIPTION
Backport 1/1 commits from #47281.

/cc @cockroachdb/release

---

Prior to this commit, we would always create a histogram on any
column that was explicitly requested for stats creation using the
syntax:
```
CREATE STATISTICS stat_name ON col_name FROM table_name;
```
However, if `col_name` was an array column, this command would fail
with the error `unable to encode table key: *tree.DArray`. The
reason for this failure is that histogram creation requires the
ability to perform key encoding on the requested column, and that
is not possible for array columns.

This commit fixes the problem by avoiding creation of a histogram
if the requested column has type array. The other statistics
(null count, distinct count, etc) do not require key encoding, so
they can still be collected succesfully for array columns.

Fixes #46964

Release note (bug fix): Fixed an error that occurred when statistics
collection was explicitly requested on a column with type array.
Release note (sql change): Histogram collection with CREATE STATISTICS
is no longer supported on columns with type array. Only row count,
distinct count, and null count are collected for array-type columns.
