### PR TITLE
sql: add job ID to queued schema change log

### DIFF
--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -1024,8 +1024,8 @@ func (p *planner) createOrUpdateSchemaChangeJob(
 			tableDesc.MutationJobs = append(tableDesc.MutationJobs, sqlbase.TableDescriptor_MutationJob{
 				MutationID: mutationID, JobID: *newJob.ID()})
 		}
-		log.Infof(ctx, "queued new schema change job for table %d, mutation %d",
-			tableDesc.ID, mutationID)
+		log.Infof(ctx, "queued new schema change job %d for table %d, mutation %d",
+			*newJob.ID(), tableDesc.ID, mutationID)
 	} else {
 		// Update the existing job.
 		oldDetails := job.Details().(jobspb.SchemaChangeDetails)


### PR DESCRIPTION
This commit adds the job ID information to the log messages that
indicates that a schema change job on a particular table has been
queued.

Release note: None