### PR TITLE
encoding: define EncodeTableKey / DecodeTableKey for Geo types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -334,6 +334,26 @@ INSERT INTO geom_operators_test VALUES
   ('Empty GeometryCollection', 'GEOMETRYCOLLECTION EMPTY')
   -- ('Partially Empty GeometryCollection', 'GEOMETRYCOLLECTION ( LINESTRING EMPTY, POINT (0.0 0.0) )'): omitted, see: #49209
 
+# GROUP BY
+query TR
+SELECT
+  a.dsc,
+  ST_Area(a.geom)
+FROM geom_operators_test a
+GROUP BY a.dsc, a.geom
+ORDER BY a.dsc
+----
+Empty GeometryCollection                  0
+Empty LineString                          0
+Faraway point                             0
+Line going through left and right square  0
+NULL                                      NULL
+Point middle of Left Square               0
+Point middle of Right Square              0
+Square (left)                             1
+Square (right)                            1
+Square overlapping left and right square  1.1
+
 # Unary operators
 query TRRRR
 SELECT
@@ -978,6 +998,26 @@ subtest geog_operators
 
 statement ok
 CREATE TABLE geog_operators_test AS SELECT dsc, geom::geography AS geog FROM geom_operators_test
+
+# GROUP BY
+query TR
+SELECT
+  a.dsc,
+  ST_Area(a.geog)
+FROM geog_operators_test a
+GROUP BY a.dsc, a.geog
+ORDER BY a.dsc
+----
+Empty GeometryCollection                  0
+Empty LineString                          0
+Faraway point                             0
+Line going through left and right square  0
+NULL                                      NULL
+Point middle of Left Square               0
+Point middle of Right Square              0
+Square (left)                             1.23087783614695e+10
+Square (right)                            1.23087783614695e+10
+Square overlapping left and right square  1.35397288423019e+10
 
 # Unary operators
 query TRRRRRRRRR

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/ipaddr"
@@ -30,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func testBasicEncodeDecode32(
@@ -1059,6 +1062,7 @@ func TestEncodeDecodeTime(t *testing.T) {
 		}
 	}
 }
+
 func TestEncodeDecodeTimeTZ(t *testing.T) {
 	// Test cases are in ascending order for TimeTZ, which means:
 	// * UTC timestamp first preference
@@ -1143,6 +1147,40 @@ func TestEncodeDecodeTimeTZ(t *testing.T) {
 	}
 }
 
+func TestEncodeDecodeGeo(t *testing.T) {
+	testCases := []string{
+		"SRID=4326;POINT(1.0 1.0)",
+		"POINT(2.0 2.0)",
+	}
+	for _, tc := range testCases {
+		t.Run(tc, func(t *testing.T) {
+			for _, dir := range []Direction{Ascending, Descending} {
+				t.Run(fmt.Sprintf("dir:%d", dir), func(t *testing.T) {
+					parsed, err := geo.ParseGeometry(tc)
+					require.NoError(t, err)
+					spatialObject := parsed.SpatialObject
+
+					var b []byte
+					var decoded geopb.SpatialObject
+					if dir == Ascending {
+						b, err = EncodeGeoAscending(b, &spatialObject)
+						require.NoError(t, err)
+						_, decoded, err = DecodeGeoAscending(b)
+						require.NoError(t, err)
+					} else {
+						b, err = EncodeGeoDescending(b, &spatialObject)
+						require.NoError(t, err)
+						_, decoded, err = DecodeGeoDescending(b)
+						require.NoError(t, err)
+					}
+					require.Equal(t, spatialObject, decoded)
+					testPeekLength(t, b)
+				})
+			}
+		})
+	}
+}
+
 type testCaseDuration struct {
 	value  duration.Duration
 	expEnc []byte
@@ -1217,8 +1255,14 @@ func TestEncodeDecodeDescending(t *testing.T) {
 }
 
 func TestPeekType(t *testing.T) {
-	encodedDurationAscending, _ := EncodeDurationAscending(nil, duration.Duration{})
-	encodedDurationDescending, _ := EncodeDurationDescending(nil, duration.Duration{})
+	encodedDurationAscending, err := EncodeDurationAscending(nil, duration.Duration{})
+	require.NoError(t, err)
+	encodedDurationDescending, err := EncodeDurationDescending(nil, duration.Duration{})
+	require.NoError(t, err)
+	encodedGeoAscending, err := EncodeGeoAscending(nil, &geopb.SpatialObject{})
+	require.NoError(t, err)
+	encodedGeoDescending, err := EncodeGeoDescending(nil, &geopb.SpatialObject{})
+	require.NoError(t, err)
 	testCases := []struct {
 		enc []byte
 		typ Type
@@ -1242,6 +1286,8 @@ func TestPeekType(t *testing.T) {
 		{EncodeTimeDescending(nil, timeutil.Now()), Time},
 		{EncodeTimeTZAscending(nil, timetz.Now()), TimeTZ},
 		{EncodeTimeTZDescending(nil, timetz.Now()), TimeTZ},
+		{encodedGeoAscending, Geo},
+		{encodedGeoDescending, GeoDesc},
 		{encodedDurationAscending, Duration},
 		{encodedDurationDescending, Duration},
 		{EncodeBitArrayAscending(nil, bitarray.BitArray{}), BitArray},

--- a/pkg/util/encoding/type_string.go
+++ b/pkg/util/encoding/type_string.go
@@ -29,13 +29,14 @@ func _() {
 	_ = x[BitArrayDesc-18]
 	_ = x[TimeTZ-19]
 	_ = x[Geo-20]
-	_ = x[ArrayKeyAsc-21]
-	_ = x[ArrayKeyDesc-22]
+	_ = x[GeoDesc-21]
+	_ = x[ArrayKeyAsc-22]
+	_ = x[ArrayKeyDesc-23]
 }
 
-const _Type_name = "UnknownNullNotNullIntFloatDecimalBytesBytesDescTimeDurationTrueFalseUUIDArrayIPAddrJSONTupleBitArrayBitArrayDescTimeTZGeoArrayKeyAscArrayKeyDesc"
+const _Type_name = "UnknownNullNotNullIntFloatDecimalBytesBytesDescTimeDurationTrueFalseUUIDArrayIPAddrJSONTupleBitArrayBitArrayDescTimeTZGeoGeoDescArrayKeyAscArrayKeyDesc"
 
-var _Type_index = [...]uint8{0, 7, 11, 18, 21, 26, 33, 38, 47, 51, 59, 63, 68, 72, 77, 83, 87, 92, 100, 112, 118, 121, 132, 144}
+var _Type_index = [...]uint8{0, 7, 11, 18, 21, 26, 33, 38, 47, 51, 59, 63, 68, 72, 77, 83, 87, 92, 100, 112, 118, 121, 128, 139, 151}
 
 func (i Type) String() string {
 	if i < 0 || i >= Type(len(_Type_index)-1) {


### PR DESCRIPTION
For GROUP BY to work, there needs to be a way of encoding / decoding
table keys for each column type. As such, define EncodeTableKey and
DecodeTableKey for geo types to be their underlying protobuf
representation (we currently have no better way!). Note that this
does not yet allow us to support PKs for geospatial (we could, but we
need some more iteration beforehand).

I've shifted the array descriptor markers around as they seem to be new
in 20.2 as well -- so they should be stable in the upcoming alpha
release.

Release note: None

