### PR TITLE
server: use "read-only" Gossip for tenants

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1659,6 +1659,12 @@ type DeprecatedGossip struct {
 	w errorutil.TenantSQLDeprecatedWrapper
 }
 
+// Start calls .Start() on the underlying Gossip instance, which is assumed to
+// be non-nil.
+func (dg DeprecatedGossip) Start(advertAddr net.Addr, resolvers []resolver.Resolver) {
+	dg.w.Deprecated(0).(*Gossip).Start(advertAddr, resolvers)
+}
+
 // deprecated trades a Github issue tracking the removal of the call for the
 // wrapped Gossip instance.
 func (dg DeprecatedGossip) deprecated(issueNo int) *Gossip {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -296,6 +296,9 @@ func MakeKVConfig(storeSpec base.StoreSpec) KVConfig {
 // SQLConfig holds the parameters that (together with a BaseConfig) allow
 // setting up a SQL server.
 type SQLConfig struct {
+	// The tenant that the SQL server runs on the behalf of.
+	TenantID roachpb.TenantID
+
 	// LeaseManagerConfig holds configuration values specific to the LeaseManager.
 	LeaseManagerConfig *base.LeaseManagerConfig
 
@@ -327,11 +330,9 @@ type SQLConfig struct {
 }
 
 // MakeSQLConfig returns a SQLConfig with default values.
-func MakeSQLConfig(
-	tenID roachpb.TenantID, // NB: unused, but used soon
-	tempStorageCfg base.TempStorageConfig,
-) SQLConfig {
+func MakeSQLConfig(tenID roachpb.TenantID, tempStorageCfg base.TempStorageConfig) SQLConfig {
 	sqlCfg := SQLConfig{
+		TenantID:           tenID,
 		MemoryPoolSize:     defaultSQLMemoryPoolSize,
 		TableStatCacheSize: defaultSQLTableStatCacheSize,
 		QueryCacheSize:     defaultSQLQueryCacheSize,

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -152,14 +152,17 @@ func MakeBaseConfig(st *cluster.Settings) BaseConfig {
 	return baseCfg
 }
 
-// Config holds parameters needed to setup a (combined KV and SQL) server.
-//
-// TODO(tbg): this should end up being just SQLConfig union KVConfig union BaseConfig.
+// Config holds the parameters needed to set up a combined KV and SQL server.
 type Config struct {
-	// Embed the base context.
 	BaseConfig
-	base.RaftConfig
+	KVConfig
 	SQLConfig
+}
+
+// KVConfig holds the parameters that (together with a BaseConfig) allow setting
+// up a KV server.
+type KVConfig struct {
+	base.RaftConfig
 
 	// Stores is specified to enable durable key-value storage.
 	Stores base.StoreSpecList
@@ -271,7 +274,27 @@ type Config struct {
 	enginesCreated bool
 }
 
-// SQLConfig holds the parameters to setup a SQL server.
+// MakeKVConfig returns a KVConfig with default values.
+func MakeKVConfig(storeSpec base.StoreSpec) KVConfig {
+	disableWebLogin := envutil.EnvOrDefaultBool("COCKROACH_DISABLE_WEB_LOGIN", false)
+	kvCfg := KVConfig{
+		DefaultSystemZoneConfig:        zonepb.DefaultSystemZoneConfig(),
+		CacheSize:                      DefaultCacheSize,
+		ScanInterval:                   defaultScanInterval,
+		ScanMinIdleTime:                defaultScanMinIdleTime,
+		ScanMaxIdleTime:                defaultScanMaxIdleTime,
+		EventLogEnabled:                defaultEventLogEnabled,
+		EnableWebSessionAuthentication: !disableWebLogin,
+		Stores: base.StoreSpecList{
+			Specs: []base.StoreSpec{storeSpec},
+		},
+	}
+	kvCfg.RaftConfig.SetDefaults()
+	return kvCfg
+}
+
+// SQLConfig holds the parameters that (together with a BaseConfig) allow
+// setting up a SQL server.
 type SQLConfig struct {
 	// LeaseManagerConfig holds configuration values specific to the LeaseManager.
 	LeaseManagerConfig *base.LeaseManagerConfig
@@ -357,25 +380,13 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 
 	sqlCfg := MakeSQLConfig(roachpb.SystemTenantID, tempStorageCfg)
 	baseCfg := MakeBaseConfig(st)
-
-	disableWebLogin := envutil.EnvOrDefaultBool("COCKROACH_DISABLE_WEB_LOGIN", false)
+	kvCfg := MakeKVConfig(storeSpec)
 
 	cfg := Config{
-		BaseConfig:                     baseCfg,
-		SQLConfig:                      sqlCfg,
-		DefaultSystemZoneConfig:        zonepb.DefaultSystemZoneConfig(),
-		CacheSize:                      DefaultCacheSize,
-		ScanInterval:                   defaultScanInterval,
-		ScanMinIdleTime:                defaultScanMinIdleTime,
-		ScanMaxIdleTime:                defaultScanMaxIdleTime,
-		EventLogEnabled:                defaultEventLogEnabled,
-		EnableWebSessionAuthentication: !disableWebLogin,
-		Stores: base.StoreSpecList{
-			Specs: []base.StoreSpec{storeSpec},
-		},
+		BaseConfig: baseCfg,
+		KVConfig:   kvCfg,
+		SQLConfig:  sqlCfg,
 	}
-
-	cfg.RaftConfig.SetDefaults()
 
 	return cfg
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -553,7 +553,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		registry:                 registry,
 		sessionRegistry:          sessionRegistry,
 		circularInternalExecutor: internalExecutor,
-		jobRegistry:              jobRegistry,
+		circularJobRegistry:      jobRegistry,
 		jobAdoptionStopFile:      jobAdoptionStopFile,
 		protectedtsProvider:      protectedtsProvider,
 	})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -549,7 +549,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		stopper:                  stopper,
 		clock:                    clock,
 		runtime:                  runtimeSampler,
-		tenantID:                 roachpb.SystemTenantID,
 		db:                       db,
 		registry:                 registry,
 		sessionRegistry:          sessionRegistry,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -140,9 +140,6 @@ type sqlServerArgs struct {
 	// samplerProcessor.
 	runtime execinfra.RuntimeStats
 
-	// The tenant that the SQL server runs on the behalf of.
-	tenantID roachpb.TenantID
-
 	// SQL uses KV, both for non-DistSQL and DistSQL execution.
 	db *kv.DB
 
@@ -170,7 +167,7 @@ type sqlServerArgs struct {
 
 func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 	execCfg := &sql.ExecutorConfig{}
-	codec := keys.MakeSQLCodec(cfg.tenantID)
+	codec := keys.MakeSQLCodec(cfg.SQLConfig.TenantID)
 
 	// Create blob service for inter-node file sharing.
 	blobService, err := blobs.NewBlobService(cfg.Settings.ExternalIODir)

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -158,7 +158,7 @@ type sqlServerArgs struct {
 	// The protected timestamps KV subsystem depends on this, so we pass a
 	// pointer to an empty struct in this configuration, which newSQLServer
 	// fills.
-	jobRegistry         *jobs.Registry
+	circularJobRegistry *jobs.Registry
 	jobAdoptionStopFile string
 
 	// The executorConfig uses the provider.
@@ -176,7 +176,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 	}
 	blobspb.RegisterBlobServer(cfg.grpcServer, blobService)
 
-	jobRegistry := cfg.jobRegistry
+	jobRegistry := cfg.circularJobRegistry
 
 	{
 		regLiveness := cfg.nodeLiveness

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -620,6 +620,7 @@ func (ts *TestServer) StartTenant(params base.TestTenantArgs) (pgAddr string, _ 
 		}
 	}
 	return startTenant(
+		ctx,
 		ts.Stopper(),
 		ts.Cfg.ClusterName,
 		ts.RPCAddr(),
@@ -629,6 +630,7 @@ func (ts *TestServer) StartTenant(params base.TestTenantArgs) (pgAddr string, _ 
 }
 
 func startTenant(
+	ctx context.Context,
 	stopper *stop.Stopper,
 	kvClusterName string, // NB: gone after https://github.com/cockroachdb/cockroach/issues/42519
 	tsRPCAddr string,
@@ -636,7 +638,6 @@ func startTenant(
 	sqlCfg SQLConfig,
 ) (pgAddr string, _ error) {
 	args := makeSQLServerArgs(stopper, kvClusterName, baseCfg, sqlCfg)
-	ctx := context.Background()
 	s, err := newSQLServer(ctx, args)
 	if err != nil {
 		return "", err

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -568,7 +568,6 @@ func testSQLServerArgs(ts *TestServer) sqlServerArgs {
 		stopper:                  stopper,
 		clock:                    clock,
 		runtime:                  status.NewRuntimeStatSampler(context.Background(), clock),
-		tenantID:                 roachpb.SystemTenantID,
 		db:                       db,
 		registry:                 registry,
 		sessionRegistry:          sql.NewSessionRegistry(),
@@ -589,7 +588,6 @@ func (ts *TestServer) StartTenant(params base.TestTenantArgs) (pgAddr string, _ 
 	}
 
 	args := testSQLServerArgs(ts)
-	args.tenantID = params.TenantID
 	if params.AllowSettingClusterSettings {
 		args.TestingKnobs.TenantTestingKnobs = &sql.TenantTestingKnobs{
 			ClusterSettingsUpdater: args.Settings.MakeUpdater(),

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -577,14 +577,14 @@ func makeSQLServerArgs(
 			grpcServer:   dummyRPCServer,
 			recorder:     dummyRecorder,
 			isMeta1Leaseholder: func(timestamp hlc.Timestamp) (bool, error) {
-				return false, errors.New("isMeta1Leaseholder is not available to tenants")
+				return false, errors.New("isMeta1Leaseholder is not available to secondary tenants")
 			},
 			nodeIDContainer: idContainer,
 			externalStorage: func(ctx context.Context, dest roachpb.ExternalStorage) (cloud.ExternalStorage, error) {
-				return nil, errors.New("external storage is not available to tenants")
+				return nil, errors.New("external storage is not available to secondary tenants")
 			},
 			externalStorageFromURI: func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
-				return nil, errors.New("external uri storage is not available to tenants")
+				return nil, errors.New("external uri storage is not available to secondary tenants")
 			},
 		},
 		SQLConfig:                &sqlCfg,


### PR DESCRIPTION
We were previously using the Gossip instance of the TestServer against
which the tenant was initialized.

This commit trims the dependency further by initializing its own Gossip
instance which is never written to (i.e. `AddInfo` is never called) and
which does not accept incoming connections.

As a reminder, the remaining problematic uses of Gossip as of this
commit are:

- making a `nodeDialer` (for `DistSender`), tracked in:
  #47909
- access to the system config:
  - `(schemaChangeGCResumer).Resume`, tracked:
    #49691
  - `database.Cache`, tracked:
    #49692
- `(physicalplan).spanResolver` (for replica oracle).
  This is likely not a blocker as we can use a "dumber" oracle in this case;
  the oracle is used for distsql physical planning of which tenants will
  do none. Tracked in: #48432

cc @ajwerner 

Release note: None