### PR TITLE
sql: add postgres enum builtins

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -506,6 +506,21 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr></tbody>
 </table>
 
+### Enum functions
+
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><a name="enum_first"></a><code>enum_first(val: anyenum) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns the first value of the input enum type.</p>
+</span></td></tr>
+<tr><td><a name="enum_last"></a><code>enum_last(val: anyenum) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns the last value of the input enum type.</p>
+</span></td></tr>
+<tr><td><a name="enum_range"></a><code>enum_range(lower: anyenum, upper: anyenum) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns all values of the input enum in an ordered array between the two arguments.</p>
+</span></td></tr>
+<tr><td><a name="enum_range"></a><code>enum_range(val: anyenum) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns all values of the input enum in an ordered array.</p>
+</span></td></tr></tbody>
+</table>
+
 ### FLOAT functions
 
 <table>

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -159,3 +159,43 @@ ALTER TYPE greeting RENAME TO greetings
 
 statement error pq: unimplemented: ALTER TYPE SET SCHEMA unsupported
 ALTER TYPE greeting SET SCHEMA newschema
+
+# Tests for enum builtins.
+statement ok
+CREATE TYPE dbs AS ENUM ('postgres', 'mysql', 'spanner', 'cockroach')
+
+query TT
+SELECT enum_first('mysql'::dbs), enum_last('spanner'::dbs)
+----
+postgres cockroach
+
+query T
+SELECT enum_range('cockroach'::dbs)
+----
+{postgres,mysql,spanner,cockroach}
+
+query TT
+SELECT enum_range(NULL, 'mysql'::dbs), enum_range('spanner'::dbs, NULL)
+----
+{postgres,mysql} {spanner,cockroach}
+
+query TT
+SELECT enum_range('postgres'::dbs, 'spanner'::dbs), enum_range('spanner'::dbs, 'cockroach'::dbs)
+----
+{postgres,mysql,spanner} {spanner,cockroach}
+
+query T
+SELECT enum_range('cockroach'::dbs, 'cockroach'::dbs)
+----
+{cockroach}
+
+query T
+SELECT enum_range('cockroach'::dbs, 'spanner'::dbs)
+----
+{}
+
+query error pq: enum_range\(\): both arguments cannot be NULL
+SELECT enum_range(NULL::dbs, NULL::dbs)
+
+query error pq: enum_range\(\): mismatched types
+SELECT enum_range('cockroach'::dbs, 'hello'::greeting)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -79,6 +79,7 @@ const (
 	categoryComparison    = "Comparison"
 	categoryCompatibility = "Compatibility"
 	categoryDateAndTime   = "Date and time"
+	categoryEnum          = "Enum"
 	categoryGenerator     = "Set-returning"
 	categoryGeospatial    = "Geospatial"
 	categoryIDGeneration  = "ID generation"
@@ -2843,6 +2844,125 @@ may increase either contention or retry errors, or both.`,
 	"json_array_length": makeBuiltin(jsonProps(), jsonArrayLengthImpl),
 
 	"jsonb_array_length": makeBuiltin(jsonProps(), jsonArrayLengthImpl),
+
+	// Enum functions.
+	"enum_first": makeBuiltin(
+		tree.FunctionProperties{NullableArgs: true, Category: categoryEnum},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"val", types.AnyEnum}},
+			ReturnType: tree.IdentityReturnType(0),
+			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if args[0] == tree.DNull {
+					return nil, pgerror.Newf(pgcode.NullValueNotAllowed, "argument cannot be NULL")
+				}
+				arg := args[0].(*tree.DEnum)
+				min, ok := arg.Min(evalCtx)
+				if !ok {
+					return nil, errors.Newf("enum %s contains no values", arg.ResolvedType().Name())
+				}
+				return min, nil
+			},
+			Info:       "Returns the first value of the input enum type.",
+			Volatility: tree.VolatilityStable,
+		},
+	),
+
+	"enum_last": makeBuiltin(
+		tree.FunctionProperties{NullableArgs: true, Category: categoryEnum},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"val", types.AnyEnum}},
+			ReturnType: tree.IdentityReturnType(0),
+			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if args[0] == tree.DNull {
+					return nil, pgerror.Newf(pgcode.NullValueNotAllowed, "argument cannot be NULL")
+				}
+				arg := args[0].(*tree.DEnum)
+				max, ok := arg.Max(evalCtx)
+				if !ok {
+					return nil, errors.Newf("enum %s contains no values", arg.ResolvedType().Name())
+				}
+				return max, nil
+			},
+			Info:       "Returns the last value of the input enum type.",
+			Volatility: tree.VolatilityStable,
+		},
+	),
+
+	"enum_range": makeBuiltin(
+		tree.FunctionProperties{NullableArgs: true, Category: categoryEnum},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"val", types.AnyEnum}},
+			ReturnType: tree.ArrayOfFirstNonNullReturnType(),
+			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if args[0] == tree.DNull {
+					return nil, pgerror.Newf(pgcode.NullValueNotAllowed, "argument cannot be NULL")
+				}
+				arg := args[0].(*tree.DEnum)
+				typ := arg.EnumTyp
+				arr := tree.NewDArray(typ)
+				for i := range typ.TypeMeta.EnumData.LogicalRepresentations {
+					enum := &tree.DEnum{
+						EnumTyp:     typ,
+						PhysicalRep: typ.TypeMeta.EnumData.PhysicalRepresentations[i],
+						LogicalRep:  typ.TypeMeta.EnumData.LogicalRepresentations[i],
+					}
+					if err := arr.Append(enum); err != nil {
+						return nil, err
+					}
+				}
+				return arr, nil
+			},
+			Info:       "Returns all values of the input enum in an ordered array.",
+			Volatility: tree.VolatilityStable,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"lower", types.AnyEnum}, {"upper", types.AnyEnum}},
+			ReturnType: tree.ArrayOfFirstNonNullReturnType(),
+			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if args[0] == tree.DNull && args[1] == tree.DNull {
+					return nil, pgerror.Newf(pgcode.NullValueNotAllowed, "both arguments cannot be NULL")
+				}
+				var bottom, top int
+				var typ *types.T
+				switch {
+				case args[0] == tree.DNull:
+					right := args[1].(*tree.DEnum)
+					typ = right.ResolvedType()
+					bottom, top = 0, typ.EnumGetIdxOfPhysical(right.PhysicalRep)
+				case args[1] == tree.DNull:
+					left := args[0].(*tree.DEnum)
+					typ = left.ResolvedType()
+					bottom, top = typ.EnumGetIdxOfPhysical(left.PhysicalRep), len(typ.TypeMeta.EnumData.PhysicalRepresentations)-1
+				default:
+					left, right := args[0].(*tree.DEnum), args[1].(*tree.DEnum)
+					if !left.ResolvedType().Equivalent(right.ResolvedType()) {
+						return nil, pgerror.Newf(
+							pgcode.DatatypeMismatch,
+							"mismatched types %s and %s",
+							left.ResolvedType(),
+							right.ResolvedType(),
+						)
+					}
+					typ = left.ResolvedType()
+					bottom, top = typ.EnumGetIdxOfPhysical(left.PhysicalRep), typ.EnumGetIdxOfPhysical(right.PhysicalRep)
+				}
+				arr := tree.NewDArray(typ)
+				for i := bottom; i <= top; i++ {
+					enum := &tree.DEnum{
+						EnumTyp:     typ,
+						PhysicalRep: typ.TypeMeta.EnumData.PhysicalRepresentations[i],
+						LogicalRep:  typ.TypeMeta.EnumData.LogicalRepresentations[i],
+					}
+					if err := arr.Append(enum); err != nil {
+						return nil, err
+					}
+				}
+				return arr, nil
+			},
+			Info:       "Returns all values of the input enum in an ordered array between the two arguments.",
+			Volatility: tree.VolatilityStable,
+		},
+	),
 
 	// Metadata functions.
 

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -364,6 +364,22 @@ func IdentityReturnType(idx int) ReturnTyper {
 	}
 }
 
+// ArrayOfFirstNonNullReturnType returns an array type from the first non-null
+// type in the argument list.
+func ArrayOfFirstNonNullReturnType() ReturnTyper {
+	return func(args []TypedExpr) *types.T {
+		if len(args) == 0 {
+			return UnknownReturnType
+		}
+		for _, arg := range args {
+			if t := arg.ResolvedType(); t.Family() != types.UnknownFamily {
+				return types.MakeArray(t)
+			}
+		}
+		return types.Unknown
+	}
+}
+
 // FirstNonNullReturnType returns the type of the first non-null argument, or
 // types.Unknown if all arguments are null. There must be at least one argument,
 // or else FirstNonNullReturnType returns UnknownReturnType. This method is used

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -1188,7 +1188,7 @@ func datumTypeToArrayElementEncodingType(t *types.T) (encoding.Type, error) {
 		return encoding.Geo, nil
 	case types.DecimalFamily:
 		return encoding.Decimal, nil
-	case types.BytesFamily, types.StringFamily, types.CollatedStringFamily:
+	case types.BytesFamily, types.StringFamily, types.CollatedStringFamily, types.EnumFamily:
 		return encoding.Bytes, nil
 	case types.TimestampFamily, types.TimestampTZFamily:
 		return encoding.Time, nil
@@ -1276,6 +1276,8 @@ func encodeArrayElement(b []byte, d tree.Datum) ([]byte, error) {
 		return encoding.EncodeUntaggedBytesValue(b, []byte(t.Contents)), nil
 	case *tree.DOidWrapper:
 		return encodeArrayElement(b, t.Wrapped)
+	case *tree.DEnum:
+		return encoding.EncodeUntaggedBytesValue(b, t.PhysicalRep), nil
 	default:
 		return nil, errors.Errorf("don't know how to encode %s (%T)", d, d)
 	}

--- a/pkg/sql/types/oid.go
+++ b/pkg/sql/types/oid.go
@@ -199,6 +199,11 @@ func calcArrayOid(elemTyp *T) oid.Oid {
 		// so return 0 for that case (since there's no T__unknown). This is what
 		// previous versions of CRDB returned for this case.
 		return unknownArrayOid
+
+	case EnumFamily:
+		// TODO (rohany): We don't automatically generate an array type for new
+		//  user defined types yet so there isn't an OID to point to yet.
+		return unknownArrayOid
 	}
 
 	// Map the OID of the array element type to the corresponding array OID.


### PR DESCRIPTION
This PR adds the enum related postgres builtin functions found here
(https://www.postgresql.org/docs/8.3/functions-enum.html). We are limited
slightly in that we cannot pass into this functions like postgres can,
since our nulls are untyped.

Fixes #48358.

Release note (sql change): Add the postgres supported enum builtins
enum_first, enum_last, and enum_range.