### PR TITLE
builtins: fix output of pg_typeof to be compatible

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1878,7 +1878,7 @@ SELECT from_uuid(b'f00d')
 query T
 SELECT pg_catalog.pg_typeof(sign(1:::decimal))
 ----
-decimal
+numeric
 
 query T
 VALUES (pg_typeof(1:::int)),
@@ -1891,15 +1891,15 @@ VALUES (pg_typeof(1:::int)),
        (pg_typeof(b'a':::bytes)),
        (pg_typeof(array[1,2,3]))
 ----
-int
-string
-bool
+bigint
+text
+boolean
 unknown
 interval
 date
-timestamptz
-bytes
-int[]
+timestamp with time zone
+bytea
+bigint[]
 
 query T
 VALUES (format_type('anyelement'::regtype, -1)),

--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -1398,17 +1398,17 @@ SET TIME ZONE -5
 query TT
 select date_trunc('day', '2011-01-02 01:30:00'::date), pg_typeof(date_trunc('day', '2011-01-02 01:30:00'::date))
 ----
-2011-01-02 00:00:00 -0500 -0500  timestamptz
+2011-01-02 00:00:00 -0500 -0500  timestamp with time zone
 
 query TT
 select date_trunc('day', '2011-01-02 01:30:00'::timestamp), pg_typeof(date_trunc('day', '2011-01-02 01:30:00'::timestamp))
 ----
-2011-01-02 00:00:00 +0000 +0000   timestamp
+2011-01-02 00:00:00 +0000 +0000  timestamp without time zone
 
 query TT
 select date_trunc('day', '2011-01-02 01:30:00+00:00'::timestamptz), pg_typeof(date_trunc('day', '2011-01-02 01:30:00+00:00'::timestamptz))
 ----
-2011-01-01 00:00:00 -0500 -0500   timestamptz
+2011-01-01 00:00:00 -0500 -0500  timestamp with time zone
 
 statement ok
 SET TIME ZONE 0
@@ -1544,32 +1544,32 @@ select extract(day from '2019-01-15'::date) as final
 query TT
 select ('2019-01-15'::date + '16:17:18'::time), pg_typeof('2019-01-15'::date + '16:17:18'::time)
 ----
-2019-01-15 16:17:18 +0000 +0000  timestamp
+2019-01-15 16:17:18 +0000 +0000  timestamp without time zone
 
 query TT
 select ('16:17:18'::time + '2019-01-15'::date), pg_typeof(('16:17:18'::time + '2019-01-15'::date))
 ----
-2019-01-15 16:17:18 +0000 +0000  timestamp
+2019-01-15 16:17:18 +0000 +0000  timestamp without time zone
 
 query TT
 select ('2019-01-15'::date + '1 hour'::interval), pg_typeof('2019-01-15'::date + '1 hour'::interval)
 ----
-2019-01-15 01:00:00 +0000 +0000  timestamp
+2019-01-15 01:00:00 +0000 +0000  timestamp without time zone
 
 query TT
 select ('1 hour'::interval + '2019-01-15'::date), pg_typeof('1 hour'::interval + '2019-01-15'::date)
 ----
-2019-01-15 01:00:00 +0000 +0000  timestamp
+2019-01-15 01:00:00 +0000 +0000  timestamp without time zone
 
 query TT
 select ('2019-01-15'::date - '16:17:18'::time), pg_typeof('2019-01-15'::date - '16:17:18'::time)
 ----
-2019-01-14 07:42:42 +0000 +0000  timestamp
+2019-01-14 07:42:42 +0000 +0000  timestamp without time zone
 
 query TT
 select ('2019-01-15'::date - '1 hour'::interval), pg_typeof('2019-01-15'::date - '1 hour'::interval)
 ----
-2019-01-14 23:00:00 +0000 +0000  timestamp
+2019-01-14 23:00:00 +0000 +0000  timestamp without time zone
 
 query B
 select '2019-01-01'::date > '2019-01-01 00:00:00+00'::timestamptz
@@ -1613,32 +1613,32 @@ SET TIME ZONE -5
 query TT
 select (date_test.date_val + date_test.time_val), pg_typeof(date_test.date_val + date_test.time_val) from date_test
 ----
-2019-01-15 16:17:18 +0000 +0000  timestamp
+2019-01-15 16:17:18 +0000 +0000  timestamp without time zone
 
 query TT
 select (date_test.time_val + date_test.date_val), pg_typeof((date_test.time_val + date_test.date_val)) from date_test
 ----
