### PR TITLE
backport-19.2: idalloc: assert against counter regressions

### DIFF
--- a/pkg/storage/idalloc/helpers_test.go
+++ b/pkg/storage/idalloc/helpers_test.go
@@ -11,6 +11,6 @@
 package idalloc
 
 // IDs returns the channel that the allocator uses to buffer available ids.
-func (ia *Allocator) IDs() <-chan uint32 {
+func (ia *Allocator) IDs() <-chan int64 {
 	return ia.ids
 }

--- a/pkg/storage/idalloc/helpers_test.go
+++ b/pkg/storage/idalloc/helpers_test.go
@@ -10,13 +10,6 @@
 
 package idalloc
 
-import "github.com/cockroachdb/cockroach/pkg/roachpb"
-
-// SetIDKey sets the key which the allocator increments.
-func (ia *Allocator) SetIDKey(idKey roachpb.Key) {
-	ia.idKey.Store(idKey)
-}
-
 // IDs returns the channel that the allocator uses to buffer available ids.
 func (ia *Allocator) IDs() <-chan uint32 {
 	return ia.ids

--- a/pkg/storage/idalloc/id_alloc.go
+++ b/pkg/storage/idalloc/id_alloc.go
@@ -12,7 +12,6 @@ package idalloc
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -23,6 +22,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/pkg/errors"
 )
+
+// Incrementer abstracts over the database which holds the key counter.
+type Incrementer func(_ context.Context, _ roachpb.Key, inc int64) (updated int64, _ error)
 
 // DBIncrementer wraps a suitable subset of *kv.DB for use with an allocator.
 func DBIncrementer(
@@ -39,16 +41,14 @@ func DBIncrementer(
 	}
 }
 
-// Incrementer abstracts over the database which holds the key counter.
-type Incrementer func(_ context.Context, _ roachpb.Key, inc int64) (new int64, _ error)
-
 // Options are the options passed to NewAllocator.
 type Options struct {
 	AmbientCtx  log.AmbientContext
 	Key         roachpb.Key
 	Incrementer Incrementer
-	BlockSize   uint32
+	BlockSize   int64
 	Stopper     *stop.Stopper
+	Fatalf      func(context.Context, string, ...interface{}) // defaults to log.Fatalf
 }
 
 // An Allocator is used to increment a key in allocation blocks of arbitrary
@@ -57,7 +57,7 @@ type Allocator struct {
 	log.AmbientContext
 	opts Options
 
-	ids  chan uint32 // Channel of available IDs
+	ids  chan int64 // Channel of available IDs
 	once sync.Once
 }
 
@@ -70,16 +70,19 @@ func NewAllocator(opts Options) (*Allocator, error) {
 	if opts.BlockSize == 0 {
 		return nil, errors.Errorf("blockSize must be a positive integer: %d", opts.BlockSize)
 	}
+	if opts.Fatalf == nil {
+		opts.Fatalf = log.Fatalf
+	}
 	opts.AmbientCtx.AddLogTag("idalloc", nil)
 	return &Allocator{
 		AmbientContext: opts.AmbientCtx,
 		opts:           opts,
-		ids:            make(chan uint32, opts.BlockSize/2+1),
+		ids:            make(chan int64, opts.BlockSize/2+1),
 	}, nil
 }
 
 // Allocate allocates a new ID from the global KV DB.
-func (ia *Allocator) Allocate(ctx context.Context) (uint32, error) {
+func (ia *Allocator) Allocate(ctx context.Context) (int64, error) {
 	ia.once.Do(ia.start)
 
 	select {
@@ -99,13 +102,14 @@ func (ia *Allocator) start() {
 	ia.opts.Stopper.RunWorker(ctx, func(ctx context.Context) {
 		defer close(ia.ids)
 
+		var prevValue int64 // for assertions
 		for {
 			var newValue int64
 			var err error
 			for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
 				if stopperErr := ia.opts.Stopper.RunTask(ctx, "idalloc: allocating block",
 					func(ctx context.Context) {
-						newValue, err = ia.opts.Incrementer(ctx, ia.opts.Key, int64(ia.opts.BlockSize))
+						newValue, err = ia.opts.Incrementer(ctx, ia.opts.Key, ia.opts.BlockSize)
 					}); stopperErr != nil {
 					return
 				}
@@ -122,19 +126,30 @@ func (ia *Allocator) start() {
 				)
 			}
 			if err != nil {
-				panic(fmt.Sprintf("unexpectedly exited id allocation retry loop: %s", err))
+				ia.opts.Fatalf(ctx, "unexpectedly exited id allocation retry loop: %s", err)
+				return
+			}
+			if prevValue != 0 && newValue < prevValue+ia.opts.BlockSize {
+				ia.opts.Fatalf(
+					ctx,
+					"counter corrupt: incremented to %d, expected at least %d + %d",
+					newValue, prevValue, ia.opts.BlockSize,
+				)
+				return
 			}
 
 			end := newValue + 1
-			start := end - int64(ia.opts.BlockSize)
+			start := end - ia.opts.BlockSize
 			if start <= 0 {
-				log.Fatalf(ctx, "allocator initialized with negative key")
+				ia.opts.Fatalf(ctx, "allocator initialized with negative key")
+				return
 			}
+			prevValue = newValue
 
 			// Add all new ids to the channel for consumption.
 			for i := start; i < end; i++ {
 				select {
-				case ia.ids <- uint32(i):
+				case ia.ids <- i:
 				case <-ia.opts.Stopper.ShouldStop():
 					return
 				}

--- a/pkg/storage/idalloc/id_alloc_test.go
+++ b/pkg/storage/idalloc/id_alloc_test.go
@@ -13,6 +13,7 @@ package idalloc_test
 import (
 	"context"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -25,9 +26,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/localtestcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 )
 
 // newTestAllocator creates and returns a new idalloc.Allocator, backed by a
@@ -39,13 +40,13 @@ func newTestAllocator(t testing.TB) (*localtestcluster.LocalTestCluster, *idallo
 		DontCreateSystemRanges:   true,
 	}
 	s.Start(t, testutils.NewNodeTestBaseContext(), kv.InitFactoryForLocalTestCluster)
-	idAlloc, err := idalloc.NewAllocator(
-		s.Cfg.AmbientCtx,
-		keys.RangeIDGenerator,
-		s.DB,
-		10, /* blockSize */
-		s.Stopper,
-	)
+	idAlloc, err := idalloc.NewAllocator(idalloc.Options{
+		AmbientCtx:  s.Cfg.AmbientCtx,
+		Key:         keys.RangeIDGenerator,
+		Incrementer: idalloc.DBIncrementer(s.DB),
+		BlockSize:   10, /* blockSize */
+		Stopper:     s.Stopper,
+	})
 	if err != nil {
 		s.Stop()
 		t.Errorf("failed to create idAllocator: %+v", err)
@@ -105,11 +106,9 @@ func TestIDAllocator(t *testing.T) {
 func TestNewAllocatorInvalidBlockSize(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	expErr := "blockSize must be a positive integer"
-	if _, err := idalloc.NewAllocator(
-		log.AmbientContext{Tracer: tracing.NewTracer()},
-		nil /* idKey */, nil, /* db */
-		0 /* blockSize */, nil, /* stopper */
-	); !testutils.IsError(err, expErr) {
+	if _, err := idalloc.NewAllocator(idalloc.Options{
+		BlockSize: 0,
+	}); !testutils.IsError(err, expErr) {
 		t.Errorf("expected err: %s, got: %+v", expErr, err)
 	}
 }
@@ -122,34 +121,53 @@ func TestNewAllocatorInvalidBlockSize(t *testing.T) {
 // 5) Check if the following allocations return correctly.
 func TestAllocateErrorAndRecovery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s, idAlloc := newTestAllocator(t)
-	defer s.Stop()
+
 	ctx := context.Background()
+
+	var mu struct {
+		sync.Mutex
+		err     error
+		counter int64
+	}
+	inc := func(_ context.Context, _ roachpb.Key, inc int64) (new int64, _ error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if mu.err != nil {
+			return 0, mu.err
+		}
+		mu.counter += inc
+		return mu.counter, nil
+	}
+
+	s := stop.NewStopper()
+	defer s.Stop(ctx)
+
+	idAlloc, err := idalloc.NewAllocator(idalloc.Options{
+		Key:         roachpb.Key("foo"),
+		Incrementer: inc,
+		BlockSize:   10,
+		Stopper:     s,
+	})
 
 	const routines = 10
 	allocd := make(chan uint32, routines)
 
 	firstID, err := idAlloc.Allocate(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if firstID != 2 {
-		t.Fatalf("expected ID is 2, but got: %d", firstID)
-	}
+	require.NoError(t, err)
+
+	require.EqualValues(t, 1, firstID)
 
 	// Make Allocator invalid.
-	idAlloc.SetIDKey(roachpb.KeyMin)
+	mu.Lock()
+	mu.err = errors.New("boom")
+	mu.Unlock()
 
 	// Should be able to get the allocated IDs, and there will be one
 	// background Allocate to get ID continuously.
 	for i := 0; i < 9; i++ {
 		id, err := idAlloc.Allocate(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if int(id) != i+3 {
-			t.Fatalf("expected ID is %d, but got: %d", i+3, id)
-		}
+		require.NoError(t, err)
+		require.EqualValues(t, i+2, id)
 	}
 
 	errChan := make(chan error, routines)
@@ -173,9 +191,7 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 
 	// Wait until all the allocations are blocked.
 	for i := 0; i < routines; i++ {
-		if err := <-errChan; err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, <-errChan)
 	}
 
 	// Attempt a few allocations with a context timeout while allocations are
@@ -190,31 +206,26 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 	}
 
 	// Make the IDAllocator valid again.
-	idAlloc.SetIDKey(keys.RangeIDGenerator)
+	mu.Lock()
+	mu.err = nil
+	mu.Unlock()
+
 	// Check if the blocked allocations return expected ID.
 	ids := make([]int, routines)
 	for i := range ids {
 		ids[i] = int(<-allocd)
-		if err := <-errChan; err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, <-errChan)
 	}
 	sort.Ints(ids)
 	for i := range ids {
-		if ids[i] != i+12 {
-			t.Errorf("expected \"%d\"th ID to be %d; got %d", i, i+12, ids[i])
-		}
+		require.EqualValues(t, i+11, ids[i], "i=%d", i)
 	}
 
 	// Check if the following allocations return expected ID.
 	for i := 0; i < routines; i++ {
 		id, err := idAlloc.Allocate(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		if int(id) != i+22 {
-			t.Errorf("expected ID is %d, but got: %d", i+22, id)
-		}
+		require.NoError(t, err)
+		require.EqualValues(t, i+21, id, "i=%d", i)
 	}
 }
 

--- a/pkg/storage/idalloc/id_alloc_test.go
+++ b/pkg/storage/idalloc/id_alloc_test.go
@@ -12,8 +12,8 @@ package idalloc_test
 
 import (
 	"context"
+	"fmt"
 	"sort"
-	"sync"
 	"testing"
 	"time"
 
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/localtestcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -66,7 +67,7 @@ func TestIDAllocator(t *testing.T) {
 	defer s.Stop()
 
 	const maxI, maxJ = 10, 10
-	allocd := make(chan uint32, maxI*maxJ)
+	allocd := make(chan int64, maxI*maxJ)
 	errChan := make(chan error, maxI*maxJ)
 
 	for i := 0; i < maxI; i++ {
@@ -125,7 +126,7 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 	ctx := context.Background()
 
 	var mu struct {
-		sync.Mutex
+		syncutil.Mutex
 		err     error
 		counter int64
 	}
@@ -148,9 +149,10 @@ func TestAllocateErrorAndRecovery(t *testing.T) {
 		BlockSize:   10,
 		Stopper:     s,
 	})
+	require.NoError(t, err)
 
 	const routines = 10
-	allocd := make(chan uint32, routines)
+	allocd := make(chan int64, routines)
 
 	firstID, err := idAlloc.Allocate(ctx)
 	require.NoError(t, err)
@@ -237,5 +239,69 @@ func TestAllocateWithStopper(t *testing.T) {
 
 	if _, err := idAlloc.Allocate(context.Background()); !testutils.IsError(err, "system is draining") {
 		t.Errorf("unexpected error: %+v", err)
+	}
+}
+
+// TestLostWriteAssertion makes sure that the Allocator performs a best-effort
+// detection of counter regressions.
+func TestLostWriteAssertion(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	s := stop.NewStopper()
+	defer s.Stop(ctx)
+
+	var mu struct {
+		syncutil.Mutex
+		counter int64
+		fatal   string
+	}
+
+	inc := func(_ context.Context, _ roachpb.Key, inc int64) (new int64, _ error) {
+		mu.Lock()
+		defer mu.Unlock()
+		mu.counter += inc
+		return mu.counter, nil
+	}
+
+	opts := idalloc.Options{
+		Key:         roachpb.Key("foo"),
+		Incrementer: inc,
+		BlockSize:   10,
+		Stopper:     s,
+		Fatalf: func(_ context.Context, format string, args ...interface{}) {
+			mu.Lock()
+			defer mu.Unlock()
+			mu.fatal = fmt.Sprintf(format, args...)
+		},
+	}
+	a, err := idalloc.NewAllocator(opts)
+	require.NoError(t, err)
+
+	// Trigger first allocation.
+	{
+		n, err := a.Allocate(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, n)
+	}
+
+	// Mess with the counter.
+	mu.Lock()
+	mu.counter--
+	mu.Unlock()
+
+	for i := 0; ; i++ {
+		n, err := a.Allocate(ctx)
+		if err != nil {
+			mu.Lock()
+			msg := mu.fatal
+			mu.Unlock()
+			require.Contains(t, msg, "counter corrupt")
+			break
+		}
+		require.EqualValues(t, 2+i, n)
+		if i > 10*int(opts.BlockSize) {
+			t.Fatal("unexpected infinite loop")
+		}
 	}
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1375,9 +1375,13 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	}
 
 	// Create ID allocators.
-	idAlloc, err := idalloc.NewAllocator(
-		s.cfg.AmbientCtx, keys.RangeIDGenerator, s.db, rangeIDAllocCount, s.stopper,
-	)
+	idAlloc, err := idalloc.NewAllocator(idalloc.Options{
+		AmbientCtx:  s.cfg.AmbientCtx,
+		Key:         keys.RangeIDGenerator,
+		Incrementer: idalloc.DBIncrementer(s.db),
+		BlockSize:   rangeIDAllocCount,
+		Stopper:     s.stopper,
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Backport 3/3 commits from #48526.

/cc @cockroachdb/release

---

Touches #48485.

Release note: None
