### PR TITLE
sql: enable simple stats for all types

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -207,19 +206,14 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 
 		columnIDs := make([]sqlbase.ColumnID, len(columns))
 		for i := range columns {
-			if columns[i].Type.Family() == types.JsonFamily {
-				return nil, unimplemented.NewWithIssuef(35844,
-					"CREATE STATISTICS is not supported for JSON columns")
-			}
 			columnIDs[i] = columns[i].ID
 		}
-		colStats = []jobspb.CreateStatsDetails_ColStat{{ColumnIDs: columnIDs, HasHistogram: false}}
-		if len(columnIDs) == 1 && columns[0].Type.Family() != types.ArrayFamily {
+		colStats = []jobspb.CreateStatsDetails_ColStat{{
+			ColumnIDs: columnIDs,
 			// By default, create histograms on all explicitly requested column stats
-			// with a single column. (We cannot create histograms on array columns
-			// because we do not support key encoding arrays.)
-			colStats[0].HasHistogram = true
-		}
+			// with a single column.
+			HasHistogram: len(columnIDs) == 1 && canHistogramType(columns[0].Type),
+		}}
 	}
 
 	// Evaluate the AS OF time, if any.
@@ -261,6 +255,10 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 	}, nil
 }
 
+func canHistogramType(t *types.T) bool {
+	return !sqlbase.ColumnTypeIsInvertedIndexable(t)
+}
+
 // maxNonIndexCols is the maximum number of non-index columns that we will use
 // when choosing a default set of column statistics.
 const maxNonIndexCols = 100
@@ -293,48 +291,56 @@ func createStatsDefaultColumns(
 			break
 		}
 
+		colIDs := desc.PrimaryIndex.ColumnIDs[: i+1 : i+1]
+
 		// Remember the requested stats so we don't request duplicates.
-		key := makeColStatKey(desc.PrimaryIndex.ColumnIDs[: i+1 : i+1])
+		key := makeColStatKey(colIDs)
 		requestedStats[key] = struct{}{}
 
+		col, err := desc.FindColumnByID(colIDs[i])
+		if err != nil {
+			return nil, err
+		}
 		colStats = append(colStats, jobspb.CreateStatsDetails_ColStat{
-			ColumnIDs:    desc.PrimaryIndex.ColumnIDs[: i+1 : i+1],
-			HasHistogram: i == 0,
+			ColumnIDs:    colIDs,
+			HasHistogram: i == 0 && canHistogramType(col.Type),
 		})
 	}
 
 	// Add column stats for each secondary index.
 	for i := range desc.Indexes {
-		if desc.Indexes[i].Type == sqlbase.IndexDescriptor_INVERTED {
-			// We don't yet support stats on inverted indexes.
-			continue
-		}
 		for j := range desc.Indexes[i].ColumnIDs {
 			if j != 0 && !multiColEnabled {
 				break
 			}
 
+			colIDs := desc.Indexes[i].ColumnIDs[: j+1 : j+1]
+
 			// Check for existing stats and remember the requested stats.
-			key := makeColStatKey(desc.Indexes[i].ColumnIDs[: j+1 : j+1])
+			key := makeColStatKey(colIDs)
 			if _, ok := requestedStats[key]; ok {
 				continue
 			}
 			requestedStats[key] = struct{}{}
 
+			col, err := desc.FindColumnByID(colIDs[j])
+			if err != nil {
+				return nil, err
+			}
 			colStats = append(colStats, jobspb.CreateStatsDetails_ColStat{
-				ColumnIDs:    desc.Indexes[i].ColumnIDs[: j+1 : j+1],
-				HasHistogram: j == 0,
+				ColumnIDs:    colIDs,
+				HasHistogram: j == 0 && canHistogramType(col.Type),
 			})
 		}
 	}
 