-2019-01-15 16:17:18 +0000 +0000  timestamp
+2019-01-15 16:17:18 +0000 +0000  timestamp without time zone
 
 query TT
 select (date_test.date_val + date_test.interval_val), pg_typeof(date_test.date_val + date_test.interval_val) from date_test
 ----
-2019-01-15 01:00:00 +0000 +0000  timestamp
+2019-01-15 01:00:00 +0000 +0000  timestamp without time zone
 
 query TT
 select (date_test.interval_val + date_test.date_val), pg_typeof(date_test.interval_val + date_test.date_val) from date_test
 ----
-2019-01-15 01:00:00 +0000 +0000  timestamp
+2019-01-15 01:00:00 +0000 +0000  timestamp without time zone
 
 query TT
 select (date_test.date_val - date_test.time_val), pg_typeof(date_test.date_val - date_test.time_val) from date_test
 ----
-2019-01-14 07:42:42 +0000 +0000  timestamp
+2019-01-14 07:42:42 +0000 +0000  timestamp without time zone
 
 query TT
 select (date_test.date_val - date_test.interval_val), pg_typeof(date_test.date_val - date_test.interval_val) from date_test
 ----
-2019-01-14 23:00:00 +0000 +0000  timestamp
+2019-01-14 23:00:00 +0000 +0000  timestamp without time zone
 
 query I
 select count(1) from date_test where date_test.date_val > '2019-01-15 00:00:00+00'::timestamptz

--- a/pkg/sql/logictest/testdata/logic_test/function_lookup
+++ b/pkg/sql/logictest/testdata/logic_test/function_lookup
@@ -2,18 +2,18 @@ statement ok
 CREATE TABLE foo(x INT DEFAULT length(pg_typeof(1234))-1)
 
 statement ok
-CREATE TABLE bar(x INT, CHECK(pg_typeof(123) = 'int'))
+CREATE TABLE bar(x INT, CHECK(pg_typeof(123) = 'bigint'))
 
 statement ok
 ALTER TABLE foo ALTER COLUMN x SET DEFAULT length(pg_typeof(123))
 
 statement ok
-ALTER TABLE foo ADD CONSTRAINT z CHECK(pg_typeof(123) = 'int')
+ALTER TABLE foo ADD CONSTRAINT z CHECK(pg_typeof(123) = 'bigint')
 
 query T
 SELECT pg_typeof(123)
 ----
-int
+bigint
 
 query I
 SELECT count(*) FROM foo GROUP BY pg_typeof(x)
@@ -24,13 +24,13 @@ SELECT * FROM foo LIMIT length(pg_typeof(123))
 ----
 
 query I
-SELECT * FROM foo WHERE pg_typeof(x) = 'int'
+SELECT * FROM foo WHERE pg_typeof(x) = 'bigint'
 ----
 
 query T
 INSERT INTO foo(x) VALUES (42) RETURNING pg_typeof(x)
 ----
-int
+bigint
 
 # CockroachDB is case-preserving for quoted identifiers like pg, and
 # function names only exist in lowercase.

--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -336,7 +336,7 @@ NULL
 query T
 SELECT pg_typeof('{"a": 1}'::JSONB->>'a')
 ----
-string
+text
 
 query T
 SELECT '{"a": 1, "b": 2}'::JSONB->>'b'

--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -119,13 +119,15 @@ SELECT k, v FROM t ORDER BY k LIMIT length(pg_typeof(123))
 1  1
 2  -4
 3  9
+4  -16
+5  25
+6  -36
 
 query II
 SELECT k, v FROM t ORDER BY k LIMIT length(pg_typeof(123)) OFFSET length(pg_typeof(123))-2
 ----
-2  -4
-3  9
-4  -16
+5  25
+6  -36
 
 query II
 SELECT k, v FROM t ORDER BY k OFFSET (SELECT count(*)-3 FROM t)

--- a/pkg/sql/logictest/testdata/logic_test/time
+++ b/pkg/sql/logictest/testdata/logic_test/time
@@ -417,7 +417,7 @@ true
 query TTTT
 select pg_typeof(localtime), pg_typeof(current_time), pg_typeof(localtime(3)), pg_typeof(current_time(3))
 ----
-time  timetz  time  timetz
+time without time zone  time with time zone  time without time zone  time with time zone
 
 subtest regression_42749
 

