### PR TITLE
release-19.2: sql: only include the number of non-null rows when building histograms

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -263,6 +263,41 @@ default_stat2    {rowid}       1          1               0
 default_stat2    {y}           1          1               1
 default_stat2    {x}           1          1               1
 
+# Add a few more rows.
+statement ok
+INSERT INTO simple VALUES (DEFAULT, DEFAULT);
+INSERT INTO simple VALUES (0, DEFAULT);
+INSERT INTO simple VALUES (DEFAULT, 0);
+INSERT INTO simple VALUES (0, 1);
+
+# Add an index.
+statement ok
+CREATE INDEX ON simple (x, y)
+
+statement ok
+CREATE STATISTICS default_stat3 FROM simple
+
+query TTIII colnames
+SELECT statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE simple]
+----
+statistics_name  column_names  row_count  distinct_count  null_count
+default_stat3    {rowid}       5          5               0
+default_stat3    {y}           5          3               3
+default_stat3    {x}           5          2               3
+
+let $hist_id_3
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE simple]
+WHERE statistics_name = 'default_stat3' AND column_names = '{y}'
+
+# The counts in each bucket should not include null values.
+query TIRI colnames
+SHOW HISTOGRAM $hist_id_3
+----
+upper_bound  range_rows  distinct_range_rows  equal_rows
+0            0           0                    1
+1            0           0                    1
+
 #
 # Test numeric references
 #

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -337,7 +337,7 @@ func (s *sampleAggregator) writeResults(ctx context.Context) error {
 					s.sr.Get(),
 					colIdx,
 					typ,
-					si.numRows,
+					si.numRows-si.numNulls,
 					distinctCount,
 					int(si.spec.HistogramMaxBuckets),
 				)
@@ -394,7 +394,8 @@ func (s *sampleAggregator) writeResults(ctx context.Context) error {
 
 // generateHistogram returns a histogram (on a given column) from a set of
 // samples.
-// numRows is the total number of rows from which values were sampled.
+// numRows is the total number of rows from which values were sampled
+// (excluding rows that have NULL values on the histogram column).
 func (s *sampleAggregator) generateHistogram(
 	ctx context.Context,
 	evalCtx *tree.EvalContext,

--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -34,7 +34,8 @@ var HistogramClusterMode = settings.RegisterBoolSetting(
 // the same number of samples (though it can vary when a boundary value has
 // high frequency).
 //
-// numRows is the total number of rows from which values were sampled.
+// numRows is the total number of rows from which values were sampled
+// (excluding rows that have NULL values on the histogram column).
 //
 // In addition to building the histogram buckets, EquiDepthHistogram also
 // estimates the number of distinct values in each bucket. It distributes the


### PR DESCRIPTION
Backport 1/3 commits from #48528.

/cc @cockroachdb/release

---

Histograms used by the optimizer are built by sampling at most 10,000
rows, splitting those rows into 200 buckets, and then scaling up the
counts of each bucket based on the total number of rows in the table.

Prior to this commit, null values in the sampled column were excluded
from the sampled values but included in the row count used to scale
up the bucket counts. This could result in inaccurate histograms when
there were many nulls.

This commit fixes the problem by excluding nulls from the row count used
to scale up the histogram bucket counts.

Release note (performance improvement): Histograms used by the optimizer
for query planning now have more accurate row counts per histogram bucket,
particularly for columns that have many null values. This results in
better plans in some cases.
