### PR TITLE
roachtest: fix typo in tpchvec/perf

### DIFF
--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -267,15 +267,20 @@ func (p *tpchVecPerfTest) postTestRunHook(t *test, conn *gosql.DB, version crdbV
 				}
 				for i := 0; i < tpchPerfTestNumRunsPerQuery; i++ {
 					rows, err := conn.Query(fmt.Sprintf(
-						"SELECT url FROM [EXPLAIN ANALYZE %s];", tpch.QueriesByNumber[queryNum],
+						"EXPLAIN ANALYZE %s;", tpch.QueriesByNumber[queryNum],
 					))
 					if err != nil {
 						t.Fatal(err)
 					}
-					defer rows.Close()
-					var url string
+					var (
+						automatic bool
+						url       string
+					)
 					rows.Next()
-					if err = rows.Scan(&url); err != nil {
+					if err = rows.Scan(&automatic, &url); err != nil {
+						t.Fatal(err)
+					}
+					if err = rows.Close(); err != nil {
 						t.Fatal(err)
 					}
 					t.Status(fmt.Sprintf("EXPLAIN ANALYZE with vectorize=%s url:\n%s", vectorizeSetting, url))


### PR DESCRIPTION
TPCH queries have semicolon at the end, so when trying to do `SELECT url
FROM [EXPLAIN ANALYZE %s];` with query replacing the `%s`, we would have
a semicolon within square brackets which would produce a syntax error.
Fix this by reading both `automatic` boolean and `url` string and
outputting the latter.

Release note: None