### PR TITLE
release-20.1: cli: Resolve past engine type correctly with encryption-at-rest

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -140,7 +140,7 @@ func OpenEngine(dir string, stopper *stop.Stopper, opts OpenEngineOptions) (stor
 	}
 
 	var db storage.Engine
-	storageEngine := resolveStorageEngineType(storage.DefaultStorageEngine, storageConfig.Dir)
+	storageEngine := resolveStorageEngineType(context.Background(), storage.DefaultStorageEngine, storageConfig)
 
 	switch storageEngine {
 	case enginepb.EngineTypePebble:

--- a/pkg/cli/interactive_tests/test_storage_engine_sticky.tcl
+++ b/pkg/cli/interactive_tests/test_storage_engine_sticky.tcl
@@ -1,0 +1,71 @@
+#! /usr/bin/env expect -f
+#
+source [file join [file dirname $argv0] common.tcl]
+
+set storedir "encryption_store"
+set keydir "$storedir/keys"
+
+spawn /bin/bash
+send "PS1=':''/# '\r"
+eexpect ":/# "
+
+start_test "Generate encryption keys."
+send "mkdir -p $keydir\n"
+send "$argv gen encryption-key -s 128 $keydir/aes-128.key\r"
+eexpect "successfully created AES-128 key: $keydir/aes-128.key"
+end_test
+
+start_test "Start normal node with default engine."
+send "$argv start-single-node --insecure --store=$storedir\r"
+eexpect "storage engine: *rocksdb"
+interrupt
+eexpect "shutdown completed"
+end_test
+
+start_test "Restart normal node with non-default engine specified."
+send "$argv start-single-node --insecure --store=$storedir --storage-engine=pebble\r"
+eexpect "storage engine: *pebble"
+interrupt
+eexpect "shutdown completed"
+end_test
+
+start_test "Restart normal node; should resort to non-default engine."
+send "$argv start-single-node --insecure --store=$storedir\r"
+eexpect "storage engine: *pebble"
+interrupt
+eexpect "shutdown completed"
+end_test
+
+start_test "Restart normal node with default engine specified."
+send "$argv start-single-node --insecure --store=$storedir --storage-engine=rocksdb\r"
+eexpect "storage engine: *rocksdb"
+interrupt
+eexpect "shutdown completed"
+end_test
+
+start_test "Restart with AES-128."
+send "$argv start-single-node --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-128.key,old-key=plain\r"
+eexpect "storage engine: *rocksdb"
+interrupt
+eexpect "shutdown completed"
+send "$argv debug encryption-status $storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-128.key,old-key=plain\r"
+eexpect "    \"Active\": true,\r\n    \"Type\": \"AES128_CTR\","
+end_test
+
+start_test "Restart with AES-128 and specify non-default engine."
+send "$argv start-single-node --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-128.key,old-key=plain --storage-engine=pebble\r"
+eexpect "storage engine: *pebble"
+interrupt
+eexpect "shutdown completed"
+send "$argv debug encryption-status $storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-128.key,old-key=plain\r"
+eexpect "    \"Active\": true,\r\n    \"Type\": \"AES128_CTR\","
+end_test
+
+start_test "Restart with AES-128 and engine unspecified; should resolve to non-default engine."
+send "$argv start-single-node --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-128.key,old-key=plain\r"
+eexpect "storage engine: *pebble"
+interrupt
+eexpect "shutdown completed"
+send "$argv debug encryption-status $storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-128.key,old-key=plain\r"
+eexpect "    \"Active\": true,\r\n    \"Type\": \"AES128_CTR\","
+end_test


### PR DESCRIPTION
20.1 backport of #48721 

---

The default engine type resolves to the last used engine type,
which is determined by reading the OPTIONS file in the store directory.
However if encrypted at rest is enabled, we need to set up the encrypted
vfs first before that file can be read. This change makes that happen.

Fixes #48148.

Release note (cli change): Make --storage-engine sticky (i.e. resolve
to the last used engine type when unspecified) even when specified
stores are encrypted at rest.