### PR TITLE
Makefile: fix handling of non-existent *.eg.go files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1558,7 +1558,7 @@ endif
 # to the present, because then it will becomes newer
 # than all the other produced artifacts downstream and force
 # them to rebuild too.
-%.eg.go: bin/execgen
+$(EXECGEN_TARGETS): bin/execgen
 	@echo EXECGEN $@
 	@execgen $@ > $@.tmp || { rm -f $@.tmp; exit 1; }
 	@cmp $@.tmp $@ 2>/dev/null && rm -f $@.tmp || mv -f $@.tmp $@
@@ -1569,6 +1569,12 @@ endif
 	    target_timestamp_file=bin/execgen; \
 	  fi; \
 	  touch -r $$target_timestamp_file $@
+
+# Add a catch-all rule for any non-existent execgen generated
+# files. This prevents build errors when switching between branches
+# that introduce or remove execgen generated files as these files are
+# persisted in bin/%.d dependency lists (e.g. in bin/logictest.d).
+%.eg.go: ;
 
 optgen-defs := pkg/sql/opt/ops/*.opt
 optgen-norm-rules := pkg/sql/opt/norm/rules/*.opt


### PR DESCRIPTION
When a `bin/*.d` file references an `*.eg.go` file, that file was
required to exist or be buildable by the Makefile. Any commit which
removed a `*.eg.go` file would violate this requirement causing the
build to fail until the offending `bin/*.d` file was removed. In order
to prevent this badness, a catchall `%.eg.go` rule is added which will
force the target dependent on the `bin/%.d` file to be rebuilt.

Fixes #49676

Release note: None