### PR TITLE
colexec: split hashtable.eg.go into two files and optimize code generation a bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -828,7 +828,8 @@ EXECGEN_TARGETS = \
   pkg/sql/colexec/count_agg.eg.go \
   pkg/sql/colexec/distinct.eg.go \
   pkg/sql/colexec/hashjoiner.eg.go \
-  pkg/sql/colexec/hashtable.eg.go \
+  pkg/sql/colexec/hashtable_distinct.eg.go \
+  pkg/sql/colexec/hashtable_full.eg.go \
   pkg/sql/colexec/hash_aggregator.eg.go \
   pkg/sql/colexec/hash_utils.eg.go \
   pkg/sql/colexec/like_ops.eg.go \

--- a/pkg/sql/colexec/.gitignore
+++ b/pkg/sql/colexec/.gitignore
@@ -7,7 +7,8 @@ const.eg.go
 count_agg.eg.go
 distinct.eg.go
 hashjoiner.eg.go
-hashtable.eg.go
+hashtable_distinct.eg.go
+hashtable_full.eg.go
 hash_utils.eg.go
 hash_aggregator.eg.go
 like_ops.eg.go

--- a/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
@@ -44,6 +44,7 @@ func genHashTable(wr io.Writer, htm hashTableMode) error {
 	s = strings.ReplaceAll(s, "_RIGHT_TYPE_WIDTH", typeWidthReplacement)
 	s = strings.ReplaceAll(s, "_ProbeType", "{{.Left.VecMethod}}")
 	s = strings.ReplaceAll(s, "_BuildType", "{{.Right.VecMethod}}")
+	s = strings.ReplaceAll(s, "_PROBING_AGAINST_ITSELF", ".ProbingAgainstItself")
 
 	s = strings.ReplaceAll(s, "_L_UNSAFEGET", "execgen.UNSAFEGET")
 	s = replaceManipulationFuncsAmbiguous(".Global.Left", s)
@@ -56,15 +57,15 @@ func genHashTable(wr io.Writer, htm hashTableMode) error {
 	checkColBody := makeFunctionRegex("_CHECK_COL_BODY", 12)
 	s = checkColBody.ReplaceAllString(
 		s,
-		`{{template "checkColBody" buildDict "Global" .Global "UseProbeSel" .UseProbeSel "UseBuildSel" .UseBuildSel "ProbeHasNulls" $7 "BuildHasNulls" $8 "AllowNullEquality" $9 "SelectDistinct" $10}}`)
+		`{{template "checkColBody" buildDict "Global" .Global "UseProbeSel" .UseProbeSel "ProbeHasNulls" $7 "BuildHasNulls" $8 "AllowNullEquality" $9 "SelectDistinct" $10 "ProbingAgainstItself" $12}}`)
 
 	checkColWithNulls := makeFunctionRegex("_CHECK_COL_WITH_NULLS", 8)
 	s = checkColWithNulls.ReplaceAllString(s,
-		`{{template "checkColWithNulls" buildDict "Global" . "UseProbeSel" $7 "UseBuildSel" $8}}`)
+		`{{template "checkColWithNulls" buildDict "Global" . "UseProbeSel" $7 "ProbingAgainstItself" $8}}`)
 
