### PR TITLE
release-19.2: sql: allow pgwire auth methods to specify a cleanup func

### DIFF
--- a/pkg/acceptance/compose/gss/psql/gss_test.go
+++ b/pkg/acceptance/compose/gss/psql/gss_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
 )
@@ -105,6 +106,43 @@ func TestGSS(t *testing.T) {
 				t.Errorf("expected err %v, got %v", tc.gssErr, err)
 			}
 		})
+	}
+}
+
+func TestGSSFileDescriptorCount(t *testing.T) {
+	// When the docker-compose.yml added a ulimit for the cockroach
+	// container the open file count would just stop there, it wouldn't
+	// cause cockroach to panic or error like I had hoped since it would
+	// allow a test to assert that multiple gss connections didn't leak
+	// file descriptors. Another possibility would be to have something
+	// track the open file count in the cockroach container, but that seems
+	// brittle and probably not worth the effort. However this test is
+	// useful when doing manual tracking of file descriptor count.
+	t.Skip("skip")
+
+	rootConnector, err := pq.NewConnector("user=root sslmode=require")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootDB := gosql.OpenDB(rootConnector)
+	defer rootDB.Close()
+
+	if _, err := rootDB.Exec(`SET CLUSTER SETTING server.host_based_authentication.configuration = $1`, "host all all all gss include_realm=0"); err != nil {
+		t.Fatal(err)
+	}
+	const user = "tester"
+	if _, err := rootDB.Exec(fmt.Sprintf(`CREATE USER IF NOT EXISTS '%s'`, user)); err != nil {
+		t.Fatal(err)
+	}
+
+	start := timeutil.Now()
+	for i := 0; i < 1000; i++ {
+		fmt.Println(i, timeutil.Since(start))
+		out, err := exec.Command("psql", "-c", "SELECT 1", "-U", user).CombinedOutput()
+		if IsError(err, "GSS authentication requires an enterprise license") {
+			t.Log(string(out))
+			t.Fatal(err)
+		}
 	}
 }
 

