### PR TITLE
sql: introduce `{Imm,M}utableTypeDescriptor` and plumbing

### DIFF
--- a/pkg/sql/catalog/catalogkv/physical_accessor.go
+++ b/pkg/sql/catalog/catalogkv/physical_accessor.go
@@ -235,7 +235,10 @@ func (a UncachedPhysicalAccessor) GetObjectDesc(
 		}
 		return nil, nil
 	case *sqlbase.TypeDescriptor:
-		return desc, nil
+		if flags.RequireMutable {
+			return sqlbase.NewMutableExistingTypeDescriptor(*desc), nil
+		}
+		return sqlbase.NewImmutableTypeDescriptor(*desc), nil
 	default:
 		return nil, nil
 	}

--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -151,7 +151,10 @@ func ResolveExistingObject(
 		if obj.TypeDesc() == nil {
 			return nil, prefix, sqlbase.NewUndefinedTypeError(&resolvedTn)
 		}
-		return obj.TypeDesc(), prefix, nil
+		if lookupFlags.RequireMutable {
+			return obj.(*sqlbase.MutableTypeDescriptor), prefix, nil
+		}
+		return obj.(*sqlbase.ImmutableTypeDescriptor), prefix, nil
 	case tree.TableObject:
 		if obj.TableDesc() == nil {
 			return nil, prefix, sqlbase.NewUndefinedRelationError(&resolvedTn)

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -138,6 +138,7 @@ func (p *planner) ResolveType(name *tree.UnresolvedObjectName) (*types.T, error)
 	lookupFlags := tree.ObjectLookupFlags{
 		CommonLookupFlags: tree.CommonLookupFlags{Required: true},
 		DesiredObjectKind: tree.TypeObject,
+		RequireMutable:    false,
 	}
 	// TODO (rohany): The ResolveAnyDescType argument doesn't do anything here
 	//  if we are looking for a type. This should be cleaned up.
@@ -146,7 +147,7 @@ func (p *planner) ResolveType(name *tree.UnresolvedObjectName) (*types.T, error)
 		return nil, err
 	}
 	tn := tree.MakeTypeNameFromPrefix(prefix, tree.Name(name.Object()))
-	tdesc := desc.(*sqlbase.TypeDescriptor)
+	tdesc := desc.(*sqlbase.ImmutableTypeDescriptor)
 	// Hydrate the types.T from the resolved descriptor. Once we cache
 	// descriptors, this hydration should install pointers to cached data.
 	switch t := tdesc.Kind; t {

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -4309,6 +4309,45 @@ func (desc *ImmutableTableDescriptor) TypeDesc() *TypeDescriptor {
 	return nil
 }
 
+// MutableTypeDescriptor is a custom type for TypeDescriptors undergoing
+// any types of modifications.
+type MutableTypeDescriptor struct {
+	TypeDescriptor
+
+	// ClusterVersion represents the version of the type descriptor read
+	// from the store.
+	ClusterVersion TypeDescriptor
+}
+
+// ImmutableTypeDescriptor is a custom type for wrapping TypeDescriptors
+// when used in a read only way.
+type ImmutableTypeDescriptor struct {
+	TypeDescriptor
+}
+
+// Avoid linter unused warnings.
+var _ = NewMutableCreatedTypeDescriptor
+
+// NewMutableCreatedTypeDescriptor returns a MutableTypeDescriptor from the
+// given type descriptor with the cluster version being the zero type. This
+// is for a type that is created in the same transaction.
+func NewMutableCreatedTypeDescriptor(desc TypeDescriptor) *MutableTypeDescriptor {
+	return &MutableTypeDescriptor{TypeDescriptor: desc}
+}
+
+// NewMutableExistingTypeDescriptor returns a MutableTypeDescriptor from the
+// given type descriptor with the cluster version also set to the descriptor.
+// This is for types that already exist.
+func NewMutableExistingTypeDescriptor(desc TypeDescriptor) *MutableTypeDescriptor {
+	return &MutableTypeDescriptor{TypeDescriptor: desc, ClusterVersion: desc}
+}
+
+// NewImmutableTypeDescriptor returns an ImmutableTypeDescriptor from the
+// given TypeDescriptor.
+func NewImmutableTypeDescriptor(desc TypeDescriptor) *ImmutableTypeDescriptor {
+	return &ImmutableTypeDescriptor{TypeDescriptor: desc}
+}
+
 // DatabaseDesc implements the ObjectDescriptor interface.
 func (desc *TypeDescriptor) DatabaseDesc() *DatabaseDescriptor {
 	return nil


### PR DESCRIPTION
This PR introduces the `ImmutableTypeDescriptor` and
`MutableTypeDescriptor` types, and plumbs them through to existing
usages. Once more descriptor refactoring completes, only operations on
`TypeDescriptor`s through these wrapper structs will be allowed.

Release note: None