### PR TITLE
opt: modify ConvertZipArraysToValues to handle json_array_elements

### DIFF
--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -1170,7 +1170,7 @@ func (c *CustomFuncs) ProjectExtraCol(
 //
 // 	3. There is at least one row.
 //
-// 	4. All tuples in the single column are either TupleExpr's or ConstExpr's
+// 	4. All tuples in the single column are either TupleExprs or ConstExprs
 //     that wrap DTuples, as opposed to dynamically generated tuples.
 //
 func (c *CustomFuncs) CanUnnestTuplesFromValues(expr memo.RelExpr) bool {
@@ -1707,22 +1707,34 @@ func (c *CustomFuncs) ZipOuterCols(zip memo.ZipExpr) opt.ColSet {
 	return colSet
 }
 
+// unnestFuncs maps function names that are supported by
+// ConvertZipArraysToValues
+var unnestFuncs = map[string]struct{}{
+	"unnest":               {},
+	"json_array_elements":  {},
+	"jsonb_array_elements": {},
+}
+
 // CanConstructValuesFromZips takes in an input ZipExpr and returns true if the
 // ProjectSet to which the zip belongs can be converted to an InnerJoinApply
 // with a Values operator on the right input.
 func (c *CustomFuncs) CanConstructValuesFromZips(zip memo.ZipExpr) bool {
-	for _, zipItem := range zip {
-		fn, ok := zipItem.Fn.(*memo.FunctionExpr)
-		if !ok || fn.Name != "unnest" {
-			// Not an unnest function.
+	for i := range zip {
+		fn, ok := zip[i].Fn.(*memo.FunctionExpr)
+		if !ok {
+			// Not a FunctionExpr.
+			return false
+		}
+		if _, ok := unnestFuncs[fn.Name]; !ok {
+			// Not a supported function.
 			return false
 		}
 		if len(fn.Args) != 1 {
-			// Unnest has more than one argument.
+			// Function has more than one argument.
 			return false
 		}
-		if !c.IsStaticArray(fn.Args[0]) {
-			// Unnest argument is not an ArrayExpr or ConstExpr wrapping a DArray.
+		if !c.IsStaticArray(fn.Args[0]) && !c.WrapsJSONArray(fn.Args[0]) {
+			// Argument is not an ArrayExpr or ConstExpr wrapping a DArray or DJSON.
 			return false
 		}
 	}
@@ -1730,12 +1742,14 @@ func (c *CustomFuncs) CanConstructValuesFromZips(zip memo.ZipExpr) bool {
 }
 
 // ConstructValuesFromZips constructs a Values operator with the elements from
-// the given ArrayExpr(s) (or ConstExpr(s) that wrap a DArray) in the given
-// ZipExpr.
+// the given ArrayExpr(s) or the ConstExpr(s) that wrap a DArray or DJSON in the
+// given ZipExpr.
 //
-// The functions contained in the ZipExpr must be unnest functions with a single
-// parameter each. The parameters of the unnest functions must be either
-// ArrayExpr's or ConstExpr's wrapping DArrays.
+// The functions contained in the ZipExpr must be unnest, json_array_elements or
+// jsonb_array_elements functions with a single parameter each. The parameters
+// of the unnest functions must be either ArrayExprs or ConstExprs wrapping
+// DArrays. The parameters of the json_array_elements functions must be
+// ConstExprs wrapping DJSON datums.
 func (c *CustomFuncs) ConstructValuesFromZips(zip memo.ZipExpr) memo.RelExpr {
 	numCols := len(zip)
 	outColTypes := make([]*types.T, numCols)
@@ -1743,17 +1757,27 @@ func (c *CustomFuncs) ConstructValuesFromZips(zip memo.ZipExpr) memo.RelExpr {
 	var outRows []memo.ScalarListExpr
 
 	// Get type and ColumnID of each column.
-	for i, zipItem := range zip {
-		arrExpr := zipItem.Fn.(*memo.FunctionExpr).Args[0]
-		outColTypes[i] = arrExpr.DataType().ArrayContents()
-		outColIDs[i] = zipItem.Cols[0]
+	for i := range zip {
+		function := zip[i].Fn.(*memo.FunctionExpr)
+		expr := function.Args[0]
+		switch function.Name {
+		case "unnest":
+			outColTypes[i] = expr.DataType().ArrayContents()
+
+		case "json_array_elements", "jsonb_array_elements":
+			outColTypes[i] = types.Jsonb
+
+		default:
+			panic(errors.AssertionFailedf("invalid function name: %v", function.Name))
+		}
+		outColIDs[i] = zip[i].Cols[0]
 	}
 
 	// addValToOutRows inserts a value into outRows at the given index.
 	addValToOutRows := func(expr opt.ScalarExpr, rIndex, cIndex int) {
 		if rIndex >= len(outRows) {
 			// If this is the largest column encountered so far, make a new row and
-			// fill with NullExpr's.
+			// fill with NullExprs.
 			outRows = append(outRows, make(memo.ScalarListExpr, numCols))
 			for i := 0; i < numCols; i++ {
 				outRows[rIndex][i] = c.f.ConstructNull(outColTypes[cIndex])
@@ -1763,24 +1787,55 @@ func (c *CustomFuncs) ConstructValuesFromZips(zip memo.ZipExpr) memo.RelExpr {
 	}
 
 	// Fill outRows with values from the arrays in the ZipExpr.
-	for i, zipItem := range zip {
-		arrExpr := zipItem.Fn.(*memo.FunctionExpr).Args[0]
-		switch t := arrExpr.(type) {
+	for i := range zip {
+		function := zip[i].Fn.(*memo.FunctionExpr)
+		param := function.Args[0]
+		switch t := param.(type) {
 		case *memo.ArrayExpr:
 			for j, val := range t.Elems {
 				addValToOutRows(val, j, i)
 			}
 
 		case *memo.ConstExpr:
-			dArray := t.Value.(*tree.DArray)
-			for j, elem := range dArray.Array {
-				val := c.f.ConstructConstVal(elem, dArray.ParamTyp)
+			// Use a ValueGenerator to retrieve values from the datums wrapped
+			// in the ConstExpr. These generators are used at runtime to unnest
+			// values from regular and JSON arrays.
+			generator, err := function.Overload.Generator(c.f.evalCtx, tree.Datums{t.Value})
+			if err != nil {
+				panic(errors.AssertionFailedf("generator retrieval failed: %v", err))
+			}
+			if err = generator.Start(c.f.evalCtx.Context, c.f.evalCtx.Txn); err != nil {
+				panic(errors.AssertionFailedf("generator.Start failed: %v", err))
+			}
+
+			for j := 0; ; j++ {
+				hasNext, err := generator.Next(c.f.evalCtx.Context)
+				if err != nil {
+					panic(errors.AssertionFailedf("generator.Next failed: %v", err))
+				}
+				if !hasNext {
+					break
+				}
+
+				vals, err := generator.Values()
+				if err != nil {
+					panic(errors.AssertionFailedf("failed to retrieve values: %v", err))
+				}
+				if len(vals) != 1 {
+					panic(errors.AssertionFailedf(
+						"ValueGenerator didn't return exactly one value: %v", log.Safe(vals)))
+				}
+				val := c.f.ConstructConstVal(vals[0], vals[0].ResolvedType())
 				addValToOutRows(val, j, i)
 			}
+			generator.Close()
+
+		default:
+			panic(errors.AssertionFailedf("invalid parameter type"))
 		}
 	}
 
-	// Convert outRows (a slice of ScalarListExpr's) into a ScalarListExpr
+	// Convert outRows (a slice of ScalarListExprs) into a ScalarListExpr
 	// containing a tuple for each row.
 	tuples := make(memo.ScalarListExpr, len(outRows))
 	for i, row := range outRows {
@@ -2202,6 +2257,17 @@ func (c *CustomFuncs) AllowNullArgs(op opt.Operator, left, right opt.ScalarExpr)
 func (c *CustomFuncs) IsJSONScalar(value opt.ScalarExpr) bool {
 	v := value.(*memo.ConstExpr).Value.(*tree.DJSON)
 	return v.JSON.Type() != json.ObjectJSONType && v.JSON.Type() != json.ArrayJSONType
+}
+
+// WrapsJSONArray returns true if the given ScalarExpr is a ConstExpr that wraps
+// a DJSON datum that contains a JSON array.
+func (c *CustomFuncs) WrapsJSONArray(expr opt.ScalarExpr) bool {
+	if constExpr, ok := expr.(*memo.ConstExpr); ok {
+		if dJSON, ok := constExpr.Value.(*tree.DJSON); ok {
+			return dJSON.JSON.Type() == json.ArrayJSONType
+		}
+	}
+	return false
 }
 
 // MakeSingleKeyJSONObject returns a JSON object with one entry, mapping key to value.

--- a/pkg/sql/opt/norm/rules/project_set.opt
+++ b/pkg/sql/opt/norm/rules/project_set.opt
@@ -2,12 +2,15 @@
 # project_set.opt contains normalization rules for the ProjectSet operator.
 # =============================================================================
 
-# ConvertZipArraysToValues applies the unnest zip function to array inputs,
-# converting them into a Values operator within an InnerJoinApply. This allows
-# Values and decorrelation rules to fire. It is especially useful in cases where
-# the array contents are passed as a PREPARE parameter, such as:
+# ConvertZipArraysToValues applies the unnest, json_array_elements and
+# jsonb_array_elements zip functions to array inputs, converting them into a
+# Values operator within an InnerJoinApply. This allows Values and decorrelation
+# rules to fire. It is especially useful in cases where the contents are passed
+# as a PREPARE parameter, such as:
 #
 #   SELECT * FROM xy WHERE y IN unnest($1)
+# or:
+#   SELECT json_array_elements($1)
 #
 # The replace pattern is equivalent to the match pattern because the
 # InnerJoinApply outputs every value in the array for every row in the input,

--- a/pkg/sql/opt/norm/testdata/rules/project_set
+++ b/pkg/sql/opt/norm/testdata/rules/project_set
@@ -1,12 +1,12 @@
 exec-ddl
-CREATE TABLE xy (x INT PRIMARY KEY, y INT)
+CREATE TABLE xy (x INT PRIMARY KEY, y INT, j JSON)
 ----
 
 # --------------------------------------------------
 # ConvertZipArraysToValues
 # --------------------------------------------------
 
-# Basic case with single unzip and only constants in array.
+# Basic unnest case with single unzip and only constants in array.
 norm expect=ConvertZipArraysToValues
 SELECT unnest(ARRAY[1,2,3])
 ----
@@ -16,6 +16,41 @@ values
  ├── (1,)
  ├── (2,)
  └── (3,)
+
+# Case with json_array_elements.
+norm expect=ConvertZipArraysToValues
+SELECT json_array_elements('[{"a": "one", "b": "two"}, {"a": "three", "b": "four"}]'::JSON)
+----
+values
+ ├── columns: json_array_elements:1!null
+ ├── cardinality: [2 - 2]
+ ├── ('{"a": "one", "b": "two"}',)
+ └── ('{"a": "three", "b": "four"}',)
+
+# Case with jsonb_array_elements.
+norm expect=ConvertZipArraysToValues
+SELECT jsonb_array_elements('[{"a": "one", "b": "two"}, {"a": "three", "b": "four"}]'::JSON)
+----
+values
+ ├── columns: jsonb_array_elements:1!null
+ ├── cardinality: [2 - 2]
+ ├── ('{"a": "one", "b": "two"}',)
+ └── ('{"a": "three", "b": "four"}',)
+
+# Case with all three matched function types and different array sizes.
+# Case with json_array_elements.
+norm expect=ConvertZipArraysToValues
+SELECT
+    unnest(ARRAY[1,2,3]),
+    json_array_elements('[{"a": "one", "b": "two"}, {"a": "three", "b": "four"}]'::JSON),
+    jsonb_array_elements('[{"x": "one", "y": "two"}]'::JSON)
+----
+values
+ ├── columns: unnest:1!null json_array_elements:2 jsonb_array_elements:3
+ ├── cardinality: [3 - 3]
+ ├── (1, '{"a": "one", "b": "two"}', '{"x": "one", "y": "two"}')
+ ├── (2, '{"a": "three", "b": "four"}', NULL)
+ └── (3, NULL, NULL)
 
 # Case with subquery in ProjectSet input.
 norm expect=ConvertZipArraysToValues
@@ -42,16 +77,16 @@ norm expect=ConvertZipArraysToValues
 SELECT unnest(ARRAY[x,y]) FROM xy
 ----
 project
- ├── columns: unnest:3
+ ├── columns: unnest:4
  └── inner-join-apply
-      ├── columns: x:1!null y:2 unnest:3
+      ├── columns: x:1!null y:2 unnest:4
       ├── fd: (1)-->(2)
       ├── scan xy
       │    ├── columns: x:1!null y:2
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
       ├── values
-      │    ├── columns: unnest:3
+      │    ├── columns: unnest:4
       │    ├── outer: (1,2)
       │    ├── cardinality: [2 - 2]
       │    ├── (x:1,)
@@ -69,15 +104,15 @@ WHERE EXISTS
 )
 ----
 semi-join-apply
- ├── columns: x:1!null y:2!null
+ ├── columns: x:1!null y:2!null j:3
  ├── key: (1)
- ├── fd: (1)-->(2)
+ ├── fd: (1)-->(2,3)
  ├── scan xy
- │    ├── columns: x:1!null y:2
+ │    ├── columns: x:1!null y:2 j:3
  │    ├── key: (1)
- │    └── fd: (1)-->(2)
+ │    └── fd: (1)-->(2,3)
  ├── values
- │    ├── columns: unnest:3
+ │    ├── columns: unnest:4
  │    ├── outer: (1)
  │    ├── cardinality: [6 - 6]
  │    ├── (NULL,)
@@ -87,41 +122,30 @@ semi-join-apply
  │    ├── (5,)
  │    └── (x:1,)
  └── filters
-      └── unnest:3 = y:2 [outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]), fd=(2)==(3), (3)==(2)]
+      └── unnest:4 = y:2 [outer=(2,4), constraints=(/2: (/NULL - ]; /4: (/NULL - ]), fd=(2)==(4), (4)==(2)]
 
-# Case with multiple arrays of different sizes.
+# Case with multiple arrays of different types and different sizes, including an
+# empty array.
 norm expect=ConvertZipArraysToValues
-SELECT unnest(ARRAY[1,2,3]), unnest(ARRAY[1,2,3,4,5,6,NULL,8,9,10]), unnest(ARRAY[]::INT[])
+SELECT
+    unnest(ARRAY['one','two','three']),
+    unnest(ARRAY[1,2,5,6,NULL,8]),
+    unnest(ARRAY[]::BOOL[]),
+    json_array_elements('[{"a": "one", "b": "two"}, {"a": "three", "b": "four"}]'::JSON),
+    jsonb_array_elements('[{"x": "one", "y": "two"}]'::JSON),
+    jsonb_array_elements('[]'::JSON)
 ----
 values
- ├── columns: unnest:1 unnest:2 unnest:3
- ├── cardinality: [10 - 10]
- ├── (1, 1, NULL)
- ├── (2, 2, NULL)
- ├── (3, 3, NULL)
- ├── (NULL, 4, NULL)
- ├── (NULL, 5, NULL)
- ├── (NULL, 6, NULL)
- ├── (NULL, NULL, NULL)
- ├── (NULL, 8, NULL)
- ├── (NULL, 9, NULL)
- └── (NULL, 10, NULL)
-
-# Case with multiple arrays of different types and different sizes.
-norm expect=ConvertZipArraysToValues
-SELECT unnest(ARRAY['one','two','three']), unnest(ARRAY[1,2,5,6,NULL,8]), unnest(ARRAY[]::BOOL[])
-----
-values
- ├── columns: unnest:1 unnest:2 unnest:3
+ ├── columns: unnest:1 unnest:2 unnest:3 json_array_elements:4 jsonb_array_elements:5 jsonb_array_elements:6
  ├── cardinality: [6 - 6]
- ├── ('one', 1, NULL)
- ├── ('two', 2, NULL)
- ├── ('three', 5, NULL)
- ├── (NULL, 6, NULL)
- ├── (NULL, NULL, NULL)
- └── (NULL, 8, NULL)
+ ├── ('one', 1, NULL, '{"a": "one", "b": "two"}', '{"x": "one", "y": "two"}', NULL)
+ ├── ('two', 2, NULL, '{"a": "three", "b": "four"}', NULL, NULL)
+ ├── ('three', 5, NULL, NULL, NULL, NULL)
+ ├── (NULL, 6, NULL, NULL, NULL, NULL)
+ ├── (NULL, NULL, NULL, NULL, NULL, NULL)
+ └── (NULL, 8, NULL, NULL, NULL, NULL)
 
-# Case with multiple empty arrays.
+# unnest case with multiple empty arrays.
 norm expect=ConvertZipArraysToValues
 SELECT unnest(ARRAY[]::STRING[]), unnest(ARRAY[]::REAL[]), unnest(ARRAY[]::INT[])
 ----
@@ -131,21 +155,51 @@ values
  ├── key: ()
  └── fd: ()-->(1-3)
 
+# json_array_elements case with empty array.
+norm expect=ConvertZipArraysToValues
+SELECT json_array_elements('[]')
+----
+values
+ ├── columns: json_array_elements:1!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1)
+
+# unnest case with array of arrays.
+norm expect=ConvertZipArraysToValues
+SELECT unnest(ARRAY[[1,2,3],[4,5]])
+----
+values
+ ├── columns: unnest:1!null
+ ├── cardinality: [2 - 2]
+ ├── (ARRAY[1,2,3],)
+ └── (ARRAY[4,5],)
+
+# json_array_elements case with array of arrays.
+norm expect=ConvertZipArraysToValues
+SELECT json_array_elements('[[{"a": "x"}],[{"a": "y"}]]')
+----
+values
+ ├── columns: json_array_elements:1!null
+ ├── cardinality: [2 - 2]
+ ├── ('[{"a": "x"}]',)
+ └── ('[{"a": "y"}]',)
+
 # Case with multiple correlated arrays.
 norm expect=ConvertZipArraysToValues
 SELECT unnest(ARRAY[x,y]), unnest(ARRAY[1,x*100]) FROM xy
 ----
 project
- ├── columns: unnest:3 unnest:4
+ ├── columns: unnest:4 unnest:5
  └── inner-join-apply
-      ├── columns: x:1!null y:2 unnest:3 unnest:4
+      ├── columns: x:1!null y:2 unnest:4 unnest:5
       ├── fd: (1)-->(2)
       ├── scan xy
       │    ├── columns: x:1!null y:2
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
       ├── values
-      │    ├── columns: unnest:3 unnest:4
+      │    ├── columns: unnest:4 unnest:5
       │    ├── outer: (1,2)
       │    ├── cardinality: [2 - 2]
       │    ├── (x:1, 1)
@@ -153,8 +207,8 @@ project
       └── filters (true)
 
 # No-op case - ConvertZipArraysToValues fires the first time but not the
-# second because the outer zip is over a variable of an array instead of an
-# array.
+# second because the outer zip is over a variable of an array instead of the
+# array itself.
 norm expect=ConvertZipArraysToValues
 SELECT unnest(x) FROM unnest(ARRAY[[1,2,3],[4,5],[6]]) AS x
 ----
@@ -173,12 +227,51 @@ project
       └── zip
            └── unnest(unnest:1) [outer=(1), side-effects]
 
-# No-op case because array_agg is not an ArrayExpr or ConstExpr with a DArray.
+# No-op case - an unnest with multiple inputs is not matched.
+norm expect-not=ConvertZipArraysToValues
+SELECT unnest(ARRAY[1,2,3], ARRAY[4,5,6])
+----
+project
+ ├── columns: unnest:3
+ ├── side-effects
+ ├── project-set
+ │    ├── columns: unnest:1 unnest:2
+ │    ├── side-effects
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── ()
+ │    └── zip
+ │         └── unnest(ARRAY[1,2,3], ARRAY[4,5,6]) [side-effects]
+ └── projections
+      └── ((unnest:1, unnest:2) AS unnest, unnest) [as=unnest:3, outer=(1,2)]
+
+# No-op case because one of the ZipItems is not valid.
+norm expect-not=ConvertZipArraysToValues
+SELECT unnest(ARRAY[1,2,3]), unnest(ARRAY[1,2,3], ARRAY[4,5,6])
+----
+project
+ ├── columns: unnest:1 unnest:4
+ ├── side-effects
+ ├── project-set
+ │    ├── columns: unnest:1 unnest:2 unnest:3
+ │    ├── side-effects
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── ()
+ │    └── zip
+ │         ├── unnest(ARRAY[1,2,3]) [side-effects]
+ │         └── unnest(ARRAY[1,2,3], ARRAY[4,5,6]) [side-effects]
+ └── projections
+      └── ((unnest:2, unnest:3) AS unnest, unnest) [as=unnest:4, outer=(2,3)]
+
+# No-op case because array_agg can only be determined at runtime.
 norm expect-not=ConvertZipArraysToValues
 SELECT unnest((SELECT array_agg(y) FROM xy))
 ----
 project-set
- ├── columns: unnest:4
+ ├── columns: unnest:5
  ├── side-effects
  ├── values
  │    ├── cardinality: [1 - 1]
@@ -188,12 +281,27 @@ project-set
       └── function: unnest [side-effects, subquery]
            └── subquery
                 └── scalar-group-by
-                     ├── columns: array_agg:3
+                     ├── columns: array_agg:4
                      ├── cardinality: [1 - 1]
                      ├── key: ()
-                     ├── fd: ()-->(3)
+                     ├── fd: ()-->(4)
                      ├── scan xy
                      │    └── columns: y:2
                      └── aggregations
-                          └── array-agg [as=array_agg:3, outer=(2)]
+                          └── array-agg [as=array_agg:4, outer=(2)]
                                └── y:2
+
+# No-op case because a JSON column can only be determined at run-time.
+norm expect-not=ConvertZipArraysToValues
+SELECT json_array_elements(j) FROM xy
+----
+project
+ ├── columns: json_array_elements:4
+ ├── side-effects
+ └── project-set
+      ├── columns: j:3 json_array_elements:4
+      ├── side-effects
+      ├── scan xy
+      │    └── columns: j:3
+      └── zip
+           └── json_array_elements(j:3) [outer=(3), side-effects]

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -542,31 +542,24 @@ WHERE
 ----
 project
  ├── columns: secondary_id:6 "?column?":7
- ├── side-effects
  ├── inner-join (lookup idtable)
- │    ├── columns: primary_id:1!null idtable.secondary_id:2!null data:3!null value:4 column5:5!null
+ │    ├── columns: primary_id:1!null idtable.secondary_id:2!null data:3!null value:4!null column5:5!null
  │    ├── key columns: [1] = [1]
  │    ├── lookup columns are key
- │    ├── side-effects
  │    ├── fd: (1)-->(2,3), (4)-->(5), (2)==(5), (5)==(2)
  │    ├── inner-join (lookup idtable@secondary_id)
- │    │    ├── columns: primary_id:1!null idtable.secondary_id:2!null value:4 column5:5!null
+ │    │    ├── columns: primary_id:1!null idtable.secondary_id:2!null value:4!null column5:5!null
  │    │    ├── key columns: [5] = [2]
- │    │    ├── side-effects
  │    │    ├── fd: (4)-->(5), (1)-->(2), (2)==(5), (5)==(2)
  │    │    ├── project
- │    │    │    ├── columns: column5:5 value:4
- │    │    │    ├── side-effects
+ │    │    │    ├── columns: column5:5 value:4!null
+ │    │    │    ├── cardinality: [2 - 2]
  │    │    │    ├── fd: (4)-->(5)
- │    │    │    ├── project-set
- │    │    │    │    ├── columns: value:4
- │    │    │    │    ├── side-effects
- │    │    │    │    ├── values
- │    │    │    │    │    ├── cardinality: [1 - 1]
- │    │    │    │    │    ├── key: ()
- │    │    │    │    │    └── ()
- │    │    │    │    └── zip
- │    │    │    │         └── json_array_elements('[{"person_id": "8e5dc104-9f38-4255-9283-fd080be16c57", "product_id": "a739c2d3-edec-413b-88d8-9c31d0414b1e"}, {"person_id": "308686c4-7415-4c2d-92d5-25b39a1c84e2", "product_id": "3f12802d-5b0f-43d7-a0d0-12ac8e88cb18"}]') [side-effects]
+ │    │    │    ├── values
+ │    │    │    │    ├── columns: value:4!null
+ │    │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    │    ├── ('{"person_id": "8e5dc104-9f38-4255-9283-fd080be16c57", "product_id": "a739c2d3-edec-413b-88d8-9c31d0414b1e"}',)
+ │    │    │    │    └── ('{"person_id": "308686c4-7415-4c2d-92d5-25b39a1c84e2", "product_id": "3f12802d-5b0f-43d7-a0d0-12ac8e88cb18"}',)
  │    │    │    └── projections
  │    │    │         └── (value:4->>'secondary_id')::UUID [as=column5:5, outer=(4)]
  │    │    └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1020,9 +1020,6 @@ values
            └── '70f03eb1-4f58-4c26-b72d-c524a9d537dd'
 
 # Get account locations of a list of cards.
-#
-# Problems:
-#   1. Tuple access is not folded with Values operator.
 opt
 WITH CardsToFind AS
 (
@@ -1248,13 +1245,6 @@ upsert transactions
 
 # Insert structured data (c=CardId, q=Quantity, s=SellPrice, b=BuyPrice)
 # represented as JSON into TransactionDetails table.
-#
-# Problems:
-#   1. WITH is not inlined into the query, because it is marked as having side
-#      effects, even though it does not.
-#   2. jsonb_array_elements should be folded into VALUES operator when it
-#      operates over constant JSON.
-#
 opt
 WITH updates AS (SELECT jsonb_array_elements('[
     {"c": 49833, "q": 4, "s": 2.89, "b": 2.29},
@@ -1268,115 +1258,110 @@ SELECT
   (Detail->'s')::TEXT::DECIMAL(10,4), (Detail->'b')::TEXT::DECIMAL(10,4)
 FROM updates
 ----
-with &1 (updates)
+upsert transactiondetails
+ ├── columns: <none>
+ ├── canary column: 21
+ ├── fetch columns: transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondate:23 cardid:24 quantity:25 transactiondetails.sellprice:26 transactiondetails.buyprice:27 transactiondetails.version:28
+ ├── insert-mapping:
+ │    ├── "?column?":11 => transactiondetails.dealerid:2
+ │    ├── bool:12 => transactiondetails.isbuy:3
+ │    ├── current_timestamp:13 => transactiondate:4
+ │    ├── int8:14 => cardid:5
+ │    ├── int8:15 => quantity:6
+ │    ├── sellprice:29 => transactiondetails.sellprice:7
+ │    ├── buyprice:30 => transactiondetails.buyprice:8
+ │    └── column18:18 => transactiondetails.version:9
+ ├── update-mapping:
+ │    ├── sellprice:29 => transactiondetails.sellprice:7
+ │    └── buyprice:30 => transactiondetails.buyprice:8
+ ├── input binding: &2
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
- ├── project-set
- │    ├── columns: jsonb_array_elements:1
+ ├── project
+ │    ├── columns: upsert_dealerid:31 upsert_isbuy:32 upsert_transactiondate:33 upsert_cardid:34 sellprice:29 buyprice:30 "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15 column18:18 transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondate:23 cardid:24 quantity:25 transactiondetails.sellprice:26 transactiondetails.buyprice:27 transactiondetails.version:28
+ │    ├── cardinality: [1 - ]
  │    ├── side-effects
- │    ├── values
- │    │    ├── cardinality: [1 - 1]
- │    │    ├── key: ()
- │    │    └── ()
- │    └── zip
- │         └── jsonb_array_elements('[{"b": 2.29, "c": 49833, "q": 4, "s": 2.89}, {"b": 17.59, "c": 29483, "q": 2, "s": 18.93}]') [side-effects]
- └── upsert transactiondetails
-      ├── columns: <none>
-      ├── canary column: 21
-      ├── fetch columns: transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondate:23 cardid:24 quantity:25 transactiondetails.sellprice:26 transactiondetails.buyprice:27 transactiondetails.version:28
-      ├── insert-mapping:
-      │    ├── "?column?":11 => transactiondetails.dealerid:2
-      │    ├── bool:12 => transactiondetails.isbuy:3
-      │    ├── current_timestamp:13 => transactiondate:4
-      │    ├── int8:14 => cardid:5
-      │    ├── int8:15 => quantity:6
-      │    ├── sellprice:29 => transactiondetails.sellprice:7
-      │    ├── buyprice:30 => transactiondetails.buyprice:8
-      │    └── column18:18 => transactiondetails.version:9
-      ├── update-mapping:
-      │    ├── sellprice:29 => transactiondetails.sellprice:7
-      │    └── buyprice:30 => transactiondetails.buyprice:8
-      ├── input binding: &2
-      ├── cardinality: [0 - 0]
-      ├── side-effects, mutations
-      ├── project
-      │    ├── columns: upsert_dealerid:31 upsert_isbuy:32 upsert_transactiondate:33 upsert_cardid:34 sellprice:29 buyprice:30 "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15 column18:18 transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondate:23 cardid:24 quantity:25 transactiondetails.sellprice:26 transactiondetails.buyprice:27 transactiondetails.version:28
-      │    ├── side-effects
-      │    ├── lax-key: (13-15,21-25)
-      │    ├── fd: ()-->(11,12), (13-15)~~>(18), (21-25)-->(26-28), (21)-->(31), (21,22)-->(32), (13,21,23)-->(33), (14,21,24)-->(34), (13-15,21-25)~~>(18,29,30)
-      │    ├── left-join (lookup transactiondetails)
-      │    │    ├── columns: "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15 column18:18 sellprice:19 buyprice:20 transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondate:23 cardid:24 quantity:25 transactiondetails.sellprice:26 transactiondetails.buyprice:27 transactiondetails.version:28
-      │    │    ├── key columns: [11 12 13 14 15] = [21 22 23 24 25]
-      │    │    ├── lookup columns are key
-      │    │    ├── side-effects
-      │    │    ├── lax-key: (13-15,21-25)
-      │    │    ├── fd: ()-->(11,12), (13-15)~~>(18-20), (21-25)-->(26-28)
-      │    │    ├── upsert-distinct-on
-      │    │    │    ├── columns: "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15 column18:18 sellprice:19 buyprice:20
-      │    │    │    ├── grouping columns: current_timestamp:13 int8:14 int8:15
-      │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
-      │    │    │    ├── side-effects
-      │    │    │    ├── lax-key: (13-15)
-      │    │    │    ├── fd: ()-->(11,12), (13-15)~~>(11,12,18-20)
-      │    │    │    ├── project
-      │    │    │    │    ├── columns: sellprice:19 buyprice:20 column18:18 "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15
-      │    │    │    │    ├── side-effects
-      │    │    │    │    ├── fd: ()-->(11,12)
-      │    │    │    │    ├── with-scan &1 (updates)
-      │    │    │    │    │    ├── columns: detail:10
-      │    │    │    │    │    └── mapping:
-      │    │    │    │    │         └──  jsonb_array_elements:1 => detail:10
-      │    │    │    │    └── projections
-      │    │    │    │         ├── crdb_internal.round_decimal_values((detail:10->'s')::STRING::DECIMAL(10,4), 4) [as=sellprice:19, outer=(10)]
-      │    │    │    │         ├── crdb_internal.round_decimal_values((detail:10->'b')::STRING::DECIMAL(10,4), 4) [as=buyprice:20, outer=(10)]
-      │    │    │    │         ├── cluster_logical_timestamp() [as=column18:18, side-effects]
-      │    │    │    │         ├── 1 [as="?column?":11]
-      │    │    │    │         ├── false [as=bool:12]
-      │    │    │    │         ├── current_timestamp() [as=current_timestamp:13, side-effects]
-      │    │    │    │         ├── (detail:10->'c')::STRING::INT8 [as=int8:14, outer=(10)]
-      │    │    │    │         └── (detail:10->'q')::STRING::INT8 [as=int8:15, outer=(10)]
-      │    │    │    └── aggregations
-      │    │    │         ├── first-agg [as=sellprice:19, outer=(19)]
-      │    │    │         │    └── sellprice:19
-      │    │    │         ├── first-agg [as=buyprice:20, outer=(20)]
-      │    │    │         │    └── buyprice:20
-      │    │    │         ├── first-agg [as=column18:18, outer=(18)]
-      │    │    │         │    └── column18:18
-      │    │    │         ├── const-agg [as="?column?":11, outer=(11)]
-      │    │    │         │    └── "?column?":11
-      │    │    │         └── const-agg [as=bool:12, outer=(12)]
-      │    │    │              └── bool:12
-      │    │    └── filters (true)
-      │    └── projections
-      │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN "?column?":11 ELSE transactiondetails.dealerid:21 END [as=upsert_dealerid:31, outer=(11,21)]
-      │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN bool:12 ELSE transactiondetails.isbuy:22 END [as=upsert_isbuy:32, outer=(12,21,22)]
-      │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN current_timestamp:13 ELSE transactiondate:23 END [as=upsert_transactiondate:33, outer=(13,21,23)]
-      │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN int8:14 ELSE cardid:24 END [as=upsert_cardid:34, outer=(14,21,24)]
-      │         ├── crdb_internal.round_decimal_values(sellprice:19, 4) [as=sellprice:29, outer=(19)]
-      │         └── crdb_internal.round_decimal_values(buyprice:20, 4) [as=buyprice:30, outer=(20)]
-      └── f-k-checks
-           ├── f-k-checks-item: transactiondetails(dealerid,isbuy,transactiondate) -> transactions(dealerid,isbuy,date)
-           │    └── anti-join (lookup transactions)
-           │         ├── columns: upsert_dealerid:37 upsert_isbuy:38 upsert_transactiondate:39
-           │         ├── key columns: [37 38 39] = [40 41 42]
-           │         ├── lookup columns are key
-           │         ├── with-scan &2
-           │         │    ├── columns: upsert_dealerid:37 upsert_isbuy:38 upsert_transactiondate:39
-           │         │    └── mapping:
-           │         │         ├──  upsert_dealerid:31 => upsert_dealerid:37
-           │         │         ├──  upsert_isbuy:32 => upsert_isbuy:38
-           │         │         └──  upsert_transactiondate:33 => upsert_transactiondate:39
-           │         └── filters (true)
-           └── f-k-checks-item: transactiondetails(cardid) -> cards(id)
-                └── anti-join (lookup cards)
-                     ├── columns: upsert_cardid:47
-                     ├── key columns: [47] = [48]
-                     ├── lookup columns are key
-                     ├── with-scan &2
-                     │    ├── columns: upsert_cardid:47
-                     │    └── mapping:
-                     │         └──  upsert_cardid:34 => upsert_cardid:47
-                     └── filters (true)
+ │    ├── lax-key: (13-15,21-25)
+ │    ├── fd: ()-->(11,12), (13-15)~~>(18), (21-25)-->(26-28), (21)-->(31), (21,22)-->(32), (13,21,23)-->(33), (14,21,24)-->(34), (13-15,21-25)~~>(18,29,30)
+ │    ├── left-join (lookup transactiondetails)
+ │    │    ├── columns: "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15 column18:18 sellprice:19 buyprice:20 transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondate:23 cardid:24 quantity:25 transactiondetails.sellprice:26 transactiondetails.buyprice:27 transactiondetails.version:28
+ │    │    ├── key columns: [11 12 13 14 15] = [21 22 23 24 25]
+ │    │    ├── lookup columns are key
+ │    │    ├── cardinality: [1 - ]
+ │    │    ├── side-effects
+ │    │    ├── lax-key: (13-15,21-25)
+ │    │    ├── fd: ()-->(11,12), (13-15)~~>(18-20), (21-25)-->(26-28)
+ │    │    ├── upsert-distinct-on
+ │    │    │    ├── columns: "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15 column18:18 sellprice:19 buyprice:20
+ │    │    │    ├── grouping columns: current_timestamp:13 int8:14 int8:15
+ │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
+ │    │    │    ├── cardinality: [1 - 2]
+ │    │    │    ├── side-effects
+ │    │    │    ├── lax-key: (13-15)
+ │    │    │    ├── fd: ()-->(11,12), (13-15)~~>(11,12,18-20)
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: sellprice:19 buyprice:20 column18:18 "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15
+ │    │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    │    ├── side-effects
+ │    │    │    │    ├── fd: ()-->(11,12)
+ │    │    │    │    ├── values
+ │    │    │    │    │    ├── columns: detail:10!null
+ │    │    │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    │    │    ├── ('{"b": 2.29, "c": 49833, "q": 4, "s": 2.89}',)
+ │    │    │    │    │    └── ('{"b": 17.59, "c": 29483, "q": 2, "s": 18.93}',)
+ │    │    │    │    └── projections
+ │    │    │    │         ├── crdb_internal.round_decimal_values((detail:10->'s')::STRING::DECIMAL(10,4), 4) [as=sellprice:19, outer=(10)]
+ │    │    │    │         ├── crdb_internal.round_decimal_values((detail:10->'b')::STRING::DECIMAL(10,4), 4) [as=buyprice:20, outer=(10)]
+ │    │    │    │         ├── cluster_logical_timestamp() [as=column18:18, side-effects]
+ │    │    │    │         ├── 1 [as="?column?":11]
+ │    │    │    │         ├── false [as=bool:12]
+ │    │    │    │         ├── current_timestamp() [as=current_timestamp:13, side-effects]
+ │    │    │    │         ├── (detail:10->'c')::STRING::INT8 [as=int8:14, outer=(10)]
+ │    │    │    │         └── (detail:10->'q')::STRING::INT8 [as=int8:15, outer=(10)]
+ │    │    │    └── aggregations
+ │    │    │         ├── first-agg [as=sellprice:19, outer=(19)]
+ │    │    │         │    └── sellprice:19
+ │    │    │         ├── first-agg [as=buyprice:20, outer=(20)]
+ │    │    │         │    └── buyprice:20
+ │    │    │         ├── first-agg [as=column18:18, outer=(18)]
+ │    │    │         │    └── column18:18
+ │    │    │         ├── const-agg [as="?column?":11, outer=(11)]
+ │    │    │         │    └── "?column?":11
+ │    │    │         └── const-agg [as=bool:12, outer=(12)]
+ │    │    │              └── bool:12
+ │    │    └── filters (true)
+ │    └── projections
+ │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN "?column?":11 ELSE transactiondetails.dealerid:21 END [as=upsert_dealerid:31, outer=(11,21)]
+ │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN bool:12 ELSE transactiondetails.isbuy:22 END [as=upsert_isbuy:32, outer=(12,21,22)]
+ │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN current_timestamp:13 ELSE transactiondate:23 END [as=upsert_transactiondate:33, outer=(13,21,23)]
+ │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN int8:14 ELSE cardid:24 END [as=upsert_cardid:34, outer=(14,21,24)]
+ │         ├── crdb_internal.round_decimal_values(sellprice:19, 4) [as=sellprice:29, outer=(19)]
+ │         └── crdb_internal.round_decimal_values(buyprice:20, 4) [as=buyprice:30, outer=(20)]
+ └── f-k-checks
+      ├── f-k-checks-item: transactiondetails(dealerid,isbuy,transactiondate) -> transactions(dealerid,isbuy,date)
+      │    └── anti-join (lookup transactions)
+      │         ├── columns: upsert_dealerid:37 upsert_isbuy:38 upsert_transactiondate:39
+      │         ├── key columns: [37 38 39] = [40 41 42]
+      │         ├── lookup columns are key
+      │         ├── with-scan &2
+      │         │    ├── columns: upsert_dealerid:37 upsert_isbuy:38 upsert_transactiondate:39
+      │         │    ├── mapping:
+      │         │    │    ├──  upsert_dealerid:31 => upsert_dealerid:37
+      │         │    │    ├──  upsert_isbuy:32 => upsert_isbuy:38
+      │         │    │    └──  upsert_transactiondate:33 => upsert_transactiondate:39
+      │         │    └── cardinality: [1 - ]
+      │         └── filters (true)
+      └── f-k-checks-item: transactiondetails(cardid) -> cards(id)
+           └── anti-join (lookup cards)
+                ├── columns: upsert_cardid:47
+                ├── key columns: [47] = [48]
+                ├── lookup columns are key
+                ├── with-scan &2
+                │    ├── columns: upsert_cardid:47
+                │    ├── mapping:
+                │    │    └──  upsert_cardid:34 => upsert_cardid:47
+                │    └── cardinality: [1 - ]
+                └── filters (true)
 
 # Delete inventory detail rows to reflect card transfers.
 opt
@@ -1400,9 +1385,6 @@ delete inventorydetails
 
 # Update CardsInfo inventory numbers (by CardId, Quantity) to reflect card
 # transfers.
-#
-# Problems:
-#   1. Tuple access is not folded with Values operator.
 opt
 WITH Updates AS
 (

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1024,9 +1024,6 @@ values
            └── '70f03eb1-4f58-4c26-b72d-c524a9d537dd'
 
 # Get account locations of a list of cards.
-#
-# Problems:
-#   1. Tuple access is not folded with Values operator.
 opt
 WITH CardsToFind AS
 (
@@ -1255,13 +1252,6 @@ upsert transactions
 
 # Insert structured data (c=CardId, q=Quantity, s=SellPrice, b=BuyPrice)
 # represented as JSON into TransactionDetails table.
-#
-# Problems:
-#   1. WITH is not inlined into the query, because it is marked as having side
-#      effects, even though it does not.
-#   2. jsonb_array_elements should be folded into VALUES operator when it
-#      operates over constant JSON.
-#
 opt
 WITH updates AS (SELECT jsonb_array_elements('[
     {"c": 49833, "q": 4, "s": 2.89, "b": 2.29},
@@ -1275,121 +1265,116 @@ SELECT
   (Detail->'s')::TEXT::DECIMAL(10,4), (Detail->'b')::TEXT::DECIMAL(10,4)
 FROM updates
 ----
-with &1 (updates)
+upsert transactiondetails
+ ├── columns: <none>
+ ├── canary column: 25
+ ├── fetch columns: transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondate:27 cardid:28 quantity:29 transactiondetails.sellprice:30 transactiondetails.buyprice:31 transactiondetails.version:32 transactiondetails.discount:33 transactiondetails.extra:34
+ ├── insert-mapping:
+ │    ├── "?column?":13 => transactiondetails.dealerid:2
+ │    ├── bool:14 => transactiondetails.isbuy:3
+ │    ├── current_timestamp:15 => transactiondate:4
+ │    ├── int8:16 => cardid:5
+ │    ├── int8:17 => quantity:6
+ │    ├── sellprice:35 => transactiondetails.sellprice:7
+ │    ├── buyprice:36 => transactiondetails.buyprice:8
+ │    ├── column20:20 => transactiondetails.version:9
+ │    └── discount:24 => transactiondetails.discount:10
+ ├── update-mapping:
+ │    ├── sellprice:35 => transactiondetails.sellprice:7
+ │    ├── buyprice:36 => transactiondetails.buyprice:8
+ │    └── upsert_discount:44 => transactiondetails.discount:10
+ ├── input binding: &2
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
- ├── project-set
- │    ├── columns: jsonb_array_elements:1
+ ├── project
+ │    ├── columns: upsert_dealerid:38 upsert_isbuy:39 upsert_transactiondate:40 upsert_cardid:41 upsert_discount:44 sellprice:35 buyprice:36 "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17 column20:20 discount:24 transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondate:27 cardid:28 quantity:29 transactiondetails.sellprice:30 transactiondetails.buyprice:31 transactiondetails.version:32 transactiondetails.discount:33 transactiondetails.extra:34
+ │    ├── cardinality: [1 - ]
  │    ├── side-effects
- │    ├── values
- │    │    ├── cardinality: [1 - 1]
- │    │    ├── key: ()
- │    │    └── ()
- │    └── zip
- │         └── jsonb_array_elements('[{"b": 2.29, "c": 49833, "q": 4, "s": 2.89}, {"b": 17.59, "c": 29483, "q": 2, "s": 18.93}]') [side-effects]
- └── upsert transactiondetails
-      ├── columns: <none>
-      ├── canary column: 25
-      ├── fetch columns: transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondate:27 cardid:28 quantity:29 transactiondetails.sellprice:30 transactiondetails.buyprice:31 transactiondetails.version:32 transactiondetails.discount:33 transactiondetails.extra:34
-      ├── insert-mapping:
-      │    ├── "?column?":13 => transactiondetails.dealerid:2
-      │    ├── bool:14 => transactiondetails.isbuy:3
-      │    ├── current_timestamp:15 => transactiondate:4
-      │    ├── int8:16 => cardid:5
-      │    ├── int8:17 => quantity:6
-      │    ├── sellprice:35 => transactiondetails.sellprice:7
-      │    ├── buyprice:36 => transactiondetails.buyprice:8
-      │    ├── column20:20 => transactiondetails.version:9
-      │    └── discount:24 => transactiondetails.discount:10
-      ├── update-mapping:
-      │    ├── sellprice:35 => transactiondetails.sellprice:7
-      │    ├── buyprice:36 => transactiondetails.buyprice:8
-      │    └── upsert_discount:44 => transactiondetails.discount:10
-      ├── input binding: &2
-      ├── cardinality: [0 - 0]
-      ├── side-effects, mutations
-      ├── project
-      │    ├── columns: upsert_dealerid:38 upsert_isbuy:39 upsert_transactiondate:40 upsert_cardid:41 upsert_discount:44 sellprice:35 buyprice:36 "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17 column20:20 discount:24 transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondate:27 cardid:28 quantity:29 transactiondetails.sellprice:30 transactiondetails.buyprice:31 transactiondetails.version:32 transactiondetails.discount:33 transactiondetails.extra:34
-      │    ├── side-effects
-      │    ├── lax-key: (15-17,25-29)
-      │    ├── fd: ()-->(13,14,24), (15-17)~~>(20), (25-29)-->(30-34), (25)-->(38), (25,26)-->(39), (15,25,27)-->(40), (16,25,28)-->(41), (15-17,25-29)~~>(20,35,36,44)
-      │    ├── left-join (lookup transactiondetails)
-      │    │    ├── columns: "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17 column20:20 sellprice:22 buyprice:23 discount:24 transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondate:27 cardid:28 quantity:29 transactiondetails.sellprice:30 transactiondetails.buyprice:31 transactiondetails.version:32 transactiondetails.discount:33 transactiondetails.extra:34
-      │    │    ├── key columns: [13 14 15 16 17] = [25 26 27 28 29]
-      │    │    ├── lookup columns are key
-      │    │    ├── side-effects
-      │    │    ├── lax-key: (15-17,25-29)
-      │    │    ├── fd: ()-->(13,14,24), (15-17)~~>(20,22,23), (25-29)-->(30-34)
-      │    │    ├── upsert-distinct-on
-      │    │    │    ├── columns: "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17 column20:20 sellprice:22 buyprice:23 discount:24
-      │    │    │    ├── grouping columns: current_timestamp:15 int8:16 int8:17
-      │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
-      │    │    │    ├── side-effects
-      │    │    │    ├── lax-key: (15-17)
-      │    │    │    ├── fd: ()-->(13,14,24), (15-17)~~>(13,14,20,22-24)
-      │    │    │    ├── project
-      │    │    │    │    ├── columns: sellprice:22 buyprice:23 discount:24 column20:20 "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17
-      │    │    │    │    ├── side-effects
-      │    │    │    │    ├── fd: ()-->(13,14,24)
-      │    │    │    │    ├── with-scan &1 (updates)
-      │    │    │    │    │    ├── columns: detail:12
-      │    │    │    │    │    └── mapping:
-      │    │    │    │    │         └──  jsonb_array_elements:1 => detail:12
-      │    │    │    │    └── projections
-      │    │    │    │         ├── crdb_internal.round_decimal_values((detail:12->'s')::STRING::DECIMAL(10,4), 4) [as=sellprice:22, outer=(12)]
-      │    │    │    │         ├── crdb_internal.round_decimal_values((detail:12->'b')::STRING::DECIMAL(10,4), 4) [as=buyprice:23, outer=(12)]
-      │    │    │    │         ├── crdb_internal.round_decimal_values(0.00001, 4) [as=discount:24]
-      │    │    │    │         ├── cluster_logical_timestamp() [as=column20:20, side-effects]
-      │    │    │    │         ├── 1 [as="?column?":13]
-      │    │    │    │         ├── false [as=bool:14]
-      │    │    │    │         ├── current_timestamp() [as=current_timestamp:15, side-effects]
-      │    │    │    │         ├── (detail:12->'c')::STRING::INT8 [as=int8:16, outer=(12)]
-      │    │    │    │         └── (detail:12->'q')::STRING::INT8 [as=int8:17, outer=(12)]
-      │    │    │    └── aggregations
-      │    │    │         ├── first-agg [as=sellprice:22, outer=(22)]
-      │    │    │         │    └── sellprice:22
-      │    │    │         ├── first-agg [as=buyprice:23, outer=(23)]
-      │    │    │         │    └── buyprice:23
-      │    │    │         ├── first-agg [as=column20:20, outer=(20)]
-      │    │    │         │    └── column20:20
-      │    │    │         ├── first-agg [as=discount:24, outer=(24)]
-      │    │    │         │    └── discount:24
-      │    │    │         ├── const-agg [as="?column?":13, outer=(13)]
-      │    │    │         │    └── "?column?":13
-      │    │    │         └── const-agg [as=bool:14, outer=(14)]
-      │    │    │              └── bool:14
-      │    │    └── filters (true)
-      │    └── projections
-      │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN "?column?":13 ELSE transactiondetails.dealerid:25 END [as=upsert_dealerid:38, outer=(13,25)]
-      │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN bool:14 ELSE transactiondetails.isbuy:26 END [as=upsert_isbuy:39, outer=(14,25,26)]
-      │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN current_timestamp:15 ELSE transactiondate:27 END [as=upsert_transactiondate:40, outer=(15,25,27)]
-      │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN int8:16 ELSE cardid:28 END [as=upsert_cardid:41, outer=(16,25,28)]
-      │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN discount:24 ELSE crdb_internal.round_decimal_values(discount:24, 4) END [as=upsert_discount:44, outer=(24,25)]
-      │         ├── crdb_internal.round_decimal_values(sellprice:22, 4) [as=sellprice:35, outer=(22)]
-      │         └── crdb_internal.round_decimal_values(buyprice:23, 4) [as=buyprice:36, outer=(23)]
-      └── f-k-checks
-           ├── f-k-checks-item: transactiondetails(dealerid,isbuy,transactiondate) -> transactions(dealerid,isbuy,date)
-           │    └── anti-join (lookup transactions)
-           │         ├── columns: upsert_dealerid:45 upsert_isbuy:46 upsert_transactiondate:47
-           │         ├── key columns: [45 46 47] = [48 49 50]
-           │         ├── lookup columns are key
-           │         ├── with-scan &2
-           │         │    ├── columns: upsert_dealerid:45 upsert_isbuy:46 upsert_transactiondate:47
-           │         │    └── mapping:
-           │         │         ├──  upsert_dealerid:38 => upsert_dealerid:45
-           │         │         ├──  upsert_isbuy:39 => upsert_isbuy:46
-           │         │         └──  upsert_transactiondate:40 => upsert_transactiondate:47
-           │         └── filters (true)
-           └── f-k-checks-item: transactiondetails(cardid) -> cards(id)
-                └── anti-join (lookup cards)
-                     ├── columns: upsert_cardid:57
-                     ├── key columns: [57] = [58]
-                     ├── lookup columns are key
-                     ├── with-scan &2
-                     │    ├── columns: upsert_cardid:57
-                     │    └── mapping:
-                     │         └──  upsert_cardid:41 => upsert_cardid:57
-                     └── filters (true)
+ │    ├── lax-key: (15-17,25-29)
+ │    ├── fd: ()-->(13,14,24), (15-17)~~>(20), (25-29)-->(30-34), (25)-->(38), (25,26)-->(39), (15,25,27)-->(40), (16,25,28)-->(41), (15-17,25-29)~~>(20,35,36,44)
+ │    ├── left-join (lookup transactiondetails)
+ │    │    ├── columns: "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17 column20:20 sellprice:22 buyprice:23 discount:24 transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondate:27 cardid:28 quantity:29 transactiondetails.sellprice:30 transactiondetails.buyprice:31 transactiondetails.version:32 transactiondetails.discount:33 transactiondetails.extra:34
+ │    │    ├── key columns: [13 14 15 16 17] = [25 26 27 28 29]
+ │    │    ├── lookup columns are key
+ │    │    ├── cardinality: [1 - ]
+ │    │    ├── side-effects
+ │    │    ├── lax-key: (15-17,25-29)
+ │    │    ├── fd: ()-->(13,14,24), (15-17)~~>(20,22,23), (25-29)-->(30-34)
+ │    │    ├── upsert-distinct-on
+ │    │    │    ├── columns: "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17 column20:20 sellprice:22 buyprice:23 discount:24
+ │    │    │    ├── grouping columns: current_timestamp:15 int8:16 int8:17
+ │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
+ │    │    │    ├── cardinality: [1 - 2]
+ │    │    │    ├── side-effects
+ │    │    │    ├── lax-key: (15-17)
+ │    │    │    ├── fd: ()-->(13,14,24), (15-17)~~>(13,14,20,22-24)
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: sellprice:22 buyprice:23 discount:24 column20:20 "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17
+ │    │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    │    ├── side-effects
+ │    │    │    │    ├── fd: ()-->(13,14,24)
+ │    │    │    │    ├── values
+ │    │    │    │    │    ├── columns: detail:12!null
+ │    │    │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    │    │    ├── ('{"b": 2.29, "c": 49833, "q": 4, "s": 2.89}',)
+ │    │    │    │    │    └── ('{"b": 17.59, "c": 29483, "q": 2, "s": 18.93}',)
+ │    │    │    │    └── projections
+ │    │    │    │         ├── crdb_internal.round_decimal_values((detail:12->'s')::STRING::DECIMAL(10,4), 4) [as=sellprice:22, outer=(12)]
+ │    │    │    │         ├── crdb_internal.round_decimal_values((detail:12->'b')::STRING::DECIMAL(10,4), 4) [as=buyprice:23, outer=(12)]
+ │    │    │    │         ├── crdb_internal.round_decimal_values(0.00001, 4) [as=discount:24]
+ │    │    │    │         ├── cluster_logical_timestamp() [as=column20:20, side-effects]
+ │    │    │    │         ├── 1 [as="?column?":13]
+ │    │    │    │         ├── false [as=bool:14]
+ │    │    │    │         ├── current_timestamp() [as=current_timestamp:15, side-effects]
+ │    │    │    │         ├── (detail:12->'c')::STRING::INT8 [as=int8:16, outer=(12)]
+ │    │    │    │         └── (detail:12->'q')::STRING::INT8 [as=int8:17, outer=(12)]
+ │    │    │    └── aggregations
+ │    │    │         ├── first-agg [as=sellprice:22, outer=(22)]
+ │    │    │         │    └── sellprice:22
+ │    │    │         ├── first-agg [as=buyprice:23, outer=(23)]
+ │    │    │         │    └── buyprice:23
+ │    │    │         ├── first-agg [as=column20:20, outer=(20)]
+ │    │    │         │    └── column20:20
+ │    │    │         ├── first-agg [as=discount:24, outer=(24)]
+ │    │    │         │    └── discount:24
+ │    │    │         ├── const-agg [as="?column?":13, outer=(13)]
+ │    │    │         │    └── "?column?":13
+ │    │    │         └── const-agg [as=bool:14, outer=(14)]
+ │    │    │              └── bool:14
+ │    │    └── filters (true)
+ │    └── projections
+ │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN "?column?":13 ELSE transactiondetails.dealerid:25 END [as=upsert_dealerid:38, outer=(13,25)]
+ │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN bool:14 ELSE transactiondetails.isbuy:26 END [as=upsert_isbuy:39, outer=(14,25,26)]
+ │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN current_timestamp:15 ELSE transactiondate:27 END [as=upsert_transactiondate:40, outer=(15,25,27)]
+ │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN int8:16 ELSE cardid:28 END [as=upsert_cardid:41, outer=(16,25,28)]
+ │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN discount:24 ELSE crdb_internal.round_decimal_values(discount:24, 4) END [as=upsert_discount:44, outer=(24,25)]
+ │         ├── crdb_internal.round_decimal_values(sellprice:22, 4) [as=sellprice:35, outer=(22)]
+ │         └── crdb_internal.round_decimal_values(buyprice:23, 4) [as=buyprice:36, outer=(23)]
+ └── f-k-checks
+      ├── f-k-checks-item: transactiondetails(dealerid,isbuy,transactiondate) -> transactions(dealerid,isbuy,date)
+      │    └── anti-join (lookup transactions)
+      │         ├── columns: upsert_dealerid:45 upsert_isbuy:46 upsert_transactiondate:47
+      │         ├── key columns: [45 46 47] = [48 49 50]
+      │         ├── lookup columns are key
+      │         ├── with-scan &2
+      │         │    ├── columns: upsert_dealerid:45 upsert_isbuy:46 upsert_transactiondate:47
+      │         │    ├── mapping:
+      │         │    │    ├──  upsert_dealerid:38 => upsert_dealerid:45
+      │         │    │    ├──  upsert_isbuy:39 => upsert_isbuy:46
+      │         │    │    └──  upsert_transactiondate:40 => upsert_transactiondate:47
+      │         │    └── cardinality: [1 - ]
+      │         └── filters (true)
+      └── f-k-checks-item: transactiondetails(cardid) -> cards(id)
+           └── anti-join (lookup cards)
+                ├── columns: upsert_cardid:57
+                ├── key columns: [57] = [58]
+                ├── lookup columns are key
+                ├── with-scan &2
+                │    ├── columns: upsert_cardid:57
+                │    ├── mapping:
+                │    │    └──  upsert_cardid:41 => upsert_cardid:57
+                │    └── cardinality: [1 - ]
+                └── filters (true)
 
 # Delete inventory detail rows to reflect card transfers.
 opt
@@ -1413,9 +1398,6 @@ delete inventorydetails
 
 # Update CardsInfo inventory numbers (by CardId, Quantity) to reflect card
 # transfers.
-#
-# Problems:
-#   1. Tuple access is not folded with Values operator.
 opt
 WITH Updates AS
 (


### PR DESCRIPTION
Previously, ConvertZipArraysToValues only handled cases where the unnest
function was called on either an ArrayExpr or a ConstExpr wrapping a
DArray.

This patch allows ConvertZipArraysToValues to also handle the
json_array_elements and jsonb_array_elements functions if they have a
single ConstExpr parameter that wraps a DJSON datum.

A query like this:
```
SELECT unnest(ARRAY[1,2,3,4,5]), json_array_elements('[{"a": "b"}, {"x": "y"}]');
```
Will now be unnested into this:
```
values
 ├── columns: unnest:1!null json_array_elements:2
 ├── cardinality: [5 - 5]
 ├── (1, '{"a": "b"}')
 ├── (2, '{"x": "y"}')
 ├── (3, NULL)
 ├── (4, NULL)
 └── (5, NULL)
```

Release note: None