### PR TITLE
geo/geodist: speed up dwithin/distance operations with bbox

### DIFF
--- a/pkg/geo/geogfn/distance.go
+++ b/pkg/geo/geogfn/distance.go
@@ -176,8 +176,6 @@ func (c *s2GeodistEdgeCrosser) ChainCrossing(p geodist.Point) bool {
 // the spheroid are different than the two closest points on the sphere.
 // See distance_test.go for examples of the "truer" distance values.
 // Since we aim to be compatible with PostGIS, we adopt the same approach.
-//
-// TODO(otan): accelerate checks with bounding boxes.
 func distanceGeographyRegions(
 	spheroid geographiclib.Spheroid,
 	useSphereOrSpheroid UseSphereOrSpheroid,
@@ -303,6 +301,13 @@ var _ geodist.DistanceCalculator = (*geographyDistanceCalculator)(nil)
 // DistanceUpdater implements geodist.DistanceCalculator.
 func (c *geographyDistanceCalculator) DistanceUpdater() geodist.DistanceUpdater {
 	return c.updater
+}
+
+// BoundingBoxIntersects implements geodist.DistanceCalculator.
+func (c *geographyDistanceCalculator) BoundingBoxIntersects() bool {
+	// Return true, as it does the safer thing beneath.
+	// TODO(otan): update bounding box intersects.
+	return true
 }
 
 // NewEdgeCrosser implements geodist.DistanceCalculator.

--- a/pkg/geo/geomfn/distance.go
+++ b/pkg/geo/geomfn/distance.go
@@ -84,7 +84,7 @@ func maxDistanceInternal(
 	a *geo.Geometry, b *geo.Geometry, stopAfterGT float64, emptyBehavior geo.EmptyBehavior,
 ) (float64, error) {
 	u := newGeomMaxDistanceUpdater(stopAfterGT)
-	c := &geomDistanceCalculator{updater: u}
+	c := &geomDistanceCalculator{updater: u, boundingBoxIntersects: a.BoundingBoxIntersects(b)}
 	return distanceInternal(a, b, c, emptyBehavior)
 }
 
@@ -94,7 +94,7 @@ func minDistanceInternal(
 	a *geo.Geometry, b *geo.Geometry, stopAfterLE float64, emptyBehavior geo.EmptyBehavior,
 ) (float64, error) {
 	u := newGeomMinDistanceUpdater(stopAfterLE)
-	c := &geomDistanceCalculator{updater: u}
+	c := &geomDistanceCalculator{updater: u, boundingBoxIntersects: a.BoundingBoxIntersects(b)}
 	return distanceInternal(a, b, c, emptyBehavior)
 }
 
@@ -381,7 +381,8 @@ func (u *geomMaxDistanceUpdater) IsMaxDistance() bool {
 
 // geomDistanceCalculator implements geodist.DistanceCalculator
 type geomDistanceCalculator struct {
-	updater geodist.DistanceUpdater
+	updater               geodist.DistanceUpdater
+	boundingBoxIntersects bool
 }
 
 var _ geodist.DistanceCalculator = (*geomDistanceCalculator)(nil)
@@ -389,6 +390,11 @@ var _ geodist.DistanceCalculator = (*geomDistanceCalculator)(nil)
 // DistanceUpdater implements geodist.DistanceCalculator.
 func (c *geomDistanceCalculator) DistanceUpdater() geodist.DistanceUpdater {
 	return c.updater
+}
+
+// BoundingBoxIntersects implements geodist.DistanceCalculator.
+func (c *geomDistanceCalculator) BoundingBoxIntersects() bool {
+	return c.boundingBoxIntersects
 }
 
 // NewEdgeCrosser implements geodist.DistanceCalculator.


### PR DESCRIPTION
We can optimize distance checks by saying if their bounding boxes do not
intersect then we only need to check the exteriors. This shaved 2-3s off
a 7s query available in the PostGIS tutorial.

Existing test cases exercise this functionality well.

Release note: None