### PR TITLE
opt: better name for update columns

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
+++ b/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
@@ -21,51 +21,51 @@ CREATE TABLE t9 (
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE t9 SET b = b + 1 WHERE a = 5
 ----
-·                         distributed  false                      ·                                 ·
-·                         vectorized   false                      ·                                 ·
-count                     ·            ·                          ()                                ·
- └── update               ·            ·                          ()                                ·
-      │                   table        t9                         ·                                 ·
-      │                   set          b                          ·                                 ·
-      │                   strategy     updater                    ·                                 ·
-      │                   auto commit  ·                          ·                                 ·
-      └── render          ·            ·                          (a, b, column11, check1, check2)  ·
-           │              render 0     a                          ·                                 ·
-           │              render 1     b                          ·                                 ·
-           │              render 2     column11                   ·                                 ·
-           │              render 3     a > column11               ·                                 ·
-           │              render 4     d IS NULL                  ·                                 ·
-           └── render     ·            ·                          (column11, a, b, d)               ·
-                │         render 0     b + 1                      ·                                 ·
-                │         render 1     a                          ·                                 ·
-                │         render 2     b                          ·                                 ·
-                │         render 3     d                          ·                                 ·
-                └── scan  ·            ·                          (a, b, d)                         ·
-·                         table        t9@primary                 ·                                 ·
-·                         spans        /5/0-/5/1/2 /5/3/1-/5/3/2  ·                                 ·
-·                         parallel     ·                          ·                                 ·
+·                         distributed  false                      ·                              ·
+·                         vectorized   false                      ·                              ·
+count                     ·            ·                          ()                             ·
+ └── update               ·            ·                          ()                             ·
+      │                   table        t9                         ·                              ·
+      │                   set          b                          ·                              ·
+      │                   strategy     updater                    ·                              ·
+      │                   auto commit  ·                          ·                              ·
+      └── render          ·            ·                          (a, b, b_new, check1, check2)  ·
+           │              render 0     a                          ·                              ·
+           │              render 1     b                          ·                              ·
+           │              render 2     b_new                      ·                              ·
+           │              render 3     a > b_new                  ·                              ·
+           │              render 4     d IS NULL                  ·                              ·
+           └── render     ·            ·                          (b_new, a, b, d)               ·
+                │         render 0     b + 1                      ·                              ·
+                │         render 1     a                          ·                              ·
+                │         render 2     b                          ·                              ·
+                │         render 3     d                          ·                              ·
+                └── scan  ·            ·                          (a, b, d)                      ·
+·                         table        t9@primary                 ·                              ·
+·                         spans        /5/0-/5/1/2 /5/3/1-/5/3/2  ·                              ·
+·                         parallel     ·                          ·                              ·
 
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE t9 SET a = 2 WHERE a = 5
 ----
-·                    distributed       false       ·                                          ·
-·                    vectorized        false       ·                                          ·
-count                ·                 ·           ()                                         ·
- └── update          ·                 ·           ()                                         ·
-      │              table             t9          ·                                          ·
-      │              set               a           ·                                          ·
-      │              strategy          updater     ·                                          ·
-      │              auto commit       ·           ·                                          ·
-      └── render     ·                 ·           (a, b, c, d, e, column11, check1, check2)  ·
-           │         render 0          a           ·                                          ·
-           │         render 1          b           ·                                          ·
-           │         render 2          c           ·                                          ·
-           │         render 3          d           ·                                          ·
-           │         render 4          e           ·                                          ·
-           │         render 5          2           ·                                          ·
-           │         render 6          b < 2       ·                                          ·
-           │         render 7          d IS NULL   ·                                          ·
-           └── scan  ·                 ·           (a, b, c, d, e)                            ·
-·                    table             t9@primary  ·                                          ·
-·                    spans             /5-/5/#     ·                                          ·
-·                    locking strength  for update  ·                                          ·
+·                    distributed       false       ·                                       ·
+·                    vectorized        false       ·                                       ·
+count                ·                 ·           ()                                      ·
+ └── update          ·                 ·           ()                                      ·
+      │              table             t9          ·                                       ·
+      │              set               a           ·                                       ·
+      │              strategy          updater     ·                                       ·
+      │              auto commit       ·           ·                                       ·
+      └── render     ·                 ·           (a, b, c, d, e, a_new, check1, check2)  ·
+           │         render 0          a           ·                                       ·
+           │         render 1          b           ·                                       ·
+           │         render 2          c           ·                                       ·
+           │         render 3          d           ·                                       ·
+           │         render 4          e           ·                                       ·
+           │         render 5          2           ·                                       ·
+           │         render 6          b < 2       ·                                       ·
+           │         render 7          d IS NULL   ·                                       ·
+           └── scan  ·                 ·           (a, b, c, d, e)                         ·
+·                    table             t9@primary  ·                                       ·
+·                    spans             /5-/5/#     ·                                       ·
+·                    locking strength  for update  ·                                       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/enums
+++ b/pkg/sql/opt/exec/execbuilder/testdata/enums
@@ -51,4 +51,3 @@ scan t
       ├── [/'hello' - /'hello']
       └── [/'hi' - /'hi']
 
-

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -719,22 +719,22 @@ count                ·            ·                            ()             
 query TTTTT
 EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123
 ----
-·                    distributed  false                          ·                            ·
-·                    vectorized   false                          ·                            ·
-count                ·            ·                              ()                           ·
- └── update          ·            ·                              ()                           ·
-      │              table        t                              ·                            ·
-      │              set          v                              ·                            ·
-      │              strategy     updater                        ·                            ·
-      │              auto commit  ·                              ·                            ·
-      └── render     ·            ·                              (k int, v int, column5 int)  ·
-           │         render 0     (k)[int]                       ·                            ·
-           │         render 1     (v)[int]                       ·                            ·
-           │         render 2     ((k)[int] + (1)[int])[int]     ·                            ·
-           └── scan  ·            ·                              (k int, v int)               ·
-·                    table        t@primary                      ·                            ·
-·                    spans        FULL SCAN                      ·                            ·
-·                    filter       ((v)[int] > (123)[int])[bool]  ·                            ·
+·                    distributed  false                          ·                          ·
+·                    vectorized   false                          ·                          ·
+count                ·            ·                              ()                         ·
+ └── update          ·            ·                              ()                         ·
+      │              table        t                              ·                          ·
+      │              set          v                              ·                          ·
+      │              strategy     updater                        ·                          ·
+      │              auto commit  ·                              ·                          ·
+      └── render     ·            ·                              (k int, v int, v_new int)  ·
+           │         render 0     (k)[int]                       ·                          ·
+           │         render 1     (v)[int]                       ·                          ·
+           │         render 2     ((k)[int] + (1)[int])[int]     ·                          ·
+           └── scan  ·            ·                              (k int, v int)             ·
+·                    table        t@primary                      ·                          ·
+·                    spans        FULL SCAN                      ·                          ·
+·                    filter       ((v)[int] > (123)[int])[bool]  ·                          ·
 
 query TTTTT
 EXPLAIN (TYPES) VALUES (1) UNION VALUES (2)

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
@@ -358,7 +358,7 @@ root                                       ·                   ·
       └── error if rows                    ·                   ·
            └── hash-join                   ·                   ·
                 │                          type                anti
-                │                          equality            (column5) = (p)
+                │                          equality            (p_new) = (p)
                 │                          right cols are key  ·
                 ├── render                 ·                   ·
                 │    └── scan buffer node  ·                   ·
@@ -390,7 +390,7 @@ root                                       ·                      ·
            └── lookup-join                 ·                      ·
                 │                          table                  parent@primary
                 │                          type                   anti
-                │                          equality               (column5) = (p)
+                │                          equality               (p_new) = (p)
                 │                          equality cols are key  ·
                 │                          parallel               ·
                 └── render                 ·                      ·
@@ -569,7 +569,7 @@ root                                       ·                   ·
       └── error if rows                    ·                   ·
            └── hash-join                   ·                   ·
                 │                          type                anti
-                │                          equality            (column5) = (p)
+                │                          equality            (p_new) = (p)
                 │                          right cols are key  ·
                 ├── render                 ·                   ·
                 │    └── scan buffer node  ·                   ·
@@ -631,7 +631,7 @@ root                                                 ·                   ·
  │    └── error if rows                              ·                   ·
  │         └── hash-join                             ·                   ·
  │              │                                    type                anti
- │              │                                    equality            (column5) = (p)
+ │              │                                    equality            (p_new) = (p)
  │              │                                    right cols are key  ·
  │              ├── render                           ·                   ·
  │              │    └── scan buffer node            ·                   ·
@@ -687,7 +687,7 @@ root                                       ·                   ·
       └── error if rows                    ·                   ·
            └── hash-join                   ·                   ·
                 │                          type                anti
-                │                          equality            (column5) = (p)
+                │                          equality            (p_new) = (p)
                 │                          right cols are key  ·
                 ├── render                 ·                   ·
                 │    └── scan buffer node  ·                   ·
@@ -721,7 +721,7 @@ root                                       ·                   ·
       └── error if rows                    ·                   ·
            └── hash-join                   ·                   ·
                 │                          type                anti
-                │                          equality            (column5) = (x)
+                │                          equality            (y_new) = (x)
                 │                          right cols are key  ·
                 ├── render                 ·                   ·
                 │    └── scan buffer node  ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -600,25 +600,25 @@ render               ·            ·          (b)     ·
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE t SET c = TRUE RETURNING b
 ----
-·                         distributed       false       ·                   ·
-·                         vectorized        false       ·                   ·
-render                    ·                 ·           (b)                 ·
- │                        render 0          b           ·                   ·
- └── run                  ·                 ·           (a, b)              ·
-      └── update          ·                 ·           (a, b)              ·
-           │              table             t           ·                   ·
-           │              set               c           ·                   ·
-           │              strategy          updater     ·                   ·
-           │              auto commit       ·           ·                   ·
-           └── render     ·                 ·           (a, b, c, column7)  ·
-                │         render 0          a           ·                   ·
-                │         render 1          b           ·                   ·
-                │         render 2          c           ·                   ·
-                │         render 3          true        ·                   ·
-                └── scan  ·                 ·           (a, b, c)           ·
-·                         table             t@primary   ·                   ·
-·                         spans             FULL SCAN   ·                   ·
-·                         locking strength  for update  ·                   ·
+·                         distributed       false       ·                 ·
+·                         vectorized        false       ·                 ·
+render                    ·                 ·           (b)               ·
+ │                        render 0          b           ·                 ·
+ └── run                  ·                 ·           (a, b)            ·
+      └── update          ·                 ·           (a, b)            ·
+           │              table             t           ·                 ·
+           │              set               c           ·                 ·
+           │              strategy          updater     ·                 ·
+           │              auto commit       ·           ·                 ·
+           └── render     ·                 ·           (a, b, c, c_new)  ·
+                │         render 0          a           ·                 ·
+                │         render 1          b           ·                 ·
+                │         render 2          c           ·                 ·
+                │         render 3          true        ·                 ·
+                └── scan  ·                 ·           (a, b, c)         ·
+·                         table             t@primary   ·                 ·
+·                         spans             FULL SCAN   ·                 ·
+·                         locking strength  for update  ·                 ·
 
 statement ok
 CREATE TABLE uvwxyz (

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -118,24 +118,24 @@ count                ·                 ·
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (1, 2)
 ----
-·                    distributed       false        ·                            ·
-·                    vectorized        false        ·                            ·
-count                ·                 ·            ()                           ·
- └── update          ·                 ·            ()                           ·
-      │              table             xyz          ·                            ·
-      │              set               x, y         ·                            ·
-      │              strategy          updater      ·                            ·
-      │              auto commit       ·            ·                            ·
-      └── render     ·                 ·            (x, y, z, column7, column8)  ·
-           │         render 0          x            ·                            ·
-           │         render 1          y            ·                            ·
-           │         render 2          z            ·                            ·
-           │         render 3          1            ·                            ·
-           │         render 4          2            ·                            ·
-           └── scan  ·                 ·            (x, y, z)                    ·
-·                    table             xyz@primary  ·                            ·
-·                    spans             FULL SCAN    ·                            ·
-·                    locking strength  for update   ·                            ·
+·                    distributed       false        ·                        ·
+·                    vectorized        false        ·                        ·
+count                ·                 ·            ()                       ·
+ └── update          ·                 ·            ()                       ·
+      │              table             xyz          ·                        ·
+      │              set               x, y         ·                        ·
+      │              strategy          updater      ·                        ·
+      │              auto commit       ·            ·                        ·
+      └── render     ·                 ·            (x, y, z, x_new, y_new)  ·
+           │         render 0          x            ·                        ·
+           │         render 1          y            ·                        ·
+           │         render 2          z            ·                        ·
+           │         render 3          1            ·                        ·
+           │         render 4          2            ·                        ·
+           └── scan  ·                 ·            (x, y, z)                ·
+·                    table             xyz@primary  ·                        ·
+·                    spans             FULL SCAN    ·                        ·
+·                    locking strength  for update   ·                        ·
 
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (y, x)
@@ -162,29 +162,29 @@ count                ·                 ·            ()               ·
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (2, 2)
 ----
-·                         distributed       false        ·                            ·
-·                         vectorized        false        ·                            ·
-count                     ·                 ·            ()                           ·
- └── update               ·                 ·            ()                           ·
-      │                   table             xyz          ·                            ·
-      │                   set               x, y         ·                            ·
-      │                   strategy          updater      ·                            ·
-      │                   auto commit       ·            ·                            ·
-      └── render          ·                 ·            (x, y, z, column7, column7)  ·
-           │              render 0          x            ·                            ·
-           │              render 1          y            ·                            ·
-           │              render 2          z            ·                            ·
-           │              render 3          column7      ·                            ·
-           │              render 4          column7      ·                            ·
-           └── render     ·                 ·            (column7, x, y, z)           ·
-                │         render 0          2            ·                            ·
-                │         render 1          x            ·                            ·
-                │         render 2          y            ·                            ·
-                │         render 3          z            ·                            ·
-                └── scan  ·                 ·            (x, y, z)                    ·
-·                         table             xyz@primary  ·                            ·
-·                         spans             FULL SCAN    ·                            ·
-·                         locking strength  for update   ·                            ·
+·                         distributed       false        ·                        ·
+·                         vectorized        false        ·                        ·
+count                     ·                 ·            ()                       ·
+ └── update               ·                 ·            ()                       ·
+      │                   table             xyz          ·                        ·
+      │                   set               x, y         ·                        ·
+      │                   strategy          updater      ·                        ·
+      │                   auto commit       ·            ·                        ·
+      └── render          ·                 ·            (x, y, z, x_new, x_new)  ·
+           │              render 0          x            ·                        ·
+           │              render 1          y            ·                        ·
+           │              render 2          z            ·                        ·
+           │              render 3          x_new        ·                        ·
+           │              render 4          x_new        ·                        ·
+           └── render     ·                 ·            (x_new, x, y, z)         ·
+                │         render 0          2            ·                        ·
+                │         render 1          x            ·                        ·
+                │         render 2          y            ·                        ·
+                │         render 3          z            ·                        ·
+                └── scan  ·                 ·            (x, y, z)                ·
+·                         table             xyz@primary  ·                        ·
+·                         spans             FULL SCAN    ·                        ·
+·                         locking strength  for update   ·                        ·
 
 statement ok
 CREATE TABLE pks (
@@ -402,27 +402,27 @@ CREATE TABLE t38799 (a INT PRIMARY KEY, b INT, c INT, INDEX foo(b), FAMILY "prim
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE t38799@foo SET c=2 WHERE a=1
 ----
-·                               distributed  false           ·                   ·
-·                               vectorized   false           ·                   ·
-count                           ·            ·               ()                  ·
- └── update                     ·            ·               ()                  ·
-      │                         table        t38799          ·                   ·
-      │                         set          c               ·                   ·
-      │                         strategy     updater         ·                   ·
-      │                         auto commit  ·               ·                   ·
-      └── render                ·            ·               (a, b, c, column7)  ·
-           │                    render 0     a               ·                   ·
-           │                    render 1     b               ·                   ·
-           │                    render 2     c               ·                   ·
-           │                    render 3     2               ·                   ·
-           └── filter           ·            ·               (a, b, c)           ·
-                │               filter       a = 1           ·                   ·
-                └── index-join  ·            ·               (a, b, c)           ·
-                     │          table        t38799@primary  ·                   ·
-                     │          key columns  a               ·                   ·
-                     └── scan   ·            ·               (a, b)              ·
-·                               table        t38799@foo      ·                   ·
-·                               spans        FULL SCAN       ·                   ·
+·                               distributed  false           ·                 ·
+·                               vectorized   false           ·                 ·
+count                           ·            ·               ()                ·
+ └── update                     ·            ·               ()                ·
+      │                         table        t38799          ·                 ·
+      │                         set          c               ·                 ·
+      │                         strategy     updater         ·                 ·
+      │                         auto commit  ·               ·                 ·
+      └── render                ·            ·               (a, b, c, c_new)  ·
+           │                    render 0     a               ·                 ·
+           │                    render 1     b               ·                 ·
+           │                    render 2     c               ·                 ·
+           │                    render 3     2               ·                 ·
+           └── filter           ·            ·               (a, b, c)         ·
+                │               filter       a = 1           ·                 ·
+                └── index-join  ·            ·               (a, b, c)         ·
+                     │          table        t38799@primary  ·                 ·
+                     │          key columns  a               ·                 ·
+                     └── scan   ·            ·               (a, b)            ·
+·                               table        t38799@foo      ·                 ·
+·                               spans        FULL SCAN       ·                 ·
 
 # ------------------------------------------------------------------------------
 # Test without implicit SELECT FOR UPDATE.
@@ -585,23 +585,23 @@ count                ·            ·
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (1, 2)
 ----
-·                    distributed  false        ·                            ·
-·                    vectorized   false        ·                            ·
-count                ·            ·            ()                           ·
- └── update          ·            ·            ()                           ·
-      │              table        xyz          ·                            ·
-      │              set          x, y         ·                            ·
-      │              strategy     updater      ·                            ·
-      │              auto commit  ·            ·                            ·
-      └── render     ·            ·            (x, y, z, column7, column8)  ·
-           │         render 0     x            ·                            ·
-           │         render 1     y            ·                            ·
-           │         render 2     z            ·                            ·
-           │         render 3     1            ·                            ·
-           │         render 4     2            ·                            ·
-           └── scan  ·            ·            (x, y, z)                    ·
-·                    table        xyz@primary  ·                            ·
-·                    spans        FULL SCAN    ·                            ·
+·                    distributed  false        ·                        ·
+·                    vectorized   false        ·                        ·
+count                ·            ·            ()                       ·
+ └── update          ·            ·            ()                       ·
+      │              table        xyz          ·                        ·
+      │              set          x, y         ·                        ·
+      │              strategy     updater      ·                        ·
+      │              auto commit  ·            ·                        ·
+      └── render     ·            ·            (x, y, z, x_new, y_new)  ·
+           │         render 0     x            ·                        ·
+           │         render 1     y            ·                        ·
+           │         render 2     z            ·                        ·
+           │         render 3     1            ·                        ·
+           │         render 4     2            ·                        ·
+           └── scan  ·            ·            (x, y, z)                ·
+·                    table        xyz@primary  ·                        ·
+·                    spans        FULL SCAN    ·                        ·
 
 query TTT
 EXPLAIN UPDATE kv SET v = v - 1 WHERE k < 3 LIMIT 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_from
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_from
@@ -97,35 +97,35 @@ render                          ·                   ·
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE abc SET b = old.b + 1, c = old.c + 2 FROM abc AS old WHERE abc.a = old.a RETURNING *
 ----
-·                          distributed         false        ·                                       ·
-·                          vectorized          false        ·                                       ·
-run                        ·                   ·            (a, b, c, a, b, c)                      ·
- └── update                ·                   ·            (a, b, c, a, b, c)                      ·
-      │                    table               abc          ·                                       ·
-      │                    set                 b, c         ·                                       ·
-      │                    strategy            updater      ·                                       ·
-      │                    auto commit         ·            ·                                       ·
-      └── render           ·                   ·            (a, b, c, column10, column11, a, b, c)  ·
-           │               render 0            a            ·                                       ·
-           │               render 1            b            ·                                       ·
-           │               render 2            c            ·                                       ·
-           │               render 3            b + 1        ·                                       ·
-           │               render 4            c + 2        ·                                       ·
-           │               render 5            a            ·                                       ·
-           │               render 6            b            ·                                       ·
-           │               render 7            c            ·                                       ·
-           └── merge-join  ·                   ·            (a, b, c, a, b, c)                      ·
-                │          type                inner        ·                                       ·
-                │          equality            (a) = (a)    ·                                       ·
-                │          left cols are key   ·            ·                                       ·
-                │          right cols are key  ·            ·                                       ·
-                │          mergeJoinOrder      +"(a=a)"     ·                                       ·
-                ├── scan   ·                   ·            (a, b, c)                               +a
-                │          table               abc@primary  ·                                       ·
-                │          spans               FULL SCAN    ·                                       ·
-                └── scan   ·                   ·            (a, b, c)                               +a
-·                          table               abc@primary  ·                                       ·
-·                          spans               FULL SCAN    ·                                       ·
+·                          distributed         false        ·                                 ·
+·                          vectorized          false        ·                                 ·
+run                        ·                   ·            (a, b, c, a, b, c)                ·
+ └── update                ·                   ·            (a, b, c, a, b, c)                ·
+      │                    table               abc          ·                                 ·
+      │                    set                 b, c         ·                                 ·
+      │                    strategy            updater      ·                                 ·
+      │                    auto commit         ·            ·                                 ·
+      └── render           ·                   ·            (a, b, c, b_new, c_new, a, b, c)  ·
+           │               render 0            a            ·                                 ·
+           │               render 1            b            ·                                 ·
+           │               render 2            c            ·                                 ·
+           │               render 3            b + 1        ·                                 ·
+           │               render 4            c + 2        ·                                 ·
+           │               render 5            a            ·                                 ·
+           │               render 6            b            ·                                 ·
+           │               render 7            c            ·                                 ·
+           └── merge-join  ·                   ·            (a, b, c, a, b, c)                ·
+                │          type                inner        ·                                 ·
+                │          equality            (a) = (a)    ·                                 ·
+                │          left cols are key   ·            ·                                 ·
+                │          right cols are key  ·            ·                                 ·
+                │          mergeJoinOrder      +"(a=a)"     ·                                 ·
+                ├── scan   ·                   ·            (a, b, c)                         +a
+                │          table               abc@primary  ·                                 ·
+                │          spans               FULL SCAN    ·                                 ·
+                └── scan   ·                   ·            (a, b, c)                         +a
+·                          table               abc@primary  ·                                 ·
+·                          spans               FULL SCAN    ·                                 ·
 
 # Update values of table from values expression
 query TTT

--- a/pkg/sql/opt/memo/testdata/logprops/update
+++ b/pkg/sql/opt/memo/testdata/logprops/update
@@ -24,25 +24,25 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) rowid:11(int) e:12(int)
  ├── update-mapping:
- │    ├── column13:13 => b:2
+ │    ├── b_new:13 => b:2
  │    ├── column15:15 => d:4
  │    └── column14:14 => e:6
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: column15:15(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null) column14:14(int!null)
+      ├── columns: column15:15(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) b_new:13(int!null) column14:14(int!null)
       ├── key: (11)
       ├── fd: ()-->(7,13,14), (11)-->(8-10,12), (9)-->(15)
       ├── prune: (7-15)
       ├── interesting orderings: (+11)
       ├── project
-      │    ├── columns: column14:14(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null)
+      │    ├── columns: column14:14(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) b_new:13(int!null)
       │    ├── key: (11)
       │    ├── fd: ()-->(7,13,14), (11)-->(8-10,12)
       │    ├── prune: (7-14)
       │    ├── interesting orderings: (+11)
       │    ├── project
-      │    │    ├── columns: column13:13(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+      │    │    ├── columns: b_new:13(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
       │    │    ├── key: (11)
       │    │    ├── fd: ()-->(7,13), (11)-->(8-10,12)
       │    │    ├── prune: (7-13)
@@ -71,13 +71,13 @@ update abcde
       │    │    │              ├── variable: a:7 [type=int]
       │    │    │              └── const: 1 [type=int]
       │    │    └── projections
-      │    │         └── const: 10 [as=column13:13, type=int]
+      │    │         └── const: 10 [as=b_new:13, type=int]
       │    └── projections
       │         └── const: 0 [as=column14:14, type=int]
       └── projections
            └── plus [as=column15:15, type=int, outer=(9,13)]
                 ├── plus [type=int]
-                │    ├── variable: column13:13 [type=int]
+                │    ├── variable: b_new:13 [type=int]
                 │    └── variable: c:9 [type=int]
                 └── const: 1 [type=int]
 
@@ -94,26 +94,26 @@ project
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null) rowid:5(int!null)
       ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) rowid:11(int) e:12(int)
       ├── update-mapping:
-      │    ├── column13:13 => b:2
+      │    ├── b_new:13 => b:2
       │    ├── column15:15 => d:4
       │    └── column14:14 => e:6
       ├── side-effects, mutations
       ├── key: (5)
       ├── fd: ()-->(1,2), (5)-->(3,4), (3)-->(4)
       └── project
-           ├── columns: column15:15(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null) column14:14(int!null)
+           ├── columns: column15:15(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) b_new:13(int!null) column14:14(int!null)
            ├── key: (11)
            ├── fd: ()-->(7,13,14), (11)-->(8-10,12), (9)-->(15)
            ├── prune: (7-15)
            ├── interesting orderings: (+11)
            ├── project
-           │    ├── columns: column14:14(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null)
+           │    ├── columns: column14:14(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) b_new:13(int!null)
            │    ├── key: (11)
            │    ├── fd: ()-->(7,13,14), (11)-->(8-10,12)
            │    ├── prune: (7-14)
            │    ├── interesting orderings: (+11)
            │    ├── project
-           │    │    ├── columns: column13:13(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+           │    │    ├── columns: b_new:13(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
            │    │    ├── key: (11)
            │    │    ├── fd: ()-->(7,13), (11)-->(8-10,12)
            │    │    ├── prune: (7-13)
@@ -142,13 +142,13 @@ project
            │    │    │              ├── variable: a:7 [type=int]
            │    │    │              └── const: 1 [type=int]
            │    │    └── projections
-           │    │         └── const: 10 [as=column13:13, type=int]
+           │    │         └── const: 10 [as=b_new:13, type=int]
            │    └── projections
            │         └── const: 0 [as=column14:14, type=int]
            └── projections
                 └── plus [as=column15:15, type=int, outer=(9,13)]
                      ├── plus [type=int]
-                     │    ├── variable: column13:13 [type=int]
+                     │    ├── variable: b_new:13 [type=int]
                      │    └── variable: c:9 [type=int]
                      └── const: 1 [type=int]
 
@@ -167,7 +167,7 @@ project
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null) rowid:5(int!null)
       ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) rowid:11(int) e:12(int)
       ├── update-mapping:
-      │    ├── column13:13 => b:2
+      │    ├── b_new:13 => b:2
       │    ├── column15:15 => d:4
       │    └── column14:14 => e:6
       ├── cardinality: [0 - 1]
@@ -175,21 +175,21 @@ project
       ├── key: ()
       ├── fd: ()-->(1-5)
       └── project
-           ├── columns: column15:15(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null) column14:14(int!null)
+           ├── columns: column15:15(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) b_new:13(int!null) column14:14(int!null)
            ├── cardinality: [0 - 1]
            ├── key: ()
            ├── fd: ()-->(7-15)
            ├── prune: (7-15)
            ├── interesting orderings: (+11)
            ├── project
-           │    ├── columns: column14:14(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null)
+           │    ├── columns: column14:14(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) b_new:13(int!null)
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    ├── fd: ()-->(7-14)
            │    ├── prune: (7-14)
            │    ├── interesting orderings: (+11)
            │    ├── project
-           │    │    ├── columns: column13:13(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+           │    │    ├── columns: b_new:13(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
            │    │    ├── cardinality: [0 - 1]
            │    │    ├── key: ()
            │    │    ├── fd: ()-->(7-13)
@@ -220,13 +220,13 @@ project
            │    │    │              ├── variable: rowid:11 [type=int]
            │    │    │              └── const: 1 [type=int]
            │    │    └── projections
-           │    │         └── const: 10 [as=column13:13, type=int]
+           │    │         └── const: 10 [as=b_new:13, type=int]
            │    └── projections
            │         └── const: 0 [as=column14:14, type=int]
            └── projections
                 └── plus [as=column15:15, type=int, outer=(9,13)]
                      ├── plus [type=int]
-                     │    ├── variable: column13:13 [type=int]
+                     │    ├── variable: b_new:13 [type=int]
                      │    └── variable: c:9 [type=int]
                      └── const: 1 [type=int]
 
@@ -243,26 +243,26 @@ project
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null) rowid:5(int!null)
       ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) rowid:11(int) e:12(int)
       ├── update-mapping:
-      │    ├── column13:13 => a:1
+      │    ├── a_new:13 => a:1
       │    ├── column15:15 => d:4
       │    └── column14:14 => e:6
       ├── side-effects, mutations
       ├── key: (5)
       ├── fd: ()-->(1), (2)==(3), (3)==(2), (5)-->(2-4), (2)-->(4)
       └── project
-           ├── columns: column15:15(int!null) a:7(int!null) b:8(int!null) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null) column14:14(int!null)
+           ├── columns: column15:15(int!null) a:7(int!null) b:8(int!null) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) a_new:13(int!null) column14:14(int!null)
            ├── key: (11)
            ├── fd: ()-->(13,14), (11)-->(7-10,12), (8)==(9), (9)==(8), (8,9)-->(15)
            ├── prune: (7-15)
            ├── interesting orderings: (+11)
            ├── project
-           │    ├── columns: column14:14(int!null) a:7(int!null) b:8(int!null) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) column13:13(int!null)
+           │    ├── columns: column14:14(int!null) a:7(int!null) b:8(int!null) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) a_new:13(int!null)
            │    ├── key: (11)
            │    ├── fd: ()-->(13,14), (11)-->(7-10,12), (8)==(9), (9)==(8)
            │    ├── prune: (7-14)
            │    ├── interesting orderings: (+11)
            │    ├── project
-           │    │    ├── columns: column13:13(int!null) a:7(int!null) b:8(int!null) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
+           │    │    ├── columns: a_new:13(int!null) a:7(int!null) b:8(int!null) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
            │    │    ├── key: (11)
            │    │    ├── fd: ()-->(13), (11)-->(7-10,12), (8)==(9), (9)==(8)
            │    │    ├── prune: (7-13)
@@ -291,7 +291,7 @@ project
            │    │    │              ├── variable: b:8 [type=int]
            │    │    │              └── variable: c:9 [type=int]
            │    │    └── projections
-           │    │         └── const: 1 [as=column13:13, type=int]
+           │    │         └── const: 1 [as=a_new:13, type=int]
            │    └── projections
            │         └── const: 0 [as=column14:14, type=int]
            └── projections

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -50,7 +50,7 @@ project
       │    └── upsert_rowid:20 => rowid:4
       ├── side-effects, mutations
       └── project
-           ├── columns: upsert_a:17(int!null) upsert_b:18(int) upsert_c:19(int) upsert_rowid:20(int) x:5(int!null) y:6(int!null) column8:8(int) column9:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int) column14:14(int!null) column15:15(int) column16:16(int)
+           ├── columns: upsert_a:17(int!null) upsert_b:18(int) upsert_c:19(int) upsert_rowid:20(int) x:5(int!null) y:6(int!null) column8:8(int) column9:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int) a_new:14(int!null) b_new:15(int) column16:16(int)
            ├── side-effects
            ├── key: (13)
            ├── fd: ()-->(5,6,8,9,14), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13), (12)-->(15), (15)-->(16), (13)-->(17), (13,15)-->(18), (13,16)-->(19), (13)-->(20)
@@ -58,7 +58,7 @@ project
            ├── reject-nulls: (10-13)
            ├── interesting orderings: (+13) (+10) (+11,+12,+13)
            ├── project
-           │    ├── columns: column16:16(int) x:5(int!null) y:6(int!null) column8:8(int) column9:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int) column14:14(int!null) column15:15(int)
+           │    ├── columns: column16:16(int) x:5(int!null) y:6(int!null) column8:8(int) column9:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int) a_new:14(int!null) b_new:15(int)
            │    ├── side-effects
            │    ├── key: (13)
            │    ├── fd: ()-->(5,6,8,9,14), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13), (12)-->(15), (15)-->(16)
@@ -66,7 +66,7 @@ project
            │    ├── reject-nulls: (10-13)
            │    ├── interesting orderings: (+13) (+10) (+11,+12,+13)
            │    ├── project
