### PR TITLE
storage: minor Pebble MVCCScan/Iterator perf improvements

### DIFF
--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -787,6 +787,7 @@ func mvccGet(
 		inconsistent:     opts.Inconsistent,
 		tombstones:       opts.Tombstones,
 		failOnMoreRecent: opts.FailOnMoreRecent,
+		keyBuf:           mvccScanner.keyBuf,
 	}
 
 	mvccScanner.init(opts.Txn)
@@ -795,7 +796,7 @@ func mvccGet(
 	if mvccScanner.err != nil {
 		return nil, nil, mvccScanner.err
 	}
-	intents, err := buildScanIntents(mvccScanner.intents.Repr())
+	intents, err := buildScanIntents(mvccScanner.intentsRepr())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2357,6 +2358,7 @@ func mvccScanToBytes(
 		inconsistent:     opts.Inconsistent,
 		tombstones:       opts.Tombstones,
 		failOnMoreRecent: opts.FailOnMoreRecent,
+		keyBuf:           mvccScanner.keyBuf,
 	}
 
 	mvccScanner.init(opts.Txn)
@@ -2373,7 +2375,7 @@ func mvccScanToBytes(
 	res.NumKeys = mvccScanner.results.count
 	res.NumBytes = mvccScanner.results.bytes
 
-	res.Intents, err = buildScanIntents(mvccScanner.intents.Repr())
+	res.Intents, err = buildScanIntents(mvccScanner.intentsRepr())
 	if err != nil {
 		return MVCCScanResult{}, err
 	}


### PR DESCRIPTION
The Pebble `MVCCScan` code path was always creating a batch reader to
decode any scanned intents because `pebbleMVCCScanner.intents.Repr()`
always returns a non-empty value. Added
`pebbleMVCCScanner.intentsRepr()` which only returns a non-nil value if
there are actually intents.

Reuse `pebbleMVCCScanner.keyBuf` and `pebbleIterator.keyBuf` in order to
remove two memory allocations from this hot path.

Merged `pebbleMVCCScanner.cur{Key,TS}` into a single `MVCCKey` field. We
were frequently constructing the `MVCCKey` from its constituent parts
and doing so showed up on CPU profiles.

Manually inlined a call to `MVCCKey.IsValue()` in
`pebbleMVCCScanner.getAndAdvance()` that shows up on CPU profiles.

Changed `pebbleIterator.Valid()` to only call through to
`pebble.Iterator.Error()` if the iterator is not valid. The
`pebble.Iterator.Error()` call was showing up on CPU profiles, and it
was completely unnecessary when the iterator is valid.

```
name                                                    old time/op    new time/op    delta
MVCCScan_Pebble/rows=1/versions=1/valueSize=8-16          2.95µs ± 1%    2.18µs ± 1%  -26.21%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=1/versions=1/valueSize=64-16         3.14µs ± 3%    2.32µs ± 1%  -26.09%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=1/versions=1/valueSize=512-16        3.82µs ± 2%    3.18µs ± 4%  -16.95%  (p=0.000 n=9+10)
MVCCScan_Pebble/rows=10/versions=1/valueSize=8-16         5.50µs ± 1%    4.48µs ± 2%  -18.61%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=10/versions=1/valueSize=64-16        6.22µs ± 1%    5.22µs ± 1%  -16.11%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=10/versions=1/valueSize=512-16       8.32µs ± 1%    7.46µs ± 2%  -10.30%  (p=0.000 n=9+9)
MVCCScan_Pebble/rows=100/versions=1/valueSize=8-16        26.2µs ± 0%    22.3µs ± 2%  -14.60%  (p=0.000 n=8+10)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64-16       30.7µs ± 4%    26.2µs ± 0%  -14.56%  (p=0.000 n=9+10)
MVCCScan_Pebble/rows=100/versions=1/valueSize=512-16      43.3µs ± 1%    39.2µs ± 1%   -9.48%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=1000/versions=1/valueSize=8-16        228µs ± 0%     192µs ± 1%  -15.90%  (p=0.000 n=9+10)
MVCCScan_Pebble/rows=1000/versions=1/valueSize=64-16       242µs ± 0%     207µs ± 1%  -14.66%  (p=0.000 n=9+9)
MVCCScan_Pebble/rows=1000/versions=1/valueSize=512-16      368µs ± 1%     335µs ± 1%   -8.76%  (p=0.000 n=9+10)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=8-16      2.10ms ± 2%    1.73ms ± 0%  -17.69%  (p=0.000 n=10+9)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64-16     2.21ms ± 1%    1.83ms ± 1%  -16.85%  (p=0.000 n=8+10)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=512-16    3.20ms ± 3%    2.73ms ± 3%  -14.65%  (p=0.000 n=10+10)
```