### PR TITLE
Backport19.2 49633: opt: fix incorrect join simplification in match simple case

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -2691,3 +2691,24 @@ CREATE TABLE source (a INT, INDEX (a));
 
 statement error there is no unique constraint matching given keys for referenced table target
 ALTER TABLE source ADD FOREIGN KEY (a) REFERENCES target (a);
+
+# Regression test for #49628.
+statement ok
+CREATE TABLE xyz (x INT, y INT, z INT, PRIMARY KEY (x, y, z));
+CREATE TABLE fk_ref
+(
+    a INT NOT NULL,
+    b INT,
+    c INT NOT NULL,
+    FOREIGN KEY (a, b, c) REFERENCES xyz (x, y, z)
+);
+INSERT INTO fk_ref (VALUES (1, NULL, 1));
+
+query IIIIII
+SELECT * FROM fk_ref LEFT JOIN xyz ON a = x
+----
+1  NULL  1  NULL  NULL  NULL
+
+statement ok
+DROP TABLE fk_ref;
+DROP TABLE xyz;


### PR DESCRIPTION
Backport 1/1 commits from #49633

/cc @cockroachdb/release

Release note: None