### PR TITLE
sql: populate rolcanlogin correctly in vtables pg_roles and pg_catalog

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1769,12 +1769,28 @@ func forEachColumnInIndex(
 }
 
 func forEachRole(
-	ctx context.Context, p *planner, fn func(username string, isRole bool) error,
+	ctx context.Context, p *planner, fn func(username string, isRole bool, noLogin bool) error,
 ) error {
-	query := `SELECT username, "isRole" FROM system.users`
+	query := `
+SELECT
+	username,
+	"isRole",
+	EXISTS(
+		SELECT
+			option
+		FROM
+			system.role_options AS r
+		WHERE
+			r.username = u.username AND option = 'NOLOGIN'
+	)
+		AS nologin
+FROM
+	system.users AS u;
+`
 	rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.Query(
 		ctx, "read-roles", p.txn, query,
 	)
+
 	if err != nil {
 		return err
 	}
@@ -1785,11 +1801,15 @@ func forEachRole(
 		if !ok {
 			return errors.Errorf("isRole should be a boolean value, found %s instead", row[1].ResolvedType())
 		}
-
-		if err := fn(string(username), bool(*isRole)); err != nil {
+		noLogin, ok := row[2].(*tree.DBool)
+		if !ok {
+			return errors.Errorf("noLogin should be a boolean value, found %s instead", row[1].ResolvedType())
+		}
+		if err := fn(string(username), bool(*isRole), bool(*noLogin)); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1475,7 +1475,7 @@ FROM pg_catalog.pg_roles
 ORDER BY rolname
 ----
 oid         rolname   rolsuper  rolinherit  rolcreaterole  rolcreatedb  rolcatupdate  rolcanlogin  rolreplication
-2310524507  admin     true      true        true           true         false         false        false
+2310524507  admin     true      true        true           true         false         true         false
 1546506610  root      true      false       true           true         false         true         false
 2264919399  testuser  false     false       false          false        false         true         false
 
@@ -2425,3 +2425,18 @@ SELECT a, oid, relname FROM jt LEFT OUTER LOOKUP JOIN pg_class ON a::oid=oid
 ----
 1   NULL  NULL
 88  88    jt
+
+subtest regression_49207
+statement ok
+CREATE ROLE role_test_login with LOGIN;
+CREATE ROLE role_test_nologin;
+
+query B
+SELECT rolcanlogin FROM pg_roles WHERE rolname = 'role_test_login';
+----
+true
+
+query B
+SELECT rolcanlogin FROM pg_roles WHERE rolname = 'role_test_nologin';
+----
+false


### PR DESCRIPTION
Fixes #49207

Previously, the `rolcanlogin` value was being populated incorrectly by assuming roles cannot login and users can login. Recent changes allow both roles and users to login.

Release note (sql change): Correctly populate rolcanlogin value for roles
in pg_roles and pg_catalog.