### PR TITLE
sql: fixes typos in datum.go and render.go

### DIFF
--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -44,13 +44,6 @@ type renderNode struct {
 	ivarHelper tree.IndexedVarHelper
 
 	// Rendering expressions for rows and corresponding output columns.
-	// populated by addOrReuseRenders()
-	// as invoked initially by initTargets() and initWhere().
-	// sortNode peeks into the render array defined by initTargets() as an optimization.
-	// sortNode adds extra renderNode renders for sort columns not requested as select targets.
-	// groupNode copies/extends the render array defined by initTargets() and
-	// will add extra renderNode renders for the aggregation sources.
-	// windowNode also adds additional renders for the window functions.
 	render []tree.TypedExpr
 
 	// columns is the set of result columns.

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -197,7 +197,7 @@ func (d Datums) Compare(evalCtx *EvalContext, other Datums) int {
 
 // IsDistinctFrom checks to see if two datums are distinct from each other. Any
 // change in value is considered distinct, however, a NULL value is NOT
-// considered disctinct from another NULL value.
+// considered distinct from another NULL value.
 func (d Datums) IsDistinctFrom(evalCtx *EvalContext, other Datums) bool {
 	if len(d) != len(other) {
 		return true


### PR DESCRIPTION
Fixes a typo in a comment in `pkg/sql/sem/tree/datum.go`.

Removes erroneous comments in `pkg/sql/render.go`.

Release note: None