### PR TITLE
colmem: reset flat bytes vector when reused

### DIFF
--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -1701,11 +1701,6 @@ func planProjectionOperators(
 		}
 
 		allocator := colmem.NewAllocator(ctx, acc)
-		// We don't know the schema yet and will update it below, right before
-		// instantiating caseOp.
-		schemaEnforcer := newBatchSchemaPrefixEnforcer(allocator, input, nil /* typs */)
-		buffer := NewBufferOp(schemaEnforcer)
-		caseOps := make([]colexecbase.Operator, len(t.Whens))
 		caseOutputType := t.ResolvedType()
 		if typeconv.TypeFamilyToCanonicalTypeFamily(caseOutputType.Family()) == types.BytesFamily {
 			// Currently, there is a contradiction between the way CASE operator
@@ -1720,6 +1715,13 @@ func planProjectionOperators(
 				"unsupported type %s", caseOutputType)
 		}
 		caseOutputIdx := len(columnTypes)
+		// We don't know the schema yet and will update it below, right before
+		// instantiating caseOp. The same goes for subsetEndIdx.
+		schemaEnforcer := newBatchSchemaSubsetEnforcer(
+			allocator, input, nil /* typs */, caseOutputIdx, -1, /* subsetEndIdx */
+		)
+		buffer := NewBufferOp(schemaEnforcer)
+		caseOps := make([]colexecbase.Operator, len(t.Whens))
 		typs = appendOneType(columnTypes, caseOutputType)
 		thenIdxs := make([]int, len(t.Whens)+1)
 		for i, when := range t.Whens {
@@ -1802,6 +1804,7 @@ func planProjectionOperators(
 		}
 
 		schemaEnforcer.typs = typs
+		schemaEnforcer.subsetEndIdx = len(typs)
 		op := NewCaseOp(allocator, buffer, caseOps, elseOp, thenIdxs, caseOutputIdx, caseOutputType)
 		internalMemUsed += op.(InternalMemoryOperator).InternalMemoryUsage()
 		return op, caseOutputIdx, typs, internalMemUsed, err
@@ -2038,7 +2041,7 @@ func planLogicalProjectionOp(
 		return nil, resultIdx, typs, internalMemUsed, err
 	}
 	allocator := colmem.NewAllocator(ctx, acc)
-	input = newBatchSchemaPrefixEnforcer(allocator, input, typs)
+	input = newBatchSchemaSubsetEnforcer(allocator, input, typs, resultIdx, len(typs))
 	switch expr.(type) {
 	case *tree.AndExpr:
 		outputOp = NewAndProjOp(

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -178,9 +178,15 @@ func (a *Allocator) MaybeAppendColumn(b coldata.Batch, t *types.T, colIdx int) {
 	}
 	width := b.Width()
 	if colIdx < width {
-		presentType := b.ColVec(colIdx).Type()
+		presentVec := b.ColVec(colIdx)
+		presentType := presentVec.Type()
 		if presentType.Identical(t) {
 			// We already have the vector of the desired type in place.
+			if presentVec.CanonicalTypeFamily() == types.BytesFamily {
+				// Flat bytes vector needs to be reset before the vector can be
+				// reused.
+				presentVec.Bytes().Reset()
+			}
 			return
 		}
 		if presentType.Family() == types.UnknownFamily {

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1222,3 +1222,70 @@ query T
 SELECT c0 FROM t47715 ORDER by c1
 ----
 1819487610
+
+# Regression for flat bytes vector not being reset when it is reused by a
+# projecting operator.
+query TTT
+WITH
+    with_194015 (col_1548014)
+        AS (
+            SELECT
+                *
+            FROM
+                (
+                    VALUES
+                        (('-28 years -2 mons -677 days -11:53:30.528699':::INTERVAL::INTERVAL + '11:55:41.419498':::TIME::TIME)::TIME + '1973-01-24':::DATE::DATE),
+                        ('1970-01-11 01:38:09.000155+00:00':::TIMESTAMP),
+                        ('1970-01-09 07:04:13.000247+00:00':::TIMESTAMP),
+                        ('1970-01-07 14:19:52.000951+00:00':::TIMESTAMP),
+                        (NULL)
+                )
+                    AS tab_240443 (col_1548014)
+        ),
+    with_194016 (col_1548015, col_1548016, col_1548017)
+        AS (
+            SELECT
+                *
+            FROM
+                (
+                    VALUES
+                        (
+                            '160.182.25.199/22':::INET::INET << 'c2af:30cb:5db8:bb79:4d11:2d0:1de8:bcea/59':::INET::INET,
+                            '09:14:05.761109':::TIME::TIME + '4 years 7 mons 345 days 23:43:13.325036':::INTERVAL::INTERVAL,
+                            B'0101010110101011101001111010100011001111001110001000101100011001101'
+                        ),
+                        (false, '14:36:41.282187':::TIME, B'011111111011001100000001101101011111110110010011110100110111100')
+                )
+                    AS tab_240444 (col_1548015, col_1548016, col_1548017)
+        ),
+    with_194017 (col_1548018)
+        AS (SELECT * FROM (VALUES ('43a30bc5-e412-426d-b99a-65783a7ed445':::UUID), (NULL), (crdb_internal.cluster_id()::UUID)) AS tab_240445 (col_1548018))
+SELECT
+    CASE
+    WHEN false THEN age('1970-01-09 08:48:24.000568+00:00':::TIMESTAMPTZ::TIMESTAMPTZ, '1970-01-07 08:40:45.000483+00:00':::TIMESTAMPTZ::TIMESTAMPTZ)::INTERVAL
+    ELSE (
+        (
+            (-0.02805450661234963150):::DECIMAL::DECIMAL
+            * array_position(
+                    (gen_random_uuid()::UUID::UUID || (NULL::UUID || NULL::UUID[])::UUID[])::UUID[],
+                    '5f29920d-7db1-4efc-b1cc-d1a7d0bcf145':::UUID::UUID
+                )::INT8::INT8
+        )::DECIMAL
+        * age('1970-01-04 07:17:45.000268+00:00':::TIMESTAMPTZ::TIMESTAMPTZ, NULL::TIMESTAMPTZ)::INTERVAL::INTERVAL
+    )
+    END::INTERVAL
+    + '-21 years -10 mons -289 days -13:27:05.205069':::INTERVAL::INTERVAL
+        AS col_1548019,
+    '1984-01-07':::DATE AS col_1548020,
+    'f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2':::UUID AS col_1548022
+FROM
+    with_194015
+ORDER BY
+    with_194015.col_1548014 DESC
+LIMIT
+    4:::INT8;
+----
+NULL  1984-01-07 00:00:00 +0000 +0000  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
+NULL  1984-01-07 00:00:00 +0000 +0000  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
+NULL  1984-01-07 00:00:00 +0000 +0000  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
+NULL  1984-01-07 00:00:00 +0000 +0000  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2


### PR DESCRIPTION
Our `MaybeAppendColumn` reuses the same vector if a vector of the
desired type is already in the requested position. However, the flat
bytes vector needs special treatment when reused - it needs to be reset
and previously we forgot to do so. This is now fixed.

The addition of vector resetting behavior required a change of
`batchSchemaPrefixEnforcer` (it is actually more like a fix) to make it
enforce that only a range (a "subset") of vectors that the projecting
operator (and its internal projecting operator chains) own. For example,
consider a scenario when we have a hash joiner that outputs two columns
which feeds into a case operator that has an output column and its
internal projecting chains use two other columns. Previously, the batch
schema prefix enforcer would be "maybe appending" all five columns
although it should only care about the columns at indices 2, 3, 4 (the
ones that case operator owns) and not pay attention to columns 0 and
1 because those are owned by the hash joiner. Now, the schema enforcer
is renamed to `batchSchemaSubsetEnforcer` and it correctly operates only
on the requested subset of columns. Without this change we would need to
modify `Allocator.MaybeAppendColumn` signature to include a boolean to
tell whether it is ok to reset the reused vector - if we didn't do it,
the batch schema enforcer would incorrectly reset the columns populated
by the hash joiner which would lead to incorrect results.

Release note (bug fix): Previously, in some cases an internal error
could occur when queries that have columns of BYTES type in the output
were executed via the vectorized engine, and this has been fixed.