-	checkColForDistinctWithNulls := makeFunctionRegex("_CHECK_COL_FOR_DISTINCT_WITH_NULLS", 7)
+	checkColForDistinctWithNulls := makeFunctionRegex("_CHECK_COL_FOR_DISTINCT_WITH_NULLS", 6)
 	s = checkColForDistinctWithNulls.ReplaceAllString(s,
-		`{{template "checkColForDistinctWithNulls" buildDict "Global" . "UseProbeSel" $6 "UseBuildSel" $7}}`)
+		`{{template "checkColForDistinctWithNulls" buildDict "Global" . "UseProbeSel" $6}}`)
 
 	checkBody := makeFunctionRegex("_CHECK_BODY", 3)
 	s = checkBody.ReplaceAllString(s,

--- a/pkg/sql/colexec/hashtable.go
+++ b/pkg/sql/colexec/hashtable.go
@@ -306,14 +306,10 @@ func (ht *hashTable) removeDuplicates(
 
 // checkCols performs a column by column checkCol on the key columns.
 func (ht *hashTable) checkCols(
-	probeVecs, buildVecs []coldata.Vec,
-	buildKeyCols []uint32,
-	nToCheck uint64,
-	probeSel []int,
-	buildSel []int,
+	probeVecs, buildVecs []coldata.Vec, buildKeyCols []uint32, nToCheck uint64, probeSel []int,
 ) {
 	for i := range ht.keyCols {
-		ht.checkCol(probeVecs[i], buildVecs[buildKeyCols[i]], i, nToCheck, probeSel, buildSel)
+		ht.checkCol(probeVecs[i], buildVecs[buildKeyCols[i]], i, nToCheck, probeSel)
 	}
 }
 

--- a/pkg/sql/colexec/hashtable_tmpl.go
+++ b/pkg/sql/colexec/hashtable_tmpl.go
@@ -194,6 +194,9 @@ func _CHECK_COL_WITH_NULLS(
 	// {{/*
 } // */}}
 
+// {{if not .HashTableMode.IsDistinct}}
+// {{with .Overloads}}
+
 // checkCol determines if the current key column in the groupID buckets matches
 // the specified equality column key. If there is a match, then the key is added
 // to differs. If the bucket has reached the end, the key is rejected. If the
@@ -243,6 +246,9 @@ func (ht *hashTable) checkCol(
 	}
 }
 
+// {{end}}
+// {{end}}
+
 // {{/*
 func _CHECK_COL_FOR_DISTINCT_WITH_NULLS(
 	ht *hashTable,
@@ -270,6 +276,9 @@ func _CHECK_COL_FOR_DISTINCT_WITH_NULLS(
 	// {{end}}
 	// {{/*
 } // */}}
+
+// {{if .HashTableMode.IsDistinct}}
+// {{with .Overloads}}
 
 func (ht *hashTable) checkColForDistinctTuples(
 	probeVec, buildVec coldata.Vec, nToCheck uint64, probeSel []int,
@@ -318,6 +327,9 @@ func (ht *hashTable) checkColForDistinctTuples(
 	}
 }
 
+// {{end}}
+// {{end}}
+
 // {{/*
 func _CHECK_BODY(ht *hashTable, nDiffers uint64, _SELECT_SAME_TUPLES bool) { // */}}
 	// {{define "checkBody" -}}
@@ -365,6 +377,8 @@ func _CHECK_BODY(ht *hashTable, nDiffers uint64, _SELECT_SAME_TUPLES bool) { // 
 	// {{/*
 } // */}}
 
+// {{if .HashTableMode.IsDistinct}}
+
 // checkBuildForDistinct finds all tuples in probeVecs that are not present in
 // buffered tuples stored in ht.vals. It stores the probeVecs's distinct tuples'
 // keyIDs in headID buffer.
@@ -398,6 +412,10 @@ func (ht *hashTable) checkBuildForDistinct(
 	return nDiffers
 }
 
+// {{end}}
+
+// {{if not .HashTableMode.IsDistinct}}
+
 // check performs an equality check between the current key in the groupID bucket
 // and the probe key at that index. If there is a match, the hashTable's same
 // array is updated to lazily populate the linked list of identical build
@@ -416,6 +434,10 @@ func (ht *hashTable) check(
 	return nDiffers
 }
 
+// {{end}}
+
+// {{if .HashTableMode.IsDistinct}}
+
 // checkProbeForDistinct performs a column by column check for duplicated tuples
 // in the probe table.
 func (ht *hashTable) checkProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, sel []int) uint64 {
@@ -428,6 +450,8 @@ func (ht *hashTable) checkProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, 
 
 	return nDiffers
 }
+
+// {{end}}
 
 // {{/*
 func _UPDATE_SEL_BODY(ht *hashTable, b coldata.Batch, sel []int, _USE_SEL bool) { // */}}
@@ -459,6 +483,8 @@ func _UPDATE_SEL_BODY(ht *hashTable, b coldata.Batch, sel []int, _USE_SEL bool) 
 	// {{end}}
 	// {{/*
 } // */}}
+
+// {{if .HashTableMode.IsDistinct}}
 
 // updateSel updates the selection vector in the given batch using the headID
 // buffer. For each nonzero keyID in headID, it will be translated to the actual
@@ -505,3 +531,5 @@ func (ht *hashTable) distinctCheck(nToCheck uint64, probeSel []int) uint64 {
 
 	return nDiffers
 }
+
+// {{end}}


### PR DESCRIPTION
**colexec: split hashtable.eg.go into two files**

In order to support ExceptAll and IntersectAll hash joins I imagine that
we would be introducing different probing modes which will do additional
tracking, so we would want to generate code for each modes separately.
In fact, we already have different building modes, and this commit
generates two files for each of them. This change reduces the size of
a single file which helps when debugging.

Release note: None

**colexec: refactor hash table template to specialize checkCol function**

Previously, `checkCol` function has been overloaded - it was used by the
hash table in different modes, and as a result it was about 35k lines of
generated code. The problem was that "full" hash table mode operates on
two differents vectors and the probe vector can have a selection whereas
distinct mode (in certain code paths) probes the vector against itself
(meaning that if there is "probe" selection vector, then there is
"build" selection vector as well - which are exactly the same), and the
template wasn't aware of these two different cases.

The function is now split up into two and each are simplified -
`checkCol` handles two different vectors with optional selection
vector on the probe side and `checkColAgainstItself` handles the case of
probing the vector against itself with optional selection vector on it.
Although some of the code gets duplicated, in the end we get smaller
amount of generated code because we totally removed the case of no
probing selection vector and present build selection vector (which was
never used previously and was simply a dead code).

Release note: None