### PR TITLE
builtins: implement certain Geometry extraction functions

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -776,9 +776,13 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="st_dwithin"></a><code>st_dwithin(geometry_a: geometry, geometry_b: geometry, distance: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if any of geometry_a is within distance units of geometry_b.</p>
 </span></td></tr>
+<tr><td><a name="st_endpoint"></a><code>st_endpoint(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the last point of a geometry which has shape LineString. Returns NULL if the geometry is not a LineString.</p>
+</span></td></tr>
 <tr><td><a name="st_equals"></a><code>st_equals(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_a is spatially equal to geometry_b, i.e. ST_Within(geometry_a, geometry_b) = ST_Within(geometry_b, geometry_a) = true.</p>
 <p>This function utilizes the GEOS module.</p>
 <p>This function will automatically use any available index.</p>
+</span></td></tr>
+<tr><td><a name="st_exteriorring"></a><code>st_exteriorring(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the exterior ring of a Polygon as a LineString. Returns NULL if the shape is not a Polygon.</p>
 </span></td></tr>
 <tr><td><a name="st_geogfromewkb"></a><code>st_geogfromewkb(val: <a href="bytes.html">bytes</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns the Geography from an EWKB representation.</p>
 </span></td></tr>
@@ -812,6 +816,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="st_geometryfromtext"></a><code>st_geometryfromtext(val: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation.</p>
 </span></td></tr>
+<tr><td><a name="st_geometryn"></a><code>st_geometryn(geometry: geometry, n: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the n-th Geometry (1-indexed). Returns NULL if out of bounds.</p>
+</span></td></tr>
 <tr><td><a name="st_geomfromewkb"></a><code>st_geomfromewkb(val: <a href="bytes.html">bytes</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from an EWKB representation.</p>
 </span></td></tr>
 <tr><td><a name="st_geomfromewkt"></a><code>st_geomfromewkt(val: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from an EWKT representation.</p>
@@ -827,6 +833,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 <tr><td><a name="st_geomfromwkb"></a><code>st_geomfromwkb(bytes: <a href="bytes.html">bytes</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKB representation with the given SRID set.</p>
 </span></td></tr>
 <tr><td><a name="st_geomfromwkb"></a><code>st_geomfromwkb(val: <a href="bytes.html">bytes</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKB representation.</p>
+</span></td></tr>
+<tr><td><a name="st_interiorringn"></a><code>st_interiorringn(geometry: geometry, n: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the n-th (1-indexed) interior ring of a Polygon as a LineString. Returns NULL if the shape is not a Polygon, or the ring does not exist.</p>
 </span></td></tr>
 <tr><td><a name="st_intersects"></a><code>st_intersects(geography_a: geography, geography_b: geography) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geography_a shares any portion of space with geography_b.</p>
 <p>The calculations performed are have a precision of 1cm.</p>
@@ -933,6 +941,18 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="st_multipolygonfromwkb"></a><code>st_multipolygonfromwkb(wkb: <a href="bytes.html">bytes</a>, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKB representation with an SRID. If the shape underneath is not MultiPolygon, NULL is returned.</p>
 </span></td></tr>
+<tr><td><a name="st_ndims"></a><code>st_ndims(geometry: geometry) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the number of dimensions of a given Geometry.</p>
+</span></td></tr>
+<tr><td><a name="st_npoints"></a><code>st_npoints(geometry: geometry) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the number of points in a given Geometry. Works for any shape type.</p>
+</span></td></tr>
+<tr><td><a name="st_numgeometries"></a><code>st_numgeometries(geometry: geometry) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the number of shapes inside a given Geometry.</p>
+</span></td></tr>
+<tr><td><a name="st_numinteriorring"></a><code>st_numinteriorring(geometry: geometry) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the number of interior rings in a Polygon Geometry. Returns NULL if the shape is not a Polygon.</p>
+</span></td></tr>
+<tr><td><a name="st_numinteriorrings"></a><code>st_numinteriorrings(geometry: geometry) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the number of interior rings in a Polygon Geometry. Returns NULL if the shape is not a Polygon.</p>
+</span></td></tr>
+<tr><td><a name="st_numpoints"></a><code>st_numpoints(geometry: geometry) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the number of points in a LineString. Returns NULL if the Geometry is not a LineString.</p>
+</span></td></tr>
 <tr><td><a name="st_overlaps"></a><code>st_overlaps(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if geometry_a intersects but does not completely contain geometry_b, or vice versa. “Does not completely” implies ST_Within(geometry_a, geometry_b) = ST_Within(geometry_b, geometry_a) = false.</p>
 <p>This function utilizes the GEOS module.</p>
 <p>This function will automatically use any available index.</p>
@@ -993,6 +1013,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="st_srid"></a><code>st_srid(geometry: geometry) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the Spatial Reference Identifier (SRID) for the ST_Geometry as defined in spatial_ref_sys table.</p>
 </span></td></tr>
+<tr><td><a name="st_startpoint"></a><code>st_startpoint(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the first point of a geometry which has shape LineString. Returns NULL if the geometry is not a LineString.</p>
+</span></td></tr>
 <tr><td><a name="st_touches"></a><code>st_touches(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if the only points in common between geometry_a and geometry_b are on the boundary. Note points do not touch other points.</p>
 <p>This function utilizes the GEOS module.</p>
 <p>This function will automatically use any available index.</p>
@@ -1004,6 +1026,10 @@ has no relationship with the commit order of concurrent transactions.</p>
 <tr><td><a name="st_wkbtosql"></a><code>st_wkbtosql(val: <a href="bytes.html">bytes</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKB representation.</p>
 </span></td></tr>
 <tr><td><a name="st_wkttosql"></a><code>st_wkttosql(val: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from a WKT or EWKT representation.</p>
+</span></td></tr>
+<tr><td><a name="st_x"></a><code>st_x(geometry: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the X coordinate of a geometry if it is a Point.</p>
+</span></td></tr>
+<tr><td><a name="st_y"></a><code>st_y(geometry: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the Y coordinate of a geometry if it is a Point.</p>
 </span></td></tr></tbody>
 </table>
 

--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -78,6 +78,15 @@ func NewGeometryFromPointCoords(x, y float64) (*Geometry, error) {
 	return &Geometry{SpatialObject: s}, nil
 }
 
+// NewGeometryFromGeom creates a new Geometry object from a geom.T object.
+func NewGeometryFromGeom(g geom.T) (*Geometry, error) {
+	spatialObject, err := spatialObjectFromGeom(g)
+	if err != nil {
+		return nil, err
+	}
+	return NewGeometry(spatialObject), nil
+}
+
 // ParseGeometry parses a Geometry from a given text.
 func ParseGeometry(str string) (*Geometry, error) {
 	spatialObject, err := parseAmbiguousText(str, geopb.DefaultGeometrySRID)

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -628,6 +628,122 @@ Square overlapping left and right square  Square (left)                         
 Square overlapping left and right square  Square (right)                            212F11FF2  false
 Square overlapping left and right square  Square overlapping left and right square  2FFF1FFF2  false
 
+# basic metadata
+query TIIITTT
+SELECT
+  a.dsc,
+  ST_NDims(a.geom),
+  ST_NPoints(a.geom),
+  ST_NumGeometries(a.geom),
+  ST_GeometryN(a.geom, 0),
+  ST_GeometryN(a.geom, 1),
+  ST_GeometryN(a.geom, 2)
+FROM geom_operators_test a
+ORDER BY a.dsc
+----
+Faraway point                             2     1     1     NULL  010100000000000000000014400000000000001440                                                                                                                                                  NULL
+Line going through left and right square  2     2     1     NULL  010200000002000000000000000000E0BF000000000000E03F000000000000E03F000000000000E03F                                                                                                          NULL
+NULL                                      NULL  NULL  NULL  NULL  NULL                                                                                                                                                                                        NULL
+Point middle of Left Square               2     1     1     NULL  0101000000000000000000E0BF000000000000E03F                                                                                                                                                  NULL
+Point middle of Right Square              2     1     1     NULL  0101000000000000000000E03F000000000000E03F                                                                                                                                                  NULL
+Square (left)                             2     5     1     NULL  01030000000100000005000000000000000000F0BF0000000000000000000000000000000000000000000000000000000000000000000000000000F03F000000000000F0BF000000000000F03F000000000000F0BF0000000000000000  NULL
+Square (right)                            2     5     1     NULL  0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000  NULL
+Square overlapping left and right square  2     5     1     NULL  010300000001000000050000009A9999999999B9BF0000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F9A9999999999B9BF000000000000F03F9A9999999999B9BF0000000000000000  NULL
+
+# Point specific operations
+query RR
+SELECT
+  ST_X(a.geom),
+  ST_Y(a.geom)
+FROM (VALUES
+  ('POINT(1.0 2.0)'::geometry),
+  ('POINT(33.0 66.0)'::geometry)
+--  ('0101000000000000000000F87F000000000000F87F'::geometry) -- POINT EMPTY -- blocked on https://github.com/twpayne/go-geom/pull/159
+) a(geom)
+----
+1   2
+33  66
+
+statement error argument to ST_X\(\) must have shape POINT
+SELECT ST_X('LINESTRING(0.0 0.0, 1.0 1.0)')
+
+statement error argument to ST_Y\(\) must have shape POINT
+SELECT ST_Y('LINESTRING(0.0 0.0, 1.0 1.0)')
+
+# LineString specific operations
+query TTI
+SELECT
+  ST_AsEWKT(ST_StartPoint(a.geom)),
+  ST_AsEWKT(ST_EndPoint(a.geom)),
+  ST_NumPoints(a.geom)
+FROM (VALUES
+  ('LINESTRING EMPTY'::geometry),
+  ('LINESTRING (0.0 0.0, 1.0 1.0, 2.0 2.0)'::geometry),
+  ('SRID=4326;LINESTRING (0.0 0.0, 1.0 1.0, 2.0 2.0)'::geometry),
+  ('MULTILINESTRING ((0.0 0.0, 1.0 1.0, 2.0 2.0), (3.0 3.0, 4.0 4.0))'::geometry)
+) a(geom)
+----
+NULL                   NULL                   0
+POINT (0 0)            POINT (2 2)            3
+SRID=4326;POINT (0 0)  SRID=4326;POINT (2 2)  3
+NULL                   NULL                   NULL
+
+# Polygon specific operations
+query IITTTT
+SELECT
+  ST_NumInteriorRing(a.geom),
+  ST_NumInteriorRings(a.geom),
+  ST_AsEWKT(ST_ExteriorRing(a.geom)),
+  ST_AsEWKT(ST_InteriorRingN(a.geom, 0)),
+  ST_AsEWKT(ST_InteriorRingN(a.geom, 1)),
+  ST_AsEWKT(ST_InteriorRingN(a.geom, 2))
+FROM (VALUES
+  ('POLYGON EMPTY'::geometry),
+  ('POLYGON((0 0,1 0, 1 1, 0 0))'::geometry),
+  ('POLYGON((0 0,1 0, 1 1, 0 0),(0.1 0.1,0.9 0.1, 0.9 0.9, 0.1 0.1))'::geometry),
+  ('SRID=4326;POLYGON((0 0,1 0, 1 1, 0 0),(0.1 0.1,0.9 0.1, 0.9 0.9, 0.1 0.1))'::geometry),
+  ('LINESTRING EMPTY'::geometry)
+) a(geom)
+----
+0     0     LINESTRING EMPTY                           NULL  NULL                                                       NULL
+0     0     LINESTRING (0 0, 1 0, 1 1, 0 0)            NULL  NULL                                                       NULL
+1     1     LINESTRING (0 0, 1 0, 1 1, 0 0)            NULL  LINESTRING (0.1 0.1, 0.9 0.1, 0.9 0.9, 0.1 0.1)            NULL
+1     1     SRID=4326;LINESTRING (0 0, 1 0, 1 1, 0 0)  NULL  SRID=4326;LINESTRING (0.1 0.1, 0.9 0.1, 0.9 0.9, 0.1 0.1)  NULL
+NULL  NULL  NULL                                       NULL  NULL                                                       NULL
+
+# Multi-Geometry related operations.
+query ITTT
+SELECT
+  ST_NumGeometries(a.geom),
+  ST_AsEWKT(ST_GeometryN(a.geom, 0)),
+  ST_AsEWKT(ST_GeometryN(a.geom, 1)),
+  ST_AsEWKT(ST_GeometryN(a.geom, 2))
+FROM (VALUES
+  ('MULTIPOINT EMPTY'::geometry),
+  ('MULTILINESTRING EMPTY'::geometry),
+  ('MULTIPOLYGON EMPTY'::geometry),
+  ('MULTIPOINT((0 0), (1 1), (2 2))'::geometry),
+  ('SRID=4326;MULTIPOINT((0 0), (1 1), (2 2))'::geometry),
+  ('MULTILINESTRING((0 0, 1 1), (2 2, 3 3))'::geometry),
+  ('SRID=4326;MULTILINESTRING((0 0, 1 1), (2 2, 3 3))'::geometry),
+  ('MULTIPOLYGON(((0 0,1 0, 1 1, 0 0)),((0.1 0.1,0.9 0.1, 0.9 0.9, 0.1 0.1)))'::geometry),
+  ('SRID=4326;MULTIPOLYGON(((0 0,1 0, 1 1, 0 0)),((0.1 0.1,0.9 0.1, 0.9 0.9, 0.1 0.1)))'::geometry),
+  ('GEOMETRYCOLLECTION (POINT (40 10),LINESTRING (10 10, 20 20, 10 40),POLYGON ((40 40, 20 45, 45 30, 40 40)))'::geometry),
+  ('SRID=4326;GEOMETRYCOLLECTION (POINT (40 10),LINESTRING (10 10, 20 20, 10 40),POLYGON ((40 40, 20 45, 45 30, 40 40)))'::geometry)
+) a(geom)
+----
+0  NULL  NULL                                      NULL
+0  NULL  NULL                                      NULL
+0  NULL  NULL                                      NULL
+3  NULL  POINT (0 0)                               POINT (1 1)
+3  NULL  SRID=4326;POINT (0 0)                     SRID=4326;POINT (1 1)
+2  NULL  LINESTRING (0 0, 1 1)                     LINESTRING (2 2, 3 3)
+2  NULL  SRID=4326;LINESTRING (0 0, 1 1)           SRID=4326;LINESTRING (2 2, 3 3)
+2  NULL  POLYGON ((0 0, 1 0, 1 1, 0 0))            POLYGON ((0.1 0.1, 0.9 0.1, 0.9 0.9, 0.1 0.1))
+2  NULL  SRID=4326;POLYGON ((0 0, 1 0, 1 1, 0 0))  SRID=4326;POLYGON ((0.1 0.1, 0.9 0.1, 0.9 0.9, 0.1 0.1))
+3  NULL  POINT (40 10)                             LINESTRING (10 10, 20 20, 10 40)
+3  NULL  SRID=4326;POINT (40 10)                   SRID=4326;LINESTRING (10 10, 20 20, 10 40)
+
 subtest geog_operators
 
 statement ok

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -21,6 +21,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/errors"
+	"github.com/twpayne/go-geom"
 )
 
 // libraryUsage is a masked bit indicating which libraries are used by
@@ -269,6 +271,32 @@ var pointCoordsToGeomOverload = tree.Overload{
 	Info:       infoBuilder{info: `Returns a new Point with the given X and Y coordinates.`}.String(),
 	Volatility: tree.VolatilityImmutable,
 }
+
+var numInteriorRingsBuiltin = makeBuiltin(
+	defProps(),
+	geometryOverload1(
+		func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+			t, err := g.Geometry.AsGeomT()
+			if err != nil {
+				return nil, err
+			}
+			switch t := t.(type) {
+			case *geom.Polygon:
+				numRings := t.NumLinearRings()
+				if numRings <= 1 {
+					return tree.NewDInt(0), nil
+				}
+				return tree.NewDInt(tree.DInt(numRings - 1)), nil
+			}
+			return tree.DNull, nil
+		},
+		types.Int,
+		infoBuilder{
+			info: "Returns the number of interior rings in a Polygon Geometry. Returns NULL if the shape is not a Polygon.",
+		},
+		tree.VolatilityImmutable,
+	),
+)
 
 var geoBuiltins = map[string]builtinDefinition{
 	//
@@ -673,6 +701,366 @@ var geoBuiltins = map[string]builtinDefinition{
 	//
 	// Unary functions.
 	//
+
+	"st_ndims": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				t, err := g.Geometry.AsGeomT()
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDInt(tree.DInt(t.Stride())), nil
+			},
+			types.Int,
+			infoBuilder{
+				info: "Returns the number of dimensions of a given Geometry.",
+			},
+			tree.VolatilityImmutable,
+		),
+	),
+	"st_startpoint": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				t, err := g.Geometry.AsGeomT()
+				if err != nil {
+					return nil, err
+				}
+				switch t := t.(type) {
+				case *geom.LineString:
+					if t.Empty() {
+						return tree.DNull, nil
+					}
+					coord := t.Coord(0)
+					retG, err := geo.NewGeometryFromGeom(
+						geom.NewPointFlat(geom.XY, []float64{coord.X(), coord.Y()}).SetSRID(t.SRID()),
+					)
+					if err != nil {
+						return nil, err
+					}
+					return &tree.DGeometry{Geometry: retG}, nil
+				}
+				return tree.DNull, nil
+			},
+			types.Geometry,
+			infoBuilder{
+				info: "Returns the first point of a geometry which has shape LineString. Returns NULL if the geometry is not a LineString.",
+			},
+			tree.VolatilityImmutable,
+		),
+	),
+	"st_endpoint": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				t, err := g.Geometry.AsGeomT()
+				if err != nil {
+					return nil, err
+				}
+				switch t := t.(type) {
+				case *geom.LineString:
+					if t.Empty() {
+						return tree.DNull, nil
+					}
+					coord := t.Coord(t.NumCoords() - 1)
+					retG, err := geo.NewGeometryFromGeom(
+						geom.NewPointFlat(geom.XY, []float64{coord.X(), coord.Y()}).SetSRID(t.SRID()),
+					)
+					if err != nil {
+						return nil, err
+					}
+					return &tree.DGeometry{Geometry: retG}, nil
+				}
+				return tree.DNull, nil
+			},
+			types.Geometry,
+			infoBuilder{
+				info: "Returns the last point of a geometry which has shape LineString. Returns NULL if the geometry is not a LineString.",
+			},
+			tree.VolatilityImmutable,
+		),
+	),
+	"st_numpoints": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				t, err := g.Geometry.AsGeomT()
+				if err != nil {
+					return nil, err
+				}
+				switch t := t.(type) {
+				case *geom.LineString:
+					return tree.NewDInt(tree.DInt(t.NumCoords())), nil
+				}
+				return tree.DNull, nil
+			},
+			types.Int,
+			infoBuilder{
+				info: "Returns the number of points in a LineString. Returns NULL if the Geometry is not a LineString.",
+			},
+			tree.VolatilityImmutable,
+		),
+	),
+	"st_npoints": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				t, err := g.Geometry.AsGeomT()
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDInt(tree.DInt(len(t.FlatCoords()) / t.Stride())), nil
+			},
+			types.Int,
+			infoBuilder{
+				info: "Returns the number of points in a given Geometry. Works for any shape type.",
+			},
+			tree.VolatilityImmutable,
+		),
+	),
+	"st_exteriorring": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				t, err := g.Geometry.AsGeomT()
+				if err != nil {
+					return nil, err
+				}
+				switch t := t.(type) {
+				case *geom.Polygon:
+					var lineString *geom.LineString
+					if t.Empty() {
+						lineString = geom.NewLineString(t.Layout())
+					} else {
+						ring := t.LinearRing(0)
+						lineString = geom.NewLineStringFlat(t.Layout(), ring.FlatCoords())
+					}
+					ret, err := geo.NewGeometryFromGeom(lineString.SetSRID(t.SRID()))
+					if err != nil {
+						return nil, err
+					}
+					return tree.NewDGeometry(ret), nil
+				}
+				return tree.DNull, nil
+			},
+			types.Geometry,
+			infoBuilder{
+				info: "Returns the exterior ring of a Polygon as a LineString. Returns NULL if the shape is not a Polygon.",
+			},
+			tree.VolatilityImmutable,
+		),
+	),
+	"st_interiorringn": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"n", types.Int}},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g := *args[0].(*tree.DGeometry)
+				n := int(*args[1].(*tree.DInt))
+				t, err := g.Geometry.AsGeomT()
+				if err != nil {
+					return nil, err
+				}
+				switch t := t.(type) {
+				case *geom.Polygon:
+					// N is 1-indexed. Ignore the exterior ring and return NULL for that case.
+					if n >= t.NumLinearRings() || n <= 0 {
+						return tree.DNull, nil
+					}
+					ring := t.LinearRing(n)
+					lineString := geom.NewLineStringFlat(t.Layout(), ring.FlatCoords()).SetSRID(t.SRID())
+					ret, err := geo.NewGeometryFromGeom(lineString)
+					if err != nil {
+						return nil, err
+					}
+					return tree.NewDGeometry(ret), nil
+				}
+				return tree.DNull, nil
+			},
+			Info: infoBuilder{
+				info: `Returns the n-th (1-indexed) interior ring of a Polygon as a LineString. Returns NULL if the shape is not a Polygon, or the ring does not exist.`,
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
+	"st_geometryn": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"n", types.Int}},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g := *args[0].(*tree.DGeometry)
+				n := int(*args[1].(*tree.DInt)) - 1
+				if n < 0 {
+					return tree.DNull, nil
+				}
+				t, err := g.Geometry.AsGeomT()
+				if err != nil {
+					return nil, err
+				}
+				switch t := t.(type) {
+				case *geom.Point, *geom.Polygon, *geom.LineString:
+					if n > 0 {
+						return tree.DNull, nil
+					}
+					return args[0], nil
+				case *geom.MultiPoint:
+					if n >= t.NumPoints() {
+						return tree.DNull, nil
+					}
+					g, err := geo.NewGeometryFromGeom(t.Point(n).SetSRID(t.SRID()))
+					if err != nil {
+						return nil, err
+					}
+					return tree.NewDGeometry(g), nil
+				case *geom.MultiLineString:
+					if n >= t.NumLineStrings() {
+						return tree.DNull, nil
+					}
+					g, err := geo.NewGeometryFromGeom(t.LineString(n).SetSRID(t.SRID()))
+					if err != nil {
+						return nil, err
+					}
+					return tree.NewDGeometry(g), nil
+				case *geom.MultiPolygon:
+					if n >= t.NumPolygons() {
+						return tree.DNull, nil
+					}
+					g, err := geo.NewGeometryFromGeom(t.Polygon(n).SetSRID(t.SRID()))
+					if err != nil {
+						return nil, err
+					}
+					return tree.NewDGeometry(g), nil
+				case *geom.GeometryCollection:
+					if n >= t.NumGeoms() {
+						return tree.DNull, nil
+					}
+					g, err := geo.NewGeometryFromGeom(t.Geom(n))
+					if err != nil {
+						return nil, err
+					}
+					gWithSRID, err := g.CloneWithSRID(geopb.SRID(t.SRID()))
+					if err != nil {
+						return nil, err
+					}
+					return tree.NewDGeometry(gWithSRID), nil
+				}
+				return tree.DNull, nil
+			},
+			Info: infoBuilder{
+				info: `Returns the n-th Geometry (1-indexed). Returns NULL if out of bounds.`,
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
+	"st_numinteriorring":  numInteriorRingsBuiltin,
+	"st_numinteriorrings": numInteriorRingsBuiltin,
+	"st_numgeometries": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				t, err := g.Geometry.AsGeomT()
+				if err != nil {
+					return nil, err
+				}
+				switch t := t.(type) {
+				case *geom.Point:
+					if t.Empty() {
+						return tree.NewDInt(0), nil
+					}
+					return tree.NewDInt(1), nil
+				case *geom.LineString:
+					if t.Empty() {
+						return tree.NewDInt(0), nil
+					}
+					return tree.NewDInt(1), nil
+				case *geom.Polygon:
+					if t.Empty() {
+						return tree.NewDInt(0), nil
+					}
+					return tree.NewDInt(1), nil
+				case *geom.MultiPoint:
+					if t.Empty() {
+						return tree.NewDInt(0), nil
+					}
+					return tree.NewDInt(tree.DInt(t.NumPoints())), nil
+				case *geom.MultiLineString:
+					if t.Empty() {
+						return tree.NewDInt(0), nil
+					}
+					return tree.NewDInt(tree.DInt(t.NumLineStrings())), nil
+				case *geom.MultiPolygon:
+					if t.Empty() {
+						return tree.NewDInt(0), nil
+					}
+					return tree.NewDInt(tree.DInt(t.NumPolygons())), nil
+				case *geom.GeometryCollection:
+					if t.Empty() {
+						return tree.NewDInt(0), nil
+					}
+					return tree.NewDInt(tree.DInt(t.NumGeoms())), nil
+				}
+				return nil, errors.Newf("unknown type: %T", t)
+			},
+			types.Int,
+			infoBuilder{
+				info: "Returns the number of shapes inside a given Geometry.",
+			},
+			tree.VolatilityImmutable,
+		),
+	),
+	"st_x": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				t, err := g.Geometry.AsGeomT()
+				if err != nil {
+					return nil, err
+				}
+				switch t := t.(type) {
+				case *geom.Point:
+					if t.Empty() {
+						return tree.DNull, nil
+					}
+					return tree.NewDFloat(tree.DFloat(t.X())), nil
+				}
+				// Ideally we should return NULL here, but following PostGIS on this.
+				return nil, errors.Newf("argument to ST_X() must have shape POINT")
+			},
+			types.Float,
+			infoBuilder{
+				info: "Returns the X coordinate of a geometry if it is a Point.",
+			},
+			tree.VolatilityImmutable,
+		),
+	),
+	"st_y": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				t, err := g.Geometry.AsGeomT()
+				if err != nil {
+					return nil, err
+				}
+				switch t := t.(type) {
+				case *geom.Point:
+					if t.Empty() {
+						return tree.DNull, nil
+					}
+					return tree.NewDFloat(tree.DFloat(t.Y())), nil
+				}
+				// Ideally we should return NULL here, but following PostGIS on this.
+				return nil, errors.Newf("argument to ST_Y() must have shape POINT")
+			},
+			types.Float,
+			infoBuilder{
+				info: "Returns the Y coordinate of a geometry if it is a Point.",
+			},
+			tree.VolatilityImmutable,
+		),
+	),
 	"st_area": makeBuiltin(
 		defProps(),
 		append(

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -141,7 +141,7 @@ func TestLint(t *testing.T) {
 		var names []string
 		for _, name := range builtins.AllBuiltinNames {
 			switch name {
-			case "extract", "trim", "overlay", "position", "substring":
+			case "extract", "trim", "overlay", "position", "substring", "st_x", "st_y":
 				// Exempt special forms: EXTRACT(... FROM ...), etc.
 			default:
 				names = append(names, strings.ToUpper(name))


### PR DESCRIPTION
Gets us over the Chapter 10 line.

Release note (sql change): Implement the following builtins:
* ST_X (resolves #49069)
* ST_Y (resolves #49070)
* ST_NDims (resolves #48992)
* ST_NumPoints (resolves #49001)
* ST_NPoints (resolves #48995)
* ST_StartPoint (resolves #49047)
* ST_EndPoint (resolves #48924)
* ST_NumInteriorRings (resolves #48999)
* ST_NumInteriorRing (resolves #48998)
* ST_InteriorRingN (resolves #48949)
* ST_ExteriorRing (resolves #48930)
* ST_NumGeometries (resolves #48997)
* ST_GeometryN (resolves #48945)