### PR TITLE
colexec: add support for bit and some arithmetic binary operators

### DIFF
--- a/pkg/sql/colexec/execgen/supported_bin_cmp_ops.go
+++ b/pkg/sql/colexec/execgen/supported_bin_cmp_ops.go
@@ -15,10 +15,15 @@ import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 // BinaryOpName is a mapping from all binary operators that are supported by
 // the vectorized engine to their names.
 var BinaryOpName = map[tree.BinaryOperator]string{
+	tree.Bitand:       "Bitand",
+	tree.Bitor:        "Bitor",
+	tree.Bitxor:       "Bitxor",
 	tree.Plus:         "Plus",
 	tree.Minus:        "Minus",
 	tree.Mult:         "Mult",
 	tree.Div:          "Div",
+	tree.FloorDiv:     "FloorDiv",
+	tree.Mod:          "Mod",
 	tree.Concat:       "Concat",
 	tree.JSONFetchVal: "JSONFetchVal",
 }

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -877,10 +877,10 @@ SELECT mod(5.0::float, 2.0), mod(1.0::float, 0.0), mod(5, 2), mod(19.3::decimal,
 # mod returns the same results as PostgreSQL 9.4.4
 # in tests below (except for the error message).
 
-query error mod\(\): zero modulus
+query error mod\(\): division by zero
 SELECT mod(5, 0)
 
-query error mod\(\): zero modulus
+query error mod\(\): division by zero
 SELECT mod(5::decimal, 0::decimal)
 
 query II

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
@@ -87,6 +87,21 @@ VALUES (
        )
 
 query T
+EXPLAIN (VEC) SELECT _inet & _inet FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projBitandDatumDatumOp
+    └ *colexec.colBatchScan
+
+query T rowsort
+SELECT _inet & _inet FROM many_types
+----
+NULL
+127.0.0.1
+192.168.0.0/16
+
+query T
 EXPLAIN (VEC) SELECT _inet - _int2 FROM many_types
 ----
 │

--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -334,7 +334,7 @@ var mathBuiltins = map[string]builtinDefinition{
 		}, "Calculates `x`%`y`.", tree.VolatilityImmutable),
 		decimalOverload2("x", "y", func(x, y *apd.Decimal) (tree.Datum, error) {
 			if y.Sign() == 0 {
-				return nil, tree.ErrZeroModulus
+				return nil, tree.ErrDivByZero
 			}
 			dd := &tree.DDecimal{}
 			_, err := tree.HighPrecisionCtx.Rem(&dd.Decimal, x, y)
@@ -346,7 +346,7 @@ var mathBuiltins = map[string]builtinDefinition{
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				y := tree.MustBeDInt(args[1])
 				if y == 0 {
-					return nil, tree.ErrZeroModulus
+					return nil, tree.ErrDivByZero
 				}
 				x := tree.MustBeDInt(args[0])
 				return tree.NewDInt(x % y), nil

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -258,7 +258,7 @@ func TestEvalError(t *testing.T) {
 		expr     string
 		expected string
 	}{
-		{`1 % 0`, `zero modulus`},
+		{`1 % 0`, `division by zero`},
 		{`1 / 0`, `division by zero`},
 		{`1::float / 0::float`, `division by zero`},
 		{`1 // 0`, `division by zero`},

--- a/pkg/sql/sem/tree/eval_test/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test/eval_test.go
@@ -208,7 +208,7 @@ func TestEval(t *testing.T) {
 				result.Op,
 				typs,
 				nil, /* output */
-				nil, /* metadataSourcesQueue */
+				result.MetadataSources,
 				nil, /* toClose */
 				nil, /* outputStatsToTrace */
 				nil, /* cancelFlow */
@@ -228,10 +228,6 @@ func TestEval(t *testing.T) {
 				t.Fatalf("unexpected metadata: %+v", meta)
 			}
 			if row == nil {
-				// Might be some metadata.
-				if meta := mat.DrainHelper(); meta.Err != nil {
-					t.Fatalf("unexpected error: %s", meta.Err)
-				}
 				t.Fatal("unexpected end of input")
 			}
 			return row[0].Datum.String()

--- a/pkg/sql/sem/tree/testdata/eval/arithmetic_operators
+++ b/pkg/sql/sem/tree/testdata/eval/arithmetic_operators
@@ -89,9 +89,29 @@ eval
 2
 
 eval
+1 // 0
+----
+division by zero
+
+eval
 -4.5 // 1.2
 ----
 -3
+
+eval
+1.0 // 0.0
+----
+division by zero
+
+eval
+1.0 // 0
+----
+division by zero
+
+eval
+1 // 0.0
+----
+division by zero
 
 eval
 3.1 % 2.0
@@ -117,6 +137,11 @@ eval
 5 % 3
 ----
 2
+
+eval
+1 % 0
+----
+division by zero
 
 eval
 1 + NULL
@@ -149,9 +174,34 @@ eval
 1
 
 eval
+1.0 % 0.0
+----
+division by zero
+
+eval
+1.0 % 0
+----
+division by zero
+
+eval
+1 % 0.0
+----
+division by zero
+
+eval
 -4.5:::float // 1.2:::float
 ----
 -3.0
+
+eval
+1:::float // 0:::float
+----
+division by zero
+
+eval
+1:::float % 0:::float
+----
+division by zero
 
 eval
 2 ^ 3

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -419,7 +419,6 @@ var ignoredErrorPatterns = []string{
 	"overflow",
 	"requested length too large",
 	"division by zero",
-	"zero modulus",
 	"is out of range",
 
 	// Type checking


### PR DESCRIPTION
**sem: unify division by zero check and fix it in a few places**

Release note (bug fix): Previously, in some cases, CockroachDB didn't
check whether the right argument of `Div` (`/`), `FloorDiv` (`//`),
or `Mod` (`%`) operations was zero, so instead of correctly returning
a "division by zero" error, we were returning `NaN`, and this is now
fixed. Additionally, the error message of "modulus by zero" has been
changed to "division by zero" to be inline with Postgres.

**colexec: add support for bit and some arithmetic binary operators**

This commit adds support for `Bitand`, `Bitor`, `Bitxor`, `FloorDiv`,
and `Mod` binary operators for both native and datum-backed types.

Release note (sql change): Vectorized execution engine now supports
`Bitand` (`&`), `Bitor` (`|`), `Bitxor` (`^`), `FloorDiv` (`//`), and
`Mod` (`%`) binary operators.