### PR TITLE
util/tracing: comment trace serialization

### DIFF
--- a/pkg/util/tracing/recorded_span.go
+++ b/pkg/util/tracing/recorded_span.go
@@ -13,6 +13,7 @@ package tracing
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 // LogMessageField is the field name used for the opentracing.Span.LogFields()
@@ -21,9 +22,9 @@ const LogMessageField = "event"
 
 func (s *RecordedSpan) String() string {
 	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprintf("=== %s (id: %d parent: %d)\n", s.Operation, s.SpanID, s.ParentSpanID))
 	for _, ev := range s.Logs {
-		sb.WriteString(ev.String())
-		sb.WriteRune('\n')
+		sb.WriteString(fmt.Sprintf("%s %s\n", ev.Time.UTC().Format(time.RFC3339Nano), ev.Msg()))
 	}
 	return sb.String()
 }

--- a/pkg/util/tracing/tracer_span.go
+++ b/pkg/util/tracing/tracer_span.go
@@ -275,8 +275,13 @@ type traceLogData struct {
 
 // String formats the given spans for human consumption, showing the
 // relationship using nesting and times as both relative to the previous event
-// and cumulative. The order in which log lines are displayed is similar to the
-// one in generateSessionTraceVTable().
+// and cumulative. Logs from the same span are kept together, before logs from
+// children spans. Each log line show the time since the beginning of the trace
+// and since the previous log line. Span starts are shown with special "===
+// <operation>" lines. For a span start, the time since the relative log line
+// can be negative when the span start follows a message from the parent that
+// was generated after the child span started (or even after the child
+// finished).
 //
 // TODO(andrei): this should be unified with
 // SessionTracing.GenerateSessionTraceVTable.
@@ -325,6 +330,9 @@ func (r Recording) FindLogMessage(pattern string) (string, bool) {
 }
 
 // visitSpan returns the log messages for sp, and all of sp's children.
+//
+// All messages from a span are kept together. Sibling spans are ordered within
+// the parent in their start order.
 func (r Recording) visitSpan(sp RecordedSpan, depth int) []traceLogData {
 	ownLogs := make([]traceLogData, 0, len(sp.Logs)+1)
 


### PR DESCRIPTION
Explain the surprising ordering of log messages versus child spans.

Release note: None