### PR TITLE
sql: Rename experimental_serial_normalization to serial_normalization

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/int_size
+++ b/pkg/sql/logictest/testdata/logic_test/int_size
@@ -84,7 +84,7 @@ subtest serial_rowid
 # return type of unique_rowid()
 
 statement ok
-SET default_int_size=4; SET experimental_serial_normalization='rowid';
+SET default_int_size=4; SET serial_normalization='rowid';
 
 statement ok
 CREATE TABLE i4_rowid (a SERIAL)
@@ -98,7 +98,7 @@ i4_rowid  CREATE TABLE i4_rowid (
 )
 
 statement ok
-SET default_int_size=8; SET experimental_serial_normalization='rowid';
+SET default_int_size=8; SET serial_normalization='rowid';
 
 statement ok
 CREATE TABLE i8_rowid (a SERIAL)
@@ -115,7 +115,7 @@ subtest serial_sql_sequence
 # When using rowid, we should see an INTx that matches the current size setting.
 
 statement ok
-SET default_int_size=4; SET experimental_serial_normalization='sql_sequence';
+SET default_int_size=4; SET serial_normalization='sql_sequence';
 
 statement ok
 CREATE TABLE i4_sql_sequence (a SERIAL)
@@ -129,7 +129,7 @@ i4_sql_sequence  CREATE TABLE i4_sql_sequence (
 )
 
 statement ok
-SET default_int_size=8; SET experimental_serial_normalization='sql_sequence';
+SET default_int_size=8; SET serial_normalization='sql_sequence';
 
 statement ok
 CREATE TABLE i8_sql_sequence (a SERIAL)
@@ -147,7 +147,7 @@ subtest serial_virtual_sequence
 # return an INT8 value.
 
 statement ok
-SET default_int_size=4; SET experimental_serial_normalization='virtual_sequence';
+SET default_int_size=4; SET serial_normalization='virtual_sequence';
 
 statement ok
 CREATE TABLE i4_virtual_sequence (a SERIAL)
@@ -161,7 +161,7 @@ i4_virtual_sequence  CREATE TABLE i4_virtual_sequence (
 )
 
 statement ok
-SET default_int_size=8; SET experimental_serial_normalization='virtual_sequence';
+SET default_int_size=8; SET serial_normalization='virtual_sequence';
 
 statement ok
 CREATE TABLE i8_virtual_sequence (a SERIAL)

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1691,7 +1691,6 @@ enable_zigzag_join                           on                  NULL      NULL 
 experimental_enable_hash_sharded_indexes     off                 NULL      NULL        NULL        string
 experimental_enable_temp_tables              off                 NULL      NULL        NULL        string
 experimental_optimizer_foreign_key_cascades  off                 NULL      NULL        NULL        string
-experimental_serial_normalization            rowid               NULL      NULL        NULL        string
 extra_float_digits                           0                   NULL      NULL        NULL        string
 force_savepoint_restart                      off                 NULL      NULL        NULL        string
 foreign_key_cascades_limit                   10000               NULL      NULL        NULL        string
@@ -1711,6 +1710,7 @@ require_explicit_primary_keys                off                 NULL      NULL 
 results_buffer_size                          16384               NULL      NULL        NULL        string
 row_security                                 off                 NULL      NULL        NULL        string
 search_path                                  public              NULL      NULL        NULL        string
+serial_normalization                         rowid               NULL      NULL        NULL        string
 server_encoding                              UTF8                NULL      NULL        NULL        string
 server_version                               9.5.0               NULL      NULL        NULL        string
 server_version_num                           90500               NULL      NULL        NULL        string
@@ -1755,7 +1755,6 @@ enable_zigzag_join                           on                  NULL  user     
 experimental_enable_hash_sharded_indexes     off                 NULL  user     NULL      off                 off
 experimental_enable_temp_tables              off                 NULL  user     NULL      off                 off
 experimental_optimizer_foreign_key_cascades  off                 NULL  user     NULL      off                 off
-experimental_serial_normalization            rowid               NULL  user     NULL      rowid               rowid
 extra_float_digits                           0                   NULL  user     NULL      0                   2
 force_savepoint_restart                      off                 NULL  user     NULL      off                 off
 foreign_key_cascades_limit                   10000               NULL  user     NULL      10000               10000
@@ -1775,6 +1774,7 @@ require_explicit_primary_keys                off                 NULL  user     
 results_buffer_size                          16384               NULL  user     NULL      16384               16384
 row_security                                 off                 NULL  user     NULL      off                 off
 search_path                                  public              NULL  user     NULL      public              public
