### PR TITLE
changefeedccl: use generous HTTP timeout

### DIFF
--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -492,9 +492,20 @@ func (e *confluentAvroEncoder) register(
 		return 0, err
 	}
 
+	const schemaRegistryHTTPTimeout = 15 * time.Second
+	// Use a generous HTTP timeout. We've seen "Client.Timeout exceeded while
+	// awaiting headers" here with the default timeout (3s at the time of writing)
+	// on overloaded nodes.
+	client := httputil.NewClientWithTimeout(schemaRegistryHTTPTimeout)
+	defer client.CloseIdleConnections()
 	// TODO(someone): connect the context to the caller to obey
 	// cancellation.
-	resp, err := httputil.Post(ctx, url.String(), confluentSchemaContentType, &buf)
+	resp, err := client.Post(
+		ctx,
+		url.String(),
+		confluentSchemaContentType,
+		&buf,
+	)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
We've seen HTTP timeouts here that we could not blame on the peer.
Our own timeout of 3s here (in `httputil.DefaultClient` might be
enough) to explain this on overloaded nodes.

Release note: None