### PR TITLE
release-20.1: sql: populate rolcanlogin correctly in vtables pg_roles and pg_catalog

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1744,12 +1744,28 @@ func forEachColumnInIndex(
 }
 
 func forEachRole(
-	ctx context.Context, p *planner, fn func(username string, isRole bool) error,
+	ctx context.Context, p *planner, fn func(username string, isRole bool, noLogin bool) error,
 ) error {
-	query := `SELECT username, "isRole" FROM system.users`
+	query := `
+SELECT
+	username,
+	"isRole",
+	EXISTS(
+		SELECT
+			option
+		FROM
+			system.role_options AS r
+		WHERE
+			r.username = u.username AND option = 'NOLOGIN'
+	)
+		AS nologin
+FROM
+	system.users AS u;
+`
 	rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.Query(
 		ctx, "read-roles", p.txn, query,
 	)
+
 	if err != nil {
 		return err
 	}
@@ -1760,11 +1776,15 @@ func forEachRole(
 		if !ok {
 			return errors.Errorf("isRole should be a boolean value, found %s instead", row[1].ResolvedType())
 		}
-
-		if err := fn(string(username), bool(*isRole)); err != nil {
+		noLogin, ok := row[2].(*tree.DBool)
+		if !ok {
+			return errors.Errorf("noLogin should be a boolean value, found %s instead", row[1].ResolvedType())
+		}
+		if err := fn(string(username), bool(*isRole), bool(*noLogin)); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1404,7 +1404,7 @@ FROM pg_catalog.pg_roles
 ORDER BY rolname
 ----
 oid         rolname   rolsuper  rolinherit  rolcreaterole  rolcreatedb  rolcatupdate  rolcanlogin  rolreplication
-2310524507  admin     true      true        true           true         false         false        false
+2310524507  admin     true      true        true           true         false         true         false
 1546506610  root      true      false       true           true         false         true         false
 2264919399  testuser  false     false       false          false        false         true         false
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -540,9 +540,10 @@ CREATE TABLE pg_catalog.pg_authid (
 )`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
-		return forEachRole(ctx, p, func(username string, isRole bool) error {
+		return forEachRole(ctx, p, func(username string, isRole bool, noLogin bool) error {
 			isRoot := tree.DBool(username == security.RootUser || username == sqlbase.AdminRole)
 			isRoleDBool := tree.DBool(isRole)
+			roleCanLogin := tree.DBool(!noLogin)
 			return addRow(
 				h.UserOid(username),          // oid
 				tree.NewDName(username),      // rolname
@@ -550,7 +551,7 @@ CREATE TABLE pg_catalog.pg_authid (
 				tree.MakeDBool(isRoleDBool),  // rolinherit. Roles inherit by default.
 				tree.MakeDBool(isRoot),       // rolcreaterole
 				tree.MakeDBool(isRoot),       // rolcreatedb
-				tree.MakeDBool(!isRoleDBool), // rolcanlogin. Only users can login.
+				tree.MakeDBool(roleCanLogin), // rolcanlogin.
 				tree.DBoolFalse,              // rolreplication
 				tree.DBoolFalse,              // rolbypassrls
 				negOneVal,                    // rolconnlimit
@@ -2148,9 +2149,10 @@ CREATE TABLE pg_catalog.pg_roles (
 		// include sensitive information such as password hashes.
 		h := makeOidHasher()
 		return forEachRole(ctx, p,
-			func(username string, isRole bool) error {
+			func(username string, isRole bool, noLogin bool) error {
 				isRoot := tree.DBool(username == security.RootUser || username == sqlbase.AdminRole)
 				isRoleDBool := tree.DBool(isRole)
+				roleCanLogin := tree.DBool(!noLogin)
 				return addRow(
 					h.UserOid(username),          // oid
 					tree.NewDName(username),      // rolname
@@ -2159,7 +2161,7 @@ CREATE TABLE pg_catalog.pg_roles (
 					tree.MakeDBool(isRoot),       // rolcreaterole
 					tree.MakeDBool(isRoot),       // rolcreatedb
 					tree.DBoolFalse,              // rolcatupdate
-					tree.MakeDBool(!isRoleDBool), // rolcanlogin. Only users can login.
+					tree.MakeDBool(roleCanLogin), // rolcanlogin.
 					tree.DBoolFalse,              // rolreplication
 					negOneVal,                    // rolconnlimit
 					passwdStarString,             // rolpassword
@@ -2591,7 +2593,7 @@ CREATE TABLE pg_catalog.pg_user (
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachRole(ctx, p,
-			func(username string, isRole bool) error {
+			func(username string, isRole bool, noLogin bool) error {
 				if isRole {
 					return nil
 				}


### PR DESCRIPTION
Backport 1/1 commits from #49389.

/cc @cockroachdb/release

---

Fixes #49207

Previously, the `rolcanlogin` value was being populated incorrectly by assuming roles cannot login and users can login. Recent changes allow both roles and users to login.

Release note (sql change): Correctly populate rolcanlogin value for roles
in pg_roles and pg_catalog.
