### PR TITLE
sql: allow pgwire auth methods to specify a cleanup func

### DIFF
--- a/pkg/acceptance/compose_test.go
+++ b/pkg/acceptance/compose_test.go
@@ -19,6 +19,7 @@ import (
 func TestComposeGSS(t *testing.T) {
 	out, err := exec.Command(
 		"docker-compose",
+		"--no-ansi",
 		"-f", filepath.Join("compose", "gss", "docker-compose.yml"),
 		"up",
 		"--build",

--- a/pkg/ccl/gssapiccl/gssapi.go
+++ b/pkg/ccl/gssapiccl/gssapi.go
@@ -41,7 +41,7 @@ const (
 )
 
 // authGSS performs GSS authentication. See:
-// https:github.com/postgres/postgres/blob/0f9cdd7dca694d487ab663d463b308919f591c02/src/backend/libpq/auth.c#L1090
+// https://github.com/postgres/postgres/blob/0f9cdd7dca694d487ab663d463b308919f591c02/src/backend/libpq/auth.c#L1090
 func authGSS(
 	ctx context.Context,
 	c pgwire.AuthConn,
@@ -51,7 +51,7 @@ func authGSS(
 	execCfg *sql.ExecutorConfig,
 	entry *hba.Entry,
 ) (security.UserAuthHook, error) {
-	return func(requestedUser string, clientConnection bool) error {
+	return func(requestedUser string, clientConnection bool) (func(), error) {
 		var (
 			majStat, minStat, lminS, gflags C.OM_uint32
 			gbuf                            C.gss_buffer_desc
@@ -65,13 +65,29 @@ func authGSS(
 		)
 
 		if err = c.SendAuthRequest(authTypeGSS, nil); err != nil {
-			return err
+			return nil, err
+		}
+
+		// This cleanup function must be called at the
+		// "completion of a communications session", not
+		// merely at the end of an authentication init. See
+		// https://tools.ietf.org/html/rfc2744.html, section
+		// `1. Introduction`, stage `d`:
+		//
+		//   At the completion of a communications session (which
+		//   may extend across several transport connections),
+		//   each application calls a GSS-API routine to delete
+		//   the security context.
+		//
+		// See https://github.com/postgres/postgres/blob/f4d59369d2ddf0ad7850112752ec42fd115825d4/src/backend/libpq/pqcomm.c#L269
+		connClose := func() {
+			C.gss_delete_sec_context(&lminS, &contextHandle, C.GSS_C_NO_BUFFER)
 		}
 
 		for {
 			token, err = c.GetPwdData()
 			if err != nil {
-				return err
+				return connClose, err
 			}
 
 			gbuf.length = C.ulong(len(token))
@@ -96,12 +112,11 @@ func authGSS(
 				outputBytes := C.GoBytes(outputToken.value, C.int(outputToken.length))
 				C.gss_release_buffer(&lminS, &outputToken)
 				if err = c.SendAuthRequest(authTypeGSSContinue, outputBytes); err != nil {
-					return err
+					return connClose, err
 				}
 			}
 			if majStat != C.GSS_S_COMPLETE && majStat != C.GSS_S_CONTINUE_NEEDED {
-				C.gss_delete_sec_context(&lminS, &contextHandle, C.GSS_C_NO_BUFFER)
-				return gssError("accepting GSS security context failed", majStat, minStat)
+				return connClose, gssError("accepting GSS security context failed", majStat, minStat)
 			}
 			if majStat != C.GSS_S_CONTINUE_NEEDED {
 				break
@@ -110,7 +125,7 @@ func authGSS(
 
 		majStat = C.gss_display_name(&minStat, srcName, &gbuf, nil)
 		if majStat != C.GSS_S_COMPLETE {
-			return gssError("retrieving GSS user name failed", majStat, minStat)
+			return connClose, gssError("retrieving GSS user name failed", majStat, minStat)
 		}
 		gssUser := C.GoStringN((*C.char)(gbuf.value), C.int(gbuf.length))
 		C.gss_release_buffer(&lminS, &gbuf)
@@ -128,25 +143,25 @@ func authGSS(
 					}
 				}
 				if !matched {
-					return errors.Errorf("GSSAPI realm (%s) didn't match any configured realm", realm)
+					return connClose, errors.Errorf("GSSAPI realm (%s) didn't match any configured realm", realm)
 				}
 			}
 			if entry.GetOption("include_realm") != "1" {
 				gssUser = gssUser[:idx]
 			}
 		} else if len(realms) > 0 {
-			return errors.New("GSSAPI did not return realm but realm matching was requested")
+			return connClose, errors.New("GSSAPI did not return realm but realm matching was requested")
 		}
 
 		if !strings.EqualFold(gssUser, requestedUser) {
-			return errors.Errorf("requested user is %s, but GSSAPI auth is for %s", requestedUser, gssUser)
+			return connClose, errors.Errorf("requested user is %s, but GSSAPI auth is for %s", requestedUser, gssUser)
 		}
 
 		// Do the license check last so that administrators are able to test whether
 		// their GSS configuration is correct. That is, the presence of this error
 		// message means they have a correctly functioning GSS/Kerberos setup,
 		// but now need to enable enterprise features.
-		return utilccl.CheckEnterpriseEnabled(execCfg.Settings, execCfg.ClusterID(), execCfg.Organization(), "GSS authentication")
+		return connClose, utilccl.CheckEnterpriseEnabled(execCfg.Settings, execCfg.ClusterID(), execCfg.Organization(), "GSS authentication")
 	}, nil
 }
 

--- a/pkg/security/auth.go
+++ b/pkg/security/auth.go
@@ -32,8 +32,9 @@ var certPrincipalMap struct {
 }
 
 // UserAuthHook authenticates a user based on their username and whether their
-// connection originates from a client or another node in the cluster.
-type UserAuthHook func(string, bool) error
+// connection originates from a client or another node in the cluster. It
+// returns an optional func that is run at connection close.
+type UserAuthHook func(string, bool) (connClose func(), _ error)
 
 // SetCertPrincipalMap sets the global principal map. Each entry in the mapping
 // list must either be empty or have the format <source>:<dest>. The principal
@@ -115,54 +116,54 @@ func UserAuthCertHook(insecureMode bool, tlsState *tls.ConnectionState) (UserAut
 		}
 	}
 
-	return func(requestedUser string, clientConnection bool) error {
+	return func(requestedUser string, clientConnection bool) (func(), error) {
 		// TODO(marc): we may eventually need stricter user syntax rules.
 		if len(requestedUser) == 0 {
-			return errors.New("user is missing")
+			return nil, errors.New("user is missing")
 		}
 
 		if !clientConnection && requestedUser != NodeUser {
-			return errors.Errorf("user %s is not allowed", requestedUser)
+			return nil, errors.Errorf("user %s is not allowed", requestedUser)
 		}
 
 		// If running in insecure mode, we have nothing to verify it against.
 		if insecureMode {
-			return nil
+			return nil, nil
 		}
 
 		// The client certificate user must match the requested user,
 		// except if the certificate user is NodeUser, which is allowed to
 		// act on behalf of all other users.
 		if !ContainsUser(requestedUser, certUsers) && !ContainsUser(NodeUser, certUsers) {
-			return errors.Errorf("requested user is %s, but certificate is for %s", requestedUser, certUsers)
+			return nil, errors.Errorf("requested user is %s, but certificate is for %s", requestedUser, certUsers)
 		}
 
-		return nil
+		return nil, nil
 	}, nil
 }
 
 // UserAuthPasswordHook builds an authentication hook based on the security
 // mode, password, and its potentially matching hash.
 func UserAuthPasswordHook(insecureMode bool, password string, hashedPassword []byte) UserAuthHook {
-	return func(requestedUser string, clientConnection bool) error {
+	return func(requestedUser string, clientConnection bool) (func(), error) {
 		if len(requestedUser) == 0 {
-			return errors.New("user is missing")
+			return nil, errors.New("user is missing")
 		}
 
 		if !clientConnection {
-			return errors.New("password authentication is only available for client connections")
+			return nil, errors.New("password authentication is only available for client connections")
 		}
 
 		if insecureMode {
-			return nil
+			return nil, nil
 		}
 
 		// If the requested user has an empty password, disallow authentication.
 		if len(password) == 0 || CompareHashAndPassword(hashedPassword, password) != nil {
-			return errors.Errorf(ErrPasswordUserAuthFailed, requestedUser)
+			return nil, errors.Errorf(ErrPasswordUserAuthFailed, requestedUser)
 		}
 
-		return nil
+		return nil, nil
 	}
 }
 

--- a/pkg/security/auth_test.go
+++ b/pkg/security/auth_test.go
@@ -200,11 +200,11 @@ func TestAuthenticationHook(t *testing.T) {
 			if err != nil {
 				return
 			}
-			err = hook(tc.username, true /* clientConnection */)
+			_, err = hook(tc.username, true /* clientConnection */)
 			if (err == nil) != tc.publicHookSuccess {
 				t.Fatalf("expected success=%t, got err=%v", tc.publicHookSuccess, err)
 			}
-			err = hook(tc.username, false /* clientConnection */)
+			_, err = hook(tc.username, false /* clientConnection */)
 			if (err == nil) != tc.privateHookSuccess {
 				t.Fatalf("expected success=%t, got err=%v", tc.privateHookSuccess, err)
 			}

--- a/pkg/sql/pgwire/auth.go
+++ b/pkg/sql/pgwire/auth.go
@@ -69,12 +69,12 @@ type authOptions struct {
 // if different from the one given initially.
 func (c *conn) handleAuthentication(
 	ctx context.Context, ac AuthConn, authOpt authOptions, execCfg *sql.ExecutorConfig,
-) error {
+) (connClose func(), _ error) {
 	if authOpt.testingSkipAuth {
-		return nil
+		return nil, nil
 	}
 	if authOpt.testingAuthHook != nil {
-		return authOpt.testingAuthHook(ctx)
+		return nil, authOpt.testingAuthHook(ctx)
 	}
 
 	sendError := func(err error) error {
@@ -89,17 +89,17 @@ func (c *conn) handleAuthentication(
 	)
 	if err != nil {
 		ac.Logf(ctx, "user retrieval failed for user=%q: %v", c.sessionArgs.User, err)
-		return sendError(err)
+		return nil, sendError(err)
 	}
 
 	if !exists {
 		ac.Logf(ctx, "user does not exist: %q", c.sessionArgs.User)
-		return sendError(errors.Errorf(security.ErrPasswordUserAuthFailed, c.sessionArgs.User))
+		return nil, sendError(errors.Errorf(security.ErrPasswordUserAuthFailed, c.sessionArgs.User))
 	}
 
 	if !canLogin {
 		ac.Logf(ctx, "%q does not have login privilege", c.sessionArgs.User)
-		return sendError(errors.Errorf(
+		return nil, sendError(errors.Errorf(
 			fmt.Sprintf("%s does not have login privilege", c.sessionArgs.User)))
 	}
 
@@ -107,7 +107,7 @@ func (c *conn) handleAuthentication(
 	tlsState, hbaEntry, methodFn, err := c.findAuthenticationMethod(authOpt)
 	if err != nil {
 		ac.Logf(ctx, "auth method lookup failed: %v", err)
-		return sendError(err)
+		return nil, sendError(err)
 	}
 	ac.Logf(ctx, "connection matches HBA rule: %s", hbaEntry.Input)
 
@@ -117,18 +117,18 @@ func (c *conn) handleAuthentication(
 
 	if err != nil {
 		ac.Logf(ctx, "authentication pre-hook failed: %v", err)
-		return sendError(err)
+		return nil, sendError(err)
 	}
-	if err := authenticationHook(c.sessionArgs.User, true /* public */); err != nil {
+	if connClose, err = authenticationHook(c.sessionArgs.User, true /* public */); err != nil {
 		ac.Logf(ctx, "authentication failed: %v", err)
-		return sendError(err)
+		return connClose, sendError(err)
 	}
 
 	ac.Logf(ctx, "authentication succeeded")
 
 	c.msgBuilder.initMsg(pgwirebase.ServerMsgAuth)
 	c.msgBuilder.putInt32(authOK)
-	return c.msgBuilder.finishMsg(c.conn)
+	return connClose, c.msgBuilder.finishMsg(c.conn)
 }
 
 func (c *conn) findAuthenticationMethod(

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -183,7 +183,7 @@ func authTrust(
 	_ *sql.ExecutorConfig,
 	_ *hba.Entry,
 ) (security.UserAuthHook, error) {
-	return func(_ string, _ bool) error { return nil }, nil
+	return func(_ string, _ bool) (func(), error) { return nil, nil }, nil
 }
 
 func authReject(
@@ -195,7 +195,7 @@ func authReject(
 	_ *sql.ExecutorConfig,
 	_ *hba.Entry,
 ) (security.UserAuthHook, error) {
-	return func(_ string, _ bool) error {
-		return errors.New("authentication rejected by configuration")
+	return func(_ string, _ bool) (func(), error) {
+		return nil, errors.New("authentication rejected by configuration")
 	}, nil
 }

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -524,6 +524,7 @@ func (c *conn) processCommandsAsync(
 		var retErr error
 		var connHandler sql.ConnectionHandler
 		var authOK bool
+		var connCloseAuthHandler func()
 		defer func() {
 			// Release resources, if we still own them.
 			if reservedOwned {
@@ -562,12 +563,15 @@ func (c *conn) processCommandsAsync(
 			if !authOK {
 				ac.AuthFail(retErr)
 			}
+			if connCloseAuthHandler != nil {
+				connCloseAuthHandler()
+			}
 			// Inform the connection goroutine of success or failure.
 			retCh <- retErr
 		}()
 
 		// Authenticate the connection.
-		if retErr = c.handleAuthentication(
+		if connCloseAuthHandler, retErr = c.handleAuthentication(
 			ctx, ac, authOpt, sqlServer.GetExecutorConfig(),
 		); retErr != nil {
 			// Auth failed or some other error.


### PR DESCRIPTION
On connection close, some auth methods may need to cleanup resources. Add
a callback for that.

This fixes a bug in the GSS auth method where replay cache file
descriptors were incorrectly kept open after connection close because
the context was not being deleted.

Release note (bug fix): stop leaking file descriptors during GSS
authentication.