### PR TITLE
importccl: fix bug where GC job would not operate on any tables

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -1351,6 +1351,7 @@ func (r *importResumer) dropTables(
 			if err := sqlbase.RemovePublicTableNamespaceEntry(ctx, txn, execCfg.Codec, tableDesc.ParentID, tableDesc.Name); err != nil {
 				return err
 			}
+			tablesToGC = append(tablesToGC, tableDesc.ID)
 		} else {
 			// IMPORT did not create this table, so we should not drop it.
 			tableDesc.State = sqlbase.TableDescriptor_PUBLIC

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1259,3 +1259,9 @@ func (r *Registry) unregister(jobID int64) {
 		delete(r.mu.jobs, jobID)
 	}
 }
+
+// TestingNudgeAdoptionQueue is used by tests to tell the registry that there is
+// a job to be adopted.
+func (r *Registry) TestingNudgeAdoptionQueue() {
+	r.adoptionCh <- struct{}{}
+}


### PR DESCRIPTION
Previously, IMPORT did not populate the tables to drop in the GCJob that
it created. Therefore the partially imported data of a failed or
canceled IMPORT job would not get GC'ed.

Fixes #48592.

Release note (bug fix): Previously, when an IMPORT failed, it created a
GC job which would behave as a no-op. Now the partially imported data
after an IMPORT fails or is canceled should be deleted.