### PR TITLE
sql: remove typo in pg_catalog.pg_aggregate table population.

### DIFF
--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2994,7 +2994,7 @@ CREATE TABLE pg_catalog.pg_aggregate (
 								sortOperatorOid = h.OperatorOid("<", argType, argType, returnType)
 
 							// Cases to determine aggregate kind.
-							case "rank", "percent_rank", "cume_dict", "dense_rank":
+							case "rank", "percent_rank", "cume_dist", "dense_rank":
 								aggregateKind = tree.NewDString("h")
 								aggNumDirectArgs = tree.NewDInt(1)
 							case "mode":


### PR DESCRIPTION
This PR corrects the typo introduced by following PR
https://github.com/cockroachdb/cockroach/pull/48126 that is update reference of builtin function
from `cume_dict` to `cume_dist`.

Release note: None