### PR TITLE
release-20.1: cli/demo: fix \demo node restart

### DIFF
--- a/pkg/cli/demo_test.go
+++ b/pkg/cli/demo_test.go
@@ -42,6 +42,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 				DisableTLSForHTTP: true,
 				SQLMemoryPoolSize: 2 << 10,
 				CacheSize:         1 << 10,
+				Insecure:          true,
 			},
 		},
 		{
@@ -55,6 +56,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 				DisableTLSForHTTP: true,
 				SQLMemoryPoolSize: 4 << 10,
 				CacheSize:         4 << 10,
+				Insecure:          true,
 			},
 		},
 	}
@@ -64,7 +66,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 		demoCtx.sqlPoolMemorySize = tc.sqlPoolMemorySize
 		demoCtx.cacheSize = tc.cacheSize
 
-		actual := testServerArgsForTransientCluster(unixSocketDetails{}, tc.nodeID, tc.joinAddr)
+		actual := testServerArgsForTransientCluster(unixSocketDetails{}, tc.nodeID, tc.joinAddr, "")
 
 		assert.Len(t, actual.StoreSpecs, 1)
 		assert.Equal(

--- a/pkg/cli/interactive_tests/test_demo_node_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_demo_node_cmds.tcl
@@ -1,7 +1,5 @@
 #! /usr/bin/env expect -f
 
-# disabled until solution found in #42634
-
 source [file join [file dirname $argv0] common.tcl]
 
 start_test "Check \\demo commands work as expected"
@@ -12,8 +10,8 @@ spawn $argv demo movr --nodes=5
 eexpect "movr>"
 
 # Wrong number of args
-send "\\demo\r"
-eexpect "Usage:"
+send "\\demo node\r"
+eexpect "\\demo expects 2 parameters"
 
 # Cannot shutdown node 1
 send "\\demo shutdown 1\r"


### PR DESCRIPTION
Backport 1/1 commits from #49382.

/cc @cockroachdb/release

---

Also re-enabled the tcl test, as TLS 1.3 has been disabled.

Resolves #49381

Release note (bug fix): Fixed a bug where `\demo node restart` would not
work due to an invalid certificate directory.
