### PR TITLE
sql: use SQLInstanceID in EXPLAIN instead of OptionalNodeIDErr

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -1,7 +1,3 @@
-# This and all the rename_* variants fail due to
-# https://github.com/cockroachdb/cockroach/issues/47900. Specifically, being
-# unable to access a node ID during EXPLAIN.
-# LogicTest: !3node-tenant
 statement ok
 CREATE TABLE users (
   uid    INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/rename_index
+++ b/pkg/sql/logictest/testdata/logic_test/rename_index
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 statement ok
 CREATE TABLE users (
   id    INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/values
+++ b/pkg/sql/logictest/testdata/logic_test/values
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 # Tests for the implicit one row, zero column values operator.
 query I
 SELECT 1


### PR DESCRIPTION
Tenants would previously not be able to run EXPLAIN because they wouldn't have
access to a NodeID. This is now fixed by using the SQLInstanceID instead, which
will provide an expected SQL-scoped identifier in a multi-tenant environment
and will translate to a NodeID in a single-tenant environment.

Release note: None (multitenancy-related change)

Closes #49072