### PR TITLE
release-20.1: server,gossip/resolver,cli: gate the SRV lookups under a new flag

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -369,6 +369,17 @@ or both forms can be used together, for example:
 </PRE>`,
 	}
 
+	JoinPreferSRVRecords = FlagInfo{
+		Name: "experimental-dns-srv",
+		Description: `
+When enabled, the node will first attempt to fetch SRV records
+from DNS for every name specified with --join. If a valid
+SRV record is found, that information is used instead
+of regular DNS A/AAAA lookups.
+This feature is experimental and may be removed or modified
+in a later version.`,
+	}
+
 	ListenAddr = FlagInfo{
 		Name: "listen-addr",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -113,6 +113,7 @@ func initCLIDefaults() {
 	serverCfg.DelayedBootstrapFn = nil
 	serverCfg.SocketFile = ""
 	serverCfg.JoinList = nil
+	serverCfg.JoinPreferSRVRecords = false
 	serverCfg.DefaultZoneConfig = zonepb.DefaultZoneConfig()
 	serverCfg.DefaultSystemZoneConfig = zonepb.DefaultSystemZoneConfig()
 	// Attempt to default serverCfg.SQLMemoryPoolSize to 25% if possible.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -390,6 +390,7 @@ func init() {
 		// --join, because it delegates its logic to that of 'start', and
 		// 'start' will check that the flag is properly defined.
 		VarFlag(f, &serverCfg.JoinList, cliflags.Join)
+		BoolFlag(f, &serverCfg.JoinPreferSRVRecords, cliflags.JoinPreferSRVRecords, serverCfg.JoinPreferSRVRecords)
 		VarFlag(f, clusterNameSetter{&baseCfg.ClusterName}, cliflags.ClusterName)
 		BoolFlag(f, &baseCfg.DisableClusterNameVerification,
 			cliflags.DisableClusterNameVerification, baseCfg.DisableClusterNameVerification)

--- a/pkg/gossip/resolver/resolver.go
+++ b/pkg/gossip/resolver/resolver.go
@@ -23,10 +23,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	lookupSRV = net.LookupSRV
-)
-
 // Resolver is an interface which provides an abstract factory for
 // net.Addr addresses. Resolvers are not thread safe.
 type Resolver interface {
@@ -116,4 +112,18 @@ func ensureHostPort(addr string, defaultPort string) string {
 	}
 
 	return net.JoinHostPort(host, port)
+}
+
+var (
+	lookupSRV = net.LookupSRV
+)
+
+// TestingOverrideSRVLookupFn enables a test to temporarily override
+// the SRV lookup function.
+func TestingOverrideSRVLookupFn(
+	fn func(service, proto, name string) (cname string, addrs []*net.SRV, err error),
+) func() {
+	prevFn := lookupSRV
+	lookupSRV = fn
+	return func() { lookupSRV = prevFn }
 }

--- a/pkg/gossip/resolver/resolver_test.go
+++ b/pkg/gossip/resolver/resolver_test.go
@@ -135,16 +135,17 @@ func TestSRV(t *testing.T) {
 	}
 
 	for tcNum, tc := range testCases {
-		lookupSRV = tc.lookuper
+		func() {
+			defer TestingOverrideSRVLookupFn(tc.lookuper)()
 
-		resolvers, err := SRV(context.TODO(), tc.address)
+			resolvers, err := SRV(context.TODO(), tc.address)
 
-		if err != nil {
-			t.Errorf("#%d: expected success, got err=%v", tcNum, err)
-		}
+			if err != nil {
+				t.Errorf("#%d: expected success, got err=%v", tcNum, err)
+			}
 
-		require.Equal(t, tc.want, resolvers, "Test #%d failed", tcNum)
+			require.Equal(t, tc.want, resolvers, "Test #%d failed", tcNum)
 
-		lookupSRV = net.LookupSRV
+		}()
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #49077.

/cc @cockroachdb/release

---
