### PR TITLE
opt: allow join filter FDs to be used in determining a left join key

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1965,10 +1965,16 @@ func (h *joinPropsHelper) setFuncDeps(rel *props.Relational) {
 			addOuterColsToFuncDep(rel.OuterCols, &rel.FuncDeps)
 
 		case opt.LeftJoinOp, opt.LeftJoinApplyOp:
-			rel.FuncDeps.MakeLeftOuter(h.rightProps.OutputCols, notNullInputCols)
+			rel.FuncDeps.MakeLeftOuter(
+				&h.leftProps.FuncDeps, &h.filtersFD,
+				h.leftProps.OutputCols, h.rightProps.OutputCols, notNullInputCols,
+			)
 
 		case opt.RightJoinOp:
-			rel.FuncDeps.MakeLeftOuter(h.leftProps.OutputCols, notNullInputCols)
+			rel.FuncDeps.MakeLeftOuter(
+				&h.rightProps.FuncDeps, &h.filtersFD,
+				h.rightProps.OutputCols, h.leftProps.OutputCols, notNullInputCols,
+			)
 
 		case opt.FullJoinOp:
 			rel.FuncDeps.MakeFullOuter(h.leftProps.OutputCols, h.rightProps.OutputCols, notNullInputCols)

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -317,8 +317,8 @@ SELECT *, rowid FROM xysd RIGHT JOIN uv ON x=u
 ----
 right-join (hash)
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int!null) rowid:7(int!null)
- ├── key: (1,7)
- ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
+ ├── key: (7)
+ ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(1-6)
  ├── prune: (2-4,6,7)
  ├── reject-nulls: (1-4)
  ├── interesting orderings: (+1) (-3,+4,+1) (+7)
@@ -1372,8 +1372,8 @@ right-join (merge)
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int!null) rowid:7(int!null)
  ├── left ordering: +1
  ├── right ordering: +5
- ├── key: (1,7)
- ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
+ ├── key: (7)
+ ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(1-6)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  │    ├── key: (1)

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -269,8 +269,8 @@ project
            │         │    │    │         ├── left-join (hash)
            │         │    │    │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:14(int) b:15(int) c:16(int) rowid:17(int)
            │         │    │    │         │    ├── side-effects
-           │         │    │    │         │    ├── key: (5,17)
-           │         │    │    │         │    ├── fd: (5)-->(6,8), (6)-->(9), (8)~~>(5,6,9), (17)-->(14-16), (14)-->(15-17), (15,16)~~>(14,17)
+           │         │    │    │         │    ├── key: (5)
+           │         │    │    │         │    ├── fd: (5)-->(6,8,14-17), (6)-->(9), (8)~~>(5,6,9), (17)-->(14-16), (14)-->(15-17), (15,16)~~>(14,17)
            │         │    │    │         │    ├── prune: (15-17)
            │         │    │    │         │    ├── reject-nulls: (14-17)
            │         │    │    │         │    ├── interesting orderings: (+17) (+14) (+15,+16,+17)
@@ -297,8 +297,8 @@ project
            │         │    │    │         │    │    │         ├── left-join (hash)
            │         │    │    │         │    │    │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
            │         │    │    │         │    │    │         │    ├── side-effects
-           │         │    │    │         │    │    │         │    ├── key: (5,13)
-           │         │    │    │         │    │    │         │    ├── fd: (5)-->(6,8), (6)-->(9), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
+           │         │    │    │         │    │    │         │    ├── key: (5)
+           │         │    │    │         │    │    │         │    ├── fd: (5)-->(6,8,10-13), (6)-->(9), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
            │         │    │    │         │    │    │         │    ├── prune: (5,6,9-12)
            │         │    │    │         │    │    │         │    ├── reject-nulls: (10-13)
            │         │    │    │         │    │    │         │    ├── interesting orderings: (+5) (+6) (+13) (+10) (+11,+12,+13)
@@ -585,32 +585,32 @@ upsert abc
  └── project
       ├── columns: upsert_a:17(int) upsert_b:18(int!null) upsert_c:19(int!null) upsert_rowid:20(int) y:6(int!null) column8:8(int!null) column9:9(int) column10:10(int!null) a:11(int) b:12(int) c:13(int) rowid:14(int) column15:15(int!null) column16:16(int!null)
       ├── side-effects
-      ├── key: (6,14)
-      ├── fd: ()-->(8,10,15,16), (6)-->(9), (14)-->(11-13), (11)-->(12-14), (12,13)~~>(11,14), (6,11,14)-->(17), (14)-->(18), (14)-->(19), (9,14)-->(20)
+      ├── key: (6)
+      ├── fd: ()-->(8,10,15,16), (6)-->(9,11-14), (14)-->(11-13), (11)-->(12-14), (12,13)~~>(11,14), (6,11,14)-->(17), (14)-->(18), (14)-->(19), (9,14)-->(20)
       ├── prune: (6,8-20)
       ├── reject-nulls: (11-14)
       ├── interesting orderings: (+14) (+11) (+12,+13,+14)
       ├── project
       │    ├── columns: column16:16(int!null) y:6(int!null) column8:8(int!null) column9:9(int) column10:10(int!null) a:11(int) b:12(int) c:13(int) rowid:14(int) column15:15(int!null)
       │    ├── side-effects
-      │    ├── key: (6,14)
-      │    ├── fd: ()-->(8,10,15,16), (6)-->(9), (14)-->(11-13), (11)-->(12-14), (12,13)~~>(11,14)
+      │    ├── key: (6)
+      │    ├── fd: ()-->(8,10,15,16), (6)-->(9,11-14), (14)-->(11-13), (11)-->(12-14), (12,13)~~>(11,14)
       │    ├── prune: (6,8-16)
       │    ├── reject-nulls: (11-14)
       │    ├── interesting orderings: (+14) (+11) (+12,+13,+14)
       │    ├── project
       │    │    ├── columns: column15:15(int!null) y:6(int!null) column8:8(int!null) column9:9(int) column10:10(int!null) a:11(int) b:12(int) c:13(int) rowid:14(int)
       │    │    ├── side-effects
-      │    │    ├── key: (6,14)
-      │    │    ├── fd: ()-->(8,10,15), (6)-->(9), (14)-->(11-13), (11)-->(12-14), (12,13)~~>(11,14)
+      │    │    ├── key: (6)
+      │    │    ├── fd: ()-->(8,10,15), (6)-->(9,11-14), (14)-->(11-13), (11)-->(12-14), (12,13)~~>(11,14)
       │    │    ├── prune: (6,8-15)
       │    │    ├── reject-nulls: (11-14)
       │    │    ├── interesting orderings: (+14) (+11) (+12,+13,+14)
       │    │    ├── left-join (hash)
       │    │    │    ├── columns: y:6(int!null) column8:8(int!null) column9:9(int) column10:10(int!null) a:11(int) b:12(int) c:13(int) rowid:14(int)
       │    │    │    ├── side-effects
-      │    │    │    ├── key: (6,14)
-      │    │    │    ├── fd: ()-->(8,10), (6)-->(9), (14)-->(11-13), (11)-->(12-14), (12,13)~~>(11,14)
+      │    │    │    ├── key: (6)
+      │    │    │    ├── fd: ()-->(8,10), (6)-->(9,11-14), (14)-->(11-13), (11)-->(12-14), (12,13)~~>(11,14)
       │    │    │    ├── prune: (12-14)
       │    │    │    ├── reject-nulls: (11-14)
       │    │    │    ├── interesting orderings: (+14) (+11) (+12,+13,+14)

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -138,8 +138,8 @@ SELECT *, rowid FROM xysd RIGHT JOIN uv ON x=u
 right-join (hash)
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int!null) rowid:7(int!null)
  ├── stats: [rows=10000, distinct(1)=500, null(1)=0]
- ├── key: (1,7)
- ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
+ ├── key: (7)
+ ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(1-6)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0]
@@ -719,8 +719,8 @@ SELECT *, rowid FROM xysd RIGHT JOIN uv ON x=u
 right-join (hash)
  ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int!null) rowid:7(int!null)
  ├── stats: [rows=10000, distinct(1)=500, null(1)=0, distinct(2)=400, null(2)=5000, distinct(3)=499.999999, null(3)=100, distinct(5)=500, null(5)=5000, distinct(2,3)=4323.45892, null(2,3)=50, distinct(3,5)=10000, null(3,5)=50, distinct(1,2,7)=10000, null(1,2,7)=0]
- ├── key: (1,7)
- ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(5,6)
+ ├── key: (7)
+ ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (7)-->(1-6)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(1,2)=5000, null(1,2)=0, distinct(2,3)=5000, null(2,3)=25]

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -1781,8 +1781,8 @@ TryDecorrelateProjectSelect
   - │    │    │    │         ├── left-join-apply
   + │    │    │    │         ├── project
     │    │    │    │         │    ├── columns: x:1!null notnull:9
-  - │    │    │    │         │    ├── key: (1)
-  - │    │    │    │         │    ├── fd: (1)-->(9)
+    │    │    │    │         │    ├── key: (1)
+    │    │    │    │         │    ├── fd: (1)-->(9)
   - │    │    │    │         │    ├── scan xy
   - │    │    │    │         │    │    ├── columns: x:1!null
   - │    │    │    │         │    │    └── key: (1)
@@ -1810,8 +1810,8 @@ TryDecorrelateProjectSelect
   - │    │    │    │         │    └── filters (true)
   + │    │    │    │         │    └── left-join-apply
   + │    │    │    │         │         ├── columns: x:1!null k:3 i:4 notnull:9
-  + │    │    │    │         │         ├── key: (1,3)
-  + │    │    │    │         │         ├── fd: (1,3)-->(4,9)
+  + │    │    │    │         │         ├── key: (1)
+  + │    │    │    │         │         ├── fd: (1)-->(3,4,9)
   + │    │    │    │         │         ├── scan xy
   + │    │    │    │         │         │    ├── columns: x:1!null
   + │    │    │    │         │         │    └── key: (1)
@@ -1866,12 +1866,14 @@ DecorrelateJoin
     │    │    │    │         ├── fd: (1)-->(10)
     │    │    │    │         ├── project
     │    │    │    │         │    ├── columns: x:1!null notnull:9
+    │    │    │    │         │    ├── key: (1)
+    │    │    │    │         │    ├── fd: (1)-->(9)
   - │    │    │    │         │    └── left-join-apply
   + │    │    │    │         │    └── left-join (hash)
     │    │    │    │         │         ├── columns: x:1!null k:3 i:4 notnull:9
-    │    │    │    │         │         ├── key: (1,3)
-  - │    │    │    │         │         ├── fd: (1,3)-->(4,9)
-  + │    │    │    │         │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
+    │    │    │    │         │         ├── key: (1)
+  - │    │    │    │         │         ├── fd: (1)-->(3,4,9)
+  + │    │    │    │         │         ├── fd: (3)-->(4), (4)~~>(9), (1)-->(3,4,9)
     │    │    │    │         │         ├── scan xy
     │    │    │    │         │         │    ├── columns: x:1!null
     │    │    │    │         │         │    └── key: (1)
@@ -1926,10 +1928,12 @@ PushFilterIntoJoinRight
     │    │    │    │         ├── fd: (1)-->(10)
     │    │    │    │         ├── project
     │    │    │    │         │    ├── columns: x:1!null notnull:9
+    │    │    │    │         │    ├── key: (1)
+    │    │    │    │         │    ├── fd: (1)-->(9)
     │    │    │    │         │    └── left-join (hash)
     │    │    │    │         │         ├── columns: x:1!null k:3 i:4 notnull:9
-    │    │    │    │         │         ├── key: (1,3)
-    │    │    │    │         │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
+    │    │    │    │         │         ├── key: (1)
+    │    │    │    │         │         ├── fd: (3)-->(4), (4)~~>(9), (1)-->(3,4,9)
     │    │    │    │         │         ├── scan xy
     │    │    │    │         │         │    ├── columns: x:1!null
     │    │    │    │         │         │    └── key: (1)
@@ -1998,10 +2002,12 @@ PushSelectIntoProject
     │    │    │    │         ├── fd: (1)-->(10)
     │    │    │    │         ├── project
     │    │    │    │         │    ├── columns: x:1!null notnull:9
+    │    │    │    │         │    ├── key: (1)
+    │    │    │    │         │    ├── fd: (1)-->(9)
     │    │    │    │         │    └── left-join (hash)
     │    │    │    │         │         ├── columns: x:1!null k:3 i:4 notnull:9
-    │    │    │    │         │         ├── key: (1,3)
-    │    │    │    │         │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
+    │    │    │    │         │         ├── key: (1)
+    │    │    │    │         │         ├── fd: (3)-->(4), (4)~~>(9), (1)-->(3,4,9)
     │    │    │    │         │         ├── scan xy
     │    │    │    │         │         │    ├── columns: x:1!null
     │    │    │    │         │         │    └── key: (1)
@@ -2070,10 +2076,12 @@ EliminateSelect
     │    │    │    │         ├── fd: (1)-->(10)
     │    │    │    │         ├── project
     │    │    │    │         │    ├── columns: x:1!null notnull:9
+    │    │    │    │         │    ├── key: (1)
+    │    │    │    │         │    ├── fd: (1)-->(9)
     │    │    │    │         │    └── left-join (hash)
     │    │    │    │         │         ├── columns: x:1!null k:3 i:4 notnull:9
-    │    │    │    │         │         ├── key: (1,3)
-    │    │    │    │         │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
+    │    │    │    │         │         ├── key: (1)
+    │    │    │    │         │         ├── fd: (3)-->(4), (4)~~>(9), (1)-->(3,4,9)
     │    │    │    │         │         ├── scan xy
     │    │    │    │         │         │    ├── columns: x:1!null
     │    │    │    │         │         │    └── key: (1)
@@ -2149,12 +2157,14 @@ PruneJoinRightCols
     │    │    │    │         ├── fd: (1)-->(10)
     │    │    │    │         ├── project
     │    │    │    │         │    ├── columns: x:1!null notnull:9
+    │    │    │    │         │    ├── key: (1)
+    │    │    │    │         │    ├── fd: (1)-->(9)
     │    │    │    │         │    └── left-join (hash)
   - │    │    │    │         │         ├── columns: x:1!null k:3 i:4 notnull:9
   + │    │    │    │         │         ├── columns: x:1!null k:3 notnull:9
-    │    │    │    │         │         ├── key: (1,3)
-  - │    │    │    │         │         ├── fd: (3)-->(4), (4)~~>(9), (1,3)-->(9)
-  + │    │    │    │         │         ├── fd: (3)-->(9)
+    │    │    │    │         │         ├── key: (1)
+  - │    │    │    │         │         ├── fd: (3)-->(4), (4)~~>(9), (1)-->(3,4,9)
+  + │    │    │    │         │         ├── fd: (3)-->(9), (1)-->(3,9)
     │    │    │    │         │         ├── scan xy
     │    │    │    │         │         │    ├── columns: x:1!null
     │    │    │    │         │         │    └── key: (1)
@@ -2216,10 +2226,14 @@ EliminateGroupByProject
     │    │    │    │         ├── fd: (1)-->(10)
   - │    │    │    │         ├── project
   - │    │    │    │         │    ├── columns: x:1!null notnull:9
+  + │    │    │    │         ├── left-join (hash)
+  + │    │    │    │         │    ├── columns: x:1!null k:3 notnull:9
+    │    │    │    │         │    ├── key: (1)
+  - │    │    │    │         │    ├── fd: (1)-->(9)
   - │    │    │    │         │    └── left-join (hash)
   - │    │    │    │         │         ├── columns: x:1!null k:3 notnull:9
-  - │    │    │    │         │         ├── key: (1,3)
-  - │    │    │    │         │         ├── fd: (3)-->(9)
+  - │    │    │    │         │         ├── key: (1)
+  - │    │    │    │         │         ├── fd: (3)-->(9), (1)-->(3,9)
   - │    │    │    │         │         ├── scan xy
   - │    │    │    │         │         │    ├── columns: x:1!null
   - │    │    │    │         │         │    └── key: (1)
@@ -2241,10 +2255,7 @@ EliminateGroupByProject
   - │    │    │    │         │         │         └── i:4 IS NOT NULL [as=notnull:9, outer=(4)]
   - │    │    │    │         │         └── filters
   - │    │    │    │         │              └── k:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
-  + │    │    │    │         ├── left-join (hash)
-  + │    │    │    │         │    ├── columns: x:1!null k:3 notnull:9
-  + │    │    │    │         │    ├── key: (1,3)
-  + │    │    │    │         │    ├── fd: (3)-->(9)
+  + │    │    │    │         │    ├── fd: (3)-->(9), (1)-->(3,9)
   + │    │    │    │         │    ├── scan xy
   + │    │    │    │         │    │    ├── columns: x:1!null
   + │    │    │    │         │    │    └── key: (1)
@@ -2306,8 +2317,8 @@ EliminateProject
   - │    │    │    │         ├── fd: (1)-->(10)
   - │    │    │    │         ├── left-join (hash)
   - │    │    │    │         │    ├── columns: x:1!null k:3 notnull:9
-  - │    │    │    │         │    ├── key: (1,3)
-  - │    │    │    │         │    ├── fd: (3)-->(9)
+  - │    │    │    │         │    ├── key: (1)
+  - │    │    │    │         │    ├── fd: (3)-->(9), (1)-->(3,9)
   - │    │    │    │         │    ├── scan xy
   - │    │    │    │         │    │    ├── columns: x:1!null
   - │    │    │    │         │    │    └── key: (1)
@@ -2334,8 +2345,8 @@ EliminateProject
   - │    │    │    │                   └── notnull:9
   + │    │    │    │    ├── left-join (hash)
   + │    │    │    │    │    ├── columns: x:1!null k:3 notnull:9
-  + │    │    │    │    │    ├── key: (1,3)
-  + │    │    │    │    │    ├── fd: (3)-->(9)
+  + │    │    │    │    │    ├── key: (1)
+  + │    │    │    │    │    ├── fd: (3)-->(9), (1)-->(3,9)
   + │    │    │    │    │    ├── scan xy
   + │    │    │    │    │    │    ├── columns: x:1!null
   + │    │    │    │    │    │    └── key: (1)
