### PR TITLE
opt: rework cascade execbuilder tests

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1054,6 +1054,8 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 			continue
 		}
 
+		log.VEventf(ctx, 1, "executing cascade for constraint %s", plan.cascades[i].FKName)
+
 		// We place a sequence point before every cascade, so
 		// that each subsequent cascade can observe the writes
 		// by the previous step.
@@ -1136,6 +1138,7 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 	}
 
 	for i := range plan.checkPlans {
+		log.VEventf(ctx, 1, "executing check query %d out of %d", i+1, len(plan.checkPlans))
 		if err := dsp.planAndRunPostquery(
 			ctx,
 			plan.checkPlans[i].plan,

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -1,5 +1,9 @@
 # LogicTest: local
 
+# The tests in this file target the legacy FK paths.
+statement ok
+SET optimizer_foreign_keys = false
+
 subtest DeleteCascade_Basic
 ### Basic Delete Cascade
 #     a

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade_opt
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade_opt
@@ -1,0 +1,655 @@
+# LogicTest: local
+
+subtest DeleteCascade_Basic
+### Basic Delete Cascade
+#     a
+#    / \
+#   b1 b2
+#  / \   \
+# c1  c2  c3
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE
+);
+
+statement ok
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE
+);
+
+statement ok
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY
+ ,delete_cascade STRING NOT NULL REFERENCES b1 ON DELETE CASCADE
+);
+
+statement ok
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY
+ ,delete_cascade STRING NOT NULL REFERENCES b1 ON DELETE CASCADE
+);
+
+statement ok
+CREATE TABLE c3 (
+  id STRING PRIMARY KEY REFERENCES b2 ON DELETE CASCADE
+);
+
+statement ok
+INSERT INTO a VALUES ('a-pk1');
+INSERT INTO b1 VALUES ('b1-pk1', 'a-pk1'), ('b1-pk2', 'a-pk1');
+INSERT INTO b2 VALUES ('b2-pk1', 'a-pk1'), ('b2-pk2', 'a-pk1');
+INSERT INTO c1 VALUES
+  ('c1-pk1-b1-pk1', 'b1-pk1')
+ ,('c1-pk2-b1-pk1', 'b1-pk1')
+ ,('c1-pk3-b1-pk2', 'b1-pk2')
+ ,('c1-pk4-b1-pk2', 'b1-pk2')
+;
+INSERT INTO c2 VALUES
+  ('c2-pk1-b1-pk1', 'b1-pk1')
+ ,('c2-pk2-b1-pk1', 'b1-pk1')
+ ,('c2-pk3-b1-pk2', 'b1-pk2')
+ ,('c2-pk4-b1-pk2', 'b1-pk2')
+;
+INSERT INTO c3 VALUES ('b2-pk1'), ('b2-pk2');
+
+statement ok
+SET tracing = on,kv,results; DELETE FROM a WHERE id = 'a-pk1'; SET tracing = off
+
+query I
+SELECT count(*) FROM [SHOW KV TRACE FOR SESSION] WHERE message LIKE 'cascading %';
+----
+5
+
+# Clean up after the test.
+statement ok
+DROP TABLE c3, c2, c1, b2, b1, a;
+
+subtest UpdateCascade_Basic
+### Basic Update Cascade
+#     a
+#    / \
+#   b1 b2
+#  / \   \
+# c1  c2  c3
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,update_cascade STRING NOT NULL UNIQUE REFERENCES a ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,update_cascade STRING NOT NULL UNIQUE REFERENCES a ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY
+ ,update_cascade STRING NOT NULL REFERENCES b1 (update_cascade) ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY
+ ,update_cascade STRING NOT NULL REFERENCES b1 (update_cascade) ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE c3 (
+  id STRING PRIMARY KEY REFERENCES b2(update_cascade) ON UPDATE CASCADE
+);
+
+statement ok
+INSERT INTO a VALUES ('original');
+INSERT INTO b1 VALUES ('b1-pk1', 'original');
+INSERT INTO b2 VALUES ('b2-pk1', 'original');
+INSERT INTO c1 VALUES
+  ('c1-pk1', 'original')
+ ,('c1-pk2', 'original')
+ ,('c1-pk3', 'original')
+ ,('c1-pk4', 'original')
+;
+INSERT INTO c2 VALUES
+  ('c2-pk1', 'original')
+ ,('c2-pk2', 'original')
+ ,('c2-pk3', 'original')
+ ,('c2-pk4', 'original')
+;
+INSERT INTO c3 VALUES ('original');
+
+# ON UPDATE CASCADE
+statement ok
+UPDATE a SET id = 'updated' WHERE id = 'original';
+
+statement ok
+SET tracing = on,kv,results; UPDATE a SET id = 'updated2' WHERE id = 'updated'; SET tracing = off
+
+query I
+SELECT count(*) FROM [SHOW KV TRACE FOR SESSION] WHERE message LIKE 'cascading %';
+----
+5
+
+# Clean up after the test.
+statement ok
+DROP TABLE c3, c2, c1, b2, b1, a;
+
+subtest DeleteSetNull_Basic1
+### Basic Delete Set Null
+#        a
+#      // \\
+#    / |  |  \
+#   b1 b2 b3 b4
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,delete_set_null STRING REFERENCES a ON DELETE SET NULL
+);
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,delete_set_null STRING REFERENCES a ON DELETE SET NULL
+);
+CREATE TABLE b3 (
+  id STRING PRIMARY KEY
+ ,delete_set_null STRING REFERENCES a ON DELETE SET NULL
+);
+CREATE TABLE b4 (
+  id STRING PRIMARY KEY
+ ,delete_set_null STRING REFERENCES a ON DELETE SET NULL
+);
+
+statement ok
+INSERT INTO a VALUES ('delete_me'), ('untouched');
+INSERT INTO b1 VALUES ('b1-pk1', 'untouched'), ('b1-pk2', 'untouched');
+INSERT INTO b2 VALUES ('b2-pk1', 'untouched'), ('b2-pk2', 'delete_me');
+INSERT INTO b3 VALUES ('b3-pk1', 'delete_me'), ('b3-pk2', 'untouched');
+INSERT INTO b4 VALUES ('b4-pk1', 'delete_me'), ('b4-pk2', 'delete_me');
+
+# Ensure that show trace adds a cascade message for each of the tables that is
+# cascaded into.
+statement ok
+SET tracing = on,kv,results; DELETE FROM a WHERE id = 'delete_me'; SET tracing = off
+
+query I
+SELECT count(*) FROM [SHOW KV TRACE FOR SESSION] WHERE message LIKE 'cascading %';
+----
+4
+
+# Clean up after the test.
+statement ok
+DROP TABLE b4, b3, b2, b1, a;
+
+subtest DeleteSetNull_Basic2
+### Basic Delete Set Null
+#     a
+#    / \
+#   b1 b2
+#  / \   \
+# c1  c2  c3
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE
+);
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE
+);
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY
+ ,delete_set_null STRING REFERENCES b1 ON DELETE SET NULL
+);
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY
+ ,delete_set_null STRING REFERENCES b1 ON DELETE SET NULL
+);
+CREATE TABLE c3 (
+  id STRING PRIMARY KEY
+ ,delete_set_null STRING REFERENCES b2 ON DELETE SET NULL
+);
+
+statement ok
+INSERT INTO a VALUES ('a-pk1');
+INSERT INTO b1 VALUES ('b1-pk1', 'a-pk1'), ('b1-pk2', 'a-pk1');
+INSERT INTO b2 VALUES ('b2-pk1', 'a-pk1'), ('b2-pk2', 'a-pk1');
+INSERT INTO c1 VALUES
+  ('c1-pk1-b1-pk1', 'b1-pk1')
+ ,('c1-pk2-b1-pk1', 'b1-pk1')
+ ,('c1-pk3-b1-pk2', 'b1-pk2')
+ ,('c1-pk4-b1-pk2', 'b1-pk2')
+;
+INSERT INTO c2 VALUES
+  ('c2-pk1-b1-pk1', 'b1-pk1')
+ ,('c2-pk2-b1-pk1', 'b1-pk1')
+ ,('c2-pk3-b1-pk2', 'b1-pk2')
+ ,('c2-pk4-b1-pk2', 'b1-pk2')
+;
+INSERT INTO c3 VALUES
+  ('c3-pk1-b2-pk1', 'b2-pk1')
+ ,('c3-pk2-b2-pk1', 'b2-pk1')
+ ,('c3-pk3-b2-pk2', 'b2-pk2')
+ ,('c3-pk4-b2-pk2', 'b2-pk2')
+;
+
+statement ok
+SET tracing = on,kv,results; DELETE FROM a WHERE id = 'a-pk1'; SET tracing = off
+
+query I
+SELECT count(*) FROM [SHOW KV TRACE FOR SESSION] WHERE message LIKE 'cascading %';
+----
+5
+
+# Clean up after the test.
+statement ok
+DROP TABLE c3, c2, c1, b2, b1, a;
+
+subtest UpdateSetNull_Basic1
+### Basic Update Set Null
+#        a
+#      // \\
+#    / |  |  \
+#   b1 b2 b3 b4
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING REFERENCES a ON UPDATE SET NULL
+);
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING REFERENCES a ON UPDATE SET NULL
+);
+CREATE TABLE b3 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING REFERENCES a ON UPDATE SET NULL
+);
+CREATE TABLE b4 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING REFERENCES a ON UPDATE SET NULL
+);
+
+statement ok
+INSERT INTO a VALUES ('original'), ('untouched');
+INSERT INTO b1 VALUES ('b1-pk1', 'untouched'), ('b1-pk2', 'untouched');
+INSERT INTO b2 VALUES ('b2-pk1', 'untouched'), ('b2-pk2', 'original');
+INSERT INTO b3 VALUES ('b3-pk1', 'original'), ('b3-pk2', 'untouched');
+INSERT INTO b3 VALUES ('b4-pk1', 'original'), ('b4-pk2', 'original');
+
+# Ensure that show trace adds a cascade message for each of the tables that is
+# cascaded into.
+statement ok
+SET tracing = on,kv,results; UPDATE a SET id = 'updated' WHERE id = 'original'; SET tracing = off
+
+query I
+SELECT count(*) FROM [SHOW KV TRACE FOR SESSION] WHERE message LIKE 'cascading %';
+----
+4
+
+# Clean up after the test.
+statement ok
+DROP TABLE b4, b3, b2, b1, a;
+
+subtest UpdateSetNull_Basic2
+### Basic Update Set Null
+#     a
+#    / \
+#   b1 b2
+#  / \   \
+# c1  c2  c3
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,update_cascade STRING UNIQUE NOT NULL REFERENCES a ON UPDATE CASCADE
+);
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,update_cascade STRING UNIQUE NOT NULL REFERENCES a ON UPDATE CASCADE
+);
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING REFERENCES b1(update_cascade) ON UPDATE SET NULL
+);
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING REFERENCES b1(update_cascade) ON UPDATE SET NULL
+);
+CREATE TABLE c3 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING REFERENCES b2(update_cascade) ON UPDATE SET NULL
+);
+
+statement ok
+INSERT INTO a VALUES ('original'), ('untouched');
+INSERT INTO b1 VALUES ('b1-pk1', 'original'), ('b1-pk2', 'untouched');
+INSERT INTO b2 VALUES ('b2-pk1', 'original'), ('b2-pk2', 'untouched');
+INSERT INTO c1 VALUES
+  ('c1-pk1-b1-pk1', 'original')
+ ,('c1-pk2-b1-pk1', 'original')
+ ,('c1-pk3-b1-pk2', 'untouched')
+ ,('c1-pk4-b1-pk2', 'untouched')
+;
+INSERT INTO c2 VALUES
+  ('c2-pk1-b1-pk1', 'original')
+ ,('c2-pk2-b1-pk1', 'original')
+ ,('c2-pk3-b1-pk2', 'untouched')
+ ,('c2-pk4-b1-pk2', 'untouched')
+;
+INSERT INTO c3 VALUES
+  ('c3-pk1-b2-pk1', 'original')
+ ,('c3-pk2-b2-pk1', 'original')
+ ,('c3-pk3-b2-pk2', 'untouched')
+ ,('c3-pk4-b2-pk2', 'untouched')
+;
+
+# Ensure that show trace adds a cascade message for each of the tables that is
+# cascaded into.
+statement ok
+SET tracing = on,kv,results; UPDATE a SET id = 'updated' WHERE id = 'original'; SET tracing = off
+
+query I
+SELECT count(*) FROM [SHOW KV TRACE FOR SESSION] WHERE message LIKE 'cascading %';
+----
+5
+
+# Clean up after the test.
+statement ok
+DROP TABLE c3, c2, c1, b2, b1, a;
+
+##############
+
+subtest DeleteSetDefault_Basic1
+### Basic Delete Set Default
+#        a
+#      // \\
+#    / |  |  \
+#   b1 b2 b3 b4
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,delete_set_default STRING DEFAULT 'b1-default' REFERENCES a ON DELETE SET DEFAULT
+);
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,delete_set_default STRING DEFAULT 'b2-default' REFERENCES a ON DELETE SET DEFAULT
+);
+CREATE TABLE b3 (
+  id STRING PRIMARY KEY
+ ,delete_set_default STRING DEFAULT 'b3-default' REFERENCES a ON DELETE SET DEFAULT
+);
+CREATE TABLE b4 (
+  id STRING PRIMARY KEY
+ ,delete_set_default STRING DEFAULT 'b4-default' REFERENCES a ON DELETE SET DEFAULT
+);
+
+statement ok
+INSERT INTO a VALUES ('delete_me'), ('untouched'), ('b2-default'), ('b3-default'), ('b4-default');
+INSERT INTO b1 VALUES ('b1-pk1', 'untouched'), ('b1-pk2', 'untouched');
+INSERT INTO b2 VALUES ('b2-pk1', 'untouched'), ('b2-pk2', 'delete_me');
+INSERT INTO b3 VALUES ('b3-pk1', 'delete_me'), ('b3-pk2', 'untouched');
+INSERT INTO b4 VALUES ('b4-pk1', 'delete_me'), ('b4-pk2', 'delete_me');
+
+# Ensure that show trace adds a cascade message for each of the tables that is
+# cascaded into.
+statement ok
+SET tracing = on,kv,results; DELETE FROM a WHERE id = 'delete_me'; SET tracing = off
+
+query I
+SELECT count(*) FROM [SHOW KV TRACE FOR SESSION] WHERE message LIKE 'cascading %';
+----
+4
+
+# Clean up after the test.
+statement ok
+DROP TABLE b4, b3, b2, b1, a;
+
+subtest DeleteSetDefault_Basic2
+### Basic Delete Set Null via an ON DELETE CASCADE
+#     a
+#    / \
+#   b1 b2
+#  / \   \
+# c1  c2  c3
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE
+);
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE
+);
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY
+ ,delete_set_default STRING DEFAULT 'b1-default' REFERENCES b1 ON DELETE SET DEFAULT
+);
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY
+ ,delete_set_default STRING DEFAULT 'b1-default' REFERENCES b1 ON DELETE SET DEFAULT
+);
+CREATE TABLE c3 (
+  id STRING PRIMARY KEY
+ ,delete_set_default STRING DEFAULT 'b2-default' REFERENCES b2 ON DELETE SET DEFAULT
+);
+
+statement ok
+INSERT INTO a VALUES ('a-pk1'), ('a-default');
+INSERT INTO b1 VALUES ('b1-pk1', 'a-pk1'), ('b1-pk2', 'a-pk1'), ('b1-default', 'a-default');
+INSERT INTO b2 VALUES ('b2-pk1', 'a-pk1'), ('b2-pk2', 'a-pk1'), ('b2-default', 'a-default');
+INSERT INTO c1 VALUES
+  ('c1-pk1-b1-pk1', 'b1-pk1')
+ ,('c1-pk2-b1-pk1', 'b1-pk1')
+ ,('c1-pk3-b1-pk2', 'b1-pk2')
+ ,('c1-pk4-b1-pk2', 'b1-pk2')
+;
+INSERT INTO c2 VALUES
+  ('c2-pk1-b1-pk1', 'b1-pk1')
+ ,('c2-pk2-b1-pk1', 'b1-pk1')
+ ,('c2-pk3-b1-pk2', 'b1-pk2')
+ ,('c2-pk4-b1-pk2', 'b1-pk2')
+;
+INSERT INTO c3 VALUES
+  ('c3-pk1-b2-pk1', 'b2-pk1')
+ ,('c3-pk2-b2-pk1', 'b2-pk1')
+ ,('c3-pk3-b2-pk2', 'b2-pk2')
+ ,('c3-pk4-b2-pk2', 'b2-pk2')
+;
+
+statement ok
+SET tracing = on,kv,results; DELETE FROM a WHERE id = 'a-pk1'; SET tracing = off
+
+query I
+SELECT count(*) FROM [SHOW KV TRACE FOR SESSION] WHERE message LIKE 'cascading %';
+----
+5
+
+# Clean up after the test.
+statement ok
+DROP TABLE c3, c2, c1, b2, b1, a;
+
+subtest UpdateSetDefault_Basic1
+### Basic Update Set Default
+#        a
+#      // \\
+#    / |  |  \
+#   b1 b2 b3 b4
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING DEFAULT 'b1-default' REFERENCES a ON UPDATE SET DEFAULT
+);
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING DEFAULT 'b2-default' REFERENCES a ON UPDATE SET DEFAULT
+);
+CREATE TABLE b3 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING DEFAULT 'b3-default' REFERENCES a ON UPDATE SET DEFAULT
+);
+CREATE TABLE b4 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING DEFAULT 'b4-default' REFERENCES a ON UPDATE SET DEFAULT
+);
+
+statement ok
+INSERT INTO a VALUES ('original'), ('untouched'), ('b1-default'), ('b2-default'), ('b3-default'), ('b4-default');
+INSERT INTO b1 VALUES ('b1-pk1', 'untouched'), ('b1-pk2', 'untouched');
+INSERT INTO b2 VALUES ('b2-pk1', 'untouched'), ('b2-pk2', 'original');
+INSERT INTO b3 VALUES ('b3-pk1', 'original'), ('b3-pk2', 'untouched');
+INSERT INTO b3 VALUES ('b4-pk1', 'original'), ('b4-pk2', 'original');
+
+# Ensure that show trace adds a cascade message for each of the tables that is
+# cascaded into.
+statement ok
+SET tracing = on,kv,results; UPDATE a SET id = 'updated' WHERE id = 'original'; SET tracing = off
+
+query I
+SELECT count(*) FROM [SHOW KV TRACE FOR SESSION] WHERE message LIKE 'cascading %';
+----
+4
+
+# Clean up after the test.
+statement ok
+DROP TABLE b4, b3, b2, b1, a;
+
+subtest UpdateSetDefault_Basic2
+### Basic UPDATE SET DEFAULT via an UPDATE CASCADE
+#     a
+#    / \
+#   b1 b2
+#  / \   \
+# c1  c2  c3
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,update_cascade STRING UNIQUE NOT NULL REFERENCES a ON UPDATE CASCADE
+);
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,update_cascade STRING UNIQUE NOT NULL REFERENCES a ON UPDATE CASCADE
+);
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING DEFAULT 'b1-default' REFERENCES b1(update_cascade) ON UPDATE SET DEFAULT
+);
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING DEFAULT 'b1-default' REFERENCES b1(update_cascade) ON UPDATE SET DEFAULT
+);
+CREATE TABLE c3 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING DEFAULT 'b2-default' REFERENCES b2(update_cascade) ON UPDATE SET DEFAULT
+);
+
+statement ok
+INSERT INTO a VALUES ('original'), ('untouched'), ('b1-default'), ('b2-default');
+INSERT INTO b1 VALUES ('b1-pk1', 'original'), ('b1-pk2', 'untouched'), ('b1-default', 'b1-default');
+INSERT INTO b2 VALUES ('b2-pk1', 'original'), ('b2-pk2', 'untouched'), ('b2-default', 'b2-default');
+INSERT INTO c1 VALUES
+  ('c1-pk1-b1-pk1', 'original')
+ ,('c1-pk2-b1-pk1', 'original')
+ ,('c1-pk3-b1-pk2', 'untouched')
+ ,('c1-pk4-b1-pk2', 'untouched')
+;
+INSERT INTO c2 VALUES
+  ('c2-pk1-b1-pk1', 'original')
+ ,('c2-pk2-b1-pk1', 'original')
+ ,('c2-pk3-b1-pk2', 'untouched')
+ ,('c2-pk4-b1-pk2', 'untouched')
+;
+INSERT INTO c3 VALUES
+  ('c3-pk1-b2-pk1', 'original')
+ ,('c3-pk2-b2-pk1', 'original')
+ ,('c3-pk3-b2-pk2', 'untouched')
+ ,('c3-pk4-b2-pk2', 'untouched')
+;
+
+# Ensure that show trace adds a cascade message for each of the tables that is
+# cascaded into.
+statement ok
+SET tracing = on,kv,results; UPDATE a SET id = 'updated' WHERE id = 'original'; SET tracing = off
+
+query I
+SELECT count(*) FROM [SHOW KV TRACE FOR SESSION] WHERE message LIKE 'cascading %';
+----
+5
+
+# Clean up after the test.
+statement ok
+DROP TABLE c3, c2, c1, b2, b1, a;
+
+# Regression for #46094.
+
+statement ok
+CREATE TABLE parent (x INT PRIMARY KEY);
+CREATE TABLE child1 (
+  id INT PRIMARY KEY,
+  x INT REFERENCES parent (x) ON DELETE CASCADE,
+  FAMILY (id, x)
+);
+CREATE TABLE child2 (
+  id INT PRIMARY KEY,
+  x INT REFERENCES parent (x) ON DELETE SET NULL,
+  FAMILY (id, x)
+);
+INSERT INTO parent VALUES (1), (2);
+INSERT INTO child1 VALUES (1, 1), (2, 1);
+INSERT INTO child2 VALUES (1, 1), (2, 1)
+
+# Here we ensure that after the cascaded deletes we don't need
+# to perform additional and unneeded FKScan operations after
+# cascade deleting or setting null to referencing rows.
+query T kvtrace(Del,FKScan)
+DELETE FROM parent WHERE x = 1
+----
+Del /Table/109/1/1/0
+Del /Table/110/2/1/1/0
+Del /Table/110/1/1/0
+Del /Table/110/2/1/2/0
+Del /Table/110/1/2/0
+Del /Table/111/2/1/1/0
+Del /Table/111/2/1/2/0

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade_opt
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade_opt
@@ -1,5 +1,13 @@
 # LogicTest: local
 
