### PR TITLE
server: thin out the main start path

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1243,10 +1243,11 @@ func (s *Server) Start(ctx context.Context) error {
 		})
 	}
 
-	if len(s.cfg.GossipBootstrapResolvers) == 0 {
-		// If the node is started without join flags, attempt self-bootstrap.
-		// Note that we're not checking whether the node is already bootstrapped;
-		// if this is the case, Bootstrap will simply fail.
+	if initServer.NeedsInit() && len(s.cfg.GossipBootstrapResolvers) == 0 {
+		// If a new node is started without join flags, self-bootstrap.
+		//
+		// Note: this is behavior slated for removal, see:
+		// https://github.com/cockroachdb/cockroach/pull/44112
 		_, err := initServer.Bootstrap(ctx, &serverpb.BootstrapRequest{})
 		switch {
 		case err == nil:

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1598,10 +1598,13 @@ func (s *Server) startServeUI(
 ) error {
 
 	// Enable the debug endpoints first to provide an earlier window into what's
-	// going on with the node in advance of exporting node functionality.
+	// going on with the node in advance of exporting node functionality. Note
+	// that these are not authenticated (to ease debugging) but instead default to
+	// allowing connections from localhost only. See the
+	// 'server.remote_debugging.mode' cluster setting.
 	//
-	// TODO(marc): when cookie-based authentication exists, apply it to all web
-	// endpoints.
+	// TODO(knz): this is not secure enough, revisit. Customers often flip this
+	// setting during debug sessions and may never flip it back.
 	s.mux.Handle(debug.Endpoint, s.debug)
 
 	// Initialize grpc-gateway mux and context in order to get the /health


### PR DESCRIPTION
It has always bothered me how much was going on there in no particular
order. This commit takes the myriad of workers and one-off operations
that go into starting a Server and adds them to a method at the end.

This has the effect that `(*Server).Start` is now more clearly occupied
only with setting up the listeners, bootstrapping, and starting the Node
and SQL Server.

Release note: None

