### PR TITLE
cli: delete `cockroach quit --decommission`

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -915,11 +915,6 @@ If specified, print the system config contents. Beware that the output will be
 long and not particularly human-readable.`,
 	}
 
-	Decommission = FlagInfo{
-		Name:        "decommission",
-		Description: `Deprecated: use 'node decommission' instead.`,
-	}
-
 	DrainWait = FlagInfo{
 		Name: "drain-wait",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -134,7 +134,6 @@ func initCLIDefaults() {
 	startCtx.inBackground = false
 	startCtx.geoLibsDir = "/usr/local/lib"
 
-	quitCtx.serverDecommission = false
 	quitCtx.drainWait = 10 * time.Minute
 
 	nodeCtx.nodeDecommissionWait = nodeDecommissionWaitAll
@@ -353,9 +352,6 @@ var startCtx struct {
 // `node drain` commands.
 // Defaults set by InitCLIDefaults() above.
 var quitCtx struct {
-	// serverDecommission indicates the server should be decommissioned
-	// before it is drained.
-	serverDecommission bool
 	// drainWait is the amount of time to wait for the server
 	// to drain. Set to 0 to disable a timeout (let the server decide).
 	drainWait time.Duration

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -567,18 +567,7 @@ func init() {
 	// Decommission command.
 	VarFlag(decommissionNodeCmd.Flags(), &nodeCtx.nodeDecommissionWait, cliflags.Wait)
 
-	// Quit command.
-	{
-		f := quitCmd.Flags()
-		// The --decommission flag for quit is now deprecated.
-		// Users should use `node decommission` and then `quit` after
-		// decommission completes.
-		// TODO(knz): Remove in 20.2.
-		BoolFlag(f, &quitCtx.serverDecommission, cliflags.Decommission, quitCtx.serverDecommission)
-		_ = f.MarkDeprecated(cliflags.Decommission.Name, `use 'cockroach node decommission' then 'cockroach quit' instead`)
-	}
-
-	// Quit and node drain.
+	// Quit and node drain commands.
 	for _, cmd := range []*cobra.Command{quitCmd, drainNodeCmd} {
 		f := cmd.Flags()
 		DurationFlag(f, &quitCtx.drainWait, cliflags.DrainWait, quitCtx.drainWait)

--- a/pkg/cli/quit.go
+++ b/pkg/cli/quit.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
@@ -66,19 +65,6 @@ func runQuit(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 	defer finish()
-
-	// If --decommission was passed, perform the decommission as first
-	// step. (Note that this flag is deprecated. It will be removed.)
-	if quitCtx.serverDecommission {
-		var myself []roachpb.NodeID // will remain empty, which means target yourself
-		if err := runDecommissionNodeImpl(ctx, c, nodeDecommissionWaitAll, myself); err != nil {
-			log.Warningf(ctx, "%v", err)
-			if server.IsWaitingForInit(err) {
-				err = errors.New("node cannot be decommissioned before it has been initialized")
-			}
-			return err
-		}
-	}
 
 	return drainAndShutdown(ctx, c)
 }


### PR DESCRIPTION
It was deprecated in v20.1, so can now be deleted.

Release note (cli change): The `--decommission` flag for `cockroach
quit` is now removed. It was previously deprecated in CockroachDB v20.1.
Users should be using `cockroach node decommission` instead.