### PR TITLE
builtins: remove geo_builtins.go reference to fold_constants_func.go

### DIFF
--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -236,7 +236,6 @@ var geographyFromText = makeBuiltin(
 	},
 )
 
-// geoBuiltins must be kept in sync with sql/opt/norm/fold_constants_funcs.go.
 var geoBuiltins = map[string]builtinDefinition{
 	//
 	// Input (Geometry)


### PR DESCRIPTION
Looks like they don't have to be kept in sync anymore :') so removing
the line reference that mentions it. This has been replaced by labelling
all functions with volatility.

Release note: None