### PR TITLE
c-deps/proj: bump PROJ to compile on more systems

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,4 +34,4 @@
 	url = https://github.com/libgeos/geos.git
 [submodule "c-deps/proj"]
 	path = c-deps/proj
-	url = https://github.com/OSGeo/PROJ.git
+	url = https://github.com/cockroachdb/PROJ.git

--- a/c-deps/proj-rebuild
+++ b/c-deps/proj-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing geos configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-1
+2


### PR DESCRIPTION
CMake is broken for the value of `PTHREAD_MUTEX_RECURSIVE` on certain
operating systems. To rectify this, we've patched PROJ at version 4.9.3
at `cc4a178` with a fix. We'll be using the CRDB fork of PROJ for the
meantime to fix this for now.

fixes #49749

Release note: None