### PR TITLE
sql: allow autocommit of last cascade

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1067,6 +1067,11 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 
 		evalCtx := evalCtxFactory()
 		execFactory := makeExecFactory(planner)
+		// The cascading query is allowed to autocommit only if it is the last
+		// cascade and there are no check queries to run.
+		if len(plan.checkPlans) > 0 || i < len(plan.cascades)-1 {
+			execFactory.disableAutoCommit()
+		}
 		cascadePlan, err := plan.cascades[i].PlanFn(
 			ctx, &planner.semaCtx, &evalCtx.EvalContext, &execFactory, buf, buf.bufferedRows.Len(),
 		)

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -100,11 +100,6 @@ func New(
 	return b
 }
 
-// DisallowAutoCommit disables auto commit.
-func (b *Builder) DisallowAutoCommit() {
-	b.allowAutoCommit = false
-}
-
 // Build constructs the execution node tree and returns its root node if no
 // error occurred.
 func (b *Builder) Build() (_ exec.Plan, err error) {

--- a/pkg/sql/opt/exec/execbuilder/cascades.go
+++ b/pkg/sql/opt/exec/execbuilder/cascades.go
@@ -254,9 +254,6 @@ func (cb *cascadeBuilder) planCascade(
 
 	// 4. Execbuild the optimized expression.
 	eb := New(execFactory, factory.Memo(), cb.b.catalog, optimizedExpr, evalCtx)
-	// TODO(radu): we could allow autocommit for the last cascade (if there are no
-	// checks to run).
-	eb.DisallowAutoCommit()
 	// Set up the With binding.
 	eb.addBuiltWithExpr(cascadeInputWithID, bufferColMap, bufferRef)
 	plan, err := eb.Build()

--- a/pkg/sql/opt/exec/execbuilder/testdata/autocommit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/autocommit
@@ -616,7 +616,8 @@ statement ok
 CREATE TABLE fk_parent (p INT PRIMARY KEY, q INT, FAMILY f1 (p, q));
 INSERT INTO fk_parent VALUES (1, 10), (2, 20), (3, 30);
 CREATE TABLE fk_child (a INT, b INT REFERENCES fk_parent(p), FAMILY f1 (a, b));
-SET optimizer_foreign_keys = true
+SET optimizer_foreign_keys = true;
+SET experimental_optimizer_foreign_key_cascades = true
 
 # Populate table descriptor cache.
 statement ok
@@ -693,6 +694,33 @@ dist sender send  r32: sending batch 1 Scan to (n1,s1):1
 dist sender send  r32: sending batch 1 Del to (n1,s1):1
 dist sender send  r32: sending batch 1 Scan to (n1,s1):1
 dist sender send  r32: sending batch 1 EndTxn to (n1,s1):1
+
+# Test with a single cascade, which should use autocommit.
+statement ok
+DROP TABLE fk_child;
+CREATE TABLE fk_child (a INT, b INT REFERENCES fk_parent(p) ON DELETE CASCADE, FAMILY f1 (a, b));
+INSERT INTO fk_child VALUES (1, 1), (2, 2)
+
+# Populate table descriptor cache.
+statement ok
+SELECT * FROM fk_parent JOIN fk_child ON p = b
+
+statement ok
+SET TRACING=ON;
+  DELETE FROM fk_parent WHERE p = 2;
+SET TRACING=OFF
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message       LIKE '%r32: sending batch%'
+  AND message   NOT LIKE '%PushTxn%'
+  AND message   NOT LIKE '%QueryTxn%'
+  AND operation NOT LIKE '%async%'
+----
+dist sender send  r32: sending batch 1 Scan to (n1,s1):1
+dist sender send  r32: sending batch 1 Del to (n1,s1):1
+dist sender send  r32: sending batch 1 Scan to (n1,s1):1
+dist sender send  r32: sending batch 2 Del, 1 EndTxn to (n1,s1):1
 
 # -----------------------
 # Multiple mutation tests


### PR DESCRIPTION
This change enables autocommit on the last opt-driven cascade if there are no
checks to run after.

Release note: None