### PR TITLE
server,gossip/resolver,cli: gate the SRV lookups under a new flag

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -375,6 +375,17 @@ or both forms can be used together, for example:
 </PRE>`,
 	}
 
+	JoinPreferSRVRecords = FlagInfo{
+		Name: "experimental-dns-srv",
+		Description: `
+When enabled, the node will first attempt to fetch SRV records
+from DNS for every name specified with --join. If a valid
+SRV record is found, that information is used instead
+of regular DNS A/AAAA lookups.
+This feature is experimental and may be removed or modified
+in a later version.`,
+	}
+
 	ListenAddr = FlagInfo{
 		Name: "listen-addr",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -114,6 +114,7 @@ func initCLIDefaults() {
 	serverCfg.DelayedBootstrapFn = nil
 	serverCfg.SocketFile = ""
 	serverCfg.JoinList = nil
+	serverCfg.JoinPreferSRVRecords = false
 	serverCfg.DefaultZoneConfig = zonepb.DefaultZoneConfig()
 	serverCfg.DefaultSystemZoneConfig = zonepb.DefaultSystemZoneConfig()
 	// Attempt to default serverCfg.SQLMemoryPoolSize to 25% if possible.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -391,6 +391,7 @@ func init() {
 		// --join, because it delegates its logic to that of 'start', and
 		// 'start' will check that the flag is properly defined.
 		VarFlag(f, &serverCfg.JoinList, cliflags.Join)
+		BoolFlag(f, &serverCfg.JoinPreferSRVRecords, cliflags.JoinPreferSRVRecords, serverCfg.JoinPreferSRVRecords)
 		VarFlag(f, clusterNameSetter{&baseCfg.ClusterName}, cliflags.ClusterName)
 		BoolFlag(f, &baseCfg.DisableClusterNameVerification,
 			cliflags.DisableClusterNameVerification, baseCfg.DisableClusterNameVerification)

--- a/pkg/gossip/resolver/resolver.go
+++ b/pkg/gossip/resolver/resolver.go
@@ -23,10 +23,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-var (
-	lookupSRV = net.LookupSRV
-)
-
 // Resolver is an interface which provides an abstract factory for
 // net.Addr addresses. Resolvers are not thread safe.
 type Resolver interface {
@@ -116,4 +112,18 @@ func ensureHostPort(addr string, defaultPort string) string {
 	}
 
 	return net.JoinHostPort(host, port)
+}
+
+var (
+	lookupSRV = net.LookupSRV
+)
+
+// TestingOverrideSRVLookupFn enables a test to temporarily override
+// the SRV lookup function.
+func TestingOverrideSRVLookupFn(
+	fn func(service, proto, name string) (cname string, addrs []*net.SRV, err error),
+) func() {
+	prevFn := lookupSRV
+	lookupSRV = fn
+	return func() { lookupSRV = prevFn }
 }

--- a/pkg/gossip/resolver/resolver_test.go
+++ b/pkg/gossip/resolver/resolver_test.go
@@ -135,16 +135,17 @@ func TestSRV(t *testing.T) {
 	}
 
 	for tcNum, tc := range testCases {
-		lookupSRV = tc.lookuper
+		func() {
+			defer TestingOverrideSRVLookupFn(tc.lookuper)()
 
-		resolvers, err := SRV(context.TODO(), tc.address)
+			resolvers, err := SRV(context.TODO(), tc.address)
 
-		if err != nil {
-			t.Errorf("#%d: expected success, got err=%v", tcNum, err)
-		}
+			if err != nil {
+				t.Errorf("#%d: expected success, got err=%v", tcNum, err)
+			}
 
-		require.Equal(t, tc.want, resolvers, "Test #%d failed", tcNum)
+			require.Equal(t, tc.want, resolvers, "Test #%d failed", tcNum)
 
-		lookupSRV = net.LookupSRV
+		}()
 	}
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -148,6 +148,11 @@ type Config struct {
 	// connecting to the gossip network.
 	JoinList base.JoinListType
 
+	// JoinPreferSRVRecords, if set, causes the lookup logic for the
+	// names in JoinList to prefer SRV records from DNS, if available,
+	// to A/AAAA records.
+	JoinPreferSRVRecords bool
+
 	// RetryOptions controls the retry behavior of the server.
 	RetryOptions retry.Options
 
@@ -650,25 +655,35 @@ func (cfg *Config) readEnvironmentVariables() {
 func (cfg *Config) parseGossipBootstrapResolvers(ctx context.Context) ([]resolver.Resolver, error) {
 	var bootstrapResolvers []resolver.Resolver
 	for _, address := range cfg.JoinList {
-		srvAddrs, err := resolver.SRV(ctx, address)
-		if err != nil {
-			return nil, err
-		}
-
-		// setup resolvers with SRV results if there were any
-		if len(srvAddrs) > 0 {
-			for _, sa := range srvAddrs {
-				resolver, err := resolver.NewResolver(sa)
-				if err != nil {
-					return nil, err
-				}
-				bootstrapResolvers = append(bootstrapResolvers, resolver)
+		if cfg.JoinPreferSRVRecords {
+			// The following code substitutes the entry in --join by the
+			// result of SRV resolution, if suitable SRV records are found
+			// for that name.
+			//
+			// TODO(knz): Delay this lookup. The logic for "regular" resolvers
+			// is delayed until the point the connection is attempted, so that
+			// fresh DNS records are used for a new connection. This makes
+			// it possible to update DNS records without restarting the node.
+			// The SRV logic here does not have this property (yet).
+			srvAddrs, err := resolver.SRV(ctx, address)
+			if err != nil {
+				return nil, err
 			}
 
-			continue
+			if len(srvAddrs) > 0 {
+				for _, sa := range srvAddrs {
+					resolver, err := resolver.NewResolver(sa)
+					if err != nil {
+						return nil, err
+					}
+					bootstrapResolvers = append(bootstrapResolvers, resolver)
+				}
+
+				continue
+			}
 		}
 
-		// otherwise use the address
+		// Otherwise, use the address.
 		resolver, err := resolver.NewResolver(address)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
In v20.1 the bootstrap resolver code was changed to prefer SRV
records, if present in DNS, to regular A/AAAA records.

This change turned out to be a bit too immature as multiple defects
were found in succession:

- the code was improperly using records with port 0.
- it would crash if DNS was not available.
- it does not follow the regular SRV naming rules, where
  a service should be named as `_svcname._tcp.xxxx`.
- it is not able to re-perform the SRV lookup after the
  node has started up, if it takes a while for the rest
  of the cluster to catch up.

Some of these issues have since been fixed, but others remain open.
In order to not let users experience trouble with this feature
until it matures a bit, this patch introduces a new CLI flag
`--experimental-dns-srv` which defaults to false.

Also this patch adds the missing test for the join resolution.

Release note (backward incompatible change): CockroachDB v20.1
introduced a new rule for the `--join` flag causing it to prefer SRV
records, if present in DNS, to look up the peer nodes to join. This
feature is experimental. However, it is also found to cause disruption
in in certain deployments. To reduce this disruption and UX surprise,
the feature is now gated behind a new command-line flag
`--experimental-dns-srv` which must now be explicitly passed to
`cockroach start` to enable it.