### PR TITLE
logictest: add 3node-tenant as default config

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -475,7 +475,10 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 
 	dummyRecorder := &status.MetricsRecorder{}
 
-	const fakeNodeID = roachpb.NodeID(9999)
+	// TODO(asubiotto): Jobs don't play well with a weird node ID in a multitenant
+	//  environment, so a node ID of 1 is used here to get tests to pass. Fixing
+	//  this is tracked in https://github.com/cockroachdb/cockroach/issues/47892.
+	const fakeNodeID = roachpb.NodeID(1)
 	var c base.NodeIDContainer
 	c.Set(context.Background(), fakeNodeID)
 	const sqlInstanceID = base.SQLInstanceID(10001)

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -109,6 +109,17 @@ import (
 // logicTestConfigs. If the directive is missing, the test is run in the
 // default configuration.
 //
+// The directive also supports blacklists, i.e. running all specified
+// configurations apart from a blacklisted configuration:
+//
+//   # LogicTest: default-configs !3node-tenant
+//
+// If a blacklist is specified without an accompanying configuration, the
+// default config is assumed. i.e., the following directive is equivalent to the
+// one above:
+//
+//   # LogicTest: !3node-tenant
+//
 // The Test-Script language is extended here for use with CockroachDB. The
 // supported directives are:
 //
@@ -554,10 +565,19 @@ var logicTestConfigs = []testClusterConfig{
 		skipShort:           true,
 	},
 	{
-		name:      "3node-tenant",
-		numNodes:  3,
-		useTenant: true,
+		name:              "3node-tenant",
+		numNodes:          3,
+		overrideAutoStats: "false",
+		useTenant:         true,
 	},
+}
+
+var logicTestConfigIdxToName = make(map[logicTestConfigIdx]string)
+
+func init() {
+	for i, cfg := range logicTestConfigs {
+		logicTestConfigIdxToName[logicTestConfigIdx(i)] = cfg.name
+	}
 }
 
 func parseTestConfig(names []string) []logicTestConfigIdx {
@@ -1345,6 +1365,70 @@ CREATE DATABASE test;
 	t.unsupported = 0
 }
 
+// applyBlacklistToConfigIdxs applies the given blacklist to config idxs,
+// returning the result.
+func applyBlacklistToConfigIdxs(
+	configIdxs []logicTestConfigIdx, blacklist map[string]struct{},
+) []logicTestConfigIdx {
+	if len(blacklist) == 0 {
+		return configIdxs
+	}
+	var newConfigIdxs []logicTestConfigIdx
+	for _, idx := range configIdxs {
+		if _, ok := blacklist[logicTestConfigIdxToName[idx]]; ok {
+			continue
+		}
+		newConfigIdxs = append(newConfigIdxs, idx)
+	}
+	return newConfigIdxs
+}
+
+// processConfigs, given a list of configNames, returns the list of
+// corresponding logicTestConfigIdxs.
+func processConfigs(t *testing.T, path string, configNames []string) []logicTestConfigIdx {
+	const blacklistChar = '!'
+	blacklist := make(map[string]struct{})
+	allConfigNamesAreBlacklistDirectives := true
+	for _, configName := range configNames {
+		if configName[0] != blacklistChar {
+			allConfigNamesAreBlacklistDirectives = false
+			continue
+		}
+		blacklist[configName[1:]] = struct{}{}
+	}
+
+	var configs []logicTestConfigIdx
+	if len(blacklist) != 0 && allConfigNamesAreBlacklistDirectives {
+		// No configs specified, this blacklist applies to the default config.
+		return applyBlacklistToConfigIdxs(defaultConfig, blacklist)
+	}
+
+	for _, configName := range configNames {
+		if configName[0] == blacklistChar {
+			continue
+		}
+		if _, ok := blacklist[configName]; ok {
+			continue
+		}
+
+		idx, ok := findLogicTestConfig(configName)
+		if !ok {
+			switch configName {
+			case defaultConfigName:
+				configs = append(configs, applyBlacklistToConfigIdxs(defaultConfig, blacklist)...)
+			case fiveNodeDefaultConfigName:
+				configs = append(configs, applyBlacklistToConfigIdxs(fiveNodeDefaultConfig, blacklist)...)
+			default:
+				t.Fatalf("%s: unknown config name %s", path, configName)
+			}
+		} else {
+			configs = append(configs, idx)
+		}
+	}
+
+	return configs
+}
+
 // readTestFileConfigs reads any LogicTest directive at the beginning of a
 // test file. A line that starts with "# LogicTest:" specifies a list of
 // configuration names. The test file is run against each of those
