### PR TITLE
roachtest: don't lose output in execCmd

### DIFF
--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,12 +67,62 @@ func (t testWrapper) logger() *logger {
 	return nil
 }
 
+func TestExecCmd(t *testing.T) {
+	cfg := &loggerConfig{stdout: os.Stdout, stderr: os.Stderr}
+	logger, err := cfg.newLogger("" /* path */)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run(`success`, func(t *testing.T) {
+		res := execCmdEx(context.Background(), logger, "/bin/bash", "-c", "echo guacamole")
+		require.NoError(t, res.err)
+		require.Contains(t, res.stdout, "guacamole")
+	})
+
+	t.Run(`error`, func(t *testing.T) {
+		res := execCmdEx(context.Background(), logger, "/bin/bash", "-c", "echo burrito; false")
+		require.Error(t, res.err)
+		require.Contains(t, res.stdout, "burrito")
+	})
+
+	t.Run(`returns-on-cancel`, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+		}()
+		tBegin := timeutil.Now()
+		require.Error(t, execCmd(ctx, logger, "/bin/bash", "-c", "sleep 100"))
+		if max, act := 99*time.Second, timeutil.Since(tBegin); max < act {
+			t.Fatalf("took %s despite cancellation", act)
+		}
+	})
+
+	t.Run(`returns-on-cancel-subprocess`, func(t *testing.T) {
+		// The tricky version of the preceding test. The difference is that the process
+		// spawns a stalling subprocess and then waits for it. See execCmdEx for a
+		// detailed discussion of how this is made work.
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+		}()
+		tBegin := timeutil.Now()
+		require.Error(t, execCmd(ctx, logger, "/bin/bash", "-c", "sleep 100& wait"))
+		if max, act := 99*time.Second, timeutil.Since(tBegin); max < act {
+			t.Fatalf("took %s despite cancellation", act)
+		}
+	})
+}
+
 func TestClusterMonitor(t *testing.T) {
 	cfg := &loggerConfig{stdout: os.Stdout, stderr: os.Stderr}
 	logger, err := cfg.newLogger("" /* path */)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	t.Run(`success`, func(t *testing.T) {
 		c := &cluster{t: testWrapper{t}, l: logger}
 		m := newMonitor(context.Background(), c)


### PR DESCRIPTION
There was a race in which a command would finish and execCmdEx return
before the goroutines we had spawned to collect the output in a buffer
had finished doing so.

I was able to tickle the symptoms in #48476 before this commit by
adding a strategic `Sleep(time.Second)` in said goroutines, so
relatively confident that this:

Closes #48476.

Release note: None