### PR TITLE
pkg: plumb contexts down to typechecking methods

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -257,22 +257,22 @@ func backupJobDescription(
 
 // backupPlanHook implements PlanHookFn.
 func backupPlanHook(
-	_ context.Context, stmt tree.Statement, p sql.PlanHookState,
+	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
 ) (sql.PlanHookRowFn, sqlbase.ResultColumns, []sql.PlanNode, bool, error) {
 	backupStmt, ok := stmt.(*tree.Backup)
 	if !ok {
 		return nil, nil, nil, false, nil
 	}
 
-	toFn, err := p.TypeAsStringArray(tree.Exprs(backupStmt.To), "BACKUP")
+	toFn, err := p.TypeAsStringArray(ctx, tree.Exprs(backupStmt.To), "BACKUP")
 	if err != nil {
 		return nil, nil, nil, false, err
 	}
-	incrementalFromFn, err := p.TypeAsStringArray(backupStmt.IncrementalFrom, "BACKUP")
+	incrementalFromFn, err := p.TypeAsStringArray(ctx, backupStmt.IncrementalFrom, "BACKUP")
 	if err != nil {
 		return nil, nil, nil, false, err
 	}
-	optsFn, err := p.TypeAsStringOpts(backupStmt.Options, backupOptionExpectValues)
+	optsFn, err := p.TypeAsStringOpts(ctx, backupStmt.Options, backupOptionExpectValues)
 	if err != nil {
 		return nil, nil, nil, false, err
 	}
@@ -322,7 +322,7 @@ func backupPlanHook(
 		endTime := p.ExecCfg().Clock.Now()
 		if backupStmt.AsOf.Expr != nil {
 			var err error
-			if endTime, err = p.EvalAsOfTimestamp(backupStmt.AsOf); err != nil {
+			if endTime, err = p.EvalAsOfTimestamp(ctx, backupStmt.AsOf); err != nil {
 				return err
 			}
 		}

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -600,7 +600,7 @@ var RestoreHeader = sqlbase.ResultColumns{
 
 // restorePlanHook implements sql.PlanHookFn.
 func restorePlanHook(
-	_ context.Context, stmt tree.Statement, p sql.PlanHookState,
+	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
 ) (sql.PlanHookRowFn, sqlbase.ResultColumns, []sql.PlanNode, bool, error) {
 	restoreStmt, ok := stmt.(*tree.Restore)
 	if !ok {
@@ -609,14 +609,14 @@ func restorePlanHook(
 
 	fromFns := make([]func() ([]string, error), len(restoreStmt.From))
 	for i := range restoreStmt.From {
-		fromFn, err := p.TypeAsStringArray(tree.Exprs(restoreStmt.From[i]), "RESTORE")
+		fromFn, err := p.TypeAsStringArray(ctx, tree.Exprs(restoreStmt.From[i]), "RESTORE")
 		if err != nil {
 			return nil, nil, nil, false, err
 		}
 		fromFns[i] = fromFn
 	}
 
-	optsFn, err := p.TypeAsStringOpts(restoreStmt.Options, restoreOptionExpectValues)
+	optsFn, err := p.TypeAsStringOpts(ctx, restoreStmt.Options, restoreOptionExpectValues)
 	if err != nil {
 		return nil, nil, nil, false, err
 	}
@@ -650,7 +650,7 @@ func restorePlanHook(
 		var endTime hlc.Timestamp
 		if restoreStmt.AsOf.Expr != nil {
 			var err error
-			endTime, err = p.EvalAsOfTimestamp(restoreStmt.AsOf)
+			endTime, err = p.EvalAsOfTimestamp(ctx, restoreStmt.AsOf)
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -48,7 +48,7 @@ func showBackupPlanHook(
 		return nil, nil, nil, false, err
 	}
 
-	toFn, err := p.TypeAsString(backup.Path, "SHOW BACKUP")
+	toFn, err := p.TypeAsString(ctx, backup.Path, "SHOW BACKUP")
 	if err != nil {
 		return nil, nil, nil, false, err
 	}
@@ -57,7 +57,7 @@ func showBackupPlanHook(
 		backupOptEncPassphrase:  sql.KVStringOptRequireValue,
 		backupOptWithPrivileges: sql.KVStringOptRequireNoValue,
 	}
-	optsFn, err := p.TypeAsStringOpts(backup.Options, expected)
+	optsFn, err := p.TypeAsStringOpts(ctx, backup.Options, expected)
 	if err != nil {
 		return nil, nil, nil, false, err
 	}

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -57,7 +57,8 @@ func parseTableDesc(createTableStmt string) (*sqlbase.TableDescriptor, error) {
 }
 
 func parseValues(tableDesc *sqlbase.TableDescriptor, values string) ([]sqlbase.EncDatumRow, error) {
-	semaCtx := &tree.SemaContext{}
+	ctx := context.Background()
+	semaCtx := tree.MakeSemaContext()
 	evalCtx := &tree.EvalContext{}
 
 	valuesStmt, err := parser.ParseOne(values)
@@ -79,7 +80,7 @@ func parseValues(tableDesc *sqlbase.TableDescriptor, values string) ([]sqlbase.E
 		for colIdx, expr := range rowTuple {
 			col := &tableDesc.Columns[colIdx]
 			typedExpr, err := sqlbase.SanitizeVarFreeExpr(
-				expr, col.Type, "avro", semaCtx, false /* allowImpure */)
+				ctx, expr, col.Type, "avro", &semaCtx, false /* allowImpure */)
 			if err != nil {
 				return nil, err
 			}
@@ -125,7 +126,9 @@ func avroFieldMetadataToColDesc(metadata string) (*sqlbase.ColumnDescriptor, err
 		return nil, err
 	}
 	def := parsed.AST.(*tree.AlterTable).Cmds[0].(*tree.AlterTableAddColumn).ColumnDef
-	col, _, _, err := sqlbase.MakeColumnDefDescs(def, &tree.SemaContext{}, &tree.EvalContext{})
+	ctx := context.Background()
+	semaCtx := tree.MakeSemaContext()
+	col, _, _, err := sqlbase.MakeColumnDefDescs(ctx, def, &semaCtx, &tree.EvalContext{})
 	return col, err
 }
 

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -54,7 +54,7 @@ func init() {
 
 // changefeedPlanHook implements sql.PlanHookFn.
 func changefeedPlanHook(
-	_ context.Context, stmt tree.Statement, p sql.PlanHookState,
+	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
 ) (sql.PlanHookRowFn, sqlbase.ResultColumns, []sql.PlanNode, bool, error) {
 	changefeedStmt, ok := stmt.(*tree.CreateChangefeed)
 	if !ok {
@@ -82,7 +82,7 @@ func changefeedPlanHook(
 		avoidBuffering = true
 	} else {
 		var err error
-		sinkURIFn, err = p.TypeAsString(changefeedStmt.SinkURI, `CREATE CHANGEFEED`)
+		sinkURIFn, err = p.TypeAsString(ctx, changefeedStmt.SinkURI, `CREATE CHANGEFEED`)
 		if err != nil {
 			return nil, nil, nil, false, err
 		}
@@ -91,7 +91,7 @@ func changefeedPlanHook(
 		}
 	}
 
-	optsFn, err := p.TypeAsStringOpts(changefeedStmt.Options, changefeedbase.ChangefeedOptionExpectValues)
+	optsFn, err := p.TypeAsStringOpts(ctx, changefeedStmt.Options, changefeedbase.ChangefeedOptionExpectValues)
 	if err != nil {
 		return nil, nil, nil, false, err
 	}
@@ -131,7 +131,7 @@ func changefeedPlanHook(
 		if cursor, ok := opts[changefeedbase.OptCursor]; ok {
 			asOf := tree.AsOfClause{Expr: tree.NewStrVal(cursor)}
 			var err error
-			if initialHighWater, err = p.EvalAsOfTimestamp(asOf); err != nil {
+			if initialHighWater, err = p.EvalAsOfTimestamp(ctx, asOf); err != nil {
 				return err
 			}
 			statementTime = initialHighWater

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -208,20 +208,20 @@ func importPlanHook(
 		return nil, nil, nil, false, errors.Errorf("IMPORT requires a cluster fully upgraded to version >= 19.2")
 	}
 
-	filesFn, err := p.TypeAsStringArray(importStmt.Files, "IMPORT")
+	filesFn, err := p.TypeAsStringArray(ctx, importStmt.Files, "IMPORT")
 	if err != nil {
 		return nil, nil, nil, false, err
 	}
 
 	var createFileFn func() (string, error)
 	if !importStmt.Bundle && !importStmt.Into && importStmt.CreateDefs == nil {
-		createFileFn, err = p.TypeAsString(importStmt.CreateFile, "IMPORT")
+		createFileFn, err = p.TypeAsString(ctx, importStmt.CreateFile, "IMPORT")
 		if err != nil {
 			return nil, nil, nil, false, err
 		}
 	}
 
-	optsFn, err := p.TypeAsStringOpts(importStmt.Options, importOptionExpectValues)
+	optsFn, err := p.TypeAsStringOpts(ctx, importStmt.Options, importOptionExpectValues)
 	if err != nil {
 		return nil, nil, nil, false, err
 	}

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -142,7 +142,7 @@ func MakeSimpleTableDescriptor(
 	}
 	create.Defs = filteredDefs
 
-	semaCtx := tree.SemaContext{}
+	semaCtx := tree.MakeSemaContext()
 	evalCtx := tree.EvalContext{
 		Context:  ctx,
 		Sequence: &importSequenceOperators{},

--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -230,7 +230,7 @@ func Load(
 				return backupccl.BackupManifest{}, errors.Wrap(err, "make row inserter")
 			}
 			cols, defaultExprs, err =
-				sqlbase.ProcessDefaultColumns(tableDesc.Columns, tableDesc, &txCtx, evalCtx)
+				sqlbase.ProcessDefaultColumns(ctx, tableDesc.Columns, tableDesc, &txCtx, evalCtx)
 			if err != nil {
 				return backupccl.BackupManifest{}, errors.Wrap(err, "process default columns")
 			}

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -454,7 +454,7 @@ func (m *pgDumpReader) readFile(
 ) error {
 	var inserts, count int64
 	ps := newPostgreStream(input, int(m.opts.MaxRowSize))
-	semaCtx := &tree.SemaContext{}
+	semaCtx := tree.MakeSemaContext()
 	for _, conv := range m.tables {
 		conv.KvBatch.Source = inputIdx
 		conv.FractionFn = input.ReadFraction
@@ -504,7 +504,7 @@ func (m *pgDumpReader) readFile(
 					return errors.Errorf("expected %d values, got %d: %v", expected, got, tuple)
 				}
 				for i, expr := range tuple {
-					typed, err := expr.TypeCheck(semaCtx, conv.VisibleColTypes[i])
+					typed, err := expr.TypeCheck(ctx, &semaCtx, conv.VisibleColTypes[i])
 					if err != nil {
 						return errors.Wrapf(err, "reading row %d (%d in insert statement %d)",
 							count, count-startingCount, inserts)

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -92,7 +92,7 @@ func valueEncodePartitionTuple(
 		}
 
 		var semaCtx tree.SemaContext
-		typedExpr, err := sqlbase.SanitizeVarFreeExpr(expr, cols[i].Type, "partition",
+		typedExpr, err := sqlbase.SanitizeVarFreeExpr(evalCtx.Context, expr, cols[i].Type, "partition",
 			&semaCtx, false /* allowImpure */)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/alter_role.go
+++ b/pkg/sql/alter_role.go
@@ -54,7 +54,10 @@ func (p *planner) AlterRoleNode(
 		return nil, err
 	}
 
-	roleOptions, err := kvOptions.ToRoleOptions(p.TypeAsStringOrNull, opName)
+	asStringOrNull := func(e tree.Expr, op string) (func() (bool, string, error), error) {
+		return p.TypeAsStringOrNull(ctx, e, op)
+	}
+	roleOptions, err := kvOptions.ToRoleOptions(asStringOrNull, opName)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +65,7 @@ func (p *planner) AlterRoleNode(
 		return nil, err
 	}
 
-	ua, err := p.getUserAuthInfo(nameE, opName)
+	ua, err := p.getUserAuthInfo(ctx, nameE, opName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/analyze_expr.go
+++ b/pkg/sql/analyze_expr.go
@@ -50,10 +50,10 @@ func (p *planner) analyzeExpr(
 	var err error
 	p.semaCtx.IVarContainer = iVarHelper.Container()
 	if requireType {
-		typedExpr, err = tree.TypeCheckAndRequire(resolved, &p.semaCtx,
+		typedExpr, err = tree.TypeCheckAndRequire(ctx, resolved, &p.semaCtx,
 			expectedType, typingContext)
 	} else {
-		typedExpr, err = tree.TypeCheck(resolved, &p.semaCtx, expectedType)
+		typedExpr, err = tree.TypeCheck(ctx, resolved, &p.semaCtx, expectedType)
 	}
 	p.semaCtx.IVarContainer = nil
 	if err != nil {

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1657,7 +1657,7 @@ func columnBackfillInTxn(
 		return nil
 	}
 	var backfiller backfill.ColumnBackfiller
-	if err := backfiller.Init(evalCtx, tableDesc); err != nil {
+	if err := backfiller.Init(ctx, evalCtx, tableDesc); err != nil {
 		return err
 	}
 	// otherTableDescs contains any other table descriptors required by the

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -62,7 +62,7 @@ type ColumnBackfiller struct {
 
 // Init initializes a column backfiller.
 func (cb *ColumnBackfiller) Init(
-	evalCtx *tree.EvalContext, desc *sqlbase.ImmutableTableDescriptor,
+	ctx context.Context, evalCtx *tree.EvalContext, desc *sqlbase.ImmutableTableDescriptor,
 ) error {
 	cb.evalCtx = evalCtx
 	var dropped []sqlbase.ColumnDescriptor
@@ -80,14 +80,21 @@ func (cb *ColumnBackfiller) Init(
 		}
 	}
 	defaultExprs, err := sqlbase.MakeDefaultExprs(
-		cb.added, &transform.ExprTransformContext{}, cb.evalCtx,
+		ctx, cb.added, &transform.ExprTransformContext{}, cb.evalCtx,
 	)
 	if err != nil {
 		return err
 	}
 	var txCtx transform.ExprTransformContext
-	computedExprs, err := sqlbase.MakeComputedExprs(cb.added, desc,
-		tree.NewUnqualifiedTableName(tree.Name(desc.Name)), &txCtx, cb.evalCtx, true /* addingCols */)
+	computedExprs, err := sqlbase.MakeComputedExprs(
+		ctx,
+		cb.added,
+		desc,
+		tree.NewUnqualifiedTableName(tree.Name(desc.Name)),
+		&txCtx,
+		cb.evalCtx,
+		true, /* addingCols */
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/colexec/builtin_funcs_test.go
+++ b/pkg/sql/colexec/builtin_funcs_test.go
@@ -179,7 +179,9 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 	}
 	inputCols := []int{0, 1, 2}
 	p := &mockTypeContext{typs: typs}
-	typedExpr, err := tree.TypeCheck(expr, &tree.SemaContext{IVarContainer: p}, types.Any)
+	semaCtx := tree.MakeSemaContext()
+	semaCtx.IVarContainer = p
+	typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/sql/colexec/select_in_test.go
+++ b/pkg/sql/colexec/select_in_test.go
@@ -222,7 +222,9 @@ func TestProjectInInt64(t *testing.T) {
 						return nil, err
 					}
 					p := &mockTypeContext{typs: []*types.T{types.Int, types.MakeTuple([]*types.T{types.Int})}}
-					typedExpr, err := tree.TypeCheck(expr, &tree.SemaContext{IVarContainer: p}, types.Any)
+					semaCtx := tree.MakeSemaContext()
+					semaCtx.IVarContainer = p
+					typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
 					if err != nil {
 						return nil, err
 					}

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -1574,7 +1574,9 @@ func createTestProjectingOperator(
 		return nil, err
 	}
 	p := &mockTypeContext{typs: inputTypes}
-	typedExpr, err := tree.TypeCheck(expr, &tree.SemaContext{IVarContainer: p}, types.Any)
+	semaCtx := tree.MakeSemaContext()
+	semaCtx.IVarContainer = p
+	typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -332,7 +332,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			}
 			typeHints = make(tree.PlaceholderTypes, stmt.NumPlaceholders)
 			for i, t := range s.Types {
-				resolved, err := tree.ResolveType(t, ex.planner.semaCtx.GetTypeResolver())
+				resolved, err := tree.ResolveType(ctx, t, ex.planner.semaCtx.GetTypeResolver())
 				if err != nil {
 					return makeErrEvent(err)
 				}
@@ -373,7 +373,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			return makeErrEvent(err)
 		}
 		var err error
-		pinfo, err = fillInPlaceholders(ps, name, s.Params, ex.sessionData.SearchPath)
+		pinfo, err = fillInPlaceholders(ctx, ps, name, s.Params, ex.sessionData.SearchPath)
 		if err != nil {
 			return makeErrEvent(err)
 		}
@@ -395,7 +395,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	// don't return any event unless an error happens.
 
 	if os.ImplicitTxn.Get() {
-		asOfTs, err := p.isAsOf(stmt.AST)
+		asOfTs, err := p.isAsOf(ctx, stmt.AST)
 		if err != nil {
 			return makeErrEvent(err)
 		}
@@ -409,7 +409,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		// the transaction's timestamp. This is useful for running AOST statements
 		// using the InternalExecutor inside an external transaction; one might want
 		// to do that to force p.avoidCachedDescriptors to be set below.
-		ts, err := p.isAsOf(stmt.AST)
+		ts, err := p.isAsOf(ctx, stmt.AST)
 		if err != nil {
 			return makeErrEvent(err)
 		}
@@ -948,7 +948,7 @@ func (ex *connExecutor) beginTransactionTimestampsAndReadMode(
 	ex.statsCollector.reset(&ex.server.sqlStats, ex.appStats, &ex.phaseTimes)
 	p := &ex.planner
 	ex.resetPlanner(ctx, p, nil /* txn */, now)
-	ts, err := p.EvalAsOfTimestamp(s.Modes.AsOf)
+	ts, err := p.EvalAsOfTimestamp(ctx, s.Modes.AsOf)
 	if err != nil {
 		return 0, time.Time{}, nil, err
 	}

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -218,7 +218,7 @@ func (ex *connExecutor) populatePrepared(
 	}
 	p.extendedEvalCtx.PrepareOnly = true
 
-	protoTS, err := p.isAsOf(stmt.AST)
+	protoTS, err := p.isAsOf(ctx, stmt.AST)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/sql/copy_file_upload.go
+++ b/pkg/sql/copy_file_upload.go
@@ -76,7 +76,7 @@ func newFileUploadMachine(
 		return nil, err
 	}
 
-	optsFn, err := f.c.p.TypeAsStringOpts(n.Options, copyFileOptionExpectValues)
+	optsFn, err := f.c.p.TypeAsStringOpts(ctx, n.Options, copyFileOptionExpectValues)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -168,9 +168,10 @@ func TestOldBitColumnMetadata(t *testing.T) {
 	// so disable leases on tables.
 	defer lease.TestingDisableTableLeases()()
 
+	ctx := context.Background()
 	params, _ := tests.CreateTestServerParams()
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(context.Background())
+	defer s.Stopper().Stop(ctx)
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -203,7 +204,7 @@ CREATE TABLE t.test (k INT);
 		t.Fatal(err)
 	}
 	colDef := alterCmd.AST.(*tree.AlterTable).Cmds[0].(*tree.AlterTableAddColumn).ColumnDef
-	col, _, _, err := sqlbase.MakeColumnDefDescs(colDef, nil, nil)
+	col, _, _, err := sqlbase.MakeColumnDefDescs(ctx, colDef, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -269,7 +269,7 @@ func setupShardedIndex(
 	for _, c := range *columns {
 		colNames = append(colNames, string(c.Column))
 	}
-	buckets, err := sqlbase.EvalShardBucketCount(semaCtx, evalCtx, bucketsExpr)
+	buckets, err := sqlbase.EvalShardBucketCount(ctx, semaCtx, evalCtx, bucketsExpr)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -217,7 +217,7 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 	// Evaluate the AS OF time, if any.
 	var asOf *hlc.Timestamp
 	if n.Options.AsOf.Expr != nil {
-		asOfTs, err := n.p.EvalAsOfTimestamp(n.Options.AsOf)
+		asOfTs, err := n.p.EvalAsOfTimestamp(ctx, n.Options.AsOf)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -134,6 +134,7 @@ func (n *createViewNode) startExec(params runParams) error {
 			return err
 		}
 		desc, err := makeViewTableDesc(
+			params.ctx,
 			viewName,
 			n.viewQuery,
 			n.dbDesc.ID,
@@ -233,6 +234,7 @@ func (n *createViewNode) Close(ctx context.Context)  {}
 // doesn't matter if reads/writes use a cached descriptor that doesn't
 // include the back-references.
 func makeViewTableDesc(
+	ctx context.Context,
 	viewName string,
 	viewQuery string,
 	parentID sqlbase.ID,
@@ -255,7 +257,7 @@ func makeViewTableDesc(
 		temporary,
 	)
 	desc.ViewQuery = viewQuery
-	if err := addResultColumns(semaCtx, evalCtx, &desc, resultColumns); err != nil {
+	if err := addResultColumns(ctx, semaCtx, evalCtx, &desc, resultColumns); err != nil {
 		return sqlbase.MutableTableDescriptor{}, err
 	}
 	return desc, nil
@@ -277,7 +279,7 @@ func (p *planner) replaceViewDesc(
 	// Reset the columns to add the new result columns onto.
 	toReplace.Columns = make([]sqlbase.ColumnDescriptor, 0, len(n.columns))
 	toReplace.NextColumnID = 0
-	if err := addResultColumns(&p.semaCtx, p.EvalContext(), toReplace, n.columns); err != nil {
+	if err := addResultColumns(ctx, &p.semaCtx, p.EvalContext(), toReplace, n.columns); err != nil {
 		return nil, err
 	}
 
@@ -337,6 +339,7 @@ func (p *planner) replaceViewDesc(
 // addResultColumns adds the resultColumns as actual column
 // descriptors onto desc.
 func addResultColumns(
+	ctx context.Context,
 	semaCtx *tree.SemaContext,
 	evalCtx *tree.EvalContext,
 	desc *sqlbase.MutableTableDescriptor,
@@ -346,7 +349,7 @@ func addResultColumns(
 		columnTableDef := tree.ColumnTableDef{Name: tree.Name(colRes.Name), Type: colRes.Typ}
 		// The new types in the CREATE VIEW column specs never use
 		// SERIAL so we need not process SERIAL types here.
-		col, _, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, semaCtx, evalCtx)
+		col, _, _, err := sqlbase.MakeColumnDefDescs(ctx, &columnTableDef, semaCtx, evalCtx)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/delegate/show_range_for_row.go
+++ b/pkg/sql/delegate/show_range_for_row.go
@@ -48,7 +48,7 @@ func (d *delegator) delegateShowRangeForRow(n *tree.ShowRangeForRow) (tree.State
 	var rowExprs tree.Exprs
 	for i, expr := range n.Row {
 		colTyp := table.Column(i).DatumType()
-		typedExpr, err := sqlbase.SanitizeVarFreeExpr(expr, colTyp, "range-for-row", &semaCtx, false)
+		typedExpr, err := sqlbase.SanitizeVarFreeExpr(d.ctx, expr, colTyp, "range-for-row", &semaCtx, false)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -47,7 +47,7 @@ func (p *planner) DropRoleNode(
 		return nil, err
 	}
 
-	names, err := p.TypeAsStringArray(namesE, opName)
+	names, err := p.TypeAsStringArray(ctx, namesE, opName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/execinfra/expr.go
+++ b/pkg/sql/execinfra/expr.go
@@ -72,7 +72,7 @@ func processExpression(
 
 	semaCtx.IVarContainer = h.Container()
 	// Convert to a fully typed expression.
-	typedExpr, err := tree.TypeCheck(expr, semaCtx, types.Any)
+	typedExpr, err := tree.TypeCheck(evalCtx.Context, expr, semaCtx, types.Any)
 	if err != nil {
 		// Type checking must succeed by now.
 		return nil, errors.NewAssertionErrorWithWrappedErrf(err, "%s", expr)

--- a/pkg/sql/execinfrapb/data.go
+++ b/pkg/sql/execinfrapb/data.go
@@ -81,16 +81,18 @@ type DistSQLTypeResolver struct {
 }
 
 // ResolveType implements tree.ResolvableTypeReference.
-func (tr *DistSQLTypeResolver) ResolveType(name *tree.UnresolvedObjectName) (*types.T, error) {
+func (tr *DistSQLTypeResolver) ResolveType(
+	context.Context, *tree.UnresolvedObjectName,
+) (*types.T, error) {
 	return nil, errors.AssertionFailedf("cannot resolve types in DistSQL by name")
 }
 
 // ResolveTypeByID implements tree.ResolvableTypeReference.
-func (tr *DistSQLTypeResolver) ResolveTypeByID(id uint32) (*types.T, error) {
+func (tr *DistSQLTypeResolver) ResolveTypeByID(ctx context.Context, id uint32) (*types.T, error) {
 	// TODO (rohany): This should eventually look into the set of cached type
 	//  descriptors before attempting to access it here.
 	typDesc, err := sqlbase.GetTypeDescFromID(
-		tr.EvalContext.Context,
+		ctx,
 		tr.EvalContext.Txn,
 		tr.EvalContext.Codec,
 		sqlbase.ID(id),

--- a/pkg/sql/execute.go
+++ b/pkg/sql/execute.go
@@ -11,6 +11,8 @@
 package sql
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -24,7 +26,11 @@ import (
 // the referenced prepared statement and correctly updated placeholder info.
 // See https://www.postgresql.org/docs/current/static/sql-execute.html for details.
 func fillInPlaceholders(
-	ps *PreparedStatement, name string, params tree.Exprs, searchPath sessiondata.SearchPath,
+	ctx context.Context,
+	ps *PreparedStatement,
+	name string,
+	params tree.Exprs,
+	searchPath sessiondata.SearchPath,
 ) (*tree.PlaceholderInfo, error) {
 	if len(ps.Types) != len(params) {
 		return nil, pgerror.Newf(pgcode.Syntax,
@@ -42,7 +48,7 @@ func fillInPlaceholders(
 			return nil, errors.AssertionFailedf("no type for placeholder %s", idx)
 		}
 		typedExpr, err := sqlbase.SanitizeVarFreeExpr(
-			e, typ, "EXECUTE parameter", /* context */
+			ctx, e, typ, "EXECUTE parameter", /* context */
 			&semaCtx, true /* allowImpure */)
 		if err != nil {
 			return nil, pgerror.WithCandidateCode(err, pgcode.WrongObjectType)

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -124,7 +124,7 @@ func buildOpaque(
 	case *tree.SetVar:
 		plan, err = p.SetVar(ctx, n)
 	case *tree.SetTransaction:
-		plan, err = p.SetTransaction(n)
+		plan, err = p.SetTransaction(ctx, n)
 	case *tree.SetSessionAuthorizationDefault:
 		plan, err = p.SetSessionAuthorizationDefault()
 	case *tree.SetSessionCharacteristics:

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -507,6 +507,7 @@ func (h *harness) prepareUsingAPI(tb testing.TB) {
 		id := tree.PlaceholderIdx(i)
 		typ, _ := h.semaCtx.Placeholders.ValueType(id)
 		texpr, err := sqlbase.SanitizeVarFreeExpr(
+			context.Background(),
 			parg,
 			typ,
 			"", /* context */

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -36,6 +36,8 @@ package optbuilder
 //   post-projection: 1 + col3
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -222,8 +224,10 @@ func (a *aggregateInfo) Walk(v tree.Visitor) tree.Expr {
 }
 
 // TypeCheck is part of the tree.Expr interface.
-func (a *aggregateInfo) TypeCheck(ctx *tree.SemaContext, desired *types.T) (tree.TypedExpr, error) {
-	if _, err := a.FuncExpr.TypeCheck(ctx, desired); err != nil {
+func (a *aggregateInfo) TypeCheck(
+	ctx context.Context, semaCtx *tree.SemaContext, desired *types.T,
+) (tree.TypedExpr, error) {
+	if _, err := a.FuncExpr.TypeCheck(ctx, semaCtx, desired); err != nil {
 		return nil, err
 	}
 	return a, nil

--- a/pkg/sql/opt/optbuilder/scope_column.go
+++ b/pkg/sql/opt/optbuilder/scope_column.go
@@ -11,6 +11,8 @@
 package optbuilder
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -125,7 +127,9 @@ func (c *scopeColumn) Walk(v tree.Visitor) tree.Expr {
 }
 
 // TypeCheck is part of the tree.Expr interface.
-func (c *scopeColumn) TypeCheck(_ *tree.SemaContext, desired *types.T) (tree.TypedExpr, error) {
+func (c *scopeColumn) TypeCheck(
+	_ context.Context, _ *tree.SemaContext, desired *types.T,
+) (tree.TypedExpr, error) {
 	return c, nil
 }
 

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -1197,7 +1197,7 @@ func (b *Builder) buildFromWithLateral(
 // validateAsOf ensures that any AS OF SYSTEM TIME timestamp is consistent with
 // that of the root statement.
 func (b *Builder) validateAsOf(asOf tree.AsOfClause) {
-	ts, err := tree.EvalAsOfTimestamp(asOf, b.semaCtx, b.evalCtx)
+	ts, err := tree.EvalAsOfTimestamp(b.ctx, asOf, b.semaCtx, b.evalCtx)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/opt/optbuilder/sql_fn.go
+++ b/pkg/sql/opt/optbuilder/sql_fn.go
@@ -11,6 +11,8 @@
 package optbuilder
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -36,8 +38,10 @@ func (s *sqlFnInfo) Walk(v tree.Visitor) tree.Expr {
 }
 
 // TypeCheck is part of the tree.Expr interface.
-func (s *sqlFnInfo) TypeCheck(ctx *tree.SemaContext, desired *types.T) (tree.TypedExpr, error) {
-	if _, err := s.FuncExpr.TypeCheck(ctx, desired); err != nil {
+func (s *sqlFnInfo) TypeCheck(
+	ctx context.Context, semaCtx *tree.SemaContext, desired *types.T,
+) (tree.TypedExpr, error) {
+	if _, err := s.FuncExpr.TypeCheck(ctx, semaCtx, desired); err != nil {
 		return nil, err
 	}
 	return s, nil

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -11,6 +11,8 @@
 package optbuilder
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -38,7 +40,9 @@ func (s *srf) Walk(v tree.Visitor) tree.Expr {
 }
 
 // TypeCheck is part of the tree.Expr interface.
-func (s *srf) TypeCheck(ctx *tree.SemaContext, desired *types.T) (tree.TypedExpr, error) {
+func (s *srf) TypeCheck(
+	_ context.Context, ctx *tree.SemaContext, desired *types.T,
+) (tree.TypedExpr, error) {
 	if ctx.Properties.Derived.SeenGenerator {
 		// This error happens if this srf struct is nested inside a raw srf that
 		// has not yet been replaced. This is possible since scope.replaceSRF first

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -11,6 +11,8 @@
 package optbuilder
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -81,7 +83,9 @@ func (s *subquery) Walk(v tree.Visitor) tree.Expr {
 }
 
 // TypeCheck is part of the tree.Expr interface.
-func (s *subquery) TypeCheck(_ *tree.SemaContext, desired *types.T) (tree.TypedExpr, error) {
+func (s *subquery) TypeCheck(
+	_ context.Context, _ *tree.SemaContext, desired *types.T,
+) (tree.TypedExpr, error) {
 	if s.typ != nil {
 		return s, nil
 	}

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -71,7 +71,7 @@ func (b *Builder) buildValuesClause(
 			}
 
 			expr := inScope.walkExprTree(tuple[colIdx])
-			texpr, err := tree.TypeCheck(expr, b.semaCtx, desired)
+			texpr, err := tree.TypeCheck(b.ctx, expr, b.semaCtx, desired)
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/sql/opt/optbuilder/window.go
+++ b/pkg/sql/opt/optbuilder/window.go
@@ -11,6 +11,7 @@
 package optbuilder
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
@@ -39,8 +40,10 @@ func (w *windowInfo) Walk(v tree.Visitor) tree.Expr {
 }
 
 // TypeCheck is part of the tree.Expr interface.
-func (w *windowInfo) TypeCheck(ctx *tree.SemaContext, desired *types.T) (tree.TypedExpr, error) {
-	if _, err := w.FuncExpr.TypeCheck(ctx, desired); err != nil {
+func (w *windowInfo) TypeCheck(
+	ctx context.Context, semaCtx *tree.SemaContext, desired *types.T,
+) (tree.TypedExpr, error) {
+	if _, err := w.FuncExpr.TypeCheck(ctx, semaCtx, desired); err != nil {
 		return nil, err
 	}
 	return w, nil

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -192,10 +192,11 @@ type Flags struct {
 // New constructs a new instance of the OptTester for the given SQL statement.
 // Metadata used by the SQL query is accessed via the catalog.
 func New(catalog cat.Catalog, sql string) *OptTester {
+	ctx := context.Background()
 	ot := &OptTester{
 		catalog: catalog,
 		sql:     sql,
-		ctx:     context.Background(),
+		ctx:     ctx,
 		semaCtx: tree.MakeSemaContext(),
 		evalCtx: tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings()),
 	}

--- a/pkg/sql/opt/testutils/testcat/alter_table.go
+++ b/pkg/sql/opt/testutils/testcat/alter_table.go
@@ -11,6 +11,7 @@
 package testcat
 
 import (
+	"context"
 	gojson "encoding/json"
 	"fmt"
 	"sort"
@@ -55,10 +56,11 @@ func (tc *Catalog) AlterTable(stmt *tree.AlterTable) {
 
 // injectTableStats sets the table statistics as specified by a JSON object.
 func injectTableStats(tt *Table, statsExpr tree.Expr) {
+	ctx := context.Background()
 	semaCtx := tree.MakeSemaContext()
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	typedExpr, err := tree.TypeCheckAndRequire(
-		statsExpr, &semaCtx, types.Jsonb, "INJECT STATISTICS",
+		ctx, statsExpr, &semaCtx, types.Jsonb, "INJECT STATISTICS",
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -797,6 +797,7 @@ func (ti *Index) Span() roachpb.Span {
 
 // PartitionByListPrefixes is part of the cat.Index interface.
 func (ti *Index) PartitionByListPrefixes() []tree.Datums {
+	ctx := context.Background()
 	p := ti.partitionBy
 	if p == nil {
 		return nil
@@ -835,7 +836,7 @@ func (ti *Index) PartitionByListPrefixes() []tree.Datums {
 			d := make(tree.Datums, len(vals))
 			for i := range vals {
 				c := tree.CastExpr{Expr: vals[i], Type: ti.Columns[i].DatumType()}
-				cTyped, err := c.TypeCheck(&semaCtx, nil)
+				cTyped, err := c.TypeCheck(ctx, &semaCtx, nil)
 				if err != nil {
 					panic(err)
 				}

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -38,7 +38,6 @@ import (
 // only include what the optimizer needs, and certain common lookups are cached
 // for faster performance.
 type optCatalog struct {
-	tree.TypeReferenceResolver
 	// planner needs to be set via a call to init before calling other methods.
 	planner *planner
 

--- a/pkg/sql/partial_index.go
+++ b/pkg/sql/partial_index.go
@@ -47,7 +47,7 @@ func validateIndexPredicate(
 	// Check that the type of the expression is a types.Bool and that there are
 	// no variable expressions (besides dummyColumnItems) and no impure
 	// functions.
-	if _, err := sqlbase.SanitizeVarFreeExpr(expr, types.Bool, "index predicate", semaCtx, false /* allowImpure */); err != nil {
+	if _, err := sqlbase.SanitizeVarFreeExpr(ctx, expr, types.Bool, "index predicate", semaCtx, false /* allowImpure */); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/pgwire/encoding_test.go
+++ b/pkg/sql/pgwire/encoding_test.go
@@ -53,6 +53,7 @@ func readEncodingTests(t testing.TB) []*encodingTest {
 	}
 	f.Close()
 
+	ctx := context.Background()
 	sema := tree.MakeSemaContext()
 	evalCtx := tree.MakeTestingEvalContext(nil)
 
@@ -74,7 +75,7 @@ func readEncodingTests(t testing.TB) []*encodingTest {
 			t.Fatal("expected 1 expr")
 		}
 		expr := selectClause.Exprs[0].Expr
-		te, err := expr.TypeCheck(&sema, types.Any)
+		te, err := expr.TypeCheck(ctx, &sema, types.Any)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/physicalplan/aggregator_funcs.go
+++ b/pkg/sql/physicalplan/aggregator_funcs.go
@@ -11,6 +11,8 @@
 package physicalplan
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -237,8 +239,9 @@ var DistAggregationTable = map[execinfrapb.AggregatorSpec_Func]DistAggregationIn
 					Type: types.Float,
 				}
 			}
-			ctx := &tree.SemaContext{IVarContainer: h.Container()}
-			return expr.TypeCheck(ctx, types.Any)
+			semaCtx := tree.MakeSemaContext()
+			semaCtx.IVarContainer = h.Container()
+			return expr.TypeCheck(context.TODO(), &semaCtx, types.Any)
 		},
 	},
 

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -76,10 +76,10 @@ type PlanHookState interface {
 	ExecCfg() *ExecutorConfig
 	DistSQLPlanner() *DistSQLPlanner
 	LeaseMgr() *lease.Manager
-	TypeAsString(e tree.Expr, op string) (func() (string, error), error)
-	TypeAsStringArray(e tree.Exprs, op string) (func() ([]string, error), error)
+	TypeAsString(ctx context.Context, e tree.Expr, op string) (func() (string, error), error)
+	TypeAsStringArray(ctx context.Context, e tree.Exprs, op string) (func() ([]string, error), error)
 	TypeAsStringOpts(
-		opts tree.KVOptions, optsValidate map[string]KVStringOptValidate,
+		ctx context.Context, opts tree.KVOptions, optsValidate map[string]KVStringOptValidate,
 	) (func() (map[string]string, error), error)
 	User() string
 	AuthorizationAccessor
@@ -87,7 +87,7 @@ type PlanHookState interface {
 	// TODO(mberhault): it would be easier to just pass a planner to plan hooks.
 	GetAllRoles(ctx context.Context) (map[string]bool, error)
 	BumpRoleMembershipTableVersion(ctx context.Context) error
-	EvalAsOfTimestamp(asOf tree.AsOfClause) (hlc.Timestamp, error)
+	EvalAsOfTimestamp(ctx context.Context, asOf tree.AsOfClause) (hlc.Timestamp, error)
 	ResolveUncachedDatabaseByName(
 		ctx context.Context, dbName string, required bool) (*UncachedDatabaseDescriptor, error)
 	ResolveMutableTableDescriptor(

--- a/pkg/sql/planner_test.go
+++ b/pkg/sql/planner_test.go
@@ -11,6 +11,7 @@
 package sql
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -21,6 +22,7 @@ import (
 
 func TestTypeAsString(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
 	p := planner{alloc: &sqlbase.DatumAlloc{}}
 	testData := []struct {
 		expr        tree.Expr
@@ -38,7 +40,7 @@ func TestTypeAsString(t *testing.T) {
 
 	t.Run("TypeAsString", func(t *testing.T) {
 		for _, td := range testData {
-			fn, err := p.TypeAsString(td.expr, "test")
+			fn, err := p.TypeAsString(ctx, td.expr, "test")
 			if err != nil {
 				if !td.expectedErr {
 					t.Fatalf("expected no error; got %v", err)
@@ -59,7 +61,7 @@ func TestTypeAsString(t *testing.T) {
 
 	t.Run("TypeAsStringArray", func(t *testing.T) {
 		for _, td := range testData {
-			fn, err := p.TypeAsStringArray([]tree.Expr{td.expr, td.expr}, "test")
+			fn, err := p.TypeAsStringArray(ctx, []tree.Expr{td.expr, td.expr}, "test")
 			if err != nil {
 				if !td.expectedErr {
 					t.Fatalf("expected no error; got %v", err)

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -131,6 +131,7 @@ func (n *renameDatabaseNode) startExec(params runParams) error {
 				}
 
 				isAllowed, referencedCol, err := isAllowedDependentDescInRenameDatabase(
+					ctx,
 					dependedOn,
 					tbDesc,
 					dependentDesc,
@@ -211,6 +212,7 @@ func (n *renameDatabaseNode) startExec(params runParams) error {
 // found to contain the database (if it exists), and an error if any.
 // This is a workaround for #45411 until #34416 is resolved.
 func isAllowedDependentDescInRenameDatabase(
+	ctx context.Context,
 	dependedOn sqlbase.TableDescriptor_Reference,
 	tbDesc *sqlbase.TableDescriptor,
 	dependentDesc *sqlbase.TableDescriptor,
@@ -245,7 +247,7 @@ func isAllowedDependentDescInRenameDatabase(
 		if err != nil {
 			return false, "", err
 		}
-		typedExpr, err := tree.TypeCheck(parsedExpr, nil, column.Type)
+		typedExpr, err := tree.TypeCheck(ctx, parsedExpr, nil, column.Type)
 		if err != nil {
 			return false, "", err
 		}

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -86,7 +86,9 @@ func (r *renderNode) Close(ctx context.Context) { r.source.plan.Close(ctx) }
 // specified in any part of the query, then it must be consistent with
 // what is known to the Executor. If the AsOfClause contains a
 // timestamp, then true will be returned.
-func (p *planner) getTimestamp(asOf tree.AsOfClause) (hlc.Timestamp, bool, error) {
+func (p *planner) getTimestamp(
+	ctx context.Context, asOf tree.AsOfClause,
+) (hlc.Timestamp, bool, error) {
 	if asOf.Expr != nil {
 		// At this point, the executor only knows how to recognize AS OF
 		// SYSTEM TIME at the top level. When it finds it there,
@@ -106,7 +108,7 @@ func (p *planner) getTimestamp(asOf tree.AsOfClause) (hlc.Timestamp, bool, error
 		// level. We accept AS OF SYSTEM TIME in multiple places (e.g. in
 		// subqueries or view queries) but they must all point to the same
 		// timestamp.
-		ts, err := p.EvalAsOfTimestamp(asOf)
+		ts, err := p.EvalAsOfTimestamp(ctx, asOf)
 		if err != nil {
 			return hlc.MaxTimestamp, false, err
 		}

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -134,7 +134,9 @@ func (p *planner) CommonLookupFlags(required bool) tree.CommonLookupFlags {
 }
 
 // ResolveType implements the TypeReferenceResolver interface.
-func (p *planner) ResolveType(name *tree.UnresolvedObjectName) (*types.T, error) {
+func (p *planner) ResolveType(
+	ctx context.Context, name *tree.UnresolvedObjectName,
+) (*types.T, error) {
 	lookupFlags := tree.ObjectLookupFlags{
 		CommonLookupFlags: tree.CommonLookupFlags{Required: true},
 		DesiredObjectKind: tree.TypeObject,
@@ -142,7 +144,7 @@ func (p *planner) ResolveType(name *tree.UnresolvedObjectName) (*types.T, error)
 	}
 	// TODO (rohany): The ResolveAnyDescType argument doesn't do anything here
 	//  if we are looking for a type. This should be cleaned up.
-	desc, prefix, err := resolver.ResolveExistingObject(p.EvalContext().Context, p, name, lookupFlags, resolver.ResolveAnyDescType)
+	desc, prefix, err := resolver.ResolveExistingObject(ctx, p, name, lookupFlags, resolver.ResolveAnyDescType)
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +170,7 @@ func (p *planner) ResolveType(name *tree.UnresolvedObjectName) (*types.T, error)
 // accessing types directly by their ID in standard SQL contexts, so error
 // out nicely here.
 // TODO (rohany): Is there a need to disable this in the general case?
-func (p *planner) ResolveTypeByID(id uint32) (*types.T, error) {
+func (p *planner) ResolveTypeByID(ctx context.Context, id uint32) (*types.T, error) {
 	return nil, errors.Newf("type id reference @%d not allowed in this context", id)
 }
 

--- a/pkg/sql/row/cascader.go
+++ b/pkg/sql/row/cascader.go
@@ -802,7 +802,7 @@ func (c *cascader) updateRows(
 			if err != nil {
 				return nil, nil, nil, 0, err
 			}
-			typedExpr, err := tree.TypeCheck(parsedExpr, nil, column.Type)
+			typedExpr, err := tree.TypeCheck(ctx, parsedExpr, nil, column.Type)
 			if err != nil {
 				return nil, nil, nil, 0, err
 			}

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -269,7 +269,7 @@ func NewDatumRowConverter(
 	// columns. All non-target columns must be nullable and will be set to NULL
 	// during import. We do however support DEFAULT on hidden columns (which is
 	// only the default _rowid one). This allows those expressions to run.
-	cols, defaultExprs, err := sqlbase.ProcessDefaultColumns(targetColDescriptors, immutDesc, &txCtx, c.EvalCtx)
+	cols, defaultExprs, err := sqlbase.ProcessDefaultColumns(ctx, targetColDescriptors, immutDesc, &txCtx, c.EvalCtx)
 	if err != nil {
 		return nil, errors.Wrap(err, "process default columns")
 	}

--- a/pkg/sql/rowexec/columnbackfiller.go
+++ b/pkg/sql/rowexec/columnbackfiller.go
@@ -36,6 +36,7 @@ var _ execinfra.Processor = &columnBackfiller{}
 var _ chunkBackfiller = &columnBackfiller{}
 
 func newColumnBackfiller(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec execinfrapb.BackfillerSpec,
@@ -60,7 +61,7 @@ func newColumnBackfiller(
 	}
 	cb.backfiller.chunks = cb
 
-	if err := cb.ColumnBackfiller.Init(cb.flowCtx.NewEvalCtx(), cb.desc); err != nil {
+	if err := cb.ColumnBackfiller.Init(ctx, cb.flowCtx.NewEvalCtx(), cb.desc); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/rowexec/processors.go
+++ b/pkg/sql/rowexec/processors.go
@@ -212,7 +212,7 @@ func NewProcessor(
 		case execinfrapb.BackfillerSpec_Index:
 			return newIndexBackfiller(flowCtx, processorID, *core.Backfiller, post, outputs[0])
 		case execinfrapb.BackfillerSpec_Column:
-			return newColumnBackfiller(flowCtx, processorID, *core.Backfiller, post, outputs[0])
+			return newColumnBackfiller(ctx, flowCtx, processorID, *core.Backfiller, post, outputs[0])
 		}
 	}
 	if core.Sampler != nil {

--- a/pkg/sql/schemachange/alter_column_type.go
+++ b/pkg/sql/schemachange/alter_column_type.go
@@ -11,6 +11,8 @@
 package schemachange
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -200,7 +202,9 @@ func classifierWidth(oldType *types.T, newType *types.T) ColumnConversionKind {
 // ClassifyConversion takes two ColumnTypes and determines "how hard"
 // the conversion is.  Note that this function will return
 // ColumnConversionTrivial if the two types are equal.
-func ClassifyConversion(oldType *types.T, newType *types.T) (ColumnConversionKind, error) {
+func ClassifyConversion(
+	ctx context.Context, oldType *types.T, newType *types.T,
+) (ColumnConversionKind, error) {
 	if oldType.Identical(newType) {
 		return ColumnConversionTrivial, nil
 	}
@@ -216,20 +220,20 @@ func ClassifyConversion(oldType *types.T, newType *types.T) (ColumnConversionKin
 	}
 
 	// See if there's existing cast logic.  If so, return general.
-	ctx := tree.MakeSemaContext()
-	if err := ctx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */); err != nil {
+	semaCtx := tree.MakeSemaContext()
+	if err := semaCtx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */); err != nil {
 		return ColumnConversionImpossible, err
 	}
 
 	// Use a placeholder just to sub in the original type.
-	fromPlaceholder, err := (&tree.Placeholder{Idx: 0}).TypeCheck(&ctx, oldType)
+	fromPlaceholder, err := (&tree.Placeholder{Idx: 0}).TypeCheck(ctx, &semaCtx, oldType)
 	if err != nil {
 		return ColumnConversionImpossible, err
 	}
 
 	// Cook up a cast expression using the placeholder.
 	cast := tree.NewTypedCastExpr(fromPlaceholder, newType)
-	if _, err := cast.TypeCheck(&ctx, nil); err == nil {
+	if _, err := cast.TypeCheck(ctx, &semaCtx, nil); err == nil {
 		return ColumnConversionGeneral, nil
 	}
 

--- a/pkg/sql/schemachange/alter_column_type_test.go
+++ b/pkg/sql/schemachange/alter_column_type_test.go
@@ -177,7 +177,7 @@ func TestColumnConversions(t *testing.T) {
 	t.Run("columnConversionInfo sanity", func(t *testing.T) {
 		for from, mid := range columnConversionInfo {
 			for to, expected := range mid {
-				actual, err := ClassifyConversion(columnType(from), columnType(to))
+				actual, err := ClassifyConversion(context.Background(), columnType(from), columnType(to))
 
 				// Verify that we only return cannot-coerce errors.
 				if err != nil {

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -207,7 +207,7 @@ func (n *scrubNode) startScrubTable(
 	tableDesc *sqlbase.ImmutableTableDescriptor,
 	tableName *tree.TableName,
 ) error {
-	ts, hasTS, err := p.getTimestamp(n.n.AsOf)
+	ts, hasTS, err := p.getTimestamp(ctx, n.n.AsOf)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/sem/builtins/aggregate_builtins_test.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins_test.go
@@ -357,12 +357,12 @@ func makeIntervalTestDatum(count int) []tree.Datum {
 
 func TestArrayAggNameOverload(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	testArrayAggAliasedTypeOverload(t, types.Name)
+	testArrayAggAliasedTypeOverload(context.Background(), t, types.Name)
 }
 
 func TestArrayAggOidOverload(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	testArrayAggAliasedTypeOverload(t, types.Oid)
+	testArrayAggAliasedTypeOverload(context.Background(), t, types.Oid)
 }
 
 // testAliasedTypeOverload is a helper function for testing ARRAY_AGG's
@@ -370,7 +370,7 @@ func TestArrayAggOidOverload(t *testing.T) {
 // These tests are necessary because some ORMs (e.g., sequelize) require
 // ARRAY_AGG to work on these aliased types and produce a result with the
 // correct type.
-func testArrayAggAliasedTypeOverload(t *testing.T, expected *types.T) {
+func testArrayAggAliasedTypeOverload(ctx context.Context, t *testing.T, expected *types.T) {
 	defer tree.MockNameTypes(map[string]*types.T{
 		"a": expected,
 	})()
@@ -380,7 +380,7 @@ func testArrayAggAliasedTypeOverload(t *testing.T, expected *types.T) {
 		t.Fatalf("%s: %v", exprStr, err)
 	}
 	typ := types.MakeArray(expected)
-	typedExpr, err := tree.TypeCheck(expr, nil, typ)
+	typedExpr, err := tree.TypeCheck(ctx, expr, nil, typ)
 	if err != nil {
 		t.Fatalf("%s: %v", expr, err)
 	}

--- a/pkg/sql/sem/tree/as_of.go
+++ b/pkg/sql/sem/tree/as_of.go
@@ -11,6 +11,7 @@
 package tree
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"time"
@@ -34,7 +35,7 @@ var errInvalidExprForAsOf = errors.Errorf("AS OF SYSTEM TIME: only constant expr
 
 // EvalAsOfTimestamp evaluates the timestamp argument to an AS OF SYSTEM TIME query.
 func EvalAsOfTimestamp(
-	asOf AsOfClause, semaCtx *SemaContext, evalCtx *EvalContext,
+	ctx context.Context, asOf AsOfClause, semaCtx *SemaContext, evalCtx *EvalContext,
 ) (tsss hlc.Timestamp, err error) {
 	// We need to save and restore the previous value of the field in
 	// semaCtx in case we are recursively called within a subquery
@@ -57,12 +58,12 @@ func EvalAsOfTimestamp(
 		if def.Name != FollowerReadTimestampFunctionName {
 			return hlc.Timestamp{}, errInvalidExprForAsOf
 		}
-		if te, err = fe.TypeCheck(semaCtx, types.TimestampTZ); err != nil {
+		if te, err = fe.TypeCheck(ctx, semaCtx, types.TimestampTZ); err != nil {
 			return hlc.Timestamp{}, err
 		}
 	} else {
 		var err error
-		te, err = asOf.Expr.TypeCheck(semaCtx, types.String)
+		te, err = asOf.Expr.TypeCheck(ctx, semaCtx, types.String)
 		if err != nil {
 			return hlc.Timestamp{}, err
 		}

--- a/pkg/sql/sem/tree/collatedstring_test.go
+++ b/pkg/sql/sem/tree/collatedstring_test.go
@@ -31,10 +31,12 @@ func TestCastToCollatedString(t *testing.T) {
 		{types.MakeCollatedString(types.MakeString(4), "en"), "test"},
 		{types.MakeCollatedString(types.MakeString(3), "en"), "tes"},
 	}
+	ctx := context.Background()
 	for _, cas := range cases {
 		t.Run("", func(t *testing.T) {
 			expr := &CastExpr{Expr: NewDString("test"), Type: cas.typ, SyntaxMode: CastShort}
-			typedexpr, err := expr.TypeCheck(&SemaContext{}, types.Any)
+			semaCtx := MakeSemaContext()
+			typedexpr, err := expr.TypeCheck(ctx, &semaCtx, types.Any)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/sem/tree/compare_test.go
+++ b/pkg/sql/sem/tree/compare_test.go
@@ -53,7 +53,7 @@ func TestEvalComparisonExprCaching(t *testing.T) {
 		ctx := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 		defer ctx.Mon.Stop(context.Background())
 		ctx.ReCache = NewRegexpCache(8)
-		typedExpr, err := TypeCheck(expr, nil, types.Any)
+		typedExpr, err := TypeCheck(context.Background(), expr, nil, types.Any)
 		if err != nil {
 			t.Fatalf("%v: %v", d, err)
 		}

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -57,12 +57,14 @@ func isConstant(expr Expr) bool {
 	return ok
 }
 
-func typeCheckConstant(c Constant, ctx *SemaContext, desired *types.T) (ret TypedExpr, err error) {
+func typeCheckConstant(
+	c Constant, semaCtx *SemaContext, desired *types.T,
+) (ret TypedExpr, err error) {
 	avail := c.AvailableTypes()
 	if desired.Family() != types.AnyFamily {
 		for _, typ := range avail {
 			if desired.Equivalent(typ) {
-				return c.ResolveAsType(ctx, desired)
+				return c.ResolveAsType(semaCtx, desired)
 			}
 		}
 	}
@@ -84,7 +86,7 @@ func typeCheckConstant(c Constant, ctx *SemaContext, desired *types.T) (ret Type
 	}
 
 	natural := avail[0]
-	return c.ResolveAsType(ctx, natural)
+	return c.ResolveAsType(semaCtx, natural)
 }
 
 func naturalConstantType(c Constant) *types.T {

--- a/pkg/sql/sem/tree/constant_eval_test.go
+++ b/pkg/sql/sem/tree/constant_eval_test.go
@@ -32,7 +32,7 @@ func TestConstantEvalArrayComparison(t *testing.T) {
 	}
 
 	semaCtx := tree.MakeSemaContext()
-	typedExpr, err := expr.TypeCheck(&semaCtx, types.Any)
+	typedExpr, err := expr.TypeCheck(context.Background(), &semaCtx, types.Any)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/sem/tree/constant_test.go
+++ b/pkg/sql/sem/tree/constant_test.go
@@ -84,7 +84,8 @@ func TestNumericConstantVerifyAndResolveAvailableTypes(t *testing.T) {
 
 		// Make sure it can be resolved as each of those types.
 		for _, availType := range avail {
-			if res, err := c.ResolveAsType(&tree.SemaContext{}, availType); err != nil {
+			semaCtx := tree.MakeSemaContext()
+			if res, err := c.ResolveAsType(&semaCtx, availType); err != nil {
 				t.Errorf("%d: expected resolving %v as available type %s would succeed, found %v",
 					i, c.ExactString(), availType, err)
 			} else {
@@ -184,7 +185,8 @@ func TestStringConstantVerifyAvailableTypes(t *testing.T) {
 				continue
 			}
 
-			if _, err := test.c.ResolveAsType(&tree.SemaContext{}, availType); err != nil {
+			semaCtx := tree.MakeSemaContext()
+			if _, err := test.c.ResolveAsType(&semaCtx, availType); err != nil {
 				if !strings.Contains(err.Error(), "could not parse") {
 					// Parsing errors are permitted for this test, as proper tree.StrVal parsing
 					// is tested in TestStringConstantTypeResolution. Any other error should
@@ -393,7 +395,8 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 				continue
 			}
 
-			res, err := test.c.ResolveAsType(&tree.SemaContext{}, availType)
+			semaCtx := tree.MakeSemaContext()
+			res, err := test.c.ResolveAsType(&semaCtx, availType)
 			if err != nil {
 				if !strings.Contains(err.Error(), "could not parse") && !strings.Contains(err.Error(), "parsing") {
 					// Parsing errors are permitted for this test, but the number of correctly

--- a/pkg/sql/sem/tree/datum_test.go
+++ b/pkg/sql/sem/tree/datum_test.go
@@ -36,7 +36,9 @@ func prepareExpr(t *testing.T, datumExpr string) tree.TypedExpr {
 	}
 	// Type checking ensures constant folding is performed and type
 	// annotations have come into effect.
-	typedExpr, err := tree.TypeCheck(expr, nil, types.Any)
+	ctx := context.Background()
+	sema := tree.MakeSemaContext()
+	typedExpr, err := tree.TypeCheck(ctx, expr, &sema, types.Any)
 	if err != nil {
 		t.Fatalf("%s: %v", datumExpr, err)
 	}

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -86,7 +86,8 @@ func TestEval(t *testing.T) {
 	t.Run("no-opt", func(t *testing.T) {
 		walkExpr(t, func(e tree.Expr) (tree.TypedExpr, error) {
 			// expr.TypeCheck to avoid constant folding.
-			typedExpr, err := e.TypeCheck(nil, types.Any)
+			semaCtx := tree.MakeSemaContext()
+			typedExpr, err := e.TypeCheck(ctx, &semaCtx, types.Any)
 			if err != nil {
 				return nil, err
 			}
@@ -124,7 +125,8 @@ func TestEval(t *testing.T) {
 				t.Fatal(err)
 			}
 			// expr.TypeCheck to avoid constant folding.
-			typedExpr, err := expr.TypeCheck(nil, types.Any)
+			semaCtx := tree.MakeSemaContext()
+			typedExpr, err := expr.TypeCheck(ctx, &semaCtx, types.Any)
 			if err != nil {
 				// An error here should have been found above by QueryRow.
 				t.Fatal(err)
@@ -141,7 +143,7 @@ func TestEval(t *testing.T) {
 						continue
 					}
 					// Figure out the type of the tuple value.
-					expr, err := tuple.Exprs[i].TypeCheck(nil, types.Any)
+					expr, err := tuple.Exprs[i].TypeCheck(ctx, &semaCtx, types.Any)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -184,7 +186,8 @@ func TestEval(t *testing.T) {
 				// method returns an error, so skip it for execution.
 				return strings.TrimSpace(d.Expected)
 			}
-			typedExpr, err := expr.TypeCheck(nil, types.Any)
+			semaCtx := tree.MakeSemaContext()
+			typedExpr, err := expr.TypeCheck(ctx, &semaCtx, types.Any)
 			if err != nil {
 				// Skip this test as it's testing an expected error which would be
 				// caught before execution.
@@ -279,7 +282,9 @@ func TestEval(t *testing.T) {
 func optBuildScalar(evalCtx *tree.EvalContext, e tree.Expr) (tree.TypedExpr, error) {
 	var o xform.Optimizer
 	o.Init(evalCtx, nil /* catalog */)
-	b := optbuilder.NewScalar(context.Background(), &tree.SemaContext{}, evalCtx, o.Factory())
+	ctx := context.Background()
+	semaCtx := tree.MakeSemaContext()
+	b := optbuilder.NewScalar(ctx, &semaCtx, evalCtx, o.Factory())
 	if err := b.Build(e); err != nil {
 		return nil, err
 	}
@@ -379,7 +384,8 @@ func TestTimeConversion(t *testing.T) {
 			t.Errorf("%s: %v", exprStr, err)
 			continue
 		}
-		typedExpr, err := expr.TypeCheck(nil, types.Timestamp)
+		semaCtx := tree.MakeSemaContext()
+		typedExpr, err := expr.TypeCheck(context.Background(), &semaCtx, types.Timestamp)
 		if err != nil {
 			t.Errorf("%s: %v", exprStr, err)
 			continue
@@ -418,7 +424,7 @@ func TestTimeConversion(t *testing.T) {
 			t.Errorf("%s: %v", exprStr, err)
 			continue
 		}
-		typedExpr, err = expr.TypeCheck(nil, types.Timestamp)
+		typedExpr, err = expr.TypeCheck(context.Background(), &semaCtx, types.Timestamp)
 		if err != nil {
 			t.Errorf("%s: %v", exprStr, err)
 			continue
@@ -532,12 +538,14 @@ func TestEvalError(t *testing.T) {
 		{`B'1001' | B'101'`, `cannot OR bit strings of different sizes`},
 		{`B'1001' # B'101'`, `cannot XOR bit strings of different sizes`},
 	}
+	ctx := context.Background()
 	for _, d := range testData {
 		expr, err := parser.ParseExpr(d.expr)
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
-		typedExpr, err := tree.TypeCheck(expr, nil, types.Any)
+		semaCtx := tree.MakeSemaContext()
+		typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
 		if err == nil {
 			evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 			defer evalCtx.Stop(context.Background())

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -12,6 +12,7 @@ package tree
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strconv"
 
@@ -36,13 +37,13 @@ type Expr interface {
 	// sub-expressions will be guaranteed to be well-typed, meaning that the method effectively
 	// maps the Expr tree into a TypedExpr tree.
 	//
-	// The ctx parameter defines the context in which to perform type checking.
+	// The semaCtx parameter defines the context in which to perform type checking.
 	// The desired parameter hints the desired type that the method's caller wants from
 	// the resulting TypedExpr. It is not valid to call TypeCheck with a nil desired
 	// type. Instead, call it with wildcard type types.Any if no specific type is
 	// desired. This restriction is also true of most methods and functions related
 	// to type checking.
-	TypeCheck(ctx *SemaContext, desired *types.T) (TypedExpr, error)
+	TypeCheck(ctx context.Context, semaCtx *SemaContext, desired *types.T) (TypedExpr, error)
 }
 
 // TypedExpr represents a well-typed expression.
@@ -1085,7 +1086,9 @@ func (node *TypedDummy) ResolvedType() *types.T {
 }
 
 // TypeCheck implements the Expr interface.
-func (node *TypedDummy) TypeCheck(*SemaContext, *types.T) (TypedExpr, error) { return node, nil }
+func (node *TypedDummy) TypeCheck(context.Context, *SemaContext, *types.T) (TypedExpr, error) {
+	return node, nil
+}
 
 // Walk implements the Expr interface.
 func (node *TypedDummy) Walk(Visitor) Expr { return node }

--- a/pkg/sql/sem/tree/expr_test.go
+++ b/pkg/sql/sem/tree/expr_test.go
@@ -109,12 +109,13 @@ func TestExprString(t *testing.T) {
 		`(1 >= 2) = (2 IS OF (BOOL))`,
 		`count(1) FILTER (WHERE true)`,
 	}
+	ctx := context.Background()
 	for _, exprStr := range testExprs {
 		expr, err := parser.ParseExpr(exprStr)
 		if err != nil {
 			t.Fatalf("%s: %v", exprStr, err)
 		}
-		typedExpr, err := tree.TypeCheck(expr, nil, types.Any)
+		typedExpr, err := tree.TypeCheck(ctx, expr, nil, types.Any)
 		if err != nil {
 			t.Fatalf("%s: %v", expr, err)
 		}
@@ -124,7 +125,7 @@ func TestExprString(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", exprStr, err)
 		}
-		typedExpr2, err := tree.TypeCheck(expr2, nil, types.Any)
+		typedExpr2, err := tree.TypeCheck(ctx, expr2, nil, types.Any)
 		if err != nil {
 			t.Fatalf("%s: %v", expr2, err)
 		}

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -11,6 +11,7 @@
 package tree_test
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -260,14 +261,15 @@ func TestFormatExpr(t *testing.T) {
 			`(_, COALESCE(_, _), ARRAY[_])`},
 	}
 
+	ctx := context.Background()
 	for i, test := range testData {
 		t.Run(fmt.Sprintf("%d %s", i, test.expr), func(t *testing.T) {
 			expr, err := parser.ParseExpr(test.expr)
 			if err != nil {
 				t.Fatal(err)
 			}
-			ctx := tree.MakeSemaContext()
-			typeChecked, err := tree.TypeCheck(expr, &ctx, types.Any)
+			semaContext := tree.MakeSemaContext()
+			typeChecked, err := tree.TypeCheck(ctx, expr, &semaContext, types.Any)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -323,10 +325,11 @@ func TestFormatExpr2(t *testing.T) {
 		// Ensure that nulls get properly type annotated when printed in an
 	}
 
+	ctx := context.Background()
 	for i, test := range testData {
 		t.Run(fmt.Sprintf("%d %s", i, test.expr), func(t *testing.T) {
-			ctx := tree.MakeSemaContext()
-			typeChecked, err := tree.TypeCheck(test.expr, &ctx, types.Any)
+			semaCtx := tree.MakeSemaContext()
+			typeChecked, err := tree.TypeCheck(ctx, test.expr, &semaCtx, types.Any)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -375,6 +378,7 @@ func TestFormatPgwireText(t *testing.T) {
 
 		{`ARRAY[e'\U00002001☃']`, `{ ☃}`},
 	}
+	ctx := context.Background()
 	var evalCtx tree.EvalContext
 	for i, test := range testData {
 		t.Run(fmt.Sprintf("%d %s", i, test.expr), func(t *testing.T) {
@@ -382,8 +386,8 @@ func TestFormatPgwireText(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			ctx := tree.MakeSemaContext()
-			typeChecked, err := tree.TypeCheck(expr, &ctx, types.Any)
+			semaCtx := tree.MakeSemaContext()
+			typeChecked, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/sem/tree/indexed_vars.go
+++ b/pkg/sql/sem/tree/indexed_vars.go
@@ -11,6 +11,8 @@
 package tree
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -53,8 +55,10 @@ func (v *IndexedVar) Walk(_ Visitor) Expr {
 }
 
 // TypeCheck is part of the Expr interface.
-func (v *IndexedVar) TypeCheck(ctx *SemaContext, desired *types.T) (TypedExpr, error) {
-	if ctx.IVarContainer == nil || ctx.IVarContainer == unboundContainer {
+func (v *IndexedVar) TypeCheck(
+	_ context.Context, semaCtx *SemaContext, desired *types.T,
+) (TypedExpr, error) {
+	if semaCtx.IVarContainer == nil || semaCtx.IVarContainer == unboundContainer {
 		// A more technically correct message would be to say that the
 		// reference is unbound and thus cannot be typed. However this is
 		// a tad bit too technical for the average SQL use case and
@@ -64,7 +68,7 @@ func (v *IndexedVar) TypeCheck(ctx *SemaContext, desired *types.T) (TypedExpr, e
 		return nil, pgerror.Newf(
 			pgcode.UndefinedColumn, "column reference @%d not allowed in this context", v.Idx+1)
 	}
-	v.typ = ctx.IVarContainer.IndexedVarResolvedType(v.Idx)
+	v.typ = semaCtx.IVarContainer.IndexedVarResolvedType(v.Idx)
 	return v, nil
 }
 

--- a/pkg/sql/sem/tree/indexed_vars_test.go
+++ b/pkg/sql/sem/tree/indexed_vars_test.go
@@ -61,8 +61,10 @@ func TestIndexedVars(t *testing.T) {
 	expr := binary(Plus, v0, binary(Mult, v1, v2))
 
 	// Verify the expression evaluates correctly.
-	semaContext := &SemaContext{IVarContainer: c}
-	typedExpr, err := expr.TypeCheck(semaContext, types.Any)
+	ctx := context.Background()
+	semaContext := MakeSemaContext()
+	semaContext.IVarContainer = c
+	typedExpr, err := expr.TypeCheck(ctx, &semaContext, types.Any)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -451,7 +451,7 @@ func (expr *ComparisonExpr) normalize(v *NormalizeVisitor) TypedExpr {
 					break
 				}
 
-				typedJ, err := dj.TypeCheck(nil, types.Jsonb)
+				typedJ, err := dj.TypeCheck(v.ctx.Context, nil, types.Jsonb)
 				if err != nil {
 					break
 				}

--- a/pkg/sql/sem/tree/normalize_test.go
+++ b/pkg/sql/sem/tree/normalize_test.go
@@ -276,6 +276,7 @@ func TestNormalizeExpr(t *testing.T) {
 		{`(ROW (a) AS a)`, `((a,) AS a)`}, // Tuple
 	}
 
+	ctx := context.Background()
 	semaCtx := tree.MakeSemaContext()
 	for _, d := range testData {
 		t.Run(d.expr, func(t *testing.T) {
@@ -283,7 +284,7 @@ func TestNormalizeExpr(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s: %v", d.expr, err)
 			}
-			typedExpr, err := expr.TypeCheck(&semaCtx, types.Any)
+			typedExpr, err := expr.TypeCheck(ctx, &semaCtx, types.Any)
 			if err != nil {
 				t.Fatalf("%s: %v", d.expr, err)
 			}

--- a/pkg/sql/sem/tree/overload_test.go
+++ b/pkg/sql/sem/tree/overload_test.go
@@ -11,6 +11,7 @@
 package tree
 
 import (
+	"context"
 	"fmt"
 	"go/constant"
 	"go/token"
@@ -246,10 +247,11 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 		{nil, []Expr{placeholder(0), intConst("1")}, []overloadImpl{binaryArrayIntFn}, unsupported, false},
 		{nil, []Expr{placeholder(0), intConst("1")}, []overloadImpl{binaryArrayIntFn}, unsupported, true},
 	}
+	ctx := context.Background()
 	for i, d := range testData {
 		t.Run(fmt.Sprintf("%v/%v", d.exprs, d.overloads), func(t *testing.T) {
-			ctx := MakeSemaContext()
-			if err := ctx.Placeholders.Init(2 /* numPlaceholders */, nil /* typeHints */); err != nil {
+			semaCtx := MakeSemaContext()
+			if err := semaCtx.Placeholders.Init(2 /* numPlaceholders */, nil /* typeHints */); err != nil {
 				t.Fatal(err)
 			}
 			desired := types.Any
@@ -257,7 +259,7 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 				desired = d.desired
 			}
 			typedExprs, fns, err := typeCheckOverloadedExprs(
-				&ctx, desired, d.overloads, d.inBinOp, d.exprs...,
+				ctx, &semaCtx, desired, d.overloads, d.inBinOp, d.exprs...,
 			)
 			assertNoErr := func() {
 				if err != nil {

--- a/pkg/sql/sem/tree/type_check_internal_test.go
+++ b/pkg/sql/sem/tree/type_check_internal_test.go
@@ -38,7 +38,7 @@ func BenchmarkTypeCheck(b *testing.B) {
 		b.Fatal(err)
 	}
 	for i := 0; i < b.N; i++ {
-		_, err := tree.TypeCheck(expr, &ctx, types.Int)
+		_, err := tree.TypeCheck(context.Background(), expr, &ctx, types.Int)
 		if err != nil {
 			b.Fatalf("unexpected error: %s", err)
 		}
@@ -56,14 +56,15 @@ func TestTypeCheckNormalize(t *testing.T) {
 		{`'Inf'::decimal`, `'Infinity':::DECIMAL`},
 		{`'-Inf'::decimal`, `'-Infinity':::DECIMAL`},
 	}
+	ctx := context.Background()
 	for _, d := range testData {
 		t.Run(d.expr, func(t *testing.T) {
 			expr, err := parser.ParseExpr(d.expr)
 			if err != nil {
 				t.Fatal(err)
 			}
-			ctx := tree.MakeSemaContext()
-			typeChecked, err := tree.TypeCheck(expr, &ctx, types.Any)
+			semaCtx := tree.MakeSemaContext()
+			typeChecked, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -177,16 +178,17 @@ func attemptTypeCheckSameTypedExprs(t *testing.T, idx int, test sameTypedExprsTe
 	if test.expectedPTypes == nil {
 		test.expectedPTypes = tree.PlaceholderTypes{}
 	}
+	ctx := context.Background()
 	forEachPerm(test.exprs, 0, func(exprs []copyableExpr) {
-		ctx := tree.MakeSemaContext()
-		if err := ctx.Placeholders.Init(len(test.ptypes), clonePlaceholderTypes(test.ptypes)); err != nil {
+		semaCtx := tree.MakeSemaContext()
+		if err := semaCtx.Placeholders.Init(len(test.ptypes), clonePlaceholderTypes(test.ptypes)); err != nil {
 			t.Fatal(err)
 		}
 		desired := types.Any
 		if test.desired != nil {
 			desired = test.desired
 		}
-		_, typ, err := tree.TypeCheckSameTypedExprs(&ctx, desired, buildExprs(exprs)...)
+		_, typ, err := tree.TypeCheckSameTypedExprs(ctx, &semaCtx, desired, buildExprs(exprs)...)
 		if err != nil {
 			t.Errorf("%d: unexpected error returned from typeCheckSameTypedExprs: %v", idx, err)
 		} else {
@@ -194,8 +196,8 @@ func attemptTypeCheckSameTypedExprs(t *testing.T, idx int, test sameTypedExprsTe
 				t.Errorf("%d: expected type %s when type checking %s, found %s",
 					idx, test.expectedType, buildExprs(exprs), typ)
 			}
-			if !reflect.DeepEqual(ctx.Placeholders.Types, test.expectedPTypes) {
-				t.Errorf("%d: expected placeholder types %v after TypeCheckSameTypedExprs for %v, found %v", idx, test.expectedPTypes, buildExprs(exprs), ctx.Placeholders.Types)
+			if !reflect.DeepEqual(semaCtx.Placeholders.Types, test.expectedPTypes) {
+				t.Errorf("%d: expected placeholder types %v after TypeCheckSameTypedExprs for %v, found %v", idx, test.expectedPTypes, buildExprs(exprs), semaCtx.Placeholders.Types)
 			}
 		}
 	})
@@ -324,9 +326,10 @@ func TestTypeCheckSameTypedExprsError(t *testing.T) {
 		// Placeholder ambiguity.
 		{ptypesNone, nil, exprs(placeholder(1), placeholder(0)), placeholderErr},
 	}
+	ctx := context.Background()
 	for i, d := range testData {
-		ctx := tree.MakeSemaContext()
-		if err := ctx.Placeholders.Init(len(d.ptypes), d.ptypes); err != nil {
+		semaCtx := tree.MakeSemaContext()
+		if err := semaCtx.Placeholders.Init(len(d.ptypes), d.ptypes); err != nil {
 			t.Error(err)
 			continue
 		}
@@ -335,7 +338,7 @@ func TestTypeCheckSameTypedExprsError(t *testing.T) {
 			desired = d.desired
 		}
 		forEachPerm(d.exprs, 0, func(exprs []copyableExpr) {
-			if _, _, err := tree.TypeCheckSameTypedExprs(&ctx, desired, buildExprs(exprs)...); !testutils.IsError(err, d.expectedErr) {
+			if _, _, err := tree.TypeCheckSameTypedExprs(ctx, &semaCtx, desired, buildExprs(exprs)...); !testutils.IsError(err, d.expectedErr) {
 				t.Errorf("%d: expected %s, but found %v", i, d.expectedErr, err)
 			}
 		})

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -11,6 +11,7 @@
 package tree_test
 
 import (
+	"context"
 	"regexp"
 	"testing"
 
@@ -191,18 +192,19 @@ func TestTypeCheck(t *testing.T) {
 		{`1 IS OF (d.t1, t2)`, `1:::INT8 IS OF (d.t1, t2)`},
 		{`1::d.t1`, `1:::INT8::d.t1`},
 	}
+	ctx := context.Background()
 	for _, d := range testData {
 		t.Run(d.expr, func(t *testing.T) {
 			expr, err := parser.ParseExpr(d.expr)
 			if err != nil {
 				t.Fatalf("%s: %v", d.expr, err)
 			}
-			ctx := tree.MakeSemaContext()
-			if err := ctx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */); err != nil {
+			semaCtx := tree.MakeSemaContext()
+			if err := semaCtx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */); err != nil {
 				t.Fatal(err)
 			}
-			ctx.TypeResolver = mapResolver
-			typeChecked, err := tree.TypeCheck(expr, &ctx, types.Any)
+			semaCtx.TypeResolver = mapResolver
+			typeChecked, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
 			if err != nil {
 				t.Fatalf("%s: unexpected error %s", d.expr, err)
 			}
@@ -310,17 +312,18 @@ func TestTypeCheckError(t *testing.T) {
 			`type "d.s.typ" does not exist`,
 		},
 	}
+	ctx := context.Background()
 	for _, d := range testData {
 		t.Run(d.expr, func(t *testing.T) {
 			// Test with a nil and non-nil semaCtx.
 			t.Run("semaCtx not nil", func(t *testing.T) {
-				ctx := tree.MakeSemaContext()
-				ctx.TypeResolver = mapResolver
+				semaCtx := tree.MakeSemaContext()
+				semaCtx.TypeResolver = mapResolver
 				expr, err := parser.ParseExpr(d.expr)
 				if err != nil {
 					t.Fatalf("%s: %v", d.expr, err)
 				}
-				if _, err := tree.TypeCheck(expr, &ctx, types.Any); !testutils.IsError(err, regexp.QuoteMeta(d.expected)) {
+				if _, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any); !testutils.IsError(err, regexp.QuoteMeta(d.expected)) {
 					t.Errorf("%s: expected %s, but found %v", d.expr, d.expected, err)
 				}
 			})
@@ -329,7 +332,7 @@ func TestTypeCheckError(t *testing.T) {
 				if err != nil {
 					t.Fatalf("%s: %v", d.expr, err)
 				}
-				if _, err := tree.TypeCheck(expr, nil, types.Any); !testutils.IsError(err, regexp.QuoteMeta(d.expected)) {
+				if _, err := tree.TypeCheck(ctx, expr, nil, types.Any); !testutils.IsError(err, regexp.QuoteMeta(d.expected)) {
 					t.Errorf("%s: expected %s, but found %v", d.expr, d.expected, err)
 				}
 			})

--- a/pkg/sql/sem/tree/type_name.go
+++ b/pkg/sql/sem/tree/type_name.go
@@ -11,6 +11,7 @@
 package tree
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -107,8 +108,8 @@ func MakeNewQualifiedTypeName(db, schema, typ string) TypeName {
 // to actually look up type metadata and transform references into
 // *types.T's.
 type TypeReferenceResolver interface {
-	ResolveType(name *UnresolvedObjectName) (*types.T, error)
-	ResolveTypeByID(id uint32) (*types.T, error)
+	ResolveType(ctx context.Context, name *UnresolvedObjectName) (*types.T, error)
+	ResolveTypeByID(ctx context.Context, id uint32) (*types.T, error)
 }
 
 // ResolvableTypeReference represents a type that is possibly unknown
@@ -125,12 +126,14 @@ var _ ResolvableTypeReference = &types.T{}
 var _ ResolvableTypeReference = &IDTypeReference{}
 
 // ResolveType converts a ResolvableTypeReference into a *types.T.
-func ResolveType(ref ResolvableTypeReference, resolver TypeReferenceResolver) (*types.T, error) {
+func ResolveType(
+	ctx context.Context, ref ResolvableTypeReference, resolver TypeReferenceResolver,
+) (*types.T, error) {
 	switch t := ref.(type) {
 	case *types.T:
 		return t, nil
 	case *ArrayTypeReference:
-		typ, err := ResolveType(t.ElementType, resolver)
+		typ, err := ResolveType(ctx, t.ElementType, resolver)
 		if err != nil {
 			return nil, err
 		}
@@ -141,12 +144,12 @@ func ResolveType(ref ResolvableTypeReference, resolver TypeReferenceResolver) (*
 			// name into a type.
 			return nil, pgerror.Newf(pgcode.UndefinedObject, "type %q does not exist", t)
 		}
-		return resolver.ResolveType(t)
+		return resolver.ResolveType(ctx, t)
 	case *IDTypeReference:
 		if resolver == nil {
 			return nil, pgerror.Newf(pgcode.UndefinedObject, "type id %d does not exist", t.ID)
 		}
-		return resolver.ResolveTypeByID(t.ID)
+		return resolver.ResolveTypeByID(ctx, t.ID)
 	default:
 		return nil, errors.AssertionFailedf("unknown resolvable type reference type %s", t)
 	}
@@ -233,7 +236,9 @@ type TestingMapTypeResolver struct {
 }
 
 // ResolveType implements the TypeReferenceResolver interface.
-func (dtr *TestingMapTypeResolver) ResolveType(name *UnresolvedObjectName) (*types.T, error) {
+func (dtr *TestingMapTypeResolver) ResolveType(
+	_ context.Context, name *UnresolvedObjectName,
+) (*types.T, error) {
 	typ, ok := dtr.typeMap[name.String()]
 	if !ok {
 		return nil, errors.Newf("type %q does not exist", name)
@@ -242,7 +247,7 @@ func (dtr *TestingMapTypeResolver) ResolveType(name *UnresolvedObjectName) (*typ
 }
 
 // ResolveTypeByID implements the TypeReferenceResolver interface.
-func (dtr *TestingMapTypeResolver) ResolveTypeByID(uint32) (*types.T, error) {
+func (dtr *TestingMapTypeResolver) ResolveTypeByID(context.Context, uint32) (*types.T, error) {
 	return nil, errors.AssertionFailedf("unimplemented")
 }
 

--- a/pkg/sql/serial.go
+++ b/pkg/sql/serial.go
@@ -89,7 +89,7 @@ func (p *planner) processSerialInColumnDef(
 	// Clear the IsSerial bit now that it's been remapped.
 	newSpec.IsSerial = false
 
-	defType, err := tree.ResolveType(d.Type, p.semaCtx.GetTypeResolver())
+	defType, err := tree.ResolveType(ctx, d.Type, p.semaCtx.GetTypeResolver())
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/pkg/sql/set_transaction.go
+++ b/pkg/sql/set_transaction.go
@@ -11,17 +11,19 @@
 package sql
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
 // SetTransaction sets a transaction's isolation level, priority, ro/rw state,
 // and as of timestamp.
-func (p *planner) SetTransaction(n *tree.SetTransaction) (planNode, error) {
+func (p *planner) SetTransaction(ctx context.Context, n *tree.SetTransaction) (planNode, error) {
 	var asOfTs hlc.Timestamp
 	if n.Modes.AsOf.Expr != nil {
 		var err error
-		asOfTs, err = p.EvalAsOfTimestamp(n.Modes.AsOf)
+		asOfTs, err = p.EvalAsOfTimestamp(ctx, n.Modes.AsOf)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/sqlbase/computed_exprs.go
+++ b/pkg/sql/sqlbase/computed_exprs.go
@@ -11,6 +11,8 @@
 package sqlbase
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -87,6 +89,7 @@ func CannotWriteToComputedColError(colName string) error {
 // and allows type checking of the compute expressions to reference
 // input columns earlier in the slice.
 func MakeComputedExprs(
+	ctx context.Context,
 	cols []ColumnDescriptor,
 	tableDesc *ImmutableTableDescriptor,
 	tn *tree.TableName,
@@ -156,7 +159,7 @@ func MakeComputedExprs(
 			return nil, err
 		}
 
-		typedExpr, err := tree.TypeCheck(expr, &semaCtx, col.Type)
+		typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, col.Type)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/sqlbase/default_exprs.go
+++ b/pkg/sql/sqlbase/default_exprs.go
@@ -11,6 +11,8 @@
 package sqlbase
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -23,7 +25,10 @@ import (
 // For every column that has no default expression, a NULL expression is reported
 // as default.
 func MakeDefaultExprs(
-	cols []ColumnDescriptor, txCtx *transform.ExprTransformContext, evalCtx *tree.EvalContext,
+	ctx context.Context,
+	cols []ColumnDescriptor,
+	txCtx *transform.ExprTransformContext,
+	evalCtx *tree.EvalContext,
 ) ([]tree.TypedExpr, error) {
 	// Check to see if any of the columns have DEFAULT expressions. If there
 	// are no DEFAULT expressions, we don't bother with constructing the
@@ -54,6 +59,7 @@ func MakeDefaultExprs(
 	}
 
 	defExprIdx := 0
+	semaCtx := tree.MakeSemaContext()
 	for i := range cols {
 		col := &cols[i]
 		if col.DefaultExpr == nil {
@@ -61,7 +67,7 @@ func MakeDefaultExprs(
 			continue
 		}
 		expr := exprs[defExprIdx]
-		typedExpr, err := tree.TypeCheck(expr, nil, col.Type)
+		typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, col.Type)
 		if err != nil {
 			return nil, err
 		}
@@ -77,6 +83,7 @@ func MakeDefaultExprs(
 // ProcessDefaultColumns adds columns with DEFAULT to cols if not present
 // and returns the defaultExprs for cols.
 func ProcessDefaultColumns(
+	ctx context.Context,
 	cols []ColumnDescriptor,
 	tableDesc *ImmutableTableDescriptor,
 	txCtx *transform.ExprTransformContext,
@@ -85,7 +92,7 @@ func ProcessDefaultColumns(
 	cols = processColumnSet(cols, tableDesc, func(col *ColumnDescriptor) bool {
 		return col.DefaultExpr != nil
 	})
-	defaultExprs, err := MakeDefaultExprs(cols, txCtx, evalCtx)
+	defaultExprs, err := MakeDefaultExprs(ctx, cols, txCtx, evalCtx)
 	return cols, defaultExprs, err
 }
 

--- a/pkg/sql/sqlbase/roundtrip_format.go
+++ b/pkg/sql/sqlbase/roundtrip_format.go
@@ -50,7 +50,8 @@ func parseAsTyp(evalCtx *tree.EvalContext, typ *types.T, s string) (tree.Datum, 
 	if err != nil {
 		return nil, err
 	}
-	typedExpr, err := tree.TypeCheck(expr, nil, typ)
+	semaCtx := tree.MakeSemaContext()
+	typedExpr, err := tree.TypeCheck(evalCtx.Context, expr, &semaCtx, typ)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/stats/json.go
+++ b/pkg/sql/stats/json.go
@@ -106,7 +106,7 @@ func (js *JSONStatistic) GetHistogram(
 	if err != nil {
 		return nil, err
 	}
-	colType, err := tree.ResolveType(colTypeRef, semaCtx.GetTypeResolver())
+	colType, err := tree.ResolveType(evalCtx.Context, colTypeRef, semaCtx.GetTypeResolver())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -561,7 +561,6 @@ func TestRandomSyntaxSQLSmith(t *testing.T) {
 func TestRandomDatumRoundtrip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	sema := tree.MakeSemaContext()
 	eval := tree.MakeTestingEvalContext(nil)
 
 	var smither *sqlsmith.Smither
@@ -599,6 +598,7 @@ func TestRandomDatumRoundtrip(t *testing.T) {
 		}
 		serializedGen := tree.Serialize(generated)
 
+		sema := tree.MakeSemaContext()
 		// We don't care about errors below because they are often
 		// caused by sqlsmith generating bogus queries. We're just
 		// looking for datums that don't match.
@@ -606,7 +606,7 @@ func TestRandomDatumRoundtrip(t *testing.T) {
 		if err != nil {
 			return nil //nolint:returnerrcheck
 		}
-		typed1, err := parsed1.TypeCheck(&sema, typ)
+		typed1, err := parsed1.TypeCheck(ctx, &sema, typ)
 		if err != nil {
 			return nil //nolint:returnerrcheck
 		}
@@ -620,7 +620,7 @@ func TestRandomDatumRoundtrip(t *testing.T) {
 		if err != nil {
 			return nil //nolint:returnerrcheck
 		}
-		typed2, err := parsed2.TypeCheck(&sema, typ)
+		typed2, err := parsed2.TypeCheck(ctx, &sema, typ)
 		if err != nil {
 			return nil //nolint:returnerrcheck
 		}

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -228,6 +228,7 @@ func (v virtualSchemaView) initVirtualTableDesc(
 		columns = overrideColumnNames(columns, create.ColumnNames)
 	}
 	mutDesc, err := makeViewTableDesc(
+		ctx,
 		create.Name.Table(),
 		tree.AsStringWithFlags(create.AsSource, tree.FmtParsable),
 		0, /* parentID */

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -113,7 +113,7 @@ func (w *windowFuncHolder) String() string { return tree.AsString(w) }
 func (w *windowFuncHolder) Walk(v tree.Visitor) tree.Expr { return w }
 
 func (w *windowFuncHolder) TypeCheck(
-	_ *tree.SemaContext, desired *types.T,
+	_ context.Context, _ *tree.SemaContext, desired *types.T,
 ) (tree.TypedExpr, error) {
 	return w, nil
 }


### PR DESCRIPTION
Fixes #49262.

Currently, our context management for name resolution during
typechecking was not very precise. This PR plumbs contexts into the
SemaContext, which allows the type resolution methods to be
appropriately parameterized with a context.

Release note: None