### PR TITLE
kvclient: fix leaseholder cache pollution

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -450,7 +450,7 @@ func (ds *DistSender) sendRPC(
 	class rpc.ConnectionClass,
 	rangeID roachpb.RangeID,
 	replicas ReplicaSlice,
-	cachedLeaseHolder roachpb.ReplicaDescriptor,
+	li leaseholderInfo,
 	withCommit bool,
 ) (*roachpb.BatchResponse, error) {
 	if len(replicas) == 0 {
@@ -473,7 +473,7 @@ func (ds *DistSender) sendRPC(
 		rangeID,
 		replicas,
 		ds.nodeDialer,
-		cachedLeaseHolder,
+		li,
 		withCommit,
 	)
 }
@@ -544,26 +544,36 @@ func (ds *DistSender) sendSingleRange(
 	// network hop, everything would still work if we had `All` here.
 	replicas := NewReplicaSlice(ds.gossip, desc.Replicas().Voters())
 
-	// If this request needs to go to a lease holder and we know who that is, move
-	// it to the front.
+	// Rearrange the replicas so that they're ordered in expectation of
+	// request latency.
+	replicas.OptimizeReplicaOrder(ds.getNodeDescriptor(), ds.rpcContext.RemoteClocks.Latency)
+
 	var cachedLeaseHolder roachpb.ReplicaDescriptor
-	canSendToFollower := ds.clusterID != nil &&
-		CanSendToFollower(ds.clusterID.Get(), ds.st, ba)
-	if !canSendToFollower && ba.RequiresLeaseHolder() {
-		if storeID, ok := ds.leaseHolderCache.Lookup(ctx, desc.RangeID); ok {
-			if i := replicas.FindReplica(storeID); i >= 0 {
-				replicas.MoveToFront(i)
-				cachedLeaseHolder = replicas[0].ReplicaDescriptor
-			}
+	if storeID, ok := ds.leaseHolderCache.Lookup(ctx, desc.RangeID); ok {
+		if i := replicas.FindReplica(storeID); i >= 0 {
+			cachedLeaseHolder = replicas[i].ReplicaDescriptor
 		}
 	}
-	if (cachedLeaseHolder == roachpb.ReplicaDescriptor{}) {
-		// Rearrange the replicas so that they're ordered in expectation of
-		// request latency.
-		replicas.OptimizeReplicaOrder(ds.getNodeDescriptor(), ds.rpcContext.RemoteClocks.Latency)
+	canFollowerRead := ds.clusterID != nil &&
+		CanSendToFollower(ds.clusterID.Get(), ds.st, ba)
+	// If this request needs to go to a lease holder and we know who that is, move
+	// it to the front.
+	sendToLeaseholder :=
+		cachedLeaseHolder != (roachpb.ReplicaDescriptor{}) &&
+			!canFollowerRead &&
+			ba.RequiresLeaseHolder()
+	if sendToLeaseholder {
+		if i := replicas.FindReplica(cachedLeaseHolder.StoreID); i >= 0 {
+			replicas.MoveToFront(i)
+		}
 	}
+	li := leaseholderInfo{
+		routeToFollower:   canFollowerRead || !ba.RequiresLeaseHolder(),
+		cachedLeaseholder: cachedLeaseHolder,
+	}
+
 	class := rpc.ConnectionClassForKey(desc.RSpan().Key)
-	br, err := ds.sendRPC(ctx, ba, class, desc.RangeID, replicas, cachedLeaseHolder, withCommit)
+	br, err := ds.sendRPC(ctx, ba, class, desc.RangeID, replicas, li, withCommit)
 	if err != nil {
 		log.VErrEventf(ctx, 2, "%v", err)
 		return nil, roachpb.NewError(err)
@@ -1651,6 +1661,18 @@ func fillSkippedResponses(
 	}
 }
 
+// leaseholderInfo contains some routing information for RPCs.
+type leaseholderInfo struct {
+	// routeToFollower is set if the request is intended to be routed to a
+	// follower - either because it's a read that looks stale enough to be served
+	// by a follower, or otherwise because the respective batch simply doesn't
+	// need the leaseholder.
+	routeToFollower bool
+	// cachedLeaseholder is the leaseholder that the cache indicated. Empty if the
+	// cache didn't have an entry for the range.
+	cachedLeaseholder roachpb.ReplicaDescriptor
+}
+
 // sendToReplicas sends one or more RPCs to clients specified by the
 // slice of replicas. On success, Send returns the first successful
 // reply. If an error occurs which is not specific to a single
@@ -1673,7 +1695,7 @@ func (ds *DistSender) sendToReplicas(
 	rangeID roachpb.RangeID,
 	replicas ReplicaSlice,
 	nodeDialer *nodedialer.Dialer,
-	cachedLeaseHolder roachpb.ReplicaDescriptor,
+	leaseholder leaseholderInfo,
 	withCommit bool,
 ) (*roachpb.BatchResponse, error) {
 	transport, err := ds.transportFactory(opts, nodeDialer, replicas)
@@ -1779,12 +1801,15 @@ func (ds *DistSender) sendToReplicas(
 			propagateError := false
 			switch tErr := br.Error.GetDetail().(type) {
 			case nil:
-				// When a request that we know could only succeed on the leaseholder comes
-				// back as successful, make sure the leaseholder cache reflects this
-				// replica. In steady state, this is almost always the case, and so we
-				// gate the update on whether the response comes from a node that we didn't
-				// know held the lease.
-				if cachedLeaseHolder != curReplica && ba.RequiresLeaseHolder() {
+				// When a request that we've attempted to route to the leaseholder comes
+				// back as successful, we assume that it must have been served by the
+				// leaseholder and so we update the leaseholder cache. In steady state,
+				// this is almost always the case, and so we gate the update on whether
+				// the response comes from a node that we didn't know held the lease.
+				updateLeaseholderCache :=
+					!leaseholder.routeToFollower &&
+						leaseholder.cachedLeaseholder != curReplica
+				if updateLeaseholderCache {
 					ds.leaseHolderCache.Update(ctx, rangeID, curReplica.StoreID)
 				}
 				return br, nil
@@ -1807,7 +1832,7 @@ func (ds *DistSender) sendToReplicas(
 					// latency.
 					ds.leaseHolderCache.Update(ctx, rangeID, lh.StoreID)
 					// Avoid an extra update to the leaseholder cache if the next RPC succeeds.
-					cachedLeaseHolder = *lh
+					leaseholder.cachedLeaseholder = *lh
 
 					// If the implicated leaseholder is not a known replica, return a SendError
 					// to signal eviction of the cached RangeDescriptor and re-send.

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -3055,9 +3055,7 @@ func TestCanSendToFollower(t *testing.T) {
 		args roachpb.BatchRequest,
 	) (*roachpb.BatchResponse, error) {
 		sentTo = r[0]
-		reply := &roachpb.BatchResponse{}
-		reply.Error = roachpb.NewErrorf("boom")
-		return reply, nil
+		return args.CreateReply(), nil
 	}
 	cfg := DistSenderConfig{
 		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
@@ -3116,9 +3114,8 @@ func TestCanSendToFollower(t *testing.T) {
 			ds.clusterID = &base.ClusterIDContainer{}
 			// set 2 to be the leaseholder
 			ds.LeaseHolderCache().Update(context.Background(), 2 /* rangeID */, 2 /* storeID */)
-			if _, pErr := kv.SendWrappedWith(context.Background(), ds, c.header, c.msg); !testutils.IsPError(pErr, "boom") {
-				t.Fatalf("%d: unexpected error: %v", i, pErr)
-			}
+			_, pErr := kv.SendWrappedWith(context.Background(), ds, c.header, c.msg)
+			require.Nil(t, pErr)
 			if sentTo.NodeID != c.expectedNode {
 				t.Fatalf("%d: unexpected replica: %v != %v", i, sentTo.NodeID, c.expectedNode)
 			}

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -3119,6 +3119,14 @@ func TestCanSendToFollower(t *testing.T) {
 			if sentTo.NodeID != c.expectedNode {
 				t.Fatalf("%d: unexpected replica: %v != %v", i, sentTo.NodeID, c.expectedNode)
 			}
+			// Check that the leaseholder cache doesn't change, even if the request is
+			// served by a follower. This tests a regression for a bug we've had where
+			// we were always updating the leaseholder cache on successful RPCs
+			// because we erroneously assumed that a success must come from the
+			// leaseholder.
+			storeID, ok := ds.LeaseHolderCache().Lookup(context.Background(), 2 /* rangeID */)
+			require.True(t, ok)
+			require.Equal(t, roachpb.StoreID(2), storeID)
 		})
 	}
 }

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -3109,18 +3109,20 @@ func TestCanSendToFollower(t *testing.T) {
 			2,
 		},
 	} {
-		sentTo = ReplicaInfo{}
-		canSend = c.canSendToFollower
-		ds := NewDistSender(cfg, g)
-		ds.clusterID = &base.ClusterIDContainer{}
-		// set 2 to be the leaseholder
-		ds.LeaseHolderCache().Update(context.Background(), 2 /* rangeID */, 2 /* storeID */)
-		if _, pErr := kv.SendWrappedWith(context.Background(), ds, c.header, c.msg); !testutils.IsPError(pErr, "boom") {
-			t.Fatalf("%d: unexpected error: %v", i, pErr)
-		}
-		if sentTo.NodeID != c.expectedNode {
-			t.Fatalf("%d: unexpected replica: %v != %v", i, sentTo.NodeID, c.expectedNode)
-		}
+		t.Run("", func(t *testing.T) {
+			sentTo = ReplicaInfo{}
+			canSend = c.canSendToFollower
+			ds := NewDistSender(cfg, g)
+			ds.clusterID = &base.ClusterIDContainer{}
+			// set 2 to be the leaseholder
+			ds.LeaseHolderCache().Update(context.Background(), 2 /* rangeID */, 2 /* storeID */)
+			if _, pErr := kv.SendWrappedWith(context.Background(), ds, c.header, c.msg); !testutils.IsPError(pErr, "boom") {
+				t.Fatalf("%d: unexpected error: %v", i, pErr)
+			}
+			if sentTo.NodeID != c.expectedNode {
+				t.Fatalf("%d: unexpected replica: %v != %v", i, sentTo.NodeID, c.expectedNode)
+			}
+		})
 	}
 }
 

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -200,7 +200,8 @@ func newNodeDesc(nodeID roachpb.NodeID) *roachpb.NodeDescriptor {
 func TestSendRPCOrder(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.Background())
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
@@ -359,56 +360,57 @@ func TestSendRPCOrder(t *testing.T) {
 	ds := NewDistSender(cfg, g)
 
 	for n, tc := range testCases {
-		log.Infof(context.Background(), "testcase %d", n)
-		verifyCall = makeVerifier(tc.expReplica)
+		t.Run("", func(t *testing.T) {
+			verifyCall = makeVerifier(tc.expReplica)
 
-		{
-			// The local node needs to get its attributes during sendRPC.
-			nd := &roachpb.NodeDescriptor{
-				NodeID:  6,
-				Address: util.MakeUnresolvedAddr("tcp", fmt.Sprintf("invalid.invalid:6")),
-				Locality: roachpb.Locality{
-					Tiers: tc.tiers,
-				},
+			{
+				// The local node needs to get its attributes during sendRPC.
+				nd := &roachpb.NodeDescriptor{
+					NodeID:  6,
+					Address: util.MakeUnresolvedAddr("tcp", fmt.Sprintf("invalid.invalid:6")),
+					Locality: roachpb.Locality{
+						Tiers: tc.tiers,
+					},
+				}
+				g.NodeID.Reset(nd.NodeID)
+				if err := g.SetNodeDescriptor(nd); err != nil {
+					t.Fatal(err)
+				}
 			}
-			g.NodeID.Reset(nd.NodeID)
-			if err := g.SetNodeDescriptor(nd); err != nil {
-				t.Fatal(err)
-			}
-		}
 
-		ds.leaseHolderCache.Update(
-			context.Background(), rangeID, roachpb.StoreID(0),
-		)
-		if tc.leaseHolder > 0 {
 			ds.leaseHolderCache.Update(
-				context.Background(), rangeID, descriptor.InternalReplicas[tc.leaseHolder-1].StoreID,
+				ctx, rangeID, roachpb.StoreID(0),
 			)
-		}
+			if tc.leaseHolder > 0 {
+				ds.leaseHolderCache.Update(
+					ctx, rangeID, descriptor.InternalReplicas[tc.leaseHolder-1].StoreID,
+				)
+			}
 
-		args := tc.args
-		{
-			header := args.Header()
-			header.Key = roachpb.Key("a")
-			args.SetHeader(header)
-		}
-		if roachpb.IsRange(args) {
-			header := args.Header()
-			header.EndKey = args.Header().Key.Next()
-			args.SetHeader(header)
-		}
-		consistency := roachpb.CONSISTENT
-		if !tc.consistent {
-			consistency = roachpb.INCONSISTENT
-		}
-		// Kill the cached NodeDescriptor, enforcing a lookup from Gossip.
-		ds.nodeDescriptor = nil
-		if _, err := kv.SendWrappedWith(context.Background(), ds, roachpb.Header{
-			RangeID:         rangeID, // Not used in this test, but why not.
-			ReadConsistency: consistency,
-		}, args); err != nil {
-			t.Errorf("%d: %s", n, err)
-		}
+			args := tc.args
+			{
+				header := args.Header()
+				header.Key = roachpb.Key("a")
+				args.SetHeader(header)
+			}
+			if roachpb.IsRange(args) {
+				header := args.Header()
+				header.EndKey = args.Header().Key.Next()
+				args.SetHeader(header)
+			}
+			consistency := roachpb.CONSISTENT
+			if !tc.consistent {
+				consistency = roachpb.INCONSISTENT
+			}
+			// Kill the cached NodeDescriptor, enforcing a lookup from Gossip.
+			ds.nodeDescriptor = nil
+			if _, err := kv.SendWrappedWith(ctx, ds, roachpb.Header{
+				RangeID:         rangeID, // Not used in this test, but why not.
+				ReadConsistency: consistency,
+			}, args); err != nil {
+				t.Errorf("%d: %s", n, err)
+			}
+		})
 	}
 }
 
@@ -3112,7 +3114,7 @@ func TestCanSendToFollower(t *testing.T) {
 		ds := NewDistSender(cfg, g)
 		ds.clusterID = &base.ClusterIDContainer{}
 		// set 2 to be the leaseholder
-		ds.LeaseHolderCache().Update(context.Background(), 2, 2)
+		ds.LeaseHolderCache().Update(context.Background(), 2 /* rangeID */, 2 /* storeID */)
 		if _, pErr := kv.SendWrappedWith(context.Background(), ds, c.header, c.msg); !testutils.IsPError(pErr, "boom") {
 			t.Fatalf("%d: unexpected error: %v", i, pErr)
 		}

--- a/pkg/kv/kvclient/kvcoord/send_test.go
+++ b/pkg/kv/kvclient/kvcoord/send_test.go
@@ -285,7 +285,7 @@ func sendBatch(
 		0, /* rangeID */
 		makeReplicas(addrs...),
 		nodeDialer,
-		roachpb.ReplicaDescriptor{},
+		leaseholderInfo{},
 		false, /* withCommit */
 	)
 }


### PR DESCRIPTION
Fixes #49391

This patch fixes a bug in the DistSender's updating of the leaseholder
cache. Prior, on most successful RPCs the DistSender inferred that the
success must come from a leaseholder, so it was updating the leaseholder
cache. This was not true for follower reads - the request was
successfully evaluated by followers, and we were erroneously inserting
these followers into the cache. We've seen this in a user cluster,
where the constant bad redirections and the resulting
NotLeaseholderErrors caused great confusion.

This patch does a tiny bit of cleanup to keep track of requests that
were not intended for the leaseholder, so that the cache is not updated
for them. I intend to backport this to 19.2 and 20.1. Independently of
this bug, I have other improvements coming which will make the updating
of kvclient cache more reliable - the server will detect when the client
has some stale info and it will explicitly communicate updates, so that
the client will no longer have to infer anything from a successful RPC.

Release note: None