### PR TITLE
sql: use `DatumAlloc` to allocate `DEnum`s when necessary

### DIFF
--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -363,8 +363,11 @@ func DecodeTableKey(
 		if err != nil {
 			return nil, nil, err
 		}
-		enum, err := tree.MakeDEnumFromPhysicalRepresentation(valType, r)
-		return enum, rkey, err
+		phys, log, err := tree.GetEnumComponentsFromPhysicalRep(valType, r)
+		if err != nil {
+			return nil, nil, err
+		}
+		return a.NewDEnum(tree.DEnum{EnumTyp: valType, PhysicalRep: phys, LogicalRep: log}), rkey, nil
 	default:
 		return nil, nil, errors.Errorf("unable to decode table key: %s", valType)
 	}
@@ -595,8 +598,11 @@ func DecodeUntaggedDatum(a *DatumAlloc, t *types.T, buf []byte) (tree.Datum, []b
 		if err != nil {
 			return nil, b, err
 		}
-		enum, err := tree.MakeDEnumFromPhysicalRepresentation(t, data)
-		return enum, b, err
+		phys, log, err := tree.GetEnumComponentsFromPhysicalRep(t, data)
+		if err != nil {
+			return nil, nil, err
+		}
+		return a.NewDEnum(tree.DEnum{EnumTyp: t, PhysicalRep: phys, LogicalRep: log}), b, nil
 	default:
 		return nil, buf, errors.Errorf("couldn't decode type %s", t)
 	}
@@ -916,7 +922,11 @@ func UnmarshalColumnValue(a *DatumAlloc, typ *types.T, value roachpb.Value) (tre
 		if err != nil {
 			return nil, err
 		}
-		return tree.MakeDEnumFromPhysicalRepresentation(typ, v)
+		phys, log, err := tree.GetEnumComponentsFromPhysicalRep(typ, v)
+		if err != nil {
+			return nil, err
+		}
+		return a.NewDEnum(tree.DEnum{EnumTyp: typ, PhysicalRep: phys, LogicalRep: log}), nil
 	default:
 		return nil, errors.Errorf("unsupported column type: %s", typ.Family())
 	}

--- a/pkg/sql/sqlbase/datum_alloc.go
+++ b/pkg/sql/sqlbase/datum_alloc.go
@@ -29,6 +29,7 @@ type DatumAlloc struct {
 	dbitArrayAlloc    []tree.DBitArray
 	ddecimalAlloc     []tree.DDecimal
 	ddateAlloc        []tree.DDate
+	denumAlloc        []tree.DEnum
 	dgeometryAlloc    []tree.DGeometry
 	dgeographyAlloc   []tree.DGeography
 	dtimeAlloc        []tree.DTime
@@ -145,6 +146,18 @@ func (a *DatumAlloc) NewDDate(v tree.DDate) *tree.DDate {
 	buf := &a.ddateAlloc
 	if len(*buf) == 0 {
 		*buf = make([]tree.DDate, datumAllocSize)
+	}
+	r := &(*buf)[0]
+	*r = v
+	*buf = (*buf)[1:]
+	return r
+}
+
+// NewDEnum allocates a DEnum.
+func (a *DatumAlloc) NewDEnum(v tree.DEnum) *tree.DEnum {
+	buf := &a.denumAlloc
+	if len(*buf) == 0 {
+		*buf = make([]tree.DEnum, datumAllocSize)
 	}
 	r := &(*buf)[0]
 	*r = v


### PR DESCRIPTION
Fixes #49427.

Release note: None