### PR TITLE
sqlbase: remove duplicate method for checking composite key encoding

### DIFF
--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -588,7 +588,7 @@ func (prj *ProjectExpr) initUnexportedFields(mem *Memo) {
 			composite := false
 			for i, ok := from.Next(0); ok; i, ok = from.Next(i + 1) {
 				typ := mem.Metadata().ColumnMeta(i).Type
-				if sqlbase.DatumTypeHasCompositeKeyEncoding(typ) {
+				if sqlbase.HasCompositeKeyEncoding(typ) {
 					composite = true
 					break
 				}

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -1052,7 +1052,7 @@ func encodeDatum(b []byte, val tree.Datum) []byte {
 	// work, because the encoding does not uniquely represent some values which
 	// should not be considered equivalent by the interner (e.g. decimal values
 	// 1.0 and 1.00).
-	if !sqlbase.DatumTypeHasCompositeKeyEncoding(val.ResolvedType()) {
+	if !sqlbase.HasCompositeKeyEncoding(val.ResolvedType()) {
 		var err error
 		b, err = sqlbase.EncodeTableKey(b, val, encoding.Ascending)
 		if err == nil {

--- a/pkg/sql/opt/norm/inline_funcs.go
+++ b/pkg/sql/opt/norm/inline_funcs.go
@@ -324,7 +324,7 @@ func (c *CustomFuncs) CanInlineConstVar(f memo.FiltersExpr) bool {
 	for i := range f {
 		if ok, l, _ := c.extractVarEqualsConst(f[i].Condition); ok {
 			colType := c.mem.Metadata().ColumnMeta(l.Col).Type
-			if sqlbase.DatumTypeHasCompositeKeyEncoding(colType) {
+			if sqlbase.HasCompositeKeyEncoding(colType) {
 				// TODO(justin): allow inlining if the check we're doing is oblivious
 				// to composite-ness.
 				continue
@@ -360,7 +360,7 @@ func (c *CustomFuncs) InlineConstVar(f memo.FiltersExpr) memo.FiltersExpr {
 	for i := range f {
 		if ok, v, e := c.extractVarEqualsConst(f[i].Condition); ok {
 			colType := c.mem.Metadata().ColumnMeta(v.Col).Type
-			if sqlbase.DatumTypeHasCompositeKeyEncoding(colType) {
+			if sqlbase.HasCompositeKeyEncoding(colType) {
 				continue
 			}
 			if _, ok := vals[v.Col]; !ok {

--- a/pkg/sql/opt/norm/join_funcs.go
+++ b/pkg/sql/opt/norm/join_funcs.go
@@ -411,7 +411,7 @@ func (c *CustomFuncs) GetEquivColsWithEquivType(
 
 	// Don't bother looking for equivalent columns if colType has a composite
 	// key encoding.
-	if sqlbase.DatumTypeHasCompositeKeyEncoding(colType) {
+	if sqlbase.HasCompositeKeyEncoding(colType) {
 		res.Add(col)
 		return res
 	}

--- a/pkg/sql/opt/norm/select_funcs.go
+++ b/pkg/sql/opt/norm/select_funcs.go
@@ -24,7 +24,7 @@ func (c *CustomFuncs) CanMapOnSetOp(src *memo.FiltersItem) bool {
 	filterProps := src.ScalarProps()
 	for i, ok := filterProps.OuterCols.Next(0); ok; i, ok = filterProps.OuterCols.Next(i + 1) {
 		colType := c.f.Metadata().ColumnMeta(i).Type
-		if sqlbase.DatumTypeHasCompositeKeyEncoding(colType) {
+		if sqlbase.HasCompositeKeyEncoding(colType) {
 			return false
 		}
 	}

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -477,7 +477,7 @@ func (jb *usingJoinBuilder) addEqualityCondition(leftCol, rightCol *scopeColumn)
 		jb.showCols[leftCol] = struct{}{}
 		jb.hideCols[rightCol] = struct{}{}
 	} else if jb.joinType == sqlbase.RightOuterJoin &&
-		!sqlbase.DatumTypeHasCompositeKeyEncoding(leftCol.typ) {
+		!sqlbase.HasCompositeKeyEncoding(leftCol.typ) {
 		// The merged column is the same as the corresponding column from the
 		// right side.
 		jb.outScope.cols = append(jb.outScope.cols, *rightCol)

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -527,7 +527,7 @@ func (c *CustomFuncs) findConstantFilterCols(
 			// different forms of the same value.
 			colID := cons.Columns.Get(0).ID()
 			colTyp := tab.Column(tabID.ColumnOrdinal(colID)).DatumType()
-			if sqlbase.DatumTypeHasCompositeKeyEncoding(colTyp) {
+			if sqlbase.HasCompositeKeyEncoding(colTyp) {
 				continue
 			}
 

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1290,22 +1290,16 @@ func (desc *MutableTableDescriptor) ensurePrimaryKey() error {
 // key, so that different strings that collate equal cannot both be used as
 // keys. The value part is the usual UTF-8 encoding of the string, stored so
 // that it can be recovered later for inspection/display.
-func HasCompositeKeyEncoding(semanticType *types.T) bool {
-	switch semanticType.Family() {
+func HasCompositeKeyEncoding(typ *types.T) bool {
+	switch typ.Family() {
 	case types.CollatedStringFamily,
 		types.FloatFamily,
 		types.DecimalFamily:
 		return true
 	case types.ArrayFamily:
-		return HasCompositeKeyEncoding(semanticType.ArrayContents())
+		return HasCompositeKeyEncoding(typ.ArrayContents())
 	}
 	return false
-}
-
-// DatumTypeHasCompositeKeyEncoding is a version of HasCompositeKeyEncoding
-// which works on datum types.
-func DatumTypeHasCompositeKeyEncoding(typ *types.T) bool {
-	return HasCompositeKeyEncoding(typ)
 }
 
 // MustBeValueEncoded returns true if columns of the given kind can only be value


### PR DESCRIPTION
`DatumTypeHasCompositeKeyEncoding` simply calls
`HasCompositeKeyEncoding` and is now removed.

Release note: None