### PR TITLE
*: fix the `fmtsafe` linter and fix the fallout

### DIFF
--- a/pkg/acceptance/localcluster/tc/tc.go
+++ b/pkg/acceptance/localcluster/tc/tc.go
@@ -98,16 +98,13 @@ func (c *Controller) AddLatency(srcIP, dstIP string, latency time.Duration) erro
 
 // CleanUp resets all interfaces back to their default tc policies.
 func (c *Controller) CleanUp() error {
-	var errs []string
+	var err error
 	for _, ifce := range c.interfaces {
-		out, err := exec.Command("sudo", strings.Split(fmt.Sprintf("tc qdisc del dev %s root", ifce), " ")...).Output()
+		out, thisErr := exec.Command("sudo", strings.Split(fmt.Sprintf("tc qdisc del dev %s root", ifce), " ")...).Output()
 		if err != nil {
-			errs = append(errs, errors.Wrapf(
-				err, "failed to remove tc rules for %q -- you may have to remove them manually: %s", ifce, out).Error())
+			err = errors.CombineErrors(err, errors.Wrapf(
+				thisErr, "failed to remove tc rules for %q -- you may have to remove them manually: %s", ifce, out))
 		}
 	}
-	if len(errs) > 0 {
-		return errors.New(strings.Join(errs, "; "))
-	}
-	return nil
+	return err
 }

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -86,7 +86,7 @@ func parseValues(tableDesc *sqlbase.TableDescriptor, values string) ([]sqlbase.E
 			}
 			datum, err := typedExpr.Eval(evalCtx)
 			if err != nil {
-				return nil, errors.Wrap(err, typedExpr.String())
+				return nil, errors.Wrapf(err, "evaluating %s", typedExpr)
 			}
 			row = append(row, sqlbase.DatumToEncDatum(col.Type, datum))
 		}

--- a/pkg/ccl/changefeedccl/cdctest/testfeed.go
+++ b/pkg/ccl/changefeedccl/cdctest/testfeed.go
@@ -255,7 +255,7 @@ func (f *jobFeed) fetchJobError() error {
 		return err
 	}
 	if len(errorStr.String) > 0 {
-		f.jobErr = errors.New(errorStr.String)
+		f.jobErr = errors.Newf("%s", errorStr.String)
 	}
 	return nil
 }

--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -216,13 +216,14 @@ func (v *beforeAfterValidator) checkRowAt(
 	}
 
 	var valid bool
-	if err := v.sqlDB.QueryRow(stmtBuf.String(), args...).Scan(&valid); err != nil {
-		return errors.Wrap(err, stmtBuf.String())
+	stmt := stmtBuf.String()
+	if err := v.sqlDB.QueryRow(stmt, args...).Scan(&valid); err != nil {
+		return errors.Wrapf(err, "while executing %s", stmt)
 	}
 	if !valid {
 		v.failures = append(v.failures, fmt.Sprintf(
 			"%q field did not agree with row at %s: %s %v",
-			field, ts.AsOfSystemTime(), stmtBuf.String(), args))
+			field, ts.AsOfSystemTime(), stmt, args))
 	}
 	return nil
 }

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
@@ -26,7 +26,7 @@ func TestTableHistoryIngestionTracking(t *testing.T) {
 	ts := func(wt int64) hlc.Timestamp { return hlc.Timestamp{WallTime: wt} }
 	validateFn := func(_ context.Context, desc *sqlbase.TableDescriptor) error {
 		if desc.Name != `` {
-			return errors.New(desc.Name)
+			return errors.Newf("descriptor: %s", desc.Name)
 		}
 		return nil
 	}
@@ -108,11 +108,11 @@ func TestTableHistoryIngestionTracking(t *testing.T) {
 	// does not validate, high-water does not change
 	require.EqualError(t, m.ingestDescriptors(ctx, ts(7), ts(10), []*sqlbase.TableDescriptor{
 		{ID: 0, Name: `whoops!`},
-	}, validateFn), `whoops!`)
+	}, validateFn), `descriptor: whoops!`)
 	require.Equal(t, ts(7), m.highWater())
 
 	// ts 10 has errored, so validate can return its error without blocking
-	require.EqualError(t, m.waitForTS(ctx, ts(10)), `whoops!`)
+	require.EqualError(t, m.waitForTS(ctx, ts(10)), `descriptor: whoops!`)
 
 	// ts 8 and 9 are still unknown
 	errCh8 = make(chan error, 1)
@@ -125,16 +125,16 @@ func TestTableHistoryIngestionTracking(t *testing.T) {
 	// turns out ts 10 is not a tight bound. ts 9 also has an error
 	require.EqualError(t, m.ingestDescriptors(ctx, ts(7), ts(9), []*sqlbase.TableDescriptor{
 		{ID: 0, Name: `oh no!`},
-	}, validateFn), `oh no!`)
+	}, validateFn), `descriptor: oh no!`)
 	require.Equal(t, ts(7), m.highWater())
-	require.EqualError(t, <-errCh9, `oh no!`)
+	require.EqualError(t, <-errCh9, `descriptor: oh no!`)
 
 	// ts 8 is still unknown
 	requireChannelEmpty(t, errCh8)
 
 	// always return the earlist error seen (so waiting for ts 10 immediately
 	// returns the 9 error now, it returned the ts 10 error above)
-	require.EqualError(t, m.waitForTS(ctx, ts(9)), `oh no!`)
+	require.EqualError(t, m.waitForTS(ctx, ts(9)), `descriptor: oh no!`)
 
 	// something earlier than ts 10 can still be okay
 	require.NoError(t, m.ingestDescriptors(ctx, ts(7), ts(8), nil, validateFn))

