### PR TITLE
backupccl: all full cluster restore of backup with no user data

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -75,28 +75,6 @@ const (
 	localFoo                    = "nodelocal://0/foo"
 )
 
-func backupRestoreTestSetupEmptyWithParams(
-	t testing.TB,
-	clusterSize int,
-	dir string,
-	init func(tc *testcluster.TestCluster),
-	params base.TestClusterArgs,
-) (ctx context.Context, tc *testcluster.TestCluster, sqlDB *sqlutils.SQLRunner, cleanup func()) {
-	ctx = context.Background()
-
-	params.ServerArgs.ExternalIODir = dir
-	tc = testcluster.StartTestCluster(t, clusterSize, params)
-	init(tc)
-
-	sqlDB = sqlutils.MakeSQLRunner(tc.Conns[0])
-
-	cleanupFn := func() {
-		tc.Stopper().Stop(context.Background()) // cleans up in memory storage's auxiliary dirs
-	}
-
-	return ctx, tc, sqlDB, cleanupFn
-}
-
 func backupRestoreTestSetupWithParams(
 	t testing.TB,
 	clusterSize int,
@@ -137,8 +115,8 @@ func backupRestoreTestSetupWithParams(
 	}
 
 	cleanupFn := func() {
-		tc.Stopper().Stop(context.Background()) // cleans up in memory storage's auxiliary dirs
-		dirCleanupFn()                          // cleans up dir, which is the nodelocal:// storage
+		tc.Stopper().Stop(ctx) // cleans up in memory storage's auxiliary dirs
+		dirCleanupFn()         // cleans up dir, which is the nodelocal:// storage
 	}
 
 	return ctx, tc, sqlDB, dir, cleanupFn

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -889,15 +889,15 @@ func createImportingTables(
 			}
 		}
 	}
-	var tempSystemDBID sqlbase.ID
+	tempSystemDBID := keys.MinNonPredefinedUserDescID
 	for id := range details.TableRewrites {
-		if uint32(id) > uint32(tempSystemDBID) {
-			tempSystemDBID = id
+		if int(id) > tempSystemDBID {
+			tempSystemDBID = int(id)
 		}
 	}
 	if details.DescriptorCoverage == tree.AllDescriptors {
 		databases = append(databases, &sqlbase.DatabaseDescriptor{
-			ID:         tempSystemDBID,
+			ID:         sqlbase.ID(tempSystemDBID),
 			Name:       restoreTempSystemDB,
 			Privileges: sqlbase.NewDefaultPrivilegeDescriptor(),
 		})

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -155,7 +155,7 @@ func allocateTableRewrites(
 
 	// Fail fast if the tables to restore are incompatible with the specified
 	// options.
-	maxDescIDInBackup := int64(0)
+	maxDescIDInBackup := int64(keys.MinNonPredefinedUserDescID)
 	for _, table := range tablesByID {
 		if int64(table.ID) > maxDescIDInBackup {
 			maxDescIDInBackup = int64(table.ID)


### PR DESCRIPTION
This commit fixes a bug in which full cluster restore assumed that a
full cluster backup had at least one user database/table to restore.

Fixes #49573.

Release note (bug fix): Previously, if one attempted to perform a full
cluster RESTORE on a backup that did not contain any user data it would
fail.