### PR TITLE
colexec: fix planning of substring operator

### DIFF
--- a/pkg/sql/colexec/builtin_funcs.go
+++ b/pkg/sql/colexec/builtin_funcs.go
@@ -121,7 +121,7 @@ func NewBuiltinFunctionOperator(
 ) (colexecbase.Operator, error) {
 	switch funcExpr.ResolvedOverload().SpecializedVecBuiltin {
 	case tree.SubstringStringIntInt:
-		input = newVectorTypeEnforcer(allocator, input, types.Bytes, outputIdx)
+		input = newVectorTypeEnforcer(allocator, input, types.String, outputIdx)
 		return newSubstringOperator(
 			allocator, columnTypes, argumentCols, outputIdx, input,
 		), nil


### PR DESCRIPTION
We mistakenly have the output type of substring operator as
`types.Bytes` and not `types.String`. This used to be ok since both were
represented by the same `coltypes.Bytes` type, but now we do the check
that the logical type of the column is identical to the one we expect,
so an assertion fails. Fix it by correctly using `types.String`.

I believe the bug could be triggered only if we have `CASE` operator
with `Substring` being in one of case branches, and the assertion
wouldn't trigger on stable branches.

Fixes: #48477.

Release note: None