### PR TITLE
sql: fix panic when virtual tables inspect tables with UDTs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1,3 +1,5 @@
+# LogicTest: !3node-tenant
+
 statement ok
 SET experimental_enable_enums=true;
 
@@ -386,3 +388,25 @@ bytes bytes
 
 query error pq: could not find \[255\] in enum representation
 SELECT b'\xFF'::as_bytes
+
+# Regression for #49300. Ensure that virtual tables have access to hydrated
+# type descriptors.
+query TT
+SHOW CREATE t1
+----
+t1  CREATE TABLE t1 (
+    x test.public.greeting NULL,
+    INDEX i (x ASC),
+    FAMILY "primary" (x, rowid)
+)
+
+# SHOW CREATE uses a virtual index, so also check the code path where a
+# descriptor scan is used.
+query T
+SELECT create_statement FROM crdb_internal.create_statements WHERE descriptor_name = 't1'
+----
+CREATE TABLE t1 (
+   x test.public.greeting NULL,
+   INDEX i (x ASC),
+   FAMILY "primary" (x, rowid)
+)

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -455,7 +455,9 @@ func (p *planner) ResolveTableName(ctx context.Context, tn *tree.TableName) (tre
 
 // LookupTableByID looks up a table, by the given descriptor ID. Based on the
 // CommonLookupFlags, it could use or skip the Collection cache. See
-// Collection.GetTableVersionByID for how it's used.
+// Collection.getTableVersionByID for how it's used.
+// TODO (SQLSchema): This should call into the set of SchemaAccessors instead
+//  of having its own logic for lookups.
 func (p *planner) LookupTableByID(
 	ctx context.Context, tableID sqlbase.ID,
 ) (catalog.TableEntry, error) {
@@ -468,6 +470,11 @@ func (p *planner) LookupTableByID(
 		if sqlbase.HasAddingTableError(err) {
 			return catalog.TableEntry{IsAdding: true}, nil
 		}
+		return catalog.TableEntry{}, err
+	}
+	// TODO (rohany): This shouldn't be needed once the descs.Collection always
+	//  returns descriptors with hydrated types.
+	if err := p.maybeHydrateTypesInDescriptor(ctx, table); err != nil {
 		return catalog.TableEntry{}, err
 	}
 	return catalog.TableEntry{Desc: table}, nil

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -4204,7 +4204,14 @@ func (desc *TypeDescriptor) SetName(name string) {
 //  ImmutableTypeDescriptor so that pointers to the cached info
 //  can be shared among callers.
 func (desc *TypeDescriptor) HydrateTypeInfo(typ *types.T) error {
-	typ.TypeMeta.Name = tree.NewUnqualifiedTypeName(tree.Name(desc.Name))
+	return desc.HydrateTypeInfoWithName(typ, tree.NewUnqualifiedTypeName(tree.Name(desc.Name)))
+}
+
+// HydrateTypeInfoWithName fills in user defined type metadata for
+// a type and also sets the name in the metadata to the passed in name.
+// This is used when hydrating a type with a known qualified name.
+func (desc *TypeDescriptor) HydrateTypeInfoWithName(typ *types.T, name *tree.TypeName) error {
+	typ.TypeMeta.Name = name
 	switch desc.Kind {
 	case TypeDescriptor_ENUM:
 		if typ.Family() != types.EnumFamily {
@@ -4228,6 +4235,31 @@ func (desc *TypeDescriptor) HydrateTypeInfo(typ *types.T) error {
 	default:
 		return errors.AssertionFailedf("unknown type descriptor kind %s", desc.Kind)
 	}
+}
+
+// HydrateTypesInTableDescriptor uses typeLookup to install metadata in the
+// types present in a table descriptor. typeLookup retrieves the fully
+// qualified name and descriptor for a particular ID.
+func HydrateTypesInTableDescriptor(
+	desc *TableDescriptor, typeLookup func(id ID) (*tree.TypeName, *TypeDescriptor, error),
+) error {
+	for i := range desc.Columns {
+		col := &desc.Columns[i]
+		if col.Type.UserDefined() {
+			// Look up its type descriptor.
+			name, typDesc, err := typeLookup(ID(col.Type.StableTypeID()))
+			if err != nil {
+				return err
+			}
+			// TODO (rohany): This should be a noop if the hydrated type
+			//  information present in the descriptor has the same version as
+			//  the resolved type descriptor we found here.
+			if err := typDesc.HydrateTypeInfoWithName(col.Type, name); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // MakeSimpleAliasTypeDescriptor creates a type descriptor that is an alias


### PR DESCRIPTION
Fixes #49300.

This PR ensures that tables retrieved by virtual tables have hydrated
types. Additionally, it ensures that all resolved user defined types
have qualified names accessible for use. Previously, this was only the
case for types that were resolved by name.

Release note: None