### PR TITLE
vendor: Bump pebble to 3b880202b00bae737b2d77e7a59dbcabdf9d78b8

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -464,7 +464,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e4f9305757fe44f0484aba1d16ea46d126c2a65d6cf238418b8920f09538fa1e"
+  digest = "1:fc792580c5d8569794695d36ca3225b8968f3dca7ec49d040d7bb102dbf64b3f"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -490,7 +490,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "43f8d507aa62091533b3370120dbbe1fe300d9a3"
+  revision = "3b880202b00bae737b2d77e7a59dbcabdf9d78b8"
 
 [[projects]]
   branch = "master"

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1267,12 +1267,11 @@ func init() {
 		return mvccValueFormatter{kv: storage.MVCCKeyValue{Key: decoded, Value: value}}
 	}
 
-	pebbleTool := tool.New()
 	// To be able to read Cockroach-written RocksDB manifests/SSTables, comparator
 	// and merger functions must be specified to pebble that match the ones used
 	// to write those files.
-	pebbleTool.RegisterMerger(storage.MVCCMerger)
-	pebbleTool.RegisterComparer(storage.MVCCComparer)
+	pebbleTool := tool.New(tool.Mergers(storage.MVCCMerger),
+		tool.DefaultComparer(storage.MVCCComparer))
 	debugPebbleCmd.AddCommand(pebbleTool.Commands...)
 	DebugCmd.AddCommand(debugPebbleCmd)
 


### PR DESCRIPTION
Bump Pebble to SHA 3b880202 and make the pkg/cli/debug change required by 5a133cfa's breaking change to the pebble/tool interface.

    3b880202 db: don't create mutable memtable in read-only mode
    4199a9a7 cmd/pebble: replay ingests, flushes faithfully
    6a32e2ca internal/private: add FlushExternalTable
    ad09a34b internal/arenaskl: ensure entire node points to allocated memory
    4a9f43e0 internal/batchskl: ensure entire node points to allocated memory
    a8570177 cmd/pebble: skip first manifest record in `bench compact new`
    ffe9617e sstable: fix missing cache unref in BenchmarkTableIter*
    5a133cfa tool: use Option pattern, add DefaultComparer option
    9d28253d cmd/pebble: add bench compact subcommands
    a17e71ed db: fix CompactionInfo documentation
    faf7ac70 tool: Show sublevels at the end of manifest dump
    30530bea internal/manifest: add Version.CheckConsistency
    7c6f5699 sstable: Fix twoLevelIterator handling around boundaries
    55d0d53e internal/manual: panic with "out of memory" on allocation failure
    00ded19f internal/manifest: Add L0SubLevels methods to pick compactions
    37f7f239 internal/metamorphic: print options, ops on comparison failures
    290f4696 internal/arenaskl: small lint warning fixes
    b4319f4f db: add stress test of snapshots and range deletions
    3e49f998 tool: Add accessors for the underlying command
    91672215 internal/cache: fix double-free of cache entries
    72c12440 tool: fix `db properties` on DBs with nondefault merger
    686bfca5 internal/manifest: remove unused intervalRangeIsBaseCompacting local

Release note: None