--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -235,7 +235,7 @@ func (sp *csvWriter) Run(ctx context.Context) {
 				break
 			}
 			if err := writer.Flush(); err != nil {
-				return errors.New(fmt.Sprintf("failed to flush csv writer, error %s", err))
+				return errors.Wrap(err, "failed to flush csv writer")
 			}
 
 			conf, err := cloud.ExternalStorageConfFromURI(sp.spec.Destination)
@@ -259,7 +259,7 @@ func (sp *csvWriter) Run(ctx context.Context) {
 			// Close writer to ensure buffer and any compression footer is flushed.
 			err = writer.Close()
 			if err != nil {
-				return errors.New(fmt.Sprintf("failed to close exporting writer, error %s", err))
+				return errors.Wrapf(err, "failed to close exporting writer")
 			}
 
 			size := writer.Len()

--- a/pkg/ccl/importccl/read_import_base.go
+++ b/pkg/ccl/importccl/read_import_base.go
@@ -236,11 +236,11 @@ func readInputFiles(
 				})
 
 				if err := grp.Wait(); err != nil {
-					return errors.Wrap(err, dataFile)
+					return errors.Wrapf(err, "%s", dataFile)
 				}
 			} else {
 				if err := fileFunc(ctx, src, dataFileIndex, resumePos[dataFileIndex], nil /* rejected */); err != nil {
-					return errors.Wrap(err, dataFile)
+					return errors.Wrapf(err, "%s", dataFile)
 				}
 			}
 			return nil

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -103,7 +103,7 @@ func valueEncodePartitionTuple(
 		}
 		datum, err := typedExpr.Eval(evalCtx)
 		if err != nil {
-			return nil, errors.Wrap(err, typedExpr.String())
+			return nil, errors.Wrapf(err, "evaluating %s", typedExpr)
 		}
 		if err := sqlbase.CheckDatumTypeFitsColumnType(&cols[i], datum.ResolvedType()); err != nil {
 			return nil, err

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1113,14 +1113,15 @@ func verifyScansOnNode(
 		}
 	}
 	if len(scansWrongNode) > 0 {
-		var err bytes.Buffer
-		fmt.Fprintf(&err, "expected to scan on %s: %s\n%s\nfull trace:",
-			node, query, strings.Join(scansWrongNode, "\n"))
+		err := errors.Newf("expected to scan on %s: %s", node, query)
+		err = errors.WithDetailf(err, "scans:\n%s", strings.Join(scansWrongNode, "\n"))
+		var trace strings.Builder
 		for _, traceLine := range traceLines {
-			err.WriteString("\n  ")
-			err.WriteString(traceLine)
+			trace.WriteString("\n  ")
+			trace.WriteString(traceLine)
 		}
-		return errors.New(err.String())
+		err = errors.WithDetailf(err, "trace:%s", trace.String())
+		return err
 	}
 	return nil
 }

--- a/pkg/ccl/storageccl/engineccl/rocksdb.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb.go
@@ -139,7 +139,7 @@ func statusToError(s C.DBStatus) error {
 	if s.data == nil {
 		return nil
 	}
-	return errors.New(cStringToGoString(s))
+	return errors.Newf("%s", cStringToGoString(s))
 }
 
 func cStatsToGoStats(stats C.MVCCStatsResult, nowNanos int64) (enginepb.MVCCStats, error) {

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1882,11 +1882,11 @@ func TestJunkPositionalArguments(t *testing.T) {
 		line := test + " " + junk
 		out, err := c.RunWithCapture(line)
 		if err != nil {
-			t.Fatal(errors.Wrap(err, strconv.Itoa(i)))
+			t.Fatalf("%d: %v", i, err)
 		}
 		exp := fmt.Sprintf("%s\nERROR: unknown command %q for \"cockroach %s\"\n", line, junk, test)
 		if exp != out {
-			t.Errorf("expected:\n%s\ngot:\n%s", exp, out)
+			t.Errorf("%d: expected:\n%s\ngot:\n%s", i, exp, out)
 		}
 	}
 }

