### PR TITLE
searchpath: add pg_extension to searchpath.Iter() before public

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1565,7 +1565,7 @@ SELECT foo.* IS NOT TRUE FROM (VALUES (1)) AS foo(x)
 query T
 SELECT current_schemas(true)
 ----
-{pg_catalog,public}
+{pg_catalog,pg_extension,public}
 
 query T
 SELECT current_schemas(false)
@@ -1577,7 +1577,7 @@ SELECT current_schemas(false)
 query T
 SELECT current_schemas(x) FROM (VALUES (true), (false)) AS t(x);
 ----
-{pg_catalog,public}
+{pg_catalog,pg_extension,public}
 {public}
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -1312,6 +1312,18 @@ SELECT * FROM pg_extension.geometry_columns WHERE f_table_name = 'pg_extension_t
 test  public  pg_extension_test  b  2  3857  LINESTRING
 test  public  pg_extension_test  c  2  0     GEOMETRY
 
+query TTTTIIT rowsort
+SELECT * FROM geography_columns WHERE f_table_name = 'pg_extension_test'
+----
+test  public  pg_extension_test  a  2     4326  POINT
+test  public  pg_extension_test  d  NULL  0     GEOMETRY
+
+query TTTTIIT rowsort
+SELECT * FROM geometry_columns WHERE f_table_name = 'pg_extension_test'
+----
+test  public  pg_extension_test  b  2  3857  LINESTRING
+test  public  pg_extension_test  c  2  0     GEOMETRY
+
 statement error not yet implemented
 SELECT * FROM pg_extension.spatial_ref_sys ORDER BY srid ASC
 

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -113,7 +113,7 @@ func classifyColumnItem(n *UnresolvedName) (VarName, error) {
 const (
 	// PublicSchema is the name of the physical schema in every
 	// database/catalog.
-	PublicSchema string = "public"
+	PublicSchema string = sessiondata.PublicSchemaName
 	// PublicSchemaName is the same, typed as Name.
 	PublicSchemaName Name = Name(PublicSchema)
 )

--- a/pkg/sql/sessiondata/search_path_test.go
+++ b/pkg/sql/sessiondata/search_path_test.go
@@ -79,6 +79,20 @@ func TestImpliedSearchPath(t *testing.T) {
 			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`, `foobar`},
 			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`foobar`},
 		},
+		{
+			explicitSearchPath:                                             []string{`public`},
+			expectedSearchPath:                                             []string{`pg_catalog`, `pg_extension`, `public`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`public`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`, `pg_extension`, `public`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`public`},
+		},
+		{
+			explicitSearchPath:                                             []string{`public`, `pg_extension`},
+			expectedSearchPath:                                             []string{`pg_catalog`, `public`, `pg_extension`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`public`, `pg_extension`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`, `public`, `pg_extension`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`public`, `pg_extension`},
+		},
 	}
 
 	for tcNum, tc := range testCases {


### PR DESCRIPTION
Release note (sql change): When doing name resolution via search path,
the `pg_extension` schema (containing tables such as `geometry_columns`,
`geography_columns` and `spatial_ref_sys`) will have an attempted
resolution before the `public` schema. This mimics PostGIS behavior
where the aforementioned tables are in the public schema, and so
by default are discoverable tables with a new CLI session.