### PR TITLE
roachtest: don't run schema change workload on 19.2 releases

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -51,11 +51,7 @@ func registerAcceptance(r *testRegistry) {
 		{
 			name: "version-upgrade",
 			fn: func(ctx context.Context, t *test, c *cluster) {
-				predV, err := PredecessorVersion(r.buildVersion)
-				if err != nil {
-					t.Fatal(err)
-				}
-				runVersionUpgrade(ctx, t, c, predV)
+				runVersionUpgrade(ctx, t, c, r.buildVersion)
 			},
 			// This test doesn't like running on old versions because it upgrades to
 			// the latest released version and then it tries to "head", where head is

--- a/pkg/cmd/roachtest/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/mixed_version_schemachange.go
@@ -13,6 +13,8 @@ package main
 import (
 	"context"
 	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/util/version"
 )
 
 func registerSchemaChangeMixedVersions(r *testRegistry) {
@@ -25,15 +27,11 @@ func registerSchemaChangeMixedVersions(r *testRegistry) {
 		MinVersion: "v20.1.0",
 		Cluster:    makeClusterSpec(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {
-			predV, err := PredecessorVersion(r.buildVersion)
-			if err != nil {
-				t.Fatal(err)
-			}
 			maxOps := 100
 			if local {
 				maxOps = 10
 			}
-			runSchemaChangeMixedVersions(ctx, t, c, maxOps, predV)
+			runSchemaChangeMixedVersions(ctx, t, c, maxOps, r.buildVersion)
 		},
 	})
 }
@@ -63,12 +61,23 @@ func runSchemaChangeWorkloadStep(maxOps int) versionStep {
 }
 
 func runSchemaChangeMixedVersions(
-	ctx context.Context, t *test, c *cluster, maxOps int, predecessorVersion string,
+	ctx context.Context, t *test, c *cluster, maxOps int, buildVersion version.Version,
 ) {
+	predecessorVersion, err := PredecessorVersion(buildVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// An empty string will lead to the cockroach binary specified by flag
 	// `cockroach` to be used.
 	const mainVersion = ""
 	schemaChangeStep := runSchemaChangeWorkloadStep(maxOps)
+	if buildVersion.Major() < 20 {
+		// Schema change workload is meant to run only on versions 19.2 or higher.
+		// If the main version is below 20.1 then then predecessor version will be
+		// below 19.2.
+		schemaChangeStep = nil
+	}
 
 	u := newVersionUpgradeTest(c,
 		uploadAndStartFromCheckpointFixture(c.All(), predecessorVersion),

--- a/pkg/cmd/roachtest/versionupgrade.go
+++ b/pkg/cmd/roachtest/versionupgrade.go
@@ -72,7 +72,11 @@ DROP TABLE test.t;
 	`),
 }
 
-func runVersionUpgrade(ctx context.Context, t *test, c *cluster, predecessorVersion string) {
+func runVersionUpgrade(ctx context.Context, t *test, c *cluster, buildVersion version.Version) {
+	predecessorVersion, err := PredecessorVersion(buildVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// This test uses fixtures and we do not have encrypted fixtures right now.
 	c.encryptDefault = false
 
@@ -159,8 +163,9 @@ func (u *versionUpgradeTest) run(ctx context.Context, t *test) {
 	}()
 
 	for _, step := range u.steps {
-		step(ctx, t, u)
-
+		if step != nil {
+			step(ctx, t, u)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #47024.

Release note (bug fix):
The schema change workload is meant for testing the behavior of schema
changes on clusters with nodes with min version 19.2. It will deadlock
on earlier versions.