### PR TITLE
coldata: optimize handling of Bytes vectors

### DIFF
--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -36,7 +36,7 @@ func TestDistinct(t *testing.T) {
 	}{
 		{
 			distinctCols: []uint32{0, 1, 2},
-			typs:         []*types.T{types.Float, types.Int, types.Bytes, types.Int},
+			typs:         []*types.T{types.Float, types.Int, types.String, types.Int},
 			tuples: tuples{
 				{nil, nil, nil, nil},
 				{nil, nil, nil, nil},
@@ -84,7 +84,7 @@ func TestDistinct(t *testing.T) {
 		},
 		{
 			distinctCols: []uint32{0, 1, 2},
-			typs:         []*types.T{types.Float, types.Int, types.Bytes, types.Int},
+			typs:         []*types.T{types.Float, types.Int, types.String, types.Int},
 			tuples: tuples{
 				{1.0, 2, "30", 4},
 				{1.0, 2, "30", 4},
@@ -132,7 +132,7 @@ func TestDistinct(t *testing.T) {
 			// This is to test hashTable deduplication with various batch size
 			// boundaries and ensure it always emits the first tuple it encountered.
 			distinctCols: []uint32{0},
-			typs:         []*types.T{types.Int, types.Bytes},
+			typs:         []*types.T{types.Int, types.String},
 			tuples: tuples{
 				{1, "1"},
 				{1, "2"},
@@ -162,7 +162,7 @@ func TestDistinct(t *testing.T) {
 	for _, tc := range tcs {
 		for _, numOfBuckets := range []uint64{1, 3, 5, hashTableNumBuckets} {
 			t.Run(fmt.Sprintf("unordered/numOfBuckets=%d", numOfBuckets), func(t *testing.T) {
-				runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier,
+				runTestsWithTyps(t, []tuples{tc.tuples}, [][]*types.T{tc.typs}, tc.expected, orderedVerifier,
 					func(input []colexecbase.Operator) (colexecbase.Operator, error) {
 						return NewUnorderedDistinct(
 							testAllocator, input[0], tc.distinctCols, tc.typs,
@@ -177,7 +177,7 @@ func TestDistinct(t *testing.T) {
 					for i, j := range rng.Perm(len(tc.distinctCols))[:numOrderedCols] {
 						orderedCols[i] = tc.distinctCols[j]
 					}
-					runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier,
+					runTestsWithTyps(t, []tuples{tc.tuples}, [][]*types.T{tc.typs}, tc.expected, orderedVerifier,
 						func(input []colexecbase.Operator) (colexecbase.Operator, error) {
 							return newPartiallyOrderedDistinct(
 								testAllocator, input[0], tc.distinctCols,
@@ -187,7 +187,7 @@ func TestDistinct(t *testing.T) {
 				})
 			}
 			t.Run("ordered", func(t *testing.T) {
-				runTests(t, []tuples{tc.tuples}, tc.expected, orderedVerifier,
+				runTestsWithTyps(t, []tuples{tc.tuples}, [][]*types.T{tc.typs}, tc.expected, orderedVerifier,
 					func(input []colexecbase.Operator) (colexecbase.Operator, error) {
 						return NewOrderedDistinct(input[0], tc.distinctCols, tc.typs)
 					})


### PR DESCRIPTION
This commit adds explicit tracking of which vectors are of Bytes type to
the MemBatch which should give us some performance improvement,
especially on the queries with hash aggregator.

It also updates the Batch.ReplaceCol contract to require the replacement
vector to be of the same type as the original vector. So far we haven't
had a use case for when this wasn't true, so we might as well enforce
it.

Release note: None