### PR TITLE
sqlbase: Add created_by columns to system.jobs

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -70,6 +70,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>20.1-5</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>20.1-6</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -65,6 +65,7 @@ const (
 	VersionEnums
 	VersionRangefeedLeases
 	VersionAlterColumnTypeGeneral
+	VersionAlterSystemJobsAddCreatedByColumns
 
 	// Add new versions here (step one of two).
 )
@@ -498,6 +499,12 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// conversions that require the column data to be rewritten.
 		Key:     VersionAlterColumnTypeGeneral,
 		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 5},
+	},
+	{
+		// VersionAlterSystemJobsTable is a version which modified system.jobs table
+		//
+		Key:     VersionAlterSystemJobsAddCreatedByColumns,
+		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 6},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/clusterversion/versionkey_string.go
+++ b/pkg/clusterversion/versionkey_string.go
@@ -41,11 +41,12 @@ func _() {
 	_ = x[VersionEnums-30]
 	_ = x[VersionRangefeedLeases-31]
 	_ = x[VersionAlterColumnTypeGeneral-32]
+	_ = x[VersionAlterSystemJobsAddCreatedByColumns-33]
 }
 
-const _VersionKey_name = "Version19_1VersionStart19_2VersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDsVersionHashShardedIndexesVersionCreateRolePrivilegeVersionStatementDiagnosticsSystemTablesVersionSchemaChangeJobVersionSavepointsVersionTimeTZTypeVersionTimePrecisionVersion20_1VersionStart20_2VersionGeospatialTypeVersionEnumsVersionRangefeedLeasesVersionAlterColumnTypeGeneral"
+const _VersionKey_name = "Version19_1VersionStart19_2VersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDsVersionHashShardedIndexesVersionCreateRolePrivilegeVersionStatementDiagnosticsSystemTablesVersionSchemaChangeJobVersionSavepointsVersionTimeTZTypeVersionTimePrecisionVersion20_1VersionStart20_2VersionGeospatialTypeVersionEnumsVersionRangefeedLeasesVersionAlterColumnTypeGeneralVersionAlterSystemJobsAddCreatedByColumns"
 
-var _VersionKey_index = [...]uint16{0, 11, 27, 49, 75, 109, 136, 176, 200, 211, 227, 258, 287, 322, 354, 380, 404, 441, 480, 499, 534, 559, 585, 624, 646, 663, 680, 700, 711, 727, 748, 760, 782, 811}
+var _VersionKey_index = [...]uint16{0, 11, 27, 49, 75, 109, 136, 176, 200, 211, 227, 258, 287, 322, 354, 380, 404, 441, 480, 499, 534, 559, 585, 624, 646, 663, 680, 700, 711, 727, 748, 760, 782, 811, 852}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -1116,6 +1116,8 @@ system         pg_extension  geometry_columns                 f_table_schema    
 system         pg_extension  geometry_columns                 srid                      6
 system         pg_extension  geometry_columns                 type                      7
 system         public        jobs                             created                   3
+system         public        jobs                             created_by_id             7
+system         public        jobs                             created_by_type           6
 system         public        jobs                             id                        1
 system         public        jobs                             payload                   4
 system         public        jobs                             progress                  5

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -659,6 +659,7 @@ indexrelid  indrelid  indnatts  indisunique  indisprimary  indisexclusion  indim
 2361445172  8         1         true         true          false           true          false           true        false         false       true       false           1        0                          0         2          NULL      NULL
 2407840836  24        3         true         true          false           true          false           true        false         false       true       false           1 2 3    0 0 0                      0 0 0     2 2 2      NULL      NULL
 2621181440  15        2         false        false         false           false         false           true        false         false       true       false           2 3      3903121477 0               0 0       2 2        NULL      NULL
+2621181441  15        2         false        false         false           false         false           true        false         false       true       false           6 7      3903121477 0               0 0       2 2        NULL      NULL
 2621181443  15        1         true         true          false           true          false           true        false         false       true       false           1        0                          0         2          NULL      NULL
 2667577107  31        1         true         true          false           true          false           true        false         false       true       false           1        0                          0         2          NULL      NULL
 2834522046  34        1         true         true          false           true          false           true        false         false       true       false           1        0                          0         2          NULL      NULL
@@ -714,6 +715,8 @@ indexrelid  operator_argument_type_oid  operator_argument_position
 2407840836  0                           3
 2621181440  0                           1
 2621181440  0                           2
+2621181441  0                           1
+2621181441  0                           2
 2621181443  0                           1
 2667577107  0                           1
 2834522046  0                           1

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -138,11 +138,13 @@ lastUpdated  TIMESTAMP  false  NULL  ·  {}         false
 query TTBTTTB
 SHOW COLUMNS FROM system.jobs
 ----
