### PR TITLE
ui: fix link to problem ranges

### DIFF
--- a/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
+++ b/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
@@ -60,7 +60,7 @@ function ProblemRangeList(props: {
         {
           _.map(ids, id => {
             return (
-              <Link key={id} className="problems-link" to={`reports/range/${id}`}>
+              <Link key={id} className="problems-link" to={`/reports/range/${id}`}>
                 {id}
               </Link>
             );


### PR DESCRIPTION
Release note (admin ui change): Fixed bug where link to
specific problem ranges had an incorrect path. Problem
ranges are now linked correctly again.

This closes #48559 