### PR TITLE
sql: fix bug where DROP TABLE on a type name panicked

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -34,3 +34,7 @@ SELECT * FROM db2.t
 
 statement error pq: type "db2.public.t" already exists
 CREATE TYPE db2.t AS ENUM ()
+
+# Regression for #48537. Dropping a table with a type name caused a panic.
+statement error pq: relation "t" does not exist
+DROP TABLE t

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -247,7 +247,11 @@ func (tc *TableCollection) getMutableTableDescriptor(
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*sqlbase.MutableTableDescriptor), err
+	mutDesc, ok := obj.(*sqlbase.MutableTableDescriptor)
+	if !ok {
+		return nil, err
+	}
+	return mutDesc, nil
 }
 
 // resolveSchemaID attempts to lookup the schema from the schemaCache if it exists,


### PR DESCRIPTION
Fixes a bug where mutable access to a type but expecting
a table panicked.

Fixes #48537.

Release note: None