@@ -2389,27 +2400,27 @@ EliminateSelect
   - │    │    │    ├── group-by
   - │    │    │    │    ├── columns: x:1!null bool_or:10
   - │    │    │    │    ├── grouping columns: x:1!null
-  - │    │    │    │    ├── key: (1)
+  + │    │    │    ├── left-join (hash)
+  + │    │    │    │    ├── columns: x:1!null k:3 notnull:9
+    │    │    │    │    ├── key: (1)
   - │    │    │    │    ├── fd: (1)-->(10)
   - │    │    │    │    ├── left-join (hash)
   - │    │    │    │    │    ├── columns: x:1!null k:3 notnull:9
-  - │    │    │    │    │    ├── key: (1,3)
-  + │    │    │    ├── left-join (hash)
-  + │    │    │    │    ├── columns: x:1!null k:3 notnull:9
-  + │    │    │    │    ├── key: (1,3)
-  + │    │    │    │    ├── fd: (3)-->(9)
+  - │    │    │    │    │    ├── key: (1)
+  - │    │    │    │    │    ├── fd: (3)-->(9), (1)-->(3,9)
+  - │    │    │    │    │    ├── scan xy
+  - │    │    │    │    │    │    ├── columns: x:1!null
+  - │    │    │    │    │    │    └── key: (1)
+  - │    │    │    │    │    ├── project
+  - │    │    │    │    │    │    ├── columns: notnull:9!null k:3!null
+  + │    │    │    │    ├── fd: (3)-->(9), (1)-->(3,9)
   + │    │    │    │    ├── scan xy
   + │    │    │    │    │    ├── columns: x:1!null
   + │    │    │    │    │    └── key: (1)
   + │    │    │    │    ├── project
   + │    │    │    │    │    ├── columns: notnull:9!null k:3!null
   + │    │    │    │    │    ├── key: (3)
-    │    │    │    │    │    ├── fd: (3)-->(9)
-  - │    │    │    │    │    ├── scan xy
-  - │    │    │    │    │    │    ├── columns: x:1!null
-  - │    │    │    │    │    │    └── key: (1)
-  - │    │    │    │    │    ├── project
-  - │    │    │    │    │    │    ├── columns: notnull:9!null k:3!null
+  + │    │    │    │    │    ├── fd: (3)-->(9)
   + │    │    │    │    │    ├── select
   + │    │    │    │    │    │    ├── columns: k:3!null i:4
     │    │    │    │    │    │    ├── key: (3)
@@ -2471,28 +2482,28 @@ EliminateSelect
   - │    │    ├── group-by
   - │    │    │    ├── columns: x:1!null bool_or:10
   - │    │    │    ├── grouping columns: x:1!null
-  - │    │    │    ├── key: (1)
-  - │    │    │    ├── fd: (1)-->(10)
-  - │    │    │    ├── left-join (hash)
-  - │    │    │    │    ├── columns: x:1!null k:3 notnull:9
-  - │    │    │    │    ├── key: (1,3)
   + │    │    ├── fd: (1)-->(10)
   + │    │    ├── left-join (hash)
   + │    │    │    ├── columns: x:1!null k:3 notnull:9
-  + │    │    │    ├── key: (1,3)
-  + │    │    │    ├── fd: (3)-->(9)
+    │    │    │    ├── key: (1)
+  - │    │    │    ├── fd: (1)-->(10)
+  - │    │    │    ├── left-join (hash)
+  - │    │    │    │    ├── columns: x:1!null k:3 notnull:9
+  - │    │    │    │    ├── key: (1)
+  - │    │    │    │    ├── fd: (3)-->(9), (1)-->(3,9)
+  - │    │    │    │    ├── scan xy
+  - │    │    │    │    │    ├── columns: x:1!null
+  - │    │    │    │    │    └── key: (1)
+  - │    │    │    │    ├── project
+  - │    │    │    │    │    ├── columns: notnull:9!null k:3!null
+  + │    │    │    ├── fd: (3)-->(9), (1)-->(3,9)
   + │    │    │    ├── scan xy
   + │    │    │    │    ├── columns: x:1!null
   + │    │    │    │    └── key: (1)
   + │    │    │    ├── project
   + │    │    │    │    ├── columns: notnull:9!null k:3!null
   + │    │    │    │    ├── key: (3)
-    │    │    │    │    ├── fd: (3)-->(9)
-  - │    │    │    │    ├── scan xy
-  - │    │    │    │    │    ├── columns: x:1!null
-  - │    │    │    │    │    └── key: (1)
-  - │    │    │    │    ├── project
-  - │    │    │    │    │    ├── columns: notnull:9!null k:3!null
+  + │    │    │    │    ├── fd: (3)-->(9)
   + │    │    │    │    ├── select
   + │    │    │    │    │    ├── columns: k:3!null i:4
     │    │    │    │    │    ├── key: (3)
@@ -2551,8 +2562,8 @@ PruneProjectCols
     │    │    ├── fd: (1)-->(10)
     │    │    ├── left-join (hash)
     │    │    │    ├── columns: x:1!null k:3 notnull:9
-    │    │    │    ├── key: (1,3)
-    │    │    │    ├── fd: (3)-->(9)
+    │    │    │    ├── key: (1)
+    │    │    │    ├── fd: (3)-->(9), (1)-->(3,9)
     │    │    │    ├── scan xy
     │    │    │    │    ├── columns: x:1!null
     │    │    │    │    └── key: (1)
@@ -2592,11 +2603,6 @@ InlineProjectInProject
   - │    ├── group-by
   - │    │    ├── columns: x:1!null bool_or:10
   - │    │    ├── grouping columns: x:1!null
-  - │    │    ├── key: (1)
-  - │    │    ├── fd: (1)-->(10)
-  - │    │    ├── left-join (hash)
-  - │    │    │    ├── columns: x:1!null k:3 notnull:9
-  - │    │    │    ├── key: (1,3)
   + ├── group-by
   + │    ├── columns: x:1!null bool_or:10
   + │    ├── grouping columns: x:1!null
@@ -2604,20 +2610,25 @@ InlineProjectInProject
   + │    ├── fd: (1)-->(10)
   + │    ├── left-join (hash)
   + │    │    ├── columns: x:1!null k:3 notnull:9
-  + │    │    ├── key: (1,3)
-  + │    │    ├── fd: (3)-->(9)
+    │    │    ├── key: (1)
+  - │    │    ├── fd: (1)-->(10)
+  - │    │    ├── left-join (hash)
+  - │    │    │    ├── columns: x:1!null k:3 notnull:9
+  - │    │    │    ├── key: (1)
+  - │    │    │    ├── fd: (3)-->(9), (1)-->(3,9)
+  - │    │    │    ├── scan xy
+  - │    │    │    │    ├── columns: x:1!null
+  - │    │    │    │    └── key: (1)
+  - │    │    │    ├── project
+  - │    │    │    │    ├── columns: notnull:9!null k:3!null
+  + │    │    ├── fd: (3)-->(9), (1)-->(3,9)
   + │    │    ├── scan xy
   + │    │    │    ├── columns: x:1!null
   + │    │    │    └── key: (1)
   + │    │    ├── project
   + │    │    │    ├── columns: notnull:9!null k:3!null
   + │    │    │    ├── key: (3)
-    │    │    │    ├── fd: (3)-->(9)
-  - │    │    │    ├── scan xy
-  - │    │    │    │    ├── columns: x:1!null
-  - │    │    │    │    └── key: (1)
-  - │    │    │    ├── project
-  - │    │    │    │    ├── columns: notnull:9!null k:3!null
+  + │    │    │    ├── fd: (3)-->(9)
   + │    │    │    ├── select
   + │    │    │    │    ├── columns: k:3!null i:4
     │    │    │    │    ├── key: (3)
@@ -2681,8 +2692,8 @@ CommuteLeftJoin (higher cost)
   - │    ├── left-join (hash)
   + │    ├── right-join (hash)
     │    │    ├── columns: x:1!null k:3 notnull:9
-    │    │    ├── key: (1,3)
-    │    │    ├── fd: (3)-->(9)
+    │    │    ├── key: (1)
+    │    │    ├── fd: (3)-->(9), (1)-->(3,9)
   - │    │    ├── scan xy
   - │    │    │    ├── columns: x:1!null
   - │    │    │    └── key: (1)
@@ -2728,8 +2739,8 @@ GenerateMergeJoins
     │    │    ├── columns: x:1!null k:3 notnull:9
   + │    │    ├── left ordering: +1
   + │    │    ├── right ordering: +3
-    │    │    ├── key: (1,3)
-    │    │    ├── fd: (3)-->(9)
+    │    │    ├── key: (1)
+    │    │    ├── fd: (3)-->(9), (1)-->(3,9)
     │    │    ├── scan xy
     │    │    │    ├── columns: x:1!null
   - │    │    │    └── key: (1)
@@ -2780,8 +2791,8 @@ GenerateMergeJoins (higher cost)
   - │    │    ├── right ordering: +3
   + │    │    ├── left ordering: +3
   + │    │    ├── right ordering: +1
-    │    │    ├── key: (1,3)
-    │    │    ├── fd: (3)-->(9)
+    │    │    ├── key: (1)
+    │    │    ├── fd: (3)-->(9), (1)-->(3,9)
   - │    │    ├── scan xy
   - │    │    │    ├── columns: x:1!null
   - │    │    │    ├── key: (1)
@@ -2831,8 +2842,8 @@ GenerateStreamingGroupBy
     │    │    ├── columns: x:1!null k:3 notnull:9
     │    │    ├── left ordering: +1
     │    │    ├── right ordering: +3
-    │    │    ├── key: (1,3)
-    │    │    ├── fd: (3)-->(9)
+    │    │    ├── key: (1)
+    │    │    ├── fd: (3)-->(9), (1)-->(3,9)
   + │    │    ├── ordering: +1
     │    │    ├── scan xy
     │    │    │    ├── columns: x:1!null
@@ -2879,8 +2890,8 @@ Final best expression
    │    │    ├── columns: x:1!null k:3 notnull:9
    │    │    ├── left ordering: +1
    │    │    ├── right ordering: +3
-   │    │    ├── key: (1,3)
-   │    │    ├── fd: (3)-->(9)
+   │    │    ├── key: (1)
+   │    │    ├── fd: (3)-->(9), (1)-->(3,9)
    │    │    ├── ordering: +1
    │    │    ├── scan xy
    │    │    │    ├── columns: x:1!null

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -69,8 +69,8 @@ update xy
  ├── side-effects, mutations
  └── left-join (hash)
       ├── columns: x:3!null y:4 u:5 v:6
-      ├── key: (3,5)
-      ├── fd: (3)-->(4), (5)-->(6)
+      ├── key: (3)
+      ├── fd: (3)-->(4-6), (5)-->(6)
       ├── scan xy
       │    ├── columns: x:3!null y:4
       │    ├── key: (3)
@@ -879,8 +879,8 @@ project
  │    ├── fd: (1)-->(10)
  │    ├── left-join (hash)
  │    │    ├── columns: k:1!null x:6 notnull:9
- │    │    ├── key: (1,6)
- │    │    ├── fd: (6)-->(9)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (6)-->(9), (1)-->(6,9)
  │    │    ├── scan a
  │    │    │    ├── columns: k:1!null
  │    │    │    └── key: (1)
@@ -960,8 +960,8 @@ project
  │    ├── fd: (1)-->(10)
  │    ├── left-join (hash)
  │    │    ├── columns: k:1!null x:6 notnull:9
- │    │    ├── key: (1,6)
- │    │    ├── fd: (6)-->(9)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (6)-->(9), (1)-->(6,9)
  │    │    ├── scan a
  │    │    │    ├── columns: k:1!null
  │    │    │    └── key: (1)
@@ -1002,8 +1002,8 @@ project
  │    ├── fd: (1)-->(2,10)
  │    ├── left-join (hash)
  │    │    ├── columns: k:1!null i:2 x:6 y:7 notnull:9
- │    │    ├── key: (1,6)
- │    │    ├── fd: (1)-->(2), (6)-->(7), (7)~~>(9), (1,6)-->(9)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2,6,7,9), (6)-->(7), (7)~~>(9)
  │    │    ├── scan a
  │    │    │    ├── columns: k:1!null i:2
  │    │    │    ├── key: (1)
@@ -1042,8 +1042,8 @@ project
  │    ├── fd: (1)-->(9,11)
  │    ├── left-join (hash)
  │    │    ├── columns: k:1!null x:6 y:7 scalar:9 notnull:10
- │    │    ├── key: (1,6)
- │    │    ├── fd: (1)-->(9), (6)-->(7), (7)~~>(10), (1,6)-->(10)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(6,7,9,10), (6)-->(7), (7)~~>(10)
  │    │    ├── project
  │    │    │    ├── columns: scalar:9 k:1!null
  │    │    │    ├── key: (1)
@@ -1270,8 +1270,8 @@ project
  │    ├── fd: (1)-->(11)
  │    ├── left-join (hash)
  │    │    ├── columns: k:1!null x:6 column10:10
- │    │    ├── key: (1,6)
- │    │    ├── fd: (6)-->(10)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (6)-->(10), (1)-->(6,10)
  │    │    ├── scan a
  │    │    │    ├── columns: k:1!null
  │    │    │    └── key: (1)
@@ -1389,8 +1389,8 @@ project
       │    ├── fd: (1)-->(10)
       │    ├── left-join (hash)
       │    │    ├── columns: k:1!null x:6 u:8
-      │    │    ├── key: (1,8)
-      │    │    ├── fd: (6)==(8), (8)==(6)
+      │    │    ├── key: (1)
+      │    │    ├── fd: (6)==(8), (8)==(6), (1)-->(6,8)
       │    │    ├── scan a
       │    │    │    ├── columns: k:1!null
       │    │    │    └── key: (1)
@@ -1431,7 +1431,8 @@ semi-join-apply
  ├── left-join (hash)
  │    ├── columns: x:6!null u:8
  │    ├── outer: (1)
- │    ├── key: (6,8)
+ │    ├── key: (6)
+ │    ├── fd: (6)-->(8)
  │    ├── scan xy
  │    │    ├── columns: x:6!null
  │    │    └── key: (6)
@@ -1545,15 +1546,16 @@ WHERE (SELECT i FROM a WHERE k=x) IS DISTINCT FROM u
 ----
 project
  ├── columns: x:1!null y:2 u:3!null v:4
+ ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4)
  └── select
       ├── columns: x:1!null y:2 u:3!null v:4 k:5 i:6
-      ├── key: (1,3,5)
-      ├── fd: (1)-->(2), (3)-->(4), (5)-->(6)
+      ├── key: (1,3)
+      ├── fd: (1)-->(2), (3)-->(4), (5)-->(6), (1,3)-->(5,6)
       ├── left-join (hash)
       │    ├── columns: x:1!null y:2 u:3!null v:4 k:5 i:6
-      │    ├── key: (1,3,5)
-      │    ├── fd: (1)-->(2), (3)-->(4), (5)-->(6)
+      │    ├── key: (1,3)
+      │    ├── fd: (1)-->(2), (3)-->(4), (5)-->(6), (1,3)-->(5,6)
       │    ├── inner-join (cross)
       │    │    ├── columns: x:1!null y:2 u:3!null v:4
       │    │    ├── key: (1,3)
@@ -1796,8 +1798,8 @@ project
       │    ├── fd: (1)-->(2), (3)-->(1,2,4,10), (1)==(4), (4)==(1)
       │    ├── left-join (hash)
       │    │    ├── columns: x:1!null y:2 u:3!null v:4!null k:5 i:6
-      │    │    ├── key: (3,5)
-      │    │    ├── fd: (1)-->(2), (3)-->(4), (1)==(4), (4)==(1), (5)-->(6)
+      │    │    ├── key: (3)
+      │    │    ├── fd: (1)-->(2), (3)-->(4-6), (1)==(4), (4)==(1), (5)-->(6)
       │    │    ├── inner-join (hash)
       │    │    │    ├── columns: x:1!null y:2 u:3!null v:4!null
       │    │    │    ├── key: (3)
@@ -2459,8 +2461,8 @@ project
       │    │    ├── fd: (1)-->(2,3,6)
       │    │    ├── left-join (hash)
       │    │    │    ├── columns: c:1!null d:2!null x:3 y:4
-      │    │    │    ├── key: (1,3)
-      │    │    │    ├── fd: (1)-->(2), (3)-->(4)
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2-4), (3)-->(4)
       │    │    │    ├── scan cd
       │    │    │    │    ├── columns: c:1!null d:2!null
       │    │    │    │    ├── key: (1)
@@ -2505,8 +2507,8 @@ project
       │    │    ├── fd: (1)-->(2-5,10,11)
       │    │    ├── left-join (hash)
       │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6 column8:8 canary:10
-      │    │    │    ├── key: (1,6)
-      │    │    │    ├── fd: (1)-->(2-5), (6)-->(8), (1,6)-->(10)
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2-6,8,10), (6)-->(8)
       │    │    │    ├── scan a
       │    │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
       │    │    │    │    ├── key: (1)
@@ -2557,8 +2559,8 @@ project
  │    ├── fd: (1)-->(12)
  │    ├── left-join (hash)
  │    │    ├── columns: a2.k:1!null a2.i:2 a.k:6 a.s:9 column11:11
- │    │    ├── key: (1,6)
- │    │    ├── fd: (1)-->(2), (6)-->(9), (1,6)-->(11)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2,6,9,11), (6)-->(9)
  │    │    ├── scan a2
  │    │    │    ├── columns: a2.k:1!null a2.i:2
  │    │    │    ├── key: (1)
@@ -3850,8 +3852,8 @@ project
       │    ├── fd: (1)-->(2-5,8)
       │    ├── left-join (hash)
       │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 u:6
-      │    │    ├── key: (1,6)
-      │    │    ├── fd: (1)-->(2-5)
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-6)
       │    │    ├── scan a
       │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
       │    │    │    ├── key: (1)
@@ -3945,8 +3947,8 @@ project
       │    │    ├── fd: (1)-->(2-5,9)
       │    │    ├── left-join (hash)
       │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6 y:7 notnull:8
-      │    │    │    ├── key: (1,6)
-      │    │    │    ├── fd: (1)-->(2-5), (6)-->(7), (7)~~>(8), (1,6)-->(8)
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2-8), (6)-->(7), (7)~~>(8)
       │    │    │    ├── scan a
       │    │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
       │    │    │    │    ├── key: (1)
