### PR TITLE
storage: Add rocksdb-vs-pebble benchmark for ExportToSst

### DIFF
--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -91,6 +91,42 @@ func BenchmarkMVCCScan_Pebble(b *testing.B) {
 	}
 }
 
+func BenchmarkExportToSst(b *testing.B) {
+	numKeys := []int{64, 512, 1024, 8192, 65536}
+	numRevisions := []int{1, 10, 100}
+	exportAllRevisions := []bool{false, true}
+	contention := []bool{false, true}
+	engineMakers := []struct {
+		name   string
+		create engineMaker
+	}{
+		{"rocksdb", setupMVCCRocksDB},
+		{"pebble", setupMVCCPebble},
+	}
+
+	for _, engineImpl := range engineMakers {
+		b.Run(engineImpl.name, func(b *testing.B) {
+			for _, numKey := range numKeys {
+				b.Run(fmt.Sprintf("numKeys=%d", numKey), func(b *testing.B) {
+					for _, numRevision := range numRevisions {
+						b.Run(fmt.Sprintf("numRevisions=%d", numRevision), func(b *testing.B) {
+							for _, exportAllRevisionsVal := range exportAllRevisions {
+								b.Run(fmt.Sprintf("exportAllRevisions=%t", exportAllRevisions), func(b *testing.B) {
+									for _, contentionVal := range contention {
+										b.Run(fmt.Sprintf("contention=%t", contentionVal), func(b *testing.B) {
+											runExportToSst(context.Background(), b, engineImpl.create, numKey, numRevision, exportAllRevisionsVal, contentionVal)
+										})
+									}
+								})
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
 func BenchmarkMVCCReverseScan_Pebble(b *testing.B) {
 	if testing.Short() {
 		b.Skip("TODO: fix benchmark")


### PR DESCRIPTION
As part of the investigation into #49710, this change adds a
benchmark for ExportToSst that tests both RocksDB and Pebble.

Here are some example runs without contention (old = rocksdb,
new = pebble):

	name                                                   old time/op  new time/op  delta
	ExportToSst/rocksdb/numKeys=64/numRevisions=1-12       43.9µs ± 3%  34.5µs ± 4%  -21.33%  (p=0.000 n=10+10)
	ExportToSst/rocksdb/numKeys=64/numRevisions=10-12       281µs ± 3%   169µs ± 6%  -39.89%  (p=0.000 n=10+10)
	ExportToSst/rocksdb/numKeys=64/numRevisions=100-12     1.82ms ±22%  1.17ms ± 1%  -35.73%  (p=0.000 n=10+9)
	ExportToSst/rocksdb/numKeys=512/numRevisions=1-12       212µs ± 6%   111µs ± 3%  -47.77%  (p=0.000 n=10+9)
	ExportToSst/rocksdb/numKeys=512/numRevisions=10-12     1.91ms ± 1%  1.19ms ± 8%  -37.65%  (p=0.000 n=10+10)
	ExportToSst/rocksdb/numKeys=512/numRevisions=100-12    13.7ms ± 3%  10.1ms ±12%  -26.21%  (p=0.000 n=10+10)
	ExportToSst/rocksdb/numKeys=1024/numRevisions=1-12      390µs ± 1%   215µs ±12%  -44.94%  (p=0.000 n=10+10)
	ExportToSst/rocksdb/numKeys=1024/numRevisions=10-12    4.01ms ± 6%  2.40ms ±16%  -40.13%  (p=0.000 n=10+9)
	ExportToSst/rocksdb/numKeys=1024/numRevisions=100-12   27.9ms ± 2%  20.8ms ± 2%  -25.48%  (p=0.000 n=10+10)
	ExportToSst/rocksdb/numKeys=8192/numRevisions=1-12     2.97ms ± 2%  1.42ms ± 5%  -52.24%  (p=0.000 n=9+10)
	ExportToSst/rocksdb/numKeys=8192/numRevisions=10-12    32.8ms ± 7%  19.1ms ± 3%  -41.59%  (p=0.000 n=10+10)
	ExportToSst/rocksdb/numKeys=8192/numRevisions=100-12    224ms ± 3%   169ms ±25%  -24.64%  (p=0.000 n=9+10)
	ExportToSst/rocksdb/numKeys=65536/numRevisions=1-12    23.7ms ± 4%  13.4ms ±20%  -43.65%  (p=0.000 n=9+10)
	ExportToSst/rocksdb/numKeys=65536/numRevisions=10-12    264ms ± 4%   201ms ±24%  -23.92%  (p=0.000 n=10+10)
	ExportToSst/rocksdb/numKeys=65536/numRevisions=100-12   1.88s ± 6%   1.23s ± 8%  -34.70%  (p=0.000 n=10+8)

And some with contention=true:

	name                                                                   old time/op  new time/op  delta
	ExportToSst/rocksdb/numKeys=65536/numRevisions=10/contention=true-12    362ms ± 7%   168ms ± 3%  -53.60%  (p=0.000 n=10+10)
	ExportToSst/rocksdb/numKeys=65536/numRevisions=100/contention=true-12   2.24s ± 6%   1.24s ±10%  -44.50%  (p=0.000 n=10+10)

Release note: None.