### PR TITLE
opt: incorporate cast volatility

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1404,6 +1404,14 @@ func BuildSharedProps(e opt.Expr, shared *props.Shared) {
 		}
 		shared.VolatilitySet.Add(t.Overload.Volatility)
 
+	case *CastExpr:
+		from, to := t.Input.DataType(), t.Typ
+		volatility, ok := tree.LookupCastVolatility(from, to)
+		if !ok {
+			panic(errors.AssertionFailedf("no volatility for cast %s::%s", from, to))
+		}
+		shared.VolatilitySet.Add(volatility)
+
 	default:
 		if opt.IsMutationOp(e) {
 			shared.CanHaveSideEffects = true

--- a/pkg/sql/opt/memo/testdata/logprops/groupby
+++ b/pkg/sql/opt/memo/testdata/logprops/groupby
@@ -270,10 +270,12 @@ group-by
  ├── columns: column1:1(int)
  ├── grouping columns: column1:1(int)
  ├── cardinality: [1 - 4]
+ ├── immutable
  ├── key: (1)
  └── values
       ├── columns: column1:1(int)
       ├── cardinality: [4 - 4]
+      ├── immutable
       ├── prune: (1)
       ├── tuple [type=tuple{int}]
       │    └── const: 1 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/insert
+++ b/pkg/sql/opt/memo/testdata/logprops/insert
@@ -68,7 +68,7 @@ insert abcde
       │    └── projections
       │         ├── const: 10 [as=column10:10, type=int]
       │         ├── function: unique_rowid [as=column11:11, type=int, volatile, side-effects]
-      │         └── cast: INT8 [as=column12:12, type=int]
+      │         └── cast: INT8 [as=column12:12, type=int, immutable]
       │              └── null [type=unknown]
       └── projections
            └── plus [as=column13:13, type=int, outer=(8,10)]
@@ -136,7 +136,7 @@ project
            │    └── projections
            │         ├── const: 10 [as=column10:10, type=int]
            │         ├── function: unique_rowid [as=column11:11, type=int, volatile, side-effects]
-           │         └── cast: INT8 [as=column12:12, type=int]
+           │         └── cast: INT8 [as=column12:12, type=int, immutable]
            │              └── null [type=unknown]
            └── projections
                 └── plus [as=column13:13, type=int, outer=(8,10)]
@@ -187,7 +187,7 @@ project
            │    └── projections
            │         ├── const: 10 [as=column10:10, type=int]
            │         ├── function: unique_rowid [as=column11:11, type=int, volatile, side-effects]
-           │         └── cast: INT8 [as=column12:12, type=int]
+           │         └── cast: INT8 [as=column12:12, type=int, immutable]
            │              └── null [type=unknown]
            └── projections
                 └── plus [as=column13:13, type=int, outer=(8,10)]
@@ -239,7 +239,7 @@ insert abcde
       │    └── projections
       │         ├── const: 10 [as=column9:9, type=int]
       │         ├── function: unique_rowid [as=column10:10, type=int, volatile, side-effects]
-      │         └── cast: INT8 [as=column11:11, type=int]
+      │         └── cast: INT8 [as=column11:11, type=int, immutable]
       │              └── null [type=unknown]
       └── projections
            └── plus [as=column12:12, type=int, outer=(8,9)]
@@ -280,6 +280,7 @@ project
            │    ├── prune: (8,10-13)
            │    ├── project
            │    │    ├── columns: int8:10(int) y:8(int!null)
+           │    │    ├── immutable
            │    │    ├── fd: ()-->(8)
            │    │    ├── prune: (8,10)
            │    │    ├── select
@@ -299,14 +300,14 @@ project
            │    │    │              ├── variable: y:8 [type=int]
            │    │    │              └── const: 1 [type=int]
            │    │    └── projections
-           │    │         └── cast: INT8 [as=int8:10, type=int, outer=(9)]
+           │    │         └── cast: INT8 [as=int8:10, type=int, outer=(9), immutable]
            │    │              └── plus [type=float]
            │    │                   ├── variable: z:9 [type=float]
            │    │                   └── const: 1.0 [type=float]
            │    └── projections
            │         ├── const: 10 [as=column11:11, type=int]
            │         ├── function: unique_rowid [as=column12:12, type=int, volatile, side-effects]
-           │         └── cast: INT8 [as=column13:13, type=int]
+           │         └── cast: INT8 [as=column13:13, type=int, immutable]
            │              └── null [type=unknown]
            └── projections
                 └── plus [as=column14:14, type=int, outer=(10,11)]

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -607,6 +607,7 @@ SELECT * FROM xysd WHERE EXISTS(SELECT * FROM (SELECT x) INNER JOIN (SELECT y) O
 ----
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── prune: (4)
@@ -618,11 +619,12 @@ select
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-3,+4,+1)
  └── filters
-      └── exists [type=bool, outer=(1-3), correlated-subquery]
+      └── exists [type=bool, outer=(1-3), immutable, correlated-subquery]
            └── inner-join (cross)
                 ├── columns: x:5(int) y:6(int)
                 ├── outer: (1-3)
                 ├── cardinality: [0 - 1]
+                ├── immutable
                 ├── key: ()
                 ├── fd: ()-->(5,6)
                 ├── prune: (6)
@@ -654,7 +656,7 @@ select
                 │    └── projections
                 │         └── variable: xysd.y:2 [as=y:6, type=int, outer=(2)]
                 └── filters
-                     └── eq [type=bool, outer=(3,5)]
+                     └── eq [type=bool, outer=(3,5), immutable]
                           ├── cast: STRING [type=string]
                           │    └── variable: x:5 [type=int]
                           └── variable: s:3 [type=string]
@@ -959,6 +961,7 @@ SELECT * FROM (VALUES (NULL), (NULL)) a FULL JOIN (VALUES (NULL), (NULL)) b ON a
 full-join (cross)
  ├── columns: column1:1(unknown) column1:2(unknown)
  ├── cardinality: [2 - 4]
+ ├── immutable
  ├── prune: (1,2)
  ├── reject-nulls: (1,2)
  ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
@@ -979,7 +982,7 @@ full-join (cross)
  │    └── tuple [type=tuple{unknown}]
  │         └── null [type=unknown]
  └── filters
-      └── cast: BOOL [type=bool]
+      └── cast: BOOL [type=bool, immutable]
            └── null [type=unknown]
 
 # Calculate full-join cardinality of one input with unknown cardinality.

--- a/pkg/sql/opt/memo/testdata/logprops/project
+++ b/pkg/sql/opt/memo/testdata/logprops/project
@@ -153,6 +153,7 @@ SELECT 1 AS a, 'foo' AS b, NULL AS c, 1::decimal + NULL AS d, NULL::STRING AS e 
 ----
 project
  ├── columns: a:5(int!null) b:6(string!null) c:7(unknown) d:7(unknown) e:8(string)
+ ├── immutable
  ├── fd: ()-->(5-8)
  ├── prune: (5-8)
  ├── scan xysd
@@ -165,7 +166,7 @@ project
       ├── const: 1 [as=a:5, type=int]
       ├── const: 'foo' [as=b:6, type=string]
       ├── null [as=c:7, type=unknown]
-      └── cast: STRING [as=e:8, type=string]
+      └── cast: STRING [as=e:8, type=string, immutable]
            └── null [type=unknown]
 
 # Project constant over input with no needed columns and ensure that there is
@@ -312,6 +313,7 @@ SELECT y, y::TEXT FROM xysd
 ----
 project
  ├── columns: y:2(int) y:5(string)
+ ├── immutable
  ├── fd: (2)-->(5)
  ├── prune: (2,5)
  ├── scan xysd
@@ -321,7 +323,7 @@ project
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-3,+4,+1)
  └── projections
-      └── cast: STRING [as=y:5, type=string, outer=(2)]
+      └── cast: STRING [as=y:5, type=string, outer=(2), immutable]
            └── variable: xysd.y:2 [type=int]
 
 # We don't have the FD: d --> d::TEXT because d is a composite type.
@@ -331,6 +333,7 @@ SELECT d, d::TEXT FROM xysd
 ----
 project
  ├── columns: d:4(decimal!null) d:5(string!null)
+ ├── immutable
  ├── prune: (4,5)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) xysd.d:4(decimal!null)
@@ -339,7 +342,7 @@ project
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-3,+4,+1)
  └── projections
-      └── cast: STRING [as=d:5, type=string, outer=(4)]
+      └── cast: STRING [as=d:5, type=string, outer=(4), immutable]
            └── variable: xysd.d:4 [type=decimal]
 
 # We have the equality relation between the synthesized column and the column

--- a/pkg/sql/opt/memo/testdata/logprops/scalar
+++ b/pkg/sql/opt/memo/testdata/logprops/scalar
@@ -6,6 +6,10 @@ exec-ddl
 CREATE TABLE uv (u INT, v INT NOT NULL)
 ----
 
+exec-ddl
+CREATE TABLE sf (s STRING, f FLOAT)
+----
+
 build
 SELECT * FROM xy WHERE x < 5
 ----
@@ -257,6 +261,7 @@ SELECT x / 1, x::float / 2.0, x::decimal / 3.0 FROM xy
 ----
 project
  ├── columns: "?column?":3(decimal!null) "?column?":4(float!null) "?column?":5(decimal!null)
+ ├── immutable
  ├── prune: (3-5)
  ├── scan xy
  │    ├── columns: x:1(int!null) y:2(int)
@@ -268,11 +273,73 @@ project
       ├── div [as="?column?":3, type=decimal, outer=(1)]
       │    ├── variable: x:1 [type=int]
       │    └── const: 1 [type=int]
