### PR TITLE
release-20.1: sql: properly handle NULL hashedPassword column in system.users

### DIFF
--- a/pkg/sql/pgwire/testdata/auth/conn_log
+++ b/pkg/sql/pgwire/testdata/auth/conn_log
@@ -267,4 +267,3 @@ I: [n1,client=XXX,local] 81 disconnected; duration: XXX
 subtest end
 
 subtest end
-

--- a/pkg/sql/pgwire/testdata/auth/special_cases
+++ b/pkg/sql/pgwire/testdata/auth/special_cases
@@ -93,3 +93,34 @@ DROP USER testuser; CREATE USER testuser
 ok
 
 subtest end user_has_both_cert_and_passwd
+
+subtest user_has_null_hashed_password_column
+
+# This test manually adds a user to the system.users table with a NULL (not
+# empty) hashedPassword and attempts to log in as that user. This used to crash
+# the server (and this test) because the authentication routine only properly
+# handled empty hashedPassword values. See #48769.
+
+sql
+INSERT INTO system.users (username, "hashedPassword") VALUES ('nopassword', NULL)
+----
+ok
+
+set_hba
+host all nopassword 0.0.0.0/0 password
+----
+# Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all nopassword 0.0.0.0/0 password
+#
+# Interpreted configuration:
+# TYPE DATABASE USER       ADDRESS   METHOD        OPTIONS
+host   all      root       all       cert-password
+host   all      nopassword 0.0.0.0/0 password
+
+connect user=nopassword
+----
+ERROR: password authentication failed for user nopassword
+
+subtest end user_has_null_hashed_password_column

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -119,7 +119,9 @@ func retrieveUserAndPassword(
 		}
 		if values != nil {
 			exists = true
-			hashedPassword = []byte(*(values[0].(*tree.DBytes)))
+			if v := values[0]; v != tree.DNull {
+				hashedPassword = []byte(*(v.(*tree.DBytes)))
+			}
 		}
 
 		if !exists {


### PR DESCRIPTION
Backport 1/2 commits from #48773.

/cc @cockroachdb/release

---

Fixes #48769.

Before this change, attempts to log in as a user with a NULL value in their "hashedPassword" column in the `system.users` table would cause the server to crash. This was because `retrieveUserAndPassword` was not properly handling NULL values.

This change fixes this. It then fixes the bug that led me to the first one - we were not properly handling nil byte slices in `golangFillQueryArguments`. Nil byte slices were being treated as empty byte slices, which resulted in confusing behavior where a nil byte slice passed to an InternalExecutor would not be NULL. I'm considered backporting this fix, but I don't think we should. I fear that doing so will have unintended consequences by tickling other bugs like what is fixed in the first commit.

Finally, this fixes `TestGolangQueryArgs`, which was completely broken and asserting that `reflect.Type(*types.T) == reflect.Type(*types.T)`.

Release note (bug fix): Manually writing a NULL value into the system.users table for the "hashedPassword" column will no longer cause a server crash during user authentication.
