### PR TITLE
opt: correctly ignore NULL in array indirection

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/sqlsmith
+++ b/pkg/sql/logictest/testdata/logic_test/sqlsmith
@@ -151,3 +151,9 @@ query T
 SELECT * FROM t WHERE (d = d) OR (d = d)
 ----
 2001-01-01 00:00:00 +0000 +0000
+
+# Regression: #48826 (array indirection with NULL argument)
+query T
+SELECT ARRAY[1][NULL]
+----
+NULL


### PR DESCRIPTION
Fixes #48826

Release note (bug fix): fix an error that could occur when using NULL
in some array indirections.