### PR TITLE
sql: move around enum stats logictest

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
@@ -189,19 +189,3 @@ __auto__         {d}           550        0
 __auto__         {d}           0          0
 __auto__         {rowid}       550        0
 __auto__         {rowid}       0          0
-
-# Test that enum columns always have histograms collected for them.
-statement ok
-CREATE TYPE e AS ENUM ('hello', 'howdy', 'hi');
-CREATE TABLE et (x e, y e, PRIMARY KEY (x));
-INSERT INTO et VALUES ('hello', 'hello'), ('howdy', 'howdy'), ('hi', 'hi');
-CREATE STATISTICS s FROM et
-
-query TTII colnames,rowsort,retry
-SELECT statistics_name, column_names, row_count, null_count
-FROM [SHOW STATISTICS FOR TABLE et] WHERE histogram_id IS NOT NULL
-ORDER BY column_names::STRING, created
-----
-statistics_name  column_names  row_count  null_count
-__auto__         {x}           3          0
-__auto__         {y}           3          0

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -617,3 +617,26 @@ ORDER BY statistics_name, column_names::STRING
 statistics_name  column_names  row_count  distinct_count  null_count  has_histogram
 arr_stats        {rowid}       4          4               0           true
 arr_stats_x      {x}           4          3               1           false
+
+# Test that enum columns always have histograms collected for them.
+statement ok
+CREATE TYPE e AS ENUM ('hello', 'howdy', 'hi');
+CREATE TABLE et (x e, y e, PRIMARY KEY (x));
+INSERT INTO et VALUES ('hello', 'hello'), ('howdy', 'howdy'), ('hi', 'hi');
+CREATE STATISTICS s FROM et
+
+query TTIIB colnames,rowsort
+SELECT
+  statistics_name,
+  column_names,
+  row_count,
+  null_count,
+  histogram_id IS NOT NULL AS has_histogram
+FROM
+  [SHOW STATISTICS FOR TABLE et]
+ORDER BY
+  column_names::STRING, created
+----
+statistics_name  column_names  row_count  null_count  has_histogram
+s                {x}           3          0           true
+s                {y}           3          0           true


### PR DESCRIPTION
Move the enum stats logictest from `distsql_automatic_stats` to
`distsql_stats`.

Release note: None