### PR TITLE
release-20.1: backupccl,sql: do not include comments in SHOW BACKUP SCHEMAS

### DIFF
--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -226,7 +226,11 @@ func backupShowerDefault(
 							tree.MakeDBool(manifest.DescriptorCoverage == tree.AllDescriptors),
 						}
 						if showSchemas {
-							schema, err := p.ShowCreate(ctx, dbName, manifest.Descriptors, table, sql.OmitMissingFKClausesFromCreate)
+							displayOptions := sql.ShowCreateDisplayOptions{
+								FKDisplayMode:  sql.OmitMissingFKClausesFromCreate,
+								IgnoreComments: true,
+							}
+							schema, err := p.ShowCreate(ctx, dbName, manifest.Descriptors, table, displayOptions)
 							if err != nil {
 								continue
 							}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1407,14 +1407,18 @@ CREATE TABLE crdb_internal.create_statements (
 				} else {
 					descType = typeTable
 					tn := (*tree.Name)(&table.Name)
-					createNofk, err = ShowCreateTable(ctx, p, tn, contextName, table, lCtx, OmitFKClausesFromCreate)
+					displayOptions := ShowCreateDisplayOptions{
+						FKDisplayMode: OmitFKClausesFromCreate,
+					}
+					createNofk, err = ShowCreateTable(ctx, p, tn, contextName, table, lCtx, displayOptions)
 					if err != nil {
 						return err
 					}
 					if err := showAlterStatementWithInterleave(ctx, tn, contextName, lCtx, table.Indexes, table, alterStmts, validateStmts); err != nil {
 						return err
 					}
-					stmt, err = ShowCreateTable(ctx, p, tn, contextName, table, lCtx, IncludeFkClausesInCreate)
+					displayOptions.FKDisplayMode = IncludeFkClausesInCreate
+					stmt, err = ShowCreateTable(ctx, p, tn, contextName, table, lCtx, displayOptions)
 				}
 				if err != nil {
 					return err

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -92,7 +92,7 @@ type PlanHookState interface {
 		ctx context.Context, tn *ObjectName, required bool, requiredType ResolveRequiredType,
 	) (table *MutableTableDescriptor, err error)
 	ShowCreate(
-		ctx context.Context, dbPrefix string, allDescs []sqlbase.Descriptor, desc *sqlbase.TableDescriptor, ignoreFKs shouldOmitFKClausesFromCreate,
+		ctx context.Context, dbPrefix string, allDescs []sqlbase.Descriptor, desc *sqlbase.TableDescriptor, displayOptions ShowCreateDisplayOptions,
 	) (string, error)
 }
 

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -37,6 +37,19 @@ const (
 	OmitMissingFKClausesFromCreate
 )
 
+// ShowCreateDisplayOptions is a container struct holding the options that
+// ShowCreate uses to determine how much information should be included in the
+// CREATE statement.
+type ShowCreateDisplayOptions struct {
+	FKDisplayMode shouldOmitFKClausesFromCreate
+	// Comment resolution requires looking up table data from system.comments
+	// table. This is sometimes not possible. For example, in the context of a
+	// SHOW BACKUP which may resolve the create statement, there is no mechanism
+	// to read any table data from the backup (nor is there a guarantee that the
+	// system.comments table is included in the backup at all).
+	IgnoreComments bool
+}
+
 // ShowCreateTable returns a valid SQL representation of the CREATE
 // TABLE statement used to create the given table.
 //
@@ -52,7 +65,7 @@ func ShowCreateTable(
 	dbPrefix string,
 	desc *sqlbase.TableDescriptor,
 	lCtx *internalLookupCtx,
-	fkDisplayMode shouldOmitFKClausesFromCreate,
+	displayOptions ShowCreateDisplayOptions,
 ) (string, error) {
 	a := &sqlbase.DatumAlloc{}
 
@@ -88,7 +101,7 @@ func ShowCreateTable(
 	}
 	// TODO (lucy): Possibly include FKs in the mutations list here, or else
 	// exclude check mutations below, for consistency.
-	if fkDisplayMode != OmitFKClausesFromCreate {
+	if displayOptions.FKDisplayMode != OmitFKClausesFromCreate {
 		for i := range desc.OutboundFKs {
 			fkCtx := tree.NewFmtCtx(tree.FmtSimple)
 			fk := &desc.OutboundFKs[i]
@@ -96,9 +109,9 @@ func ShowCreateTable(
 			fkCtx.FormatNameP(&fk.Name)
 			fkCtx.WriteString(" ")
 			if err := showForeignKeyConstraint(&fkCtx.Buffer, dbPrefix, desc, fk, lCtx); err != nil {
-				if fkDisplayMode == OmitMissingFKClausesFromCreate {
+				if displayOptions.FKDisplayMode == OmitMissingFKClausesFromCreate {
 					continue
-				} else { // When fkDisplayMode == IncludeFkClausesInCreate.
+				} else { // When FKDisplayMode == IncludeFkClausesInCreate.
 					return "", err
 				}
 			}
@@ -114,7 +127,7 @@ func ShowCreateTable(
 		// Initialize to false if Interleave has no ancestors, indicating that the
 		// index is not interleaved at all.
 		includeInterleaveClause := len(idx.Interleave.Ancestors) == 0
-		if fkDisplayMode != OmitFKClausesFromCreate {
+		if displayOptions.FKDisplayMode != OmitFKClausesFromCreate {
 			// The caller is instructing us to not omit FK clauses from inside the CREATE.
 			// (i.e. the caller does not want them as separate DDL.)
 			// Since we're including FK clauses, we need to also include the PARTITION and INTERLEAVE
@@ -156,8 +169,10 @@ func ShowCreateTable(
 		return "", err
 	}
 
-	if err := showComments(desc, selectComment(ctx, p, desc.ID), &f.Buffer); err != nil {
-		return "", err
+	if !displayOptions.IgnoreComments {
+		if err := showComments(desc, selectComment(ctx, p, desc.ID), &f.Buffer); err != nil {
+			return "", err
+		}
 	}
 
 	return f.CloseAndGetString(), nil
@@ -188,7 +203,7 @@ func (p *planner) ShowCreate(
 	dbPrefix string,
 	allDescs []sqlbase.Descriptor,
 	desc *sqlbase.TableDescriptor,
-	ignoreFKs shouldOmitFKClausesFromCreate,
+	displayOptions ShowCreateDisplayOptions,
 ) (string, error) {
 	var stmt string
 	var err error
@@ -199,7 +214,7 @@ func (p *planner) ShowCreate(
 		stmt, err = ShowCreateSequence(ctx, tn, desc)
 	} else {
 		lCtx := newInternalLookupCtxFromDescriptors(allDescs, nil /* want all tables */)
-		stmt, err = ShowCreateTable(ctx, p, tn, dbPrefix, desc, lCtx, ignoreFKs)
+		stmt, err = ShowCreateTable(ctx, p, tn, dbPrefix, desc, lCtx, displayOptions)
 	}
 
 	return stmt, err


### PR DESCRIPTION
Backport 1/1 commits from #48167.

/cc @cockroachdb/release

---

SHOW BACKUP SCHEMAS shows all of the tables in the backup and the SHOW
CREATE TABLE statement of the associated table, using ShowCreate.
ShowCreate includes the comments on the table, but this requires reading
table data from outside the lookup scope of ShowCreate. To show the
comments on a particular table, the comments need to be read from the
system.comments table, which poses 2 difficulties:

1. The system.comments data may not be present in the backup at all.
2. There currently is no way to read this data from a backup even if it
were included.

To address this, the display options for ShowCreate were expanded to
include a flag indicating whether or not comments should be ignored.

Previously, the SHOW BACKUP testing structure did not exercise that
SHOW BACKUP may be run on a different cluster than the one issuing the
backup. This commit updates the testing to ensure that the SHOW BACKUP
commands are run on a new cluster to ensure that the command does not
reference data outside of the BACKUP file.

Release note (bug fix): SHOW BACKUP SCHEMAS no longer shows
table comments as they may be inaccurate.
