### PR TITLE
sql: rename columns in partial index predicates

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -126,3 +126,46 @@ t6  CREATE TABLE t6 (
     FAMILY "primary" (a, rowid)
 )
 
+#### Renaming a column updates the index predicates.
+
+statement ok
+ALTER TABLE t6 RENAME COLUMN a TO b
+
+query TT
+SHOW CREATE TABLE t6
+----
+t6  CREATE TABLE t6 (
+    b INT8 NULL,
+    INDEX t6_a_idx (b ASC) WHERE b > 0,
+    INDEX t6_a_idx1 (b ASC) WHERE b > 1,
+    INDEX t6_a_idx2 (b DESC) WHERE b > 2,
+    UNIQUE INDEX t6_a_key (b ASC) WHERE b > 3,
+    UNIQUE INDEX t6_a_key1 (b ASC) WHERE b > 4,
+    UNIQUE INDEX t6_a_key2 (b DESC) WHERE b > 5,
+    INDEX t6i1 (b ASC) WHERE b > 6,
+    INDEX t6i2 (b ASC) WHERE b > 7,
+    INDEX t6i3 (b DESC) WHERE b > 8,
+    FAMILY "primary" (b, rowid)
+)
+
+#### Renaming a table keeps the index predicates intact.
+
+statement ok
+ALTER TABLE t6 RENAME TO t7
+
+query TT
+SHOW CREATE TABLE t7
+----
+t7  CREATE TABLE t7 (
+    b INT8 NULL,
+    INDEX t6_a_idx (b ASC) WHERE b > 0,
+    INDEX t6_a_idx1 (b ASC) WHERE b > 1,
+    INDEX t6_a_idx2 (b DESC) WHERE b > 2,
+    UNIQUE INDEX t6_a_key (b ASC) WHERE b > 3,
+    UNIQUE INDEX t6_a_key1 (b ASC) WHERE b > 4,
+    UNIQUE INDEX t6_a_key2 (b DESC) WHERE b > 5,
+    INDEX t6i1 (b ASC) WHERE b > 6,
+    INDEX t6i2 (b ASC) WHERE b > 7,
+    INDEX t6i3 (b DESC) WHERE b > 8,
+    FAMILY "primary" (b, rowid)
+)

--- a/pkg/sql/schemaexpr/column.go
+++ b/pkg/sql/schemaexpr/column.go
@@ -124,6 +124,38 @@ func FormatColumnForDisplay(
 	return f.CloseAndGetString(), nil
 }
 
+// RenameColumn replaces any occurrence of the column from in expr with to, and
+// returns a string representation of the new expression.
+func RenameColumn(expr string, from tree.Name, to tree.Name) (string, error) {
+	parsed, err := parser.ParseExpr(expr)
+	if err != nil {
+		return "", err
+	}
+
+	replaceFn := func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+		if vBase, ok := expr.(tree.VarName); ok {
+			v, err := vBase.NormalizeVarName()
+			if err != nil {
+				return false, nil, err
+			}
+			if c, ok := v.(*tree.ColumnItem); ok {
+				if string(c.ColumnName) == string(from) {
+					c.ColumnName = to
+				}
+			}
+			return false, v, nil
+		}
+		return true, expr, nil
+	}
+
+	renamed, err := tree.SimpleVisit(parsed, replaceFn)
+	if err != nil {
+		return "", err
+	}
+
+	return renamed.String(), nil
+}
+
 // iterColDescriptors iterates over the expression's variable columns and
 // calls f on each.
 //


### PR DESCRIPTION
This commit makes an `ALTER TABLE ... RENAME COLUMN ...` statment
replace the old column names in partial index predicates with the new
column name. For example:

    CREATE TABLE t (a INT, INDEX (a) WHERE a > 0)
    ALTER TABLE t RENAME COLUMN a TO b

The partial index predicate expression, `a > 0`, will now be replaced
with `b > 0`.

Release note: None