### PR TITLE
opt: synthesize check constraints on enum columns

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/enums
+++ b/pkg/sql/opt/exec/execbuilder/testdata/enums
@@ -31,20 +31,20 @@ query T
 EXPLAIN (OPT) SELECT * FROM t WHERE x > 'hello'
 ----
 scan t
- └── constraint: /1: [/'howdy' - ]
+ └── constraint: /1: [/'howdy' - /'hi']
 
 # Test that we can perform constrained scans using secondary indexes too.
 query T
 EXPLAIN (OPT) SELECT * FROM t WHERE y = 'hello'
 ----
 scan t@i
- └── constraint: /2/1: [/'hello' - /'hello']
+ └── constraint: /2/1: [/'hello'/'hello' - /'hello'/'hi']
 
 query T
 EXPLAIN (OPT) SELECT * FROM t WHERE y > 'hello' AND y < 'hi'
 ----
 scan t@i
- └── constraint: /2/1: [/'howdy' - /'howdy']
+ └── constraint: /2/1: [/'howdy'/'hello' - /'howdy'/'hi']
 
 query T
 EXPLAIN (opt) SELECT * FROM t WHERE x IN ('hello', 'hi')
@@ -53,3 +53,16 @@ scan t
  └── constraint: /1
       ├── [/'hello' - /'hello']
       └── [/'hi' - /'hi']
+
+statement ok
+CREATE TABLE checks (x greeting NOT NULL, y int, INDEX (x, y))
+
+# Check that inferred check constraints from enum columns are used in plans.
+query T
+EXPLAIN (OPT) SELECT x, y FROM checks WHERE y = 2
+----
+scan checks@checks_x_y_idx
+ └── constraint: /1/2/3
+      ├── [/'hello'/2 - /'hello'/2]
+      ├── [/'howdy'/2 - /'howdy'/2]
+      └── [/'hi'/2 - /'hi'/2]

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3837,6 +3837,21 @@ func MakeDEnumFromLogicalRepresentation(typ *types.T, rep string) (*DEnum, error
 	}, nil
 }
 
+// MakeAllDEnumsInType generates a slice of all values in an enum.
+// TODO (rohany): In the future, take an option of whether to include
+//  non-writeable enum values or not.
+func MakeAllDEnumsInType(typ *types.T) []Datum {
+	result := make([]Datum, len(typ.TypeMeta.EnumData.LogicalRepresentations))
+	for i := 0; i < len(result); i++ {
+		result[i] = &DEnum{
+			EnumTyp:     typ,
+			PhysicalRep: typ.TypeMeta.EnumData.PhysicalRepresentations[i],
+			LogicalRep:  typ.TypeMeta.EnumData.LogicalRepresentations[i],
+		}
+	}
+	return result
+}
+
 // Format implements the NodeFormatter interface.
 func (d *DEnum) Format(ctx *FmtCtx) {
 	if ctx.HasFlags(fmtStaticallyFormatUserDefinedTypes) {


### PR DESCRIPTION
Fixes #49263.

This PR teaches the optimizer how to synthesize check constraints on
columns of an ENUM type, allowing queries like:

```
CREATE TYPE t AS ENUM ('howdy', 'hello');
CREATE TABLE tt (x t, y INT, PRIMARY KEY (x, y));
SELECT x, y FROM tt WHERE y = 2
```

to be planned using constrained spans on the enum values, rather than a
full table scan.

Release note (performance improvement): Allow the optimizer to use enum
information to generate better query plans.