### PR TITLE
sql: validate partial index predicates

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -323,7 +323,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				}
 
 			case *tree.CheckConstraintTableDef:
-				ck, err := MakeCheckConstraint(params.ctx,
+				ck, err := makeCheckConstraint(params.ctx,
 					n.tableDesc, d, inuseNames, &params.p.semaCtx, *tn)
 				if err != nil {
 					return err

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -99,7 +99,7 @@ func (p *planner) setupFamilyAndConstraintForShard(
 	}
 	// Avoid creating duplicate check constraints.
 	if _, ok := inuseNames[ckName]; !ok {
-		ck, err := MakeCheckConstraint(ctx, tableDesc, ckDef, inuseNames,
+		ck, err := makeCheckConstraint(ctx, tableDesc, ckDef, inuseNames,
 			&p.semaCtx, p.tableName)
 		if err != nil {
 			return err
@@ -199,9 +199,16 @@ func MakeIndexDescriptor(
 		telemetry.Inc(sqltelemetry.HashShardedIndexCounter)
 	}
 
-	// TODO(mgartner): remove this once partial indexes are fully supported.
-	if n.Predicate != nil && !params.SessionData().PartialIndexes {
-		return nil, unimplemented.NewWithIssue(9683, "partial indexes are not supported")
+	if n.Predicate != nil {
+		// TODO(mgartner): remove this once partial indexes are fully supported.
+		if !params.SessionData().PartialIndexes {
+			return nil, unimplemented.NewWithIssue(9683, "partial indexes are not supported")
+		}
+
+		_, err := validateIndexPredicate(params.ctx, tableDesc, n.Predicate, &params.p.semaCtx, n.Table)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if err := indexDesc.FillColumns(n.Columns); err != nil {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1175,6 +1175,18 @@ func makeTableDescIfAs(
 	return desc, err
 }
 
+// dequalifyColumnRefs returns an expression with table names stripped from
+// qualified column names.
+//
+// For example:
+//
+//   tab.a > 0 AND tab.b = 'foo'
+//   =>
+//   a > 0 AND b = 'foo'
+//
+// This dequalification is necessary when CHECK constraints or partial index
+// predicates are created. If the table name was not stripped, these expressions
+// would become invalid if the table is renamed.
 func dequalifyColumnRefs(
 	ctx context.Context, source *sqlbase.DataSourceInfo, expr tree.Expr,
 ) (tree.Expr, error) {
@@ -1465,9 +1477,16 @@ func MakeTableDesc(
 				}
 				idx.Partitioning = partitioning
 			}
-			// TODO(mgartner): remove this once partial indexes are fully supported.
-			if d.Predicate != nil && !sessionData.PartialIndexes {
-				return desc, unimplemented.NewWithIssue(9683, "partial indexes are not supported")
+			if d.Predicate != nil {
+				// TODO(mgartner): remove this once partial indexes are fully supported.
+				if !sessionData.PartialIndexes {
+					return desc, unimplemented.NewWithIssue(9683, "partial indexes are not supported")
+				}
+
+				_, err := validateIndexPredicate(ctx, &desc, d.Predicate, semaCtx, n.Table)
+				if err != nil {
+					return desc, err
+				}
 			}
 
 			if err := desc.AddIndex(idx, false); err != nil {
@@ -1501,9 +1520,16 @@ func MakeTableDesc(
 				}
 				idx.Partitioning = partitioning
 			}
-			// TODO(mgartner): remove this once partial indexes are fully supported.
-			if d.Predicate != nil && !sessionData.PartialIndexes {
-				return desc, unimplemented.NewWithIssue(9683, "partial indexes are not supported")
+			if d.Predicate != nil {
+				// TODO(mgartner): remove this once partial indexes are fully supported.
+				if !sessionData.PartialIndexes {
+					return desc, unimplemented.NewWithIssue(9683, "partial indexes are not supported")
+				}
+
+				_, err := validateIndexPredicate(ctx, &desc, d.Predicate, semaCtx, n.Table)
+				if err != nil {
+					return desc, err
+				}
 			}
 			if err := desc.AddIndex(idx, d.PrimaryKey); err != nil {
 				return desc, err
@@ -1670,7 +1696,7 @@ func MakeTableDesc(
 			// Pass, handled above.
 
 		case *tree.CheckConstraintTableDef:
-			ck, err := MakeCheckConstraint(ctx, &desc, d, generatedNames, semaCtx, n.Table)
+			ck, err := makeCheckConstraint(ctx, &desc, d, generatedNames, semaCtx, n.Table)
 			if err != nil {
 				return desc, err
 			}
@@ -1998,8 +2024,9 @@ func makeObjectAlreadyExistsError(collidingObject sqlbase.DescriptorProto, name 
 	return nil
 }
 
-// dummyColumnItem is used in MakeCheckConstraint to construct an expression
-// that can be both type-checked and examined for variable expressions.
+// dummyColumnItem is used in makeCheckConstraint and validateIndexPredicate to
+// construct an expression that can be both type-checked and examined for
+// variable expressions.
 type dummyColumnItem struct {
 	typ *types.T
 	// name is only used for error-reporting.
@@ -2207,9 +2234,8 @@ func iterColDescriptorsInExpr(
 
 		col, dropped, err := desc.FindColumnByName(c.ColumnName)
 		if err != nil || dropped {
-			return false, nil, pgerror.Newf(pgcode.InvalidTableDefinition,
-				"column %q not found, referenced in %q",
-				c.ColumnName, rootExpr)
+			return false, nil, pgerror.Newf(pgcode.UndefinedColumn,
+				"column %q does not exist, referenced in %q", c.ColumnName, rootExpr.String())
 		}
 
 		if err := f(col); err != nil {
@@ -2296,10 +2322,10 @@ func validateComputedColumn(
 // this new expression tree alongside a set containing the ColumnID of each
 // column seen in the expression.
 func replaceVars(
-	desc *sqlbase.MutableTableDescriptor, expr tree.Expr,
+	desc *sqlbase.MutableTableDescriptor, rootExpr tree.Expr,
 ) (tree.Expr, map[sqlbase.ColumnID]struct{}, error) {
 	colIDs := make(map[sqlbase.ColumnID]struct{})
-	newExpr, err := tree.SimpleVisit(expr, func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+	newExpr, err := tree.SimpleVisit(rootExpr, func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
 		vBase, ok := expr.(tree.VarName)
 		if !ok {
 			// Not a VarName, don't do anything to this node.
@@ -2318,8 +2344,8 @@ func replaceVars(
 
 		col, dropped, err := desc.FindColumnByName(c.ColumnName)
 		if err != nil || dropped {
-			return false, nil, fmt.Errorf("column %q not found for constraint %q",
-				c.ColumnName, expr.String())
+			return false, nil, pgerror.Newf(pgcode.UndefinedColumn,
+				"column %q does not exist, referenced in %q", c.ColumnName, rootExpr.String())
 		}
 		colIDs[col.ID] = struct{}{}
 		// Convert to a dummy node of the correct type.
@@ -2328,8 +2354,8 @@ func replaceVars(
 	return newExpr, colIDs, err
 }
 
-// MakeCheckConstraint makes a descriptor representation of a check from a def.
-func MakeCheckConstraint(
+// makeCheckConstraint makes a descriptor representation of a check from a def.
+func makeCheckConstraint(
 	ctx context.Context,
 	desc *sqlbase.MutableTableDescriptor,
 	d *tree.CheckConstraintTableDef,

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -102,7 +102,7 @@ CREATE TABLE bad (a INT CHECK(sum(a) OVER () > 1))
 statement error pq: unsupported binary operator: <bool> - <bool>
 CREATE TABLE t4 (a INT CHECK (false - true))
 
-statement error column "b" not found, referenced in "a < b"
+statement error pgcode 42703 column "b" does not exist, referenced in "a < b"
 CREATE TABLE t4 (a INT, CHECK (a < b), CHECK (a+b+c+d < 20))
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -1,0 +1,75 @@
+#### Partial Indexes
+
+# TODO(mgartner): remove this once partial indexes are fully supported.
+statement ok
+SET experimental_partial_indexes=on
+
+#### Validate partial index predicates.
+
+statement ok
+CREATE TABLE t1 (a INT, INDEX (a) WHERE a = 0)
+
+statement ok
+CREATE TABLE t2 (a INT, INDEX (a) WHERE false)
+
+# Allow immutable functions.
+statement ok
+CREATE TABLE t3 (a INT, INDEX (a) WHERE abs(1) > 2)
+
+# Don't allow non-boolean expressions.
+statement error expected index predicate expression to have type bool, but '1' has type int
+CREATE TABLE error (a INT, INDEX (a) WHERE 1)
+
+# Don't allow columns not in table.
+statement error pgcode 42703 column "b" does not exist, referenced in "b = 3"
+CREATE TABLE error (a INT, INDEX (a) WHERE b = 3)
+
+# Don't allow mutable functions.
+# TODO(mgartner): The error code for this should be 42P17, not 0A000.
+statement error pgcode 0A000 impure functions are not allowed in index predicate
+CREATE TABLE error (t TIMESTAMPTZ, INDEX (t) WHERE t < now())
+
+# Don't allow variable subexpressions.
+statement error pgcode 42601 variable sub-expressions are not allowed in index predicate
+CREATE TABLE error (a INT, INDEX (a) WHERE count(*) = 1)
+
+# Don't allow subqueries.
+statement error pgcode 42601 variable sub-expressions are not allowed in index predicate
+CREATE TABLE error (a INT, INDEX (a) WHERE (SELECT true))
+
+# Don't allow aggregate functions.
+statement error pgcode 42803 aggregate functions are not allowed in index predicate
+CREATE TABLE error (a INT, INDEX (a) WHERE sum(a) > 1)
+
+# Don't allow window functions.
+statement error pgcode 42P20 window functions are not allowed in index predicate
+CREATE TABLE error (a INT, INDEX (a) WHERE row_number() OVER () > 1)
+
+# Don't allow set-returning functions.
+statement error pgcode 0A000 generator functions are not allowed in index predicate
+CREATE TABLE error (a INT, INDEX (a) WHERE generate_series(1, 1))
+
+# Fail on bad types.
+statement error pq: unsupported binary operator: <bool> - <bool>
+CREATE TABLE error (a INT, INDEX (a) WHERE false - true)
+
+#### Validate CREATE TABLE ... UNIQUE INDEX predicate.
+
+statement ok
+CREATE TABLE t4 (a INT, UNIQUE INDEX (a) WHERE a = 0)
+
+# Don't allow invalid predicates.
+statement error expected index predicate expression to have type bool, but '1' has type int
+CREATE TABLE error (a INT, UNIQUE INDEX (a) WHERE 1)
+
+#### Validate CREATE INDEX predicate.
+
+statement ok
+CREATE TABLE t (a INT)
+
+statement ok
+CREATE INDEX i1 ON t (a) WHERE a = 0
+
+# Don't allow invalid predicates.
+statement error expected index predicate expression to have type bool, but '1' has type int
+CREATE INDEX error ON t (a) WHERE 1

--- a/pkg/sql/partial_index.go
+++ b/pkg/sql/partial_index.go
@@ -1,0 +1,55 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
+
+// validateIndexPredicate validates that an expression is a valid partial index
+// predicate. If the expression is valid, it returns an expression with the
+// columns replaced with dummyColumnItems and the constants folded.
+//
+// A predicate expression is valid if all of the following are true:
+//
+//   - It results in a boolean.
+//   - It refers only to columns in the table.
+//   - It does not include subqueries.
+//   - It does not include mutable, aggregate, window, or set returning
+//     functions.
+//
+func validateIndexPredicate(
+	ctx context.Context,
+	desc *sqlbase.MutableTableDescriptor,
+	expr tree.Expr,
+	semaCtx *tree.SemaContext,
+	tableName tree.TableName,
+) (tree.Expr, error) {
+
+	// Replace column variables with dummyColumnItems.
+	expr, _, err := replaceVars(desc, expr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check that the type of the expression is a types.Bool and that there are
+	// no variable expressions (besides dummyColumnItems) and no impure
+	// functions.
+	if _, err := sqlbase.SanitizeVarFreeExpr(expr, types.Bool, "index predicate", semaCtx, false /* allowImpure */); err != nil {
+		return nil, err
+	}
+
+	return expr, nil
+}


### PR DESCRIPTION
This commit adds validation for partial index predicates. Errors are
now returned when the user attempts to create a partial index with an
invalid predicate.

A predicate expression is valid if all of the following are true:

   - It results in a boolean.
   - It refers only to columns in the table.
   - It does not include mutable, aggregate, window, or set returning
     functions.

This commit also fixes the error code when non-existant columns are
referenced in a CHECK constraint. For example, consider the statement:

    CREATE TABLE t (a INT, CHECK (b = 3));

This now produces the correct error code 42703, matching Postgres's
behavior.

Fixes #49342

Release note: None
