### PR TITLE
sql: fix bug where create stats job evalcontext had a missing txn

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -405,6 +405,9 @@ func (r *createStatsResumer) Resume(
 
 		planCtx := dsp.NewPlanningCtx(ctx, evalCtx, txn)
 		planCtx.planner = p
+		// Set the transaction on the EvalContext to this txn. This allows for
+		// use of the txn during processor setup during the execution of the flow.
+		evalCtx.Txn = txn
 		if err := dsp.planAndRunCreateStats(
 			ctx, evalCtx, planCtx, txn, r.job, NewRowResultWriter(rows),
 		); err != nil {


### PR DESCRIPTION
This PR fixes a bug I ran into where the txn on the EvalContext
of the create stats job didn't have a transaction. This would cause
any processor setup that needed a transaction (in the future, statistics
creation on tables with user defined types) to panic with a nil txn.

Release note: None