-      ├── div [as="?column?":4, type=float, outer=(1)]
+      ├── div [as="?column?":4, type=float, outer=(1), immutable]
       │    ├── cast: FLOAT8 [type=float]
       │    │    └── variable: x:1 [type=int]
       │    └── const: 2.0 [type=float]
-      └── div [as="?column?":5, type=decimal, outer=(1)]
+      └── div [as="?column?":5, type=decimal, outer=(1), immutable]
            ├── cast: DECIMAL [type=decimal]
            │    └── variable: x:1 [type=int]
            └── const: 3.0 [type=decimal]
+
+# Verify that we take into account the volatility of casts.
+build
+SELECT s::TIMESTAMP FROM sf
+----
+project
+ ├── columns: s:4(timestamp)
+ ├── stable
+ ├── prune: (4)
+ ├── scan sf
+ │    ├── columns: sf.s:1(string) f:2(float) rowid:3(int!null)
+ │    ├── key: (3)
+ │    ├── fd: (3)-->(1,2)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+3)
+ └── projections
+      └── cast: TIMESTAMP [as=s:4, type=timestamp, outer=(1), stable]
+           └── variable: sf.s:1 [type=string]
+
+build
+SELECT f::STRING FROM sf
+----
+project
+ ├── columns: f:4(string)
+ ├── stable
+ ├── prune: (4)
+ ├── scan sf
+ │    ├── columns: s:1(string) sf.f:2(float) rowid:3(int!null)
+ │    ├── key: (3)
+ │    ├── fd: (3)-->(1,2)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+3)
+ └── projections
+      └── cast: STRING [as=f:4, type=string, outer=(2), stable]
+           └── variable: sf.f:2 [type=float]
+
+build
+SELECT ARRAY(SELECT f FROM sf)::STRING[]
+----
+project
+ ├── columns: array:4(string[])
+ ├── cardinality: [1 - 1]
+ ├── stable
+ ├── key: ()
+ ├── fd: ()-->(4)
+ ├── prune: (4)
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── tuple [type=tuple]
+ └── projections
+      └── cast: STRING[] [as=array:4, type=string[], stable, subquery]
+           └── array-flatten [type=float[]]
+                └── project
+                     ├── columns: f:2(float)
+                     ├── prune: (2)
+                     └── scan sf
+                          ├── columns: s:1(string) f:2(float) rowid:3(int!null)
+                          ├── key: (3)
+                          ├── fd: (3)-->(1,2)
+                          ├── prune: (1-3)
+                          └── interesting orderings: (+3)

--- a/pkg/sql/opt/memo/testdata/logprops/values
+++ b/pkg/sql/opt/memo/testdata/logprops/values
@@ -8,6 +8,7 @@ SELECT * FROM (VALUES (1, 2), (3, 4), (NULL, 5))
 values
  ├── columns: column1:1(int) column2:2(int!null)
  ├── cardinality: [3 - 3]
+ ├── immutable
  ├── prune: (1,2)
  ├── tuple [type=tuple{int, int}]
  │    ├── const: 1 [type=int]
@@ -43,6 +44,7 @@ SELECT * FROM (VALUES (NULL, 2), (3, NULL), (5, 6))
 values
  ├── columns: column1:1(int) column2:2(int)
  ├── cardinality: [3 - 3]
+ ├── immutable
  ├── prune: (1,2)
  ├── tuple [type=tuple{int, int}]
  │    ├── cast: INT8 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/window
+++ b/pkg/sql/opt/memo/testdata/logprops/window
@@ -148,14 +148,17 @@ SELECT lag('foo'::string) OVER (), lag(1) OVER () FROM kv
 ----
 project
  ├── columns: lag:8(string) lag:9(int)
+ ├── immutable
  ├── prune: (8,9)
  └── window partition=()
       ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) lag:8(string) lag:9(int) lag_1_arg1:10(string!null) lag_1_arg2:11(int!null) lag_1_arg3:12(string) lag_2_arg3:13(int)
+      ├── immutable
       ├── key: (1)
       ├── fd: ()-->(10-13), (1)-->(2-7)
       ├── prune: (1-9)
       ├── project
       │    ├── columns: lag_1_arg1:10(string!null) lag_1_arg2:11(int!null) lag_1_arg3:12(string) lag_2_arg3:13(int) k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    ├── immutable
       │    ├── key: (1)
       │    ├── fd: ()-->(10-13), (1)-->(2-7)
       │    ├── prune: (1-7,10-13)
@@ -167,12 +170,12 @@ project
       │    │    ├── prune: (1-7)
       │    │    └── interesting orderings: (+1)
       │    └── projections
-      │         ├── cast: STRING [as=lag_1_arg1:10, type=string]
+      │         ├── cast: STRING [as=lag_1_arg1:10, type=string, immutable]
       │         │    └── const: 'foo' [type=string]
       │         ├── const: 1 [as=lag_1_arg2:11, type=int]
-      │         ├── cast: STRING [as=lag_1_arg3:12, type=string]
+      │         ├── cast: STRING [as=lag_1_arg3:12, type=string, immutable]
       │         │    └── null [type=unknown]
-      │         └── cast: INT8 [as=lag_2_arg3:13, type=int]
+      │         └── cast: INT8 [as=lag_2_arg3:13, type=int, immutable]
       │              └── null [type=unknown]
       └── windows
            ├── lag [as=lag:8, type=string, outer=(10-12)]

--- a/pkg/sql/opt/memo/testdata/logprops/with
+++ b/pkg/sql/opt/memo/testdata/logprops/with
@@ -117,14 +117,14 @@ WITH foo AS (SELECT $1::INT) SELECT 1 FROM foo
 with &1 (foo)
  ├── columns: "?column?":3(int!null)
  ├── cardinality: [1 - 1]
- ├── has-placeholder
+ ├── immutable, has-placeholder
  ├── key: ()
  ├── fd: ()-->(3)
  ├── prune: (3)
  ├── project
  │    ├── columns: int8:1(int)
  │    ├── cardinality: [1 - 1]
- │    ├── has-placeholder
+ │    ├── immutable, has-placeholder
  │    ├── key: ()
  │    ├── fd: ()-->(1)
  │    ├── prune: (1)
@@ -133,7 +133,7 @@ with &1 (foo)
  │    │    ├── key: ()
  │    │    └── tuple [type=tuple]
  │    └── projections
- │         └── cast: INT8 [as=int8:1, type=int]
+ │         └── cast: INT8 [as=int8:1, type=int, immutable]
  │              └── placeholder: $1 [type=string]
  └── project
       ├── columns: "?column?":3(int!null)

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -17,18 +17,22 @@ limit
  ├── columns: y:2(int!null) x:3(string!null) c:5(int!null)
  ├── internal-ordering: +2
  ├── cardinality: [0 - 10]
+ ├── immutable
  ├── fd: (2)-->(5)
  ├── ordering: +2
  ├── sort
  │    ├── columns: y:2(int!null) b.x:3(string!null) c:5(int!null)
+ │    ├── immutable
  │    ├── fd: (2)-->(5)
  │    ├── ordering: +2
  │    ├── limit hint: 10.00
  │    └── project
  │         ├── columns: c:5(int!null) y:2(int!null) b.x:3(string!null)
+ │         ├── immutable
  │         ├── fd: (2)-->(5)
  │         ├── select
  │         │    ├── columns: a.x:1(int!null) y:2(int!null) b.x:3(string!null) z:4(decimal!null)
+ │         │    ├── immutable
  │         │    ├── key: (1,3)
  │         │    ├── fd: (1)-->(2), (3)-->(4)
  │         │    ├── inner-join (cross)
@@ -45,7 +49,7 @@ limit
  │         │    │    │    └── fd: (3)-->(4)
  │         │    │    └── filters (true)
  │         │    └── filters
- │         │         └── and [type=bool, outer=(1-3), constraints=(/2: [/2 - ])]
+ │         │         └── and [type=bool, outer=(1-3), immutable, constraints=(/2: [/2 - ])]
  │         │              ├── gt [type=bool]
  │         │              │    ├── variable: y:2 [type=int]
  │         │              │    └── const: 1 [type=int]
@@ -69,27 +73,32 @@ LIMIT 10
 project
  ├── columns: y:2(int!null) x:3(string!null) c:6(int!null)
  ├── cardinality: [0 - 10]
+ ├── immutable
  ├── fd: (2)-->(6)
  ├── ordering: +2
  ├── limit
  │    ├── columns: y:2(int!null) b.x:3(string!null) column5:5(string!null)
  │    ├── internal-ordering: +2
  │    ├── cardinality: [0 - 10]
+ │    ├── immutable
  │    ├── fd: (3)==(5), (5)==(3)
  │    ├── ordering: +2
  │    ├── inner-join (lookup b)
  │    │    ├── columns: y:2(int!null) b.x:3(string!null) column5:5(string!null)
  │    │    ├── key columns: [5] = [3]
  │    │    ├── lookup columns are key
+ │    │    ├── immutable
  │    │    ├── fd: (3)==(5), (5)==(3)
  │    │    ├── ordering: +2
  │    │    ├── limit hint: 10.00
  │    │    ├── sort
  │    │    │    ├── columns: y:2(int!null) column5:5(string!null)
+ │    │    │    ├── immutable
  │    │    │    ├── ordering: +2
  │    │    │    ├── limit hint: 100.00
  │    │    │    └── project
  │    │    │         ├── columns: column5:5(string!null) y:2(int!null)
+ │    │    │         ├── immutable
  │    │    │         ├── select
  │    │    │         │    ├── columns: a.x:1(int!null) y:2(int!null)
  │    │    │         │    ├── key: (1)
@@ -103,7 +112,7 @@ project
  │    │    │         │              ├── variable: y:2 [type=int]
  │    │    │         │              └── const: 1 [type=int]
  │    │    │         └── projections
