### PR TITLE
sqlmigrations: move namespace migration post-finalization

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1477,6 +1477,8 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.cluster_name"></a><code>crdb_internal.cluster_name() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the cluster name.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.completed_migrations"></a><code>crdb_internal.completed_migrations() &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
 <tr><td><a name="crdb_internal.encode_key"></a><code>crdb_internal.encode_key(table_id: <a href="int.html">int</a>, index_id: <a href="int.html">int</a>, row_tuple: anyelement) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Generate the key for a row on a particular table and index.</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.force_assertion_error"></a><code>crdb_internal.force_assertion_error(msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>

--- a/pkg/cmd/roachtest/namespace_upgrade.go
+++ b/pkg/cmd/roachtest/namespace_upgrade.go
@@ -1,0 +1,273 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
+)
+
+func registerNamespaceUpgrade(r *testRegistry) {
+	r.Add(testSpec{
+		Name:  "version/namespace-upgrade",
+		Owner: OwnerSQLSchema,
+		// This test is a regression test designed to test for #49092.
+		// It drops objects from the 19.2 node after the 20.1 node joins the
+		// cluster, and also drops/adds objects in each of the states before, during
+		// and after the migration, making sure results are as we expect.
+		MinVersion: "v20.1.0",
+		Cluster:    makeClusterSpec(3),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			predV, err := PredecessorVersion(r.buildVersion)
+			if err != nil {
+				t.Fatal(err)
+			}
+			runNamespaceUpgrade(ctx, t, c, predV)
+		},
+	})
+}
+
+func createTableStep(node int, table string) versionStep {
+	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
+		db := u.conn(ctx, t, node)
+		_, err := db.ExecContext(ctx,
+			fmt.Sprintf(`CREATE TABLE %s (a INT)`, table))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func createDBStep(node int, name string) versionStep {
+	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
+		db := u.conn(ctx, t, node)
+		_, err := db.ExecContext(ctx,
+			fmt.Sprintf(`CREATE DATABASE %s`, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func dropTableStep(node int, table string) versionStep {
+	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
+		db := u.conn(ctx, t, node)
+		_, err := db.ExecContext(ctx,
+			fmt.Sprintf(`DROP TABLE %s`, table))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func dropDBStep(node int, name string) versionStep {
+	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
+		db := u.conn(ctx, t, node)
+		_, err := db.ExecContext(ctx,
+			fmt.Sprintf(`DROP DATABASE %s`, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func renameDBStep(node int, oldDB string, newDB string) versionStep {
+	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
+		db := u.conn(ctx, t, node)
+		_, err := db.ExecContext(ctx,
+			fmt.Sprintf(`ALTER DATABASE %s RENAME TO %s`, oldDB, newDB))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func renameTableStep(node int, oldTable string, newTable string) versionStep {
+	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
+		db := u.conn(ctx, t, node)
+		_, err := db.ExecContext(ctx,
+			fmt.Sprintf(`ALTER TABLE %s RENAME TO %s`, oldTable, newTable))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func truncateTableStep(node int, table string) versionStep {
+	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
+		db := u.conn(ctx, t, node)
+		_, err := db.ExecContext(ctx,
+			fmt.Sprintf(`TRUNCATE %s`, table))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func showDatabasesStep(node int) versionStep {
+	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
+		db := u.conn(ctx, t, node)
+		_, err := db.ExecContext(ctx,
+			`SHOW DATABASES`)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func changeMigrationSetting(node int, enable bool) versionStep {
+	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
+		db := u.conn(ctx, t, node)
+		_, err := db.ExecContext(ctx, `SET CLUSTER SETTING testing.system_namespace_migration.enabled = $1`, enable)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func verifyNoOrphanedOldEntries(node int) versionStep {
+	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
+		db := u.conn(ctx, t, node)
+		// Check that there are no rows in namespace that aren't in namespace2,
+		// except for the old entry for namespace (descriptor 2) which we don't
+		//copy.
+		row := db.QueryRowContext(ctx,
+			`SELECT count(*) FROM [2 AS namespace] WHERE id != 2 AND id NOT IN (SELECT id FROM [30 as namespace2])`)
+		var count int
+		if err := row.Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		if count != 0 {
+			t.Fatal("unexpected entries found in namespace but not in namespace2")
+		}
+	}
+
+}
+
+func uploadAndStart(nodes nodeListOption, v string) versionStep {
+	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
+		// Put and start the binary.
+		args := u.uploadVersion(ctx, t, nodes, v)
+		// NB: can't start sequentially since cluster already bootstrapped.
+		u.c.Start(ctx, t, nodes, args, startArgsDontEncrypt, roachprodArgOption{"--sequential=false"})
+	}
+}
+
+func runNamespaceUpgrade(ctx context.Context, t *test, c *cluster, predecessorVersion string) {
+	roachNodes := c.All()
+	// An empty string means that the cockroach binary specified by flag
+	// `cockroach` will be used.
+	const mainVersion = ""
+	u := newVersionUpgradeTest(c,
+		uploadAndStart(roachNodes, predecessorVersion),
+		waitForUpgradeStep(roachNodes),
+		preventAutoUpgradeStep(1),
+
+		// Make some objects on node 1.
+		createTableStep(1, "a"),
+		createTableStep(1, "todrop"),
+		createTableStep(1, "torename"),
+		createTableStep(1, "totruncate"),
+		createDBStep(1, "foo"),
+		createDBStep(1, "todrop"),
+		createDBStep(1, "torename"),
+
+		// Upgrade Node 3.
+		binaryUpgradeStep(c.Node(3), mainVersion),
+
+		// Disable the migration. We'll re-enable it later.
+		changeMigrationSetting(3, false),
+
+		// Drop the objects on node 1, which is still on the old version.
+		dropTableStep(1, "a"),
+		dropDBStep(1, "foo"),
+
+		// Verify that the new node can still run SHOW DATABASES.
+		showDatabasesStep(3),
+		// Verify that the new node can recreate the dropped objects.
+		createTableStep(3, "a"),
+		createDBStep(3, "foo"),
+
+		// Drop the objects on node 1 again, which is still on the old version.
+		dropTableStep(1, "a"),
+		dropDBStep(1, "foo"),
+
+		// Upgrade the other 2 nodes.
+		binaryUpgradeStep(c.Node(1), mainVersion),
+		binaryUpgradeStep(c.Node(2), mainVersion),
+
+		// Finalize upgrade.
+		allowAutoUpgradeStep(1),
+
+		waitForUpgradeStep(roachNodes),
+
+		// After finalization, but before upgrade, add a table, drop a table,
+		// rename a table, and truncate a table.
+		createTableStep(1, "fresh"),
+		createDBStep(1, "fresh"),
+		dropTableStep(1, "todrop"),
+		dropDBStep(1, "todrop"),
+		renameTableStep(1, "torename", "new"),
+		renameDBStep(1, "torename", "new"),
+		truncateTableStep(1, "totruncate"),
+
+		// Re-enable the migration.
+		changeMigrationSetting(1, true),
+
+		// Wait for the migration to finish.
+		func(ctx context.Context, t *test, u *versionUpgradeTest) {
+			t.l.Printf("waiting for cluster to finish namespace migration\n")
+
+			for _, i := range roachNodes {
+				err := retry.ForDuration(30*time.Second, func() error {
+					db := u.conn(ctx, t, i)
+					// This is copied from pkg/sqlmigrations/migrations.go. We don't
+					// export it just for this test because it feels unnecessary.
+					const systemNamespaceMigrationName = "upgrade system.namespace post-20.1-finalization"
+					var complete bool
+					if err := db.QueryRowContext(ctx,
+						`SELECT crdb_internal.completed_migrations() @> ARRAY[$1::string]`,
+						systemNamespaceMigrationName,
+					).Scan(&complete); err != nil {
+						t.Fatal(err)
+					}
+					if !complete {
+						return fmt.Errorf("%d: migration not complete", i)
+					}
+					return nil
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		},
+
+		// Verify that there are no remaining entries that only live in the old
+		// namespace table.
+		verifyNoOrphanedOldEntries(1),
+
+		// Verify that the cluster can run SHOW DATABASES and re-use the names.
+		showDatabasesStep(3),
+		createTableStep(1, "a"),
+		createDBStep(1, "foo"),
+		createTableStep(1, "torename"),
+		createDBStep(1, "torename"),
+		createTableStep(1, "todrop"),
+		createDBStep(1, "todrop"),
+
+		verifyNoOrphanedOldEntries(1),
+	)
+	u.run(ctx, t)
+
+}

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -57,6 +57,7 @@ func registerTests(r *testRegistry) {
 	registerLargeRange(r)
 	registerLedger(r)
 	registerLibPQ(r)
+	registerNamespaceUpgrade(r)
 	registerNetwork(r)
 	registerPgjdbc(r)
 	registerPgx(r)

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -625,20 +625,18 @@ func (s *sqlServer) start(
 		return err
 	}
 
-	{
-		// Run startup migrations (note: these depend on jobs subsystem running).
-		var bootstrapVersion roachpb.Version
-		if err := s.execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-			return txn.GetProto(ctx, keys.BootstrapVersionKey, &bootstrapVersion)
-		}); err != nil {
-			return err
-		}
-		if err := migMgr.EnsureMigrations(ctx, bootstrapVersion); err != nil {
-			return errors.Wrap(err, "ensuring SQL migrations")
-		}
-
-		log.Infof(ctx, "done ensuring all necessary migrations have run")
+	var bootstrapVersion roachpb.Version
+	if err := s.execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		return txn.GetProto(ctx, keys.BootstrapVersionKey, &bootstrapVersion)
+	}); err != nil {
+		return err
 	}
+	// Run startup migrations (note: these depend on jobs subsystem running).
+	if err := migMgr.EnsureMigrations(ctx, bootstrapVersion); err != nil {
+		return errors.Wrap(err, "ensuring SQL migrations")
+	}
+
+	log.Infof(ctx, "done ensuring all necessary migrations have run")
 
 	// Start serving SQL clients.
 	if err := s.startServeSQL(ctx, stopper, connManager, pgL, socketFile); err != nil {
@@ -648,6 +646,12 @@ func (s *sqlServer) start(
 	// Start the async migration to upgrade 19.2-style jobs so they can be run by
 	// the job registry in 20.1.
 	if err := migMgr.StartSchemaChangeJobMigration(ctx); err != nil {
+		return err
+	}
+
+	// Start the async migration to upgrade namespace entries from the old
+	// namespace table (id 2) to the new one (id 30).
+	if err := migMgr.StartSystemNamespaceMigration(ctx, bootstrapVersion); err != nil {
 		return err
 	}
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -3745,6 +3746,33 @@ may increase either contention or retry errors, or both.`,
 			},
 			Info:       "This function is used internally to round decimal array values during mutations.",
 			Volatility: tree.VolatilityStable,
+		},
+	),
+	"crdb_internal.completed_migrations": makeBuiltin(
+		tree.FunctionProperties{
+			Category: categorySystemInfo,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.StringArray),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				prefix := ctx.Codec.MigrationKeyPrefix()
+				keyvals, err := ctx.Txn.Scan(ctx.Context, prefix, prefix.PrefixEnd(), 0 /* maxRows */)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to get list of completed migrations")
+				}
+				ret := &tree.DArray{ParamTyp: types.String, Array: make(tree.Datums, 0, len(keyvals))}
+				for _, keyval := range keyvals {
+					key := keyval.Key
+					if len(key) > len(keys.MigrationPrefix) {
+						key = key[len(keys.MigrationPrefix):]
+					}
+					ret.Array = append(ret.Array, tree.NewDString(string(key)))
+				}
+				return ret, nil
+			},
+			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility: tree.VolatilityVolatile,
 		},
 	),
 }

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -283,9 +284,10 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		newDescriptorIDs:    staticIDs(keys.NamespaceTableID),
 	},
 	{
-		// Introduced in v20.1.
-		name:                "migrate system.namespace_deprecated entries into system.namespace",
-		workFn:              migrateSystemNamespace,
+		// Introduced in v20.10. Replaced in v20.1.1 and v20.2 by the
+		// StartSystemNamespaceMigration post-finalization-style migration.
+		name: "migrate system.namespace_deprecated entries into system.namespace",
+		// workFn:              migrateSystemNamespace,
 		includedInBootstrap: clusterversion.VersionByKey(clusterversion.VersionNamespaceTableWithSchemas),
 	},
 	{
@@ -685,6 +687,12 @@ func schemaChangeJobMigrationKey(codec keys.SQLCodec) roachpb.Key {
 	return append(codec.MigrationKeyPrefix(), roachpb.RKey(schemaChangeJobMigrationName)...)
 }
 
+var systemNamespaceMigrationName = "upgrade system.namespace post-20.1-finalization"
+
+func systemNamespaceMigrationKey(codec keys.SQLCodec) roachpb.Key {
+	return append(codec.MigrationKeyPrefix(), roachpb.RKey(systemNamespaceMigrationName)...)
+}
+
 // schemaChangeJobMigrationKeyForTable returns a key prefixed with
 // schemaChangeJobMigrationKey for a specific table, to store the completion
 // status for adding a new job if the table was being added or needed to drain
@@ -763,6 +771,194 @@ func (m *Manager) StartSchemaChangeJobMigration(ctx context.Context) error {
 			fn()
 		}
 	})
+}
+
+var systemNamespaceMigrationEnabled = settings.RegisterBoolSetting(
+	"testing.system_namespace_migration.enabled",
+	"internal testing only: disable the system namespace migration",
+	true,
+)
+
+// StartSystemNamespaceMigration starts an async task to run the migration that
+// migrates entries from system.namespace (descriptor 2) to system.namespace2
+// (descriptor 30). The task first waits until the upgrade to 20.1 is finalized
+// before running the migration. The migration is retried until it succeeds (on
+// any node).
+func (m *Manager) StartSystemNamespaceMigration(
+	ctx context.Context, bootstrapVersion roachpb.Version,
+) error {
+	if !bootstrapVersion.Less(clusterversion.VersionByKey(clusterversion.VersionNamespaceTableWithSchemas)) {
+		// Our bootstrap version is equal to or greater than 20.1, where no old
+		// namespace table is created: we can skip this migration.
+		return nil
+	}
+	return m.stopper.RunAsyncTask(ctx, "run-system-namespace-migration", func(ctx context.Context) {
+		log.Info(ctx, "starting wait for upgrade finalization before system.namespace migration")
+		// First wait for the cluster to finalize the upgrade to 20.1. These values
+		// were chosen to be similar to the retry loop for finalizing the cluster
+		// upgrade.
+		waitRetryOpts := retry.Options{
+			InitialBackoff: 10 * time.Second,
+			MaxBackoff:     10 * time.Second,
+			Closer:         m.stopper.ShouldQuiesce(),
+		}
+		for retry := retry.StartWithCtx(ctx, waitRetryOpts); retry.Next(); {
+			if !systemNamespaceMigrationEnabled.Get(&m.settings.SV) {
+				continue
+			}
+			if m.settings.Version.IsActive(ctx, clusterversion.VersionNamespaceTableWithSchemas) {
+				break
+			}
+		}
+		select {
+		case <-m.stopper.ShouldQuiesce():
+			return
+		default:
+		}
+		log.VEventf(ctx, 2, "detected upgrade finalization for system.namespace migration")
+
+		migrationKey := systemNamespaceMigrationKey(m.codec)
+		// Check whether this migration has already been completed.
+		if kv, err := m.db.Get(ctx, migrationKey); err != nil {
+			log.Infof(ctx, "error getting record of system.namespace migration: %s", err.Error())
+		} else if kv.Exists() {
+			log.Infof(ctx, "system.namespace migration already complete")
+			return
+		}
+
+		// Now run the migration. This is retried indefinitely until it finishes.
+		log.Infof(ctx, "starting system.namespace migration")
+		r := runner{
+			db:          m.db,
+			codec:       m.codec,
+			sqlExecutor: m.sqlExecutor,
+			settings:    m.settings,
+		}
+		migrationRetryOpts := retry.Options{
+			InitialBackoff: 1 * time.Minute,
+			MaxBackoff:     10 * time.Minute,
+			Closer:         m.stopper.ShouldQuiesce(),
+		}
+		startTime := timeutil.Now().String()
+		for migRetry := retry.Start(migrationRetryOpts); migRetry.Next(); {
+			if err := m.migrateSystemNamespace(ctx, migrationKey, r, startTime); err != nil {
+				log.Errorf(ctx, "error attempting running system.namespace migration, will retry: %s %s", err.Error(),
+					startTime)
+				continue
+			}
+			break
+		}
+	})
+}
+
+// migrateSystemNamespace migrates entries from the deprecated system.namespace
+// table to the new one, which includes a parentSchemaID column. Each database
+// entry is copied to the new table along with a corresponding entry for the
+// 'public' schema. Each table entry is copied over with the public schema as
+// as its parentSchemaID.
+//
+// Only entries that do not exist in the new table are copied.
+//
+// New database and table entries continue to be written to the deprecated
+// namespace table until VersionNamespaceTableWithSchemas is active. This means
+// that an additional migration will be necessary in 20.2 to catch any new
+// entries which may have been missed by this one. In the meantime, namespace
+// lookups fall back to the deprecated table if a name is not found in the new
+// one.
+func (m *Manager) migrateSystemNamespace(
+	ctx context.Context, migrationKey roachpb.Key, r runner, startTime string,
+) error {
+	migrateCtx, cancel := m.stopper.WithCancelOnQuiesce(ctx)
+	defer cancel()
+	migrateCtx = logtags.AddTag(migrateCtx, "system-namespace-migration", nil)
+	// Loop until there's no more work to be done.
+	workLeft := true
+	for workLeft {
+		if err := m.db.Txn(migrateCtx, func(ctx context.Context, txn *kv.Txn) error {
+			// Check again to see if someone else wrote the migration key.
+			if kv, err := txn.Get(ctx, migrationKey); err != nil {
+				log.Infof(ctx, "error getting record of system.namespace migration: %s", err.Error())
+				// Retry the migration.
+				return err
+			} else if kv.Exists() {
+				// Give up, no work to be done.
+				log.Infof(ctx, "system.namespace migration already complete")
+				return nil
+			}
+			// Fetch all entries that are not present in the new namespace table. Each
+			// of these entries will be copied to the new table.
+			//
+			// Note that we are very careful to always delete from both namespace tables
+			// in 20.1, so there's no possibility that we'll be overwriting a deleted
+			// table that existed in the old table and the new table but was deleted
+			// from only the new table.
+			const batchSize = 1000
+			q := fmt.Sprintf(
+				`SELECT "parentID", name, id FROM [%d AS namespace_deprecated]
+              WHERE id NOT IN (SELECT id FROM [%d AS namespace]) LIMIT %d`,
+				sqlbase.DeprecatedNamespaceTable.ID, sqlbase.NamespaceTable.ID, batchSize+1)
+			rows, err := r.sqlExecutor.QueryEx(
+				ctx, "read-deprecated-namespace-table", txn,
+				sqlbase.InternalExecutorSessionDataOverride{
+					User: security.RootUser,
+				},
+				q)
+			if err != nil {
+				return err
+			}
+			log.Infof(ctx, "Migrating system.namespace chunk with %d rows", len(rows))
+			for i, row := range rows {
+				workLeft = false
+				// We found some rows from the query, which means that we can't quit
+				// just yet.
+				if i >= batchSize {
+					workLeft = true
+					// Just process 1000 rows at a time.
+					break
+				}
+				parentID := sqlbase.ID(tree.MustBeDInt(row[0]))
+				name := string(tree.MustBeDString(row[1]))
+				id := sqlbase.ID(tree.MustBeDInt(row[2]))
+				if parentID == keys.RootNamespaceID {
+					// This row represents a database. Add it to the new namespace table.
+					databaseKey := sqlbase.NewDatabaseKey(name)
+					if err := txn.Put(ctx, databaseKey.Key(r.codec), id); err != nil {
+						return err
+					}
+					// Also create a 'public' schema for this database.
+					schemaKey := sqlbase.NewSchemaKey(id, "public")
+					log.VEventf(ctx, 2, "Migrating system.namespace entry for database %s", name)
+					if err := txn.Put(ctx, schemaKey.Key(r.codec), keys.PublicSchemaID); err != nil {
+						return err
+					}
+				} else {
+					// This row represents a table. Add it to the new namespace table with the
+					// schema set to 'public'.
+					if id == keys.DeprecatedNamespaceTableID {
+						// The namespace table itself was already handled in
+						// createNewSystemNamespaceDescriptor. Do not overwrite it with the
+						// deprecated ID.
+						continue
+					}
+					tableKey := sqlbase.NewTableKey(parentID, keys.PublicSchemaID, name)
+					log.VEventf(ctx, 2, "Migrating system.namespace entry for table %s", name)
+					if err := txn.Put(ctx, tableKey.Key(r.codec), id); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	// No more work to be done.
+	log.Infof(migrateCtx, "system.namespace migration completed")
+	if err := m.db.Put(migrateCtx, migrationKey, startTime); err != nil {
+		log.Warningf(migrateCtx, "error persisting record of system.namespace migration, will retry: %s", err.Error())
+		return err
+	}
+	return nil
 }
 
 // migrateSchemaChangeJobs runs the schema change job migration. The migration
@@ -1397,64 +1593,6 @@ func addCreateRoleToAdminAndRoot(ctx context.Context, r runner) error {
 		"add role options table and upsert admin with CREATEROLE",
 		upsertCreateRoleStmt,
 		security.RootUser)
-}
-
-// migrateSystemNamespace migrates entries from the deprecated system.namespace
-// table to the new one, which includes a parentSchemaID column. Each database
-// entry is copied to the new table along with a corresponding entry for the
-// 'public' schema. Each table entry is copied over with the public schema as
-// as its parentSchemaID.
-//
-// New database and table entries continue to be written to the deprecated
-// namespace table until VersionNamespaceTableWithSchemas is active. This means
-// that an additional migration will be necessary in 20.2 to catch any new
-// entries which may have been missed by this one. In the meantime, namespace
-// lookups fall back to the deprecated table if a name is not found in the new
-// one.
-func migrateSystemNamespace(ctx context.Context, r runner) error {
-	q := fmt.Sprintf(
-		`SELECT "parentID", name, id FROM [%d AS namespace_deprecated]`,
-		sqlbase.DeprecatedNamespaceTable.ID)
-	rows, err := r.sqlExecutor.QueryEx(
-		ctx, "read-deprecated-namespace-table", nil, /* txn */
-		sqlbase.InternalExecutorSessionDataOverride{
-			User: security.RootUser,
-		},
-		q)
-	if err != nil {
-		return err
-	}
-	for _, row := range rows {
-		parentID := sqlbase.ID(tree.MustBeDInt(row[0]))
-		name := string(tree.MustBeDString(row[1]))
-		id := sqlbase.ID(tree.MustBeDInt(row[2]))
-		if parentID == keys.RootNamespaceID {
-			// This row represents a database. Add it to the new namespace table.
-			databaseKey := sqlbase.NewDatabaseKey(name)
-			if err := r.db.Put(ctx, databaseKey.Key(r.codec), id); err != nil {
-				return err
-			}
-			// Also create a 'public' schema for this database.
-			schemaKey := sqlbase.NewSchemaKey(id, "public")
-			if err := r.db.Put(ctx, schemaKey.Key(r.codec), keys.PublicSchemaID); err != nil {
-				return err
-			}
-		} else {
-			// This row represents a table. Add it to the new namespace table with the
-			// schema set to 'public'.
-			if id == keys.DeprecatedNamespaceTableID {
-				// The namespace table itself was already handled in
-				// createNewSystemNamespaceDescriptor. Do not overwrite it with the
-				// deprecated ID.
-				continue
-			}
-			tableKey := sqlbase.NewTableKey(parentID, keys.PublicSchemaID, name)
-			if err := r.db.Put(ctx, tableKey.Key(r.codec), id); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 func createReportsMetaTable(ctx context.Context, r runner) error {


### PR DESCRIPTION
Fixes #49090.
Fixes #49092.

This commit removes the namespace migration, and replaces it with a
post-finalization async migration in the style of the schema change jobs
migration that only runs after the 20.1 version bit is flipped.

This change prevents an issue with dropping a table or database from a
19.2 node after the migration ran. That operation would orphan an entry in
system.namespace2, since the migration would have moved the entry to
system.namespace2 already, but the drop would only remove the entry
from system.namespace.

The migration additionally only moves entries from system.namespace to
system.namespace2 if there isn't already an entry in system.namespace2
for that descriptor id. This should be safe and idempotent. Here are
some things to note:

1. No nodes write to namespace2 until 20.1 is finalized.
2. 20.1 nodes always delete from both namespace and namespace2.

In the happy path, there are no entries in system.namespace2 when the
migration runs. All entries are copied in.

If, after finalization but before the migration, a node:

- Adds a table: the new entry will go only to system.namespace2, and
  there will be no system.namespace entry to copy, so no problem
- Deletes a table: the entry will be removed from system.namespace2 and
  system.namespace, so there will be no system.namespace entry to copy.
- Renames a table: the old entry will be removed from system.namespace
  and system.namespce2, and the new entry will be added to
  system.namespace2, so there will be no system.namespace entry to copy.
- Truncates a table: same as rename.

Note this is all the same for views, sequences, and databases, but
databases, views, and sequences don't support truncate.

If this migration is run a second time, it's impossible to find any
entries in system.namespace that aren't also in system.namespace2,
because 20.1 nodes always delete from both tables when they delete, so
the migration will do nothing.

----

One complication is that, due to the issue explained at the top of this
commit, there can exist orphaned entries in system.descriptor2 that are
not in system.descriptor at the time that this migration runs. This
migration makes no effort to clean these orphans up, but it doesn't
affect the run of the migration.

Release note (bug fix): Prevent namespace orphans (manifesting as
`database "" not found` errors) when migrating from 19.2.