### PR TITLE
sql: add a weak form of implicit casting for overloads on enums

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -832,7 +832,7 @@ SELECT ARRAY['a','b','c'] || 'd'::text
 ----
 {a,b,c,d}
 
-query error unsupported binary operator
+query error pq: could not parse "d" as type string\[\]
 SELECT ARRAY['a','b','c'] || 'd'
 
 query T

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -688,7 +688,7 @@ SELECT * FROM x ORDER BY a
 6 12 10
 
 # Verify a bad statement fails.
-statement error unsupported binary operator: <int> \+ <string> \(desired <int>\)
+statement error pq: could not parse "a" as type int
 ALTER TABLE x ADD COLUMN d INT AS (a + 'a') STORED
 
 statement error could not parse "a" as type int

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -97,14 +97,14 @@ hello
 
 query BBBBBBBBBBB
 SELECT 'hello'::greeting < 'howdy'::greeting,
-       'howdy'::greeting < 'hi':: greeting,
-       'hi'::greeting > 'hello'::greeting,
+       'howdy'::greeting < 'hi',
+       'hi' > 'hello'::greeting,
        'howdy'::greeting < 'hello'::greeting,
-       'hi'::greeting <= 'hi'::greeting,
+       'hi'::greeting <= 'hi',
        NULL < 'hello'::greeting,
        'hi'::greeting < NULL,
        'hello'::greeting = 'hello'::greeting,
-       'hello'::greeting != 'hi'::greeting,
+       'hello' != 'hi'::greeting,
        'howdy'::greeting IS NOT DISTINCT FROM NULL,
        'hello'::greeting IN ('hi'::greeting, 'howdy'::greeting, 'hello'::greeting)
 ----
@@ -132,6 +132,18 @@ CREATE TYPE greeting2 AS ENUM ('hello')
 
 statement error pq: invalid cast: greeting -> greeting2
 SELECT 'hello'::greeting::greeting2
+
+# Ensure that we can perform a limited form of implicit casts for
+# the case of ENUM binary operations with strings.
+query BB
+SELECT 'hello'::greeting != 'howdy', 'hi' > 'hello'::greeting
+----
+true true
+
+# Check that the implicit cast gives an appropriate error message
+# when firing but unable to complete the type check.
+statement error pq: invalid input value for enum greeting: "notagreeting"
+SELECT 'hello'::greeting = 'notagreeting'
 
 statement error pq: value type greeting cannot be used for table columns
 CREATE TABLE bad (x greeting)

--- a/pkg/sql/logictest/testdata/logic_test/suboperators
+++ b/pkg/sql/logictest/testdata/logic_test/suboperators
@@ -371,7 +371,7 @@ SELECT 1 = ANY (1, 2, 3)
 ----
 true
 
-query error unsupported comparison operator: <int> = <string>
+query error pq: could not parse "foo" as type int
 SELECT 1 = ANY (1, 2, 3.3, 'foo')
 
 query B
@@ -419,7 +419,7 @@ SELECT 1::decimal = ANY (((1.0, 1.1)))
 ----
 true
 
-query error unsupported comparison operator: <int> = <string>
+query error pq: could not parse "hello" as type int
 SELECT 1 = ANY (1, 'hello', 3)
 
 query B

--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -136,10 +136,10 @@ SELECT ts FROM untyped WHERE ts != '2015-09-18 00:00:00'
 
 # Regression tests for #15050
 
-statement error unsupported comparison operator: <timestamptz> < <string>
+statement error pq: parsing as type timestamp: could not parse "Not Timestamp"
 CREATE TABLE t15050a (c DECIMAL DEFAULT CASE WHEN now() < 'Not Timestamp' THEN 2 ELSE 2 END);
 
-statement error unsupported comparison operator: <timestamptz> < <string>
+statement error pq: parsing as type timestamp: could not parse "Not Timestamp"
 CREATE TABLE t15050b (c DECIMAL DEFAULT IF(now() < 'Not Timestamp', 2, 2));
 
 # Regression tests for #15632

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -1319,10 +1319,10 @@ SELECT k, lead(k, w) OVER (PARTITION BY v ORDER BY w, k) FROM kv ORDER BY 1
 10  NULL
 11  NULL
 
-query error unknown signature: lag\(int, int, string\)
+query error pq: lag\(\): could not parse "FOO" as type int
 SELECT k, lag(k, 1, 'FOO') OVER () FROM kv ORDER BY 1
 
-query error unknown signature: lead\(int, int, string\)
+query error pq: lead\(\): could not parse "FOO" as type int
 SELECT k, lead(k, 1, 'FOO') OVER () FROM kv ORDER BY 1
 
 query error unknown signature: lag\(int, int, string\)
@@ -1734,7 +1734,7 @@ SELECT k, last_value(v) OVER (PARTITION BY k) FROM kv ORDER BY 1
 10  4
 11  NULL
 
-query error unknown signature: nth_value\(int, string\)
+query error pq: nth_value\(\): could not parse "FOO" as type int
 SELECT k, nth_value(v, 'FOO') OVER () FROM kv ORDER BY 1
 
 query error argument of nth_value\(\) must be greater than zero

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -2715,7 +2715,7 @@ corr(int, float) -> float
 build
 SELECT corr('foo', v) FROM kv
 ----
-error (42883): unknown signature: corr(string, int)
+error (22P02): corr(): could not parse "foo" as type int: strconv.ParseInt: parsing "foo": invalid syntax
 
 # Tests for string_agg.
 

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3788,6 +3788,10 @@ func MakeDEnumFromPhysicalRepresentation(typ *types.T, rep []byte) *DEnum {
 // and input logical representation. It returns an error if the input
 // logical representation is invalid.
 func MakeDEnumFromLogicalRepresentation(typ *types.T, rep string) (*DEnum, error) {
+	// Return a nice error if the input requested type is types.AnyEnum.
+	if typ.Oid() == oid.T_anyenum {
+		return nil, errors.New("cannot create enum of unspecified type")
+	}
 	// Take a pointer into the enum metadata rather than holding on
 	// to a pointer to the input string.
 	idx, err := typ.EnumGetIdxOfLogical(rep)

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1102,7 +1102,7 @@ func (t *T) StableTypeID() uint32 {
 
 // UserDefined returns whether or not t is a user defined type.
 func (t *T) UserDefined() bool {
-	return t.StableTypeID() != 0
+	return t.Family() == EnumFamily
 }
 
 // Name returns a single word description of the type that describes it


### PR DESCRIPTION
This PR adds a special case of implicit casting for common operations on
enums. In particular, this allows for queries that use a binary
operation where one side of the operation is an enum and the other side
is a string. For example, `SELECT x FROM t WHERE x = 'hello'`, where `x`
is an enum type that 'hello' is a value of.

An alternative is to explicitly add overloads for both combinations of
`enum x string` for all overloads, but I think this is a simpler
solution.

This PR also brings some overload resolution errors closer to the errors
returned by Postgres.

Release note: None