### PR TITLE
release-19.2: colrpc: change Inbox stream errors from InternalError to ExpectedError

### DIFF
--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -317,7 +317,7 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 				return i.zeroBatch
 			}
 			i.errCh <- err
-			execerror.VectorizedInternalPanic(err)
+			execerror.NonVectorizedPanic(err)
 		}
 		if len(m.Data.Metadata) != 0 {
 			for _, rpm := range m.Data.Metadata {


### PR DESCRIPTION
Backport 1/1 commits from #49260.

/cc @cockroachdb/release

---

Errors in the Inbox that happen when reading from a stream were previously
propagated as InternalErrors which have an attached stack trace and cause a
sentry report to be sent.

These types of errors should be ExpectedErrors instead, since there is nothing
unexpected about them. For example, if a context is canceled by the user, that
should be propagated as a normal error.

Release note (bug fix): some benign errors were previously reported as
unexpected internal errors by the vectorized execution engine, this is now
fixed

Fixes #49519 
Fixes #49518 
Fixes #49516 
Fixes #49515 
Fixes #49514 