### PR TITLE
opt: ON UPDATE cascades for Upsert

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -3786,3 +3786,215 @@ SELECT * FROM self_abcd ORDER BY (a, b, c, d)
 # Clean up.
 statement ok
 DROP TABLE self_abcd
+
+subtest UpsertCascade
+
+statement ok
+CREATE TABLE parent (pk INT PRIMARY KEY, p INT UNIQUE)
+
+statement ok
+CREATE TABLE child (pk INT PRIMARY KEY, p INT REFERENCES parent(p) ON UPDATE CASCADE)
+
+statement ok
+INSERT INTO parent VALUES (1, 1), (2, 2);
+INSERT INTO child VALUES (1, 1), (2, 1), (3, 2), (4, 2)
+
+statement ok
+UPSERT INTO parent VALUES (2, 20), (3, 3)
+
+query II rowsort
+SELECT * FROM child
+----
+1  1
+2  1
+3  20
+4  20
+
+statement ok
+INSERT INTO parent VALUES (1, 1), (4, 4) ON CONFLICT (pk) DO UPDATE SET p = parent.pk * 10
+
+query II rowsort
+SELECT * FROM child
+----
+1  10
+2  10
+3  20
+4  20
+
+statement ok
+INSERT INTO parent VALUES (100, 20) ON CONFLICT(p) DO UPDATE SET p = 50
+
+query II rowsort
+SELECT * FROM child
+----
+1  10
+2  10
+3  50
+4  50
+
+statement ok
+DROP TABLE child, parent
+
+subtest UpsertMultiColCascade
+
+statement ok
+CREATE TABLE parent (pk INT PRIMARY KEY, p INT, q INT, UNIQUE (p,q))
+
+statement ok
+CREATE TABLE child (pk INT PRIMARY KEY, p INT, q INT, CONSTRAINT fk FOREIGN KEY (p,q) REFERENCES parent(p,q) ON UPDATE CASCADE)
+
+statement ok
+INSERT INTO parent VALUES (1, 1, 1), (2, 2, 2);
+INSERT INTO child VALUES (1, 1, 1), (2, 1, 1), (3, 2, 2), (4, 2, 2)
+
+statement ok
+UPSERT INTO parent(pk, p) VALUES (1, 1)
+
+query III rowsort
+SELECT * FROM child
+----
+1  1  1
+2  1  1
+3  2  2
+4  2  2
+
+statement ok
+UPSERT INTO parent(pk, q) VALUES (2, 20)
+
+query III rowsort
+SELECT * FROM child
+----
+1  1  1
+2  1  1
+3  2  20
+4  2  20
+
+statement ok
+UPSERT INTO parent VALUES (1, 10, 10)
+
+query III rowsort
+SELECT * FROM child
+----
+1  10  10
+2  10  10
+3  2   20
+4  2   20
+
+statement ok
+DROP TABLE child, parent
+
+subtest UpsertSetNull
+
+statement ok
+CREATE TABLE parent (pk INT PRIMARY KEY, p INT UNIQUE)
+
+statement ok
+CREATE TABLE child (pk INT PRIMARY KEY, p INT REFERENCES parent(p) ON UPDATE SET NULL)
+
+statement ok
+INSERT INTO parent VALUES (1, 1), (2, 2);
+INSERT INTO child VALUES (1, 1), (2, 1), (3, 2), (4, 2)
+
+statement ok
+UPSERT INTO parent VALUES (2, 20), (3, 3)
+
+query II rowsort
+SELECT * FROM child
+----
+1  1
+2  1
+3  NULL
+4  NULL
+
+# Verify that updating to the same value does not trigger the action.
+statement ok
+UPSERT INTO parent VALUES (1, 1)
+
+query II rowsort
+SELECT * FROM child
+----
+1  1
+2  1
+3  NULL
+4  NULL
+
+# Verify that a partial update that does not touch the FK column
+# does not trigger the action.
+statement ok
+UPSERT INTO parent(pk) VALUES (1)
+
+query II rowsort
+SELECT * FROM child
+----
+1  1
+2  1
+3  NULL
+4  NULL
+
+statement ok
+INSERT INTO parent VALUES (100, 1) ON CONFLICT(p) DO UPDATE SET p = 50
+
+query II rowsort
+SELECT * FROM child
+----
+1  NULL
+2  NULL
+3  NULL
+4  NULL
+
+statement ok
+DROP TABLE child, parent
+
+subtest UpsertSetDefault
+
+statement ok
+CREATE TABLE parent (pk INT PRIMARY KEY, p INT UNIQUE)
+
+statement ok
+CREATE TABLE child (pk INT PRIMARY KEY, p INT DEFAULT 1 REFERENCES parent(p) ON UPDATE SET DEFAULT)
+
+statement ok
+INSERT INTO parent VALUES (1, 1), (2, 2);
+INSERT INTO child VALUES (1, 1), (2, 1), (3, 2), (4, 2)
+
+# Verify that updating to the same value does not trigger the action.
+statement ok
+UPSERT INTO parent VALUES (2, 2)
+
+query II rowsort
+SELECT * FROM child
+----
+1  1
+2  1
+3  2
+4  2
+
+# Verify that a partial update that does not touch the FK column
+# does not trigger the action.
+statement ok
+UPSERT INTO parent(pk) VALUES (2)
+
+query II rowsort
+SELECT * FROM child
+----
+1  1
+2  1
+3  2
+4  2
+
+statement ok
+UPSERT INTO parent VALUES (2, 20), (3, 3)
+
+query II rowsort
+SELECT * FROM child
+----
+1  1
+2  1
+3  1
+4  1
+
+statement error foreign key violation: values \[1\] in columns \[p\] referenced in table "child"
+INSERT INTO parent VALUES (100, 1) ON CONFLICT(p) DO UPDATE SET p = 50
+
+statement ok
+DROP TABLE child, parent

--- a/pkg/sql/logictest/testdata/logic_test/cascade_opt
+++ b/pkg/sql/logictest/testdata/logic_test/cascade_opt
@@ -4044,3 +4044,215 @@ SELECT * FROM self_abcd ORDER BY (a, b, c, d)
 # Clean up.
 statement ok
 DROP TABLE self_abcd
+
+subtest UpsertCascade
+
+statement ok
+CREATE TABLE parent (pk INT PRIMARY KEY, p INT UNIQUE)
+
+statement ok
+CREATE TABLE child (pk INT PRIMARY KEY, p INT REFERENCES parent(p) ON UPDATE CASCADE)
+
+statement ok
+INSERT INTO parent VALUES (1, 1), (2, 2);
+INSERT INTO child VALUES (1, 1), (2, 1), (3, 2), (4, 2)
+
+statement ok
+UPSERT INTO parent VALUES (2, 20), (3, 3)
+
+query II rowsort
+SELECT * FROM child
+----
+1  1
+2  1
+3  20
+4  20
+
+statement ok
+INSERT INTO parent VALUES (1, 1), (4, 4) ON CONFLICT (pk) DO UPDATE SET p = parent.pk * 10
+
+query II rowsort
+SELECT * FROM child
+----
+1  10
+2  10
+3  20
+4  20
+
+statement ok
+INSERT INTO parent VALUES (100, 20) ON CONFLICT(p) DO UPDATE SET p = 50
+
+query II rowsort
+SELECT * FROM child
+----
+1  10
+2  10
+3  50
+4  50
+
+statement ok
+DROP TABLE child, parent
+
+subtest UpsertMultiColCascade
+
+statement ok
+CREATE TABLE parent (pk INT PRIMARY KEY, p INT, q INT, UNIQUE (p,q))
+
+statement ok
+CREATE TABLE child (pk INT PRIMARY KEY, p INT, q INT, CONSTRAINT fk FOREIGN KEY (p,q) REFERENCES parent(p,q) ON UPDATE CASCADE)
+
+statement ok
+INSERT INTO parent VALUES (1, 1, 1), (2, 2, 2);
+INSERT INTO child VALUES (1, 1, 1), (2, 1, 1), (3, 2, 2), (4, 2, 2)
+
+statement ok
+UPSERT INTO parent(pk, p) VALUES (1, 1)
+
+query III rowsort
+SELECT * FROM child
+----
+1  1  1
+2  1  1
+3  2  2
+4  2  2
+
+statement ok
+UPSERT INTO parent(pk, q) VALUES (2, 20)
+
+query III rowsort
+SELECT * FROM child
+----
+1  1  1
+2  1  1
+3  2  20
+4  2  20
+
+statement ok
+UPSERT INTO parent VALUES (1, 10, 10)
+
+query III rowsort
+SELECT * FROM child
+----
+1  10  10
+2  10  10
+3  2   20
+4  2   20
+
+statement ok
+DROP TABLE child, parent
+
+subtest UpsertSetNull
+
+statement ok
+CREATE TABLE parent (pk INT PRIMARY KEY, p INT UNIQUE)
+
+statement ok
+CREATE TABLE child (pk INT PRIMARY KEY, p INT REFERENCES parent(p) ON UPDATE SET NULL)
+
+statement ok
+INSERT INTO parent VALUES (1, 1), (2, 2);
+INSERT INTO child VALUES (1, 1), (2, 1), (3, 2), (4, 2)
+
+statement ok
+UPSERT INTO parent VALUES (2, 20), (3, 3)
+
+query II rowsort
+SELECT * FROM child
+----
+1  1
+2  1
+3  NULL
+4  NULL
+
+# Verify that updating to the same value does not trigger the action.
+statement ok
+UPSERT INTO parent VALUES (1, 1)
+
+query II rowsort
+SELECT * FROM child
+----
+1  1
+2  1
+3  NULL
+4  NULL
+
+# Verify that a partial update that does not touch the FK column
+# does not trigger the action.
+statement ok
+UPSERT INTO parent(pk) VALUES (1)
+
+query II rowsort
+SELECT * FROM child
+----
+1  1
+2  1
+3  NULL
+4  NULL
+
+statement ok
+INSERT INTO parent VALUES (100, 1) ON CONFLICT(p) DO UPDATE SET p = 50
+
+query II rowsort
+SELECT * FROM child
+----
+1  NULL
+2  NULL
+3  NULL
+4  NULL
+
+statement ok
+DROP TABLE child, parent
+
+subtest UpsertSetDefault
+
+statement ok
+CREATE TABLE parent (pk INT PRIMARY KEY, p INT UNIQUE)
+
+statement ok
+CREATE TABLE child (pk INT PRIMARY KEY, p INT DEFAULT 1 REFERENCES parent(p) ON UPDATE SET DEFAULT)
+
+statement ok
+INSERT INTO parent VALUES (1, 1), (2, 2);
+INSERT INTO child VALUES (1, 1), (2, 1), (3, 2), (4, 2)
+
+# Verify that updating to the same value does not trigger the action.
+statement ok
+UPSERT INTO parent VALUES (2, 2)
+
+query II rowsort
+SELECT * FROM child
+----
+1  1
+2  1
+3  2
+4  2
+
+# Verify that a partial update that does not touch the FK column
+# does not trigger the action.
+statement ok
+UPSERT INTO parent(pk) VALUES (2)
+
+query II rowsort
+SELECT * FROM child
+----
+1  1
+2  1
+3  2
+4  2
+
+statement ok
+UPSERT INTO parent VALUES (2, 20), (3, 3)
+
+query II rowsort
+SELECT * FROM child
+----
+1  1
+2  1
+3  1
+4  1
+
+statement error update on table "child" violates foreign key constraint "fk_p_ref_parent"\nDETAIL: Key \(p\)=\(1\) is not present in table "parent"\.
+INSERT INTO parent VALUES (100, 1) ON CONFLICT(p) DO UPDATE SET p = 50
+
+statement ok
+DROP TABLE child, parent

