### PR TITLE
geo: allow case insensitive SRID= at the start of EWKT

### DIFF
--- a/pkg/geo/parse.go
+++ b/pkg/geo/parse.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/geo/geos"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/twpayne/go-geom"
 	"github.com/twpayne/go-geom/encoding/ewkb"
 	"github.com/twpayne/go-geom/encoding/ewkbhex"
@@ -154,7 +155,7 @@ func parseEWKT(
 	str geopb.EWKT, defaultSRID geopb.SRID, overwrite defaultSRIDOverwriteSetting,
 ) (geopb.SpatialObject, error) {
 	srid := defaultSRID
-	if strings.HasPrefix(string(str), sridPrefix) {
+	if hasPrefixIgnoreCase(string(str), sridPrefix) {
 		end := strings.Index(string(str[sridPrefixLen:]), ";")
 		if end != -1 {
 			if overwrite != DefaultSRIDShouldOverwrite {
@@ -182,4 +183,18 @@ func parseEWKT(
 		return geopb.SpatialObject{}, err
 	}
 	return parseEWKBRaw(ewkb)
+}
+
+// hasPrefixIgnoreCase returns whether a given str begins with a prefix, ignoring case.
+// It assumes that the string and prefix contains only ASCII bytes.
+func hasPrefixIgnoreCase(str string, prefix string) bool {
+	if len(str) < len(prefix) {
+		return false
+	}
+	for i := 0; i < len(prefix); i++ {
+		if util.ToLowerSingleByte(str[i]) != util.ToLowerSingleByte(prefix[i]) {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/geo/parse_test.go
+++ b/pkg/geo/parse_test.go
@@ -192,6 +192,17 @@ func TestParseGeometry(t *testing.T) {
 			"",
 		},
 		{
+			"SRid=3857;POINT(1.0 1.0)",
+			&Geometry{
+				SpatialObject: geopb.SpatialObject{
+					EWKB:  []byte("\x01\x01\x00\x00\x20\x11\x0F\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),
+					SRID:  3857,
+					Shape: geopb.Shape_Point,
+				},
+			},
+			"",
+		},
+		{
 			"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f",
 			&Geometry{
 				SpatialObject: geopb.SpatialObject{

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -30,3 +30,12 @@ func GetSingleRune(s string) (rune, error) {
 	}
 	return r, nil
 }
+
+// ToLowerSingleByte returns the the lowercase of a given single ASCII byte.
+// A non ASCII byte is returned unchanged.
+func ToLowerSingleByte(b byte) byte {
+	if b >= 'A' && b <= 'Z' {
+		return 'a' + (b - 'A')
+	}
+	return b
+}

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -10,7 +10,11 @@
 
 package util
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestGetSingleRune(t *testing.T) {
 	tests := []struct {
@@ -32,6 +36,28 @@ func TestGetSingleRune(t *testing.T) {
 			if tc.expected != got {
 				t.Fatalf("expected %v, got %v", tc.expected, got)
 			}
+		})
+	}
+}
+
+func TestToLowerSingleByte(t *testing.T) {
+	testCases := []struct {
+		from     byte
+		expected byte
+	}{
+		{'a', 'a'},
+		{'A', 'a'},
+		{'c', 'c'},
+		{'C', 'c'},
+		{'Z', 'z'},
+		{'1', '1'},
+		{'\n', '\n'},
+	}
+
+	for _, tc := range testCases {
+		t.Run(string(tc.from), func(t *testing.T) {
+			ret := ToLowerSingleByte(tc.from)
+			require.Equal(t, tc.expected, ret)
 		})
 	}
 }


### PR DESCRIPTION
PostGIS allows any combination of `srid` at the beginning of the string.
Follow the same allowance by having a case insensitive HasPrefix.

Release note: None