### PR TITLE
opt: remove AllowUnsupportedExpr optbuilder knob

### DIFF
--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -298,7 +298,6 @@ func buildFilters(
 		return memo.FiltersExpr{}, err
 	}
 	b := optbuilder.NewScalar(context.Background(), semaCtx, evalCtx, f)
-	b.AllowUnsupportedExpr = true
 	if err := b.Build(expr); err != nil {
 		return memo.FiltersExpr{}, err
 	}

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -59,12 +59,6 @@ type Builder struct {
 	// These fields can be set before calling Build to control various aspects of
 	// the building process.
 
-	// AllowUnsupportedExpr is a control knob: if set, when building a scalar, the
-	// builder takes any TypedExpr node that it doesn't recognize and wraps that
-	// expression in an UnsupportedExpr node. This is temporary; it is used for
-	// interfacing with the old planning code.
-	AllowUnsupportedExpr bool
-
 	// KeepPlaceholders is a control knob: if set, optbuilder will never replace
 	// a placeholder operator with its assigned value, even when it is available.
 	// This is used when re-preparing invalidated queries.

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -114,7 +114,6 @@ func TestBuilder(t *testing.T) {
 				// of the build process.
 				o.DisableOptimizations()
 				b := optbuilder.NewScalar(ctx, &semaCtx, &evalCtx, o.Factory())
-				b.AllowUnsupportedExpr = tester.Flags.AllowUnsupportedExpr
 				err = b.Build(expr)
 				if err != nil {
 					return fmt.Sprintf("error: %s\n", strings.TrimSpace(err.Error()))

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -133,11 +133,6 @@ func (b *Builder) buildScalar(
 		out = b.factory.ConstructCollate(in, t.Locale)
 
 	case *tree.ArrayFlatten:
-		if b.AllowUnsupportedExpr {
-			out = b.factory.ConstructUnsupportedExpr(t)
-			break
-		}
-
 		s := t.Subquery.(*subquery)
 
 		inCol := s.cols[0].id
@@ -426,11 +421,7 @@ func (b *Builder) buildScalar(
 		out = b.factory.ConstructConstVal(t, t.ResolvedType())
 
 	default:
-		if b.AllowUnsupportedExpr {
-			out = b.factory.ConstructUnsupportedExpr(scalar)
-		} else {
-			panic(unimplemented.Newf(fmt.Sprintf("optbuilder.%T", scalar), "not yet implemented: scalar expression: %T", scalar))
-		}
+		panic(unimplemented.Newf(fmt.Sprintf("optbuilder.%T", scalar), "not yet implemented: scalar expression: %T", scalar))
 	}
 
 	return b.finishBuildScalar(scalar, out, inScope, outScope, outCol)

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -921,11 +921,6 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 		}
 
 	case *tree.ArrayFlatten:
-		if s.builder.AllowUnsupportedExpr {
-			// TODO(rytaft): Temporary fix for #24171 and #24170.
-			break
-		}
-
 		if sub, ok := t.Subquery.(*tree.Subquery); ok {
 			// Copy the ArrayFlatten expression so that the tree isn't mutated.
 			copy := *t
@@ -936,11 +931,6 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 		}
 
 	case *tree.ComparisonExpr:
-		if s.builder.AllowUnsupportedExpr {
-			// TODO(rytaft): Temporary fix for #24171 and #24170.
-			break
-		}
-
 		switch t.Operator {
 		case tree.In, tree.NotIn, tree.Any, tree.Some, tree.All:
 			if sub, ok := t.Right.(*tree.Subquery); ok {
@@ -954,11 +944,6 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 		}
 
 	case *tree.Subquery:
-		if s.builder.AllowUnsupportedExpr {
-			// TODO(rytaft): Temporary fix for #24171, #24170 and #24225.
-			return false, expr
-		}
-
 		if t.Exists {
 			expr = s.replaceSubquery(
 				t, true /* wrapInTuple */, -1 /* desiredNumColumns */, noExtraColsAllowed,

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -788,7 +788,7 @@ concat [type=jsonb]
  ├── variable: "@1":1 [type=jsonb]
  └── variable: "@2":2 [type=jsonb]
 
-build-scalar allow-unsupported
+build-scalar
 'hello' COLLATE en
 ----
 collate [type=collatedstring{en}]

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -137,7 +137,7 @@ project
  └── projections
       └── (a:1 + b:2) + c:3 [as=foo:4]
 
-build allow-unsupported
+build
 SELECT a,b FROM abc WHERE CASE WHEN a != 0 THEN b/a > 1.5 ELSE false END
 ----
 project
@@ -575,7 +575,7 @@ project
  └── scan boolean_table
       └── columns: id:1!null value:2
 
-build allow-unsupported
+build
 SELECT CASE WHEN NULL THEN 1 ELSE 2 END
 ----
 project

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -118,12 +118,6 @@ type Flags struct {
 	// MemoFormat controls the output detail of memo command directives.
 	MemoFormat xform.FmtFlags
 
-	// AllowUnsupportedExpr if set: when building a scalar, the optbuilder takes
-	// any TypedExpr node that it doesn't recognize and wraps that expression in
-	// an UnsupportedExpr node. This is temporary; it is used for interfacing with
-	// the old planning code.
-	AllowUnsupportedExpr bool
-
 	// FullyQualifyNames if set: when building a query, the optbuilder fully
 	// qualifies all column names before adding them to the metadata. This flag
 	// allows us to test that name resolution works correctly, and avoids
@@ -313,8 +307,6 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 //      (show|hide)-(all|miscprops|constraints|scalars|types|...)
 //    See formatFlags for all flags. Multiple flags can be specified; each flag
 //    modifies the existing set of the flags.
-//
-//  - allow-unsupported: wrap unsupported expressions in UnsupportedOp.
 //
 //  - fully-qualify-names: fully qualify all column names in the test output.
 //
@@ -656,9 +648,6 @@ func (f *Flags) Set(arg datadriven.CmdArg) error {
 				f.ExprFormat &= ^formatFlags[parts[1]]
 			}
 		}
-
-	case "allow-unsupported":
-		f.AllowUnsupportedExpr = true
 
 	case "fully-qualify-names":
 		f.FullyQualifyNames = true
@@ -1412,7 +1401,6 @@ func (ot *OptTester) buildExpr(factory *norm.Factory) error {
 	}
 	ot.semaCtx.Annotations = tree.MakeAnnotations(stmt.NumAnnotations)
 	b := optbuilder.New(ot.ctx, &ot.semaCtx, &ot.evalCtx, ot.catalog, factory, stmt.AST)
-	b.AllowUnsupportedExpr = ot.Flags.AllowUnsupportedExpr
 	return b.Build()
 }
 

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -280,7 +280,6 @@ func optBuildScalar(evalCtx *tree.EvalContext, e tree.Expr) (tree.TypedExpr, err
 	var o xform.Optimizer
 	o.Init(evalCtx, nil /* catalog */)
 	b := optbuilder.NewScalar(context.Background(), &tree.SemaContext{}, evalCtx, o.Factory())
-	b.AllowUnsupportedExpr = true
 	if err := b.Build(e); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Removing this flag which is no longer useful.

Release note: None