--- a/pkg/sql/logictest/testdata/logic_test/cascade_opt
+++ b/pkg/sql/logictest/testdata/logic_test/cascade_opt
@@ -3974,13 +3974,11 @@ DROP TABLE c, b, a;
 # modifies the original table (#42117).
 subtest SelfReferencingCheckFail
 
-# TODO(radu): remove the FAMILY when #42120 is fixed.
 statement ok
 CREATE TABLE self_ab (
   a INT UNIQUE,
   b INT DEFAULT 1 CHECK (b != 1),
-  INDEX (b),
-  FAMILY (a, b)
+  INDEX (b)
 )
 
 statement ok
@@ -4006,3 +4004,43 @@ ALTER TABLE self_ab ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES self_ab_parent
 
 statement error failed to satisfy CHECK constraint \(b != 1\)
 UPDATE self_ab_parent SET p = 3 WHERE p = 2
+
+# Clean up.
+statement ok
+DROP TABLE self_ab, self_ab_parent
+
+# Extra test for self referencing foreign keys with set default.
+subtest SelfReferencingSetDefault
+
+statement ok
+CREATE TABLE self_abcd (
+  a INT DEFAULT 2,
+  b INT DEFAULT 2,
+  c INT DEFAULT 2,
+  d INT DEFAULT 2,
+  INDEX (c),
+  INDEX (d),
+  PRIMARY KEY (a), FAMILY (a, b, c, d)
+)
+
+statement ok
+INSERT INTO self_abcd VALUES (1, 2, 3, 4), (4, 1, 2, 3), (3, 4, 1, 2), (2, 3, 4, 1)
+
+statement ok
+ALTER TABLE self_abcd ADD CONSTRAINT fk1 FOREIGN KEY (c) REFERENCES self_abcd(a) ON UPDATE SET DEFAULT;
+ALTER TABLE self_abcd ADD CONSTRAINT fk2 FOREIGN KEY (d) REFERENCES self_abcd(a) ON UPDATE SET DEFAULT
+
+statement ok
+UPDATE self_abcd SET a = 5 WHERE a = 1
+
+query IIII
+SELECT * FROM self_abcd ORDER BY (a, b, c, d)
+----
+2  3  4  2
+3  4  2  2
+4  1  2  3
+5  2  3  4
+
+# Clean up.
+statement ok
+DROP TABLE self_abcd

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -411,6 +411,10 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (execPlan, error) {
 		return execPlan{}, err
 	}
 
