### PR TITLE
colexec: fix performance inefficiency in materializer

### DIFF
--- a/pkg/sql/colexec/builtin_funcs.go
+++ b/pkg/sql/colexec/builtin_funcs.go
@@ -72,7 +72,7 @@ func (b *defaultBuiltinFuncOperator) Next(ctx context.Context) coldata.Batch {
 
 				for j := range b.argumentCols {
 					col := batch.ColVec(b.argumentCols[j])
-					b.row[j] = PhysicalTypeColElemToDatum(col, rowIdx, b.da, b.columnTypes[b.argumentCols[j]])
+					b.row[j] = PhysicalTypeColElemToDatum(col, rowIdx, &b.da, b.columnTypes[b.argumentCols[j]])
 					hasNulls = hasNulls || b.row[j] == tree.DNull
 				}
 

--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -897,7 +897,7 @@ func (rf *cFetcher) pushState(state fetcherState) {
 // getDatumAt returns the converted datum object at the given (colIdx, rowIdx).
 // This function is meant for tracing and should not be used in hot paths.
 func (rf *cFetcher) getDatumAt(colIdx int, rowIdx int, typ *types.T) tree.Datum {
-	return PhysicalTypeColElemToDatum(rf.machine.colvecs[colIdx], rowIdx, rf.table.da, typ)
+	return PhysicalTypeColElemToDatum(rf.machine.colvecs[colIdx], rowIdx, &rf.table.da, typ)
 }
 
 // processValue processes the state machine's current value component, setting

--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -173,7 +173,7 @@ func (m *Materializer) next() (sqlbase.EncDatumRow, *execinfrapb.ProducerMetadat
 		typs := m.OutputTypes()
 		for colIdx := 0; colIdx < len(typs); colIdx++ {
 			col := m.batch.ColVec(colIdx)
-			m.row[colIdx].Datum = PhysicalTypeColElemToDatum(col, rowIdx, m.da, typs[colIdx])
+			m.row[colIdx].Datum = PhysicalTypeColElemToDatum(col, rowIdx, &m.da, typs[colIdx])
 		}
 		return m.ProcessRowHelper(m.row), nil
 	}

--- a/pkg/sql/colexec/projection_ops_test.go
+++ b/pkg/sql/colexec/projection_ops_test.go
@@ -266,8 +266,8 @@ func TestRandomComparisons(t *testing.T) {
 			)
 		}
 		for i := range lDatums {
-			lDatums[i] = PhysicalTypeColElemToDatum(lVec, i, da, typ)
-			rDatums[i] = PhysicalTypeColElemToDatum(rVec, i, da, typ)
+			lDatums[i] = PhysicalTypeColElemToDatum(lVec, i, &da, typ)
+			rDatums[i] = PhysicalTypeColElemToDatum(rVec, i, &da, typ)
 		}
 		for _, cmpOp := range []tree.ComparisonOperator{tree.EQ, tree.NE, tree.LT, tree.LE, tree.GT, tree.GE} {
 			for i := range lDatums {

--- a/pkg/sql/colexec/vec_elem_to_datum.go
+++ b/pkg/sql/colexec/vec_elem_to_datum.go
@@ -29,7 +29,7 @@ import (
 // that this function handles nulls as well, so there is no need for a separate
 // null check.
 func PhysicalTypeColElemToDatum(
-	col coldata.Vec, rowIdx int, da sqlbase.DatumAlloc, ct *types.T,
+	col coldata.Vec, rowIdx int, da *sqlbase.DatumAlloc, ct *types.T,
 ) tree.Datum {
 	if col.MaybeHasNulls() {
 		if col.Nulls().NullAt(rowIdx) {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -592,7 +592,7 @@ func (s *Server) newConnExecutor(
 			settings: s.cfg.Settings,
 		},
 		memMetrics: memMetrics,
-		planner:    planner{execCfg: s.cfg},
+		planner:    planner{execCfg: s.cfg, alloc: &sqlbase.DatumAlloc{}},
 
 		// ctxHolder will be reset at the start of run(). We only define
 		// it here so that an early call to close() doesn't panic.

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -104,7 +104,7 @@ func newCopyMachine(
 		columns: n.Columns,
 		txnOpt:  txnOpt,
 		// The planner will be prepared before use.
-		p:              planner{execCfg: execCfg},
+		p:              planner{execCfg: execCfg, alloc: &sqlbase.DatumAlloc{}},
 		execInsertPlan: execInsertPlan,
 	}
 

--- a/pkg/sql/copy_file_upload.go
+++ b/pkg/sql/copy_file_upload.go
@@ -57,7 +57,7 @@ func newFileUploadMachine(
 	c := &copyMachine{
 		conn: conn,
 		// The planner will be prepared before use.
-		p: planner{execCfg: execCfg},
+		p: planner{execCfg: execCfg, alloc: &sqlbase.DatumAlloc{}},
 	}
 	f = &fileUploadMachine{
 		c:  c,

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -394,7 +394,7 @@ func (n *createTableNode) startExec(params runParams) error {
 				desc.Columns,
 				row.SkipFKs,
 				nil, /* fkTables */
-				&params.p.alloc)
+				params.p.alloc)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -192,7 +192,7 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 		sqlbase.ScanLockingStrength_FOR_NONE,
 		false, /* returnRangeInfo */
 		false, /* isCheck */
-		&params.p.alloc,
+		params.p.alloc,
 		allTables...,
 	); err != nil {
 		return err

--- a/pkg/sql/join_test.go
+++ b/pkg/sql/join_test.go
@@ -24,7 +24,7 @@ import (
 func newTestScanNode(kvDB *kv.DB, tableName string) (*scanNode, error) {
 	desc := sqlbase.GetImmutableTableDescriptor(kvDB, keys.SystemSQLCodec, sqlutils.TestDB, tableName)
 
-	p := planner{}
+	p := planner{alloc: &sqlbase.DatumAlloc{}}
 	scan := p.Scan()
 	scan.desc = desc
 	err := scan.initDescDefaults(p.curPlan.deps, publicColumnsCfg)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1231,7 +1231,7 @@ func (ef *execFactory) ConstructInsert(
 	}
 	// Create the table inserter, which does the bulk of the work.
 	ri, err := row.MakeInserter(
-		ctx, ef.planner.txn, ef.planner.ExecCfg().Codec, tabDesc, colDescs, checkFKs, fkTables, &ef.planner.alloc,
+		ctx, ef.planner.txn, ef.planner.ExecCfg().Codec, tabDesc, colDescs, checkFKs, fkTables, ef.planner.alloc,
 	)
 	if err != nil {
 		return nil, err
@@ -1296,7 +1296,7 @@ func (ef *execFactory) ConstructInsertFastPath(
 
 	// Create the table inserter, which does the bulk of the work.
 	ri, err := row.MakeInserter(
-		ctx, ef.planner.txn, ef.planner.ExecCfg().Codec, tabDesc, colDescs, row.SkipFKs, nil /* fkTables */, &ef.planner.alloc,
+		ctx, ef.planner.txn, ef.planner.ExecCfg().Codec, tabDesc, colDescs, row.SkipFKs, nil /* fkTables */, ef.planner.alloc,
 	)
 	if err != nil {
 		return nil, err
@@ -1408,7 +1408,7 @@ func (ef *execFactory) ConstructUpdate(
 		row.UpdaterDefault,
 		checkFKs,
 		ef.planner.EvalContext(),
-		&ef.planner.alloc,
+		ef.planner.alloc,
 	)
 	if err != nil {
 		return nil, err
@@ -1554,7 +1554,7 @@ func (ef *execFactory) ConstructUpsert(
 		insertColDescs,
 		checkFKs,
 		fkTables,
-		&ef.planner.alloc,
+		ef.planner.alloc,
 	)
 	if err != nil {
 		return nil, err
@@ -1572,7 +1572,7 @@ func (ef *execFactory) ConstructUpsert(
 		row.UpdaterDefault,
 		checkFKs,
 		ef.planner.EvalContext(),
-		&ef.planner.alloc,
+		ef.planner.alloc,
 	)
 	if err != nil {
 		return nil, err
@@ -1599,7 +1599,7 @@ func (ef *execFactory) ConstructUpsert(
 			insertCols: ri.InsertCols,
 			tw: optTableUpserter{
 				ri:            ri,
-				alloc:         &ef.planner.alloc,
+				alloc:         ef.planner.alloc,
 				canaryOrdinal: int(canaryCol),
 				fkTables:      fkTables,
 				fetchCols:     fetchColDescs,
@@ -1688,7 +1688,7 @@ func (ef *execFactory) ConstructDelete(
 		fetchColDescs,
 		checkFKs,
 		ef.planner.EvalContext(),
-		&ef.planner.alloc,
+		ef.planner.alloc,
 	)
 	if err != nil {
 		return nil, err
@@ -1703,7 +1703,7 @@ func (ef *execFactory) ConstructDelete(
 	*del = deleteNode{
 		source: input.(planNode),
 		run: deleteRun{
-			td: tableDeleter{rd: rd, alloc: &ef.planner.alloc},
+			td: tableDeleter{rd: rd, alloc: ef.planner.alloc},
 		},
 	}
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -182,7 +182,7 @@ type planner struct {
 	// Use a common datum allocator across all the plan nodes. This separates the
 	// plan lifetime from the lifetime of returned results allowing plan nodes to
 	// be pool allocated.
-	alloc sqlbase.DatumAlloc
+	alloc *sqlbase.DatumAlloc
 
 	// optPlanningCtx stores the optimizer planning context, which contains
 	// data structures that can be reused between queries (for efficiency).
@@ -269,7 +269,7 @@ func newInternalPlanner(
 		ts = readTimestamp.GoTime()
 	}
 
-	p := &planner{execCfg: execCfg}
+	p := &planner{execCfg: execCfg, alloc: &sqlbase.DatumAlloc{}}
 
 	p.txn = txn
 	p.stmt = nil

--- a/pkg/sql/planner_test.go
+++ b/pkg/sql/planner_test.go
@@ -15,12 +15,13 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 func TestTypeAsString(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	p := planner{}
+	p := planner{alloc: &sqlbase.DatumAlloc{}}
 	testData := []struct {
 		expr        tree.Expr
 		expected    string

--- a/pkg/sql/rowcontainer/disk_row_container_test.go
+++ b/pkg/sql/rowcontainer/disk_row_container_test.go
@@ -150,14 +150,14 @@ func TestDiskRowContainer(t *testing.T) {
 					// Ensure the datum fields are set and no errors occur when
 					// decoding.
 					for i, encDatum := range readRow {
-						if err := encDatum.EnsureDecoded(typs[i], &d.datumAlloc); err != nil {
+						if err := encDatum.EnsureDecoded(typs[i], d.datumAlloc); err != nil {
 							t.Fatal(err)
 						}
 					}
 
 					// Check equality of the row we wrote and the row we read.
 					for i := range row {
-						if cmp, err := readRow[i].Compare(typs[i], &d.datumAlloc, &evalCtx, &row[i]); err != nil {
+						if cmp, err := readRow[i].Compare(typs[i], d.datumAlloc, &evalCtx, &row[i]); err != nil {
 							t.Fatal(err)
 						} else if cmp != 0 {
 							t.Fatalf("encoded %s but decoded %s", row.String(typs), readRow.String(typs))
@@ -213,14 +213,14 @@ func TestDiskRowContainer(t *testing.T) {
 					// Ensure datum fields are set and no errors occur when
 					// decoding.
 					for i, encDatum := range row {
-						if err := encDatum.EnsureDecoded(types[i], &d.datumAlloc); err != nil {
+						if err := encDatum.EnsureDecoded(types[i], d.datumAlloc); err != nil {
 							t.Fatal(err)
 						}
 					}
 
 					// Check sorted order.
 					if cmp, err := compareRows(
-						types, sortedRows.EncRow(numKeysRead), row, &evalCtx, &d.datumAlloc, ordering,
+						types, sortedRows.EncRow(numKeysRead), row, &evalCtx, d.datumAlloc, ordering,
 					); err != nil {
 						t.Fatal(err)
 					} else if cmp != 0 {

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -112,12 +112,20 @@ func newDistinct(
 	var returnProcessor execinfra.RowSourcedProcessor = d
 	if allSorted {
 		// We can use the faster sortedDistinct processor.
-		sd := &sortedDistinct{
-			distinct: *d,
-		}
-		// Set d to the new distinct copy for further initialization.
 		// TODO(asubiotto): We should have a distinctBase, rather than making a copy
 		// of a distinct processor.
+		sd := &sortedDistinct{
+			distinct: distinct{
+				input:            input,
+				orderedCols:      spec.OrderedColumns,
+				distinctCols:     distinctCols,
+				memAcc:           memMonitor.MakeBoundAccount(),
+				types:            input.OutputTypes(),
+				nullsAreDistinct: spec.NullsAreDistinct,
+				errorOnDup:       spec.ErrorOnDup,
+			},
+		}
+		// Set d to the new distinct copy for further initialization.
 		d = &sd.distinct
 		returnProcessor = sd
 	}

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -106,7 +106,7 @@ func (ib *indexBackfiller) prepare(ctx context.Context) error {
 	return nil
 }
 
-func (ib indexBackfiller) close(ctx context.Context) {
+func (ib *indexBackfiller) close(ctx context.Context) {
 	ib.adder.Close(ctx)
 }
 

--- a/pkg/sql/sqlbase/datum_alloc.go
+++ b/pkg/sql/sqlbase/datum_alloc.go
@@ -10,11 +10,17 @@
 
 package sqlbase
 
-import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
 
 // DatumAlloc provides batch allocation of datum pointers, amortizing the cost
 // of the allocations.
+// NOTE: it *must* be passed in by a pointer.
 type DatumAlloc struct {
+	_ util.NoCopy
+
 	datumAlloc        []tree.Datum
 	dintAlloc         []tree.DInt
 	dfloatAlloc       []tree.DFloat


### PR DESCRIPTION
**colexec: fix performance inefficiency in materializer**

We mistakenly were passing `sqlbase.DatumAlloc` by value, and not by
pointer, and as a result we would always be allocating 16 datums but
using only 1 - i.e. we were not only not pooling the allocations, but
actually making a bunch of useless allocations as well.

This inefficiency becomes noticeable when the vectorized query returns
many rows and when we have wrapped processors and those processors get
a lot of input rows - in all cases when we need to materialize a lot.
For example, TPC-H query 16 sees about 10% improvement (it returns 18k
rows) and TPC-DS query 6 sees 2x improvement (it has wrapped hash
aggregator with a decimal column) with this fix.

Release note (performance improvement): A performance inefficiency has
been fixed in the vectorized execution engine which results in speed ups
on all queries when run via the vectorized engine, with most noticeable
gains on the queries that output many rows.

**sqlbase: prohibit copying DatumAlloc by value**

This commit adds `_ util.NoCopy` to `DatumAlloc` struct to prevent us
from misusing it. A few places failed the linter, and those have been
addressed, but there was no performance problems AFAICT due to the
removed copies by value.

Release note: None