### PR TITLE
kvclient: rationalize ctx cancelation for range lookups

### DIFF
--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -162,7 +162,7 @@ func runTestImport(t *testing.T, batchSizeValue int64) {
 			// splits to exercise that codepath, but we also want to make sure we
 			// still handle an unexpected split, so we make our own range cache and
 			// only populate it with one of our two splits.
-			mockCache := kvcoord.NewRangeDescriptorCache(s.ClusterSettings(), nil, func() int64 { return 2 << 10 })
+			mockCache := kvcoord.NewRangeDescriptorCache(s.ClusterSettings(), nil, func() int64 { return 2 << 10 }, s.Stopper())
 			addr, err := keys.Addr(key(0))
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -284,7 +284,7 @@ func NewDistSender(cfg DistSenderConfig, g *gossip.Gossip) *DistSender {
 	getRangeDescCacheSize := func() int64 {
 		return rangeDescriptorCacheSize.Get(&ds.st.SV)
 	}
-	ds.rangeCache = NewRangeDescriptorCache(ds.st, rdb, getRangeDescCacheSize)
+	ds.rangeCache = NewRangeDescriptorCache(ds.st, rdb, getRangeDescCacheSize, cfg.RPCContext.Stopper)
 	ds.leaseHolderCache = NewLeaseHolderCache(getRangeDescCacheSize)
 	if tf := cfg.TestingKnobs.TransportFactory; tf != nil {
 		ds.transportFactory = tf

--- a/pkg/kv/kvclient/kvcoord/range_cache.go
+++ b/pkg/kv/kvclient/kvcoord/range_cache.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/biogo/store/llrb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -24,12 +25,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/cache"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
+	"github.com/opentracing/opentracing-go"
 )
 
 // rangeCacheKey is the key type used to store and sort values in the
@@ -67,7 +71,8 @@ type RangeDescriptorDB interface {
 // arbitrary keys. Descriptors are initially queried from storage
 // using a RangeDescriptorDB, but are cached for subsequent lookups.
 type RangeDescriptorCache struct {
-	st *cluster.Settings
+	st      *cluster.Settings
+	stopper *stop.Stopper
 	// RangeDescriptorDB is used to retrieve range descriptors from the
 	// database, which will be cached by this structure.
 	db RangeDescriptorDB
@@ -175,9 +180,9 @@ func makeLookupRequestKey(
 // uses the given RangeDescriptorDB as the underlying source of range
 // descriptors.
 func NewRangeDescriptorCache(
-	st *cluster.Settings, db RangeDescriptorDB, size func() int64,
+	st *cluster.Settings, db RangeDescriptorDB, size func() int64, stopper *stop.Stopper,
 ) *RangeDescriptorCache {
-	rdc := &RangeDescriptorCache{st: st, db: db}
+	rdc := &RangeDescriptorCache{st: st, db: db, stopper: stopper}
 	rdc.rangeCache.cache = cache.NewOrderedCache(cache.Config{
 		Policy: cache.CacheLRU,
 		ShouldEvict: func(n int, _, _ interface{}) bool {
@@ -358,57 +363,70 @@ func (rdc *RangeDescriptorCache) tryLookupRangeDescriptor(
 	}
 	requestKey := makeLookupRequestKey(key, prevDesc, useReverseScan)
 	resC, leader := rdc.lookupRequests.DoChan(requestKey, func() (interface{}, error) {
-		ctx := ctx // disable shadows linter
-		ctx, reqSpan := tracing.ForkCtxSpan(ctx, "range lookup")
-		defer tracing.FinishSpan(reqSpan)
-
-		rs, preRs, err := rdc.performRangeLookup(ctx, key, useReverseScan)
-		if err != nil {
-			return nil, err
-		}
-
 		var lookupRes lookupResult
-		switch len(rs) {
-		case 0:
-			return nil, fmt.Errorf("no range descriptors returned for %s", key)
-		case 1:
-			desc := &rs[0]
-			lookupRes = lookupResult{
-				desc: desc,
-				evictToken: rdc.makeEvictionToken(desc, func(ctx context.Context) error {
-					return rdc.evictCachedRangeDescriptorLocked(ctx, key, desc, useReverseScan)
-				}),
-			}
-		case 2:
-			desc := &rs[0]
-			nextDesc := rs[1]
-			lookupRes = lookupResult{
-				desc: desc,
-				evictToken: rdc.makeEvictionToken(desc, func(ctx context.Context) error {
-					return rdc.insertRangeDescriptorsLocked(ctx, nextDesc)
-				}),
-			}
-		default:
-			panic(fmt.Sprintf("more than 2 matching range descriptors returned for %s: %v", key, rs))
-		}
+		if err := rdc.stopper.RunTaskWithErr(ctx, "rangecache: range lookup", func(ctx context.Context) error {
+			ctx, reqSpan := tracing.ForkCtxSpan(ctx, "range lookup")
+			defer tracing.FinishSpan(reqSpan)
+			// Clear the context's cancelation. This request services potentially many
+			// callers waiting for its result, and using the flight's leader's
+			// cancelation doesn't make sense.
+			ctx = logtags.WithTags(context.Background(), logtags.FromContext(ctx))
+			ctx = opentracing.ContextWithSpan(ctx, reqSpan)
 
-		// We want to be assured that all goroutines which experienced a cache miss
-		// have joined our in-flight request, and all others will experience a
-		// cache hit. This requires atomicity across cache population and
-		// notification, hence this exclusive lock.
-		rdc.rangeCache.Lock()
-		defer rdc.rangeCache.Unlock()
+			// Since we don't inherit any other cancelation, let's put in a generous
+			// timeout as some protection against unavailable meta ranges.
+			var rs, preRs []roachpb.RangeDescriptor
+			if err := contextutil.RunWithTimeout(ctx, "range lookup", 10*time.Second,
+				func(ctx context.Context) error {
+					var err error
+					rs, preRs, err = rdc.performRangeLookup(ctx, key, useReverseScan)
+					return err
+				}); err != nil {
+				return err
+			}
 
-		// These need to be separate because we need to preserve the pointer to rs[0]
-		// so that the compare-and-evict logic works correctly in EvictCachedRangeDescriptor.
-		// An append could cause a copy, which would change the address of rs[0]. We insert
-		// the prefetched descriptors first to avoid any unintended overwriting. We then
-		// only insert the first desired descriptor, since any other descriptor in rs would
-		// overwrite rs[0]. Instead, these are handled with the evictToken.
-		if err := rdc.insertRangeDescriptorsLocked(ctx, preRs...); err != nil {
-			log.Warningf(ctx, "range cache inserting prefetched descriptors failed: %v", err)
-		}
-		if err := rdc.insertRangeDescriptorsLocked(ctx, rs[:1]...); err != nil {
+			switch len(rs) {
+			case 0:
+				return fmt.Errorf("no range descriptors returned for %s", key)
+			case 1:
+				desc := &rs[0]
+				lookupRes = lookupResult{
+					desc: desc,
+					evictToken: rdc.makeEvictionToken(desc, func(ctx context.Context) error {
+						return rdc.evictCachedRangeDescriptorLocked(ctx, key, desc, useReverseScan)
+					}),
+				}
+			case 2:
+				desc := &rs[0]
+				nextDesc := rs[1]
+				lookupRes = lookupResult{
+					desc: desc,
+					evictToken: rdc.makeEvictionToken(desc, func(ctx context.Context) error {
+						return rdc.insertRangeDescriptorsLocked(ctx, nextDesc)
+					}),
+				}
+			default:
+				panic(fmt.Sprintf("more than 2 matching range descriptors returned for %s: %v", key, rs))
+			}
+
+			// We want to be assured that all goroutines which experienced a cache miss
+			// have joined our in-flight request, and all others will experience a
+			// cache hit. This requires atomicity across cache population and
+			// notification, hence this exclusive lock.
+			rdc.rangeCache.Lock()
+			defer rdc.rangeCache.Unlock()
+
+			// These need to be separate because we need to preserve the pointer to rs[0]
+			// so that the compare-and-evict logic works correctly in EvictCachedRangeDescriptor.
+			// An append could cause a copy, which would change the address of rs[0]. We insert
+			// the prefetched descriptors first to avoid any unintended overwriting. We then
+			// only insert the first desired descriptor, since any other descriptor in rs would
+			// overwrite rs[0]. Instead, these are handled with the evictToken.
+			if err := rdc.insertRangeDescriptorsLocked(ctx, preRs...); err != nil {
+				log.Warningf(ctx, "range cache inserting prefetched descriptors failed: %v", err)
+			}
+			return rdc.insertRangeDescriptorsLocked(ctx, rs[:1]...)
+		}); err != nil {
 			return nil, err
 		}
 		return lookupRes, nil
@@ -419,15 +437,7 @@ func (rdc *RangeDescriptorCache) tryLookupRangeDescriptor(
 	// we risk it racing with an inflight request.
 	rdc.rangeCache.RUnlock()
 
-	// We only want to wait on context cancellation here if we are not the
-	// leader of the lookupRequest. If we are the leader then we'll wait for
-	// lower levels to propagate the context cancellation error over resC. This
-	// assures that as the leader we always wait for the function passed to
-	// DoChan to return before returning from this method.
-	ctxDone := ctx.Done()
-	if leader {
-		ctxDone = nil
-	} else {
+	if !leader {
 		log.VEvent(ctx, 2, "coalesced range lookup request onto in-flight one")
 		if rdc.coalesced != nil {
 			rdc.coalesced <- struct{}{}
@@ -438,7 +448,7 @@ func (rdc *RangeDescriptorCache) tryLookupRangeDescriptor(
 	var res singleflight.Result
 	select {
 	case res = <-resC:
-	case <-ctxDone:
+	case <-ctx.Done():
 		return nil, nil, errors.Wrap(ctx.Err(), "aborted during range descriptor lookup")
 	}
 

--- a/pkg/kv/kvclient/kvcoord/range_cache_test.go
+++ b/pkg/kv/kvclient/kvcoord/range_cache_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/proto"
@@ -238,7 +239,7 @@ func initTestDescriptorDB(t *testing.T) *testDescriptorDB {
 			db.splitRange(t, keys.RangeMetaKey(roachpb.RKey(string(char))))
 		}
 	}
-	db.cache = NewRangeDescriptorCache(st, db, staticSize(2<<10))
+	db.cache = NewRangeDescriptorCache(st, db, staticSize(2<<10), stop.NewStopper())
 	return db
 }
 
@@ -499,16 +500,10 @@ func TestRangeCacheCoalescedRequests(t *testing.T) {
 
 // TestRangeCacheContextCancellation tests the behavior that for an ongoing
 // RangeDescriptor lookup, if the context passed in gets canceled the lookup
-// returns with an error indicating so. The result of the context cancellation
-// differs between requests that lead RangeLookup requests and requests that
-// coalesce onto existing RangeLookup requests.
-// - If the context of a RangeLookup request follower is canceled, the follower
-//   will stop waiting on the inflight request, but will not have an effect on
-//   the inflight request.
-// - If the context of a RangeLookup request leader is canceled, the lookup
-//   itself will also be canceled. This means that any followers waiting on the
-//   inflight request will also see the context cancellation. This is ok, though,
-//   because DistSender will transparently retry the lookup.
+// returns with an error indicating so. Canceling the ctx does not stop the
+// in-flight lookup though (even though the requester has returned from
+// lookupRangeDescriptorInternal()) - other requesters that joined the same
+// flight are unaffected by the ctx cancelation.
 func TestRangeCacheContextCancellation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	db := initTestDescriptorDB(t)
@@ -536,59 +531,39 @@ func TestRangeCacheContextCancellation(t *testing.T) {
 	}
 
 	expectContextCancellation := func(t *testing.T, c <-chan error) {
+		t.Helper()
 		if err := <-c; !errors.Is(err, context.Canceled) {
 			t.Errorf("expected context cancellation error, found %v", err)
 		}
 	}
 	expectNoError := func(t *testing.T, c <-chan error) {
+		t.Helper()
 		if err := <-c; err != nil {
 			t.Errorf("unexpected error, found %v", err)
 		}
 	}
 
-	// If a RangeDescriptor lookup joins an inflight RangeLookup, it can cancel
-	// its context to stop waiting on the range lookup. This context cancellation
-	// will not affect the "leader" of the inflight lookup or any other
-	// "followers" who are also waiting on the inflight request.
-	t.Run("Follower", func(t *testing.T) {
-		ctx1 := context.TODO() // leader
-		ctx2, cancel := context.WithCancel(context.TODO())
-		ctx3 := context.TODO()
+	ctx1, cancel := context.WithCancel(context.Background()) // leader
+	ctx2 := context.Background()
+	ctx3 := context.Background()
 
-		db.pauseRangeLookups()
-		key1 := roachpb.RKey("aa")
-		errC1 := lookupAndWaitUntilJoin(ctx1, key1, true)
-		errC2 := lookupAndWaitUntilJoin(ctx2, key1, false)
-		errC3 := lookupAndWaitUntilJoin(ctx3, key1, false)
+	db.pauseRangeLookups()
+	key1 := roachpb.RKey("aa")
+	errC1 := lookupAndWaitUntilJoin(ctx1, key1, true)
+	errC2 := lookupAndWaitUntilJoin(ctx2, key1, false)
 
-		cancel()
-		expectContextCancellation(t, errC2)
+	// Cancel the leader and check that it gets an error.
+	cancel()
+	expectContextCancellation(t, errC1)
 
-		db.resumeRangeLookups()
-		expectNoError(t, errC1)
-		expectNoError(t, errC3)
-	})
+	// While lookups are still blocked, launch another one. This new request
+	// should join the flight just like c2.
+	errC3 := lookupAndWaitUntilJoin(ctx3, key1, false)
 
-	// If a RangeDescriptor lookup leads a RangeLookup because there are no
-	// inflight lookups when it misses the cache,  the it can cancel it context
-	// to cancel the range lookup. This context cancellation will be propagated
-	// to all "followers" who are also waiting on the inflight request.
-	t.Run("Leader", func(t *testing.T) {
-		ctx1, cancel := context.WithCancel(context.TODO()) // leader
-		ctx2 := context.TODO()
-		ctx3 := context.TODO()
-
-		db.pauseRangeLookups()
-		key2 := roachpb.RKey("zz")
-		errC1 := lookupAndWaitUntilJoin(ctx1, key2, true)
-		errC2 := lookupAndWaitUntilJoin(ctx2, key2, false)
-		errC3 := lookupAndWaitUntilJoin(ctx3, key2, false)
-
-		cancel()
-		expectContextCancellation(t, errC1)
-		expectContextCancellation(t, errC2)
-		expectContextCancellation(t, errC3)
-	})
+	// Let the flight finish.
+	db.resumeRangeLookups()
+	expectNoError(t, errC2)
+	expectNoError(t, errC3)
 }
 
 // TestRangeCacheDetectSplit verifies that when the cache detects a split
@@ -965,7 +940,7 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 	}
 
 	st := cluster.MakeTestingClusterSettings()
-	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10))
+	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), stop.NewStopper())
 	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(roachpb.RKeyMax)), defDesc)
 
 	// Now, add a new, overlapping set of descriptors.
@@ -1062,7 +1037,7 @@ func TestRangeCacheClearOverlappingMeta(t *testing.T) {
 	}
 
 	st := cluster.MakeTestingClusterSettings()
-	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10))
+	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), stop.NewStopper())
 	if err := cache.InsertRangeDescriptors(ctx, firstDesc, restDesc); err != nil {
 		t.Fatal(err)
 	}
@@ -1096,7 +1071,7 @@ func TestGetCachedRangeDescriptorInverted(t *testing.T) {
 	}
 
 	st := cluster.MakeTestingClusterSettings()
-	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10))
+	cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), stop.NewStopper())
 	for _, rd := range testData {
 		cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(rd.EndKey)), rd)
 	}
