### PR TITLE
 geo/geomfn: implement ST_MaxDistance / ST_DFullyWithin

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -750,6 +750,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 <p>This function utilizes the GEOS module.</p>
 <p>This function will automatically use any available index.</p>
 </span></td></tr>
+<tr><td><a name="st_dfullywithin"></a><code>st_dfullywithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if every pair of points comprising geometry_a and geometry_b are within distance units. In other words, the ST_MaxDistance between geometry_a and geometry_b is less than or equal to distance units.</p>
+</span></td></tr>
 <tr><td><a name="st_distance"></a><code>st_distance(geography_a: geography, geography_b: geography) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the distance in meters between geography_a and geography_b.  Uses a spheroid to perform the operation.&quot;\n\nWhen operating on a spheroid, this function will use the sphere to calculate the closest two points using S2. The spheroid distance between these two points is calculated using GeographicLib. This follows observed PostGIS behavior.</p>
 <p>This function utilizes the GeographicLib library for spheroid calculations.</p>
 <p>This function will automatically use any available index.</p>
@@ -864,6 +866,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 <tr><td><a name="st_linestringfromwkb"></a><code>st_linestringfromwkb(wkb: <a href="bytes.html">bytes</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKB representation with an SRID. If the shape underneath is not LineString, NULL is returned.</p>
 </span></td></tr>
 <tr><td><a name="st_makepoint"></a><code>st_makepoint(x: <a href="float.html">float</a>, y: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a new Point with the given X and Y coordinates.</p>
+</span></td></tr>
+<tr><td><a name="st_maxdistance"></a><code>st_maxdistance(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the maximum distance across every pair of points comprising the given geometries. Note if the geometries are the same, it will return the maximum distance between the geometry’s vertexes.</p>
 </span></td></tr>
 <tr><td><a name="st_mlinefromtext"></a><code>st_mlinefromtext(str: <a href="string.html">string</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation with an SRID. If the shape underneath is not MultiLineString, NULL is returned. If the SRID is present in both the EWKT and the argument, the argument value is used.</p>
 </span></td></tr>

--- a/pkg/geo/geodist/geodist.go
+++ b/pkg/geo/geodist/geodist.go
@@ -78,6 +78,8 @@ type DistanceUpdater interface {
 	OnIntersects() bool
 	// Distance returns the distance to return so far.
 	Distance() float64
+	// IsMaxDistance returns whether the updater is looking for maximum distance.
+	IsMaxDistance() bool
 }
 
 // EdgeCrosser is a provided hook that calculates whether edges intersect.
@@ -150,8 +152,9 @@ func ShapeDistance(c DistanceCalculator, a Shape, b Shape) (bool, error) {
 	return false, errors.Newf("unknown shape: %T", a)
 }
 
-// onPointToEdgesExceptFirstEdgeStart updates the distance using the edges between a point and a shape.
-// It will only check the ends of the edges, and assumes the check against .Edge(0).V0 is not required.
+// onPointToEdgesExceptFirstEdgeStart updates the distance against the edges of a shape and a point.
+// It will only check the V1 of each edge and assumes the first edge start does not need the distance
+// to be computed.
 func onPointToEdgesExceptFirstEdgeStart(c DistanceCalculator, a Point, b shapeWithEdges) bool {
 	for edgeIdx := 0; edgeIdx < b.NumEdges(); edgeIdx++ {
 		edge := b.Edge(edgeIdx)
@@ -159,11 +162,16 @@ func onPointToEdgesExceptFirstEdgeStart(c DistanceCalculator, a Point, b shapeWi
 		if c.DistanceUpdater().Update(a, edge.V1) {
 			return true
 		}
-		// Also project the point to the infinite line of the edge, and compare if the closestPoint
-		// lies on the edge.
-		if closestPoint, ok := c.ClosestPointToEdge(edge, a); ok {
-			if c.DistanceUpdater().Update(a, closestPoint) {
-				return true
+		// The max distance between a point and the set of points representing an edge is the
+		// maximum distance from the point and the pair of end-points of the edge, so we don't
+		// need to update the distance using the projected point.
+		if !c.DistanceUpdater().IsMaxDistance() {
+			// Also project the point to the infinite line of the edge, and compare if the closestPoint
+			// lies on the edge.
+			if closestPoint, ok := c.ClosestPointToEdge(edge, a); ok {
+				if c.DistanceUpdater().Update(a, closestPoint) {
+					return true
+				}
 			}
 		}
 	}
@@ -183,9 +191,20 @@ func onPointToLineString(c DistanceCalculator, a Point, b LineString) bool {
 // onPointToPolygon updates the distance between a point and a polygon.
 // Returns true if the calling function should early exit.
 func onPointToPolygon(c DistanceCalculator, a Point, b Polygon) bool {
-	// If the exterior ring does not contain the point, we just need to calculate the distance to
+	// MaxDistance: When computing the maximum distance, the cases are:
+	//   - The point P is not contained in the exterior of the polygon G.
+	//     Say vertex V is the vertex of the exterior of the polygon that is
+	//     furthest away from point P (among all the exterior vertices).
+	//   - One can prove that any vertex of the holes will be closer to point P than vertex V.
+	//     Similarly we can prove that any point in the interior of the polygin is closer to P than vertex V.
+	//     Therefore we only need to compare with the exterior.
+	//   - The point P is contained in the exterior and inside a hole of polygon G.
+	//     One can again prove that the furthest point in the polygon from P is one of the vertices of the exterior.
+	//   - The point P is contained in the polygon. One can again prove the same property.
+	//   So we only need to compare with the exterior ring.
+	// MinDistance: If the exterior ring does not contain the point, we just need to calculate the distance to
 	// the exterior ring.
-	if !c.PointInLinearRing(a, b.LinearRing(0)) {
+	if c.DistanceUpdater().IsMaxDistance() || !c.PointInLinearRing(a, b.LinearRing(0)) {
 		return onPointToEdgesExceptFirstEdgeStart(c, a, b.LinearRing(0))
 	}
 	// At this point it may be inside a hole.
@@ -210,9 +229,13 @@ func onShapeEdgesToShapeEdges(c DistanceCalculator, a shapeWithEdges, b shapeWit
 		crosser := c.NewEdgeCrosser(aEdge, b.Edge(0).V0)
 		for bEdgeIdx := 0; bEdgeIdx < b.NumEdges(); bEdgeIdx++ {
 			bEdge := b.Edge(bEdgeIdx)
-			// If the edges cross, the distance is 0.
-			if crosser.ChainCrossing(bEdge.V1) {
-				return c.DistanceUpdater().OnIntersects()
+			// Max distance between 2 edges is the maximum of the distance across pairs of vertices chosen from each edge.
+			// It does not matter whether the edges cross, so we skip this check.
+			if !c.DistanceUpdater().IsMaxDistance() {
+				// If the edges cross, the distance is 0.
+				if crosser.ChainCrossing(bEdge.V1) {
+					return c.DistanceUpdater().OnIntersects()
+				}
 			}
 
 			// Compare each vertex against the edge of the other.
@@ -230,10 +253,12 @@ func onShapeEdgesToShapeEdges(c DistanceCalculator, a shapeWithEdges, b shapeWit
 					c.DistanceUpdater().Update(toCheck.vertex, toCheck.edge.V1) {
 					return true
 				}
-				// Also check the projection of the vertex onto the edge.
-				if closestPoint, ok := c.ClosestPointToEdge(toCheck.edge, toCheck.vertex); ok {
-					if c.DistanceUpdater().Update(toCheck.vertex, closestPoint) {
-						return true
+				if !c.DistanceUpdater().IsMaxDistance() {
+					// Also check the projection of the vertex onto the edge.
+					if closestPoint, ok := c.ClosestPointToEdge(toCheck.edge, toCheck.vertex); ok {
+						if c.DistanceUpdater().Update(toCheck.vertex, closestPoint) {
+							return true
+						}
 					}
 				}
 			}
@@ -245,14 +270,17 @@ func onShapeEdgesToShapeEdges(c DistanceCalculator, a shapeWithEdges, b shapeWit
 // onLineStringToPolygon updates the distance between a polyline and a polygon.
 // Returns true if the calling function should early exit.
 func onLineStringToPolygon(c DistanceCalculator, a LineString, b Polygon) bool {
-	// If we know at least one point is outside the exterior ring, then there are two cases:
-	// * the line is always outside the exterior ring. We only need to compare the line
-	//   against the exterior ring.
-	// * the line intersects with the exterior ring.
-	// In both these cases, we can defer to the edge to edge comparison between the line
-	// and the exterior ring.
-	// We use the first point of the linestring for this check.
-	if !c.PointInLinearRing(a.Vertex(0), b.LinearRing(0)) {
+	// MinDistance: If we know at least one point is outside the exterior ring, then there are two cases:
+	//   * the line is always outside the exterior ring. We only need to compare the line
+	//     against the exterior ring.
+	//   * the line intersects with the exterior ring.
+	//   In both these cases, we can defer to the edge to edge comparison between the line
+	//   and the exterior ring.
+	//   We use the first point of the linestring for this check.
+	// MaxDistance: the furthest distance from a LineString to a Polygon is always against the
+	//   exterior ring. This follows the reasoning under "onPointToPolygon", but we must now
+	//   check each point in the LineString.
+	if c.DistanceUpdater().IsMaxDistance() || !c.PointInLinearRing(a.Vertex(0), b.LinearRing(0)) {
 		return onShapeEdgesToShapeEdges(c, a, b.LinearRing(0))
 	}
 
@@ -291,6 +319,7 @@ func onPolygonToPolygon(c DistanceCalculator, a Polygon, b Polygon) bool {
 	aFirstPoint := a.LinearRing(0).Vertex(0)
 	bFirstPoint := b.LinearRing(0).Vertex(0)
 
+	// MinDistance:
 	// If there is at least one point on the the exterior ring of B that is outside the exterior ring
 	// of A, then we have one of these two cases:
 	// * The exterior rings of A and B intersect. The distance can always be found by comparing
@@ -304,7 +333,14 @@ func onPolygonToPolygon(c DistanceCalculator, a Polygon, b Polygon) bool {
 	// that is outside the exterior ring of B.
 	//
 	// As such, we only need to compare the exterior rings if we detect this.
-	if !c.PointInLinearRing(bFirstPoint, a.LinearRing(0)) && !c.PointInLinearRing(aFirstPoint, b.LinearRing(0)) {
+	//
+	// MaxDistance:
+	// The furthest distance between two polygons is always against the exterior rings of each other.
+	// This closely follows the reasoning pointed out in "onPointToPolygon". Holes are always located
+	// inside the exterior ring of a polygon, so the exterior ring will always contain a point
+	// with a larger max distance.
+	if c.DistanceUpdater().IsMaxDistance() ||
+		(!c.PointInLinearRing(bFirstPoint, a.LinearRing(0)) && !c.PointInLinearRing(aFirstPoint, b.LinearRing(0))) {
 		return onShapeEdgesToShapeEdges(c, a.LinearRing(0), b.LinearRing(0))
 	}
 

--- a/pkg/geo/geogfn/distance.go
+++ b/pkg/geo/geogfn/distance.go
@@ -276,6 +276,11 @@ func (u *spheroidMinDistanceUpdater) OnIntersects() bool {
 	return true
 }
 
+// IsMaxDistance implements the geodist.DistanceUpdater interface.
+func (u *spheroidMinDistanceUpdater) IsMaxDistance() bool {
+	return false
+}
+
 // spheroidDistanceCalculator implements geodist.DistanceCalculator
 type spheroidDistanceCalculator struct {
 	updater *spheroidMinDistanceUpdater

--- a/pkg/geo/geomfn/distance.go
+++ b/pkg/geo/geomfn/distance.go
@@ -28,6 +28,15 @@ func MinDistance(a *geo.Geometry, b *geo.Geometry) (float64, error) {
 	return minDistanceInternal(a, b, 0)
 }
 
+// MaxDistance returns the maximum distance across every pair of points comprising
+// geometries A and B.
+func MaxDistance(a *geo.Geometry, b *geo.Geometry) (float64, error) {
+	if a.SRID() != b.SRID() {
+		return 0, geo.NewMismatchingSRIDsError(a, b)
+	}
+	return maxDistanceInternal(a, b, math.MaxFloat64)
+}
+
 // DWithin determines if any part of geometry A is within D units of geometry B.
 func DWithin(a *geo.Geometry, b *geo.Geometry, d float64) (bool, error) {
 	if a.SRID() != b.SRID() {
@@ -41,6 +50,31 @@ func DWithin(a *geo.Geometry, b *geo.Geometry, d float64) (bool, error) {
 		return false, err
 	}
 	return dist <= d, nil
+}
+
+// DFullyWithin determines whether the maximum distance across every pair of points
+// comprising geometries A and B is within D units.
+func DFullyWithin(a *geo.Geometry, b *geo.Geometry, d float64) (bool, error) {
+	if a.SRID() != b.SRID() {
+		return false, geo.NewMismatchingSRIDsError(a, b)
+	}
+	if d < 0 {
+		return false, errors.Newf("dwithin distance cannot be less than zero")
+	}
+	dist, err := maxDistanceInternal(a, b, d)
+	if err != nil {
+		return false, err
+	}
+	return dist <= d, nil
+}
+
+// maxDistanceInternal finds the maximum distance between two geometries.
+// We can re-use the same algorithm as min-distance, allowing skips of checks that involve
+// the interiors or intersections as those will always be less then the maximum min-distance.
+func maxDistanceInternal(a *geo.Geometry, b *geo.Geometry, stopAfterGT float64) (float64, error) {
+	u := newGeomMaxDistanceUpdater(stopAfterGT)
+	c := &geomDistanceCalculator{updater: u}
+	return distanceInternal(a, b, c)
 }
 
 // minDistanceInternal finds the minimum distance between two geometries.
@@ -273,9 +307,60 @@ func (u *geomMinDistanceUpdater) OnIntersects() bool {
 	return true
 }
 
+// IsMaxDistance implements the geodist.DistanceUpdater interface.
+func (u *geomMinDistanceUpdater) IsMaxDistance() bool {
+	return false
+}
+
+// geomMaxDistanceUpdater finds the maximum distance using geom calculations.
+// Methods will return early if it finds a distance > stopAfterGT.
+type geomMaxDistanceUpdater struct {
+	currentValue float64
+	stopAfterGT  float64
+}
+
+var _ geodist.DistanceUpdater = (*geomMaxDistanceUpdater)(nil)
+
+// newGeomMaxDistanceUpdater returns a new geomMaxDistanceUpdater with the
+// correct arguments set up.
+func newGeomMaxDistanceUpdater(stopAfterGT float64) *geomMaxDistanceUpdater {
+	return &geomMaxDistanceUpdater{
+		currentValue: 0,
+		stopAfterGT:  stopAfterGT,
+	}
+}
+
+// Distance implements the DistanceUpdater interface.
+func (u *geomMaxDistanceUpdater) Distance() float64 {
+	return u.currentValue
+}
+
+// Update implements the geodist.DistanceUpdater interface.
+func (u *geomMaxDistanceUpdater) Update(aInterface geodist.Point, bInterface geodist.Point) bool {
+	a := aInterface.(*geomGeodistPoint).Coord
+	b := bInterface.(*geomGeodistPoint).Coord
+
+	dist := coordNorm(coordSub(a, b))
+	if dist > u.currentValue {
+		u.currentValue = dist
+		return dist > u.stopAfterGT
+	}
+	return false
+}
+
+// OnIntersects implements the geodist.DistanceUpdater interface.
+func (u *geomMaxDistanceUpdater) OnIntersects() bool {
+	return false
+}
+
+// IsMaxDistance implements the geodist.DistanceUpdater interface.
+func (u *geomMaxDistanceUpdater) IsMaxDistance() bool {
+	return true
+}
+
 // geomDistanceCalculator implements geodist.DistanceCalculator
 type geomDistanceCalculator struct {
-	updater *geomMinDistanceUpdater
+	updater geodist.DistanceUpdater
 }
 
 var _ geodist.DistanceCalculator = (*geomDistanceCalculator)(nil)

--- a/pkg/geo/geomfn/distance_test.go
+++ b/pkg/geo/geomfn/distance_test.go
@@ -25,11 +25,13 @@ var distanceTestCases = []struct {
 	a                   string
 	b                   string
 	expectedMinDistance float64
+	expectedMaxDistance float64
 }{
 	{
 		"Same POINTs",
 		"POINT(1.0 1.0)",
 		"POINT(1.0 1.0)",
+		0,
 		0,
 	},
 	{
@@ -37,138 +39,161 @@ var distanceTestCases = []struct {
 		"POINT(1.0 1.0)",
 		"POINT(2.0 1.0)",
 		1,
+		1,
 	},
 	{
 		"POINT on LINESTRING",
 		"POINT(0.5 0.5)",
 		"LINESTRING(0.0 0.0, 1.0 1.0, 2.0 2.0)",
 		0,
+		2.1213203435596424,
 	},
 	{
 		"POINT away from LINESTRING",
 		"POINT(3.0 3.0)",
 		"LINESTRING(0.0 0.0, 1.0 1.0, 2.0 2.0)",
 		1.4142135623730951,
+		4.242640687119285,
 	},
 	{
 		"Same LINESTRING",
 		"LINESTRING(0.0 0.0, 1.0 1.0, 2.0 2.0)",
 		"LINESTRING(0.0 0.0, 1.0 1.0, 2.0 2.0)",
 		0,
+		2.8284271247461903,
 	},
 	{
 		"Intersecting LINESTRING",
 		"LINESTRING(0.0 0.0, 1.0 1.0, 2.0 2.0)",
 		"LINESTRING(0.5 0.0, 0.5 3.0)",
 		0,
+		3.0413812651491097,
 	},
 	{
 		"LINESTRING does not meet",
 		"LINESTRING(6.0 6.0, 7.0 7.0, 8.0 8.0)",
 		"LINESTRING(0.0 0.0, 3.0 -3.0)",
 		8.48528137423857,
+		12.083045973594572,
 	},
 	{
 		"POINT in POLYGON",
 		"POINT(0.5 0.5)",
 		"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
 		0,
+		0.7071067811865476,
 	},
 	{
 		"POINT in POLYGON hole",
 		"POINT(0.5 0.5)",
 		"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0), (0.2 0.2, 0.6 0.2, 0.6 0.6, 0.2 0.6, 0.2 0.2))",
 		0.09999999999999998,
+		0.7071067811865476,
 	},
 	{
 		"POINT not in POLYGON hole",
 		"POINT(0.1 0.1)",
 		"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0), (0.2 0.2, 0.6 0.2, 0.6 0.6, 0.2 0.6, 0.2 0.2))",
 		0,
+		1.2727922061357855,
 	},
 	{
 		"POINT outside of POLYGON",
 		"POINT(1.5 1.5)",
 		"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
 		0.7071067811865476,
+		2.1213203435596424,
 	},
 	{
 		"LINESTRING intersects POLYGON",
 		"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
 		"LINESTRING(-0.5 -0.5, 0.5 0.5)",
 		0,
+		2.1213203435596424,
 	},
 	{
 		"LINESTRING outside of POLYGON",
 		"LINESTRING(-0.5 -0.5, -0.5 0.5)",
 		"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
 		0.5,
+		2.1213203435596424,
 	},
 	{
 		"POLYGON is the same",
 		"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
 		"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
 		0,
+		1.4142135623730951,
 	},
 	{
 		"POLYGON inside POLYGON",
 		"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
 		"POLYGON((0.1 0.1, 0.9 0.1, 0.9 0.9, 0.1 0.9, 0.1 0.1))",
 		0,
+		1.2727922061357855,
 	},
 	{
 		"POLYGON to POLYGON intersecting through its hole",
 		"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0), (0.2 0.2, 0.2 0.4, 0.4 0.4, 0.4 0.2, 0.2 0.2))",
 		"POLYGON((0.15 0.25, 0.35 0.25, 0.35 0.35, 0.25 0.35, 0.15 0.25))",
 		0,
+		1.1335784048754634,
 	},
 	{
 		"POLYGON inside POLYGON hole",
 		"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0), (0.1 0.1, 0.9 0.1, 0.9 0.9, 0.1 0.9, 0.1 0.1))",
 		"POLYGON((0.2 0.2, 0.8 0.2, 0.8 0.8, 0.2 0.8, 0.2 0.2))",
 		0.09999999999999998,
+		1.1313708498984762,
 	},
 	{
 		"POLYGON outside POLYGON",
 		"POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))",
 		"POLYGON((3.0 3.0, 4.0 3.0, 4.0 4.0, 3.0 4.0, 3.0 3.0))",
 		2.8284271247461903,
+		5.656854249492381,
 	},
 	{
 		"MULTIPOINT to MULTIPOINT",
 		"MULTIPOINT((1.0 1.0), (2.0 2.0))",
 		"MULTIPOINT((2.5 2.5), (3.0 3.0))",
 		0.7071067811865476,
+		2.8284271247461903,
 	},
 	{
 		"MULTIPOINT to MULTILINESTRING",
 		"MULTILINESTRING((1.0 1.0, 1.1 1.1), (2.0 2.0, 2.1 2.1))",
 		"MULTIPOINT(2.0 2.0, 1.0 1.0, 3.0 3.0)",
 		0,
+		2.8284271247461903,
 	},
 	{
 		"MULTIPOINT to MULTIPOLYGON",
 		"MULTIPOINT ((2.0 3.0), (10 42))",
 		"MULTIPOLYGON (((15 5, 40 10, 10 20, 5 10, 15 5)),((30 20, 45 40, 10 40, 30 20)))",
 		2,
+		56.72741841473134,
 	},
 	{
 		"MULTILINESTRING to MULTILINESTRING",
 		"MULTILINESTRING((1.0 1.0, 1.1 1.1), (2.0 2.0, 2.1 2.1), (3.0 3.0, 3.1 3.1))",
 		"MULTILINESTRING((2.0 2.0, 2.1 2.1), (4.0 3.0, 3.1 3.1))",
 		0,
+		3.605551275463989,
 	},
 	{
 		"MULTILINESTRING to MULTIPOLYGON",
 		"MULTIPOLYGON (((15 5, 40 10, 10 20, 5 10, 15 5)),((30 20, 45 40, 10 40, 30 20)))",
 		"MULTILINESTRING((3 3, -4 -4), (45 41, 48 48, 52 52))",
 		1,
+		65.85590330410783,
 	},
 	{
 		"MULTIPOLYGON to MULTIPOLYGON",
 		"MULTIPOLYGON (((15 5, 40 10, 10 20, 5 10, 15 5)),((30 20, 45 40, 10 40, 30 20)))",
 		"MULTIPOLYGON (((30 20, 45 40, 15 45, 30 20)))",
 		0,
+		50,
 	},
 }
 
@@ -200,6 +225,31 @@ func TestMinDistance(t *testing.T) {
 				tc.expectedMinDistance,
 				ret,
 			)
+		})
+	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := MinDistance(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
+}
+
+func TestMaxDistance(t *testing.T) {
+	for _, tc := range distanceTestCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			a, err := geo.ParseGeometry(tc.a)
+			require.NoError(t, err)
+			b, err := geo.ParseGeometry(tc.b)
+			require.NoError(t, err)
+
+			// Try in both directions.
+			ret, err := MaxDistance(a, b)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedMaxDistance, ret)
+
+			ret, err = MaxDistance(b, a)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedMaxDistance, ret)
 		})
 	}
 
@@ -246,6 +296,62 @@ func TestDWithin(t *testing.T) {
 						require.False(t, dwithin)
 
 						dwithin, err = DWithin(a, b, val)
+						require.NoError(t, err)
+						require.False(t, dwithin)
+					})
+				}
+			}
+		})
+	}
+
+	t.Run("errors if SRIDs mismatch", func(t *testing.T) {
+		_, err := MinDistance(mismatchingSRIDGeometryA, mismatchingSRIDGeometryB)
+		requireMismatchingSRIDError(t, err)
+	})
+
+	t.Run("errors if distance < 0", func(t *testing.T) {
+		_, err := DWithin(geo.MustParseGeometry("POINT(1.0 2.0)"), geo.MustParseGeometry("POINT(3.0 4.0)"), -0.01)
+		require.Error(t, err)
+	})
+}
+
+func TestDFullyWithin(t *testing.T) {
+	for _, tc := range distanceTestCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			a, err := geo.ParseGeometry(tc.a)
+			require.NoError(t, err)
+			b, err := geo.ParseGeometry(tc.b)
+			require.NoError(t, err)
+
+			for _, val := range []float64{
+				tc.expectedMaxDistance,
+				tc.expectedMaxDistance + 0.1,
+				tc.expectedMaxDistance + 1,
+				tc.expectedMaxDistance * 2,
+			} {
+				t.Run(fmt.Sprintf("dfullywithin:%f", val), func(t *testing.T) {
+					dwithax, err := DFullyWithin(a, b, val)
+					require.NoError(t, err)
+					require.True(t, dwithax)
+
+					dwithax, err = DFullyWithin(a, b, val)
+					require.NoError(t, err)
+					require.True(t, dwithax)
+				})
+			}
+
+			for _, val := range []float64{
+				tc.expectedMaxDistance - 0.1,
+				tc.expectedMaxDistance - 1,
+				tc.expectedMaxDistance / 2,
+			} {
+				if val > 0 {
+					t.Run(fmt.Sprintf("dfullywithin:%f", val), func(t *testing.T) {
+						dwithin, err := DFullyWithin(a, b, val)
+						require.NoError(t, err)
+						require.False(t, dwithin)
+
+						dwithin, err = DFullyWithin(a, b, val)
 						require.NoError(t, err)
 						require.False(t, dwithin)
 					})

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -243,79 +243,80 @@ Square (right)                            1     0     4
 Square overlapping left and right square  1.1   0     4.2
 
 # Binary operators
-query TTR
+query TTRR
 SELECT
   a.dsc,
   b.dsc,
-  ST_Distance(a.geom, b.geom)
+  ST_Distance(a.geom, b.geom),
+  ST_MaxDistance(a.geom, b.geom)
 FROM geom_operators_test a
 JOIN geom_operators_test b ON (1=1)
 ORDER BY a.dsc, b.dsc
 ----
-Faraway point                             Faraway point                             0
-Faraway point                             Line going through left and right square  6.36396103067893
-Faraway point                             NULL                                      NULL
-Faraway point                             Point middle of Left Square               7.10633520177595
-Faraway point                             Point middle of Right Square              6.36396103067893
-Faraway point                             Square (left)                             6.40312423743285
-Faraway point                             Square (right)                            5.65685424949238
-Faraway point                             Square overlapping left and right square  5.65685424949238
-Line going through left and right square  Faraway point                             6.36396103067893
-Line going through left and right square  Line going through left and right square  0
-Line going through left and right square  NULL                                      NULL
-Line going through left and right square  Point middle of Left Square               0
-Line going through left and right square  Point middle of Right Square              0
-Line going through left and right square  Square (left)                             0
-Line going through left and right square  Square (right)                            0
-Line going through left and right square  Square overlapping left and right square  0
-NULL                                      Faraway point                             NULL
-NULL                                      Line going through left and right square  NULL
-NULL                                      NULL                                      NULL
-NULL                                      Point middle of Left Square               NULL
-NULL                                      Point middle of Right Square              NULL
-NULL                                      Square (left)                             NULL
-NULL                                      Square (right)                            NULL
-NULL                                      Square overlapping left and right square  NULL
-Point middle of Left Square               Faraway point                             7.10633520177595
-Point middle of Left Square               Line going through left and right square  0
-Point middle of Left Square               NULL                                      NULL
-Point middle of Left Square               Point middle of Left Square               0
-Point middle of Left Square               Point middle of Right Square              1
-Point middle of Left Square               Square (left)                             0
-Point middle of Left Square               Square (right)                            0.5
-Point middle of Left Square               Square overlapping left and right square  0.4
-Point middle of Right Square              Faraway point                             6.36396103067893
-Point middle of Right Square              Line going through left and right square  0
-Point middle of Right Square              NULL                                      NULL
-Point middle of Right Square              Point middle of Left Square               1
-Point middle of Right Square              Point middle of Right Square              0
-Point middle of Right Square              Square (left)                             0.5
-Point middle of Right Square              Square (right)                            0
-Point middle of Right Square              Square overlapping left and right square  0
-Square (left)                             Faraway point                             6.40312423743285
-Square (left)                             Line going through left and right square  0
-Square (left)                             NULL                                      NULL
-Square (left)                             Point middle of Left Square               0
-Square (left)                             Point middle of Right Square              0.5
-Square (left)                             Square (left)                             0
-Square (left)                             Square (right)                            0
-Square (left)                             Square overlapping left and right square  0
-Square (right)                            Faraway point                             5.65685424949238
-Square (right)                            Line going through left and right square  0
-Square (right)                            NULL                                      NULL
-Square (right)                            Point middle of Left Square               0.5
-Square (right)                            Point middle of Right Square              0
-Square (right)                            Square (left)                             0
-Square (right)                            Square (right)                            0
-Square (right)                            Square overlapping left and right square  0
-Square overlapping left and right square  Faraway point                             5.65685424949238
-Square overlapping left and right square  Line going through left and right square  0
-Square overlapping left and right square  NULL                                      NULL
-Square overlapping left and right square  Point middle of Left Square               0.4
-Square overlapping left and right square  Point middle of Right Square              0
-Square overlapping left and right square  Square (left)                             0
-Square overlapping left and right square  Square (right)                            0
-Square overlapping left and right square  Square overlapping left and right square  0
+Faraway point                             Faraway point                             0                 0
+Faraway point                             Line going through left and right square  6.36396103067893  7.10633520177595
+Faraway point                             NULL                                      NULL              NULL
+Faraway point                             Point middle of Left Square               7.10633520177595  7.10633520177595
+Faraway point                             Point middle of Right Square              6.36396103067893  6.36396103067893
+Faraway point                             Square (left)                             6.40312423743285  7.81024967590665
+Faraway point                             Square (right)                            5.65685424949238  7.07106781186548
+Faraway point                             Square overlapping left and right square  5.65685424949238  7.14212853426764
+Line going through left and right square  Faraway point                             6.36396103067893  7.10633520177595
+Line going through left and right square  Line going through left and right square  0                 1
+Line going through left and right square  NULL                                      NULL              NULL
+Line going through left and right square  Point middle of Left Square               0                 1
+Line going through left and right square  Point middle of Right Square              0                 1
+Line going through left and right square  Square (left)                             0                 1.58113883008419
+Line going through left and right square  Square (right)                            0                 1.58113883008419
+Line going through left and right square  Square overlapping left and right square  0                 1.58113883008419
+NULL                                      Faraway point                             NULL              NULL
+NULL                                      Line going through left and right square  NULL              NULL
+NULL                                      NULL                                      NULL              NULL
+NULL                                      Point middle of Left Square               NULL              NULL
+NULL                                      Point middle of Right Square              NULL              NULL
+NULL                                      Square (left)                             NULL              NULL
+NULL                                      Square (right)                            NULL              NULL
+NULL                                      Square overlapping left and right square  NULL              NULL
+Point middle of Left Square               Faraway point                             7.10633520177595  7.10633520177595
+Point middle of Left Square               Line going through left and right square  0                 1
+Point middle of Left Square               NULL                                      NULL              NULL
+Point middle of Left Square               Point middle of Left Square               0                 0
+Point middle of Left Square               Point middle of Right Square              1                 1
+Point middle of Left Square               Square (left)                             0                 0.707106781186548
+Point middle of Left Square               Square (right)                            0.5               1.58113883008419
+Point middle of Left Square               Square overlapping left and right square  0.4               1.58113883008419
+Point middle of Right Square              Faraway point                             6.36396103067893  6.36396103067893
+Point middle of Right Square              Line going through left and right square  0                 1
+Point middle of Right Square              NULL                                      NULL              NULL
+Point middle of Right Square              Point middle of Left Square               1                 1
+Point middle of Right Square              Point middle of Right Square              0                 0
+Point middle of Right Square              Square (left)                             0.5               1.58113883008419
+Point middle of Right Square              Square (right)                            0                 0.707106781186548
+Point middle of Right Square              Square overlapping left and right square  0                 0.781024967590665
+Square (left)                             Faraway point                             6.40312423743285  7.81024967590665
+Square (left)                             Line going through left and right square  0                 1.58113883008419
+Square (left)                             NULL                                      NULL              NULL
+Square (left)                             Point middle of Left Square               0                 0.707106781186548
+Square (left)                             Point middle of Right Square              0.5               1.58113883008419
+Square (left)                             Square (left)                             0                 1.4142135623731
+Square (left)                             Square (right)                            0                 2.23606797749979
+Square (left)                             Square overlapping left and right square  0                 2.23606797749979
+Square (right)                            Faraway point                             5.65685424949238  7.07106781186548
+Square (right)                            Line going through left and right square  0                 1.58113883008419
+Square (right)                            NULL                                      NULL              NULL
+Square (right)                            Point middle of Left Square               0.5               1.58113883008419
+Square (right)                            Point middle of Right Square              0                 0.707106781186548
+Square (right)                            Square (left)                             0                 2.23606797749979
+Square (right)                            Square (right)                            0                 1.4142135623731
+Square (right)                            Square overlapping left and right square  0                 1.48660687473185
+Square overlapping left and right square  Faraway point                             5.65685424949238  7.14212853426764
+Square overlapping left and right square  Line going through left and right square  0                 1.58113883008419
+Square overlapping left and right square  NULL                                      NULL              NULL
+Square overlapping left and right square  Point middle of Left Square               0.4               1.58113883008419
+Square overlapping left and right square  Point middle of Right Square              0                 0.781024967590665
+Square overlapping left and right square  Square (left)                             0                 2.23606797749979
+Square overlapping left and right square  Square (right)                            0                 1.48660687473185
+Square overlapping left and right square  Square overlapping left and right square  0                 1.48660687473185
 
 # Binary predicates
 query TTBBBBBBBBBB
@@ -402,79 +403,80 @@ Square overlapping left and right square  Square (right)                        
 Square overlapping left and right square  Square overlapping left and right square  true   true   true   false  false  true   true   false  false  true
 
 # DWithin
-query TTB
+query TTBB
 SELECT
   a.dsc,
   b.dsc,
-  ST_DWithin(a.geom, b.geom, 1)
+  ST_DWithin(a.geom, b.geom, 1),
+  ST_DFullyWithin(a.geom, b.geom, 1)
 FROM geom_operators_test a
 JOIN geom_operators_test b ON (1=1)
 ORDER BY a.dsc, b.dsc
 ----
-Faraway point                             Faraway point                             true
-Faraway point                             Line going through left and right square  false
-Faraway point                             NULL                                      NULL
-Faraway point                             Point middle of Left Square               false
-Faraway point                             Point middle of Right Square              false
-Faraway point                             Square (left)                             false
-Faraway point                             Square (right)                            false
-Faraway point                             Square overlapping left and right square  false
-Line going through left and right square  Faraway point                             false
-Line going through left and right square  Line going through left and right square  true
-Line going through left and right square  NULL                                      NULL
-Line going through left and right square  Point middle of Left Square               true
-Line going through left and right square  Point middle of Right Square              true
-Line going through left and right square  Square (left)                             true
-Line going through left and right square  Square (right)                            true
-Line going through left and right square  Square overlapping left and right square  true
-NULL                                      Faraway point                             NULL
-NULL                                      Line going through left and right square  NULL
-NULL                                      NULL                                      NULL
-NULL                                      Point middle of Left Square               NULL
-NULL                                      Point middle of Right Square              NULL
-NULL                                      Square (left)                             NULL
-NULL                                      Square (right)                            NULL
-NULL                                      Square overlapping left and right square  NULL
-Point middle of Left Square               Faraway point                             false
-Point middle of Left Square               Line going through left and right square  true
-Point middle of Left Square               NULL                                      NULL
-Point middle of Left Square               Point middle of Left Square               true
-Point middle of Left Square               Point middle of Right Square              true
-Point middle of Left Square               Square (left)                             true
-Point middle of Left Square               Square (right)                            true
-Point middle of Left Square               Square overlapping left and right square  true
-Point middle of Right Square              Faraway point                             false
-Point middle of Right Square              Line going through left and right square  true
-Point middle of Right Square              NULL                                      NULL
-Point middle of Right Square              Point middle of Left Square               true
-Point middle of Right Square              Point middle of Right Square              true
-Point middle of Right Square              Square (left)                             true
-Point middle of Right Square              Square (right)                            true
-Point middle of Right Square              Square overlapping left and right square  true
-Square (left)                             Faraway point                             false
-Square (left)                             Line going through left and right square  true
-Square (left)                             NULL                                      NULL
-Square (left)                             Point middle of Left Square               true
-Square (left)                             Point middle of Right Square              true
-Square (left)                             Square (left)                             true
-Square (left)                             Square (right)                            true
-Square (left)                             Square overlapping left and right square  true
-Square (right)                            Faraway point                             false
-Square (right)                            Line going through left and right square  true
-Square (right)                            NULL                                      NULL
-Square (right)                            Point middle of Left Square               true
-Square (right)                            Point middle of Right Square              true
-Square (right)                            Square (left)                             true
-Square (right)                            Square (right)                            true
-Square (right)                            Square overlapping left and right square  true
-Square overlapping left and right square  Faraway point                             false
-Square overlapping left and right square  Line going through left and right square  true
-Square overlapping left and right square  NULL                                      NULL
-Square overlapping left and right square  Point middle of Left Square               true
-Square overlapping left and right square  Point middle of Right Square              true
-Square overlapping left and right square  Square (left)                             true
-Square overlapping left and right square  Square (right)                            true
-Square overlapping left and right square  Square overlapping left and right square  true
+Faraway point                             Faraway point                             true   true
+Faraway point                             Line going through left and right square  false  false
+Faraway point                             NULL                                      NULL   NULL
+Faraway point                             Point middle of Left Square               false  false
+Faraway point                             Point middle of Right Square              false  false
+Faraway point                             Square (left)                             false  false
+Faraway point                             Square (right)                            false  false
+Faraway point                             Square overlapping left and right square  false  false
+Line going through left and right square  Faraway point                             false  false
+Line going through left and right square  Line going through left and right square  true   true
+Line going through left and right square  NULL                                      NULL   NULL
+Line going through left and right square  Point middle of Left Square               true   true
+Line going through left and right square  Point middle of Right Square              true   true
+Line going through left and right square  Square (left)                             true   false
+Line going through left and right square  Square (right)                            true   false
+Line going through left and right square  Square overlapping left and right square  true   false
+NULL                                      Faraway point                             NULL   NULL
+NULL                                      Line going through left and right square  NULL   NULL
+NULL                                      NULL                                      NULL   NULL
+NULL                                      Point middle of Left Square               NULL   NULL
+NULL                                      Point middle of Right Square              NULL   NULL
+NULL                                      Square (left)                             NULL   NULL
+NULL                                      Square (right)                            NULL   NULL
+NULL                                      Square overlapping left and right square  NULL   NULL
+Point middle of Left Square               Faraway point                             false  false
+Point middle of Left Square               Line going through left and right square  true   true
+Point middle of Left Square               NULL                                      NULL   NULL
+Point middle of Left Square               Point middle of Left Square               true   true
+Point middle of Left Square               Point middle of Right Square              true   true
+Point middle of Left Square               Square (left)                             true   true
+Point middle of Left Square               Square (right)                            true   false
+Point middle of Left Square               Square overlapping left and right square  true   false
+Point middle of Right Square              Faraway point                             false  false
+Point middle of Right Square              Line going through left and right square  true   true
+Point middle of Right Square              NULL                                      NULL   NULL
+Point middle of Right Square              Point middle of Left Square               true   true
+Point middle of Right Square              Point middle of Right Square              true   true
+Point middle of Right Square              Square (left)                             true   false
+Point middle of Right Square              Square (right)                            true   true
+Point middle of Right Square              Square overlapping left and right square  true   true
+Square (left)                             Faraway point                             false  false
+Square (left)                             Line going through left and right square  true   false
+Square (left)                             NULL                                      NULL   NULL
+Square (left)                             Point middle of Left Square               true   true
+Square (left)                             Point middle of Right Square              true   false
+Square (left)                             Square (left)                             true   false
+Square (left)                             Square (right)                            true   false
+Square (left)                             Square overlapping left and right square  true   false
+Square (right)                            Faraway point                             false  false
+Square (right)                            Line going through left and right square  true   false
+Square (right)                            NULL                                      NULL   NULL
+Square (right)                            Point middle of Left Square               true   false
+Square (right)                            Point middle of Right Square              true   true
+Square (right)                            Square (left)                             true   false
+Square (right)                            Square (right)                            true   false
+Square (right)                            Square overlapping left and right square  true   false
+Square overlapping left and right square  Faraway point                             false  false
+Square overlapping left and right square  Line going through left and right square  true   false
+Square overlapping left and right square  NULL                                      NULL   NULL
+Square overlapping left and right square  Point middle of Left Square               true   false
+Square overlapping left and right square  Point middle of Right Square              true   true
+Square overlapping left and right square  Square (left)                             true   false
+Square overlapping left and right square  Square (right)                            true   false
+Square overlapping left and right square  Square overlapping left and right square  true   false
 
 # DE-9IM relations
 query TTTB

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -855,6 +855,24 @@ Note ST_Perimeter is only valid for Polygon - use ST_Length for LineString.`,
 			Volatility: tree.VolatilityImmutable,
 		},
 	),
+	"st_maxdistance": makeBuiltin(
+		defProps(),
+		geometryOverload2(
+			func(ctx *tree.EvalContext, a, b *tree.DGeometry) (tree.Datum, error) {
+				ret, err := geomfn.MaxDistance(a.Geometry, b.Geometry)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDFloat(tree.DFloat(ret)), nil
+			},
+			types.Float,
+			infoBuilder{
+				info: `Returns the maximum distance across every pair of points comprising the given geometries. ` +
+					`Note if the geometries are the same, it will return the maximum distance between the geometry's vertexes.`,
+			},
+			tree.VolatilityImmutable,
+		),
+	),
 
 	//
 	// Binary Predicates
@@ -932,6 +950,32 @@ Note ST_Perimeter is only valid for Polygon - use ST_Length for LineString.`,
 				canUseIndex:  true,
 			},
 		),
+	),
+	"st_dfullywithin": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry_a", types.Geometry},
+				{"geometry_b", types.Geometry},
+				{"distance", types.Float},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				a := args[0].(*tree.DGeometry)
+				b := args[1].(*tree.DGeometry)
+				dist := args[2].(*tree.DFloat)
+				ret, err := geomfn.DFullyWithin(a.Geometry, b.Geometry, float64(*dist))
+				if err != nil {
+					return nil, err
+				}
+				return tree.MakeDBool(tree.DBool(ret)), nil
+			},
+			Info: infoBuilder{
+				info: "Returns true if every pair of points comprising geometry_a and geometry_b are within distance units. " +
+					"In other words, the ST_MaxDistance between geometry_a and geometry_b is less than or equal to distance units.",
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
 	),
 	"st_dwithin": makeBuiltin(
 		defProps(),


### PR DESCRIPTION
Based on top of #49085.

MaxDistance/DFullyWithin is a specialisation of distance, where it takes
the maximum of distances found instead and disregards intersections and
closest points. The `stopAfterLE` condition becomes `stopAfterGT`.

Resolves #48983, resolves #48916

Release note (sql change): Implemented the ST_MaxDistance and
ST_DFullyWithin function for geometries.

