### PR TITLE
changefeedccl: change default flush interval to 5s

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -312,21 +312,22 @@ func emitEntries(
 		}
 
 		// If the resolved timestamp frequency is specified, use it as a rough
-		// approximation of how latency-sensitive the changefeed user is. If
-		// it's not, fall back to the poll interval.
+		// approximation of how latency-sensitive the changefeed user is. If it's
+		// not, fall back to a default of 5s
 		//
-		// The current poller implementation means we emit a changefeed-level
-		// resolved timestamps to the user once per changefeedPollInterval. This
-		// buffering adds on average timeBetweenFlushes/2 to that latency. With
-		// timeBetweenFlushes and changefeedPollInterval both set to 1s, TPCC
-		// was seeing about 100x more time spent emitting than flushing.
-		// Dividing by 5 tries to balance these a bit, but ultimately is fairly
-		// unprincipled.
+		// With timeBetweenFlushes and changefeedPollInterval both set to 1s, TPCC
+		// was seeing about 100x more time spent emitting than flushing when tested
+		// with low-latency sinks like Kafka. However when using cloud-storage
+		// sinks, flushes can take much longer and trying to flush too often can
+		// thus end up spending too much time flushing and not enough in emitting to
+		// keep up with the feed. If a user does not specify a 'resolved' time, we
+		// instead default to 5s, which is hopefully long enough to account for most
+		// possible sink latencies we could see without falling behind.
 		//
 		// NB: As long as we periodically get new span-level resolved timestamps
-		// from the poller (which should always happen, even if the watched data
-		// is not changing), then this is sufficient and we don't have to do
-		// anything fancy with timers.
+		// from the poller (which should always happen, even if the watched data is
+		// not changing), then this is sufficient and we don't have to do anything
+		// fancy with timers.
 		var timeBetweenFlushes time.Duration
 		if r, ok := details.Opts[changefeedbase.OptResolvedTimestamps]; ok && r != `` {
 			var err error
@@ -334,7 +335,7 @@ func emitEntries(
 				return nil, err
 			}
 		} else {
-			timeBetweenFlushes = changefeedbase.TableDescriptorPollInterval.Get(&settings.SV) / 5
+			timeBetweenFlushes = time.Second * 5
 		}
 		if len(resolvedSpans) == 0 ||
 			(timeutil.Since(lastFlush) < timeBetweenFlushes && !boundaryReached) {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1417,7 +1417,7 @@ func TestChangefeedMonitoring(t *testing.T) {
 
 		// Not reading from foo will backpressure it and max_behind_nanos will grow.
 		sqlDB.Exec(t, `INSERT INTO foo VALUES (2)`)
-		const expectedLatency = 100 * time.Millisecond
+		const expectedLatency = 5 * time.Second
 		sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = $1`,
 			(expectedLatency / 3).String())
 		sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.close_fraction = 1.0`)


### PR DESCRIPTION
We observed a customer cluster's changefeeds to cloud storage 'getting stuck'
which on further investigation was determined to be happening because they
were spending too much time in flushing. This was because they were writing to
a cloud sink and the default flush interval of 200ms (poller interval of 1s / 5)
meant it spent all of its time flushing. This default was picked testing with
lower-latency sinks and was noted in a comment as somewhat arbitrary.

This change does two things: it increases the default to the poller interval
if unspecified, instead of poller interval / 5, meaning 1s instead of 200ms
at the default setting, and if the sink being used is cloud storage, it
changes it to the greater of that or 5s. Users who truely desire lower latency
can of course specify their own 'resolved' interval, so this change in the
default is for those that are indifferent, and increasing the latency to 1s or 5s
reduces the chance of hiitting this unfortunate edge case when the sink is too slow.

Release note (enterprise change): The default flush interval for changefeeds that do not specify a 'resolved' option is now 1s instead of 200ms, or 5s if the changefeed sink is cloud-storage.