### PR TITLE
settings: retire two settings removed in 20.1

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -62,6 +62,8 @@ var retiredSettings = map[string]struct{}{
 	// removed as of 20.1.
 	"schemachanger.lease.duration":       {},
 	"schemachanger.lease.renew_fraction": {},
+	"sql.distsql.temp_storage.joins":     {},
+	"sql.distsql.temp_storage.sorts":     {},
 	// removes as of 20.2.
 	"rocksdb.ingest_backpressure.pending_compaction_threshold": {},
 }


### PR DESCRIPTION
The two settings were removed in #47357.

Release note: None