@@ -4013,8 +4015,8 @@ project
  │    ├── fd: (1)-->(4,9,11)
  │    ├── left-join (hash)
  │    │    ├── columns: k:1!null s:4 x:6 y:7 scalar:9 notnull:10
- │    │    ├── key: (1,6)
- │    │    ├── fd: (1)-->(4,9), (6)-->(7), (7)~~>(10), (1,6)-->(10)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(4,6,7,9,10), (6)-->(7), (7)~~>(10)
  │    │    ├── project
  │    │    │    ├── columns: scalar:9 k:1!null s:4
  │    │    │    ├── key: (1)
@@ -4068,8 +4070,8 @@ project
       │    ├── fd: (1)-->(2-5,11)
       │    ├── left-join (hash)
       │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8 true:10
-      │    │    ├── key: (1,8)
-      │    │    ├── fd: (1)-->(2-5), (1,8)-->(10)
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-5,8,10)
       │    │    ├── scan a
       │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
       │    │    │    ├── key: (1)
@@ -4122,7 +4124,8 @@ project
  ├── columns: x:8
  ├── left-join (hash)
  │    ├── columns: k:1!null xy.x:6
- │    ├── key: (1,6)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(6)
  │    ├── scan a
  │    │    ├── columns: k:1!null
  │    │    └── key: (1)
@@ -4150,14 +4153,16 @@ project
  ├── fd: ()-->(17,19-21)
  ├── group-by
  │    ├── columns: k:1!null xy.x:6 count_rows:16!null
- │    ├── grouping columns: k:1!null xy.x:6
- │    ├── key: (1,6)
- │    ├── fd: (1,6)-->(16)
+ │    ├── grouping columns: k:1!null
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(6,16)
  │    ├── left-join (hash)
  │    │    ├── columns: k:1!null xy.x:6 xy.y:15
+ │    │    ├── fd: (1)-->(6)
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: k:1!null xy.x:6
- │    │    │    ├── key: (1,6)
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(6)
  │    │    │    ├── scan a
  │    │    │    │    ├── columns: k:1!null
  │    │    │    │    └── key: (1)
@@ -4171,8 +4176,10 @@ project
  │    │    └── filters
  │    │         └── xy.y:15 = k:1 [outer=(1,15), constraints=(/1: (/NULL - ]; /15: (/NULL - ]), fd=(1)==(15), (15)==(1)]
  │    └── aggregations
- │         └── count [as=count_rows:16, outer=(15)]
- │              └── xy.y:15
+ │         ├── count [as=count_rows:16, outer=(15)]
+ │         │    └── xy.y:15
+ │         └── const-agg [as=xy.x:6, outer=(6)]
+ │              └── xy.x:6
  └── projections
       ├── 5 [as=a:17]
       ├── xy.x:6 [as=x:18, outer=(6)]
@@ -4428,8 +4435,8 @@ project
       │    │    ├── fd: (6)-->(11)
       │    │    ├── left-join (hash)
       │    │    │    ├── columns: x:6!null y:7 u:8 true:10
-      │    │    │    ├── key: (6,8)
-      │    │    │    ├── fd: (6)-->(7), (6,8)-->(10)
+      │    │    │    ├── key: (6)
+      │    │    │    ├── fd: (6)-->(7,8,10)
       │    │    │    ├── scan xy
       │    │    │    │    ├── columns: x:6!null y:7
       │    │    │    │    ├── key: (6)
@@ -4472,8 +4479,8 @@ project
       │    │    ├── fd: (1)-->(5), (6)-->(7), (1,6)-->(5,7,11)
       │    │    ├── left-join (hash)
       │    │    │    ├── columns: k:1!null i:2 j:5 x:6!null y:7 u:8 v:9 notnull:10
-      │    │    │    ├── key: (1,6,8)
-      │    │    │    ├── fd: (1)-->(2,5), (6)-->(7), (8)-->(9), (9)~~>(10), (1,6,8)-->(10)
+      │    │    │    ├── key: (1,6)
+      │    │    │    ├── fd: (1)-->(2,5), (6)-->(7), (8)-->(9), (9)~~>(10), (1,6)-->(8-10)
       │    │    │    ├── inner-join (cross)
       │    │    │    │    ├── columns: k:1!null i:2 j:5 x:6!null y:7
       │    │    │    │    ├── key: (1,6)
@@ -4750,8 +4757,8 @@ project
       │    ├── columns: v:4
       │    └── left-join (hash)
       │         ├── columns: x:1!null u:3 v:4
-      │         ├── key: (1,3)
-      │         ├── fd: (3)-->(4)
+      │         ├── key: (1)
+      │         ├── fd: (3)-->(4), (1)-->(3,4)
       │         ├── scan xy
       │         │    ├── columns: x:1!null
       │         │    └── key: (1)
@@ -4777,14 +4784,15 @@ group-by
  ├── project-set
  │    ├── columns: x:1!null y:2 v:4 generate_series:5
  │    ├── side-effects
- │    ├── fd: (1)-->(2)
+ │    ├── fd: (1)-->(2,4)
  │    ├── project
  │    │    ├── columns: x:1!null y:2 v:4
- │    │    ├── fd: (1)-->(2)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2,4)
  │    │    └── left-join (hash)
  │    │         ├── columns: x:1!null y:2 u:3 v:4
- │    │         ├── key: (1,3)
- │    │         ├── fd: (1)-->(2), (3)-->(4)
+ │    │         ├── key: (1)
+ │    │         ├── fd: (1)-->(2-4), (3)-->(4)
  │    │         ├── scan xy
  │    │         │    ├── columns: x:1!null y:2
  │    │         │    ├── key: (1)
@@ -4815,12 +4823,12 @@ project
       │    ├── columns: y:7 v:9
       │    └── left-join (hash)
       │         ├── columns: k:1!null x:6 y:7 u:8 v:9
-      │         ├── key: (1,6,8)
-      │         ├── fd: (6)-->(7), (8)-->(9)
+      │         ├── key: (1)
+      │         ├── fd: (6)-->(7), (1)-->(6-9), (8)-->(9)
       │         ├── left-join (hash)
       │         │    ├── columns: k:1!null x:6 y:7
-      │         │    ├── key: (1,6)
-      │         │    ├── fd: (6)-->(7)
+      │         │    ├── key: (1)
+      │         │    ├── fd: (6)-->(7), (1)-->(6,7)
       │         │    ├── scan a
       │         │    │    ├── columns: k:1!null
       │         │    │    └── key: (1)
@@ -4856,12 +4864,12 @@ project
  │    │    ├── columns: v:7 xy.x:9
  │    │    └── left-join (hash)
  │    │         ├── columns: k:1!null u:6 v:7 xy.x:9
- │    │         ├── key: (1,6,9)
- │    │         ├── fd: (6)-->(7)
+ │    │         ├── key: (1)
+ │    │         ├── fd: (6)-->(7), (1)-->(6,7,9)
  │    │         ├── left-join (hash)
  │    │         │    ├── columns: k:1!null u:6 v:7
- │    │         │    ├── key: (1,6)
- │    │         │    ├── fd: (6)-->(7)
+ │    │         │    ├── key: (1)
+ │    │         │    ├── fd: (6)-->(7), (1)-->(6,7)
  │    │         │    ├── scan a
  │    │         │    │    ├── columns: k:1!null
  │    │         │    │    └── key: (1)

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -313,7 +313,7 @@ distinct-on
 # EliminateMax1Row is disabled to ensure that an EnsureDistinctOn operator is
 # created.
 norm expect=EliminateGroupByProject disable=EliminateMax1Row
-SELECT (SELECT y FROM xy WHERE x=k) FROM a
+SELECT (SELECT y FROM xy WHERE x+y=k) FROM a
 ----
 project
  ├── columns: y:8
@@ -324,18 +324,20 @@ project
  │    ├── key: (1)
  │    ├── fd: (1)-->(7)
  │    ├── left-join (hash)
- │    │    ├── columns: k:1!null x:6 xy.y:7
- │    │    ├── key: (1,6)
- │    │    ├── fd: (6)-->(7)
+ │    │    ├── columns: k:1!null xy.y:7 column9:9
  │    │    ├── scan a
  │    │    │    ├── columns: k:1!null
  │    │    │    └── key: (1)
- │    │    ├── scan xy
- │    │    │    ├── columns: x:6!null xy.y:7
- │    │    │    ├── key: (6)
- │    │    │    └── fd: (6)-->(7)
+ │    │    ├── project
+ │    │    │    ├── columns: column9:9 xy.y:7
+ │    │    │    ├── scan xy
+ │    │    │    │    ├── columns: x:6!null xy.y:7
+ │    │    │    │    ├── key: (6)
+ │    │    │    │    └── fd: (6)-->(7)
+ │    │    │    └── projections
+ │    │    │         └── x:6 + xy.y:7 [as=column9:9, outer=(6,7)]
  │    │    └── filters
- │    │         └── x:6 = k:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ │    │         └── k:1 = column9:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
  │    └── aggregations
  │         └── const-agg [as=xy.y:7, outer=(7)]
  │              └── xy.y:7
@@ -684,12 +686,14 @@ upsert xy
  ├── side-effects, mutations
  └── project
       ├── columns: upsert_y:10 y:4!null column5:5 x:6 y:7
-      ├── key: (6)
-      ├── fd: ()-->(4,5), (6)-->(7), (6)-->(10)
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(4-7,10)
       ├── left-join (hash)
       │    ├── columns: y:4!null column5:5 x:6 y:7
-      │    ├── key: (6)
-      │    ├── fd: ()-->(4,5), (6)-->(7)
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(4-7)
       │    ├── max1-row
       │    │    ├── columns: y:4!null column5:5
       │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
@@ -839,8 +843,8 @@ upsert abc
  ├── side-effects, mutations
  └── left-join (hash)
       ├── columns: b:5!null "?column?":7!null "?column?":8!null a:9 b:10 c:11
-      ├── key: (5,9-11)
-      ├── fd: ()-->(7,8)
+      ├── key: (5)
+      ├── fd: ()-->(7,8), (5)-->(9-11)
       ├── ensure-upsert-distinct-on
       │    ├── columns: b:5!null "?column?":7!null "?column?":8!null
       │    ├── grouping columns: b:5!null
@@ -1462,12 +1466,14 @@ upsert a
  ├── side-effects, mutations
  └── project
       ├── columns: upsert_f:23 i:7!null "?column?":11!null "?column?":12!null column13:13 column14:14 k:15 i:16 f:17 s:18 j:19
-      ├── key: (15)
-      ├── fd: ()-->(7,11-14), (15)-->(16-19,23), (16,18)-->(15,17,19), (16,17)~~>(15,18,19)
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(7,11-19,23)
       ├── left-join (hash)
       │    ├── columns: i:7!null "?column?":11!null "?column?":12!null column13:13 column14:14 k:15 i:16 f:17 s:18 j:19
-      │    ├── key: (15)
-      │    ├── fd: ()-->(7,11-14), (15)-->(16-19), (16,18)-->(15,17,19), (16,17)~~>(15,18,19)
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(7,11-19)
       │    ├── max1-row
       │    │    ├── columns: i:7!null "?column?":11!null "?column?":12!null column13:13 column14:14
       │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
@@ -1891,13 +1897,13 @@ upsert a
  └── project
       ├── columns: upsert_f:19 column1:6!null column2:7!null column3:8!null column9:9 column10:10 k:11 i:12 f:13 s:14 j:15
       ├── cardinality: [1 - ]
-      ├── key: (7,8,11)
-      ├── fd: ()-->(9,10), (7,8)-->(6), (11)-->(12-15), (12,14)-->(11,13,15), (12,13)~~>(11,14,15), (7,8,11)-->(19)
+      ├── key: (7,8)
+      ├── fd: ()-->(9,10), (7,8)-->(6,11-15,19), (11)-->(12-15), (12,14)-->(11,13,15), (12,13)~~>(11,14,15)
       ├── left-join (hash)
       │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10 k:11 i:12 f:13 s:14 j:15
       │    ├── cardinality: [1 - ]
-      │    ├── key: (7,8,11)
-      │    ├── fd: ()-->(9,10), (7,8)-->(6), (11)-->(12-15), (12,14)-->(11,13,15), (12,13)~~>(11,14,15)
+      │    ├── key: (7,8)
+      │    ├── fd: ()-->(9,10), (7,8)-->(6,11-15), (11)-->(12-15), (12,14)-->(11,13,15), (12,13)~~>(11,14,15)
       │    ├── ensure-upsert-distinct-on
       │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10
       │    │    ├── grouping columns: column2:7!null column3:8!null

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -52,8 +52,8 @@ SELECT * FROM a RIGHT JOIN b ON k=x
 ----
 left-join (hash)
  ├── columns: k:1 i:2 f:3 s:4 j:5 x:6!null y:7
- ├── key: (1,6)
- ├── fd: (6)-->(7), (1)-->(2-5)
+ ├── key: (6)
+ ├── fd: (6)-->(1-5,7), (1)-->(2-5)
  ├── scan b
  │    ├── columns: x:6!null y:7
  │    ├── key: (6)
@@ -147,8 +147,8 @@ SELECT * FROM a LEFT JOIN b ON a.k=b.x AND a.i=1
 ----
 left-join (hash)
  ├── columns: k:1!null i:2 f:3!null s:4 j:5 x:6 y:7
- ├── key: (1,6)
- ├── fd: (1)-->(2-5), (6)-->(7)
+ ├── key: (1)
+ ├── fd: (1)-->(2-7), (6)-->(7)
  ├── scan a
  │    ├── columns: k:1!null i:2 f:3!null s:4 j:5
  │    ├── key: (1)
@@ -236,8 +236,8 @@ SELECT * FROM b LEFT JOIN a ON (a.i<0 OR a.i>10) AND b.y=1 AND a.s='foo' AND b.x
 ----
 left-join (hash)
  ├── columns: x:1!null y:2 k:3 i:4 f:5 s:6 j:7
- ├── key: (1,3)
- ├── fd: (1)-->(2), (3)-->(4,5,7), (1,3)-->(6)
+ ├── key: (1)
+ ├── fd: (1)-->(2-7), (3)-->(4,5,7)
  ├── scan b
  │    ├── columns: x:1!null y:2
  │    ├── key: (1)
@@ -263,8 +263,8 @@ SELECT * FROM b RIGHT JOIN a ON b.x=a.k AND a.i=1
 ----
 left-join (hash)
  ├── columns: x:1 y:2 k:3!null i:4 f:5!null s:6 j:7
- ├── key: (1,3)
- ├── fd: (3)-->(4-7), (1)-->(2)
+ ├── key: (3)
+ ├── fd: (3)-->(1,2,4-7), (1)-->(2)
  ├── scan a
  │    ├── columns: k:3!null i:4 f:5!null s:6 j:7
  │    ├── key: (3)
@@ -467,8 +467,8 @@ SELECT * FROM a LEFT JOIN b ON a.k=b.x AND a.k + b.y > 5 AND b.x * a.i = 3
 ----
 left-join (hash)
  ├── columns: k:1!null i:2 f:3!null s:4 j:5 x:6 y:7
- ├── key: (1,6)
- ├── fd: (1)-->(2-5), (6)-->(7)
+ ├── key: (1)
+ ├── fd: (1)-->(2-7), (6)-->(7)
  ├── scan a
  │    ├── columns: k:1!null i:2 f:3!null s:4 j:5
  │    ├── key: (1)
@@ -492,8 +492,8 @@ SELECT * FROM a LEFT JOIN b ON a.k=b.x AND a.k > 5 AND b.x IN (3, 7, 10)
 ----
 left-join (hash)
  ├── columns: k:1!null i:2 f:3!null s:4 j:5 x:6 y:7
- ├── key: (1,6)
- ├── fd: (1)-->(2-5), (6)-->(7)
+ ├── key: (1)
+ ├── fd: (1)-->(2-7), (6)-->(7)
  ├── scan a
  │    ├── columns: k:1!null i:2 f:3!null s:4 j:5
  │    ├── key: (1)
@@ -1744,8 +1744,8 @@ SELECT * FROM a FULL JOIN (SELECT * FROM a WHERE k>0) AS a2 ON a.k=a2.k
 ----
 left-join (hash)
  ├── columns: k:1!null i:2 f:3!null s:4 j:5 k:6 i:7 f:8 s:9 j:10
- ├── key: (1,6)
- ├── fd: (1)-->(2-5), (6)-->(7-10)
+ ├── key: (1)
+ ├── fd: (1)-->(2-10), (6)-->(7-10)
  ├── scan a
  │    ├── columns: k:1!null i:2 f:3!null s:4 j:5
  │    ├── key: (1)
@@ -1909,8 +1909,8 @@ ON c.z = a.k
 ----
 left-join (hash)
  ├── columns: x:1!null y:2!null z:3!null k:4 i:5 f:6 s:7 j:8
- ├── key: (1,4)
- ├── fd: (1)-->(2,3), (4)-->(5-8)
+ ├── key: (1)
+ ├── fd: (1)-->(2-8), (4)-->(5-8)
  ├── scan c
  │    ├── columns: x:1!null y:2!null z:3!null
  │    ├── key: (1)
@@ -1931,8 +1931,8 @@ ON c.x = a.k
 ----
 left-join (hash)
  ├── columns: x:1!null y:2!null z:3!null k:4 i:5 f:6 s:7 j:8
- ├── key: (1,4)
- ├── fd: (1)-->(2,3), (4)-->(5-8)
+ ├── key: (1)
+ ├── fd: (1)-->(2-8), (4)-->(5-8)
  ├── scan c
  │    ├── columns: x:1!null y:2!null z:3!null
  │    ├── key: (1)
@@ -2129,8 +2129,8 @@ ON c.y = a.k
 ----
 left-join (hash)
  ├── columns: x:1!null y:2!null z:3!null k:4 i:5 f:6 s:7 j:8
- ├── key: (1,4)
- ├── fd: (1)-->(2,3), (4)-->(5-8)
+ ├── key: (1)
+ ├── fd: (1)-->(2-8), (4)-->(5-8)
  ├── scan c
  │    ├── columns: x:1!null y:2!null z:3!null
  │    ├── key: (1)
