### PR TITLE
kv/kvserver,storage: fix spanset assertions when running on Pebble

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -4513,7 +4513,7 @@ func TestReplicaLaziness(t *testing.T) {
 	})
 
 	testWithAction(func() roachpb.Request {
-		scan := scanArgs(roachpb.KeyMin, roachpb.KeyMax)
+		scan := scanArgs(roachpb.Key("a"), roachpb.Key("b"))
 		return scan
 	})
 }

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -102,7 +102,7 @@ func (i *Iterator) Valid() (bool, error) {
 	}
 	ok, err := i.i.Valid()
 	if err != nil {
-		return false, i.err
+		return false, err
 	}
 	return ok && !i.invalid, nil
 }
@@ -110,13 +110,15 @@ func (i *Iterator) Valid() (bool, error) {
 // Next is part of the engine.Iterator interface.
 func (i *Iterator) Next() {
 	i.i.Next()
-	if i.spansOnly {
-		if i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: i.UnsafeKey().Key}) != nil {
-			i.invalid = true
-		}
-	} else {
-		if i.spans.CheckAllowedAt(SpanReadOnly, roachpb.Span{Key: i.UnsafeKey().Key}, i.ts) != nil {
-			i.invalid = true
+	if ok, _ := i.i.Valid(); ok {
+		if i.spansOnly {
+			if i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: i.UnsafeKey().Key}) != nil {
+				i.invalid = true
+			}
+		} else {
+			if i.spans.CheckAllowedAt(SpanReadOnly, roachpb.Span{Key: i.UnsafeKey().Key}, i.ts) != nil {
+				i.invalid = true
+			}
 		}
 	}
 }
@@ -124,13 +126,15 @@ func (i *Iterator) Next() {
 // Prev is part of the engine.Iterator interface.
 func (i *Iterator) Prev() {
 	i.i.Prev()
-	if i.spansOnly {
-		if i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: i.UnsafeKey().Key}) != nil {
-			i.invalid = true
-		}
-	} else {
-		if i.spans.CheckAllowedAt(SpanReadOnly, roachpb.Span{Key: i.UnsafeKey().Key}, i.ts) != nil {
-			i.invalid = true
+	if ok, _ := i.i.Valid(); ok {
+		if i.spansOnly {
+			if i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: i.UnsafeKey().Key}) != nil {
+				i.invalid = true
+			}
+		} else {
+			if i.spans.CheckAllowedAt(SpanReadOnly, roachpb.Span{Key: i.UnsafeKey().Key}, i.ts) != nil {
+				i.invalid = true
+			}
 		}
 	}
 }
@@ -138,13 +142,15 @@ func (i *Iterator) Prev() {
 // NextKey is part of the engine.Iterator interface.
 func (i *Iterator) NextKey() {
 	i.i.NextKey()
-	if i.spansOnly {
-		if i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: i.UnsafeKey().Key}) != nil {
-			i.invalid = true
-		}
-	} else {
-		if i.spans.CheckAllowedAt(SpanReadOnly, roachpb.Span{Key: i.UnsafeKey().Key}, i.ts) != nil {
-			i.invalid = true
+	if ok, _ := i.i.Valid(); ok {
+		if i.spansOnly {
+			if i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: i.UnsafeKey().Key}) != nil {
+				i.invalid = true
+			}
+		} else {
+			if i.spans.CheckAllowedAt(SpanReadOnly, roachpb.Span{Key: i.UnsafeKey().Key}, i.ts) != nil {
+				i.invalid = true
+			}
 		}
 	}
 }

--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -16,7 +16,6 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -525,7 +524,7 @@ func (p *pebbleMVCCScanner) advanceKeyAtEnd() bool {
 		// Iterating to the next key might have caused the iterator to reach the
 		// end of the key space. If that happens, back up to the very last key.
 		p.peeked = false
-		p.parent.SeekLT(MVCCKey{Key: keys.MaxKey})
+		p.parent.SeekLT(MVCCKey{Key: p.end})
 		if !p.updateCurrent() {
 			return false
 		}
@@ -665,7 +664,7 @@ func (p *pebbleMVCCScanner) iterNext() bool {
 		if !p.iterValid() {
 			// We were peeked off the beginning of iteration. Seek to the first
 			// entry, and then advance one step.
-			p.parent.SeekGE(MVCCKey{})
+			p.parent.SeekGE(MVCCKey{Key: p.start})
 			if !p.iterValid() {
 				return false
 			}


### PR DESCRIPTION
Fix spanset assertions when running race-enabled tests on Pebble. In
race-enabled tests, `pebbleMVCCScanner` runs on a `spanset.Iterator`
which asserts that the keys used are within the spans declared by the KV
op. `pebbleMVCCScanner.scan()` was violating these assertions at the
scan boundaries due to the usage of `MVCCKey{}` (a.k.a. min-key) and
`keys.KeyMax`.

Fix `spanset.Iterator.{Next,Prev,NextKey}` to only check whether the key
is allowed if the underlying iterator is valid. This doesn't appear to
have been a problem in practice, but the previous code was definitely
incorrect.

Fix `TestReplicaLaziness` to not scan from
`[keys.KeyMin,keys.KeyMax]`. That's not a valid thing to do and runs
afoul of the spanset assertions when running on Pebble.

Fixes #48461
Fixes #48460

Release note: None