### PR TITLE
kvserver: remove unused replica corruption check

### DIFF
--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -515,7 +515,7 @@ func (m *multiTestContext) initGossipNetwork() {
 	m.gossipStores()
 	testutils.SucceedsSoon(m.t, func() error {
 		for i := 0; i < len(m.stores); i++ {
-			if _, alive, _ := m.storePools[i].GetStoreList(roachpb.RangeID(0)); alive != len(m.stores) {
+			if _, alive, _ := m.storePools[i].GetStoreList(); alive != len(m.stores) {
 				return errors.Errorf("node %d's store pool only has %d alive stores, expected %d",
 					m.stores[i].Ident.NodeID, alive, len(m.stores))
 			}

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -375,8 +375,8 @@ func (r *Replica) IsRaftGroupInitialized() bool {
 
 // GetStoreList exposes getStoreList for testing only, but with a hardcoded
 // storeFilter of storeFilterNone.
-func (sp *StorePool) GetStoreList(rangeID roachpb.RangeID) (StoreList, int, int) {
-	list, available, throttled := sp.getStoreList(rangeID, storeFilterNone)
+func (sp *StorePool) GetStoreList() (StoreList, int, int) {
+	list, available, throttled := sp.getStoreList(storeFilterNone)
 	return list, available, len(throttled)
 }
 

--- a/pkg/kv/kvserver/node_liveness_test.go
+++ b/pkg/kv/kvserver/node_liveness_test.go
@@ -656,7 +656,7 @@ func TestNodeLivenessSetDraining(t *testing.T) {
 		testutils.SucceedsSoon(t, func() error {
 			for i, sp := range mtc.storePools {
 				curNodeID := mtc.gossips[i].NodeID.Get()
-				sl, alive, _ := sp.GetStoreList(0)
+				sl, alive, _ := sp.GetStoreList()
 				if alive != expectedLive {
 					return errors.Errorf(
 						"expected %d live stores but got %d from node %d",
@@ -690,7 +690,7 @@ func TestNodeLivenessSetDraining(t *testing.T) {
 		testutils.SucceedsSoon(t, func() error {
 			for i, sp := range mtc.storePools {
 				curNodeID := mtc.gossips[i].NodeID.Get()
-				sl, alive, _ := sp.GetStoreList(0)
+				sl, alive, _ := sp.GetStoreList()
 				if alive != expectedLive {
 					return errors.Errorf(
 						"expected %d live stores but got %d from node %d",

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2134,7 +2134,7 @@ func (s *Store) relocateOne(
 		return nil, nil, err
 	}
 
-	storeList, _, _ := s.allocator.storePool.getStoreList(desc.RangeID, storeFilterNone)
+	storeList, _, _ := s.allocator.storePool.getStoreList(storeFilterNone)
 	storeMap := storeListToMap(storeList)
 
 	// Compute which replica to add and/or remove, respectively. We ask the allocator

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -233,7 +233,7 @@ func (rq *replicateQueue) shouldQueue(
 	if !rq.store.TestingKnobs().DisableReplicaRebalancing {
 		rangeUsageInfo := rangeUsageInfoForRepl(repl)
 		_, _, _, ok := rq.allocator.RebalanceTarget(
-			ctx, zone, repl.RaftStatus(), desc.RangeID, voterReplicas, rangeUsageInfo, storeFilterThrottled)
+			ctx, zone, repl.RaftStatus(), voterReplicas, rangeUsageInfo, storeFilterThrottled)
 		if ok {
 			log.VEventf(ctx, 2, "rebalance target found, enqueuing")
 			return true, 0
@@ -245,7 +245,7 @@ func (rq *replicateQueue) shouldQueue(
 	if lease, _ := repl.GetLease(); repl.IsLeaseValid(lease, now) {
 		if rq.canTransferLease() &&
 			rq.allocator.ShouldTransferLease(
-				ctx, zone, voterReplicas, lease.Replica.StoreID, desc.RangeID, repl.leaseholderStats) {
+				ctx, zone, voterReplicas, lease.Replica.StoreID, repl.leaseholderStats) {
 			log.VEventf(ctx, 2, "lease transfer needed, enqueuing")
 			return true, 0
 		}
@@ -320,8 +320,7 @@ func (rq *replicateQueue) processOneChange(
 	// Avoid taking action if the range has too many dead replicas to make
 	// quorum.
 	voterReplicas := desc.Replicas().Voters()
-	liveVoterReplicas, deadVoterReplicas := rq.allocator.storePool.liveAndDeadReplicas(
-		desc.RangeID, voterReplicas)
+	liveVoterReplicas, deadVoterReplicas := rq.allocator.storePool.liveAndDeadReplicas(voterReplicas)
 	{
 		unavailable := !desc.Replicas().CanMakeProgress(func(rDesc roachpb.ReplicaDescriptor) bool {
 			for _, inner := range liveVoterReplicas {
@@ -379,8 +378,7 @@ func (rq *replicateQueue) processOneChange(
 		}
 		return rq.addOrReplace(ctx, repl, voterReplicas, liveVoterReplicas, removeIdx, dryRun)
 	case AllocatorReplaceDecommissioning:
-		decommissioningReplicas := rq.allocator.storePool.decommissioningReplicas(
-			desc.RangeID, voterReplicas)
+		decommissioningReplicas := rq.allocator.storePool.decommissioningReplicas(voterReplicas)
 		if len(decommissioningReplicas) == 0 {
 			// Nothing to do.
 			return false, nil
@@ -481,7 +479,6 @@ func (rq *replicateQueue) addOrReplace(
 	newStore, details, err := rq.allocator.AllocateTarget(
 		ctx,
 		zone,
-		desc.RangeID,
 		remainingLiveReplicas,
 	)
 	if err != nil {
@@ -522,7 +519,6 @@ func (rq *replicateQueue) addOrReplace(
 		_, _, err := rq.allocator.AllocateTarget(
 			ctx,
 			zone,
-			desc.RangeID,
 			oldPlusNewReplicas,
 		)
 		if err != nil {
@@ -719,8 +715,7 @@ func (rq *replicateQueue) removeDecommissioning(
 	ctx context.Context, repl *Replica, dryRun bool,
 ) (requeue bool, _ error) {
 	desc, _ := repl.DescAndZone()
-	decommissioningReplicas := rq.allocator.storePool.decommissioningReplicas(
-		desc.RangeID, desc.Replicas().All())
+	decommissioningReplicas := rq.allocator.storePool.decommissioningReplicas(desc.Replicas().All())
 	if len(decommissioningReplicas) == 0 {
 		log.VEventf(ctx, 1, "range of replica %s was identified as having decommissioning replicas, "+
 			"but no decommissioning replicas were found", repl)
@@ -837,7 +832,7 @@ func (rq *replicateQueue) considerRebalance(
 	if !rq.store.TestingKnobs().DisableReplicaRebalancing {
 		rangeUsageInfo := rangeUsageInfoForRepl(repl)
 		addTarget, removeTarget, details, ok := rq.allocator.RebalanceTarget(
-			ctx, zone, repl.RaftStatus(), desc.RangeID, existingReplicas, rangeUsageInfo,
+			ctx, zone, repl.RaftStatus(), existingReplicas, rangeUsageInfo,
 			storeFilterThrottled)
 		if !ok {
 			log.VEventf(ctx, 1, "no suitable rebalance target")
@@ -952,7 +947,6 @@ func (rq *replicateQueue) findTargetAndTransferLease(
 		zone,
 		desc.Replicas().Voters(),
 		repl.store.StoreID(),
-		desc.RangeID,
 		repl.leaseholderStats,
 		opts.checkTransferLeaseSource,
 		opts.checkCandidateFullness,

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -196,7 +196,7 @@ func (sr *StoreRebalancer) Start(ctx context.Context, stopper *stop.Stopper) {
 				continue
 			}
 
-			storeList, _, _ := sr.rq.allocator.storePool.getStoreList(roachpb.RangeID(0), storeFilterNone)
+			storeList, _, _ := sr.rq.allocator.storePool.getStoreList(storeFilterNone)
 			sr.rebalanceStore(ctx, mode, storeList)
 		}
 	})

--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -116,7 +116,7 @@ func TestChooseLeaseToTransfer(t *testing.T) {
 	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(noLocalityStores, t)
-	storeList, _, _ := a.storePool.getStoreList(firstRangeID, storeFilterThrottled)
+	storeList, _, _ := a.storePool.getStoreList(storeFilterThrottled)
 	storeMap := storeListToMap(storeList)
 
 	const minQPS = 800
@@ -199,7 +199,7 @@ func TestChooseReplicaToRebalance(t *testing.T) {
 	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(noLocalityStores, t)
-	storeList, _, _ := a.storePool.getStoreList(firstRangeID, storeFilterThrottled)
+	storeList, _, _ := a.storePool.getStoreList(storeFilterThrottled)
 	storeMap := storeListToMap(storeList)
 
 	const minQPS = 800
@@ -307,7 +307,7 @@ func TestNoLeaseTransferToBehindReplicas(t *testing.T) {
 	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(noLocalityStores, t)
-	storeList, _, _ := a.storePool.getStoreList(firstRangeID, storeFilterThrottled)
+	storeList, _, _ := a.storePool.getStoreList(storeFilterThrottled)
 	storeMap := storeListToMap(storeList)
 
 	const minQPS = 800


### PR DESCRIPTION
Look specifically towards `storeStatusReplicaCorrupted` and
`(*storeDetail).status`. The rest of the diff is fall out from having
removed the unused range ID being plumbed all the way through.

Release note: None