--- a/pkg/cli/debug_synctest.go
+++ b/pkg/cli/debug_synctest.go
@@ -58,7 +58,7 @@ type scriptNemesis string
 func (sn scriptNemesis) exec(arg string) error {
 	b, err := exec.Command(string(sn), arg).CombinedOutput()
 	if err != nil {
-		return errors.Wrap(err, string(b))
+		return errors.WithDetailf(err, "command output:\n%s", string(b))
 	}
 	fmt.Fprintf(stderr, "%s %s: %s", sn, arg, b)
 	return nil

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -237,7 +237,8 @@ func checkDemoConfiguration(
 		}
 
 		// If geo-partition-replicas is requested, make sure the workload has a Partitioning step.
-		configErr := errors.New(fmt.Sprintf("workload %s is not configured to have a partitioning step", gen.Meta().Name))
+		configErr := errors.Newf(
+			"workload %s is not configured to have a partitioning step", gen.Meta().Name)
 		hookser, ok := gen.(workload.Hookser)
 		if !ok {
 			return nil, configErr

--- a/pkg/cli/error.go
+++ b/pkg/cli/error.go
@@ -229,7 +229,7 @@ func MaybeDecorateGRPCError(
 		connRefused := func() error {
 			extra := extraInsecureHint()
 			return errors.Errorf("server closed the connection.\n"+
-				"Is this a CockroachDB node?\n"+extra+"\n%v", err)
+				"Is this a CockroachDB node?\n%s\n%v", extra, err)
 		}
 
 		// Is this an "unable to connect" type of error?

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -1570,7 +1570,7 @@ func (c *cliState) serverSideParse(sql string) (helpText string, err error) {
 			hint = ""
 		}
 		// In any case report that there was an error while parsing.
-		err := errors.New(message)
+		err := errors.Newf("%s", message)
 		err = pgerror.WithCandidateCode(err, code)
 		if hint != "" {
 			err = errors.WithHint(err, hint)

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -760,11 +760,11 @@ If problems persist, please see %s.`
 			// Attempt to start the server.
 			if err := s.Start(ctx); err != nil {
 				if le := (*server.ListenError)(nil); errors.As(err, &le) {
-					const errorPrefix = "consider changing the port via --"
+					const errorPrefix = "consider changing the port via --%s"
 					if le.Addr == serverCfg.Addr {
-						err = errors.Wrap(err, errorPrefix+cliflags.ListenAddr.Name)
+						err = errors.Wrapf(err, errorPrefix, cliflags.ListenAddr.Name)
 					} else if le.Addr == serverCfg.HTTPAddr {
-						err = errors.Wrap(err, errorPrefix+cliflags.ListenHTTPAddr.Name)
+						err = errors.Wrapf(err, errorPrefix, cliflags.ListenHTTPAddr.Name)
 					}
 				}
 

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -336,7 +336,7 @@ func runDebugZip(cmd *cobra.Command, args []string) (retErr error) {
 			selectClause = "*"
 		}
 		if err := dumpTableDataForZip(z, sqlConn, timeout, base, table, selectClause); err != nil {
-			return errors.Wrap(err, table)
+			return errors.Wrapf(err, "fetching %s", table)
 		}
 	}
 
@@ -432,7 +432,7 @@ func runDebugZip(cmd *cobra.Command, args []string) (retErr error) {
 					selectClause = "*"
 				}
 				if err := dumpTableDataForZip(z, curSQLConn, timeout, prefix, table, selectClause); err != nil {
-					return errors.Wrap(err, table)
+					return errors.Wrapf(err, "fetching %s", table)
 				}
 			}
 

--- a/pkg/cmd/cmpconn/compare.go
+++ b/pkg/cmd/cmpconn/compare.go
@@ -37,7 +37,7 @@ func CompareVals(a, b []interface{}) error {
 		return nil
 	}
 	if diff := cmp.Diff(a, b, cmpOptions...); diff != "" {
-		return errors.New(diff)
+		return errors.Newf("unexpected diff:\n%s", diff)
 	}
 	return nil
 }

--- a/pkg/cmd/github-post/main.go
+++ b/pkg/cmd/github-post/main.go
@@ -162,7 +162,7 @@ func listFailures(
 				continue
 			}
 			if err := json.Unmarshal([]byte(line), &te); err != nil {
-				return errors.Wrap(err, line)
+				return errors.Wrapf(err, "unable to parse %q", line)
 			}
 		}
 		lastEvent = te

--- a/pkg/cmd/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/cmd/roachprod/vm/flagstub/flagstub.go
@@ -23,12 +23,12 @@ import (
 // implemented as no-op or no-value. All other operations will
 // return the provided error.
 func New(delegate vm.Provider, unimplemented string) vm.Provider {
-	return &provider{delegate: delegate, unimplemented: errors.New(unimplemented)}
+	return &provider{delegate: delegate, unimplemented: unimplemented}
 }
 
 type provider struct {
 	delegate      vm.Provider
-	unimplemented error
+	unimplemented string
 }
 
 // CleanSSH implements vm.Provider and is a no-op.
@@ -43,17 +43,17 @@ func (p *provider) ConfigSSH() error {
 
 // Create implements vm.Provider and returns Unimplemented.
 func (p *provider) Create(names []string, opts vm.CreateOpts) error {
-	return p.unimplemented
+	return errors.Newf("%s", p.unimplemented)
 }
 
 // Delete implements vm.Provider and returns Unimplemented.
 func (p *provider) Delete(vms vm.List) error {
-	return p.unimplemented
+	return errors.Newf("%s", p.unimplemented)
 }
 
 // Extend implements vm.Provider and returns Unimplemented.
 func (p *provider) Extend(vms vm.List, lifetime time.Duration) error {
-	return p.unimplemented
+	return errors.Newf("%s", p.unimplemented)
 }
 
 // FindActiveAccount implements vm.Provider and returns an empty account.

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -363,7 +363,7 @@ func runCDCBank(ctx context.Context, t *test, c *cluster) {
 			}
 		}
 		if failures := v.Failures(); len(failures) > 0 {
-			return errors.New("validator failures:\n" + strings.Join(failures, "\n"))
+			return errors.Newf("validator failures:\n%s", strings.Join(failures, "\n"))
 		}
 		return nil
 	})

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -807,7 +807,7 @@ func (r *testRunner) runTest(
 			// We really shouldn't get here unless the test code somehow managed
 			// to deadlock without blocking on anything remote - since we killed
 			// everything.
-			msg := "test timed out and afterwards failed to respond to cancelation"
+			const msg = "test timed out and afterwards failed to respond to cancelation"
 			t.l.PrintfCtx(ctx, msg)
 			r.collectClusterLogs(ctx, c, t.l)
 			// We return an error here because the test goroutine is still running, so

--- a/pkg/col/coldata/bytes_test.go
+++ b/pkg/col/coldata/bytes_test.go
@@ -107,7 +107,9 @@ func applyMethodsAndVerify(
 			b1Window.AssertOffsetsAreNonDecreasing(b1Window.Len())
 			debugString += fmt.Sprintf("\n%s\n", b1Window)
 			if err := verifyEqual(b1Window, b2Window); err != nil {
-				return errors.Wrap(err, fmt.Sprintf("\ndebugString:\n%sflat:\n%sreference:\n%s", debugString, b1Window.String(), prettyByteSlice(b2Window)))
+				return errors.Wrapf(err,
+					"\ndebugString:\n%s\nflat:\n%s\nreference:\n%s",
+					debugString, b1Window.String(), prettyByteSlice(b2Window))
 			}
 			continue
 		case copySlice, appendSlice:
@@ -157,7 +159,9 @@ func applyMethodsAndVerify(
 		b1.AssertOffsetsAreNonDecreasing(b1.Len())
 		debugString += fmt.Sprintf("\n%s\n", b1)
 		if err := verifyEqual(b1, b2); err != nil {
-			return errors.Wrap(err, fmt.Sprintf("\ndebugString:\n%sflat (maxSetIdx=%d):\n%sreference:\n%s", debugString, b1.maxSetIndex, b1.String(), prettyByteSlice(b2)))
+			return errors.Wrapf(err,
+				"\ndebugString:\n%s\nflat (maxSetIdx=%d):\n%s\nreference:\n%s",
+				debugString, b1.maxSetIndex, b1.String(), prettyByteSlice(b2))
 		}
 	}
 	return nil

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -1047,8 +1047,9 @@ func TestJobLifecycle(t *testing.T) {
 
 		t.Run("non-nil error marks job as failed", func(t *testing.T) {
 			job, exp := createDefaultJob()
-			exp.Error = "boom"
-			if err := job.Failed(ctx, errors.New(exp.Error)); err != nil {
+			boom := errors.New("boom")
+			exp.Error = boom.Error()
+			if err := job.Failed(ctx, boom); err != nil {
 				t.Fatal(err)
 			}
 			if err := exp.verify(job.ID(), jobs.StatusFailed); err != nil {

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -1133,7 +1133,7 @@ func TestTxnAbortCount(t *testing.T) {
 
 	value := []byte("value")
 
-	intentionalErrText := "intentional error to cause abort"
+	const intentionalErrText = "intentional error to cause abort"
 	// Test aborted transaction.
 	if err := s.DB.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
 		key := []byte("key-abort")

--- a/pkg/kv/kvserver/queue_test.go
+++ b/pkg/kv/kvserver/queue_test.go
@@ -322,7 +322,7 @@ func TestBaseQueueSamePriorityFIFO(t *testing.T) {
 	for _, repl := range repls {
 		added, err := bq.testingAdd(ctx, repl, 0.0)
 		if err != nil {
-			t.Fatal(errors.Wrap(err, repl.String()))
+			t.Fatalf("%s: %v", repl, err)
 		}
 		if !added {
 			t.Fatalf("%v not added", repl)

--- a/pkg/kv/kvserver/raft_test.go
+++ b/pkg/kv/kvserver/raft_test.go
@@ -43,7 +43,7 @@ func TestWrapNumbersAsSafe(t *testing.T) {
 	}
 
 	wrapNumbersAsSafe(reportables...)
-	format := "some reportables"
+	const format = "some reportables"
 	err := errors.WithSafeDetails(leafErr{}, format, reportables...)
 
 	const expected = `<kvserver.leafErr>

--- a/pkg/kv/kvserver/replica_application_cmd.go
+++ b/pkg/kv/kvserver/replica_application_cmd.go
@@ -211,8 +211,9 @@ func (d *decodedRaftEntry) decodeConfChangeEntry(e *raftpb.Entry) error {
 		}
 		d.confChange.ConfChangeI = cc
 	default:
-		err := errors.New("unknown entry type")
-		return wrapWithNonDeterministicFailure(err, err.Error())
+		const msg = "unknown entry type"
+		err := errors.New(msg)
+		return wrapWithNonDeterministicFailure(err, msg)
 	}
 	if err := protoutil.Unmarshal(d.confChange.AsV2().Context, &d.confChange.ConfChangeContext); err != nil {
 		return wrapWithNonDeterministicFailure(err, "while unmarshaling ConfChangeContext")

--- a/pkg/kv/kvserver/replica_sideload_disk.go
+++ b/pkg/kv/kvserver/replica_sideload_disk.go
@@ -270,7 +270,7 @@ func (ss *diskSideloadStorage) forEach(
 			return errors.Wrapf(err, "while parsing %q during TruncateTo", match)
 		}
 		if err := visit(logIdx, match); err != nil {
-			return errors.Wrap(err, match)
+			return errors.Wrapf(err, "matching pattern %q", match)
 		}
 	}
 	return nil

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -61,7 +61,7 @@ func entryEq(l, r raftpb.Entry) error {
 		return errors.Wrap(err, "unmarshalling RHS")
 	}
 	if !reflect.DeepEqual(lc, rc) {
-		return errors.New(strings.Join(pretty.Diff(lc, rc), "\n"))
+		return errors.Newf("unexpected:\n%s", strings.Join(pretty.Diff(lc, rc), "\n"))
 	}
 	return nil
 }

--- a/pkg/kv/kvserver/reports/constraint_stats_report_test.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report_test.go
@@ -450,7 +450,7 @@ func (c constraintEntry) toReportEntry(
 	zk, ok := objects[c.object]
 	if !ok {
 		return ConstraintStatusKey{}, ConstraintStatus{},
-			errors.AssertionFailedf("missing object: " + c.object)
+			errors.AssertionFailedf("missing object: %s", c.object)
 	}
 	k := ConstraintStatusKey{
 		ZoneKey:       zk,

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2594,7 +2594,7 @@ func (s *Store) AllocatorDryRun(ctx context.Context, repl *Replica) (tracing.Rec
 // power an admin debug endpoint.
 func (s *Store) ManuallyEnqueue(
 	ctx context.Context, queueName string, repl *Replica, skipShouldQueue bool,
-) (tracing.Recording, string, error) {
+) (recording tracing.Recording, processError error, enqueueError error) {
 	ctx = repl.AnnotateCtx(ctx)
 
 	var queue queueImpl
@@ -2606,12 +2606,12 @@ func (s *Store) ManuallyEnqueue(
 		}
 	}
 	if queue == nil {
-		return nil, "", errors.Errorf("unknown queue type %q", queueName)
+		return nil, nil, errors.Errorf("unknown queue type %q", queueName)
 	}
 
 	sysCfg := s.cfg.Gossip.GetSystemConfig()
 	if sysCfg == nil {
-		return nil, "", errors.New("cannot run queue without a valid system config; make sure the cluster " +
+		return nil, nil, errors.New("cannot run queue without a valid system config; make sure the cluster " +
 			"has been initialized and all nodes connected to it")
 	}
 
@@ -2620,10 +2620,10 @@ func (s *Store) ManuallyEnqueue(
 	if needsLease {
 		hasLease, pErr := repl.getLeaseForGossip(ctx)
 		if pErr != nil {
-			return nil, "", pErr.GoError()
+			return nil, nil, pErr.GoError()
 		}
 		if !hasLease {
-			return nil, fmt.Sprintf("replica %v does not have the range lease", repl), nil
+			return nil, errors.Newf("replica %v does not have the range lease", repl), nil
 		}
 	}
 
@@ -2636,16 +2636,13 @@ func (s *Store) ManuallyEnqueue(
 		shouldQueue, priority := queue.shouldQueue(ctx, s.cfg.Clock.Now(), repl, sysCfg)
 		log.Eventf(ctx, "shouldQueue=%v, priority=%f", shouldQueue, priority)
 		if !shouldQueue {
-			return collect(), "", nil
+			return collect(), nil, nil
 		}
 	}
 
 	log.Eventf(ctx, "running %s.process", queueName)
-	err := queue.process(ctx, repl, sysCfg)
-	if err != nil {
-		return collect(), err.Error(), nil
-	}
-	return collect(), "", nil
+	processErr := queue.process(ctx, repl, sysCfg)
+	return collect(), processErr, nil
 }
 
 // GetClusterVersion reads the the cluster version from the store-local version

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1021,22 +1021,22 @@ func (s *adminServer) RangeLog(
 		var event kvserverpb.RangeLogEvent
 		var ts time.Time
 		if err := scanner.ScanIndex(row, 0, &ts); err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("Timestamp didn't parse correctly: %s", row[0].String()))
+			return nil, errors.Wrapf(err, "timestamp didn't parse correctly: %s", row[0].String())
 		}
 		event.Timestamp = ts
 		var rangeID int64
 		if err := scanner.ScanIndex(row, 1, &rangeID); err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("RangeID didn't parse correctly: %s", row[1].String()))
+			return nil, errors.Wrapf(err, "RangeID didn't parse correctly: %s", row[1].String())
 		}
 		event.RangeID = roachpb.RangeID(rangeID)
 		var storeID int64
 		if err := scanner.ScanIndex(row, 2, &storeID); err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("StoreID didn't parse correctly: %s", row[2].String()))
+			return nil, errors.Wrapf(err, "StoreID didn't parse correctly: %s", row[2].String())
 		}
 		event.StoreID = roachpb.StoreID(int32(storeID))
 		var eventTypeString string
 		if err := scanner.ScanIndex(row, 3, &eventTypeString); err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("EventType didn't parse correctly: %s", row[3].String()))
