### PR TITLE
sql: deal with retriable errors in `DROP INDEX`

### DIFF
--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -86,12 +86,15 @@ func (n *dropIndexNode) startExec(params runParams) error {
 		// drop need to be visible to the second drop.
 		tableDesc, err := params.p.ResolveMutableTableDescriptor(
 			ctx, index.tn, true /*required*/, ResolveRequireTableDesc)
-		if err != nil {
+		if sqlbase.IsUndefinedRelationError(err) {
 			// Somehow the descriptor we had during planning is not there
 			// any more.
 			return errors.NewAssertionErrorWithWrappedErrf(err,
 				"table descriptor for %q became unavailable within same txn",
 				tree.ErrString(index.tn))
+		}
+		if err != nil {
+			return err
 		}
 
 		// If we couldn't find the index by name, this is either a legitimate error or

--- a/pkg/sql/helpers_test.go
+++ b/pkg/sql/helpers_test.go
@@ -25,6 +25,9 @@ type tableVersionID struct {
 	version sqlbase.DescriptorVersion
 }
 
+// SQLTxnName is the transaction name used by sql transactions.
+const SQLTxnName = sqlTxnName
+
 // LeaseRemovalTracker can be used to wait for leases to be removed from the
 // store (leases are removed from the store async w.r.t. LeaseManager
 // operations).

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -29,7 +29,7 @@ ReadyForQuery
 ----
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
-{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":496,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":499,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 


### PR DESCRIPTION
Prior to this commit we would assume any error while retrieving a descriptor
during the execution of `DROP INDEX` was an assertion failure. This was
overly paranoid. Plenty of retriable errors are possible (and furthermore
so are errors due to shutdown). The only error we should freak out about
is if we discover the relation is not defined.

Fixes #48474.

Release note (bug fix): Fix bug where contended `DROP INDEX` queries return
an assertion failure error rather than a retriable error.