--- a/pkg/acceptance/compose_test.go
+++ b/pkg/acceptance/compose_test.go
@@ -19,8 +19,10 @@ import (
 func TestComposeGSS(t *testing.T) {
 	out, err := exec.Command(
 		"docker-compose",
+		"--no-ansi",
 		"-f", filepath.Join("compose", "gss", "docker-compose.yml"),
 		"up",
+		"--force-recreate",
 		"--build",
 		"--exit-code-from", "psql",
 	).CombinedOutput()

--- a/pkg/ccl/gssapiccl/gssapi.go
+++ b/pkg/ccl/gssapiccl/gssapi.go
@@ -39,7 +39,7 @@ const (
 )
 
 // authGSS performs GSS authentication. See:
-// https:github.com/postgres/postgres/blob/0f9cdd7dca694d487ab663d463b308919f591c02/src/backend/libpq/auth.c#L1090
+// https://github.com/postgres/postgres/blob/0f9cdd7dca694d487ab663d463b308919f591c02/src/backend/libpq/auth.c#L1090
 func authGSS(
 	c pgwire.AuthConn,
 	tlsState tls.ConnectionState,
@@ -48,7 +48,7 @@ func authGSS(
 	execCfg *sql.ExecutorConfig,
 	entry *hba.Entry,
 ) (security.UserAuthHook, error) {
-	return func(requestedUser string, clientConnection bool) error {
+	return func(requestedUser string, clientConnection bool) (func(), error) {
 		var (
 			majStat, minStat, lminS, gflags C.OM_uint32
 			gbuf                            C.gss_buffer_desc
@@ -62,13 +62,29 @@ func authGSS(
 		)
 
 		if err = c.SendAuthRequest(authTypeGSS, nil); err != nil {
-			return err
+			return nil, err
+		}
+
+		// This cleanup function must be called at the
+		// "completion of a communications session", not
+		// merely at the end of an authentication init. See
+		// https://tools.ietf.org/html/rfc2744.html, section
+		// `1. Introduction`, stage `d`:
+		//
+		//   At the completion of a communications session (which
+		//   may extend across several transport connections),
+		//   each application calls a GSS-API routine to delete
+		//   the security context.
+		//
+		// See https://github.com/postgres/postgres/blob/f4d59369d2ddf0ad7850112752ec42fd115825d4/src/backend/libpq/pqcomm.c#L269
+		connClose := func() {
+			C.gss_delete_sec_context(&lminS, &contextHandle, C.GSS_C_NO_BUFFER)
 		}
 
 		for {
 			token, err = c.GetPwdData()
 			if err != nil {
-				return err
+				return connClose, err
 			}
 
 			gbuf.length = C.ulong(len(token))
@@ -93,12 +109,11 @@ func authGSS(
 				outputBytes := C.GoBytes(outputToken.value, C.int(outputToken.length))
 				C.gss_release_buffer(&lminS, &outputToken)
 				if err = c.SendAuthRequest(authTypeGSSContinue, outputBytes); err != nil {
-					return err
+					return connClose, err
 				}
 			}
 			if majStat != C.GSS_S_COMPLETE && majStat != C.GSS_S_CONTINUE_NEEDED {
-				C.gss_delete_sec_context(&lminS, &contextHandle, C.GSS_C_NO_BUFFER)
-				return gssError("accepting GSS security context failed", majStat, minStat)
+				return connClose, gssError("accepting GSS security context failed", majStat, minStat)
 			}
 			if majStat != C.GSS_S_CONTINUE_NEEDED {
 				break
@@ -107,7 +122,7 @@ func authGSS(
 
 		majStat = C.gss_display_name(&minStat, srcName, &gbuf, nil)
 		if majStat != C.GSS_S_COMPLETE {
-			return gssError("retrieving GSS user name failed", majStat, minStat)
+			return connClose, gssError("retrieving GSS user name failed", majStat, minStat)
 		}
 		gssUser := C.GoStringN((*C.char)(gbuf.value), C.int(gbuf.length))
 		C.gss_release_buffer(&lminS, &gbuf)
@@ -125,25 +140,25 @@ func authGSS(
 					}
 				}
 				if !matched {
-					return errors.Errorf("GSSAPI realm (%s) didn't match any configured realm", realm)
+					return connClose, errors.Errorf("GSSAPI realm (%s) didn't match any configured realm", realm)
 				}
 			}
 			if entry.GetOption("include_realm") != "1" {
 				gssUser = gssUser[:idx]
 			}
 		} else if len(realms) > 0 {
-			return errors.New("GSSAPI did not return realm but realm matching was requested")
+			return connClose, errors.New("GSSAPI did not return realm but realm matching was requested")
 		}
 
 		if !strings.EqualFold(gssUser, requestedUser) {
-			return errors.Errorf("requested user is %s, but GSSAPI auth is for %s", requestedUser, gssUser)
+			return connClose, errors.Errorf("requested user is %s, but GSSAPI auth is for %s", requestedUser, gssUser)
 		}
 
 		// Do the license check last so that administrators are able to test whether
 		// their GSS configuration is correct. That is, the presence of this error
 		// message means they have a correctly functioning GSS/Kerberos setup,
 		// but now need to enable enterprise features.
-		return utilccl.CheckEnterpriseEnabled(execCfg.Settings, execCfg.ClusterID(), execCfg.Organization(), "GSS authentication")
+		return connClose, utilccl.CheckEnterpriseEnabled(execCfg.Settings, execCfg.ClusterID(), execCfg.Organization(), "GSS authentication")
 	}, nil
 }
 

--- a/pkg/security/auth_test.go
+++ b/pkg/security/auth_test.go
@@ -109,11 +109,11 @@ func TestAuthenticationHook(t *testing.T) {
 		if err != nil {
 			continue
 		}
-		err = hook(tc.username, true /*public*/)
+		_, err = hook(tc.username, true /*public*/)
 		if (err == nil) != tc.publicHookSuccess {
 			t.Fatalf("#%d: expected success=%t, got err=%v", tcNum, tc.publicHookSuccess, err)
 		}
-		err = hook(tc.username, false /*not public*/)
+		_, err = hook(tc.username, false /*not public*/)
 		if (err == nil) != tc.privateHookSuccess {
 			t.Fatalf("#%d: expected success=%t, got err=%v", tcNum, tc.privateHookSuccess, err)
 		}


### PR DESCRIPTION
Backport 1/1 commits from #49572.

/cc @cockroachdb/release

---

On connection close, some auth methods may need to cleanup resources. Add
a callback for that.

This fixes a bug in the GSS auth method where replay cache file
descriptors were incorrectly kept open after connection close because
the context was not being deleted.

Release note (bug fix): stop leaking file descriptors during GSS
authentication.