### PR TITLE
opt: improve the rule that converts COUNT to COUNT_ROWS

### DIFF
--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -52,6 +52,13 @@ func (c *CustomFuncs) DerefOrderingChoice(result *physical.OrderingChoice) physi
 	return *result
 }
 
+// ExprIsNeverNull returns true if we can prove that the given scalar expression
+// is always non-NULL. Any variables that refer to columns in the notNullCols
+// set are assumed to be non-NULL. See memo.ExprIsNeverNull.
+func (c *CustomFuncs) ExprIsNeverNull(e opt.ScalarExpr, notNullCols opt.ColSet) bool {
+	return memo.ExprIsNeverNull(e, notNullCols)
+}
+
 // ----------------------------------------------------------------------
 //
 // Typing functions

--- a/pkg/sql/opt/norm/rules/groupby.opt
+++ b/pkg/sql/opt/norm/rules/groupby.opt
@@ -285,17 +285,15 @@
 )
 
 # ConvertCountToCountRows replaces a Count operator performed on a non-null
-# column with a CountRows operator. CountRows is significantly faster to execute
-# than Count.
+# expression with a CountRows operator. CountRows is significantly faster to
+# execute than Count.
 [ConvertCountToCountRows, Normalize]
 (GroupBy | ScalarGroupBy
     $input:*
     $aggregations:[
         ...
-        $item:(AggregationsItem
-                (Count (Variable $inputColID:*))
-            ) &
-            (IsColNotNull $inputColID $input)
+        $item:(AggregationsItem (Count $arg:*)) &
+            (ExprIsNeverNull $arg (NotNullCols $input))
         ...
     ]
     $groupingPrivate:*

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -2772,7 +2772,7 @@ scalar-group-by
 # ConvertCountToCountRows
 # --------------------------------------------------
 
-# ScalarGroupBy case.
+# ScalarGroupBy cases.
 norm expect=ConvertCountToCountRows
 SELECT count(z) FROM xyzbs
 ----
@@ -2785,7 +2785,31 @@ scalar-group-by
  └── aggregations
       └── count-rows [as=count:6]
 
-# GroupBy case.
+norm expect=ConvertCountToCountRows
+SELECT count(1) FROM xyzbs
+----
+scalar-group-by
+ ├── columns: count:7!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7)
+ ├── scan xyzbs
+ └── aggregations
+      └── count-rows [as=count:7]
+
+norm expect=ConvertCountToCountRows
+SELECT count(1 + z) FROM xyzbs
+----
+scalar-group-by
+ ├── columns: count:7!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7)
+ ├── scan xyzbs
+ └── aggregations
+      └── count-rows [as=count:7]
+
+# GroupBy cases.
 norm expect=ConvertCountToCountRows
 SELECT count(z) FROM xyzbs GROUP BY s
 ----
@@ -2800,6 +2824,36 @@ project
       │    └── columns: s:5
       └── aggregations
            └── count-rows [as=count:6]
+
+norm expect=ConvertCountToCountRows
+SELECT count(1) FROM xyzbs GROUP BY s
+----
+project
+ ├── columns: count:7!null
+ └── group-by
+      ├── columns: s:5 count:7!null
+      ├── grouping columns: s:5
+      ├── key: (5)
+      ├── fd: (5)-->(7)
+      ├── scan xyzbs
+      │    └── columns: s:5
+      └── aggregations
+           └── count-rows [as=count:7]
+
+norm expect=ConvertCountToCountRows
+SELECT count(1+z) FROM xyzbs GROUP BY s
+----
+project
+ ├── columns: count:7!null
+ └── group-by
+      ├── columns: s:5 count:7!null
+      ├── grouping columns: s:5
+      ├── key: (5)
+      ├── fd: (5)-->(7)
+      ├── scan xyzbs
+      │    └── columns: s:5
+      └── aggregations
+           └── count-rows [as=count:7]
 
 # Case with multiple aggregate functions.
 # Expecting to activate on z and b but not y, because y can be null.


### PR DESCRIPTION
Improve the ConvertCountToCountRows rule to check for any scalar expression that
is never null, not just bare variable references.

Release note (performance improvement): `COUNT` is now converted to `COUNT(*)`
(aka `COUNT_ROWS`) in more cases.