### PR TITLE
server: fix bug where SQL stats were not flushed into reportable stats

### DIFF
--- a/pkg/server/stats_test.go
+++ b/pkg/server/stats_test.go
@@ -14,12 +14,18 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 )
 
 func TestTelemetrySQLStatsIndependence(t *testing.T) {
@@ -67,6 +73,62 @@ CREATE TABLE t.test (x INT PRIMARY KEY);
 	if !foundStat {
 		t.Fatal("expected to find stats for insert query, but didn't")
 	}
+}
+
+func TestEnsureSQLStatsAreFlushedForTelemetry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	params, _ := tests.CreateTestServerParams()
+	params.Settings = cluster.MakeClusterSettings()
+	// Set the SQL stat refresh rate very low so that SQL stats are continuously
+	// flushed into the telemetry reporting stats pool.
+	sql.SQLStatReset.Override(&params.Settings.SV, 10*time.Millisecond)
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	// Run some queries against the database.
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (x INT PRIMARY KEY);
+INSERT INTO t.test VALUES (1);
+INSERT INTO t.test VALUES (2);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	statusServer := s.(*TestServer).status
+	sqlServer := s.(*TestServer).Server.sqlServer.pgServer.SQLServer
+	testutils.SucceedsSoon(t, func() error {
+		// Get the diagnostic info.
+		res, err := statusServer.Diagnostics(ctx, &serverpb.DiagnosticsRequest{NodeId: "local"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		found := false
+		for _, stat := range res.SqlStats {
+			// These stats are scrubbed, so look for our scrubbed statement.
+			if strings.HasPrefix(stat.Key.Query, "INSERT INTO _ VALUES (_)") {
+				found = true
+			}
+		}
+
+		if !found {
+			return errors.New("expected to find query stats, but didn't")
+		}
+
+		// We should also not find the stat in the SQL stats pool, since the SQL
+		// stats are getting flushed.
+		stats := sqlServer.GetScrubbedStmtStats()
+		for _, stat := range stats {
+			// These stats are scrubbed, so look for our scrubbed statement.
+			if strings.HasPrefix(stat.Key.Query, "INSERT INTO _ VALUES (_)") {
+				t.Error("expected to not find stat, but did")
+			}
+		}
+		return nil
+	})
 }
 
 func TestSQLStatCollection(t *testing.T) {


### PR DESCRIPTION
Touches #49388.

This was caused by the background loops use an incorrect setup to reset
collected stats.

Also, fix a bug where statements issued at the same time that the SQL
stats are flushed would not be reported.

Release note: None