- │    │    │              └── cast: STRING [as=column5:5, type=string, outer=(1)]
+ │    │    │              └── cast: STRING [as=column5:5, type=string, outer=(1), immutable]
  │    │    │                   └── variable: a.x:1 [type=int]
  │    │    └── filters (true)
  │    └── const: 10 [type=int]

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -1015,6 +1015,7 @@ SELECT a, b::string FROM t47742 WHERE b = true
 ----
 project
  ├── columns: a:1(int) b:4(string!null)
+ ├── immutable
  ├── stats: [rows=2640.64496]
  ├── fd: ()-->(4)
  ├── index-join t47742
@@ -1032,7 +1033,7 @@ project
  │         ├── key: (3)
  │         └── fd: ()-->(2)
  └── projections
-      └── t47742.b:2::STRING [as=b:4, type=string, outer=(2)]
+      └── t47742.b:2::STRING [as=b:4, type=string, outer=(2), immutable]
 
 # Multi-column stats tests.
 exec-ddl

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -691,11 +691,13 @@ WHERE
 ----
 index-join lineitem
  ├── columns: l_orderkey:1(int!null) l_partkey:2(int!null) l_suppkey:3(int!null) l_linenumber:4(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null) l_shipdate:11(date!null) l_commitdate:12(date!null) l_receiptdate:13(date!null) l_shipinstruct:14(char!null) l_shipmode:15(char!null) l_comment:16(varchar!null)
+ ├── stable
  ├── stats: [rows=111.111111, distinct(11)=33.3333333, null(11)=0]
  ├── key: (1,4)
  ├── fd: (1,4)-->(2,3,5-16)
  └── select
       ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null)
+      ├── stable
       ├── stats: [rows=111.111111]
       ├── key: (1,4)
       ├── fd: (1,4)-->(11)
@@ -706,7 +708,7 @@ index-join lineitem
       │    ├── key: (1,4)
       │    └── fd: (1,4)-->(11)
       └── filters
-           └── l_shipdate:11::TIMESTAMPTZ < '1995-10-01' [type=bool, outer=(11)]
+           └── l_shipdate:11::TIMESTAMPTZ < '1995-10-01' [type=bool, outer=(11), stable]
 
 # These queries should generate zigzag joins in xform rules. The column statistics
 # should be comparable between the norm'd and fully optimized expressions.
@@ -1419,10 +1421,12 @@ SELECT x FROM t WHERE x
 ----
 with &1 (t)
  ├── columns: x:6(bool!null)
+ ├── immutable
  ├── stats: [rows=1.98e+20, distinct(6)=1, null(6)=0]
  ├── fd: ()-->(6)
  ├── project
  │    ├── columns: x:5(bool)
+ │    ├── immutable
  │    ├── stats: [rows=4e+20]
  │    ├── left-join (cross)
  │    │    ├── columns: t1.x:1(bool) t2.x:3(bool)
@@ -1435,7 +1439,7 @@ with &1 (t)
  │    │    │    └── stats: [rows=2e+10]
  │    │    └── filters (true)
  │    └── projections
- │         └── (t1.x:1::INT8 << 5533)::BOOL OR t2.x:3 [as=x:5, type=bool, outer=(1,3)]
+ │         └── (t1.x:1::INT8 << 5533)::BOOL OR t2.x:3 [as=x:5, type=bool, outer=(1,3), immutable]
  └── select
       ├── columns: x:6(bool!null)
       ├── stats: [rows=1.98e+20, distinct(6)=1, null(6)=0]

--- a/pkg/sql/opt/memo/testdata/stats/upsert
+++ b/pkg/sql/opt/memo/testdata/stats/upsert
@@ -111,16 +111,19 @@ with &1
  │    ├── stats: [rows=9.94974874]
  │    └── project
  │         ├── columns: upsert_x:13(string) upsert_y:14(int!null) upsert_z:15(float) a:4(int!null) b:5(string) column8:8(float) xyz.x:9(string) xyz.y:10(int) xyz.z:11(float) y_new:12(int!null)
+ │         ├── immutable
  │         ├── stats: [rows=9.94974874]
  │         ├── lax-key: (5,9)
  │         ├── fd: ()-->(8,12), (5)~~>(4), (9)-->(10,11), (5,9)-->(13), (4,9)-->(14), (5,9)~~>(4,14,15)
  │         ├── project
  │         │    ├── columns: y_new:12(int!null) a:4(int!null) b:5(string) column8:8(float) xyz.x:9(string) xyz.y:10(int) xyz.z:11(float)
+ │         │    ├── immutable
  │         │    ├── stats: [rows=9.94974874]
  │         │    ├── lax-key: (5,9)
  │         │    ├── fd: ()-->(8,12), (5)~~>(4), (9)-->(10,11)
  │         │    ├── left-join (hash)
  │         │    │    ├── columns: a:4(int!null) b:5(string) column8:8(float) xyz.x:9(string) xyz.y:10(int) xyz.z:11(float)
+ │         │    │    ├── immutable
  │         │    │    ├── stats: [rows=9.94974874, distinct(9)=9.94974874, null(9)=0]
  │         │    │    ├── lax-key: (5,9)
  │         │    │    ├── fd: ()-->(8), (5)~~>(4), (9)-->(10,11)
@@ -128,11 +131,13 @@ with &1
  │         │    │    │    ├── columns: a:4(int!null) b:5(string) column8:8(float)
  │         │    │    │    ├── grouping columns: b:5(string)
  │         │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
+ │         │    │    │    ├── immutable
  │         │    │    │    ├── stats: [rows=9.94974874, distinct(4)=6.31184239, null(4)=0, distinct(5)=9.94974874, null(5)=0]
  │         │    │    │    ├── lax-key: (5)
  │         │    │    │    ├── fd: ()-->(8), (5)~~>(4,8)
  │         │    │    │    ├── project
  │         │    │    │    │    ├── columns: column8:8(float) a:4(int!null) b:5(string)
+ │         │    │    │    │    ├── immutable
  │         │    │    │    │    ├── stats: [rows=9.94974874, distinct(5)=6.31184239, null(5)=0]
  │         │    │    │    │    ├── fd: ()-->(8)
  │         │    │    │    │    ├── project
@@ -154,7 +159,7 @@ with &1
  │         │    │    │    │    │         └── filters
  │         │    │    │    │    │              └── c:6 = 1.0 [type=bool, outer=(6), constraints=(/6: [/1.0 - /1.0]; tight), fd=()-->(6)]
  │         │    │    │    │    └── projections
- │         │    │    │    │         └── NULL::FLOAT8 [as=column8:8, type=float]
+ │         │    │    │    │         └── NULL::FLOAT8 [as=column8:8, type=float, immutable]
  │         │    │    │    └── aggregations
  │         │    │    │         ├── first-agg [as=a:4, type=int, outer=(4)]
  │         │    │    │         │    └── a:4 [type=int]
@@ -204,6 +209,7 @@ upsert xyz
  └── project
       ├── columns: column8:8(float) a:4(int!null) b:5(string)
       ├── cardinality: [0 - 0]
+      ├── immutable
       ├── stats: [rows=0]
       ├── fd: ()-->(8)
       ├── project
@@ -227,7 +233,7 @@ upsert xyz
       │         └── filters
       │              └── false [type=bool]
       └── projections
-           └── NULL::FLOAT8 [as=column8:8, type=float]
+           └── NULL::FLOAT8 [as=column8:8, type=float, immutable]
 
 # Nullable conflict column. Ensure that ensure-upsert-distinct-on passes through
 # the input's null count.
@@ -280,6 +286,7 @@ upsert uv
       │    │    │    │    ├── stats: [rows=1000, distinct(6)=100, null(6)=0]
       │    │    │    │    ├── project
       │    │    │    │    │    ├── columns: z:6(int)
+      │    │    │    │    │    ├── immutable
       │    │    │    │    │    ├── stats: [rows=1000, distinct(6)=100, null(6)=0]
       │    │    │    │    │    ├── scan xyz
       │    │    │    │    │    │    ├── columns: x:3(string!null) y:4(int!null) xyz.z:5(float)
@@ -287,7 +294,7 @@ upsert uv
       │    │    │    │    │    │    ├── key: (3)
       │    │    │    │    │    │    └── fd: (3)-->(4,5)
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── xyz.z:5::INT8 [as=z:6, type=int, outer=(5)]
+      │    │    │    │    │         └── xyz.z:5::INT8 [as=z:6, type=int, outer=(5), immutable]
       │    │    │    │    └── projections
       │    │    │    │         └── unique_rowid() [as=column7:7, type=int, volatile, side-effects]
       │    │    │    └── aggregations

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q11
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q11
@@ -46,6 +46,7 @@ ORDER BY
 sort
  ├── save-table-name: q11_sort_1
  ├── columns: ps_partkey:1(int!null) value:18(float!null)
+ ├── immutable
  ├── stats: [rows=9927.82897, distinct(1)=9927.82897, null(1)=0, distinct(18)=9927.82897, null(18)=0]
  ├── key: (1)
  ├── fd: (1)-->(18)
@@ -53,6 +54,7 @@ sort
  └── select
       ├── save-table-name: q11_select_2
       ├── columns: ps_partkey:1(int!null) sum:18(float!null)
+      ├── immutable
       ├── stats: [rows=9927.82897, distinct(1)=9927.82897, null(1)=0, distinct(18)=9927.82897, null(18)=0]
       ├── key: (1)
       ├── fd: (1)-->(18)
@@ -60,12 +62,14 @@ sort
       │    ├── save-table-name: q11_group_by_3
       │    ├── columns: ps_partkey:1(int!null) sum:18(float!null)
       │    ├── grouping columns: ps_partkey:1(int!null)
