### PR TITLE
rowcontainer,rowexec: switch joinReader to use DiskBackedNumberedRowC…

### DIFF
--- a/pkg/sql/rowcontainer/numbered_row_container_test.go
+++ b/pkg/sql/rowcontainer/numbered_row_container_test.go
@@ -61,17 +61,15 @@ func TestNumberedRowContainerDeDuping(t *testing.T) {
 		st,
 	)
 	diskMonitor := execinfra.NewTestDiskMonitor(ctx, st)
+	defer diskMonitor.Stop(ctx)
 
 	memoryBudget := math.MaxInt64
 	if rng.Intn(2) == 0 {
 		fmt.Printf("using smallMemoryBudget to spill to disk\n")
 		memoryBudget = smallMemoryBudget
 	}
-
 	memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(int64(memoryBudget)))
 	defer memoryMonitor.Stop(ctx)
-	diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
-	defer diskMonitor.Stop(ctx)
 
 	// Use random types and random rows.
 	types := sqlbase.RandSortingTypes(rng, numCols)
@@ -149,17 +147,15 @@ func TestNumberedRowContainerIteratorCaching(t *testing.T) {
 		st,
 	)
 	diskMonitor := execinfra.NewTestDiskMonitor(ctx, st)
+	defer diskMonitor.Stop(ctx)
 
 	numRows := 200
 	const numCols = 2
 	// This memory budget allows for some caching, but typically cannot
 	// cache all the rows.
 	const memoryBudget = 12000
-
 	memoryMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(memoryBudget))
 	defer memoryMonitor.Stop(ctx)
-	diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
-	defer diskMonitor.Stop(ctx)
 
 	// Use random types and random rows.
 	rng, _ := randutil.NewPseudoRand()
@@ -223,12 +219,120 @@ func TestNumberedRowContainerIteratorCaching(t *testing.T) {
 	}
 }
 
