### PR TITLE
workload: rename leftover vectorize option 'auto' to 'on'

### DIFF
--- a/pkg/workload/tpcds/tpcds.go
+++ b/pkg/workload/tpcds/tpcds.go
@@ -66,7 +66,7 @@ var tpcdsMeta = workload.Meta{
 				`Note that --queries-to-omit flag has a higher precedence`)
 		g.flags.DurationVar(&g.queryTimeLimit, `query-time-limit`, 5*time.Minute,
 			`Time limit for a single run of a query`)
-		g.flags.StringVar(&g.vectorize, `vectorize`, `auto`,
+		g.flags.StringVar(&g.vectorize, `vectorize`, `on`,
 			`Set vectorize session variable`)
 		g.connFlags = workload.NewConnFlags(&g.flags)
 		return g

--- a/pkg/workload/tpch/tpch.go
+++ b/pkg/workload/tpch/tpch.go
@@ -105,7 +105,7 @@ var tpchMeta = workload.Meta{
 		g.flags.BoolVar(&g.disableChecks, `disable-checks`, false,
 			"Disable checking the output against the expected rows (default false). "+
 				"Note that the checks are only supported for scale factor 1")
-		g.flags.StringVar(&g.vectorize, `vectorize`, `auto`,
+		g.flags.StringVar(&g.vectorize, `vectorize`, `on`,
 			`Set vectorize session variable`)
 		g.flags.BoolVar(&g.verbose, `verbose`, false,
 			`Prints out the queries being run as well as histograms`)


### PR DESCRIPTION
Release note: None