+      │    ├── immutable
       │    ├── stats: [rows=29783.4869, distinct(1)=29783.4869, null(1)=0, distinct(18)=29783.4869, null(18)=0]
       │    ├── key: (1)
       │    ├── fd: (1)-->(18)
       │    ├── project
       │    │    ├── save-table-name: q11_project_4
       │    │    ├── columns: column17:17(float!null) ps_partkey:1(int!null)
+      │    │    ├── immutable
       │    │    ├── stats: [rows=32258.0645, distinct(1)=29783.4869, null(1)=0, distinct(17)=31617.9161, null(17)=0]
       │    │    ├── inner-join (lookup partsupp)
       │    │    │    ├── save-table-name: q11_lookup_join_5
@@ -109,18 +113,19 @@ sort
       │    │    │    │    └── filters (true)
       │    │    │    └── filters (true)
       │    │    └── projections
-      │    │         └── ps_supplycost:4 * ps_availqty:3::FLOAT8 [as=column17:17, type=float, outer=(3,4)]
+      │    │         └── ps_supplycost:4 * ps_availqty:3::FLOAT8 [as=column17:17, type=float, outer=(3,4), immutable]
       │    └── aggregations
       │         └── sum [as=sum:18, type=float, outer=(17)]
       │              └── column17:17 [type=float]
       └── filters
-           └── gt [type=bool, outer=(18), subquery, constraints=(/18: (/NULL - ])]
+           └── gt [type=bool, outer=(18), immutable, subquery, constraints=(/18: (/NULL - ])]
                 ├── sum:18 [type=float]
                 └── subquery [type=float]
                      └── project
                           ├── save-table-name: q11_project_10
                           ├── columns: "?column?":37(float)
                           ├── cardinality: [1 - 1]
+                          ├── immutable
                           ├── stats: [rows=1, distinct(37)=1, null(37)=0]
                           ├── key: ()
                           ├── fd: ()-->(37)
@@ -128,12 +133,14 @@ sort
                           │    ├── save-table-name: q11_scalar_group_by_11
                           │    ├── columns: sum:36(float)
                           │    ├── cardinality: [1 - 1]
+                          │    ├── immutable
                           │    ├── stats: [rows=1, distinct(36)=1, null(36)=0]
                           │    ├── key: ()
                           │    ├── fd: ()-->(36)
                           │    ├── project
                           │    │    ├── save-table-name: q11_project_12
                           │    │    ├── columns: column35:35(float!null)
+                          │    │    ├── immutable
                           │    │    ├── stats: [rows=32258.0645, distinct(35)=31617.9161, null(35)=0]
                           │    │    ├── inner-join (lookup partsupp)
                           │    │    │    ├── save-table-name: q11_lookup_join_13
@@ -176,7 +183,7 @@ sort
                           │    │    │    │    └── filters (true)
                           │    │    │    └── filters (true)
                           │    │    └── projections
-                          │    │         └── ps_supplycost:22 * ps_availqty:21::FLOAT8 [as=column35:35, type=float, outer=(21,22)]
+                          │    │         └── ps_supplycost:22 * ps_availqty:21::FLOAT8 [as=column35:35, type=float, outer=(21,22), immutable]
                           │    └── aggregations
                           │         └── sum [as=sum:36, type=float, outer=(35)]
                           │              └── column35:35 [type=float]

--- a/pkg/sql/opt/norm/testdata/rules/agg
+++ b/pkg/sql/opt/norm/testdata/rules/agg
@@ -106,16 +106,18 @@ FROM a
 scalar-group-by
  ├── columns: count:7!null sum:9 sum_int:10 avg:11 stddev:12 variance:13 xor_agg:15 array_agg:16 json_agg:17
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(7,9-13,15-17)
  ├── project
  │    ├── columns: column8:8 column14:14 i:2 f:3 j:5
+ │    ├── immutable
  │    ├── fd: (2)-->(8)
  │    ├── scan a
  │    │    └── columns: i:2 f:3 s:4 j:5
  │    └── projections
  │         ├── i:2 > 5 [as=column8:8, outer=(2)]
