### PR TITLE
storage: use pebble/vfs semantics in FS

### DIFF
--- a/pkg/kv/kvserver/replica_sideload_disk.go
+++ b/pkg/kv/kvserver/replica_sideload_disk.go
@@ -208,11 +208,9 @@ func (ss *diskSideloadStorage) purgeFile(ctx context.Context, filename string) (
 
 // Clear implements SideloadStorage.
 func (ss *diskSideloadStorage) Clear(_ context.Context) error {
-	err := ss.eng.RemoveDirAndFiles(ss.dir)
-	if os.IsNotExist(err) {
-		ss.dirCreated = false
-		return nil
-	}
+	// TODO(jackson): Update this and the rest of `os.` filesystem calls in
+	// this impl to use ss.eng.
+	err := os.RemoveAll(ss.dir)
 	ss.dirCreated = ss.dirCreated && err != nil
 	return err
 }

--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -413,7 +413,7 @@ func (d *diskQueue) Close(ctx context.Context) error {
 	if err := d.CloseRead(); err != nil {
 		return err
 	}
-	if err := d.cfg.FS.RemoveDirAndFiles(filepath.Join(d.cfg.Path, d.dirName)); err != nil {
+	if err := d.cfg.FS.RemoveAll(filepath.Join(d.cfg.Path, d.dirName)); err != nil {
 		return err
 	}
 	totalSize := int64(0)

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1318,11 +1318,13 @@ func TestEngineFS(t *testing.T) {
 	}
 }
 
-// These FS implementations are not in-memory.
-var engineRealFSImpls = []struct {
+type engineImpl struct {
 	name   string
 	create func(*testing.T, string) Engine
-}{
+}
+
+// These FS implementations are not in-memory.
+var engineRealFSImpls = []engineImpl{
 	{"rocksdb", func(t *testing.T, dir string) Engine {
 		db, err := NewRocksDB(
 			RocksDBConfig{
@@ -1375,9 +1377,9 @@ func TestEngineFSFileNotFoundError(t *testing.T) {
 				t.Fatalf("expected IsNotExist, but got %v (%T)", err, err)
 			}
 
-			// Verify RemoveDirAndFiles returns os.ErrNotExist if dir does not exist.
-			if err := db.RemoveDirAndFiles("/non/existent/file"); !os.IsNotExist(err) {
-				t.Fatalf("expected IsNotExist, but got %v (%T)", err, err)
+			// Verify RemoveAll returns nil if path does not exist.
+			if err := db.RemoveAll("/non/existent/file"); err != nil {
+				t.Fatalf("expected nil, but got %v (%T)", err, err)
 			}
 
 			fname := filepath.Join(dir, "random.file")
@@ -1416,6 +1418,81 @@ func TestEngineFSFileNotFoundError(t *testing.T) {
 			if err := db.Remove(fname); !os.IsNotExist(err) {
 				t.Fatalf("expected IsNotExist, but got %v (%T)", err, err)
 			}
+		})
+	}
+}
+
+func TestFS(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var engineImpls []engineImpl
+	engineImpls = append(engineImpls, engineRealFSImpls...)
+	engineImpls = append(engineImpls,
+		engineImpl{
+			name: "rocksdb_mem",
+			create: func(_ *testing.T, _ string) Engine {
+				return createTestRocksDBEngine()
+			},
+		},
+		engineImpl{
+			name: "pebble_mem",
+			create: func(_ *testing.T, _ string) Engine {
+				return createTestPebbleEngine()
+			},
+		})
+
+	for _, impl := range engineImpls {
+		t.Run(impl.name, func(t *testing.T) {
+			dir, cleanupDir := testutils.TempDir(t)
+			defer cleanupDir()
+			fs := impl.create(t, dir)
+			defer fs.Close()
+
+			path := func(rel string) string {
+				return filepath.Join(dir, rel)
+			}
+			expectLS := func(dir string, want []string) {
+				t.Helper()
+
+				got, err := fs.List(dir)
+				require.NoError(t, err)
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("fs.List(%q) = %#v, want %#v", dir, got, want)
+				}
+			}
+
+			// Create a/ and assert that it's empty.
+			require.NoError(t, fs.MkdirAll(path("a")))
+			expectLS(path("a"), []string{})
+
+			// Create a/b/ and a/b/c/ in a single MkdirAll call.
+			// Then ensure that a duplicate call returns a nil error.
+			require.NoError(t, fs.MkdirAll(path("a/b/c")))
+			require.NoError(t, fs.MkdirAll(path("a/b/c")))
+			expectLS(path("a"), []string{"b"})
+			expectLS(path("a/b"), []string{"c"})
+			expectLS(path("a/b/c"), []string{})
+
+			// Create a file at a/b/c/foo.
+			f, err := fs.Create(path("a/b/c/foo"))
+			require.NoError(t, err)
+			require.NoError(t, f.Close())
+			expectLS(path("a/b/c"), []string{"foo"})
+
+			// Create a file at a/b/c/bar.
+			f, err = fs.Create(path("a/b/c/bar"))
+			require.NoError(t, err)
+			require.NoError(t, f.Close())
+			expectLS(path("a/b/c"), []string{"bar", "foo"})
+
+			// RemoveAll a file.
+			require.NoError(t, fs.RemoveAll(path("a/b/c/bar")))
+			expectLS(path("a/b/c"), []string{"foo"})
+
+			// RemoveAll a directory that contains subdirectories and
+			// descendant files.
+			require.NoError(t, fs.RemoveAll(path("a/b")))
+			expectLS(path("a"), []string{})
 		})
 	}
 }

--- a/pkg/storage/fs/fs.go
+++ b/pkg/storage/fs/fs.go
@@ -59,10 +59,8 @@ type FS interface {
 	// RemoveDir removes the named dir.
 	RemoveDir(name string) error
 
-	// RemoveDirAndFiles deletes the directory and any files it contains but
-	// not subdirectories. If dir does not exist, RemoveDirAndFiles returns nil
-	// (no error).
-	RemoveDirAndFiles(dir string) error
+	// RemoveAll deletes the path and any children it contains.
+	RemoveAll(dir string) error
 
 	// List returns a listing of the given directory. The names returned are
 	// relative to the directory.

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -984,15 +984,8 @@ func (p *Pebble) Remove(filename string) error {
 	return p.fs.Remove(filename)
 }
 
-// RemoveDirAndFiles implements the Engine interface.
-func (p *Pebble) RemoveDirAndFiles(dir string) error {
-	// NB RemoveAll does not return an error if dir does not exist, but we want
-	// RemoveDirAndFiles to return an error in that case to match the RocksDB
-	// behavior.
-	_, err := p.fs.Stat(dir)
-	if err != nil {
-		return err
-	}
+// RemoveAll implements the Engine interface.
+func (p *Pebble) RemoveAll(dir string) error {
 	return p.fs.RemoveAll(dir)
 }
 
@@ -1060,7 +1053,9 @@ func (p *Pebble) RemoveDir(name string) error {
 
 // List implements the FS interface.
 func (p *Pebble) List(name string) ([]string, error) {
-	return p.fs.List(name)
+	dirents, err := p.fs.List(name)
+	sort.Strings(dirents)
+	return dirents, err
 }
 
 // CreateCheckpoint implements the Engine interface.

--- a/pkg/storage/tee.go
+++ b/pkg/storage/tee.go
@@ -508,14 +508,14 @@ func (t *TeeEngine) Remove(filename string) error {
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 
-// RemoveDirAndFiles implements the Engine interface.
-func (t *TeeEngine) RemoveDirAndFiles(dir string) error {
-	err := t.eng1.RemoveDirAndFiles(dir)
+// RemoveAll implements the Engine interface.
+func (t *TeeEngine) RemoveAll(dir string) error {
+	err := t.eng1.RemoveAll(dir)
 	dir2, ok := t.remapPath(dir)
 	if !ok {
 		return err
 	}
-	err2 := t.eng2.RemoveDirAndFiles(dir2)
+	err2 := t.eng2.RemoveAll(dir2)
 	return fatalOnErrorMismatch(t.ctx, err, err2)
 }
 


### PR DESCRIPTION
Adapt the FS interface to expose semantics more aligned with the
pebble/vfs.FS interface, adapting the RocksDB engine to implement the
same semantics in both in-memory and on-disk envs.

Some of the specific changes:

* Replace RemoveDirAndFiles with RemoveAll which removes all descendants
of a path (both subdirectories and files) and does not error if the path
does not exist.
* Adapt the RocksDB MkdirAll implementation to actually create parent
directories and to not error if the directory already exists.
* Remove '.' and '..' directory entries from the RocksDB on-disk List
output.

In a follow up, we'll be able to use the now consistent MkdirAll and
RemoveAll to create the auxiliary directory in the same filesystem
(in-mem or otherwise) used by the store.

Fixes #45098.

Release note: none