-           │    │    ├── columns: column14:14(int!null) column15:15(int) x:5(int!null) y:6(int!null) column8:8(int) column9:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int)
+           │    │    ├── columns: a_new:14(int!null) b_new:15(int) x:5(int!null) y:6(int!null) column8:8(int) column9:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int)
            │    │    ├── side-effects
            │    │    ├── key: (13)
            │    │    ├── fd: ()-->(5,6,8,9,14), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13), (12)-->(15)
@@ -155,13 +155,13 @@ project
            │    │    │              ├── variable: column9:9 [type=int]
            │    │    │              └── variable: c:12 [type=int]
            │    │    └── projections
-           │    │         ├── const: 1 [as=column14:14, type=int]
-           │    │         └── plus [as=column15:15, type=int, outer=(6,12)]
+           │    │         ├── const: 1 [as=a_new:14, type=int]
+           │    │         └── plus [as=b_new:15, type=int, outer=(6,12)]
            │    │              ├── variable: y:6 [type=int]
            │    │              └── variable: c:12 [type=int]
            │    └── projections
            │         └── plus [as=column16:16, type=int, outer=(15)]
-           │              ├── variable: column15:15 [type=int]
+           │              ├── variable: b_new:15 [type=int]
            │              └── const: 1 [type=int]
            └── projections
                 ├── case [as=upsert_a:17, type=int, outer=(5,13,14)]
@@ -171,7 +171,7 @@ project
                 │    │    │    ├── variable: rowid:13 [type=int]
                 │    │    │    └── null [type=unknown]
                 │    │    └── variable: x:5 [type=int]
-                │    └── variable: column14:14 [type=int]
+                │    └── variable: a_new:14 [type=int]
                 ├── case [as=upsert_b:18, type=int, outer=(6,13,15)]
                 │    ├── true [type=bool]
                 │    ├── when [type=int]
@@ -179,7 +179,7 @@ project
                 │    │    │    ├── variable: rowid:13 [type=int]
                 │    │    │    └── null [type=unknown]
                 │    │    └── variable: y:6 [type=int]
-                │    └── variable: column15:15 [type=int]
+                │    └── variable: b_new:15 [type=int]
                 ├── case [as=upsert_c:19, type=int, outer=(9,13,16)]
                 │    ├── true [type=bool]
                 │    ├── when [type=int]
@@ -583,7 +583,7 @@ upsert abc
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: upsert_a:17(int) upsert_b:18(int!null) upsert_c:19(int!null) upsert_rowid:20(int) y:6(int!null) column8:8(int!null) column9:9(int) column10:10(int!null) a:11(int) b:12(int) c:13(int) rowid:14(int) column15:15(int!null) column16:16(int!null)
+      ├── columns: upsert_a:17(int) upsert_b:18(int!null) upsert_c:19(int!null) upsert_rowid:20(int) y:6(int!null) column8:8(int!null) column9:9(int) column10:10(int!null) a:11(int) b:12(int) c:13(int) rowid:14(int) b_new:15(int!null) column16:16(int!null)
       ├── side-effects
       ├── key: (6,14)
       ├── fd: ()-->(8,10,15,16), (6)-->(9), (14)-->(11-13), (11)-->(12-14), (12,13)~~>(11,14), (6,11,14)-->(17), (14)-->(18), (14)-->(19), (9,14)-->(20)
@@ -591,7 +591,7 @@ upsert abc
       ├── reject-nulls: (11-14)
       ├── interesting orderings: (+14) (+11) (+12,+13,+14)
       ├── project
-      │    ├── columns: column16:16(int!null) y:6(int!null) column8:8(int!null) column9:9(int) column10:10(int!null) a:11(int) b:12(int) c:13(int) rowid:14(int) column15:15(int!null)
+      │    ├── columns: column16:16(int!null) y:6(int!null) column8:8(int!null) column9:9(int) column10:10(int!null) a:11(int) b:12(int) c:13(int) rowid:14(int) b_new:15(int!null)
       │    ├── side-effects
       │    ├── key: (6,14)
       │    ├── fd: ()-->(8,10,15,16), (6)-->(9), (14)-->(11-13), (11)-->(12-14), (12,13)~~>(11,14)
@@ -599,7 +599,7 @@ upsert abc
       │    ├── reject-nulls: (11-14)
       │    ├── interesting orderings: (+14) (+11) (+12,+13,+14)
       │    ├── project
-      │    │    ├── columns: column15:15(int!null) y:6(int!null) column8:8(int!null) column9:9(int) column10:10(int!null) a:11(int) b:12(int) c:13(int) rowid:14(int)
+      │    │    ├── columns: b_new:15(int!null) y:6(int!null) column8:8(int!null) column9:9(int) column10:10(int!null) a:11(int) b:12(int) c:13(int) rowid:14(int)
       │    │    ├── side-effects
       │    │    ├── key: (6,14)
       │    │    ├── fd: ()-->(8,10,15), (6)-->(9), (14)-->(11-13), (11)-->(12-14), (12,13)~~>(11,14)
@@ -683,10 +683,10 @@ upsert abc
       │    │    │              ├── variable: y:6 [type=int]
       │    │    │              └── variable: a:11 [type=int]
       │    │    └── projections
-      │    │         └── const: 2 [as=column15:15, type=int]
+      │    │         └── const: 2 [as=b_new:15, type=int]
       │    └── projections
       │         └── plus [as=column16:16, type=int, outer=(15)]
-      │              ├── variable: column15:15 [type=int]
+      │              ├── variable: b_new:15 [type=int]
       │              └── const: 1 [type=int]
       └── projections
            ├── case [as=upsert_a:17, type=int, outer=(6,11,14)]
@@ -704,7 +704,7 @@ upsert abc
            │    │    │    ├── variable: rowid:14 [type=int]
            │    │    │    └── null [type=unknown]
            │    │    └── variable: column8:8 [type=int]
-           │    └── variable: column15:15 [type=int]
+           │    └── variable: b_new:15 [type=int]
            ├── case [as=upsert_c:19, type=int, outer=(10,14,16)]
            │    ├── true [type=bool]
            │    ├── when [type=int]

--- a/pkg/sql/opt/memo/testdata/stats/update
+++ b/pkg/sql/opt/memo/testdata/stats/update
@@ -48,13 +48,13 @@ with &1
  │    ├── columns: xyz.x:1(string!null) xyz.y:2(int!null) xyz.z:3(float!null)
  │    ├── fetch columns: xyz.x:4(string) xyz.y:5(int) xyz.z:6(float)
  │    ├── update-mapping:
- │    │    └── column7:7 => xyz.y:2
+ │    │    └── y_new:7 => xyz.y:2
  │    ├── side-effects, mutations
  │    ├── stats: [rows=10]
  │    ├── key: (1)
  │    ├── fd: ()-->(2,3)
  │    └── project
- │         ├── columns: column7:7(int!null) xyz.x:4(string!null) xyz.y:5(int!null) xyz.z:6(float!null)
+ │         ├── columns: y_new:7(int!null) xyz.x:4(string!null) xyz.y:5(int!null) xyz.z:6(float!null)
  │         ├── stats: [rows=10]
  │         ├── key: (4)
  │         ├── fd: ()-->(6,7), (4)-->(5)
@@ -71,7 +71,7 @@ with &1
  │         │    └── filters
  │         │         └── xyz.z:6 = 5.5 [type=bool, outer=(6), constraints=(/6: [/5.5 - /5.5]; tight), fd=()-->(6)]
  │         └── projections
- │              └── 5 [as=column7:7, type=int]
+ │              └── 5 [as=y_new:7, type=int]
  └── select
       ├── columns: x:8(string!null) y:9(int!null) z:10(float!null)
       ├── stats: [rows=3.33333333, distinct(8)=3.33333333, null(8)=0]
@@ -97,13 +97,13 @@ update xyz
  ├── columns: x:1(string!null) y:2(int!null) z:3(float)
  ├── fetch columns: x:4(string) y:5(int) z:6(float)
  ├── update-mapping:
- │    └── column7:7 => x:1
+ │    └── x_new:7 => x:1
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  ├── stats: [rows=0]
  ├── fd: ()-->(1)
  └── project
-      ├── columns: column7:7(string!null) x:4(string!null) y:5(int!null) z:6(float)
+      ├── columns: x_new:7(string!null) x:4(string!null) y:5(int!null) z:6(float)
       ├── cardinality: [0 - 0]
       ├── stats: [rows=0]
       ├── key: (4)
@@ -122,4 +122,4 @@ update xyz
       │    └── filters
       │         └── false [type=bool]
       └── projections
-           └── 'foo' [as=column7:7, type=string]
+           └── 'foo' [as=x_new:7, type=string]

--- a/pkg/sql/opt/memo/testdata/stats/upsert
+++ b/pkg/sql/opt/memo/testdata/stats/upsert
@@ -110,12 +110,12 @@ with &1
  │    ├── side-effects, mutations
  │    ├── stats: [rows=9.94974874]
  │    └── project
- │         ├── columns: upsert_x:13(string) upsert_y:14(int!null) upsert_z:15(float) a:4(int!null) b:5(string) column8:8(float) xyz.x:9(string) xyz.y:10(int) xyz.z:11(float) column12:12(int!null)
+ │         ├── columns: upsert_x:13(string) upsert_y:14(int!null) upsert_z:15(float) a:4(int!null) b:5(string) column8:8(float) xyz.x:9(string) xyz.y:10(int) xyz.z:11(float) y_new:12(int!null)
  │         ├── stats: [rows=9.94974874]
  │         ├── lax-key: (5,9)
  │         ├── fd: ()-->(8,12), (5)~~>(4), (9)-->(10,11), (5,9)-->(13), (4,9)-->(14), (5,9)~~>(4,14,15)
  │         ├── project
- │         │    ├── columns: column12:12(int!null) a:4(int!null) b:5(string) column8:8(float) xyz.x:9(string) xyz.y:10(int) xyz.z:11(float)
+ │         │    ├── columns: y_new:12(int!null) a:4(int!null) b:5(string) column8:8(float) xyz.x:9(string) xyz.y:10(int) xyz.z:11(float)
  │         │    ├── stats: [rows=9.94974874]
  │         │    ├── lax-key: (5,9)
  │         │    ├── fd: ()-->(8,12), (5)~~>(4), (9)-->(10,11)
@@ -168,10 +168,10 @@ with &1
  │         │    │    └── filters
  │         │    │         └── b:5 = xyz.x:9 [type=bool, outer=(5,9), constraints=(/5: (/NULL - ]; /9: (/NULL - ]), fd=(5)==(9), (9)==(5)]
  │         │    └── projections
- │         │         └── 5 [as=column12:12, type=int]
+ │         │         └── 5 [as=y_new:12, type=int]
  │         └── projections
  │              ├── CASE WHEN xyz.x:9 IS NULL THEN b:5 ELSE xyz.x:9 END [as=upsert_x:13, type=string, outer=(5,9)]
- │              ├── CASE WHEN xyz.x:9 IS NULL THEN a:4 ELSE column12:12 END [as=upsert_y:14, type=int, outer=(4,9,12)]
+ │              ├── CASE WHEN xyz.x:9 IS NULL THEN a:4 ELSE y_new:12 END [as=upsert_y:14, type=int, outer=(4,9,12)]
  │              └── CASE WHEN xyz.x:9 IS NULL THEN column8:8 ELSE xyz.z:11 END [as=upsert_z:15, type=float, outer=(8,9,11)]
  └── select
       ├── columns: x:16(string!null) y:17(int!null) z:18(float)
@@ -249,13 +249,13 @@ upsert uv
  ├── side-effects, mutations
  ├── stats: [rows=0]
  └── project
-      ├── columns: upsert_u:11(int) upsert_v:12(int) z:6(int) column7:7(int) u:8(int) v:9(int) column10:10(int!null)
+      ├── columns: upsert_u:11(int) upsert_v:12(int) z:6(int) column7:7(int) u:8(int) v:9(int) v_new:10(int!null)
       ├── side-effects
       ├── stats: [rows=1000]
       ├── lax-key: (6,8)
       ├── fd: ()-->(10), (6)~~>(7), (8)-->(9), (9)~~>(8), (7,8)-->(11), (6,8)-->(12), (6,8)~~>(7,11)
       ├── project
-      │    ├── columns: column10:10(int!null) z:6(int) column7:7(int) u:8(int) v:9(int)
+      │    ├── columns: v_new:10(int!null) z:6(int) column7:7(int) u:8(int) v:9(int)
       │    ├── side-effects
       │    ├── stats: [rows=1000]
       │    ├── lax-key: (6,8)
@@ -301,10 +301,10 @@ upsert uv
       │    │    └── filters
       │    │         └── z:6 = v:9 [type=bool, outer=(6,9), constraints=(/6: (/NULL - ]; /9: (/NULL - ]), fd=(6)==(9), (9)==(6)]
       │    └── projections
-      │         └── 1 [as=column10:10, type=int]
+      │         └── 1 [as=v_new:10, type=int]
       └── projections
            ├── CASE WHEN u:8 IS NULL THEN column7:7 ELSE u:8 END [as=upsert_u:11, type=int, outer=(7,8)]
-           └── CASE WHEN u:8 IS NULL THEN z:6 ELSE column10:10 END [as=upsert_v:12, type=int, outer=(6,8,10)]
+           └── CASE WHEN u:8 IS NULL THEN z:6 ELSE v_new:10 END [as=upsert_v:12, type=int, outer=(6,8,10)]
 
 # Multiple conflict columns.
 # TODO(andyk): The null counts for the left join are surprisingly high. It's due
@@ -331,12 +331,12 @@ upsert mno
  ├── side-effects, mutations
  ├── stats: [rows=0]
  └── project
-      ├── columns: upsert_m:11(int) upsert_n:12(int) upsert_o:13(int) m:4(int!null) n:5(int) o:6(int) m:7(int) n:8(int) o:9(int) column10:10(int!null)
+      ├── columns: upsert_m:11(int) upsert_n:12(int) upsert_o:13(int) m:4(int!null) n:5(int) o:6(int) m:7(int) n:8(int) o:9(int) o_new:10(int!null)
       ├── stats: [rows=2000]
       ├── key: (4,7)
       ├── fd: ()-->(10), (4)-->(5,6), (5,6)~~>(4), (7)-->(8,9), (8,9)~~>(7), (4,7)-->(11), (5,7,8)-->(12), (6,7)-->(13)
       ├── project
-      │    ├── columns: column10:10(int!null) m:4(int!null) n:5(int) o:6(int) m:7(int) n:8(int) o:9(int)
+      │    ├── columns: o_new:10(int!null) m:4(int!null) n:5(int) o:6(int) m:7(int) n:8(int) o:9(int)
       │    ├── stats: [rows=2000]
       │    ├── key: (4,7)
       │    ├── fd: ()-->(10), (4)-->(5,6), (5,6)~~>(4), (7)-->(8,9), (8,9)~~>(7)
@@ -369,8 +369,8 @@ upsert mno
       │    │         ├── n:5 = n:8 [type=bool, outer=(5,8), constraints=(/5: (/NULL - ]; /8: (/NULL - ]), fd=(5)==(8), (8)==(5)]
       │    │         └── o:6 = o:9 [type=bool, outer=(6,9), constraints=(/6: (/NULL - ]; /9: (/NULL - ]), fd=(6)==(9), (9)==(6)]
       │    └── projections
-      │         └── 5 [as=column10:10, type=int]
+      │         └── 5 [as=o_new:10, type=int]
       └── projections
            ├── CASE WHEN m:7 IS NULL THEN m:4 ELSE m:7 END [as=upsert_m:11, type=int, outer=(4,7)]
            ├── CASE WHEN m:7 IS NULL THEN n:5 ELSE n:8 END [as=upsert_n:12, type=int, outer=(5,7,8)]
-           └── CASE WHEN m:7 IS NULL THEN o:6 ELSE column10:10 END [as=upsert_o:13, type=int, outer=(6,7,10)]
+           └── CASE WHEN m:7 IS NULL THEN o:6 ELSE o_new:10 END [as=upsert_o:13, type=int, outer=(6,7,10)]

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -166,13 +166,13 @@ update computed
  ├── columns: <none>
  ├── fetch columns: a:4 b:5 c:6
  ├── update-mapping:
- │    ├── column7:7 => a:1
- │    ├── column8:8 => b:2
+ │    ├── a_new:7 => a:1
+ │    ├── b_new:8 => b:2
  │    └── column9:9 => c:3
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: column9:9!null column7:7!null column8:8!null a:4!null b:5 c:6
+      ├── columns: column9:9!null a_new:7!null b_new:8!null a:4!null b:5 c:6
       ├── key: (4)
       ├── fd: ()-->(7-9), (4)-->(5,6)
       ├── scan computed
@@ -184,8 +184,8 @@ update computed
       │    └── fd: (4)-->(5,6)
       └── projections
            ├── 4 [as=column9:9]
-           ├── 1 [as=column7:7]
-           └── 2 [as=column8:8]
+           ├── 1 [as=a_new:7]
+           └── 2 [as=b_new:8]
 
 # Inline constants from Values expression.
 norm expect=InlineProjectConstants

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -1901,11 +1901,11 @@ update "family"
  ├── columns: <none>
  ├── fetch columns: a:6 b:7 c:8 d:9 e:10
  ├── update-mapping:
- │    └── column11:11 => a:1
+ │    └── a_new:11 => a:1
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: column11:11!null a:6!null b:7 c:8 d:9 e:10
+      ├── columns: a_new:11!null a:6!null b:7 c:8 d:9 e:10
       ├── key: (6)
       ├── fd: (6)-->(7-11)
       ├── select
@@ -1919,7 +1919,7 @@ update "family"
       │    └── filters
       │         └── a:6 > 100 [outer=(6), constraints=(/6: [/101 - ]; tight)]
       └── projections
-           └── a:6 + 1 [as=column11:11, outer=(6)]
+           └── a:6 + 1 [as=a_new:11, outer=(6)]
 
 # Do not prune columns that must be returned.
 norm expect=(PruneMutationFetchCols, PruneMutationReturnCols)
@@ -1932,12 +1932,12 @@ project
       ├── columns: a:1!null b:2
       ├── fetch columns: a:6 b:7 c:8 d:9
       ├── update-mapping:
-      │    └── column11:11 => c:3
+      │    └── c_new:11 => c:3
       ├── side-effects, mutations
       ├── key: (1)
       ├── fd: (1)-->(2)
       └── project
-           ├── columns: column11:11 a:6!null b:7 c:8 d:9
+           ├── columns: c_new:11 a:6!null b:7 c:8 d:9
            ├── key: (6)
            ├── fd: (6)-->(7-9), (8)-->(11)
            ├── scan "family"
@@ -1945,7 +1945,7 @@ project
            │    ├── key: (6)
            │    └── fd: (6)-->(7-9)
            └── projections
-                └── c:8 + 1 [as=column11:11, outer=(8)]
+                └── c:8 + 1 [as=c_new:11, outer=(8)]
 
 # Prune unused upsert columns.
 norm expect=PruneMutationInputCols
@@ -2289,12 +2289,12 @@ project
       ├── columns: a:1 b:2 c:3 d:4 e:5 f:6 g:7 rowid:8!null
       ├── fetch columns: a:9 b:10 c:11 d:12 e:13 f:14 g:15 rowid:16
       ├── update-mapping:
-      │    └── column17:17 => a:1
+      │    └── a_new:17 => a:1
       ├── side-effects, mutations
       ├── key: (8)
       ├── fd: (8)-->(1-7)
       └── project
-           ├── columns: column17:17 a:9 b:10 c:11 d:12 e:13 f:14 g:15 rowid:16!null
+           ├── columns: a_new:17 a:9 b:10 c:11 d:12 e:13 f:14 g:15 rowid:16!null
            ├── key: (16)
            ├── fd: (16)-->(9-15), (9)~~>(10-16), (9)-->(17)
            ├── scan returning_test
@@ -2302,7 +2302,7 @@ project
            │    ├── key: (16)
            │    └── fd: (16)-->(9-15), (9)~~>(10-16)
            └── projections
-                └── a:9 + 1 [as=column17:17, outer=(9)]
+                └── a:9 + 1 [as=a_new:17, outer=(9)]
 
 
 # Fetch all the columns in the (d, e, f, g) family as d is being set.
@@ -2318,12 +2318,12 @@ project
       ├── columns: a:1 d:4 rowid:8!null
       ├── fetch columns: a:9 d:12 e:13 f:14 g:15 rowid:16
       ├── update-mapping:
-      │    └── column17:17 => d:4
+      │    └── d_new:17 => d:4
       ├── side-effects, mutations
       ├── key: (8)
       ├── fd: (8)-->(1,4), (1)~~>(4,8)
       └── project
-           ├── columns: column17:17 a:9 d:12 e:13 f:14 g:15 rowid:16!null
+           ├── columns: d_new:17 a:9 d:12 e:13 f:14 g:15 rowid:16!null
            ├── key: (16)
            ├── fd: (16)-->(9,12-15), (9)~~>(12-16), (9,12)-->(17)
            ├── scan returning_test
@@ -2331,7 +2331,7 @@ project
            │    ├── key: (16)
            │    └── fd: (16)-->(9,12-15), (9)~~>(12-16)
            └── projections
-                └── a:9 + d:12 [as=column17:17, outer=(9,12)]
+                └── a:9 + d:12 [as=d_new:17, outer=(9,12)]
 
 # Fetch only whats being updated (not the (d, e, f, g) family).
 norm
@@ -2344,12 +2344,12 @@ project
       ├── columns: a:1 rowid:8!null
       ├── fetch columns: a:9 rowid:16
       ├── update-mapping:
-      │    └── column17:17 => a:1
+      │    └── a_new:17 => a:1
       ├── side-effects, mutations
       ├── key: (8)
       ├── fd: (8)-->(1)
       └── project
-           ├── columns: column17:17 a:9 rowid:16!null
+           ├── columns: a_new:17 a:9 rowid:16!null
            ├── key: (16)
            ├── fd: (16)-->(9,17), (9)~~>(16,17)
            ├── scan returning_test
@@ -2357,7 +2357,7 @@ project
            │    ├── key: (16)
            │    └── fd: (16)-->(9,12), (9)~~>(12,16)
            └── projections
-                └── a:9 + d:12 [as=column17:17, outer=(9,12)]
+                └── a:9 + d:12 [as=a_new:17, outer=(9,12)]
 
 # We only fetch the minimal set of columns which is (a, b, c, rowid).
 norm
@@ -2372,13 +2372,13 @@ project
       ├── columns: a:1 b:2 c:3 rowid:8!null
       ├── fetch columns: a:9 b:10 c:11 rowid:16
       ├── update-mapping:
-      │    ├── column17:17 => a:1
+      │    ├── a_new:17 => a:1
       │    └── a:9 => b:2
       ├── side-effects, mutations
       ├── key: (8)
       ├── fd: (8)-->(1-3), (2)~~>(1,3,8)
       └── project
-           ├── columns: column17:17 a:9 b:10 c:11 rowid:16!null
+           ├── columns: a_new:17 a:9 b:10 c:11 rowid:16!null
            ├── key: (16)
            ├── fd: (16)-->(9-11), (9)~~>(10,11,16), (9,10)-->(17)
            ├── scan returning_test
@@ -2386,7 +2386,7 @@ project
            │    ├── key: (16)
            │    └── fd: (16)-->(9-11), (9)~~>(10,11,16)
            └── projections
-                └── a:9 + b:10 [as=column17:17, outer=(9,10)]
+                └── a:9 + b:10 [as=a_new:17, outer=(9,10)]
 
 
 # We apply the PruneMutationReturnCols rule multiple times, to get
@@ -2405,12 +2405,12 @@ with &1
  │         ├── columns: returning_test.a:1 returning_test.b:2 returning_test.c:3 rowid:8!null
  │         ├── fetch columns: returning_test.a:9 returning_test.b:10 returning_test.c:11 rowid:16
  │         ├── update-mapping:
- │         │    └── column17:17 => returning_test.a:1
+ │         │    └── a_new:17 => returning_test.a:1
  │         ├── side-effects, mutations
  │         ├── key: (8)
  │         ├── fd: (8)-->(1-3)
  │         └── project
- │              ├── columns: column17:17 returning_test.a:9 returning_test.b:10 returning_test.c:11 rowid:16!null
+ │              ├── columns: a_new:17 returning_test.a:9 returning_test.b:10 returning_test.c:11 rowid:16!null
  │              ├── key: (16)
  │              ├── fd: (16)-->(9-11), (9)~~>(10,11,16), (9)-->(17)
  │              ├── scan returning_test
@@ -2418,7 +2418,7 @@ with &1
  │              │    ├── key: (16)
  │              │    └── fd: (16)-->(9-11), (9)~~>(10,11,16)
  │              └── projections
- │                   └── returning_test.a:9 + 1 [as=column17:17, outer=(9)]
+ │                   └── returning_test.a:9 + 1 [as=a_new:17, outer=(9)]
  └── project
       ├── columns: a:21
       ├── with-scan &1
@@ -2445,12 +2445,12 @@ with &1
  │         ├── columns: returning_test.a:1 returning_test.b:2 returning_test.c:3 rowid:8!null
  │         ├── fetch columns: returning_test.a:9 returning_test.b:10 returning_test.c:11 rowid:16
  │         ├── update-mapping:
- │         │    └── column17:17 => returning_test.a:1
+ │         │    └── a_new:17 => returning_test.a:1
  │         ├── side-effects, mutations
  │         ├── key: (8)
  │         ├── fd: (8)-->(1-3)
  │         └── project
- │              ├── columns: column17:17 returning_test.a:9 returning_test.b:10 returning_test.c:11 rowid:16!null
+ │              ├── columns: a_new:17 returning_test.a:9 returning_test.b:10 returning_test.c:11 rowid:16!null
  │              ├── key: (16)
  │              ├── fd: (16)-->(9-11), (9)~~>(10,11,16), (9)-->(17)
  │              ├── scan returning_test
@@ -2458,7 +2458,7 @@ with &1
  │              │    ├── key: (16)
  │              │    └── fd: (16)-->(9-11), (9)~~>(10,11,16)
  │              └── projections
- │                   └── returning_test.a:9 + 1 [as=column17:17, outer=(9)]
+ │                   └── returning_test.a:9 + 1 [as=a_new:17, outer=(9)]
  └── project
       ├── columns: a:21!null
       ├── select
@@ -2491,12 +2491,12 @@ with &2
  │         ├── columns: returning_test.a:11 returning_test.b:12 returning_test.c:13 rowid:18!null
  │         ├── fetch columns: returning_test.a:19 returning_test.b:20 returning_test.c:21 rowid:26
  │         ├── update-mapping:
- │         │    └── column27:27 => returning_test.a:11
+ │         │    └── a_new:27 => returning_test.a:11
  │         ├── side-effects, mutations
  │         ├── key: (18)
  │         ├── fd: (18)-->(11-13)
  │         └── project
- │              ├── columns: column27:27 returning_test.a:19 returning_test.b:20 returning_test.c:21 rowid:26!null
+ │              ├── columns: a_new:27 returning_test.a:19 returning_test.b:20 returning_test.c:21 rowid:26!null
  │              ├── key: (26)
  │              ├── fd: (26)-->(19-21), (19)~~>(20,21,26), (19)-->(27)
  │              ├── scan returning_test
@@ -2504,7 +2504,7 @@ with &2
  │              │    ├── key: (26)
  │              │    └── fd: (26)-->(19-21), (19)~~>(20,21,26)
  │              └── projections
- │                   └── returning_test.a:19 + 1 [as=column27:27, outer=(19)]
+ │                   └── returning_test.a:19 + 1 [as=a_new:27, outer=(19)]
  └── inner-join (cross)
       ├── columns: a:9 b:10 a:31!null b:32
       ├── fd: (9)~~>(10)

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-update
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-update
@@ -13,26 +13,26 @@ update child
  ├── columns: <none>
  ├── fetch columns: c:3 child.p:4
  ├── update-mapping:
- │    └── column5:5 => child.p:2
+ │    └── p_new:5 => child.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: column5:5!null c:3!null child.p:4!null
+ │    ├── columns: p_new:5!null c:3!null child.p:4!null
  │    ├── scan child
  │    │    └── columns: c:3!null child.p:4!null
  │    └── projections
- │         └── 4 [as=column5:5]
+ │         └── 4 [as=p_new:5]
  └── f-k-checks
       └── f-k-checks-item: child(p) -> parent(p)
            └── anti-join (hash)
-                ├── columns: column5:6!null
+                ├── columns: p_new:6!null
                 ├── with-scan &1
-                │    ├── columns: column5:6!null
+                │    ├── columns: p_new:6!null
                 │    └── mapping:
-                │         └──  column5:5 => column5:6
+                │         └──  p_new:5 => p_new:6
                 ├── scan parent
                 │    └── columns: parent.p:8!null
                 └── filters
-                     └── column5:6 = parent.p:8
+                     └── p_new:6 = parent.p:8
 
 build
 UPDATE parent SET p = p+1
@@ -41,14 +41,14 @@ update parent
  ├── columns: <none>
  ├── fetch columns: x:4 parent.p:5 other:6
  ├── update-mapping:
- │    └── column7:7 => parent.p:2
+ │    └── p_new:7 => parent.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: column7:7!null x:4 parent.p:5!null other:6
+ │    ├── columns: p_new:7!null x:4 parent.p:5!null other:6
  │    ├── scan parent
  │    │    └── columns: x:4 parent.p:5!null other:6
  │    └── projections
- │         └── parent.p:5 + 1 [as=column7:7]
+ │         └── parent.p:5 + 1 [as=p_new:7]
  └── f-k-checks
       └── f-k-checks-item: child(p) -> parent(p)
            └── semi-join (hash)
@@ -56,15 +56,15 @@ update parent
                 ├── except
                 │    ├── columns: p:8!null
                 │    ├── left columns: p:8!null
-                │    ├── right columns: column7:9
+                │    ├── right columns: p_new:9
                 │    ├── with-scan &1
                 │    │    ├── columns: p:8!null
                 │    │    └── mapping:
                 │    │         └──  parent.p:5 => p:8
                 │    └── with-scan &1
-                │         ├── columns: column7:9!null
+                │         ├── columns: p_new:9!null
                 │         └── mapping:
-                │              └──  column7:7 => column7:9
+                │              └──  p_new:7 => p_new:9
                 ├── scan child
                 │    └── columns: child.p:11!null
                 └── filters
@@ -81,14 +81,14 @@ update child
  ├── columns: <none>
  ├── fetch columns: child.c:3 p:4
  ├── update-mapping:
- │    └── column5:5 => child.c:1
+ │    └── c_new:5 => child.c:1
  ├── input binding: &1
  ├── project
- │    ├── columns: column5:5!null child.c:3!null p:4!null
+ │    ├── columns: c_new:5!null child.c:3!null p:4!null
  │    ├── scan child
  │    │    └── columns: child.c:3!null p:4!null
  │    └── projections
- │         └── 4 [as=column5:5]
+ │         └── 4 [as=c_new:5]
  └── f-k-checks
       └── f-k-checks-item: grandchild(c) -> child(c)
            └── semi-join (hash)
@@ -96,15 +96,15 @@ update child
                 ├── except
                 │    ├── columns: c:6!null
                 │    ├── left columns: c:6!null
-                │    ├── right columns: column5:7
+                │    ├── right columns: c_new:7
                 │    ├── with-scan &1
                 │    │    ├── columns: c:6!null
                 │    │    └── mapping:
                 │    │         └──  child.c:3 => c:6
                 │    └── with-scan &1
-                │         ├── columns: column5:7!null
+                │         ├── columns: c_new:7!null
                 │         └── mapping:
-                │              └──  column5:5 => column5:7
+                │              └──  c_new:5 => c_new:7
                 ├── scan grandchild
                 │    └── columns: grandchild.c:9!null
                 └── filters
@@ -118,26 +118,26 @@ update child
  ├── columns: <none>
  ├── fetch columns: c:3 child.p:4
  ├── update-mapping:
- │    └── column5:5 => child.p:2
+ │    └── p_new:5 => child.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: column5:5!null c:3!null child.p:4!null
+ │    ├── columns: p_new:5!null c:3!null child.p:4!null
  │    ├── scan child
  │    │    └── columns: c:3!null child.p:4!null
  │    └── projections
- │         └── 4 [as=column5:5]
+ │         └── 4 [as=p_new:5]
  └── f-k-checks
       └── f-k-checks-item: child(p) -> parent(p)
            └── anti-join (hash)
-                ├── columns: column5:6!null
+                ├── columns: p_new:6!null
                 ├── with-scan &1
-                │    ├── columns: column5:6!null
+                │    ├── columns: p_new:6!null
                 │    └── mapping:
-                │         └──  column5:5 => column5:6
+                │         └──  p_new:5 => p_new:6
                 ├── scan parent
                 │    └── columns: parent.p:8!null
                 └── filters
-                     └── column5:6 = parent.p:8
+                     └── p_new:6 = parent.p:8
 
 build
 UPDATE child SET p = p
