### PR TITLE
release-20.1: security: Disable TLS 1.3

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -120,10 +120,15 @@ vols="${vols} --volume=${HOME}/.yarn-cache:${container_home}/.yarn-cache${cached
 
 # If we're running in an environment that's using git alternates, like TeamCity,
 # we must mount the path to the real git objects for git to work in the container.
-alternates_file=${cockroach_toplevel}/.git/objects/info/alternates
-if test -e "${alternates_file}"; then
-  alternates_path=$(cat "${alternates_file}")
-  vols="${vols} --volume=${alternates_path}:${alternates_path}${cached_volume_mode}"
+# alternates_file=${cockroach_toplevel}/.git/objects/info/alternates
+# if test -e "${alternates_file}"; then
+#   alternates_path=$(cat "${alternates_file}")
+#   vols="${vols} --volume=${alternates_path}:${alternates_path}${cached_volume_mode}"
+# fi
+
+teamcity_alternates="/home/agent/system/git/"
+if test -d "${teamcity_alternates}"; then
+    vols="${vols} --volume=${teamcity_alternates}:${teamcity_alternates}${cached_volume_mode}"
 fi
 
 if [ "${BUILDER_HIDE_GOPATH_SRC:-}" != "1" ]; then

--- a/pkg/security/tls.go
+++ b/pkg/security/tls.go
@@ -222,5 +222,12 @@ func newBaseTLSConfig(caPEM []byte) (*tls.Config, error) {
 		},
 
 		MinVersion: tls.VersionTLS12,
+		// The go and java implementations of TLS 1.3 do not interoperate (until
+		// Java version 11.0.7, which was released only a couple of weeks before
+		// CRDB 20.1). Disable TLS 1.3 in version 20.1 to avoid pain during the
+		// transition period; it should be enabled in 20.2 once the java patch
+		// has had time to be deployed.
+		// https://github.com/cockroachdb/cockroach/issues/48294
+		MaxVersion: tls.VersionTLS12,
 	}, nil
 }


### PR DESCRIPTION
The go and java implementations of TLS 1.3 do not interoperate (until
Java version 11.0.7, which was released only a couple of weeks before
CRDB 20.1). Disable TLS 1.3 in version 20.1 to avoid pain during the
transition period; it should be enabled in 20.2 once the java patch
has had time to be deployed.

Fixes #48294

Release note (bug fix): TLS 1.3 is now disabled by default to improve
compatibility with Java.

Git notes: The commit in this PR has v20.1.0-rc.2 as its ancestor, so it can be used directly for the next build. It is being merged into release-20.1 so it will be included in future patch releases. It is deliberately not going into master at this time so we can continue to test compatibility with TLS 1.3 in preparation for hopefully enabling it by default in 20.2. 