### PR TITLE
release-19.2: build/packer: Update TeamCity agent disk image

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -42,7 +42,8 @@ if [ "$(uname)" = "Darwin" ]; then
   cached_volume_mode=:cached
 fi
 
-GOPATH=$(go env GOPATH)
+# We don't want this to emit -json output.
+GOPATH=$(GOFLAGS=; go env GOPATH)
 gopath0=${GOPATH%%:*}
 gocache=${GOCACHEPATH-$gopath0}
 

--- a/build/packer/teamcity-agent.json
+++ b/build/packer/teamcity-agent.json
@@ -8,11 +8,11 @@
       "project_id": "cockroach-teamcity",
       "source_image_family": "ubuntu-1804-lts",
       "zone": "us-east1-b",
-      "machine_type": "n1-highcpu-32",
+      "machine_type": "n1-standard-32",
       "image_name": "{{user `image_id`}}",
       "image_description": "{{user `image_id`}}",
       "ssh_username": "packer",
-      "disk_size": 50,
+      "disk_size": 256,
       "disk_type": "pd-ssd"
   }],
 

--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -15,17 +15,13 @@ EOF
 # Avoid saving any Bash history.
 HISTSIZE=0
 
-# At the time of writing we really want 1.11, but that doesn't
-# exist in the PPA yet.
-GOVERS=1.10
-
 # Add third-party APT repositories.
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0EBFCD88
 cat > /etc/apt/sources.list.d/docker.list <<EOF
-deb https://download.docker.com/linux/ubuntu xenial stable
+deb https://download.docker.com/linux/ubuntu bionic stable
 EOF
-apt-add-repository ppa:webupd8team/java
-add-apt-repository ppa:gophers/archive
+# Per https://github.com/golang/go/wiki/Ubuntu
+add-apt-repository ppa:longsleep/golang-backports
 # Git 2.7, which ships with Xenial, has a bug where submodule metadata sometimes
 # uses absolute paths instead of relative paths, which means the affected
 # submodules cannot be mounted in Docker containers. Use the latest version of
@@ -33,27 +29,20 @@ add-apt-repository ppa:gophers/archive
 add-apt-repository ppa:git-core/ppa
 apt-get update --yes
 
-# Auto-accept the Oracle Java license agreement.
-debconf-set-selections <<< "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true"
-
 # Install the necessary dependencies. Keep this list small!
 apt-get install --yes \
   docker-ce \
   docker-compose \
   gnome-keyring \
   git \
-  golang-${GOVERS} \
-  oracle-java8-installer \
+  golang-go \
+  openjdk-11-jre-headless \
   unzip
 # Installing gnome-keyring prevents the error described in
 # https://github.com/moby/moby/issues/34048
 
-# Link Go into the PATH; the PPA installs it into /usr/lib/go-1.x/bin.
-ln -s /usr/lib/go-${GOVERS}/bin/go /usr/bin/go
-
-# Add a user for the TeamCity agent with Docker rights.
-adduser agent --disabled-password
-adduser agent docker
+# Give the user for the TeamCity agent Docker rights.
+usermod -a -G docker agent
 
 # Download the TeamCity agent code and install its configuration.
 # N.B.: This must be done as the agent user.

--- a/build/teamcity-acceptance.sh
+++ b/build/teamcity-acceptance.sh
@@ -12,7 +12,8 @@ tc_start_block "Prepare environment for acceptance tests"
 # that it exists before running the test.
 export TMPDIR=$PWD/artifacts/acceptance
 mkdir -p "$TMPDIR"
-type=$(go env GOOS)
+# Disable global -json flag.
+type=$(GOFLAGS=; go env GOOS)
 tc_end_block "Prepare environment for acceptance tests"
 
 tc_start_block "Compile CockroachDB"


### PR DESCRIPTION
Backport 1/1 commits from #48542.

/cc @cockroachdb/release

---

Several of the upstream packages that our TeamCity builder image depends on
have been removed or obsoleted. Specifically, Oracle Java 8 is no longer
available to download and has been replaced by OpenJDK 11. The golang backport
has been upgraded to a modern version as well.

The golang update necessitates changing a few invocation of the go tool to
unset the GOFLAGS environment variable provided by TeamCity that globally
enables json output.

I have verified that this new image passes the tests on a fork of the "GitHub
CI" suite.

The base disk image size has been increased to 256Gb.  A subsequent change will
be made to the image to enable LRU deletion of Docker images, which have been
contributing to disk-space exhaustion.

Release note: None
