### PR TITLE
opt: add correlation check in PushFilterIntoSetOp

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/subquery_correlated
+++ b/pkg/sql/logictest/testdata/logic_test/subquery_correlated
@@ -1258,3 +1258,42 @@ WHERE
 2  {CA}
 4  {WY}
 6  {WA}
+
+# Regression test for #48638.
+statement ok
+CREATE TABLE IF NOT EXISTS t_48638 (
+  key INTEGER NOT NULL,
+  value INTEGER NOT NULL,
+  PRIMARY KEY (key, value))
+
+statement ok
+INSERT INTO t_48638 values (1, 4);
+INSERT INTO t_48638 values (4, 3);
+INSERT INTO t_48638 values (3, 2);
+INSERT INTO t_48638 values (4, 1);
+INSERT INTO t_48638 values (1, 2);
+INSERT INTO t_48638 values (6, 5);
+INSERT INTO t_48638 values (7, 8);
+
+query II rowsort
+SELECT *
+FROM t_48638
+WHERE key IN (
+  WITH v AS (
+    SELECT
+      level1.value AS value, level1.key AS level1, level2.key AS level2, level3.key AS level3
+    FROM
+      t_48638 AS level2
+      RIGHT JOIN (SELECT * FROM t_48638 WHERE value = 4) AS level1 ON level1.value = level2.key
+      LEFT JOIN (SELECT * FROM t_48638) AS level3 ON level3.key = level2.value
+  )
+  SELECT v.level1 FROM v WHERE v.level1 IS NOT NULL
+  UNION ALL SELECT v.level2 FROM v WHERE v.level2 IS NOT NULL
+  UNION ALL SELECT v.level3 FROM v WHERE v.level3 IS NOT NULL
+)
+----
+1  2
+1  4
+3  2
+4  1
+4  3

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -373,10 +373,19 @@ $input
 # Union (All):        (A Union B) \ C => (A \ C) Union (B \ C)
 # Intersection (All): (A Intersect B) \ C => (A \ C) Intersect (B \ C)
 # Except (All):       (A Except B) \ C => (A \ C) Except (B \ C)
+#
+# We don't push a filter down if it references outer columns because doing so
+# prevents decorrelation.
 [PushFilterIntoSetOp, Normalize]
 (Select
     $input:(Set $left:* $right:* $colmap:*)
-    $filter:[ ... $item:* & (CanMapOnSetOp $item) ... ]
+    $filter:[
+        ...
+        $item:* &
+            (CanMapOnSetOp $item) &
+            (IsBoundBy $item $inputCols:(OutputCols $input))
+        ...
+    ]
 )
 =>
 (Select

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -1651,60 +1651,6 @@ union
            └── (a.i:7 < 10) AND (a.i:7 > 1) [outer=(7), constraints=(/7: [/2 - /9]; tight)]
 
 norm expect=PushFilterIntoSetOp
-SELECT
-(SELECT k FROM
-((SELECT k FROM b)
-  UNION ALL
-  (SELECT k FROM b))
-WHERE k < i)
-FROM a
-----
-project
- ├── columns: k:17
- ├── ensure-distinct-on
- │    ├── columns: a.k:1!null k:16
- │    ├── grouping columns: a.k:1!null
- │    ├── error: "more than one row returned by a subquery used as an expression"
- │    ├── key: (1)
- │    ├── fd: (1)-->(16)
- │    ├── left-join-apply
- │    │    ├── columns: a.k:1!null a.i:2 k:16
- │    │    ├── fd: (1)-->(2)
- │    │    ├── scan a
- │    │    │    ├── columns: a.k:1!null a.i:2
- │    │    │    ├── key: (1)
- │    │    │    └── fd: (1)-->(2)
- │    │    ├── union-all
- │    │    │    ├── columns: k:16!null
- │    │    │    ├── left columns: b.k:6
- │    │    │    ├── right columns: b.k:11
- │    │    │    ├── outer: (2)
- │    │    │    ├── select
- │    │    │    │    ├── columns: b.k:6!null
- │    │    │    │    ├── outer: (2)
- │    │    │    │    ├── key: (6)
- │    │    │    │    ├── scan b
- │    │    │    │    │    ├── columns: b.k:6!null
- │    │    │    │    │    └── key: (6)
- │    │    │    │    └── filters
- │    │    │    │         └── b.k:6 < a.i:2 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
- │    │    │    └── select
- │    │    │         ├── columns: b.k:11!null
- │    │    │         ├── outer: (2)
- │    │    │         ├── key: (11)
- │    │    │         ├── scan b
- │    │    │         │    ├── columns: b.k:11!null
- │    │    │         │    └── key: (11)
- │    │    │         └── filters
- │    │    │              └── b.k:11 < a.i:2 [outer=(2,11), constraints=(/2: (/NULL - ]; /11: (/NULL - ])]
- │    │    └── filters (true)
- │    └── aggregations
- │         └── const-agg [as=k:16, outer=(16)]
- │              └── k:16
- └── projections
-      └── k:16 [as=k:17, outer=(16)]
-
-norm expect=PushFilterIntoSetOp
 SELECT k FROM
 ((SELECT k FROM b)
   EXCEPT
@@ -2009,6 +1955,49 @@ union-all
                 │         └── filters
                 │              └── a.k:24 = 1 [outer=(24), constraints=(/24: [/1 - /1]; tight), fd=()-->(24)]
                 └── random() < 0.5 [side-effects]
+
+# No-op case because the filter references outer columns.
+norm expect-not=PushFilterIntoSetOp
+SELECT
+  (
+    SELECT k
+    FROM ((SELECT k FROM b) UNION ALL (SELECT k FROM b))
+    WHERE k < i
+  )
+FROM a
+----
+project
+ ├── columns: k:17
+ ├── ensure-distinct-on
+ │    ├── columns: a.k:1!null k:16
+ │    ├── grouping columns: a.k:1!null
+ │    ├── error: "more than one row returned by a subquery used as an expression"
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(16)
+ │    ├── left-join (cross)
+ │    │    ├── columns: a.k:1!null a.i:2 k:16
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── scan a
+ │    │    │    ├── columns: a.k:1!null a.i:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    ├── union-all
+ │    │    │    ├── columns: k:16!null
+ │    │    │    ├── left columns: b.k:6
+ │    │    │    ├── right columns: b.k:11
+ │    │    │    ├── scan b
+ │    │    │    │    ├── columns: b.k:6!null
+ │    │    │    │    └── key: (6)
+ │    │    │    └── scan b
+ │    │    │         ├── columns: b.k:11!null
+ │    │    │         └── key: (11)
+ │    │    └── filters
+ │    │         └── k:16 < a.i:2 [outer=(2,16), constraints=(/2: (/NULL - ]; /16: (/NULL - ])]
+ │    └── aggregations
+ │         └── const-agg [as=k:16, outer=(16)]
+ │              └── k:16
+ └── projections
+      └── k:16 [as=k:17, outer=(16)]
 
 norm
 SELECT * FROM ((values (1,2))


### PR DESCRIPTION
Previously, the PushFilterIntoSetOp rule matched even on FiltersItems
that referenced outer columns. This led to outer columns being pushed
down, which prevented decorrelation.

This patch adds a condition to the match pattern that prevents the rule
from matching if the FiltersItem references an outer column.

Fixes #48638

Release note (sql change): Fix issue with optimizing subqueries involving
set operations that can prevent queries from executing.