### PR TITLE
release-20.1: sql: fix panic when SHOW RANGES is called with a virtual table

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -530,3 +530,11 @@ query T
 SELECT crdb_internal.pretty_key(crdb_internal.encode_key(70, 4, (1, )), 0)
 ----
 /70/4/1/0
+
+# Regression test for #44326. SHOW RANGES on a virtual table should cause
+# an error, not a panic.
+query error \"crdb_internal.tables\" is a virtual table
+SHOW RANGES FROM TABLE crdb_internal.tables
+
+query error \"crdb_internal.tables\" is a virtual table
+SHOW RANGE FROM TABLE crdb_internal.tables FOR ROW (0, 0)

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -64,6 +64,11 @@ func ResolveTableIndex(
 				pgcode.WrongObjectType, "%q is not a table", name.Table.TableName,
 			)
 		}
+		if table.IsVirtualTable() {
+			return nil, DataSourceName{}, pgerror.Newf(
+				pgcode.WrongObjectType, "%q is a virtual table", name.Table.String(),
+			)
+		}
 		if name.Index == "" {
 			// Return primary index.
 			return table.Index(0), tn, nil


### PR DESCRIPTION
Backport 1/1 commits from #47500.

/cc @cockroachdb/release

---

Prior to this commit, calling `SHOW RANGES` or `SHOW RANGE FOR ROW` with
a virtual table caused a panic, since virtual tables have no ranges.
This commit fixes the problem by returning an error instead of a panic.

Fixes #44326

Release note (bug fix): Fixed a panic that could occur when SHOW RANGES
or SHOW RANGE FOR ROW was called with a virtual table.
