### PR TITLE
sql: cleanup pgwire datadriven tests

### DIFF
--- a/pkg/sql/pgwire/testdata/pgtest/row_description
+++ b/pkg/sql/pgwire/testdata/pgtest/row_description
@@ -59,7 +59,7 @@ Query {"String": "SELECT a FROM tab1"}
 until
 ReadyForQuery
 ----
-{"Type":"RowDescription","Fields":[{"Name":"a","TableOID":55,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
+{"Type":"RowDescription","Fields":[{"Name":"a","TableOID":52,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
 {"Type":"DataRow","Values":[{"text":"1"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
@@ -71,7 +71,7 @@ Query {"String": "SELECT tab1.a, tab2.c FROM tab1 JOIN tab2 ON tab1.a = tab2.tab
 until
 ReadyForQuery
 ----
-{"Type":"RowDescription","Fields":[{"Name":"a","TableOID":55,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0},{"Name":"c","TableOID":56,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
+{"Type":"RowDescription","Fields":[{"Name":"a","TableOID":52,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0},{"Name":"c","TableOID":53,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
 {"Type":"DataRow","Values":[{"text":"1"},{"text":"4"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
@@ -83,7 +83,7 @@ Query {"String": "SELECT * FROM v WHERE v1 = 1"}
 until
 ReadyForQuery
 ----
-{"Type":"RowDescription","Fields":[{"Name":"v1","TableOID":55,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0},{"Name":"v2","TableOID":56,"TableAttributeNumber":2,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
+{"Type":"RowDescription","Fields":[{"Name":"v1","TableOID":52,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0},{"Name":"v2","TableOID":53,"TableAttributeNumber":2,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
 {"Type":"DataRow","Values":[{"text":"1"},{"text":"1"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/testutils/pgtest/datadriven.go
+++ b/pkg/testutils/pgtest/datadriven.go
@@ -21,9 +21,22 @@ import (
 	"github.com/jackc/pgx/pgproto3"
 )
 
-// Walk walks path for datadriven files and calls RunTest on them.
-func Walk(t *testing.T, path, addr, user string) {
+// WalkWithRunningServer walks path for datadriven files and calls RunTest on them.
+// It is used when an existing server is desired for each test.
+func WalkWithRunningServer(t *testing.T, path, addr, user string) {
 	datadriven.Walk(t, path, func(t *testing.T, path string) {
+		RunTest(t, path, addr, user)
+	})
+}
+
+// WalkWithNewServer walks path for datadriven files and calls RunTest on them,
+// but creates a new server for each test file.
+func WalkWithNewServer(
+	t *testing.T, path string, newServer func() (addr, user string, cleanup func()),
+) {
+	datadriven.Walk(t, path, func(t *testing.T, path string) {
+		addr, user, cleanup := newServer()
+		defer cleanup()
 		RunTest(t, path, addr, user)
 	})
 }


### PR DESCRIPTION
This PR adjusts the pgwire datadriven tests to create a new test
server for each file, rather than sharing the same one. Sharing
the same file causes the files to depend on eachother, causing
spurious failures when editing them (for example in #48455).

Release note: None