### PR TITLE
storage/cloud: Open data stream early to ensure blob exists

### DIFF
--- a/pkg/storage/cloud/gcs_storage.go
+++ b/pkg/storage/cloud/gcs_storage.go
@@ -224,11 +224,15 @@ func (r *resumingGoogleStorageReader) Close() error {
 
 func (g *gcsStorage) ReadFile(ctx context.Context, basename string) (io.ReadCloser, error) {
 	// https://github.com/cockroachdb/cockroach/issues/23859
-	return &resumingGoogleStorageReader{
+	reader := &resumingGoogleStorageReader{
 		ctx:    ctx,
 		bucket: g.bucket,
 		object: path.Join(g.prefix, basename),
-	}, nil
+	}
+	if err := reader.openStream(); err != nil {
+		return nil, err
+	}
+	return reader, nil
 }
 
 func (g *gcsStorage) ListFiles(ctx context.Context, patternSuffix string) ([]string, error) {


### PR DESCRIPTION
Fixes #48427

Open google cloud storage stream before returning reader from ReadFile
method.  This is done in order to verify that the blob exists and to
return better errors to the caller.

Release notes (improvement): Improved error reporting when trying to access
non-existent google cloud storage blob.