### PR TITLE
sql: fill pg_extension.geometry_columns/geography_columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -877,15 +877,28 @@ Square overlapping left and right square  Square overlapping left and right squa
 
 subtest pg_extension
 
-statement error not yet implemented
-SELECT * FROM pg_extension.geography_columns
+statement ok
+CREATE TABLE pg_extension_test (
+  a geography(point, 4326),
+  b geometry(linestring, 3857),
+  c geometry,
+  d geography
+)
 
-statement error not yet implemented
-SELECT * FROM pg_extension.geometry_columns
+query TTTTIIT rowsort
+SELECT * FROM pg_extension.geography_columns WHERE f_table_name = 'pg_extension_test'
+----
+test  public  pg_extension_test  a  2     4326  POINT
+test  public  pg_extension_test  d  NULL  0     GEOMETRY
+
+query TTTTIIT rowsort
+SELECT * FROM pg_extension.geometry_columns WHERE f_table_name = 'pg_extension_test'
+----
+test  public  pg_extension_test  b  2  3857  LINESTRING
+test  public  pg_extension_test  c  2  0     GEOMETRY
 
 statement error not yet implemented
 SELECT * FROM pg_extension.spatial_ref_sys ORDER BY srid ASC
-
 
 subtest st_srid
 

--- a/pkg/sql/pg_extension.go
+++ b/pkg/sql/pg_extension.go
@@ -12,9 +12,13 @@ package sql
 
 import (
 	"context"
+	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 )
 
@@ -32,6 +36,70 @@ var pgExtension = virtualSchema{
 	validWithNoDatabaseContext: false,
 }
 
+func postgisColumnsTablePopulator(
+	matchingFamily types.Family,
+) func(context.Context, *planner, *DatabaseDescriptor, func(...tree.Datum) error) error {
+	return func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		return forEachTableDesc(
+			ctx,
+			p,
+			dbContext,
+			hideVirtual,
+			func(db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor) error {
+				if !table.IsPhysicalTable() {
+					return nil
+				}
+				if p.CheckAnyPrivilege(ctx, table) != nil {
+					return nil
+				}
+				for _, colDesc := range table.Columns {
+					if colDesc.Type.Family() != matchingFamily {
+						continue
+					}
+					m, err := colDesc.Type.GeoMetadata()
+					if err != nil {
+						return err
+					}
+
+					var datumNDims tree.Datum
+					switch m.Shape {
+					case geopb.Shape_Point, geopb.Shape_LineString, geopb.Shape_Polygon,
+						geopb.Shape_MultiPoint, geopb.Shape_MultiLineString, geopb.Shape_MultiPolygon,
+						geopb.Shape_GeometryCollection:
+						datumNDims = tree.NewDInt(2)
+					case geopb.Shape_Geometry, geopb.Shape_Unset:
+						// For geometry_columns, the query in PostGIS COALESCES the value to 2.
+						// Otherwise, the value is NULL.
+						if matchingFamily == types.GeometryFamily {
+							datumNDims = tree.NewDInt(2)
+						} else {
+							datumNDims = tree.DNull
+						}
+					}
+
+					shapeName := m.Shape.String()
+					if m.Shape == geopb.Shape_Unset {
+						shapeName = geopb.Shape_Geometry.String()
+					}
+
+					if err := addRow(
+						tree.NewDString(db.GetName()),
+						tree.NewDString(scName),
+						tree.NewDString(table.GetName()),
+						tree.NewDString(colDesc.Name),
+						datumNDims,
+						tree.NewDInt(tree.DInt(m.SRID)),
+						tree.NewDString(strings.ToUpper(shapeName)),
+					); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		)
+	}
+}
+
 var pgExtensionGeographyColumnsTable = virtualSchemaTable{
 	comment: `Shows all defined geography columns. Matches PostGIS' geography_columns functionality.`,
 	schema: `
@@ -44,9 +112,7 @@ CREATE TABLE pg_extension.geography_columns (
 	srid integer,
 	type text
 )`,
-	generator: func(ctx context.Context, p *planner, db *DatabaseDescriptor) (virtualTableGenerator, cleanupFunc, error) {
-		return nil, func() {}, errors.Newf("not yet implemented")
-	},
+	populate: postgisColumnsTablePopulator(types.GeographyFamily),
 }
 
 var pgExtensionGeometryColumnsTable = virtualSchemaTable{
@@ -61,9 +127,7 @@ CREATE TABLE pg_extension.geometry_columns (
 	srid integer,
 	type text
 )`,
-	generator: func(ctx context.Context, p *planner, db *DatabaseDescriptor) (virtualTableGenerator, cleanupFunc, error) {
-		return nil, func() {}, errors.Newf("not yet implemented")
-	},
+	populate: postgisColumnsTablePopulator(types.GeometryFamily),
 }
 
 var pgExtensionSpatialRefSysTable = virtualSchemaTable{

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -838,6 +838,15 @@ func MakeGeography(shape geopb.Shape, srid geopb.SRID) *T {
 	}}
 }
 
+// GeoMetadata returns the GeoMetadata of the type object if it exists.
+// This should only exist on Geometry and Geography types.
+func (t *T) GeoMetadata() (*GeoMetadata, error) {
+	if t.InternalType.GeoMetadata == nil {
+		return nil, errors.Newf("GeoMetadata does not exist on type")
+	}
+	return t.InternalType.GeoMetadata, nil
+}
+
 var (
 	// DefaultIntervalTypeMetadata returns a duration field that is unset,
 	// using INTERVAL or INTERVAL ( iconst32 ) syntax instead of INTERVAL


### PR DESCRIPTION
Release note (sql change): Populate the pg_extension.geometry_columns
and pg_extension.geography_columns virtual table with metadata for
tables which store have columns relevant to geometry or geography data
types.