### PR TITLE
opt: normalize comparison with nested timezone function

### DIFF
--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -72,6 +73,16 @@ func (c *CustomFuncs) IntConst(d *tree.DInt) opt.ScalarExpr {
 //   scalar lists.
 //
 // ----------------------------------------------------------------------
+
+// FirstScalarListExpr returns the first ScalarExpr in the given list.
+func (c *CustomFuncs) FirstScalarListExpr(list memo.ScalarListExpr) opt.ScalarExpr {
+	return list[0]
+}
+
+// SecondScalarListExpr returns the second ScalarExpr in the given list.
+func (c *CustomFuncs) SecondScalarListExpr(list memo.ScalarListExpr) opt.ScalarExpr {
+	return list[1]
+}
 
 // NeedSortedUniqueList returns true if the given list is composed entirely of
 // constant values that are either not in sorted order or have duplicates. If
@@ -140,9 +151,32 @@ func (c *CustomFuncs) HasColType(scalar opt.ScalarExpr, dstTyp *types.T) bool {
 	return scalar.DataType().Identical(dstTyp)
 }
 
+// EqualsString returns true if the given strings are equal. This function is
+// useful in matching expressions that have string fields.
+//
+// For example, NormalizeCmpTimeZoneFunction uses this function implicitly to
+// match a specific function, like so:
+//
+//   (Function $args:* (FunctionPrivate "timezone"))
+//
+func (c *CustomFuncs) EqualsString(left string, right string) bool {
+	return left == right
+}
+
 // IsString returns true if the given scalar expression is of type String.
 func (c *CustomFuncs) IsString(scalar opt.ScalarExpr) bool {
 	return scalar.DataType().Family() == types.StringFamily
+}
+
+// IsTimestamp returns true if the given scalar expression is of type Timestamp.
+func (c *CustomFuncs) IsTimestamp(scalar opt.ScalarExpr) bool {
+	return scalar.DataType().Family() == types.TimestampFamily
+}
+
+// IsTimestampTZ returns true if the given scalar expression is of type
+// TimestampTZ.
+func (c *CustomFuncs) IsTimestampTZ(scalar opt.ScalarExpr) bool {
+	return scalar.DataType().Family() == types.TimestampTZFamily
 }
 
 // BoolType returns the boolean SQL type.
@@ -2215,6 +2249,43 @@ func (c *CustomFuncs) NormalizeTupleEquality(left, right memo.ScalarListExpr) op
 		}
 	}
 	return result
+}
+
+// MakeTimeZoneFunction constructs a new timezone() function with the given zone
+// and timestamp as arguments. The type of the function result is TIMESTAMPTZ if
+// ts is of type TIMESTAMP, or TIMESTAMP if is of type TIMESTAMPTZ.
+func (c *CustomFuncs) MakeTimeZoneFunction(zone opt.ScalarExpr, ts opt.ScalarExpr) opt.ScalarExpr {
+	argType := types.TimestampTZ
+	resultType := types.Timestamp
+	if ts.DataType().Family() == types.TimestampFamily {
+		argType, resultType = resultType, argType
+	}
+
+	args := make(memo.ScalarListExpr, 2)
+	args[0] = zone
+	args[1] = ts
+
+	props, overload := findTimeZoneFunction(argType)
+	return c.f.ConstructFunction(args, &memo.FunctionPrivate{
+		Name:       "timezone",
+		Typ:        resultType,
+		Properties: props,
+		Overload:   overload,
+	})
+}
+
+// findTimeZoneFunction returns the function properties and overload of the
+// timezone() function with a second argument that matches the given input type.
+// If no overload is found, findTimeZoneFunction panics.
+func findTimeZoneFunction(typ *types.T) (*tree.FunctionProperties, *tree.Overload) {
+	props, overloads := builtins.GetBuiltinProperties("timezone")
+	for o := range overloads {
+		overload := &overloads[o]
+		if overload.Types.MatchAt(typ, 1) {
+			return props, overload
+		}
+	}
+	panic(errors.AssertionFailedf("could not find overload for timezone"))
 }
 
 // ----------------------------------------------------------------------

