### PR TITLE
sql: fix issue with mixed cascade paths

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1060,6 +1060,10 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 		// We place a sequence point before every cascade, so
 		// that each subsequent cascade can observe the writes
 		// by the previous step.
+		// TODO(radu): the cascades themselves can have more cascades; if any of
+		// those fall back to legacy cascades code, it will disable stepping. So we
+		// have to reenable stepping each time.
+		_ = planner.Txn().ConfigureStepping(ctx, kv.SteppingEnabled)
 		if err := planner.Txn().Step(ctx); err != nil {
 			recv.SetError(err)
 			return false
@@ -1120,6 +1124,10 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 
 	// We place a sequence point before the checks, so that they observe the
 	// writes of the main query and/or any cascades.
+	// TODO(radu): the cascades themselves can have more cascades; if any of
+	// those fall back to legacy cascades code, it will disable stepping. So we
+	// have to reenable stepping each time.
+	_ = planner.Txn().ConfigureStepping(ctx, kv.SteppingEnabled)
 	if err := planner.Txn().Step(ctx); err != nil {
 		recv.SetError(err)
 		return false

--- a/pkg/sql/logictest/testdata/logic_test/cascade_opt
+++ b/pkg/sql/logictest/testdata/logic_test/cascade_opt
@@ -3,11 +3,11 @@
 statement ok
 SET optimizer_foreign_keys = true
 
-# Tests for the experimental opt-driven cascades.
-subtest OptDriven
-
 statement ok
 SET experimental_optimizer_foreign_key_cascades = true
+
+# Tests for the experimental opt-driven cascades.
+subtest OptDriven
 
 # Single delete cascade.
 statement ok
@@ -262,10 +262,6 @@ DELETE FROM self WHERE a = 1
 
 statement ok
 RESET foreign_key_cascades_limit
-
-# TODO(radu): enable when we support Cascades.
-statement ok
-SET experimental_optimizer_foreign_key_cascades = false
 
 statement ok
 DROP TABLE self
@@ -767,7 +763,7 @@ INSERT INTO c2 VALUES
 INSERT INTO d VALUES ('d-pk1-c2-pk4-b1-pk2', 'c2-pk4-b1-pk2');
 
 # ON DELETE CASCADE
-statement error pq: foreign key violation: values \['c2-pk4-b1-pk2'\] in columns \[id\] referenced in table "d"
+statement error delete on table "c2" violates foreign key constraint "fk_delete_restrict_ref_c2" on table "d"\nDETAIL: Key \(id\)=\('c2-pk4-b1-pk2'\) is still referenced from table "d"\.
 DELETE FROM a WHERE id = 'a-pk1';
 
 # Clean up after the test.
@@ -938,7 +934,7 @@ SELECT
 2 1 2 1 1 2
 
 # ON DELETE CASCADE
-statement error pq: foreign key violation: values \['pk1'\] in columns \[id\] referenced in table "c3"
+statement error delete on table "b2" violates foreign key constraint "fk_id_ref_b2" on table "c3"\nDETAIL: Key \(id\)=\('pk1'\) is still referenced from table "c3"\.
 DELETE FROM a WHERE id = 'pk1';
 
 # Clean up after the test.


### PR DESCRIPTION
Currently the new optimizer-driven cascades path only supports ON DELETE
CASCADE; everything else falls back on the old path. So it is possible to get a
new-style cascade that itself has an old-style cascade. When this happens, the
old-style code disables transaction stepping, which leads to an error the next
time the new code tries to Step the transaction.

The fix is to re-enable stepping each time. This is temporary until the new path
supports everything.

With this fix, we can now enable the new cascades for the entire `cascades_opt`
logictest file.

Release note: None