### PR TITLE
lease: fix flakey TestRangefeedUpdatesHandledProperlyInTheFaceOfRaces

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -2253,8 +2253,8 @@ func TestRangefeedUpdatesHandledProperlyInTheFaceOfRaces(t *testing.T) {
 	unblockAll := make(chan struct{})
 	args := base.TestServerArgs{
 		Knobs: base.TestingKnobs{
-			Server: &server.TestingKnobs{
-				BootstrapVersionOverride: clusterversion.VersionByKey(clusterversion.VersionRangefeedLeases),
+			SQLLeaseManager: &lease.ManagerTestingKnobs{
+				AlwaysUseRangefeeds: true,
 			},
 		},
 	}


### PR DESCRIPTION
When this test was introduced, the cluster version override was added to
ensure that rangefeeds would be used. This was not necessary given the
other testing knob which this change adopts. The problem with overrriding
the version is that it can happen after the automatic version upgrade already
occurs leading to a fatal error due to trying to downgrade the cluster
version.

Release note: None