### PR TITLE
release-19.2: acceptance: build GSS test binary in docker image

### DIFF
--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     image: ubuntu:xenial-20170214
     depends_on:
       - kdc
-    command: /cockroach/cockroach --certs-dir=/certs start --listen-addr cockroach
+    command: /cockroach/cockroach --certs-dir=/certs start-single-node --listen-addr cockroach
     environment:
       - KRB5_KTNAME=/keytab/crdb.keytab
     volumes:

--- a/pkg/acceptance/compose/gss/psql/Dockerfile
+++ b/pkg/acceptance/compose/gss/psql/Dockerfile
@@ -1,24 +1,18 @@
+
+# Build the test binary in a multistage build.
+FROM golang:1.13 AS builder
+WORKDIR /workspace
+COPY . .
+RUN go get -d -t -tags gss_compose
+RUN go test -v -c -tags gss_compose -o gss.test
+
+# Copy the test binary to an image with psql and krb installed.
 FROM postgres:11
 
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
-  build-essential \
-  ca-certificates \
-  curl \
-  git \
   krb5-user
 
-RUN curl --retry 5 https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar xz -C /usr/local
-
-ENV PATH="/usr/local/go/bin:${PATH}"
-
-COPY gss_test.go /test/
-
-# Fetch the go packages we need but remove the script so it can be
-# volume mounted at run-time enabling it to be changed without rebuilding
-# the image.
-RUN cd /test \
-  && go get -d -t -tags gss_compose \
-  && rm -rf /test
+COPY --from=builder /workspace/gss.test .
 
 ENTRYPOINT ["/start.sh"]

--- a/pkg/acceptance/compose/gss/psql/start.sh
+++ b/pkg/acceptance/compose/gss/psql/start.sh
@@ -4,4 +4,4 @@ set -e
 
 echo psql | kinit tester@MY.EX
 
-go test -tags gss_compose /test/gss_test.go
+./gss.test


### PR DESCRIPTION
Backport 1/1 commits from #47978.

/cc @cockroachdb/release

---

Previously the curl/tar step was failing with errors I didn't know how to
fix regarding SSL. Instead of trying to download Go, use a docker image
and build the test binary in it. This should be much more successful.

Fixes #47954

Release note: None
