### PR TITLE
sql: always create histograms for enum columns

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -328,7 +328,7 @@ func createStatsDefaultColumns(
 		if _, ok := requestedStats[key]; !ok && col.Type.Family() != types.JsonFamily {
 			colStats = append(colStats, jobspb.CreateStatsDetails_ColStat{
 				ColumnIDs:    colList,
-				HasHistogram: col.Type.Family() == types.BoolFamily,
+				HasHistogram: col.Type.Family() == types.BoolFamily || col.Type.Family() == types.EnumFamily,
 			})
 			nonIdxCols++
 		}

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
@@ -189,3 +189,19 @@ __auto__         {d}           550        0
 __auto__         {d}           0          0
 __auto__         {rowid}       550        0
 __auto__         {rowid}       0          0
+
+# Test that enum columns always have histograms collected for them.
+statement ok
+CREATE TYPE e AS ENUM ('hello', 'howdy', 'hi');
+CREATE TABLE et (x e, y e, PRIMARY KEY (x));
+INSERT INTO et VALUES ('hello', 'hello'), ('howdy', 'howdy'), ('hi', 'hi');
+CREATE STATISTICS s FROM et
+
+query TTII colnames,rowsort,retry
+SELECT statistics_name, column_names, row_count, null_count
+FROM [SHOW STATISTICS FOR TABLE et] WHERE histogram_id IS NOT NULL
+ORDER BY column_names::STRING, created
+----
+statistics_name  column_names  row_count  null_count
+__auto__         {x}           3          0
+__auto__         {y}           3          0


### PR DESCRIPTION
Fixes #49264.

Currently, we always collect histograms for boolean columns. That logic
is extended to collect histograms for ENUM columns as well.

Release note: None