### PR TITLE
server: don't stop iterating ranges if a range is missing

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1363,10 +1363,10 @@ func (s *statusServer) Ranges(
 			// Use IterateRangeDescriptors to read from the engine only
 			// because it's already exported.
 			err := kvserver.IterateRangeDescriptors(ctx, store.Engine(),
-				func(desc roachpb.RangeDescriptor) (bool, error) {
+				func(desc roachpb.RangeDescriptor) (done bool, _ error) {
 					rep, err := store.GetReplica(desc.RangeID)
 					if errors.HasType(err, (*roachpb.RangeNotFoundError)(nil)) {
-						return true, nil // continue
+						return false, nil // continue
 					}
 					if err != nil {
 						return true, err


### PR DESCRIPTION
In #33585 we added a commit to not return an error when a range is msising
when iterating the set of ranges for the status server. This change seems
to have stopped the iteration of ranges in this case, which I don't believe
was the intention.

This PR is a drive-by, it's not clear when this case happens.

Release note: None