### PR TITLE
opt: expose interleaving information in the catalog

### DIFF
--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -165,6 +165,49 @@ type Index interface {
 	//   [ /us/seattle\x00 -               ]
 	//
 	PartitionByListPrefixes() []tree.Datums
+
+	// InterleaveAncestorCount returns the number of interleave ancestors for this
+	// index (or zero if this is not an interleaved index). Each ancestor is an
+	// index (usually from another table) with a key that shares a prefix with
+	// the key of this index.
+	//
+	// Each ancestor contributes one or more key columns; together these pieces
+	// form a prefix of an index key.
+	//
+	// The ancestors appear in the order they appear in an encoded key. This means
+	// they are always in the far-to-near ancestor order (e.g.
+	// grand-grand-parent, grand-parent, parent).
+	//
+	//
+	// Example:
+	//   Index 1 -> /a/b
+	//   Index 2 -> /a/b/c
+	//   Index 3 -> /a/b/c/d
+	//
+	// Index 3 has two ancestors; the first is index 1 (contributing 2 key
+	// columns) and the second is index 2 (contributing 1 key column).
+	InterleaveAncestorCount() int
+
+	// InterleaveAncestor returns information about an ancestor index.
+	//
+	// numKeyCols is the number of key columns that this ancestor contributes to
+	// an encoded key. In other words: each ancestor has a shared key prefix
+	// with this index; numKeyCols is the difference the shared prefix length for
+	// this ancestor and the shared prefix length for the previous ancestor.
+	// See InterleaveAncestorCount for an example.
+	InterleaveAncestor(i int) (table, index StableID, numKeyCols int)
+
+	// InterleavedByCount returns the number of indexes (usually from other
+	// tables) that are interleaved into this index.
+	//
+	// Note that these indexes can themselves be interleaved by other indexes, but
+	// this list contains only those for which this index is a direct interleave
+	// parent.
+	InterleavedByCount() int
+
+	// InterleavedBy returns information about an index that is interleaved into
+	// this index; see InterleavedByCount.
+	InterleavedBy(i int) (table, index StableID)
 }
 
 // IndexColumn describes a single column that is part of an index definition.

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -41,10 +41,6 @@ type Table interface {
 	// information_schema tables.
 	IsVirtualTable() bool
 
-	// IsInterleaved returns true if any of this table's indexes are interleaved
-	// with index(es) from other table(s).
-	IsInterleaved() bool
-
 	// ColumnCount returns the number of public columns in the table. Public
 	// columns are not currently being added or dropped from the table. This
 	// method should be used when mutation columns can be ignored (the common

--- a/pkg/sql/opt/exec/execbuilder/testdata/catalog
+++ b/pkg/sql/opt/exec/execbuilder/testdata/catalog
@@ -179,3 +179,91 @@ TABLE parent
  ├── REFERENCED BY CONSTRAINT fk FOREIGN KEY child (p, q, r) REFERENCES parent (p, q, r)
  └── REFERENCED BY CONSTRAINT fk FOREIGN KEY child2 (p, q, r) REFERENCES parent (p, q, r) MATCH FULL ON DELETE SET NULL
 scan parent
+
+# Tests with interleaved tables.
+statement ok
+CREATE TABLE a (a INT PRIMARY KEY, other INT, FAMILY (a,other))
+
+statement ok
+CREATE TABLE ab (
+  a INT, b INT, PRIMARY KEY (a,b), FAMILY (a,b)
+) INTERLEAVE IN PARENT a(a)
+
+statement ok
+CREATE TABLE abc (k INT PRIMARY KEY, a INT, b INT, c INT, FAMILY (a,b,c));
+CREATE INDEX abc_idx ON abc(a,b,c) INTERLEAVE IN PARENT ab(a,b)
+
+statement ok
+CREATE TABLE abx (
+  a INT, b INT, x INT,
+  PRIMARY KEY (a,b,x),
+  FAMILY (a,b,x)
+) INTERLEAVE IN PARENT ab(a,b)
+
+query T
+EXPLAIN (OPT, CATALOG) SELECT * FROM a
+----
+TABLE a
+ ├── a int not null
+ ├── other int
+ ├── FAMILY fam_0_a_other (a, other)
+ └── INDEX primary
+      ├── a int not null
+      └── interleaved by
+           └── table=60 index=1
+scan a
+
+query T
+EXPLAIN (OPT, CATALOG) SELECT * FROM ab
+----
+TABLE ab
+ ├── a int not null
+ ├── b int not null
+ ├── FAMILY fam_0_a_b (a, b)
+ └── INDEX primary
+      ├── a int not null
+      ├── b int not null
+      ├── interleave ancestors
+      │    └── table=59 index=1 (1 key column)
+      └── interleaved by
+           ├── table=61 index=2
+           └── table=62 index=1
+scan ab
+
+query T
+EXPLAIN (OPT, CATALOG) SELECT * FROM abc
+----
+TABLE abc
+ ├── k int not null
+ ├── a int
+ ├── b int
+ ├── c int
+ ├── FAMILY fam_0_a_b_c_k (a, b, c, k)
+ ├── INDEX primary
+ │    └── k int not null
+ └── INDEX abc_idx
+      ├── a int
+      ├── b int
+      ├── c int
+      ├── k int not null
+      └── interleave ancestors
+           ├── table=59 index=1 (1 key column)
+           └── table=60 index=1 (1 key column)
+scan abc
+
+query T
+EXPLAIN (OPT, CATALOG) SELECT * FROM abx
+----
+TABLE abx
+ ├── a int not null
+ ├── b int not null
+ ├── x int not null
+ ├── FAMILY fam_0_a_b_x (a, b, x)
+ └── INDEX primary
+      ├── a int not null
+      ├── b int not null
+      ├── x int not null
+      └── interleave ancestors
+           ├── table=59 index=1 (1 key column)
+           └── table=60 index=1 (1 key column)
+scan abx

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -595,11 +595,6 @@ func (tt *Table) IsVirtualTable() bool {
 	return tt.IsVirtual
 }
 
-// IsInterleaved is part of the cat.Table interface.
-func (tt *Table) IsInterleaved() bool {
-	return false
-}
-
 // ColumnCount is part of the cat.Table interface.
 func (tt *Table) ColumnCount() int {
 	return len(tt.Columns) - tt.writeOnlyColCount - tt.deleteOnlyColCount
@@ -858,6 +853,26 @@ func (ti *Index) PartitionByListPrefixes() []tree.Datums {
 		}
 	}
 	return res
+}
+
+// InterleaveAncestorCount is part of the cat.Index interface.
+func (ti *Index) InterleaveAncestorCount() int {
+	return 0
+}
+
+// InterleaveAncestor is part of the cat.Index interface.
+func (ti *Index) InterleaveAncestor(i int) (table, index cat.StableID, numKeyCols int) {
+	panic("no interleavings")
+}
+
+// InterleavedByCount is part of the cat.Index interface.
+func (ti *Index) InterleavedByCount() int {
+	return 0
+}
+
+// InterleavedBy is part of the cat.Index interface.
+func (ti *Index) InterleavedBy(i int) (table, index cat.StableID) {
+	panic("no interleavings")
 }
 
 // Column implements the cat.Column interface for testing purposes.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -725,11 +725,6 @@ func (ot *optTable) IsVirtualTable() bool {
 	return false
 }
 
