### PR TITLE
sql: fix bug where show create could show partitions of dropped indexes

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2452,12 +2452,12 @@ CREATE TABLE crdb_internal.zones (
 				}
 
 				for i, s := range subzones {
-					index, err := table.FindIndexByID(sqlbase.IndexID(s.IndexID))
-					if err != nil {
-						if errors.Is(err, sqlbase.ErrIndexGCMutationsList) {
-							continue
-						}
-						return err
+					index := table.FindActiveIndexByID(sqlbase.IndexID(s.IndexID))
+					if index == nil {
+						// If we can't find an active index that corresponds to this index
+						// ID then continue, as the index is being dropped, or is already
+						// dropped and in the GC queue.
+						continue
 					}
 					if zoneSpecifier != nil {
 						zs := zs

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2908,6 +2908,21 @@ func (desc *TableDescriptor) FindIndexByID(id IndexID) (*IndexDescriptor, error)
 	return nil, fmt.Errorf("index-id \"%d\" does not exist", id)
 }
 
+// FindActiveIndexByID returns the index with the specified ID, or nil if it
+// does not exist. It only searches active indexes.
+func (desc *TableDescriptor) FindActiveIndexByID(id IndexID) *IndexDescriptor {
+	if desc.PrimaryIndex.ID == id {
+		return &desc.PrimaryIndex
+	}
+	for i := range desc.Indexes {
+		idx := &desc.Indexes[i]
+		if idx.ID == id {
+			return idx
+		}
+	}
+	return nil
+}
+
 // FindIndexByIndexIdx returns an active index with the specified
 // index's index which has a domain of [0, # of secondary indexes] and whether
 // the index is a secondary index.


### PR DESCRIPTION
Release note (bug fix): Fix a bug where the `SHOW CREATE` statement
would sometimes show a partitioning step for an index that has been
dropped.