### PR TITLE
colexec: HashRouter fixes

### DIFF
--- a/pkg/sql/colexec/routers_test.go
+++ b/pkg/sql/colexec/routers_test.go
@@ -965,7 +965,7 @@ func BenchmarkHashRouter(b *testing.B) {
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					input.ResetBatchesToReturn(numInputBatches)
-					r.reset(ctx)
+					r.resetForBenchmarks(ctx)
 					wg.Add(len(outputs))
 					for j := range outputs {
 						go func(j int) {


### PR DESCRIPTION
This commit renames routerOutputOp.reset to resetForBenchmarks to make it
explicit that this method is to be called only during benchmarks. The method
could previously be called during normal execution since it implemented the
`resetter` interface.

Unlocks in the routerOutputOp are now called in defers, to ensure that if a
panic occurs (which is normal during vectorized execution), the lock is
unlocked properly.

Release note (bug fix): possible deadlock during vectorized query execution has
been fixed