### PR TITLE
release-20.1: sqlmigrations: move namespace migration post-finalization

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1099,6 +1099,8 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.cluster_name"></a><code>crdb_internal.cluster_name() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the cluster name.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.completed_migrations"></a><code>crdb_internal.completed_migrations() &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
 <tr><td><a name="crdb_internal.encode_key"></a><code>crdb_internal.encode_key(table_id: <a href="int.html">int</a>, index_id: <a href="int.html">int</a>, row_tuple: anyelement) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Generate the key for a row on a particular table and index.</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.force_assertion_error"></a><code>crdb_internal.force_assertion_error(msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1790,6 +1790,12 @@ func (s *Server) Start(ctx context.Context) error {
 		return err
 	}
 
+	// Start the async migration to upgrade namespace entries from the old
+	// namespace table (id 2) to the new one (id 30).
+	if err := migMgr.StartSystemNamespaceMigration(ctx, bootstrapVersion); err != nil {
+		return err
+	}
+
 	// Record node start in telemetry. Get the right counter for this storage
 	// engine type as well as type of start (initial boot vs restart).
 	nodeStartCounter := "storage.engine."

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -189,13 +189,6 @@ func (p *planner) truncateTable(
 	//
 	// TODO(vivek): Fix properly along with #12123.
 	zoneKey := config.MakeZoneKey(uint32(tableDesc.ID))
-	nameKey := sqlbase.MakeObjectNameKey(
-		ctx,
-		p.ExecCfg().Settings,
-		tableDesc.ParentID,
-		tableDesc.GetParentSchemaID(),
-		tableDesc.GetName(),
-	).Key()
 	key := sqlbase.MakeObjectNameKey(
 		ctx, p.ExecCfg().Settings,
 		newTableDesc.ParentID,
@@ -203,15 +196,11 @@ func (p *planner) truncateTable(
 		newTableDesc.Name,
 	).Key()
 
-	b := &kv.Batch{}
-	// Use CPut because we want to remove a specific name -> id map.
-	if traceKV {
-		log.VEventf(ctx, 2, "CPut %s -> nil", nameKey)
-	}
-	var existingIDVal roachpb.Value
-	existingIDVal.SetInt(int64(tableDesc.ID))
-	b.CPut(nameKey, nil, &existingIDVal)
-	if err := p.txn.Run(ctx, b); err != nil {
+	// Remove the old namespace entry.
+	if err := sqlbase.RemoveObjectNamespaceEntry(
+		ctx, p.txn,
+		tableDesc.ParentID, tableDesc.GetParentSchemaID(), tableDesc.GetName(),
+		traceKV); err != nil {
 		return err
 	}
 
@@ -281,7 +270,7 @@ func (p *planner) truncateTable(
 	}
 
 	// Copy the zone config.
-	b = &kv.Batch{}
+	b := &kv.Batch{}
 	b.Get(zoneKey)
 	if err := p.txn.Run(ctx, b); err != nil {
 		return err


### PR DESCRIPTION
Backport 1/1 commits from #49099.

/cc @cockroachdb/release

---

Fixes #49090.
Fixes #49092.

This commit removes the namespace migration, and replaces it with a
post-finalization async migration in the style of the schema change jobs
migration that only runs after the 20.1 version bit is flipped.

This change prevents an issue with dropping a table or database from a
19.2 node after the migration ran. That operation would orphan an entry in
system.namespace2, since the migration would have moved the entry to
system.namespace2 already, but the drop would only remove the entry
from system.namespace.

The migration additionally only moves entries from system.namespace to
system.namespace2 if there isn't already an entry in system.namespace2
for that descriptor id. This should be safe and idempotent. Here are
some things to note:

1. No nodes write to namespace2 until 20.1 is finalized.
2. 20.1 nodes always delete from both namespace and namespace2.

In the happy path, there are no entries in system.namespace2 when the
migration runs. All entries are copied in.

If, after finalization but before the migration, a node:

- Adds a table: the new entry will go only to system.namespace2, and
  there will be no system.namespace entry to copy, so no problem
- Deletes a table: the entry will be removed from system.namespace2 and
  system.namespace, so there will be no system.namespace entry to copy.
- Renames a table: the old entry will be removed from system.namespace
  and system.namespce2, and the new entry will be added to
  system.namespace2, so there will be no system.namespace entry to copy.
- Truncates a table: same as rename.

Note this is all the same for views, sequences, and databases, but
databases, views, and sequences don't support truncate.

If this migration is run a second time, it's impossible to find any
entries in system.namespace that aren't also in system.namespace2,
because 20.1 nodes always delete from both tables when they delete, so
the migration will do nothing.

----

One complication is that, due to the issue explained at the top of this
commit, there can exist orphaned entries in system.descriptor2 that are
not in system.descriptor at the time that this migration runs. This
migration makes no effort to clean these orphans up, but it doesn't
affect the run of the migration.

Release note (bug fix): Prevent namespace orphans (manifesting as
`database "" not found` errors) when migrating from 19.2.
