### PR TITLE
sql: unify "will distribute" check

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -871,8 +871,9 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	var subqueryPlanCtx *PlanningCtx
 	var distributeSubquery bool
 	if maybeDistribute {
-		distributeSubquery = shouldDistributePlan(
-			ctx, planner.SessionData().DistSQLMode, dsp, subqueryPlan.plan)
+		distributeSubquery = willDistributePlan(
+			ctx, planner.execCfg.NodeID, planner.SessionData().DistSQLMode, subqueryPlan.plan,
+		)
 	}
 	if distributeSubquery {
 		subqueryPlanCtx = dsp.NewPlanningCtx(ctx, evalCtx, planner.txn)
@@ -1173,8 +1174,9 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	var postqueryPlanCtx *PlanningCtx
 	var distributePostquery bool
 	if maybeDistribute {
-		distributePostquery = shouldDistributePlan(
-			ctx, planner.SessionData().DistSQLMode, dsp, postqueryPlan)
+		distributePostquery = willDistributePlan(
+			ctx, planner.execCfg.NodeID, planner.SessionData().DistSQLMode, postqueryPlan,
+		)
 	}
 	if distributePostquery {
 		postqueryPlanCtx = dsp.NewPlanningCtx(ctx, evalCtx, planner.txn)

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -188,11 +188,14 @@ func populateExplain(
 ) error {
 	// Determine the "distributed" and "vectorized" values, which we will emit as
 	// special rows.
-	var isDistSQL, isVec bool
+	var willDistribute, willVectorize bool
 	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
-	isDistSQL, _ = willDistributePlan(distSQLPlanner, plan.main, params)
+	willDistribute = willDistributePlanForExplainPurposes(
+		params.ctx, params.extendedEvalCtx.ExecCfg.NodeID,
+		params.extendedEvalCtx.SessionData.DistSQLMode, plan.main,
+	)
 	outerSubqueries := params.p.curPlan.subqueryPlans
-	planCtx := makeExplainVecPlanningCtx(distSQLPlanner, params, stmtType, plan.subqueryPlans, isDistSQL)
+	planCtx := makeExplainPlanningCtx(distSQLPlanner, params, stmtType, plan.subqueryPlans, willDistribute)
 	defer func() {
 		planCtx.planner.curPlan.subqueryPlans = outerSubqueries
 	}()
@@ -211,21 +214,21 @@ func populateExplain(
 
 		ctxSessionData := flowCtx.EvalCtx.SessionData
 		vectorizedThresholdMet := physicalPlan.MaxEstimatedRowCount >= ctxSessionData.VectorizeRowCountThreshold
-		isVec = true
+		willVectorize = true
 		if ctxSessionData.VectorizeMode == sessiondata.VectorizeOff {
-			isVec = false
+			willVectorize = false
 		} else if !vectorizedThresholdMet && (ctxSessionData.VectorizeMode == sessiondata.Vectorize201Auto || ctxSessionData.VectorizeMode == sessiondata.VectorizeOn) {
-			isVec = false
+			willVectorize = false
 		} else {
 			thisNodeID := distSQLPlanner.nodeDesc.NodeID
 			for nodeID, flow := range flows {
 				fuseOpt := flowinfra.FuseNormally
-				if nodeID == thisNodeID && !isDistSQL {
+				if nodeID == thisNodeID && !willDistribute {
 					fuseOpt = flowinfra.FuseAggressively
 				}
 				_, err := colflow.SupportsVectorized(params.ctx, flowCtx, flow.Processors, fuseOpt, nil /* output */)
-				isVec = isVec && (err == nil)
-				if !isVec {
+				willVectorize = willVectorize && (err == nil)
+				if !willVectorize {
 					break
 				}
 			}
@@ -258,10 +261,10 @@ func populateExplain(
 	}
 
 	// First, emit the "distributed" and "vectorized" information rows.
-	if err := emitRow("", 0, "", "distributed", fmt.Sprintf("%t", isDistSQL), "", ""); err != nil {
+	if err := emitRow("", 0, "", "distributed", fmt.Sprintf("%t", willDistribute), "", ""); err != nil {
 		return err
 	}
-	if err := emitRow("", 0, "", "vectorized", fmt.Sprintf("%t", isVec), "", ""); err != nil {
+	if err := emitRow("", 0, "", "vectorized", fmt.Sprintf("%t", willVectorize), "", ""); err != nil {
 		return err
 	}
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_auto_mode
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_auto_mode
@@ -5,6 +5,11 @@
 # The cluster size or distsql mode aren't important for these tests.
 #
 
+# "local" logic test configuration overrides the DistSQL mode to 'off', but
+# we're interested in behavior with 'auto' in this test file.
+statement ok
+SET distsql=auto
+
 statement ok
 CREATE TABLE kv (k INT PRIMARY KEY, v INT)
 


### PR DESCRIPTION
This commit unifies the way we do "will distribute" check (there is a
special case for different EXPLAIN variants because some actually
distributed queries do not go through the DistSQL physical planner).
It also removes the receiver from the utility methods
`checkSupportForNode` and `checkExpr` that verify whether DistSQL
engine supports certain things as a preliminary step to making the
distribution decision in execbuilder. Additionally, it updates a few
comments.

Release note: None