### PR TITLE
cli: clean up internal code around `cockroach demo`

### DIFF
--- a/pkg/cli/demo_cluster.go
+++ b/pkg/cli/demo_cluster.go
@@ -328,8 +328,9 @@ func (c *transientCluster) cleanup(ctx context.Context) {
 	}
 }
 
-// DrainNode will gracefully attempt to drain a node in the cluster.
-func (c *transientCluster) DrainNode(nodeID roachpb.NodeID) error {
+// DrainAndShutdown will gracefully attempt to drain a node in the cluster, and
+// then shut it down.
+func (c *transientCluster) DrainAndShutdown(nodeID roachpb.NodeID) error {
 	nodeIndex := int(nodeID - 1)
 
 	if nodeIndex < 0 || nodeIndex >= len(c.servers) {

--- a/pkg/cli/quit.go
+++ b/pkg/cli/quit.go
@@ -84,7 +84,7 @@ func runQuit(cmd *cobra.Command, args []string) (err error) {
 }
 
 // drainAndShutdown attempts to drain the server and then shut it
-// down. When given an empty onModes slice, it's a hard shutdown.
+// down.
 func drainAndShutdown(ctx context.Context, c serverpb.AdminClient) (err error) {
 	hardError, remainingWork, err := doDrain(ctx, c)
 	if hardError {
@@ -98,10 +98,8 @@ func drainAndShutdown(ctx context.Context, c serverpb.AdminClient) (err error) {
 	if err != nil {
 		log.Warningf(ctx, "drain did not complete successfully; hard shutdown may cause disruption")
 	}
-	// We have already performed the drain above. We use a nil array
-	// of drain modes to indicate no further drain needs to be attempted
-	// and go straight to shutdown. We try two times just in case there
-	// is a transient error.
+	// We have already performed the drain above, so now go straight to
+	// shutdown. We try twice just in case there is a transient error.
 	hardErr, err := doShutdown(ctx, c)
 	if err != nil && !hardErr {
 		log.Warningf(ctx, "hard shutdown attempt failed, retrying: %v", err)

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -514,7 +514,7 @@ func (c *cliState) handleDemo(cmd []string, nextState, errState cliStateEnum) cl
 
 	switch cmd[0] {
 	case "shutdown":
-		if err := demoCtx.transientCluster.DrainNode(roachpb.NodeID(nodeID)); err != nil {
+		if err := demoCtx.transientCluster.DrainAndShutdown(roachpb.NodeID(nodeID)); err != nil {
 			return c.internalServerError(errState, err)
 		}
 		fmt.Printf("node %d has been shutdown\n", nodeID)


### PR DESCRIPTION
Remove stale references to `onModes` and use a more appropriately named
method.

Release note: None