### PR TITLE
release-20.1: sql: delete public schema on DROP DATABASE

### DIFF
--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -73,8 +73,9 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 	}
 
 	var tbNames TableNames
-	tempSchemasToDelete := make(map[ClusterWideID]struct{})
+	schemasToDelete := make([]string, 0, len(schemas))
 	for _, schema := range schemas {
+		schemasToDelete = append(schemasToDelete, schema)
 		toAppend, err := GetObjectNames(
 			ctx, p.txn, p, dbDesc, schema, true, /*explicitPrefix*/
 		)
@@ -82,14 +83,6 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 			return nil, err
 		}
 		tbNames = append(tbNames, toAppend...)
-
-		isTempSchema, clusterWideID, err := temporarySchemaSessionID(schema)
-		if err != nil {
-			return nil, err
-		}
-		if isTempSchema {
-			tempSchemasToDelete[clusterWideID] = struct{}{}
-		}
 	}
 
 	if len(tbNames) > 0 {
@@ -156,11 +149,6 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 	td, err = p.filterCascadedTables(ctx, td)
 	if err != nil {
 		return nil, err
-	}
-
-	schemasToDelete := make([]string, 0, len(tempSchemasToDelete))
-	for clusterWideID := range tempSchemasToDelete {
-		schemasToDelete = append(schemasToDelete, temporarySchemaName(clusterWideID))
 	}
 
 	return &dropDatabaseNode{n: n, dbDesc: dbDesc, td: td, schemasToDelete: schemasToDelete}, nil

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -230,10 +230,15 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 		t.Fatal(err)
 	}
 
+	sqlRun := sqlutils.MakeSQLRunner(sqlDB)
+	// There are no more namespace entries referencing this database as its
+	// parent.
+	namespaceQuery := fmt.Sprintf(`SELECT * FROM system.namespace WHERE "parentID"  = %d`, dbDesc.ID)
+	sqlRun.CheckQueryResults(t, namespaceQuery, [][]string{})
+
 	// Job still running, waiting for GC.
 	// TODO (lucy): Maybe this test API should use an offset starting
 	// from the most recent job instead.
-	sqlRun := sqlutils.MakeSQLRunner(sqlDB)
 	if err := jobutils.VerifySystemJob(t, sqlRun, 0, jobspb.TypeSchemaChange, jobs.StatusSucceeded, jobs.Record{
 		Username:    security.RootUser,
 		Description: "DROP DATABASE t CASCADE",


### PR DESCRIPTION
Backport 1/1 commits from #49125.

/cc @cockroachdb/release

---

When a database is dropped, so should the namespace entry for its PUBLIC
schema.

Fixes #49124.

Release note (bug fix): Previously when a database was dropped, it would
not drop the entry for its public schema in the system.namespace table.
This bug is now fixed.
