### PR TITLE
release-19.2: sql: allow global access for pg_database table

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -248,6 +248,19 @@ oid  datname        datconnlimit  datlastsysoid  datfrozenxid  datminmxid  datta
 52   test           -1            0              NULL          NULL        0              NULL
 54   constraint_db  -1            0              NULL          NULL        0              NULL
 
+user testuser
+
+# Should be globally visible
+query OTIOIIOT colnames
+SELECT oid, datname, datconnlimit, datlastsysoid, datfrozenxid, datminmxid, dattablespace, datacl
+FROM pg_catalog.pg_database
+ORDER BY oid LIMIT 1
+----
+oid  datname        datconnlimit  datlastsysoid  datfrozenxid  datminmxid  dattablespace  datacl
+1    system         -1            0              NULL          NULL        0              NULL
+
+user root
+
 ## pg_catalog.pg_tables
 
 statement ok

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -977,7 +977,7 @@ CREATE TABLE pg_catalog.pg_database (
 	datacl STRING[]
 )`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return forEachDatabaseDesc(ctx, p, nil /*all databases*/, true, /* requiresPrivileges */
+		return forEachDatabaseDesc(ctx, p, nil /*all databases*/, false, /* requiresPrivileges */
 			func(db *sqlbase.DatabaseDescriptor) error {
 				return addRow(
 					defaultOid(db.ID),          // oid


### PR DESCRIPTION
Backport 1/1 commits from #48744.

/cc @cockroachdb/release

---

In Postgres, this table is world-readable, so we should match.

fixes #48726

Release note (sql change): The pg_database table in pg_catalog
no longer require privileges on any database in order for the
data to be visible.
