### PR TITLE
release-20.1: sql: fix bug where columns couldn't be dropped after a pk change

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1130,3 +1130,11 @@ SELECT index_id, index_name FROM crdb_internal.table_indexes WHERE descriptor_na
 6  i1
 7  i2
 8  i3
+
+# Regression for #49079.
+statement ok
+DROP TABLE t;
+CREATE TABLE t (x INT, y INT, z INT, PRIMARY KEY (x, y));
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (y);
+SET sql_safe_updates=false;
+ALTER TABLE t DROP COLUMN z

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -3076,6 +3076,9 @@ func (desc *MutableTableDescriptor) MakeMutationComplete(m DescriptorMutation) e
 			}
 			newIndex.Name = "primary"
 			desc.PrimaryIndex = *protoutil.Clone(newIndex).(*IndexDescriptor)
+			// The primary index "implicitly" stores all columns in the table.
+			// Explicitly including them in the stored columns list is incorrect.
+			desc.PrimaryIndex.StoreColumnNames, desc.PrimaryIndex.StoreColumnIDs = nil, nil
 			idx, err := getIndexIdxByID(newIndex.ID)
 			if err != nil {
 				return err


### PR DESCRIPTION
Backport 1/1 commits from #49081.

/cc @cockroachdb/release

---

Fixes #49079.

Release note (bug fix): Fix a bug where columns of a table could not
be dropped after a primary key change.
