### PR TITLE
kvserver: remove migration to remove preemptive snapshots

### DIFF
--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/errors"
 )
 
 // DestroyReason indicates if a replica is alive, destroyed, corrupted or pending destruction.
@@ -62,58 +61,6 @@ func (s destroyStatus) IsAlive() bool {
 // Removed returns whether the replica has been removed.
 func (s destroyStatus) Removed() bool {
 	return s.reason == destroyReasonRemoved
-}
-
-// removePreemptiveSnapshot is a migration put in place during the 20.1 release
-// to remove any on-disk preemptive snapshots which may still be resident on a
-// 19.2 node's store due to a rapid upgrade.
-//
-// As of 19.2, a range can never process commands while it is not part of a
-// range. It is still possible that on-disk replica state exists which does not
-// contain this Store exist from when this store was running 19.1 and was not
-// removed during 19.2. For the sake of this method and elsewhere we'll define
-// a preemptive snapshot as on-disk data corresponding to an initialized range
-// which has a range descriptor which does not contain this store.
-//
-// In 19.1 when a Replica processes a command which removes it from the range
-// it does not immediately destroy its data. In fact it just assumed that it
-// would not be getting more commands appended to its log. In some cases a
-// Replica would continue to apply commands even while it was not a part of the
-// range. This was unfortunate as it is not possible to uphold certain invariants
-// for stores which are not a part of a range when it processes a command. Not
-// only did the above behavior of processing commands regardless of whether the
-// current store was in the range wasn't just happenstance, it was a fundamental
-// property that was relied upon for the change replicas protocol. In 19.2 we
-// adopt learner Replicas which are added to the raft group as a non-voting
-// member before receiving a snapshot of the state. In all previous versions
-// we did not have voters. The legacy protocol instead relied on sending a
-// snapshot of raft state and then the Replica had to apply log entries up to
-// the point where it was added to the range.
-//
-// TODO(ajwerner): Remove during 20.2.
-func removePreemptiveSnapshot(
-	ctx context.Context, s *Store, desc *roachpb.RangeDescriptor,
-) (err error) {
-	batch := s.Engine().NewWriteOnlyBatch()
-	defer batch.Close()
-	const rangeIDLocalOnly = false
-	const mustClearRange = false
-	defer func() {
-		if err != nil {
-			err = errors.Wrapf(err, "failed to remove preemptive snapshot for range %v", desc)
-		}
-	}()
-	if err := clearRangeData(desc, s.Engine(), batch, rangeIDLocalOnly, mustClearRange); err != nil {
-		return err
-	}
-	if err := writeTombstoneKey(ctx, batch, desc.RangeID, desc.NextReplicaID); err != nil {
-		return err
-	}
-	if err := batch.Commit(true); err != nil {
-		return err
-	}
-	log.Infof(ctx, "removed preemptive snapshot for %v", desc)
-	return nil
 }
 
 // mergedTombstoneReplicaID is the replica ID written into the tombstone

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1450,12 +1450,16 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 				// range which has processed a raft command to remove itself (which is
 				// possible prior to 19.2 or if the DisableEagerReplicaRemoval is
 				// enabled) and has not yet been removed by the replica gc queue.
-				// We treat both cases the same way.
-				//
-				// TODO(ajwerner): Remove this migration in 20.2. It exists in 20.1 to
-				// find and remove any pre-emptive snapshots which may have been sent by
-				// a 19.1 or older node to this node while it was running 19.2.
-				return false /* done */, removePreemptiveSnapshot(ctx, s, &desc)
+				// We treat both cases the same way. These should no longer exist in
+				// 20.2 or after as there was a migration in 20.1 to remove them and
+				// no pre-emptive snapshot should have been sent since 19.2 was
+				// finalized.
+				return false /* done */, errors.AssertionFailedf(
+					"found RangeDescriptor for range %d at generation %d which does not"+
+						" contain this store %d",
+					log.Safe(desc.RangeID),
+					log.Safe(desc.Generation),
+					log.Safe(s.StoreID()))
 			}
 
 			rep, err := newReplica(ctx, &desc, s, replicaDesc.ReplicaID)

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -43,7 +43,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -3186,105 +3185,6 @@ func TestSnapshotRateLimit(t *testing.T) {
 			}
 		})
 	}
