### PR TITLE
server: properly set up new pipes on every loopback connection

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -406,7 +406,7 @@
 
 [[projects]]
   branch = "v1.2.4-cockroach20.1"
-  digest = "1:f3e110587a7cde6152fe8861a5873ffb552232b8a91ce444075397f4ebabd4cd"
+  digest = "1:b71a73b66891223c46f81a6195774911b79320181b54963196e843e8c3566461"
   name = "github.com/cockroachdb/errors"
   packages = [
     ".",
@@ -429,7 +429,7 @@
     "withstack",
   ]
   pruneopts = "UT"
-  revision = "fcfc812fae48db497f9fb1dbc7b4d4041caa06fa"
+  revision = "ad1964b7f01491050a580f32fa2566ea66518cbd"
 
 [[projects]]
   digest = "1:a44e537b3e080ff297315d166956dba9607f070644a89be78b59af6c54876b64"

--- a/pkg/server/loopback.go
+++ b/pkg/server/loopback.go
@@ -1,0 +1,118 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"net"
+	"sync"
+
+	"github.com/cockroachdb/cmux"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/errors"
+)
+
+// loopbackListener implements a local listener
+// that delivers net.Conns via its Connect() method
+// based on the other side calls to its Accept() method.
+type loopbackListener struct {
+	stopper *stop.Stopper
+
+	closeOnce sync.Once
+	active    chan struct{}
+
+	// requests are tokens from the Connect() method to the
+	// Accept() method.
+	requests chan struct{}
+	// conns are responses from the Accept() method
+	// to the Connect() method.
+	conns chan net.Conn
+}
+
+var _ net.Listener = (*loopbackListener)(nil)
+
+// note that we need to use cmux.ErrListenerClosed as base (leaf)
+// error so that it is recognized as special case in
+// netutil.IsClosedConnection.
+var errLocalListenerClosed = errors.Wrap(cmux.ErrListenerClosed, "loopback listener")
+
+// Accept waits for and returns the next connection to the listener.
+func (l *loopbackListener) Accept() (conn net.Conn, err error) {
+	select {
+	case <-l.stopper.ShouldQuiesce():
+		return nil, errLocalListenerClosed
+	case <-l.active:
+		return nil, errLocalListenerClosed
+	case <-l.requests:
+	}
+	c1, c2 := net.Pipe()
+	select {
+	case l.conns <- c1:
+		return c2, nil
+	case <-l.stopper.ShouldQuiesce():
+	case <-l.active:
+	}
+	err = errLocalListenerClosed
+	err = errors.CombineErrors(err, c1.Close())
+	err = errors.CombineErrors(err, c2.Close())
+	return nil, err
+}
+
+// Close closes the listener.
+// Any blocked Accept operations will be unblocked and return errors.
+func (l *loopbackListener) Close() error {
+	l.closeOnce.Do(func() {
+		close(l.active)
+	})
+	return nil
+}
+
+// Addr returns the listener's network address.
+func (l *loopbackListener) Addr() net.Addr {
+	return loopbackAddr{}
+}
+
+// Connect signals the Accept method that a conn is needed.
+func (l *loopbackListener) Connect(ctx context.Context) (net.Conn, error) {
+	// Send request to acceptor.
+	select {
+	case <-l.stopper.ShouldQuiesce():
+		return nil, errLocalListenerClosed
+	case <-l.active:
+		return nil, errLocalListenerClosed
+	case l.requests <- struct{}{}:
+	}
+	// Get conn from acceptor.
+	select {
+	case <-l.stopper.ShouldQuiesce():
+		return nil, errLocalListenerClosed
+	case <-l.active:
+		return nil, errLocalListenerClosed
+	case conn := <-l.conns:
+		return conn, nil
+	}
+}
+
+func newLoopbackListener(ctx context.Context, stopper *stop.Stopper) *loopbackListener {
+	return &loopbackListener{
+		stopper:  stopper,
+		active:   make(chan struct{}),
+		requests: make(chan struct{}),
+		conns:    make(chan net.Conn),
+	}
+}
+
+type loopbackAddr struct{}
+
+var _ net.Addr = loopbackAddr{}
+
+func (loopbackAddr) Network() string { return "pipe" }
+func (loopbackAddr) String() string  { return "loopback" }

--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -153,9 +153,7 @@ func (s *Server) ServeWith(
 // IsClosedConnection returns true if err is cmux.ErrListenerClosed,
 // grpc.ErrServerStopped, io.EOF, or the net package's errClosed.
 func IsClosedConnection(err error) bool {
-	return err == cmux.ErrListenerClosed ||
-		err == grpc.ErrServerStopped ||
-		err == io.EOF ||
+	return errors.IsAny(err, cmux.ErrListenerClosed, grpc.ErrServerStopped, io.EOF) ||
 		strings.Contains(err.Error(), "use of closed network connection")
 }
 
@@ -163,7 +161,7 @@ func IsClosedConnection(err error) bool {
 // cmux.ErrListenerClosed, or the net package's errClosed.
 func FatalIfUnexpected(err error) {
 	if err != nil && !IsClosedConnection(err) {
-		log.Fatalf(context.TODO(), "%v", err)
+		log.Fatalf(context.TODO(), "%+v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #42828.

Prior to this patch, the loopback connection for the HTTP <-> RPC
gateway was using a single `net.Pipe` call. This was fragile because
the RPC subsystem can close is end of the connection under multiple
timeout scenarios, and the loopback conn would become unoperable from
that point.

This patch changes the code to hand off a new net.Pipe pair upon
every new loopback dial.

Release note (bug fix): A long-standing bug has been fixed where HTTP
requests would start to fail with error 503 "`transport:
authentication handshake failed: io: read/write on closed pipe`" and
never become possible again until the node is restarted. This bug
existed since v2.1 or some time prior.