-	// Add all remaining non-json columns in the table, up to maxNonIndexCols.
+	// Add all remaining columns in the table, up to maxNonIndexCols.
 	nonIdxCols := 0
 	for i := 0; i < len(desc.Columns) && nonIdxCols < maxNonIndexCols; i++ {
 		col := &desc.Columns[i]
 		colList := []sqlbase.ColumnID{col.ID}
 		key := makeColStatKey(colList)
-		if _, ok := requestedStats[key]; !ok && col.Type.Family() != types.JsonFamily {
+		if _, ok := requestedStats[key]; !ok {
 			colStats = append(colStats, jobspb.CreateStatsDetails_ColStat{
 				ColumnIDs:    colList,
 				HasHistogram: col.Type.Family() == types.BoolFamily || col.Type.Family() == types.EnumFamily,

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -560,54 +560,6 @@ CREATE TABLE t (x int); INSERT INTO t VALUES (1); ALTER TABLE t DROP COLUMN x
 statement ok
 CREATE STATISTICS s FROM t
 
-# Regression test for #35150.
-statement ok
-CREATE TABLE groups (data JSON); INSERT INTO groups VALUES ('{"data": {"domain": "github.com"}}')
-
-# Ensure that trying to create statistics on a JSON column gives an appropriate error.
-statement error CREATE STATISTICS is not supported for JSON columns
-CREATE STATISTICS s ON data FROM groups
-
-# The json column is not included in the default columns.
-statement ok
-CREATE STATISTICS s FROM groups
-
-query TT colnames
-SELECT statistics_name, column_names
-FROM [SHOW STATISTICS FOR TABLE groups] ORDER BY statistics_name, column_names::STRING
-----
-statistics_name  column_names
-s                {rowid}
-
-# Regression test for #35764.
-statement ok
-CREATE TABLE users (
-  profile_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  last_updated TIMESTAMP DEFAULT now(),
-  user_profile JSONB,
-  INVERTED INDEX user_details (user_profile)
-)
-
-statement ok
-INSERT INTO users (user_profile) VALUES
-  ('{"first_name": "Lola", "last_name": "Dog", "location": "NYC", "online" : true, "friends" : 547}'),
-  ('{"first_name": "Ernie", "status": "Looking for treats", "location" : "Brooklyn"}'),
-  ('{"first_name": "Carl", "last_name": "Kimball", "location": "NYC", "breed": "Boston Terrier"}'
-)
-
-# Ensure that trying to create statistics with default columns does not fail
-# when there is an inverted index.
-statement ok
-CREATE STATISTICS s FROM users
-
-query TTI colnames
-SELECT statistics_name, column_names, row_count
-FROM [SHOW STATISTICS FOR TABLE users] ORDER BY statistics_name, column_names::STRING
-----
-statistics_name  column_names    row_count
-s                {last_updated}  3
-s                {profile_id}    3
-
 # Arrays are supported.
 statement ok
 CREATE TABLE arr (x INT[])
@@ -668,3 +620,71 @@ ORDER BY
 statistics_name  column_names  row_count  null_count  has_histogram
 s                {x}           3          0           true
 s                {y}           3          0           true
+
+# JSON and other inverted-index columns. See also #35150.
+statement ok
+CREATE TABLE groups (data JSON); INSERT INTO groups VALUES ('{"data": {"domain": "github.com"}}')
+
+# JSON can be specified.
+statement ok
+CREATE STATISTICS s ON data FROM groups
+
+query TT colnames
+SELECT statistics_name, column_names
+FROM [SHOW STATISTICS FOR TABLE groups] ORDER BY statistics_name, column_names::STRING
+----
+statistics_name  column_names
+s                {data}
+
+# JSON is auto-included.
+statement ok
+CREATE STATISTICS s FROM groups
+
+query TT colnames
+SELECT statistics_name, column_names
+FROM [SHOW STATISTICS FOR TABLE groups] ORDER BY statistics_name, column_names::STRING
+----
+statistics_name  column_names
+s                {data}
+s                {rowid}
+
+# See #35764
+statement ok
+CREATE TABLE users (
+  profile_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  last_updated TIMESTAMP DEFAULT now(),
+  user_profile JSONB,
+  INVERTED INDEX user_details (user_profile)
+)
+
+statement ok
+INSERT INTO users (user_profile) VALUES
+  ('{"first_name": "Lola", "last_name": "Dog", "location": "NYC", "online" : true, "friends" : 547}'),
+  ('{"first_name": "Ernie", "status": "Looking for treats", "location" : "Brooklyn"}'),
+  ('{"first_name": "Ernie", "status": "Looking for treats", "location" : "Brooklyn"}'),
+  (NULL),
+  ('{"first_name": "Carl", "last_name": "Kimball", "location": "NYC", "breed": "Boston Terrier"}'
+)
+
+# Ensure that trying to create statistics with default columns does not fail
+# when there is an inverted index.
+statement ok
+CREATE STATISTICS s FROM users
+
+query TTIIIB colnames
+SELECT
+  statistics_name,
+  column_names,
+  row_count,
+  distinct_count,
+  null_count,
+  histogram_id IS NOT NULL AS has_histogram
+FROM
+  [SHOW STATISTICS FOR TABLE users]
+ORDER BY
+  statistics_name, column_names
+----
+statistics_name  column_names    row_count  distinct_count  null_count  has_histogram
+s                {last_updated}  5          1               0           false
+s                {profile_id}    5          5               0           true
+s                {user_profile}  5          4               1           false

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -3,6 +3,10 @@
 # Tests that verify we retrieve the stats correctly. Note that we can't create
 # statistics if distsql mode is OFF.
 
+# Disable automatic stats to prevent flakes if auto stats run.
+statement ok
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
+
 statement ok
 CREATE TABLE uv (u INT, v INT, INDEX (u) STORING (v), INDEX (v) STORING (u));
 INSERT INTO uv VALUES (1, 1), (1, 2), (1, 3), (1, 4), (2, 4), (2, 5), (2, 6), (2, 7)
@@ -253,3 +257,70 @@ distinct-on
       ├── ordering: +1
       ├── prune: (2)
       └── interesting orderings: (+1) (+2)
+
+# Verify basic stats for JSON are used.
+
+statement ok
+CREATE TABLE tj (j JSON)
+
+statement ok
+INSERT INTO tj VALUES (NULL), ('1'), ('true'), ('true'), ('{}')
+
+query T
+EXPLAIN (OPT, VERBOSE) SELECT DISTINCT j FROM tj WHERE j IS NULL
+----
+limit
+ ├── columns: j:1
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── stats: [rows=1]
+ ├── cost: 222.05
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── select
+ │    ├── columns: j:1
+ │    ├── immutable
+ │    ├── stats: [rows=10, distinct(1)=1, null(1)=10]
+ │    ├── cost: 222.03
+ │    ├── fd: ()-->(1)
+ │    ├── limit hint: 1.00
+ │    ├── scan tj
+ │    │    ├── columns: j:1
+ │    │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10]
+ │    │    ├── cost: 212.02
+ │    │    ├── limit hint: 100.00
+ │    │    └── prune: (1)
+ │    └── filters
+ │         └── j:1 IS NULL [outer=(1), immutable, constraints=(/1: [/NULL - /NULL]; tight), fd=()-->(1)]
+ └── 1
+
+statement ok
+CREATE STATISTICS tj FROM tj
+
+query T
+EXPLAIN (OPT, VERBOSE) SELECT DISTINCT j FROM tj WHERE j IS NULL
+----
+limit
+ ├── columns: j:1
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── stats: [rows=1]
+ ├── cost: 5.4
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── select
+ │    ├── columns: j:1
+ │    ├── immutable
+ │    ├── stats: [rows=1, distinct(1)=1, null(1)=1]
+ │    ├── cost: 5.38
+ │    ├── fd: ()-->(1)
+ │    ├── limit hint: 1.00
+ │    ├── scan tj
+ │    │    ├── columns: j:1
+ │    │    ├── stats: [rows=5, distinct(1)=4, null(1)=1]
+ │    │    ├── cost: 5.32
+ │    │    ├── limit hint: 5.00
+ │    │    └── prune: (1)
+ │    └── filters
+ │         └── j:1 IS NULL [outer=(1), immutable, constraints=(/1: [/NULL - /NULL]; tight), fd=()-->(1)]
+ └── 1


### PR DESCRIPTION
Improve datum fingerprinting (used by rowexec/sampler.go) to work
correctly for all types. Previously, due to the hardcoded assumption that
JSON was the only non-key encodable type, it would error if presented
a geo/geom type.

Use MustBeValueEncoded when fingerprinting and determining if a type can
create a histogram. This should be future proof if we add new types or
teach types how to key encode.

Fixes #35844
Informs #48219

Release note: None