### PR TITLE
colexec: add support for Concat binary operator

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -154,11 +154,16 @@ func registerBinOpOutputTypes() {
 	binOpOutputTypes[tree.Plus][typePair{types.TimestampTZFamily, anyWidth, types.IntervalFamily, anyWidth}] = types.TimestampTZ
 	binOpOutputTypes[tree.Minus][typePair{types.TimestampTZFamily, anyWidth, types.IntervalFamily, anyWidth}] = types.TimestampTZ
 	binOpOutputTypes[tree.Plus][typePair{types.IntervalFamily, anyWidth, types.TimestampTZFamily, anyWidth}] = types.TimestampTZ
+
+	binOpOutputTypes[tree.Concat] = map[typePair]*types.T{
+		{types.BytesFamily, anyWidth, types.BytesFamily, anyWidth}:                                       types.Bytes,
+		{typeconv.DatumVecCanonicalTypeFamily, anyWidth, typeconv.DatumVecCanonicalTypeFamily, anyWidth}: types.Any,
+	}
 }
 
 func populateBinOpOverloads() {
 	registerBinOpOutputTypes()
-	for _, op := range []tree.BinaryOperator{tree.Plus, tree.Minus, tree.Mult, tree.Div} {
+	for _, op := range []tree.BinaryOperator{tree.Plus, tree.Minus, tree.Mult, tree.Div, tree.Concat} {
 		ob := &overloadBase{
 			kind:  binaryOverload,
 			Name:  execgen.BinaryOpName[op],
@@ -181,6 +186,29 @@ func populateBinOpOverloads() {
 // produces binary operator output for a particular type.
 type binOpTypeCustomizer interface {
 	getBinOpAssignFunc() assignFunc
+}
+
+func (bytesCustomizer) getBinOpAssignFunc() assignFunc {
+	return func(op *lastArgWidthOverload, targetElem, leftElem, rightElem, targetCol, leftCol, rightCol string) string {
+		var result string
+		if op.overloadBase.BinOp == tree.Concat {
+			caller, idx, err := parseNonIndexableTargetElem(targetElem)
+			if err != nil {
+				return fmt.Sprintf("colexecerror.InternalError(\"%s\")", err)
+			}
+			result = fmt.Sprintf(`
+			{
+				var r = []byte{}
+				r = append(r, %s...)
+				r = append(r, %s...)
+				%s
+			}
+			`, leftElem, rightElem, set(types.BytesFamily, caller, idx, "r"))
+		} else {
+			colexecerror.InternalError(fmt.Sprintf("unhandled binary operator %s", op.overloadBase.BinOp.String()))
+		}
+		return result
+	}
 }
 
 func (decimalCustomizer) getBinOpAssignFunc() assignFunc {
@@ -566,23 +594,10 @@ func executeBinOpOnDatums(
 	prelude, targetElem, leftColdataExtDatum, rightDatumElem, leftCol, rightCol string,
 	datumVecOnRightSide bool,
 ) string {
-	// We expect the target to be of the form "projVec[idx]", however,
-	// datumVec doesn't support indexing, so we need to translate that into
-	// a set operation.
-	//
-	// First, we check that target matches our expectations (it doesn't
-	// only in overloads_test_utils_gen.go).
-	if !regexp.MustCompile(`.*\[.*]`).MatchString(targetElem) {
-		return fmt.Sprintf("colexecerror.InternalError(\"couldn't translate indexing on datum vec\")")
+	vecVariable, idxVariable, err := parseNonIndexableTargetElem(targetElem)
+	if err != nil {
+		return fmt.Sprintf("colexecerror.InternalError(\"%s\")", err)
 	}
-	// Next, we separate the target into two tokens preemptively removing
-	// the closing square bracket.
-	tokens := strings.Split(targetElem[:len(targetElem)-1], "[")
-	if len(tokens) != 2 {
-		colexecerror.InternalError("unexpectedly len(tokens) != 2")
-	}
-	vecVariable := tokens[0]
-	idxVariable := tokens[1]
 	return fmt.Sprintf(`
 			%s
 			_res, err := %s.BinFn(_overloadHelper.binFn, %s, %s)
@@ -667,4 +682,23 @@ func (c nonDatumDatumCustomizer) getBinOpAssignFunc() assignFunc {
 			leftCol, rightCol, true, /* datumVecOnRightSide */
 		)
 	}
+}
+
+// Some target element has form "caller[index]", however, types like Bytes and datumVec
+// don't support indexing, we need to translate that into a set operation.This method
+// is used to extract caller and index value from targetElem.
+func parseNonIndexableTargetElem(targetElem string) (caller string, index string, err error) {
+	if !regexp.MustCompile(`.*\[.*]`).MatchString(targetElem) {
+		err = fmt.Errorf("couldn't translate indexing on target element: %s", targetElem)
+		return
+	}
+	// Next, we separate the target into two tokens preemptively removing
+	// the closing square bracket.
+	tokens := strings.Split(targetElem[:len(targetElem)-1], "[")
+	if len(tokens) != 2 {
+		colexecerror.InternalError("unexpectedly len(tokens) != 2")
+	}
+	caller = tokens[0]
+	index = tokens[1]
+	return
 }

--- a/pkg/sql/colexec/execgen/supported_bin_cmp_ops.go
+++ b/pkg/sql/colexec/execgen/supported_bin_cmp_ops.go
@@ -15,10 +15,11 @@ import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 // BinaryOpName is a mapping from all binary operators that are supported by
 // the vectorized engine to their names.
 var BinaryOpName = map[tree.BinaryOperator]string{
-	tree.Plus:  "Plus",
-	tree.Minus: "Minus",
-	tree.Mult:  "Mult",
-	tree.Div:   "Div",
+	tree.Plus:   "Plus",
+	tree.Minus:  "Minus",
+	tree.Mult:   "Mult",
+	tree.Div:    "Div",
+	tree.Concat: "Concat",
 }
 
 // ComparisonOpName is a mapping from all comparison operators that are

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
@@ -18,13 +18,15 @@ CREATE TABLE many_types (
     _interval    INTERVAL,
     _inet        INet,
     _json        JSON,
-    _time        Time
+    _time        Time,
+    _varbit      VARBIT
 )
 
 statement ok
 INSERT
   INTO many_types
 VALUES (
+        NULL,
         NULL,
         NULL,
         NULL,
@@ -60,7 +62,8 @@ VALUES (
        '12:34:56.123456',
        '127.0.0.1',
        '[1, "hello", {"a": ["foo", {"b": 3}]}]',
-       '1:00:00.001'
+       '1:00:00.001',
+       B'1'
        ),
        (
        true,
@@ -79,7 +82,8 @@ VALUES (
        '01:23:45.012345',
        '192.168.0.0/16',
        '[2, "hi", {"b": ["bar", {"c": 4}]}]',
-       '1:00:00.456'
+       '1:00:00.456',
+       B'11'
        )
 
 query T
@@ -171,6 +175,67 @@ SELECT _json - _int FROM many_types
 NULL
 [1, "hello", {"a": ["foo", {"b": 3}]}]
 [2, "hi", {"b": ["bar", {"c": 4}]}]
+
+query T
+EXPLAIN (VEC) SELECT _bytes || _bytes FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projConcatBytesBytesOp
+    └ *colexec.colBatchScan
+
+query T
+SELECT _bytes || _bytes FROM many_types
+----
+NULL
+123123
+456456
+
+query T
+EXPLAIN (VEC) SELECT _string || _string FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projConcatBytesBytesOp
+    └ *colexec.colBatchScan
+
+query T
+SELECT _string || _string FROM many_types
+----
+NULL
+123123
+456456
+
+query T
+EXPLAIN (VEC) SELECT _json || _json FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projConcatDatumDatumOp
+    └ *colexec.colBatchScan
+
+query T
+SELECT _json || _json FROM many_types
+----
+NULL
+[1, "hello", {"a": ["foo", {"b": 3}]}, 1, "hello", {"a": ["foo", {"b": 3}]}]
+[2, "hi", {"b": ["bar", {"c": 4}]}, 2, "hi", {"b": ["bar", {"c": 4}]}]
+
+query T
+EXPLAIN (VEC) SELECT _varbit || _varbit FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projConcatDatumDatumOp
+    └ *colexec.colBatchScan
+
+query T
+SELECT _varbit || _varbit FROM many_types
+----
+NULL
+11
+1111
+
 
 # Make sure we fall back to row engine when we have a mixed-type expression
 # with dates.


### PR DESCRIPTION
Previously, the vectorized engine lacked support for concat binary
operator.
This commit added this support. I implemented concat for bytes
referrering to same operator for row-oriented egine. Since there was
already a "getBinOpAssignFunc" implemented for "datumCustomizer", I
just registered the output type for Concat operator for datum type, so
that Concat operator for datum type would be generated as expected.

Resolves: #49466
See also: #49463