@@ -2275,12 +2275,12 @@ SELECT * FROM a LEFT JOIN (SELECT x FROM b WHERE y=10) ON x=k
 ----
 project
  ├── columns: k:1!null i:2 f:3!null s:4 j:5 x:6
- ├── key: (1,6)
- ├── fd: (1)-->(2-5)
+ ├── key: (1)
+ ├── fd: (1)-->(2-6)
  └── left-join (hash)
       ├── columns: k:1!null i:2 f:3!null s:4 j:5 x:6 y:7
-      ├── key: (1,6)
-      ├── fd: (1)-->(2-5), (1,6)-->(7)
+      ├── key: (1)
+      ├── fd: (1)-->(2-7)
       ├── scan a
       │    ├── columns: k:1!null i:2 f:3!null s:4 j:5
       │    ├── key: (1)
@@ -2337,12 +2337,12 @@ SELECT * FROM (SELECT x FROM b WHERE y=10) LEFT JOIN a ON x=k
 ----
 project
  ├── columns: x:1!null k:3 i:4 f:5 s:6 j:7
- ├── key: (1,3)
- ├── fd: (3)-->(4-7)
+ ├── key: (1)
+ ├── fd: (3)-->(4-7), (1)-->(3-7)
  └── left-join (hash)
       ├── columns: x:1!null y:2!null k:3 i:4 f:5 s:6 j:7
-      ├── key: (1,3)
-      ├── fd: ()-->(2), (3)-->(4-7)
+      ├── key: (1)
+      ├── fd: ()-->(2), (3)-->(4-7), (1)-->(3-7)
       ├── select
       │    ├── columns: x:1!null y:2!null
       │    ├── key: (1)

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -730,12 +730,12 @@ SELECT * FROM ab LEFT JOIN uv ON a = u LIMIT 10
 limit
  ├── columns: a:1!null b:2 u:3 v:4
  ├── cardinality: [0 - 10]
- ├── key: (1,3)
- ├── fd: (1)-->(2), (3)-->(4)
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)-->(4)
  ├── left-join (hash)
  │    ├── columns: a:1!null b:2 u:3 v:4
- │    ├── key: (1,3)
- │    ├── fd: (1)-->(2), (3)-->(4)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3)-->(4)
  │    ├── limit hint: 10.00
  │    ├── limit
  │    │    ├── columns: a:1!null b:2
@@ -764,19 +764,19 @@ limit
  ├── columns: a:1!null b:2 u:3 v:4
  ├── internal-ordering: +1
  ├── cardinality: [0 - 10]
- ├── key: (1,3)
- ├── fd: (1)-->(2), (3)-->(4)
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)-->(4)
  ├── ordering: +1
  ├── sort
  │    ├── columns: a:1!null b:2 u:3 v:4
- │    ├── key: (1,3)
- │    ├── fd: (1)-->(2), (3)-->(4)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3)-->(4)
  │    ├── ordering: +1
  │    ├── limit hint: 10.00
  │    └── left-join (hash)
  │         ├── columns: a:1!null b:2 u:3 v:4
- │         ├── key: (1,3)
- │         ├── fd: (1)-->(2), (3)-->(4)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-4), (3)-->(4)
  │         ├── limit
  │         │    ├── columns: a:1!null b:2
  │         │    ├── internal-ordering: +1
@@ -805,19 +805,19 @@ limit
  ├── columns: a:1!null b:2 u:3 v:4
  ├── internal-ordering: +2
  ├── cardinality: [0 - 10]
- ├── key: (1,3)
- ├── fd: (1)-->(2), (3)-->(4)
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)-->(4)
  ├── ordering: +2
  ├── sort
  │    ├── columns: a:1!null b:2 u:3 v:4
- │    ├── key: (1,3)
- │    ├── fd: (1)-->(2), (3)-->(4)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3)-->(4)
  │    ├── ordering: +2
  │    ├── limit hint: 10.00
  │    └── left-join (hash)
  │         ├── columns: a:1!null b:2 u:3 v:4
- │         ├── key: (1,3)
- │         ├── fd: (1)-->(2), (3)-->(4)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-4), (3)-->(4)
  │         ├── limit
  │         │    ├── columns: a:1!null b:2
  │         │    ├── internal-ordering: +2
@@ -852,19 +852,19 @@ limit
  ├── columns: a:1!null b:2 u:3 v:4
  ├── internal-ordering: +3
  ├── cardinality: [0 - 10]
- ├── key: (1,3)
- ├── fd: (1)-->(2), (3)-->(4)
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)-->(4)
  ├── ordering: +3
  ├── sort
  │    ├── columns: a:1!null b:2 u:3 v:4
- │    ├── key: (1,3)
- │    ├── fd: (1)-->(2), (3)-->(4)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3)-->(4)
  │    ├── ordering: +3
  │    ├── limit hint: 10.00
  │    └── left-join (hash)
  │         ├── columns: a:1!null b:2 u:3 v:4
- │         ├── key: (1,3)
- │         ├── fd: (1)-->(2), (3)-->(4)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-4), (3)-->(4)
  │         ├── scan ab
  │         │    ├── columns: a:1!null b:2
  │         │    ├── key: (1)
@@ -885,19 +885,19 @@ limit
  ├── columns: a:1!null b:2 u:3 v:4
  ├── internal-ordering: +4
  ├── cardinality: [0 - 10]
- ├── key: (1,3)
- ├── fd: (1)-->(2), (3)-->(4)
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)-->(4)
  ├── ordering: +4
  ├── sort
  │    ├── columns: a:1!null b:2 u:3 v:4
- │    ├── key: (1,3)
- │    ├── fd: (1)-->(2), (3)-->(4)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3)-->(4)
  │    ├── ordering: +4
  │    ├── limit hint: 10.00
  │    └── left-join (hash)
  │         ├── columns: a:1!null b:2 u:3 v:4
- │         ├── key: (1,3)
- │         ├── fd: (1)-->(2), (3)-->(4)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-4), (3)-->(4)
  │         ├── scan ab
  │         │    ├── columns: a:1!null b:2
  │         │    ├── key: (1)
@@ -911,7 +911,7 @@ limit
  └── 10
 
 norm expect-not=PushLimitIntoLeftJoin
-SELECT * FROM ab LEFT JOIN uv ON a = u ORDER BY a, v LIMIT 10
+SELECT * FROM ab LEFT JOIN uv ON b = v ORDER BY a, v LIMIT 10
 ----
 limit
  ├── columns: a:1!null b:2 u:3 v:4
@@ -939,7 +939,7 @@ limit
  │         │    ├── key: (3)
  │         │    └── fd: (3)-->(4)
  │         └── filters
- │              └── a:1 = u:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+ │              └── b:2 = v:4 [outer=(2,4), constraints=(/2: (/NULL - ]; /4: (/NULL - ]), fd=(2)==(4), (4)==(2)]
  └── 10
 
 norm expect-not=PushLimitIntoLeftJoin
@@ -949,19 +949,19 @@ limit
  ├── columns: a:1!null b:2 u:3 v:4
  ├── internal-ordering: +3,+2
  ├── cardinality: [0 - 10]
- ├── key: (1,3)
- ├── fd: (1)-->(2), (3)-->(4)
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)-->(4)
  ├── ordering: +3,+2
  ├── sort
  │    ├── columns: a:1!null b:2 u:3 v:4
- │    ├── key: (1,3)
- │    ├── fd: (1)-->(2), (3)-->(4)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3)-->(4)
  │    ├── ordering: +3,+2
  │    ├── limit hint: 10.00
  │    └── left-join (hash)
  │         ├── columns: a:1!null b:2 u:3 v:4
- │         ├── key: (1,3)
- │         ├── fd: (1)-->(2), (3)-->(4)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-4), (3)-->(4)
  │         ├── scan ab
  │         │    ├── columns: a:1!null b:2
  │         │    ├── key: (1)
@@ -982,12 +982,12 @@ SELECT * FROM (SELECT * FROM ab LIMIT 5) LEFT JOIN uv ON a = u LIMIT 10
 limit
  ├── columns: a:1!null b:2 u:3 v:4
  ├── cardinality: [0 - 10]
- ├── key: (1,3)
- ├── fd: (1)-->(2), (3)-->(4)
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)-->(4)
  ├── left-join (hash)
  │    ├── columns: a:1!null b:2 u:3 v:4
- │    ├── key: (1,3)
- │    ├── fd: (1)-->(2), (3)-->(4)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3)-->(4)
  │    ├── limit hint: 10.00
  │    ├── limit
  │    │    ├── columns: a:1!null b:2
@@ -1015,12 +1015,12 @@ SELECT * FROM (SELECT * FROM ab LIMIT 20) LEFT JOIN uv ON a = u LIMIT 10
 limit
  ├── columns: a:1!null b:2 u:3 v:4
  ├── cardinality: [0 - 10]
- ├── key: (1,3)
- ├── fd: (1)-->(2), (3)-->(4)
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)-->(4)
  ├── left-join (hash)
  │    ├── columns: a:1!null b:2 u:3 v:4
- │    ├── key: (1,3)
- │    ├── fd: (1)-->(2), (3)-->(4)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3)-->(4)
  │    ├── limit hint: 10.00
  │    ├── limit
  │    │    ├── columns: a:1!null b:2
@@ -1060,8 +1060,8 @@ limit
  ├── fd: ()-->(1-4)
  ├── left-join (hash)
  │    ├── columns: a:1!null b:2 u:3 v:4
- │    ├── key: (1,3)
- │    ├── fd: (1)-->(2), (3)-->(4)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3)-->(4)
  │    ├── limit hint: 1.00
  │    ├── scan ab
  │    │    ├── columns: a:1!null b:2

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -704,8 +704,8 @@ SELECT a.k, a.i, xy.* FROM a LEFT JOIN xy ON a.k=xy.x AND a.i<5
 ----
 left-join (hash)
  ├── columns: k:1!null i:2 x:5 y:6
- ├── key: (1,5)
- ├── fd: (1)-->(2), (5)-->(6)
+ ├── key: (1)
+ ├── fd: (1)-->(2,5,6), (5)-->(6)
  ├── scan a
  │    ├── columns: k:1!null i:2
  │    ├── key: (1)
@@ -973,8 +973,8 @@ SELECT xy.*, a.k, a.i FROM xy LEFT JOIN a ON xy.x=a.k AND a.i<xy.x
 ----
 left-join (hash)
  ├── columns: x:1!null y:2 k:3 i:4
- ├── key: (1,3)
- ├── fd: (1)-->(2), (3)-->(4)
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)-->(4)
  ├── scan xy
  │    ├── columns: x:1!null y:2
  │    ├── key: (1)
@@ -1127,11 +1127,12 @@ SELECT a.k, xy.x, a.k+xy.x AS r FROM a LEFT JOIN xy ON a.k=xy.x
 ----
 project
  ├── columns: k:1!null x:5 r:7
- ├── key: (1,5)
- ├── fd: (1,5)-->(7)
+ ├── key: (1)
+ ├── fd: (1)-->(5), (1,5)-->(7)
  ├── left-join (hash)
  │    ├── columns: k:1!null x:5
- │    ├── key: (1,5)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(5)
  │    ├── scan a
  │    │    ├── columns: k:1!null
  │    │    └── key: (1)
@@ -2636,9 +2637,10 @@ UPSERT INTO returning_test (a, b, c) VALUES (1, 2, 'c') RETURNING a, b, c, d
 ----
 project
  ├── columns: a:1!null b:2!null c:3!null d:4
- ├── cardinality: [1 - ]
+ ├── cardinality: [1 - 1]
  ├── side-effects, mutations
- ├── fd: ()-->(1-3)
+ ├── key: ()
+ ├── fd: ()-->(1-4)
  └── upsert returning_test
       ├── columns: a:1!null b:2!null c:3!null d:4 rowid:8!null
       ├── canary column: 21
@@ -2662,21 +2664,22 @@ project
       │    ├── column3:11 => c:3
       │    ├── upsert_d:22 => d:4
       │    └── upsert_rowid:26 => rowid:8
-      ├── cardinality: [1 - ]
+      ├── cardinality: [1 - 1]
       ├── side-effects, mutations
-      ├── fd: ()-->(1-3)
+      ├── key: ()
+      ├── fd: ()-->(1-4,8)
       └── project
            ├── columns: upsert_d:22 upsert_rowid:26 column1:9!null column2:10!null column3:11!null column12:12 column13:13 a:14 b:15 c:16 d:17 rowid:21
-           ├── cardinality: [1 - ]
+           ├── cardinality: [1 - 1]
            ├── side-effects
-           ├── key: (21)
-           ├── fd: ()-->(9-13), (21)-->(14-17), (14)~~>(15-17,21), (17,21)-->(22), (21)-->(26)
+           ├── key: ()
+           ├── fd: ()-->(9-17,21,22,26)
            ├── left-join (hash)
            │    ├── columns: column1:9!null column2:10!null column3:11!null column12:12 column13:13 a:14 b:15 c:16 d:17 rowid:21
-           │    ├── cardinality: [1 - ]
+           │    ├── cardinality: [1 - 1]
            │    ├── side-effects
-           │    ├── key: (21)
-           │    ├── fd: ()-->(9-13), (21)-->(14-17), (14)~~>(15-17,21)
+           │    ├── key: ()
+           │    ├── fd: ()-->(9-17,21)
            │    ├── ensure-upsert-distinct-on
            │    │    ├── columns: column1:9!null column2:10!null column3:11!null column12:12 column13:13
            │    │    ├── grouping columns: column13:13

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -615,12 +615,12 @@ SELECT * FROM a LEFT JOIN xy ON a.k=xy.x WHERE a.k > 5 AND (xy.x = 6 OR xy.x IS 
 ----
 select
  ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6 y:7
- ├── key: (1,6)
- ├── fd: (1)-->(2-5), (6)-->(7)
+ ├── key: (1)
+ ├── fd: (1)-->(2-7), (6)-->(7)
  ├── left-join (hash)
  │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6 y:7
- │    ├── key: (1,6)
- │    ├── fd: (1)-->(2-5), (6)-->(7)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-7), (6)-->(7)
  │    ├── select
  │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
  │    │    ├── key: (1)
@@ -710,8 +710,8 @@ SELECT * FROM a LEFT JOIN xy ON a.k=xy.x WHERE a.f=1.1
 ----
 left-join (hash)
  ├── columns: k:1!null i:2 f:3!null s:4 j:5 x:6 y:7
- ├── key: (1,6)
- ├── fd: ()-->(3), (1)-->(2,4,5), (6)-->(7)
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2,4-7), (6)-->(7)
  ├── select
  │    ├── columns: k:1!null i:2 f:3!null s:4 j:5
  │    ├── key: (1)
@@ -735,12 +735,12 @@ WHERE a.f=1.1 AND (a.i<xy.y OR xy.y IS NULL) AND (a.s='foo' OR a.s='bar')
 ----
 select
  ├── columns: k:1!null i:2 f:3!null s:4!null j:5 x:6 y:7
- ├── key: (1,6)
- ├── fd: ()-->(3), (1)-->(2,4,5), (6)-->(7)
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2,4-7), (6)-->(7)
  ├── left-join (hash)
  │    ├── columns: k:1!null i:2 f:3!null s:4!null j:5 x:6 y:7
- │    ├── key: (1,6)
- │    ├── fd: ()-->(3), (1)-->(2,4,5), (6)-->(7)
+ │    ├── key: (1)
+ │    ├── fd: ()-->(3), (1)-->(2,4-7), (6)-->(7)
  │    ├── select
  │    │    ├── columns: k:1!null i:2 f:3!null s:4!null j:5
  │    │    ├── key: (1)
@@ -801,12 +801,12 @@ SELECT * FROM a RIGHT JOIN xy ON a.k=xy.x WHERE a.i=100 OR a.i IS NULL
 ----
 select
  ├── columns: k:1 i:2 f:3 s:4 j:5 x:6!null y:7
- ├── key: (1,6)
- ├── fd: (6)-->(7), (1)-->(2-5)
+ ├── key: (6)
+ ├── fd: (6)-->(1-5,7), (1)-->(2-5)
  ├── left-join (hash)
  │    ├── columns: k:1 i:2 f:3 s:4 j:5 x:6!null y:7
- │    ├── key: (1,6)
- │    ├── fd: (6)-->(7), (1)-->(2-5)
+ │    ├── key: (6)
+ │    ├── fd: (6)-->(1-5,7), (1)-->(2-5)
  │    ├── scan xy
  │    │    ├── columns: x:6!null y:7
  │    │    ├── key: (6)
@@ -899,12 +899,12 @@ SELECT * FROM xy LEFT JOIN a ON a.k=xy.x WHERE a.i=100 OR a.i IS NULL
 ----
 select
  ├── columns: x:1!null y:2 k:3 i:4 f:5 s:6 j:7
- ├── key: (1,3)
- ├── fd: (1)-->(2), (3)-->(4-7)
+ ├── key: (1)
+ ├── fd: (1)-->(2-7), (3)-->(4-7)
  ├── left-join (hash)
  │    ├── columns: x:1!null y:2 k:3 i:4 f:5 s:6 j:7
- │    ├── key: (1,3)
- │    ├── fd: (1)-->(2), (3)-->(4-7)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-7), (3)-->(4-7)
  │    ├── scan xy
  │    │    ├── columns: x:1!null y:2
  │    │    ├── key: (1)