+	if err := b.buildFKCascades(ups.WithID, ups.FKCascades); err != nil {
+		return execPlan{}, err
+	}
+
 	// If UPSERT returns rows, they contain all non-mutation columns from the
 	// table, in the same order they're defined in the table. Each output column
 	// value is taken from an insert, fetch, or update column, depending on the

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -511,6 +511,13 @@ func (cb *onUpdateCascadeBuilder) Build(
 // the columns that contain the old FK values, followed by the columns that
 // contain the new FK values.
 //
+// Note that for Upserts we need to only perform actions for rows that
+// correspond to updates (and not inserts). Normally these would be selected by
+// a "canaryCol IS NOT NULL" filters. However, that is not necessary because for
+// inserted rows the "old" values are all NULL and won't match anything in the
+// inner-join anyway. This reasoning is very similar to that of FK checks for
+// Upserts (see buildFKChecksForUpsert).
+//
 func (b *Builder) buildUpdateCascadeMutationInput(
 	childTable cat.Table,
 	childTableAlias *tree.TableName,

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
@@ -222,6 +222,266 @@ root
                                ├── p_new:18 = parent_multi.p:21
                                └── q:19 = parent_multi.q:22
 
+build-cascades
+UPSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20)
+----
+root
+ ├── upsert parent_multi
+ │    ├── columns: <none>
+ │    ├── canary column: 7
+ │    ├── fetch columns: pk:7 p:8 q:9
+ │    ├── insert-mapping:
+ │    │    ├── column1:4 => pk:1
+ │    │    ├── column2:5 => p:2
+ │    │    └── column3:6 => q:3
+ │    ├── update-mapping:
+ │    │    ├── column2:5 => p:2
+ │    │    └── column3:6 => q:3
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk
+ │    └── project
+ │         ├── columns: upsert_pk:10 column1:4!null column2:5!null column3:6!null pk:7 p:8 q:9
+ │         ├── left-join (hash)
+ │         │    ├── columns: column1:4!null column2:5!null column3:6!null pk:7 p:8 q:9
+ │         │    ├── ensure-upsert-distinct-on
+ │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+ │         │    │    ├── grouping columns: column1:4!null
+ │         │    │    ├── values
+ │         │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+ │         │    │    │    ├── (1, 10, 10)
+ │         │    │    │    └── (2, 20, 20)
+ │         │    │    └── aggregations
+ │         │    │         ├── first-agg [as=column2:5]
+ │         │    │         │    └── column2:5
+ │         │    │         └── first-agg [as=column3:6]
+ │         │    │              └── column3:6
+ │         │    ├── scan parent_multi
+ │         │    │    └── columns: pk:7!null p:8 q:9
+ │         │    └── filters
+ │         │         └── column1:4 = pk:7
+ │         └── projections
+ │              └── CASE WHEN pk:7 IS NULL THEN column1:4 ELSE pk:7 END [as=upsert_pk:10]
+ └── cascade
+      └── update child_multi
+           ├── columns: <none>
+           ├── fetch columns: c:14 child_multi.p:15 child_multi.q:16
+           ├── update-mapping:
+           │    ├── column2:19 => child_multi.p:12
+           │    └── column3:20 => child_multi.q:13
+           ├── input binding: &2
+           ├── inner-join (hash)
+           │    ├── columns: c:14!null child_multi.p:15!null child_multi.q:16!null p:17!null q:18!null column2:19!null column3:20!null
+           │    ├── scan child_multi
+           │    │    └── columns: c:14!null child_multi.p:15 child_multi.q:16
+           │    ├── select
+           │    │    ├── columns: p:17 q:18 column2:19!null column3:20!null
+           │    │    ├── with-scan &1
+           │    │    │    ├── columns: p:17 q:18 column2:19!null column3:20!null
+           │    │    │    └── mapping:
+           │    │    │         ├──  parent_multi.p:8 => p:17
+           │    │    │         ├──  parent_multi.q:9 => q:18
+           │    │    │         ├──  column2:5 => column2:19
+           │    │    │         └──  column3:6 => column3:20
+           │    │    └── filters
+           │    │         └── (p:17 IS DISTINCT FROM column2:19) OR (q:18 IS DISTINCT FROM column3:20)
+           │    └── filters
+           │         ├── child_multi.p:15 = p:17
+           │         └── child_multi.q:16 = q:18
+           └── f-k-checks
+                └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
+                     └── anti-join (hash)
+                          ├── columns: column2:21!null column3:22!null
+                          ├── with-scan &2
+                          │    ├── columns: column2:21!null column3:22!null
+                          │    └── mapping:
+                          │         ├──  column2:19 => column2:21
+                          │         └──  column3:20 => column3:22
+                          ├── scan parent_multi
+                          │    └── columns: parent_multi.p:24 parent_multi.q:25
+                          └── filters
+                               ├── column2:21 = parent_multi.p:24
+                               └── column3:22 = parent_multi.q:25
+
+# Upsert that only touches one of the FK columns.
+build-cascades
+UPSERT INTO parent_multi(pk, p) VALUES (1, 10), (2, 20)
+----
+root
+ ├── upsert parent_multi
+ │    ├── columns: <none>
+ │    ├── canary column: 7
+ │    ├── fetch columns: pk:7 p:8 q:9
+ │    ├── insert-mapping:
+ │    │    ├── column1:4 => pk:1
+ │    │    ├── column2:5 => p:2
+ │    │    └── column6:6 => q:3
+ │    ├── update-mapping:
+ │    │    └── column2:5 => p:2
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk
+ │    └── project
+ │         ├── columns: upsert_pk:10 upsert_q:11 column1:4!null column2:5!null column6:6 pk:7 p:8 q:9
+ │         ├── left-join (hash)
+ │         │    ├── columns: column1:4!null column2:5!null column6:6 pk:7 p:8 q:9
+ │         │    ├── ensure-upsert-distinct-on
+ │         │    │    ├── columns: column1:4!null column2:5!null column6:6
+ │         │    │    ├── grouping columns: column1:4!null
+ │         │    │    ├── project
+ │         │    │    │    ├── columns: column6:6 column1:4!null column2:5!null
+ │         │    │    │    ├── values
+ │         │    │    │    │    ├── columns: column1:4!null column2:5!null
+ │         │    │    │    │    ├── (1, 10)
+ │         │    │    │    │    └── (2, 20)
+ │         │    │    │    └── projections
+ │         │    │    │         └── NULL::INT8 [as=column6:6]
+ │         │    │    └── aggregations
+ │         │    │         ├── first-agg [as=column2:5]
+ │         │    │         │    └── column2:5
+ │         │    │         └── first-agg [as=column6:6]
+ │         │    │              └── column6:6
+ │         │    ├── scan parent_multi
+ │         │    │    └── columns: pk:7!null p:8 q:9
+ │         │    └── filters
+ │         │         └── column1:4 = pk:7
+ │         └── projections
+ │              ├── CASE WHEN pk:7 IS NULL THEN column1:4 ELSE pk:7 END [as=upsert_pk:10]
+ │              └── CASE WHEN pk:7 IS NULL THEN column6:6 ELSE q:9 END [as=upsert_q:11]
+ └── cascade
+      └── update child_multi
+           ├── columns: <none>
+           ├── fetch columns: c:15 child_multi.p:16 child_multi.q:17
+           ├── update-mapping:
+           │    ├── column2:20 => child_multi.p:13
+           │    └── q:21 => child_multi.q:14
+           ├── input binding: &2
+           ├── inner-join (hash)
+           │    ├── columns: c:15!null child_multi.p:16!null child_multi.q:17!null p:18!null q:19!null column2:20!null q:21
+           │    ├── scan child_multi
+           │    │    └── columns: c:15!null child_multi.p:16 child_multi.q:17
+           │    ├── select
+           │    │    ├── columns: p:18 q:19 column2:20!null q:21
+           │    │    ├── with-scan &1
+           │    │    │    ├── columns: p:18 q:19 column2:20!null q:21
+           │    │    │    └── mapping:
+           │    │    │         ├──  parent_multi.p:8 => p:18
+           │    │    │         ├──  parent_multi.q:9 => q:19
+           │    │    │         ├──  column2:5 => column2:20
+           │    │    │         └──  parent_multi.q:9 => q:21
+           │    │    └── filters
+           │    │         └── (p:18 IS DISTINCT FROM column2:20) OR (q:19 IS DISTINCT FROM q:21)
+           │    └── filters
+           │         ├── child_multi.p:16 = p:18
+           │         └── child_multi.q:17 = q:19
+           └── f-k-checks
+                └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
+                     └── anti-join (hash)
+                          ├── columns: column2:22!null q:23!null
+                          ├── select
+                          │    ├── columns: column2:22!null q:23!null
+                          │    ├── with-scan &2
+                          │    │    ├── columns: column2:22!null q:23
+                          │    │    └── mapping:
+                          │    │         ├──  column2:20 => column2:22
+                          │    │         └──  q:21 => q:23
+                          │    └── filters
+                          │         └── q:23 IS NOT NULL
+                          ├── scan parent_multi
+                          │    └── columns: parent_multi.p:25 parent_multi.q:26
+                          └── filters
+                               ├── column2:22 = parent_multi.p:25
+                               └── q:23 = parent_multi.q:26
+
+build-cascades
+INSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20) ON CONFLICT (p,q) DO UPDATE SET p = 100
+----
+root
+ ├── upsert parent_multi
+ │    ├── columns: <none>
+ │    ├── canary column: 7
+ │    ├── fetch columns: pk:7 p:8 q:9
+ │    ├── insert-mapping:
+ │    │    ├── column1:4 => pk:1
+ │    │    ├── column2:5 => p:2
+ │    │    └── column3:6 => q:3
+ │    ├── update-mapping:
+ │    │    └── upsert_p:12 => p:2
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk
+ │    └── project
+ │         ├── columns: upsert_pk:11 upsert_p:12!null upsert_q:13 column1:4!null column2:5!null column3:6!null pk:7 p:8 q:9 p_new:10!null
+ │         ├── project
+ │         │    ├── columns: p_new:10!null column1:4!null column2:5!null column3:6!null pk:7 p:8 q:9
+ │         │    ├── left-join (hash)
+ │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null pk:7 p:8 q:9
+ │         │    │    ├── ensure-upsert-distinct-on
+ │         │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+ │         │    │    │    ├── grouping columns: column2:5!null column3:6!null
+ │         │    │    │    ├── values
+ │         │    │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+ │         │    │    │    │    ├── (1, 10, 10)
+ │         │    │    │    │    └── (2, 20, 20)
+ │         │    │    │    └── aggregations
+ │         │    │    │         └── first-agg [as=column1:4]
+ │         │    │    │              └── column1:4
+ │         │    │    ├── scan parent_multi
+ │         │    │    │    └── columns: pk:7!null p:8 q:9
+ │         │    │    └── filters
+ │         │    │         ├── column2:5 = p:8
+ │         │    │         └── column3:6 = q:9
+ │         │    └── projections
+ │         │         └── 100 [as=p_new:10]
+ │         └── projections
+ │              ├── CASE WHEN pk:7 IS NULL THEN column1:4 ELSE pk:7 END [as=upsert_pk:11]
+ │              ├── CASE WHEN pk:7 IS NULL THEN column2:5 ELSE p_new:10 END [as=upsert_p:12]
+ │              └── CASE WHEN pk:7 IS NULL THEN column3:6 ELSE q:9 END [as=upsert_q:13]
+ └── cascade
+      └── update child_multi
+           ├── columns: <none>
+           ├── fetch columns: c:17 child_multi.p:18 child_multi.q:19
+           ├── update-mapping:
+           │    ├── upsert_p:22 => child_multi.p:15
+           │    └── q:23 => child_multi.q:16
+           ├── input binding: &2
+           ├── inner-join (hash)
+           │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p:20!null q:21!null upsert_p:22!null q:23
+           │    ├── scan child_multi
+           │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19
+           │    ├── select
+           │    │    ├── columns: p:20 q:21 upsert_p:22!null q:23
+           │    │    ├── with-scan &1
+           │    │    │    ├── columns: p:20 q:21 upsert_p:22!null q:23
+           │    │    │    └── mapping:
+           │    │    │         ├──  parent_multi.p:8 => p:20
+           │    │    │         ├──  parent_multi.q:9 => q:21
+           │    │    │         ├──  upsert_p:12 => upsert_p:22
+           │    │    │         └──  parent_multi.q:9 => q:23
+           │    │    └── filters
+           │    │         └── (p:20 IS DISTINCT FROM upsert_p:22) OR (q:21 IS DISTINCT FROM q:23)
+           │    └── filters
+           │         ├── child_multi.p:18 = p:20
+           │         └── child_multi.q:19 = q:21
+           └── f-k-checks
+                └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
+                     └── anti-join (hash)
+                          ├── columns: upsert_p:24!null q:25!null
+                          ├── select
+                          │    ├── columns: upsert_p:24!null q:25!null
+                          │    ├── with-scan &2
+                          │    │    ├── columns: upsert_p:24!null q:25
+                          │    │    └── mapping:
+                          │    │         ├──  upsert_p:22 => upsert_p:24
+                          │    │         └──  q:23 => q:25
+                          │    └── filters
+                          │         └── q:25 IS NOT NULL
+                          ├── scan parent_multi
+                          │    └── columns: parent_multi.p:27 parent_multi.q:28
+                          └── filters
+                               ├── upsert_p:24 = parent_multi.p:27
+                               └── q:25 = parent_multi.q:28
+
 # Test a two-level cascade.
 exec-ddl
 CREATE TABLE grandchild (
@@ -343,3 +603,126 @@ root
                                └── filters
                                     ├── c:33 = child_multi.c:35
                                     └── q_new:34 = child_multi.q:37
+
+build-cascades
+UPSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20)
+----
+root
+ ├── upsert parent_multi
+ │    ├── columns: <none>
+ │    ├── canary column: 7
+ │    ├── fetch columns: pk:7 p:8 q:9
+ │    ├── insert-mapping:
+ │    │    ├── column1:4 => pk:1
+ │    │    ├── column2:5 => p:2
+ │    │    └── column3:6 => q:3
+ │    ├── update-mapping:
+ │    │    ├── column2:5 => p:2
+ │    │    └── column3:6 => q:3
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk
+ │    └── project
+ │         ├── columns: upsert_pk:10 column1:4!null column2:5!null column3:6!null pk:7 p:8 q:9
+ │         ├── left-join (hash)
+ │         │    ├── columns: column1:4!null column2:5!null column3:6!null pk:7 p:8 q:9
+ │         │    ├── ensure-upsert-distinct-on
+ │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+ │         │    │    ├── grouping columns: column1:4!null
+ │         │    │    ├── values
+ │         │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+ │         │    │    │    ├── (1, 10, 10)
+ │         │    │    │    └── (2, 20, 20)
+ │         │    │    └── aggregations
+ │         │    │         ├── first-agg [as=column2:5]
+ │         │    │         │    └── column2:5
+ │         │    │         └── first-agg [as=column3:6]
+ │         │    │              └── column3:6
+ │         │    ├── scan parent_multi
+ │         │    │    └── columns: pk:7!null p:8 q:9
+ │         │    └── filters
+ │         │         └── column1:4 = pk:7
+ │         └── projections
+ │              └── CASE WHEN pk:7 IS NULL THEN column1:4 ELSE pk:7 END [as=upsert_pk:10]
+ └── cascade
+      ├── update child_multi
+      │    ├── columns: <none>
+      │    ├── fetch columns: c:14 child_multi.p:15 child_multi.q:16
+      │    ├── update-mapping:
+      │    │    ├── column2:19 => child_multi.p:12
+      │    │    └── column3:20 => child_multi.q:13
+      │    ├── input binding: &2
+      │    ├── cascades
+      │    │    └── fk2
+      │    ├── inner-join (hash)
+      │    │    ├── columns: c:14!null child_multi.p:15!null child_multi.q:16!null p:17!null q:18!null column2:19!null column3:20!null
+      │    │    ├── scan child_multi
+      │    │    │    └── columns: c:14!null child_multi.p:15 child_multi.q:16
+      │    │    ├── select
+      │    │    │    ├── columns: p:17 q:18 column2:19!null column3:20!null
+      │    │    │    ├── with-scan &1
+      │    │    │    │    ├── columns: p:17 q:18 column2:19!null column3:20!null
+      │    │    │    │    └── mapping:
+      │    │    │    │         ├──  parent_multi.p:8 => p:17
+      │    │    │    │         ├──  parent_multi.q:9 => q:18
+      │    │    │    │         ├──  column2:5 => column2:19
+      │    │    │    │         └──  column3:6 => column3:20
+      │    │    │    └── filters
+      │    │    │         └── (p:17 IS DISTINCT FROM column2:19) OR (q:18 IS DISTINCT FROM column3:20)
+      │    │    └── filters
+      │    │         ├── child_multi.p:15 = p:17
+      │    │         └── child_multi.q:16 = q:18
+      │    └── f-k-checks
+      │         └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
+      │              └── anti-join (hash)
+      │                   ├── columns: column2:21!null column3:22!null
+      │                   ├── with-scan &2
+      │                   │    ├── columns: column2:21!null column3:22!null
+      │                   │    └── mapping:
+      │                   │         ├──  column2:19 => column2:21
+      │                   │         └──  column3:20 => column3:22
+      │                   ├── scan parent_multi
+      │                   │    └── columns: parent_multi.p:24 parent_multi.q:25
+      │                   └── filters
+      │                        ├── column2:21 = parent_multi.p:24
+      │                        └── column3:22 = parent_multi.q:25
+      └── cascade
+           └── update grandchild
+                ├── columns: <none>
+                ├── fetch columns: g:29 grandchild.c:30 grandchild.q:31
+                ├── update-mapping:
+                │    ├── c:34 => grandchild.c:27
+                │    └── column3:35 => grandchild.q:28
+                ├── input binding: &3
+                ├── inner-join (hash)
+                │    ├── columns: g:29!null grandchild.c:30!null grandchild.q:31!null c:32!null q:33!null c:34!null column3:35!null
+                │    ├── scan grandchild
+                │    │    └── columns: g:29!null grandchild.c:30 grandchild.q:31
+                │    ├── select
+                │    │    ├── columns: c:32!null q:33!null c:34!null column3:35!null
+                │    │    ├── with-scan &2
+                │    │    │    ├── columns: c:32!null q:33!null c:34!null column3:35!null
+                │    │    │    └── mapping:
+                │    │    │         ├──  child_multi.c:14 => c:32
+                │    │    │         ├──  child_multi.q:16 => q:33
+                │    │    │         ├──  child_multi.c:14 => c:34
+                │    │    │         └──  column3:20 => column3:35
+                │    │    └── filters
+                │    │         └── (c:32 IS DISTINCT FROM c:34) OR (q:33 IS DISTINCT FROM column3:35)
+                │    └── filters
+                │         ├── grandchild.c:30 = c:32
+                │         └── grandchild.q:31 = q:33
+                └── f-k-checks
+                     └── f-k-checks-item: grandchild(c,q) -> child_multi(c,q)
+                          └── anti-join (hash)
+                               ├── columns: c:36!null column3:37!null
+                               ├── with-scan &3
+                               │    ├── columns: c:36!null column3:37!null
+                               │    └── mapping:
+                               │         ├──  c:34 => c:36
+                               │         └──  column3:35 => column3:37
+                               ├── scan child_multi
+                               │    └── columns: child_multi.c:38!null child_multi.q:40
+                               └── filters
+                                    ├── c:36 = child_multi.c:38
+                                    └── column3:37 = child_multi.q:40

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
@@ -351,3 +351,411 @@ root
                                └── filters
                                     ├── c_new:37 = child_multi.c:39
                                     └── q_new:38 = child_multi.q:41
