### PR TITLE
sql: switch internal executor to iterator pattern

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math/rand"
 	"os"
 	"strings"
 	"time"
@@ -624,15 +623,17 @@ func (r *Registry) isOrphaned(ctx context.Context, payload *jobspb.Payload) (boo
 func (r *Registry) cleanupOldJobs(ctx context.Context, olderThan time.Time) error {
 	const stmt = `SELECT id, payload, status, created FROM system.jobs WHERE created < $1
 		      ORDER BY created LIMIT 1000`
-	rows, err := r.ex.Query(ctx, "gc-jobs", nil /* txn */, stmt, olderThan)
+	rows, err := r.ex.QueryIterator(ctx, "gc-jobs", nil /* txn */, sqlbase.NodeUserSessionDataOverride, stmt, olderThan)
 	if err != nil {
 		return err
 	}
 
 	toDelete := tree.NewDArray(types.Int)
-	toDelete.Array = make(tree.Datums, 0, len(rows))
+	toDelete.Array = make(tree.Datums, 0, 1000)
 	oldMicros := timeutil.ToUnixMicros(olderThan)
-	for _, row := range rows {
+	var ok bool
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
 		payload, err := UnmarshalPayload(row[1])
 		if err != nil {
 			return err
@@ -651,6 +652,9 @@ func (r *Registry) cleanupOldJobs(ctx context.Context, olderThan time.Time) erro
 		if remove {
 			toDelete.Array = append(toDelete.Array, row[0])
 		}
+	}
+	if err != nil {
+		return err
 	}
 	if len(toDelete.Array) > 0 {
 		log.Infof(ctx, "cleaning up %d expired job records", len(toDelete.Array))
@@ -1032,23 +1036,22 @@ func (r *Registry) adoptionDisabled(ctx context.Context) bool {
 func (r *Registry) maybeAdoptJob(
 	ctx context.Context, nlw sqlbase.OptionalNodeLiveness, randomizeJobOrder bool,
 ) error {
-	const stmt = `
-SELECT id, payload, progress IS NULL, status
+	ordering := "created DESC"
+	if randomizeJobOrder {
+		ordering = "random()"
+	}
+	stmt := fmt.Sprintf(`SELECT id, payload, progress IS NULL, status
 FROM system.jobs
-WHERE status IN ($1, $2, $3, $4, $5) ORDER BY created DESC`
-	rows, err := r.ex.Query(
-		ctx, "adopt-job", nil /* txn */, stmt,
+WHERE status IN ($1, $2, $3, $4, $5) ORDER BY %s`, ordering)
+	rows, err := r.ex.QueryIterator(
+		ctx, "adopt-job", nil, /* txn */
+		sqlbase.RootUserDataOverride,
+		stmt,
 		StatusPending, StatusRunning, StatusCancelRequested, StatusPauseRequested, StatusReverting,
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed querying for jobs")
 	}
-
-	if randomizeJobOrder {
-		rand.Seed(timeutil.Now().UnixNano())
-		rand.Shuffle(len(rows), func(i, j int) { rows[i], rows[j] = rows[j], rows[i] })
-	}
-
 	type nodeStatus struct {
 		isLive bool
 	}
@@ -1084,12 +1087,10 @@ WHERE status IN ($1, $2, $3, $4, $5) ORDER BY created DESC`
 		}
 	}
 
-	if log.V(3) {
-		log.Infof(ctx, "evaluating %d jobs for adoption", len(rows))
-	}
-
 	var adopted int
-	for _, row := range rows {
+	var ok bool
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
 		if adopted >= maxAdoptionsPerLoop {
 			// Leave excess jobs for other nodes to get their fair share.
 			break
@@ -1259,7 +1260,7 @@ WHERE status IN ($1, $2, $3, $4, $5) ORDER BY created DESC`
 		adopted++
 	}
 
-	return nil
+	return err
 }
 
 func (r *Registry) newLease() *jobspb.Lease {

--- a/pkg/jobs/scheduled_job.go
+++ b/pkg/jobs/scheduled_job.go
@@ -273,7 +273,7 @@ func (j *ScheduledJob) Create(ctx context.Context, ex sqlutil.InternalExecutor, 
 		return err
 	}
 
-	rows, retCols, err := ex.QueryWithCols(ctx, "sched-create", txn,
+	row, retCols, err := ex.QueryRowWithCols(ctx, "sched-create", txn,
 		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		fmt.Sprintf("INSERT INTO %s (%s) VALUES(%s) RETURNING schedule_id",
 			j.env.ScheduledJobsTableName(), strings.Join(cols, ","), generatePlaceholders(len(qargs))),
@@ -284,11 +284,7 @@ func (j *ScheduledJob) Create(ctx context.Context, ex sqlutil.InternalExecutor, 
 		return err
 	}
 
-	if len(rows) != 1 {
-		return errors.New("failed to create new schedule")
-	}
-
-	return j.InitFromDatums(rows[0], retCols)
+	return j.InitFromDatums(row, retCols)
 }
 
 // Update saves changes made to this schedule.

--- a/pkg/jobs/scheduled_job_executor.go
+++ b/pkg/jobs/scheduled_job_executor.go
@@ -133,7 +133,7 @@ func lookupScheduleAndExecutor(
 	scheduleID int64,
 	txn *kv.Txn,
 ) (*ScheduledJob, ScheduledJobExecutor, error) {
-	rows, cols, err := ex.QueryWithCols(ctx, "lookup-schedule", txn,
+	row, cols, err := ex.QueryRowWithCols(ctx, "lookup-schedule", txn,
 		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		fmt.Sprintf(
 			"SELECT schedule_id, schedule_details, executor_type FROM %s WHERE schedule_id = %d",
@@ -143,14 +143,8 @@ func lookupScheduleAndExecutor(
 		return nil, nil, err
 	}
 
-	if len(rows) != 1 {
-		return nil, nil, errors.Newf(
-			"expected to find 1 schedule, found %d with schedule_id=%d",
-			len(rows), scheduleID)
-	}
-
 	j := NewScheduledJob(env)
-	if err := j.InitFromDatums(rows[0], cols); err != nil {
+	if err := j.InitFromDatums(row, cols); err != nil {
 		return nil, nil, err
 	}
 	executor, err := NewScheduledJobExecutor(j.ExecutorType())

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -591,6 +591,33 @@ type wrappedInternalExecutor struct {
 	}
 }
 
+func (ie *wrappedInternalExecutor) QueryRowWithCols(
+	ctx context.Context,
+	opName string,
+	txn *kv.Txn,
+	session sqlbase.InternalExecutorSessionDataOverride,
+	stmt string,
+	qargs ...interface{},
+) (tree.Datums, sqlbase.ResultColumns, error) {
+	return ie.wrapped.QueryRowWithCols(ctx, opName, txn, session, stmt, qargs...)
+}
+
+func (ie *wrappedInternalExecutor) QueryIterator(
+	ctx context.Context,
+	opName string,
+	txn *kv.Txn,
+	session sqlbase.InternalExecutorSessionDataOverride,
+	stmt string,
+	qargs ...interface{},
+) (sqlutil.InternalRows, error) {
+	if f := ie.getErrFunc(); f != nil {
+		if err := f(stmt); err != nil {
+			return nil, err
+		}
+	}
+	return ie.wrapped.QueryIterator(ctx, opName, txn, session, stmt, qargs...)
+}
+
 var _ sqlutil.InternalExecutor = &wrappedInternalExecutor{}
 
 func (ie *wrappedInternalExecutor) Exec(
@@ -610,33 +637,6 @@ func (ie *wrappedInternalExecutor) ExecEx(
 	panic("unimplemented")
 }
 
-func (ie *wrappedInternalExecutor) QueryEx(
-	ctx context.Context,
-	opName string,
-	txn *kv.Txn,
-	session sqlbase.InternalExecutorSessionDataOverride,
-	stmt string,
-	qargs ...interface{},
-) ([]tree.Datums, error) {
-	if f := ie.getErrFunc(); f != nil {
-		if err := f(stmt); err != nil {
-			return nil, err
-		}
-	}
-	return ie.wrapped.QueryEx(ctx, opName, txn, session, stmt, qargs...)
-}
-
-func (ie *wrappedInternalExecutor) QueryWithCols(
-	ctx context.Context,
-	opName string,
-	txn *kv.Txn,
-	o sqlbase.InternalExecutorSessionDataOverride,
-	statement string,
-	qargs ...interface{},
-) ([]tree.Datums, sqlbase.ResultColumns, error) {
-	panic("unimplemented")
-}
-
 func (ie *wrappedInternalExecutor) QueryRowEx(
 	ctx context.Context,
 	opName string,
@@ -651,12 +651,6 @@ func (ie *wrappedInternalExecutor) QueryRowEx(
 		}
 	}
 	return ie.wrapped.QueryRowEx(ctx, opName, txn, session, stmt, qargs...)
-}
-
-func (ie *wrappedInternalExecutor) Query(
-	ctx context.Context, opName string, txn *kv.Txn, statement string, params ...interface{},
-) ([]tree.Datums, error) {
-	panic("not implemented")
 }
 
 func (ie *wrappedInternalExecutor) QueryRow(

--- a/pkg/kv/kvserver/reports/constraint_stats_report.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -173,15 +174,18 @@ func (r *replicationConstraintStatsReportSaver) loadPreviousVersion(
 	}
 	const prevViolations = "select zone_id, subzone_id, type, config, " +
 		"violating_ranges from system.replication_constraint_stats"
-	rows, err := ex.Query(
-		ctx, "get-previous-replication-constraint-stats", txn, prevViolations,
+	rows, err := ex.QueryIterator(
+		ctx, "get-previous-replication-constraint-stats", txn,
+		sqlbase.RootUserDataOverride, prevViolations,
 	)
 	if err != nil {
 		return err
 	}
 
-	r.previousVersion = make(ConstraintReport, len(rows))
-	for _, row := range rows {
+	r.previousVersion = make(ConstraintReport, 16)
+	var ok bool
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
 		key := ConstraintStatusKey{}
 		key.ZoneID = (config.SystemTenantObjectID)(*row[0].(*tree.DInt))
 		key.SubzoneID = base.SubzoneID((*row[1].(*tree.DInt)))
@@ -190,7 +194,7 @@ func (r *replicationConstraintStatsReportSaver) loadPreviousVersion(
 		r.previousVersion[key] = ConstraintStatus{(int)(*row[4].(*tree.DInt))}
 	}
 
-	return nil
+	return err
 }
 
 func (r *replicationConstraintStatsReportSaver) updateTimestamp(

--- a/pkg/kv/kvserver/reports/critical_localities_report.go
+++ b/pkg/kv/kvserver/reports/critical_localities_report.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/errors"
 )
@@ -103,15 +104,17 @@ func (r *replicationCriticalLocalitiesReportSaver) loadPreviousVersion(
 	}
 	const prevViolations = "select zone_id, subzone_id, locality, at_risk_ranges " +
 		"from system.replication_critical_localities"
-	rows, err := ex.Query(
-		ctx, "get-previous-replication-critical-localities", txn, prevViolations,
+	rows, err := ex.QueryIterator(
+		ctx, "get-previous-replication-critical-localities", txn, sqlbase.RootUserDataOverride, prevViolations,
 	)
 	if err != nil {
 		return err
 	}
 
-	r.previousVersion = make(LocalityReport, len(rows))
-	for _, row := range rows {
+	r.previousVersion = make(LocalityReport, 16)
+	var ok bool
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
 		key := localityKey{}
 		key.ZoneID = (config.SystemTenantObjectID)(*row[0].(*tree.DInt))
 		key.SubzoneID = base.SubzoneID(*row[1].(*tree.DInt))
@@ -119,7 +122,7 @@ func (r *replicationCriticalLocalitiesReportSaver) loadPreviousVersion(
 		r.previousVersion[key] = localityStatus{(int32)(*row[3].(*tree.DInt))}
 	}
 
-	return nil
+	return err
 }
 
 func (r *replicationCriticalLocalitiesReportSaver) updateTimestamp(

--- a/pkg/kv/kvserver/reports/critical_localities_report_test.go
+++ b/pkg/kv/kvserver/reports/critical_localities_report_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -146,15 +147,22 @@ func TestLocalityReport(t *testing.T) {
 func TableData(
 	ctx context.Context, tableName string, executor sqlutil.InternalExecutor,
 ) [][]string {
-	if rows, err := executor.Query(
-		ctx, "test-select-"+tableName, nil /* txn */, "select * from "+tableName); err == nil {
-		result := make([][]string, 0, len(rows))
-		for _, row := range rows {
+	if rows, err := executor.QueryIterator(
+		ctx, "test-select-"+tableName, nil, /* txn */
+		sqlbase.NoSessionDataOverride,
+		"select * from "+tableName); err == nil {
+		result := make([][]string, 0)
+		var ok bool
+		for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+			row := rows.Cur()
 			stringRow := make([]string, 0, row.Len())
 			for _, item := range row {
 				stringRow = append(stringRow, item.String())
 			}
 			result = append(result, stringRow)
+		}
+		if err != nil {
+			panic("Error " + err.Error())
 		}
 		return result
 	}

--- a/pkg/kv/kvserver/reports/replication_stats_report.go
+++ b/pkg/kv/kvserver/reports/replication_stats_report.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -111,15 +112,17 @@ func (r *replicationStatsReportSaver) loadPreviousVersion(
 	const prevViolations = "select zone_id, subzone_id, total_ranges, " +
 		"unavailable_ranges, under_replicated_ranges, over_replicated_ranges " +
 		"from system.replication_stats"
-	rows, err := ex.Query(
-		ctx, "get-previous-replication-stats", txn, prevViolations,
+	rows, err := ex.QueryIterator(
+		ctx, "get-previous-replication-stats", txn, sqlbase.RootUserDataOverride, prevViolations,
 	)
 	if err != nil {
 		return err
 	}
 
-	r.previousVersion = make(RangeReport, len(rows))
-	for _, row := range rows {
+	r.previousVersion = make(RangeReport, 16)
+	var ok bool
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
 		key := ZoneKey{}
 		key.ZoneID = (config.SystemTenantObjectID)(*row[0].(*tree.DInt))
 		key.SubzoneID = base.SubzoneID(*row[1].(*tree.DInt))
@@ -131,7 +134,7 @@ func (r *replicationStatsReportSaver) loadPreviousVersion(
 		}
 	}
 
-	return nil
+	return err
 }
 
 func (r *replicationStatsReportSaver) updateTimestamp(

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -228,7 +228,7 @@ func (s *adminServer) Databases(
 		return nil, err
 	}
 
-	rows, err := s.server.sqlServer.internalExecutor.QueryEx(
+	rows, err := s.server.sqlServer.internalExecutor.QueryIterator(
 		ctx, "admin-show-dbs", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: sessionUser},
 		"SHOW DATABASES",
@@ -238,13 +238,18 @@ func (s *adminServer) Databases(
 	}
 
 	var resp serverpb.DatabasesResponse
-	for _, row := range rows {
+	var ok bool
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
 		dbDatum, ok := tree.AsDString(row[0])
 		if !ok {
 			return nil, s.serverErrorf("type assertion failed on db name: %T", row[0])
 		}
 		dbName := string(dbDatum)
 		resp.Databases = append(resp.Databases, dbName)
+	}
+	if err != nil {
+		return nil, s.serverError(err)
 	}
 
 	return &resp, nil
@@ -268,11 +273,12 @@ func (s *adminServer) DatabaseDetails(
 	// TODO(cdo): Use placeholders when they're supported by SHOW.
 
 	// Marshal grants.
-	rows, cols, err := s.server.sqlServer.internalExecutor.QueryWithCols(
+	rows, err := s.server.sqlServer.internalExecutor.QueryIterator(
 		ctx, "admin-show-grants", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		fmt.Sprintf("SHOW GRANTS ON DATABASE %s", escDBName),
 	)
+	cols := rows.Types()
 	if s.isNotFoundError(err) {
 		return nil, status.Errorf(codes.NotFound, "%s", err)
 	}
@@ -288,7 +294,9 @@ func (s *adminServer) DatabaseDetails(
 		)
 
 		scanner := makeResultScanner(cols)
-		for _, row := range rows {
+		var ok bool
+		for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+			row := rows.Cur()
 			var schemaName string
 			if err := scanner.Scan(row, schemaCol, &schemaName); err != nil {
 				return nil, err
@@ -310,20 +318,25 @@ func (s *adminServer) DatabaseDetails(
 			grant.Privileges = strings.Split(privileges, ",")
 			resp.Grants = append(resp.Grants, grant)
 		}
+		if err != nil {
+			return nil, s.serverError(err)
+		}
 	}
 
 	// Marshal table names.
-	rows, cols, err = s.server.sqlServer.internalExecutor.QueryWithCols(
+	rows, err = s.server.sqlServer.internalExecutor.QueryIterator(
 		ctx, "admin-show-tables", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
-		fmt.Sprintf("SHOW TABLES FROM %s", escDBName),
+		fmt.Sprintf("SELECT schema_name, table_name FROM [SHOW TABLES FROM %s]", escDBName),
 	)
+
 	if s.isNotFoundError(err) {
 		return nil, status.Errorf(codes.NotFound, "%s", err)
 	}
 	if err != nil {
 		return nil, s.serverError(err)
 	}
+	cols = rows.Types()
 
 	// Marshal table names.
 	{
@@ -331,7 +344,9 @@ func (s *adminServer) DatabaseDetails(
 		if a, e := len(cols), 3; a != e {
 			return nil, s.serverErrorf("show tables columns mismatch: %d != expected %d", a, e)
 		}
-		for _, row := range rows {
+		var ok bool
+		for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+			row := rows.Cur()
 			var schemaName, tableName string
 			if err := scanner.Scan(row, "schema_name", &schemaName); err != nil {
 				return nil, err
@@ -343,6 +358,9 @@ func (s *adminServer) DatabaseDetails(
 				return nil, err
 			}
 			resp.TableNames = append(resp.TableNames, tableName)
+		}
+		if err != nil {
+			return nil, s.serverError(err)
 		}
 	}
 
@@ -395,7 +413,7 @@ func (s *adminServer) TableDetails(
 	var resp serverpb.TableDetailsResponse
 
 	// Marshal SHOW COLUMNS result.
-	rows, cols, err := s.server.sqlServer.internalExecutor.QueryWithCols(
+	rows, err := s.server.sqlServer.internalExecutor.QueryIterator(
 		ctx, "admin-show-columns",
 		nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
@@ -420,8 +438,11 @@ func (s *adminServer) TableDetails(
 			genCol     = "generation_expression"
 			hiddenCol  = "is_hidden"
 		)
+		cols := rows.Types()
 		scanner := makeResultScanner(cols)
-		for _, row := range rows {
+		var ok bool
+		for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+			row := rows.Cur()
 			var col serverpb.TableDetailsResponse_Column
 			if err := scanner.Scan(row, colCol, &col.Name); err != nil {
 				return nil, err
@@ -455,10 +476,13 @@ func (s *adminServer) TableDetails(
 			}
 			resp.Columns = append(resp.Columns, col)
 		}
+		if err != nil {
+			return nil, s.serverError(err)
+		}
 	}
 
 	// Marshal SHOW INDEX result.
-	rows, cols, err = s.server.sqlServer.internalExecutor.QueryWithCols(
+	rows, err = s.server.sqlServer.internalExecutor.QueryIterator(
 		ctx, "admin-showindex", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		fmt.Sprintf("SHOW INDEX FROM %s", escQualTable),
@@ -479,8 +503,11 @@ func (s *adminServer) TableDetails(
 			storingCol   = "storing"
 			implicitCol  = "implicit"
 		)
+		cols := rows.Types()
 		scanner := makeResultScanner(cols)
-		for _, row := range rows {
+		var ok bool
+		for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+			row := rows.Cur()
 			// Marshal grant, splitting comma-separated privileges into a proper slice.
 			var index serverpb.TableDetailsResponse_Index
 			if err := scanner.Scan(row, nameCol, &index.Name); err != nil {
@@ -508,10 +535,13 @@ func (s *adminServer) TableDetails(
 			}
 			resp.Indexes = append(resp.Indexes, index)
 		}
+		if err != nil {
+			return nil, s.serverError(err)
+		}
 	}
 
 	// Marshal SHOW GRANTS result.
-	rows, cols, err = s.server.sqlServer.internalExecutor.QueryWithCols(
+	rows, err = s.server.sqlServer.internalExecutor.QueryIterator(
 		ctx, "admin-show-grants", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		fmt.Sprintf("SHOW GRANTS ON TABLE %s", escQualTable),
@@ -527,8 +557,11 @@ func (s *adminServer) TableDetails(
 			userCol       = "grantee"
 			privilegesCol = "privilege_type"
 		)
+		cols := rows.Types()
 		scanner := makeResultScanner(cols)
-		for _, row := range rows {
+		var ok bool
+		for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+			row := rows.Cur()
 			// Marshal grant, splitting comma-separated privileges into a proper slice.
 			var grant serverpb.TableDetailsResponse_Grant
 			var privileges string
@@ -541,10 +574,13 @@ func (s *adminServer) TableDetails(
 			grant.Privileges = strings.Split(privileges, ",")
 			resp.Grants = append(resp.Grants, grant)
 		}
+		if err != nil {
+			return nil, s.serverError(err)
+		}
 	}
 
 	// Marshal SHOW CREATE result.
-	rows, cols, err = s.server.sqlServer.internalExecutor.QueryWithCols(
+	row, cols, err := s.server.sqlServer.internalExecutor.QueryRowWithCols(
 		ctx, "admin-show-create", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		fmt.Sprintf("SHOW CREATE %s", escQualTable),
@@ -557,13 +593,10 @@ func (s *adminServer) TableDetails(
 	}
 	{
 		const createCol = "create_statement"
-		if len(rows) != 1 {
-			return nil, s.serverErrorf("create response not available.")
-		}
 
 		scanner := makeResultScanner(cols)
 		var createStmt string
-		if err := scanner.Scan(rows[0], createCol, &createStmt); err != nil {
+		if err := scanner.Scan(row, createCol, &createStmt); err != nil {
 			return nil, err
 		}
 
@@ -848,7 +881,7 @@ func (s *adminServer) Users(
 		return nil, err
 	}
 	query := `SELECT username FROM system.users WHERE "isRole" = false`
-	rows, err := s.server.sqlServer.internalExecutor.QueryEx(
+	rows, err := s.server.sqlServer.internalExecutor.QueryIterator(
 		ctx, "admin-users", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		query,
@@ -858,8 +891,13 @@ func (s *adminServer) Users(
 	}
 
 	var resp serverpb.UsersResponse
-	for _, row := range rows {
+	var ok bool
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
 		resp.Users = append(resp.Users, serverpb.UsersResponse_User{Username: string(tree.MustBeDString(row[0]))})
+	}
+	if err != nil {
+		return nil, s.serverError(err)
 	}
 	return &resp, nil
 }
@@ -907,7 +945,7 @@ func (s *adminServer) Events(
 	if len(q.Errors()) > 0 {
 		return nil, s.serverErrors(q.Errors())
 	}
-	rows, cols, err := s.server.sqlServer.internalExecutor.QueryWithCols(
+	rows, err := s.server.sqlServer.internalExecutor.QueryIterator(
 		ctx, "admin-events", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		q.String(), q.QueryArguments()...)
@@ -917,8 +955,11 @@ func (s *adminServer) Events(
 
 	// Marshal response.
 	var resp serverpb.EventsResponse
+	cols := rows.Types()
 	scanner := makeResultScanner(cols)
-	for _, row := range rows {
+	var ok bool
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
 		var event serverpb.EventsResponse_Event
 		var ts time.Time
 		if err := scanner.ScanIndex(row, 0, &ts); err != nil {
@@ -947,6 +988,9 @@ func (s *adminServer) Events(
 		}
 
 		resp.Events = append(resp.Events, event)
+	}
+	if err != nil {
+		return nil, s.serverError(err)
 	}
 	return &resp, nil
 }
@@ -999,7 +1043,7 @@ func (s *adminServer) RangeLog(
 	if len(q.Errors()) > 0 {
 		return nil, s.serverErrors(q.Errors())
 	}
-	rows, cols, err := s.server.sqlServer.internalExecutor.QueryWithCols(
+	rows, err := s.server.sqlServer.internalExecutor.QueryIterator(
 		ctx, "admin-range-log", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		q.String(), q.QueryArguments()...,
@@ -1010,11 +1054,14 @@ func (s *adminServer) RangeLog(
 
 	// Marshal response.
 	var resp serverpb.RangeLogResponse
+	cols := rows.Types()
 	if len(cols) != 6 {
 		return nil, errors.Errorf("incorrect number of columns in response, expected 6, got %d", len(cols))
 	}
 	scanner := makeResultScanner(cols)
-	for _, row := range rows {
+	var ok bool
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
 		var event kvserverpb.RangeLogEvent
 		var ts time.Time
 		if err := scanner.ScanIndex(row, 0, &ts); err != nil {
@@ -1087,6 +1134,9 @@ func (s *adminServer) RangeLog(
 			PrettyInfo: prettyInfo,
 		})
 	}
+	if err != nil {
+		return nil, s.serverError(err)
+	}
 	return &resp, nil
 }
 
@@ -1112,7 +1162,7 @@ func (s *adminServer) getUIData(
 	if err := query.Errors(); err != nil {
 		return nil, s.serverErrorf("error constructing query: %v", err)
 	}
-	rows, err := s.server.sqlServer.internalExecutor.QueryEx(
+	rows, err := s.server.sqlServer.internalExecutor.QueryIterator(
 		ctx, "admin-getUIData", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		query.String(), query.QueryArguments()...,
@@ -1123,7 +1173,9 @@ func (s *adminServer) getUIData(
 
 	// Marshal results.
 	resp := serverpb.GetUIDataResponse{KeyValues: make(map[string]serverpb.GetUIDataResponse_Value)}
-	for _, row := range rows {
+	var ok bool
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
 		dKey, ok := tree.AsDString(row[0])
 		if !ok {
 			return nil, s.serverErrorf("unexpected type for UI key: %T", row[0])
@@ -1144,6 +1196,9 @@ func (s *adminServer) getUIData(
 			Value:       []byte(*dValue),
 			LastUpdated: dLastUpdated.Time,
 		}
+	}
+	if err != nil {
+		return nil, s.serverError(err)
 	}
 	return &resp, nil
 }
@@ -1427,7 +1482,7 @@ func (s *adminServer) Jobs(
 	if req.Limit > 0 {
 		q.Append(" LIMIT $", tree.DInt(req.Limit))
 	}
-	rows, cols, err := s.server.sqlServer.internalExecutor.QueryWithCols(
+	rows, err := s.server.sqlServer.internalExecutor.QueryIterator(
 		ctx, "admin-jobs", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		q.String(), q.QueryArguments()...,
@@ -1436,12 +1491,18 @@ func (s *adminServer) Jobs(
 		return nil, s.serverError(err)
 	}
 
+	cols := rows.Types()
 	scanner := makeResultScanner(cols)
 	resp := serverpb.JobsResponse{
-		Jobs: make([]serverpb.JobsResponse_Job, len(rows)),
+		Jobs: make([]serverpb.JobsResponse_Job, 0),
 	}
-	for i, row := range rows {
-		job := &resp.Jobs[i]
+	i := 0
+	var ok bool
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
+		resp.Jobs = append(resp.Jobs, serverpb.JobsResponse_Job{})
+		job := &resp.Jobs[len(resp.Jobs)-1]
+		i++
 		var fractionCompletedOrNil *float32
 		var highwaterOrNil *apd.Decimal
 		var runningStatusOrNil *string
@@ -1481,6 +1542,9 @@ func (s *adminServer) Jobs(
 			job.RunningStatus = *runningStatusOrNil
 		}
 	}
+	if err != nil {
+		return nil, s.serverError(err)
+	}
 
 	return &resp, nil
 }
@@ -1497,7 +1561,7 @@ func (s *adminServer) Locations(
 
 	q := makeSQLQuery()
 	q.Append(`SELECT "localityKey", "localityValue", latitude, longitude FROM system.locations`)
-	rows, cols, err := s.server.sqlServer.internalExecutor.QueryWithCols(
+	rows, err := s.server.sqlServer.internalExecutor.QueryIterator(
 		ctx, "admin-locations", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		q.String(),
@@ -1506,12 +1570,18 @@ func (s *adminServer) Locations(
 		return nil, s.serverError(err)
 	}
 
+	cols := rows.Types()
 	scanner := makeResultScanner(cols)
 	resp := serverpb.LocationsResponse{
-		Locations: make([]serverpb.LocationsResponse_Location, len(rows)),
+		Locations: make([]serverpb.LocationsResponse_Location, 0),
 	}
-	for i, row := range rows {
-		loc := &resp.Locations[i]
+	i := 0
+	var ok bool
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
+		resp.Locations = append(resp.Locations, serverpb.LocationsResponse_Location{})
+		loc := &resp.Locations[len(resp.Locations)-1]
+		i++
 		lat, lon := new(apd.Decimal), new(apd.Decimal)
 		if err := scanner.ScanAll(
 			row, &loc.LocalityKey, &loc.LocalityValue, lat, lon); err != nil {
@@ -1523,6 +1593,9 @@ func (s *adminServer) Locations(
 		if loc.Longitude, err = lon.Float64(); err != nil {
 			return nil, s.serverError(err)
 		}
+	}
+	if err != nil {
+		return nil, s.serverError(err)
 	}
 
 	return &resp, nil
@@ -1553,7 +1626,7 @@ func (s *adminServer) QueryPlan(
 	explain := fmt.Sprintf(
 		"SELECT json FROM [EXPLAIN (DISTSQL) %s]",
 		strings.Trim(req.Query, ";"))
-	rows, err := s.server.sqlServer.internalExecutor.QueryEx(
+	row, err := s.server.sqlServer.internalExecutor.QueryRowEx(
 		ctx, "admin-query-plan", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		explain,
@@ -1562,7 +1635,6 @@ func (s *adminServer) QueryPlan(
 		return nil, s.serverError(err)
 	}
 
-	row := rows[0]
 	dbDatum, ok := tree.AsDString(row[0])
 	if !ok {
 		return nil, s.serverErrorf("type assertion failed on json: %T", row)
@@ -1743,7 +1815,7 @@ func (s *adminServer) DataDistribution(
 	// and deleted tables (as opposed to e.g. information_schema) because we are interested
 	// in the data for all ranges, not just ranges for visible tables.
 	tablesQuery := `SELECT name, table_id, database_name, drop_time FROM "".crdb_internal.tables WHERE schema_name = 'public'`
-	rows1, err := s.server.sqlServer.internalExecutor.QueryEx(
+	rows, err := s.server.sqlServer.internalExecutor.QueryIterator(
 		ctx, "admin-replica-matrix", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		tablesQuery,
@@ -1755,7 +1827,9 @@ func (s *adminServer) DataDistribution(
 	// Used later when we're scanning Meta2 and only have IDs, not names.
 	tableInfosByTableID := map[uint32]serverpb.DataDistributionResponse_TableInfo{}
 
-	for _, row := range rows1 {
+	var ok bool
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
 		tableName := (*string)(row[0].(*tree.DString))
 		tableID := uint32(tree.MustBeDInt(row[1]))
 		dbName := (*string)(row[2].(*tree.DString))
@@ -1785,7 +1859,7 @@ func (s *adminServer) DataDistribution(
 				`SELECT zone_id FROM [SHOW ZONE CONFIGURATION FOR TABLE %s.%s]`,
 				(*tree.Name)(dbName), (*tree.Name)(tableName),
 			)
-			rows, err := s.server.sqlServer.internalExecutor.QueryEx(
+			row, err := s.server.sqlServer.internalExecutor.QueryRowEx(
 				ctx, "admin-replica-matrix", nil, /* txn */
 				sqlbase.InternalExecutorSessionDataOverride{User: userName},
 				zoneConfigQuery,
@@ -1794,13 +1868,7 @@ func (s *adminServer) DataDistribution(
 				return nil, s.serverError(err)
 			}
 
-			if len(rows) != 1 {
-				return nil, s.serverError(fmt.Errorf(
-					"could not get zone config for table %s; %d rows returned", *tableName, len(rows),
-				))
-			}
-			zcRow := rows[0]
-			zcID = int64(tree.MustBeDInt(zcRow[0]))
+			zcID = int64(tree.MustBeDInt(row[0]))
 		}
 
 		// Insert table.
@@ -1811,6 +1879,9 @@ func (s *adminServer) DataDistribution(
 		}
 		dbInfo.TableInfo[*tableName] = tableInfo
 		tableInfosByTableID[tableID] = tableInfo
+	}
+	if err != nil {
+		return nil, s.serverError(err)
 	}
 
 	// Get replica counts.
@@ -1862,7 +1933,7 @@ func (s *adminServer) DataDistribution(
 		FROM crdb_internal.zones
 		WHERE target IS NOT NULL
 	`
-	rows2, err := s.server.sqlServer.internalExecutor.QueryEx(
+	rows, err = s.server.sqlServer.internalExecutor.QueryIterator(
 		ctx, "admin-replica-matrix", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		zoneConfigsQuery)
@@ -1870,7 +1941,8 @@ func (s *adminServer) DataDistribution(
 		return nil, s.serverError(err)
 	}
 
-	for _, row := range rows2 {
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
 		target := string(tree.MustBeDString(row[0]))
 		zcSQL := tree.MustBeDString(row[1])
 		zcBytes := tree.MustBeDBytes(row[2])
@@ -1884,6 +1956,9 @@ func (s *adminServer) DataDistribution(
 			Config:    zcProto,
 			ConfigSQL: string(zcSQL),
 		}
+	}
+	if err != nil {
+		return nil, s.serverError(err)
 	}
 
 	return resp, nil
@@ -2277,7 +2352,7 @@ func (s *adminServer) queryZone(
 	ctx context.Context, userName string, id descpb.ID,
 ) (zonepb.ZoneConfig, bool, error) {
 	const query = `SELECT crdb_internal.get_zone_config($1)`
-	rows, cols, err := s.server.sqlServer.internalExecutor.QueryWithCols(
+	rows, cols, err := s.server.sqlServer.internalExecutor.QueryRowWithCols(
 		ctx,
 		"admin-query-zone",
 		nil, /* txn */
@@ -2289,19 +2364,15 @@ func (s *adminServer) queryZone(
 		return *zonepb.NewZoneConfig(), false, err
 	}
 
-	if len(rows) != 1 {
-		return *zonepb.NewZoneConfig(), false, errors.Errorf("invalid number of rows returned: %s (%d)", query, id)
-	}
-
 	var zoneBytes []byte
 	scanner := makeResultScanner(cols)
-	if isNull, err := scanner.IsNull(rows[0], cols[0].Name); err != nil {
+	if isNull, err := scanner.IsNull(rows, cols[0].Name); err != nil {
 		return *zonepb.NewZoneConfig(), false, err
 	} else if isNull {
 		return *zonepb.NewZoneConfig(), false, nil
 	}
 
-	err = scanner.ScanIndex(rows[0], 0, &zoneBytes)
+	err = scanner.ScanIndex(rows, 0, &zoneBytes)
 	if err != nil {
 		return *zonepb.NewZoneConfig(), false, err
 	}
@@ -2334,7 +2405,7 @@ func (s *adminServer) queryNamespaceID(
 	ctx context.Context, userName string, parentID descpb.ID, name string,
 ) (descpb.ID, error) {
 	const query = `SELECT crdb_internal.get_namespace_id($1, $2)`
-	rows, cols, err := s.server.sqlServer.internalExecutor.QueryWithCols(
+	rows, cols, err := s.server.sqlServer.internalExecutor.QueryRowWithCols(
 		ctx, "admin-query-namespace-ID", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: userName},
 		query, parentID, name,
@@ -2343,19 +2414,15 @@ func (s *adminServer) queryNamespaceID(
 		return 0, err
 	}
 
-	if len(rows) != 1 {
-		return 0, errors.Errorf("invalid number of rows returned: %s (%d, %s)", query, parentID, name)
-	}
-
 	var id int64
 	scanner := makeResultScanner(cols)
-	if isNull, err := scanner.IsNull(rows[0], cols[0].Name); err != nil {
+	if isNull, err := scanner.IsNull(rows, cols[0].Name); err != nil {
 		return 0, err
 	} else if isNull {
 		return 0, errors.Errorf("namespace %s with ParentID %d not found", name, parentID)
 	}
 
-	err = scanner.ScanIndex(rows[0], 0, &id)
+	err = scanner.ScanIndex(rows, 0, &id)
 	if err != nil {
 		return 0, err
 	}
@@ -2423,19 +2490,16 @@ func (s *adminServer) hasAdminRole(ctx context.Context, sessionUser string) (boo
 		// Shortcut.
 		return true, nil
 	}
-	rows, cols, err := s.server.sqlServer.internalExecutor.QueryWithCols(
+	row, err := s.server.sqlServer.internalExecutor.QueryRowEx(
 		ctx, "check-is-admin", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: sessionUser},
 		"SELECT crdb_internal.is_admin()")
 	if err != nil {
 		return false, err
 	}
-	if len(rows) != 1 || len(cols) != 1 {
-		return false, errors.AssertionFailedf("hasAdminRole: expected 1 row, got %d", len(rows))
-	}
-	dbDatum, ok := tree.AsDBool(rows[0][0])
+	dbDatum, ok := tree.AsDBool(row[0])
 	if !ok {
-		return false, errors.AssertionFailedf("hasAdminRole: expected bool, got %T", rows[0][0])
+		return false, errors.AssertionFailedf("hasAdminRole: expected bool, got %T", row[0])
 	}
 	return bool(dbDatum), nil
 }

--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/diagnosticspb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -321,31 +320,39 @@ func (s *Server) getReportingInfo(
 	// Read the system.settings table to determine the settings for which we have
 	// explicitly set values -- the in-memory SV has the set and default values
 	// flattened for quick reads, but we'd rather only report the non-defaults.
-	if datums, err := s.sqlServer.internalExecutor.QueryEx(
+	if rows, err := s.sqlServer.internalExecutor.QueryIterator(
 		ctx, "read-setting", nil, /* txn */
-		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
+		sqlbase.RootUserDataOverride,
 		"SELECT name FROM system.settings",
 	); err != nil {
 		log.Warningf(ctx, "failed to read settings: %s", err)
 	} else {
-		info.AlteredSettings = make(map[string]string, len(datums))
-		for _, row := range datums {
+		info.AlteredSettings = make(map[string]string)
+
+		var ok bool
+		for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+			row := rows.Cur()
 			name := string(tree.MustBeDString(row[0]))
 			info.AlteredSettings[name] = settings.RedactedValue(name, &s.st.SV)
 		}
+		if err != nil {
+			log.Warningf(ctx, "failed to read settings: %s", err)
+		}
 	}
 
-	if datums, err := s.sqlServer.internalExecutor.QueryEx(
+	if rows, err := s.sqlServer.internalExecutor.QueryIterator(
 		ctx,
 		"read-zone-configs",
 		nil, /* txn */
-		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
+		sqlbase.RootUserDataOverride,
 		"SELECT id, config FROM system.zones",
 	); err != nil {
 		log.Warningf(ctx, "%v", err)
 	} else {
 		info.ZoneConfigs = make(map[int64]zonepb.ZoneConfig)
-		for _, row := range datums {
+		var ok bool
+		for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+			row := rows.Cur()
 			id := int64(tree.MustBeDInt(row[0]))
 			var zone zonepb.ZoneConfig
 			if bytes, ok := row[1].(*tree.DBytes); !ok {
@@ -359,6 +366,9 @@ func (s *Server) getReportingInfo(
 			var anonymizedZone zonepb.ZoneConfig
 			anonymizeZoneConfig(&anonymizedZone, zone, secret)
 			info.ZoneConfigs[id] = anonymizedZone
+		}
+		if err != nil {
+			log.Warningf(ctx, "%v", err)
 		}
 	}
 

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -350,14 +350,17 @@ func (p *planner) resolveMemberOfWithAdminOption(
 		}
 		visited[m] = struct{}{}
 
-		rows, err := p.ExecCfg().InternalExecutor.Query(
-			ctx, "expand-roles", nil /* txn */, lookupRolesStmt, m,
+		rows, err := p.ExecCfg().InternalExecutor.QueryIterator(
+			ctx, "expand-roles", nil /* txn */, sqlbase.RootUserDataOverride,
+			lookupRolesStmt, m,
 		)
 		if err != nil {
 			return nil, err
 		}
 
-		for _, row := range rows {
+		var ok bool
+		for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+			row := rows.Cur()
 			roleName := tree.MustBeDString(row[0])
 			isAdmin := row[1].(*tree.DBool)
 
@@ -365,6 +368,9 @@ func (p *planner) resolveMemberOfWithAdminOption(
 
 			// We need to expand this role. Let the "pop" worry about already-visited elements.
 			toVisit = append(toVisit, string(roleName))
+		}
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -412,7 +418,7 @@ func (p *planner) HasRoleOption(ctx context.Context, roleOption roleoption.Optio
 		}
 	}
 
-	hasRolePrivilege, err := p.ExecCfg().InternalExecutor.QueryEx(
+	hasRolePrivilege, err := p.ExecCfg().InternalExecutor.QueryRowEx(
 		ctx, "has-role-option", p.Txn(),
 		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		fmt.Sprintf(

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1371,6 +1371,8 @@ func (ex *connExecutor) execCmd(ctx context.Context) error {
 		cmd.command())
 	defer sp.Finish()
 
+	log.Infof(ctx, "[%s pos:%d] executing %s",
+		ex.machine.CurState(), pos, cmd)
 	if log.ExpensiveLogEnabled(ctx, 2) || ex.eventLog != nil {
 		ex.sessionEventf(ctx, "[%s pos:%d] executing %s",
 			ex.machine.CurState(), pos, cmd)

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -510,10 +510,11 @@ func checkRunningJobs(ctx context.Context, job *jobs.Job, p *planner) error {
 	}
 	const stmt = `SELECT id, payload FROM system.jobs WHERE status IN ($1, $2, $3) ORDER BY created`
 
-	rows, err := p.ExecCfg().InternalExecutor.Query(
+	rows, err := p.ExecCfg().InternalExecutor.QueryIterator(
 		ctx,
 		"get-jobs",
 		nil, /* txn */
+		sqlbase.RootUserDataOverride,
 		stmt,
 		jobs.StatusPending,
 		jobs.StatusRunning,
@@ -523,7 +524,9 @@ func checkRunningJobs(ctx context.Context, job *jobs.Job, p *planner) error {
 		return err
 	}
 
-	for _, row := range rows {
+	var ok bool
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
 		payload, err := jobs.UnmarshalPayload(row[1])
 		if err != nil {
 			return err
@@ -540,7 +543,7 @@ func checkRunningJobs(ctx context.Context, job *jobs.Job, p *planner) error {
 			return stats.ConcurrentCreateStatsError
 		}
 	}
-	return nil
+	return err
 }
 
 // OnFailOrCancel is part of the jobs.Resumer interface.

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -662,3 +662,19 @@ func (ie *lazyInternalExecutor) QueryRow(
 	})
 	return ie.InternalExecutor.QueryRow(ctx, opName, txn, stmt, qargs...)
 }
+
+func (ie *lazyInternalExecutor) QueryRowWithCols(
+	ctx context.Context,
+	opName string,
+	txn *kv.Txn,
+	opts sqlbase.InternalExecutorSessionDataOverride,
+	stmt string,
+	qargs ...interface{},
+) (tree.Datums, sqlbase.ResultColumns, error) {
+	ie.once.Do(func() {
+		ie.InternalExecutor = ie.newInternalExecutor()
+	})
+	return ie.InternalExecutor.QueryRowWithCols(ctx, opName, txn, opts, stmt, qargs...)
+}
+
+var _ sqlutil.InternalExecutor = &lazyInternalExecutor{}

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -428,7 +428,7 @@ func (c *stmtEnvCollector) query(query string) (string, error) {
 		c.ctx,
 		"stmtEnvCollector",
 		nil, /* txn */
-		sqlbase.NoSessionDataOverride,
+		sqlbase.RootUserDataOverride,
 		query,
 	)
 	if err != nil {

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"context"
 	"math"
+	"runtime/debug"
 	"strings"
 	"sync"
 
@@ -28,9 +29,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 )
@@ -112,14 +113,18 @@ func (ie *InternalExecutor) SetSessionData(sessionData *sessiondata.SessionData)
 func (ie *InternalExecutor) initConnEx(
 	ctx context.Context,
 	txn *kv.Txn,
+	ch chan rowOrErr,
 	sd *sessiondata.SessionData,
 	syncCallback func([]resWithPos),
+	setColsCallback func(sqlbase.ResultColumns),
 	errCallback func(error),
 ) (*StmtBuf, *sync.WaitGroup, error) {
 	clientComm := &internalClientComm{
 		sync: syncCallback,
 		// init lastDelivered below the position of the first result (0).
-		lastDelivered: -1,
+		lastDelivered:   -1,
+		ch:              ch,
+		setColsCallback: setColsCallback,
 	}
 
 	// When the connEx is serving an internal executor, it can inherit the
@@ -186,48 +191,62 @@ func (ie *InternalExecutor) initConnEx(
 	return stmtBuf, &wg, nil
 }
 
-// Query executes the supplied SQL statement and returns the resulting rows.
-// If no user has been previously set through SetSessionData, the statement is
-// executed as the root user.
-//
-// If txn is not nil, the statement will be executed in the respective txn.
-//
-// Query is deprecated because it may transparently execute a query as root. Use
-// QueryEx instead.
-func (ie *InternalExecutor) Query(
-	ctx context.Context, opName string, txn *kv.Txn, stmt string, qargs ...interface{},
-) ([]tree.Datums, error) {
-	return ie.QueryEx(ctx, opName, txn, ie.maybeRootSessionDataOverride(opName), stmt, qargs...)
-}
-
-// QueryEx is like Query, but allows the caller to override some session data
-// fields (e.g. the user).
-//
-// The fields set in session that are set override the respective fields if they
-// have previously been set through SetSessionData().
-func (ie *InternalExecutor) QueryEx(
+func (ie *InternalExecutor) QueryIterator(
 	ctx context.Context,
 	opName string,
 	txn *kv.Txn,
 	session sqlbase.InternalExecutorSessionDataOverride,
 	stmt string,
 	qargs ...interface{},
-) ([]tree.Datums, error) {
-	datums, _, err := ie.queryInternal(ctx, opName, txn, session, stmt, qargs...)
-	return datums, err
-}
-
-// QueryWithCols is like QueryEx, but it also returns the computed ResultColumns
-// of the input query.
-func (ie *InternalExecutor) QueryWithCols(
-	ctx context.Context,
-	opName string,
-	txn *kv.Txn,
-	session sqlbase.InternalExecutorSessionDataOverride,
-	stmt string,
-	qargs ...interface{},
-) ([]tree.Datums, sqlbase.ResultColumns, error) {
+) (sqlutil.InternalRows, error) {
 	return ie.queryInternal(ctx, opName, txn, session, stmt, qargs...)
+}
+
+type rowOrErr struct {
+	row tree.Datums
+	err error
+}
+
+type rowsIterator struct {
+	ch chan rowOrErr
+
+	lastRow tree.Datums
+
+	resultCols sqlbase.ResultColumns
+}
+
+func (r *rowsIterator) Cur() tree.Datums {
+	return r.lastRow
+}
+
+func (r *rowsIterator) Next(ctx context.Context) (bool, error) {
+	select {
+	case rowOrErr, ok := <-r.ch:
+		if !ok {
+			return false, nil
+		}
+		if rowOrErr.err != nil {
+			return false, rowOrErr.err
+		}
+		if rowOrErr.row == nil {
+			return false, errors.AssertionFailedf("invalid state: empty rowOrErr")
+		}
+		r.lastRow = rowOrErr.row
+		return true, nil
+
+	case <-ctx.Done():
+		return false, ctx.Err()
+
+	}
+}
+
+func (r *rowsIterator) Close() error {
+	// Currently no op
+	return nil
+}
+
+func (r *rowsIterator) Types() sqlbase.ResultColumns {
+	return r.resultCols
 }
 
 func (ie *InternalExecutor) queryInternal(
@@ -237,12 +256,8 @@ func (ie *InternalExecutor) queryInternal(
 	sessionDataOverride sqlbase.InternalExecutorSessionDataOverride,
 	stmt string,
 	qargs ...interface{},
-) ([]tree.Datums, sqlbase.ResultColumns, error) {
-	res, err := ie.execInternal(ctx, opName, txn, sessionDataOverride, stmt, qargs...)
-	if err != nil {
-		return nil, nil, err
-	}
-	return res.rows, res.cols, res.err
+) (*rowsIterator, error) {
+	return ie.execInternal(ctx, opName, txn, sessionDataOverride, stmt, qargs...)
 }
 
 // QueryRow is like Query, except it returns a single row, or nil if not row is
@@ -268,18 +283,35 @@ func (ie *InternalExecutor) QueryRowEx(
 	stmt string,
 	qargs ...interface{},
 ) (tree.Datums, error) {
-	rows, err := ie.QueryEx(ctx, opName, txn, session, stmt, qargs...)
+	cols, _, err := ie.QueryRowWithCols(ctx, opName, txn, session, stmt, qargs...)
+	return cols, err
+}
+
+func (ie *InternalExecutor) QueryRowWithCols(
+	ctx context.Context,
+	opName string,
+	txn *kv.Txn,
+	session sqlbase.InternalExecutorSessionDataOverride,
+	stmt string,
+	qargs ...interface{},
+) (tree.Datums, sqlbase.ResultColumns, error) {
+	it, err := ie.QueryIterator(ctx, opName, txn, session, stmt, qargs...)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	switch len(rows) {
-	case 0:
-		return nil, nil
-	case 1:
-		return rows[0], nil
-	default:
-		return nil, &tree.MultipleResultsError{SQL: stmt}
+	defer it.Close()
+	var ok bool
+	var row tree.Datums
+	for ok, err = it.Next(ctx); ok && err == nil; ok, err = it.Next(ctx) {
+		if row != nil {
+			return nil, nil, &tree.MultipleResultsError{SQL: stmt}
+		}
+		row = it.Cur()
 	}
+	if err != nil {
+		return nil, nil, err
+	}
+	return row, it.Types(), nil
 }
 
 // Exec executes the supplied SQL statement and returns the number of rows
@@ -309,18 +341,31 @@ func (ie *InternalExecutor) ExecEx(
 	stmt string,
 	qargs ...interface{},
 ) (int, error) {
-	res, err := ie.execInternal(ctx, opName, txn, session, stmt, qargs...)
+	it, err := ie.execInternal(ctx, opName, txn, session, stmt, qargs...)
 	if err != nil {
 		return 0, err
 	}
-	return res.rowsAffected, res.err
+	var rowsAffected int
+	var foundARow bool
+	for ok, err := it.Next(ctx); ok && err == nil; ok, err = it.Next(ctx) {
+		row := it.Cur()
+		foundARow = true
+		rowsAffected = int(tree.MustBeDInt(row[0]))
+	}
+	if err != nil {
+		return 0, err
+	}
+	if !foundARow {
+		return 0, errors.NewAssertionErrorWithWrappedErrf(err, "unexpectedly found no rows affected row")
+	}
+	return rowsAffected, nil
 }
 
 type result struct {
-	rows         []tree.Datums
+	rowChan      chan tree.Datums
+	errChan      chan error
 	rowsAffected int
 	cols         sqlbase.ResultColumns
-	err          error
 }
 
 // applyOverrides overrides the respective fields from sd for all the fields set on o.
@@ -370,7 +415,7 @@ func (ie *InternalExecutor) execInternal(
 	sessionDataOverride sqlbase.InternalExecutorSessionDataOverride,
 	stmt string,
 	qargs ...interface{},
-) (retRes result, retErr error) {
+) (r *rowsIterator, retErr error) {
 	ctx = logtags.AddTag(ctx, "intExec", opName)
 
 	var sd *sessiondata.SessionData
@@ -383,7 +428,8 @@ func (ie *InternalExecutor) execInternal(
 	}
 	applyOverrides(sessionDataOverride, sd)
 	if sd.User == "" {
-		return result{}, errors.AssertionFailedf("no user specified for internal query")
+		debug.PrintStack()
+		return nil, errors.AssertionFailedf("no user specified for internal query")
 	}
 	if sd.ApplicationName == "" {
 		sd.ApplicationName = catconstants.InternalAppNamePrefix + "-" + opName
@@ -399,60 +445,79 @@ func (ie *InternalExecutor) execInternal(
 		if retErr != nil && !errIsRetriable(retErr) {
 			retErr = errors.Wrapf(retErr, "%s", opName)
 		}
-		if retRes.err != nil && !errIsRetriable(retRes.err) {
-			retRes.err = errors.Wrapf(retRes.err, "%s", opName)
-		}
+
 	}()
 
-	ctx, sp := tracing.EnsureChildSpan(ctx, ie.s.cfg.AmbientCtx.Tracer, opName)
-	defer sp.Finish()
+	/*
+		ctx, sp := tracing.EnsureChildSpan(ctx, ie.s.cfg.AmbientCtx.Tracer, opName)
+		defer sp.Finish()
+	*/
 
 	timeReceived := timeutil.Now()
 	parseStart := timeReceived
 	parsed, err := parser.ParseOne(stmt)
 	if err != nil {
-		return result{}, err
+		return nil, err
 	}
+	returnRows := parsed.AST.StatementType() == tree.Rows
 	parseEnd := timeutil.Now()
 
 	// resPos will be set to the position of the command that represents the
 	// statement we care about before that command is sent for execution.
 	var resPos CmdPos
 
-	resCh := make(chan result)
+	ch := make(chan rowOrErr, 32)
+	var rowsAffected int
 	var resultsReceived bool
+	var stmtBuf *StmtBuf
 	syncCallback := func(results []resWithPos) {
+		defer stmtBuf.Close()
 		resultsReceived = true
 		for _, res := range results {
-			if res.pos == resPos {
-				resCh <- result{rows: res.rows, rowsAffected: res.RowsAffected(), cols: res.cols, err: res.Err()}
-				return
+			if res.err != nil && !errIsRetriable(res.err) {
+				res.err = errors.Wrapf(res.err, opName)
 			}
 			if res.err != nil {
-				// If we encounter an error, there's no point in looking further; the
-				// rest of the commands in the batch have been skipped.
-				resCh <- result{err: res.Err()}
+				ch <- rowOrErr{err: res.err}
+			}
+			if res.pos == resPos {
+				rowsAffected = res.RowsAffected()
+				if returnRows {
+					close(ch)
+				}
 				return
 			}
 		}
-		resCh <- result{err: errors.AssertionFailedf("missing result for pos: %d and no previous error", resPos)}
+		ch <- rowOrErr{err: errors.AssertionFailedf("missing result for pos: %d and no previous error", resPos)}
 	}
 	errCallback := func(err error) {
 		if resultsReceived {
 			return
 		}
-		resCh <- result{err: err}
+		if err != nil && !errIsRetriable(err) {
+			err = errors.Wrapf(err, opName)
+		}
+		ch <- rowOrErr{err: err}
+		if returnRows {
+			close(ch)
+		}
 	}
-	stmtBuf, wg, err := ie.initConnEx(ctx, txn, sd, syncCallback, errCallback)
+
+	colsCh := make(chan sqlbase.ResultColumns)
+	setColsCallback := func(columns sqlbase.ResultColumns) {
+		colsCh <- columns
+		close(colsCh)
+	}
+	stmtBuf, wg, err := ie.initConnEx(ctx, txn, ch, sd, syncCallback, setColsCallback, errCallback)
 	if err != nil {
-		return result{}, err
+		return nil, err
 	}
 
 	// Transforms the args to datums. The datum types will be passed as type hints
 	// to the PrepareStmt command.
 	datums, err := golangFillQueryArguments(qargs...)
 	if err != nil {
-		return result{}, err
+		return nil, err
 	}
 	typeHints := make(tree.PlaceholderTypes, len(datums))
 	for i, d := range datums {
@@ -469,7 +534,7 @@ func (ie *InternalExecutor) execInternal(
 				ParseStart:   parseStart,
 				ParseEnd:     parseEnd,
 			}); err != nil {
-			return result{}, err
+			return nil, err
 		}
 	} else {
 		resPos = 2
@@ -482,25 +547,51 @@ func (ie *InternalExecutor) execInternal(
 				TypeHints:  typeHints,
 			},
 		); err != nil {
-			return result{}, err
+			return nil, err
 		}
 
 		if err := stmtBuf.Push(ctx, BindStmt{internalArgs: datums}); err != nil {
-			return result{}, err
+			return nil, err
 		}
 
 		if err := stmtBuf.Push(ctx, ExecPortal{TimeReceived: timeReceived}); err != nil {
-			return result{}, err
+			return nil, err
 		}
 	}
 	if err := stmtBuf.Push(ctx, Sync{}); err != nil {
-		return result{}, err
+		return nil, err
 	}
 
-	res := <-resCh
-	stmtBuf.Close()
+	if returnRows {
+		// Return a channel.
+		var cols sqlbase.ResultColumns
+		select {
+		case cols = <-colsCh:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		return &rowsIterator{
+			ch:         ch,
+			resultCols: cols,
+		}, nil
+	}
+
+	// Wait til completion.
 	wg.Wait()
-	return res, nil
+	resultCols := sqlbase.ResultColumns{
+		sqlbase.ResultColumn{
+			Name: "rows_affected",
+			Typ:  types.Int,
+		},
+	}
+	ch <- rowOrErr{row: tree.Datums{
+		tree.NewDInt(tree.DInt(rowsAffected)),
+	}}
+	close(ch)
+	return &rowsIterator{
+		ch:         ch,
+		resultCols: resultCols,
+	}, nil
 }
 
 // internalClientComm is an implementation of ClientComm used by the
@@ -514,7 +605,9 @@ type internalClientComm struct {
 
 	// sync, if set, is called whenever a Sync is executed. It returns all the
 	// results since the previous Sync.
-	sync func([]resWithPos)
+	sync            func([]resWithPos)
+	ch              chan rowOrErr
+	setColsCallback func(sqlbase.ResultColumns)
 }
 
 type resWithPos struct {
@@ -540,6 +633,8 @@ func (icc *internalClientComm) CreateStatementResult(
 // closed.
 func (icc *internalClientComm) createRes(pos CmdPos, onClose func(error)) *bufferedCommandResult {
 	res := &bufferedCommandResult{
+		ch:              icc.ch,
+		setColsCallback: icc.setColsCallback,
 		closeCallback: func(res *bufferedCommandResult, typ resCloseType, err error) {
 			if typ == discarded {
 				return

--- a/pkg/sql/internal_test.go
+++ b/pkg/sql/internal_test.go
@@ -132,16 +132,16 @@ func TestQueryIsAdminWithNoTxn(t *testing.T) {
 
 	for _, tc := range testData {
 		t.Run(tc.user, func(t *testing.T) {
-			rows, cols, err := ie.QueryWithCols(ctx, "test", nil, /* txn */
+			rows, cols, err := ie.QueryRowWithCols(ctx, "test", nil, /* txn */
 				sqlbase.InternalExecutorSessionDataOverride{User: tc.user},
 				"SELECT crdb_internal.is_admin()")
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(rows) != 1 || len(cols) != 1 {
+			if len(cols) != 1 {
 				t.Fatalf("unexpected result shape %d, %d", len(rows), len(cols))
 			}
-			isAdmin := bool(*rows[0][0].(*tree.DBool))
+			isAdmin := bool(*rows[0].(*tree.DBool))
 			if isAdmin != tc.expAdmin {
 				t.Fatalf("expected %q admin %v, got %v", tc.user, tc.expAdmin, isAdmin)
 			}
@@ -252,9 +252,9 @@ func TestInternalExecAppNameInitialization(t *testing.T) {
 }
 
 type testInternalExecutor interface {
-	Query(
+	QueryRow(
 		ctx context.Context, opName string, txn *kv.Txn, stmt string, qargs ...interface{},
-	) ([]tree.Datums, error)
+	) (tree.Datums, error)
 	Exec(
 		ctx context.Context, opName string, txn *kv.Txn, stmt string, qargs ...interface{},
 	) (int, error)
@@ -267,12 +267,10 @@ func testInternalExecutorAppNameInitialization(
 	ie testInternalExecutor,
 ) {
 	// Check that the application_name is set properly in the executor.
-	if rows, err := ie.Query(context.Background(), "test-query", nil,
+	if row, err := ie.QueryRow(context.Background(), "test-query", nil,
 		"SHOW application_name"); err != nil {
 		t.Fatal(err)
-	} else if len(rows) != 1 {
-		t.Fatalf("expected 1 row, got: %+v", rows)
-	} else if appName := string(*rows[0][0].(*tree.DString)); appName != expectedAppName {
+	} else if appName := string(*row[0].(*tree.DString)); appName != expectedAppName {
 		t.Fatalf("unexpected app name: expected %q, got %q", expectedAppName, appName)
 	}
 
@@ -280,7 +278,7 @@ func testInternalExecutorAppNameInitialization(
 	// have this keep running until we cancel it below.
 	errChan := make(chan error)
 	go func() {
-		_, err := ie.Query(context.Background(),
+		_, err := ie.QueryRow(context.Background(),
 			"test-query",
 			nil, /* txn */
 			"SELECT pg_sleep(1337666)")
@@ -296,7 +294,7 @@ func testInternalExecutorAppNameInitialization(
 	// When it does, we capture the query ID.
 	var queryID string
 	testutils.SucceedsSoon(t, func() error {
-		rows, err := ie.Query(context.Background(),
+		row, err := ie.QueryRow(context.Background(),
 			"find-query",
 			nil, /* txn */
 			// We need to assemble the magic string so that this SELECT
@@ -305,32 +303,26 @@ func testInternalExecutorAppNameInitialization(
 		if err != nil {
 			return err
 		}
-		switch len(rows) {
-		case 0:
+		if row == nil {
 			// The SucceedsSoon test may find this a couple of times before
 			// this succeeds.
 			return fmt.Errorf("query not started yet")
-		case 1:
-			appName := string(*rows[0][1].(*tree.DString))
-			if appName != expectedAppName {
-				return fmt.Errorf("unexpected app name: expected %q, got %q", expectedAppName, appName)
-			}
-
-			// Good app name, retrieve query ID for later cancellation.
-			queryID = string(*rows[0][0].(*tree.DString))
-			return nil
-		default:
-			return fmt.Errorf("unexpected results: %+v", rows)
 		}
+		appName := string(*row[1].(*tree.DString))
+		if appName != expectedAppName {
+			return fmt.Errorf("unexpected app name: expected %q, got %q", expectedAppName, appName)
+		}
+
+		// Good app name, retrieve query ID for later cancellation.
+		queryID = string(*row[0].(*tree.DString))
+		return nil
 	})
 
 	// Check that the query shows up in the internal tables without error.
-	if rows, err := ie.Query(context.Background(), "find-query", nil,
+	if row, err := ie.QueryRow(context.Background(), "find-query", nil,
 		"SELECT application_name FROM crdb_internal.node_queries WHERE query LIKE '%337' || '666%'"); err != nil {
 		t.Fatal(err)
-	} else if len(rows) != 1 {
-		t.Fatalf("expected 1 query, got: %+v", rows)
-	} else if appName := string(*rows[0][0].(*tree.DString)); appName != expectedAppName {
+	} else if appName := string(*row[0].(*tree.DString)); appName != expectedAppName {
 		t.Fatalf("unexpected app name: expected %q, got %q", expectedAppName, appName)
 	}
 
@@ -350,12 +342,10 @@ func testInternalExecutorAppNameInitialization(
 	}
 
 	// Now check that it was properly registered in statistics.
-	if rows, err := ie.Query(context.Background(), "find-query", nil,
+	if row, err := ie.QueryRow(context.Background(), "find-query", nil,
 		"SELECT application_name FROM crdb_internal.node_statement_statistics WHERE key LIKE 'SELECT' || ' pg_sleep(%'"); err != nil {
 		t.Fatal(err)
-	} else if len(rows) != 1 {
-		t.Fatalf("expected 1 query, got: %+v", rows)
-	} else if appName := string(*rows[0][0].(*tree.DString)); appName != expectedAppNameInStats {
+	} else if appName := string(*row[0].(*tree.DString)); appName != expectedAppNameInStats {
 		t.Fatalf("unexpected app name: expected %q, got %q", expectedAppNameInStats, appName)
 	}
 }

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
@@ -226,7 +225,7 @@ func processPgxStartup(ctx context.Context, s serverutils.TestServerInterface, c
 func execQuery(
 	ctx context.Context, query string, s serverutils.TestServerInterface, c *conn,
 ) error {
-	rows, cols, err := s.InternalExecutor().(sqlutil.InternalExecutor).QueryWithCols(
+	rows, err := s.InternalExecutor().(sqlutil.InternalExecutor).QueryIterator(
 		ctx, "test", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser, Database: "system"},
 		query,
@@ -234,7 +233,7 @@ func execQuery(
 	if err != nil {
 		return err
 	}
-	return sendResult(ctx, c, cols, rows)
+	return sendResult(ctx, c, rows)
 }
 
 func client(ctx context.Context, serverAddr net.Addr, wg *sync.WaitGroup) error {
@@ -353,15 +352,17 @@ func makeTestingConvCfg() sessiondata.DataConversionConfig {
 //
 // TODO(andrei): Tests using this should probably switch to using the similar
 // routines in the connection once conn learns how to write rows.
-func sendResult(
-	ctx context.Context, c *conn, cols sqlbase.ResultColumns, rows []tree.Datums,
-) error {
+func sendResult(ctx context.Context, c *conn, rows sqlutil.InternalRows) error {
+	cols := rows.Types()
 	if err := c.writeRowDescription(ctx, cols, nil /* formatCodes */, c.conn); err != nil {
 		return err
 	}
 
 	defaultConv := makeTestingConvCfg()
-	for _, row := range rows {
+	var ok bool
+	var err error
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
 		c.msgBuilder.initMsg(pgwirebase.ServerMsgDataRow)
 		c.msgBuilder.putInt16(int16(len(row)))
 		for i, col := range row {
@@ -371,6 +372,9 @@ func sendResult(
 		if err := c.msgBuilder.finishMsg(c.conn); err != nil {
 			return err
 		}
+	}
+	if err != nil {
+		return err
 	}
 
 	return finishQuery(execute, c)

--- a/pkg/sql/scrub_constraint.go
+++ b/pkg/sql/scrub_constraint.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
@@ -44,9 +45,8 @@ type sqlCheckConstraintCheckOperation struct {
 // sqlCheckConstraintCheckRun contains the run-time state for
 // sqlCheckConstraintCheckOperation during local execution.
 type sqlCheckConstraintCheckRun struct {
-	started  bool
-	rows     []tree.Datums
-	rowIndex int
+	started bool
+	rows    sqlutil.InternalRows
 }
 
 func newSQLCheckConstraintCheckOperation(
@@ -97,8 +97,10 @@ func (o *sqlCheckConstraintCheckOperation) Start(params runParams) error {
 		}
 	}
 
-	rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.Query(
-		ctx, "check-constraint", params.p.txn, tree.AsStringWithFlags(sel, tree.FmtParsable),
+	rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryIterator(
+		ctx, "check-constraint", params.p.txn,
+		sqlbase.RootUserDataOverride,
+		tree.AsStringWithFlags(sel, tree.FmtParsable),
 	)
 	if err != nil {
 		return err
@@ -118,8 +120,10 @@ func (o *sqlCheckConstraintCheckOperation) Start(params runParams) error {
 
 // Next implements the checkOperation interface.
 func (o *sqlCheckConstraintCheckOperation) Next(params runParams) (tree.Datums, error) {
-	row := o.run.rows[o.run.rowIndex]
-	o.run.rowIndex++
+	if ok, err := o.run.rows.Next(params.ctx); !ok || err != nil {
+		return nil, err
+	}
+	row := o.run.rows.Cur()
 	timestamp, err := tree.MakeDTimestamp(
 		params.extendedEvalCtx.GetStmtTimestamp(),
 		time.Nanosecond,
@@ -166,7 +170,7 @@ func (o *sqlCheckConstraintCheckOperation) Started() bool {
 
 // Done implements the checkOperation interface.
 func (o *sqlCheckConstraintCheckOperation) Done(ctx context.Context) bool {
-	return o.run.rows == nil || o.run.rowIndex >= len(o.run.rows)
+	return o.run.rows == nil
 }
 
 // Close implements the checkOperation interface.

--- a/pkg/sql/scrub_fk.go
+++ b/pkg/sql/scrub_fk.go
@@ -73,13 +73,20 @@ func (o *sqlForeignKeyCheckOperation) Start(params runParams) error {
 		return err
 	}
 
-	rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.Query(
-		ctx, "scrub-fk", params.p.txn, checkQuery,
+	rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryIterator(
+		ctx, "scrub-fk", params.p.txn, sqlbase.NoSessionDataOverride, checkQuery,
 	)
 	if err != nil {
 		return err
 	}
-	o.run.rows = rows
+	var ok bool
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
+		o.run.rows = append(o.run.rows, row)
+	}
+	if err != nil {
+		return err
+	}
 
 	if len(o.constraint.FK.OriginColumnIDs) > 1 && o.constraint.FK.Match == descpb.ForeignKeyReference_FULL {
 		// Check if there are any disallowed references where some columns are NULL
@@ -92,13 +99,19 @@ func (o *sqlForeignKeyCheckOperation) Start(params runParams) error {
 		if err != nil {
 			return err
 		}
-		rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.Query(
-			ctx, "scrub-fk", params.p.txn, checkNullsQuery,
+		rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryIterator(
+			ctx, "scrub-fk", params.p.txn, sqlbase.NoSessionDataOverride, checkNullsQuery,
 		)
 		if err != nil {
 			return err
 		}
-		o.run.rows = append(o.run.rows, rows...)
+		for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+			row := rows.Cur()
+			o.run.rows = append(o.run.rows, row)
+		}
+		if err != nil {
+			return err
+		}
 	}
 
 	// Collect the expected types for the query results. This is all

--- a/pkg/sql/scrub_index.go
+++ b/pkg/sql/scrub_index.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
@@ -50,9 +51,8 @@ type indexCheckOperation struct {
 // indexCheckRun contains the run-time state for indexCheckOperation
 // during local execution.
 type indexCheckRun struct {
-	started  bool
-	rows     []tree.Datums
-	rowIndex int
+	started bool
+	rows    sqlutil.InternalRows
 }
 
 func newIndexCheckOperation(
@@ -123,8 +123,8 @@ func (o *indexCheckOperation) Start(params runParams) error {
 		colNames(pkColumns), colNames(otherColumns), o.tableDesc.ID, o.indexDesc.ID,
 	)
 
-	rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.Query(
-		ctx, "scrub-index", params.p.txn, checkQuery,
+	rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryIterator(
+		ctx, "scrub-index", params.p.txn, sqlbase.RootUserDataOverride, checkQuery,
 	)
 	if err != nil {
 		return err
@@ -142,8 +142,10 @@ func (o *indexCheckOperation) Start(params runParams) error {
 
 // Next implements the checkOperation interface.
 func (o *indexCheckOperation) Next(params runParams) (tree.Datums, error) {
-	row := o.run.rows[o.run.rowIndex]
-	o.run.rowIndex++
+	if ok, err := o.run.rows.Next(params.ctx); !ok || err != nil {
+		return nil, err
+	}
+	row := o.run.rows.Cur()
 
 	// Check if this row has results from the left. See the comment above
 	// createIndexCheckQuery indicating why this is true.
@@ -224,7 +226,7 @@ func (o *indexCheckOperation) Started() bool {
 
 // Done implements the checkOperation interface.
 func (o *indexCheckOperation) Done(ctx context.Context) bool {
-	return o.run.rows == nil || o.run.rowIndex >= len(o.run.rows)
+	return o.run.rows == nil
 }
 
 // Close4 implements the checkOperation interface.

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2918,12 +2918,6 @@ type ClientNoticeSender interface {
 // this to sqlutil.InternalExecutor or sql.InternalExecutor, and use the
 // alternatives.
 type InternalExecutor interface {
-	// Query is part of the sqlutil.InternalExecutor interface.
-	Query(
-		ctx context.Context, opName string, txn *kv.Txn,
-		stmt string, qargs ...interface{},
-	) ([]Datums, error)
-
 	// QueryRow is part of the sqlutil.InternalExecutor interface.
 	QueryRow(
 		ctx context.Context, opName string, txn *kv.Txn, stmt string, qargs ...interface{},

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -178,7 +178,11 @@ func ShowCreateTable(
 	}
 
 	if !displayOptions.IgnoreComments {
-		if err := showComments(tn, desc, selectComment(ctx, p, desc.ID), &f.Buffer); err != nil {
+		comments, err := selectComment(ctx, p, desc.ID)
+		if err != nil {
+			return "", err
+		}
+		if err := showComments(tn, desc, comments, &f.Buffer); err != nil {
 			return "", err
 		}
 	}

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -39,15 +39,19 @@ type comment struct {
 
 // selectComment retrieves all the comments pertaining to a table (comments on the table
 // itself but also column and index comments.)
-func selectComment(ctx context.Context, p PlanHookState, tableID descpb.ID) (tc *tableComments) {
+func selectComment(
+	ctx context.Context, p PlanHookState, tableID descpb.ID,
+) (tc *tableComments, err error) {
 	query := fmt.Sprintf("SELECT type, object_id, sub_id, comment FROM system.comments WHERE object_id = %d", tableID)
 
-	commentRows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.Query(
-		ctx, "show-tables-with-comment", p.Txn(), query)
+	rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryIterator(
+		ctx, "show-tables-with-comment", p.Txn(), sqlbase.NoSessionDataOverride, query)
 	if err != nil {
 		log.VEventf(ctx, 1, "%q", err)
 	} else {
-		for _, row := range commentRows {
+		var ok bool
+		for ok, err = rows.Next(ctx); ok && err == nil; ok, err = rows.Next(ctx) {
+			row := rows.Cur()
 			commentType := int(tree.MustBeDInt(row[0]))
 			switch commentType {
 			case keys.TableCommentType, keys.ColumnCommentType, keys.IndexCommentType:
@@ -68,9 +72,12 @@ func selectComment(ctx context.Context, p PlanHookState, tableID descpb.ID) (tc 
 				}
 			}
 		}
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return tc
+	return tc, nil
 }
 
 // ShowCreateView returns a valid SQL representation of the CREATE VIEW

--- a/pkg/sql/sqlbase/internal.go
+++ b/pkg/sql/sqlbase/internal.go
@@ -35,3 +35,7 @@ var NoSessionDataOverride = InternalExecutorSessionDataOverride{}
 // NodeUserSessionDataOverride is an InternalExecutorSessionDataOverride which
 // overrides the users to the NodeUser.
 var NodeUserSessionDataOverride = InternalExecutorSessionDataOverride{User: security.NodeUser}
+
+// NoSessionDataOverride is the empty InternalExecutorSessionDataOverride which
+// does not override any session data.
+var RootUserDataOverride = InternalExecutorSessionDataOverride{User: security.RootUser}

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -467,15 +467,19 @@ FROM system.table_statistics
 WHERE "tableID" = $1
 ORDER BY "createdAt" DESC
 `
-	rows, err := sc.SQLExecutor.Query(
-		ctx, "get-table-statistics", nil /* txn */, getTableStatisticsStmt, tableID,
+	rows, err := sc.SQLExecutor.QueryIterator(
+		ctx, "get-table-statistics", nil, /* txn */
+		sqlbase.RootUserDataOverride,
+		getTableStatisticsStmt, tableID,
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	var statsList []*TableStatistic
-	for _, row := range rows {
+	var ok bool
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
 		stats, err := parseStats(ctx, sc.ClientDB, sc.Codec, row)
 		if err != nil {
 			return nil, err
@@ -483,5 +487,5 @@ ORDER BY "createdAt" DESC
 		statsList = append(statsList, stats)
 	}
 
-	return statsList, nil
+	return statsList, err
 }

--- a/pkg/sql/unsplit.go
+++ b/pkg/sql/unsplit.go
@@ -106,8 +106,8 @@ func (n *unsplitAllNode) startExec(params runParams) error {
 	if n.index.ID != n.tableDesc.PrimaryIndex.ID {
 		indexName = n.index.Name
 	}
-	ranges, err := params.p.ExtendedEvalContext().InternalExecutor.(*InternalExecutor).QueryEx(
-		params.ctx, "split points query", params.p.txn, sqlbase.InternalExecutorSessionDataOverride{},
+	rows, err := params.p.ExtendedEvalContext().InternalExecutor.(*InternalExecutor).QueryIterator(
+		params.ctx, "split points query", params.p.txn, sqlbase.NoSessionDataOverride,
 		statement,
 		dbDesc.GetName(),
 		n.tableDesc.Name,
@@ -116,9 +116,11 @@ func (n *unsplitAllNode) startExec(params runParams) error {
 	if err != nil {
 		return err
 	}
-	n.run.keys = make([][]byte, len(ranges))
-	for i, d := range ranges {
-		n.run.keys[i] = []byte(*(d[0].(*tree.DBytes)))
+	n.run.keys = make([][]byte, 0)
+	var ok bool
+	for ok, err = rows.Next(params.ctx); ok && err == nil; ok, err = rows.Next(params.ctx) {
+		d := rows.Cur()
+		n.run.keys = append(n.run.keys, []byte(*(d[0].(*tree.DBytes))))
 	}
 
 	return nil

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -132,7 +132,7 @@ func retrieveUserAndPassword(
 		getLoginDependencies := `SELECT option, value FROM system.role_options ` +
 			`WHERE username=$1 AND option IN ('NOLOGIN', 'VALID UNTIL')`
 
-		loginDependencies, err := ie.QueryEx(
+		rows, err := ie.QueryIterator(
 			ctx, "get-login-dependencies", nil, /* txn */
 			sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 			getLoginDependencies,
@@ -145,7 +145,9 @@ func retrieveUserAndPassword(
 		// To support users created before 20.1, allow all USERS/ROLES to login
 		// if NOLOGIN is not found.
 		canLogin = true
-		for _, row := range loginDependencies {
+		var ok bool
+		for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+			row := rows.Cur()
 			option := string(tree.MustBeDString(row[0]))
 
 			if option == "NOLOGIN" {
@@ -168,7 +170,7 @@ func retrieveUserAndPassword(
 			}
 		}
 
-		return nil
+		return err
 	})
 
 	if err != nil {
@@ -188,7 +190,7 @@ var userLoginTimeout = settings.RegisterPublicNonNegativeDurationSetting(
 // GetAllRoles returns a "set" (map) of Roles -> true.
 func (p *planner) GetAllRoles(ctx context.Context) (map[string]bool, error) {
 	query := `SELECT username FROM system.users`
-	rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryEx(
+	rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryIterator(
 		ctx, "read-users", p.txn,
 		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		query)
@@ -197,9 +199,14 @@ func (p *planner) GetAllRoles(ctx context.Context) (map[string]bool, error) {
 	}
 
 	users := make(map[string]bool)
-	for _, row := range rows {
+	row := make(tree.Datums, 1)
+	var ok bool
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
 		username := tree.MustBeDString(row[0])
 		users[string(username)] = true
+	}
+	if err != nil {
+		return nil, err
 	}
 	return users, nil
 }

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -913,7 +913,7 @@ func (m *Manager) migrateSystemNamespace(
 				`SELECT "parentID", name, id FROM [%d AS namespace_deprecated]
               WHERE id NOT IN (SELECT id FROM [%d AS namespace]) LIMIT %d`,
 				sqlbase.DeprecatedNamespaceTable.ID, sqlbase.NamespaceTable.ID, batchSize+1)
-			rows, err := r.sqlExecutor.QueryEx(
+			rows, err := r.sqlExecutor.QueryIterator(
 				ctx, "read-deprecated-namespace-table", txn,
 				sqlbase.InternalExecutorSessionDataOverride{
 					User: security.RootUser,
@@ -922,8 +922,11 @@ func (m *Manager) migrateSystemNamespace(
 			if err != nil {
 				return err
 			}
-			log.Infof(ctx, "Migrating system.namespace chunk with %d rows", len(rows))
-			for i, row := range rows {
+			log.Infof(ctx, "Migrating system.namespace chunk")
+			i := -1
+			for ok, err := rows.Next(ctx); ok && err == nil; ok, err = rows.Next(ctx) {
+				i++
+				row := rows.Cur()
 				workLeft = false
 				// We found some rows from the query, which means that we can't quit
 				// just yet.
@@ -991,7 +994,7 @@ func migrateSchemaChangeJobs(ctx context.Context, r runner, registry *jobs.Regis
 	// Get all jobs that aren't Succeeded and evaluate whether they need a
 	// migration. (Jobs that are canceled in 19.2 could still have in-progress
 	// schema changes.)
-	rows, err := r.sqlExecutor.QueryEx(
+	rows, err := r.sqlExecutor.QueryIterator(
 		ctx, "jobs-for-migration", nil, /* txn */
 		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 		"SELECT id, payload FROM system.jobs WHERE status != $1", jobs.StatusSucceeded,
@@ -999,7 +1002,9 @@ func migrateSchemaChangeJobs(ctx context.Context, r runner, registry *jobs.Regis
 	if err != nil {
 		return err
 	}
-	for _, row := range rows {
+	var ok bool
+	for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
 		jobID := int64(tree.MustBeDInt(row[0]))
 		log.VEventf(ctx, 2, "job %d: evaluating for schema change job migration", jobID)
 
@@ -1056,6 +1061,9 @@ func migrateSchemaChangeJobs(ctx context.Context, r runner, registry *jobs.Regis
 		}
 		log.Infof(ctx, "job %d: completed schema change job migration", jobID)
 	}
+	if err != nil {
+		return err
+	}
 
 	// Finally, we iterate through all table descriptors and jobs, and create jobs
 	// for any tables in the ADD state or that have draining names that don't
@@ -1089,7 +1097,7 @@ func migrateSchemaChangeJobs(ctx context.Context, r runner, registry *jobs.Regis
 		allDescs = descs
 
 		// Get all running schema change jobs.
-		rows, err := r.sqlExecutor.QueryEx(
+		rows, err := r.sqlExecutor.QueryIterator(
 			ctx, "preexisting-jobs", txn,
 			sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
 			"SELECT id, payload FROM system.jobs WHERE status = $1", jobs.StatusRunning,
@@ -1097,7 +1105,8 @@ func migrateSchemaChangeJobs(ctx context.Context, r runner, registry *jobs.Regis
 		if err != nil {
 			return err
 		}
-		for _, row := range rows {
+		for ok, err = rows.Next(ctx); err == nil && ok; ok, err = rows.Next(ctx) {
+			row := rows.Cur()
 			jobID := int64(tree.MustBeDInt(row[0]))
 			payload, err := jobs.UnmarshalPayload(row[1])
 			if err != nil {
@@ -1120,7 +1129,7 @@ func migrateSchemaChangeJobs(ctx context.Context, r runner, registry *jobs.Regis
 				}
 			}
 		}
-		return nil
+		return err
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
Note: this is still very much WIP

This commit removes the non-streaming way of using the internal
executor, replacing it with a simple iterator style interface.

Release note (sql change): internal queries are streamed instead of
buffered, potentially using less memory.