+# The tests in this file target the new optimizer-driven FK paths (with
+# fall back on the legacy paths for unsupported cases).
+statement ok
+SET optimizer_foreign_keys = true
+
+statement ok
+SET experimental_optimizer_foreign_key_cascades = true
+
 subtest DeleteCascade_Basic
 ### Basic Delete Cascade
 #     a
@@ -11,36 +19,40 @@ subtest DeleteCascade_Basic
 statement ok
 CREATE TABLE a (
   id STRING PRIMARY KEY
-);
+)
 
 statement ok
 CREATE TABLE b1 (
-  id STRING PRIMARY KEY
- ,delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE
-);
+  id STRING PRIMARY KEY,
+  delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE,
+  FAMILY (id, delete_cascade)
+)
 
 statement ok
 CREATE TABLE b2 (
-  id STRING PRIMARY KEY
- ,delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE
-);
+  id STRING PRIMARY KEY,
+  delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE,
+  FAMILY (id, delete_cascade)
+)
 
 statement ok
 CREATE TABLE c1 (
-  id STRING PRIMARY KEY
- ,delete_cascade STRING NOT NULL REFERENCES b1 ON DELETE CASCADE
-);
+  id STRING PRIMARY KEY,
+  delete_cascade STRING NOT NULL REFERENCES b1 ON DELETE CASCADE,
+  FAMILY (id, delete_cascade)
+)
 
 statement ok
 CREATE TABLE c2 (
-  id STRING PRIMARY KEY
- ,delete_cascade STRING NOT NULL REFERENCES b1 ON DELETE CASCADE
-);
+  id STRING PRIMARY KEY,
+  delete_cascade STRING NOT NULL REFERENCES b1 ON DELETE CASCADE,
+  FAMILY (id, delete_cascade)
+)
 
 statement ok
 CREATE TABLE c3 (
   id STRING PRIMARY KEY REFERENCES b2 ON DELETE CASCADE
-);
+)
 
 statement ok
 INSERT INTO a VALUES ('a-pk1');
