### PR TITLE
storage: quiet Pebble logging in tests

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -360,12 +360,12 @@ type pebbleLogger struct {
 func (l pebbleLogger) Infof(format string, args ...interface{}) {
 	if pebbleLog != nil {
 		pebbleLog.LogfDepth(l.ctx, l.depth, format, args...)
-		// Only log INFO logs to the normal CockroachDB log at --v=3 and above.
-		if !log.V(3) {
-			return
-		}
+		return
 	}
-	log.InfofDepth(l.ctx, l.depth, format, args...)
+	// Only log INFO logs to the normal CockroachDB log at --v=3 and above.
+	if log.V(3) {
+		log.InfofDepth(l.ctx, l.depth, format, args...)
+	}
 }
 
 func (l pebbleLogger) Fatalf(format string, args ...interface{}) {


### PR DESCRIPTION
Change Pebble's logging to match the behavior of RocksDB's logging for
tests: the Pebble INFO logs are now only to the main log at `--v=3` and
above. Previously the Pebble INFO logs were always being output if
`InitPebbleLogger` had not been called, which is the case for almost all
tests.

Release note: None