### PR TITLE
cli: fix dump with interleaved primary keys

### DIFF
--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -458,6 +458,7 @@ CREATE TABLE d.orders (
 	PRIMARY KEY (customer, id),
 	CONSTRAINT fk_customer FOREIGN KEY (customer) REFERENCES d.customers
 ) INTERLEAVE IN PARENT d.customers (customer);
+CREATE INDEX i ON d.orders (customer, total) INTERLEAVE IN PARENT d.customers (customer);
 `
 
 	_, err := c.RunWithCaptureArgs([]string{"sql", "-e", create})
@@ -480,7 +481,7 @@ CREATE TABLE orders (
 ) INTERLEAVE IN PARENT customers (customer);
 
 ALTER TABLE orders ADD CONSTRAINT fk_customer FOREIGN KEY (customer) REFERENCES customers(id);
-CREATE UNIQUE INDEX "primary" ON orders (customer ASC, id ASC) INTERLEAVE IN PARENT customers (customer);
+CREATE INDEX i ON orders (customer ASC, total ASC) INTERLEAVE IN PARENT customers (customer);
 
 -- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
 ALTER TABLE orders VALIDATE CONSTRAINT fk_customer;

--- a/pkg/cli/testdata/dump/interleave_index
+++ b/pkg/cli/testdata/dump/interleave_index
@@ -109,9 +109,5 @@ CREATE TABLE d (
 	CONSTRAINT "primary" PRIMARY KEY (x ASC, y DESC, z DESC),
 	FAMILY "primary" (x, y, z)
 ) INTERLEAVE IN PARENT a (x, y);
-
-CREATE UNIQUE INDEX "primary" ON d (x ASC, y DESC, z DESC) INTERLEAVE IN PARENT a (x, y);
-
--- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
 ----
 ----

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1427,8 +1427,7 @@ CREATE TABLE crdb_internal.create_statements (
 			if err != nil {
 				return err
 			}
-			allIdx := append(table.Indexes, table.PrimaryIndex)
-			if err := showAlterStatementWithInterleave(ctx, tn, contextName, lookup, allIdx, table, alterStmts,
+			if err := showAlterStatementWithInterleave(ctx, tn, contextName, lookup, table.Indexes, table, alterStmts,
 				validateStmts); err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes #48323.

Release note (bug fix): Fixes a bug where `cockroach dump` on tables
with interleaved primary keys would erroneously include and extra
`CREATE UNIQUE INDEX "primary" ... INTERLEAVE IN PARENT` statement
in the dump output. This made it impossible to reimport dumped data
without manual editing.