@@ -170,43 +170,43 @@ update child
  ├── columns: <none>
  ├── fetch columns: child.c:3 child.p:4
  ├── update-mapping:
- │    ├── column6:6 => child.c:1
- │    └── column5:5 => child.p:2
+ │    ├── c_new:6 => child.c:1
+ │    └── p_new:5 => child.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: column5:5!null column6:6!null child.c:3!null child.p:4!null
+ │    ├── columns: p_new:5!null c_new:6!null child.c:3!null child.p:4!null
  │    ├── scan child
  │    │    └── columns: child.c:3!null child.p:4!null
  │    └── projections
- │         ├── child.p:4 + 1 [as=column5:5]
- │         └── child.c:3 + 1 [as=column6:6]
+ │         ├── child.p:4 + 1 [as=p_new:5]
+ │         └── child.c:3 + 1 [as=c_new:6]
  └── f-k-checks
       ├── f-k-checks-item: child(p) -> parent(p)
       │    └── anti-join (hash)
-      │         ├── columns: column5:7!null
+      │         ├── columns: p_new:7!null
       │         ├── with-scan &1
-      │         │    ├── columns: column5:7!null
+      │         │    ├── columns: p_new:7!null
       │         │    └── mapping:
-      │         │         └──  column5:5 => column5:7
+      │         │         └──  p_new:5 => p_new:7
       │         ├── scan parent
       │         │    └── columns: parent.p:9!null
       │         └── filters
-      │              └── column5:7 = parent.p:9
+      │              └── p_new:7 = parent.p:9
       └── f-k-checks-item: grandchild(c) -> child(c)
            └── semi-join (hash)
                 ├── columns: c:11!null
                 ├── except
                 │    ├── columns: c:11!null
                 │    ├── left columns: c:11!null
-                │    ├── right columns: column6:12
+                │    ├── right columns: c_new:12
                 │    ├── with-scan &1
                 │    │    ├── columns: c:11!null
                 │    │    └── mapping:
                 │    │         └──  child.c:3 => c:11
                 │    └── with-scan &1
-                │         ├── columns: column6:12!null
+                │         ├── columns: c_new:12!null
                 │         └── mapping:
-                │              └──  column6:6 => column6:12
+                │              └──  c_new:6 => c_new:12
                 ├── scan grandchild
                 │    └── columns: grandchild.c:14!null
                 └── filters
@@ -225,13 +225,13 @@ update child_nullable
  ├── columns: <none>
  ├── fetch columns: c:3 p:4
  ├── update-mapping:
- │    └── column5:5 => p:2
+ │    └── p_new:5 => p:2
  └── project
-      ├── columns: column5:5 c:3!null p:4
+      ├── columns: p_new:5 c:3!null p:4
       ├── scan child_nullable
       │    └── columns: c:3!null p:4
       └── projections
-           └── NULL::INT8 [as=column5:5]
+           └── NULL::INT8 [as=p_new:5]
 
 # Multiple grandchild tables
 exec-ddl
@@ -245,26 +245,26 @@ update child
  ├── columns: <none>
  ├── fetch columns: c:3 child.p:4
  ├── update-mapping:
- │    └── column5:5 => child.p:2
+ │    └── p_new:5 => child.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: column5:5!null c:3!null child.p:4!null
+ │    ├── columns: p_new:5!null c:3!null child.p:4!null
  │    ├── scan child
  │    │    └── columns: c:3!null child.p:4!null
  │    └── projections
- │         └── 4 [as=column5:5]
+ │         └── 4 [as=p_new:5]
  └── f-k-checks
       └── f-k-checks-item: child(p) -> parent(p)
            └── anti-join (hash)
-                ├── columns: column5:6!null
+                ├── columns: p_new:6!null
                 ├── with-scan &1
-                │    ├── columns: column5:6!null
+                │    ├── columns: p_new:6!null
                 │    └── mapping:
-                │         └──  column5:5 => column5:6
+                │         └──  p_new:5 => p_new:6
                 ├── scan parent
                 │    └── columns: parent.p:8!null
                 └── filters
-                     └── column5:6 = parent.p:8
+                     └── p_new:6 = parent.p:8
 
 exec-ddl
 CREATE TABLE self (x INT PRIMARY KEY, y INT NOT NULL REFERENCES self(x))
@@ -277,26 +277,26 @@ update self
  ├── columns: <none>
  ├── fetch columns: x:3 y:4
  ├── update-mapping:
- │    └── column5:5 => y:2
+ │    └── y_new:5 => y:2
  ├── input binding: &1
  ├── project
- │    ├── columns: column5:5!null x:3!null y:4!null
+ │    ├── columns: y_new:5!null x:3!null y:4!null
  │    ├── scan self
  │    │    └── columns: x:3!null y:4!null
  │    └── projections
- │         └── 3 [as=column5:5]
+ │         └── 3 [as=y_new:5]
  └── f-k-checks
       └── f-k-checks-item: self(y) -> self(x)
            └── anti-join (hash)
-                ├── columns: column5:6!null
+                ├── columns: y_new:6!null
                 ├── with-scan &1
-                │    ├── columns: column5:6!null
+                │    ├── columns: y_new:6!null
                 │    └── mapping:
-                │         └──  column5:5 => column5:6
+                │         └──  y_new:5 => y_new:6
                 ├── scan self
                 │    └── columns: x:7!null
                 └── filters
-                     └── column5:6 = x:7
+                     └── y_new:6 = x:7
 
 build
 UPDATE self SET x = 3
@@ -305,14 +305,14 @@ update self
  ├── columns: <none>
  ├── fetch columns: self.x:3 y:4
  ├── update-mapping:
- │    └── column5:5 => self.x:1
+ │    └── x_new:5 => self.x:1
  ├── input binding: &1
  ├── project
- │    ├── columns: column5:5!null self.x:3!null y:4!null
+ │    ├── columns: x_new:5!null self.x:3!null y:4!null
  │    ├── scan self
  │    │    └── columns: self.x:3!null y:4!null
  │    └── projections
- │         └── 3 [as=column5:5]
+ │         └── 3 [as=x_new:5]
  └── f-k-checks
       └── f-k-checks-item: self(y) -> self(x)
            └── semi-join (hash)
@@ -320,15 +320,15 @@ update self
                 ├── except
                 │    ├── columns: x:6!null
                 │    ├── left columns: x:6!null
-                │    ├── right columns: column5:7
+                │    ├── right columns: x_new:7
                 │    ├── with-scan &1
                 │    │    ├── columns: x:6!null
                 │    │    └── mapping:
                 │    │         └──  self.x:3 => x:6
                 │    └── with-scan &1
-                │         ├── columns: column5:7!null
+                │         ├── columns: x_new:7!null
                 │         └── mapping:
-                │              └──  column5:5 => column5:7
+                │              └──  x_new:5 => x_new:7
                 ├── scan self
                 │    └── columns: y:9!null
                 └── filters
@@ -354,11 +354,11 @@ update child_multicol_simple
  ├── columns: <none>
  ├── fetch columns: k:5 a:6 b:7 c:8
  ├── update-mapping:
- │    ├── column9:9 => a:2
- │    ├── column10:10 => b:3
- │    └── column9:9 => c:4
+ │    ├── a_new:9 => a:2
+ │    ├── b_new:10 => b:3
+ │    └── a_new:9 => c:4
  └── project
-      ├── columns: column9:9!null column10:10 k:5!null a:6 b:7 c:8
+      ├── columns: a_new:9!null b_new:10 k:5!null a:6 b:7 c:8
       ├── select
       │    ├── columns: k:5!null a:6 b:7 c:8
       │    ├── scan child_multicol_simple
@@ -366,8 +366,8 @@ update child_multicol_simple
       │    └── filters
       │         └── k:5 = 1
       └── projections
-           ├── 1 [as=column9:9]
-           └── NULL::INT8 [as=column10:10]
+           ├── 1 [as=a_new:9]
+           └── NULL::INT8 [as=b_new:10]
 
 exec-ddl
 CREATE TABLE child_multicol_full (
@@ -385,12 +385,12 @@ update child_multicol_full
  ├── columns: <none>
  ├── fetch columns: k:5 child_multicol_full.a:6 child_multicol_full.b:7 child_multicol_full.c:8
  ├── update-mapping:
- │    ├── column9:9 => child_multicol_full.a:2
- │    ├── column10:10 => child_multicol_full.b:3
- │    └── column9:9 => child_multicol_full.c:4
+ │    ├── a_new:9 => child_multicol_full.a:2
+ │    ├── b_new:10 => child_multicol_full.b:3
+ │    └── a_new:9 => child_multicol_full.c:4
  ├── input binding: &1
  ├── project
- │    ├── columns: column9:9!null column10:10 k:5!null child_multicol_full.a:6 child_multicol_full.b:7 child_multicol_full.c:8
+ │    ├── columns: a_new:9!null b_new:10 k:5!null child_multicol_full.a:6 child_multicol_full.b:7 child_multicol_full.c:8
  │    ├── select
  │    │    ├── columns: k:5!null child_multicol_full.a:6 child_multicol_full.b:7 child_multicol_full.c:8
  │    │    ├── scan child_multicol_full
@@ -398,24 +398,24 @@ update child_multicol_full
  │    │    └── filters
  │    │         └── k:5 = 1
  │    └── projections
- │         ├── 1 [as=column9:9]
- │         └── NULL::INT8 [as=column10:10]
+ │         ├── 1 [as=a_new:9]
+ │         └── NULL::INT8 [as=b_new:10]
  └── f-k-checks
       └── f-k-checks-item: child_multicol_full(a,b,c) -> parent_multicol(a,b,c)
            └── anti-join (hash)
-                ├── columns: column9:11!null column10:12 column9:13!null
+                ├── columns: a_new:11!null b_new:12 a_new:13!null
                 ├── with-scan &1
-                │    ├── columns: column9:11!null column10:12 column9:13!null
+                │    ├── columns: a_new:11!null b_new:12 a_new:13!null
                 │    └── mapping:
-                │         ├──  column9:9 => column9:11
-                │         ├──  column10:10 => column10:12
-                │         └──  column9:9 => column9:13
+                │         ├──  a_new:9 => a_new:11
+                │         ├──  b_new:10 => b_new:12
+                │         └──  a_new:9 => a_new:13
                 ├── scan parent_multicol
                 │    └── columns: parent_multicol.a:14!null parent_multicol.b:15!null parent_multicol.c:16!null
                 └── filters
-                     ├── column9:11 = parent_multicol.a:14
-                     ├── column10:12 = parent_multicol.b:15
-                     └── column9:13 = parent_multicol.c:16
+                     ├── a_new:11 = parent_multicol.a:14
+                     ├── b_new:12 = parent_multicol.b:15
+                     └── a_new:13 = parent_multicol.c:16
 
 build
 UPDATE child_multicol_full SET a = NULL, b = NULL, c = NULL WHERE k = 1
@@ -424,11 +424,11 @@ update child_multicol_full
  ├── columns: <none>
  ├── fetch columns: k:5 a:6 b:7 c:8
  ├── update-mapping:
- │    ├── column9:9 => a:2
- │    ├── column9:9 => b:3
- │    └── column9:9 => c:4
+ │    ├── a_new:9 => a:2
+ │    ├── a_new:9 => b:3
+ │    └── a_new:9 => c:4
  └── project
-      ├── columns: column9:9 k:5!null a:6 b:7 c:8
+      ├── columns: a_new:9 k:5!null a:6 b:7 c:8
       ├── select
       │    ├── columns: k:5!null a:6 b:7 c:8
       │    ├── scan child_multicol_full
@@ -436,7 +436,7 @@ update child_multicol_full
       │    └── filters
       │         └── k:5 = 1
       └── projections
-           └── NULL::INT8 [as=column9:9]
+           └── NULL::INT8 [as=a_new:9]
 
 exec-ddl
 CREATE TABLE two (a int, b int, primary key (a, b))
@@ -466,31 +466,31 @@ update fam
  ├── columns: <none>
  ├── fetch columns: fam.a:7 fam.b:8 c:9 fam.d:10 rowid:12
  ├── update-mapping:
- │    └── column13:13 => c:3
+ │    └── c_new:13 => c:3
  ├── input binding: &1
  ├── project
- │    ├── columns: column13:13!null fam.a:7 fam.b:8 c:9 fam.d:10 rowid:12!null
+ │    ├── columns: c_new:13!null fam.a:7 fam.b:8 c:9 fam.d:10 rowid:12!null
  │    ├── scan fam
  │    │    └── columns: fam.a:7 fam.b:8 c:9 fam.d:10 rowid:12!null
  │    └── projections
- │         └── 3 [as=column13:13]
+ │         └── 3 [as=c_new:13]
  └── f-k-checks
       └── f-k-checks-item: fam(c,d) -> two(a,b)
            └── anti-join (hash)
-                ├── columns: column13:14!null d:15!null
+                ├── columns: c_new:14!null d:15!null
                 ├── select
-                │    ├── columns: column13:14!null d:15!null
+                │    ├── columns: c_new:14!null d:15!null
                 │    ├── with-scan &1
-                │    │    ├── columns: column13:14!null d:15
+                │    │    ├── columns: c_new:14!null d:15
                 │    │    └── mapping:
-                │    │         ├──  column13:13 => column13:14
+                │    │         ├──  c_new:13 => c_new:14
                 │    │         └──  fam.d:10 => d:15
                 │    └── filters
                 │         └── d:15 IS NOT NULL
                 ├── scan two
                 │    └── columns: two.a:16!null two.b:17!null
                 └── filters
-                     ├── column13:14 = two.a:16
+                     ├── c_new:14 = two.a:16
                      └── d:15 = two.b:17
 
 norm
@@ -500,32 +500,32 @@ update fam
  ├── columns: <none>
  ├── fetch columns: fam.c:9 d:10 e:11 rowid:12
  ├── update-mapping:
- │    └── column13:13 => d:4
+ │    └── d_new:13 => d:4
  ├── input binding: &1
  ├── project
- │    ├── columns: column13:13!null fam.c:9 d:10 e:11 rowid:12!null
+ │    ├── columns: d_new:13!null fam.c:9 d:10 e:11 rowid:12!null
  │    ├── scan fam
  │    │    └── columns: fam.c:9 d:10 e:11 rowid:12!null
  │    └── projections
- │         └── 3 [as=column13:13]
+ │         └── 3 [as=d_new:13]
  └── f-k-checks
       └── f-k-checks-item: fam(c,d) -> two(a,b)
            └── anti-join (hash)
-                ├── columns: c:14!null column13:15!null
+                ├── columns: c:14!null d_new:15!null
                 ├── select
-                │    ├── columns: c:14!null column13:15!null
+                │    ├── columns: c:14!null d_new:15!null
                 │    ├── with-scan &1
-                │    │    ├── columns: c:14 column13:15!null
+                │    │    ├── columns: c:14 d_new:15!null
                 │    │    └── mapping:
                 │    │         ├──  fam.c:9 => c:14
-                │    │         └──  column13:13 => column13:15
+                │    │         └──  d_new:13 => d_new:15
                 │    └── filters
                 │         └── c:14 IS NOT NULL
                 ├── scan two
                 │    └── columns: two.a:16!null two.b:17!null
                 └── filters
                      ├── c:14 = two.a:16
-                     └── column13:15 = two.b:17
+                     └── d_new:15 = two.b:17
 
 exec-ddl
 CREATE TABLE child_cascade (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p) ON UPDATE CASCADE)
@@ -539,11 +539,11 @@ update parent
  ├── columns: <none>
  ├── fetch columns: x:4 parent.p:5 other:6
  ├── update-mapping:
- │    └── column7:7 => parent.p:2
+ │    └── p_new:7 => parent.p:2
  ├── fk-fallback
  └── project
-      ├── columns: column7:7!null x:4 parent.p:5!null other:6
+      ├── columns: p_new:7!null x:4 parent.p:5!null other:6
       ├── scan parent
       │    └── columns: x:4 parent.p:5!null other:6
       └── projections
-           └── parent.p:5 + 1 [as=column7:7]
+           └── parent.p:5 + 1 [as=p_new:7]

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
@@ -208,9 +208,9 @@ upsert c1
  │    └── upsert_p:12 => c1.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_c:11 upsert_p:12!null upsert_i:13 column1:4!null column2:5!null column6:6 c:7 c1.p:8 i:9 column10:10!null
+ │    ├── columns: upsert_c:11 upsert_p:12!null upsert_i:13 column1:4!null column2:5!null column6:6 c:7 c1.p:8 i:9 p_new:10!null
  │    ├── project
- │    │    ├── columns: column10:10!null column1:4!null column2:5!null column6:6 c:7 c1.p:8 i:9
+ │    │    ├── columns: p_new:10!null column1:4!null column2:5!null column6:6 c:7 c1.p:8 i:9
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:4!null column2:5!null column6:6 c:7 c1.p:8 i:9
  │    │    │    ├── ensure-upsert-distinct-on
@@ -234,10 +234,10 @@ upsert c1
  │    │    │    └── filters
  │    │    │         └── column1:4 = c:7
  │    │    └── projections
- │    │         └── column2:5 + 1 [as=column10:10]
+ │    │         └── column2:5 + 1 [as=p_new:10]
  │    └── projections
  │         ├── CASE WHEN c:7 IS NULL THEN column1:4 ELSE c:7 END [as=upsert_c:11]
- │         ├── CASE WHEN c:7 IS NULL THEN column2:5 ELSE column10:10 END [as=upsert_p:12]
+ │         ├── CASE WHEN c:7 IS NULL THEN column2:5 ELSE p_new:10 END [as=upsert_p:12]
  │         └── CASE WHEN c:7 IS NULL THEN column6:6 ELSE i:9 END [as=upsert_i:13]
  └── f-k-checks
       └── f-k-checks-item: c1(p) -> p(p)
@@ -267,9 +267,9 @@ upsert c1
  │    └── upsert_i:14 => i:3
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_c:12 upsert_p:13 upsert_i:14 u:4!null v:5!null column7:7 c:8 c1.p:9 i:10 column11:11
+ │    ├── columns: upsert_c:12 upsert_p:13 upsert_i:14 u:4!null v:5!null column7:7 c:8 c1.p:9 i:10 i_new:11
  │    ├── project
- │    │    ├── columns: column11:11 u:4!null v:5!null column7:7 c:8 c1.p:9 i:10
+ │    │    ├── columns: i_new:11 u:4!null v:5!null column7:7 c:8 c1.p:9 i:10
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: u:4!null v:5!null column7:7 c:8 c1.p:9 i:10
  │    │    │    ├── ensure-upsert-distinct-on
@@ -293,11 +293,11 @@ upsert c1
  │    │    │    └── filters
  │    │    │         └── u:4 = c:8
  │    │    └── projections
- │    │         └── c:8 + 1 [as=column11:11]
+ │    │         └── c:8 + 1 [as=i_new:11]
  │    └── projections
  │         ├── CASE WHEN c:8 IS NULL THEN u:4 ELSE c:8 END [as=upsert_c:12]
  │         ├── CASE WHEN c:8 IS NULL THEN v:5 ELSE c1.p:9 END [as=upsert_p:13]
- │         └── CASE WHEN c:8 IS NULL THEN column7:7 ELSE column11:11 END [as=upsert_i:14]
+ │         └── CASE WHEN c:8 IS NULL THEN column7:7 ELSE i_new:11 END [as=upsert_i:14]
  └── f-k-checks
       └── f-k-checks-item: c1(p) -> p(p)
            └── anti-join (hash)
@@ -328,9 +328,9 @@ upsert c2
  │    └── upsert_c:5 => c:1
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_c:5!null column1:2!null c:3 column4:4!null
+ │    ├── columns: upsert_c:5!null column1:2!null c:3 c_new:4!null
  │    ├── project
- │    │    ├── columns: column4:4!null column1:2!null c:3
+ │    │    ├── columns: c_new:4!null column1:2!null c:3
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:2!null c:3
  │    │    │    ├── ensure-upsert-distinct-on
@@ -345,9 +345,9 @@ upsert c2
  │    │    │    └── filters
  │    │    │         └── column1:2 = c:3
  │    │    └── projections
- │    │         └── 1 [as=column4:4]
+ │    │         └── 1 [as=c_new:4]
  │    └── projections
- │         └── CASE WHEN c:3 IS NULL THEN column1:2 ELSE column4:4 END [as=upsert_c:5]
+ │         └── CASE WHEN c:3 IS NULL THEN column1:2 ELSE c_new:4 END [as=upsert_c:5]
  └── f-k-checks
       └── f-k-checks-item: c2(c) -> p(p)
            └── anti-join (hash)
@@ -489,9 +489,9 @@ upsert c4
  │    └── upsert_other:15 => c4.other:3
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_c:13 upsert_a:14 upsert_other:15 x:4 y:5 z:6 c:9 a:10 c4.other:11 column12:12!null
+ │    ├── columns: upsert_c:13 upsert_a:14 upsert_other:15 x:4 y:5 z:6 c:9 a:10 c4.other:11 other_new:12!null
  │    ├── project
- │    │    ├── columns: column12:12!null x:4 y:5 z:6 c:9 a:10 c4.other:11
+ │    │    ├── columns: other_new:12!null x:4 y:5 z:6 c:9 a:10 c4.other:11
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: x:4 y:5 z:6 c:9 a:10 c4.other:11
  │    │    │    ├── ensure-upsert-distinct-on
@@ -511,11 +511,11 @@ upsert c4
  │    │    │    └── filters
  │    │    │         └── y:5 = a:10
  │    │    └── projections
- │    │         └── 1 [as=column12:12]
+ │    │         └── 1 [as=other_new:12]
  │    └── projections
  │         ├── CASE WHEN c:9 IS NULL THEN x:4 ELSE c:9 END [as=upsert_c:13]
  │         ├── CASE WHEN c:9 IS NULL THEN y:5 ELSE a:10 END [as=upsert_a:14]
- │         └── CASE WHEN c:9 IS NULL THEN z:6 ELSE column12:12 END [as=upsert_other:15]
+ │         └── CASE WHEN c:9 IS NULL THEN z:6 ELSE other_new:12 END [as=upsert_other:15]
  └── f-k-checks
       └── f-k-checks-item: c4(a) -> p(p)
            └── anti-join (hash)
@@ -548,9 +548,9 @@ upsert c4
  │    └── upsert_a:14 => a:2
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_c:13 upsert_a:14 upsert_other:15 x:4 y:5 z:6 c:9 a:10 c4.other:11 column12:12!null
+ │    ├── columns: upsert_c:13 upsert_a:14 upsert_other:15 x:4 y:5 z:6 c:9 a:10 c4.other:11 a_new:12!null
  │    ├── project
- │    │    ├── columns: column12:12!null x:4 y:5 z:6 c:9 a:10 c4.other:11
+ │    │    ├── columns: a_new:12!null x:4 y:5 z:6 c:9 a:10 c4.other:11
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: x:4 y:5 z:6 c:9 a:10 c4.other:11
  │    │    │    ├── ensure-upsert-distinct-on
@@ -570,10 +570,10 @@ upsert c4
  │    │    │    └── filters
  │    │    │         └── y:5 = a:10
  │    │    └── projections
- │    │         └── 5 [as=column12:12]
+ │    │         └── 5 [as=a_new:12]
  │    └── projections
  │         ├── CASE WHEN c:9 IS NULL THEN x:4 ELSE c:9 END [as=upsert_c:13]
- │         ├── CASE WHEN c:9 IS NULL THEN y:5 ELSE column12:12 END [as=upsert_a:14]
+ │         ├── CASE WHEN c:9 IS NULL THEN y:5 ELSE a_new:12 END [as=upsert_a:14]
  │         └── CASE WHEN c:9 IS NULL THEN z:6 ELSE c4.other:11 END [as=upsert_other:15]
  └── f-k-checks
       └── f-k-checks-item: c4(a) -> p(p)
@@ -948,9 +948,9 @@ upsert cpq
  │    └── upsert_p:15 => cpq.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_c:14 upsert_p:15!null upsert_q:16 upsert_other:17 column1:5!null column6:6!null column7:7!null column8:8 c:9 cpq.p:10 cpq.q:11 cpq.other:12 column13:13!null
+ │    ├── columns: upsert_c:14 upsert_p:15!null upsert_q:16 upsert_other:17 column1:5!null column6:6!null column7:7!null column8:8 c:9 cpq.p:10 cpq.q:11 cpq.other:12 p_new:13!null
  │    ├── project
- │    │    ├── columns: column13:13!null column1:5!null column6:6!null column7:7!null column8:8 c:9 cpq.p:10 cpq.q:11 cpq.other:12
+ │    │    ├── columns: p_new:13!null column1:5!null column6:6!null column7:7!null column8:8 c:9 cpq.p:10 cpq.q:11 cpq.other:12
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:5!null column6:6!null column7:7!null column8:8 c:9 cpq.p:10 cpq.q:11 cpq.other:12
  │    │    │    ├── ensure-upsert-distinct-on
@@ -978,10 +978,10 @@ upsert cpq
  │    │    │    └── filters
  │    │    │         └── column1:5 = c:9
  │    │    └── projections
- │    │         └── 10 [as=column13:13]
+ │    │         └── 10 [as=p_new:13]
  │    └── projections
  │         ├── CASE WHEN c:9 IS NULL THEN column1:5 ELSE c:9 END [as=upsert_c:14]
- │         ├── CASE WHEN c:9 IS NULL THEN column6:6 ELSE column13:13 END [as=upsert_p:15]
+ │         ├── CASE WHEN c:9 IS NULL THEN column6:6 ELSE p_new:13 END [as=upsert_p:15]
  │         ├── CASE WHEN c:9 IS NULL THEN column7:7 ELSE cpq.q:11 END [as=upsert_q:16]
  │         └── CASE WHEN c:9 IS NULL THEN column8:8 ELSE cpq.other:12 END [as=upsert_other:17]
  └── f-k-checks
@@ -1231,9 +1231,9 @@ upsert p1
  │    └── upsert_p:8 => p1.p:1
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_p:8!null upsert_other:9 column1:3!null column2:4!null p1.p:5 other:6 column7:7!null
+ │    ├── columns: upsert_p:8!null upsert_other:9 column1:3!null column2:4!null p1.p:5 other:6 p_new:7!null
  │    ├── project
- │    │    ├── columns: column7:7!null column1:3!null column2:4!null p1.p:5 other:6
+ │    │    ├── columns: p_new:7!null column1:3!null column2:4!null p1.p:5 other:6
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:3!null column2:4!null p1.p:5 other:6
  │    │    │    ├── ensure-upsert-distinct-on
@@ -1251,9 +1251,9 @@ upsert p1
  │    │    │    └── filters
  │    │    │         └── column1:3 = p1.p:5
  │    │    └── projections
- │    │         └── column1:3 + 1 [as=column7:7]
+ │    │         └── column1:3 + 1 [as=p_new:7]
  │    └── projections
- │         ├── CASE WHEN p1.p:5 IS NULL THEN column1:3 ELSE column7:7 END [as=upsert_p:8]
+ │         ├── CASE WHEN p1.p:5 IS NULL THEN column1:3 ELSE p_new:7 END [as=upsert_p:8]
  │         └── CASE WHEN p1.p:5 IS NULL THEN column2:4 ELSE other:6 END [as=upsert_other:9]
  └── f-k-checks
       └── f-k-checks-item: p1c(p) -> p1(p)
@@ -1290,9 +1290,9 @@ upsert p1
  ├── update-mapping:
  │    └── upsert_other:9 => other:2
  └── project
-      ├── columns: upsert_p:8 upsert_other:9 column1:3!null column2:4!null p:5 other:6 column7:7
+      ├── columns: upsert_p:8 upsert_other:9 column1:3!null column2:4!null p:5 other:6 other_new:7
       ├── project
-      │    ├── columns: column7:7 column1:3!null column2:4!null p:5 other:6
+      │    ├── columns: other_new:7 column1:3!null column2:4!null p:5 other:6
       │    ├── left-join (hash)
       │    │    ├── columns: column1:3!null column2:4!null p:5 other:6
       │    │    ├── ensure-upsert-distinct-on
@@ -1310,10 +1310,10 @@ upsert p1
       │    │    └── filters
       │    │         └── column1:3 = p:5
       │    └── projections
-      │         └── other:6 + 1 [as=column7:7]
+      │         └── other:6 + 1 [as=other_new:7]
       └── projections
            ├── CASE WHEN p:5 IS NULL THEN column1:3 ELSE p:5 END [as=upsert_p:8]
-           └── CASE WHEN p:5 IS NULL THEN column2:4 ELSE column7:7 END [as=upsert_other:9]
+           └── CASE WHEN p:5 IS NULL THEN column2:4 ELSE other_new:7 END [as=upsert_other:9]
 
 # Similar tests when the FK column is not the PK.
 exec-ddl
@@ -1393,9 +1393,9 @@ upsert p2
  ├── update-mapping:
  │    └── upsert_p:8 => p:1
  └── project
-      ├── columns: upsert_p:8!null upsert_fk:9 column1:3!null column2:4!null p:5 fk:6 column7:7!null
+      ├── columns: upsert_p:8!null upsert_fk:9 column1:3!null column2:4!null p:5 fk:6 p_new:7!null
       ├── project
-      │    ├── columns: column7:7!null column1:3!null column2:4!null p:5 fk:6
+      │    ├── columns: p_new:7!null column1:3!null column2:4!null p:5 fk:6
       │    ├── left-join (hash)
       │    │    ├── columns: column1:3!null column2:4!null p:5 fk:6
       │    │    ├── ensure-upsert-distinct-on
@@ -1413,9 +1413,9 @@ upsert p2
       │    │    └── filters
       │    │         └── column1:3 = p:5
       │    └── projections
-      │         └── column1:3 + 1 [as=column7:7]
+      │         └── column1:3 + 1 [as=p_new:7]
       └── projections
-           ├── CASE WHEN p:5 IS NULL THEN column1:3 ELSE column7:7 END [as=upsert_p:8]
+           ├── CASE WHEN p:5 IS NULL THEN column1:3 ELSE p_new:7 END [as=upsert_p:8]
            └── CASE WHEN p:5 IS NULL THEN column2:4 ELSE fk:6 END [as=upsert_fk:9]
 
 # This statement can change existing values of the fk column, so the FK check
@@ -1434,9 +1434,9 @@ upsert p2
  │    └── upsert_fk:9 => p2.fk:2
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_p:8 upsert_fk:9!null column1:3!null column2:4!null p:5 p2.fk:6 column7:7!null
+ │    ├── columns: upsert_p:8 upsert_fk:9!null column1:3!null column2:4!null p:5 p2.fk:6 fk_new:7!null
  │    ├── project
- │    │    ├── columns: column7:7!null column1:3!null column2:4!null p:5 p2.fk:6
+ │    │    ├── columns: fk_new:7!null column1:3!null column2:4!null p:5 p2.fk:6
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:3!null column2:4!null p:5 p2.fk:6
  │    │    │    ├── ensure-upsert-distinct-on
@@ -1454,10 +1454,10 @@ upsert p2
  │    │    │    └── filters
  │    │    │         └── column1:3 = p:5
  │    │    └── projections
- │    │         └── column2:4 + 1 [as=column7:7]
+ │    │         └── column2:4 + 1 [as=fk_new:7]
  │    └── projections
  │         ├── CASE WHEN p:5 IS NULL THEN column1:3 ELSE p:5 END [as=upsert_p:8]
- │         └── CASE WHEN p:5 IS NULL THEN column2:4 ELSE column7:7 END [as=upsert_fk:9]
+ │         └── CASE WHEN p:5 IS NULL THEN column2:4 ELSE fk_new:7 END [as=upsert_fk:9]
  └── f-k-checks
       └── f-k-checks-item: p2c(fk) -> p2(fk)
            └── semi-join (hash)
@@ -1494,9 +1494,9 @@ upsert p2
  ├── update-mapping:
  │    └── upsert_p:8 => p:1
  └── project
-      ├── columns: upsert_p:8!null upsert_fk:9 column1:3!null column2:4!null p:5 fk:6 column7:7!null
+      ├── columns: upsert_p:8!null upsert_fk:9 column1:3!null column2:4!null p:5 fk:6 p_new:7!null
       ├── project
-      │    ├── columns: column7:7!null column1:3!null column2:4!null p:5 fk:6
+      │    ├── columns: p_new:7!null column1:3!null column2:4!null p:5 fk:6
       │    ├── left-join (hash)
       │    │    ├── columns: column1:3!null column2:4!null p:5 fk:6
       │    │    ├── ensure-upsert-distinct-on
@@ -1514,9 +1514,9 @@ upsert p2
       │    │    └── filters
       │    │         └── column2:4 = fk:6
       │    └── projections
-      │         └── column1:3 + 1 [as=column7:7]
+      │         └── column1:3 + 1 [as=p_new:7]
       └── projections