--- a/pkg/sql/opt/norm/testdata/rules/side_effects
+++ b/pkg/sql/opt/norm/testdata/rules/side_effects
@@ -130,15 +130,16 @@ SELECT * FROM a WHERE (CASE WHEN i<0 THEN 5 ELSE (SELECT y FROM xy WHERE x=i LIM
 ----
 project
  ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── key: (1)
  ├── fd: (1)-->(2-5)
  └── select
       ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6 y:7
-      ├── key: (1,6)
-      ├── fd: (1)-->(2-5), (6)-->(7)
+      ├── key: (1)
+      ├── fd: (1)-->(2-7), (6)-->(7)
       ├── left-join (hash)
       │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6 y:7
-      │    ├── key: (1,6)
-      │    ├── fd: (1)-->(2-5), (6)-->(7)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-7), (6)-->(7)
       │    ├── scan a
       │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
       │    │    ├── key: (1)
@@ -292,16 +293,17 @@ SELECT * FROM a WHERE IFERROR(1/0, (SELECT y::DECIMAL FROM xy WHERE x = i))=k
 project
  ├── columns: k:1!null i:2 f:3 s:4 j:5
  ├── side-effects
+ ├── key: (1)
  ├── fd: (1)-->(2-5)
  └── select
       ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6 y:8
       ├── side-effects
-      ├── key: (1,6)
-      ├── fd: (1)-->(2-5), (6)-->(8)
+      ├── key: (1)
+      ├── fd: (1)-->(2-6,8), (6)-->(8)
       ├── left-join (hash)
       │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6 y:8
-      │    ├── key: (1,6)
-      │    ├── fd: (1)-->(2-5), (6)-->(8)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-6,8), (6)-->(8)
       │    ├── scan a
       │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
       │    │    ├── key: (1)

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -1146,18 +1146,199 @@ func (f *FuncDepSet) MakeApply(inner *FuncDepSet) {
 // MakeLeftOuter modifies the cartesian product FD set to reflect the impact of
 // adding NULL-extended rows to the results of an inner join. An inner join can
 // be modeled as a cartesian product + ON filtering, and an outer join is
-// modeled as an inner join + union of NULL-extended rows. MakeLeftOuter
-// performs the final step, given the set of columns that will be null-extended
-// (i.e. columns from the null-providing side(s) of the join), as well as the
-// set of input columns from both sides of the join that are not null.
+// modeled as an inner join + union of NULL-extended rows. MakeLeftOuter enacts
+// the filtering and null-extension of the cartesian product. If it is possible
+// to prove that there is a key over the join result that consists only of
+// columns from the left input, that key will be used.
 //
 // This same logic applies for right joins as well (by reversing sides).
 //
 // See the "Left outer join" section on page 84 of the Master's Thesis for the
 // impact of outer joins on FDs.
-func (f *FuncDepSet) MakeLeftOuter(rightCols, notNullInputCols opt.ColSet) {
+func (f *FuncDepSet) MakeLeftOuter(
+	leftFDs, filtersFDs *FuncDepSet, leftCols, rightCols, notNullInputCols opt.ColSet,
+) {
+	// The columns from the left input form a key over the result of the LeftJoin
+	// if the following conditions are met:
+	//
+	//  1. The left input has a strict key.
+	//
+	//  2. The left columns form a strict key over the filtered cartesian product.
+	//     (In other words, the left columns would form a key over an inner join
+	//      with the same filters).
+	//
+	// The above conditions are sufficient because a strict key (over the filtered
+	// cartesian product) that only contains columns from the left side implies
+	// that no left rows were duplicated. This is because even a single duplicated
+	// row would prohibit a strict key containing only those columns. And if there
+	// was already a strict key in the original left input, adding back filtered
+	// left rows will not create any duplicates. This means that the LeftJoin will
+	// not duplicate any of the left rows. Therefore, a key over the left input
+	// must also be a key over the result of the join.
+	//
+	// If the conditions are not met, a key over the unfiltered cartesian product
+	// (if one exists) is used. Why is this key valid to use?
+	//
+	//   * A left join can filter rows and null-extend rows from the cartesian
+	//     product.
+	//   * Filtering rows does not affect the presence of a key.
+	//   * Null-extending rows does not affect the presence of a key because the
+	//     cartesian product could only have a key if the left and right inputs
+	//     also had keys (see FuncDepSet.MakeProduct). Therefore, null-extended
+	//     left rows that are added back by the left join must be unique.
+	//
+	// As an example, consider this data and this query:
+	//
+	//   a      b
+	//   -      -
+	//   1      1
+	//   2      2
+	//   3
+	//   4
+	//
+	//   SELECT * FROM a_tab LEFT JOIN b_tab ON a < 3
+	//
+	// Both tables a and b have a strict key. If we take their cartesian product,
+	// we get something like this:
+	//
+	//   a  b
+	//   ----
+	//   1  1
+	//   1  2
+	//   2  1
+	//   2  2
+	//   3  1
+	//   3  2
+	//   4  1
+	//   4  2
+	//
+	// Now, columns a and b together form a strict key over the cartesian product.
+	// If either a or b had duplicate rows to begin with, a key over the cartesian
+	// product would not be possible. Now, the left join's "a < 3" on condition is
+	// applied:
+	//
+	//   a  b
+	//   ----
+	//   1  1
+	//   1  2
+	//   2  1
+	//   2  2
+	//
+	// Finally, the left join adds back the rows of a, null-extending b:
+	//
+	//   a  b
+	//   ----
+	//   1  1
+	//   1  2
+	//   2  1
+	//   2  2
+	//   3  NULL
+	//   4  NULL
+	//
+	// Since a had a key to begin with, the "3" and "4" rows that are added back
+	// are unique. Therefore, a and b are a strict key for the left join.
+	//
+	// TODO(drewk): support for lax keys/dependencies from the right input can be
+	//  added if it turns out to be useful.
+
+	// Save a strict key from the left input, if one exists.
+	leftKey, leftHasKey := leftFDs.StrictKey()
+
+	// Save a key from the unfiltered cartesian product, if one exists.
+	oldKey := f.key
+	oldKeyType := f.hasKey
+
+	// If the left input has a key, add the FDs from the join filters to a copy of
+	// the cartesian product FD set. Next, check whether the columns of the left
+	// input form a strict key over the result of applying the join filters to the
+	// cartesian product.
+	//
+	// We have to apply the filters to a copy because filter FDs are often not
+	// valid after null-extended rows are added. For example:
+	//
+	//   a  b  c     d     e
+	//   ----------------------
+	//   1  1  1     NULL  1
+	//   1  2  NULL  NULL  NULL
+	//   2  1  NULL  NULL  NULL
+	//
+	// Let's say this table is the result of a join between 'ab' and 'cde'. The
+	// join condition might have included e = 1, but it would not be correct to
+	// add the corresponding constant FD to the final join FD set because the e
+	// column has been null extended, and therefore the condition doesn't hold for
+	// the final outer join result.
+	leftColsAreInnerJoinKey := false
+	if leftHasKey {
+		c := FuncDepSet{}
+		c.CopyFrom(f)
+		c.AddFrom(filtersFDs)
+		leftColsAreInnerJoinKey = c.ColsAreStrictKey(leftCols)
+	}
+
+	// Modify the cartesian product FD set to reflect the impact of adding
+	// NULL-extended rows to the results of the filtered cartesian product (or, in
+	// other words, the results of an inner join).
+	f.nullExtendRightRows(rightCols, notNullInputCols)
+
+	// If the conditions have been met, use the key from the left side. Otherwise,
+	// use the key from the cartesian product.
+	if leftHasKey && leftColsAreInnerJoinKey {
+		f.setKey(leftKey, strictKey)
+	} else {
+		// See the comment at the top of the function for why it is valid to use the
+		// key from the cartesian product.
+		f.setKey(oldKey, oldKeyType)
+		// Call tryToReduceKey with only the left columns from notNullInputCols
+		// because the right columns may have been null-extended.
+		f.tryToReduceKey(leftCols.Intersection(notNullInputCols))
+	}
+	// ensureKeyClosure must be called when oldKey is used as well as the new
+	// leftKey because nullExtendRightRows can remove FDs, such that the closure
+	// of oldKey ends up missing some columns from the right.
+	f.ensureKeyClosure(leftCols.Union(rightCols))
+}
+
+// MakeFullOuter modifies the cartesian product FD set to reflect the impact of
+// adding NULL-extended rows to the results of an inner join. An inner join can
+// be modeled as a cartesian product + ON filtering, and an outer join is
+// modeled as an inner join + union of NULL-extended rows. MakeFullOuter
+// performs the final step for a full join, given the set of columns on each
+// side, as well as the set of input columns from both sides of the join that
+// are not null.
+func (f *FuncDepSet) MakeFullOuter(leftCols, rightCols, notNullInputCols opt.ColSet) {
+	if f.hasKey == strictKey {
+		if f.key.Empty() {
+			// The cartesian product has an empty key when both sides have an empty key;
+			// but the outer join can have two rows so the empty key doesn't hold.
+			f.hasKey = noKey
+			f.key = opt.ColSet{}
+		} else if !f.key.Intersects(notNullInputCols) {
+			// If the cartesian product has a strict key, the key holds on the full
+			// outer result only if one of the key columns is known to be not-null in
+			// the input. Otherwise, a row where all the key columns are NULL can
+			// "conflict" with a row where these columns are NULL because of
+			// null-extension. For example:
+			//   -- t1 and t2 each have one row containing NULL for column x.
+			//   SELECT * FROM t1 FULL JOIN t2 ON t1.x=t2.x
+			//
+			//   t1.x  t2.x
+			//   ----------
+			//   NULL  NULL
+			//   NULL  NULL
+			f.hasKey = laxKey
+		}
+	}
+	f.nullExtendRightRows(leftCols, notNullInputCols)
+	f.nullExtendRightRows(rightCols, notNullInputCols)
+	f.ensureKeyClosure(leftCols.Union(rightCols))
+}
+
+// nullExtendRightRows is used by MakeLeftOuter and MakeFullOuter to modify the
+// cartesian product FD set to reflect the impact of adding NULL-extended rows
+// to the results of an inner join. See the MakeLeftOuter comment for more
+// information.
+func (f *FuncDepSet) nullExtendRightRows(rightCols, notNullInputCols opt.ColSet) {
 	var newFDs []funcDep
-	allCols := f.ColSet()
 
 	n := 0
 	for i := range f.deps {
@@ -1255,48 +1436,6 @@ func (f *FuncDepSet) MakeLeftOuter(rightCols, notNullInputCols opt.ColSet) {
 		fd := &newFDs[i]
 		f.addDependency(fd.from, fd.to, fd.strict, fd.equiv)
 	}
-
-	// Note that there is no impact on any key that may be present for the
-	// relation. If there is a key, then that means the row-providing side of
-	// the join had its own key, and any added rows will therefore be unique.
-	// However, the key's closure may no longer include all columns in the
-	// relation, due to removing FDs and/or making them lax, so if necessary,
-	// add a new strict FD that ensures the key's closure is maintained.
-	f.ensureKeyClosure(allCols)
-}
-
-// MakeFullOuter modifies the cartesian product FD set to reflect the impact of
-// adding NULL-extended rows to the results of an inner join. An inner join can
-// be modeled as a cartesian product + ON filtering, and an outer join is
-// modeled as an inner join + union of NULL-extended rows. MakeFullOuter
-// performs the final step for a full join, given the set of columns on each
-// side, as well as the set of input columns from both sides of the join that
-// are not null.
-func (f *FuncDepSet) MakeFullOuter(leftCols, rightCols, notNullInputCols opt.ColSet) {
-	if f.hasKey == strictKey {
-		if f.key.Empty() {
-			// The cartesian product has an empty key when both sides have an empty key;
-			// but the outer join can have two rows so the empty key doesn't hold.
-			f.hasKey = noKey
-			f.key = opt.ColSet{}
-		} else if !f.key.Intersects(notNullInputCols) {
-			// If the cartesian product has a strict key, the key holds on the full
-			// outer result only if one of the key columns is known to be not-null in
-			// the input. Otherwise, a row where all the key columns are NULL can
-			// "conflict" with a row where these columns are NULL because of
-			// null-extension. For example:
-			//   -- t1 and t2 each have one row containing NULL for column x.
-			//   SELECT * FROM t1 FULL JOIN t2 ON t1.x=t2.x
-			//
-			//   t1.x  t2.x
-			//   ----------
-			//   NULL  NULL
-			//   NULL  NULL
-			f.hasKey = laxKey
-		}
-	}
-	f.MakeLeftOuter(leftCols, notNullInputCols)
-	f.MakeLeftOuter(rightCols, notNullInputCols)
 }
 
 // EquivReps returns one "representative" column from each equivalency group in

--- a/pkg/sql/opt/props/func_dep_test.go
+++ b/pkg/sql/opt/props/func_dep_test.go
@@ -35,16 +35,19 @@ func TestFuncDeps_ColsAreKey(t *testing.T) {
 	// CREATE TABLE abcde (a INT PRIMARY KEY, b INT, c INT, d INT, e INT)
 	// CREATE UNIQUE INDEX ON abcde (b, c)
 	// CREATE TABLE mnpq (m INT, n INT, p INT, q INT, PRIMARY KEY (m, n))
-	// SELECT * FROM abcde LEFT OUTER JOIN (SELECT *, p+q FROM mnpq) ON c=1 AND m=1 WHERE a=m
+	// This case wouldn't actually happen with a real world query.
+	var loj props.FuncDepSet
+	preservedCols := c(1, 2, 3, 4, 5)
 	nullExtendedCols := c(10, 11, 12, 13, 14)
-	loj := makeAbcdeFD(t)
+	abcde := makeAbcdeFD(t)
 	mnpq := makeMnpqFD(t)
 	mnpq.AddSynthesizedCol(c(12, 13), 14)
+	loj.CopyFrom(abcde)
 	loj.MakeProduct(mnpq)
 	loj.AddConstants(c(3))
-	loj.MakeLeftOuter(nullExtendedCols, c(1, 10, 11))
+	loj.MakeLeftOuter(abcde, &props.FuncDepSet{}, preservedCols, nullExtendedCols, c(1, 10, 11))
 	loj.AddEquivalency(1, 10)
-	verifyFD(t, loj, "key(10,11); ()-->(3), (1)-->(2,4,5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (12,13)~~>(14), (1,10,11)-->(14), (1)==(10), (10)==(1)")
+	verifyFD(t, &loj, "key(10,11); ()-->(3), (1)-->(2,4,5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (12,13)~~>(14), (1,10,11)-->(14), (1)==(10), (10)==(1)")
 
 	testcases := []struct {
 		cols   opt.ColSet
@@ -69,8 +72,8 @@ func TestFuncDeps_ColsAreKey(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		testColsAreStrictKey(t, loj, tc.cols, tc.strict)
-		testColsAreLaxKey(t, loj, tc.cols, tc.lax)
+		testColsAreStrictKey(t, &loj, tc.cols, tc.strict)
+		testColsAreLaxKey(t, &loj, tc.cols, tc.lax)
 	}
 }
 
@@ -93,12 +96,12 @@ func TestFuncDeps_ComputeClosure(t *testing.T) {
 	// (c)==(b)
 	// (d)-->(e)
 	fd2 := &props.FuncDepSet{}
-	fd2.AddConstants(c(1, 2))
-	fd2.AddSynthesizedCol(c(1), 4)
-	fd2.MakeLeftOuter(c(1, 4), c())
+	// This isn't intended to create a real lax key; just a lax dependency.
+	fd2.AddLaxKey(c(1), c(1, 4))
+	fd2.AddConstants(c(2))
 	fd2.AddEquivalency(2, 3)
 	fd2.AddSynthesizedCol(c(4), 5)
-	verifyFD(t, fd2, "()-->(2,3), (1)~~>(4), (2)==(3), (3)==(2), (4)-->(5)")
+	verifyFD(t, fd2, "lax-key(1); ()-->(2,3), (1)~~>(4), (2)==(3), (3)==(2), (4)-->(5)")
 
 	testcases := []struct {
 		fd       *props.FuncDepSet
@@ -131,12 +134,12 @@ func TestFuncDeps_InClosureOf(t *testing.T) {
 	// (c)==(b)
 	// (d)-->(e)
 	fd := &props.FuncDepSet{}
-	fd.AddConstants(c(1, 2))
-	fd.AddSynthesizedCol(c(1), 4)
-	fd.MakeLeftOuter(c(1, 4), c())
+	fd.AddConstants(c(2))
+	// This isn't intended to create a real lax key; just a lax dependency.
+	fd.AddLaxKey(c(1), c(1, 4))
 	fd.AddEquivalency(2, 3)
 	fd.AddSynthesizedCol(c(4), 5)
-	verifyFD(t, fd, "()-->(2,3), (1)~~>(4), (2)==(3), (3)==(2), (4)-->(5)")
+	verifyFD(t, fd, "lax-key(1); ()-->(2,3), (1)~~>(4), (2)==(3), (3)==(2), (4)-->(5)")
 
 	testcases := []struct {
 		cols     []opt.ColumnID
@@ -177,13 +180,13 @@ func TestFuncDeps_ComputeEquivClosure(t *testing.T) {
 	// (a)~~>(e)
 	// (a)-->(f)
 	fd1 := &props.FuncDepSet{}
-	fd1.AddSynthesizedCol(c(1), 5)
-	fd1.MakeLeftOuter(c(1, 5), c())
+	// This isn't intended to create a real lax key; just a lax dependency.
+	fd1.AddLaxKey(c(1), c(1, 5))
 	fd1.AddSynthesizedCol(c(1), 6)
 	fd1.AddEquivalency(1, 2)
 	fd1.AddEquivalency(2, 3)
 	fd1.AddEquivalency(1, 4)
-	verifyFD(t, fd1, "(1)~~>(5), (1)-->(6), (1)==(2-4), (2)==(1,3,4), (3)==(1,2,4), (4)==(1-3)")
+	verifyFD(t, fd1, "lax-key(1); (1)~~>(5), (1)-->(6), (1)==(2-4), (2)==(1,3,4), (3)==(1,2,4), (4)==(1-3)")
 
 	testcases := []struct {
 		fd       *props.FuncDepSet
@@ -213,12 +216,12 @@ func TestFuncDeps_EquivReps(t *testing.T) {
 	// (a)~~>(e)
 	// (a)-->(f)
 	fd1 := &props.FuncDepSet{}
-	fd1.AddSynthesizedCol(c(1), 5)
-	fd1.MakeLeftOuter(c(1, 5), c())
+	// This isn't intended to create a real lax key; just a lax dependency.
+	fd1.AddLaxKey(c(1), c(1, 5))
 	fd1.AddSynthesizedCol(c(1), 6)
 	fd1.AddEquivalency(1, 2)
 	fd1.AddEquivalency(2, 3)
-	verifyFD(t, fd1, "(1)~~>(5), (1)-->(6), (1)==(2,3), (2)==(1,3), (3)==(1,2)")
+	verifyFD(t, fd1, "lax-key(1); (1)~~>(5), (1)-->(6), (1)==(2,3), (2)==(1,3), (3)==(1,2)")
 
 	// (a)==(b,d)
 	// (b)==(a,c)
@@ -229,7 +232,7 @@ func TestFuncDeps_EquivReps(t *testing.T) {
 	fd2 := &props.FuncDepSet{}
 	fd2.CopyFrom(fd1)
 	fd2.AddEquivalency(1, 4)
-	verifyFD(t, fd2, "(1)~~>(5), (1)-->(6), (1)==(2-4), (2)==(1,3,4), (3)==(1,2,4), (4)==(1-3)")
+	verifyFD(t, fd2, "lax-key(1); (1)~~>(5), (1)-->(6), (1)==(2-4), (2)==(1,3,4), (3)==(1,2,4), (4)==(1-3)")
 
 	// (a)==(b,d)
 	// (b)==(a,c)
@@ -240,7 +243,7 @@ func TestFuncDeps_EquivReps(t *testing.T) {
 	fd3 := &props.FuncDepSet{}
 	fd3.CopyFrom(fd1)
 	fd3.AddEquivalency(4, 5)
-	verifyFD(t, fd3, "(1)~~>(5), (1)-->(6), (1)==(2,3), (2)==(1,3), (3)==(1,2), (4)==(5), (5)==(4)")
+	verifyFD(t, fd3, "lax-key(1); (1)~~>(5), (1)-->(6), (1)==(2,3), (2)==(1,3), (3)==(1,2), (4)==(5), (5)==(4)")
 
 	testcases := []struct {
 		fd       *props.FuncDepSet
@@ -363,12 +366,15 @@ func TestFuncDeps_MakeNotNull(t *testing.T) {
 	// CREATE TABLE abcde (a INT PRIMARY KEY, b INT, c INT, d INT, e INT)
 	// CREATE UNIQUE INDEX ON abcde (b, c)
 	// CREATE TABLE mnpq (m INT, n INT, p INT, q INT, PRIMARY KEY (m, n))
-	// SELECT * FROM abcde LEFT OUTER JOIN mnpq ON a=1 AND b=1 AND m=1 AND p=1 WHERE p IS NOT NULL
+	// SELECT * FROM (SELECT * FROM abcde WHERE a=1 AND b=1)
+	//   LEFT OUTER JOIN (SELECT * FROM mnpq WHERE m=1 AND p=1) ON True
+	//   WHERE p IS NOT NULL
+	preservedCols := c(1, 2, 3, 4, 5)
 	nullExtendedCols := c(10, 11, 12, 13)
 	loj := makeProductFD(t)
 	loj.AddConstants(c(1, 2, 10, 12))
 	verifyFD(t, loj, "key(11); ()-->(1-5,10,12), (11)-->(13)")
-	loj.MakeLeftOuter(nullExtendedCols, c(1, 2, 10, 11, 12))
+	loj.MakeLeftOuter(abcde, &props.FuncDepSet{}, preservedCols, nullExtendedCols, c(1, 2, 10, 11, 12))
 	verifyFD(t, loj, "key(11); ()-->(1-5), (11)-->(10,12,13)")
 	loj.MakeNotNull(c(1, 2, 12))
 	verifyFD(t, loj, "key(11); ()-->(1-5), (11)-->(10,12,13)")
@@ -898,131 +904,212 @@ func TestFuncDeps_MakeApply(t *testing.T) {
 }
 
 func TestFuncDeps_MakeLeftOuter(t *testing.T) {
-	// All determinant columns in null-supplying side are nullable.
+	// All determinant columns in null-extended side are nullable.
 	//   CREATE TABLE abcde (a INT PRIMARY KEY, b INT, c INT, d INT, e INT)
 	//   CREATE UNIQUE INDEX ON abcde (b, c)
 	//   CREATE TABLE mnpq (m INT, n INT, p INT, q INT, PRIMARY KEY (m, n))
 	//   SELECT * FROM abcde LEFT OUTER JOIN (SELECT *, p+q FROM mnpq) ON True
+	var loj props.FuncDepSet
+	preservedCols := c(1, 2, 3, 4, 5)
 	nullExtendedCols := c(10, 11, 12, 13, 14)
-	loj := makeAbcdeFD(t)
+	abcde := makeAbcdeFD(t)
 	mnpq := makeMnpqFD(t)
 	mnpq.AddSynthesizedCol(c(12, 13), 14)
+	loj.CopyFrom(abcde)
 	loj.MakeProduct(mnpq)
-	verifyFD(t, loj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (12,13)-->(14)")
-	loj.MakeLeftOuter(nullExtendedCols, c(1, 10, 11))
-	verifyFD(t, loj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (12,13)~~>(14), (1,10,11)-->(14)")
+	verifyFD(t, &loj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (12,13)-->(14)")
+	loj.MakeLeftOuter(abcde, &props.FuncDepSet{}, preservedCols, nullExtendedCols, c(1, 10, 11))
+	verifyFD(t, &loj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (12,13)~~>(14), (1,10,11)-->(14)")
 
-	// One determinant column in null-supplying side is not null.
+	// One determinant column in null-extended side is not null.
 	//   SELECT * FROM abcde LEFT OUTER JOIN (SELECT *, m+q FROM mnpq) ON True
+	preservedCols = c(1, 2, 3, 4, 5)
 	nullExtendedCols = c(10, 11, 12, 13, 14)
-	loj = makeAbcdeFD(t)
+	abcde = makeAbcdeFD(t)
 	mnpq = makeMnpqFD(t)
 	mnpq.AddSynthesizedCol(c(10, 13), 14)
+	loj.CopyFrom(abcde)
 	loj.MakeProduct(mnpq)
-	verifyFD(t, loj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (10,13)-->(14)")
-	loj.MakeLeftOuter(nullExtendedCols, c(1, 10, 11))
-	verifyFD(t, loj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (10,13)-->(14)")
+	verifyFD(t, &loj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (10,13)-->(14)")
+	loj.MakeLeftOuter(abcde, &props.FuncDepSet{}, preservedCols, nullExtendedCols, c(1, 10, 11))
+	verifyFD(t, &loj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (10,13)-->(14)")
 
-	// Add constants on both sides of outer join.
-	//   SELECT * FROM abcde RIGHT OUTER JOIN mnpq ON b=1 AND c=1 AND p=1
+	// Inputs have constant columns. Constant columns on the row-supplying side
+	// stay constant, while constant columns on the null-supplying side are not
+	// constant after null-extension.
+	var roj props.FuncDepSet
+	preservedCols = c(10, 11, 12, 13)
 	nullExtendedCols = c(1, 2, 3, 4, 5)
-	roj := makeAbcdeFD(t)
+	abcde = makeAbcdeFD(t)
+	roj.CopyFrom(abcde)
 	roj.MakeProduct(makeMnpqFD(t))
 	roj.AddConstants(c(2, 3, 12))
 	roj.MakeNotNull(c(2, 3, 12))
-	verifyFD(t, roj, "key(10,11); ()-->(2,3,12), (1)-->(4,5), (2,3)-->(1,4,5), (10,11)-->(13)")
-	roj.MakeLeftOuter(nullExtendedCols, c(1, 2, 3, 10, 11, 12))
-	verifyFD(t, roj, "key(10,11); ()-->(12), (1)-->(4,5), (2,3)-->(1,4,5), (10,11)-->(1-5,13)")
+	verifyFD(t, &roj, "key(10,11); ()-->(2,3,12), (1)-->(4,5), (2,3)-->(1,4,5), (10,11)-->(13)")
+	roj.MakeLeftOuter(mnpq, &props.FuncDepSet{}, preservedCols, nullExtendedCols, c(1, 2, 3, 10, 11, 12))
+	verifyFD(t, &roj, "key(10,11); ()-->(12), (1)-->(4,5), (2,3)-->(1,4,5), (10,11)-->(1-5,13)")
+
+	// Add constants on both sides of outer join. None of the resulting columns
+	// are constant, because rows are added back after filtering on the
+	// row-supplying side, and the null-supplying side is null-extended.
+	//   SELECT * FROM abcde RIGHT OUTER JOIN mnpq ON b=1 AND c=1 AND p=1
+	filters := props.FuncDepSet{}
+	preservedCols = c(10, 11, 12, 13)
+	nullExtendedCols = c(1, 2, 3, 4, 5)
+	abcde = makeAbcdeFD(t)
+	roj.CopyFrom(abcde)
+	roj.MakeProduct(makeMnpqFD(t))
+	filters.AddConstants(c(2, 3, 12))
+	filters.MakeNotNull(c(2, 3, 12))
+	verifyFD(t, &roj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13)")
+	roj.MakeLeftOuter(mnpq, &filters, preservedCols, nullExtendedCols, c(1, 2, 3, 10, 11, 12))
+	verifyFD(t, &roj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13)")
 
 	// Test equivalency on both sides of outer join.
-	//   SELECT * FROM abcde RIGHT OUTER JOIN mnpq ON b=c AND c=d AND m=p AND m=q
+	preservedCols = c(10, 11, 12, 13)
 	nullExtendedCols = c(1, 2, 3, 4, 5)
-	roj = makeAbcdeFD(t)
+	abcde = makeAbcdeFD(t)
+	roj.CopyFrom(abcde)
 	roj.MakeProduct(makeMnpqFD(t))
 	roj.AddEquivalency(2, 3)
 	roj.AddEquivalency(3, 4)
 	roj.AddEquivalency(10, 12)
 	roj.AddEquivalency(10, 13)
-	verifyFD(t, roj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,5), (10,11)-->(12,13), (2)==(3,4), (3)==(2,4), (4)==(2,3), (10)==(12,13), (12)==(10,13), (13)==(10,12)")
-	roj.MakeLeftOuter(nullExtendedCols, c(1, 2, 3, 10, 11, 13))
-	verifyFD(t, roj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,5), (10,11)-->(12,13), (2)==(3,4), (3)==(2,4), (4)==(2,3), (10)==(12,13), (12)==(10,13), (13)==(10,12)")
+	verifyFD(t, &roj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,5), (10,11)-->(12,13), (2)==(3,4), (3)==(2,4), (4)==(2,3), (10)==(12,13), (12)==(10,13), (13)==(10,12)")
+	roj.MakeLeftOuter(mnpq, &props.FuncDepSet{}, preservedCols, nullExtendedCols, c(1, 2, 3, 10, 11, 13))
+	verifyFD(t, &roj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,5), (10,11)-->(12,13), (2)==(3,4), (3)==(2,4), (4)==(2,3), (10)==(12,13), (12)==(10,13), (13)==(10,12)")
+
+	// Test equivalencies on both sides of outer join in filters.
+	//   SELECT * FROM abcde RIGHT OUTER JOIN mnpq ON b=c AND c=d AND m=p AND m=q
+	filters = props.FuncDepSet{}
+	preservedCols = c(10, 11, 12, 13)
+	nullExtendedCols = c(1, 2, 3, 4, 5)
+	abcde = makeAbcdeFD(t)
+	roj.CopyFrom(abcde)
+	roj.MakeProduct(makeMnpqFD(t))
+	filters.AddEquivalency(2, 3)
+	filters.AddEquivalency(3, 4)
+	filters.AddEquivalency(10, 12)
+	filters.AddEquivalency(10, 13)
+	verifyFD(t, &roj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13)")
+	roj.MakeLeftOuter(mnpq, &filters, preservedCols, nullExtendedCols, c(1, 2, 3, 10, 11, 13))
+	verifyFD(t, &roj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13)")
 
 	// Test equivalency that crosses join boundary.
-	//   SELECT * FROM abcde RIGHT OUTER JOIN mnpq ON a=m
+	preservedCols = c(10, 11, 12, 13)
 	nullExtendedCols = c(1, 2, 3, 4, 5)
-	roj = makeAbcdeFD(t)
+	abcde = makeAbcdeFD(t)
+	roj.CopyFrom(abcde)
 	roj.MakeProduct(makeMnpqFD(t))
 	roj.AddEquivalency(1, 10)
-	verifyFD(t, roj, "key(10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(10), (10)==(1)")
-	roj.MakeLeftOuter(nullExtendedCols, c(1, 10, 11))
-	verifyFD(t, roj, "key(10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(1-5,12,13), (1)~~>(10)")
+	verifyFD(t, &roj, "key(10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(10), (10)==(1)")
+	roj.MakeLeftOuter(mnpq, &props.FuncDepSet{}, preservedCols, nullExtendedCols, c(1, 10, 11))
+	verifyFD(t, &roj, "key(10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(1-5,12,13), (1)~~>(10)")
+
+	// Test filter equivalency that crosses join boundary.
+	//   SELECT * FROM abcde RIGHT OUTER JOIN mnpq ON a=m
+	filters = props.FuncDepSet{}
+	preservedCols = c(10, 11, 12, 13)
+	nullExtendedCols = c(1, 2, 3, 4, 5)
+	abcde = makeAbcdeFD(t)
+	roj.CopyFrom(abcde)
+	roj.MakeProduct(makeMnpqFD(t))
+	filters.AddEquivalency(1, 10)
+	verifyFD(t, &roj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13)")
+	roj.MakeLeftOuter(mnpq, &filters, preservedCols, nullExtendedCols, c(1, 10, 11))
+	verifyFD(t, &roj, "key(10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(1-5,12,13)")
 
 	// Test equivalency that includes columns from both sides of join boundary.
-	//   SELECT * FROM abcde RIGHT OUTER JOIN mnpq ON a=m AND a=b
+	preservedCols = c(10, 11, 12, 13)
 	nullExtendedCols = c(1, 2, 3, 4, 5)
-	roj = makeAbcdeFD(t)
+	abcde = makeAbcdeFD(t)
+	roj.CopyFrom(abcde)
 	roj.MakeProduct(makeMnpqFD(t))
 	roj.AddEquivalency(1, 10)
 	roj.AddEquivalency(1, 2)
-	verifyFD(t, roj, "key(10,11); (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(2,10), (10)==(1,2), (2)==(1,10)")
-	roj.MakeLeftOuter(nullExtendedCols, c(1, 2, 10, 11))
-	verifyFD(t, roj, "key(10,11); (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(1-5,12,13), (1)==(2), (2)==(1), (1)~~>(10), (2)~~>(10)")
+	verifyFD(t, &roj, "key(10,11); (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1)==(2,10), (10)==(1,2), (2)==(1,10)")
+	roj.MakeLeftOuter(mnpq, &props.FuncDepSet{}, preservedCols, nullExtendedCols, c(1, 2, 10, 11))
+	verifyFD(t, &roj, "key(10,11); (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(1-5,12,13), (1)==(2), (2)==(1), (1)~~>(10), (2)~~>(10)")
+
+	// Test filter equivalency that includes columns from both sides of join
+	// boundary.
+	//   SELECT * FROM abcde RIGHT OUTER JOIN mnpq ON a=m AND a=b
+	filters = props.FuncDepSet{}
+	preservedCols = c(10, 11, 12, 13)
+	nullExtendedCols = c(1, 2, 3, 4, 5)
+	abcde = makeAbcdeFD(t)
+	roj.CopyFrom(abcde)
+	roj.MakeProduct(makeMnpqFD(t))
+	filters.AddEquivalency(1, 10)
+	filters.AddEquivalency(1, 2)
+	verifyFD(t, &roj, "key(1,10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(12,13)")
+	roj.MakeLeftOuter(mnpq, &filters, preservedCols, nullExtendedCols, c(1, 2, 10, 11))
+	verifyFD(t, &roj, "key(10,11); (1)-->(2-5), (2,3)~~>(1,4,5), (10,11)-->(1-5,12,13)")
 
 	// Test multiple calls to MakeLeftOuter, where the first creates determinant with
 	// columns from both sides of join.
 	//   SELECT * FROM (SELECT * FROM abcde WHERE b=1) FULL JOIN mnpq ON True
+	preservedCols = c(10, 11, 12, 13)
+	preservedCols2 := c(1, 2, 3, 4, 5)
 	nullExtendedCols = c(1, 2, 3, 4, 5)
 	nullExtendedCols2 := c(10, 11, 12, 13)
-	roj = makeAbcdeFD(t)
+	abcde = makeAbcdeFD(t)
+	roj.CopyFrom(abcde)
 	roj.AddConstants(c(2))
 	roj.MakeProduct(makeMnpqFD(t))
-	verifyFD(t, roj, "key(1,10,11); ()-->(2), (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(12,13)")
-	roj.MakeLeftOuter(nullExtendedCols, c(1, 2, 10, 11))
-	verifyFD(t, roj, "key(1,10,11); (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1,10,11)-->(2)")
-	roj.MakeLeftOuter(nullExtendedCols2, c(1, 2, 10, 11))
-	verifyFD(t, roj, "key(1,10,11); (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1,10,11)-->(2)")
+	verifyFD(t, &roj, "key(1,10,11); ()-->(2), (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(12,13)")
+	roj.MakeLeftOuter(mnpq, &props.FuncDepSet{}, preservedCols, nullExtendedCols, c(1, 2, 10, 11))
+	verifyFD(t, &roj, "key(1,10,11); (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1,10,11)-->(2)")
+	roj.MakeLeftOuter(abcde, &props.FuncDepSet{}, preservedCols2, nullExtendedCols2, c(1, 2, 10, 11))
+	verifyFD(t, &roj, "key(1,10,11); (1)-->(3-5), (2,3)~~>(1,4,5), (10,11)-->(12,13), (1,10,11)-->(2)")
 
 	// Join keyless relations with nullable columns.
 	//   SELECT * FROM (SELECT d, e, d+e FROM abcde) LEFT JOIN (SELECT p, q, p+q FROM mnpq) ON True
+	preservedCols = c(4, 5, 6)
 	nullExtendedCols = c(12, 13, 14)
-	loj = makeAbcdeFD(t)
-	loj.AddSynthesizedCol(c(4, 5), 6)
-	loj.ProjectCols(c(4, 5, 6))
+	abcde = makeAbcdeFD(t)
 	mnpq = makeMnpqFD(t)
 	mnpq.AddSynthesizedCol(c(12, 13), 14)
 	mnpq.ProjectCols(c(12, 13, 14))
+	loj.CopyFrom(abcde)
+	loj.AddSynthesizedCol(c(4, 5), 6)
+	loj.ProjectCols(c(4, 5, 6))
 	loj.MakeProduct(mnpq)
-	verifyFD(t, loj, "(4,5)-->(6), (12,13)-->(14)")
-	loj.MakeLeftOuter(nullExtendedCols, c())
-	verifyFD(t, loj, "(4,5)-->(6), (12,13)~~>(14)")
-	testColsAreStrictKey(t, loj, c(4, 5, 6, 12, 13, 14), false)
+	verifyFD(t, &loj, "(4,5)-->(6), (12,13)-->(14)")
+	loj.MakeLeftOuter(abcde, &props.FuncDepSet{}, preservedCols, nullExtendedCols, c())
+	verifyFD(t, &loj, "(4,5)-->(6), (12,13)~~>(14)")
+	testColsAreStrictKey(t, &loj, c(4, 5, 6, 12, 13, 14), false)
 
 	// Join keyless relations with not-null columns.
 	//   SELECT * FROM (SELECT d, e, d+e FROM abcde WHERE d>e) LEFT JOIN (SELECT p, q, p+q FROM mnpq WHERE p>q) ON True
+	preservedCols = c(4, 5, 6)
 	nullExtendedCols = c(12, 13, 14)
-	loj = makeAbcdeFD(t)
+	abcde = makeAbcdeFD(t)
+	mnpq = makeMnpqFD(t)
+	mnpq.AddSynthesizedCol(c(12, 13), 14)
+	mnpq.ProjectCols(c(12, 13, 14))
+	loj.CopyFrom(abcde)
 	loj.AddSynthesizedCol(c(4, 5), 6)
 	loj.ProjectCols(c(4, 5, 6))
-	mnpq = makeMnpqFD(t)
-	mnpq.AddSynthesizedCol(c(12, 13), 14)
-	mnpq.ProjectCols(c(12, 13, 14))
 	loj.MakeProduct(mnpq)
-	verifyFD(t, loj, "(4,5)-->(6), (12,13)-->(14)")
-	loj.MakeLeftOuter(nullExtendedCols, c(4, 5, 12, 13))
-	verifyFD(t, loj, "(4,5)-->(6), (12,13)-->(14)")
-	testColsAreStrictKey(t, loj, c(4, 5, 6, 12, 13, 14), false)
+	verifyFD(t, &loj, "(4,5)-->(6), (12,13)-->(14)")
+	loj.MakeLeftOuter(abcde, &props.FuncDepSet{}, preservedCols, nullExtendedCols, c(4, 5, 12, 13))
+	verifyFD(t, &loj, "(4,5)-->(6), (12,13)-->(14)")
+	testColsAreStrictKey(t, &loj, c(4, 5, 6, 12, 13, 14), false)
 
 	// SELECT * FROM abcde LEFT JOIN LATERAL (SELECT p, q, p+q FROM mnpq) ON True
+	preservedCols = c(1, 2, 3, 4, 5)
 	nullExtendedCols = c(12, 13, 14)
-	loj = makeAbcdeFD(t)
+	abcde = makeAbcdeFD(t)
 	mnpq = makeMnpqFD(t)
 	mnpq.AddSynthesizedCol(c(12, 13), 14)
 	mnpq.ProjectCols(c(12, 13, 14))
+	loj.CopyFrom(abcde)
 	verifyFD(t, mnpq, "(12,13)-->(14)")
 	loj.MakeApply(mnpq)
-	verifyFD(t, loj, "(1)-->(2-5), (2,3)~~>(1,4,5), (1,12,13)-->(14)")
-	loj.MakeLeftOuter(nullExtendedCols, c(1))
-	verifyFD(t, loj, "(1)-->(2-5), (2,3)~~>(1,4,5)")
+	verifyFD(t, &loj, "(1)-->(2-5), (2,3)~~>(1,4,5), (1,12,13)-->(14)")
+	loj.MakeLeftOuter(abcde, &props.FuncDepSet{}, preservedCols, nullExtendedCols, c(1))
+	verifyFD(t, &loj, "(1)-->(2-5), (2,3)~~>(1,4,5)")
 }
 
 func TestFuncDeps_MakeFullOuter(t *testing.T) {

--- a/pkg/sql/opt/testutils/opttester/testdata/opt-steps
+++ b/pkg/sql/opt/testutils/opttester/testdata/opt-steps
@@ -152,8 +152,8 @@ Initial expression
 ================================================================================
   left-join (hash)
    ├── columns: id:1(int!null) customer_id:2(int) status:3(string!null) id:4(int) name:5(string) address:6(string)
-   ├── key: (1,4)
-   ├── fd: (1)-->(2,3), (4)-->(5,6)
+   ├── key: (1)
+   ├── fd: (1)-->(2-6), (4)-->(5,6)
    ├── scan orders
    │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
    │    ├── check constraint expressions
@@ -179,8 +179,8 @@ NormalizeInConst
 ================================================================================
    left-join (hash)
     ├── columns: id:1(int!null) customer_id:2(int) status:3(string!null) id:4(int) name:5(string) address:6(string)
-    ├── key: (1,4)
-    ├── fd: (1)-->(2,3), (4)-->(5,6)
+    ├── key: (1)
+    ├── fd: (1)-->(2-6), (4)-->(5,6)
     ├── scan orders
     │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
     │    ├── check constraint expressions
@@ -214,8 +214,8 @@ CommuteLeftJoin (higher cost)
   -left-join (hash)
   +right-join (hash)
     ├── columns: id:1(int!null) customer_id:2(int) status:3(string!null) id:4(int) name:5(string) address:6(string)
-    ├── key: (1,4)
-    ├── fd: (1)-->(2,3), (4)-->(5,6)
+    ├── key: (1)
+    ├── fd: (1)-->(2-6), (4)-->(5,6)
   + ├── scan customers
   + │    ├── columns: customers.id:4(int!null) name:5(string!null) address:6(string)
   + │    ├── key: (4)
@@ -250,8 +250,8 @@ GenerateLookupJoins (higher cost)
     ├── columns: id:1(int!null) customer_id:2(int) status:3(string!null) id:4(int) name:5(string) address:6(string)
   + ├── key columns: [2] = [4]
   + ├── lookup columns are key
-    ├── key: (1,4)
-    ├── fd: (1)-->(2,3), (4)-->(5,6)
+    ├── key: (1)
+    ├── fd: (1)-->(2-6), (4)-->(5,6)
     ├── scan orders
     │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
     │    ├── check constraint expressions
@@ -282,8 +282,8 @@ GenerateMergeJoins (higher cost)
   - ├── lookup columns are key
   + ├── left ordering: +4
   + ├── right ordering: +2
-    ├── key: (1,4)
-    ├── fd: (1)-->(2,3), (4)-->(5,6)
+    ├── key: (1)
+    ├── fd: (1)-->(2-6), (4)-->(5,6)
   - ├── scan orders
   + ├── scan customers
   + │    ├── columns: customers.id:4(int!null) name:5(string!null) address:6(string)
@@ -321,8 +321,8 @@ Final best expression
 ================================================================================
   left-join (hash)
    ├── columns: id:1(int!null) customer_id:2(int) status:3(string!null) id:4(int) name:5(string) address:6(string)
-   ├── key: (1,4)
-   ├── fd: (1)-->(2,3), (4)-->(5,6)
+   ├── key: (1)
+   ├── fd: (1)-->(2-6), (4)-->(5,6)
    ├── scan orders
    │    ├── columns: orders.id:1(int!null) customer_id:2(int) status:3(string!null)
    │    ├── check constraint expressions

--- a/pkg/sql/opt/xform/testdata/external/activerecord
+++ b/pkg/sql/opt/xform/testdata/external/activerecord
@@ -114,15 +114,17 @@ ORDER BY a.attnum
 ----
 sort
  ├── columns: attname:2!null format_type:65 pg_get_expr:66 attnotnull:13!null atttypid:3!null atttypmod:9!null collname:67 comment:68  [hidden: attnum:6!null]
- ├── fd: (6)-->(2,3,9,13,65,68), (2)-->(3,6,9,13,65,68), (3,9)-->(65), (6)-->(68)
+ ├── key: (6)
+ ├── fd: (6)-->(2,3,9,13,65-68), (2)-->(3,6,9,13,65-68), (3,9)-->(65), (6)-->(68)
  ├── ordering: +6
  └── project
       ├── columns: format_type:65 pg_get_expr:66 collname:67 comment:68 attname:2!null atttypid:3!null attnum:6!null atttypmod:9!null attnotnull:13!null
-      ├── fd: (6)-->(2,3,9,13,65,68), (2)-->(3,6,9,13,65,68), (3,9)-->(65), (6)-->(68)
+      ├── key: (6)
+      ├── fd: (6)-->(2,3,9,13,65-68), (2)-->(3,6,9,13,65-68), (3,9)-->(65), (6)-->(68)
       ├── right-join (hash)
       │    ├── columns: attrelid:1!null attname:2!null atttypid:3!null attnum:6!null atttypmod:9!null attnotnull:13!null attisdropped:15!null attcollation:18!null adrelid:23 adnum:24 adbin:25 c.oid:27 c.collname:28 t.oid:34 typcollation:61
-      │    ├── key: (6,24,27,34)
-      │    ├── fd: ()-->(1,15), (6)-->(2,3,9,13,18), (2)-->(3,6,9,13,18), (24)-->(25), (6,24)-->(23), (27)-->(28), (34)-->(61)
+      │    ├── key: (6)
+      │    ├── fd: ()-->(1,15), (6)-->(2,3,9,13,18,23-25,27,28,34,61), (2)-->(3,6,9,13,18), (24)-->(25), (27)-->(28), (34)-->(61)
       │    ├── inner-join (cross)
       │    │    ├── columns: c.oid:27!null c.collname:28!null t.oid:34!null typcollation:61!null
       │    │    ├── key: (27,34)
@@ -141,8 +143,8 @@ sort
       │    │    ├── columns: attrelid:1!null attname:2!null atttypid:3!null attnum:6!null atttypmod:9!null attnotnull:13!null attisdropped:15!null attcollation:18!null adrelid:23 adnum:24 adbin:25
       │    │    ├── left ordering: +1,+6
       │    │    ├── right ordering: +23,+24
-      │    │    ├── key: (6,24)
-      │    │    ├── fd: ()-->(1,15), (6)-->(2,3,9,13,18), (2)-->(3,6,9,13,18), (24)-->(25), (6,24)-->(23)
+      │    │    ├── key: (6)
+      │    │    ├── fd: ()-->(1,15), (6)-->(2,3,9,13,18,23-25), (2)-->(3,6,9,13,18), (24)-->(25)
       │    │    ├── select
       │    │    │    ├── columns: attrelid:1!null attname:2!null atttypid:3!null attnum:6!null atttypmod:9!null attnotnull:13!null attisdropped:15!null attcollation:18!null
       │    │    │    ├── key: (6)

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -1593,8 +1593,8 @@ where
 ----
 right-join (hash)
  ├── columns: id1_0_0_:1!null id1_8_1_:3 location2_0_0_:2 address2_8_1_:4 zip3_8_1_:5
- ├── key: (1,3)
- ├── fd: (1)-->(2), (3)-->(4,5)
+ ├── key: (1)
+ ├── fd: (1)-->(2-5), (3)-->(4,5)
  ├── scan location3_
  │    ├── columns: location3_.id:3!null address:4 zip:5!null
  │    ├── key: (3)
@@ -1687,13 +1687,14 @@ where
 ----
 project
  ├── columns: newspape1_23_0_:1!null news_new2_23_0_:2!null formula140_0_:9 news_id1_21_1_:3!null detail2_21_1_:4 title3_21_1_:5
- ├── fd: ()-->(1), (3)-->(4,5), (2)==(3), (3)==(2)
+ ├── key: (3)
+ ├── fd: ()-->(1), (3)-->(4,5,9), (2)==(3), (3)==(2)
  ├── left-join (lookup news)
  │    ├── columns: newspaper_id:1!null news_news_id:2!null news1_.news_id:3!null news1_.detail:4 news1_.title:5 a0.news_id:6 a0.title:8
  │    ├── key columns: [2] = [6]
  │    ├── lookup columns are key
- │    ├── key: (3,6)
- │    ├── fd: ()-->(1), (3)-->(4,5), (2)==(3), (3)==(2), (6)-->(8)
+ │    ├── key: (3)
+ │    ├── fd: ()-->(1), (3)-->(4-6,8), (2)==(3), (3)==(2), (6)-->(8)
  │    ├── inner-join (lookup news)
  │    │    ├── columns: newspaper_id:1!null news_news_id:2!null news1_.news_id:3!null news1_.detail:4 news1_.title:5
  │    │    ├── key columns: [2] = [3]
@@ -1766,25 +1767,26 @@ WHERE ref0_.generationuser_id = 1;
 ----
 project
  ├── columns: generati1_2_0_:1!null ref_id2_2_0_:2!null formula131_0_:19 formula132_0_:20 formula133_0_:21 id1_0_1_:3!null age2_0_1_:4 culture3_0_1_:5 descript4_0_1_:6
- ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2)
+ ├── key: (3)
+ ├── fd: ()-->(1), (3)-->(4-6,19-21), (2)==(3), (3)==(2)
  ├── left-join (lookup generationgroup)
  │    ├── columns: generationuser_id:1!null ref_id:2!null generation1_.id:3!null generation1_.age:4 generation1_.culture:5 generation1_.description:6 a13.id:7 a13.age:8 a15.id:11 a15.culture:13 a13.id:15 a13.description:18
  │    ├── key columns: [2] = [15]
  │    ├── lookup columns are key
- │    ├── key: (3,7,11,15)
- │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2), (7)-->(8), (11)-->(13), (15)-->(18)
+ │    ├── key: (3)
+ │    ├── fd: ()-->(1), (3)-->(4-8,11,13,15,18), (2)==(3), (3)==(2), (7)-->(8), (11)-->(13), (15)-->(18)
  │    ├── left-join (lookup generationgroup)
  │    │    ├── columns: generationuser_id:1!null ref_id:2!null generation1_.id:3!null generation1_.age:4 generation1_.culture:5 generation1_.description:6 a13.id:7 a13.age:8 a15.id:11 a15.culture:13
  │    │    ├── key columns: [2] = [11]
  │    │    ├── lookup columns are key
- │    │    ├── key: (3,7,11)
- │    │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2), (7)-->(8), (11)-->(13)
+ │    │    ├── key: (3)
+ │    │    ├── fd: ()-->(1), (3)-->(4-8,11,13), (2)==(3), (3)==(2), (7)-->(8), (11)-->(13)
  │    │    ├── left-join (lookup generationgroup)
  │    │    │    ├── columns: generationuser_id:1!null ref_id:2!null generation1_.id:3!null generation1_.age:4 generation1_.culture:5 generation1_.description:6 a13.id:7 a13.age:8
  │    │    │    ├── key columns: [2] = [7]
  │    │    │    ├── lookup columns are key
- │    │    │    ├── key: (3,7)
- │    │    │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2), (7)-->(8)
+ │    │    │    ├── key: (3)
+ │    │    │    ├── fd: ()-->(1), (3)-->(4-8), (2)==(3), (3)==(2), (7)-->(8)
  │    │    │    ├── inner-join (lookup generationgroup)
  │    │    │    │    ├── columns: generationuser_id:1!null ref_id:2!null generation1_.id:3!null generation1_.age:4 generation1_.culture:5 generation1_.description:6
  │    │    │    │    ├── key columns: [2] = [3]
@@ -2100,28 +2102,28 @@ FROM
 ----
 project
  ├── columns: customer1_0_0_:1!null customer1_1_1_:4 ordernum2_1_1_:5 customer1_2_2_:7 ordernum2_2_2_:8 producti3_2_2_:9 producti1_3_3_:11 name2_0_0_:2!null address3_0_0_:3!null orderdat3_1_1_:6 formula103_1_:30 customer1_1_0__:4 ordernum2_1_0__:5 ordernum2_0__:5 quantity4_2_2_:10 customer1_2_1__:7 ordernum2_2_1__:8 producti3_2_1__:9 descript2_3_3_:12 cost3_3_3_:13 numberav4_3_3_:14 formula104_3_:31
- ├── key: (1,4,5,7-9,11)
- ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9,11)-->(2,3,6,10,12-14,30,31)
+ ├── key: (1,4,5,7-9)
+ ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9)-->(2,3,6,10-14,30,31)
  ├── group-by
  │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null orders1_.customerid:4 orders1_.ordernumber:5 orderdate:6 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9 lineitems2_.quantity:10 product3_.productid:11 product3_.description:12 product3_.cost:13 product3_.numberavailable:14 sum:24 sum:29
- │    ├── grouping columns: customer0_.customerid:1!null orders1_.customerid:4 orders1_.ordernumber:5 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9 product3_.productid:11
- │    ├── key: (1,4,5,7-9,11)
- │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9,11)-->(2,3,6,10,12-14,24,29)
+ │    ├── grouping columns: customer0_.customerid:1!null orders1_.customerid:4 orders1_.ordernumber:5 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9
+ │    ├── key: (1,4,5,7-9)
+ │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9)-->(2,3,6,10-14,24,29)
  │    ├── left-join (hash)
  │    │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null orders1_.customerid:4 orders1_.ordernumber:5 orderdate:6 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9 lineitems2_.quantity:10 product3_.productid:11 product3_.description:12 product3_.cost:13 product3_.numberavailable:14 sum:24 li.productid:27 li.quantity:28
- │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9,11)-->(2,3,6,10,12-14,24)
+ │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9)-->(2,3,6,10-14,24)
  │    │    ├── group-by
  │    │    │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null orders1_.customerid:4 orders1_.ordernumber:5 orderdate:6 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9 lineitems2_.quantity:10 product3_.productid:11 product3_.description:12 product3_.cost:13 product3_.numberavailable:14 sum:24
- │    │    │    ├── grouping columns: customer0_.customerid:1!null orders1_.customerid:4 orders1_.ordernumber:5 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9 product3_.productid:11
- │    │    │    ├── key: (1,4,5,7-9,11)
- │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9,11)-->(2,3,6,10,12-14,24)
+ │    │    │    ├── grouping columns: customer0_.customerid:1!null orders1_.customerid:4 orders1_.ordernumber:5 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9
+ │    │    │    ├── key: (1,4,5,7-9)
+ │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9)-->(2,3,6,10-14,24)
  │    │    │    ├── left-join (hash)
  │    │    │    │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null orders1_.customerid:4 orders1_.ordernumber:5 orderdate:6 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9 lineitems2_.quantity:10 product3_.productid:11 product3_.description:12 product3_.cost:13 product3_.numberavailable:14 li.customerid:15 li.ordernumber:16 column23:23
- │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14)
+ │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9)-->(11-14)
  │    │    │    │    ├── left-join (hash)
  │    │    │    │    │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null orders1_.customerid:4 orders1_.ordernumber:5 orderdate:6 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9 lineitems2_.quantity:10 product3_.productid:11 product3_.description:12 product3_.cost:13 product3_.numberavailable:14
- │    │    │    │    │    ├── key: (1,4,5,7-9,11)
- │    │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14)
+ │    │    │    │    │    ├── key: (1,4,5,7-9)
+ │    │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9)-->(11-14)
  │    │    │    │    │    ├── left-join (hash)
  │    │    │    │    │    │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null orders1_.customerid:4 orders1_.ordernumber:5 orderdate:6 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9 lineitems2_.quantity:10
  │    │    │    │    │    │    ├── key: (1,4,5,7-9)
@@ -2188,6 +2190,8 @@ project
  │    │    │         │    └── orderdate:6
  │    │    │         ├── const-agg [as=lineitems2_.quantity:10, outer=(10)]
  │    │    │         │    └── lineitems2_.quantity:10
+ │    │    │         ├── const-agg [as=product3_.productid:11, outer=(11)]
+ │    │    │         │    └── product3_.productid:11
  │    │    │         ├── const-agg [as=product3_.description:12, outer=(12)]
  │    │    │         │    └── product3_.description:12
  │    │    │         ├── const-agg [as=product3_.cost:13, outer=(13)]
@@ -2209,6 +2213,8 @@ project
  │         │    └── orderdate:6
  │         ├── const-agg [as=lineitems2_.quantity:10, outer=(10)]
  │         │    └── lineitems2_.quantity:10
+ │         ├── const-agg [as=product3_.productid:11, outer=(11)]
+ │         │    └── product3_.productid:11
  │         ├── const-agg [as=product3_.description:12, outer=(12)]
  │         │    └── product3_.description:12
  │         ├── const-agg [as=product3_.cost:13, outer=(13)]

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -162,39 +162,39 @@ WHERE ((c.relkind = 'r'::CHAR) OR (c.relkind = 'f'::CHAR)) AND (n.nspname = 'pub
 ----
 project
  ├── columns: oid:1!null schemaname:29!null tablename:2!null relacl:26 tableowner:133 description:134 relkind:17!null cluster:92 hasoids:20!null hasindexes:13!null hasrules:22!null tablespace:33 param:27 hastriggers:23!null unlogged:15!null ftoptions:120 srvname:122 reltuples:10!null inhtable:135!null inhschemaname:69 inhtablename:42
- ├── fd: ()-->(29), (1)-->(2,10,13,15,17,20,22,23,26,27,133,134), (2)-->(1,10,13,15,17,20,22,23,26,27,133,134)
+ ├── fd: ()-->(29), (1)-->(2,10,13,15,17,20,22,23,26,27,33,133,134), (2)-->(1,10,13,15,17,20,22,23,26,27,33,133,134)
  ├── group-by
  │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:29!null spcname:33 c2.relname:42 n2.nspname:69 ci.relname:92 ftoptions:120 srvname:122 count_rows:132!null rownum:136!null
  │    ├── grouping columns: rownum:136!null
  │    ├── key: (136)
- │    ├── fd: ()-->(29), (1)-->(2,5,10,13,15,17,20,22,23,26,27), (2)-->(1,5,10,13,15,17,20,22,23,26,27), (136)-->(1,2,5,10,13,15,17,20,22,23,26,27,29,33,42,69,92,120,122,132)
+ │    ├── fd: ()-->(29), (1)-->(2,5,10,13,15,17,20,22,23,26,27,33), (2)-->(1,5,10,13,15,17,20,22,23,26,27,33), (136)-->(1,2,5,10,13,15,17,20,22,23,26,27,29,33,42,69,92,120,122,132)
  │    ├── right-join (hash)
  │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null t.oid:32 spcname:33 i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72 indrelid:73 indisclustered:79 ci.oid:91 ci.relname:92 ftrelid:118 ftserver:119 ftoptions:120 fs.oid:121 srvname:122 pg_inherits.inhparent:130 rownum:136!null
- │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92), (118)-->(119,120), (121)-->(122), (122)-->(121), (136)-->(1,2,5,8,10,13,15,17,20,22,23,26,27,32,33,38,39,41-43,68,69,72,73,79,91,92,118-122)
+ │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,32,33), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92), (118)-->(119,120), (121)-->(122), (122)-->(121), (136)-->(1,2,5,8,10,13,15,17,20,22,23,26,27,32,33,38,39,41-43,68,69,72,73,79,91,92,118-122)
  │    │    ├── scan pg_inherits
  │    │    │    └── columns: pg_inherits.inhparent:130!null
  │    │    ├── ordinality
  │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null t.oid:32 spcname:33 i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72 indrelid:73 indisclustered:79 ci.oid:91 ci.relname:92 ftrelid:118 ftserver:119 ftoptions:120 fs.oid:121 srvname:122 rownum:136!null
  │    │    │    ├── key: (136)
- │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92), (118)-->(119,120), (121)-->(122), (122)-->(121), (136)-->(1-3,5,8,10,13,15,17,20,22,23,26-29,32,33,38,39,41-43,68,69,72,73,79,91,92,118-122)
+ │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,32,33), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92), (118)-->(119,120), (121)-->(122), (122)-->(121), (136)-->(1-3,5,8,10,13,15,17,20,22,23,26-29,32,33,38,39,41-43,68,69,72,73,79,91,92,118-122)
  │    │    │    └── left-join (lookup pg_foreign_server)
  │    │    │         ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null t.oid:32 spcname:33 i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72 indrelid:73 indisclustered:79 ci.oid:91 ci.relname:92 ftrelid:118 ftserver:119 ftoptions:120 fs.oid:121 srvname:122
  │    │    │         ├── key columns: [119] = [121]
  │    │    │         ├── lookup columns are key
- │    │    │         ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92), (118)-->(119,120), (121)-->(122), (122)-->(121)
+ │    │    │         ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,32,33), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92), (118)-->(119,120), (121)-->(122), (122)-->(121)
  │    │    │         ├── left-join (lookup pg_foreign_table)
  │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null t.oid:32 spcname:33 i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72 indrelid:73 indisclustered:79 ci.oid:91 ci.relname:92 ftrelid:118 ftserver:119 ftoptions:120
  │    │    │         │    ├── key columns: [1] = [118]
  │    │    │         │    ├── lookup columns are key
