### PR TITLE
geo/geomfn: implement ST_AsBinary({geometry,text})

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -703,7 +703,11 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="st_asbinary"></a><code>st_asbinary(geography: geography) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns the WKB representation of a given Geography.</p>
 </span></td></tr>
+<tr><td><a name="st_asbinary"></a><code>st_asbinary(geography: geography, xdr_or_ndr: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns the WKB representation of a given Geography. This variant has a second argument denoting the encoding - <code>xdr</code> for big endian and <code>ndr</code> for little endian.</p>
+</span></td></tr>
 <tr><td><a name="st_asbinary"></a><code>st_asbinary(geometry: geometry) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns the WKB representation of a given Geometry.</p>
+</span></td></tr>
+<tr><td><a name="st_asbinary"></a><code>st_asbinary(geometry: geometry, xdr_or_ndr: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns the WKB representation of a given Geometry. This variant has a second argument denoting the encoding - <code>xdr</code> for big endian and <code>ndr</code> for little endian.</p>
 </span></td></tr>
 <tr><td><a name="st_asewkb"></a><code>st_asewkb(geography: geography) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns the EWKB representation of a given Geography.</p>
 </span></td></tr>

--- a/pkg/geo/encode.go
+++ b/pkg/geo/encode.go
@@ -12,6 +12,7 @@ package geo
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"strings"
 
@@ -51,12 +52,12 @@ func EWKBToEWKT(b geopb.EWKB) (geopb.EWKT, error) {
 }
 
 // EWKBToWKB transforms a given EWKB to WKB.
-func EWKBToWKB(b geopb.EWKB) (geopb.WKB, error) {
+func EWKBToWKB(b geopb.EWKB, byteOrder binary.ByteOrder) (geopb.WKB, error) {
 	t, err := ewkb.Unmarshal([]byte(b))
 	if err != nil {
 		return nil, err
 	}
-	ret, err := wkb.Marshal(t, EWKBEncodingFormat)
+	ret, err := wkb.Marshal(t, byteOrder)
 	return geopb.WKB(ret), err
 }
 
@@ -79,7 +80,7 @@ func EWKBToWKBHex(b geopb.EWKB) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	ret, err := wkbhex.Encode(t, EWKBEncodingFormat)
+	ret, err := wkbhex.Encode(t, DefaultEWKBEncodingFormat)
 	return strings.ToUpper(ret), err
 }
 
@@ -98,4 +99,16 @@ func EWKBToKML(b geopb.EWKB) (string, error) {
 		return "", err
 	}
 	return buf.String(), nil
+}
+
+// StringToByteOrder returns the byte order of string.
+func StringToByteOrder(s string) binary.ByteOrder {
+	switch strings.ToLower(s) {
+	case "ndr":
+		return binary.LittleEndian
+	case "xdr":
+		return binary.BigEndian
+	default:
+		return DefaultEWKBEncodingFormat
+	}
 }

--- a/pkg/geo/encode_test.go
+++ b/pkg/geo/encode_test.go
@@ -70,7 +70,7 @@ func TestEWKBToWKB(t *testing.T) {
 		t.Run(string(tc.ewkt), func(t *testing.T) {
 			so, err := parseEWKT(tc.ewkt, geopb.DefaultGeometrySRID, DefaultSRIDIsHint)
 			require.NoError(t, err)
-			encoded, err := EWKBToWKB(so.EWKB)
+			encoded, err := EWKBToWKB(so.EWKB, DefaultEWKBEncodingFormat)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, encoded)
 		})

--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -21,8 +21,8 @@ import (
 	"github.com/twpayne/go-geom/encoding/ewkb"
 )
 
-// EWKBEncodingFormat is the encoding format for EWKB.
-var EWKBEncodingFormat = binary.LittleEndian
+// DefaultEWKBEncodingFormat is the default encoding format for EWKB.
+var DefaultEWKBEncodingFormat = binary.LittleEndian
 
 //
 // Geospatial Type
@@ -461,7 +461,7 @@ func S2RegionsFromGeom(geomRepr geom.T) []s2.Region {
 
 // spatialObjectFromGeom creates a geopb.SpatialObject from a geom.T.
 func spatialObjectFromGeom(t geom.T) (geopb.SpatialObject, error) {
-	ret, err := ewkb.Marshal(t, EWKBEncodingFormat)
+	ret, err := ewkb.Marshal(t, DefaultEWKBEncodingFormat)
 	if err != nil {
 		return geopb.SpatialObject{}, err
 	}

--- a/pkg/geo/geomfn/unary_operators.go
+++ b/pkg/geo/geomfn/unary_operators.go
@@ -41,7 +41,7 @@ func Length(g *geo.Geometry) (float64, error) {
 			case *geom.Point, *geom.MultiPoint, *geom.Polygon, *geom.MultiPolygon:
 				continue
 			case *geom.LineString, *geom.MultiLineString:
-				subGEWKB, err := ewkb.Marshal(subG, geo.EWKBEncodingFormat)
+				subGEWKB, err := ewkb.Marshal(subG, geo.DefaultEWKBEncodingFormat)
 				if err != nil {
 					return 0, err
 				}
@@ -80,7 +80,7 @@ func Perimeter(g *geo.Geometry) (float64, error) {
 			case *geom.Point, *geom.MultiPoint, *geom.LineString, *geom.MultiLineString:
 				continue
 			case *geom.Polygon, *geom.MultiPolygon:
-				subGEWKB, err := ewkb.Marshal(subG, geo.EWKBEncodingFormat)
+				subGEWKB, err := ewkb.Marshal(subG, geo.DefaultEWKBEncodingFormat)
 				if err != nil {
 					return 0, err
 				}

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -209,11 +209,13 @@ SELECT
 ----
 true  true
 
-query TTTTTTTT
+query TTTTTTTTTT
 SELECT
   ST_AsText(geom),
   ST_AsEWKT(geom),
   ST_AsBinary(geom),
+  ST_AsBinary(geom, 'ndr'),
+  ST_AsBinary(geom, 'xdr'),
   ST_AsEWKB(geom),
   ST_AsHexWKB(geom),
   ST_AsHexEWKB(geom),
@@ -221,27 +223,29 @@ SELECT
   ST_AsGeoJSON(geom)
 FROM parse_test ORDER BY id ASC
 ----
-POINT (1 2)                                    POINT (1 2)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+POINT (1 2)                                    POINT (1 2)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
 <Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
 <Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 2)                                    SRID=4004;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 164 15 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020A40F0000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+POINT (1 2)                                    SRID=4004;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 164 15 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020A40F0000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
 <Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 2)                                    POINT (1 2)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+POINT (1 2)                                    POINT (1 2)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
 <Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 2)                                    POINT (1 2)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+POINT (1 2)                                    POINT (1 2)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
 <Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 1)                                    POINT (1 1)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  0101000000000000000000F03F000000000000F03F  0101000000000000000000F03F000000000000F03F  <?xml version="1.0" encoding="UTF-8"?>
+POINT (1 1)                                    POINT (1 1)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [0 0 0 0 1 63 240 0 0 0 0 0 0 63 240 0 0 0 0 0 0]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  0101000000000000000000F03F000000000000F03F  0101000000000000000000F03F000000000000F03F  <?xml version="1.0" encoding="UTF-8"?>
 <Point><coordinates>1,1</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":null}
-POINT (1 1)                                    POINT (1 1)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  0101000000000000000000F03F000000000000F03F  0101000000000000000000F03F000000000000F03F  <?xml version="1.0" encoding="UTF-8"?>
+POINT (1 1)                                    POINT (1 1)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [0 0 0 0 1 63 240 0 0 0 0 0 0 63 240 0 0 0 0 0 0]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  0101000000000000000000F03F000000000000F03F  0101000000000000000000F03F000000000000F03F  <?xml version="1.0" encoding="UTF-8"?>
 <Point><coordinates>1,1</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":null}
-NULL                                           NULL                                                                                  NULL  NULL  NULL  NULL  NULL  NULL
+NULL                                           NULL                                                                                  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL
 
-query TTTTTTTT
+query TTTTTTTTTT
 SELECT
   ST_AsText(geog),
   ST_AsEWKT(geog),
   ST_AsBinary(geog),
+  ST_AsBinary(geog, 'ndr'),
+  ST_AsBinary(geog, 'xdr'),
   ST_AsEWKB(geog),
   ST_AsHexWKB(geog),
   ST_AsHexEWKB(geog),
@@ -249,21 +253,21 @@ SELECT
   ST_AsGeoJSON(geog)
 FROM parse_test ORDER BY id ASC
 ----
-POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
 <Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
 <Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
 <Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
 <Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
+POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  0101000000000000000000F03F0000000000000040  0101000020E6100000000000000000F03F0000000000000040  <?xml version="1.0" encoding="UTF-8"?>
 <Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 1)                                    SRID=4326;POINT (1 1)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  0101000000000000000000F03F000000000000F03F  0101000020E6100000000000000000F03F000000000000F03F  <?xml version="1.0" encoding="UTF-8"?>