@@ -63,10 +75,42 @@ INSERT INTO c3 VALUES ('b2-pk1'), ('b2-pk2');
 statement ok
 SET tracing = on,kv,results; DELETE FROM a WHERE id = 'a-pk1'; SET tracing = off
 
-query I
-SELECT count(*) FROM [SHOW KV TRACE FOR SESSION] WHERE message LIKE 'cascading %';
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION]
+WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
 ----
-5
+Del /Table/53/1/"a-pk1"/0
+executing cascade for constraint fk_delete_cascade_ref_a
+Del /Table/54/2/"a-pk1"/"b1-pk1"/0
+Del /Table/54/1/"b1-pk1"/0
+Del /Table/54/2/"a-pk1"/"b1-pk2"/0
+Del /Table/54/1/"b1-pk2"/0
+executing cascade for constraint fk_delete_cascade_ref_a
+Del /Table/55/2/"a-pk1"/"b2-pk1"/0
+Del /Table/55/1/"b2-pk1"/0
+Del /Table/55/2/"a-pk1"/"b2-pk2"/0
+Del /Table/55/1/"b2-pk2"/0
+executing cascade for constraint fk_delete_cascade_ref_b1
+Del /Table/56/2/"b1-pk1"/"c1-pk1-b1-pk1"/0
+Del /Table/56/1/"c1-pk1-b1-pk1"/0
+Del /Table/56/2/"b1-pk1"/"c1-pk2-b1-pk1"/0
+Del /Table/56/1/"c1-pk2-b1-pk1"/0
+Del /Table/56/2/"b1-pk2"/"c1-pk3-b1-pk2"/0
+Del /Table/56/1/"c1-pk3-b1-pk2"/0
+Del /Table/56/2/"b1-pk2"/"c1-pk4-b1-pk2"/0
+Del /Table/56/1/"c1-pk4-b1-pk2"/0
+executing cascade for constraint fk_delete_cascade_ref_b1
+Del /Table/57/2/"b1-pk1"/"c2-pk1-b1-pk1"/0
+Del /Table/57/1/"c2-pk1-b1-pk1"/0
+Del /Table/57/2/"b1-pk1"/"c2-pk2-b1-pk1"/0
+Del /Table/57/1/"c2-pk2-b1-pk1"/0
+Del /Table/57/2/"b1-pk2"/"c2-pk3-b1-pk2"/0
+Del /Table/57/1/"c2-pk3-b1-pk2"/0
+Del /Table/57/2/"b1-pk2"/"c2-pk4-b1-pk2"/0
+Del /Table/57/1/"c2-pk4-b1-pk2"/0
+executing cascade for constraint fk_id_ref_b2
+Del /Table/58/1/"b2-pk1"/0
+Del /Table/58/1/"b2-pk2"/0
 
 # Clean up after the test.
 statement ok
