### PR TITLE
opt: fix constraint tightness for unions with contradictions

### DIFF
--- a/pkg/sql/opt/memo/constraint_builder.go
+++ b/pkg/sql/opt/memo/constraint_builder.go
@@ -438,16 +438,60 @@ func (cb *constraintsBuilder) buildConstraints(e opt.ScalarExpr) (_ *constraint.
 		cr, tightr := cb.buildConstraints(t.Right)
 		res := cl.Union(cb.evalCtx, cr)
 
-		// The union may not be "tight" because the new constraint set might allow
-		// additional combinations of values that neither of the input sets allowed.
-		// For example:
-		//   (x > 1 AND y > 10) OR (x < 5 AND y < 50)
-		// the union is unconstrained (and thus allows combinations like x,y = 10,0).
+		// The union may not be "tight" because the new constraint set might
+		// allow combinations of values that the expression does not allow.
 		//
-		// An exception is if we know the input sets and union each only involve a
-		// single constraint, which means all three constraints have the same
-		// columns. In this case, we can determine tightness based on the tightness
-		// of the input sets.
+		// For example, consider the expression:
+		//
+		//   (@1 = 4 AND @2 = 6) OR (@1 = 5 AND @2 = 7)
+		//
+		// The resulting constraint set is:
+		//
+		//   /1: [/4 - /4] [/5 - /5]
+		//   /2: [/6 - /6] [/7 - /7]
+		//
+		// This constraint set is not tight, because it allows values for @1
+		// and @2 that the original expression does not, such as @1=4, @2=7.
+		//
+		// However, there are three cases in which the union constraint set is
+		// tight.
+		//
+		// First, if the left, right, and result sets have a single constraint,
+		// then the result constraint is tight if the left and right are tight.
+		// If there is a single constraint for all three sets, it implies that
+		// the sets involve the same column. Therefore it is safe to determine
+		// the tightness of the union based on the tightness of the left and
+		// right.
+		//
+		// Second, if one of the left or right set is a contradiction, then the
+		// result constraint is tight if the other input set is tight. This is
+		// because contradictions are tight and fully describe the set of
+		// values that the original expression allows - none.
+		//
+		// For example, consider the expression:
+		//
+		//   (@1 = 4 AND @1 = 6) OR (@1 = 5 AND @2 = 7)
+		//
+		// The resulting constraint set is:
+		//
+		//   /1: [/5 - /5]
+		//   /2: [/7 - /7]
+		//
+		// This constraint set is tight, because there are no values for @1 and
+		// @2 that satisfy the set but do not satisfy the expression.
+		//
+		// Third, if both the left and the right set are contradictions, then
+		// the result set is tight. This is because contradictions are tight
+		// and, as explained above, they fully describe the set of values that
+		// satisfy their expression. Note that this third case is generally
+		// covered by the second case, but it's mentioned here for the sake of
+		// explicitness.
+		if cl == contradiction {
+			return res, tightr
+		}
+		if cr == contradiction {
+			return res, tightl
+		}
 		tight := tightl && tightr && cl.Length() == 1 && cr.Length() == 1 && res.Length() == 1
 		return res, tight
 

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -1298,3 +1298,59 @@ select
                 └── lt [type=bool]
                      ├── variable: y:2 [type=int]
                      └── const: 50 [type=int]
+
+# A union constraint set is tight if the left is a contradiction and the right
+# is tight.
+opt
+SELECT * FROM a WHERE (x = 1 AND x = 3) OR (x = 10 AND y = 20)
+----
+select
+ ├── columns: x:1(int!null) y:2(int!null)
+ ├── fd: ()-->(1,2)
+ ├── scan a
+ │    ├── columns: x:1(int) y:2(int)
+ │    └── prune: (1,2)
+ └── filters
+      └── or [type=bool, outer=(1,2), constraints=(/1: [/10 - /10]; /2: [/20 - /20]; tight), fd=()-->(1,2)]
+           ├── and [type=bool]
+           │    ├── eq [type=bool]
+           │    │    ├── variable: x:1 [type=int]
+           │    │    └── const: 1 [type=int]
+           │    └── eq [type=bool]
+           │         ├── variable: x:1 [type=int]
+           │         └── const: 3 [type=int]
+           └── and [type=bool]
+                ├── eq [type=bool]
+                │    ├── variable: x:1 [type=int]
+                │    └── const: 10 [type=int]
+                └── eq [type=bool]
+                     ├── variable: y:2 [type=int]
+                     └── const: 20 [type=int]
+
+# A union constraint set is tight if the right is a contradiction and the left
+# is tight.
+opt
+SELECT * FROM a WHERE (x = 10 AND y = 20) OR (x = 1 AND x = 3) 
+----
+select
+ ├── columns: x:1(int!null) y:2(int!null)
+ ├── fd: ()-->(1,2)
+ ├── scan a
+ │    ├── columns: x:1(int) y:2(int)
+ │    └── prune: (1,2)
+ └── filters
+      └── or [type=bool, outer=(1,2), constraints=(/1: [/10 - /10]; /2: [/20 - /20]; tight), fd=()-->(1,2)]
+           ├── and [type=bool]
+           │    ├── eq [type=bool]
+           │    │    ├── variable: x:1 [type=int]
+           │    │    └── const: 10 [type=int]
+           │    └── eq [type=bool]
+           │         ├── variable: y:2 [type=int]
+           │         └── const: 20 [type=int]
+           └── and [type=bool]
+                ├── eq [type=bool]
+                │    ├── variable: x:1 [type=int]
+                │    └── const: 1 [type=int]
+                └── eq [type=bool]
+                     ├── variable: x:1 [type=int]
+                     └── const: 3 [type=int]

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -1918,3 +1918,33 @@ select
  │                     <--- '2020-02-11 07:25:00+00:00' ------ '2020-03-21 06:45:41+00:00' ------ '2020-04-21 06:25:41+00:00'
  └── filters
       └── created:3 = '2020-04-11 06:25:41+00:00' [type=bool, outer=(3), constraints=(/3: [/'2020-04-11 06:25:41+00:00' - /'2020-04-11 06:25:41+00:00']; tight), fd=()-->(3)]
+
+exec-ddl
+ALTER TABLE a INJECT STATISTICS '[
+  {
+    "columns": ["x"],
+    "created_at": "2020-05-26 03:02:57.841772+00:00",
+    "row_count": 1000,
+    "distinct_count": 1000
+  }
+]'
+----
+
+# Regression test for #48828. Stats for BETWEEN SYMMETRIC should be based on
+# the tight constraint rather than calculated as 1/3rd of the cardinality.
+norm
+SELECT * FROM a WHERE x BETWEEN SYMMETRIC 25 and 50
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── cardinality: [0 - 26]
+ ├── stats: [rows=26, distinct(1)=26, null(1)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── scan a
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── filters
+      └── ((x:1 >= 25) AND (x:1 <= 50)) OR ((x:1 >= 50) AND (x:1 <= 25)) [type=bool, outer=(1), constraints=(/1: [/25 - /50]; tight)]

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1835,7 +1835,7 @@ inner-join (zigzag pqr@q pqr@r)
  ├── fd: ()-->(2,3)
  └── filters
       ├── q:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
-      └── ((r:3 < 1) AND (r:3 > 1)) OR ((r:3 >= 2) AND (r:3 <= 2)) [outer=(3), constraints=(/3: [/2 - /2]), fd=()-->(3)]
+      └── ((r:3 < 1) AND (r:3 > 1)) OR ((r:3 >= 2) AND (r:3 <= 2)) [outer=(3), constraints=(/3: [/2 - /2]; tight), fd=()-->(3)]
 
 # Nested zigzag case - zigzag join needs to be wrapped in a lookup join to
 # satisfy required columns.


### PR DESCRIPTION
This commit improves how tightness is determined for a union of
contradictions. Previously, these would never be considered tight. Now,
a union constraint is tight if one child is a contradiction and the
other child is a tight constraint.

With this change, the statistics builder will generate more accurate
statistics in more cases. When constraints are not tight, the statistics
builder cannot determine the number of possible distinct values allowed
by the constraint.

A concrete example of this is with the query:

    SELECT a FROM t WHERE a BETWEEN SYMMETRIC 50 and 25

This query is normalized to:

    SELECT a FROM t WHERE (a >= 50 AND a <= 25) OR (a >= 25 AND a <= 50)

The resulting constraint on `a` is [/25 - /50].

Before this commit, this constraint was not considered tight. As a
result, the statistics builder could not use the cardinality of this
constraint, so it would fall back to estimating the number of matching
rows as one-third of the number of the rows in the table.

Now, the constraint is marked tight, and the statistics builder
correctly determines that the number of distinct values in this
constraint is 26.

Fixes #48828

Release note (performance improvement): The optimizer can now
determine more accurate costs for query plans with a combination of
disjunctions and contradictions.