### PR TITLE
rowcontainer: add a benchmark that compares DiskBackedNumberedRowCont…

### DIFF
--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -655,6 +655,8 @@ type DiskBackedIndexedRowContainer struct {
 	// error is encountered.
 	maxCacheSize int
 	cacheMemAcc  mon.BoundAccount
+	hitCount     int
+	missCount    int
 
 	// DisableCache is intended for testing only. It can be set to true to
 	// disable reading and writing from the row cache.
@@ -782,8 +784,10 @@ func (f *DiskBackedIndexedRowContainer) GetRow(
 		// cache will contain 4 rows at positions 0, 1, 2, and 3.
 		if pos >= f.firstCachedRowPos && pos < f.nextPosToCache {
 			requestedRowCachePos := pos - f.firstCachedRowPos
+			f.hitCount++
 			return f.indexedRowsCache.Get(requestedRowCachePos).(tree.IndexedRow), nil
 		}
+		f.missCount++
 		if f.diskRowIter == nil {
 			f.diskRowIter = f.DiskBackedRowContainer.drc.NewIterator(ctx)
 			f.diskRowIter.Rewind()


### PR DESCRIPTION
…ainer

and DiskBackedIndexedRowContainer read performance

The benchmark uses two access patterns, inspired by lookup join and
inverted join. The latter is more random and reads only a subset of the
stored rows.

```
BenchmarkNumberedContainerIteratorCaching/lookup-join/11000/indexed-16         	   58747	     21647 ns/op	    5097 B/op	     157 allocs/op
BenchmarkNumberedContainerIteratorCaching/lookup-join/11000/numbered-16        	  764589	      1362 ns/op	     811 B/op	       9 allocs/op
BenchmarkNumberedContainerIteratorCaching/lookup-join/102400/indexed-16        	   56755	     22072 ns/op	    5222 B/op	     156 allocs/op
BenchmarkNumberedContainerIteratorCaching/lookup-join/102400/numbered-16       	  799171	      1322 ns/op	     748 B/op	       8 allocs/op
BenchmarkNumberedContainerIteratorCaching/lookup-join/512000/indexed-16        	   61783	     20462 ns/op	    5451 B/op	     145 allocs/op
BenchmarkNumberedContainerIteratorCaching/lookup-join/512000/numbered-16       	  905247	      1229 ns/op	     631 B/op	       7 allocs/op
BenchmarkNumberedContainerIteratorCaching/lookup-join/2560000/indexed-16       	   74767	     14736 ns/op	    5544 B/op	     103 allocs/op
BenchmarkNumberedContainerIteratorCaching/lookup-join/2560000/numbered-16      	 1738810	       691 ns/op	     315 B/op	       3 allocs/op
BenchmarkNumberedContainerIteratorCaching/inverted-join/11000/indexed-16       	    4567	    275083 ns/op	   63635 B/op	    1969 allocs/op
BenchmarkNumberedContainerIteratorCaching/inverted-join/11000/numbered-16      	   45824	     26748 ns/op	    1184 B/op	      13 allocs/op
BenchmarkNumberedContainerIteratorCaching/inverted-join/102400/indexed-16      	    4234	    272036 ns/op	   64874 B/op	    1970 allocs/op
BenchmarkNumberedContainerIteratorCaching/inverted-join/102400/numbered-16     	  114686	     10517 ns/op	    1477 B/op	      16 allocs/op
BenchmarkNumberedContainerIteratorCaching/inverted-join/512000/indexed-16      	    4261	    277071 ns/op	   70229 B/op	    1967 allocs/op
BenchmarkNumberedContainerIteratorCaching/inverted-join/512000/numbered-16     	  322872	      3395 ns/op	     705 B/op	       7 allocs/op
BenchmarkNumberedContainerIteratorCaching/inverted-join/2560000/indexed-16     	    4207	    276748 ns/op	   97295 B/op	    1970 allocs/op
BenchmarkNumberedContainerIteratorCaching/inverted-join/2560000/numbered-16    	10015344	       127 ns/op	      33 B/op	       0 allocs/op
```

Release note: None