### PR TITLE
opt: fix incorrect join simplification in cross join input case

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -1093,3 +1093,22 @@ CREATE TABLE t44746_1(c1 INT)
 # Note: an "error parsing regexp" would also be acceptable here.
 statement ok
 SELECT * FROM t44746_0 FULL JOIN t44746_1 ON (SUBSTRING('', ')') = '') = (c1 > 0)
+
+# Regression test for #49630.
+statement ok
+DROP TABLE empty;
+CREATE TABLE xy (x INT PRIMARY KEY, y INT);
+CREATE TABLE fk_ref (r INT NOT NULL REFERENCES xy (x));
+CREATE TABLE empty (v INT);
+INSERT INTO xy (VALUES (1, 1));
+INSERT INTO fk_ref (VALUES (1));
+
+query IIII
+SELECT * FROM fk_ref LEFT JOIN (SELECT * FROM xy INNER JOIN empty ON True) ON r = x
+----
+1  NULL  NULL  NULL
+
+statement ok
+DROP TABLE empty;
+DROP TABLE fk_ref;
+DROP TABLE xy;

--- a/pkg/sql/opt/norm/join_funcs.go
+++ b/pkg/sql/opt/norm/join_funcs.go
@@ -496,6 +496,12 @@ func (c *CustomFuncs) eqConditionsToColMap(
 func (c *CustomFuncs) JoinFiltersMatchAllLeftRows(
 	left, right memo.RelExpr, filters memo.FiltersExpr,
 ) bool {
+	if filters.IsTrue() {
+		// Fast path: if this is a cross join, left rows are guaranteed to match if
+		// the right input is guaranteed to have at least one row.
+		return !right.Relational().Cardinality.CanBeZero()
+	}
+
 	unfilteredCols := c.deriveUnfilteredCols(right)
 	if unfilteredCols.Empty() {
 		// Condition #3: right input has no columns which contain values from
@@ -686,15 +692,12 @@ func (c *CustomFuncs) deriveUnfilteredCols(in memo.RelExpr) opt.ColSet {
 		right := t.Child(1).(memo.RelExpr)
 		on := *t.Child(2).(*memo.FiltersExpr)
 
-		// Cross join always preserves left/right rows.
-		isCrossJoin := on.IsTrue()
-
 		// Inner joins may preserve left/right rows, according to
 		// JoinFiltersMatchAllLeftRows conditions.
-		if isCrossJoin || c.JoinFiltersMatchAllLeftRows(left, right, on) {
+		if c.JoinFiltersMatchAllLeftRows(left, right, on) {
 			relational.Rule.UnfilteredCols.UnionWith(c.deriveUnfilteredCols(left))
 		}
-		if isCrossJoin || c.JoinFiltersMatchAllLeftRows(right, left, on) {
+		if c.JoinFiltersMatchAllLeftRows(right, left, on) {
 			relational.Rule.UnfilteredCols.UnionWith(c.deriveUnfilteredCols(right))
 		}
 	}


### PR DESCRIPTION
Previously, the SimplifyLeftJoinWithoutFilters and
SimplifyRightJoinWithoutFilters rules could incorrectly simplify an
outer join when one of the join inputs was a cross join between
relations that were not guaranteed to have rows.

This patch modifies JoinFiltersMatchAllLeftRows to be able to handle
cross joins.

Fixes #49630

Release note: None