### PR TITLE
pgwire: trim statements past the conn executor's rewind pos eagerly

### DIFF
--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -549,6 +549,13 @@ func (buf *StmtBuf) Rewind(ctx context.Context, pos CmdPos) {
 	buf.mu.curPos = pos
 }
 
+// Len returns the buffer's length.
+func (buf *StmtBuf) Len() int {
+	buf.mu.Lock()
+	defer buf.mu.Unlock()
+	return buf.mu.data.Len()
+}
+
 // RowDescOpt specifies whether a result needs a row description message.
 type RowDescOpt bool
 
@@ -836,6 +843,11 @@ type rewindCapability struct {
 func (rc *rewindCapability) rewindAndUnlock(ctx context.Context) {
 	rc.cl.RTrim(ctx, rc.rewindPos)
 	rc.buf.Rewind(ctx, rc.rewindPos)
+	rc.cl.Close()
+}
+
+// close closes the underlying ClientLock.
+func (rc *rewindCapability) close() {
 	rc.cl.Close()
 }
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -731,6 +731,9 @@ type ExecutorTestingKnobs struct {
 	// statement.
 	AfterExecute func(ctx context.Context, stmt string, err error)
 
+	// AfterExecCmd is called after successful execution of any command.
+	AfterExecCmd func(ctx context.Context, cmd Command, buf *StmtBuf)
+
 	// DisableAutoCommit, if set, disables the auto-commit functionality of some
 	// SQL statements. That functionality allows some statements to commit
 	// directly when they're executed in an implicit SQL txn, without waiting for


### PR DESCRIPTION
Previously, the conn executor held on to all executed statements in case they
needed to be retried. These would only be discarded once the transaction
committed. This could lead to a memory blowup in some cases.

With the knowledge that statements whose results have been returned cannot be
retried, this commit eagerly discards those statements every time a command is
executed rather than waiting for the transaction to commit.

Release note (bug fix): executing a large number of statements in a transaction
without committing could previously crash a cockroach server, this is now
fixed.

Addresses #47969