### PR TITLE
opt: correctly type Null in SimplifySameVarEqualities

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/sqlsmith
+++ b/pkg/sql/logictest/testdata/logic_test/sqlsmith
@@ -141,3 +141,12 @@ NULL  1984-01-07 00:00:00 +0000 +0000  NULL  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d
 NULL  1984-01-07 00:00:00 +0000 +0000  NULL  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
 NULL  1984-01-07 00:00:00 +0000 +0000  NULL  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
 NULL  1984-01-07 00:00:00 +0000 +0000  NULL  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
+
+# Regression: #48267 (invalid opt transformation of OR with NULL)
+statement ok
+CREATE TABLE t (d) AS VALUES ('2001-01-01'::DATE)
+
+query T
+SELECT * FROM t WHERE (d = d) OR (d = d)
+----
+2001-01-01 00:00:00 +0000 +0000

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -377,8 +377,8 @@
 )
 =>
 (Or
-    (IsNot $left (Null $typ:(TypeOf $left)))
-    (Null $typ)
+    (IsNot $left (Null (TypeOf $left)))
+    (Null (BoolType))
 )
 
 # SimplifySameVarInequalities converts `x != x` and other inequality
@@ -391,6 +391,6 @@
 )
 =>
 (And
-    (Is $left (Null $typ:(TypeOf $left)))
-    (Null $typ)
+    (Is $left (Null (TypeOf $left)))
+    (Null (BoolType))
 )

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1868,7 +1868,7 @@ project
  │    ├── columns: k:1!null
  │    └── key: (1)
  └── projections
-      └── (k:1 IS DISTINCT FROM CAST(NULL AS INT8)) OR CAST(NULL AS INT8) [as="?column?":7, outer=(1)]
+      └── (k:1 IS DISTINCT FROM CAST(NULL AS INT8)) OR CAST(NULL AS BOOL) [as="?column?":7, outer=(1)]
 
 # --------------------------------------------------
 # SimplifySameVarInequalities
@@ -1946,4 +1946,4 @@ project
  │    ├── columns: k:1!null
  │    └── key: (1)
  └── projections
-      └── (k:1 IS NOT DISTINCT FROM CAST(NULL AS INT8)) AND CAST(NULL AS INT8) [as="?column?":7, outer=(1)]
+      └── (k:1 IS NOT DISTINCT FROM CAST(NULL AS INT8)) AND CAST(NULL AS BOOL) [as="?column?":7, outer=(1)]


### PR DESCRIPTION
Since IS always returns a bool (and OR always takes a bool) the second
NULL in SimplifySameVarEqualities should be a bool.

Fixes #48267