### PR TITLE
release-20.1: colexec: add memory accounting to hash aggregator

### DIFF
--- a/pkg/sql/colexec/aggregator.go
+++ b/pkg/sql/colexec/aggregator.go
@@ -238,21 +238,28 @@ func makeAggregateFuncs(
 		case execinfrapb.AggregatorSpec_ANY_NOT_NULL:
 			funcs[i], err = newAnyNotNullAgg(allocator, aggTyps[i][0])
 		case execinfrapb.AggregatorSpec_AVG:
-			funcs[i], err = newAvgAgg(aggTyps[i][0])
+			funcs[i], err = newAvgAgg(allocator, aggTyps[i][0])
 		case execinfrapb.AggregatorSpec_SUM, execinfrapb.AggregatorSpec_SUM_INT:
-			funcs[i], err = newSumAgg(aggTyps[i][0])
+			funcs[i], err = newSumAgg(allocator, aggTyps[i][0])
 		case execinfrapb.AggregatorSpec_COUNT_ROWS:
-			funcs[i] = newCountRowAgg()
+			funcs[i] = newCountRowAgg(allocator)
 		case execinfrapb.AggregatorSpec_COUNT:
-			funcs[i] = newCountAgg()
+			funcs[i] = newCountAgg(allocator)
 		case execinfrapb.AggregatorSpec_MIN:
 			funcs[i], err = newMinAgg(allocator, aggTyps[i][0])
 		case execinfrapb.AggregatorSpec_MAX:
 			funcs[i], err = newMaxAgg(allocator, aggTyps[i][0])
 		case execinfrapb.AggregatorSpec_BOOL_AND:
-			funcs[i] = newBoolAndAgg()
+			funcs[i] = newBoolAndAgg(allocator)
 		case execinfrapb.AggregatorSpec_BOOL_OR:
-			funcs[i] = newBoolOrAgg()
+			funcs[i] = newBoolOrAgg(allocator)
+		// NOTE: if you're adding an implementation of a new aggregate
+		// function, make sure to account for the memory under that struct in
+		// its constructor.
+		// TODO(yuzefovich): at the moment, we're updating the allocator on
+		// every created aggregate function. This hits the performance of the
+		// hash aggregator when group sizes are small. We should "batch" the
+		// accounting to address it.
 		default:
 			return nil, errors.Errorf("unsupported columnar aggregate function %s", aggFns[i].String())
 		}