+			return nil, errors.Wrapf(err, "EventType didn't parse correctly: %s", row[3].String())
 		}
 		if eventType, ok := kvserverpb.RangeLogEventType_value[eventTypeString]; ok {
 			event.EventType = kvserverpb.RangeLogEventType(eventType)
@@ -1047,7 +1047,7 @@ func (s *adminServer) RangeLog(
 		var otherRangeID int64
 		if row[4].String() != "NULL" {
 			if err := scanner.ScanIndex(row, 4, &otherRangeID); err != nil {
-				return nil, errors.Wrap(err, fmt.Sprintf("OtherRangeID didn't parse correctly: %s", row[4].String()))
+				return nil, errors.Wrapf(err, "OtherRangeID didn't parse correctly: %s", row[4].String())
 			}
 			event.OtherRangeID = roachpb.RangeID(otherRangeID)
 		}
@@ -1056,10 +1056,10 @@ func (s *adminServer) RangeLog(
 		if row[5].String() != "NULL" {
 			var info string
 			if err := scanner.ScanIndex(row, 5, &info); err != nil {
-				return nil, errors.Wrap(err, fmt.Sprintf("info didn't parse correctly: %s", row[5].String()))
+				return nil, errors.Wrapf(err, "info didn't parse correctly: %s", row[5].String())
 			}
 			if err := json.Unmarshal([]byte(info), &event.Info); err != nil {
-				return nil, errors.Wrap(err, fmt.Sprintf("info didn't parse correctly: %s", info))
+				return nil, errors.Wrapf(err, "info didn't parse correctly: %s", info)
 			}
 			if event.Info.NewDesc != nil {
 				if !includeRawKeys {
@@ -2023,7 +2023,9 @@ func (s *adminServer) enqueueRangeLocal(
 		return response, nil
 	}
 	response.Details[0].Events = recordedSpansToTraceEvents(traceSpans)
-	response.Details[0].Error = processErr
+	if processErr != nil {
+		response.Details[0].Error = processErr.Error()
+	}
 	return response, nil
 }
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1064,7 +1064,7 @@ func (ts *TestServer) SplitRange(
 		return nil
 	}); err != nil {
 		if len(wrappedMsg) > 0 {
-			return roachpb.RangeDescriptor{}, roachpb.RangeDescriptor{}, errors.Wrap(err, wrappedMsg)
+			err = errors.Wrapf(err, "%s", wrappedMsg)
 		}
 		return roachpb.RangeDescriptor{}, roachpb.RangeDescriptor{}, err
 	}

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -44,7 +44,7 @@ func (d *dummy) Unmarshal(data []byte) error {
 
 func (d *dummy) Marshal() ([]byte, error) {
 	if c := d.msg1 + d.growsbyone; strings.Contains(c, ".") {
-		return nil, errors.New("must not contain dots: " + c)
+		return nil, errors.Newf("must not contain dots: %s", c)
 	}
 	return []byte(d.msg1 + "." + d.growsbyone), nil
 }
@@ -715,14 +715,10 @@ func batchRegisterSettings(t *testing.T, keyPrefix string, count int) (name stri
 	defer func() {
 		// Catch panic and convert it to an error.
 		if r := recover(); r != nil {
-			// Check exactly what the panic was and create error.
-			switch x := r.(type) {
-			case string:
-				err = errors.New(x)
-			case error:
-				err = x
-			default:
-				err = errors.Errorf("unknown panic: %v", x)
+			if panicErr, ok := r.(error); ok {
+				err = errors.WithStackDepth(panicErr, 1)
+			} else {
+				err = errors.NewWithDepthf(1, "panic: %v", r)
 			}
 		}
 	}()

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2111,9 +2111,8 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		if res.Err() != nil {
 			err := errorutil.UnexpectedWithIssueErrorf(
 				26687,
-				"programming error: non-error event "+
-					advInfo.txnEvent.String()+ //the event is included like this so that it doesn't get sanitized
-					" generated even though res.Err() has been set to: %s",
+				"programming error: non-error event %s generated even though res.Err() has been set to: %s",
+				errors.Safe(advInfo.txnEvent.String()),
 				res.Err())
 			log.Errorf(ex.Ctx(), "%v", err)
 			errorutil.SendReport(ex.Ctx(), &ex.server.cfg.Settings.SV, err)

--- a/pkg/sql/delegate/show_range_for_row.go
+++ b/pkg/sql/delegate/show_range_for_row.go
@@ -57,7 +57,7 @@ func (d *delegator) delegateShowRangeForRow(n *tree.ShowRangeForRow) (tree.State
 		}
 		datum, err := typedExpr.Eval(d.evalCtx)
 		if err != nil {
-			return nil, errors.Wrap(err, typedExpr.String())
+			return nil, errors.Wrapf(err, "%s", typedExpr)
 		}
 		rowExprs = append(rowExprs, datum)
 	}

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -392,11 +392,14 @@ func (ie *InternalExecutor) execInternal(
 		// We wrap errors with the opName, but not if they're retriable - in that
 		// case we need to leave the error intact so that it can be retried at a
 		// higher level.
+		//
+		// TODO(knz): track the callers and check whether opName could be turned
+		// into a type safe for reporting.
 		if retErr != nil && !errIsRetriable(retErr) {
-			retErr = errors.Wrapf(retErr, opName)
+			retErr = errors.Wrapf(retErr, "%s", opName)
 		}
 		if retRes.err != nil && !errIsRetriable(retRes.err) {
-			retRes.err = errors.Wrapf(retRes.err, opName)
+			retRes.err = errors.Wrapf(retRes.err, "%s", opName)
 		}
 	}()
 

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2498,7 +2498,7 @@ func (t *logicTest) execQuery(query logicQuery) error {
 		for _, line := range t.formatValues(actualResultsRaw, query.valsPerLine) {
 			fmt.Fprintf(&buf, "    %s\n", line)
 		}
-		return errors.New(buf.String())
+		return errors.Newf("%s", buf.String())
 	}
 
 	if query.label != "" {

--- a/pkg/sql/parser/lexer.go
+++ b/pkg/sql/parser/lexer.go
@@ -191,7 +191,7 @@ func (l *lexer) setErr(err error) {
 
 func (l *lexer) Error(e string) {
 	e = strings.TrimPrefix(e, "syntax error: ") // we'll add it again below.
-	l.lastError = pgerror.WithCandidateCode(errors.New(e), pgcode.Syntax)
+	l.lastError = pgerror.WithCandidateCode(errors.Newf("%s", e), pgcode.Syntax)
 	l.populateErrorDetails()
 }
 

--- a/pkg/sql/pgwire/auth.go
+++ b/pkg/sql/pgwire/auth.go
@@ -13,7 +13,6 @@ package pgwire
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"net"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -100,7 +99,7 @@ func (c *conn) handleAuthentication(
 	if !canLogin {
 		ac.Logf(ctx, "%q does not have login privilege", c.sessionArgs.User)
 		return nil, sendError(errors.Errorf(
-			fmt.Sprintf("%s does not have login privilege", c.sessionArgs.User)))
+			"%s does not have login privilege", c.sessionArgs.User))
 	}
 
 	// Retrieve the authentication method.

--- a/pkg/sql/save_table.go
+++ b/pkg/sql/save_table.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/errors"
 )
@@ -89,7 +88,7 @@ func (n *saveTableNode) issue(params runParams) error {
 			nil, /* txn */
 			stmt,
 		); err != nil {
-			return pgerror.Wrapf(err, "while running %s", stmt)
+			return errors.Wrapf(err, "while running %s", stmt)
 		}
 		v.Rows = nil
 	}

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"golang.org/x/text/language"
@@ -694,7 +695,7 @@ func (expr *CoalesceExpr) TypeCheck(
 ) (TypedExpr, error) {
 	typedSubExprs, retType, err := TypeCheckSameTypedExprs(ctx, semaCtx, desired, expr.Exprs...)
 	if err != nil {
-		return nil, decorateTypeCheckError(err, fmt.Sprintf("incompatible %s expressions", expr.Name))
+		return nil, decorateTypeCheckError(err, "incompatible %s expressions", log.Safe(expr.Name))
 	}
 
 	for i, subExpr := range typedSubExprs {

--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -109,7 +109,7 @@ func checkStatsForTable(
 	// returned stats match the expected values.
 	statsList, err := sc.GetTableStats(ctx, tableID)
 	if err != nil {
-		return errors.Errorf(err.Error())
+		return errors.Wrap(err, "retrieving stats")
 	}
 	if !checkStats(statsList, expected) {
 		return errors.Errorf("for lookup of key %d, expected stats %s, got %s", tableID, expected, statsList)

--- a/pkg/storage/cloud/gcs_storage.go
+++ b/pkg/storage/cloud/gcs_storage.go
@@ -13,7 +13,6 @@ package cloud
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 	"io"
 	"net/url"
 	"path"
@@ -107,7 +106,7 @@ func makeGCSStorage(
 		}
 		decodedKey, err := base64.StdEncoding.DecodeString(conf.Credentials)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("decoding value of %s", CredentialsParam))
+			return nil, errors.Wrapf(err, "decoding value of %s", CredentialsParam)
 		}
 		source, err := google.JWTConfigFromJSON(decodedKey, scope)
 		if err != nil {

--- a/pkg/storage/rocksdb.go
+++ b/pkg/storage/rocksdb.go
@@ -1199,7 +1199,7 @@ func (r *RocksDB) GetUserProperties() (enginepb.SSTUserPropertiesCollection, err
 		return enginepb.SSTUserPropertiesCollection{}, err
 	}
 	if ssts.Error != "" {
-		return enginepb.SSTUserPropertiesCollection{}, errors.New(ssts.Error)
+		return enginepb.SSTUserPropertiesCollection{}, errors.Newf("%s", ssts.Error)
 	}
 	return ssts, nil
 }

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1756,6 +1756,11 @@ func TestLint(t *testing.T) {
 			// own redact code.
 			stream.GrepNot(`pkg/util/log/crash_reporting\.go:.*invalid direct cast on error object`),
 			stream.GrepNot(`pkg/util/log/crash_reporting\.go:.*invalid direct comparison of error object`),
+			// The logging package translates log.Fatal calls into errors.
+			// We can't use the regular exception mechanism via functions.go
+			// because addStructured takes its positional argument as []interface{},
+			// instead of ...interface{}.
+			stream.GrepNot(`pkg/util/log/structured\.go:\d+:\d+: addStructured\(\): format argument is not a constant expression`),
 		}
 
 		roachlint, err := exec.LookPath("roachvet")

--- a/pkg/testutils/lint/passes/fmtsafe/functions.go
+++ b/pkg/testutils/lint/passes/fmtsafe/functions.go
@@ -36,6 +36,8 @@ var requireConstMsg = map[string]bool{
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire.newAdminShutdownErr": true,
 
+	"(*github.com/cockroachdb/cockroach/pkg/parser/lexer).Error": true,
+
 	"github.com/cockroachdb/cockroach/pkg/util/log.Shout":     true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.Info":      true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.Warning":   true,
@@ -92,6 +94,9 @@ var requireConstFmt = map[string]bool{
 	"(*github.com/cockroachdb/cockroach/pkg/kv/kvserver.raftLogger).Errorf":   true,
 	"(*github.com/cockroachdb/cockroach/pkg/kv/kvserver.raftLogger).Fatalf":   true,
 	"(*github.com/cockroachdb/cockroach/pkg/kv/kvserver.raftLogger).Panicf":   true,
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver.makeNonDeterministicFailure":     true,
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver.wrapWithNonDeterministicFailure": true,
 
 	"(go.etcd.io/etcd/raft.Logger).Debugf":   true,
 	"(go.etcd.io/etcd/raft.Logger).Infof":    true,
@@ -150,20 +155,28 @@ var requireConstFmt = map[string]bool{
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase.NewDependentObjectErrorf": true,
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree.newSourceNotFoundError": true,
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree.decorateTypeCheckError": true,
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder.unimplementedWithIssueDetailf": true,
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror.Newf":                true,
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror.NewWithDepthf":       true,
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror.Noticef":             true,
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror.DangerousStatementf": true,
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror.Wrapf":               true,
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror.WrapWithDepthf":      true,
 
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice.Newf":                                   true,
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice.NewWithSeverityf":                       true,
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase.NewProtocolViolationErrorf":           true,
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase.NewInvalidBinaryRepresentationErrorf": true,
+
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil.UnexpectedWithIssueErrorf": true,
 
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented.Newf":                  true,
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented.NewWithDepthf":         true,
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented.NewWithIssuef":         true,
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented.NewWithIssueDetailf":   true,
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented.unimplementedInternal": true,
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate.inputErrorf": true,
 }

--- a/pkg/util/contextutil/context_test.go
+++ b/pkg/util/contextutil/context_test.go
@@ -75,7 +75,7 @@ func TestRunWithTimeout(t *testing.T) {
 // cause should be the returned error and not context.DeadlineExceeded.
 func TestRunWithTimeoutWithoutDeadlineExceeded(t *testing.T) {
 	ctx := context.Background()
-	notContextDeadlineExceeded := errors.New(context.DeadlineExceeded.Error())
+	notContextDeadlineExceeded := errors.Handled(context.DeadlineExceeded)
 	err := RunWithTimeout(ctx, "foo", 1, func(ctx context.Context) error {
 		<-ctx.Done()
 		return notContextDeadlineExceeded

--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -316,11 +316,11 @@ func SendReport(
 func ReportOrPanic(
 	ctx context.Context, sv *settings.Values, format string, reportables ...interface{},
 ) {
+	err := errors.Newf(format, reportables...)
 	if !build.IsRelease() || (sv != nil && PanicOnAssertions.Get(sv)) {
-		panic(fmt.Sprintf(format, reportables...))
+		panic(err)
 	}
-	Warningf(ctx, format, reportables...)
-	err := errors.Newf("internal error: "+format, reportables...)
+	Warningf(ctx, "%v", err)
 	sendCrashReport(ctx, sv, err, ReportTypeError)
 }
 

--- a/pkg/util/log/structured.go
+++ b/pkg/util/log/structured.go
@@ -58,7 +58,7 @@ func addStructured(ctx context.Context, s Severity, depth int, format string, ar
 		// We load the ReportingSettings from the a global singleton in this
 		// call path. See the singleton's comment for a rationale.
 		if sv := settings.TODO(); sv != nil {
-			err := errors.NewWithDepthf(depth+1, "fatal error: "+format, args...)
+			err := errors.NewWithDepthf(depth+1, format, args...)
 			sendCrashReport(ctx, sv, err, ReportTypePanic)
 		}
 	}

--- a/pkg/util/timeutil/pgdate/parsing.go
+++ b/pkg/util/timeutil/pgdate/parsing.go
@@ -145,19 +145,20 @@ func ParseTimestamp(now time.Time, mode ParseMode, s string) (time.Time, error) 
 
 // badFieldPrefixError constructs an error with pg code InvalidDatetimeFormat.
 func badFieldPrefixError(field field, prefix rune) error {
-	return inputErrorf("unexpected separator '%s' for field %s", string(prefix), errors.Safe(field.Pretty()))
+	return inputErrorf("unexpected separator '%s' for field %s",
+		string(prefix), errors.Safe(field.Pretty()))
 }
 
 // inputErrorf returns an error with pg code InvalidDatetimeFormat.
 func inputErrorf(format string, args ...interface{}) error {
-	return pgerror.WithCandidateCode(errors.Newf(format, args...), pgcode.InvalidDatetimeFormat)
+	err := errors.Newf(format, args...)
+	return pgerror.WithCandidateCode(err, pgcode.InvalidDatetimeFormat)
 }
 
 // outOfRangeError returns an error with pg code DatetimeFieldOverflow.
 func outOfRangeError(field string, val int) error {
-	return pgerror.WithCandidateCode(
-		errors.Newf("field %s value %d is out of range", errors.Safe(field), errors.Safe(val)),
-		pgcode.DatetimeFieldOverflow)
+	err := errors.Newf("field %s value %d is out of range", errors.Safe(field), errors.Safe(val))
+	return pgerror.WithCandidateCode(err, pgcode.DatetimeFieldOverflow)
 }
 
 // parseError ensures that any error we return to the client will

--- a/pkg/workload/cli/check.go
+++ b/pkg/workload/cli/check.go
@@ -67,7 +67,7 @@ func check(gen workload.Generator, urls []string, dbName string) error {
 		fn = hooks.Hooks().CheckConsistency
 	}
 	if fn == nil {
-		return errors.Errorf(`no consistency checks are defined for %s` + gen.Meta().Name)
+		return errors.Errorf(`no consistency checks are defined for %s`, gen.Meta().Name)
 	}
 
 	sqlDB, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))

--- a/pkg/workload/tpch/tpch.go
+++ b/pkg/workload/tpch/tpch.go
@@ -173,7 +173,7 @@ func (w *tpch) Hooks() workload.Hooks {
 						// Return the error for any other reason.
 						const duplFKErr = "columns cannot be used by multiple foreign key constraints"
 						if !strings.Contains(err.Error(), duplFKErr) {
-							return errors.Wrap(err, fkStmt)
+							return errors.Wrapf(err, "while executing %s", fkStmt)
 						}
 					}
 				}


### PR DESCRIPTION
Found while working on  #49447.

The `fmtsafe` linter added in #48040 #48048 was actually
malfunctioning because it was not stripping the vendor prefix
properly.

This patch fixes it.

Fixing the linter uncovered a range of defects throughout the
remainder of the code, some benign and some outright bugs.

Examples:

```
  return pgerror.Wrapf(err, "while running %s", stmt)
```
(The second argument should be the pgcode, not the error string!)

```
 return errors.Errorf(`no consistency checks are defined for %s` + gen.Meta().Name)
```
(Incompatible use of `%s` and string concatenation.)

```
  errors.New(fmt.Sprintf("foo %s", blah))
```
(Should use `Newf()` instead to capture more data in telemetry.)

Release note: None