+
+build-cascades
+UPSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20)
+----
+root
+ ├── upsert parent_multi
+ │    ├── columns: <none>
+ │    ├── canary column: 7
+ │    ├── fetch columns: pk:7 p:8 q:9
+ │    ├── insert-mapping:
+ │    │    ├── column1:4 => pk:1
+ │    │    ├── column2:5 => p:2
+ │    │    └── column3:6 => q:3
+ │    ├── update-mapping:
+ │    │    ├── column2:5 => p:2
+ │    │    └── column3:6 => q:3
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk
+ │    └── project
+ │         ├── columns: upsert_pk:10 column1:4!null column2:5!null column3:6!null pk:7 p:8 q:9
+ │         ├── left-join (hash)
+ │         │    ├── columns: column1:4!null column2:5!null column3:6!null pk:7 p:8 q:9
+ │         │    ├── ensure-upsert-distinct-on
+ │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+ │         │    │    ├── grouping columns: column1:4!null
+ │         │    │    ├── values
+ │         │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+ │         │    │    │    ├── (1, 10, 10)
+ │         │    │    │    └── (2, 20, 20)
+ │         │    │    └── aggregations
+ │         │    │         ├── first-agg [as=column2:5]
+ │         │    │         │    └── column2:5
+ │         │    │         └── first-agg [as=column3:6]
+ │         │    │              └── column3:6
+ │         │    ├── scan parent_multi
+ │         │    │    └── columns: pk:7!null p:8 q:9
+ │         │    └── filters
+ │         │         └── column1:4 = pk:7
+ │         └── projections
+ │              └── CASE WHEN pk:7 IS NULL THEN column1:4 ELSE pk:7 END [as=upsert_pk:10]
+ └── cascade
+      ├── update child_multi
+      │    ├── columns: <none>
+      │    ├── fetch columns: c:14 child_multi.p:15 child_multi.q:16
+      │    ├── update-mapping:
+      │    │    ├── p_new:21 => child_multi.p:12
+      │    │    └── q_new:22 => child_multi.q:13
+      │    ├── input binding: &2
+      │    ├── cascades
+      │    │    └── fk2
+      │    ├── project
+      │    │    ├── columns: p_new:21!null q_new:22!null c:14!null child_multi.p:15!null child_multi.q:16!null p:17!null q:18!null column2:19!null column3:20!null
+      │    │    ├── inner-join (hash)
+      │    │    │    ├── columns: c:14!null child_multi.p:15!null child_multi.q:16!null p:17!null q:18!null column2:19!null column3:20!null
+      │    │    │    ├── scan child_multi
+      │    │    │    │    └── columns: c:14!null child_multi.p:15 child_multi.q:16
+      │    │    │    ├── select
+      │    │    │    │    ├── columns: p:17 q:18 column2:19!null column3:20!null
+      │    │    │    │    ├── with-scan &1
+      │    │    │    │    │    ├── columns: p:17 q:18 column2:19!null column3:20!null
+      │    │    │    │    │    └── mapping:
+      │    │    │    │    │         ├──  parent_multi.p:8 => p:17
+      │    │    │    │    │         ├──  parent_multi.q:9 => q:18
+      │    │    │    │    │         ├──  column2:5 => column2:19
+      │    │    │    │    │         └──  column3:6 => column3:20
+      │    │    │    │    └── filters
+      │    │    │    │         └── (p:17 IS DISTINCT FROM column2:19) OR (q:18 IS DISTINCT FROM column3:20)
+      │    │    │    └── filters
+      │    │    │         ├── child_multi.p:15 = p:17
+      │    │    │         └── child_multi.q:16 = q:18
+      │    │    └── projections
+      │    │         ├── 0 [as=p_new:21]
+      │    │         └── 1 [as=q_new:22]
+      │    └── f-k-checks
+      │         └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
+      │              └── anti-join (hash)
+      │                   ├── columns: p_new:23!null q_new:24!null
+      │                   ├── with-scan &2
+      │                   │    ├── columns: p_new:23!null q_new:24!null
+      │                   │    └── mapping:
+      │                   │         ├──  p_new:21 => p_new:23
+      │                   │         └──  q_new:22 => q_new:24
+      │                   ├── scan parent_multi
+      │                   │    └── columns: parent_multi.p:26 parent_multi.q:27
+      │                   └── filters
+      │                        ├── p_new:23 = parent_multi.p:26
+      │                        └── q_new:24 = parent_multi.q:27
+      └── cascade
+           └── update grandchild
+                ├── columns: <none>
+                ├── fetch columns: g:31 grandchild.c:32 grandchild.q:33
+                ├── update-mapping:
+                │    ├── c_new:38 => grandchild.c:29
+                │    └── q_new:39 => grandchild.q:30
+                ├── input binding: &3
+                ├── project
+                │    ├── columns: c_new:38!null q_new:39!null g:31!null grandchild.c:32!null grandchild.q:33!null c:34!null q:35!null c:36!null q_new:37!null
+                │    ├── inner-join (hash)
+                │    │    ├── columns: g:31!null grandchild.c:32!null grandchild.q:33!null c:34!null q:35!null c:36!null q_new:37!null
+                │    │    ├── scan grandchild
+                │    │    │    └── columns: g:31!null grandchild.c:32 grandchild.q:33
+                │    │    ├── select
+                │    │    │    ├── columns: c:34!null q:35!null c:36!null q_new:37!null
+                │    │    │    ├── with-scan &2
+                │    │    │    │    ├── columns: c:34!null q:35!null c:36!null q_new:37!null
+                │    │    │    │    └── mapping:
+                │    │    │    │         ├──  child_multi.c:14 => c:34
+                │    │    │    │         ├──  child_multi.q:16 => q:35
+                │    │    │    │         ├──  child_multi.c:14 => c:36
+                │    │    │    │         └──  q_new:22 => q_new:37
+                │    │    │    └── filters
+                │    │    │         └── (c:34 IS DISTINCT FROM c:36) OR (q:35 IS DISTINCT FROM q_new:37)
+                │    │    └── filters
+                │    │         ├── grandchild.c:32 = c:34
+                │    │         └── grandchild.q:33 = q:35
+                │    └── projections
+                │         ├── 10 [as=c_new:38]
+                │         └── 11 [as=q_new:39]
+                └── f-k-checks
+                     └── f-k-checks-item: grandchild(c,q) -> child_multi(c,q)
+                          └── anti-join (hash)
+                               ├── columns: c_new:40!null q_new:41!null
+                               ├── with-scan &3
+                               │    ├── columns: c_new:40!null q_new:41!null
+                               │    └── mapping:
+                               │         ├──  c_new:38 => c_new:40
+                               │         └──  q_new:39 => q_new:41
+                               ├── scan child_multi
+                               │    └── columns: child_multi.c:42!null child_multi.q:44
+                               └── filters
+                                    ├── c_new:40 = child_multi.c:42
+                                    └── q_new:41 = child_multi.q:44
+
+# Upsert that only touches one of the FK columns.
+build-cascades
+UPSERT INTO parent_multi(pk, p) VALUES (1, 10), (2, 20)
+----
+root
+ ├── upsert parent_multi
+ │    ├── columns: <none>
+ │    ├── canary column: 7
+ │    ├── fetch columns: pk:7 p:8 q:9
+ │    ├── insert-mapping:
+ │    │    ├── column1:4 => pk:1
+ │    │    ├── column2:5 => p:2
+ │    │    └── column6:6 => q:3
+ │    ├── update-mapping:
+ │    │    └── column2:5 => p:2
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk
+ │    └── project
+ │         ├── columns: upsert_pk:10 upsert_q:11 column1:4!null column2:5!null column6:6 pk:7 p:8 q:9
+ │         ├── left-join (hash)
+ │         │    ├── columns: column1:4!null column2:5!null column6:6 pk:7 p:8 q:9
+ │         │    ├── ensure-upsert-distinct-on
+ │         │    │    ├── columns: column1:4!null column2:5!null column6:6
+ │         │    │    ├── grouping columns: column1:4!null
+ │         │    │    ├── project
+ │         │    │    │    ├── columns: column6:6 column1:4!null column2:5!null
+ │         │    │    │    ├── values
+ │         │    │    │    │    ├── columns: column1:4!null column2:5!null
+ │         │    │    │    │    ├── (1, 10)
+ │         │    │    │    │    └── (2, 20)
+ │         │    │    │    └── projections
+ │         │    │    │         └── NULL::INT8 [as=column6:6]
+ │         │    │    └── aggregations
+ │         │    │         ├── first-agg [as=column2:5]
+ │         │    │         │    └── column2:5
+ │         │    │         └── first-agg [as=column6:6]
+ │         │    │              └── column6:6
+ │         │    ├── scan parent_multi
+ │         │    │    └── columns: pk:7!null p:8 q:9
+ │         │    └── filters
+ │         │         └── column1:4 = pk:7
+ │         └── projections
+ │              ├── CASE WHEN pk:7 IS NULL THEN column1:4 ELSE pk:7 END [as=upsert_pk:10]
+ │              └── CASE WHEN pk:7 IS NULL THEN column6:6 ELSE q:9 END [as=upsert_q:11]
+ └── cascade
+      ├── update child_multi
+      │    ├── columns: <none>
+      │    ├── fetch columns: c:15 child_multi.p:16 child_multi.q:17
+      │    ├── update-mapping:
+      │    │    ├── p_new:22 => child_multi.p:13
+      │    │    └── q_new:23 => child_multi.q:14
+      │    ├── input binding: &2
+      │    ├── cascades
+      │    │    └── fk2
+      │    ├── project
+      │    │    ├── columns: p_new:22!null q_new:23!null c:15!null child_multi.p:16!null child_multi.q:17!null p:18!null q:19!null column2:20!null q:21
+      │    │    ├── inner-join (hash)
+      │    │    │    ├── columns: c:15!null child_multi.p:16!null child_multi.q:17!null p:18!null q:19!null column2:20!null q:21
+      │    │    │    ├── scan child_multi
+      │    │    │    │    └── columns: c:15!null child_multi.p:16 child_multi.q:17
+      │    │    │    ├── select
+      │    │    │    │    ├── columns: p:18 q:19 column2:20!null q:21
+      │    │    │    │    ├── with-scan &1
+      │    │    │    │    │    ├── columns: p:18 q:19 column2:20!null q:21
+      │    │    │    │    │    └── mapping:
+      │    │    │    │    │         ├──  parent_multi.p:8 => p:18
+      │    │    │    │    │         ├──  parent_multi.q:9 => q:19
+      │    │    │    │    │         ├──  column2:5 => column2:20
+      │    │    │    │    │         └──  parent_multi.q:9 => q:21
+      │    │    │    │    └── filters
+      │    │    │    │         └── (p:18 IS DISTINCT FROM column2:20) OR (q:19 IS DISTINCT FROM q:21)
+      │    │    │    └── filters
+      │    │    │         ├── child_multi.p:16 = p:18
+      │    │    │         └── child_multi.q:17 = q:19
+      │    │    └── projections
+      │    │         ├── 0 [as=p_new:22]
+      │    │         └── 1 [as=q_new:23]
+      │    └── f-k-checks
+      │         └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
+      │              └── anti-join (hash)
+      │                   ├── columns: p_new:24!null q_new:25!null
+      │                   ├── with-scan &2
+      │                   │    ├── columns: p_new:24!null q_new:25!null
+      │                   │    └── mapping:
+      │                   │         ├──  p_new:22 => p_new:24
+      │                   │         └──  q_new:23 => q_new:25
+      │                   ├── scan parent_multi
+      │                   │    └── columns: parent_multi.p:27 parent_multi.q:28
+      │                   └── filters
+      │                        ├── p_new:24 = parent_multi.p:27
+      │                        └── q_new:25 = parent_multi.q:28
+      └── cascade
+           └── update grandchild
+                ├── columns: <none>
+                ├── fetch columns: g:32 grandchild.c:33 grandchild.q:34
+                ├── update-mapping:
+                │    ├── c_new:39 => grandchild.c:30
+                │    └── q_new:40 => grandchild.q:31
+                ├── input binding: &3
+                ├── project
+                │    ├── columns: c_new:39!null q_new:40!null g:32!null grandchild.c:33!null grandchild.q:34!null c:35!null q:36!null c:37!null q_new:38!null
+                │    ├── inner-join (hash)
+                │    │    ├── columns: g:32!null grandchild.c:33!null grandchild.q:34!null c:35!null q:36!null c:37!null q_new:38!null
+                │    │    ├── scan grandchild
+                │    │    │    └── columns: g:32!null grandchild.c:33 grandchild.q:34
+                │    │    ├── select
+                │    │    │    ├── columns: c:35!null q:36!null c:37!null q_new:38!null
+                │    │    │    ├── with-scan &2
+                │    │    │    │    ├── columns: c:35!null q:36!null c:37!null q_new:38!null
+                │    │    │    │    └── mapping:
+                │    │    │    │         ├──  child_multi.c:15 => c:35
+                │    │    │    │         ├──  child_multi.q:17 => q:36
+                │    │    │    │         ├──  child_multi.c:15 => c:37
+                │    │    │    │         └──  q_new:23 => q_new:38
+                │    │    │    └── filters
+                │    │    │         └── (c:35 IS DISTINCT FROM c:37) OR (q:36 IS DISTINCT FROM q_new:38)
+                │    │    └── filters
+                │    │         ├── grandchild.c:33 = c:35
+                │    │         └── grandchild.q:34 = q:36
+                │    └── projections
+                │         ├── 10 [as=c_new:39]
+                │         └── 11 [as=q_new:40]
+                └── f-k-checks
+                     └── f-k-checks-item: grandchild(c,q) -> child_multi(c,q)
+                          └── anti-join (hash)
+                               ├── columns: c_new:41!null q_new:42!null
+                               ├── with-scan &3
+                               │    ├── columns: c_new:41!null q_new:42!null
+                               │    └── mapping:
+                               │         ├──  c_new:39 => c_new:41
+                               │         └──  q_new:40 => q_new:42
+                               ├── scan child_multi
+                               │    └── columns: child_multi.c:43!null child_multi.q:45
+                               └── filters
+                                    ├── c_new:41 = child_multi.c:43
+                                    └── q_new:42 = child_multi.q:45
+
+build-cascades
+INSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20) ON CONFLICT (p,q) DO UPDATE SET p = 100
+----
+root
+ ├── upsert parent_multi
+ │    ├── columns: <none>
+ │    ├── canary column: 7
+ │    ├── fetch columns: pk:7 p:8 q:9
+ │    ├── insert-mapping:
+ │    │    ├── column1:4 => pk:1
+ │    │    ├── column2:5 => p:2
+ │    │    └── column3:6 => q:3
+ │    ├── update-mapping:
+ │    │    └── upsert_p:12 => p:2
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk
+ │    └── project
+ │         ├── columns: upsert_pk:11 upsert_p:12!null upsert_q:13 column1:4!null column2:5!null column3:6!null pk:7 p:8 q:9 p_new:10!null
+ │         ├── project
+ │         │    ├── columns: p_new:10!null column1:4!null column2:5!null column3:6!null pk:7 p:8 q:9
+ │         │    ├── left-join (hash)
+ │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null pk:7 p:8 q:9
+ │         │    │    ├── ensure-upsert-distinct-on
+ │         │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+ │         │    │    │    ├── grouping columns: column2:5!null column3:6!null
+ │         │    │    │    ├── values
+ │         │    │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+ │         │    │    │    │    ├── (1, 10, 10)
+ │         │    │    │    │    └── (2, 20, 20)
+ │         │    │    │    └── aggregations
+ │         │    │    │         └── first-agg [as=column1:4]
+ │         │    │    │              └── column1:4
+ │         │    │    ├── scan parent_multi
+ │         │    │    │    └── columns: pk:7!null p:8 q:9
+ │         │    │    └── filters
+ │         │    │         ├── column2:5 = p:8
+ │         │    │         └── column3:6 = q:9
+ │         │    └── projections
+ │         │         └── 100 [as=p_new:10]
+ │         └── projections
+ │              ├── CASE WHEN pk:7 IS NULL THEN column1:4 ELSE pk:7 END [as=upsert_pk:11]
+ │              ├── CASE WHEN pk:7 IS NULL THEN column2:5 ELSE p_new:10 END [as=upsert_p:12]
+ │              └── CASE WHEN pk:7 IS NULL THEN column3:6 ELSE q:9 END [as=upsert_q:13]
+ └── cascade
+      ├── update child_multi
+      │    ├── columns: <none>
+      │    ├── fetch columns: c:17 child_multi.p:18 child_multi.q:19
+      │    ├── update-mapping:
+      │    │    ├── p_new:24 => child_multi.p:15
+      │    │    └── q_new:25 => child_multi.q:16
+      │    ├── input binding: &2
+      │    ├── cascades
+      │    │    └── fk2
+      │    ├── project
+      │    │    ├── columns: p_new:24!null q_new:25!null c:17!null child_multi.p:18!null child_multi.q:19!null p:20!null q:21!null upsert_p:22!null q:23
+      │    │    ├── inner-join (hash)
+      │    │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p:20!null q:21!null upsert_p:22!null q:23
+      │    │    │    ├── scan child_multi
+      │    │    │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19
+      │    │    │    ├── select
+      │    │    │    │    ├── columns: p:20 q:21 upsert_p:22!null q:23
+      │    │    │    │    ├── with-scan &1
+      │    │    │    │    │    ├── columns: p:20 q:21 upsert_p:22!null q:23
+      │    │    │    │    │    └── mapping:
+      │    │    │    │    │         ├──  parent_multi.p:8 => p:20
+      │    │    │    │    │         ├──  parent_multi.q:9 => q:21
+      │    │    │    │    │         ├──  upsert_p:12 => upsert_p:22
+      │    │    │    │    │         └──  parent_multi.q:9 => q:23
+      │    │    │    │    └── filters
+      │    │    │    │         └── (p:20 IS DISTINCT FROM upsert_p:22) OR (q:21 IS DISTINCT FROM q:23)
+      │    │    │    └── filters
+      │    │    │         ├── child_multi.p:18 = p:20
+      │    │    │         └── child_multi.q:19 = q:21
+      │    │    └── projections
+      │    │         ├── 0 [as=p_new:24]
+      │    │         └── 1 [as=q_new:25]
+      │    └── f-k-checks
+      │         └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
+      │              └── anti-join (hash)
+      │                   ├── columns: p_new:26!null q_new:27!null
+      │                   ├── with-scan &2
+      │                   │    ├── columns: p_new:26!null q_new:27!null
+      │                   │    └── mapping:
+      │                   │         ├──  p_new:24 => p_new:26
+      │                   │         └──  q_new:25 => q_new:27
+      │                   ├── scan parent_multi
+      │                   │    └── columns: parent_multi.p:29 parent_multi.q:30
+      │                   └── filters
+      │                        ├── p_new:26 = parent_multi.p:29
+      │                        └── q_new:27 = parent_multi.q:30
+      └── cascade
+           └── update grandchild
+                ├── columns: <none>
+                ├── fetch columns: g:34 grandchild.c:35 grandchild.q:36
+                ├── update-mapping:
+                │    ├── c_new:41 => grandchild.c:32
+                │    └── q_new:42 => grandchild.q:33
+                ├── input binding: &3
+                ├── project
+                │    ├── columns: c_new:41!null q_new:42!null g:34!null grandchild.c:35!null grandchild.q:36!null c:37!null q:38!null c:39!null q_new:40!null
+                │    ├── inner-join (hash)
+                │    │    ├── columns: g:34!null grandchild.c:35!null grandchild.q:36!null c:37!null q:38!null c:39!null q_new:40!null
+                │    │    ├── scan grandchild
+                │    │    │    └── columns: g:34!null grandchild.c:35 grandchild.q:36
+                │    │    ├── select
+                │    │    │    ├── columns: c:37!null q:38!null c:39!null q_new:40!null
+                │    │    │    ├── with-scan &2
+                │    │    │    │    ├── columns: c:37!null q:38!null c:39!null q_new:40!null
+                │    │    │    │    └── mapping:
+                │    │    │    │         ├──  child_multi.c:17 => c:37
+                │    │    │    │         ├──  child_multi.q:19 => q:38
+                │    │    │    │         ├──  child_multi.c:17 => c:39
+                │    │    │    │         └──  q_new:25 => q_new:40
+                │    │    │    └── filters
+                │    │    │         └── (c:37 IS DISTINCT FROM c:39) OR (q:38 IS DISTINCT FROM q_new:40)
+                │    │    └── filters
+                │    │         ├── grandchild.c:35 = c:37
+                │    │         └── grandchild.q:36 = q:38
+                │    └── projections
+                │         ├── 10 [as=c_new:41]
+                │         └── 11 [as=q_new:42]
+                └── f-k-checks
+                     └── f-k-checks-item: grandchild(c,q) -> child_multi(c,q)
+                          └── anti-join (hash)
+                               ├── columns: c_new:43!null q_new:44!null
+                               ├── with-scan &3
+                               │    ├── columns: c_new:43!null q_new:44!null
+                               │    └── mapping:
+                               │         ├──  c_new:41 => c_new:43
+                               │         └──  q_new:42 => q_new:44
+                               ├── scan child_multi
+                               │    └── columns: child_multi.c:45!null child_multi.q:47
+                               └── filters
+                                    ├── c_new:43 = child_multi.c:45
+                                    └── q_new:44 = child_multi.q:47

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
@@ -273,3 +273,318 @@ root
                      │         └── grandchild.q:24 = q:26
                      └── projections
                           └── NULL::INT8 [as=c_new:29]