@@ -160,20 +204,24 @@ CREATE TABLE a (
   id STRING PRIMARY KEY
 );
 CREATE TABLE b1 (
-  id STRING PRIMARY KEY
- ,delete_set_null STRING REFERENCES a ON DELETE SET NULL
+  id STRING PRIMARY KEY,
+  delete_set_null STRING REFERENCES a ON DELETE SET NULL,
+  FAMILY (id, delete_set_null)
 );
 CREATE TABLE b2 (
-  id STRING PRIMARY KEY
- ,delete_set_null STRING REFERENCES a ON DELETE SET NULL
+  id STRING PRIMARY KEY,
+  delete_set_null STRING REFERENCES a ON DELETE SET NULL,
+  FAMILY (id, delete_set_null)
 );
 CREATE TABLE b3 (
-  id STRING PRIMARY KEY
- ,delete_set_null STRING REFERENCES a ON DELETE SET NULL
+  id STRING PRIMARY KEY,
+  delete_set_null STRING REFERENCES a ON DELETE SET NULL,
+  FAMILY (id, delete_set_null)
 );
 CREATE TABLE b4 (
-  id STRING PRIMARY KEY
- ,delete_set_null STRING REFERENCES a ON DELETE SET NULL
+  id STRING PRIMARY KEY,
+  delete_set_null STRING REFERENCES a ON DELETE SET NULL,
+  FAMILY (id, delete_set_null)
 );
 
 statement ok
