### PR TITLE
geo/geomfn: use GEOSRelatePattern for ST_ContainsProperly

### DIFF
--- a/pkg/geo/geomfn/binary_predicates.go
+++ b/pkg/geo/geomfn/binary_predicates.go
@@ -50,15 +50,13 @@ func Contains(a *geo.Geometry, b *geo.Geometry) (bool, error) {
 
 // ContainsProperly returns whether geometry A properly contains geometry B.
 func ContainsProperly(a *geo.Geometry, b *geo.Geometry) (bool, error) {
-	// No GEOS CAPI to call ContainsProperly; fallback to Relate.
-	relate, err := Relate(a, b)
-	if err != nil {
-		return false, err
+	if a.SRID() != b.SRID() {
+		return false, geo.NewMismatchingSRIDsError(a, b)
 	}
 	if !a.BoundingBoxIntersects(b) {
 		return false, nil
 	}
-	return MatchesDE9IM(relate, "T**FF*FF*")
+	return geos.RelatePattern(a.EWKB(), b.EWKB(), "T**FF*FF*")
 }
 
 // Crosses returns whether geometry A crosses geometry B.

--- a/pkg/geo/geomfn/de9im.go
+++ b/pkg/geo/geomfn/de9im.go
@@ -25,6 +25,14 @@ func Relate(a *geo.Geometry, b *geo.Geometry) (string, error) {
 	return geos.Relate(a.EWKB(), b.EWKB())
 }
 
+// RelatePattern returns whether the DE-9IM relation between A and B matches.
+func RelatePattern(a *geo.Geometry, b *geo.Geometry, pattern string) (bool, error) {
+	if a.SRID() != b.SRID() {
+		return false, geo.NewMismatchingSRIDsError(a, b)
+	}
+	return geos.RelatePattern(a.EWKB(), b.EWKB(), pattern)
+}
+
 // MatchesDE9IM checks whether the given DE-9IM relation matches the DE-91M pattern.
 // Assumes the relation has been computed, and such has no 'T' and '*' characters.
 // See: https://en.wikipedia.org/wiki/DE-9IM.

--- a/pkg/geo/geos/geos.go
+++ b/pkg/geo/geos/geos.go
@@ -432,3 +432,18 @@ func Relate(a geopb.EWKB, b geopb.EWKB) (string, error) {
 	}
 	return string(cStringToSafeGoBytes(ret)), nil
 }
+
+// RelatePattern whether A and B have a DE-9IM relation matching the given pattern.
+func RelatePattern(a geopb.EWKB, b geopb.EWKB, pattern string) (bool, error) {
+	g, err := ensureInitInternal()
+	if err != nil {
+		return false, err
+	}
+	var ret C.char
+	if err := statusToError(
+		C.CR_GEOS_RelatePattern(g, goToCSlice(a), goToCSlice(b), goToCSlice([]byte(pattern)), &ret),
+	); err != nil {
+		return false, err
+	}
+	return ret == 1, nil
+}

--- a/pkg/geo/geos/geos.h
+++ b/pkg/geo/geos/geos.h
@@ -61,35 +61,37 @@ CR_GEOS_Status CR_GEOS_ClipEWKBByRect(CR_GEOS* lib, CR_GEOS_Slice wkb, double xm
 // Unary operators.
 //
 
-CR_GEOS_Status CR_GEOS_Area(CR_GEOS* lib, CR_GEOS_Slice a, double *ret);
-CR_GEOS_Status CR_GEOS_Length(CR_GEOS* lib, CR_GEOS_Slice a, double *ret);
-CR_GEOS_Status CR_GEOS_Centroid(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_String *centroidEWKB);
+CR_GEOS_Status CR_GEOS_Area(CR_GEOS* lib, CR_GEOS_Slice a, double* ret);
+CR_GEOS_Status CR_GEOS_Length(CR_GEOS* lib, CR_GEOS_Slice a, double* ret);
+CR_GEOS_Status CR_GEOS_Centroid(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_String* centroidEWKB);
 
 //
 // Binary operators.
 //
 
-CR_GEOS_Status CR_GEOS_Distance(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, double *ret);
+CR_GEOS_Status CR_GEOS_Distance(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, double* ret);
 
 //
 // Binary predicates.
 //
 
-CR_GEOS_Status CR_GEOS_Covers(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char *ret);
-CR_GEOS_Status CR_GEOS_CoveredBy(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char *ret);
-CR_GEOS_Status CR_GEOS_Contains(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char *ret);
-CR_GEOS_Status CR_GEOS_Crosses(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char *ret);
-CR_GEOS_Status CR_GEOS_Equals(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char *ret);
-CR_GEOS_Status CR_GEOS_Intersects(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char *ret);
-CR_GEOS_Status CR_GEOS_Overlaps(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char *ret);
-CR_GEOS_Status CR_GEOS_Touches(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char *ret);
-CR_GEOS_Status CR_GEOS_Within(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char *ret);
+CR_GEOS_Status CR_GEOS_Covers(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char* ret);
+CR_GEOS_Status CR_GEOS_CoveredBy(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char* ret);
+CR_GEOS_Status CR_GEOS_Contains(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char* ret);
+CR_GEOS_Status CR_GEOS_Crosses(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char* ret);
+CR_GEOS_Status CR_GEOS_Equals(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char* ret);
+CR_GEOS_Status CR_GEOS_Intersects(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char* ret);
+CR_GEOS_Status CR_GEOS_Overlaps(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char* ret);
+CR_GEOS_Status CR_GEOS_Touches(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char* ret);
+CR_GEOS_Status CR_GEOS_Within(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, char* ret);
 
 //
 // DE-9IM related
 //
 
-CR_GEOS_Status CR_GEOS_Relate(CR_GEOS *lib, CR_GEOS_Slice a, CR_GEOS_Slice b, CR_GEOS_String *ret);
+CR_GEOS_Status CR_GEOS_Relate(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b, CR_GEOS_String* ret);
+CR_GEOS_Status CR_GEOS_RelatePattern(CR_GEOS* lib, CR_GEOS_Slice a, CR_GEOS_Slice b,
+                                     CR_GEOS_Slice pattern, char* ret);
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -1854,11 +1854,7 @@ Note ST_Perimeter is only valid for Polygon - use ST_Length for LineString.`,
 				a := args[0].(*tree.DGeometry)
 				b := args[1].(*tree.DGeometry)
 				pattern := args[2].(*tree.DString)
-				relation, err := geomfn.Relate(a.Geometry, b.Geometry)
-				if err != nil {
-					return nil, err
-				}
-				ret, err := geomfn.MatchesDE9IM(relation, string(*pattern))
+				ret, err := geomfn.RelatePattern(a.Geometry, b.Geometry, string(*pattern))
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
GEOSRelatePattern seems to avoid the checks for wildcards, making
ST_ContainsProperly faster.

Release note: None