### PR TITLE
sql: add the max/min aggregations on ENUMs

### DIFF
--- a/docs/generated/sql/aggregates.md
+++ b/docs/generated/sql/aggregates.md
@@ -105,6 +105,8 @@
 </span></td></tr>
 <tr><td><a name="max"></a><code>max(arg1: <a href="uuid.html">uuid</a>) &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
 </span></td></tr>
+<tr><td><a name="max"></a><code>max(arg1: anyenum) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
+</span></td></tr>
 <tr><td><a name="max"></a><code>max(arg1: collatedstring{*}) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
 </span></td></tr>
 <tr><td><a name="max"></a><code>max(arg1: geography) &rarr; geography</code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
@@ -144,6 +146,8 @@
 <tr><td><a name="min"></a><code>min(arg1: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
 </span></td></tr>
 <tr><td><a name="min"></a><code>min(arg1: <a href="uuid.html">uuid</a>) &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
+</span></td></tr>
+<tr><td><a name="min"></a><code>min(arg1: anyenum) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
 </span></td></tr>
 <tr><td><a name="min"></a><code>min(arg1: collatedstring{*}) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -345,6 +345,22 @@ hello 3 4 1
 howdy 5 6 0
 hi 10 10 10
 
+# Test aggregations on ENUM columns.
+query TT
+SELECT max(x), min(x) FROM enum_agg
+----
+hi hello
+
+# Test that enums without any members can still get an aggregate
+# resolved when distributing a flow.
+statement ok
+CREATE TYPE empty AS ENUM ();
+CREATE TABLE empty_enum (x empty)
+
+query TT
+SELECT max(x), min(x) FROM empty_enum
+----
+NULL NULL
 
 # Regression to ensure that statistics jobs can be run on tables
 # with user defined types.

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2092,6 +2092,7 @@ JOIN pg_operator c ON c.oprname = '>' AND b.proargtypes[0] = c.oprleft AND b.pro
 WHERE (b.proname = 'max' OR b.proname = 'bool_or') AND c.oid = a.aggsortop;
 ----
 oid         oprname  aggsortop
+1224236426  >        1224236426
 3636536082  >        3636536082
 3636536082  >        3636536082
 2948286002  >        2948286002
@@ -2123,6 +2124,7 @@ JOIN pg_operator c ON c.oprname = '<' AND b.proargtypes[0] = c.oprleft AND b.pro
 WHERE (b.proname = 'min' OR b.proname = 'bool_and' OR b.proname = 'every') AND c.oid = a.aggsortop;
 ----
 oid         oprname  aggsortop
+3859576864  <        3859576864
 2134593616  <        2134593616
 2134593616  <        2134593616
 2134593616  <        2134593616

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -80,7 +80,7 @@ func aggPropsNullableArgs() tree.FunctionProperties {
 // allMaxMinAggregateTypes contains extra types that aren't in
 // types.Scalar that the max/min aggregate functions are defined on.
 var allMaxMinAggregateTypes = append(
-	[]*types.T{types.AnyCollatedString},
+	[]*types.T{types.AnyCollatedString, types.AnyEnum},
 	types.Scalar...,
 )
 


### PR DESCRIPTION
Fixes #48370.

Release note (sql change): Add the max/min aggregation on ENUM types.