### PR TITLE
sql/catalog: rename ObjectDescriptor to Descriptor

### DIFF
--- a/pkg/sql/catalog/accessor.go
+++ b/pkg/sql/catalog/accessor.go
@@ -40,5 +40,5 @@ type Accessor interface {
 	// descriptor and that of its parent database. If the object is not
 	// found and flags.required is true, an error is returned, otherwise
 	// a nil reference is returned.
-	GetObjectDesc(ctx context.Context, txn *kv.Txn, settings *cluster.Settings, codec keys.SQLCodec, db, schema, object string, flags tree.ObjectLookupFlags) (ObjectDescriptor, error)
+	GetObjectDesc(ctx context.Context, txn *kv.Txn, settings *cluster.Settings, codec keys.SQLCodec, db, schema, object string, flags tree.ObjectLookupFlags) (Descriptor, error)
 }

--- a/pkg/sql/catalog/accessors/logical_schema_accessors.go
+++ b/pkg/sql/catalog/accessors/logical_schema_accessors.go
@@ -95,7 +95,7 @@ func (l *LogicalSchemaAccessor) GetObjectDesc(
 	codec keys.SQLCodec,
 	db, schema, object string,
 	flags tree.ObjectLookupFlags,
-) (catalog.ObjectDescriptor, error) {
+) (catalog.Descriptor, error) {
 	switch flags.DesiredObjectKind {
 	case tree.TypeObject:
 		// TODO(ajwerner): Change this function if we ever expose non-table objects

--- a/pkg/sql/catalog/accessors/physical_schema_accessors.go
+++ b/pkg/sql/catalog/accessors/physical_schema_accessors.go
@@ -110,7 +110,7 @@ func (a *CachedPhysicalAccessor) GetObjectDesc(
 	codec keys.SQLCodec,
 	db, schema, object string,
 	flags tree.ObjectLookupFlags,
-) (catalog.ObjectDescriptor, error) {
+) (catalog.Descriptor, error) {
 	switch flags.DesiredObjectKind {
 	case tree.TypeObject:
 		// TypeObjects are not caches so fall through to the underlying physical

--- a/pkg/sql/catalog/catalog.go
+++ b/pkg/sql/catalog/catalog.go
@@ -15,8 +15,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
-// ObjectDescriptor provides table information for results from a name lookup.
-type ObjectDescriptor interface {
+// Descriptor provides table information for results from a name lookup.
+type Descriptor interface {
 	tree.NameResolutionResult
 
 	// DatabaseDesc returns the underlying database descriptor, or nil if the
@@ -43,7 +43,7 @@ type VirtualSchemas interface {
 
 // VirtualSchema represents a collection of VirtualObjects.
 type VirtualSchema interface {
-	Desc() ObjectDescriptor
+	Desc() Descriptor
 	NumTables() int
 	VisitTables(func(object VirtualObject))
 	GetObjectByName(name string) (VirtualObject, error)
@@ -51,7 +51,7 @@ type VirtualSchema interface {
 
 // VirtualObject is a virtual schema object.
 type VirtualObject interface {
-	Desc() ObjectDescriptor
+	Desc() Descriptor
 }
 
 // TableEntry is the value type of FkTableMetadata: An optional table

--- a/pkg/sql/catalog/catalogkv/physical_accessor.go
+++ b/pkg/sql/catalog/catalogkv/physical_accessor.go
@@ -161,7 +161,7 @@ func (a UncachedPhysicalAccessor) GetObjectDesc(
 	codec keys.SQLCodec,
 	db, schema, object string,
 	flags tree.ObjectLookupFlags,
-) (catalog.ObjectDescriptor, error) {
+) (catalog.Descriptor, error) {
 	// Look up the database ID.
 	dbID, err := GetDatabaseID(ctx, txn, codec, db, flags.Required)
 	if err != nil || dbID == sqlbase.InvalidID {

--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -144,7 +144,7 @@ func ResolveExistingObject(
 		return nil, prefix, nil
 	}
 
-	obj := descI.(catalog.ObjectDescriptor)
+	obj := descI.(catalog.Descriptor)
 	switch lookupFlags.DesiredObjectKind {
 	case tree.TypeObject:
 		if obj.TypeDesc() == nil {

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -290,7 +290,7 @@ type virtualSchemaEntry struct {
 	allTableNames   map[string]struct{}
 }
 
-func (v virtualSchemaEntry) Desc() catalog.ObjectDescriptor {
+func (v virtualSchemaEntry) Desc() catalog.Descriptor {
 	return v.desc
 }
 
@@ -322,7 +322,7 @@ type virtualDefEntry struct {
 	validWithNoDatabaseContext bool
 }
 
-func (e virtualDefEntry) Desc() catalog.ObjectDescriptor {
+func (e virtualDefEntry) Desc() catalog.Descriptor {
 	return sqlbase.NewImmutableTableDescriptor(*e.desc)
 }
 


### PR DESCRIPTION
We're trying to define Object as a member of a schema. Today that's not really
true because Objects are currently members of databases and not schemas but
we'll get there. Descriptor is the general term for all entities which are in
the catalog, resolvable by a name, and live in the descriptor table.

Release note: None