### PR TITLE
util/log: fix missing tags in Sentry reports

### DIFF
--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -304,11 +304,14 @@ func ReportOrPanic(
 	sendCrashReport(ctx, sv, err, ReportTypeError)
 }
 
-const maxTagLen = 500
+// Sentry max tag value length.
+// From: https://github.com/getsentry/sentry-docs/pull/1304/files
+const maxTagLen = 200
 
 func maybeTruncate(tagValue string) string {
 	if len(tagValue) > maxTagLen {
-		return tagValue[:maxTagLen] + " [...]"
+		const truncatedSuffix = " [...]"
+		return tagValue[:maxTagLen-len(truncatedSuffix)] + truncatedSuffix
 	}
 	return tagValue
 }


### PR DESCRIPTION
The "current statement" tag was often found missing.
Turns out the limit Sentry-side is 200 characters,
and we only truncated at 500.

Release note: None