### PR TITLE
release-20.1: colexec: fix performance inefficiency in materializer

### DIFF
--- a/pkg/sql/colexec/builtin_funcs.go
+++ b/pkg/sql/colexec/builtin_funcs.go
@@ -67,7 +67,7 @@ func (b *defaultBuiltinFuncOperator) Next(ctx context.Context) coldata.Batch {
 
 				for j := range b.argumentCols {
 					col := batch.ColVec(b.argumentCols[j])
-					b.row[j] = PhysicalTypeColElemToDatum(col, rowIdx, b.da, &b.columnTypes[b.argumentCols[j]])
+					b.row[j] = PhysicalTypeColElemToDatum(col, rowIdx, &b.da, &b.columnTypes[b.argumentCols[j]])
 					hasNulls = hasNulls || b.row[j] == tree.DNull
 				}
 

--- a/pkg/sql/colexec/cfetcher.go
+++ b/pkg/sql/colexec/cfetcher.go
@@ -896,7 +896,7 @@ func (rf *cFetcher) pushState(state fetcherState) {
 // getDatumAt returns the converted datum object at the given (colIdx, rowIdx).
 // This function is meant for tracing and should not be used in hot paths.
 func (rf *cFetcher) getDatumAt(colIdx int, rowIdx int, typ types.T) tree.Datum {
-	return PhysicalTypeColElemToDatum(rf.machine.colvecs[colIdx], rowIdx, rf.table.da, &typ)
+	return PhysicalTypeColElemToDatum(rf.machine.colvecs[colIdx], rowIdx, &rf.table.da, &typ)
 }
 
 // processValue processes the state machine's current value component, setting

--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -172,7 +172,7 @@ func (m *Materializer) next() (sqlbase.EncDatumRow, *execinfrapb.ProducerMetadat
 		typs := m.OutputTypes()
 		for colIdx := 0; colIdx < len(typs); colIdx++ {
 			col := m.batch.ColVec(colIdx)
-			m.row[colIdx].Datum = PhysicalTypeColElemToDatum(col, rowIdx, m.da, &typs[colIdx])
+			m.row[colIdx].Datum = PhysicalTypeColElemToDatum(col, rowIdx, &m.da, &typs[colIdx])
 		}
 		return m.ProcessRowHelper(m.row), nil
 	}

--- a/pkg/sql/colexec/projection_ops_test.go
+++ b/pkg/sql/colexec/projection_ops_test.go
@@ -252,8 +252,8 @@ func TestRandomComparisons(t *testing.T) {
 		coldata.RandomVec(rng, typ, bytesFixedLength, lVec, numTuples, 0)
 		coldata.RandomVec(rng, typ, bytesFixedLength, rVec, numTuples, 0)
 		for i := range lDatums {
-			lDatums[i] = PhysicalTypeColElemToDatum(lVec, i, da, ct)
-			rDatums[i] = PhysicalTypeColElemToDatum(rVec, i, da, ct)
+			lDatums[i] = PhysicalTypeColElemToDatum(lVec, i, &da, ct)
+			rDatums[i] = PhysicalTypeColElemToDatum(rVec, i, &da, ct)
 		}
 		for _, cmpOp := range []tree.ComparisonOperator{tree.EQ, tree.NE, tree.LT, tree.LE, tree.GT, tree.GE} {
 			for i := range lDatums {

--- a/pkg/sql/colexec/vec_elem_to_datum.go
+++ b/pkg/sql/colexec/vec_elem_to_datum.go
@@ -29,7 +29,7 @@ import (
 // that this function handles nulls as well, so there is no need for a separate
 // null check.
 func PhysicalTypeColElemToDatum(
-	col coldata.Vec, rowIdx int, da sqlbase.DatumAlloc, ct *types.T,
+	col coldata.Vec, rowIdx int, da *sqlbase.DatumAlloc, ct *types.T,
 ) tree.Datum {
 	if col.MaybeHasNulls() {
 		if col.Nulls().NullAt(rowIdx) {


### PR DESCRIPTION
Backport 1/2 commits from #48669.

/cc @cockroachdb/release

---

**colexec: fix performance inefficiency in materializer**

We mistakenly were passing `sqlbase.DatumAlloc` by value, and not by
pointer, and as a result we would always be allocating 16 datums but
using only 1 - i.e. we were not only not pooling the allocations, but
actually making a bunch of useless allocations as well.

This inefficiency becomes noticeable when the vectorized query returns
many rows and when we have wrapped processors and those processors get
a lot of input rows - in all cases when we need to materialize a lot.
For example, TPC-H query 16 sees about 10% improvement (it returns 18k
rows) and TPC-DS query 6 sees 2x improvement (it has wrapped hash
aggregator with a decimal column) with this fix.

Release note (performance improvement): A performance inefficiency has
been fixed in the vectorized execution engine which results in speed ups
on all queries when run via the vectorized engine, with most noticeable
gains on the queries that output many rows.
