### PR TITLE
Use faster set for column IDs in schemaexpr

### DIFF
--- a/pkg/sql/schemaexpr/column.go
+++ b/pkg/sql/schemaexpr/column.go
@@ -60,46 +60,6 @@ func DequalifyColumnRefs(
 	)
 }
 
-// iterColDescriptors iterates over the expression's variable columns and
-// calls f on each.
-//
-// If the expression references a column that does not exist in the table
-// descriptor, iterColDescriptors errs with pgcode.UndefinedColumn.
-func iterColDescriptors(
-	desc *sqlbase.MutableTableDescriptor, rootExpr tree.Expr, f func(*sqlbase.ColumnDescriptor) error,
-) error {
-	_, err := tree.SimpleVisit(rootExpr, func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
-		vBase, ok := expr.(tree.VarName)
-		if !ok {
-			// Not a VarName, don't do anything to this node.
-			return true, expr, nil
-		}
-
-		v, err := vBase.NormalizeVarName()
-		if err != nil {
-			return false, nil, err
-		}
-
-		c, ok := v.(*tree.ColumnItem)
-		if !ok {
-			return true, expr, nil
-		}
-
-		col, dropped, err := desc.FindColumnByName(c.ColumnName)
-		if err != nil || dropped {
-			return false, nil, pgerror.Newf(pgcode.UndefinedColumn,
-				"column %q does not exist, referenced in %q", c.ColumnName, rootExpr.String())
-		}
-
-		if err := f(col); err != nil {
-			return false, nil, err
-		}
-		return false, expr, err
-	})
-
-	return err
-}
-
 // DeserializeTableDescExpr takes in a serialized expression and a table, and
 // returns an expression that has all user defined types resolved for
 // formatting. It is intended to be used when displaying a serialized
@@ -116,7 +76,7 @@ func DeserializeTableDescExpr(
 	if err != nil {
 		return nil, err
 	}
-	expr, _, err = desc.ReplaceColumnVarsInExprWithDummies(expr)
+	expr, _, err = replaceVars(desc, expr)
 	if err != nil {
 		return nil, err
 	}
@@ -162,4 +122,128 @@ func FormatColumnForDisplay(
 		f.WriteString(") STORED")
 	}
 	return f.CloseAndGetString(), nil
+}
+
+// iterColDescriptors iterates over the expression's variable columns and
+// calls f on each.
+//
+// If the expression references a column that does not exist in the table
+// descriptor, iterColDescriptors errs with pgcode.UndefinedColumn.
+func iterColDescriptors(
+	desc *sqlbase.MutableTableDescriptor, rootExpr tree.Expr, f func(*sqlbase.ColumnDescriptor) error,
+) error {
+	_, err := tree.SimpleVisit(rootExpr, func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+		vBase, ok := expr.(tree.VarName)
+		if !ok {
+			// Not a VarName, don't do anything to this node.
+			return true, expr, nil
+		}
+
+		v, err := vBase.NormalizeVarName()
+		if err != nil {
+			return false, nil, err
+		}
+
+		c, ok := v.(*tree.ColumnItem)
+		if !ok {
+			return true, expr, nil
+		}
+
+		col, dropped, err := desc.FindColumnByName(c.ColumnName)
+		if err != nil || dropped {
+			return false, nil, pgerror.Newf(pgcode.UndefinedColumn,
+				"column %q does not exist, referenced in %q", c.ColumnName, rootExpr.String())
+		}
+
+		if err := f(col); err != nil {
+			return false, nil, err
+		}
+		return false, expr, err
+	})
+
+	return err
+}
+
+// dummyColumn represents a variable column that can type-checked. It is used
+// in validating check constraint and partial index predicate expressions. This
+// validation requires that the expression can be both both typed-checked and
+// examined for variable expressions.
+type dummyColumn struct {
+	typ  *types.T
+	name tree.Name
+}
+
+// String implements the Stringer interface.
+func (d *dummyColumn) String() string {
+	return tree.AsString(d)
+}
+
+// Format implements the NodeFormatter interface.
+func (d *dummyColumn) Format(ctx *tree.FmtCtx) {
+	d.name.Format(ctx)
+}
+
+// Walk implements the Expr interface.
+func (d *dummyColumn) Walk(_ tree.Visitor) tree.Expr {
+	return d
+}
+
+// TypeCheck implements the Expr interface.
+func (d *dummyColumn) TypeCheck(
+	_ context.Context, _ *tree.SemaContext, desired *types.T,
+) (tree.TypedExpr, error) {
+	return d, nil
+}
+
+// Eval implements the TypedExpr interface.
+func (*dummyColumn) Eval(_ *tree.EvalContext) (tree.Datum, error) {
+	panic("dummyColumnItem.Eval() is undefined")
+}
+
+// ResolvedType implements the TypedExpr interface.
+func (d *dummyColumn) ResolvedType() *types.T {
+	return d.typ
+}
+
+// replaceVars replaces the occurrences of column names in an expression with
+// dummyColumns containing their type, so that they may be type-checked. It
+// returns this new expression tree alongside a set containing the ColumnID of
+// each column seen in the expression.
+//
+// If the expression references a column that does not exist in the table
+// descriptor, replaceVars errs with pgcode.UndefinedColumn.
+func replaceVars(
+	desc *sqlbase.TableDescriptor, rootExpr tree.Expr,
+) (tree.Expr, sqlbase.TableColSet, error) {
+	var colIDs sqlbase.TableColSet
+
+	newExpr, err := tree.SimpleVisit(rootExpr, func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+		vBase, ok := expr.(tree.VarName)
+		if !ok {
+			// Not a VarName, don't do anything to this node.
+			return true, expr, nil
+		}
+
+		v, err := vBase.NormalizeVarName()
+		if err != nil {
+			return false, nil, err
+		}
+
+		c, ok := v.(*tree.ColumnItem)
+		if !ok {
+			return true, expr, nil
+		}
+
+		col, dropped, err := desc.FindColumnByName(c.ColumnName)
+		if err != nil || dropped {
+			return false, nil, pgerror.Newf(pgcode.UndefinedColumn,
+				"column %q does not exist, referenced in %q", c.ColumnName, rootExpr.String())
+		}
+		colIDs.Add(col.ID)
+
+		// Convert to a dummyColumn of the correct type.
+		return false, &dummyColumn{typ: col.Type, name: c.ColumnName}, nil
+	})
+
+	return newExpr, colIDs, err
 }

