### PR TITLE
sql: trim down gossip deprecation calls

### DIFF
--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -215,13 +215,10 @@ func createBenchmarkChangefeed(
 	}
 	_, withDiff := details.Opts[changefeedbase.OptDiff]
 	kvfeedCfg := kvfeed.Config{
-		Settings: settings,
-		DB:       s.DB(),
-		Clock:    feedClock,
-		Gossip: gossip.MakeDeprecatedGossip(
-			s.GossipI().(*gossip.Gossip),
-			true, /* exposed */
-		),
+		Settings:         settings,
+		DB:               s.DB(),
+		Clock:            feedClock,
+		Gossip:           gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
 		Spans:            spans,
 		Targets:          details.Targets,
 		Sink:             buf,

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
@@ -108,7 +107,10 @@ func distChangefeedFlow(
 
 	// Changefeed flows handle transactional consistency themselves.
 	var noTxn *kv.Txn
-	gatewayNodeID := execCfg.NodeID.DeprecatedNodeID(distsql.MultiTenancyIssueNo)
+	gatewayNodeID, err := execCfg.NodeID.OptionalNodeIDErr(48274)
+	if err != nil {
+		return err
+	}
 	dsp := phs.DistSQLPlanner()
 	evalCtx := phs.ExtendedEvalContext()
 	planCtx := dsp.NewPlanningCtx(ctx, evalCtx, noTxn)

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1638,12 +1638,9 @@ type DeprecatedGossip struct {
 	w errorutil.TenantSQLDeprecatedWrapper
 }
 
-// Deprecated trades a Github issue tracking the removal of the call for the
+// deprecated trades a Github issue tracking the removal of the call for the
 // wrapped Gossip instance.
-//
-// Use of Gossip from within the SQL layer is **deprecated**. Please do not
-// introduce new uses of it.
-func (dg DeprecatedGossip) Deprecated(issueNo int) *Gossip {
+func (dg DeprecatedGossip) deprecated(issueNo int) *Gossip {
 	// NB: some tests use a nil Gossip.
 	g, _ := dg.w.Deprecated(issueNo).(*Gossip)
 	return g
@@ -1654,11 +1651,29 @@ func (dg DeprecatedGossip) Deprecated(issueNo int) *Gossip {
 // Use of Gossip from within the SQL layer is **deprecated**. Please do not
 // introduce new uses of it.
 func (dg DeprecatedGossip) DeprecatedSystemConfig(issueNo int) *config.SystemConfig {
-	g := dg.Deprecated(issueNo)
+	g := dg.deprecated(issueNo)
 	if g == nil {
 		return nil // a few unit tests
 	}
 	return g.GetSystemConfig()
+}
+
+// DeprecatedOracleGossip trims down *gossip.Gossip for use in the Oracle.
+//
+// NB: we're trying to get rid of this dep altogether, see:
+// https://github.com/cockroachdb/cockroach/issues/48432
+type DeprecatedOracleGossip interface {
+	GetNodeDescriptor(roachpb.NodeID) (*roachpb.NodeDescriptor, error)
+	GetNodeIDForStoreID(roachpb.StoreID) (roachpb.NodeID, error)
+}
+
+// DeprecatedOracleGossip returns an DeprecatedOracleGossip (a Gossip for use with the
+// replicaoracle package).
+//
+// Use of Gossip from within the SQL layer is **deprecated**. Please do not
+// introduce new uses of it.
+func (dg DeprecatedGossip) DeprecatedOracleGossip(issueNo int) DeprecatedOracleGossip {
+	return dg.deprecated(issueNo)
 }
 
 // DeprecatedRegisterSystemConfigChannel calls RegisterSystemConfigChannel on
@@ -1667,7 +1682,7 @@ func (dg DeprecatedGossip) DeprecatedSystemConfig(issueNo int) *config.SystemCon
 // Use of Gossip from within the SQL layer is **deprecated**. Please do not
 // introduce new uses of it.
 func (dg DeprecatedGossip) DeprecatedRegisterSystemConfigChannel(issueNo int) <-chan struct{} {
-	g := dg.Deprecated(issueNo)
+	g := dg.deprecated(issueNo)
 	return g.RegisterSystemConfigChannel()
 }
 

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1649,6 +1649,28 @@ func (dg DeprecatedGossip) Deprecated(issueNo int) *Gossip {
 	return g
 }
 
+// DeprecatedSystemConfig calls GetSystemConfig on the wrapped Gossip instance.
+//
+// Use of Gossip from within the SQL layer is **deprecated**. Please do not
+// introduce new uses of it.
+func (dg DeprecatedGossip) DeprecatedSystemConfig(issueNo int) *config.SystemConfig {
+	g := dg.Deprecated(issueNo)
+	if g == nil {
+		return nil // a few unit tests
+	}
+	return g.GetSystemConfig()
+}
+
+// DeprecatedRegisterSystemConfigChannel calls RegisterSystemConfigChannel on
+// the wrapped Gossip instance.
+//
+// Use of Gossip from within the SQL layer is **deprecated**. Please do not
+// introduce new uses of it.
+func (dg DeprecatedGossip) DeprecatedRegisterSystemConfigChannel(issueNo int) <-chan struct{} {
+	g := dg.Deprecated(issueNo)
+	return g.RegisterSystemConfigChannel()
+}
+
 // OptionalErr returns the Gossip instance if the wrapper was set up to allow
 // it. Otherwise, it returns an error referring to the optionally passed in
 // issues.

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1664,3 +1664,17 @@ func (dg DeprecatedGossip) OptionalErr(issueNos ...int) (*Gossip, error) {
 	g, _ := v.(*Gossip)
 	return g, nil
 }
+
+// Optional is like OptionalErr, but returns false if Gossip is not exposed.
+//
+// Use of Gossip from within the SQL layer is **deprecated**. Please do not
+// introduce new uses of it.
+func (dg DeprecatedGossip) Optional(issueNos ...int) (*Gossip, bool) {
+	v, ok := dg.w.Optional()
+	if !ok {
+		return nil, false
+	}
+	// NB: some tests use a nil Gossip.
+	g, _ := v.(*Gossip)
+	return g, true
+}

--- a/pkg/kv/kvclient/kvcoord/replica_slice.go
+++ b/pkg/kv/kvclient/kvcoord/replica_slice.go
@@ -15,7 +15,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/shuffle"
@@ -42,7 +41,12 @@ type ReplicaSlice []ReplicaInfo
 // NewReplicaSlice creates a ReplicaSlice from the replicas listed in the range
 // descriptor and using gossip to lookup node descriptors. Replicas on nodes
 // that are not gossiped are omitted from the result.
-func NewReplicaSlice(gossip *gossip.Gossip, replicas []roachpb.ReplicaDescriptor) ReplicaSlice {
+func NewReplicaSlice(
+	gossip interface {
+		GetNodeDescriptor(roachpb.NodeID) (*roachpb.NodeDescriptor, error)
+	},
+	replicas []roachpb.ReplicaDescriptor,
+) ReplicaSlice {
 	if gossip == nil {
 		return nil
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -527,7 +527,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			distSender:             distSender,
 			statusServer:           serverpb.MakeOptionalStatusServer(sStatus),
 			nodeLiveness:           nodeLiveness,
-			gossip:                 gossip.MakeDeprecatedGossip(g, true /* exposed */),
+			gossip:                 gossip.MakeExposedGossip(g),
 			nodeDialer:             nodeDialer,
 			grpcServer:             grpcServer.Server,
 			recorder:               recorder,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -401,7 +401,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 			cfg.rpcContext,
 			distSQLServer,
 			cfg.distSender,
-			cfg.gossip.Deprecated(distsql.MultiTenancyIssueNo),
+			cfg.gossip,
 			cfg.stopper,
 			cfg.nodeLiveness,
 			cfg.nodeDialer,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -530,7 +530,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 	stmtDiagnosticsRegistry := stmtdiagnostics.NewRegistry(
 		cfg.circularInternalExecutor,
 		cfg.db,
-		cfg.gossip.Deprecated(47893),
+		cfg.gossip,
 		cfg.Settings,
 	)
 	execCfg.StmtDiagnosticsRecorder = stmtDiagnosticsRegistry

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -535,7 +535,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 	)
 	execCfg.StmtDiagnosticsRecorder = stmtDiagnosticsRegistry
 
-	leaseMgr.RefreshLeases(cfg.stopper, cfg.db, cfg.gossip.Deprecated(47150))
+	leaseMgr.RefreshLeases(cfg.stopper, cfg.db, cfg.gossip)
 	leaseMgr.PeriodicallyRefreshSomeLeases()
 
 	temporaryObjectCleaner := sql.NewTemporaryObjectCleaner(

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -409,7 +409,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 
 		TableStatsCache: stats.NewTableStatisticsCache(
 			cfg.SQLTableStatCacheSize,
-			cfg.gossip.Deprecated(47925),
+			cfg.gossip,
 			cfg.db,
 			cfg.circularInternalExecutor,
 		),

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -492,7 +492,7 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 			distSender:   ds,
 			statusServer: noStatusServer,
 			nodeLiveness: nl,
-			gossip:       gossip.MakeDeprecatedGossip(g, false /* exposed */),
+			gossip:       gossip.MakeUnexposedGossip(g),
 			nodeDialer:   nd,
 			grpcServer:   dummyRPCServer,
 			recorder:     dummyRecorder,

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1223,8 +1223,10 @@ func injectTableStats(
 	// update is handled asynchronously).
 	params.extendedEvalCtx.ExecCfg.TableStatsCache.InvalidateTableStats(params.ctx, desc.ID)
 
-	return stats.GossipTableStatAdded(
-		params.extendedEvalCtx.ExecCfg.Gossip.Deprecated(47925), desc.ID)
+	if g, ok := params.extendedEvalCtx.ExecCfg.Gossip.Optional(47925); ok {
+		return stats.GossipTableStatAdded(g, desc.ID)
+	}
+	return nil
 }
 
 func (p *planner) removeColumnComment(

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -318,13 +318,12 @@ func makeMetrics(internal bool) Metrics {
 
 // Start starts the Server's background processing.
 func (s *Server) Start(ctx context.Context, stopper *stop.Stopper) {
-	g := s.cfg.Gossip.Deprecated(47150)
-	gossipUpdateC := g.RegisterSystemConfigChannel()
+	gossipUpdateC := s.cfg.Gossip.DeprecatedRegisterSystemConfigChannel(47150)
 	stopper.RunWorker(ctx, func(ctx context.Context) {
 		for {
 			select {
 			case <-gossipUpdateC:
-				sysCfg := g.GetSystemConfig()
+				sysCfg := s.cfg.Gossip.DeprecatedSystemConfig(47150)
 				s.dbCache.updateSystemConfig(sysCfg)
 			case <-stopper.ShouldStop():
 				return

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -257,6 +257,7 @@ func startConnExecutor(
 	st := cluster.MakeTestingClusterSettings()
 	nodeID := base.TestingIDContainer
 	distSQLMetrics := execinfra.MakeDistSQLMetrics(time.Hour /* histogramWindow */)
+	gw := gossip.MakeDeprecatedGossip(nil, true /* exposed */)
 	cfg := &ExecutorConfig{
 		AmbientCtx:      testutils.MakeAmbientCtx(),
 		Settings:        st,
@@ -279,14 +280,14 @@ func startConnExecutor(
 				NodeID:         nodeID,
 			}),
 			nil, /* distSender */
-			nil, /* gossip */
+			gw,
 			stopper,
 			dummyLivenessProvider{}, /* liveness */
 			nil,                     /* nodeDialer */
 		),
 		QueryCache:              querycache.New(0),
 		TestingKnobs:            ExecutorTestingKnobs{},
-		StmtDiagnosticsRecorder: stmtdiagnostics.NewRegistry(nil, nil, gossip.DeprecatedGossip{}, st),
+		StmtDiagnosticsRecorder: stmtdiagnostics.NewRegistry(nil, nil, gw, st),
 	}
 	pool := mon.MakeUnlimitedMonitor(
 		context.Background(), "test", mon.MemoryResource,

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -257,7 +257,7 @@ func startConnExecutor(
 	st := cluster.MakeTestingClusterSettings()
 	nodeID := base.TestingIDContainer
 	distSQLMetrics := execinfra.MakeDistSQLMetrics(time.Hour /* histogramWindow */)
-	gw := gossip.MakeDeprecatedGossip(nil, true /* exposed */)
+	gw := gossip.MakeExposedGossip(nil)
 	cfg := &ExecutorConfig{
 		AmbientCtx:      testutils.MakeAmbientCtx(),
 		Settings:        st,

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -285,7 +286,7 @@ func startConnExecutor(
 		),
 		QueryCache:              querycache.New(0),
 		TestingKnobs:            ExecutorTestingKnobs{},
-		StmtDiagnosticsRecorder: stmtdiagnostics.NewRegistry(nil, nil, nil, st),
+		StmtDiagnosticsRecorder: stmtdiagnostics.NewRegistry(nil, nil, gossip.DeprecatedGossip{}, st),
 	}
 	pool := mon.MakeUnlimitedMonitor(
 		context.Background(), "test", mon.MemoryResource,

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -72,7 +72,7 @@ func NewServer(ctx context.Context, cfg execinfra.ServerConfig) *ServerImpl {
 	ds := &ServerImpl{
 		ServerConfig:  cfg,
 		regexpCache:   tree.NewRegexpCache(512),
-		flowRegistry:  flowinfra.NewFlowRegistry(cfg.NodeID.DeprecatedNodeID(MultiTenancyIssueNo)),
+		flowRegistry:  flowinfra.NewFlowRegistry(cfg.NodeID.SQLInstanceID()),
 		flowScheduler: flowinfra.NewFlowScheduler(cfg.AmbientContext, cfg.Stopper, cfg.Settings, cfg.Metrics),
 		memMonitor: mon.MakeMonitor(
 			"distsql",

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -92,15 +92,19 @@ func NewServer(ctx context.Context, cfg execinfra.ServerConfig) *ServerImpl {
 func (ds *ServerImpl) Start() {
 	// Gossip the version info so that other nodes don't plan incompatible flows
 	// for us.
-	if err := ds.ServerConfig.Gossip.Deprecated(MultiTenancyIssueNo).AddInfoProto(
-		gossip.MakeDistSQLNodeVersionKey(ds.ServerConfig.NodeID.DeprecatedNodeID(MultiTenancyIssueNo)),
-		&execinfrapb.DistSQLVersionGossipInfo{
-			Version:            execinfra.Version,
-			MinAcceptedVersion: execinfra.MinAcceptedVersion,
-		},
-		0, // ttl - no expiration
-	); err != nil {
-		panic(err)
+	if g, ok := ds.ServerConfig.Gossip.Optional(MultiTenancyIssueNo); ok {
+		if nodeID, ok := ds.ServerConfig.NodeID.OptionalNodeID(); ok {
+			if err := g.AddInfoProto(
+				gossip.MakeDistSQLNodeVersionKey(nodeID),
+				&execinfrapb.DistSQLVersionGossipInfo{
+					Version:            execinfra.Version,
+					MinAcceptedVersion: execinfra.MinAcceptedVersion,
+				},
+				0, // ttl - no expiration
+			); err != nil {
+				panic(err)
+			}
+		}
 	}
 
 	if err := ds.setDraining(false); err != nil {
@@ -124,7 +128,7 @@ func (ds *ServerImpl) Drain(
 	if ds.ServerConfig.TestingKnobs.DrainFast {
 		flowWait = 0
 		minWait = 0
-	} else if len(ds.Gossip.Deprecated(MultiTenancyIssueNo).Outgoing()) == 0 {
+	} else if g, ok := ds.Gossip.Optional(MultiTenancyIssueNo); !ok || len(g.Outgoing()) == 0 {
 		// If there is only one node in the cluster (us), there's no need to
 		// wait a minimum time for the draining state to be gossiped.
 		minWait = 0
@@ -142,13 +146,16 @@ func (ds *ServerImpl) setDraining(drain bool) error {
 		_ = MultiTenancyIssueNo // related issue
 		return nil
 	}
-	return ds.ServerConfig.Gossip.Deprecated(MultiTenancyIssueNo).AddInfoProto(
-		gossip.MakeDistSQLDrainingKey(nodeID),
-		&execinfrapb.DistSQLDrainingInfo{
-			Draining: drain,
-		},
-		0, // ttl - no expiration
-	)
+	if g, ok := ds.ServerConfig.Gossip.Optional(MultiTenancyIssueNo); ok {
+		return g.AddInfoProto(
+			gossip.MakeDistSQLDrainingKey(nodeID),
+			&execinfrapb.DistSQLDrainingInfo{
+				Draining: drain,
+			},
+			0, // ttl - no expiration
+		)
+	}
+	return nil
 }
 
 // FlowVerIsCompatible checks a flow's version is compatible with this node's

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -816,15 +816,16 @@ func TestPartitionSpans(t *testing.T) {
 				ranges: tc.ranges,
 			}
 
+			gw := gossip.MakeDeprecatedGossip(mockGossip, true /* exposed */)
 			dsp := DistSQLPlanner{
 				planVersion:  execinfra.Version,
 				st:           cluster.MakeTestingClusterSettings(),
 				nodeDesc:     *tsp.nodes[tc.gatewayNode-1],
 				stopper:      stopper,
 				spanResolver: tsp,
-				gossip:       mockGossip,
+				gossip:       gw,
 				nodeHealth: distSQLNodeHealth{
-					gossip: mockGossip,
+					gossip: gw,
 					connHealth: func(node roachpb.NodeID, _ rpc.ConnectionClass) error {
 						for _, n := range tc.deadNodes {
 							if int(node) == n {
@@ -1000,15 +1001,16 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 				ranges: ranges,
 			}
 
+			gw := gossip.MakeDeprecatedGossip(mockGossip, true /* exposed */)
 			dsp := DistSQLPlanner{
 				planVersion:  tc.planVersion,
 				st:           cluster.MakeTestingClusterSettings(),
 				nodeDesc:     *tsp.nodes[gatewayNode-1],
 				stopper:      stopper,
 				spanResolver: tsp,
-				gossip:       mockGossip,
+				gossip:       gw,
 				nodeHealth: distSQLNodeHealth{
-					gossip: mockGossip,
+					gossip: gw,
 					connHealth: func(roachpb.NodeID, rpc.ConnectionClass) error {
 						// All the nodes are healthy.
 						return nil
@@ -1095,15 +1097,16 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 		ranges: ranges,
 	}
 
+	gw := gossip.MakeDeprecatedGossip(mockGossip, true /* exposed */)
 	dsp := DistSQLPlanner{
 		planVersion:  execinfra.Version,
 		st:           cluster.MakeTestingClusterSettings(),
 		nodeDesc:     *tsp.nodes[gatewayNode-1],
 		stopper:      stopper,
 		spanResolver: tsp,
-		gossip:       mockGossip,
+		gossip:       gw,
 		nodeHealth: distSQLNodeHealth{
-			gossip: mockGossip,
+			gossip: gw,
 			connHealth: func(node roachpb.NodeID, _ rpc.ConnectionClass) error {
 				_, err := mockGossip.GetNodeIDAddress(node)
 				return err
@@ -1197,10 +1200,11 @@ func TestCheckNodeHealth(t *testing.T) {
 		{notLive, "not using n5 due to liveness: node n5 is not live"},
 	}
 
+	gw := gossip.MakeDeprecatedGossip(mockGossip, true /* exposed */)
 	for _, test := range livenessTests {
 		t.Run("liveness", func(t *testing.T) {
 			h := distSQLNodeHealth{
-				gossip:     mockGossip,
+				gossip:     gw,
 				connHealth: connHealthy,
 				isLive:     test.isLive,
 			}
@@ -1221,7 +1225,7 @@ func TestCheckNodeHealth(t *testing.T) {
 	for _, test := range connHealthTests {
 		t.Run("connHealth", func(t *testing.T) {
 			h := distSQLNodeHealth{
-				gossip:     mockGossip,
+				gossip:     gw,
 				connHealth: test.connHealth,
 				isLive:     live,
 			}

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -816,7 +816,7 @@ func TestPartitionSpans(t *testing.T) {
 				ranges: tc.ranges,
 			}
 
-			gw := gossip.MakeDeprecatedGossip(mockGossip, true /* exposed */)
+			gw := gossip.MakeExposedGossip(mockGossip)
 			dsp := DistSQLPlanner{
 				planVersion:  execinfra.Version,
 				st:           cluster.MakeTestingClusterSettings(),
@@ -1001,7 +1001,7 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 				ranges: ranges,
 			}
 
-			gw := gossip.MakeDeprecatedGossip(mockGossip, true /* exposed */)
+			gw := gossip.MakeExposedGossip(mockGossip)
 			dsp := DistSQLPlanner{
 				planVersion:  tc.planVersion,
 				st:           cluster.MakeTestingClusterSettings(),
@@ -1097,7 +1097,7 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 		ranges: ranges,
 	}
 
-	gw := gossip.MakeDeprecatedGossip(mockGossip, true /* exposed */)
+	gw := gossip.MakeExposedGossip(mockGossip)
 	dsp := DistSQLPlanner{
 		planVersion:  execinfra.Version,
 		st:           cluster.MakeTestingClusterSettings(),
@@ -1200,7 +1200,7 @@ func TestCheckNodeHealth(t *testing.T) {
 		{notLive, "not using n5 due to liveness: node n5 is not live"},
 	}
 
-	gw := gossip.MakeDeprecatedGossip(mockGossip, true /* exposed */)
+	gw := gossip.MakeExposedGossip(mockGossip)
 	for _, test := range livenessTests {
 		t.Run("liveness", func(t *testing.T) {
 			h := distSQLNodeHealth{

--- a/pkg/sql/flowinfra/flow_registry_test.go
+++ b/pkg/sql/flowinfra/flow_registry_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -71,7 +70,7 @@ func lookupStreamInfo(
 
 func TestFlowRegistry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	reg := NewFlowRegistry(roachpb.NodeID(0))
+	reg := NewFlowRegistry(0)
 
 	id1 := execinfrapb.FlowID{UUID: uuid.MakeV4()}
 	f1 := &FlowBase{}
@@ -210,7 +209,7 @@ func TestFlowRegistry(t *testing.T) {
 // are propagated to their consumers and future attempts to connect them fail.
 func TestStreamConnectionTimeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	reg := NewFlowRegistry(roachpb.NodeID(0))
+	reg := NewFlowRegistry(0)
 
 	jiffy := time.Nanosecond
 
@@ -278,7 +277,7 @@ func TestStreamConnectionTimeout(t *testing.T) {
 func TestHandshake(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	reg := NewFlowRegistry(roachpb.NodeID(0))
+	reg := NewFlowRegistry(0)
 
 	tests := []struct {
 		name                   string
@@ -377,7 +376,7 @@ func TestFlowRegistryDrain(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.TODO()
-	reg := NewFlowRegistry(roachpb.NodeID(0))
+	reg := NewFlowRegistry(0)
 
 	flow := &FlowBase{}
 	id := execinfrapb.FlowID{UUID: uuid.MakeV4()}

--- a/pkg/sql/gcjob/gc_job.go
+++ b/pkg/sql/gcjob/gc_job.go
@@ -126,7 +126,7 @@ func (r schemaChangeGCResumer) Resume(
 			// TTL whenever we get an update on one of the tables/indexes (or the db)
 			// that this job is responsible for, and computing the earliest deadline
 			// from our set of cached TTL values.
-			cfg := execCfg.Gossip.Deprecated(47150).GetSystemConfig()
+			cfg := execCfg.Gossip.DeprecatedSystemConfig(47150)
 			zoneConfigUpdated := false
 			zoneCfgFilter.ForModified(cfg, func(kv roachpb.KeyValue) {
 				zoneConfigUpdated = true

--- a/pkg/sql/gcjob/refresh_statuses.go
+++ b/pkg/sql/gcjob/refresh_statuses.go
@@ -81,7 +81,7 @@ func updateStatusForGCElements(
 	progress *jobspb.SchemaChangeGCProgress,
 ) (expired bool, timeToNextTrigger time.Time) {
 	defTTL := execCfg.DefaultZoneConfig.GC.TTLSeconds
-	cfg := execCfg.Gossip.Deprecated(47150).GetSystemConfig()
+	cfg := execCfg.Gossip.DeprecatedSystemConfig(47150)
 	protectedtsCache := execCfg.ProtectedTimestampProvider
 
 	earliestDeadline := timeutil.Unix(0, int64(math.MaxInt64))
@@ -275,6 +275,6 @@ func setupConfigWatcher(
 ) (gossip.SystemConfigDeltaFilter, <-chan struct{}) {
 	k := execCfg.Codec.IndexPrefix(uint32(keys.ZonesTableID), uint32(keys.ZonesTablePrimaryIndexID))
 	zoneCfgFilter := gossip.MakeSystemConfigDeltaFilter(k)
-	gossipUpdateC := execCfg.Gossip.Deprecated(47150).RegisterSystemConfigChannel()
+	gossipUpdateC := execCfg.Gossip.DeprecatedRegisterSystemConfigChannel(47150)
 	return zoneCfgFilter, gossipUpdateC
 }

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -1773,16 +1773,16 @@ func (m *LeaseManager) findTableState(tableID sqlbase.ID, create bool) *tableSta
 
 // RefreshLeases starts a goroutine that refreshes the lease manager
 // leases for tables received in the latest system configuration via gossip.
-func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *kv.DB, g *gossip.Gossip) {
+func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *kv.DB, gw gossip.DeprecatedGossip) {
 	ctx := context.TODO()
 	s.RunWorker(ctx, func(ctx context.Context) {
 		descKeyPrefix := m.codec.TablePrefix(uint32(sqlbase.DescriptorTable.ID))
 		cfgFilter := gossip.MakeSystemConfigDeltaFilter(descKeyPrefix)
-		gossipUpdateC := g.RegisterSystemConfigChannel()
+		gossipUpdateC := gw.DeprecatedRegisterSystemConfigChannel(47150)
 		for {
 			select {
 			case <-gossipUpdateC:
-				cfg := g.GetSystemConfig()
+				cfg := gw.DeprecatedSystemConfig(47150)
 				if m.testingKnobs.GossipUpdateEvent != nil {
 					if err := m.testingKnobs.GossipUpdateEvent(cfg); err != nil {
 						break

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -74,11 +74,7 @@ func (oc *optCatalog) reset() {
 		oc.dataSources = make(map[*sqlbase.ImmutableTableDescriptor]cat.DataSource)
 	}
 
-	g := oc.planner.execCfg.Gossip.Deprecated(47150)
-	// Gossip can be nil in testing scenarios.
-	if g != nil {
-		oc.cfg = g.GetSystemConfig()
-	}
+	oc.cfg = oc.planner.execCfg.Gossip.DeprecatedSystemConfig(47150)
 }
 
 // optSchema is a wrapper around sqlbase.DatabaseDescriptor that implements the

--- a/pkg/sql/physicalplan/replicaoracle/oracle.go
+++ b/pkg/sql/physicalplan/replicaoracle/oracle.go
@@ -44,7 +44,7 @@ var (
 type Config struct {
 	NodeDesc         roachpb.NodeDescriptor
 	Settings         *cluster.Settings
-	Gossip           *gossip.Gossip
+	Gossip           gossip.DeprecatedOracleGossip
 	RPCContext       *rpc.Context
 	LeaseHolderCache *kvcoord.LeaseHolderCache
 }
@@ -117,7 +117,7 @@ func MakeQueryState() QueryState {
 // randomOracle is a Oracle that chooses the lease holder randomly
 // among the replicas in a range descriptor.
 type randomOracle struct {
-	gossip *gossip.Gossip
+	gossip gossip.DeprecatedOracleGossip
 }
 
 var _ OracleFactory = &randomOracle{}
@@ -141,7 +141,7 @@ func (o *randomOracle) ChoosePreferredReplica(
 }
 
 type closestOracle struct {
-	gossip      *gossip.Gossip
+	gossip      gossip.DeprecatedOracleGossip
 	latencyFunc kvcoord.LatencyFunc
 	// nodeDesc is the descriptor of the current node. It will be used to give
 	// preference to the current node and others "close" to it.
@@ -189,7 +189,7 @@ const maxPreferredRangesPerLeaseHolder = 10
 type binPackingOracle struct {
 	leaseHolderCache                 *kvcoord.LeaseHolderCache
 	maxPreferredRangesPerLeaseHolder int
-	gossip                           *gossip.Gossip
+	gossip                           gossip.DeprecatedOracleGossip
 	latencyFunc                      kvcoord.LatencyFunc
 	// nodeDesc is the descriptor of the current node. It will be used to give
 	// preference to the current node and others "close" to it.
@@ -268,7 +268,7 @@ func (o *binPackingOracle) ChoosePreferredReplica(
 // is available in gossip. If no nodes are available, a RangeUnavailableError is
 // returned.
 func replicaSliceOrErr(
-	desc roachpb.RangeDescriptor, gsp *gossip.Gossip,
+	desc roachpb.RangeDescriptor, gsp gossip.DeprecatedOracleGossip,
 ) (kvcoord.ReplicaSlice, error) {
 	// Learner replicas won't serve reads/writes, so send only to the `Voters`
 	// replicas. This is just an optimization to save a network hop, everything

--- a/pkg/sql/physicalplan/span_resolver.go
+++ b/pkg/sql/physicalplan/span_resolver.go
@@ -139,7 +139,7 @@ func NewSpanResolver(
 		nodeDesc: nodeDesc,
 		oracleFactory: replicaoracle.NewOracleFactory(policy, replicaoracle.Config{
 			Settings:         st,
-			Gossip:           gw.Deprecated(48432),
+			Gossip:           gw.DeprecatedOracleGossip(48432),
 			NodeDesc:         nodeDesc,
 			RPCContext:       rpcCtx,
 			LeaseHolderCache: distSender.LeaseHolderCache(),

--- a/pkg/sql/physicalplan/span_resolver.go
+++ b/pkg/sql/physicalplan/span_resolver.go
@@ -117,7 +117,7 @@ type SpanResolverIterator interface {
 // spanResolver implements SpanResolver.
 type spanResolver struct {
 	st            *cluster.Settings
-	gossip        *gossip.Gossip
+	gossip        gossip.DeprecatedGossip
 	distSender    *kvcoord.DistSender
 	nodeDesc      roachpb.NodeDescriptor
 	oracleFactory replicaoracle.OracleFactory
@@ -129,7 +129,7 @@ var _ SpanResolver = &spanResolver{}
 func NewSpanResolver(
 	st *cluster.Settings,
 	distSender *kvcoord.DistSender,
-	gossip *gossip.Gossip,
+	gw gossip.DeprecatedGossip,
 	nodeDesc roachpb.NodeDescriptor,
 	rpcCtx *rpc.Context,
 	policy replicaoracle.Policy,
@@ -139,13 +139,13 @@ func NewSpanResolver(
 		nodeDesc: nodeDesc,
 		oracleFactory: replicaoracle.NewOracleFactory(policy, replicaoracle.Config{
 			Settings:         st,
-			Gossip:           gossip,
+			Gossip:           gw.Deprecated(48432),
 			NodeDesc:         nodeDesc,
 			RPCContext:       rpcCtx,
 			LeaseHolderCache: distSender.LeaseHolderCache(),
 		}),
 		distSender: distSender,
-		gossip:     gossip,
+		gossip:     gw,
 	}
 }
 
@@ -153,9 +153,6 @@ func NewSpanResolver(
 type spanResolverIterator struct {
 	// it is a wrapper RangeIterator.
 	it *kvcoord.RangeIterator
-	// gossip is used to resolve NodeIds to addresses and node attributes, used to
-	// giving preference to close-by replicas.
-	gossip *gossip.Gossip
 	// oracle is used to choose a lease holders for ranges when one isn't present
 	// in the cache.
 	oracle replicaoracle.Oracle
@@ -174,7 +171,6 @@ var _ SpanResolverIterator = &spanResolverIterator{}
 // NewSpanResolverIterator creates a new SpanResolverIterator.
 func (sr *spanResolver) NewSpanResolverIterator(txn *kv.Txn) SpanResolverIterator {
 	return &spanResolverIterator{
-		gossip:     sr.gossip,
 		it:         kvcoord.NewRangeIterator(sr.distSender),
 		oracle:     sr.oracleFactory.Oracle(txn),
 		queryState: replicaoracle.MakeQueryState(),

--- a/pkg/sql/physicalplan/span_resolver_test.go
+++ b/pkg/sql/physicalplan/span_resolver_test.go
@@ -86,7 +86,7 @@ func TestSpanResolverUsesCaches(t *testing.T) {
 	lr := physicalplan.NewSpanResolver(
 		s3.Cfg.Settings,
 		s3.DistSenderI().(*kvcoord.DistSender),
-		gossip.MakeDeprecatedGossip(s3.Gossip(), true /* exposed */),
+		gossip.MakeExposedGossip(s3.Gossip()),
 		s3.GetNode().Descriptor, nil,
 		replicaoracle.BinPackingChoice)
 
@@ -194,7 +194,7 @@ func TestSpanResolver(t *testing.T) {
 	lr := physicalplan.NewSpanResolver(
 		s.(*server.TestServer).Cfg.Settings,
 		s.DistSenderI().(*kvcoord.DistSender),
-		gossip.MakeDeprecatedGossip(s.GossipI().(*gossip.Gossip), true /* exposed */),
+		gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
 		s.(*server.TestServer).GetNode().Descriptor, nil,
 		replicaoracle.BinPackingChoice)
 
@@ -289,7 +289,7 @@ func TestMixedDirections(t *testing.T) {
 	lr := physicalplan.NewSpanResolver(
 		s.(*server.TestServer).Cfg.Settings,
 		s.DistSenderI().(*kvcoord.DistSender),
-		gossip.MakeDeprecatedGossip(s.GossipI().(*gossip.Gossip), true /* exposed */),
+		gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
 		s.(*server.TestServer).GetNode().Descriptor,
 		nil,
 		replicaoracle.BinPackingChoice)

--- a/pkg/sql/physicalplan/span_resolver_test.go
+++ b/pkg/sql/physicalplan/span_resolver_test.go
@@ -85,7 +85,9 @@ func TestSpanResolverUsesCaches(t *testing.T) {
 
 	lr := physicalplan.NewSpanResolver(
 		s3.Cfg.Settings,
-		s3.DistSenderI().(*kvcoord.DistSender), s3.Gossip(), s3.GetNode().Descriptor, nil,
+		s3.DistSenderI().(*kvcoord.DistSender),
+		gossip.MakeDeprecatedGossip(s3.Gossip(), true /* exposed */),
+		s3.GetNode().Descriptor, nil,
 		replicaoracle.BinPackingChoice)
 
 	var spans []spanWithDir
@@ -191,7 +193,8 @@ func TestSpanResolver(t *testing.T) {
 	rowRanges, tableDesc := setupRanges(db, s.(*server.TestServer), cdb, t)
 	lr := physicalplan.NewSpanResolver(
 		s.(*server.TestServer).Cfg.Settings,
-		s.DistSenderI().(*kvcoord.DistSender), s.GossipI().(*gossip.Gossip),
+		s.DistSenderI().(*kvcoord.DistSender),
+		gossip.MakeDeprecatedGossip(s.GossipI().(*gossip.Gossip), true /* exposed */),
 		s.(*server.TestServer).GetNode().Descriptor, nil,
 		replicaoracle.BinPackingChoice)
 
@@ -285,7 +288,8 @@ func TestMixedDirections(t *testing.T) {
 	rowRanges, tableDesc := setupRanges(db, s.(*server.TestServer), cdb, t)
 	lr := physicalplan.NewSpanResolver(
 		s.(*server.TestServer).Cfg.Settings,
-		s.DistSenderI().(*kvcoord.DistSender), s.GossipI().(*gossip.Gossip),
+		s.DistSenderI().(*kvcoord.DistSender),
+		gossip.MakeDeprecatedGossip(s.GossipI().(*gossip.Gossip), true /* exposed */),
 		s.(*server.TestServer).GetNode().Descriptor,
 		nil,
 		replicaoracle.BinPackingChoice)

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -388,11 +388,11 @@ func (s *sampleAggregator) writeResults(ctx context.Context) error {
 		return err
 	}
 
-	// Gossip invalidation of the stat caches for this table.
-	return stats.GossipTableStatAdded(
-		s.FlowCtx.Cfg.Gossip.Deprecated(47925),
-		s.tableID,
-	)
+	if g, ok := s.FlowCtx.Cfg.Gossip.Optional(47925); ok {
+		// Gossip invalidation of the stat caches for this table.
+		return stats.GossipTableStatAdded(g, s.tableID)
+	}
+	return nil
 }
 
 // generateHistogram returns a histogram (on a given column) from a set of

--- a/pkg/sql/rowexec/sample_aggregator_test.go
+++ b/pkg/sql/rowexec/sample_aggregator_test.go
@@ -51,10 +51,7 @@ func TestSampleAggregator(t *testing.T) {
 				Settings: st,
 				DB:       kvDB,
 				Executor: server.InternalExecutor().(sqlutil.InternalExecutor),
-				Gossip: gossip.MakeDeprecatedGossip(
-					server.GossipI().(*gossip.Gossip),
-					true, /* exposed */
-				),
+				Gossip:   gossip.MakeExposedGossip(server.GossipI().(*gossip.Gossip)),
 			},
 		}
 		// Override the default memory limit. If memLimitBytes is small but

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -55,7 +55,13 @@ func TestMaybeRefreshStats(t *testing.T) {
 
 	executor := s.InternalExecutor().(sqlutil.InternalExecutor)
 	descA := sqlbase.GetTableDescriptor(s.DB(), keys.SystemSQLCodec, "t", "a")
-	cache := NewTableStatisticsCache(10 /* cacheSize */, s.GossipI().(*gossip.Gossip), kvDB, executor)
+	cache := NewTableStatisticsCache(
+		10, /* cacheSize */
+		gossip.MakeDeprecatedGossip(s.GossipI().(*gossip.Gossip),
+			true /* exposed */),
+		kvDB,
+		executor,
+	)
 	refresher := MakeRefresher(st, executor, cache, time.Microsecond /* asOfTime */)
 
 	// There should not be any stats yet.
@@ -125,7 +131,7 @@ func TestAverageRefreshTime(t *testing.T) {
 
 	executor := s.InternalExecutor().(sqlutil.InternalExecutor)
 	tableID := sqlbase.GetTableDescriptor(s.DB(), keys.SystemSQLCodec, "t", "a").ID
-	cache := NewTableStatisticsCache(10 /* cacheSize */, s.GossipI().(*gossip.Gossip), kvDB, executor)
+	cache := NewTableStatisticsCache(10 /* cacheSize */, gossip.MakeDeprecatedGossip(s.GossipI().(*gossip.Gossip), true /* exposed */), kvDB, executor)
 	refresher := MakeRefresher(st, executor, cache, time.Microsecond /* asOfTime */)
 
 	checkAverageRefreshTime := func(expected time.Duration) error {
@@ -350,7 +356,12 @@ func TestAutoStatsReadOnlyTables(t *testing.T) {
 		CREATE TABLE t.a (k INT PRIMARY KEY);`)
 
 	executor := s.InternalExecutor().(sqlutil.InternalExecutor)
-	cache := NewTableStatisticsCache(10 /* cacheSize */, s.GossipI().(*gossip.Gossip), kvDB, executor)
+	cache := NewTableStatisticsCache(
+		10, /* cacheSize */
+		gossip.MakeDeprecatedGossip(s.GossipI().(*gossip.Gossip), true /* exposed */),
+		kvDB,
+		executor,
+	)
 	refresher := MakeRefresher(st, executor, cache, time.Microsecond /* asOfTime */)
 
 	AutomaticStatisticsClusterMode.Override(&st.SV, true)
@@ -381,7 +392,12 @@ func TestNoRetryOnFailure(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 
 	executor := s.InternalExecutor().(sqlutil.InternalExecutor)
-	cache := NewTableStatisticsCache(10 /* cacheSize */, s.GossipI().(*gossip.Gossip), kvDB, executor)
+	cache := NewTableStatisticsCache(
+		10, /* cacheSize */
+		gossip.MakeDeprecatedGossip(s.GossipI().(*gossip.Gossip), true /* exposed */),
+		kvDB,
+		executor,
+	)
 	r := MakeRefresher(st, executor, cache, time.Microsecond /* asOfTime */)
 
 	// Try to refresh stats on a table that doesn't exist.

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -57,8 +57,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	descA := sqlbase.GetTableDescriptor(s.DB(), keys.SystemSQLCodec, "t", "a")
 	cache := NewTableStatisticsCache(
 		10, /* cacheSize */
-		gossip.MakeDeprecatedGossip(s.GossipI().(*gossip.Gossip),
-			true /* exposed */),
+		gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
 		kvDB,
 		executor,
 	)
@@ -131,7 +130,12 @@ func TestAverageRefreshTime(t *testing.T) {
 
 	executor := s.InternalExecutor().(sqlutil.InternalExecutor)
 	tableID := sqlbase.GetTableDescriptor(s.DB(), keys.SystemSQLCodec, "t", "a").ID
-	cache := NewTableStatisticsCache(10 /* cacheSize */, gossip.MakeDeprecatedGossip(s.GossipI().(*gossip.Gossip), true /* exposed */), kvDB, executor)
+	cache := NewTableStatisticsCache(
+		10, /* cacheSize */
+		gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
+		kvDB,
+		executor,
+	)
 	refresher := MakeRefresher(st, executor, cache, time.Microsecond /* asOfTime */)
 
 	checkAverageRefreshTime := func(expected time.Duration) error {
@@ -358,7 +362,7 @@ func TestAutoStatsReadOnlyTables(t *testing.T) {
 	executor := s.InternalExecutor().(sqlutil.InternalExecutor)
 	cache := NewTableStatisticsCache(
 		10, /* cacheSize */
-		gossip.MakeDeprecatedGossip(s.GossipI().(*gossip.Gossip), true /* exposed */),
+		gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
 		kvDB,
 		executor,
 	)
@@ -394,7 +398,7 @@ func TestNoRetryOnFailure(t *testing.T) {
 	executor := s.InternalExecutor().(sqlutil.InternalExecutor)
 	cache := NewTableStatisticsCache(
 		10, /* cacheSize */
-		gossip.MakeDeprecatedGossip(s.GossipI().(*gossip.Gossip), true /* exposed */),
+		gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
 		kvDB,
 		executor,
 	)

--- a/pkg/sql/stats/delete_stats_test.go
+++ b/pkg/sql/stats/delete_stats_test.go
@@ -34,7 +34,12 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 	s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	ex := s.InternalExecutor().(sqlutil.InternalExecutor)
-	cache := NewTableStatisticsCache(10 /* cacheSize */, s.GossipI().(*gossip.Gossip), db, ex)
+	cache := NewTableStatisticsCache(
+		10, /* cacheSize */
+		gossip.MakeDeprecatedGossip(s.GossipI().(*gossip.Gossip), true /* exposed */),
+		db,
+		ex,
+	)
 
 	// The test data must be ordered by CreatedAt DESC so the calculated set of
 	// expected deleted stats is correct.

--- a/pkg/sql/stats/delete_stats_test.go
+++ b/pkg/sql/stats/delete_stats_test.go
@@ -36,7 +36,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 	ex := s.InternalExecutor().(sqlutil.InternalExecutor)
 	cache := NewTableStatisticsCache(
 		10, /* cacheSize */
-		gossip.MakeDeprecatedGossip(s.GossipI().(*gossip.Gossip), true /* exposed */),
+		gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
 		db,
 		ex,
 	)

--- a/pkg/sql/stats/gossip_invalidation_test.go
+++ b/pkg/sql/stats/gossip_invalidation_test.go
@@ -38,7 +38,7 @@ func TestGossipInvalidation(t *testing.T) {
 
 	sc := stats.NewTableStatisticsCache(
 		10, /* cacheSize */
-		tc.Server(0).GossipI().(*gossip.Gossip),
+		gossip.MakeDeprecatedGossip(tc.Server(0).GossipI().(*gossip.Gossip), true /* exposed */),
 		tc.Server(0).DB(),
 		tc.Server(0).InternalExecutor().(sqlutil.InternalExecutor),
 	)

--- a/pkg/sql/stats/gossip_invalidation_test.go
+++ b/pkg/sql/stats/gossip_invalidation_test.go
@@ -38,7 +38,7 @@ func TestGossipInvalidation(t *testing.T) {
 
 	sc := stats.NewTableStatisticsCache(
 		10, /* cacheSize */
-		gossip.MakeDeprecatedGossip(tc.Server(0).GossipI().(*gossip.Gossip), true /* exposed */),
+		gossip.MakeExposedGossip(tc.Server(0).GossipI().(*gossip.Gossip)),
 		tc.Server(0).DB(),
 		tc.Server(0).InternalExecutor().(sqlutil.InternalExecutor),
 	)

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -55,7 +55,6 @@ type TableStatisticsCache struct {
 		// from the system table.
 		numInternalQueries int64
 	}
-	Gossip      *gossip.Gossip
 	ClientDB    *kv.DB
 	SQLExecutor sqlutil.InternalExecutor
 }
@@ -77,10 +76,9 @@ type cacheEntry struct {
 // NewTableStatisticsCache creates a new TableStatisticsCache that can hold
 // statistics for <cacheSize> tables.
 func NewTableStatisticsCache(
-	cacheSize int, g *gossip.Gossip, db *kv.DB, sqlExecutor sqlutil.InternalExecutor,
+	cacheSize int, gw gossip.DeprecatedGossip, db *kv.DB, sqlExecutor sqlutil.InternalExecutor,
 ) *TableStatisticsCache {
 	tableStatsCache := &TableStatisticsCache{
-		Gossip:      g,
 		ClientDB:    db,
 		SQLExecutor: sqlExecutor,
 	}
@@ -90,11 +88,13 @@ func NewTableStatisticsCache(
 	})
 	// The stat cache requires redundant callbacks as it is using gossip to
 	// signal the presence of new stats, not to actually propagate them.
-	g.RegisterCallback(
-		gossip.MakePrefixPattern(gossip.KeyTableStatAddedPrefix),
-		tableStatsCache.tableStatAddedGossipUpdate,
-		gossip.Redundant,
-	)
+	if g, ok := gw.Optional(47925); ok {
+		g.RegisterCallback(
+			gossip.MakePrefixPattern(gossip.KeyTableStatAddedPrefix),
+			tableStatsCache.tableStatAddedGossipUpdate,
+			gossip.Redundant,
+		)
+	}
 	return tableStatsCache
 }
 

--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -225,7 +225,12 @@ func TestCacheBasic(t *testing.T) {
 	// Create a cache and iteratively query the cache for each tableID. This
 	// will result in the cache getting populated. When the stats cache size is
 	// exceeded, entries should be evicted according to the LRU policy.
-	sc := NewTableStatisticsCache(2 /* cacheSize */, s.GossipI().(*gossip.Gossip), db, ex)
+	sc := NewTableStatisticsCache(
+		2, /* cacheSize */
+		gossip.MakeDeprecatedGossip(s.GossipI().(*gossip.Gossip), true /* exposed */),
+		db,
+		ex,
+	)
 	for _, tableID := range tableIDs {
 		if err := checkStatsForTable(ctx, sc, expectedStats[tableID], tableID); err != nil {
 			t.Fatal(err)
@@ -278,8 +283,12 @@ func TestCacheWait(t *testing.T) {
 		tableIDs = append(tableIDs, tableID)
 	}
 	sort.Sort(tableIDs)
-
-	sc := NewTableStatisticsCache(len(tableIDs), s.GossipI().(*gossip.Gossip), db, ex)
+	sc := NewTableStatisticsCache(
+		len(tableIDs), /* cacheSize */
+		gossip.MakeDeprecatedGossip(s.GossipI().(*gossip.Gossip), true /* exposed */),
+		db,
+		ex,
+	)
 	for _, tableID := range tableIDs {
 		if err := checkStatsForTable(ctx, sc, expectedStats[tableID], tableID); err != nil {
 			t.Fatal(err)

--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -227,7 +227,7 @@ func TestCacheBasic(t *testing.T) {
 	// exceeded, entries should be evicted according to the LRU policy.
 	sc := NewTableStatisticsCache(
 		2, /* cacheSize */
-		gossip.MakeDeprecatedGossip(s.GossipI().(*gossip.Gossip), true /* exposed */),
+		gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
 		db,
 		ex,
 	)
@@ -285,7 +285,7 @@ func TestCacheWait(t *testing.T) {
 	sort.Sort(tableIDs)
 	sc := NewTableStatisticsCache(
 		len(tableIDs), /* cacheSize */
-		gossip.MakeDeprecatedGossip(s.GossipI().(*gossip.Gossip), true /* exposed */),
+		gossip.MakeExposedGossip(s.GossipI().(*gossip.Gossip)),
 		db,
 		ex,
 	)


### PR DESCRIPTION
This series of commits revisits all of the calls to `DeprecatedGossip.Deprecated()` and removes all of them. Instead, a few specialized accessors remain, namely access to the system config and the corresponding trigger channel, as well as resolving between nodeID, storeID, and addresses.

This gives us a precise picture: we need #47150 to avoid the system config gossip, and we need to fix #48432. After that, we *should* be able to start SQL with a nil Gossip (though we would only do so for tenants, due to the many "nonessential" but important things lost when running without Gossip, such as DistSQL).

cc @ajwerner 