@@ -1378,23 +1462,7 @@ func readTestFileConfigs(t *testing.T, path string) []logicTestConfigIdx {
 			if len(fields) == 2 {
 				t.Fatalf("%s: empty LogicTest directive", path)
 			}
-			var configs []logicTestConfigIdx
-			for _, configName := range fields[2:] {
-				idx, ok := findLogicTestConfig(configName)
-				if !ok {
-					switch configName {
-					case defaultConfigName:
-						configs = append(configs, defaultConfig...)
-					case fiveNodeDefaultConfigName:
-						configs = append(configs, fiveNodeDefaultConfig...)
-					default:
-						t.Fatalf("%s: unknown config name %s", path, configName)
-					}
-				} else {
-					configs = append(configs, idx)
-				}
-			}
-			return configs
+			return processConfigs(t, path, fields[2:])
 		}
 	}
 	// No directive found, return the default config.

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -565,8 +565,10 @@ var logicTestConfigs = []testClusterConfig{
 		skipShort:           true,
 	},
 	{
-		name:              "3node-tenant",
-		numNodes:          3,
+		name:     "3node-tenant",
+		numNodes: 3,
+		// overrideAutoStats will disable automatic stats on the cluster this tenant
+		// is connected to.
 		overrideAutoStats: "false",
 		useTenant:         true,
 	},
@@ -605,6 +607,7 @@ var (
 		"fakedist-vec-auto-disk",
 		"fakedist-metadata",
 		"fakedist-disk",
+		"3node-tenant",
 	}
 	// fiveNodeDefaultConfigName is a special alias for all 5 node configs.
 	fiveNodeDefaultConfigName  = "5node-default-configs"

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1,3 +1,7 @@
+# 3node-tenant fails due to
+# https://github.com/cockroachdb/cockroach/issues/47900.
+# LogicTest: !3node-tenant
+
 statement ok
 SET experimental_enable_hash_sharded_indexes = true
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1,3 +1,5 @@
+# LogicTest: !3node-tenant
+
 statement ok
 CREATE TABLE other (b INT PRIMARY KEY)
 

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1,3 +1,9 @@
+# 3node-tenant fails due to:
+# https://github.com/cockroachdb/cockroach/issues/48375
+# Specifically, a status server is unavailable when attempting to set a zone
+# config.
+# LogicTest: !3node-tenant
+
 statement ok
 CREATE TABLE foo (a int)
 

--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -1,3 +1,6 @@
+# This test times out when run with 3node-tenant.
+# LogicTest: !3node-tenant
+
 # The tests in this file target the legacy FK paths.
 statement ok
 SET optimizer_foreign_keys = false

--- a/pkg/sql/logictest/testdata/logic_test/cascade_opt
+++ b/pkg/sql/logictest/testdata/logic_test/cascade_opt
@@ -1,3 +1,6 @@
+# This test times out when run with 3node-tenant.
+# LogicTest: !3node-tenant
+
 # The tests in this file target the new optimizer-driven FK paths (with
 # fall back on the legacy paths for unsupported cases).
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1,3 +1,4 @@
+# LogicTest: !3node-tenant
 query error database "crdb_internal" does not exist
 ALTER DATABASE crdb_internal RENAME TO not_crdb_internal
 

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -1,3 +1,4 @@
+# LogicTest: !3node-tenant
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -1,3 +1,4 @@
+# LogicTest: !3node-tenant
 ##################
 # TABLE DDL
 ##################

--- a/pkg/sql/logictest/testdata/logic_test/family
+++ b/pkg/sql/logictest/testdata/logic_test/family
@@ -1,3 +1,4 @@
+# LogicTest: !3node-tenant
 # a is the primary key so b gets optimized into a one column value. The c, d
 # family has two columns, so it's encoded as a tuple
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -1,3 +1,4 @@
+# LogicTest: !3node-tenant
 # The tests in this file target the legacy FK paths.
 statement ok
 SET optimizer_foreign_keys = false

