### PR TITLE
colexec: clean up materializer a bit

### DIFF
--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -66,7 +66,6 @@ func wrapRowSources(
 				processorID,
 				input,
 				inputTypes[i],
-				&execinfrapb.PostProcessSpec{},
 				nil, /* output */
 				nil, /* metadataSourcesQueue */
 				nil, /* toClose */

--- a/pkg/sql/colexec/materializer_test.go
+++ b/pkg/sql/colexec/materializer_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
-	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -54,7 +53,6 @@ func TestColumnarizeMaterialize(t *testing.T) {
 		1, /* processorID */
 		c,
 		typs,
-		&execinfrapb.PostProcessSpec{},
 		nil, /* output */
 		nil, /* metadataSourcesQueue */
 		nil, /* toClose */
@@ -140,7 +138,6 @@ func TestMaterializeTypes(t *testing.T) {
 		1, /* processorID */
 		c,
 		typs,
-		&execinfrapb.PostProcessSpec{},
 		nil, /* output */
 		nil, /* metadataSourcesQueue */
 		nil, /* toClose */
@@ -195,7 +192,6 @@ func BenchmarkColumnarizeMaterialize(b *testing.B) {
 			1, /* processorID */
 			c,
 			types,
-			&execinfrapb.PostProcessSpec{},
 			nil, /* output */
 			nil, /* metadataSourcesQueue */
 			nil, /* toClose */

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
-	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -90,7 +89,6 @@ func TestSupportedSQLTypesIntegration(t *testing.T) {
 				1, /* processorID */
 				arrowOp,
 				typs,
-				&execinfrapb.PostProcessSpec{},
 				output,
 				nil, /* metadataSourcesQueue */
 				nil, /* toClose */

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -890,7 +890,6 @@ func (s *vectorizedFlowCreator) setupOutput(
 			pspec.ProcessorID,
 			op,
 			columnTypes,
-			&execinfrapb.PostProcessSpec{},
 			s.syncFlowConsumer,
 			metadataSourcesQueue,
 			toClose,

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -303,7 +303,6 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					1, /* processorID */
 					materializerInput,
 					typs,
-					&execinfrapb.PostProcessSpec{},
 					nil, /* output */
 					materializerMetadataSources,
 					[]colexec.IdempotentCloser{callbackCloser{closeCb: func() error {

--- a/pkg/sql/colflow/vectorized_meta_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_meta_propagation_test.go
@@ -76,7 +76,6 @@ func TestVectorizedMetaPropagation(t *testing.T) {
 		2, /* processorID */
 		noop,
 		types,
-		&execinfrapb.PostProcessSpec{},
 		nil, /* output */
 		[]execinfrapb.MetadataSource{col},
 		nil, /* toClose */

--- a/pkg/sql/colflow/vectorized_panic_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_panic_propagation_test.go
@@ -58,7 +58,6 @@ func TestVectorizedInternalPanic(t *testing.T) {
 		1, /* processorID */
 		vee,
 		types,
-		&execinfrapb.PostProcessSpec{},
 		nil, /* output */
 		nil, /* metadataSourceQueue */
 		nil, /* toClose */
@@ -106,7 +105,6 @@ func TestNonVectorizedPanicPropagation(t *testing.T) {
 		1, /* processorID */
 		nvee,
 		types,
-		&execinfrapb.PostProcessSpec{},
 		nil, /* output */
 		nil, /* metadataSourceQueue */
 		nil, /* toClose */

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -144,7 +144,6 @@ func verifyColOperator(args verifyColOperatorArgs) error {
 		int32(len(args.inputs))+2,
 		result.Op,
 		args.outputTypes,
-		&execinfrapb.PostProcessSpec{},
 		nil, /* output */
 		result.MetadataSources,
 		nil, /* toClose */

--- a/pkg/sql/distsql/vectorized_panic_propagation_test.go
+++ b/pkg/sql/distsql/vectorized_panic_propagation_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colflow"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
-	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
@@ -60,7 +59,6 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 			},
 		},
 		nil, /* typs */
-		&execinfrapb.PostProcessSpec{},
 		&distsqlutils.RowBuffer{},
 		nil, /* metadataSourceQueue */
 		nil, /* toClose */

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -244,7 +244,6 @@ func TestEval(t *testing.T) {
 				0, /* processorID */
 				result.Op,
 				typs,
-				&execinfrapb.PostProcessSpec{},
 				nil, /* output */
 				nil, /* metadataSourcesQueue */
 				nil, /* toClose */


### PR DESCRIPTION
While working on cfetcher + materializer instead of table reader,
I noticed something weird - that we get `OutputTypes` in the
materializer, and use those when converting physical vectors to datums.
I thought this was a bug because `OutputTypes` returns the type schema
after post-processing stage, and internal type schema of a processor
could be different. It turns out we simply always pass in empty
`PostProcessSpec` into the materializer because we expect the input
operator to handle the post-processing itself. This commit cleans it up
by removing that unused argument and the call to `ProcessRowHelper`.

Release note: None