### PR TITLE
rowcontainer: row container for inverted index computations

### DIFF
--- a/pkg/kv/kvserver/diskmap/disk_map.go
+++ b/pkg/kv/kvserver/diskmap/disk_map.go
@@ -70,7 +70,8 @@ type SortedDiskMapBatchWriter interface {
 	// Flush flushes all writes to the underlying store. The batch can be reused
 	// after a call to Flush().
 	Flush() error
-
+	// The number of put calls since the last time the writer was flushed.
+	NumPutsSinceFlush() int
 	// Close flushes all writes to the underlying store and frees up resources
 	// held by the batch writer.
 	Close(context.Context) error

--- a/pkg/sql/rowcontainer/disk_row_container_test.go
+++ b/pkg/sql/rowcontainer/disk_row_container_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	math "math"
 	"math/rand"
+	"sort"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -29,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
 )
 
 // compareRows compares l and r according to a column ordering. Returns -1 if
@@ -238,6 +240,127 @@ func TestDiskRowContainer(t *testing.T) {
 			}()
 		}
 	})
+
+	t.Run("DeDupingRowContainer", func(t *testing.T) {
+		numCols := 2
+		numRows := 10
+		ordering := sqlbase.ColumnOrdering{
+			sqlbase.ColumnOrderInfo{
+				ColIdx:    0,
+				Direction: encoding.Ascending,
+			},
+			sqlbase.ColumnOrderInfo{
+				ColIdx:    1,
+				Direction: encoding.Descending,
+			},
+		}
+		// Use random types and random rows.
+		types := sqlbase.RandSortingTypes(rng, numCols)
+		numRows, rows := makeUniqueRows(t, &evalCtx, rng, numRows, types, ordering)
+		d := MakeDiskRowContainer(&diskMonitor, types, ordering, tempEngine)
+		defer d.Close(ctx)
+		d.DoDeDuplicate()
+		addRowsRepeatedly := func() {
+			// Add some number of de-duplicated rows using AddRow() to exercise the
+			// code path in DiskRowContainer that gets exercised by
+			// DiskBackedRowContainer when it spills from memory to disk.
+			addRowCalls := rng.Intn(numRows)
+			for i := 0; i < addRowCalls; i++ {
+				require.NoError(t, d.AddRow(ctx, rows[i]))
+				require.Equal(t, d.bufferedRows.NumPutsSinceFlush(), len(d.deDupCache))
+			}
+			// Repeatedly add the same set of rows.
+			for i := 0; i < 3; i++ {
+				if i == 2 && rng.Intn(2) == 0 {
+					// Clear the de-dup cache so that a SortedDiskMapIterator is needed
+					// to de-dup.
+					d.testingFlushBuffer(ctx)
+				}
+				for j := 0; j < numRows; j++ {
+					idx, err := d.AddRowWithDeDup(ctx, rows[j])
+					require.NoError(t, err)
+					require.Equal(t, j, idx)
+				}
+			}
+		}
+		addRowsRepeatedly()
+		// Reset and add the rows in a different order.
+		require.NoError(t, d.UnsafeReset(ctx))
+		rand.Shuffle(len(rows), func(i, j int) {
+			rows[i], rows[j] = rows[j], rows[i]
+		})
+		addRowsRepeatedly()
+	})
+
+	t.Run("NumberedRowIterator", func(t *testing.T) {
+		numCols := 2
+		numRows := 10
+		// Use random types and random rows.
+		types := sqlbase.RandSortingTypes(rng, numCols)
+		rows := sqlbase.RandEncDatumRowsOfTypes(rng, numRows, types)
+		// There are no ordering columns when using the numberedRowIterator.
+		d := MakeDiskRowContainer(&diskMonitor, types, nil, tempEngine)
+		defer d.Close(ctx)
+		for i := 0; i < numRows; i++ {
+			require.NoError(t, d.AddRow(ctx, rows[i]))
+		}
+		require.NotEqual(t, 0, d.MeanEncodedRowBytes())
+		iter := d.newNumberedIterator(ctx)
+		defer iter.Close()
+		// Checks equality of rows[index] and the current position of iter.
+		checkEq := func(index int) {
+			valid, err := iter.Valid()
+			require.True(t, valid)
+			require.NoError(t, err)
+			row, err := iter.Row()
+			require.NoError(t, err)
+			require.Equal(t, rows[index].String(types), row.String(types))
+		}
+		for i := 0; i < numRows; i++ {
+			// Seek to a random position and iterate until the end.
+			index := rng.Intn(numRows)
+			iter.seekToIndex(index)
+			checkEq(index)
+			for index++; index < numRows; index++ {
+				iter.Next()
+				checkEq(index)
+			}
+		}
+	})
+}
+
+// makeUniqueRows can return a row count < numRows (always > 0 when numRows >
+// 0), hence it also returns the actual returned count (to remind the caller).
+func makeUniqueRows(
+	t *testing.T,
+	evalCtx *tree.EvalContext,
+	rng *rand.Rand,
+	numRows int,
+	types []*types.T,
+	ordering sqlbase.ColumnOrdering,
+) (int, sqlbase.EncDatumRows) {
+	rows := sqlbase.RandEncDatumRowsOfTypes(rng, numRows, types)
+	// It is possible there was some duplication, so remove duplicates.
+	var alloc sqlbase.DatumAlloc
+	sort.Slice(rows, func(i, j int) bool {
+		cmp, err := rows[i].Compare(types, &alloc, ordering, evalCtx, rows[j])
+		require.NoError(t, err)
+		return cmp < 0
+	})
+	deDupedRows := rows[:1]
+	for i := 1; i < len(rows); i++ {
+		cmp, err := rows[i].Compare(types, &alloc, ordering, evalCtx, deDupedRows[len(deDupedRows)-1])
+		require.NoError(t, err)
+		if cmp != 0 {
+			deDupedRows = append(deDupedRows, rows[i])
+		}
+	}
+	rows = deDupedRows
+	// Shuffle so that not adding in sorted order.
+	rand.Shuffle(len(rows), func(i, j int) {
+		rows[i], rows[j] = rows[j], rows[i]
+	})
+	return len(rows), rows
 }
 
 func TestDiskRowContainerDiskFull(t *testing.T) {

--- a/pkg/sql/rowcontainer/numbered_row_container.go
+++ b/pkg/sql/rowcontainer/numbered_row_container.go
@@ -1,0 +1,589 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rowcontainer
+
+import (
+	"container/heap"
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/diskmap"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/errors"
+)
+
+// DiskBackedNumberedRowContainer that stores a map from idx => row, where idx is a
+// 0-based dense numbering. Optionally, if deDup is true, it can de-duplicate the
+// rows before assigning a number. It spills to disk if needed.
+type DiskBackedNumberedRowContainer struct {
+	deDup bool
+	rc    *DiskBackedRowContainer
+
+	deduper DeDupingRowContainer
+
+	storedTypes []*types.T
+	idx         int // the index of the next row to be added into the container
+
+	rowIter       *numberedDiskRowIterator
+	rowIterMemAcc mon.BoundAccount
+	DisableCache  bool
+}
+
+// NewDiskBackedNumberedRowContainer creates a DiskBackedNumberedRowContainer.
+//
+// Arguments:
+//  - deDup is true if it should de-duplicate.
+//  - types is the schema of rows that will be added to this container.
+//  - evalCtx defines the context.
+//  - engine is the underlying store that rows are stored on when the container
+//    spills to disk.
+//  - memoryMonitor is used to monitor this container's memory usage.
+//  - diskMonitor is used to monitor this container's disk usage.
+//  - rowCapacity (if not 0) specifies the number of rows in-memory container
+//    should be preallocated for.
+func NewDiskBackedNumberedRowContainer(
+	deDup bool,
+	types []*types.T,
+	evalCtx *tree.EvalContext,
+	engine diskmap.Factory,
+	memoryMonitor *mon.BytesMonitor,
+	diskMonitor *mon.BytesMonitor,
+	rowCapacity int,
+) *DiskBackedNumberedRowContainer {
+	d := &DiskBackedNumberedRowContainer{
+		deDup:         deDup,
+		storedTypes:   types,
+		rowIterMemAcc: memoryMonitor.MakeBoundAccount(),
+	}
+	d.rc = &DiskBackedRowContainer{}
+	d.rc.Init(nil /*ordering*/, types, evalCtx, engine, memoryMonitor, diskMonitor, rowCapacity)
+	if deDup {
+		ordering := make(sqlbase.ColumnOrdering, len(types))
+		for i := range types {
+			ordering[i].ColIdx = i
+			ordering[i].Direction = encoding.Ascending
+		}
+		deduper := &DiskBackedRowContainer{}
+		deduper.Init(ordering, types, evalCtx, engine, memoryMonitor, diskMonitor, rowCapacity)
+		deduper.DoDeDuplicate()
+		d.deduper = deduper
+	}
+	return d
+}
+
+// Len returns the number of rows in this container.
+func (d *DiskBackedNumberedRowContainer) Len() int {
+	return d.idx
+}
+
+// UsingDisk returns whether the primary container is using disk.
+func (d *DiskBackedNumberedRowContainer) UsingDisk() bool {
+	return d.rc.UsingDisk()
+}
+
+// testingSpillToDisk is for tests to spill the container(s)
+// to disk.
+func (d *DiskBackedNumberedRowContainer) testingSpillToDisk(ctx context.Context) error {
+	if !d.rc.UsingDisk() {
+		if err := d.rc.SpillToDisk(ctx); err != nil {
+			return err
+		}
+	}
+	if d.deDup && !d.deduper.(*DiskBackedRowContainer).UsingDisk() {
+		if err := d.deduper.(*DiskBackedRowContainer).SpillToDisk(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AddRow tries to add a row. It returns the position of the
+// row in the container.
+func (d *DiskBackedNumberedRowContainer) AddRow(
+	ctx context.Context, row sqlbase.EncDatumRow,
+) (int, error) {
+	if d.deDup {
+		assignedIdx, err := d.deduper.AddRowWithDeDup(ctx, row)
+		if err != nil {
+			return 0, err
+		}
+		if assignedIdx < d.idx {
+			// Existing row.
+			return assignedIdx, nil
+		} else if assignedIdx != d.idx {
+			panic(fmt.Sprintf("DiskBackedNumberedRowContainer bug: assignedIdx %d != d.idx %d",
+				assignedIdx, d.idx))
+		}
+		// Else assignedIdx == d.idx, so a new row.
+	}
+	idx := d.idx
+	// An error in AddRow() will cause the two row containers
+	// to no longer be in-step with each other wrt the numbering
+	// but that is not a concern since the caller will not
+	// continue using d after an error.
+	d.idx++
+	return idx, d.rc.AddRow(ctx, row)
+}
+
+// SetupForRead must be called before calling GetRow(). No more AddRow() calls
+// are permitted (before UnsafeReset()). See the comment for
+// NumberedDiskRowIterator for how we use the future accesses.
+func (d *DiskBackedNumberedRowContainer) SetupForRead(ctx context.Context, accesses [][]int) {
+	if !d.rc.UsingDisk() {
+		return
+	}
+	rowIter := d.rc.drc.newNumberedIterator(ctx)
+	meanBytesPerRow := d.rc.drc.MeanEncodedRowBytes()
+	if meanBytesPerRow == 0 {
+		meanBytesPerRow = 100 // arbitrary
+	}
+	// TODO(sumeer): make bytesPerSSBlock a parameter to
+	// NewDiskBackedNumberedRowContainer.
+	const bytesPerSSBlock = 32 * 1024
+	meanRowsPerSSBlock := bytesPerSSBlock / meanBytesPerRow
+	const maxCacheSize = 4096
+	cacheSize := maxCacheSize
+	if d.DisableCache {
+		// This is not an efficient way to disable the cache, but ok for tests.
+		cacheSize = 0
+	}
+	d.rowIter = newNumberedDiskRowIterator(
+		ctx, rowIter, accesses, meanRowsPerSSBlock, cacheSize, &d.rowIterMemAcc)
+}
+
+// GetRow returns a row with the given index. If skip is true the row is not
+// actually read and just indicates a read that is being skipped. It is used
+// to maintain synchronization with the future, since the caller can skip
+// accesses for semi-joins and anti-joins.
+func (d *DiskBackedNumberedRowContainer) GetRow(
+	ctx context.Context, idx int, skip bool,
+) (sqlbase.EncDatumRow, error) {
+	if !d.rc.UsingDisk() {
+		if skip {
+			return nil, nil
+		}
+		return d.rc.mrc.EncRow(idx), nil
+	}
+	return d.rowIter.getRow(ctx, idx, skip)
+}
+
+// UnsafeReset resets this container to be reused.
+func (d *DiskBackedNumberedRowContainer) UnsafeReset(ctx context.Context) error {
+	if d.rowIter != nil {
+		d.rowIter.close()
+		d.rowIterMemAcc.Clear(ctx)
+		d.rowIter = nil
+	}
+	d.idx = 0
+	if err := d.rc.UnsafeReset(ctx); err != nil {
+		return err
+	}
+	if d.deduper != nil {
+		if err := d.deduper.UnsafeReset(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Close closes the container.
+func (d *DiskBackedNumberedRowContainer) Close(ctx context.Context) {
+	if d.rowIter != nil {
+		d.rowIter.close()
+	}
+	d.rowIterMemAcc.Close(ctx)
+	d.rc.Close(ctx)
+	if d.deduper != nil {
+		d.deduper.Close(ctx)
+	}
+}
+
+// numberedDiskRowIterator wraps a numberedRowIterator and adds two pieces
+// of functionality:
+// - decides between seek and next when positioning the iterator.
+// - maintains a cache.
+//
+// Cache:
+//
+// The callers of GetRow() know the full pattern of future accesses,
+// represented as a [][]int where the int is the row number. Within a slice
+// they access in increasing order of index (since forward iteration is
+// cheaper), but across different slices there is no such constraint. Caching
+// policies like LRU work without knowing the future, and use "recency" of row
+// R (number of other distinct rows accessed since last access to row R) as a
+// proxy for "reuse distance" of row R (number of distinct rows that will be
+// accessed from one access of R to the next access of R). More sophisticated
+// policies try to use the recently observed reuse distance as a predictor for
+// the future reuse distance. In our case we know the exact reuse distance
+// from each access of row R to its next access, so one can construct an
+// optimal cache policy for a certain cache size: keep track of the current
+// reuse distance for each element of the cache and evict the one with the
+// highest reuse distance. A cache miss causes the retrieved entry to be added
+// to a full cache only if its reuse distance to the next access is less than
+// the highest reuse distance currently in the cache. This optimality requires
+// some book-keeping overhead:
+//
+// - A map with O(R) entries where R is the number of unique rows that will be
+//   accessed and an overall size proportional to the total number of accesses.
+//   Overall this is within a constant factor of [][]int, but the constant could
+//   be high. Note that we need this map because when doing Next() on the iterator
+//   we encounter entries different from the ones that caused this cache miss
+//   and we need to decide whether to cache them -- if we had a random access
+//   iterator such that sequential access was the same cost as random
+//   access, then a single []int with the next reuse position for each access
+//   would have sufficed.
+// - A heap containing the rows in the cache that is updated on each cache hit,
+//   and whenever a row is evicted or added to the cache. This is O(log N) where
+//   N is the number of entries in the cache.
+//
+// Overall, this may be too much memory and cpu overhead for not enough
+// benefit, but it will put an upper bound on what we can achieve with a
+// cache. And for inverted index queries involving intersection it is possible
+// that the row container contains far more rows than the number of unique
+// rows that will be accessed, so a small cache which knows the future could
+// be very beneficial. One motivation for this approach was that #48118
+// mentioned low observed cache hit rates with a simpler approach. And since
+// we turn off ssblock caching for these underlying storage engine, the
+// cost of a cache miss is high.
+//
+// TODO(sumeer):
+// - Before integrating with joinReader, try some realistic benchmarks.
+// - Use some realistic inverted index workloads (including geospatial) to
+//   measure the effect of this cache.
+type numberedDiskRowIterator struct {
+	rowIter *numberedRowIterator
+	// After creation, the rowIter is not positioned. isPositioned transitions
+	// once from false => true.
+	isPositioned bool
+	// The current index the rowIter is positioned at, when isPositioned == true.
+	idxRowIter int
+	// The mean number of rows per ssblock.
+	meanRowsPerSSBlock int
+	// The maximum number of rows in the cache. This can be shrunk under memory
+	// pressure.
+	maxCacheSize int
+	memAcc       *mon.BoundAccount
+
+	// The cache. It contains an entry for all the rows that will be accessed,
+	// and not just the ones for which we currently have a cached EncDatumRow.
+	cache map[int]*cacheElement
+	// The current access index in the sequence of all the accesses. This is
+	// used to know where we are in the known future.
+	accessIdx int
+	// A max heap containing only the rows for which we have a cached
+	// EncDatumRow. The top element has the highest nextAccess and is the
+	// best candidate to evict.
+	cacheHeap  cacheMaxNextAccessHeap
+	datumAlloc sqlbase.DatumAlloc
+	rowAlloc   sqlbase.EncDatumRowAlloc
+
+	hitCount  int
+	missCount int
+}
+
+type cacheElement struct {
+	// The future accesses for this row, expressed as the accessIdx when it will
+	// happen. We update this slice to remove the first entry whenever an access
+	// happens, so when non-empty, accesses[0] represents the next access, and
+	// when empty there are no more accesses left.
+	accesses []int
+	// row is non-nil for a cached row.
+	row sqlbase.EncDatumRow
+	// When row is non-nil, this is the element in the heap.
+	heapElement cacheRowHeapElement
+}
+
+type cacheRowHeapElement struct {
+	// The index of this cached row.
+	rowIdx int
+	// The next access of this cached row.
+	nextAccess int
+	// The index in the heap.
+	heapIdx int
+}
+
+type cacheMaxNextAccessHeap []*cacheRowHeapElement
+
+func (h cacheMaxNextAccessHeap) Len() int { return len(h) }
+func (h cacheMaxNextAccessHeap) Less(i, j int) bool {
+	return h[i].nextAccess > h[j].nextAccess
+}
+func (h cacheMaxNextAccessHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].heapIdx = i
+	h[j].heapIdx = j
+}
+func (h *cacheMaxNextAccessHeap) Push(x interface{}) {
+	n := len(*h)
+	elem := x.(*cacheRowHeapElement)
+	elem.heapIdx = n
+	*h = append(*h, elem)
+}
+func (h *cacheMaxNextAccessHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	elem := old[n-1]
+	elem.heapIdx = -1
+	*h = old[0 : n-1]
+	return elem
+}
+
+// TODO(sumeer): memory accounting for map and heap.
+func newNumberedDiskRowIterator(
+	_ context.Context,
+	rowIter *numberedRowIterator,
+	accesses [][]int,
+	meanRowsPerSSBlock int,
+	maxCacheSize int,
+	memAcc *mon.BoundAccount,
+) *numberedDiskRowIterator {
+	n := &numberedDiskRowIterator{
+		rowIter:            rowIter,
+		meanRowsPerSSBlock: meanRowsPerSSBlock,
+		maxCacheSize:       maxCacheSize,
+		memAcc:             memAcc,
+		cache:              make(map[int]*cacheElement, maxCacheSize),
+	}
+	var accessIdx int
+	for _, accSlice := range accesses {
+		for _, rowIdx := range accSlice {
+			elem := n.cache[rowIdx]
+			if elem == nil {
+				elem = &cacheElement{}
+				elem.heapElement.rowIdx = rowIdx
+				n.cache[rowIdx] = elem
+			}
+			elem.accesses = append(elem.accesses, accessIdx)
+			accessIdx++
+		}
+	}
+	return n
+}
+
+func (n *numberedDiskRowIterator) close() {
+	n.rowIter.Close()
+}
+
+func (n *numberedDiskRowIterator) getRow(
+	ctx context.Context, idx int, skip bool,
+) (sqlbase.EncDatumRow, error) {
+	thisAccessIdx := n.accessIdx
+	n.accessIdx++
+	elem, ok := n.cache[idx]
+	if !ok {
+		return nil, errors.Errorf("caller is accessing a row that was not specified up front")
+	}
+	if len(elem.accesses) == 0 || elem.accesses[0] != thisAccessIdx {
+		return nil, errors.Errorf("caller is no longer synchronized with future accesses")
+	}
+	elem.accesses = elem.accesses[1:]
+	var nextAccess int
+	if len(elem.accesses) > 0 {
+		nextAccess = elem.accesses[0]
+	} else {
+		nextAccess = math.MaxInt32
+	}
+
+	// Check for cache hit. This also updates the heap position,
+	// which we need to do even for skip == true.
+	if elem.row != nil {
+		n.hitCount++
+		elem.heapElement.nextAccess = nextAccess
+		heap.Fix(&n.cacheHeap, elem.heapElement.heapIdx)
+		if skip {
+			return nil, nil
+		}
+		return elem.row, nil
+	}
+
+	// Cache miss.
+	n.missCount++
+	// If skip, we can just return.
+	if skip {
+		return nil, nil
+	}
+
+	// Need to position the rowIter. We could add Prev(), since the engine supports
+	// it, if benchmarks indicate it would help. For now we just Seek() for that
+	// case.
+	if n.isPositioned && idx >= n.idxRowIter && (idx-n.idxRowIter <= n.meanRowsPerSSBlock) {
+		// Need to move forward, possibly within the same ssblock, so use Next().
+		// It is possible we are already positioned at the right place.
+		for i := idx - n.idxRowIter; i > 0; {
+			n.rowIter.Next()
+			if valid, err := n.rowIter.Valid(); err != nil || !valid {
+				if err != nil {
+					return nil, err
+				}
+				return nil, errors.Errorf("caller is asking for index higher than any added index")
+			}
+			n.idxRowIter++
+			i--
+			if i == 0 {
+				break
+			}
+			// i > 0. This is before the row we want to return, but it may
+			// be worthwhile to cache it.
+			preElem, ok := n.cache[n.idxRowIter]
+			if !ok {
+				// This is a row that is never accessed.
+				continue
+			}
+			if preElem.row != nil {
+				// Already in cache.
+				continue
+			}
+			if len(preElem.accesses) == 0 {
+				// No accesses left.
+				continue
+			}
+			if err := n.tryAddCache(ctx, preElem); err != nil {
+				return nil, err
+			}
+		}
+		// Try adding to cache
+		return n.tryAddCacheAndReturnRow(ctx, elem)
+	}
+	n.rowIter.seekToIndex(idx)
+	n.isPositioned = true
+	n.idxRowIter = idx
+	if valid, err := n.rowIter.Valid(); err != nil || !valid {
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.Errorf("caller is asking for index higher than any added index")
+	}
+	// Try adding to cache
+	return n.tryAddCacheAndReturnRow(ctx, elem)
+}
+
+func (n *numberedDiskRowIterator) ensureDecodedAndCopy(
+	row sqlbase.EncDatumRow,
+) (sqlbase.EncDatumRow, error) {
+	for i := range row {
+		if err := row[i].EnsureDecoded(n.rowIter.rowContainer.types[i], &n.datumAlloc); err != nil {
+			return nil, err
+		}
+	}
+	return n.rowAlloc.CopyRow(row), nil
+}
+
+func (n *numberedDiskRowIterator) tryAddCacheAndReturnRow(
+	ctx context.Context, elem *cacheElement,
+) (sqlbase.EncDatumRow, error) {
+	r, err := n.rowIter.Row()
+	if err != nil {
+		return nil, err
+	}
+	row, err := n.ensureDecodedAndCopy(r)
+	if err != nil {
+		return nil, err
+	}
+	return row, n.tryAddCacheHelper(ctx, elem, row, true)
+}
+
+func (n *numberedDiskRowIterator) tryAddCache(ctx context.Context, elem *cacheElement) error {
+	// We don't want to pay the cost of rowIter.Row() if the row will not be
+	// added to the cache. But to do correct memory accounting, which is needed
+	// for the precise caching decision, we do need the EncDatumRow. So we do a
+	// cheap check that is a good predictor of whether the row will be cached,
+	// and then call rowIter.Row().
+	cacheSize := len(n.cacheHeap)
+	if cacheSize == n.maxCacheSize && (cacheSize == 0 || n.cacheHeap[0].nextAccess <= elem.accesses[0]) {
+		return nil
+	}
+	row, err := n.rowIter.Row()
+	if err != nil {
+		return err
+	}
+	return n.tryAddCacheHelper(ctx, elem, row, false)
+}
+
+func (n *numberedDiskRowIterator) tryAddCacheHelper(
+	ctx context.Context, elem *cacheElement, row sqlbase.EncDatumRow, alreadyDecodedAndCopied bool,
+) error {
+	if len(elem.accesses) == 0 {
+		return nil
+	}
+	if elem.row != nil {
+		log.Fatalf(ctx, "adding row to cache when it is already in cache")
+	}
+	nextAccess := elem.accesses[0]
+	evict := func() error {
+		heapElem := heap.Pop(&n.cacheHeap).(*cacheRowHeapElement)
+		evictElem, ok := n.cache[heapElem.rowIdx]
+		if !ok {
+			return errors.Errorf("bug: element not in cache map")
+		}
+		bytes := evictElem.row.Size()
+		n.memAcc.Shrink(ctx, int64(bytes))
+		evictElem.row = nil
+		return nil
+	}
+	rowBytesUsage := -1
+	for {
+		if n.maxCacheSize == 0 {
+			return nil
+		}
+		if len(n.cacheHeap) == n.maxCacheSize && n.cacheHeap[0].nextAccess <= nextAccess {
+			return nil
+		}
+		if len(n.cacheHeap) >= n.maxCacheSize {
+			if err := evict(); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// We shrink maxCacheSize such that it is a good current indicator of how
+		// many rows memAcc will allow us to place in the cache. So it is likely
+		// that this row can be added. Decode the row to get the correct
+		// rowBytesUsage.
+		if !alreadyDecodedAndCopied {
+			var err error
+			row, err = n.ensureDecodedAndCopy(row)
+			if err != nil {
+				return err
+			}
+			alreadyDecodedAndCopied = true
+		}
+		if rowBytesUsage == -1 {
+			rowBytesUsage = int(row.Size())
+		}
+		if err := n.memAcc.Grow(ctx, int64(rowBytesUsage)); err != nil {
+			if sqlbase.IsOutOfMemoryError(err) {
+				// Could not grow the memory to handle this row, so reduce the
+				// maxCacheSize (max count of entries), to the current number of
+				// entries in the cache. The assumption here is that rows in the cache
+				// are of similar size. Using maxCacheSize to make eviction decisions
+				// is cheaper than calling Grow().
+				n.maxCacheSize = len(n.cacheHeap)
+				continue
+			} else {
+				return err
+			}
+		} else {
+			// There is room in the cache.
+			break
+		}
+	}
+	// Add to cache.
+	elem.heapElement.nextAccess = nextAccess
+	elem.row = row
+	heap.Push(&n.cacheHeap, &elem.heapElement)
+	return nil
+}

--- a/pkg/sql/rowcontainer/numbered_row_container_test.go
+++ b/pkg/sql/rowcontainer/numbered_row_container_test.go
@@ -1,0 +1,225 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rowcontainer
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests the de-duping functionality of DiskBackedNumberedRowContainer.
+func TestNumberedRowContainerDeDuping(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	tempEngine, _, err := storage.NewTempEngine(ctx, storage.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tempEngine.Close()
+
+	numRows := 20
+	const numCols = 2
+	const smallMemoryBudget = 40
+	rng, _ := randutil.NewPseudoRand()
+
+	memoryMonitor := mon.MakeMonitor(
+		"test-mem",
+		mon.MemoryResource,
+		nil,           /* curCount */
+		nil,           /* maxHist */
+		-1,            /* increment */
+		math.MaxInt64, /* noteworthy */
+		st,
+	)
+	diskMonitor := execinfra.NewTestDiskMonitor(ctx, st)
+
+	memoryBudget := math.MaxInt64
+	if rng.Intn(2) == 0 {
+		fmt.Printf("using smallMemoryBudget to spill to disk\n")
+		memoryBudget = smallMemoryBudget
+	}
+
+	memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(int64(memoryBudget)))
+	defer memoryMonitor.Stop(ctx)
+	diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	defer diskMonitor.Stop(ctx)
+
+	// Use random types and random rows.
+	types := sqlbase.RandSortingTypes(rng, numCols)
+	ordering := sqlbase.ColumnOrdering{
+		sqlbase.ColumnOrderInfo{
+			ColIdx:    0,
+			Direction: encoding.Ascending,
+		},
+		sqlbase.ColumnOrderInfo{
+			ColIdx:    1,
+			Direction: encoding.Descending,
+		},
+	}
+	numRows, rows := makeUniqueRows(t, &evalCtx, rng, numRows, types, ordering)
+	rc := NewDiskBackedNumberedRowContainer(
+		true /*deDup*/, types, &evalCtx, tempEngine, &memoryMonitor, diskMonitor,
+		0 /*rowCapacity*/)
+	defer rc.Close(ctx)
+
+	// Each pass does an UnsafeReset at the end.
+	for passWithReset := 0; passWithReset < 2; passWithReset++ {
+		// Insert rows.
+		for insertPass := 0; insertPass < 2; insertPass++ {
+			for i := 0; i < numRows; i++ {
+				idx, err := rc.AddRow(ctx, rows[i])
+				require.NoError(t, err)
+				require.Equal(t, i, idx)
+			}
+		}
+		// Random access of the inserted rows.
+		var accesses []int
+		for i := 0; i < 2*numRows; i++ {
+			accesses = append(accesses, rng.Intn(numRows))
+		}
+		rc.SetupForRead(ctx, [][]int{accesses})
+		for i := 0; i < len(accesses); i++ {
+			skip := rng.Intn(10) == 0
+			row, err := rc.GetRow(ctx, accesses[i], skip)
+			require.NoError(t, err)
+			if skip {
+				continue
+			}
+			require.Equal(t, rows[accesses[i]].String(types), row.String(types))
+		}
+		// Reset and reorder the rows for the next pass.
+		rand.Shuffle(numRows, func(i, j int) {
+			rows[i], rows[j] = rows[j], rows[i]
+		})
+		require.NoError(t, rc.UnsafeReset(ctx))
+	}
+}
+
+// Tests the iterator and iterator caching of DiskBackedNumberedRowContainer.
+// Does not utilize the de-duping functionality since that is tested
+// elsewhere.
+func TestNumberedRowContainerIteratorCaching(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	tempEngine, _, err := storage.NewTempEngine(ctx, storage.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tempEngine.Close()
+
+	memoryMonitor := mon.MakeMonitor(
+		"test-mem",
+		mon.MemoryResource,
+		nil,           /* curCount */
+		nil,           /* maxHist */
+		-1,            /* increment */
+		math.MaxInt64, /* noteworthy */
+		st,
+	)
+	diskMonitor := execinfra.NewTestDiskMonitor(ctx, st)
+
+	numRows := 200
+	const numCols = 2
+	// This memory budget allows for some caching, but typically cannot
+	// cache all the rows.
+	const memoryBudget = 12000
+
+	memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(memoryBudget))
+	defer memoryMonitor.Stop(ctx)
+	diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	defer diskMonitor.Stop(ctx)
+
+	// Use random types and random rows.
+	rng, _ := randutil.NewPseudoRand()
+
+	types := sqlbase.RandSortingTypes(rng, numCols)
+	ordering := sqlbase.ColumnOrdering{
+		sqlbase.ColumnOrderInfo{
+			ColIdx:    0,
+			Direction: encoding.Ascending,
+		},
+		sqlbase.ColumnOrderInfo{
+			ColIdx:    1,
+			Direction: encoding.Descending,
+		},
+	}
+	numRows, rows := makeUniqueRows(t, &evalCtx, rng, numRows, types, ordering)
+	rc := NewDiskBackedNumberedRowContainer(
+		false /*deDup*/, types, &evalCtx, tempEngine, &memoryMonitor, diskMonitor,
+		0 /*rowCapacity*/)
+	defer rc.Close(ctx)
+
+	// Each pass does an UnsafeReset at the end.
+	for passWithReset := 0; passWithReset < 2; passWithReset++ {
+		// Insert rows.
+		for i := 0; i < numRows; i++ {
+			idx, err := rc.AddRow(ctx, rows[i])
+			require.NoError(t, err)
+			require.Equal(t, i, idx)
+		}
+		// We want all the memory to be usable by the cache, so spill to disk.
+		require.NoError(t, rc.testingSpillToDisk(ctx))
+		require.True(t, rc.UsingDisk())
+		// Random access of the inserted rows.
+		var accesses [][]int
+		for i := 0; i < 2*numRows; i++ {
+			var access []int
+			for j := 0; j < 4; j++ {
+				access = append(access, rng.Intn(numRows))
+			}
+			accesses = append(accesses, access)
+		}
+		rc.SetupForRead(ctx, accesses)
+		for _, access := range accesses {
+			for _, index := range access {
+				skip := rng.Intn(10) == 0
+				row, err := rc.GetRow(ctx, index, skip)
+				require.NoError(t, err)
+				if skip {
+					continue
+				}
+				require.Equal(t, rows[index].String(types), row.String(types))
+			}
+		}
+		fmt.Printf("hits: %d, misses: %d, maxCacheSize: %d\n",
+			rc.rowIter.hitCount, rc.rowIter.missCount, rc.rowIter.maxCacheSize)
+		// Reset and reorder the rows for the next pass.
+		rand.Shuffle(numRows, func(i, j int) {
+			rows[i], rows[j] = rows[j], rows[i]
+		})
+		require.NoError(t, rc.UnsafeReset(ctx))
+	}
+}
+
+// TODO(sumeer): Benchmarks:
+// - de-duping with and without spilling.
+// - read throughput with and without cache under various read access patterns.

--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -81,6 +81,23 @@ type IndexedRowContainer interface {
 	GetRow(ctx context.Context, idx int) (tree.IndexedRow, error)
 }
 
+// DeDupingRowContainer is a container that de-duplicates rows added to the
+// container, and assigns them a dense index starting from 0, representing
+// when that row was first added. It only supports a configuration where all
+// the columns are encoded into the key -- relaxing this is not hard, but is
+// not worth adding the code without a use for it.
+type DeDupingRowContainer interface {
+	// AddRowWithDeDup adds the given row if not already present in the
+	// container. It returns the dense number of when the row is first
+	// added.
+	AddRowWithDeDup(context.Context, sqlbase.EncDatumRow) (int, error)
+	// UnsafeReset resets the container, allowing for reuse. It renders all
+	// previously allocated rows unsafe.
+	UnsafeReset(context.Context) error
+	// Close frees up resources held by the container.
+	Close(context.Context)
+}
+
 // RowIterator is a simple iterator used to iterate over sqlbase.EncDatumRows.
 // Example use:
 // 	var i RowIterator
@@ -347,6 +364,16 @@ type DiskBackedRowContainer struct {
 	mrc *MemRowContainer
 	drc *DiskRowContainer
 
+	// See comment in DoDeDuplicate().
+	deDuplicate bool
+	keyToIndex  map[string]int
+	// Encoding helpers for de-duplication:
+	// encodings keeps around the DatumEncoding equivalents of the encoding
+	// directions in ordering to avoid conversions in hot paths.
+	encodings  []sqlbase.DatumEncoding
+	datumAlloc sqlbase.DatumAlloc
+	scratchKey []byte
+
 	spilled bool
 
 	// The following fields are used to create a DiskRowContainer when spilling
@@ -356,6 +383,7 @@ type DiskBackedRowContainer struct {
 }
 
 var _ ReorderableRowContainer = &DiskBackedRowContainer{}
+var _ DeDupingRowContainer = &DiskBackedRowContainer{}
 
 // Init initializes a DiskBackedRowContainer.
 // Arguments:
@@ -386,6 +414,24 @@ func (f *DiskBackedRowContainer) Init(
 	f.src = &mrc
 	f.engine = engine
 	f.diskMonitor = diskMonitor
+	f.encodings = make([]sqlbase.DatumEncoding, len(ordering))
+	for i, orderInfo := range ordering {
+		f.encodings[i] = sqlbase.EncodingDirToDatumEncoding(orderInfo.Direction)
+	}
+}
+
+// DoDeDuplicate causes DiskBackedRowContainer to behave as an implementation
+// of DeDupingRowContainer. It should not be mixed with calls to AddRow(). It
+// de-duplicates the keys such that only the first row with the given key will
+// be stored. The index returned in AddRowWithDedup() is a dense index
+// starting from 0, representing when that key was first added. This feature
+// does not combine with Sort(), Reorder() etc., and only to be used for
+// assignment of these dense indexes. The main reason to add this to
+// DiskBackedRowContainer is to avoid significant code duplication in
+// constructing another row container.
+func (f *DiskBackedRowContainer) DoDeDuplicate() {
+	f.deDuplicate = true
+	f.keyToIndex = make(map[string]int)
 }
 
 // Len is part of the SortableRowContainer interface.
@@ -405,6 +451,49 @@ func (f *DiskBackedRowContainer) AddRow(ctx context.Context, row sqlbase.EncDatu
 		}
 		// Add the row that caused the memory error.
 		return f.src.AddRow(ctx, row)
+	}
+	return nil
+}
+
+// AddRowWithDeDup is part of the DeDupingRowContainer interface.
+func (f *DiskBackedRowContainer) AddRowWithDeDup(
+	ctx context.Context, row sqlbase.EncDatumRow,
+) (int, error) {
+	if !f.UsingDisk() {
+		if err := f.encodeKey(ctx, row); err != nil {
+			return 0, err
+		}
+		encodedStr := string(f.scratchKey)
+		idx, ok := f.keyToIndex[encodedStr]
+		if ok {
+			return idx, nil
+		}
+		idx = f.Len()
+		if err := f.AddRow(ctx, row); err != nil {
+			return 0, err
+		}
+		// AddRow may have spilled and deleted the map.
+		if !f.UsingDisk() {
+			f.keyToIndex[encodedStr] = idx
+		}
+		return idx, nil
+	}
+	// Using disk.
+	return f.drc.AddRowWithDeDup(ctx, row)
+}
+
+func (f *DiskBackedRowContainer) encodeKey(ctx context.Context, row sqlbase.EncDatumRow) error {
+	if len(row) != len(f.mrc.types) {
+		log.Fatalf(ctx, "invalid row length %d, expected %d", len(row), len(f.mrc.types))
+	}
+	f.scratchKey = f.scratchKey[:0]
+	for i, orderInfo := range f.mrc.ordering {
+		col := orderInfo.ColIdx
+		var err error
+		f.scratchKey, err = row[col].Encode(f.mrc.types[col], &f.datumAlloc, f.encodings[i], f.scratchKey)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -446,6 +535,9 @@ func (f *DiskBackedRowContainer) NewFinalIterator(ctx context.Context) RowIterat
 // UnsafeReset resets the container for reuse. The DiskBackedRowContainer will
 // reset to use memory if it is using disk.
 func (f *DiskBackedRowContainer) UnsafeReset(ctx context.Context) error {
+	if f.deDuplicate {
+		f.keyToIndex = make(map[string]int)
+	}
 	if f.drc != nil {
 		f.drc.Close(ctx)
 		f.src = f.mrc
@@ -461,6 +553,9 @@ func (f *DiskBackedRowContainer) Close(ctx context.Context) {
 		f.drc.Close(ctx)
 	}
 	f.mrc.Close(ctx)
+	if f.deDuplicate {
+		f.keyToIndex = nil
+	}
 }
 
 // Spilled returns whether or not the DiskBackedRowContainer spilled to disk
@@ -496,6 +591,13 @@ func (f *DiskBackedRowContainer) SpillToDisk(ctx context.Context) error {
 		return errors.New("already using disk")
 	}
 	drc := MakeDiskRowContainer(f.diskMonitor, f.mrc.types, f.mrc.ordering, f.engine)
+	if f.deDuplicate {
+		drc.DoDeDuplicate()
+		// After spilling to disk we don't need this map to de-duplicate. The
+		// DiskRowContainer will do the de-duplication. Calling AddRow() below
+		// is correct since these rows are already de-duplicated.
+		f.keyToIndex = nil
+	}
 	i := f.mrc.NewFinalIterator(ctx)
 	defer i.Close()
 	for i.Rewind(); ; i.Next() {

--- a/pkg/sql/rowcontainer/row_container_test.go
+++ b/pkg/sql/rowcontainer/row_container_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -32,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 // verifyRows verifies that the rows read with the given RowIterator match up
@@ -335,6 +337,91 @@ func TestDiskBackedRowContainer(t *testing.T) {
 			t.Fatal("memory monitor reports unexpected usage")
 		}
 	})
+}
+
+func TestDiskBackedRowContainerDeDuping(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	tempEngine, _, err := storage.NewTempEngine(ctx, storage.DefaultStorageEngine, base.TempStorageConfig{InMemory: true}, base.DefaultTestStoreSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tempEngine.Close()
+
+	memoryMonitor := mon.MakeMonitor(
+		"test-mem",
+		mon.MemoryResource,
+		nil,           /* curCount */
+		nil,           /* maxHist */
+		-1,            /* increment */
+		math.MaxInt64, /* noteworthy */
+		st,
+	)
+	diskMonitor := execinfra.NewTestDiskMonitor(ctx, st)
+
+	memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	defer memoryMonitor.Stop(ctx)
+	diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	defer diskMonitor.Stop(ctx)
+
+	numRows := 10
+	// Use 2 columns with both ascending and descending ordering to exercise
+	// all possibilities with the randomly chosen types.
+	const numCols = 2
+	ordering := sqlbase.ColumnOrdering{
+		sqlbase.ColumnOrderInfo{
+			ColIdx:    0,
+			Direction: encoding.Ascending,
+		},
+		sqlbase.ColumnOrderInfo{
+			ColIdx:    1,
+			Direction: encoding.Descending,
+		},
+	}
+	rng, _ := randutil.NewPseudoRand()
+	// Use random types and random rows.
+	types := sqlbase.RandSortingTypes(rng, numCols)
+	numRows, rows := makeUniqueRows(t, &evalCtx, rng, numRows, types, ordering)
+	rc := DiskBackedRowContainer{}
+	rc.Init(
+		ordering,
+		types,
+		&evalCtx,
+		tempEngine,
+		&memoryMonitor,
+		diskMonitor,
+		0, /* rowCapacity */
+	)
+	defer rc.Close(ctx)
+	rc.DoDeDuplicate()
+
+	for run := 0; run < 2; run++ {
+		// Add rows to a DiskBackedRowContainer, and make it spill to disk halfway
+		// through, and keep adding rows.
+		mid := numRows / 2
+		for i := 0; i < mid; i++ {
+			idx, err := rc.AddRowWithDeDup(ctx, rows[i])
+			require.NoError(t, err)
+			require.Equal(t, i, idx)
+		}
+		require.Equal(t, false, rc.UsingDisk())
+		require.NoError(t, rc.SpillToDisk(ctx))
+		require.Equal(t, true, rc.UsingDisk())
+
+		for i := mid; i < numRows; i++ {
+			idx, err := rc.AddRowWithDeDup(ctx, rows[i])
+			require.NoError(t, err)
+			require.Equal(t, i, idx)
+		}
+		// Reset and reorder the rows for the next run.
+		rand.Shuffle(numRows, func(i, j int) {
+			rows[i], rows[j] = rows[j], rows[i]
+		})
+		require.NoError(t, rc.UnsafeReset(ctx))
+	}
 }
 
 // verifyOrdering checks whether the rows in src are ordered according to


### PR DESCRIPTION
DiskBackedNumberedRowContainer is a container that stores
index => row mappings, where the index is densely numbered
starting from 0.
It has two uses:
- It can be used for joinReader (lookup join) to replace the
  current use of DiskBackedIndexedRowContainer.
- It has the additional ability to de-duplicate the key of the
  rows written to it (where all the columns in the row are in
  the key). This is the mode in which it will be used for inverted
  index computations.

The index => row mapping is stored using a DiskBackedRowContainer,
since the latter already has most of the needed support for
first writing to memory and then spilling to disk -- the key
is set to be empty. After spilling, when DiskRowContainer is the
underlying container, we rely on the RowID it introduces. For reading
from the DiskRowContainer, there is a new numberedRowIterator that
supports a seekToIndex() method, which can be used to avoid iterating
over many intermediate ssblocks.

The DiskBackedNumberedRowContainer has a numberedDiskRowIterator
that uses the aforementioned numberedRowIterator and decides when to
seek or next. Additionally, it contains an in-memory cache -- due
to the cache misses observed in issue 48118, this cache uses knowledge of
the full future access pattern that is known for both joinReader and
the inverted index cases to optimally cache. This caching algorithm
has not been experimentally validated and it is possible that it may
not improve cache hit rates (it will be significantly better than LRU
if the reuse distance is greater than the cache size). It has more
book-keeping overhead so some experimental validation will be done
before integrating with joinReader.

For de-duplication, needed for inverted index computations,
one additionally needs a row => index map.
This is constructed by modifying DiskBackedRowContainer and
introducing a de-duplicate mode. To make this work without flushing
the batch after each write, we maintain a map[string]uint64 for the
rows that are in the batch. The coordination between this map and the
batch flushes required the introduction of
SortedDiskMapBatchWriter.NumPutsSinceFlush()

This code currently lacks tests -- I am looking for early feedback.
It includes a strawman integration with joinReader -- that will be
removed before merging.

Release note: None