--- a/pkg/sql/logictest/testdata/logic_test/jobs
+++ b/pkg/sql/logictest/testdata/logic_test/jobs
@@ -1,3 +1,8 @@
+# 3node-tenant fails due to AUTO STATS being returned in SHOW JOBS. Changing
+# the cluster setting to disable auto stats doesn't work:
+# https://github.com/cockroachdb/cockroach/issues/47918
+# LogicTest: !3node-tenant
+
 # These test verify that a user's job are visible via
 # crdb_internal.jobs and SHOW JOBS.
 

--- a/pkg/sql/logictest/testdata/logic_test/privileges_comments
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_comments
@@ -1,3 +1,4 @@
+# LogicTest: !3node-tenant
 # Disable automatic stats to avoid flakiness.
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false

--- a/pkg/sql/logictest/testdata/logic_test/privileges_table
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_table
@@ -1,3 +1,4 @@
+# LogicTest: !3node-tenant
 # Disable automatic stats to avoid flakiness.
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false

--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -1,3 +1,7 @@
+# This and all the rename_* variants fail due to
+# https://github.com/cockroachdb/cockroach/issues/47900. Specifically, being
+# unable to access a node ID during EXPLAIN.
+# LogicTest: !3node-tenant
 statement ok
 CREATE TABLE users (
   uid    INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -1,3 +1,4 @@
+# LogicTest: !3node-tenant
 query T
 SHOW DATABASES
 ----

--- a/pkg/sql/logictest/testdata/logic_test/rename_index
+++ b/pkg/sql/logictest/testdata/logic_test/rename_index
@@ -1,3 +1,4 @@
+# LogicTest: !3node-tenant
 statement ok
 CREATE TABLE users (
   id    INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -1,3 +1,4 @@
+# LogicTest: !3node-tenant
 statement error pgcode 42P01 relation "foo" does not exist
 ALTER TABLE foo RENAME TO bar
 

--- a/pkg/sql/logictest/testdata/logic_test/run_control
+++ b/pkg/sql/logictest/testdata/logic_test/run_control
@@ -1,3 +1,4 @@
+# LogicTest: !3node-tenant
 query error job with ID 1 does not exist
 PAUSE JOB 1
 

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1,3 +1,4 @@
+# LogicTest: !3node-tenant
 # Disable automatic stats to avoid flakiness (sometimes causes retry errors).
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_retry
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_retry
@@ -1,3 +1,4 @@
+# LogicTest: !3node-tenant
 # This test reproduces https://github.com/cockroachdb/cockroach/issues/23979
 
 # Schema changes that experienced retriable errors in RELEASE

--- a/pkg/sql/logictest/testdata/logic_test/sqlsmith
+++ b/pkg/sql/logictest/testdata/logic_test/sqlsmith
@@ -1,3 +1,4 @@
+# LogicTest: !3node-tenant
 # This file contains regression tests discovered by sqlsmith.
 
 

--- a/pkg/sql/logictest/testdata/logic_test/truncate
+++ b/pkg/sql/logictest/testdata/logic_test/truncate
@@ -1,3 +1,4 @@
+# LogicTest: !3node-tenant
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/values
+++ b/pkg/sql/logictest/testdata/logic_test/values
@@ -1,3 +1,4 @@
+# LogicTest: !3node-tenant
 # Tests for the implicit one row, zero column values operator.
 query I
 SELECT 1

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -1,4 +1,4 @@
-# LogicTest: default-configs 5node-default-configs
+# LogicTest: default-configs !3node-tenant 5node-default-configs
 
 statement ok
 CREATE TABLE kv (

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -1,3 +1,4 @@
+# LogicTest: !3node-tenant
 # Check that we can alter the default zone config.
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -1,3 +1,4 @@
+# LogicTest: !3node-tenant
 query TTT
 EXPLAIN SELECT * FROM pg_catalog.pg_class WHERE oid = 50
 ----


### PR DESCRIPTION
Closes #47901

The logic test directive now supports syntax to blacklist a configuration, i.e.
running all specified configurations apart from a blacklisted configuration:
```
 # LogicTest: default-configs !3node-tenant
```
If a blacklist is specified without an accompanying configuration, the
default config is assumed. i.e., the following directive is equivalent to the
one above:
```
 # LogicTest: !3node-tenant
```

The second commit adds the `3node-tenant` config to the list of default
configs and adds it as a blacklist in any files that fail under this config.

Release note: None (testing change)