### PR TITLE
release-19.2: cli: fix `cockroach dump` with collated strings

### DIFF
--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -441,12 +441,12 @@ func getMetadataForTable(conn *sqlConn, md basicMetadata, ts string) (tableMetad
 		}
 
 		// Transform the type name to an internal coltype.
-		sql := fmt.Sprintf("ALTER TABLE woo ALTER COLUMN woo SET DATA TYPE %s", typ)
+		sql := fmt.Sprintf("CREATE TABLE woo (x %s)", typ)
 		stmt, err := parser.ParseOne(sql)
 		if err != nil {
 			return tableMetadata{}, fmt.Errorf("type %s is not a valid CockroachDB type", typ)
 		}
-		coltyp := stmt.AST.(*tree.AlterTable).Cmds[0].(*tree.AlterTableAlterColumnType).ToType
+		coltyp := stmt.AST.(*tree.CreateTable).Defs[0].(*tree.ColumnTableDef).Type
 
 		coltypes[name] = coltyp
 		if colnames.Len() > 0 {
@@ -550,6 +550,7 @@ func dumpTableData(w io.Writer, conn *sqlConn, clusterTS string, bmd basicMetada
 		return err
 	}
 
+	var collationEnv tree.CollationEnvironment
 	bs := fmt.Sprintf("SELECT %s FROM %s AS OF SYSTEM TIME %s ORDER BY PRIMARY KEY %[2]s",
 		md.columnNames,
 		md.name,
@@ -619,7 +620,17 @@ func dumpTableData(w io.Writer, conn *sqlConn, clusterTS string, bmd basicMetada
 				case float64:
 					d = tree.NewDFloat(tree.DFloat(t))
 				case string:
-					d = tree.NewDString(t)
+					switch ct := md.columnTypes[cols[si]]; ct.Family() {
+					case types.StringFamily:
+						d = tree.NewDString(t)
+					case types.CollatedStringFamily:
+						d, err = tree.NewDCollatedString(t, ct.Locale(), &collationEnv)
+						if err != nil {
+							return err
+						}
+					default:
+						return errors.AssertionFailedf("unknown string type %s", ct)
+					}
 				case []byte:
 					// TODO(knz): this approach is brittle+flawed, see #28948.
 					switch ct := md.columnTypes[cols[si]]; ct.Family() {

--- a/pkg/cli/testdata/dump/row
+++ b/pkg/cli/testdata/dump/row
@@ -19,7 +19,8 @@ CREATE TABLE d.t (
 	e1 decimal(2),
 	e2 decimal(2, 1),
 	s1 string(1),
-	FAMILY "primary" (i, f, d, t, ts, n, o, u, ip, j, ary, tz, e1, e2, s1, rowid),
+	s2 string collate en_u_ks_level2,
+	FAMILY "primary" (i, f, d, t, ts, n, o, u, ip, j, ary, tz, e1, e2, s1, s2, rowid),
 	FAMILY fam_1_s (s),
 	FAMILY fam_2_b (b),
 	FAMILY fam_3_e (e)
@@ -42,7 +43,8 @@ INSERT INTO d.t VALUES (
 	'2016-01-25 10:10:10',
 	3.4,
 	4.5,
-	's'
+	's',
+	'hello' COLLATE en_u_ks_level2
 );
 INSERT INTO d.t VALUES (DEFAULT);
 INSERT INTO d.t (f, e) VALUES (
@@ -77,17 +79,18 @@ CREATE TABLE t (
 	e1 DECIMAL(2) NULL,
 	e2 DECIMAL(2,1) NULL,
 	s1 STRING(1) NULL,
-	FAMILY "primary" (i, f, d, t, ts, n, o, u, ip, j, ary, tz, e1, e2, s1, rowid),
+	s2 STRING COLLATE en_u_ks_level2 NULL,
+	FAMILY "primary" (i, f, d, t, ts, n, o, u, ip, j, ary, tz, e1, e2, s1, s2, rowid),
 	FAMILY fam_1_s (s),
 	FAMILY fam_2_b (b),
 	FAMILY fam_3_e (e)
 );
 
-INSERT INTO t (i, f, s, b, d, t, ts, n, o, e, u, ip, j, ary, tz, e1, e2, s1) VALUES
-	(1, 2.3, 'striiing', '\x613162326333', '2016-03-26', '01:02:03.456', '2016-01-25 10:10:10+00:00', '02:30:30', true, 1.2345, 'e9716c74-2638-443d-90ed-ffde7bea7d1d', '192.168.0.1', '{"a": "b"}', ARRAY['hello','world'], '2016-01-25 10:10:10+00:00', 3, 4.5, 's'),
-	(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
-	(NULL, '+Inf', NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'Infinity', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
-	(NULL, '-Inf', NULL, NULL, NULL, NULL, NULL, NULL, NULL, '-Infinity', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
-	(NULL, 'NaN', NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'NaN', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO t (i, f, s, b, d, t, ts, n, o, e, u, ip, j, ary, tz, e1, e2, s1, s2) VALUES
+	(1, 2.3, 'striiing', '\x613162326333', '2016-03-26', '01:02:03.456', '2016-01-25 10:10:10+00:00', '02:30:30', true, 1.2345, 'e9716c74-2638-443d-90ed-ffde7bea7d1d', '192.168.0.1', '{"a": "b"}', ARRAY['hello','world'], '2016-01-25 10:10:10+00:00', 3, 4.5, 's', 'hello' COLLATE en_u_ks_level2),
+	(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+	(NULL, '+Inf', NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'Infinity', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+	(NULL, '-Inf', NULL, NULL, NULL, NULL, NULL, NULL, NULL, '-Infinity', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+	(NULL, 'NaN', NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'NaN', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 ----
 ----


### PR DESCRIPTION
Backport 1/1 commits from #48687.

/cc @cockroachdb/release

---

Fixes #48278.

Release note (bug fix): Fix a bug where `cockroach dump` on a table
with collated strings would omit the collation clause for the data
insertion statements.
