### PR TITLE
sql/pgwire: test that TypeModifier is set for prepared statements 

### DIFF
--- a/pkg/sql/pgwire/testdata/pgtest/row_description
+++ b/pkg/sql/pgwire/testdata/pgtest/row_description
@@ -119,3 +119,22 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"text":"hello"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# 80 = ASCII 'P' for Portal
+send
+Parse {"Name": "s", "Query": "SELECT b FROM tab3"}
+Bind {"DestinationPortal": "p", "PreparedStatement": "s"}
+Describe {"ObjectType": 80, "Name": "p"}
+Execute {"Portal": "p"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"RowDescription","Fields":[{"Name":"b","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":1042,"DataTypeSize":-1,"TypeModifier":12,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"hello"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/testutils/pgtest/datadriven.go
+++ b/pkg/testutils/pgtest/datadriven.go
@@ -175,6 +175,8 @@ func toMessage(typ string) interface{} {
 		return &pgproto3.CommandComplete{}
 	case "DataRow":
 		return &pgproto3.DataRow{}
+	case "Describe":
+		return &pgproto3.Describe{}
 	case "ErrorResponse":
 		return &pgproto3.ErrorResponse{}
 	case "Execute":


### PR DESCRIPTION
Previously, the TypeModifier would always be -1 for prepared statements.
As of a recent change, it is populated correctly when available.

This test verifies the new behavior and also adds support for testing
the Describe message of the extended protocol in the pgtest package.

touches #49215 but there is still more work for that issue.

Release note: none