### PR TITLE
roachprod: disable over-eager assertion

### DIFF
--- a/pkg/cmd/roachprod/hosts.go
+++ b/pkg/cmd/roachprod/hosts.go
@@ -160,9 +160,13 @@ func loadClusters() error {
 			} else {
 				return newInvalidHostsLineErr(l)
 			}
-			if n == "" {
-				return newInvalidHostsLineErr(l)
-			}
+			// NB: it turns out we do see empty hosts here if we are concurrently
+			// creating clusters and this sync is picking up a cluster that's not
+			// ready yet. See:
+			// https://github.com/cockroachdb/cockroach/issues/49542#issuecomment-634563130
+			// if n == "" {
+			// 	return newInvalidHostsLineErr(l)
+			// }
 
 			var locality string
 			if len(fields) > 0 {


### PR DESCRIPTION
The assertion indeed found a problem, though one that appears unrelated
to the problem it was supposed to find. For now, we're better off
without the assertion.

See:
https://github.com/cockroachdb/cockroach/issues/49542#issuecomment-634563130.

Release note: None