--- a/pkg/sql/schemaexpr/doc.go
+++ b/pkg/sql/schemaexpr/doc.go
@@ -11,25 +11,6 @@
 /*
 Package schemaexpr provides utilities for dealing with expressions with table
 schemas, such as check constraints, computed columns, and partial index
-predicates. It provides the following utilities.
-
-CheckConstraintBuilder
-
-  Validates and builds sql.TableDescriptor_CheckConstraints from
-  tree.CheckConstraintTableDefs.
-
-ComputedColumnValidator
-
-  Validates computed columns and can determine if a non-computed column has
-  dependent computed columns.
-
-PartialIndexValidator
-
-  Validates partial index predicates and dequalifies the columns referenced.
-
-DequalifyColumnRefs
-
-  Strips database and table names from qualified columns.
-
+predicates.
 */
 package schemaexpr

--- a/pkg/sql/schemaexpr/partial_index.go
+++ b/pkg/sql/schemaexpr/partial_index.go
@@ -58,7 +58,7 @@ func NewIndexPredicateValidator(
 func (v *IndexPredicateValidator) Validate(expr tree.Expr) (tree.Expr, error) {
 	// Replace the column variables with dummyColumns so that they can be
 	// type-checked.
-	replacedExpr, _, err := v.desc.ReplaceColumnVarsInExprWithDummies(expr)
+	replacedExpr, _, err := replaceVars(&v.desc.TableDescriptor, expr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/sqlbase/table_col_set.go
+++ b/pkg/sql/sqlbase/table_col_set.go
@@ -29,9 +29,6 @@ func MakeTableColSet(vals ...ColumnID) TableColSet {
 // Add adds a column to the set. No-op if the column is already in the set.
 func (s *TableColSet) Add(col ColumnID) { s.set.Add(int(col)) }
 
-// Remove removes a column from the set. No-op if the column is not in the set.
-func (s *TableColSet) Remove(col ColumnID) { s.set.Remove(int(col)) }
-
 // Contains returns true if the set contains the column.
 func (s TableColSet) Contains(col ColumnID) bool { return s.set.Contains(int(col)) }
 
@@ -40,13 +37,6 @@ func (s TableColSet) Empty() bool { return s.set.Empty() }
 
 // Len returns the number of the columns in the set.
 func (s TableColSet) Len() int { return s.set.Len() }
-
-// Next returns the first value in the set which is >= startVal. If there is no
-// such column, the second return value is false.
-func (s TableColSet) Next(startVal ColumnID) (ColumnID, bool) {
-	c, ok := s.set.Next(int(startVal))
-	return ColumnID(c), ok
-}
 
 // ForEach calls a function for each column in the set (in increasing order).
 func (s TableColSet) ForEach(f func(col ColumnID)) { s.set.ForEach(func(i int) { f(ColumnID(i)) }) }
@@ -63,40 +53,6 @@ func (s TableColSet) Ordered() []ColumnID {
 	})
 	return result
 }
-
-// Copy returns a copy of s which can be modified independently.
-func (s TableColSet) Copy() TableColSet { return TableColSet{set: s.set.Copy()} }
-
-// UnionWith adds all the columns from rhs to this set.
-func (s *TableColSet) UnionWith(rhs TableColSet) { s.set.UnionWith(rhs.set) }
-
-// Union returns the union of s and rhs as a new set.
-func (s TableColSet) Union(rhs TableColSet) TableColSet { return TableColSet{set: s.set.Union(rhs.set)} }
-
-// IntersectionWith removes any columns not in rhs from this set.
-func (s *TableColSet) IntersectionWith(rhs TableColSet) { s.set.IntersectionWith(rhs.set) }
-
-// Intersection returns the intersection of s and rhs as a new set.
-func (s TableColSet) Intersection(rhs TableColSet) TableColSet {
-	return TableColSet{set: s.set.Intersection(rhs.set)}
-}
-
-// DifferenceWith removes any elements in rhs from this set.
-func (s *TableColSet) DifferenceWith(rhs TableColSet) { s.set.DifferenceWith(rhs.set) }
-
-// Difference returns the elements of s that are not in rhs as a new set.
-func (s TableColSet) Difference(rhs TableColSet) TableColSet {
-	return TableColSet{set: s.set.Difference(rhs.set)}
-}
-
-// Intersects returns true if s has any elements in common with rhs.
-func (s TableColSet) Intersects(rhs TableColSet) bool { return s.set.Intersects(rhs.set) }
-
-// Equals returns true if the two sets are identical.
-func (s TableColSet) Equals(rhs TableColSet) bool { return s.set.Equals(rhs.set) }
-
-// SubsetOf returns true if rhs contains all the elements in s.
-func (s TableColSet) SubsetOf(rhs TableColSet) bool { return s.set.SubsetOf(rhs.set) }
 
 // String returns a list representation of elements. Sequential runs of positive
 // numbers are shown as ranges. For example, for the set {1, 2, 3  5, 6, 10},

--- a/pkg/sql/sqlbase/table_col_set.go
+++ b/pkg/sql/sqlbase/table_col_set.go
@@ -1,0 +1,104 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqlbase
+
+import "github.com/cockroachdb/cockroach/pkg/util"
+
+// TableColSet efficiently stores an unordered set of column ids.
+type TableColSet struct {
+	set util.FastIntSet
+}
+
+// MakeTableColSet returns a set initialized with the given values.
+func MakeTableColSet(vals ...ColumnID) TableColSet {
+	var res TableColSet
+	for _, v := range vals {
+		res.Add(v)
+	}
+	return res
+}
+
+// Add adds a column to the set. No-op if the column is already in the set.
+func (s *TableColSet) Add(col ColumnID) { s.set.Add(int(col)) }
+
+// Remove removes a column from the set. No-op if the column is not in the set.
+func (s *TableColSet) Remove(col ColumnID) { s.set.Remove(int(col)) }
+
+// Contains returns true if the set contains the column.
+func (s TableColSet) Contains(col ColumnID) bool { return s.set.Contains(int(col)) }
+
+// Empty returns true if the set is empty.
+func (s TableColSet) Empty() bool { return s.set.Empty() }
+
+// Len returns the number of the columns in the set.
+func (s TableColSet) Len() int { return s.set.Len() }
+
+// Next returns the first value in the set which is >= startVal. If there is no
+// such column, the second return value is false.
+func (s TableColSet) Next(startVal ColumnID) (ColumnID, bool) {
+	c, ok := s.set.Next(int(startVal))
+	return ColumnID(c), ok
+}
+
+// ForEach calls a function for each column in the set (in increasing order).
+func (s TableColSet) ForEach(f func(col ColumnID)) { s.set.ForEach(func(i int) { f(ColumnID(i)) }) }
+
+// Ordered returns a slice with all the ColumnIDs in the set, in increasing
+// order.
+func (s TableColSet) Ordered() []ColumnID {
+	if s.Empty() {
+		return nil
+	}
+	result := make([]ColumnID, 0, s.Len())
+	s.ForEach(func(i ColumnID) {
+		result = append(result, i)
+	})
+	return result
+}
+
+// Copy returns a copy of s which can be modified independently.
+func (s TableColSet) Copy() TableColSet { return TableColSet{set: s.set.Copy()} }
+
+// UnionWith adds all the columns from rhs to this set.
+func (s *TableColSet) UnionWith(rhs TableColSet) { s.set.UnionWith(rhs.set) }
+
+// Union returns the union of s and rhs as a new set.
+func (s TableColSet) Union(rhs TableColSet) TableColSet { return TableColSet{set: s.set.Union(rhs.set)} }
+
+// IntersectionWith removes any columns not in rhs from this set.
+func (s *TableColSet) IntersectionWith(rhs TableColSet) { s.set.IntersectionWith(rhs.set) }
+
+// Intersection returns the intersection of s and rhs as a new set.
+func (s TableColSet) Intersection(rhs TableColSet) TableColSet {
+	return TableColSet{set: s.set.Intersection(rhs.set)}
+}
+
+// DifferenceWith removes any elements in rhs from this set.
+func (s *TableColSet) DifferenceWith(rhs TableColSet) { s.set.DifferenceWith(rhs.set) }
+
+// Difference returns the elements of s that are not in rhs as a new set.
+func (s TableColSet) Difference(rhs TableColSet) TableColSet {
+	return TableColSet{set: s.set.Difference(rhs.set)}
+}
+
+// Intersects returns true if s has any elements in common with rhs.
+func (s TableColSet) Intersects(rhs TableColSet) bool { return s.set.Intersects(rhs.set) }
+
+// Equals returns true if the two sets are identical.
+func (s TableColSet) Equals(rhs TableColSet) bool { return s.set.Equals(rhs.set) }
+
+// SubsetOf returns true if rhs contains all the elements in s.
+func (s TableColSet) SubsetOf(rhs TableColSet) bool { return s.set.SubsetOf(rhs.set) }
+
+// String returns a list representation of elements. Sequential runs of positive
+// numbers are shown as ranges. For example, for the set {1, 2, 3  5, 6, 10},
+// the output is "(1-3,5,6,10)".
+func (s TableColSet) String() string { return s.set.String() }

--- a/pkg/sql/sqlbase/table_col_set_test.go
+++ b/pkg/sql/sqlbase/table_col_set_test.go
@@ -1,0 +1,66 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqlbase
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+func BenchmarkColSet(b *testing.B) {
+	// Verify that the wrapper doesn't add overhead (as was the case with earlier
+	// go versions which couldn't do mid-stack inlining).
+	const n = 50
+	b.Run("fastintset", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var c util.FastIntSet
+			for j := 0; j < n; j++ {
+				c.Add(j)
+			}
+		}
+	})
+	b.Run("colset", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var c TableColSet
+			for j := 0; j < n; j++ {
+				c.Add(ColumnID(j))
+			}
+		}
+	})
+}
+
+func TestColSet_Ordered(t *testing.T) {
+	testData := []struct {
+		set      TableColSet
+		expected []ColumnID
+	}{
+		{MakeTableColSet(1, 2, 3), []ColumnID{1, 2, 3}},
+		{MakeTableColSet(3, 5, 6, 17), []ColumnID{3, 5, 6, 17}},
+		{MakeTableColSet(9, 4, 6, 1), []ColumnID{1, 4, 6, 9}},
+	}
+
+	for _, d := range testData {
+		t.Run(d.set.String(), func(t *testing.T) {
+			res := d.set.Ordered()
+
+			if len(res) != len(d.expected) {
+				t.Fatalf("%s: expected %v, got %v", d.set, d.expected, res)
+			}
+
+			for i := 0; i < len(res); i++ {
+				if res[i] != d.expected[i] {
+					t.Errorf("%s: expected %v, got %v", d.set, d.expected, res)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### sqlbase: add ColSet wrapper for util.FastIntSet of ColumnID

There are numerous places where a `map[sqlbase.ColumnID]struct{}` or a
`util.FastIntSet` is used to represent a set of `sqlbase.ColumnID`. This
commit adds a typed wrapper around `util.FastIntSet` which is an
efficient and ergonimic replacement for maps and `util.FastIntSet`.

Release note: None

#### schemaexpr: use sqlbase.ColSet instead of maps

This commit replaces maps used as sets of integers with sqlbase.ColSet
because it is a more efficient set implementation.

Release note: None
