### PR TITLE
kv/kvserver: fix another spanset assertions when running on Pebble

### DIFF
--- a/pkg/kv/kvserver/batch_spanset_test.go
+++ b/pkg/kv/kvserver/batch_spanset_test.go
@@ -223,7 +223,7 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 	t.Run("reverse scans", func(t *testing.T) {
 		iter := spanset.NewIterator(eng.NewIterator(storage.IterOptions{UpperBound: roachpb.KeyMax}), &ss)
 		defer iter.Close()
-		iter.SeekLT(outsideKey)
+		iter.SeekLT(outsideKey4)
 		if _, err := iter.Valid(); !isReadSpanErr(err) {
 			t.Fatalf("SeekLT: unexpected error %v", err)
 		}


### PR DESCRIPTION
Fixes #47506.

This commit fixes another (see #48490) pair of spanset assertions when
running race-enabled tests on Pebble. In race-enabled tests,
`pebbleMVCCScanner` runs on a `spanset.Iterator` which asserts that the
keys used are within the spans declared by the KV op.
pebbleMVCCScanner.scan() was violating these assertions at the scan
boundaries due to uses of SeekGE on the end key of the declared span.

The fix is to extend #48490 to `SeekGE` and `SeekLT` - only checking
whether the key is allowed if the underlying iterator is valid. This
allows users like the `pebbleMVCCScanner` to scan past their allowable
key bounds and rely on the IterOptions bounds they have previously
provided to stop them without risking an "undeclared span" error.

It's not 100% clear that this is the right change. For one, this change
makes it so that an iterator that seeks past its allowed key bounds
but does not find any keys will not return an error. Still, I think
this is better than forcing callers to check whether they are seeking
past their key bounds before calling seek like we do now. If we like
the current behavior, we'll need to fix this in `pebbleMVCCScanner`
itself. We can discuss this further on the PR.