### PR TITLE
cli/interactive_tests: deflake test_missing_log_output

### DIFF
--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -29,8 +29,13 @@ eexpect ":/# "
 # NB: we can't just grep for the broken pipe output, because it may take
 # a while for the server to initiate the next log line where it will detect
 # the broken pipe error.
+#
 # We use -F and not -f because the log file may be rotated during the test.
-send "tail -F logs/db/logs/cockroach.log\r"
+#
+# We also watch all the log files in the directory, because the error
+# is only reported on the logger which is writing first after stderr
+# is has been broken, and that may be the secondary logger.
+send "tail -F `find logs/db/logs -type l`\r"
 eexpect "log: exiting because of error: write /dev/stderr: broken pipe"
 interrupt
 eexpect ":/# "

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl.disabled
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl.disabled
@@ -21,14 +21,16 @@ eexpect ":/# "
 end_test
 
 start_test "Check that a broken stderr prints a message to the log files."
-send "$argv start-single-node -s=path=logs/db --insecure --logtostderr --vmodule=*=1 2>&1 | cat\r"
+# We use --log-file-max-size to avoid rotations during the test.
+send "$argv start-single-node -s=path=logs/db --log-file-max-size=100M --insecure --logtostderr --vmodule=*=1 2>&1 | cat\r"
 eexpect "CockroachDB node starting"
 system "killall cat"
 eexpect ":/# "
 # NB: we can't just grep for the broken pipe output, because it may take
 # a while for the server to initiate the next log line where it will detect
 # the broken pipe error.
-send "tail -f logs/db/logs/cockroach.log\r"
+# We use -F and not -f because the log file may be rotated during the test.
+send "tail -F logs/db/logs/cockroach.log\r"
 eexpect "log: exiting because of error: write /dev/stderr: broken pipe"
 interrupt
 eexpect ":/# "


### PR DESCRIPTION
Fixes #48413

(Logging is hard!)

The proper fix would be to redirect exit errors to the main log file, instead of whichever file the erroring logger is managing. I think this will come for free when I rework the sink logic a bit later.