### PR TITLE
cli: limit flag for debug range-data / debug keys

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -885,6 +885,11 @@ Exclusive end key and format as [<format>:]<key>. Supported formats: raw, hex,
 human, rangeID. The raw format supports escaped text. For example, "raw:\x01k"
 is the prefix for range local keys. The hex format takes an encoded MVCCKey.`}
 
+	Limit = FlagInfo{
+		Name:        "limit",
+		Description: `Maximum number of keys to return.`,
+	}
+
 	Values = FlagInfo{
 		Name:        "values",
 		Description: `Print values along with their associated key.`,

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -105,7 +105,7 @@ func initCLIDefaults() {
 	debugCtx.replicated = false
 	debugCtx.inputFile = ""
 	debugCtx.printSystemConfig = false
-	debugCtx.maxResults = 1000
+	debugCtx.maxResults = 0
 	debugCtx.ballastSize = base.SizeSpec{InBytes: 1000000000}
 
 	serverCfg.GoroutineDumpDirName = ""
@@ -306,7 +306,7 @@ var debugCtx struct {
 	inputFile         string
 	ballastSize       base.SizeSpec
 	printSystemConfig bool
-	maxResults        int64
+	maxResults        int
 }
 
 // startCtx captures the command-line arguments for the `start` command.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -686,12 +686,14 @@ func init() {
 		f := debugKeysCmd.Flags()
 		VarFlag(f, (*mvccKey)(&debugCtx.startKey), cliflags.From)
 		VarFlag(f, (*mvccKey)(&debugCtx.endKey), cliflags.To)
+		IntFlag(f, &debugCtx.maxResults, cliflags.Limit, debugCtx.maxResults)
 		BoolFlag(f, &debugCtx.values, cliflags.Values, debugCtx.values)
 		BoolFlag(f, &debugCtx.sizes, cliflags.Sizes, debugCtx.sizes)
 	}
 	{
 		f := debugRangeDataCmd.Flags()
 		BoolFlag(f, &debugCtx.replicated, cliflags.Replicated, debugCtx.replicated)
+		IntFlag(f, &debugCtx.maxResults, cliflags.Limit, debugCtx.maxResults)
 	}
 	{
 		f := debugGossipValuesCmd.Flags()


### PR DESCRIPTION
There was a teasing maxResults field already, completely unused.

Release note: None