### PR TITLE
sql: distsql spec creation in execbuilder plumbing

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -749,7 +749,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 
 	var cols sqlbase.ResultColumns
 	if stmt.AST.StatementType() == tree.Rows {
-		cols = planColumns(planner.curPlan.main)
+		cols = planner.curPlan.main.planColumns()
 	}
 	if err := ex.initStatementResult(ctx, res, stmt, cols); err != nil {
 		res.SetError(err)

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -348,14 +348,14 @@ func makeColStatKey(cols []sqlbase.ColumnID) string {
 	return colSet.String()
 }
 
-// makePlanForExplainDistSQL is part of the distSQLExplainable interface.
-func (n *createStatsNode) makePlanForExplainDistSQL(
+// newPlanForExplainDistSQL is part of the distSQLExplainable interface.
+func (n *createStatsNode) newPlanForExplainDistSQL(
 	planCtx *PlanningCtx, distSQLPlanner *DistSQLPlanner,
-) (PhysicalPlan, error) {
+) (*PhysicalPlan, error) {
 	// Create a job record but don't actually start the job.
 	record, err := n.makeJobRecord(planCtx.ctx)
 	if err != nil {
-		return PhysicalPlan{}, err
+		return nil, err
 	}
 	job := n.p.ExecCfg().JobRegistry.NewJob(*record)
 

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -266,7 +266,7 @@ func newQueryNotSupportedErrorf(format string, args ...interface{}) error {
 }
 
 // planNodeNotSupportedErr is the catch-all error value returned from
-// checkSupportForNode when a planNode type does not support distributed
+// checkSupportForPlanNode when a planNode type does not support distributed
 // execution.
 var planNodeNotSupportedErr = newQueryNotSupportedError("unsupported node")
 
@@ -275,7 +275,7 @@ var cannotDistributeRowLevelLockingErr = newQueryNotSupportedError(
 )
 
 // mustWrapNode returns true if a node has no DistSQL-processor equivalent.
-// This must be kept in sync with createPlanForNode.
+// This must be kept in sync with createPhysPlanForPlanNode.
 // TODO(jordan): refactor these to use the observer pattern to avoid duplication.
 func (dsp *DistSQLPlanner) mustWrapNode(planCtx *PlanningCtx, node planNode) bool {
 	switch n := node.(type) {
@@ -296,7 +296,7 @@ func (dsp *DistSQLPlanner) mustWrapNode(planCtx *PlanningCtx, node planNode) boo
 	case *unaryNode:
 	case *unionNode:
 	case *valuesNode:
-		// This is unfortunately duplicated by createPlanForNode, and must be kept
+		// This is unfortunately duplicated by createPhysPlanForPlanNode, and must be kept
 		// in sync with its implementation.
 		if !n.specifiedInQuery || planCtx.isLocal || planCtx.noEvalSubqueries {
 			return true
@@ -311,28 +311,28 @@ func (dsp *DistSQLPlanner) mustWrapNode(planCtx *PlanningCtx, node planNode) boo
 	return false
 }
 
-// checkSupportForNode returns a distRecommendation (as described above) or
+// checkSupportForPlanNode returns a distRecommendation (as described above) or
 // cannotDistribute and an error if the plan subtree is not distributable.
 // The error doesn't indicate complete failure - it's instead the reason that
 // this plan couldn't be distributed.
 // TODO(radu): add tests for this.
-func checkSupportForNode(node planNode) (distRecommendation, error) {
+func checkSupportForPlanNode(node planNode) (distRecommendation, error) {
 	switch n := node.(type) {
 	// Keep these cases alphabetized, please!
 	case *distinctNode:
-		return checkSupportForNode(n.plan)
+		return checkSupportForPlanNode(n.plan)
 
 	case *exportNode:
-		return checkSupportForNode(n.source)
+		return checkSupportForPlanNode(n.source)
 
 	case *filterNode:
 		if err := checkExpr(n.filter); err != nil {
 			return cannotDistribute, err
 		}
-		return checkSupportForNode(n.source.plan)
+		return checkSupportForPlanNode(n.source.plan)
 
 	case *groupNode:
-		rec, err := checkSupportForNode(n.plan)
+		rec, err := checkSupportForPlanNode(n.plan)
 		if err != nil {
 			return cannotDistribute, err
 		}
@@ -342,20 +342,20 @@ func checkSupportForNode(node planNode) (distRecommendation, error) {
 	case *indexJoinNode:
 		// n.table doesn't have meaningful spans, but we need to check support (e.g.
 		// for any filtering expression).
-		if _, err := checkSupportForNode(n.table); err != nil {
+		if _, err := checkSupportForPlanNode(n.table); err != nil {
 			return cannotDistribute, err
 		}
-		return checkSupportForNode(n.input)
+		return checkSupportForPlanNode(n.input)
 
 	case *joinNode:
 		if err := checkExpr(n.pred.onCond); err != nil {
 			return cannotDistribute, err
 		}
-		recLeft, err := checkSupportForNode(n.left.plan)
+		recLeft, err := checkSupportForPlanNode(n.left.plan)
 		if err != nil {
 			return cannotDistribute, err
 		}
-		recRight, err := checkSupportForNode(n.right.plan)
+		recRight, err := checkSupportForPlanNode(n.right.plan)
 		if err != nil {
 			return cannotDistribute, err
 		}
@@ -375,19 +375,19 @@ func checkSupportForNode(node planNode) (distRecommendation, error) {
 		if err := checkExpr(n.offsetExpr); err != nil {
 			return cannotDistribute, err
 		}
-		return checkSupportForNode(n.plan)
+		return checkSupportForPlanNode(n.plan)
 
 	case *lookupJoinNode:
 		if err := checkExpr(n.onCond); err != nil {
 			return cannotDistribute, err
 		}
-		if _, err := checkSupportForNode(n.input); err != nil {
+		if _, err := checkSupportForPlanNode(n.input); err != nil {
 			return cannotDistribute, err
 		}
 		return shouldDistribute, nil
 
 	case *projectSetNode:
-		return checkSupportForNode(n.source)
+		return checkSupportForPlanNode(n.source)
 
 	case *renderNode:
 		for _, e := range n.render {
@@ -395,7 +395,7 @@ func checkSupportForNode(node planNode) (distRecommendation, error) {
 				return cannotDistribute, err
 			}
 		}
-		return checkSupportForNode(n.source.plan)
+		return checkSupportForPlanNode(n.source.plan)
 
 	case *scanNode:
 		if n.lockingStrength != sqlbase.ScanLockingStrength_FOR_NONE {
@@ -428,7 +428,7 @@ func checkSupportForNode(node planNode) (distRecommendation, error) {
 		return rec, nil
 
 	case *sortNode:
-		rec, err := checkSupportForNode(n.plan)
+		rec, err := checkSupportForPlanNode(n.plan)
 		if err != nil {
 			return cannotDistribute, err
 		}
@@ -440,11 +440,11 @@ func checkSupportForNode(node planNode) (distRecommendation, error) {
 		return canDistribute, nil
 
 	case *unionNode:
-		recLeft, err := checkSupportForNode(n.left)
+		recLeft, err := checkSupportForPlanNode(n.left)
 		if err != nil {
 			return cannotDistribute, err
 		}
-		recRight, err := checkSupportForNode(n.right)
+		recRight, err := checkSupportForPlanNode(n.right)
 		if err != nil {
 			return cannotDistribute, err
 		}
@@ -468,7 +468,7 @@ func checkSupportForNode(node planNode) (distRecommendation, error) {
 		return canDistribute, nil
 
 	case *windowNode:
-		return checkSupportForNode(n.plan)
+		return checkSupportForPlanNode(n.plan)
 
 	case *zeroNode:
 		return canDistribute, nil
@@ -1772,7 +1772,7 @@ func (dsp *DistSQLPlanner) addAggregators(
 func (dsp *DistSQLPlanner) createPlanForIndexJoin(
 	planCtx *PlanningCtx, n *indexJoinNode,
 ) (PhysicalPlan, error) {
-	plan, err := dsp.createPlanForNode(planCtx, n.input)
+	plan, err := dsp.createPhysPlanForPlanNode(planCtx, n.input)
 	if err != nil {
 		return PhysicalPlan{}, err
 	}
@@ -1847,7 +1847,7 @@ func (dsp *DistSQLPlanner) createPlanForIndexJoin(
 func (dsp *DistSQLPlanner) createPlanForLookupJoin(
 	planCtx *PlanningCtx, n *lookupJoinNode,
 ) (PhysicalPlan, error) {
-	plan, err := dsp.createPlanForNode(planCtx, n.input)
+	plan, err := dsp.createPhysPlanForPlanNode(planCtx, n.input)
 	if err != nil {
 		return PhysicalPlan{}, err
 	}
@@ -2129,11 +2129,11 @@ func (dsp *DistSQLPlanner) createPlanForJoin(
 	//
 	//  - The routers of the joiner processors are the result routers of the plan.
 
-	leftPlan, err := dsp.createPlanForNode(planCtx, n.left.plan)
+	leftPlan, err := dsp.createPhysPlanForPlanNode(planCtx, n.left.plan)
 	if err != nil {
 		return PhysicalPlan{}, err
 	}
-	rightPlan, err := dsp.createPlanForNode(planCtx, n.right.plan)
+	rightPlan, err := dsp.createPhysPlanForPlanNode(planCtx, n.right.plan)
 	if err != nil {
 		return PhysicalPlan{}, err
 	}
@@ -2243,7 +2243,16 @@ func (dsp *DistSQLPlanner) createPlanForJoin(
 	return p, nil
 }
 
-func (dsp *DistSQLPlanner) createPlanForNode(
+func (dsp *DistSQLPlanner) createPhysPlan(
+	planCtx *PlanningCtx, plan planMaybePhysical,
+) (physPlan PhysicalPlan, err error) {
+	if plan.isPhysicalPlan() {
+		return *plan.physPlan, nil
+	}
+	return dsp.createPhysPlanForPlanNode(planCtx, plan.planNode)
+}
+
+func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 	planCtx *PlanningCtx, node planNode,
 ) (plan PhysicalPlan, err error) {
 	planCtx.planDepth++
@@ -2257,7 +2266,7 @@ func (dsp *DistSQLPlanner) createPlanForNode(
 		plan, err = dsp.createPlanForExport(planCtx, n)
 
 	case *filterNode:
-		plan, err = dsp.createPlanForNode(planCtx, n.source.plan)
+		plan, err = dsp.createPhysPlanForPlanNode(planCtx, n.source.plan)
 		if err != nil {
 			return PhysicalPlan{}, err
 		}
@@ -2267,7 +2276,7 @@ func (dsp *DistSQLPlanner) createPlanForNode(
 		}
 
 	case *groupNode:
-		plan, err = dsp.createPlanForNode(planCtx, n.plan)
+		plan, err = dsp.createPhysPlanForPlanNode(planCtx, n.plan)
 		if err != nil {
 			return PhysicalPlan{}, err
 		}
@@ -2283,7 +2292,7 @@ func (dsp *DistSQLPlanner) createPlanForNode(
 		plan, err = dsp.createPlanForJoin(planCtx, n)
 
 	case *limitNode:
-		plan, err = dsp.createPlanForNode(planCtx, n.plan)
+		plan, err = dsp.createPhysPlanForPlanNode(planCtx, n.plan)
 		if err != nil {
 			return PhysicalPlan{}, err
 		}
@@ -2304,7 +2313,7 @@ func (dsp *DistSQLPlanner) createPlanForNode(
 		plan, err = dsp.createPlanForProjectSet(planCtx, n)
 
 	case *renderNode:
-		plan, err = dsp.createPlanForNode(planCtx, n.source.plan)
+		plan, err = dsp.createPhysPlanForPlanNode(planCtx, n.source.plan)
 		if err != nil {
 			return PhysicalPlan{}, err
 		}
@@ -2317,7 +2326,7 @@ func (dsp *DistSQLPlanner) createPlanForNode(
 		plan, err = dsp.createTableReaders(planCtx, n)
 
 	case *sortNode:
-		plan, err = dsp.createPlanForNode(planCtx, n.plan)
+		plan, err = dsp.createPhysPlanForPlanNode(planCtx, n.plan)
 		if err != nil {
 			return PhysicalPlan{}, err
 		}
@@ -2331,7 +2340,7 @@ func (dsp *DistSQLPlanner) createPlanForNode(
 		plan, err = dsp.createPlanForSetOp(planCtx, n)
 
 	case *valuesNode:
-		// Just like in checkSupportForNode, if a valuesNode wasn't specified in
+		// Just like in checkSupportForPlanNode, if a valuesNode wasn't specified in
 		// the query, it means that it was autogenerated for things that we don't
 		// want to be distributing, like populating values from a virtual table. So,
 		// we wrap the plan instead.
@@ -2347,7 +2356,7 @@ func (dsp *DistSQLPlanner) createPlanForNode(
 		// evaluatable.
 		//
 		// NB: If you change this conditional, you must also change it in
-		// checkSupportForNode!
+		// checkSupportForPlanNode!
 		if !n.specifiedInQuery || planCtx.isLocal || planCtx.noEvalSubqueries {
 			plan, err = dsp.wrapPlan(planCtx, n)
 		} else {
@@ -2430,7 +2439,7 @@ func (dsp *DistSQLPlanner) wrapPlan(planCtx *PlanningCtx, n planNode) (PhysicalP
 			// control of planning back to the DistSQL physical planner.
 			if !dsp.mustWrapNode(planCtx, plan) {
 				firstNotWrapped = plan
-				p, err = dsp.createPlanForNode(planCtx, plan)
+				p, err = dsp.createPhysPlanForPlanNode(planCtx, plan)
 				if err != nil {
 					return false, err
 				}
@@ -2653,7 +2662,7 @@ func createDistinctSpec(n *distinctNode, cols []int) *execinfrapb.DistinctSpec {
 func (dsp *DistSQLPlanner) createPlanForDistinct(
 	planCtx *PlanningCtx, n *distinctNode,
 ) (PhysicalPlan, error) {
-	plan, err := dsp.createPlanForNode(planCtx, n.plan)
+	plan, err := dsp.createPhysPlanForPlanNode(planCtx, n.plan)
 	if err != nil {
 		return PhysicalPlan{}, err
 	}
@@ -2682,7 +2691,7 @@ func (dsp *DistSQLPlanner) createPlanForDistinct(
 func (dsp *DistSQLPlanner) createPlanForOrdinality(
 	planCtx *PlanningCtx, n *ordinalityNode,
 ) (PhysicalPlan, error) {
-	plan, err := dsp.createPlanForNode(planCtx, n.source)
+	plan, err := dsp.createPhysPlanForPlanNode(planCtx, n.source)
 	if err != nil {
 		return PhysicalPlan{}, err
 	}
@@ -2728,7 +2737,7 @@ func createProjectSetSpec(
 func (dsp *DistSQLPlanner) createPlanForProjectSet(
 	planCtx *PlanningCtx, n *projectSetNode,
 ) (PhysicalPlan, error) {
-	plan, err := dsp.createPlanForNode(planCtx, n.source)
+	plan, err := dsp.createPhysPlanForPlanNode(planCtx, n.source)
 	if err != nil {
 		return PhysicalPlan{}, err
 	}
@@ -2817,12 +2826,12 @@ func (dsp *DistSQLPlanner) createPlanForSetOp(
 	planCtx *PlanningCtx, n *unionNode,
 ) (PhysicalPlan, error) {
 	leftLogicalPlan := n.left
-	leftPlan, err := dsp.createPlanForNode(planCtx, n.left)
+	leftPlan, err := dsp.createPhysPlanForPlanNode(planCtx, n.left)
 	if err != nil {
 		return PhysicalPlan{}, err
 	}
 	rightLogicalPlan := n.right
-	rightPlan, err := dsp.createPlanForNode(planCtx, n.right)
+	rightPlan, err := dsp.createPhysPlanForPlanNode(planCtx, n.right)
 	if err != nil {
 		return PhysicalPlan{}, err
 	}
@@ -3029,7 +3038,7 @@ func (dsp *DistSQLPlanner) createPlanForSetOp(
 func (dsp *DistSQLPlanner) createPlanForWindow(
 	planCtx *PlanningCtx, n *windowNode,
 ) (PhysicalPlan, error) {
-	plan, err := dsp.createPlanForNode(planCtx, n.plan)
+	plan, err := dsp.createPhysPlanForPlanNode(planCtx, n.plan)
 	if err != nil {
 		return PhysicalPlan{}, err
 	}
@@ -3175,7 +3184,7 @@ func (dsp *DistSQLPlanner) createPlanForWindow(
 func (dsp *DistSQLPlanner) createPlanForExport(
 	planCtx *PlanningCtx, n *exportNode,
 ) (PhysicalPlan, error) {
-	plan, err := dsp.createPlanForNode(planCtx, n.source)
+	plan, err := dsp.createPhysPlanForPlanNode(planCtx, n.source)
 	if err != nil {
 		return PhysicalPlan{}, err
 	}

--- a/pkg/sql/distsql_plan_ctas.go
+++ b/pkg/sql/distsql_plan_ctas.go
@@ -50,6 +50,6 @@ func PlanAndRunCTAS(
 
 	// Make copy of evalCtx as Run might modify it.
 	evalCtxCopy := planner.ExtendedEvalContextCopy()
-	dsp.FinalizePlan(planCtx, &physPlan)
-	dsp.Run(planCtx, txn, &physPlan, recv, evalCtxCopy, nil /* finishedSetupFn */)()
+	dsp.FinalizePlan(planCtx, physPlan)
+	dsp.Run(planCtx, txn, physPlan, recv, evalCtxCopy, nil /* finishedSetupFn */)()
 }

--- a/pkg/sql/distsql_plan_ctas.go
+++ b/pkg/sql/distsql_plan_ctas.go
@@ -27,7 +27,7 @@ func PlanAndRunCTAS(
 	planner *planner,
 	txn *kv.Txn,
 	isLocal bool,
-	in planNode,
+	in planMaybePhysical,
 	out execinfrapb.ProcessorCoreUnion,
 	recv *DistSQLReceiver,
 ) {
@@ -35,22 +35,21 @@ func PlanAndRunCTAS(
 	planCtx.planner = planner
 	planCtx.stmtType = tree.Rows
 
-	p, err := dsp.createPlanForNode(planCtx, in)
+	physPlan, err := dsp.createPhysPlan(planCtx, in)
 	if err != nil {
 		recv.SetError(errors.Wrapf(err, "constructing distSQL plan"))
 		return
 	}
-
-	p.AddNoGroupingStage(
+	physPlan.AddNoGroupingStage(
 		out, execinfrapb.PostProcessSpec{}, rowexec.CTASPlanResultTypes, execinfrapb.Ordering{},
 	)
 
 	// The bulk row writers will emit a binary encoded BulkOpSummary.
-	p.PlanToStreamColMap = []int{0}
-	p.ResultTypes = rowexec.CTASPlanResultTypes
+	physPlan.PlanToStreamColMap = []int{0}
+	physPlan.ResultTypes = rowexec.CTASPlanResultTypes
 
 	// Make copy of evalCtx as Run might modify it.
 	evalCtxCopy := planner.ExtendedEvalContextCopy()
-	dsp.FinalizePlan(planCtx, &p)
-	dsp.Run(planCtx, txn, &p, recv, evalCtxCopy, nil /* finishedSetupFn */)()
+	dsp.FinalizePlan(planCtx, &physPlan)
+	dsp.Run(planCtx, txn, &physPlan, recv, evalCtxCopy, nil /* finishedSetupFn */)()
 }

--- a/pkg/sql/distsql_plan_join.go
+++ b/pkg/sql/distsql_plan_join.go
@@ -34,9 +34,10 @@ var planInterleavedJoins = settings.RegisterBoolSetting(
 
 func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 	planCtx *PlanningCtx, n *joinNode,
-) (plan PhysicalPlan, ok bool, err error) {
+) (plan *PhysicalPlan, ok bool, err error) {
+	plan = &PhysicalPlan{}
 	if !useInterleavedJoin(n) {
-		return PhysicalPlan{}, false, nil
+		return nil, false, nil
 	}
 
 	leftScan, leftOk := n.left.plan.(*scanNode)
@@ -45,13 +46,13 @@ func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 	// We know they are scan nodes from useInterleaveJoin, but we add
 	// this check to prevent future panics.
 	if !leftOk || !rightOk {
-		return PhysicalPlan{}, false, errors.AssertionFailedf("left and right children of join node must be scan nodes to execute an interleaved join")
+		return nil, false, errors.AssertionFailedf("left and right children of join node must be scan nodes to execute an interleaved join")
 	}
 
 	// We iterate through each table and collate their metadata for
 	// the InterleavedReaderJoinerSpec.
 	tables := make([]execinfrapb.InterleavedReaderJoinerSpec_Table, 2)
-	plans := make([]PhysicalPlan, 2)
+	plans := make([]*PhysicalPlan, 2)
 	var totalLimitHint int64
 	for i, t := range []struct {
 		scan      *scanNode
@@ -72,7 +73,7 @@ func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 		// onCond and columns.
 		var err error
 		if plans[i], err = dsp.createTableReaders(planCtx, t.scan); err != nil {
-			return PhysicalPlan{}, false, err
+			return nil, false, err
 		}
 
 		eqCols := eqCols(t.eqIndices, plans[i].PlanToStreamColMap)
@@ -107,7 +108,7 @@ func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 	post, joinToStreamColMap := joinOutColumns(n, plans[0].PlanToStreamColMap, plans[1].PlanToStreamColMap)
 	onExpr, err := remapOnExpr(planCtx, n, plans[0].PlanToStreamColMap, plans[1].PlanToStreamColMap)
 	if err != nil {
-		return PhysicalPlan{}, false, err
+		return nil, false, err
 	}
 
 	ancestor, descendant := n.interleavedNodes()
@@ -115,11 +116,11 @@ func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 	// We partition each set of spans to their respective nodes.
 	ancsPartitions, err := dsp.PartitionSpans(planCtx, ancestor.spans)
 	if err != nil {
-		return PhysicalPlan{}, false, err
+		return nil, false, err
 	}
 	descPartitions, err := dsp.PartitionSpans(planCtx, descendant.spans)
 	if err != nil {
-		return PhysicalPlan{}, false, err
+		return nil, false, err
 	}
 
 	// We want to ensure that all child spans with a given interleave
@@ -139,7 +140,7 @@ func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 	// partitioned to node 2 and 3, then we need to move the child spans
 	// to node 1 where the PK1 = 1 parent row is read.
 	if descPartitions, err = alignInterleavedSpans(n, ancsPartitions, descPartitions); err != nil {
-		return PhysicalPlan{}, false, err
+		return nil, false, err
 	}
 
 	// Figure out which nodes we need to schedule a processor on.
@@ -229,7 +230,7 @@ func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 	plan.PlanToStreamColMap = joinToStreamColMap
 	plan.ResultTypes, err = getTypesForPlanResult(n, joinToStreamColMap)
 	if err != nil {
-		return PhysicalPlan{}, false, err
+		return nil, false, err
 	}
 
 	plan.SetMergeOrdering(dsp.convertOrdering(n.reqOrdering, plan.PlanToStreamColMap))

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -57,9 +57,9 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 	desc *sqlbase.ImmutableTableDescriptor,
 	reqStats []requestedStat,
 	job *jobs.Job,
-) (PhysicalPlan, error) {
+) (*PhysicalPlan, error) {
 	if len(reqStats) == 0 {
-		return PhysicalPlan{}, errors.New("no stats requested")
+		return nil, errors.New("no stats requested")
 	}
 
 	details := job.Details().(jobspb.CreateStatsDetails)
@@ -80,18 +80,18 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 	scan := scanNode{desc: desc}
 	err := scan.initDescDefaults(colCfg)
 	if err != nil {
-		return PhysicalPlan{}, err
+		return nil, err
 	}
 	sb := span.MakeBuilder(planCtx.planner.ExecCfg().Codec, desc.TableDesc(), scan.index)
 	scan.spans, err = sb.UnconstrainedSpans()
 	if err != nil {
-		return PhysicalPlan{}, err
+		return nil, err
 	}
 	scan.isFull = true
 
 	p, err := dsp.createTableReaders(planCtx, &scan)
 	if err != nil {
-		return PhysicalPlan{}, err
+		return nil, err
 	}
 
 	if details.AsOf != nil {
@@ -160,7 +160,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 	// Estimate the expected number of rows based on existing stats in the cache.
 	tableStats, err := planCtx.planner.execCfg.TableStatsCache.GetTableStats(planCtx.ctx, desc.ID)
 	if err != nil {
-		return PhysicalPlan{}, err
+		return nil, err
 	}
 
 	var rowsExpected uint64
@@ -205,7 +205,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 
 func (dsp *DistSQLPlanner) createPlanForCreateStats(
 	planCtx *PlanningCtx, job *jobs.Job,
-) (PhysicalPlan, error) {
+) (*PhysicalPlan, error) {
 	details := job.Details().(jobspb.CreateStatsDetails)
 	reqStats := make([]requestedStat, len(details.ColumnStats))
 	histogramCollectionEnabled := stats.HistogramClusterMode.Get(&dsp.st.SV)
@@ -238,7 +238,7 @@ func (dsp *DistSQLPlanner) planAndRunCreateStats(
 		return err
 	}
 
-	dsp.FinalizePlan(planCtx, &physPlan)
+	dsp.FinalizePlan(planCtx, physPlan)
 
 	recv := MakeDistSQLReceiver(
 		ctx,
@@ -254,6 +254,6 @@ func (dsp *DistSQLPlanner) planAndRunCreateStats(
 	)
 	defer recv.Release()
 
-	dsp.Run(planCtx, txn, &physPlan, recv, evalCtx, nil /* finishedSetupFn */)()
+	dsp.Run(planCtx, txn, physPlan, recv, evalCtx, nil /* finishedSetupFn */)()
 	return resultRows.Err()
 }

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -886,7 +886,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	if err != nil {
 		return err
 	}
-	dsp.FinalizePlan(subqueryPlanCtx, &subqueryPhysPlan)
+	dsp.FinalizePlan(subqueryPlanCtx, subqueryPhysPlan)
 
 	// TODO(arjun): #28264: We set up a row container, wrap it in a row
 	// receiver, and use it and serialize the results of the subquery. The type
@@ -916,7 +916,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	subqueryRowReceiver := NewRowResultWriter(rows)
 	subqueryRecv.resultWriter = subqueryRowReceiver
 	subqueryPlans[planIdx].started = true
-	dsp.Run(subqueryPlanCtx, planner.txn, &subqueryPhysPlan, subqueryRecv, evalCtx, nil /* finishedSetupFn */)()
+	dsp.Run(subqueryPlanCtx, planner.txn, subqueryPhysPlan, subqueryRecv, evalCtx, nil /* finishedSetupFn */)()
 	if subqueryRecv.commErr != nil {
 		return subqueryRecv.commErr
 	}
@@ -1003,9 +1003,9 @@ func (dsp *DistSQLPlanner) PlanAndRun(
 		recv.SetError(err)
 		return func() {}
 	}
-	dsp.FinalizePlan(planCtx, &physPlan)
+	dsp.FinalizePlan(planCtx, physPlan)
 	recv.expectedRowsRead = int64(physPlan.TotalEstimatedScannedRows)
-	return dsp.Run(planCtx, txn, &physPlan, recv, evalCtx, nil /* finishedSetupFn */)
+	return dsp.Run(planCtx, txn, physPlan, recv, evalCtx, nil /* finishedSetupFn */)
 }
 
 // PlanAndRunCascadesAndChecks runs any cascade and check queries.
@@ -1189,13 +1189,13 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	if err != nil {
 		return err
 	}
-	dsp.FinalizePlan(postqueryPlanCtx, &postqueryPhysPlan)
+	dsp.FinalizePlan(postqueryPlanCtx, postqueryPhysPlan)
 
 	postqueryRecv := recv.clone()
 	// TODO(yuzefovich): at the moment, errOnlyResultWriter is sufficient here,
 	// but it may not be the case when we support cascades through the optimizer.
 	postqueryRecv.resultWriter = &errOnlyResultWriter{}
-	dsp.Run(postqueryPlanCtx, planner.txn, &postqueryPhysPlan, postqueryRecv, evalCtx, nil /* finishedSetupFn */)()
+	dsp.Run(postqueryPlanCtx, planner.txn, postqueryPhysPlan, postqueryRecv, evalCtx, nil /* finishedSetupFn */)()
 	if postqueryRecv.commErr != nil {
 		return postqueryRecv.commErr
 	}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -882,7 +882,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	// Don't close the top-level plan from subqueries - someone else will handle
 	// that.
 	subqueryPlanCtx.ignoreClose = true
-	subqueryPhysPlan, err := dsp.createPlanForNode(subqueryPlanCtx, subqueryPlan.plan)
+	subqueryPhysPlan, err := dsp.createPhysPlan(subqueryPlanCtx, subqueryPlan.plan)
 	if err != nil {
 		return err
 	}
@@ -993,12 +993,12 @@ func (dsp *DistSQLPlanner) PlanAndRun(
 	evalCtx *extendedEvalContext,
 	planCtx *PlanningCtx,
 	txn *kv.Txn,
-	plan planNode,
+	plan planMaybePhysical,
 	recv *DistSQLReceiver,
 ) (cleanup func()) {
 	log.VEventf(ctx, 1, "creating DistSQL plan with isLocal=%v", planCtx.isLocal)
 
-	physPlan, err := dsp.createPlanForNode(planCtx, plan)
+	physPlan, err := dsp.createPhysPlan(planCtx, plan)
 	if err != nil {
 		recv.SetError(err)
 		return func() {}
@@ -1148,7 +1148,7 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 // planAndRunPostquery runs a cascade or check query.
 func (dsp *DistSQLPlanner) planAndRunPostquery(
 	ctx context.Context,
-	postqueryPlan planNode,
+	postqueryPlan planMaybePhysical,
 	planner *planner,
 	evalCtx *extendedEvalContext,
 	recv *DistSQLReceiver,
@@ -1185,7 +1185,7 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 		}
 	}
 
-	postqueryPhysPlan, err := dsp.createPlanForNode(postqueryPlanCtx, postqueryPlan)
+	postqueryPhysPlan, err := dsp.createPhysPlan(postqueryPlanCtx, postqueryPlan)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1059,14 +1059,14 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 		}
 
 		evalCtx := evalCtxFactory()
-		execFactory := makeExecFactory(planner)
+		execFactory := newExecFactory(planner)
 		// The cascading query is allowed to autocommit only if it is the last
 		// cascade and there are no check queries to run.
 		if len(plan.checkPlans) > 0 || i < len(plan.cascades)-1 {
 			execFactory.disableAutoCommit()
 		}
 		cascadePlan, err := plan.cascades[i].PlanFn(
-			ctx, &planner.semaCtx, &evalCtx.EvalContext, &execFactory, buf, buf.bufferedRows.Len(),
+			ctx, &planner.semaCtx, &evalCtx.EvalContext, execFactory, buf, buf.bufferedRows.Len(),
 		)
 		if err != nil {
 			recv.SetError(err)

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -1,0 +1,434 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+)
+
+type distSQLSpecExecFactory struct {
+}
+
+var _ exec.Factory = &distSQLSpecExecFactory{}
+
+func newDistSQLSpecExecFactory() exec.Factory {
+	return &distSQLSpecExecFactory{}
+}
+
+func (e *distSQLSpecExecFactory) ConstructValues(
+	rows [][]tree.TypedExpr, cols sqlbase.ResultColumns,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructScan(
+	table cat.Table,
+	index cat.Index,
+	needed exec.TableColumnOrdinalSet,
+	indexConstraint *constraint.Constraint,
+	hardLimit int64,
+	softLimit int64,
+	reverse bool,
+	maxResults uint64,
+	reqOrdering exec.OutputOrdering,
+	rowCount float64,
+	locking *tree.LockingItem,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructFilter(
+	n exec.Node, filter tree.TypedExpr, reqOrdering exec.OutputOrdering,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructSimpleProject(
+	n exec.Node, cols []exec.NodeColumnOrdinal, colNames []string, reqOrdering exec.OutputOrdering,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructRender(
+	n exec.Node,
+	columns sqlbase.ResultColumns,
+	exprs tree.TypedExprs,
+	reqOrdering exec.OutputOrdering,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructApplyJoin(
+	joinType sqlbase.JoinType,
+	left exec.Node,
+	rightColumns sqlbase.ResultColumns,
+	onCond tree.TypedExpr,
+	planRightSideFn exec.ApplyJoinPlanRightSideFn,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructHashJoin(
+	joinType sqlbase.JoinType,
+	left, right exec.Node,
+	leftEqCols, rightEqCols []exec.NodeColumnOrdinal,
+	leftEqColsAreKey, rightEqColsAreKey bool,
+	extraOnCond tree.TypedExpr,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructMergeJoin(
+	joinType sqlbase.JoinType,
+	left, right exec.Node,
+	onCond tree.TypedExpr,
+	leftOrdering, rightOrdering sqlbase.ColumnOrdering,
+	reqOrdering exec.OutputOrdering,
+	leftEqColsAreKey, rightEqColsAreKey bool,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructGroupBy(
+	input exec.Node,
+	groupCols []exec.NodeColumnOrdinal,
+	groupColOrdering sqlbase.ColumnOrdering,
+	aggregations []exec.AggInfo,
+	reqOrdering exec.OutputOrdering,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructScalarGroupBy(
+	input exec.Node, aggregations []exec.AggInfo,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructDistinct(
+	input exec.Node,
+	distinctCols, orderedCols exec.NodeColumnOrdinalSet,
+	reqOrdering exec.OutputOrdering,
+	nullsAreDistinct bool,
+	errorOnDup string,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructSetOp(
+	typ tree.UnionType, all bool, left, right exec.Node,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructSort(
+	input exec.Node, ordering sqlbase.ColumnOrdering, alreadyOrderedPrefix int,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructOrdinality(
+	input exec.Node, colName string,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructIndexJoin(
+	input exec.Node,
+	table cat.Table,
+	keyCols []exec.NodeColumnOrdinal,
+	tableCols exec.TableColumnOrdinalSet,
+	reqOrdering exec.OutputOrdering,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructLookupJoin(
+	joinType sqlbase.JoinType,
+	input exec.Node,
+	table cat.Table,
+	index cat.Index,
+	eqCols []exec.NodeColumnOrdinal,
+	eqColsAreKey bool,
+	lookupCols exec.TableColumnOrdinalSet,
+	onCond tree.TypedExpr,
+	reqOrdering exec.OutputOrdering,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructGeoLookupJoin(
+	joinType sqlbase.JoinType,
+	geoRelationshipType geoindex.RelationshipType,
+	input exec.Node,
+	table cat.Table,
+	index cat.Index,
+	geoCol exec.NodeColumnOrdinal,
+	lookupCols exec.TableColumnOrdinalSet,
+	onCond tree.TypedExpr,
+	reqOrdering exec.OutputOrdering,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructZigzagJoin(
+	leftTable cat.Table,
+	leftIndex cat.Index,
+	rightTable cat.Table,
+	rightIndex cat.Index,
+	leftEqCols []exec.NodeColumnOrdinal,
+	rightEqCols []exec.NodeColumnOrdinal,
+	leftCols exec.NodeColumnOrdinalSet,
+	rightCols exec.NodeColumnOrdinalSet,
+	onCond tree.TypedExpr,
+	fixedVals []exec.Node,
+	reqOrdering exec.OutputOrdering,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructLimit(
+	input exec.Node, limit, offset tree.TypedExpr,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructMax1Row(
+	input exec.Node, errorText string,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructProjectSet(
+	n exec.Node, exprs tree.TypedExprs, zipCols sqlbase.ResultColumns, numColsPerGen []int,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructWindow(
+	input exec.Node, window exec.WindowInfo,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) RenameColumns(
+	input exec.Node, colNames []string,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructPlan(
+	root exec.Node, subqueries []exec.Subquery, cascades []exec.Cascade, checks []exec.Node,
+) (exec.Plan, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructExplainOpt(
+	plan string, envOpts exec.ExplainEnvData,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructExplain(
+	options *tree.ExplainOptions, stmtType tree.StatementType, plan exec.Plan,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructShowTrace(
+	typ tree.ShowTraceType, compact bool,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructInsert(
+	input exec.Node,
+	table cat.Table,
+	insertCols exec.TableColumnOrdinalSet,
+	returnCols exec.TableColumnOrdinalSet,
+	checkCols exec.CheckOrdinalSet,
+	allowAutoCommit bool,
+	skipFKChecks bool,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructInsertFastPath(
+	rows [][]tree.TypedExpr,
+	table cat.Table,
+	insertCols exec.TableColumnOrdinalSet,
+	returnCols exec.TableColumnOrdinalSet,
+	checkCols exec.CheckOrdinalSet,
+	fkChecks []exec.InsertFastPathFKCheck,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructUpdate(
+	input exec.Node,
+	table cat.Table,
+	fetchCols exec.TableColumnOrdinalSet,
+	updateCols exec.TableColumnOrdinalSet,
+	returnCols exec.TableColumnOrdinalSet,
+	checks exec.CheckOrdinalSet,
+	passthrough sqlbase.ResultColumns,
+	allowAutoCommit bool,
+	skipFKChecks bool,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructUpsert(
+	input exec.Node,
+	table cat.Table,
+	canaryCol exec.NodeColumnOrdinal,
+	insertCols exec.TableColumnOrdinalSet,
+	fetchCols exec.TableColumnOrdinalSet,
+	updateCols exec.TableColumnOrdinalSet,
+	returnCols exec.TableColumnOrdinalSet,
+	checks exec.CheckOrdinalSet,
+	allowAutoCommit bool,
+	skipFKChecks bool,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructDelete(
+	input exec.Node,
+	table cat.Table,
+	fetchCols exec.TableColumnOrdinalSet,
+	returnCols exec.TableColumnOrdinalSet,
+	allowAutoCommit bool,
+	skipFKChecks bool,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructDeleteRange(
+	table cat.Table,
+	needed exec.TableColumnOrdinalSet,
+	indexConstraint *constraint.Constraint,
+	interleavedTables []cat.Table,
+	maxReturnedKeys int,
+	allowAutoCommit bool,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructCreateTable(
+	input exec.Node, schema cat.Schema, ct *tree.CreateTable,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructCreateView(
+	schema cat.Schema,
+	viewName string,
+	ifNotExists bool,
+	replace bool,
+	temporary bool,
+	viewQuery string,
+	columns sqlbase.ResultColumns,
+	deps opt.ViewDeps,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructSequenceSelect(sequence cat.Sequence) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructSaveTable(
+	input exec.Node, table *cat.DataSourceName, colNames []string,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructErrorIfRows(
+	input exec.Node, mkErr func(tree.Datums) error,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructOpaque(metadata opt.OpaqueMetadata) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructAlterTableSplit(
+	index cat.Index, input exec.Node, expiration tree.TypedExpr,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructAlterTableUnsplit(
+	index cat.Index, input exec.Node,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructAlterTableUnsplitAll(index cat.Index) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructAlterTableRelocate(
+	index cat.Index, input exec.Node, relocateLease bool,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructBuffer(
+	input exec.Node, label string,
+) (exec.BufferNode, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructScanBuffer(
+	ref exec.BufferNode, label string,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructRecursiveCTE(
+	initial exec.Node, fn exec.RecursiveCTEIterationFn, label string,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructControlJobs(
+	command tree.JobCommand, input exec.Node,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructCancelQueries(
+	input exec.Node, ifExists bool,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructCancelSessions(
+	input exec.Node, ifExists bool,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}
+
+func (e *distSQLSpecExecFactory) ConstructExport(
+	input exec.Node, fileName tree.TypedExpr, fileFormat string, options []exec.KVOption,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+}

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -247,6 +247,10 @@ func (e *distSQLSpecExecFactory) ConstructExplainOpt(
 func (e *distSQLSpecExecFactory) ConstructExplain(
 	options *tree.ExplainOptions, stmtType tree.StatementType, plan exec.Plan,
 ) (exec.Node, error) {
+	// TODO(yuzefovich): make sure to return the same nice error in some
+	// variants of EXPLAIN when subqueries are present as we do in the old path.
+	// TODO(yuzefovich): make sure that local plan nodes that create
+	// distributed jobs are shown as "distributed". See distSQLExplainable.
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
 }
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -260,7 +260,7 @@ const ExperimentalDistSQLPlanningClusterSettingName = "sql.defaults.experimental
 // transition when going from opt.Expr to DistSQL processor specs.
 var experimentalDistSQLPlanningClusterMode = settings.RegisterEnumSetting(
 	ExperimentalDistSQLPlanningClusterSettingName,
-	"default experimental_distsql_planning mode",
+	"default experimental_distsql_planning mode; enables experimental opt-driven DistSQL planning",
 	"off",
 	map[int64]string{
 		int64(sessiondata.ExperimentalDistSQLPlanningOff): "off",
@@ -899,7 +899,7 @@ func willDistributePlan(
 	ctx context.Context,
 	nodeID *base.SQLIDContainer,
 	distSQLMode sessiondata.DistSQLExecMode,
-	plan planNode,
+	plan planMaybePhysical,
 ) bool {
 	if _, singleTenant := nodeID.OptionalNodeID(); !singleTenant {
 		return false
@@ -909,15 +909,33 @@ func willDistributePlan(
 	}
 
 	// Don't try to run empty nodes (e.g. SET commands) with distSQL.
-	if _, ok := plan.(*zeroNode); ok {
-		return false
+	if plan.isPhysicalPlan() {
+		// zeroNode as the root of the planNode tree is represented by a
+		// physical plan with a single values processor that has 0 rows.
+		if len(plan.physPlan.Processors) == 1 {
+			if valuesSpec := plan.physPlan.Processors[0].Spec.Core.Values; valuesSpec != nil {
+				if valuesSpec.NumRows == 0 {
+					return false
+				}
+			}
+		}
+	} else {
+		if _, ok := plan.planNode.(*zeroNode); ok {
+			return false
+		}
 	}
 
-	rec, err := checkSupportForNode(plan)
-	if err != nil {
-		// Don't use distSQL for this request.
-		log.VEventf(ctx, 1, "query not supported for distSQL: %s", err)
-		return false
+	var rec distRecommendation
+	if plan.isPhysicalPlan() {
+		rec = plan.recommendation
+	} else {
+		var err error
+		rec, err = checkSupportForPlanNode(plan.planNode)
+		if err != nil {
+			// Don't use distSQL for this request.
+			log.VEventf(ctx, 1, "query not supported for distSQL: %s", err)
+			return false
+		}
 	}
 
 	return shouldDistributeGivenRecAndMode(rec, distSQLMode)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -251,6 +251,23 @@ var experimentalAlterColumnTypeGeneralMode = settings.RegisterBoolSetting(
 	false,
 )
 
+// ExperimentalDistSQLPlanningClusterSettingName is the name for the cluster
+// setting that controls experimentalDistSQLPlanningClusterMode below.
+const ExperimentalDistSQLPlanningClusterSettingName = "sql.defaults.experimental_distsql_planning"
+
+// experimentalDistSQLPlanningClusterMode can be used to enable
+// optimizer-driven DistSQL planning that sidesteps intermediate planNode
+// transition when going from opt.Expr to DistSQL processor specs.
+var experimentalDistSQLPlanningClusterMode = settings.RegisterEnumSetting(
+	ExperimentalDistSQLPlanningClusterSettingName,
+	"default experimental_distsql_planning mode",
+	"off",
+	map[int64]string{
+		int64(sessiondata.ExperimentalDistSQLPlanningOff): "off",
+		int64(sessiondata.ExperimentalDistSQLPlanningOn):  "on",
+	},
+)
+
 // VectorizeClusterSettingName is the name for the cluster setting that controls
 // the VectorizeClusterMode below.
 const VectorizeClusterSettingName = "sql.defaults.vectorize"
@@ -1989,6 +2006,12 @@ func (m *sessionDataMutator) SetZigzagJoinEnabled(val bool) {
 
 func (m *sessionDataMutator) SetEnumsEnabled(val bool) {
 	m.data.EnumsEnabled = val
+}
+
+func (m *sessionDataMutator) SetExperimentalDistSQLPlanning(
+	val sessiondata.ExperimentalDistSQLPlanningMode,
+) {
+	m.data.ExperimentalDistSQLPlanningMode = val
 }
 
 func (m *sessionDataMutator) SetRequireExplicitPrimaryKeys(val bool) {

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -74,14 +74,16 @@ func willDistributePlanForExplainPurposes(
 	ctx context.Context,
 	nodeID *base.SQLIDContainer,
 	distSQLMode sessiondata.DistSQLExecMode,
-	plan planNode,
+	plan planMaybePhysical,
 ) bool {
-	if _, ok := plan.(distSQLExplainable); ok {
-		// This is a special case for plans that will be actually distributed
-		// but are represented using local plan nodes (for example, "create
-		// statistics" is handled by the jobs framework which is responsible
-		// for setting up the correct DistSQL infrastructure).
-		return true
+	if !plan.isPhysicalPlan() {
+		if _, ok := plan.planNode.(distSQLExplainable); ok {
+			// This is a special case for plans that will be actually distributed
+			// but are represented using local plan nodes (for example, "create
+			// statistics" is handled by the jobs framework which is responsible
+			// for setting up the correct DistSQL infrastructure).
+			return true
+		}
 	}
 	return willDistributePlan(ctx, nodeID, distSQLMode, plan)
 }
@@ -146,7 +148,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 		}
 	}
 
-	plan, err := makePhysicalPlan(planCtx, distSQLPlanner, n.plan.main)
+	physPlan, err := makePhysPlanForExplainPurposes(planCtx, distSQLPlanner, n.plan.main)
 	if err != nil {
 		if len(n.plan.subqueryPlans) > 0 {
 			return errors.New("running EXPLAIN (DISTSQL) on this query is " +
@@ -154,8 +156,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 		}
 		return err
 	}
-
-	distSQLPlanner.FinalizePlan(planCtx, &plan)
+	distSQLPlanner.FinalizePlan(planCtx, &physPlan)
 
 	var diagram execinfrapb.FlowDiagram
 	if n.analyze {
@@ -213,7 +214,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 		planCtx.saveDiagramShowInputTypes = n.options.Flags[tree.ExplainFlagTypes]
 
 		distSQLPlanner.Run(
-			planCtx, newParams.p.txn, &plan, recv, newParams.extendedEvalCtx, nil, /* finishedSetupFn */
+			planCtx, newParams.p.txn, &physPlan, recv, newParams.extendedEvalCtx, nil, /* finishedSetupFn */
 		)()
 
 		n.run.executedStatement = true
@@ -228,7 +229,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 	} else {
 		// TODO(asubiotto): This cast from SQLInstanceID to NodeID is temporary:
 		//  https://github.com/cockroachdb/cockroach/issues/49596
-		flows := plan.GenerateFlowSpecs(roachpb.NodeID(params.extendedEvalCtx.NodeID.SQLInstanceID()))
+		flows := physPlan.GenerateFlowSpecs(roachpb.NodeID(params.extendedEvalCtx.NodeID.SQLInstanceID()))
 		showInputTypes := n.options.Flags[tree.ExplainFlagTypes]
 		diagram, err = execinfrapb.GeneratePlanDiagram(params.p.stmt.String(), flows, showInputTypes)
 		if err != nil {
@@ -301,15 +302,18 @@ func (n *explainDistSQLNode) Close(ctx context.Context) {
 	n.plan.close(ctx)
 }
 
-func makePhysicalPlan(
-	planCtx *PlanningCtx, distSQLPlanner *DistSQLPlanner, plan planNode,
+func makePhysPlanForExplainPurposes(
+	planCtx *PlanningCtx, distSQLPlanner *DistSQLPlanner, plan planMaybePhysical,
 ) (PhysicalPlan, error) {
+	if plan.isPhysicalPlan() {
+		return *plan.physPlan, nil
+	}
 	var physPlan PhysicalPlan
 	var err error
-	if planNode, ok := plan.(distSQLExplainable); ok {
+	if planNode, ok := plan.planNode.(distSQLExplainable); ok {
 		physPlan, err = planNode.makePlanForExplainDistSQL(planCtx, distSQLPlanner)
 	} else {
-		physPlan, err = distSQLPlanner.createPlanForNode(planCtx, plan)
+		physPlan, err = distSQLPlanner.createPhysPlanForPlanNode(planCtx, plan.planNode)
 	}
 	if err != nil {
 		return PhysicalPlan{}, err

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -59,10 +59,10 @@ type explainDistSQLRun struct {
 // distributed jobs. The plan node should implement this interface so that
 // EXPLAIN (DISTSQL) will show the DistSQL plan instead of the local plan node.
 type distSQLExplainable interface {
-	// makePlanForExplainDistSQL returns the DistSQL physical plan that can be
+	// newPlanForExplainDistSQL returns the DistSQL physical plan that can be
 	// used by the explainDistSQLNode to generate flow specs (and run in the case
 	// of EXPLAIN ANALYZE).
-	makePlanForExplainDistSQL(*PlanningCtx, *DistSQLPlanner) (PhysicalPlan, error)
+	newPlanForExplainDistSQL(*PlanningCtx, *DistSQLPlanner) (*PhysicalPlan, error)
 }
 
 // willDistributePlanForExplainPurposes determines whether we will distribute
@@ -148,7 +148,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 		}
 	}
 
-	physPlan, err := makePhysPlanForExplainPurposes(planCtx, distSQLPlanner, n.plan.main)
+	physPlan, err := newPhysPlanForExplainPurposes(planCtx, distSQLPlanner, n.plan.main)
 	if err != nil {
 		if len(n.plan.subqueryPlans) > 0 {
 			return errors.New("running EXPLAIN (DISTSQL) on this query is " +
@@ -156,7 +156,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 		}
 		return err
 	}
-	distSQLPlanner.FinalizePlan(planCtx, &physPlan)
+	distSQLPlanner.FinalizePlan(planCtx, physPlan)
 
 	var diagram execinfrapb.FlowDiagram
 	if n.analyze {
@@ -214,7 +214,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 		planCtx.saveDiagramShowInputTypes = n.options.Flags[tree.ExplainFlagTypes]
 
 		distSQLPlanner.Run(
-			planCtx, newParams.p.txn, &physPlan, recv, newParams.extendedEvalCtx, nil, /* finishedSetupFn */
+			planCtx, newParams.p.txn, physPlan, recv, newParams.extendedEvalCtx, nil, /* finishedSetupFn */
 		)()
 
 		n.run.executedStatement = true
@@ -302,21 +302,21 @@ func (n *explainDistSQLNode) Close(ctx context.Context) {
 	n.plan.close(ctx)
 }
 
-func makePhysPlanForExplainPurposes(
+func newPhysPlanForExplainPurposes(
 	planCtx *PlanningCtx, distSQLPlanner *DistSQLPlanner, plan planMaybePhysical,
-) (PhysicalPlan, error) {
+) (*PhysicalPlan, error) {
 	if plan.isPhysicalPlan() {
-		return *plan.physPlan, nil
+		return plan.physPlan, nil
 	}
-	var physPlan PhysicalPlan
+	var physPlan *PhysicalPlan
 	var err error
 	if planNode, ok := plan.planNode.(distSQLExplainable); ok {
-		physPlan, err = planNode.makePlanForExplainDistSQL(planCtx, distSQLPlanner)
+		physPlan, err = planNode.newPlanForExplainDistSQL(planCtx, distSQLPlanner)
 	} else {
 		physPlan, err = distSQLPlanner.createPhysPlanForPlanNode(planCtx, plan.planNode)
 	}
 	if err != nil {
-		return PhysicalPlan{}, err
+		return nil, err
 	}
 	return physPlan, nil
 }

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
+	"github.com/cockroachdb/errors"
 )
 
 const (
@@ -198,7 +199,7 @@ func populateExplain(
 	defer func() {
 		planCtx.planner.curPlan.subqueryPlans = outerSubqueries
 	}()
-	physicalPlan, err := makePhysicalPlan(planCtx, distSQLPlanner, plan.main)
+	physicalPlan, err := makePhysPlanForExplainPurposes(planCtx, distSQLPlanner, plan.main)
 	if err == nil {
 		// There might be an issue making the physical plan, but that should not
 		// cause an error or panic, so swallow the error. See #40677 for example.
@@ -293,16 +294,21 @@ func observePlan(
 	returnError bool,
 	subqueryFmtFlags tree.FmtFlags,
 ) error {
+	if plan.main.isPhysicalPlan() {
+		return errors.AssertionFailedf(
+			"EXPLAIN of a query with opt-driven DistSQL planning is not supported",
+		)
+	}
 	// If there are any subqueries, cascades, or checks in the plan, we
 	// enclose everything as children of a virtual "root" node.
 	if len(plan.subqueryPlans) > 0 || len(plan.cascades) > 0 || len(plan.checkPlans) > 0 {
-		if _, err := observer.enterNode(ctx, "root", plan.main); err != nil && returnError {
+		if _, err := observer.enterNode(ctx, "root", plan.main.planNode); err != nil && returnError {
 			return err
 		}
 	}
 
 	// Explain the main plan.
-	if err := walkPlan(ctx, plan.main, observer); err != nil && returnError {
+	if err := walkPlan(ctx, plan.main.planNode, observer); err != nil && returnError {
 		return err
 	}
 
@@ -321,8 +327,8 @@ func observePlan(
 			tree.AsStringWithFlags(s.subquery, subqueryFmtFlags),
 		)
 		observer.attr("subquery", "exec mode", rowexec.SubqueryExecModeNames[s.execMode])
-		if s.plan != nil {
-			if err := walkPlan(ctx, s.plan, observer); err != nil && returnError {
+		if s.plan.planNode != nil {
+			if err := walkPlan(ctx, s.plan.planNode, observer); err != nil && returnError {
 				return err
 			}
 		} else if s.started {
@@ -350,8 +356,8 @@ func observePlan(
 		if _, err := observer.enterNode(ctx, "fk-check", nil /* plan */); err != nil && returnError {
 			return err
 		}
-		if plan.checkPlans[i].plan != nil {
-			if err := walkPlan(ctx, plan.checkPlans[i].plan, observer); err != nil && returnError {
+		if plan.checkPlans[i].plan.planNode != nil {
+			if err := walkPlan(ctx, plan.checkPlans[i].plan.planNode, observer); err != nil && returnError {
 				return err
 			}
 		}
@@ -361,7 +367,7 @@ func observePlan(
 	}
 
 	if len(plan.subqueryPlans) > 0 || len(plan.cascades) > 0 || len(plan.checkPlans) > 0 {
-		if err := observer.leaveNode("root", plan.main); err != nil && returnError {
+		if err := observer.leaveNode("root", plan.main.planNode); err != nil && returnError {
 			return err
 		}
 	}

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -61,11 +61,11 @@ func (n *explainVecNode) startExec(params runParams) error {
 		params.extendedEvalCtx.SessionData.DistSQLMode, n.plan,
 	)
 	outerSubqueries := params.p.curPlan.subqueryPlans
-	planCtx := makeExplainPlanningCtx(distSQLPlanner, params, n.stmtType, n.subqueryPlans, willDistribute)
+	planCtx := newPlanningCtxForExplainPurposes(distSQLPlanner, params, n.stmtType, n.subqueryPlans, willDistribute)
 	defer func() {
 		planCtx.planner.curPlan.subqueryPlans = outerSubqueries
 	}()
-	physPlan, err := makePhysPlanForExplainPurposes(planCtx, distSQLPlanner, n.plan)
+	physPlan, err := newPhysPlanForExplainPurposes(planCtx, distSQLPlanner, n.plan)
 	if err != nil {
 		if len(n.subqueryPlans) > 0 {
 			return errors.New("running EXPLAIN (VEC) on this query is " +
@@ -74,13 +74,13 @@ func (n *explainVecNode) startExec(params runParams) error {
 		return err
 	}
 
-	distSQLPlanner.FinalizePlan(planCtx, &physPlan)
+	distSQLPlanner.FinalizePlan(planCtx, physPlan)
 	nodeID, err := params.extendedEvalCtx.NodeID.OptionalNodeIDErr(distsql.MultiTenancyIssueNo)
 	if err != nil {
 		return err
 	}
 	flows := physPlan.GenerateFlowSpecs(nodeID)
-	flowCtx := makeFlowCtx(planCtx, physPlan, params)
+	flowCtx := newFlowCtxForExplainPurposes(planCtx, params)
 	flowCtx.Cfg.ClusterID = &distSQLPlanner.rpcCtx.ClusterID
 
 	// We want to get the vectorized plan which would be executed with the
@@ -128,8 +128,8 @@ func (n *explainVecNode) startExec(params runParams) error {
 	return nil
 }
 
-func makeFlowCtx(planCtx *PlanningCtx, plan PhysicalPlan, params runParams) *execinfra.FlowCtx {
-	flowCtx := &execinfra.FlowCtx{
+func newFlowCtxForExplainPurposes(planCtx *PlanningCtx, params runParams) *execinfra.FlowCtx {
+	return &execinfra.FlowCtx{
 		NodeID:  planCtx.EvalContext().NodeID,
 		EvalCtx: planCtx.EvalContext(),
 		Cfg: &execinfra.ServerConfig{
@@ -138,10 +138,9 @@ func makeFlowCtx(planCtx *PlanningCtx, plan PhysicalPlan, params runParams) *exe
 			VecFDSemaphore: params.p.execCfg.DistSQLSrv.VecFDSemaphore,
 		},
 	}
-	return flowCtx
 }
 
-func makeExplainPlanningCtx(
+func newPlanningCtxForExplainPurposes(
 	distSQLPlanner *DistSQLPlanner,
 	params runParams,
 	stmtType tree.StatementType,

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -36,7 +36,7 @@ type explainVecNode struct {
 	optColumnsSlot
 
 	options *tree.ExplainOptions
-	plan    planNode
+	plan    planMaybePhysical
 
 	stmtType tree.StatementType
 
@@ -65,7 +65,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 	defer func() {
 		planCtx.planner.curPlan.subqueryPlans = outerSubqueries
 	}()
-	plan, err := makePhysicalPlan(planCtx, distSQLPlanner, n.plan)
+	physPlan, err := makePhysPlanForExplainPurposes(planCtx, distSQLPlanner, n.plan)
 	if err != nil {
 		if len(n.subqueryPlans) > 0 {
 			return errors.New("running EXPLAIN (VEC) on this query is " +
@@ -74,13 +74,13 @@ func (n *explainVecNode) startExec(params runParams) error {
 		return err
 	}
 
-	distSQLPlanner.FinalizePlan(planCtx, &plan)
+	distSQLPlanner.FinalizePlan(planCtx, &physPlan)
 	nodeID, err := params.extendedEvalCtx.NodeID.OptionalNodeIDErr(distsql.MultiTenancyIssueNo)
 	if err != nil {
 		return err
 	}
-	flows := plan.GenerateFlowSpecs(nodeID)
-	flowCtx := makeFlowCtx(planCtx, plan, params)
+	flows := physPlan.GenerateFlowSpecs(nodeID)
+	flowCtx := makeFlowCtx(planCtx, physPlan, params)
 	flowCtx.Cfg.ClusterID = &distSQLPlanner.rpcCtx.ClusterID
 
 	// We want to get the vectorized plan which would be executed with the

--- a/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning
+++ b/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning
@@ -1,0 +1,22 @@
+# Test that we can set the session variable and cluster setting.
+statement ok
+SET experimental_distsql_planning = off
+
+statement ok
+SET experimental_distsql_planning = on
+
+statement ok
+SET CLUSTER SETTING sql.defaults.experimental_distsql_planning = off
+
+statement ok
+SET CLUSTER SETTING sql.defaults.experimental_distsql_planning = on
+
+statement ok
+SET experimental_distsql_planning = always
+
+# Test that a SELECT query fails but others don't.
+statement ok
+CREATE TABLE kv (k INT PRIMARY KEY, v INT); INSERT INTO kv VALUES (1, 1), (2, 1)
+
+statement error pq: unimplemented: experimental opt-driven distsql planning
+SELECT * FROM kv

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1727,6 +1727,7 @@ enable_experimental_alter_column_type_general  off                 NULL      NUL
 enable_implicit_select_for_update              on                  NULL      NULL        NULL        string
 enable_insert_fast_path                        on                  NULL      NULL        NULL        string
 enable_zigzag_join                             on                  NULL      NULL        NULL        string
+experimental_distsql_planning                  off                 NULL      NULL        NULL        string
 experimental_enable_enums                      on                  NULL      NULL        NULL        string
 experimental_enable_hash_sharded_indexes       off                 NULL      NULL        NULL        string
 experimental_enable_temp_tables                off                 NULL      NULL        NULL        string
@@ -1794,6 +1795,7 @@ enable_experimental_alter_column_type_general  off                 NULL  user   
 enable_implicit_select_for_update              on                  NULL  user     NULL      on                  on
 enable_insert_fast_path                        on                  NULL  user     NULL      on                  on
 enable_zigzag_join                             on                  NULL  user     NULL      on                  on
+experimental_distsql_planning                  off                 NULL  user     NULL      off                 off
 experimental_enable_enums                      on                  NULL  user     NULL      off                 off
 experimental_enable_hash_sharded_indexes       off                 NULL  user     NULL      off                 off
 experimental_enable_temp_tables                off                 NULL  user     NULL      off                 off
@@ -1857,6 +1859,7 @@ enable_experimental_alter_column_type_general  NULL    NULL     NULL     NULL   
 enable_implicit_select_for_update              NULL    NULL     NULL     NULL        NULL
 enable_insert_fast_path                        NULL    NULL     NULL     NULL        NULL
 enable_zigzag_join                             NULL    NULL     NULL     NULL        NULL
+experimental_distsql_planning                  NULL    NULL     NULL     NULL        NULL
 experimental_enable_enums                      NULL    NULL     NULL     NULL        NULL
 experimental_enable_hash_sharded_indexes       NULL    NULL     NULL     NULL        NULL
 experimental_enable_temp_tables                NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -42,6 +42,7 @@ enable_experimental_alter_column_type_general  off
 enable_implicit_select_for_update              on
 enable_insert_fast_path                        on
 enable_zigzag_join                             on
+experimental_distsql_planning                  off
 experimental_enable_enums                      off
 experimental_enable_hash_sharded_indexes       off
 experimental_enable_temp_tables                off

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -44,8 +44,8 @@ type execFactory struct {
 
 var _ exec.Factory = &execFactory{}
 
-func makeExecFactory(p *planner) execFactory {
-	return execFactory{
+func newExecFactory(p *planner) *execFactory {
+	return &execFactory{
 		planner:         p,
 		allowAutoCommit: p.autoCommit,
 	}

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1055,7 +1055,7 @@ func (ef *execFactory) ConstructPlan(
 		auditEvents:     ef.planner.curPlan.auditEvents,
 		instrumentation: ef.planner.curPlan.instrumentation,
 	}
-	res.main = root.(planNode)
+	res.main.planNode = root.(planNode)
 	if len(subqueries) > 0 {
 		res.subqueryPlans = make([]subquery, len(subqueries))
 		for i := range subqueries {
@@ -1075,7 +1075,7 @@ func (ef *execFactory) ConstructPlan(
 				return nil, errors.Errorf("invalid SubqueryMode %d", in.Mode)
 			}
 			out.expanded = true
-			out.plan = in.Root.(planNode)
+			out.plan.planNode = in.Root.(planNode)
 		}
 	}
 	if len(cascades) > 0 {
@@ -1087,7 +1087,7 @@ func (ef *execFactory) ConstructPlan(
 	if len(checks) > 0 {
 		res.checkPlans = make([]checkPlan, len(checks))
 		for i := range checks {
-			res.checkPlans[i].plan = checks[i].(planNode)
+			res.checkPlans[i].plan.planNode = checks[i].(planNode)
 		}
 	}
 

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -310,6 +310,38 @@ type planTop struct {
 	distSQLDiagrams []execinfrapb.FlowDiagram
 }
 
+// planMaybePhysical is a utility struct representing a plan. It can currently
+// use either planNode or DistSQL spec representation, but eventually will be
+// replaced by the latter representation directly.
+type planMaybePhysical struct {
+	planNode planNode
+	// physPlan (when non-nil) contains the physical plan that has not yet
+	// been finalized.
+	physPlan *PhysicalPlan
+	// recommendation (when physPlan is non-nil) is the recommendation about
+	// the distribution of the physical plan.
+	recommendation distRecommendation
+}
+
+func (p planMaybePhysical) isPhysicalPlan() bool {
+	return p.physPlan != nil
+}
+
+func (p planMaybePhysical) planColumns() sqlbase.ResultColumns {
+	if p.isPhysicalPlan() {
+		// TODO(yuzefovich): update this once we support creating table reader
+		// specs directly in the optimizer (see #47474).
+		return nil
+	}
+	return planColumns(p.planNode)
+}
+
+func (p planMaybePhysical) Close(ctx context.Context) {
+	if p.planNode != nil {
+		p.planNode.Close(ctx)
+	}
+}
+
 // planComponents groups together the various components of the entire query
 // plan.
 type planComponents struct {
@@ -317,7 +349,7 @@ type planComponents struct {
 	subqueryPlans []subquery
 
 	// plan for the main query.
-	main planNode
+	main planMaybePhysical
 
 	// cascades contains metadata for all cascades.
 	cascades []cascadeMetadata
@@ -331,42 +363,42 @@ type cascadeMetadata struct {
 	exec.Cascade
 	// plan for the cascade. This plan is not populated upfront; it is created
 	// only when it needs to run, after the main query (and previous cascades).
-	plan planNode
+	plan planMaybePhysical
 }
 
 // checkPlan is a query tree that is executed after the main one. It can only
 // return an error (for example, foreign key violation).
 type checkPlan struct {
-	plan planNode
+	plan planMaybePhysical
 }
 
 // close calls Close on all plan trees.
 func (p *planComponents) close(ctx context.Context) {
-	if p.main != nil {
+	if p.main.planNode != nil {
 		p.main.Close(ctx)
-		p.main = nil
+		p.main.planNode = nil
 	}
 
 	for i := range p.subqueryPlans {
 		// Once a subquery plan has been evaluated, it already closes its
 		// plan.
-		if p.subqueryPlans[i].plan != nil {
+		if p.subqueryPlans[i].plan.planNode != nil {
 			p.subqueryPlans[i].plan.Close(ctx)
-			p.subqueryPlans[i].plan = nil
+			p.subqueryPlans[i].plan.planNode = nil
 		}
 	}
 
 	for i := range p.cascades {
-		if p.cascades[i].plan != nil {
+		if p.cascades[i].plan.planNode != nil {
 			p.cascades[i].plan.Close(ctx)
-			p.cascades[i].plan = nil
+			p.cascades[i].plan.planNode = nil
 		}
 	}
 
 	for i := range p.checkPlans {
-		if p.checkPlans[i].plan != nil {
+		if p.checkPlans[i].plan.planNode != nil {
 			p.checkPlans[i].plan.Close(ctx)
-			p.checkPlans[i].plan = nil
+			p.checkPlans[i].plan.planNode = nil
 		}
 	}
 }
@@ -380,7 +412,9 @@ func (p *planTop) init(stmt *Statement, appStats *appStats) {
 
 // close ensures that the plan's resources have been deallocated.
 func (p *planTop) close(ctx context.Context) {
-	if p.main != nil {
+	if p.main.planNode != nil {
+		// TODO(yuzefovich): update this once we support creating table reader
+		// specs directly in the optimizer (see #47474).
 		p.instrumentation.savePlanInfo(ctx, p)
 	}
 	p.planComponents.close(ctx)

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/execbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
@@ -23,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -173,11 +175,39 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 
 	// Build the plan tree.
 	root := execMemo.RootExpr()
-	execFactory := makeExecFactory(p)
-	bld := execbuilder.New(&execFactory, execMemo, &opc.catalog, root, p.EvalContext())
-	plan, err := bld.Build()
-	if err != nil {
-		return err
+	var (
+		plan exec.Plan
+		bld  *execbuilder.Builder
+	)
+	if mode := p.SessionData().ExperimentalDistSQLPlanningMode; mode != sessiondata.ExperimentalDistSQLPlanningOff {
+		bld = execbuilder.New(newDistSQLSpecExecFactory(), execMemo, &opc.catalog, root, p.EvalContext())
+		plan, err = bld.Build()
+		if err != nil {
+			if mode == sessiondata.ExperimentalDistSQLPlanningAlways &&
+				p.stmt.AST.StatementTag() == "SELECT" {
+				// We do not fallback to the old path because experimental
+				// planning is set to 'always' and we have a SELECT statement,
+				// so we return an error.
+				// We use a simple heuristic to check whether the statement is
+				// a SELECT, and the reasoning behind it is that we want to be
+				// able to run certain statement types (e.g. SET) regardless of
+				// whether they are supported by the new factory.
+				// TODO(yuzefovich): update this once we support more than just
+				// SELECT statements (see #47473).
+				return err
+			}
+			// We will fallback to the old path.
+			bld = nil
+		}
+	}
+	if bld == nil {
+		// If bld is non-nil, then experimental planning has succeeded and has
+		// already created a plan.
+		bld = execbuilder.New(newExecFactory(p), execMemo, &opc.catalog, root, p.EvalContext())
+		plan, err = bld.Build()
+		if err != nil {
+			return err
+		}
 	}
 
 	result := plan.(*planTop)

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -219,7 +219,7 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 		result.flags.Set(planFlagIsDDL)
 	}
 
-	cols := planColumns(result.main)
+	cols := result.main.planColumns()
 	if stmt.ExpectedTypes != nil {
 		if !stmt.ExpectedTypes.TypesEqual(cols) {
 			return pgerror.New(pgcode.FeatureNotSupported, "cached plan must not change result type")

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -25,7 +25,7 @@ type subquery struct {
 	execMode rowexec.SubqueryExecMode
 	expanded bool
 	started  bool
-	plan     planNode
+	plan     planMaybePhysical
 	result   tree.Datum
 }
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -384,6 +384,26 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`experimental_distsql_planning`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`experimental_distsql_planning`),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			mode, ok := sessiondata.ExperimentalDistSQLPlanningModeFromString(s)
+			if !ok {
+				return newVarValueError(`experimental_distsql_planning`, s,
+					"off", "on", "always")
+			}
+			m.SetExperimentalDistSQLPlanning(mode)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return evalCtx.SessionData.ExperimentalDistSQLPlanningMode.String()
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return sessiondata.ExperimentalDistSQLPlanningMode(experimentalDistSQLPlanningClusterMode.Get(sv)).String()
+		},
+	},
+
+	// CockroachDB extension.
 	`experimental_enable_enums`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`experimental_enable_enums`),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -660,10 +660,10 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 		}
 
 	case *explainDistSQLNode:
-		n.plan.main = v.visit(n.plan.main)
+		n.plan.main.planNode = v.visit(n.plan.main.planNode)
 
 	case *explainVecNode:
-		n.plan = v.visit(n.plan)
+		n.plan.planNode = v.visit(n.plan.planNode)
 
 	case *ordinalityNode:
 		n.source = v.visit(n.source)
@@ -684,7 +684,7 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 		n.plan = v.visit(n.plan)
 
 	case *explainPlanNode:
-		n.plan.main = v.visit(n.plan.main)
+		n.plan.main.planNode = v.visit(n.plan.main.planNode)
 
 	case *cancelQueriesNode:
 		n.rows = v.visit(n.rows)


### PR DESCRIPTION
**sql: add stub exec.Factory for opt-driven distsql planning**

This commit adds a stub implementation of `exec.Factory` interface that
will be creating DistSQL processor specs directly from `opt.Expr`,
sidestepping intermediate `planNode` phase.

It also introduces a new private cluster setting
"sql.defaults.experimental_distsql_planning" as well as a session
variable "experimental_distsql_planning" which determine whether the new
factory is used, set to `off` by default (other options are `on` and
`always` - the latter is only for the session variable).

`Off` planning mode means using the old code path, `on` means attempting
to use the new code path but falling back to the old one if we encounter
an error, and `always` means using only the new code path and do not
fallback in case of an error. Currently the fallback doesn't occur with
`always` only for SELECT statements (so that we could run other
statements types, like SET), meaning that when`always` option is used,
if we encounter an unsupported node while planning a SELECT statement,
an error is returned, but if we encounter an unsupported node while
planning a statement other than SELECT, we still fallback to the old
code (in a sense `always` behaves exactly like `on` for all statement
types except for SELECTs).

Release note: None

**sql: add plumbing for phys plan creation directly in execbuilder**

This commit introduces `planMaybePhysical` utility struct that
represents a plan and uses either planNode ("logical") or DistSQL spec
("physical") representations. It will be removed once we are able to
create all processor specs in execbuilder directly. This struct has been
plumbed in all places that need to look at the plan, but in most of them
only the logical representation is supported. However, the main codepath
for executing a statement supports both, and if physical representation
is used, then we bypass distsql physical planner.

This commit also renames `checkSupportForNode` to
`checkSupportForPlanNode` and `createPlanForNode` to
`createPhysPlanForPlanNode` to make their purpose more clear.

Addresses: #47474.

Release note: None

**sql: operate on pointers to PhysicalPlan**

This commit changes `createPlanFor*` methods to operate on pointers to
`PhysicalPlan` instead of values. It also renames and cleans up some
explain-related utility methods.

Release note: None