--- a/pkg/sql/opt/norm/rules/comp.opt
+++ b/pkg/sql/opt/norm/rules/comp.opt
@@ -148,3 +148,61 @@
 (Is | IsNot $left:(Null) $right:^(Null))
 =>
 ((OpName) $right $left)
+
+# NormalizeCmpTimeZoneFunction normalizes timezone functions within
+# comparison operators. It only matches expressions when:
+#
+#   1. The left side of the comparison is a timezone() function.
+#   2. The second argument to timezone() is a variable of type TIMESTAMP.
+#   3. The right side of the comparison is a constant value TIMESTAMPTZ.
+#
+# Here's an example:
+#
+#   timezone('America/Denver', ts) = '2020-06-01 12:35:55-07'
+#   =>
+#   ts = timezone('America/Denver', '2020-06-01 12:35:55-07')
+#
+# This normalization is valid because the overloaded function timezone(zone,
+# TIMESTAMP) is the inverse of timezone(zone, TIMESTAMPTZ).
+[NormalizeCmpTimeZoneFunction, Normalize]
+(Eq | Ge | Gt | Le | Lt
+    (Function $args:* $private:(FunctionPrivate "timezone"))
+    $right:(ConstValue) &
+        (IsTimestampTZ $right) &
+        (IsTimestamp $ts:(SecondScalarListExpr $args)) &
+        ^(IsConstValueOrTuple $ts)
+)
+=>
+((OpName)
+    $ts
+    (MakeTimeZoneFunction (FirstScalarListExpr $args) $right)
+)
+
+# NormalizeCmpTimeZoneFunctionTZ normalizes timezone functions within
+# comparison operators. It only matches expressions when:
+#
+#   1. The left side of the comparison is a timezone() function.
+#   2. The second argument to timezone() is a variable of type TIMESTAMPTZ.
+#   3. The right side of the comparison is a constant value TIMESTAMP.
+#
+# Here's an example:
+#
+#   timezone('America/Denver', tz) = '2020-06-01 12:35:55'
+#   =>
+#   tz = timezone('America/Denver', '2020-06-01 12:35:55')
+#
+# This normalization is possible because the overloaded function timezone(zone,
+# TIMESTAMPTZ) is the inverse of timezone(zone, TIMESTAMP).
+[NormalizeCmpTimeZoneFunctionTZ, Normalize]
+(Eq | Ge | Gt | Le | Lt
+    (Function $args:* $private:(FunctionPrivate "timezone"))
+    $right:(ConstValue) &
+        (IsTimestamp $right) &
+        (IsTimestampTZ $tz:(SecondScalarListExpr $args)) &
+        ^(IsConstValueOrTuple $tz)
+)
+=>
+((OpName)
+    $tz
+    (MakeTimeZoneFunction (FirstScalarListExpr $args) $right)
+)

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -386,3 +386,99 @@ values
  ├── key: ()
  ├── fd: ()-->(1,2)
  └── (true, false)
