### PR TITLE
[DNM] pgwire: trim statements past the conn executor's rewind pos eagerly

### DIFF
--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -835,13 +835,23 @@ func TestTrimFlushedStatements(t *testing.T) {
 
 					// Set stmtBufMaxLen once.
 					l := buf.Len()
+					set := false
 					if stmtBufMaxLen == -1 {
 						stmtBufMaxLen = l
+						set = true
 					}
 
 					// Verify that the buffer doesn't grow.
+					failed := false
 					if l > stmtBufMaxLen {
 						stmtBufLenOnFailure = l
+						failed = true
+					}
+					if set {
+						t.Log("set stmtBufMaxLen to", stmtBufMaxLen, cmd.String())
+					}
+					if failed {
+						t.Log("failed length check length was", stmtBufLenOnFailure, cmd.String())
 					}
 				},
 			},

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -549,6 +549,13 @@ func (buf *StmtBuf) Rewind(ctx context.Context, pos CmdPos) {
 	buf.mu.curPos = pos
 }
 
+// Len returns the buffer's length.
+func (buf *StmtBuf) Len() int {
+	buf.mu.Lock()
+	defer buf.mu.Unlock()
+	return buf.mu.data.Len()
+}
+
 // RowDescOpt specifies whether a result needs a row description message.
 type RowDescOpt bool
 
@@ -836,6 +843,11 @@ type rewindCapability struct {
 func (rc *rewindCapability) rewindAndUnlock(ctx context.Context) {
 	rc.cl.RTrim(ctx, rc.rewindPos)
 	rc.buf.Rewind(ctx, rc.rewindPos)
+	rc.cl.Close()
+}
+
+// close closes the underlying ClientLock.
+func (rc *rewindCapability) close() {
 	rc.cl.Close()
 }
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -724,6 +724,9 @@ type ExecutorTestingKnobs struct {
 	// statement.
 	AfterExecute func(ctx context.Context, stmt string, err error)
 
+	// AfterExecCmd is called after successful execution of any command.
+	AfterExecCmd func(ctx context.Context, cmd Command, buf *StmtBuf)
+
 	// DisableAutoCommit, if set, disables the auto-commit functionality of some
 	// SQL statements. That functionality allows some statements to commit
 	// directly when they're executed in an implicit SQL txn, without waiting for


### PR DESCRIPTION
DNM, trying to debug a failure that only seems to happen on CI