-           ├── CASE WHEN p:5 IS NULL THEN column1:3 ELSE column7:7 END [as=upsert_p:8]
+           ├── CASE WHEN p:5 IS NULL THEN column1:3 ELSE p_new:7 END [as=upsert_p:8]
            └── CASE WHEN p:5 IS NULL THEN column2:4 ELSE fk:6 END [as=upsert_fk:9]
 
 build
@@ -1533,9 +1533,9 @@ upsert p2
  │    └── upsert_fk:9 => p2.fk:2
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_p:8 upsert_fk:9!null column1:3!null column2:4!null p:5 p2.fk:6 column7:7!null
+ │    ├── columns: upsert_p:8 upsert_fk:9!null column1:3!null column2:4!null p:5 p2.fk:6 fk_new:7!null
  │    ├── project
- │    │    ├── columns: column7:7!null column1:3!null column2:4!null p:5 p2.fk:6
+ │    │    ├── columns: fk_new:7!null column1:3!null column2:4!null p:5 p2.fk:6
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:3!null column2:4!null p:5 p2.fk:6
  │    │    │    ├── ensure-upsert-distinct-on
@@ -1553,10 +1553,10 @@ upsert p2
  │    │    │    └── filters
  │    │    │         └── column2:4 = p2.fk:6
  │    │    └── projections
- │    │         └── column2:4 + 1 [as=column7:7]
+ │    │         └── column2:4 + 1 [as=fk_new:7]
  │    └── projections
  │         ├── CASE WHEN p:5 IS NULL THEN column1:3 ELSE p:5 END [as=upsert_p:8]
- │         └── CASE WHEN p:5 IS NULL THEN column2:4 ELSE column7:7 END [as=upsert_fk:9]
+ │         └── CASE WHEN p:5 IS NULL THEN column2:4 ELSE fk_new:7 END [as=upsert_fk:9]
  └── f-k-checks
       └── f-k-checks-item: p2c(fk) -> p2(fk)
            └── semi-join (hash)
@@ -1853,9 +1853,9 @@ upsert pq
  ├── update-mapping:
  │    └── upsert_k:14 => k:1
  └── project
-      ├── columns: upsert_k:14 upsert_p:15 upsert_q:16 upsert_other:17 column1:5!null column2:6!null column3:7!null column4:8!null k:9 p:10 q:11 other:12 column13:13
+      ├── columns: upsert_k:14 upsert_p:15 upsert_q:16 upsert_other:17 column1:5!null column2:6!null column3:7!null column4:8!null k:9 p:10 q:11 other:12 k_new:13
       ├── project
-      │    ├── columns: column13:13 column1:5!null column2:6!null column3:7!null column4:8!null k:9 p:10 q:11 other:12
+      │    ├── columns: k_new:13 column1:5!null column2:6!null column3:7!null column4:8!null k:9 p:10 q:11 other:12
       │    ├── left-join (hash)
       │    │    ├── columns: column1:5!null column2:6!null column3:7!null column4:8!null k:9 p:10 q:11 other:12
       │    │    ├── ensure-upsert-distinct-on
@@ -1876,9 +1876,9 @@ upsert pq
       │    │         ├── column2:6 = p:10
       │    │         └── column3:7 = q:11
       │    └── projections
-      │         └── k:9 + 1 [as=column13:13]
+      │         └── k:9 + 1 [as=k_new:13]
       └── projections
-           ├── CASE WHEN k:9 IS NULL THEN column1:5 ELSE column13:13 END [as=upsert_k:14]
+           ├── CASE WHEN k:9 IS NULL THEN column1:5 ELSE k_new:13 END [as=upsert_k:14]
            ├── CASE WHEN k:9 IS NULL THEN column2:6 ELSE p:10 END [as=upsert_p:15]
            ├── CASE WHEN k:9 IS NULL THEN column3:7 ELSE q:11 END [as=upsert_q:16]
            └── CASE WHEN k:9 IS NULL THEN column4:8 ELSE other:12 END [as=upsert_other:17]
@@ -1899,9 +1899,9 @@ upsert pq
  │    └── upsert_p:15 => pq.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_k:14 upsert_p:15 upsert_q:16 upsert_other:17 column1:5!null column2:6!null column3:7!null column4:8!null k:9 pq.p:10 pq.q:11 pq.other:12 column13:13
+ │    ├── columns: upsert_k:14 upsert_p:15 upsert_q:16 upsert_other:17 column1:5!null column2:6!null column3:7!null column4:8!null k:9 pq.p:10 pq.q:11 pq.other:12 p_new:13
  │    ├── project
- │    │    ├── columns: column13:13 column1:5!null column2:6!null column3:7!null column4:8!null k:9 pq.p:10 pq.q:11 pq.other:12
+ │    │    ├── columns: p_new:13 column1:5!null column2:6!null column3:7!null column4:8!null k:9 pq.p:10 pq.q:11 pq.other:12
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null column4:8!null k:9 pq.p:10 pq.q:11 pq.other:12
  │    │    │    ├── ensure-upsert-distinct-on
@@ -1922,10 +1922,10 @@ upsert pq
  │    │    │         ├── column2:6 = pq.p:10
  │    │    │         └── column3:7 = pq.q:11
  │    │    └── projections
- │    │         └── pq.p:10 + 1 [as=column13:13]
+ │    │         └── pq.p:10 + 1 [as=p_new:13]
  │    └── projections
  │         ├── CASE WHEN k:9 IS NULL THEN column1:5 ELSE k:9 END [as=upsert_k:14]
- │         ├── CASE WHEN k:9 IS NULL THEN column2:6 ELSE column13:13 END [as=upsert_p:15]
+ │         ├── CASE WHEN k:9 IS NULL THEN column2:6 ELSE p_new:13 END [as=upsert_p:15]
  │         ├── CASE WHEN k:9 IS NULL THEN column3:7 ELSE pq.q:11 END [as=upsert_q:16]
  │         └── CASE WHEN k:9 IS NULL THEN column4:8 ELSE pq.other:12 END [as=upsert_other:17]
  └── f-k-checks
@@ -1990,9 +1990,9 @@ upsert pq
  ├── update-mapping:
  │    └── upsert_other:17 => other:4
  └── project
-      ├── columns: upsert_k:14 upsert_p:15 upsert_q:16 upsert_other:17!null column1:5!null column2:6!null column3:7!null column4:8!null k:9 p:10 q:11 other:12 column13:13!null
+      ├── columns: upsert_k:14 upsert_p:15 upsert_q:16 upsert_other:17!null column1:5!null column2:6!null column3:7!null column4:8!null k:9 p:10 q:11 other:12 other_new:13!null
       ├── project
-      │    ├── columns: column13:13!null column1:5!null column2:6!null column3:7!null column4:8!null k:9 p:10 q:11 other:12
+      │    ├── columns: other_new:13!null column1:5!null column2:6!null column3:7!null column4:8!null k:9 p:10 q:11 other:12
       │    ├── left-join (hash)
       │    │    ├── columns: column1:5!null column2:6!null column3:7!null column4:8!null k:9 p:10 q:11 other:12
       │    │    ├── ensure-upsert-distinct-on
@@ -2014,12 +2014,12 @@ upsert pq
       │    │    └── filters
       │    │         └── column1:5 = k:9
       │    └── projections
-      │         └── 5 [as=column13:13]
+      │         └── 5 [as=other_new:13]
       └── projections
            ├── CASE WHEN k:9 IS NULL THEN column1:5 ELSE k:9 END [as=upsert_k:14]
            ├── CASE WHEN k:9 IS NULL THEN column2:6 ELSE p:10 END [as=upsert_p:15]
            ├── CASE WHEN k:9 IS NULL THEN column3:7 ELSE q:11 END [as=upsert_q:16]
-           └── CASE WHEN k:9 IS NULL THEN column4:8 ELSE column13:13 END [as=upsert_other:17]
+           └── CASE WHEN k:9 IS NULL THEN column4:8 ELSE other_new:13 END [as=upsert_other:17]
 
 build
 INSERT INTO pq VALUES (1, 1, 1, 1), (2, 2, 2, 2) ON CONFLICT (k) DO UPDATE SET q = 5
@@ -2037,9 +2037,9 @@ upsert pq
  │    └── upsert_q:16 => pq.q:3
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_k:14 upsert_p:15 upsert_q:16!null upsert_other:17 column1:5!null column2:6!null column3:7!null column4:8!null k:9 pq.p:10 pq.q:11 pq.other:12 column13:13!null
+ │    ├── columns: upsert_k:14 upsert_p:15 upsert_q:16!null upsert_other:17 column1:5!null column2:6!null column3:7!null column4:8!null k:9 pq.p:10 pq.q:11 pq.other:12 q_new:13!null
  │    ├── project
- │    │    ├── columns: column13:13!null column1:5!null column2:6!null column3:7!null column4:8!null k:9 pq.p:10 pq.q:11 pq.other:12
+ │    │    ├── columns: q_new:13!null column1:5!null column2:6!null column3:7!null column4:8!null k:9 pq.p:10 pq.q:11 pq.other:12
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null column4:8!null k:9 pq.p:10 pq.q:11 pq.other:12
  │    │    │    ├── ensure-upsert-distinct-on
@@ -2061,11 +2061,11 @@ upsert pq
  │    │    │    └── filters
  │    │    │         └── column1:5 = k:9
  │    │    └── projections
- │    │         └── 5 [as=column13:13]
+ │    │         └── 5 [as=q_new:13]
  │    └── projections
  │         ├── CASE WHEN k:9 IS NULL THEN column1:5 ELSE k:9 END [as=upsert_k:14]
  │         ├── CASE WHEN k:9 IS NULL THEN column2:6 ELSE pq.p:10 END [as=upsert_p:15]
- │         ├── CASE WHEN k:9 IS NULL THEN column3:7 ELSE column13:13 END [as=upsert_q:16]
+ │         ├── CASE WHEN k:9 IS NULL THEN column3:7 ELSE q_new:13 END [as=upsert_q:16]
  │         └── CASE WHEN k:9 IS NULL THEN column4:8 ELSE pq.other:12 END [as=upsert_other:17]
  └── f-k-checks
       ├── f-k-checks-item: cpq(p,q) -> pq(p,q)
@@ -2227,9 +2227,9 @@ upsert tab2
  │    └── upsert_e:13 => tab2.e:3
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_c:11 upsert_d:12 upsert_e:13 column1:4!null column2:5!null column3:6!null c:7 d:8 tab2.e:9 column10:10
+ │    ├── columns: upsert_c:11 upsert_d:12 upsert_e:13 column1:4!null column2:5!null column3:6!null c:7 d:8 tab2.e:9 e_new:10
  │    ├── project
- │    │    ├── columns: column10:10 column1:4!null column2:5!null column3:6!null c:7 d:8 tab2.e:9
+ │    │    ├── columns: e_new:10 column1:4!null column2:5!null column3:6!null c:7 d:8 tab2.e:9
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null c:7 d:8 tab2.e:9
  │    │    │    ├── ensure-upsert-distinct-on
@@ -2248,11 +2248,11 @@ upsert tab2
  │    │    │    └── filters
  │    │    │         └── column1:4 = c:7
  │    │    └── projections
- │    │         └── tab2.e:9 + 1 [as=column10:10]
+ │    │         └── tab2.e:9 + 1 [as=e_new:10]
  │    └── projections
  │         ├── CASE WHEN c:7 IS NULL THEN column1:4 ELSE c:7 END [as=upsert_c:11]
  │         ├── CASE WHEN c:7 IS NULL THEN column2:5 ELSE d:8 END [as=upsert_d:12]
- │         └── CASE WHEN c:7 IS NULL THEN column3:6 ELSE column10:10 END [as=upsert_e:13]
+ │         └── CASE WHEN c:7 IS NULL THEN column3:6 ELSE e_new:10 END [as=upsert_e:13]
  └── f-k-checks
       ├── f-k-checks-item: tab2(d) -> tab1(b)
       │    └── anti-join (hash)
@@ -2305,9 +2305,9 @@ upsert tab2
  │    └── upsert_d:12 => d:2
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_c:11 upsert_d:12 upsert_e:13 column1:4!null column2:5!null column3:6!null c:7 d:8 e:9 column10:10
+ │    ├── columns: upsert_c:11 upsert_d:12 upsert_e:13 column1:4!null column2:5!null column3:6!null c:7 d:8 e:9 d_new:10
  │    ├── project
- │    │    ├── columns: column10:10 column1:4!null column2:5!null column3:6!null c:7 d:8 e:9
+ │    │    ├── columns: d_new:10 column1:4!null column2:5!null column3:6!null c:7 d:8 e:9
  │    │    ├── left-join (hash)
  │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null c:7 d:8 e:9
  │    │    │    ├── ensure-upsert-distinct-on
@@ -2326,10 +2326,10 @@ upsert tab2
  │    │    │    └── filters
  │    │    │         └── column3:6 = e:9
  │    │    └── projections
- │    │         └── d:8 + 1 [as=column10:10]
+ │    │         └── d:8 + 1 [as=d_new:10]
  │    └── projections
  │         ├── CASE WHEN c:7 IS NULL THEN column1:4 ELSE c:7 END [as=upsert_c:11]
- │         ├── CASE WHEN c:7 IS NULL THEN column2:5 ELSE column10:10 END [as=upsert_d:12]
+ │         ├── CASE WHEN c:7 IS NULL THEN column2:5 ELSE d_new:10 END [as=upsert_d:12]
  │         └── CASE WHEN c:7 IS NULL THEN column3:6 ELSE e:9 END [as=upsert_e:13]
  └── f-k-checks
       └── f-k-checks-item: tab2(d) -> tab1(b)

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-default
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-default
@@ -27,10 +27,10 @@ root
            ├── columns: <none>
            ├── fetch columns: c:5 child.p:6
            ├── update-mapping:
-           │    └── column8:8 => child.p:4
+           │    └── p_new:8 => child.p:4
            ├── input binding: &2
            ├── project
-           │    ├── columns: column8:8!null c:5!null child.p:6
+           │    ├── columns: p_new:8!null c:5!null child.p:6
            │    ├── semi-join (hash)
            │    │    ├── columns: c:5!null child.p:6
            │    │    ├── scan child
@@ -42,19 +42,19 @@ root
            │    │    └── filters
            │    │         └── child.p:6 = p:7
            │    └── projections
-           │         └── 0 [as=column8:8]
+           │         └── 0 [as=p_new:8]
            └── f-k-checks
                 └── f-k-checks-item: child(p) -> parent(p)
                      └── anti-join (hash)
-                          ├── columns: column8:9!null
+                          ├── columns: p_new:9!null
                           ├── with-scan &2
-                          │    ├── columns: column8:9!null
+                          │    ├── columns: p_new:9!null
                           │    └── mapping:
-                          │         └──  column8:8 => column8:9
+                          │         └──  p_new:8 => p_new:9
                           ├── scan parent
                           │    └── columns: parent.p:10!null
                           └── filters
-                               └── column8:9 = parent.p:10
+                               └── p_new:9 = parent.p:10
 
 exec-ddl
 DROP TABLE child
@@ -87,9 +87,9 @@ root
            ├── columns: <none>
            ├── fetch columns: c:5 child_null.p:6
            ├── update-mapping:
-           │    └── column8:8 => child_null.p:4
+           │    └── p_new:8 => child_null.p:4
            └── project
-                ├── columns: column8:8 c:5!null child_null.p:6
+                ├── columns: p_new:8 c:5!null child_null.p:6
                 ├── semi-join (hash)
                 │    ├── columns: c:5!null child_null.p:6
                 │    ├── scan child_null
@@ -101,7 +101,7 @@ root
                 │    └── filters
                 │         └── child_null.p:6 = p:7
                 └── projections
-                     └── NULL::INT8 [as=column8:8]
+                     └── NULL::INT8 [as=p_new:8]
 
 exec-ddl
 CREATE TABLE parent_multicol (p INT, q INT, r INT, PRIMARY KEY (p, q, r))
@@ -144,17 +144,17 @@ root
            ├── fetch columns: child_multicol.c:12 child_multicol.p:13 child_multicol.q:14 child_multicol.r:15 x:16
            ├── update-mapping:
            │    ├── child_multicol.c:12 => child_multicol.p:8
-           │    ├── column20:20 => child_multicol.q:9
-           │    ├── column21:21 => child_multicol.r:10
+           │    ├── q_new:20 => child_multicol.q:9
+           │    ├── r_new:21 => child_multicol.r:10
            │    └── column22:22 => x:11
            ├── check columns: check1:23
            ├── input binding: &2
            ├── project
-           │    ├── columns: check1:23!null child_multicol.c:12!null child_multicol.p:13 child_multicol.q:14 child_multicol.r:15 x:16 column20:20 column21:21 column22:22
+           │    ├── columns: check1:23!null child_multicol.c:12!null child_multicol.p:13 child_multicol.q:14 child_multicol.r:15 x:16 q_new:20 r_new:21 column22:22
            │    ├── project
-           │    │    ├── columns: column22:22 child_multicol.c:12!null child_multicol.p:13 child_multicol.q:14 child_multicol.r:15 x:16 column20:20 column21:21
+           │    │    ├── columns: column22:22 child_multicol.c:12!null child_multicol.p:13 child_multicol.q:14 child_multicol.r:15 x:16 q_new:20 r_new:21
            │    │    ├── project
-           │    │    │    ├── columns: column20:20 column21:21 child_multicol.c:12!null child_multicol.p:13 child_multicol.q:14 child_multicol.r:15 x:16
+           │    │    │    ├── columns: q_new:20 r_new:21 child_multicol.c:12!null child_multicol.p:13 child_multicol.q:14 child_multicol.r:15 x:16
            │    │    │    ├── semi-join (hash)
            │    │    │    │    ├── columns: child_multicol.c:12!null child_multicol.p:13 child_multicol.q:14 child_multicol.r:15 x:16
            │    │    │    │    ├── scan child_multicol
@@ -173,30 +173,30 @@ root
            │    │    │    │         ├── child_multicol.q:14 = q:18
            │    │    │    │         └── child_multicol.r:15 = r:19
            │    │    │    └── projections
-           │    │    │         ├── child_multicol.p:13 + 1 [as=column20:20]
-           │    │    │         └── child_multicol.p:13 + child_multicol.q:14 [as=column21:21]
+           │    │    │         ├── child_multicol.p:13 + 1 [as=q_new:20]
+           │    │    │         └── child_multicol.p:13 + child_multicol.q:14 [as=r_new:21]
            │    │    └── projections
-           │    │         └── (child_multicol.c:12 + column20:20) + column21:21 [as=column22:22]
+           │    │         └── (child_multicol.c:12 + q_new:20) + r_new:21 [as=column22:22]
            │    └── projections
            │         └── (child_multicol.c:12 > 100) OR (child_multicol.c:12 > child_multicol.c:12) [as=check1:23]
            └── f-k-checks
                 └── f-k-checks-item: child_multicol(p,q,r) -> parent_multicol(p,q,r)
                      └── anti-join (hash)
-                          ├── columns: c:24!null column20:25!null column21:26!null
+                          ├── columns: c:24!null q_new:25!null r_new:26!null
                           ├── select
-                          │    ├── columns: c:24!null column20:25!null column21:26!null
+                          │    ├── columns: c:24!null q_new:25!null r_new:26!null
                           │    ├── with-scan &2
-                          │    │    ├── columns: c:24!null column20:25 column21:26
+                          │    │    ├── columns: c:24!null q_new:25 r_new:26
                           │    │    └── mapping:
                           │    │         ├──  child_multicol.c:12 => c:24
-                          │    │         ├──  column20:20 => column20:25
-                          │    │         └──  column21:21 => column21:26
+                          │    │         ├──  q_new:20 => q_new:25
+                          │    │         └──  r_new:21 => r_new:26
                           │    └── filters
-                          │         ├── column20:25 IS NOT NULL
-                          │         └── column21:26 IS NOT NULL
+                          │         ├── q_new:25 IS NOT NULL
+                          │         └── r_new:26 IS NOT NULL
                           ├── scan parent_multicol
                           │    └── columns: parent_multicol.p:27!null parent_multicol.q:28!null parent_multicol.r:29!null
                           └── filters
                                ├── c:24 = parent_multicol.p:27
-                               ├── column20:25 = parent_multicol.q:28
-                               └── column21:26 = parent_multicol.r:29
+                               ├── q_new:25 = parent_multicol.q:28
+                               └── r_new:26 = parent_multicol.r:29

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-null
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-null
@@ -27,9 +27,9 @@ root
            ├── columns: <none>
            ├── fetch columns: c:5 child.p:6
            ├── update-mapping:
-           │    └── column8:8 => child.p:4
+           │    └── p_new:8 => child.p:4
            └── project
-                ├── columns: column8:8 c:5!null child.p:6
+                ├── columns: p_new:8 c:5!null child.p:6
                 ├── semi-join (hash)
                 │    ├── columns: c:5!null child.p:6
                 │    ├── scan child
@@ -41,7 +41,7 @@ root
                 │    └── filters
                 │         └── child.p:6 = p:7
                 └── projections
-                     └── NULL::INT8 [as=column8:8]
+                     └── NULL::INT8 [as=p_new:8]
 
 exec-ddl
 CREATE TABLE parent_multicol (p INT, q INT, r INT, PRIMARY KEY (p, q, r))
@@ -82,17 +82,17 @@ root
            ├── columns: <none>
            ├── fetch columns: c:12 child_multicol.p:13 child_multicol.q:14 child_multicol.r:15 x:16
            ├── update-mapping:
-           │    ├── column20:20 => child_multicol.p:8
-           │    ├── column20:20 => child_multicol.q:9
-           │    ├── column20:20 => child_multicol.r:10
+           │    ├── p_new:20 => child_multicol.p:8
+           │    ├── p_new:20 => child_multicol.q:9
+           │    ├── p_new:20 => child_multicol.r:10
            │    └── column21:21 => x:11
            ├── check columns: check1:22
            └── project
-                ├── columns: check1:22!null c:12!null child_multicol.p:13 child_multicol.q:14 child_multicol.r:15 x:16 column20:20 column21:21
+                ├── columns: check1:22!null c:12!null child_multicol.p:13 child_multicol.q:14 child_multicol.r:15 x:16 p_new:20 column21:21
                 ├── project
-                │    ├── columns: column21:21 c:12!null child_multicol.p:13 child_multicol.q:14 child_multicol.r:15 x:16 column20:20
+                │    ├── columns: column21:21 c:12!null child_multicol.p:13 child_multicol.q:14 child_multicol.r:15 x:16 p_new:20
                 │    ├── project
-                │    │    ├── columns: column20:20 c:12!null child_multicol.p:13 child_multicol.q:14 child_multicol.r:15 x:16
+                │    │    ├── columns: p_new:20 c:12!null child_multicol.p:13 child_multicol.q:14 child_multicol.r:15 x:16
                 │    │    ├── semi-join (hash)
                 │    │    │    ├── columns: c:12!null child_multicol.p:13 child_multicol.q:14 child_multicol.r:15 x:16
                 │    │    │    ├── scan child_multicol
@@ -113,8 +113,8 @@ root
                 │    │    │         ├── child_multicol.q:14 = q:18
                 │    │    │         └── child_multicol.r:15 = r:19
                 │    │    └── projections
-                │    │         └── NULL::INT8 [as=column20:20]
+                │    │         └── NULL::INT8 [as=p_new:20]
                 │    └── projections
-                │         └── (column20:20 + column20:20) + column20:20 [as=column21:21]
+                │         └── (p_new:20 + p_new:20) + p_new:20 [as=column21:21]
                 └── projections
-                     └── (c:12 > 100) OR (column20:20 IS NOT NULL) [as=check1:22]
+                     └── (c:12 > 100) OR (p_new:20 IS NOT NULL) [as=check1:22]

--- a/pkg/sql/opt/optbuilder/testdata/projection-reuse
+++ b/pkg/sql/opt/optbuilder/testdata/projection-reuse
@@ -193,10 +193,10 @@ update abcd
  ├── columns: <none>
  ├── fetch columns: a:6 b:7 c:8 d:9 rowid:10
  ├── update-mapping:
- │    ├── column11:11 => a:1
- │    └── column12:12 => b:2
+ │    ├── a_new:11 => a:1
+ │    └── b_new:12 => b:2
  └── project
-      ├── columns: column11:11 column12:12 a:6!null b:7 c:8 d:9 rowid:10!null
+      ├── columns: a_new:11 b_new:12 a:6!null b:7 c:8 d:9 rowid:10!null
       ├── select
       │    ├── columns: a:6!null b:7 c:8 d:9 rowid:10!null
       │    ├── scan abcd
@@ -204,5 +204,5 @@ update abcd
       │    └── filters
       │         └── a:6 = 1.0
       └── projections
-           ├── random() [as=column11:11]
-           └── random() [as=column12:12]
+           ├── random() [as=a_new:11]
+           └── random() [as=b_new:12]

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -65,13 +65,13 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7 b:8 c:9 d:10 e:11 rowid:12
  ├── update-mapping:
- │    ├── column13:13 => a:1
+ │    ├── a_new:13 => a:1
  │    ├── column14:14 => d:4
- │    └── column13:13 => e:5
+ │    └── a_new:13 => e:5
  └── project
-      ├── columns: column14:14 a:7!null b:8 c:9 d:10 e:11 rowid:12!null column13:13!null
+      ├── columns: column14:14 a:7!null b:8 c:9 d:10 e:11 rowid:12!null a_new:13!null
       ├── project
-      │    ├── columns: column13:13!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
+      │    ├── columns: a_new:13!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    ├── select
       │    │    ├── columns: a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    │    ├── scan abcde
@@ -84,7 +84,7 @@ update abcde
       │    │    └── filters
       │    │         └── a:7 = 1
       │    └── projections
-      │         └── 2 [as=column13:13]
+      │         └── 2 [as=a_new:13]
       └── projections
            └── (b:8 + c:9) + 1 [as=column14:14]
 
@@ -96,16 +96,16 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7 b:8 c:9 d:10 e:11 rowid:12
  ├── update-mapping:
- │    ├── column13:13 => a:1
- │    ├── column14:14 => b:2
- │    ├── column15:15 => c:3
+ │    ├── a_new:13 => a:1
+ │    ├── b_new:14 => b:2
+ │    ├── c_new:15 => c:3
  │    ├── column17:17 => d:4
- │    ├── column13:13 => e:5
- │    └── column16:16 => rowid:6
+ │    ├── a_new:13 => e:5
+ │    └── rowid_new:16 => rowid:6
  └── project
-      ├── columns: column17:17!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null column13:13!null column14:14!null column15:15!null column16:16!null
+      ├── columns: column17:17!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null a_new:13!null b_new:14!null c_new:15!null rowid_new:16!null
       ├── project
-      │    ├── columns: column13:13!null column14:14!null column15:15!null column16:16!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
+      │    ├── columns: a_new:13!null b_new:14!null c_new:15!null rowid_new:16!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    ├── scan abcde
       │    │    ├── columns: a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    │    └── computed column expressions
@@ -114,12 +114,12 @@ update abcde
       │    │         └── e:11
       │    │              └── a:7
       │    └── projections
-      │         ├── 1 [as=column13:13]
-      │         ├── 2 [as=column14:14]
-      │         ├── 3 [as=column15:15]
-      │         └── 4 [as=column16:16]
+      │         ├── 1 [as=a_new:13]
+      │         ├── 2 [as=b_new:14]
+      │         ├── 3 [as=c_new:15]
+      │         └── 4 [as=rowid_new:16]
       └── projections
-           └── (column14:14 + column15:15) + 1 [as=column17:17]
+           └── (b_new:14 + c_new:15) + 1 [as=column17:17]
 
 # Set all non-computed columns in reverse order.
 build
@@ -129,16 +129,16 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7 b:8 c:9 d:10 e:11 rowid:12
  ├── update-mapping:
- │    ├── column16:16 => a:1
- │    ├── column15:15 => b:2
- │    ├── column14:14 => c:3
+ │    ├── a_new:16 => a:1
+ │    ├── b_new:15 => b:2
+ │    ├── c_new:14 => c:3
  │    ├── column17:17 => d:4
- │    ├── column16:16 => e:5
- │    └── column13:13 => rowid:6
+ │    ├── a_new:16 => e:5
+ │    └── rowid_new:13 => rowid:6
  └── project
-      ├── columns: column17:17!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null column13:13!null column14:14!null column15:15!null column16:16!null
+      ├── columns: column17:17!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null rowid_new:13!null c_new:14!null b_new:15!null a_new:16!null
       ├── project
-      │    ├── columns: column13:13!null column14:14!null column15:15!null column16:16!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
+      │    ├── columns: rowid_new:13!null c_new:14!null b_new:15!null a_new:16!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    ├── scan abcde
       │    │    ├── columns: a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    │    └── computed column expressions
@@ -147,12 +147,12 @@ update abcde
       │    │         └── e:11
       │    │              └── a:7
       │    └── projections
-      │         ├── 1 [as=column13:13]
-      │         ├── 2 [as=column14:14]
-      │         ├── 3 [as=column15:15]
-      │         └── 4 [as=column16:16]
+      │         ├── 1 [as=rowid_new:13]
+      │         ├── 2 [as=c_new:14]
+      │         ├── 3 [as=b_new:15]
+      │         └── 4 [as=a_new:16]
       └── projections
-           └── (column15:15 + column14:14) + 1 [as=column17:17]
+           └── (b_new:15 + c_new:14) + 1 [as=column17:17]
 
 # Set all non-computed columns to NULL.
 build
@@ -162,16 +162,16 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7 b:8 c:9 d:10 e:11 rowid:12
  ├── update-mapping:
- │    ├── column13:13 => a:1
- │    ├── column13:13 => b:2
- │    ├── column13:13 => c:3
+ │    ├── a_new:13 => a:1
+ │    ├── a_new:13 => b:2
+ │    ├── a_new:13 => c:3
  │    ├── column14:14 => d:4
- │    ├── column13:13 => e:5
- │    └── column13:13 => rowid:6
+ │    ├── a_new:13 => e:5
+ │    └── a_new:13 => rowid:6
  └── project
-      ├── columns: column14:14 a:7!null b:8 c:9 d:10 e:11 rowid:12!null column13:13
+      ├── columns: column14:14 a:7!null b:8 c:9 d:10 e:11 rowid:12!null a_new:13
       ├── project
-      │    ├── columns: column13:13 a:7!null b:8 c:9 d:10 e:11 rowid:12!null
+      │    ├── columns: a_new:13 a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    ├── scan abcde
       │    │    ├── columns: a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    │    └── computed column expressions
@@ -180,9 +180,9 @@ update abcde
       │    │         └── e:11
       │    │              └── a:7
       │    └── projections
-      │         └── NULL::INT8 [as=column13:13]
+      │         └── NULL::INT8 [as=a_new:13]
       └── projections
-           └── (column13:13 + column13:13) + 1 [as=column14:14]
+           └── (a_new:13 + a_new:13) + 1 [as=column14:14]
 
 # Set columns using variable expressions.
 build
@@ -192,14 +192,14 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7 b:8 c:9 d:10 e:11 rowid:12
  ├── update-mapping:
- │    ├── column13:13 => a:1
- │    ├── column14:14 => b:2
+ │    ├── a_new:13 => a:1
+ │    ├── b_new:14 => b:2
  │    ├── column15:15 => d:4
- │    └── column13:13 => e:5
+ │    └── a_new:13 => e:5
  └── project
-      ├── columns: column15:15 a:7!null b:8!null c:9 d:10 e:11!null rowid:12!null column13:13!null column14:14
+      ├── columns: column15:15 a:7!null b:8!null c:9 d:10 e:11!null rowid:12!null a_new:13!null b_new:14
       ├── project
-      │    ├── columns: column13:13!null column14:14 a:7!null b:8!null c:9 d:10 e:11!null rowid:12!null
+      │    ├── columns: a_new:13!null b_new:14 a:7!null b:8!null c:9 d:10 e:11!null rowid:12!null
       │    ├── select
       │    │    ├── columns: a:7!null b:8!null c:9 d:10 e:11!null rowid:12!null
       │    │    ├── scan abcde
@@ -212,10 +212,10 @@ update abcde
       │    │    └── filters
       │    │         └── b:8 > e:11
       │    └── projections
-      │         ├── a:7 + 1 [as=column13:13]
-      │         └── b:8 * c:9 [as=column14:14]
+      │         ├── a:7 + 1 [as=a_new:13]
+      │         └── b:8 * c:9 [as=b_new:14]
       └── projections
-           └── (column14:14 + c:9) + 1 [as=column15:15]
+           └── (b_new:14 + c:9) + 1 [as=column15:15]
 
 # Set columns using aliased expressions.
 build
@@ -249,13 +249,13 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7 b:8 c:9 d:10 e:11 rowid:12
  ├── update-mapping:
- │    ├── column13:13 => b:2
+ │    ├── b_new:13 => b:2
  │    ├── column14:14 => d:4
  │    └── a:7 => e:5
  └── project
-      ├── columns: column14:14 a:7!null b:8 c:9 d:10 e:11 rowid:12!null column13:13!null
+      ├── columns: column14:14 a:7!null b:8 c:9 d:10 e:11 rowid:12!null b_new:13!null
       ├── project
