### PR TITLE
deps: bump cockroachdb/errors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -376,7 +376,8 @@
   revision = "edce558372380347c6fef147e62f5559a9f8413d"
 
 [[projects]]
-  digest = "1:35ff61e02c035785971ac6ec04d54428307a986412e5d0aea86b8b7f45677d09"
+  branch = "v1.2.3-cockroachdb19.2"
+  digest = "1:97dc514f2ae2e31577d7e5a541bb010b9811f9923a59c131a7d7da232d51851d"
   name = "github.com/cockroachdb/errors"
   packages = [
     ".",
@@ -399,8 +400,7 @@
     "withstack",
   ]
   pruneopts = "UT"
-  revision = "7ba395ace80575c71104187a222f77bf23c19326"
-  version = "v1.2.3"
+  revision = "6e28db11fa4b207dcffe7c5926929a5e6312bde1"
 
 [[projects]]
   digest = "1:cd936a7edd1897083994b6d397f9c975a5a8dc58e845f0cf3d1e5cf4717b918b"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,6 +31,11 @@ ignored = [
   "github.com/google/protobuf/examples/tutorial",
 ]
 
+[[constraint]]
+  name = "github.com/cockroachdb/errors"
+  branch = "v1.2.3-cockroachdb19.2"
+
+
 # The collation tables must never change.
 [[constraint]]
   name = "golang.org/x/text"

--- a/Makefile
+++ b/Makefile
@@ -621,7 +621,7 @@ $(ROCKSDB_DIR)/Makefile: $(C_DEPS_DIR)/rocksdb-rebuild | bin/.submodules-initial
 	  -DSNAPPY_LIBRARIES=$(LIBSNAPPY) -DSNAPPY_INCLUDE_DIR="$(SNAPPY_SRC_DIR);$(SNAPPY_DIR)" -DWITH_SNAPPY=ON \
 	  $(if $(use-stdmalloc),,-DJEMALLOC_LIBRARIES=$(LIBJEMALLOC) -DJEMALLOC_INCLUDE_DIR=$(JEMALLOC_DIR)/include -DWITH_JEMALLOC=ON) \
 	  -DCMAKE_BUILD_TYPE=$(if $(ENABLE_ROCKSDB_ASSERTIONS),Debug,Release) \
-	  -DFAIL_ON_WARNINGS=$(if $(findstring windows,$(XGOOS)),0,1) \
+	  -DFAIL_ON_WARNINGS=0 \
 	  -DUSE_RTTI=1
 
 $(SNAPPY_DIR)/Makefile: $(C_DEPS_DIR)/snappy-rebuild | bin/.submodules-initialized

--- a/pkg/util/hlc/timestamp.pb.go
+++ b/pkg/util/hlc/timestamp.pb.go
@@ -435,7 +435,9 @@ var (
 	ErrIntOverflowTimestamp   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("util/hlc/timestamp.proto", fileDescriptor_timestamp_7743fc20d6f93748) }
+func init() {
+	proto.RegisterFile("util/hlc/timestamp.proto", fileDescriptor_timestamp_7743fc20d6f93748)
+}
 
 var fileDescriptor_timestamp_7743fc20d6f93748 = []byte{
 	// 191 bytes of a gzipped FileDescriptorProto


### PR DESCRIPTION
cc @cockroachdb/release 

Note to the reviewers: these fixes already made their way to the release-20.1 and master branch as part of unrelated commits. The impact of the bug had not been understood at that point, hence the lack of specific release notes previously. It does not affect 19.1 and prior versions.

----

This imports the following fixes:

- `errors.Cause()` was improperly implemented. This was (potentially)
  affecting the reporting of errors encountered in the CLI.  It was also
  causing the `quit` command to sometimes fail with errors "compressed
  flag set with identity or empty encoding" or "Decompressor is not
  installed" even though there was code to handle these cases.

- `errors.IsAny()` was properly implemented. This was likely affecting:

  - the inability of schema changes to properly abort upon
    various internal errors (i.e. `isPermanentSchemaChangeError()` was not
    doing what it says on the label).
  - logging of errors in schema changes.
  - logging of errors during IMPORT from HTTP sources.
  - the reporting of hints upon timeout errors in the CLI.

Release note (bug fix): Some schema changes could previously have
become stuck and unable to abort on their own (and would require a
manual `CANCEL QUERY` or `CANCEL JOB`). This has been fixed. This bug
had been introduced in CockroachDB v19.2.


