### PR TITLE
geo/geomfn: implement ST_Buffer

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -744,6 +744,69 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="st_astext"></a><code>st_astext(geometry: geometry) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the WKT representation of a given Geometry.</p>
 </span></td></tr>
+<tr><td><a name="st_buffer"></a><code>st_buffer(geometry: geometry, distance: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry that represents all points whose distance is less than or equal to the given distance
+from the given Geometry.</p>
+<p>This function utilizes the GEOS module.</p>
+</span></td></tr>
+<tr><td><a name="st_buffer"></a><code>st_buffer(geometry: geometry, distance: <a href="float.html">float</a>, buffer_style_params: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry that represents all points whose distance is less than or equal to the given distance from the
+given Geometry.</p>
+<p>This variant takes in a space separate parameter string, which will augment the buffer styles. Valid parameters are:</p>
+<ul>
+<li>quad_segs=&lt;int&gt;, default 8</li>
+<li>endcap=&lt;round|flat|butt|square&gt;, default round</li>
+<li>join=&lt;round|mitre|miter|bevel&gt;, default round</li>
+<li>side=&lt;both|left|right&gt;, default both</li>
+<li>mitre_limit=&lt;float&gt;, default 5.0</li>
+</ul>
+<p>This function utilizes the GEOS module.</p>
+</span></td></tr>
+<tr><td><a name="st_buffer"></a><code>st_buffer(geometry: geometry, distance: <a href="float.html">float</a>, quad_segs: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry that represents all points whose distance is less than or equal to the given distance from the
+given Geometry.</p>
+<p>This variant approximates the circle into quad_seg segments per line (the default is 8).</p>
+<p>This function utilizes the GEOS module.</p>
+</span></td></tr>
+<tr><td><a name="st_buffer"></a><code>st_buffer(geometry_str: <a href="string.html">string</a>, distance: <a href="decimal.html">decimal</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry that represents all points whose distance is less than or equal to the given distance
+from the given Geometry.</p>
+<p>This function utilizes the GEOS module.</p>
+</span></td></tr>
+<tr><td><a name="st_buffer"></a><code>st_buffer(geometry_str: <a href="string.html">string</a>, distance: <a href="decimal.html">decimal</a>, buffer_style_params: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry that represents all points whose distance is less than or equal to the given distance from the
+given Geometry.</p>
+<p>This variant takes in a space separate parameter string, which will augment the buffer styles. Valid parameters are:</p>
+<ul>
+<li>quad_segs=&lt;int&gt;, default 8</li>
+<li>endcap=&lt;round|flat|butt|square&gt;, default round</li>
+<li>join=&lt;round|mitre|miter|bevel&gt;, default round</li>
+<li>side=&lt;both|left|right&gt;, default both</li>
+<li>mitre_limit=&lt;float&gt;, default 5.0</li>
+</ul>
+<p>This function utilizes the GEOS module.</p>
+</span></td></tr>
+<tr><td><a name="st_buffer"></a><code>st_buffer(geometry_str: <a href="string.html">string</a>, distance: <a href="decimal.html">decimal</a>, quad_segs: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry that represents all points whose distance is less than or equal to the given distance from the
+given Geometry.</p>
+<p>This variant approximates the circle into quad_seg segments per line (the default is 8).</p>
+<p>This function utilizes the GEOS module.</p>
+</span></td></tr>
+<tr><td><a name="st_buffer"></a><code>st_buffer(geometry_str: <a href="string.html">string</a>, distance: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry that represents all points whose distance is less than or equal to the given distance
+from the given Geometry.</p>
+<p>This function utilizes the GEOS module.</p>
+</span></td></tr>
+<tr><td><a name="st_buffer"></a><code>st_buffer(geometry_str: <a href="string.html">string</a>, distance: <a href="float.html">float</a>, buffer_style_params: <a href="string.html">string</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry that represents all points whose distance is less than or equal to the given distance from the
+given Geometry.</p>
+<p>This variant takes in a space separate parameter string, which will augment the buffer styles. Valid parameters are:</p>
+<ul>
+<li>quad_segs=&lt;int&gt;, default 8</li>
+<li>endcap=&lt;round|flat|butt|square&gt;, default round</li>
+<li>join=&lt;round|mitre|miter|bevel&gt;, default round</li>
+<li>side=&lt;both|left|right&gt;, default both</li>
+<li>mitre_limit=&lt;float&gt;, default 5.0</li>
+</ul>
+<p>This function utilizes the GEOS module.</p>
+</span></td></tr>
+<tr><td><a name="st_buffer"></a><code>st_buffer(geometry_str: <a href="string.html">string</a>, distance: <a href="float.html">float</a>, quad_segs: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry that represents all points whose distance is less than or equal to the given distance from the
+given Geometry.</p>
+<p>This variant approximates the circle into quad_seg segments per line (the default is 8).</p>
+<p>This function utilizes the GEOS module.</p>
+</span></td></tr>
 <tr><td><a name="st_centroid"></a><code>st_centroid(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the centroid of the given geometry.</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td></tr>
@@ -1039,7 +1102,6 @@ has no relationship with the commit order of concurrent transactions.</p>
 <tr><td><a name="st_segmentize"></a><code>st_segmentize(geography: geography, max_segment_length_meters: <a href="float.html">float</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Returns a modified Geography having no segment longer than the given max_segment_length meters.</p>
 <p>The calculations are done on a sphere.</p>
 <p>This function utilizes the S2 library for spherical calculations.</p>
-<p>This function will automatically use any available index.</p>
 </span></td></tr>
 <tr><td><a name="st_setsrid"></a><code>st_setsrid(geography: geography, srid: <a href="int.html">int</a>) &rarr; geography</code></td><td><span class="funcdesc"><p>Sets a Geography to a new SRID without transforming the coordinates.</p>
 </span></td></tr>

--- a/pkg/geo/geomfn/buffer.go
+++ b/pkg/geo/geomfn/buffer.go
@@ -1,0 +1,121 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/cockroachdb/cockroach/pkg/geo/geos"
+	"github.com/cockroachdb/errors"
+)
+
+// BufferParams is a wrapper around the geos.BufferParams.
+type BufferParams struct {
+	p geos.BufferParams
+}
+
+// MakeDefaultBufferParams returns the default BufferParams/
+func MakeDefaultBufferParams() BufferParams {
+	return BufferParams{
+		p: geos.BufferParams{
+			EndCapStyle:      geos.BufferParamsEndCapStyleRound,
+			JoinStyle:        geos.BufferParamsJoinStyleRound,
+			SingleSided:      false,
+			QuadrantSegments: 8,
+			MitreLimit:       5.0,
+		},
+	}
+}
+
+// WithQuadrantSegments returns a copy of the BufferParams with the quadrantSegments set.
+func (b BufferParams) WithQuadrantSegments(quadrantSegments int) BufferParams {
+	ret := b
+	ret.p.QuadrantSegments = quadrantSegments
+	return ret
+}
+
+// ParseBufferParams parses the given buffer params from a SQL string into
+// the BufferParams form.
+// The string must be of the same format as specified by https://postgis.net/docs/ST_Buffer.html.
+// Returns the BufferParams, as well as the modified distance.
+func ParseBufferParams(s string, distance float64) (BufferParams, float64, error) {
+	p := MakeDefaultBufferParams()
+	fields := strings.Fields(s)
+	for _, field := range fields {
+		fParams := strings.Split(field, "=")
+		if len(fParams) != 2 {
+			return BufferParams{}, 0, errors.Newf("unknown buffer parameter: %s", fParams)
+		}
+		f, val := fParams[0], fParams[1]
+		switch strings.ToLower(f) {
+		case "quad_segs":
+			valInt, err := strconv.ParseInt(val, 10, 64)
+			if err != nil {
+				return BufferParams{}, 0, errors.Wrapf(err, "invalid int for %s: %s", f, val)
+			}
+			p.p.QuadrantSegments = int(valInt)
+		case "endcap":
+			switch strings.ToLower(val) {
+			case "round":
+				p.p.EndCapStyle = geos.BufferParamsEndCapStyleRound
+			case "flat", "butt":
+				p.p.EndCapStyle = geos.BufferParamsEndCapStyleFlat
+			case "square":
+				p.p.EndCapStyle = geos.BufferParamsEndCapStyleSquare
+			default:
+				return BufferParams{}, 0, errors.Newf("unknown endcap: %s (accepted: round, flat, square)", val)
+			}
+		case "join":
+			switch strings.ToLower(val) {
+			case "round":
+				p.p.JoinStyle = geos.BufferParamsJoinStyleRound
+			case "mitre", "miter":
+				p.p.JoinStyle = geos.BufferParamsJoinStyleMitre
+			case "bevel":
+				p.p.JoinStyle = geos.BufferParamsJoinStyleBevel
+			default:
+				return BufferParams{}, 0, errors.Newf("unknown join: %s (accepted: round, mitre, bevel)", val)
+			}
+		case "mitre_limit", "miter_limit":
+			valFloat, err := strconv.ParseFloat(val, 64)
+			if err != nil {
+				return BufferParams{}, 0, errors.Wrapf(err, "invalid float for %s: %s", f, val)
+			}
+			p.p.MitreLimit = valFloat
+		case "side":
+			switch strings.ToLower(val) {
+			case "both":
+				p.p.SingleSided = false
+			case "left":
+				p.p.SingleSided = true
+			case "right":
+				p.p.SingleSided = true
+				distance *= -1
+			default:
+				return BufferParams{}, 0, errors.Newf("unknown side: %s (accepted: both, left, right)", val)
+			}
+		default:
+			return BufferParams{}, 0, errors.Newf("unknown field: %s (accepted fields: quad_segs, endcap, join, mitre_limit, side)", f)
+		}
+	}
+	return p, distance, nil
+}
+
+// Buffer buffers a given Geometry by the supplied parameters.
+func Buffer(g *geo.Geometry, params BufferParams, distance float64) (*geo.Geometry, error) {
+	bufferedGeom, err := geos.Buffer(g.EWKB(), params.p, distance)
+	if err != nil {
+		return nil, err
+	}
+	return geo.ParseGeometryFromEWKB(bufferedGeom)
+}

--- a/pkg/geo/geomfn/buffer_test.go
+++ b/pkg/geo/geomfn/buffer_test.go
@@ -1,0 +1,86 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geomfn
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo/geos"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBufferParams(t *testing.T) {
+	testCases := []struct {
+		s string
+		d float64
+
+		expected  BufferParams
+		expectedD float64
+	}{
+		{
+			s: "",
+			d: 100,
+			expected: BufferParams{p: geos.BufferParams{
+				EndCapStyle:      geos.BufferParamsEndCapStyleRound,
+				JoinStyle:        geos.BufferParamsJoinStyleRound,
+				SingleSided:      false,
+				QuadrantSegments: 8,
+				MitreLimit:       5.0,
+			}},
+			expectedD: 100,
+		},
+		{
+			s: "endcap=flat  join=mitre quad_segs=4",
+			d: 100,
+			expected: BufferParams{p: geos.BufferParams{
+				EndCapStyle:      geos.BufferParamsEndCapStyleFlat,
+				JoinStyle:        geos.BufferParamsJoinStyleMitre,
+				SingleSided:      false,
+				QuadrantSegments: 4,
+				MitreLimit:       5.0,
+			}},
+			expectedD: 100,
+		},
+		{
+			s: "side=left",
+			d: 100,
+			expected: BufferParams{p: geos.BufferParams{
+				EndCapStyle:      geos.BufferParamsEndCapStyleRound,
+				JoinStyle:        geos.BufferParamsJoinStyleRound,
+				SingleSided:      true,
+				QuadrantSegments: 8,
+				MitreLimit:       5.0,
+			}},
+			expectedD: 100,
+		},
+		{
+			s: "side=right",
+			d: 100,
+			expected: BufferParams{p: geos.BufferParams{
+				EndCapStyle:      geos.BufferParamsEndCapStyleRound,
+				JoinStyle:        geos.BufferParamsJoinStyleRound,
+				SingleSided:      true,
+				QuadrantSegments: 8,
+				MitreLimit:       5.0,
+			}},
+			expectedD: -100,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.s, func(t *testing.T) {
+			s, d, err := ParseBufferParams(tc.s, tc.d)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, s)
+			require.Equal(t, tc.expectedD, d)
+		})
+	}
+}

--- a/pkg/geo/geos/geos.h
+++ b/pkg/geo/geos/geos.h
@@ -37,6 +37,15 @@ typedef struct {
   size_t len;
 } CR_GEOS_String;
 
+// CR_GEOS_BufferParams are parameters that will be passed to buffer.
+typedef struct {
+  int endCapStyle;
+  int joinStyle;
+  int singleSided;
+  int quadrantSegments;
+  double mitreLimit;
+} CR_GEOS_BufferParamsInput;
+
 typedef CR_GEOS_String CR_GEOS_Status;
 
 // CR_GEOS contains all the functions loaded by GEOS.
@@ -49,13 +58,16 @@ typedef struct CR_GEOS CR_GEOS;
 // The error returned does not need to be freed (see comment for CR_GEOS_Slice).
 CR_GEOS_Slice CR_GEOS_Init(CR_GEOS_Slice loc, CR_GEOS** lib);
 
-// CR_GEOS_WKTToWKB converts a given WKT into it's WKB form. The wkt slice must be
+// CR_GEOS_WKTToWKB converts a given WKT into it's EWKB form. The wkt slice must be
 // convertible to a NUL character terminated C string.
 CR_GEOS_Status CR_GEOS_WKTToEWKB(CR_GEOS* lib, CR_GEOS_Slice wkt, int srid, CR_GEOS_String* ewkb);
 
-// CR_GEOS_ClipEWKBByRect clips a given WKB by the given rectangle.
-CR_GEOS_Status CR_GEOS_ClipEWKBByRect(CR_GEOS* lib, CR_GEOS_Slice wkb, double xmin, double ymin,
+// CR_GEOS_ClipEWKBByRect clips a given EWKB by the given rectangle.
+CR_GEOS_Status CR_GEOS_ClipEWKBByRect(CR_GEOS* lib, CR_GEOS_Slice ewkb, double xmin, double ymin,
                                       double xmax, double ymax, CR_GEOS_String* clippedEWKB);
+// CR_GEOS_Buffer buffers a given EWKB by the given distance and params.
+CR_GEOS_Status CR_GEOS_Buffer(CR_GEOS* lib, CR_GEOS_Slice ewkb, CR_GEOS_BufferParamsInput params,
+                              double distance, CR_GEOS_String* ret);
 
 //
 // Unary operators.
@@ -92,6 +104,7 @@ CR_GEOS_Status CR_GEOS_Within(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, ch
 CR_GEOS_Status CR_GEOS_Relate(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, CR_GEOS_String* ret);
 CR_GEOS_Status CR_GEOS_RelatePattern(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b,
                                      CR_GEOS_Slice pattern, char* ret);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -757,6 +757,35 @@ Square overlapping left and right square  Square (left)                         
 Square overlapping left and right square  Square (right)                            true   false
 Square overlapping left and right square  Square overlapping left and right square  true   false
 
+# Buffer -- unfortunately due to floating point precision, these results can be off by small
+# epsilon across operating systems. Until ST_AsEWKT with precision is implemented, we'll have to
+# verify that it works by checking another statistic for now.
+query TIII
+SELECT
+  a.dsc,
+  ST_NPoints(ST_Buffer(a.geom, 10)),
+  ST_NPoints(ST_Buffer(a.geom, 10, 2)),
+  ST_NPoints(ST_Buffer(a.geom, 10, 'quad_segs=4 endcap=flat'))
+FROM geom_operators_test a
+ORDER BY a.dsc
+----
+Empty GeometryCollection                  0     0     0
+Empty LineString                          0     0     0
+Faraway point                             33    9     0
+Line going through left and right square  35    11    5
+NULL                                      NULL  NULL  NULL
+Point middle of Left Square               33    9     0
+Point middle of Right Square              33    9     0
+Square (left)                             37    13    21
+Square (right)                            37    13    21
+Square overlapping left and right square  37    13    21
+
+# Test raw string with ST_Buffer
+query I
+SELECT ST_NPoints(ST_Buffer('SRID=4326;POINT(0 0)', 10.0))
+----
+33
+
 # DE-9IM relations
 query TTTB
 SELECT

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -318,6 +318,33 @@ var areaOverloadGeometry1 = geometryOverload1(
 	tree.VolatilityImmutable,
 )
 
+var stBufferInfoBuilder = infoBuilder{
+	info: `Returns a Geometry that represents all points whose distance is less than or equal to the given distance
+from the given Geometry.`,
+	libraryUsage: usesGEOS,
+}
+
+var stBufferWithParamsInfoBuilder = infoBuilder{
+	info: `Returns a Geometry that represents all points whose distance is less than or equal to the given distance from the
+given Geometry.
+
+This variant takes in a space separate parameter string, which will augment the buffer styles. Valid parameters are:
+* quad_segs=<int>, default 8
+* endcap=<round|flat|butt|square>, default round
+* join=<round|mitre|miter|bevel>, default round
+* side=<both|left|right>, default both
+* mitre_limit=<float>, default 5.0`,
+	libraryUsage: usesGEOS,
+}
+
+var stBufferWithQuadSegInfoBuilder = infoBuilder{
+	info: `Returns a Geometry that represents all points whose distance is less than or equal to the given distance from the
+given Geometry.
+
+This variant approximates the circle into quad_seg segments per line (the default is 8).`,
+	libraryUsage: usesGEOS,
+}
+
 var geoBuiltins = map[string]builtinDefinition{
 	//
 	// Input (Geometry)
@@ -1936,8 +1963,275 @@ Note ST_Perimeter is only valid for Polygon - use ST_Length for LineString.`,
 
 The calculations are done on a sphere.`,
 				libraryUsage: usesS2,
-				canUseIndex:  true,
 			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
+	"st_buffer": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry", types.Geometry},
+				{"distance", types.Float},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g := args[0].(*tree.DGeometry)
+				distance := *args[1].(*tree.DFloat)
+
+				ret, err := geomfn.Buffer(g.Geometry, geomfn.MakeDefaultBufferParams(), float64(distance))
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			Info:       stBufferInfoBuilder.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry", types.Geometry},
+				{"distance", types.Float},
+				{"quad_segs", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g := args[0].(*tree.DGeometry)
+				distance := *args[1].(*tree.DFloat)
+				quadSegs := *args[2].(*tree.DInt)
+
+				ret, err := geomfn.Buffer(
+					g.Geometry,
+					geomfn.MakeDefaultBufferParams().WithQuadrantSegments(int(quadSegs)),
+					float64(distance),
+				)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			Info:       stBufferWithQuadSegInfoBuilder.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry", types.Geometry},
+				{"distance", types.Float},
+				{"buffer_style_params", types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g := args[0].(*tree.DGeometry)
+				distance := *args[1].(*tree.DFloat)
+				paramsString := *args[2].(*tree.DString)
+
+				params, modifiedDistance, err := geomfn.ParseBufferParams(string(paramsString), float64(distance))
+				if err != nil {
+					return nil, err
+				}
+
+				ret, err := geomfn.Buffer(
+					g.Geometry,
+					params,
+					modifiedDistance,
+				)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			Info:       stBufferWithParamsInfoBuilder.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry_str", types.String},
+				{"distance", types.Float},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				gStr := *args[0].(*tree.DString)
+				distance := *args[1].(*tree.DFloat)
+
+				g, err := geo.ParseGeometry(string(gStr))
+				if err != nil {
+					return nil, err
+				}
+				ret, err := geomfn.Buffer(g, geomfn.MakeDefaultBufferParams(), float64(distance))
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			Info:       stBufferInfoBuilder.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry_str", types.String},
+				// This should be float, but for this to work equivalently to the psql type system,
+				// we have to make a decimal definition.
+				{"distance", types.Decimal},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				gStr := *args[0].(*tree.DString)
+				distance, err := args[1].(*tree.DDecimal).Float64()
+				if err != nil {
+					return nil, err
+				}
+
+				g, err := geo.ParseGeometry(string(gStr))
+				if err != nil {
+					return nil, err
+				}
+				ret, err := geomfn.Buffer(g, geomfn.MakeDefaultBufferParams(), distance)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			Info:       stBufferInfoBuilder.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry_str", types.String},
+				{"distance", types.Float},
+				{"quad_segs", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				gStr := *args[0].(*tree.DString)
+				distance := *args[1].(*tree.DFloat)
+				quadSegs := *args[2].(*tree.DInt)
+
+				g, err := geo.ParseGeometry(string(gStr))
+				if err != nil {
+					return nil, err
+				}
+
+				ret, err := geomfn.Buffer(
+					g,
+					geomfn.MakeDefaultBufferParams().WithQuadrantSegments(int(quadSegs)),
+					float64(distance),
+				)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			Info:       stBufferWithQuadSegInfoBuilder.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry_str", types.String},
+				// This should be float, but for this to work equivalently to the psql type system,
+				// we have to make a decimal definition.
+				{"distance", types.Decimal},
+				{"quad_segs", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				gStr := *args[0].(*tree.DString)
+				distance, err := args[1].(*tree.DDecimal).Float64()
+				if err != nil {
+					return nil, err
+				}
+				quadSegs := *args[2].(*tree.DInt)
+
+				g, err := geo.ParseGeometry(string(gStr))
+				if err != nil {
+					return nil, err
+				}
+
+				ret, err := geomfn.Buffer(
+					g,
+					geomfn.MakeDefaultBufferParams().WithQuadrantSegments(int(quadSegs)),
+					distance,
+				)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			Info:       stBufferWithQuadSegInfoBuilder.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry_str", types.String},
+				{"distance", types.Float},
+				{"buffer_style_params", types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				gStr := *args[0].(*tree.DString)
+				distance := *args[1].(*tree.DFloat)
+				paramsString := *args[2].(*tree.DString)
+
+				g, err := geo.ParseGeometry(string(gStr))
+				if err != nil {
+					return nil, err
+				}
+
+				params, modifiedDistance, err := geomfn.ParseBufferParams(string(paramsString), float64(distance))
+				if err != nil {
+					return nil, err
+				}
+
+				ret, err := geomfn.Buffer(
+					g,
+					params,
+					modifiedDistance,
+				)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			Info:       stBufferWithParamsInfoBuilder.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry_str", types.String},
+				// This should be float, but for this to work equivalently to the psql type system,
+				// we have to make a decimal definition.
+				{"distance", types.Decimal},
+				{"buffer_style_params", types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				gStr := *args[0].(*tree.DString)
+				distance, err := args[1].(*tree.DDecimal).Float64()
+				if err != nil {
+					return nil, err
+				}
+				paramsString := *args[2].(*tree.DString)
+
+				g, err := geo.ParseGeometry(string(gStr))
+				if err != nil {
+					return nil, err
+				}
+
+				params, modifiedDistance, err := geomfn.ParseBufferParams(string(paramsString), distance)
+				if err != nil {
+					return nil, err
+				}
+
+				ret, err := geomfn.Buffer(
+					g,
+					params,
+					modifiedDistance,
+				)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			Info:       stBufferWithParamsInfoBuilder.String(),
 			Volatility: tree.VolatilityImmutable,
 		},
 	),

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1069,6 +1069,7 @@ func TestLint(t *testing.T) {
 
 		ignoredRules := []string{
 			"licence",
+			"mitre",   // PostGIS commands spell these as mitre.
 			"analyse", // required by SQL grammar
 		}
 


### PR DESCRIPTION
Implemented ST_Buffer. Had to write our own parsing logic to make it
compatible with C.

Also ran clang-format and fixed up a few bad infos.

Resolves #48890
Resolves #48891
Resolves #48802
Resolves #48803
Resolves #48804

Release note (sql change): Implement ST_Buffer for geometry and string
variants.