-      │    ├── columns: column13:13!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
+      │    ├── columns: b_new:13!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    ├── limit
       │    │    ├── columns: a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    │    ├── internal-ordering: +7
@@ -276,9 +276,9 @@ update abcde
       │    │    │              └── a:7 > 0
       │    │    └── 10
       │    └── projections
-      │         └── 1 [as=column13:13]
+      │         └── 1 [as=b_new:13]
       └── projections
-           └── (column13:13 + c:9) + 1 [as=column14:14]
+           └── (b_new:13 + c:9) + 1 [as=column14:14]
 
 # UPDATE with index hints.
 exec-ddl
@@ -298,9 +298,9 @@ update xyzw
  ├── columns: <none>
  ├── fetch columns: x:5 y:6 z:7 w:8
  ├── update-mapping:
- │    └── column9:9 => x:1
+ │    └── x_new:9 => x:1
  └── project
-      ├── columns: column9:9!null x:5!null y:6 z:7!null w:8
+      ├── columns: x_new:9!null x:5!null y:6 z:7!null w:8
       ├── select
       │    ├── columns: x:5!null y:6 z:7!null w:8
       │    ├── scan xyzw
@@ -309,7 +309,7 @@ update xyzw
       │    └── filters
       │         └── z:7 = 1
       └── projections
-           └── 2 [as=column9:9]
+           └── 2 [as=x_new:9]
 
 build
 UPDATE xyzw@foo SET x=2 WHERE z=1
@@ -318,9 +318,9 @@ update xyzw
  ├── columns: <none>
  ├── fetch columns: x:5 y:6 z:7 w:8
  ├── update-mapping:
- │    └── column9:9 => x:1
+ │    └── x_new:9 => x:1
  └── project
-      ├── columns: column9:9!null x:5!null y:6 z:7!null w:8
+      ├── columns: x_new:9!null x:5!null y:6 z:7!null w:8
       ├── select
       │    ├── columns: x:5!null y:6 z:7!null w:8
       │    ├── scan xyzw
@@ -329,7 +329,7 @@ update xyzw
       │    └── filters
       │         └── z:7 = 1
       └── projections
-           └── 2 [as=column9:9]
+           └── 2 [as=x_new:9]
 
 build
 UPDATE xyzw@{FORCE_INDEX=foo,ASC} SET x=2 WHERE z=1
@@ -338,9 +338,9 @@ update xyzw
  ├── columns: <none>
  ├── fetch columns: x:5 y:6 z:7 w:8
  ├── update-mapping:
- │    └── column9:9 => x:1
+ │    └── x_new:9 => x:1
  └── project
-      ├── columns: column9:9!null x:5!null y:6 z:7!null w:8
+      ├── columns: x_new:9!null x:5!null y:6 z:7!null w:8
       ├── select
       │    ├── columns: x:5!null y:6 z:7!null w:8
       │    ├── scan xyzw
@@ -349,7 +349,7 @@ update xyzw
       │    └── filters
       │         └── z:7 = 1
       └── projections
-           └── 2 [as=column9:9]
+           └── 2 [as=x_new:9]
 
 build
 UPDATE xyzw@{FORCE_INDEX=foo,DESC} SET x=2 WHERE z=1
@@ -358,9 +358,9 @@ update xyzw
  ├── columns: <none>
  ├── fetch columns: x:5 y:6 z:7 w:8
  ├── update-mapping:
- │    └── column9:9 => x:1
+ │    └── x_new:9 => x:1
  └── project
-      ├── columns: column9:9!null x:5!null y:6 z:7!null w:8
+      ├── columns: x_new:9!null x:5!null y:6 z:7!null w:8
       ├── select
       │    ├── columns: x:5!null y:6 z:7!null w:8
       │    ├── scan xyzw,rev
@@ -369,7 +369,7 @@ update xyzw
       │    └── filters
       │         └── z:7 = 1
       └── projections
-           └── 2 [as=column9:9]
+           └── 2 [as=x_new:9]
 
 build
 UPDATE xyzw@{NO_INDEX_JOIN} SET x=2 WHERE z=1
@@ -378,9 +378,9 @@ update xyzw
  ├── columns: <none>
  ├── fetch columns: x:5 y:6 z:7 w:8
  ├── update-mapping:
- │    └── column9:9 => x:1
+ │    └── x_new:9 => x:1
  └── project
-      ├── columns: column9:9!null x:5!null y:6 z:7!null w:8
+      ├── columns: x_new:9!null x:5!null y:6 z:7!null w:8
       ├── select
       │    ├── columns: x:5!null y:6 z:7!null w:8
       │    ├── scan xyzw
@@ -389,7 +389,7 @@ update xyzw
       │    └── filters
       │         └── z:7 = 1
       └── projections
-           └── 2 [as=column9:9]
+           └── 2 [as=x_new:9]
 
 build
 UPDATE xyzw@bad_idx SET x=2 WHERE z=1
@@ -405,15 +405,15 @@ update xyz
  ├── columns: <none>
  ├── fetch columns: x:4 y:5 z:6
  ├── update-mapping:
- │    ├── column7:7 => y:2
- │    └── column8:8 => z:3
+ │    ├── y_new:7 => y:2
+ │    └── z_new:8 => z:3
  └── project
-      ├── columns: column7:7!null column8:8!null x:4!null y:5 z:6
+      ├── columns: y_new:7!null z_new:8!null x:4!null y:5 z:6
       ├── scan xyz
       │    └── columns: x:4!null y:5 z:6
       └── projections
-           ├── 1 [as=column7:7]
-           └── 1.0 [as=column8:8]
+           ├── 1 [as=y_new:7]
+           └── 1.0 [as=z_new:8]
 
 # Use placeholders.
 build
@@ -423,17 +423,17 @@ update xyz
  ├── columns: <none>
  ├── fetch columns: x:4 y:5 z:6
  ├── update-mapping:
- │    ├── column7:7 => x:1
- │    ├── column8:8 => y:2
- │    └── column9:9 => z:3
+ │    ├── x_new:7 => x:1
+ │    ├── y_new:8 => y:2
+ │    └── z_new:9 => z:3
  └── project
-      ├── columns: column7:7 column8:8 column9:9 x:4!null y:5 z:6
+      ├── columns: x_new:7 y_new:8 z_new:9 x:4!null y:5 z:6
       ├── scan xyz
       │    └── columns: x:4!null y:5 z:6
       └── projections
-           ├── $1 [as=column7:7]
-           ├── $2 [as=column8:8]
-           └── $3 [as=column9:9]
+           ├── $1 [as=x_new:7]
+           ├── $2 [as=y_new:8]
+           └── $3 [as=z_new:9]
 
 # Duplicate expressions with placeholders.
 build
@@ -443,14 +443,14 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7 b:8 c:9 d:10 e:11 rowid:12
  ├── update-mapping:
- │    ├── column13:13 => a:1
- │    ├── column13:13 => b:2
+ │    ├── a_new:13 => a:1
+ │    ├── a_new:13 => b:2
  │    ├── column14:14 => d:4
- │    └── column13:13 => e:5
+ │    └── a_new:13 => e:5
  └── project
-      ├── columns: column14:14 a:7!null b:8 c:9!null d:10 e:11 rowid:12!null column13:13
+      ├── columns: column14:14 a:7!null b:8 c:9!null d:10 e:11 rowid:12!null a_new:13
       ├── project
-      │    ├── columns: column13:13 a:7!null b:8 c:9!null d:10 e:11 rowid:12!null
+      │    ├── columns: a_new:13 a:7!null b:8 c:9!null d:10 e:11 rowid:12!null
       │    ├── select
       │    │    ├── columns: a:7!null b:8 c:9!null d:10 e:11 rowid:12!null
       │    │    ├── scan abcde
@@ -463,9 +463,9 @@ update abcde
       │    │    └── filters
       │    │         └── c:9 = 10
       │    └── projections
-      │         └── $1 + 1 [as=column13:13]
+      │         └── $1 + 1 [as=a_new:13]
       └── projections
-           └── (column13:13 + c:9) + 1 [as=column14:14]
+           └── (a_new:13 + c:9) + 1 [as=column14:14]
 
 
 # Unknown target table.
@@ -573,13 +573,13 @@ project
       ├── columns: a:1!null b:2 c:3 d:4 e:5!null rowid:6!null
       ├── fetch columns: a:7 b:8 c:9 d:10 e:11 rowid:12
       ├── update-mapping:
-      │    ├── column13:13 => a:1
+      │    ├── a_new:13 => a:1
       │    ├── column14:14 => d:4
-      │    └── column13:13 => e:5
+      │    └── a_new:13 => e:5
       └── project
-           ├── columns: column14:14 a:7!null b:8 c:9 d:10 e:11 rowid:12!null column13:13!null
+           ├── columns: column14:14 a:7!null b:8 c:9 d:10 e:11 rowid:12!null a_new:13!null
            ├── project
-           │    ├── columns: column13:13!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
+           │    ├── columns: a_new:13!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
            │    ├── select
            │    │    ├── columns: a:7!null b:8 c:9 d:10 e:11 rowid:12!null
            │    │    ├── scan abcde
@@ -592,7 +592,7 @@ project
            │    │    └── filters
            │    │         └── a:7 = 1
            │    └── projections
-           │         └── 2 [as=column13:13]
+           │         └── 2 [as=a_new:13]
            └── projections
                 └── (b:8 + c:9) + 1 [as=column14:14]
 
@@ -606,13 +606,13 @@ project
  │    ├── columns: a:1!null b:2 c:3 d:4 e:5!null rowid:6!null
  │    ├── fetch columns: a:7 b:8 c:9 d:10 e:11 rowid:12
  │    ├── update-mapping:
- │    │    ├── column13:13 => a:1
+ │    │    ├── a_new:13 => a:1
  │    │    ├── column14:14 => d:4
- │    │    └── column13:13 => e:5
+ │    │    └── a_new:13 => e:5
  │    └── project
- │         ├── columns: column14:14 a:7!null b:8 c:9 d:10 e:11 rowid:12!null column13:13!null
+ │         ├── columns: column14:14 a:7!null b:8 c:9 d:10 e:11 rowid:12!null a_new:13!null
  │         ├── project
- │         │    ├── columns: column13:13!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
+ │         │    ├── columns: a_new:13!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
  │         │    ├── select
  │         │    │    ├── columns: a:7!null b:8 c:9 d:10 e:11 rowid:12!null
  │         │    │    ├── scan foo
@@ -625,7 +625,7 @@ project
  │         │    │    └── filters
  │         │    │         └── a:7 = 1
  │         │    └── projections
- │         │         └── 2 [as=column13:13]
+ │         │         └── 2 [as=a_new:13]
  │         └── projections
  │              └── (b:8 + c:9) + 1 [as=column14:14]
  └── projections
@@ -644,13 +644,13 @@ with &1
  │         ├── columns: abcde.a:1!null abcde.b:2 abcde.c:3 abcde.d:4 abcde.e:5!null rowid:6!null
  │         ├── fetch columns: abcde.a:7 abcde.b:8 abcde.c:9 abcde.d:10 abcde.e:11 rowid:12
  │         ├── update-mapping:
- │         │    ├── column13:13 => abcde.a:1
+ │         │    ├── a_new:13 => abcde.a:1
  │         │    ├── column14:14 => abcde.d:4
- │         │    └── column13:13 => abcde.e:5
+ │         │    └── a_new:13 => abcde.e:5
  │         └── project
- │              ├── columns: column14:14 abcde.a:7!null abcde.b:8 abcde.c:9 abcde.d:10 abcde.e:11 rowid:12!null column13:13!null
+ │              ├── columns: column14:14 abcde.a:7!null abcde.b:8 abcde.c:9 abcde.d:10 abcde.e:11 rowid:12!null a_new:13!null
  │              ├── project
- │              │    ├── columns: column13:13!null abcde.a:7!null abcde.b:8 abcde.c:9 abcde.d:10 abcde.e:11 rowid:12!null
+ │              │    ├── columns: a_new:13!null abcde.a:7!null abcde.b:8 abcde.c:9 abcde.d:10 abcde.e:11 rowid:12!null
  │              │    ├── limit
  │              │    │    ├── columns: abcde.a:7!null abcde.b:8 abcde.c:9 abcde.d:10 abcde.e:11 rowid:12!null
  │              │    │    ├── internal-ordering: +8
@@ -671,7 +671,7 @@ with &1
  │              │    │    │              └── abcde.a:7 > 0
  │              │    │    └── 10
  │              │    └── projections
- │              │         └── 2 [as=column13:13]
+ │              │         └── 2 [as=a_new:13]
  │              └── projections
  │                   └── (abcde.b:8 + abcde.c:9) + 1 [as=column14:14]
  └── project
@@ -697,11 +697,11 @@ project
       ├── update-mapping:
       │    ├── column14:14 => d:4
       │    ├── a:7 => e:5
-      │    └── column13:13 => rowid:6
+      │    └── rowid_new:13 => rowid:6
       └── project
-           ├── columns: column14:14 a:7!null b:8 c:9 d:10 e:11 rowid:12!null column13:13!null
+           ├── columns: column14:14 a:7!null b:8 c:9 d:10 e:11 rowid:12!null rowid_new:13!null
            ├── project
-           │    ├── columns: column13:13!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
+           │    ├── columns: rowid_new:13!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
            │    ├── scan abcde
            │    │    ├── columns: a:7!null b:8 c:9 d:10 e:11 rowid:12!null
            │    │    └── computed column expressions
@@ -710,7 +710,7 @@ project
            │    │         └── e:11
            │    │              └── a:7
            │    └── projections
-           │         └── rowid:12 + 1 [as=column13:13]
+           │         └── rowid:12 + 1 [as=rowid_new:13]
            └── projections
                 └── (b:8 + c:9) + 1 [as=column14:14]
 
@@ -738,14 +738,14 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7 b:8 c:9 d:10 e:11 rowid:12
  ├── update-mapping:
- │    ├── column13:13 => b:2
- │    ├── column14:14 => c:3
+ │    ├── b_new:13 => b:2
+ │    ├── c_new:14 => c:3
  │    ├── column15:15 => d:4
  │    └── a:7 => e:5
  └── project
-      ├── columns: column15:15 a:7!null b:8 c:9 d:10 e:11 rowid:12!null column13:13 column14:14!null
+      ├── columns: column15:15 a:7!null b:8 c:9 d:10 e:11 rowid:12!null b_new:13 c_new:14!null
       ├── project
-      │    ├── columns: column13:13 column14:14!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
+      │    ├── columns: b_new:13 c_new:14!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    ├── scan abcde
       │    │    ├── columns: a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    │    └── computed column expressions
@@ -754,10 +754,10 @@ update abcde
       │    │         └── e:11
       │    │              └── a:7
       │    └── projections
-      │         ├── NULL::INT8 [as=column13:13]
-      │         └── 10 [as=column14:14]
+      │         ├── NULL::INT8 [as=b_new:13]
+      │         └── 10 [as=c_new:14]
       └── projections
-           └── (column13:13 + column14:14) + 1 [as=column15:15]
+           └── (b_new:13 + c_new:14) + 1 [as=column15:15]
 
 # Allow not-null column to be updated with NULL DEFAULT value (would fail at
 # runtime if there are any rows to update).
@@ -768,13 +768,13 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7 b:8 c:9 d:10 e:11 rowid:12
  ├── update-mapping:
- │    ├── column13:13 => a:1
+ │    ├── a_new:13 => a:1
  │    ├── column14:14 => d:4
- │    └── column13:13 => e:5
+ │    └── a_new:13 => e:5
  └── project
-      ├── columns: column14:14 a:7!null b:8 c:9 d:10 e:11 rowid:12!null column13:13
+      ├── columns: column14:14 a:7!null b:8 c:9 d:10 e:11 rowid:12!null a_new:13
       ├── project
-      │    ├── columns: column13:13 a:7!null b:8 c:9 d:10 e:11 rowid:12!null
+      │    ├── columns: a_new:13 a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    ├── scan abcde
       │    │    ├── columns: a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    │    └── computed column expressions
@@ -783,7 +783,7 @@ update abcde
       │    │         └── e:11
       │    │              └── a:7
       │    └── projections
-      │         └── NULL::INT8 [as=column13:13]
+      │         └── NULL::INT8 [as=a_new:13]
       └── projections
            └── (b:8 + c:9) + 1 [as=column14:14]
 
@@ -803,15 +803,15 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7 b:8 c:9 d:10 e:11 rowid:12
  ├── update-mapping:
- │    ├── column13:13 => a:1
- │    ├── column14:14 => b:2
- │    ├── column15:15 => c:3
+ │    ├── a_new:13 => a:1
+ │    ├── b_new:14 => b:2
+ │    ├── c_new:15 => c:3
  │    ├── column16:16 => d:4
- │    └── column13:13 => e:5
+ │    └── a_new:13 => e:5
  └── project
-      ├── columns: column16:16!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null column13:13!null column14:14!null column15:15!null
+      ├── columns: column16:16!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null a_new:13!null b_new:14!null c_new:15!null
       ├── project
-      │    ├── columns: column13:13!null column14:14!null column15:15!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
+      │    ├── columns: a_new:13!null b_new:14!null c_new:15!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    ├── scan abcde
       │    │    ├── columns: a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    │    └── computed column expressions
@@ -820,11 +820,11 @@ update abcde
       │    │         └── e:11
       │    │              └── a:7
       │    └── projections
-      │         ├── 1 [as=column13:13]
-      │         ├── 2 [as=column14:14]
-      │         └── 3 [as=column15:15]
+      │         ├── 1 [as=a_new:13]
+      │         ├── 2 [as=b_new:14]
+      │         └── 3 [as=c_new:15]
       └── projections
-           └── (column14:14 + column15:15) + 1 [as=column16:16]
+           └── (b_new:14 + c_new:15) + 1 [as=column16:16]
 
 build
 UPDATE abcde SET (c) = (NULL), (b, a) = (1, 2)
@@ -833,15 +833,15 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7 b:8 c:9 d:10 e:11 rowid:12
  ├── update-mapping:
- │    ├── column15:15 => a:1
- │    ├── column14:14 => b:2
- │    ├── column13:13 => c:3
+ │    ├── a_new:15 => a:1
+ │    ├── b_new:14 => b:2
+ │    ├── c_new:13 => c:3
  │    ├── column16:16 => d:4
- │    └── column15:15 => e:5
+ │    └── a_new:15 => e:5
  └── project
-      ├── columns: column16:16 a:7!null b:8 c:9 d:10 e:11 rowid:12!null column13:13 column14:14!null column15:15!null
+      ├── columns: column16:16 a:7!null b:8 c:9 d:10 e:11 rowid:12!null c_new:13 b_new:14!null a_new:15!null
       ├── project
-      │    ├── columns: column13:13 column14:14!null column15:15!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
+      │    ├── columns: c_new:13 b_new:14!null a_new:15!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    ├── scan abcde
       │    │    ├── columns: a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    │    └── computed column expressions
@@ -850,11 +850,11 @@ update abcde
       │    │         └── e:11
       │    │              └── a:7
       │    └── projections
-      │         ├── NULL::INT8 [as=column13:13]
-      │         ├── 1 [as=column14:14]
-      │         └── 2 [as=column15:15]
+      │         ├── NULL::INT8 [as=c_new:13]
+      │         ├── 1 [as=b_new:14]
+      │         └── 2 [as=a_new:15]
       └── projections
-           └── (column14:14 + column13:13) + 1 [as=column16:16]
+           └── (b_new:14 + c_new:13) + 1 [as=column16:16]
 
 # Tuples + DEFAULT.
 build
@@ -864,14 +864,14 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7 b:8 c:9 d:10 e:11 rowid:12
  ├── update-mapping:
- │    ├── column13:13 => b:2
- │    ├── column14:14 => c:3
+ │    ├── b_new:13 => b:2
+ │    ├── c_new:14 => c:3
  │    ├── column15:15 => d:4
  │    └── a:7 => e:5
  └── project
-      ├── columns: column15:15 a:7!null b:8 c:9 d:10 e:11 rowid:12!null column13:13 column14:14!null
+      ├── columns: column15:15 a:7!null b:8 c:9 d:10 e:11 rowid:12!null b_new:13 c_new:14!null
       ├── project
-      │    ├── columns: column13:13 column14:14!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
+      │    ├── columns: b_new:13 c_new:14!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    ├── scan abcde
       │    │    ├── columns: a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    │    └── computed column expressions
@@ -880,10 +880,10 @@ update abcde
       │    │         └── e:11
       │    │              └── a:7
       │    └── projections
-      │         ├── NULL::INT8 [as=column13:13]
-      │         └── 10 [as=column14:14]
+      │         ├── NULL::INT8 [as=b_new:13]
+      │         └── 10 [as=c_new:14]
       └── projections
-           └── (column13:13 + column14:14) + 1 [as=column15:15]
+           └── (b_new:13 + c_new:14) + 1 [as=column15:15]
 
 # Tuples + non-null DEFAULT.
 build
@@ -893,14 +893,14 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7 b:8 c:9 d:10 e:11 rowid:12
  ├── update-mapping:
- │    ├── column13:13 => a:1
- │    ├── column13:13 => b:2
+ │    ├── a_new:13 => a:1
+ │    ├── a_new:13 => b:2
  │    ├── column14:14 => d:4
- │    └── column13:13 => e:5
+ │    └── a_new:13 => e:5
  └── project
-      ├── columns: column14:14 a:7!null b:8 c:9 d:10 e:11 rowid:12!null column13:13
+      ├── columns: column14:14 a:7!null b:8 c:9 d:10 e:11 rowid:12!null a_new:13
       ├── project
-      │    ├── columns: column13:13 a:7!null b:8 c:9 d:10 e:11 rowid:12!null
+      │    ├── columns: a_new:13 a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    ├── scan abcde
       │    │    ├── columns: a:7!null b:8 c:9 d:10 e:11 rowid:12!null
       │    │    └── computed column expressions
@@ -909,9 +909,9 @@ update abcde
       │    │         └── e:11
       │    │              └── a:7
       │    └── projections
-      │         └── NULL::INT8 [as=column13:13]
+      │         └── NULL::INT8 [as=a_new:13]
       └── projections
-           └── (column13:13 + c:9) + 1 [as=column14:14]
+           └── (a_new:13 + c:9) + 1 [as=column14:14]
 
 build
 UPDATE abcde SET (a, b)=(1, 2, 3)
@@ -1020,14 +1020,14 @@ update abcde
  ├── update-mapping:
  │    ├── y:14 => a:1
  │    ├── y1:16 => b:2
- │    ├── column17:17 => c:3
+ │    ├── c_new:17 => c:3
  │    ├── column19:19 => d:4
  │    ├── y:14 => e:5
- │    └── column18:18 => rowid:6
+ │    └── rowid_new:18 => rowid:6
  └── project
-      ├── columns: column19:19 a:7!null b:8 c:9 d:10 e:11 rowid:12!null y:14 y1:16 column17:17!null column18:18!null
+      ├── columns: column19:19 a:7!null b:8 c:9 d:10 e:11 rowid:12!null y:14 y1:16 c_new:17!null rowid_new:18!null
       ├── project
-      │    ├── columns: column17:17!null column18:18!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null y:14 y1:16
+      │    ├── columns: c_new:17!null rowid_new:18!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null y:14 y1:16
       │    ├── left-join-apply
       │    │    ├── columns: a:7!null b:8 c:9 d:10 e:11 rowid:12!null y:14 y1:16
       │    │    ├── scan abcde
@@ -1047,10 +1047,10 @@ update abcde
       │    │    │              └── y:14 + 1 [as=y1:16]
       │    │    └── filters (true)
       │    └── projections
-      │         ├── 1 [as=column17:17]
-      │         └── 2 [as=column18:18]
+      │         ├── 1 [as=c_new:17]
+      │         └── 2 [as=rowid_new:18]
       └── projections
-           └── (y1:16 + column17:17) + 1 [as=column19:19]
+           └── (y1:16 + c_new:17) + 1 [as=column19:19]
 
 # Use subquery SET expression after other expressions.
 build
@@ -1060,16 +1060,16 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7 b:8 c:9 d:10 e:11 rowid:12
  ├── update-mapping:
- │    ├── column17:17 => a:1
- │    ├── column18:18 => b:2
+ │    ├── a_new:17 => a:1
+ │    ├── b_new:18 => b:2
  │    ├── y:14 => c:3
  │    ├── column19:19 => d:4
- │    ├── column17:17 => e:5
+ │    ├── a_new:17 => e:5
  │    └── y1:16 => rowid:6
  └── project
-      ├── columns: column19:19 a:7!null b:8 c:9 d:10 e:11 rowid:12!null y:14 y1:16 column17:17!null column18:18!null
+      ├── columns: column19:19 a:7!null b:8 c:9 d:10 e:11 rowid:12!null y:14 y1:16 a_new:17!null b_new:18!null
       ├── project
-      │    ├── columns: column17:17!null column18:18!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null y:14 y1:16
+      │    ├── columns: a_new:17!null b_new:18!null a:7!null b:8 c:9 d:10 e:11 rowid:12!null y:14 y1:16
       │    ├── left-join-apply
       │    │    ├── columns: a:7!null b:8 c:9 d:10 e:11 rowid:12!null y:14 y1:16
       │    │    ├── scan abcde
@@ -1089,10 +1089,10 @@ update abcde
       │    │    │              └── y:14 + 1 [as=y1:16]
       │    │    └── filters (true)
       │    └── projections
-      │         ├── 1 [as=column17:17]
-      │         └── 2 [as=column18:18]
+      │         ├── 1 [as=a_new:17]
+      │         └── 2 [as=b_new:18]
       └── projections
-           └── (column18:18 + y:14) + 1 [as=column19:19]
+           └── (b_new:18 + y:14) + 1 [as=column19:19]
 
 # Multiple subqueries in SET expressions.
 build
@@ -1151,11 +1151,11 @@ update xyz
  ├── columns: <none>
  ├── fetch columns: x:4 y:5 z:6
  ├── update-mapping:
- │    ├── column9:9 => x:1
+ │    ├── x_new:9 => x:1
  │    ├── three:8 => y:2
  │    └── two:7 => z:3
  └── project
-      ├── columns: column9:9!null x:4!null y:5 z:6 two:7 three:8
+      ├── columns: x_new:9!null x:4!null y:5 z:6 two:7 three:8
       ├── left-join-apply
       │    ├── columns: x:4!null y:5 z:6 two:7 three:8
       │    ├── scan xyz
@@ -1171,7 +1171,7 @@ update xyz
       │    │              └── 3 [as=three:8]
       │    └── filters (true)
       └── projections
-           └── 'foo' [as=column9:9]
+           └── 'foo' [as=x_new:9]
 
 # SET expression contains correlated subquery + alias.
 build
@@ -1183,13 +1183,13 @@ project
       ├── columns: abcde1.a:1!null abcde1.b:2 abcde1.c:3 abcde1.d:4 abcde1.e:5!null abcde1.rowid:6!null
       ├── fetch columns: abcde1.a:7 abcde1.b:8 abcde1.c:9 abcde1.d:10 abcde1.e:11 abcde1.rowid:12
       ├── update-mapping:
-      │    ├── column19:19 => abcde1.b:2
+      │    ├── b_new:19 => abcde1.b:2
       │    ├── column20:20 => abcde1.d:4
       │    └── abcde1.a:7 => abcde1.e:5
       └── project
-           ├── columns: column20:20 abcde1.a:7!null abcde1.b:8 abcde1.c:9 abcde1.d:10 abcde1.e:11 abcde1.rowid:12!null column19:19
+           ├── columns: column20:20 abcde1.a:7!null abcde1.b:8 abcde1.c:9 abcde1.d:10 abcde1.e:11 abcde1.rowid:12!null b_new:19
            ├── project
-           │    ├── columns: column19:19 abcde1.a:7!null abcde1.b:8 abcde1.c:9 abcde1.d:10 abcde1.e:11 abcde1.rowid:12!null
+           │    ├── columns: b_new:19 abcde1.a:7!null abcde1.b:8 abcde1.c:9 abcde1.d:10 abcde1.e:11 abcde1.rowid:12!null
            │    ├── scan abcde1
            │    │    ├── columns: abcde1.a:7!null abcde1.b:8 abcde1.c:9 abcde1.d:10 abcde1.e:11 abcde1.rowid:12!null
            │    │    └── computed column expressions
@@ -1198,7 +1198,7 @@ project
            │    │         └── abcde1.e:11
            │    │              └── abcde1.a:7
            │    └── projections
-           │         └── subquery [as=column19:19]
+           │         └── subquery [as=b_new:19]
            │              └── max1-row
            │                   ├── columns: abcde2.b:14
            │                   └── project
@@ -1215,7 +1215,7 @@ project
            │                             └── filters
            │                                  └── abcde2.rowid:18 = abcde1.a:7
            └── projections
-                └── (column19:19 + abcde1.c:9) + 1 [as=column20:20]
+                └── (b_new:19 + abcde1.c:9) + 1 [as=column20:20]
 
 # Too many values.
 build
@@ -1334,30 +1334,30 @@ update mutation
  ├── columns: <none>
  ├── fetch columns: m:6 n:7 o:8 p:9 q:10
  ├── update-mapping:
- │    ├── column11:11 => m:1
+ │    ├── m_new:11 => m:1
  │    ├── column12:12 => o:3
  │    └── column13:13 => p:4
  ├── check columns: check1:14
  └── project
-      ├── columns: check1:14!null m:6!null n:7 o:8 p:9 q:10 column11:11!null column12:12!null column13:13
+      ├── columns: check1:14!null m:6!null n:7 o:8 p:9 q:10 m_new:11!null column12:12!null column13:13
       ├── project
-      │    ├── columns: column13:13 m:6!null n:7 o:8 p:9 q:10 column11:11!null column12:12!null
+      │    ├── columns: column13:13 m:6!null n:7 o:8 p:9 q:10 m_new:11!null column12:12!null
       │    ├── project
-      │    │    ├── columns: column12:12!null m:6!null n:7 o:8 p:9 q:10 column11:11!null
+      │    │    ├── columns: column12:12!null m:6!null n:7 o:8 p:9 q:10 m_new:11!null
       │    │    ├── project
-      │    │    │    ├── columns: column11:11!null m:6!null n:7 o:8 p:9 q:10
+      │    │    │    ├── columns: m_new:11!null m:6!null n:7 o:8 p:9 q:10
       │    │    │    ├── scan mutation
       │    │    │    │    ├── columns: m:6!null n:7 o:8 p:9 q:10
       │    │    │    │    └── check constraint expressions
       │    │    │    │         └── m:6 > 0
       │    │    │    └── projections
-      │    │    │         └── 1 [as=column11:11]
+      │    │    │         └── 1 [as=m_new:11]
       │    │    └── projections
       │    │         └── 10 [as=column12:12]
       │    └── projections
       │         └── column12:12 + n:7 [as=column13:13]
       └── projections
-           └── column11:11 > 0 [as=check1:14]
+           └── m_new:11 > 0 [as=check1:14]
 
 # Update column that mutation column depends upon.
 build
@@ -1367,32 +1367,32 @@ update mutation
  ├── columns: <none>
  ├── fetch columns: m:6 n:7 o:8 p:9 q:10
  ├── update-mapping:
- │    ├── column11:11 => m:1
- │    ├── column12:12 => n:2
+ │    ├── m_new:11 => m:1
+ │    ├── n_new:12 => n:2
  │    ├── column13:13 => o:3
  │    └── column14:14 => p:4
  ├── check columns: check1:15
  └── project
-      ├── columns: check1:15!null m:6!null n:7 o:8 p:9 q:10 column11:11!null column12:12!null column13:13!null column14:14!null
+      ├── columns: check1:15!null m:6!null n:7 o:8 p:9 q:10 m_new:11!null n_new:12!null column13:13!null column14:14!null
       ├── project
-      │    ├── columns: column14:14!null m:6!null n:7 o:8 p:9 q:10 column11:11!null column12:12!null column13:13!null
+      │    ├── columns: column14:14!null m:6!null n:7 o:8 p:9 q:10 m_new:11!null n_new:12!null column13:13!null
       │    ├── project
-      │    │    ├── columns: column13:13!null m:6!null n:7 o:8 p:9 q:10 column11:11!null column12:12!null
+      │    │    ├── columns: column13:13!null m:6!null n:7 o:8 p:9 q:10 m_new:11!null n_new:12!null
       │    │    ├── project
-      │    │    │    ├── columns: column11:11!null column12:12!null m:6!null n:7 o:8 p:9 q:10
+      │    │    │    ├── columns: m_new:11!null n_new:12!null m:6!null n:7 o:8 p:9 q:10
       │    │    │    ├── scan mutation
       │    │    │    │    ├── columns: m:6!null n:7 o:8 p:9 q:10
       │    │    │    │    └── check constraint expressions
       │    │    │    │         └── m:6 > 0
       │    │    │    └── projections
