### PR TITLE
server: trim deps in StartTenant

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -682,9 +682,9 @@ type TempStorageConfig struct {
 	SpecIdx int
 }
 
-// ExternalIOConfig describes various configuration options pertaining
+// SQLExternalIOConfig describes various configuration options pertaining
 // to external storage implementations.
-type ExternalIOConfig struct {
+type SQLExternalIOConfig struct {
 	// Disables the use of external HTTP endpoints.
 	// This turns off http:// external storage as well as any custom
 	// endpoints cloud storage implementations.

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -713,9 +713,9 @@ type TempStorageConfig struct {
 	Spec StoreSpec
 }
 
-// SQLExternalIOConfig describes various configuration options pertaining
+// ExternalIODirConfig describes various configuration options pertaining
 // to external storage implementations.
-type SQLExternalIOConfig struct {
+type ExternalIODirConfig struct {
 	// Disables the use of external HTTP endpoints.
 	// This turns off http:// external storage as well as any custom
 	// endpoints cloud storage implementations.

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -678,8 +678,8 @@ type TempStorageConfig struct {
 	// use. If InMemory is set, than this has to be a memory monitor; otherwise it
 	// has to be a disk monitor.
 	Mon *mon.BytesMonitor
-	// StoreIdx stores the index of the StoreSpec this TempStorageConfig will use.
-	SpecIdx int
+	// Spec stores the StoreSpec this TempStorageConfig will use.
+	Spec StoreSpec
 }
 
 // SQLExternalIOConfig describes various configuration options pertaining
@@ -702,12 +702,11 @@ type SQLExternalIOConfig struct {
 func TempStorageConfigFromEnv(
 	ctx context.Context,
 	st *cluster.Settings,
-	firstStore StoreSpec,
+	useStore StoreSpec,
 	parentDir string,
 	maxSizeBytes int64,
-	specIdx int,
 ) TempStorageConfig {
-	inMem := parentDir == "" && firstStore.InMemory
+	inMem := parentDir == "" && useStore.InMemory
 	var monitorName string
 	if inMem {
 		monitorName = "in-mem temp storage"
@@ -727,7 +726,7 @@ func TempStorageConfigFromEnv(
 	return TempStorageConfig{
 		InMemory: inMem,
 		Mon:      &monitor,
-		SpecIdx:  specIdx,
+		Spec:     useStore,
 	}
 }
 

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -78,7 +78,7 @@ type TestServerArgs struct {
 
 	// Fields copied to the server.Config.
 	Insecure                    bool
-	RetryOptions                retry.Options
+	RetryOptions                retry.Options // TODO(tbg): make testing knob.
 	SocketFile                  string
 	ScanInterval                time.Duration
 	ScanMinIdleTime             time.Duration

--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -203,7 +202,7 @@ func createBenchmarkChangefeed(
 	sink := makeBenchSink()
 
 	settings := s.ClusterSettings()
-	metrics := MakeMetrics(server.DefaultHistogramWindowInterval).(*Metrics)
+	metrics := MakeMetrics(base.DefaultHistogramWindowInterval()).(*Metrics)
 	buf := kvfeed.MakeChanBuffer()
 	leaseMgr := s.LeaseManager().(*lease.Manager)
 	mm := mon.MakeUnlimitedMonitor(

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -98,7 +98,7 @@ func TestCloudStorageSink(t *testing.T) {
 
 	clientFactory := blobs.TestBlobServiceClient(settings.ExternalIODir)
 	externalStorageFromURI := func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
-		return cloud.ExternalStorageFromURI(ctx, uri, base.SQLExternalIOConfig{}, settings, clientFactory)
+		return cloud.ExternalStorageFromURI(ctx, uri, base.ExternalIODirConfig{}, settings, clientFactory)
 	}
 
 	t.Run(`golden`, func(t *testing.T) {

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -98,7 +98,7 @@ func TestCloudStorageSink(t *testing.T) {
 
 	clientFactory := blobs.TestBlobServiceClient(settings.ExternalIODir)
 	externalStorageFromURI := func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
-		return cloud.ExternalStorageFromURI(ctx, uri, base.ExternalIOConfig{}, settings, clientFactory)
+		return cloud.ExternalStorageFromURI(ctx, uri, base.SQLExternalIOConfig{}, settings, clientFactory)
 	}
 
 	t.Run(`golden`, func(t *testing.T) {

--- a/pkg/ccl/cliccl/load.go
+++ b/pkg/ccl/cliccl/load.go
@@ -59,7 +59,7 @@ func runLoadShow(cmd *cobra.Command, args []string) error {
 	}
 
 	externalStorageFromURI := func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
-		return cloud.ExternalStorageFromURI(ctx, uri, base.SQLExternalIOConfig{},
+		return cloud.ExternalStorageFromURI(ctx, uri, base.ExternalIODirConfig{},
 			cluster.NoSettings, blobs.TestEmptyBlobClientFactory)
 	}
 	// This reads the raw backup descriptor (with table descriptors possibly not

--- a/pkg/ccl/cliccl/load.go
+++ b/pkg/ccl/cliccl/load.go
@@ -59,7 +59,7 @@ func runLoadShow(cmd *cobra.Command, args []string) error {
 	}
 
 	externalStorageFromURI := func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
-		return cloud.ExternalStorageFromURI(ctx, uri, base.ExternalIOConfig{},
+		return cloud.ExternalStorageFromURI(ctx, uri, base.SQLExternalIOConfig{},
 			cluster.NoSettings, blobs.TestEmptyBlobClientFactory)
 	}
 	// This reads the raw backup descriptor (with table descriptors possibly not

--- a/pkg/ccl/importccl/import_processor_test.go
+++ b/pkg/ccl/importccl/import_processor_test.go
@@ -797,7 +797,7 @@ func externalStorageFactory(
 	if err != nil {
 		return nil, err
 	}
-	return cloud.MakeExternalStorage(ctx, dest, base.ExternalIOConfig{},
+	return cloud.MakeExternalStorage(ctx, dest, base.SQLExternalIOConfig{},
 		nil, blobs.TestBlobServiceClient(workdir))
 }
 

--- a/pkg/ccl/importccl/import_processor_test.go
+++ b/pkg/ccl/importccl/import_processor_test.go
@@ -797,7 +797,7 @@ func externalStorageFactory(
 	if err != nil {
 		return nil, err
 	}
-	return cloud.MakeExternalStorage(ctx, dest, base.SQLExternalIOConfig{},
+	return cloud.MakeExternalStorage(ctx, dest, base.ExternalIODirConfig{},
 		nil, blobs.TestBlobServiceClient(workdir))
 }
 

--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -120,7 +120,7 @@ func Load(
 	if err != nil {
 		return backupccl.BackupManifest{}, err
 	}
-	dir, err := cloud.MakeExternalStorage(ctx, conf, base.SQLExternalIOConfig{},
+	dir, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{},
 		cluster.NoSettings, blobClientFactory)
 	if err != nil {
 		return backupccl.BackupManifest{}, errors.Wrap(err, "export storage from URI")

--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -120,7 +120,7 @@ func Load(
 	if err != nil {
 		return backupccl.BackupManifest{}, err
 	}
-	dir, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIOConfig{},
+	dir, err := cloud.MakeExternalStorage(ctx, conf, base.SQLExternalIOConfig{},
 		cluster.NoSettings, blobClientFactory)
 	if err != nil {
 		return backupccl.BackupManifest{}, errors.Wrap(err, "export storage from URI")

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -39,7 +39,7 @@ var serverCfg = func() server.Config {
 	settings.SetCanonicalValuesContainer(&st.SV)
 
 	s := server.MakeConfig(context.Background(), st)
-	s.SQLAuditLogDirName = &sqlAuditLogDir
+	s.AuditLogDirName = &sqlAuditLogDir
 	return s
 }()
 
@@ -112,14 +112,14 @@ func initCLIDefaults() {
 	serverCfg.HeapProfileDirName = ""
 	serverCfg.ReadyFn = nil
 	serverCfg.DelayedBootstrapFn = nil
-	serverCfg.SQLSocketFile = ""
+	serverCfg.SocketFile = ""
 	serverCfg.JoinList = nil
 	serverCfg.JoinPreferSRVRecords = false
 	serverCfg.DefaultZoneConfig = zonepb.DefaultZoneConfig()
 	serverCfg.DefaultSystemZoneConfig = zonepb.DefaultSystemZoneConfig()
-	// Attempt to default serverCfg.SQLMemoryPoolSize to 25% if possible.
+	// Attempt to default serverCfg.MemoryPoolSize to 25% if possible.
 	if bytes, _ := memoryPercentResolver(25); bytes != 0 {
-		serverCfg.SQLMemoryPoolSize = bytes
+		serverCfg.MemoryPoolSize = bytes
 	}
 
 	startCtx.serverInsecure = baseCfg.Insecure

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -112,7 +112,7 @@ func initCLIDefaults() {
 	serverCfg.HeapProfileDirName = ""
 	serverCfg.ReadyFn = nil
 	serverCfg.DelayedBootstrapFn = nil
-	serverCfg.SocketFile = ""
+	serverCfg.SQLSocketFile = ""
 	serverCfg.JoinList = nil
 	serverCfg.JoinPreferSRVRecords = false
 	serverCfg.DefaultZoneConfig = zonepb.DefaultZoneConfig()

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -324,7 +324,7 @@ func init() {
 		StringFlag(f, &serverSocketDir, cliflags.SocketDir, serverSocketDir)
 		// --socket is deprecated as of 20.1.
 		// TODO(knz): remove in 20.2.
-		StringFlag(f, &serverCfg.SQLSocketFile, cliflags.Socket, serverCfg.SQLSocketFile)
+		StringFlag(f, &serverCfg.SocketFile, cliflags.Socket, serverCfg.SocketFile)
 		_ = f.MarkDeprecated(cliflags.Socket.Name, "use the --socket-dir and --listen-addr flags instead")
 		BoolFlag(f, &startCtx.unencryptedLocalhostHTTP, cliflags.UnencryptedLocalhostHTTP, startCtx.unencryptedLocalhostHTTP)
 
@@ -372,10 +372,10 @@ func init() {
 		BoolFlag(f, &startCtx.serverInsecure, cliflags.ServerInsecure, startCtx.serverInsecure)
 
 		// Enable/disable various external storage endpoints.
-		serverCfg.SQLExternalIOConfig = base.SQLExternalIOConfig{}
-		BoolFlag(f, &serverCfg.SQLExternalIOConfig.DisableHTTP,
+		serverCfg.ExternalIODirConfig = base.ExternalIODirConfig{}
+		BoolFlag(f, &serverCfg.ExternalIODirConfig.DisableHTTP,
 			cliflags.ExternalIODisableHTTP, false)
-		BoolFlag(f, &serverCfg.SQLExternalIOConfig.DisableImplicitCredentials,
+		BoolFlag(f, &serverCfg.ExternalIODirConfig.DisableImplicitCredentials,
 			cliflags.ExtenralIODisableImplicitCredentials, false)
 
 		// Certificates directory. Use a server-specific flag and value to ignore environment
@@ -420,7 +420,7 @@ func init() {
 		StringFlag(f, &startCtx.tempDir, cliflags.TempDir, startCtx.tempDir)
 		StringFlag(f, &startCtx.externalIODir, cliflags.ExternalIODir, startCtx.externalIODir)
 
-		VarFlag(f, serverCfg.SQLAuditLogDirName, cliflags.SQLAuditLogDirName)
+		VarFlag(f, serverCfg.AuditLogDirName, cliflags.SQLAuditLogDirName)
 	}
 
 	// Log flags.
@@ -786,16 +786,16 @@ func extraServerFlagInit(cmd *cobra.Command) error {
 
 	// Construct the socket name, if requested.
 	if !fs.Lookup(cliflags.Socket.Name).Changed && fs.Lookup(cliflags.SocketDir.Name).Changed {
-		// If --socket (DEPRECATED) was set, then serverCfg.SQLSocketFile is
+		// If --socket (DEPRECATED) was set, then serverCfg.SocketFile is
 		// already set and we don't want to change it.
 		// However, if --socket-dir is set, then we'll use that.
 		// There are two cases:
 		// --socket-dir is set and is empty; in this case the user is telling us "disable the socket".
 		// is set and non-empty. Then it should be used as specified.
 		if serverSocketDir == "" {
-			serverCfg.SQLSocketFile = ""
+			serverCfg.SocketFile = ""
 		} else {
-			serverCfg.SQLSocketFile = filepath.Join(serverSocketDir, ".s.PGSQL."+serverListenPort)
+			serverCfg.SocketFile = filepath.Join(serverSocketDir, ".s.PGSQL."+serverListenPort)
 		}
 	}
 

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -372,10 +372,10 @@ func init() {
 		BoolFlag(f, &startCtx.serverInsecure, cliflags.ServerInsecure, startCtx.serverInsecure)
 
 		// Enable/disable various external storage endpoints.
-		serverCfg.ExternalIOConfig = base.ExternalIOConfig{}
-		BoolFlag(f, &serverCfg.ExternalIOConfig.DisableHTTP,
+		serverCfg.SQLExternalIOConfig = base.SQLExternalIOConfig{}
+		BoolFlag(f, &serverCfg.SQLExternalIOConfig.DisableHTTP,
 			cliflags.ExternalIODisableHTTP, false)
-		BoolFlag(f, &serverCfg.ExternalIOConfig.DisableImplicitCredentials,
+		BoolFlag(f, &serverCfg.SQLExternalIOConfig.DisableImplicitCredentials,
 			cliflags.ExtenralIODisableImplicitCredentials, false)
 
 		// Certificates directory. Use a server-specific flag and value to ignore environment

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -324,7 +324,7 @@ func init() {
 		StringFlag(f, &serverSocketDir, cliflags.SocketDir, serverSocketDir)
 		// --socket is deprecated as of 20.1.
 		// TODO(knz): remove in 20.2.
-		StringFlag(f, &serverCfg.SocketFile, cliflags.Socket, serverCfg.SocketFile)
+		StringFlag(f, &serverCfg.SQLSocketFile, cliflags.Socket, serverCfg.SQLSocketFile)
 		_ = f.MarkDeprecated(cliflags.Socket.Name, "use the --socket-dir and --listen-addr flags instead")
 		BoolFlag(f, &startCtx.unencryptedLocalhostHTTP, cliflags.UnencryptedLocalhostHTTP, startCtx.unencryptedLocalhostHTTP)
 
@@ -786,16 +786,16 @@ func extraServerFlagInit(cmd *cobra.Command) error {
 
 	// Construct the socket name, if requested.
 	if !fs.Lookup(cliflags.Socket.Name).Changed && fs.Lookup(cliflags.SocketDir.Name).Changed {
-		// If --socket (DEPRECATED) was set, then serverCfg.SocketFile is
+		// If --socket (DEPRECATED) was set, then serverCfg.SQLSocketFile is
 		// already set and we don't want to change it.
 		// However, if --socket-dir is set, then we'll use that.
 		// There are two cases:
 		// --socket-dir is set and is empty; in this case the user is telling us "disable the socket".
 		// is set and non-empty. Then it should be used as specified.
 		if serverSocketDir == "" {
-			serverCfg.SocketFile = ""
+			serverCfg.SQLSocketFile = ""
 		} else {
-			serverCfg.SocketFile = filepath.Join(serverSocketDir, ".s.PGSQL."+serverListenPort)
+			serverCfg.SQLSocketFile = filepath.Join(serverSocketDir, ".s.PGSQL."+serverListenPort)
 		}
 	}
 

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -706,9 +706,9 @@ func TestServerSocketSettings(t *testing.T) {
 			if err := extraServerFlagInit(startCmd); err != nil {
 				t.Fatal(err)
 			}
-			if td.expectedSocket != serverCfg.SocketFile {
-				t.Errorf("%d. serverCfg.SocketFile expected '%s', but got '%s'. td.args was '%#v'.",
-					i, td.expectedSocket, serverCfg.SocketFile, td.args)
+			if td.expectedSocket != serverCfg.SQLSocketFile {
+				t.Errorf("%d. serverCfg.SQLSocketFile expected '%s', but got '%s'. td.args was '%#v'.",
+					i, td.expectedSocket, serverCfg.SQLSocketFile, td.args)
 			}
 		})
 	}

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -155,8 +155,8 @@ func TestSQLMemoryPoolFlagValue(t *testing.T) {
 		if err := f.Parse(args); err != nil {
 			t.Fatal(err)
 		}
-		if c.expected != serverCfg.SQLMemoryPoolSize {
-			t.Errorf("expected %d, but got %d", c.expected, serverCfg.SQLMemoryPoolSize)
+		if c.expected != serverCfg.MemoryPoolSize {
+			t.Errorf("expected %d, but got %d", c.expected, serverCfg.MemoryPoolSize)
 		}
 	}
 
@@ -174,8 +174,8 @@ func TestSQLMemoryPoolFlagValue(t *testing.T) {
 		}
 		expectedLow := (maxMem * 28) / 100
 		expectedHigh := (maxMem * 32) / 100
-		if serverCfg.SQLMemoryPoolSize < expectedLow || serverCfg.SQLMemoryPoolSize > expectedHigh {
-			t.Errorf("expected %d-%d, but got %d", expectedLow, expectedHigh, serverCfg.SQLMemoryPoolSize)
+		if serverCfg.MemoryPoolSize < expectedLow || serverCfg.MemoryPoolSize > expectedHigh {
+			t.Errorf("expected %d-%d, but got %d", expectedLow, expectedHigh, serverCfg.MemoryPoolSize)
 		}
 	}
 }
@@ -706,9 +706,9 @@ func TestServerSocketSettings(t *testing.T) {
 			if err := extraServerFlagInit(startCmd); err != nil {
 				t.Fatal(err)
 			}
-			if td.expectedSocket != serverCfg.SQLSocketFile {
-				t.Errorf("%d. serverCfg.SQLSocketFile expected '%s', but got '%s'. td.args was '%#v'.",
-					i, td.expectedSocket, serverCfg.SQLSocketFile, td.args)
+			if td.expectedSocket != serverCfg.SocketFile {
+				t.Errorf("%d. serverCfg.SocketFile expected '%s', but got '%s'. td.args was '%#v'.",
+					i, td.expectedSocket, serverCfg.SocketFile, td.args)
 			}
 		})
 	}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -584,7 +584,7 @@ func runStart(cmd *cobra.Command, args []string, disableReplication bool) error 
 		}
 	}
 	useStore := serverCfg.Stores.Specs[specIdx]
-	if serverCfg.TempStorageConfig, err = initTempStorageConfig(ctx, serverCfg.Settings, stopper, useStore, specIdx); err != nil {
+	if serverCfg.SQLTempStorageConfig, err = initTempStorageConfig(ctx, serverCfg.Settings, stopper, useStore, specIdx); err != nil {
 		return err
 	}
 

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -820,8 +820,8 @@ If problems persist, please see %s.`
 			fmt.Fprintf(tw, "sql:\t%s\n", pgURL)
 
 			fmt.Fprintf(tw, "RPC client flags:\t%s\n", clientFlagsRPC())
-			if len(serverCfg.SocketFile) != 0 {
-				fmt.Fprintf(tw, "socket:\t%s\n", serverCfg.SocketFile)
+			if len(serverCfg.SQLSocketFile) != 0 {
+				fmt.Fprintf(tw, "socket:\t%s\n", serverCfg.SQLSocketFile)
 			}
 			fmt.Fprintf(tw, "logs:\t%s\n", flag.Lookup("log-dir").Value)
 			if serverCfg.SQLAuditLogDirName.IsSet() {

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
@@ -417,7 +417,7 @@ func registerKVGracefulDraining(r *testRegistry) {
 				StartNanos: now.Add(-runDuration).UnixNano(),
 				EndNanos:   now.UnixNano(),
 				// Check the performance in each timeseries sample interval.
-				SampleNanos: server.DefaultMetricsSampleInterval.Nanoseconds(),
+				SampleNanos: base.DefaultMetricsSampleInterval.Nanoseconds(),
 				Queries: []tspb.Query{
 					{
 						Name:             "cr.node.sql.query.count",

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -90,7 +89,7 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 		ac := log.AmbientContext{Tracer: tracing.NewTracer()}
 		r := jobs.MakeRegistry(
 			ac, s.Stopper(), clock, nodeLiveness, db, s.InternalExecutor().(sqlutil.InternalExecutor),
-			idContainer, s.ClusterSettings(), server.DefaultHistogramWindowInterval, jobs.FakePHS, "",
+			idContainer, s.ClusterSettings(), base.DefaultHistogramWindowInterval(), jobs.FakePHS, "",
 		)
 		if err := r.Start(ctx, s.Stopper(), cancelInterval, adoptInterval); err != nil {
 			t.Fatal(err)

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -468,7 +468,7 @@ func NewContextWithTestingKnobs(
 	ctx.Stopper = stopper
 	ctx.heartbeatInterval = baseCtx.RPCHeartbeatInterval
 	ctx.RemoteClocks = newRemoteClockMonitor(
-		ctx.LocalClock, 10*ctx.heartbeatInterval, baseCtx.HistogramWindowInterval)
+		ctx.LocalClock, 10*ctx.heartbeatInterval, baseCtx.HistogramWindowInterval())
 	ctx.heartbeatTimeout = 2 * ctx.heartbeatInterval
 	ctx.metrics = makeMetrics()
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -362,7 +362,7 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 		SQLTableStatCacheSize: defaultSQLTableStatCacheSize,
 		SQLQueryCacheSize:     defaultSQLQueryCacheSize,
 		SQLTempStorageConfig: base.TempStorageConfigFromEnv(
-			ctx, st, storeSpec, "" /* parentDir */, base.DefaultTempStorageMaxSizeBytes, 0),
+			ctx, st, storeSpec, "" /* parentDir */, base.DefaultTempStorageMaxSizeBytes),
 		SQLLeaseManagerConfig: base.NewLeaseManagerConfig(),
 	}
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -126,6 +126,10 @@ type BothConfig struct {
 	// ReadWithinUncertaintyIntervalError.
 	MaxOffset MaxOffsetType
 
+	// StorageEngine specifies the engine type (eg. rocksdb, pebble) to use to
+	// instantiate stores.
+	StorageEngine enginepb.EngineType
+
 	// TestingKnobs is used for internal test controls only.
 	TestingKnobs base.TestingKnobs
 }
@@ -141,10 +145,6 @@ type Config struct {
 
 	// Stores is specified to enable durable key-value storage.
 	Stores base.StoreSpecList
-
-	// StorageEngine specifies the engine type (eg. rocksdb, pebble) to use to
-	// instantiate stores.
-	StorageEngine enginepb.EngineType
 
 	// Attrs specifies a colon-separated list of node topography or machine
 	// capabilities, used to match capabilities or location preferences specified
@@ -337,9 +337,10 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 	}
 
 	bothCfg := BothConfig{
-		Config:    new(base.Config),
-		MaxOffset: MaxOffsetType(base.DefaultMaxClockOffset),
-		Settings:  st,
+		Config:        new(base.Config),
+		Settings:      st,
+		MaxOffset:     MaxOffsetType(base.DefaultMaxClockOffset),
+		StorageEngine: storage.DefaultStorageEngine,
 	}
 
 	cfg := Config{
@@ -356,7 +357,6 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 		Stores: base.StoreSpecList{
 			Specs: []base.StoreSpec{storeSpec},
 		},
-		StorageEngine: storage.DefaultStorageEngine,
 	}
 	cfg.AmbientCtx.Tracer = st.Tracer
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -118,7 +118,7 @@ type Config struct {
 	base.RaftConfig
 
 	// LeaseManagerConfig holds configuration values specific to the LeaseManager.
-	LeaseManagerConfig *base.LeaseManagerConfig
+	SQLLeaseManagerConfig *base.LeaseManagerConfig
 
 	// SocketFile, if non-empty, sets up a TLS-free local listener using
 	// a unix datagram socket at the specified path.
@@ -133,11 +133,11 @@ type Config struct {
 
 	// TempStorageConfig is used to configure temp storage, which stores
 	// ephemeral data when processing large queries.
-	TempStorageConfig base.TempStorageConfig
+	SQLTempStorageConfig base.TempStorageConfig
 
-	// ExternalIOConfig is used to configure external storage
+	// SQLExternalIOConfig is used to configure external storage
 	// access (http://, nodelocal://, etc)
-	ExternalIOConfig base.ExternalIOConfig
+	SQLExternalIOConfig base.SQLExternalIOConfig
 
 	// Attrs specifies a colon-separated list of node topography or machine
 	// capabilities, used to match capabilities or location preferences specified
@@ -362,14 +362,14 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 			Specs: []base.StoreSpec{storeSpec},
 		},
 		StorageEngine: storage.DefaultStorageEngine,
-		TempStorageConfig: base.TempStorageConfigFromEnv(
+		SQLTempStorageConfig: base.TempStorageConfigFromEnv(
 			ctx, st, storeSpec, "" /* parentDir */, base.DefaultTempStorageMaxSizeBytes, 0),
 	}
 	cfg.AmbientCtx.Tracer = st.Tracer
 
 	cfg.Config.InitDefaults()
 	cfg.RaftConfig.SetDefaults()
-	cfg.LeaseManagerConfig = base.NewLeaseManagerConfig()
+	cfg.SQLLeaseManagerConfig = base.NewLeaseManagerConfig()
 
 	return cfg
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -126,6 +126,14 @@ type BothConfig struct {
 	// ReadWithinUncertaintyIntervalError.
 	MaxOffset MaxOffsetType
 
+	// DefaultZoneConfig is used to set the default zone config inside the server.
+	// It can be overridden during tests by setting the DefaultZoneConfigOverride
+	// server testing knob.
+	DefaultZoneConfig zonepb.ZoneConfig
+
+	// Locality is a description of the topography of the server.
+	Locality roachpb.Locality
+
 	// StorageEngine specifies the engine type (eg. rocksdb, pebble) to use to
 	// instantiate stores.
 	StorageEngine enginepb.EngineType
@@ -214,17 +222,10 @@ type Config struct {
 	// Environment Variable: COCKROACH_SCAN_MAX_IDLE_TIME
 	ScanMaxIdleTime time.Duration
 
-	// DefaultZoneConfig is used to set the default zone config inside the server.
-	// It can be overridden during tests by setting the DefaultZoneConfigOverride
-	// server testing knob.
-	DefaultZoneConfig zonepb.ZoneConfig
 	// DefaultSystemZoneConfig is used to set the default system zone config
 	// inside the server. It can be overridden during tests by setting the
 	// DefaultSystemZoneConfigOverride server testing knob.
 	DefaultSystemZoneConfig zonepb.ZoneConfig
-
-	// Locality is a description of the topography of the server.
-	Locality roachpb.Locality
 
 	// LocalityAddresses contains private IP addresses the can only be accessed
 	// in the corresponding locality.
@@ -337,16 +338,16 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 	}
 
 	bothCfg := BothConfig{
-		Config:        new(base.Config),
-		Settings:      st,
-		MaxOffset:     MaxOffsetType(base.DefaultMaxClockOffset),
-		StorageEngine: storage.DefaultStorageEngine,
+		Config:            new(base.Config),
+		Settings:          st,
+		MaxOffset:         MaxOffsetType(base.DefaultMaxClockOffset),
+		DefaultZoneConfig: zonepb.DefaultZoneConfig(),
+		StorageEngine:     storage.DefaultStorageEngine,
 	}
 
 	cfg := Config{
 		BothConfig:                     bothCfg,
 		SQLConfig:                      sqlCfg,
-		DefaultZoneConfig:              zonepb.DefaultZoneConfig(),
 		DefaultSystemZoneConfig:        zonepb.DefaultSystemZoneConfig(),
 		CacheSize:                      DefaultCacheSize,
 		ScanInterval:                   defaultScanInterval,

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -169,6 +169,8 @@ type Config struct {
 	JoinPreferSRVRecords bool
 
 	// RetryOptions controls the retry behavior of the server.
+	//
+	// TODO(tbg): this is only ever used in one test. Make it a testing knob.
 	RetryOptions retry.Options
 
 	// CacheSize is the amount of memory in bytes to use for caching data.

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -105,13 +105,9 @@ func (mo *MaxOffsetType) String() string {
 	return time.Duration(*mo).String()
 }
 
-// BothConfig holds parameters that are needed to setup either a KV or a SQL
+// BaseConfig holds parameters that are needed to setup either a KV or a SQL
 // server.
-//
-// TODO(tbg): you might almost call it... base.Config. Too many names flying
-// around here. Consider moving the whole Config shebang into `base` and
-// unifying.
-type BothConfig struct {
+type BaseConfig struct {
 	Settings *cluster.Settings
 	*base.Config
 
@@ -144,10 +140,10 @@ type BothConfig struct {
 
 // Config holds parameters needed to setup a (combined KV and SQL) server.
 //
-// TODO(tbg): this should end up being just SQLConfig union KVConfig union BothConfig.
+// TODO(tbg): this should end up being just SQLConfig union KVConfig union BaseConfig.
 type Config struct {
 	// Embed the base context.
-	BothConfig
+	BaseConfig
 	base.RaftConfig
 	SQLConfig
 
@@ -264,33 +260,33 @@ type Config struct {
 // SQLConfig holds the parameters to setup a SQL server.
 type SQLConfig struct {
 	// LeaseManagerConfig holds configuration values specific to the LeaseManager.
-	SQLLeaseManagerConfig *base.LeaseManagerConfig
+	LeaseManagerConfig *base.LeaseManagerConfig
 
-	// SQLSocketFile, if non-empty, sets up a TLS-free local listener using
+	// SocketFile, if non-empty, sets up a TLS-free local listener using
 	// a unix datagram socket at the specified path.
-	SQLSocketFile string
+	SocketFile string
 
 	// TempStorageConfig is used to configure temp storage, which stores
 	// ephemeral data when processing large queries.
-	SQLTempStorageConfig base.TempStorageConfig
+	TempStorageConfig base.TempStorageConfig
 
-	// SQLExternalIOConfig is used to configure external storage
+	// ExternalIODirConfig is used to configure external storage
 	// access (http://, nodelocal://, etc)
-	SQLExternalIOConfig base.SQLExternalIOConfig
+	ExternalIODirConfig base.ExternalIODirConfig
 
-	// SQLMemoryPoolSize is the amount of memory in bytes that can be
+	// MemoryPoolSize is the amount of memory in bytes that can be
 	// used by SQL clients to store row data in server RAM.
-	SQLMemoryPoolSize int64
+	MemoryPoolSize int64
 
-	// SQLAuditLogDirName is the target directory name for SQL audit logs.
-	SQLAuditLogDirName *log.DirName
+	// AuditLogDirName is the target directory name for SQL audit logs.
+	AuditLogDirName *log.DirName
 
-	// SQLTableStatCacheSize is the size (number of tables) of the table
+	// TableStatCacheSize is the size (number of tables) of the table
 	// statistics cache.
-	SQLTableStatCacheSize int
+	TableStatCacheSize int
 
-	// SQLQueryCacheSize is the memory size (in bytes) of the query plan cache.
-	SQLQueryCacheSize int64
+	// QueryCacheSize is the memory size (in bytes) of the query plan cache.
+	QueryCacheSize int64
 }
 
 // setOpenFileLimit sets the soft limit for open file descriptors to the hard
@@ -331,15 +327,15 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 	disableWebLogin := envutil.EnvOrDefaultBool("COCKROACH_DISABLE_WEB_LOGIN", false)
 
 	sqlCfg := SQLConfig{
-		SQLMemoryPoolSize:     defaultSQLMemoryPoolSize,
-		SQLTableStatCacheSize: defaultSQLTableStatCacheSize,
-		SQLQueryCacheSize:     defaultSQLQueryCacheSize,
-		SQLTempStorageConfig: base.TempStorageConfigFromEnv(
+		MemoryPoolSize:     defaultSQLMemoryPoolSize,
+		TableStatCacheSize: defaultSQLTableStatCacheSize,
+		QueryCacheSize:     defaultSQLQueryCacheSize,
+		TempStorageConfig: base.TempStorageConfigFromEnv(
 			ctx, st, storeSpec, "" /* parentDir */, base.DefaultTempStorageMaxSizeBytes),
-		SQLLeaseManagerConfig: base.NewLeaseManagerConfig(),
+		LeaseManagerConfig: base.NewLeaseManagerConfig(),
 	}
 
-	bothCfg := BothConfig{
+	bothCfg := BaseConfig{
 		Config:            new(base.Config),
 		Settings:          st,
 		MaxOffset:         MaxOffsetType(base.DefaultMaxClockOffset),
@@ -348,7 +344,7 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 	}
 
 	cfg := Config{
-		BothConfig:                     bothCfg,
+		BaseConfig:                     bothCfg,
 		SQLConfig:                      sqlCfg,
 		DefaultSystemZoneConfig:        zonepb.DefaultSystemZoneConfig(),
 		CacheSize:                      DefaultCacheSize,
@@ -376,7 +372,7 @@ func (cfg *Config) String() string {
 	w := tabwriter.NewWriter(&buf, 2, 1, 2, ' ', 0)
 	fmt.Fprintln(w, "max offset\t", cfg.MaxOffset)
 	fmt.Fprintln(w, "cache size\t", humanizeutil.IBytes(cfg.CacheSize))
-	fmt.Fprintln(w, "SQL memory pool size\t", humanizeutil.IBytes(cfg.SQLMemoryPoolSize))
+	fmt.Fprintln(w, "SQL memory pool size\t", humanizeutil.IBytes(cfg.MemoryPoolSize))
 	fmt.Fprintln(w, "scan interval\t", cfg.ScanInterval)
 	fmt.Fprintln(w, "scan min idle time\t", cfg.ScanMinIdleTime)
 	fmt.Fprintln(w, "scan max idle time\t", cfg.ScanMaxIdleTime)

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -454,7 +454,7 @@ func (n *Node) start(
 		}
 	}
 
-	n.startComputePeriodicMetrics(n.stopper, DefaultMetricsSampleInterval)
+	n.startComputePeriodicMetrics(n.stopper, base.DefaultMetricsSampleInterval)
 
 	// Be careful about moving this line above `startStores`; store migrations rely
 	// on the fact that the cluster version has not been updated via Gossip (we

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -381,7 +381,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// This function defines how ExternalStorage objects are created.
 	externalStorage := func(ctx context.Context, dest roachpb.ExternalStorage) (cloud.ExternalStorage, error) {
 		return cloud.MakeExternalStorage(
-			ctx, dest, cfg.ExternalIOConfig, st,
+			ctx, dest, cfg.SQLExternalIOConfig, st,
 			blobs.NewBlobClientFactory(
 				nodeIDContainer.Get(),
 				nodeDialer,
@@ -391,7 +391,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	}
 	externalStorageFromURI := func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
 		return cloud.ExternalStorageFromURI(
-			ctx, uri, cfg.ExternalIOConfig, st,
+			ctx, uri, cfg.SQLExternalIOConfig, st,
 			blobs.NewBlobClientFactory(
 				nodeIDContainer.Get(),
 				nodeDialer,
@@ -1957,7 +1957,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // TempDir returns the filepath of the temporary directory used for temp storage.
 // It is empty for an in-memory temp storage.
 func (s *Server) TempDir() string {
-	return s.cfg.TempStorageConfig.Path
+	return s.cfg.SQLTempStorageConfig.Path
 }
 
 // PGServer exports the pgwire server. Used by tests.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1549,7 +1549,7 @@ func (s *Server) Start(ctx context.Context) error {
 		s.cfg.TestingKnobs,
 		connManager,
 		pgL,
-		s.cfg.SocketFile,
+		s.cfg.SQLSocketFile,
 		orphanedLeasesTimeThresholdNanos,
 	); err != nil {
 		return err

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -535,7 +535,11 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			externalStorageFromURI: externalStorageFromURI,
 			isMeta1Leaseholder:     node.stores.IsMeta1Leaseholder,
 		},
-		Config:                   &cfg, // NB: s.cfg has a populated AmbientContext.
+		// NB: s.cfg has a populated AmbientContext.
+		Config: &cfg,
+		// TODO(tbg): use this once we get rid of Config
+		// SQLConfig:                &cfg.SQLConfig,
+		// BothConfig:               &cfg.BothConfig,
 		stopper:                  stopper,
 		clock:                    clock,
 		runtime:                  runtimeSampler,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1406,13 +1406,13 @@ func (s *Server) Start(ctx context.Context) error {
 	s.recorder.AddNode(s.registry, s.node.Descriptor, s.node.startedAt, s.cfg.AdvertiseAddr, s.cfg.HTTPAdvertiseAddr, s.cfg.SQLAdvertiseAddr)
 
 	// Begin recording runtime statistics.
-	if err := s.startSampleEnvironment(ctx, DefaultMetricsSampleInterval); err != nil {
+	if err := s.startSampleEnvironment(ctx, base.DefaultMetricsSampleInterval); err != nil {
 		return err
 	}
 
 	// Begin recording time series data collected by the status monitor.
 	s.tsDB.PollSource(
-		s.cfg.AmbientCtx, s.recorder, DefaultMetricsSampleInterval, ts.Resolution10s, s.stopper,
+		s.cfg.AmbientCtx, s.recorder, base.DefaultMetricsSampleInterval, ts.Resolution10s, s.stopper,
 	)
 
 	var graphiteOnce sync.Once
@@ -1470,7 +1470,7 @@ func (s *Server) Start(ctx context.Context) error {
 	})
 
 	// Begin recording status summaries.
-	s.node.startWriteNodeStatus(DefaultMetricsSampleInterval)
+	s.node.startWriteNodeStatus(base.DefaultMetricsSampleInterval)
 
 	// Start the protected timestamp subsystem.
 	if err := s.protectedtsProvider.Start(ctx, s.stopper); err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -543,11 +543,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			externalStorageFromURI: externalStorageFromURI,
 			isMeta1Leaseholder:     node.stores.IsMeta1Leaseholder,
 		},
-		// NB: s.cfg has a populated AmbientContext.
-		Config: &cfg,
-		// TODO(tbg): use this once we get rid of Config
-		// SQLConfig:                &cfg.SQLConfig,
-		// BothConfig:               &cfg.BothConfig,
+		SQLConfig:                &cfg.SQLConfig,
+		BothConfig:               &cfg.BothConfig,
 		stopper:                  stopper,
 		clock:                    clock,
 		runtime:                  runtimeSampler,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -381,7 +381,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// This function defines how ExternalStorage objects are created.
 	externalStorage := func(ctx context.Context, dest roachpb.ExternalStorage) (cloud.ExternalStorage, error) {
 		return cloud.MakeExternalStorage(
-			ctx, dest, cfg.SQLExternalIOConfig, st,
+			ctx, dest, cfg.ExternalIODirConfig, st,
 			blobs.NewBlobClientFactory(
 				nodeIDContainer.Get(),
 				nodeDialer,
@@ -391,7 +391,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	}
 	externalStorageFromURI := func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
 		return cloud.ExternalStorageFromURI(
-			ctx, uri, cfg.SQLExternalIOConfig, st,
+			ctx, uri, cfg.ExternalIODirConfig, st,
 			blobs.NewBlobClientFactory(
 				nodeIDContainer.Get(),
 				nodeDialer,
@@ -544,7 +544,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			isMeta1Leaseholder:     node.stores.IsMeta1Leaseholder,
 		},
 		SQLConfig:                &cfg.SQLConfig,
-		BothConfig:               &cfg.BothConfig,
+		BaseConfig:               &cfg.BaseConfig,
 		stopper:                  stopper,
 		clock:                    clock,
 		runtime:                  runtimeSampler,
@@ -1559,7 +1559,7 @@ func (s *Server) Start(ctx context.Context) error {
 		s.cfg.TestingKnobs,
 		connManager,
 		pgL,
-		s.cfg.SQLSocketFile,
+		s.cfg.SocketFile,
 		orphanedLeasesTimeThresholdNanos,
 	); err != nil {
 		return err
@@ -1967,7 +1967,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // TempDir returns the filepath of the temporary directory used for temp storage.
 // It is empty for an in-memory temp storage.
 func (s *Server) TempDir() string {
-	return s.cfg.SQLTempStorageConfig.Path
+	return s.cfg.TempStorageConfig.Path
 }
 
 // PGServer exports the pgwire server. Used by tests.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -520,6 +520,14 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		gw.RegisterService(grpcServer.Server)
 	}
 
+	var jobAdoptionStopFile string
+	for _, spec := range cfg.Stores.Specs {
+		if !spec.InMemory && spec.Path != "" {
+			jobAdoptionStopFile = filepath.Join(spec.Path, jobs.PreventAdoptionFile)
+			break
+		}
+	}
+
 	sqlServer, err := newSQLServer(ctx, sqlServerArgs{
 		sqlServerOptionalArgs: sqlServerOptionalArgs{
 			rpcContext:             rpcContext,
@@ -549,6 +557,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		sessionRegistry:          sessionRegistry,
 		circularInternalExecutor: internalExecutor,
 		jobRegistry:              jobRegistry,
+		jobAdoptionStopFile:      jobAdoptionStopFile,
 		protectedtsProvider:      protectedtsProvider,
 	})
 	if err != nil {

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -133,6 +133,7 @@ type sqlServerArgs struct {
 	// TODO(tbg): replace Config with:
 	// *SQLConfig
 	// *BothConfig
+
 	stopper *stop.Stopper
 
 	// SQL uses the clock to assign timestamps to transactions, among many

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -231,7 +231,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 		codec,
 		lmKnobs,
 		cfg.stopper,
-		cfg.LeaseManagerConfig,
+		cfg.SQLLeaseManagerConfig,
 	)
 
 	// Set up internal memory metrics for use by internal SQL executors.
@@ -262,8 +262,8 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 
 	// Set up the DistSQL temp engine.
 
-	useStoreSpec := cfg.Stores.Specs[cfg.TempStorageConfig.SpecIdx]
-	tempEngine, tempFS, err := storage.NewTempEngine(ctx, cfg.StorageEngine, cfg.TempStorageConfig, useStoreSpec)
+	useStoreSpec := cfg.Stores.Specs[cfg.SQLTempStorageConfig.SpecIdx]
+	tempEngine, tempFS, err := storage.NewTempEngine(ctx, cfg.StorageEngine, cfg.SQLTempStorageConfig, useStoreSpec)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating temp storage")
 	}
@@ -271,12 +271,12 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 	// Remove temporary directory linked to tempEngine after closing
 	// tempEngine.
 	cfg.stopper.AddCloser(stop.CloserFn(func() {
-		firstStore := cfg.Stores.Specs[cfg.TempStorageConfig.SpecIdx]
+		firstStore := cfg.Stores.Specs[cfg.SQLTempStorageConfig.SpecIdx]
 		var err error
 		if firstStore.InMemory {
 			// First store is in-memory so we remove the temp
 			// directory directly since there is no record file.
-			err = os.RemoveAll(cfg.TempStorageConfig.Path)
+			err = os.RemoveAll(cfg.SQLTempStorageConfig.Path)
 		} else {
 			// If record file exists, we invoke CleanupTempDirs to
 			// also remove the record after the temp directory is
@@ -308,14 +308,14 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 		Stopper:        cfg.stopper,
 
 		TempStorage:     tempEngine,
-		TempStoragePath: cfg.TempStorageConfig.Path,
+		TempStoragePath: cfg.SQLTempStorageConfig.Path,
 		TempFS:          tempFS,
 		// COCKROACH_VEC_MAX_OPEN_FDS specifies the maximum number of open file
 		// descriptors that the vectorized execution engine may have open at any
 		// one time. This limit is implemented as a weighted semaphore acquired
 		// before opening files.
 		VecFDSemaphore: semaphore.New(envutil.EnvOrDefaultInt("COCKROACH_VEC_MAX_OPEN_FDS", colexec.VecMaxOpenFDsLimit)),
-		DiskMonitor:    cfg.TempStorageConfig.Mon,
+		DiskMonitor:    cfg.SQLTempStorageConfig.Mon,
 
 		ParentMemoryMonitor: &rootSQLMemoryMonitor,
 		BulkAdder: func(
@@ -337,7 +337,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 		ExternalStorage:        cfg.externalStorage,
 		ExternalStorageFromURI: cfg.externalStorageFromURI,
 	}
-	cfg.TempStorageConfig.Mon.SetMetrics(distSQLMetrics.CurDiskBytesCount, distSQLMetrics.MaxDiskBytesHist)
+	cfg.SQLTempStorageConfig.Mon.SetMetrics(distSQLMetrics.CurDiskBytesCount, distSQLMetrics.MaxDiskBytesHist)
 	if distSQLTestingKnobs := cfg.TestingKnobs.DistSQL; distSQLTestingKnobs != nil {
 		distSQLCfg.TestingKnobs = *distSQLTestingKnobs.(*execinfra.TestingKnobs)
 	}

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -129,10 +129,8 @@ type sqlServerOptionalArgs struct {
 type sqlServerArgs struct {
 	sqlServerOptionalArgs
 
-	*Config
-	// TODO(tbg): replace Config with:
-	// *SQLConfig
-	// *BothConfig
+	*SQLConfig
+	*BothConfig
 
 	stopper *stop.Stopper
 
@@ -493,7 +491,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 	sqlMemMetrics := sql.MakeMemMetrics("sql", cfg.HistogramWindowInterval())
 	pgServer := pgwire.MakeServer(
 		cfg.AmbientCtx,
-		cfg.Config.Config,
+		cfg.Config,
 		cfg.Settings,
 		sqlMemMetrics,
 		&rootSQLMemoryMonitor,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -130,6 +130,9 @@ type sqlServerArgs struct {
 	sqlServerOptionalArgs
 
 	*Config
+	// TODO(tbg): replace Config with:
+	// *SQLConfig
+	// *BothConfig
 	stopper *stop.Stopper
 
 	// SQL uses the clock to assign timestamps to transactions, among many

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -265,7 +265,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 
 	// Set up the DistSQL temp engine.
 
-	useStoreSpec := cfg.Stores.Specs[cfg.SQLTempStorageConfig.SpecIdx]
+	useStoreSpec := cfg.SQLTempStorageConfig.Spec
 	tempEngine, tempFS, err := storage.NewTempEngine(ctx, cfg.StorageEngine, cfg.SQLTempStorageConfig, useStoreSpec)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating temp storage")
@@ -274,17 +274,17 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 	// Remove temporary directory linked to tempEngine after closing
 	// tempEngine.
 	cfg.stopper.AddCloser(stop.CloserFn(func() {
-		firstStore := cfg.Stores.Specs[cfg.SQLTempStorageConfig.SpecIdx]
+		useStore := cfg.SQLTempStorageConfig.Spec
 		var err error
-		if firstStore.InMemory {
-			// First store is in-memory so we remove the temp
+		if useStore.InMemory {
+			// Used store is in-memory so we remove the temp
 			// directory directly since there is no record file.
 			err = os.RemoveAll(cfg.SQLTempStorageConfig.Path)
 		} else {
 			// If record file exists, we invoke CleanupTempDirs to
 			// also remove the record after the temp directory is
 			// removed.
-			recordPath := filepath.Join(firstStore.Path, TempDirsRecordFilename)
+			recordPath := filepath.Join(useStore.Path, TempDirsRecordFilename)
 			err = storage.CleanupTempDirs(recordPath)
 		}
 		if err != nil {

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -243,7 +243,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 		}
 	}
 	cfg.Stores = base.StoreSpecList{Specs: params.StoreSpecs}
-	if params.TempStorageConfig != (base.TempStorageConfig{}) {
+	if params.TempStorageConfig.InMemory || params.TempStorageConfig.Path != "" {
 		cfg.SQLTempStorageConfig = params.TempStorageConfig
 	}
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -439,17 +439,85 @@ func (d dummyProtectedTSProvider) Protect(context.Context, *kv.Txn, *ptpb.Record
 }
 
 func testSQLServerArgs(ts *TestServer) sqlServerArgs {
-	st := cluster.MakeTestingClusterSettings()
 	stopper := ts.Stopper()
+	// If we used a dummy gossip, DistSQL and random other things won't work.
+	// Just use the test server's for now.
+	//
+	// TODO(tbg): drop the Gossip dependency.
+	g := ts.Gossip()
+	ts = nil // prevent usage below
 
-	cfg := makeTestConfig(st)
+	st := cluster.MakeTestingClusterSettings()
 
-	clock := hlc.NewClock(hlc.UnixNano, 1)
-	rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
+	var sqlConfig SQLConfig
+	var bothConfig BothConfig
+	{
+		cfg := makeTestConfig(st)
+		sqlConfig = cfg.SQLConfig
+		bothConfig = cfg.BothConfig
+	}
 
-	nl := allErrorsFakeLiveness{}
+	clock := hlc.NewClock(hlc.UnixNano, time.Duration(bothConfig.MaxOffset))
 
-	ds := ts.DistSender()
+	var rpcTestingKnobs rpc.ContextTestingKnobs
+	if p, ok := bothConfig.TestingKnobs.Server.(*TestingKnobs); ok {
+		rpcTestingKnobs = p.ContextTestingKnobs
+	}
+	rpcContext := rpc.NewContextWithTestingKnobs(
+		bothConfig.AmbientCtx,
+		bothConfig.Config,
+		clock,
+		stopper,
+		st,
+		rpcTestingKnobs,
+	)
+
+	var dsKnobs kvcoord.ClientTestingKnobs
+	if dsKnobsP, ok := bothConfig.TestingKnobs.DistSQL.(*kvcoord.ClientTestingKnobs); ok {
+		dsKnobs = *dsKnobsP
+	}
+	rpcRetryOptions := base.DefaultRetryOptions()
+	resolver := gossip.AddressResolver(g) // TODO(tbg): break gossip dep
+	nodeDialer := nodedialer.New(rpcContext, resolver)
+	dsCfg := kvcoord.DistSenderConfig{
+		AmbientCtx:        bothConfig.AmbientCtx,
+		Settings:          st,
+		Clock:             clock,
+		RPCRetryOptions:   &rpcRetryOptions,
+		RPCContext:        rpcContext,
+		RangeDescriptorDB: nil, // use DistSender itself
+		NodeDialer:        nodeDialer,
+		TestingKnobs:      dsKnobs,
+	}
+	ds := kvcoord.NewDistSender(dsCfg, g)
+
+	var clientKnobs kvcoord.ClientTestingKnobs
+	if p, ok := bothConfig.TestingKnobs.KVClient.(*kvcoord.ClientTestingKnobs); ok {
+		clientKnobs = *p
+	}
+	// TODO(tbg): expose this registry via prometheus. See:
+	// https://github.com/cockroachdb/cockroach/issues/47905
+	registry := metric.NewRegistry()
+	txnMetrics := kvcoord.MakeTxnMetrics(bothConfig.HistogramWindowInterval())
+	registry.AddMetricStruct(txnMetrics)
+	tcsFactory := kvcoord.NewTxnCoordSenderFactory(
+		kvcoord.TxnCoordSenderFactoryConfig{
+			AmbientCtx:        bothConfig.AmbientCtx,
+			Settings:          st,
+			Clock:             clock,
+			Stopper:           stopper,
+			HeartbeatInterval: base.DefaultTxnHeartbeatInterval,
+			Linearizable:      false,
+			Metrics:           txnMetrics,
+			TestingKnobs:      clientKnobs,
+		},
+		ds,
+	)
+	db := kv.NewDB(
+		bothConfig.AmbientCtx,
+		tcsFactory,
+		clock,
+	)
 
 	circularInternalExecutor := &sql.InternalExecutor{}
 	// Protected timestamps won't be available (at first) in multi-tenant
@@ -457,7 +525,7 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 	var protectedTSProvider protectedts.Provider
 	{
 		pp, err := ptprovider.New(ptprovider.Config{
-			DB:               ts.DB(),
+			DB:               db,
 			InternalExecutor: circularInternalExecutor,
 			Settings:         st,
 		})
@@ -466,15 +534,6 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 		}
 		protectedTSProvider = dummyProtectedTSProvider{pp}
 	}
-
-	registry := metric.NewRegistry()
-
-	// If we used a dummy gossip, DistSQL and random other things won't work.
-	// Just use the test server's for now.
-	// g := gossip.NewTest(nodeID, nil, nil, stopper, registry, nil)
-	g := ts.Gossip()
-
-	nd := nodedialer.New(rpcContext, gossip.AddressResolver(ts.Gossip()))
 
 	dummyRecorder := &status.MetricsRecorder{}
 
@@ -497,9 +556,9 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 			rpcContext:   rpcContext,
 			distSender:   ds,
 			statusServer: noStatusServer,
-			nodeLiveness: nl,
+			nodeLiveness: allErrorsFakeLiveness{},
 			gossip:       gossip.MakeUnexposedGossip(g),
-			nodeDialer:   nd,
+			nodeDialer:   nodeDialer,
 			grpcServer:   dummyRPCServer,
 			recorder:     dummyRecorder,
 			isMeta1Leaseholder: func(timestamp hlc.Timestamp) (bool, error) {
@@ -513,13 +572,13 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 				return nil, errors.New("fake external uri storage")
 			},
 		},
-		SQLConfig:                &cfg.SQLConfig,
-		BothConfig:               &cfg.BothConfig,
+		SQLConfig:                &sqlConfig,
+		BothConfig:               &bothConfig,
 		stopper:                  stopper,
 		clock:                    clock,
 		runtime:                  status.NewRuntimeStatSampler(context.Background(), clock),
 		tenantID:                 roachpb.SystemTenantID,
-		db:                       ts.DB(),
+		db:                       db,
 		registry:                 registry,
 		sessionRegistry:          sql.NewSessionRegistry(),
 		circularInternalExecutor: circularInternalExecutor,
@@ -545,6 +604,8 @@ func (ts *TestServer) StartTenant(params base.TestTenantArgs) (pgAddr string, _ 
 			ClusterSettingsUpdater: args.Settings.MakeUpdater(),
 		}
 	}
+	ts = nil // proves we're not using it below
+
 	s, err := newSQLServer(ctx, args)
 	if err != nil {
 		return "", err
@@ -566,8 +627,8 @@ func (ts *TestServer) StartTenant(params base.TestTenantArgs) (pgAddr string, _ 
 	if err != nil {
 		return "", err
 	}
-	ts.Stopper().RunWorker(ctx, func(ctx context.Context) {
-		<-ts.Stopper().ShouldQuiesce()
+	args.stopper.RunWorker(ctx, func(ctx context.Context) {
+		<-args.stopper.ShouldQuiesce()
 		// NB: we can't do this as a Closer because (*Server).ServeWith is
 		// running in a worker and usually sits on accept(pgL) which unblocks
 		// only when pgL closes. In other words, pgL needs to close when

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -86,7 +86,7 @@ func makeTestConfig(st *cluster.Settings) Config {
 
 	// Configure the default in-memory temp storage for all tests unless
 	// otherwise configured.
-	cfg.SQLTempStorageConfig = base.DefaultTestTempStorageConfig(st)
+	cfg.TempStorageConfig = base.DefaultTestTempStorageConfig(st)
 
 	// Load test certs. In addition, the tests requiring certs
 	// need to call security.SetAssetLoader(securitytest.EmbeddedAssets)
@@ -126,16 +126,16 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	cfg.RaftConfig = params.RaftConfig
 	cfg.RaftConfig.SetDefaults()
 	if params.LeaseManagerConfig != nil {
-		cfg.SQLLeaseManagerConfig = params.LeaseManagerConfig
+		cfg.LeaseManagerConfig = params.LeaseManagerConfig
 	} else {
-		cfg.SQLLeaseManagerConfig = base.NewLeaseManagerConfig()
+		cfg.LeaseManagerConfig = base.NewLeaseManagerConfig()
 	}
 	if params.JoinAddr != "" {
 		cfg.JoinList = []string{params.JoinAddr}
 	}
 	cfg.ClusterName = params.ClusterName
 	cfg.Insecure = params.Insecure
-	cfg.SQLSocketFile = params.SocketFile
+	cfg.SocketFile = params.SocketFile
 	cfg.RetryOptions = params.RetryOptions
 	cfg.Locality = params.Locality
 	if knobs := params.Knobs.Store; knobs != nil {
@@ -173,7 +173,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 		cfg.EventLogEnabled = false
 	}
 	if params.SQLMemoryPoolSize != 0 {
-		cfg.SQLMemoryPoolSize = params.SQLMemoryPoolSize
+		cfg.MemoryPoolSize = params.SQLMemoryPoolSize
 	}
 	if params.CacheSize != 0 {
 		cfg.CacheSize = params.CacheSize
@@ -244,7 +244,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	}
 	cfg.Stores = base.StoreSpecList{Specs: params.StoreSpecs}
 	if params.TempStorageConfig.InMemory || params.TempStorageConfig.Path != "" {
-		cfg.SQLTempStorageConfig = params.TempStorageConfig
+		cfg.TempStorageConfig = params.TempStorageConfig
 	}
 
 	if cfg.TestingKnobs.Store == nil {
@@ -451,28 +451,28 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 	st := cluster.MakeTestingClusterSettings()
 
 	var sqlConfig SQLConfig
-	var bothConfig BothConfig
+	var baseConfig BaseConfig
 	{
 		cfg := makeTestConfig(st)
 		sqlConfig = cfg.SQLConfig
-		bothConfig = cfg.BothConfig
+		baseConfig = cfg.BaseConfig
 		// TODO(tbg): this is needed so that the RPC heartbeats between the testcluster
 		// and this tenant work.
 		//
 		// TODO(tbg): address this when we introduce the real tenant RPCs in:
 		// https://github.com/cockroachdb/cockroach/issues/47898
-		bothConfig.ClusterName = clusterName
+		baseConfig.ClusterName = clusterName
 	}
 
-	clock := hlc.NewClock(hlc.UnixNano, time.Duration(bothConfig.MaxOffset))
+	clock := hlc.NewClock(hlc.UnixNano, time.Duration(baseConfig.MaxOffset))
 
 	var rpcTestingKnobs rpc.ContextTestingKnobs
-	if p, ok := bothConfig.TestingKnobs.Server.(*TestingKnobs); ok {
+	if p, ok := baseConfig.TestingKnobs.Server.(*TestingKnobs); ok {
 		rpcTestingKnobs = p.ContextTestingKnobs
 	}
 	rpcContext := rpc.NewContextWithTestingKnobs(
-		bothConfig.AmbientCtx,
-		bothConfig.Config,
+		baseConfig.AmbientCtx,
+		baseConfig.Config,
 		clock,
 		stopper,
 		st,
@@ -480,14 +480,14 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 	)
 
 	var dsKnobs kvcoord.ClientTestingKnobs
-	if dsKnobsP, ok := bothConfig.TestingKnobs.DistSQL.(*kvcoord.ClientTestingKnobs); ok {
+	if dsKnobsP, ok := baseConfig.TestingKnobs.DistSQL.(*kvcoord.ClientTestingKnobs); ok {
 		dsKnobs = *dsKnobsP
 	}
 	rpcRetryOptions := base.DefaultRetryOptions()
 	resolver := gossip.AddressResolver(g) // TODO(tbg): break gossip dep
 	nodeDialer := nodedialer.New(rpcContext, resolver)
 	dsCfg := kvcoord.DistSenderConfig{
-		AmbientCtx:        bothConfig.AmbientCtx,
+		AmbientCtx:        baseConfig.AmbientCtx,
 		Settings:          st,
 		Clock:             clock,
 		RPCRetryOptions:   &rpcRetryOptions,
@@ -499,17 +499,17 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 	ds := kvcoord.NewDistSender(dsCfg, g)
 
 	var clientKnobs kvcoord.ClientTestingKnobs
-	if p, ok := bothConfig.TestingKnobs.KVClient.(*kvcoord.ClientTestingKnobs); ok {
+	if p, ok := baseConfig.TestingKnobs.KVClient.(*kvcoord.ClientTestingKnobs); ok {
 		clientKnobs = *p
 	}
 	// TODO(tbg): expose this registry via prometheus. See:
 	// https://github.com/cockroachdb/cockroach/issues/47905
 	registry := metric.NewRegistry()
-	txnMetrics := kvcoord.MakeTxnMetrics(bothConfig.HistogramWindowInterval())
+	txnMetrics := kvcoord.MakeTxnMetrics(baseConfig.HistogramWindowInterval())
 	registry.AddMetricStruct(txnMetrics)
 	tcsFactory := kvcoord.NewTxnCoordSenderFactory(
 		kvcoord.TxnCoordSenderFactoryConfig{
-			AmbientCtx:        bothConfig.AmbientCtx,
+			AmbientCtx:        baseConfig.AmbientCtx,
 			Settings:          st,
 			Clock:             clock,
 			Stopper:           stopper,
@@ -521,7 +521,7 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 		ds,
 	)
 	db := kv.NewDB(
-		bothConfig.AmbientCtx,
+		baseConfig.AmbientCtx,
 		tcsFactory,
 		clock,
 	)
@@ -580,7 +580,7 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 			},
 		},
 		SQLConfig:                &sqlConfig,
-		BothConfig:               &bothConfig,
+		BaseConfig:               &baseConfig,
 		stopper:                  stopper,
 		clock:                    clock,
 		runtime:                  status.NewRuntimeStatSampler(context.Background(), clock),

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -135,7 +135,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	}
 	cfg.ClusterName = params.ClusterName
 	cfg.Insecure = params.Insecure
-	cfg.SocketFile = params.SocketFile
+	cfg.SQLSocketFile = params.SocketFile
 	cfg.RetryOptions = params.RetryOptions
 	cfg.Locality = params.Locality
 	if knobs := params.Knobs.Store; knobs != nil {

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -513,9 +513,8 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 				return nil, errors.New("fake external uri storage")
 			},
 		},
-		Config: &cfg,
-		// SQLConfig:                &cfg.SQLConfig,
-		// BothConfig:               &cfg.BothConfig,
+		SQLConfig:                &cfg.SQLConfig,
+		BothConfig:               &cfg.BothConfig,
 		stopper:                  stopper,
 		clock:                    clock,
 		runtime:                  status.NewRuntimeStatSampler(context.Background(), clock),
@@ -583,7 +582,7 @@ func (ts *TestServer) StartTenant(params base.TestTenantArgs) (pgAddr string, _ 
 
 	if err := s.start(ctx,
 		args.stopper,
-		args.Config.TestingKnobs,
+		args.TestingKnobs,
 		connManager,
 		pgL,
 		socketFile,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -440,6 +440,7 @@ func (d dummyProtectedTSProvider) Protect(context.Context, *kv.Txn, *ptpb.Record
 
 func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 	stopper := ts.Stopper()
+	clusterName := ts.Cfg.ClusterName
 	// If we used a dummy gossip, DistSQL and random other things won't work.
 	// Just use the test server's for now.
 	//
@@ -455,6 +456,12 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 		cfg := makeTestConfig(st)
 		sqlConfig = cfg.SQLConfig
 		bothConfig = cfg.BothConfig
+		// TODO(tbg): this is needed so that the RPC heartbeats between the testcluster
+		// and this tenant work.
+		//
+		// TODO(tbg): address this when we introduce the real tenant RPCs in:
+		// https://github.com/cockroachdb/cockroach/issues/47898
+		bothConfig.ClusterName = clusterName
 	}
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Duration(bothConfig.MaxOffset))

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -513,7 +513,9 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 				return nil, errors.New("fake external uri storage")
 			},
 		},
-		Config:                   &cfg,
+		Config: &cfg,
+		// SQLConfig:                &cfg.SQLConfig,
+		// BothConfig:               &cfg.BothConfig,
 		stopper:                  stopper,
 		clock:                    clock,
 		runtime:                  status.NewRuntimeStatSampler(context.Background(), clock),

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -86,7 +86,7 @@ func makeTestConfig(st *cluster.Settings) Config {
 
 	// Configure the default in-memory temp storage for all tests unless
 	// otherwise configured.
-	cfg.TempStorageConfig = base.DefaultTestTempStorageConfig(st)
+	cfg.SQLTempStorageConfig = base.DefaultTestTempStorageConfig(st)
 
 	// Load test certs. In addition, the tests requiring certs
 	// need to call security.SetAssetLoader(securitytest.EmbeddedAssets)
@@ -126,9 +126,9 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	cfg.RaftConfig = params.RaftConfig
 	cfg.RaftConfig.SetDefaults()
 	if params.LeaseManagerConfig != nil {
-		cfg.LeaseManagerConfig = params.LeaseManagerConfig
+		cfg.SQLLeaseManagerConfig = params.LeaseManagerConfig
 	} else {
-		cfg.LeaseManagerConfig = base.NewLeaseManagerConfig()
+		cfg.SQLLeaseManagerConfig = base.NewLeaseManagerConfig()
 	}
 	if params.JoinAddr != "" {
 		cfg.JoinList = []string{params.JoinAddr}
@@ -244,7 +244,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	}
 	cfg.Stores = base.StoreSpecList{Specs: params.StoreSpecs}
 	if params.TempStorageConfig != (base.TempStorageConfig{}) {
-		cfg.TempStorageConfig = params.TempStorageConfig
+		cfg.SQLTempStorageConfig = params.TempStorageConfig
 	}
 
 	if cfg.TestingKnobs.Store == nil {

--- a/pkg/sql/stats/automatic_stats_manual_test.go
+++ b/pkg/sql/stats/automatic_stats_manual_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -98,7 +97,7 @@ func TestAdaptiveThrottling(t *testing.T) {
 
 		// Sleep for 2 * DefaultMetricsSampleInterval, to make sure the runtime
 		// stats reflect the load we want.
-		sleep := 2 * server.DefaultMetricsSampleInterval
+		sleep := 2 * base.DefaultMetricsSampleInterval
 		fmt.Printf("Sleeping for %s\n", sleep)
 		time.Sleep(sleep)
 		step("Create stats", func() {

--- a/pkg/storage/cloud/external_storage.go
+++ b/pkg/storage/cloud/external_storage.go
@@ -230,7 +230,7 @@ func ExternalStorageConfFromURI(path string) (roachpb.ExternalStorage, error) {
 func ExternalStorageFromURI(
 	ctx context.Context,
 	uri string,
-	externalConfig base.ExternalIOConfig,
+	externalConfig base.SQLExternalIOConfig,
 	settings *cluster.Settings,
 	blobClientFactory blobs.BlobClientFactory,
 ) (ExternalStorage, error) {
@@ -279,7 +279,7 @@ func SanitizeExternalStorageURI(path string, extraParams []string) (string, erro
 func MakeExternalStorage(
 	ctx context.Context,
 	dest roachpb.ExternalStorage,
-	conf base.ExternalIOConfig,
+	conf base.SQLExternalIOConfig,
 	settings *cluster.Settings,
 	blobClientFactory blobs.BlobClientFactory,
 ) (ExternalStorage, error) {

--- a/pkg/storage/cloud/external_storage.go
+++ b/pkg/storage/cloud/external_storage.go
@@ -230,7 +230,7 @@ func ExternalStorageConfFromURI(path string) (roachpb.ExternalStorage, error) {
 func ExternalStorageFromURI(
 	ctx context.Context,
 	uri string,
-	externalConfig base.SQLExternalIOConfig,
+	externalConfig base.ExternalIODirConfig,
 	settings *cluster.Settings,
 	blobClientFactory blobs.BlobClientFactory,
 ) (ExternalStorage, error) {
@@ -279,7 +279,7 @@ func SanitizeExternalStorageURI(path string, extraParams []string) (string, erro
 func MakeExternalStorage(
 	ctx context.Context,
 	dest roachpb.ExternalStorage,
-	conf base.SQLExternalIOConfig,
+	conf base.ExternalIODirConfig,
 	settings *cluster.Settings,
 	blobClientFactory blobs.BlobClientFactory,
 ) (ExternalStorage, error) {

--- a/pkg/storage/cloud/external_storage_test.go
+++ b/pkg/storage/cloud/external_storage_test.go
@@ -62,7 +62,7 @@ func storeFromURI(
 		t.Fatal(err)
 	}
 	// Setup a sink for the given args.
-	s, err := MakeExternalStorage(ctx, conf, base.SQLExternalIOConfig{}, testSettings, clientFactory)
+	s, err := MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, testSettings, clientFactory)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,11 +70,11 @@ func storeFromURI(
 }
 
 func testExportStore(t *testing.T, storeURI string, skipSingleFile bool) {
-	testExportStoreWithExternalIOConfig(t, base.SQLExternalIOConfig{}, storeURI, skipSingleFile)
+	testExportStoreWithExternalIOConfig(t, base.ExternalIODirConfig{}, storeURI, skipSingleFile)
 }
 
 func testExportStoreWithExternalIOConfig(
-	t *testing.T, ioConf base.SQLExternalIOConfig, storeURI string, skipSingleFile bool,
+	t *testing.T, ioConf base.ExternalIODirConfig, storeURI string, skipSingleFile bool,
 ) {
 	ctx := context.Background()
 
@@ -476,7 +476,7 @@ func TestWorkloadStorage(t *testing.T) {
 
 	{
 		s, err := ExternalStorageFromURI(
-			ctx, bankURL().String(), base.SQLExternalIOConfig{},
+			ctx, bankURL().String(), base.ExternalIODirConfig{},
 			settings, blobs.TestEmptyBlobClientFactory,
 		)
 		require.NoError(t, err)
@@ -496,7 +496,7 @@ func TestWorkloadStorage(t *testing.T) {
 		params := map[string]string{
 			`row-start`: `1`, `row-end`: `3`, `payload-bytes`: `14`, `batch-size`: `1`}
 		s, err := ExternalStorageFromURI(
-			ctx, bankURL(params).String(), base.SQLExternalIOConfig{},
+			ctx, bankURL(params).String(), base.ExternalIODirConfig{},
 			settings, blobs.TestEmptyBlobClientFactory,
 		)
 		require.NoError(t, err)
@@ -511,32 +511,32 @@ func TestWorkloadStorage(t *testing.T) {
 	}
 
 	_, err := ExternalStorageFromURI(
-		ctx, `workload:///nope`, base.SQLExternalIOConfig{},
+		ctx, `workload:///nope`, base.ExternalIODirConfig{},
 		settings, blobs.TestEmptyBlobClientFactory,
 	)
 	require.EqualError(t, err, `path must be of the form /<format>/<generator>/<table>: /nope`)
 	_, err = ExternalStorageFromURI(
-		ctx, `workload:///fmt/bank/bank?version=`, base.SQLExternalIOConfig{},
+		ctx, `workload:///fmt/bank/bank?version=`, base.ExternalIODirConfig{},
 		settings, blobs.TestEmptyBlobClientFactory,
 	)
 	require.EqualError(t, err, `unsupported format: fmt`)
 	_, err = ExternalStorageFromURI(
-		ctx, `workload:///csv/nope/nope?version=`, base.SQLExternalIOConfig{},
+		ctx, `workload:///csv/nope/nope?version=`, base.ExternalIODirConfig{},
 		settings, blobs.TestEmptyBlobClientFactory,
 	)
 	require.EqualError(t, err, `unknown generator: nope`)
 	_, err = ExternalStorageFromURI(
-		ctx, `workload:///csv/bank/bank`, base.SQLExternalIOConfig{},
+		ctx, `workload:///csv/bank/bank`, base.ExternalIODirConfig{},
 		settings, blobs.TestEmptyBlobClientFactory,
 	)
 	require.EqualError(t, err, `parameter version is required`)
 	_, err = ExternalStorageFromURI(
-		ctx, `workload:///csv/bank/bank?version=`, base.SQLExternalIOConfig{},
+		ctx, `workload:///csv/bank/bank?version=`, base.ExternalIODirConfig{},
 		settings, blobs.TestEmptyBlobClientFactory,
 	)
 	require.EqualError(t, err, `expected bank version "" but got "1.0.0"`)
 	_, err = ExternalStorageFromURI(
-		ctx, `workload:///csv/bank/bank?version=nope`, base.SQLExternalIOConfig{},
+		ctx, `workload:///csv/bank/bank?version=nope`, base.ExternalIODirConfig{},
 		settings, blobs.TestEmptyBlobClientFactory,
 	)
 	require.EqualError(t, err, `expected bank version "nope" but got "1.0.0"`)

--- a/pkg/storage/cloud/external_storage_test.go
+++ b/pkg/storage/cloud/external_storage_test.go
@@ -62,7 +62,7 @@ func storeFromURI(
 		t.Fatal(err)
 	}
 	// Setup a sink for the given args.
-	s, err := MakeExternalStorage(ctx, conf, base.ExternalIOConfig{}, testSettings, clientFactory)
+	s, err := MakeExternalStorage(ctx, conf, base.SQLExternalIOConfig{}, testSettings, clientFactory)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,11 +70,11 @@ func storeFromURI(
 }
 
 func testExportStore(t *testing.T, storeURI string, skipSingleFile bool) {
-	testExportStoreWithExternalIOConfig(t, base.ExternalIOConfig{}, storeURI, skipSingleFile)
+	testExportStoreWithExternalIOConfig(t, base.SQLExternalIOConfig{}, storeURI, skipSingleFile)
 }
 
 func testExportStoreWithExternalIOConfig(
-	t *testing.T, ioConf base.ExternalIOConfig, storeURI string, skipSingleFile bool,
+	t *testing.T, ioConf base.SQLExternalIOConfig, storeURI string, skipSingleFile bool,
 ) {
 	ctx := context.Background()
 
@@ -476,7 +476,7 @@ func TestWorkloadStorage(t *testing.T) {
 
 	{
 		s, err := ExternalStorageFromURI(
-			ctx, bankURL().String(), base.ExternalIOConfig{},
+			ctx, bankURL().String(), base.SQLExternalIOConfig{},
 			settings, blobs.TestEmptyBlobClientFactory,
 		)
 		require.NoError(t, err)
@@ -496,7 +496,7 @@ func TestWorkloadStorage(t *testing.T) {
 		params := map[string]string{
 			`row-start`: `1`, `row-end`: `3`, `payload-bytes`: `14`, `batch-size`: `1`}
 		s, err := ExternalStorageFromURI(
-			ctx, bankURL(params).String(), base.ExternalIOConfig{},
+			ctx, bankURL(params).String(), base.SQLExternalIOConfig{},
 			settings, blobs.TestEmptyBlobClientFactory,
 		)
 		require.NoError(t, err)
@@ -511,32 +511,32 @@ func TestWorkloadStorage(t *testing.T) {
 	}
 
 	_, err := ExternalStorageFromURI(
-		ctx, `workload:///nope`, base.ExternalIOConfig{},
+		ctx, `workload:///nope`, base.SQLExternalIOConfig{},
 		settings, blobs.TestEmptyBlobClientFactory,
 	)
 	require.EqualError(t, err, `path must be of the form /<format>/<generator>/<table>: /nope`)
 	_, err = ExternalStorageFromURI(
-		ctx, `workload:///fmt/bank/bank?version=`, base.ExternalIOConfig{},
+		ctx, `workload:///fmt/bank/bank?version=`, base.SQLExternalIOConfig{},
 		settings, blobs.TestEmptyBlobClientFactory,
 	)
 	require.EqualError(t, err, `unsupported format: fmt`)
 	_, err = ExternalStorageFromURI(
-		ctx, `workload:///csv/nope/nope?version=`, base.ExternalIOConfig{},
+		ctx, `workload:///csv/nope/nope?version=`, base.SQLExternalIOConfig{},
 		settings, blobs.TestEmptyBlobClientFactory,
 	)
 	require.EqualError(t, err, `unknown generator: nope`)
 	_, err = ExternalStorageFromURI(
-		ctx, `workload:///csv/bank/bank`, base.ExternalIOConfig{},
+		ctx, `workload:///csv/bank/bank`, base.SQLExternalIOConfig{},
 		settings, blobs.TestEmptyBlobClientFactory,
 	)
 	require.EqualError(t, err, `parameter version is required`)
 	_, err = ExternalStorageFromURI(
-		ctx, `workload:///csv/bank/bank?version=`, base.ExternalIOConfig{},
+		ctx, `workload:///csv/bank/bank?version=`, base.SQLExternalIOConfig{},
 		settings, blobs.TestEmptyBlobClientFactory,
 	)
 	require.EqualError(t, err, `expected bank version "" but got "1.0.0"`)
 	_, err = ExternalStorageFromURI(
-		ctx, `workload:///csv/bank/bank?version=nope`, base.ExternalIOConfig{},
+		ctx, `workload:///csv/bank/bank?version=nope`, base.SQLExternalIOConfig{},
 		settings, blobs.TestEmptyBlobClientFactory,
 	)
 	require.EqualError(t, err, `expected bank version "nope" but got "1.0.0"`)

--- a/pkg/storage/cloud/gcs_storage.go
+++ b/pkg/storage/cloud/gcs_storage.go
@@ -65,7 +65,7 @@ func (g *gcsStorage) Conf() roachpb.ExternalStorage {
 
 func makeGCSStorage(
 	ctx context.Context,
-	ioConf base.ExternalIOConfig,
+	ioConf base.SQLExternalIOConfig,
 	conf *roachpb.ExternalStorage_GCS,
 	settings *cluster.Settings,
 ) (ExternalStorage, error) {

--- a/pkg/storage/cloud/gcs_storage.go
+++ b/pkg/storage/cloud/gcs_storage.go
@@ -65,7 +65,7 @@ func (g *gcsStorage) Conf() roachpb.ExternalStorage {
 
 func makeGCSStorage(
 	ctx context.Context,
-	ioConf base.SQLExternalIOConfig,
+	ioConf base.ExternalIODirConfig,
 	conf *roachpb.ExternalStorage_GCS,
 	settings *cluster.Settings,
 ) (ExternalStorage, error) {

--- a/pkg/storage/cloud/gcs_storage_test.go
+++ b/pkg/storage/cloud/gcs_storage_test.go
@@ -102,7 +102,7 @@ func TestAntagonisticRead(t *testing.T) {
 	require.NoError(t, err)
 
 	s, err := MakeExternalStorage(
-		context.Background(), conf, base.SQLExternalIOConfig{}, testSettings, nil)
+		context.Background(), conf, base.ExternalIODirConfig{}, testSettings, nil)
 	require.NoError(t, err)
 	stream, err := s.ReadFile(context.Background(), "")
 	require.NoError(t, err)

--- a/pkg/storage/cloud/gcs_storage_test.go
+++ b/pkg/storage/cloud/gcs_storage_test.go
@@ -102,7 +102,7 @@ func TestAntagonisticRead(t *testing.T) {
 	require.NoError(t, err)
 
 	s, err := MakeExternalStorage(
-		context.Background(), conf, base.ExternalIOConfig{}, testSettings, nil)
+		context.Background(), conf, base.SQLExternalIOConfig{}, testSettings, nil)
 	require.NoError(t, err)
 	stream, err := s.ReadFile(context.Background(), "")
 	require.NoError(t, err)

--- a/pkg/storage/cloud/http_storage_test.go
+++ b/pkg/storage/cloud/http_storage_test.go
@@ -149,7 +149,7 @@ func TestPutHttp(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		s, err := MakeExternalStorage(ctx, conf, base.ExternalIOConfig{},
+		s, err := MakeExternalStorage(ctx, conf, base.SQLExternalIOConfig{},
 			testSettings, blobs.TestEmptyBlobClientFactory)
 		if err != nil {
 			t.Fatal(err)
@@ -288,7 +288,7 @@ func TestHttpGetWithCancelledContext(t *testing.T) {
 }
 
 func TestCanDisableHttp(t *testing.T) {
-	conf := base.ExternalIOConfig{
+	conf := base.SQLExternalIOConfig{
 		DisableHTTP: true,
 	}
 	s, err := MakeExternalStorage(
@@ -320,7 +320,7 @@ func TestExternalStorageCanUseHTTPProxy(t *testing.T) {
 	conf, err := ExternalStorageConfFromURI("http://my-server")
 	require.NoError(t, err)
 	s, err := MakeExternalStorage(
-		context.Background(), conf, base.ExternalIOConfig{}, testSettings, nil)
+		context.Background(), conf, base.SQLExternalIOConfig{}, testSettings, nil)
 	require.NoError(t, err)
 	stream, err := s.ReadFile(context.Background(), "file")
 	require.NoError(t, err)

--- a/pkg/storage/cloud/http_storage_test.go
+++ b/pkg/storage/cloud/http_storage_test.go
@@ -149,7 +149,7 @@ func TestPutHttp(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		s, err := MakeExternalStorage(ctx, conf, base.SQLExternalIOConfig{},
+		s, err := MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{},
 			testSettings, blobs.TestEmptyBlobClientFactory)
 		if err != nil {
 			t.Fatal(err)
@@ -288,7 +288,7 @@ func TestHttpGetWithCancelledContext(t *testing.T) {
 }
 
 func TestCanDisableHttp(t *testing.T) {
-	conf := base.SQLExternalIOConfig{
+	conf := base.ExternalIODirConfig{
 		DisableHTTP: true,
 	}
 	s, err := MakeExternalStorage(
@@ -320,7 +320,7 @@ func TestExternalStorageCanUseHTTPProxy(t *testing.T) {
 	conf, err := ExternalStorageConfFromURI("http://my-server")
 	require.NoError(t, err)
 	s, err := MakeExternalStorage(
-		context.Background(), conf, base.SQLExternalIOConfig{}, testSettings, nil)
+		context.Background(), conf, base.ExternalIODirConfig{}, testSettings, nil)
 	require.NoError(t, err)
 	stream, err := s.ReadFile(context.Background(), "file")
 	require.NoError(t, err)

--- a/pkg/storage/cloud/nodelocal_storage_test.go
+++ b/pkg/storage/cloud/nodelocal_storage_test.go
@@ -44,7 +44,7 @@ func TestLocalIOLimits(t *testing.T) {
 	clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
 
 	baseDir, err := ExternalStorageFromURI(
-		ctx, "nodelocal://0/", base.ExternalIOConfig{}, testSettings, clientFactory)
+		ctx, "nodelocal://0/", base.SQLExternalIOConfig{}, testSettings, clientFactory)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestLocalIOLimits(t *testing.T) {
 	for dest, expected := range map[string]string{allowed: "", "/../../blah": "not allowed"} {
 		u := fmt.Sprintf("nodelocal://0%s", dest)
 		e, err := ExternalStorageFromURI(
-			ctx, u, base.ExternalIOConfig{}, testSettings, clientFactory)
+			ctx, u, base.SQLExternalIOConfig{}, testSettings, clientFactory)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/storage/cloud/nodelocal_storage_test.go
+++ b/pkg/storage/cloud/nodelocal_storage_test.go
@@ -44,7 +44,7 @@ func TestLocalIOLimits(t *testing.T) {
 	clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
 
 	baseDir, err := ExternalStorageFromURI(
-		ctx, "nodelocal://0/", base.SQLExternalIOConfig{}, testSettings, clientFactory)
+		ctx, "nodelocal://0/", base.ExternalIODirConfig{}, testSettings, clientFactory)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestLocalIOLimits(t *testing.T) {
 	for dest, expected := range map[string]string{allowed: "", "/../../blah": "not allowed"} {
 		u := fmt.Sprintf("nodelocal://0%s", dest)
 		e, err := ExternalStorageFromURI(
-			ctx, u, base.SQLExternalIOConfig{}, testSettings, clientFactory)
+			ctx, u, base.ExternalIODirConfig{}, testSettings, clientFactory)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/storage/cloud/s3_storage.go
+++ b/pkg/storage/cloud/s3_storage.go
@@ -57,7 +57,7 @@ func s3QueryParams(conf *roachpb.ExternalStorage_S3) string {
 
 func makeS3Storage(
 	ctx context.Context,
-	ioConf base.SQLExternalIOConfig,
+	ioConf base.ExternalIODirConfig,
 	conf *roachpb.ExternalStorage_S3,
 	settings *cluster.Settings,
 ) (ExternalStorage, error) {

--- a/pkg/storage/cloud/s3_storage.go
+++ b/pkg/storage/cloud/s3_storage.go
@@ -57,7 +57,7 @@ func s3QueryParams(conf *roachpb.ExternalStorage_S3) string {
 
 func makeS3Storage(
 	ctx context.Context,
-	ioConf base.ExternalIOConfig,
+	ioConf base.SQLExternalIOConfig,
 	conf *roachpb.ExternalStorage_S3,
 	settings *cluster.Settings,
 ) (ExternalStorage, error) {

--- a/pkg/storage/cloud/s3_storage_test.go
+++ b/pkg/storage/cloud/s3_storage_test.go
@@ -45,7 +45,7 @@ func TestPutS3(t *testing.T) {
 	t.Run("auth-empty-no-cred", func(t *testing.T) {
 		_, err := ExternalStorageFromURI(
 			ctx, fmt.Sprintf("s3://%s/%s", bucket, "backup-test-default"),
-			base.SQLExternalIOConfig{}, testSettings, blobs.TestEmptyBlobClientFactory,
+			base.ExternalIODirConfig{}, testSettings, blobs.TestEmptyBlobClientFactory,
 		)
 		require.EqualError(t, err, fmt.Sprintf(
 			`%s is set to '%s', but %s is not set`,
@@ -132,7 +132,7 @@ func TestPutS3Endpoint(t *testing.T) {
 
 func TestS3DisallowCustomEndpoints(t *testing.T) {
 	s3, err := makeS3Storage(context.Background(),
-		base.SQLExternalIOConfig{DisableHTTP: true},
+		base.ExternalIODirConfig{DisableHTTP: true},
 		&roachpb.ExternalStorage_S3{Endpoint: "http://do.not.go.there/"}, nil,
 	)
 	require.Nil(t, s3)
@@ -142,7 +142,7 @@ func TestS3DisallowCustomEndpoints(t *testing.T) {
 func TestS3DisallowImplicitCredentials(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s3, err := makeS3Storage(context.Background(),
-		base.SQLExternalIOConfig{DisableImplicitCredentials: true},
+		base.ExternalIODirConfig{DisableImplicitCredentials: true},
 		&roachpb.ExternalStorage_S3{
 			Endpoint: "http://do-not-go-there",
 			Auth:     authParamImplicit,

--- a/pkg/storage/cloud/s3_storage_test.go
+++ b/pkg/storage/cloud/s3_storage_test.go
@@ -45,7 +45,7 @@ func TestPutS3(t *testing.T) {
 	t.Run("auth-empty-no-cred", func(t *testing.T) {
 		_, err := ExternalStorageFromURI(
 			ctx, fmt.Sprintf("s3://%s/%s", bucket, "backup-test-default"),
-			base.ExternalIOConfig{}, testSettings, blobs.TestEmptyBlobClientFactory,
+			base.SQLExternalIOConfig{}, testSettings, blobs.TestEmptyBlobClientFactory,
 		)
 		require.EqualError(t, err, fmt.Sprintf(
 			`%s is set to '%s', but %s is not set`,
@@ -132,7 +132,7 @@ func TestPutS3Endpoint(t *testing.T) {
 
 func TestS3DisallowCustomEndpoints(t *testing.T) {
 	s3, err := makeS3Storage(context.Background(),
-		base.ExternalIOConfig{DisableHTTP: true},
+		base.SQLExternalIOConfig{DisableHTTP: true},
 		&roachpb.ExternalStorage_S3{Endpoint: "http://do.not.go.there/"}, nil,
 	)
 	require.Nil(t, s3)
@@ -142,7 +142,7 @@ func TestS3DisallowCustomEndpoints(t *testing.T) {
 func TestS3DisallowImplicitCredentials(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s3, err := makeS3Storage(context.Background(),
-		base.ExternalIOConfig{DisableImplicitCredentials: true},
+		base.SQLExternalIOConfig{DisableImplicitCredentials: true},
 		&roachpb.ExternalStorage_S3{
 			Endpoint: "http://do-not-go-there",
 			Auth:     authParamImplicit,


### PR DESCRIPTION
`(*TestServer).StartTenant` now uses only the Gossip instance(*) from
the TestServer and sets everything else up from scratch. This
demonstrates that mod the Gossip dependency, we're en route to
running the SQL server in a standalone process.

Informs #49104.

(*): and the Stopper, but that's fine.

Release note: None