+
+build-cascades
+UPSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20)
+----
+root
+ ├── upsert parent_multi
+ │    ├── columns: <none>
+ │    ├── canary column: 7
+ │    ├── fetch columns: pk:7 p:8 q:9
+ │    ├── insert-mapping:
+ │    │    ├── column1:4 => pk:1
+ │    │    ├── column2:5 => p:2
+ │    │    └── column3:6 => q:3
+ │    ├── update-mapping:
+ │    │    ├── column2:5 => p:2
+ │    │    └── column3:6 => q:3
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk
+ │    └── project
+ │         ├── columns: upsert_pk:10 column1:4!null column2:5!null column3:6!null pk:7 p:8 q:9
+ │         ├── left-join (hash)
+ │         │    ├── columns: column1:4!null column2:5!null column3:6!null pk:7 p:8 q:9
+ │         │    ├── ensure-upsert-distinct-on
+ │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+ │         │    │    ├── grouping columns: column1:4!null
+ │         │    │    ├── values
+ │         │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+ │         │    │    │    ├── (1, 10, 10)
+ │         │    │    │    └── (2, 20, 20)
+ │         │    │    └── aggregations
+ │         │    │         ├── first-agg [as=column2:5]
+ │         │    │         │    └── column2:5
+ │         │    │         └── first-agg [as=column3:6]
+ │         │    │              └── column3:6
+ │         │    ├── scan parent_multi
+ │         │    │    └── columns: pk:7!null p:8 q:9
+ │         │    └── filters
+ │         │         └── column1:4 = pk:7
+ │         └── projections
+ │              └── CASE WHEN pk:7 IS NULL THEN column1:4 ELSE pk:7 END [as=upsert_pk:10]
+ └── cascade
+      ├── update child_multi
+      │    ├── columns: <none>
+      │    ├── fetch columns: c:14 child_multi.p:15 child_multi.q:16
+      │    ├── update-mapping:
+      │    │    ├── p_new:21 => child_multi.p:12
+      │    │    └── p_new:21 => child_multi.q:13
+      │    ├── input binding: &2
+      │    ├── cascades
+      │    │    └── fk2
+      │    └── project
+      │         ├── columns: p_new:21 c:14!null child_multi.p:15!null child_multi.q:16!null p:17!null q:18!null column2:19!null column3:20!null
+      │         ├── inner-join (hash)
+      │         │    ├── columns: c:14!null child_multi.p:15!null child_multi.q:16!null p:17!null q:18!null column2:19!null column3:20!null
+      │         │    ├── scan child_multi
+      │         │    │    └── columns: c:14!null child_multi.p:15 child_multi.q:16
+      │         │    ├── select
+      │         │    │    ├── columns: p:17 q:18 column2:19!null column3:20!null
+      │         │    │    ├── with-scan &1
+      │         │    │    │    ├── columns: p:17 q:18 column2:19!null column3:20!null
+      │         │    │    │    └── mapping:
+      │         │    │    │         ├──  parent_multi.p:8 => p:17
+      │         │    │    │         ├──  parent_multi.q:9 => q:18
+      │         │    │    │         ├──  column2:5 => column2:19
+      │         │    │    │         └──  column3:6 => column3:20
+      │         │    │    └── filters
+      │         │    │         └── (p:17 IS DISTINCT FROM column2:19) OR (q:18 IS DISTINCT FROM column3:20)
+      │         │    └── filters
+      │         │         ├── child_multi.p:15 = p:17
+      │         │         └── child_multi.q:16 = q:18
+      │         └── projections
+      │              └── NULL::INT8 [as=p_new:21]
+      └── cascade
+           └── update grandchild
+                ├── columns: <none>
+                ├── fetch columns: g:25 grandchild.c:26 grandchild.q:27
+                ├── update-mapping:
+                │    ├── c_new:32 => grandchild.c:23
+                │    └── c_new:32 => grandchild.q:24
+                └── project
+                     ├── columns: c_new:32 g:25!null grandchild.c:26!null grandchild.q:27!null c:28!null q:29!null c:30!null p_new:31
+                     ├── inner-join (hash)
+                     │    ├── columns: g:25!null grandchild.c:26!null grandchild.q:27!null c:28!null q:29!null c:30!null p_new:31
+                     │    ├── scan grandchild
+                     │    │    └── columns: g:25!null grandchild.c:26 grandchild.q:27
+                     │    ├── select
+                     │    │    ├── columns: c:28!null q:29!null c:30!null p_new:31
+                     │    │    ├── with-scan &2
+                     │    │    │    ├── columns: c:28!null q:29!null c:30!null p_new:31
+                     │    │    │    └── mapping:
+                     │    │    │         ├──  child_multi.c:14 => c:28
+                     │    │    │         ├──  child_multi.q:16 => q:29
+                     │    │    │         ├──  child_multi.c:14 => c:30
+                     │    │    │         └──  p_new:21 => p_new:31
+                     │    │    └── filters
+                     │    │         └── (c:28 IS DISTINCT FROM c:30) OR (q:29 IS DISTINCT FROM p_new:31)
+                     │    └── filters
+                     │         ├── grandchild.c:26 = c:28
+                     │         └── grandchild.q:27 = q:29
+                     └── projections
+                          └── NULL::INT8 [as=c_new:32]
+
+# Upsert that only touches one of the FK columns.
+build-cascades
+UPSERT INTO parent_multi(pk, p) VALUES (1, 10), (2, 20)
+----
+root
+ ├── upsert parent_multi
+ │    ├── columns: <none>
+ │    ├── canary column: 7
+ │    ├── fetch columns: pk:7 p:8 q:9
+ │    ├── insert-mapping:
+ │    │    ├── column1:4 => pk:1
+ │    │    ├── column2:5 => p:2
+ │    │    └── column6:6 => q:3
+ │    ├── update-mapping:
+ │    │    └── column2:5 => p:2
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk
+ │    └── project
+ │         ├── columns: upsert_pk:10 upsert_q:11 column1:4!null column2:5!null column6:6 pk:7 p:8 q:9
+ │         ├── left-join (hash)
+ │         │    ├── columns: column1:4!null column2:5!null column6:6 pk:7 p:8 q:9
+ │         │    ├── ensure-upsert-distinct-on
+ │         │    │    ├── columns: column1:4!null column2:5!null column6:6
+ │         │    │    ├── grouping columns: column1:4!null
+ │         │    │    ├── project
+ │         │    │    │    ├── columns: column6:6 column1:4!null column2:5!null
+ │         │    │    │    ├── values
+ │         │    │    │    │    ├── columns: column1:4!null column2:5!null
+ │         │    │    │    │    ├── (1, 10)
+ │         │    │    │    │    └── (2, 20)
+ │         │    │    │    └── projections
+ │         │    │    │         └── NULL::INT8 [as=column6:6]
+ │         │    │    └── aggregations
+ │         │    │         ├── first-agg [as=column2:5]
+ │         │    │         │    └── column2:5
+ │         │    │         └── first-agg [as=column6:6]
+ │         │    │              └── column6:6
+ │         │    ├── scan parent_multi
+ │         │    │    └── columns: pk:7!null p:8 q:9
+ │         │    └── filters
+ │         │         └── column1:4 = pk:7
+ │         └── projections
+ │              ├── CASE WHEN pk:7 IS NULL THEN column1:4 ELSE pk:7 END [as=upsert_pk:10]
+ │              └── CASE WHEN pk:7 IS NULL THEN column6:6 ELSE q:9 END [as=upsert_q:11]
+ └── cascade
+      ├── update child_multi
+      │    ├── columns: <none>
+      │    ├── fetch columns: c:15 child_multi.p:16 child_multi.q:17
+      │    ├── update-mapping:
+      │    │    ├── p_new:22 => child_multi.p:13
+      │    │    └── p_new:22 => child_multi.q:14
+      │    ├── input binding: &2
+      │    ├── cascades
+      │    │    └── fk2
+      │    └── project
+      │         ├── columns: p_new:22 c:15!null child_multi.p:16!null child_multi.q:17!null p:18!null q:19!null column2:20!null q:21
+      │         ├── inner-join (hash)
+      │         │    ├── columns: c:15!null child_multi.p:16!null child_multi.q:17!null p:18!null q:19!null column2:20!null q:21
+      │         │    ├── scan child_multi
+      │         │    │    └── columns: c:15!null child_multi.p:16 child_multi.q:17
+      │         │    ├── select
+      │         │    │    ├── columns: p:18 q:19 column2:20!null q:21
+      │         │    │    ├── with-scan &1
+      │         │    │    │    ├── columns: p:18 q:19 column2:20!null q:21
+      │         │    │    │    └── mapping:
+      │         │    │    │         ├──  parent_multi.p:8 => p:18
+      │         │    │    │         ├──  parent_multi.q:9 => q:19
+      │         │    │    │         ├──  column2:5 => column2:20
+      │         │    │    │         └──  parent_multi.q:9 => q:21
+      │         │    │    └── filters
+      │         │    │         └── (p:18 IS DISTINCT FROM column2:20) OR (q:19 IS DISTINCT FROM q:21)
+      │         │    └── filters
+      │         │         ├── child_multi.p:16 = p:18
+      │         │         └── child_multi.q:17 = q:19
+      │         └── projections
+      │              └── NULL::INT8 [as=p_new:22]
+      └── cascade
+           └── update grandchild
+                ├── columns: <none>
+                ├── fetch columns: g:26 grandchild.c:27 grandchild.q:28
+                ├── update-mapping:
+                │    ├── c_new:33 => grandchild.c:24
+                │    └── c_new:33 => grandchild.q:25
+                └── project
+                     ├── columns: c_new:33 g:26!null grandchild.c:27!null grandchild.q:28!null c:29!null q:30!null c:31!null p_new:32
+                     ├── inner-join (hash)
+                     │    ├── columns: g:26!null grandchild.c:27!null grandchild.q:28!null c:29!null q:30!null c:31!null p_new:32
+                     │    ├── scan grandchild
+                     │    │    └── columns: g:26!null grandchild.c:27 grandchild.q:28
+                     │    ├── select
+                     │    │    ├── columns: c:29!null q:30!null c:31!null p_new:32
+                     │    │    ├── with-scan &2
+                     │    │    │    ├── columns: c:29!null q:30!null c:31!null p_new:32
+                     │    │    │    └── mapping:
+                     │    │    │         ├──  child_multi.c:15 => c:29
+                     │    │    │         ├──  child_multi.q:17 => q:30
+                     │    │    │         ├──  child_multi.c:15 => c:31
+                     │    │    │         └──  p_new:22 => p_new:32
+                     │    │    └── filters
+                     │    │         └── (c:29 IS DISTINCT FROM c:31) OR (q:30 IS DISTINCT FROM p_new:32)
+                     │    └── filters
+                     │         ├── grandchild.c:27 = c:29
+                     │         └── grandchild.q:28 = q:30
+                     └── projections
+                          └── NULL::INT8 [as=c_new:33]
+
+build-cascades
+INSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20) ON CONFLICT (p,q) DO UPDATE SET p = 100
+----
+root
+ ├── upsert parent_multi
+ │    ├── columns: <none>
+ │    ├── canary column: 7
+ │    ├── fetch columns: pk:7 p:8 q:9
+ │    ├── insert-mapping:
+ │    │    ├── column1:4 => pk:1
+ │    │    ├── column2:5 => p:2
+ │    │    └── column3:6 => q:3
+ │    ├── update-mapping:
+ │    │    └── upsert_p:12 => p:2
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk
+ │    └── project
+ │         ├── columns: upsert_pk:11 upsert_p:12!null upsert_q:13 column1:4!null column2:5!null column3:6!null pk:7 p:8 q:9 p_new:10!null
+ │         ├── project
+ │         │    ├── columns: p_new:10!null column1:4!null column2:5!null column3:6!null pk:7 p:8 q:9
+ │         │    ├── left-join (hash)
+ │         │    │    ├── columns: column1:4!null column2:5!null column3:6!null pk:7 p:8 q:9
+ │         │    │    ├── ensure-upsert-distinct-on
+ │         │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+ │         │    │    │    ├── grouping columns: column2:5!null column3:6!null
+ │         │    │    │    ├── values
+ │         │    │    │    │    ├── columns: column1:4!null column2:5!null column3:6!null
+ │         │    │    │    │    ├── (1, 10, 10)
+ │         │    │    │    │    └── (2, 20, 20)
+ │         │    │    │    └── aggregations
+ │         │    │    │         └── first-agg [as=column1:4]
+ │         │    │    │              └── column1:4
+ │         │    │    ├── scan parent_multi
+ │         │    │    │    └── columns: pk:7!null p:8 q:9
+ │         │    │    └── filters
+ │         │    │         ├── column2:5 = p:8
+ │         │    │         └── column3:6 = q:9
+ │         │    └── projections
+ │         │         └── 100 [as=p_new:10]
+ │         └── projections
+ │              ├── CASE WHEN pk:7 IS NULL THEN column1:4 ELSE pk:7 END [as=upsert_pk:11]
+ │              ├── CASE WHEN pk:7 IS NULL THEN column2:5 ELSE p_new:10 END [as=upsert_p:12]
+ │              └── CASE WHEN pk:7 IS NULL THEN column3:6 ELSE q:9 END [as=upsert_q:13]
+ └── cascade
+      ├── update child_multi
+      │    ├── columns: <none>
+      │    ├── fetch columns: c:17 child_multi.p:18 child_multi.q:19
+      │    ├── update-mapping:
+      │    │    ├── p_new:24 => child_multi.p:15
+      │    │    └── p_new:24 => child_multi.q:16
+      │    ├── input binding: &2
+      │    ├── cascades
+      │    │    └── fk2
+      │    └── project
+      │         ├── columns: p_new:24 c:17!null child_multi.p:18!null child_multi.q:19!null p:20!null q:21!null upsert_p:22!null q:23
+      │         ├── inner-join (hash)
+      │         │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p:20!null q:21!null upsert_p:22!null q:23
+      │         │    ├── scan child_multi
+      │         │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19
+      │         │    ├── select
+      │         │    │    ├── columns: p:20 q:21 upsert_p:22!null q:23
+      │         │    │    ├── with-scan &1
+      │         │    │    │    ├── columns: p:20 q:21 upsert_p:22!null q:23
+      │         │    │    │    └── mapping:
+      │         │    │    │         ├──  parent_multi.p:8 => p:20
+      │         │    │    │         ├──  parent_multi.q:9 => q:21
+      │         │    │    │         ├──  upsert_p:12 => upsert_p:22
+      │         │    │    │         └──  parent_multi.q:9 => q:23
+      │         │    │    └── filters
+      │         │    │         └── (p:20 IS DISTINCT FROM upsert_p:22) OR (q:21 IS DISTINCT FROM q:23)
+      │         │    └── filters
+      │         │         ├── child_multi.p:18 = p:20
+      │         │         └── child_multi.q:19 = q:21
+      │         └── projections
+      │              └── NULL::INT8 [as=p_new:24]
+      └── cascade
+           └── update grandchild
+                ├── columns: <none>
+                ├── fetch columns: g:28 grandchild.c:29 grandchild.q:30
+                ├── update-mapping:
+                │    ├── c_new:35 => grandchild.c:26
+                │    └── c_new:35 => grandchild.q:27
+                └── project
+                     ├── columns: c_new:35 g:28!null grandchild.c:29!null grandchild.q:30!null c:31!null q:32!null c:33!null p_new:34
+                     ├── inner-join (hash)
+                     │    ├── columns: g:28!null grandchild.c:29!null grandchild.q:30!null c:31!null q:32!null c:33!null p_new:34
+                     │    ├── scan grandchild
+                     │    │    └── columns: g:28!null grandchild.c:29 grandchild.q:30
+                     │    ├── select
+                     │    │    ├── columns: c:31!null q:32!null c:33!null p_new:34
+                     │    │    ├── with-scan &2
+                     │    │    │    ├── columns: c:31!null q:32!null c:33!null p_new:34
+                     │    │    │    └── mapping:
+                     │    │    │         ├──  child_multi.c:17 => c:31
+                     │    │    │         ├──  child_multi.q:19 => q:32
+                     │    │    │         ├──  child_multi.c:17 => c:33
+                     │    │    │         └──  p_new:24 => p_new:34
+                     │    │    └── filters
+                     │    │         └── (c:31 IS DISTINCT FROM c:33) OR (q:32 IS DISTINCT FROM p_new:34)
+                     │    └── filters
+                     │         ├── grandchild.c:29 = c:31
+                     │         └── grandchild.q:30 = q:32
+                     └── projections
+                          └── NULL::INT8 [as=c_new:35]


### PR DESCRIPTION
This change implements ON UPDATE actions for Upsert operations. The existing
machinery for Update can be used without modification.

Release note: None