-      │    │    │         ├── 1 [as=column11:11]
-      │    │    │         └── 2 [as=column12:12]
+      │    │    │         ├── 1 [as=m_new:11]
+      │    │    │         └── 2 [as=n_new:12]
       │    │    └── projections
       │    │         └── 10 [as=column13:13]
       │    └── projections
-      │         └── column13:13 + column12:12 [as=column14:14]
+      │         └── column13:13 + n_new:12 [as=column14:14]
       └── projections
-           └── column11:11 > 0 [as=check1:15]
+           └── m_new:11 > 0 [as=check1:15]
 
 # Ensure that ORDER BY wildcard does not select mutation columns.
 build
@@ -1402,18 +1402,18 @@ update mutation
  ├── columns: <none>
  ├── fetch columns: m:6 n:7 o:8 p:9 q:10
  ├── update-mapping:
- │    ├── column11:11 => m:1
+ │    ├── m_new:11 => m:1
  │    ├── column12:12 => o:3
  │    └── column13:13 => p:4
  ├── check columns: check1:14
  └── project
-      ├── columns: check1:14!null m:6!null n:7 o:8 p:9 q:10 column11:11!null column12:12!null column13:13
+      ├── columns: check1:14!null m:6!null n:7 o:8 p:9 q:10 m_new:11!null column12:12!null column13:13
       ├── project
-      │    ├── columns: column13:13 m:6!null n:7 o:8 p:9 q:10 column11:11!null column12:12!null
+      │    ├── columns: column13:13 m:6!null n:7 o:8 p:9 q:10 m_new:11!null column12:12!null
       │    ├── project
-      │    │    ├── columns: column12:12!null m:6!null n:7 o:8 p:9 q:10 column11:11!null
+      │    │    ├── columns: column12:12!null m:6!null n:7 o:8 p:9 q:10 m_new:11!null
       │    │    ├── project
-      │    │    │    ├── columns: column11:11!null m:6!null n:7 o:8 p:9 q:10
+      │    │    │    ├── columns: m_new:11!null m:6!null n:7 o:8 p:9 q:10
       │    │    │    ├── limit
       │    │    │    │    ├── columns: m:6!null n:7 o:8 p:9 q:10
       │    │    │    │    ├── internal-ordering: +6,+7
@@ -1428,13 +1428,13 @@ update mutation
       │    │    │    │    │         └── ordering: +6
       │    │    │    │    └── 10
       │    │    │    └── projections
-      │    │    │         └── 1 [as=column11:11]
+      │    │    │         └── 1 [as=m_new:11]
       │    │    └── projections
       │    │         └── 10 [as=column12:12]
       │    └── projections
       │         └── column12:12 + n:7 [as=column13:13]
       └── projections
-           └── column11:11 > 0 [as=check1:14]
+           └── m_new:11 > 0 [as=check1:14]
 
 # Try to return a mutation column.
 build
@@ -1478,17 +1478,17 @@ update checks
  ├── columns: <none>
  ├── fetch columns: a:5 b:6 c:7 d:8
  ├── update-mapping:
- │    ├── column9:9 => a:1
- │    ├── column10:10 => b:2
- │    ├── column11:11 => c:3
+ │    ├── a_new:9 => a:1
+ │    ├── b_new:10 => b:2
+ │    ├── c_new:11 => c:3
  │    └── column12:12 => d:4
  ├── check columns: check1:13 check2:14
  └── project
-      ├── columns: check1:13!null check2:14!null a:5!null b:6 c:7 d:8 column9:9!null column10:10!null column11:11!null column12:12!null
+      ├── columns: check1:13!null check2:14!null a:5!null b:6 c:7 d:8 a_new:9!null b_new:10!null c_new:11!null column12:12!null
       ├── project
-      │    ├── columns: column12:12!null a:5!null b:6 c:7 d:8 column9:9!null column10:10!null column11:11!null
+      │    ├── columns: column12:12!null a:5!null b:6 c:7 d:8 a_new:9!null b_new:10!null c_new:11!null
       │    ├── project
-      │    │    ├── columns: column9:9!null column10:10!null column11:11!null a:5!null b:6 c:7 d:8
+      │    │    ├── columns: a_new:9!null b_new:10!null c_new:11!null a:5!null b:6 c:7 d:8
       │    │    ├── scan checks
       │    │    │    ├── columns: a:5!null b:6 c:7 d:8
       │    │    │    ├── check constraint expressions
@@ -1497,14 +1497,14 @@ update checks
       │    │    │         └── d:8
       │    │    │              └── c:7 + 1
       │    │    └── projections
-      │    │         ├── 1 [as=column9:9]
-      │    │         ├── 2 [as=column10:10]
-      │    │         └── 3 [as=column11:11]
+      │    │         ├── 1 [as=a_new:9]
+      │    │         ├── 2 [as=b_new:10]
+      │    │         └── 3 [as=c_new:11]
       │    └── projections
-      │         └── column11:11 + 1 [as=column12:12]
+      │         └── c_new:11 + 1 [as=column12:12]
       └── projections
-           ├── column10:10 < column12:12 [as=check1:13]
-           └── column9:9 > 0 [as=check2:14]
+           ├── b_new:10 < column12:12 [as=check1:13]
+           └── a_new:9 > 0 [as=check2:14]
 
 # Do not update columns for one of the constraints.
 build
@@ -1514,15 +1514,15 @@ update checks
  ├── columns: <none>
  ├── fetch columns: a:5 b:6 c:7 d:8
  ├── update-mapping:
- │    ├── column9:9 => a:1
+ │    ├── a_new:9 => a:1
  │    └── column10:10 => d:4
  ├── check columns: check1:11 check2:12
  └── project
-      ├── columns: check1:11 check2:12!null a:5!null b:6 c:7 d:8 column9:9!null column10:10
+      ├── columns: check1:11 check2:12!null a:5!null b:6 c:7 d:8 a_new:9!null column10:10
       ├── project
-      │    ├── columns: column10:10 a:5!null b:6 c:7 d:8 column9:9!null
+      │    ├── columns: column10:10 a:5!null b:6 c:7 d:8 a_new:9!null
       │    ├── project
-      │    │    ├── columns: column9:9!null a:5!null b:6 c:7 d:8
+      │    │    ├── columns: a_new:9!null a:5!null b:6 c:7 d:8
       │    │    ├── scan checks
       │    │    │    ├── columns: a:5!null b:6 c:7 d:8
       │    │    │    ├── check constraint expressions
@@ -1531,12 +1531,12 @@ update checks
       │    │    │         └── d:8
       │    │    │              └── c:7 + 1
       │    │    └── projections
-      │    │         └── 1 [as=column9:9]
+      │    │         └── 1 [as=a_new:9]
       │    └── projections
       │         └── c:7 + 1 [as=column10:10]
       └── projections
            ├── b:6 < column10:10 [as=check1:11]
-           └── column9:9 > 0 [as=check2:12]
+           └── a_new:9 > 0 [as=check2:12]
 
 # Update one column in constraint, but not the other.
 build
@@ -1546,15 +1546,15 @@ update checks
  ├── columns: <none>
  ├── fetch columns: a:5 b:6 c:7 d:8
  ├── update-mapping:
- │    ├── column9:9 => b:2
+ │    ├── b_new:9 => b:2
  │    └── column10:10 => d:4
  ├── check columns: check1:11 check2:12
  └── project
-      ├── columns: check1:11 check2:12!null a:5!null b:6 c:7 d:8 column9:9!null column10:10
+      ├── columns: check1:11 check2:12!null a:5!null b:6 c:7 d:8 b_new:9!null column10:10
       ├── project
-      │    ├── columns: column10:10 a:5!null b:6 c:7 d:8 column9:9!null
+      │    ├── columns: column10:10 a:5!null b:6 c:7 d:8 b_new:9!null
       │    ├── project
-      │    │    ├── columns: column9:9!null a:5!null b:6 c:7 d:8
+      │    │    ├── columns: b_new:9!null a:5!null b:6 c:7 d:8
       │    │    ├── scan checks
       │    │    │    ├── columns: a:5!null b:6 c:7 d:8
       │    │    │    ├── check constraint expressions
@@ -1563,11 +1563,11 @@ update checks
       │    │    │         └── d:8
       │    │    │              └── c:7 + 1
       │    │    └── projections
-      │    │         └── 2 [as=column9:9]
+      │    │         └── 2 [as=b_new:9]
       │    └── projections
       │         └── c:7 + 1 [as=column10:10]
       └── projections
-           ├── column9:9 < column10:10 [as=check1:11]
+           ├── b_new:9 < column10:10 [as=check1:11]
            └── a:5 > 0 [as=check2:12]
 
 # Update using tuple and subquery.

--- a/pkg/sql/opt/optbuilder/testdata/update_from
+++ b/pkg/sql/opt/optbuilder/testdata/update_from
@@ -14,10 +14,10 @@ update abc
  ├── columns: <none>
  ├── fetch columns: abc.a:4 abc.b:5 abc.c:6
  ├── update-mapping:
- │    ├── column10:10 => abc.b:2
- │    └── column11:11 => abc.c:3
+ │    ├── b_new:10 => abc.b:2
+ │    └── c_new:11 => abc.c:3
  └── project
-      ├── columns: column10:10 column11:11 abc.a:4!null abc.b:5 abc.c:6 other.a:7!null other.b:8 other.c:9
+      ├── columns: b_new:10 c_new:11 abc.a:4!null abc.b:5 abc.c:6 other.a:7!null other.b:8 other.c:9
       ├── inner-join (merge)
       │    ├── columns: abc.a:4!null abc.b:5 abc.c:6 other.a:7!null other.b:8 other.c:9
       │    ├── left ordering: +4
@@ -30,8 +30,8 @@ update abc
       │    │    └── ordering: +7
       │    └── filters (true)
       └── projections
-           ├── other.b:8 + 1 [as=column10:10]
-           └── other.c:9 + 1 [as=column11:11]
+           ├── other.b:8 + 1 [as=b_new:10]
+           └── other.c:9 + 1 [as=c_new:11]
 
 # Test when Update uses multiple tables.
 opt
@@ -84,10 +84,10 @@ update abc
  ├── columns: a:1!null new_b:2 old_b:8 new_c:3 old_c:9
  ├── fetch columns: abc.a:4 abc.b:5 abc.c:6
  ├── update-mapping:
- │    ├── column10:10 => abc.b:2
- │    └── column11:11 => abc.c:3
+ │    ├── b_new:10 => abc.b:2
+ │    └── c_new:11 => abc.c:3
  └── project
-      ├── columns: column10:10 column11:11 abc.a:4!null abc.b:5 abc.c:6 old.b:8 old.c:9
+      ├── columns: b_new:10 c_new:11 abc.a:4!null abc.b:5 abc.c:6 old.b:8 old.c:9
       ├── inner-join (merge)
       │    ├── columns: abc.a:4!null abc.b:5 abc.c:6 old.a:7!null old.b:8 old.c:9
       │    ├── left ordering: +4
@@ -100,8 +100,8 @@ update abc
       │    │    └── ordering: +7
       │    └── filters (true)
       └── projections
-           ├── old.b:8 + 1 [as=column10:10]
-           └── old.c:9 + 2 [as=column11:11]
+           ├── old.b:8 + 1 [as=b_new:10]
+           └── old.c:9 + 2 [as=c_new:11]
 
 # Check if RETURNING * returns everything
 opt
@@ -111,10 +111,10 @@ update abc
  ├── columns: a:1!null b:2 c:3 a:7 b:8 c:9
  ├── fetch columns: abc.a:4 abc.b:5 abc.c:6
  ├── update-mapping:
- │    ├── column10:10 => abc.b:2
- │    └── column11:11 => abc.c:3
+ │    ├── b_new:10 => abc.b:2
+ │    └── c_new:11 => abc.c:3
  └── project
-      ├── columns: column10:10 column11:11 abc.a:4!null abc.b:5 abc.c:6 old.a:7!null old.b:8 old.c:9
+      ├── columns: b_new:10 c_new:11 abc.a:4!null abc.b:5 abc.c:6 old.a:7!null old.b:8 old.c:9
       ├── inner-join (merge)
       │    ├── columns: abc.a:4!null abc.b:5 abc.c:6 old.a:7!null old.b:8 old.c:9
       │    ├── left ordering: +4
@@ -127,8 +127,8 @@ update abc
       │    │    └── ordering: +7
       │    └── filters (true)
       └── projections
-           ├── old.b:8 + 1 [as=column10:10]
-           └── old.c:9 + 2 [as=column11:11]
+           ├── old.b:8 + 1 [as=b_new:10]
+           └── old.c:9 + 2 [as=c_new:11]
 
 # Check if the joins are optimized (check if the filters are pushed down).
 opt
@@ -138,10 +138,10 @@ update abc
  ├── columns: <none>
  ├── fetch columns: abc.a:4 abc.b:5 abc.c:6
  ├── update-mapping:
- │    ├── column10:10 => abc.b:2
- │    └── column11:11 => abc.c:3
+ │    ├── b_new:10 => abc.b:2
+ │    └── c_new:11 => abc.c:3
  └── project
-      ├── columns: column10:10 column11:11 abc.a:4!null abc.b:5 abc.c:6 old.a:7!null old.b:8 old.c:9
+      ├── columns: b_new:10 c_new:11 abc.a:4!null abc.b:5 abc.c:6 old.a:7!null old.b:8 old.c:9
       ├── inner-join (cross)
       │    ├── columns: abc.a:4!null abc.b:5 abc.c:6 old.a:7!null old.b:8 old.c:9
       │    ├── scan abc
@@ -152,8 +152,8 @@ update abc
       │    │    └── constraint: /7: [/2 - /2]
       │    └── filters (true)
       └── projections
-           ├── old.b:8 + 1 [as=column10:10]
-           └── old.c:9 + 2 [as=column11:11]
+           ├── old.b:8 + 1 [as=b_new:10]
+           └── old.c:9 + 2 [as=c_new:11]
 
 # Update values of table from values expression
 opt

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -89,11 +89,11 @@ upsert abc
  │    ├── upsert_a:16 => a:1
  │    └── upsert_c:18 => c:3
  └── project
-      ├── columns: upsert_a:16!null upsert_b:17 upsert_c:18 upsert_rowid:19 x:5!null y:6 column8:8 column9:9 a:10 b:11 c:12 rowid:13 column14:14!null column15:15
+      ├── columns: upsert_a:16!null upsert_b:17 upsert_c:18 upsert_rowid:19 x:5!null y:6 column8:8 column9:9 a:10 b:11 c:12 rowid:13 a_new:14!null column15:15
       ├── project
-      │    ├── columns: column15:15 x:5!null y:6 column8:8 column9:9 a:10 b:11 c:12 rowid:13 column14:14!null
+      │    ├── columns: column15:15 x:5!null y:6 column8:8 column9:9 a:10 b:11 c:12 rowid:13 a_new:14!null
       │    ├── project
-      │    │    ├── columns: column14:14!null x:5!null y:6 column8:8 column9:9 a:10 b:11 c:12 rowid:13
+      │    │    ├── columns: a_new:14!null x:5!null y:6 column8:8 column9:9 a:10 b:11 c:12 rowid:13
       │    │    ├── left-join (hash)
       │    │    │    ├── columns: x:5!null y:6 column8:8 column9:9 a:10 b:11 c:12 rowid:13
       │    │    │    ├── ensure-upsert-distinct-on
@@ -126,11 +126,11 @@ upsert abc
       │    │    │    └── filters
       │    │    │         └── x:5 = a:10
       │    │    └── projections
-      │    │         └── 5 [as=column14:14]
+      │    │         └── 5 [as=a_new:14]
       │    └── projections
       │         └── b:11 + 1 [as=column15:15]
       └── projections
-           ├── CASE WHEN rowid:13 IS NULL THEN x:5 ELSE column14:14 END [as=upsert_a:16]
+           ├── CASE WHEN rowid:13 IS NULL THEN x:5 ELSE a_new:14 END [as=upsert_a:16]
            ├── CASE WHEN rowid:13 IS NULL THEN y:6 ELSE b:11 END [as=upsert_b:17]
            ├── CASE WHEN rowid:13 IS NULL THEN column9:9 ELSE column15:15 END [as=upsert_c:18]
            └── CASE WHEN rowid:13 IS NULL THEN column8:8 ELSE rowid:13 END [as=upsert_rowid:19]
@@ -165,11 +165,11 @@ project
       │    ├── upsert_c:19 => c:3
       │    └── upsert_rowid:20 => rowid:4
       └── project
-           ├── columns: upsert_a:17!null upsert_b:18 upsert_c:19 upsert_rowid:20 x:5!null y:6 z:7 column8:8 a:9 b:10 c:11 rowid:12 column13:13!null column14:14!null column15:15!null column16:16!null
+           ├── columns: upsert_a:17!null upsert_b:18 upsert_c:19 upsert_rowid:20 x:5!null y:6 z:7 column8:8 a:9 b:10 c:11 rowid:12 a_new:13!null b_new:14!null rowid_new:15!null column16:16!null
            ├── project
-           │    ├── columns: column16:16!null x:5!null y:6 z:7 column8:8 a:9 b:10 c:11 rowid:12 column13:13!null column14:14!null column15:15!null
+           │    ├── columns: column16:16!null x:5!null y:6 z:7 column8:8 a:9 b:10 c:11 rowid:12 a_new:13!null b_new:14!null rowid_new:15!null
            │    ├── project
-           │    │    ├── columns: column13:13!null column14:14!null column15:15!null x:5!null y:6 z:7 column8:8 a:9 b:10 c:11 rowid:12
+           │    │    ├── columns: a_new:13!null b_new:14!null rowid_new:15!null x:5!null y:6 z:7 column8:8 a:9 b:10 c:11 rowid:12
            │    │    ├── left-join (hash)
            │    │    │    ├── columns: x:5!null y:6 z:7 column8:8 a:9 b:10 c:11 rowid:12
            │    │    │    ├── ensure-upsert-distinct-on
@@ -195,16 +195,16 @@ project
            │    │    │         ├── y:6 = b:10
            │    │    │         └── column8:8 = c:11
            │    │    └── projections
-           │    │         ├── 1 [as=column13:13]
-           │    │         ├── 2 [as=column14:14]
-           │    │         └── 3 [as=column15:15]
+           │    │         ├── 1 [as=a_new:13]
+           │    │         ├── 2 [as=b_new:14]
+           │    │         └── 3 [as=rowid_new:15]
            │    └── projections
-           │         └── column14:14 + 1 [as=column16:16]
+           │         └── b_new:14 + 1 [as=column16:16]
            └── projections
-                ├── CASE WHEN rowid:12 IS NULL THEN x:5 ELSE column13:13 END [as=upsert_a:17]
-                ├── CASE WHEN rowid:12 IS NULL THEN y:6 ELSE column14:14 END [as=upsert_b:18]
+                ├── CASE WHEN rowid:12 IS NULL THEN x:5 ELSE a_new:13 END [as=upsert_a:17]
+                ├── CASE WHEN rowid:12 IS NULL THEN y:6 ELSE b_new:14 END [as=upsert_b:18]
                 ├── CASE WHEN rowid:12 IS NULL THEN column8:8 ELSE column16:16 END [as=upsert_c:19]
-                └── CASE WHEN rowid:12 IS NULL THEN z:7 ELSE column15:15 END [as=upsert_rowid:20]
+                └── CASE WHEN rowid:12 IS NULL THEN z:7 ELSE rowid_new:15 END [as=upsert_rowid:20]
 
 # UPDATE + WHERE clause.
 build
@@ -227,11 +227,11 @@ upsert abc
  │    ├── upsert_b:17 => b:2
  │    └── upsert_c:18 => c:3
  └── project
-      ├── columns: upsert_a:16 upsert_b:17 upsert_c:18 upsert_rowid:19 x:5!null y:6 column8:8 column9:9 a:10 b:11 c:12 rowid:13 column14:14!null column15:15!null
+      ├── columns: upsert_a:16 upsert_b:17 upsert_c:18 upsert_rowid:19 x:5!null y:6 column8:8 column9:9 a:10 b:11 c:12 rowid:13 b_new:14!null column15:15!null
       ├── project
-      │    ├── columns: column15:15!null x:5!null y:6 column8:8 column9:9 a:10 b:11 c:12 rowid:13 column14:14!null
+      │    ├── columns: column15:15!null x:5!null y:6 column8:8 column9:9 a:10 b:11 c:12 rowid:13 b_new:14!null
       │    ├── project
-      │    │    ├── columns: column14:14!null x:5!null y:6 column8:8 column9:9 a:10 b:11 c:12 rowid:13
+      │    │    ├── columns: b_new:14!null x:5!null y:6 column8:8 column9:9 a:10 b:11 c:12 rowid:13
       │    │    ├── select
       │    │    │    ├── columns: x:5!null y:6 column8:8 column9:9 a:10 b:11 c:12 rowid:13
       │    │    │    ├── left-join (hash)
@@ -268,12 +268,12 @@ upsert abc
       │    │    │    └── filters
       │    │    │         └── (rowid:13 IS NULL) OR (a:10 > 0)
       │    │    └── projections
-      │    │         └── 10 [as=column14:14]
+      │    │         └── 10 [as=b_new:14]
       │    └── projections
-      │         └── column14:14 + 1 [as=column15:15]
+      │         └── b_new:14 + 1 [as=column15:15]
       └── projections
            ├── CASE WHEN rowid:13 IS NULL THEN x:5 ELSE a:10 END [as=upsert_a:16]
-           ├── CASE WHEN rowid:13 IS NULL THEN y:6 ELSE column14:14 END [as=upsert_b:17]
+           ├── CASE WHEN rowid:13 IS NULL THEN y:6 ELSE b_new:14 END [as=upsert_b:17]
            ├── CASE WHEN rowid:13 IS NULL THEN column9:9 ELSE column15:15 END [as=upsert_c:18]
            └── CASE WHEN rowid:13 IS NULL THEN column8:8 ELSE rowid:13 END [as=upsert_rowid:19]
 
@@ -308,11 +308,11 @@ sort
       │         │    ├── upsert_c:17 => abc.c:3
       │         │    └── upsert_rowid:18 => rowid:4
       │         └── project
-      │              ├── columns: upsert_a:15 upsert_b:16!null upsert_c:17!null upsert_rowid:18 column1:5!null column2:6!null column7:7 column8:8!null abc.a:9 abc.b:10 abc.c:11 rowid:12 column13:13!null column14:14!null
+      │              ├── columns: upsert_a:15 upsert_b:16!null upsert_c:17!null upsert_rowid:18 column1:5!null column2:6!null column7:7 column8:8!null abc.a:9 abc.b:10 abc.c:11 rowid:12 b_new:13!null column14:14!null
       │              ├── project
-      │              │    ├── columns: column14:14!null column1:5!null column2:6!null column7:7 column8:8!null abc.a:9 abc.b:10 abc.c:11 rowid:12 column13:13!null
+      │              │    ├── columns: column14:14!null column1:5!null column2:6!null column7:7 column8:8!null abc.a:9 abc.b:10 abc.c:11 rowid:12 b_new:13!null
       │              │    ├── project
-      │              │    │    ├── columns: column13:13!null column1:5!null column2:6!null column7:7 column8:8!null abc.a:9 abc.b:10 abc.c:11 rowid:12
+      │              │    │    ├── columns: b_new:13!null column1:5!null column2:6!null column7:7 column8:8!null abc.a:9 abc.b:10 abc.c:11 rowid:12
       │              │    │    ├── left-join (hash)
       │              │    │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8!null abc.a:9 abc.b:10 abc.c:11 rowid:12
       │              │    │    │    ├── ensure-upsert-distinct-on
@@ -345,12 +345,12 @@ sort
       │              │    │    │    └── filters
       │              │    │    │         └── column1:5 = abc.a:9
       │              │    │    └── projections
-      │              │    │         └── 1 [as=column13:13]
+      │              │    │         └── 1 [as=b_new:13]
       │              │    └── projections
-      │              │         └── column13:13 + 1 [as=column14:14]
+      │              │         └── b_new:13 + 1 [as=column14:14]
       │              └── projections
       │                   ├── CASE WHEN rowid:12 IS NULL THEN column1:5 ELSE abc.a:9 END [as=upsert_a:15]
-      │                   ├── CASE WHEN rowid:12 IS NULL THEN column2:6 ELSE column13:13 END [as=upsert_b:16]
+      │                   ├── CASE WHEN rowid:12 IS NULL THEN column2:6 ELSE b_new:13 END [as=upsert_b:16]
       │                   ├── CASE WHEN rowid:12 IS NULL THEN column8:8 ELSE column14:14 END [as=upsert_c:17]
       │                   └── CASE WHEN rowid:12 IS NULL THEN column7:7 ELSE rowid:12 END [as=upsert_rowid:18]
       └── with-scan &1
@@ -380,11 +380,11 @@ upsert tab
  │    ├── upsert_a:15 => a:1
  │    └── upsert_c:17 => c:3
  └── project
-      ├── columns: upsert_a:15 upsert_b:16 upsert_c:17 upsert_rowid:18 column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12 column13:13 column14:14
+      ├── columns: upsert_a:15 upsert_b:16 upsert_c:17 upsert_rowid:18 column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12 a_new:13 column14:14
       ├── project
-      │    ├── columns: column14:14 column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12 column13:13
+      │    ├── columns: column14:14 column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12 a_new:13
       │    ├── project
-      │    │    ├── columns: column13:13 column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12
+      │    │    ├── columns: a_new:13 column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12
       │    │    ├── left-join (hash)
       │    │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12
       │    │    │    ├── ensure-upsert-distinct-on
@@ -416,11 +416,11 @@ upsert tab
       │    │    │    └── filters
       │    │    │         └── column1:5 = a:9
       │    │    └── projections
-      │    │         └── a:9 * column1:5 [as=column13:13]
+      │    │         └── a:9 * column1:5 [as=a_new:13]
       │    └── projections
       │         └── b:10 + 1 [as=column14:14]
       └── projections
-           ├── CASE WHEN rowid:12 IS NULL THEN column1:5 ELSE column13:13 END [as=upsert_a:15]
+           ├── CASE WHEN rowid:12 IS NULL THEN column1:5 ELSE a_new:13 END [as=upsert_a:15]
            ├── CASE WHEN rowid:12 IS NULL THEN column2:6 ELSE b:10 END [as=upsert_b:16]
            ├── CASE WHEN rowid:12 IS NULL THEN column8:8 ELSE column14:14 END [as=upsert_c:17]
            └── CASE WHEN rowid:12 IS NULL THEN column7:7 ELSE rowid:12 END [as=upsert_rowid:18]
@@ -445,11 +445,11 @@ upsert abc
  │    ├── upsert_a:15 => a:1
  │    └── upsert_c:17 => c:3
  └── project
-      ├── columns: upsert_a:15!null upsert_b:16 upsert_c:17 upsert_rowid:18 column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12 column13:13!null column14:14
+      ├── columns: upsert_a:15!null upsert_b:16 upsert_c:17 upsert_rowid:18 column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12 a_new:13!null column14:14
       ├── project
-      │    ├── columns: column14:14 column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12 column13:13!null
+      │    ├── columns: column14:14 column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12 a_new:13!null
       │    ├── project
-      │    │    ├── columns: column13:13!null column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12
+      │    │    ├── columns: a_new:13!null column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12
       │    │    ├── left-join (hash)
       │    │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12
       │    │    │    ├── ensure-upsert-distinct-on
@@ -480,11 +480,11 @@ upsert abc
       │    │    │         ├── column2:6 = b:10
       │    │    │         └── column8:8 = c:11
       │    │    └── projections
-      │    │         └── 5 [as=column13:13]
+      │    │         └── 5 [as=a_new:13]
       │    └── projections
       │         └── b:10 + 1 [as=column14:14]
       └── projections
-           ├── CASE WHEN rowid:12 IS NULL THEN column1:5 ELSE column13:13 END [as=upsert_a:15]
+           ├── CASE WHEN rowid:12 IS NULL THEN column1:5 ELSE a_new:13 END [as=upsert_a:15]
            ├── CASE WHEN rowid:12 IS NULL THEN column2:6 ELSE b:10 END [as=upsert_b:16]
            ├── CASE WHEN rowid:12 IS NULL THEN column8:8 ELSE column14:14 END [as=upsert_c:17]
            └── CASE WHEN rowid:12 IS NULL THEN column7:7 ELSE rowid:12 END [as=upsert_rowid:18]
@@ -662,9 +662,9 @@ project
  │    │    ├── upsert_y:14 => y:2
  │    │    └── upsert_z:15 => z:3
  │    └── project
- │         ├── columns: upsert_x:13!null upsert_y:14 upsert_z:15!null column1:4!null column2:5!null column3:6!null x:7 y:8 z:9 column10:10!null column11:11 column12:12!null
+ │         ├── columns: upsert_x:13!null upsert_y:14 upsert_z:15!null column1:4!null column2:5!null column3:6!null x:7 y:8 z:9 x_new:10!null y_new:11 z_new:12!null
  │         ├── project
- │         │    ├── columns: column10:10!null column11:11 column12:12!null column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
+ │         │    ├── columns: x_new:10!null y_new:11 z_new:12!null column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
  │         │    ├── select
  │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null x:7 y:8 z:9
  │         │    │    ├── left-join (hash)
@@ -687,13 +687,13 @@ project
  │         │    │    └── filters
  │         │    │         └── (x:7 IS NULL) OR (column2:5 > y:8)
  │         │    └── projections
- │         │         ├── column1:4 + 1 [as=column10:10]
- │         │         ├── column2:5 * y:8 [as=column11:11]
- │         │         └── column1:4 - column3:6 [as=column12:12]
+ │         │         ├── column1:4 + 1 [as=x_new:10]
+ │         │         ├── column2:5 * y:8 [as=y_new:11]
+ │         │         └── column1:4 - column3:6 [as=z_new:12]
  │         └── projections
- │              ├── CASE WHEN x:7 IS NULL THEN column1:4 ELSE column10:10 END [as=upsert_x:13]
- │              ├── CASE WHEN x:7 IS NULL THEN column2:5 ELSE column11:11 END [as=upsert_y:14]
- │              └── CASE WHEN x:7 IS NULL THEN column3:6 ELSE column12:12 END [as=upsert_z:15]
+ │              ├── CASE WHEN x:7 IS NULL THEN column1:4 ELSE x_new:10 END [as=upsert_x:13]
+ │              ├── CASE WHEN x:7 IS NULL THEN column2:5 ELSE y_new:11 END [as=upsert_y:14]
+ │              └── CASE WHEN x:7 IS NULL THEN column3:6 ELSE z_new:12 END [as=upsert_z:15]
  └── projections
       ├── x:1 * 2 [as="?column?":16]
       └── y:2 + z:3 [as="?column?":17]
@@ -819,11 +819,11 @@ upsert abc
  │    ├── upsert_b:17 => b:2
  │    └── upsert_c:18 => c:3
  └── project
-      ├── columns: upsert_a:16 upsert_b:17!null upsert_c:18!null upsert_rowid:19 column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12 column13:13 column14:14!null column15:15!null
+      ├── columns: upsert_a:16 upsert_b:17!null upsert_c:18!null upsert_rowid:19 column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12 a_new:13 b_new:14!null column15:15!null
       ├── project
-      │    ├── columns: column15:15!null column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12 column13:13 column14:14!null
+      │    ├── columns: column15:15!null column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12 a_new:13 b_new:14!null
       │    ├── project
-      │    │    ├── columns: column13:13 column14:14!null column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12
+      │    │    ├── columns: a_new:13 b_new:14!null column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12
       │    │    ├── left-join (hash)
       │    │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8!null a:9 b:10 c:11 rowid:12
       │    │    │    ├── ensure-upsert-distinct-on
@@ -855,13 +855,13 @@ upsert abc
       │    │    │    └── filters
       │    │    │         └── column1:5 = a:9
       │    │    └── projections
-      │    │         ├── NULL::INT8 [as=column13:13]
-      │    │         └── 10 [as=column14:14]
+      │    │         ├── NULL::INT8 [as=a_new:13]
+      │    │         └── 10 [as=b_new:14]
       │    └── projections
-      │         └── column14:14 + 1 [as=column15:15]
+      │         └── b_new:14 + 1 [as=column15:15]
       └── projections
-           ├── CASE WHEN rowid:12 IS NULL THEN column1:5 ELSE column13:13 END [as=upsert_a:16]
-           ├── CASE WHEN rowid:12 IS NULL THEN column2:6 ELSE column14:14 END [as=upsert_b:17]
+           ├── CASE WHEN rowid:12 IS NULL THEN column1:5 ELSE a_new:13 END [as=upsert_a:16]
+           ├── CASE WHEN rowid:12 IS NULL THEN column2:6 ELSE b_new:14 END [as=upsert_b:17]
            ├── CASE WHEN rowid:12 IS NULL THEN column8:8 ELSE column15:15 END [as=upsert_c:18]
            └── CASE WHEN rowid:12 IS NULL THEN column7:7 ELSE rowid:12 END [as=upsert_rowid:19]
 
