### PR TITLE
colexec: introduce column names into templated functions

### DIFF
--- a/pkg/sql/colexec/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/avg_agg_tmpl.go
@@ -50,13 +50,13 @@ const _TYPE_WIDTH = 0
 // _ASSIGN_DIV_INT64 is the template division function for assigning the first
 // input to the result of the second input / the third input, where the third
 // input is an int64.
-func _ASSIGN_DIV_INT64(_, _, _ string) {
+func _ASSIGN_DIV_INT64(_, _, _, _, _, _ string) {
 	colexecerror.InternalError("")
 }
 
 // _ASSIGN_ADD is the template addition function for assigning the first input
 // to the result of the second input + the third input.
-func _ASSIGN_ADD(_, _, _ string) {
+func _ASSIGN_ADD(_, _, _, _, _, _ string) {
 	colexecerror.InternalError("")
 }
 
@@ -170,7 +170,7 @@ func (a *avg_TYPEAgg) Flush() {
 	if !a.scratch.foundNonNullForCurrentGroup {
 		a.scratch.nulls.SetNull(a.scratch.curIdx)
 	} else {
-		_ASSIGN_DIV_INT64(a.scratch.vec[a.scratch.curIdx], a.scratch.curSum, a.scratch.curCount)
+		_ASSIGN_DIV_INT64(a.scratch.vec[a.scratch.curIdx], a.scratch.curSum, a.scratch.curCount, a.scratch.vec, _, _)
 	}
 	a.scratch.curIdx++
 }
@@ -199,7 +199,7 @@ func _ACCUMULATE_AVG(a *_AGG_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS bo
 				a.scratch.nulls.SetNull(a.scratch.curIdx)
 			} else {
 				// {{with .Global}}
-				_ASSIGN_DIV_INT64(a.scratch.vec[a.scratch.curIdx], a.scratch.curSum, a.scratch.curCount)
+				_ASSIGN_DIV_INT64(a.scratch.vec[a.scratch.curIdx], a.scratch.curSum, a.scratch.curCount, a.scratch.vec, _, _)
 				// {{end}}
 			}
 		}
@@ -224,7 +224,7 @@ func _ACCUMULATE_AVG(a *_AGG_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS bo
 	isNull = false
 	// {{end}}
 	if !isNull {
-		_ASSIGN_ADD(a.scratch.curSum, a.scratch.curSum, col[i])
+		_ASSIGN_ADD(a.scratch.curSum, a.scratch.curSum, col[i], _, _, col)
 		a.scratch.curCount++
 		a.scratch.foundNonNullForCurrentGroup = true
 	}

--- a/pkg/sql/colexec/distinct_tmpl.go
+++ b/pkg/sql/colexec/distinct_tmpl.go
@@ -123,7 +123,7 @@ type _GOTYPESLICE interface{}
 
 // _ASSIGN_NE is the template equality function for assigning the first input
 // to the result of the second input != the third input.
-func _ASSIGN_NE(_ bool, _, _ _GOTYPE) bool {
+func _ASSIGN_NE(_ bool, _, _, _, _, _ _GOTYPE) bool {
 	colexecerror.InternalError("")
 }
 
@@ -373,7 +373,7 @@ func _CHECK_DISTINCT(
 	// {{with .Global}}
 	v := execgen.UNSAFEGET(col, checkIdx)
 	var unique bool
-	_ASSIGN_NE(unique, v, lastVal)
+	_ASSIGN_NE(unique, v, lastVal, _, col, _)
 	outputCol[outputIdx] = outputCol[outputIdx] || unique
 	execgen.COPYVAL(lastVal, v)
 	// {{end}}
@@ -412,7 +412,7 @@ func _CHECK_DISTINCT_WITH_NULLS(
 		} else {
 			// Neither value is null, so we must compare.
 			var unique bool
-			_ASSIGN_NE(unique, v, lastVal)
+			_ASSIGN_NE(unique, v, lastVal, _, col, _)
 			outputCol[outputIdx] = outputCol[outputIdx] || unique
 		}
 		execgen.COPYVAL(lastVal, v)

--- a/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
@@ -22,11 +22,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
-func (o lastArgWidthOverload) AssignAdd(target, l, r string) string {
-	return o.WidthOverloads[0].Assign(target, l, r)
+func (o lastArgWidthOverload) AssignAdd(
+	targetElem, leftElem, rightElem, targetCol, leftCol, rightCol string,
+) string {
+	return o.WidthOverloads[0].Assign(targetElem, leftElem, rightElem, targetCol, leftCol, rightCol)
 }
 
-func (o lastArgWidthOverload) AssignDivInt64(target, l, r string) string {
+func (o lastArgWidthOverload) AssignDivInt64(
+	targetElem, leftElem, rightElem, _, _, _ string,
+) string {
 	switch o.lastArgTypeOverload.CanonicalTypeFamily {
 	case types.DecimalFamily:
 		return fmt.Sprintf(`
@@ -34,10 +38,10 @@ func (o lastArgWidthOverload) AssignDivInt64(target, l, r string) string {
 			if _, err := tree.DecimalCtx.Quo(&%s, &%s, &%s); err != nil {
 			colexecerror.InternalError(err)
 		}`,
-			target, r, target, l, target,
+			targetElem, rightElem, targetElem, leftElem, targetElem,
 		)
 	case types.FloatFamily:
-		return fmt.Sprintf("%s = %s / float64(%s)", target, l, r)
+		return fmt.Sprintf("%s = %s / float64(%s)", targetElem, leftElem, rightElem)
 	}
 	colexecerror.InternalError("unsupported avg agg type")
 	// This code is unreachable, but the compiler cannot infer that.
@@ -66,10 +70,10 @@ func genAvgAgg(wr io.Writer) error {
 	s = strings.ReplaceAll(s, "_TYPE", "{{.VecMethod}}")
 	s = strings.ReplaceAll(s, "TemplateType", "{{.VecMethod}}")
 
-	assignDivRe := makeFunctionRegex("_ASSIGN_DIV_INT64", 3)
-	s = assignDivRe.ReplaceAllString(s, makeTemplateFunctionCall("AssignDivInt64", 3))
-	assignAddRe := makeFunctionRegex("_ASSIGN_ADD", 3)
-	s = assignAddRe.ReplaceAllString(s, makeTemplateFunctionCall("Global.AssignAdd", 3))
+	assignDivRe := makeFunctionRegex("_ASSIGN_DIV_INT64", 6)
+	s = assignDivRe.ReplaceAllString(s, makeTemplateFunctionCall("AssignDivInt64", 6))
+	assignAddRe := makeFunctionRegex("_ASSIGN_ADD", 6)
+	s = assignAddRe.ReplaceAllString(s, makeTemplateFunctionCall("Global.AssignAdd", 6))
 
 	accumulateAvg := makeFunctionRegex("_ACCUMULATE_AVG", 4)
 	s = accumulateAvg.ReplaceAllString(s, `{{template "accumulateAvg" buildDict "Global" . "HasNulls" $4}}`)

--- a/pkg/sql/colexec/execgen/cmd/execgen/distinct_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/distinct_gen.go
@@ -36,8 +36,8 @@ func genDistinctOps(wr io.Writer) error {
 	s = strings.ReplaceAll(s, "_TYPE", "{{.VecMethod}}")
 	s = strings.ReplaceAll(s, "TemplateType", "{{.VecMethod}}")
 
-	assignNeRe := makeFunctionRegex("_ASSIGN_NE", 3)
-	s = assignNeRe.ReplaceAllString(s, makeTemplateFunctionCall("Assign", 3))
+	assignNeRe := makeFunctionRegex("_ASSIGN_NE", 6)
+	s = assignNeRe.ReplaceAllString(s, makeTemplateFunctionCall("Assign", 6))
 
 	innerLoopRe := makeFunctionRegex("_CHECK_DISTINCT", 5)
 	s = innerLoopRe.ReplaceAllString(s, `{{template "checkDistinct" buildDict "Global" .}}`)

--- a/pkg/sql/colexec/execgen/cmd/execgen/hash_aggregator_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hash_aggregator_gen.go
@@ -35,8 +35,8 @@ func genHashAggregator(wr io.Writer) error {
 
 	s = replaceManipulationFuncsAmbiguous(".Global", s)
 
-	assignCmpRe := makeFunctionRegex("_ASSIGN_NE", 3)
-	s = assignCmpRe.ReplaceAllString(s, makeTemplateFunctionCall("Global.Assign", 3))
+	assignCmpRe := makeFunctionRegex("_ASSIGN_NE", 6)
+	s = assignCmpRe.ReplaceAllString(s, makeTemplateFunctionCall("Global.Assign", 6))
 
 	populateSels := makeFunctionRegex("_POPULATE_SELS", 3)
 	s = populateSels.ReplaceAllString(s, `{{template "populateSels" buildDict "Global" . "BatchHasSelection" $3}}`)

--- a/pkg/sql/colexec/execgen/cmd/execgen/hash_utils_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hash_utils_gen.go
@@ -32,8 +32,8 @@ func genHashUtils(wr io.Writer) error {
 	s = strings.ReplaceAll(s, "_TYPE", "{{.VecMethod}}")
 	s = strings.ReplaceAll(s, "TemplateType", "{{.VecMethod}}")
 
-	assignHash := makeFunctionRegex("_ASSIGN_HASH", 2)
-	s = assignHash.ReplaceAllString(s, makeTemplateFunctionCall("Global.UnaryAssign", 2))
+	assignHash := makeFunctionRegex("_ASSIGN_HASH", 4)
+	s = assignHash.ReplaceAllString(s, makeTemplateFunctionCall("Global.UnaryAssign", 4))
 
 	rehash := makeFunctionRegex("_REHASH_BODY", 8)
 	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "HasSel" $7 "HasNulls" $8}}`)

--- a/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
@@ -43,8 +43,8 @@ func genHashTable(wr io.Writer) error {
 	s = strings.ReplaceAll(s, "_R_UNSAFEGET", "execgen.UNSAFEGET")
 	s = replaceManipulationFuncsAmbiguous(".Global.Right", s)
 
-	assignNeRe := makeFunctionRegex("_ASSIGN_NE", 3)
-	s = assignNeRe.ReplaceAllString(s, makeTemplateFunctionCall("Global.Right.Assign", 3))
+	assignNeRe := makeFunctionRegex("_ASSIGN_NE", 6)
+	s = assignNeRe.ReplaceAllString(s, makeTemplateFunctionCall("Global.Right.Assign", 6))
 
 	checkColBody := makeFunctionRegex("_CHECK_COL_BODY", 12)
 	s = checkColBody.ReplaceAllString(

--- a/pkg/sql/colexec/execgen/cmd/execgen/like_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/like_ops_gen.go
@@ -57,7 +57,7 @@ func genLikeOps(wr io.Writer) error {
 		return err
 	}
 	bytesRepresentation := toPhysicalRepresentation(types.BytesFamily, anyWidth)
-	makeOverload := func(name string, rightGoType string, assignFunc func(target, l, r string) string) *twoArgsResolvedOverload {
+	makeOverload := func(name string, rightGoType string, assignFunc func(targetElem, leftElem, rightElem string) string) *twoArgsResolvedOverload {
 		base := &overloadBase{
 			Name: name,
 		}
@@ -90,8 +90,8 @@ func genLikeOps(wr io.Writer) error {
 			RetType:      types.Bool,
 			RetVecMethod: toVecMethod(types.BoolFamily, anyWidth),
 			RetGoType:    toPhysicalRepresentation(types.BoolFamily, anyWidth),
-			AssignFunc: func(_ *lastArgWidthOverload, target, l, r string) string {
-				return assignFunc(target, l, r)
+			AssignFunc: func(_ *lastArgWidthOverload, targetElem, leftElem, rightElem, _, _, _ string) string {
+				return assignFunc(targetElem, leftElem, rightElem)
 			},
 		}
 		rightTypeOverload.WidthOverloads[0] = rightWidthOverload
@@ -102,23 +102,23 @@ func genLikeOps(wr io.Writer) error {
 		}
 	}
 	overloads := []*twoArgsResolvedOverload{
-		makeOverload("Prefix", bytesRepresentation, func(target, l, r string) string {
-			return fmt.Sprintf("%s = bytes.HasPrefix(%s, %s)", target, l, r)
+		makeOverload("Prefix", bytesRepresentation, func(targetElem, leftElem, rightElem string) string {
+			return fmt.Sprintf("%s = bytes.HasPrefix(%s, %s)", targetElem, leftElem, rightElem)
 		}),
-		makeOverload("Suffix", bytesRepresentation, func(target, l, r string) string {
-			return fmt.Sprintf("%s = bytes.HasSuffix(%s, %s)", target, l, r)
+		makeOverload("Suffix", bytesRepresentation, func(targetElem, leftElem, rightElem string) string {
+			return fmt.Sprintf("%s = bytes.HasSuffix(%s, %s)", targetElem, leftElem, rightElem)
 		}),
-		makeOverload("Regexp", "*regexp.Regexp", func(target, l, r string) string {
-			return fmt.Sprintf("%s = %s.Match(%s)", target, r, l)
+		makeOverload("Regexp", "*regexp.Regexp", func(targetElem, leftElem, rightElem string) string {
+			return fmt.Sprintf("%s = %s.Match(%s)", targetElem, rightElem, leftElem)
 		}),
-		makeOverload("NotPrefix", bytesRepresentation, func(target, l, r string) string {
-			return fmt.Sprintf("%s = !bytes.HasPrefix(%s, %s)", target, l, r)
+		makeOverload("NotPrefix", bytesRepresentation, func(targetElem, leftElem, rightElem string) string {
+			return fmt.Sprintf("%s = !bytes.HasPrefix(%s, %s)", targetElem, leftElem, rightElem)
 		}),
-		makeOverload("NotSuffix", bytesRepresentation, func(target, l, r string) string {
-			return fmt.Sprintf("%s = !bytes.HasSuffix(%s, %s)", target, l, r)
+		makeOverload("NotSuffix", bytesRepresentation, func(targetElem, leftElem, rightElem string) string {
+			return fmt.Sprintf("%s = !bytes.HasSuffix(%s, %s)", targetElem, leftElem, rightElem)
 		}),
-		makeOverload("NotRegexp", "*regexp.Regexp", func(target, l, r string) string {
-			return fmt.Sprintf("%s = !%s.Match(%s)", target, r, l)
+		makeOverload("NotRegexp", "*regexp.Regexp", func(targetElem, leftElem, rightElem string) string {
+			return fmt.Sprintf("%s = !%s.Match(%s)", targetElem, rightElem, leftElem)
 		}),
 	}
 	return tmpl.Execute(wr, overloads)

--- a/pkg/sql/colexec/execgen/cmd/execgen/mergejoinbase_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/mergejoinbase_gen.go
@@ -35,8 +35,8 @@ func genMergeJoinBase(wr io.Writer) error {
 	s = strings.ReplaceAll(s, "_TYPE", "{{.VecMethod}}")
 	s = strings.ReplaceAll(s, "TemplateType", "{{.VecMethod}}")
 
-	assignEqRe := makeFunctionRegex("_ASSIGN_EQ", 3)
-	s = assignEqRe.ReplaceAllString(s, makeTemplateFunctionCall("Assign", 3))
+	assignEqRe := makeFunctionRegex("_ASSIGN_EQ", 6)
+	s = assignEqRe.ReplaceAllString(s, makeTemplateFunctionCall("Assign", 6))
 
 	s = replaceManipulationFuncs(s)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/mergejoiner_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/mergejoiner_gen.go
@@ -102,11 +102,11 @@ func genMergeJoinOps(wr io.Writer, jti joinTypeInfo) error {
 	rightSwitch := makeFunctionRegex("_RIGHT_SWITCH", 3)
 	s = rightSwitch.ReplaceAllString(s, `{{template "rightSwitch" buildDict "Global" $ "JoinType" $1 "HasSelection" $2  "HasNulls" $3}}`)
 
-	assignEqRe := makeFunctionRegex("_ASSIGN_EQ", 3)
-	s = assignEqRe.ReplaceAllString(s, makeTemplateFunctionCall("Assign", 3))
+	assignEqRe := makeFunctionRegex("_ASSIGN_EQ", 6)
+	s = assignEqRe.ReplaceAllString(s, makeTemplateFunctionCall("Assign", 6))
 
-	assignLtRe := makeFunctionRegex("_ASSIGN_CMP", 3)
-	s = assignLtRe.ReplaceAllString(s, makeTemplateFunctionCall("Compare", 3))
+	assignLtRe := makeFunctionRegex("_ASSIGN_CMP", 5)
+	s = assignLtRe.ReplaceAllString(s, makeTemplateFunctionCall("Compare", 5))
 
 	s = replaceManipulationFuncs(s)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/min_max_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/min_max_agg_gen.go
@@ -57,8 +57,8 @@ func genMinMaxAgg(wr io.Writer) error {
 	s = strings.ReplaceAll(s, "_TYPE", "{{.VecMethod}}")
 	s = strings.ReplaceAll(s, "TemplateType", "{{.VecMethod}}")
 
-	assignCmpRe := makeFunctionRegex("_ASSIGN_CMP", 3)
-	s = assignCmpRe.ReplaceAllString(s, makeTemplateFunctionCall("Assign", 3))
+	assignCmpRe := makeFunctionRegex("_ASSIGN_CMP", 6)
+	s = assignCmpRe.ReplaceAllString(s, makeTemplateFunctionCall("Assign", 6))
 
 	accumulateMinMax := makeFunctionRegex("_ACCUMULATE_MINMAX", 4)
 	s = accumulateMinMax.ReplaceAllString(s, `{{template "accumulateMinMax" buildDict "Global" . "HasNulls" $4}}`)

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_cmp.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_cmp.go
@@ -75,12 +75,12 @@ func populateCmpOpOverloads() {
 			cmpOpOutputTypes,
 			func(lawo *lastArgWidthOverload, customizer typeCustomizer) {
 				if b, ok := customizer.(cmpOpTypeCustomizer); ok {
-					lawo.AssignFunc = func(op *lastArgWidthOverload, target, l, r string) string {
-						cmp := b.getCmpOpCompareFunc()("cmpResult", l, r)
+					lawo.AssignFunc = func(op *lastArgWidthOverload, targetElem, leftElem, rightElem, targetCol, leftCol, rightCol string) string {
+						cmp := b.getCmpOpCompareFunc()("cmpResult", leftElem, rightElem, leftCol, rightCol)
 						if cmp == "" {
 							return ""
 						}
-						args := map[string]string{"Target": target, "Cmp": cmp, "Op": op.overloadBase.OpStr}
+						args := map[string]string{"Target": targetElem, "Cmp": cmp, "Op": op.overloadBase.OpStr}
 						buf := strings.Builder{}
 						t := template.Must(template.New("").Parse(`
 										{
@@ -109,8 +109,8 @@ type cmpOpTypeCustomizer interface {
 }
 
 func (boolCustomizer) getCmpOpCompareFunc() compareFunc {
-	return func(target, l, r string) string {
-		args := map[string]string{"Target": target, "Left": l, "Right": r}
+	return func(targetElem, leftElem, rightElem, leftCol, rightCol string) string {
+		args := map[string]string{"Target": targetElem, "Left": leftElem, "Right": rightElem}
 		buf := strings.Builder{}
 		// Inline the code from tree.CompareBools
 		t := template.Must(template.New("").Parse(`
@@ -131,14 +131,14 @@ func (boolCustomizer) getCmpOpCompareFunc() compareFunc {
 }
 
 func (bytesCustomizer) getCmpOpCompareFunc() compareFunc {
-	return func(target, l, r string) string {
-		return fmt.Sprintf("%s = bytes.Compare(%s, %s)", target, l, r)
+	return func(targetElem, leftElem, rightElem, leftCol, rightCol string) string {
+		return fmt.Sprintf("%s = bytes.Compare(%s, %s)", targetElem, leftElem, rightElem)
 	}
 }
 
 func (decimalCustomizer) getCmpOpCompareFunc() compareFunc {
-	return func(target, l, r string) string {
-		return fmt.Sprintf("%s = tree.CompareDecimals(&%s, &%s)", target, l, r)
+	return func(targetElem, leftElem, rightElem, leftCol, rightCol string) string {
+		return fmt.Sprintf("%s = tree.CompareDecimals(&%s, &%s)", targetElem, leftElem, rightElem)
 	}
 }
 
@@ -147,11 +147,11 @@ func (c floatCustomizer) getCmpOpCompareFunc() compareFunc {
 }
 
 func getFloatCmpOpCompareFunc(checkLeftNan, checkRightNan bool) compareFunc {
-	return func(target, l, r string) string {
+	return func(targetElem, leftElem, rightElem, leftCol, rightCol string) string {
 		args := map[string]interface{}{
-			"Target":        target,
-			"Left":          l,
-			"Right":         r,
+			"Target":        targetElem,
+			"Left":          leftElem,
+			"Right":         rightElem,
 			"CheckLeftNan":  checkLeftNan,
 			"CheckRightNan": checkRightNan}
 		buf := strings.Builder{}
@@ -189,8 +189,8 @@ func getFloatCmpOpCompareFunc(checkLeftNan, checkRightNan bool) compareFunc {
 }
 
 func (c intCustomizer) getCmpOpCompareFunc() compareFunc {
-	return func(target, l, r string) string {
-		args := map[string]string{"Target": target, "Left": l, "Right": r}
+	return func(targetElem, leftElem, rightElem, leftCol, rightCol string) string {
+		args := map[string]string{"Target": targetElem, "Left": leftElem, "Right": rightElem}
 		buf := strings.Builder{}
 		// To allow ints of different sizes to be compared, always upcast to int64.
 		t := template.Must(template.New("").Parse(`
@@ -214,8 +214,8 @@ func (c intCustomizer) getCmpOpCompareFunc() compareFunc {
 }
 
 func (c decimalFloatCustomizer) getCmpOpCompareFunc() compareFunc {
-	return func(target, l, r string) string {
-		args := map[string]string{"Target": target, "Left": l, "Right": r}
+	return func(targetElem, leftElem, rightElem, leftCol, rightCol string) string {
+		args := map[string]string{"Target": targetElem, "Left": leftElem, "Right": rightElem}
 		buf := strings.Builder{}
 		t := template.Must(template.New("").Parse(`
 			{
@@ -234,8 +234,8 @@ func (c decimalFloatCustomizer) getCmpOpCompareFunc() compareFunc {
 }
 
 func (c decimalIntCustomizer) getCmpOpCompareFunc() compareFunc {
-	return func(target, l, r string) string {
-		args := map[string]string{"Target": target, "Left": l, "Right": r}
+	return func(targetElem, leftElem, rightElem, leftCol, rightCol string) string {
+		args := map[string]string{"Target": targetElem, "Left": leftElem, "Right": rightElem}
 		buf := strings.Builder{}
 		t := template.Must(template.New("").Parse(`
 			{
@@ -252,8 +252,8 @@ func (c decimalIntCustomizer) getCmpOpCompareFunc() compareFunc {
 }
 
 func (c floatDecimalCustomizer) getCmpOpCompareFunc() compareFunc {
-	return func(target, l, r string) string {
-		args := map[string]string{"Target": target, "Left": l, "Right": r}
+	return func(targetElem, leftElem, rightElem, leftCol, rightCol string) string {
+		args := map[string]string{"Target": targetElem, "Left": leftElem, "Right": rightElem}
 		buf := strings.Builder{}
 		t := template.Must(template.New("").Parse(`
 			{
@@ -272,8 +272,8 @@ func (c floatDecimalCustomizer) getCmpOpCompareFunc() compareFunc {
 }
 
 func (c intDecimalCustomizer) getCmpOpCompareFunc() compareFunc {
-	return func(target, l, r string) string {
-		args := map[string]string{"Target": target, "Left": l, "Right": r}
+	return func(targetElem, leftElem, rightElem, leftCol, rightCol string) string {
+		args := map[string]string{"Target": targetElem, "Left": leftElem, "Right": rightElem}
 		buf := strings.Builder{}
 		t := template.Must(template.New("").Parse(`
 			{
@@ -303,8 +303,8 @@ func (c intFloatCustomizer) getCmpOpCompareFunc() compareFunc {
 }
 
 func (c timestampCustomizer) getCmpOpCompareFunc() compareFunc {
-	return func(target, l, r string) string {
-		args := map[string]string{"Target": target, "Left": l, "Right": r}
+	return func(targetElem, leftElem, rightElem, leftCol, rightCol string) string {
+		args := map[string]string{"Target": targetElem, "Left": leftElem, "Right": rightElem}
 		buf := strings.Builder{}
 		// Inline the code from tree.compareTimestamps.
 		t := template.Must(template.New("").Parse(`
@@ -324,7 +324,7 @@ func (c timestampCustomizer) getCmpOpCompareFunc() compareFunc {
 }
 
 func (c intervalCustomizer) getCmpOpCompareFunc() compareFunc {
-	return func(target, l, r string) string {
-		return fmt.Sprintf("%s = %s.Compare(%s)", target, l, r)
+	return func(targetElem, leftElem, rightElem, leftCol, rightCol string) string {
+		return fmt.Sprintf("%s = %s.Compare(%s)", targetElem, leftElem, rightElem)
 	}
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_test_utils_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_test_utils_gen.go
@@ -41,7 +41,7 @@ func {{template "opName" .}}(a {{.Left.GoType}}, b {{.Right.GoType}}) {{.Right.R
 	// However, the scratch is not used in all of the functions, so we add this
 	// to go around "unused" error.
 	_ = decimalScratch
-	{{(.Right.Assign "r" "a" "b")}}
+	{{(.Right.Assign "r" "a" "b" "" "" "")}}
 	return r
 }
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/projection_ops_gen.go
@@ -57,8 +57,8 @@ func replaceProjTmplVariables(tmpl string) string {
 	tmpl = strings.ReplaceAll(tmpl, "_R_TYP", "{{.Right.VecMethod}}")
 	tmpl = strings.ReplaceAll(tmpl, "_RET_TYP", "{{.Right.RetVecMethod}}")
 
-	assignRe := makeFunctionRegex("_ASSIGN", 3)
-	tmpl = assignRe.ReplaceAllString(tmpl, makeTemplateFunctionCall("Right.Assign", 3))
+	assignRe := makeFunctionRegex("_ASSIGN", 6)
+	tmpl = assignRe.ReplaceAllString(tmpl, makeTemplateFunctionCall("Right.Assign", 6))
 
 	tmpl = strings.ReplaceAll(tmpl, "_HAS_NULLS", "$hasNulls")
 	setProjectionRe := makeFunctionRegex("_SET_PROJECTION", 1)

--- a/pkg/sql/colexec/execgen/cmd/execgen/select_in_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/select_in_gen.go
@@ -35,8 +35,8 @@ func genSelectIn(wr io.Writer) error {
 	s = strings.ReplaceAll(s, "_TYPE", "{{.VecMethod}}")
 	s = strings.ReplaceAll(s, "TemplateType", "{{.VecMethod}}")
 
-	assignEq := makeFunctionRegex("_ASSIGN_EQ", 3)
-	s = assignEq.ReplaceAllString(s, makeTemplateFunctionCall("Assign", 3))
+	assignEq := makeFunctionRegex("_ASSIGN_EQ", 6)
+	s = assignEq.ReplaceAllString(s, makeTemplateFunctionCall("Assign", 6))
 
 	s = replaceManipulationFuncs(s)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/selection_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/selection_ops_gen.go
@@ -39,8 +39,8 @@ func getSelectionOpsTmpl() (*template.Template, error) {
 	s = strings.ReplaceAll(s, "_L_TYP", "{{.Left.VecMethod}}")
 	s = strings.ReplaceAll(s, "_R_TYP", "{{.Right.VecMethod}}")
 
-	assignCmpRe := makeFunctionRegex("_ASSIGN_CMP", 3)
-	s = assignCmpRe.ReplaceAllString(s, makeTemplateFunctionCall("Right.Assign", 3))
+	assignCmpRe := makeFunctionRegex("_ASSIGN_CMP", 6)
+	s = assignCmpRe.ReplaceAllString(s, makeTemplateFunctionCall("Right.Assign", 6))
 
 	s = replaceManipulationFuncsAmbiguous(".Left", s)
 	s = strings.ReplaceAll(s, "_R_UNSAFEGET", "execgen.UNSAFEGET")

--- a/pkg/sql/colexec/execgen/cmd/execgen/sort_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/sort_gen.go
@@ -54,8 +54,8 @@ func genSortOps(wr io.Writer) error {
 	s = strings.ReplaceAll(s, "_ISNULL", "{{$nulls}}")
 	s = strings.ReplaceAll(s, "_HANDLES_NULLS", "{{if $nulls}}WithNulls{{else}}{{end}}")
 
-	assignLtRe := makeFunctionRegex("_ASSIGN_LT", 3)
-	s = assignLtRe.ReplaceAllString(s, makeTemplateFunctionCall("Assign", 3))
+	assignLtRe := makeFunctionRegex("_ASSIGN_LT", 6)
+	s = assignLtRe.ReplaceAllString(s, makeTemplateFunctionCall("Assign", 6))
 
 	s = replaceManipulationFuncs(s)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/sum_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/sum_agg_gen.go
@@ -36,8 +36,8 @@ func genSumAgg(wr io.Writer) error {
 	s = strings.ReplaceAll(s, "_TYPE", "{{.VecMethod}}")
 	s = strings.ReplaceAll(s, "TemplateType", "{{.VecMethod}}")
 
-	assignAddRe := makeFunctionRegex("_ASSIGN_ADD", 3)
-	s = assignAddRe.ReplaceAllString(s, makeTemplateFunctionCall("Global.Assign", 3))
+	assignAddRe := makeFunctionRegex("_ASSIGN_ADD", 6)
+	s = assignAddRe.ReplaceAllString(s, makeTemplateFunctionCall("Global.Assign", 6))
 
 	accumulateSum := makeFunctionRegex("_ACCUMULATE_SUM", 4)
 	s = accumulateSum.ReplaceAllString(s, `{{template "accumulateSum" buildDict "Global" . "HasNulls" $4}}`)

--- a/pkg/sql/colexec/execgen/cmd/execgen/values_differ_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/values_differ_gen.go
@@ -35,8 +35,8 @@ func genValuesDiffer(wr io.Writer) error {
 	s = strings.ReplaceAll(s, "_TYPE", "{{.VecMethod}}")
 	s = strings.ReplaceAll(s, "TemplateType", "{{.VecMethod}}")
 
-	assignNeRe := makeFunctionRegex("_ASSIGN_NE", 3)
-	s = assignNeRe.ReplaceAllString(s, makeTemplateFunctionCall("Assign", 3))
+	assignNeRe := makeFunctionRegex("_ASSIGN_NE", 6)
+	s = assignNeRe.ReplaceAllString(s, makeTemplateFunctionCall("Assign", 6))
 
 	s = replaceManipulationFuncs(s)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/vec_comparators_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/vec_comparators_gen.go
@@ -33,8 +33,8 @@ func genVecComparators(wr io.Writer) error {
 	s = strings.ReplaceAll(s, "_GOTYPESLICE", "{{.GoTypeSliceName}}")
 	s = strings.ReplaceAll(s, "_TYPE", "{{.VecMethod}}")
 
-	compareRe := makeFunctionRegex("_COMPARE", 3)
-	s = compareRe.ReplaceAllString(s, makeTemplateFunctionCall("Compare", 3))
+	compareRe := makeFunctionRegex("_COMPARE", 5)
+	s = compareRe.ReplaceAllString(s, makeTemplateFunctionCall("Compare", 5))
 
 	s = replaceManipulationFuncs(s)
 

--- a/pkg/sql/colexec/hash_aggregator_tmpl.go
+++ b/pkg/sql/colexec/hash_aggregator_tmpl.go
@@ -55,7 +55,7 @@ const _TYPE_WIDTH = 0
 
 // _ASSIGN_NE is the template function for assigning the result of comparing
 // the second input to the third input into the first input.
-func _ASSIGN_NE(_, _, _ interface{}) int {
+func _ASSIGN_NE(_, _, _, _, _, _ interface{}) int {
 	colexecerror.InternalError("")
 }
 
@@ -142,7 +142,7 @@ func _MATCH_LOOP(
 		rhsVal := execgen.UNSAFEGET(rhsCol, rowIdx)
 
 		var cmp bool
-		_ASSIGN_NE(cmp, lhsVal, rhsVal)
+		_ASSIGN_NE(cmp, lhsVal, rhsVal, _, lhsCol, rhsCol)
 		diff[selIdx] = diff[selIdx] || cmp
 	}
 

--- a/pkg/sql/colexec/hash_utils_tmpl.go
+++ b/pkg/sql/colexec/hash_utils_tmpl.go
@@ -57,7 +57,7 @@ const _TYPE_WIDTH = 0
 
 // _ASSIGN_HASH is the template equality function for assigning the first input
 // to the result of the hash value of the second input.
-func _ASSIGN_HASH(_, _ interface{}) uint64 {
+func _ASSIGN_HASH(_, _, _, _ interface{}) uint64 {
 	colexecerror.InternalError("")
 }
 
@@ -97,7 +97,7 @@ func _REHASH_BODY(
 		// {{end}}
 		v := execgen.UNSAFEGET(keys, selIdx)
 		p := uintptr(buckets[i])
-		_ASSIGN_HASH(p, v)
+		_ASSIGN_HASH(p, v, _, keys)
 		buckets[i] = uint64(p)
 	}
 	// {{end}}

--- a/pkg/sql/colexec/hashtable_tmpl.go
+++ b/pkg/sql/colexec/hashtable_tmpl.go
@@ -58,7 +58,7 @@ const _RIGHT_TYPE_WIDTH = 0
 
 // _ASSIGN_NE is the template equality function for assigning the first input
 // to the result of the the second input != the third input.
-func _ASSIGN_NE(_, _, _ interface{}) int {
+func _ASSIGN_NE(_, _, _, _, _, _ interface{}) int {
 	colexecerror.InternalError("")
 }
 
@@ -145,7 +145,7 @@ func _CHECK_COL_BODY(
 				probeVal := _L_UNSAFEGET(probeKeys, probeIdx)
 				buildVal := _R_UNSAFEGET(buildKeys, buildIdx)
 				var unique bool
-				_ASSIGN_NE(unique, probeVal, buildVal)
+				_ASSIGN_NE(unique, probeVal, buildVal, _, probeKeys, buildKeys)
 
 				ht.probeScratch.differs[toCheck] = ht.probeScratch.differs[toCheck] || unique
 			}

--- a/pkg/sql/colexec/mergejoinbase_tmpl.go
+++ b/pkg/sql/colexec/mergejoinbase_tmpl.go
@@ -69,7 +69,7 @@ type _GOTYPE interface{}
 
 // _ASSIGN_EQ is the template equality function for assigning the first input
 // to the result of the the second input == the third input.
-func _ASSIGN_EQ(_, _, _ interface{}) int {
+func _ASSIGN_EQ(_, _, _, _, _, _ interface{}) int {
 	colexecerror.InternalError("")
 }
 
@@ -119,7 +119,7 @@ func (o *mergeJoinBase) isBufferedGroupFinished(
 				col := batch.ColVec(int(colIdx)).TemplateType()
 				curVal = execgen.UNSAFEGET(col, tupleToLookAtIdx)
 				var match bool
-				_ASSIGN_EQ(match, prevVal, curVal)
+				_ASSIGN_EQ(match, prevVal, curVal, _, bufferedCol, col)
 				if !match {
 					return true
 				}

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -71,7 +71,7 @@ const _TYPE_WIDTH = 0
 
 // _ASSIGN_EQ is the template equality function for assigning the first input
 // to the result of the second input == the third input.
-func _ASSIGN_EQ(_, _, _ interface{}) int {
+func _ASSIGN_EQ(_, _, _, _, _, _ interface{}) int {
 	colexecerror.InternalError("")
 }
 
@@ -81,7 +81,7 @@ func _ASSIGN_EQ(_, _, _ interface{}) int {
 // - negative if left < right
 // - zero if left == right
 // - positive if left > right.
-func _ASSIGN_CMP(_, _, _ interface{}) int {
+func _ASSIGN_CMP(_, _, _, _, _ interface{}) int {
 	colexecerror.VectorizedInternalPanic("")
 }
 
@@ -161,7 +161,7 @@ func _PROBE_SWITCH(
 						cmp   int
 						match bool
 					)
-					_ASSIGN_CMP(cmp, lVal, rVal)
+					_ASSIGN_CMP(cmp, lVal, rVal, lKeys, rKeys)
 					if cmp == 0 {
 						// Find the length of the groups on each side.
 						lGroupLength, rGroupLength := 1, 1
@@ -182,7 +182,7 @@ func _PROBE_SWITCH(
 								// {{end}}
 								lSelIdx := _L_SEL_IND
 								newLVal := execgen.UNSAFEGET(lKeys, lSelIdx)
-								_ASSIGN_EQ(match, newLVal, lVal)
+								_ASSIGN_EQ(match, newLVal, lVal, _, lKeys, lKeys)
 								if !match {
 									lComplete = true
 									break
@@ -206,7 +206,7 @@ func _PROBE_SWITCH(
 								// {{end}}
 								rSelIdx := _R_SEL_IND
 								newRVal := execgen.UNSAFEGET(rKeys, rSelIdx)
-								_ASSIGN_EQ(match, newRVal, rVal)
+								_ASSIGN_EQ(match, newRVal, rVal, _, rKeys, rKeys)
 								if !match {
 									rComplete = true
 									break
@@ -430,7 +430,7 @@ func _INCREMENT_LEFT_SWITCH(
 		lSelIdx = _L_SEL_IND
 		// {{with .Global}}
 		newLVal := execgen.UNSAFEGET(lKeys, lSelIdx)
-		_ASSIGN_EQ(match, newLVal, lVal)
+		_ASSIGN_EQ(match, newLVal, lVal, _, lKeys, lKeys)
 		// {{end}}
 		if !match {
 			break
@@ -484,7 +484,7 @@ func _INCREMENT_RIGHT_SWITCH(
 		rSelIdx = _R_SEL_IND
 		// {{with .Global}}
 		newRVal := execgen.UNSAFEGET(rKeys, rSelIdx)
-		_ASSIGN_EQ(match, newRVal, rVal)
+		_ASSIGN_EQ(match, newRVal, rVal, _, rKeys, rKeys)
 		// {{end}}
 		if !match {
 			break

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -76,7 +76,7 @@ const _TYPE_WIDTH = 0
 // _ASSIGN_CMP is the template function for assigning true to the first input
 // if the second input compares successfully to the third input. The comparison
 // operator is tree.LT for MIN and is tree.GT for MAX.
-func _ASSIGN_CMP(_, _, _ string) bool {
+func _ASSIGN_CMP(_, _, _, _, _, _ string) bool {
 	colexecerror.InternalError("")
 }
 
@@ -249,7 +249,7 @@ func _ACCUMULATE_MINMAX(a *_AGG_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS
 		} else {
 			var cmp bool
 			candidate := execgen.UNSAFEGET(col, i)
-			_ASSIGN_CMP(cmp, candidate, a.curAgg)
+			_ASSIGN_CMP(cmp, candidate, a.curAgg, _, col, _)
 			if cmp {
 				execgen.COPYVAL(a.curAgg, candidate)
 			}

--- a/pkg/sql/colexec/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_const_ops_tmpl.go
@@ -79,7 +79,7 @@ type _NON_CONST_GOTYPESLICE interface{}
 
 // _ASSIGN is the template function for assigning the first input to the result
 // of computation an operation on the second and the third inputs.
-func _ASSIGN(_, _, _ interface{}) {
+func _ASSIGN(_, _, _, _, _, _ interface{}) {
 	colexecerror.InternalError("")
 }
 
@@ -188,9 +188,9 @@ func _SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS bool) { // */}}
 		// {{end}}
 		arg := execgen.UNSAFEGET(col, i)
 		// {{if _IS_CONST_LEFT}}
-		_ASSIGN(projCol[i], p.constArg, arg)
+		_ASSIGN(projCol[i], p.constArg, arg, projCol, _, col)
 		// {{else}}
-		_ASSIGN(projCol[i], arg, p.constArg)
+		_ASSIGN(projCol[i], arg, p.constArg, projCol, col, _)
 		// {{end}}
 		// {{if _HAS_NULLS}}
 	}

--- a/pkg/sql/colexec/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_non_const_ops_tmpl.go
@@ -68,7 +68,7 @@ const _RIGHT_TYPE_WIDTH = 0
 
 // _ASSIGN is the template function for assigning the first input to the result
 // of computation an operation on the second and the third inputs.
-func _ASSIGN(_, _, _ interface{}) {
+func _ASSIGN(_, _, _, _, _, _ interface{}) {
 	colexecerror.InternalError("")
 }
 
@@ -213,7 +213,7 @@ func _SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS bool) { // */}}
 		// {{end}}
 		arg1 := _L_UNSAFEGET(col1, i)
 		arg2 := _R_UNSAFEGET(col2, i)
-		_ASSIGN(projCol[i], arg1, arg2)
+		_ASSIGN(projCol[i], arg1, arg2, projCol, col1, col2)
 		// {{if _HAS_NULLS}}
 	}
 	// {{end}}

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -70,7 +70,7 @@ const _CANONICAL_TYPE_FAMILY = types.UnknownFamily
 // _TYPE_WIDTH is the template variable.
 const _TYPE_WIDTH = 0
 
-func _ASSIGN_EQ(_, _, _ interface{}) int {
+func _ASSIGN_EQ(_, _, _, _, _, _ interface{}) int {
 	colexecerror.InternalError("")
 }
 
@@ -195,7 +195,7 @@ func fillDatumRow_TYPE(t *types.T, datumTuple *tree.DTuple) ([]_GOTYPE, bool, er
 func cmpIn_TYPE(target _GOTYPE, filterRow []_GOTYPE, hasNulls bool) comparisonResult {
 	for i := range filterRow {
 		var cmp bool
-		_ASSIGN_EQ(cmp, target, filterRow[i])
+		_ASSIGN_EQ(cmp, target, filterRow[i], _, _, _)
 		if cmp {
 			return siTrue
 		}

--- a/pkg/sql/colexec/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/selection_ops_tmpl.go
@@ -75,7 +75,7 @@ const _RIGHT_TYPE_WIDTH = 0
 
 // _ASSIGN_CMP is the template function for assigning the result of comparing
 // the second input to the third input into the first input.
-func _ASSIGN_CMP(_, _, _ interface{}) int {
+func _ASSIGN_CMP(_, _, _, _, _, _ interface{}) int {
 	colexecerror.InternalError("")
 }
 
@@ -91,7 +91,7 @@ func _SEL_CONST_LOOP(_HAS_NULLS bool) { // */}}
 		for _, i := range sel {
 			var cmp bool
 			arg := execgen.UNSAFEGET(col, i)
-			_ASSIGN_CMP(cmp, arg, p.constArg)
+			_ASSIGN_CMP(cmp, arg, p.constArg, _, col, _)
 			// {{if _HAS_NULLS}}
 			isNull = nulls.NullAt(i)
 			// {{else}}
@@ -109,7 +109,7 @@ func _SEL_CONST_LOOP(_HAS_NULLS bool) { // */}}
 		for execgen.RANGE(i, col, 0, n) {
 			var cmp bool
 			arg := execgen.UNSAFEGET(col, i)
-			_ASSIGN_CMP(cmp, arg, p.constArg)
+			_ASSIGN_CMP(cmp, arg, p.constArg, _, col, _)
 			// {{if _HAS_NULLS}}
 			isNull = nulls.NullAt(i)
 			// {{else}}
@@ -137,7 +137,7 @@ func _SEL_LOOP(_HAS_NULLS bool) { // */}}
 			var cmp bool
 			arg1 := execgen.UNSAFEGET(col1, i)
 			arg2 := _R_UNSAFEGET(col2, i)
-			_ASSIGN_CMP(cmp, arg1, arg2)
+			_ASSIGN_CMP(cmp, arg1, arg2, _, col1, col2)
 			// {{if _HAS_NULLS}}
 			isNull = nulls.NullAt(i)
 			// {{else}}
@@ -163,7 +163,7 @@ func _SEL_LOOP(_HAS_NULLS bool) { // */}}
 			var cmp bool
 			arg1 := execgen.UNSAFEGET(col1, i)
 			arg2 := _R_UNSAFEGET(col2, i)
-			_ASSIGN_CMP(cmp, arg1, arg2)
+			_ASSIGN_CMP(cmp, arg1, arg2, _, col1, col2)
 			// {{if _HAS_NULLS}}
 			isNull = nulls.NullAt(i)
 			// {{else}}

--- a/pkg/sql/colexec/sort_tmpl.go
+++ b/pkg/sql/colexec/sort_tmpl.go
@@ -80,7 +80,7 @@ const _ISNULL = false
 
 // _ASSIGN_LT is the template equality function for assigning the first input
 // to the result of the second input < the third input.
-func _ASSIGN_LT(_, _, _ string) bool {
+func _ASSIGN_LT(_, _, _, _, _, _ string) bool {
 	colexecerror.InternalError("")
 }
 
@@ -212,7 +212,7 @@ func (s *sort_TYPE_DIR_HANDLES_NULLSOp) Less(i, j int) bool {
 	// We always indirect via the order vector.
 	arg1 := execgen.UNSAFEGET(s.sortCol, s.order[i])
 	arg2 := execgen.UNSAFEGET(s.sortCol, s.order[j])
-	_ASSIGN_LT(lt, arg1, arg2)
+	_ASSIGN_LT(lt, arg1, arg2, _, s.sortCol, s.sortCol)
 	return lt
 }
 

--- a/pkg/sql/colexec/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/sum_agg_tmpl.go
@@ -53,7 +53,7 @@ const _TYPE_WIDTH = 0
 
 // _ASSIGN_ADD is the template addition function for assigning the first input
 // to the result of the second input + the third input.
-func _ASSIGN_ADD(_, _, _ string) {
+func _ASSIGN_ADD(_, _, _, _, _, _ string) {
 	colexecerror.InternalError("")
 }
 
@@ -212,7 +212,7 @@ func _ACCUMULATE_SUM(a *sum_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS boo
 	isNull = false
 	// {{end}}
 	if !isNull {
-		_ASSIGN_ADD(a.scratch.curAgg, a.scratch.curAgg, col[i])
+		_ASSIGN_ADD(a.scratch.curAgg, a.scratch.curAgg, col[i], _, _, col)
 		a.scratch.foundNonNullForCurrentGroup = true
 	}
 	// {{end}}

--- a/pkg/sql/colexec/values_differ_tmpl.go
+++ b/pkg/sql/colexec/values_differ_tmpl.go
@@ -58,7 +58,7 @@ const _TYPE_WIDTH = 0
 
 // _ASSIGN_NE is the template equality function for assigning the first input
 // to the result of the second input != the third input.
-func _ASSIGN_NE(_, _, _ string) bool {
+func _ASSIGN_NE(_, _, _, _, _, _ string) bool {
 	colexecerror.InternalError("")
 }
 
@@ -88,7 +88,7 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			arg1 := execgen.UNSAFEGET(aCol, aValueIdx)
 			arg2 := execgen.UNSAFEGET(bCol, bValueIdx)
 			var unique bool
-			_ASSIGN_NE(unique, arg1, arg2)
+			_ASSIGN_NE(unique, arg1, arg2, _, aCol, bCol)
 			return unique
 			// {{end}}
 		}

--- a/pkg/sql/colexec/vec_comparators_tmpl.go
+++ b/pkg/sql/colexec/vec_comparators_tmpl.go
@@ -71,7 +71,7 @@ const _TYPE_WIDTH = 0
 
 // _COMPARE is the template equality function for assigning the first input
 // to the result of comparing second and third inputs.
-func _COMPARE(_, _, _ string) bool {
+func _COMPARE(_, _, _, _, _ string) bool {
 	colexecerror.InternalError("")
 }
 
@@ -116,7 +116,7 @@ func (c *_TYPEVecComparator) compare(vecIdx1, vecIdx2 int, valIdx1, valIdx2 int)
 	left := execgen.UNSAFEGET(c.vecs[vecIdx1], valIdx1)
 	right := execgen.UNSAFEGET(c.vecs[vecIdx2], valIdx2)
 	var cmp int
-	_COMPARE(cmp, left, right)
+	_COMPARE(cmp, left, right, c.vecs[vecIdx1], c.vecs[vecIdx2])
 	return cmp
 }
 


### PR DESCRIPTION
This commit changes signatures of `assignFunc` and `compareFunc` that we
use during the code generation to include variable names for the
"columns" of elements that the functions operate on. Previously, those
would only include variable names of "elements". This will be helpful in
the follow-up work on datum-backed vector.

Release note: None