-id        INT8       false  unique_rowid()     ·  {primary,jobs_status_created_idx}  false
-status    STRING     false  NULL               ·  {jobs_status_created_idx}          false
-created   TIMESTAMP  false  now():::TIMESTAMP  ·  {jobs_status_created_idx}          false
-payload   BYTES      false  NULL               ·  {}                                 false
-progress  BYTES      true   NULL               ·  {}                                 false
+id               INT8       false  unique_rowid()     ·  {primary,jobs_status_created_idx,jobs_created_by_type_created_by_id_idx}  false
+status           STRING     false  NULL               ·  {jobs_status_created_idx,jobs_created_by_type_created_by_id_idx}          false
+created          TIMESTAMP  false  now():::TIMESTAMP  ·  {jobs_status_created_idx}                                                 false
+payload          BYTES      false  NULL               ·  {}                                                                        false
+progress         BYTES      true   NULL               ·  {}                                                                        false
+created_by_type  STRING     true   NULL               ·  {jobs_created_by_type_created_by_id_idx}                                  false
+created_by_id    INT8       true   NULL               ·  {jobs_created_by_type_created_by_id_idx}                                  false
 
 query TTBTTTB
 SHOW COLUMNS FROM system.settings

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -155,6 +155,8 @@ CREATE TABLE system.ui (
 
 	// Note: this schema is changed in a migration (a progress column is added in
 	// a separate family).
+	// NB: main column family uses old, pre created_by_type/created_by_id columns, named.
+	// This is done to minimize migration work required.
 	JobsTableSchema = `
 CREATE TABLE system.jobs (
 	id                INT8      DEFAULT unique_rowid() PRIMARY KEY,
@@ -162,8 +164,12 @@ CREATE TABLE system.jobs (
 	created           TIMESTAMP NOT NULL DEFAULT now(),
 	payload           BYTES     NOT NULL,
 	progress          BYTES,
+	created_by_type   STRING,
+	created_by_id     INT,
 	INDEX (status, created),
-	FAMILY (id, status, created, payload),
+	INDEX (created_by_type, created_by_id) STORING (status),
+
+	FAMILY fam_0_id_status_created_payload (id, status, created, payload, created_by_type, created_by_id),
 	FAMILY progress (progress)
 );`
 
@@ -812,14 +818,19 @@ var (
 			{Name: "created", ID: 3, Type: types.Timestamp, DefaultExpr: &nowString},
 			{Name: "payload", ID: 4, Type: types.Bytes},
 			{Name: "progress", ID: 5, Type: types.Bytes, Nullable: true},
+			{Name: "created_by_type", ID: 6, Type: types.String, Nullable: true},
+			{Name: "created_by_id", ID: 7, Type: types.Int, Nullable: true},
 		},
-		NextColumnID: 6,
+		NextColumnID: 8,
 		Families: []ColumnFamilyDescriptor{
 			{
+				// NB: We are using family name that existed prior to adding created_by_type and
+				// created_by_id columns.  This is done to minimize and simplify migration work
+				// that needed to be done.
 				Name:        "fam_0_id_status_created_payload",
 				ID:          0,
-				ColumnNames: []string{"id", "status", "created", "payload"},
-				ColumnIDs:   []ColumnID{1, 2, 3, 4},
+				ColumnNames: []string{"id", "status", "created", "payload", "created_by_type", "created_by_id"},
+				ColumnIDs:   []ColumnID{1, 2, 3, 4, 6, 7},
 			},
 			{
 				Name:            "progress",
@@ -842,8 +853,20 @@ var (
 				ExtraColumnIDs:   []ColumnID{1},
 				Version:          SecondaryIndexFamilyFormatVersion,
 			},
+			{
+				Name:             "jobs_created_by_type_created_by_id_idx",
+				ID:               3,
+				Unique:           false,
+				ColumnNames:      []string{"created_by_type", "created_by_id"},
+				ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC, IndexDescriptor_ASC},
+				ColumnIDs:        []ColumnID{6, 7},
+				StoreColumnIDs:   []ColumnID{2},
+				StoreColumnNames: []string{"status"},
+				ExtraColumnIDs:   []ColumnID{1},
+				Version:          SecondaryIndexFamilyFormatVersion,
+			},
 		},
-		NextIndexID:    3,
+		NextIndexID:    4,
 		Privileges:     NewCustomSuperuserPrivilegeDescriptor(SystemAllowedPrivileges[keys.JobsTableID]),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -319,6 +319,13 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		name:   "add CREATEROLE privilege to admin/root",
 		workFn: addCreateRoleToAdminAndRoot,
 	},
+	{
+		// Introduced in v20.2.
+		name:   "add created_by columns to system.jobs",
+		workFn: alterSystemJobsAddCreatedByColumns,
+		includedInBootstrap: clusterversion.VersionByKey(
+			clusterversion.VersionAlterSystemJobsAddCreatedByColumns),
+	},
 }
 
 func staticIDs(
@@ -1850,4 +1857,30 @@ func depublicizeSystemComments(ctx context.Context, r runner) error {
 		}
 	}
 	return nil
