### PR TITLE
opt: throw error if ordered-set aggregate is malformed

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -2547,3 +2547,10 @@ query TT
 SHOW CREATE osagg_view
 ----
 osagg_view  CREATE VIEW osagg_view (disc, cont) AS SELECT percentile_disc(0.50) WITHIN GROUP (ORDER BY f), percentile_cont(0.50) WITHIN GROUP (ORDER BY f DESC) FROM test.public.osagg
+
+# Test malformed ordered-set aggregation.
+statement error ordered-set aggregations must have a WITHIN GROUP clause containing one ORDER BY column
+SELECT percentile_disc(0.50) FROM osagg
+
+statement error ordered-set aggregations must have a WITHIN GROUP clause containing one ORDER BY column
+SELECT percentile_cont(0.50) FROM osagg

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -1062,6 +1062,13 @@ func (s *scope) replaceAggregate(f *tree.FuncExpr, def *tree.FunctionDefinition)
 	fCopy := *f
 	// Override ordered-set aggregates to use their impl counterparts.
 	if orderedSetDef, found := isOrderedSetAggregate(def); found {
+		// Ensure that the aggregation is well formed.
+		if f.AggType != tree.OrderedSetAgg || len(f.OrderBy) != 1 {
+			panic(pgerror.Newf(
+				pgcode.InvalidFunctionDefinition,
+				"ordered-set aggregations must have a WITHIN GROUP clause containing one ORDER BY column"))
+		}
+
 		// Override function definition.
 		def = orderedSetDef
 		fCopy.Func.FunctionReference = orderedSetDef


### PR DESCRIPTION
Currently, if an ordered-set aggregate contains no WITHIN GROUP clause
or no single ORDER BY column, no error is thrown and thus we end up with
a panic when we try to access the missing ORDER BY column.
Instead, throw a syntax error to the user.

Resolves: #49240

Release note: None