### PR TITLE
sql/pgwire: Make it possible to send out-of-band noticies immediately.

### DIFF
--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -685,9 +685,8 @@ type RestrictedCommandResult interface {
 	// This gets flushed only when the CommandResult is closed.
 	AppendParamStatusUpdate(string, string)
 
-	// AppendNotice appends a notice to the result.
-	// This gets flushed only when the CommandResult is closed.
-	AppendNotice(noticeErr error)
+	// SendNotice sends notification message to the client.
+	SendNotice(ctx context.Context, noticeErr error) error
 
 	// SetColumns informs the client about the schema of the result. The columns
 	// can be nil.
@@ -876,15 +875,13 @@ func (r *bufferedCommandResult) AppendParamStatusUpdate(key string, val string) 
 	panic("unimplemented")
 }
 
-// AppendNotice is part of the RestrictedCommandResult interface.
-func (r *bufferedCommandResult) AppendNotice(noticeErr error) {
-	panic("unimplemented")
+// SendNotice is part of the RestrictedCommandResult interface.
+func (r *bufferedCommandResult) SendNotice(ctx context.Context, noticeErr error) error {
+	return nil
 }
 
 // ResetStmtType is part of the RestrictedCommandResult interface.
-func (r *bufferedCommandResult) ResetStmtType(stmt tree.Statement) {
-	panic("unimplemented")
-}
+func (r *bufferedCommandResult) ResetStmtType(stmt tree.Statement) {}
 
 // AddRow is part of the RestrictedCommandResult interface.
 func (r *bufferedCommandResult) AddRow(ctx context.Context, row tree.Datums) error {

--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -202,14 +202,9 @@ func (r *commandResult) AppendParamStatusUpdate(param string, val string) {
 	)
 }
 
-// AppendNotice is part of the CommandResult interface.
-func (r *commandResult) AppendNotice(noticeErr error) {
-	r.flushBeforeCloseFuncs = append(
-		r.flushBeforeCloseFuncs,
-		func(ctx context.Context) error {
-			return r.conn.bufferNotice(ctx, noticeErr)
-		},
-	)
+// SendNotice is part of the CommandResult interface.
+func (r *commandResult) SendNotice(ctx context.Context, noticeErr error) error {
+	return r.conn.sendNotice(ctx, noticeErr)
 }
 
 // SetColumns is part of the CommandResult interface.

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -607,9 +607,9 @@ func (c *conn) bufferParamStatus(param, value string) error {
 	return c.msgBuilder.finishMsg(&c.writerState.buf)
 }
 
-func (c *conn) bufferNotice(ctx context.Context, noticeErr error) error {
+func (c *conn) sendNotice(ctx context.Context, noticeErr error) error {
 	c.msgBuilder.initMsg(pgwirebase.ServerMsgNoticeResponse)
-	return writeErrFields(ctx, c.sv, noticeErr, &c.msgBuilder, &c.writerState.buf)
+	return writeErrFields(ctx, c.sv, noticeErr, &c.msgBuilder, c.conn)
 }
 
 func (c *conn) sendInitialConnData(

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2712,7 +2712,7 @@ type EvalSessionAccessor interface {
 // distributed processors).
 type ClientNoticeSender interface {
 	// SendClientNotice sends a notice out-of-band to the client.
-	SendClientNotice(ctx context.Context, notice error)
+	SendClientNotice(ctx context.Context, notice error) error
 }
 
 // InternalExecutor is a subset of sqlutil.InternalExecutor (which, in turn, is

--- a/pkg/sql/sqlbase/evalctx.go
+++ b/pkg/sql/sqlbase/evalctx.go
@@ -163,7 +163,7 @@ type DummyClientNoticeSender struct{}
 var _ tree.ClientNoticeSender = &DummyClientNoticeSender{}
 
 // SendClientNotice is part of the tree.ClientNoticeSender interface.
-func (c *DummyClientNoticeSender) SendClientNotice(context.Context, error) {}
+func (c *DummyClientNoticeSender) SendClientNotice(context.Context, error) error { return nil }
 
 // DummyTenantOperator implements the tree.TenantOperator interface.
 type DummyTenantOperator struct{}


### PR DESCRIPTION
Improves out-of-band notice sending mechanism to make it possible
to send and flush notices before command completes.

Some commands, such as IMPORT run for very long time.  This change
makes it possible to notify user about important events.
For example, IMPORT statement will display a warning if the user
attempts to import files that are too large.  Importing very large
files often leads to poor user experience (and slow imports).
The notification message tells the user about that and suggests
for ways to improve performance.

Release notes (enhancement): IMPORT statement now warns the user
if we attempt to import very large files.  Improrting large files
often results in suboptimal performand and poor user experience,
where for long periods of time the user has no idea if the job is
making progress.  We now show a warning message if we import
large files, and recommend good mitigation strategies.