### PR TITLE
geo/geo*fn: error when comparing two geometries of different SRIDs

### DIFF
--- a/pkg/geo/errors.go
+++ b/pkg/geo/errors.go
@@ -1,0 +1,25 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geo
+
+import "github.com/cockroachdb/errors"
+
+// NewMismatchingSRIDsError returns the error message for SRIDs of GeospatialTypes
+// a and b being a mismatch.
+func NewMismatchingSRIDsError(a GeospatialType, b GeospatialType) error {
+	return errors.Newf(
+		"operation on mixed SRIDs forbidden: (%s, %d) != (%s, %d)",
+		a.Shape(),
+		a.SRID(),
+		b.Shape(),
+		b.SRID(),
+	)
+}

--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -24,6 +24,17 @@ import (
 // EWKBEncodingFormat is the encoding format for EWKB.
 var EWKBEncodingFormat = binary.LittleEndian
 
+// GeospatialType are functions that are common between all Geospatial types.
+type GeospatialType interface {
+	// SRID returns the SRID of the given type.
+	SRID() geopb.SRID
+	// Shape returns the Shape of the given type.
+	Shape() geopb.Shape
+}
+
+var _ GeospatialType = (*Geometry)(nil)
+var _ GeospatialType = (*Geography)(nil)
+
 //
 // Geometry
 //
@@ -262,6 +273,11 @@ func (g *Geography) EWKB() geopb.EWKB {
 // SRID returns the SRID representation of the Geography.
 func (g *Geography) SRID() geopb.SRID {
 	return g.SpatialObject.SRID
+}
+
+// Shape returns the shape of the Geography.
+func (g *Geography) Shape() geopb.Shape {
+	return g.SpatialObject.Shape
 }
 
 // AsS2 converts a given Geography into it's S2 form.

--- a/pkg/geo/geogfn/covers.go
+++ b/pkg/geo/geogfn/covers.go
@@ -40,6 +40,14 @@ import (
 //       'linestring(0.0 0.0, 2.0 0.0)'::geography
 //     );
 func Covers(a *geo.Geography, b *geo.Geography) (bool, error) {
+	if a.SRID() != b.SRID() {
+		return false, geo.NewMismatchingSRIDsError(a, b)
+	}
+	return covers(a, b)
+}
+
+// covers is the internal calculation for Covers.
+func covers(a *geo.Geography, b *geo.Geography) (bool, error) {
 	aRegions, err := a.AsS2()
 	if err != nil {
 		return false, err
@@ -75,7 +83,10 @@ func Covers(a *geo.Geography, b *geo.Geography) (bool, error) {
 // CoveredBy returns whether geography A is covered by geography B.
 // See Covers for limitations.
 func CoveredBy(a *geo.Geography, b *geo.Geography) (bool, error) {
-	return Covers(b, a)
+	if a.SRID() != b.SRID() {
+		return false, geo.NewMismatchingSRIDsError(a, b)
+	}
+	return covers(b, a)
 }
 
 // regionCovers returns whether aRegion completely covers bRegion.

--- a/pkg/geo/geogfn/covers_test.go
+++ b/pkg/geo/geogfn/covers_test.go
@@ -372,4 +372,11 @@ func TestCovers(t *testing.T) {
 			require.Equal(t, tc.expected, coveredBy)
 		})
 	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := Covers(mismatchingSRIDGeographyA, mismatchingSRIDGeographyB)
+		requireMismatchingSRIDError(t, err)
+		_, err = CoveredBy(mismatchingSRIDGeographyA, mismatchingSRIDGeographyB)
+		requireMismatchingSRIDError(t, err)
+	})
 }

--- a/pkg/geo/geogfn/distance.go
+++ b/pkg/geo/geogfn/distance.go
@@ -33,6 +33,10 @@ const (
 func Distance(
 	a *geo.Geography, b *geo.Geography, useSphereOrSpheroid useSphereOrSpheroid,
 ) (float64, error) {
+	if a.SRID() != b.SRID() {
+		return 0, geo.NewMismatchingSRIDsError(a, b)
+	}
+
 	aRegions, err := a.AsS2()
 	if err != nil {
 		return 0, err

--- a/pkg/geo/geogfn/distance_test.go
+++ b/pkg/geo/geogfn/distance_test.go
@@ -265,4 +265,9 @@ func TestDistance(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := Distance(mismatchingSRIDGeographyA, mismatchingSRIDGeographyB, UseSpheroid)
+		requireMismatchingSRIDError(t, err)
+	})
 }

--- a/pkg/geo/geogfn/dwithin.go
+++ b/pkg/geo/geogfn/dwithin.go
@@ -21,6 +21,10 @@ import (
 func DWithin(
 	a *geo.Geography, b *geo.Geography, distance float64, useSphereOrSpheroid useSphereOrSpheroid,
 ) (bool, error) {
+	if a.SRID() != b.SRID() {
+		return false, geo.NewMismatchingSRIDsError(a, b)
+	}
+
 	aRegions, err := a.AsS2()
 	if err != nil {
 		return false, err

--- a/pkg/geo/geogfn/dwithin_test.go
+++ b/pkg/geo/geogfn/dwithin_test.go
@@ -96,4 +96,9 @@ func TestDWithin(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := DWithin(mismatchingSRIDGeographyA, mismatchingSRIDGeographyB, 0, UseSpheroid)
+		requireMismatchingSRIDError(t, err)
+	})
 }

--- a/pkg/geo/geogfn/geogfn_test.go
+++ b/pkg/geo/geogfn/geogfn_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geogfn
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/stretchr/testify/require"
+)
+
+var mismatchingSRIDGeographyA = geo.MustParseGeography("SRID=3857;POINT(1.0 1.0)")
+var mismatchingSRIDGeographyB = geo.MustParseGeography("SRID=4326;LINESTRING(1.0 1.0, 2.0 2.0)")
+
+// requireMismatchingSRIDError checks errors fall as expected for mismatching SRIDs.
+func requireMismatchingSRIDError(t *testing.T, err error) {
+	require.Error(t, err)
+	require.EqualError(t, err, `operation on mixed SRIDs forbidden: (Point, 3857) != (LineString, 4326)`)
+}

--- a/pkg/geo/geogfn/intersects.go
+++ b/pkg/geo/geogfn/intersects.go
@@ -21,6 +21,10 @@ import (
 // This calculation is done on the sphere.
 // Precision of intersect measurements is up to 1cm.
 func Intersects(a *geo.Geography, b *geo.Geography) (bool, error) {
+	if a.SRID() != b.SRID() {
+		return false, geo.NewMismatchingSRIDsError(a, b)
+	}
+
 	aRegions, err := a.AsS2()
 	if err != nil {
 		return false, err

--- a/pkg/geo/geogfn/intersects_test.go
+++ b/pkg/geo/geogfn/intersects_test.go
@@ -277,4 +277,9 @@ func TestIntersects(t *testing.T) {
 			require.Equal(t, tc.expected, intersects)
 		})
 	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := Intersects(mismatchingSRIDGeographyA, mismatchingSRIDGeographyB)
+		requireMismatchingSRIDError(t, err)
+	})
 }

--- a/pkg/geo/geomfn/binary_operators.go
+++ b/pkg/geo/geomfn/binary_operators.go
@@ -17,5 +17,8 @@ import (
 
 // MinDistance returns the minimum distance between geometries A and B.
 func MinDistance(a *geo.Geometry, b *geo.Geometry) (float64, error) {
+	if a.SRID() != b.SRID() {
+		return 0, geo.NewMismatchingSRIDsError(a, b)
+	}
 	return geos.MinDistance(a.EWKB(), b.EWKB())
 }

--- a/pkg/geo/geomfn/binary_operators_test.go
+++ b/pkg/geo/geomfn/binary_operators_test.go
@@ -136,4 +136,9 @@ func TestMinDistance(t *testing.T) {
 			require.Equal(t, tc.expected, ret)
 		})
 	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := MinDistance(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
 }

--- a/pkg/geo/geomfn/binary_predicates.go
+++ b/pkg/geo/geomfn/binary_predicates.go
@@ -17,45 +17,72 @@ import (
 
 // Covers returns whether geometry A covers geometry B.
 func Covers(a *geo.Geometry, b *geo.Geometry) (bool, error) {
+	if a.SRID() != b.SRID() {
+		return false, geo.NewMismatchingSRIDsError(a, b)
+	}
 	return geos.Covers(a.EWKB(), b.EWKB())
 }
 
 // CoveredBy returns whether geometry A is covered by geometry B.
 func CoveredBy(a *geo.Geometry, b *geo.Geometry) (bool, error) {
+	if a.SRID() != b.SRID() {
+		return false, geo.NewMismatchingSRIDsError(a, b)
+	}
 	return geos.CoveredBy(a.EWKB(), b.EWKB())
 }
 
 // Contains returns whether geometry A contains geometry B.
 func Contains(a *geo.Geometry, b *geo.Geometry) (bool, error) {
+	if a.SRID() != b.SRID() {
+		return false, geo.NewMismatchingSRIDsError(a, b)
+	}
 	return geos.Contains(a.EWKB(), b.EWKB())
 }
 
 // Crosses returns whether geometry A crosses geometry B.
 func Crosses(a *geo.Geometry, b *geo.Geometry) (bool, error) {
+	if a.SRID() != b.SRID() {
+		return false, geo.NewMismatchingSRIDsError(a, b)
+	}
 	return geos.Crosses(a.EWKB(), b.EWKB())
 }
 
 // Equals returns whether geometry A equals geometry B.
 func Equals(a *geo.Geometry, b *geo.Geometry) (bool, error) {
+	if a.SRID() != b.SRID() {
+		return false, geo.NewMismatchingSRIDsError(a, b)
+	}
 	return geos.Equals(a.EWKB(), b.EWKB())
 }
 
 // Intersects returns whether geometry A intersects geometry B.
 func Intersects(a *geo.Geometry, b *geo.Geometry) (bool, error) {
+	if a.SRID() != b.SRID() {
+		return false, geo.NewMismatchingSRIDsError(a, b)
+	}
 	return geos.Intersects(a.EWKB(), b.EWKB())
 }
 
 // Overlaps returns whether geometry A overlaps geometry B.
 func Overlaps(a *geo.Geometry, b *geo.Geometry) (bool, error) {
+	if a.SRID() != b.SRID() {
+		return false, geo.NewMismatchingSRIDsError(a, b)
+	}
 	return geos.Overlaps(a.EWKB(), b.EWKB())
 }
 
 // Touches returns whether geometry A touches geometry B.
 func Touches(a *geo.Geometry, b *geo.Geometry) (bool, error) {
+	if a.SRID() != b.SRID() {
+		return false, geo.NewMismatchingSRIDsError(a, b)
+	}
 	return geos.Touches(a.EWKB(), b.EWKB())
 }
 
 // Within returns whether geometry A is within geometry B.
 func Within(a *geo.Geometry, b *geo.Geometry) (bool, error) {
+	if a.SRID() != b.SRID() {
+		return false, geo.NewMismatchingSRIDsError(a, b)
+	}
 	return geos.Within(a.EWKB(), b.EWKB())
 }

--- a/pkg/geo/geomfn/binary_predicates_test.go
+++ b/pkg/geo/geomfn/binary_predicates_test.go
@@ -45,6 +45,11 @@ func TestCovers(t *testing.T) {
 			require.Equal(t, tc.expected, g)
 		})
 	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := Covers(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
 }
 
 func TestCoveredBy(t *testing.T) {
@@ -65,6 +70,11 @@ func TestCoveredBy(t *testing.T) {
 			require.Equal(t, tc.expected, g)
 		})
 	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := CoveredBy(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
 }
 
 func TestContains(t *testing.T) {
@@ -85,6 +95,11 @@ func TestContains(t *testing.T) {
 			require.Equal(t, tc.expected, g)
 		})
 	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := Contains(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
 }
 
 func TestCrosses(t *testing.T) {
@@ -107,6 +122,11 @@ func TestCrosses(t *testing.T) {
 			require.Equal(t, tc.expected, g)
 		})
 	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := Crosses(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
 }
 
 func TestEquals(t *testing.T) {
@@ -128,6 +148,11 @@ func TestEquals(t *testing.T) {
 			require.Equal(t, tc.expected, g)
 		})
 	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := Equals(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
 }
 
 func TestIntersects(t *testing.T) {
@@ -151,6 +176,11 @@ func TestIntersects(t *testing.T) {
 			require.Equal(t, tc.expected, g)
 		})
 	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := Intersects(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
 }
 
 func TestOverlaps(t *testing.T) {
@@ -172,6 +202,11 @@ func TestOverlaps(t *testing.T) {
 			require.Equal(t, tc.expected, g)
 		})
 	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := Overlaps(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
 }
 
 func TestTouches(t *testing.T) {
@@ -192,6 +227,11 @@ func TestTouches(t *testing.T) {
 			require.Equal(t, tc.expected, g)
 		})
 	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := Touches(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
 }
 
 func TestWithin(t *testing.T) {
@@ -212,4 +252,9 @@ func TestWithin(t *testing.T) {
 			require.Equal(t, tc.expected, g)
 		})
 	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := Within(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
 }

--- a/pkg/geo/geomfn/geomfn_test.go
+++ b/pkg/geo/geomfn/geomfn_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/stretchr/testify/require"
+)
+
+var mismatchingSRIDGeometryA = geo.MustParseGeometry("SRID=3857;POINT(1.0 1.0)")
+var mismatchingSRIDGeometryB = geo.MustParseGeometry("SRID=4326;LINESTRING(1.0 1.0, 2.0 2.0)")
+
+// requireMismatchingSRIDError checks errors fall as expected for mismatching SRIDs.
+func requireMismatchingSRIDError(t *testing.T, err error) {
+	require.Error(t, err)
+	require.EqualError(t, err, `operation on mixed SRIDs forbidden: (Point, 3857) != (LineString, 4326)`)
+}


### PR DESCRIPTION
When operating on more than one geo type, we must ensure that if we compare
SRIDs that mismatch, we report an error. We've done this for all binary
predicates implemented so far in Geometry and Geography.

Furthermore, this PR adds an interface for Geospatial types. It makes
things a little bit neater, and we can extend this as we go along.

Release note: None