### PR TITLE
Backport19.1 49633: opt: fix incorrect join simplification in match simple case

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -2323,3 +2323,24 @@ ALTER TABLE table1_42498 ADD FOREIGN KEY (col2, col1) REFERENCES table2_42498 (c
 
 statement ok
 DROP TABLE table1_42498, table2_42498 CASCADE
+
+# Regression test for #49628.
+statement ok
+CREATE TABLE xyz (x INT, y INT, z INT, PRIMARY KEY (x, y, z));
+CREATE TABLE fk_ref
+(
+    a INT NOT NULL,
+    b INT,
+    c INT NOT NULL,
+    FOREIGN KEY (a, b, c) REFERENCES xyz (x, y, z)
+);
+INSERT INTO fk_ref (VALUES (1, NULL, 1));
+
+query IIIIII
+SELECT * FROM fk_ref LEFT JOIN xyz ON a = x
+----
+1  NULL  1  NULL  NULL  NULL
+
+statement ok
+DROP TABLE fk_ref;
+DROP TABLE xyz;


### PR DESCRIPTION
Backport 1/1 commits from #49633

/cc @cockroachdb/release

Release note: None