### PR TITLE
colexec: short-circuit hash join when build side is empty

### DIFF
--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -1168,8 +1168,7 @@ func TestHashJoinerProjection(t *testing.T) {
 	hjOp, err := NewColOperator(ctx, flowCtx, args)
 	require.NoError(t, err)
 	hjOp.Op.Init()
-	for {
-		b := hjOp.Op.Next(ctx)
+	for b := hjOp.Op.Next(ctx); b.Length() > 0; b = hjOp.Op.Next(ctx) {
 		// The output types should be {Int64, Int64, Bool, Decimal, Float64, Bytes}
 		// and we check this explicitly.
 		b.ColVec(0).Int64()
@@ -1178,8 +1177,5 @@ func TestHashJoinerProjection(t *testing.T) {
 		b.ColVec(3).Decimal()
 		b.ColVec(4).Float64()
 		b.ColVec(5).Bytes()
-		if b.Length() == 0 {
-			break
-		}
 	}
 }


### PR DESCRIPTION
Previously, we would always fully consume both sides of the join, even
when the build (right) side is empty. We can, however, short-circuit in
such case for INNER, RIGHT OUTER, and LEFT SEMI joins and skip probing
phase altogether in such scenarios. For example, this helps query 93 of
TPC-DS benchmark with scale factor 1.

Release note: None