### PR TITLE
geo/geomfn: accelerate spatial predicates with bounding box checks

### DIFF
--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -216,6 +216,11 @@ func (g *Geometry) AsGeomT() (geom.T, error) {
 	return ewkb.Unmarshal(g.SpatialObject.EWKB)
 }
 
+// Empty returns whether the given Geometry is empty.
+func (g *Geometry) Empty() bool {
+	return g.SpatialObject.BoundingBox == nil
+}
+
 // EWKB returns the EWKB representation of the Geometry.
 func (g *Geometry) EWKB() geopb.EWKB {
 	return g.SpatialObject.EWKB
@@ -229,6 +234,12 @@ func (g *Geometry) SRID() geopb.SRID {
 // Shape returns the shape of the Geometry.
 func (g *Geometry) Shape() geopb.Shape {
 	return g.SpatialObject.Shape
+}
+
+// BoundingBoxIntersects returns whether the bounding box of the given geometry
+// intersects with the other.
+func (g *Geometry) BoundingBoxIntersects(o *Geometry) bool {
+	return g.SpatialObject.BoundingBox.Intersects(o.SpatialObject.BoundingBox)
 }
 
 //

--- a/pkg/geo/geomfn/binary_predicates.go
+++ b/pkg/geo/geomfn/binary_predicates.go
@@ -20,6 +20,9 @@ func Covers(a *geo.Geometry, b *geo.Geometry) (bool, error) {
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a, b)
 	}
+	if !a.BoundingBoxIntersects(b) {
+		return false, nil
+	}
 	return geos.Covers(a.EWKB(), b.EWKB())
 }
 
@@ -28,6 +31,9 @@ func CoveredBy(a *geo.Geometry, b *geo.Geometry) (bool, error) {
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a, b)
 	}
+	if !a.BoundingBoxIntersects(b) {
+		return false, nil
+	}
 	return geos.CoveredBy(a.EWKB(), b.EWKB())
 }
 
@@ -35,6 +41,9 @@ func CoveredBy(a *geo.Geometry, b *geo.Geometry) (bool, error) {
 func Contains(a *geo.Geometry, b *geo.Geometry) (bool, error) {
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a, b)
+	}
+	if !a.BoundingBoxIntersects(b) {
+		return false, nil
 	}
 	return geos.Contains(a.EWKB(), b.EWKB())
 }
@@ -46,6 +55,9 @@ func ContainsProperly(a *geo.Geometry, b *geo.Geometry) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	if !a.BoundingBoxIntersects(b) {
+		return false, nil
+	}
 	return MatchesDE9IM(relate, "T**FF*FF*")
 }
 
@@ -53,6 +65,9 @@ func ContainsProperly(a *geo.Geometry, b *geo.Geometry) (bool, error) {
 func Crosses(a *geo.Geometry, b *geo.Geometry) (bool, error) {
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a, b)
+	}
+	if !a.BoundingBoxIntersects(b) {
+		return false, nil
 	}
 	return geos.Crosses(a.EWKB(), b.EWKB())
 }
@@ -62,6 +77,15 @@ func Equals(a *geo.Geometry, b *geo.Geometry) (bool, error) {
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a, b)
 	}
+	// Empty items are equal to each other.
+	// Do this check before the BoundingBoxIntersects check, as we would otherwise
+	// return false.
+	if a.Empty() && b.Empty() {
+		return true, nil
+	}
+	if !a.BoundingBoxIntersects(b) {
+		return false, nil
+	}
 	return geos.Equals(a.EWKB(), b.EWKB())
 }
 
@@ -69,6 +93,9 @@ func Equals(a *geo.Geometry, b *geo.Geometry) (bool, error) {
 func Intersects(a *geo.Geometry, b *geo.Geometry) (bool, error) {
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a, b)
+	}
+	if !a.BoundingBoxIntersects(b) {
+		return false, nil
 	}
 	return geos.Intersects(a.EWKB(), b.EWKB())
 }
@@ -78,6 +105,9 @@ func Overlaps(a *geo.Geometry, b *geo.Geometry) (bool, error) {
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a, b)
 	}
+	if !a.BoundingBoxIntersects(b) {
+		return false, nil
+	}
 	return geos.Overlaps(a.EWKB(), b.EWKB())
 }
 
@@ -86,6 +116,9 @@ func Touches(a *geo.Geometry, b *geo.Geometry) (bool, error) {
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a, b)
 	}
+	if !a.BoundingBoxIntersects(b) {
+		return false, nil
+	}
 	return geos.Touches(a.EWKB(), b.EWKB())
 }
 
