### PR TITLE
kvserver: disconnect rangefeeds before applying a merge

### DIFF
--- a/pkg/kv/kvserver/client_rangefeed_test.go
+++ b/pkg/kv/kvserver/client_rangefeed_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -101,4 +102,79 @@ func TestRangefeedWorksOnSystemRangesUnconditionally(t *testing.T) {
 		require.Regexp(t, `rangefeeds require the kv\.rangefeed.enabled setting`,
 			ds.RangeFeed(ctx, scratchSpan, startTS, false /* withDiff */, evChan))
 	})
+}
+
+// TestMergeOfRangeEventTableWhileRunningRangefeed ensures that it is safe
+// for a range merge transaction which has laid down intents on the RHS of the
+// merge commit while a rangefeed is running on the RHS. At the time of writing,
+// the only such range that this can happen to is the RangeEventTable.
+func TestMergeOfRangeEventTableWhileRunningRangefeed(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		// Using ReplicationManual will disable the merge queue.
+		ReplicationMode: base.ReplicationManual,
+	})
+	ctx := context.Background()
+	defer tc.Stopper().Stop(ctx)
+
+	// Set a short closed timestamp interval so that we don't need to wait long
+	// for resolved events off of the rangefeed later.
+	_, err := tc.ServerConn(0).Exec(
+		"SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms'")
+	require.NoError(t, err)
+
+	// Find the range containing the range event table and then find the range
+	// to its left.
+	rangeEventTableStart := keys.SystemSQLCodec.TablePrefix(keys.RangeEventTableID)
+	require.NoError(t, tc.WaitForSplitAndInitialization(rangeEventTableStart))
+	store, _ := getFirstStoreReplica(t, tc.Server(0), rangeEventTableStart)
+	var lhsRepl *kvserver.Replica
+	store.VisitReplicas(func(repl *kvserver.Replica) (wantMore bool) {
+		if repl.Desc().EndKey.AsRawKey().Equal(rangeEventTableStart) {
+			lhsRepl = repl
+			return false
+		}
+		return true
+	})
+	require.NotNil(t, lhsRepl)
+
+	// Set up a rangefeed for the lhs.
+	db := tc.Server(0).DB()
+	ds := tc.Server(0).DistSenderI().(*kvcoord.DistSender)
+
+	rangefeedCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	rangefeedErrChan := make(chan error, 1)
+	// Make the buffer large so we don't risk blocking.
+	eventCh := make(chan *roachpb.RangeFeedEvent, 1000)
+	start := db.Clock().Now()
+	go func() {
+		rangefeedErrChan <- ds.RangeFeed(rangefeedCtx,
+			lhsRepl.Desc().RSpan().AsRawSpanWithNoLocals(),
+			start,
+			false, /* withDiff */
+			eventCh)
+	}()
+
+	// Wait for an event on the rangefeed to let us know that we're connected.
+	<-eventCh
+
+	// Merge the range event table range with its lhs neighbor.
+	require.NoError(t, db.AdminMerge(ctx, lhsRepl.Desc().StartKey.AsRawKey()))
+
+	// Ensure that we get a checkpoint after the merge.
+	afterMerge := db.Clock().Now()
+	for ev := range eventCh {
+		if ev.Checkpoint == nil {
+			continue
+		}
+		if afterMerge.Less(ev.Checkpoint.ResolvedTS) {
+			break
+		}
+	}
+
+	// Cancel the rangefeed and ensure we get the right error.
+	cancel()
+	require.Regexp(t, context.Canceled.Error(), <-rangefeedErrChan)
 }

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -130,7 +130,7 @@ func (i iteratorWithCloser) Close() {
 func (r *Replica) RangeFeed(
 	args *roachpb.RangeFeedRequest, stream roachpb.Internal_RangeFeedServer,
 ) *roachpb.Error {
-	if !r.isSystemRangeRLocked() && !RangefeedEnabled.Get(&r.store.cfg.Settings.SV) {
+	if !r.isSystemRange() && !RangefeedEnabled.Get(&r.store.cfg.Settings.SV) {
 		return roachpb.NewErrorf("rangefeeds require the kv.rangefeed.enabled setting. See %s",
 			base.DocsURL(`change-data-capture.html#enable-rangefeeds-to-reduce-latency`))
 	}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1947,7 +1947,7 @@ func (s *Store) recordNewPerSecondStats(newQPS, newWPS float64) {
 
 // VisitReplicas invokes the visitor on the Store's Replicas until the visitor returns false.
 // Replicas which are added to the Store after iteration begins may or may not be observed.
-func (s *Store) VisitReplicas(visitor func(*Replica) bool) {
+func (s *Store) VisitReplicas(visitor func(*Replica) (wantMore bool)) {
 	v := newStoreReplicaVisitor(s)
 	v.Visit(visitor)
 }

--- a/pkg/kv/kvserver/store_merge.go
+++ b/pkg/kv/kvserver/store_merge.go
@@ -43,25 +43,6 @@ func (s *Store) MergeRange(
 	leftRepl.raftMu.AssertHeld()
 	rightRepl.raftMu.AssertHeld()
 
-	// Shut down rangefeed processors on either side of the merge.
-	//
-	// It isn't strictly necessary to shut-down a rangefeed processor on the
-	// surviving replica in a merge, but we choose to in order to avoid clients
-	// who were monitoring both sides of the merge from establishing multiple
-	// partial rangefeeds to the surviving range.
-	// TODO(nvanbenschoten): does this make sense? We could just adjust the
-	// bounds of the leftRepl.Processor.
-	//
-	// NB: removeInitializedReplicaRaftMuLocked also disconnects any initialized
-	// rangefeeds with REASON_REPLICA_REMOVED. That's ok because we will have
-	// already disconnected the rangefeed here.
-	leftRepl.disconnectRangefeedWithReason(
-		roachpb.RangeFeedRetryError_REASON_RANGE_MERGED,
-	)
-	rightRepl.disconnectRangefeedWithReason(
-		roachpb.RangeFeedRetryError_REASON_RANGE_MERGED,
-	)
-
 	if err := rightRepl.postDestroyRaftMuLocked(ctx, rightRepl.GetMVCCStats()); err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -308,16 +308,6 @@ func (s *Store) SplitRange(
 	// clear them.
 	leftRepl.concMgr.OnRangeSplit()
 
-	// The rangefeed processor will no longer be provided logical ops for
-	// its entire range, so it needs to be shut down and all registrations
-	// need to retry.
-	// TODO(nvanbenschoten): It should be possible to only reject registrations
-	// that overlap with the new range of the split and keep registrations that
-	// are only interested in keys that are still on the original range running.
-	leftRepl.disconnectRangefeedWithReason(
-		roachpb.RangeFeedRetryError_REASON_RANGE_SPLIT,
-	)
-
 	// Clear the original range's request stats, since they include requests for
 	// spans that are now owned by the new range.
 	leftRepl.leaseholderStats.resetRequestCounts()


### PR DESCRIPTION
This commit changes where we disconnect rangefeeds in the face of a merge
trigger. Prior to this commit, we'd disconnect the rangefeed after applying
the merge to the engine and, importantly, after feeding the logical ops to
the rangefeed (which happens in pre-apply). Now we'll disconnect the rangefeed
from both sides prior to applying the command and prior to sending the logical
ops.

No release note is needed because the bug that this fixes couldn't be tickled
before the 20.2 release as it was not possible to create a rangefeed on the
system config span as a client and the system never did it.

Fixes #48770.

Release note: None