@@ -188,10 +236,19 @@ INSERT INTO b4 VALUES ('b4-pk1', 'delete_me'), ('b4-pk2', 'delete_me');
 statement ok
 SET tracing = on,kv,results; DELETE FROM a WHERE id = 'delete_me'; SET tracing = off
 
-query I
-SELECT count(*) FROM [SHOW KV TRACE FOR SESSION] WHERE message LIKE 'cascading %';
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION]
+WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
 ----
-4
+Del /Table/65/1/"delete_me"/0
+executing cascade for constraint fk_delete_set_null_ref_a
+executing cascade for constraint fk_delete_set_null_ref_a
+Del /Table/67/2/"delete_me"/"b2-pk2"/0
+executing cascade for constraint fk_delete_set_null_ref_a
+Del /Table/68/2/"delete_me"/"b3-pk1"/0
+executing cascade for constraint fk_delete_set_null_ref_a
+Del /Table/69/2/"delete_me"/"b4-pk1"/0
+Del /Table/69/2/"delete_me"/"b4-pk2"/0
 
 # Clean up after the test.
 statement ok
@@ -210,24 +267,29 @@ CREATE TABLE a (
   id STRING PRIMARY KEY
 );
 CREATE TABLE b1 (
-  id STRING PRIMARY KEY
- ,delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE
+  id STRING PRIMARY KEY,
+  delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE,
+  FAMILY (id, delete_cascade)
 );
 CREATE TABLE b2 (
-  id STRING PRIMARY KEY
- ,delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE
+  id STRING PRIMARY KEY,
+  delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE,
+  FAMILY (id, delete_cascade)
 );
 CREATE TABLE c1 (
-  id STRING PRIMARY KEY
- ,delete_set_null STRING REFERENCES b1 ON DELETE SET NULL
+  id STRING PRIMARY KEY,
+  delete_set_null STRING REFERENCES b1 ON DELETE SET NULL,
+  FAMILY (id, delete_set_null)
 );
 CREATE TABLE c2 (
-  id STRING PRIMARY KEY
- ,delete_set_null STRING REFERENCES b1 ON DELETE SET NULL
+  id STRING PRIMARY KEY,
+  delete_set_null STRING REFERENCES b1 ON DELETE SET NULL,
+  FAMILY (id, delete_set_null)
 );
 CREATE TABLE c3 (
-  id STRING PRIMARY KEY
- ,delete_set_null STRING REFERENCES b2 ON DELETE SET NULL
+  id STRING PRIMARY KEY,
+  delete_set_null STRING REFERENCES b2 ON DELETE SET NULL,
+  FAMILY (id, delete_set_null)
 );
 
 statement ok