+
+# --------------------------------------------------
+# NormalizeCmpTimeZoneFunction
+# --------------------------------------------------
+exec-ddl
+CREATE TABLE t (ts TIMESTAMP, tz TIMESTAMPTZ)
+----
+
+norm expect=NormalizeCmpTimeZoneFunction
+SELECT timezone('America/Denver', ts) >= '2020-06-01 12:35:55-07' FROM t
+----
+project
+ ├── columns: "?column?":4
+ ├── scan t
+ │    └── columns: ts:1
+ └── projections
+      └── ts:1 >= '2020-06-01 13:35:55+00:00' [as="?column?":4, outer=(1)]
+
+# Apply after commuting the inequality.
+norm expect=NormalizeCmpTimeZoneFunction
+SELECT '2020-06-01 12:35:55-07' >= timezone('America/Denver', ts)  FROM t
+----
+project
+ ├── columns: "?column?":4
+ ├── scan t
+ │    └── columns: ts:1
+ └── projections
+      └── ts:1 <= '2020-06-01 13:35:55+00:00' [as="?column?":4, outer=(1)]
+
+# Don't normalize when the right-hand-side is not a constant.
+norm expect-not=NormalizeCmpTimeZoneFunction
+SELECT timezone('America/Denver', ts) >= tz FROM t
+----
+project
+ ├── columns: "?column?":4
+ ├── scan t
+ │    └── columns: ts:1 tz:2
+ └── projections
+      └── tz:2 <= timezone('America/Denver', ts:1) [as="?column?":4, outer=(1,2)]
+
+# Don't normalize when the timezone() arguments are constants.
+norm expect-not=NormalizeCmpTimeZoneFunction
+SELECT timezone('America/Denver', '2020-06-01 12:35:55'::TIMESTAMP) >= tz FROM t
+----
+project
+ ├── columns: "?column?":4
+ ├── scan t
+ │    └── columns: tz:2
+ └── projections
+      └── tz:2 <= '2020-06-01 18:35:55+00:00' [as="?column?":4, outer=(2)]
+
+# --------------------------------------------------
+# NormalizeCmpTimeZoneFunctionTZ
+# --------------------------------------------------
+norm expect=NormalizeCmpTimeZoneFunctionTZ
+SELECT timezone('America/Denver', tz) >= '2020-06-01 12:35:55' FROM t
+----
+project
+ ├── columns: "?column?":4
+ ├── scan t
+ │    └── columns: tz:2
+ └── projections
+      └── tz:2 >= '2020-06-01 18:35:55+00:00' [as="?column?":4, outer=(2)]
+
+# Apply after commuting the inequality.
+norm expect=NormalizeCmpTimeZoneFunctionTZ
+SELECT '2020-06-01 12:35:55' >= timezone('America/Denver', tz)  FROM t
+----
+project
+ ├── columns: "?column?":4
+ ├── scan t
+ │    └── columns: tz:2
+ └── projections
+      └── tz:2 <= '2020-06-01 18:35:55+00:00' [as="?column?":4, outer=(2)]
+
+# Don't normalize when the right-hand-side is not a constant.
+norm expect-not=NormalizeCmpTimeZoneFunctionTZ
+SELECT timezone('America/Denver', tz) >= ts FROM t
+----
+project
+ ├── columns: "?column?":4
+ ├── scan t
+ │    └── columns: ts:1 tz:2
+ └── projections
+      └── ts:1 <= timezone('America/Denver', tz:2) [as="?column?":4, outer=(1,2)]
+
+# Don't normalize when the timezone() arguments are constants.
+norm expect-not=NormalizeCmpTimeZoneFunctionTZ
+SELECT timezone('America/Denver', '2020-06-01 12:35:55-07'::TIMESTAMPTZ) >= ts FROM t
+----
+project
+ ├── columns: "?column?":4
+ ├── scan t
+ │    └── columns: ts:1
+ └── projections
+      └── ts:1 <= '2020-06-01 13:35:55+00:00' [as="?column?":4, outer=(1)]


### PR DESCRIPTION
Previously, th optimizer was unable to generate constrained index scans
on TIMESTAMP or TIMESTAMPTZ indexes when the indexed column was wrapped
with the `timezone()` function (an alias of `AT TIME ZONE`).

For example, consider the table and index below.

    CREATE TABLE t (k int primary key, tz TIMESTAMPTZ)
    CREATE INDEX i ON t (tz)

Prior to this commit, the query below would not result in an constrained
index scan.

    SELECT k FROM t WHERE
      timezone('America/Denver', tz) >= '2020-06-01 12:35:55'

This commit adds two normalization rules that allow constrained index
scans to be generated for this case. The rules apply the inverse of the
`timezone()` function to the constant value on the right side of the
comparison operator. Because `timezone(zone, TIMESTAMP)` is the inverse
of `timezone(zone, TIMESTAMPTZ)`, `timezone` is simply moved from
the left side of the comparison to the right.

For exampe, the query in the example above normalizes to the query
below.

    SELECT k FROM t WHERE
      tz >= timezone('America/Denver', '2020-06-01 12:35:55')

The FoldFunction normalization rule further normalizes the right side of
the comparison to a constant TIMESTAMPTZ, allowing for a constrained
index scan to be generated during exploration.

Fixes #48149

Release note (performance improvement): The optimizer now normalizes a
comparison operator (=, >=, <=, <, >) with a nested "timezone" function
applied to a variable. This results in the generation of constrained
index scans in more cases, and therefore, better query plans.