### PR TITLE
server: Resolve default engine type in testserver

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sqlmigrations"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -79,6 +80,10 @@ func makeTestConfig(st *cluster.Settings) Config {
 
 	// Configure test storage engine.
 	cfg.StorageEngine = storage.DefaultStorageEngine
+	// Resolve the storage engine to a specific type if it's the default value.
+	if cfg.StorageEngine == enginepb.EngineTypeDefault {
+		cfg.StorageEngine = enginepb.EngineTypePebble
+	}
 
 	// Configure the default in-memory temp storage for all tests unless
 	// otherwise configured.


### PR DESCRIPTION
Previously we weren't resolving the engine type if it was
set to EngineTypeDefault in the testserver. This would silently
resolve to Pebble (and in 20.1, rocksdb) anyway, so it was
only a concern in sentry reports where it would show up as
`default`. Since `cockroach demo` uses the test server and
has sentry reports enabled, that was an oversight.

Release note (bug fix): Report engine type correctly in bug reports
when using `cockroach demo`.