### PR TITLE
cli: deprecate `cockroach quit`

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1387,8 +1387,6 @@ Available Commands:
   start-single-node start a single-node cluster
   init              initialize a cluster
   cert              create ca, node, and client certs
-  quit              drain and shut down a node
-
   sql               open a sql shell
   auth-session      log in and out of HTTP sessions
   node              list, inspect, drain or remove nodes

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -112,7 +112,7 @@ start_test "Test that quit does not show INFO by default with --logtostderr"
 # are printed between the marker and the (first line) error message
 # from quit. Quit will error out because the server is already stopped.
 send "echo marker; $argv quit --logtostderr 2>&1 | grep -vE '^\[WEF\]\[0-9\]+|^node is draining'\r"
-eexpect "marker\r\nok"
+eexpect "marker\r\nCommand \"quit\" is deprecated"
 eexpect ":/# "
 end_test
 

--- a/pkg/cli/quit.go
+++ b/pkg/cli/quit.go
@@ -26,22 +26,23 @@ import (
 )
 
 // quitCmd command shuts down the node server.
+// TODO(irfansharif): Delete this subcommand once v20.2 is cut.
 var quitCmd = &cobra.Command{
 	Use:   "quit",
 	Short: "drain and shut down a node\n",
 	Long: `
-Shut down the server. The first stage is drain, where the server
-stops accepting client connections, then stops extant
-connections, and finally pushes range leases onto other nodes,
-subject to various timeout parameters configurable via
-cluster settings. After the first stage completes,
-the server process is shut down.
-
-See also 'cockroach node drain' to drain a server
-without stopping the server process.
+Shut down the server. The first stage is drain, where the server stops accepting
+client connections, then stops extant connections, and finally pushes range
+leases onto other nodes, subject to various timeout parameters configurable via
+cluster settings. After the first stage completes, the server process is shut
+down.
 `,
 	Args: cobra.NoArgs,
 	RunE: MaybeDecorateGRPCError(runQuit),
+	Deprecated: `see 'cockroach node drain' instead to drain a 
+server without terminating the server process (which can in turn be done using 
+an orchestration layer or a process manager, or by sending a termination signal
+directly).`,
 }
 
 // runQuit accesses the quit shutdown path.


### PR DESCRIPTION
`cockroach quit` has been hollowed out in favor of `cockroach node`
subcommands (specifically `cockroach node drain`. To actually quit the
cockroach process, we now encourage users to send
SIG{KILL/TERM/INT/QUIT} instead.

Release note: `cockroach quit` is now deprecated. Users should lean on
the subcommands under `cockroach node` instead, and use
SIG{KILL/TERM/INT/QUIT} signals to quit the cockroach process.

---

@knz: I'm actually not sure about any of this. This was prompted by 
conversations in #cli internally. The deprecation message should/could also 
be improved, so suggestions are welcome.