### PR TITLE
interactive_tests: skip test_missing_log_output.tcl

### DIFF
--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl.disabled
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl.disabled
@@ -1,5 +1,7 @@
 #! /usr/bin/env expect -f
 
+# disabled until #48413 is resolved.
+
 source [file join [file dirname $argv0] common.tcl]
 
 spawn /bin/bash


### PR DESCRIPTION
Touches https://github.com/cockroachdb/cockroach/issues/48413 - this has flaked quite a few times for me in master / on bors.

Release note: None