### PR TITLE
sql,opt: add support for AddGeometryColumn function

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -679,6 +679,18 @@ has no relationship with the commit order of concurrent transactions.</p>
 <table>
 <thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
 <tbody>
+<tr><td><a name="addgeometrycolumn"></a><code>addgeometrycolumn(catalog_name: <a href="string.html">string</a>, schema_name: <a href="string.html">string</a>, table_name: <a href="string.html">string</a>, column_name: <a href="string.html">string</a>, srid: <a href="int.html">int</a>, type: <a href="string.html">string</a>, dimension: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Adds a new geometry column to an existing table and returns metadata about the column created.</p>
+</span></td></tr>
+<tr><td><a name="addgeometrycolumn"></a><code>addgeometrycolumn(catalog_name: <a href="string.html">string</a>, schema_name: <a href="string.html">string</a>, table_name: <a href="string.html">string</a>, column_name: <a href="string.html">string</a>, srid: <a href="int.html">int</a>, type: <a href="string.html">string</a>, dimension: <a href="int.html">int</a>, use_typmod: <a href="bool.html">bool</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Adds a new geometry column to an existing table and returns metadata about the column created.</p>
+</span></td></tr>
+<tr><td><a name="addgeometrycolumn"></a><code>addgeometrycolumn(schema_name: <a href="string.html">string</a>, table_name: <a href="string.html">string</a>, column_name: <a href="string.html">string</a>, srid: <a href="int.html">int</a>, type: <a href="string.html">string</a>, dimension: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Adds a new geometry column to an existing table and returns metadata about the column created.</p>
+</span></td></tr>
+<tr><td><a name="addgeometrycolumn"></a><code>addgeometrycolumn(schema_name: <a href="string.html">string</a>, table_name: <a href="string.html">string</a>, column_name: <a href="string.html">string</a>, srid: <a href="int.html">int</a>, type: <a href="string.html">string</a>, dimension: <a href="int.html">int</a>, use_typmod: <a href="bool.html">bool</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Adds a new geometry column to an existing table and returns metadata about the column created.</p>
+</span></td></tr>
+<tr><td><a name="addgeometrycolumn"></a><code>addgeometrycolumn(table_name: <a href="string.html">string</a>, column_name: <a href="string.html">string</a>, srid: <a href="int.html">int</a>, type: <a href="string.html">string</a>, dimension: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Adds a new geometry column to an existing table and returns metadata about the column created.</p>
+</span></td></tr>
+<tr><td><a name="addgeometrycolumn"></a><code>addgeometrycolumn(table_name: <a href="string.html">string</a>, column_name: <a href="string.html">string</a>, srid: <a href="int.html">int</a>, type: <a href="string.html">string</a>, dimension: <a href="int.html">int</a>, use_typmod: <a href="bool.html">bool</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Adds a new geometry column to an existing table and returns metadata about the column created.</p>
+</span></td></tr>
 <tr><td><a name="st_area"></a><code>st_area(geography: geography) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the area of the given geography in meters^2. Uses a spheroid to perform the operation.</p>
 <p>This function utilizes the GeographicLib library for spheroid calculations.</p>
 </span></td></tr>

--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
@@ -1,0 +1,243 @@
+# LogicTest: local
+
+# ------------------------------------------------------------------------------
+# AddGeometryColumn tests
+# ------------------------------------------------------------------------------
+statement ok
+CREATE TABLE my_spatial_table (k INT PRIMARY KEY)
+
+query T
+SELECT AddGeometryColumn ('test','public','my_spatial_table','geom1',4326,'POINT',2)
+----
+test.public.my_spatial_table.geom1 SRID:4326 TYPE:POINT DIMS:2
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT AddGeometryColumn ('test','public','my_spatial_table','geom1',4326,'POINT',2)
+----
+·                           distributed    false                                                                               ·                    ·
+·                           vectorized     false                                                                               ·                    ·
+root                        ·              ·                                                                                   (addgeometrycolumn)  ·
+ ├── values                 ·              ·                                                                                   (addgeometrycolumn)  ·
+ │                          size           1 column, 1 row                                                                     ·                    ·
+ │                          row 0, expr 0  addgeometrycolumn('test', 'public', 'my_spatial_table', 'geom1', 4326, 'POINT', 2)  ·                    ·
+ └── subquery               ·              ·                                                                                   ·                    ·
+      │                     id             @S1                                                                                 ·                    ·
+      │                     original sql   ALTER TABLE test.public.my_spatial_table ADD COLUMN geom1 GEOMETRY(POINT,4326)      ·                    ·
+      │                     exec mode      all rows                                                                            ·                    ·
+      └── buffer node       ·              ·                                                                                   ()                   ·
+           │                label          buffer 1                                                                            ·                    ·
+           └── alter table  ·              ·                                                                                   ()                   ·
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE my_spatial_table]
+----
+CREATE TABLE my_spatial_table (
+   k INT8 NOT NULL,
+   geom1 GEOMETRY(POINT,4326) NULL,
+   CONSTRAINT "primary" PRIMARY KEY (k ASC),
+   FAMILY "primary" (k, geom1)
+)
+
+query T
+SELECT AddGeometryColumn ('public','my_spatial_table','geom2',4326,'POLYGON',2)
+----
+public.my_spatial_table.geom2 SRID:4326 TYPE:POLYGON DIMS:2
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE my_spatial_table]
+----
+CREATE TABLE my_spatial_table (
+   k INT8 NOT NULL,
+   geom1 GEOMETRY(POINT,4326) NULL,
+   geom2 GEOMETRY(POLYGON,4326) NULL,
+   CONSTRAINT "primary" PRIMARY KEY (k ASC),
+   FAMILY "primary" (k, geom1, geom2)
+)
+
+query T
+SELECT AddGeometryColumn ('my_spatial_table','geom3',4326,'MULTIPOLYGON',2)
+----
+my_spatial_table.geom3 SRID:4326 TYPE:MULTIPOLYGON DIMS:2
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE my_spatial_table]
+----
+CREATE TABLE my_spatial_table (
+   k INT8 NOT NULL,
+   geom1 GEOMETRY(POINT,4326) NULL,
+   geom2 GEOMETRY(POLYGON,4326) NULL,
+   geom3 GEOMETRY(MULTIPOLYGON,4326) NULL,
+   CONSTRAINT "primary" PRIMARY KEY (k ASC),
+   FAMILY "primary" (k, geom1, geom2, geom3)
+)
+
+query T
+SELECT AddGeometryColumn ('test','public','my_spatial_table','geom4',4326,'LINESTRING',2,true)
+----
+test.public.my_spatial_table.geom4 SRID:4326 TYPE:LINESTRING DIMS:2
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE my_spatial_table]
+----
+CREATE TABLE my_spatial_table (
+   k INT8 NOT NULL,
+   geom1 GEOMETRY(POINT,4326) NULL,
+   geom2 GEOMETRY(POLYGON,4326) NULL,
+   geom3 GEOMETRY(MULTIPOLYGON,4326) NULL,
+   geom4 GEOMETRY(LINESTRING,4326) NULL,
+   CONSTRAINT "primary" PRIMARY KEY (k ASC),
+   FAMILY "primary" (k, geom1, geom2, geom3, geom4)
+)
+
+query T
+SELECT AddGeometryColumn ('public','my_spatial_table','geom5',4326,'MULTIPOINT',2,true)
+----
+public.my_spatial_table.geom5 SRID:4326 TYPE:MULTIPOINT DIMS:2
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE my_spatial_table]
+----
+CREATE TABLE my_spatial_table (
+   k INT8 NOT NULL,
+   geom1 GEOMETRY(POINT,4326) NULL,
+   geom2 GEOMETRY(POLYGON,4326) NULL,
+   geom3 GEOMETRY(MULTIPOLYGON,4326) NULL,
+   geom4 GEOMETRY(LINESTRING,4326) NULL,
+   geom5 GEOMETRY(MULTIPOINT,4326) NULL,
+   CONSTRAINT "primary" PRIMARY KEY (k ASC),
+   FAMILY "primary" (k, geom1, geom2, geom3, geom4, geom5)
+)
+
+query T
+SELECT AddGeometryColumn ('my_spatial_table','geom6',4326,'MULTILINESTRING',2,true)
+----
+my_spatial_table.geom6 SRID:4326 TYPE:MULTILINESTRING DIMS:2
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE my_spatial_table]
+----
+CREATE TABLE my_spatial_table (
+   k INT8 NOT NULL,
+   geom1 GEOMETRY(POINT,4326) NULL,
+   geom2 GEOMETRY(POLYGON,4326) NULL,
+   geom3 GEOMETRY(MULTIPOLYGON,4326) NULL,
+   geom4 GEOMETRY(LINESTRING,4326) NULL,
+   geom5 GEOMETRY(MULTIPOINT,4326) NULL,
+   geom6 GEOMETRY(MULTILINESTRING,4326) NULL,
+   CONSTRAINT "primary" PRIMARY KEY (k ASC),
+   FAMILY "primary" (k, geom1, geom2, geom3, geom4, geom5, geom6)
+)
+
+query error relation "missing_table" does not exist
+SELECT AddGeometryColumn ('missing_table','geom',4326,'POINT',2)
+
+query error column "geom6" of relation "my_spatial_table" already exists
+SELECT AddGeometryColumn ('my_spatial_table','geom6',4326,'POINT',2)
+
+query error unimplemented: useTypmod=false is currently not supported with AddGeometryColumn
+SELECT AddGeometryColumn ('my_spatial_table','geom7',4326,'POINT',2,false)
+
+query error only dimension=2 is currently supported
+SELECT AddGeometryColumn ('my_spatial_table','geom7',4326,'POINT',3)
+
+query error unimplemented: non-constant argument passed to addgeometrycolumn
+SELECT AddGeometryColumn ('my_spatial_table','geom'||k::string,4326,'POINT',2) FROM my_spatial_table
+
+query error at or near "fakeshape": syntax error
+SELECT AddGeometryColumn ('my_spatial_table','geom7',4326,'FAKESHAPE',2)
+
+statement ok
+CREATE TABLE other_table (k INT PRIMARY KEY); INSERT INTO other_table VALUES (1), (2)
+
+# It's ok to select other columns and multiple rows. Each geom column only gets
+# added once.
+query ITT
+SELECT
+  k,
+  AddGeometryColumn ('my_spatial_table','geom7',4326,'POINT',2),
+  AddGeometryColumn ('my_spatial_table','geom8',4326,'POINT',2)
+FROM other_table
+----
+1  my_spatial_table.geom7 SRID:4326 TYPE:POINT DIMS:2  my_spatial_table.geom8 SRID:4326 TYPE:POINT DIMS:2
+2  my_spatial_table.geom7 SRID:4326 TYPE:POINT DIMS:2  my_spatial_table.geom8 SRID:4326 TYPE:POINT DIMS:2
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT
+  k,
+  AddGeometryColumn ('my_spatial_table','geom7',4326,'POINT',2),
+  AddGeometryColumn ('my_spatial_table','geom8',4326,'POINT',2)
+FROM other_table
+----
+·                           distributed   false                                                               ·                                          ·
+·                           vectorized    true                                                                ·                                          ·
+root                        ·             ·                                                                   (k, addgeometrycolumn, addgeometrycolumn)  ·
+ ├── render                 ·             ·                                                                   (k, addgeometrycolumn, addgeometrycolumn)  ·
+ │    │                     render 0      k                                                                   ·                                          ·
+ │    │                     render 1      addgeometrycolumn('my_spatial_table', 'geom7', 4326, 'POINT', 2)    ·                                          ·
+ │    │                     render 2      addgeometrycolumn('my_spatial_table', 'geom8', 4326, 'POINT', 2)    ·                                          ·
+ │    └── scan              ·             ·                                                                   (k)                                        ·
+ │                          table         other_table@primary                                                 ·                                          ·
+ │                          spans         FULL SCAN                                                           ·                                          ·
+ ├── subquery               ·             ·                                                                   ·                                          ·
+ │    │                     id            @S1                                                                 ·                                          ·
+ │    │                     original sql  ALTER TABLE my_spatial_table ADD COLUMN geom7 GEOMETRY(POINT,4326)  ·                                          ·
+ │    │                     exec mode     all rows                                                            ·                                          ·
+ │    └── buffer node       ·             ·                                                                   ()                                         ·
+ │         │                label         buffer 1                                                            ·                                          ·
+ │         └── alter table  ·             ·                                                                   ()                                         ·
+ └── subquery               ·             ·                                                                   ·                                          ·
+      │                     id            @S2                                                                 ·                                          ·
+      │                     original sql  ALTER TABLE my_spatial_table ADD COLUMN geom8 GEOMETRY(POINT,4326)  ·                                          ·
+      │                     exec mode     all rows                                                            ·                                          ·
+      └── buffer node       ·             ·                                                                   ()                                         ·
+           │                label         buffer 2                                                            ·                                          ·
+           └── alter table  ·             ·                                                                   ()                                         ·
+
+# TODO(rytaft): Figure out why goem7 didn't get added even though the ALTER
+# TABLE statement is included in the EXPLAIN plan above.
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE my_spatial_table]
+----
+CREATE TABLE my_spatial_table (
+   k INT8 NOT NULL,
+   geom1 GEOMETRY(POINT,4326) NULL,
+   geom2 GEOMETRY(POLYGON,4326) NULL,
+   geom3 GEOMETRY(MULTIPOLYGON,4326) NULL,
+   geom4 GEOMETRY(LINESTRING,4326) NULL,
+   geom5 GEOMETRY(MULTIPOINT,4326) NULL,
+   geom6 GEOMETRY(MULTILINESTRING,4326) NULL,
+   geom8 GEOMETRY(POINT,4326) NULL,
+   CONSTRAINT "primary" PRIMARY KEY (k ASC),
+   FAMILY "primary" (k, geom1, geom2, geom3, geom4, geom5, geom6, geom8)
+)
+
+# In a WHERE clause.
+query I
+SELECT * FROM other_table WHERE AddGeometryColumn ('my_spatial_table','geom9',4326,'GEOMETRY',2) IS NOT NULL
+----
+1
+2
+
+# In a subquery.
+query T
+SELECT (SELECT AddGeometryColumn ('my_spatial_table','geom10',0,'GEOMETRYCOLLECTION',2))
+----
+my_spatial_table.geom10 SRID:0 TYPE:GEOMETRYCOLLECTION DIMS:2
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE my_spatial_table]
+----
+CREATE TABLE my_spatial_table (
+   k INT8 NOT NULL,
+   geom1 GEOMETRY(POINT,4326) NULL,
+   geom2 GEOMETRY(POLYGON,4326) NULL,
+   geom3 GEOMETRY(MULTIPOLYGON,4326) NULL,
+   geom4 GEOMETRY(LINESTRING,4326) NULL,
+   geom5 GEOMETRY(MULTIPOINT,4326) NULL,
+   geom6 GEOMETRY(MULTILINESTRING,4326) NULL,
+   geom8 GEOMETRY(POINT,4326) NULL,
+   geom9 GEOMETRY(GEOMETRY,4326) NULL,
+   geom10 GEOMETRY(GEOMETRYCOLLECTION) NULL,
+   CONSTRAINT "primary" PRIMARY KEY (k ASC),
+   FAMILY "primary" (k, geom1, geom2, geom3, geom4, geom5, geom6, geom8, geom9, geom10)
+)

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -445,6 +445,10 @@ func (c *CustomFuncs) FoldFunction(
 // FoldFunctionWhitelist contains non-immutable functions that are nevertheless
 // known to be safe for folding.
 var FoldFunctionWhitelist = map[string]struct{}{
+	// The SQL statement is generated in the optbuilder phase, so the remaining
+	// function execution is immutable.
+	"addgeometrycolumn": {},
+
 	// Query plan cache is invalidated on location changes.
 	"crdb_internal.locality_value": {},
 }

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -836,6 +836,10 @@ func isGenerator(def *tree.FunctionDefinition) bool {
 	return def.Class == tree.GeneratorClass
 }
 
+func isSQLFn(def *tree.FunctionDefinition) bool {
+	return def.Class == tree.SQLClass
+}
+
 func newGroupingError(name *tree.Name) error {
 	return pgerror.Newf(pgcode.Grouping,
 		"column \"%s\" must appear in the GROUP BY clause or be used in an aggregate function",

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -364,6 +364,9 @@ func (b *Builder) buildScalar(
 		to := b.buildScalar(t.TypedTo(), inScope, nil, nil, colRefs)
 		out = b.buildRangeCond(t.Not, t.Symmetric, inputFrom, from, inputTo, to)
 
+	case *sqlFnInfo:
+		out = b.buildSQLFn(t, inScope, outScope, outCol, colRefs)
+
 	case *srf:
 		if len(t.cols) == 1 {
 			if inGroupingContext {

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -915,6 +915,11 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 			break
 		}
 
+		if isSQLFn(def) {
+			expr = s.replaceSQLFn(t, def)
+			break
+		}
+
 	case *tree.ArrayFlatten:
 		if s.builder.AllowUnsupportedExpr {
 			// TODO(rytaft): Temporary fix for #24171 and #24170.
@@ -1241,6 +1246,40 @@ func (s *scope) replaceWindowFn(f *tree.FuncExpr, def *tree.FunctionDefinition) 
 
 	s.windows = append(s.windows, *info.col)
 
+	return &info
+}
+
+// replaceSQLFn replaces a tree.SQLClass function with a sqlFnInfo struct. See
+// comments above tree.SQLClass and sqlFnInfo for details.
+func (s *scope) replaceSQLFn(f *tree.FuncExpr, def *tree.FunctionDefinition) tree.Expr {
+	// We need to save and restore the previous value of the field in
+	// semaCtx in case we are recursively called within a subquery
+	// context.
+	defer s.builder.semaCtx.Properties.Restore(s.builder.semaCtx.Properties)
+
+	s.builder.semaCtx.Properties.Require("SQL function", tree.RejectSpecial)
+
+	expr := f.Walk(s)
+	typedFunc, err := tree.TypeCheck(expr, s.builder.semaCtx, types.Any)
+	if err != nil {
+		panic(err)
+	}
+
+	f = typedFunc.(*tree.FuncExpr)
+	args := make(memo.ScalarListExpr, len(f.Exprs))
+	for i, arg := range f.Exprs {
+		args[i] = s.builder.buildScalar(arg.(tree.TypedExpr), s, nil, nil, nil)
+	}
+
+	info := sqlFnInfo{
+		FuncExpr: f,
+		def: memo.FunctionPrivate{
+			Name:       def.Name,
+			Properties: &def.FunctionProperties,
+			Overload:   f.ResolvedOverload(),
+		},
+		args: args,
+	}
 	return &info
 }
 

--- a/pkg/sql/opt/optbuilder/sql_fn.go
+++ b/pkg/sql/opt/optbuilder/sql_fn.go
@@ -1,0 +1,91 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package optbuilder
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// sqlFnInfo stores information about a tree.SQLClass function, which is a
+// function that executes a SQL statement as a side effect of the function call.
+// See the comment above tree.SQLClass for more info.
+type sqlFnInfo struct {
+	*tree.FuncExpr
+
+	def  memo.FunctionPrivate
+	args memo.ScalarListExpr
+}
+
+// Walk is part of the tree.Expr interface.
+func (s *sqlFnInfo) Walk(v tree.Visitor) tree.Expr {
+	return s
+}
+
+// TypeCheck is part of the tree.Expr interface.
+func (s *sqlFnInfo) TypeCheck(ctx *tree.SemaContext, desired *types.T) (tree.TypedExpr, error) {
+	if _, err := s.FuncExpr.TypeCheck(ctx, desired); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// buildSQLFn builds a SQL statement from the given tree.SQLClass function and
+// hoists it into a CTE. It then builds the original function as a scalar
+// expression and returns it.
+func (b *Builder) buildSQLFn(
+	info *sqlFnInfo, inScope, outScope *scope, outCol *scopeColumn, colRefs *opt.ColSet,
+) opt.ScalarExpr {
+	// Get the arguments to the function.
+	exprs := make(tree.Datums, len(info.args))
+	for i := range exprs {
+		if !memo.CanExtractConstDatum(info.args[i]) {
+			panic(unimplemented.NewWithIssuef(49448, "non-constant argument passed to %s\n",
+				log.Safe(info.def.Name),
+			))
+		}
+		exprs[i] = memo.ExtractConstDatum(info.args[i])
+	}
+
+	// Get the SQL statement and parse it.
+	sql, err := info.def.Overload.SQLFn(b.evalCtx, exprs)
+	if err != nil {
+		panic(err)
+	}
+	stmt, err := parser.ParseOne(sql)
+	if err != nil {
+		panic(err)
+	}
+
+	// Build the SQL statement and hoist it into a CTE.
+	b.semaCtx.Annotations = tree.MakeAnnotations(stmt.NumAnnotations)
+	emptyScope := b.allocScope()
+	innerScope := b.buildStmt(stmt.AST, nil /* desiredTypes */, emptyScope)
+
+	id := b.factory.Memo().NextWithID()
+	cte := cteSource{
+		name:         tree.AliasClause{},
+		cols:         innerScope.makePresentationWithHiddenCols(),
+		originalExpr: stmt.AST,
+		expr:         innerScope.expr,
+		id:           id,
+		bindingProps: innerScope.expr.Relational(),
+	}
+	b.cteStack[len(b.cteStack)-1] = append(b.cteStack[len(b.cteStack)-1], cte)
+
+	// Build and return the original function.
+	return b.buildScalar(info.FuncExpr, inScope, outScope, outCol, colRefs)
+}

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -18,8 +18,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/geo/geogfn"
 	"github.com/cockroachdb/cockroach/pkg/geo/geomfn"
 	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 )
 
@@ -1256,6 +1259,266 @@ The calculations are done on a sphere.`,
 			Volatility: tree.VolatilityImmutable,
 		},
 	),
+
+	//
+	// Schema changes
+	//
+	"addgeometrycolumn": makeBuiltin(
+		tree.FunctionProperties{
+			Class:    tree.SQLClass,
+			Category: categoryGeospatial,
+			Impure:   true,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"table_name", types.String},
+				{"column_name", types.String},
+				{"srid", types.Int},
+				{"type", types.String},
+				{"dimension", types.Int},
+				{"use_typmod", types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.String),
+			SQLFn: func(ctx *tree.EvalContext, args tree.Datums) (string, error) {
+				return addGeometryColumnSQL(
+					ctx,
+					"", /* catalogName */
+					"", /* schemaName */
+					string(tree.MustBeDString(args[0])),
+					string(tree.MustBeDString(args[1])),
+					int(tree.MustBeDInt(args[2])),
+					string(tree.MustBeDString(args[3])),
+					int(tree.MustBeDInt(args[4])),
+					bool(tree.MustBeDBool(args[5])),
+				)
+			},
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				return addGeometryColumnSummary(
+					ctx,
+					"", /* catalogName */
+					"", /* schemaName */
+					string(tree.MustBeDString(args[0])),
+					string(tree.MustBeDString(args[1])),
+					int(tree.MustBeDInt(args[2])),
+					string(tree.MustBeDString(args[3])),
+					int(tree.MustBeDInt(args[4])),
+					bool(tree.MustBeDBool(args[5])),
+				)
+			},
+			Info: infoBuilder{
+				info: `Adds a new geometry column to an existing table and returns metadata about the column created.`,
+			}.String(),
+			Volatility: tree.VolatilityVolatile,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"schema_name", types.String},
+				{"table_name", types.String},
+				{"column_name", types.String},
+				{"srid", types.Int},
+				{"type", types.String},
+				{"dimension", types.Int},
+				{"use_typmod", types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.String),
+			SQLFn: func(ctx *tree.EvalContext, args tree.Datums) (string, error) {
+				return addGeometryColumnSQL(
+					ctx,
+					"", /* catalogName */
+					string(tree.MustBeDString(args[0])),
+					string(tree.MustBeDString(args[1])),
+					string(tree.MustBeDString(args[2])),
+					int(tree.MustBeDInt(args[3])),
+					string(tree.MustBeDString(args[4])),
+					int(tree.MustBeDInt(args[5])),
+					bool(tree.MustBeDBool(args[6])),
+				)
+			},
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				return addGeometryColumnSummary(
+					ctx,
+					"", /* catalogName */
+					string(tree.MustBeDString(args[0])),
+					string(tree.MustBeDString(args[1])),
+					string(tree.MustBeDString(args[2])),
+					int(tree.MustBeDInt(args[3])),
+					string(tree.MustBeDString(args[4])),
+					int(tree.MustBeDInt(args[5])),
+					bool(tree.MustBeDBool(args[6])),
+				)
+			},
+			Info: infoBuilder{
+				info: `Adds a new geometry column to an existing table and returns metadata about the column created.`,
+			}.String(),
+			Volatility: tree.VolatilityVolatile,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"catalog_name", types.String},
+				{"schema_name", types.String},
+				{"table_name", types.String},
+				{"column_name", types.String},
+				{"srid", types.Int},
+				{"type", types.String},
+				{"dimension", types.Int},
+				{"use_typmod", types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.String),
+			SQLFn: func(ctx *tree.EvalContext, args tree.Datums) (string, error) {
+				return addGeometryColumnSQL(
+					ctx,
+					string(tree.MustBeDString(args[0])),
+					string(tree.MustBeDString(args[1])),
+					string(tree.MustBeDString(args[2])),
+					string(tree.MustBeDString(args[3])),
+					int(tree.MustBeDInt(args[4])),
+					string(tree.MustBeDString(args[5])),
+					int(tree.MustBeDInt(args[6])),
+					bool(tree.MustBeDBool(args[7])),
+				)
+			},
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				return addGeometryColumnSummary(
+					ctx,
+					string(tree.MustBeDString(args[0])),
+					string(tree.MustBeDString(args[1])),
+					string(tree.MustBeDString(args[2])),
+					string(tree.MustBeDString(args[3])),
+					int(tree.MustBeDInt(args[4])),
+					string(tree.MustBeDString(args[5])),
+					int(tree.MustBeDInt(args[6])),
+					bool(tree.MustBeDBool(args[7])),
+				)
+			},
+			Info: infoBuilder{
+				info: `Adds a new geometry column to an existing table and returns metadata about the column created.`,
+			}.String(),
+			Volatility: tree.VolatilityVolatile,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"table_name", types.String},
+				{"column_name", types.String},
+				{"srid", types.Int},
+				{"type", types.String},
+				{"dimension", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.String),
+			SQLFn: func(ctx *tree.EvalContext, args tree.Datums) (string, error) {
+				return addGeometryColumnSQL(
+					ctx,
+					"", /* catalogName */
+					"", /* schemaName */
+					string(tree.MustBeDString(args[0])),
+					string(tree.MustBeDString(args[1])),
+					int(tree.MustBeDInt(args[2])),
+					string(tree.MustBeDString(args[3])),
+					int(tree.MustBeDInt(args[4])),
+					true, /* useTypmod */
+				)
+			},
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				return addGeometryColumnSummary(
+					ctx,
+					"", /* catalogName */
+					"", /* schemaName */
+					string(tree.MustBeDString(args[0])),
+					string(tree.MustBeDString(args[1])),
+					int(tree.MustBeDInt(args[2])),
+					string(tree.MustBeDString(args[3])),
+					int(tree.MustBeDInt(args[4])),
+					true, /* useTypmod */
+				)
+			},
+			Info: infoBuilder{
+				info: `Adds a new geometry column to an existing table and returns metadata about the column created.`,
+			}.String(),
+			Volatility: tree.VolatilityVolatile,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"schema_name", types.String},
+				{"table_name", types.String},
+				{"column_name", types.String},
+				{"srid", types.Int},
+				{"type", types.String},
+				{"dimension", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.String),
+			SQLFn: func(ctx *tree.EvalContext, args tree.Datums) (string, error) {
+				return addGeometryColumnSQL(
+					ctx,
+					"", /* catalogName */
+					string(tree.MustBeDString(args[0])),
+					string(tree.MustBeDString(args[1])),
+					string(tree.MustBeDString(args[2])),
+					int(tree.MustBeDInt(args[3])),
+					string(tree.MustBeDString(args[4])),
+					int(tree.MustBeDInt(args[5])),
+					true, /* useTypmod */
+				)
+			},
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				return addGeometryColumnSummary(
+					ctx,
+					"", /* catalogName */
+					string(tree.MustBeDString(args[0])),
+					string(tree.MustBeDString(args[1])),
+					string(tree.MustBeDString(args[2])),
+					int(tree.MustBeDInt(args[3])),
+					string(tree.MustBeDString(args[4])),
+					int(tree.MustBeDInt(args[5])),
+					true, /* useTypmod */
+				)
+			},
+			Info: infoBuilder{
+				info: `Adds a new geometry column to an existing table and returns metadata about the column created.`,
+			}.String(),
+			Volatility: tree.VolatilityVolatile,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"catalog_name", types.String},
+				{"schema_name", types.String},
+				{"table_name", types.String},
+				{"column_name", types.String},
+				{"srid", types.Int},
+				{"type", types.String},
+				{"dimension", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.String),
+			SQLFn: func(ctx *tree.EvalContext, args tree.Datums) (string, error) {
+				return addGeometryColumnSQL(
+					ctx,
+					string(tree.MustBeDString(args[0])),
+					string(tree.MustBeDString(args[1])),
+					string(tree.MustBeDString(args[2])),
+					string(tree.MustBeDString(args[3])),
+					int(tree.MustBeDInt(args[4])),
+					string(tree.MustBeDString(args[5])),
+					int(tree.MustBeDInt(args[6])),
+					true, /* useTypmod */
+				)
+			},
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				return addGeometryColumnSummary(
+					ctx,
+					string(tree.MustBeDString(args[0])),
+					string(tree.MustBeDString(args[1])),
+					string(tree.MustBeDString(args[2])),
+					string(tree.MustBeDString(args[3])),
+					int(tree.MustBeDInt(args[4])),
+					string(tree.MustBeDString(args[5])),
+					int(tree.MustBeDInt(args[6])),
+					true, /* useTypmod */
+				)
+			},
+			Info: infoBuilder{
+				info: `Adds a new geometry column to an existing table and returns metadata about the column created.`,
+			}.String(),
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
 }
 
 // geometryOverload1 hides the boilerplate for builtins operating on one geometry.
@@ -1444,4 +1707,73 @@ func initGeoBuiltins() {
 		v.props.Category = categoryGeospatial
 		builtins[k] = v
 	}
+}
+
+// addGeometryColumnSQL returns the SQL statement that should be executed to
+// add a geometry column.
+func addGeometryColumnSQL(
+	ctx *tree.EvalContext,
+	catalogName string,
+	schemaName string,
+	tableName string,
+	columnName string,
+	srid int,
+	shape string,
+	dimension int,
+	useTypmod bool,
+) (string, error) {
+	if dimension != 2 {
+		return "", pgerror.Newf(
+			pgcode.FeatureNotSupported,
+			"only dimension=2 is currently supported",
+		)
+	}
+	if !useTypmod {
+		return "", unimplemented.NewWithIssue(
+			49402,
+			"useTypmod=false is currently not supported with AddGeometryColumn",
+		)
+	}
+
+	tn := makeTableName(catalogName, schemaName, tableName)
+	stmt := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s GEOMETRY(%s,%d)",
+		tn.String(),
+		columnName,
+		shape,
+		srid,
+	)
+	return stmt, nil
+}
+
+// addGeometryColumnSummary returns metadata about the geometry column that
+// was added.
+func addGeometryColumnSummary(
+	ctx *tree.EvalContext,
+	catalogName string,
+	schemaName string,
+	tableName string,
+	columnName string,
+	srid int,
+	shape string,
+	dimension int,
+	useTypmod bool,
+) (tree.Datum, error) {
+	tn := makeTableName(catalogName, schemaName, tableName)
+	summary := fmt.Sprintf("%s.%s SRID:%d TYPE:%s DIMS:%d",
+		tn.String(),
+		columnName,
+		srid,
+		strings.ToUpper(shape),
+		dimension,
+	)
+	return tree.NewDString(summary), nil
+}
+
+func makeTableName(catalogName string, schemaName string, tableName string) tree.UnresolvedName {
+	if catalogName != "" {
+		return tree.MakeUnresolvedName(catalogName, schemaName, tableName)
+	} else if schemaName != "" {
+		return tree.MakeUnresolvedName(schemaName, tableName)
+	}
+	return tree.MakeUnresolvedName(tableName)
 }

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -122,6 +122,18 @@ const (
 	WindowClass
 	// GeneratorClass is a builtin generator function.
 	GeneratorClass
+	// SQLClass is a builtin function that executes a SQL statement as a side
+	// effect of the function call.
+	//
+	// For example, AddGeometryColumn is a SQLClass function that executes an
+	// ALTER TABLE ... ADD COLUMN statement to add a geometry column to an
+	// existing table. It returns metadata about the column added.
+	//
+	// All builtin functions of this class should include a definition for
+	// Overload.SQLFn, which returns the SQL statement to be executed. They
+	// should also include a definition for Overload.Fn, which is executed
+	// like a NormalClass function and returns a Datum.
+	SQLClass
 )
 
 // Avoid vet warning about unused enum value.

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -68,6 +68,10 @@ type Overload struct {
 	Fn            func(*EvalContext, Datums) (Datum, error)
 	Generator     GeneratorFactory
 
+	// SQLFn must be set for overloads of type SQLClass. It should return a SQL
+	// statement which will be executed as a common table expression in the query.
+	SQLFn func(*EvalContext, Datums) (string, error)
+
 	// counter, if non-nil, should be incremented upon successful
 	// type check of expressions using this overload.
 	counter telemetry.Counter


### PR DESCRIPTION
This commit adds support for the `AddGeometryColumn` function, which
executes an `ALTER TABLE ... ADD COLUMN` statement to add a geometry
column to a table as a side effect of executing the function. The
function itself returns a string with metadata summarizing the schema
change.

Since we don't yet support UDFs in CockroachDB, this commit adds support
for `AddGeometryColumn` (and future similar functions) by building the DDL
statement in the `optbuilder` phase of the optimizer and hoisting it into a
CTE before execution. The limitation with this approach is that all
arguments to the function must be constant.

Fixes #48061

Release note (sql change): Added support for the AddGeometryColumn
function, which adds a new geometry column to an existing table and
returns metadata about the column created. This improves compatibility
with PostGIS.