### PR TITLE
sql: fix bug where columns couldn't be dropped after a pk change

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1169,3 +1169,11 @@ t  CREATE TABLE t (
    UNIQUE INDEX t_crdb_internal_x_shard_2_x_key (x ASC) USING HASH WITH BUCKET_COUNT = 2,
    FAMILY fam_0_x_y_crdb_internal_x_shard_2 (x, y, crdb_internal_x_shard_2, crdb_internal_y_shard_2)
 )
+
+# Regression for #49079.
+statement ok
+DROP TABLE t;
+CREATE TABLE t (x INT, y INT, z INT, PRIMARY KEY (x, y));
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (y);
+SET sql_safe_updates=false;
+ALTER TABLE t DROP COLUMN z

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -3161,6 +3161,9 @@ func (desc *MutableTableDescriptor) MakeMutationComplete(m DescriptorMutation) e
 			}
 			newIndex.Name = "primary"
 			desc.PrimaryIndex = *protoutil.Clone(newIndex).(*IndexDescriptor)
+			// The primary index "implicitly" stores all columns in the table.
+			// Explicitly including them in the stored columns list is incorrect.
+			desc.PrimaryIndex.StoreColumnNames, desc.PrimaryIndex.StoreColumnIDs = nil, nil
 			idx, err := getIndexIdxByID(newIndex.ID)
 			if err != nil {
 				return err


### PR DESCRIPTION
Fixes #49079.

Release note (bug fix): Fix a bug where columns of a table could not
be dropped after a primary key change.