### PR TITLE
roachtest: get bigger machines for alterpk-tpcc-250

### DIFF
--- a/pkg/cmd/roachtest/alterpk.go
+++ b/pkg/cmd/roachtest/alterpk.go
@@ -179,7 +179,7 @@ func registerAlterPK(r *testRegistry) {
 		// Use a 4 node cluster -- 3 nodes will run cockroach, and the last will be the
 		// workload driver node.
 		MinVersion: "v20.1.0",
-		Cluster:    makeClusterSpec(4, cpu(16)),
+		Cluster:    makeClusterSpec(4, cpu(32)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runAlterPKTPCC(ctx, t, c, 250 /* warehouses */, true /* expensiveChecks */)
 		},


### PR DESCRIPTION
The test has been failing for a while now because we're operating very
close to memory limit. Usually, 3.3.2.6 expensive check query ends up
crashing the node, sometimes it hits SQL memory limit. I've been staring
at it for a while, but there is a discrepancy between the memory usage
reported in runtime stats in logs and the usage that shows up in heap
profiles (for example, I could see 8GB in the former and 3GB in the
latter), and I couldn't figure out where that gaps goes. I don't think
spending any more time on this issue is worthwhile, so this commit bumps
the machine type from cpu-16 to cpu-32 which doubles available RAM from
14.4 to 28.8.

Fixes: #48428.

Release note: None