### PR TITLE
release-20.1: rowexec: fix bug where windower was not using fingerprint

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -3806,3 +3806,22 @@ SELECT a, b, rank() OVER w, dense_rank() OVER w, percent_rank() OVER w, cume_dis
 0  2  2  2  1  1
 1  1  1  1  0  0.5
 1  2  2  2  1  1
+
+# Regression test for windower not using EncDatum.Fingerprint.
+statement ok
+SELECT
+	array_agg(t_pk.table_name ORDER BY t_pk.table_name)
+FROM
+	information_schema.statistics AS i
+	LEFT JOIN (
+			SELECT
+				array_agg(c.column_name) AS table_primary_key_columns,
+				c.table_name
+			FROM
+				information_schema.columns AS c
+			GROUP BY
+				c.table_name
+		)
+			AS t_pk ON i.table_name = t_pk.table_name
+GROUP BY
+	t_pk.table_primary_key_columns

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
-	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
@@ -677,7 +676,7 @@ func (w *windower) computeWindowFunctions(ctx context.Context, evalCtx *tree.Eva
 						"hash column %d, row with only %d columns", errors.Safe(col), errors.Safe(len(row)))
 				}
 				var err error
-				w.scratch, err = row[int(col)].Encode(&w.inputTypes[int(col)], &w.datumAlloc, flowinfra.PreferredEncoding, w.scratch)
+				w.scratch, err = row[int(col)].Fingerprint(&w.inputTypes[int(col)], &w.datumAlloc, w.scratch)
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/sqlbase/encoded_datum.go
+++ b/pkg/sql/sqlbase/encoded_datum.go
@@ -279,15 +279,21 @@ func (ed *EncDatum) Encode(
 // fingerprints of a set of datums are appended together, the resulting
 // fingerprint will uniquely identify the set.
 func (ed *EncDatum) Fingerprint(typ *types.T, a *DatumAlloc, appendTo []byte) ([]byte, error) {
-	if err := ed.EnsureDecoded(typ, a); err != nil {
-		return nil, err
-	}
+	// Note: we don't ed.EnsureDecoded on top of this method, because the default
+	// case uses ed.Encode, which has a fast path if the encoded bytes are already
+	// the right encoding.
 	switch typ.Family() {
 	case types.JsonFamily:
+		if err := ed.EnsureDecoded(typ, a); err != nil {
+			return nil, err
+		}
 		// We must use value encodings without a column ID even if the EncDatum already
 		// is encoded with the value encoding so that the hashes are indeed unique.
 		return EncodeTableValue(appendTo, ColumnID(encoding.NoColumnID), ed.Datum, a.scratch)
 	case types.ArrayFamily:
+		if err := ed.EnsureDecoded(typ, a); err != nil {
+			return nil, err
+		}
 		// Arrays may contain composite data, so we cannot just value
 		// encode an array (that would give same-valued composite
 		// datums a different encoding).


### PR DESCRIPTION
Backport 1/1 commits from #49234.

/cc @cockroachdb/release

---

Release note (bug fix): Fix a bug with use of arrays combined with
window functions causing a query failure.
