### PR TITLE
release-20.1: colexec: fix type schema for LEFT SEMI and LEFT ANTI joins

### DIFF
--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -883,7 +883,12 @@ func NewColOperator(
 			}
 			result.ColumnTypes = make([]types.T, len(leftLogTypes)+len(rightLogTypes))
 			copy(result.ColumnTypes, leftLogTypes)
-			copy(result.ColumnTypes[len(leftLogTypes):], rightLogTypes)
+			if core.HashJoiner.Type == sqlbase.JoinType_LEFT_SEMI ||
+				core.HashJoiner.Type == sqlbase.JoinType_LEFT_ANTI {
+				result.ColumnTypes = result.ColumnTypes[:len(leftLogTypes):len(leftLogTypes)]
+			} else {
+				copy(result.ColumnTypes[len(leftLogTypes):], rightLogTypes)
+			}
 
 			if !core.HashJoiner.OnExpr.Empty() && core.HashJoiner.Type == sqlbase.JoinType_INNER {
 				if err = result.planAndMaybeWrapOnExprAsFilter(ctx, flowCtx, core.HashJoiner.OnExpr, streamingMemAccount, processorConstructor); err != nil {
@@ -948,6 +953,12 @@ func NewColOperator(
 			result.ToClose = append(result.ToClose, mj.(IdempotentCloser))
 			result.ColumnTypes = make([]types.T, len(leftLogTypes)+len(rightLogTypes))
 			copy(result.ColumnTypes, leftLogTypes)
+			if core.MergeJoiner.Type == sqlbase.JoinType_LEFT_SEMI ||
+				core.MergeJoiner.Type == sqlbase.JoinType_LEFT_ANTI {
+				result.ColumnTypes = result.ColumnTypes[:len(leftLogTypes):len(leftLogTypes)]
+			} else {
+				copy(result.ColumnTypes[len(leftLogTypes):], rightLogTypes)
+			}
 			copy(result.ColumnTypes[len(leftLogTypes):], rightLogTypes)
 
 			if onExpr != nil {

--- a/pkg/sql/logictest/testdata/logic_test/merge_join
+++ b/pkg/sql/logictest/testdata/logic_test/merge_join
@@ -58,3 +58,14 @@ SELECT * FROM t44798_0 NATURAL JOIN t44798_1
 ----
 0
 2
+
+# Regression test for batch type schema prefix mismatch after LEFT ANTI join
+# (48622).
+statement ok
+CREATE TABLE l (l INT PRIMARY KEY); INSERT INTO l VALUES (1), (2);
+CREATE TABLE r (r INT PRIMARY KEY); INSERT INTO r VALUES (1)
+
+query IB
+SELECT *, true FROM (SELECT l FROM l WHERE l NOT IN (SELECT r FROM r))
+----
+2 true


### PR DESCRIPTION
Backport 1/1 commits from #48659.

/cc @cockroachdb/release

---

LEFT SEMI and LEFT ANTI joins output only all the columns from the left,
however, we mistakenly put the columns from the right into
`result.ColumnTypes`.

Fixes: #48622.

Release note (bug fix): Previously, CockroachDB could encounter an
internal error when a query with LEFT SEMI or LEFT ANTI join was
performed via the vectorized execution engine in some cases, and now
this has been fixed. This is likely to occur only with `vectorize=on`
setting.
