### PR TITLE
sql: enable creation of indexes on tables with user defined types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -585,3 +585,84 @@ enum_checks  CREATE TABLE enum_checks (
              CONSTRAINT check_x CHECK (x = 'hello':::test.public.greeting::test.public.greeting),
              CONSTRAINT "check" CHECK ('hello':::test.public.greeting = 'hello':::test.public.greeting)
 )
+
+subtest schema_changes
+
+# Ensure that we can drop and create indexes on user defined type columns,
+# as well as on other columns when the table has a user defined type column.
+statement ok
+CREATE TABLE sc (x greeting NOT NULL, y int NOT NULL);
+INSERT INTO sc VALUES ('hello', 0), ('howdy', 1), ('hi', 2);
+
+statement ok
+CREATE INDEX i1 ON sc (x);
+CREATE INDEX i2 ON sc (y);
+CREATE INDEX i3 ON sc (x, y)
+
+query T rowsort
+SELECT x FROM sc@i1
+----
+hello
+howdy
+hi
+
+query TI rowsort
+SELECT x, y FROM sc@i3
+----
+hello 0
+howdy 1
+hi 2
+
+statement ok
+DROP INDEX sc@i1;
+DROP INDEX sc@i2;
+DROP INDEX sc@i3
+
+# Test the above, but exercise the schema change in txn code path.
+statement ok
+DROP TABLE sc
+
+statement ok
+BEGIN;
+CREATE TABLE sc (x greeting NOT NULL, y int NOT NULL);
+INSERT INTO sc VALUES ('hello', 0), ('howdy', 1), ('hi', 2);
+CREATE INDEX i1 ON sc (x);
+CREATE INDEX i2 ON sc (y);
+CREATE INDEX i3 ON sc (x, y)
+
+query T rowsort
+SELECT x FROM sc@i1
+----
+hello
+howdy
+hi
+
+query TI rowsort
+SELECT x, y FROM sc@i3
+----
+hello 0
+howdy 1
+hi 2
+
+statement ok
+DROP INDEX sc@i1;
+DROP INDEX sc@i2;
+DROP INDEX sc@i3;
+COMMIT
+
+# Ensure that we can create an index on a table and type created in
+# the same transaction.
+statement ok
+BEGIN;
+CREATE TYPE in_txn AS ENUM ('in', 'txn');
+CREATE TABLE tbl_in_txn (x in_txn);
+INSERT INTO tbl_in_txn VALUES ('txn');
+CREATE INDEX i ON tbl_in_txn (x)
+
+query T
+SELECT * FROM tbl_in_txn@i
+----
+txn
+
+statement ok
+ROLLBACK

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -79,7 +79,11 @@ func newIndexBackfiller(
 	}
 	ib.backfiller.chunks = ib
 
-	if err := ib.IndexBackfiller.Init(flowCtx.NewEvalCtx(), ib.desc); err != nil {
+	// Copy in the DB pointer from flowCtx into evalCtx, because the Init
+	// step needs access to the DB.
+	evalCtx := flowCtx.NewEvalCtx()
+	evalCtx.DB = flowCtx.Cfg.DB
+	if err := ib.IndexBackfiller.Init(evalCtx, ib.desc); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Work for #48728.

This PR teaches the index backfill infrastructure to hydrate types
before use.

Release note: None