### PR TITLE
kvserver: don't track closed timestamp for expiration-based leases

### DIFF
--- a/pkg/kv/kvserver/client_closed_timestamp_test.go
+++ b/pkg/kv/kvserver/client_closed_timestamp_test.go
@@ -102,7 +102,8 @@ func TestClosedTimestampWorksWhenRequestsAreSentToNonLeaseHolders(t *testing.T) 
 		if afterLease != nil {
 			afterLease()
 		}
-		nowClosed := repl.MaxClosed(ctx)
+		nowClosed, ok := repl.MaxClosed(ctx)
+		require.True(t, ok)
 		lease, _ := repl.GetLease()
 		if lease.Replica.NodeID != target.NodeID {
 			t.Fatalf("lease was unexpectedly transferred away which should" +
@@ -116,7 +117,8 @@ func TestClosedTimestampWorksWhenRequestsAreSentToNonLeaseHolders(t *testing.T) 
 				t.Fatalf("lease was unexpectedly transferred away which should" +
 					" not happen given the very long timeouts")
 			}
-			closed := repl.MaxClosed(ctx)
+			closed, ok := repl.MaxClosed(ctx)
+			require.True(t, ok)
 			if closed.Less(targetClosed) {
 				return errors.Errorf("closed timestamp %v not yet after target %v", closed, targetClosed)
 			}

--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -15,16 +15,21 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -332,4 +337,62 @@ func TestStoreMetrics(t *testing.T) {
 
 	verifyRocksDBStats(t, mtc.stores[0])
 	verifyRocksDBStats(t, mtc.stores[1])
+}
+
+// TestStoreMaxBehindNanosOnlyTracksEpochBasedLeases ensures that the metric
+// ClosedTimestampMaxBehindNanos does not follow the start time of expiration
+// based leases. Expiration based leases don't publish closed timestamps.
+func TestStoreMaxBehindNanosOnlyTracksEpochBasedLeases(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			// Set a long timeout so that no lease or liveness ever times out.
+			RaftConfig: base.RaftConfig{RaftElectionTimeoutTicks: 100},
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	// We want to choose setting values such that this test doesn't take too long
+	// with the caveat that under extreme stress, we need to make sure that the
+	// subsystem remains live.
+	const closedTimestampDuration = 15 * time.Millisecond
+	const closedTimestampFraction = 1
+	tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = $1",
+		closedTimestampDuration.String())
+	tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.close_fraction = $1",
+		closedTimestampFraction)
+
+	// Let's get to a point where we know that we have an expiration based lease
+	// with a start time more than some time ago and then we have a max closed
+	// value more recent.
+	_, meta2Repl1 := getFirstStoreReplica(t, tc.Server(0), keys.Meta2Prefix)
+
+	// Transfer the lease for the meta range to ensure that it has a non-zero
+	// start time.
+	require.NoError(t, tc.TransferRangeLease(*meta2Repl1.Desc(), tc.Target(1)))
+
+	testutils.SucceedsSoon(t, func() error {
+		_, metaRepl := getFirstStoreReplica(t, tc.Server(1), keys.Meta2Prefix)
+		l, _ := metaRepl.GetLease()
+		if l.Start == (hlc.Timestamp{}) {
+			return errors.Errorf("don't have a lease for meta1 yet: %v %v", l, meta2Repl1)
+		}
+		sinceExpBasedLeaseStart := timeutil.Since(timeutil.Unix(0, l.Start.WallTime))
+		for i := 0; i < tc.NumServers(); i++ {
+			s, _ := getFirstStoreReplica(t, tc.Server(i), keys.Meta1Prefix)
+			require.NoError(t, s.ComputeMetrics(ctx, 0))
+			maxBehind := time.Duration(s.Metrics().ClosedTimestampMaxBehindNanos.Value())
+			// We want to make sure that maxBehind ends up being much smaller than the
+			// start of an expiration based lease.
+			const behindMultiple = 5
+			if maxBehind*behindMultiple > sinceExpBasedLeaseStart {
+				return errors.Errorf("store %v has a ClosedTimestampMaxBehindNanos"+
+					" of %v which is not way less than the an expiration-based lease start, %v",
+					s.StoreID(), maxBehind, sinceExpBasedLeaseStart)
+			}
+		}
+		return nil
+	})
 }

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -276,7 +276,7 @@ func (r *Replica) LastAssignedLeaseIndex() uint64 {
 }
 
 // MaxClosed returns the maximum closed timestamp known to the Replica.
-func (r *Replica) MaxClosed(ctx context.Context) hlc.Timestamp {
+func (r *Replica) MaxClosed(ctx context.Context) (_ hlc.Timestamp, ok bool) {
 	return r.maxClosed(ctx)
 }
 

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -975,7 +975,7 @@ func (r *Replica) State() storagepb.RangeInfo {
 	// NB: this acquires an RLock(). Reentrant RLocks are deadlock prone, so do
 	// this first before RLocking below. Performance of this extra lock
 	// acquisition is not a concern.
-	ri.ActiveClosedTimestamp = r.maxClosed(context.Background())
+	ri.ActiveClosedTimestamp, _ = r.maxClosed(context.Background())
 
 	// NB: numRangefeedRegistrations doesn't require Replica.mu to be locked.
 	// However, it does require coordination between multiple goroutines, so

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -595,7 +595,7 @@ func (r *Replica) handleClosedTimestampUpdateRaftMuLocked(ctx context.Context) {
 	}
 
 	// Determine what the maximum closed timestamp is for this replica.
-	closedTS := r.maxClosed(ctx)
+	closedTS, _ := r.maxClosed(ctx)
 
 	// If the closed timestamp is sufficiently stale, signal that we want an
 	// update to the leaseholder so that it will eventually begin to progress

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2392,7 +2392,8 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		if wps, dur := rep.writeStats.avgQPS(); dur >= MinStatsDuration {
 			averageWritesPerSecond += wps
 		}
-		if mc := rep.maxClosed(ctx); minMaxClosedTS.IsEmpty() || mc.Less(minMaxClosedTS) {
+		mc, ok := rep.maxClosed(ctx)
+		if ok && (minMaxClosedTS.IsEmpty() || mc.Less(minMaxClosedTS)) {
 			minMaxClosedTS = mc
 		}
 		return true // more

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -149,7 +149,7 @@ func splitPreApply(
 	// the hazard and ensures that no replica on the RHS is created with an
 	// initialMaxClosed that could be violated by a proposal on the RHS's
 	// initial leaseholder. See #44878.
-	initialMaxClosed := r.maxClosed(ctx)
+	initialMaxClosed, _ := r.maxClosed(ctx)
 	rightRepl.mu.Lock()
 	rightRepl.mu.initialMaxClosed = initialMaxClosed
 	rightRepl.mu.Unlock()


### PR DESCRIPTION
Epoch-based leases are a requirement for the closed-timestamp
subsystem. Closed timestamp records only make sense in the context
of node-liveness epochs. Expiration-based leases have a maxClosed()
value equal to their lease start time. This genearlly means that
until the oldest expiration-based lease on a node changes, the
closed timestamp lag on that node will grow.

Release note (bug fix): Fixed bug which falsly indicated that
`kv.closed_timestamp.max_behind_nanos` was almost always growing.