### PR TITLE
settings: Bump minimum supported version to 20.1

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -511,7 +511,7 @@ var (
 	// to HEAD; if we were to set binaryMinSupportedVersion to Version19_2,
 	// that wouldn't work since you'd have to go through the final 19.2 binary
 	// before going to HEAD.
-	binaryMinSupportedVersion = VersionByKey(VersionStart19_2)
+	binaryMinSupportedVersion = VersionByKey(Version20_1)
 
 	// binaryVersion is the version of this binary.
 	//


### PR DESCRIPTION
Bump minimum supported version to 20.1 since work has
started on 20.2

Release notes: None