### PR TITLE
storage: refactor FS interface

### DIFF
--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -533,14 +533,14 @@ func addSSTablePreApply(
 			// If the fs supports it, make a hard-link for rocks to ingest. We cannot
 			// pass it the path in the sideload store as it deletes the passed path on
 			// success.
-			if linkErr := eng.LinkFile(path, ingestPath); linkErr == nil {
+			if linkErr := eng.Link(path, ingestPath); linkErr == nil {
 				ingestErr := eng.IngestExternalFiles(ctx, []string{ingestPath})
 				if ingestErr == nil {
 					// Adding without modification succeeded, no copy necessary.
 					log.Eventf(ctx, "ingested SSTable at index %d, term %d: %s", index, term, ingestPath)
 					return false
 				}
-				if rmErr := eng.DeleteFile(ingestPath); rmErr != nil {
+				if rmErr := eng.Remove(ingestPath); rmErr != nil {
 					log.Fatalf(ctx, "failed to move ingest sst: %v", rmErr)
 				}
 				const seqNoMsg = "Global seqno is required, but disabled"

--- a/pkg/kv/kvserver/replica_sideload_disk.go
+++ b/pkg/kv/kvserver/replica_sideload_disk.go
@@ -197,7 +197,7 @@ func (ss *diskSideloadStorage) purgeFile(ctx context.Context, filename string) (
 	if err != nil {
 		return 0, err
 	}
-	if err := ss.eng.DeleteFile(filename); err != nil {
+	if err := ss.eng.Remove(filename); err != nil {
 		if os.IsNotExist(err) {
 			return 0, errSideloadedFileNotFound
 		}
@@ -208,7 +208,7 @@ func (ss *diskSideloadStorage) purgeFile(ctx context.Context, filename string) (
 
 // Clear implements SideloadStorage.
 func (ss *diskSideloadStorage) Clear(_ context.Context) error {
-	err := ss.eng.DeleteDirAndFiles(ss.dir)
+	err := ss.eng.RemoveDirAndFiles(ss.dir)
 	if os.IsNotExist(err) {
 		ss.dirCreated = false
 		return nil

--- a/pkg/kv/kvserver/replica_sst_snapshot_storage.go
+++ b/pkg/kv/kvserver/replica_sst_snapshot_storage.go
@@ -159,7 +159,7 @@ func (f *SSTSnapshotStorageFile) openFile() error {
 			return err
 		}
 	}
-	file, err := f.scratch.storage.engine.CreateFile(f.filename)
+	file, err := f.scratch.storage.engine.Create(f.filename)
 	if err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/syncing_write.go
+++ b/pkg/kv/kvserver/syncing_write.go
@@ -84,7 +84,7 @@ func writeFileSyncing(
 		sync = false
 	}
 
-	f, err := eng.CreateFile(filename)
+	f, err := eng.Create(filename)
 	if err != nil {
 		if strings.Contains(err.Error(), "No such file or directory") {
 			return os.ErrNotExist

--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -366,7 +366,7 @@ func newDiskQueue(
 	if d.cfg.CacheMode != DiskQueueCacheModeDefault {
 		d.writeBufferLimit = d.cfg.BufferSizeBytes / 2
 	}
-	if err := cfg.FS.CreateDir(filepath.Join(cfg.Path, d.dirName)); err != nil {
+	if err := cfg.FS.MkdirAll(filepath.Join(cfg.Path, d.dirName)); err != nil {
 		return nil, err
 	}
 	// rotateFile will create a new file to write to.
@@ -413,7 +413,7 @@ func (d *diskQueue) Close(ctx context.Context) error {
 	if err := d.CloseRead(); err != nil {
 		return err
 	}
-	if err := d.cfg.FS.DeleteDirAndFiles(filepath.Join(d.cfg.Path, d.dirName)); err != nil {
+	if err := d.cfg.FS.RemoveDirAndFiles(filepath.Join(d.cfg.Path, d.dirName)); err != nil {
 		return err
 	}
 	totalSize := int64(0)
@@ -439,7 +439,7 @@ func (d *diskQueue) Close(ctx context.Context) error {
 // to write to.
 func (d *diskQueue) rotateFile(ctx context.Context) error {
 	fName := filepath.Join(d.cfg.Path, d.dirName, strconv.Itoa(d.seqNo))
-	f, err := d.cfg.FS.CreateFileWithSync(fName, bytesPerSync)
+	f, err := d.cfg.FS.CreateWithSync(fName, bytesPerSync)
 	if err != nil {
 		return err
 	}
@@ -577,7 +577,7 @@ func (d *diskQueue) maybeInitDeserializer(ctx context.Context) (bool, error) {
 			}
 			if !d.rewindable {
 				// Remove current file.
-				if err := d.cfg.FS.DeleteFile(d.files[d.readFileIdx].name); err != nil {
+				if err := d.cfg.FS.Remove(d.files[d.readFileIdx].name); err != nil {
 					return false, err
 				}
 				fileSize := int64(d.files[d.readFileIdx].totalSize)
@@ -596,7 +596,7 @@ func (d *diskQueue) maybeInitDeserializer(ctx context.Context) (bool, error) {
 	}
 	if d.readFile == nil {
 		// File is not open.
-		f, err := d.cfg.FS.OpenFile(fileToRead.name)
+		f, err := d.cfg.FS.Open(fileToRead.name)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -96,7 +96,7 @@ func TestDiskQueue(t *testing.T) {
 					require.NoError(t, err)
 
 					// Verify that a directory was created.
-					directories, err := queueCfg.FS.ListDir(queueCfg.Path)
+					directories, err := queueCfg.FS.List(queueCfg.Path)
 					require.NoError(t, err)
 					require.Equal(t, 1, len(directories))
 
@@ -158,7 +158,7 @@ func TestDiskQueue(t *testing.T) {
 					require.NoError(t, q.Close(ctx))
 
 					// Verify no directories are left over.
-					directories, err = queueCfg.FS.ListDir(queueCfg.Path)
+					directories, err = queueCfg.FS.List(queueCfg.Path)
 					require.NoError(t, err)
 					require.Equal(t, 0, len(directories))
 				})

--- a/pkg/sql/colcontainer/partitionedqueue_test.go
+++ b/pkg/sql/colcontainer/partitionedqueue_test.go
@@ -58,8 +58,8 @@ func (f *fdCountingFS) assertOpenFDs(
 	require.Equal(t, expectedReadFDs, f.readFDs)
 }
 
-func (f *fdCountingFS) CreateFile(name string) (fs.File, error) {
-	file, err := f.FS.CreateFile(name)
+func (f *fdCountingFS) Create(name string) (fs.File, error) {
+	file, err := f.FS.Create(name)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +67,8 @@ func (f *fdCountingFS) CreateFile(name string) (fs.File, error) {
 	return &fdCountingFSFile{File: file, onCloseCb: func() { f.writeFDs-- }}, nil
 }
 
-func (f *fdCountingFS) CreateFileWithSync(name string, bytesPerSync int) (fs.File, error) {
-	file, err := f.FS.CreateFileWithSync(name, bytesPerSync)
+func (f *fdCountingFS) CreateWithSync(name string, bytesPerSync int) (fs.File, error) {
+	file, err := f.FS.CreateWithSync(name, bytesPerSync)
 	if err != nil {
 		return nil, err
 	}
@@ -76,8 +76,8 @@ func (f *fdCountingFS) CreateFileWithSync(name string, bytesPerSync int) (fs.Fil
 	return &fdCountingFSFile{File: file, onCloseCb: func() { f.writeFDs-- }}, nil
 }
 
-func (f *fdCountingFS) OpenFile(name string) (fs.File, error) {
-	file, err := f.FS.OpenFile(name)
+func (f *fdCountingFS) Open(name string) (fs.File, error) {
+	file, err := f.FS.Open(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/colexec/spilling_queue_test.go
+++ b/pkg/sql/colexec/spilling_queue_test.go
@@ -144,7 +144,7 @@ func TestSpillingQueue(t *testing.T) {
 				require.NoError(t, q.close(ctx))
 
 				// Verify no directories are left over.
-				directories, err := queueCfg.FS.ListDir(queueCfg.Path)
+				directories, err := queueCfg.FS.List(queueCfg.Path)
 				require.NoError(t, err)
 				require.Equal(t, 0, len(directories))
 			})

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -264,12 +264,12 @@ func TestVectorizedFlowTempDirectory(t *testing.T) {
 		).(*vectorizedFlow)
 	}
 
-	dirs, err := ngn.ListDir(tempPath)
+	dirs, err := ngn.List(tempPath)
 	require.NoError(t, err)
 	numDirsTheTestStartedWith := len(dirs)
 	checkDirs := func(t *testing.T, numExtraDirs int) {
 		t.Helper()
-		dirs, err := ngn.ListDir(tempPath)
+		dirs, err := ngn.List(tempPath)
 		require.NoError(t, err)
 		expectedNumDirs := numDirsTheTestStartedWith + numExtraDirs
 		require.Equal(t, expectedNumDirs, len(dirs), "expected %d directories but found %d: %s", expectedNumDirs, len(dirs), dirs)
@@ -366,12 +366,12 @@ func TestVectorizedFlowTempDirectory(t *testing.T) {
 		errCh := make(chan error)
 		go func() {
 			createTempDir()
-			errCh <- ngn.CreateDir(filepath.Join(vf.tempStorage.path, "async"))
+			errCh <- ngn.MkdirAll(filepath.Join(vf.tempStorage.path, "async"))
 		}()
 		createTempDir()
 		// Both goroutines should be able to create their subdirectories within the
 		// flow's temporary directory.
-		require.NoError(t, ngn.CreateDir(filepath.Join(vf.tempStorage.path, "main_goroutine")))
+		require.NoError(t, ngn.MkdirAll(filepath.Join(vf.tempStorage.path, "main_goroutine")))
 		require.NoError(t, <-errCh)
 		vf.Cleanup(ctx)
 		checkDirs(t, 0)

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1228,25 +1228,25 @@ func TestEngineFS(t *testing.T) {
 				)
 				switch s[0] {
 				case "create":
-					g, err = e.CreateFile(s[1])
+					g, err = e.Create(s[1])
 				case "create-with-sync":
-					g, err = e.CreateFileWithSync(s[1], 1)
+					g, err = e.CreateWithSync(s[1], 1)
 				case "link":
-					err = e.LinkFile(s[1], s[2])
+					err = e.Link(s[1], s[2])
 				case "open":
-					g, err = e.OpenFile(s[1])
+					g, err = e.Open(s[1])
 				case "opendir":
 					g, err = e.OpenDir(s[1])
 				case "delete":
-					err = e.DeleteFile(s[1])
+					err = e.Remove(s[1])
 				case "rename":
-					err = e.RenameFile(s[1], s[2])
+					err = e.Rename(s[1], s[2])
 				case "create-dir":
-					err = e.CreateDir(s[1])
+					err = e.MkdirAll(s[1])
 				case "delete-dir":
-					err = e.DeleteDir(s[1])
+					err = e.RemoveDir(s[1])
 				case "list-dir":
-					result, err := e.ListDir(s[1])
+					result, err := e.List(s[1])
 					if err != nil {
 						break
 					}
@@ -1370,19 +1370,19 @@ func TestEngineFSFileNotFoundError(t *testing.T) {
 			db := engineImpl.create(t, dir)
 			defer db.Close()
 
-			// Verify DeleteFile returns os.ErrNotExist if file does not exist.
-			if err := db.DeleteFile("/non/existent/file"); !os.IsNotExist(err) {
+			// Verify Remove returns os.ErrNotExist if file does not exist.
+			if err := db.Remove("/non/existent/file"); !os.IsNotExist(err) {
 				t.Fatalf("expected IsNotExist, but got %v (%T)", err, err)
 			}
 
-			// Verify DeleteDirAndFiles returns os.ErrNotExist if dir does not exist.
-			if err := db.DeleteDirAndFiles("/non/existent/file"); !os.IsNotExist(err) {
+			// Verify RemoveDirAndFiles returns os.ErrNotExist if dir does not exist.
+			if err := db.RemoveDirAndFiles("/non/existent/file"); !os.IsNotExist(err) {
 				t.Fatalf("expected IsNotExist, but got %v (%T)", err, err)
 			}
 
 			fname := filepath.Join(dir, "random.file")
 			data := "random data"
-			if f, err := db.CreateFile(fname); err != nil {
+			if f, err := db.Create(fname); err != nil {
 				t.Fatalf("unable to open file with filename %s, got err %v", fname, err)
 			} else {
 				// Write data to file so we can read it later.
@@ -1403,7 +1403,7 @@ func TestEngineFSFileNotFoundError(t *testing.T) {
 				t.Errorf("expected content in %s is '%s', got '%s'", fname, data, string(b))
 			}
 
-			if err := db.DeleteFile(fname); err != nil {
+			if err := db.Remove(fname); err != nil {
 				t.Errorf("unable to delete file with filename %s, got err %v", fname, err)
 			}
 
@@ -1412,8 +1412,8 @@ func TestEngineFSFileNotFoundError(t *testing.T) {
 				t.Fatalf("expected IsNotExist, but got %v (%T)", err, err)
 			}
 
-			// Verify DeleteFile returns os.ErrNotExist if deleting an already deleted file.
-			if err := db.DeleteFile(fname); !os.IsNotExist(err) {
+			// Verify Remove returns os.ErrNotExist if deleting an already deleted file.
+			if err := db.Remove(fname); !os.IsNotExist(err) {
 				t.Fatalf("expected IsNotExist, but got %v (%T)", err, err)
 			}
 		})

--- a/pkg/storage/fs/fs.go
+++ b/pkg/storage/fs/fs.go
@@ -25,46 +25,46 @@ type File interface {
 
 // FS provides a filesystem interface.
 type FS interface {
-	// CreateFile creates the named file for writing, truncating it if it already
+	// Create creates the named file for writing, truncating it if it already
 	// exists.
-	CreateFile(name string) (File, error)
+	Create(name string) (File, error)
 
-	// CreateFileWithSync is similar to CreateFile, but the file is periodically
+	// CreateWithSync is similar to Create, but the file is periodically
 	// synced whenever more than bytesPerSync bytes accumulate. This syncing
 	// does not provide any persistency guarantees, but can prevent latency
 	// spikes.
-	CreateFileWithSync(name string, bytesPerSync int) (File, error)
+	CreateWithSync(name string, bytesPerSync int) (File, error)
 
-	// LinkFile creates newname as a hard link to the oldname file.
-	LinkFile(oldname, newname string) error
+	// Link creates newname as a hard link to the oldname file.
+	Link(oldname, newname string) error
 
-	// OpenFile opens the named file for reading.
-	OpenFile(name string) (File, error)
+	// Open opens the named file for reading.
+	Open(name string) (File, error)
 
 	// OpenDir opens the named directory for syncing.
 	OpenDir(name string) (File, error)
 
-	// DeleteFile removes the named file. If the file with given name doesn't exist, return an error
-	// that returns true from os.IsNotExist().
-	DeleteFile(name string) error
+	// Remove removes the named file. If the file with given name doesn't
+	// exist, return an error that returns true from os.IsNotExist().
+	Remove(name string) error
 
-	// RenameFile renames a file. It overwrites the file at newname if one exists,
+	// Rename renames a file. It overwrites the file at newname if one exists,
 	// the same as os.Rename.
-	RenameFile(oldname, newname string) error
+	Rename(oldname, newname string) error
 
-	// CreateDir creates the named dir. Does nothing if the directory already
-	// exists.
-	CreateDir(name string) error
+	// MkdirAll creates the named dir and its parents. Does nothing if the
+	// directory already exists.
+	MkdirAll(name string) error
 
-	// DeleteDir removes the named dir.
-	DeleteDir(name string) error
+	// RemoveDir removes the named dir.
+	RemoveDir(name string) error
 
-	// DeleteDirAndFiles deletes the directory and any files it contains but
-	// not subdirectories. If dir does not exist, DeleteDirAndFiles returns nil
+	// RemoveDirAndFiles deletes the directory and any files it contains but
+	// not subdirectories. If dir does not exist, RemoveDirAndFiles returns nil
 	// (no error).
-	DeleteDirAndFiles(dir string) error
+	RemoveDirAndFiles(dir string) error
 
-	// ListDir returns a listing of the given directory. The names returned are
+	// List returns a listing of the given directory. The names returned are
 	// relative to the directory.
-	ListDir(name string) ([]string, error)
+	List(name string) ([]string, error)
 }

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -979,15 +979,15 @@ func (p *Pebble) WriteFile(filename string, data []byte) error {
 	return err
 }
 
-// DeleteFile implements the FS interface.
-func (p *Pebble) DeleteFile(filename string) error {
+// Remove implements the FS interface.
+func (p *Pebble) Remove(filename string) error {
 	return p.fs.Remove(filename)
 }
 
-// DeleteDirAndFiles implements the Engine interface.
-func (p *Pebble) DeleteDirAndFiles(dir string) error {
+// RemoveDirAndFiles implements the Engine interface.
+func (p *Pebble) RemoveDirAndFiles(dir string) error {
 	// NB RemoveAll does not return an error if dir does not exist, but we want
-	// DeleteDirAndFiles to return an error in that case to match the RocksDB
+	// RemoveDirAndFiles to return an error in that case to match the RocksDB
 	// behavior.
 	_, err := p.fs.Stat(dir)
 	if err != nil {
@@ -996,15 +996,15 @@ func (p *Pebble) DeleteDirAndFiles(dir string) error {
 	return p.fs.RemoveAll(dir)
 }
 
-// LinkFile implements the FS interface.
-func (p *Pebble) LinkFile(oldname, newname string) error {
+// Link implements the FS interface.
+func (p *Pebble) Link(oldname, newname string) error {
 	return p.fs.Link(oldname, newname)
 }
 
 var _ fs.FS = &Pebble{}
 
-// CreateFile implements the FS interface.
-func (p *Pebble) CreateFile(name string) (fs.File, error) {
+// Create implements the FS interface.
+func (p *Pebble) Create(name string) (fs.File, error) {
 	// TODO(peter): On RocksDB, the MemEnv allows creating a file when the parent
 	// directory does not exist. Various tests in the storage package depend on
 	// this because they are accidentally creating the required directory on the
@@ -1016,8 +1016,8 @@ func (p *Pebble) CreateFile(name string) (fs.File, error) {
 	return p.fs.Create(name)
 }
 
-// CreateFileWithSync implements the FS interface.
-func (p *Pebble) CreateFileWithSync(name string, bytesPerSync int) (fs.File, error) {
+// CreateWithSync implements the FS interface.
+func (p *Pebble) CreateWithSync(name string, bytesPerSync int) (fs.File, error) {
 	// TODO(peter): On RocksDB, the MemEnv allows creating a file when the parent
 	// directory does not exist. Various tests in the storage package depend on
 	// this because they are accidentally creating the required directory on the
@@ -1033,8 +1033,8 @@ func (p *Pebble) CreateFileWithSync(name string, bytesPerSync int) (fs.File, err
 	return vfs.NewSyncingFile(f, vfs.SyncingFileOptions{BytesPerSync: bytesPerSync}), nil
 }
 
-// OpenFile implements the FS interface.
-func (p *Pebble) OpenFile(name string) (fs.File, error) {
+// Open implements the FS interface.
+func (p *Pebble) Open(name string) (fs.File, error) {
 	return p.fs.Open(name)
 }
 
@@ -1043,23 +1043,23 @@ func (p *Pebble) OpenDir(name string) (fs.File, error) {
 	return p.fs.OpenDir(name)
 }
 
-// RenameFile implements the FS interface.
-func (p *Pebble) RenameFile(oldname, newname string) error {
+// Rename implements the FS interface.
+func (p *Pebble) Rename(oldname, newname string) error {
 	return p.fs.Rename(oldname, newname)
 }
 
-// CreateDir implements the FS interface.
-func (p *Pebble) CreateDir(name string) error {
+// MkdirAll implements the FS interface.
+func (p *Pebble) MkdirAll(name string) error {
 	return p.fs.MkdirAll(name, 0755)
 }
 
-// DeleteDir implements the FS interface.
-func (p *Pebble) DeleteDir(name string) error {
+// RemoveDir implements the FS interface.
+func (p *Pebble) RemoveDir(name string) error {
 	return p.fs.Remove(name)
 }
 
-// ListDir implements the FS interface.
-func (p *Pebble) ListDir(name string) ([]string, error) {
+// List implements the FS interface.
+func (p *Pebble) List(name string) ([]string, error) {
 	return p.fs.List(name)
 }
 

--- a/pkg/storage/rocksdb.go
+++ b/pkg/storage/rocksdb.go
@@ -3265,28 +3265,29 @@ func (r *RocksDB) WriteFile(filename string, data []byte) error {
 	return statusToError(C.DBEnvWriteFile(r.rdb, goToCSlice([]byte(filename)), goToCSlice(data)))
 }
 
-// DeleteFile deletes the file with the given filename from this RocksDB's env.
+// Remove deletes the file with the given filename from this RocksDB's env.
 // If the file with given filename doesn't exist, return os.ErrNotExist.
-func (r *RocksDB) DeleteFile(filename string) error {
+func (r *RocksDB) Remove(filename string) error {
 	if err := statusToError(C.DBEnvDeleteFile(r.rdb, goToCSlice([]byte(filename)))); err != nil {
 		return notFoundErrOrDefault(err)
 	}
 	return nil
 }
 
-// DeleteDirAndFiles deletes the directory and any files it contains but
+// RemoveDirAndFiles deletes the directory and any files it contains but
 // not subdirectories from this RocksDB's env. If dir does not exist,
 // return os.ErrNotExist.
-func (r *RocksDB) DeleteDirAndFiles(dir string) error {
+func (r *RocksDB) RemoveDirAndFiles(dir string) error {
 	if err := statusToError(C.DBEnvDeleteDirAndFiles(r.rdb, goToCSlice([]byte(dir)))); err != nil {
 		return notFoundErrOrDefault(err)
 	}
 	return nil
 }
 
-// LinkFile creates 'newname' as a hard link to 'oldname'. This use the Env responsible for the file
-// which may handle extra logic (eg: copy encryption settings for EncryptedEnv).
-func (r *RocksDB) LinkFile(oldname, newname string) error {
+// Link creates 'newname' as a hard link to 'oldname'. This use the Env
+// responsible for the file which may handle extra logic (eg: copy encryption
+// settings for EncryptedEnv).
+func (r *RocksDB) Link(oldname, newname string) error {
 	if err := statusToError(C.DBEnvLinkFile(r.rdb, goToCSlice([]byte(oldname)), goToCSlice([]byte(newname)))); err != nil {
 		return &os.LinkError{
 			Op:  "link",
@@ -3469,13 +3470,13 @@ func (f *rocksdbDirectory) ReadAt(p []byte, off int64) (n int, err error) {
 
 var _ fs.FS = &RocksDB{}
 
-// CreateFile implements the FS interface.
-func (r *RocksDB) CreateFile(name string) (fs.File, error) {
-	return r.CreateFileWithSync(name, 0)
+// Create implements the FS interface.
+func (r *RocksDB) Create(name string) (fs.File, error) {
+	return r.CreateWithSync(name, 0)
 }
 
-// CreateFileWithSync implements the FS interface.
-func (r *RocksDB) CreateFileWithSync(name string, bytesPerSync int) (fs.File, error) {
+// CreateWithSync implements the FS interface.
+func (r *RocksDB) CreateWithSync(name string, bytesPerSync int) (fs.File, error) {
 	var file C.DBWritableFile
 	if err := statusToError(C.DBEnvOpenFile(
 		r.rdb, goToCSlice([]byte(name)), C.uint64_t(bytesPerSync), &file)); err != nil {
@@ -3484,8 +3485,8 @@ func (r *RocksDB) CreateFileWithSync(name string, bytesPerSync int) (fs.File, er
 	return &rocksdbWritableFile{file: file, rdb: r.rdb}, nil
 }
 
-// OpenFile implements the FS interface.
-func (r *RocksDB) OpenFile(name string) (fs.File, error) {
+// Open implements the FS interface.
+func (r *RocksDB) Open(name string) (fs.File, error) {
 	var file C.DBReadableFile
 	if err := statusToError(C.DBEnvOpenReadableFile(r.rdb, goToCSlice([]byte(name)), &file)); err != nil {
 		return nil, notFoundErrOrDefault(err)
@@ -3502,23 +3503,23 @@ func (r *RocksDB) OpenDir(name string) (fs.File, error) {
 	return &rocksdbDirectory{file: file, rdb: r.rdb}, nil
 }
 
-// RenameFile implements the FS interface.
-func (r *RocksDB) RenameFile(oldname, newname string) error {
+// Rename implements the FS interface.
+func (r *RocksDB) Rename(oldname, newname string) error {
 	return statusToError(C.DBEnvRenameFile(r.rdb, goToCSlice([]byte(oldname)), goToCSlice([]byte(newname))))
 }
 
-// CreateDir implements the FS interface.
-func (r *RocksDB) CreateDir(name string) error {
+// MkdirAll implements the FS interface.
+func (r *RocksDB) MkdirAll(name string) error {
 	return statusToError(C.DBEnvCreateDir(r.rdb, goToCSlice([]byte(name))))
 }
 
-// DeleteDir implements the FS interface.
-func (r *RocksDB) DeleteDir(name string) error {
+// RemoveDir implements the FS interface.
+func (r *RocksDB) RemoveDir(name string) error {
 	return statusToError(C.DBEnvDeleteDir(r.rdb, goToCSlice([]byte(name))))
 }
 
-// ListDir implements the FS interface.
-func (r *RocksDB) ListDir(name string) ([]string, error) {
+// List implements the FS interface.
+func (r *RocksDB) List(name string) ([]string, error) {
 	list := C.DBEnvListDir(r.rdb, goToCSlice([]byte(name)))
 	n := list.n
 	names := list.names

--- a/pkg/storage/tee.go
+++ b/pkg/storage/tee.go
@@ -361,7 +361,7 @@ func (t *TeeEngine) IngestExternalFiles(ctx context.Context, paths []string) err
 			if err != nil {
 				return err
 			}
-			f, err := t.eng2.CreateFile(paths2[i])
+			f, err := t.eng2.Create(paths2[i])
 			if err != nil {
 				return err
 			}
@@ -404,16 +404,16 @@ func (t *TeeEngine) InMem() bool {
 	return t.eng1.InMem()
 }
 
-// CreateFile implements the FS interface.
-func (t *TeeEngine) CreateFile(filename string) (fs.File, error) {
+// Create implements the FS interface.
+func (t *TeeEngine) Create(filename string) (fs.File, error) {
 	_ = os.MkdirAll(filepath.Dir(filename), 0755)
-	file1, err := t.eng1.CreateFile(filename)
+	file1, err := t.eng1.Create(filename)
 	filename2, ok := t.remapPath(filename)
 	if !ok {
 		return file1, err
 	}
 	_ = os.MkdirAll(filepath.Dir(filename2), 0755)
-	file2, err2 := t.eng2.CreateFile(filename2)
+	file2, err2 := t.eng2.Create(filename2)
 	if err = fatalOnErrorMismatch(t.ctx, err, err2); err != nil {
 		return nil, err
 	}
@@ -424,16 +424,16 @@ func (t *TeeEngine) CreateFile(filename string) (fs.File, error) {
 	}, nil
 }
 
-// CreateFileWithSync implements the FS interface.
-func (t *TeeEngine) CreateFileWithSync(filename string, bytesPerSync int) (fs.File, error) {
+// CreateWithSync implements the FS interface.
+func (t *TeeEngine) CreateWithSync(filename string, bytesPerSync int) (fs.File, error) {
 	_ = os.MkdirAll(filepath.Dir(filename), 0755)
-	file1, err := t.eng1.CreateFileWithSync(filename, bytesPerSync)
+	file1, err := t.eng1.CreateWithSync(filename, bytesPerSync)
 	filename2, ok := t.remapPath(filename)
 	if !ok {
 		return file1, err
 	}
 	_ = os.MkdirAll(filepath.Dir(filename2), 0755)
-	file2, err2 := t.eng2.CreateFileWithSync(filename2, bytesPerSync)
+	file2, err2 := t.eng2.CreateWithSync(filename2, bytesPerSync)
 	if err = fatalOnErrorMismatch(t.ctx, err, err2); err != nil {
 		return nil, err
 	}
@@ -444,14 +444,14 @@ func (t *TeeEngine) CreateFileWithSync(filename string, bytesPerSync int) (fs.Fi
 	}, nil
 }
 
-// OpenFile implements the FS interface.
-func (t *TeeEngine) OpenFile(filename string) (fs.File, error) {
-	file1, err := t.eng1.OpenFile(filename)
+// Open implements the FS interface.
+func (t *TeeEngine) Open(filename string) (fs.File, error) {
+	file1, err := t.eng1.Open(filename)
 	filename2, ok := t.remapPath(filename)
 	if !ok {
 		return file1, err
 	}
-	file2, err2 := t.eng2.OpenFile(filename2)
+	file2, err2 := t.eng2.Open(filename2)
 	if err = fatalOnErrorMismatch(t.ctx, err, err2); err != nil {
 		return nil, err
 	}
@@ -497,82 +497,82 @@ func (t *TeeEngine) WriteFile(filename string, data []byte) error {
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
-// DeleteFile implements the FS interface.
-func (t *TeeEngine) DeleteFile(filename string) error {
-	err := t.eng1.DeleteFile(filename)
+// Remove implements the FS interface.
+func (t *TeeEngine) Remove(filename string) error {
+	err := t.eng1.Remove(filename)
 	filename2, ok := t.remapPath(filename)
 	if !ok {
 		return err
 	}
-	err2 := t.eng2.DeleteFile(filename2)
+	err2 := t.eng2.Remove(filename2)
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
-// DeleteDirAndFiles implements the Engine interface.
-func (t *TeeEngine) DeleteDirAndFiles(dir string) error {
-	err := t.eng1.DeleteDirAndFiles(dir)
+// RemoveDirAndFiles implements the Engine interface.
+func (t *TeeEngine) RemoveDirAndFiles(dir string) error {
+	err := t.eng1.RemoveDirAndFiles(dir)
 	dir2, ok := t.remapPath(dir)
 	if !ok {
 		return err
 	}
-	err2 := t.eng2.DeleteDirAndFiles(dir2)
+	err2 := t.eng2.RemoveDirAndFiles(dir2)
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
-// LinkFile implements the FS interface.
-func (t *TeeEngine) LinkFile(oldname, newname string) error {
-	err := t.eng1.LinkFile(oldname, newname)
+// Link implements the FS interface.
+func (t *TeeEngine) Link(oldname, newname string) error {
+	err := t.eng1.Link(oldname, newname)
 	oldname2, ok := t.remapPath(oldname)
 	if !ok {
 		return err
 	}
 	newname2, _ := t.remapPath(newname)
-	err2 := t.eng2.LinkFile(oldname2, newname2)
+	err2 := t.eng2.Link(oldname2, newname2)
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
-// RenameFile implements the FS interface.
-func (t *TeeEngine) RenameFile(oldname, newname string) error {
-	err := t.eng1.RenameFile(oldname, newname)
+// Rename implements the FS interface.
+func (t *TeeEngine) Rename(oldname, newname string) error {
+	err := t.eng1.Rename(oldname, newname)
 	oldname2, ok := t.remapPath(oldname)
 	if !ok {
 		return err
 	}
 	newname2, _ := t.remapPath(newname)
-	err2 := t.eng2.RenameFile(oldname2, newname2)
+	err2 := t.eng2.Rename(oldname2, newname2)
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
-// CreateDir implements the FS interface.
-func (t *TeeEngine) CreateDir(name string) error {
-	err := t.eng1.CreateDir(name)
+// MkdirAll implements the FS interface.
+func (t *TeeEngine) MkdirAll(name string) error {
+	err := t.eng1.MkdirAll(name)
 	name2, ok := t.remapPath(name)
 	if !ok {
 		return err
 	}
-	err2 := t.eng2.CreateDir(name2)
+	err2 := t.eng2.MkdirAll(name2)
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
-// DeleteDir implements the FS interface.
-func (t *TeeEngine) DeleteDir(name string) error {
-	err := t.eng1.DeleteDir(name)
+// RemoveDir implements the FS interface.
+func (t *TeeEngine) RemoveDir(name string) error {
+	err := t.eng1.RemoveDir(name)
 	name2, ok := t.remapPath(name)
 	if !ok {
 		return err
 	}
-	err2 := t.eng2.DeleteDir(name2)
+	err2 := t.eng2.RemoveDir(name2)
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
-// ListDir implements the FS interface.
-func (t *TeeEngine) ListDir(name string) ([]string, error) {
-	list1, err := t.eng1.ListDir(name)
+// List implements the FS interface.
+func (t *TeeEngine) List(name string) ([]string, error) {
+	list1, err := t.eng1.List(name)
 	name2, ok := t.remapPath(name)
 	if !ok {
 		return list1, err
 	}
-	_, err2 := t.eng2.ListDir(name2)
+	_, err2 := t.eng2.List(name2)
 	if err = fatalOnErrorMismatch(t.ctx, err, err2); err != nil {
 		return nil, err
 	}

--- a/pkg/testutils/colcontainerutils/diskqueuecfg.go
+++ b/pkg/testutils/colcontainerutils/diskqueuecfg.go
@@ -36,7 +36,7 @@ func NewTestingDiskQueueCfg(t testing.TB, inMem bool) (colcontainer.DiskQueueCfg
 	if inMem {
 		ngn := storage.NewDefaultInMem()
 		testingFS = ngn.(fs.FS)
-		if err := testingFS.CreateDir(inMemDirName); err != nil {
+		if err := testingFS.MkdirAll(inMemDirName); err != nil {
 			t.Fatal(err)
 		}
 		path = inMemDirName


### PR DESCRIPTION
Refactor the Engine FS interface's method names to more closely match
those in Pebble's VFS interface (and the standard library os package
equivalents).

Release note: None