### PR TITLE
release-20.1: sqlmigrations: fix handling of mutations in schema change job migration

### DIFF
--- a/pkg/sql/schema_change_migrations_test.go
+++ b/pkg/sql/schema_change_migrations_test.go
@@ -896,3 +896,76 @@ func TestGCJobCreated(t *testing.T) {
 		[][]string{{"1"}},
 	)
 }
+
+// TestMissingMutation tests that a malformed table descriptor with a
+// MutationJob but no Mutation for the given job causes the job to fail with an
+// error. Regression test for #48786.
+func TestMissingMutation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer setTestJobsAdoptInterval()()
+	schemaChangeBlocked, descriptorUpdated := make(chan struct{}), make(chan struct{})
+	migratedJob := false
+	var schemaChangeJobID int64
+	params, _ := tests.CreateTestServerParams()
+	params.Knobs.SQLMigrationManager = &sqlmigrations.MigrationManagerTestingKnobs{
+		AlwaysRunJobMigration: true,
+	}
+	params.Knobs.SQLSchemaChanger = &sql.SchemaChangerTestingKnobs{
+		RunBeforeResume: func(jobID int64) error {
+			if !migratedJob {
+				migratedJob = true
+				schemaChangeJobID = jobID
+				close(schemaChangeBlocked)
+			}
+
+			<-descriptorUpdated
+			return jobs.NewRetryJobError("stop this job until cluster upgrade")
+		},
+	}
+	s, sqlDB, kvDB := serverutils.StartServer(t, params)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer s.Stopper().Stop(ctx)
+	registry := s.JobRegistry().(*jobs.Registry)
+
+	_, err := sqlDB.Exec(`CREATE DATABASE t; CREATE TABLE t.test(k INT PRIMARY KEY, v INT);`)
+	require.NoError(t, err)
+
+	bg := ctxgroup.WithContext(ctx)
+	// Start a schema change on the table in a separate goroutine.
+	bg.Go(func() error {
+		if _, err := sqlDB.ExecContext(ctx, `ALTER TABLE t.test ADD COLUMN a INT;`); err != nil {
+			cancel()
+			return err
+		}
+		return nil
+	})
+
+	<-schemaChangeBlocked
+
+	// Rewrite the job to be a 19.2-style job.
+	require.NoError(t, migrateJobToOldFormat(kvDB, registry, schemaChangeJobID, AddColumn))
+
+	// To get the table descriptor into the (invalid) state we're trying to test,
+	// clear the mutations on the table descriptor.
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
+	tableDesc.Mutations = nil
+	require.NoError(
+		t, kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			if err := txn.SetSystemConfigTrigger(); err != nil {
+				return err
+			}
+			return kvDB.Put(ctx, sqlbase.MakeDescMetadataKey(
+				tableDesc.GetID()), sqlbase.WrapDescriptor(tableDesc),
+			)
+		}),
+	)
+
+	// Run the migration.
+	migMgr := s.MigrationManager().(*sqlmigrations.Manager)
+	require.NoError(t, migMgr.StartSchemaChangeJobMigration(ctx))
+
+	close(descriptorUpdated)
+
+	err = bg.Wait()
+	require.Regexp(t, fmt.Sprintf("mutation %d not found for MutationJob %d", 1, schemaChangeJobID), err)
+}

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -1009,9 +1009,25 @@ func migrateMutationJobForTable(
 			continue
 		}
 		log.VEventf(
-			ctx, 2, "job %d: found corresponding mutation %d on table %d",
+			ctx, 2, "job %d: found corresponding MutationJob %d on table %d",
 			*job.ID(), mutationJob.MutationID, tableDesc.ID,
 		)
+		var mutation *sqlbase.DescriptorMutation
+		for i := range tableDesc.Mutations {
+			if tableDesc.Mutations[i].MutationID == mutationJob.MutationID {
+				mutation = &tableDesc.Mutations[i]
+				break
+			}
+		}
+		if mutation == nil {
+			// In theory, MutationJobs[i] corresponds to Mutations[i] in 19.2 and
+			// earlier versions, so this should never happen. However, we've seen this
+			// happen (#48786), so we have to be defensive.
+			mutationNotFoundError := errors.AssertionFailedf("mutation %d not found for MutationJob %d",
+				mutationJob.MutationID, mutationJob.JobID)
+			log.Errorf(ctx, "%v", mutationNotFoundError)
+			return registry.Failed(ctx, txn, *job.ID(), mutationNotFoundError)
+		}
 
 		// Update the job details and status based on the table descriptor
 		// state.
@@ -1030,7 +1046,6 @@ func migrateMutationJobForTable(
 			md.Payload.Lease = &jobspb.Lease{}
 			ju.UpdatePayload(md.Payload)
 
-			mutation := &tableDesc.Mutations[i]
 			// If the mutation exists on the table descriptor, then the schema
 			// change isn't actually in a terminal state, regardless of what the
 			// job status is. So we force the status to Reverting if there's any


### PR DESCRIPTION
Backport 1/1 commits from #48823.

/cc @cockroachdb/release

---

The migration for schema change jobs assumed that a table descriptor's
`MutationJobs` were always synced with `Mutations`, so we were indexing
into `Mutations` with the `MutationJobs` index. In practice, if this
assumption doesn't hold due to some previous buggy schema change, we
risk crashing with an out of bounds error or looking up the wrong
mutation. This PR adds a step to find the mutation with the expected ID
and mark the job as failed if the mutation doesn't exist.

Fixes #48786.

Release note (bug fix): Fix a problem introduced in v20.1.0 where the
migration for ongoing schema change jobs would cause the node to panic
with an index out of bounds error, upon encountering a malformed table
descriptor with no schema change mutation corresponding to the job to be
migrated.
