### PR TITLE
opt: make for loop in MapScanFilterCols more idiomatic

### DIFF
--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -2690,10 +2690,10 @@ func (c *CustomFuncs) MapScanFilterCols(
 	}
 
 	// Map the columns of each filter in the FiltersExpr.
-	newFilters := make([]memo.FiltersItem, 0, len(filters))
+	newFilters := make([]memo.FiltersItem, len(filters))
 	for i := range filters {
 		expr := c.MapFiltersItemCols(&filters[i], colMap)
-		newFilters = append(newFilters, c.e.f.ConstructFiltersItem(expr))
+		newFilters[i] = c.e.f.ConstructFiltersItem(expr)
 	}
 
 	return newFilters


### PR DESCRIPTION
This is a small clean-up to make a for loop within `MapScanFilterCols`
of `xform/custom_funcs.go` more consistent with the style found
elsewhere in the file. It now uses slice indexing to build a
`FiltersExpr` rather than `append`.

Release note: None