### PR TITLE
release-20.1: vendor: bump pebble to e6f57fcc8db7016fec64e59bd5aa9b64d050ee4e

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -464,7 +464,7 @@
 
 [[projects]]
   branch = "crl-release-20.1"
-  digest = "1:da6aafa8c3148636600ca6d3e0518381bff7314a22d49212040a1ed4d6417206"
+  digest = "1:3928c9ad1dfa8ab6449da5d69ecee273308812f6d27ed1e683566e7103488bdb"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -490,7 +490,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "b46a83e31ff105cf3ffa3dcc67c4e9223b6b2f0a"
+  revision = "e6f57fcc8db7016fec64e59bd5aa9b64d050ee4e"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
* internal/cache: fix double-free of cache entries
* sstable: support NeedCompact method for property collectors

Release note (bug fix): Fix a nil pointer dereference in Pebble's block
cache due to a rare "double free" of a block.

Release note (bug fix): Fix Pebble to properly mark sstables for
compaction which contain range tombstones. This matches the behavior
when using RocksDB and ensures that space used for temporary storage is
reclaimed quickly.