### PR TITLE
sql/physicalplan: small refactor

### DIFF
--- a/pkg/sql/physicalplan/replicaoracle/oracle.go
+++ b/pkg/sql/physicalplan/replicaoracle/oracle.go
@@ -229,11 +229,6 @@ func (o *binPackingOracle) ChoosePreferredReplica(
 		}
 	}
 
-	// If we've assigned the range before, return that assignment.
-	if repl, ok := queryState.AssignedRanges[desc.RangeID]; ok {
-		return repl, nil
-	}
-
 	replicas, err := replicaSliceOrErr(desc, o.gossip)
 	if err != nil {
 		return roachpb.ReplicaDescriptor{}, err

--- a/pkg/sql/physicalplan/span_resolver.go
+++ b/pkg/sql/physicalplan/span_resolver.go
@@ -264,12 +264,18 @@ func (it *spanResolverIterator) ReplicaInfo(
 		panic(it.Error())
 	}
 
+	// If we've assigned the range before, return that assignment.
+	rngID := it.it.Desc().RangeID
+	if repl, ok := it.queryState.AssignedRanges[rngID]; ok {
+		return repl, nil
+	}
+
 	repl, err := it.oracle.ChoosePreferredReplica(
 		ctx, *it.it.Desc(), it.queryState)
 	if err != nil {
 		return roachpb.ReplicaDescriptor{}, err
 	}
 	it.queryState.RangesPerNode[repl.NodeID]++
-	it.queryState.AssignedRanges[it.it.Desc().RangeID] = repl
+	it.queryState.AssignedRanges[rngID] = repl
 	return repl, nil
 }

--- a/pkg/sql/physicalplan/span_resolver_test.go
+++ b/pkg/sql/physicalplan/span_resolver_test.go
@@ -15,7 +15,6 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
@@ -347,11 +346,6 @@ func setupRanges(
 		}
 	}
 
-	// TODO(andrei): The sleep below serves to remove the noise that the
-	// RangeCache might encounter, clobbering descriptors with old versions.
-	// Remove once all the causes of such clobbering, listed in #10751, have been
-	// fixed.
-	time.Sleep(300 * time.Millisecond)
 	// Run a select across the whole table to populate the caches with all the
 	// ranges.
 	if _, err := db.Exec(`SELECT count(1) from test`); err != nil {


### PR DESCRIPTION
This patch lifts the concern about consistently resolving spans from a
single range to the same node up to the spanResolver, from one of the
replica oracles. Regardless of what oracle is used (i.e. the
lease-holder aware one, or the follower-reads one), making a single node
in charge of all the spans that fall within one range seems like a good
idea. Currently only the leaseholder oracle was doing this.
This makes SpanResolver.ReplicaInfo() idempotent.