### PR TITLE
ui: Error message for non-table data on Databases page

### DIFF
--- a/pkg/ui/src/views/databases/containers/databases/nonTableSummary.spec.tsx
+++ b/pkg/ui/src/views/databases/containers/databases/nonTableSummary.spec.tsx
@@ -1,0 +1,72 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { shallow } from "enzyme";
+import { noop } from "lodash";
+import { assert } from "chai";
+import Long from "long";
+
+import "src/enzymeInit";
+import { NonTableSummary } from "./nonTableSummary";
+import { refreshNonTableStats } from "src/redux/apiReducers";
+import { cockroach } from "src/js/protos";
+import Loading from "src/views/shared/components/loading";
+import NonTableStatsResponse = cockroach.server.serverpb.NonTableStatsResponse;
+
+describe("NonTableSummary", () => {
+  describe("Loading data", () => {
+    it("successfully loads data", () => {
+      const tableStatsData = new NonTableStatsResponse({
+        internal_use_stats: {
+          approximate_disk_bytes: Long.fromNumber(1),
+          missing_nodes: [],
+          node_count: Long.fromNumber(1),
+          range_count: Long.fromNumber(1),
+          replica_count: Long.fromNumber(1),
+          stats: null,
+        },
+        time_series_stats: {
+          approximate_disk_bytes: Long.fromNumber(1),
+          missing_nodes: [],
+          node_count: Long.fromNumber(1),
+          range_count: Long.fromNumber(1),
+          replica_count: Long.fromNumber(1),
+          stats: null,
+        },
+      });
+      const wrapper = shallow(<NonTableSummary
+        nonTableStats={tableStatsData}
+        nonTableStatsValid={true}
+        refreshNonTableStats={noop as typeof refreshNonTableStats}
+        lastError={undefined} />);
+      const loadingWrapper = wrapper.find(Loading).dive();
+      assert.isTrue(loadingWrapper.find(".database-summary-table").exists());
+    });
+
+    it("shows error message when failed request", () => {
+      const error = {
+        name: "Forbidden",
+        message: "Insufficient privileges to view this resource",
+      };
+      const wrapper = shallow(<NonTableSummary
+        nonTableStats={null}
+        nonTableStatsValid={true}
+        refreshNonTableStats={noop as typeof refreshNonTableStats}
+        lastError={error} />);
+
+      const loadingWrapper = wrapper.find(Loading).dive();
+      assert.isTrue(loadingWrapper.exists());
+
+      const errorText = loadingWrapper.find("li > b").at(0).text();
+      assert.equal(errorText, error.message);
+    });
+  });
+});

--- a/pkg/ui/src/views/databases/containers/databases/nonTableSummary.tsx
+++ b/pkg/ui/src/views/databases/containers/databases/nonTableSummary.tsx
@@ -15,6 +15,9 @@ import { refreshNonTableStats } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import { FixLong } from "src/util/fixLong";
 import { Bytes } from "src/util/format";
+import Loading from "src/views/shared/components/loading";
+import { CachedDataReducerState } from "src/redux/cachedDataReducer";
+import { NonTableStatsResponseMessage } from "src/util/api";
 
 interface TimeSeriesSummaryProps {
   nonTableStats: protos.cockroach.server.serverpb.NonTableStatsResponse;
@@ -22,11 +25,12 @@ interface TimeSeriesSummaryProps {
   // information.
   nonTableStatsValid: boolean;
   refreshNonTableStats: typeof refreshNonTableStats;
+  lastError: CachedDataReducerState<NonTableStatsResponseMessage>["lastError"];
 }
 
 // NonTableSummary displays a summary section describing the current data
 // usage of the time series system.
-class NonTableSummary extends React.Component<TimeSeriesSummaryProps> {
+export class NonTableSummary extends React.Component<TimeSeriesSummaryProps> {
   componentDidMount() {
     // Refresh nodes status query when mounting.
     this.props.refreshNonTableStats();
@@ -38,7 +42,7 @@ class NonTableSummary extends React.Component<TimeSeriesSummaryProps> {
     this.props.refreshNonTableStats();
   }
 
-  renderTable() {
+  renderTable = () => {
     return (
       <div className="database-summary-table sql-table">
         <table className="sort-table">
@@ -85,7 +89,6 @@ class NonTableSummary extends React.Component<TimeSeriesSummaryProps> {
   }
 
   render() {
-    const hasData = this.props.nonTableStats != null;
     return (
       <div className="database-summary">
         <div className="database-summary-title">
@@ -93,7 +96,11 @@ class NonTableSummary extends React.Component<TimeSeriesSummaryProps> {
         </div>
         <div className="l-columns">
           <div className="l-columns__left">
-            { hasData ? this.renderTable() : "loading..." }
+            <Loading
+              loading={!this.props.nonTableStats}
+              error={this.props.lastError}
+              render={this.renderTable}
+            />
           </div>
           <div className="l-columns__right" />
         </div>
@@ -110,6 +117,7 @@ const mapStateToProps = (state: AdminUIState) => {
   return {
     nonTableStats: ntStats && ntStats.data,
     nonTableStatsValid: ntStats && ntStats.valid,
+    lastError: ntStats && ntStats.lastError,
   };
 };
 


### PR DESCRIPTION
Resolves one part of issue #48152

Previously, error messages received on request for
non-table data on Databases page is not handled and not
displayed for users.

Now, default error message is shown in response to errors.

Release note (admin ui change): Show default error message
about restricted permissions for non-admin users on
Databases page.

Test cases to validate correct behavior:
- Databases page loads table info for a user with `admin` role
- Databases page shows the default error message with `insufficient rights` message for non-admin user.
- The loading indicator is displayed while response is not received.

Before
<img width="997" alt="before" src="https://user-images.githubusercontent.com/3106437/83411207-70681700-a420-11ea-96d8-7664d91297aa.png">

After
<img width="1133" alt="after" src="https://user-images.githubusercontent.com/3106437/83411218-75c56180-a420-11ea-9fe5-766338e815ba.png">
