### PR TITLE
geo: remove geoproj dependency for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1541,8 +1541,6 @@ bin/execgen_out.d: bin/execgen
 	@echo EXECGEN $@; execgen -M $(EXECGEN_TARGETS) >$@.tmp || { rm -f $@.tmp; exit 1; }
 	@mv -f $@.tmp $@
 
-bin/execgen: $(LIBPROJ) $(CGO_FLAGS_FILES)
-
 # No need to pull all the world in when a user just wants
 # to know how to invoke `make` or clean up.
 ifneq ($(build-with-dep-files),)

--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -15,7 +15,6 @@ import (
 	"encoding/binary"
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
-	_ "github.com/cockroachdb/cockroach/pkg/geo/geoproj" // blank import to make sure PROJ compiles
 	"github.com/cockroachdb/errors"
 	"github.com/golang/geo/s2"
 	"github.com/twpayne/go-geom"

--- a/pkg/geo/geogfn/geogfn.go
+++ b/pkg/geo/geogfn/geogfn.go
@@ -10,8 +10,6 @@
 
 package geogfn
 
-import _ "github.com/cockroachdb/cockroach/pkg/geo/geoproj" // blank import to make sure PROJ compiles
-
 // UseSphereOrSpheroid indicates whether to use a Sphere or Spheroid
 // for certain calculations.
 type UseSphereOrSpheroid bool


### PR DESCRIPTION
Seems to be breaking Upload Binaries (not sure why) because execgen
depends on geo. The dependencies should make it work (not sure why it
doesn't), but it doesn't seem important to solve this atm (planning to hide
it in some sort of dependency injection hack later).

Release note: None