### PR TITLE
opt: show diff in optfmt linter

### DIFF
--- a/pkg/sql/opt/optgen/cmd/optfmt/main.go
+++ b/pkg/sql/opt/optgen/cmd/optfmt/main.go
@@ -22,11 +22,12 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang"
 	"github.com/cockroachdb/cockroach/pkg/util/pretty"
+	"github.com/pmezard/go-difflib/difflib"
 )
 
 var (
 	write   = flag.Bool("w", false, "write result to (source) file instead of stdout")
-	list    = flag.Bool("l", false, "list files whose formatting differs from optfmt's")
+	list    = flag.Bool("l", false, "list diffs when formatting differs from optfmt's")
 	verify  = flag.Bool("verify", false, "verify output order")
 	exprgen = flag.Bool("e", false, "format an exprgen expression")
 )
@@ -87,7 +88,15 @@ func main() {
 			}
 		}
 		if *list {
-			fmt.Println(name)
+			diff := difflib.UnifiedDiff{
+				A:        difflib.SplitLines(string(orig)),
+				FromFile: name,
+				B:        difflib.SplitLines(prettied),
+				ToFile:   name,
+				Context:  4,
+			}
+			diffText, _ := difflib.GetUnifiedDiffString(diff)
+			fmt.Print(diffText)
 		} else if !*write {
 			fmt.Print(prettied)
 		}


### PR DESCRIPTION
The optfmt linter only shows the problematic files. This can be inconvenient for
anyone who doesn't regularly touch .opt files and has optfmt set up in their
editor (or has no idea what it even is). This change improves `optfmt -l` to
include a diff which can be applied to fix the files. Sample output:

```
--- FAIL: TestLint (0.00s)
    --- FAIL: TestLint/TestOptfmt (0.20s)
        lint_test.go:340:
            --- /go/src/github.com/cockroachdb/cockroach/pkg/sql/opt/norm/rules/agg.opt
            +++ /go/src/github.com/cockroachdb/cockroach/pkg/sql/opt/norm/rules/agg.opt
            @@ -5,9 +5,8 @@

             # EliminateAggDistinct removes AggDistinct for aggregations where DISTINCT
             # never modifies the result; for example: min(DISTINCT x).
             [EliminateAggDistinct, Normalize]
            -(AggDistinct
            -$input:(Min | Max | BoolAnd | BoolOr))
            +(AggDistinct $input:(Min | Max | BoolAnd | BoolOr))
             =>
             $input

            --- /go/src/github.com/cockroachdb/cockroach/pkg/sql/opt/norm/rules/bool.opt
            +++ /go/src/github.com/cockroachdb/cockroach/pkg/sql/opt/norm/rules/bool.opt
            @@ -152,9 +152,10 @@
             # This transformation is useful for finding a conjunct that can be pushed down
             # in the query tree. For example, if the redundant conjunct A is fully bound by
             # one side of a join, it can be pushed through the join, even if B AND C cannot.
             [ExtractRedundantConjunct, Normalize]
            -(Or $left:^(Or)
            +(Or
            +    $left:^(Or)
                 $right:^(Or) &
                     (Succeeded
                         $conjunct:(FindRedundantConjunct $left $right)
                     )
FAIL
FAIL	github.com/cockroachdb/cockroach/pkg/testutils/lint	0.227s
```

Release note: None