+// Tests that the DiskBackedNumberedRowContainer and
+// DiskBackedIndexedRowContainer return the same results.
+func TestCompareNumberedAndIndexedRowContainers(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	rng, _ := randutil.NewPseudoRand()
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	tempEngine, _, err := storage.NewTempEngine(ctx, storage.DefaultStorageEngine, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tempEngine.Close()
+
+	diskMonitor := execinfra.NewTestDiskMonitor(ctx, st)
+	defer diskMonitor.Stop(ctx)
+
+	numRows := 200
+	const numCols = 2
+	// This memory budget allows for some caching, but typically cannot
+	// cache all the rows.
+	var memoryBudget int64 = 12000
+	if rng.Intn(2) == 0 {
+		memoryBudget = math.MaxInt64
+	}
+
+	// Use random types and random rows.
+	types := sqlbase.RandSortingTypes(rng, numCols)
+	ordering := sqlbase.ColumnOrdering{
+		sqlbase.ColumnOrderInfo{
+			ColIdx:    0,
+			Direction: encoding.Ascending,
+		},
+		sqlbase.ColumnOrderInfo{
+			ColIdx:    1,
+			Direction: encoding.Descending,
+		},
+	}
+	numRows, rows := makeUniqueRows(t, &evalCtx, rng, numRows, types, ordering)
+
+	var containers [2]numberedContainer
+	containers[0] = makeNumberedContainerUsingIRC(
+		ctx, t, types, &evalCtx, tempEngine, st, memoryBudget, diskMonitor)
+	containers[1] = makeNumberedContainerUsingNRC(
+		ctx, t, types, &evalCtx, tempEngine, st, memoryBudget, diskMonitor)
+	defer func() {
+		for _, rc := range containers {
+			rc.close(ctx)
+		}
+	}()
+
+	// Each pass does an UnsafeReset at the end.
+	for passWithReset := 0; passWithReset < 2; passWithReset++ {
+		// Insert rows.
+		for i := 0; i < numRows; i++ {
+			for _, rc := range containers {
+				err := rc.addRow(ctx, rows[i])
+				require.NoError(t, err)
+			}
+		}
+		// We want all the memory to be usable by the cache, so spill to disk.
+		if memoryBudget != math.MaxInt64 {
+			for _, rc := range containers {
+				require.NoError(t, rc.spillToDisk(ctx))
+			}
+		}
+
+		// Random access of the inserted rows.
+		var accesses [][]int
+		for i := 0; i < 2*numRows; i++ {
+			var access []int
+			for j := 0; j < 4; j++ {
+				access = append(access, rng.Intn(numRows))
+			}
+			accesses = append(accesses, access)
+		}
+		for _, rc := range containers {
+			rc.setupForRead(ctx, accesses)
+		}
+		for _, access := range accesses {
+			for _, index := range access {
+				skip := rng.Intn(10) == 0
+				var rows [2]sqlbase.EncDatumRow
+				for i, rc := range containers {
+					row, err := rc.getRow(ctx, index, skip)
+					require.NoError(t, err)
+					rows[i] = row
+				}
+				if skip {
+					continue
+				}
+				require.Equal(t, rows[0].String(types), rows[1].String(types))
+			}
+		}
+		// Reset and reorder the rows for the next pass.
+		rand.Shuffle(numRows, func(i, j int) {
+			rows[i], rows[j] = rows[j], rows[i]
+		})
+		for _, rc := range containers {
+			require.NoError(t, rc.unsafeReset(ctx))
+		}
+	}
+}
+
 // Adapter interface that can be implemented using both DiskBackedNumberedRowContainer
 // and DiskBackedIndexedRowContainer.
 type numberedContainer interface {
 	addRow(context.Context, sqlbase.EncDatumRow) error
 	setupForRead(ctx context.Context, accesses [][]int)
-	getRow(ctx context.Context, idx int) (sqlbase.EncDatumRow, error)
+	getRow(ctx context.Context, idx int, skip bool) (sqlbase.EncDatumRow, error)
+	spillToDisk(context.Context) error
+	unsafeReset(context.Context) error
 	close(context.Context)
 }
 
@@ -245,9 +349,15 @@ func (d numberedContainerUsingNRC) setupForRead(ctx context.Context, accesses []
 	d.rc.SetupForRead(ctx, accesses)
 }
 func (d numberedContainerUsingNRC) getRow(
-	ctx context.Context, idx int,
+	ctx context.Context, idx int, skip bool,
 ) (sqlbase.EncDatumRow, error) {
 	return d.rc.GetRow(ctx, idx, false)
+}
+func (d numberedContainerUsingNRC) spillToDisk(ctx context.Context) error {
+	return d.rc.testingSpillToDisk(ctx)
+}
+func (d numberedContainerUsingNRC) unsafeReset(ctx context.Context) error {
+	return d.rc.UnsafeReset(ctx)
 }
 func (d numberedContainerUsingNRC) close(ctx context.Context) {
 	d.rc.Close(ctx)
@@ -255,7 +365,7 @@ func (d numberedContainerUsingNRC) close(ctx context.Context) {
 }
 func makeNumberedContainerUsingNRC(
 	ctx context.Context,
-	b *testing.B,
+	t testing.TB,
 	types []*types.T,
 	evalCtx *tree.EvalContext,
 	engine diskmap.Factory,
@@ -266,7 +376,7 @@ func makeNumberedContainerUsingNRC(
 	memoryMonitor := makeMemMonitorAndStart(ctx, st, memoryBudget)
 	rc := NewDiskBackedNumberedRowContainer(
 		false /* deDup */, types, evalCtx, engine, memoryMonitor, diskMonitor, 0 /* rowCapacity */)
-	require.NoError(b, rc.testingSpillToDisk(ctx))
+	require.NoError(t, rc.testingSpillToDisk(ctx))
 	return numberedContainerUsingNRC{rc: rc, memoryMonitor: memoryMonitor}
 }
 
@@ -280,13 +390,25 @@ func (d numberedContainerUsingIRC) addRow(ctx context.Context, row sqlbase.EncDa
 }
 func (d numberedContainerUsingIRC) setupForRead(context.Context, [][]int) {}
 func (d numberedContainerUsingIRC) getRow(
-	ctx context.Context, idx int,
+	ctx context.Context, idx int, skip bool,
 ) (sqlbase.EncDatumRow, error) {
+	if skip {
+		return nil, nil
+	}
 	row, err := d.rc.GetRow(ctx, idx)
 	if err != nil {
 		return nil, err
 	}
 	return row.(IndexedRow).Row, nil
+}
+func (d numberedContainerUsingIRC) spillToDisk(ctx context.Context) error {
+	if d.rc.UsingDisk() {
+		return nil
+	}
+	return d.rc.SpillToDisk(ctx)
+}
+func (d numberedContainerUsingIRC) unsafeReset(ctx context.Context) error {
+	return d.rc.UnsafeReset(ctx)
 }
 func (d numberedContainerUsingIRC) close(ctx context.Context) {
 	d.rc.Close(ctx)
@@ -294,7 +416,7 @@ func (d numberedContainerUsingIRC) close(ctx context.Context) {
 }
 func makeNumberedContainerUsingIRC(
 	ctx context.Context,
-	b *testing.B,
+	t require.TestingT,
 	types []*types.T,
 	evalCtx *tree.EvalContext,
 	engine diskmap.Factory,
@@ -305,7 +427,7 @@ func makeNumberedContainerUsingIRC(
 	memoryMonitor := makeMemMonitorAndStart(ctx, st, memoryBudget)
 	rc := NewDiskBackedIndexedRowContainer(
 		nil /* ordering */, types, evalCtx, engine, memoryMonitor, diskMonitor, 0 /* rowCapacity */)
-	require.NoError(b, rc.SpillToDisk(ctx))
+	require.NoError(t, rc.SpillToDisk(ctx))
 	return numberedContainerUsingIRC{rc: rc, memoryMonitor: memoryMonitor}
 }
 
@@ -518,7 +640,7 @@ func BenchmarkNumberedContainerIteratorCaching(b *testing.B) {
 					nc.setupForRead(ctx, accesses)
 					for i := 0; i < len(accesses); i++ {
 						for j := 0; j < len(accesses[i]); j++ {
-							if _, err := nc.getRow(ctx, accesses[i][j]); err != nil {
+							if _, err := nc.getRow(ctx, accesses[i][j], false /* skip */); err != nil {
 								b.Fatal(err)
 							}
 						}
@@ -547,8 +669,5 @@ func BenchmarkNumberedContainerIteratorCaching(b *testing.B) {
 }
 
 // TODO(sumeer):
-// - Randomized correctness test comparing the rows returned by
-//   DiskBacked{Numbered,Indexed}RowContainer.
 // - Benchmarks:
 //   - de-duping with and without spilling.
-//   - different batch sizes for the left side.

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -215,9 +215,8 @@ func (jr *joinReader) initJoinReaderStrategy(
 	// Initialize memory monitors and row container for looked up rows.
 	jr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "joiner-limited")
 	jr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.Cfg.DiskMonitor, "joinreader-disk")
-	drc := rowcontainer.NewDiskBackedIndexedRowContainer(
-		// TODO(asubiotto): Does a nil ordering make sense in all cases?
-		nil, /* ordering */
+	drc := rowcontainer.NewDiskBackedNumberedRowContainer(
+		false, /* deDup */
 		typs,
 		jr.EvalCtx,
 		jr.FlowCtx.Cfg.TempStorage,
@@ -411,6 +410,7 @@ func (jr *joinReader) performLookup() (joinReaderState, *execinfrapb.ProducerMet
 		}
 	}
 	log.VEvent(jr.Ctx, 1, "done joining rows")
+	jr.strategy.prepareToEmit(jr.Ctx)
 
 	return jrEmittingRows, nil
 }

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -839,94 +839,112 @@ func BenchmarkJoinReader(b *testing.B) {
 	for _, reqOrdering := range []bool{true, false} {
 		for columnIdx, columnDef := range rightSideColumnDefs {
 			for _, numLookupRows := range []int{1, 1 << 4 /* 16 */, 1 << 8 /* 256 */, 1 << 10 /* 1024 */, 1 << 12 /* 4096 */, 1 << 13 /* 8192 */, 1 << 14 /* 16384 */, 1 << 15 /* 32768 */, 1 << 16 /* 65,536 */, 1 << 19 /* 524,288 */} {
-				if rightSz/columnDef.matchesPerLookupRow < numLookupRows {
-					// This case does not make sense since we won't have distinct lookup
-					// rows. We don't currently merge spans which could make this an
-					// interesting case to benchmark, but we probably should.
-					continue
-				}
-
-				eqColsAreKey := []bool{false}
-				if numLookupRows == 1 {
-					// For this case, execute the parallel lookup case as well.
-					eqColsAreKey = []bool{true, false}
-				}
-				for _, parallel := range eqColsAreKey {
-					benchmarkName := fmt.Sprintf("reqOrdering=%t/matchratio=oneto%s/lookuprows=%d", reqOrdering, columnDef.name, numLookupRows)
-					if parallel {
-						benchmarkName += "/parallel=true"
+				for _, memoryLimit := range []int64{100 << 10, math.MaxInt64} {
+					memoryLimitStr := "mem=unlimited"
+					if memoryLimit != math.MaxInt64 {
+						if !reqOrdering {
+							// Smaller memory limit is not relevant when there is no ordering.
+							continue
+						}
+						memoryLimitStr = fmt.Sprintf("mem=%dKB", memoryLimit/(1<<10))
+						// The benchmark workloads are such that each right row never joins
+						// with more than one left row. And the access pattern of right rows
+						// accessed across all the left rows is monotonically increasing. So
+						// once spilled to disk, the reads will always need to get from disk
+						// (caching cannot improve performance).
+						//
+						// TODO(sumeer): add workload that can benefit from caching.
 					}
-					b.Run(benchmarkName, func(b *testing.B) {
-						tableName := tableSizeToName(rightSz)
+					if rightSz/columnDef.matchesPerLookupRow < numLookupRows {
+						// This case does not make sense since we won't have distinct lookup
+						// rows. We don't currently merge spans which could make this an
+						// interesting case to benchmark, but we probably should.
+						continue
+					}
 
-						// Get the table descriptor and find the index that will provide us with
-						// the expected match ratio.
-						tableDesc := sqlbase.GetTableDescriptor(kvDB, keys.SystemSQLCodec, "test", tableName)
-						indexIdx := uint32(0)
-						for i := range tableDesc.Indexes {
-							require.Equal(b, 1, len(tableDesc.Indexes[i].ColumnNames), "all indexes created in this benchmark should only contain one column")
-							if tableDesc.Indexes[i].ColumnNames[0] == columnDef.name {
-								// Found indexIdx.
-								indexIdx = uint32(i + 1)
-								break
-							}
+					eqColsAreKey := []bool{false}
+					if numLookupRows == 1 {
+						// For this case, execute the parallel lookup case as well.
+						eqColsAreKey = []bool{true, false}
+					}
+					for _, parallel := range eqColsAreKey {
+						benchmarkName := fmt.Sprintf("reqOrdering=%t/matchratio=oneto%s/lookuprows=%d/%s",
+							reqOrdering, columnDef.name, numLookupRows, memoryLimitStr)
+						if parallel {
+							benchmarkName += "/parallel=true"
 						}
-						if indexIdx == 0 {
-							b.Fatalf("failed to find secondary index for column %s", columnDef.name)
-						}
-						input := newRowGeneratingSource(sqlbase.OneIntCol, sqlutils.ToRowFn(func(rowIdx int) tree.Datum {
-							// Convert to 0-based.
-							return tree.NewDInt(tree.DInt(rowIdx - 1))
-						}), numLookupRows)
-						output := rowDisposer{}
+						b.Run(benchmarkName, func(b *testing.B) {
+							tableName := tableSizeToName(rightSz)
 
-						spec := execinfrapb.JoinReaderSpec{
-							Table:               *tableDesc,
-							LookupColumns:       []uint32{0},
-							LookupColumnsAreKey: parallel,
-							IndexIdx:            indexIdx,
-							MaintainOrdering:    reqOrdering,
-						}
-						// Post specifies that only the columns contained in the secondary index
-						// need to be output.
-						post := execinfrapb.PostProcessSpec{
-							Projection:    true,
-							OutputColumns: []uint32{uint32(columnIdx + 1)},
-						}
+							// Get the table descriptor and find the index that will provide us with
+							// the expected match ratio.
+							tableDesc := sqlbase.GetTableDescriptor(kvDB, keys.SystemSQLCodec, "test", tableName)
+							indexIdx := uint32(0)
+							for i := range tableDesc.Indexes {
+								require.Equal(b, 1, len(tableDesc.Indexes[i].ColumnNames), "all indexes created in this benchmark should only contain one column")
+								if tableDesc.Indexes[i].ColumnNames[0] == columnDef.name {
+									// Found indexIdx.
+									indexIdx = uint32(i + 1)
+									break
+								}
+							}
+							if indexIdx == 0 {
+								b.Fatalf("failed to find secondary index for column %s", columnDef.name)
+							}
+							input := newRowGeneratingSource(sqlbase.OneIntCol, sqlutils.ToRowFn(func(rowIdx int) tree.Datum {
+								// Convert to 0-based.
+								return tree.NewDInt(tree.DInt(rowIdx - 1))
+							}), numLookupRows)
+							output := rowDisposer{}
 
-						expectedNumOutputRows := numLookupRows * columnDef.matchesPerLookupRow
-						b.ResetTimer()
-						// The number of bytes processed in this benchmark is the number of
-						// lookup bytes processed + the number of result bytes. We only look
-						// up using a single int column and the request only a single int column
-						// contained in the index.
-						b.SetBytes(int64((numLookupRows * 8) + (expectedNumOutputRows * 8)))
+							spec := execinfrapb.JoinReaderSpec{
+								Table:               *tableDesc,
+								LookupColumns:       []uint32{0},
+								LookupColumnsAreKey: parallel,
+								IndexIdx:            indexIdx,
+								MaintainOrdering:    reqOrdering,
+							}
+							// Post specifies that only the columns contained in the secondary index
+							// need to be output.
+							post := execinfrapb.PostProcessSpec{
+								Projection:    true,
+								OutputColumns: []uint32{uint32(columnIdx + 1)},
+							}
 
-						spilled := false
-						for i := 0; i < b.N; i++ {
-							jr, err := newJoinReader(&flowCtx, 0 /* processorID */, &spec, input, &post, &output)
-							if err != nil {
-								b.Fatal(err)
-							}
-							jr.Run(ctx)
-							if !spilled && jr.(*joinReader).Spilled() {
-								spilled = true
-							}
-							meta := output.DrainMeta(ctx)
-							if meta != nil {
-								b.Fatalf("unexpected metadata: %v", meta)
-							}
-							if output.NumRowsDisposed() != expectedNumOutputRows {
-								b.Fatalf("got %d output rows, expected %d", output.NumRowsDisposed(), expectedNumOutputRows)
-							}
-							output.ResetNumRowsDisposed()
-							input.Reset()
-						}
+							expectedNumOutputRows := numLookupRows * columnDef.matchesPerLookupRow
+							b.ResetTimer()
+							// The number of bytes processed in this benchmark is the number of
+							// lookup bytes processed + the number of result bytes. We only look
+							// up using a single int column and the request only a single int column
+							// contained in the index.
+							b.SetBytes(int64((numLookupRows * 8) + (expectedNumOutputRows * 8)))
 
-						if spilled {
-							b.Log("joinReader spilled to disk in at least one of the benchmark iterations")
-						}
-					})
+							spilled := false
+							for i := 0; i < b.N; i++ {
+								flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = memoryLimit
+								jr, err := newJoinReader(&flowCtx, 0 /* processorID */, &spec, input, &post, &output)
+								if err != nil {
+									b.Fatal(err)
+								}
+								jr.Run(ctx)
+								if !spilled && jr.(*joinReader).Spilled() {
+									spilled = true
+								}
+								meta := output.DrainMeta(ctx)
+								if meta != nil {
+									b.Fatalf("unexpected metadata: %v", meta)
+								}
+								if output.NumRowsDisposed() != expectedNumOutputRows {
+									b.Fatalf("got %d output rows, expected %d", output.NumRowsDisposed(), expectedNumOutputRows)
+								}
+								output.ResetNumRowsDisposed()
+								input.Reset()
+							}
+							if spilled {
+								b.Log("joinReader spilled to disk in at least one of the benchmark iterations")
+							}
+						})
+					}
 				}
 			}
 		}


### PR DESCRIPTION
…ontainer

Additionally,
- added a randomized correctness test that compares the results of the indexed
  and numbered containers.
- added benchmark cases to the joinReader benchmark that limit memory. None of the
  workloads have repeated reads of the same right row and all access the right
  rows in monotonically increasing order so the difference between the two
  containers is due to the numbered container avoiding the overhead of populating
  the cache.
- reduced the number of slice allocations in newNumberedDiskRowIterator.

Fixes #48118

Release note: None