### PR TITLE
changefeedccl: fix bug where job ID was omitted from behind log message

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -898,7 +898,7 @@ func (cf *changeFrontier) maybeLogBehindSpan(frontierChanged bool) (isBehind boo
 	}
 
 	description := `sinkless feed`
-	if cf.isSinkless() {
+	if !cf.isSinkless() {
 		description = fmt.Sprintf("job %d", cf.spec.JobID)
 	}
 	if frontierChanged {


### PR DESCRIPTION
Introduced in the 20.1 refactor.

Release note (enterprise change): Fix bug where the job ID of a lagging
changefeed would be omitted and instead it would be reported as sinkless.