### PR TITLE
[wip] server: embed base.Config by value

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -192,7 +192,7 @@ func clearFlagChanges(cmd *cobra.Command) {
 // cliContext captures the command-line parameters of most CLI commands.
 type cliContext struct {
 	// Embed the base context.
-	*base.Config
+	base.Config
 
 	// isInteractive indicates whether the session is interactive, that
 	// is, the commands executed are extremely likely to be *input* from

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1332,7 +1332,7 @@ func getClientGRPCConn(
 	stopper := stop.NewStopper()
 	rpcContext := rpc.NewContext(
 		log.AmbientContext{Tracer: cfg.Settings.Tracer},
-		cfg.Config,
+		&cfg.Config,
 		clock,
 		stopper,
 		cfg.Settings,

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -109,7 +109,7 @@ func (mo *MaxOffsetType) String() string {
 // server.
 type BaseConfig struct {
 	Settings *cluster.Settings
-	*base.Config
+	base.Config
 
 	// AmbientCtx is used to annotate contexts used inside the server.
 	AmbientCtx log.AmbientContext
@@ -142,13 +142,12 @@ type BaseConfig struct {
 func MakeBaseConfig(st *cluster.Settings) BaseConfig {
 	baseCfg := BaseConfig{
 		AmbientCtx:        log.AmbientContext{Tracer: st.Tracer},
-		Config:            new(base.Config),
 		Settings:          st,
 		MaxOffset:         MaxOffsetType(base.DefaultMaxClockOffset),
 		DefaultZoneConfig: zonepb.DefaultZoneConfig(),
 		StorageEngine:     storage.DefaultStorageEngine,
 	}
-	baseCfg.InitDefaults()
+	baseCfg.Config.InitDefaults()
 	return baseCfg
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -254,11 +254,11 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	if knobs := cfg.TestingKnobs.Server; knobs != nil {
 		serverKnobs := knobs.(*TestingKnobs)
 		rpcContext = rpc.NewContextWithTestingKnobs(
-			cfg.AmbientCtx, cfg.Config, clock, stopper, cfg.Settings,
+			cfg.AmbientCtx, &cfg.Config, clock, stopper, cfg.Settings,
 			serverKnobs.ContextTestingKnobs,
 		)
 	} else {
-		rpcContext = rpc.NewContext(cfg.AmbientCtx, cfg.Config, clock, stopper,
+		rpcContext = rpc.NewContext(cfg.AmbientCtx, &cfg.Config, clock, stopper,
 			cfg.Settings)
 	}
 	rpcContext.HeartbeatCB = func() {
@@ -499,7 +499,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	sStatus := newStatusServer(
 		cfg.AmbientCtx,
 		st,
-		cfg.Config,
+		&cfg.Config,
 		sAdmin,
 		db,
 		g,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -497,7 +497,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 	sqlMemMetrics := sql.MakeMemMetrics("sql", cfg.HistogramWindowInterval())
 	pgServer := pgwire.MakeServer(
 		cfg.AmbientCtx,
-		cfg.Config,
+		&cfg.Config,
 		cfg.Settings,
 		sqlMemMetrics,
 		&rootSQLMemoryMonitor,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -458,7 +458,7 @@ func makeSQLServerArgs(
 	}
 	rpcContext := rpc.NewContextWithTestingKnobs(
 		baseCfg.AmbientCtx,
-		baseCfg.Config,
+		&baseCfg.Config,
 		clock,
 		stopper,
 		st,


### PR DESCRIPTION
This breaks a lot of things, so we must have relied on mutating the original memory before and now don't any more. Posting this PR to fix up and land later.

Release note: None