@@ -93,6 +126,9 @@ func Touches(a *geo.Geometry, b *geo.Geometry) (bool, error) {
 func Within(a *geo.Geometry, b *geo.Geometry) (bool, error) {
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a, b)
+	}
+	if !a.BoundingBoxIntersects(b) {
+		return false, nil
 	}
 	return geos.Within(a.EWKB(), b.EWKB())
 }

--- a/pkg/geo/geomfn/binary_predicates_test.go
+++ b/pkg/geo/geomfn/binary_predicates_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 var (
+	emptyRect            = geo.MustParseGeometry("POLYGON EMPTY")
+	emptyLine            = geo.MustParseGeometry("LINESTRING EMPTY")
 	leftRect             = geo.MustParseGeometry("POLYGON((-1.0 0.0, 0.0 0.0, 0.0 1.0, -1.0 1.0, -1.0 0.0))")
 	leftRectPoint        = geo.MustParseGeometry("POINT(-0.5 0.5)")
 	rightRect            = geo.MustParseGeometry("POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))")
@@ -162,6 +164,9 @@ func TestEquals(t *testing.T) {
 		b        *geo.Geometry
 		expected bool
 	}{
+		{emptyLine, emptyRect, true},
+		{emptyLine, emptyLine, true},
+		{emptyRect, emptyRect, true},
 		{rightRect, rightRectPoint, false},
 		{rightRectPoint, rightRect, false},
 		{leftRect, rightRect, false},

--- a/pkg/geo/geopb/bbox.go
+++ b/pkg/geo/geopb/bbox.go
@@ -29,3 +29,21 @@ func (b *BoundingBox) Update(x, y float64) {
 	b.MinY = math.Min(b.MinY, y)
 	b.MaxY = math.Max(b.MaxY, y)
 }
+
+// Intersects returns whether the BoundingBoxes intersect.
+// Empty bounding boxes never intersect.
+func (b *BoundingBox) Intersects(o *BoundingBox) bool {
+	// If either side is empty, they do not intersect.
+	if b == nil || o == nil {
+		return false
+	}
+	// If any rectangle is completely above the other, they do not intersect.
+	if b.MinY > o.MaxY || o.MinY > b.MaxY {
+		return false
+	}
+	// If any rectangle is completely on the left of the other, they do not intersect.
+	if b.MinX > o.MaxX || o.MinX > b.MaxX {
+		return false
+	}
+	return true
+}

--- a/pkg/geo/geopb/bbox_test.go
+++ b/pkg/geo/geopb/bbox_test.go
@@ -1,0 +1,69 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package geopb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoundingBoxIntersects(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		a        *BoundingBox
+		b        *BoundingBox
+		expected bool
+	}{
+		{
+			desc:     "same bounding box intersects",
+			a:        &BoundingBox{MinX: 0, MaxX: 1, MinY: 0, MaxY: 1},
+			b:        &BoundingBox{MinX: 0, MaxX: 1, MinY: 0, MaxY: 1},
+			expected: true,
+		},
+		{
+			desc:     "overlapping bounding box intersects",
+			a:        &BoundingBox{MinX: 0, MaxX: 1, MinY: 0, MaxY: 1},
+			b:        &BoundingBox{MinX: 0.5, MaxX: 1.5, MinY: 0.5, MaxY: 1.5},
+			expected: true,
+		},
+		{
+			desc:     "touching bounding box intersects",
+			a:        &BoundingBox{MinX: 0, MaxX: 1, MinY: 0, MaxY: 1},
+			b:        &BoundingBox{MinX: 1, MaxX: 2, MinY: 1, MaxY: 2},
+			expected: true,
+		},
+		{
+			desc:     "bounding box that is left does not intersect",
+			a:        &BoundingBox{MinX: 0, MaxX: 1, MinY: 0, MaxY: 1},
+			b:        &BoundingBox{MinX: 1.5, MaxX: 2, MinY: 0, MaxY: 1},
+			expected: false,
+		},
+		{
+			desc:     "higher bounding box does not intersect",
+			a:        &BoundingBox{MinX: 0, MaxX: 1, MinY: 0, MaxY: 1},
+			b:        &BoundingBox{MinX: 0, MaxX: 1, MinY: 1.5, MaxY: 2},
+			expected: false,
+		},
+		{
+			desc:     "completely disjoint bounding box does not intersect",
+			a:        &BoundingBox{MinX: 0, MaxX: 1, MinY: 0, MaxY: 1},
+			b:        &BoundingBox{MinX: -3, MaxX: -2, MinY: 1.5, MaxY: 2},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.a.Intersects(tc.b))
+		})
+	}
+}


### PR DESCRIPTION
We are able to accelerate certain spatial predicates by determining
earlier on whether their bounding boxes intersect. This PR applies that
change.

It is worth noting that I have not applied this to geogfn yet, as the
bounding box for geogfns should be 3D. That's a biggish change that I
will leave for a follow up PR.

Release note: None