+POINT (1 1)                                    SRID=4326;POINT (1 1)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [0 0 0 0 1 63 240 0 0 0 0 0 0 63 240 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  0101000000000000000000F03F000000000000F03F  0101000020E6100000000000000000F03F000000000000F03F  <?xml version="1.0" encoding="UTF-8"?>
 <Point><coordinates>1,1</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":null}
-POINT (1 1)                                    SRID=4326;POINT (1 1)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  0101000000000000000000F03F000000000000F03F  0101000020E6100000000000000000F03F000000000000F03F  <?xml version="1.0" encoding="UTF-8"?>
+POINT (1 1)                                    SRID=4326;POINT (1 1)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [0 0 0 0 1 63 240 0 0 0 0 0 0 63 240 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  0101000000000000000000F03F000000000000F03F  0101000020E6100000000000000000F03F000000000000F03F  <?xml version="1.0" encoding="UTF-8"?>
 <Point><coordinates>1,1</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":null}
-NULL                                           NULL                                                                                  NULL  NULL  NULL  NULL  NULL  NULL
+NULL                                           NULL                                                                                  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL
 
 query TTTTTTTT
 SELECT


### PR DESCRIPTION
Fixes #48379, #48870

Release note (sql change): Implemented the geometry based builtins `ST_AsBinary` with encoding.