### PR TITLE
sql: unskip TestTruncateWhileColumnBackfill and fix validation of check constraints 

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -628,6 +628,11 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 func TestDropWhileBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	defer func(oldInterval time.Duration) {
+		jobs.DefaultAdoptInterval = oldInterval
+	}(jobs.DefaultAdoptInterval)
+	jobs.DefaultAdoptInterval = 50 * time.Millisecond
+
 	// protects backfillNotification
 	var mu syncutil.Mutex
 	backfillNotification := make(chan struct{})
@@ -4120,28 +4125,28 @@ func TestTruncateWhileColumnBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 43990)
+	defer func(oldInterval time.Duration) {
+		jobs.DefaultAdoptInterval = oldInterval
+	}(jobs.DefaultAdoptInterval)
+	jobs.DefaultAdoptInterval = 50 * time.Millisecond
 
 	backfillNotification := make(chan struct{})
 	backfillCount := int64(0)
 	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
-		// Runs schema changes asynchronously.
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
-			// TODO (lucy): if/when this test gets reinstated, figure out what knobs are
-			// needed.
+			BackfillChunkSize: 100,
 		},
 		DistSQL: &execinfra.TestingKnobs{
 			RunBeforeBackfillChunk: func(sp roachpb.Span) error {
 				switch atomic.LoadInt64(&backfillCount) {
-				case 3:
+				case 2:
 					// Notify in the middle of a backfill.
 					if backfillNotification != nil {
 						close(backfillNotification)
 						backfillNotification = nil
 					}
-					// Never complete the backfill.
-					return context.DeadlineExceeded
+					return nil
 				default:
 					atomic.AddInt64(&backfillCount, 1)
 				}
@@ -4160,44 +4165,44 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	}
 
 	// Bulk insert.
-	const maxValue = 5000
+	maxValue := 4000
+	if util.RaceEnabled {
+		// Race builds are a lot slower, so use a smaller number of rows.
+		// We expect this to also reduce the memory footprint of the test.
+		maxValue = 300
+	}
 	if err := bulkInsertIntoTable(sqlDB, maxValue); err != nil {
 		t.Fatal(err)
 	}
 
 	notify := backfillNotification
 
-	const add_column = `ALTER TABLE t.public.test ADD COLUMN x DECIMAL NOT NULL DEFAULT 1.4::DECIMAL, ADD CHECK (x >= 0)`
-	if _, err := sqlDB.Exec(add_column); err != nil {
-		t.Fatal(err)
-	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	const add_column = `ALTER TABLE t.test ADD COLUMN x DECIMAL NOT NULL DEFAULT 1.4::DECIMAL, ADD CHECK (x >= 0)`
+	var addColErr error
+	go func() {
+		_, addColErr = sqlDB.Exec(add_column)
+		wg.Done()
+	}()
 
-	const drop_column = `ALTER TABLE t.public.test DROP COLUMN v`
+	const drop_column = `ALTER TABLE t.test DROP COLUMN v`
 	if _, err := sqlDB.Exec(drop_column); err != nil {
 		t.Fatal(err)
 	}
 
-	// Check that an outstanding schema change exists.
-	tableDesc := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "test")
-	oldID := tableDesc.ID
-	if lenMutations := len(tableDesc.Mutations); lenMutations != 3 {
-		t.Fatalf("%d outstanding schema change", lenMutations)
+	// Wait for backfill to have started.
+	<-notify
+	if _, err := sqlDB.Exec("TRUNCATE TABLE t.test"); err != nil {
+		t.Fatal(err)
 	}
 
-	// Run TRUNCATE.
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		<-notify
-		if _, err := sqlDB.Exec("TRUNCATE TABLE t.test"); err != nil {
-			t.Error(err)
-		}
-		wg.Done()
-	}()
+	// Wait for ADD COLUMN to complete.
 	wg.Wait()
+	require.NoError(t, addColErr)
 
 	// The new table is truncated.
-	tableDesc = catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "test")
+	tableDesc := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "test")
 	tablePrefix := keys.SystemSQLCodec.TablePrefix(uint32(tableDesc.ID))
 	tableEnd := tablePrefix.PrefixEnd()
 	if kvs, err := kvDB.Scan(context.Background(), tablePrefix, tableEnd, 0); err != nil {
@@ -4218,26 +4223,6 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	}
 	if checks := tableDesc.AllActiveAndInactiveChecks(); len(checks) != 1 {
 		t.Fatalf("expected 1 check, found %d", len(checks))
-	}
-
-	sqlRun := sqlutils.MakeSQLRunner(sqlDB)
-	if err := jobutils.VerifySystemJob(t, sqlRun, 0, jobspb.TypeSchemaChange, jobs.StatusSucceeded, jobs.Record{
-		Username:    security.RootUser,
-		Description: add_column,
-		DescriptorIDs: descpb.IDs{
-			oldID,
-		},
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if err := jobutils.VerifySystemJob(t, sqlRun, 1, jobspb.TypeSchemaChange, jobs.StatusSucceeded, jobs.Record{
-		Username:    security.RootUser,
-		Description: drop_column,
-		DescriptorIDs: descpb.IDs{
-			oldID,
-		},
-	}); err != nil {
-		t.Fatal(err)
 	}
 }
 

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -3051,21 +3051,24 @@ func (desc *MutableTableDescriptor) MakeMutationComplete(m descpb.DescriptorMuta
 		case *descpb.DescriptorMutation_Constraint:
 			switch t.Constraint.ConstraintType {
 			case descpb.ConstraintToUpdate_CHECK:
-				switch t.Constraint.Check.Validity {
-				case descpb.ConstraintValidity_Validating:
-					// Constraint already added, just mark it as Validated
-					for _, c := range desc.Checks {
-						if c.Name == t.Constraint.Name {
+				if t.Constraint.Check.Validity == descpb.ConstraintValidity_Dropping {
+					break
+				}
+				var found bool
+				for _, c := range desc.Checks {
+					if c.Name == t.Constraint.Name {
+						if t.Constraint.Check.Validity != descpb.ConstraintValidity_Unvalidated {
 							c.Validity = descpb.ConstraintValidity_Validated
-							break
 						}
+						found = true
+						break
 					}
-				case descpb.ConstraintValidity_Unvalidated:
-					// add the constraint to the list of check constraints on the table
-					// descriptor
+				}
+				if !found {
+					if t.Constraint.Check.Validity != descpb.ConstraintValidity_Unvalidated {
+						t.Constraint.Check.Validity = descpb.ConstraintValidity_Validated
+					}
 					desc.Checks = append(desc.Checks, &t.Constraint.Check)
-				default:
-					return errors.AssertionFailedf("invalid constraint validity state: %d", t.Constraint.Check.Validity)
 				}
 			case descpb.ConstraintToUpdate_FOREIGN_KEY:
 				switch t.Constraint.ForeignKey.Validity {


### PR DESCRIPTION
The test was previously skipped because it was timing out.  When the
timeout problem was fixed it revealed a bug with check constraints not
being re-added after truncate.

Fixes #43990.

Release note (bug fix): if a table with a check constraint is truncate
while being backfilled the check constraint may get lost.