### PR TITLE
kvserver: TestReplicateQueueDownReplicate

### DIFF
--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -753,6 +753,7 @@ func (tc *TestCluster) findMemberStore(storeID roachpb.StoreID) (*kvserver.Store
 // TODO(andrei): This method takes inexplicably long.
 // I think it shouldn't need any retries. See #38565.
 func (tc *TestCluster) WaitForFullReplication() error {
+	log.Infof(context.TODO(), "WaitForFullReplication")
 	start := timeutil.Now()
 	defer func() {
 		end := timeutil.Now()
@@ -872,6 +873,17 @@ func (tc *TestCluster) WaitForNodeLiveness(t testing.TB) {
 // ReplicationMode implements TestClusterInterface.
 func (tc *TestCluster) ReplicationMode() base.TestClusterReplicationMode {
 	return tc.replicationMode
+}
+
+// ToggleReplicateQueues activates or deactivates the replication queues on all
+// the stores on all the nodes.
+func (tc *TestCluster) ToggleReplicateQueues(active bool) {
+	for _, s := range tc.Servers {
+		_ = s.Stores().VisitStores(func(store *kvserver.Store) error {
+			store.SetReplicateQueueActive(active)
+			return nil
+		})
+	}
 }
 
 type testClusterFactoryImpl struct{}


### PR DESCRIPTION
This test was trying to upreplicate a range and then wait for the
replication queue to downreplicate it. The test had rotted back when we
switched the replication factor of system ranges from 3x to 5x; with
5x replication, the range started off as having 5 replicas so the
upreplication step was unnecessary. Worse, the upreplication part was
flaky, presumably because it was constantly racing with the replication
queue trying to downreplicate the range (although I couldn't repro
despite a lot of stress).

Fixes #48284

Release note: None