### PR TITLE
opt: introduce VolatilitySet logical property

### DIFF
--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -612,6 +612,9 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			f.Buffer.WriteString(name)
 		}
 
+		if !relational.VolatilitySet.IsLeakProof() {
+			writeFlag(relational.VolatilitySet.String())
+		}
 		if relational.CanHaveSideEffects {
 			writeFlag("side-effects")
 		}
@@ -873,6 +876,9 @@ func (f *ExprFmtCtx) scalarPropsStrings(scalar opt.ScalarExpr) []string {
 		if !f.HasFlags(ExprFmtHideMiscProps) {
 			if !scalarProps.OuterCols.Empty() {
 				emitProp("outer=%s", scalarProps.OuterCols)
+			}
+			if !scalarProps.VolatilitySet.IsLeakProof() {
+				emitProp(scalarProps.VolatilitySet.String())
 			}
 			if scalarProps.CanHaveSideEffects {
 				emitProp("side-effects")

--- a/pkg/sql/opt/memo/testdata/logprops/constraints-null
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints-null
@@ -99,11 +99,12 @@ SELECT * FROM xy WHERE x > abs(y)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
+ ├── immutable
  ├── scan xy
  │    ├── columns: x:1(int) y:2(int)
  │    └── prune: (1,2)
  └── filters
-      └── gt [type=bool, outer=(1,2), constraints=(/1: (/NULL - ])]
+      └── gt [type=bool, outer=(1,2), immutable, constraints=(/1: (/NULL - ])]
            ├── variable: x:1 [type=int]
            └── function: abs [type=int]
                 └── variable: y:2 [type=int]
@@ -114,12 +115,13 @@ SELECT * FROM xy WHERE sin(x::float)::int < x
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
+ ├── immutable
  ├── prune: (2)
  ├── scan xy
  │    ├── columns: x:1(int) y:2(int)
  │    └── prune: (1,2)
  └── filters
-      └── gt [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+      └── gt [type=bool, outer=(1), immutable, constraints=(/1: (/NULL - ])]
            ├── variable: x:1 [type=int]
            └── cast: INT8 [type=int]
                 └── function: sin [type=float]

--- a/pkg/sql/opt/memo/testdata/logprops/delete
+++ b/pkg/sql/opt/memo/testdata/logprops/delete
@@ -24,7 +24,7 @@ delete abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) rowid:11(int) e:12(int)
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── select
       ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
       ├── key: (11)
@@ -55,13 +55,13 @@ DELETE FROM abcde WHERE a=1 RETURNING *
 ----
 project
  ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int)
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── fd: ()-->(1)
  ├── prune: (1-4)
  └── delete abcde
       ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) rowid:5(int!null)
       ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) rowid:11(int) e:12(int)
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: (5)
       ├── fd: ()-->(1), (5)-->(2-4)
       ├── prune: (1-4)
@@ -96,7 +96,7 @@ DELETE FROM abcde WHERE rowid=1 RETURNING *
 project
  ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int)
  ├── cardinality: [0 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(1-4)
  ├── prune: (1-4)
@@ -104,7 +104,7 @@ project
       ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) rowid:5(int!null)
       ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) rowid:11(int) e:12(int)
       ├── cardinality: [0 - 1]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: ()
       ├── fd: ()-->(1-5)
       ├── prune: (1-4)
@@ -139,13 +139,13 @@ DELETE FROM abcde WHERE b=c RETURNING *;
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int)
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── fd: (2)==(3), (3)==(2)
  ├── prune: (1-4)
  └── delete abcde
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) rowid:5(int!null)
       ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) rowid:11(int) e:12(int)
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: (5)
       ├── fd: (2)==(3), (3)==(2), (5)-->(1-4)
       ├── prune: (1-4)

--- a/pkg/sql/opt/memo/testdata/logprops/insert
+++ b/pkg/sql/opt/memo/testdata/logprops/insert
@@ -30,18 +30,18 @@ insert abcde
  │    ├── column11:11 => rowid:5
  │    └── column12:12 => e:6
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: column13:13(int!null) y:8(int!null) column10:10(int!null) column11:11(int) column12:12(int)
       ├── cardinality: [0 - 10]
-      ├── side-effects
+      ├── volatile, side-effects
       ├── fd: ()-->(10,12), (8)-->(13)
       ├── prune: (8,10-13)
       ├── interesting orderings: (+8)
       ├── project
       │    ├── columns: column10:10(int!null) column11:11(int) column12:12(int) y:8(int!null)
       │    ├── cardinality: [0 - 10]
-      │    ├── side-effects
+      │    ├── volatile, side-effects
       │    ├── fd: ()-->(10,12)
       │    ├── prune: (8,10-12)
       │    ├── interesting orderings: (+8)
@@ -67,7 +67,7 @@ insert abcde
       │    │    └── const: 10 [type=int]
       │    └── projections
       │         ├── const: 10 [as=column10:10, type=int]
-      │         ├── function: unique_rowid [as=column11:11, type=int, side-effects]
+      │         ├── function: unique_rowid [as=column11:11, type=int, volatile, side-effects]
       │         └── cast: INT8 [as=column12:12, type=int]
       │              └── null [type=unknown]
       └── projections
@@ -84,7 +84,7 @@ INSERT INTO abcde (a, b) SELECT y, y FROM xyz ORDER BY y, z LIMIT 10 RETURNING *
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null)
  ├── cardinality: [0 - 10]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── fd: ()-->(3), (1)==(2), (2)==(1), (1)-->(4)
  ├── prune: (1-4)
  └── insert abcde
@@ -97,19 +97,19 @@ project
       │    ├── column11:11 => rowid:5
       │    └── column12:12 => e:6
       ├── cardinality: [0 - 10]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── fd: ()-->(3), (1)==(2), (2)==(1), (1)-->(4)
       └── project
            ├── columns: column13:13(int!null) y:8(int!null) column10:10(int!null) column11:11(int) column12:12(int)
            ├── cardinality: [0 - 10]
-           ├── side-effects
+           ├── volatile, side-effects
            ├── fd: ()-->(10,12), (8)-->(13)
            ├── prune: (8,10-13)
            ├── interesting orderings: (+8)
            ├── project
            │    ├── columns: column10:10(int!null) column11:11(int) column12:12(int) y:8(int!null)
            │    ├── cardinality: [0 - 10]
-           │    ├── side-effects
+           │    ├── volatile, side-effects
            │    ├── fd: ()-->(10,12)
            │    ├── prune: (8,10-12)
            │    ├── interesting orderings: (+8)
@@ -135,7 +135,7 @@ project
            │    │    └── const: 10 [type=int]
            │    └── projections
            │         ├── const: 10 [as=column10:10, type=int]
-           │         ├── function: unique_rowid [as=column11:11, type=int, side-effects]
+           │         ├── function: unique_rowid [as=column11:11, type=int, volatile, side-effects]
            │         └── cast: INT8 [as=column12:12, type=int]
            │              └── null [type=unknown]
            └── projections
@@ -151,7 +151,7 @@ INSERT INTO abcde (a, b) SELECT y, y FROM xyz ORDER BY y, z RETURNING *
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null)
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── fd: ()-->(3), (1)==(2), (2)==(1), (1)-->(4)
  ├── prune: (1-4)
  └── insert abcde
@@ -163,16 +163,16 @@ project
       │    ├── column13:13 => d:4
       │    ├── column11:11 => rowid:5
       │    └── column12:12 => e:6
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── fd: ()-->(3), (1)==(2), (2)==(1), (1)-->(4)
       └── project
            ├── columns: column13:13(int!null) y:8(int!null) column10:10(int!null) column11:11(int) column12:12(int)
-           ├── side-effects
+           ├── volatile, side-effects
            ├── fd: ()-->(10,12), (8)-->(13)
            ├── prune: (8,10-13)
            ├── project
            │    ├── columns: column10:10(int!null) column11:11(int) column12:12(int) y:8(int!null)
-           │    ├── side-effects
+           │    ├── volatile, side-effects
            │    ├── fd: ()-->(10,12)
            │    ├── prune: (8,10-12)
            │    ├── project
@@ -186,7 +186,7 @@ project
            │    │         └── interesting orderings: (+7)
            │    └── projections
            │         ├── const: 10 [as=column10:10, type=int]
-           │         ├── function: unique_rowid [as=column11:11, type=int, side-effects]
+           │         ├── function: unique_rowid [as=column11:11, type=int, volatile, side-effects]
            │         └── cast: INT8 [as=column12:12, type=int]
            │              └── null [type=unknown]
            └── projections
@@ -210,20 +210,20 @@ insert abcde
  │    ├── column10:10 => rowid:5
  │    └── column11:11 => e:6
  ├── cardinality: [1 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(1-5)
  └── project
       ├── columns: column12:12(int!null) column1:7(int!null) column2:8(int!null) column9:9(int!null) column10:10(int) column11:11(int)
       ├── cardinality: [1 - 1]
-      ├── side-effects
+      ├── volatile, side-effects
       ├── key: ()
       ├── fd: ()-->(7-12)
       ├── prune: (7-12)
       ├── project
       │    ├── columns: column9:9(int!null) column10:10(int) column11:11(int) column1:7(int!null) column2:8(int!null)
       │    ├── cardinality: [1 - 1]
-      │    ├── side-effects
+      │    ├── volatile, side-effects
       │    ├── key: ()
       │    ├── fd: ()-->(7-11)
       │    ├── prune: (7-11)
@@ -238,7 +238,7 @@ insert abcde
       │    │         └── const: 2 [type=int]
       │    └── projections
       │         ├── const: 10 [as=column9:9, type=int]
-      │         ├── function: unique_rowid [as=column10:10, type=int, side-effects]
+      │         ├── function: unique_rowid [as=column10:10, type=int, volatile, side-effects]
       │         └── cast: INT8 [as=column11:11, type=int]
       │              └── null [type=unknown]
       └── projections
@@ -254,7 +254,7 @@ INSERT INTO abcde (a, b) SELECT y, (z+1)::int FROM xyz WHERE y=1 RETURNING a, c;
 ----
 project
  ├── columns: a:1(int!null) c:3(int!null)
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── fd: ()-->(1,3)
  ├── prune: (1,3)
  └── insert abcde
@@ -266,16 +266,16 @@ project
       │    ├── column14:14 => d:4
       │    ├── column12:12 => rowid:5
       │    └── column13:13 => e:6
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── fd: ()-->(1,3), (2)-->(4)
       └── project
            ├── columns: column14:14(int) y:8(int!null) int8:10(int) column11:11(int!null) column12:12(int) column13:13(int)
-           ├── side-effects
+           ├── volatile, side-effects
            ├── fd: ()-->(8,11,13), (10)-->(14)
            ├── prune: (8,10-14)
            ├── project
            │    ├── columns: column11:11(int!null) column12:12(int) column13:13(int) y:8(int!null) int8:10(int)
-           │    ├── side-effects
+           │    ├── volatile, side-effects
            │    ├── fd: ()-->(8,11,13)
            │    ├── prune: (8,10-13)
            │    ├── project
@@ -305,7 +305,7 @@ project
            │    │                   └── const: 1.0 [type=float]
            │    └── projections
            │         ├── const: 10 [as=column11:11, type=int]
-           │         ├── function: unique_rowid [as=column12:12, type=int, side-effects]
+           │         ├── function: unique_rowid [as=column12:12, type=int, volatile, side-effects]
            │         └── cast: INT8 [as=column13:13, type=int]
            │              └── null [type=unknown]
            └── projections

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -1444,13 +1444,13 @@ SELECT (SELECT m FROM
 ----
 with &1
  ├── columns: m:19(int)
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── fd: ()-->(19)
  ├── prune: (19)
  ├── project
  │    ├── columns: uv.u:4(int!null) uv.v:5(int!null)
  │    ├── cardinality: [1 - 1]
- │    ├── side-effects, mutations
+ │    ├── volatile, side-effects, mutations
  │    ├── key: ()
  │    ├── fd: ()-->(4,5)
  │    ├── prune: (4,5)
@@ -1461,13 +1461,13 @@ with &1
  │         │    ├── column2:8 => uv.v:5
  │         │    └── column9:9 => rowid:6
  │         ├── cardinality: [1 - 1]
- │         ├── side-effects, mutations
+ │         ├── volatile, side-effects, mutations
  │         ├── key: ()
  │         ├── fd: ()-->(4-6)
  │         └── values
  │              ├── columns: column1:7(int!null) column2:8(int!null) column9:9(int)
  │              ├── cardinality: [1 - 1]
- │              ├── side-effects
+ │              ├── volatile, side-effects
  │              ├── key: ()
  │              ├── fd: ()-->(7-9)
  │              ├── prune: (7-9)

--- a/pkg/sql/opt/memo/testdata/logprops/limit
+++ b/pkg/sql/opt/memo/testdata/logprops/limit
@@ -57,7 +57,7 @@ SELECT * FROM xyzs LIMIT (SELECT 1)
 ----
 limit
  ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-4)
@@ -113,7 +113,7 @@ SELECT (SELECT x FROM kuv LIMIT y) FROM xyzs
 ----
 project
  ├── columns: x:9(int)
- ├── side-effects
+ ├── immutable, side-effects
  ├── prune: (9)
  ├── scan xyzs
  │    ├── columns: xyzs.x:1(int!null) y:2(int) z:3(float!null) s:4(string)
@@ -122,19 +122,19 @@ project
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-4,+3,+1)
  └── projections
-      └── subquery [as=x:9, type=int, outer=(1,2), side-effects, correlated-subquery]
+      └── subquery [as=x:9, type=int, outer=(1,2), immutable, side-effects, correlated-subquery]
            └── max1-row
                 ├── columns: x:8(int)
                 ├── error: "more than one row returned by a subquery used as an expression"
                 ├── outer: (1,2)
                 ├── cardinality: [0 - 1]
-                ├── side-effects
+                ├── immutable, side-effects
                 ├── key: ()
                 ├── fd: ()-->(8)
                 └── limit
                      ├── columns: x:8(int)
                      ├── outer: (1,2)
-                     ├── side-effects
+                     ├── immutable, side-effects
                      ├── fd: ()-->(8)
                      ├── prune: (8)
                      ├── project

--- a/pkg/sql/opt/memo/testdata/logprops/scalar
+++ b/pkg/sql/opt/memo/testdata/logprops/scalar
@@ -31,6 +31,7 @@ SELECT xy.x + 1 = length('foo') + xy.y AS a, uv.rowid * xy.x AS b FROM xy, uv
 ----
 project
  ├── columns: a:6(bool) b:7(int!null)
+ ├── immutable
  ├── prune: (6,7)
  ├── inner-join (cross)
  │    ├── columns: x:1(int!null) y:2(int) u:3(int) v:4(int!null) rowid:5(int!null)
@@ -52,7 +53,7 @@ project
  │    │    └── interesting orderings: (+5)
  │    └── filters (true)
  └── projections
-      ├── eq [as=a:6, type=bool, outer=(1,2)]
+      ├── eq [as=a:6, type=bool, outer=(1,2), immutable]
       │    ├── plus [type=int]
       │    │    ├── variable: x:1 [type=int]
       │    │    └── const: 1 [type=int]
@@ -186,26 +187,26 @@ GROUP BY div
 group-by
  ├── columns: sum:7(decimal!null) div:3(decimal)
  ├── grouping columns: div:3(decimal)
- ├── side-effects
+ ├── stable, side-effects
  ├── key: (3)
  ├── fd: (3)-->(7)
  ├── prune: (7)
  ├── project
  │    ├── columns: x:1(int!null) div:3(decimal)
- │    ├── side-effects
+ │    ├── stable, side-effects
  │    ├── fd: (1)-->(3)
  │    ├── prune: (1,3)
  │    ├── interesting orderings: (+1)
  │    └── inner-join (hash)
  │         ├── columns: x:1(int!null) y:2(int) div:3(decimal) u:4(int!null) v:5(int!null)
- │         ├── side-effects
+ │         ├── stable, side-effects
  │         ├── fd: (1)-->(2,3), (1)==(4), (4)==(1)
  │         ├── prune: (2,3,5)
  │         ├── interesting orderings: (+1)
  │         ├── multiplicity: left-rows(zero-or-more), right-rows(one-or-zero)
  │         ├── project
  │         │    ├── columns: div:3(decimal) x:1(int!null) y:2(int)
- │         │    ├── side-effects
+ │         │    ├── immutable, side-effects
  │         │    ├── key: (1)
  │         │    ├── fd: (1)-->(2,3)
  │         │    ├── prune: (1-3)
@@ -217,16 +218,16 @@ group-by
  │         │    │    ├── prune: (1,2)
  │         │    │    └── interesting orderings: (+1)
  │         │    └── projections
- │         │         └── div [as=div:3, type=decimal, outer=(1,2), side-effects]
+ │         │         └── div [as=div:3, type=decimal, outer=(1,2), immutable, side-effects]
  │         │              ├── variable: x:1 [type=int]
  │         │              └── variable: y:2 [type=int]
  │         ├── project
  │         │    ├── columns: u:4(int) v:5(int!null)
- │         │    ├── side-effects
+ │         │    ├── stable, side-effects
  │         │    ├── prune: (4,5)
  │         │    └── select
  │         │         ├── columns: u:4(int) v:5(int!null) rowid:6(int!null)
- │         │         ├── side-effects
+ │         │         ├── stable, side-effects
  │         │         ├── key: (6)
  │         │         ├── fd: (6)-->(4,5)
  │         │         ├── prune: (4-6)
@@ -238,7 +239,7 @@ group-by
  │         │         │    ├── prune: (4-6)
  │         │         │    └── interesting orderings: (+6)
  │         │         └── filters
- │         │              └── gt [type=bool, side-effects]
+ │         │              └── gt [type=bool, stable, side-effects]
  │         │                   ├── function: now [type=timestamptz]
  │         │                   └── const: '2018-01-01 00:00:00+00:00' [type=timestamptz]
  │         └── filters

--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -206,7 +206,7 @@ SELECT * FROM a FOR UPDATE
 scan a
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
  ├── locking: for-update
- ├── side-effects
+ ├── volatile, side-effects
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (1-4)

--- a/pkg/sql/opt/memo/testdata/logprops/srfs
+++ b/pkg/sql/opt/memo/testdata/logprops/srfs
@@ -12,12 +12,12 @@ SELECT generate_series(0,1) FROM (SELECT * FROM xy LIMIT 0)
 project-set
  ├── columns: generate_series:3(int)
  ├── cardinality: [0 - 0]
- ├── side-effects
+ ├── immutable, side-effects
  ├── values
  │    ├── cardinality: [0 - 0]
  │    └── key: ()
  └── zip
-      └── function: generate_series [type=int, side-effects]
+      └── function: generate_series [type=int, immutable, side-effects]
            ├── const: 0 [type=int]
            └── const: 1 [type=int]
 

--- a/pkg/sql/opt/memo/testdata/logprops/update
+++ b/pkg/sql/opt/memo/testdata/logprops/update
@@ -28,7 +28,7 @@ update abcde
  │    ├── column15:15 => d:4
  │    └── column14:14 => e:6
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: column15:15(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) b_new:13(int!null) column14:14(int!null)
       ├── key: (11)
@@ -87,7 +87,7 @@ UPDATE abcde SET b=10 WHERE a=1 RETURNING *
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null)
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── fd: ()-->(1,2), (3)-->(4)
  ├── prune: (1-4)
  └── update abcde
@@ -97,7 +97,7 @@ project
       │    ├── b_new:13 => b:2
       │    ├── column15:15 => d:4
       │    └── column14:14 => e:6
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: (5)
       ├── fd: ()-->(1,2), (5)-->(3,4), (3)-->(4)
       └── project
@@ -159,7 +159,7 @@ UPDATE abcde SET b=10 WHERE rowid=1 RETURNING *
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null)
  ├── cardinality: [0 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(1-4)
  ├── prune: (1-4)
@@ -171,7 +171,7 @@ project
       │    ├── column15:15 => d:4
       │    └── column14:14 => e:6
       ├── cardinality: [0 - 1]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: ()
       ├── fd: ()-->(1-5)
       └── project
@@ -236,7 +236,7 @@ UPDATE abcde SET a=1 WHERE b=c RETURNING *;
 ----
 project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null)
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── fd: ()-->(1), (2)==(3), (3)==(2), (2)-->(4)
  ├── prune: (1-4)
  └── update abcde
@@ -246,7 +246,7 @@ project
       │    ├── a_new:13 => a:1
       │    ├── column15:15 => d:4
       │    └── column14:14 => e:6
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: (5)
       ├── fd: ()-->(1), (2)==(3), (3)==(2), (5)-->(2-4), (2)-->(4)
       └── project

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -28,7 +28,7 @@ RETURNING *
 ----
 project
  ├── columns: a:1(int!null) b:2(int) c:3(int)
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── prune: (1-3)
  └── upsert abc
       ├── columns: a:1(int!null) b:2(int) c:3(int) rowid:4(int!null)
@@ -48,10 +48,10 @@ project
       │    ├── upsert_b:18 => b:2
       │    ├── upsert_c:19 => c:3
       │    └── upsert_rowid:20 => rowid:4
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       └── project
            ├── columns: upsert_a:17(int!null) upsert_b:18(int) upsert_c:19(int) upsert_rowid:20(int) x:5(int!null) y:6(int!null) column8:8(int) column9:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int) a_new:14(int!null) b_new:15(int) column16:16(int)
-           ├── side-effects
+           ├── volatile, side-effects
            ├── key: (13)
            ├── fd: ()-->(5,6,8,9,14), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13), (12)-->(15), (15)-->(16), (13)-->(17), (13,15)-->(18), (13,16)-->(19), (13)-->(20)
            ├── prune: (5,6,8-20)
@@ -59,7 +59,7 @@ project
            ├── interesting orderings: (+13) (+10) (+11,+12,+13)
            ├── project
            │    ├── columns: column16:16(int) x:5(int!null) y:6(int!null) column8:8(int) column9:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int) a_new:14(int!null) b_new:15(int)
-           │    ├── side-effects
+           │    ├── volatile, side-effects
            │    ├── key: (13)
            │    ├── fd: ()-->(5,6,8,9,14), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13), (12)-->(15), (15)-->(16)
            │    ├── prune: (5,6,8-16)
@@ -67,7 +67,7 @@ project
            │    ├── interesting orderings: (+13) (+10) (+11,+12,+13)
            │    ├── project
            │    │    ├── columns: a_new:14(int!null) b_new:15(int) x:5(int!null) y:6(int!null) column8:8(int) column9:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int)
-           │    │    ├── side-effects
+           │    │    ├── volatile, side-effects
            │    │    ├── key: (13)
            │    │    ├── fd: ()-->(5,6,8,9,14), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13), (12)-->(15)
            │    │    ├── prune: (5,6,8-15)
@@ -75,7 +75,7 @@ project
            │    │    ├── interesting orderings: (+13) (+10) (+11,+12,+13)
            │    │    ├── left-join (hash)
            │    │    │    ├── columns: x:5(int!null) y:6(int!null) column8:8(int) column9:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int)
-           │    │    │    ├── side-effects
+           │    │    │    ├── volatile, side-effects
            │    │    │    ├── key: (13)
            │    │    │    ├── fd: ()-->(5,6,8,9), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
            │    │    │    ├── prune: (10,13)
@@ -87,19 +87,19 @@ project
            │    │    │    │    ├── grouping columns: y:6(int!null) column9:9(int!null)
            │    │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
            │    │    │    │    ├── cardinality: [0 - 1]
-           │    │    │    │    ├── side-effects
+           │    │    │    │    ├── volatile, side-effects
            │    │    │    │    ├── key: ()
            │    │    │    │    ├── fd: ()-->(5,6,8,9)
            │    │    │    │    ├── project
            │    │    │    │    │    ├── columns: column9:9(int!null) x:5(int!null) y:6(int!null) column8:8(int)
-           │    │    │    │    │    ├── side-effects
+           │    │    │    │    │    ├── volatile, side-effects
            │    │    │    │    │    ├── key: (5)
            │    │    │    │    │    ├── fd: ()-->(6,9), (5)-->(8)
            │    │    │    │    │    ├── prune: (5,6,8,9)
            │    │    │    │    │    ├── interesting orderings: (+5) (+6)
            │    │    │    │    │    ├── project
            │    │    │    │    │    │    ├── columns: column8:8(int) x:5(int!null) y:6(int!null)
-           │    │    │    │    │    │    ├── side-effects
+           │    │    │    │    │    │    ├── volatile, side-effects
            │    │    │    │    │    │    ├── key: (5)
            │    │    │    │    │    │    ├── fd: ()-->(6), (5)-->(8)
            │    │    │    │    │    │    ├── prune: (5,6,8)
@@ -127,7 +127,7 @@ project
            │    │    │    │    │    │    │                   ├── variable: y:6 [type=int]
            │    │    │    │    │    │    │                   └── const: 1 [type=int]
            │    │    │    │    │    │    └── projections
-           │    │    │    │    │    │         └── function: unique_rowid [as=column8:8, type=int, side-effects]
+           │    │    │    │    │    │         └── function: unique_rowid [as=column8:8, type=int, volatile, side-effects]
            │    │    │    │    │    └── projections
            │    │    │    │    │         └── plus [as=column9:9, type=int, outer=(6)]
            │    │    │    │    │              ├── variable: y:6 [type=int]
@@ -207,7 +207,7 @@ RETURNING *
 ----
 project
  ├── columns: a:1(int!null) b:2(int) c:3(int)
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: (1)
  ├── fd: (1)-->(2,3), (2)-->(3), (2,3)~~>(1)
  ├── prune: (1-3)
@@ -218,31 +218,31 @@ project
       │    ├── y:6 => b:2
       │    ├── column9:9 => c:3
       │    └── column8:8 => rowid:4
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: (1)
       ├── fd: (1)-->(2-4), (2)-->(3), (4)~~>(1-3), (2,3)~~>(1,4)
       └── upsert-distinct-on
            ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
            ├── grouping columns: y:6(int) column9:9(int)
-           ├── side-effects
+           ├── volatile, side-effects
            ├── key: (5)
            ├── fd: (5)-->(6,8,9), (6)-->(9), (8)~~>(5,6,9), (6,9)~~>(5,8)
            ├── project
            │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
-           │    ├── side-effects
+           │    ├── volatile, side-effects
            │    ├── key: (5)
            │    ├── fd: (5)-->(6,8,9), (6)-->(9), (8)~~>(5,6,9)
            │    ├── prune: (5,6,8,9)
            │    └── select
            │         ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:18(int) b:19(int) c:20(int) rowid:21(int)
-           │         ├── side-effects
+           │         ├── volatile, side-effects
            │         ├── key: (5)
            │         ├── fd: ()-->(18-21), (5)-->(6,8,9), (6)-->(9), (8)~~>(5,6,9)
            │         ├── prune: (18)
            │         ├── interesting orderings: (+21) (+18) (+19,+20,+21)
            │         ├── left-join (hash)
            │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:18(int) b:19(int) c:20(int) rowid:21(int)
-           │         │    ├── side-effects
+           │         │    ├── volatile, side-effects
            │         │    ├── key: (5,21)
            │         │    ├── fd: (5)-->(6,8,9), (6)-->(9), (8)~~>(5,6,9), (21)-->(18-20), (18)-->(19-21), (19,20)~~>(18,21)
            │         │    ├── prune: (18,21)
@@ -252,25 +252,25 @@ project
            │         │    ├── upsert-distinct-on
            │         │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
            │         │    │    ├── grouping columns: x:5(int!null)
-           │         │    │    ├── side-effects
+           │         │    │    ├── volatile, side-effects
            │         │    │    ├── key: (5)
            │         │    │    ├── fd: (5)-->(6,8,9), (6)-->(9), (8)~~>(5,6,9)
            │         │    │    ├── project
            │         │    │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
-           │         │    │    │    ├── side-effects
+           │         │    │    │    ├── volatile, side-effects
            │         │    │    │    ├── key: (5)
            │         │    │    │    ├── fd: (5)-->(6,8), (6)-->(9), (8)~~>(5,6,9)
            │         │    │    │    ├── prune: (5,6,8,9)
            │         │    │    │    └── select
            │         │    │    │         ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:14(int) b:15(int) c:16(int) rowid:17(int)
-           │         │    │    │         ├── side-effects
+           │         │    │    │         ├── volatile, side-effects
            │         │    │    │         ├── key: (5)
            │         │    │    │         ├── fd: ()-->(14-17), (5)-->(6,8), (6)-->(9), (8)~~>(5,6,9)
            │         │    │    │         ├── prune: (15-17)
            │         │    │    │         ├── interesting orderings: (+17) (+14) (+15,+16,+17)
            │         │    │    │         ├── left-join (hash)
            │         │    │    │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:14(int) b:15(int) c:16(int) rowid:17(int)
-           │         │    │    │         │    ├── side-effects
+           │         │    │    │         │    ├── volatile, side-effects
            │         │    │    │         │    ├── key: (5)
            │         │    │    │         │    ├── fd: (5)-->(6,8,14-17), (6)-->(9), (8)~~>(5,6,9), (17)-->(14-16), (14)-->(15-17), (15,16)~~>(14,17)
            │         │    │    │         │    ├── prune: (15-17)
@@ -280,26 +280,26 @@ project
            │         │    │    │         │    ├── upsert-distinct-on
            │         │    │    │         │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
            │         │    │    │         │    │    ├── grouping columns: column8:8(int)
-           │         │    │    │         │    │    ├── side-effects
+           │         │    │    │         │    │    ├── volatile, side-effects
            │         │    │    │         │    │    ├── key: (5)
            │         │    │    │         │    │    ├── fd: (5)-->(6,8), (6)-->(9), (8)~~>(5,6,9)
            │         │    │    │         │    │    ├── project
            │         │    │    │         │    │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int)
-           │         │    │    │         │    │    │    ├── side-effects
+           │         │    │    │         │    │    │    ├── volatile, side-effects
            │         │    │    │         │    │    │    ├── key: (5)
            │         │    │    │         │    │    │    ├── fd: (5)-->(6,8), (6)-->(9)
            │         │    │    │         │    │    │    ├── prune: (5,6,8,9)
            │         │    │    │         │    │    │    ├── interesting orderings: (+5) (+6)
            │         │    │    │         │    │    │    └── select
            │         │    │    │         │    │    │         ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
-           │         │    │    │         │    │    │         ├── side-effects
+           │         │    │    │         │    │    │         ├── volatile, side-effects
            │         │    │    │         │    │    │         ├── key: (5)
            │         │    │    │         │    │    │         ├── fd: ()-->(10-13), (5)-->(6,8), (6)-->(9)
            │         │    │    │         │    │    │         ├── prune: (5,6,9-12)
            │         │    │    │         │    │    │         ├── interesting orderings: (+5) (+6) (+13) (+10) (+11,+12,+13)
            │         │    │    │         │    │    │         ├── left-join (hash)
            │         │    │    │         │    │    │         │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
-           │         │    │    │         │    │    │         │    ├── side-effects
+           │         │    │    │         │    │    │         │    ├── volatile, side-effects
            │         │    │    │         │    │    │         │    ├── key: (5)
            │         │    │    │         │    │    │         │    ├── fd: (5)-->(6,8,10-13), (6)-->(9), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
            │         │    │    │         │    │    │         │    ├── prune: (5,6,9-12)
@@ -308,14 +308,14 @@ project
            │         │    │    │         │    │    │         │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
            │         │    │    │         │    │    │         │    ├── project
            │         │    │    │         │    │    │         │    │    ├── columns: column9:9(int) x:5(int!null) y:6(int) column8:8(int)
-           │         │    │    │         │    │    │         │    │    ├── side-effects
+           │         │    │    │         │    │    │         │    │    ├── volatile, side-effects
            │         │    │    │         │    │    │         │    │    ├── key: (5)
            │         │    │    │         │    │    │         │    │    ├── fd: (5)-->(6,8), (6)-->(9)
            │         │    │    │         │    │    │         │    │    ├── prune: (5,6,8,9)
            │         │    │    │         │    │    │         │    │    ├── interesting orderings: (+5) (+6)
            │         │    │    │         │    │    │         │    │    ├── project
            │         │    │    │         │    │    │         │    │    │    ├── columns: column8:8(int) x:5(int!null) y:6(int)
-           │         │    │    │         │    │    │         │    │    │    ├── side-effects
+           │         │    │    │         │    │    │         │    │    │    ├── volatile, side-effects
            │         │    │    │         │    │    │         │    │    │    ├── key: (5)
            │         │    │    │         │    │    │         │    │    │    ├── fd: (5)-->(6,8)
            │         │    │    │         │    │    │         │    │    │    ├── prune: (5,6,8)
@@ -333,7 +333,7 @@ project
            │         │    │    │         │    │    │         │    │    │    │         ├── prune: (5-7)
            │         │    │    │         │    │    │         │    │    │    │         └── interesting orderings: (+5) (+6,+7,+5) (+7,+6,+5)
            │         │    │    │         │    │    │         │    │    │    └── projections
-           │         │    │    │         │    │    │         │    │    │         └── function: unique_rowid [as=column8:8, type=int, side-effects]
+           │         │    │    │         │    │    │         │    │    │         └── function: unique_rowid [as=column8:8, type=int, volatile, side-effects]
            │         │    │    │         │    │    │         │    │    └── projections
            │         │    │    │         │    │    │         │    │         └── plus [as=column9:9, type=int, outer=(6)]
            │         │    │    │         │    │    │         │    │              ├── variable: y:6 [type=int]
@@ -425,7 +425,7 @@ UPSERT INTO abc (a) VALUES (1), (2) RETURNING b+c
 project
  ├── columns: "?column?":17(int)
  ├── cardinality: [1 - ]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── prune: (17)
  ├── upsert abc
  │    ├── columns: a:1(int!null) b:2(int) c:3(int) rowid:4(int!null)
@@ -445,11 +445,11 @@ project
  │    │    ├── upsert_c:15 => c:3
  │    │    └── upsert_rowid:16 => rowid:4
  │    ├── cardinality: [1 - ]
- │    ├── side-effects, mutations
+ │    ├── volatile, side-effects, mutations
  │    └── project
  │         ├── columns: upsert_b:14(int) upsert_c:15(int) upsert_rowid:16(int) column1:5(int!null) column6:6(int!null) column7:7(int) column8:8(int!null) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int)
  │         ├── cardinality: [1 - ]
- │         ├── side-effects
+ │         ├── volatile, side-effects
  │         ├── lax-key: (7,12)
  │         ├── fd: ()-->(6,8), (7)~~>(5), (12)-->(9-11), (9)-->(10-12), (10,11)~~>(9,12), (10)-->(13), (10,12)-->(14), (12,13)-->(15), (7,12)-->(16)
  │         ├── prune: (5-16)
@@ -458,7 +458,7 @@ project
  │         ├── project
  │         │    ├── columns: column13:13(int) column1:5(int!null) column6:6(int!null) column7:7(int) column8:8(int!null) a:9(int) b:10(int) c:11(int) rowid:12(int)
  │         │    ├── cardinality: [1 - ]
- │         │    ├── side-effects
+ │         │    ├── volatile, side-effects
  │         │    ├── lax-key: (7,12)
  │         │    ├── fd: ()-->(6,8), (7)~~>(5), (12)-->(9-11), (9)-->(10-12), (10,11)~~>(9,12), (10)-->(13)
  │         │    ├── prune: (5-13)
@@ -467,7 +467,7 @@ project
  │         │    ├── left-join (hash)
  │         │    │    ├── columns: column1:5(int!null) column6:6(int!null) column7:7(int) column8:8(int!null) a:9(int) b:10(int) c:11(int) rowid:12(int)
  │         │    │    ├── cardinality: [1 - ]
- │         │    │    ├── side-effects
+ │         │    │    ├── volatile, side-effects
  │         │    │    ├── lax-key: (7,12)
  │         │    │    ├── fd: ()-->(6,8), (7)~~>(5), (12)-->(9-11), (9)-->(10-12), (10,11)~~>(9,12)
  │         │    │    ├── prune: (9-11)
@@ -479,19 +479,19 @@ project
  │         │    │    │    ├── grouping columns: column7:7(int)
  │         │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
  │         │    │    │    ├── cardinality: [1 - 2]
- │         │    │    │    ├── side-effects
+ │         │    │    │    ├── volatile, side-effects
  │         │    │    │    ├── lax-key: (7)
  │         │    │    │    ├── fd: ()-->(6,8), (7)~~>(5,6,8)
  │         │    │    │    ├── project
  │         │    │    │    │    ├── columns: column8:8(int!null) column1:5(int!null) column6:6(int!null) column7:7(int)
  │         │    │    │    │    ├── cardinality: [2 - 2]
- │         │    │    │    │    ├── side-effects
+ │         │    │    │    │    ├── volatile, side-effects
  │         │    │    │    │    ├── fd: ()-->(6,8)
  │         │    │    │    │    ├── prune: (5-8)
  │         │    │    │    │    ├── project
  │         │    │    │    │    │    ├── columns: column6:6(int!null) column7:7(int) column1:5(int!null)
  │         │    │    │    │    │    ├── cardinality: [2 - 2]
- │         │    │    │    │    │    ├── side-effects
+ │         │    │    │    │    │    ├── volatile, side-effects
  │         │    │    │    │    │    ├── fd: ()-->(6)
  │         │    │    │    │    │    ├── prune: (5-7)
  │         │    │    │    │    │    ├── values
@@ -504,7 +504,7 @@ project
  │         │    │    │    │    │    │         └── const: 2 [type=int]
  │         │    │    │    │    │    └── projections
  │         │    │    │    │    │         ├── const: 10 [as=column6:6, type=int]
- │         │    │    │    │    │         └── function: unique_rowid [as=column7:7, type=int, side-effects]
+ │         │    │    │    │    │         └── function: unique_rowid [as=column7:7, type=int, volatile, side-effects]
  │         │    │    │    │    └── projections
  │         │    │    │    │         └── plus [as=column8:8, type=int, outer=(6)]
  │         │    │    │    │              ├── variable: column6:6 [type=int]
@@ -586,10 +586,10 @@ upsert abc
  │    ├── upsert_b:18 => b:2
  │    └── upsert_c:19 => c:3
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: upsert_a:17(int) upsert_b:18(int!null) upsert_c:19(int!null) upsert_rowid:20(int) y:6(int!null) column8:8(int!null) column9:9(int) column10:10(int!null) a:11(int) b:12(int) c:13(int) rowid:14(int) b_new:15(int!null) column16:16(int!null)
-      ├── side-effects
+      ├── volatile, side-effects
       ├── key: (6)
       ├── fd: ()-->(8,10,15,16), (6)-->(9,11-14), (14)-->(11-13), (11)-->(12-14), (12,13)~~>(11,14), (6,11,14)-->(17), (14)-->(18), (14)-->(19), (9,14)-->(20)
       ├── prune: (6,8-20)
@@ -597,7 +597,7 @@ upsert abc
       ├── interesting orderings: (+14) (+11) (+12,+13,+14)
       ├── project
       │    ├── columns: column16:16(int!null) y:6(int!null) column8:8(int!null) column9:9(int) column10:10(int!null) a:11(int) b:12(int) c:13(int) rowid:14(int) b_new:15(int!null)
-      │    ├── side-effects
+      │    ├── volatile, side-effects
       │    ├── key: (6)
       │    ├── fd: ()-->(8,10,15,16), (6)-->(9,11-14), (14)-->(11-13), (11)-->(12-14), (12,13)~~>(11,14)
       │    ├── prune: (6,8-16)
@@ -605,7 +605,7 @@ upsert abc
       │    ├── interesting orderings: (+14) (+11) (+12,+13,+14)
       │    ├── project
       │    │    ├── columns: b_new:15(int!null) y:6(int!null) column8:8(int!null) column9:9(int) column10:10(int!null) a:11(int) b:12(int) c:13(int) rowid:14(int)
-      │    │    ├── side-effects
+      │    │    ├── volatile, side-effects
       │    │    ├── key: (6)
       │    │    ├── fd: ()-->(8,10,15), (6)-->(9,11-14), (14)-->(11-13), (11)-->(12-14), (12,13)~~>(11,14)
       │    │    ├── prune: (6,8-15)
@@ -613,7 +613,7 @@ upsert abc
       │    │    ├── interesting orderings: (+14) (+11) (+12,+13,+14)
       │    │    ├── left-join (hash)
       │    │    │    ├── columns: y:6(int!null) column8:8(int!null) column9:9(int) column10:10(int!null) a:11(int) b:12(int) c:13(int) rowid:14(int)
-      │    │    │    ├── side-effects
+      │    │    │    ├── volatile, side-effects
       │    │    │    ├── key: (6)
       │    │    │    ├── fd: ()-->(8,10), (6)-->(9,11-14), (14)-->(11-13), (11)-->(12-14), (12,13)~~>(11,14)
       │    │    │    ├── prune: (12-14)
@@ -624,18 +624,18 @@ upsert abc
       │    │    │    │    ├── columns: y:6(int!null) column8:8(int!null) column9:9(int) column10:10(int!null)
       │    │    │    │    ├── grouping columns: y:6(int!null)
       │    │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
-      │    │    │    │    ├── side-effects
+      │    │    │    │    ├── volatile, side-effects
       │    │    │    │    ├── key: (6)
       │    │    │    │    ├── fd: ()-->(8,10), (6)-->(8-10)
       │    │    │    │    ├── project
       │    │    │    │    │    ├── columns: column10:10(int!null) y:6(int!null) column8:8(int!null) column9:9(int)
-      │    │    │    │    │    ├── side-effects
+      │    │    │    │    │    ├── volatile, side-effects
       │    │    │    │    │    ├── fd: ()-->(8,10)
       │    │    │    │    │    ├── prune: (6,8-10)
       │    │    │    │    │    ├── interesting orderings: (+6)
       │    │    │    │    │    ├── project
       │    │    │    │    │    │    ├── columns: column8:8(int!null) column9:9(int) y:6(int!null)
-      │    │    │    │    │    │    ├── side-effects
+      │    │    │    │    │    │    ├── volatile, side-effects
       │    │    │    │    │    │    ├── fd: ()-->(8)
       │    │    │    │    │    │    ├── prune: (6,8,9)
       │    │    │    │    │    │    ├── interesting orderings: (+6)
@@ -661,7 +661,7 @@ upsert abc
       │    │    │    │    │    │    │                   └── null [type=unknown]
       │    │    │    │    │    │    └── projections
       │    │    │    │    │    │         ├── const: 10 [as=column8:8, type=int]
-      │    │    │    │    │    │         └── function: unique_rowid [as=column9:9, type=int, side-effects]
+      │    │    │    │    │    │         └── function: unique_rowid [as=column9:9, type=int, volatile, side-effects]
       │    │    │    │    │    └── projections
       │    │    │    │    │         └── plus [as=column10:10, type=int, outer=(8)]
       │    │    │    │    │              ├── variable: column8:8 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/with
+++ b/pkg/sql/opt/memo/testdata/logprops/with
@@ -35,14 +35,14 @@ WITH foo AS (SELECT 1/0) SELECT * FROM foo
 with &1 (foo)
  ├── columns: "?column?":2(decimal!null)
  ├── cardinality: [1 - 1]
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: ()
  ├── fd: ()-->(2)
  ├── prune: (2)
  ├── project
  │    ├── columns: "?column?":1(decimal!null)
  │    ├── cardinality: [1 - 1]
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── key: ()
  │    ├── fd: ()-->(1)
  │    ├── prune: (1)
@@ -51,7 +51,7 @@ with &1 (foo)
  │    │    ├── key: ()
  │    │    └── tuple [type=tuple]
  │    └── projections
- │         └── div [as="?column?":1, type=decimal, side-effects]
+ │         └── div [as="?column?":1, type=decimal, immutable, side-effects]
  │              ├── const: 1 [type=int]
  │              └── const: 0 [type=int]
  └── with-scan &1 (foo)
@@ -71,7 +71,7 @@ WITH foo AS (SELECT 1) SELECT 1/0 FROM foo
 with &1 (foo)
  ├── columns: "?column?":3(decimal!null)
  ├── cardinality: [1 - 1]
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: ()
  ├── fd: ()-->(3)
  ├── prune: (3)
@@ -90,7 +90,7 @@ with &1 (foo)
  └── project
       ├── columns: "?column?":3(decimal!null)
       ├── cardinality: [1 - 1]
-      ├── side-effects
+      ├── immutable, side-effects
       ├── key: ()
       ├── fd: ()-->(3)
       ├── prune: (3)
@@ -107,7 +107,7 @@ with &1 (foo)
       │    └── cte-uses
       │         └── &1: count=1 used-columns=(1)
       └── projections
-           └── div [as="?column?":3, type=decimal, side-effects]
+           └── div [as="?column?":3, type=decimal, immutable, side-effects]
                 ├── const: 1 [type=int]
                 └── const: 0 [type=int]
 

--- a/pkg/sql/opt/memo/testdata/stats/delete
+++ b/pkg/sql/opt/memo/testdata/stats/delete
@@ -40,14 +40,14 @@ WHERE x > 'foo'
 ----
 with &1
  ├── columns: x:7(string!null) y:8(int!null) z:9(float!null)
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── stats: [rows=3.33333333, distinct(7)=3.33333333, null(7)=0]
  ├── key: (7)
  ├── fd: ()-->(9), (7)-->(8)
  ├── delete xyz
  │    ├── columns: xyz.x:1(string!null) xyz.y:2(int!null) xyz.z:3(float!null)
  │    ├── fetch columns: xyz.x:4(string) xyz.y:5(int) xyz.z:6(float)
- │    ├── side-effects, mutations
+ │    ├── volatile, side-effects, mutations
  │    ├── stats: [rows=10]
  │    ├── key: (1)
  │    ├── fd: ()-->(3), (1)-->(2)
@@ -88,7 +88,7 @@ delete xyz
  ├── columns: x:1(string!null) y:2(int!null) z:3(float)
  ├── fetch columns: x:4(string) y:5(int) z:6(float)
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── stats: [rows=0]
  ├── key: (1)
  ├── fd: (1)-->(2,3)

--- a/pkg/sql/opt/memo/testdata/stats/insert
+++ b/pkg/sql/opt/memo/testdata/stats/insert
@@ -40,7 +40,7 @@ WHERE z > 1.0
 ----
 with &1
  ├── columns: x:8(string!null) y:9(int!null) z:10(float!null)
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── stats: [rows=69.4736842, distinct(10)=6.66666667, null(10)=0]
  ├── fd: ()-->(8)
  ├── insert xyz
@@ -49,7 +49,7 @@ with &1
  │    │    ├── b:5 => xyz.x:1
  │    │    ├── a:4 => xyz.y:2
  │    │    └── c:6 => xyz.z:3
- │    ├── side-effects, mutations
+ │    ├── volatile, side-effects, mutations
  │    ├── stats: [rows=200]
  │    ├── fd: ()-->(1)
  │    └── project
@@ -97,7 +97,7 @@ insert xyz
  │    ├── a:4 => y:2
  │    └── c:6 => z:3
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── stats: [rows=0]
  └── project
       ├── columns: a:4(int!null) b:5(string) c:6(float)

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -1392,6 +1392,7 @@ FROM
 ----
 full-join (cross)
  ├── columns: a:1(int) b:2(int) c:3(int) a:4(int) b:5(int) c:6(int)
+ ├── immutable
  ├── stats: [rows=100]
  ├── key: (1,2)
  ├── fd: (1,2)-->(3-6)
@@ -1407,7 +1408,7 @@ full-join (cross)
  │    ├── key: ()
  │    └── fd: ()-->(4-6)
  └── filters
-      └── is [type=bool, subquery]
+      └── is [type=bool, immutable, subquery]
            ├── function: not_like_escape [type=bool]
            │    ├── '' [type=string]
            │    ├── CAST(NULL AS STRING) [type=string]

--- a/pkg/sql/opt/memo/testdata/stats/limit
+++ b/pkg/sql/opt/memo/testdata/stats/limit
@@ -61,7 +61,7 @@ SELECT * FROM a WHERE s = 'foo' LIMIT (SELECT 5 AS c)
 ----
 limit
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null)
- ├── side-effects
+ ├── immutable, side-effects
  ├── stats: [rows=200]
  ├── key: (1)
  ├── fd: ()-->(3), (1)-->(2,4), (4)-->(1,2)

--- a/pkg/sql/opt/memo/testdata/stats/project
+++ b/pkg/sql/opt/memo/testdata/stats/project
@@ -87,10 +87,12 @@ SELECT * FROM (SELECT concat(s, y::string) FROM a) AS q(v) WHERE v = 'foo'
 ----
 select
  ├── columns: v:5(string!null)
+ ├── stable
  ├── stats: [rows=20, distinct(5)=1, null(5)=0]
  ├── fd: ()-->(5)
  ├── project
  │    ├── columns: concat:5(string)
+ │    ├── stable
  │    ├── stats: [rows=2000, distinct(5)=100, null(5)=0]
  │    ├── scan a
  │    │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
@@ -98,7 +100,7 @@ select
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    └── projections
- │         └── concat(s:3, y:2::STRING) [as=concat:5, type=string, outer=(2,3)]
+ │         └── concat(s:3, y:2::STRING) [as=concat:5, type=string, outer=(2,3), stable]
  └── filters
       └── concat:5 = 'foo' [type=bool, outer=(5), constraints=(/5: [/'foo' - /'foo']; tight), fd=()-->(5)]
 
@@ -109,11 +111,13 @@ SELECT * FROM (SELECT concat(s, y::string), x FROM a) AS q(v, x) GROUP BY v, x
 group-by
  ├── columns: v:5(string) x:1(int!null)
  ├── grouping columns: x:1(int!null) concat:5(string)
+ ├── stable
  ├── stats: [rows=2000, distinct(1,5)=2000, null(1,5)=0]
  ├── key: (1)
  ├── fd: (1)-->(5)
  └── project
       ├── columns: concat:5(string) x:1(int!null)
+      ├── stable
       ├── stats: [rows=2000, distinct(1,5)=2000, null(1,5)=0]
       ├── key: (1)
       ├── fd: (1)-->(5)
@@ -123,7 +127,7 @@ group-by
       │    ├── key: (1)
       │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
       └── projections
-           └── concat(s:3, y:2::STRING) [as=concat:5, type=string, outer=(2,3)]
+           └── concat(s:3, y:2::STRING) [as=concat:5, type=string, outer=(2,3), stable]
 
 # No available stats for column y.
 build
@@ -244,10 +248,12 @@ SELECT * FROM (SELECT concat(s, y::string) FROM a) AS q(v) WHERE v = 'foo'
 ----
 select
  ├── columns: v:5(string!null)
+ ├── stable
  ├── stats: [rows=1, distinct(5)=1, null(5)=0]
  ├── fd: ()-->(5)
  ├── project
  │    ├── columns: concat:5(string)
+ │    ├── stable
  │    ├── stats: [rows=2000, distinct(5)=2000, null(5)=0]
  │    ├── scan a
  │    │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
@@ -255,7 +261,7 @@ select
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    └── projections
- │         └── concat(s:3, y:2::STRING) [as=concat:5, type=string, outer=(2,3)]
+ │         └── concat(s:3, y:2::STRING) [as=concat:5, type=string, outer=(2,3), stable]
  └── filters
       └── concat:5 = 'foo' [type=bool, outer=(5), constraints=(/5: [/'foo' - /'foo']; tight), fd=()-->(5)]
 

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -507,14 +507,17 @@ WHERE
 ----
 project
  ├── columns: "?column?":26(int!null)
+ ├── immutable
  ├── stats: [rows=1]
  ├── fd: ()-->(26)
  ├── select
  │    ├── columns: col1:25(bool!null)
+ │    ├── immutable
  │    ├── stats: [rows=1, distinct(25)=1, null(25)=0]
  │    ├── fd: ()-->(25)
  │    ├── project
  │    │    ├── columns: col1:25(bool)
+ │    │    ├── immutable
  │    │    ├── stats: [rows=333333.333, distinct(25)=333333.333, null(25)=0]
  │    │    ├── inner-join (cross)
  │    │    │    ├── columns: tab0.e:5(varchar) tab0.f:6("char") tab0.h:8(varchar) tab0.j:10(float!null) tab1.e:16(varchar) tab1.f:17("char") tab1.j:21(float!null)
@@ -528,7 +531,7 @@ project
  │    │    │    └── filters
  │    │    │         └── tab0.j:10 IN (tab1.j:21,) [type=bool, outer=(10,21)]
  │    │    └── projections
- │    │         └── CASE WHEN ilike_escape(regexp_replace(tab0.h:8, tab1.e:16, tab0.f:6, tab0.e:5::STRING), tab1.f:17, '') THEN true ELSE false END [as=col1:25, type=bool, outer=(5,6,8,16,17)]
+ │    │         └── CASE WHEN ilike_escape(regexp_replace(tab0.h:8, tab1.e:16, tab0.f:6, tab0.e:5::STRING), tab1.f:17, '') THEN true ELSE false END [as=col1:25, type=bool, outer=(5,6,8,16,17), immutable]
  │    └── filters
  │         └── col1:25 [type=bool, outer=(25), constraints=(/25: [/true - /true]; tight), fd=()-->(25)]
  └── projections

--- a/pkg/sql/opt/memo/testdata/stats/srfs
+++ b/pkg/sql/opt/memo/testdata/stats/srfs
@@ -9,15 +9,15 @@ JOIN generate_series(1, 4) c ON true
 ----
 inner-join (cross)
  ├── columns: a:1(string) upper:2(string) generate_series:3(int) upper:4(string) c:5(int)
- ├── side-effects
+ ├── immutable, side-effects
  ├── stats: [rows=100, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=90, distinct(3)=7, null(3)=1, distinct(4)=1, null(4)=90, distinct(5)=7, null(5)=1]
  ├── inner-join (cross)
  │    ├── columns: upper:1(string) upper:2(string) generate_series:3(int) upper:4(string)
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── stats: [rows=10, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=9, distinct(3)=7, null(3)=0.1, distinct(4)=1, null(4)=9]
  │    ├── project-set
  │    │    ├── columns: upper:2(string) generate_series:3(int) upper:4(string)
- │    │    ├── side-effects
+ │    │    ├── immutable, side-effects
  │    │    ├── stats: [rows=10, distinct(2)=1, null(2)=9, distinct(3)=7, null(3)=0.1, distinct(4)=1, null(4)=9]
  │    │    ├── values
  │    │    │    ├── cardinality: [1 - 1]
@@ -26,7 +26,7 @@ inner-join (cross)
  │    │    │    └── () [type=tuple]
  │    │    └── zip
  │    │         ├── 'DEF' [type=string]
- │    │         ├── generate_series(1, 3) [type=int, side-effects]
+ │    │         ├── generate_series(1, 3) [type=int, immutable, side-effects]
  │    │         └── 'GHI' [type=string]
  │    ├── project-set
  │    │    ├── columns: upper:1(string)
@@ -41,7 +41,7 @@ inner-join (cross)
  │    └── filters (true)
  ├── project-set
  │    ├── columns: generate_series:5(int)
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── stats: [rows=10, distinct(5)=7, null(5)=0.1]
  │    ├── values
  │    │    ├── cardinality: [1 - 1]
@@ -49,7 +49,7 @@ inner-join (cross)
  │    │    ├── key: ()
  │    │    └── () [type=tuple]
  │    └── zip
- │         └── generate_series(1, 4) [type=int, side-effects]
+ │         └── generate_series(1, 4) [type=int, immutable, side-effects]
  └── filters (true)
 
 opt
@@ -58,16 +58,16 @@ SELECT * FROM (SELECT * FROM upper('abc') a, generate_series(1, 2) b) GROUP BY a
 distinct-on
  ├── columns: a:1(string) b:2(int)
  ├── grouping columns: upper:1(string) generate_series:2(int)
- ├── side-effects
+ ├── immutable, side-effects
  ├── stats: [rows=7, distinct(1,2)=7, null(1,2)=0]
  ├── key: (1,2)
  └── inner-join (cross)
       ├── columns: upper:1(string) generate_series:2(int)
-      ├── side-effects
+      ├── immutable, side-effects
       ├── stats: [rows=10, distinct(1,2)=7, null(1,2)=0]
       ├── project-set
       │    ├── columns: generate_series:2(int)
-      │    ├── side-effects
+      │    ├── immutable, side-effects
       │    ├── stats: [rows=10, distinct(2)=7, null(2)=0.1]
       │    ├── values
       │    │    ├── cardinality: [1 - 1]
@@ -75,7 +75,7 @@ distinct-on
       │    │    ├── key: ()
       │    │    └── () [type=tuple]
       │    └── zip
-      │         └── generate_series(1, 2) [type=int, side-effects]
+      │         └── generate_series(1, 2) [type=int, immutable, side-effects]
       ├── project-set
       │    ├── columns: upper:1(string)
       │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
@@ -117,7 +117,7 @@ SELECT xy.*, generate_series(x, y), generate_series(0, 1) FROM xy
 ----
 project-set
  ├── columns: x:1(int!null) y:2(int) generate_series:3(int) generate_series:4(int)
- ├── side-effects
+ ├── immutable, side-effects
  ├── stats: [rows=10000, distinct(3)=700, null(3)=100, distinct(4)=7, null(4)=100, distinct(1,3)=10000, null(1,3)=0, distinct(2,4)=700, null(2,4)=1, distinct(3,4)=4900, null(3,4)=1]
  ├── fd: (1)-->(2)
  ├── scan xy
@@ -126,8 +126,8 @@ project-set
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── zip
-      ├── generate_series(x:1, y:2) [type=int, outer=(1,2), side-effects]
-      └── generate_series(0, 1) [type=int, side-effects]
+      ├── generate_series(x:1, y:2) [type=int, outer=(1,2), immutable, side-effects]
+      └── generate_series(0, 1) [type=int, immutable, side-effects]
 
 exec-ddl
 CREATE TABLE articles (
@@ -161,17 +161,17 @@ SELECT id FROM articles WHERE title = ANY(
 distinct-on
  ├── columns: id:1(int!null)
  ├── grouping columns: id:1(int!null)
- ├── side-effects
+ ├── immutable, side-effects
  ├── stats: [rows=9.85601173, distinct(1)=9.85601173, null(1)=0]
  ├── key: (1)
  └── select
       ├── columns: id:1(int!null) title:4(string!null) tag_list:6(string[]) upper:10(string!null) unnest:11(string) generate_series:12(int) lower:13(string)
-      ├── side-effects
+      ├── immutable, side-effects
       ├── stats: [rows=9.9, distinct(1)=9.85601173, null(1)=0, distinct(4)=9.9, null(4)=0, distinct(10)=9.9, null(10)=0]
       ├── fd: (1)-->(4,6), (4)==(10), (10)==(4)
       ├── project-set
       │    ├── columns: id:1(int!null) title:4(string) tag_list:6(string[]) upper:10(string) unnest:11(string) generate_series:12(int) lower:13(string)
-      │    ├── side-effects
+      │    ├── immutable, side-effects
       │    ├── stats: [rows=10000, distinct(1)=1000, null(1)=0, distinct(4)=100, null(4)=100, distinct(10)=100, null(10)=9000]
       │    ├── fd: (1)-->(4,6)
       │    ├── scan articles
@@ -180,9 +180,9 @@ distinct-on
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(4,6)
       │    └── zip
-      │         ├── upper(title:4) [type=string, outer=(4)]
-      │         ├── unnest(tag_list:6) [type=string, outer=(6), side-effects]
-      │         ├── generate_series(0, 1) [type=int, side-effects]
+      │         ├── upper(title:4) [type=string, outer=(4), immutable]
+      │         ├── unnest(tag_list:6) [type=string, outer=(6), immutable, side-effects]
+      │         ├── generate_series(0, 1) [type=int, immutable, side-effects]
       │         └── 'abc' [type=string]
       └── filters
            └── title:4 = upper:10 [type=bool, outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
@@ -195,17 +195,17 @@ SELECT id FROM articles WHERE title = ANY(
 distinct-on
  ├── columns: id:1(int!null)
  ├── grouping columns: id:1(int!null)
- ├── side-effects
+ ├── immutable, side-effects
  ├── stats: [rows=13.9135391, distinct(1)=13.9135391, null(1)=0]
  ├── key: (1)
  └── select
       ├── columns: id:1(int!null) title:4(string!null) tag_list:6(string[]) upper:10(string) unnest:11(string!null) generate_series:12(int) lower:13(string)
-      ├── side-effects
+      ├── immutable, side-effects
       ├── stats: [rows=14.0014286, distinct(1)=13.9135391, null(1)=0, distinct(4)=14.0014286, null(4)=0, distinct(11)=14.0014286, null(11)=0]
       ├── fd: (1)-->(4,6), (4)==(11), (11)==(4)
       ├── project-set
       │    ├── columns: id:1(int!null) title:4(string) tag_list:6(string[]) upper:10(string) unnest:11(string) generate_series:12(int) lower:13(string)
-      │    ├── side-effects
+      │    ├── immutable, side-effects
       │    ├── stats: [rows=10000, distinct(1)=1000, null(1)=0, distinct(4)=100, null(4)=100, distinct(11)=700, null(11)=100]
       │    ├── fd: (1)-->(4,6)
       │    ├── scan articles
@@ -214,9 +214,9 @@ distinct-on
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(4,6)
       │    └── zip
-      │         ├── upper(title:4) [type=string, outer=(4)]
-      │         ├── unnest(tag_list:6) [type=string, outer=(6), side-effects]
-      │         ├── generate_series(0, 1) [type=int, side-effects]
+      │         ├── upper(title:4) [type=string, outer=(4), immutable]
+      │         ├── unnest(tag_list:6) [type=string, outer=(6), immutable, side-effects]
+      │         ├── generate_series(0, 1) [type=int, immutable, side-effects]
       │         └── 'abc' [type=string]
       └── filters
            └── title:4 = unnest:11 [type=bool, outer=(4,11), constraints=(/4: (/NULL - ]; /11: (/NULL - ]), fd=(4)==(11), (11)==(4)]
@@ -229,17 +229,17 @@ SELECT id FROM articles WHERE id = ANY(
 distinct-on
  ├── columns: id:1(int!null)
  ├── grouping columns: id:1(int!null)
- ├── side-effects
+ ├── immutable, side-effects
  ├── stats: [rows=6, distinct(1)=6, null(1)=0]
  ├── key: (1)
  └── select
       ├── columns: id:1(int!null) title:4(string) tag_list:6(string[]) upper:10(string) unnest:11(string) generate_series:12(int!null) lower:13(string)
-      ├── side-effects
+      ├── immutable, side-effects
       ├── stats: [rows=9.9, distinct(1)=6, null(1)=0, distinct(12)=6, null(12)=0]
       ├── fd: (1)-->(4,6), (1)==(12), (12)==(1)
       ├── project-set
       │    ├── columns: id:1(int!null) title:4(string) tag_list:6(string[]) upper:10(string) unnest:11(string) generate_series:12(int) lower:13(string)
-      │    ├── side-effects
+      │    ├── immutable, side-effects
       │    ├── stats: [rows=10000, distinct(1)=1000, null(1)=0, distinct(12)=7, null(12)=100]
       │    ├── fd: (1)-->(4,6)
       │    ├── scan articles
@@ -248,9 +248,9 @@ distinct-on
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(4,6)
       │    └── zip
-      │         ├── upper(title:4) [type=string, outer=(4)]
-      │         ├── unnest(tag_list:6) [type=string, outer=(6), side-effects]
-      │         ├── generate_series(0, 1) [type=int, side-effects]
+      │         ├── upper(title:4) [type=string, outer=(4), immutable]
+      │         ├── unnest(tag_list:6) [type=string, outer=(6), immutable, side-effects]
+      │         ├── generate_series(0, 1) [type=int, immutable, side-effects]
       │         └── 'abc' [type=string]
       └── filters
            └── id:1 = generate_series:12 [type=bool, outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
@@ -263,17 +263,17 @@ SELECT id FROM articles WHERE title = ANY(
 distinct-on
  ├── columns: id:1(int!null)
  ├── grouping columns: id:1(int!null)
- ├── side-effects
+ ├── immutable, side-effects
  ├── stats: [rows=9.85601173, distinct(1)=9.85601173, null(1)=0]
  ├── key: (1)
  └── select
       ├── columns: id:1(int!null) title:4(string!null) tag_list:6(string[]) upper:10(string) unnest:11(string) generate_series:12(int) lower:13(string!null)
-      ├── side-effects
+      ├── immutable, side-effects
       ├── stats: [rows=9.9, distinct(1)=9.85601173, null(1)=0, distinct(4)=1e-10, null(4)=0, distinct(13)=1e-10, null(13)=0]
       ├── fd: (1)-->(4,6), (4)==(13), (13)==(4)
       ├── project-set
       │    ├── columns: id:1(int!null) title:4(string) tag_list:6(string[]) upper:10(string) unnest:11(string) generate_series:12(int) lower:13(string)
-      │    ├── side-effects
+      │    ├── immutable, side-effects
       │    ├── stats: [rows=10000, distinct(1)=1000, null(1)=0, distinct(4)=100, null(4)=100, distinct(13)=1, null(13)=9000]
       │    ├── fd: (1)-->(4,6)
       │    ├── scan articles
@@ -282,9 +282,9 @@ distinct-on
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(4,6)
       │    └── zip
-      │         ├── upper(title:4) [type=string, outer=(4)]
-      │         ├── unnest(tag_list:6) [type=string, outer=(6), side-effects]
-      │         ├── generate_series(0, 1) [type=int, side-effects]
+      │         ├── upper(title:4) [type=string, outer=(4), immutable]
+      │         ├── unnest(tag_list:6) [type=string, outer=(6), immutable, side-effects]
+      │         ├── generate_series(0, 1) [type=int, immutable, side-effects]
       │         └── 'abc' [type=string]
       └── filters
            └── title:4 = lower:13 [type=bool, outer=(4,13), constraints=(/4: (/NULL - ]; /13: (/NULL - ]), fd=(4)==(13), (13)==(4)]

--- a/pkg/sql/opt/memo/testdata/stats/update
+++ b/pkg/sql/opt/memo/testdata/stats/update
@@ -40,7 +40,7 @@ WHERE x > 'foo'
 ----
 with &1
  ├── columns: x:8(string!null) y:9(int!null) z:10(float!null)
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── stats: [rows=3.33333333, distinct(8)=3.33333333, null(8)=0]
  ├── key: (8)
  ├── fd: ()-->(9,10)
@@ -49,7 +49,7 @@ with &1
  │    ├── fetch columns: xyz.x:4(string) xyz.y:5(int) xyz.z:6(float)
  │    ├── update-mapping:
  │    │    └── y_new:7 => xyz.y:2
- │    ├── side-effects, mutations
+ │    ├── volatile, side-effects, mutations
  │    ├── stats: [rows=10]
  │    ├── key: (1)
  │    ├── fd: ()-->(2,3)
@@ -99,7 +99,7 @@ update xyz
  ├── update-mapping:
  │    └── x_new:7 => x:1
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── stats: [rows=0]
  ├── fd: ()-->(1)
  └── project

--- a/pkg/sql/opt/memo/testdata/stats/upsert
+++ b/pkg/sql/opt/memo/testdata/stats/upsert
@@ -90,7 +90,7 @@ WHERE y=10
 ----
 with &1
  ├── columns: x:16(string!null) y:17(int!null) z:18(float)
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── stats: [rows=9.94974874, distinct(17)=0.994974874, null(17)=0]
  ├── fd: ()-->(17)
  ├── upsert xyz
@@ -107,7 +107,7 @@ with &1
  │    │    ├── upsert_x:13 => xyz.x:1
  │    │    ├── upsert_y:14 => xyz.y:2
  │    │    └── upsert_z:15 => xyz.z:3
- │    ├── side-effects, mutations
+ │    ├── volatile, side-effects, mutations
  │    ├── stats: [rows=9.94974874]
  │    └── project
  │         ├── columns: upsert_x:13(string) upsert_y:14(int!null) upsert_z:15(float) a:4(int!null) b:5(string) column8:8(float) xyz.x:9(string) xyz.y:10(int) xyz.z:11(float) y_new:12(int!null)
@@ -198,7 +198,7 @@ upsert xyz
  │    ├── a:4 => y:2
  │    └── column8:8 => z:3
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── stats: [rows=0]
  ├── fd: ()-->(3)
  └── project
@@ -246,23 +246,23 @@ upsert uv
  ├── update-mapping:
  │    └── upsert_v:12 => v:2
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── stats: [rows=0]
  └── project
       ├── columns: upsert_u:11(int) upsert_v:12(int) z:6(int) column7:7(int) u:8(int) v:9(int) v_new:10(int!null)
-      ├── side-effects
+      ├── volatile, side-effects
       ├── stats: [rows=1000]
       ├── lax-key: (6,8)
       ├── fd: ()-->(10), (6)~~>(7), (8)-->(9), (9)~~>(8), (7,8)-->(11), (6,8)-->(12), (6,8)~~>(7,11)
       ├── project
       │    ├── columns: v_new:10(int!null) z:6(int) column7:7(int) u:8(int) v:9(int)
-      │    ├── side-effects
+      │    ├── volatile, side-effects
       │    ├── stats: [rows=1000]
       │    ├── lax-key: (6,8)
       │    ├── fd: ()-->(10), (6)~~>(7), (8)-->(9), (9)~~>(8)
       │    ├── left-join (hash)
       │    │    ├── columns: z:6(int) column7:7(int) u:8(int) v:9(int)
-      │    │    ├── side-effects
+      │    │    ├── volatile, side-effects
       │    │    ├── stats: [rows=1000, distinct(9)=991, null(9)=0]
       │    │    ├── lax-key: (6,8)
       │    │    ├── fd: (6)~~>(7), (8)-->(9), (9)~~>(8)
@@ -270,13 +270,13 @@ upsert uv
       │    │    │    ├── columns: z:6(int) column7:7(int)
       │    │    │    ├── grouping columns: z:6(int)
       │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
-      │    │    │    ├── side-effects
+      │    │    │    ├── volatile, side-effects
       │    │    │    ├── stats: [rows=1000, distinct(6)=1000, null(6)=0]
       │    │    │    ├── lax-key: (6)
       │    │    │    ├── fd: (6)~~>(7)
       │    │    │    ├── project
       │    │    │    │    ├── columns: column7:7(int) z:6(int)
-      │    │    │    │    ├── side-effects
+      │    │    │    │    ├── volatile, side-effects
       │    │    │    │    ├── stats: [rows=1000, distinct(6)=100, null(6)=0]
       │    │    │    │    ├── project
       │    │    │    │    │    ├── columns: z:6(int)
@@ -289,7 +289,7 @@ upsert uv
       │    │    │    │    │    └── projections
       │    │    │    │    │         └── xyz.z:5::INT8 [as=z:6, type=int, outer=(5)]
       │    │    │    │    └── projections
-      │    │    │    │         └── unique_rowid() [as=column7:7, type=int, side-effects]
+      │    │    │    │         └── unique_rowid() [as=column7:7, type=int, volatile, side-effects]
       │    │    │    └── aggregations
       │    │    │         └── first-agg [as=column7:7, type=int, outer=(7)]
       │    │    │              └── column7:7 [type=int]
@@ -328,7 +328,7 @@ upsert mno
  ├── update-mapping:
  │    └── upsert_o:13 => o:3
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── stats: [rows=0]
  └── project
       ├── columns: upsert_m:11(int) upsert_n:12(int) upsert_o:13(int) m:4(int!null) n:5(int) o:6(int) m:7(int) n:8(int) o:9(int) o_new:10(int!null)

--- a/pkg/sql/opt/memo/testdata/stats/values
+++ b/pkg/sql/opt/memo/testdata/stats/values
@@ -27,13 +27,13 @@ distinct-on
  ├── columns: x:1(int) y:2(int!null)
  ├── grouping columns: column1:1(int) column2:2(int!null)
  ├── cardinality: [1 - 5]
- ├── side-effects
+ ├── volatile, side-effects
  ├── stats: [rows=4, distinct(1,2)=4, null(1,2)=0]
  ├── key: (1,2)
  └── values
       ├── columns: column1:1(int) column2:2(int!null)
       ├── cardinality: [5 - 5]
-      ├── side-effects
+      ├── volatile, side-effects
       ├── stats: [rows=5, distinct(1,2)=4, null(1,2)=0]
       ├── (1, 2) [type=tuple{int, int}]
       ├── (1, 2) [type=tuple{int, int}]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q07
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q07
@@ -62,6 +62,7 @@ ORDER BY
 sort
  ├── save-table-name: q7_sort_1
  ├── columns: supp_nation:42(char!null) cust_nation:46(char!null) l_year:49(float) revenue:51(float!null)
+ ├── immutable
  ├── stats: [rows=974.320532, distinct(42)=1.33333333, null(42)=0, distinct(46)=1.33333333, null(46)=0, distinct(49)=730.981616, null(49)=0, distinct(51)=974.320532, null(51)=0, distinct(42,46,49)=974.320532, null(42,46,49)=0]
  ├── key: (42,46,49)
  ├── fd: (42,46,49)-->(51)
@@ -70,12 +71,14 @@ sort
       ├── save-table-name: q7_group_by_2
       ├── columns: n1.n_name:42(char!null) n2.n_name:46(char!null) l_year:49(float) sum:51(float!null)
       ├── grouping columns: n1.n_name:42(char!null) n2.n_name:46(char!null) l_year:49(float)
+      ├── immutable
       ├── stats: [rows=974.320532, distinct(42)=1.33333333, null(42)=0, distinct(46)=1.33333333, null(46)=0, distinct(49)=730.981616, null(49)=0, distinct(51)=974.320532, null(51)=0, distinct(42,46,49)=974.320532, null(42,46,49)=0]
       ├── key: (42,46,49)
       ├── fd: (42,46,49)-->(51)
       ├── project
       │    ├── save-table-name: q7_project_3
       │    ├── columns: l_year:49(float) volume:50(float!null) n1.n_name:42(char!null) n2.n_name:46(char!null)
+      │    ├── immutable
       │    ├── stats: [rows=7741.78379, distinct(42)=1.33333333, null(42)=0, distinct(46)=1.33333333, null(46)=0, distinct(49)=730.981616, null(49)=0, distinct(50)=7579.92926, null(50)=0, distinct(42,46,49)=974.320532, null(42,46,49)=0]
       │    ├── inner-join (hash)
       │    │    ├── save-table-name: q7_inner_join_4
@@ -144,7 +147,7 @@ sort
       │    │         ├── s_suppkey:1 = l_suppkey:10 [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
       │    │         └── s_nationkey:4 = n1.n_nationkey:41 [type=bool, outer=(4,41), constraints=(/4: (/NULL - ]; /41: (/NULL - ]), fd=(4)==(41), (41)==(4)]
       │    └── projections
-      │         ├── extract('year', l_shipdate:18) [as=l_year:49, type=float, outer=(18)]
+      │         ├── extract('year', l_shipdate:18) [as=l_year:49, type=float, outer=(18), immutable]
       │         └── l_extendedprice:13 * (1.0 - l_discount:14) [as=volume:50, type=float, outer=(13,14)]
       └── aggregations
            └── sum [as=sum:51, type=float, outer=(50)]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q08
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q08
@@ -62,7 +62,7 @@ ORDER BY
 sort
  ├── save-table-name: q8_sort_1
  ├── columns: o_year:61(float) mkt_share:66(float!null)
- ├── side-effects
+ ├── immutable, side-effects
  ├── stats: [rows=717.329701, distinct(61)=717.329701, null(61)=0, distinct(66)=717.329701, null(66)=0]
  ├── key: (61)
  ├── fd: (61)-->(66)
@@ -70,7 +70,7 @@ sort
  └── project
       ├── save-table-name: q8_project_2
       ├── columns: mkt_share:66(float!null) o_year:61(float)
-      ├── side-effects
+      ├── immutable, side-effects
       ├── stats: [rows=717.329701, distinct(61)=717.329701, null(61)=0, distinct(66)=717.329701, null(66)=0]
       ├── key: (61)
       ├── fd: (61)-->(66)
@@ -78,16 +78,19 @@ sort
       │    ├── save-table-name: q8_group_by_3
       │    ├── columns: o_year:61(float) sum:64(float!null) sum:65(float!null)
       │    ├── grouping columns: o_year:61(float)
+      │    ├── immutable
       │    ├── stats: [rows=717.329701, distinct(61)=717.329701, null(61)=0, distinct(64)=717.329701, null(64)=0, distinct(65)=717.329701, null(65)=0, distinct(64,65)=717.329701, null(64,65)=0]
       │    ├── key: (61)
       │    ├── fd: (61)-->(64,65)
       │    ├── project
       │    │    ├── save-table-name: q8_project_4
       │    │    ├── columns: column63:63(float!null) o_year:61(float) volume:62(float!null)
+      │    │    ├── immutable
       │    │    ├── stats: [rows=2908.77768, distinct(61)=717.329701, null(61)=0, distinct(62)=2896.77415, null(62)=0, distinct(63)=2896.99622, null(63)=0]
       │    │    ├── project
       │    │    │    ├── save-table-name: q8_project_5
       │    │    │    ├── columns: o_year:61(float) volume:62(float!null) n2.n_name:55(char!null)
+      │    │    │    ├── immutable
       │    │    │    ├── stats: [rows=2908.77768, distinct(55)=24.9055527, null(55)=0, distinct(61)=717.329701, null(61)=0, distinct(62)=2896.77415, null(62)=0, distinct(55,62)=2896.99622, null(55,62)=0]
       │    │    │    ├── inner-join (hash)
       │    │    │    │    ├── save-table-name: q8_inner_join_6
@@ -239,7 +242,7 @@ sort
       │    │    │    │    └── filters
       │    │    │    │         └── p_partkey:1 = l_partkey:18 [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
       │    │    │    └── projections
-      │    │    │         ├── extract('year', o_orderdate:37) [as=o_year:61, type=float, outer=(37)]
+      │    │    │         ├── extract('year', o_orderdate:37) [as=o_year:61, type=float, outer=(37), immutable]
       │    │    │         └── l_extendedprice:22 * (1.0 - l_discount:23) [as=volume:62, type=float, outer=(22,23)]
       │    │    └── projections
       │    │         └── CASE WHEN n2.n_name:55 = 'BRAZIL' THEN volume:62 ELSE 0.0 END [as=column63:63, type=float, outer=(55,62)]
@@ -249,7 +252,7 @@ sort
       │         └── sum [as=sum:65, type=float, outer=(62)]
       │              └── volume:62 [type=float]
       └── projections
-           └── sum:64 / sum:65 [as=mkt_share:66, type=float, outer=(64,65), side-effects]
+           └── sum:64 / sum:65 [as=mkt_share:66, type=float, outer=(64,65), immutable, side-effects]
 
 
 stats table=q8_sort_1

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q09
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q09
@@ -60,6 +60,7 @@ ORDER BY
 sort
  ├── save-table-name: q9_sort_1
  ├── columns: nation:48(char!null) o_year:51(float) sum_profit:53(float!null)
+ ├── immutable
  ├── stats: [rows=1500.68104, distinct(48)=25, null(48)=0, distinct(51)=1208.19298, null(51)=0, distinct(53)=1500.68104, null(53)=0, distinct(48,51)=1500.68104, null(48,51)=0]
  ├── key: (48,51)
  ├── fd: (48,51)-->(53)
@@ -68,12 +69,14 @@ sort
       ├── save-table-name: q9_group_by_2
       ├── columns: n_name:48(char!null) o_year:51(float) sum:53(float!null)
       ├── grouping columns: n_name:48(char!null) o_year:51(float)
+      ├── immutable
       ├── stats: [rows=1500.68104, distinct(48)=25, null(48)=0, distinct(51)=1208.19298, null(51)=0, distinct(53)=1500.68104, null(53)=0, distinct(48,51)=1500.68104, null(48,51)=0]
       ├── key: (48,51)
       ├── fd: (48,51)-->(53)
       ├── project
       │    ├── save-table-name: q9_project_3
       │    ├── columns: o_year:51(float) amount:52(float!null) n_name:48(char!null)
+      │    ├── immutable
       │    ├── stats: [rows=2406.66318, distinct(48)=25, null(48)=0, distinct(51)=1208.19298, null(51)=0, distinct(52)=1508.01915, null(52)=0, distinct(48,51)=1500.68104, null(48,51)=0]
       │    ├── inner-join (lookup part)
       │    │    ├── save-table-name: q9_lookup_join_4
@@ -153,7 +156,7 @@ sort
       │    │    └── filters
       │    │         └── p_name:2 LIKE '%green%' [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
       │    └── projections
-      │         ├── extract('year', o_orderdate:42) [as=o_year:51, type=float, outer=(42)]
+      │         ├── extract('year', o_orderdate:42) [as=o_year:51, type=float, outer=(42), immutable]
       │         └── (l_extendedprice:22 * (1.0 - l_discount:23)) - (ps_supplycost:36 * l_quantity:21) [as=amount:52, type=float, outer=(21-23,36)]
       └── aggregations
            └── sum [as=sum:53, type=float, outer=(52)]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q14
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q14
@@ -34,7 +34,7 @@ project
  ├── save-table-name: q14_project_1
  ├── columns: promo_revenue:30(float)
  ├── cardinality: [1 - 1]
- ├── side-effects
+ ├── immutable, side-effects
  ├── stats: [rows=1, distinct(30)=1, null(30)=0]
  ├── key: ()
  ├── fd: ()-->(30)
@@ -90,7 +90,7 @@ project
  │         └── sum [as=sum:29, type=float, outer=(28)]
  │              └── column28:28 [type=float]
  └── projections
-      └── (sum:27 * 100.0) / sum:29 [as=promo_revenue:30, type=float, outer=(27,29), side-effects]
+      └── (sum:27 * 100.0) / sum:29 [as=promo_revenue:30, type=float, outer=(27,29), immutable, side-effects]
 
 stats table=q14_project_1
 ----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q22
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q22
@@ -56,6 +56,7 @@ ORDER BY
 sort
  ├── save-table-name: q22_sort_1
  ├── columns: cntrycode:27(string) numcust:28(int!null) totacctbal:29(float!null)
+ ├── immutable
  ├── stats: [rows=1e-10, distinct(27)=1e-10, null(27)=0, distinct(28)=1e-10, null(28)=0, distinct(29)=1e-10, null(29)=0]
  ├── key: (27)
  ├── fd: (27)-->(28,29)
@@ -64,23 +65,27 @@ sort
       ├── save-table-name: q22_group_by_2
       ├── columns: cntrycode:27(string) count_rows:28(int!null) sum:29(float!null)
       ├── grouping columns: cntrycode:27(string)
+      ├── immutable
       ├── stats: [rows=1e-10, distinct(27)=1e-10, null(27)=0, distinct(28)=1e-10, null(28)=0, distinct(29)=1e-10, null(29)=0]
       ├── key: (27)
       ├── fd: (27)-->(28,29)
       ├── project
       │    ├── save-table-name: q22_project_3
       │    ├── columns: cntrycode:27(string) c_acctbal:6(float!null)
+      │    ├── immutable
       │    ├── stats: [rows=1e-10, distinct(6)=1e-10, null(6)=0, distinct(27)=1e-10, null(27)=0]
       │    ├── anti-join (lookup orders@o_ck)
       │    │    ├── save-table-name: q22_lookup_join_4
       │    │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
       │    │    ├── key columns: [1] = [19]
+      │    │    ├── immutable
       │    │    ├── stats: [rows=1e-10, distinct(1)=1e-10, null(1)=0, distinct(5)=1e-10, null(5)=0, distinct(6)=1e-10, null(6)=0]
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(5,6)
       │    │    ├── select
       │    │    │    ├── save-table-name: q22_select_5
       │    │    │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
+      │    │    │    ├── immutable
       │    │    │    ├── stats: [rows=16666.6667, distinct(1)=16658.9936, null(1)=0, distinct(5)=16666.6667, null(5)=0, distinct(6)=16666.6667, null(6)=0]
       │    │    │    ├── key: (1)
       │    │    │    ├── fd: (1)-->(5,6)
@@ -93,20 +98,22 @@ sort
       │    │    │    │    ├── key: (1)
       │    │    │    │    └── fd: (1)-->(5,6)
       │    │    │    └── filters
-      │    │    │         ├── substring(c_phone:5, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [type=bool, outer=(5)]
-      │    │    │         └── gt [type=bool, outer=(6), subquery, constraints=(/6: (/NULL - ])]
+      │    │    │         ├── substring(c_phone:5, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [type=bool, outer=(5), immutable]
+      │    │    │         └── gt [type=bool, outer=(6), immutable, subquery, constraints=(/6: (/NULL - ])]
       │    │    │              ├── c_acctbal:6 [type=float]
       │    │    │              └── subquery [type=float]
       │    │    │                   └── scalar-group-by
       │    │    │                        ├── save-table-name: q22_scalar_group_by_7
       │    │    │                        ├── columns: avg:17(float)
       │    │    │                        ├── cardinality: [1 - 1]
+      │    │    │                        ├── immutable
       │    │    │                        ├── stats: [rows=1, distinct(17)=1, null(17)=0]
       │    │    │                        ├── key: ()
       │    │    │                        ├── fd: ()-->(17)
       │    │    │                        ├── select
       │    │    │                        │    ├── save-table-name: q22_select_8
       │    │    │                        │    ├── columns: c_phone:13(char!null) c_acctbal:14(float!null)
+      │    │    │                        │    ├── immutable
       │    │    │                        │    ├── stats: [rows=16666.6667, distinct(13)=16666.6667, null(13)=0, distinct(14)=16666.6667, null(14)=0]
       │    │    │                        │    ├── scan customer
       │    │    │                        │    │    ├── save-table-name: q22_scan_9
@@ -114,13 +121,13 @@ sort
       │    │    │                        │    │    └── stats: [rows=150000, distinct(13)=150000, null(13)=0, distinct(14)=140628, null(14)=0]
       │    │    │                        │    └── filters
       │    │    │                        │         ├── c_acctbal:14 > 0.0 [type=bool, outer=(14), constraints=(/14: [/5e-324 - ]; tight)]
-      │    │    │                        │         └── substring(c_phone:13, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [type=bool, outer=(13)]
+      │    │    │                        │         └── substring(c_phone:13, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [type=bool, outer=(13), immutable]
       │    │    │                        └── aggregations
       │    │    │                             └── avg [as=avg:17, type=float, outer=(14)]
       │    │    │                                  └── c_acctbal:14 [type=float]
       │    │    └── filters (true)
       │    └── projections
-      │         └── substring(c_phone:5, 1, 2) [as=cntrycode:27, type=string, outer=(5)]
+      │         └── substring(c_phone:5, 1, 2) [as=cntrycode:27, type=string, outer=(5), immutable]
       └── aggregations
            ├── count-rows [as=count_rows:28, type=int]
            └── sum [as=sum:29, type=float, outer=(6)]

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -66,7 +66,7 @@ SELECT * FROM a WHERE random()::int>a.i+a.i
 ----
 select
  ├── columns: k:1!null i:2 f:3 s:4 j:5 d:6
- ├── side-effects
+ ├── volatile, side-effects
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan a
@@ -74,7 +74,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      └── random()::INT8 > (i:2 + i:2) [outer=(2), side-effects]
+      └── random()::INT8 > (i:2 + i:2) [outer=(2), volatile, side-effects]
 
 # --------------------------------------------------
 # NormalizeCmpPlusConst
@@ -647,10 +647,11 @@ SELECT timezone('America/Denver', ts) >= tz FROM t
 ----
 project
  ├── columns: "?column?":4
+ ├── immutable
  ├── scan t
  │    └── columns: ts:1 tz:2
  └── projections
-      └── tz:2 <= timezone('America/Denver', ts:1) [as="?column?":4, outer=(1,2)]
+      └── tz:2 <= timezone('America/Denver', ts:1) [as="?column?":4, outer=(1,2), immutable]
 
 # Don't normalize when the timezone() arguments are constants.
 norm expect-not=NormalizeCmpTimeZoneFunction
@@ -693,10 +694,11 @@ SELECT timezone('America/Denver', tz) >= ts FROM t
 ----
 project
  ├── columns: "?column?":4
+ ├── immutable
  ├── scan t
  │    └── columns: ts:1 tz:2
  └── projections
-      └── ts:1 <= timezone('America/Denver', tz:2) [as="?column?":4, outer=(1,2)]
+      └── ts:1 <= timezone('America/Denver', tz:2) [as="?column?":4, outer=(1,2), immutable]
 
 # Don't normalize when the timezone() arguments are constants.
 norm expect-not=NormalizeCmpTimeZoneFunctionTZ

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -66,7 +66,7 @@ update xy
  │    ├── u:5 => x:1
  │    └── v:6 => y:2
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── left-join (hash)
       ├── columns: x:3!null y:4 u:5 v:6
       ├── key: (3)
@@ -102,7 +102,7 @@ upsert xy
  │    ├── upsert_x:9 => x:1
  │    └── upsert_y:10 => y:2
  ├── cardinality: [2 - ]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: upsert_x:9 upsert_y:10 column1:3!null column2:4!null x:5 y:6
       ├── cardinality: [2 - ]
@@ -144,7 +144,7 @@ delete xy
  ├── columns: <none>
  ├── fetch columns: x:3
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── semi-join (hash)
       ├── columns: x:3!null
       ├── key: (3)
@@ -166,17 +166,17 @@ SELECT generate_series(0, 5) FROM xy
 ----
 inner-join (cross)
  ├── columns: generate_series:3
- ├── side-effects
+ ├── immutable, side-effects
  ├── scan xy
  ├── project-set
  │    ├── columns: generate_series:3
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── values
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── key: ()
  │    │    └── ()
  │    └── zip
- │         └── generate_series(0, 5) [side-effects]
+ │         └── generate_series(0, 5) [immutable, side-effects]
  └── filters (true)
 
 norm expect=DecorrelateProjectSet
@@ -184,7 +184,7 @@ SELECT * FROM a WHERE i IN (SELECT generate_series(k, i) FROM xy)
 ----
 semi-join-apply
  ├── columns: k:1!null i:2!null f:3 s:4 j:5
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
@@ -194,18 +194,18 @@ semi-join-apply
  ├── inner-join (cross)
  │    ├── columns: generate_series:8
  │    ├── outer: (1,2)
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── scan xy
  │    ├── project-set
  │    │    ├── columns: generate_series:8
  │    │    ├── outer: (1,2)
- │    │    ├── side-effects
+ │    │    ├── immutable, side-effects
  │    │    ├── values
  │    │    │    ├── cardinality: [1 - 1]
  │    │    │    ├── key: ()
  │    │    │    └── ()
  │    │    └── zip
- │    │         └── generate_series(k:1, i:2) [outer=(1,2), side-effects]
+ │    │         └── generate_series(k:1, i:2) [outer=(1,2), immutable, side-effects]
  │    └── filters (true)
  └── filters
       └── i:2 = generate_series:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
@@ -215,39 +215,39 @@ SELECT generate_series(0, (SELECT generate_series(1,0) FROM xy)) FROM uv
 ----
 inner-join (cross)
  ├── columns: generate_series:6
- ├── side-effects
+ ├── immutable, side-effects
  ├── scan uv
  ├── project-set
  │    ├── columns: generate_series:6
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── values
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── key: ()
  │    │    └── ()
  │    └── zip
- │         └── function: generate_series [side-effects, subquery]
+ │         └── function: generate_series [immutable, side-effects, subquery]
  │              ├── 0
  │              └── subquery
  │                   └── max1-row
  │                        ├── columns: generate_series:5
  │                        ├── error: "more than one row returned by a subquery used as an expression"
  │                        ├── cardinality: [0 - 1]
- │                        ├── side-effects
+ │                        ├── immutable, side-effects
  │                        ├── key: ()
  │                        ├── fd: ()-->(5)
  │                        └── inner-join (cross)
  │                             ├── columns: generate_series:5
- │                             ├── side-effects
+ │                             ├── immutable, side-effects
  │                             ├── scan xy
  │                             ├── project-set
  │                             │    ├── columns: generate_series:5
- │                             │    ├── side-effects
+ │                             │    ├── immutable, side-effects
  │                             │    ├── values
  │                             │    │    ├── cardinality: [1 - 1]
  │                             │    │    ├── key: ()
  │                             │    │    └── ()
  │                             │    └── zip
- │                             │         └── generate_series(1, 0) [side-effects]
+ │                             │         └── generate_series(1, 0) [immutable, side-effects]
  │                             └── filters (true)
  └── filters (true)
 
@@ -2749,20 +2749,20 @@ SELECT * FROM xy WHERE EXISTS(SELECT generate_series(x, 10), generate_series(y, 
 group-by
  ├── columns: x:1!null y:2
  ├── grouping columns: x:1!null
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── project-set
  │    ├── columns: x:1!null y:2 generate_series:3 generate_series:4
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── fd: (1)-->(2)
  │    ├── scan xy
  │    │    ├── columns: x:1!null y:2
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2)
  │    └── zip
- │         ├── generate_series(x:1, 10) [outer=(1), side-effects]
- │         └── generate_series(y:2, 10) [outer=(2), side-effects]
+ │         ├── generate_series(x:1, 10) [outer=(1), immutable, side-effects]
+ │         └── generate_series(y:2, 10) [outer=(2), immutable, side-effects]
  └── aggregations
       └── const-agg [as=y:2, outer=(2)]
            └── y:2
@@ -3839,10 +3839,12 @@ SELECT * FROM a WHERE (0, length((SELECT count(*) FROM uv WHERE k=u)::string)) >
 ----
 project
  ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  └── select
       ├── columns: k:1!null i:2 f:3 s:4 j:5 count_rows:8!null
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2-5,8)
       ├── group-by
@@ -3875,7 +3877,7 @@ project
       │         └── const-agg [as=j:5, outer=(5)]
       │              └── j:5
       └── filters
-           └── ((0, length(count_rows:8::STRING)) > (0, 1)) OR (i:2 = 1) [outer=(2,8)]
+           └── ((0, length(count_rows:8::STRING)) > (0, 1)) OR (i:2 = 1) [outer=(2,8), immutable]
 
 # Exists within a disjunction.
 norm expect=HoistSelectSubquery
@@ -4749,10 +4751,10 @@ SELECT generate_series(1, (SELECT v FROM uv WHERE u=x)) FROM xy
 ----
 project
  ├── columns: generate_series:5
- ├── side-effects
+ ├── immutable, side-effects
  └── project-set
       ├── columns: v:4 generate_series:5
-      ├── side-effects
+      ├── immutable, side-effects
       ├── project
       │    ├── columns: v:4
       │    └── left-join (hash)
@@ -4769,7 +4771,7 @@ project
       │         └── filters
       │              └── u:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
       └── zip
-           └── generate_series(1, v:4) [outer=(4), side-effects]
+           └── generate_series(1, v:4) [outer=(4), immutable, side-effects]
 
 # Zip correlation within EXISTS.
 norm expect=(HoistProjectSetSubquery,TryDecorrelateSemiJoin,TryDecorrelateProjectSet)
@@ -4778,12 +4780,12 @@ SELECT * FROM xy WHERE EXISTS(SELECT * FROM generate_series(1, (SELECT v FROM uv
 group-by
  ├── columns: x:1!null y:2
  ├── grouping columns: x:1!null
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── project-set
  │    ├── columns: x:1!null y:2 v:4 generate_series:5
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── fd: (1)-->(2,4)
  │    ├── project
  │    │    ├── columns: x:1!null y:2 v:4
@@ -4804,7 +4806,7 @@ group-by
  │    │         └── filters
  │    │              └── u:3 = x:1 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
  │    └── zip
- │         └── generate_series(1, v:4) [outer=(4), side-effects]
+ │         └── generate_series(1, v:4) [outer=(4), immutable, side-effects]
  └── aggregations
       └── const-agg [as=y:2, outer=(2)]
            └── y:2
@@ -4815,10 +4817,10 @@ SELECT generate_series((select y FROM xy WHERE x=k), (SELECT v FROM uv WHERE u=k
 ----
 project
  ├── columns: generate_series:10
- ├── side-effects
+ ├── immutable, side-effects
  └── project-set
       ├── columns: y:7 v:9 generate_series:10
-      ├── side-effects
+      ├── immutable, side-effects
       ├── project
       │    ├── columns: y:7 v:9
       │    └── left-join (hash)
@@ -4845,7 +4847,7 @@ project
       │         └── filters
       │              └── u:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
       └── zip
-           └── generate_series(y:7, v:9) [outer=(7,9), side-effects]
+           └── generate_series(y:7, v:9) [outer=(7,9), immutable, side-effects]
 
 # Multiple functions.
 norm expect=HoistProjectSetSubquery
@@ -4856,10 +4858,10 @@ FROM a
 ----
 project
  ├── columns: generate_series:8 information_schema._pg_expandarray:13
- ├── side-effects
+ ├── immutable, side-effects
  ├── project-set
  │    ├── columns: v:7 generate_series:8 xy.x:9 x:11 n:12
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── project
  │    │    ├── columns: v:7 xy.x:9
  │    │    └── left-join (hash)
@@ -4885,8 +4887,8 @@ project
  │    │         └── filters
  │    │              └── xy.x:9 = k:1 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
  │    └── zip
- │         ├── generate_series(1, v:7) [outer=(7), side-effects]
- │         └── information_schema._pg_expandarray(ARRAY[xy.x:9]) [outer=(9), side-effects]
+ │         ├── generate_series(1, v:7) [outer=(7), immutable, side-effects]
+ │         └── information_schema._pg_expandarray(ARRAY[xy.x:9]) [outer=(9), immutable, side-effects]
  └── projections
       └── ((x:11, n:12) AS x, n) [as=information_schema._pg_expandarray:13, outer=(11,12)]
 
@@ -4895,11 +4897,11 @@ SELECT a, generate_series(1, (SELECT a)) FROM (VALUES (1)) AS v (a)
 ----
 project
  ├── columns: a:1!null generate_series:3
- ├── side-effects
+ ├── immutable, side-effects
  ├── fd: ()-->(1)
  └── project-set
       ├── columns: column1:1!null a:2 generate_series:3
-      ├── side-effects
+      ├── immutable, side-effects
       ├── fd: ()-->(1,2)
       ├── inner-join-apply
       │    ├── columns: column1:1!null a:2
@@ -4921,18 +4923,18 @@ project
       │    │    └── (column1:1,)
       │    └── filters (true)
       └── zip
-           └── generate_series(1, a:2) [outer=(2), side-effects]
+           └── generate_series(1, a:2) [outer=(2), immutable, side-effects]
 
 norm expect=HoistProjectSetSubquery
 SELECT a, generate_series(1, (SELECT a)), generate_series(1, (SELECT a)) FROM (VALUES (1)) AS v (a)
 ----
 project
  ├── columns: a:1!null generate_series:3 generate_series:5
- ├── side-effects
+ ├── immutable, side-effects
  ├── fd: ()-->(1)
  └── project-set
       ├── columns: column1:1!null a:2 generate_series:3 a:4 generate_series:5
-      ├── side-effects
+      ├── immutable, side-effects
       ├── fd: ()-->(1,2,4)
       ├── inner-join-apply
       │    ├── columns: column1:1!null a:2 a:4
@@ -4967,8 +4969,8 @@ project
       │    │    └── (column1:1,)
       │    └── filters (true)
       └── zip
-           ├── generate_series(1, a:2) [outer=(2), side-effects]
-           └── generate_series(1, a:4) [outer=(4), side-effects]
+           ├── generate_series(1, a:2) [outer=(2), immutable, side-effects]
+           └── generate_series(1, a:4) [outer=(4), immutable, side-effects]
 
 exec-ddl
 CREATE TABLE articles (
@@ -4997,13 +4999,13 @@ limit
  ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9
  ├── internal-ordering: +8
  ├── cardinality: [0 - 10]
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: (1)
  ├── fd: (1)-->(2-9)
  ├── ordering: +8
  ├── sort
  │    ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-9)
  │    ├── ordering: +8
@@ -5011,23 +5013,23 @@ limit
  │    └── group-by
  │         ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9
  │         ├── grouping columns: id:1!null
- │         ├── side-effects
+ │         ├── immutable, side-effects
  │         ├── key: (1)
  │         ├── fd: (1)-->(2-9)
  │         ├── select
  │         │    ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9 unnest:10!null
- │         │    ├── side-effects
+ │         │    ├── immutable, side-effects
  │         │    ├── fd: ()-->(10), (1)-->(2-9)
  │         │    ├── project-set
  │         │    │    ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9 unnest:10
- │         │    │    ├── side-effects
+ │         │    │    ├── immutable, side-effects
  │         │    │    ├── fd: (1)-->(2-9)
  │         │    │    ├── scan a0
  │         │    │    │    ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9
  │         │    │    │    ├── key: (1)
  │         │    │    │    └── fd: (1)-->(2-9)
  │         │    │    └── zip
- │         │    │         └── unnest(tag_list:6) [outer=(6), side-effects]
+ │         │    │         └── unnest(tag_list:6) [outer=(6), immutable, side-effects]
  │         │    └── filters
  │         │         └── unnest:10 = 'dragons' [outer=(10), constraints=(/10: [/'dragons' - /'dragons']; tight), fd=()-->(10)]
  │         └── aggregations
@@ -5057,23 +5059,23 @@ SELECT * FROM articles, xy WHERE EXISTS(
 ----
 project
  ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9 x:10!null y:11
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: (1,10)
  ├── fd: (1)-->(2-9), (1,10)-->(2-9,11)
  └── select
       ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9 x:10!null y:11 true_agg:17!null
-      ├── side-effects
+      ├── immutable, side-effects
       ├── key: (1,10)
       ├── fd: (1)-->(2-9), (1,10)-->(2-9,11,17)
       ├── group-by
       │    ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9 x:10!null y:11 true_agg:17
       │    ├── grouping columns: id:1!null x:10!null
-      │    ├── side-effects
+      │    ├── immutable, side-effects
       │    ├── key: (1,10)
       │    ├── fd: (1)-->(2-9), (1,10)-->(2-9,11,17)
       │    ├── inner-join-apply
       │    │    ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9 x:10!null y:11 true:16
-      │    │    ├── side-effects
+      │    │    ├── immutable, side-effects
       │    │    ├── fd: (1)-->(2-9), (1,10)-->(11)
       │    │    ├── scan articles
       │    │    │    ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9
@@ -5082,7 +5084,7 @@ project
       │    │    ├── left-join-apply
       │    │    │    ├── columns: x:10!null y:11 true:16
       │    │    │    ├── outer: (1,4,6)
-      │    │    │    ├── side-effects
+      │    │    │    ├── immutable, side-effects
       │    │    │    ├── fd: (10)-->(11)
       │    │    │    ├── scan xy
       │    │    │    │    ├── columns: x:10!null y:11
@@ -5091,21 +5093,21 @@ project
       │    │    │    ├── project
       │    │    │    │    ├── columns: true:16!null
       │    │    │    │    ├── outer: (1,4,6,10)
-      │    │    │    │    ├── side-effects
+      │    │    │    │    ├── immutable, side-effects
       │    │    │    │    ├── fd: ()-->(16)
       │    │    │    │    ├── project-set
       │    │    │    │    │    ├── columns: generate_series:12 length:13 upper:14 unnest:15
       │    │    │    │    │    ├── outer: (1,4,6,10)
-      │    │    │    │    │    ├── side-effects
+      │    │    │    │    │    ├── immutable, side-effects
       │    │    │    │    │    ├── values
       │    │    │    │    │    │    ├── cardinality: [1 - 1]
       │    │    │    │    │    │    ├── key: ()
       │    │    │    │    │    │    └── ()
       │    │    │    │    │    └── zip
-      │    │    │    │    │         ├── generate_series(x:10, id:1) [outer=(1,10), side-effects]
-      │    │    │    │    │         ├── length(title:4) [outer=(4)]
-      │    │    │    │    │         ├── upper(title:4) [outer=(4)]
-      │    │    │    │    │         └── unnest(tag_list:6) [outer=(6), side-effects]
+      │    │    │    │    │         ├── generate_series(x:10, id:1) [outer=(1,10), immutable, side-effects]
+      │    │    │    │    │         ├── length(title:4) [outer=(4), immutable]
+      │    │    │    │    │         ├── upper(title:4) [outer=(4), immutable]
+      │    │    │    │    │         └── unnest(tag_list:6) [outer=(6), immutable, side-effects]
       │    │    │    │    └── projections
       │    │    │    │         └── true [as=true:16]
       │    │    │    └── filters (true)
@@ -5142,24 +5144,24 @@ SELECT id FROM articles WHERE title = ANY(
 distinct-on
  ├── columns: id:1!null
  ├── grouping columns: id:1!null
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: (1)
  └── select
       ├── columns: id:1!null title:4!null tag_list:6 upper:10 unnest:11!null generate_series:12 lower:13
-      ├── side-effects
+      ├── immutable, side-effects
       ├── fd: (1)-->(4,6), (4)==(11), (11)==(4)
       ├── project-set
       │    ├── columns: id:1!null title:4 tag_list:6 upper:10 unnest:11 generate_series:12 lower:13
-      │    ├── side-effects
+      │    ├── immutable, side-effects
       │    ├── fd: (1)-->(4,6)
       │    ├── scan articles
       │    │    ├── columns: id:1!null title:4 tag_list:6
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(4,6)
       │    └── zip
-      │         ├── upper(title:4) [outer=(4)]
-      │         ├── unnest(tag_list:6) [outer=(6), side-effects]
-      │         ├── generate_series(0, 1) [side-effects]
+      │         ├── upper(title:4) [outer=(4), immutable]
+      │         ├── unnest(tag_list:6) [outer=(6), immutable, side-effects]
+      │         ├── generate_series(0, 1) [immutable, side-effects]
       │         └── 'abc'
       └── filters
            └── title:4 = unnest:11 [outer=(4,11), constraints=(/4: (/NULL - ]; /11: (/NULL - ]), fd=(4)==(11), (11)==(4)]

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -308,7 +308,7 @@ SELECT 1::INT / 0::INT
 values
  ├── columns: "?column?":1
  ├── cardinality: [1 - 1]
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: ()
  ├── fd: ()-->(1)
  └── (1 / 0,)
@@ -820,7 +820,7 @@ SELECT now(), current_user(), current_database()
 values
  ├── columns: now:1 current_user:2 current_database:3
  ├── cardinality: [1 - 1]
- ├── side-effects
+ ├── stable, side-effects
  ├── key: ()
  ├── fd: ()-->(1-3)
  └── (now(), current_user(), current_database())

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -358,7 +358,7 @@ insert nullablecols
  │    ├── i:6 => c3:3
  │    └── i:6 => rowid:4
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── upsert-distinct-on
       ├── columns: i:6!null
       ├── grouping columns: i:6!null
@@ -420,7 +420,7 @@ upsert nullablecols
  ├── update-mapping:
  │    └── upsert_c3:22 => c3:3
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: upsert_c3:22!null i:6!null c1:15 c2:16 c3:17 rowid:18
       ├── key: (6,18)
@@ -627,7 +627,7 @@ insert xy
  │    ├── y:4 => x:1
  │    └── column5:5 => y:2
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: y:4!null column5:5
       ├── cardinality: [0 - 1]
@@ -683,7 +683,7 @@ upsert xy
  ├── update-mapping:
  │    └── upsert_y:10 => y:2
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: upsert_y:10 y:4!null column5:5 x:6 y:7
       ├── cardinality: [0 - 1]
@@ -733,7 +733,7 @@ insert xy
  │    ├── y:4 => x:1
  │    └── column5:5 => y:2
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── upsert-distinct-on
       ├── columns: y:4 column5:5
       ├── grouping columns: y:4
@@ -784,7 +784,7 @@ upsert xy
  ├── update-mapping:
  │    └── upsert_y:10 => y:2
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: upsert_y:10 y:4 column5:5 x:6 y:7
       ├── lax-key: (4,6)
@@ -840,7 +840,7 @@ upsert abc
  ├── update-mapping:
  │    └── "?column?":7 => a:1
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── left-join (hash)
       ├── columns: b:5!null "?column?":7!null "?column?":8!null a:9 b:10 c:11
       ├── key: (5)
@@ -889,7 +889,7 @@ upsert abc
  ├── update-mapping:
  │    └── upsert_c:14 => c:3
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: upsert_c:14!null b:5!null c:6!null "?column?":7 a:8 b:9 c:10
       ├── lax-key: (6-10)
@@ -1353,7 +1353,7 @@ insert a
  │    ├── "?column?":12 => s:4
  │    └── column14:14 => j:5
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: i:7!null "?column?":11!null "?column?":12!null column13:13 column14:14
       ├── cardinality: [0 - 1]
@@ -1463,7 +1463,7 @@ upsert a
  ├── update-mapping:
  │    └── upsert_f:23 => f:3
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: upsert_f:23 i:7!null "?column?":11!null "?column?":12!null column13:13 column14:14 k:15 i:16 f:17 s:18 j:19
       ├── cardinality: [0 - 1]
@@ -1721,12 +1721,12 @@ distinct-on
  ├── columns: x:1
  ├── grouping columns: column1:1
  ├── cardinality: [1 - 2]
- ├── side-effects
+ ├── volatile, side-effects
  ├── key: (1)
  └── values
       ├── columns: column1:1
       ├── cardinality: [2 - 2]
-      ├── side-effects
+      ├── volatile, side-effects
       ├── (1,)
       └── (unique_rowid(),)
 
@@ -1794,7 +1794,7 @@ insert a
  │    ├── column2:7 => s:4
  │    └── column10:10 => j:5
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: column1:6!null column2:7 column3:8 column9:9 column10:10
       ├── fd: ()-->(9,10)
@@ -1844,7 +1844,7 @@ upsert a
  ├── update-mapping:
  │    └── upsert_f:19 => f:3
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: upsert_f:19 column1:6!null column2:7 column3:8 column9:9 column10:10 k:11 i:12 f:13 s:14 j:15
       ├── cardinality: [2 - ]
@@ -1893,7 +1893,7 @@ upsert a
  ├── update-mapping:
  │    └── upsert_f:19 => f:3
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: upsert_f:19 column1:6!null column2:7!null column3:8!null column9:9 column10:10 k:11 i:12 f:13 s:14 j:15
       ├── cardinality: [1 - ]
@@ -1955,7 +1955,7 @@ insert a
  │    ├── column2:7 => s:4
  │    └── column10:10 => j:5
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null column10:10
       ├── fd: ()-->(10)
@@ -2029,7 +2029,7 @@ insert a
  │    ├── column2:7 => s:4
  │    └── column10:10 => j:5
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── upsert-distinct-on
       ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10
       ├── grouping columns: column3:8!null column9:9
@@ -2128,55 +2128,55 @@ insert a
  │    ├── column2:7 => s:4
  │    └── column10:10 => j:5
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10
-      ├── side-effects
+      ├── volatile, side-effects
       ├── fd: ()-->(10), (6)~~>(7-9)
       └── select
            ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 i:17 s:19 i:22 f:23
-           ├── side-effects
+           ├── volatile, side-effects
            ├── lax-key: (6,17,19,22,23)
            ├── fd: ()-->(10,19,22), (6)~~>(7-9)
            ├── left-join (hash)
            │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 i:17 s:19 i:22 f:23
-           │    ├── side-effects
+           │    ├── volatile, side-effects
            │    ├── lax-key: (6,17,19,22,23)
            │    ├── fd: ()-->(10,19), (6)~~>(7-9)
            │    ├── select
            │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 i:17 s:19
-           │    │    ├── side-effects
+           │    │    ├── volatile, side-effects
            │    │    ├── lax-key: (6,17,19)
            │    │    ├── fd: ()-->(10,19), (6)~~>(7-9)
            │    │    ├── left-join (hash)
            │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 i:17 s:19
-           │    │    │    ├── side-effects
+           │    │    │    ├── volatile, side-effects
            │    │    │    ├── lax-key: (6,17,19)
            │    │    │    ├── fd: ()-->(10), (6)~~>(7-9)
            │    │    │    ├── upsert-distinct-on
            │    │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10
            │    │    │    │    ├── grouping columns: column1:6
-           │    │    │    │    ├── side-effects
+           │    │    │    │    ├── volatile, side-effects
            │    │    │    │    ├── lax-key: (6)
            │    │    │    │    ├── fd: ()-->(10), (6)~~>(7-10)
            │    │    │    │    ├── select
            │    │    │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 k:11
-           │    │    │    │    │    ├── side-effects
+           │    │    │    │    │    ├── volatile, side-effects
            │    │    │    │    │    ├── fd: ()-->(10,11)
            │    │    │    │    │    ├── left-join (hash)
            │    │    │    │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 k:11
            │    │    │    │    │    │    ├── cardinality: [2 - ]
-           │    │    │    │    │    │    ├── side-effects
+           │    │    │    │    │    │    ├── volatile, side-effects
            │    │    │    │    │    │    ├── fd: ()-->(10)
            │    │    │    │    │    │    ├── project
            │    │    │    │    │    │    │    ├── columns: column10:10 column1:6 column2:7!null column3:8!null column4:9!null
            │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
-           │    │    │    │    │    │    │    ├── side-effects
+           │    │    │    │    │    │    │    ├── volatile, side-effects
            │    │    │    │    │    │    │    ├── fd: ()-->(10)
            │    │    │    │    │    │    │    ├── values
            │    │    │    │    │    │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null
            │    │    │    │    │    │    │    │    ├── cardinality: [2 - 2]
-           │    │    │    │    │    │    │    │    ├── side-effects
+           │    │    │    │    │    │    │    │    ├── volatile, side-effects
            │    │    │    │    │    │    │    │    ├── (unique_rowid(), 'foo', 1, 1.0)
            │    │    │    │    │    │    │    │    └── (unique_rowid(), 'bar', 2, 2.0)
            │    │    │    │    │    │    │    └── projections
@@ -2229,7 +2229,7 @@ insert a
  │    ├── "?column?":11 => s:4
  │    └── column13:13 => j:5
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── upsert-distinct-on
       ├── columns: i:7!null "?column?":11!null column12:12 column13:13
       ├── grouping columns: i:7!null

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -170,7 +170,7 @@ update computed
  │    ├── b_new:8 => b:2
  │    └── column9:9 => c:3
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: column9:9!null a_new:7!null b_new:8!null a:4!null b:5 c:6
       ├── key: (4)
@@ -580,14 +580,14 @@ LIMIT
 project
  ├── columns: c0:6!null
  ├── cardinality: [0 - 107]
- ├── side-effects
+ ├── stable+volatile, side-effects
  └── limit
       ├── columns: c0:6!null c1:7!null
       ├── cardinality: [0 - 107]
-      ├── side-effects
+      ├── stable+volatile, side-effects
       ├── select
       │    ├── columns: c0:6!null c1:7!null
-      │    ├── side-effects
+      │    ├── stable+volatile, side-effects
       │    ├── limit hint: 107.00
       │    ├── project
       │    │    ├── columns: c0:6!null c1:7!null
@@ -599,7 +599,7 @@ project
       │    │         ├── crdb_internal.public.zones.zone_id:1 + 1 [as=c0:6, outer=(1)]
       │    │         └── crdb_internal.public.zones.zone_id:1 + 2 [as=c1:7, outer=(1)]
       │    └── filters
-      │         └── le [outer=(6,7), side-effects, correlated-subquery]
+      │         └── le [outer=(6,7), stable+volatile, side-effects, correlated-subquery]
       │              ├── case
       │              │    ├── true
       │              │    ├── when

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -873,17 +873,17 @@ SELECT * FROM t1, t2 WHERE a = b AND age(b, TIMESTAMPTZ '2017-01-01') > INTERVAL
 ----
 inner-join (cross)
  ├── columns: a:1!null b:3!null
- ├── side-effects
+ ├── immutable, side-effects
  ├── fd: (1)==(3), (3)==(1)
  ├── scan t1
  │    └── columns: a:1
  ├── select
  │    ├── columns: b:3
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── scan t2
  │    │    └── columns: b:3
  │    └── filters
- │         └── age(b:3, '2017-01-01 00:00:00+00:00') > '1 day' [outer=(3), side-effects]
+ │         └── age(b:3, '2017-01-01 00:00:00+00:00') > '1 day' [outer=(3), immutable, side-effects]
  └── filters
       └── a:1 = b:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
 
@@ -1789,6 +1789,7 @@ SELECT * FROM (SELECT length(s), f FROM a) AS a FULL JOIN a AS a2 ON a.f=a2.f
 ----
 inner-join (hash)
  ├── columns: length:6 f:3!null k:7!null i:8 f:9!null s:10 j:11
+ ├── immutable
  ├── fd: (7)-->(8-11), (3)==(9), (9)==(3)
  ├── scan a2
  │    ├── columns: a2.k:7!null a2.i:8 a2.f:9!null a2.s:10 a2.j:11
@@ -1796,10 +1797,11 @@ inner-join (hash)
  │    └── fd: (7)-->(8-11)
  ├── project
  │    ├── columns: length:6 a.f:3!null
+ │    ├── immutable
  │    ├── scan a
  │    │    └── columns: a.f:3!null a.s:4
  │    └── projections
- │         └── length(a.s:4) [as=length:6, outer=(4)]
+ │         └── length(a.s:4) [as=length:6, outer=(4), immutable]
  └── filters
       └── a.f:3 = a2.f:9 [outer=(3,9), constraints=(/3: (/NULL - ]; /9: (/NULL - ]), fd=(3)==(9), (9)==(3)]
 
@@ -2917,6 +2919,7 @@ SELECT * FROM xy FULL JOIN uv ON (substring('', ')') = '') = (u > 0)
 ----
 full-join (cross)
  ├── columns: x:1 y:2 u:3 v:4
+ ├── immutable
  ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4)
  ├── scan xy
@@ -2928,4 +2931,4 @@ full-join (cross)
  │    ├── key: (3)
  │    └── fd: (3)-->(4)
  └── filters
-      └── (substring('', ')') = '') = (u:3 > 0) [outer=(3)]
+      └── (substring('', ')') = '') = (u:3 > 0) [outer=(3), immutable]

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -98,7 +98,7 @@ SELECT * FROM (SELECT * FROM a LIMIT 0) LIMIT -1
 limit
  ├── columns: k:1!null i:2!null f:3!null s:4!null j:5!null
  ├── cardinality: [0 - 0]
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: ()
  ├── fd: ()-->(1-5)
  ├── values
@@ -275,7 +275,7 @@ SELECT * FROM a LIMIT -1
 limit
  ├── columns: k:1!null i:2 f:3 s:4 j:5
  ├── cardinality: [0 - 0]
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: ()
  ├── fd: ()-->(1-5)
  ├── scan a
@@ -1055,7 +1055,7 @@ SELECT * FROM ab LEFT JOIN uv ON a = u LIMIT -1
 limit
  ├── columns: a:1!null b:2 u:3 v:4
  ├── cardinality: [0 - 0]
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: ()
  ├── fd: ()-->(1-4)
  ├── left-join (hash)

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -494,6 +494,7 @@ SELECT (least(tup, (1,2))).a FROM (VALUES (((1,2) AS a,b), ((3,4) AS a,b))) v(tu
 project
  ├── columns: a:3
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(3)
  ├── values
@@ -503,7 +504,7 @@ project
  │    ├── fd: ()-->(1)
  │    └── (((1, 2) AS a, b),)
  └── projections
-      └── (least(column1:1, (1, 2))).a [as=a:3, outer=(1)]
+      └── (least(column1:1, (1, 2))).a [as=a:3, outer=(1), immutable]
 
 # --------------------------------------------------
 # PushColumnRemappingIntoValues

--- a/pkg/sql/opt/norm/testdata/rules/project_set
+++ b/pkg/sql/opt/norm/testdata/rules/project_set
@@ -214,10 +214,10 @@ SELECT unnest(x) FROM unnest(ARRAY[[1,2,3],[4,5],[6]]) AS x
 ----
 project
  ├── columns: unnest:2
- ├── side-effects
+ ├── immutable, side-effects
  └── project-set
       ├── columns: unnest:1!null unnest:2
-      ├── side-effects
+      ├── immutable, side-effects
       ├── values
       │    ├── columns: unnest:1!null
       │    ├── cardinality: [3 - 3]
@@ -225,7 +225,7 @@ project
       │    ├── (ARRAY[4,5],)
       │    └── (ARRAY[6],)
       └── zip
-           └── unnest(unnest:1) [outer=(1), side-effects]
+           └── unnest(unnest:1) [outer=(1), immutable, side-effects]
 
 # No-op case - an unnest with multiple inputs is not matched.
 norm expect-not=ConvertZipArraysToValues
@@ -233,16 +233,16 @@ SELECT unnest(ARRAY[1,2,3], ARRAY[4,5,6])
 ----
 project
  ├── columns: unnest:3
- ├── side-effects
+ ├── immutable, side-effects
  ├── project-set
  │    ├── columns: unnest:1 unnest:2
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── values
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── key: ()
  │    │    └── ()
  │    └── zip
- │         └── unnest(ARRAY[1,2,3], ARRAY[4,5,6]) [side-effects]
+ │         └── unnest(ARRAY[1,2,3], ARRAY[4,5,6]) [immutable, side-effects]
  └── projections
       └── ((unnest:1, unnest:2) AS unnest, unnest) [as=unnest:3, outer=(1,2)]
 
@@ -252,17 +252,17 @@ SELECT unnest(ARRAY[1,2,3]), unnest(ARRAY[1,2,3], ARRAY[4,5,6])
 ----
 project
  ├── columns: unnest:1 unnest:4
- ├── side-effects
+ ├── immutable, side-effects
  ├── project-set
  │    ├── columns: unnest:1 unnest:2 unnest:3
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── values
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── key: ()
  │    │    └── ()
  │    └── zip
- │         ├── unnest(ARRAY[1,2,3]) [side-effects]
- │         └── unnest(ARRAY[1,2,3], ARRAY[4,5,6]) [side-effects]
+ │         ├── unnest(ARRAY[1,2,3]) [immutable, side-effects]
+ │         └── unnest(ARRAY[1,2,3], ARRAY[4,5,6]) [immutable, side-effects]
  └── projections
       └── ((unnest:2, unnest:3) AS unnest, unnest) [as=unnest:4, outer=(2,3)]
 
@@ -272,13 +272,13 @@ SELECT unnest((SELECT array_agg(y) FROM xy))
 ----
 project-set
  ├── columns: unnest:5
- ├── side-effects
+ ├── immutable, side-effects
  ├── values
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
  │    └── ()
  └── zip
-      └── function: unnest [side-effects, subquery]
+      └── function: unnest [immutable, side-effects, subquery]
            └── subquery
                 └── scalar-group-by
                      ├── columns: array_agg:4
@@ -297,11 +297,11 @@ SELECT json_array_elements(j) FROM xy
 ----
 project
  ├── columns: json_array_elements:4
- ├── side-effects
+ ├── immutable, side-effects
  └── project-set
       ├── columns: j:3 json_array_elements:4
-      ├── side-effects
+      ├── immutable, side-effects
       ├── scan xy
       │    └── columns: j:3
       └── zip
-           └── json_array_elements(j:3) [outer=(3), side-effects]
+           └── json_array_elements(j:3) [outer=(3), immutable, side-effects]

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -65,12 +65,13 @@ SELECT k+length(s) AS r FROM (SELECT i, k, s || 'foo' AS s FROM a) a
 ----
 project
  ├── columns: r:6
+ ├── immutable
  ├── scan a
  │    ├── columns: k:1!null a.s:4
  │    ├── key: (1)
  │    └── fd: (1)-->(4)
  └── projections
-      └── k:1 + length(a.s:4 || 'foo') [as=r:6, outer=(1,4)]
+      └── k:1 + length(a.s:4 || 'foo') [as=r:6, outer=(1,4), immutable]
 
 # Discard non-computed columns and keep computed column.
 norm expect=PruneProjectCols
@@ -78,10 +79,12 @@ SELECT l, l*2, k FROM (SELECT length(s) l, * FROM a) a
 ----
 project
  ├── columns: l:5 "?column?":6 k:1!null
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(5), (5)-->(6)
  ├── project
  │    ├── columns: l:5 k:1!null
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(5)
  │    ├── scan a
@@ -89,7 +92,7 @@ project
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(4)
  │    └── projections
- │         └── length(s:4) [as=l:5, outer=(4)]
+ │         └── length(s:4) [as=l:5, outer=(4), immutable]
  └── projections
       └── l:5 * 2 [as="?column?":6, outer=(5)]
 
@@ -99,10 +102,12 @@ SELECT l*l AS r, k FROM (SELECT k, length(s) l, i FROM a) a
 ----
 project
  ├── columns: r:6 k:1!null
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(6)
  ├── project
  │    ├── columns: l:5 k:1!null
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(5)
  │    ├── scan a
@@ -110,7 +115,7 @@ project
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(4)
  │    └── projections
- │         └── length(s:4) [as=l:5, outer=(4)]
+ │         └── length(s:4) [as=l:5, outer=(4), immutable]
  └── projections
       └── l:5 * l:5 [as=r:6, outer=(5)]
 
@@ -1565,18 +1570,18 @@ SELECT a, b, generate_series(c, 10) FROM abcde
 ----
 project
  ├── columns: a:1!null b:2 generate_series:6
- ├── side-effects
+ ├── immutable, side-effects
  ├── fd: (1)-->(2)
  └── project-set
       ├── columns: a:1!null b:2 c:3 generate_series:6
-      ├── side-effects
+      ├── immutable, side-effects
       ├── fd: (1)-->(2,3), (2,3)~~>(1)
       ├── scan abcde
       │    ├── columns: a:1!null b:2 c:3
       │    ├── key: (1)
       │    └── fd: (1)-->(2,3), (2,3)~~>(1)
       └── zip
-           └── generate_series(c:3, 10) [outer=(3), side-effects]
+           └── generate_series(c:3, 10) [outer=(3), immutable, side-effects]
 
 norm expect=PruneProjectSetCols
 SELECT k FROM a WHERE EXISTS(SELECT * FROM ROWS FROM (generate_series(i, k), length(s)))
@@ -1584,19 +1589,19 @@ SELECT k FROM a WHERE EXISTS(SELECT * FROM ROWS FROM (generate_series(i, k), len
 distinct-on
  ├── columns: k:1!null
  ├── grouping columns: k:1!null
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: (1)
  └── project-set
       ├── columns: k:1!null i:2 s:4 generate_series:5 length:6
-      ├── side-effects
+      ├── immutable, side-effects
       ├── fd: (1)-->(2,4)
       ├── scan a
       │    ├── columns: k:1!null i:2 s:4
       │    ├── key: (1)
       │    └── fd: (1)-->(2,4)
       └── zip
-           ├── generate_series(i:2, k:1) [outer=(1,2), side-effects]
-           └── length(s:4) [outer=(4)]
+           ├── generate_series(i:2, k:1) [outer=(1,2), immutable, side-effects]
+           └── length(s:4) [outer=(4), immutable]
 
 # --------------------------------------------------
 # PruneWindowInputCols
@@ -1728,9 +1733,11 @@ SELECT round(avg(k) OVER (PARTITION BY f ORDER BY s)) FROM a ORDER BY 1
 ----
 sort
  ├── columns: round:6
+ ├── immutable
  ├── ordering: +6
  └── project
       ├── columns: round:6
+      ├── immutable
       ├── window partition=(3) ordering=+4 opt(3)
       │    ├── columns: k:1!null f:3 s:4 avg:5
       │    ├── key: (1)
@@ -1743,7 +1750,7 @@ sort
       │         └── avg [as=avg:5, outer=(1)]
       │              └── k:1
       └── projections
-           └── round(avg:5) [as=round:6, outer=(5)]
+           └── round(avg:5) [as=round:6, outer=(5), immutable]
 
 norm expect=(PruneWindowInputCols,PruneWindowOutputCols) format=show-all
 SELECT x FROM (SELECT ntile(i) OVER () x, ntile(f::int) OVER () y FROM a)
@@ -1780,7 +1787,7 @@ delete a
  ├── columns: <none>
  ├── fetch columns: k:5
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── scan a
       ├── columns: k:5!null
       └── key: (5)
@@ -1793,7 +1800,7 @@ delete a
  ├── columns: <none>
  ├── fetch columns: k:5
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── limit
       ├── columns: k:5!null column9:9!null
       ├── internal-ordering: +9
@@ -1832,7 +1839,7 @@ delete abcde
  ├── columns: <none>
  ├── fetch columns: a:6 b:7 c:8
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── select
       ├── columns: a:6!null b:7 c:8
       ├── key: (6)
@@ -1852,7 +1859,7 @@ delete mutation
  ├── columns: <none>
  ├── fetch columns: a:6 b:7 d:9 e:10
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── scan mutation
       ├── columns: a:6!null b:7 d:9 e:10
       ├── key: (6)
@@ -1864,7 +1871,7 @@ DELETE FROM a RETURNING k, s
 delete a
  ├── columns: k:1!null s:4
  ├── fetch columns: k:5 s:8
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: (1)
  ├── fd: (1)-->(4)
  └── scan a
@@ -1882,7 +1889,7 @@ update "family"
  ├── update-mapping:
  │    └── c:8 => b:2
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── select
       ├── columns: a:6!null b:7 c:8
       ├── key: (6)
@@ -1904,7 +1911,7 @@ update "family"
  ├── update-mapping:
  │    └── a_new:11 => a:1
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: a_new:11!null a:6!null b:7 c:8 d:9 e:10
       ├── key: (6)
@@ -1928,13 +1935,13 @@ UPDATE family SET c=c+1 RETURNING b
 ----
 project
  ├── columns: b:2
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── update "family"
       ├── columns: a:1!null b:2
       ├── fetch columns: a:6 b:7 c:8 d:9
       ├── update-mapping:
       │    └── c_new:11 => c:3
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: (1)
       ├── fd: (1)-->(2)
       └── project
@@ -1964,7 +1971,7 @@ upsert a
  ├── update-mapping:
  │    └── upsert_i:15 => i:2
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: upsert_i:15 column1:5!null column2:6!null column7:7 column8:8 k:9 i:10 f:11 s:12
       ├── cardinality: [1 - 1]
@@ -2018,7 +2025,7 @@ upsert a
  │    ├── upsert_f:16 => f:3
  │    └── upsert_s:17 => s:4
  ├── cardinality: [1 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(1-4)
  └── project
@@ -2072,7 +2079,7 @@ upsert "family"
  ├── update-mapping:
  │    └── column2:7 => b:2
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── left-join (cross)
       ├── columns: column1:6!null column2:7!null column8:8 a:9 b:10
       ├── cardinality: [1 - 1]
@@ -2103,7 +2110,7 @@ INSERT INTO family VALUES (1, 2, 3, 4, 5) ON CONFLICT (a) DO UPDATE SET c = 10 R
 project
  ├── columns: e:5
  ├── cardinality: [1 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(5)
  └── upsert "family"
@@ -2122,7 +2129,7 @@ project
       │    ├── upsert_a:17 => a:1
       │    └── upsert_e:21 => e:5
       ├── cardinality: [1 - 1]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: ()
       ├── fd: ()-->(1,5)
       └── project
@@ -2176,7 +2183,7 @@ upsert "family"
  ├── update-mapping:
  │    └── upsert_d:20 => d:4
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: upsert_d:20!null column1:6!null column2:7!null column3:8!null column4:9!null column10:10 a:11 c:13 d:14
       ├── cardinality: [1 - 1]
@@ -2225,7 +2232,7 @@ upsert mutation
  │    ├── upsert_b:17 => b:2
  │    └── column9:9 => d:4
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: upsert_b:17!null column1:6!null column2:7!null column3:8!null column9:9 a:10 b:11 c:12 d:13 e:14
       ├── cardinality: [1 - 1]
@@ -2285,13 +2292,13 @@ UPDATE returning_test SET a = a + 1 RETURNING *
 ----
 project
  ├── columns: a:1 b:2 c:3 d:4 e:5 f:6 g:7
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── update returning_test
       ├── columns: a:1 b:2 c:3 d:4 e:5 f:6 g:7 rowid:8!null
       ├── fetch columns: a:9 b:10 c:11 d:12 e:13 f:14 g:15 rowid:16
       ├── update-mapping:
       │    └── a_new:17 => a:1
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: (8)
       ├── fd: (8)-->(1-7)
       └── project
@@ -2312,7 +2319,7 @@ UPDATE returning_test SET d = a + d RETURNING a, d
 ----
 project
  ├── columns: a:1 d:4
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── lax-key: (1,4)
  ├── fd: (1)~~>(4)
  └── update returning_test
@@ -2320,7 +2327,7 @@ project
       ├── fetch columns: a:9 d:12 e:13 f:14 g:15 rowid:16
       ├── update-mapping:
       │    └── d_new:17 => d:4
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: (8)
       ├── fd: (8)-->(1,4), (1)~~>(4,8)
       └── project
@@ -2340,13 +2347,13 @@ UPDATE returning_test SET a = a + d RETURNING a
 ----
 project
  ├── columns: a:1
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── update returning_test
       ├── columns: a:1 rowid:8!null
       ├── fetch columns: a:9 rowid:16
       ├── update-mapping:
       │    └── a_new:17 => a:1
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: (8)
       ├── fd: (8)-->(1)
       └── project
@@ -2366,7 +2373,7 @@ UPDATE returning_test SET (b, a) = (a, a + b) RETURNING a, b, c
 ----
 project
  ├── columns: a:1 b:2 c:3
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── lax-key: (1-3)
  ├── fd: (2)~~>(1,3)
  └── update returning_test
@@ -2375,7 +2382,7 @@ project
       ├── update-mapping:
       │    ├── a_new:17 => a:1
       │    └── a:9 => b:2
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: (8)
       ├── fd: (8)-->(1-3), (2)~~>(1,3,8)
       └── project
@@ -2398,16 +2405,16 @@ SELECT a FROM [SELECT a, b FROM [UPDATE returning_test SET a = a + 1 RETURNING a
 ----
 with &1
  ├── columns: a:21
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── project
  │    ├── columns: returning_test.a:1 returning_test.b:2 returning_test.c:3
- │    ├── side-effects, mutations
+ │    ├── volatile, side-effects, mutations
  │    └── update returning_test
  │         ├── columns: returning_test.a:1 returning_test.b:2 returning_test.c:3 rowid:8!null
  │         ├── fetch columns: returning_test.a:9 returning_test.b:10 returning_test.c:11 rowid:16
  │         ├── update-mapping:
  │         │    └── a_new:17 => returning_test.a:1
- │         ├── side-effects, mutations
+ │         ├── volatile, side-effects, mutations
  │         ├── key: (8)
  │         ├── fd: (8)-->(1-3)
  │         └── project
@@ -2438,16 +2445,16 @@ SELECT a FROM [SELECT a, b FROM [UPDATE returning_test SET a = a + 1 RETURNING a
 ----
 with &1
  ├── columns: a:21!null
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── project
  │    ├── columns: returning_test.a:1 returning_test.b:2 returning_test.c:3
- │    ├── side-effects, mutations
+ │    ├── volatile, side-effects, mutations
  │    └── update returning_test
  │         ├── columns: returning_test.a:1 returning_test.b:2 returning_test.c:3 rowid:8!null
  │         ├── fetch columns: returning_test.a:9 returning_test.b:10 returning_test.c:11 rowid:16
  │         ├── update-mapping:
  │         │    └── a_new:17 => returning_test.a:1
- │         ├── side-effects, mutations
+ │         ├── volatile, side-effects, mutations
  │         ├── key: (8)
  │         ├── fd: (8)-->(1-3)
  │         └── project
@@ -2483,17 +2490,17 @@ FROM
 ----
 with &2
  ├── columns: a:9 b:10 a:31!null b:32
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── fd: (9)~~>(10)
  ├── project
  │    ├── columns: returning_test.a:11 returning_test.b:12 returning_test.c:13
- │    ├── side-effects, mutations
+ │    ├── volatile, side-effects, mutations
  │    └── update returning_test
  │         ├── columns: returning_test.a:11 returning_test.b:12 returning_test.c:13 rowid:18!null
  │         ├── fetch columns: returning_test.a:19 returning_test.b:20 returning_test.c:21 rowid:26
  │         ├── update-mapping:
  │         │    └── a_new:27 => returning_test.a:11
- │         ├── side-effects, mutations
+ │         ├── volatile, side-effects, mutations
  │         ├── key: (18)
  │         ├── fd: (18)-->(11-13)
  │         └── project
@@ -2543,7 +2550,7 @@ INSERT INTO returning_test VALUES (1, 2, 'c') ON CONFLICT (a) DO UPDATE SET a = 
 project
  ├── columns: a:1 b:2 c:3
  ├── cardinality: [1 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(1-3)
  └── upsert returning_test
@@ -2567,25 +2574,25 @@ project
       │    ├── upsert_c:25 => c:3
       │    └── upsert_rowid:30 => rowid:8
       ├── cardinality: [1 - 1]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: ()
       ├── fd: ()-->(1-3,8)
       └── project
            ├── columns: upsert_a:23 upsert_b:24 upsert_c:25 upsert_rowid:30 column1:9!null column2:10!null column3:11!null column12:12 column13:13 a:14 b:15 c:16 rowid:21
            ├── cardinality: [1 - 1]
-           ├── side-effects
+           ├── volatile, side-effects
            ├── key: ()
            ├── fd: ()-->(9-16,21,23-25,30)
            ├── left-join (cross)
            │    ├── columns: column1:9!null column2:10!null column3:11!null column12:12 column13:13 a:14 b:15 c:16 rowid:21
            │    ├── cardinality: [1 - 1]
-           │    ├── side-effects
+           │    ├── volatile, side-effects
            │    ├── key: ()
            │    ├── fd: ()-->(9-16,21)
            │    ├── values
            │    │    ├── columns: column1:9!null column2:10!null column3:11!null column12:12 column13:13
            │    │    ├── cardinality: [1 - 1]
-           │    │    ├── side-effects
+           │    │    ├── volatile, side-effects
            │    │    ├── key: ()
            │    │    ├── fd: ()-->(9-13)
            │    │    └── (1, 2, 'c', CAST(NULL AS INT8), unique_rowid())
@@ -2612,13 +2619,13 @@ DELETE FROM returning_test WHERE a < b + d RETURNING a, b, d
 ----
 project
  ├── columns: a:1!null b:2 d:4
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: (1)
  ├── fd: (1)-->(2,4)
  └── delete returning_test
       ├── columns: a:1!null b:2 d:4 rowid:8!null
       ├── fetch columns: a:9 b:10 d:12 rowid:16
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: (8)
       ├── fd: (8)-->(1,2,4), (1)-->(2,4,8)
       └── select
@@ -2638,7 +2645,7 @@ UPSERT INTO returning_test (a, b, c) VALUES (1, 2, 'c') RETURNING a, b, c, d
 project
  ├── columns: a:1!null b:2!null c:3!null d:4
  ├── cardinality: [1 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(1-4)
  └── upsert returning_test
@@ -2665,19 +2672,19 @@ project
       │    ├── upsert_d:22 => d:4
       │    └── upsert_rowid:26 => rowid:8
       ├── cardinality: [1 - 1]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: ()
       ├── fd: ()-->(1-4,8)
       └── project
            ├── columns: upsert_d:22 upsert_rowid:26 column1:9!null column2:10!null column3:11!null column12:12 column13:13 a:14 b:15 c:16 d:17 rowid:21
            ├── cardinality: [1 - 1]
-           ├── side-effects
+           ├── volatile, side-effects
            ├── key: ()
            ├── fd: ()-->(9-17,21,22,26)
            ├── left-join (hash)
            │    ├── columns: column1:9!null column2:10!null column3:11!null column12:12 column13:13 a:14 b:15 c:16 d:17 rowid:21
            │    ├── cardinality: [1 - 1]
-           │    ├── side-effects
+           │    ├── volatile, side-effects
            │    ├── key: ()
            │    ├── fd: ()-->(9-17,21)
            │    ├── ensure-upsert-distinct-on
@@ -2685,13 +2692,13 @@ project
            │    │    ├── grouping columns: column13:13
            │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
            │    │    ├── cardinality: [1 - 1]
-           │    │    ├── side-effects
+           │    │    ├── volatile, side-effects
            │    │    ├── key: ()
            │    │    ├── fd: ()-->(9-13)
            │    │    ├── values
            │    │    │    ├── columns: column1:9!null column2:10!null column3:11!null column12:12 column13:13
            │    │    │    ├── cardinality: [1 - 1]
-           │    │    │    ├── side-effects
+           │    │    │    ├── volatile, side-effects
            │    │    │    ├── key: ()
            │    │    │    ├── fd: ()-->(9-13)
            │    │    │    └── (1, 2, 'c', CAST(NULL AS INT8), unique_rowid())
@@ -2732,7 +2739,7 @@ update abcde
  ├── update-mapping:
  │    ├── "family".b:12 => abcde.b:2
  │    └── "family".c:13 => abcde.c:3
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: (1)
  ├── fd: (1)-->(12,13)
  └── inner-join (hash)

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -223,10 +223,11 @@ SELECT s NOT IN ('foo', s || 'foo', 'bar', length(s)::string, NULL) AS r FROM a
 ----
 project
  ├── columns: r:7
+ ├── immutable
  ├── scan a
  │    └── columns: s:4
  └── projections
-      └── s:4 NOT IN ('foo', s:4 || 'foo', 'bar', length(s:4)::STRING, NULL) [as=r:7, outer=(4)]
+      └── s:4 NOT IN ('foo', s:4 || 'foo', 'bar', length(s:4)::STRING, NULL) [as=r:7, outer=(4), immutable]
 
 # Regression test #36031.
 norm expect-not=NormalizeInConst
@@ -1504,39 +1505,39 @@ SELECT ARRAY(SELECT generate_series(1, a.k) ORDER BY 1 DESC) FROM a
 ----
 project
  ├── columns: array:9
- ├── side-effects
+ ├── immutable, side-effects
  ├── group-by
  │    ├── columns: k:1!null canary:10 array_agg:11
  │    ├── grouping columns: k:1!null
  │    ├── internal-ordering: -7
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── key: (1)
  │    ├── fd: (1)-->(10,11)
  │    ├── sort
  │    │    ├── columns: k:1!null generate_series:7 canary:10
- │    │    ├── side-effects
+ │    │    ├── immutable, side-effects
  │    │    ├── ordering: -7
  │    │    └── left-join-apply
  │    │         ├── columns: k:1!null generate_series:7 canary:10
- │    │         ├── side-effects
+ │    │         ├── immutable, side-effects
  │    │         ├── scan a
  │    │         │    ├── columns: k:1!null
  │    │         │    └── key: (1)
  │    │         ├── project
  │    │         │    ├── columns: canary:10!null generate_series:7
  │    │         │    ├── outer: (1)
- │    │         │    ├── side-effects
+ │    │         │    ├── immutable, side-effects
  │    │         │    ├── fd: ()-->(10)
  │    │         │    ├── project-set
  │    │         │    │    ├── columns: generate_series:7
  │    │         │    │    ├── outer: (1)
- │    │         │    │    ├── side-effects
+ │    │         │    │    ├── immutable, side-effects
  │    │         │    │    ├── values
  │    │         │    │    │    ├── cardinality: [1 - 1]
  │    │         │    │    │    ├── key: ()
  │    │         │    │    │    └── ()
  │    │         │    │    └── zip
- │    │         │    │         └── generate_series(1, k:1) [outer=(1), side-effects]
+ │    │         │    │         └── generate_series(1, k:1) [outer=(1), immutable, side-effects]
  │    │         │    └── projections
  │    │         │         └── true [as=canary:10]
  │    │         └── filters (true)

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -1418,7 +1418,7 @@ SELECT k, g FROM a, generate_series(0, a.k, 10) AS g WHERE k = 1
 ----
 project-set
  ├── columns: k:1!null g:6
- ├── side-effects
+ ├── immutable, side-effects
  ├── fd: ()-->(1)
  ├── select
  │    ├── columns: k:1!null
@@ -1431,7 +1431,7 @@ project-set
  │    └── filters
  │         └── k:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
  └── zip
-      └── generate_series(0, k:1, 10) [outer=(1), side-effects]
+      └── generate_series(0, k:1, 10) [outer=(1), immutable, side-effects]
 
 # Make sure that filters aren't pushed down when not bound by the input, so PushSelectIntoProjectSet is not triggered.
 norm expect-not=PushSelectIntoProjectSet
@@ -1439,15 +1439,15 @@ SELECT k, g FROM a, generate_series(0, a.k, 10) AS g WHERE g > 1
 ----
 select
  ├── columns: k:1!null g:6!null
- ├── side-effects
+ ├── immutable, side-effects
  ├── project-set
  │    ├── columns: k:1!null generate_series:6
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── scan a
  │    │    ├── columns: k:1!null
  │    │    └── key: (1)
  │    └── zip
- │         └── generate_series(0, k:1, 10) [outer=(1), side-effects]
+ │         └── generate_series(0, k:1, 10) [outer=(1), immutable, side-effects]
  └── filters
       └── generate_series:6 > 1 [outer=(6), constraints=(/6: [/2 - ]; tight)]
 
@@ -1457,11 +1457,11 @@ SELECT k, g FROM a, generate_series(0, a.k, 10) AS g WHERE g > 1 AND k = 1
 ----
 select
  ├── columns: k:1!null g:6!null
- ├── side-effects
+ ├── immutable, side-effects
  ├── fd: ()-->(1)
  ├── project-set
  │    ├── columns: k:1!null generate_series:6
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── fd: ()-->(1)
  │    ├── select
  │    │    ├── columns: k:1!null
@@ -1474,7 +1474,7 @@ select
  │    │    └── filters
  │    │         └── k:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
  │    └── zip
- │         └── generate_series(0, k:1, 10) [outer=(1), side-effects]
+ │         └── generate_series(0, k:1, 10) [outer=(1), immutable, side-effects]
  └── filters
       └── generate_series:6 > 1 [outer=(6), constraints=(/6: [/2 - ]; tight)]
 
@@ -1664,27 +1664,27 @@ union
  ├── columns: k:11!null
  ├── left columns: b.k:1
  ├── right columns: a.i:7
- ├── side-effects
+ ├── volatile, side-effects
  ├── key: (11)
  ├── select
  │    ├── columns: b.k:1!null
  │    ├── cardinality: [0 - 8]
- │    ├── side-effects
+ │    ├── volatile, side-effects
  │    ├── key: (1)
  │    ├── scan b
  │    │    ├── columns: b.k:1!null
  │    │    └── key: (1)
  │    └── filters
  │         ├── (b.k:1 < 10) AND (b.k:1 > 1) [outer=(1), constraints=(/1: [/2 - /9]; tight)]
- │         └── random() < 0.5 [side-effects]
+ │         └── random() < 0.5 [volatile, side-effects]
  └── select
       ├── columns: a.i:7!null
-      ├── side-effects
+      ├── volatile, side-effects
       ├── scan a
       │    └── columns: a.i:7
       └── filters
            ├── (a.i:7 < 10) AND (a.i:7 > 1) [outer=(7), constraints=(/7: [/2 - /9]; tight)]
-           └── random() < 0.5 [side-effects]
+           └── random() < 0.5 [volatile, side-effects]
 
 norm expect=PushFilterIntoSetOp
 SELECT * FROM
@@ -1749,15 +1749,15 @@ union-all
  ├── columns: k:23!null
  ├── left columns: k:11
  ├── right columns: k:22
- ├── side-effects
+ ├── volatile, side-effects
  ├── union-all
  │    ├── columns: k:11!null
  │    ├── left columns: b.k:1
  │    ├── right columns: b.k:6
- │    ├── side-effects
+ │    ├── volatile, side-effects
  │    ├── select
  │    │    ├── columns: b.k:1!null
- │    │    ├── side-effects
+ │    │    ├── volatile, side-effects
  │    │    ├── key: (1)
  │    │    ├── scan b
  │    │    │    ├── columns: b.k:1!null
@@ -1775,10 +1775,10 @@ union-all
  │    │         │         │    └── fd: (24)-->(25-28)
  │    │         │         └── filters
  │    │         │              └── a.k:24 = 1 [outer=(24), constraints=(/24: [/1 - /1]; tight), fd=()-->(24)]
- │    │         └── random() < 0.5 [side-effects]
+ │    │         └── random() < 0.5 [volatile, side-effects]
  │    └── select
  │         ├── columns: b.k:6!null
- │         ├── side-effects
+ │         ├── volatile, side-effects
  │         ├── key: (6)
  │         ├── scan b
  │         │    ├── columns: b.k:6!null
@@ -1796,15 +1796,15 @@ union-all
  │              │         │    └── fd: (24)-->(25-28)
  │              │         └── filters
  │              │              └── a.k:24 = 1 [outer=(24), constraints=(/24: [/1 - /1]; tight), fd=()-->(24)]
- │              └── random() < 0.5 [side-effects]
+ │              └── random() < 0.5 [volatile, side-effects]
  └── union-all
       ├── columns: k:22!null
       ├── left columns: b.k:12
       ├── right columns: b.k:17
-      ├── side-effects
+      ├── volatile, side-effects
       ├── select
       │    ├── columns: b.k:12!null
-      │    ├── side-effects
+      │    ├── volatile, side-effects
       │    ├── key: (12)
       │    ├── scan b
       │    │    ├── columns: b.k:12!null
@@ -1822,10 +1822,10 @@ union-all
       │         │         │    └── fd: (24)-->(25-28)
       │         │         └── filters
       │         │              └── a.k:24 = 1 [outer=(24), constraints=(/24: [/1 - /1]; tight), fd=()-->(24)]
-      │         └── random() < 0.5 [side-effects]
+      │         └── random() < 0.5 [volatile, side-effects]
       └── select
            ├── columns: b.k:17!null
-           ├── side-effects
+           ├── volatile, side-effects
            ├── key: (17)
            ├── scan b
            │    ├── columns: b.k:17!null
@@ -1843,7 +1843,7 @@ union-all
                 │         │    └── fd: (24)-->(25-28)
                 │         └── filters
                 │              └── a.k:24 = 1 [outer=(24), constraints=(/24: [/1 - /1]; tight), fd=()-->(24)]
-                └── random() < 0.5 [side-effects]
+                └── random() < 0.5 [volatile, side-effects]
 
 # No-op case because the filter references outer columns.
 norm expect-not=PushFilterIntoSetOp
@@ -1898,7 +1898,7 @@ except
  ├── left columns: column1:1!null column2:2!null
  ├── right columns: column1:3 column2:4
  ├── cardinality: [0 - 1]
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: (1,2)
  ├── values
  │    ├── columns: column1:1!null column2:2!null
@@ -1909,7 +1909,7 @@ except
  └── select
       ├── columns: column1:3!null column2:4!null
       ├── cardinality: [0 - 1]
-      ├── side-effects
+      ├── immutable, side-effects
       ├── key: ()
       ├── fd: ()-->(3,4)
       ├── values
@@ -1919,7 +1919,7 @@ except
       │    ├── fd: ()-->(3,4)
       │    └── (0, 1)
       └── filters
-           └── (1 / 0) > 0 [side-effects]
+           └── (1 / 0) > 0 [immutable, side-effects]
 
 norm
 SELECT * FROM ((values (1.0::decimal)) EXCEPT (values (1.00::decimal))) WHERE column1::string != '1.00';

--- a/pkg/sql/opt/norm/testdata/rules/side_effects
+++ b/pkg/sql/opt/norm/testdata/rules/side_effects
@@ -18,13 +18,13 @@ SELECT * FROM a ORDER BY length('foo'), random()+1.0
 ----
 sort
  ├── columns: k:1!null i:2 f:3 s:4 j:5  [hidden: column7:7]
- ├── side-effects
+ ├── volatile, side-effects
  ├── key: (1)
  ├── fd: (1)-->(2-5,7)
  ├── ordering: +7
  └── project
       ├── columns: column7:7 k:1!null i:2 f:3 s:4 j:5
-      ├── side-effects
+      ├── volatile, side-effects
       ├── key: (1)
       ├── fd: (1)-->(2-5,7)
       ├── scan a
@@ -32,7 +32,7 @@ sort
       │    ├── key: (1)
       │    └── fd: (1)-->(2-5)
       └── projections
-           └── random() + 1.0 [as=column7:7, side-effects]
+           └── random() + 1.0 [as=column7:7, volatile, side-effects]
 
 # Don't allow GROUP BY column to be eliminated if it has a side effect.
 norm
@@ -40,16 +40,16 @@ SELECT avg(f) FROM a WHERE i=5 GROUP BY i+(random()*10)::int, i+1
 ----
 project
  ├── columns: avg:6
- ├── side-effects
+ ├── volatile, side-effects
  └── group-by
       ├── columns: avg:6 column7:7
       ├── grouping columns: column7:7
-      ├── side-effects
+      ├── volatile, side-effects
       ├── key: (7)
       ├── fd: (7)-->(6)
       ├── project
       │    ├── columns: column7:7 f:3
-      │    ├── side-effects
+      │    ├── volatile, side-effects
       │    ├── select
       │    │    ├── columns: i:2!null f:3
       │    │    ├── fd: ()-->(2)
@@ -58,7 +58,7 @@ project
       │    │    └── filters
       │    │         └── i:2 = 5 [outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
       │    └── projections
-      │         └── i:2 + (random() * 10.0)::INT8 [as=column7:7, outer=(2), side-effects]
+      │         └── i:2 + (random() * 10.0)::INT8 [as=column7:7, outer=(2), volatile, side-effects]
       └── aggregations
            └── avg [as=avg:6, outer=(3)]
                 └── f:3
@@ -76,12 +76,12 @@ SELECT * FROM a INNER JOIN xy ON k=x WHERE k=random()
 ----
 inner-join (hash)
  ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6!null y:7
- ├── side-effects
+ ├── volatile, side-effects
  ├── key: (6)
  ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
  ├── select
  │    ├── columns: k:1!null i:2 f:3 s:4 j:5
- │    ├── side-effects
+ │    ├── volatile, side-effects
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
  │    ├── scan a
@@ -89,10 +89,10 @@ inner-join (hash)
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2-5)
  │    └── filters
- │         └── k:1 = random() [outer=(1), side-effects, constraints=(/1: (/NULL - ])]
+ │         └── k:1 = random() [outer=(1), volatile, side-effects, constraints=(/1: (/NULL - ])]
  ├── select
  │    ├── columns: x:6!null y:7
- │    ├── side-effects
+ │    ├── volatile, side-effects
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
  │    ├── scan xy
@@ -100,7 +100,7 @@ inner-join (hash)
  │    │    ├── key: (6)
  │    │    └── fd: (6)-->(7)
  │    └── filters
- │         └── x:6 = random() [outer=(6), side-effects, constraints=(/6: (/NULL - ])]
+ │         └── x:6 = random() [outer=(6), volatile, side-effects, constraints=(/6: (/NULL - ])]
  └── filters
       └── k:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
@@ -159,11 +159,11 @@ SELECT CASE WHEN i<0 THEN (SELECT y FROM xy WHERE x=i LIMIT (random()*10)::int) 
 ----
 project
  ├── columns: case:8
- ├── side-effects
+ ├── volatile, side-effects
  ├── scan a
  │    └── columns: i:2
  └── projections
-      └── case [as=case:8, outer=(2), side-effects, correlated-subquery]
+      └── case [as=case:8, outer=(2), volatile, side-effects, correlated-subquery]
            ├── true
            ├── when
            │    ├── i:2 < 0
@@ -172,14 +172,14 @@ project
            │              ├── columns: y:7
            │              ├── outer: (2)
            │              ├── cardinality: [0 - 1]
-           │              ├── side-effects
+           │              ├── volatile, side-effects
            │              ├── key: ()
            │              ├── fd: ()-->(7)
            │              └── limit
            │                   ├── columns: x:6!null y:7
            │                   ├── outer: (2)
            │                   ├── cardinality: [0 - 1]
-           │                   ├── side-effects
+           │                   ├── volatile, side-effects
            │                   ├── key: ()
            │                   ├── fd: ()-->(6,7)
            │                   ├── select
@@ -203,7 +203,7 @@ SELECT * FROM a WHERE (CASE WHEN i<0 THEN 5 ELSE (SELECT y FROM xy WHERE x=i AND
 ----
 select
  ├── columns: k:1!null i:2 f:3 s:4 j:5
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
@@ -211,7 +211,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── eq [outer=(1,2), side-effects, correlated-subquery, constraints=(/1: (/NULL - ])]
+      └── eq [outer=(1,2), immutable, side-effects, correlated-subquery, constraints=(/1: (/NULL - ])]
            ├── k:1
            └── case
                 ├── true
@@ -223,14 +223,14 @@ select
                           ├── columns: y:7
                           ├── outer: (2)
                           ├── cardinality: [0 - 1]
-                          ├── side-effects
+                          ├── immutable, side-effects
                           ├── key: ()
                           ├── fd: ()-->(7)
                           └── select
                                ├── columns: x:6!null y:7
                                ├── outer: (2)
                                ├── cardinality: [0 - 1]
-                               ├── side-effects
+                               ├── immutable, side-effects
                                ├── key: ()
                                ├── fd: ()-->(6,7)
                                ├── scan xy
@@ -239,7 +239,7 @@ select
                                │    └── fd: (6)-->(7)
                                └── filters
                                     ├── x:6 = i:2 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
-                                    └── (5 / y:7) > 1 [outer=(7), side-effects]
+                                    └── (5 / y:7) > 1 [outer=(7), immutable, side-effects]
 
 
 # Don't decorrelate IFERROR branch if there are side effects
@@ -248,7 +248,7 @@ SELECT * FROM a WHERE IFERROR(1/0, (SELECT y::DECIMAL FROM xy WHERE x = i AND 5/
 ----
 select
  ├── columns: k:1!null i:2 f:3 s:4 j:5
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
@@ -256,7 +256,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── eq [outer=(1,2), side-effects, correlated-subquery, constraints=(/1: (/NULL - ])]
+      └── eq [outer=(1,2), immutable, side-effects, correlated-subquery, constraints=(/1: (/NULL - ])]
            ├── k:1
            └── if-err
                 ├── 1 / 0
@@ -266,14 +266,14 @@ select
                                ├── columns: y:8
                                ├── outer: (2)
                                ├── cardinality: [0 - 1]
-                               ├── side-effects
+                               ├── immutable, side-effects
                                ├── key: ()
                                ├── fd: ()-->(8)
                                ├── select
                                │    ├── columns: x:6!null xy.y:7
                                │    ├── outer: (2)
                                │    ├── cardinality: [0 - 1]
-                               │    ├── side-effects
+                               │    ├── immutable, side-effects
                                │    ├── key: ()
                                │    ├── fd: ()-->(6,7)
                                │    ├── scan xy
@@ -282,7 +282,7 @@ select
                                │    │    └── fd: (6)-->(7)
                                │    └── filters
                                │         ├── x:6 = i:2 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
-                               │         └── (5 / xy.y:7) > 1 [outer=(7), side-effects]
+                               │         └── (5 / xy.y:7) > 1 [outer=(7), immutable, side-effects]
                                └── projections
                                     └── xy.y:7::DECIMAL [as=y:8, outer=(7)]
 
@@ -292,12 +292,12 @@ SELECT * FROM a WHERE IFERROR(1/0, (SELECT y::DECIMAL FROM xy WHERE x = i))=k
 ----
 project
  ├── columns: k:1!null i:2 f:3 s:4 j:5
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  └── select
       ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6 y:8
-      ├── side-effects
+      ├── immutable, side-effects
       ├── key: (1)
       ├── fd: (1)-->(2-6,8), (6)-->(8)
       ├── left-join (hash)
@@ -321,4 +321,4 @@ project
       │    └── filters
       │         └── x:6 = i:2 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
       └── filters
-           └── k:1 = IFERROR(1 / 0, y:8) [outer=(1,8), side-effects, constraints=(/1: (/NULL - ])]
+           └── k:1 = IFERROR(1 / 0, y:8) [outer=(1,8), immutable, side-effects, constraints=(/1: (/NULL - ])]

--- a/pkg/sql/opt/norm/testdata/rules/window
+++ b/pkg/sql/opt/norm/testdata/rules/window
@@ -158,14 +158,14 @@ SELECT * FROM (SELECT i, s, f, rank() OVER (PARTITION BY i, f) FROM a) WHERE ran
 ----
 window partition=(2,3)
  ├── columns: i:2 s:4 f:3 rank:6
- ├── side-effects
+ ├── volatile, side-effects
  ├── select
  │    ├── columns: i:2 f:3 s:4
- │    ├── side-effects
+ │    ├── volatile, side-effects
  │    ├── scan a
  │    │    └── columns: i:2 f:3 s:4
  │    └── filters
- │         └── random() < 0.5 [side-effects]
+ │         └── random() < 0.5 [volatile, side-effects]
  └── windows
       └── rank [as=rank:6]
 

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -424,7 +424,7 @@ WITH foo AS (INSERT INTO a VALUES (1) RETURNING *) SELECT * FROM foo
 with &1 (foo)
  ├── columns: k:11!null i:12 f:13 s:14 j:15
  ├── cardinality: [1 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(11-15)
  ├── insert a
@@ -436,7 +436,7 @@ with &1 (foo)
  │    │    ├── column9:9 => a.s:4
  │    │    └── column10:10 => a.j:5
  │    ├── cardinality: [1 - 1]
- │    ├── side-effects, mutations
+ │    ├── volatile, side-effects, mutations
  │    ├── key: ()
  │    ├── fd: ()-->(1-5)
  │    └── values
@@ -463,13 +463,13 @@ WITH foo AS (SELECT 1/0) SELECT * FROM foo
 with &1 (foo)
  ├── columns: "?column?":2
  ├── cardinality: [1 - 1]
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: ()
  ├── fd: ()-->(2)
  ├── values
  │    ├── columns: "?column?":1
  │    ├── cardinality: [1 - 1]
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── key: ()
  │    ├── fd: ()-->(1)
  │    └── (1 / 0,)
@@ -577,7 +577,7 @@ WITH cte AS (INSERT INTO child VALUES (1, 1) RETURNING c) SELECT c FROM cte UNIO
 with &2 (cte)
  ├── columns: c:10(int!null)
  ├── cardinality: [1 - 2]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── stats: [rows=2, distinct(10)=2, null(10)=0]
  ├── cost: 1037.7025
  ├── key: (10)
@@ -588,7 +588,7 @@ with &2 (cte)
  │    │    └── column2:4 => t.public.child.p:2
  │    ├── input binding: &1
  │    ├── cardinality: [1 - 1]
- │    ├── side-effects, mutations
+ │    ├── volatile, side-effects, mutations
  │    ├── stats: [rows=1]
  │    ├── cost: 1037.5925
  │    ├── key: ()
@@ -736,13 +736,13 @@ with &1 (foo)
  ├── columns: "?column?":2
  ├── materialized
  ├── cardinality: [1 - 1]
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: ()
  ├── fd: ()-->(2)
  ├── values
  │    ├── columns: "?column?":1
  │    ├── cardinality: [1 - 1]
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── key: ()
  │    ├── fd: ()-->(1)
  │    └── (1 / 0,)
@@ -761,7 +761,7 @@ WITH foo AS NOT MATERIALIZED (SELECT 1/0) SELECT * FROM foo
 values
  ├── columns: "?column?":2
  ├── cardinality: [1 - 1]
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: ()
  ├── fd: ()-->(2)
  └── (1 / 0,)

--- a/pkg/sql/opt/norm/testdata/rules/zero_cardinality
+++ b/pkg/sql/opt/norm/testdata/rules/zero_cardinality
@@ -75,7 +75,7 @@ SELECT * FROM (SELECT CASE WHEN k < 0 THEN 3 / 0 ELSE 3 END FROM b) WHERE false
 project
  ├── columns: case:6!null
  ├── cardinality: [0 - 0]
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: ()
  ├── fd: ()-->(6)
  ├── values
@@ -84,4 +84,4 @@ project
  │    ├── key: ()
  │    └── fd: ()-->(1)
  └── projections
-      └── CASE WHEN k:1 < 0 THEN 3 / 0 ELSE 3 END [as=case:6, outer=(1), side-effects]
+      └── CASE WHEN k:1 < 0 THEN 3 / 0 ELSE 3 END [as=case:6, outer=(1), immutable, side-effects]

--- a/pkg/sql/opt/props/logical.go
+++ b/pkg/sql/opt/props/logical.go
@@ -87,6 +87,9 @@ type Shared struct {
 	// time searching subtrees that don't contain subqueries.
 	HasCorrelatedSubquery bool
 
+	// VolatilitySet contains the set of volatilities contained in the expression.
+	VolatilitySet VolatilitySet
+
 	// CanHaveSideEffects is true if the expression modifies state outside its
 	// own scope, or if depends upon state that may change across evaluations. An
 	// expression can have side effects if it can do any of the following:

--- a/pkg/sql/opt/props/volatility.go
+++ b/pkg/sql/opt/props/volatility.go
@@ -1,0 +1,106 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package props
+
+import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+
+// VolatilitySet tracks the set of operator volatilities contained inside an
+// expression. See tree.Volatility for more info on volatility values.
+//
+// The reason why we use a set (rather than the "maximum" volatility) is that
+// for plan caching purposes, we want to distinguish the case when a stable
+// operator is used - regardless of whether a volatile operator is used. For
+// example, consider these two statements:
+//   (1) INSERT INTO t VALUES (gen_random_uuid(), '2020-10-09')
+//   (2) INSERT INTO t VALUES (gen_random_uuid(), now())
+// For (1) we can cache the final optimized plan. For (2), we can only cache the
+// memo if we don't constant fold stable operators, and subsequently fold them
+// each time we try to execute an instance of the query.
+//
+// TODO(radu): transfer the comment for CanHaveSideEffects here clarifying the
+// optimizer policy around volatility and side-effects.
+type VolatilitySet uint8
+
+// Add a volatility to the set.
+func (vs *VolatilitySet) Add(v tree.Volatility) {
+	*vs |= volatilityBit(v)
+}
+
+// AddImmutable is a convenience shorthand for adding VolatilityImmutable.
+func (vs *VolatilitySet) AddImmutable() {
+	vs.Add(tree.VolatilityImmutable)
+}
+
+// AddStable is a convenience shorthand for adding VolatilityStable.
+func (vs *VolatilitySet) AddStable() {
+	vs.Add(tree.VolatilityStable)
+}
+
+// AddVolatile is a convenience shorthand for adding VolatilityVolatile.
+func (vs *VolatilitySet) AddVolatile() {
+	vs.Add(tree.VolatilityVolatile)
+}
+
+// UnionWith sets the receiver to the union of the two volatility sets.
+func (vs *VolatilitySet) UnionWith(other VolatilitySet) {
+	*vs = *vs | other
+}
+
+// IsLeakProof returns true if the set is empty or only contains
+// VolatilityLeakProof.
+func (vs VolatilitySet) IsLeakProof() bool {
+	return vs == 0 || vs == volatilityBit(tree.VolatilityLeakProof)
+}
+
+// HasStable returns true if the set contains VolatilityStable.
+func (vs VolatilitySet) HasStable() bool {
+	return (vs & volatilityBit(tree.VolatilityStable)) != 0
+}
+
+// HasVolatile returns true if the set contains VolatilityVolatile.
+func (vs VolatilitySet) HasVolatile() bool {
+	return (vs & volatilityBit(tree.VolatilityVolatile)) != 0
+}
+
+func (vs VolatilitySet) String() string {
+	// The only properties we care about are IsLeakProof(), HasStable() and
+	// HasVolatile(). We print one of the strings below:
+	//
+	//    String            | IsLeakProof | HasStable | HasVolatile
+	//   -------------------+-------------+-----------+-------------
+	//    "leak-proof"      | true        | false     | false
+	//    "immutable"       | false       | false     | false
+	//    "stable"          | false       | true      | false
+	//    "volatile"        | false       | false     | true
+	//    "stable+volatile" | false       | true      | true
+	//
+	// These are the only valid combinations for these properties.
+	//
+	if vs.IsLeakProof() {
+		return "leak-proof"
+	}
+	hasStable := vs.HasStable()
+	hasVolatile := vs.HasVolatile()
+	switch {
+	case !hasStable && !hasVolatile:
+		return "immutable"
+	case hasStable && !hasVolatile:
+		return "stable"
+	case hasVolatile && !hasStable:
+		return "volatile"
+	default:
+		return "stable+volatile"
+	}
+}
+
+func volatilityBit(v tree.Volatility) VolatilitySet {
+	return 1 << VolatilitySet(v)
+}

--- a/pkg/sql/opt/props/volatility_test.go
+++ b/pkg/sql/opt/props/volatility_test.go
@@ -1,0 +1,57 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package props
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVolatilitySet(t *testing.T) {
+	var v VolatilitySet
+
+	check := func(str string, isLeakProof, hasStable, hasVolatile bool) {
+		t.Helper()
+
+		require.Equal(t, v.String(), str)
+		require.Equal(t, v.IsLeakProof(), isLeakProof)
+		require.Equal(t, v.HasStable(), hasStable)
+		require.Equal(t, v.HasVolatile(), hasVolatile)
+	}
+	check("leak-proof", true, false, false)
+
+	v.Add(tree.VolatilityLeakProof)
+	check("leak-proof", true, false, false)
+
+	v.AddImmutable()
+	check("immutable", false, false, false)
+
+	v.AddStable()
+	check("stable", false, true, false)
+
+	v.AddVolatile()
+	check("stable+volatile", false, true, true)
+
+	v = 0
+	v.AddVolatile()
+	check("volatile", false, false, true)
+
+	var w VolatilitySet
+	w.AddImmutable()
+	v.UnionWith(w)
+	check("volatile", false, false, true)
+
+	w.AddStable()
+	v.UnionWith(w)
+	check("stable+volatile", false, true, true)
+}

--- a/pkg/sql/opt/xform/testdata/external/activerecord
+++ b/pkg/sql/opt/xform/testdata/external/activerecord
@@ -114,11 +114,13 @@ ORDER BY a.attnum
 ----
 sort
  ├── columns: attname:2!null format_type:65 pg_get_expr:66 attnotnull:13!null atttypid:3!null atttypmod:9!null collname:67 comment:68  [hidden: attnum:6!null]
+ ├── stable
  ├── key: (6)
  ├── fd: (6)-->(2,3,9,13,65-68), (2)-->(3,6,9,13,65-68), (3,9)-->(65), (6)-->(68)
  ├── ordering: +6
  └── project
       ├── columns: format_type:65 pg_get_expr:66 collname:67 comment:68 attname:2!null atttypid:3!null attnum:6!null atttypmod:9!null attnotnull:13!null
+      ├── stable
       ├── key: (6)
       ├── fd: (6)-->(2,3,9,13,65-68), (2)-->(3,6,9,13,65-68), (3,9)-->(65), (6)-->(68)
       ├── right-join (hash)
@@ -174,7 +176,7 @@ sort
       │         ├── c.oid:27 = attcollation:18 [outer=(18,27), constraints=(/18: (/NULL - ]; /27: (/NULL - ]), fd=(18)==(27), (27)==(18)]
       │         └── t.oid:34 = atttypid:3 [outer=(3,34), constraints=(/3: (/NULL - ]; /34: (/NULL - ]), fd=(3)==(34), (34)==(3)]
       └── projections
-           ├── format_type(atttypid:3, atttypmod:9) [as=format_type:65, outer=(3,9)]
-           ├── pg_get_expr(adbin:25, adrelid:23) [as=pg_get_expr:66, outer=(23,25)]
+           ├── format_type(atttypid:3, atttypmod:9) [as=format_type:65, outer=(3,9), stable]
+           ├── pg_get_expr(adbin:25, adrelid:23) [as=pg_get_expr:66, outer=(23,25), stable]
            ├── c.collname:28 [as=collname:67, outer=(28)]
-           └── col_description(attrelid:1, attnum:6) [as=comment:68, outer=(1,6)]
+           └── col_description(attrelid:1, attnum:6) [as=comment:68, outer=(1,6), stable]

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -542,6 +542,7 @@ WHERE
 ----
 project
  ├── columns: secondary_id:6 "?column?":7
+ ├── stable
  ├── inner-join (lookup idtable)
  │    ├── columns: primary_id:1!null idtable.secondary_id:2!null data:3!null value:4!null column5:5!null
  │    ├── key columns: [1] = [1]
@@ -566,4 +567,4 @@ project
  │    └── filters (true)
  └── projections
       ├── value:4->>'secondary_id' [as=secondary_id:6, outer=(4)]
-      └── data:3 || jsonb_build_object('primary_id', primary_id:1) [as="?column?":7, outer=(1,3)]
+      └── data:3 || jsonb_build_object('primary_id', primary_id:1) [as="?column?":7, outer=(1,3), stable]

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -2530,6 +2530,7 @@ FROM
 ----
 project
  ├── columns: id1_0_0_:1!null c_name2_0_0_:2 formula0_0_:6
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2), (2)-->(6)
  ├── inner-join (merge)
@@ -2549,7 +2550,7 @@ project
  │    │    └── ordering: +3
  │    └── filters (true)
  └── projections
-      └── length(this_.c_name:2) [as=formula0_0_:6, outer=(2)]
+      └── length(this_.c_name:2) [as=formula0_0_:6, outer=(2), immutable]
 
 exec-ddl
 drop table t_name

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -162,6 +162,7 @@ WHERE ((c.relkind = 'r'::CHAR) OR (c.relkind = 'f'::CHAR)) AND (n.nspname = 'pub
 ----
 project
  ├── columns: oid:1!null schemaname:29!null tablename:2!null relacl:26 tableowner:133 description:134 relkind:17!null cluster:92 hasoids:20!null hasindexes:13!null hasrules:22!null tablespace:33 param:27 hastriggers:23!null unlogged:15!null ftoptions:120 srvname:122 reltuples:10!null inhtable:135!null inhschemaname:69 inhtablename:42
+ ├── stable
  ├── fd: ()-->(29), (1)-->(2,10,13,15,17,20,22,23,26,27,33,133,134), (2)-->(1,10,13,15,17,20,22,23,26,27,33,133,134)
  ├── group-by
  │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:29!null spcname:33 c2.relname:42 n2.nspname:69 ci.relname:92 ftoptions:120 srvname:122 count_rows:132!null rownum:136!null
@@ -308,6 +309,6 @@ project
  │         └── const-agg [as=srvname:122, outer=(122)]
  │              └── srvname:122
  └── projections
-      ├── pg_get_userbyid(c.relowner:5) [as=tableowner:133, outer=(5)]
-      ├── obj_description(c.oid:1) [as=description:134, outer=(1)]
+      ├── pg_get_userbyid(c.relowner:5) [as=tableowner:133, outer=(5), stable]
+      ├── obj_description(c.oid:1) [as=description:134, outer=(1), stable]
       └── count_rows:132 > 0 [as=inhtable:135, outer=(132)]

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -161,10 +161,12 @@ ORDER BY schemaname, tablename
 ----
 sort
  ├── columns: oid:1!null schemaname:29!null tablename:2!null relacl:26 tableowner:133 description:134 relkind:17!null cluster:92 hasoids:20!null hasindexes:13!null hasrules:22!null tablespace:33 param:27 hastriggers:23!null unlogged:15!null ftoptions:120 srvname:122 reltuples:10!null inhtable:135!null inhschemaname:69 inhtablename:42
+ ├── stable
  ├── fd: ()-->(29), (1)-->(2,10,13,15,17,20,22,23,26,27,33,133,134), (2)-->(1,10,13,15,17,20,22,23,26,27,33,133,134)
  ├── ordering: +2 opt(29) [actual: +2]
  └── project
       ├── columns: tableowner:133 description:134 inhtable:135!null c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:29!null spcname:33 c2.relname:42 n2.nspname:69 ci.relname:92 ftoptions:120 srvname:122
+      ├── stable
       ├── fd: ()-->(29), (1)-->(2,10,13,15,17,20,22,23,26,27,33,133,134), (2)-->(1,10,13,15,17,20,22,23,26,27,33,133,134)
       ├── group-by
       │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:29!null spcname:33 c2.relname:42 n2.nspname:69 ci.relname:92 ftoptions:120 srvname:122 count_rows:132!null rownum:136!null
@@ -311,6 +313,6 @@ sort
       │         └── const-agg [as=srvname:122, outer=(122)]
       │              └── srvname:122
       └── projections
-           ├── pg_get_userbyid(c.relowner:5) [as=tableowner:133, outer=(5)]
-           ├── obj_description(c.oid:1) [as=description:134, outer=(1)]
+           ├── pg_get_userbyid(c.relowner:5) [as=tableowner:133, outer=(5), stable]
+           ├── obj_description(c.oid:1) [as=description:134, outer=(1), stable]
            └── count_rows:132 > 0 [as=inhtable:135, outer=(132)]

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -159,7 +159,7 @@ order by anon_1.flavors_id asc
 ----
 project
  ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:29 flavor_extra_specs_1_updated_at:30 flavor_extra_specs_1_id:25 flavor_extra_specs_1_key:26 flavor_extra_specs_1_value:27 flavor_extra_specs_1_flavor_id:28
- ├── side-effects, has-placeholder
+ ├── immutable, side-effects, has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── ordering: +1
@@ -167,14 +167,14 @@ project
       ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:23 flavor_extra_specs_1.id:25 key:26 value:27 flavor_extra_specs_1.flavor_id:28 flavor_extra_specs_1.created_at:29 flavor_extra_specs_1.updated_at:30
       ├── left ordering: +1
       ├── right ordering: +28
-      ├── side-effects, has-placeholder
+      ├── immutable, side-effects, has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
       ├── ordering: +1
       ├── limit
       │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:23
       │    ├── internal-ordering: +1
-      │    ├── side-effects, has-placeholder
+      │    ├── immutable, side-effects, has-placeholder
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │    ├── ordering: +1
@@ -338,18 +338,18 @@ order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
 sort
  ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11!null anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:38 flavor_extra_specs_1_updated_at:39 flavor_extra_specs_1_id:34 flavor_extra_specs_1_key:35 flavor_extra_specs_1_value:36 flavor_extra_specs_1_flavor_id:37
- ├── side-effects, has-placeholder
+ ├── immutable, side-effects, has-placeholder
  ├── key: (1,34)
  ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35-39), (35,37)-->(34,36,38,39)
  ├── ordering: +7 opt(11) [actual: +7]
  └── project
       ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:34 key:35 value:36 flavor_extra_specs_1.flavor_id:37 flavor_extra_specs_1.created_at:38 flavor_extra_specs_1.updated_at:39
-      ├── side-effects, has-placeholder
+      ├── immutable, side-effects, has-placeholder
       ├── key: (1,34)
       ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35-39), (35,37)-->(34,36,38,39)
       └── right-join (hash)
            ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:32 flavor_extra_specs_1.id:34 key:35 value:36 flavor_extra_specs_1.flavor_id:37 flavor_extra_specs_1.created_at:38 flavor_extra_specs_1.updated_at:39
-           ├── side-effects, has-placeholder
+           ├── immutable, side-effects, has-placeholder
            ├── key: (1,34)
            ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35-39), (35,37)-->(34,36,38,39)
            ├── scan flavor_extra_specs_1
@@ -359,7 +359,7 @@ sort
            ├── limit
            │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:32
            │    ├── internal-ordering: +7 opt(11)
-           │    ├── side-effects, has-placeholder
+           │    ├── immutable, side-effects, has-placeholder
            │    ├── key: (1)
            │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    ├── offset
@@ -593,18 +593,18 @@ order by anon_1.instance_types_flavorid asc,
 ----
 sort
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:34 instance_type_extra_specs_1_updated_at:35 instance_type_extra_specs_1_deleted_at:33 instance_type_extra_specs_1_deleted:32 instance_type_extra_specs_1_id:28 instance_type_extra_specs_1_key:29 instance_type_extra_specs_1_value:30 instance_type_extra_specs_1_instance_type_id:31
- ├── side-effects, has-placeholder
+ ├── immutable, side-effects, has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── ordering: +7,+1
  └── project
       ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:28 key:29 value:30 instance_type_extra_specs_1.instance_type_id:31 instance_type_extra_specs_1.deleted:32 instance_type_extra_specs_1.deleted_at:33 instance_type_extra_specs_1.created_at:34 instance_type_extra_specs_1.updated_at:35
-      ├── side-effects, has-placeholder
+      ├── immutable, side-effects, has-placeholder
       ├── key: (1,28)
       ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
       └── right-join (hash)
            ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:26 instance_type_extra_specs_1.id:28 key:29 value:30 instance_type_extra_specs_1.instance_type_id:31 instance_type_extra_specs_1.deleted:32 instance_type_extra_specs_1.deleted_at:33 instance_type_extra_specs_1.created_at:34 instance_type_extra_specs_1.updated_at:35
-           ├── side-effects, has-placeholder
+           ├── immutable, side-effects, has-placeholder
            ├── key: (1,28)
            ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
            ├── select
@@ -621,7 +621,7 @@ sort
            ├── limit
            │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:26
            │    ├── internal-ordering: +7,+1
-           │    ├── side-effects, has-placeholder
+           │    ├── immutable, side-effects, has-placeholder
            │    ├── key: (1)
            │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    ├── offset
@@ -944,12 +944,12 @@ from (select instance_types.created_at as instance_types_created_at,
 ----
 project
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2!null anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:34 instance_type_extra_specs_1_updated_at:35 instance_type_extra_specs_1_deleted_at:33 instance_type_extra_specs_1_deleted:32 instance_type_extra_specs_1_id:28 instance_type_extra_specs_1_key:29 instance_type_extra_specs_1_value:30 instance_type_extra_specs_1_instance_type_id:31
- ├── side-effects, has-placeholder
+ ├── immutable, side-effects, has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  └── right-join (hash)
       ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:26 instance_type_extra_specs_1.id:28 key:29 value:30 instance_type_extra_specs_1.instance_type_id:31 instance_type_extra_specs_1.deleted:32 instance_type_extra_specs_1.deleted_at:33 instance_type_extra_specs_1.created_at:34 instance_type_extra_specs_1.updated_at:35
-      ├── side-effects, has-placeholder
+      ├── immutable, side-effects, has-placeholder
       ├── key: (1,28)
       ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
       ├── select
@@ -965,7 +965,7 @@ project
       │         └── instance_type_extra_specs_1.deleted:32 = $7 [outer=(32), constraints=(/32: (/NULL - ])]
       ├── limit
       │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:26
-      │    ├── side-effects, has-placeholder
+      │    ├── immutable, side-effects, has-placeholder
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
       │    ├── offset
@@ -1125,12 +1125,12 @@ from (select instance_types.created_at as instance_types_created_at,
 ----
 project
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:34 instance_type_extra_specs_1_updated_at:35 instance_type_extra_specs_1_deleted_at:33 instance_type_extra_specs_1_deleted:32 instance_type_extra_specs_1_id:28 instance_type_extra_specs_1_key:29 instance_type_extra_specs_1_value:30 instance_type_extra_specs_1_instance_type_id:31
- ├── side-effects, has-placeholder
+ ├── immutable, side-effects, has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  └── right-join (hash)
       ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:26 instance_type_extra_specs_1.id:28 key:29 value:30 instance_type_extra_specs_1.instance_type_id:31 instance_type_extra_specs_1.deleted:32 instance_type_extra_specs_1.deleted_at:33 instance_type_extra_specs_1.created_at:34 instance_type_extra_specs_1.updated_at:35
-      ├── side-effects, has-placeholder
+      ├── immutable, side-effects, has-placeholder
       ├── key: (1,28)
       ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
       ├── select
@@ -1146,7 +1146,7 @@ project
       │         └── instance_type_extra_specs_1.deleted:32 = $7 [outer=(32), constraints=(/32: (/NULL - ])]
       ├── limit
       │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:26
-      │    ├── side-effects, has-placeholder
+      │    ├── immutable, side-effects, has-placeholder
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
       │    ├── offset
@@ -1298,12 +1298,12 @@ from (select flavors.created_at as flavors_created_at,
 ----
 project
  ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:29 flavor_extra_specs_1_updated_at:30 flavor_extra_specs_1_id:25 flavor_extra_specs_1_key:26 flavor_extra_specs_1_value:27 flavor_extra_specs_1_flavor_id:28
- ├── side-effects, has-placeholder
+ ├── immutable, side-effects, has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  └── right-join (hash)
       ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:23 flavor_extra_specs_1.id:25 key:26 value:27 flavor_extra_specs_1.flavor_id:28 flavor_extra_specs_1.created_at:29 flavor_extra_specs_1.updated_at:30
-      ├── side-effects, has-placeholder
+      ├── immutable, side-effects, has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
       ├── scan flavor_extra_specs_1
@@ -1312,7 +1312,7 @@ project
       │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
       ├── limit
       │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:23
-      │    ├── side-effects, has-placeholder
+      │    ├── immutable, side-effects, has-placeholder
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │    ├── offset
@@ -1457,12 +1457,12 @@ from (select flavors.created_at as flavors_created_at,
 ----
 project
  ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:29 flavor_extra_specs_1_updated_at:30 flavor_extra_specs_1_id:25 flavor_extra_specs_1_key:26 flavor_extra_specs_1_value:27 flavor_extra_specs_1_flavor_id:28
- ├── side-effects, has-placeholder
+ ├── immutable, side-effects, has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  └── right-join (hash)
       ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:23 flavor_extra_specs_1.id:25 key:26 value:27 flavor_extra_specs_1.flavor_id:28 flavor_extra_specs_1.created_at:29 flavor_extra_specs_1.updated_at:30
-      ├── side-effects, has-placeholder
+      ├── immutable, side-effects, has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
       ├── scan flavor_extra_specs_1
@@ -1471,7 +1471,7 @@ project
       │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
       ├── limit
       │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:23
-      │    ├── side-effects, has-placeholder
+      │    ├── immutable, side-effects, has-placeholder
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │    ├── offset
@@ -1620,18 +1620,18 @@ order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
 sort
  ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:29 flavor_extra_specs_1_updated_at:30 flavor_extra_specs_1_id:25 flavor_extra_specs_1_key:26 flavor_extra_specs_1_value:27 flavor_extra_specs_1_flavor_id:28
- ├── side-effects, has-placeholder
+ ├── immutable, side-effects, has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── ordering: +7
  └── project
       ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:25 key:26 value:27 flavor_extra_specs_1.flavor_id:28 flavor_extra_specs_1.created_at:29 flavor_extra_specs_1.updated_at:30
-      ├── side-effects, has-placeholder
+      ├── immutable, side-effects, has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
       └── right-join (hash)
            ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:23 flavor_extra_specs_1.id:25 key:26 value:27 flavor_extra_specs_1.flavor_id:28 flavor_extra_specs_1.created_at:29 flavor_extra_specs_1.updated_at:30
-           ├── side-effects, has-placeholder
+           ├── immutable, side-effects, has-placeholder
            ├── key: (1,25)
            ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
            ├── scan flavor_extra_specs_1
@@ -1641,7 +1641,7 @@ sort
            ├── limit
            │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:23
            │    ├── internal-ordering: +7
-           │    ├── side-effects, has-placeholder
+           │    ├── immutable, side-effects, has-placeholder
            │    ├── key: (1)
            │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    ├── offset
@@ -1805,18 +1805,18 @@ order by anon_1.instance_types_flavorid asc,
 ----
 sort
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:34 instance_type_extra_specs_1_updated_at:35 instance_type_extra_specs_1_deleted_at:33 instance_type_extra_specs_1_deleted:32 instance_type_extra_specs_1_id:28 instance_type_extra_specs_1_key:29 instance_type_extra_specs_1_value:30 instance_type_extra_specs_1_instance_type_id:31
- ├── side-effects, has-placeholder
+ ├── immutable, side-effects, has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── ordering: +7,+1
  └── project
       ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:28 key:29 value:30 instance_type_extra_specs_1.instance_type_id:31 instance_type_extra_specs_1.deleted:32 instance_type_extra_specs_1.deleted_at:33 instance_type_extra_specs_1.created_at:34 instance_type_extra_specs_1.updated_at:35
-      ├── side-effects, has-placeholder
+      ├── immutable, side-effects, has-placeholder
       ├── key: (1,28)
       ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
       └── right-join (hash)
            ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:26 instance_type_extra_specs_1.id:28 key:29 value:30 instance_type_extra_specs_1.instance_type_id:31 instance_type_extra_specs_1.deleted:32 instance_type_extra_specs_1.deleted_at:33 instance_type_extra_specs_1.created_at:34 instance_type_extra_specs_1.updated_at:35
-           ├── side-effects, has-placeholder
+           ├── immutable, side-effects, has-placeholder
            ├── key: (1,28)
            ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
            ├── select
@@ -1833,7 +1833,7 @@ sort
            ├── limit
            │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:26
            │    ├── internal-ordering: +7,+1
-           │    ├── side-effects, has-placeholder
+           │    ├── immutable, side-effects, has-placeholder
            │    ├── key: (1)
            │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    ├── offset
@@ -2000,12 +2000,12 @@ from (select instance_types.created_at as instance_types_created_at,
 ----
 project
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:34 instance_type_extra_specs_1_updated_at:35 instance_type_extra_specs_1_deleted_at:33 instance_type_extra_specs_1_deleted:32 instance_type_extra_specs_1_id:28 instance_type_extra_specs_1_key:29 instance_type_extra_specs_1_value:30 instance_type_extra_specs_1_instance_type_id:31
- ├── side-effects, has-placeholder
+ ├── immutable, side-effects, has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  └── right-join (hash)
       ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:26 instance_type_extra_specs_1.id:28 key:29 value:30 instance_type_extra_specs_1.instance_type_id:31 instance_type_extra_specs_1.deleted:32 instance_type_extra_specs_1.deleted_at:33 instance_type_extra_specs_1.created_at:34 instance_type_extra_specs_1.updated_at:35
-      ├── side-effects, has-placeholder
+      ├── immutable, side-effects, has-placeholder
       ├── key: (1,28)
       ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
       ├── select
@@ -2021,7 +2021,7 @@ project
       │         └── instance_type_extra_specs_1.deleted:32 = $7 [outer=(32), constraints=(/32: (/NULL - ])]
       ├── limit
       │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:26
-      │    ├── side-effects, has-placeholder
+      │    ├── immutable, side-effects, has-placeholder
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
       │    ├── offset
@@ -2314,18 +2314,18 @@ order by anon_1.instance_types_flavorid asc,
 ----
 sort
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:34 instance_type_extra_specs_1_updated_at:35 instance_type_extra_specs_1_deleted_at:33 instance_type_extra_specs_1_deleted:32 instance_type_extra_specs_1_id:28 instance_type_extra_specs_1_key:29 instance_type_extra_specs_1_value:30 instance_type_extra_specs_1_instance_type_id:31
- ├── side-effects, has-placeholder
+ ├── immutable, side-effects, has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── ordering: +7,+1
  └── project
       ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:28 key:29 value:30 instance_type_extra_specs_1.instance_type_id:31 instance_type_extra_specs_1.deleted:32 instance_type_extra_specs_1.deleted_at:33 instance_type_extra_specs_1.created_at:34 instance_type_extra_specs_1.updated_at:35
-      ├── side-effects, has-placeholder
+      ├── immutable, side-effects, has-placeholder
       ├── key: (1,28)
       ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
       └── right-join (hash)
            ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:26 instance_type_extra_specs_1.id:28 key:29 value:30 instance_type_extra_specs_1.instance_type_id:31 instance_type_extra_specs_1.deleted:32 instance_type_extra_specs_1.deleted_at:33 instance_type_extra_specs_1.created_at:34 instance_type_extra_specs_1.updated_at:35
-           ├── side-effects, has-placeholder
+           ├── immutable, side-effects, has-placeholder
            ├── key: (1,28)
            ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
            ├── select
@@ -2342,7 +2342,7 @@ sort
            ├── limit
            │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:26
            │    ├── internal-ordering: +7,+1
-           │    ├── side-effects, has-placeholder
+           │    ├── immutable, side-effects, has-placeholder
            │    ├── key: (1)
            │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    ├── offset
@@ -2502,18 +2502,18 @@ order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
 sort
  ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:29 flavor_extra_specs_1_updated_at:30 flavor_extra_specs_1_id:25 flavor_extra_specs_1_key:26 flavor_extra_specs_1_value:27 flavor_extra_specs_1_flavor_id:28
- ├── side-effects, has-placeholder
+ ├── immutable, side-effects, has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── ordering: +7
  └── project
       ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:25 key:26 value:27 flavor_extra_specs_1.flavor_id:28 flavor_extra_specs_1.created_at:29 flavor_extra_specs_1.updated_at:30
-      ├── side-effects, has-placeholder
+      ├── immutable, side-effects, has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
       └── right-join (hash)
            ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:23 flavor_extra_specs_1.id:25 key:26 value:27 flavor_extra_specs_1.flavor_id:28 flavor_extra_specs_1.created_at:29 flavor_extra_specs_1.updated_at:30
-           ├── side-effects, has-placeholder
+           ├── immutable, side-effects, has-placeholder
            ├── key: (1,25)
            ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
            ├── scan flavor_extra_specs_1
@@ -2523,7 +2523,7 @@ sort
            ├── limit
            │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:23
            │    ├── internal-ordering: +7
-           │    ├── side-effects, has-placeholder
+           │    ├── immutable, side-effects, has-placeholder
            │    ├── key: (1)
            │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    ├── offset
@@ -2687,7 +2687,7 @@ order by anon_1.instance_types_flavorid asc,
 ----
 project
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11!null anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:45 instance_type_extra_specs_1_updated_at:46 instance_type_extra_specs_1_deleted_at:44 instance_type_extra_specs_1_deleted:43 instance_type_extra_specs_1_id:39 instance_type_extra_specs_1_key:40 instance_type_extra_specs_1_value:41 instance_type_extra_specs_1_instance_type_id:42
- ├── side-effects, has-placeholder
+ ├── immutable, side-effects, has-placeholder
  ├── key: (1,39)
  ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
  ├── ordering: +7,+1 opt(11) [actual: +7,+1]
@@ -2695,21 +2695,21 @@ project
       ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:37 instance_type_extra_specs_1.id:39 key:40 value:41 instance_type_extra_specs_1.instance_type_id:42 instance_type_extra_specs_1.deleted:43 instance_type_extra_specs_1.deleted_at:44 instance_type_extra_specs_1.created_at:45 instance_type_extra_specs_1.updated_at:46
       ├── key columns: [39] = [39]
       ├── lookup columns are key
-      ├── side-effects, has-placeholder
+      ├── immutable, side-effects, has-placeholder
       ├── key: (1,39)
       ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
       ├── ordering: +7,+1 opt(11) [actual: +7,+1]
       ├── left-join (lookup instance_type_extra_specs@secondary)
       │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:37 instance_type_extra_specs_1.id:39 key:40 instance_type_extra_specs_1.instance_type_id:42 instance_type_extra_specs_1.deleted:43
       │    ├── key columns: [1] = [42]
-      │    ├── side-effects, has-placeholder
+      │    ├── immutable, side-effects, has-placeholder
       │    ├── key: (1,39)
       │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40,42,43), (40,42,43)~~>(39)
       │    ├── ordering: +7,+1 opt(11) [actual: +7,+1]
       │    ├── limit
       │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:37
       │    │    ├── internal-ordering: +7,+1 opt(11)
-      │    │    ├── side-effects, has-placeholder
+      │    │    ├── immutable, side-effects, has-placeholder
       │    │    ├── key: (1)
       │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
       │    │    ├── ordering: +7,+1 opt(11) [actual: +7,+1]
@@ -2958,18 +2958,18 @@ order by anon_1.instance_types_deleted asc,
 ----
 sort
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:34 instance_type_extra_specs_1_updated_at:35 instance_type_extra_specs_1_deleted_at:33 instance_type_extra_specs_1_deleted:32 instance_type_extra_specs_1_id:28 instance_type_extra_specs_1_key:29 instance_type_extra_specs_1_value:30 instance_type_extra_specs_1_instance_type_id:31
- ├── side-effects, has-placeholder
+ ├── immutable, side-effects, has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── ordering: +13,+1
  └── project
       ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:28 key:29 value:30 instance_type_extra_specs_1.instance_type_id:31 instance_type_extra_specs_1.deleted:32 instance_type_extra_specs_1.deleted_at:33 instance_type_extra_specs_1.created_at:34 instance_type_extra_specs_1.updated_at:35
-      ├── side-effects, has-placeholder
+      ├── immutable, side-effects, has-placeholder
       ├── key: (1,28)
       ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
       └── right-join (hash)
            ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:26 instance_type_extra_specs_1.id:28 key:29 value:30 instance_type_extra_specs_1.instance_type_id:31 instance_type_extra_specs_1.deleted:32 instance_type_extra_specs_1.deleted_at:33 instance_type_extra_specs_1.created_at:34 instance_type_extra_specs_1.updated_at:35
-           ├── side-effects, has-placeholder
+           ├── immutable, side-effects, has-placeholder
            ├── key: (1,28)
            ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
            ├── select
@@ -2986,7 +2986,7 @@ sort
            ├── limit
            │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:26
            │    ├── internal-ordering: +13,+1
-           │    ├── side-effects, has-placeholder
+           │    ├── immutable, side-effects, has-placeholder
            │    ├── key: (1)
            │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    ├── offset
@@ -3145,12 +3145,12 @@ from (select flavors.created_at as flavors_created_at,
 ----
 project
  ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:29 flavor_extra_specs_1_updated_at:30 flavor_extra_specs_1_id:25 flavor_extra_specs_1_key:26 flavor_extra_specs_1_value:27 flavor_extra_specs_1_flavor_id:28
- ├── side-effects, has-placeholder
+ ├── immutable, side-effects, has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  └── right-join (hash)
       ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:23 flavor_extra_specs_1.id:25 key:26 value:27 flavor_extra_specs_1.flavor_id:28 flavor_extra_specs_1.created_at:29 flavor_extra_specs_1.updated_at:30
-      ├── side-effects, has-placeholder
+      ├── immutable, side-effects, has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
       ├── scan flavor_extra_specs_1
@@ -3159,7 +3159,7 @@ project
       │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
       ├── limit
       │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:23
-      │    ├── side-effects, has-placeholder
+      │    ├── immutable, side-effects, has-placeholder
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │    ├── offset
@@ -3307,18 +3307,18 @@ order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
 sort
  ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 anon_1_flavors_description:13 flavor_extra_specs_1_created_at:29 flavor_extra_specs_1_updated_at:30 flavor_extra_specs_1_id:25 flavor_extra_specs_1_key:26 flavor_extra_specs_1_value:27 flavor_extra_specs_1_flavor_id:28
- ├── side-effects, has-placeholder
+ ├── immutable, side-effects, has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── ordering: +7
  └── project
       ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:25 key:26 value:27 flavor_extra_specs_1.flavor_id:28 flavor_extra_specs_1.created_at:29 flavor_extra_specs_1.updated_at:30
-      ├── side-effects, has-placeholder
+      ├── immutable, side-effects, has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (25)-->(26-30), (26,28)-->(25,27,29,30)
       └── right-join (hash)
            ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 true_agg:23 flavor_extra_specs_1.id:25 key:26 value:27 flavor_extra_specs_1.flavor_id:28 flavor_extra_specs_1.created_at:29 flavor_extra_specs_1.updated_at:30
-           ├── side-effects, has-placeholder
+           ├── immutable, side-effects, has-placeholder
            ├── key: (1,25)
            ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15), (25)-->(26-30), (26,28)-->(25,27,29,30)
            ├── scan flavor_extra_specs_1
@@ -3328,7 +3328,7 @@ sort
            ├── limit
            │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 true_agg:23
            │    ├── internal-ordering: +7
-           │    ├── side-effects, has-placeholder
+           │    ├── immutable, side-effects, has-placeholder
            │    ├── key: (1)
            │    ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15)
            │    ├── sort

--- a/pkg/sql/opt/xform/testdata/external/pgadmin
+++ b/pkg/sql/opt/xform/testdata/external/pgadmin
@@ -81,18 +81,22 @@ WHERE
 ----
 project
  ├── columns: PID:3 User:5 Database:2 "Backend start":10 Client:37 Application:6 Query:19 "Query start":12 "Xact start":11
+ ├── stable
  ├── select
  │    ├── columns: datname:2 pid:3 username:5 application_name:6 client_addr:7 client_hostname:8 client_port:9 backend_start:10 xact_start:11 query_start:12 query:19 sa.rowid:20!null "?column?":36!null
+ │    ├── stable
  │    ├── key: (20)
  │    ├── fd: ()-->(36), (20)-->(2,3,5-12,19)
  │    ├── ensure-distinct-on
  │    │    ├── columns: datname:2 pid:3 username:5 application_name:6 client_addr:7 client_hostname:8 client_port:9 backend_start:10 xact_start:11 query_start:12 query:19 sa.rowid:20!null "?column?":36
  │    │    ├── grouping columns: sa.rowid:20!null
  │    │    ├── error: "more than one row returned by a subquery used as an expression"
+ │    │    ├── stable
  │    │    ├── key: (20)
  │    │    ├── fd: (20)-->(2,3,5-12,19,36)
  │    │    ├── left-join-apply
  │    │    │    ├── columns: datname:2 pid:3 usesysid:4 username:5 application_name:6 client_addr:7 client_hostname:8 client_port:9 backend_start:10 xact_start:11 query_start:12 query:19 sa.rowid:20!null "?column?":36
+ │    │    │    ├── stable
  │    │    │    ├── fd: (20)-->(2-12,19)
  │    │    │    ├── scan sa
  │    │    │    │    ├── columns: datname:2 pid:3 usesysid:4 username:5 application_name:6 client_addr:7 client_hostname:8 client_port:9 backend_start:10 xact_start:11 query_start:12 query:19 sa.rowid:20!null
@@ -101,12 +105,14 @@ project
  │    │    │    ├── project
  │    │    │    │    ├── columns: "?column?":36
  │    │    │    │    ├── outer: (4)
+ │    │    │    │    ├── stable
  │    │    │    │    ├── select
  │    │    │    │    │    ├── columns: oid:21 rolname:22!null rolsuper:23
+ │    │    │    │    │    ├── stable
  │    │    │    │    │    ├── scan r
  │    │    │    │    │    │    └── columns: oid:21 rolname:22 rolsuper:23
  │    │    │    │    │    └── filters
- │    │    │    │    │         └── rolname:22 = current_user() [outer=(22), constraints=(/22: (/NULL - ])]
+ │    │    │    │    │         └── rolname:22 = current_user() [outer=(22), stable, constraints=(/22: (/NULL - ])]
  │    │    │    │    └── projections
  │    │    │    │         └── rolsuper:23 OR (oid:21 = usesysid:4) [as="?column?":36, outer=(4,21,23)]
  │    │    │    └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/pgjdbc
+++ b/pkg/sql/opt/xform/testdata/external/pgjdbc
@@ -82,6 +82,7 @@ WHERE
 ----
 project
  ├── columns: type_cat:71 type_schem:34!null type_name:2!null class_name:71 data_type:72 remarks:73 base_type:74
+ ├── stable
  ├── fd: ()-->(71)
  ├── ensure-distinct-on
  │    ├── columns: t.oid:1 t.typname:2!null t.typtype:7 nspname:34!null case:70 rownum:75!null
@@ -131,5 +132,5 @@ project
  └── projections
       ├── NULL [as=type_cat:71]
       ├── CASE WHEN t.typtype:7 = 'c' THEN 'STRUCT' ELSE 'DISTINCT' END [as=data_type:72, outer=(7)]
-      ├── obj_description(t.oid:1, 'pg_type') [as=remarks:73, outer=(1)]
+      ├── obj_description(t.oid:1, 'pg_type') [as=remarks:73, outer=(1), stable]
       └── CASE WHEN t.typtype:7 = 'd' THEN case:70 END [as=base_type:74, outer=(7,70)]

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -24,7 +24,7 @@ RETURNING d_tax, d_next_o_id
 project
  ├── columns: d_tax:9 d_next_o_id:11
  ├── cardinality: [0 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(9,11)
  └── update district
@@ -33,7 +33,7 @@ project
       ├── update-mapping:
       │    └── d_next_o_id_new:23 => d_next_o_id:11
       ├── cardinality: [0 - 1]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: ()
       ├── fd: ()-->(1,2,9,11)
       └── project
@@ -150,7 +150,7 @@ insert "order"
  │    └── column7:15 => o_all_local:8
  ├── input binding: &1
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── values
  │    ├── columns: column1:9!null column2:10!null column3:11!null column4:12!null column5:13!null column6:14!null column7:15!null column16:16
  │    ├── cardinality: [1 - 1]
@@ -188,7 +188,7 @@ insert new_order
  │    └── column3:6 => no_w_id:3
  ├── input binding: &1
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── values
  │    ├── columns: column1:4!null column2:5!null column3:6!null
  │    ├── cardinality: [1 - 1]
@@ -311,11 +311,11 @@ update stock
  │    ├── s_order_cnt_new:37 => s_order_cnt:15
  │    └── s_remote_cnt_new:38 => s_remote_cnt:16
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: s_quantity_new:35 s_ytd_new:36 s_order_cnt_new:37 s_remote_cnt_new:38 s_i_id:18!null s_w_id:19!null s_quantity:20 s_dist_01:21 s_dist_02:22 s_dist_03:23 s_dist_04:24 s_dist_05:25 s_dist_06:26 s_dist_07:27 s_dist_08:28 s_dist_09:29 s_dist_10:30 s_ytd:31 s_order_cnt:32 s_remote_cnt:33 s_data:34
       ├── cardinality: [0 - 13]
-      ├── side-effects
+      ├── volatile, side-effects
       ├── key: (18)
       ├── fd: ()-->(19), (18)-->(20-35), (18)-->(36-38)
       ├── scan stock
@@ -338,7 +338,7 @@ update stock
       │    ├── key: (18)
       │    └── fd: ()-->(19), (18)-->(20-34)
       └── projections
-           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 26 WHEN (7853, 0) THEN 10 WHEN (8497, 0) THEN 62 WHEN (10904, 0) THEN 54 WHEN (16152, 0) THEN 80 WHEN (41382, 0) THEN 18 WHEN (55952, 0) THEN 56 WHEN (64817, 0) THEN 26 WHEN (66335, 0) THEN 30 WHEN (76567, 0) THEN 71 WHEN (81680, 0) THEN 51 WHEN (89641, 0) THEN 51 WHEN (89905, 0) THEN 77 ELSE crdb_internal.force_error('', 'unknown case') END [as=s_quantity_new:35, outer=(18,19), side-effects]
+           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 26 WHEN (7853, 0) THEN 10 WHEN (8497, 0) THEN 62 WHEN (10904, 0) THEN 54 WHEN (16152, 0) THEN 80 WHEN (41382, 0) THEN 18 WHEN (55952, 0) THEN 56 WHEN (64817, 0) THEN 26 WHEN (66335, 0) THEN 30 WHEN (76567, 0) THEN 71 WHEN (81680, 0) THEN 51 WHEN (89641, 0) THEN 51 WHEN (89905, 0) THEN 77 ELSE crdb_internal.force_error('', 'unknown case') END [as=s_quantity_new:35, outer=(18,19), volatile, side-effects]
            ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 6 WHEN (7853, 0) THEN 9 WHEN (8497, 0) THEN 13 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 2 WHEN (41382, 0) THEN 3 WHEN (55952, 0) THEN 10 WHEN (64817, 0) THEN 31 WHEN (66335, 0) THEN 9 WHEN (76567, 0) THEN 7 WHEN (81680, 0) THEN 4 WHEN (89641, 0) THEN 13 WHEN (89905, 0) THEN 20 END [as=s_ytd_new:36, outer=(18,19)]
            ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 1 WHEN (7853, 0) THEN 1 WHEN (8497, 0) THEN 2 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 1 WHEN (41382, 0) THEN 1 WHEN (55952, 0) THEN 1 WHEN (64817, 0) THEN 4 WHEN (66335, 0) THEN 2 WHEN (76567, 0) THEN 1 WHEN (81680, 0) THEN 1 WHEN (89641, 0) THEN 2 WHEN (89905, 0) THEN 4 END [as=s_order_cnt_new:37, outer=(18,19)]
            └── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 0 WHEN (7853, 0) THEN 0 WHEN (8497, 0) THEN 0 WHEN (10904, 0) THEN 0 WHEN (16152, 0) THEN 0 WHEN (41382, 0) THEN 0 WHEN (55952, 0) THEN 0 WHEN (64817, 0) THEN 0 WHEN (66335, 0) THEN 0 WHEN (76567, 0) THEN 0 WHEN (81680, 0) THEN 0 WHEN (89641, 0) THEN 0 WHEN (89905, 0) THEN 0 END [as=s_remote_cnt_new:38, outer=(18,19)]
@@ -369,10 +369,11 @@ insert order_line
  │    └── column9:19 => ol_dist_info:10
  ├── input binding: &1
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── project
  │    ├── columns: ol_amount:21 column20:20 column1:11!null column2:12!null column3:13!null column4:14!null column5:15!null column6:16!null column7:17!null column9:19!null
  │    ├── cardinality: [6 - 6]
+ │    ├── immutable
  │    ├── fd: ()-->(20)
  │    ├── values
  │    │    ├── columns: column1:11!null column2:12!null column3:13!null column4:14!null column5:15!null column6:16!null column7:17!null column8:18!null column9:19!null
@@ -384,7 +385,7 @@ insert order_line
  │    │    ├── (3045, 2, 10, 4, 56624, 0, 6, 273.360000, 'RsaCXoEzmssaF9m9cdLXe0Yh')
  │    │    └── (3045, 2, 10, 6, 92966, 0, 4, 366.760000, 'saCXoEzmssaF9m9cdLXe0Yhg')
  │    └── projections
- │         ├── crdb_internal.round_decimal_values(column8:18, 2) [as=ol_amount:21, outer=(18)]
+ │         ├── crdb_internal.round_decimal_values(column8:18, 2) [as=ol_amount:21, outer=(18), immutable]
  │         └── CAST(NULL AS TIMESTAMP) [as=column20:20]
  └── f-k-checks
       ├── f-k-checks-item: order_line(ol_w_id,ol_d_id,ol_o_id) -> order(o_w_id,o_d_id,o_id)
@@ -431,7 +432,7 @@ RETURNING w_name, w_street_1, w_street_2, w_city, w_state, w_zip
 project
  ├── columns: w_name:2 w_street_1:3 w_street_2:4 w_city:5 w_state:6 w_zip:7
  ├── cardinality: [0 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(2-7)
  └── update warehouse
@@ -440,12 +441,13 @@ project
       ├── update-mapping:
       │    └── w_ytd:20 => warehouse.w_ytd:9
       ├── cardinality: [0 - 1]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: ()
       ├── fd: ()-->(1-7)
       └── project
            ├── columns: w_ytd:20 w_id:10!null w_name:11 w_street_1:12 w_street_2:13 w_city:14 w_state:15 w_zip:16 w_tax:17 warehouse.w_ytd:18
            ├── cardinality: [0 - 1]
+           ├── immutable
            ├── key: ()
            ├── fd: ()-->(10-18,20)
            ├── scan warehouse
@@ -455,7 +457,7 @@ project
            │    ├── key: ()
            │    └── fd: ()-->(10-18)
            └── projections
-                └── crdb_internal.round_decimal_values(warehouse.w_ytd:18 + 3860.61, 2) [as=w_ytd:20, outer=(18)]
+                └── crdb_internal.round_decimal_values(warehouse.w_ytd:18 + 3860.61, 2) [as=w_ytd:20, outer=(18), immutable]
 
 opt format=hide-qual
 UPDATE district SET d_ytd = d_ytd + 3860.61 WHERE (d_w_id = 10) AND (d_id = 5)
@@ -464,7 +466,7 @@ RETURNING d_name, d_street_1, d_street_2, d_city, d_state, d_zip
 project
  ├── columns: d_name:3 d_street_1:4 d_street_2:5 d_city:6 d_state:7 d_zip:8
  ├── cardinality: [0 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(3-8)
  └── update district
@@ -473,12 +475,13 @@ project
       ├── update-mapping:
       │    └── d_ytd:24 => district.d_ytd:10
       ├── cardinality: [0 - 1]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: ()
       ├── fd: ()-->(1-8)
       └── project
            ├── columns: d_ytd:24 d_id:12!null d_w_id:13!null d_name:14 d_street_1:15 d_street_2:16 d_city:17 d_state:18 d_zip:19 d_tax:20 district.d_ytd:21 d_next_o_id:22
            ├── cardinality: [0 - 1]
+           ├── immutable
            ├── key: ()
            ├── fd: ()-->(12-22,24)
            ├── scan district
@@ -488,7 +491,7 @@ project
            │    ├── key: ()
            │    └── fd: ()-->(12-22)
            └── projections
-                └── crdb_internal.round_decimal_values(district.d_ytd:21 + 3860.61, 2) [as=d_ytd:24, outer=(21)]
+                └── crdb_internal.round_decimal_values(district.d_ytd:21 + 3860.61, 2) [as=d_ytd:24, outer=(21), immutable]
 
 opt format=hide-qual
 SELECT c_id
@@ -552,7 +555,7 @@ RETURNING
 project
  ├── columns: c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 case:49
  ├── cardinality: [0 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(4-17,49)
  ├── update customer
@@ -564,12 +567,13 @@ project
  │    │    ├── c_payment_cnt_new:45 => c_payment_cnt:19
  │    │    └── c_data_new:46 => c_data:21
  │    ├── cardinality: [0 - 1]
- │    ├── side-effects, mutations
+ │    ├── volatile, side-effects, mutations
  │    ├── key: ()
  │    ├── fd: ()-->(1-17,21)
  │    └── project
  │         ├── columns: c_balance:47 c_ytd_payment:48 c_payment_cnt_new:45 c_data_new:46 c_id:22!null c_d_id:23!null c_w_id:24!null c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 customer.c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
  │         ├── cardinality: [0 - 1]
+ │         ├── immutable
  │         ├── key: ()
  │         ├── fd: ()-->(22-42,45-48)
  │         ├── scan customer
@@ -579,12 +583,12 @@ project
  │         │    ├── key: ()
  │         │    └── fd: ()-->(22-42)
  │         └── projections
- │              ├── crdb_internal.round_decimal_values(customer.c_balance:38 - 3860.61, 2) [as=c_balance:47, outer=(38)]
- │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:39 + 3860.61, 2) [as=c_ytd_payment:48, outer=(39)]
+ │              ├── crdb_internal.round_decimal_values(customer.c_balance:38 - 3860.61, 2) [as=c_balance:47, outer=(38), immutable]
+ │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:39 + 3860.61, 2) [as=c_ytd_payment:48, outer=(39), immutable]
  │              ├── c_payment_cnt:40 + 1 [as=c_payment_cnt_new:45, outer=(40)]
- │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42, 500) ELSE c_data:42 END [as=c_data_new:46, outer=(22-24,35,42)]
+ │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42, 500) ELSE c_data:42 END [as=c_data_new:46, outer=(22-24,35,42), immutable]
  └── projections
-      └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:49, outer=(14,21)]
+      └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:49, outer=(14,21), immutable]
 
 opt format=hide-qual
 INSERT INTO history
@@ -606,11 +610,11 @@ insert history
  │    └── column8:17 => h_data:9
  ├── input binding: &1
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── values
  │    ├── columns: column1:10!null column2:11!null column3:12!null column4:13!null column5:14!null column7:16!null column8:17!null column18:18 h_amount:19!null
  │    ├── cardinality: [1 - 1]
- │    ├── side-effects
+ │    ├── volatile, side-effects
  │    ├── key: ()
  │    ├── fd: ()-->(10-14,16-19)
  │    └── (1343, 5, 10, 5, 10, '2019-08-26 16:50:41+00:00', '8    Kdcgphy3', gen_random_uuid(), 3860.61)
@@ -806,7 +810,7 @@ RETURNING
 project
  ├── columns: o_d_id:2!null o_c_id:4
  ├── cardinality: [0 - 10]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: (2)
  ├── fd: (2)-->(4)
  └── update "order"
@@ -815,7 +819,7 @@ project
       ├── update-mapping:
       │    └── o_carrier_id_new:17 => o_carrier_id:6
       ├── cardinality: [0 - 10]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: (2)
       ├── fd: ()-->(1,3), (2)-->(4)
       └── project
@@ -877,10 +881,11 @@ update customer
  │    ├── c_balance:45 => customer.c_balance:17
  │    └── c_delivery_cnt_new:43 => c_delivery_cnt:20
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: c_balance:45 c_delivery_cnt_new:43 c_id:22!null c_d_id:23!null c_w_id:24!null c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
       ├── cardinality: [0 - 10]
+      ├── immutable
       ├── key: (22,23)
       ├── fd: ()-->(24), (22,23)-->(25-42,45), (41)-->(43)
       ├── scan customer
@@ -900,7 +905,7 @@ update customer
       │    ├── key: (22,23)
       │    └── fd: ()-->(24), (22,23)-->(25-42)
       └── projections
-           ├── crdb_internal.round_decimal_values(customer.c_balance:38 + CASE c_d_id:23 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 END, 2) [as=c_balance:45, outer=(23,38)]
+           ├── crdb_internal.round_decimal_values(customer.c_balance:38 + CASE c_d_id:23 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 END, 2) [as=c_balance:45, outer=(23,38), immutable]
            └── c_delivery_cnt:41 + 1 [as=c_delivery_cnt_new:43, outer=(41)]
 
 opt format=hide-qual
@@ -922,7 +927,7 @@ delete new_order
  ├── columns: <none>
  ├── fetch columns: no_o_id:4 no_d_id:5 no_w_id:6
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── scan new_order
       ├── columns: no_o_id:4!null no_d_id:5!null no_w_id:6!null
       ├── constraint: /6/5/4
@@ -963,7 +968,7 @@ update order_line
  ├── update-mapping:
  │    └── ol_delivery_d_new:21 => ol_delivery_d:7
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: ol_delivery_d_new:21!null ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null ol_number:14!null ol_i_id:15!null ol_supply_w_id:16 ol_delivery_d:17 ol_quantity:18 ol_amount:19 ol_dist_info:20
       ├── key: (12,14)

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -27,7 +27,7 @@ RETURNING d_tax, d_next_o_id
 project
  ├── columns: d_tax:9 d_next_o_id:11
  ├── cardinality: [0 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(9,11)
  └── update district
@@ -36,7 +36,7 @@ project
       ├── update-mapping:
       │    └── d_next_o_id_new:23 => d_next_o_id:11
       ├── cardinality: [0 - 1]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: ()
       ├── fd: ()-->(1,2,9,11)
       └── project
@@ -153,7 +153,7 @@ insert "order"
  │    └── column7:15 => o_all_local:8
  ├── input binding: &1
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── values
  │    ├── columns: column1:9!null column2:10!null column3:11!null column4:12!null column5:13!null column6:14!null column7:15!null column16:16
  │    ├── cardinality: [1 - 1]
@@ -191,7 +191,7 @@ insert new_order
  │    └── column3:6 => no_w_id:3
  ├── input binding: &1
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── values
  │    ├── columns: column1:4!null column2:5!null column3:6!null
  │    ├── cardinality: [1 - 1]
@@ -314,11 +314,11 @@ update stock
  │    ├── s_order_cnt_new:37 => s_order_cnt:15
  │    └── s_remote_cnt_new:38 => s_remote_cnt:16
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: s_quantity_new:35 s_ytd_new:36 s_order_cnt_new:37 s_remote_cnt_new:38 s_i_id:18!null s_w_id:19!null s_quantity:20 s_dist_01:21 s_dist_02:22 s_dist_03:23 s_dist_04:24 s_dist_05:25 s_dist_06:26 s_dist_07:27 s_dist_08:28 s_dist_09:29 s_dist_10:30 s_ytd:31 s_order_cnt:32 s_remote_cnt:33 s_data:34
       ├── cardinality: [0 - 13]
-      ├── side-effects
+      ├── volatile, side-effects
       ├── key: (18)
       ├── fd: ()-->(19), (18)-->(20-35), (18)-->(36-38)
       ├── scan stock
@@ -341,7 +341,7 @@ update stock
       │    ├── key: (18)
       │    └── fd: ()-->(19), (18)-->(20-34)
       └── projections
-           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 26 WHEN (7853, 0) THEN 10 WHEN (8497, 0) THEN 62 WHEN (10904, 0) THEN 54 WHEN (16152, 0) THEN 80 WHEN (41382, 0) THEN 18 WHEN (55952, 0) THEN 56 WHEN (64817, 0) THEN 26 WHEN (66335, 0) THEN 30 WHEN (76567, 0) THEN 71 WHEN (81680, 0) THEN 51 WHEN (89641, 0) THEN 51 WHEN (89905, 0) THEN 77 ELSE crdb_internal.force_error('', 'unknown case') END [as=s_quantity_new:35, outer=(18,19), side-effects]
+           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 26 WHEN (7853, 0) THEN 10 WHEN (8497, 0) THEN 62 WHEN (10904, 0) THEN 54 WHEN (16152, 0) THEN 80 WHEN (41382, 0) THEN 18 WHEN (55952, 0) THEN 56 WHEN (64817, 0) THEN 26 WHEN (66335, 0) THEN 30 WHEN (76567, 0) THEN 71 WHEN (81680, 0) THEN 51 WHEN (89641, 0) THEN 51 WHEN (89905, 0) THEN 77 ELSE crdb_internal.force_error('', 'unknown case') END [as=s_quantity_new:35, outer=(18,19), volatile, side-effects]
            ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 6 WHEN (7853, 0) THEN 9 WHEN (8497, 0) THEN 13 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 2 WHEN (41382, 0) THEN 3 WHEN (55952, 0) THEN 10 WHEN (64817, 0) THEN 31 WHEN (66335, 0) THEN 9 WHEN (76567, 0) THEN 7 WHEN (81680, 0) THEN 4 WHEN (89641, 0) THEN 13 WHEN (89905, 0) THEN 20 END [as=s_ytd_new:36, outer=(18,19)]
            ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 1 WHEN (7853, 0) THEN 1 WHEN (8497, 0) THEN 2 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 1 WHEN (41382, 0) THEN 1 WHEN (55952, 0) THEN 1 WHEN (64817, 0) THEN 4 WHEN (66335, 0) THEN 2 WHEN (76567, 0) THEN 1 WHEN (81680, 0) THEN 1 WHEN (89641, 0) THEN 2 WHEN (89905, 0) THEN 4 END [as=s_order_cnt_new:37, outer=(18,19)]
            └── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 0 WHEN (7853, 0) THEN 0 WHEN (8497, 0) THEN 0 WHEN (10904, 0) THEN 0 WHEN (16152, 0) THEN 0 WHEN (41382, 0) THEN 0 WHEN (55952, 0) THEN 0 WHEN (64817, 0) THEN 0 WHEN (66335, 0) THEN 0 WHEN (76567, 0) THEN 0 WHEN (81680, 0) THEN 0 WHEN (89641, 0) THEN 0 WHEN (89905, 0) THEN 0 END [as=s_remote_cnt_new:38, outer=(18,19)]
@@ -372,10 +372,11 @@ insert order_line
  │    └── column9:19 => ol_dist_info:10
  ├── input binding: &1
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── project
  │    ├── columns: ol_amount:21 column20:20 column1:11!null column2:12!null column3:13!null column4:14!null column5:15!null column6:16!null column7:17!null column9:19!null
  │    ├── cardinality: [6 - 6]
+ │    ├── immutable
  │    ├── fd: ()-->(20)
  │    ├── values
  │    │    ├── columns: column1:11!null column2:12!null column3:13!null column4:14!null column5:15!null column6:16!null column7:17!null column8:18!null column9:19!null
@@ -387,7 +388,7 @@ insert order_line
  │    │    ├── (3045, 2, 10, 4, 56624, 0, 6, 273.360000, 'RsaCXoEzmssaF9m9cdLXe0Yh')
  │    │    └── (3045, 2, 10, 6, 92966, 0, 4, 366.760000, 'saCXoEzmssaF9m9cdLXe0Yhg')
  │    └── projections
- │         ├── crdb_internal.round_decimal_values(column8:18, 2) [as=ol_amount:21, outer=(18)]
+ │         ├── crdb_internal.round_decimal_values(column8:18, 2) [as=ol_amount:21, outer=(18), immutable]
  │         └── CAST(NULL AS TIMESTAMP) [as=column20:20]
  └── f-k-checks
       ├── f-k-checks-item: order_line(ol_w_id,ol_d_id,ol_o_id) -> order(o_w_id,o_d_id,o_id)
@@ -434,7 +435,7 @@ RETURNING w_name, w_street_1, w_street_2, w_city, w_state, w_zip
 project
  ├── columns: w_name:2 w_street_1:3 w_street_2:4 w_city:5 w_state:6 w_zip:7
  ├── cardinality: [0 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(2-7)
  └── update warehouse
@@ -443,12 +444,13 @@ project
       ├── update-mapping:
       │    └── w_ytd:20 => warehouse.w_ytd:9
       ├── cardinality: [0 - 1]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: ()
       ├── fd: ()-->(1-7)
       └── project
            ├── columns: w_ytd:20 w_id:10!null w_name:11 w_street_1:12 w_street_2:13 w_city:14 w_state:15 w_zip:16 w_tax:17 warehouse.w_ytd:18
            ├── cardinality: [0 - 1]
+           ├── immutable
            ├── key: ()
            ├── fd: ()-->(10-18,20)
            ├── scan warehouse
@@ -458,7 +460,7 @@ project
            │    ├── key: ()
            │    └── fd: ()-->(10-18)
            └── projections
-                └── crdb_internal.round_decimal_values(warehouse.w_ytd:18 + 3860.61, 2) [as=w_ytd:20, outer=(18)]
+                └── crdb_internal.round_decimal_values(warehouse.w_ytd:18 + 3860.61, 2) [as=w_ytd:20, outer=(18), immutable]
 
 opt format=hide-qual
 UPDATE district SET d_ytd = d_ytd + 3860.61 WHERE (d_w_id = 10) AND (d_id = 5)
@@ -467,7 +469,7 @@ RETURNING d_name, d_street_1, d_street_2, d_city, d_state, d_zip
 project
  ├── columns: d_name:3 d_street_1:4 d_street_2:5 d_city:6 d_state:7 d_zip:8
  ├── cardinality: [0 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(3-8)
  └── update district
@@ -476,12 +478,13 @@ project
       ├── update-mapping:
       │    └── d_ytd:24 => district.d_ytd:10
       ├── cardinality: [0 - 1]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: ()
       ├── fd: ()-->(1-8)
       └── project
            ├── columns: d_ytd:24 d_id:12!null d_w_id:13!null d_name:14 d_street_1:15 d_street_2:16 d_city:17 d_state:18 d_zip:19 d_tax:20 district.d_ytd:21 d_next_o_id:22
            ├── cardinality: [0 - 1]
+           ├── immutable
            ├── key: ()
            ├── fd: ()-->(12-22,24)
            ├── scan district
@@ -491,7 +494,7 @@ project
            │    ├── key: ()
            │    └── fd: ()-->(12-22)
            └── projections
-                └── crdb_internal.round_decimal_values(district.d_ytd:21 + 3860.61, 2) [as=d_ytd:24, outer=(21)]
+                └── crdb_internal.round_decimal_values(district.d_ytd:21 + 3860.61, 2) [as=d_ytd:24, outer=(21), immutable]
 
 opt format=hide-qual
 SELECT c_id
@@ -555,7 +558,7 @@ RETURNING
 project
  ├── columns: c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 case:49
  ├── cardinality: [0 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(4-17,49)
  ├── update customer
@@ -567,12 +570,13 @@ project
  │    │    ├── c_payment_cnt_new:45 => c_payment_cnt:19
  │    │    └── c_data_new:46 => c_data:21
  │    ├── cardinality: [0 - 1]
- │    ├── side-effects, mutations
+ │    ├── volatile, side-effects, mutations
  │    ├── key: ()
  │    ├── fd: ()-->(1-17,21)
  │    └── project
  │         ├── columns: c_balance:47 c_ytd_payment:48 c_payment_cnt_new:45 c_data_new:46 c_id:22!null c_d_id:23!null c_w_id:24!null c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 customer.c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
  │         ├── cardinality: [0 - 1]
+ │         ├── immutable
  │         ├── key: ()
  │         ├── fd: ()-->(22-42,45-48)
  │         ├── scan customer
@@ -582,12 +586,12 @@ project
  │         │    ├── key: ()
  │         │    └── fd: ()-->(22-42)
  │         └── projections
- │              ├── crdb_internal.round_decimal_values(customer.c_balance:38 - 3860.61, 2) [as=c_balance:47, outer=(38)]
- │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:39 + 3860.61, 2) [as=c_ytd_payment:48, outer=(39)]
+ │              ├── crdb_internal.round_decimal_values(customer.c_balance:38 - 3860.61, 2) [as=c_balance:47, outer=(38), immutable]
+ │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:39 + 3860.61, 2) [as=c_ytd_payment:48, outer=(39), immutable]
  │              ├── c_payment_cnt:40 + 1 [as=c_payment_cnt_new:45, outer=(40)]
- │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42, 500) ELSE c_data:42 END [as=c_data_new:46, outer=(22-24,35,42)]
+ │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42, 500) ELSE c_data:42 END [as=c_data_new:46, outer=(22-24,35,42), immutable]
  └── projections
-      └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:49, outer=(14,21)]
+      └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:49, outer=(14,21), immutable]
 
 opt format=hide-qual
 INSERT INTO history
@@ -609,11 +613,11 @@ insert history
  │    └── column8:17 => h_data:9
  ├── input binding: &1
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── values
  │    ├── columns: column1:10!null column2:11!null column3:12!null column4:13!null column5:14!null column7:16!null column8:17!null column18:18 h_amount:19!null
  │    ├── cardinality: [1 - 1]
- │    ├── side-effects
+ │    ├── volatile, side-effects
  │    ├── key: ()
  │    ├── fd: ()-->(10-14,16-19)
  │    └── (1343, 5, 10, 5, 10, '2019-08-26 16:50:41+00:00', '8    Kdcgphy3', gen_random_uuid(), 3860.61)
@@ -809,7 +813,7 @@ RETURNING
 project
  ├── columns: o_d_id:2!null o_c_id:4
  ├── cardinality: [0 - 10]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: (2)
  ├── fd: (2)-->(4)
  └── update "order"
@@ -818,7 +822,7 @@ project
       ├── update-mapping:
       │    └── o_carrier_id_new:17 => o_carrier_id:6
       ├── cardinality: [0 - 10]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: (2)
       ├── fd: ()-->(1,3), (2)-->(4)
       └── project
@@ -880,10 +884,11 @@ update customer
  │    ├── c_balance:45 => customer.c_balance:17
  │    └── c_delivery_cnt_new:43 => c_delivery_cnt:20
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: c_balance:45 c_delivery_cnt_new:43 c_id:22!null c_d_id:23!null c_w_id:24!null c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
       ├── cardinality: [0 - 10]
+      ├── immutable
       ├── key: (22,23)
       ├── fd: ()-->(24), (22,23)-->(25-42,45), (41)-->(43)
       ├── scan customer
@@ -903,7 +908,7 @@ update customer
       │    ├── key: (22,23)
       │    └── fd: ()-->(24), (22,23)-->(25-42)
       └── projections
-           ├── crdb_internal.round_decimal_values(customer.c_balance:38 + CASE c_d_id:23 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 END, 2) [as=c_balance:45, outer=(23,38)]
+           ├── crdb_internal.round_decimal_values(customer.c_balance:38 + CASE c_d_id:23 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 END, 2) [as=c_balance:45, outer=(23,38), immutable]
            └── c_delivery_cnt:41 + 1 [as=c_delivery_cnt_new:43, outer=(41)]
 
 opt format=hide-qual
@@ -925,7 +930,7 @@ delete new_order
  ├── columns: <none>
  ├── fetch columns: no_o_id:4 no_d_id:5 no_w_id:6
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── scan new_order
       ├── columns: no_o_id:4!null no_d_id:5!null no_w_id:6!null
       ├── constraint: /6/5/4
@@ -965,7 +970,7 @@ update order_line
  ├── update-mapping:
  │    └── ol_delivery_d_new:21 => ol_delivery_d:7
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: ol_delivery_d_new:21!null ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null ol_number:14!null ol_i_id:15!null ol_supply_w_id:16 ol_delivery_d:17 ol_quantity:18 ol_amount:19 ol_dist_info:20
       ├── key: (12,14)

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -21,7 +21,7 @@ RETURNING d_tax, d_next_o_id
 project
  ├── columns: d_tax:9 d_next_o_id:11
  ├── cardinality: [0 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(9,11)
  └── update district
@@ -30,7 +30,7 @@ project
       ├── update-mapping:
       │    └── d_next_o_id_new:23 => d_next_o_id:11
       ├── cardinality: [0 - 1]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: ()
       ├── fd: ()-->(1,2,9,11)
       └── project
@@ -147,7 +147,7 @@ insert "order"
  │    └── column7:15 => o_all_local:8
  ├── input binding: &1
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── values
  │    ├── columns: column1:9!null column2:10!null column3:11!null column4:12!null column5:13!null column6:14!null column7:15!null column16:16
  │    ├── cardinality: [1 - 1]
@@ -185,7 +185,7 @@ insert new_order
  │    └── column3:6 => no_w_id:3
  ├── input binding: &1
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── values
  │    ├── columns: column1:4!null column2:5!null column3:6!null
  │    ├── cardinality: [1 - 1]
@@ -308,11 +308,11 @@ update stock
  │    ├── s_order_cnt_new:37 => s_order_cnt:15
  │    └── s_remote_cnt_new:38 => s_remote_cnt:16
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: s_quantity_new:35 s_ytd_new:36 s_order_cnt_new:37 s_remote_cnt_new:38 s_i_id:18!null s_w_id:19!null s_quantity:20 s_dist_01:21 s_dist_02:22 s_dist_03:23 s_dist_04:24 s_dist_05:25 s_dist_06:26 s_dist_07:27 s_dist_08:28 s_dist_09:29 s_dist_10:30 s_ytd:31 s_order_cnt:32 s_remote_cnt:33 s_data:34
       ├── cardinality: [0 - 13]
-      ├── side-effects
+      ├── volatile, side-effects
       ├── key: (18)
       ├── fd: ()-->(19), (18)-->(20-35), (18)-->(36-38)
       ├── scan stock
@@ -335,7 +335,7 @@ update stock
       │    ├── key: (18)
       │    └── fd: ()-->(19), (18)-->(20-34)
       └── projections
-           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 26 WHEN (7853, 0) THEN 10 WHEN (8497, 0) THEN 62 WHEN (10904, 0) THEN 54 WHEN (16152, 0) THEN 80 WHEN (41382, 0) THEN 18 WHEN (55952, 0) THEN 56 WHEN (64817, 0) THEN 26 WHEN (66335, 0) THEN 30 WHEN (76567, 0) THEN 71 WHEN (81680, 0) THEN 51 WHEN (89641, 0) THEN 51 WHEN (89905, 0) THEN 77 ELSE crdb_internal.force_error('', 'unknown case') END [as=s_quantity_new:35, outer=(18,19), side-effects]
+           ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 26 WHEN (7853, 0) THEN 10 WHEN (8497, 0) THEN 62 WHEN (10904, 0) THEN 54 WHEN (16152, 0) THEN 80 WHEN (41382, 0) THEN 18 WHEN (55952, 0) THEN 56 WHEN (64817, 0) THEN 26 WHEN (66335, 0) THEN 30 WHEN (76567, 0) THEN 71 WHEN (81680, 0) THEN 51 WHEN (89641, 0) THEN 51 WHEN (89905, 0) THEN 77 ELSE crdb_internal.force_error('', 'unknown case') END [as=s_quantity_new:35, outer=(18,19), volatile, side-effects]
            ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 6 WHEN (7853, 0) THEN 9 WHEN (8497, 0) THEN 13 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 2 WHEN (41382, 0) THEN 3 WHEN (55952, 0) THEN 10 WHEN (64817, 0) THEN 31 WHEN (66335, 0) THEN 9 WHEN (76567, 0) THEN 7 WHEN (81680, 0) THEN 4 WHEN (89641, 0) THEN 13 WHEN (89905, 0) THEN 20 END [as=s_ytd_new:36, outer=(18,19)]
            ├── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 1 WHEN (7853, 0) THEN 1 WHEN (8497, 0) THEN 2 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 1 WHEN (41382, 0) THEN 1 WHEN (55952, 0) THEN 1 WHEN (64817, 0) THEN 4 WHEN (66335, 0) THEN 2 WHEN (76567, 0) THEN 1 WHEN (81680, 0) THEN 1 WHEN (89641, 0) THEN 2 WHEN (89905, 0) THEN 4 END [as=s_order_cnt_new:37, outer=(18,19)]
            └── CASE (s_i_id:18, s_w_id:19) WHEN (6823, 0) THEN 0 WHEN (7853, 0) THEN 0 WHEN (8497, 0) THEN 0 WHEN (10904, 0) THEN 0 WHEN (16152, 0) THEN 0 WHEN (41382, 0) THEN 0 WHEN (55952, 0) THEN 0 WHEN (64817, 0) THEN 0 WHEN (66335, 0) THEN 0 WHEN (76567, 0) THEN 0 WHEN (81680, 0) THEN 0 WHEN (89641, 0) THEN 0 WHEN (89905, 0) THEN 0 END [as=s_remote_cnt_new:38, outer=(18,19)]
@@ -366,10 +366,11 @@ insert order_line
  │    └── column9:19 => ol_dist_info:10
  ├── input binding: &1
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── project
  │    ├── columns: ol_amount:21 column20:20 column1:11!null column2:12!null column3:13!null column4:14!null column5:15!null column6:16!null column7:17!null column9:19!null
  │    ├── cardinality: [6 - 6]
+ │    ├── immutable
  │    ├── fd: ()-->(20)
  │    ├── values
  │    │    ├── columns: column1:11!null column2:12!null column3:13!null column4:14!null column5:15!null column6:16!null column7:17!null column8:18!null column9:19!null
@@ -381,7 +382,7 @@ insert order_line
  │    │    ├── (3045, 2, 10, 4, 56624, 0, 6, 273.360000, 'RsaCXoEzmssaF9m9cdLXe0Yh')
  │    │    └── (3045, 2, 10, 6, 92966, 0, 4, 366.760000, 'saCXoEzmssaF9m9cdLXe0Yhg')
  │    └── projections
- │         ├── crdb_internal.round_decimal_values(column8:18, 2) [as=ol_amount:21, outer=(18)]
+ │         ├── crdb_internal.round_decimal_values(column8:18, 2) [as=ol_amount:21, outer=(18), immutable]
  │         └── CAST(NULL AS TIMESTAMP) [as=column20:20]
  └── f-k-checks
       ├── f-k-checks-item: order_line(ol_w_id,ol_d_id,ol_o_id) -> order(o_w_id,o_d_id,o_id)
@@ -428,7 +429,7 @@ RETURNING w_name, w_street_1, w_street_2, w_city, w_state, w_zip
 project
  ├── columns: w_name:2 w_street_1:3 w_street_2:4 w_city:5 w_state:6 w_zip:7
  ├── cardinality: [0 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(2-7)
  └── update warehouse
@@ -437,12 +438,13 @@ project
       ├── update-mapping:
       │    └── w_ytd:20 => warehouse.w_ytd:9
       ├── cardinality: [0 - 1]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: ()
       ├── fd: ()-->(1-7)
       └── project
            ├── columns: w_ytd:20 w_id:10!null w_name:11 w_street_1:12 w_street_2:13 w_city:14 w_state:15 w_zip:16 w_tax:17 warehouse.w_ytd:18
            ├── cardinality: [0 - 1]
+           ├── immutable
            ├── key: ()
            ├── fd: ()-->(10-18,20)
            ├── scan warehouse
@@ -452,7 +454,7 @@ project
            │    ├── key: ()
            │    └── fd: ()-->(10-18)
            └── projections
-                └── crdb_internal.round_decimal_values(warehouse.w_ytd:18 + 3860.61, 2) [as=w_ytd:20, outer=(18)]
+                └── crdb_internal.round_decimal_values(warehouse.w_ytd:18 + 3860.61, 2) [as=w_ytd:20, outer=(18), immutable]
 
 opt format=hide-qual
 UPDATE district SET d_ytd = d_ytd + 3860.61 WHERE (d_w_id = 10) AND (d_id = 5)
@@ -461,7 +463,7 @@ RETURNING d_name, d_street_1, d_street_2, d_city, d_state, d_zip
 project
  ├── columns: d_name:3 d_street_1:4 d_street_2:5 d_city:6 d_state:7 d_zip:8
  ├── cardinality: [0 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(3-8)
  └── update district
@@ -470,12 +472,13 @@ project
       ├── update-mapping:
       │    └── d_ytd:24 => district.d_ytd:10
       ├── cardinality: [0 - 1]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: ()
       ├── fd: ()-->(1-8)
       └── project
            ├── columns: d_ytd:24 d_id:12!null d_w_id:13!null d_name:14 d_street_1:15 d_street_2:16 d_city:17 d_state:18 d_zip:19 d_tax:20 district.d_ytd:21 d_next_o_id:22
            ├── cardinality: [0 - 1]
+           ├── immutable
            ├── key: ()
            ├── fd: ()-->(12-22,24)
            ├── scan district
@@ -485,7 +488,7 @@ project
            │    ├── key: ()
            │    └── fd: ()-->(12-22)
            └── projections
-                └── crdb_internal.round_decimal_values(district.d_ytd:21 + 3860.61, 2) [as=d_ytd:24, outer=(21)]
+                └── crdb_internal.round_decimal_values(district.d_ytd:21 + 3860.61, 2) [as=d_ytd:24, outer=(21), immutable]
 
 opt format=hide-qual
 SELECT c_id
@@ -549,7 +552,7 @@ RETURNING
 project
  ├── columns: c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 case:49
  ├── cardinality: [0 - 1]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(4-17,49)
  ├── update customer
@@ -561,12 +564,13 @@ project
  │    │    ├── c_payment_cnt_new:45 => c_payment_cnt:19
  │    │    └── c_data_new:46 => c_data:21
  │    ├── cardinality: [0 - 1]
- │    ├── side-effects, mutations
+ │    ├── volatile, side-effects, mutations
  │    ├── key: ()
  │    ├── fd: ()-->(1-17,21)
  │    └── project
  │         ├── columns: c_balance:47 c_ytd_payment:48 c_payment_cnt_new:45 c_data_new:46 c_id:22!null c_d_id:23!null c_w_id:24!null c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 customer.c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
  │         ├── cardinality: [0 - 1]
+ │         ├── immutable
  │         ├── key: ()
  │         ├── fd: ()-->(22-42,45-48)
  │         ├── scan customer
@@ -576,12 +580,12 @@ project
  │         │    ├── key: ()
  │         │    └── fd: ()-->(22-42)
  │         └── projections
- │              ├── crdb_internal.round_decimal_values(customer.c_balance:38 - 3860.61, 2) [as=c_balance:47, outer=(38)]
- │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:39 + 3860.61, 2) [as=c_ytd_payment:48, outer=(39)]
+ │              ├── crdb_internal.round_decimal_values(customer.c_balance:38 - 3860.61, 2) [as=c_balance:47, outer=(38), immutable]
+ │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:39 + 3860.61, 2) [as=c_ytd_payment:48, outer=(39), immutable]
  │              ├── c_payment_cnt:40 + 1 [as=c_payment_cnt_new:45, outer=(40)]
- │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42, 500) ELSE c_data:42 END [as=c_data_new:46, outer=(22-24,35,42)]
+ │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42, 500) ELSE c_data:42 END [as=c_data_new:46, outer=(22-24,35,42), immutable]
  └── projections
-      └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:49, outer=(14,21)]
+      └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:49, outer=(14,21), immutable]
 
 opt format=hide-qual
 INSERT INTO history
@@ -603,11 +607,11 @@ insert history
  │    └── column8:17 => h_data:9
  ├── input binding: &1
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── values
  │    ├── columns: column1:10!null column2:11!null column3:12!null column4:13!null column5:14!null column7:16!null column8:17!null column18:18 h_amount:19!null
  │    ├── cardinality: [1 - 1]
- │    ├── side-effects
+ │    ├── volatile, side-effects
  │    ├── key: ()
  │    ├── fd: ()-->(10-14,16-19)
  │    └── (1343, 5, 10, 5, 10, '2019-08-26 16:50:41+00:00', '8    Kdcgphy3', gen_random_uuid(), 3860.61)
@@ -807,7 +811,7 @@ RETURNING
 project
  ├── columns: o_d_id:2!null o_c_id:4
  ├── cardinality: [0 - 10]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: (2)
  ├── fd: (2)-->(4)
  └── update "order"
@@ -816,7 +820,7 @@ project
       ├── update-mapping:
       │    └── o_carrier_id_new:17 => o_carrier_id:6
       ├── cardinality: [0 - 10]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: (2)
       ├── fd: ()-->(1,3), (2)-->(4)
       └── project
@@ -878,10 +882,11 @@ update customer
  │    ├── c_balance:45 => customer.c_balance:17
  │    └── c_delivery_cnt_new:43 => c_delivery_cnt:20
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: c_balance:45 c_delivery_cnt_new:43 c_id:22!null c_d_id:23!null c_w_id:24!null c_first:25 c_middle:26 c_last:27 c_street_1:28 c_street_2:29 c_city:30 c_state:31 c_zip:32 c_phone:33 c_since:34 c_credit:35 c_credit_lim:36 c_discount:37 customer.c_balance:38 c_ytd_payment:39 c_payment_cnt:40 c_delivery_cnt:41 c_data:42
       ├── cardinality: [0 - 10]
+      ├── immutable
       ├── key: (22,23)
       ├── fd: ()-->(24), (22,23)-->(25-42,45), (41)-->(43)
       ├── scan customer
@@ -901,7 +906,7 @@ update customer
       │    ├── key: (22,23)
       │    └── fd: ()-->(24), (22,23)-->(25-42)
       └── projections
-           ├── crdb_internal.round_decimal_values(customer.c_balance:38 + CASE c_d_id:23 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 END, 2) [as=c_balance:45, outer=(23,38)]
+           ├── crdb_internal.round_decimal_values(customer.c_balance:38 + CASE c_d_id:23 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 END, 2) [as=c_balance:45, outer=(23,38), immutable]
            └── c_delivery_cnt:41 + 1 [as=c_delivery_cnt_new:43, outer=(41)]
 
 opt format=hide-qual
@@ -923,7 +928,7 @@ delete new_order
  ├── columns: <none>
  ├── fetch columns: no_o_id:4 no_d_id:5 no_w_id:6
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── scan new_order
       ├── columns: no_o_id:4!null no_d_id:5!null no_w_id:6!null
       ├── constraint: /6/5/4
@@ -963,7 +968,7 @@ update order_line
  ├── update-mapping:
  │    └── ol_delivery_d_new:21 => ol_delivery_d:7
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: ol_delivery_d_new:21!null ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null ol_number:14!null ol_i_id:15!null ol_supply_w_id:16 ol_delivery_d:17 ol_quantity:18 ol_amount:19 ol_dist_info:20
       ├── key: (12,14)

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -691,16 +691,19 @@ ORDER BY
 ----
 sort
  ├── columns: supp_nation:42!null cust_nation:46!null l_year:49 revenue:51!null
+ ├── immutable
  ├── key: (42,46,49)
  ├── fd: (42,46,49)-->(51)
  ├── ordering: +42,+46,+49
  └── group-by
       ├── columns: n1.n_name:42!null n2.n_name:46!null l_year:49 sum:51!null
       ├── grouping columns: n1.n_name:42!null n2.n_name:46!null l_year:49
+      ├── immutable
       ├── key: (42,46,49)
       ├── fd: (42,46,49)-->(51)
       ├── project
       │    ├── columns: l_year:49 volume:50!null n1.n_name:42!null n2.n_name:46!null
+      │    ├── immutable
       │    ├── inner-join (hash)
       │    │    ├── columns: s_suppkey:1!null s_nationkey:4!null l_orderkey:8!null l_suppkey:10!null l_extendedprice:13!null l_discount:14!null l_shipdate:18!null o_orderkey:24!null o_custkey:25!null c_custkey:33!null c_nationkey:36!null n1.n_nationkey:41!null n1.n_name:42!null n2.n_nationkey:45!null n2.n_name:46!null
       │    │    ├── fd: (1)-->(4), (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8), (1)==(10), (10)==(1), (4)==(41), (41)==(4)
@@ -744,7 +747,7 @@ sort
       │    │         ├── s_suppkey:1 = l_suppkey:10 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
       │    │         └── s_nationkey:4 = n1.n_nationkey:41 [outer=(4,41), constraints=(/4: (/NULL - ]; /41: (/NULL - ]), fd=(4)==(41), (41)==(4)]
       │    └── projections
-      │         ├── extract('year', l_shipdate:18) [as=l_year:49, outer=(18)]
+      │         ├── extract('year', l_shipdate:18) [as=l_year:49, outer=(18), immutable]
       │         └── l_extendedprice:13 * (1.0 - l_discount:14) [as=volume:50, outer=(13,14)]
       └── aggregations
            └── sum [as=sum:51, outer=(50)]
@@ -807,24 +810,27 @@ ORDER BY
 ----
 sort
  ├── columns: o_year:61 mkt_share:66!null
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: (61)
  ├── fd: (61)-->(66)
  ├── ordering: +61
  └── project
       ├── columns: mkt_share:66!null o_year:61
-      ├── side-effects
+      ├── immutable, side-effects
       ├── key: (61)
       ├── fd: (61)-->(66)
       ├── group-by
       │    ├── columns: o_year:61 sum:64!null sum:65!null
       │    ├── grouping columns: o_year:61
+      │    ├── immutable
       │    ├── key: (61)
       │    ├── fd: (61)-->(64,65)
       │    ├── project
       │    │    ├── columns: column63:63!null o_year:61 volume:62!null
+      │    │    ├── immutable
       │    │    ├── project
       │    │    │    ├── columns: o_year:61 volume:62!null n2.n_name:55!null
+      │    │    │    ├── immutable
       │    │    │    ├── inner-join (hash)
       │    │    │    │    ├── columns: p_partkey:1!null p_type:5!null s_suppkey:10!null s_nationkey:13!null l_orderkey:17!null l_partkey:18!null l_suppkey:19!null l_extendedprice:22!null l_discount:23!null o_orderkey:33!null o_custkey:34!null o_orderdate:37!null c_custkey:42!null c_nationkey:45!null n1.n_nationkey:50!null n1.n_regionkey:52!null n2.n_nationkey:54!null n2.n_name:55!null r_regionkey:58!null r_name:59!null
       │    │    │    │    ├── fd: ()-->(5,59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13), (1)==(18), (18)==(1)
@@ -913,7 +919,7 @@ sort
       │    │    │    │    └── filters
       │    │    │    │         └── p_partkey:1 = l_partkey:18 [outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
       │    │    │    └── projections
-      │    │    │         ├── extract('year', o_orderdate:37) [as=o_year:61, outer=(37)]
+      │    │    │         ├── extract('year', o_orderdate:37) [as=o_year:61, outer=(37), immutable]
       │    │    │         └── l_extendedprice:22 * (1.0 - l_discount:23) [as=volume:62, outer=(22,23)]
       │    │    └── projections
       │    │         └── CASE WHEN n2.n_name:55 = 'BRAZIL' THEN volume:62 ELSE 0.0 END [as=column63:63, outer=(55,62)]
@@ -923,7 +929,7 @@ sort
       │         └── sum [as=sum:65, outer=(62)]
       │              └── volume:62
       └── projections
-           └── sum:64 / sum:65 [as=mkt_share:66, outer=(64,65), side-effects]
+           └── sum:64 / sum:65 [as=mkt_share:66, outer=(64,65), immutable, side-effects]
 
 # --------------------------------------------------
 # Q9
@@ -980,16 +986,19 @@ ORDER BY
 ----
 sort
  ├── columns: nation:48!null o_year:51 sum_profit:53!null
+ ├── immutable
  ├── key: (48,51)
  ├── fd: (48,51)-->(53)
  ├── ordering: +48,-51
  └── group-by
       ├── columns: n_name:48!null o_year:51 sum:53!null
       ├── grouping columns: n_name:48!null o_year:51
+      ├── immutable
       ├── key: (48,51)
       ├── fd: (48,51)-->(53)
       ├── project
       │    ├── columns: o_year:51 amount:52!null n_name:48!null
+      │    ├── immutable
       │    ├── inner-join (lookup part)
       │    │    ├── columns: p_partkey:1!null p_name:2!null s_suppkey:10!null s_nationkey:13!null l_orderkey:17!null l_partkey:18!null l_suppkey:19!null l_quantity:21!null l_extendedprice:22!null l_discount:23!null ps_partkey:33!null ps_suppkey:34!null ps_supplycost:36!null o_orderkey:38!null o_orderdate:42!null n_nationkey:47!null n_name:48!null
       │    │    ├── key columns: [18] = [1]
@@ -1034,7 +1043,7 @@ sort
       │    │    └── filters
       │    │         └── p_name:2 LIKE '%green%' [outer=(2), constraints=(/2: (/NULL - ])]
       │    └── projections
-      │         ├── extract('year', o_orderdate:42) [as=o_year:51, outer=(42)]
+      │         ├── extract('year', o_orderdate:42) [as=o_year:51, outer=(42), immutable]
       │         └── (l_extendedprice:22 * (1.0 - l_discount:23)) - (ps_supplycost:36 * l_quantity:21) [as=amount:52, outer=(21-23,36)]
       └── aggregations
            └── sum [as=sum:53, outer=(52)]
@@ -1487,7 +1496,7 @@ WHERE
 project
  ├── columns: promo_revenue:30
  ├── cardinality: [1 - 1]
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: ()
  ├── fd: ()-->(30)
  ├── scalar-group-by
@@ -1522,7 +1531,7 @@ project
  │         └── sum [as=sum:29, outer=(28)]
  │              └── column28:28
  └── projections
-      └── (sum:27 * 100.0) / sum:29 [as=promo_revenue:30, outer=(27,29), side-effects]
+      └── (sum:27 * 100.0) / sum:29 [as=promo_revenue:30, outer=(27,29), immutable, side-effects]
 
 # --------------------------------------------------
 # Q15
@@ -2393,23 +2402,28 @@ ORDER BY
 ----
 sort
  ├── columns: cntrycode:27 numcust:28!null totacctbal:29!null
+ ├── immutable
  ├── key: (27)
  ├── fd: (27)-->(28,29)
  ├── ordering: +27
  └── group-by
       ├── columns: cntrycode:27 count_rows:28!null sum:29!null
       ├── grouping columns: cntrycode:27
+      ├── immutable
       ├── key: (27)
       ├── fd: (27)-->(28,29)
       ├── project
       │    ├── columns: cntrycode:27 c_acctbal:6!null
+      │    ├── immutable
       │    ├── anti-join (lookup orders@o_ck)
       │    │    ├── columns: c_custkey:1!null c_phone:5!null c_acctbal:6!null
       │    │    ├── key columns: [1] = [19]
+      │    │    ├── immutable
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(5,6)
       │    │    ├── select
       │    │    │    ├── columns: c_custkey:1!null c_phone:5!null c_acctbal:6!null
+      │    │    │    ├── immutable
       │    │    │    ├── key: (1)
       │    │    │    ├── fd: (1)-->(5,6)
       │    │    │    ├── scan customer
@@ -2417,28 +2431,30 @@ sort
       │    │    │    │    ├── key: (1)
       │    │    │    │    └── fd: (1)-->(5,6)
       │    │    │    └── filters
-      │    │    │         ├── substring(c_phone:5, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [outer=(5)]
-      │    │    │         └── gt [outer=(6), subquery, constraints=(/6: (/NULL - ])]
+      │    │    │         ├── substring(c_phone:5, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [outer=(5), immutable]
+      │    │    │         └── gt [outer=(6), immutable, subquery, constraints=(/6: (/NULL - ])]
       │    │    │              ├── c_acctbal:6
       │    │    │              └── subquery
       │    │    │                   └── scalar-group-by
       │    │    │                        ├── columns: avg:17
       │    │    │                        ├── cardinality: [1 - 1]
+      │    │    │                        ├── immutable
       │    │    │                        ├── key: ()
       │    │    │                        ├── fd: ()-->(17)
       │    │    │                        ├── select
       │    │    │                        │    ├── columns: c_phone:13!null c_acctbal:14!null
+      │    │    │                        │    ├── immutable
       │    │    │                        │    ├── scan customer
       │    │    │                        │    │    └── columns: c_phone:13!null c_acctbal:14!null
       │    │    │                        │    └── filters
       │    │    │                        │         ├── c_acctbal:14 > 0.0 [outer=(14), constraints=(/14: [/5e-324 - ]; tight)]
-      │    │    │                        │         └── substring(c_phone:13, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [outer=(13)]
+      │    │    │                        │         └── substring(c_phone:13, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [outer=(13), immutable]
       │    │    │                        └── aggregations
       │    │    │                             └── avg [as=avg:17, outer=(14)]
       │    │    │                                  └── c_acctbal:14
       │    │    └── filters (true)
       │    └── projections
-      │         └── substring(c_phone:5, 1, 2) [as=cntrycode:27, outer=(5)]
+      │         └── substring(c_phone:5, 1, 2) [as=cntrycode:27, outer=(5), immutable]
       └── aggregations
            ├── count-rows [as=count_rows:28]
            └── sum [as=sum:29, outer=(6)]

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -700,14 +700,17 @@ ORDER BY
 group-by
  ├── columns: supp_nation:42!null cust_nation:46!null l_year:49 revenue:51!null
  ├── grouping columns: n1.n_name:42!null n2.n_name:46!null l_year:49
+ ├── immutable
  ├── key: (42,46,49)
  ├── fd: (42,46,49)-->(51)
  ├── ordering: +42,+46,+49
  ├── sort
  │    ├── columns: n1.n_name:42!null n2.n_name:46!null l_year:49 volume:50!null
+ │    ├── immutable
  │    ├── ordering: +42,+46,+49
  │    └── project
  │         ├── columns: l_year:49 volume:50!null n1.n_name:42!null n2.n_name:46!null
+ │         ├── immutable
  │         ├── inner-join (hash)
  │         │    ├── columns: s_suppkey:1!null s_nationkey:4!null l_orderkey:8!null l_suppkey:10!null l_extendedprice:13!null l_discount:14!null l_shipdate:18!null o_orderkey:24!null o_custkey:25!null c_custkey:33!null c_nationkey:36!null n1.n_nationkey:41!null n1.n_name:42!null n2.n_nationkey:45!null n2.n_name:46!null
  │         │    ├── fd: (1)-->(4), (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8), (1)==(10), (10)==(1), (4)==(41), (41)==(4)
@@ -764,7 +767,7 @@ group-by
  │         │         ├── s_suppkey:1 = l_suppkey:10 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
  │         │         └── s_nationkey:4 = n1.n_nationkey:41 [outer=(4,41), constraints=(/4: (/NULL - ]; /41: (/NULL - ]), fd=(4)==(41), (41)==(4)]
  │         └── projections
- │              ├── extract('year', l_shipdate:18) [as=l_year:49, outer=(18)]
+ │              ├── extract('year', l_shipdate:18) [as=l_year:49, outer=(18), immutable]
  │              └── l_extendedprice:13 * (1.0 - l_discount:14) [as=volume:50, outer=(13,14)]
  └── aggregations
       └── sum [as=sum:51, outer=(50)]
@@ -827,24 +830,27 @@ ORDER BY
 ----
 sort
  ├── columns: o_year:61 mkt_share:66!null
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: (61)
  ├── fd: (61)-->(66)
  ├── ordering: +61
  └── project
       ├── columns: mkt_share:66!null o_year:61
-      ├── side-effects
+      ├── immutable, side-effects
       ├── key: (61)
       ├── fd: (61)-->(66)
       ├── group-by
       │    ├── columns: o_year:61 sum:64!null sum:65!null
       │    ├── grouping columns: o_year:61
+      │    ├── immutable
       │    ├── key: (61)
       │    ├── fd: (61)-->(64,65)
       │    ├── project
       │    │    ├── columns: column63:63!null o_year:61 volume:62!null
+      │    │    ├── immutable
       │    │    ├── project
       │    │    │    ├── columns: o_year:61 volume:62!null n2.n_name:55!null
+      │    │    │    ├── immutable
       │    │    │    ├── inner-join (lookup part)
       │    │    │    │    ├── columns: p_partkey:1!null p_type:5!null s_suppkey:10!null s_nationkey:13!null l_orderkey:17!null l_partkey:18!null l_suppkey:19!null l_extendedprice:22!null l_discount:23!null o_orderkey:33!null o_custkey:34!null o_orderdate:37!null c_custkey:42!null c_nationkey:45!null n1.n_nationkey:50!null n1.n_regionkey:52!null n2.n_nationkey:54!null n2.n_name:55!null r_regionkey:58!null r_name:59!null
       │    │    │    │    ├── key columns: [18] = [1]
@@ -921,7 +927,7 @@ sort
       │    │    │    │    └── filters
       │    │    │    │         └── p_type:5 = 'ECONOMY ANODIZED STEEL' [outer=(5), constraints=(/5: [/'ECONOMY ANODIZED STEEL' - /'ECONOMY ANODIZED STEEL']; tight), fd=()-->(5)]
       │    │    │    └── projections
-      │    │    │         ├── extract('year', o_orderdate:37) [as=o_year:61, outer=(37)]
+      │    │    │         ├── extract('year', o_orderdate:37) [as=o_year:61, outer=(37), immutable]
       │    │    │         └── l_extendedprice:22 * (1.0 - l_discount:23) [as=volume:62, outer=(22,23)]
       │    │    └── projections
       │    │         └── CASE WHEN n2.n_name:55 = 'BRAZIL' THEN volume:62 ELSE 0.0 END [as=column63:63, outer=(55,62)]
@@ -931,7 +937,7 @@ sort
       │         └── sum [as=sum:65, outer=(62)]
       │              └── volume:62
       └── projections
-           └── sum:64 / sum:65 [as=mkt_share:66, outer=(64,65), side-effects]
+           └── sum:64 / sum:65 [as=mkt_share:66, outer=(64,65), immutable, side-effects]
 
 # --------------------------------------------------
 # Q9
@@ -988,16 +994,19 @@ ORDER BY
 ----
 sort
  ├── columns: nation:48!null o_year:51 sum_profit:53!null
+ ├── immutable
  ├── key: (48,51)
  ├── fd: (48,51)-->(53)
  ├── ordering: +48,-51
  └── group-by
       ├── columns: n_name:48!null o_year:51 sum:53!null
       ├── grouping columns: n_name:48!null o_year:51
+      ├── immutable
       ├── key: (48,51)
       ├── fd: (48,51)-->(53)
       ├── project
       │    ├── columns: o_year:51 amount:52!null n_name:48!null
+      │    ├── immutable
       │    ├── inner-join (lookup part)
       │    │    ├── columns: p_partkey:1!null p_name:2!null s_suppkey:10!null s_nationkey:13!null l_orderkey:17!null l_partkey:18!null l_suppkey:19!null l_quantity:21!null l_extendedprice:22!null l_discount:23!null ps_partkey:33!null ps_suppkey:34!null ps_supplycost:36!null o_orderkey:38!null o_orderdate:42!null n_nationkey:47!null n_name:48!null
       │    │    ├── key columns: [18] = [1]
@@ -1042,7 +1051,7 @@ sort
       │    │    └── filters
       │    │         └── p_name:2 LIKE '%green%' [outer=(2), constraints=(/2: (/NULL - ])]
       │    └── projections
-      │         ├── extract('year', o_orderdate:42) [as=o_year:51, outer=(42)]
+      │         ├── extract('year', o_orderdate:42) [as=o_year:51, outer=(42), immutable]
       │         └── (l_extendedprice:22 * (1.0 - l_discount:23)) - (ps_supplycost:36 * l_quantity:21) [as=amount:52, outer=(21-23,36)]
       └── aggregations
            └── sum [as=sum:53, outer=(52)]
@@ -1476,7 +1485,7 @@ WHERE
 project
  ├── columns: promo_revenue:30
  ├── cardinality: [1 - 1]
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: ()
  ├── fd: ()-->(30)
  ├── scalar-group-by
@@ -1510,7 +1519,7 @@ project
  │         └── sum [as=sum:29, outer=(28)]
  │              └── column28:28
  └── projections
-      └── (sum:27 * 100.0) / sum:29 [as=promo_revenue:30, outer=(27,29), side-effects]
+      └── (sum:27 * 100.0) / sum:29 [as=promo_revenue:30, outer=(27,29), immutable, side-effects]
 
 # --------------------------------------------------
 # Q15
@@ -2344,22 +2353,27 @@ ORDER BY
 group-by
  ├── columns: cntrycode:27 numcust:28!null totacctbal:29!null
  ├── grouping columns: cntrycode:27
+ ├── immutable
  ├── key: (27)
  ├── fd: (27)-->(28,29)
  ├── ordering: +27
  ├── sort
  │    ├── columns: c_acctbal:6!null cntrycode:27
+ │    ├── immutable
  │    ├── ordering: +27
  │    └── project
  │         ├── columns: cntrycode:27 c_acctbal:6!null
+ │         ├── immutable
  │         ├── anti-join (merge)
  │         │    ├── columns: c_custkey:1!null c_phone:5!null c_acctbal:6!null
  │         │    ├── left ordering: +1
  │         │    ├── right ordering: +19
+ │         │    ├── immutable
  │         │    ├── key: (1)
  │         │    ├── fd: (1)-->(5,6)
  │         │    ├── select
  │         │    │    ├── columns: c_custkey:1!null c_phone:5!null c_acctbal:6!null
+ │         │    │    ├── immutable
  │         │    │    ├── key: (1)
  │         │    │    ├── fd: (1)-->(5,6)
  │         │    │    ├── ordering: +1
@@ -2369,22 +2383,24 @@ group-by
  │         │    │    │    ├── fd: (1)-->(5,6)
  │         │    │    │    └── ordering: +1
  │         │    │    └── filters
- │         │    │         ├── substring(c_phone:5, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [outer=(5)]
- │         │    │         └── gt [outer=(6), subquery, constraints=(/6: (/NULL - ])]
+ │         │    │         ├── substring(c_phone:5, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [outer=(5), immutable]
+ │         │    │         └── gt [outer=(6), immutable, subquery, constraints=(/6: (/NULL - ])]
  │         │    │              ├── c_acctbal:6
  │         │    │              └── subquery
  │         │    │                   └── scalar-group-by
  │         │    │                        ├── columns: avg:17
  │         │    │                        ├── cardinality: [1 - 1]
+ │         │    │                        ├── immutable
  │         │    │                        ├── key: ()
  │         │    │                        ├── fd: ()-->(17)
  │         │    │                        ├── select
  │         │    │                        │    ├── columns: c_phone:13!null c_acctbal:14!null
+ │         │    │                        │    ├── immutable
  │         │    │                        │    ├── scan customer
  │         │    │                        │    │    └── columns: c_phone:13!null c_acctbal:14!null
  │         │    │                        │    └── filters
  │         │    │                        │         ├── c_acctbal:14 > 0.0 [outer=(14), constraints=(/14: [/5e-324 - ]; tight)]
- │         │    │                        │         └── substring(c_phone:13, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [outer=(13)]
+ │         │    │                        │         └── substring(c_phone:13, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [outer=(13), immutable]
  │         │    │                        └── aggregations
  │         │    │                             └── avg [as=avg:17, outer=(14)]
  │         │    │                                  └── c_acctbal:14
@@ -2393,7 +2409,7 @@ group-by
  │         │    │    └── ordering: +19
  │         │    └── filters (true)
  │         └── projections
- │              └── substring(c_phone:5, 1, 2) [as=cntrycode:27, outer=(5)]
+ │              └── substring(c_phone:5, 1, 2) [as=cntrycode:27, outer=(5), immutable]
  └── aggregations
       ├── count-rows [as=count_rows:28]
       └── sum [as=sum:29, outer=(6)]

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -928,6 +928,7 @@ ORDER BY extract(day from d.TransactionDate)
 ----
 sort
  ├── columns: extract:37 totalsell:32!null totalbuy:34!null totalprofit:36!null
+ ├── stable
  ├── stats: [rows=1171234.57, distinct(37)=1171234.57, null(37)=0]
  ├── key: (37)
  ├── fd: (37)-->(32,34,36)
@@ -935,11 +936,13 @@ sort
  └── group-by
       ├── columns: sum:32!null sum:34!null sum:36!null column37:37
       ├── grouping columns: column37:37
+      ├── stable
       ├── stats: [rows=1171234.57, distinct(37)=1171234.57, null(37)=0]
       ├── key: (37)
       ├── fd: (37)-->(32,34,36)
       ├── project
       │    ├── columns: column31:31!null column33:33!null column35:35!null column37:37
+      │    ├── stable
       │    ├── stats: [rows=1198631.87, distinct(37)=1171234.57, null(37)=0]
       │    ├── inner-join (hash)
       │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:9!null transactions.isbuy:10!null date:11!null accountname:12!null customername:13!null id:16!null cardsinfo.dealerid:22!null cardsinfo.cardid:23!null
@@ -996,7 +999,7 @@ sort
       │         ├── transactiondetails.sellprice:6 * quantity:5 [as=column31:31, outer=(5,6)]
       │         ├── transactiondetails.buyprice:7 * quantity:5 [as=column33:33, outer=(5,7)]
       │         ├── quantity:5 * (transactiondetails.sellprice:6 - transactiondetails.buyprice:7) [as=column35:35, outer=(5-7)]
-      │         └── extract('day', transactiondate:3) [as=column37:37, outer=(3)]
+      │         └── extract('day', transactiondate:3) [as=column37:37, outer=(3), stable]
       └── aggregations
            ├── sum [as=sum:32, outer=(31)]
            │    └── column31:31
@@ -1214,11 +1217,11 @@ insert transactions
  │    ├── column6:13 => operationid:6
  │    └── column14:14 => version:7
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── values
       ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null column6:13!null column14:14
       ├── cardinality: [1 - 1]
-      ├── side-effects
+      ├── volatile, side-effects
       ├── key: ()
       ├── fd: ()-->(8-14)
       └── (1, false, '2020-03-01 00:00:00+00:00', 'the-account', 'the-customer', '70f03eb1-4f58-4c26-b72d-c524a9d537dd', cluster_logical_timestamp())
@@ -1245,17 +1248,17 @@ upsert transactions
  │    ├── column5:12 => customername:5
  │    └── column6:13 => operationid:6
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── left-join (cross)
       ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null column6:13!null column14:14 dealerid:15 isbuy:16 date:17 accountname:18 customername:19 operationid:20 version:21
       ├── cardinality: [1 - 1]
-      ├── side-effects
+      ├── volatile, side-effects
       ├── key: ()
       ├── fd: ()-->(8-21)
       ├── values
       │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null column6:13!null column14:14
       │    ├── cardinality: [1 - 1]
-      │    ├── side-effects
+      │    ├── volatile, side-effects
       │    ├── key: ()
       │    ├── fd: ()-->(8-14)
       │    └── (1, false, '2020-03-01 00:00:00+00:00', 'the-account', 'the-customer', '70f03eb1-4f58-4c26-b72d-c524a9d537dd', cluster_logical_timestamp())
@@ -1300,11 +1303,11 @@ upsert transactiondetails
  │    └── buyprice:30 => transactiondetails.buyprice:8
  ├── input binding: &2
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── stable+volatile, side-effects, mutations
  ├── project
  │    ├── columns: upsert_dealerid:31 upsert_isbuy:32 upsert_transactiondate:33 upsert_cardid:34 sellprice:29 buyprice:30 "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15 column18:18 transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondate:23 cardid:24 quantity:25 transactiondetails.sellprice:26 transactiondetails.buyprice:27 transactiondetails.version:28
  │    ├── cardinality: [1 - ]
- │    ├── side-effects
+ │    ├── stable+volatile, side-effects
  │    ├── lax-key: (13-15,21-25)
  │    ├── fd: ()-->(11,12), (13-15)~~>(18), (21-25)-->(26-28), (21)-->(31), (21,22)-->(32), (13,21,23)-->(33), (14,21,24)-->(34), (13-15,21-25)~~>(18,29,30)
  │    ├── left-join (lookup transactiondetails)
@@ -1312,7 +1315,7 @@ upsert transactiondetails
  │    │    ├── key columns: [11 12 13 14 15] = [21 22 23 24 25]
  │    │    ├── lookup columns are key
  │    │    ├── cardinality: [1 - ]
- │    │    ├── side-effects
+ │    │    ├── stable+volatile, side-effects
  │    │    ├── lax-key: (13-15,21-25)
  │    │    ├── fd: ()-->(11,12), (13-15)~~>(18-20), (21-25)-->(26-28)
  │    │    ├── ensure-upsert-distinct-on
@@ -1320,13 +1323,13 @@ upsert transactiondetails
  │    │    │    ├── grouping columns: current_timestamp:13 int8:14 int8:15
  │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
  │    │    │    ├── cardinality: [1 - 2]
- │    │    │    ├── side-effects
+ │    │    │    ├── stable+volatile, side-effects
  │    │    │    ├── lax-key: (13-15)
  │    │    │    ├── fd: ()-->(11,12), (13-15)~~>(11,12,18-20)
  │    │    │    ├── project
  │    │    │    │    ├── columns: sellprice:19 buyprice:20 column18:18 "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15
  │    │    │    │    ├── cardinality: [2 - 2]
- │    │    │    │    ├── side-effects
+ │    │    │    │    ├── stable+volatile, side-effects
  │    │    │    │    ├── fd: ()-->(11,12)
  │    │    │    │    ├── values
  │    │    │    │    │    ├── columns: detail:10!null
@@ -1334,12 +1337,12 @@ upsert transactiondetails
  │    │    │    │    │    ├── ('{"b": 2.29, "c": 49833, "q": 4, "s": 2.89}',)
  │    │    │    │    │    └── ('{"b": 17.59, "c": 29483, "q": 2, "s": 18.93}',)
  │    │    │    │    └── projections
- │    │    │    │         ├── crdb_internal.round_decimal_values((detail:10->'s')::STRING::DECIMAL(10,4), 4) [as=sellprice:19, outer=(10)]
- │    │    │    │         ├── crdb_internal.round_decimal_values((detail:10->'b')::STRING::DECIMAL(10,4), 4) [as=buyprice:20, outer=(10)]
- │    │    │    │         ├── cluster_logical_timestamp() [as=column18:18, side-effects]
+ │    │    │    │         ├── crdb_internal.round_decimal_values((detail:10->'s')::STRING::DECIMAL(10,4), 4) [as=sellprice:19, outer=(10), immutable]
+ │    │    │    │         ├── crdb_internal.round_decimal_values((detail:10->'b')::STRING::DECIMAL(10,4), 4) [as=buyprice:20, outer=(10), immutable]
+ │    │    │    │         ├── cluster_logical_timestamp() [as=column18:18, volatile, side-effects]
  │    │    │    │         ├── 1 [as="?column?":11]
  │    │    │    │         ├── false [as=bool:12]
- │    │    │    │         ├── current_timestamp() [as=current_timestamp:13, side-effects]
+ │    │    │    │         ├── current_timestamp() [as=current_timestamp:13, stable, side-effects]
  │    │    │    │         ├── (detail:10->'c')::STRING::INT8 [as=int8:14, outer=(10)]
  │    │    │    │         └── (detail:10->'q')::STRING::INT8 [as=int8:15, outer=(10)]
  │    │    │    └── aggregations
@@ -1359,8 +1362,8 @@ upsert transactiondetails
  │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN bool:12 ELSE transactiondetails.isbuy:22 END [as=upsert_isbuy:32, outer=(12,21,22)]
  │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN current_timestamp:13 ELSE transactiondate:23 END [as=upsert_transactiondate:33, outer=(13,21,23)]
  │         ├── CASE WHEN transactiondetails.dealerid:21 IS NULL THEN int8:14 ELSE cardid:24 END [as=upsert_cardid:34, outer=(14,21,24)]
- │         ├── crdb_internal.round_decimal_values(sellprice:19, 4) [as=sellprice:29, outer=(19)]
- │         └── crdb_internal.round_decimal_values(buyprice:20, 4) [as=buyprice:30, outer=(20)]
+ │         ├── crdb_internal.round_decimal_values(sellprice:19, 4) [as=sellprice:29, outer=(19), immutable]
+ │         └── crdb_internal.round_decimal_values(buyprice:20, 4) [as=buyprice:30, outer=(20), immutable]
  └── f-k-checks
       ├── f-k-checks-item: transactiondetails(dealerid,isbuy,transactiondate) -> transactions(dealerid,isbuy,date)
       │    └── anti-join (lookup transactions)
@@ -1396,7 +1399,7 @@ delete inventorydetails
  ├── columns: <none>
  ├── fetch columns: dealerid:6 cardid:7 accountname:8
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── scan inventorydetails@inventorydetails_auto_index_inventorydetailscardidkey
       ├── columns: dealerid:6!null cardid:7!null accountname:8!null
       ├── constraint: /7/6/8
@@ -1428,7 +1431,7 @@ update ci
  ├── update-mapping:
  │    └── actualinventory_new:33 => actualinventory:12
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: actualinventory_new:33 ci.dealerid:15!null ci.cardid:16!null buyprice:17!null sellprice:18!null discount:19!null desiredinventory:20!null actualinventory:21!null maxinventory:22!null ci.version:23!null c:24!null q:25!null
       ├── key: (16)

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -932,6 +932,7 @@ ORDER BY extract(day from d.TransactionDate)
 ----
 sort
  ├── columns: extract:45 totalsell:40!null totalbuy:42!null totalprofit:44!null
+ ├── stable
  ├── stats: [rows=1171234.57, distinct(45)=1171234.57, null(45)=0]
  ├── key: (45)
  ├── fd: (45)-->(40,42,44)
@@ -939,11 +940,13 @@ sort
  └── group-by
       ├── columns: sum:40!null sum:42!null sum:44!null column45:45
       ├── grouping columns: column45:45
+      ├── stable
       ├── stats: [rows=1171234.57, distinct(45)=1171234.57, null(45)=0]
       ├── key: (45)
       ├── fd: (45)-->(40,42,44)
       ├── project
       │    ├── columns: column39:39!null column41:41!null column43:43!null column45:45
+      │    ├── stable
       │    ├── stats: [rows=1198631.87, distinct(45)=1171234.57, null(45)=0]
       │    ├── inner-join (hash)
       │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null id:20!null cardsinfo.dealerid:26!null cardsinfo.cardid:27!null
@@ -1000,7 +1003,7 @@ sort
       │         ├── transactiondetails.sellprice:6 * quantity:5 [as=column39:39, outer=(5,6)]
       │         ├── transactiondetails.buyprice:7 * quantity:5 [as=column41:41, outer=(5,7)]
       │         ├── quantity:5 * (transactiondetails.sellprice:6 - transactiondetails.buyprice:7) [as=column43:43, outer=(5-7)]
-      │         └── extract('day', transactiondate:3) [as=column45:45, outer=(3)]
+      │         └── extract('day', transactiondate:3) [as=column45:45, outer=(3), stable]
       └── aggregations
            ├── sum [as=sum:40, outer=(39)]
            │    └── column39:39
@@ -1219,11 +1222,11 @@ insert transactions
  │    ├── column16:16 => version:7
  │    └── column17:17 => olddate:8
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── values
       ├── columns: column1:10!null column2:11!null column3:12!null column4:13!null column5:14!null column6:15!null column16:16 column17:17!null
       ├── cardinality: [1 - 1]
-      ├── side-effects
+      ├── volatile, side-effects
       ├── key: ()
       ├── fd: ()-->(10-17)
       └── (1, false, '2020-03-01 00:00:00+00:00', 'the-account', 'the-customer', '70f03eb1-4f58-4c26-b72d-c524a9d537dd', cluster_logical_timestamp(), '0001-01-01 00:00:00+00:00')
@@ -1252,17 +1255,17 @@ upsert transactions
  │    ├── column6:15 => operationid:6
  │    └── column17:17 => olddate:8
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── left-join (cross)
       ├── columns: column1:10!null column2:11!null column3:12!null column4:13!null column5:14!null column6:15!null column16:16 column17:17!null dealerid:18 isbuy:19 date:20 accountname:21 customername:22 operationid:23 version:24 olddate:25 extra:26
       ├── cardinality: [1 - 1]
-      ├── side-effects
+      ├── volatile, side-effects
       ├── key: ()
       ├── fd: ()-->(10-26)
       ├── values
       │    ├── columns: column1:10!null column2:11!null column3:12!null column4:13!null column5:14!null column6:15!null column16:16 column17:17!null
       │    ├── cardinality: [1 - 1]
-      │    ├── side-effects
+      │    ├── volatile, side-effects
       │    ├── key: ()
       │    ├── fd: ()-->(10-17)
       │    └── (1, false, '2020-03-01 00:00:00+00:00', 'the-account', 'the-customer', '70f03eb1-4f58-4c26-b72d-c524a9d537dd', cluster_logical_timestamp(), '0001-01-01 00:00:00+00:00')
@@ -1309,11 +1312,11 @@ upsert transactiondetails
  │    └── upsert_discount:44 => transactiondetails.discount:10
  ├── input binding: &2
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── stable+volatile, side-effects, mutations
  ├── project
  │    ├── columns: upsert_dealerid:38 upsert_isbuy:39 upsert_transactiondate:40 upsert_cardid:41 upsert_discount:44 sellprice:35 buyprice:36 "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17 column20:20 discount:24!null transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondate:27 cardid:28 quantity:29 transactiondetails.sellprice:30 transactiondetails.buyprice:31 transactiondetails.version:32 transactiondetails.discount:33 transactiondetails.extra:34
  │    ├── cardinality: [1 - ]
- │    ├── side-effects
+ │    ├── stable+volatile, side-effects
  │    ├── lax-key: (15-17,25-29)
  │    ├── fd: ()-->(13,14,24), (15-17)~~>(20), (25-29)-->(30-34), (25)-->(38), (25,26)-->(39), (15,25,27)-->(40), (16,25,28)-->(41), (15-17,25-29)~~>(20,35,36,44)
  │    ├── left-join (lookup transactiondetails)
@@ -1321,7 +1324,7 @@ upsert transactiondetails
  │    │    ├── key columns: [13 14 15 16 17] = [25 26 27 28 29]
  │    │    ├── lookup columns are key
  │    │    ├── cardinality: [1 - ]
- │    │    ├── side-effects
+ │    │    ├── stable+volatile, side-effects
  │    │    ├── lax-key: (15-17,25-29)
  │    │    ├── fd: ()-->(13,14,24), (15-17)~~>(20,22,23), (25-29)-->(30-34)
  │    │    ├── ensure-upsert-distinct-on
@@ -1329,13 +1332,13 @@ upsert transactiondetails
  │    │    │    ├── grouping columns: current_timestamp:15 int8:16 int8:17
  │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
  │    │    │    ├── cardinality: [1 - 2]
- │    │    │    ├── side-effects
+ │    │    │    ├── stable+volatile, side-effects
  │    │    │    ├── lax-key: (15-17)
  │    │    │    ├── fd: ()-->(13,14,24), (15-17)~~>(13,14,20,22-24)
  │    │    │    ├── project
  │    │    │    │    ├── columns: sellprice:22 buyprice:23 discount:24!null column20:20 "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17
  │    │    │    │    ├── cardinality: [2 - 2]
- │    │    │    │    ├── side-effects
+ │    │    │    │    ├── stable+volatile, side-effects
  │    │    │    │    ├── fd: ()-->(13,14,24)
  │    │    │    │    ├── values
  │    │    │    │    │    ├── columns: detail:12!null
@@ -1343,13 +1346,13 @@ upsert transactiondetails
  │    │    │    │    │    ├── ('{"b": 2.29, "c": 49833, "q": 4, "s": 2.89}',)
  │    │    │    │    │    └── ('{"b": 17.59, "c": 29483, "q": 2, "s": 18.93}',)
  │    │    │    │    └── projections
- │    │    │    │         ├── crdb_internal.round_decimal_values((detail:12->'s')::STRING::DECIMAL(10,4), 4) [as=sellprice:22, outer=(12)]
- │    │    │    │         ├── crdb_internal.round_decimal_values((detail:12->'b')::STRING::DECIMAL(10,4), 4) [as=buyprice:23, outer=(12)]
+ │    │    │    │         ├── crdb_internal.round_decimal_values((detail:12->'s')::STRING::DECIMAL(10,4), 4) [as=sellprice:22, outer=(12), immutable]
+ │    │    │    │         ├── crdb_internal.round_decimal_values((detail:12->'b')::STRING::DECIMAL(10,4), 4) [as=buyprice:23, outer=(12), immutable]
  │    │    │    │         ├── 0.0000 [as=discount:24]
- │    │    │    │         ├── cluster_logical_timestamp() [as=column20:20, side-effects]
+ │    │    │    │         ├── cluster_logical_timestamp() [as=column20:20, volatile, side-effects]
  │    │    │    │         ├── 1 [as="?column?":13]
  │    │    │    │         ├── false [as=bool:14]
- │    │    │    │         ├── current_timestamp() [as=current_timestamp:15, side-effects]
+ │    │    │    │         ├── current_timestamp() [as=current_timestamp:15, stable, side-effects]
  │    │    │    │         ├── (detail:12->'c')::STRING::INT8 [as=int8:16, outer=(12)]
  │    │    │    │         └── (detail:12->'q')::STRING::INT8 [as=int8:17, outer=(12)]
  │    │    │    └── aggregations
@@ -1371,9 +1374,9 @@ upsert transactiondetails
  │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN bool:14 ELSE transactiondetails.isbuy:26 END [as=upsert_isbuy:39, outer=(14,25,26)]
  │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN current_timestamp:15 ELSE transactiondate:27 END [as=upsert_transactiondate:40, outer=(15,25,27)]
  │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN int8:16 ELSE cardid:28 END [as=upsert_cardid:41, outer=(16,25,28)]
- │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN discount:24 ELSE crdb_internal.round_decimal_values(discount:24, 4) END [as=upsert_discount:44, outer=(24,25)]
- │         ├── crdb_internal.round_decimal_values(sellprice:22, 4) [as=sellprice:35, outer=(22)]
- │         └── crdb_internal.round_decimal_values(buyprice:23, 4) [as=buyprice:36, outer=(23)]
+ │         ├── CASE WHEN transactiondetails.dealerid:25 IS NULL THEN discount:24 ELSE crdb_internal.round_decimal_values(discount:24, 4) END [as=upsert_discount:44, outer=(24,25), immutable]
+ │         ├── crdb_internal.round_decimal_values(sellprice:22, 4) [as=sellprice:35, outer=(22), immutable]
+ │         └── crdb_internal.round_decimal_values(buyprice:23, 4) [as=buyprice:36, outer=(23), immutable]
  └── f-k-checks
       ├── f-k-checks-item: transactiondetails(dealerid,isbuy,transactiondate) -> transactions(dealerid,isbuy,date)
       │    └── anti-join (lookup transactions)
@@ -1409,7 +1412,7 @@ delete inventorydetails
  ├── columns: <none>
  ├── fetch columns: dealerid:8 cardid:9 accountname:10
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── scan inventorydetails@inventorydetails_auto_index_inventorydetailscardidkey
       ├── columns: dealerid:8!null cardid:9!null accountname:10!null
       ├── constraint: /9/8/10
@@ -1444,9 +1447,10 @@ update ci
  │    ├── column44:44 => notes:16
  │    └── column45:45 => oldinventory:17
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: discountbuyprice:47 column44:44 column45:45!null actualinventory_new:43 ci.dealerid:19!null ci.cardid:20!null buyprice:21!null sellprice:22!null discount:23!null desiredinventory:24!null actualinventory:25!null maxinventory:26!null ci.version:27!null ci.discountbuyprice:28 notes:29 oldinventory:30 ci.extra:31 c:32!null q:33!null
+      ├── immutable
       ├── key: (20)
       ├── fd: ()-->(19,44,45), (20)-->(21-33,43,47), (27)-->(20-26,28-31), (20)==(32), (32)==(20)
       ├── group-by
@@ -1548,7 +1552,7 @@ update ci
       │         └── const-agg [as=q:33, outer=(33)]
       │              └── q:33
       └── projections
-           ├── crdb_internal.round_decimal_values(buyprice:21 - discount:23, 4) [as=discountbuyprice:47, outer=(21,23)]
+           ├── crdb_internal.round_decimal_values(buyprice:21 - discount:23, 4) [as=discountbuyprice:47, outer=(21,23), immutable]
            ├── CAST(NULL AS STRING) [as=column44:44]
            ├── 0 [as=column45:45]
            └── COALESCE(sum_int:41, 0) [as=actualinventory_new:43, outer=(41)]

--- a/pkg/sql/opt/xform/testdata/external/ycsb
+++ b/pkg/sql/opt/xform/testdata/external/ycsb
@@ -29,7 +29,7 @@ update usertable
  ├── update-mapping:
  │    └── field5_new:23 => field5:7
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: field5_new:23!null ycsb_key:12!null field5:18
       ├── cardinality: [0 - 1]
@@ -105,7 +105,7 @@ insert usertable
  │    ├── column10:21 => field8:10
  │    └── column11:22 => field9:11
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── values
       ├── columns: column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column6:17!null column7:18!null column8:19!null column9:20!null column10:21!null column11:22!null
       ├── cardinality: [1 - 1]
@@ -173,7 +173,7 @@ update usertable
  ├── update-mapping:
  │    └── field5_new:23 => field5:7
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  └── project
       ├── columns: field5_new:23!null ycsb_key:12!null field5:18
       ├── cardinality: [0 - 1]

--- a/pkg/sql/opt/xform/testdata/physprops/limit_hint
+++ b/pkg/sql/opt/xform/testdata/physprops/limit_hint
@@ -387,11 +387,11 @@ SELECT *, generate_series(1, t.x) FROM t LIMIT 10
 limit
  ├── columns: x:1!null y:2 z:3 generate_series:4
  ├── cardinality: [0 - 10]
- ├── side-effects
+ ├── immutable, side-effects
  ├── fd: (1)-->(2,3)
  ├── project-set
  │    ├── columns: x:1!null y:2 z:3 generate_series:4
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── fd: (1)-->(2,3)
  │    ├── limit hint: 10.00
  │    ├── scan t
@@ -400,7 +400,7 @@ limit
  │    │    ├── fd: (1)-->(2,3)
  │    │    └── limit hint: 10.00
  │    └── zip
- │         └── generate_series(1, x:1) [outer=(1), side-effects]
+ │         └── generate_series(1, x:1) [outer=(1), immutable, side-effects]
  └── 10
 
 # --------------------------------------------------
@@ -507,25 +507,25 @@ SELECT DISTINCT t44683.c0 FROM t44683, v44683 LIMIT -1;
 limit
  ├── columns: c0:1
  ├── cardinality: [0 - 0]
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: ()
  ├── fd: ()-->(1)
  ├── distinct-on
  │    ├── columns: c0:1
  │    ├── grouping columns: c0:1
  │    ├── cardinality: [0 - 0]
- │    ├── side-effects
+ │    ├── immutable, side-effects
  │    ├── key: (1)
  │    ├── limit hint: 1.00
  │    └── inner-join (cross)
  │         ├── columns: c0:1
  │         ├── cardinality: [0 - 0]
- │         ├── side-effects
+ │         ├── immutable, side-effects
  │         ├── scan t44683
  │         │    └── columns: c0:1
  │         ├── limit
  │         │    ├── cardinality: [0 - 0]
- │         │    ├── side-effects
+ │         │    ├── immutable, side-effects
  │         │    ├── key: ()
  │         │    ├── scan t44683
  │         │    │    └── limit hint: 1.00
@@ -553,13 +553,13 @@ SELECT * FROM v0, t0 NATURAL JOIN t1 LIMIT -1
 project
  ├── columns: c0:3!null c0:4!null
  ├── cardinality: [0 - 0]
- ├── side-effects
+ ├── immutable, side-effects
  ├── key: ()
  ├── fd: ()-->(3,4)
  └── limit
       ├── columns: "?column?":3!null t0.c0:4!null t1.c0:6!null
       ├── cardinality: [0 - 0]
-      ├── side-effects
+      ├── immutable, side-effects
       ├── key: ()
       ├── fd: ()-->(3,4,6)
       ├── inner-join (lookup t0@t0_c0_key)
@@ -567,25 +567,25 @@ project
       │    ├── key columns: [6] = [4]
       │    ├── lookup columns are key
       │    ├── cardinality: [0 - 0]
-      │    ├── side-effects
+      │    ├── immutable, side-effects
       │    ├── fd: ()-->(3), (4)==(6), (6)==(4)
       │    ├── limit hint: 1.00
       │    ├── inner-join (cross)
       │    │    ├── columns: "?column?":3!null t1.c0:6
       │    │    ├── cardinality: [0 - 0]
-      │    │    ├── side-effects
+      │    │    ├── immutable, side-effects
       │    │    ├── fd: ()-->(3)
       │    │    ├── scan t1
       │    │    │    └── columns: t1.c0:6
       │    │    ├── project
       │    │    │    ├── columns: "?column?":3!null
       │    │    │    ├── cardinality: [0 - 0]
-      │    │    │    ├── side-effects
+      │    │    │    ├── immutable, side-effects
       │    │    │    ├── key: ()
       │    │    │    ├── fd: ()-->(3)
       │    │    │    ├── limit
       │    │    │    │    ├── cardinality: [0 - 0]
-      │    │    │    │    ├── side-effects
+      │    │    │    │    ├── immutable, side-effects
       │    │    │    │    ├── key: ()
       │    │    │    │    ├── scan t1
       │    │    │    │    │    └── limit hint: 1.00

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1439,13 +1439,13 @@ SELECT * FROM [INSERT INTO abc SELECT * FROM xyz ORDER BY y, z LIMIT 2 RETURNING
 sort
  ├── columns: a:7!null b:8!null c:9!null
  ├── cardinality: [0 - 2]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: (7-9)
  ├── ordering: +8
  └── with &1
       ├── columns: a:7!null b:8!null c:9!null
       ├── cardinality: [0 - 2]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── key: (7-9)
       ├── insert abc
       │    ├── columns: abc.a:1!null abc.b:2!null abc.c:3!null
@@ -1454,7 +1454,7 @@ sort
       │    │    ├── y:5 => abc.b:2
       │    │    └── z:6 => abc.c:3
       │    ├── cardinality: [0 - 2]
-      │    ├── side-effects, mutations
+      │    ├── volatile, side-effects, mutations
       │    ├── key: (1-3)
       │    └── limit
       │         ├── columns: x:4!null y:5!null z:6!null
@@ -1488,12 +1488,12 @@ ORDER BY y
 sort
  ├── columns: x:9!null y:10!null z:11!null
  ├── cardinality: [0 - 2]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── ordering: +10
  └── with &1
       ├── columns: x:9!null y:10!null z:11!null
       ├── cardinality: [0 - 2]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── insert xyz
       │    ├── columns: xyz.x:1!null xyz.y:2!null xyz.z:3!null
       │    ├── insert-mapping:
@@ -1501,7 +1501,7 @@ sort
       │    │    ├── c:6 => xyz.y:2
       │    │    └── d:7 => xyz.z:3
       │    ├── cardinality: [0 - 2]
-      │    ├── side-effects, mutations
+      │    ├── volatile, side-effects, mutations
       │    └── scan abcd@cd
       │         ├── columns: b:5 c:6 d:7
       │         └── limit: 2
@@ -1524,13 +1524,13 @@ ORDER BY y
 sort
  ├── columns: x:9!null y:10!null z:11!null
  ├── cardinality: [0 - 2]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── fd: (9)==(10), (10)==(9)
  ├── ordering: +(9|10) [actual: +9]
  └── with &1
       ├── columns: x:9!null y:10!null z:11!null
       ├── cardinality: [0 - 2]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── fd: (9)==(10), (10)==(9)
       ├── insert xyz
       │    ├── columns: xyz.x:1!null xyz.y:2!null xyz.z:3!null
@@ -1539,7 +1539,7 @@ sort
       │    │    ├── c:6 => xyz.y:2
       │    │    └── d:7 => xyz.z:3
       │    ├── cardinality: [0 - 2]
-      │    ├── side-effects, mutations
+      │    ├── volatile, side-effects, mutations
       │    └── scan abcd@cd
       │         ├── columns: b:5 c:6 d:7
       │         └── limit: 2
@@ -1563,7 +1563,7 @@ SELECT * FROM [INSERT INTO abc SELECT * FROM xyz ORDER BY y, z RETURNING *]
 ----
 with &1
  ├── columns: a:7!null b:8!null c:9!null
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: (7-9)
  ├── insert abc
  │    ├── columns: abc.a:1!null abc.b:2!null abc.c:3!null
@@ -1571,7 +1571,7 @@ with &1
  │    │    ├── x:4 => abc.a:1
  │    │    ├── y:5 => abc.b:2
  │    │    └── z:6 => abc.c:3
- │    ├── side-effects, mutations
+ │    ├── volatile, side-effects, mutations
  │    ├── key: (1-3)
  │    └── scan xyz
  │         ├── columns: x:4!null y:5!null z:6!null
@@ -1594,16 +1594,16 @@ SELECT * FROM [UPDATE abcd SET (a, b)=(1, 2) RETURNING *] ORDER BY c
 ----
 sort
  ├── columns: a:13!null b:14!null c:15 d:16
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── fd: ()-->(13,14)
  ├── ordering: +15 opt(13,14) [actual: +15]
  └── with &1
       ├── columns: a:13!null b:14!null c:15 d:16
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── fd: ()-->(13,14)
       ├── project
       │    ├── columns: abcd.a:1!null abcd.b:2!null abcd.c:3 abcd.d:4
-      │    ├── side-effects, mutations
+      │    ├── volatile, side-effects, mutations
       │    ├── fd: ()-->(1,2)
       │    └── update abcd
       │         ├── columns: abcd.a:1!null abcd.b:2!null abcd.c:3 abcd.d:4 rowid:5!null
@@ -1611,7 +1611,7 @@ sort
       │         ├── update-mapping:
       │         │    ├── a_new:11 => abcd.a:1
       │         │    └── b_new:12 => abcd.b:2
-      │         ├── side-effects, mutations
+      │         ├── volatile, side-effects, mutations
       │         ├── key: (5)
       │         ├── fd: ()-->(1,2), (5)-->(3,4)
       │         └── project
@@ -1643,23 +1643,23 @@ ORDER BY c, d
 sort
  ├── columns: a:12 b:13 c:14 d:15
  ├── cardinality: [0 - 10]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── ordering: +14,+15
  └── with &1
       ├── columns: a:12 b:13 c:14 d:15
       ├── cardinality: [0 - 10]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── project
       │    ├── columns: abcd.a:1 abcd.b:2 abcd.c:3 abcd.d:4
       │    ├── cardinality: [0 - 10]
-      │    ├── side-effects, mutations
+      │    ├── volatile, side-effects, mutations
       │    └── update abcd
       │         ├── columns: abcd.a:1 abcd.b:2 abcd.c:3 abcd.d:4 rowid:5!null
       │         ├── fetch columns: abcd.a:6 abcd.b:7 abcd.c:8 abcd.d:9 rowid:10
       │         ├── update-mapping:
       │         │    └── b_new:11 => abcd.b:2
       │         ├── cardinality: [0 - 10]
-      │         ├── side-effects, mutations
+      │         ├── volatile, side-effects, mutations
       │         ├── key: (5)
       │         ├── fd: (5)-->(1-4)
       │         └── project
@@ -1694,25 +1694,25 @@ ORDER BY b, d
 sort
  ├── columns: a:12 b:13!null c:14!null d:15
  ├── cardinality: [0 - 10]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── fd: (13)==(14), (14)==(13)
  ├── ordering: +(13|14),+15 [actual: +13,+15]
  └── with &1
       ├── columns: a:12 b:13!null c:14!null d:15
       ├── cardinality: [0 - 10]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── fd: (13)==(14), (14)==(13)
       ├── project
       │    ├── columns: abcd.a:1 abcd.b:2 abcd.c:3 abcd.d:4
       │    ├── cardinality: [0 - 10]
-      │    ├── side-effects, mutations
+      │    ├── volatile, side-effects, mutations
       │    └── update abcd
       │         ├── columns: abcd.a:1 abcd.b:2 abcd.c:3 abcd.d:4 rowid:5!null
       │         ├── fetch columns: abcd.a:6 abcd.b:7 abcd.c:8 abcd.d:9 rowid:10
       │         ├── update-mapping:
       │         │    └── b_new:11 => abcd.b:2
       │         ├── cardinality: [0 - 10]
-      │         ├── side-effects, mutations
+      │         ├── volatile, side-effects, mutations
       │         ├── key: (5)
       │         ├── fd: (5)-->(1-4)
       │         └── project
@@ -1761,11 +1761,11 @@ ORDER BY b
 ----
 sort
  ├── columns: a:14!null b:15!null c:16!null
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── ordering: +15
  └── with &1
       ├── columns: a:14!null b:15!null c:16!null
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── upsert abc
       │    ├── columns: abc.a:1!null abc.b:2!null abc.c:3!null
       │    ├── canary column: 7
@@ -1780,7 +1780,7 @@ sort
       │    │    ├── upsert_a:11 => abc.a:1
       │    │    ├── upsert_b:12 => abc.b:2
       │    │    └── upsert_c:13 => abc.c:3
-      │    ├── side-effects, mutations
+      │    ├── volatile, side-effects, mutations
       │    └── project
       │         ├── columns: upsert_a:11!null upsert_b:12 upsert_c:13 x:4!null y:5!null z:6!null abc.a:7 abc.b:8 abc.c:9
       │         ├── key: (4-6)
@@ -1835,18 +1835,18 @@ SELECT * FROM [DELETE FROM abcd RETURNING *] ORDER BY c
 ----
 sort
  ├── columns: a:11 b:12 c:13 d:14
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── ordering: +13
  └── with &1
       ├── columns: a:11 b:12 c:13 d:14
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── project
       │    ├── columns: abcd.a:1 abcd.b:2 abcd.c:3 abcd.d:4
-      │    ├── side-effects, mutations
+      │    ├── volatile, side-effects, mutations
       │    └── delete abcd
       │         ├── columns: abcd.a:1 abcd.b:2 abcd.c:3 abcd.d:4 rowid:5!null
       │         ├── fetch columns: abcd.a:6 abcd.b:7 abcd.c:8 abcd.d:9 rowid:10
-      │         ├── side-effects, mutations
+      │         ├── volatile, side-effects, mutations
       │         ├── key: (5)
       │         ├── fd: (5)-->(1-4)
       │         └── scan abcd
@@ -1870,21 +1870,21 @@ ORDER BY c, d
 sort
  ├── columns: a:11 b:12 c:13 d:14
  ├── cardinality: [0 - 10]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── ordering: +13,+14
  └── with &1
       ├── columns: a:11 b:12 c:13 d:14
       ├── cardinality: [0 - 10]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── project
       │    ├── columns: abcd.a:1 abcd.b:2 abcd.c:3 abcd.d:4
       │    ├── cardinality: [0 - 10]
-      │    ├── side-effects, mutations
+      │    ├── volatile, side-effects, mutations
       │    └── delete abcd
       │         ├── columns: abcd.a:1 abcd.b:2 abcd.c:3 abcd.d:4 rowid:5!null
       │         ├── fetch columns: abcd.a:6 abcd.b:7 abcd.c:8 abcd.d:9 rowid:10
       │         ├── cardinality: [0 - 10]
-      │         ├── side-effects, mutations
+      │         ├── volatile, side-effects, mutations
       │         ├── key: (5)
       │         ├── fd: (5)-->(1-4)
       │         └── scan abcd@cd
@@ -1912,23 +1912,23 @@ ORDER BY b, d
 sort
  ├── columns: a:11 b:12!null c:13!null d:14
  ├── cardinality: [0 - 10]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── fd: (12)==(13), (13)==(12)
  ├── ordering: +(12|13),+14 [actual: +12,+14]
  └── with &1
       ├── columns: a:11 b:12!null c:13!null d:14
       ├── cardinality: [0 - 10]
-      ├── side-effects, mutations
+      ├── volatile, side-effects, mutations
       ├── fd: (12)==(13), (13)==(12)
       ├── project
       │    ├── columns: abcd.a:1 abcd.b:2 abcd.c:3 abcd.d:4
       │    ├── cardinality: [0 - 10]
-      │    ├── side-effects, mutations
+      │    ├── volatile, side-effects, mutations
       │    └── delete abcd
       │         ├── columns: abcd.a:1 abcd.b:2 abcd.c:3 abcd.d:4 rowid:5!null
       │         ├── fetch columns: abcd.a:6 abcd.b:7 abcd.c:8 abcd.d:9 rowid:10
       │         ├── cardinality: [0 - 10]
-      │         ├── side-effects, mutations
+      │         ├── volatile, side-effects, mutations
       │         ├── key: (5)
       │         ├── fd: (5)-->(1-4)
       │         └── scan abcd@cd

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1648,16 +1648,18 @@ GROUP BY n.name, n.geom
 ----
 project
  ├── columns: name:13!null popn_per_sqkm:16
- ├── side-effects
+ ├── immutable, side-effects
  ├── group-by
  │    ├── columns: name:13!null n.geom:14 sum:15
  │    ├── grouping columns: name:13!null n.geom:14
+ │    ├── immutable
  │    ├── key: (13,14)
  │    ├── fd: (13,14)-->(15)
  │    ├── inner-join (lookup nyc_census_blocks)
  │    │    ├── columns: popn_total:3 c.boroname:9!null c.geom:10 n.boroname:12!null name:13!null n.geom:14
  │    │    ├── key columns: [1] = [1]
  │    │    ├── lookup columns are key
+ │    │    ├── immutable
  │    │    ├── fd: (9)==(12), (12)==(9)
  │    │    ├── inner-join (geo-lookup nyc_census_blocks@nyc_census_blocks_geo_idx)
  │    │    │    ├── columns: c.gid:1!null n.boroname:12 name:13!null n.geom:14
@@ -1670,13 +1672,13 @@ project
  │    │    │    │         └── (name:13 = 'Upper West Side') OR (name:13 = 'Upper East Side') [outer=(13), constraints=(/13: [/'Upper East Side' - /'Upper East Side'] [/'Upper West Side' - /'Upper West Side']; tight)]
  │    │    │    └── filters (true)
  │    │    └── filters
- │    │         ├── st_intersects(c.geom:10, n.geom:14) [outer=(10,14)]
+ │    │         ├── st_intersects(c.geom:10, n.geom:14) [outer=(10,14), immutable]
  │    │         └── c.boroname:9 = n.boroname:12 [outer=(9,12), constraints=(/9: (/NULL - ]; /12: (/NULL - ]), fd=(9)==(12), (12)==(9)]
  │    └── aggregations
  │         └── sum [as=sum:15, outer=(3)]
  │              └── popn_total:3
  └── projections
-      └── sum:15 / (st_area(n.geom:14) / 1e+06) [as=popn_per_sqkm:16, outer=(14,15), side-effects]
+      └── sum:15 / (st_area(n.geom:14) / 1e+06) [as=popn_per_sqkm:16, outer=(14,15), immutable, side-effects]
 
 memo expect=GenerateGeoLookupJoins
 SELECT
@@ -2227,17 +2229,17 @@ SELECT q,r FROM pqr WHERE q = 1 AND r = 2 FOR UPDATE
 ----
 select
  ├── columns: q:2!null r:3!null
- ├── side-effects
+ ├── volatile, side-effects
  ├── fd: ()-->(2,3)
  ├── index-join pqr
  │    ├── columns: q:2 r:3
- │    ├── side-effects
+ │    ├── volatile, side-effects
  │    ├── fd: ()-->(2)
  │    └── scan pqr@q
  │         ├── columns: p:1!null q:2!null
  │         ├── constraint: /2/1: [/1 - /1]
  │         ├── locking: for-update
- │         ├── side-effects
+ │         ├── volatile, side-effects
  │         ├── key: (1)
  │         └── fd: ()-->(2)
  └── filters
@@ -2462,12 +2464,12 @@ FROM
 with &1
  ├── columns: bool:22!null
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
+ ├── volatile, side-effects, mutations
  ├── key: ()
  ├── fd: ()-->(22)
  ├── project
  │    ├── columns: "?column?":16!null
- │    ├── side-effects, mutations
+ │    ├── volatile, side-effects, mutations
  │    ├── fd: ()-->(16)
  │    ├── insert abc
  │    │    ├── columns: abc.rowid:8!null
@@ -2476,15 +2478,15 @@ with &1
  │    │    │    ├── column14:14 => abc.b:6
  │    │    │    ├── column14:14 => abc.c:7
  │    │    │    └── column15:15 => abc.rowid:8
- │    │    ├── side-effects, mutations
+ │    │    ├── volatile, side-effects, mutations
  │    │    └── project
  │    │         ├── columns: column14:14 column15:15 "?column?":13!null
- │    │         ├── side-effects
+ │    │         ├── volatile, side-effects
  │    │         ├── fd: ()-->(13,14)
  │    │         ├── scan abc
  │    │         └── projections
  │    │              ├── CAST(NULL AS INT8) [as=column14:14]
- │    │              ├── unique_rowid() [as=column15:15, side-effects]
+ │    │              ├── unique_rowid() [as=column15:15, volatile, side-effects]
  │    │              └── 1 [as="?column?":13]
  │    └── projections
  │         └── 1 [as="?column?":16]
@@ -2569,54 +2571,54 @@ union-all
  ├── left columns: "?column?":3
  ├── right columns: "?column?":6
  ├── cardinality: [4 - 12]
- ├── side-effects
+ ├── volatile, side-effects
  ├── project
  │    ├── columns: "?column?":3!null
  │    ├── cardinality: [2 - 6]
- │    ├── side-effects
+ │    ├── volatile, side-effects
  │    ├── fd: ()-->(3)
  │    ├── left-join (cross)
  │    │    ├── cardinality: [2 - 6]
- │    │    ├── side-effects
+ │    │    ├── volatile, side-effects
  │    │    ├── values
  │    │    │    ├── cardinality: [2 - 2]
  │    │    │    ├── ()
  │    │    │    └── ()
  │    │    ├── select
  │    │    │    ├── cardinality: [0 - 3]
- │    │    │    ├── side-effects
+ │    │    │    ├── volatile, side-effects
  │    │    │    ├── values
  │    │    │    │    ├── cardinality: [3 - 3]
  │    │    │    │    ├── ()
  │    │    │    │    ├── ()
  │    │    │    │    └── ()
  │    │    │    └── filters
- │    │    │         └── random() = 0.0 [side-effects]
+ │    │    │         └── random() = 0.0 [volatile, side-effects]
  │    │    └── filters (true)
  │    └── projections
  │         └── 1 [as="?column?":3]
  └── project
       ├── columns: "?column?":6!null
       ├── cardinality: [2 - 6]
-      ├── side-effects
+      ├── volatile, side-effects
       ├── fd: ()-->(6)
       ├── left-join (cross)
       │    ├── cardinality: [2 - 6]
-      │    ├── side-effects
+      │    ├── volatile, side-effects
       │    ├── values
       │    │    ├── cardinality: [2 - 2]
       │    │    ├── ()
       │    │    └── ()
       │    ├── select
       │    │    ├── cardinality: [0 - 3]
-      │    │    ├── side-effects
+      │    │    ├── volatile, side-effects
       │    │    ├── values
       │    │    │    ├── cardinality: [3 - 3]
       │    │    │    ├── ()
       │    │    │    ├── ()
       │    │    │    └── ()
       │    │    └── filters
-      │    │         └── random() = 0.0 [side-effects]
+      │    │         └── random() = 0.0 [volatile, side-effects]
       │    └── filters (true)
       └── projections
            └── 1 [as="?column?":6]
@@ -2844,19 +2846,19 @@ SELECT b,a FROM t5 WHERE b @> '{"a":1, "c":2}' FOR UPDATE
 ----
 select
  ├── columns: b:2 a:1!null
- ├── side-effects
+ ├── volatile, side-effects
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── index-join t5
  │    ├── columns: a:1!null b:2
- │    ├── side-effects
+ │    ├── volatile, side-effects
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── scan t5@b_idx
  │         ├── columns: a:1!null
  │         ├── constraint: /2/1: [/'{"a": 1}' - /'{"a": 1}']
  │         ├── locking: for-update
- │         ├── side-effects
+ │         ├── volatile, side-effects
  │         └── key: (1)
  └── filters
       └── b:2 @> '{"a": 1, "c": 2}' [outer=(2)]

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -90,7 +90,7 @@ SELECT s FROM a LIMIT (SELECT k FROM a LIMIT 1)
 ----
 limit
  ├── columns: s:4
- ├── side-effects
+ ├── immutable, side-effects
  ├── scan a@s_idx
  │    └── columns: s:4
  └── subquery
@@ -130,7 +130,7 @@ scan a
  ├── columns: k:1!null i:2 f:3 s:4 j:5
  ├── limit: 1
  ├── locking: for-update
- ├── side-effects
+ ├── volatile, side-effects
  ├── key: ()
  └── fd: ()-->(1-5)
 
@@ -143,7 +143,7 @@ scan a@s_idx
  ├── constraint: /4/1: [/'foo' - /'foo']
  ├── limit: 1
  ├── locking: for-update
- ├── side-effects
+ ├── volatile, side-effects
  ├── key: ()
  └── fd: ()-->(4)
 
@@ -540,7 +540,7 @@ SELECT * FROM kuv ORDER BY u LIMIT 5 FOR UPDATE
 index-join kuv
  ├── columns: k:1!null u:2 v:3
  ├── cardinality: [0 - 5]
- ├── side-effects
+ ├── volatile, side-effects
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── ordering: +2
@@ -548,7 +548,7 @@ index-join kuv
       ├── columns: k:1!null u:2
       ├── limit: 5
       ├── locking: for-update
-      ├── side-effects
+      ├── volatile, side-effects
       ├── key: (1)
       ├── fd: (1)-->(2)
       └── ordering: +2

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -492,7 +492,7 @@ SELECT s, i, f FROM a ORDER BY s FOR UPDATE
 scan a@s_idx
  ├── columns: s:4 i:2 f:3
  ├── locking: for-update
- ├── side-effects
+ ├── volatile, side-effects
  └── ordering: +4
 
 # Collated strings are treated properly.

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -688,7 +688,7 @@ scan a
  ├── constraint: /1: [/1 - /1]
  ├── locking: for-update
  ├── cardinality: [0 - 1]
- ├── side-effects
+ ├── volatile, side-effects
  ├── key: ()
  └── fd: ()-->(1)
 
@@ -698,7 +698,7 @@ SELECT * FROM b WHERE v >= 1 AND v <= 10 FOR UPDATE
 index-join b
  ├── columns: k:1!null u:2 v:3!null j:4
  ├── cardinality: [0 - 10]
- ├── side-effects
+ ├── volatile, side-effects
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)-->(1,2,4)
  └── scan b@v
@@ -706,7 +706,7 @@ index-join b
       ├── constraint: /3: [/1 - /10]
       ├── locking: for-update
       ├── cardinality: [0 - 10]
-      ├── side-effects
+      ├── volatile, side-effects
       ├── key: (1)
       └── fd: (1)-->(3), (3)-->(1)
 
@@ -716,13 +716,13 @@ SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1 FOR UPDATE
 select
  ├── columns: k:1!null u:2 v:3!null j:4
  ├── cardinality: [0 - 10]
- ├── side-effects
+ ├── volatile, side-effects
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)-->(1,2,4)
  ├── index-join b
  │    ├── columns: k:1!null u:2 v:3 j:4
  │    ├── cardinality: [0 - 10]
- │    ├── side-effects
+ │    ├── volatile, side-effects
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3)-->(1), (3)~~>(1,2,4)
  │    └── scan b@v
@@ -730,7 +730,7 @@ select
  │         ├── constraint: /3: [/1 - /10]
  │         ├── locking: for-update
  │         ├── cardinality: [0 - 10]
- │         ├── side-effects
+ │         ├── volatile, side-effects
  │         ├── key: (1)
  │         └── fd: (1)-->(3), (3)-->(1)
  └── filters
@@ -974,18 +974,18 @@ SELECT k FROM b WHERE j @> '{"a": "b"}' FOR UPDATE
 ----
 project
  ├── columns: k:1!null
- ├── side-effects
+ ├── volatile, side-effects
  ├── key: (1)
  └── index-join b
       ├── columns: k:1!null j:4
-      ├── side-effects
+      ├── volatile, side-effects
       ├── key: (1)
       ├── fd: (1)-->(4)
       └── scan b@inv_idx
            ├── columns: k:1!null
            ├── constraint: /4/1: [/'{"a": "b"}' - /'{"a": "b"}']
            ├── locking: for-update
-           ├── side-effects
+           ├── volatile, side-effects
            └── key: (1)
 
 # Tests for array inverted indexes.


### PR DESCRIPTION
This commit adds a `VolatilitySet` logical property that will replace
`CanHaveSideEffects`. For now, the property is not used for anything. The property
reflects the volatility of any functions; future changes will incorporate the
volatility of casts and scalar operators.

The reason for why we need a set (rather than the "max" volatility) is that we
will need to reoptimize a cached expression if it contains stable operators
(regardless of whether it also contains volatile operators).

Release note: None