### PR TITLE
cli: delete `cockroach node decommission --wait=live`

### DIFF
--- a/pkg/cli/flags_util.go
+++ b/pkg/cli/flags_util.go
@@ -282,7 +282,6 @@ type nodeDecommissionWaitType int
 
 const (
 	nodeDecommissionWaitAll nodeDecommissionWaitType = iota
-	nodeDecommissionWaitLive
 	nodeDecommissionWaitNone
 )
 
@@ -294,12 +293,11 @@ func (s *nodeDecommissionWaitType) String() string {
 	switch *s {
 	case nodeDecommissionWaitAll:
 		return "all"
-	case nodeDecommissionWaitLive:
-		return "live"
 	case nodeDecommissionWaitNone:
 		return "none"
+	default:
+		panic("unexpected node decommission wait type (possible values: all, none)")
 	}
-	return ""
 }
 
 // Set implements the pflag.Value interface.
@@ -307,13 +305,11 @@ func (s *nodeDecommissionWaitType) Set(value string) error {
 	switch value {
 	case "all":
 		*s = nodeDecommissionWaitAll
-	case "live":
-		*s = nodeDecommissionWaitLive
 	case "none":
 		*s = nodeDecommissionWaitNone
 	default:
 		return fmt.Errorf("invalid node decommission parameter: %s "+
-			"(possible values: all, live, none)", value)
+			"(possible values: all, none)", value)
 	}
 	return nil
 }

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -369,9 +369,6 @@ func runDecommissionNodeImpl(
 	wait nodeDecommissionWaitType,
 	nodeIDs []roachpb.NodeID,
 ) error {
-	if wait == nodeDecommissionWaitLive {
-		fmt.Fprintln(stderr, "\n--wait=live is deprecated and is treated as --wait=all")
-	}
 	minReplicaCount := int64(math.MaxInt64)
 	opts := retry.Options{
 		InitialBackoff: 5 * time.Millisecond,


### PR DESCRIPTION
It was deprecated a while ago.

Release note: `cockroach node decommission --wait=live` is no longer
supported. It was deprecated in an earlier release.