### PR TITLE
release-20.1: colexec: fix bug with decoding composite values in cfetcher

### DIFF
--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -364,6 +364,21 @@ func (rf *cFetcher) Init(
 			}
 		}
 	}
+	// Unique secondary indexes contain the extra column IDs as part of
+	// the value component. We process these separately, so we need to know
+	// what extra columns are composite or not.
+	if table.isSecondaryIndex && table.index.Unique {
+		for _, id := range table.index.ExtraColumnIDs {
+			colIdx, ok := tableArgs.ColIdxMap[id]
+			if ok && neededCols.Contains(int(id)) {
+				if compositeColumnIDs.Contains(int(id)) {
+					table.compositeIndexColOrdinals.Add(colIdx)
+				} else {
+					table.neededValueColsByIdx.Remove(colIdx)
+				}
+			}
+		}
+	}
 
 	// - If there are interleaves, we need to read the index key in order to
 	//   determine whether this row is actually part of the index we're scanning.
@@ -1103,6 +1118,14 @@ func (rf *cFetcher) processValueBytes(
 		}
 		rf.machine.prettyValueBuf.Reset()
 	}
+
+	// Composite columns that are key encoded in the value (like the pk columns
+	// in a unique secondary index) have gotten removed from the set of
+	// remaining value columns. So, we need to add them back in here in case
+	// they have full value encoded composite values.
+	rf.table.compositeIndexColOrdinals.ForEach(func(i int) {
+		rf.machine.remainingValueColsByIdx.Add(i)
+	})
 
 	var (
 		colIDDiff          uint32

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1211,3 +1211,14 @@ CREATE INDEX ON t47029_1(c0) INTERLEAVE IN PARENT t47029_0(c0)
 query I
 SELECT * FROM t47029_0 WHERE (t47029_0.rowid > 0) IS NULL
 ----
+
+# Regression for #47115 (cfetcher sometimes not reading value component
+# of composite encoded data).
+statement ok
+CREATE TABLE t47715 (c0 DECIMAL PRIMARY KEY, c1 INT UNIQUE);
+INSERT INTO t47715(c0) VALUES (1819487610)
+
+query T
+SELECT c0 FROM t47715 ORDER by c1
+----
+1819487610


### PR DESCRIPTION
Backport 1/1 commits from #48052.

/cc @cockroachdb/release

---

Fixes #47115.

This PR fixes a bug where the primary key data in secondary indexes
was being decoded incorrectly in the cfetcher. Precisely, the cfetcher
maintained a set of found value columns per row. When decoding primary
key values in a secondary index, it would remove value columns from
this set as it found them. However, once decoding the value it would
stop once it thought it found everything in the set, rather than reading
the full value. This caused it to mistakenly exit early when the value
component contained composite data, instead of reading this composite
data.

Release note (bug fix): A bug where vectorized queries on composite
datatypes could sometimes return invalid data.
