### PR TITLE
sql: handle tuples with nulls for IN operator 

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -389,6 +389,13 @@ SELECT 1 IN (NULL, 2)
 ----
 NULL
 
+# Note: The desired behavior here differs from the desired behavior of
+# NULL IN <subquery> as tested below.
+query B
+SELECT NULL IN ((1, 1))
+----
+NULL
+
 query B
 SELECT (1, NULL) IN ((1, 1))
 ----
@@ -398,6 +405,23 @@ query B
 SELECT (2, NULL) IN ((1, 1))
 ----
 false
+
+query error unsupported comparison operator: .* expected 1 to be of type tuple, found type int
+SELECT () IN (1,2)
+
+query error unsupported comparison operator: .* expected tuple \(1, 2\) to have a length of 0
+SELECT () IN ((1,2))
+
+query B
+SELECT () IN (());
+----
+true
+
+query error unsupported comparison operator: .* could not parse "string" as type int
+SELECT ('string', NULL) IN ((1, 1))
+
+query error unsupported comparison operator: .* expected tuple \(1, 1\) to have a length of 3
+SELECT (2, 'string', NULL) IN ((1, 1))
 
 query B
 SELECT (1, 1) IN ((1, NULL))
@@ -419,6 +443,21 @@ query B
 SELECT (1, NULL) IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
 ----
 NULL
+
+query error unsupported comparison operator: <unknown> IN <tuple{tuple{int AS a, int AS b}}>
+SELECT NULL IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b));
+
+query error unsupported comparison operator: <tuple> IN <tuple{int}>
+SELECT () IN (SELECT * FROM (VALUES (1)) AS t(a))
+
+query error unsupported comparison operator: <tuple> IN <tuple{tuple{int AS a, int AS b}}>
+SELECT () IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
+
+query error unsupported comparison operator: <tuple{string, unknown}> IN <tuple{tuple{int AS a, int AS b}}>
+SELECT ('string', NULL) IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
+
+query error unsupported comparison operator: <tuple{int, string, unknown}> IN <tuple{tuple{int AS a, int AS b}}>
+SELECT (2, 'string', NULL) IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
 
 query B
 SELECT (2, NULL) IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
@@ -444,6 +483,21 @@ query B
 SELECT NULL NOT IN (SELECT * FROM (VALUES (1)) AS t(a))
 ----
 NULL
+
+query error unsupported comparison operator: <unknown> IN <tuple{tuple{int AS a, int AS b}}>
+SELECT NULL NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
+
+query error unsupported comparison operator: <tuple> IN <tuple{int}>
+SELECT () NOT IN (SELECT * FROM (VALUES (1)) AS t(a))
+
+query error unsupported comparison operator: <tuple> IN <tuple{tuple{int AS a, int AS b}}>
+SELECT () NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
+
+query error unsupported comparison operator: <tuple{string, unknown}> IN <tuple{tuple{int AS a, int AS b}}>
+SELECT ('string', NULL) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
+
+query error unsupported comparison operator: <tuple{int, string, unknown}> IN <tuple{tuple{int AS a, int AS b}}>
+SELECT (2, 'string', NULL) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
 
 query B
 SELECT (1, NULL) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1846,31 +1846,12 @@ func typeCheckSubqueryWithIn(left, right *types.T) error {
 			return pgerror.Newf(pgcode.InvalidParameterValue,
 				unsupportedCompErrFmt, fmt.Sprintf(compSignatureFmt, left, In, right))
 		}
-		// If the left type is NULL or is a tuple containing NULLS, then it won't
-		// be equivalent to the right type, but should pass type-checking.
-		if hasUnknownFamily(left) {
-			return nil
-		}
-		if !left.Equivalent(right.TupleContents()[0]) {
+		if !left.EquivalentOrNull(right.TupleContents()[0]) {
 			return pgerror.Newf(pgcode.InvalidParameterValue,
 				unsupportedCompErrFmt, fmt.Sprintf(compSignatureFmt, left, In, right))
 		}
 	}
 	return nil
-}
-
-func hasUnknownFamily(t *types.T) bool {
-	if t.Family() == types.UnknownFamily {
-		return true
-	}
-	if t.Family() == types.TupleFamily {
-		for _, tc := range t.TupleContents() {
-			if hasUnknownFamily(tc) {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func typeCheckComparisonOp(


### PR DESCRIPTION
A previous change had allowed any query of the form <left> IN <subquery>
to typecheck as long as <left> is NULL or a tuple containing any NULLS.

This erroneously allowed something like `('s', NULL) IN (1, 2)` to
typecheck. Now, this is fixed, by making sure all the non-null tuple
elements have the same type.

A release note is omitted as this fixes a bug that is only present in
non-published versions of CockroachDB.

See #49723 and https://github.com/cockroachdb/cockroach/pull/49767#pullrequestreview-422136291

Release note: None