### PR TITLE
sql/pgwire: populate type modifier in RowDescription

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -135,6 +135,7 @@ func newCopyMachine(
 			Typ:            cols[i].Type,
 			TableID:        tableDesc.GetID(),
 			PGAttributeNum: cols[i].GetLogicalColumnID(),
+			TypeModifier:   cols[i].Type.TypeModifier(),
 		}
 	}
 	c.rowsMemAcc = c.p.extendedEvalCtx.Mon.MakeBoundAccount()

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -285,9 +285,9 @@ func (ef *execFactory) ConstructSimpleProject(
 	for i, col := range cols {
 		v := rb.r.ivarHelper.IndexedVar(int(col))
 		if colNames == nil {
-			rb.addExpr(v, inputCols[col].Name, inputCols[col].TableID, inputCols[col].PGAttributeNum)
+			rb.addExpr(v, inputCols[col].Name, inputCols[col].TableID, inputCols[col].PGAttributeNum, inputCols[col].GetTypeModifier())
 		} else {
-			rb.addExpr(v, colNames[i], 0 /* tableID */, 0 /* pgAttributeNum */)
+			rb.addExpr(v, colNames[i], 0 /* tableID */, 0 /* pgAttributeNum */, v.ResolvedType().TypeModifier())
 		}
 	}
 	return rb.res, nil
@@ -312,7 +312,7 @@ func (ef *execFactory) ConstructRender(
 	rb.init(n, reqOrdering, len(exprs))
 	for i, expr := range exprs {
 		expr = rb.r.ivarHelper.Rebind(expr, false /* alsoReset */, true /* normalizeToNonNil */)
-		rb.addExpr(expr, colNames[i], 0 /* tableID */, 0 /* pgAttributeNum */)
+		rb.addExpr(expr, colNames[i], 0 /* tableID */, 0 /* pgAttributeNum */, -1 /* typeModifier */)
 	}
 	return rb.res, nil
 }
@@ -2046,7 +2046,11 @@ func (rb *renderBuilder) init(n exec.Node, reqOrdering exec.OutputOrdering, cap 
 
 // addExpr adds a new render expression with the given name.
 func (rb *renderBuilder) addExpr(
-	expr tree.TypedExpr, colName string, tableID sqlbase.ID, pgAttributeNum sqlbase.ColumnID,
+	expr tree.TypedExpr,
+	colName string,
+	tableID sqlbase.ID,
+	pgAttributeNum sqlbase.ColumnID,
+	typeModifier int32,
 ) {
 	rb.r.render = append(rb.r.render, expr)
 	rb.r.columns = append(
@@ -2056,6 +2060,7 @@ func (rb *renderBuilder) addExpr(
 			Typ:            expr.ResolvedType(),
 			TableID:        tableID,
 			PGAttributeNum: pgAttributeNum,
+			TypeModifier:   typeModifier,
 		},
 	)
 }

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1287,16 +1287,7 @@ func (c *conn) writeRowDescription(
 		c.msgBuilder.putInt16(int16(column.PGAttributeNum)) // Column attribute ID (optional).
 		c.msgBuilder.putInt32(int32(typ.oid))
 		c.msgBuilder.putInt16(int16(typ.size))
-		// The type modifier (atttypmod) is used to include various extra information
-		// about the type being sent. -1 is used for values which don't make use of
-		// atttypmod and is generally an acceptable catch-all for those that do.
-		// See https://www.postgresql.org/docs/9.6/static/catalog-pg-attribute.html
-		// for information on atttypmod. In theory we differ from Postgres by never
-		// giving the scale/precision, and by not including the length of a VARCHAR,
-		// but it's not clear if any drivers/ORMs depend on this.
-		//
-		// TODO(justin): It would be good to include this information when possible.
-		c.msgBuilder.putInt32(-1)
+		c.msgBuilder.putInt32(column.GetTypeModifier()) // Type modifier
 		if formatCodes == nil {
 			c.msgBuilder.putInt16(int16(pgwirebase.FormatText))
 		} else {

--- a/pkg/sql/pgwire/testdata/pgtest/row_description
+++ b/pkg/sql/pgwire/testdata/pgtest/row_description
@@ -87,3 +87,35 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"text":"1"},{"text":"1"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "CREATE TABLE tab3 (a int primary key, b char(8))"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "INSERT INTO tab3 VALUES(4,'hello')"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "SELECT b FROM tab3"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"RowDescription","Fields":[{"Name":"b","TableOID":55,"TableAttributeNumber":2,"DataTypeOID":1042,"DataTypeSize":-1,"TypeModifier":12,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"hello"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/sqlbase/result_columns.go
+++ b/pkg/sql/sqlbase/result_columns.go
@@ -30,6 +30,7 @@ type ResultColumn struct {
 	// reference, these fields are zeroes.
 	TableID        ID       // OID of column's source table (pg_attribute.attrelid).
 	PGAttributeNum ColumnID // Column's number in source table (pg_attribute.attnum).
+	TypeModifier   int32    // Type-specific data size (pg_attribute.atttypmod).
 }
 
 // ResultColumns is the type used throughout the sql module to
@@ -56,10 +57,21 @@ func ResultColumnsFromColDescs(tableID ID, colDescs []ColumnDescriptor) ResultCo
 				Hidden:         hidden,
 				TableID:        tableID,
 				PGAttributeNum: colDesc.GetLogicalColumnID(),
+				TypeModifier:   typ.TypeModifier(),
 			},
 		)
 	}
 	return cols
+}
+
+// GetTypeModifier returns the type modifier for this column. If it is not set,
+// it defaults to returning -1.
+func (r ResultColumn) GetTypeModifier() int32 {
+	if r.TypeModifier != 0 {
+		return r.TypeModifier
+	}
+
+	return -1
 }
 
 // TypesEqual returns whether the length and types of r matches other. If

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1069,6 +1069,31 @@ func (t *T) Precision() int32 {
 	return t.InternalType.Precision
 }
 
+// TypeModifier returns the type modifier of the type. This corresponds to the
+// pg_attribute.atttypmod column. atttypmod records type-specific data supplied
+// at table creation time (for example, the maximum length of a varchar column).
+// The value will be -1 for types that do not need atttypmod.
+func (t *T) TypeModifier() int32 {
+	typeModifier := int32(-1)
+	if width := t.Width(); width != 0 {
+		switch t.Family() {
+		case StringFamily:
+			// Postgres adds 4 to the attypmod for bounded string types, the
+			// var header size.
+			typeModifier = width + 4
+		case BitFamily:
+			typeModifier = width
+		case DecimalFamily:
+			// attTypMod is calculated by putting the precision in the upper
+			// bits and the scale in the lower bits of a 32-bit int, and adding
+			// 4 (the var header size). We mock this for clients' sake. See
+			// numeric.c.
+			typeModifier = ((t.Precision() << 16) | width) + 4
+		}
+	}
+	return typeModifier
+}
+
 // Scale is an alias method for Width, used for clarity for types in
 // DecimalFamily.
 func (t *T) Scale() int32 {

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -338,6 +338,7 @@ func (e virtualDefEntry) getPlanInfo(
 			Typ:            col.Type,
 			TableID:        table.GetID(),
 			PGAttributeNum: col.GetLogicalColumnID(),
+			TypeModifier:   col.Type.TypeModifier(),
 		})
 	}
 


### PR DESCRIPTION
Previously, the TypeModifier would always be -1. Now it is populated
with the value from pg_attribute.atttypmod when available.

Release note (sql change): The RowDescription message of the pgwire
protocol now contains the type modifier for each column in the result
set. This corresponds to pg_attribute.atttypmod. If it is not available,
the value is -1, as it was before.