### PR TITLE
sql: don't split ranges on user-defined types or schemas

### DIFF
--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -131,7 +131,10 @@ func (s *SystemConfig) GetDesc(key roachpb.Key) *roachpb.Value {
 		// configs through proper channels.
 		//
 		// Getting here outside tests is impossible.
-		val := roachpb.MakeValueFromBytes(nil)
+		var val roachpb.Value
+		if err := val.SetProto(sqlbase.WrapDescriptor(&sqlbase.TableDescriptor{})); err != nil {
+			panic(err)
+		}
 		return &val
 	}
 	return nil
@@ -533,7 +536,7 @@ func (s *SystemConfig) shouldSplit(ID uint32) bool {
 		shouldSplit = true
 	} else {
 		desc := s.GetDesc(keys.TODOSQLCodec.DescMetadataKey(ID))
-		shouldSplit = desc != nil && sqlbase.ShouldSplitAtID(ID, desc)
+		shouldSplit = desc != nil && sqlbase.ShouldSplitAtDesc(desc)
 	}
 	// Populate the cache.
 	s.mu.Lock()

--- a/pkg/config/system_test.go
+++ b/pkg/config/system_test.go
@@ -48,7 +48,13 @@ func sqlKV(tableID uint32, indexID, descriptorID uint64) roachpb.KeyValue {
 }
 
 func descriptor(descriptorID uint64) roachpb.KeyValue {
-	return kv(sqlbase.MakeDescMetadataKey(keys.SystemSQLCodec, sqlbase.ID(descriptorID)), nil)
+	k := sqlbase.MakeDescMetadataKey(keys.SystemSQLCodec, sqlbase.ID(descriptorID))
+	v := sqlbase.WrapDescriptor(&sqlbase.TableDescriptor{})
+	kv := roachpb.KeyValue{Key: k}
+	if err := kv.Value.SetProto(v); err != nil {
+		panic(err)
+	}
+	return kv
 }
 
 func zoneConfig(descriptorID uint32, spans ...zonepb.SubzoneSpan) roachpb.KeyValue {

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1303,7 +1303,7 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 		for i := keys.MinUserDescID; i <= userTableMax; i++ {
 			// We don't care about the value, just the key.
 			key := sqlbase.MakeDescMetadataKey(keys.SystemSQLCodec, sqlbase.ID(i))
-			if err := txn.Put(ctx, key, &sqlbase.Descriptor{}); err != nil {
+			if err := txn.Put(ctx, key, sqlbase.WrapDescriptor(&sqlbase.TableDescriptor{})); err != nil {
 				return err
 			}
 		}
@@ -1367,7 +1367,7 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 		// This time, only write the last table descriptor. Splits only occur for
 		// the descriptor we add. We don't care about the value, just the key.
 		k := sqlbase.MakeDescMetadataKey(keys.SystemSQLCodec, sqlbase.ID(userTableMax))
-		return txn.Put(ctx, k, &sqlbase.Descriptor{})
+		return txn.Put(ctx, k, sqlbase.WrapDescriptor(&sqlbase.TableDescriptor{}))
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/kvserver/gossip_test.go
+++ b/pkg/kv/kvserver/gossip_test.go
@@ -212,10 +212,12 @@ func TestGossipAfterAbortOfSystemConfigTransactionAfterFailureDueToIntents(t *te
 	txB := db.NewTxn(ctx, "b")
 
 	require.NoError(t, txA.SetSystemConfigTrigger())
-	require.NoError(t, txA.Put(ctx, keys.SystemSQLCodec.DescMetadataKey(1000), &sqlbase.Descriptor{}))
+	require.NoError(t, txA.Put(
+		ctx, keys.SystemSQLCodec.DescMetadataKey(1000), sqlbase.WrapDescriptor(&sqlbase.DatabaseDescriptor{})))
 
 	require.NoError(t, txB.SetSystemConfigTrigger())
-	require.NoError(t, txB.Put(ctx, keys.SystemSQLCodec.DescMetadataKey(2000), &sqlbase.Descriptor{}))
+	require.NoError(t, txB.Put(
+		ctx, keys.SystemSQLCodec.DescMetadataKey(2000), sqlbase.WrapDescriptor(&sqlbase.DatabaseDescriptor{})))
 
 	const someTime = 10 * time.Millisecond
 	clearNotifictions := func(ch <-chan struct{}) {

--- a/pkg/sql/sqlbase/system_test.go
+++ b/pkg/sql/sqlbase/system_test.go
@@ -1,0 +1,32 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqlbase
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldSplitAtDesc(t *testing.T) {
+	for inner, should := range map[DescriptorProto]bool{
+		&TableDescriptor{}:                    true,
+		&TableDescriptor{ViewQuery: "SELECT"}: false,
+		&DatabaseDescriptor{}:                 false,
+		&TypeDescriptor{}:                     false,
+		&SchemaDescriptor{}:                   false,
+	} {
+		var rawDesc roachpb.Value
+		require.NoError(t, rawDesc.SetProto(WrapDescriptor(inner)))
+		require.Equal(t, should, ShouldSplitAtDesc(&rawDesc))
+	}
+}


### PR DESCRIPTION
Noticed while working on multi-tenancy and confirmed that this
was an issue manually.

```
root@127.0.0.1:51841/movr> set experimental_enable_enums=true;
SET

Time: 259µs

root@127.0.0.1:51841/movr> select count(*) from crdb_internal.ranges;
  count
---------
     62
(1 row)

Time: 2.251ms

root@127.0.0.1:51841/movr> CREATE TYPE t AS ENUM ();
CREATE TYPE

Time: 1.698ms

root@127.0.0.1:51841/movr> select count(*) from crdb_internal.ranges;
  count
---------
     63
(1 row)

Time: 1.815ms
```

I tried to write a logic test that did essentially this, but that
ended up being pretty frustrating to get right and the end result
seemed too fragile to be worth it.