### PR TITLE
colexec: some memory accounting and performance optimizations

### DIFF
--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -154,7 +154,7 @@ type memColumn struct {
 func NewMemColumn(t *types.T, n int) Vec {
 	nulls := NewNulls(n)
 
-	switch canonicalTypeFamily := typeconv.TypeFamilyToCanonicalTypeFamily[t.Family()]; canonicalTypeFamily {
+	switch canonicalTypeFamily := typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()); canonicalTypeFamily {
 	case types.BoolFamily:
 		return &memColumn{t: t, canonicalTypeFamily: canonicalTypeFamily, col: make([]bool, n), nulls: nulls}
 	case types.BytesFamily:

--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -91,7 +91,7 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 	n := batch.Length()
 	for i, typ := range c.typs {
 		vec := batch.ColVec(i)
-		canonicalTypeFamily := typeconv.TypeFamilyToCanonicalTypeFamily[typ.Family()]
+		canonicalTypeFamily := typeconv.TypeFamilyToCanonicalTypeFamily(typ.Family())
 
 		var arrowBitmap []byte
 		if vec.MaybeHasNulls() {
@@ -251,7 +251,7 @@ func (c *ArrowBatchConverter) ArrowToBatch(data []*array.Data, b coldata.Batch) 
 		d := data[i]
 
 		var arr array.Interface
-		switch typeconv.TypeFamilyToCanonicalTypeFamily[typ.Family()] {
+		switch typeconv.TypeFamilyToCanonicalTypeFamily(typ.Family()) {
 		case types.BoolFamily:
 			boolArr := array.NewBooleanData(d)
 			vecArr := vec.Bool()
@@ -336,7 +336,7 @@ func (c *ArrowBatchConverter) ArrowToBatch(data []*array.Data, b coldata.Batch) 
 			arr = bytesArr
 		default:
 			var col interface{}
-			switch typeconv.TypeFamilyToCanonicalTypeFamily[typ.Family()] {
+			switch typeconv.TypeFamilyToCanonicalTypeFamily(typ.Family()) {
 			case types.IntFamily:
 				switch typ.Width() {
 				case 16:

--- a/pkg/col/colserde/file.go
+++ b/pkg/col/colserde/file.go
@@ -328,7 +328,7 @@ func schema(fb *flatbuffers.Builder, typs []*types.T) flatbuffers.UOffsetT {
 	for idx, typ := range typs {
 		var fbTyp byte
 		var fbTypOffset flatbuffers.UOffsetT
-		switch typeconv.TypeFamilyToCanonicalTypeFamily[typ.Family()] {
+		switch typeconv.TypeFamilyToCanonicalTypeFamily(typ.Family()) {
 		case types.BoolFamily:
 			arrowserde.BoolStart(fb)
 			fbTypOffset = arrowserde.BoolEnd(fb)

--- a/pkg/col/colserde/record_batch.go
+++ b/pkg/col/colserde/record_batch.go
@@ -36,7 +36,7 @@ func numBuffersForType(t *types.T) int {
 	// Nearly all types are represented by 2 memory.Buffers. One buffer for the
 	// null bitmap and one for the values.
 	numBuffers := 2
-	switch typeconv.TypeFamilyToCanonicalTypeFamily[t.Family()] {
+	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
 	case types.BytesFamily, types.DecimalFamily, types.TimestampTZFamily, types.IntervalFamily:
 		// This type has an extra offsets buffer.
 		numBuffers = 3

--- a/pkg/col/colserde/record_batch_test.go
+++ b/pkg/col/colserde/record_batch_test.go
@@ -56,7 +56,7 @@ func randomDataFromType(rng *rand.Rand, t *types.T, n int, nullProbability float
 	}
 
 	var builder array.Builder
-	switch typeconv.TypeFamilyToCanonicalTypeFamily[t.Family()] {
+	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
 	case types.BoolFamily:
 		builder = array.NewBooleanBuilder(memory.DefaultAllocator)
 		data := make([]bool, n)

--- a/pkg/sql/colexec/aggregator.go
+++ b/pkg/sql/colexec/aggregator.go
@@ -250,7 +250,7 @@ func makeAggregateFuncs(
 		case execinfrapb.AggregatorSpec_SUM, execinfrapb.AggregatorSpec_SUM_INT:
 			funcs[i], err = newSumAgg(allocator, aggTyps[i][0])
 		case execinfrapb.AggregatorSpec_COUNT_ROWS:
-			funcs[i] = newCountRowAgg(allocator)
+			funcs[i] = newCountRowsAgg(allocator)
 		case execinfrapb.AggregatorSpec_COUNT:
 			funcs[i] = newCountAgg(allocator)
 		case execinfrapb.AggregatorSpec_MIN:

--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -61,7 +61,7 @@ const _TYPE_WIDTH = 0
 // */}}
 
 func newAnyNotNullAgg(allocator *colmem.Allocator, t *types.T) (aggregateFunc, error) {
-	switch typeconv.TypeFamilyToCanonicalTypeFamily[t.Family()] {
+	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
 	// {{range .}}
 	case _CANONICAL_TYPE_FAMILY:
 		switch t.Width() {

--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -21,6 +21,7 @@ package colexec
 
 import (
 	"time"
+	"unsafe"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -66,6 +67,7 @@ func newAnyNotNullAgg(allocator *colmem.Allocator, t *types.T) (aggregateFunc, e
 		switch t.Width() {
 		// {{range .WidthOverloads}}
 		case _TYPE_WIDTH:
+			allocator.AdjustMemoryUsage(int64(sizeOfAnyNotNull_TYPEAgg))
 			return &anyNotNull_TYPEAgg{allocator: allocator}, nil
 			// {{end}}
 		}
@@ -90,6 +92,10 @@ type anyNotNull_TYPEAgg struct {
 	curAgg                      _GOTYPE
 	foundNonNullForCurrentGroup bool
 }
+
+var _ aggregateFunc = &anyNotNull_TYPEAgg{}
+
+const sizeOfAnyNotNull_TYPEAgg = unsafe.Sizeof(&anyNotNull_TYPEAgg{})
 
 func (a *anyNotNull_TYPEAgg) Init(groups []bool, vec coldata.Vec) {
 	a.groups = groups

--- a/pkg/sql/colexec/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/avg_agg_tmpl.go
@@ -63,7 +63,7 @@ func _ASSIGN_ADD(_, _, _ string) {
 // */}}
 
 func newAvgAgg(allocator *colmem.Allocator, t *types.T) (aggregateFunc, error) {
-	switch typeconv.TypeFamilyToCanonicalTypeFamily[t.Family()] {
+	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
 	// {{range .}}
 	case _CANONICAL_TYPE_FAMILY:
 		switch t.Width() {

--- a/pkg/sql/colexec/bool_and_or_agg_tmpl.go
+++ b/pkg/sql/colexec/bool_and_or_agg_tmpl.go
@@ -20,8 +20,11 @@
 package colexec
 
 import (
+	"unsafe"
+
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 )
 
 // Remove unused warning.
@@ -40,7 +43,8 @@ func _ASSIGN_BOOL_OP(_, _, _ string) {
 
 // {{range .}}
 
-func newBool_OP_TYPEAgg() aggregateFunc {
+func newBool_OP_TYPEAgg(allocator *colmem.Allocator) aggregateFunc {
+	allocator.AdjustMemoryUsage(int64(sizeOfBool_OP_TYPEAgg))
 	return &bool_OP_TYPEAgg{}
 }
 
@@ -55,6 +59,10 @@ type bool_OP_TYPEAgg struct {
 	curIdx int
 	curAgg bool
 }
+
+var _ aggregateFunc = &bool_OP_TYPEAgg{}
+
+const sizeOfBool_OP_TYPEAgg = unsafe.Sizeof(&bool_OP_TYPEAgg{})
 
 func (b *bool_OP_TYPEAgg) Init(groups []bool, vec coldata.Vec) {
 	b.groups = groups

--- a/pkg/sql/colexec/bool_and_or_agg_tmpl.go
+++ b/pkg/sql/colexec/bool_and_or_agg_tmpl.go
@@ -49,7 +49,6 @@ func newBool_OP_TYPEAgg(allocator *colmem.Allocator) aggregateFunc {
 }
 
 type bool_OP_TYPEAgg struct {
-	done       bool
 	sawNonNull bool
 
 	groups []bool
@@ -74,7 +73,6 @@ func (b *bool_OP_TYPEAgg) Init(groups []bool, vec coldata.Vec) {
 func (b *bool_OP_TYPEAgg) Reset() {
 	b.curIdx = -1
 	b.nulls.UnsetNulls()
-	b.done = false
 	// _DEFAULT_VAL indicates whether we are doing an AND aggregate or OR aggregate.
 	// For bool_and the _DEFAULT_VAL is true and for bool_or the _DEFAULT_VAL is false.
 	b.curAgg = _DEFAULT_VAL
@@ -92,20 +90,7 @@ func (b *bool_OP_TYPEAgg) SetOutputIndex(idx int) {
 }
 
 func (b *bool_OP_TYPEAgg) Compute(batch coldata.Batch, inputIdxs []uint32) {
-	if b.done {
-		return
-	}
 	inputLen := batch.Length()
-	if inputLen == 0 {
-		if !b.sawNonNull {
-			b.nulls.SetNull(b.curIdx)
-		} else {
-			b.vec[b.curIdx] = b.curAgg
-		}
-		b.curIdx++
-		b.done = true
-		return
-	}
 	vec, sel := batch.ColVec(int(inputIdxs[0])), batch.Selection()
 	col, nulls := vec.Bool(), vec.Nulls()
 	if sel != nil {
@@ -119,6 +104,15 @@ func (b *bool_OP_TYPEAgg) Compute(batch coldata.Batch, inputIdxs []uint32) {
 			_ACCUMULATE_BOOLEAN(b, nulls, i)
 		}
 	}
+}
+
+func (b *bool_OP_TYPEAgg) Flush() {
+	if !b.sawNonNull {
+		b.nulls.SetNull(b.curIdx)
+	} else {
+		b.vec[b.curIdx] = b.curAgg
+	}
+	b.curIdx++
 }
 
 func (b *bool_OP_TYPEAgg) HandleEmptyInputScalar() {

--- a/pkg/sql/colexec/cast_tmpl.go
+++ b/pkg/sql/colexec/cast_tmpl.go
@@ -175,13 +175,13 @@ func GetCastOperator(
 		}, nil
 	}
 	leftType, rightType := fromType, toType
-	switch typeconv.TypeFamilyToCanonicalTypeFamily[leftType.Family()] {
+	switch typeconv.TypeFamilyToCanonicalTypeFamily(leftType.Family()) {
 	// {{range .LeftFamilies}}
 	case _LEFT_CANONICAL_TYPE_FAMILY:
 		switch leftType.Width() {
 		// {{range .LeftWidths}}
 		case _LEFT_TYPE_WIDTH:
-			switch typeconv.TypeFamilyToCanonicalTypeFamily[rightType.Family()] {
+			switch typeconv.TypeFamilyToCanonicalTypeFamily(rightType.Family()) {
 			// {{range .RightFamilies}}
 			case _RIGHT_CANONICAL_TYPE_FAMILY:
 				switch rightType.Width() {

--- a/pkg/sql/colexec/const_tmpl.go
+++ b/pkg/sql/colexec/const_tmpl.go
@@ -71,7 +71,7 @@ func NewConstOp(
 	outputIdx int,
 ) (colexecbase.Operator, error) {
 	input = newVectorTypeEnforcer(allocator, input, t, outputIdx)
-	switch typeconv.TypeFamilyToCanonicalTypeFamily[t.Family()] {
+	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
 	// {{range .}}
 	case _CANONICAL_TYPE_FAMILY:
 		switch t.Width() {

--- a/pkg/sql/colexec/distinct_tmpl.go
+++ b/pkg/sql/colexec/distinct_tmpl.go
@@ -138,7 +138,7 @@ const _TYPE_WIDTH = 0
 func newSingleDistinct(
 	input colexecbase.Operator, distinctColIdx int, outputCol []bool, t *types.T,
 ) (colexecbase.Operator, error) {
-	switch typeconv.TypeFamilyToCanonicalTypeFamily[t.Family()] {
+	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
 	// {{range .}}
 	case _CANONICAL_TYPE_FAMILY:
 		switch t.Width() {
@@ -175,7 +175,7 @@ type partitioner interface {
 
 // newPartitioner returns a new partitioner on type t.
 func newPartitioner(t *types.T) (partitioner, error) {
-	switch typeconv.TypeFamilyToCanonicalTypeFamily[t.Family()] {
+	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
 	// {{range .}}
 	case _CANONICAL_TYPE_FAMILY:
 		switch t.Width() {

--- a/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
@@ -29,9 +29,9 @@ func (o lastArgWidthOverload) AssignAdd(target, l, r string) string {
 func (o lastArgWidthOverload) AssignDivInt64(target, l, r string) string {
 	switch o.lastArgTypeOverload.CanonicalTypeFamily {
 	case types.DecimalFamily:
-		return fmt.Sprintf(
-			`%s.SetInt64(%s)
-if _, err := tree.DecimalCtx.Quo(&%s, &%s, &%s); err != nil {
+		return fmt.Sprintf(`
+			%s.SetInt64(%s)
+			if _, err := tree.DecimalCtx.Quo(&%s, &%s, &%s); err != nil {
 			colexecerror.InternalError(err)
 		}`,
 			target, r, target, l, target,

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
@@ -428,7 +428,7 @@ func (b *argWidthOverloadBase) Get(target, i string) string {
 
 // ReturnGet is a function that should only be used in templates.
 func (o *lastArgWidthOverload) ReturnGet(target, i string) string {
-	return get(typeconv.TypeFamilyToCanonicalTypeFamily[o.RetType.Family()], target, i)
+	return get(typeconv.TypeFamilyToCanonicalTypeFamily(o.RetType.Family()), target, i)
 }
 
 // CopyVal is a function that should only be used in templates.

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -1687,7 +1687,7 @@ func planProjectionOperators(
 		buffer := NewBufferOp(schemaEnforcer)
 		caseOps := make([]colexecbase.Operator, len(t.Whens))
 		caseOutputType := t.ResolvedType()
-		if typeconv.TypeFamilyToCanonicalTypeFamily[caseOutputType.Family()] == types.BytesFamily {
+		if typeconv.TypeFamilyToCanonicalTypeFamily(caseOutputType.Family()) == types.BytesFamily {
 			// Currently, there is a contradiction between the way CASE operator
 			// works (which populates its output in arbitrary order) and the flat
 			// bytes implementation of Bytes type (which prohibits sets in arbitrary

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -252,11 +252,9 @@ func (op *hashAggregator) Next(ctx context.Context) coldata.Batch {
 				remainingAggFuncs := op.aggFuncMap[op.output.resumeHashCode][op.output.resumeIdx:]
 				for groupIdx, aggFunc := range remainingAggFuncs {
 					if curOutputIdx < coldata.BatchSize() {
-						for fnIdx, fn := range aggFunc.fns {
+						for _, fn := range aggFunc.fns {
 							fn.SetOutputIndex(curOutputIdx)
-							// Passing a zero batch into an aggregation function causing it to
-							// flush the agg result to the output batch at curOutputIdx.
-							fn.Compute(coldata.ZeroBatch, op.aggCols[fnIdx])
+							fn.Flush()
 						}
 					} else {
 						op.output.resumeIdx = op.output.resumeIdx + groupIdx
@@ -274,9 +272,9 @@ func (op *hashAggregator) Next(ctx context.Context) coldata.Batch {
 			for aggHashCode, aggFuncs := range op.aggFuncMap {
 				for groupIdx, aggFunc := range aggFuncs {
 					if curOutputIdx < coldata.BatchSize() {
-						for fnIdx, fn := range aggFunc.fns {
+						for _, fn := range aggFunc.fns {
 							fn.SetOutputIndex(curOutputIdx)
-							fn.Compute(coldata.ZeroBatch, op.aggCols[fnIdx])
+							fn.Flush()
 						}
 					} else {
 						// If current batch is filled, we record where we left off

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -12,6 +12,7 @@ package colexec
 
 import (
 	"context"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
@@ -208,6 +209,8 @@ func NewHashAggregator(
 		groupCols:                  groupCols,
 		groupTypes:                 groupTypes,
 		groupCanonicalTypeFamilies: typeconv.ToCanonicalTypeFamilies(groupTypes),
+
+		alloc: hashAggFuncsAlloc{allocator: allocator},
 	}, err
 }
 
@@ -442,6 +445,11 @@ type hashAggFuncs struct {
 	fns []aggregateFunc
 }
 
+const sizeOfHashAggFuncs = unsafe.Sizeof(&hashAggFuncs{})
+
+// TODO(yuzefovich): we need to account for memory used by this map. It is
+// likely that we will replace Golang's map with our vectorized hash table, so
+// we might hold off with fixing the accounting until then.
 type hashAggFuncMap map[uint64][]*hashAggFuncs
 
 func (v *hashAggFuncs) init(group []bool, b coldata.Batch) {
@@ -465,11 +473,13 @@ const hashAggFuncsAllocSize = 64
 // hashAggFuncsAlloc is a utility struct that batches allocations of
 // hashAggFuncs.
 type hashAggFuncsAlloc struct {
-	buf []hashAggFuncs
+	allocator *colmem.Allocator
+	buf       []hashAggFuncs
 }
 
 func (a *hashAggFuncsAlloc) newHashAggFuncs() *hashAggFuncs {
 	if len(a.buf) == 0 {
+		a.allocator.AdjustMemoryUsage(int64(hashAggFuncsAllocSize * sizeOfHashAggFuncs))
 		a.buf = make([]hashAggFuncs, hashAggFuncsAllocSize)
 	}
 	ret := &a.buf[0]

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -88,7 +88,7 @@ func _ASSIGN_CMP(_, _, _ string) bool {
 // {{$agg := .AggNameLower}}
 
 func new_AGG_TITLEAgg(allocator *colmem.Allocator, t *types.T) (aggregateFunc, error) {
-	switch typeconv.TypeFamilyToCanonicalTypeFamily[t.Family()] {
+	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
 	// {{range .Overloads}}
 	case _CANONICAL_TYPE_FAMILY:
 		switch t.Width() {

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"math"
 	"time"
+	"unsafe"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -93,6 +94,7 @@ func new_AGG_TITLEAgg(allocator *colmem.Allocator, t *types.T) (aggregateFunc, e
 		switch t.Width() {
 		// {{range .WidthOverloads}}
 		case _TYPE_WIDTH:
+			allocator.AdjustMemoryUsage(int64(sizeOf_AGG_TYPEAgg))
 			return &_AGG_TYPEAgg{allocator: allocator}, nil
 			// {{end}}
 		}
@@ -125,6 +127,8 @@ type _AGG_TYPEAgg struct {
 }
 
 var _ aggregateFunc = &_AGG_TYPEAgg{}
+
+const sizeOf_AGG_TYPEAgg = unsafe.Sizeof(&_AGG_TYPEAgg{})
 
 func (a *_AGG_TYPEAgg) Init(groups []bool, v coldata.Vec) {
 	a.groups = groups

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -108,7 +108,6 @@ func new_AGG_TITLEAgg(allocator *colmem.Allocator, t *types.T) (aggregateFunc, e
 
 type _AGG_TYPEAgg struct {
 	allocator *colmem.Allocator
-	done      bool
 	groups    []bool
 	curIdx    int
 	// curAgg holds the running min/max, so we can index into the slice once per
@@ -142,7 +141,6 @@ func (a *_AGG_TYPEAgg) Reset() {
 	a.curIdx = -1
 	a.foundNonNullForCurrentGroup = false
 	a.nulls.UnsetNulls()
-	a.done = false
 }
 
 func (a *_AGG_TYPEAgg) CurrentOutputIndex() int {
@@ -157,28 +155,7 @@ func (a *_AGG_TYPEAgg) SetOutputIndex(idx int) {
 }
 
 func (a *_AGG_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
-	if a.done {
-		return
-	}
 	inputLen := b.Length()
-	if inputLen == 0 {
-		// The aggregation is finished. Flush the last value. If we haven't found
-		// any non-nulls for this group so far, the output for this group should
-		// be null.
-		if !a.foundNonNullForCurrentGroup {
-			a.nulls.SetNull(a.curIdx)
-		} else {
-			a.allocator.PerformOperation(
-				[]coldata.Vec{a.vec},
-				func() {
-					execgen.SET(a.col, a.curIdx, a.curAgg)
-				},
-			)
-		}
-		a.curIdx++
-		a.done = true
-		return
-	}
 	vec, sel := b.ColVec(int(inputIdxs[0])), b.Selection()
 	col, nulls := vec._TYPE(), vec.Nulls()
 	a.allocator.PerformOperation(
@@ -211,6 +188,18 @@ func (a *_AGG_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 			}
 		},
 	)
+}
+
+func (a *_AGG_TYPEAgg) Flush() {
+	// The aggregation is finished. Flush the last value. If we haven't found
+	// any non-nulls for this group so far, the output for this group should
+	// be null.
+	if !a.foundNonNullForCurrentGroup {
+		a.nulls.SetNull(a.curIdx)
+	} else {
+		execgen.SET(a.col, a.curIdx, a.curAgg)
+	}
+	a.curIdx++
 }
 
 func (a *_AGG_TYPEAgg) HandleEmptyInputScalar() {

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -222,7 +222,7 @@ func (o *OrderedSynchronizer) Init() {
 	o.outColsMap = make([]int, len(o.typs))
 	for i, outVec := range o.output.ColVecs() {
 		o.outNulls[i] = outVec.Nulls()
-		switch typeconv.TypeFamilyToCanonicalTypeFamily[o.typs[i].Family()] {
+		switch typeconv.TypeFamilyToCanonicalTypeFamily(o.typs[i].Family()) {
 		// {{range .}}
 		case _CANONICAL_TYPE_FAMILY:
 			switch o.typs[i].Width() {

--- a/pkg/sql/colexec/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_const_ops_tmpl.go
@@ -267,13 +267,13 @@ func GetProjection_CONST_SIDEConstOperator(
 		switch op {
 		// {{range .BinOps}}
 		case tree._NAME:
-			switch typeconv.TypeFamilyToCanonicalTypeFamily[leftType.Family()] {
+			switch typeconv.TypeFamilyToCanonicalTypeFamily(leftType.Family()) {
 			// {{range .LeftFamilies}}
 			case _LEFT_CANONICAL_TYPE_FAMILY:
 				switch leftType.Width() {
 				// {{range .LeftWidths}}
 				case _LEFT_TYPE_WIDTH:
-					switch typeconv.TypeFamilyToCanonicalTypeFamily[rightType.Family()] {
+					switch typeconv.TypeFamilyToCanonicalTypeFamily(rightType.Family()) {
 					// {{range .RightFamilies}}
 					case _RIGHT_CANONICAL_TYPE_FAMILY:
 						switch rightType.Width() {
@@ -301,13 +301,13 @@ func GetProjection_CONST_SIDEConstOperator(
 		switch op {
 		// {{range .CmpOps}}
 		case tree._NAME:
-			switch typeconv.TypeFamilyToCanonicalTypeFamily[leftType.Family()] {
+			switch typeconv.TypeFamilyToCanonicalTypeFamily(leftType.Family()) {
 			// {{range .LeftFamilies}}
 			case _LEFT_CANONICAL_TYPE_FAMILY:
 				switch leftType.Width() {
 				// {{range .LeftWidths}}
 				case _LEFT_TYPE_WIDTH:
-					switch typeconv.TypeFamilyToCanonicalTypeFamily[rightType.Family()] {
+					switch typeconv.TypeFamilyToCanonicalTypeFamily(rightType.Family()) {
 					// {{range .RightFamilies}}
 					case _RIGHT_CANONICAL_TYPE_FAMILY:
 						switch rightType.Width() {

--- a/pkg/sql/colexec/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_non_const_ops_tmpl.go
@@ -279,13 +279,13 @@ func GetProjectionOperator(
 		switch op {
 		// {{range .BinOps}}
 		case tree._NAME:
-			switch typeconv.TypeFamilyToCanonicalTypeFamily[leftType.Family()] {
+			switch typeconv.TypeFamilyToCanonicalTypeFamily(leftType.Family()) {
 			// {{range .LeftFamilies}}
 			case _LEFT_CANONICAL_TYPE_FAMILY:
 				switch leftType.Width() {
 				// {{range .LeftWidths}}
 				case _LEFT_TYPE_WIDTH:
-					switch typeconv.TypeFamilyToCanonicalTypeFamily[rightType.Family()] {
+					switch typeconv.TypeFamilyToCanonicalTypeFamily(rightType.Family()) {
 					// {{range .RightFamilies}}
 					case _RIGHT_CANONICAL_TYPE_FAMILY:
 						switch rightType.Width() {
@@ -306,13 +306,13 @@ func GetProjectionOperator(
 		switch op {
 		// {{range .CmpOps}}
 		case tree._NAME:
-			switch typeconv.TypeFamilyToCanonicalTypeFamily[leftType.Family()] {
+			switch typeconv.TypeFamilyToCanonicalTypeFamily(leftType.Family()) {
 			// {{range .LeftFamilies}}
 			case _LEFT_CANONICAL_TYPE_FAMILY:
 				switch leftType.Width() {
 				// {{range .LeftWidths}}
 				case _LEFT_TYPE_WIDTH:
-					switch typeconv.TypeFamilyToCanonicalTypeFamily[rightType.Family()] {
+					switch typeconv.TypeFamilyToCanonicalTypeFamily(rightType.Family()) {
 					// {{range .RightFamilies}}
 					case _RIGHT_CANONICAL_TYPE_FAMILY:
 						switch rightType.Width() {

--- a/pkg/sql/colexec/rowstovec_tmpl.go
+++ b/pkg/sql/colexec/rowstovec_tmpl.go
@@ -104,7 +104,7 @@ func EncDatumRowsToColVec(
 	allocator.PerformOperation(
 		[]coldata.Vec{vec},
 		func() {
-			switch typeconv.TypeFamilyToCanonicalTypeFamily[t.Family()] {
+			switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
 			// {{range .}}
 			case _CANONICAL_TYPE_FAMILY:
 				switch t.Width() {

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -96,7 +96,7 @@ func GetInProjectionOperator(
 ) (colexecbase.Operator, error) {
 	input = newVectorTypeEnforcer(allocator, input, types.Bool, resultIdx)
 	var err error
-	switch typeconv.TypeFamilyToCanonicalTypeFamily[t.Family()] {
+	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
 	// {{range .}}
 	case _CANONICAL_TYPE_FAMILY:
 		switch t.Width() {
@@ -125,7 +125,7 @@ func GetInOperator(
 	t *types.T, input colexecbase.Operator, colIdx int, datumTuple *tree.DTuple, negate bool,
 ) (colexecbase.Operator, error) {
 	var err error
-	switch typeconv.TypeFamilyToCanonicalTypeFamily[t.Family()] {
+	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
 	// {{range .}}
 	case _CANONICAL_TYPE_FAMILY:
 		switch t.Width() {

--- a/pkg/sql/colexec/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/selection_ops_tmpl.go
@@ -320,13 +320,13 @@ func GetSelectionConstOperator(
 	switch cmpOp {
 	// {{range .CmpOps}}
 	case tree._NAME:
-		switch typeconv.TypeFamilyToCanonicalTypeFamily[leftType.Family()] {
+		switch typeconv.TypeFamilyToCanonicalTypeFamily(leftType.Family()) {
 		// {{range .LeftFamilies}}
 		case _LEFT_CANONICAL_TYPE_FAMILY:
 			switch leftType.Width() {
 			// {{range .LeftWidths}}
 			case _LEFT_TYPE_WIDTH:
-				switch typeconv.TypeFamilyToCanonicalTypeFamily[constType.Family()] {
+				switch typeconv.TypeFamilyToCanonicalTypeFamily(constType.Family()) {
 				// {{range .RightFamilies}}
 				case _RIGHT_CANONICAL_TYPE_FAMILY:
 					switch constType.Width() {
@@ -364,13 +364,13 @@ func GetSelectionOperator(
 	switch cmpOp {
 	// {{range .CmpOps}}
 	case tree._NAME:
-		switch typeconv.TypeFamilyToCanonicalTypeFamily[leftType.Family()] {
+		switch typeconv.TypeFamilyToCanonicalTypeFamily(leftType.Family()) {
 		// {{range .LeftFamilies}}
 		case _LEFT_CANONICAL_TYPE_FAMILY:
 			switch leftType.Width() {
 			// {{range .LeftWidths}}
 			case _LEFT_TYPE_WIDTH:
-				switch typeconv.TypeFamilyToCanonicalTypeFamily[rightType.Family()] {
+				switch typeconv.TypeFamilyToCanonicalTypeFamily(rightType.Family()) {
 				// {{range .RightFamilies}}
 				case _RIGHT_CANONICAL_TYPE_FAMILY:
 					switch rightType.Width() {

--- a/pkg/sql/colexec/sort_tmpl.go
+++ b/pkg/sql/colexec/sort_tmpl.go
@@ -92,7 +92,7 @@ func isSorterSupported(t *types.T, dir execinfrapb.Ordering_Column_Direction) bo
 	switch dir {
 	// {{range .DirOverloads}}
 	case _DIR_ENUM:
-		switch typeconv.TypeFamilyToCanonicalTypeFamily[t.Family()] {
+		switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
 		// {{range .FamilyOverloads}}
 		case _CANONICAL_TYPE_FAMILY:
 			switch t.Width() {
@@ -121,7 +121,7 @@ func newSingleSorter(
 		// {{range .DirOverloads}}
 		// {{$dir := .DirString}}
 		case _DIR_ENUM:
-			switch typeconv.TypeFamilyToCanonicalTypeFamily[t.Family()] {
+			switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
 			// {{range .FamilyOverloads}}
 			case _CANONICAL_TYPE_FAMILY:
 				switch t.Width() {

--- a/pkg/sql/colexec/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/sum_agg_tmpl.go
@@ -60,7 +60,7 @@ func _ASSIGN_ADD(_, _, _ string) {
 // */}}
 
 func newSumAgg(allocator *colmem.Allocator, t *types.T) (aggregateFunc, error) {
-	switch typeconv.TypeFamilyToCanonicalTypeFamily[t.Family()] {
+	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
 	// {{range .}}
 	case _CANONICAL_TYPE_FAMILY:
 		switch t.Width() {

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -1436,7 +1436,7 @@ func (tc *joinTestCase) mutateTypes() []*joinTestCase {
 					if tups[i][j] == nil {
 						continue
 					}
-					switch typeconv.TypeFamilyToCanonicalTypeFamily[typ.Family()] {
+					switch typeconv.TypeFamilyToCanonicalTypeFamily(typ.Family()) {
 					case types.DecimalFamily:
 						var d apd.Decimal
 						_, _ = d.SetFloat64(float64(tups[i][j].(int)))

--- a/pkg/sql/colexec/vec_comparators_tmpl.go
+++ b/pkg/sql/colexec/vec_comparators_tmpl.go
@@ -149,7 +149,7 @@ func (c *_TYPEVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 // {{end}}
 
 func GetVecComparator(t *types.T, numVecs int) vecComparator {
-	switch typeconv.TypeFamilyToCanonicalTypeFamily[t.Family()] {
+	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
 	// {{range .}}
 	case _CANONICAL_TYPE_FAMILY:
 		switch t.Width() {

--- a/pkg/sql/colflow/vectorized_flow_space_test.go
+++ b/pkg/sql/colflow/vectorized_flow_space_test.go
@@ -232,13 +232,24 @@ func TestVectorizeAllocatorSpaceError(t *testing.T) {
 				// accounts, so if the spilling is supported, we do *not* want to use
 				// streaming memory account.
 				args.TestingKnobs.UseStreamingMemAccountForBuffering = !tc.spillingSupported
-				result, err := colexec.NewColOperator(ctx, flowCtx, args)
-				require.NoError(t, err)
-				err = colexecerror.CatchVectorizedRuntimeError(func() {
-					result.Op.Init()
-					result.Op.Next(ctx)
-					result.Op.Next(ctx)
-				})
+				var (
+					result colexec.NewColOperatorResult
+					err    error
+				)
+				// The memory error can occur either during planning or during
+				// execution, and we want to actually execute the "query" only
+				// if there was no error during planning. That is why we have
+				// two separate panic-catchers.
+				if err = colexecerror.CatchVectorizedRuntimeError(func() {
+					result, err = colexec.NewColOperator(ctx, flowCtx, args)
+					require.NoError(t, err)
+				}); err == nil {
+					err = colexecerror.CatchVectorizedRuntimeError(func() {
+						result.Op.Init()
+						result.Op.Next(ctx)
+						result.Op.Next(ctx)
+					})
+				}
 				for _, memAccount := range result.OpAccounts {
 					memAccount.Close(ctx)
 				}


### PR DESCRIPTION
**colexec: account for aggregate functions structs**

Previously, we were not accounting for the memory used by aggregate
functions structs. This behavior is acceptable in case of ordered
aggregator (because we will only constant number of such structs), but
it's no bueno for the hash aggregator - we will be creating a separate
struct for each group. This is now fixed by performing the memory
accounting upon creation of these aggregate functions structs.

This commit also adds accounting for `hashAggFuncs` structs in the hash
aggregator.

However, this commit does not address the missing memory accounting of
the Golang's `map` that we use for mapping a hash code to all aggregate
builtins (i.e. "groups") that correspond to that hash code. This is left
as TODO, but we need to address it for 20.2. A note here is that we
might be replacing the usage of this `map` with our vectorized hash
table, so it'll probably make sense to wait for that.

Addresses: #48428.

Release note: None

**colexec: introduce Flush method into aggregateFunc interface**

I was looking at cpu profile with memory intensive hash aggregation, and
it was saying that we spend noticeable amount of time checking whether
aggregation function is `done`. This can be avoided if we refactor the
interface slightly which is what this commit does.

Previously, we used `Compute` method to both compute the aggregation on
non-empty batch and to flush the result of aggregation of the last group
on an empty batch. These two purposes are now split into two functions:
the former is done by the same `Compute` function and the latter is done
by newly-introduced `Flush` function which must be called to "flush" the
result for the last group.

Release note: None

**colexec: generate different structs for two COUNT variants**

In one profile I saw noticeable time spent on an `if` condition that
determines whether we have `count_rows` aggregate or not. This commit
refactors the template to generate two different structs which allows us
to remove that check.

Release note: None

**typeconv: change map usage to family switch**

In a cpu profile I noticed that some time was spent in the accesses to
the map when instantiating aggregate funcs. This can be avoided by
changing the usage of map to a switch on a type family, and the function
should be inlined.

Release note: None