@@ -256,10 +318,36 @@ INSERT INTO c3 VALUES
 statement ok
 SET tracing = on,kv,results; DELETE FROM a WHERE id = 'a-pk1'; SET tracing = off
 
-query I
-SELECT count(*) FROM [SHOW KV TRACE FOR SESSION] WHERE message LIKE 'cascading %';
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION]
+WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
 ----
-5
+Del /Table/70/1/"a-pk1"/0
+executing cascade for constraint fk_delete_cascade_ref_a
+Del /Table/71/2/"a-pk1"/"b1-pk1"/0
+Del /Table/71/1/"b1-pk1"/0
+Del /Table/71/2/"a-pk1"/"b1-pk2"/0
+Del /Table/71/1/"b1-pk2"/0
+executing cascade for constraint fk_delete_cascade_ref_a
+Del /Table/72/2/"a-pk1"/"b2-pk1"/0
+Del /Table/72/1/"b2-pk1"/0
+Del /Table/72/2/"a-pk1"/"b2-pk2"/0
+Del /Table/72/1/"b2-pk2"/0
+executing cascade for constraint fk_delete_set_null_ref_b1
+Del /Table/73/2/"b1-pk1"/"c1-pk1-b1-pk1"/0
+Del /Table/73/2/"b1-pk1"/"c1-pk2-b1-pk1"/0
+Del /Table/73/2/"b1-pk2"/"c1-pk3-b1-pk2"/0
+Del /Table/73/2/"b1-pk2"/"c1-pk4-b1-pk2"/0
+executing cascade for constraint fk_delete_set_null_ref_b1
+Del /Table/74/2/"b1-pk1"/"c2-pk1-b1-pk1"/0
+Del /Table/74/2/"b1-pk1"/"c2-pk2-b1-pk1"/0
+Del /Table/74/2/"b1-pk2"/"c2-pk3-b1-pk2"/0
+Del /Table/74/2/"b1-pk2"/"c2-pk4-b1-pk2"/0
+executing cascade for constraint fk_delete_set_null_ref_b2
+Del /Table/75/2/"b2-pk1"/"c3-pk1-b2-pk1"/0
+Del /Table/75/2/"b2-pk1"/"c3-pk2-b2-pk1"/0
+Del /Table/75/2/"b2-pk2"/"c3-pk3-b2-pk2"/0
+Del /Table/75/2/"b2-pk2"/"c3-pk4-b2-pk2"/0
 
 # Clean up after the test.
 statement ok