-// IsInterleaved is part of the cat.Table interface.
-func (ot *optTable) IsInterleaved() bool {
-	return ot.desc.IsInterleaved()
-}
-
 // ColumnCount is part of the cat.Table interface.
 func (ot *optTable) ColumnCount() int {
 	return len(ot.desc.Columns)
@@ -1033,6 +1028,28 @@ func (oi *optIndex) PartitionByListPrefixes() []tree.Datums {
 		}
 	}
 	return res
+}
+
+// InterleaveAncestorCount is part of the cat.Index interface.
+func (oi *optIndex) InterleaveAncestorCount() int {
+	return len(oi.desc.Interleave.Ancestors)
+}
+
+// InterleaveAncestor is part of the cat.Index interface.
+func (oi *optIndex) InterleaveAncestor(i int) (table, index cat.StableID, numKeyCols int) {
+	a := &oi.desc.Interleave.Ancestors[i]
+	return cat.StableID(a.TableID), cat.StableID(a.IndexID), int(a.SharedPrefixLen)
+}
+
+// InterleavedByCount is part of the cat.Index interface.
+func (oi *optIndex) InterleavedByCount() int {
+	return len(oi.desc.InterleavedBy)
+}
+
+// InterleavedBy is part of the cat.Index interface.
+func (oi *optIndex) InterleavedBy(i int) (table, index cat.StableID) {
+	ref := &oi.desc.InterleavedBy[i]
+	return cat.StableID(ref.Table), cat.StableID(ref.Index)
 }
 
 type optTableStat struct {
@@ -1392,11 +1409,6 @@ func (ot *optVirtualTable) IsVirtualTable() bool {
 	return true
 }
 
-// IsInterleaved is part of the cat.Table interface.
-func (ot *optVirtualTable) IsInterleaved() bool {
-	return ot.desc.IsInterleaved()
-}
-
 // ColumnCount is part of the cat.Table interface.
 func (ot *optVirtualTable) ColumnCount() int {
 	// Virtual tables expose an extra (bogus) PK column.
@@ -1671,6 +1683,26 @@ func (oi *optVirtualIndex) Ordinal() int {
 // PartitionByListPrefixes is part of the cat.Index interface.
 func (oi *optVirtualIndex) PartitionByListPrefixes() []tree.Datums {
 	panic("no partition")
+}
+
+// InterleaveAncestorCount is part of the cat.Index interface.
+func (oi *optVirtualIndex) InterleaveAncestorCount() int {
+	return 0
+}
+
+// InterleaveAncestor is part of the cat.Index interface.
+func (oi *optVirtualIndex) InterleaveAncestor(i int) (table, index cat.StableID, numKeyCols int) {
+	panic("no interleavings")
+}
+
+// InterleavedByCount is part of the cat.Index interface.
+func (oi *optVirtualIndex) InterleavedByCount() int {
+	return 0
+}
+
+// InterleavedBy is part of the cat.Index interface.
+func (oi *optVirtualIndex) InterleavedBy(i int) (table, index cat.StableID) {
+	panic("no interleavings")
 }
 
 // optVirtualFamily is a dummy implementation of cat.Family for the only family


### PR DESCRIPTION
Expose the interleaving information in the catalog. It will be used to
reimplement the interleaved, cascading delete fast path, currently implemented
in `sql/delete.go` (necessary for the fast path to work with opt-driven FK
cascades).

Release note: None