+serial_normalization                         rowid               NULL  user     NULL      rowid               rowid
 server_encoding                              UTF8                NULL  user     NULL      UTF8                UTF8
 server_version                               9.5.0               NULL  user     NULL      9.5.0               9.5.0
 server_version_num                           90500               NULL  user     NULL      90500               90500
@@ -1815,7 +1815,6 @@ enable_zigzag_join                           NULL    NULL     NULL     NULL     
 experimental_enable_hash_sharded_indexes     NULL    NULL     NULL     NULL        NULL
 experimental_enable_temp_tables              NULL    NULL     NULL     NULL        NULL
 experimental_optimizer_foreign_key_cascades  NULL    NULL     NULL     NULL        NULL
-experimental_serial_normalization            NULL    NULL     NULL     NULL        NULL
 extra_float_digits                           NULL    NULL     NULL     NULL        NULL
 force_savepoint_restart                      NULL    NULL     NULL     NULL        NULL
 foreign_key_cascades_limit                   NULL    NULL     NULL     NULL        NULL
@@ -1836,6 +1835,7 @@ require_explicit_primary_keys                NULL    NULL     NULL     NULL     
 results_buffer_size                          NULL    NULL     NULL     NULL        NULL
 row_security                                 NULL    NULL     NULL     NULL        NULL
 search_path                                  NULL    NULL     NULL     NULL        NULL
+serial_normalization                         NULL    NULL     NULL     NULL        NULL
 server_encoding                              NULL    NULL     NULL     NULL        NULL
 server_version                               NULL    NULL     NULL     NULL        NULL
 server_version_num                           NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/serial
+++ b/pkg/sql/logictest/testdata/logic_test/serial
@@ -94,7 +94,7 @@ DROP TABLE serials, smallbig, serial
 subtest serial_virtual_sequence
 
 statement ok
-SET experimental_serial_normalization = virtual_sequence
+SET serial_normalization = virtual_sequence
 
 # Force the sequence for column "c" to bump to 2.
 statement ok
@@ -199,7 +199,7 @@ DROP TABLE serials, smallbig, serial
 subtest serial_sql_sequence
 
 statement ok
-SET experimental_serial_normalization = sql_sequence
+SET serial_normalization = sql_sequence
 
 statement ok
 CREATE TABLE serial (

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -44,7 +44,6 @@ enable_zigzag_join                           on
 experimental_enable_hash_sharded_indexes     off
 experimental_enable_temp_tables              off
 experimental_optimizer_foreign_key_cascades  off
-experimental_serial_normalization            rowid
 extra_float_digits                           0
 force_savepoint_restart                      off
 foreign_key_cascades_limit                   10000
@@ -64,6 +63,7 @@ require_explicit_primary_keys                off
 results_buffer_size                          16384
 row_security                                 off
 search_path                                  public
+serial_normalization                         rowid
 server_encoding                              UTF8
 server_version                               9.5.0
 server_version_num                           90500

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -199,7 +199,7 @@ DROP SEQUENCE pg_temp.temp_seq
 
 # Allow temporary tables to use serial for temporary schemas.
 statement ok
-SET experimental_serial_normalization='sql_sequence'
+SET serial_normalization='sql_sequence'
 
 statement ok
 CREATE TEMP TABLE ref_temp_table (a SERIAL)
@@ -216,7 +216,7 @@ statement ok
 DROP SEQUENCE pg_temp.temp_seq; DROP SEQUENCE pg_temp.ref_temp_table_a_seq; DROP TABLE a
 
 statement ok
-SET experimental_serial_normalization='rowid'
+SET serial_normalization='rowid'
 
 subtest table_with_on_commit
 

--- a/pkg/sql/temporary_schema_test.go
+++ b/pkg/sql/temporary_schema_test.go
@@ -46,7 +46,7 @@ func TestCleanupSchemaObjects(t *testing.T) {
 
 	_, err = conn.ExecContext(ctx, `
 SET experimental_enable_temp_tables=true;
-SET experimental_serial_normalization='sql_sequence';
+SET serial_normalization='sql_sequence';
 CREATE TEMP TABLE a (a SERIAL, c INT);
 ALTER TABLE a ADD COLUMN b SERIAL;
 CREATE TEMP SEQUENCE a_sequence;

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -642,11 +642,11 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
-	`experimental_serial_normalization`: {
+	`serial_normalization`: {
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
 			mode, ok := sessiondata.SerialNormalizationModeFromString(s)
 			if !ok {
-				return newVarValueError(`experimental_serial_normalization`, s,
+				return newVarValueError(`serial_normalization`, s,
 					"rowid", "virtual_sequence", "sql_sequence")
 			}
 			m.SetSerialNormalizationMode(mode)


### PR DESCRIPTION
Fixes #48550

Release note (sql change): Rename experimental_serial_normalization session variable to serial_normalization since the setting is no longer experimental.