### PR TITLE
release-19.2: sql: properly handle NULL hashedPassword column in system.users

### DIFF
--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -40,7 +40,10 @@ func GetUserHashedPassword(
 	if values == nil {
 		return false, nil, nil
 	}
-	hashedPassword := []byte(*(values[0].(*tree.DBytes)))
+	var hashedPassword []byte
+	if v := values[0]; v != tree.DNull {
+		hashedPassword = []byte(*(v.(*tree.DBytes)))
+	}
 	return true, hashedPassword, nil
 }
 


### PR DESCRIPTION
Backport 1/2 commits from #48773.

/cc @cockroachdb/release

---

Fixes #48769.

Before this change, attempts to log in as a user with a NULL value in their "hashedPassword" column in the `system.users` table would cause the server to crash. This was because `retrieveUserAndPassword` was not properly handling NULL values.

This change fixes this. It then fixes the bug that led me to the first one - we were not properly handling nil byte slices in `golangFillQueryArguments`. Nil byte slices were being treated as empty byte slices, which resulted in confusing behavior where a nil byte slice passed to an InternalExecutor would not be NULL. I'm considered backporting this fix, but I don't think we should. I fear that doing so will have unintended consequences by tickling other bugs like what is fixed in the first commit.

Finally, this fixes `TestGolangQueryArgs`, which was completely broken and asserting that `reflect.Type(*types.T) == reflect.Type(*types.T)`.

Release note (bug fix): Manually writing a NULL value into the system.users table for the "hashedPassword" column will no longer cause a server crash during user authentication.
