### PR TITLE
release-20.1: backport #48229 & #49089

### DIFF
--- a/pkg/storage/cloud/external_storage.go
+++ b/pkg/storage/cloud/external_storage.go
@@ -398,7 +398,9 @@ func delayedRetry(ctx context.Context, fn func() error) error {
 // happen if we didn't read from the connection too long due to e.g. load),
 // the same as unexpected eof errors.
 func isResumableHTTPError(err error) bool {
-	return errors.Is(err, io.ErrUnexpectedEOF) || sysutil.IsErrConnectionReset(err)
+	return errors.Is(err, io.ErrUnexpectedEOF) ||
+		sysutil.IsErrConnectionReset(err) ||
+		sysutil.IsErrConnectionRefused(err)
 }
 
 // Maximum number of times we can attempt to retry reading from external storage,

--- a/pkg/storage/cloud/gcs_storage.go
+++ b/pkg/storage/cloud/gcs_storage.go
@@ -224,11 +224,15 @@ func (r *resumingGoogleStorageReader) Close() error {
 
 func (g *gcsStorage) ReadFile(ctx context.Context, basename string) (io.ReadCloser, error) {
 	// https://github.com/cockroachdb/cockroach/issues/23859
-	return &resumingGoogleStorageReader{
+	reader := &resumingGoogleStorageReader{
 		ctx:    ctx,
 		bucket: g.bucket,
 		object: path.Join(g.prefix, basename),
-	}, nil
+	}
+	if err := reader.openStream(); err != nil {
+		return nil, err
+	}
+	return reader, nil
 }
 
 func (g *gcsStorage) ListFiles(ctx context.Context, patternSuffix string) ([]string, error) {

--- a/pkg/storage/cloud/gcs_storage_test.go
+++ b/pkg/storage/cloud/gcs_storage_test.go
@@ -1,0 +1,112 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cloud
+
+import (
+	"context"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
+	"github.com/stretchr/testify/require"
+)
+
+var econnrefused = &net.OpError{Err: &os.SyscallError{
+	Syscall: "test",
+	Err:     sysutil.ECONNREFUSED,
+}}
+
+var econnreset = &net.OpError{Err: &os.SyscallError{
+	Syscall: "test",
+	Err:     sysutil.ECONNRESET,
+}}
+
+type antagonisticDialer struct {
+	net.Dialer
+	rnd               *rand.Rand
+	numRepeatFailures *int
+}
+
+type antagonisticConn struct {
+	net.Conn
+	rnd               *rand.Rand
+	numRepeatFailures *int
+}
+
+func (d *antagonisticDialer) DialContext(
+	ctx context.Context, network, addr string,
+) (net.Conn, error) {
+	if network == "tcp" && addr == "storage.googleapis.com:443" {
+		if *d.numRepeatFailures < maxNoProgressReads && d.rnd.Int()%2 == 0 {
+			*(d.numRepeatFailures)++
+			return nil, econnrefused
+		}
+		c, err := d.Dialer.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+
+		return &antagonisticConn{Conn: c, rnd: d.rnd, numRepeatFailures: d.numRepeatFailures}, nil
+	}
+	return d.Dialer.DialContext(ctx, network, addr)
+}
+
+func (c *antagonisticConn) Read(b []byte) (int, error) {
+	if *c.numRepeatFailures < maxNoProgressReads && c.rnd.Int()%2 == 0 {
+		*(c.numRepeatFailures)++
+		return 0, econnreset
+	}
+	return c.Conn.Read(b)
+}
+
+func TestAntagonisticRead(t *testing.T) {
+	if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") == "" {
+		// This test requires valid GS credential file.
+		return
+	}
+
+	rnd, _ := randutil.NewPseudoRand()
+	failures := 0
+	// Override DialContext implementation in http transport.
+	dialer := &antagonisticDialer{rnd: rnd, numRepeatFailures: &failures}
+
+	// Override transport to return antagonistic connection.
+	transport := http.DefaultTransport.(*http.Transport)
+	transport.DialContext =
+		func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, addr)
+		}
+	transport.DisableKeepAlives = true
+
+	defer func() {
+		transport.DialContext = nil
+		transport.DisableKeepAlives = false
+	}()
+
+	gsFile := "gs://cockroach-fixtures/tpch-csv/sf-1/region.tbl?AUTH=implicit"
+	conf, err := ExternalStorageConfFromURI(gsFile)
+	require.NoError(t, err)
+
+	s, err := MakeExternalStorage(
+		context.TODO(), conf, base.ExternalIOConfig{}, testSettings, nil)
+	require.NoError(t, err)
+	stream, err := s.ReadFile(context.TODO(), "")
+	require.NoError(t, err)
+	defer stream.Close()
+	_, err = ioutil.ReadAll(stream)
+	require.NoError(t, err)
+}

--- a/pkg/util/sysutil/sysutil.go
+++ b/pkg/util/sysutil/sysutil.go
@@ -15,11 +15,12 @@
 package sysutil
 
 import (
-	"net"
 	"os"
 	"os/exec"
 	"os/signal"
 	"syscall"
+
+	"github.com/cockroachdb/errors"
 )
 
 // Signal is syscall.Signal.
@@ -27,6 +28,12 @@ type Signal = syscall.Signal
 
 // Errno is syscall.Errno.
 type Errno = syscall.Errno
+
+// Exported syscall.Errno constants.
+const (
+	ECONNRESET   = syscall.ECONNRESET
+	ECONNREFUSED = syscall.ECONNREFUSED
+)
 
 // FSInfo describes a filesystem. It is returned by StatFS.
 type FSInfo struct {
@@ -64,10 +71,10 @@ func RefreshSignaledChan() <-chan os.Signal {
 // IsErrConnectionReset returns true if an
 // error is a "connection reset by peer" error.
 func IsErrConnectionReset(err error) bool {
-	if opErr, ok := err.(*net.OpError); ok {
-		if sysErr, ok := opErr.Err.(*os.SyscallError); ok {
-			return sysErr.Err == syscall.ECONNRESET
-		}
-	}
-	return false
+	return errors.Is(err, syscall.ECONNRESET)
+}
+
+// IsErrConnectionRefused returns true if an error is a "connection refused" error.
+func IsErrConnectionRefused(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED)
 }


### PR DESCRIPTION
Backport:
  * 2/2 commits from "storage/cloud: Make google storage reader handle download interrupts." (#48229)
  * 1/1 commits from "storage/cloud: Open data stream early to ensure blob exists" (#49089)

Please see individual PRs for details.

/cc @cockroachdb/release
