### PR TITLE
release-20.1: import test deflakes

### DIFF
--- a/c-deps/libroach/ccl/ctr_stream.cc
+++ b/c-deps/libroach/ccl/ctr_stream.cc
@@ -77,7 +77,7 @@ rocksdb::Status CTRCipherStreamCreator::CreateCipherStreamFromSettings(
   auto key = key_manager_->GetKey(enc_settings.key_id());
   if (key == nullptr) {
     return rocksdb::Status::InvalidArgument(fmt::StringPrintf(
-        "key_manager does not have a key with ID %s", enc_settings.key_id().c_str()));
+        "store key ID %s was not found", enc_settings.key_id().c_str()));
   }
 
   result->reset(new CTRCipherStream(key, enc_settings.nonce(), enc_settings.counter()));

--- a/pkg/ccl/storageccl/engineccl/pebble_key_manager.go
+++ b/pkg/ccl/storageccl/engineccl/pebble_key_manager.go
@@ -95,7 +95,7 @@ func (m *StoreKeyManager) GetKey(id string) (*enginepbccl.SecretKey, error) {
 	if m.oldKey.Info.KeyId == id {
 		return m.oldKey, nil
 	}
-	return nil, fmt.Errorf("store key with id: %s was not found", id)
+	return nil, fmt.Errorf("store key ID %s was not found", id)
 }
 
 func loadKeyFromFile(fs vfs.FS, filename string) (*enginepbccl.SecretKey, error) {

--- a/pkg/cli/interactive_tests/test_encryption.tcl
+++ b/pkg/cli/interactive_tests/test_encryption.tcl
@@ -67,7 +67,7 @@ send "$argv start-single-node --insecure --store=$storedir\r"
 eexpect "encryption was used on this store before, but no encryption flags specified."
 # Try with the wrong key.
 send "$argv start-single-node --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-192.key,old-key=plain\r"
-eexpect "key_manager does not have a key with ID"
+eexpect "store key ID * was not found"
 end_test
 
 start_test "Restart with AES-256."
@@ -86,5 +86,5 @@ send "$argv start-single-node --insecure --store=$storedir\r"
 eexpect "encryption was used on this store before, but no encryption flags specified."
 # Try with the wrong key.
 send "$argv start-single-node --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-192.key,old-key=plain\r"
-eexpect "key_manager does not have a key with ID"
+eexpect "store key ID * was not found"
 end_test

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -23,7 +23,13 @@ send "$argv start-single-node -s=path=logs/db --insecure --logtostderr --vmodule
 eexpect "CockroachDB node starting"
 system "killall cat"
 eexpect ":/# "
-system "grep -F 'log: exiting because of error: write /dev/stderr: broken pipe' logs/db/logs/cockroach.log"
+# NB: we can't just grep for the broken pipe output, because it may take
+# a while for the server to initiate the next log line where it will detect
+# the broken pipe error.
+send "tail -f logs/db/logs/cockroach.log\r"
+eexpect "log: exiting because of error: write /dev/stderr: broken pipe"
+interrupt
+eexpect ":/# "
 end_test
 
 start_test "Check that a broken log file prints a message to stderr."

--- a/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
+++ b/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
@@ -78,6 +78,9 @@ expect {
     "cannot allocate memory" {}
     "std::bad_alloc" {}
     "Resource temporarily unavailable" {}
+    # TODO(peter): Pebble's behavior is to segfault on failed manual
+    # allocations. We should provide a cleaner signal.
+    "signal SIGSEGV" {}
     timeout { handle_timeout "memory allocation error" }
 }
 eexpect ":/# "


### PR DESCRIPTION
Backport:
  * 1/1 commits from "cli/interactive_tests: fix Pebble failures" (#48355)
  * 1/1 commits from "cli/interactive_tests: deflake missing_log_output" (#48431)

Please see individual PRs for details.

/cc @cockroachdb/release
