### PR TITLE
roachpb: refuse nil desc in NewRangeKeyMismatchError

### DIFF
--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -169,7 +169,7 @@ func (db *testSender) Send(
 	}
 	repl := db.store.LookupReplica(rs.Key)
 	if repl == nil || !repl.Desc().ContainsKeyRange(rs.Key, rs.EndKey) {
-		return nil, roachpb.NewError(roachpb.NewRangeKeyMismatchError(rs.Key.AsRawKey(), rs.EndKey.AsRawKey(), nil))
+		panic(fmt.Sprintf("didn't find right replica for key: %s", rs.Key))
 	}
 	ba.RangeID = repl.RangeID
 	repDesc, err := repl.GetReplicaDescriptor()

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -382,9 +382,12 @@ var _ ErrorDetailInterface = &RangeNotFoundError{}
 
 // NewRangeKeyMismatchError initializes a new RangeKeyMismatchError.
 func NewRangeKeyMismatchError(start, end Key, desc *RangeDescriptor) *RangeKeyMismatchError {
-	if desc != nil && !desc.IsInitialized() {
-		// We must never send uninitialized ranges back to the client (nil
-		// is fine) guard against regressions of #6027.
+	if desc == nil {
+		panic("NewRangeKeyMismatchError with nil descriptor")
+	}
+	if !desc.IsInitialized() {
+		// We must never send uninitialized ranges back to the client guard against
+		// regressions of #6027.
 		panic(fmt.Sprintf("descriptor is not initialized: %+v", desc))
 	}
 	return &RangeKeyMismatchError{


### PR DESCRIPTION
Since recently RangeKeyMismatchError does not support nil descriptors,
but it still had code that pretended to deal with nils (even though a
nil would have exploded a bit later). Only one test caller was passing a
nil, and it turns out that was dead code.

Release note: None