@@ -1243,7 +1218,7 @@ func TestRangeCacheGeneration(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			st := cluster.MakeTestingClusterSettings()
-			cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10))
+			cache := NewRangeDescriptorCache(st, nil, staticSize(2<<10), stop.NewStopper())
 			err := cache.InsertRangeDescriptors(ctx, *descAM1, *descMZ3, *tc.insertDesc)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -254,7 +254,7 @@ func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 
 	size := func() int64 { return 2 << 10 }
 	st := cluster.MakeTestingClusterSettings()
-	rangeCache := kvcoord.NewRangeDescriptorCache(st, nil /* db */, size)
+	rangeCache := kvcoord.NewRangeDescriptorCache(st, nil /* db */, size, stop.NewStopper())
 	leaseCache := kvcoord.NewLeaseHolderCache(size)
 	r := MakeDistSQLReceiver(
 		context.TODO(), nil /* resultWriter */, tree.Rows,


### PR DESCRIPTION
Before this patch, canceling a range lookup's ctx while the respective
db lookup was in-flight behaved differently depending on whether the
request was the leader of the respective singleflight, or a follower. A
leader's cancelation would propagate to all the followers, which is bad.
This patch makes db lookups run detached from any caller's context -
they are un-cancelable (but get a timeout).

Release note: None