@@ -890,13 +890,13 @@ upsert mutation
  │    └── upsert_p:19 => p:4
  ├── check columns: check1:20
  └── project
-      ├── columns: check1:20 column1:6!null column2:7!null column8:8!null column9:9!null m:10 n:11 o:12 p:13 q:14 column15:15 column16:16 upsert_m:17 upsert_n:18 upsert_p:19
+      ├── columns: check1:20 column1:6!null column2:7!null column8:8!null column9:9!null m:10 n:11 o:12 p:13 q:14 m_new:15 column16:16 upsert_m:17 upsert_n:18 upsert_p:19
       ├── project
-      │    ├── columns: upsert_m:17 upsert_n:18 upsert_p:19 column1:6!null column2:7!null column8:8!null column9:9!null m:10 n:11 o:12 p:13 q:14 column15:15 column16:16
+      │    ├── columns: upsert_m:17 upsert_n:18 upsert_p:19 column1:6!null column2:7!null column8:8!null column9:9!null m:10 n:11 o:12 p:13 q:14 m_new:15 column16:16
       │    ├── project
-      │    │    ├── columns: column16:16 column1:6!null column2:7!null column8:8!null column9:9!null m:10 n:11 o:12 p:13 q:14 column15:15
+      │    │    ├── columns: column16:16 column1:6!null column2:7!null column8:8!null column9:9!null m:10 n:11 o:12 p:13 q:14 m_new:15
       │    │    ├── project
-      │    │    │    ├── columns: column15:15 column1:6!null column2:7!null column8:8!null column9:9!null m:10 n:11 o:12 p:13 q:14
+      │    │    │    ├── columns: m_new:15 column1:6!null column2:7!null column8:8!null column9:9!null m:10 n:11 o:12 p:13 q:14
       │    │    │    ├── left-join (hash)
       │    │    │    │    ├── columns: column1:6!null column2:7!null column8:8!null column9:9!null m:10 n:11 o:12 p:13 q:14
       │    │    │    │    ├── ensure-upsert-distinct-on
@@ -927,11 +927,11 @@ upsert mutation
       │    │    │    │    └── filters
       │    │    │    │         └── column1:6 = m:10
       │    │    │    └── projections
-      │    │    │         └── m:10 + 1 [as=column15:15]
+      │    │    │         └── m:10 + 1 [as=m_new:15]
       │    │    └── projections
       │    │         └── column8:8 + n:11 [as=column16:16]
       │    └── projections
-      │         ├── CASE WHEN m:10 IS NULL THEN column1:6 ELSE column15:15 END [as=upsert_m:17]
+      │         ├── CASE WHEN m:10 IS NULL THEN column1:6 ELSE m_new:15 END [as=upsert_m:17]
       │         ├── CASE WHEN m:10 IS NULL THEN column2:7 ELSE n:11 END [as=upsert_n:18]
       │         └── CASE WHEN m:10 IS NULL THEN column9:9 ELSE column16:16 END [as=upsert_p:19]
       └── projections
@@ -1314,13 +1314,13 @@ upsert checks
  │    └── upsert_d:19 => d:4
  ├── check columns: check1:20 check2:21
  └── project
-      ├── columns: check1:20 check2:21 column1:5!null column2:6!null column7:7 column8:8 a:9 b:10 c:11 d:12 column13:13!null column14:14!null column15:15!null upsert_a:16 upsert_b:17!null upsert_c:18 upsert_d:19
+      ├── columns: check1:20 check2:21 column1:5!null column2:6!null column7:7 column8:8 a:9 b:10 c:11 d:12 b_new:13!null c_new:14!null column15:15!null upsert_a:16 upsert_b:17!null upsert_c:18 upsert_d:19
       ├── project
-      │    ├── columns: upsert_a:16 upsert_b:17!null upsert_c:18 upsert_d:19 column1:5!null column2:6!null column7:7 column8:8 a:9 b:10 c:11 d:12 column13:13!null column14:14!null column15:15!null
+      │    ├── columns: upsert_a:16 upsert_b:17!null upsert_c:18 upsert_d:19 column1:5!null column2:6!null column7:7 column8:8 a:9 b:10 c:11 d:12 b_new:13!null c_new:14!null column15:15!null
       │    ├── project
-      │    │    ├── columns: column15:15!null column1:5!null column2:6!null column7:7 column8:8 a:9 b:10 c:11 d:12 column13:13!null column14:14!null
+      │    │    ├── columns: column15:15!null column1:5!null column2:6!null column7:7 column8:8 a:9 b:10 c:11 d:12 b_new:13!null c_new:14!null
       │    │    ├── project
-      │    │    │    ├── columns: column13:13!null column14:14!null column1:5!null column2:6!null column7:7 column8:8 a:9 b:10 c:11 d:12
+      │    │    │    ├── columns: b_new:13!null c_new:14!null column1:5!null column2:6!null column7:7 column8:8 a:9 b:10 c:11 d:12
       │    │    │    ├── left-join (hash)
       │    │    │    │    ├── columns: column1:5!null column2:6!null column7:7 column8:8 a:9 b:10 c:11 d:12
       │    │    │    │    ├── ensure-upsert-distinct-on
@@ -1354,14 +1354,14 @@ upsert checks
       │    │    │    │    └── filters
       │    │    │    │         └── column1:5 = a:9
       │    │    │    └── projections
-      │    │    │         ├── 3 [as=column13:13]
-      │    │    │         └── 4 [as=column14:14]
+      │    │    │         ├── 3 [as=b_new:13]
+      │    │    │         └── 4 [as=c_new:14]
       │    │    └── projections
-      │    │         └── column14:14 + 1 [as=column15:15]
+      │    │         └── c_new:14 + 1 [as=column15:15]
       │    └── projections
       │         ├── CASE WHEN a:9 IS NULL THEN column1:5 ELSE a:9 END [as=upsert_a:16]
-      │         ├── CASE WHEN a:9 IS NULL THEN column2:6 ELSE column13:13 END [as=upsert_b:17]
-      │         ├── CASE WHEN a:9 IS NULL THEN column7:7 ELSE column14:14 END [as=upsert_c:18]
+      │         ├── CASE WHEN a:9 IS NULL THEN column2:6 ELSE b_new:13 END [as=upsert_b:17]
+      │         ├── CASE WHEN a:9 IS NULL THEN column7:7 ELSE c_new:14 END [as=upsert_c:18]
       │         └── CASE WHEN a:9 IS NULL THEN column8:8 ELSE column15:15 END [as=upsert_d:19]
       └── projections
            ├── upsert_b:17 < upsert_d:19 [as=check1:20]
@@ -1509,13 +1509,13 @@ upsert checks
  │    └── upsert_d:22 => d:4
  ├── check columns: check1:23 check2:24
  └── project
-      ├── columns: check1:23 check2:24!null abc.a:5!null abc.b:6 column9:9 column10:10 checks.a:11 checks.b:12 checks.c:13 d:14 column18:18 column19:19 upsert_b:20 upsert_c:21 upsert_d:22
+      ├── columns: check1:23 check2:24!null abc.a:5!null abc.b:6 column9:9 column10:10 checks.a:11 checks.b:12 checks.c:13 d:14 b_new:18 column19:19 upsert_b:20 upsert_c:21 upsert_d:22
       ├── project
-      │    ├── columns: upsert_b:20 upsert_c:21 upsert_d:22 abc.a:5!null abc.b:6 column9:9 column10:10 checks.a:11 checks.b:12 checks.c:13 d:14 column18:18 column19:19
+      │    ├── columns: upsert_b:20 upsert_c:21 upsert_d:22 abc.a:5!null abc.b:6 column9:9 column10:10 checks.a:11 checks.b:12 checks.c:13 d:14 b_new:18 column19:19
       │    ├── project
-      │    │    ├── columns: column19:19 abc.a:5!null abc.b:6 column9:9 column10:10 checks.a:11 checks.b:12 checks.c:13 d:14 column18:18
+      │    │    ├── columns: column19:19 abc.a:5!null abc.b:6 column9:9 column10:10 checks.a:11 checks.b:12 checks.c:13 d:14 b_new:18
       │    │    ├── project
-      │    │    │    ├── columns: column18:18 abc.a:5!null abc.b:6 column9:9 column10:10 checks.a:11 checks.b:12 checks.c:13 d:14
+      │    │    │    ├── columns: b_new:18 abc.a:5!null abc.b:6 column9:9 column10:10 checks.a:11 checks.b:12 checks.c:13 d:14
       │    │    │    ├── left-join (hash)
       │    │    │    │    ├── columns: abc.a:5!null abc.b:6 column9:9 column10:10 checks.a:11 checks.b:12 checks.c:13 d:14
       │    │    │    │    ├── ensure-upsert-distinct-on
@@ -1553,7 +1553,7 @@ upsert checks
       │    │    │    │    └── filters
       │    │    │    │         └── abc.a:5 = checks.a:11
       │    │    │    └── projections
-      │    │    │         └── subquery [as=column18:18]
+      │    │    │         └── subquery [as=b_new:18]
       │    │    │              └── max1-row
       │    │    │                   ├── columns: x:15!null
       │    │    │                   └── project
@@ -1567,7 +1567,7 @@ upsert checks
       │    │    └── projections
       │    │         └── checks.c:13 + 1 [as=column19:19]
       │    └── projections
-      │         ├── CASE WHEN checks.a:11 IS NULL THEN abc.b:6 ELSE column18:18 END [as=upsert_b:20]
+      │         ├── CASE WHEN checks.a:11 IS NULL THEN abc.b:6 ELSE b_new:18 END [as=upsert_b:20]
       │         ├── CASE WHEN checks.a:11 IS NULL THEN column9:9 ELSE checks.c:13 END [as=upsert_c:21]
       │         └── CASE WHEN checks.a:11 IS NULL THEN column10:10 ELSE column19:19 END [as=upsert_d:22]
       └── projections
@@ -1591,9 +1591,9 @@ upsert xyz
  ├── update-mapping:
  │    └── upsert_y:13 => y:2
  └── project
-      ├── columns: upsert_x:12 upsert_y:13 upsert_z:14 a:4!null b:5 c:6 x:8 y:9 z:10 column11:11!null
+      ├── columns: upsert_x:12 upsert_y:13 upsert_z:14 a:4!null b:5 c:6 x:8 y:9 z:10 y_new:11!null
       ├── project
-      │    ├── columns: column11:11!null a:4!null b:5 c:6 x:8 y:9 z:10
+      │    ├── columns: y_new:11!null a:4!null b:5 c:6 x:8 y:9 z:10
       │    ├── left-join (hash)
       │    │    ├── columns: a:4!null b:5 c:6 x:8 y:9 z:10
       │    │    ├── ensure-upsert-distinct-on
@@ -1615,10 +1615,10 @@ upsert xyz
       │    │         ├── b:5 = y:9
       │    │         └── c:6 = z:10
       │    └── projections
-      │         └── 5 [as=column11:11]
+      │         └── 5 [as=y_new:11]
       └── projections
            ├── CASE WHEN x:8 IS NULL THEN a:4 ELSE x:8 END [as=upsert_x:12]
-           ├── CASE WHEN x:8 IS NULL THEN b:5 ELSE column11:11 END [as=upsert_y:13]
+           ├── CASE WHEN x:8 IS NULL THEN b:5 ELSE y_new:11 END [as=upsert_y:13]
            └── CASE WHEN x:8 IS NULL THEN c:6 ELSE z:10 END [as=upsert_z:14]
 
 # ------------------------------------------------------------------------------

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -698,13 +698,13 @@ with &1 (t)
            ├── columns: x.a:4 b:5 rowid:6!null
            ├── fetch columns: x.a:7 b:8 rowid:9
            ├── update-mapping:
-           │    └── column11:11 => x.a:4
+           │    └── a_new:11 => x.a:4
            └── project
-                ├── columns: column11:11 x.a:7 b:8 rowid:9!null
+                ├── columns: a_new:11 x.a:7 b:8 rowid:9!null
                 ├── scan x
                 │    └── columns: x.a:7 b:8 rowid:9!null
                 └── projections
-                     └── subquery [as=column11:11]
+                     └── subquery [as=a_new:11]
                           └── max1-row
                                ├── columns: a:10
                                └── with-scan &1 (t)

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -210,9 +210,10 @@ func (mb *mutationBuilder) addUpdateCols(exprs tree.UpdateExprs) {
 		}
 
 		// Add new column to the projections scope.
-		desiredType := mb.md.ColumnMeta(targetColID).Type
+		targetColMeta := mb.md.ColumnMeta(targetColID)
+		desiredType := targetColMeta.Type
 		texpr := inScope.resolveType(expr, desiredType)
-		scopeCol := mb.b.addColumn(projectionsScope, "" /* alias */, texpr)
+		scopeCol := mb.b.addColumn(projectionsScope, targetColMeta.Alias+"_new", texpr)
 		scopeColOrd := scopeOrdinal(len(projectionsScope.cols) - 1)
 		mb.b.buildScalar(texpr, inScope, projectionsScope, scopeCol, nil)
 

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -31,13 +31,13 @@ project
       ├── columns: d_id:1!null d_w_id:2!null d_tax:9 d_next_o_id:11
       ├── fetch columns: d_id:12 d_w_id:13 d_name:14 d_street_1:15 d_street_2:16 d_city:17 d_state:18 d_zip:19 d_tax:20 d_ytd:21 d_next_o_id:22
       ├── update-mapping:
-      │    └── column23:23 => d_next_o_id:11
+      │    └── d_next_o_id_new:23 => d_next_o_id:11
       ├── cardinality: [0 - 1]
       ├── side-effects, mutations
       ├── key: ()
       ├── fd: ()-->(1,2,9,11)
       └── project
-           ├── columns: column23:23 d_id:12!null d_w_id:13!null d_name:14 d_street_1:15 d_street_2:16 d_city:17 d_state:18 d_zip:19 d_tax:20 d_ytd:21 d_next_o_id:22
+           ├── columns: d_next_o_id_new:23 d_id:12!null d_w_id:13!null d_name:14 d_street_1:15 d_street_2:16 d_city:17 d_state:18 d_zip:19 d_tax:20 d_ytd:21 d_next_o_id:22
            ├── cardinality: [0 - 1]
            ├── key: ()
            ├── fd: ()-->(12-23)
@@ -48,7 +48,7 @@ project
            │    ├── key: ()
            │    └── fd: ()-->(12-22)
            └── projections
-                └── d_next_o_id:22 + 1 [as=column23:23, outer=(22)]
+                └── d_next_o_id:22 + 1 [as=d_next_o_id_new:23, outer=(22)]
 
 opt format=hide-qual
 SELECT w_tax FROM warehouse WHERE w_id = 10
@@ -306,14 +306,14 @@ update stock
  ├── columns: <none>
  ├── fetch columns: s_i_id:18 s_w_id:19 s_quantity:20 s_dist_01:21 s_dist_02:22 s_dist_03:23 s_dist_04:24 s_dist_05:25 s_dist_06:26 s_dist_07:27 s_dist_08:28 s_dist_09:29 s_dist_10:30 s_ytd:31 s_order_cnt:32 s_remote_cnt:33 s_data:34
  ├── update-mapping:
- │    ├── column35:35 => s_quantity:3
- │    ├── column36:36 => s_ytd:14
- │    ├── column37:37 => s_order_cnt:15
- │    └── column38:38 => s_remote_cnt:16
+ │    ├── s_quantity_new:35 => s_quantity:3
+ │    ├── s_ytd_new:36 => s_ytd:14
+ │    ├── s_order_cnt_new:37 => s_order_cnt:15
+ │    └── s_remote_cnt_new:38 => s_remote_cnt:16
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: column35:35 column36:36 column37:37 column38:38 s_i_id:18!null s_w_id:19!null s_quantity:20 s_dist_01:21 s_dist_02:22 s_dist_03:23 s_dist_04:24 s_dist_05:25 s_dist_06:26 s_dist_07:27 s_dist_08:28 s_dist_09:29 s_dist_10:30 s_ytd:31 s_order_cnt:32 s_remote_cnt:33 s_data:34
+      ├── columns: s_quantity_new:35 s_ytd_new:36 s_order_cnt_new:37 s_remote_cnt_new:38 s_i_id:18!null s_w_id:19!null s_quantity:20 s_dist_01:21 s_dist_02:22 s_dist_03:23 s_dist_04:24 s_dist_05:25 s_dist_06:26 s_dist_07:27 s_dist_08:28 s_dist_09:29 s_dist_10:30 s_ytd:31 s_order_cnt:32 s_remote_cnt:33 s_data:34
       ├── cardinality: [0 - 13]
       ├── side-effects
       ├── key: (18)
@@ -338,10 +338,10 @@ update stock
       │    ├── key: (18)
       │    └── fd: ()-->(19), (18)-->(20-34)
       └── projections
-           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 26 WHEN (7853, 0) THEN 10 WHEN (8497, 0) THEN 62 WHEN (10904, 0) THEN 54 WHEN (16152, 0) THEN 80 WHEN (41382, 0) THEN 18 WHEN (55952, 0) THEN 56 WHEN (64817, 0) THEN 26 WHEN (66335, 0) THEN 30 WHEN (76567, 0) THEN 71 WHEN (81680, 0) THEN 51 WHEN (89641, 0) THEN 51 WHEN (89905, 0) THEN 77 ELSE crdb_internal.force_error('', 'unknown case') END [as=column35:35, outer=(18,19), side-effects]
-           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 6 WHEN (7853, 0) THEN 9 WHEN (8497, 0) THEN 13 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 2 WHEN (41382, 0) THEN 3 WHEN (55952, 0) THEN 10 WHEN (64817, 0) THEN 31 WHEN (66335, 0) THEN 9 WHEN (76567, 0) THEN 7 WHEN (81680, 0) THEN 4 WHEN (89641, 0) THEN 13 WHEN (89905, 0) THEN 20 END [as=column36:36, outer=(18,19)]
-           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 1 WHEN (7853, 0) THEN 1 WHEN (8497, 0) THEN 2 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 1 WHEN (41382, 0) THEN 1 WHEN (55952, 0) THEN 1 WHEN (64817, 0) THEN 4 WHEN (66335, 0) THEN 2 WHEN (76567, 0) THEN 1 WHEN (81680, 0) THEN 1 WHEN (89641, 0) THEN 2 WHEN (89905, 0) THEN 4 END [as=column37:37, outer=(18,19)]
-           └── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 0 WHEN (7853, 0) THEN 0 WHEN (8497, 0) THEN 0 WHEN (10904, 0) THEN 0 WHEN (16152, 0) THEN 0 WHEN (41382, 0) THEN 0 WHEN (55952, 0) THEN 0 WHEN (64817, 0) THEN 0 WHEN (66335, 0) THEN 0 WHEN (76567, 0) THEN 0 WHEN (81680, 0) THEN 0 WHEN (89641, 0) THEN 0 WHEN (89905, 0) THEN 0 END [as=column38:38, outer=(18,19)]
+           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 26 WHEN (7853, 0) THEN 10 WHEN (8497, 0) THEN 62 WHEN (10904, 0) THEN 54 WHEN (16152, 0) THEN 80 WHEN (41382, 0) THEN 18 WHEN (55952, 0) THEN 56 WHEN (64817, 0) THEN 26 WHEN (66335, 0) THEN 30 WHEN (76567, 0) THEN 71 WHEN (81680, 0) THEN 51 WHEN (89641, 0) THEN 51 WHEN (89905, 0) THEN 77 ELSE crdb_internal.force_error('', 'unknown case') END [as=s_quantity_new:35, outer=(18,19), side-effects]
+           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 6 WHEN (7853, 0) THEN 9 WHEN (8497, 0) THEN 13 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 2 WHEN (41382, 0) THEN 3 WHEN (55952, 0) THEN 10 WHEN (64817, 0) THEN 31 WHEN (66335, 0) THEN 9 WHEN (76567, 0) THEN 7 WHEN (81680, 0) THEN 4 WHEN (89641, 0) THEN 13 WHEN (89905, 0) THEN 20 END [as=s_ytd_new:36, outer=(18,19)]
+           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 1 WHEN (7853, 0) THEN 1 WHEN (8497, 0) THEN 2 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 1 WHEN (41382, 0) THEN 1 WHEN (55952, 0) THEN 1 WHEN (64817, 0) THEN 4 WHEN (66335, 0) THEN 2 WHEN (76567, 0) THEN 1 WHEN (81680, 0) THEN 1 WHEN (89641, 0) THEN 2 WHEN (89905, 0) THEN 4 END [as=s_order_cnt_new:37, outer=(18,19)]
+           └── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 0 WHEN (7853, 0) THEN 0 WHEN (8497, 0) THEN 0 WHEN (10904, 0) THEN 0 WHEN (16152, 0) THEN 0 WHEN (41382, 0) THEN 0 WHEN (55952, 0) THEN 0 WHEN (64817, 0) THEN 0 WHEN (66335, 0) THEN 0 WHEN (76567, 0) THEN 0 WHEN (81680, 0) THEN 0 WHEN (89641, 0) THEN 0 WHEN (89905, 0) THEN 0 END [as=s_remote_cnt_new:38, outer=(18,19)]
 
 opt format=hide-qual
 INSERT INTO order_line
@@ -561,14 +561,14 @@ project
  │    ├── update-mapping:
  │    │    ├── c_balance:47 => customer.c_balance:17
  │    │    ├── c_ytd_payment:48 => customer.c_ytd_payment:18
- │    │    ├── column45:45 => c_payment_cnt:19
- │    │    └── column46:46 => c_data:21
+ │    │    ├── c_payment_cnt_new:45 => c_payment_cnt:19
+ │    │    └── c_data_new:46 => c_data:21
  │    ├── cardinality: [0 - 1]
  │    ├── side-effects, mutations
  │    ├── key: ()
  │    ├── fd: ()-->(1-17,21)
  │    └── project
- │         ├── columns: c_balance:47 c_ytd_payment:48 column45:45 column46:46 c_id:22!null c_d_id:23!null c_w_id:24!null c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 customer.c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
+ │         ├── columns: c_balance:47 c_ytd_payment:48 c_payment_cnt_new:45 c_data_new:46 c_id:22!null c_d_id:23!null c_w_id:24!null c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 customer.c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
  │         ├── cardinality: [0 - 1]
  │         ├── key: ()
  │         ├── fd: ()-->(22-42,45-48)
@@ -581,8 +581,8 @@ project
  │         └── projections
  │              ├── crdb_internal.round_decimal_values(customer.c_balance:38 - 3860.61, 2) [as=c_balance:47, outer=(38)]
  │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:39 + 3860.61, 2) [as=c_ytd_payment:48, outer=(39)]
- │              ├── c_payment_cnt:40 + 1 [as=column45:45, outer=(40)]
- │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42, 500) ELSE c_data:42 END [as=column46:46, outer=(22-24,35,42)]
+ │              ├── c_payment_cnt:40 + 1 [as=c_payment_cnt_new:45, outer=(40)]
+ │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42, 500) ELSE c_data:42 END [as=c_data_new:46, outer=(22-24,35,42)]
  └── projections
       └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:49, outer=(14,21)]
 
@@ -813,13 +813,13 @@ project
       ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_c_id:4
       ├── fetch columns: o_id:9 o_d_id:10 o_w_id:11 o_c_id:12 o_entry_d:13 o_carrier_id:14 o_ol_cnt:15 o_all_local:16
       ├── update-mapping:
-      │    └── column17:17 => o_carrier_id:6
+      │    └── o_carrier_id_new:17 => o_carrier_id:6
       ├── cardinality: [0 - 10]
       ├── side-effects, mutations
       ├── key: (2)
       ├── fd: ()-->(1,3), (2)-->(4)
       └── project
-           ├── columns: column17:17!null o_id:9!null o_d_id:10!null o_w_id:11!null o_c_id:12 o_entry_d:13 o_carrier_id:14 o_ol_cnt:15 o_all_local:16
+           ├── columns: o_carrier_id_new:17!null o_id:9!null o_d_id:10!null o_w_id:11!null o_c_id:12 o_entry_d:13 o_carrier_id:14 o_ol_cnt:15 o_all_local:16
            ├── cardinality: [0 - 10]
            ├── key: (10)
            ├── fd: ()-->(9,11,17), (10)-->(12-16)
@@ -840,7 +840,7 @@ project
            │    ├── key: (10)
            │    └── fd: ()-->(9,11), (10)-->(12-16)
            └── projections
-                └── 10 [as=column17:17]
+                └── 10 [as=o_carrier_id_new:17]
 
 opt format=hide-qual
 UPDATE customer
@@ -875,11 +875,11 @@ update customer
  ├── fetch columns: c_id:22 c_d_id:23 c_w_id:24 c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
  ├── update-mapping:
  │    ├── c_balance:45 => customer.c_balance:17
- │    └── column43:43 => c_delivery_cnt:20
+ │    └── c_delivery_cnt_new:43 => c_delivery_cnt:20
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: c_balance:45 column43:43 c_id:22!null c_d_id:23!null c_w_id:24!null c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
+      ├── columns: c_balance:45 c_delivery_cnt_new:43 c_id:22!null c_d_id:23!null c_w_id:24!null c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
       ├── cardinality: [0 - 10]
       ├── key: (22,23)
       ├── fd: ()-->(24), (22,23)-->(25-42,45), (41)-->(43)
@@ -901,7 +901,7 @@ update customer
       │    └── fd: ()-->(24), (22,23)-->(25-42)
       └── projections
            ├── crdb_internal.round_decimal_values(customer.c_balance:38 + CASE c_d_id:23 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 END, 2) [as=c_balance:45, outer=(23,38)]
-           └── c_delivery_cnt:41 + 1 [as=column43:43, outer=(41)]
+           └── c_delivery_cnt:41 + 1 [as=c_delivery_cnt_new:43, outer=(41)]
 
 opt format=hide-qual
 DELETE FROM new_order
@@ -961,11 +961,11 @@ update order_line
  ├── columns: <none>
  ├── fetch columns: ol_o_id:11 ol_d_id:12 ol_w_id:13 ol_number:14 ol_i_id:15 ol_supply_w_id:16 ol_delivery_d:17 ol_quantity:18 ol_amount:19 ol_dist_info:20
  ├── update-mapping:
- │    └── column21:21 => ol_delivery_d:7
+ │    └── ol_delivery_d_new:21 => ol_delivery_d:7
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: column21:21!null ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null ol_number:14!null ol_i_id:15!null ol_supply_w_id:16 ol_delivery_d:17 ol_quantity:18 ol_amount:19 ol_dist_info:20
+      ├── columns: ol_delivery_d_new:21!null ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null ol_number:14!null ol_i_id:15!null ol_supply_w_id:16 ol_delivery_d:17 ol_quantity:18 ol_amount:19 ol_dist_info:20
       ├── key: (12,14)
       ├── fd: ()-->(11,13,21), (12,14)-->(15-20)
       ├── scan order_line
@@ -984,7 +984,7 @@ update order_line
       │    ├── key: (12,14)
       │    └── fd: ()-->(11,13), (12,14)-->(15-20)
       └── projections
-           └── '2019-08-26 16:50:41+00:00' [as=column21:21]
+           └── '2019-08-26 16:50:41+00:00' [as=ol_delivery_d_new:21]
 
 # --------------------------------------------------
 # 2.8 The Stock-Level Transaction

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -34,13 +34,13 @@ project
       ├── columns: d_id:1!null d_w_id:2!null d_tax:9 d_next_o_id:11
       ├── fetch columns: d_id:12 d_w_id:13 d_name:14 d_street_1:15 d_street_2:16 d_city:17 d_state:18 d_zip:19 d_tax:20 d_ytd:21 d_next_o_id:22
       ├── update-mapping:
-      │    └── column23:23 => d_next_o_id:11
+      │    └── d_next_o_id_new:23 => d_next_o_id:11
       ├── cardinality: [0 - 1]
       ├── side-effects, mutations
       ├── key: ()
       ├── fd: ()-->(1,2,9,11)
       └── project
-           ├── columns: column23:23 d_id:12!null d_w_id:13!null d_name:14 d_street_1:15 d_street_2:16 d_city:17 d_state:18 d_zip:19 d_tax:20 d_ytd:21 d_next_o_id:22
+           ├── columns: d_next_o_id_new:23 d_id:12!null d_w_id:13!null d_name:14 d_street_1:15 d_street_2:16 d_city:17 d_state:18 d_zip:19 d_tax:20 d_ytd:21 d_next_o_id:22
            ├── cardinality: [0 - 1]
            ├── key: ()
            ├── fd: ()-->(12-23)
@@ -51,7 +51,7 @@ project
            │    ├── key: ()
            │    └── fd: ()-->(12-22)
            └── projections
-                └── d_next_o_id:22 + 1 [as=column23:23, outer=(22)]
+                └── d_next_o_id:22 + 1 [as=d_next_o_id_new:23, outer=(22)]
 
 opt format=hide-qual
 SELECT w_tax FROM warehouse WHERE w_id = 10
@@ -309,14 +309,14 @@ update stock
  ├── columns: <none>
  ├── fetch columns: s_i_id:18 s_w_id:19 s_quantity:20 s_dist_01:21 s_dist_02:22 s_dist_03:23 s_dist_04:24 s_dist_05:25 s_dist_06:26 s_dist_07:27 s_dist_08:28 s_dist_09:29 s_dist_10:30 s_ytd:31 s_order_cnt:32 s_remote_cnt:33 s_data:34
  ├── update-mapping:
- │    ├── column35:35 => s_quantity:3
- │    ├── column36:36 => s_ytd:14
- │    ├── column37:37 => s_order_cnt:15
- │    └── column38:38 => s_remote_cnt:16
+ │    ├── s_quantity_new:35 => s_quantity:3
+ │    ├── s_ytd_new:36 => s_ytd:14
+ │    ├── s_order_cnt_new:37 => s_order_cnt:15
+ │    └── s_remote_cnt_new:38 => s_remote_cnt:16
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: column35:35 column36:36 column37:37 column38:38 s_i_id:18!null s_w_id:19!null s_quantity:20 s_dist_01:21 s_dist_02:22 s_dist_03:23 s_dist_04:24 s_dist_05:25 s_dist_06:26 s_dist_07:27 s_dist_08:28 s_dist_09:29 s_dist_10:30 s_ytd:31 s_order_cnt:32 s_remote_cnt:33 s_data:34
+      ├── columns: s_quantity_new:35 s_ytd_new:36 s_order_cnt_new:37 s_remote_cnt_new:38 s_i_id:18!null s_w_id:19!null s_quantity:20 s_dist_01:21 s_dist_02:22 s_dist_03:23 s_dist_04:24 s_dist_05:25 s_dist_06:26 s_dist_07:27 s_dist_08:28 s_dist_09:29 s_dist_10:30 s_ytd:31 s_order_cnt:32 s_remote_cnt:33 s_data:34
       ├── cardinality: [0 - 13]
       ├── side-effects
       ├── key: (18)
@@ -341,10 +341,10 @@ update stock
       │    ├── key: (18)
       │    └── fd: ()-->(19), (18)-->(20-34)
       └── projections
