### PR TITLE
settings: fix RegisterPublicNonNegativeDurationSettingWithMaximum

### DIFF
--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -117,6 +117,7 @@ func RegisterPublicNonNegativeDurationSetting(
 
 // RegisterPublicNonNegativeDurationSettingWithMaximum defines a new setting with
 // type duration, makes it public, and sets a maximum value.
+// The maximum value is an allowed value.
 func RegisterPublicNonNegativeDurationSettingWithMaximum(
 	key, desc string, defaultValue time.Duration, maxValue time.Duration,
 ) *DurationSetting {
@@ -124,7 +125,7 @@ func RegisterPublicNonNegativeDurationSettingWithMaximum(
 		if v < 0 {
 			return errors.Errorf("cannot set %s to a negative duration: %s", key, v)
 		}
-		if v >= maxValue {
+		if v > maxValue {
 			return errors.Errorf("cannot set %s to a value larger than %s", key, maxValue)
 		}
 		return nil


### PR DESCRIPTION
`RegisterPublicNonNegativeDurationSettingWithMaximum` should include the
maximum. Seems broken by `ac3c72339b82d9f85fd8112977a542b87fb5e712`.

Resolves https://github.com/cockroachdb/cockroach/issues/48337.

Release note (bug fix): Re-allow
`diagnostics.forced_sql_stat_reset.interval`,
`diagnostics.sql_stat_reset.interval` and `external.graphite.interval`
to set to their maximum values (24hr, 24hr and 15min respectively). This
previously only excluded these values to be allowed.