### PR TITLE
sql: add EnsureUpsertDistinctOn operator

### DIFF
--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -291,7 +291,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 	// Special-case handling for GroupBy private; print grouping columns
 	// and internal ordering in addition to full set of columns.
 	case *GroupByExpr, *ScalarGroupByExpr, *DistinctOnExpr, *EnsureDistinctOnExpr,
-		*UpsertDistinctOnExpr:
+		*UpsertDistinctOnExpr, *EnsureUpsertDistinctOnExpr:
 		private := e.Private().(*GroupingPrivate)
 		if !f.HasFlags(ExprFmtHideColumns) && !private.GroupingCols.Empty() {
 			f.formatColList(e, tp, "grouping columns:", opt.ColSetToList(private.GroupingCols))

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -441,6 +441,12 @@ func (b *logicalPropsBuilder) buildUpsertDistinctOnProps(
 	b.buildGroupingExprProps(distinctOn, rel)
 }
 
+func (b *logicalPropsBuilder) buildEnsureUpsertDistinctOnProps(
+	distinctOn *EnsureUpsertDistinctOnExpr, rel *props.Relational,
+) {
+	b.buildGroupingExprProps(distinctOn, rel)
+}
+
 func (b *logicalPropsBuilder) buildGroupingExprProps(groupExpr RelExpr, rel *props.Relational) {
 	BuildSharedProps(groupExpr, &rel.Shared)
 
@@ -509,9 +515,10 @@ func (b *logicalPropsBuilder) buildGroupingExprProps(groupExpr RelExpr, rel *pro
 
 		// The output of most of the grouping operators forms a strict key because
 		// they eliminate all duplicates in the grouping columns. However, the
-		// UpsertDistinctOn operator does not group NULL values together, so it
-		// only forms a lax key when NULL values are possible.
-		if groupExpr.Op() == opt.UpsertDistinctOnOp && !groupingCols.SubsetOf(rel.NotNullCols) {
+		// UpsertDistinctOn and EnsureUpsertDistinctOn operators do not group
+		// NULL values together, so they only form a lax key when NULL values
+		// are possible.
+		if groupPrivate.NullsAreDistinct && !groupingCols.SubsetOf(rel.NotNullCols) {
 			rel.FuncDeps.AddLaxKey(groupingCols, rel.OutputCols)
 		} else {
 			rel.FuncDeps.AddStrictKey(groupingCols, rel.OutputCols)

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -371,7 +371,7 @@ func (sb *statisticsBuilder) colStat(colSet opt.ColSet, e RelExpr) *props.Column
 		return sb.colStatSetNode(colSet, e)
 
 	case opt.GroupByOp, opt.ScalarGroupByOp, opt.DistinctOnOp, opt.EnsureDistinctOnOp,
-		opt.UpsertDistinctOnOp:
+		opt.UpsertDistinctOnOp, opt.EnsureUpsertDistinctOnOp:
 		return sb.colStatGroupBy(colSet, e)
 
 	case opt.LimitOp:
@@ -1547,9 +1547,9 @@ func (sb *statisticsBuilder) colStatGroupBy(
 		}
 	}
 
-	if groupNode.Op() == opt.UpsertDistinctOnOp {
-		// UpsertDistinctOp inherits NullCount from child, since it does not group
-		// NULL values.
+	if groupNode.Op() == opt.UpsertDistinctOnOp || groupNode.Op() == opt.EnsureUpsertDistinctOnOp {
+		// UpsertDistinctOnOp and EnsureUpsertDistinctOnOp inherit NullCount from
+		// child, since they do not group NULL values.
 		colStat.NullCount = inputColStat.NullCount
 	} else {
 		// For other group by operators, we only have 1 possible null value.

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -188,7 +188,7 @@ project
       │    │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
       │    │    ├── prune: (3,4,6)
       │    │    ├── reject-nulls: (6,8)
-      │    │    ├── interesting orderings: (+8) (+1) (-3,+4,+1)
+      │    │    ├── interesting orderings: (+1) (-3,+4,+1) (+8)
       │    │    ├── inner-join (cross)
       │    │    │    ├── columns: v:6(int!null) m:8(int!null)
       │    │    │    ├── prune: (6,8)

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -81,7 +81,7 @@ project
            │    │    │    ├── prune: (10,13)
            │    │    │    ├── reject-nulls: (10-13)
            │    │    │    ├── interesting orderings: (+13) (+10) (+11,+12,+13)
-           │    │    │    ├── upsert-distinct-on
+           │    │    │    ├── ensure-upsert-distinct-on
            │    │    │    │    ├── columns: x:5(int!null) y:6(int!null) column8:8(int) column9:9(int!null)
            │    │    │    │    ├── grouping columns: y:6(int!null) column9:9(int!null)
            │    │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
@@ -469,7 +469,7 @@ project
  │         │    │    ├── prune: (9-11)
  │         │    │    ├── reject-nulls: (9-12)
  │         │    │    ├── interesting orderings: (+12) (+9) (+10,+11,+12)
- │         │    │    ├── upsert-distinct-on
+ │         │    │    ├── ensure-upsert-distinct-on
  │         │    │    │    ├── columns: column1:5(int!null) column6:6(int!null) column7:7(int) column8:8(int!null)
  │         │    │    │    ├── grouping columns: column7:7(int)
  │         │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
@@ -560,8 +560,8 @@ project
            ├── variable: b:2 [type=int]
            └── variable: c:3 [type=int]
 
-# upsert-distinct-on should create strict key in case where all grouping columns
-# are not NULL.
+# ensure-upsert-distinct-on should create strict key in case where all grouping
+# columns are not NULL.
 build
 INSERT INTO abc (a)
 SELECT y FROM xyz WHERE y IS NOT NULL
@@ -614,7 +614,7 @@ upsert abc
       │    │    │    ├── prune: (12-14)
       │    │    │    ├── reject-nulls: (11-14)
       │    │    │    ├── interesting orderings: (+14) (+11) (+12,+13,+14)
-      │    │    │    ├── upsert-distinct-on
+      │    │    │    ├── ensure-upsert-distinct-on
       │    │    │    │    ├── columns: y:6(int!null) column8:8(int!null) column9:9(int) column10:10(int!null)
       │    │    │    │    ├── grouping columns: y:6(int!null)
       │    │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"

--- a/pkg/sql/opt/memo/testdata/stats/upsert
+++ b/pkg/sql/opt/memo/testdata/stats/upsert
@@ -124,7 +124,7 @@ with &1
  │         │    │    ├── stats: [rows=9.94974874, distinct(9)=9.94974874, null(9)=0]
  │         │    │    ├── lax-key: (5,9)
  │         │    │    ├── fd: ()-->(8), (5)~~>(4), (9)-->(10,11)
- │         │    │    ├── upsert-distinct-on
+ │         │    │    ├── ensure-upsert-distinct-on
  │         │    │    │    ├── columns: a:4(int!null) b:5(string) column8:8(float)
  │         │    │    │    ├── grouping columns: b:5(string)
  │         │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
@@ -229,8 +229,8 @@ upsert xyz
       └── projections
            └── NULL::FLOAT8 [as=column8:8, type=float]
 
-# Nullable conflict column. Ensure that upsert-distinct-on passes through the
-# input's null count.
+# Nullable conflict column. Ensure that ensure-upsert-distinct-on passes through
+# the input's null count.
 build
 INSERT INTO uv (v)
 SELECT z::int FROM xyz
@@ -266,7 +266,7 @@ upsert uv
       │    │    ├── stats: [rows=1000, distinct(9)=991, null(9)=0]
       │    │    ├── lax-key: (6,8)
       │    │    ├── fd: (6)~~>(7), (8)-->(9), (9)~~>(8)
-      │    │    ├── upsert-distinct-on
+      │    │    ├── ensure-upsert-distinct-on
       │    │    │    ├── columns: z:6(int) column7:7(int)
       │    │    │    ├── grouping columns: z:6(int)
       │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
@@ -345,7 +345,7 @@ upsert mno
       │    │    ├── stats: [rows=2000, distinct(8)=21.0526316, null(8)=1988.94737, distinct(9)=21.0526316, null(9)=2000]
       │    │    ├── key: (4,7)
       │    │    ├── fd: (4)-->(5,6), (5,6)~~>(4), (7)-->(8,9), (8,9)~~>(7)
-      │    │    ├── upsert-distinct-on
+      │    │    ├── ensure-upsert-distinct-on
       │    │    │    ├── columns: m:4(int!null) n:5(int) o:6(int)
       │    │    │    ├── grouping columns: n:5(int) o:6(int)
       │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -2523,7 +2523,8 @@ func (c *CustomFuncs) MakeArrayAggCol(typ *types.T) opt.ColumnID {
 }
 
 // MakeGrouping constructs a new GroupingPrivate using the given grouping
-// columns and OrderingChoice. ErrorOnDup will be empty.
+// columns and OrderingChoice. ErrorOnDup will be empty and NullsAreDistinct
+// will be false.
 func (c *CustomFuncs) MakeGrouping(
 	groupingCols opt.ColSet, ordering physical.OrderingChoice,
 ) *memo.GroupingPrivate {
@@ -2531,7 +2532,8 @@ func (c *CustomFuncs) MakeGrouping(
 }
 
 // MakeErrorOnDupGrouping constructs a new GroupingPrivate using the given
-// grouping columns, OrderingChoice, and ErrorOnDup text.
+// grouping columns, OrderingChoice, and ErrorOnDup text. NullsAreDistinct will
+// be false.
 func (c *CustomFuncs) MakeErrorOnDupGrouping(
 	groupingCols opt.ColSet, ordering physical.OrderingChoice, errorText string,
 ) *memo.GroupingPrivate {
@@ -2540,16 +2542,17 @@ func (c *CustomFuncs) MakeErrorOnDupGrouping(
 	}
 }
 
+// NullsAreDistinct returns true if a distinct operator with the given
+// GroupingPrivate treats NULL values as not equal to one another
+// (i.e. distinct). UpsertDistinctOp and EnsureUpsertDistinctOp treat NULL
+// values as distinct, whereas DistinctOp does not.
+func (c *CustomFuncs) NullsAreDistinct(private *memo.GroupingPrivate) bool {
+	return private.NullsAreDistinct
+}
+
 // ErrorOnDup returns the error text contained by the given GroupingPrivate.
 func (c *CustomFuncs) ErrorOnDup(private *memo.GroupingPrivate) string {
 	return private.ErrorOnDup
-}
-
-// RaisesErrorOnDup returns true if an EnsureDistinctOn or UpsertDistinctOn
-// operator with the given GroupingPrivate raises an error upon detection
-// of duplicate values.
-func (c *CustomFuncs) RaisesErrorOnDup(private *memo.GroupingPrivate) bool {
-	return private.ErrorOnDup != ""
 }
 
 // ExtractGroupingOrdering returns the ordering associated with the input

--- a/pkg/sql/opt/norm/rules/groupby.opt
+++ b/pkg/sql/opt/norm/rules/groupby.opt
@@ -32,7 +32,7 @@
 # something the GroupBy operators can do on their own.
 [EliminateGroupByProject, Normalize]
 (GroupBy | ScalarGroupBy | DistinctOn | EnsureDistinctOn
-        | UpsertDistinctOn
+        | UpsertDistinctOn | EnsureUpsertDistinctOn
     $input:(Project $innerInput:*) &
         (ColsAreSubset
             (OutputCols $input)
@@ -85,7 +85,7 @@
 #   SELECT c FROM t WHERE c IS NULL
 #
 [ReduceNotNullGroupingCols, Normalize]
-(UpsertDistinctOn
+(UpsertDistinctOn | EnsureUpsertDistinctOn
     $input:*
     $aggregations:*
     $groupingPrivate:* &
@@ -166,15 +166,14 @@
 # is equivalent to:
 #   SELECT a, b FROM ab WHERE a=1 LIMIT 1
 #
-# Note that this rule does not apply to UpsertDistinctOn with ErrorOnDup = true,
-# since that will raise an error if there are duplicate rows.
+# Note that this rule does not apply to EnsureDistinctOn or
+# EnsureUpsertDistinctOn, since they will raise an error if there are duplicate
+# rows.
 [EliminateDistinctNoColumns, Normalize]
 (DistinctOn | UpsertDistinctOn
     $input:*
     $aggregations:*
-    $groupingPrivate:* &
-        (HasNoGroupingCols $groupingPrivate) &
-        ^(RaisesErrorOnDup $groupingPrivate)
+    $groupingPrivate:* & (HasNoGroupingCols $groupingPrivate)
 )
 =>
 (ConstructProjectionFromDistinctOn
@@ -191,14 +190,13 @@
 # except that Max1Row will raise an error if there are no grouping columns and
 # the input has more than one row. No grouping columns means there is at most
 # one group. And the Max1Row operator is needed to raise an error if that group
-# has more than one row, which is a requirement of the Upsert operator.
+# has more than one row, which is a requirement of the EnsureDistinct and
+# EnsureUpsertDistinct operators.
 [EliminateEnsureDistinctNoColumns, Normalize]
-(EnsureDistinctOn | UpsertDistinctOn
+(EnsureDistinctOn | EnsureUpsertDistinctOn
     $input:*
     $aggregations:*
-    $groupingPrivate:* &
-        (HasNoGroupingCols $groupingPrivate) &
-        (RaisesErrorOnDup $groupingPrivate)
+    $groupingPrivate:* & (HasNoGroupingCols $groupingPrivate)
 )
 =>
 (ConstructProjectionFromDistinctOn
@@ -219,14 +217,14 @@
 # find. If a test case for EnsureDistinctOn is found, it should be added to the
 # match pattern.
 [EliminateDistinctOnValues, Normalize]
-(DistinctOn | UpsertDistinctOn
+(DistinctOn | UpsertDistinctOn | EnsureUpsertDistinctOn
     $input:*
     $aggregations:*
     $groupingPrivate:* &
         (AreValuesDistinct
             $input
             (GroupingCols $groupingPrivate)
-            (NullsAreDistinct (OpName))
+            (NullsAreDistinct $groupingPrivate)
         )
 )
 =>

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -346,6 +346,64 @@ project
 norm expect=EliminateGroupByProject
 INSERT INTO nullablecols (rowid, c1, c2, c3)
 SELECT i, i, i, i FROM (SELECT * FROM a WHERE EXISTS(SELECT * FROM a) AND k>0)
+ON CONFLICT (c1) DO NOTHING
+----
+insert nullablecols
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── i:6 => c1:1
+ │    ├── i:6 => c2:2
+ │    ├── i:6 => c3:3
+ │    └── i:6 => rowid:4
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── upsert-distinct-on
+      ├── columns: i:6!null
+      ├── grouping columns: i:6!null
+      ├── key: (6)
+      └── select
+           ├── columns: k:5!null i:6!null c1:15 rowid:18
+           ├── key: (5)
+           ├── fd: ()-->(15,18), (5)-->(6)
+           ├── left-join (hash)
+           │    ├── columns: k:5!null i:6!null c1:15 rowid:18
+           │    ├── key: (5,18)
+           │    ├── fd: (5)-->(6), (18)-->(15), (15)~~>(18)
+           │    ├── select
+           │    │    ├── columns: k:5!null i:6!null
+           │    │    ├── key: (5)
+           │    │    ├── fd: (5)-->(6)
+           │    │    ├── scan a
+           │    │    │    ├── columns: k:5!null i:6!null
+           │    │    │    ├── key: (5)
+           │    │    │    └── fd: (5)-->(6)
+           │    │    └── filters
+           │    │         ├── exists [subquery]
+           │    │         │    └── limit
+           │    │         │         ├── columns: k:10!null i:11!null f:12 s:13!null j:14
+           │    │         │         ├── cardinality: [0 - 1]
+           │    │         │         ├── key: ()
+           │    │         │         ├── fd: ()-->(10-14)
+           │    │         │         ├── scan a
+           │    │         │         │    ├── columns: k:10!null i:11!null f:12 s:13!null j:14
+           │    │         │         │    ├── key: (10)
+           │    │         │         │    ├── fd: (10)-->(11-14), (11,13)-->(10,12,14), (11,12)~~>(10,13,14)
+           │    │         │         │    └── limit hint: 1.00
+           │    │         │         └── 1
+           │    │         └── k:5 > 0 [outer=(5), constraints=(/5: [/1 - ]; tight)]
+           │    ├── scan nullablecols
+           │    │    ├── columns: c1:15 rowid:18!null
+           │    │    ├── key: (18)
+           │    │    └── fd: (18)-->(15), (15)~~>(18)
+           │    └── filters
+           │         └── i:6 = c1:15 [outer=(6,15), constraints=(/6: (/NULL - ]; /15: (/NULL - ]), fd=(6)==(15), (15)==(6)]
+           └── filters
+                └── rowid:18 IS NULL [outer=(18), constraints=(/18: [/NULL - /NULL]; tight), fd=()-->(18)]
+
+# EnsureUpsertDistinctOn case.
+norm expect=EliminateGroupByProject
+INSERT INTO nullablecols (rowid, c1, c2, c3)
+SELECT i, i, i, i FROM (SELECT * FROM a WHERE EXISTS(SELECT * FROM a) AND k>0)
 ON CONFLICT (c1) DO UPDATE SET c3=1
 ----
 upsert nullablecols
@@ -369,7 +427,7 @@ upsert nullablecols
       │    ├── columns: i:6!null c1:15 c2:16 c3:17 rowid:18
       │    ├── key: (6,18)
       │    ├── fd: (18)-->(15-17), (15)~~>(16-18), (16,17)~~>(15,18)
-      │    ├── upsert-distinct-on
+      │    ├── ensure-upsert-distinct-on
       │    │    ├── columns: i:6!null
       │    │    ├── grouping columns: i:6!null
       │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
@@ -559,6 +617,58 @@ distinct-on
 norm expect=ReduceNotNullGroupingCols
 INSERT INTO xy (x)
 SELECT y FROM xy WHERE y=0
+ON CONFLICT (x) DO NOTHING
+----
+insert xy
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── y:4 => x:1
+ │    └── column5:5 => y:2
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── project
+      ├── columns: y:4!null column5:5
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(4,5)
+      └── limit
+           ├── columns: y:4!null column5:5 x:6
+           ├── cardinality: [0 - 1]
+           ├── key: ()
+           ├── fd: ()-->(4-6)
+           ├── select
+           │    ├── columns: y:4!null column5:5 x:6
+           │    ├── fd: ()-->(4-6)
+           │    ├── limit hint: 1.00
+           │    ├── left-join (hash)
+           │    │    ├── columns: y:4!null column5:5 x:6
+           │    │    ├── fd: ()-->(4,5)
+           │    │    ├── limit hint: 1.00
+           │    │    ├── project
+           │    │    │    ├── columns: column5:5 y:4!null
+           │    │    │    ├── fd: ()-->(4,5)
+           │    │    │    ├── select
+           │    │    │    │    ├── columns: y:4!null
+           │    │    │    │    ├── fd: ()-->(4)
+           │    │    │    │    ├── scan xy
+           │    │    │    │    │    └── columns: y:4
+           │    │    │    │    └── filters
+           │    │    │    │         └── y:4 = 0 [outer=(4), constraints=(/4: [/0 - /0]; tight), fd=()-->(4)]
+           │    │    │    └── projections
+           │    │    │         └── CAST(NULL AS INT8) [as=column5:5]
+           │    │    ├── scan xy
+           │    │    │    ├── columns: x:6!null
+           │    │    │    └── key: (6)
+           │    │    └── filters
+           │    │         └── y:4 = x:6 [outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ]), fd=(4)==(6), (6)==(4)]
+           │    └── filters
+           │         └── x:6 IS NULL [outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
+           └── 1
+
+# EnsureUpsertDistinctOn should reduce non-nullable constant grouping column.
+norm expect=ReduceNotNullGroupingCols
+INSERT INTO xy (x)
+SELECT y FROM xy WHERE y=0
 ON CONFLICT (x) DO UPDATE SET y=1
 ----
 upsert xy
@@ -611,6 +721,53 @@ upsert xy
 norm expect-not=ReduceNotNullGroupingCols
 INSERT INTO xy (x)
 SELECT y FROM xy WHERE y IS NULL
+ON CONFLICT (x) DO NOTHING
+----
+insert xy
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── y:4 => x:1
+ │    └── column5:5 => y:2
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── upsert-distinct-on
+      ├── columns: y:4 column5:5
+      ├── grouping columns: y:4
+      ├── lax-key: (4)
+      ├── fd: ()-->(4,5)
+      ├── select
+      │    ├── columns: y:4 column5:5 x:6
+      │    ├── fd: ()-->(4-6)
+      │    ├── left-join (hash)
+      │    │    ├── columns: y:4 column5:5 x:6
+      │    │    ├── fd: ()-->(4,5)
+      │    │    ├── project
+      │    │    │    ├── columns: column5:5 y:4
+      │    │    │    ├── fd: ()-->(4,5)
+      │    │    │    ├── select
+      │    │    │    │    ├── columns: y:4
+      │    │    │    │    ├── fd: ()-->(4)
+      │    │    │    │    ├── scan xy
+      │    │    │    │    │    └── columns: y:4
+      │    │    │    │    └── filters
+      │    │    │    │         └── y:4 IS NULL [outer=(4), constraints=(/4: [/NULL - /NULL]; tight), fd=()-->(4)]
+      │    │    │    └── projections
+      │    │    │         └── CAST(NULL AS INT8) [as=column5:5]
+      │    │    ├── scan xy
+      │    │    │    ├── columns: x:6!null
+      │    │    │    └── key: (6)
+      │    │    └── filters
+      │    │         └── y:4 = x:6 [outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ]), fd=(4)==(6), (6)==(4)]
+      │    └── filters
+      │         └── x:6 IS NULL [outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
+      └── aggregations
+           └── first-agg [as=column5:5, outer=(5)]
+                └── column5:5
+
+# EnsureUpsertDistinctOn should not reduce nullable constant grouping column.
+norm expect-not=ReduceNotNullGroupingCols
+INSERT INTO xy (x)
+SELECT y FROM xy WHERE y IS NULL
 ON CONFLICT (x) DO UPDATE SET y=1
 ----
 upsert xy
@@ -632,7 +789,7 @@ upsert xy
       │    ├── columns: y:4 column5:5 x:6 y:7
       │    ├── lax-key: (4,6)
       │    ├── fd: ()-->(4,5), (6)-->(7)
-      │    ├── upsert-distinct-on
+      │    ├── ensure-upsert-distinct-on
       │    │    ├── columns: y:4 column5:5
       │    │    ├── grouping columns: y:4
       │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
@@ -684,7 +841,7 @@ upsert abc
       ├── columns: b:5!null "?column?":7!null "?column?":8!null a:9 b:10 c:11
       ├── key: (5,9-11)
       ├── fd: ()-->(7,8)
-      ├── upsert-distinct-on
+      ├── ensure-upsert-distinct-on
       │    ├── columns: b:5!null "?column?":7!null "?column?":8!null
       │    ├── grouping columns: b:5!null
       │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
@@ -737,7 +894,7 @@ upsert abc
       │    ├── columns: b:5!null c:6!null "?column?":7 a:8 b:9 c:10
       │    ├── lax-key: (6-10)
       │    ├── fd: ()-->(5,7)
-      │    ├── upsert-distinct-on
+      │    ├── ensure-upsert-distinct-on
       │    │    ├── columns: b:5!null c:6!null "?column?":7
       │    │    ├── grouping columns: c:6!null "?column?":7
       │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
@@ -1284,7 +1441,7 @@ project
  └── projections
       └── xy.x:6 [as=x:8, outer=(6)]
 
-# UpsertDistinctOn case.
+# EnsureUpsertDistinctOn case.
 norm expect=EliminateEnsureDistinctNoColumns
 INSERT INTO a (k, i, s) SELECT 1, i, 'foo' FROM a WHERE i = 1
 ON CONFLICT (s, i) DO UPDATE SET f=1.1
@@ -1620,6 +1777,52 @@ distinct-on
 # UpsertDistinctOn treats NULL values as distinct, so it can be eliminated.
 norm expect=EliminateDistinctOnValues
 INSERT INTO a (k, s, i) VALUES (1, NULL, NULL), (1, NULL, NULL)
+ON CONFLICT (s, i) DO NOTHING
+----
+insert a
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:6 => k:1
+ │    ├── column3:8 => i:2
+ │    ├── column9:9 => f:3
+ │    ├── column2:7 => s:4
+ │    └── column10:10 => j:5
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── project
+      ├── columns: column1:6!null column2:7 column3:8 column9:9 column10:10
+      ├── fd: ()-->(9,10)
+      └── select
+           ├── columns: column1:6!null column2:7 column3:8 column9:9 column10:10 i:12 s:14
+           ├── fd: ()-->(9,10,14)
+           ├── left-join (hash)
+           │    ├── columns: column1:6!null column2:7 column3:8 column9:9 column10:10 i:12 s:14
+           │    ├── cardinality: [2 - ]
+           │    ├── fd: ()-->(9,10)
+           │    ├── project
+           │    │    ├── columns: column9:9 column10:10 column1:6!null column2:7 column3:8
+           │    │    ├── cardinality: [2 - 2]
+           │    │    ├── fd: ()-->(9,10)
+           │    │    ├── values
+           │    │    │    ├── columns: column1:6!null column2:7 column3:8
+           │    │    │    ├── cardinality: [2 - 2]
+           │    │    │    ├── (1, NULL, NULL)
+           │    │    │    └── (1, NULL, NULL)
+           │    │    └── projections
+           │    │         ├── CAST(NULL AS FLOAT8) [as=column9:9]
+           │    │         └── CAST(NULL AS JSONB) [as=column10:10]
+           │    ├── scan a
+           │    │    ├── columns: i:12!null s:14!null
+           │    │    └── key: (12,14)
+           │    └── filters
+           │         ├── column2:7 = s:14 [outer=(7,14), constraints=(/7: (/NULL - ]; /14: (/NULL - ]), fd=(7)==(14), (14)==(7)]
+           │         └── column3:8 = i:12 [outer=(8,12), constraints=(/8: (/NULL - ]; /12: (/NULL - ]), fd=(8)==(12), (12)==(8)]
+           └── filters
+                └── s:14 IS NULL [outer=(14), constraints=(/14: [/NULL - /NULL]; tight), fd=()-->(14)]
+
+# EnsureUpsertDistinctOn treats NULL values as distinct, so it can be eliminated.
+norm expect=EliminateDistinctOnValues
+INSERT INTO a (k, s, i) VALUES (1, NULL, NULL), (1, NULL, NULL)
 ON CONFLICT (s, i) DO UPDATE SET f=1.0
 ----
 upsert a
@@ -1666,7 +1869,7 @@ upsert a
       └── projections
            └── CASE WHEN k:11 IS NULL THEN column9:9 ELSE 1.0 END [as=upsert_f:19, outer=(9,11)]
 
-# UpsertDistinctOn is not removed when there are duplicates.
+# EnsureUpsertDistinctOn is not removed when there are duplicates.
 norm expect-not=EliminateDistinctOnValues
 INSERT INTO a (k, s, i) VALUES (1, 'foo', 1), (2, 'bar', 2), (3, 'foo', 1)
 ON CONFLICT (s, i) DO UPDATE SET f=1.0
@@ -1695,7 +1898,7 @@ upsert a
       │    ├── cardinality: [1 - ]
       │    ├── key: (7,8,11)
       │    ├── fd: ()-->(9,10), (7,8)-->(6), (11)-->(12-15), (12,14)-->(11,13,15), (12,13)~~>(11,14,15)
-      │    ├── upsert-distinct-on
+      │    ├── ensure-upsert-distinct-on
       │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10
       │    │    ├── grouping columns: column2:7!null column3:8!null
       │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -2677,7 +2677,7 @@ project
            │    ├── side-effects
            │    ├── key: (21)
            │    ├── fd: ()-->(9-13), (21)-->(14-17), (14)~~>(15-17,21)
-           │    ├── upsert-distinct-on
+           │    ├── ensure-upsert-distinct-on
            │    │    ├── columns: column1:9!null column2:10!null column3:11!null column12:12 column13:13
            │    │    ├── grouping columns: column13:13
            │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -523,8 +523,9 @@ define GroupBy {
 }
 
 # GroupingPrivate is shared between the grouping-related operators: GroupBy
-# ScalarGroupBy, DistinctOn, EnsureDistinctOn, and UpsertDistinctOn. This allows
-# the operators to be treated polymorphically.
+# ScalarGroupBy, DistinctOn, EnsureDistinctOn, UpsertDistinctOn, and
+# EnsureUpsertDistinctOn. This allows the operators to be treated
+# polymorphically.
 [Private]
 define GroupingPrivate {
     # GroupingCols partitions the GroupBy input rows into aggregation groups.
@@ -545,9 +546,15 @@ define GroupingPrivate {
     # orderings that contain grouping columns.
     Ordering OrderingChoice
 
+    # NullsAreDistinct specifies the null behavior of the grouping operator. If
+    # true, the operator considers nulls to be distinct for grouping purposes.
+    # NullsAreDistinct should only be true for UpsertDistinctOn and
+    # EnsureUpsertDistinctOn.
+    NullsAreDistinct bool
+
     # ErrorOnDup, if non-empty, triggers an error with the given text if any
-    # aggregation group contains more than one row. This can only be true for
-    # the EnsureDistinctOn and UpsertDistinctOn operators.
+    # aggregation group contains more than one row. This can only take on a
+    # value for the EnsureDistinctOn and EnsureUpsertDistinctOn operators.
     ErrorOnDup string
 }
 
@@ -616,6 +623,9 @@ define DistinctOn {
 # distinct grouping contains more than one row. Or in other words, it "ensures"
 # that the input is distinct on the grouping columns.
 #
+# EnsureDistinctOn is used when nulls are not considered distinct for grouping
+# purposes and an error should be raised when duplicates are detected.
+#
 # Rules should only "push through" or eliminate an EnsureDistinctOn if they
 # preserve the expected error behavior. For example, it would be invalid to
 # push a Select filter into an EnsureDistinctOn, as it might eliminate rows
@@ -628,22 +638,38 @@ define EnsureDistinctOn {
 }
 
 # UpsertDistinctOn is a variation on DistinctOn that is only used with UPSERT
-# and INSERT..ON CONFLICT statements. It differs from DistinctOn in two ways:
+# and INSERT..ON CONFLICT statements. Unlike DistinctOn, UpsertDistinctOn treats
+# NULL values as not equal to one another for purposes of grouping. Two rows
+# having a NULL-valued grouping column will be placed in different groups. This
+# differs from DistinctOn behavior, where the two rows would be grouped
+# together. This behavior difference reflects SQL semantics, in which a unique
+# index key still allows multiple NULL values.
 #
-#   1. Null behavior: UpsertDistinctOn treats NULL values as not equal to one
-#      another for purposes of grouping. Two rows having a NULL-valued grouping
-#      column will be placed in different groups. This differs from DistinctOn
-#      behavior, where the two rows would be grouped together. This behavior
-#      difference reflects SQL semantics, in which a unique index key still
-#      allows multiple NULL values.
-#
-#   2. Duplicate behavior: UpsertDistinctOn raises an error if any distinct
-#      grouping contains more than one row. It has "input must be distinct"
-#      semantics rather than "make the input distinct" semantics. This is used
-#      to ensure that no row will be updated more than once.
-#
+# UpsertDistinctOn is used when nulls are considered distinct for grouping
+# purposes and duplicates should be filtered out without raising an error.
 [Relational, Grouping, Telemetry]
 define UpsertDistinctOn {
+    Input RelExpr
+    Aggregations AggregationsExpr
+    _ GroupingPrivate
+}
+
+# EnsureUpsertDistinctOn is a variation on UpsertDistinctOn that is only used
+# with UPSERT and INSERT..ON CONFLICT statements. Like UpsertDistinctOn,
+# EnsureUpsertDistinctOn treats NULL values as not equal to one another for
+# purposes of grouping. Unlike UpsertDistinctOn, it raises an error if any
+# distinct grouping contains more than one row. Or in other words, it "ensures"
+# that the input is distinct on the grouping columns.
+#
+# EnsureUpsertDistinctOn is used when nulls are considered distinct for grouping
+# purposes and an error should be raised when duplicates are detected.
+#
+# Rules should only "push through" or eliminate an EnsureUpsertDistinctOn if
+# they preserve the expected error behavior. For example, it would be invalid to
+# push a Select filter into an EnsureUpsertDistinctOn, as it might eliminate
+# rows that would otherwise trigger the EnsureUpsertDistinctOn error.
+[Relational, Grouping, Telemetry]
+define EnsureUpsertDistinctOn {
     Input RelExpr
     Aggregations AggregationsExpr
     _ GroupingPrivate

--- a/pkg/sql/opt/optbuilder/distinct.go
+++ b/pkg/sql/opt/optbuilder/distinct.go
@@ -54,7 +54,8 @@ func (b *Builder) constructDistinct(inScope *scope) memo.RelExpr {
 // operator rather than the DistinctOn operator (see the UpsertDistinctOn
 // operator comment for details on the differences). The errorOnDup parameter
 // controls whether multiple rows in the same distinct group trigger an error.
-// This can only be set to true in the UpsertDistinctOn case.
+// This can only take on a value in the EnsureDistinctOn and
+// EnsureUpsertDistinctOn cases.
 func (b *Builder) buildDistinctOn(
 	distinctOnCols opt.ColSet, inScope *scope, nullsAreDistinct bool, errorOnDup string,
 ) (outScope *scope) {
@@ -95,7 +96,8 @@ func (b *Builder) buildDistinctOn(
 		}
 	}
 
-	private := memo.GroupingPrivate{GroupingCols: distinctOnCols.Copy(), ErrorOnDup: errorOnDup}
+	private := memo.GroupingPrivate{GroupingCols: distinctOnCols.Copy(),
+		NullsAreDistinct: nullsAreDistinct, ErrorOnDup: errorOnDup}
 
 	// The ordering is used for intra-group ordering. Ordering with respect to the
 	// DISTINCT ON columns doesn't affect intra-group ordering, so we add these
@@ -155,11 +157,17 @@ func (b *Builder) buildDistinctOn(
 
 	input := inScope.expr.(memo.RelExpr)
 	if nullsAreDistinct {
-		outScope.expr = b.factory.ConstructUpsertDistinctOn(input, aggs, &private)
-	} else if errorOnDup == "" {
-		outScope.expr = b.factory.ConstructDistinctOn(input, aggs, &private)
+		if errorOnDup == "" {
+			outScope.expr = b.factory.ConstructUpsertDistinctOn(input, aggs, &private)
+		} else {
+			outScope.expr = b.factory.ConstructEnsureUpsertDistinctOn(input, aggs, &private)
+		}
 	} else {
-		outScope.expr = b.factory.ConstructEnsureDistinctOn(input, aggs, &private)
+		if errorOnDup == "" {
+			outScope.expr = b.factory.ConstructDistinctOn(input, aggs, &private)
+		} else {
+			outScope.expr = b.factory.ConstructEnsureDistinctOn(input, aggs, &private)
+		}
 	}
 	return outScope
 }

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -774,10 +774,10 @@ func (mb *mutationBuilder) buildInputForUpsert(
 	// Upsert could affect the same row more than once, which can lead to index
 	// corruption. See issue #44466 for more context.
 	//
-	// Ignore any ordering requested by the input. Since the UpsertDistinctOn
-	// operator does not allow multiple rows in distinct groupings, the internal
-	// ordering is meaningless (and can trigger a misleading error in
-	// buildDistinctOn if present).
+	// Ignore any ordering requested by the input. Since the
+	// EnsureUpsertDistinctOn operator does not allow multiple rows in distinct
+	// groupings, the internal ordering is meaningless (and can trigger a
+	// misleading error in buildDistinctOn if present).
 	var conflictCols opt.ColSet
 	for ord, ok := conflictOrds.Next(0); ok; ord, ok = conflictOrds.Next(ord + 1) {
 		conflictCols.Add(mb.outScope.cols[mb.insertOrds[ord]].id)

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
@@ -49,7 +49,7 @@ upsert c1
  │    ├── columns: upsert_c:10 column1:4!null column2:5!null column6:6 c:7 c1.p:8 i:9
  │    ├── left-join (hash)
  │    │    ├── columns: column1:4!null column2:5!null column6:6 c:7 c1.p:8 i:9
- │    │    ├── upsert-distinct-on
+ │    │    ├── ensure-upsert-distinct-on
  │    │    │    ├── columns: column1:4!null column2:5!null column6:6
  │    │    │    ├── grouping columns: column1:4!null
  │    │    │    ├── project
@@ -100,7 +100,7 @@ upsert c1
  │    ├── columns: upsert_c:10 upsert_p:11 upsert_i:12 column1:4!null column5:5!null column6:6 c:7 c1.p:8 i:9
  │    ├── left-join (hash)
  │    │    ├── columns: column1:4!null column5:5!null column6:6 c:7 c1.p:8 i:9
- │    │    ├── upsert-distinct-on
+ │    │    ├── ensure-upsert-distinct-on
  │    │    │    ├── columns: column1:4!null column5:5!null column6:6
  │    │    │    ├── grouping columns: column1:4!null
  │    │    │    ├── project
@@ -158,7 +158,7 @@ upsert c1
  │    ├── columns: upsert_c:13 x:4 xyzw.y:5 column9:9 c:10 c1.p:11 i:12
  │    ├── left-join (hash)
  │    │    ├── columns: x:4 xyzw.y:5 column9:9 c:10 c1.p:11 i:12
- │    │    ├── upsert-distinct-on
+ │    │    ├── ensure-upsert-distinct-on
  │    │    │    ├── columns: x:4 xyzw.y:5 column9:9
  │    │    │    ├── grouping columns: x:4
  │    │    │    ├── project
@@ -213,7 +213,7 @@ upsert c1
  │    │    ├── columns: column10:10!null column1:4!null column2:5!null column6:6 c:7 c1.p:8 i:9
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:4!null column2:5!null column6:6 c:7 c1.p:8 i:9
- │    │    │    ├── upsert-distinct-on
+ │    │    │    ├── ensure-upsert-distinct-on
  │    │    │    │    ├── columns: column1:4!null column2:5!null column6:6
  │    │    │    │    ├── grouping columns: column1:4!null
  │    │    │    │    ├── project
@@ -272,7 +272,7 @@ upsert c1
  │    │    ├── columns: column11:11 u:4!null v:5!null column7:7 c:8 c1.p:9 i:10
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: u:4!null v:5!null column7:7 c:8 c1.p:9 i:10
- │    │    │    ├── upsert-distinct-on
+ │    │    │    ├── ensure-upsert-distinct-on
  │    │    │    │    ├── columns: u:4!null v:5!null column7:7
  │    │    │    │    ├── grouping columns: u:4!null
  │    │    │    │    ├── project
@@ -333,7 +333,7 @@ upsert c2
  │    │    ├── columns: column4:4!null column1:2!null c:3
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:2!null c:3
- │    │    │    ├── upsert-distinct-on
+ │    │    │    ├── ensure-upsert-distinct-on
  │    │    │    │    ├── columns: column1:2!null
  │    │    │    │    ├── grouping columns: column1:2!null
  │    │    │    │    └── values
@@ -384,7 +384,7 @@ upsert c3
  │    ├── columns: upsert_c:7 column1:3!null column2:4 c:5 c3.p:6
  │    ├── left-join (hash)
  │    │    ├── columns: column1:3!null column2:4 c:5 c3.p:6
- │    │    ├── upsert-distinct-on
+ │    │    ├── ensure-upsert-distinct-on
  │    │    │    ├── columns: column1:3!null column2:4
  │    │    │    ├── grouping columns: column1:3!null
  │    │    │    ├── values
@@ -432,7 +432,7 @@ upsert c3
  │    ├── columns: upsert_c:7 upsert_p:8 column1:3!null column4:4 c:5 c3.p:6
  │    ├── left-join (hash)
  │    │    ├── columns: column1:3!null column4:4 c:5 c3.p:6
- │    │    ├── upsert-distinct-on
+ │    │    ├── ensure-upsert-distinct-on
  │    │    │    ├── columns: column1:3!null column4:4
  │    │    │    ├── grouping columns: column1:3!null
  │    │    │    ├── project
@@ -494,7 +494,7 @@ upsert c4
  │    │    ├── columns: column12:12!null x:4 y:5 z:6 c:9 a:10 c4.other:11
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: x:4 y:5 z:6 c:9 a:10 c4.other:11
- │    │    │    ├── upsert-distinct-on
+ │    │    │    ├── ensure-upsert-distinct-on
  │    │    │    │    ├── columns: x:4 y:5 z:6
  │    │    │    │    ├── grouping columns: y:5
  │    │    │    │    ├── project
@@ -553,7 +553,7 @@ upsert c4
  │    │    ├── columns: column12:12!null x:4 y:5 z:6 c:9 a:10 c4.other:11
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: x:4 y:5 z:6 c:9 a:10 c4.other:11
- │    │    │    ├── upsert-distinct-on
+ │    │    │    ├── ensure-upsert-distinct-on
  │    │    │    │    ├── columns: x:4 y:5 z:6
  │    │    │    │    ├── grouping columns: y:5
  │    │    │    │    ├── project
@@ -640,7 +640,7 @@ upsert cpq
  │    ├── columns: upsert_c:13 column1:5!null column2:6!null column3:7!null column4:8!null c:9 cpq.p:10 cpq.q:11 cpq.other:12
  │    ├── left-join (hash)
  │    │    ├── columns: column1:5!null column2:6!null column3:7!null column4:8!null c:9 cpq.p:10 cpq.q:11 cpq.other:12
- │    │    ├── upsert-distinct-on
+ │    │    ├── ensure-upsert-distinct-on
  │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null column4:8!null
  │    │    │    ├── grouping columns: column1:5!null
  │    │    │    ├── values
@@ -696,7 +696,7 @@ upsert cpq
  │    ├── columns: upsert_c:14 x:5 xyzw.y:6 xyzw.z:7 w:8 c:10 cpq.p:11 cpq.q:12 cpq.other:13
  │    ├── left-join (hash)
  │    │    ├── columns: x:5 xyzw.y:6 xyzw.z:7 w:8 c:10 cpq.p:11 cpq.q:12 cpq.other:13
- │    │    ├── upsert-distinct-on
+ │    │    ├── ensure-upsert-distinct-on
  │    │    │    ├── columns: x:5 xyzw.y:6 xyzw.z:7 w:8
  │    │    │    ├── grouping columns: x:5
  │    │    │    ├── project
@@ -755,7 +755,7 @@ upsert cpq
  │    ├── columns: upsert_c:16 upsert_q:17 upsert_other:18 x:5 xyzw.y:6 column10:10!null column11:11 c:12 cpq.p:13 cpq.q:14 cpq.other:15
  │    ├── left-join (hash)
  │    │    ├── columns: x:5 xyzw.y:6 column10:10!null column11:11 c:12 cpq.p:13 cpq.q:14 cpq.other:15
- │    │    ├── upsert-distinct-on
+ │    │    ├── ensure-upsert-distinct-on
  │    │    │    ├── columns: x:5 xyzw.y:6 column10:10!null column11:11
  │    │    │    ├── grouping columns: x:5
  │    │    │    ├── project
@@ -819,7 +819,7 @@ upsert cpq
  │    ├── columns: upsert_c:17 upsert_p:18 upsert_q:19 upsert_other:20 x:5 column10:10!null column11:11!null column12:12 c:13 cpq.p:14 cpq.q:15 cpq.other:16
  │    ├── left-join (hash)
  │    │    ├── columns: x:5 column10:10!null column11:11!null column12:12 c:13 cpq.p:14 cpq.q:15 cpq.other:16
- │    │    ├── upsert-distinct-on
+ │    │    ├── ensure-upsert-distinct-on
  │    │    │    ├── columns: x:5 column10:10!null column11:11!null column12:12
  │    │    │    ├── grouping columns: x:5
  │    │    │    ├── project
@@ -891,7 +891,7 @@ upsert cpq
  │    ├── columns: upsert_c:17 x:5 column10:10!null column11:11!null column12:12 c:13 cpq.p:14 cpq.q:15 cpq.other:16
  │    ├── left-join (hash)
  │    │    ├── columns: x:5 column10:10!null column11:11!null column12:12 c:13 cpq.p:14 cpq.q:15 cpq.other:16
- │    │    ├── upsert-distinct-on
+ │    │    ├── ensure-upsert-distinct-on
  │    │    │    ├── columns: x:5 column10:10!null column11:11!null column12:12
  │    │    │    ├── grouping columns: x:5
  │    │    │    ├── project
@@ -953,7 +953,7 @@ upsert cpq
  │    │    ├── columns: column13:13!null column1:5!null column6:6!null column7:7!null column8:8 c:9 cpq.p:10 cpq.q:11 cpq.other:12
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:5!null column6:6!null column7:7!null column8:8 c:9 cpq.p:10 cpq.q:11 cpq.other:12
- │    │    │    ├── upsert-distinct-on
+ │    │    │    ├── ensure-upsert-distinct-on
  │    │    │    │    ├── columns: column1:5!null column6:6!null column7:7!null column8:8
  │    │    │    │    ├── grouping columns: column1:5!null
  │    │    │    │    ├── project
@@ -1039,7 +1039,7 @@ upsert cmulti
  │    ├── columns: upsert_a:14 upsert_b:15 x:5 y:6 xyzw.z:7 w:8 a:10 b:11 c:12 d:13
  │    ├── left-join (hash)
  │    │    ├── columns: x:5 y:6 xyzw.z:7 w:8 a:10 b:11 c:12 d:13
- │    │    ├── upsert-distinct-on
+ │    │    ├── ensure-upsert-distinct-on
  │    │    │    ├── columns: x:5 y:6 xyzw.z:7 w:8
  │    │    │    ├── grouping columns: x:5 y:6
  │    │    │    ├── project
@@ -1104,7 +1104,7 @@ upsert cmulti
  │    ├── columns: upsert_a:15 upsert_b:16 upsert_d:17 x:5 y:6 xyzw.z:7 column10:10!null a:11 b:12 c:13 d:14
  │    ├── left-join (hash)
  │    │    ├── columns: x:5 y:6 xyzw.z:7 column10:10!null a:11 b:12 c:13 d:14
- │    │    ├── upsert-distinct-on
+ │    │    ├── ensure-upsert-distinct-on
  │    │    │    ├── columns: x:5 y:6 xyzw.z:7 column10:10!null
  │    │    │    ├── grouping columns: x:5 y:6
  │    │    │    ├── project
@@ -1198,7 +1198,7 @@ upsert p1
       ├── columns: upsert_p:7 column1:3!null column2:4!null p:5 other:6
       ├── left-join (hash)
       │    ├── columns: column1:3!null column2:4!null p:5 other:6
-      │    ├── upsert-distinct-on
+      │    ├── ensure-upsert-distinct-on
       │    │    ├── columns: column1:3!null column2:4!null
       │    │    ├── grouping columns: column1:3!null
       │    │    ├── values
@@ -1236,7 +1236,7 @@ upsert p1
  │    │    ├── columns: column7:7!null column1:3!null column2:4!null p1.p:5 other:6
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:3!null column2:4!null p1.p:5 other:6
- │    │    │    ├── upsert-distinct-on
+ │    │    │    ├── ensure-upsert-distinct-on
  │    │    │    │    ├── columns: column1:3!null column2:4!null
  │    │    │    │    ├── grouping columns: column1:3!null
  │    │    │    │    ├── values
@@ -1295,7 +1295,7 @@ upsert p1
       │    ├── columns: column7:7 column1:3!null column2:4!null p:5 other:6
       │    ├── left-join (hash)
       │    │    ├── columns: column1:3!null column2:4!null p:5 other:6
-      │    │    ├── upsert-distinct-on
+      │    │    ├── ensure-upsert-distinct-on
       │    │    │    ├── columns: column1:3!null column2:4!null
       │    │    │    ├── grouping columns: column1:3!null
       │    │    │    ├── values
@@ -1341,7 +1341,7 @@ upsert p2
  │    ├── columns: upsert_p:7 column1:3!null column2:4!null p:5 p2.fk:6
  │    ├── left-join (hash)
  │    │    ├── columns: column1:3!null column2:4!null p:5 p2.fk:6
- │    │    ├── upsert-distinct-on
+ │    │    ├── ensure-upsert-distinct-on
  │    │    │    ├── columns: column1:3!null column2:4!null
  │    │    │    ├── grouping columns: column1:3!null
  │    │    │    ├── values
@@ -1398,7 +1398,7 @@ upsert p2
       │    ├── columns: column7:7!null column1:3!null column2:4!null p:5 fk:6
       │    ├── left-join (hash)
       │    │    ├── columns: column1:3!null column2:4!null p:5 fk:6
-      │    │    ├── upsert-distinct-on
+      │    │    ├── ensure-upsert-distinct-on
       │    │    │    ├── columns: column1:3!null column2:4!null
       │    │    │    ├── grouping columns: column1:3!null
       │    │    │    ├── values
@@ -1439,7 +1439,7 @@ upsert p2
  │    │    ├── columns: column7:7!null column1:3!null column2:4!null p:5 p2.fk:6
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:3!null column2:4!null p:5 p2.fk:6
- │    │    │    ├── upsert-distinct-on
+ │    │    │    ├── ensure-upsert-distinct-on
  │    │    │    │    ├── columns: column1:3!null column2:4!null
  │    │    │    │    ├── grouping columns: column1:3!null
  │    │    │    │    ├── values
@@ -1499,7 +1499,7 @@ upsert p2
       │    ├── columns: column7:7!null column1:3!null column2:4!null p:5 fk:6
       │    ├── left-join (hash)
       │    │    ├── columns: column1:3!null column2:4!null p:5 fk:6
-      │    │    ├── upsert-distinct-on
+      │    │    ├── ensure-upsert-distinct-on
       │    │    │    ├── columns: column1:3!null column2:4!null
       │    │    │    ├── grouping columns: column2:4!null
       │    │    │    ├── values
@@ -1538,7 +1538,7 @@ upsert p2
  │    │    ├── columns: column7:7!null column1:3!null column2:4!null p:5 p2.fk:6
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:3!null column2:4!null p:5 p2.fk:6
- │    │    │    ├── upsert-distinct-on
+ │    │    │    ├── ensure-upsert-distinct-on
  │    │    │    │    ├── columns: column1:3!null column2:4!null
  │    │    │    │    ├── grouping columns: column2:4!null
  │    │    │    │    ├── values
@@ -1594,7 +1594,7 @@ upsert p2
       ├── columns: upsert_p:7 upsert_fk:8 column1:3!null column4:4 p:5 fk:6
       ├── left-join (hash)
       │    ├── columns: column1:3!null column4:4 p:5 fk:6
-      │    ├── upsert-distinct-on
+      │    ├── ensure-upsert-distinct-on
       │    │    ├── columns: column1:3!null column4:4
       │    │    ├── grouping columns: column1:3!null
       │    │    ├── project
@@ -1641,7 +1641,7 @@ upsert pq
  │    ├── columns: upsert_k:13 column1:5!null column2:6!null column3:7!null column4:8!null k:9 pq.p:10 pq.q:11 pq.other:12
  │    ├── left-join (hash)
  │    │    ├── columns: column1:5!null column2:6!null column3:7!null column4:8!null k:9 pq.p:10 pq.q:11 pq.other:12
- │    │    ├── upsert-distinct-on
+ │    │    ├── ensure-upsert-distinct-on
  │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null column4:8!null
  │    │    │    ├── grouping columns: column1:5!null
  │    │    │    ├── values
@@ -1724,7 +1724,7 @@ upsert pq
       ├── columns: upsert_k:11 upsert_p:12 upsert_q:13 upsert_other:14 column1:5!null column6:6 k:7 p:8 q:9 other:10
       ├── left-join (hash)
       │    ├── columns: column1:5!null column6:6 k:7 p:8 q:9 other:10
-      │    ├── upsert-distinct-on
+      │    ├── ensure-upsert-distinct-on
       │    │    ├── columns: column1:5!null column6:6
       │    │    ├── grouping columns: column1:5!null
       │    │    ├── project
@@ -1767,7 +1767,7 @@ upsert pq
  │    ├── columns: upsert_k:12 upsert_p:13 upsert_other:14 column1:5!null column2:6!null column7:7 k:8 pq.p:9 pq.q:10 pq.other:11
  │    ├── left-join (hash)
  │    │    ├── columns: column1:5!null column2:6!null column7:7 k:8 pq.p:9 pq.q:10 pq.other:11
- │    │    ├── upsert-distinct-on
+ │    │    ├── ensure-upsert-distinct-on
  │    │    │    ├── columns: column1:5!null column2:6!null column7:7
  │    │    │    ├── grouping columns: column1:5!null
  │    │    │    ├── project
@@ -1858,7 +1858,7 @@ upsert pq
       │    ├── columns: column13:13 column1:5!null column2:6!null column3:7!null column4:8!null k:9 p:10 q:11 other:12
       │    ├── left-join (hash)
       │    │    ├── columns: column1:5!null column2:6!null column3:7!null column4:8!null k:9 p:10 q:11 other:12
-      │    │    ├── upsert-distinct-on
+      │    │    ├── ensure-upsert-distinct-on
       │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null column4:8!null
       │    │    │    ├── grouping columns: column2:6!null column3:7!null
       │    │    │    ├── values
@@ -1904,7 +1904,7 @@ upsert pq
  │    │    ├── columns: column13:13 column1:5!null column2:6!null column3:7!null column4:8!null k:9 pq.p:10 pq.q:11 pq.other:12
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null column4:8!null k:9 pq.p:10 pq.q:11 pq.other:12
- │    │    │    ├── upsert-distinct-on
+ │    │    │    ├── ensure-upsert-distinct-on
  │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null column4:8!null
  │    │    │    │    ├── grouping columns: column2:6!null column3:7!null
  │    │    │    │    ├── values
@@ -1995,7 +1995,7 @@ upsert pq
       │    ├── columns: column13:13!null column1:5!null column2:6!null column3:7!null column4:8!null k:9 p:10 q:11 other:12
       │    ├── left-join (hash)
       │    │    ├── columns: column1:5!null column2:6!null column3:7!null column4:8!null k:9 p:10 q:11 other:12
-      │    │    ├── upsert-distinct-on
+      │    │    ├── ensure-upsert-distinct-on
       │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null column4:8!null
       │    │    │    ├── grouping columns: column1:5!null
       │    │    │    ├── values
@@ -2042,7 +2042,7 @@ upsert pq
  │    │    ├── columns: column13:13!null column1:5!null column2:6!null column3:7!null column4:8!null k:9 pq.p:10 pq.q:11 pq.other:12
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null column4:8!null k:9 pq.p:10 pq.q:11 pq.other:12
- │    │    │    ├── upsert-distinct-on
+ │    │    │    ├── ensure-upsert-distinct-on
  │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null column4:8!null
  │    │    │    │    ├── grouping columns: column1:5!null
  │    │    │    │    ├── values
@@ -2158,7 +2158,7 @@ upsert tab2
  │    ├── columns: upsert_c:10 column1:4!null column2:5 column3:6 c:7 d:8 tab2.e:9
  │    ├── left-join (hash)
  │    │    ├── columns: column1:4!null column2:5 column3:6 c:7 d:8 tab2.e:9
- │    │    ├── upsert-distinct-on
+ │    │    ├── ensure-upsert-distinct-on
  │    │    │    ├── columns: column1:4!null column2:5 column3:6
  │    │    │    ├── grouping columns: column1:4!null
  │    │    │    ├── values
@@ -2232,7 +2232,7 @@ upsert tab2
  │    │    ├── columns: column10:10 column1:4!null column2:5!null column3:6!null c:7 d:8 tab2.e:9
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null c:7 d:8 tab2.e:9
- │    │    │    ├── upsert-distinct-on
+ │    │    │    ├── ensure-upsert-distinct-on
  │    │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null
  │    │    │    │    ├── grouping columns: column1:4!null
  │    │    │    │    ├── values
@@ -2310,7 +2310,7 @@ upsert tab2
  │    │    ├── columns: column10:10 column1:4!null column2:5!null column3:6!null c:7 d:8 e:9
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null c:7 d:8 e:9
- │    │    │    ├── upsert-distinct-on
+ │    │    │    ├── ensure-upsert-distinct-on
  │    │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null
  │    │    │    │    ├── grouping columns: column3:6!null
  │    │    │    │    ├── values
@@ -2382,7 +2382,7 @@ upsert self
  │    ├── columns: upsert_a:14 upsert_b:15 x:5 y:6 xyzw.z:7 xyzw.w:8 a:10 self.b:11 self.c:12 self.d:13
  │    ├── left-join (hash)
  │    │    ├── columns: x:5 y:6 xyzw.z:7 xyzw.w:8 a:10 self.b:11 self.c:12 self.d:13
- │    │    ├── upsert-distinct-on
+ │    │    ├── ensure-upsert-distinct-on
  │    │    │    ├── columns: x:5 y:6 xyzw.z:7 xyzw.w:8
  │    │    │    ├── grouping columns: x:5 y:6
  │    │    │    ├── project

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -96,7 +96,7 @@ upsert abc
       │    │    ├── columns: column14:14!null x:5!null y:6 column8:8 column9:9 a:10 b:11 c:12 rowid:13
       │    │    ├── left-join (hash)
       │    │    │    ├── columns: x:5!null y:6 column8:8 column9:9 a:10 b:11 c:12 rowid:13
-      │    │    │    ├── upsert-distinct-on
+      │    │    │    ├── ensure-upsert-distinct-on
       │    │    │    │    ├── columns: x:5!null y:6 column8:8 column9:9
       │    │    │    │    ├── grouping columns: x:5!null
       │    │    │    │    ├── project
@@ -172,7 +172,7 @@ project
            │    │    ├── columns: column13:13!null column14:14!null column15:15!null x:5!null y:6 z:7 column8:8 a:9 b:10 c:11 rowid:12
            │    │    ├── left-join (hash)
            │    │    │    ├── columns: x:5!null y:6 z:7 column8:8 a:9 b:10 c:11 rowid:12
-           │    │    │    ├── upsert-distinct-on
+           │    │    │    ├── ensure-upsert-distinct-on
            │    │    │    │    ├── columns: x:5!null y:6 z:7 column8:8
            │    │    │    │    ├── grouping columns: y:6 column8:8
            │    │    │    │    ├── project
@@ -236,7 +236,7 @@ upsert abc
       │    │    │    ├── columns: x:5!null y:6 column8:8 column9:9 a:10 b:11 c:12 rowid:13
       │    │    │    ├── left-join (hash)
       │    │    │    │    ├── columns: x:5!null y:6 column8:8 column9:9 a:10 b:11 c:12 rowid:13
-      │    │    │    │    ├── upsert-distinct-on
+      │    │    │    │    ├── ensure-upsert-distinct-on
       │    │    │    │    │    ├── columns: x:5!null y:6 column8:8 column9:9
       │    │    │    │    │    ├── grouping columns: x:5!null
       │    │    │    │    │    ├── project
@@ -315,7 +315,7 @@ sort
       │              │    │    ├── columns: column13:13!null column1:5!null column2:6!null column7:7 column8:8!null abc.a:9 abc.b:10 abc.c:11 rowid:12
       │              │    │    ├── left-join (hash)
       │              │    │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8!null abc.a:9 abc.b:10 abc.c:11 rowid:12
-      │              │    │    │    ├── upsert-distinct-on
+      │              │    │    │    ├── ensure-upsert-distinct-on
       │              │    │    │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8!null
       │              │    │    │    │    ├── grouping columns: column1:5!null
       │              │    │    │    │    ├── project
@@ -387,7 +387,7 @@ upsert tab
       │    │    ├── columns: column13:13 column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12
       │    │    ├── left-join (hash)
       │    │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12
-      │    │    │    ├── upsert-distinct-on
+      │    │    │    ├── ensure-upsert-distinct-on
       │    │    │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8!null
       │    │    │    │    ├── grouping columns: column1:5!null
       │    │    │    │    ├── project
@@ -452,7 +452,7 @@ upsert abc
       │    │    ├── columns: column13:13!null column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12
       │    │    ├── left-join (hash)
       │    │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12
-      │    │    │    ├── upsert-distinct-on
+      │    │    │    ├── ensure-upsert-distinct-on
       │    │    │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8!null
       │    │    │    │    ├── grouping columns: column2:6!null column8:8!null
       │    │    │    │    ├── project
@@ -669,7 +669,7 @@ project
  │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
  │         │    │    ├── left-join (hash)
  │         │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
- │         │    │    │    ├── upsert-distinct-on
+ │         │    │    │    ├── ensure-upsert-distinct-on
  │         │    │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null
  │         │    │    │    │    ├── grouping columns: column2:5!null column3:6!null
  │         │    │    │    │    ├── values
@@ -749,7 +749,7 @@ upsert abc
       │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12 x:13 "?column?":16
       │    │    ├── left-join (hash)
       │    │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12
-      │    │    │    ├── upsert-distinct-on
+      │    │    │    ├── ensure-upsert-distinct-on
       │    │    │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8!null
       │    │    │    │    ├── grouping columns: column1:5!null
       │    │    │    │    ├── project
@@ -826,7 +826,7 @@ upsert abc
       │    │    ├── columns: column13:13 column14:14!null column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12
       │    │    ├── left-join (hash)
       │    │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12
-      │    │    │    ├── upsert-distinct-on
+      │    │    │    ├── ensure-upsert-distinct-on
       │    │    │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8!null
       │    │    │    │    ├── grouping columns: column1:5!null
       │    │    │    │    ├── project
@@ -899,7 +899,7 @@ upsert mutation
       │    │    │    ├── columns: column15:15 column1:6!null column2:7!null column8:8!null column9:9!null m:10 n:11 o:12 p:13 q:14
       │    │    │    ├── left-join (hash)
       │    │    │    │    ├── columns: column1:6!null column2:7!null column8:8!null column9:9!null m:10 n:11 o:12 p:13 q:14
-      │    │    │    │    ├── upsert-distinct-on
+      │    │    │    │    ├── ensure-upsert-distinct-on
       │    │    │    │    │    ├── columns: column1:6!null column2:7!null column8:8!null column9:9!null
       │    │    │    │    │    ├── grouping columns: column1:6!null
       │    │    │    │    │    ├── project
@@ -960,7 +960,7 @@ upsert xyz
       ├── columns: upsert_x:9 column1:4!null column5:5 x:6 y:7 z:8
       ├── left-join (hash)
       │    ├── columns: column1:4!null column5:5 x:6 y:7 z:8
-      │    ├── upsert-distinct-on
+      │    ├── ensure-upsert-distinct-on
       │    │    ├── columns: column1:4!null column5:5
       │    │    ├── grouping columns: column1:4!null
       │    │    ├── project
@@ -1023,7 +1023,7 @@ with &1
  │              ├── columns: upsert_rowid:13 column1:5!null column2:6!null column7:7 column8:8!null abc.a:9 abc.b:10 abc.c:11 rowid:12
  │              ├── left-join (hash)
  │              │    ├── columns: column1:5!null column2:6!null column7:7 column8:8!null abc.a:9 abc.b:10 abc.c:11 rowid:12
- │              │    ├── upsert-distinct-on
+ │              │    ├── ensure-upsert-distinct-on
  │              │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8!null
  │              │    │    ├── grouping columns: column7:7
  │              │    │    ├── project
@@ -1080,7 +1080,7 @@ upsert xyz
       ├── columns: upsert_x:10 column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
       ├── left-join (hash)
       │    ├── columns: column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
-      │    ├── upsert-distinct-on
+      │    ├── ensure-upsert-distinct-on
       │    │    ├── columns: column1:4!null column2:5!null column3:6!null
       │    │    ├── grouping columns: column2:5!null
       │    │    ├── values
@@ -1139,7 +1139,7 @@ upsert checks
       │    ├── columns: upsert_a:13 column1:5!null column2:6!null column3:7!null column8:8!null a:9 b:10 c:11 d:12
       │    ├── left-join (hash)
       │    │    ├── columns: column1:5!null column2:6!null column3:7!null column8:8!null a:9 b:10 c:11 d:12
-      │    │    ├── upsert-distinct-on
+      │    │    ├── ensure-upsert-distinct-on
       │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null column8:8!null
       │    │    │    ├── grouping columns: column1:5!null
       │    │    │    ├── project
@@ -1196,7 +1196,7 @@ upsert mutation
       │    ├── columns: upsert_m:15 column1:6!null column2:7!null column8:8!null column9:9!null m:10 n:11 o:12 p:13 q:14
       │    ├── left-join (hash)
       │    │    ├── columns: column1:6!null column2:7!null column8:8!null column9:9!null m:10 n:11 o:12 p:13 q:14
-      │    │    ├── upsert-distinct-on
+      │    │    ├── ensure-upsert-distinct-on
       │    │    │    ├── columns: column1:6!null column2:7!null column8:8!null column9:9!null
       │    │    │    ├── grouping columns: column1:6!null
       │    │    │    ├── project
@@ -1253,7 +1253,7 @@ upsert mutation
       │    ├── columns: upsert_m:15 column1:6!null column2:7!null column8:8!null column9:9!null m:10 n:11 o:12 p:13 q:14
       │    ├── left-join (hash)
       │    │    ├── columns: column1:6!null column2:7!null column8:8!null column9:9!null m:10 n:11 o:12 p:13 q:14
-      │    │    ├── upsert-distinct-on
+      │    │    ├── ensure-upsert-distinct-on
       │    │    │    ├── columns: column1:6!null column2:7!null column8:8!null column9:9!null
       │    │    │    ├── grouping columns: column1:6!null
       │    │    │    ├── project
@@ -1323,7 +1323,7 @@ upsert checks
       │    │    │    ├── columns: column13:13!null column14:14!null column1:5!null column2:6!null column7:7 column8:8 a:9 b:10 c:11 d:12
       │    │    │    ├── left-join (hash)
       │    │    │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8 a:9 b:10 c:11 d:12
-      │    │    │    │    ├── upsert-distinct-on
+      │    │    │    │    ├── ensure-upsert-distinct-on
       │    │    │    │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8
       │    │    │    │    │    ├── grouping columns: column1:5!null
       │    │    │    │    │    ├── project
@@ -1448,7 +1448,7 @@ upsert checks
       │    │    ├── columns: column13:13 column1:5!null column2:6!null column7:7 column8:8 a:9 b:10 c:11 d:12
       │    │    ├── left-join (hash)
       │    │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8 a:9 b:10 c:11 d:12
-      │    │    │    ├── upsert-distinct-on
+      │    │    │    ├── ensure-upsert-distinct-on
       │    │    │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8
       │    │    │    │    ├── grouping columns: column1:5!null
       │    │    │    │    ├── project
@@ -1518,7 +1518,7 @@ upsert checks
       │    │    │    ├── columns: column18:18 abc.a:5!null abc.b:6 column9:9 column10:10 checks.a:11 checks.b:12 checks.c:13 d:14
       │    │    │    ├── left-join (hash)
       │    │    │    │    ├── columns: abc.a:5!null abc.b:6 column9:9 column10:10 checks.a:11 checks.b:12 checks.c:13 d:14
-      │    │    │    │    ├── upsert-distinct-on
+      │    │    │    │    ├── ensure-upsert-distinct-on
       │    │    │    │    │    ├── columns: abc.a:5!null abc.b:6 column9:9 column10:10
       │    │    │    │    │    ├── grouping columns: abc.a:5!null
       │    │    │    │    │    ├── project
@@ -1596,7 +1596,7 @@ upsert xyz
       │    ├── columns: column11:11!null a:4!null b:5 c:6 x:8 y:9 z:10
       │    ├── left-join (hash)
       │    │    ├── columns: a:4!null b:5 c:6 x:8 y:9 z:10
-      │    │    ├── upsert-distinct-on
+      │    │    ├── ensure-upsert-distinct-on
       │    │    │    ├── columns: a:4!null b:5 c:6
       │    │    │    ├── grouping columns: b:5 c:6
       │    │    │    ├── project

--- a/pkg/sql/opt/optgen/lang/support/textmate/OptGen.tmbundle/Syntaxes/optgen.tmLanguage
+++ b/pkg/sql/opt/optgen/lang/support/textmate/OptGen.tmbundle/Syntaxes/optgen.tmLanguage
@@ -233,6 +233,9 @@
                         GroupingPrivate |
                         ScalarGroupBy |
                         DistinctOn |
+                        EnsureDistinctOn |
+                        UpsertDistinctOn |
+                        EnsureUpsertDistinctOn |
                         Union |
                         SetPrivate |
                         Intersect |

--- a/pkg/sql/opt/optgen/lang/support/vim/cropt.vim
+++ b/pkg/sql/opt/optgen/lang/support/vim/cropt.vim
@@ -52,7 +52,8 @@ syn keyword operator IndexJoin IndexJoinPrivate LookupJoin LookupJoinPrivate
 syn keyword operator MergeJoin MergeJoinPrivate
 syn keyword operator InnerJoinApply LeftJoinApply
 syn keyword operator SemiJoinApply AntiJoinApply
-syn keyword operator GroupBy GroupingPrivate ScalarGroupBy DistinctOn
+syn keyword operator GroupBy GroupingPrivate ScalarGroupBy
+syn keyword operator DistinctOn EnsureDistinctOn UpsertDistinctOn EnsureUpsertDistinctOn
 syn keyword operator Union SetPrivate Intersect Except UnionAll IntersectAll ExceptAll
 syn keyword operator Limit Offset Max1Row Explain ExplainPrivate
 syn keyword operator ShowTraceForSession ShowTracePrivate RowNumber RowNumberPrivate ProjectSet

--- a/pkg/sql/opt/optgen/lang/support/vscode/cockroachdb.optgen-1.0.0/syntaxes/optgen.tmLanguage
+++ b/pkg/sql/opt/optgen/lang/support/vscode/cockroachdb.optgen-1.0.0/syntaxes/optgen.tmLanguage
@@ -233,6 +233,9 @@
                         GroupingPrivate |
                         ScalarGroupBy |
                         DistinctOn |
+                        EnsureDistinctOn |
+                        UpsertDistinctOn |
+                        EnsureUpsertDistinctOn |
                         Union |
                         SetPrivate |
                         Intersect |

--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -167,6 +167,11 @@ func init() {
 		buildChildReqOrdering: distinctOnBuildChildReqOrdering,
 		buildProvidedOrdering: distinctOnBuildProvided,
 	}
+	funcMap[opt.EnsureUpsertDistinctOnOp] = funcs{
+		canProvideOrdering:    distinctOnCanProvideOrdering,
+		buildChildReqOrdering: distinctOnBuildChildReqOrdering,
+		buildProvidedOrdering: distinctOnBuildProvided,
+	}
 	funcMap[opt.SortOp] = funcs{
 		canProvideOrdering:    nil, // should never get called
 		buildChildReqOrdering: sortBuildChildReqOrdering,

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -193,7 +193,7 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 		cost = c.computeSetCost(candidate)
 
 	case opt.GroupByOp, opt.ScalarGroupByOp, opt.DistinctOnOp, opt.EnsureDistinctOnOp,
-		opt.UpsertDistinctOnOp:
+		opt.UpsertDistinctOnOp, opt.EnsureUpsertDistinctOnOp:
 		cost = c.computeGroupingCost(candidate, required)
 
 	case opt.LimitOp:

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -2388,6 +2388,14 @@ func (c *CustomFuncs) GenerateStreamingGroupBy(
 				GroupingPrivate: newPrivate,
 			}
 			c.e.mem.AddUpsertDistinctOnToGroup(&newExpr, grp)
+
+		case opt.EnsureUpsertDistinctOnOp:
+			newExpr := memo.EnsureUpsertDistinctOnExpr{
+				Input:           input,
+				Aggregations:    aggs,
+				GroupingPrivate: newPrivate,
+			}
+			c.e.mem.AddEnsureUpsertDistinctOnToGroup(&newExpr, grp)
 		}
 	}
 }

--- a/pkg/sql/opt/xform/rules/groupby.opt
+++ b/pkg/sql/opt/xform/rules/groupby.opt
@@ -108,7 +108,8 @@
 # grouping columns, we can execute aggregations in a streaming fashion which is
 # more efficient.
 [GenerateStreamingGroupBy, Explore]
-(GroupBy | DistinctOn | UpsertDistinctOn
+(GroupBy | DistinctOn | EnsureDistinctOn | UpsertDistinctOn
+        | EnsureUpsertDistinctOn
     $input:*
     $aggs:*
     $private:* & (IsCanonicalGroupBy $private)

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1305,7 +1305,7 @@ upsert transactiondetails
  │    │    ├── side-effects
  │    │    ├── lax-key: (13-15,21-25)
  │    │    ├── fd: ()-->(11,12), (13-15)~~>(18-20), (21-25)-->(26-28)
- │    │    ├── upsert-distinct-on
+ │    │    ├── ensure-upsert-distinct-on
  │    │    │    ├── columns: "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15 column18:18 sellprice:19 buyprice:20
  │    │    │    ├── grouping columns: current_timestamp:13 int8:14 int8:15
  │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1314,7 +1314,7 @@ upsert transactiondetails
  │    │    ├── side-effects
  │    │    ├── lax-key: (15-17,25-29)
  │    │    ├── fd: ()-->(13,14,24), (15-17)~~>(20,22,23), (25-29)-->(30-34)
- │    │    ├── upsert-distinct-on
+ │    │    ├── ensure-upsert-distinct-on
  │    │    │    ├── columns: "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17 column20:20 sellprice:22 buyprice:23 discount:24!null
  │    │    │    ├── grouping columns: current_timestamp:15 int8:16 int8:17
  │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1790,7 +1790,7 @@ sort
       │         │    ├── key columns: [4 5 6] = [7 8 9]
       │         │    ├── lookup columns are key
       │         │    ├── key: (4-9)
-      │         │    ├── upsert-distinct-on
+      │         │    ├── ensure-upsert-distinct-on
       │         │    │    ├── columns: x:4!null y:5!null z:6!null
       │         │    │    ├── grouping columns: x:4!null y:5!null z:6!null
       │         │    │    ├── internal-ordering: +5,+6

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -1714,7 +1714,146 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
  ├── G6: (variable u)
  └── G7: (variable v)
 
+# Ensure that streaming ensure-distinct-on will be used.
+memo
+SELECT (SELECT w FROM kuvw WHERE v=1 AND x=u) FROM xyz ORDER BY x+1, x
+----
+memo (optimized, ~24KB, required=[presentation: w:8] [ordering: +9,+1])
+ ├── G1: (project G2 G3 x)
+ │    ├── [presentation: w:8] [ordering: +9,+1]
+ │    │    ├── best: (sort G1)
+ │    │    └── cost: 1352.04
+ │    └── []
+ │         ├── best: (project G2 G3 x)
+ │         └── cost: 1121.74
+ ├── G2: (ensure-distinct-on G4 G5 cols=(1)) (ensure-distinct-on G4 G5 cols=(1),ordering=+1)
+ │    └── []
+ │         ├── best: (ensure-distinct-on G4="[ordering: +1]" G5 cols=(1),ordering=+1)
+ │         └── cost: 1091.73
+ ├── G3: (projections G6 G7)
+ ├── G4: (left-join G8 G9 G10) (right-join G9 G8 G10) (merge-join G8 G9 G11 left-join,+1,+5) (lookup-join G12 G11 kuvw@uvw,keyCols=[1 10],outCols=(1,5-7)) (lookup-join G13 G10 kuvw@vw,keyCols=[11],outCols=(1,5-7)) (merge-join G9 G8 G11 right-join,+5,+1)
+ │    ├── [ordering: +1]
+ │    │    ├── best: (merge-join G8="[ordering: +1]" G9="[ordering: +5 opt(6)]" G11 left-join,+1,+5)
+ │    │    └── cost: 1061.71
+ │    └── []
+ │         ├── best: (merge-join G8="[ordering: +1]" G9="[ordering: +5 opt(6)]" G11 left-join,+1,+5)
+ │         └── cost: 1061.71
+ ├── G5: (aggregations G14)
+ ├── G6: (variable kuvw.w)
+ ├── G7: (plus G15 G16)
+ ├── G8: (scan xyz,cols=(1)) (scan xyz@xy,cols=(1)) (scan xyz@zyx,cols=(1)) (scan xyz@yy,cols=(1))
+ │    ├── [ordering: +1]
+ │    │    ├── best: (scan xyz@xy,cols=(1))
+ │    │    └── cost: 1030.02
+ │    └── []
+ │         ├── best: (scan xyz@xy,cols=(1))
+ │         └── cost: 1030.02
+ ├── G9: (select G17 G18) (scan kuvw@vw,cols=(5-7),constrained)
+ │    ├── [ordering: +5 opt(6)]
+ │    │    ├── best: (sort G9)
+ │    │    └── cost: 11.58
+ │    └── []
+ │         ├── best: (scan kuvw@vw,cols=(5-7),constrained)
+ │         └── cost: 10.71
+ ├── G10: (filters G19)
+ ├── G11: (filters)
+ ├── G12: (project G8 G20 x)
+ │    ├── [ordering: +1]
+ │    │    ├── best: (project G8="[ordering: +1]" G20 x)
+ │    │    └── cost: 1050.03
+ │    └── []
+ │         ├── best: (project G8 G20 x)
+ │         └── cost: 1050.03
+ ├── G13: (project G8 G20 x)
+ │    ├── [ordering: +1]
+ │    │    ├── best: (project G8="[ordering: +1]" G20 x)
+ │    │    └── cost: 1050.03
+ │    └── []
+ │         ├── best: (project G8 G20 x)
+ │         └── cost: 1050.03
+ ├── G14: (const-agg G6)
+ ├── G15: (variable x)
+ ├── G16: (const 1)
+ ├── G17: (scan kuvw,cols=(5-7)) (scan kuvw@uvw,cols=(5-7)) (scan kuvw@wvu,cols=(5-7)) (scan kuvw@vw,cols=(5-7)) (scan kuvw@w,cols=(5-7))
+ │    ├── [ordering: +5 opt(6)]
+ │    │    ├── best: (scan kuvw@uvw,cols=(5-7))
+ │    │    └── cost: 1070.02
+ │    └── []
+ │         ├── best: (scan kuvw,cols=(5-7))
+ │         └── cost: 1070.02
+ ├── G18: (filters G21)
+ ├── G19: (eq G15 G22)
+ ├── G20: (projections G16)
+ ├── G21: (eq G23 G16)
+ ├── G22: (variable u)
+ └── G23: (variable v)
+
 # Ensure that streaming upsert-distinct-on will be used.
+memo
+INSERT INTO xyz SELECT v, w, 1.0 FROM kuvw ON CONFLICT (x) DO NOTHING
+----
+memo (optimized, ~19KB, required=[])
+ ├── G1: (insert G2 G3 xyz)
+ │    └── []
+ │         ├── best: (insert G2 G3 xyz)
+ │         └── cost: 2150.50
+ ├── G2: (upsert-distinct-on G4 G5 cols=(6)) (upsert-distinct-on G4 G5 cols=(6),ordering=+6 opt(8,9))
+ │    └── []
+ │         ├── best: (upsert-distinct-on G4="[ordering: +6 opt(8,9)]" G5 cols=(6),ordering=+6 opt(8,9))
+ │         └── cost: 2150.49
+ ├── G3: (f-k-checks)
+ ├── G4: (select G6 G7)
+ │    ├── [ordering: +6 opt(8,9)]
+ │    │    ├── best: (select G6="[ordering: +6 opt(8,9)]" G7)
+ │    │    └── cost: 2150.07
+ │    └── []
+ │         ├── best: (select G6 G7)
+ │         └── cost: 2150.07
+ ├── G5: (aggregations G8 G9)
+ ├── G6: (left-join G10 G11 G12) (right-join G11 G10 G12) (merge-join G10 G11 G13 left-join,+6,+9) (lookup-join G10 G13 xyz,keyCols=[6],outCols=(6-9)) (lookup-join G10 G13 xyz@xy,keyCols=[6],outCols=(6-9)) (merge-join G11 G10 G13 right-join,+9,+6)
+ │    ├── [ordering: +6 opt(8,9)]
+ │    │    ├── best: (merge-join G10="[ordering: +6 opt(8)]" G11="[ordering: +9]" G13 left-join,+6,+9)
+ │    │    └── cost: 2140.06
+ │    └── []
+ │         ├── best: (merge-join G10="[ordering: +6 opt(8)]" G11="[ordering: +9]" G13 left-join,+6,+9)
+ │         └── cost: 2140.06
+ ├── G7: (filters G14)
+ ├── G8: (first-agg G15)
+ ├── G9: (first-agg G16)
+ ├── G10: (project G17 G18 v w)
+ │    ├── [ordering: +6 opt(8)]
+ │    │    ├── best: (project G17="[ordering: +6]" G18 v w)
+ │    │    └── cost: 1080.03
+ │    └── []
+ │         ├── best: (project G17 G18 v w)
+ │         └── cost: 1080.03
+ ├── G11: (scan xyz,cols=(9)) (scan xyz@xy,cols=(9)) (scan xyz@zyx,cols=(9)) (scan xyz@yy,cols=(9))
+ │    ├── [ordering: +9]
+ │    │    ├── best: (scan xyz@xy,cols=(9))
+ │    │    └── cost: 1030.02
+ │    └── []
+ │         ├── best: (scan xyz@xy,cols=(9))
+ │         └── cost: 1030.02
+ ├── G12: (filters G19)
+ ├── G13: (filters)
+ ├── G14: (is G20 G21)
+ ├── G15: (variable w)
+ ├── G16: (variable "?column?")
+ ├── G17: (scan kuvw,cols=(6,7)) (scan kuvw@uvw,cols=(6,7)) (scan kuvw@wvu,cols=(6,7)) (scan kuvw@vw,cols=(6,7)) (scan kuvw@w,cols=(6,7))
+ │    ├── [ordering: +6]
+ │    │    ├── best: (scan kuvw@vw,cols=(6,7))
+ │    │    └── cost: 1060.02
+ │    └── []
+ │         ├── best: (scan kuvw,cols=(6,7))
+ │         └── cost: 1060.02
+ ├── G18: (projections G22)
+ ├── G19: (eq G23 G20)
+ ├── G20: (variable x)
+ ├── G21: (null)
+ ├── G22: (const 1.0)
+ └── G23: (variable v)
+
+# Ensure that streaming ensure-upsert-distinct-on will be used.
 memo
 INSERT INTO xyz SELECT v, w, 1.0 FROM kuvw ON CONFLICT (x) DO UPDATE SET z=2.0
 ----
@@ -1733,12 +1872,12 @@ memo (optimized, ~19KB, required=[])
  │         ├── best: (merge-join G7="[ordering: +9]" G6="[ordering: +6 opt(8)]" G9 right-join,+9,+6)
  │         └── cost: 2210.08
  ├── G5: (projections G11)
- ├── G6: (upsert-distinct-on G12 G13 cols=(6)) (upsert-distinct-on G12 G13 cols=(6),ordering=+6 opt(8))
+ ├── G6: (ensure-upsert-distinct-on G12 G13 cols=(6)) (ensure-upsert-distinct-on G12 G13 cols=(6),ordering=+6 opt(8))
  │    ├── [ordering: +6 opt(8)]
- │    │    ├── best: (upsert-distinct-on G12="[ordering: +6 opt(8)]" G13 cols=(6))
+ │    │    ├── best: (ensure-upsert-distinct-on G12="[ordering: +6 opt(8)]" G13 cols=(6))
  │    │    └── cost: 1120.05
  │    └── []
- │         ├── best: (upsert-distinct-on G12="[ordering: +6 opt(8)]" G13 cols=(6),ordering=+6 opt(8))
+ │         ├── best: (ensure-upsert-distinct-on G12="[ordering: +6 opt(8)]" G13 cols=(6),ordering=+6 opt(8))
  │         └── cost: 1120.05
  ├── G7: (scan xyz) (scan xyz@zyx)
  │    ├── [ordering: +9]


### PR DESCRIPTION
Previously, the UpsertDistinctOn operator handled both the case
where an error is thrown when duplicates are detected and the
case  where duplicates are simply removed when encountered.

This patch adds the EnsureUpsertDistinctOn operator, which is to be
used in the case when nulls are considered distinct for grouping
purposes and an error should be raised when duplicates are encountered.
UpsertDistinctOn should now only be used when nulls are considered 
distinct and duplicates should be removed _without_ raising an error.

This way, there will be a separate distinct operator for every unique
combination of null behavior and error behavior.

Release note: None