- │         └── s:4::BYTES [as=column14:14, outer=(4)]
+ │         └── s:4::BYTES [as=column14:14, outer=(4), immutable]
  └── aggregations
       ├── agg-distinct [as=count:7, outer=(2)]
       │    └── count

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -92,6 +92,7 @@ WHERE
 select
  ├── columns: k:1!null i:2!null f:3 s:4 j:5 d:6
  ├── cardinality: [0 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(1-6)
  ├── scan a
@@ -102,7 +103,7 @@ select
       ├── (i:2 >= 2) AND (i:2 > 6) [outer=(2), constraints=(/2: [/7 - ]; tight)]
       ├── k:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
       ├── (f:3 + f:3) < 3.0 [outer=(3)]
-      └── i:2::INTERVAL >= '01:00:00' [outer=(2)]
+      └── i:2::INTERVAL >= '01:00:00' [outer=(2), immutable]
 
 # Try case that should not match pattern because Minus overload is not defined.
 norm expect-not=NormalizeCmpPlusConst
@@ -110,6 +111,7 @@ SELECT * FROM a WHERE s::date + '02:00:00'::time = '2000-01-01T02:00:00'::timest
 ----
 select
  ├── columns: k:1!null i:2 f:3 s:4 j:5 d:6
+ ├── stable
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan a
@@ -117,7 +119,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      └── (s:4::DATE + '02:00:00') = '2000-01-01 02:00:00+00:00' [outer=(4)]
+      └── (s:4::DATE + '02:00:00') = '2000-01-01 02:00:00+00:00' [outer=(4), stable]
 
 # --------------------------------------------------
 # NormalizeCmpMinusConst
@@ -136,6 +138,7 @@ WHERE
 select
  ├── columns: k:1!null i:2!null f:3 s:4 j:5 d:6!null
  ├── cardinality: [0 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(1-6)
  ├── scan a
@@ -146,7 +149,7 @@ select
       ├── (i:2 >= 4) AND (i:2 < 14) [outer=(2), constraints=(/2: [/4 - /13]; tight)]
       ├── k:1 = 3 [outer=(1), constraints=(/1: [/3 - /3]; tight), fd=()-->(1)]
       ├── (f:3 + f:3) < 7.0 [outer=(3)]
-      ├── (f:3 + i:2::FLOAT8) >= 110.0 [outer=(2,3)]
+      ├── (f:3 + i:2::FLOAT8) >= 110.0 [outer=(2,3), immutable]
       └── d:6 >= '2018-09-30' [outer=(6), constraints=(/6: [/'2018-09-30' - ]; tight)]
 
 # Try case that should not match pattern because Plus overload is not defined.
@@ -155,6 +158,7 @@ SELECT * FROM a WHERE s::json - 1 = '[1]'::json
 ----
 select
  ├── columns: k:1!null i:2 f:3 s:4 j:5 d:6
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan a
@@ -162,7 +166,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      └── (s:4::JSONB - 1) = '[1]' [outer=(4)]
+      └── (s:4::JSONB - 1) = '[1]' [outer=(4), immutable]
 
 # --------------------------------------------------
 # NormalizeCmpConstMinus
@@ -180,6 +184,7 @@ WHERE
 select
  ├── columns: k:1!null i:2!null f:3 s:4 j:5 d:6
  ├── cardinality: [0 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(1-6)
  ├── scan a
@@ -190,7 +195,7 @@ select
       ├── (i:2 >= -2) AND (i:2 > 10) [outer=(2), constraints=(/2: [/11 - ]; tight)]
       ├── k:1 = -1 [outer=(1), constraints=(/1: [/-1 - /-1]; tight), fd=()-->(1)]
       ├── (f:3 + f:3) > -3.0 [outer=(3)]
-      └── (f:3 + i:2::FLOAT8) <= -90.0 [outer=(2,3)]
+      └── (f:3 + i:2::FLOAT8) <= -90.0 [outer=(2,3), immutable]
 
 # Try case that should not match pattern because Minus overload is not defined.
 norm expect-not=NormalizeCmpConstMinus

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -2490,23 +2490,28 @@ SELECT * FROM a WHERE 'foo'=(SELECT concat_agg(y::string) FROM xy WHERE x=k)
 ----
 project
  ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  └── select
       ├── columns: k:1!null i:2 f:3 s:4 j:5 concat_agg:9!null
+      ├── immutable
       ├── key: (1)
       ├── fd: ()-->(9), (1)-->(2-5)
       ├── project
       │    ├── columns: concat_agg:9 k:1!null i:2 f:3 s:4 j:5
+      │    ├── immutable
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-5,9)
       │    ├── group-by
       │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 canary:10 concat_agg:11
       │    │    ├── grouping columns: k:1!null
+      │    │    ├── immutable
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(2-5,10,11)
       │    │    ├── left-join (hash)
       │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6 column8:8 canary:10
+      │    │    │    ├── immutable
       │    │    │    ├── key: (1)
       │    │    │    ├── fd: (1)-->(2-6,8,10), (6)-->(8)
       │    │    │    ├── scan a
@@ -2515,6 +2520,7 @@ project
       │    │    │    │    └── fd: (1)-->(2-5)
       │    │    │    ├── project
       │    │    │    │    ├── columns: canary:10!null column8:8 x:6!null
+      │    │    │    │    ├── immutable
       │    │    │    │    ├── key: (6)
       │    │    │    │    ├── fd: ()-->(10), (6)-->(8)
       │    │    │    │    ├── scan xy
@@ -2523,7 +2529,7 @@ project
       │    │    │    │    │    └── fd: (6)-->(7)
       │    │    │    │    └── projections
       │    │    │    │         ├── true [as=canary:10]
-      │    │    │    │         └── y:7::STRING [as=column8:8, outer=(7)]
+      │    │    │    │         └── y:7::STRING [as=column8:8, outer=(7), immutable]
       │    │    │    └── filters
       │    │    │         └── x:6 = k:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       │    │    └── aggregations
@@ -2600,22 +2606,27 @@ WHERE EXISTS
 group-by
  ├── columns: x:1!null y:2
  ├── grouping columns: x:1!null
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── select
  │    ├── columns: x:1!null y:2 k:3!null i:4!null max:13!null
+ │    ├── immutable
  │    ├── key: (1,3)
  │    ├── fd: (1)-->(2), (3)-->(4), (1,3)-->(2,4,13), (4)==(13), (13)==(4)
  │    ├── group-by
  │    │    ├── columns: x:1!null y:2 k:3!null i:4 max:13!null
  │    │    ├── grouping columns: x:1!null k:3!null
+ │    │    ├── immutable
  │    │    ├── key: (1,3)
  │    │    ├── fd: (1)-->(2), (3)-->(4), (1,3)-->(2,4,13)
  │    │    ├── inner-join (hash)
  │    │    │    ├── columns: x:1!null y:2 k:3!null i:4 i:9!null f:10!null column14:14!null
+ │    │    │    ├── immutable
  │    │    │    ├── fd: (1)-->(2), (2)-->(14), (3)-->(4), (10)==(14), (14)==(10)
  │    │    │    ├── project
  │    │    │    │    ├── columns: column14:14 x:1!null y:2
+ │    │    │    │    ├── immutable
  │    │    │    │    ├── key: (1)
  │    │    │    │    ├── fd: (1)-->(2), (2)-->(14)
  │    │    │    │    ├── scan xy
@@ -2623,7 +2634,7 @@ group-by
  │    │    │    │    │    ├── key: (1)
  │    │    │    │    │    └── fd: (1)-->(2)
  │    │    │    │    └── projections
- │    │    │    │         └── y:2::FLOAT8 [as=column14:14, outer=(2)]
+ │    │    │    │         └── y:2::FLOAT8 [as=column14:14, outer=(2), immutable]
  │    │    │    ├── inner-join (cross)
  │    │    │    │    ├── columns: k:3!null i:4 i:9!null f:10
  │    │    │    │    ├── fd: (3)-->(4)
@@ -5217,10 +5228,12 @@ SELECT * FROM a WHERE i < ANY(SELECT y FROM xy) AND s = ANY(SELECT y::string FRO
 ----
 semi-join (cross)
  ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── semi-join (hash)
  │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
  │    ├── scan a
@@ -5229,10 +5242,11 @@ semi-join (cross)
  │    │    └── fd: (1)-->(2-5)
  │    ├── project
  │    │    ├── columns: y:10
+ │    │    ├── immutable
  │    │    ├── scan xy
  │    │    │    └── columns: xy.y:9
  │    │    └── projections
- │    │         └── xy.y:9::STRING [as=y:10, outer=(9)]
+ │    │         └── xy.y:9::STRING [as=y:10, outer=(9), immutable]
  │    └── filters
  │         └── s:4 = y:10 [outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
  ├── scan xy
@@ -5348,10 +5362,12 @@ SELECT * FROM a WHERE i < ALL(SELECT y FROM xy) AND s <> ALL(SELECT y::string FR
 ----
 anti-join (cross)
  ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── anti-join (cross)
  │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
  │    ├── scan a
@@ -5360,10 +5376,11 @@ anti-join (cross)
  │    │    └── fd: (1)-->(2-5)
  │    ├── project
  │    │    ├── columns: y:10
+ │    │    ├── immutable
  │    │    ├── scan xy
  │    │    │    └── columns: xy.y:9
  │    │    └── projections
- │    │         └── xy.y:9::STRING [as=y:10, outer=(9)]
+ │    │         └── xy.y:9::STRING [as=y:10, outer=(9), immutable]
  │    └── filters
  │         └── (s:4 = y:10) IS NOT false [outer=(4,10)]
  ├── scan xy
@@ -5436,10 +5453,12 @@ SELECT * FROM a WHERE i = ANY(SELECT y FROM xy) AND s <> ALL(SELECT y::string FR
 ----
 semi-join (hash)
  ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── anti-join (cross)
  │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
  │    ├── scan a
@@ -5448,10 +5467,11 @@ semi-join (hash)
  │    │    └── fd: (1)-->(2-5)
  │    ├── project
  │    │    ├── columns: y:10
+ │    │    ├── immutable
  │    │    ├── scan xy
  │    │    │    └── columns: xy.y:9
  │    │    └── projections
- │    │         └── xy.y:9::STRING [as=y:10, outer=(9)]
+ │    │         └── xy.y:9::STRING [as=y:10, outer=(9), immutable]
  │    └── filters
  │         └── (s:4 = y:10) IS NOT false [outer=(4,10)]
  ├── scan xy

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -61,6 +61,7 @@ FROM a
 ----
 project
  ├── columns: ra:7 rb:8 sa:9 sb:10 ta:11 tb:12 ua:13 ub:14 va:15 vb:16 wa:17 wb:18
+ ├── immutable
  ├── fd: ()-->(7-14)
  ├── scan a
  │    └── columns: i:2 arr:6
@@ -73,10 +74,10 @@ project
       ├── CAST(NULL AS FLOAT8) [as=tb:12]
       ├── CAST(NULL AS INT8) [as=ua:13]
       ├── CAST(NULL AS INT8) [as=ub:14]
-      ├── arr:6::DECIMAL[] || CAST(NULL AS DECIMAL[]) [as=va:15, outer=(6)]
-      ├── CAST(NULL AS STRING[]) || arr:6::STRING[] [as=vb:16, outer=(6)]
-      ├── i:2::DECIMAL || CAST(NULL AS DECIMAL[]) [as=wa:17, outer=(2)]
-      └── CAST(NULL AS FLOAT8[]) || i:2::FLOAT8 [as=wb:18, outer=(2)]
+      ├── arr:6::DECIMAL[] || CAST(NULL AS DECIMAL[]) [as=va:15, outer=(6), immutable]
+      ├── CAST(NULL AS STRING[]) || arr:6::STRING[] [as=vb:16, outer=(6), immutable]
+      ├── i:2::DECIMAL || CAST(NULL AS DECIMAL[]) [as=wa:17, outer=(2), immutable]
+      └── CAST(NULL AS FLOAT8[]) || i:2::FLOAT8 [as=wb:18, outer=(2), immutable]
 
 norm
 SELECT

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -94,6 +94,7 @@ SELECT * FROM (VALUES (0.0), (0.00), (0.000)) AS v (x) WHERE x = 0 AND x::STRING
 select
  ├── columns: x:1!null
  ├── cardinality: [0 - 3]
+ ├── immutable
  ├── fd: ()-->(1)
  ├── values
  │    ├── columns: column1:1!null
@@ -103,7 +104,7 @@ select
  │    └── (0.000,)
  └── filters
       ├── column1:1 = 0 [outer=(1), constraints=(/1: [/0 - /0]; tight), fd=()-->(1)]
-      └── column1:1::STRING = '0.00' [outer=(1)]
+      └── column1:1::STRING = '0.00' [outer=(1), immutable]
 
 # The rule should trigger, but not inline the composite type.
 norm expect=InlineConstVar
@@ -112,6 +113,7 @@ SELECT * FROM (VALUES (0.0, 'a'), (0.00, 'b'), (0.000, 'b')) AS v (x, y) WHERE x
 select
  ├── columns: x:1!null y:2!null
  ├── cardinality: [0 - 3]
+ ├── immutable
  ├── fd: ()-->(1,2)
  ├── values
  │    ├── columns: column1:1!null column2:2!null
@@ -121,7 +123,7 @@ select
  │    └── (0.000, 'b')
  └── filters
       ├── column1:1 = 0 [outer=(1), constraints=(/1: [/0 - /0]; tight), fd=()-->(1)]
-      ├── column1:1::STRING = '0.00' [outer=(1)]
+      ├── column1:1::STRING = '0.00' [outer=(1), immutable]
       └── column2:2 = 'b' [outer=(2), constraints=(/2: [/'b' - /'b']; tight), fd=()-->(2)]
 
 # Ensure that InlineConstVar fires before filter pushdown rules.

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -368,10 +368,12 @@ SELECT * FROM a INNER JOIN b ON a.k=b.x AND a.i=b.x AND a.i=b.y AND a.f + b.y::F
 ----
 inner-join (hash)
  ├── columns: k:1!null i:2!null f:3!null s:4 j:5 x:6!null y:7!null
+ ├── immutable
  ├── key: (6)
  ├── fd: (1)-->(3-5), (1)==(2,6,7), (2)==(1,6,7), (6)==(1,2,7), (7)==(1,2,6)
  ├── select
  │    ├── columns: k:1!null i:2!null f:3!null s:4 j:5
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(3-5), (1)==(2), (2)==(1)
  │    ├── scan a
@@ -379,8 +381,8 @@ inner-join (hash)
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2-5)
  │    └── filters
- │         ├── (f:3 + k:1::FLOAT8) > 5.0 [outer=(1,3)]
- │         ├── (s:4 || k:1::STRING) = 'foo1' [outer=(1,4)]
+ │         ├── (f:3 + k:1::FLOAT8) > 5.0 [outer=(1,3), immutable]
+ │         ├── (s:4 || k:1::STRING) = 'foo1' [outer=(1,4), immutable]
  │         └── k:1 = i:2 [outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
  ├── select
  │    ├── columns: x:6!null y:7!null
@@ -700,17 +702,19 @@ FROM (VALUES (1.0), (2.0)) AS t1(x), (VALUES (1.00), (2.00)) AS t2(y)WHERE x=y A
 inner-join (hash)
  ├── columns: x:1!null y:2!null
  ├── cardinality: [0 - 4]
+ ├── immutable
  ├── fd: (1)==(2), (2)==(1)
  ├── select
  │    ├── columns: column1:1!null
  │    ├── cardinality: [0 - 2]
+ │    ├── immutable
  │    ├── values
  │    │    ├── columns: column1:1!null
  │    │    ├── cardinality: [2 - 2]
  │    │    ├── (1.0,)
  │    │    └── (2.0,)
  │    └── filters
- │         └── column1:1::STRING = '1.0' [outer=(1)]
+ │         └── column1:1::STRING = '1.0' [outer=(1), immutable]
  ├── values
  │    ├── columns: column1:2!null
  │    ├── cardinality: [2 - 2]
@@ -2489,6 +2493,7 @@ ON a.f>=b.z::float AND (a.k=b.x) IS True AND a.f>=b.z::float AND (a.i=b.y) IS NO
 ----
 inner-join (hash)
  ├── columns: k:1!null i:2!null f:3!null s:4 j:5 x:6!null y:7!null z:8!null
+ ├── immutable
  ├── key: (6)
  ├── fd: (1)-->(2-5), (6)-->(7), (7)-->(8), (1)==(6), (6)==(1), (2)==(7), (7)==(2)
  ├── select
@@ -2518,8 +2523,8 @@ inner-join (hash)
  │    └── projections
  │         └── y:7 + 1 [as=z:8, outer=(7)]
  └── filters
-      ├── f:3 >= z:8::FLOAT8 [outer=(3,8), constraints=(/3: (/NULL - ])]
-      ├── f:3 >= z:8::FLOAT8 [outer=(3,8), constraints=(/3: (/NULL - ])]
+      ├── f:3 >= z:8::FLOAT8 [outer=(3,8), immutable, constraints=(/3: (/NULL - ])]
+      ├── f:3 >= z:8::FLOAT8 [outer=(3,8), immutable, constraints=(/3: (/NULL - ])]
       ├── k:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       └── i:2 = y:7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
 

--- a/pkg/sql/opt/norm/testdata/rules/numeric
+++ b/pkg/sql/opt/norm/testdata/rules/numeric
@@ -33,20 +33,22 @@ SELECT i + 0::decimal FROM a
 ----
 project
  ├── columns: "?column?":6
+ ├── immutable
  ├── scan a
  │    └── columns: i:2
  └── projections
-      └── i:2::DECIMAL [as="?column?":6, outer=(2)]
+      └── i:2::DECIMAL [as="?column?":6, outer=(2), immutable]
 
 norm expect=FoldZeroPlus
 SELECT 0::decimal + i FROM a
 ----
 project
  ├── columns: "?column?":6
+ ├── immutable
  ├── scan a
  │    └── columns: i:2
  └── projections
-      └── i:2::DECIMAL [as="?column?":6, outer=(2)]
+      └── i:2::DECIMAL [as="?column?":6, outer=(2), immutable]
 
 # --------------------------------------------------
 # FoldMinusZero
@@ -75,10 +77,11 @@ SELECT i - 0::decimal FROM a
 ----
 project
  ├── columns: "?column?":6
+ ├── immutable
  ├── scan a
  │    └── columns: i:2
  └── projections
-      └── i:2::DECIMAL [as="?column?":6, outer=(2)]
+      └── i:2::DECIMAL [as="?column?":6, outer=(2), immutable]
 
 # Regression test for #35612.
 norm expect-not=FoldMinusZero
@@ -121,20 +124,22 @@ SELECT i * 1::decimal FROM a
 ----
 project
  ├── columns: "?column?":6
+ ├── immutable
  ├── scan a
  │    └── columns: i:2
  └── projections
-      └── i:2::DECIMAL [as="?column?":6, outer=(2)]
+      └── i:2::DECIMAL [as="?column?":6, outer=(2), immutable]
 
 norm expect=FoldOneMult
 SELECT 1::decimal * i FROM a
 ----
 project
  ├── columns: "?column?":6
+ ├── immutable
  ├── scan a
  │    └── columns: i:2
  └── projections
-      └── i:2::DECIMAL [as="?column?":6, outer=(2)]
+      └── i:2::DECIMAL [as="?column?":6, outer=(2), immutable]
 
 # --------------------------------------------------
 # FoldDivOne
@@ -149,10 +154,11 @@ FROM a
 ----
 project
  ├── columns: r:6 s:7 t:8
+ ├── immutable
  ├── scan a
  │    └── columns: i:2 f:3 d:4
  └── projections
-      ├── i:2::DECIMAL [as=r:6, outer=(2)]
+      ├── i:2::DECIMAL [as=r:6, outer=(2), immutable]
       ├── f:3 [as=s:7, outer=(3)]
       └── d:4 [as=t:8, outer=(4)]
 
@@ -162,20 +168,22 @@ SELECT i / 1::decimal FROM a
 ----
 project
  ├── columns: "?column?":6
+ ├── immutable
  ├── scan a
  │    └── columns: i:2
  └── projections
-      └── i:2::DECIMAL [as="?column?":6, outer=(2)]
+      └── i:2::DECIMAL [as="?column?":6, outer=(2), immutable]
 
 norm expect=FoldDivOne
 SELECT i / 1::int8 FROM a
 ----
 project
  ├── columns: "?column?":6
+ ├── immutable
  ├── scan a
  │    └── columns: i:2
  └── projections
-      └── i:2::DECIMAL [as="?column?":6, outer=(2)]
+      └── i:2::DECIMAL [as="?column?":6, outer=(2), immutable]
 
 # --------------------------------------------------
 # InvertMinus

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -203,13 +203,13 @@ SELECT column1+1, 3 FROM (VALUES ($1::int, $2::int))
 project
  ├── columns: "?column?":3 "?column?":4!null
  ├── cardinality: [1 - 1]
- ├── has-placeholder
+ ├── immutable, has-placeholder
  ├── key: ()
  ├── fd: ()-->(3,4)
  ├── values
  │    ├── columns: column1:1
  │    ├── cardinality: [1 - 1]
- │    ├── has-placeholder
+ │    ├── immutable, has-placeholder
  │    ├── key: ()
  │    ├── fd: ()-->(1)
  │    └── ($1::INT8,)

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -254,11 +254,13 @@ SELECT i FROM (SELECT k, i, s, f/2.0 f FROM a WHERE k = 5) a2 WHERE i::float = f
 project
  ├── columns: i:2
  ├── cardinality: [0 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(2)
  └── select
       ├── columns: i:2 f:5!null
       ├── cardinality: [0 - 1]
+      ├── immutable
       ├── key: ()
       ├── fd: ()-->(2,5)
       ├── project
@@ -280,7 +282,7 @@ project
       │    └── projections
       │         └── a.f:3 / 2.0 [as=f:5, outer=(3)]
       └── filters
-           └── f:5 = i:2::FLOAT8 [outer=(2,5), constraints=(/5: (/NULL - ])]
+           └── f:5 = i:2::FLOAT8 [outer=(2,5), immutable, constraints=(/5: (/NULL - ])]
 
 # Detect PruneSelectCols and PushSelectIntoProject dependency cycle.
 norm
@@ -1309,15 +1311,17 @@ SELECT avg(s::int+i), s, i FROM a GROUP BY s, i, i+1
 group-by
  ├── columns: avg:6 s:4 i:2
  ├── grouping columns: i:2 s:4
+ ├── immutable
  ├── key: (2,4)
  ├── fd: (2,4)-->(6)
  ├── project
  │    ├── columns: column5:5 i:2 s:4
+ │    ├── immutable
  │    ├── fd: (2,4)-->(5)
  │    ├── scan a
  │    │    └── columns: i:2 s:4
  │    └── projections
- │         └── i:2 + s:4::INT8 [as=column5:5, outer=(2,4)]
+ │         └── i:2 + s:4::INT8 [as=column5:5, outer=(2,4), immutable]
  └── aggregations
       └── avg [as=avg:6, outer=(5)]
            └── column5:5

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -181,17 +181,18 @@ FROM a
 ----
 project
  ├── columns: i:7 arr:8 s:9 s:10 i:11 s:12 array:13 array:14
+ ├── stable
  ├── scan a
  │    └── columns: a.i:2 a.s:4 a.arr:6
  └── projections
-      ├── a.i:2::FLOAT8 [as=i:7, outer=(2)]
-      ├── a.arr:6::DECIMAL[] [as=arr:8, outer=(6)]
-      ├── a.s:4::JSONB [as=s:9, outer=(4)]
-      ├── a.s:4::VARCHAR(2) [as=s:10, outer=(4)]
-      ├── a.i:2::INT2::INT8 [as=i:11, outer=(2)]
-      ├── a.s:4::CHAR::VARCHAR [as=s:12, outer=(4)]
-      ├── ARRAY[a.i:2, 2]::OIDVECTOR [as=array:13, outer=(2)]
-      └── ARRAY[a.i:2, 2]::INT2VECTOR [as=array:14, outer=(2)]
+      ├── a.i:2::FLOAT8 [as=i:7, outer=(2), immutable]
+      ├── a.arr:6::DECIMAL[] [as=arr:8, outer=(6), immutable]
+      ├── a.s:4::JSONB [as=s:9, outer=(4), immutable]
+      ├── a.s:4::VARCHAR(2) [as=s:10, outer=(4), immutable]
+      ├── a.i:2::INT2::INT8 [as=i:11, outer=(2), immutable]
+      ├── a.s:4::CHAR::VARCHAR [as=s:12, outer=(4), immutable]
+      ├── ARRAY[a.i:2, 2]::OIDVECTOR [as=array:13, outer=(2), stable]
+      └── ARRAY[a.i:2, 2]::INT2VECTOR [as=array:14, outer=(2), immutable]
 
 # --------------------------------------------------
 # NormalizeInConst

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -1927,6 +1927,7 @@ SELECT * FROM ((values (1.0::decimal)) EXCEPT (values (1.00::decimal))) WHERE co
 select
  ├── columns: column1:1!null
  ├── cardinality: [0 - 1]
+ ├── immutable
  ├── key: (1)
  ├── except
  │    ├── columns: column1:1!null
@@ -1947,4 +1948,4 @@ select
  │         ├── fd: ()-->(2)
  │         └── (1.00,)
  └── filters
-      └── column1:1::STRING != '1.00' [outer=(1)]
+      └── column1:1::STRING != '1.00' [outer=(1), immutable]

--- a/pkg/sql/opt/norm/testdata/rules/side_effects
+++ b/pkg/sql/opt/norm/testdata/rules/side_effects
@@ -284,7 +284,7 @@ select
                                │         ├── x:6 = i:2 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
                                │         └── (5 / xy.y:7) > 1 [outer=(7), immutable, side-effects]
                                └── projections
-                                    └── xy.y:7::DECIMAL [as=y:8, outer=(7)]
+                                    └── xy.y:7::DECIMAL [as=y:8, outer=(7), immutable]
 
 # Decorrelate IFERROR branch if there are no side effects
 norm
@@ -302,6 +302,7 @@ project
       ├── fd: (1)-->(2-6,8), (6)-->(8)
       ├── left-join (hash)
       │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6 y:8
+      │    ├── immutable
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-6,8), (6)-->(8)
       │    ├── scan a
@@ -310,6 +311,7 @@ project
       │    │    └── fd: (1)-->(2-5)
       │    ├── project
       │    │    ├── columns: y:8 x:6!null
+      │    │    ├── immutable
       │    │    ├── key: (6)
       │    │    ├── fd: (6)-->(8)
       │    │    ├── scan xy
@@ -317,7 +319,7 @@ project
       │    │    │    ├── key: (6)
       │    │    │    └── fd: (6)-->(7)
       │    │    └── projections
-      │    │         └── xy.y:7::DECIMAL [as=y:8, outer=(7)]
+      │    │         └── xy.y:7::DECIMAL [as=y:8, outer=(7), immutable]
       │    └── filters
       │         └── x:6 = i:2 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
       └── filters

--- a/pkg/sql/opt/norm/testdata/rules/window
+++ b/pkg/sql/opt/norm/testdata/rules/window
@@ -234,12 +234,15 @@ SELECT * FROM (SELECT i, f, rank() OVER (PARTITION BY k ORDER BY f) FROM a) WHER
 ----
 project
  ├── columns: i:2 f:3 rank:6
+ ├── immutable
  └── window partition=(1)
       ├── columns: k:1!null i:2 f:3 rank:6
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2,3)
       ├── select
       │    ├── columns: k:1!null i:2 f:3
+      │    ├── immutable
       │    ├── key: (1)
       │    ├── fd: (1)-->(2,3)
       │    ├── scan a
@@ -247,7 +250,7 @@ project
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(2,3)
       │    └── filters
-      │         └── (i:2 * f:3::INT8) = 3 [outer=(2,3)]
+      │         └── (i:2 * f:3::INT8) = 3 [outer=(2,3), immutable]
       └── windows
            └── rank [as=rank:6]
 

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -547,14 +547,17 @@ project
  │    ├── columns: primary_id:1!null idtable.secondary_id:2!null data:3!null value:4!null column5:5!null
  │    ├── key columns: [1] = [1]
  │    ├── lookup columns are key
+ │    ├── immutable
  │    ├── fd: (1)-->(2,3), (4)-->(5), (2)==(5), (5)==(2)
  │    ├── inner-join (lookup idtable@secondary_id)
  │    │    ├── columns: primary_id:1!null idtable.secondary_id:2!null value:4!null column5:5!null
  │    │    ├── key columns: [5] = [2]
+ │    │    ├── immutable
  │    │    ├── fd: (4)-->(5), (1)-->(2), (2)==(5), (5)==(2)
  │    │    ├── project
  │    │    │    ├── columns: column5:5 value:4!null
  │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    ├── immutable
  │    │    │    ├── fd: (4)-->(5)
  │    │    │    ├── values
  │    │    │    │    ├── columns: value:4!null
@@ -562,7 +565,7 @@ project
  │    │    │    │    ├── ('{"person_id": "8e5dc104-9f38-4255-9283-fd080be16c57", "product_id": "a739c2d3-edec-413b-88d8-9c31d0414b1e"}',)
  │    │    │    │    └── ('{"person_id": "308686c4-7415-4c2d-92d5-25b39a1c84e2", "product_id": "3f12802d-5b0f-43d7-a0d0-12ac8e88cb18"}',)
  │    │    │    └── projections
- │    │    │         └── (value:4->>'secondary_id')::UUID [as=column5:5, outer=(4)]
+ │    │    │         └── (value:4->>'secondary_id')::UUID [as=column5:5, outer=(4), immutable]
  │    │    └── filters (true)
  │    └── filters (true)
  └── projections

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -974,24 +974,24 @@ where
 ----
 project
  ├── columns: id1_2_:1!null address2_2_:2 createdo3_2_:3 name4_2_:4 nickname5_2_:5 version6_2_:6!null
- ├── has-placeholder
+ ├── immutable, has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  └── inner-join (lookup person)
       ├── columns: person0_.id:1!null address:2 createdon:3 name:4 nickname:5 version:6!null person_id:10!null
       ├── key columns: [10] = [1]
       ├── lookup columns are key
-      ├── has-placeholder
+      ├── immutable, has-placeholder
       ├── key: (10)
       ├── fd: (1)-->(2-6), (1)==(10), (10)==(1)
       ├── distinct-on
       │    ├── columns: person_id:10
       │    ├── grouping columns: person_id:10
-      │    ├── has-placeholder
+      │    ├── immutable, has-placeholder
       │    ├── key: (10)
       │    └── select
       │         ├── columns: phones1_.id:7!null person_id:10
-      │         ├── has-placeholder
+      │         ├── immutable, has-placeholder
       │         ├── key: (7)
       │         ├── fd: (7)-->(10)
       │         ├── scan phones1_
@@ -999,7 +999,7 @@ project
       │         │    ├── key: (7)
       │         │    └── fd: (7)-->(10)
       │         └── filters
-      │              └── phones1_.id:7 = $1::INT8 [outer=(7), constraints=(/7: (/NULL - ])]
+      │              └── phones1_.id:7 = $1::INT8 [outer=(7), immutable, constraints=(/7: (/NULL - ])]
       └── filters (true)
 
 opt
@@ -1024,24 +1024,24 @@ where
 ----
 project
  ├── columns: id1_2_:1!null address2_2_:2 createdo3_2_:3 name4_2_:4 nickname5_2_:5 version6_2_:6!null
- ├── has-placeholder
+ ├── immutable, has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  └── inner-join (lookup person)
       ├── columns: person0_.id:1!null address:2 createdon:3 name:4 nickname:5 version:6!null person_id:10!null
       ├── key columns: [10] = [1]
       ├── lookup columns are key
-      ├── has-placeholder
+      ├── immutable, has-placeholder
       ├── key: (10)
       ├── fd: (1)-->(2-6), (1)==(10), (10)==(1)
       ├── distinct-on
       │    ├── columns: person_id:10
       │    ├── grouping columns: person_id:10
-      │    ├── has-placeholder
+      │    ├── immutable, has-placeholder
       │    ├── key: (10)
       │    └── select
       │         ├── columns: phones1_.id:7!null person_id:10
-      │         ├── has-placeholder
+      │         ├── immutable, has-placeholder
       │         ├── key: (7)
       │         ├── fd: (7)-->(10)
       │         ├── scan phones1_
@@ -1049,7 +1049,7 @@ project
       │         │    ├── key: (7)
       │         │    └── fd: (7)-->(10)
       │         └── filters
-      │              └── phones1_.id:7 = $1::INT8 [outer=(7), constraints=(/7: (/NULL - ])]
+      │              └── phones1_.id:7 = $1::INT8 [outer=(7), immutable, constraints=(/7: (/NULL - ])]
       └── filters (true)
 
 opt
@@ -1110,7 +1110,7 @@ where
 ----
 anti-join (hash)
  ├── columns: id1_4_:1!null phone_nu2_4_:2 person_i4_4_:4 phone_ty3_4_:3
- ├── has-placeholder
+ ├── stable, has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── scan phone0_
@@ -1119,11 +1119,11 @@ anti-join (hash)
  │    └── fd: (1)-->(2-4)
  ├── select
  │    ├── columns: phone_id:6!null repairtimestamps:7
- │    ├── has-placeholder
+ │    ├── stable, has-placeholder
  │    ├── scan repairtime1_
  │    │    └── columns: phone_id:6!null repairtimestamps:7
  │    └── filters
- │         └── (repairtimestamps:7 >= $1::DATE) IS NOT false [outer=(7)]
+ │         └── (repairtimestamps:7 >= $1::DATE) IS NOT false [outer=(7), stable]
  └── filters
       └── id:1 = phone_id:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 

--- a/pkg/sql/opt/xform/testdata/external/pgadmin
+++ b/pkg/sql/opt/xform/testdata/external/pgadmin
@@ -144,4 +144,4 @@ project
  │    └── filters
  │         └── "?column?":36 [outer=(36), constraints=(/36: [/true - /true]; tight), fd=()-->(36)]
  └── projections
-      └── CASE WHEN (client_hostname:8 IS NOT NULL) AND (client_hostname:8 != '') THEN (client_hostname:8 || ':') || client_port:9::STRING WHEN (client_addr:7 IS NOT NULL) AND (client_addr:7::STRING != '') THEN (client_addr:7::STRING || ':') || client_port:9::STRING WHEN client_port:9 = -1 THEN 'local pipe' ELSE 'localhost:' || client_port:9::STRING END [as=Client:37, outer=(7-9)]
+      └── CASE WHEN (client_hostname:8 IS NOT NULL) AND (client_hostname:8 != '') THEN (client_hostname:8 || ':') || client_port:9::STRING WHEN (client_addr:7 IS NOT NULL) AND (client_addr:7::STRING != '') THEN (client_addr:7::STRING || ':') || client_port:9::STRING WHEN client_port:9 = -1 THEN 'local pipe' ELSE 'localhost:' || client_port:9::STRING END [as=Client:37, outer=(7-9), immutable]

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -1211,20 +1211,24 @@ ORDER BY
 ----
 sort
  ├── columns: ps_partkey:1!null value:18!null
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(18)
  ├── ordering: -18
  └── select
       ├── columns: ps_partkey:1!null sum:18!null
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(18)
       ├── group-by
       │    ├── columns: ps_partkey:1!null sum:18!null
       │    ├── grouping columns: ps_partkey:1!null
+      │    ├── immutable
       │    ├── key: (1)
       │    ├── fd: (1)-->(18)
       │    ├── project
       │    │    ├── columns: column17:17!null ps_partkey:1!null
+      │    │    ├── immutable
       │    │    ├── inner-join (lookup partsupp)
       │    │    │    ├── columns: ps_partkey:1!null ps_suppkey:2!null ps_availqty:3!null ps_supplycost:4!null s_suppkey:6!null s_nationkey:9!null n_nationkey:13!null n_name:14!null
       │    │    │    ├── key columns: [1 2] = [1 2]
@@ -1255,26 +1259,29 @@ sort
       │    │    │    │    └── filters (true)
       │    │    │    └── filters (true)
       │    │    └── projections
-      │    │         └── ps_supplycost:4 * ps_availqty:3::FLOAT8 [as=column17:17, outer=(3,4)]
+      │    │         └── ps_supplycost:4 * ps_availqty:3::FLOAT8 [as=column17:17, outer=(3,4), immutable]
       │    └── aggregations
       │         └── sum [as=sum:18, outer=(17)]
       │              └── column17:17
       └── filters
-           └── gt [outer=(18), subquery, constraints=(/18: (/NULL - ])]
+           └── gt [outer=(18), immutable, subquery, constraints=(/18: (/NULL - ])]
                 ├── sum:18
                 └── subquery
                      └── project
                           ├── columns: "?column?":37
                           ├── cardinality: [1 - 1]
+                          ├── immutable
                           ├── key: ()
                           ├── fd: ()-->(37)
                           ├── scalar-group-by
                           │    ├── columns: sum:36
                           │    ├── cardinality: [1 - 1]
+                          │    ├── immutable
                           │    ├── key: ()
                           │    ├── fd: ()-->(36)
                           │    ├── project
                           │    │    ├── columns: column35:35!null
+                          │    │    ├── immutable
                           │    │    ├── inner-join (lookup partsupp)
                           │    │    │    ├── columns: ps_suppkey:20!null ps_availqty:21!null ps_supplycost:22!null s_suppkey:24!null s_nationkey:27!null n_nationkey:31!null n_name:32!null
                           │    │    │    ├── key columns: [19 20] = [19 20]
@@ -1304,7 +1311,7 @@ sort
                           │    │    │    │    └── filters (true)
                           │    │    │    └── filters (true)
                           │    │    └── projections
-                          │    │         └── ps_supplycost:22 * ps_availqty:21::FLOAT8 [as=column35:35, outer=(21,22)]
+                          │    │         └── ps_supplycost:22 * ps_availqty:21::FLOAT8 [as=column35:35, outer=(21,22), immutable]
                           │    └── aggregations
                           │         └── sum [as=sum:36, outer=(35)]
                           │              └── column35:35

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -1212,20 +1212,24 @@ ORDER BY
 ----
 sort
  ├── columns: ps_partkey:1!null value:18!null
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(18)
  ├── ordering: -18
  └── select
       ├── columns: ps_partkey:1!null sum:18!null
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(18)
       ├── group-by
       │    ├── columns: ps_partkey:1!null sum:18!null
       │    ├── grouping columns: ps_partkey:1!null
+      │    ├── immutable
       │    ├── key: (1)
       │    ├── fd: (1)-->(18)
       │    ├── project
       │    │    ├── columns: column17:17!null ps_partkey:1!null
+      │    │    ├── immutable
       │    │    ├── inner-join (hash)
       │    │    │    ├── columns: ps_partkey:1!null ps_suppkey:2!null ps_availqty:3!null ps_supplycost:4!null s_suppkey:6!null s_nationkey:9!null n_nationkey:13!null n_name:14!null
       │    │    │    ├── key: (1,6)
@@ -1253,26 +1257,29 @@ sort
       │    │    │    └── filters
       │    │    │         └── ps_suppkey:2 = s_suppkey:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
       │    │    └── projections
-      │    │         └── ps_supplycost:4 * ps_availqty:3::FLOAT8 [as=column17:17, outer=(3,4)]
+      │    │         └── ps_supplycost:4 * ps_availqty:3::FLOAT8 [as=column17:17, outer=(3,4), immutable]
       │    └── aggregations
       │         └── sum [as=sum:18, outer=(17)]
       │              └── column17:17
       └── filters
-           └── gt [outer=(18), subquery, constraints=(/18: (/NULL - ])]
+           └── gt [outer=(18), immutable, subquery, constraints=(/18: (/NULL - ])]
                 ├── sum:18
                 └── subquery
                      └── project
                           ├── columns: "?column?":37
                           ├── cardinality: [1 - 1]
+                          ├── immutable
                           ├── key: ()
                           ├── fd: ()-->(37)
                           ├── scalar-group-by
                           │    ├── columns: sum:36
                           │    ├── cardinality: [1 - 1]
+                          │    ├── immutable
                           │    ├── key: ()
                           │    ├── fd: ()-->(36)
                           │    ├── project
                           │    │    ├── columns: column35:35!null
+                          │    │    ├── immutable
                           │    │    ├── inner-join (hash)
                           │    │    │    ├── columns: ps_suppkey:20!null ps_availqty:21!null ps_supplycost:22!null s_suppkey:24!null s_nationkey:27!null n_nationkey:31!null n_name:32!null
                           │    │    │    ├── fd: ()-->(32), (24)-->(27), (27)==(31), (31)==(27), (20)==(24), (24)==(20)
@@ -1297,7 +1304,7 @@ sort
                           │    │    │    └── filters
                           │    │    │         └── ps_suppkey:20 = s_suppkey:24 [outer=(20,24), constraints=(/20: (/NULL - ]; /24: (/NULL - ]), fd=(20)==(24), (24)==(20)]
                           │    │    └── projections
-                          │    │         └── ps_supplycost:22 * ps_availqty:21::FLOAT8 [as=column35:35, outer=(21,22)]
+                          │    │         └── ps_supplycost:22 * ps_availqty:21::FLOAT8 [as=column35:35, outer=(21,22), immutable]
                           │    └── aggregations
                           │         └── sum [as=sum:36, outer=(35)]
                           │              └── column35:35

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1343,8 +1343,8 @@ upsert transactiondetails
  │    │    │    │         ├── 1 [as="?column?":11]
  │    │    │    │         ├── false [as=bool:12]
  │    │    │    │         ├── current_timestamp() [as=current_timestamp:13, stable, side-effects]
- │    │    │    │         ├── (detail:10->'c')::STRING::INT8 [as=int8:14, outer=(10)]
- │    │    │    │         └── (detail:10->'q')::STRING::INT8 [as=int8:15, outer=(10)]
+ │    │    │    │         ├── (detail:10->'c')::STRING::INT8 [as=int8:14, outer=(10), immutable]
+ │    │    │    │         └── (detail:10->'q')::STRING::INT8 [as=int8:15, outer=(10), immutable]
  │    │    │    └── aggregations
  │    │    │         ├── first-agg [as=sellprice:19, outer=(19)]
  │    │    │         │    └── sellprice:19

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1353,8 +1353,8 @@ upsert transactiondetails
  │    │    │    │         ├── 1 [as="?column?":13]
  │    │    │    │         ├── false [as=bool:14]
  │    │    │    │         ├── current_timestamp() [as=current_timestamp:15, stable, side-effects]
- │    │    │    │         ├── (detail:12->'c')::STRING::INT8 [as=int8:16, outer=(12)]
- │    │    │    │         └── (detail:12->'q')::STRING::INT8 [as=int8:17, outer=(12)]
+ │    │    │    │         ├── (detail:12->'c')::STRING::INT8 [as=int8:16, outer=(12), immutable]
+ │    │    │    │         └── (detail:12->'q')::STRING::INT8 [as=int8:17, outer=(12), immutable]
  │    │    │    └── aggregations
  │    │    │         ├── first-agg [as=sellprice:22, outer=(22)]
  │    │    │         │    └── sellprice:22

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -444,8 +444,8 @@ func isCastDeepValid(castFrom, castTo *types.T) (bool, telemetry.Counter) {
 		return castFrom.Equivalent(castTo), sqltelemetry.EnumCastCounter
 	}
 
-	cast, ok := castsMap[castsMapKey{from: fromFamily, to: toFamily}]
-	if !ok {
+	cast := lookupCast(fromFamily, toFamily)
+	if cast == nil {
 		return false, nil
 	}
 	return true, cast.counter


### PR DESCRIPTION
This change incorporates the new cast volatility information into the
VolatilitySet property.

Release note: None