@@ -398,20 +486,24 @@ CREATE TABLE a (
   id STRING PRIMARY KEY
 );
 CREATE TABLE b1 (
-  id STRING PRIMARY KEY
- ,delete_set_default STRING DEFAULT 'b1-default' REFERENCES a ON DELETE SET DEFAULT
+  id STRING PRIMARY KEY,
+  delete_set_default STRING DEFAULT 'b1-default' REFERENCES a ON DELETE SET DEFAULT,
+  FAMILY (id, delete_set_default)
 );
 CREATE TABLE b2 (
-  id STRING PRIMARY KEY
- ,delete_set_default STRING DEFAULT 'b2-default' REFERENCES a ON DELETE SET DEFAULT
+  id STRING PRIMARY KEY,
+  delete_set_default STRING DEFAULT 'b2-default' REFERENCES a ON DELETE SET DEFAULT,
+  FAMILY (id, delete_set_default)
 );
 CREATE TABLE b3 (
-  id STRING PRIMARY KEY
- ,delete_set_default STRING DEFAULT 'b3-default' REFERENCES a ON DELETE SET DEFAULT
+  id STRING PRIMARY KEY,
+  delete_set_default STRING DEFAULT 'b3-default' REFERENCES a ON DELETE SET DEFAULT,
+  FAMILY (id, delete_set_default)
 );
 CREATE TABLE b4 (
-  id STRING PRIMARY KEY
- ,delete_set_default STRING DEFAULT 'b4-default' REFERENCES a ON DELETE SET DEFAULT
+  id STRING PRIMARY KEY,
+  delete_set_default STRING DEFAULT 'b4-default' REFERENCES a ON DELETE SET DEFAULT,
+  FAMILY (id, delete_set_default)
 );
 
 statement ok
@@ -426,10 +518,19 @@ INSERT INTO b4 VALUES ('b4-pk1', 'delete_me'), ('b4-pk2', 'delete_me');
 statement ok
 SET tracing = on,kv,results; DELETE FROM a WHERE id = 'delete_me'; SET tracing = off
 
-query I
-SELECT count(*) FROM [SHOW KV TRACE FOR SESSION] WHERE message LIKE 'cascading %';
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION]
+WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
 ----
