### PR TITLE
release-19.2: kvclient: fix leaseholder cache pollution

### DIFF
--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -3188,18 +3188,20 @@ func TestCanSendToFollower(t *testing.T) {
 			2,
 		},
 	} {
-		sentTo = ReplicaInfo{}
-		canSend = c.canSendToFollower
-		ds := NewDistSender(cfg, g)
-		ds.clusterID = &base.ClusterIDContainer{}
-		// set 2 to be the leaseholder
-		ds.LeaseHolderCache().Update(context.Background(), 2 /* rangeID */, 2 /* storeID */)
-		if _, pErr := client.SendWrappedWith(context.Background(), ds, c.header, c.msg); !testutils.IsPError(pErr, "boom") {
-			t.Fatalf("%d: unexpected error: %v", i, pErr)
-		}
-		if sentTo.NodeID != c.expectedNode {
-			t.Fatalf("%d: unexpected replica: %v != %v", i, sentTo.NodeID, c.expectedNode)
-		}
+		t.Run("", func(t *testing.T) {
+			sentTo = ReplicaInfo{}
+			canSend = c.canSendToFollower
+			ds := NewDistSender(cfg, g)
+			ds.clusterID = &base.ClusterIDContainer{}
+			// set 2 to be the leaseholder
+			ds.LeaseHolderCache().Update(context.Background(), 2 /* rangeID */, 2 /* storeID */)
+			if _, pErr := client.SendWrappedWith(context.Background(), ds, c.header, c.msg); !testutils.IsPError(pErr, "boom") {
+				t.Fatalf("%d: unexpected error: %v", i, pErr)
+			}
+			if sentTo.NodeID != c.expectedNode {
+				t.Fatalf("%d: unexpected replica: %v != %v", i, sentTo.NodeID, c.expectedNode)
+			}
+		})
 	}
 }
 

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -3135,9 +3135,7 @@ func TestCanSendToFollower(t *testing.T) {
 		args roachpb.BatchRequest,
 	) (*roachpb.BatchResponse, error) {
 		sentTo = r[0]
-		reply := &roachpb.BatchResponse{}
-		reply.Error = roachpb.NewErrorf("boom")
-		return reply, nil
+		return args.CreateReply(), nil
 	}
 	cfg := DistSenderConfig{
 		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
@@ -3195,9 +3193,8 @@ func TestCanSendToFollower(t *testing.T) {
 			ds.clusterID = &base.ClusterIDContainer{}
 			// set 2 to be the leaseholder
 			ds.LeaseHolderCache().Update(context.Background(), 2 /* rangeID */, 2 /* storeID */)
-			if _, pErr := client.SendWrappedWith(context.Background(), ds, c.header, c.msg); !testutils.IsPError(pErr, "boom") {
-				t.Fatalf("%d: unexpected error: %v", i, pErr)
-			}
+			_, pErr := client.SendWrappedWith(context.Background(), ds, c.header, c.msg)
+			require.Nil(t, pErr)
 			if sentTo.NodeID != c.expectedNode {
 				t.Fatalf("%d: unexpected replica: %v != %v", i, sentTo.NodeID, c.expectedNode)
 			}

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -201,7 +201,8 @@ func newNodeDesc(nodeID roachpb.NodeID) *roachpb.NodeDescriptor {
 func TestSendRPCOrder(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
@@ -359,56 +360,57 @@ func TestSendRPCOrder(t *testing.T) {
 	ds := NewDistSender(cfg, g)
 
 	for n, tc := range testCases {
-		log.Infof(context.TODO(), "testcase %d", n)
-		verifyCall = makeVerifier(tc.expReplica)
+		t.Run("", func(t *testing.T) {
+			verifyCall = makeVerifier(tc.expReplica)
 
-		{
-			// The local node needs to get its attributes during sendRPC.
-			nd := &roachpb.NodeDescriptor{
-				NodeID:  6,
-				Address: util.MakeUnresolvedAddr("tcp", fmt.Sprintf("invalid.invalid:6")),
-				Locality: roachpb.Locality{
-					Tiers: tc.tiers,
-				},
+			{
+				// The local node needs to get its attributes during sendRPC.
+				nd := &roachpb.NodeDescriptor{
+					NodeID:  6,
+					Address: util.MakeUnresolvedAddr("tcp", fmt.Sprintf("invalid.invalid:6")),
+					Locality: roachpb.Locality{
+						Tiers: tc.tiers,
+					},
+				}
+				g.NodeID.Reset(nd.NodeID)
+				if err := g.SetNodeDescriptor(nd); err != nil {
+					t.Fatal(err)
+				}
 			}
-			g.NodeID.Reset(nd.NodeID)
-			if err := g.SetNodeDescriptor(nd); err != nil {
-				t.Fatal(err)
-			}
-		}
 
-		ds.leaseHolderCache.Update(
-			context.TODO(), rangeID, roachpb.StoreID(0),
-		)
-		if tc.leaseHolder > 0 {
 			ds.leaseHolderCache.Update(
-				context.TODO(), rangeID, descriptor.InternalReplicas[tc.leaseHolder-1].StoreID,
+				ctx, rangeID, roachpb.StoreID(0),
 			)
-		}
+			if tc.leaseHolder > 0 {
+				ds.leaseHolderCache.Update(
+					ctx, rangeID, descriptor.InternalReplicas[tc.leaseHolder-1].StoreID,
+				)
+			}
 
-		args := tc.args
-		{
-			header := args.Header()
-			header.Key = roachpb.Key("a")
-			args.SetHeader(header)
-		}
-		if roachpb.IsRange(args) {
-			header := args.Header()
-			header.EndKey = args.Header().Key.Next()
-			args.SetHeader(header)
-		}
-		consistency := roachpb.CONSISTENT
-		if !tc.consistent {
-			consistency = roachpb.INCONSISTENT
-		}
-		// Kill the cached NodeDescriptor, enforcing a lookup from Gossip.
-		ds.nodeDescriptor = nil
-		if _, err := client.SendWrappedWith(context.Background(), ds, roachpb.Header{
-			RangeID:         rangeID, // Not used in this test, but why not.
-			ReadConsistency: consistency,
-		}, args); err != nil {
-			t.Errorf("%d: %s", n, err)
-		}
+			args := tc.args
+			{
+				header := args.Header()
+				header.Key = roachpb.Key("a")
+				args.SetHeader(header)
+			}
+			if roachpb.IsRange(args) {
+				header := args.Header()
+				header.EndKey = args.Header().Key.Next()
+				args.SetHeader(header)
+			}
+			consistency := roachpb.CONSISTENT
+			if !tc.consistent {
+				consistency = roachpb.INCONSISTENT
+			}
+			// Kill the cached NodeDescriptor, enforcing a lookup from Gossip.
+			ds.nodeDescriptor = nil
+			if _, err := client.SendWrappedWith(ctx, ds, roachpb.Header{
+				RangeID:         rangeID, // Not used in this test, but why not.
+				ReadConsistency: consistency,
+			}, args); err != nil {
+				t.Errorf("%d: %s", n, err)
+			}
+		})
 	}
 }
 
@@ -3191,7 +3193,7 @@ func TestCanSendToFollower(t *testing.T) {
 		ds := NewDistSender(cfg, g)
 		ds.clusterID = &base.ClusterIDContainer{}
 		// set 2 to be the leaseholder
-		ds.LeaseHolderCache().Update(context.TODO(), 2, 2)
+		ds.LeaseHolderCache().Update(context.Background(), 2 /* rangeID */, 2 /* storeID */)
 		if _, pErr := client.SendWrappedWith(context.Background(), ds, c.header, c.msg); !testutils.IsPError(pErr, "boom") {
 			t.Fatalf("%d: unexpected error: %v", i, pErr)
 		}

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -3198,6 +3198,14 @@ func TestCanSendToFollower(t *testing.T) {
 			if sentTo.NodeID != c.expectedNode {
 				t.Fatalf("%d: unexpected replica: %v != %v", i, sentTo.NodeID, c.expectedNode)
 			}
+			// Check that the leaseholder cache doesn't change, even if the request is
+			// served by a follower. This tests a regression for a bug we've had where
+			// we were always updating the leaseholder cache on successful RPCs
+			// because we erroneously assumed that a success must come from the
+			// leaseholder.
+			storeID, ok := ds.LeaseHolderCache().Lookup(context.Background(), 2 /* rangeID */)
+			require.True(t, ok)
+			require.Equal(t, roachpb.StoreID(2), storeID)
 		})
 	}
 }

--- a/pkg/kv/send_test.go
+++ b/pkg/kv/send_test.go
@@ -283,7 +283,7 @@ func sendBatch(
 		0, /* rangeID */
 		makeReplicas(addrs...),
 		nodeDialer,
-		roachpb.ReplicaDescriptor{},
+		leaseholderInfo{},
 		false, /* withCommit */
 	)
 }


### PR DESCRIPTION
Backport 4/4 commits from #49400.

/cc @cockroachdb/release

---

Fixes #49391

This patch fixes a bug in the DistSender's updating of the leaseholder
cache. Prior, on most successful RPCs the DistSender inferred that the
success must come from a leaseholder, so it was updating the leaseholder
cache. This was not true for follower reads - the request was
successfully evaluated by followers, and we were erroneously inserting
these followers into the cache. We've seen this in a user cluster,
where the constant bad redirections and the resulting
NotLeaseholderErrors caused great confusion.

This patch does a tiny bit of cleanup to keep track of requests that
were not intended for the leaseholder, so that the cache is not updated
for them. I intend to backport this to 19.2 and 20.1. Independently of
this bug, I have other improvements coming which will make the updating
of kvclient cache more reliable - the server will detect when the client
has some stale info and it will explicitly communicate updates, so that
the client will no longer have to infer anything from a successful RPC.

Release note: None
