### PR TITLE
opt: add rule to eliminate a do-nothing join under a GroupBy

### DIFF
--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -514,10 +514,13 @@ func (c *CustomFuncs) sharedProps(e opt.Expr) *props.Shared {
 //
 // ----------------------------------------------------------------------
 
-// HasColsInOrdering returns true if all columns that appear in an ordering are
-// output columns of the input expression.
-func (c *CustomFuncs) HasColsInOrdering(input memo.RelExpr, ordering physical.OrderingChoice) bool {
-	return ordering.CanProjectCols(input.Relational().OutputCols)
+// OrderingCanProjectCols returns true if the given OrderingChoice can be
+// expressed using only the given columns. Or in other words, at least one
+// column from every ordering group is a member of the given ColSet.
+func (c *CustomFuncs) OrderingCanProjectCols(
+	ordering physical.OrderingChoice, cols opt.ColSet,
+) bool {
+	return ordering.CanProjectCols(cols)
 }
 
 // OrderingCols returns all non-optional columns that are part of the given
@@ -527,8 +530,8 @@ func (c *CustomFuncs) OrderingCols(ordering physical.OrderingChoice) opt.ColSet 
 }
 
 // PruneOrdering removes any columns referenced by an OrderingChoice that are
-// not part of the needed column set. Should only be called if HasColsInOrdering
-// is true.
+// not part of the needed column set. Should only be called if
+// OrderingCanProjectCols is true.
 func (c *CustomFuncs) PruneOrdering(
 	ordering physical.OrderingChoice, needed opt.ColSet,
 ) physical.OrderingChoice {
@@ -834,6 +837,44 @@ func (c *CustomFuncs) ExtractGroupingOrdering(
 	private *memo.GroupingPrivate,
 ) physical.OrderingChoice {
 	return private.Ordering
+}
+
+// ----------------------------------------------------------------------
+//
+// Join functions
+//   General functions related to join operators.
+//
+// ----------------------------------------------------------------------
+
+// JoinDoesNotDuplicateLeftRows returns true if the given InnerJoin, LeftJoin or
+// FullJoin is guaranteed not to output any given row from its left input more
+// than once.
+func (c *CustomFuncs) JoinDoesNotDuplicateLeftRows(join memo.RelExpr) bool {
+	mult := memo.DeriveJoinMultiplicity(join)
+	return mult.JoinDoesNotDuplicateLeftRows()
+}
+
+// JoinDoesNotDuplicateRightRows returns true if the given InnerJoin, LeftJoin
+// or FullJoin is guaranteed not to output any given row from its right input
+// more than once.
+func (c *CustomFuncs) JoinDoesNotDuplicateRightRows(join memo.RelExpr) bool {
+	mult := memo.DeriveJoinMultiplicity(join)
+	return mult.JoinDoesNotDuplicateRightRows()
+}
+
+// JoinPreservesLeftRows returns true if the given InnerJoin, LeftJoin or
+// FullJoin is guaranteed to output every row from its left input at least once.
+func (c *CustomFuncs) JoinPreservesLeftRows(join memo.RelExpr) bool {
+	mult := memo.DeriveJoinMultiplicity(join)
+	return mult.JoinPreservesLeftRows()
+}
+
+// JoinPreservesRightRows returns true if the given InnerJoin, LeftJoin or
+// FullJoin is guaranteed to output every row from its right input at least
+// once.
+func (c *CustomFuncs) JoinPreservesRightRows(join memo.RelExpr) bool {
+	mult := memo.DeriveJoinMultiplicity(join)
+	return mult.JoinPreservesRightRows()
 }
 
 // ----------------------------------------------------------------------

--- a/pkg/sql/opt/norm/rules/groupby.opt
+++ b/pkg/sql/opt/norm/rules/groupby.opt
@@ -9,6 +9,111 @@
 =>
 (DistinctOn $input $aggregations $groupingPrivate)
 
+# EliminateGroupByProject discards a nested Project operator that is only
+# removing columns from its input (and not synthesizing new ones). That's
+# something the GroupBy operators can do on their own.
+#
+# Note: EliminateGroupByProject should be located above
+# EliminateJoinUnderGroupByLeft so that it can remove any interfering Projects.
+[EliminateGroupByProject, Normalize]
+(GroupBy | ScalarGroupBy | DistinctOn | EnsureDistinctOn
+        | UpsertDistinctOn | EnsureUpsertDistinctOn
+    $input:(Project $innerInput:*) &
+        (ColsAreSubset
+            (OutputCols $input)
+            (OutputCols $innerInput)
+        )
+    $aggregations:*
+    $groupingPrivate:*
+)
+=>
+((OpName) $innerInput $aggregations $groupingPrivate)
+
+# EliminateJoinUnderGroupByLeft removes a Join operator and its right input if
+# it can be proven that the removal does not affect the output of the parent
+# grouping operator. This is the case if:
+#
+# 1. Only columns from the left input are being used by the grouping operator.
+#
+# 2. It can be proven that removal of the Join does not affect the result of the
+#    grouping operator's aggregate functions.
+#
+# 3. The OrderingChoice of the grouping operator can be expressed with only
+#    columns from the left input. Or in other words, at least one column in
+#    every ordering group is one of the left output columns.
+#
+# Condition #2 is only true when the following are all true:
+#
+# 1. All left rows are included in the output of the join. See the comment above
+#    filtersMatchAllLeftRows in multiplicity_builder.go for more information on
+#    when this is the case.
+# 2. Either the join does not duplicate any left rows, or the join duplicates
+#    left rows but the grouping operator's aggregate functions ignore duplicate
+#    values. See the comment above filtersMatchLeftRowsAtMostOnce in
+#    multiplicity_builder.go for more information on when rows are duplicated.
+# 3. The join does not null-extend the left columns.
+#
+# EliminateJoinUnderGroupByLeft should stay at the top of the file so that it
+# has a chance to fire before rules like EliminateDistinctOn that might prevent
+# matching.
+[EliminateJoinUnderGroupByLeft, Normalize]
+(GroupBy | ScalarGroupBy | DistinctOn
+    $input:(InnerJoin | LeftJoin $left:*)
+    $aggs:*
+    $private:(GroupingPrivate $groupingCols:* $ordering:*) &
+        (OrderingCanProjectCols
+            $ordering
+            $leftCols:(OutputCols $left)
+        ) &
+        (ColsAreSubset
+            (UnionCols
+                $groupingCols
+                (AggregationOuterCols $aggs)
+            )
+            $leftCols
+        ) &
+        (CanEliminateJoinUnderGroupByLeft $input $aggs)
+)
+=>
+((OpName)
+    $left
+    $aggs
+    (MakeGrouping
+        $groupingCols
+        (PruneOrdering $ordering $leftCols)
+    )
+)
+
+# EliminateJoinUnderGroupByRight is symmetric with
+# EliminateJoinUnderGroupByLeft, except that it only matches on InnerJoins.
+[EliminateJoinUnderGroupByRight, Normalize]
+(GroupBy | ScalarGroupBy | DistinctOn
+    $input:(InnerJoin * $right:*)
+    $aggs:*
+    $private:(GroupingPrivate $groupingCols:* $ordering:*) &
+        (OrderingCanProjectCols
+            $ordering
+            $rightCols:(OutputCols $right)
+        ) &
+        (ColsAreSubset
+            (UnionCols
+                $groupingCols
+                (AggregationOuterCols $aggs)
+            )
+            $rightCols
+        ) &
+        (CanEliminateJoinUnderGroupByRight $input $aggs)
+)
+=>
+((OpName)
+    $right
+    $aggs
+    (MakeGrouping
+        $groupingCols
+        (PruneOrdering $ordering $rightCols)
+    )
+)
+
 # EliminateDistinct discards a DistinctOn operator that is eliminating duplicate
 # rows by using grouping columns that are statically known to form a strong key.
 # By definition, a strong key does not allow duplicate values, so the GroupBy is
@@ -26,23 +131,6 @@
 )
 =>
 (Project $input [] (GroupingOutputCols $groupingPrivate $aggs))
-
-# EliminateGroupByProject discards a nested Project operator that is only
-# removing columns from its input (and not synthesizing new ones). That's
-# something the GroupBy operators can do on their own.
-[EliminateGroupByProject, Normalize]
-(GroupBy | ScalarGroupBy | DistinctOn | EnsureDistinctOn
-        | UpsertDistinctOn | EnsureUpsertDistinctOn
-    $input:(Project $innerInput:*) &
-        (ColsAreSubset
-            (OutputCols $input)
-            (OutputCols $innerInput)
-        )
-    $aggregations:*
-    $groupingPrivate:*
-)
-=>
-((OpName) $innerInput $aggregations $groupingPrivate)
 
 # ReduceGroupingCols eliminates redundant grouping columns from the GroupBy
 # operator and replaces them by ConstAgg aggregate functions. A grouping

--- a/pkg/sql/opt/norm/rules/limit.opt
+++ b/pkg/sql/opt/norm/rules/limit.opt
@@ -26,15 +26,15 @@ $input
 (Limit
     (Project $input:* $projections:* $passthrough:*)
     $limit:*
-    $ordering:* & (HasColsInOrdering $input $ordering)
+    $ordering:* &
+        (OrderingCanProjectCols
+            $ordering
+            $cols:(OutputCols $input)
+        )
 )
 =>
 (Project
-    (Limit
-        $input
-        $limit
-        (PruneOrdering $ordering (OutputCols $input))
-    )
+    (Limit $input $limit (PruneOrdering $ordering $cols))
     $projections
     $passthrough
 )
@@ -46,15 +46,15 @@ $input
 (Offset
     (Project $input:* $projections:* $passthrough:*)
     $offset:*
-    $ordering:* & (HasColsInOrdering $input $ordering)
+    $ordering:* &
+        (OrderingCanProjectCols
+            $ordering
+            $cols:(OutputCols $input)
+        )
 )
 =>
 (Project
-    (Offset
-        $input
-        $offset
-        (PruneOrdering $ordering (OutputCols $input))
-    )
+    (Offset $input $offset (PruneOrdering $ordering $cols))
     $projections
     $passthrough
 )
@@ -101,7 +101,10 @@ $input
     (Ordinality $input:* $private:*)
     $limit:*
     $limitOrdering:* &
-        (HasColsInOrdering $input $limitOrdering) &
+        (OrderingCanProjectCols
+            $limitOrdering
+            (OutputCols $input)
+        ) &
         (OrderingIntersects
             (OrdinalityOrdering $private)
             $limitOrdering
@@ -131,16 +134,16 @@ $input
     $limitExpr:(Const $limit:*) &
         (IsPositiveInt $limit) &
         ^(LimitGeMaxRows $limit $left)
-    $ordering:* & (HasColsInOrdering $left $ordering)
+    $ordering:* &
+        (OrderingCanProjectCols
+            $ordering
+            $cols:(OutputCols $left)
+        )
 )
 =>
 (Limit
     (LeftJoin
-        (Limit
-            $left
-            $limitExpr
-            (PruneOrdering $ordering (OutputCols $left))
-        )
+        (Limit $left $limitExpr (PruneOrdering $ordering $cols))
         $right
         $on
         $private

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -20,6 +20,16 @@ CREATE TABLE xy
 ----
 
 exec-ddl
+CREATE TABLE fks
+(
+    k INT PRIMARY KEY,
+    v INT,
+    r1 INT NOT NULL REFERENCES xy(x),
+    r2 INT REFERENCES xy(x)
+)
+----
+
+exec-ddl
 CREATE TABLE abc
 (
     a INT,
@@ -99,6 +109,374 @@ group-by
       └── sum [as=sum:6, outer=(3)]
            └── f:3
 
+# --------------------------------------------------
+# EliminateJoinUnderGroupByLeft
+# --------------------------------------------------
+
+# Simple DistinctOn case with a LeftJoin on an equality between primary keys.
+norm expect=EliminateJoinUnderGroupByLeft
+SELECT DISTINCT ON (x) x, y FROM xy LEFT JOIN fks ON x=k
+----
+scan xy
+ ├── columns: x:1!null y:2
+ ├── key: (1)
+ └── fd: (1)-->(2)
+
+# RightJoin case. The RightJoin is turned into a LeftJoin, so
+# EliminateJoinUnderGroupByLeft matches it.
+norm expect=EliminateJoinUnderGroupByLeft
+SELECT DISTINCT ON (x) x, y FROM fks RIGHT JOIN xy ON x=k
+----
+scan xy
+ ├── columns: x:5!null y:6
+ ├── key: (5)
+ └── fd: (5)-->(6)
+
+# InnerJoin case. The Values operator in the join guarantees cardinality of at
+# least one, so rows from the left input are guaranteed to be included in the
+# join at least once.
+norm expect=EliminateJoinUnderGroupByLeft
+SELECT k, max(r1) FROM fks INNER JOIN (SELECT * FROM (VALUES (1), (2)) f(t)) ON True GROUP BY k
+----
+group-by
+ ├── columns: k:1!null max:6!null
+ ├── grouping columns: k:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(6)
+ ├── scan fks
+ │    ├── columns: k:1!null r1:3!null
+ │    ├── key: (1)
+ │    └── fd: (1)-->(3)
+ └── aggregations
+      └── max [as=max:6, outer=(3)]
+           └── r1:3
+
+# Case with ScalarGroupBy with a sum aggregate that doesn't ignore duplicates.
+# The join can be eliminated because r1 is a foreign key referencing x, which
+# implies that the rows of fks are not being duplicated by the join.
+norm expect=EliminateJoinUnderGroupByLeft
+SELECT sum(k) FROM fks LEFT JOIN xy ON x=r1
+----
+scalar-group-by
+ ├── columns: sum:7
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7)
+ ├── scan fks
+ │    ├── columns: k:1!null
+ │    └── key: (1)
+ └── aggregations
+      └── sum [as=sum:7, outer=(1)]
+           └── k:1
+
+# LeftJoin case with possible duplicate rows. The rule can fire because the
+# output of the max aggregate is not affected by duplicate rows.
+norm expect=EliminateJoinUnderGroupByLeft
+SELECT x, max(y) FROM xy LEFT JOIN fks ON True GROUP BY x
+----
+group-by
+ ├── columns: x:1!null max:7
+ ├── grouping columns: x:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(7)
+ ├── scan xy
+ │    ├── columns: x:1!null y:2
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── aggregations
+      └── max [as=max:7, outer=(2)]
+           └── y:2
+
+# LeftJoin case with a not-null foreign key equality filter and a sum aggregate.
+norm expect=EliminateJoinUnderGroupByLeft
+SELECT k, sum(r1) FROM fks LEFT JOIN xy ON x=r1 GROUP BY k
+----
+group-by
+ ├── columns: k:1!null sum:7!null
+ ├── grouping columns: k:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(7)
+ ├── scan fks
+ │    ├── columns: k:1!null r1:3!null
+ │    ├── key: (1)
+ │    └── fd: (1)-->(3)
+ └── aggregations
+      └── sum [as=sum:7, outer=(3)]
+           └── r1:3
+
+# The LeftJoin guarantees that all left rows will be included in the output, and
+# since k is a key column, no rows from xy will be duplicated. Therefore the sum
+# aggregate will not be affected by join removal.
+norm expect=EliminateJoinUnderGroupByLeft
+SELECT x, sum(y) FROM xy LEFT JOIN fks ON x=k GROUP BY x
+----
+group-by
+ ├── columns: x:1!null sum:7
+ ├── grouping columns: x:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(7)
+ ├── scan xy
+ │    ├── columns: x:1!null y:2
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── aggregations
+      └── sum [as=sum:7, outer=(2)]
+           └── y:2
+
+# The LeftJoin guarantees that all left rows will be included in the output, and
+# since r2 is a foreign key referencing x, it is guaranteed that no left rows
+# will be matched more than once. Therefore, the sum aggregate will be
+# unaffected by join removal.
+norm expect=EliminateJoinUnderGroupByLeft
+SELECT k, sum(r1) FROM fks LEFT JOIN xy ON x=r2 GROUP BY k
+----
+group-by
+ ├── columns: k:1!null sum:7!null
+ ├── grouping columns: k:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(7)
+ ├── scan fks
+ │    ├── columns: k:1!null r1:3!null
+ │    ├── key: (1)
+ │    └── fd: (1)-->(3)
+ └── aggregations
+      └── sum [as=sum:7, outer=(3)]
+           └── r1:3
+
+# InnerJoin case. Because r1 is a non-null foreign key that references x, the
+# join output is guaranteed to include every left row exactly once.
+norm expect=EliminateJoinUnderGroupByLeft
+SELECT k, sum(r1) FROM fks INNER JOIN xy ON x=r1 GROUP BY k
+----
+group-by
+ ├── columns: k:1!null sum:7!null
+ ├── grouping columns: k:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(7)
+ ├── scan fks
+ │    ├── columns: k:1!null r1:3!null
+ │    ├── key: (1)
+ │    └── fd: (1)-->(3)
+ └── aggregations
+      └── sum [as=sum:7, outer=(3)]
+           └── r1:3
+
+# Case with an ordering on left columns.
+norm expect=EliminateJoinUnderGroupByLeft
+SELECT max(y) FROM xy LEFT JOIN fks ON x = k GROUP BY x ORDER BY x
+----
+group-by
+ ├── columns: max:7  [hidden: x:1!null]
+ ├── grouping columns: x:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(7)
+ ├── ordering: +1
+ ├── scan xy
+ │    ├── columns: x:1!null y:2
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    └── ordering: +1
+ └── aggregations
+      └── max [as=max:7, outer=(2)]
+           └── y:2
+
+# No-op case because the InnerJoin will return no rows if fks is empty.
+norm expect-not=EliminateJoinUnderGroupByLeft
+SELECT DISTINCT ON (x) x, y FROM xy INNER JOIN fks ON True
+----
+distinct-on
+ ├── columns: x:1!null y:2
+ ├── grouping columns: x:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── inner-join (cross)
+ │    ├── columns: x:1!null y:2
+ │    ├── fd: (1)-->(2)
+ │    ├── scan xy
+ │    │    ├── columns: x:1!null y:2
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    ├── scan fks
+ │    └── filters (true)
+ └── aggregations
+      └── first-agg [as=y:2, outer=(2)]
+           └── y:2
+
+# No-op case because the DistinctOn is using columns from the right input.
+norm expect-not=EliminateJoinUnderGroupByLeft
+SELECT DISTINCT ON (x) y, k FROM xy LEFT JOIN fks ON True
+----
+distinct-on
+ ├── columns: y:2 k:3  [hidden: x:1!null]
+ ├── grouping columns: x:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── left-join (cross)
+ │    ├── columns: x:1!null y:2 k:3
+ │    ├── key: (1,3)
+ │    ├── fd: (1)-->(2)
+ │    ├── scan xy
+ │    │    ├── columns: x:1!null y:2
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    ├── scan fks
+ │    │    ├── columns: k:3!null
+ │    │    └── key: (3)
+ │    └── filters (true)
+ └── aggregations
+      ├── first-agg [as=y:2, outer=(2)]
+      │    └── y:2
+      └── first-agg [as=k:3, outer=(3)]
+           └── k:3
+
+# No-op case because an InnerJoin on true may create duplicate rows that will
+# affect the output of the sum on r1.
+norm expect-not=EliminateJoinUnderGroupByLeft
+SELECT k, sum(r1) FROM fks INNER JOIN xy ON True GROUP BY k
+----
+group-by
+ ├── columns: k:1!null sum:7!null
+ ├── grouping columns: k:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(7)
+ ├── inner-join (cross)
+ │    ├── columns: k:1!null r1:3!null
+ │    ├── fd: (1)-->(3)
+ │    ├── scan fks
+ │    │    ├── columns: k:1!null r1:3!null
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(3)
+ │    ├── scan xy
+ │    └── filters (true)
+ └── aggregations
+      └── sum [as=sum:7, outer=(3)]
+           └── r1:3
+
+# No-op case with a foreign key equality filter and a sum aggregate. No-op
+# because r2 is nullable and therefore the InnerJoin may filter out rows.
+norm expect-not=EliminateJoinUnderGroupByLeft
+SELECT k, sum(r1) FROM fks INNER JOIN xy ON x=r2 GROUP BY k
+----
+group-by
+ ├── columns: k:1!null sum:7!null
+ ├── grouping columns: k:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(7)
+ ├── inner-join (hash)
+ │    ├── columns: k:1!null r1:3!null r2:4!null x:5!null
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(3,4), (4)==(5), (5)==(4)
+ │    ├── scan fks
+ │    │    ├── columns: k:1!null r1:3!null r2:4
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(3,4)
+ │    ├── scan xy
+ │    │    ├── columns: x:5!null
+ │    │    └── key: (5)
+ │    └── filters
+ │         └── x:5 = r2:4 [outer=(4,5), constraints=(/4: (/NULL - ]; /5: (/NULL - ]), fd=(4)==(5), (5)==(4)]
+ └── aggregations
+      └── sum [as=sum:7, outer=(3)]
+           └── r1:3
+
+# No-op case because the ordering includes a column from the right input.
+norm expect-not=EliminateJoinUnderGroupByLeft
+SELECT x, max(y) FROM xy LEFT JOIN fks ON True GROUP BY x, k ORDER BY x, k
+----
+group-by
+ ├── columns: x:1!null max:7  [hidden: k:3]
+ ├── grouping columns: x:1!null k:3
+ ├── key: (1,3)
+ ├── fd: (1,3)-->(7)
+ ├── ordering: +1,+3
+ ├── sort
+ │    ├── columns: x:1!null y:2 k:3
+ │    ├── key: (1,3)
+ │    ├── fd: (1)-->(2)
+ │    ├── ordering: +1,+3
+ │    └── left-join (cross)
+ │         ├── columns: x:1!null y:2 k:3
+ │         ├── key: (1,3)
+ │         ├── fd: (1)-->(2)
+ │         ├── scan xy
+ │         │    ├── columns: x:1!null y:2
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(2)
+ │         ├── scan fks
+ │         │    ├── columns: k:3!null
+ │         │    └── key: (3)
+ │         └── filters (true)
+ └── aggregations
+      └── max [as=max:7, outer=(2)]
+           └── y:2
+
+# Currently a no-op case even though we could hypothetically remove the join,
+# since the presence of a not-null foreign key in fks implies that either both
+# tables will have a cardinality of at least one, or both will have a
+# cardinality of zero.
+norm expect-not=EliminateJoinUnderGroupByLeft
+SELECT DISTINCT ON (k) k, v FROM fks INNER JOIN xy ON True
+----
+distinct-on
+ ├── columns: k:1!null v:2
+ ├── grouping columns: k:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── inner-join (cross)
+ │    ├── columns: k:1!null v:2
+ │    ├── fd: (1)-->(2)
+ │    ├── scan fks
+ │    │    ├── columns: k:1!null v:2
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    ├── scan xy
+ │    └── filters (true)
+ └── aggregations
+      └── first-agg [as=v:2, outer=(2)]
+           └── v:2
+
+# --------------------------------------------------
+# EliminateJoinUnderGroupByRight
+# --------------------------------------------------
+
+# InnerJoin case.
+norm expect=EliminateJoinUnderGroupByRight
+SELECT k, sum(r1) FROM xy INNER JOIN fks ON x = r1 GROUP BY k
+----
+group-by
+ ├── columns: k:3!null sum:7!null
+ ├── grouping columns: k:3!null
+ ├── key: (3)
+ ├── fd: (3)-->(7)
+ ├── scan fks
+ │    ├── columns: k:3!null r1:5!null
+ │    ├── key: (3)
+ │    └── fd: (3)-->(5)
+ └── aggregations
+      └── sum [as=sum:7, outer=(5)]
+           └── r1:5
+
+# No-op case because columns from the right side of a left join are being used.
+norm expect-not=EliminateJoinUnderGroupByRight
+SELECT max(r1) FROM xy LEFT JOIN fks ON x = r1
+----
+scalar-group-by
+ ├── columns: max:7
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7)
+ ├── left-join (hash)
+ │    ├── columns: x:1!null r1:5
+ │    ├── scan xy
+ │    │    ├── columns: x:1!null
+ │    │    └── key: (1)
+ │    ├── scan fks
+ │    │    └── columns: r1:5!null
+ │    └── filters
+ │         └── x:1 = r1:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+ └── aggregations
+      └── max [as=max:7, outer=(5)]
+           └── r1:5
 
 # --------------------------------------------------
 # EliminateDistinct

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -385,6 +385,24 @@ func AggregatesCanMerge(inner, outer Operator) bool {
 	}
 }
 
+// AggregateIgnoresDuplicates returns true if the output of the given aggregate
+// operator does not change when duplicate rows are added to the input.
+func AggregateIgnoresDuplicates(op Operator) bool {
+	switch op {
+	case AnyNotNullAggOp, BitAndAggOp, BitOrAggOp, BoolAndOp, BoolOrOp,
+		ConstAggOp, ConstNotNullAggOp, FirstAggOp, MaxOp, MinOp:
+		return true
+
+	case ArrayAggOp, AvgOp, ConcatAggOp, CountOp, CorrOp, CountRowsOp, SumIntOp,
+		SumOp, SqrDiffOp, VarianceOp, StdDevOp, XorAggOp, JsonAggOp, JsonbAggOp,
+		StringAggOp, PercentileDiscOp, PercentileContOp:
+		return false
+
+	default:
+		panic(errors.AssertionFailedf("unhandled op %s", log.Safe(op)))
+	}
+}
+
 // OpaqueMetadata is an object stored in OpaqueRelExpr and passed
 // through to the exec factory.
 type OpaqueMetadata interface {

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -578,15 +578,6 @@ project
 
 # Get version of last card that was changed.
 #
-# Problems:
-#   1. CardsView is actually a join between Cards and CardsInfo tables. But the
-#      optimizer is missing join elimination rules. If those were available, we
-#      could eliminate the join to Cards (because of FK).
-#   2. InnerJoin can be pushed below GroupBy, which would put the GroupBy as the
-#      input of the ScalarGroupBy.
-#   3. Furthermore, the join with the second Cards table could be eliminated,
-#      just as with #1.
-#
 opt format=show-stats
 SELECT coalesce(max(Version), 0) FROM GlobalCardsView
 ----
@@ -602,60 +593,14 @@ project
  │    ├── stats: [rows=1]
  │    ├── key: ()
  │    ├── fd: ()-->(30)
- │    ├── limit
- │    │    ├── columns: c.id:1!null cardid:8!null max:29!null
- │    │    ├── internal-ordering: -29
- │    │    ├── cardinality: [0 - 1]
- │    │    ├── stats: [rows=1]
- │    │    ├── key: ()
- │    │    ├── fd: ()-->(1,8,29)
- │    │    ├── inner-join (lookup cards)
- │    │    │    ├── columns: c.id:1!null cardid:8!null max:29!null
- │    │    │    ├── key columns: [8] = [1]
- │    │    │    ├── lookup columns are key
- │    │    │    ├── stats: [rows=56607.9417, distinct(1)=56607.9417, null(1)=0, distinct(8)=56607.9417, null(8)=0]
- │    │    │    ├── key: (8)
- │    │    │    ├── fd: (8)-->(29), (1)==(8), (8)==(1)
- │    │    │    ├── ordering: -29
- │    │    │    ├── limit hint: 1.00
- │    │    │    ├── sort
- │    │    │    │    ├── columns: cardid:8!null max:29!null
- │    │    │    │    ├── stats: [rows=56607.9417, distinct(8)=56607.9417, null(8)=0, distinct(29)=56607.9417, null(29)=0]
- │    │    │    │    ├── key: (8)
- │    │    │    │    ├── fd: (8)-->(29)
- │    │    │    │    ├── ordering: -29
- │    │    │    │    ├── limit hint: 100.00
- │    │    │    │    └── group-by
- │    │    │    │         ├── columns: cardid:8!null max:29!null
- │    │    │    │         ├── grouping columns: cardid:8!null
- │    │    │    │         ├── stats: [rows=56607.9417, distinct(8)=56607.9417, null(8)=0, distinct(29)=56607.9417, null(29)=0]
- │    │    │    │         ├── key: (8)
- │    │    │    │         ├── fd: (8)-->(29)
- │    │    │    │         ├── inner-join (hash)
- │    │    │    │         │    ├── columns: dealerid:7!null cardid:8!null version:15!null cards.id:16!null
- │    │    │    │         │    ├── stats: [rows=233333.333, distinct(8)=56607.9417, null(8)=0, distinct(16)=56607.9417, null(16)=0]
- │    │    │    │         │    ├── key: (7,16)
- │    │    │    │         │    ├── fd: (7,8)-->(15), (7,15)-->(8), (8)==(16), (16)==(8)
- │    │    │    │         │    ├── scan cardsinfo@cardsinfoversionindex
- │    │    │    │         │    │    ├── columns: dealerid:7!null cardid:8!null version:15!null
- │    │    │    │         │    │    ├── constraint: /7/15: [/1 - /4]
- │    │    │    │         │    │    ├── stats: [rows=233333.333, distinct(7)=4, null(7)=0, distinct(8)=56607.9417, null(8)=0, distinct(15)=233333.333, null(15)=0]
- │    │    │    │         │    │    ├── key: (7,8)
- │    │    │    │         │    │    └── fd: (7,8)-->(15), (7,15)-->(8)
- │    │    │    │         │    ├── scan cards@cardsnamesetnumber
- │    │    │    │         │    │    ├── columns: cards.id:16!null
- │    │    │    │         │    │    ├── stats: [rows=57000, distinct(16)=57000, null(16)=0]
- │    │    │    │         │    │    └── key: (16)
- │    │    │    │         │    └── filters
- │    │    │    │         │         └── cardid:8 = cards.id:16 [outer=(8,16), constraints=(/8: (/NULL - ]; /16: (/NULL - ]), fd=(8)==(16), (16)==(8)]
- │    │    │    │         └── aggregations
- │    │    │    │              └── max [as=max:29, outer=(15)]
- │    │    │    │                   └── version:15
- │    │    │    └── filters (true)
- │    │    └── 1
+ │    ├── scan cardsinfo@cardsinfoversionindex
+ │    │    ├── columns: dealerid:7!null version:15!null
+ │    │    ├── constraint: /7/15: [/1 - /4]
+ │    │    ├── stats: [rows=233333.333, distinct(7)=4, null(7)=0]
+ │    │    └── key: (7,15)
  │    └── aggregations
- │         └── const-agg [as=max:30, outer=(29)]
- │              └── max:29
+ │         └── max [as=max:30, outer=(15)]
+ │              └── version:15
  └── projections
       └── COALESCE(max:30, 0) [as=coalesce:31, outer=(30)]
 

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -584,15 +584,6 @@ project
 
 # Get version of last card that was changed.
 #
-# Problems:
-#   1. CardsView is actually a join between Cards and CardsInfo tables. But the
-#      optimizer is missing join elimination rules. If those were available, we
-#      could eliminate the join to Cards (because of FK).
-#   2. InnerJoin can be pushed below GroupBy, which would put the GroupBy as the
-#      input of the ScalarGroupBy.
-#   3. Furthermore, the join with the second Cards table could be eliminated,
-#      just as with #1.
-#
 opt format=show-stats
 SELECT coalesce(max(Version), 0) FROM GlobalCardsView
 ----
@@ -608,60 +599,14 @@ project
  │    ├── stats: [rows=1]
  │    ├── key: ()
  │    ├── fd: ()-->(34)
- │    ├── limit
- │    │    ├── columns: c.id:1!null cardid:8!null max:33!null
- │    │    ├── internal-ordering: -33
- │    │    ├── cardinality: [0 - 1]
- │    │    ├── stats: [rows=1]
- │    │    ├── key: ()
- │    │    ├── fd: ()-->(1,8,33)
- │    │    ├── inner-join (lookup cards)
- │    │    │    ├── columns: c.id:1!null cardid:8!null max:33!null
- │    │    │    ├── key columns: [8] = [1]
- │    │    │    ├── lookup columns are key
- │    │    │    ├── stats: [rows=56607.9417, distinct(1)=56607.9417, null(1)=0, distinct(8)=56607.9417, null(8)=0]
- │    │    │    ├── key: (8)
- │    │    │    ├── fd: (8)-->(33), (1)==(8), (8)==(1)
- │    │    │    ├── ordering: -33
- │    │    │    ├── limit hint: 1.00
- │    │    │    ├── sort
- │    │    │    │    ├── columns: cardid:8!null max:33!null
- │    │    │    │    ├── stats: [rows=56607.9417, distinct(8)=56607.9417, null(8)=0, distinct(33)=56607.9417, null(33)=0]
- │    │    │    │    ├── key: (8)
- │    │    │    │    ├── fd: (8)-->(33)
- │    │    │    │    ├── ordering: -33
- │    │    │    │    ├── limit hint: 100.00
- │    │    │    │    └── group-by
- │    │    │    │         ├── columns: cardid:8!null max:33!null
- │    │    │    │         ├── grouping columns: cardid:8!null
- │    │    │    │         ├── stats: [rows=56607.9417, distinct(8)=56607.9417, null(8)=0, distinct(33)=56607.9417, null(33)=0]
- │    │    │    │         ├── key: (8)
- │    │    │    │         ├── fd: (8)-->(33)
- │    │    │    │         ├── inner-join (hash)
- │    │    │    │         │    ├── columns: dealerid:7!null cardid:8!null version:15!null cards.id:20!null
- │    │    │    │         │    ├── stats: [rows=233333.333, distinct(8)=56607.9417, null(8)=0, distinct(20)=56607.9417, null(20)=0]
- │    │    │    │         │    ├── key: (7,20)
- │    │    │    │         │    ├── fd: (7,8)-->(15), (7,15)-->(8), (8)==(20), (20)==(8)
- │    │    │    │         │    ├── scan cardsinfo@cardsinfoversionindex
- │    │    │    │         │    │    ├── columns: dealerid:7!null cardid:8!null version:15!null
- │    │    │    │         │    │    ├── constraint: /7/15: [/1 - /4]
- │    │    │    │         │    │    ├── stats: [rows=233333.333, distinct(7)=4, null(7)=0, distinct(8)=56607.9417, null(8)=0, distinct(15)=233333.333, null(15)=0]
- │    │    │    │         │    │    ├── key: (7,8)
- │    │    │    │         │    │    └── fd: (7,8)-->(15), (7,15)-->(8)
- │    │    │    │         │    ├── scan cards@cardsnamesetnumber
- │    │    │    │         │    │    ├── columns: cards.id:20!null
- │    │    │    │         │    │    ├── stats: [rows=57000, distinct(20)=57000, null(20)=0]
- │    │    │    │         │    │    └── key: (20)
- │    │    │    │         │    └── filters
- │    │    │    │         │         └── cardid:8 = cards.id:20 [outer=(8,20), constraints=(/8: (/NULL - ]; /20: (/NULL - ]), fd=(8)==(20), (20)==(8)]
- │    │    │    │         └── aggregations
- │    │    │    │              └── max [as=max:33, outer=(15)]
- │    │    │    │                   └── version:15
- │    │    │    └── filters (true)
- │    │    └── 1
+ │    ├── scan cardsinfo@cardsinfoversionindex
+ │    │    ├── columns: dealerid:7!null version:15!null
+ │    │    ├── constraint: /7/15: [/1 - /4]
+ │    │    ├── stats: [rows=233333.333, distinct(7)=4, null(7)=0]
+ │    │    └── key: (7,15)
  │    └── aggregations
- │         └── const-agg [as=max:34, outer=(33)]
- │              └── max:33
+ │         └── max [as=max:34, outer=(15)]
+ │              └── version:15
  └── projections
       └── COALESCE(max:34, 0) [as=coalesce:35, outer=(34)]
 


### PR DESCRIPTION
Previously, a join under a grouping operator could not be eliminated
even when doing so would not effect the output of the grouping operator.

This patch introduces two rules that match grouping operators (Groupby,
ScalarGroupBy and DistinctOn) that take a LeftJoin or InnerJoin as input.
The join is removed if the following conditions are met:

1. Only columns from the left (or right)  input are being used.

2. It can be statically proven that removal of the join will not effect
   the output of the grouping operator.
```
CREATE TABLE xy (x INT PRIMARY KEY, y INT);
CREATE TABLE uv (u INT PRIMARY KEY, v INT);

SELECT x, sum(y) FROM xy LEFT JOIN uv ON x=u GROUP BY x;
=>
SELECT x, sum(y) FROM xy GROUP BY x;
```

Fixes #49141

Release note (sql change): The optimizer can now eliminate an unnecessary
join that is the input to a GroupBy operator.