### PR TITLE
sql: add the `var_samp` builtin alias

### DIFF
--- a/docs/generated/sql/aggregates.md
+++ b/docs/generated/sql/aggregates.md
@@ -199,6 +199,12 @@
 </span></td></tr>
 <tr><td><a name="sum_int"></a><code>sum_int(arg1: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the sum of the selected values.</p>
 </span></td></tr>
+<tr><td><a name="var_samp"></a><code>var_samp(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the variance of the selected values.</p>
+</span></td></tr>
+<tr><td><a name="var_samp"></a><code>var_samp(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the variance of the selected values.</p>
+</span></td></tr>
+<tr><td><a name="var_samp"></a><code>var_samp(arg1: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the variance of the selected values.</p>
+</span></td></tr>
 <tr><td><a name="variance"></a><code>variance(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the variance of the selected values.</p>
 </span></td></tr>
 <tr><td><a name="variance"></a><code>variance(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the variance of the selected values.</p>

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -10,10 +10,10 @@ CREATE TABLE kv (
 )
 
 # Aggregate functions return NULL if there are no rows.
-query IIIIRRRRRBBTII
-SELECT min(1), max(1), count(1), sum_int(1), avg(1), sum(1), stddev(1), stddev_samp(1), variance(1), bool_and(true), bool_and(false), xor_agg(b'\x01'), bit_and(1), bit_or(1) FROM kv
+query IIIIRRRRRRBBTII
+SELECT min(1), max(1), count(1), sum_int(1), avg(1), sum(1), stddev(1), stddev_samp(1), var_samp(1), variance(1), bool_and(true), bool_and(false), xor_agg(b'\x01'), bit_and(1), bit_or(1) FROM kv
 ----
-NULL NULL 0 NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL
+NULL NULL 0 NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL NULL
 
 # Regression test for #29695
 query T
@@ -774,7 +774,7 @@ SELECT max(x) FROM xyz WHERE (z, y) = (3.0, 2)
 # VARIANCE/STDDEV
 
 query RRR
-SELECT variance(x), variance(y::decimal), round(variance(z), 14) FROM xyz
+SELECT var_samp(x), variance(y::decimal), round(var_samp(z), 14) FROM xyz
 ----
 9 4.5 6.33333333333333
 

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -804,7 +804,7 @@ func (b *Builder) constructAggregate(name string, args []opt.ScalarExpr) opt.Sca
 		return b.factory.ConstructSum(args[0])
 	case "sqrdiff":
 		return b.factory.ConstructSqrDiff(args[0])
-	case "variance":
+	case "variance", "var_samp":
 		return b.factory.ConstructVariance(args[0])
 	case "stddev", "stddev_samp":
 		return b.factory.ConstructStdDev(args[0])

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -294,14 +294,9 @@ var aggregates = map[string]builtinDefinition{
 		),
 	)),
 
-	"variance": makeBuiltin(aggProps(),
-		makeAggOverload([]*types.T{types.Int}, types.Decimal, newIntVarianceAggregate,
-			"Calculates the variance of the selected values.", tree.VolatilityImmutable),
-		makeAggOverload([]*types.T{types.Decimal}, types.Decimal, newDecimalVarianceAggregate,
-			"Calculates the variance of the selected values.", tree.VolatilityImmutable),
-		makeAggOverload([]*types.T{types.Float}, types.Float, newFloatVarianceAggregate,
-			"Calculates the variance of the selected values.", tree.VolatilityImmutable),
-	),
+	// variance is a historical alias for var_samp.
+	"variance": makeVarianceBuiltin(),
+	"var_samp": makeVarianceBuiltin(),
 
 	// stddev is a historical alias for stddev_samp.
 	"stddev":      makeStdDevBuiltin(),
@@ -514,6 +509,17 @@ func makeStdDevBuiltin() builtinDefinition {
 			"Calculates the standard deviation of the selected values.", tree.VolatilityImmutable),
 		makeAggOverload([]*types.T{types.Float}, types.Float, newFloatStdDevAggregate,
 			"Calculates the standard deviation of the selected values.", tree.VolatilityImmutable),
+	)
+}
+
+func makeVarianceBuiltin() builtinDefinition {
+	return makeBuiltin(aggProps(),
+		makeAggOverload([]*types.T{types.Int}, types.Decimal, newIntVarianceAggregate,
+			"Calculates the variance of the selected values.", tree.VolatilityImmutable),
+		makeAggOverload([]*types.T{types.Decimal}, types.Decimal, newDecimalVarianceAggregate,
+			"Calculates the variance of the selected values.", tree.VolatilityImmutable),
+		makeAggOverload([]*types.T{types.Float}, types.Float, newFloatVarianceAggregate,
+			"Calculates the variance of the selected values.", tree.VolatilityImmutable),
 	)
 }
 


### PR DESCRIPTION
Fixes #48101.

Add the `var_samp` alias for the `variance` aggregate builtin.

Release note: None