### PR TITLE
release-20.1: server: ignore SRV results with port 0 for --join list lookups

### DIFF
--- a/pkg/gossip/resolver/resolver.go
+++ b/pkg/gossip/resolver/resolver.go
@@ -55,7 +55,6 @@ func SRV(ctx context.Context, name string) ([]string, error) {
 	}
 
 	if name == "" {
-		// nolint:returnerrcheck
 		return nil, nil
 	}
 
@@ -73,9 +72,11 @@ func SRV(ctx context.Context, name string) ([]string, error) {
 		return nil, nil
 	}
 
-	var addrs = make([]string, len(recs))
-	for i, r := range recs {
-		addrs[i] = net.JoinHostPort(r.Target, fmt.Sprintf("%d", r.Port))
+	addrs := []string{}
+	for _, r := range recs {
+		if r.Port != 0 {
+			addrs = append(addrs, net.JoinHostPort(r.Target, fmt.Sprintf("%d", r.Port)))
+		}
 	}
 
 	return addrs, nil

--- a/pkg/gossip/resolver/resolver_test.go
+++ b/pkg/gossip/resolver/resolver_test.go
@@ -109,6 +109,7 @@ func TestSRV(t *testing.T) {
 		srvs := []*net.SRV{
 			{Target: "node1", Port: 26222},
 			{Target: "node2", Port: 35222},
+			{Target: "node3", Port: 0},
 		}
 
 		return "cluster", srvs, nil


### PR DESCRIPTION
Backport 1/1 commits from #48325.

/cc @cockroachdb/release

---

In the real world it is possible to get an SRV result with port 0 which does not make practical sense and leads to unnecessary attempts to open a connection to that port. Now SRV
records with port 0 are ignored.

