### PR TITLE
sql: implement ConstructScan in the new factory

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1031,21 +1031,12 @@ func (dsp *DistSQLPlanner) CheckNodeHealthAndVersion(
 func (dsp *DistSQLPlanner) createTableReaders(
 	planCtx *PlanningCtx, n *scanNode,
 ) (*PhysicalPlan, error) {
-	// scanNodeToTableOrdinalMap is a map from scan node column ordinal to
-	// table reader column ordinal.
-	//
-	// scanNodes can have columns set up in a few different ways, depending on the
-	// colCfg. The heuristic planner always creates scanNodes with all public
-	// columns (even if some of them aren't even in the index we are scanning).
-	// The optimizer creates scanNodes with a specific set of wanted columns; in
-	// this case we have to create a map from scanNode column ordinal to table
-	// column ordinal (which is what the TableReader uses).
-	var scanNodeToTableOrdinalMap []int
 	if n.colCfg.addUnwantedAsHidden {
 		panic("addUnwantedAsHidden not supported")
-	} else if n.colCfg.wantedColumns != nil {
-		scanNodeToTableOrdinalMap = toTableOrdinals(n.cols, n.desc, n.colCfg.visibility)
 	}
+	// scanNodeToTableOrdinalMap is a map from scan node column ordinal to
+	// table reader column ordinal.
+	scanNodeToTableOrdinalMap := toTableOrdinals(n.cols, n.desc, n.colCfg.visibility)
 	spec, post, err := initTableReaderSpec(n, planCtx, scanNodeToTableOrdinalMap)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2116,6 +2116,14 @@ func (dsp *DistSQLPlanner) createPlanForZigzagJoin(
 	return plan, nil
 }
 
+func getTypesFromResultColumns(cols sqlbase.ResultColumns) []*types.T {
+	typs := make([]*types.T, len(cols))
+	for i, col := range cols {
+		typs[i] = col.Typ
+	}
+	return typs
+}
+
 // getTypesForPlanResult returns the types of the elements in the result streams
 // of a plan that corresponds to a given planNode. If planToStreamColMap is nil,
 // a 1-1 mapping is assumed.
@@ -2123,11 +2131,7 @@ func getTypesForPlanResult(node planNode, planToStreamColMap []int) ([]*types.T,
 	nodeColumns := planColumns(node)
 	if planToStreamColMap == nil {
 		// No remapping.
-		types := make([]*types.T, len(nodeColumns))
-		for i := range nodeColumns {
-			types[i] = nodeColumns[i].Typ
-		}
-		return types, nil
+		return getTypesFromResultColumns(nodeColumns), nil
 	}
 	numCols := 0
 	for _, streamCol := range planToStreamColMap {

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -22,12 +22,13 @@ import (
 )
 
 type distSQLSpecExecFactory struct {
+	planner *planner
 }
 
 var _ exec.Factory = &distSQLSpecExecFactory{}
 
-func newDistSQLSpecExecFactory() exec.Factory {
-	return &distSQLSpecExecFactory{}
+func newDistSQLSpecExecFactory(p *planner) exec.Factory {
+	return &distSQLSpecExecFactory{planner: p}
 }
 
 func (e *distSQLSpecExecFactory) ConstructValues(
@@ -235,7 +236,7 @@ func (e *distSQLSpecExecFactory) RenameColumns(
 func (e *distSQLSpecExecFactory) ConstructPlan(
 	root exec.Node, subqueries []exec.Subquery, cascades []exec.Cascade, checks []exec.Node,
 ) (exec.Plan, error) {
-	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+	return constructPlan(e.planner, root, subqueries, cascades, checks)
 }
 
 func (e *distSQLSpecExecFactory) ConstructExplainOpt(

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -12,23 +12,28 @@ package sql
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/span"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 )
 
 type distSQLSpecExecFactory struct {
 	planner *planner
+	dsp     *DistSQLPlanner
 }
 
 var _ exec.Factory = &distSQLSpecExecFactory{}
 
 func newDistSQLSpecExecFactory(p *planner) exec.Factory {
-	return &distSQLSpecExecFactory{planner: p}
+	return &distSQLSpecExecFactory{planner: p, dsp: p.extendedEvalCtx.DistSQLPlanner}
 }
 
 func (e *distSQLSpecExecFactory) ConstructValues(
@@ -37,6 +42,9 @@ func (e *distSQLSpecExecFactory) ConstructValues(
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
 }
 
+// ConstructScan implements exec.Factory interface by combining the logic that
+// performs scanNode creation of execFactory.ConstructScan and physical
+// planning of table readers of DistSQLPlanner.createTableReaders.
 func (e *distSQLSpecExecFactory) ConstructScan(
 	table cat.Table,
 	index cat.Index,
@@ -50,12 +58,135 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	rowCount float64,
 	locking *tree.LockingItem,
 ) (exec.Node, error) {
-	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+	if table.IsVirtualTable() {
+		return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+	}
+
+	var p PhysicalPlan
+	// Although we don't yet recommend distributing plans where soft limits
+	// propagate to scan nodes because we don't have infrastructure to only
+	// plan for a few ranges at a time, the propagation of the soft limits
+	// to scan nodes has been added in 20.1 release, so to keep the
+	// previous behavior we continue to ignore the soft limits for now.
+	// TODO(yuzefovich): pay attention to the soft limits.
+	recommendation := canDistribute
+
+	// Phase 1: set up all necessary infrastructure for table reader planning
+	// below. This phase is equivalent to what execFactory.ConstructScan does.
+	tabDesc := table.(*optTable).desc
+	indexDesc := index.(*optIndex).desc
+	colCfg := makeScanColumnsConfig(table, needed)
+	sb := span.MakeBuilder(e.planner.ExecCfg().Codec, tabDesc.TableDesc(), indexDesc)
+
+	// Note that initColsForScan and setting ResultColumns below are equivalent
+	// to what scan.initTable call does in execFactory.ConstructScan.
+	cols, err := initColsForScan(tabDesc, colCfg)
+	if err != nil {
+		return nil, err
+	}
+	p.ResultColumns = sqlbase.ResultColumnsFromColDescs(tabDesc.GetID(), cols)
+
+	if indexConstraint != nil && indexConstraint.IsContradiction() {
+		// TODO(yuzefovich): once ConstructValues is implemented, consider
+		// calling it here.
+		physPlan, err := e.dsp.createValuesPlan(
+			getTypesFromResultColumns(p.ResultColumns), 0 /* numRows */, nil, /* rawBytes */
+		)
+		return planMaybePhysical{physPlan: physPlan, recommendation: canDistribute}, err
+	}
+
+	// TODO(yuzefovich): scanNode adds "parallel" attribute in walk.go when
+	// scanNode.canParallelize() returns true. We should plumb that info from
+	// here somehow as well.
+	var spans roachpb.Spans
+	spans, err = sb.SpansFromConstraint(indexConstraint, needed, false /* forDelete */)
+	if err != nil {
+		return nil, err
+	}
+	isFullTableScan := len(spans) == 1 && spans[0].EqualValue(
+		tabDesc.IndexSpan(e.planner.ExecCfg().Codec, indexDesc.ID),
+	)
+	if err = colCfg.assertValidReqOrdering(reqOrdering); err != nil {
+		return nil, err
+	}
+
+	// Check if we are doing a full scan.
+	if isFullTableScan {
+		recommendation = recommendation.compose(shouldDistribute)
+	}
+
+	// Phase 2: perform the table reader planning. This phase is equivalent to
+	// what DistSQLPlanner.createTableReaders does.
+	colsToTableOrdinalMap := toTableOrdinals(cols, tabDesc, colCfg.visibility)
+	trSpec := physicalplan.NewTableReaderSpec()
+	*trSpec = execinfrapb.TableReaderSpec{
+		Table:      *tabDesc.TableDesc(),
+		Reverse:    reverse,
+		IsCheck:    false,
+		Visibility: colCfg.visibility,
+		// Retain the capacity of the spans slice.
+		Spans: trSpec.Spans[:0],
+	}
+	trSpec.IndexIdx, err = getIndexIdx(indexDesc, tabDesc)
+	if err != nil {
+		return nil, err
+	}
+	if locking != nil {
+		trSpec.LockingStrength = sqlbase.ToScanLockingStrength(locking.Strength)
+		trSpec.LockingWaitPolicy = sqlbase.ToScanLockingWaitPolicy(locking.WaitPolicy)
+		if trSpec.LockingStrength != sqlbase.ScanLockingStrength_FOR_NONE {
+			// Scans that are performing row-level locking cannot currently be
+			// distributed because their locks would not be propagated back to
+			// the root transaction coordinator.
+			// TODO(nvanbenschoten): lift this restriction.
+			recommendation = cannotDistribute
+		}
+	}
+
+	// Note that we don't do anything about the possible filter here since we
+	// don't know yet whether we will have it. ConstructFilter is responsible
+	// for pushing the filter down into the post-processing stage of this scan.
+	post := execinfrapb.PostProcessSpec{}
+	if hardLimit != 0 {
+		post.Limit = uint64(hardLimit)
+	} else if softLimit != 0 {
+		trSpec.LimitHint = softLimit
+	}
+
+	distribute := shouldDistributeGivenRecAndMode(recommendation, e.planner.extendedEvalCtx.SessionData.DistSQLMode)
+	if _, singleTenant := e.planner.execCfg.NodeID.OptionalNodeID(); !singleTenant {
+		distribute = false
+	}
+
+	evalCtx := e.planner.ExtendedEvalContext()
+	planCtx := e.dsp.NewPlanningCtx(evalCtx.Context, evalCtx, e.planner.txn, distribute)
+	err = e.dsp.planTableReaders(
+		planCtx,
+		&p,
+		&tableReaderPlanningInfo{
+			spec:                   trSpec,
+			post:                   post,
+			desc:                   tabDesc,
+			spans:                  spans,
+			reverse:                reverse,
+			scanVisibility:         colCfg.visibility,
+			maxResults:             maxResults,
+			estimatedRowCount:      uint64(rowCount),
+			reqOrdering:            ReqOrdering(reqOrdering),
+			cols:                   cols,
+			colsToTableOrdrinalMap: colsToTableOrdinalMap,
+		},
+	)
+
+	return planMaybePhysical{physPlan: &p, recommendation: recommendation}, err
 }
 
 func (e *distSQLSpecExecFactory) ConstructFilter(
 	n exec.Node, filter tree.TypedExpr, reqOrdering exec.OutputOrdering,
 ) (exec.Node, error) {
+	// TODO(yuzefovich): figure out how to push the filter into the table
+	// reader when it already doesn't have a filter and it doesn't have a hard
+	// limit.
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
 }
 
@@ -230,7 +361,11 @@ func (e *distSQLSpecExecFactory) ConstructWindow(
 func (e *distSQLSpecExecFactory) RenameColumns(
 	input exec.Node, colNames []string,
 ) (exec.Node, error) {
-	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+	inputCols := input.(planMaybePhysical).physPlan.ResultColumns
+	for i := range inputCols {
+		inputCols[i].Name = colNames[i]
+	}
+	return input, nil
 }
 
 func (e *distSQLSpecExecFactory) ConstructPlan(

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -1,0 +1,82 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
+	"github.com/cockroachdb/errors"
+)
+
+func constructPlan(
+	planner *planner,
+	root exec.Node,
+	subqueries []exec.Subquery,
+	cascades []exec.Cascade,
+	checks []exec.Node,
+) (exec.Plan, error) {
+	res := &planTop{
+		// TODO(radu): these fields can be modified by planning various opaque
+		// statements. We should have a cleaner way of plumbing these.
+		avoidBuffering:  planner.curPlan.avoidBuffering,
+		auditEvents:     planner.curPlan.auditEvents,
+		instrumentation: planner.curPlan.instrumentation,
+	}
+	assignPlan := func(plan *planMaybePhysical, node exec.Node) {
+		switch n := node.(type) {
+		case planNode:
+			plan.planNode = n
+		case planMaybePhysical:
+			*plan = n
+		default:
+			panic(fmt.Sprintf("unexpected node type %T", node))
+		}
+	}
+	assignPlan(&res.main, root)
+	if len(subqueries) > 0 {
+		res.subqueryPlans = make([]subquery, len(subqueries))
+		for i := range subqueries {
+			in := &subqueries[i]
+			out := &res.subqueryPlans[i]
+			out.subquery = in.ExprNode
+			switch in.Mode {
+			case exec.SubqueryExists:
+				out.execMode = rowexec.SubqueryExecModeExists
+			case exec.SubqueryOneRow:
+				out.execMode = rowexec.SubqueryExecModeOneRow
+			case exec.SubqueryAnyRows:
+				out.execMode = rowexec.SubqueryExecModeAllRowsNormalized
+			case exec.SubqueryAllRows:
+				out.execMode = rowexec.SubqueryExecModeAllRows
+			default:
+				return nil, errors.Errorf("invalid SubqueryMode %d", in.Mode)
+			}
+			out.expanded = true
+			assignPlan(&out.plan, in.Root)
+		}
+	}
+	if len(cascades) > 0 {
+		res.cascades = make([]cascadeMetadata, len(cascades))
+		for i := range cascades {
+			res.cascades[i].Cascade = cascades[i]
+		}
+	}
+	if len(checks) > 0 {
+		res.checkPlans = make([]checkPlan, len(checks))
+		for i := range checks {
+			assignPlan(&res.checkPlans[i].plan, checks[i])
+		}
+	}
+
+	return res, nil
+}

--- a/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning
+++ b/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning
@@ -14,9 +14,41 @@ SET CLUSTER SETTING sql.defaults.experimental_distsql_planning = on
 statement ok
 SET experimental_distsql_planning = always
 
-# Test that a SELECT query fails but others don't.
 statement ok
-CREATE TABLE kv (k INT PRIMARY KEY, v INT); INSERT INTO kv VALUES (1, 1), (2, 1)
+CREATE TABLE kv (k INT PRIMARY KEY, v INT); INSERT INTO kv VALUES (1, 1), (2, 1), (3, 2)
 
-statement error pq: unimplemented: experimental opt-driven distsql planning
+query II colnames,rowsort
 SELECT * FROM kv
+----
+k v
+1 1
+2 1
+3 2
+
+query I colnames,rowsort
+SELECT k FROM kv
+----
+k
+1
+2
+3
+
+query I colnames,rowsort
+SELECT v FROM kv
+----
+v
+1
+1
+2
+
+# Projections are not yet supported.
+statement error pq: unimplemented: experimental opt-driven distsql planning
+SELECT v, k FROM kv
+
+# Renders are not yet supported.
+statement error pq: unimplemented: experimental opt-driven distsql planning
+SELECT k + v FROM kv
+
+# Filters are not yet supported.
+statement error pq: unimplemented: experimental opt-driven distsql planning
+SELECT * FROM kv WHERE k > v

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
-	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
@@ -2038,24 +2037,4 @@ func makeColDescList(table cat.Table, cols exec.TableColumnOrdinalSet) []sqlbase
 		colDescs = append(colDescs, *table.Column(i).(*sqlbase.ColumnDescriptor))
 	}
 	return colDescs
-}
-
-// makeScanColumnsConfig builds a scanColumnsConfig struct by constructing a
-// list of descriptor IDs for columns in the given cols set. Columns are
-// identified by their ordinal position in the table schema.
-func makeScanColumnsConfig(table cat.Table, cols exec.TableColumnOrdinalSet) scanColumnsConfig {
-	// Set visibility=execinfra.ScanVisibilityPublicAndNotPublic, since all
-	// columns in the "cols" set should be projected, regardless of whether
-	// they're public or non- public. The caller decides which columns to
-	// include (or not include). Note that when wantedColumns is non-empty,
-	// the visibility flag will never trigger the addition of more columns.
-	colCfg := scanColumnsConfig{
-		wantedColumns: make([]tree.ColumnID, 0, cols.Len()),
-		visibility:    execinfra.ScanVisibilityPublicAndNotPublic,
-	}
-	for c, ok := cols.Next(0); ok; c, ok = cols.Next(c + 1) {
-		desc := table.Column(c).(*sqlbase.ColumnDescriptor)
-		colCfg.wantedColumns = append(colCfg.wantedColumns, tree.ColumnID(desc.ID))
-	}
-	return colCfg
 }

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
-	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/span"
@@ -131,10 +130,8 @@ func (ef *execFactory) ConstructScan(
 	scan.isFull = len(scan.spans) == 1 && scan.spans[0].EqualValue(
 		scan.desc.IndexSpan(ef.planner.ExecCfg().Codec, scan.index.ID),
 	)
-	for i := range reqOrdering {
-		if reqOrdering[i].ColIdx >= len(colCfg.wantedColumns) {
-			return nil, errors.Errorf("invalid reqOrdering: %v", reqOrdering)
-		}
+	if err = colCfg.assertValidReqOrdering(reqOrdering); err != nil {
+		return nil, err
 	}
 	scan.reqOrdering = ReqOrdering(reqOrdering)
 	scan.estimatedRowCount = uint64(rowCount)
@@ -1048,50 +1045,7 @@ func (ef *execFactory) ConstructPlan(
 	if spool, ok := root.(*spoolNode); ok {
 		root = spool.source
 	}
-	res := &planTop{
-		// TODO(radu): these fields can be modified by planning various opaque
-		// statements. We should have a cleaner way of plumbing these.
-		avoidBuffering:  ef.planner.curPlan.avoidBuffering,
-		auditEvents:     ef.planner.curPlan.auditEvents,
-		instrumentation: ef.planner.curPlan.instrumentation,
-	}
-	res.main.planNode = root.(planNode)
-	if len(subqueries) > 0 {
-		res.subqueryPlans = make([]subquery, len(subqueries))
-		for i := range subqueries {
-			in := &subqueries[i]
-			out := &res.subqueryPlans[i]
-			out.subquery = in.ExprNode
-			switch in.Mode {
-			case exec.SubqueryExists:
-				out.execMode = rowexec.SubqueryExecModeExists
-			case exec.SubqueryOneRow:
-				out.execMode = rowexec.SubqueryExecModeOneRow
-			case exec.SubqueryAnyRows:
-				out.execMode = rowexec.SubqueryExecModeAllRowsNormalized
-			case exec.SubqueryAllRows:
-				out.execMode = rowexec.SubqueryExecModeAllRows
-			default:
-				return nil, errors.Errorf("invalid SubqueryMode %d", in.Mode)
-			}
-			out.expanded = true
-			out.plan.planNode = in.Root.(planNode)
-		}
-	}
-	if len(cascades) > 0 {
-		res.cascades = make([]cascadeMetadata, len(cascades))
-		for i := range cascades {
-			res.cascades[i].Cascade = cascades[i]
-		}
-	}
-	if len(checks) > 0 {
-		res.checkPlans = make([]checkPlan, len(checks))
-		for i := range checks {
-			res.checkPlans[i].plan.planNode = checks[i].(planNode)
-		}
-	}
-
-	return res, nil
+	return constructPlan(ef.planner, root, subqueries, cascades, checks)
 }
 
 // urlOutputter handles writing strings into an encoded URL for EXPLAIN (OPT,

--- a/pkg/sql/physicalplan/physical_plan.go
+++ b/pkg/sql/physicalplan/physical_plan.go
@@ -77,7 +77,7 @@ type PhysicalPlan struct {
 	LocalProcessors []execinfra.LocalProcessor
 
 	// LocalProcessorIndexes contains pointers to all of the RowSourceIdx fields
-	// of the  LocalPlanNodeSpecs that were created. This list is in the same
+	// of the LocalPlanNodeSpecs that were created. This list is in the same
 	// order as LocalProcessors, and is kept up-to-date so that LocalPlanNodeSpecs
 	// always have the correct index into the LocalProcessors slice.
 	LocalProcessorIndexes []*uint32
@@ -104,6 +104,10 @@ type PhysicalPlan struct {
 	// This is aliased with InputSyncSpec.ColumnTypes, so it must not be modified
 	// in-place during planning.
 	ResultTypes []*types.T
+
+	// ResultColumns is the schema (result columns) of the rows produced by the
+	// ResultRouters.
+	ResultColumns sqlbase.ResultColumns
 
 	// MergeOrdering is the ordering guarantee for the result streams that must be
 	// maintained when the streams eventually merge. The column indexes refer to

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -329,9 +329,7 @@ func (p planMaybePhysical) isPhysicalPlan() bool {
 
 func (p planMaybePhysical) planColumns() sqlbase.ResultColumns {
 	if p.isPhysicalPlan() {
-		// TODO(yuzefovich): update this once we support creating table reader
-		// specs directly in the optimizer (see #47474).
-		return nil
+		return p.physPlan.ResultColumns
 	}
 	return planColumns(p.planNode)
 }

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -181,7 +181,7 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 		bld  *execbuilder.Builder
 	)
 	if mode := p.SessionData().ExperimentalDistSQLPlanningMode; mode != sessiondata.ExperimentalDistSQLPlanningOff {
-		bld = execbuilder.New(newDistSQLSpecExecFactory(), execMemo, &opc.catalog, root, p.EvalContext())
+		bld = execbuilder.New(newDistSQLSpecExecFactory(p), execMemo, &opc.catalog, root, p.EvalContext())
 		plan, err = bld.Build()
 		if err != nil {
 			if mode == sessiondata.ExperimentalDistSQLPlanningAlways &&

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -180,6 +180,9 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 		plan exec.Plan
 		bld  *execbuilder.Builder
 	)
+	// TODO(yuzefovich): we're creating a new exec.Factory for every query, but
+	// we probably could pool those allocations using sync.Pool. Investigate
+	// this.
 	if mode := p.SessionData().ExperimentalDistSQLPlanningMode; mode != sessiondata.ExperimentalDistSQLPlanningOff {
 		bld = execbuilder.New(newDistSQLSpecExecFactory(p), execMemo, &opc.catalog, root, p.EvalContext())
 		plan, err = bld.Build()

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -131,6 +132,15 @@ type scanColumnsConfig struct {
 	// If visibility is set to execinfra.ScanVisibilityPublicAndNotPublic, then
 	// mutation columns can be added to the list of columns.
 	visibility execinfrapb.ScanVisibility
+}
+
+func (cfg scanColumnsConfig) assertValidReqOrdering(reqOrdering exec.OutputOrdering) error {
+	for i := range reqOrdering {
+		if reqOrdering[i].ColIdx >= len(cfg.wantedColumns) {
+			return errors.Errorf("invalid reqOrdering: %v", reqOrdering)
+		}
+	}
+	return nil
 }
 
 var publicColumnsCfg = scanColumnsConfig{}


### PR DESCRIPTION
**sql: extract out planning of table readers into a separate method**

This commit extract most of the logic of `createTableReaders` into
a separate method that performs the actual physical planning of table
readers given already created `TableReaderSpec`s. This will allow for
reuse in the follow-up work. This commit additionally slightly refactors
a few other things for reuse.

Release note: None

**sql: implement ConstructPlan by new factory**

This commit extracts the logic of `execFactory.ConstructPlan` into the
function to be used by both factories. It also extracts out another
small helper.

Release note: None

**sql: implement ConstructScan in distsql spec factory**

This commit adds an implementation of
`distSQLSpecExecFactory.ConstructScan` which combines the logic that
performs `scanNode` creation of `execFactory.ConstructScan` and physical
planning of table readers of `DistSQLPlanner.createTableReaders`.
I tried to refactor the code so that there is not much duplication going
on.

Notably, simple projections, renders, and filters are not yet
implemented.

Closes: #47474.

Release note: None

**sql: enforce the assumption that `wantedColumns` is not nil for scans**

After the examining the code closer, I see that now in all code paths we
populate `scanColumnsConfig.wantedColumns` to ask for the specific
columns to be scanned. Previously, this map could be left as `nil` which
would mean that all columns of the table should be scanned. This was
used only by the heuristic planner which has been removed, so we can now
update the assumption of the scan columns config. This allows us to
clean up the comments a bit.

This commit also moves `makeColumnsConfig` function into the shared util
file because it is used by both factories.

Release note: None