### PR TITLE
sql: serialize UDTs in expressions in a stable way

### DIFF
--- a/pkg/cli/testdata/dump/computed
+++ b/pkg/cli/testdata/dump/computed
@@ -14,7 +14,7 @@ dump d t
 ----
 CREATE TABLE t (
 	a INT8 NOT NULL,
-	b INT8 NULL AS (a + 1) STORED,
+	b INT8 NULL AS (a + 1:::INT8) STORED,
 	CONSTRAINT "primary" PRIMARY KEY (a ASC),
 	FAMILY "primary" (a, b)
 );

--- a/pkg/sql/execinfrapb/data.go
+++ b/pkg/sql/execinfrapb/data.go
@@ -133,7 +133,7 @@ func HydrateTypeSlice(evalCtx *tree.EvalContext, typs []*types.T) error {
 // IndexedVar formatting function needs to be added on. It replaces placeholders
 // with their values.
 func ExprFmtCtxBase(evalCtx *tree.EvalContext) *tree.FmtCtx {
-	fmtCtx := tree.NewFmtCtx(tree.FmtDistSQLSerialization)
+	fmtCtx := tree.NewFmtCtx(tree.FmtCheckEquivalence)
 	fmtCtx.SetPlaceholderFormat(
 		func(fmtCtx *tree.FmtCtx, p *tree.Placeholder) {
 			d, err := p.Eval(evalCtx)
@@ -173,7 +173,7 @@ func (e *Expression) Empty() bool {
 // String implements the Stringer interface.
 func (e Expression) String() string {
 	if e.LocalExpr != nil {
-		ctx := tree.NewFmtCtx(tree.FmtDistSQLSerialization)
+		ctx := tree.NewFmtCtx(tree.FmtCheckEquivalence)
 		ctx.FormatNode(e.LocalExpr)
 		return ctx.CloseAndGetString()
 	}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -170,20 +171,6 @@ func dNameOrNull(s string) tree.Datum {
 		return tree.DNull
 	}
 	return tree.NewDName(s)
-}
-
-func dStringPtrOrEmpty(s *string) tree.Datum {
-	if s == nil {
-		return emptyString
-	}
-	return tree.NewDString(*s)
-}
-
-func dStringPtrOrNull(s *string) tree.Datum {
-	if s == nil {
-		return tree.DNull
-	}
-	return tree.NewDString(*s)
 }
 
 func dIntFnOrNull(fn func() (int32, bool)) tree.Datum {
@@ -387,14 +374,30 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 					collationSchema = pgCatalogNameDString
 					collationName = tree.NewDString(locale)
 				}
+				colDefault := tree.DNull
+				if column.DefaultExpr != nil {
+					colExpr, err := schemaexpr.DeserializeTableDescExpr(ctx, &p.semaCtx, table, *column.DefaultExpr)
+					if err != nil {
+						return err
+					}
+					colDefault = tree.NewDString(tree.SerializeForDisplay(colExpr))
+				}
+				colComputed := emptyString
+				if column.ComputeExpr != nil {
+					colExpr, err := schemaexpr.DeserializeTableDescExpr(ctx, &p.semaCtx, table, *column.ComputeExpr)
+					if err != nil {
+						return err
+					}
+					colComputed = tree.NewDString(tree.SerializeForDisplay(colExpr))
+				}
 				return addRow(
 					dbNameStr,                    // table_catalog
 					scNameStr,                    // table_schema
 					tree.NewDString(table.Name),  // table_name
 					tree.NewDString(column.Name), // column_name
 					tree.NewDInt(tree.DInt(column.GetLogicalColumnID())), // ordinal_position
-					dStringPtrOrNull(column.DefaultExpr),                 // column_default
-					yesOrNoDatum(column.Nullable),                        // is_nullable
+					colDefault,                    // column_default
+					yesOrNoDatum(column.Nullable), // is_nullable
 					tree.NewDString(column.Type.InformationSchemaName()), // data_type
 					characterMaximumLength(column.Type),                  // character_maximum_length
 					characterOctetLength(column.Type),                    // character_octet_length
@@ -430,7 +433,7 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 					tree.DNull,                                           // identity_minimum
 					tree.DNull,                                           // identity_cycle
 					yesOrNoDatum(column.IsComputed()),                    // is_generated
-					dStringPtrOrEmpty(column.ComputeExpr),                // generation_expression
+					colComputed,                                          // generation_expression
 					yesOrNoDatum(table.IsTable() &&
 						!table.IsVirtualTable() &&
 						!column.IsComputed(),

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -91,7 +91,7 @@ query TTTTB colnames
 SHOW CONSTRAINTS FROM t
 ----
 table_name  constraint_name  constraint_type  details                              validated
-t           check_a          CHECK            CHECK ((a > 0))                      true
+t           check_a          CHECK            CHECK ((a > 0:::INT8))               true
 t           fk_f_ref_other   FOREIGN KEY      FOREIGN KEY (f) REFERENCES other(b)  true
 t           foo              UNIQUE           UNIQUE (b ASC)                       true
 t           primary          PRIMARY KEY      PRIMARY KEY (a ASC)                  true
@@ -105,7 +105,7 @@ ALTER TABLE t DROP CONSTRAINT check_a
 statement ok
 INSERT INTO t (a, f) VALUES (-2, 9)
 
-statement error validation of CHECK "a > 0" failed on row: a=-2, f=9, b=NULL, c=NULL
+statement error validation of CHECK "a > 0:::INT8" failed on row: a=-2, f=9, b=NULL, c=NULL
 ALTER TABLE t ADD CONSTRAINT check_a CHECK (a > 0)
 
 statement ok
@@ -120,7 +120,7 @@ INSERT INTO t (a) VALUES (-3)
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a         CHECK        CHECK ((a > 0))                      true
+t  check_a         CHECK        CHECK ((a > 0:::INT8))               true
 t  fk_f_ref_other  FOREIGN KEY  FOREIGN KEY (f) REFERENCES other(b)  true
 t  foo             UNIQUE       UNIQUE (b ASC)                       true
 t  primary         PRIMARY KEY  PRIMARY KEY (a ASC)                  true
@@ -138,8 +138,8 @@ ALTER TABLE t ADD CHECK (a > 0)
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a         CHECK        CHECK ((a > 0))                      true
-t  check_a1        CHECK        CHECK ((a > 0))                      true
+t  check_a         CHECK        CHECK ((a > 0:::INT8))               true
+t  check_a1        CHECK        CHECK ((a > 0:::INT8))               true
 t  fk_f_ref_other  FOREIGN KEY  FOREIGN KEY (f) REFERENCES other(b)  true
 t  foo             UNIQUE       UNIQUE (b ASC)                       true
 t  primary         PRIMARY KEY  PRIMARY KEY (a ASC)                  true
@@ -160,8 +160,8 @@ ALTER TABLE t VALIDATE CONSTRAINT check_a
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a         CHECK        CHECK ((a > 0))                      true
-t  check_a1        CHECK        CHECK ((a > 0))                      true
+t  check_a         CHECK        CHECK ((a > 0:::INT8))               true
+t  check_a1        CHECK        CHECK ((a > 0:::INT8))               true
 t  fk_f_ref_other  FOREIGN KEY  FOREIGN KEY (f) REFERENCES other(b)  true
 t  foo             UNIQUE       UNIQUE (b ASC)                       true
 t  primary         PRIMARY KEY  PRIMARY KEY (a ASC)                  true
@@ -374,24 +374,24 @@ ALTER TABLE t ADD g INT DEFAULT 1 CHECK (g > 0)
 statement ok
 ALTER TABLE t ADD h INT CHECK (h > 0) CHECK (h < 10) UNIQUE
 
-statement error pq: validation of CHECK "i < 0" failed on row:.* i=1
+statement error pq: validation of CHECK "i < 0:::INT8" failed on row:.* i=1
 ALTER TABLE t ADD i INT DEFAULT 1 CHECK (i < 0)
 
 statement error pq: validation of CHECK "i < g" failed on row:.* g=1.* i=1
 ALTER TABLE t ADD i INT DEFAULT 1 CHECK (i < g)
 
-statement error pq: validation of CHECK "i > 0" failed on row:.* g=1.* i=0
+statement error pq: validation of CHECK "i > 0:::INT8" failed on row:.* g=1.* i=0
 ALTER TABLE t ADD i INT AS (g - 1) STORED CHECK (i > 0)
 
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_f   CHECK        CHECK ((f > 1))      true
-t  check_g   CHECK        CHECK ((g > 0))      true
-t  check_h   CHECK        CHECK ((h > 0))      true
-t  check_h1  CHECK        CHECK ((h < 10))     true
-t  primary   PRIMARY KEY  PRIMARY KEY (a ASC)  true
-t  t_h_key   UNIQUE       UNIQUE (h ASC)       true
+t  check_f   CHECK        CHECK ((f > 1:::INT8))  true
+t  check_g   CHECK        CHECK ((g > 0:::INT8))  true
+t  check_h   CHECK        CHECK ((h > 0:::INT8))  true
+t  check_h1  CHECK        CHECK ((h < 10:::INT8)) true
+t  primary   PRIMARY KEY  PRIMARY KEY (a ASC)     true
+t  t_h_key   UNIQUE       UNIQUE (h ASC)          true
 
 statement ok
 DROP TABLE t
@@ -424,13 +424,13 @@ ALTER TABLE t ADD COLUMN u INT UNIQUE, ADD COLUMN v INT UNIQUE, ADD CONSTRAINT c
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_c_b  CHECK        CHECK ((c > b))      true
-t  ck         CHECK        CHECK ((a > 0))      true
-t  primary    PRIMARY KEY  PRIMARY KEY (a ASC)  true
-t  t_d_key    UNIQUE       UNIQUE (d ASC)       true
-t  t_e_key    UNIQUE       UNIQUE (e ASC)       true
-t  t_u_key    UNIQUE       UNIQUE (u ASC)       true
-t  t_v_key    UNIQUE       UNIQUE (v ASC)       true
+t  check_c_b  CHECK        CHECK ((c > b))         true
+t  ck         CHECK        CHECK ((a > 0:::INT8))  true
+t  primary    PRIMARY KEY  PRIMARY KEY (a ASC)     true
+t  t_d_key    UNIQUE       UNIQUE (d ASC)          true
+t  t_e_key    UNIQUE       UNIQUE (e ASC)          true
+t  t_u_key    UNIQUE       UNIQUE (u ASC)          true
+t  t_v_key    UNIQUE       UNIQUE (v ASC)          true
 
 statement ok
 DROP TABLE t
@@ -971,7 +971,7 @@ CREATE TABLE t (a int);
 statement ok
 INSERT INTO t VALUES (10), (15), (17)
 
-statement error pq: validation of CHECK "a < 16" failed on row: a=17
+statement error pq: validation of CHECK "a < 16:::INT8" failed on row: a=17
 ALTER TABLE t ADD CHECK (a < 16)
 
 statement ok
@@ -983,13 +983,13 @@ ALTER TABLE t ADD CHECK (a < 16) NOT VALID
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a   CHECK  CHECK  ((a < 100))  true
-t  check_a1  CHECK  CHECK  ((a < 16))  false
+t  check_a   CHECK  CHECK  ((a < 100:::INT8))  true
+t  check_a1  CHECK  CHECK  ((a < 16:::INT8))   false
 
-query error pq: failed to satisfy CHECK constraint \(a < 16\)
+query error pq: failed to satisfy CHECK constraint \(a < 16:::INT8\)
 INSERT INTO t VALUES (20)
 
-statement error pq: validation of CHECK "a < 16" failed on row: a=17
+statement error pq: validation of CHECK "a < 16:::INT8" failed on row: a=17
 ALTER TABLE t VALIDATE CONSTRAINT check_a1
 
 statement ok
@@ -1001,8 +1001,8 @@ ALTER TABLE t VALIDATE CONSTRAINT check_a1
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  check_a   CHECK  CHECK  ((a < 100))  true
-t  check_a1  CHECK  CHECK  ((a < 16))   true
+t  check_a   CHECK  CHECK  ((a < 100:::INT8))  true
+t  check_a1  CHECK  CHECK  ((a < 16:::INT8))   true
 
 subtest regression_42858
 

--- a/pkg/sql/logictest/testdata/logic_test/cascade_opt
+++ b/pkg/sql/logictest/testdata/logic_test/cascade_opt
@@ -2235,20 +2235,20 @@ b  20
 c  10
 
 # Perform another cascading update that should fail c.less_than_100.
-statement error pq: failed to satisfy CHECK constraint \(id < 100\)
+statement error pq: failed to satisfy CHECK constraint \(id < 100:::INT8\)
 UPDATE a SET id = id*10;
 
 # Perform another cascading update that should fail b.less_than_1000 or
 # c.less_than_100. The order of which check fails first is not deterministic.
-statement error pq: failed to satisfy CHECK constraint \(id < (100|1000)\)
+statement error pq: failed to satisfy CHECK constraint \(id < (100|1000):::INT8\)
 UPDATE a SET id = id*1000;
 
 # Perform another cascading update that should fail b.less_than_1000.
-statement error pq: failed to satisfy CHECK constraint \(id < 1000\)
+statement error pq: failed to satisfy CHECK constraint \(id < 1000:::INT8\)
 UPDATE a SET id = id*1000 WHERE id > 10;
 
 # And check another direct cascading constraint c.no_99.
-statement error pq: failed to satisfy CHECK constraint \(id != 99\)
+statement error pq: failed to satisfy CHECK constraint \(id != 99:::INT8\)
 UPDATE a SET id = 99 WHERE id = 10;
 
 # But it should still be possible to cascade an update that doesn't hit c.
@@ -2340,18 +2340,18 @@ c  10  20
 c  20  10
 
 # Try to update one value to fail c.less_than_100
-statement error pq: failed to satisfy CHECK constraint \(\(id1 \+ id2\) < 100\)
+statement error pq: failed to satisfy CHECK constraint \(\(id1 \+ id2\) < 100:::INT8\)
 UPDATE a SET id = id*10;
 
 # Try to update one value to fail c.less_than_100 or c.less_than_1000
-statement error pq: failed to satisfy CHECK constraint \(\(id1 \+ id2\) < 100\)
+statement error pq: failed to satisfy CHECK constraint \(\(id1 \+ id2\) < 100:::INT8\)
 UPDATE a SET id = id*10;
 
 # Try to update one value to fail c.less_than_100
-statement error pq: failed to satisfy CHECK constraint \(\(id1 \+ id2\) < 1000\)
+statement error pq: failed to satisfy CHECK constraint \(\(id1 \+ id2\) < 1000:::INT8\)
 UPDATE a SET id = 1000 WHERE id = 30;
 
-statement error pq: failed to satisfy CHECK constraint \(\(id1 \+ id2\) < 1000\)
+statement error pq: failed to satisfy CHECK constraint \(\(id1 \+ id2\) < 1000:::INT8\)
 UPDATE a SET id = 1000 WHERE id = 40;
 
 # Update a value that would fail the check if it was cascaded, but wasn't.
@@ -3991,7 +3991,7 @@ ALTER TABLE self_ab ADD CONSTRAINT fk FOREIGN KEY (b) REFERENCES self_ab (a) ON 
 
 # This update would cause the references to 2 to get reset to the default,
 # which violates the check.
-statement error failed to satisfy CHECK constraint \(b != 1\)
+statement error failed to satisfy CHECK constraint \(b != 1:::INT8\)
 UPDATE self_ab SET a = 3 WHERE a = 2
 
 # Make sure the check fails when we apply the same update through a cascade.
@@ -4004,5 +4004,5 @@ INSERT INTO self_ab_parent VALUES (1), (2)
 statement ok
 ALTER TABLE self_ab ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES self_ab_parent (p) ON UPDATE CASCADE
 
-statement error failed to satisfy CHECK constraint \(b != 1\)
+statement error failed to satisfy CHECK constraint \(b != 1:::INT8\)
 UPDATE self_ab_parent SET p = 3 WHERE p = 2

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -19,13 +19,13 @@ ALTER TABLE t1 DROP COLUMN to_delete
 statement ok
 INSERT INTO t1 (a, b) VALUES (4, -2)
 
-statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(a > 0\)
+statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(a > 0:::INT8\)
 INSERT INTO t1 VALUES (-3, -1)
 
-statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(b < 0\)
+statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(b < 0:::INT8\)
 INSERT INTO t1 VALUES (3, 1)
 
-statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(b > -100\)
+statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(b > \(-100\):::INT8\)
 INSERT INTO t1 VALUES (3, -101)
 
 statement ok
@@ -40,7 +40,7 @@ INSERT INTO t1 (b) VALUES (-1)
 statement ok
 CREATE TABLE t2 (a INT DEFAULT -1 CHECK (a >= 0), b INT CHECK (b <= 0), CHECK (b < a))
 
-statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(a >= 0\)
+statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(a >= 0:::INT8\)
 INSERT INTO t2 (b) VALUES (-2)
 
 ### Rename column with check constraint
@@ -48,7 +48,7 @@ INSERT INTO t2 (b) VALUES (-2)
 statement ok
 ALTER TABLE t2 RENAME COLUMN b TO c
 
-statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(c <= 0\)
+statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(c <= 0:::INT8\)
 INSERT INTO t2 (a, c) VALUES (2, 1)
 
 statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(c < a\)
@@ -221,11 +221,11 @@ t7  CREATE TABLE t7 (
     y INT8 NULL,
     z INT8 NULL,
     FAMILY "primary" (x, y, z, rowid),
-    CONSTRAINT check_x CHECK (x > 0),
-    CONSTRAINT check_x_y CHECK ((x + y) > 0),
-    CONSTRAINT check_y_z CHECK ((y + z) > 0),
-    CONSTRAINT check_y_z1 CHECK ((y + z) = 0),
-    CONSTRAINT named_constraint CHECK (z = 1)
+    CONSTRAINT check_x CHECK (x > 0:::INT8),
+    CONSTRAINT check_x_y CHECK ((x + y) > 0:::INT8),
+    CONSTRAINT check_y_z CHECK ((y + z) > 0:::INT8),
+    CONSTRAINT check_y_z1 CHECK ((y + z) = 0:::INT8),
+    CONSTRAINT named_constraint CHECK (z = 1:::INT8)
 )
 
 # Check that table references are dequalified in their stored representation.
@@ -256,9 +256,9 @@ SHOW CREATE TABLE t8
 t8  CREATE TABLE t8 (
     a INT8 NULL,
     FAMILY "primary" (a, rowid),
-    CONSTRAINT check_a CHECK (a > 0),
-    CONSTRAINT check_a1 CHECK (a > 0),
-    CONSTRAINT check_a2 CHECK (a > 0)
+    CONSTRAINT check_a CHECK (a > 0:::INT8),
+    CONSTRAINT check_a1 CHECK (a > 0:::INT8),
+    CONSTRAINT check_a2 CHECK (a > 0:::INT8)
 )
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -352,7 +352,7 @@ SHOW CREATE TABLE quoted_coll
 quoted_coll  CREATE TABLE quoted_coll (
   a STRING COLLATE en NULL,
   b STRING COLLATE en_US NULL,
-  c STRING COLLATE en_Us NULL DEFAULT 'c':::STRING COLLATE en_Us,
+  c STRING COLLATE en_Us NULL DEFAULT 'c':::STRING COLLATE en_us,
   d STRING COLLATE en_u_ks_level1 NULL DEFAULT 'd':::STRING::STRING COLLATE en_u_ks_level1,
   e STRING COLLATE en_us NULL AS (a COLLATE en_us) STORED,
   FAMILY "primary" (a, b, c, d, e, rowid)

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -13,7 +13,7 @@ SHOW CREATE TABLE with_no_column_refs
 with_no_column_refs  CREATE TABLE with_no_column_refs (
                      a INT8 NULL,
                      b INT8 NULL,
-                     c INT8 NULL AS (3) STORED,
+                     c INT8 NULL AS (3:::INT8) STORED,
                      FAMILY "primary" (a, b, c, rowid)
 )
 
@@ -31,7 +31,7 @@ SHOW CREATE TABLE extra_parens
 extra_parens  CREATE TABLE extra_parens (
               a INT8 NULL,
               b INT8 NULL,
-              c INT8 NULL AS ((3)) STORED,
+              c INT8 NULL AS (3:::INT8) STORED,
               FAMILY "primary" (a, b, c, rowid)
 )
 
@@ -654,7 +654,7 @@ SELECT generation_expression FROM information_schema.columns
 WHERE table_name = 'x' and column_name = 'b'
 ----
 generation_expression
-a * 2
+a * 2:::INT8
 
 query I
 SELECT count(*) FROM information_schema.columns
@@ -674,8 +674,8 @@ SHOW CREATE TABLE x
 ----
 x  CREATE TABLE x (
    a INT8 NULL,
-   b INT8 NULL AS (a * 2) STORED,
-   c INT8 NOT NULL AS (a + 4) STORED,
+   b INT8 NULL AS (a * 2:::INT8) STORED,
+   c INT8 NOT NULL AS (a + 4:::INT8) STORED,
    FAMILY "primary" (a, b, rowid, c)
 )
 
@@ -787,7 +787,7 @@ query TT
 SHOW CREATE t42418
 ----
 t42418  CREATE TABLE t42418 (
-        x INT8 NULL AS (1) STORED,
-        y INT8 NULL AS (1) STORED,
+        x INT8 NULL AS (1:::INT8) STORED,
+        y INT8 NULL AS (1:::INT8) STORED,
         FAMILY "primary" (x, rowid, y)
 )

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -157,7 +157,7 @@ like_constraints  CREATE TABLE like_constraints (
                   h INT8 NULL,
                   j JSONB NULL,
                   FAMILY "primary" (a, b, c, h, j, rowid),
-                  CONSTRAINT check_a CHECK (a > 3)
+                  CONSTRAINT check_a CHECK (a > 3:::INT8)
 )
 
 statement ok
@@ -189,7 +189,7 @@ SHOW CREATE TABLE like_generated
 like_generated  CREATE TABLE like_generated (
                 a INT8 NOT NULL,
                 b STRING NOT NULL,
-                c DECIMAL NULL AS (a + 3) STORED,
+                c DECIMAL NULL AS (a + 3:::DECIMAL) STORED,
                 h INT8 NULL,
                 j JSONB NULL,
                 FAMILY "primary" (a, b, c, h, j, rowid)
@@ -219,7 +219,7 @@ SHOW CREATE TABLE like_all
 like_all  CREATE TABLE like_all (
           a INT8 NOT NULL,
           b STRING NOT NULL DEFAULT 'foo':::STRING,
-          c DECIMAL NULL AS (a + 3) STORED,
+          c DECIMAL NULL AS (a + 3:::DECIMAL) STORED,
           h INT8 NULL,
           j JSONB NULL,
           CONSTRAINT "primary" PRIMARY KEY (a ASC, b ASC),
@@ -227,7 +227,7 @@ like_all  CREATE TABLE like_all (
           INDEX like_table_c_idx (c ASC) STORING (j),
           INVERTED INDEX like_table_j_idx (j),
           FAMILY "primary" (a, b, c, h, j),
-          CONSTRAINT check_a CHECK (a > 3)
+          CONSTRAINT check_a CHECK (a > 3:::INT8)
 )
 
 statement ok
@@ -241,7 +241,7 @@ SHOW CREATE TABLE like_mixed
 like_mixed  CREATE TABLE like_mixed (
             a INT8 NOT NULL,
             b STRING NOT NULL DEFAULT 'foo':::STRING,
-            c DECIMAL NULL AS (a + 3) STORED,
+            c DECIMAL NULL AS (a + 3:::DECIMAL) STORED,
             h INT8 NULL,
             j JSONB NULL,
             CONSTRAINT "primary" PRIMARY KEY (a ASC, b ASC),

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -418,7 +418,7 @@ SELECT ARRAY['hello']::_greeting, ARRAY['hello'::greeting]
 {hello} {hello}
 
 # Test that we can't mix enums in an array.
-query error pq: expected 'cockroach'::dbs to be of type greeting, found type dbs
+query error pq: expected 'cockroach'::test.public.dbs to be of type greeting, found type dbs
 SELECT ARRAY['hello'::greeting, 'cockroach'::dbs]
 
 statement ok
@@ -469,3 +469,119 @@ WHERE
   descriptor_name = 'enum_array' AND column_name = 'x'
 ----
 x  family:ArrayFamily width:0 precision:0 locale:"" visible_type:0 oid:100064 array_contents:<InternalType:<family:EnumFamily width:0 precision:0 locale:"" visible_type:0 oid:100063 time_precision_is_set:false udt_metadata:<stable_type_id:63 stable_array_type_id:64 > > TypeMeta:<> > time_precision_is_set:false udt_metadata:<stable_type_id:64 stable_array_type_id:0 >
+
+# Test tables using enums in DEFAULT expressions.
+statement ok
+CREATE TABLE enum_default (
+  x INT,
+  y greeting DEFAULT 'hello',
+  z BOOL DEFAULT ('hello':::greeting IS OF (greeting, greeting)),
+  FAMILY (x, y, z)
+);
+INSERT INTO enum_default VALUES (1), (2)
+
+query ITB rowsort
+SELECT * FROM enum_default
+----
+1 hello true
+2 hello true
+
+# Test that enum default values are formatted in human readable ways.
+query TT
+SHOW CREATE enum_default
+----
+enum_default  CREATE TABLE enum_default (
+              x INT8 NULL,
+              y test.public.greeting NULL DEFAULT 'hello':::test.public.greeting,
+              z BOOL NULL DEFAULT 'hello':::test.public.greeting IS OF (test.public.greeting, test.public.greeting),
+              FAMILY fam_0_x_y_z_rowid (x, y, z, rowid)
+)
+
+# Test crdb_internal.table_columns.
+query TT
+SELECT
+  column_name, default_expr
+FROM
+  crdb_internal.table_columns
+WHERE
+  descriptor_name='enum_default' AND (column_name = 'y' OR column_name = 'z')
+ORDER BY
+  column_name
+----
+y  'hello':::test.public.greeting
+z  'hello':::test.public.greeting IS OF (test.public.greeting, test.public.greeting)
+
+# Test information_schema.columns.
+query TT
+SELECT
+  column_name, column_default
+FROM
+  information_schema.columns
+WHERE
+  table_name='enum_default' AND (column_name = 'y' OR column_name = 'z')
+ORDER BY
+  column_name
+----
+y  'hello':::test.public.greeting
+z  'hello':::test.public.greeting IS OF (test.public.greeting, test.public.greeting)
+
+# Test computed columns with enum values.
+statement ok
+CREATE TABLE enum_computed (
+  x INT,
+  y greeting AS ('hello') STORED,
+  z BOOL AS (w = 'howdy') STORED,
+  w greeting,
+  FAMILY (x, y, z)
+);
+INSERT INTO enum_computed (x, w) VALUES (1, 'hello'), (2, 'hello')
+
+query ITBT rowsort
+SELECT * FROM enum_computed
+----
+1 hello false hello
+2 hello false hello
+
+query TT
+SHOW CREATE enum_computed
+----
+enum_computed  CREATE TABLE enum_computed (
+               x INT8 NULL,
+               y test.public.greeting NULL AS ('hello':::test.public.greeting) STORED,
+               z BOOL NULL AS (w = 'howdy':::test.public.greeting) STORED,
+               w test.public.greeting NULL,
+               FAMILY fam_0_x_y_z_w_rowid (x, y, z, w, rowid)
+)
+
+# Test information_schema.columns.
+query TT
+SELECT
+  column_name, generation_expression
+FROM
+  information_schema.columns
+WHERE
+  table_name='enum_computed' AND (column_name = 'y' OR column_name = 'z')
+ORDER BY
+  column_name
+----
+y  'hello':::test.public.greeting
+z  w = 'howdy':::test.public.greeting
+
+# Test check constraints with enum values.
+statement ok
+CREATE TABLE enum_checks (
+  x greeting,
+  CHECK (x = 'hello'::greeting),
+  CHECK ('hello':::greeting = 'hello':::greeting)
+);
+INSERT INTO enum_checks VALUES ('hello')
+
+query TT
+SHOW CREATE enum_checks
+----
+enum_checks  CREATE TABLE enum_checks (
+             x test.public.greeting NULL,
+             FAMILY "primary" (x, rowid),
+             CONSTRAINT check_x CHECK (x = 'hello':::test.public.greeting::test.public.greeting),
+             CONSTRAINT "check" CHECK ('hello':::test.public.greeting = 'hello':::test.public.greeting)
+)

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -1050,8 +1050,8 @@ ORDER BY CONSTRAINT_CATALOG, CONSTRAINT_NAME
 ----
 constraint_catalog  constraint_schema  constraint_name          check_clause
 constraint_db       public             541687103_59_1_not_null  p IS NOT NULL
-constraint_db       public             c2                       ((a < 99))
-constraint_db       public             check_a                  ((a > 4))
+constraint_db       public             c2                       ((a < 99:::INT8))
+constraint_db       public             check_a                  ((a > 4:::INT8))
 
 query TTTTTTT colnames
 SELECT *
@@ -1077,8 +1077,8 @@ ORDER BY tc.table_schema, tc.table_name, cc.constraint_name
 ----
 table_schema  table_name  constraint_name          check_clause
 public        t1          541687103_59_1_not_null  p IS NOT NULL
-public        t1          c2                       ((a < 99))
-public        t1          check_a                  ((a > 4))
+public        t1          c2                       ((a < 99:::INT8))
+public        t1          check_a                  ((a > 4:::INT8))
 
 statement ok
 DROP DATABASE constraint_db CASCADE
@@ -1391,7 +1391,7 @@ WHERE table_schema = 'public' AND table_name = 'computed'
 ----
 column_name  is_generated  generation_expression  is_updatable
 a            NO            ·                      YES
-b            YES           a + 1                  NO
+b            YES           a + 1:::INT8           NO
 rowid        NO            ·                      YES
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/parallel_stmts_compat
+++ b/pkg/sql/logictest/testdata/logic_test/parallel_stmts_compat
@@ -27,7 +27,7 @@ INSERT INTO kv VALUES (1, 2) RETURNING NOTHING
 statement ok
 UPSERT INTO kv VALUES (2, 2) RETURNING NOTHING
 
-statement error failed to satisfy CHECK constraint \(v < 100\)
+statement error failed to satisfy CHECK constraint \(v < 100:::INT8\)
 UPSERT INTO kv VALUES (2, 500) RETURNING NOTHING
 
 statement ok
@@ -139,7 +139,7 @@ BEGIN
 statement ok
 UPSERT INTO kv VALUES (1, 8) RETURNING NOTHING
 
-statement error failed to satisfy CHECK constraint \(v < 100\)
+statement error failed to satisfy CHECK constraint \(v < 100:::INT8\)
 UPSERT INTO kv VALUES (4, 500) RETURNING NOTHING
 
 statement error current transaction is aborted, commands ignored until end of transaction block

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -779,7 +779,7 @@ ORDER BY con.oid
 ----
 oid         conname    connamespace  contype
 2143281868  fk         2332901747    f
-3236224800  check_b    2332901747    c
+2792001267  check_b    2332901747    c
 3572320190  primary    2332901747    p
 4089604113  fk         2332901747    f
 4243354484  t1_a_key   2332901747    u
@@ -854,11 +854,11 @@ JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
 WHERE n.nspname = 'public' AND contype IN ('c', 'p', 'u')
 ORDER BY con.oid
 ----
-conname    confkey  conpfeqop  conppeqop  conffeqop  conexclop  conbin    consrc
-check_b    NULL     NULL       NULL       NULL       NULL       (b > 11)  (b > 11)
-primary    NULL     NULL       NULL       NULL       NULL       NULL      NULL
-t1_a_key   NULL     NULL       NULL       NULL       NULL       NULL      NULL
-index_key  NULL     NULL       NULL       NULL       NULL       NULL      NULL
+conname    confkey  conpfeqop  conppeqop  conffeqop  conexclop  conbin           consrc
+check_b    NULL     NULL       NULL       NULL       NULL       (b > 11:::INT8)  (b > 11:::INT8)
+primary    NULL     NULL       NULL       NULL       NULL       NULL             NULL
+t1_a_key   NULL     NULL       NULL       NULL       NULL       NULL             NULL
+index_key  NULL     NULL       NULL       NULL       NULL       NULL             NULL
 
 query TTTTTTTT colnames
 SELECT conname, confkey, conpfeqop, conppeqop, conffeqop, conexclop, conbin, consrc

--- a/pkg/sql/logictest/testdata/logic_test/rename_constraint
+++ b/pkg/sql/logictest/testdata/logic_test/rename_constraint
@@ -17,7 +17,7 @@ CREATE TABLE t (
    CONSTRAINT cf FOREIGN KEY (x) REFERENCES t(x),
    UNIQUE INDEX cu (x ASC),
    FAMILY "primary" (x, y, rowid),
-   CONSTRAINT cc CHECK (x > 10)
+   CONSTRAINT cc CHECK (x > 10:::INT8)
 )
 
 query TT
@@ -43,7 +43,7 @@ CREATE TABLE t (
    CONSTRAINT cf2 FOREIGN KEY (x) REFERENCES t(x),
    UNIQUE INDEX cu2 (x ASC),
    FAMILY "primary" (x, y, rowid),
-   CONSTRAINT cc2 CHECK (x > 10)
+   CONSTRAINT cc2 CHECK (x > 10:::INT8)
 )
 
 query TT
@@ -93,7 +93,7 @@ CREATE TABLE t (
    CONSTRAINT cf4 FOREIGN KEY (x) REFERENCES t(x),
    UNIQUE INDEX cu4 (x ASC),
    FAMILY "primary" (x, y, rowid),
-   CONSTRAINT cc4 CHECK (x > 10)
+   CONSTRAINT cc4 CHECK (x > 10:::INT8)
 )
 
 query TT

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -952,9 +952,9 @@ COMMIT
 query TTTTB
 SHOW CONSTRAINTS FROM check_table
 ----
-check_table  c_0      CHECK        CHECK ((c > 0))      false
-check_table  d_0      CHECK        CHECK ((d > 0))      true
-check_table  primary  PRIMARY KEY  PRIMARY KEY (k ASC)  true
+check_table  c_0      CHECK        CHECK ((c > 0:::INT8))  false
+check_table  d_0      CHECK        CHECK ((d > 0:::INT8))  true
+check_table  primary  PRIMARY KEY  PRIMARY KEY (k ASC)     true
 
 statement ok
 BEGIN
@@ -965,7 +965,7 @@ ALTER TABLE check_table ADD e INT DEFAULT 0
 statement ok
 ALTER TABLE check_table ADD CONSTRAINT e_0 CHECK (e > 0)
 
-statement error pgcode XXA00 validation of CHECK "e > 0" failed on row: k=1, c=NULL, d=1, e=0
+statement error pgcode XXA00 validation of CHECK "e > 0:::INT8" failed on row: k=1, c=NULL, d=1, e=0
 COMMIT
 
 # Test rollbacks after error in expression evaluation
@@ -985,9 +985,9 @@ COMMIT
 query TTTTB
 SHOW CONSTRAINTS FROM check_table
 ----
-check_table  c_0      CHECK        CHECK ((c > 0))      false
-check_table  d_0      CHECK        CHECK ((d > 0))      true
-check_table  primary  PRIMARY KEY  PRIMARY KEY (k ASC)  true
+check_table  c_0      CHECK        CHECK ((c > 0:::INT8))  false
+check_table  d_0      CHECK        CHECK ((d > 0:::INT8))  true
+check_table  primary  PRIMARY KEY  PRIMARY KEY (k ASC)     true
 
 # Adding column e was rolled back
 query TTBTTTB
@@ -1035,7 +1035,7 @@ ALTER TABLE check_table ADD CHECK (a >= 0)
 statement ok
 ALTER TABLE check_table ADD CHECK (a < 0)
 
-statement error pgcode XXA00 validation of CHECK \"a < 0\" failed on row: k=0, a=0
+statement error pgcode XXA00 validation of CHECK \"a < 0:::INT8\" failed on row: k=0, a=0
 COMMIT
 
 query TTTTB
@@ -1170,8 +1170,8 @@ COMMIT
 query TTTTB
 SHOW CONSTRAINTS FROM check_table
 ----
-check_table  ck_a  CHECK  CHECK ((a = 0))  true
-check_table  ck_b  CHECK  CHECK ((b > 0))  true
+check_table  ck_a  CHECK  CHECK ((a = 0:::INT8))  true
+check_table  ck_b  CHECK  CHECK ((b > 0:::INT8))  true
 check_table  ck_c  CHECK  CHECK ((c > b))  true
 
 # Also test insert/update to ensure constraint was added in a valid state (with correct column IDs, etc.)
@@ -1197,7 +1197,7 @@ statement ok
 INSERT INTO check_table VALUES (0)
 
 # This validates the constraint for existing rows, because it's in the same txn as CREATE TABLE
-statement error validation of CHECK "a > 0" failed on row: a=0
+statement error validation of CHECK "a > 0:::INT8" failed on row: a=0
 ALTER TABLE check_table ADD CONSTRAINT ck CHECK (a > 0)
 
 statement ok
@@ -1216,7 +1216,7 @@ statement ok
 ALTER TABLE check_table ADD COLUMN b INT DEFAULT 0
 
 # This validates the constraint for existing rows, because it's in the same txn as CREATE TABLE
-statement error validation of CHECK "b > 0" failed on row: a=0, b=0
+statement error validation of CHECK "b > 0:::INT8" failed on row: a=0, b=0
 ALTER TABLE check_table ADD CONSTRAINT ck CHECK (b > 0)
 
 statement ok
@@ -1232,7 +1232,7 @@ statement ok
 INSERT INTO check_table VALUES (0)
 
 # Test ADD COLUMN and ADD CONSTRAINT in the same ALTER TABLE statement
-statement error validation of CHECK "c > 0" failed on row: a=0, c=0
+statement error validation of CHECK "c > 0:::INT8" failed on row: a=0, c=0
 ALTER TABLE check_table ADD COLUMN c INT DEFAULT 0, ADD CONSTRAINT ck CHECK (c > 0)
 
 statement ok
@@ -1590,7 +1590,7 @@ ALTER TABLE t DROP CONSTRAINT c
 
 # Since the check constraint is dropped in the schema changer after the
 # transaction commits, it's still enforced during the rest of the transaction.
-statement error pq: failed to satisfy CHECK constraint \(a > 0\)
+statement error pq: failed to satisfy CHECK constraint \(a > 0:::INT8\)
 INSERT INTO t VALUES (0)
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -224,7 +224,7 @@ test.public.users  CREATE TABLE users (
                    FAMILY fam_2_nickname (nickname),
                    FAMILY fam_3_username_email (username, email),
                    CONSTRAINT check_nickname_name CHECK (length(nickname) < length(name)),
-                   CONSTRAINT check_nickname CHECK (length(nickname) < 10)
+                   CONSTRAINT check_nickname CHECK (length(nickname) < 10:::INT8)
 )
 
 statement ok
@@ -239,10 +239,10 @@ query TTTTB colnames
 SHOW CONSTRAINTS FROM test.dupe_generated
 ----
 table_name      constraint_name  constraint_type  details             validated
-dupe_generated  check_bar        CHECK            CHECK ((bar > 2))   true
-dupe_generated  check_foo        CHECK            CHECK ((foo > 2))   true
-dupe_generated  check_foo1       CHECK            CHECK ((foo < 10))  true
-dupe_generated  check_foo2       CHECK            CHECK ((foo > 1))   true
+dupe_generated  check_bar        CHECK            CHECK ((bar > 2:::INT8))   true
+dupe_generated  check_foo        CHECK            CHECK ((foo > 2:::INT8))   true
+dupe_generated  check_foo1       CHECK            CHECK ((foo < 10:::INT8))  true
+dupe_generated  check_foo2       CHECK            CHECK ((foo > 1:::INT8))   true
 
 statement ok
 CREATE TABLE test.named_constraints (
@@ -282,7 +282,7 @@ test.public.named_constraints  CREATE TABLE named_constraints (
                                FAMILY fam_2_nickname (nickname),
                                FAMILY fam_3_username_email (username, email),
                                CONSTRAINT ck2 CHECK (length(nickname) < length(name)),
-                               CONSTRAINT ck1 CHECK (length(nickname) < 10)
+                               CONSTRAINT ck1 CHECK (length(nickname) < 10:::INT8)
 )
 
 query TTTTB colnames
@@ -290,7 +290,7 @@ SHOW CONSTRAINTS FROM test.named_constraints
 ----
 table_name         constraint_name  constraint_type  details                                    validated
 named_constraints  bar              UNIQUE           UNIQUE (id ASC, name ASC)                  true
-named_constraints  ck1              CHECK            CHECK ((length(nickname) < 10))            true
+named_constraints  ck1              CHECK            CHECK ((length(nickname) < 10:::INT8))     true
 named_constraints  ck2              CHECK            CHECK ((length(nickname) < length(name)))  true
 named_constraints  pk               PRIMARY KEY      PRIMARY KEY (id ASC)                       true
 named_constraints  uq               UNIQUE           UNIQUE (email ASC)                         true

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -534,7 +534,7 @@ CREATE TABLE ab(
 statement count 1
 INSERT INTO ab(a, b) VALUES (1, 0);
 
-statement error pq: failed to satisfy CHECK constraint \(b < 1\)
+statement error pq: failed to satisfy CHECK constraint \(b < 1:::INT8\)
 INSERT INTO ab(a, b) VALUES (1, 0) ON CONFLICT(a) DO UPDATE SET b=12312313;
 
 statement count 1
@@ -552,34 +552,34 @@ CREATE TABLE abc_check(
 statement count 1
 INSERT INTO abc_check(a, b, c) VALUES (1, 0, 2);
 
-statement error pq: failed to satisfy CHECK constraint \(b < 1\)
+statement error pq: failed to satisfy CHECK constraint \(b < 1:::INT8\)
 INSERT INTO abc_check(a, b, c) VALUES (1, 0, 2) ON CONFLICT(a) DO UPDATE SET b=12312313;
 
-statement error pq: failed to satisfy CHECK constraint \(b < 1\)
+statement error pq: failed to satisfy CHECK constraint \(b < 1:::INT8\)
 INSERT INTO abc_check(a, b, c) VALUES (1, 0, 2) ON CONFLICT(a) DO UPDATE SET (b, c) = (1, 1);
 
-statement error pq: failed to satisfy CHECK constraint \(c > 1\)
+statement error pq: failed to satisfy CHECK constraint \(c > 1:::INT8\)
 INSERT INTO abc_check(a, b, c) VALUES (1, 0, 2) ON CONFLICT(a) DO UPDATE SET (b, c) = (-1, 1);
 
 statement count 1
 INSERT INTO abc_check(a, b, c) VALUES (2, 0, 3);
 
-statement error pq: failed to satisfy CHECK constraint \(b < 1\)
+statement error pq: failed to satisfy CHECK constraint \(b < 1:::INT8\)
 INSERT INTO abc_check(c, a, b) VALUES (3, 2, 0) ON CONFLICT(a) DO UPDATE SET b=12312313;
 
-statement error pq: failed to satisfy CHECK constraint \(b < 1\)
+statement error pq: failed to satisfy CHECK constraint \(b < 1:::INT8\)
 INSERT INTO abc_check(a, c) VALUES (2, 3) ON CONFLICT(a) DO UPDATE SET b=12312313;
 
-statement error pq: failed to satisfy CHECK constraint \(c > 1\)
+statement error pq: failed to satisfy CHECK constraint \(c > 1:::INT8\)
 INSERT INTO abc_check(a, c) VALUES (2, 3) ON CONFLICT(a) DO UPDATE SET c=1;
 
-statement error pq: failed to satisfy CHECK constraint \(c > 1\)
+statement error pq: failed to satisfy CHECK constraint \(c > 1:::INT8\)
 INSERT INTO abc_check(c, a) VALUES (3, 2) ON CONFLICT(a) DO UPDATE SET c=1;
 
-statement error pq: failed to satisfy CHECK constraint \(b < 1\)
+statement error pq: failed to satisfy CHECK constraint \(b < 1:::INT8\)
 INSERT INTO abc_check(c, a) VALUES (3, 2) ON CONFLICT(a) DO UPDATE SET b=123123123;
 
-statement error pq: failed to satisfy CHECK constraint \(b < 1\)
+statement error pq: failed to satisfy CHECK constraint \(b < 1:::INT8\)
 INSERT INTO abc_check(c, a) VALUES (3, 2) ON CONFLICT(a) DO UPDATE SET b=123123123;
 
 subtest 29495

--- a/pkg/sql/opt/exec/execbuilder/testdata/catalog
+++ b/pkg/sql/opt/exec/execbuilder/testdata/catalog
@@ -44,11 +44,11 @@ TABLE abcdef
  ├── a int not null
  ├── b int
  ├── c int default (10:::INT8)
- ├── d int as ((b + c) + 1) stored
+ ├── d int as ((b + c) + 1:::INT8) stored
  ├── e int as (a) stored
  ├── f int not null
  ├── rowid int not null default (unique_rowid()) [hidden]
- ├── CHECK (f > 2)
+ ├── CHECK (f > 2:::INT8)
  └── INDEX primary
       └── rowid int not null default (unique_rowid()) [hidden]
 scan abcdef

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -414,7 +414,7 @@ INSERT INTO t35364 (x) VALUES (1.5) ON CONFLICT (x) DO UPDATE SET x=2.5 RETURNIN
 ----
 3  3  9
 
-statement error pq: failed to satisfy CHECK constraint \(z >= 7\)
+statement error pq: failed to satisfy CHECK constraint \(z >= 7:::DECIMAL\)
 UPSERT INTO t35364 (x) VALUES (0)
 
 # ------------------------------------------------------------------------------

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -409,6 +409,13 @@ CREATE TABLE pg_catalog.pg_attrdef (
 			if err != nil {
 				defSrc = tree.NewDString(*column.DefaultExpr)
 			} else {
+				// Use type check to resolve types in expr. We don't use
+				// DeserializeTableDescExpr here because that returns a typed
+				// expression under the hood. Since typed expressions don't contain
+				// type annotations, we wouldn't format some defaults as intended.
+				if _, err := expr.TypeCheck(ctx, &p.semaCtx, types.Any); err != nil {
+					return err
+				}
 				ctx := tree.NewFmtCtx(tree.FmtPGAttrdefAdbin)
 				ctx.FormatNode(expr)
 				defSrc = tree.NewDString(ctx.String())

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -159,12 +159,13 @@ func (p *planner) ResolveType(
 	return tdesc.MakeTypesT(&tn, p.makeTypeLookupFn(ctx))
 }
 
-// ResolveTypeByID implements the tree.TypeResolver interface. We disallow
-// accessing types directly by their ID in standard SQL contexts, so error
-// out nicely here.
-// TODO (rohany): Is there a need to disable this in the general case?
+// ResolveTypeByID implements the tree.TypeResolver interface.
 func (p *planner) ResolveTypeByID(ctx context.Context, id uint32) (*types.T, error) {
-	return nil, errors.Newf("type id reference @%d not allowed in this context", id)
+	name, desc, err := resolver.ResolveTypeDescByID(ctx, p.txn, p.ExecCfg().Codec, sqlbase.ID(id))
+	if err != nil {
+		return nil, err
+	}
+	return desc.MakeTypesT(name, p.makeTypeLookupFn(ctx))
 }
 
 // maybeHydrateTypesInDescriptor hydrates any types.T's in the input descriptor.

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -4437,7 +4437,7 @@ ALTER TABLE t.test ADD COLUMN c INT AS (v + 4) STORED, ADD COLUMN d INT DEFAULT 
 	}
 	q := fmt.Sprintf("INSERT INTO t.test (k, v) VALUES (%d, -1)", maxValue+10)
 	if _, err := sqlDB.Exec(q); !testutils.IsError(err,
-		`failed to satisfy CHECK constraint \(c >= 4\)`) {
+		`failed to satisfy CHECK constraint \(c >= 4:::INT8\)`) {
 		t.Fatalf("err = %+v", err)
 	}
 
@@ -5404,7 +5404,7 @@ CREATE TABLE t.test (
 	wg.Add(1)
 	go func() {
 		_, err := sqlDB.Exec(`ALTER TABLE t.test ADD COLUMN a INT AS (v - 1) STORED, ADD CHECK (a < v AND a > -1000 AND a IS NOT NULL)`)
-		if !testutils.IsError(err, `validation of CHECK "\(\(a < v\) AND \(a > -1000\)\) AND \(a IS NOT NULL\)" failed on row: k=1003, v=-1003, a=-1004`) {
+		if !testutils.IsError(err, `validation of CHECK "\(\(a < v\) AND \(a > \(-1000\):::INT8\)\) AND \(a IS NOT NULL\)" failed on row: k=1003, v=-1003, a=-1004`) {
 			t.Error(err)
 		}
 		wg.Done()

--- a/pkg/sql/schemaexpr/check_constraint.go
+++ b/pkg/sql/schemaexpr/check_constraint.go
@@ -87,34 +87,6 @@ func (b *CheckConstraintBuilder) Build(
 		}
 	}
 
-	// Replace the column variables with dummyColumns so that they can be
-	// type-checked.
-	replacedExpr, colIDsUsed, err := replaceVars(b.desc, c.Expr)
-	if err != nil {
-		return nil, err
-	}
-
-	// Verify that the expression results in a boolean and does not use
-	// invalid functions.
-	_, err = sqlbase.SanitizeVarFreeExpr(
-		b.ctx,
-		replacedExpr,
-		types.Bool,
-		"CHECK",
-		b.semaCtx,
-		true, /* allowImpure */
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	// Collect and sort the column IDs referenced in the check expression.
-	colIDs := make(sqlbase.ColumnIDs, 0, len(colIDsUsed))
-	for colID := range colIDsUsed {
-		colIDs = append(colIDs, colID)
-	}
-	sort.Sort(colIDs)
-
 	source := sqlbase.NewSourceInfoForSingleTable(
 		b.tableName, sqlbase.ResultColumnsFromColDescs(
 			b.desc.GetID(),
@@ -128,8 +100,36 @@ func (b *CheckConstraintBuilder) Build(
 		return nil, err
 	}
 
+	// Replace the column variables with dummyColumns so that they can be
+	// type-checked.
+	replacedExpr, colIDsUsed, err := b.desc.ReplaceColumnVarsInExprWithDummies(expr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify that the expression results in a boolean and does not use
+	// invalid functions.
+	typedExpr, err := sqlbase.SanitizeVarFreeExpr(
+		b.ctx,
+		replacedExpr,
+		types.Bool,
+		"CHECK",
+		b.semaCtx,
+		true, /* allowImpure */
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Collect and sort the column IDs referenced in the check expression.
+	colIDs := make(sqlbase.ColumnIDs, 0, colIDsUsed.Len())
+	colIDsUsed.ForEach(func(id int) {
+		colIDs = append(colIDs, sqlbase.ColumnID(id))
+	})
+	sort.Sort(colIDs)
+
 	return &sqlbase.TableDescriptor_CheckConstraint{
-		Expr:      tree.Serialize(expr),
+		Expr:      tree.Serialize(typedExpr),
 		Name:      name,
 		ColumnIDs: colIDs,
 		Hidden:    c.Hidden,

--- a/pkg/sql/schemaexpr/check_constraint_test.go
+++ b/pkg/sql/schemaexpr/check_constraint_test.go
@@ -54,9 +54,9 @@ func TestCheckConstraintBuilder_Build(t *testing.T) {
 		{"", "a", true, "a", "check_a"},
 		{"", "a", true, "a", "check_a1"},
 		{"", "a", true, "a", "check_a2"},
-		{"", "a AND b = 0", true, "a AND (b = 0)", "check_a_b"},
-		{"", "a AND b = 1", true, "a AND (b = 1)", "check_a_b1"},
-		{"", "a AND b = 1", true, "a AND (b = 1)", "check_a_b2"},
+		{"", "a AND b = 0", true, "a AND (b = 0:::INT8)", "check_a_b"},
+		{"", "a AND b = 1", true, "a AND (b = 1:::INT8)", "check_a_b1"},
+		{"", "a AND b = 1", true, "a AND (b = 1:::INT8)", "check_a_b2"},
 
 		// Respect that "check_a3" has been marked, so the next check constraint
 		// with "a" should be "check_a4".
@@ -65,15 +65,15 @@ func TestCheckConstraintBuilder_Build(t *testing.T) {
 
 		// Allow expressions that result in a bool.
 		{"ck", "a", true, "a", "ck"},
-		{"ck", "b = 0", true, "b = 0", "ck"},
-		{"ck", "a AND b = 0", true, "a AND (b = 0)", "ck"},
+		{"ck", "b = 0", true, "b = 0:::INT8", "ck"},
+		{"ck", "a AND b = 0", true, "a AND (b = 0:::INT8)", "ck"},
 		{"ck", "a IS NULL", true, "a IS NULL", "ck"},
 		{"ck", "b IN (1, 2)", true, "b IN (1:::INT8, 2:::INT8)", "ck"},
 
 		// Allow immutable functions.
-		{"ck", "abs(b) > 0", true, "abs(b) > 0", "ck"},
-		{"ck", "c || c = 'foofoo'", true, "(c || c) = 'foofoo'", "ck"},
-		{"ck", "lower(c) = 'bar'", true, "lower(c) = 'bar'", "ck"},
+		{"ck", "abs(b) > 0", true, "abs(b) > 0:::INT8", "ck"},
+		{"ck", "c || c = 'foofoo'", true, "(c || c) = 'foofoo':::STRING", "ck"},
+		{"ck", "lower(c) = 'bar'", true, "lower(c) = 'bar':::STRING", "ck"},
 
 		// Allow mutable functions.
 		{"ck", "b > random()", true, "b > random()", "ck"},
@@ -99,9 +99,9 @@ func TestCheckConstraintBuilder_Build(t *testing.T) {
 		// Dequalify column names.
 		{"ck", "bar.a", true, "a", "ck"},
 		{"ck", "foo.bar.a", true, "a", "ck"},
-		{"ck", "bar.b = 0", true, "b = 0", "ck"},
-		{"ck", "foo.bar.b = 0", true, "b = 0", "ck"},
-		{"ck", "bar.a AND foo.bar.b = 0", true, "a AND (b = 0)", "ck"},
+		{"ck", "bar.b = 0", true, "b = 0:::INT8", "ck"},
+		{"ck", "foo.bar.b = 0", true, "b = 0:::INT8", "ck"},
+		{"ck", "bar.a AND foo.bar.b = 0", true, "a AND (b = 0:::INT8)", "ck"},
 	}
 
 	for _, d := range testData {

--- a/pkg/sql/schemaexpr/computed_column.go
+++ b/pkg/sql/schemaexpr/computed_column.go
@@ -35,6 +35,7 @@ func NewComputedColumnValidator(
 	ctx context.Context, desc *sqlbase.MutableTableDescriptor, semaCtx *tree.SemaContext,
 ) ComputedColumnValidator {
 	return ComputedColumnValidator{
+		ctx:     ctx,
 		desc:    desc,
 		semaCtx: semaCtx,
 	}
@@ -48,6 +49,8 @@ func NewComputedColumnValidator(
 //   - It does not have a default value.
 //   - It does not reference other computed columns.
 //
+// It additionally updates the target computed column with the serialized
+// typed expression.
 // TODO(mgartner): Add unit tests for Validate.
 func (v *ComputedColumnValidator) Validate(d *tree.ColumnTableDef) error {
 	if d.HasDefaultExpr() {
@@ -100,7 +103,7 @@ func (v *ComputedColumnValidator) Validate(d *tree.ColumnTableDef) error {
 
 	// Replace the column variables with dummyColumns so that they can be
 	// type-checked.
-	replacedExpr, _, err := replaceVars(v.desc, d.Computed.Expr)
+	replacedExpr, _, err := v.desc.ReplaceColumnVarsInExprWithDummies(d.Computed.Expr)
 	if err != nil {
 		return err
 	}
@@ -114,7 +117,7 @@ func (v *ComputedColumnValidator) Validate(d *tree.ColumnTableDef) error {
 	// Check that the type of the expression is of type defType and that there
 	// are no variable expressions (besides dummyColumnItems) and no impure
 	// functions.
-	_, err = sqlbase.SanitizeVarFreeExpr(
+	typedExpr, err := sqlbase.SanitizeVarFreeExpr(
 		v.ctx,
 		replacedExpr,
 		defType,
@@ -124,6 +127,16 @@ func (v *ComputedColumnValidator) Validate(d *tree.ColumnTableDef) error {
 	if err != nil {
 		return err
 	}
+
+	// Get the column that this definition points to.
+	targetCol, _, err := v.desc.FindColumnByName(d.Name)
+	if err != nil {
+		return err
+	}
+	// In order to safely serialize user defined types and their members, we
+	// need to serialize the typed expression here.
+	s := tree.Serialize(typedExpr)
+	targetCol.ComputeExpr = &s
 
 	return nil
 }

--- a/pkg/sql/schemaexpr/partial_index.go
+++ b/pkg/sql/schemaexpr/partial_index.go
@@ -58,7 +58,7 @@ func NewIndexPredicateValidator(
 func (v *IndexPredicateValidator) Validate(expr tree.Expr) (tree.Expr, error) {
 	// Replace the column variables with dummyColumns so that they can be
 	// type-checked.
-	replacedExpr, _, err := replaceVars(v.desc, expr)
+	replacedExpr, _, err := v.desc.ReplaceColumnVarsInExprWithDummies(expr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -127,10 +127,17 @@ const (
 	// compatible with pg_get_indexdef.
 	FmtPGIndexDef
 
-	// If set, user defined types will be printed as '@id', where id is the
-	// stable type ID for the user defined type. This is used in DistSQL flows
-	// where we don't want to perform name resolution of types again.
-	fmtFormatUserDefinedTypesAsIDs
+	// If set, user defined types and datums of user defined types will be
+	// formatted in a way that is stable across changes to the underlying type.
+	// For type names, this means that they will be formatted as '@id'. For enum
+	// members, this means that they will be serialized as their bytes physical
+	// representations.
+	fmtStaticallyFormatUserDefinedTypes
+
+	// fmtFormatByteLiterals instructs bytes to be formatted as byte literals
+	// rather than string literals. For example, the bytes \x40 will be formatted
+	// as b'\x40' rather than '\x40'.
+	fmtFormatByteLiterals
 )
 
 // Composite/derived flag definitions follow.
@@ -141,9 +148,15 @@ const (
 	FmtPgwireText FmtFlags = fmtPgwireFormat | FmtFlags(lex.EncBareStrings)
 
 	// FmtParsable instructs the pretty-printer to produce a representation that
-	// can be parsed into an equivalent expression (useful for serialization of
-	// expressions).
+	// can be parsed into an equivalent expression.
 	FmtParsable FmtFlags = fmtDisambiguateDatumTypes | FmtParsableNumerics
+
+	// FmtSerializable instructs the pretty-printer to produce a representation
+	// for expressions that can be serialized to disk. It serializes user defined
+	// types using representations that are stable across changes of the type
+	// itself. This should be used when serializing expressions that will be
+	// stored on disk, like DEFAULT expressions of columns.
+	FmtSerializable FmtFlags = FmtParsable | fmtStaticallyFormatUserDefinedTypes
 
 	// FmtCheckEquivalence instructs the pretty-printer to produce a representation
 	// that can be used to check equivalence of expressions. Specifically:
@@ -153,13 +166,13 @@ const (
 	//    annotations. This is necessary because datums of different types
 	//    can otherwise be formatted to the same string: (for example the
 	//    DDecimal 1 and the DInt 1).
-	FmtCheckEquivalence FmtFlags = fmtSymbolicVars | fmtDisambiguateDatumTypes | FmtParsableNumerics
-
-	// FmtDistSQLSerialization is just like FmtCheckEquivalence, but it can be
-	// used to serialize expressions for query distribution. In particular, it
-	// includes the flag fmtFormatUserDefinedTypesAsIDs which serializes user
-	// defined types in a way that avoids name resolution for DistSQL evaluation.
-	FmtDistSQLSerialization FmtFlags = FmtCheckEquivalence | fmtFormatUserDefinedTypesAsIDs
+	//  - user defined types and datums of user defined types are formatted
+	//    using static representations to avoid name resolution and invalidation
+	//    due to changes in the underlying type.
+	FmtCheckEquivalence FmtFlags = fmtSymbolicVars |
+		fmtDisambiguateDatumTypes |
+		FmtParsableNumerics |
+		fmtStaticallyFormatUserDefinedTypes
 
 	// FmtArrayToString is a special composite flag suitable
 	// for the output of array_to_string(). This de-quotes
@@ -412,10 +425,16 @@ func ErrString(n NodeFormatter) string {
 	return AsStringWithFlags(n, FmtBareIdentifiers)
 }
 
-// Serialize pretty prints a node to a string using FmtParsable; it is
-// appropriate when we store expressions into strings that are later parsed back
-// into expressions.
+// Serialize pretty prints a node to a string using FmtSerializable; it is
+// appropriate when we store expressions into strings that are stored on disk
+// and may be later parsed back into expressions.
 func Serialize(n NodeFormatter) string {
+	return AsStringWithFlags(n, FmtSerializable)
+}
+
+// SerializeForDisplay pretty prints a node to a string using FmtParsable.
+// It is appropriate when printing expressions that are visible to end users.
+func SerializeForDisplay(n NodeFormatter) string {
 	return AsStringWithFlags(n, FmtParsable)
 }
 

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -510,6 +510,7 @@ func (expr *CastExpr) TypeCheck(
 	if ok, c := isCastDeepValid(castFrom, exprType); ok {
 		telemetry.Inc(c)
 		expr.Expr = typedSubExpr
+		expr.Type = exprType
 		expr.typ = exprType
 		return expr, nil
 	}
@@ -559,6 +560,7 @@ func (expr *AnnotateTypeExpr) TypeCheck(
 	if err != nil {
 		return nil, err
 	}
+	expr.Type = annotateType
 	subExpr, err := typeCheckAndRequire(
 		ctx,
 		semaCtx,
@@ -1118,6 +1120,7 @@ func (expr *IsOfTypeExpr) TypeCheck(
 		if err != nil {
 			return nil, err
 		}
+		expr.Types[i] = typ
 		expr.resolvedTypes[i] = typ
 	}
 	expr.Expr = exprTyped

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -189,8 +189,8 @@ func TestTypeCheck(t *testing.T) {
 		// pre-resolution name is not going to get formatted.
 		{`1:::d.t1`, `1:::INT8`},
 		{`1:::d.s.t3 + 1.4`, `1:::DECIMAL + 1.4:::DECIMAL`},
-		{`1 IS OF (d.t1, t2)`, `1:::INT8 IS OF (d.t1, t2)`},
-		{`1::d.t1`, `1:::INT8::d.t1`},
+		{`1 IS OF (d.t1, t2)`, `1:::INT8 IS OF (INT8, STRING)`},
+		{`1::d.t1`, `1:::INT8::INT8`},
 	}
 	ctx := context.Background()
 	for _, d := range testData {

--- a/pkg/sql/sem/tree/type_name.go
+++ b/pkg/sql/sem/tree/type_name.go
@@ -147,7 +147,7 @@ func ResolveType(
 
 // FormatTypeReference formats a ResolvableTypeReference.
 func (ctx *FmtCtx) FormatTypeReference(ref ResolvableTypeReference) {
-	if ctx.HasFlags(fmtFormatUserDefinedTypesAsIDs) {
+	if ctx.HasFlags(fmtStaticallyFormatUserDefinedTypes) {
 		switch t := ref.(type) {
 		case *types.T:
 			if t.UserDefined() {

--- a/pkg/sql/sem/tree/var_name.go
+++ b/pkg/sql/sem/tree/var_name.go
@@ -131,6 +131,7 @@ type ColumnItem struct {
 }
 
 // Format implements the NodeFormatter interface.
+// If this is updated, then dummyColumnItem.Format should be updated as well.
 func (c *ColumnItem) Format(ctx *FmtCtx) {
 	if c.TableName != nil {
 		c.TableName.Format(ctx)

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -85,7 +86,11 @@ func ShowCreateTable(
 			f.WriteString(",")
 		}
 		f.WriteString("\n\t")
-		f.WriteString(col.SQLString())
+		colstr, err := schemaexpr.FormatColumnForDisplay(ctx, &p.RunParams(ctx).p.semaCtx, desc, col)
+		if err != nil {
+			return "", err
+		}
+		f.WriteString(colstr)
 		if desc.IsPhysicalTable() && desc.PrimaryIndex.ColumnIDs[0] == col.ID {
 			// Only set primaryKeyIsOnVisibleColumn to true if the primary key
 			// is on a visible column (not rowid).
@@ -158,7 +163,9 @@ func ShowCreateTable(
 
 	// Create the FAMILY and CONSTRAINTs of the CREATE statement
 	showFamilyClause(desc, f)
-	showConstraintClause(desc, f)
+	if err := showConstraintClause(ctx, desc, &p.RunParams(ctx).p.semaCtx, f); err != nil {
+		return "", err
+	}
 
 	if err := showCreateInterleave(&desc.PrimaryIndex, &f.Buffer, dbPrefix, lCtx); err != nil {
 		return "", err

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -76,7 +76,7 @@ func TestShowCreateTable(t *testing.T) {
 	t TIMESTAMP NULL DEFAULT now():::TIMESTAMP,
 	FAMILY "primary" (i, v, t, rowid),
 	FAMILY fam_1_s (s),
-	CONSTRAINT check_i CHECK (i > 0)
+	CONSTRAINT check_i CHECK (i > 0:::INT8)
 )`,
 		},
 		{
@@ -95,7 +95,7 @@ func TestShowCreateTable(t *testing.T) {
 	t TIMESTAMP NULL DEFAULT now():::TIMESTAMP,
 	FAMILY "primary" (i, v, t, rowid),
 	FAMILY fam_1_s (s),
-	CONSTRAINT check_i CHECK (i > 0)
+	CONSTRAINT check_i CHECK (i > 0:::INT8)
 )`,
 		},
 		{
@@ -111,7 +111,7 @@ func TestShowCreateTable(t *testing.T) {
 	s STRING NULL,
 	FAMILY "primary" (i, rowid),
 	FAMILY fam_1_s (s),
-	CONSTRAINT ck CHECK (i > 0)
+	CONSTRAINT ck CHECK (i > 0:::INT8)
 )`,
 		},
 		{

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -833,6 +834,85 @@ func (desc *TableDescriptor) AllActiveAndInactiveChecks() []*TableDescriptor_Che
 		}
 	}
 	return checks
+}
+
+// ReplaceColumnVarsInExprWithDummies replaces the occurrences of column names in an expression with
+// dummies containing their type, so that they may be typechecked. It returns
+// this new expression tree alongside a set containing the ColumnID of each
+// column seen in the expression.
+func (desc *TableDescriptor) ReplaceColumnVarsInExprWithDummies(
+	rootExpr tree.Expr,
+) (tree.Expr, util.FastIntSet, error) {
+	var colIDs util.FastIntSet
+	newExpr, err := tree.SimpleVisit(rootExpr, func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+		vBase, ok := expr.(tree.VarName)
+		if !ok {
+			// Not a VarName, don't do anything to this node.
+			return true, expr, nil
+		}
+
+		v, err := vBase.NormalizeVarName()
+		if err != nil {
+			return false, nil, err
+		}
+
+		c, ok := v.(*tree.ColumnItem)
+		if !ok {
+			return true, expr, nil
+		}
+
+		col, dropped, err := desc.FindColumnByName(c.ColumnName)
+		if err != nil || dropped {
+			return false, nil, pgerror.Newf(pgcode.UndefinedColumn,
+				"column %q does not exist, referenced in %q", c.ColumnName, rootExpr.String())
+		}
+		colIDs.Add(int(col.ID))
+		// Convert to a dummy node of the correct type.
+		return false, &dummyColumnItem{typ: col.Type, name: c.ColumnName}, nil
+	})
+	return newExpr, colIDs, err
+}
+
+// dummyColumnItem is used in makeCheckConstraint and validateIndexPredicate to
+// construct an expression that can be both type-checked and examined for
+// variable expressions. It can also be used to format typed expressions
+// containing column references.
+type dummyColumnItem struct {
+	typ  *types.T
+	name tree.Name
+}
+
+// String implements the Stringer interface.
+func (d *dummyColumnItem) String() string {
+	return tree.AsString(d)
+}
+
+// Format implements the NodeFormatter interface.
+// It should be kept in line with ColumnItem.Format.
+func (d *dummyColumnItem) Format(ctx *tree.FmtCtx) {
+	ctx.FormatNode(&d.name)
+}
+
+// Walk implements the Expr interface.
+func (d *dummyColumnItem) Walk(_ tree.Visitor) tree.Expr {
+	return d
+}
+
+// TypeCheck implements the Expr interface.
+func (d *dummyColumnItem) TypeCheck(
+	_ context.Context, _ *tree.SemaContext, desired *types.T,
+) (tree.TypedExpr, error) {
+	return d, nil
+}
+
+// Eval implements the TypedExpr interface.
+func (*dummyColumnItem) Eval(_ *tree.EvalContext) (tree.Datum, error) {
+	panic("dummyColumnItem.Eval() is undefined")
+}
+
+// ResolvedType implements the TypedExpr interface.
+func (d *dummyColumnItem) ResolvedType() *types.T {
+	return d.typ
 }
 
 // GetColumnFamilyForShard returns the column family that a newly added shard column

--- a/pkg/sql/sqlbase/structured.pb.go
+++ b/pkg/sql/sqlbase/structured.pb.go
@@ -74,7 +74,7 @@ func (x *ConstraintValidity) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ConstraintValidity) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{0}
+	return fileDescriptor_structured_6e223c312147c376, []int{0}
 }
 
 type ForeignKeyReference_Action int32
@@ -119,7 +119,7 @@ func (x *ForeignKeyReference_Action) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Action) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{0, 0}
+	return fileDescriptor_structured_6e223c312147c376, []int{0, 0}
 }
 
 // Match is the algorithm used to compare composite keys.
@@ -159,7 +159,7 @@ func (x *ForeignKeyReference_Match) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Match) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{0, 1}
+	return fileDescriptor_structured_6e223c312147c376, []int{0, 1}
 }
 
 // The direction of a column in the index.
@@ -196,7 +196,7 @@ func (x *IndexDescriptor_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{7, 0}
+	return fileDescriptor_structured_6e223c312147c376, []int{7, 0}
 }
 
 // The type of the index.
@@ -233,7 +233,7 @@ func (x *IndexDescriptor_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{7, 1}
+	return fileDescriptor_structured_6e223c312147c376, []int{7, 1}
 }
 
 type ConstraintToUpdate_ConstraintType int32
@@ -276,7 +276,7 @@ func (x *ConstraintToUpdate_ConstraintType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ConstraintToUpdate_ConstraintType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{8, 0}
+	return fileDescriptor_structured_6e223c312147c376, []int{8, 0}
 }
 
 // A descriptor within a mutation is unavailable for reads, writes
@@ -341,7 +341,7 @@ func (x *DescriptorMutation_State) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_State) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{11, 0}
+	return fileDescriptor_structured_6e223c312147c376, []int{11, 0}
 }
 
 // Direction of mutation.
@@ -384,7 +384,7 @@ func (x *DescriptorMutation_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{11, 1}
+	return fileDescriptor_structured_6e223c312147c376, []int{11, 1}
 }
 
 // State is set if this TableDescriptor is in the process of being added or deleted.
@@ -435,7 +435,7 @@ func (x *TableDescriptor_State) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TableDescriptor_State) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{12, 0}
+	return fileDescriptor_structured_6e223c312147c376, []int{12, 0}
 }
 
 // AuditMode indicates which auditing actions to take when this table is used.
@@ -472,7 +472,7 @@ func (x *TableDescriptor_AuditMode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TableDescriptor_AuditMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{12, 1}
+	return fileDescriptor_structured_6e223c312147c376, []int{12, 1}
 }
 
 // Represents the kind of type that this type descriptor represents.
@@ -512,7 +512,7 @@ func (x *TypeDescriptor_Kind) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TypeDescriptor_Kind) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{14, 0}
+	return fileDescriptor_structured_6e223c312147c376, []int{14, 0}
 }
 
 // ForeignKeyReference is deprecated, replaced by ForeignKeyConstraint in v19.2
@@ -542,7 +542,7 @@ func (m *ForeignKeyReference) Reset()         { *m = ForeignKeyReference{} }
 func (m *ForeignKeyReference) String() string { return proto.CompactTextString(m) }
 func (*ForeignKeyReference) ProtoMessage()    {}
 func (*ForeignKeyReference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{0}
+	return fileDescriptor_structured_6e223c312147c376, []int{0}
 }
 func (m *ForeignKeyReference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -604,7 +604,7 @@ func (m *ForeignKeyConstraint) Reset()         { *m = ForeignKeyConstraint{} }
 func (m *ForeignKeyConstraint) String() string { return proto.CompactTextString(m) }
 func (*ForeignKeyConstraint) ProtoMessage()    {}
 func (*ForeignKeyConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{1}
+	return fileDescriptor_structured_6e223c312147c376, []int{1}
 }
 func (m *ForeignKeyConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -635,7 +635,10 @@ type ColumnDescriptor struct {
 	Type     *types.T `protobuf:"bytes,3,opt,name=type" json:"type,omitempty"`
 	Nullable bool     `protobuf:"varint,4,opt,name=nullable" json:"nullable"`
 	// Default expression to use to populate the column on insert if no
-	// value is provided.
+	// value is provided. Note that it is not correct to use DefaultExpr
+	// as output to display to a user. User defined types within DefaultExpr
+	// have been serialized in a internal format. Instead, format the result
+	// of DeserializeTableDescExpr.
 	DefaultExpr *string `protobuf:"bytes,5,opt,name=default_expr,json=defaultExpr" json:"default_expr,omitempty"`
 	Hidden      bool    `protobuf:"varint,6,opt,name=hidden" json:"hidden"`
 	// Ids of sequences used in this column's DEFAULT expression, in calls to nextval().
@@ -643,7 +646,10 @@ type ColumnDescriptor struct {
 	// Ids of sequences that the column owns.
 	OwnsSequenceIds []ID `protobuf:"varint,12,rep,name=owns_sequence_ids,json=ownsSequenceIds,casttype=ID" json:"owns_sequence_ids,omitempty"`
 	// Expression to use to compute the value of this column if this is a
-	// computed column.
+	// computed column. Note that it is not correct to use ComputeExpr
+	// as output to display to a user. User defined types within ComputeExpr
+	// have been serialized in a internal format. Instead, format the result
+	// of DeserializeTableDescExpr.
 	ComputeExpr *string `protobuf:"bytes,11,opt,name=compute_expr,json=computeExpr" json:"compute_expr,omitempty"`
 	// LogicalColumnID must be accessed through the accessor, since it is set
 	// lazily, it is incorrect to access it directly.
@@ -660,7 +666,7 @@ func (m *ColumnDescriptor) Reset()         { *m = ColumnDescriptor{} }
 func (m *ColumnDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnDescriptor) ProtoMessage()    {}
 func (*ColumnDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{2}
+	return fileDescriptor_structured_6e223c312147c376, []int{2}
 }
 func (m *ColumnDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -716,7 +722,7 @@ func (m *ColumnFamilyDescriptor) Reset()         { *m = ColumnFamilyDescriptor{}
 func (m *ColumnFamilyDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnFamilyDescriptor) ProtoMessage()    {}
 func (*ColumnFamilyDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{3}
+	return fileDescriptor_structured_6e223c312147c376, []int{3}
 }
 func (m *ColumnFamilyDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -762,7 +768,7 @@ func (m *InterleaveDescriptor) Reset()         { *m = InterleaveDescriptor{} }
 func (m *InterleaveDescriptor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor) ProtoMessage()    {}
 func (*InterleaveDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{4}
+	return fileDescriptor_structured_6e223c312147c376, []int{4}
 }
 func (m *InterleaveDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -806,7 +812,7 @@ func (m *InterleaveDescriptor_Ancestor) Reset()         { *m = InterleaveDescrip
 func (m *InterleaveDescriptor_Ancestor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor_Ancestor) ProtoMessage()    {}
 func (*InterleaveDescriptor_Ancestor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{4, 0}
+	return fileDescriptor_structured_6e223c312147c376, []int{4, 0}
 }
 func (m *InterleaveDescriptor_Ancestor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -861,7 +867,7 @@ func (m *ShardedDescriptor) Reset()         { *m = ShardedDescriptor{} }
 func (m *ShardedDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ShardedDescriptor) ProtoMessage()    {}
 func (*ShardedDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{5}
+	return fileDescriptor_structured_6e223c312147c376, []int{5}
 }
 func (m *ShardedDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -906,7 +912,7 @@ func (m *PartitioningDescriptor) Reset()         { *m = PartitioningDescriptor{}
 func (m *PartitioningDescriptor) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor) ProtoMessage()    {}
 func (*PartitioningDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{6}
+	return fileDescriptor_structured_6e223c312147c376, []int{6}
 }
 func (m *PartitioningDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -949,7 +955,7 @@ func (m *PartitioningDescriptor_List) Reset()         { *m = PartitioningDescrip
 func (m *PartitioningDescriptor_List) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_List) ProtoMessage()    {}
 func (*PartitioningDescriptor_List) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{6, 0}
+	return fileDescriptor_structured_6e223c312147c376, []int{6, 0}
 }
 func (m *PartitioningDescriptor_List) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -994,7 +1000,7 @@ func (m *PartitioningDescriptor_Range) Reset()         { *m = PartitioningDescri
 func (m *PartitioningDescriptor_Range) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_Range) ProtoMessage()    {}
 func (*PartitioningDescriptor_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{6, 1}
+	return fileDescriptor_structured_6e223c312147c376, []int{6, 1}
 }
 func (m *PartitioningDescriptor_Range) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1158,7 +1164,7 @@ func (m *IndexDescriptor) Reset()         { *m = IndexDescriptor{} }
 func (m *IndexDescriptor) String() string { return proto.CompactTextString(m) }
 func (*IndexDescriptor) ProtoMessage()    {}
 func (*IndexDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{7}
+	return fileDescriptor_structured_6e223c312147c376, []int{7}
 }
 func (m *IndexDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1209,7 +1215,7 @@ func (m *ConstraintToUpdate) Reset()         { *m = ConstraintToUpdate{} }
 func (m *ConstraintToUpdate) String() string { return proto.CompactTextString(m) }
 func (*ConstraintToUpdate) ProtoMessage()    {}
 func (*ConstraintToUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{8}
+	return fileDescriptor_structured_6e223c312147c376, []int{8}
 }
 func (m *ConstraintToUpdate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1252,7 +1258,7 @@ func (m *PrimaryKeySwap) Reset()         { *m = PrimaryKeySwap{} }
 func (m *PrimaryKeySwap) String() string { return proto.CompactTextString(m) }
 func (*PrimaryKeySwap) ProtoMessage()    {}
 func (*PrimaryKeySwap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{9}
+	return fileDescriptor_structured_6e223c312147c376, []int{9}
 }
 func (m *PrimaryKeySwap) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1289,7 +1295,7 @@ func (m *ComputedColumnSwap) Reset()         { *m = ComputedColumnSwap{} }
 func (m *ComputedColumnSwap) String() string { return proto.CompactTextString(m) }
 func (*ComputedColumnSwap) ProtoMessage()    {}
 func (*ComputedColumnSwap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{10}
+	return fileDescriptor_structured_6e223c312147c376, []int{10}
 }
 func (m *ComputedColumnSwap) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1345,7 +1351,7 @@ func (m *DescriptorMutation) Reset()         { *m = DescriptorMutation{} }
 func (m *DescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*DescriptorMutation) ProtoMessage()    {}
 func (*DescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{11}
+	return fileDescriptor_structured_6e223c312147c376, []int{11}
 }
 func (m *DescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1724,7 +1730,7 @@ func (m *TableDescriptor) Reset()         { *m = TableDescriptor{} }
 func (m *TableDescriptor) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor) ProtoMessage()    {}
 func (*TableDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{12}
+	return fileDescriptor_structured_6e223c312147c376, []int{12}
 }
 func (m *TableDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2024,7 +2030,7 @@ func (m *TableDescriptor_SchemaChangeLease) Reset()         { *m = TableDescript
 func (m *TableDescriptor_SchemaChangeLease) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SchemaChangeLease) ProtoMessage()    {}
 func (*TableDescriptor_SchemaChangeLease) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{12, 0}
+	return fileDescriptor_structured_6e223c312147c376, []int{12, 0}
 }
 func (m *TableDescriptor_SchemaChangeLease) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2050,6 +2056,11 @@ func (m *TableDescriptor_SchemaChangeLease) XXX_DiscardUnknown() {
 var xxx_messageInfo_TableDescriptor_SchemaChangeLease proto.InternalMessageInfo
 
 type TableDescriptor_CheckConstraint struct {
+	// Expr is the expression that this check constraint represents.
+	// Note that it is not correct to use Expr as output to display
+	// to a user. User defined types within Expr have been serialized
+	// in a internal format. Instead, format the result of
+	// DeserializeTableDescExpr.
 	Expr     string             `protobuf:"bytes,1,opt,name=expr" json:"expr"`
 	Name     string             `protobuf:"bytes,2,opt,name=name" json:"name"`
 	Validity ConstraintValidity `protobuf:"varint,3,opt,name=validity,enum=cockroach.sql.sqlbase.ConstraintValidity" json:"validity"`
@@ -2065,7 +2076,7 @@ func (m *TableDescriptor_CheckConstraint) Reset()         { *m = TableDescriptor
 func (m *TableDescriptor_CheckConstraint) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_CheckConstraint) ProtoMessage()    {}
 func (*TableDescriptor_CheckConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{12, 1}
+	return fileDescriptor_structured_6e223c312147c376, []int{12, 1}
 }
 func (m *TableDescriptor_CheckConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2171,7 +2182,7 @@ func (m *TableDescriptor_NameInfo) Reset()         { *m = TableDescriptor_NameIn
 func (m *TableDescriptor_NameInfo) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_NameInfo) ProtoMessage()    {}
 func (*TableDescriptor_NameInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{12, 2}
+	return fileDescriptor_structured_6e223c312147c376, []int{12, 2}
 }
 func (m *TableDescriptor_NameInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2211,7 +2222,7 @@ func (m *TableDescriptor_Reference) Reset()         { *m = TableDescriptor_Refer
 func (m *TableDescriptor_Reference) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Reference) ProtoMessage()    {}
 func (*TableDescriptor_Reference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{12, 3}
+	return fileDescriptor_structured_6e223c312147c376, []int{12, 3}
 }
 func (m *TableDescriptor_Reference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2248,7 +2259,7 @@ func (m *TableDescriptor_MutationJob) Reset()         { *m = TableDescriptor_Mut
 func (m *TableDescriptor_MutationJob) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_MutationJob) ProtoMessage()    {}
 func (*TableDescriptor_MutationJob) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{12, 4}
+	return fileDescriptor_structured_6e223c312147c376, []int{12, 4}
 }
 func (m *TableDescriptor_MutationJob) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2291,7 +2302,7 @@ func (m *TableDescriptor_SequenceOpts) Reset()         { *m = TableDescriptor_Se
 func (m *TableDescriptor_SequenceOpts) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SequenceOpts) ProtoMessage()    {}
 func (*TableDescriptor_SequenceOpts) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{12, 5}
+	return fileDescriptor_structured_6e223c312147c376, []int{12, 5}
 }
 func (m *TableDescriptor_SequenceOpts) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2331,7 +2342,7 @@ func (m *TableDescriptor_SequenceOpts_SequenceOwner) String() string {
 }
 func (*TableDescriptor_SequenceOpts_SequenceOwner) ProtoMessage() {}
 func (*TableDescriptor_SequenceOpts_SequenceOwner) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{12, 5, 0}
+	return fileDescriptor_structured_6e223c312147c376, []int{12, 5, 0}
 }
 func (m *TableDescriptor_SequenceOpts_SequenceOwner) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2371,7 +2382,7 @@ func (m *TableDescriptor_Replacement) Reset()         { *m = TableDescriptor_Rep
 func (m *TableDescriptor_Replacement) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Replacement) ProtoMessage()    {}
 func (*TableDescriptor_Replacement) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{12, 6}
+	return fileDescriptor_structured_6e223c312147c376, []int{12, 6}
 }
 func (m *TableDescriptor_Replacement) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2408,7 +2419,7 @@ func (m *TableDescriptor_GCDescriptorMutation) Reset()         { *m = TableDescr
 func (m *TableDescriptor_GCDescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_GCDescriptorMutation) ProtoMessage()    {}
 func (*TableDescriptor_GCDescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{12, 7}
+	return fileDescriptor_structured_6e223c312147c376, []int{12, 7}
 }
 func (m *TableDescriptor_GCDescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2447,7 +2458,7 @@ func (m *DatabaseDescriptor) Reset()         { *m = DatabaseDescriptor{} }
 func (m *DatabaseDescriptor) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDescriptor) ProtoMessage()    {}
 func (*DatabaseDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{13}
+	return fileDescriptor_structured_6e223c312147c376, []int{13}
 }
 func (m *DatabaseDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2520,7 +2531,7 @@ func (m *TypeDescriptor) Reset()         { *m = TypeDescriptor{} }
 func (m *TypeDescriptor) String() string { return proto.CompactTextString(m) }
 func (*TypeDescriptor) ProtoMessage()    {}
 func (*TypeDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{14}
+	return fileDescriptor_structured_6e223c312147c376, []int{14}
 }
 func (m *TypeDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2611,7 +2622,7 @@ func (m *TypeDescriptor_EnumMember) Reset()         { *m = TypeDescriptor_EnumMe
 func (m *TypeDescriptor_EnumMember) String() string { return proto.CompactTextString(m) }
 func (*TypeDescriptor_EnumMember) ProtoMessage()    {}
 func (*TypeDescriptor_EnumMember) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{14, 0}
+	return fileDescriptor_structured_6e223c312147c376, []int{14, 0}
 }
 func (m *TypeDescriptor_EnumMember) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2653,7 +2664,7 @@ func (m *SchemaDescriptor) Reset()         { *m = SchemaDescriptor{} }
 func (m *SchemaDescriptor) String() string { return proto.CompactTextString(m) }
 func (*SchemaDescriptor) ProtoMessage()    {}
 func (*SchemaDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{15}
+	return fileDescriptor_structured_6e223c312147c376, []int{15}
 }
 func (m *SchemaDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2721,7 +2732,7 @@ func (m *Descriptor) Reset()         { *m = Descriptor{} }
 func (m *Descriptor) String() string { return proto.CompactTextString(m) }
 func (*Descriptor) ProtoMessage()    {}
 func (*Descriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_253488f1967898b4, []int{16}
+	return fileDescriptor_structured_6e223c312147c376, []int{16}
 }
 func (m *Descriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -13885,10 +13896,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/sqlbase/structured.proto", fileDescriptor_structured_253488f1967898b4)
+	proto.RegisterFile("sql/sqlbase/structured.proto", fileDescriptor_structured_6e223c312147c376)
 }
 
-var fileDescriptor_structured_253488f1967898b4 = []byte{
+var fileDescriptor_structured_6e223c312147c376 = []byte{
 	// 4195 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x3a, 0x49, 0x6f, 0x23, 0x57,
 	0x7a, 0x2a, 0xee, 0xfc, 0xb8, 0xa8, 0xf8, 0xb4, 0x34, 0x5b, 0xf6, 0x48, 0x6a, 0xb6, 0xdb, 0xd6,

--- a/pkg/sql/sqlbase/structured.proto
+++ b/pkg/sql/sqlbase/structured.proto
@@ -127,7 +127,10 @@ message ColumnDescriptor {
   optional bool nullable = 4 [(gogoproto.nullable) = false];
   reserved 8;
   // Default expression to use to populate the column on insert if no
-  // value is provided.
+  // value is provided. Note that it is not correct to use DefaultExpr
+  // as output to display to a user. User defined types within DefaultExpr
+  // have been serialized in a internal format. Instead, format the result
+  // of DeserializeTableDescExpr.
   optional string default_expr = 5;
   reserved 9;
   optional bool hidden = 6 [(gogoproto.nullable) = false];
@@ -137,7 +140,10 @@ message ColumnDescriptor {
   // Ids of sequences that the column owns.
   repeated uint32 owns_sequence_ids = 12 [(gogoproto.casttype) = "ID"];
   // Expression to use to compute the value of this column if this is a
-  // computed column.
+  // computed column. Note that it is not correct to use ComputeExpr
+  // as output to display to a user. User defined types within ComputeExpr
+  // have been serialized in a internal format. Instead, format the result
+  // of DeserializeTableDescExpr.
   optional string compute_expr = 11;
   // LogicalColumnID must be accessed through the accessor, since it is set
   // lazily, it is incorrect to access it directly.
@@ -723,6 +729,11 @@ message TableDescriptor {
 
   message CheckConstraint {
     option (gogoproto.equal) = true;
+    // Expr is the expression that this check constraint represents.
+    // Note that it is not correct to use Expr as output to display
+    // to a user. User defined types within Expr have been serialized
+    // in a internal format. Instead, format the result of
+    // DeserializeTableDescExpr.
     optional string expr = 1 [(gogoproto.nullable) = false];
     optional string name = 2 [(gogoproto.nullable) = false];
     optional ConstraintValidity validity = 3 [(gogoproto.nullable) = false];

--- a/pkg/sql/testdata/telemetry/sql-stats
+++ b/pkg/sql/testdata/telemetry/sql-stats
@@ -16,7 +16,7 @@ INSERT INTO foo.a SELECT unnest(ARRAY[1,2,3,4,5]);
 SET CLUSTER SETTING cluster.organization = 'ACME';
 SELECT (1, 20, 30, 40) = (SELECT a, 1, 2, 3 FROM foo.a LIMIT 1);
 ----
-error: pq: failed to satisfy CHECK constraint (a > 1)
+error: pq: failed to satisfy CHECK constraint (a > 1:::INT8)
 sql-stats
  └── $ some app
       ├── [nodist] CREATE DATABASE _


### PR DESCRIPTION
Fixes #49379.

This PR ensures that serialized expressions stored durably in table
descriptors are serialized in a format that is stable across changes to
user defined types present in those expressions. An effect of this
change is that these expressions must be reparsed and formatted in a
human readable way before display in statements like `SHOW CREATE
TABLE`. 

Release note: None