### PR TITLE
rowexec: remove redundant err check

### DIFF
--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -150,9 +150,6 @@ func (ag *aggregatorBase) init(
 				return errors.Wrapf(err, "%s", argument)
 			}
 			argTypes[len(aggInfo.ColIdx)+j] = d.ResolvedType()
-			if err != nil {
-				return errors.Wrapf(err, "%s", argument)
-			}
 			arguments[j] = d
 		}
 


### PR DESCRIPTION
It seems like a leftover from some refactor.

Release note: None