- │    │    │         │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92), (118)-->(119,120)
+ │    │    │         │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,32,33), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92), (118)-->(119,120)
  │    │    │         │    ├── left-join (lookup pg_class)
  │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null t.oid:32 spcname:33 i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72 indrelid:73 indisclustered:79 ci.oid:91 ci.relname:92
  │    │    │         │    │    ├── key columns: [72] = [91]
  │    │    │         │    │    ├── lookup columns are key
- │    │    │         │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92)
+ │    │    │         │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,32,33), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92)
  │    │    │         │    │    ├── right-join (hash)
  │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null t.oid:32 spcname:33 i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72 indrelid:73 indisclustered:79
- │    │    │         │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73)
+ │    │    │         │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,32,33), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73)
  │    │    │         │    │    │    ├── select
  │    │    │         │    │    │    │    ├── columns: i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72!null indrelid:73!null indisclustered:79!null
  │    │    │         │    │    │    │    ├── key: (72)
@@ -207,7 +207,7 @@ project
  │    │    │         │    │    │    │         └── indisclustered:79 = true [outer=(79), constraints=(/79: [/true - /true]; tight), fd=()-->(79)]
  │    │    │         │    │    │    ├── right-join (hash)
  │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null t.oid:32 spcname:33 i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69
- │    │    │         │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68)
+ │    │    │         │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,32,33), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68)
  │    │    │         │    │    │    │    ├── left-join (hash)
  │    │    │         │    │    │    │    │    ├── columns: i.inhrelid:38!null i.inhparent:39!null c2.oid:41!null c2.relname:42!null c2.relnamespace:43!null n2.oid:68 n2.nspname:69
  │    │    │         │    │    │    │    │    ├── fd: (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)-->(69), (69)-->(68)
