### PR TITLE
ui: fix incorrect display of table replica count

### DIFF
--- a/pkg/ui/src/views/databases/containers/tableDetails/index.tsx
+++ b/pkg/ui/src/views/databases/containers/tableDetails/index.tsx
@@ -128,7 +128,7 @@ export class TableMain extends React.Component<TableMainProps, {}> {
                         </Col>
                         <Col span={12}>
                           <div className="summary--card__counting">
-                            <h3 className="summary--card__counting--value">{tableInfo.numIndices}</h3>
+                            <h3 className="summary--card__counting--value">{tableInfo.numReplicas}</h3>
                             <p className="summary--card__counting--label">Replicas</p>
                           </div>
                         </Col>

--- a/pkg/ui/src/views/databases/data/tableInfo.tsx
+++ b/pkg/ui/src/views/databases/data/tableInfo.tsx
@@ -28,6 +28,7 @@ export class TableInfo {
   public rangeCount: number;
   public createStatement: string;
   public grants: protos.cockroach.server.serverpb.TableDetailsResponse.IGrant[];
+  public numReplicas: number;
   constructor(name: string, details: TableDetailsResponse, stats: TableStatsResponse) {
       this.name = name;
       this.id = details && details.descriptor_id.toNumber();
@@ -36,6 +37,7 @@ export class TableInfo {
       this.rangeCount = stats && stats.range_count && stats.range_count.toNumber();
       this.createStatement = details && details.create_table_statement;
       this.grants = details && details.grants;
+      this.numReplicas = details && details.zone_config && details.zone_config.num_replicas;
       if (stats) {
           this.mvccSize = stats.stats;
           this.physicalSize = FixLong(stats.approximate_disk_bytes).toNumber();


### PR DESCRIPTION
was shown indices instead of replicas.

Resolves: #48599

Release note (ui): Previously the replicas count on the table details page was incorrectly showing number of indices. This has been corrected to show the number of replicas"