### PR TITLE
release-20.1: ui: restore preset options in metrics timepicker

### DIFF
--- a/pkg/ui/src/views/cluster/components/range/index.tsx
+++ b/pkg/ui/src/views/cluster/components/range/index.tsx
@@ -20,7 +20,7 @@ export enum DateTypes {
   DATE_TO,
 }
 
-type RangeOption = {
+export type RangeOption = {
   value: string;
   label: string;
   timeLabel: string;
@@ -126,7 +126,28 @@ class RangeSelect extends React.Component<RangeSelectProps, RangeSelectState> {
 
   toggleCustomPicker = (custom: boolean) => () => this.setState({ custom }, this.clearPanelValues);
 
-  toggleDropDown = () => this.setState({ opened: !this.state.opened }, this.toggleCustomPicker(this.state.opened ));
+  toggleDropDown = () => {
+    this.setState(
+      (prevState) => {
+        return {
+          opened: !prevState.opened,
+          /*
+          Always close the custom date picker pane when toggling the dropdown.
+
+          The user must always manually choose to open it because right now we have
+          no button to "go back" to the list of presets from the custom timepicker.
+           */
+          custom: false,
+        };
+      },
+      () => {
+      if (this.state.opened) {
+        this.props.onOpened();
+      } else {
+        this.props.onClosed();
+      }
+    });
+  }
 
   handleOptionButtonOnClick = (option: RangeOption) => () => {
     trackTimeScaleSelected(option.label);

--- a/pkg/ui/src/views/cluster/components/range/range.spec.tsx
+++ b/pkg/ui/src/views/cluster/components/range/range.spec.tsx
@@ -1,0 +1,41 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import RangeSelect, {RangeOption} from "src/views/cluster/components/range/index";
+import {mount} from "enzyme";
+import moment from "moment";
+import {TimeWindow} from "src/redux/timewindow";
+import { assert } from "chai";
+import "src/enzymeInit";
+
+describe("RangeSelect", function() {
+  describe("basic dropdown", function() {
+    it("should show all options on dropdown activation", function() {
+      const options: RangeOption[] = [
+        { value: "1", label: "1", timeLabel: "1" },
+        { value: "2", label: "2", timeLabel: "2" },
+        { value: "3", label: "3", timeLabel: "3" },
+      ];
+      const value: TimeWindow = {
+        start: moment.utc().subtract(moment.duration(1, "day")),
+        end: moment.utc(),
+      };
+      const rangeSelect = mount(<RangeSelect options={options} onChange={() => {}}
+                                             changeDate={() => {}}
+                                             value={value} selected={{}}
+                                             onOpened={() => {}}
+                                             useTimeRange={false} />);
+
+      rangeSelect.find(".click-zone").simulate("click");
+      assert.lengthOf(rangeSelect.find("button .__option-label"), 3);
+    });
+  });
+});


### PR DESCRIPTION
Backport 1/1 commits from #49133.

/cc @cockroachdb/release

---

Previously, a bug was introduced that forced the timepicker
on the metrics page to only show the custom pane. This
made it impossible to use the time presets (1 day, 1 week, etc.)
that are helpful to operators.

This change restores the preset picker that takes precendence
over the custom time picker.

The custom time picker will now *only* show up when a user
clicks the "Custom" selection at the bottom of the dropdown.
Since the custom pane does not have a "back to presets" button,
this ensures that an operator always has the option to use
presets first since those are simpler to manipulate.

Release note (admin ui change): Fixed a bug where the metrics
timepicker was always defaulting to the "Custom" date pane. Access
to time window presets has been restored and is always shown
first. The "Custom" pane is accessed by selecting "Custom" in the
dropdown as before.

This closes #48049