-}
-
-// TestPreemptiveSnapshotsAreRemoved exercises a migration in 20.1 to remove any
-// data on disk for a Replica which holds a descriptor in its state that does
-// not contain the store. Prior to 20.1 such Replica state could exist on disk
-// in two scenario both generally due to a rapid upgrade from 19.1 to 19.2.
-//
-// See the comment on removePreemptiveSnapshot().
-//
-// TODO(ajwerner): remove this in 20.2 with removePreemptiveSnapshot().
-func TestPreemptiveSnapshotsAreRemoved(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	// Create a store with a preemptive snapshot sitting in its engine before it's
-	// started. Ensure that the preemptive snapshots are removed and the replicas
-	// for those ranges are not created.
-	//
-	ctx := context.Background()
-	stopper := stop.NewStopper()
-	defer stopper.Stop(ctx)
-	config := TestStoreConfig(hlc.NewClock(hlc.UnixNano, base.DefaultMaxClockOffset))
-	s := createTestStoreWithoutStart(t, stopper, testStoreOpts{}, &config)
-	tablePrefix := keys.SystemSQLCodec.TablePrefix(42)
-	tablePrefixEnd := tablePrefix.PrefixEnd()
-	const rangeID = 42
-
-	desc := roachpb.NewRangeDescriptor(
-		rangeID,
-		roachpb.RKey(tablePrefix),
-		roachpb.RKey(tablePrefixEnd),
-		roachpb.MakeReplicaDescriptors([]roachpb.ReplicaDescriptor{
-			{
-				NodeID:    2,
-				StoreID:   2,
-				ReplicaID: 2,
-			},
-		}),
-	)
-	const replicatedOnly, seekEnd = false, false
-	it := rditer.NewReplicaDataIterator(desc, s.Engine(), replicatedOnly, seekEnd)
-	defer it.Close()
-	lease := roachpb.Lease{
-		Start: s.Clock().Now(),
-	}
-	state := kvserverpb.ReplicaState{
-		Desc:        desc,
-		Lease:       &lease,
-		GCThreshold: &hlc.Timestamp{},
-		TruncatedState: &roachpb.RaftTruncatedState{
-			Term:  1,
-			Index: 11,
-		},
-		Stats: &enginepb.MVCCStats{ContainsEstimates: 1},
-	}
-	// Write some data into the range and then write the range descriptor and
-	// state.
-	func() {
-		b := s.engine.NewBatch()
-		defer b.Close()
-		stl := stateloader.Make(rangeID)
-		const N = 100
-		for i := 0; i < N; i++ {
-			const colID = 1
-			prefix := tablePrefix[0:len(tablePrefix):len(tablePrefix)]
-			k := roachpb.Key(encoding.EncodeIntValue(prefix, colID, int64(i)))
-			require.NoError(t, storage.MVCCBlindPutProto(ctx, b, state.Stats,
-				k, s.Clock().Now(), desc, nil))
-		}
-		require.NoError(t, storage.MVCCBlindPutProto(ctx, b, state.Stats,
-			keys.RangeDescriptorKey(desc.StartKey), hlc.Timestamp{}, desc, nil))
-		_, err := stl.Save(ctx, b, state, stateloader.TruncatedStateUnreplicated)
-		require.NoError(t, err)
-		require.NoError(t, b.Commit(true /* sync */))
-	}()
-
-	// Start the store.
-	require.NoError(t, s.Start(ctx, stopper))
-
-	// Ensure that the data for the preemptive snapshot has been removed.
-	snap := s.engine.NewSnapshot()
-	defer snap.Close()
-	it = rditer.NewReplicaDataIterator(desc, snap, replicatedOnly, seekEnd)
-	defer it.Close()
-	// The only key for the range we should find is the tombstone.
-	tombstoneKey := keys.RangeTombstoneKey(rangeID)
-	var foundTombstoneKey bool
-	for ; ; it.Next() {
-		ok, err := it.Valid()
-		require.NoError(t, err)
-		if !ok {
-			break
-		}
-		// There should not be any data other than the tombstone key.
-		if k := it.UnsafeKey(); k.Equal(storage.MVCCKey{Key: tombstoneKey}) {
-			foundTombstoneKey = true
-		} else {
-			t.Fatalf("found data in the range which should have been removed: %v", k)
-		}
-	}
-	require.True(t, foundTombstoneKey)
 }
 
 func BenchmarkStoreGetReplica(b *testing.B) {


### PR DESCRIPTION
This migration ran in 20.1 to remove pre-emptive snapshots which may have
existed from before 19.2 was finalized. This migration is no longer relevant.

Release note: None