### PR TITLE
server: use unique fake node ID in StartTenant

### DIFF
--- a/pkg/server/server_sql_test.go
+++ b/pkg/server/server_sql_test.go
@@ -39,7 +39,7 @@ func TestSQLServer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	tc := serverutils.StartTestCluster(t, 1, base.TestClusterArgs{})
+	tc := serverutils.StartTestCluster(t, 3, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(ctx)
 
 	db := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)})

--- a/pkg/server/server_sql_test.go
+++ b/pkg/server/server_sql_test.go
@@ -49,6 +49,8 @@ func TestSQLServer(t *testing.T) {
 	r.Exec(t, `CREATE DATABASE foo`)
 	r.Exec(t, `CREATE TABLE foo.kv (k STRING PRIMARY KEY, v STRING)`)
 	r.Exec(t, `INSERT INTO foo.kv VALUES('foo', 'bar')`)
+	// Cause an index backfill operation.
+	r.Exec(t, `CREATE INDEX ON foo.kv (v)`)
 	t.Log(sqlutils.MatrixToStr(r.QueryStr(t, `SET distsql=off; SELECT * FROM foo.kv`)))
 	t.Log(sqlutils.MatrixToStr(r.QueryStr(t, `SET distsql=auto; SELECT * FROM foo.kv`)))
 }

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -433,9 +433,6 @@ func (d dummyProtectedTSProvider) Protect(context.Context, *kv.Txn, *ptpb.Record
 	return errors.New("fake protectedts.Provider")
 }
 
-// TODO(asubiotto): Jobs don't play well with a weird node ID in a multitenant
-//  environment, so a node ID of 1 is used here to get tests to pass. Fixing
-//  this is tracked in https://github.com/cockroachdb/cockroach/issues/47892.
 const fakeNodeID = roachpb.NodeID(123456789)
 
 func makeSQLServerArgs(

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -436,7 +436,7 @@ func (d dummyProtectedTSProvider) Protect(context.Context, *kv.Txn, *ptpb.Record
 // TODO(asubiotto): Jobs don't play well with a weird node ID in a multitenant
 //  environment, so a node ID of 1 is used here to get tests to pass. Fixing
 //  this is tracked in https://github.com/cockroachdb/cockroach/issues/47892.
-const fakeNodeID = roachpb.NodeID(1)
+const fakeNodeID = roachpb.NodeID(123456789)
 
 func makeSQLServerArgs(
 	stopper *stop.Stopper, kvClusterName string, baseCfg BaseConfig, sqlCfg SQLConfig,

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3213,10 +3213,14 @@ func (dsp *DistSQLPlanner) createPlanForExport(
 
 // NewPlanningCtx returns a new PlanningCtx. When distribute is false, a
 // lightweight version PlanningCtx is returned that can be used when the caller
-// knows plans will only be run on one node.
+// knows plans will only be run on one node. It is coerced to false on SQL
+// SQL tenants (in which case only local planning is supported), regardless of
+// the passed-in value.
 func (dsp *DistSQLPlanner) NewPlanningCtx(
 	ctx context.Context, evalCtx *extendedEvalContext, txn *kv.Txn, distribute bool,
 ) *PlanningCtx {
+	// Tenants can not distribute plans.
+	distribute = distribute && evalCtx.Codec.ForSystemTenant()
 	planCtx := &PlanningCtx{
 		ctx:             ctx,
 		ExtendedEvalCtx: evalCtx,

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -836,7 +836,9 @@ func TestPartitionSpans(t *testing.T) {
 				},
 			}
 
-			planCtx := dsp.NewPlanningCtx(context.Background(), nil /* evalCtx */, nil /* txn */, true /* distribute */)
+			planCtx := dsp.NewPlanningCtx(context.Background(), &extendedEvalContext{
+				EvalContext: tree.EvalContext{Codec: keys.SystemSQLCodec},
+			}, nil /* txn */, true /* distribute */)
 			var spans []roachpb.Span
 			for _, s := range tc.spans {
 				spans = append(spans, roachpb.Span{Key: roachpb.Key(s[0]), EndKey: roachpb.Key(s[1])})
@@ -1017,7 +1019,9 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 				},
 			}
 
-			planCtx := dsp.NewPlanningCtx(context.Background(), nil /* evalCtx */, nil /* txn */, true /* distribute */)
+			planCtx := dsp.NewPlanningCtx(context.Background(), &extendedEvalContext{
+				EvalContext: tree.EvalContext{Codec: keys.SystemSQLCodec},
+			}, nil /* txn */, true /* distribute */)
 			partitions, err := dsp.PartitionSpans(planCtx, roachpb.Spans{span})
 			if err != nil {
 				t.Fatal(err)
@@ -1113,7 +1117,9 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 		},
 	}
 
-	planCtx := dsp.NewPlanningCtx(context.Background(), nil /* evalCtx */, nil /* txn */, true /* distribute */)
+	planCtx := dsp.NewPlanningCtx(context.Background(), &extendedEvalContext{
+		EvalContext: tree.EvalContext{Codec: keys.SystemSQLCodec},
+	}, nil /* txn */, true /* distribute */)
 	partitions, err := dsp.PartitionSpans(planCtx, roachpb.Spans{span})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
We had previously hard-coded a NodeID of 1 (matching the underlying
TestServer's NodeID) to make "things work" for SQL tenants. The
commits in this lifted this restriction, so we now use a (static)
NodeID which is highly unlikely to match any NodeID from the KV
layer.

The main work item was to make sure DistSQL does not schedule any
flows.
There are many places in the SQL codebase that construct flows and it
was difficult to ensure that none of them attempt to schedule a nonlocal
one. (We do error out when we attempt to SetupFlow them, though).

Release note: None