### PR TITLE
ui: fix network page render on missing localities

### DIFF
--- a/pkg/ui/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/index.tsx
@@ -234,22 +234,30 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
     data.forEach(values => {
       const localities = searchQuery(values.locality).split(",");
       localities.forEach((locality: string) => {
-        const value = locality.match(/^\w+/gi) ? locality.match(/^\w+/gi)[0] : null;
-        if (!sort.some(x => x.id === value)) {
-          const sortValue: NetworkSort = { id: value, filters: [] };
-          data.forEach(item => {
-            const valueLocality = searchQuery(values.locality).split(",");
-            const itemLocality = searchQuery(item.locality);
-            valueLocality.forEach(val => {
-              const itemLocalitySplited = val.match(/^\w+/gi) ? val.match(/^\w+/gi)[0] : null;
-              if (val === "cluster" && value === "cluster") {
-                sortValue.filters = [...sortValue.filters, { name: item.nodeID.toString(), address: item.address }];
-              } else if (itemLocalitySplited === value && !sortValue.filters.reduce((accumulator, vendor) => (accumulator || vendor.name === getValueFromString(value, itemLocality)), false)) {
-                sortValue.filters = [...sortValue.filters, { name: getValueFromString(value, itemLocality), address: item.address }];
-              }
+        if (locality !== "") {
+          const value = locality.match(/^\w+/gi) ? locality.match(/^\w+/gi)[0] : null;
+          if (!sort.some(x => x.id === value)) {
+            const sortValue: NetworkSort = {id: value, filters: []};
+            data.forEach(item => {
+              const valueLocality = searchQuery(values.locality).split(",");
+              const itemLocality = searchQuery(item.locality);
+              valueLocality.forEach(val => {
+                const itemLocalitySplited = val.match(/^\w+/gi) ? val.match(/^\w+/gi)[0] : null;
+                if (val === "cluster" && value === "cluster") {
+                  sortValue.filters = [...sortValue.filters, {
+                    name: item.nodeID.toString(),
+                    address: item.address,
+                  }];
+                } else if (itemLocalitySplited === value && !sortValue.filters.reduce((accumulator, vendor) => (accumulator || vendor.name === getValueFromString(value, itemLocality)), false)) {
+                  sortValue.filters = [...sortValue.filters, {
+                    name: getValueFromString(value, itemLocality),
+                    address: item.address,
+                  }];
+                }
+              });
             });
-          });
-          sort.push(sortValue);
+            sort.push(sortValue);
+          }
         }
       });
     });


### PR DESCRIPTION
The code was making assumptions that a multi-node cluster
would have localities defined on the nodes. Without
localities defined, the page would fail to render.

Release note (admin ui change): Fixed a bug where a multi-node
cluster without localities defined wouldn't be able to
render the "Network Latency" page.

Part of #48353.