### PR TITLE
release-19.2: colexec: fix bug with decoding composite values in cfetcher

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1120,3 +1120,14 @@ CREATE INDEX ON t47029_1(c0) INTERLEAVE IN PARENT t47029_0(c0)
 query I
 SELECT * FROM t47029_0 WHERE (t47029_0.rowid > 0) IS NULL
 ----
+
+# Regression for #47115 (cfetcher sometimes not reading value component
+# of composite encoded data).
+statement ok
+CREATE TABLE t47715 (c0 DECIMAL PRIMARY KEY, c1 INT UNIQUE);
+INSERT INTO t47715(c0) VALUES (1819487610)
+
+query T
+SELECT c0 FROM t47715 ORDER by c1
+----
+1819487610


### PR DESCRIPTION
Backport 1/1 commits from #48052.

/cc @cockroachdb/release

---

Fixes #47115.

This PR fixes a bug where the primary key data in secondary indexes
was being decoded incorrectly in the cfetcher. Precisely, the cfetcher
maintained a set of found value columns per row. When decoding primary
key values in a secondary index, it would remove value columns from
this set as it found them. However, once decoding the value it would
stop once it thought it found everything in the set, rather than reading
the full value. This caused it to mistakenly exit early when the value
component contained composite data, instead of reading this composite
data.

Release note (bug fix): A bug where vectorized queries on composite
datatypes could sometimes return invalid data.
