### PR TITLE
sql: prohibit phase 2 tenants from setting cluster settings

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -193,3 +193,12 @@ const (
 	// all with a single replica on node 1.
 	ReplicationManual
 )
+
+// TestTenantArgs are the arguments used when creating a tenant from a
+// TestServer.
+type TestTenantArgs struct {
+	TenantID roachpb.TenantID
+	// AllowSettingClusterSettings, if true, allows the tenant to set in-memory
+	// cluster settings.
+	AllowSettingClusterSettings bool
+}

--- a/pkg/base/testing_knobs.go
+++ b/pkg/base/testing_knobs.go
@@ -31,4 +31,5 @@ type TestingKnobs struct {
 	SQLEvalContext      ModuleTestingKnobs
 	RegistryLiveness    ModuleTestingKnobs
 	Server              ModuleTestingKnobs
+	TenantTestingKnobs  ModuleTestingKnobs
 }

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -479,6 +479,9 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 	if pgwireKnobs := cfg.TestingKnobs.PGWireTestingKnobs; pgwireKnobs != nil {
 		execCfg.PGWireTestingKnobs = pgwireKnobs.(*sql.PGWireTestingKnobs)
 	}
+	if tenantKnobs := cfg.TestingKnobs.TenantTestingKnobs; tenantKnobs != nil {
+		execCfg.TenantTestingKnobs = tenantKnobs.(*sql.TenantTestingKnobs)
+	}
 
 	statsRefresher := stats.MakeRefresher(
 		cfg.Settings,

--- a/pkg/server/server_sql_test.go
+++ b/pkg/server/server_sql_test.go
@@ -16,9 +16,13 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
 )
 
 // TestSQLServer starts up a semi-dedicated SQL server and runs some smoke test
@@ -38,7 +42,7 @@ func TestSQLServer(t *testing.T) {
 	tc := serverutils.StartTestCluster(t, 1, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(ctx)
 
-	db := serverutils.StartTenant(t, tc.Server(0), roachpb.MakeTenantID(10))
+	db := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)})
 	defer db.Close()
 	r := sqlutils.MakeSQLRunner(db)
 	r.QueryStr(t, `SELECT 1`)