@@ -473,7 +480,7 @@ func extractAggTypes(aggCols [][]uint32, colTypes []coltypes.T) [][]coltypes.T {
 // columns of types 'inputTypes' (which can be empty in case of COUNT_ROWS) is
 // supported.
 func isAggregateSupported(
-	aggFn execinfrapb.AggregatorSpec_Func, inputTypes []types.T,
+	allocator *Allocator, aggFn execinfrapb.AggregatorSpec_Func, inputTypes []types.T,
 ) (bool, error) {
 	aggTypes, err := typeconv.FromColumnTypes(inputTypes)
 	if err != nil {
@@ -495,7 +502,7 @@ func isAggregateSupported(
 		}
 	}
 	_, err = makeAggregateFuncs(
-		nil, /* allocator */
+		allocator,
 		[][]coltypes.T{aggTypes},
 		[]execinfrapb.AggregatorSpec_Func{aggFn},
 	)

--- a/pkg/sql/colexec/allocator.go
+++ b/pkg/sql/colexec/allocator.go
@@ -215,8 +215,18 @@ func (a *Allocator) PerformOperation(destVecs []coldata.Vec, operation func()) {
 	operation()
 	after := getVecsMemoryFootprint(destVecs)
 
-	delta := after - before
-	if delta >= 0 {
+	a.AdjustMemoryUsage(after - before)
+}
+
+// Used returns the number of bytes currently allocated through this allocator.
+func (a *Allocator) Used() int64 {
+	return a.acc.Used()
+}
+
+// AdjustMemoryUsage adjusts the number of bytes currently allocated through
+// this allocator by delta bytes (which can be both positive or negative).
+func (a *Allocator) AdjustMemoryUsage(delta int64) {
+	if delta > 0 {
 		if err := a.acc.Grow(a.ctx, delta); err != nil {
 			execerror.VectorizedInternalPanic(err)
 		}
@@ -225,14 +235,12 @@ func (a *Allocator) PerformOperation(destVecs []coldata.Vec, operation func()) {
 	}
 }
 
-// Used returns the number of bytes currently allocated through this allocator.
-func (a *Allocator) Used() int64 {
-	return a.acc.Used()
-}
-
 // ReleaseMemory reduces the number of bytes currently allocated through this
-// allocator by (at most) size bytes.
+// allocator by (at most) size bytes. size must be non-negative.
 func (a *Allocator) ReleaseMemory(size int64) {
+	if size < 0 {
+		execerror.VectorizedInternalPanic(fmt.Sprintf("unexpectedly negative size in ReleaseMemory: %d", size))
+	}
 	if size > a.acc.Used() {
 		size = a.acc.Used()
 	}

--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -21,6 +21,7 @@ package colexec
 
 import (
 	"time"
+	"unsafe"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -36,6 +37,7 @@ func newAnyNotNullAgg(allocator *Allocator, t coltypes.T) (aggregateFunc, error)
 	switch t {
 	// {{range .}}
 	case _TYPES_T:
+		allocator.AdjustMemoryUsage(int64(sizeOfAnyNotNull_TYPEAgg))
 		return &anyNotNull_TYPEAgg{allocator: allocator}, nil
 		// {{end}}
 	default:
@@ -82,6 +84,10 @@ type anyNotNull_TYPEAgg struct {
 	curAgg                      _GOTYPE
 	foundNonNullForCurrentGroup bool
 }
+
+var _ aggregateFunc = &anyNotNull_TYPEAgg{}
+
+const sizeOfAnyNotNull_TYPEAgg = unsafe.Sizeof(anyNotNull_TYPEAgg{})
 
 func (a *anyNotNull_TYPEAgg) Init(groups []bool, vec coldata.Vec) {
 	a.groups = groups

--- a/pkg/sql/colexec/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/avg_agg_tmpl.go
@@ -20,6 +20,8 @@
 package colexec
 
 import (
+	"unsafe"
+
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
@@ -52,10 +54,11 @@ func _ASSIGN_ADD(_, _, _ string) {
 
 // */}}
 
-func newAvgAgg(t coltypes.T) (aggregateFunc, error) {
+func newAvgAgg(allocator *Allocator, t coltypes.T) (aggregateFunc, error) {
 	switch t {
 	// {{range .}}
 	case _TYPES_T:
+		allocator.AdjustMemoryUsage(int64(sizeOfAvg_TYPEAgg))
 		return &avg_TYPEAgg{}, nil
 	// {{end}}
 	default:
@@ -89,6 +92,8 @@ type avg_TYPEAgg struct {
 }
 
 var _ aggregateFunc = &avg_TYPEAgg{}
+
+const sizeOfAvg_TYPEAgg = unsafe.Sizeof(avg_TYPEAgg{})
 
 func (a *avg_TYPEAgg) Init(groups []bool, v coldata.Vec) {
 	a.groups = groups

--- a/pkg/sql/colexec/bool_and_or_agg_tmpl.go
+++ b/pkg/sql/colexec/bool_and_or_agg_tmpl.go
@@ -20,6 +20,8 @@
 package colexec
 
 import (
+	"unsafe"
+
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	// {{/*
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execerror"
@@ -43,7 +45,8 @@ func _ASSIGN_BOOL_OP(_, _, _ string) {
 
 // {{range .}}
 
-func newBool_OP_TYPEAgg() aggregateFunc {
+func newBool_OP_TYPEAgg(allocator *Allocator) aggregateFunc {
+	allocator.AdjustMemoryUsage(int64(sizeOfBool_OP_TYPEAgg))
 	return &bool_OP_TYPEAgg{}
 }
 
@@ -58,6 +61,10 @@ type bool_OP_TYPEAgg struct {
 	curIdx int
 	curAgg bool
 }
+
+var _ aggregateFunc = &bool_OP_TYPEAgg{}
+
+const sizeOfBool_OP_TYPEAgg = unsafe.Sizeof(bool_OP_TYPEAgg{})
 
 func (b *bool_OP_TYPEAgg) Init(groups []bool, vec coldata.Vec) {
 	b.groups = groups

--- a/pkg/sql/colexec/count_agg_tmpl.go
+++ b/pkg/sql/colexec/count_agg_tmpl.go
@@ -19,17 +19,23 @@
 
 package colexec
 
-import "github.com/cockroachdb/cockroach/pkg/col/coldata"
+import (
+	"unsafe"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+)
 
 // newCountRowAgg creates a COUNT(*) aggregate, which counts every row in the
 // result unconditionally.
-func newCountRowAgg() *countAgg {
+func newCountRowAgg(allocator *Allocator) *countAgg {
+	allocator.AdjustMemoryUsage(int64(sizeOfCountAgg))
 	return &countAgg{countRow: true}
 }
 
 // newCountAgg creates a COUNT(col) aggregate, which counts every row in the
 // result where the value of col is not null.
-func newCountAgg() *countAgg {
+func newCountAgg(allocator *Allocator) *countAgg {
+	allocator.AdjustMemoryUsage(int64(sizeOfCountAgg))
 	return &countAgg{countRow: false}
 }
 
@@ -44,6 +50,10 @@ type countAgg struct {
 	done     bool
 	countRow bool
 }
+
+var _ aggregateFunc = &countAgg{}
+
+const sizeOfCountAgg = unsafe.Sizeof(countAgg{})
 
 func (a *countAgg) Init(groups []bool, vec coldata.Vec) {
 	a.groups = groups

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"math"
 	"time"
+	"unsafe"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -80,10 +81,11 @@ func new_AGG_TITLEAgg(allocator *Allocator, t coltypes.T) (aggregateFunc, error)
 	switch t {
 	// {{range .Overloads}}
 	case _TYPES_T:
+		allocator.AdjustMemoryUsage(int64(sizeOf_AGG_TYPEAgg))
 		return &_AGG_TYPEAgg{allocator: allocator}, nil
 	// {{end}}
 	default:
-		return nil, errors.Errorf("unsupported min agg type %s", t)
+		return nil, errors.Errorf("unsupported min/max agg type %s", t)
 	}
 }
 
@@ -110,6 +112,8 @@ type _AGG_TYPEAgg struct {
 }
 
 var _ aggregateFunc = &_AGG_TYPEAgg{}
+
+const sizeOf_AGG_TYPEAgg = unsafe.Sizeof(_AGG_TYPEAgg{})
 
 func (a *_AGG_TYPEAgg) Init(groups []bool, v coldata.Vec) {
 	a.groups = groups

--- a/pkg/sql/colexec/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/sum_agg_tmpl.go
@@ -20,6 +20,8 @@
 package colexec
 
 import (
+	"unsafe"
+
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coltypes"
@@ -49,10 +51,11 @@ func _ASSIGN_ADD(_, _, _ string) {
 
 // */}}
 
-func newSumAgg(t coltypes.T) (aggregateFunc, error) {
+func newSumAgg(allocator *Allocator, t coltypes.T) (aggregateFunc, error) {
 	switch t {
 	// {{range .}}
 	case _TYPES_T:
+		allocator.AdjustMemoryUsage(int64(sizeOfSum_TYPEAgg))
 		return &sum_TYPEAgg{}, nil
 	// {{end}}
 	default:
@@ -82,6 +85,8 @@ type sum_TYPEAgg struct {
 }
 
 var _ aggregateFunc = &sum_TYPEAgg{}
+
+const sizeOfSum_TYPEAgg = unsafe.Sizeof(sum_TYPEAgg{})
 
 func (a *sum_TYPEAgg) Init(groups []bool, v coldata.Vec) {
 	a.groups = groups


### PR DESCRIPTION
Backport 1/4 commits from #48511.

/cc @cockroachdb/release

---

**colexec: account for aggregate functions structs**

Previously, we were not accounting for the memory used by aggregate
functions structs. This behavior is acceptable in case of ordered
aggregator (because we will only constant number of such structs), but
it's no bueno for the hash aggregator - we will be creating a separate
struct for each group. This is now fixed by performing the memory
accounting upon creation of these aggregate functions structs.

This commit also adds accounting for `hashAggFuncs` structs in the hash
aggregator.

However, this commit does not address the missing memory accounting of
the Golang's `map` that we use for mapping a hash code to all aggregate
builtins (i.e. "groups") that correspond to that hash code. This is left
as TODO, but we need to address it for 20.2. A note here is that we
might be replacing the usage of this `map` with our vectorized hash
table, so it'll probably make sense to wait for that.

Addresses: #48428.

Release note: None