### PR TITLE
release-19.2: sql,importccl: prevent DROP DATABASE CASCADE if there are offline tables

### DIFF
--- a/pkg/ccl/importccl/client_import_test.go
+++ b/pkg/ccl/importccl/client_import_test.go
@@ -1,0 +1,96 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package importccl_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDropDatabaseCascadeDuringImportsFails ensures that dropping a database
+// while an IMPORT is ongoing fails with an error. This is critical because
+// otherwise we may end up with orphaned table descriptors. See #48589 for
+// more details.
+func TestDropDatabaseCascadeDuringImportsFails(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	args := base.TestClusterArgs{}
+	tc := testcluster.StartTestCluster(t, 1, args)
+	defer tc.Stopper().Stop(ctx)
+
+	tc.WaitForNodeLiveness(t)
+	require.NoError(t, tc.WaitForFullReplication())
+
+	db := tc.ServerConn(0)
+	runner := sqlutils.MakeSQLRunner(db)
+
+	// Use some names that need quoting to ensure that the error quoting is correct.
+	const dbName, tableName = `"fooBarBaz"`, `"foo bar"`
+	runner.Exec(t, `CREATE DATABASE `+dbName)
+
+	mkServer := func(method string, handler func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == method {
+				handler(w, r)
+			}
+		}))
+	}
+
+	// Let's start an import into this table of ours.
+	allowResponse := make(chan struct{})
+	var gotRequestOnce sync.Once
+	gotRequest := make(chan struct{})
+	srv := mkServer("GET", func(w http.ResponseWriter, r *http.Request) {
+		gotRequestOnce.Do(func() { close(gotRequest) })
+		select {
+		case <-allowResponse:
+		case <-ctx.Done(): // Deal with test failures.
+		}
+		_, _ = w.Write([]byte("1,asdfasdfasdfasdf"))
+	})
+	defer srv.Close()
+
+	importErrCh := make(chan error, 1)
+	go func() {
+		_, err := db.Exec(`IMPORT TABLE `+dbName+"."+tableName+
+			` (k INT, v STRING) CSV DATA ($1)`, srv.URL)
+		importErrCh <- err
+	}()
+	select {
+	case <-gotRequest:
+	case err := <-importErrCh:
+		t.Fatalf("err %v", err)
+	}
+
+	_, err := db.Exec(`DROP DATABASE "fooBarBaz" CASCADE`)
+	require.Regexp(t, `cannot drop a database with OFFLINE tables, ensure `+
+		dbName+`\.public\.`+tableName+` is dropped or made public before dropping`+
+		` database `+dbName, err)
+	pgErr := new(pq.Error)
+	require.True(t, errors.As(err, &pgErr))
+	require.Equal(t, pgcode.ObjectNotInPrerequisiteState, string(pgErr.Code))
+
+	close(allowResponse)
+	require.NoError(t, <-importErrCh)
+	runner.Exec(t, `DROP DATABASE `+dbName+` CASCADE`)
+}

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -441,7 +441,8 @@ func importPlanHook(
 			// - Look at if/how cleanup/rollback works. Reconsider the cpu from the
 			//   desc version (perhaps we should be re-reading instead?).
 			// - Write _a lot_ of tests.
-			found, err := p.ResolveMutableTableDescriptor(ctx, table, true, sql.ResolveRequireTableDesc)
+			found, err := p.ResolveMutableTableDescriptor(ctx, table, true /* required */, false, /* includeOffline */
+				sql.ResolveRequireTableDesc)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -30,9 +30,7 @@ type createIndexNode struct {
 //   notes: postgres requires CREATE on the table.
 //          mysql requires INDEX on the table.
 func (p *planner) CreateIndex(ctx context.Context, n *tree.CreateIndex) (planNode, error) {
-	tableDesc, err := p.ResolveMutableTableDescriptor(
-		ctx, &n.Table, true /*required*/, ResolveRequireTableDesc,
-	)
+	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, &n.Table, true /* required */, false /* includeOffline */, ResolveRequireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -457,7 +457,8 @@ func ResolveFK(
 		originColumnIDs[i] = col.ID
 	}
 
-	target, err := ResolveMutableExistingObject(ctx, sc, &d.Table, true /*required*/, ResolveRequireTableDesc)
+	target, err := ResolveMutableExistingObject(ctx, sc, &d.Table,
+		true /* required */, false /* includeOffline */, ResolveRequireTableDesc)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -86,13 +86,21 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 
 	td := make([]toDelete, 0, len(tbNames))
 	for i := range tbNames {
-		tbDesc, err := p.prepareDrop(ctx, &tbNames[i], false /*required*/, ResolveAnyDescType)
+		tbDesc, err := p.prepareDrop(ctx, &tbNames[i],
+			false /*required*/, true /* includeOffline */, ResolveAnyDescType)
 		if err != nil {
 			return nil, err
 		}
 		if tbDesc == nil {
 			continue
 		}
+		if tbDesc.State == sqlbase.TableDescriptor_OFFLINE {
+			return nil, pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+				"cannot drop a database with OFFLINE tables, ensure %s is"+
+					" dropped or made public before dropping database %s",
+				tbNames[i].String(), tree.AsString((*tree.Name)(&dbDesc.Name)))
+		}
+
 		// Recursively check permissions on all dependent views, since some may
 		// be in different databases.
 		for _, ref := range tbDesc.DependedOnBy {

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -66,8 +66,8 @@ func (n *dropIndexNode) startExec(params runParams) error {
 		// the list: when two or more index names refer to the same table,
 		// the mutation list and new version number created by the first
 		// drop need to be visible to the second drop.
-		tableDesc, err := params.p.ResolveMutableTableDescriptor(
-			ctx, index.tn, true /*required*/, ResolveRequireTableDesc)
+		tableDesc, err := params.p.ResolveMutableTableDescriptor(ctx, index.tn,
+			true /* required */, false /* includeOffline */, ResolveRequireTableDesc)
 		if err != nil {
 			// Somehow the descriptor we had during newPlan() is not there
 			// any more.

--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -28,7 +28,7 @@ func (p *planner) DropSequence(ctx context.Context, n *tree.DropSequence) (planN
 	td := make([]toDelete, 0, len(n.Names))
 	for i := range n.Names {
 		tn := &n.Names[i]
-		droppedDesc, err := p.prepareDrop(ctx, tn, !n.IfExists, ResolveRequireSequenceDesc)
+		droppedDesc, err := p.prepareDrop(ctx, tn, !n.IfExists, false /* includeOffline */, ResolveRequireSequenceDesc)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -49,7 +49,7 @@ func (p *planner) DropTable(ctx context.Context, n *tree.DropTable) (planNode, e
 	td := make(map[sqlbase.ID]toDelete, len(n.Names))
 	for i := range n.Names {
 		tn := &n.Names[i]
-		droppedDesc, err := p.prepareDrop(ctx, tn, !n.IfExists, ResolveRequireTableDesc)
+		droppedDesc, err := p.prepareDrop(ctx, tn, !n.IfExists, false /* includeOffline */, ResolveRequireTableDesc)
 		if err != nil {
 			return nil, err
 		}
@@ -157,9 +157,12 @@ func (*dropTableNode) Close(context.Context)        {}
 // new leases for it and existing leases are released).
 // If the table does not exist, this function returns a nil descriptor.
 func (p *planner) prepareDrop(
-	ctx context.Context, name *tree.TableName, required bool, requiredType ResolveRequiredType,
+	ctx context.Context,
+	name *tree.TableName,
+	required, includeOffline bool,
+	requiredType ResolveRequiredType,
 ) (*sqlbase.MutableTableDescriptor, error) {
-	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, name, required, requiredType)
+	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, name, required, includeOffline, requiredType)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -34,7 +34,7 @@ func (p *planner) DropView(ctx context.Context, n *tree.DropView) (planNode, err
 	td := make([]toDelete, 0, len(n.Names))
 	for i := range n.Names {
 		tn := &n.Names[i]
-		droppedDesc, err := p.prepareDrop(ctx, tn, !n.IfExists, ResolveRequireViewDesc)
+		droppedDesc, err := p.prepareDrop(ctx, tn, !n.IfExists, false /* includeOffline */, ResolveRequireViewDesc)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -89,7 +89,7 @@ type PlanHookState interface {
 	ResolveUncachedDatabaseByName(
 		ctx context.Context, dbName string, required bool) (*UncachedDatabaseDescriptor, error)
 	ResolveMutableTableDescriptor(
-		ctx context.Context, tn *ObjectName, required bool, requiredType ResolveRequiredType,
+		ctx context.Context, tn *ObjectName, required, includeOffline bool, requiredType ResolveRequiredType,
 	) (table *MutableTableDescriptor, err error)
 }
 

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -35,7 +35,7 @@ type renameColumnNode struct {
 //          mysql requires ALTER, CREATE, INSERT on the table.
 func (p *planner) RenameColumn(ctx context.Context, n *tree.RenameColumn) (planNode, error) {
 	// Check if table exists.
-	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, &n.Table, !n.IfExists, ResolveRequireTableDesc)
+	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, &n.Table, !n.IfExists, false /* includeOffline */, ResolveRequireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -43,7 +43,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 		toRequire = ResolveRequireSequenceDesc
 	}
 
-	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, &oldTn, !n.IfExists, toRequire)
+	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, &oldTn, !n.IfExists, false /* includeOffline */, toRequire)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -313,13 +313,15 @@ func maybeAddSequenceDependencies(
 		var seqDesc *MutableTableDescriptor
 		p, ok := sc.(*planner)
 		if ok {
-			seqDesc, err = p.ResolveMutableTableDescriptor(ctx, &tn, true /*required*/, ResolveRequireSequenceDesc)
+			seqDesc, err = p.ResolveMutableTableDescriptor(ctx, &tn, true, /* required */
+				false /* includeOffline */, ResolveRequireSequenceDesc)
 			if err != nil {
 				return nil, err
 			}
 		} else {
 			// This is only executed via IMPORT which uses its own resolver.
-			seqDesc, err = ResolveMutableExistingObject(ctx, sc, &tn, true /*required*/, ResolveRequireSequenceDesc)
+			seqDesc, err = ResolveMutableExistingObject(ctx, sc, &tn, true, /* required */
+				false /* includeOffline */, ResolveRequireSequenceDesc)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -61,8 +61,7 @@ func (t *truncateNode) startExec(params runParams) error {
 
 	for i := range n.Tables {
 		tn := &n.Tables[i]
-		tableDesc, err := p.ResolveMutableTableDescriptor(
-			ctx, tn, true /*required*/, ResolveRequireTableDesc)
+		tableDesc, err := p.ResolveMutableTableDescriptor(ctx, tn, true /* required */, false /* includeOffline */, ResolveRequireTableDesc)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -67,7 +67,7 @@ var roleMembersTableName = tree.MakeTableName("system", "role_members")
 // BumpRoleMembershipTableVersion increases the table version for the
 // role membership table.
 func (p *planner) BumpRoleMembershipTableVersion(ctx context.Context) error {
-	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, &roleMembersTableName, true, ResolveAnyDescType)
+	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, &roleMembersTableName, true /* required */, false /* includeOffline */, ResolveAnyDescType)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Backport 1/1 commits from #48596.

/cc @cockroachdb/release

---

See the issue for more commentary on the problem. In short, we never dropped
offline tables during `DROP DATABASE ... CASCADE` which would end up leaving
those tables completely orphaned. Orphaned tables with no parent are a problem.

Perhaps it would be better to stop the relevant jobs and then clean up after
them but that's a much more involved fix.

Fixes #48589.

Release note (bug fix): Prevent dropping of databases which contain tables
which are currently offline due to `IMPORT` or `RESTORE`. Previously dropping
a database in this state could lead to a corrupted schema which prevented
running backups.