@@ -232,8 +232,8 @@ project
  │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null t.oid:32 spcname:33
  │    │    │         │    │    │    │    │    ├── key columns: [8] = [32]
  │    │    │         │    │    │    │    │    ├── lookup columns are key
- │    │    │         │    │    │    │    │    ├── key: (1,32)
- │    │    │         │    │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32)
+ │    │    │         │    │    │    │    │    ├── key: (1)
+ │    │    │         │    │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,32,33), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32)
  │    │    │         │    │    │    │    │    ├── inner-join (hash)
  │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null
  │    │    │         │    │    │    │    │    │    ├── key: (1)

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -161,43 +161,43 @@ ORDER BY schemaname, tablename
 ----
 sort
  ├── columns: oid:1!null schemaname:29!null tablename:2!null relacl:26 tableowner:133 description:134 relkind:17!null cluster:92 hasoids:20!null hasindexes:13!null hasrules:22!null tablespace:33 param:27 hastriggers:23!null unlogged:15!null ftoptions:120 srvname:122 reltuples:10!null inhtable:135!null inhschemaname:69 inhtablename:42
- ├── fd: ()-->(29), (1)-->(2,10,13,15,17,20,22,23,26,27,133,134), (2)-->(1,10,13,15,17,20,22,23,26,27,133,134)
+ ├── fd: ()-->(29), (1)-->(2,10,13,15,17,20,22,23,26,27,33,133,134), (2)-->(1,10,13,15,17,20,22,23,26,27,33,133,134)
  ├── ordering: +2 opt(29) [actual: +2]
  └── project
       ├── columns: tableowner:133 description:134 inhtable:135!null c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:29!null spcname:33 c2.relname:42 n2.nspname:69 ci.relname:92 ftoptions:120 srvname:122
