### PR TITLE
sql: fix panic when attempting to clone a table with a UDT

### DIFF
--- a/pkg/sql/sem/tree/type_name.go
+++ b/pkg/sql/sem/tree/type_name.go
@@ -66,16 +66,6 @@ func (t *TypeName) FQString() string {
 
 func (t *TypeName) objectName() {}
 
-// Basename implements the types.UserDefinedTypeName interface.
-func (t *TypeName) Basename() string {
-	return t.Type()
-}
-
-// FQName implements the types.UserDefinedTypeName interface.
-func (t *TypeName) FQName() string {
-	return t.FQString()
-}
-
 // NewUnqualifiedTypeName returns a new base type name.
 func NewUnqualifiedTypeName(typ Name) *TypeName {
 	return &TypeName{objName{

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -4405,7 +4405,7 @@ func (desc *TypeDescriptor) HydrateTypeInfo(typ *types.T) error {
 // a type and also sets the name in the metadata to the passed in name.
 // This is used when hydrating a type with a known qualified name.
 func (desc *TypeDescriptor) HydrateTypeInfoWithName(typ *types.T, name *tree.TypeName) error {
-	typ.TypeMeta.Name = name
+	typ.TypeMeta.Name = types.MakeUserDefinedTypeName(name.Catalog(), name.Schema(), name.Object())
 	switch desc.Kind {
 	case TypeDescriptor_ENUM:
 		if typ.Family() != types.EnumFamily {


### PR DESCRIPTION
Due to how the type metadata was represented, there could have
been structs with unimplemented fields in the `TypeMeta`'s
`UserDefinedTypeName`. This would cause protobuf to panic when
attempting to perform reflection into `types.T` when cloning.

Release note: None