### PR TITLE
smithcmp: rename auto to 201auto in tpch config files

### DIFF
--- a/pkg/cmd/roachtest/tpchvec_smithcmp.toml
+++ b/pkg/cmd/roachtest/tpchvec_smithcmp.toml
@@ -511,13 +511,6 @@ initsql = """
 set vectorize=off;
 """
 
-[databases.vec-auto]
-addr = "postgresql://root@localhost:26257/tpch?sslmode=disable"
-allowmutations = true
-initsql = """
-set vectorize=auto;
-"""
-
 [databases.vec-on]
 addr = "postgresql://root@localhost:26257/tpch?sslmode=disable"
 allowmutations = true

--- a/pkg/cmd/smithcmp/tpch.toml
+++ b/pkg/cmd/smithcmp/tpch.toml
@@ -513,11 +513,11 @@ initsql = """
 set vectorize=off;
 """
 
-[databases.vec-auto]
+[databases.vec-201auto]
 addr = "postgresql://root@localhost:26257/tpch?sslmode=disable"
 allowmutations = true
 initsql = """
-set vectorize=auto;
+set vectorize=201auto;
 """
 
 [databases.vec-on]


### PR DESCRIPTION
This commit also removes `auto` option from `tpchvec_smithcmp.toml`
config file because that option has different names in 20.2 and 20.1,
and we run the test on both. The alternative is to introduce a separate
config file, but I don't think `auto` option gives us much more test
coverage than already present `off` and `on` do.

Fixes: #48484.

Release note: None