### PR TITLE
pkg/util: avoid conflicting lock order in log

### DIFF
--- a/pkg/util/log/exit_override.go
+++ b/pkg/util/log/exit_override.go
@@ -79,7 +79,11 @@ func (l *loggerT) exitLocked(err error) {
 	f := logging.mu.exitOverride.f
 	logging.mu.Unlock()
 	if f != nil {
+		// Avoid conflicting lock order between l.mu and locks in f.
+		l.mu.Unlock()
 		f(2, err)
+		// Avoid double unlock on l.mu.
+		l.mu.Lock()
 	} else {
 		os.Exit(2)
 	}


### PR DESCRIPTION
This PR fixes #48447 and #48470
https://github.com/cockroachdb/cockroach/blob/cb60e7536f81c0c3eae854e4774c66a01a4f691c/pkg/util/log/exit_override.go#L51-L56
https://github.com/cockroachdb/cockroach/blob/cb60e7536f81c0c3eae854e4774c66a01a4f691c/pkg/util/log/exit_override.go#L78-L82
https://github.com/cockroachdb/cockroach/blob/cb60e7536f81c0c3eae854e4774c66a01a4f691c/pkg/cmd/zerosum/main.go#L440-L443
`loggerT.mu.Lock()` (`l.mu.Lock()` not `logging.mu.Lock()`) is held before calling `f(2, err)`.
`f` is set to an anonymous function calling `c.Close()` by `main()`.
https://github.com/cockroachdb/cockroach/blob/cb60e7536f81c0c3eae854e4774c66a01a4f691c/pkg/cmd/zerosum/main.go#L440-L443
`c.Close()` will call `n.Kill()` (containing `Node.Lock()`) and `Stop()` (containing `Stopper.mu.Lock()`)
https://github.com/cockroachdb/cockroach/blob/cb60e7536f81c0c3eae854e4774c66a01a4f691c/pkg/acceptance/localcluster/cluster.go#L218-L222
But  in other places, `Node.Lock()` and `Stopper.mu.Lock()` are called before `loggerT.mu.Lock()`.
Thus conflicting lock order occurs.
The patch here is to add `l.mu.Unlock()` before calling `f`. 
But there has been an `Unlock()` after calling `exitLocked()` and `outputToStderr()`:
https://github.com/cockroachdb/cockroach/blob/cb60e7536f81c0c3eae854e4774c66a01a4f691c/pkg/util/log/clog.go#L265-L275
So I also add `l.mu.Lock()` after calling `f` to avoid double unlock.