### PR TITLE
hlc: micro-optimize hlc CAS

### DIFF
--- a/pkg/util/hlc/hlc_test.go
+++ b/pkg/util/hlc/hlc_test.go
@@ -251,7 +251,7 @@ func TestHLCPhysicalClockJump(t *testing.T) {
 			// This should not fatal as tickerCh has ticked
 			a.Equal(false, fatal)
 			// After ticker ticks, last physical time should be equal to physical now
-			lastPhysicalTime := c.lastPhysicalTime
+			lastPhysicalTime := atomic.LoadInt64(&c.lastPhysicalTime)
 			physicalNow := c.PhysicalNow()
 			a.Equal(lastPhysicalTime, physicalNow)
 


### PR DESCRIPTION
This patch saves an atomic load after a successful CAS.
Two readers have suggested it before (me and Ben), so let's do it even
if it doesn't move any needles.

Release note: None