### PR TITLE
backport-20.1: idalloc: assert against counter regressions

### DIFF
--- a/pkg/kv/kvserver/idalloc/helpers_test.go
+++ b/pkg/kv/kvserver/idalloc/helpers_test.go
@@ -11,6 +11,6 @@
 package idalloc
 
 // IDs returns the channel that the allocator uses to buffer available ids.
-func (ia *Allocator) IDs() <-chan uint32 {
+func (ia *Allocator) IDs() <-chan int64 {
 	return ia.ids
 }

--- a/pkg/kv/kvserver/idalloc/helpers_test.go
+++ b/pkg/kv/kvserver/idalloc/helpers_test.go
@@ -10,13 +10,6 @@
 
 package idalloc
 
-import "github.com/cockroachdb/cockroach/pkg/roachpb"
-
-// SetIDKey sets the key which the allocator increments.
-func (ia *Allocator) SetIDKey(idKey roachpb.Key) {
-	ia.idKey.Store(idKey)
-}
-
 // IDs returns the channel that the allocator uses to buffer available ids.
 func (ia *Allocator) IDs() <-chan uint32 {
 	return ia.ids

--- a/pkg/kv/kvserver/idalloc/id_alloc.go
+++ b/pkg/kv/kvserver/idalloc/id_alloc.go
@@ -12,7 +12,6 @@ package idalloc
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -23,6 +22,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/pkg/errors"
 )
+
+// Incrementer abstracts over the database which holds the key counter.
+type Incrementer func(_ context.Context, _ roachpb.Key, inc int64) (updated int64, _ error)
 
 // DBIncrementer wraps a suitable subset of *kv.DB for use with an allocator.
 func DBIncrementer(
@@ -39,16 +41,14 @@ func DBIncrementer(
 	}
 }
 
-// Incrementer abstracts over the database which holds the key counter.
-type Incrementer func(_ context.Context, _ roachpb.Key, inc int64) (new int64, _ error)
-
 // Options are the options passed to NewAllocator.
 type Options struct {
 	AmbientCtx  log.AmbientContext
 	Key         roachpb.Key
 	Incrementer Incrementer
-	BlockSize   uint32
+	BlockSize   int64
 	Stopper     *stop.Stopper
+	Fatalf      func(context.Context, string, ...interface{}) // defaults to log.Fatalf
 }
 
 // An Allocator is used to increment a key in allocation blocks of arbitrary
@@ -57,7 +57,7 @@ type Allocator struct {
 	log.AmbientContext
 	opts Options
 
-	ids  chan uint32 // Channel of available IDs
+	ids  chan int64 // Channel of available IDs
 	once sync.Once
 }
 
@@ -70,16 +70,19 @@ func NewAllocator(opts Options) (*Allocator, error) {
 	if opts.BlockSize == 0 {
 		return nil, errors.Errorf("blockSize must be a positive integer: %d", opts.BlockSize)
 	}
+	if opts.Fatalf == nil {
+		opts.Fatalf = log.Fatalf
+	}
 	opts.AmbientCtx.AddLogTag("idalloc", nil)
 	return &Allocator{
 		AmbientContext: opts.AmbientCtx,
 		opts:           opts,
-		ids:            make(chan uint32, opts.BlockSize/2+1),
+		ids:            make(chan int64, opts.BlockSize/2+1),
 	}, nil
 }
 
 // Allocate allocates a new ID from the global KV DB.
-func (ia *Allocator) Allocate(ctx context.Context) (uint32, error) {
+func (ia *Allocator) Allocate(ctx context.Context) (int64, error) {
 	ia.once.Do(ia.start)
 
 	select {
@@ -99,13 +102,14 @@ func (ia *Allocator) start() {
 	ia.opts.Stopper.RunWorker(ctx, func(ctx context.Context) {
 		defer close(ia.ids)
 
+		var prevValue int64 // for assertions
 		for {
 			var newValue int64
 			var err error
 			for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
 				if stopperErr := ia.opts.Stopper.RunTask(ctx, "idalloc: allocating block",
 					func(ctx context.Context) {
-						newValue, err = ia.opts.Incrementer(ctx, ia.opts.Key, int64(ia.opts.BlockSize))
+						newValue, err = ia.opts.Incrementer(ctx, ia.opts.Key, ia.opts.BlockSize)
 					}); stopperErr != nil {
 					return
 				}
@@ -122,19 +126,30 @@ func (ia *Allocator) start() {
 				)
 			}
 			if err != nil {
-				panic(fmt.Sprintf("unexpectedly exited id allocation retry loop: %s", err))
+				ia.opts.Fatalf(ctx, "unexpectedly exited id allocation retry loop: %s", err)
+				return
+			}
+			if prevValue != 0 && newValue < prevValue+ia.opts.BlockSize {
+				ia.opts.Fatalf(
+					ctx,
+					"counter corrupt: incremented to %d, expected at least %d + %d",
+					newValue, prevValue, ia.opts.BlockSize,
+				)
+				return
 			}
 
 			end := newValue + 1
-			start := end - int64(ia.opts.BlockSize)
+			start := end - ia.opts.BlockSize
 			if start <= 0 {
-				log.Fatalf(ctx, "allocator initialized with negative key")
+				ia.opts.Fatalf(ctx, "allocator initialized with negative key")
+				return
 			}
+			prevValue = newValue
 
 			// Add all new ids to the channel for consumption.
 			for i := start; i < end; i++ {
 				select {
-				case ia.ids <- uint32(i):
+				case ia.ids <- i:
 				case <-ia.opts.Stopper.ShouldStop():
 					return
 				}

--- a/pkg/kv/kvserver/idalloc/id_alloc.go
+++ b/pkg/kv/kvserver/idalloc/id_alloc.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -25,20 +24,41 @@ import (
 	"github.com/pkg/errors"
 )
 
-// An Allocator is used to increment a key in allocation blocks
-// of arbitrary size.
-//
-// Note: if all you want is to increment a key and retry on retryable errors,
-// see client.IncrementValRetryable().
+// DBIncrementer wraps a suitable subset of *kv.DB for use with an allocator.
+func DBIncrementer(
+	db interface {
+		Inc(ctx context.Context, key interface{}, value int64) (kv.KeyValue, error)
+	},
+) Incrementer {
+	return func(ctx context.Context, key roachpb.Key, inc int64) (int64, error) {
+		res, err := db.Inc(ctx, key, inc)
+		if err != nil {
+			return 0, err
+		}
+		return res.Value.GetInt()
+	}
+}
+
+// Incrementer abstracts over the database which holds the key counter.
+type Incrementer func(_ context.Context, _ roachpb.Key, inc int64) (new int64, _ error)
+
+// Options are the options passed to NewAllocator.
+type Options struct {
+	AmbientCtx  log.AmbientContext
+	Key         roachpb.Key
+	Incrementer Incrementer
+	BlockSize   uint32
+	Stopper     *stop.Stopper
+}
+
+// An Allocator is used to increment a key in allocation blocks of arbitrary
+// size.
 type Allocator struct {
 	log.AmbientContext
+	opts Options
 
-	idKey     atomic.Value
-	db        *kv.DB
-	blockSize uint32      // Block allocation size
-	ids       chan uint32 // Channel of available IDs
-	stopper   *stop.Stopper
-	once      sync.Once
+	ids  chan uint32 // Channel of available IDs
+	once sync.Once
 }
 
 // NewAllocator creates a new ID allocator which increments the specified key in
@@ -46,22 +66,16 @@ type Allocator struct {
 // an int value (and it needs to be positive since id 0 is a sentinel used
 // internally by the allocator that can't be generated). The first value
 // returned is the existing value + 1, or 1 if the key did not previously exist.
-func NewAllocator(
-	ambient log.AmbientContext, idKey roachpb.Key, db *kv.DB, blockSize uint32, stopper *stop.Stopper,
-) (*Allocator, error) {
-	if blockSize == 0 {
-		return nil, errors.Errorf("blockSize must be a positive integer: %d", blockSize)
+func NewAllocator(opts Options) (*Allocator, error) {
+	if opts.BlockSize == 0 {
+		return nil, errors.Errorf("blockSize must be a positive integer: %d", opts.BlockSize)
 	}
-	ia := &Allocator{
-		AmbientContext: ambient,
-		db:             db,
-		blockSize:      blockSize,
-		ids:            make(chan uint32, blockSize/2+1),
-		stopper:        stopper,
-	}
-	ia.idKey.Store(idKey)
-
-	return ia, nil
+	opts.AmbientCtx.AddLogTag("idalloc", nil)
+	return &Allocator{
+		AmbientContext: opts.AmbientCtx,
+		opts:           opts,
+		ids:            make(chan uint32, opts.BlockSize/2+1),
+	}, nil
 }
 
 // Allocate allocates a new ID from the global KV DB.
@@ -82,34 +96,37 @@ func (ia *Allocator) Allocate(ctx context.Context) (uint32, error) {
 
 func (ia *Allocator) start() {
 	ctx := ia.AnnotateCtx(context.Background())
-	ia.stopper.RunWorker(ctx, func(ctx context.Context) {
+	ia.opts.Stopper.RunWorker(ctx, func(ctx context.Context) {
 		defer close(ia.ids)
 
 		for {
 			var newValue int64
 			var err error
-			var res kv.KeyValue
 			for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
-				idKey := ia.idKey.Load().(roachpb.Key)
-				if err := ia.stopper.RunTask(ctx, "storage.Allocator: allocating block", func(ctx context.Context) {
-					res, err = ia.db.Inc(ctx, idKey, int64(ia.blockSize))
-				}); err != nil {
-					log.Warning(ctx, err)
+				if stopperErr := ia.opts.Stopper.RunTask(ctx, "idalloc: allocating block",
+					func(ctx context.Context) {
+						newValue, err = ia.opts.Incrementer(ctx, ia.opts.Key, int64(ia.opts.BlockSize))
+					}); stopperErr != nil {
 					return
 				}
 				if err == nil {
-					newValue = res.ValueInt()
 					break
 				}
 
-				log.Warningf(ctx, "unable to allocate %d ids from %s: %+v", ia.blockSize, idKey, err)
+				log.Warningf(
+					ctx,
+					"unable to allocate %d ids from %s: %+v",
+					ia.opts.BlockSize,
+					ia.opts.Key,
+					err,
+				)
 			}
 			if err != nil {
 				panic(fmt.Sprintf("unexpectedly exited id allocation retry loop: %s", err))
 			}
 
 			end := newValue + 1
-			start := end - int64(ia.blockSize)
+			start := end - int64(ia.opts.BlockSize)
 			if start <= 0 {
 				log.Fatalf(ctx, "allocator initialized with negative key")
 			}
@@ -118,7 +135,7 @@ func (ia *Allocator) start() {
 			for i := start; i < end; i++ {
 				select {
 				case ia.ids <- uint32(i):
-				case <-ia.stopper.ShouldStop():
+				case <-ia.opts.Stopper.ShouldStop():
 					return
 				}
 			}

--- a/pkg/kv/kvserver/idalloc/id_alloc_test.go
+++ b/pkg/kv/kvserver/idalloc/id_alloc_test.go
@@ -12,8 +12,8 @@ package idalloc_test
 
 import (
 	"context"
+	"fmt"
 	"sort"
-	"sync"
 	"testing"
 	"time"
 
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/localtestcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -66,7 +67,7 @@ func TestIDAllocator(t *testing.T) {
 	defer s.Stop()
 
 	const maxI, maxJ = 10, 10
-	allocd := make(chan uint32, maxI*maxJ)
+	allocd := make(chan int64, maxI*maxJ)
 	errChan := make(chan error, maxI*maxJ)
 
 	for i := 0; i < maxI; i++ {
@@ -125,7 +126,7 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 	ctx := context.Background()
 
 	var mu struct {
-		sync.Mutex
+		syncutil.Mutex
 		err     error
 		counter int64
 	}
@@ -148,9 +149,10 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 		BlockSize:   10,
 		Stopper:     s,
 	})
+	require.NoError(t, err)
 
 	const routines = 10
-	allocd := make(chan uint32, routines)
+	allocd := make(chan int64, routines)
 
 	firstID, err := idAlloc.Allocate(ctx)
 	require.NoError(t, err)
@@ -237,5 +239,69 @@ func TestAllocateWithStopper(t *testing.T) {
 
 	if _, err := idAlloc.Allocate(context.Background()); !testutils.IsError(err, "system is draining") {
 		t.Errorf("unexpected error: %+v", err)
+	}
+}
+
+// TestLostWriteAssertion makes sure that the Allocator performs a best-effort
+// detection of counter regressions.
+func TestLostWriteAssertion(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	s := stop.NewStopper()
+	defer s.Stop(ctx)
+
+	var mu struct {
+		syncutil.Mutex
+		counter int64
+		fatal   string
+	}
+
+	inc := func(_ context.Context, _ roachpb.Key, inc int64) (new int64, _ error) {
+		mu.Lock()
+		defer mu.Unlock()
+		mu.counter += inc
+		return mu.counter, nil
+	}
+
+	opts := idalloc.Options{
+		Key:         roachpb.Key("foo"),
+		Incrementer: inc,
+		BlockSize:   10,
+		Stopper:     s,
+		Fatalf: func(_ context.Context, format string, args ...interface{}) {
+			mu.Lock()
+			defer mu.Unlock()
+			mu.fatal = fmt.Sprintf(format, args...)
+		},
+	}
+	a, err := idalloc.NewAllocator(opts)
+	require.NoError(t, err)
+
+	// Trigger first allocation.
+	{
+		n, err := a.Allocate(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, n)
+	}
+
+	// Mess with the counter.
+	mu.Lock()
+	mu.counter--
+	mu.Unlock()
+
+	for i := 0; ; i++ {
+		n, err := a.Allocate(ctx)
+		if err != nil {
+			mu.Lock()
+			msg := mu.fatal
+			mu.Unlock()
+			require.Contains(t, msg, "counter corrupt")
+			break
+		}
+		require.EqualValues(t, 2+i, n)
+		if i > 10*int(opts.BlockSize) {
+			t.Fatal("unexpected infinite loop")
+		}
 	}
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1378,9 +1378,13 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	}
 
 	// Create ID allocators.
-	idAlloc, err := idalloc.NewAllocator(
-		s.cfg.AmbientCtx, keys.RangeIDGenerator, s.db, rangeIDAllocCount, s.stopper,
-	)
+	idAlloc, err := idalloc.NewAllocator(idalloc.Options{
+		AmbientCtx:  s.cfg.AmbientCtx,
+		Key:         keys.RangeIDGenerator,
+		Incrementer: idalloc.DBIncrementer(s.db),
+		BlockSize:   rangeIDAllocCount,
+		Stopper:     s.stopper,
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Backport 3/3 commits from #48526.

/cc @cockroachdb/release

---

Touches #48485.

Release note: None
