### PR TITLE
opt: fix incorrect join simplification in match simple case

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -3203,3 +3203,24 @@ ALTER TABLE t2 DROP CONSTRAINT fk1; ALTER TABLE t2 DROP CONSTRAINT fk2; TRUNCATE
 
 statement ok
 DROP TABLE t2 CASCADE; DROP TABLE t1 CASCADE
+
+# Regression test for #49628.
+statement ok
+CREATE TABLE xyz (x INT, y INT, z INT, PRIMARY KEY (x, y, z));
+CREATE TABLE fk_ref
+(
+    a INT NOT NULL,
+    b INT,
+    c INT NOT NULL,
+    FOREIGN KEY (a, b, c) REFERENCES xyz (x, y, z)
+);
+INSERT INTO fk_ref (VALUES (1, NULL, 1));
+
+query IIIIII
+SELECT * FROM fk_ref LEFT JOIN xyz ON a = x
+----
+1  NULL  1  NULL  NULL  NULL
+
+statement ok
+DROP TABLE fk_ref;
+DROP TABLE xyz;

--- a/pkg/sql/opt/norm/join_funcs.go
+++ b/pkg/sql/opt/norm/join_funcs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -628,8 +629,17 @@ func (c *CustomFuncs) JoinFiltersMatchAllLeftRows(
 		for j := 0; j < numCols; j++ {
 			indexLeftCol := leftTab.ColumnID(fkRef.OriginColumnOrdinal(leftTabMeta.Table, j))
 
-			// Not every fk column needs to be in the equality conditions.
 			if !remainingLeftColIDs.Contains(indexLeftCol) {
+				// Not all FK columns are part of the equality conditions. There are two
+				// cases:
+				// 1. MATCH SIMPLE/PARTIAL: if this column is nullable, rows from this
+				//    foreign key are not guaranteed to match.
+				// 2. MATCH FULL: FK rows are still guaranteed to match because the
+				//    non-present columns can only be NULL if all FK columns are NULL.
+				if fkRef.MatchMethod() != tree.MatchFull && !leftColIDs.Contains(indexLeftCol) {
+					fkMatch = false
+					break
+				}
 				continue
 			}
 


### PR DESCRIPTION
Previously, the SimplifyLeftJoinWithoutFilters and
SimplifyRightJoinWithoutFilters rules could incorrectly simplify an
outer join with an equality on a match simple multicolumn foreign key.

This patch introduces a check that invalidates a foreign key if a
nullable column is discovered and the key is not match full.

Fixes #49628

Release note: None