-           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 26 WHEN (7853, 0) THEN 10 WHEN (8497, 0) THEN 62 WHEN (10904, 0) THEN 54 WHEN (16152, 0) THEN 80 WHEN (41382, 0) THEN 18 WHEN (55952, 0) THEN 56 WHEN (64817, 0) THEN 26 WHEN (66335, 0) THEN 30 WHEN (76567, 0) THEN 71 WHEN (81680, 0) THEN 51 WHEN (89641, 0) THEN 51 WHEN (89905, 0) THEN 77 ELSE crdb_internal.force_error('', 'unknown case') END [as=column35:35, outer=(18,19), side-effects]
-           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 6 WHEN (7853, 0) THEN 9 WHEN (8497, 0) THEN 13 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 2 WHEN (41382, 0) THEN 3 WHEN (55952, 0) THEN 10 WHEN (64817, 0) THEN 31 WHEN (66335, 0) THEN 9 WHEN (76567, 0) THEN 7 WHEN (81680, 0) THEN 4 WHEN (89641, 0) THEN 13 WHEN (89905, 0) THEN 20 END [as=column36:36, outer=(18,19)]
-           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 1 WHEN (7853, 0) THEN 1 WHEN (8497, 0) THEN 2 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 1 WHEN (41382, 0) THEN 1 WHEN (55952, 0) THEN 1 WHEN (64817, 0) THEN 4 WHEN (66335, 0) THEN 2 WHEN (76567, 0) THEN 1 WHEN (81680, 0) THEN 1 WHEN (89641, 0) THEN 2 WHEN (89905, 0) THEN 4 END [as=column37:37, outer=(18,19)]
-           └── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 0 WHEN (7853, 0) THEN 0 WHEN (8497, 0) THEN 0 WHEN (10904, 0) THEN 0 WHEN (16152, 0) THEN 0 WHEN (41382, 0) THEN 0 WHEN (55952, 0) THEN 0 WHEN (64817, 0) THEN 0 WHEN (66335, 0) THEN 0 WHEN (76567, 0) THEN 0 WHEN (81680, 0) THEN 0 WHEN (89641, 0) THEN 0 WHEN (89905, 0) THEN 0 END [as=column38:38, outer=(18,19)]
+           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 26 WHEN (7853, 0) THEN 10 WHEN (8497, 0) THEN 62 WHEN (10904, 0) THEN 54 WHEN (16152, 0) THEN 80 WHEN (41382, 0) THEN 18 WHEN (55952, 0) THEN 56 WHEN (64817, 0) THEN 26 WHEN (66335, 0) THEN 30 WHEN (76567, 0) THEN 71 WHEN (81680, 0) THEN 51 WHEN (89641, 0) THEN 51 WHEN (89905, 0) THEN 77 ELSE crdb_internal.force_error('', 'unknown case') END [as=s_quantity_new:35, outer=(18,19), side-effects]
+           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 6 WHEN (7853, 0) THEN 9 WHEN (8497, 0) THEN 13 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 2 WHEN (41382, 0) THEN 3 WHEN (55952, 0) THEN 10 WHEN (64817, 0) THEN 31 WHEN (66335, 0) THEN 9 WHEN (76567, 0) THEN 7 WHEN (81680, 0) THEN 4 WHEN (89641, 0) THEN 13 WHEN (89905, 0) THEN 20 END [as=s_ytd_new:36, outer=(18,19)]
+           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 1 WHEN (7853, 0) THEN 1 WHEN (8497, 0) THEN 2 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 1 WHEN (41382, 0) THEN 1 WHEN (55952, 0) THEN 1 WHEN (64817, 0) THEN 4 WHEN (66335, 0) THEN 2 WHEN (76567, 0) THEN 1 WHEN (81680, 0) THEN 1 WHEN (89641, 0) THEN 2 WHEN (89905, 0) THEN 4 END [as=s_order_cnt_new:37, outer=(18,19)]
+           └── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 0 WHEN (7853, 0) THEN 0 WHEN (8497, 0) THEN 0 WHEN (10904, 0) THEN 0 WHEN (16152, 0) THEN 0 WHEN (41382, 0) THEN 0 WHEN (55952, 0) THEN 0 WHEN (64817, 0) THEN 0 WHEN (66335, 0) THEN 0 WHEN (76567, 0) THEN 0 WHEN (81680, 0) THEN 0 WHEN (89641, 0) THEN 0 WHEN (89905, 0) THEN 0 END [as=s_remote_cnt_new:38, outer=(18,19)]
 
 opt format=hide-qual
 INSERT INTO order_line
@@ -564,14 +564,14 @@ project
  │    ├── update-mapping:
  │    │    ├── c_balance:47 => customer.c_balance:17
  │    │    ├── c_ytd_payment:48 => customer.c_ytd_payment:18
- │    │    ├── column45:45 => c_payment_cnt:19
- │    │    └── column46:46 => c_data:21
+ │    │    ├── c_payment_cnt_new:45 => c_payment_cnt:19
+ │    │    └── c_data_new:46 => c_data:21
  │    ├── cardinality: [0 - 1]
  │    ├── side-effects, mutations
  │    ├── key: ()
  │    ├── fd: ()-->(1-17,21)
  │    └── project
- │         ├── columns: c_balance:47 c_ytd_payment:48 column45:45 column46:46 c_id:22!null c_d_id:23!null c_w_id:24!null c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 customer.c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
+ │         ├── columns: c_balance:47 c_ytd_payment:48 c_payment_cnt_new:45 c_data_new:46 c_id:22!null c_d_id:23!null c_w_id:24!null c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 customer.c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
  │         ├── cardinality: [0 - 1]
  │         ├── key: ()
  │         ├── fd: ()-->(22-42,45-48)
@@ -584,8 +584,8 @@ project
  │         └── projections
  │              ├── crdb_internal.round_decimal_values(customer.c_balance:38 - 3860.61, 2) [as=c_balance:47, outer=(38)]
  │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:39 + 3860.61, 2) [as=c_ytd_payment:48, outer=(39)]
- │              ├── c_payment_cnt:40 + 1 [as=column45:45, outer=(40)]
- │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42, 500) ELSE c_data:42 END [as=column46:46, outer=(22-24,35,42)]
+ │              ├── c_payment_cnt:40 + 1 [as=c_payment_cnt_new:45, outer=(40)]
+ │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42, 500) ELSE c_data:42 END [as=c_data_new:46, outer=(22-24,35,42)]
  └── projections
       └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:49, outer=(14,21)]
 
@@ -816,13 +816,13 @@ project
       ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_c_id:4
       ├── fetch columns: o_id:9 o_d_id:10 o_w_id:11 o_c_id:12 o_entry_d:13 o_carrier_id:14 o_ol_cnt:15 o_all_local:16
       ├── update-mapping:
-      │    └── column17:17 => o_carrier_id:6
+      │    └── o_carrier_id_new:17 => o_carrier_id:6
       ├── cardinality: [0 - 10]
       ├── side-effects, mutations
       ├── key: (2)
       ├── fd: ()-->(1,3), (2)-->(4)
       └── project
-           ├── columns: column17:17!null o_id:9!null o_d_id:10!null o_w_id:11!null o_c_id:12 o_entry_d:13 o_carrier_id:14 o_ol_cnt:15 o_all_local:16
+           ├── columns: o_carrier_id_new:17!null o_id:9!null o_d_id:10!null o_w_id:11!null o_c_id:12 o_entry_d:13 o_carrier_id:14 o_ol_cnt:15 o_all_local:16
            ├── cardinality: [0 - 10]
            ├── key: (10)
            ├── fd: ()-->(9,11,17), (10)-->(12-16)
@@ -843,7 +843,7 @@ project
            │    ├── key: (10)
            │    └── fd: ()-->(9,11), (10)-->(12-16)
            └── projections
-                └── 10 [as=column17:17]
+                └── 10 [as=o_carrier_id_new:17]
 
 opt format=hide-qual
 UPDATE customer
@@ -878,11 +878,11 @@ update customer
  ├── fetch columns: c_id:22 c_d_id:23 c_w_id:24 c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
  ├── update-mapping:
  │    ├── c_balance:45 => customer.c_balance:17
- │    └── column43:43 => c_delivery_cnt:20
+ │    └── c_delivery_cnt_new:43 => c_delivery_cnt:20
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: c_balance:45 column43:43 c_id:22!null c_d_id:23!null c_w_id:24!null c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
+      ├── columns: c_balance:45 c_delivery_cnt_new:43 c_id:22!null c_d_id:23!null c_w_id:24!null c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
       ├── cardinality: [0 - 10]
       ├── key: (22,23)
       ├── fd: ()-->(24), (22,23)-->(25-42,45), (41)-->(43)
@@ -904,7 +904,7 @@ update customer
       │    └── fd: ()-->(24), (22,23)-->(25-42)
       └── projections
            ├── crdb_internal.round_decimal_values(customer.c_balance:38 + CASE c_d_id:23 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 END, 2) [as=c_balance:45, outer=(23,38)]
-           └── c_delivery_cnt:41 + 1 [as=column43:43, outer=(41)]
+           └── c_delivery_cnt:41 + 1 [as=c_delivery_cnt_new:43, outer=(41)]
 
 opt format=hide-qual
 DELETE FROM new_order
@@ -963,11 +963,11 @@ update order_line
  ├── columns: <none>
  ├── fetch columns: ol_o_id:11 ol_d_id:12 ol_w_id:13 ol_number:14 ol_i_id:15 ol_supply_w_id:16 ol_delivery_d:17 ol_quantity:18 ol_amount:19 ol_dist_info:20
  ├── update-mapping:
- │    └── column21:21 => ol_delivery_d:7
+ │    └── ol_delivery_d_new:21 => ol_delivery_d:7
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: column21:21!null ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null ol_number:14!null ol_i_id:15!null ol_supply_w_id:16 ol_delivery_d:17 ol_quantity:18 ol_amount:19 ol_dist_info:20
+      ├── columns: ol_delivery_d_new:21!null ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null ol_number:14!null ol_i_id:15!null ol_supply_w_id:16 ol_delivery_d:17 ol_quantity:18 ol_amount:19 ol_dist_info:20
       ├── key: (12,14)
       ├── fd: ()-->(11,13,21), (12,14)-->(15-20)
       ├── scan order_line
@@ -986,7 +986,7 @@ update order_line
       │    ├── key: (12,14)
       │    └── fd: ()-->(11,13), (12,14)-->(15-20)
       └── projections
-           └── '2019-08-26 16:50:41+00:00' [as=column21:21]
+           └── '2019-08-26 16:50:41+00:00' [as=ol_delivery_d_new:21]
 
 # --------------------------------------------------
 # 2.8 The Stock-Level Transaction

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -28,13 +28,13 @@ project
       ├── columns: d_id:1!null d_w_id:2!null d_tax:9 d_next_o_id:11
       ├── fetch columns: d_id:12 d_w_id:13 d_name:14 d_street_1:15 d_street_2:16 d_city:17 d_state:18 d_zip:19 d_tax:20 d_ytd:21 d_next_o_id:22
       ├── update-mapping:
-      │    └── column23:23 => d_next_o_id:11
+      │    └── d_next_o_id_new:23 => d_next_o_id:11
       ├── cardinality: [0 - 1]
       ├── side-effects, mutations
       ├── key: ()
       ├── fd: ()-->(1,2,9,11)
       └── project
-           ├── columns: column23:23 d_id:12!null d_w_id:13!null d_name:14 d_street_1:15 d_street_2:16 d_city:17 d_state:18 d_zip:19 d_tax:20 d_ytd:21 d_next_o_id:22
+           ├── columns: d_next_o_id_new:23 d_id:12!null d_w_id:13!null d_name:14 d_street_1:15 d_street_2:16 d_city:17 d_state:18 d_zip:19 d_tax:20 d_ytd:21 d_next_o_id:22
            ├── cardinality: [0 - 1]
            ├── key: ()
            ├── fd: ()-->(12-23)
@@ -45,7 +45,7 @@ project
            │    ├── key: ()
            │    └── fd: ()-->(12-22)
            └── projections
-                └── d_next_o_id:22 + 1 [as=column23:23, outer=(22)]
+                └── d_next_o_id:22 + 1 [as=d_next_o_id_new:23, outer=(22)]
 
 opt format=hide-qual
 SELECT w_tax FROM warehouse WHERE w_id = 10
@@ -303,14 +303,14 @@ update stock
  ├── columns: <none>
  ├── fetch columns: s_i_id:18 s_w_id:19 s_quantity:20 s_dist_01:21 s_dist_02:22 s_dist_03:23 s_dist_04:24 s_dist_05:25 s_dist_06:26 s_dist_07:27 s_dist_08:28 s_dist_09:29 s_dist_10:30 s_ytd:31 s_order_cnt:32 s_remote_cnt:33 s_data:34
  ├── update-mapping:
- │    ├── column35:35 => s_quantity:3
- │    ├── column36:36 => s_ytd:14
- │    ├── column37:37 => s_order_cnt:15
- │    └── column38:38 => s_remote_cnt:16
+ │    ├── s_quantity_new:35 => s_quantity:3
+ │    ├── s_ytd_new:36 => s_ytd:14
+ │    ├── s_order_cnt_new:37 => s_order_cnt:15
+ │    └── s_remote_cnt_new:38 => s_remote_cnt:16
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: column35:35 column36:36 column37:37 column38:38 s_i_id:18!null s_w_id:19!null s_quantity:20 s_dist_01:21 s_dist_02:22 s_dist_03:23 s_dist_04:24 s_dist_05:25 s_dist_06:26 s_dist_07:27 s_dist_08:28 s_dist_09:29 s_dist_10:30 s_ytd:31 s_order_cnt:32 s_remote_cnt:33 s_data:34
+      ├── columns: s_quantity_new:35 s_ytd_new:36 s_order_cnt_new:37 s_remote_cnt_new:38 s_i_id:18!null s_w_id:19!null s_quantity:20 s_dist_01:21 s_dist_02:22 s_dist_03:23 s_dist_04:24 s_dist_05:25 s_dist_06:26 s_dist_07:27 s_dist_08:28 s_dist_09:29 s_dist_10:30 s_ytd:31 s_order_cnt:32 s_remote_cnt:33 s_data:34
       ├── cardinality: [0 - 13]
       ├── side-effects
       ├── key: (18)
@@ -335,10 +335,10 @@ update stock
       │    ├── key: (18)
       │    └── fd: ()-->(19), (18)-->(20-34)
       └── projections
-           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 26 WHEN (7853, 0) THEN 10 WHEN (8497, 0) THEN 62 WHEN (10904, 0) THEN 54 WHEN (16152, 0) THEN 80 WHEN (41382, 0) THEN 18 WHEN (55952, 0) THEN 56 WHEN (64817, 0) THEN 26 WHEN (66335, 0) THEN 30 WHEN (76567, 0) THEN 71 WHEN (81680, 0) THEN 51 WHEN (89641, 0) THEN 51 WHEN (89905, 0) THEN 77 ELSE crdb_internal.force_error('', 'unknown case') END [as=column35:35, outer=(18,19), side-effects]
-           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 6 WHEN (7853, 0) THEN 9 WHEN (8497, 0) THEN 13 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 2 WHEN (41382, 0) THEN 3 WHEN (55952, 0) THEN 10 WHEN (64817, 0) THEN 31 WHEN (66335, 0) THEN 9 WHEN (76567, 0) THEN 7 WHEN (81680, 0) THEN 4 WHEN (89641, 0) THEN 13 WHEN (89905, 0) THEN 20 END [as=column36:36, outer=(18,19)]
-           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 1 WHEN (7853, 0) THEN 1 WHEN (8497, 0) THEN 2 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 1 WHEN (41382, 0) THEN 1 WHEN (55952, 0) THEN 1 WHEN (64817, 0) THEN 4 WHEN (66335, 0) THEN 2 WHEN (76567, 0) THEN 1 WHEN (81680, 0) THEN 1 WHEN (89641, 0) THEN 2 WHEN (89905, 0) THEN 4 END [as=column37:37, outer=(18,19)]
-           └── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 0 WHEN (7853, 0) THEN 0 WHEN (8497, 0) THEN 0 WHEN (10904, 0) THEN 0 WHEN (16152, 0) THEN 0 WHEN (41382, 0) THEN 0 WHEN (55952, 0) THEN 0 WHEN (64817, 0) THEN 0 WHEN (66335, 0) THEN 0 WHEN (76567, 0) THEN 0 WHEN (81680, 0) THEN 0 WHEN (89641, 0) THEN 0 WHEN (89905, 0) THEN 0 END [as=column38:38, outer=(18,19)]
+           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 26 WHEN (7853, 0) THEN 10 WHEN (8497, 0) THEN 62 WHEN (10904, 0) THEN 54 WHEN (16152, 0) THEN 80 WHEN (41382, 0) THEN 18 WHEN (55952, 0) THEN 56 WHEN (64817, 0) THEN 26 WHEN (66335, 0) THEN 30 WHEN (76567, 0) THEN 71 WHEN (81680, 0) THEN 51 WHEN (89641, 0) THEN 51 WHEN (89905, 0) THEN 77 ELSE crdb_internal.force_error('', 'unknown case') END [as=s_quantity_new:35, outer=(18,19), side-effects]
+           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 6 WHEN (7853, 0) THEN 9 WHEN (8497, 0) THEN 13 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 2 WHEN (41382, 0) THEN 3 WHEN (55952, 0) THEN 10 WHEN (64817, 0) THEN 31 WHEN (66335, 0) THEN 9 WHEN (76567, 0) THEN 7 WHEN (81680, 0) THEN 4 WHEN (89641, 0) THEN 13 WHEN (89905, 0) THEN 20 END [as=s_ytd_new:36, outer=(18,19)]
+           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 1 WHEN (7853, 0) THEN 1 WHEN (8497, 0) THEN 2 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 1 WHEN (41382, 0) THEN 1 WHEN (55952, 0) THEN 1 WHEN (64817, 0) THEN 4 WHEN (66335, 0) THEN 2 WHEN (76567, 0) THEN 1 WHEN (81680, 0) THEN 1 WHEN (89641, 0) THEN 2 WHEN (89905, 0) THEN 4 END [as=s_order_cnt_new:37, outer=(18,19)]
+           └── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 0 WHEN (7853, 0) THEN 0 WHEN (8497, 0) THEN 0 WHEN (10904, 0) THEN 0 WHEN (16152, 0) THEN 0 WHEN (41382, 0) THEN 0 WHEN (55952, 0) THEN 0 WHEN (64817, 0) THEN 0 WHEN (66335, 0) THEN 0 WHEN (76567, 0) THEN 0 WHEN (81680, 0) THEN 0 WHEN (89641, 0) THEN 0 WHEN (89905, 0) THEN 0 END [as=s_remote_cnt_new:38, outer=(18,19)]
 
 opt format=hide-qual
 INSERT INTO order_line
@@ -558,14 +558,14 @@ project
  │    ├── update-mapping:
  │    │    ├── c_balance:47 => customer.c_balance:17
  │    │    ├── c_ytd_payment:48 => customer.c_ytd_payment:18
- │    │    ├── column45:45 => c_payment_cnt:19
- │    │    └── column46:46 => c_data:21
+ │    │    ├── c_payment_cnt_new:45 => c_payment_cnt:19
+ │    │    └── c_data_new:46 => c_data:21
  │    ├── cardinality: [0 - 1]
  │    ├── side-effects, mutations
  │    ├── key: ()
  │    ├── fd: ()-->(1-17,21)
  │    └── project
- │         ├── columns: c_balance:47 c_ytd_payment:48 column45:45 column46:46 c_id:22!null c_d_id:23!null c_w_id:24!null c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 customer.c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
+ │         ├── columns: c_balance:47 c_ytd_payment:48 c_payment_cnt_new:45 c_data_new:46 c_id:22!null c_d_id:23!null c_w_id:24!null c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 customer.c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
  │         ├── cardinality: [0 - 1]
  │         ├── key: ()
  │         ├── fd: ()-->(22-42,45-48)
@@ -578,8 +578,8 @@ project
  │         └── projections
  │              ├── crdb_internal.round_decimal_values(customer.c_balance:38 - 3860.61, 2) [as=c_balance:47, outer=(38)]
  │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:39 + 3860.61, 2) [as=c_ytd_payment:48, outer=(39)]
- │              ├── c_payment_cnt:40 + 1 [as=column45:45, outer=(40)]
- │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42, 500) ELSE c_data:42 END [as=column46:46, outer=(22-24,35,42)]
+ │              ├── c_payment_cnt:40 + 1 [as=c_payment_cnt_new:45, outer=(40)]
+ │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42, 500) ELSE c_data:42 END [as=c_data_new:46, outer=(22-24,35,42)]
  └── projections
       └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:49, outer=(14,21)]
 
@@ -810,13 +810,13 @@ project
       ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_c_id:4
       ├── fetch columns: o_id:9 o_d_id:10 o_w_id:11 o_c_id:12 o_entry_d:13 o_carrier_id:14 o_ol_cnt:15 o_all_local:16
       ├── update-mapping:
-      │    └── column17:17 => o_carrier_id:6
+      │    └── o_carrier_id_new:17 => o_carrier_id:6
       ├── cardinality: [0 - 10]
       ├── side-effects, mutations
       ├── key: (2)
       ├── fd: ()-->(1,3), (2)-->(4)
       └── project
-           ├── columns: column17:17!null o_id:9!null o_d_id:10!null o_w_id:11!null o_c_id:12 o_entry_d:13 o_carrier_id:14 o_ol_cnt:15 o_all_local:16
+           ├── columns: o_carrier_id_new:17!null o_id:9!null o_d_id:10!null o_w_id:11!null o_c_id:12 o_entry_d:13 o_carrier_id:14 o_ol_cnt:15 o_all_local:16
            ├── cardinality: [0 - 10]
            ├── key: (10)
            ├── fd: ()-->(9,11,17), (10)-->(12-16)
@@ -837,7 +837,7 @@ project
            │    ├── key: (10)
            │    └── fd: ()-->(9,11), (10)-->(12-16)
            └── projections
-                └── 10 [as=column17:17]
+                └── 10 [as=o_carrier_id_new:17]
 
 opt format=hide-qual
 UPDATE customer
@@ -872,11 +872,11 @@ update customer
  ├── fetch columns: c_id:22 c_d_id:23 c_w_id:24 c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
  ├── update-mapping:
  │    ├── c_balance:45 => customer.c_balance:17
- │    └── column43:43 => c_delivery_cnt:20
+ │    └── c_delivery_cnt_new:43 => c_delivery_cnt:20
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: c_balance:45 column43:43 c_id:22!null c_d_id:23!null c_w_id:24!null c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
+      ├── columns: c_balance:45 c_delivery_cnt_new:43 c_id:22!null c_d_id:23!null c_w_id:24!null c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
       ├── cardinality: [0 - 10]
       ├── key: (22,23)
       ├── fd: ()-->(24), (22,23)-->(25-42,45), (41)-->(43)
@@ -898,7 +898,7 @@ update customer
       │    └── fd: ()-->(24), (22,23)-->(25-42)
       └── projections
            ├── crdb_internal.round_decimal_values(customer.c_balance:38 + CASE c_d_id:23 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 END, 2) [as=c_balance:45, outer=(23,38)]
-           └── c_delivery_cnt:41 + 1 [as=column43:43, outer=(41)]
+           └── c_delivery_cnt:41 + 1 [as=c_delivery_cnt_new:43, outer=(41)]
 
 opt format=hide-qual
 DELETE FROM new_order
@@ -957,11 +957,11 @@ update order_line
  ├── columns: <none>
  ├── fetch columns: ol_o_id:11 ol_d_id:12 ol_w_id:13 ol_number:14 ol_i_id:15 ol_supply_w_id:16 ol_delivery_d:17 ol_quantity:18 ol_amount:19 ol_dist_info:20
  ├── update-mapping:
- │    └── column21:21 => ol_delivery_d:7
+ │    └── ol_delivery_d_new:21 => ol_delivery_d:7
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: column21:21!null ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null ol_number:14!null ol_i_id:15!null ol_supply_w_id:16 ol_delivery_d:17 ol_quantity:18 ol_amount:19 ol_dist_info:20
+      ├── columns: ol_delivery_d_new:21!null ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null ol_number:14!null ol_i_id:15!null ol_supply_w_id:16 ol_delivery_d:17 ol_quantity:18 ol_amount:19 ol_dist_info:20
       ├── key: (12,14)
       ├── fd: ()-->(11,13,21), (12,14)-->(15-20)
       ├── scan order_line
@@ -980,7 +980,7 @@ update order_line
       │    ├── key: (12,14)
       │    └── fd: ()-->(11,13), (12,14)-->(15-20)
       └── projections
-           └── '2019-08-26 16:50:41+00:00' [as=column21:21]
+           └── '2019-08-26 16:50:41+00:00' [as=ol_delivery_d_new:21]
 
 # --------------------------------------------------
 # 2.8 The Stock-Level Transaction

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1416,11 +1416,11 @@ update ci
  ├── columns: <none>
  ├── fetch columns: ci.dealerid:15 ci.cardid:16 buyprice:17 sellprice:18 discount:19 desiredinventory:20 actualinventory:21 maxinventory:22 ci.version:23
  ├── update-mapping:
- │    └── column33:33 => actualinventory:12
+ │    └── actualinventory_new:33 => actualinventory:12
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: column33:33 ci.dealerid:15!null ci.cardid:16!null buyprice:17!null sellprice:18!null discount:19!null desiredinventory:20!null actualinventory:21!null maxinventory:22!null ci.version:23!null c:24!null q:25!null
+      ├── columns: actualinventory_new:33 ci.dealerid:15!null ci.cardid:16!null buyprice:17!null sellprice:18!null discount:19!null desiredinventory:20!null actualinventory:21!null maxinventory:22!null ci.version:23!null c:24!null q:25!null
       ├── key: (16)
       ├── fd: ()-->(15), (16)-->(17-25,33), (23)-->(16-22), (16)==(24), (24)==(16)
       ├── group-by
@@ -1506,4 +1506,4 @@ update ci
       │         └── const-agg [as=q:25, outer=(25)]
       │              └── q:25
       └── projections
-           └── COALESCE(sum_int:31, 0) [as=column33:33, outer=(31)]
+           └── COALESCE(sum_int:31, 0) [as=actualinventory_new:33, outer=(31)]

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1429,14 +1429,14 @@ update ci
  ├── columns: <none>
  ├── fetch columns: ci.dealerid:19 ci.cardid:20 buyprice:21 sellprice:22 discount:23 desiredinventory:24 actualinventory:25 maxinventory:26 ci.version:27 ci.discountbuyprice:28 notes:29 oldinventory:30 ci.extra:31
  ├── update-mapping:
- │    ├── column43:43 => actualinventory:12
+ │    ├── actualinventory_new:43 => actualinventory:12
  │    ├── discountbuyprice:47 => ci.discountbuyprice:15
  │    ├── column44:44 => notes:16
  │    └── column45:45 => oldinventory:17
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: discountbuyprice:47 column44:44 column45:45!null column43:43 ci.dealerid:19!null ci.cardid:20!null buyprice:21!null sellprice:22!null discount:23!null desiredinventory:24!null actualinventory:25!null maxinventory:26!null ci.version:27!null ci.discountbuyprice:28 notes:29 oldinventory:30 ci.extra:31 c:32!null q:33!null
+      ├── columns: discountbuyprice:47 column44:44 column45:45!null actualinventory_new:43 ci.dealerid:19!null ci.cardid:20!null buyprice:21!null sellprice:22!null discount:23!null desiredinventory:24!null actualinventory:25!null maxinventory:26!null ci.version:27!null ci.discountbuyprice:28 notes:29 oldinventory:30 ci.extra:31 c:32!null q:33!null
       ├── key: (20)
       ├── fd: ()-->(19,44,45), (20)-->(21-33,43,47), (27)-->(20-26,28-31), (20)==(32), (32)==(20)
       ├── group-by
@@ -1541,4 +1541,4 @@ update ci
            ├── crdb_internal.round_decimal_values(buyprice:21 - discount:23, 4) [as=discountbuyprice:47, outer=(21,23)]
            ├── CAST(NULL AS STRING) [as=column44:44]
            ├── 0 [as=column45:45]
-           └── COALESCE(sum_int:41, 0) [as=column43:43, outer=(41)]
+           └── COALESCE(sum_int:41, 0) [as=actualinventory_new:43, outer=(41)]

--- a/pkg/sql/opt/xform/testdata/external/ycsb
+++ b/pkg/sql/opt/xform/testdata/external/ycsb
@@ -27,11 +27,11 @@ update usertable
  ├── columns: <none>
  ├── fetch columns: ycsb_key:12 field5:18
  ├── update-mapping:
- │    └── column23:23 => field5:7
+ │    └── field5_new:23 => field5:7
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: column23:23!null ycsb_key:12!null field5:18
+      ├── columns: field5_new:23!null ycsb_key:12!null field5:18
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(12,18,23)
@@ -42,7 +42,7 @@ update usertable
       │    ├── key: ()
       │    └── fd: ()-->(12,18)
       └── projections
-           └── 'field5data' [as=column23:23]
+           └── 'field5data' [as=field5_new:23]
 
 # --------------------------------------------------
 # Workload B: Read mostly
@@ -171,11 +171,11 @@ update usertable
  ├── columns: <none>
  ├── fetch columns: ycsb_key:12 field5:18
  ├── update-mapping:
- │    └── column23:23 => field5:7
+ │    └── field5_new:23 => field5:7
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: column23:23!null ycsb_key:12!null field5:18
+      ├── columns: field5_new:23!null ycsb_key:12!null field5:18
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(12,18,23)
@@ -186,4 +186,4 @@ update usertable
       │    ├── key: ()
       │    └── fd: ()-->(12,18)
       └── projections
-           └── 'field5data' [as=column23:23]
+           └── 'field5data' [as=field5_new:23]

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1609,13 +1609,13 @@ sort
       │         ├── columns: abcd.a:1!null abcd.b:2!null abcd.c:3 abcd.d:4 rowid:5!null
       │         ├── fetch columns: abcd.a:6 abcd.b:7 abcd.c:8 abcd.d:9 rowid:10
       │         ├── update-mapping:
-      │         │    ├── column11:11 => abcd.a:1
-      │         │    └── column12:12 => abcd.b:2
+      │         │    ├── a_new:11 => abcd.a:1
+      │         │    └── b_new:12 => abcd.b:2
       │         ├── side-effects, mutations
       │         ├── key: (5)
       │         ├── fd: ()-->(1,2), (5)-->(3,4)
       │         └── project
-      │              ├── columns: column11:11!null column12:12!null abcd.a:6 abcd.b:7 abcd.c:8 abcd.d:9 rowid:10!null
+      │              ├── columns: a_new:11!null b_new:12!null abcd.a:6 abcd.b:7 abcd.c:8 abcd.d:9 rowid:10!null
       │              ├── key: (10)
       │              ├── fd: ()-->(11,12), (10)-->(6-9)
       │              ├── scan abcd
@@ -1623,8 +1623,8 @@ sort
       │              │    ├── key: (10)
       │              │    └── fd: (10)-->(6-9)
       │              └── projections
-      │                   ├── 1 [as=column11:11]
-      │                   └── 2 [as=column12:12]
+      │                   ├── 1 [as=a_new:11]
+      │                   └── 2 [as=b_new:12]
       └── with-scan &1
            ├── columns: a:13!null b:14!null c:15 d:16
            ├── mapping:
@@ -1657,13 +1657,13 @@ sort
       │         ├── columns: abcd.a:1 abcd.b:2 abcd.c:3 abcd.d:4 rowid:5!null
       │         ├── fetch columns: abcd.a:6 abcd.b:7 abcd.c:8 abcd.d:9 rowid:10
       │         ├── update-mapping:
-      │         │    └── column11:11 => abcd.b:2
+      │         │    └── b_new:11 => abcd.b:2
       │         ├── cardinality: [0 - 10]
       │         ├── side-effects, mutations
       │         ├── key: (5)
       │         ├── fd: (5)-->(1-4)
       │         └── project
-      │              ├── columns: column11:11 abcd.a:6 abcd.b:7 abcd.c:8 abcd.d:9 rowid:10!null
+      │              ├── columns: b_new:11 abcd.a:6 abcd.b:7 abcd.c:8 abcd.d:9 rowid:10!null
       │              ├── cardinality: [0 - 10]
       │              ├── key: (10)
       │              ├── fd: (10)-->(6-9), (7)-->(11)
@@ -1673,7 +1673,7 @@ sort
       │              │    ├── key: (10)
       │              │    └── fd: (10)-->(6-9)
       │              └── projections
-      │                   └── abcd.b:7 + 1 [as=column11:11, outer=(7)]
+      │                   └── abcd.b:7 + 1 [as=b_new:11, outer=(7)]
       └── with-scan &1
            ├── columns: a:12 b:13 c:14 d:15
            ├── mapping:
@@ -1710,13 +1710,13 @@ sort
       │         ├── columns: abcd.a:1 abcd.b:2 abcd.c:3 abcd.d:4 rowid:5!null
       │         ├── fetch columns: abcd.a:6 abcd.b:7 abcd.c:8 abcd.d:9 rowid:10
       │         ├── update-mapping:
-      │         │    └── column11:11 => abcd.b:2
+      │         │    └── b_new:11 => abcd.b:2
       │         ├── cardinality: [0 - 10]
       │         ├── side-effects, mutations
       │         ├── key: (5)
       │         ├── fd: (5)-->(1-4)
       │         └── project
-      │              ├── columns: column11:11 abcd.a:6 abcd.b:7 abcd.c:8 abcd.d:9 rowid:10!null
+      │              ├── columns: b_new:11 abcd.a:6 abcd.b:7 abcd.c:8 abcd.d:9 rowid:10!null
       │              ├── cardinality: [0 - 10]
       │              ├── key: (10)
       │              ├── fd: (10)-->(6-9), (7)-->(11)
@@ -1726,7 +1726,7 @@ sort
       │              │    ├── key: (10)
       │              │    └── fd: (10)-->(6-9)
       │              └── projections
-      │                   └── abcd.b:7 + 1 [as=column11:11, outer=(7)]
+      │                   └── abcd.b:7 + 1 [as=b_new:11, outer=(7)]
       └── select
            ├── columns: a:12 b:13!null c:14!null d:15
            ├── cardinality: [0 - 10]


### PR DESCRIPTION
For UPDATE, we synthesize columns with the new values. Currently, such a column
gets a very generic name like `column5`. This change sets it to a more useful
name, like `a_new` (where `a` is the table column name). This improves
readability of update expressions.

Release note: None