@@ -47,4 +51,21 @@ func TestSQLServer(t *testing.T) {
 	r.Exec(t, `INSERT INTO foo.kv VALUES('foo', 'bar')`)
 	t.Log(sqlutils.MatrixToStr(r.QueryStr(t, `SET distsql=off; SELECT * FROM foo.kv`)))
 	t.Log(sqlutils.MatrixToStr(r.QueryStr(t, `SET distsql=auto; SELECT * FROM foo.kv`)))
+}
+
+func TestTenantCannotSetClusterSetting(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	tc := serverutils.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	// StartTenant with the default permissions to
+	db := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10), AllowSettingClusterSettings: false})
+	defer db.Close()
+	_, err := db.Exec(`SET CLUSTER SETTING sql.defaults.vectorize=off`)
+	var pqErr *pq.Error
+	ok := errors.As(err, &pqErr)
+	require.True(t, ok, "expected err to be a *pq.Error but is of type %T. error is: %v", err)
+	require.Equal(t, pq.ErrorCode(pgcode.InsufficientPrivilege), pqErr.Code, "err %v has unexpected code", err)
 }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -638,6 +638,7 @@ type ExecutorConfig struct {
 	GCJobTestingKnobs         *GCJobTestingKnobs
 	DistSQLRunTestingKnobs    *execinfra.TestingKnobs
 	EvalContextTestingKnobs   tree.EvalContextTestingKnobs
+	TenantTestingKnobs        *TenantTestingKnobs
 	// HistogramWindowInterval is (server.Config).HistogramWindowInterval.
 	HistogramWindowInterval time.Duration
 
@@ -773,6 +774,25 @@ var _ base.ModuleTestingKnobs = &PGWireTestingKnobs{}
 
 // ModuleTestingKnobs implements the base.ModuleTestingKnobs interface.
 func (*PGWireTestingKnobs) ModuleTestingKnobs() {}
+
+// TenantTestingKnobs contains knobs for tenant behavior.
+type TenantTestingKnobs struct {
+	// ClusterSettingsUpdater is a field that if set, allows the tenant to set
+	// in-memory cluster settings. SQL tenants are otherwise prohibited from
+	// setting cluster settings.
+	ClusterSettingsUpdater settings.Updater
+}
+
+var _ base.ModuleTestingKnobs = &TenantTestingKnobs{}
+
+// ModuleTestingKnobs implements the base.ModuleTestingKnobs interface.
+func (*TenantTestingKnobs) ModuleTestingKnobs() {}
+
+// CanSetClusterSettings is a helper method that returns whether the tenant can
+// set in-memory cluster settings.
+func (k *TenantTestingKnobs) CanSetClusterSettings() bool {
+	return k != nil && k.ClusterSettingsUpdater != nil
+}
 
 // databaseCacheHolder is a thread-safe container for a *Cache.
 // It also allows clients to block until the cache is updated to a desired

--- a/pkg/sql/logictest/testdata/logic_test/jobs
+++ b/pkg/sql/logictest/testdata/logic_test/jobs
@@ -1,7 +1,6 @@
 # 3node-tenant fails due to AUTO STATS being returned in SHOW JOBS. Changing
 # the cluster setting to disable auto stats doesn't work:
 # https://github.com/cockroachdb/cockroach/issues/47918
-# LogicTest: !3node-tenant
 
 # These test verify that a user's job are visible via
 # crdb_internal.jobs and SHOW JOBS.

--- a/pkg/sql/logictest/testdata/logic_test/privileges_comments
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_comments
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 # Disable automatic stats to avoid flakiness.
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false

--- a/pkg/sql/logictest/testdata/logic_test/tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant
@@ -58,3 +58,20 @@ UPDATE system.tenants SET active = false WHERE id = 10
 
 statement error pgcode 42501 user root does not have DELETE privilege on relation tenants
 DELETE FROM system.tenants WHERE id = 10
+
+# Verify that tenants are able to set in-memory cluster settings in logic tests.
+statement ok
+SET CLUSTER SETTING sql.defaults.vectorize='off'
+
+query T
+SHOW CLUSTER SETTING sql.defaults.vectorize
+----
+off
+
+statement ok
+RESET CLUSTER SETTING sql.defaults.vectorize
+
+query T
+SHOW CLUSTER SETTING sql.defaults.vectorize
+----
+on

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -21,6 +21,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -51,6 +53,12 @@ func (p *planner) SetClusterSetting(
 		return nil, err
 	}
 
+	if !p.execCfg.TenantTestingKnobs.CanSetClusterSettings() && !p.execCfg.Codec.ForSystemTenant() {
+		// Setting cluster settings is disabled for phase 2 tenants if a test does
+		// not explicitly allow for setting in-memory cluster settings.
+		return nil, pgerror.Newf(pgcode.InsufficientPrivilege, "only the system tenant can SET CLUSTER SETTING")
+	}
+
 	name := strings.ToLower(n.Name)
 	st := p.EvalContext().Settings
 	v, ok := settings.Lookup(name, settings.LookupForLocalAccess)
@@ -61,6 +69,12 @@ func (p *planner) SetClusterSetting(
 	setting, ok := v.(settings.WritableSetting)
 	if !ok {
 		return nil, errors.AssertionFailedf("expected writable setting, got %T", v)
+	}
+
+	if _, ok := setting.(*settings.StateMachineSetting); ok && p.execCfg.TenantTestingKnobs.CanSetClusterSettings() {
+		// A tenant that is allowed to set in-memory cluster settings is attempting
+		// to set a state machine setting, which is disallowed due to complexity.
+		return nil, pgerror.Newf(pgcode.InsufficientPrivilege, "only the system tenant can set state machine settings")
 	}
 
 	var value tree.TypedExpr
@@ -107,6 +121,30 @@ func (p *planner) SetClusterSetting(
 func (n *setClusterSettingNode) startExec(params runParams) error {
 	if !params.p.ExtendedEvalContext().TxnImplicit {
 		return errors.Errorf("SET CLUSTER SETTING cannot be used inside a transaction")
+	}
+
+	if !params.p.execCfg.Codec.ForSystemTenant() {
+		// Sanity check that this tenant is able to set in-memory settings.
+		if !params.p.execCfg.TenantTestingKnobs.CanSetClusterSettings() {
+			return errors.Errorf("tenants cannot set cluster settings, this permission should have been checked at plan time")
+		}
+		var encodedValue string
+		if n.value == nil {
+			encodedValue = n.setting.EncodedDefault()
+		} else {
+			value, err := n.value.Eval(params.p.EvalContext())
+			if err != nil {
+				return err
+			}
+			if _, ok := n.setting.(*settings.StateMachineSetting); ok {
+				return errors.Errorf("tenants cannot change state machine settings, this should've been checked at plan time")
+			}
+			encodedValue, err = toSettingString(params.ctx, n.st, n.name, n.setting, value, nil /* prev */)
+			if err != nil {
+				return err
+			}
+		}
+		return params.p.execCfg.TenantTestingKnobs.ClusterSettingsUpdater.Set(n.name, encodedValue, n.setting.Typ())
 	}
 
 	execCfg := params.extendedEvalCtx.ExecCfg

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -196,7 +196,7 @@ type TestServerInterface interface {
 	ReportDiagnostics(ctx context.Context)
 
 	// StartTenant spawns off tenant process connecting to this TestServer.
-	StartTenant(tenantID roachpb.TenantID) (pgAddr string, _ error)
+	StartTenant(params base.TestTenantArgs) (pgAddr string, _ error)
 }
 
 // TestServerFactory encompasses the actual implementation of the shim
@@ -261,8 +261,8 @@ func StartServerRaw(args base.TestServerArgs) (TestServerInterface, error) {
 // StartTenant starts a tenant SQL server connecting to the supplied test
 // server. It uses the server's stopper to shut down automatically. However,
 // the returned DB is for the caller to close.
-func StartTenant(t testing.TB, ts TestServerInterface, tenantID roachpb.TenantID) *gosql.DB {
-	pgAddr, err := ts.StartTenant(tenantID)
+func StartTenant(t testing.TB, ts TestServerInterface, params base.TestTenantArgs) *gosql.DB {
+	pgAddr, err := ts.StartTenant(params)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The first commit is in #49547 

I wanted to get this PR out for early feedback. Before merging, I want to get #49547 in and then re-run the logic tests to see if any now pass without the 3node-tenant blacklist (at least one should, but it might fail for other reasons).

This commit also adds a testing knob that allows tenants to set in-memory
settings in tests using an updater, which is used in logic tests.

Release note: None (no user-visible change)

Closes #47917

The question of whitelisting settings is not addressed in this PR, @tbg how strongly do you feel about that? AFAIU, whitelisting settings would only be applicable to tests so I'm not sure how useful it is, but haven't thought much about it.