### PR TITLE
builtins: add missing UnwrapDatum call and change panics to error

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -14,3 +14,7 @@ query O
 SELECT pg_my_temp_schema()
 ----
 0
+
+# Regression test for #49072.
+statement ok
+SELECT has_table_privilege('root'::NAME, 0, 'select')


### PR DESCRIPTION
getNameForArg does not handle tree.DOidWrappers. The assumption in this code is
that the datum gets unwrapped before calling this code. This commit adds a
missing UnwrapDatum call and changes an unhandled type panic to an error
instead.

Release note (bug fix): a panic observed as "unexpected arg type
tree.DOidWrapper" has been fixed.

Closes #43166