### PR TITLE
util/log,*: subsume log.Safe under errors.Safe

### DIFF
--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -90,8 +90,8 @@ eexpect "CockroachDB node starting"
 
 system "($argv sql --insecure -e \"select crdb_internal.force_panic('helloworld')\" || true)&"
 # Check the panic is reported on the server's stderr
+eexpect "a SQL panic has occurred"
 eexpect "panic: helloworld"
-eexpect "panic while executing"
 eexpect "goroutine"
 eexpect ":/# "
 # Check the panic is reported on the server log file
@@ -99,7 +99,6 @@ send "cat logs/db/logs/cockroach.log\r"
 eexpect "a SQL panic has occurred"
 eexpect "helloworld"
 eexpect "a panic has occurred"
-eexpect "panic while executing"
 eexpect "goroutine"
 eexpect ":/# "
 

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -620,8 +620,8 @@ func (rsl StateLoader) SynthesizeHardState(
 	}
 
 	if oldHS.Commit > newHS.Commit {
-		return log.Safe(errors.Errorf("can't decrease HardState.Commit from %d to %d",
-			oldHS.Commit, newHS.Commit))
+		return errors.Newf("can't decrease HardState.Commit from %d to %d",
+			log.Safe(oldHS.Commit), log.Safe(newHS.Commit))
 	}
 	if oldHS.Term > newHS.Term {
 		// The existing HardState is allowed to be ahead of us, which is

--- a/pkg/roachpb/app_stats.go
+++ b/pkg/roachpb/app_stats.go
@@ -13,7 +13,7 @@ package roachpb
 import (
 	"math"
 
-	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 )
 
 // GetVariance retrieves the variance of the values.
@@ -60,7 +60,7 @@ func AddNumericStats(a, b NumericStat, countA, countB int64) NumericStat {
 // reg cluster.
 func (si SensitiveInfo) GetScrubbedCopy() SensitiveInfo {
 	output := SensitiveInfo{}
-	output.LastErr = log.Redact(si.LastErr)
+	output.LastErr = errors.Redact(si.LastErr)
 	// Not copying over MostRecentPlanDescription until we have an algorithm to scrub plan nodes.
 	return output
 }

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -796,7 +796,7 @@ func (ts TransactionStatus) IsCommittedOrStaging() bool {
 	return ts == COMMITTED || ts == STAGING
 }
 
-var _ log.SafeMessager = Transaction{}
+var _ errors.SafeMessager = Transaction{}
 
 // MakeTransaction creates a new transaction. The transaction key is
 // composed using the specified baseKey (for locality with data

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -16,6 +16,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -43,6 +44,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx"
 	"github.com/lib/pq"
+	"github.com/pmezard/go-difflib/difflib"
 	"github.com/stretchr/testify/require"
 )
 
@@ -55,37 +57,97 @@ INSERT INTO sensitive(super, sensible) VALUES('that', 'nobody', 'must', 'see');
 select * from crdb_internal.node_runtime_info;
 `
 
-	rUnsafe := "i'm not safe"
-	rSafe := log.Safe("something safe")
+	t.Run("unsafe", func(t *testing.T) {
+		rUnsafe := "i'm not safe"
+		safeErr := sql.AnonymizeStatementsForReporting("testing", stmt, rUnsafe)
 
-	safeErr := sql.AnonymizeStatementsForReporting("testing", stmt, rUnsafe)
+		const expMessage = "panic: i'm not safe"
+		actMessage := safeErr.Error()
+		if actMessage != expMessage {
+			t.Errorf("wanted: %s\ngot: %s", expMessage, actMessage)
+		}
 
-	const (
-		expMessage = "panic while testing 2 statements: INSERT INTO _(_, _) VALUES " +
-			"(_, _, __more2__); SELECT * FROM _._; caused by i'm not safe"
-		expSafeRedactedMessage = "?:0: panic while testing 2 statements: INSERT INTO _(_, _) VALUES " +
-			"(_, _, __more2__); SELECT * FROM _._: caused by <redacted>"
-		expSafeSafeMessage = "?:0: panic while testing 2 statements: INSERT INTO _(_, _) VALUES " +
-			"(_, _, __more2__); SELECT * FROM _._: caused by something safe"
-	)
+		const expSafeRedactedMessage = `...conn_executor_test.go:NN: <*errors.errorString>
+wrapper: <*safedetails.withSafeDetails>
+(more details:)
+panic: %v
+-- arg 1: <string>
+wrapper: <*withstack.withStack>
+(more details:)
+github.com/cockroachdb/cockroach/pkg/sql_test.TestAnonymizeStatementsForReporting.func1
+	...conn_executor_test.go:NN
+testing.tRunner
+	...testing.go:NN
+runtime.goexit
+	...asm_amd64.s:NN
+wrapper: <*safedetails.withSafeDetails>
+(more details:)
+panic while %s %d statements: %s
+-- arg 1: testing
+-- arg 2: 2
+-- arg 3: INSERT INTO _(_, _) VALUES (_, _, __more2__); SELECT * FROM _._`
+		actSafeRedactedMessage := fileref.ReplaceAllString(errors.Redact(safeErr), "...$2:NN")
+		if actSafeRedactedMessage != expSafeRedactedMessage {
+			diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+				A:        difflib.SplitLines(expSafeRedactedMessage),
+				B:        difflib.SplitLines(actSafeRedactedMessage),
+				FromFile: "Expected",
+				FromDate: "",
+				ToFile:   "Actual",
+				ToDate:   "",
+				Context:  1,
+			})
+			t.Errorf("Diff:\n%s", diff)
+		}
 
-	actMessage := safeErr.Error()
-	if actMessage != expMessage {
-		t.Fatalf("wanted: %s\ngot: %s", expMessage, actMessage)
-	}
+	})
 
-	actSafeRedactedMessage := log.ReportablesToSafeError(0, "", []interface{}{safeErr}).Error()
-	if actSafeRedactedMessage != expSafeRedactedMessage {
-		t.Fatalf("wanted: %s\ngot: %s", expSafeRedactedMessage, actSafeRedactedMessage)
-	}
+	t.Run("safe", func(t *testing.T) {
+		rSafe := log.Safe("something safe")
+		safeErr := sql.AnonymizeStatementsForReporting("testing", stmt, rSafe)
 
-	safeErr = sql.AnonymizeStatementsForReporting("testing", stmt, rSafe)
+		const expMessage = "panic: something safe"
+		actMessage := safeErr.Error()
+		if actMessage != expMessage {
+			t.Errorf("wanted: %s\ngot: %s", expMessage, actMessage)
+		}
 
-	actSafeSafeMessage := log.ReportablesToSafeError(0, "", []interface{}{safeErr}).Error()
-	if actSafeSafeMessage != expSafeSafeMessage {
-		t.Fatalf("wanted: %s\ngot: %s", expSafeSafeMessage, actSafeSafeMessage)
-	}
+		const expSafeSafeMessage = `...conn_executor_test.go:NN: <*errors.errorString>
+wrapper: <*safedetails.withSafeDetails>
+(more details:)
+panic: %v
+-- arg 1: something safe
+wrapper: <*withstack.withStack>
+(more details:)
+github.com/cockroachdb/cockroach/pkg/sql_test.TestAnonymizeStatementsForReporting.func2
+	...conn_executor_test.go:NN
+testing.tRunner
+	...testing.go:NN
+runtime.goexit
+	...asm_amd64.s:NN
+wrapper: <*safedetails.withSafeDetails>
+(more details:)
+panic while %s %d statements: %s
+-- arg 1: testing
+-- arg 2: 2
+-- arg 3: INSERT INTO _(_, _) VALUES (_, _, __more2__); SELECT * FROM _._`
+		actSafeSafeMessage := fileref.ReplaceAllString(errors.Redact(safeErr), "...$2:NN")
+		if actSafeSafeMessage != expSafeSafeMessage {
+			diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+				A:        difflib.SplitLines(expSafeSafeMessage),
+				B:        difflib.SplitLines(actSafeSafeMessage),
+				FromFile: "Expected",
+				FromDate: "",
+				ToFile:   "Actual",
+				ToDate:   "",
+				Context:  1,
+			})
+			t.Errorf("Diff:\n%s", diff)
+		}
+	})
 }
+
+var fileref = regexp.MustCompile(`((?:[a-zA-Z0-9\._@-]*/)*)([a-zA-Z0-9._@-]*\.(?:go|s)):\d+`)
 
 // Test that a connection closed abruptly while a SQL txn is in progress results
 // in that txn being rolled back.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1281,9 +1281,10 @@ func AnonymizeStatementsForReporting(action, sqlStmts string, r interface{}) err
 		anonStmtsStr = anonStmtsStr[:panicLogOutputCutoffChars] + " [...]"
 	}
 
-	return log.Safe(
-		fmt.Sprintf("panic while %s %d statements: %s", action, len(anonymized), anonStmtsStr),
-	).WithCause(r)
+	panicErr := log.PanicAsError(1, r)
+	return errors.WithSafeDetails(panicErr,
+		"panic while %s %d statements: %s",
+		errors.Safe(action), errors.Safe(len(anonymized)), errors.Safe(anonStmtsStr))
 }
 
 // SessionTracing holds the state used by SET TRACING {ON,OFF,LOCAL} statements in

--- a/pkg/storage/enginepb/mvcc.go
+++ b/pkg/storage/enginepb/mvcc.go
@@ -17,7 +17,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 )
 
 // TxnEpoch is a zero-indexed epoch for a transaction. When a transaction
@@ -387,7 +387,7 @@ func (t TxnMeta) SafeMessage() string {
 	return buf.String()
 }
 
-var _ log.SafeMessager = (*TxnMeta)(nil)
+var _ errors.SafeMessager = (*TxnMeta)(nil)
 
 // FormatBytesAsKey is injected by module roachpb as dependency upon initialization.
 var FormatBytesAsKey = func(k []byte) string {

--- a/pkg/storage/error.go
+++ b/pkg/storage/error.go
@@ -14,7 +14,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 )
 
 // A Error wraps an error returned from a RocksDB operation.
@@ -22,7 +22,7 @@ type Error struct {
 	msg string
 }
 
-var _ log.SafeMessager = (*Error)(nil)
+var _ errors.SafeMessager = (*Error)(nil)
 
 // Error implements the error interface.
 func (err *Error) Error() string {

--- a/pkg/util/interval/btree_based_interval.go
+++ b/pkg/util/interval/btree_based_interval.go
@@ -15,7 +15,6 @@ package interval
 import (
 	"sort"
 
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 )
@@ -100,7 +99,9 @@ func newBTreeWithDegree(overlapper Overlapper, minimumDegree int) *btree {
 
 func isValidInterface(a Interface) error {
 	if a == nil {
-		return log.Safe(errors.New("nil interface"))
+		// Note: Newf instead of New so that the error message is revealed
+		// in redact calls.
+		return errors.Newf("nil interface")
 	}
 	r := a.Range()
 	return rangeError(r)

--- a/pkg/util/interval/interval.go
+++ b/pkg/util/interval/interval.go
@@ -27,21 +27,20 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
 // ErrInvertedRange is returned if an interval is used where the start value is greater
 // than the end value.
-var ErrInvertedRange error = &log.SafeType{V: errors.New("interval: inverted range")}
+var ErrInvertedRange = errors.Newf("interval: inverted range")
 
 // ErrEmptyRange is returned if an interval is used where the start value is equal
 // to the end value.
-var ErrEmptyRange error = &log.SafeType{V: errors.New("interval: empty range")}
+var ErrEmptyRange = errors.Newf("interval: empty range")
 
 // ErrNilRange is returned if an interval is used where both the start value and
 // the end value are nil. This is a specialization of ErrEmptyRange.
-var ErrNilRange error = &log.SafeType{V: errors.New("interval: nil range")}
+var ErrNilRange = errors.Newf("interval: nil range")
 
 func rangeError(r Range) error {
 	switch r.Start.Compare(r.End) {

--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -11,28 +11,18 @@
 package log
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"net"
-	"os"
-	"path/filepath"
-	"runtime"
 	"runtime/debug"
-	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/caller"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stacktrace"
-	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	raven "github.com/getsentry/raven-go"
-	pkgErr "github.com/pkg/errors"
 )
 
 // The call stack here is usually:
@@ -112,97 +102,8 @@ func RecoverAndReportNonfatalPanic(ctx context.Context, sv *settings.Values) {
 	}
 }
 
-// SafeMessager is implemented by objects which have a way of representing
-// themselves suitably redacted for anonymized reporting.
-type SafeMessager interface {
-	SafeMessage() string
-}
-
-// A SafeType panic can be reported verbatim, i.e. does not leak information.
-// A nil `*SafeType` is not valid for use and may cause panics.
-type SafeType struct {
-	V      interface{}
-	causes []interface{} // unsafe
-}
-
-var _ SafeMessager = SafeType{}
-var _ interfaceCauser = SafeType{}
-
-type interfaceCauser interface {
-	Cause() interface{}
-}
-
-// SafeMessage implements SafeMessager. It does not recurse into
-// the SafeType's Cause()s.
-func (st SafeType) SafeMessage() string {
-	return fmt.Sprintf("%v", st.V)
-}
-
-// Format implements fmt.Formatter.
-func (st SafeType) Format(s fmt.State, verb rune) {
-	switch {
-	case verb == 'v' && s.Flag('+'):
-		fmt.Fprintf(s, "%s", st.Error())
-	default:
-		// "%d" etc with log.Safe() should minimally work.
-		// TODO(knz): This may lose some flags.
-		fmt.Fprintf(s, fmt.Sprintf("%%%c", verb), st.V)
-	}
-}
-
-// Error implements error as a convenience.
-func (st SafeType) Error() string {
-	var buf bytes.Buffer
-	fmt.Fprint(&buf, st.SafeMessage())
-	for _, cause := range st.causes {
-		fmt.Fprintf(&buf, "; caused by %v", cause)
-	}
-	return buf.String()
-}
-
-// SafeType implements fmt.Stringer as a convenience.
-func (st SafeType) String() string {
-	return st.SafeMessage()
-}
-
-// Cause returns the value passed to Chain() when this SafeType
-// was created (or nil).
-func (st SafeType) Cause() interface{} {
-	if len(st.causes) == 0 {
-		return nil
-	}
-	v := "<redacted>"
-	if messager, ok := st.causes[0].(SafeMessager); ok {
-		v = messager.SafeMessage()
-	}
-	return SafeType{
-		V:      v,
-		causes: st.causes[1:],
-	}
-}
-
-// Safe constructs a SafeType. It is equivalent to `Chain(v, nil)`.
-func Safe(v interface{}) SafeType {
-	return SafeType{V: v}
-}
-
-// WithCause links a safe message and a child about which nothing is assumed,
-// but for which the hope is that some anonymized parts can be obtained from it.
-func (st SafeType) WithCause(cause interface{}) SafeType {
-	causes := st.causes
-	for cause != nil {
-		causes = append(causes, cause)
-		causer, ok := cause.(interfaceCauser)
-		if !ok {
-			break
-		}
-		cause = causer.Cause()
-	}
-	return SafeType{
-		V:      st.V,
-		causes: causes,
-	}
-}
+// Safe constructs a SafeMessager.
+var Safe = errors.Safe
 
 // ReportPanic reports a panic has occurred on the real stderr.
 func ReportPanic(ctx context.Context, sv *settings.Values, r interface{}, depth int) {
@@ -224,11 +125,19 @@ func ReportPanic(ctx context.Context, sv *settings.Values, r interface{}, depth 
 		mainLog.printPanicToFile(r)
 	}
 
-	SendCrashReport(ctx, sv, depth+1, "", []interface{}{r}, ReportTypePanic)
+	sendCrashReport(ctx, sv, PanicAsError(depth+1, r), ReportTypePanic)
 
 	// Ensure that the logs are flushed before letting a panic
 	// terminate the server.
 	Flush()
+}
+
+// PanicAsError turns r into an error if it is not one already.
+func PanicAsError(depth int, r interface{}) error {
+	if err, ok := r.(error); ok {
+		return errors.WithStackDepth(err, depth+1)
+	}
+	return errors.NewWithDepthf(depth+1, "panic: %v", r)
 }
 
 var crashReportURL = func() string {
@@ -288,149 +197,6 @@ func uptimeTag(now time.Time) string {
 	}
 }
 
-type safeError struct {
-	message string
-}
-
-func (e *safeError) Error() string {
-	return e.message
-}
-
-// Redact returns a redacted version of the supplied item that is safe to use in
-// anonymized reporting.
-func Redact(r interface{}) string {
-	typAnd := func(i interface{}, text string) string {
-		typ := ErrorSource(i)
-		if typ == "" {
-			typ = fmt.Sprintf("%T", i)
-		}
-		if text == "" {
-			return typ
-		}
-		if strings.HasPrefix(typ, "errors.") {
-			// Don't bother reporting the type for errors.New() and its
-			// nondescript siblings. Note that errors coming from pkg/errors
-			// usually have `typ` overridden to file:line above, so they won't
-			// hit this path.
-			return text
-		}
-		return typ + ": " + text
-	}
-
-	handle := func(r interface{}) string {
-		switch t := r.(type) {
-		case SafeMessager:
-			return t.SafeMessage()
-		case error:
-			// continue below
-		default:
-			return typAnd(r, "")
-		}
-
-		// Now that we're looking at an error, see if it's one we can
-		// deconstruct for maximum (safe) clarity. Separating this from the
-		// block above ensures that the types below actually implement `error`.
-		switch t := r.(error).(type) {
-		case runtime.Error:
-			return typAnd(t, t.Error())
-		case sysutil.Errno:
-			return typAnd(t, t.Error())
-		case *os.SyscallError:
-			s := Redact(t.Err)
-			return typAnd(t, fmt.Sprintf("%s: %s", t.Syscall, s))
-		case *os.PathError:
-			// It hardly matters, but avoid mutating the original.
-			cpy := *t
-			t = &cpy
-			t.Path = "<redacted>"
-			return typAnd(t, t.Error())
-		case *os.LinkError:
-			// It hardly matters, but avoid mutating the original.
-			cpy := *t
-			t = &cpy
-
-			t.Old, t.New = "<redacted>", "<redacted>"
-			return typAnd(t, t.Error())
-		case *net.OpError:
-			// It hardly matters, but avoid mutating the original.
-			cpy := *t
-			t = &cpy
-			t.Source = &util.UnresolvedAddr{NetworkField: "tcp", AddressField: "redacted"}
-			t.Addr = &util.UnresolvedAddr{NetworkField: "tcp", AddressField: "redacted"}
-			t.Err = errors.New(Redact(t.Err))
-			return typAnd(t, t.Error())
-		default:
-		}
-
-		// Still an error, but not one we know how to deconstruct.
-
-		switch r.(error) {
-		case context.DeadlineExceeded:
-		case context.Canceled:
-		case os.ErrInvalid:
-		case os.ErrPermission:
-		case os.ErrExist:
-		case os.ErrNotExist:
-		case os.ErrClosed:
-		default:
-			// Not a whitelisted sentinel error.
-			return typAnd(r, "")
-		}
-		// Whitelisted sentinel error.
-		return typAnd(r, r.(error).Error())
-	}
-
-	reportable := handle(r)
-
-	switch c := r.(type) {
-	case interfaceCauser:
-		cause := c.Cause()
-		if cause != nil {
-			reportable += ": caused by " + Redact(c.Cause())
-		}
-	case (interface {
-		Cause() error
-	}):
-		reportable += ": caused by " + Redact(c.Cause())
-	}
-	return reportable
-}
-
-// ReportablesToSafeError inspects the given format string (taken as not needing
-// redaction) and reportables, redacts them appropriately and returns an error
-// that is safe to pass to anonymized reporting. The given depth is used to
-// insert a callsite when positive.
-func ReportablesToSafeError(depth int, format string, reportables []interface{}) error {
-	if len(reportables) == 0 {
-		reportables = []interface{}{"nothing reported"}
-	}
-
-	file := "?"
-	var line int
-	if depth > 0 {
-		file, line, _ = caller.Lookup(depth + 1)
-	}
-
-	redacted := make([]string, 0, len(reportables))
-	for i := range reportables {
-		redacted = append(redacted, Redact(reportables[i]))
-	}
-	reportables = nil
-
-	var sep string
-	// TODO(tschottdorf): it would be nice to massage the format so that all of its verbs are replaced by %v
-	// (so that we could now call `fmt.Sprintf(newFormat, reportables...)`).
-	// This isn't trivial. For example, "%ss %.2f %#v %U+%04X %%" would become "%ss %s %s %s %%".
-	// The logic to do that is known to `fmt.Printf` but we'd have to copy it here.
-	if format != "" {
-		sep = " | "
-	}
-	err := &safeError{
-		message: fmt.Sprintf("%s:%d: %s%s%s", filepath.Base(file), line, format, sep, strings.Join(redacted, "; ")),
-	}
-	return err
-}
-
 // ReportType is used to differentiate between an actual crash/panic and just
 // reporting an error. This data is useful for stability purposes.
 type ReportType int
@@ -443,36 +209,19 @@ const (
 	ReportTypeError
 )
 
-// SendCrashReport posts to sentry. The `reportables` is essentially the `args...` in
-// `log.Fatalf(format, args...)` (similarly for `log.Fatal`) or `[]interface{}{arg}` in
-// `panic(arg)`.
-//
-// The format string and those items in `reportables` which are a) an error or b) (values of or
-// pointers to) `log.Safe` will be used verbatim to construct the error that is reported to sentry.
-//
-// TODO(dt,knz,sql-team): we need to audit all sprintf'ing of values into the errors and strings
-// passed to panic, to ensure raw user data is kept separate and can thus be elided here. For now,
-// the type is about all we can assume is safe to report, which combined with file and line info
-// should be at least somewhat helpful in telling us where crashes are coming from. We capture the
-// full stacktrace below, so we only need the short file and line here help uniquely identify the
-// error. Some exceptions, like a runtime.Error, are assumed to be fine as-is.
+// sendCrashReport posts to sentry.
 //
 // The crashReportType parameter adds a tag to the event that shows if the
 // cluster did indeed crash or not.
-func SendCrashReport(
-	ctx context.Context,
-	sv *settings.Values,
-	depth int,
-	format string,
-	reportables []interface{},
-	crashReportType ReportType,
+func sendCrashReport(
+	ctx context.Context, sv *settings.Values, err error, crashReportType ReportType,
 ) {
 	if !ShouldSendReport(sv) {
 		return
 	}
-	err := ReportablesToSafeError(depth+1, format, reportables)
-	ex := raven.NewException(err, stacktrace.NewStackTrace(depth+1))
-	SendReport(ctx, err.Error(), crashReportType, nil, ex)
+
+	errMsg, packetDetails, extraDetails := errors.BuildSentryReport(err)
+	SendReport(ctx, errMsg, crashReportType, extraDetails, packetDetails...)
 }
 
 // ShouldSendReport returns true iff SendReport() should be called.
@@ -551,7 +300,8 @@ func ReportOrPanic(
 		panic(fmt.Sprintf(format, reportables...))
 	}
 	Warningf(ctx, format, reportables...)
-	SendCrashReport(ctx, sv, 1 /* depth */, format, reportables, ReportTypeError)
+	err := errors.Newf("internal error: "+format, reportables...)
+	sendCrashReport(ctx, sv, err, ReportTypeError)
 }
 
 const maxTagLen = 500
@@ -574,19 +324,4 @@ var tagFns []tagFn
 // This is intended to be called by other packages at init time.
 func RegisterTagFn(key string, value func(context.Context) string) {
 	tagFns = append(tagFns, tagFn{key, value})
-}
-
-// ErrorSource attempts to return the file:line where `i` was created if `i` has
-// that information (i.e. if it is an errors.withStack). Returns "" otherwise.
-func ErrorSource(i interface{}) string {
-	type stackTracer interface {
-		StackTrace() pkgErr.StackTrace
-	}
-	if e, ok := i.(stackTracer); ok {
-		tr := e.StackTrace()
-		if len(tr) > 0 {
-			return fmt.Sprintf("%v", tr[0]) // prints file:line
-		}
-	}
-	return ""
 }

--- a/pkg/util/log/crash_reporting_test.go
+++ b/pkg/util/log/crash_reporting_test.go
@@ -12,9 +12,9 @@ package log
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"os"
+	"regexp"
 	"runtime"
 	"testing"
 	"time"
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/pmezard/go-difflib/difflib"
 )
 
 // Renumber lines so they're stable no matter what changes above. (We
@@ -31,10 +32,8 @@ import (
 //line crash_reporting_test.go:1000
 
 type safeErrorTestCase struct {
-	format string
-	rs     []interface{}
+	err    error
 	expErr string
-	expStr string
 }
 
 // Exposed globally so it can be injected with platform-specific tests.
@@ -42,107 +41,279 @@ var safeErrorTestCases = func() []safeErrorTestCase {
 	var errSentinel = struct{ error }{} // explodes if Error() called
 	var errFundamental = errors.Errorf("%s", "not recoverable :(")
 	var errWrapped1 = errors.Wrap(errFundamental, "not recoverable :(")
-	var errWrapped2 = errors.Wrapf(errWrapped1, "not recoverable :(")
+	var errWrapped2 = errors.Wrapf(errWrapped1, "this is reportable")
 	var errWrapped3 = errors.Wrap(errWrapped2, "not recoverable :(")
-	var errWrappedSentinel = errors.Wrap(errors.Wrapf(errSentinel, "unseen"), "unsung")
+	var errWrappedSentinel = errors.Wrap(errors.Wrapf(errSentinel, "this is reportable"), "seecret")
 
 	runtimeErr := makeTypeAssertionErr()
 
 	return []safeErrorTestCase{
 		{
-			// Intended result of panic(context.DeadlineExceeded). Note that this is a known sentinel
-			// error but a safeError is returned.
-			format: "", rs: []interface{}{context.DeadlineExceeded},
-			expErr: "?:0: context.deadlineExceededError: context deadline exceeded",
-			expStr: "%!(EXTRA context.deadlineExceededError=context deadline exceeded)",
+			// Special case in errors.Redact().
+			err:    context.DeadlineExceeded,
+			expErr: "context.deadlineExceededError: context deadline exceeded",
 		},
 		{
-			// Intended result of panic(runtimeErr) which exhibits special case of known safe error.
-			format: "", rs: []interface{}{runtimeErr},
-			expErr: "?:0: *runtime.TypeAssertionError: interface conversion: interface {} is nil, not int",
-			expStr: "",
+			// Special case in errors.Redact().
+			err:    runtimeErr,
+			expErr: "*runtime.TypeAssertionError: interface conversion: interface {} is nil, not int",
 		},
 		{
 			// Same as last, but skipping through to the cause: panic(errors.Wrap(safeErr, "gibberish")).
-			format: "", rs: []interface{}{errors.Wrap(runtimeErr, "unseen")},
-			expErr: "?:0: crash_reporting_test.go:1035: caused by *errutil.withMessage: caused by *runtime.TypeAssertionError: interface conversion: interface {} is nil, not int",
-			expStr: "",
+			err: errors.Wrap(runtimeErr, "unseen"),
+			expErr: `...crash_reporting_test.go:NN: *runtime.TypeAssertionError: interface conversion: interface {} is nil, not int
+wrapper: <*errutil.withMessage>
+wrapper: <*withstack.withStack>
+(more details:)
+github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+	...crash_reporting_test.go:NN
+github.com/cockroachdb/cockroach/pkg/util/log.init
+	...crash_reporting_test.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.main
+	...proc.go:NN
+runtime.goexit
+	...asm_amd64.s:NN`,
 		},
 		{
-			// Special-casing switched off when format string present.
-			format: "%s", rs: []interface{}{runtimeErr},
-			expErr: "?:0: %s | *runtime.TypeAssertionError: interface conversion: interface {} is nil, not int",
-			expStr: "interface conversion: interface {} is nil, not int",
+			// Safe errors revealed in safe details of error wraps/objects.
+			err: errors.Newf("%s", runtimeErr),
+			expErr: `...crash_reporting_test.go:NN: <*errors.errorString>
+wrapper: <*safedetails.withSafeDetails>
+(more details:)
+%s
+-- arg 1: *runtime.TypeAssertionError: interface conversion: interface {} is nil, not int
+wrapper: <*withstack.withStack>
+(more details:)
+github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+	...crash_reporting_test.go:NN
+github.com/cockroachdb/cockroach/pkg/util/log.init
+	...crash_reporting_test.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.main
+	...proc.go:NN
+runtime.goexit
+	...asm_amd64.s:NN`,
 		},
 		{
-			// Special-casing switched off when more than one reportable present.
-			format: "", rs: []interface{}{runtimeErr, "foo"},
-			expErr: "?:0: *runtime.TypeAssertionError: interface conversion: interface {} is nil, not int; string",
-			expStr: "",
+			// More embedding of safe details.
+			err: errors.WithSafeDetails(runtimeErr, "foo"),
+			expErr: `*runtime.TypeAssertionError: interface conversion: interface {} is nil, not int
+wrapper: <*safedetails.withSafeDetails>
+(more details:)
+foo`,
 		},
 		{
-			format: "I like %s and %q and my pin code is %d or %d", rs: []interface{}{Safe("A"), &SafeType{V: "B"}, 1234, Safe(9999)},
-			expErr: "?:0: I like %s and %q and my pin code is %d or %d | A; B; int; 9999",
-			expStr: "I like A and \"B\" and my pin code is 1234 or 9999",
+			err: errors.Newf("I like %s and my pin code is %d or %d", Safe("A"), 1234, Safe(9999)),
+			expErr: `...crash_reporting_test.go:NN: <*errors.errorString>
+wrapper: <*safedetails.withSafeDetails>
+(more details:)
+I like %s and my pin code is %d or %d
+-- arg 1: A
+-- arg 2: <int>
+-- arg 3: 9999
+wrapper: <*withstack.withStack>
+(more details:)
+github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+	...crash_reporting_test.go:NN
+github.com/cockroachdb/cockroach/pkg/util/log.init
+	...crash_reporting_test.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.main
+	...proc.go:NN
+runtime.goexit
+	...asm_amd64.s:NN`,
 		},
 		{
-			format: "outer %+v", rs: []interface{}{
-				errors.Wrapf(context.Canceled, "this will unfortunately be lost: %d", Safe(6)),
-			},
-			expErr: "?:0: outer %+v | crash_reporting_test.go:1058: caused by *safedetails.withSafeDetails: caused by *errutil.withMessage: caused by *errors.errorString: context canceled",
-			expStr: "",
+			err: errors.Wrapf(context.Canceled, "this is preserved: %d", Safe(6)),
+			expErr: `...crash_reporting_test.go:NN: *errors.errorString: context canceled
+wrapper: <*errutil.withMessage>
+wrapper: <*safedetails.withSafeDetails>
+(more details:)
+this is preserved: %d
+-- arg 1: 6
+wrapper: <*withstack.withStack>
+(more details:)
+github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+	...crash_reporting_test.go:NN
+github.com/cockroachdb/cockroach/pkg/util/log.init
+	...crash_reporting_test.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.main
+	...proc.go:NN
+runtime.goexit
+	...asm_amd64.s:NN`,
 		},
 		{
 			// Verify that the special case still scrubs inside of the error.
-			format: "", rs: []interface{}{&os.LinkError{Op: "moo", Old: "sec", New: "cret", Err: errors.New("assumed safe")}},
-			expErr: "?:0: *os.LinkError: moo <redacted> <redacted>: assumed safe",
-			expStr: "",
+			err: &os.LinkError{Op: "moo", Old: "sec", New: "cret", Err: errors.WithSafeDetails(leafErr{}, "assumed safe")},
+			expErr: `<log.leafErr>
+wrapper: <*safedetails.withSafeDetails>
+(more details:)
+assumed safe
+wrapper: *os.LinkError: moo <redacted> <redacted>`,
 		},
 		{
 			// Verify that unknown sentinel errors print at least their type (regression test).
 			// Also, that its Error() is never called (since it would panic).
-			format: "%s", rs: []interface{}{errWrappedSentinel},
-			expErr: "?:0: %s | crash_reporting_test.go:1015: caused by *errutil.withMessage: caused by crash_reporting_test.go:1015: caused by *safedetails.withSafeDetails: caused by *errutil.withMessage: caused by struct { error }",
-			expStr: "",
+			err: errWrappedSentinel,
+			expErr: `...crash_reporting_test.go:NN: <struct { error }>
+wrapper: <*errutil.withMessage>
+wrapper: <*safedetails.withSafeDetails>
+(more details:)
+this is reportable
+wrapper: <*withstack.withStack>
+(more details:)
+github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+	...crash_reporting_test.go:NN
+github.com/cockroachdb/cockroach/pkg/util/log.init
+	...crash_reporting_test.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.main
+	...proc.go:NN
+runtime.goexit
+	...asm_amd64.s:NN
+wrapper: <*errutil.withMessage>
+wrapper: <*withstack.withStack>
+(more details:)
+github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+	...crash_reporting_test.go:NN
+github.com/cockroachdb/cockroach/pkg/util/log.init
+	...crash_reporting_test.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.main
+	...proc.go:NN
+runtime.goexit
+	...asm_amd64.s:NN`,
 		},
 		{
-			format: "", rs: []interface{}{errWrapped3},
-			expErr: "?:0: crash_reporting_test.go:1014: caused by *errutil.withMessage: caused by crash_reporting_test.go:1013: caused by *safedetails.withSafeDetails: caused by *errutil.withMessage: caused by crash_reporting_test.go:1012: caused by *errutil.withMessage: caused by crash_reporting_test.go:1011: caused by *safedetails.withSafeDetails: caused by *errors.errorString",
-			expStr: "",
+			err: errWrapped3,
+			expErr: `...crash_reporting_test.go:NN: <*errors.errorString>
+wrapper: <*safedetails.withSafeDetails>
+(more details:)
+%s
+-- arg 1: <string>
+wrapper: <*withstack.withStack>
+(more details:)
+github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+	...crash_reporting_test.go:NN
+github.com/cockroachdb/cockroach/pkg/util/log.init
+	...crash_reporting_test.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.main
+	...proc.go:NN
+runtime.goexit
+	...asm_amd64.s:NN
+wrapper: <*errutil.withMessage>
+wrapper: <*withstack.withStack>
+(more details:)
+github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+	...crash_reporting_test.go:NN
+github.com/cockroachdb/cockroach/pkg/util/log.init
+	...crash_reporting_test.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.main
+	...proc.go:NN
+runtime.goexit
+	...asm_amd64.s:NN
+wrapper: <*errutil.withMessage>
+wrapper: <*safedetails.withSafeDetails>
+(more details:)
+this is reportable
+wrapper: <*withstack.withStack>
+(more details:)
+github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+	...crash_reporting_test.go:NN
+github.com/cockroachdb/cockroach/pkg/util/log.init
+	...crash_reporting_test.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.main
+	...proc.go:NN
+runtime.goexit
+	...asm_amd64.s:NN
+wrapper: <*errutil.withMessage>
+wrapper: <*withstack.withStack>
+(more details:)
+github.com/cockroachdb/cockroach/pkg/util/log.glob..func4
+	...crash_reporting_test.go:NN
+github.com/cockroachdb/cockroach/pkg/util/log.init
+	...crash_reporting_test.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.doInit
+	...proc.go:NN
+runtime.main
+	...proc.go:NN
+runtime.goexit
+	...asm_amd64.s:NN`,
 		},
 		{
-			format: "", rs: []interface{}{&net.OpError{Op: "write", Net: "tcp", Source: &util.UnresolvedAddr{AddressField: "sensitive-source"}, Addr: &util.UnresolvedAddr{AddressField: "sensitive-addr"}, Err: errors.New("not safe")}},
-			expErr: "?:0: *net.OpError: write tcp redacted->redacted: crash_reporting_test.go:1082: caused by *errors.errorString",
-			expStr: "",
+			err: &net.OpError{
+				Op:     "write",
+				Net:    "tcp",
+				Source: &util.UnresolvedAddr{AddressField: "sensitive-source"},
+				Addr:   &util.UnresolvedAddr{AddressField: "sensitive-addr"},
+				Err:    leafErr{},
+			},
+			expErr: `<log.leafErr>
+wrapper: *net.OpError: write tcp<redacted>-><redacted>`,
 		},
 	}
 }()
 
 func TestCrashReportingSafeError(t *testing.T) {
+	fileref := regexp.MustCompile(`((?:[a-zA-Z0-9\._@-]*/)*)([a-zA-Z0-9._@-]*\.(?:go|s)):\d+`)
+
 	for _, test := range safeErrorTestCases {
 		t.Run("safeErr", func(t *testing.T) {
-			err := ReportablesToSafeError(0, test.format, test.rs)
-			if err == nil {
-				t.Fatal(err)
-			}
-			const expType = "*log.safeError"
-			if typStr := fmt.Sprintf("%T", err); typStr != expType {
-				t.Errorf("expected type:\n%s\ngot type:\n%s", expType, typStr)
-			}
-			if errStr := err.Error(); errStr != test.expErr {
-				t.Errorf("expected:\n%q\ngot:\n%q", test.expErr, errStr)
+			errStr := errors.Redact(test.err)
+			errStr = fileref.ReplaceAllString(errStr, "...$2:NN")
+			if errStr != test.expErr {
+				diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+					A:        difflib.SplitLines(test.expErr),
+					B:        difflib.SplitLines(errStr),
+					FromFile: "Expected",
+					FromDate: "",
+					ToFile:   "Actual",
+					ToDate:   "",
+					Context:  1,
+				})
+				t.Errorf("Diff:\n%s", diff)
 			}
 		})
-		if test.expStr != "" {
-			t.Run("fmt", func(t *testing.T) {
-				msg := fmt.Sprintf(test.format, test.rs...)
-				if msg != test.expStr {
-					t.Errorf("expected:\n%q\ngot:\n%q", test.expStr, msg)
-				}
-			})
-		}
 	}
 }
+
+type leafErr struct{}
+
+func (leafErr) Error() string { return "error" }
 
 func TestingSetCrashReportingURL(url string) func() {
 	oldCrashReportURL := crashReportURL
@@ -180,29 +351,6 @@ func TestUptimeTag(t *testing.T) {
 		if a, e := uptimeTag(tc.crashTime), tc.expected; a != e {
 			t.Errorf("uptimeTag(%v) got %v, want %v)", tc.crashTime, a, e)
 		}
-	}
-}
-
-func TestWithCause(t *testing.T) {
-	parent := Safe("roses are safe").
-		WithCause(
-			Safe("violets").
-				WithCause("are").
-				WithCause(Safe("too")),
-		).WithCause("bugs sure do suck").
-		WithCause("and so do you").
-		WithCause(Safe("j/k ❤"))
-
-	if a, e := parent.SafeMessage(), "roses are safe"; a != e {
-		t.Fatalf("expected %s, got %s", e, a)
-	}
-
-	act := ReportablesToSafeError(0, "", []interface{}{parent}).Error()
-	const exp = "?:0: roses are safe: caused by violets: caused by <redacted>: " +
-		"caused by too: caused by <redacted>: caused by <redacted>: caused by j/k ❤"
-
-	if act != exp {
-		t.Fatalf("wanted %s, got %s", exp, act)
 	}
 }
 

--- a/pkg/util/log/crash_reporting_unix_test.go
+++ b/pkg/util/log/crash_reporting_unix_test.go
@@ -20,7 +20,8 @@ import (
 
 func init() {
 	safeErrorTestCases = append(safeErrorTestCases, safeErrorTestCase{
-		format: "", rs: []interface{}{os.NewSyscallError("write", unix.ENOSPC)},
-		expErr: "?:0: *os.SyscallError: write: syscall.Errno: no space left on device",
+		err: os.NewSyscallError("write", unix.ENOSPC),
+		expErr: `syscall.Errno: no space left on device
+wrapper: *os.SyscallError: write`,
 	})
 }

--- a/pkg/util/log/main_test.go
+++ b/pkg/util/log/main_test.go
@@ -30,6 +30,7 @@ func TestMain(m *testing.M) {
 
 	// MakeTestingClusterSettings initializes log.ReportingSettings to this
 	// instance of setting values.
+	// TODO(knz): This comment appears to be untrue.
 	st := cluster.MakeTestingClusterSettings()
 	log.DiagnosticsReportingEnabled.Override(&st.SV, false)
 	log.CrashReports.Override(&st.SV, false)

--- a/pkg/util/log/structured.go
+++ b/pkg/util/log/structured.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 )
 
@@ -57,7 +58,8 @@ func addStructured(ctx context.Context, s Severity, depth int, format string, ar
 		// We load the ReportingSettings from the a global singleton in this
 		// call path. See the singleton's comment for a rationale.
 		if sv := settings.TODO(); sv != nil {
-			SendCrashReport(ctx, sv, depth+2, format, args, ReportTypePanic)
+			err := errors.NewWithDepthf(depth+1, "fatal error: "+format, args...)
+			sendCrashReport(ctx, sv, err, ReportTypePanic)
 		}
 	}
 	// MakeMessage already added the tags when forming msg, we don't want


### PR DESCRIPTION
Depends on https://github.com/cockroachdb/errors/pull/32
(will need to prepend a commit that bumps the dep)

This patch removes the "safe error", "safe messenger" and message
redaction facilities in package `util/log` and teaches their callers
to use the equivalent facilities in `cockroachdb/errors` instead.

Release note: None