### PR TITLE
release-20.1: schemachange: speed up slow schema changes

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1588,9 +1588,24 @@ func (r schemaChangeResumer) Resume(
 				return r.job.MakeSessionBoundInternalExecutor(ctx, sd)
 			},
 		}
-		if err := sc.exec(ctx); err != nil {
+		opts := retry.Options{
+			InitialBackoff: 100 * time.Millisecond,
+			MaxBackoff:     20 * time.Second,
+			Multiplier:     1.5,
+		}
+
+		// The schema change may have to be retried if it is not first in line or
+		// for other retriable reasons so we run it in an exponential backoff retry
+		// loop. The loop terminates only if the context is canceled.
+		var scErr error
+		for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+			// Note that r.Next always returns true on first run so exec will be
+			// called at least once before there is a chance for this loop to exit.
+			scErr = sc.exec(ctx)
 			switch {
-			case errors.Is(err, sqlbase.ErrDescriptorNotFound):
+			case scErr == nil:
+				return nil
+			case errors.Is(scErr, sqlbase.ErrDescriptorNotFound):
 				// If the table descriptor for the ID can't be found, we assume that
 				// another job to drop the table got to it first, and consider this job
 				// finished.
@@ -1601,22 +1616,17 @@ func (r schemaChangeResumer) Resume(
 					tableID, mutationID,
 				)
 				return nil
-			case ctx.Err() != nil:
-				// If the context was canceled, the job registry will retry the job.
-				// We check for this case so that we can just return the error without
-				// wrapping it in a retry error.
-				return err
-			case !isPermanentSchemaChangeError(err):
+			case !isPermanentSchemaChangeError(scErr):
 				// Check if the error is on a whitelist of errors we should retry on,
-				// including the schema change not having the first mutation in line,
-				// and have the job registry retry.
-				return jobs.NewRetryJobError(err.Error())
+				// including the schema change not having the first mutation in line.
 			default:
 				// All other errors lead to a failed job.
-				return err
+				return scErr
 			}
 		}
-		return nil
+		// If the context was canceled, the job registry will retry the job. We can
+		// just return the error without wrapping it in a retry error.
+		return scErr
 	}
 
 	// For an empty database, the zone config for it was already GC'ed and there's


### PR DESCRIPTION
Backport 1/1 commits from #48608.

/cc @cockroachdb/release

---

Touches #45150.
Fixes #47607.
Touches #47790.

Release note (performance improvement):
Before this a simple schema change could take 30s+.
The reason was that if the schema change is not first
in line in the table mutation queue it would return a
re-triable error and the jobs framework will re-adopt and
run it later. The problem is that the job adoption loop
is 30s.

To repro run this for some time:
```
cockroach sql --insecure --watch 1s -e 'drop table if exists users cascade; create table users (id uuid not null, name varchar(255) not null, email varchar(255) not null, password varchar(255) not null, remember_token varchar(100) null, created_at timestamp(0) without time zone null, updated_at timestamp(0) without time zone null, deleted_at timestamp(0) without time zone null); alter table users add primary key (id); alter table users add constraint users_email_unique unique (email);'
```

Instead of returning on re-triable errors we retry with exponential
backoff in the schema change code. This pattern of dealing with
re-triable errors in client job code is encouraged vs relying on the
registry because the latter leads to slowness and additionally to more
complicated test fixtures that rely on hacking with the internals of the
job registry,