-      ├── fd: ()-->(29), (1)-->(2,10,13,15,17,20,22,23,26,27,133,134), (2)-->(1,10,13,15,17,20,22,23,26,27,133,134)
+      ├── fd: ()-->(29), (1)-->(2,10,13,15,17,20,22,23,26,27,33,133,134), (2)-->(1,10,13,15,17,20,22,23,26,27,33,133,134)
       ├── group-by
       │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:29!null spcname:33 c2.relname:42 n2.nspname:69 ci.relname:92 ftoptions:120 srvname:122 count_rows:132!null rownum:136!null
       │    ├── grouping columns: rownum:136!null
       │    ├── key: (136)
-      │    ├── fd: ()-->(29), (1)-->(2,5,10,13,15,17,20,22,23,26,27), (2)-->(1,5,10,13,15,17,20,22,23,26,27), (136)-->(1,2,5,10,13,15,17,20,22,23,26,27,29,33,42,69,92,120,122,132)
+      │    ├── fd: ()-->(29), (1)-->(2,5,10,13,15,17,20,22,23,26,27,33), (2)-->(1,5,10,13,15,17,20,22,23,26,27,33), (136)-->(1,2,5,10,13,15,17,20,22,23,26,27,29,33,42,69,92,120,122,132)
       │    ├── right-join (hash)
       │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null t.oid:32 spcname:33 i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72 indrelid:73 indisclustered:79 ci.oid:91 ci.relname:92 ftrelid:118 ftserver:119 ftoptions:120 fs.oid:121 srvname:122 pg_inherits.inhparent:130 rownum:136!null
-      │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92), (118)-->(119,120), (121)-->(122), (122)-->(121), (136)-->(1,2,5,8,10,13,15,17,20,22,23,26,27,32,33,38,39,41-43,68,69,72,73,79,91,92,118-122)
+      │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,32,33), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92), (118)-->(119,120), (121)-->(122), (122)-->(121), (136)-->(1,2,5,8,10,13,15,17,20,22,23,26,27,32,33,38,39,41-43,68,69,72,73,79,91,92,118-122)
       │    │    ├── scan pg_inherits
       │    │    │    └── columns: pg_inherits.inhparent:130!null
       │    │    ├── ordinality
       │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null t.oid:32 spcname:33 i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72 indrelid:73 indisclustered:79 ci.oid:91 ci.relname:92 ftrelid:118 ftserver:119 ftoptions:120 fs.oid:121 srvname:122 rownum:136!null
       │    │    │    ├── key: (136)
-      │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92), (118)-->(119,120), (121)-->(122), (122)-->(121), (136)-->(1-3,5,8,10,13,15,17,20,22,23,26-29,32,33,38,39,41-43,68,69,72,73,79,91,92,118-122)
+      │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,32,33), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92), (118)-->(119,120), (121)-->(122), (122)-->(121), (136)-->(1-3,5,8,10,13,15,17,20,22,23,26-29,32,33,38,39,41-43,68,69,72,73,79,91,92,118-122)
       │    │    │    └── left-join (lookup pg_foreign_server)
       │    │    │         ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null t.oid:32 spcname:33 i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72 indrelid:73 indisclustered:79 ci.oid:91 ci.relname:92 ftrelid:118 ftserver:119 ftoptions:120 fs.oid:121 srvname:122
       │    │    │         ├── key columns: [119] = [121]
       │    │    │         ├── lookup columns are key
-      │    │    │         ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92), (118)-->(119,120), (121)-->(122), (122)-->(121)
+      │    │    │         ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,32,33), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92), (118)-->(119,120), (121)-->(122), (122)-->(121)
       │    │    │         ├── left-join (lookup pg_foreign_table)
       │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null t.oid:32 spcname:33 i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72 indrelid:73 indisclustered:79 ci.oid:91 ci.relname:92 ftrelid:118 ftserver:119 ftoptions:120
       │    │    │         │    ├── key columns: [1] = [118]
       │    │    │         │    ├── lookup columns are key
-      │    │    │         │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92), (118)-->(119,120)
+      │    │    │         │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,32,33), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92), (118)-->(119,120)
       │    │    │         │    ├── left-join (lookup pg_class)
       │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null t.oid:32 spcname:33 i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72 indrelid:73 indisclustered:79 ci.oid:91 ci.relname:92
       │    │    │         │    │    ├── key columns: [72] = [91]
       │    │    │         │    │    ├── lookup columns are key
-      │    │    │         │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92)
+      │    │    │         │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,32,33), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), (91)-->(92)
       │    │    │         │    │    ├── right-join (hash)
       │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null t.oid:32 spcname:33 i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72 indrelid:73 indisclustered:79
-      │    │    │         │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73)
+      │    │    │         │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,32,33), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73)
       │    │    │         │    │    │    ├── select
       │    │    │         │    │    │    │    ├── columns: i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72!null indrelid:73!null indisclustered:79!null
       │    │    │         │    │    │    │    ├── key: (72)
@@ -210,7 +210,7 @@ sort
       │    │    │         │    │    │    │         └── indisclustered:79 = true [outer=(79), constraints=(/79: [/true - /true]; tight), fd=()-->(79)]
       │    │    │         │    │    │    ├── right-join (hash)
       │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null t.oid:32 spcname:33 i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69
-      │    │    │         │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68)
+      │    │    │         │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,32,33), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68)
       │    │    │         │    │    │    │    ├── left-join (hash)
       │    │    │         │    │    │    │    │    ├── columns: i.inhrelid:38!null i.inhparent:39!null c2.oid:41!null c2.relname:42!null c2.relnamespace:43!null n2.oid:68 n2.nspname:69
       │    │    │         │    │    │    │    │    ├── fd: (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)-->(69), (69)-->(68)
@@ -235,8 +235,8 @@ sort
       │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null t.oid:32 spcname:33
       │    │    │         │    │    │    │    │    ├── key columns: [8] = [32]
       │    │    │         │    │    │    │    │    ├── lookup columns are key
-      │    │    │         │    │    │    │    │    ├── key: (1,32)
-      │    │    │         │    │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32)
+      │    │    │         │    │    │    │    │    ├── key: (1)
+      │    │    │         │    │    │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,32,33), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32)
       │    │    │         │    │    │    │    │    ├── inner-join (hash)
       │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null
       │    │    │         │    │    │    │    │    │    ├── key: (1)

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1783,13 +1783,14 @@ sort
       │    ├── side-effects, mutations
       │    └── project
       │         ├── columns: upsert_a:11!null upsert_b:12 upsert_c:13 x:4!null y:5!null z:6!null abc.a:7 abc.b:8 abc.c:9
-      │         ├── key: (4-9)
-      │         ├── fd: (4,7)-->(11), (5,7,8)-->(12), (6,7,9)-->(13)
+      │         ├── key: (4-6)
+      │         ├── fd: (4-6)-->(7-9), (4,7)-->(11), (5,7,8)-->(12), (6,7,9)-->(13)
       │         ├── left-join (lookup abc)
       │         │    ├── columns: x:4!null y:5!null z:6!null abc.a:7 abc.b:8 abc.c:9
       │         │    ├── key columns: [4 5 6] = [7 8 9]
       │         │    ├── lookup columns are key
-      │         │    ├── key: (4-9)
+      │         │    ├── key: (4-6)
+      │         │    ├── fd: (4-6)-->(7-9)
       │         │    ├── ensure-upsert-distinct-on
       │         │    │    ├── columns: x:4!null y:5!null z:6!null
       │         │    │    ├── grouping columns: x:4!null y:5!null z:6!null


### PR DESCRIPTION
Previously, the functional dependencies from a join's "on" filters were
not used in determining the key of the output of a left join.

This patch allows a key that only has columns from the left input of the
LeftJoin to be used if one can be proven to exist.

The columns of the left input of the LeftJoin form a strict key over the
result of the left join when the following conditions are met:

 1. The original left input had a strict key.

 2. The columns of the left input form a strict key over the result of an
    InnerJoin between the left and right inputs on the given filters.
    (Or, in other words, the left columns form a strict key over the
     filtered cartesian product of the join inputs).

If the above conditions do not hold, a key over the unfiltered cartesian
product will simply be used, if there is one.

Release note: None