### PR TITLE
sql: clean up of scanNode and some other things

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -113,7 +113,7 @@ func distChangefeedFlow(
 	}
 	dsp := phs.DistSQLPlanner()
 	evalCtx := phs.ExtendedEvalContext()
-	planCtx := dsp.NewPlanningCtx(ctx, evalCtx, noTxn)
+	planCtx := dsp.NewPlanningCtx(ctx, evalCtx, noTxn, true /* distribute */)
 
 	var spanPartitions []sql.SpanPartition
 	if details.SinkURI == `` {

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -259,9 +259,7 @@ func runPlanInsidePlan(
 
 	// Make a copy of the EvalContext so it can be safely modified.
 	evalCtx := params.p.ExtendedEvalContextCopy()
-	planCtx := params.p.extendedEvalCtx.ExecCfg.DistSQLPlanner.newLocalPlanningCtx(params.ctx, evalCtx)
-	// Always plan local.
-	planCtx.isLocal = true
+	planCtx := params.p.extendedEvalCtx.ExecCfg.DistSQLPlanner.NewPlanningCtx(params.ctx, evalCtx, params.p.txn, false /* distribute */)
 	plannerCopy := *params.p
 	planCtx.planner = &plannerCopy
 	planCtx.planner.curPlan = *plan

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -871,7 +871,7 @@ func (sc *SchemaChanger) distBackfill(
 			)
 			defer recv.Release()
 
-			planCtx := sc.distSQLPlanner.NewPlanningCtx(ctx, &evalCtx, txn)
+			planCtx := sc.distSQLPlanner.NewPlanningCtx(ctx, &evalCtx, txn, true /* distribute */)
 			plan, err := sc.distSQLPlanner.createBackfiller(
 				planCtx, backfillType, *tableDesc.TableDesc(), duration, chunkSize, todoSpans, otherTableDescs, readAsOf,
 			)

--- a/pkg/sql/colexec/colbatch_scan.go
+++ b/pkg/sql/colexec/colbatch_scan.go
@@ -116,7 +116,7 @@ func newColBatchScan(
 
 	limitHint := execinfra.LimitHint(spec.LimitHint, post)
 
-	returnMutations := spec.Visibility == execinfrapb.ScanVisibility_PUBLIC_AND_NOT_PUBLIC
+	returnMutations := spec.Visibility == execinfra.ScanVisibilityPublicAndNotPublic
 	typs := spec.Table.ColumnTypesWithMutations(returnMutations)
 	evalCtx := flowCtx.NewEvalCtx()
 	// Before we can safely use types from the table descriptor, we need to
@@ -182,7 +182,7 @@ func initCRowFetcher(
 	}
 
 	cols := immutDesc.Columns
-	if scanVisibility == execinfrapb.ScanVisibility_PUBLIC_AND_NOT_PUBLIC {
+	if scanVisibility == execinfra.ScanVisibilityPublicAndNotPublic {
 		cols = immutDesc.ReadableColumns
 	}
 	tableArgs := row.FetcherTableArgs{

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -650,7 +650,7 @@ func NewColOperator(
 			// still responsible for doing the cancellation check on their own while
 			// performing long operations.
 			result.Op = NewCancelChecker(result.Op)
-			returnMutations := core.TableReader.Visibility == execinfrapb.ScanVisibility_PUBLIC_AND_NOT_PUBLIC
+			returnMutations := core.TableReader.Visibility == execinfra.ScanVisibilityPublicAndNotPublic
 			result.ColumnTypes = core.TableReader.Table.ColumnTypesWithMutations(returnMutations)
 		case core.Aggregator != nil:
 			if err := checkNumIn(inputs, 1); err != nil {

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -861,13 +861,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 	defer recv.Release()
 
 	evalCtx := planner.ExtendedEvalContext()
-	var planCtx *PlanningCtx
-	if distribute {
-		planCtx = ex.server.cfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, planner.txn)
-	} else {
-		planCtx = ex.server.cfg.DistSQLPlanner.newLocalPlanningCtx(ctx, evalCtx)
-	}
-	planCtx.isLocal = !distribute
+	planCtx := ex.server.cfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, planner.txn, distribute)
 	planCtx.planner = planner
 	planCtx.stmtType = recv.stmtType
 	if planner.collectBundle {

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -408,7 +408,7 @@ func (r *createStatsResumer) Resume(
 			txn.SetFixedTimestamp(ctx, *details.AsOf)
 		}
 
-		planCtx := dsp.NewPlanningCtx(ctx, evalCtx, txn)
+		planCtx := dsp.NewPlanningCtx(ctx, evalCtx, txn, true /* distribute */)
 		planCtx.planner = p
 		if err := dsp.planAndRunCreateStats(
 			ctx, evalCtx, planCtx, txn, r.job, NewRowResultWriter(rows),

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -176,9 +176,9 @@ func (d *deleteNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	// If result rows need to be accumulated, do it.
 	if d.run.rows != nil {
 		// The new values can include all columns, the construction of the
-		// values has used publicAndNonPublicColumns so the values may
-		// contain additional columns for every newly dropped column not
-		// visible. We do not want them to be available for RETURNING.
+		// values has used execinfra.ScanVisibilityPublicAndNotPublic so the
+		// values may contain additional columns for every newly dropped column
+		// not visible. We do not want them to be available for RETURNING.
 		//
 		// d.run.rows.NumCols() is guaranteed to only contain the requested
 		// public columns.

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3205,26 +3205,24 @@ func (dsp *DistSQLPlanner) createPlanForExport(
 	return plan, nil
 }
 
-// NewPlanningCtx returns a new PlanningCtx.
+// NewPlanningCtx returns a new PlanningCtx. When distribute is false, a
+// lightweight version PlanningCtx is returned that can be used when the caller
+// knows plans will only be run on one node.
 func (dsp *DistSQLPlanner) NewPlanningCtx(
-	ctx context.Context, evalCtx *extendedEvalContext, txn *kv.Txn,
+	ctx context.Context, evalCtx *extendedEvalContext, txn *kv.Txn, distribute bool,
 ) *PlanningCtx {
-	planCtx := dsp.newLocalPlanningCtx(ctx, evalCtx)
+	planCtx := &PlanningCtx{
+		ctx:             ctx,
+		ExtendedEvalCtx: evalCtx,
+		isLocal:         !distribute,
+	}
+	if !distribute {
+		return planCtx
+	}
 	planCtx.spanIter = dsp.spanResolver.NewSpanResolverIterator(txn)
 	planCtx.NodeStatuses = make(map[roachpb.NodeID]NodeStatus)
 	planCtx.NodeStatuses[dsp.nodeDesc.NodeID] = NodeOK
 	return planCtx
-}
-
-// newLocalPlanningCtx is a lightweight version of NewPlanningCtx that can be
-// used when the caller knows plans will only be run on one node.
-func (dsp *DistSQLPlanner) newLocalPlanningCtx(
-	ctx context.Context, evalCtx *extendedEvalContext,
-) *PlanningCtx {
-	return &PlanningCtx{
-		ctx:             ctx,
-		ExtendedEvalCtx: evalCtx,
-	}
 }
 
 // FinalizePlan adds a final "result" stage if necessary and populates the

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -836,7 +836,7 @@ func TestPartitionSpans(t *testing.T) {
 				},
 			}
 
-			planCtx := dsp.NewPlanningCtx(context.Background(), nil /* evalCtx */, nil /* txn */)
+			planCtx := dsp.NewPlanningCtx(context.Background(), nil /* evalCtx */, nil /* txn */, true /* distribute */)
 			var spans []roachpb.Span
 			for _, s := range tc.spans {
 				spans = append(spans, roachpb.Span{Key: roachpb.Key(s[0]), EndKey: roachpb.Key(s[1])})
@@ -1017,7 +1017,7 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 				},
 			}
 
-			planCtx := dsp.NewPlanningCtx(context.Background(), nil /* evalCtx */, nil /* txn */)
+			planCtx := dsp.NewPlanningCtx(context.Background(), nil /* evalCtx */, nil /* txn */, true /* distribute */)
 			partitions, err := dsp.PartitionSpans(planCtx, roachpb.Spans{span})
 			if err != nil {
 				t.Fatal(err)
@@ -1113,7 +1113,7 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 		},
 	}
 
-	planCtx := dsp.NewPlanningCtx(context.Background(), nil /* evalCtx */, nil /* txn */)
+	planCtx := dsp.NewPlanningCtx(context.Background(), nil /* evalCtx */, nil /* txn */, true /* distribute */)
 	partitions, err := dsp.PartitionSpans(planCtx, roachpb.Spans{span})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -105,7 +105,7 @@ func (c *callbackResultWriter) Err() error {
 func (dsp *DistSQLPlanner) setupAllNodesPlanning(
 	ctx context.Context, evalCtx *extendedEvalContext, execCfg *ExecutorConfig,
 ) (*PlanningCtx, []roachpb.NodeID, error) {
-	planCtx := dsp.NewPlanningCtx(ctx, evalCtx, nil /* txn */)
+	planCtx := dsp.NewPlanningCtx(ctx, evalCtx, nil /* txn */, true /* distribute */)
 
 	ss, err := execCfg.StatusServer.OptionalErr(47900)
 	if err != nil {

--- a/pkg/sql/distsql_plan_ctas.go
+++ b/pkg/sql/distsql_plan_ctas.go
@@ -31,8 +31,7 @@ func PlanAndRunCTAS(
 	out execinfrapb.ProcessorCoreUnion,
 	recv *DistSQLReceiver,
 ) {
-	planCtx := dsp.NewPlanningCtx(ctx, planner.ExtendedEvalContext(), txn)
-	planCtx.isLocal = isLocal
+	planCtx := dsp.NewPlanningCtx(ctx, planner.ExtendedEvalContext(), txn, !isLocal)
 	planCtx.planner = planner
 	planCtx.stmtType = tree.Rows
 

--- a/pkg/sql/distsql_plan_join.go
+++ b/pkg/sql/distsql_plan_join.go
@@ -71,7 +71,7 @@ func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 		// out to be very useful for computing ordering and remapping the
 		// onCond and columns.
 		var err error
-		if plans[i], err = dsp.createTableReaders(planCtx, t.scan, nil); err != nil {
+		if plans[i], err = dsp.createTableReaders(planCtx, t.scan); err != nil {
 			return PhysicalPlan{}, false, err
 		}
 

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -78,7 +78,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 
 	// Create the table readers; for this we initialize a dummy scanNode.
 	scan := scanNode{desc: desc}
-	err := scan.initDescDefaults(nil /* planDependencies */, colCfg)
+	err := scan.initDescDefaults(colCfg)
 	if err != nil {
 		return PhysicalPlan{}, err
 	}
@@ -89,7 +89,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 	}
 	scan.isFull = true
 
-	p, err := dsp.createTableReaders(planCtx, &scan, nil /* overrideResultColumns */)
+	p, err := dsp.createTableReaders(planCtx, &scan)
 	if err != nil {
 		return PhysicalPlan{}, err
 	}
@@ -104,7 +104,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 	}
 
 	sketchSpecs := make([]execinfrapb.SketchSpec, len(reqStats))
-	sampledColumnIDs := make([]sqlbase.ColumnID, scan.valNeededForCol.Len())
+	sampledColumnIDs := make([]sqlbase.ColumnID, len(scan.cols))
 	for i, s := range reqStats {
 		spec := execinfrapb.SketchSpec{
 			SketchType:          execinfrapb.SketchType_HLL_PLUS_PLUS_V1,

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -865,20 +865,13 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	subqueryMemAccount := subqueryMonitor.MakeBoundAccount()
 	defer subqueryMemAccount.Close(ctx)
 
-	var subqueryPlanCtx *PlanningCtx
 	var distributeSubquery bool
 	if maybeDistribute {
 		distributeSubquery = willDistributePlan(
 			ctx, planner.execCfg.NodeID, planner.SessionData().DistSQLMode, subqueryPlan.plan,
 		)
 	}
-	if distributeSubquery {
-		subqueryPlanCtx = dsp.NewPlanningCtx(ctx, evalCtx, planner.txn)
-	} else {
-		subqueryPlanCtx = dsp.newLocalPlanningCtx(ctx, evalCtx)
-	}
-
-	subqueryPlanCtx.isLocal = !distributeSubquery
+	subqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner.txn, distributeSubquery)
 	subqueryPlanCtx.planner = planner
 	subqueryPlanCtx.stmtType = tree.Rows
 	if planner.collectBundle {
@@ -1176,20 +1169,13 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	postqueryMemAccount := postqueryMonitor.MakeBoundAccount()
 	defer postqueryMemAccount.Close(ctx)
 
-	var postqueryPlanCtx *PlanningCtx
 	var distributePostquery bool
 	if maybeDistribute {
 		distributePostquery = willDistributePlan(
 			ctx, planner.execCfg.NodeID, planner.SessionData().DistSQLMode, postqueryPlan,
 		)
 	}
-	if distributePostquery {
-		postqueryPlanCtx = dsp.NewPlanningCtx(ctx, evalCtx, planner.txn)
-	} else {
-		postqueryPlanCtx = dsp.newLocalPlanningCtx(ctx, evalCtx)
-	}
-
-	postqueryPlanCtx.isLocal = !distributePostquery
+	postqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner.txn, distributePostquery)
 	postqueryPlanCtx.planner = planner
 	postqueryPlanCtx.stmtType = tree.Rows
 	postqueryPlanCtx.ignoreClose = true

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -155,11 +155,10 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 		defer p.curPlan.close(ctx)
 
 		evalCtx := p.ExtendedEvalContext()
-		planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, nil /* txn */)
-		// We need isLocal = false so that we executing the plan involves marshaling
+		// We need distribute = true so that executing the plan involves marshaling
 		// the root txn meta to leaf txns. Local flows can start in aborted txns
 		// because they just use the root txn.
-		planCtx.isLocal = false
+		planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, nil /* txn */, true /* distribute */)
 		planCtx.planner = p
 		planCtx.stmtType = recv.stmtType
 

--- a/pkg/sql/execinfra/scanbase.go
+++ b/pkg/sql/execinfra/scanbase.go
@@ -10,7 +10,10 @@
 
 package execinfra
 
-import "github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
 
 // ParallelScanResultThreshold is the number of results up to which, if the
 // maximum number of results returned by a scan is known, the table reader
@@ -32,3 +35,9 @@ func ScanShouldLimitBatches(maxResults uint64, limitHint int64, flowCtx *FlowCtx
 	}
 	return true
 }
+
+// Prettier aliases for execinfrapb.ScanVisibility values.
+const (
+	ScanVisibilityPublic             = execinfrapb.ScanVisibility_PUBLIC
+	ScanVisibilityPublicAndNotPublic = execinfrapb.ScanVisibility_PUBLIC_AND_NOT_PUBLIC
+)

--- a/pkg/sql/execinfrapb/processors_sql.pb.go
+++ b/pkg/sql/execinfrapb/processors_sql.pb.go
@@ -64,7 +64,7 @@ func (x *ScanVisibility) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ScanVisibility) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{0}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{0}
 }
 
 // These mirror the aggregate functions supported by sql/parser. See
@@ -175,7 +175,7 @@ func (x *AggregatorSpec_Func) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (AggregatorSpec_Func) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{12, 0}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{12, 0}
 }
 
 type AggregatorSpec_Type int32
@@ -221,7 +221,7 @@ func (x *AggregatorSpec_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (AggregatorSpec_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{12, 1}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{12, 1}
 }
 
 type WindowerSpec_WindowFunc int32
@@ -285,7 +285,7 @@ func (x *WindowerSpec_WindowFunc) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_WindowFunc) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{15, 0}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{15, 0}
 }
 
 // Mode indicates which mode of framing is used.
@@ -329,7 +329,7 @@ func (x *WindowerSpec_Frame_Mode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_Mode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{15, 1, 0}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{15, 1, 0}
 }
 
 // BoundType indicates which type of boundary is used.
@@ -376,7 +376,7 @@ func (x *WindowerSpec_Frame_BoundType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_BoundType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{15, 1, 1}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{15, 1, 1}
 }
 
 // Exclusion specifies the type of frame exclusion.
@@ -419,7 +419,7 @@ func (x *WindowerSpec_Frame_Exclusion) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_Exclusion) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{15, 1, 2}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{15, 1, 2}
 }
 
 // ValuesCoreSpec is the core of a processor that has no inputs and generates
@@ -439,7 +439,7 @@ func (m *ValuesCoreSpec) Reset()         { *m = ValuesCoreSpec{} }
 func (m *ValuesCoreSpec) String() string { return proto.CompactTextString(m) }
 func (*ValuesCoreSpec) ProtoMessage()    {}
 func (*ValuesCoreSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{0}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{0}
 }
 func (m *ValuesCoreSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -494,9 +494,9 @@ type TableReaderSpec struct {
 	// check. This is only true during SCRUB commands.
 	IsCheck bool `protobuf:"varint,6,opt,name=is_check,json=isCheck" json:"is_check"`
 	// Indicates the visibility level of the columns that should be returned.
-	// Normally, will be set to public. Will be set to publicAndNotPublic if the
-	// consumer of this TableReader expects to be able to see in-progress schema
-	// changes.
+	// Normally, will be set to PUBLIC. Will be set to PUBLIC_AND_NOT_PUBLIC if
+	// the consumer of this TableReader expects to be able to see in-progress
+	// schema changes.
 	Visibility ScanVisibility `protobuf:"varint,7,opt,name=visibility,enum=cockroach.sql.distsqlrun.ScanVisibility" json:"visibility"`
 	// If non-zero, this is a guarantee for the upper bound of rows a TableReader
 	// will read. If 0, the number of results is unbounded.
@@ -544,7 +544,7 @@ func (m *TableReaderSpec) Reset()         { *m = TableReaderSpec{} }
 func (m *TableReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*TableReaderSpec) ProtoMessage()    {}
 func (*TableReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{1}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{1}
 }
 func (m *TableReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -581,9 +581,9 @@ type IndexSkipTableReaderSpec struct {
 	IndexIdx uint32            `protobuf:"varint,2,opt,name=index_idx,json=indexIdx" json:"index_idx"`
 	Spans    []TableReaderSpan `protobuf:"bytes,3,rep,name=spans" json:"spans"`
 	// Indicates the visibility level of the columns that should be returned.
-	// Normally, will be set to public. Will be set to publicAndNotPublic if the
-	// consumer of this TableReader expects to be able to see in-progress schema
-	// changes.
+	// Normally, will be set to PUBLIC. Will be set to PUBLIC_AND_NOT_PUBLIC if
+	// the consumer of this TableReader expects to be able to see in-progress
+	// schema changes.
 	Visibility ScanVisibility `protobuf:"varint,4,opt,name=visibility,enum=cockroach.sql.distsqlrun.ScanVisibility" json:"visibility"`
 	Reverse    bool           `protobuf:"varint,5,opt,name=reverse" json:"reverse"`
 	// Indicates the row-level locking strength to be used by the scan. If set to
@@ -602,7 +602,7 @@ func (m *IndexSkipTableReaderSpec) Reset()         { *m = IndexSkipTableReaderSp
 func (m *IndexSkipTableReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*IndexSkipTableReaderSpec) ProtoMessage()    {}
 func (*IndexSkipTableReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{2}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{2}
 }
 func (m *IndexSkipTableReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -704,7 +704,7 @@ func (m *JoinReaderSpec) Reset()         { *m = JoinReaderSpec{} }
 func (m *JoinReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*JoinReaderSpec) ProtoMessage()    {}
 func (*JoinReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{3}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{3}
 }
 func (m *JoinReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -748,7 +748,7 @@ func (m *SorterSpec) Reset()         { *m = SorterSpec{} }
 func (m *SorterSpec) String() string { return proto.CompactTextString(m) }
 func (*SorterSpec) ProtoMessage()    {}
 func (*SorterSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{4}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{4}
 }
 func (m *SorterSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -810,7 +810,7 @@ func (m *DistinctSpec) Reset()         { *m = DistinctSpec{} }
 func (m *DistinctSpec) String() string { return proto.CompactTextString(m) }
 func (*DistinctSpec) ProtoMessage()    {}
 func (*DistinctSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{5}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{5}
 }
 func (m *DistinctSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -845,7 +845,7 @@ func (m *OrdinalitySpec) Reset()         { *m = OrdinalitySpec{} }
 func (m *OrdinalitySpec) String() string { return proto.CompactTextString(m) }
 func (*OrdinalitySpec) ProtoMessage()    {}
 func (*OrdinalitySpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{6}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{6}
 }
 func (m *OrdinalitySpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -903,7 +903,7 @@ func (m *ZigzagJoinerSpec) Reset()         { *m = ZigzagJoinerSpec{} }
 func (m *ZigzagJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*ZigzagJoinerSpec) ProtoMessage()    {}
 func (*ZigzagJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{7}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{7}
 }
 func (m *ZigzagJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -979,7 +979,7 @@ func (m *MergeJoinerSpec) Reset()         { *m = MergeJoinerSpec{} }
 func (m *MergeJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*MergeJoinerSpec) ProtoMessage()    {}
 func (*MergeJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{8}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{8}
 }
 func (m *MergeJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1066,7 +1066,7 @@ func (m *HashJoinerSpec) Reset()         { *m = HashJoinerSpec{} }
 func (m *HashJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*HashJoinerSpec) ProtoMessage()    {}
 func (*HashJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{9}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{9}
 }
 func (m *HashJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1160,7 +1160,7 @@ func (m *InvertedJoinerSpec) Reset()         { *m = InvertedJoinerSpec{} }
 func (m *InvertedJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*InvertedJoinerSpec) ProtoMessage()    {}
 func (*InvertedJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{10}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{10}
 }
 func (m *InvertedJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1211,7 +1211,7 @@ func (m *InvertedFiltererSpec) Reset()         { *m = InvertedFiltererSpec{} }
 func (m *InvertedFiltererSpec) String() string { return proto.CompactTextString(m) }
 func (*InvertedFiltererSpec) ProtoMessage()    {}
 func (*InvertedFiltererSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{11}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{11}
 }
 func (m *InvertedFiltererSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1257,7 +1257,7 @@ func (m *AggregatorSpec) Reset()         { *m = AggregatorSpec{} }
 func (m *AggregatorSpec) String() string { return proto.CompactTextString(m) }
 func (*AggregatorSpec) ProtoMessage()    {}
 func (*AggregatorSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{12}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{12}
 }
 func (m *AggregatorSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1308,7 +1308,7 @@ func (m *AggregatorSpec_Aggregation) Reset()         { *m = AggregatorSpec_Aggre
 func (m *AggregatorSpec_Aggregation) String() string { return proto.CompactTextString(m) }
 func (*AggregatorSpec_Aggregation) ProtoMessage()    {}
 func (*AggregatorSpec_Aggregation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{12, 0}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{12, 0}
 }
 func (m *AggregatorSpec_Aggregation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1383,7 +1383,7 @@ func (m *InterleavedReaderJoinerSpec) Reset()         { *m = InterleavedReaderJo
 func (m *InterleavedReaderJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*InterleavedReaderJoinerSpec) ProtoMessage()    {}
 func (*InterleavedReaderJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{13}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{13}
 }
 func (m *InterleavedReaderJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1439,7 +1439,7 @@ func (m *InterleavedReaderJoinerSpec_Table) Reset()         { *m = InterleavedRe
 func (m *InterleavedReaderJoinerSpec_Table) String() string { return proto.CompactTextString(m) }
 func (*InterleavedReaderJoinerSpec_Table) ProtoMessage()    {}
 func (*InterleavedReaderJoinerSpec_Table) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{13, 0}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{13, 0}
 }
 func (m *InterleavedReaderJoinerSpec_Table) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1479,7 +1479,7 @@ func (m *ProjectSetSpec) Reset()         { *m = ProjectSetSpec{} }
 func (m *ProjectSetSpec) String() string { return proto.CompactTextString(m) }
 func (*ProjectSetSpec) ProtoMessage()    {}
 func (*ProjectSetSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{14}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{14}
 }
 func (m *ProjectSetSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1521,7 +1521,7 @@ func (m *WindowerSpec) Reset()         { *m = WindowerSpec{} }
 func (m *WindowerSpec) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec) ProtoMessage()    {}
 func (*WindowerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{15}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{15}
 }
 func (m *WindowerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1557,7 +1557,7 @@ func (m *WindowerSpec_Func) Reset()         { *m = WindowerSpec_Func{} }
 func (m *WindowerSpec_Func) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Func) ProtoMessage()    {}
 func (*WindowerSpec_Func) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{15, 0}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{15, 0}
 }
 func (m *WindowerSpec_Func) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1593,7 +1593,7 @@ func (m *WindowerSpec_Frame) Reset()         { *m = WindowerSpec_Frame{} }
 func (m *WindowerSpec_Frame) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame) ProtoMessage()    {}
 func (*WindowerSpec_Frame) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{15, 1}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{15, 1}
 }
 func (m *WindowerSpec_Frame) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1634,7 +1634,7 @@ func (m *WindowerSpec_Frame_Bound) Reset()         { *m = WindowerSpec_Frame_Bou
 func (m *WindowerSpec_Frame_Bound) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame_Bound) ProtoMessage()    {}
 func (*WindowerSpec_Frame_Bound) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{15, 1, 0}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{15, 1, 0}
 }
 func (m *WindowerSpec_Frame_Bound) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1670,7 +1670,7 @@ func (m *WindowerSpec_Frame_Bounds) Reset()         { *m = WindowerSpec_Frame_Bo
 func (m *WindowerSpec_Frame_Bounds) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame_Bounds) ProtoMessage()    {}
 func (*WindowerSpec_Frame_Bounds) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{15, 1, 1}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{15, 1, 1}
 }
 func (m *WindowerSpec_Frame_Bounds) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1720,7 +1720,7 @@ func (m *WindowerSpec_WindowFn) Reset()         { *m = WindowerSpec_WindowFn{} }
 func (m *WindowerSpec_WindowFn) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_WindowFn) ProtoMessage()    {}
 func (*WindowerSpec_WindowFn) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_sql_a06c797e19086240, []int{15, 2}
+	return fileDescriptor_processors_sql_c1e87fb3f4a49645, []int{15, 2}
 }
 func (m *WindowerSpec_WindowFn) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7940,10 +7940,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/execinfrapb/processors_sql.proto", fileDescriptor_processors_sql_a06c797e19086240)
+	proto.RegisterFile("sql/execinfrapb/processors_sql.proto", fileDescriptor_processors_sql_c1e87fb3f4a49645)
 }
 
-var fileDescriptor_processors_sql_a06c797e19086240 = []byte{
+var fileDescriptor_processors_sql_c1e87fb3f4a49645 = []byte{
 	// 2616 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xd4, 0x59, 0x4b, 0x8f, 0xdb, 0xd6,
 	0xf5, 0x1f, 0xea, 0xad, 0xa3, 0xc7, 0xd0, 0xd7, 0x93, 0x58, 0x51, 0xfe, 0x18, 0x8f, 0x95, 0xd7,

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -83,9 +83,9 @@ message TableReaderSpec {
   optional bool is_check = 6 [(gogoproto.nullable) = false];
 
   // Indicates the visibility level of the columns that should be returned.
-  // Normally, will be set to public. Will be set to publicAndNotPublic if the
-  // consumer of this TableReader expects to be able to see in-progress schema
-  // changes.
+  // Normally, will be set to PUBLIC. Will be set to PUBLIC_AND_NOT_PUBLIC if
+  // the consumer of this TableReader expects to be able to see in-progress
+  // schema changes.
   optional ScanVisibility visibility = 7 [(gogoproto.nullable) = false];
 
   // If non-zero, this is a guarantee for the upper bound of rows a TableReader
@@ -147,9 +147,9 @@ message IndexSkipTableReaderSpec {
   repeated TableReaderSpan spans = 3 [(gogoproto.nullable) = false];
 
   // Indicates the visibility level of the columns that should be returned.
-  // Normally, will be set to public. Will be set to publicAndNotPublic if the
-  // consumer of this TableReader expects to be able to see in-progress schema
-  // changes.
+  // Normally, will be set to PUBLIC. Will be set to PUBLIC_AND_NOT_PUBLIC if
+  // the consumer of this TableReader expects to be able to see in-progress
+  // schema changes.
   optional ScanVisibility visibility = 4 [(gogoproto.nullable) = false];
 
   optional bool reverse = 5 [(gogoproto.nullable) = false];

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -92,8 +92,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 		params.ctx, params.extendedEvalCtx.ExecCfg.NodeID,
 		params.extendedEvalCtx.SessionData.DistSQLMode, n.plan.main,
 	)
-	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx, params.p.txn)
-	planCtx.isLocal = !willDistribute
+	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx, params.p.txn, willDistribute)
 	planCtx.ignoreClose = true
 	planCtx.planner = params.p
 	planCtx.stmtType = n.stmtType

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -148,8 +148,7 @@ func makeExplainPlanningCtx(
 	subqueryPlans []subquery,
 	willDistribute bool,
 ) *PlanningCtx {
-	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx, params.p.txn)
-	planCtx.isLocal = !willDistribute
+	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx, params.p.txn, willDistribute)
 	planCtx.ignoreClose = true
 	planCtx.planner = params.p
 	planCtx.stmtType = stmtType

--- a/pkg/sql/join_test.go
+++ b/pkg/sql/join_test.go
@@ -27,7 +27,7 @@ func newTestScanNode(kvDB *kv.DB, tableName string) (*scanNode, error) {
 	p := planner{alloc: &sqlbase.DatumAlloc{}}
 	scan := p.Scan()
 	scan.desc = desc
-	err := scan.initDescDefaults(p.curPlan.deps, publicColumnsCfg)
+	err := scan.initDescDefaults(publicColumnsCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
@@ -2094,14 +2095,14 @@ func makeColDescList(table cat.Table, cols exec.TableColumnOrdinalSet) []sqlbase
 // list of descriptor IDs for columns in the given cols set. Columns are
 // identified by their ordinal position in the table schema.
 func makeScanColumnsConfig(table cat.Table, cols exec.TableColumnOrdinalSet) scanColumnsConfig {
-	// Set visibility=publicAndNonPublicColumns, since all columns in the "cols"
-	// set should be projected, regardless of whether they're public or non-
-	// public. The caller decides which columns to include (or not include). Note
-	// that when wantedColumns is non-empty, the visibility flag will never
-	// trigger the addition of more columns.
+	// Set visibility=execinfra.ScanVisibilityPublicAndNotPublic, since all
+	// columns in the "cols" set should be projected, regardless of whether
+	// they're public or non- public. The caller decides which columns to
+	// include (or not include). Note that when wantedColumns is non-empty,
+	// the visibility flag will never trigger the addition of more columns.
 	colCfg := scanColumnsConfig{
 		wantedColumns: make([]tree.ColumnID, 0, cols.Len()),
-		visibility:    publicAndNonPublicColumns,
+		visibility:    execinfra.ScanVisibilityPublicAndNotPublic,
 	}
 	for c, ok := cols.Next(0); ok; c, ok = cols.Next(c + 1) {
 		desc := table.Column(c).(*sqlbase.ColumnDescriptor)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -117,7 +117,6 @@ func (ef *execFactory) ConstructScan(
 	}
 
 	scan.index = indexDesc
-	scan.isSecondaryIndex = (indexDesc != &tabDesc.PrimaryIndex)
 	scan.hardLimit = hardLimit
 	scan.softLimit = softLimit
 
@@ -642,7 +641,6 @@ func (ef *execFactory) ConstructIndexJoin(
 
 	primaryIndex := tabDesc.GetPrimaryIndex()
 	tableScan.index = &primaryIndex
-	tableScan.isSecondaryIndex = false
 	tableScan.disableBatchLimit()
 
 	n := &indexJoinNode{
@@ -686,7 +684,6 @@ func (ef *execFactory) ConstructLookupJoin(
 	}
 
 	tableScan.index = indexDesc
-	tableScan.isSecondaryIndex = (indexDesc != &tabDesc.PrimaryIndex)
 
 	n := &lookupJoinNode{
 		input:        input.(planNode),
@@ -752,7 +749,6 @@ func (ef *execFactory) constructVirtualTableLookupJoin(
 		return nil, err
 	}
 	tableScan.index = indexDesc
-	tableScan.isSecondaryIndex = true
 	vtableCols := sqlbase.ResultColumnsFromColDescs(tableDesc.ID, tableDesc.Columns)
 	projectedVtableCols := planColumns(&tableScan)
 	outputCols := make(sqlbase.ResultColumns, 0, len(inputCols)+len(projectedVtableCols))
@@ -820,7 +816,6 @@ func (ef *execFactory) constructScanForZigzag(
 	}
 
 	scan.index = indexDesc
-	scan.isSecondaryIndex = (indexDesc.ID != tableDesc.PrimaryIndex.ID)
 
 	return scan, nil
 }

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -290,13 +290,6 @@ type planTop struct {
 	mem     *memo.Memo
 	catalog *optCatalog
 
-	// deps, if non-nil, collects the table/view dependencies for this query.
-	// Any planNode constructors that resolves a table name or reference in the query
-	// to a descriptor must register this descriptor into planDeps.
-	// This is (currently) used by CREATE VIEW.
-	// TODO(knz): Remove this in favor of a better encapsulated mechanism.
-	deps planDependencies
-
 	// auditEvents becomes non-nil if any of the descriptors used by
 	// current statement is causing an auditing event. See exec_log.go.
 	auditEvents []auditEvent

--- a/pkg/sql/rowexec/index_skip_table_reader.go
+++ b/pkg/sql/rowexec/index_skip_table_reader.go
@@ -78,7 +78,7 @@ func newIndexSkipTableReader(
 
 	t := istrPool.Get().(*indexSkipTableReader)
 
-	returnMutations := spec.Visibility == execinfrapb.ScanVisibility_PUBLIC_AND_NOT_PUBLIC
+	returnMutations := spec.Visibility == execinfra.ScanVisibilityPublicAndNotPublic
 	types := spec.Table.ColumnTypesWithMutations(returnMutations)
 	t.ignoreMisplannedRanges = flowCtx.Local
 	t.reverse = spec.Reverse

--- a/pkg/sql/rowexec/indexjoiner.go
+++ b/pkg/sql/rowexec/indexjoiner.go
@@ -78,7 +78,7 @@ func newIndexJoiner(
 		desc:      spec.Table,
 		batchSize: indexJoinerBatchSize,
 	}
-	needMutations := spec.Visibility == execinfrapb.ScanVisibility_PUBLIC_AND_NOT_PUBLIC
+	needMutations := spec.Visibility == execinfra.ScanVisibilityPublicAndNotPublic
 	if err := ij.Init(
 		ij,
 		post,

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -113,7 +113,7 @@ func newJoinReader(
 	if err != nil {
 		return nil, err
 	}
-	returnMutations := spec.Visibility == execinfrapb.ScanVisibility_PUBLIC_AND_NOT_PUBLIC
+	returnMutations := spec.Visibility == execinfra.ScanVisibilityPublicAndNotPublic
 	jr.colIdxMap = jr.desc.ColumnIdxMapWithMutations(returnMutations)
 
 	columnIDs, _ := jr.index.FullColumnIDs()

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -73,7 +73,7 @@ func initRowFetcher(
 	}
 
 	cols := immutDesc.Columns
-	if scanVisibility == execinfrapb.ScanVisibility_PUBLIC_AND_NOT_PUBLIC {
+	if scanVisibility == execinfra.ScanVisibilityPublicAndNotPublic {
 		cols = immutDesc.ReadableColumns
 	}
 	tableArgs := row.FetcherTableArgs{

--- a/pkg/sql/rowexec/scrub_tablereader.go
+++ b/pkg/sql/rowexec/scrub_tablereader.go
@@ -124,7 +124,7 @@ func newScrubTableReader(
 	if _, _, err := initRowFetcher(
 		flowCtx, &fetcher, &tr.tableDesc, int(spec.IndexIdx), tr.tableDesc.ColumnIdxMap(),
 		spec.Reverse, neededColumns, true /* isCheck */, &tr.alloc,
-		execinfrapb.ScanVisibility_PUBLIC, spec.LockingStrength,
+		execinfra.ScanVisibilityPublic, spec.LockingStrength,
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -89,7 +89,7 @@ func newTableReader(
 	tr.maxResults = spec.MaxResults
 	tr.maxTimestampAge = time.Duration(spec.MaxTimestampAgeNanos)
 
-	returnMutations := spec.Visibility == execinfrapb.ScanVisibility_PUBLIC_AND_NOT_PUBLIC
+	returnMutations := spec.Visibility == execinfra.ScanVisibilityPublicAndNotPublic
 	types := spec.Table.ColumnTypesWithMutations(returnMutations)
 	tr.ignoreMisplannedRanges = flowCtx.Local
 	if err := tr.Init(

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -451,7 +451,7 @@ func (z *zigzagJoiner) setupInfo(
 		neededCols,
 		false, /* check */
 		info.alloc,
-		execinfrapb.ScanVisibility_PUBLIC,
+		execinfra.ScanVisibilityPublic,
 		// NB: zigzag joins are disabled when a row-level locking clause is
 		// supplied, so there is no locking strength on *ZigzagJoinerSpec.
 		sqlbase.ScanLockingStrength_FOR_NONE,

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -12,7 +12,6 @@ package sql
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -124,28 +123,6 @@ type scanNode struct {
 	lockingWaitPolicy sqlbase.ScanLockingWaitPolicy
 }
 
-// scanVisibility represents which table columns should be included in a scan.
-type scanVisibility int8
-
-const (
-	publicColumns scanVisibility = 0
-	// Use this to request mutation columns that are currently being
-	// backfilled. These columns are needed to correctly update/delete
-	// a row by correctly constructing ColumnFamilies and Indexes.
-	publicAndNonPublicColumns scanVisibility = 1
-)
-
-func (s scanVisibility) toDistSQLScanVisibility() execinfrapb.ScanVisibility {
-	switch s {
-	case publicColumns:
-		return execinfrapb.ScanVisibility_PUBLIC
-	case publicAndNonPublicColumns:
-		return execinfrapb.ScanVisibility_PUBLIC_AND_NOT_PUBLIC
-	default:
-		panic(fmt.Sprintf("Unknown visibility %+v", s))
-	}
-}
-
 // scanColumnsConfig controls the "schema" of a scan node. The zero value is the
 // default: all "public" columns.
 // Note that not all columns in the schema are read and decoded; that is further
@@ -165,9 +142,9 @@ type scanColumnsConfig struct {
 	// wantedColumns.
 	addUnwantedAsHidden bool
 
-	// If visibility is set to publicAndNonPublicColumns, then mutation columns
-	// can be added to the list of columns.
-	visibility scanVisibility
+	// If visibility is set to execinfra.ScanVisibilityPublicAndNotPublic, then
+	// mutation columns can be added to the list of columns.
+	visibility execinfrapb.ScanVisibility
 }
 
 var publicColumnsCfg = scanColumnsConfig{}
@@ -322,7 +299,7 @@ func (n *scanNode) initCols() error {
 
 	if n.colCfg.wantedColumns == nil {
 		// Add all active and maybe mutation columns.
-		if n.colCfg.visibility == publicColumns {
+		if n.colCfg.visibility == execinfra.ScanVisibilityPublic {
 			n.cols = n.desc.Columns
 		} else {
 			n.cols = n.desc.ReadableColumns
@@ -336,7 +313,7 @@ func (n *scanNode) initCols() error {
 		var c *sqlbase.ColumnDescriptor
 		var err error
 		isBackfillCol := false
-		if id := sqlbase.ColumnID(wc); n.colCfg.visibility == publicColumns {
+		if id := sqlbase.ColumnID(wc); n.colCfg.visibility == execinfra.ScanVisibilityPublic {
 			c, err = n.desc.FindActiveColumnByID(id)
 		} else {
 			c, isBackfillCol, err = n.desc.FindReadableColumnByID(id)

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -45,34 +45,23 @@ type scanNode struct {
 	index *sqlbase.IndexDescriptor
 
 	// Set if an index was explicitly specified.
-	specifiedIndex        *sqlbase.IndexDescriptor
-	specifiedIndexReverse bool
+	specifiedIndex *sqlbase.IndexDescriptor
 	// Set if the NO_INDEX_JOIN hint was given.
 	noIndexJoin bool
 
 	colCfg scanColumnsConfig
 	// The table columns, possibly including ones currently in schema changes.
+	// TODO(radu/knz): currently we always load the entire row from KV and only
+	// skip unnecessary decodes to Datum. Investigate whether performance is to
+	// be gained (e.g. for tables with wide rows) by reading only certain
+	// columns from KV using point lookups instead of a single range lookup for
+	// the entire row.
 	cols []sqlbase.ColumnDescriptor
 	// There is a 1-1 correspondence between cols and resultColumns.
 	resultColumns sqlbase.ResultColumns
 
-	// For each column in resultColumns, indicates if the value is
-	// needed (used as an optimization when the upper layer doesn't need
-	// all values).
-	// TODO(radu/knz): currently the optimization always loads the
-	// entire row from KV and only skips unnecessary decodes to
-	// Datum. Investigate whether performance is to be gained (e.g. for
-	// tables with wide rows) by reading only certain columns from KV
-	// using point lookups instead of a single range lookup for the
-	// entire row.
-	valNeededForCol util.FastIntSet
-
 	// Map used to get the index for columns in cols.
 	colIdxMap map[sqlbase.ColumnID]int
-
-	// The number of backfill columns among cols. These backfill
-	// columns are always the last columns within cols.
-	numBackfillColumns int
 
 	spans   []roachpb.Span
 	reverse bool
@@ -100,9 +89,6 @@ type scanNode struct {
 
 	// Is this a full scan of an index?
 	isFull bool
-
-	// Is this a scan of a secondary index?
-	isSecondaryIndex bool
 
 	// Indicates if this scanNode will do a physical data check. This is
 	// only true when running SCRUB commands.
@@ -251,7 +237,7 @@ func (n *scanNode) initTable(
 	}
 
 	n.noIndexJoin = (indexFlags != nil && indexFlags.NoIndexJoin)
-	return n.initDescDefaults(p.curPlan.deps, colCfg)
+	return n.initDescDefaults(colCfg)
 }
 
 func (n *scanNode) lookupSpecifiedIndex(indexFlags *tree.IndexFlags) error {
@@ -287,52 +273,44 @@ func (n *scanNode) lookupSpecifiedIndex(indexFlags *tree.IndexFlags) error {
 			return errors.Errorf("index [%d] not found", indexFlags.IndexID)
 		}
 	}
-	if indexFlags.Direction == tree.Descending {
-		n.specifiedIndexReverse = true
-	}
 	return nil
 }
 
-// initCols initializes n.cols and n.numBackfillColumns according to n.desc and n.colCfg.
-func (n *scanNode) initCols() error {
-	n.numBackfillColumns = 0
-
-	if n.colCfg.wantedColumns == nil {
+// initColsForScan initializes cols according to desc and colCfg.
+func initColsForScan(
+	desc *sqlbase.ImmutableTableDescriptor, colCfg scanColumnsConfig,
+) (cols []sqlbase.ColumnDescriptor, err error) {
+	if colCfg.wantedColumns == nil {
 		// Add all active and maybe mutation columns.
-		if n.colCfg.visibility == execinfra.ScanVisibilityPublic {
-			n.cols = n.desc.Columns
+		if colCfg.visibility == execinfra.ScanVisibilityPublic {
+			cols = desc.Columns
 		} else {
-			n.cols = n.desc.ReadableColumns
-			n.numBackfillColumns = len(n.desc.ReadableColumns) - len(n.desc.Columns)
+			cols = desc.ReadableColumns
 		}
-		return nil
+		return cols, nil
 	}
 
-	n.cols = make([]sqlbase.ColumnDescriptor, 0, len(n.desc.ReadableColumns))
-	for _, wc := range n.colCfg.wantedColumns {
+	cols = make([]sqlbase.ColumnDescriptor, 0, len(desc.ReadableColumns))
+	for _, wc := range colCfg.wantedColumns {
 		var c *sqlbase.ColumnDescriptor
 		var err error
-		isBackfillCol := false
-		if id := sqlbase.ColumnID(wc); n.colCfg.visibility == execinfra.ScanVisibilityPublic {
-			c, err = n.desc.FindActiveColumnByID(id)
+		if id := sqlbase.ColumnID(wc); colCfg.visibility == execinfra.ScanVisibilityPublic {
+			c, err = desc.FindActiveColumnByID(id)
 		} else {
-			c, isBackfillCol, err = n.desc.FindReadableColumnByID(id)
+			c, _, err = desc.FindReadableColumnByID(id)
 		}
 		if err != nil {
-			return err
+			return cols, err
 		}
 
-		n.cols = append(n.cols, *c)
-		if isBackfillCol {
-			n.numBackfillColumns++
-		}
+		cols = append(cols, *c)
 	}
 
-	if n.colCfg.addUnwantedAsHidden {
-		for i := range n.desc.Columns {
-			c := &n.desc.Columns[i]
+	if colCfg.addUnwantedAsHidden {
+		for i := range desc.Columns {
+			c := &desc.Columns[i]
 			found := false
-			for _, wc := range n.colCfg.wantedColumns {
+			for _, wc := range colCfg.wantedColumns {
 				if sqlbase.ColumnID(wc) == c.ID {
 					found = true
 					break
@@ -341,40 +319,23 @@ func (n *scanNode) initCols() error {
 			if !found {
 				col := *c
 				col.Hidden = true
-				n.cols = append(n.cols, col)
+				cols = append(cols, col)
 			}
 		}
 	}
 
-	return nil
+	return cols, nil
 }
 
 // Initializes the column structures.
-func (n *scanNode) initDescDefaults(planDeps planDependencies, colCfg scanColumnsConfig) error {
+func (n *scanNode) initDescDefaults(colCfg scanColumnsConfig) error {
 	n.colCfg = colCfg
 	n.index = &n.desc.PrimaryIndex
 
-	if err := n.initCols(); err != nil {
+	var err error
+	n.cols, err = initColsForScan(n.desc, n.colCfg)
+	if err != nil {
 		return err
-	}
-
-	// Register the dependency to the planner, if requested.
-	if planDeps != nil {
-		indexID := sqlbase.IndexID(0)
-		if n.specifiedIndex != nil {
-			indexID = n.specifiedIndex.ID
-		}
-		usedColumns := make([]sqlbase.ColumnID, len(n.cols))
-		for i := range n.cols {
-			usedColumns[i] = n.cols[i].ID
-		}
-		deps := planDeps[n.desc.ID]
-		deps.desc = n.desc
-		deps.deps = append(deps.deps, sqlbase.TableDescriptor_Reference{
-			IndexID:   indexID,
-			ColumnIDs: usedColumns,
-		})
-		planDeps[n.desc.ID] = deps
 	}
 
 	// Set up the rest of the scanNode.
@@ -382,10 +343,6 @@ func (n *scanNode) initDescDefaults(planDeps planDependencies, colCfg scanColumn
 	n.colIdxMap = make(map[sqlbase.ColumnID]int, len(n.cols))
 	for i, c := range n.cols {
 		n.colIdxMap[c.ID] = i
-	}
-	n.valNeededForCol = util.FastIntSet{}
-	if len(n.cols) > 0 {
-		n.valNeededForCol.AddRange(0, len(n.cols)-1)
 	}
 	n.filterVars = tree.MakeIndexedVarHelper(n, len(n.cols))
 	return nil

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -119,7 +119,7 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 	}
 	scan.isFull = true
 
-	planCtx := params.extendedEvalCtx.DistSQLPlanner.NewPlanningCtx(ctx, params.extendedEvalCtx, params.p.txn)
+	planCtx := params.extendedEvalCtx.DistSQLPlanner.NewPlanningCtx(ctx, params.extendedEvalCtx, params.p.txn, true /* distribute */)
 	physPlan, err := params.extendedEvalCtx.DistSQLPlanner.createScrubPhysicalCheck(
 		planCtx, scan, *o.tableDesc.TableDesc(), *o.indexDesc, params.p.ExecCfg().Clock.Now())
 	if err != nil {

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -135,8 +135,7 @@ func (dsp *DistSQLPlanner) Exec(
 	defer recv.Release()
 
 	evalCtx := p.ExtendedEvalContext()
-	planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p.txn)
-	planCtx.isLocal = !distribute
+	planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p.txn, distribute)
 	planCtx.planner = p
 	planCtx.stmtType = recv.stmtType
 

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -314,9 +314,9 @@ func (u *updateNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	// If result rows need to be accumulated, do it.
 	if u.run.rows != nil {
 		// The new values can include all columns, the construction of the
-		// values has used publicAndNonPublicColumns so the values may
-		// contain additional columns for every newly added column not yet
-		// visible. We do not want them to be available for RETURNING.
+		// values has used execinfra.ScanVisibilityPublicAndNotPublic so the
+		// values may contain additional columns for every newly added column
+		// not yet visible. We do not want them to be available for RETURNING.
 		//
 		// MakeUpdater guarantees that the first columns of the new values
 		// are those specified u.columns.


### PR DESCRIPTION
**sql: unify PlanningCtx constructors into one**

Release note: None

**sql: remove separate scanVisilibity struct**

This commit removes `sql.scanVisibility` in favor of protobuf-generated
`execinfrapb.ScanVisibility`. It also introduces prettier aliases for
the two values into `execinfra` package that are now used throughout the
code.

Release note: None

**sql: clean up of scan node and a few other things**

This commit does the following cleanups of `scanNode`:
1. refactors `scanNode.initCols` method to be standalone (it will
probably be reused later by distsql spec exec factory).
2. removes `numBackfillColumns`, `specifiedIndexReverse`, and
`isSecondaryIndex` fields since they are no longer used.
3. refactors the code to remove `valNeededForCols` field which was
always consecutive numbers in range `[0, len(n.cols)-1]`.
4. refactors `getIndexIdx` method to not depend on `scanNode`.

Additionally, this commit removes `planDependencies` business
from `planTop` since optimizer now handles CREATE VIEW and handles
the plan dependencies on its own (and CREATE VIEW was the single
user of that struct in the plan top).

Also, it removes (which seems like) unnecessary call to `planColumns`
when creating distinct spec and an unused parameter from
`createTableReaders` method.

Addresses: #47474.

Release note: None