--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -258,7 +258,7 @@ subtest localtimestamp_test
 query TTTT
 select pg_typeof(localtimestamp), pg_typeof(current_timestamp), pg_typeof(localtimestamp(3)), pg_typeof(current_timestamp(3))
 ----
-timestamp  timestamptz  timestamp  timestamptz
+timestamp without time zone  timestamp with time zone  timestamp without time zone  timestamp with time zone
 
 query B
 select localtimestamp(3) - localtimestamp <= '1ms'::interval

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -79,12 +79,12 @@ query IT rowsort
 SELECT x, pg_typeof(y) FROM (SELECT 1, NULL UNION ALL SELECT 2, 4) AS t(x, y)
 ----
 1  unknown
-2  int
+2  bigint
 
 query IT rowsort
 SELECT x, pg_typeof(y) FROM (SELECT 1, 3 UNION ALL SELECT 2, NULL) AS t(x, y)
 ----
-1  int
+1  bigint
 2  unknown
 
 # INTERSECT with NULL columns in operands works.

--- a/pkg/sql/plan_opt_test.go
+++ b/pkg/sql/plan_opt_test.go
@@ -486,17 +486,17 @@ SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
 			r0.Exec(t, "PREPARE c3 (decimal) AS SELECT pg_typeof(1 + $1)") // Should miss the cache.
 			h.AssertStats(t, 3 /* hits */, 6 /* misses */)
 
-			r0.CheckQueryResults(t, "EXECUTE a1 (1)", [][]string{{"int"}})
-			r0.CheckQueryResults(t, "EXECUTE a2 (1)", [][]string{{"int"}})
-			r0.CheckQueryResults(t, "EXECUTE a3 (1)", [][]string{{"int"}})
+			r0.CheckQueryResults(t, "EXECUTE a1 (1)", [][]string{{"bigint"}})
+			r0.CheckQueryResults(t, "EXECUTE a2 (1)", [][]string{{"bigint"}})
+			r0.CheckQueryResults(t, "EXECUTE a3 (1)", [][]string{{"bigint"}})
 
-			r0.CheckQueryResults(t, "EXECUTE b1 (1)", [][]string{{"float"}})
-			r0.CheckQueryResults(t, "EXECUTE b2 (1)", [][]string{{"float"}})
-			r0.CheckQueryResults(t, "EXECUTE b3 (1)", [][]string{{"float"}})
+			r0.CheckQueryResults(t, "EXECUTE b1 (1)", [][]string{{"double precision"}})
+			r0.CheckQueryResults(t, "EXECUTE b2 (1)", [][]string{{"double precision"}})
+			r0.CheckQueryResults(t, "EXECUTE b3 (1)", [][]string{{"double precision"}})
 
-			r0.CheckQueryResults(t, "EXECUTE c1 (1)", [][]string{{"decimal"}})
-			r0.CheckQueryResults(t, "EXECUTE c2 (1)", [][]string{{"decimal"}})
-			r0.CheckQueryResults(t, "EXECUTE c3 (1)", [][]string{{"decimal"}})
+			r0.CheckQueryResults(t, "EXECUTE c1 (1)", [][]string{{"numeric"}})
+			r0.CheckQueryResults(t, "EXECUTE c2 (1)", [][]string{{"numeric"}})
+			r0.CheckQueryResults(t, "EXECUTE c3 (1)", [][]string{{"numeric"}})
 		})
 	})
 }

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -737,7 +737,7 @@ var pgBuiltins = map[string]builtinDefinition{
 			Types:      tree.ArgTypes{{"val", types.Any}},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				return tree.NewDString(args[0].ResolvedType().String()), nil
+				return tree.NewDString(args[0].ResolvedType().SQLStandardName()), nil
 			},
 			Info: notUsableInfo,
 		},

--- a/pkg/sql/sem/tree/testdata/eval/hex
+++ b/pkg/sql/sem/tree/testdata/eval/hex
@@ -25,7 +25,7 @@ X'636174'
 eval
 pg_typeof(x'636174')
 ----
-'bytes'
+'bytea'
 
 eval
 '\x636174'::bytes


### PR DESCRIPTION
Previously, the builtin pg_typeof was returning a CockroachDB-specific
type string for each type. This is not quite correct - we want to return
the "SQL Standard Type Name" for each datatype to match what Postgres
does.

Release note (sql change): improve compatibility of pg_typeof builtin
function.