### PR TITLE
roachtest: skip acceptance/many-splits on <=19.1

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -43,7 +43,10 @@ func registerAcceptance(r *testRegistry) {
 		{name: "gossip/restart-node-one", fn: runGossipRestartNodeOne},
 		{name: "gossip/locality-address", fn: runCheckLocalityIPAddress},
 		{name: "rapid-restart", fn: runRapidRestart},
-		{name: "many-splits", fn: runManySplits},
+		{
+			name: "many-splits", fn: runManySplits,
+			minVersion: "v19.2.0", // SQL syntax unsupported on 19.1.x
+		},
 		{name: "status-server", fn: runStatusServer},
 		{
 			name: "version-upgrade",


### PR DESCRIPTION
The syntax the test uses is not supported prior to 19.2.

Release note: None