-4
+Del /Table/87/1/"delete_me"/0
+executing cascade for constraint fk_delete_set_default_ref_a
+executing cascade for constraint fk_delete_set_default_ref_a
+Del /Table/89/2/"delete_me"/"b2-pk2"/0
+executing cascade for constraint fk_delete_set_default_ref_a
+Del /Table/90/2/"delete_me"/"b3-pk1"/0
+executing cascade for constraint fk_delete_set_default_ref_a
+Del /Table/91/2/"delete_me"/"b4-pk1"/0
+Del /Table/91/2/"delete_me"/"b4-pk2"/0
 
 # Clean up after the test.
 statement ok
@@ -448,24 +549,29 @@ CREATE TABLE a (
   id STRING PRIMARY KEY
 );
 CREATE TABLE b1 (
-  id STRING PRIMARY KEY
- ,delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE
+  id STRING PRIMARY KEY,
+  delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE,
+  FAMILY (id, delete_cascade)
 );
 CREATE TABLE b2 (
-  id STRING PRIMARY KEY
- ,delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE
+  id STRING PRIMARY KEY,
+  delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE,
+  FAMILY (id, delete_cascade)
 );
 CREATE TABLE c1 (
-  id STRING PRIMARY KEY
- ,delete_set_default STRING DEFAULT 'b1-default' REFERENCES b1 ON DELETE SET DEFAULT
+  id STRING PRIMARY KEY,
+  delete_set_default STRING DEFAULT 'b1-default' REFERENCES b1 ON DELETE SET DEFAULT,
+  FAMILY (id, delete_set_default)
 );
 CREATE TABLE c2 (
-  id STRING PRIMARY KEY
- ,delete_set_default STRING DEFAULT 'b1-default' REFERENCES b1 ON DELETE SET DEFAULT
+  id STRING PRIMARY KEY,
+  delete_set_default STRING DEFAULT 'b1-default' REFERENCES b1 ON DELETE SET DEFAULT,
+  FAMILY (id, delete_set_default)
 );
 CREATE TABLE c3 (
-  id STRING PRIMARY KEY
- ,delete_set_default STRING DEFAULT 'b2-default' REFERENCES b2 ON DELETE SET DEFAULT
+  id STRING PRIMARY KEY,
+  delete_set_default STRING DEFAULT 'b2-default' REFERENCES b2 ON DELETE SET DEFAULT,
+  FAMILY (id, delete_set_default)
 );
 
 statement ok
@@ -494,10 +600,36 @@ INSERT INTO c3 VALUES
 statement ok
 SET tracing = on,kv,results; DELETE FROM a WHERE id = 'a-pk1'; SET tracing = off
 
-query I
-SELECT count(*) FROM [SHOW KV TRACE FOR SESSION] WHERE message LIKE 'cascading %';
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION]
+WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
 ----
-5
+Del /Table/92/1/"a-pk1"/0
+executing cascade for constraint fk_delete_cascade_ref_a
+Del /Table/93/2/"a-pk1"/"b1-pk1"/0
+Del /Table/93/1/"b1-pk1"/0
+Del /Table/93/2/"a-pk1"/"b1-pk2"/0
+Del /Table/93/1/"b1-pk2"/0
+executing cascade for constraint fk_delete_cascade_ref_a
+Del /Table/94/2/"a-pk1"/"b2-pk1"/0
+Del /Table/94/1/"b2-pk1"/0
+Del /Table/94/2/"a-pk1"/"b2-pk2"/0
+Del /Table/94/1/"b2-pk2"/0
+executing cascade for constraint fk_delete_set_default_ref_b1
+Del /Table/95/2/"b1-pk1"/"c1-pk1-b1-pk1"/0
+Del /Table/95/2/"b1-pk1"/"c1-pk2-b1-pk1"/0
+Del /Table/95/2/"b1-pk2"/"c1-pk3-b1-pk2"/0
+Del /Table/95/2/"b1-pk2"/"c1-pk4-b1-pk2"/0
+executing cascade for constraint fk_delete_set_default_ref_b1
+Del /Table/96/2/"b1-pk1"/"c2-pk1-b1-pk1"/0
+Del /Table/96/2/"b1-pk1"/"c2-pk2-b1-pk1"/0
+Del /Table/96/2/"b1-pk2"/"c2-pk3-b1-pk2"/0
+Del /Table/96/2/"b1-pk2"/"c2-pk4-b1-pk2"/0
+executing cascade for constraint fk_delete_set_default_ref_b2
+Del /Table/97/2/"b2-pk1"/"c3-pk1-b2-pk1"/0
+Del /Table/97/2/"b2-pk1"/"c3-pk2-b2-pk1"/0
+Del /Table/97/2/"b2-pk2"/"c3-pk3-b2-pk2"/0
+Del /Table/97/2/"b2-pk2"/"c3-pk4-b2-pk2"/0
 
 # Clean up after the test.
 statement ok


### PR DESCRIPTION
#### opt: add cascade_opt execbuilder test

Copy the `cascade` test file. In a subsequent commit, `cascade` will test the
legacy path and `cascade_opt` will test the opt-driven path (similar to the
logictests).

Release note: None

#### opt: rework cascade execbuilder tests

Reworking the cascade_opt tracing tests to work with the new path.

Release note: None