### PR TITLE
colexec: add binary overloads on datum-backed types

### DIFF
--- a/pkg/col/coldataext/datum_vec.go
+++ b/pkg/col/coldataext/datum_vec.go
@@ -53,9 +53,17 @@ func newDatumVec(t *types.T, n int, evalCtx *tree.EvalContext) coldata.DatumVec 
 	}
 }
 
+// BinFn evaluates the provided binary function between the receiver and other.
+// dVec is the datumVec that stores either d or other (it doesn't matter which
+// one because it is used only to supply the eval context).
+func (d *Datum) BinFn(binFn *tree.BinOp, dVec, other interface{}) (tree.Datum, error) {
+	return binFn.Fn(dVec.(*datumVec).evalCtx, d.Datum, maybeUnwrapDatum(other))
+}
+
 // CompareDatum returns the comparison between d and other. The other is
 // assumed to be tree.Datum. dVec is the datumVec that stores either d or other
-// and is needed to supply the eval context.
+// (it doesn't matter which one because it is used only to supply the eval
+// context).
 // Note that the method is named differently from "Compare" so that we do not
 // overload tree.Datum.Compare method.
 func (d *Datum) CompareDatum(dVec, other interface{}) int {

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -12,9 +12,11 @@ package main
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"text/template"
 
+	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -43,14 +45,45 @@ var binaryOpDecCtx = map[tree.BinaryOperator]string{
 }
 
 var compatibleCanonicalTypeFamilies = map[types.Family][]types.Family{
-	types.BoolFamily:        {types.BoolFamily},
-	types.BytesFamily:       {types.BytesFamily},
-	types.DecimalFamily:     append(numericCanonicalTypeFamilies, types.IntervalFamily),
-	types.IntFamily:         append(numericCanonicalTypeFamilies, types.IntervalFamily),
-	types.FloatFamily:       append(numericCanonicalTypeFamilies, types.IntervalFamily),
-	types.TimestampTZFamily: timeCanonicalTypeFamilies,
-	types.IntervalFamily:    append(numericCanonicalTypeFamilies, timeCanonicalTypeFamilies...),
-	// TODO(yuzefovich): add support for binary overloads on datum-backed types.
+	types.BoolFamily: append([]types.Family{},
+		types.BoolFamily,
+		typeconv.DatumVecCanonicalTypeFamily,
+	),
+	types.BytesFamily: {
+		types.BytesFamily,
+	},
+	types.DecimalFamily: append(
+		numericCanonicalTypeFamilies,
+		types.IntervalFamily,
+		typeconv.DatumVecCanonicalTypeFamily,
+	),
+	types.IntFamily: append(
+		numericCanonicalTypeFamilies,
+		types.IntervalFamily,
+		typeconv.DatumVecCanonicalTypeFamily,
+	),
+	types.FloatFamily: append(
+		numericCanonicalTypeFamilies,
+		types.IntervalFamily,
+		typeconv.DatumVecCanonicalTypeFamily,
+	),
+	types.TimestampTZFamily: append([]types.Family{},
+		types.TimestampTZFamily,
+		types.IntervalFamily,
+	),
+	types.IntervalFamily: append(
+		numericCanonicalTypeFamilies,
+		types.TimestampTZFamily,
+		types.IntervalFamily,
+		typeconv.DatumVecCanonicalTypeFamily,
+	),
+	typeconv.DatumVecCanonicalTypeFamily: append(
+		[]types.Family{
+			typeconv.DatumVecCanonicalTypeFamily,
+			types.BoolFamily,
+			types.IntervalFamily,
+		}, numericCanonicalTypeFamilies...,
+	),
 }
 
 // sameTypeBinaryOpToOverloads maps a binary operator to all of the overloads
@@ -91,6 +124,13 @@ func registerBinOpOutputTypes() {
 		for _, intWidth := range supportedWidthsByCanonicalTypeFamily[types.IntFamily] {
 			binOpOutputTypes[binOp][typePair{types.DecimalFamily, anyWidth, types.IntFamily, intWidth}] = types.Decimal
 			binOpOutputTypes[binOp][typePair{types.IntFamily, intWidth, types.DecimalFamily, anyWidth}] = types.Decimal
+		}
+
+		for _, compatibleFamily := range compatibleCanonicalTypeFamilies[typeconv.DatumVecCanonicalTypeFamily] {
+			for _, width := range supportedWidthsByCanonicalTypeFamily[compatibleFamily] {
+				binOpOutputTypes[binOp][typePair{typeconv.DatumVecCanonicalTypeFamily, anyWidth, compatibleFamily, width}] = types.Any
+				binOpOutputTypes[binOp][typePair{compatibleFamily, width, typeconv.DatumVecCanonicalTypeFamily, anyWidth}] = types.Any
+			}
 		}
 	}
 
@@ -505,5 +545,126 @@ func (c decimalIntervalCustomizer) getBinOpAssignFunc() assignFunc {
 			colexecerror.InternalError(fmt.Sprintf("unhandled binary operator %s", op.overloadBase.BinOp.String()))
 		}
 		return ""
+	}
+}
+
+// executeBinOpOnDatums returns a string that performs a binary operation on
+// two datum elements. It takes the following arguments:
+// - prelude - will be prepended before binary function evaluation and should
+// be used to do any setup (like converting non-datum element to its datum
+// equivalent)
+// - targetElem - same as targetElem parameter in assignFunc signature
+// - leftColdataExtDatum - the variable name of the left datum element that
+// must be of *coldataext.Datum type
+// - rightDatumElem - the variable name of the right datum element which could
+// be *coldataext.Datum, tree.Datum, or nil
+// - leftCol and rightCol - same as corresponding parameters in assignFunc
+// signature
+// - datumVecOnRightSide - indicates whether we have datum-backed vector on the
+// right side (it'll be used only to supply the eval context).
+func executeBinOpOnDatums(
+	prelude, targetElem, leftColdataExtDatum, rightDatumElem, leftCol, rightCol string,
+	datumVecOnRightSide bool,
+) string {
+	// We expect the target to be of the form "projVec[idx]", however,
+	// datumVec doesn't support indexing, so we need to translate that into
+	// a set operation.
+	//
+	// First, we check that target matches our expectations (it doesn't
+	// only in overloads_test_utils_gen.go).
+	if !regexp.MustCompile(`.*\[.*]`).MatchString(targetElem) {
+		return fmt.Sprintf("colexecerror.InternalError(\"couldn't translate indexing on datum vec\")")
+	}
+	// Next, we separate the target into two tokens preemptively removing
+	// the closing square bracket.
+	tokens := strings.Split(targetElem[:len(targetElem)-1], "[")
+	if len(tokens) != 2 {
+		colexecerror.InternalError("unexpectedly len(tokens) != 2")
+	}
+	vecVariable := tokens[0]
+	idxVariable := tokens[1]
+	return fmt.Sprintf(`
+			%s
+			_res, err := %s.BinFn(_overloadHelper.binFn, %s, %s)
+			if err != nil {
+				colexecerror.ExpectedError(err)
+			}
+			%s
+		`, prelude, leftColdataExtDatum, getDatumVecVariableName(leftCol, rightCol, datumVecOnRightSide), rightDatumElem,
+		set(typeconv.DatumVecCanonicalTypeFamily, vecVariable, idxVariable, "_res"),
+	)
+}
+
+func (c datumCustomizer) getBinOpAssignFunc() assignFunc {
+	return func(op *lastArgWidthOverload, targetElem, leftElem, rightElem, targetCol, leftCol, rightCol string) string {
+		return executeBinOpOnDatums(
+			"" /* prelude */, targetElem,
+			leftElem+".(*coldataext.Datum)", rightElem,
+			leftCol, rightCol, false, /* datumVecOnRightSide */
+		)
+	}
+}
+
+// convertNativeToDatum returns a string that converts nativeElem to a
+// tree.Datum that is stored in local variable named datumElemVarName.
+func convertNativeToDatum(
+	canonicalTypeFamily types.Family, nativeElem, datumElemVarName string,
+) string {
+	var runtimeConversion string
+	switch canonicalTypeFamily {
+	case types.BoolFamily:
+		runtimeConversion = fmt.Sprintf("tree.DBool(%s)", nativeElem)
+	case types.IntFamily:
+		// TODO(yuzefovich): dates are represented as ints, so this will need
+		// to be updated once we allow mixed-type operations on dates.
+		runtimeConversion = fmt.Sprintf("tree.DInt(%s)", nativeElem)
+	case types.FloatFamily:
+		runtimeConversion = fmt.Sprintf("tree.DFloat(%s)", nativeElem)
+	case types.DecimalFamily:
+		runtimeConversion = fmt.Sprintf("tree.DDecimal{Decimal: %s}", nativeElem)
+	case types.IntervalFamily:
+		runtimeConversion = fmt.Sprintf("tree.DInterval{Duration: %s}", nativeElem)
+	default:
+		colexecerror.InternalError(fmt.Sprintf("unexpected canonical type family: %s", canonicalTypeFamily))
+	}
+	return fmt.Sprintf(`
+			_convertedNativeElem := %[1]s
+			var %[2]s tree.Datum
+			%[2]s = &_convertedNativeElem
+			`, runtimeConversion, datumElemVarName)
+}
+
+func (c datumNonDatumCustomizer) getBinOpAssignFunc() assignFunc {
+	return func(op *lastArgWidthOverload, targetElem, leftElem, rightElem, targetCol, leftCol, rightCol string) string {
+		const rightDatumElem = "_nonDatumArgAsDatum"
+		prelude := convertNativeToDatum(
+			op.lastArgTypeOverload.CanonicalTypeFamily, rightElem, rightDatumElem,
+		)
+		return executeBinOpOnDatums(
+			prelude, targetElem,
+			leftElem+".(*coldataext.Datum)", rightDatumElem,
+			leftCol, rightCol, false, /* datumVecOnRightSide */
+		)
+	}
+}
+
+func (c nonDatumDatumCustomizer) getBinOpAssignFunc() assignFunc {
+	return func(op *lastArgWidthOverload, targetElem, leftElem, rightElem, targetCol, leftCol, rightCol string) string {
+		const (
+			leftDatumElem       = "_nonDatumArgAsDatum"
+			leftColdataExtDatum = "_nonDatumArgAsColdataExtDatum"
+		)
+		prelude := fmt.Sprintf(`
+			%s
+			%s := &coldataext.Datum{Datum: %s}
+			`,
+			convertNativeToDatum(c.leftCanonicalTypeFamily, leftElem, leftDatumElem),
+			leftColdataExtDatum, leftDatumElem,
+		)
+		return executeBinOpOnDatums(
+			prelude, targetElem,
+			leftColdataExtDatum, rightElem,
+			leftCol, rightCol, true, /* datumVecOnRightSide */
+		)
 	}
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -256,7 +256,7 @@ func (c intCustomizer) getBinOpAssignFunc() assignFunc {
 				if {{.Right}} == 0 {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
 				}
-				leftTmpDec, rightTmpDec := &decimalScratch.tmpDec1, &decimalScratch.tmpDec2
+				leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
 				leftTmpDec.SetFinite(int64({{.Left}}), 0)
 				rightTmpDec.SetFinite(int64({{.Right}}), 0)
 				if _, err := tree.{{.Ctx}}.Quo(&{{.Target}}, leftTmpDec, rightTmpDec); err != nil {
@@ -293,7 +293,7 @@ func (c decimalIntCustomizer) getBinOpAssignFunc() assignFunc {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
 				}
 				{{end}}
-				tmpDec := &decimalScratch.tmpDec1
+				tmpDec := &_overloadHelper.tmpDec1
 				tmpDec.SetFinite(int64({{.Right}}), 0)
 				if _, err := tree.{{.Ctx}}.{{.Op}}(&{{.Target}}, &{{.Left}}, tmpDec); err != nil {
 					colexecerror.ExpectedError(err)
@@ -319,7 +319,7 @@ func (c intDecimalCustomizer) getBinOpAssignFunc() assignFunc {
 		buf := strings.Builder{}
 		t := template.Must(template.New("").Parse(`
 			{
-				tmpDec := &decimalScratch.tmpDec1
+				tmpDec := &_overloadHelper.tmpDec1
 				tmpDec.SetFinite(int64({{.Left}}), 0)
 				{{if .IsDivision}}
 				cond, err := tree.{{.Ctx}}.{{.Op}}(&{{.Target}}, tmpDec, &{{.Right}})

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_cmp.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_cmp.go
@@ -310,13 +310,13 @@ func (c timestampCustomizer) getCmpOpCompareFunc() compareFunc {
 		buf := strings.Builder{}
 		// Inline the code from tree.compareTimestamps.
 		t := template.Must(template.New("").Parse(`
-      if {{.Left}}.Before({{.Right}}) {
-				{{.Target}} = -1
-			} else if {{.Right}}.Before({{.Left}}) {
-				{{.Target}} = 1
-			} else { 
-        {{.Target}} = 0
-      }`))
+		if {{.Left}}.Before({{.Right}}) {
+			{{.Target}} = -1
+		} else if {{.Right}}.Before({{.Left}}) {
+			{{.Target}} = 1
+		} else {
+			{{.Target}} = 0
+		}`))
 
 		if err := t.Execute(&buf, args); err != nil {
 			colexecerror.InternalError(err)
@@ -333,13 +333,7 @@ func (c intervalCustomizer) getCmpOpCompareFunc() compareFunc {
 
 func (c datumCustomizer) getCmpOpCompareFunc() compareFunc {
 	return func(targetElem, leftElem, rightElem, leftCol, rightCol string) string {
-		// In most cases, we have a datum coming from coldataext.datumVec on
-		// the left side, but it is also possible that we have a constant datum
-		// on the left, then the datum vec will be on the right side.
-		datumVecVariableName := leftCol
-		if datumVecVariableName == "_" {
-			datumVecVariableName = rightCol
-		}
+		datumVecVariableName := getDatumVecVariableName(leftCol, rightCol, false /* preferRightSide */)
 		return fmt.Sprintf(`
 			%s = %s.(*coldataext.Datum).CompareDatum(%s, %s)
 		`, targetElem, leftElem, datumVecVariableName, rightElem)

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_cmp.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_cmp.go
@@ -221,7 +221,7 @@ func (c decimalFloatCustomizer) getCmpOpCompareFunc() compareFunc {
 		buf := strings.Builder{}
 		t := template.Must(template.New("").Parse(`
 			{
-				tmpDec := &decimalScratch.tmpDec1
+				tmpDec := &_overloadHelper.tmpDec1
 				if _, err := tmpDec.SetFloat64(float64({{.Right}})); err != nil {
 					colexecerror.ExpectedError(err)
 				}
@@ -241,7 +241,7 @@ func (c decimalIntCustomizer) getCmpOpCompareFunc() compareFunc {
 		buf := strings.Builder{}
 		t := template.Must(template.New("").Parse(`
 			{
-				tmpDec := &decimalScratch.tmpDec1
+				tmpDec := &_overloadHelper.tmpDec1
 				tmpDec.SetFinite(int64({{.Right}}), 0)
 				{{.Target}} = tree.CompareDecimals(&{{.Left}}, tmpDec)
 			}
@@ -259,7 +259,7 @@ func (c floatDecimalCustomizer) getCmpOpCompareFunc() compareFunc {
 		buf := strings.Builder{}
 		t := template.Must(template.New("").Parse(`
 			{
-				tmpDec := &decimalScratch.tmpDec1
+				tmpDec := &_overloadHelper.tmpDec1
 				if _, err := tmpDec.SetFloat64(float64({{.Left}})); err != nil {
 					colexecerror.ExpectedError(err)
 				}
@@ -279,7 +279,7 @@ func (c intDecimalCustomizer) getCmpOpCompareFunc() compareFunc {
 		buf := strings.Builder{}
 		t := template.Must(template.New("").Parse(`
 			{
-				tmpDec := &decimalScratch.tmpDec1
+				tmpDec := &_overloadHelper.tmpDec1
 				tmpDec.SetFinite(int64({{.Left}}), 0)
 				{{.Target}} = tree.CompareDecimals(tmpDec, &{{.Right}})
 			}

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_hash.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_hash.go
@@ -90,7 +90,7 @@ func (decimalCustomizer) getHashAssignFunc() assignFunc {
 		return fmt.Sprintf(`
 			// In order for equal decimals to hash to the same value we need to
 			// remove the trailing zeroes if there are any.
-			tmpDec := &decimalScratch.tmpDec1
+			tmpDec := &_overloadHelper.tmpDec1
 			tmpDec.Reduce(&%[1]s)
 			b := []byte(tmpDec.String())`, vElem) +
 			fmt.Sprintf(hashByteSliceString, targetElem, "b")

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_test_utils_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_test_utils_gen.go
@@ -43,11 +43,11 @@ import (
 func {{template "opName" .}}(a {{.Left.GoType}}, b {{.Right.GoType}}) {{.Right.RetGoType}} {
 	var r {{.Right.RetGoType}}
 	// In order to inline the templated code of overloads, we need to have a
-	// "decimalScratch" local variable of type "decimalOverloadScratch".
-	var decimalScratch decimalOverloadScratch
+	// "_overloadHelper" local variable of type "overloadHelper".
+	var _overloadHelper overloadHelper
 	// However, the scratch is not used in all of the functions, so we add this
 	// to go around "unused" error.
-	_ = decimalScratch
+	_ = _overloadHelper
 	{{(.Right.Assign "r" "a" "b" "" "" "")}}
 	return r
 }

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -166,7 +166,7 @@ type hashAggregator struct {
 	aggFnsAlloc    *aggregateFuncsAlloc
 	hashAlloc      hashAggFuncsAlloc
 	cancelChecker  CancelChecker
-	decimalScratch decimalOverloadScratch
+	overloadHelper overloadHelper
 	datumAlloc     sqlbase.DatumAlloc
 }
 
@@ -329,7 +329,7 @@ func (op *hashAggregator) buildSelectionForEachHashCode(ctx context.Context, b c
 			nKeys,
 			b.Selection(),
 			op.cancelChecker,
-			op.decimalScratch,
+			op.overloadHelper,
 			&op.datumAlloc,
 		)
 	}

--- a/pkg/sql/colexec/hash_utils.go
+++ b/pkg/sql/colexec/hash_utils.go
@@ -109,7 +109,7 @@ type tupleHashDistributor struct {
 	// cancelChecker is used during the hashing of the rows to distribute to
 	// check for query cancellation.
 	cancelChecker  CancelChecker
-	decimalScratch decimalOverloadScratch
+	overloadHelper overloadHelper
 	datumAlloc     sqlbase.DatumAlloc
 }
 
@@ -132,7 +132,7 @@ func (d *tupleHashDistributor) distribute(
 	initHash(d.buckets, n, d.initHashValue)
 
 	for _, i := range hashCols {
-		rehash(ctx, d.buckets, b.ColVec(int(i)), n, b.Selection(), d.cancelChecker, d.decimalScratch, &d.datumAlloc)
+		rehash(ctx, d.buckets, b.ColVec(int(i)), n, b.Selection(), d.cancelChecker, d.overloadHelper, &d.datumAlloc)
 	}
 
 	finalizeHash(d.buckets, n, uint64(len(d.selections)))

--- a/pkg/sql/colexec/hash_utils_test.go
+++ b/pkg/sql/colexec/hash_utils_test.go
@@ -38,16 +38,16 @@ func TestHashFunctionFamily(t *testing.T) {
 	}
 	numBuckets := uint64(16)
 	var (
-		cancelChecker  CancelChecker
-		decimalScratch decimalOverloadScratch
-		datumAlloc     sqlbase.DatumAlloc
+		cancelChecker     CancelChecker
+		overloadHelperVar overloadHelper
+		datumAlloc        sqlbase.DatumAlloc
 	)
 
 	for initHashValue, buckets := range [][]uint64{bucketsA, bucketsB} {
 		// We need +1 here because 0 is not a valid initial hash value.
 		initHash(buckets, nKeys, uint64(initHashValue+1))
 		for _, keysCol := range keys {
-			rehash(ctx, buckets, keysCol, nKeys, nil /* sel */, cancelChecker, decimalScratch, &datumAlloc)
+			rehash(ctx, buckets, keysCol, nKeys, nil /* sel */, cancelChecker, overloadHelperVar, &datumAlloc)
 		}
 		finalizeHash(buckets, nKeys, numBuckets)
 	}

--- a/pkg/sql/colexec/hash_utils_tmpl.go
+++ b/pkg/sql/colexec/hash_utils_tmpl.go
@@ -126,9 +126,12 @@ func rehash(
 	nKeys int,
 	sel []int,
 	cancelChecker CancelChecker,
-	decimalScratch decimalOverloadScratch,
+	overloadHelper overloadHelper,
 	datumAlloc *sqlbase.DatumAlloc,
 ) {
+	// In order to inline the templated code of overloads, we need to have a
+	// "_overloadHelper" local variable of type "overloadHelper".
+	_overloadHelper := overloadHelper
 	switch col.CanonicalTypeFamily() {
 	// {{range .}}
 	case _CANONICAL_TYPE_FAMILY:

--- a/pkg/sql/colexec/hashtable.go
+++ b/pkg/sql/colexec/hashtable.go
@@ -166,7 +166,7 @@ type hashTable struct {
 	// each other.
 	allowNullEquality bool
 
-	decimalScratch decimalOverloadScratch
+	overloadHelper overloadHelper
 	datumAlloc     sqlbase.DatumAlloc
 	cancelChecker  CancelChecker
 
@@ -380,7 +380,7 @@ func (ht *hashTable) computeBuckets(
 	}
 
 	for i := range ht.keyCols {
-		rehash(ctx, buckets, keys[i], nKeys, sel, ht.cancelChecker, ht.decimalScratch, &ht.datumAlloc)
+		rehash(ctx, buckets, keys[i], nKeys, sel, ht.cancelChecker, ht.overloadHelper, &ht.datumAlloc)
 	}
 
 	finalizeHash(buckets, nKeys, ht.numBuckets)

--- a/pkg/sql/colexec/hashtable_tmpl.go
+++ b/pkg/sql/colexec/hashtable_tmpl.go
@@ -239,8 +239,8 @@ func _CHECK_COL_FUNCTION_TEMPLATE(_PROBING_AGAINST_ITSELF bool, _DELETING_PROBE_
 	// {{$deletingProbeMode := .DeletingProbeMode}}
 	// {{with .Global}}
 	// In order to inline the templated code of overloads, we need to have a
-	// `decimalScratch` local variable of type `decimalOverloadScratch`.
-	decimalScratch := ht.decimalScratch
+	// `_overloadHelper` local variable of type `overloadHelper`.
+	_overloadHelper := ht.overloadHelper
 	switch probeVec.CanonicalTypeFamily() {
 	// {{range .LeftFamilies}}
 	case _LEFT_CANONICAL_TYPE_FAMILY:

--- a/pkg/sql/colexec/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_const_ops_tmpl.go
@@ -108,11 +108,11 @@ type _OP_CONST_NAME struct {
 
 func (p _OP_CONST_NAME) Next(ctx context.Context) coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
-	// `decimalScratch` local variable of type `decimalOverloadScratch`.
-	decimalScratch := p.decimalScratch
+	// `_overloadHelper` local variable of type `overloadHelper`.
+	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
-	_ = decimalScratch
+	_ = _overloadHelper
 	batch := p.input.Next(ctx)
 	n := batch.Length()
 	if n == 0 {
@@ -246,13 +246,15 @@ func GetProjection_CONST_SIDEConstOperator(
 	colIdx int,
 	constArg tree.Datum,
 	outputIdx int,
+	overloadHelper overloadHelper,
 ) (colexecbase.Operator, error) {
 	input = newVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projConstOpBase := projConstOpBase{
-		OneInputNode: NewOneInputNode(input),
-		allocator:    allocator,
-		colIdx:       colIdx,
-		outputIdx:    outputIdx,
+		OneInputNode:   NewOneInputNode(input),
+		allocator:      allocator,
+		colIdx:         colIdx,
+		outputIdx:      outputIdx,
+		overloadHelper: overloadHelper,
 	}
 	var (
 		c   interface{}

--- a/pkg/sql/colexec/projection_ops_test.go
+++ b/pkg/sql/colexec/projection_ops_test.go
@@ -166,7 +166,7 @@ func TestGetProjectionConstOperator(t *testing.T) {
 	outputIdx := 5
 	op, err := GetProjectionRConstOperator(
 		testAllocator, types.Float, types.Float, types.Float,
-		binOp, input, colIdx, constArg, outputIdx,
+		binOp, input, colIdx, constArg, outputIdx, overloadHelper{},
 	)
 	if err != nil {
 		t.Error(err)
@@ -195,7 +195,7 @@ func TestGetProjectionConstMixedTypeOperator(t *testing.T) {
 	outputIdx := 5
 	op, err := GetProjectionRConstOperator(
 		testAllocator, types.Int, types.Int2, types.Int,
-		binOp, input, colIdx, constArg, outputIdx,
+		binOp, input, colIdx, constArg, outputIdx, overloadHelper{},
 	)
 	if err != nil {
 		t.Error(err)
@@ -320,7 +320,7 @@ func TestGetProjectionOperator(t *testing.T) {
 	outputIdx := 9
 	op, err := GetProjectionOperator(
 		testAllocator, typ, typ, types.Int2,
-		binOp, input, col1Idx, col2Idx, outputIdx,
+		binOp, input, col1Idx, col2Idx, outputIdx, overloadHelper{},
 	)
 	if err != nil {
 		t.Error(err)

--- a/pkg/sql/colexec/selection_ops_test.go
+++ b/pkg/sql/colexec/selection_ops_test.go
@@ -73,7 +73,7 @@ func TestGetSelectionConstOperator(t *testing.T) {
 	colIdx := 3
 	constVal := int64(31)
 	constArg := tree.NewDDate(pgdate.MakeCompatibleDateFromDisk(constVal))
-	op, err := GetSelectionConstOperator(types.Date, types.Date, cmpOp, input, colIdx, constArg)
+	op, err := GetSelectionConstOperator(types.Date, types.Date, cmpOp, input, colIdx, constArg, overloadHelper{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -96,7 +96,7 @@ func TestGetSelectionConstMixedTypeOperator(t *testing.T) {
 	colIdx := 3
 	constVal := int16(31)
 	constArg := tree.NewDInt(tree.DInt(constVal))
-	op, err := GetSelectionConstOperator(types.Int, types.Int2, cmpOp, input, colIdx, constArg)
+	op, err := GetSelectionConstOperator(types.Int, types.Int2, cmpOp, input, colIdx, constArg, overloadHelper{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -119,7 +119,7 @@ func TestGetSelectionOperator(t *testing.T) {
 	var input colexecbase.Operator
 	col1Idx := 5
 	col2Idx := 7
-	op, err := GetSelectionOperator(ct, ct, cmpOp, input, col1Idx, col2Idx)
+	op, err := GetSelectionOperator(ct, ct, cmpOp, input, col1Idx, col2Idx, overloadHelper{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/sql/colexec/utils.go
+++ b/pkg/sql/colexec/utils.go
@@ -48,6 +48,7 @@ var (
 // before the inlined overloaded code.
 type overloadHelper struct {
 	tmpDec1, tmpDec2 apd.Decimal
+	binFn            *tree.BinOp
 }
 
 // makeWindowIntoBatch updates windowedBatch so that it provides a "window"

--- a/pkg/sql/colexec/utils.go
+++ b/pkg/sql/colexec/utils.go
@@ -41,11 +41,12 @@ var (
 	zeroIntervalValue duration.Duration
 )
 
-// decimalOverloadScratch is a utility struct that helps us avoid allocations
-// of temporary decimals on every overloaded operation with them. In order for
-// the templates to see it correctly, a local variable named `scratch` of this
-// type must be declared before the inlined overloaded code.
-type decimalOverloadScratch struct {
+// overloadHelper is a utility struct that helps us avoid allocations
+// of temporary decimals on every overloaded operation with them as well as
+// plumbs through other useful information. In order for the templates to see
+// it correctly, a local variable named `_overloadHelper` of this type must be declared
+// before the inlined overloaded code.
+type overloadHelper struct {
 	tmpDec1, tmpDec2 apd.Decimal
 }
 

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -1600,7 +1600,7 @@ func createTestProjectingOperator(
 	if canFallbackToRowexec {
 		args.ProcessorConstructor = rowexec.NewProcessor
 	} else {
-		// Is is possible that there is a valid projecting operator with the
+		// It is possible that there is a valid projecting operator with the
 		// given input types, but the vectorized engine doesn't support it. In
 		// such case in the production code we fall back to row-by-row engine,
 		// but the caller of this method doesn't want such behavior. In order

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
@@ -1,0 +1,182 @@
+# LogicTest: local
+
+statement ok
+CREATE TABLE many_types (
+    _bool        BOOL,
+    _bytes       BYTES,
+    _date        DATE,
+    _decimal     DECIMAL,
+    _int2        INT2,
+    _int4        INT4,
+    _int         INT8,
+    _oid         OID,
+    _float       FLOAT8,
+    _string      STRING,
+    _uuid        UUID,
+    _timestamp   TIMESTAMP,
+    _timestamptz TIMESTAMPTZ,
+    _interval    INTERVAL,
+    _inet        INet,
+    _json        JSON,
+    _time        Time
+)
+
+statement ok
+INSERT
+  INTO many_types
+VALUES (
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL
+       ),
+       (
+       false,
+       '123',
+       '2019-10-22',
+       1.23,
+       123,
+       123,
+       123,
+       123,
+       1.23,
+       '123',
+       '63616665-6630-3064-6465-616462656562',
+       '1-1-18 1:00:00.001',
+       '1-1-18 1:00:00.001-8',
+       '12:34:56.123456',
+       '127.0.0.1',
+       '[1, "hello", {"a": ["foo", {"b": 3}]}]',
+       '1:00:00.001'
+       ),
+       (
+       true,
+       '456',
+       '2020-05-21',
+       4.56,
+       456,
+       456,
+       456,
+       456,
+       4.56,
+       '456',
+       '63616665-0000-0000-6465-616462656562',
+       '1-1-18 1:00:00.456',
+       '1-1-18 1:00:00.456-8',
+       '01:23:45.012345',
+       '192.168.0.0/16',
+       '[2, "hi", {"b": ["bar", {"c": 4}]}]',
+       '1:00:00.456'
+       )
+
+query T
+EXPLAIN (VEC) SELECT _inet - _int2 FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projMinusDatumInt16Op
+    └ *colexec.colBatchScan
+
+query T rowsort
+SELECT _inet - _int2 FROM many_types
+----
+NULL
+126.255.255.134
+192.167.254.56/16
+
+query T
+EXPLAIN (VEC) SELECT _inet - 1 FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projMinusDatumInt64ConstOp
+    └ *colexec.colBatchScan
+
+query T rowsort
+SELECT _inet - 1 FROM many_types
+----
+NULL
+127.0.0.0
+192.167.255.255/16
+
+query T
+EXPLAIN (VEC) SELECT _int4 + _inet FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projPlusInt32DatumOp
+    └ *colexec.colBatchScan
+
+query T rowsort
+SELECT _int4 + _inet FROM many_types
+----
+NULL
+127.0.0.124
+192.168.1.200/16
+
+query T
+EXPLAIN (VEC) SELECT 2 + _inet FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projPlusDatumInt64ConstOp
+    └ *colexec.colBatchScan
+
+query T rowsort
+SELECT 2 + _inet FROM many_types
+----
+NULL
+127.0.0.3
+192.168.0.2/16
+
+query T
+EXPLAIN (VEC) SELECT _time + _interval FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projPlusDatumIntervalOp
+    └ *colexec.colBatchScan
+
+query T rowsort
+SELECT _time + _interval FROM many_types
+----
+NULL
+0000-01-01 13:34:56.124456 +0000 UTC
+0000-01-01 02:23:45.468345 +0000 UTC
+
+query T
+EXPLAIN (VEC) SELECT _json - _int FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projMinusDatumInt64Op
+    └ *colexec.colBatchScan
+
+query T rowsort
+SELECT _json - _int FROM many_types
+----
+NULL
+[1, "hello", {"a": ["foo", {"b": 3}]}]
+[2, "hi", {"b": ["bar", {"c": 4}]}]
+
+# Make sure we fall back to row engine when we have a mixed-type expression
+# with dates.
+query T
+EXPLAIN (VEC) SELECT _time + _date FROM many_types
+----
+│
+└ Node 1
+  └ *rowexec.tableReader

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_types
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_types
@@ -1,6 +1,7 @@
 # LogicTest: local fakedist
 
-# Check that all types supported by the vectorized engine can be read correctly.
+# Check that all native types as well as some datum-backed types can be read
+# correctly.
 statement ok
 CREATE TABLE all_types (
     _bool        BOOL,
@@ -16,13 +17,17 @@ CREATE TABLE all_types (
     _uuid        UUID,
     _timestamp   TIMESTAMP,
     _timestamptz TIMESTAMPTZ,
-    _interval  INTERVAL
+    _interval    INTERVAL,
+    _inet        INet,
+    _json        JSON
 )
 
 statement ok
 INSERT
   INTO all_types
 VALUES (
+        NULL,
+        NULL,
         NULL,
         NULL,
         NULL,
@@ -52,62 +57,16 @@ VALUES (
        '63616665-6630-3064-6465-616462656562',
        '1-1-18 1:00:00.001',
        '1-1-18 1:00:00.001-8',
-       '12:34:56.123456'
+       '12:34:56.123456',
+       '127.0.0.1',
+       '[1, "hello", {"a": ["foo", {"b": 3}]}]'
        )
 
-query BTTRIIIORTTTTT
+query BTTRIIIORTTTTTTT
 SELECT * FROM all_types ORDER BY 1
 ----
-NULL   NULL  NULL                             NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL                                  NULL                                 NULL                               NULL
-false  123   2019-10-22 00:00:00 +0000 +0000  1.23  123   123   123   123   1.23  123   63616665-6630-3064-6465-616462656562  2001-01-18 01:00:00.001 +0000 +0000  2001-01-18 09:00:00.001 +0000 UTC  12:34:56.123456
-
-statement ok
-CREATE TABLE skip_unneeded_cols (
-  _id UUID,
-  _id2 INT8,
-  _float FLOAT8,
-  _unsupported1 INT ARRAY,
-  _bool BOOL,
-  _unsupported2 INT ARRAY,
-  _bool2 BOOL,
-  PRIMARY KEY(_id, _id2)
-)
-
-statement ok
-INSERT INTO skip_unneeded_cols VALUES ('63616665-6630-3064-6465-616462656562', 1, '1.2', NULL, true, NULL, false)
-
-statement ok
-SET vectorize=experimental_always
-
-query IBB
-SELECT _id2, _bool, _bool2 FROM skip_unneeded_cols
-----
-1 true false
-
-statement ok
-RESET vectorize
-
-# This query uses a builtin that returns currently unsupported type
-# (TimestampTZ). We're only interested in not getting an error. See #42871.
-statement ok
-SELECT experimental_strptime(_string, _string) IS NULL FROM all_types
-
-statement ok
-CREATE TABLE unsupported_type (id INT PRIMARY KEY, unsupported INT ARRAY)
-
-statement ok
-INSERT INTO unsupported_type (id) SELECT * FROM generate_series(1, 2000)
-
-statement ok
-SET vectorize=experimental_always
-
-# This query makes sure that CFetcher when reading from a table with an
-# unhandled type (that isn't needed) is reset correctly between batches.
-statement ok
-SELECT id FROM unsupported_type LIMIT 1 OFFSET 1100
-
-statement ok
-RESET vectorize
+NULL   NULL  NULL                             NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL                                  NULL                                 NULL                               NULL             NULL       NULL
+false  123   2019-10-22 00:00:00 +0000 +0000  1.23  123   123   123   123   1.23  123   63616665-6630-3064-6465-616462656562  2001-01-18 01:00:00.001 +0000 +0000  2001-01-18 09:00:00.001 +0000 UTC  12:34:56.123456  127.0.0.1  [1, "hello", {"a": ["foo", {"b": 3}]}]
 
 # Regression test for #44904 (mismatched physical types between materializer's
 # input and output, root of the problem is outside of the vectorized engine).

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3190,22 +3190,22 @@ func (expr *BinaryExpr) Eval(ctx *EvalContext) (Datum, error) {
 	if err != nil {
 		return nil, err
 	}
-	if left == DNull && !expr.fn.NullableArgs {
+	if left == DNull && !expr.Fn.NullableArgs {
 		return DNull, nil
 	}
 	right, err := expr.Right.(TypedExpr).Eval(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if right == DNull && !expr.fn.NullableArgs {
+	if right == DNull && !expr.Fn.NullableArgs {
 		return DNull, nil
 	}
-	res, err := expr.fn.Fn(ctx, left, right)
+	res, err := expr.Fn.Fn(ctx, left, right)
 	if err != nil {
 		return nil, err
 	}
 	if ctx.TestingKnobs.AssertBinaryExprReturnTypes {
-		if err := ensureExpectedType(expr.fn.ReturnType, res); err != nil {
+		if err := ensureExpectedType(expr.Fn.ReturnType, res); err != nil {
 			return nil, errors.NewAssertionErrorWithWrappedErrf(err,
 				"binary op %q", expr)
 		}

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1187,7 +1187,7 @@ type BinaryExpr struct {
 	Left, Right Expr
 
 	typeAnnotation
-	fn *BinOp
+	Fn *BinOp
 }
 
 // TypedLeft returns the BinaryExpr's left expression as a TypedExpr.
@@ -1203,7 +1203,7 @@ func (node *BinaryExpr) TypedRight() TypedExpr {
 // ResolvedBinOp returns the resolved binary op overload; can only be called
 // after Resolve (which happens during TypeCheck).
 func (node *BinaryExpr) ResolvedBinOp() *BinOp {
-	return node.fn
+	return node.Fn
 }
 
 // NewTypedBinaryExpr returns a new BinaryExpr that is well-typed.
@@ -1223,7 +1223,7 @@ func (node *BinaryExpr) memoizeFn() {
 		panic(errors.AssertionFailedf("lookup for BinaryExpr %s's BinOp failed",
 			AsStringWithFlags(node, FmtShowTypes)))
 	}
-	node.fn = fn
+	node.Fn = fn
 }
 
 // newBinExprIfValidOverload constructs a new BinaryExpr if and only
@@ -1237,7 +1237,7 @@ func newBinExprIfValidOverload(op BinaryOperator, left TypedExpr, right TypedExp
 			Operator: op,
 			Left:     left,
 			Right:    right,
-			fn:       fn,
+			Fn:       fn,
 		}
 		expr.typ = returnTypeToFixedType(fn.returnType())
 		return expr

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -118,7 +118,7 @@ func (expr *BinaryExpr) normalize(v *NormalizeVisitor) TypedExpr {
 	right := expr.TypedRight()
 	expectedType := expr.ResolvedType()
 
-	if !expr.fn.NullableArgs && (left == DNull || right == DNull) {
+	if !expr.Fn.NullableArgs && (left == DNull || right == DNull) {
 		return DNull
 	}
 

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -361,7 +361,7 @@ func (expr *BinaryExpr) TypeCheck(ctx *SemaContext, desired *types.T) (TypedExpr
 	}
 
 	expr.Left, expr.Right = leftTyped, rightTyped
-	expr.fn = binOp
+	expr.Fn = binOp
 	expr.typ = binOp.returnType()(typedSubExprs)
 	return expr, nil
 }
@@ -2436,7 +2436,7 @@ func (v stripFuncsVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 	case *UnaryExpr:
 		t.fn = nil
 	case *BinaryExpr:
-		t.fn = nil
+		t.Fn = nil
 	case *ComparisonExpr:
 		t.fn = nil
 	case *FuncExpr:


### PR DESCRIPTION
**tree, colexec: preliminary steps for datum-backed binary overloads**

This commit does a few things that are preliminary to adding support of
binary operations on datum-backed vectors:
1. it exports `fn` field of `tree.BinaryExpr` - we will be using this
function to evaluate the binary operation on datum-backed vectors
2. it renames `decimalOverloadScratch` to `overloadHelper` and plumbs it
from the planning stage for projection and selection operators. This
struct will be used to supply the resolved `BinaryExpr.Fn` function (and
possibly other information) later
3. it cleans up `vectorize_types` logic test a bit since we now support
all types.

Release note: None

**colexec: add support for binary operations on datum-backed types**

This commit adds the support for 4 binary operations when at least one
of the arguments is datum-backed vector and the result is datum-backed
vector as well. We reuse the same function that row engine uses when
evaluating such expressions, and the function is plumbed during the
planning via `overloadHelper` struct. Native (i.e. not datum-backed)
arguments are converted to datums at runtime.

Release note: None