+}
+
+func alterSystemJobsAddCreatedByColumns(ctx context.Context, r runner) error {
+	// NB: we use family name as it existed in the original system.jobs schema to
+	// minimize migration work needed (avoid renames).
+	addColsStmt := `
+ALTER TABLE system.jobs
+ADD COLUMN IF NOT EXISTS created_by_type STRING FAMILY fam_0_id_status_created_payload,
+ADD COLUMN IF NOT EXISTS created_by_id INT FAMILY fam_0_id_status_created_payload
+`
+	addIdxStmt := `
+CREATE INDEX IF NOT EXISTS jobs_created_by_type_created_by_id_idx
+ON system.jobs (created_by_type, created_by_id) 
+STORING (status)
+`
+	asNode := sqlbase.InternalExecutorSessionDataOverride{
+		User: security.NodeUser,
+	}
+
+	if _, err := r.sqlExecutor.ExecEx(
+		ctx, "add-jobs-cols", nil, asNode, addColsStmt); err != nil {
+		return err
+	}
+
+	_, err := r.sqlExecutor.ExecEx(ctx, "add-jobs-idx", nil, asNode, addIdxStmt)
+	return err
 }

--- a/pkg/sqlmigrations/migrations_test.go
+++ b/pkg/sqlmigrations/migrations_test.go
@@ -807,3 +807,76 @@ func TestMigrateNamespaceTableDescriptors(t *testing.T) {
 		return nil
 	}))
 }
+
+func TestAlterSystemJobsTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	// We need to use "old" jobs table descriptor without newly added columns
+	// in order to test migration.
+	// oldJobsTableSchema is system.jobs definition prior to 20.2
+	oldJobsTableSchema := `
+CREATE TABLE system.jobs (
+	id                INT8      DEFAULT unique_rowid() PRIMARY KEY,
+	status            STRING    NOT NULL,
+	created           TIMESTAMP NOT NULL DEFAULT now(),
+	payload           BYTES     NOT NULL,
+	progress          BYTES,
+	INDEX (status, created),
+
+	FAMILY (id, status, created, payload),
+	FAMILY progress (progress)
+)
+`
+	oldJobsTable, err := sql.CreateTestTableDescriptor(
+		context.Background(),
+		keys.SystemDatabaseID,
+		keys.JobsTableID,
+		oldJobsTableSchema,
+		sqlbase.JobsTable.Privileges,
+	)
+	require.NoError(t, err)
+
+	const primaryFamilyName = "fam_0_id_status_created_payload"
+	oldPrimaryFamilyColumns := []string{"id", "status", "created", "payload"}
+	newPrimaryFamilyColumns := append(
+		oldPrimaryFamilyColumns, "created_by_type", "created_by_id")
+
+	// Sanity check oldJobsTable does not have new columns.
+	require.Equal(t, 5, len(oldJobsTable.Columns))
+	require.Equal(t, 2, len(oldJobsTable.Families))
+	require.Equal(t, primaryFamilyName, oldJobsTable.Families[0].Name)
+	require.Equal(t, oldPrimaryFamilyColumns, oldJobsTable.Families[0].ColumnNames)
+
+	jobsTable := sqlbase.JobsTable
+	sqlbase.JobsTable = oldJobsTable
+	defer func() {
+		sqlbase.JobsTable = jobsTable
+	}()
+
+	mt := makeMigrationTest(ctx, t)
+	defer mt.close(ctx)
+
+	migration := mt.pop(t, "add created_by columns to system.jobs")
+	mt.start(t, base.TestServerArgs{})
+
+	// Run migration and verify we have added columns and renamed column family.
+	require.NoError(t, mt.runMigration(ctx, migration))
+
+	newJobsTable := sqlbase.GetTableDescriptor(
+		mt.kvDB, keys.SystemSQLCodec, "system", "jobs")
+	require.Equal(t, 7, len(newJobsTable.Columns))
+	require.Equal(t, "created_by_type", newJobsTable.Columns[5].Name)
+	require.Equal(t, "created_by_id", newJobsTable.Columns[6].Name)
+	require.Equal(t, 2, len(newJobsTable.Families))
+	// Ensure we keep old family name.
+	require.Equal(t, primaryFamilyName, newJobsTable.Families[0].Name)
+	// Make sure our primary family has new columns added to it.
+	require.Equal(t, newPrimaryFamilyColumns, newJobsTable.Families[0].ColumnNames)
+
+	// Run the migration again -- it should be a no-op.
+	require.NoError(t, mt.runMigration(ctx, migration))
+	newJobsTableAgain := sqlbase.GetTableDescriptor(
+		mt.kvDB, keys.SystemSQLCodec, "system", "jobs")
+	require.True(t, proto.Equal(newJobsTable, newJobsTableAgain))
+}


### PR DESCRIPTION
Informs #49346

Add created_by_type and created_by_id columns, along with the index over
these columns, to the system.jobs table.

Add sql migration code to migrate old definition to the new one.

See https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20200414_scheduled_jobs.md

Release Notes: None