### PR TITLE
ui: fix page header overlap

### DIFF
--- a/pkg/ui/src/views/app/containers/layout/layout.styl
+++ b/pkg/ui/src/views/app/containers/layout/layout.styl
@@ -29,20 +29,6 @@ $subnav-background  = $background-color
 
 .page-config
   padding-left 24px
-  // Stick to the top.
-  position sticky
-  position -webkit-sticky
-  top 0
-  // We want 10px of spacing above and below this div when
-  // it's fixed during scrolling, but not when the page
-  // is scrolled to the top. This combination of padding
-  // and negative margins achieves that.
-  padding-bottom 10px
-  padding-top 10px
-  margin-bottom -10px
-  margin-top -10px
-
-  z-index $z-index-page-config
   background-color $background-color
 
   &__list


### PR DESCRIPTION
in new design we do not support sticky headers of tables, and css leftovers lead to display issues

Resolves: #48348

Release note(ui): fix jobs page header overlapping scrollbars