### PR TITLE
sql: make pg_namespace globally visible

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -231,6 +231,21 @@ oid         nspname             nspowner  nspacl
 1841002695  pg_extension        NULL      NULL
 3426283741  public              NULL      NULL
 
+user testuser
+
+# Should be globally visible
+query OTOT colnames
+SELECT * FROM pg_catalog.pg_namespace
+----
+oid         nspname             nspowner  nspacl
+3604332469  crdb_internal       NULL      NULL
+3672231114  information_schema  NULL      NULL
+2508829085  pg_catalog          NULL      NULL
+1841002695  pg_extension        NULL      NULL
+3426283741  public              NULL      NULL
+
+user root
+
 ## pg_catalog.pg_database
 
 query OTOITTBB colnames

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1869,7 +1869,7 @@ CREATE TABLE pg_catalog.pg_namespace (
 )`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
-		return forEachDatabaseDesc(ctx, p, dbContext, true, /* requiresPrivileges */
+		return forEachDatabaseDesc(ctx, p, dbContext, false, /* requiresPrivileges */
 			func(db *sqlbase.DatabaseDescriptor) error {
 				return forEachSchemaName(ctx, p, db, func(s string) error {
 					return addRow(


### PR DESCRIPTION
fixes #49313

In Postgres, this table is world-readable, so we should match.

Release note (sql change): The pg_namespace table in pg_catalog
no longer require privileges on any database in order for the
data to be visible.
