### PR TITLE
sql: enable column backfills on UDTs

### DIFF
--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -119,6 +119,7 @@ func Load(
 	evalCtx.SetTxnTimestamp(curTime)
 	evalCtx.SetStmtTimestamp(curTime)
 	evalCtx.Codec = keys.TODOSQLCodec
+	semaCtx := tree.MakeSemaContext()
 
 	blobClientFactory := blobs.TestBlobServiceClient(writeToDir)
 	conf, err := cloud.ExternalStorageConfFromURI(uri)
@@ -235,7 +236,7 @@ func Load(
 				return backupccl.BackupManifest{}, errors.Wrap(err, "make row inserter")
 			}
 			cols, defaultExprs, err =
-				sqlbase.ProcessDefaultColumns(ctx, tableDesc.Columns, tableDesc, &txCtx, evalCtx)
+				sqlbase.ProcessDefaultColumns(ctx, tableDesc.Columns, tableDesc, &txCtx, evalCtx, &semaCtx)
 			if err != nil {
 				return backupccl.BackupManifest{}, errors.Wrap(err, "process default columns")
 			}

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1978,6 +1978,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			ReCache:            ex.server.reCache,
 			InternalExecutor:   &ie,
 			DB:                 ex.server.cfg.DB,
+			TypeResolver:       p,
 		},
 		SessionMutator:    ex.dataMutator,
 		VirtualSchemas:    ex.server.cfg.VirtualSchemas,

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -324,6 +324,9 @@ func (ds *ServerImpl) setupFlow(
 			InternalExecutor:   ie,
 			Txn:                leafTxn,
 		}
+		// Since we are constructing an EvalContext on a remote node, outfit it
+		// with a DistSQLTypeResolver.
+		evalCtx.TypeResolver = &execinfrapb.DistSQLTypeResolver{EvalContext: evalCtx}
 		evalCtx.SetStmtTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.StmtTimestampNanos))
 		evalCtx.SetTxnTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.TxnTimestampNanos))
 		var haveSequences bool

--- a/pkg/sql/execinfra/expr.go
+++ b/pkg/sql/execinfra/expr.go
@@ -158,7 +158,7 @@ func (eh *ExprHelper) Init(
 	}
 	var err error
 	semaContext := tree.MakeSemaContext()
-	semaContext.TypeResolver = evalCtx.DistSQLTypeResolver
+	semaContext.TypeResolver = evalCtx.TypeResolver
 	eh.Expr, err = processExpression(expr, evalCtx, &semaContext, &eh.Vars)
 	if err != nil {
 		return err

--- a/pkg/sql/execinfra/flow_context.go
+++ b/pkg/sql/execinfra/flow_context.go
@@ -71,7 +71,7 @@ type FlowCtx struct {
 // var context.
 func (ctx *FlowCtx) NewEvalCtx() *tree.EvalContext {
 	evalCopy := ctx.EvalCtx.Copy()
-	evalCopy.DistSQLTypeResolver = &execinfrapb.DistSQLTypeResolver{EvalContext: evalCopy}
+	evalCopy.TypeResolver = &execinfrapb.DistSQLTypeResolver{EvalContext: evalCopy}
 	return evalCopy
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -869,3 +869,83 @@ howdy cockroach
 
 statement ok
 ROLLBACK
+
+# Tests for column additions with enum tables.
+statement ok
+CREATE TABLE column_add (x greeting);
+INSERT INTO column_add VALUES ('hello')
+
+# Test that we can backfill a column when an enum column is in the table.
+statement ok
+ALTER TABLE column_add ADD COLUMN y INT DEFAULT 1
+
+query TI
+SELECT * FROM column_add
+----
+hello 1
+
+# Test that we can add an enum column with a default value.
+statement ok
+ALTER TABLE column_add ADD COLUMN z greeting DEFAULT 'howdy'
+
+query TIT
+SELECT * FROM column_add
+----
+hello 1 howdy
+
+# Test that we can add an enum computed column.
+statement ok
+ALTER TABLE column_add ADD COLUMN w greeting AS ('hi') STORED
+
+query TITT
+SELECT * FROM column_add
+----
+hello 1 howdy hi
+
+# Test that we can add a computed column that uses an enum.
+statement ok
+ALTER TABLE column_add ADD COLUMN v BOOL AS (z < 'hi' AND x >= 'hello') STORED
+
+query TITTB
+SELECT * FROM column_add
+----
+hello 1 howdy hi true
+
+# Repeat the above process on a new table in a transaction to exercise
+# the schema change in txn codepath.
+statement ok
+DROP TABLE column_add
+
+statement ok
+BEGIN;
+CREATE TABLE column_add (x greeting);
+INSERT INTO column_add VALUES ('hello');
+ALTER TABLE column_add ADD COLUMN y INT DEFAULT 1;
+ALTER TABLE column_add ADD COLUMN z greeting DEFAULT 'howdy';
+ALTER TABLE column_add ADD COLUMN w greeting AS ('hi') STORED;
+ALTER TABLE column_add ADD COLUMN v BOOL AS (z < 'hi' AND x >= 'hello') STORED
+
+query TITTB
+SELECT * FROM column_add
+----
+hello 1 howdy hi true
+
+statement ok
+COMMIT
+
+# Lastly, ensure that we can create a column using a type created in the
+# same transaction.
+statement ok
+BEGIN;
+CREATE TYPE in_txn AS ENUM ('in', 'txn');
+CREATE TABLE tbl_in_txn (x INT);
+INSERT INTO tbl_in_txn VALUES (1);
+ALTER TABLE tbl_in_txn ADD COLUMN y in_txn DEFAULT 'txn';
+
+query IT
+SELECT * FROM tbl_in_txn
+----
+1 txn
+
+statement ok
+ROLLBACK

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -305,6 +305,7 @@ func newInternalPlanner(
 	p.extendedEvalCtx.ClusterName = execCfg.RPCContext.ClusterName()
 	p.extendedEvalCtx.NodeID = execCfg.NodeID
 	p.extendedEvalCtx.Locality = execCfg.Locality
+	p.extendedEvalCtx.TypeResolver = p
 
 	p.sessionDataMutator = dataMutator
 	p.autoCommit = false

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -266,11 +266,12 @@ func NewDatumRowConverter(
 	}
 
 	var txCtx transform.ExprTransformContext
+	semaCtx := tree.MakeSemaContext()
 	// We do not currently support DEFAULT expressions on target or non-target
 	// columns. All non-target columns must be nullable and will be set to NULL
 	// during import. We do however support DEFAULT on hidden columns (which is
 	// only the default _rowid one). This allows those expressions to run.
-	cols, defaultExprs, err := sqlbase.ProcessDefaultColumns(ctx, targetColDescriptors, immutDesc, &txCtx, c.EvalCtx)
+	cols, defaultExprs, err := sqlbase.ProcessDefaultColumns(ctx, targetColDescriptors, immutDesc, &txCtx, c.EvalCtx, &semaCtx)
 	if err != nil {
 		return nil, errors.Wrap(err, "process default columns")
 	}

--- a/pkg/sql/rowexec/columnbackfiller.go
+++ b/pkg/sql/rowexec/columnbackfiller.go
@@ -61,7 +61,9 @@ func newColumnBackfiller(
 	}
 	cb.backfiller.chunks = cb
 
-	if err := cb.ColumnBackfiller.Init(ctx, cb.flowCtx.NewEvalCtx(), cb.desc); err != nil {
+	evalCtx := cb.flowCtx.NewEvalCtx()
+	evalCtx.DB = cb.flowCtx.Cfg.DB
+	if err := cb.ColumnBackfiller.Init(ctx, evalCtx, cb.desc); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/schemaexpr/computed_column.go
+++ b/pkg/sql/schemaexpr/computed_column.go
@@ -16,8 +16,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 )
 
@@ -186,4 +188,118 @@ func (v *ComputedColumnValidator) ValidateNoDependents(col *sqlbase.ColumnDescri
 	}
 
 	return nil
+}
+
+// descContainer is a helper type that implements tree.IndexedVarContainer; it
+// is used to type check computed columns and does not support evaluation.
+type descContainer struct {
+	cols []sqlbase.ColumnDescriptor
+}
+
+func (j *descContainer) IndexedVarEval(idx int, ctx *tree.EvalContext) (tree.Datum, error) {
+	panic("unsupported")
+}
+
+func (j *descContainer) IndexedVarResolvedType(idx int) *types.T {
+	return j.cols[idx].Type
+}
+
+func (*descContainer) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
+	return nil
+}
+
+// MakeComputedExprs returns a slice of the computed expressions for the
+// slice of input column descriptors, or nil if none of the input column
+// descriptors have computed expressions.
+// The length of the result slice matches the length of the input column
+// descriptors. For every column that has no computed expression, a NULL
+// expression is reported.
+// addingCols indicates if the input column descriptors are being added
+// and allows type checking of the compute expressions to reference
+// input columns earlier in the slice.
+func MakeComputedExprs(
+	ctx context.Context,
+	cols []sqlbase.ColumnDescriptor,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
+	tn *tree.TableName,
+	txCtx *transform.ExprTransformContext,
+	evalCtx *tree.EvalContext,
+	semaCtx *tree.SemaContext,
+	addingCols bool,
+) ([]tree.TypedExpr, error) {
+	// Check to see if any of the columns have computed expressions. If there
+	// are none, we don't bother with constructing the map as the expressions
+	// are all NULL.
+	haveComputed := false
+	for i := range cols {
+		if cols[i].IsComputed() {
+			haveComputed = true
+			break
+		}
+	}
+	if !haveComputed {
+		return nil, nil
+	}
+
+	// Build the computed expressions map from the parsed statement.
+	computedExprs := make([]tree.TypedExpr, 0, len(cols))
+	exprStrings := make([]string, 0, len(cols))
+	for i := range cols {
+		col := &cols[i]
+		if col.IsComputed() {
+			exprStrings = append(exprStrings, *col.ComputeExpr)
+		}
+	}
+	exprs, err := parser.ParseExprs(exprStrings)
+	if err != nil {
+		return nil, err
+	}
+
+	// We need an ivarHelper and sourceInfo, unlike DEFAULT, since computed
+	// columns can reference other columns and thus need to be able to resolve
+	// column names (at this stage they only need to resolve the types so that
+	// the expressions can be typechecked - we have no need to evaluate them).
+	iv := &descContainer{tableDesc.Columns}
+	ivarHelper := tree.MakeIndexedVarHelper(iv, len(tableDesc.Columns))
+
+	source := sqlbase.NewSourceInfoForSingleTable(*tn, sqlbase.ResultColumnsFromColDescs(tableDesc.GetID(), tableDesc.Columns))
+	semaCtx.IVarContainer = iv
+
+	addColumnInfo := func(col *sqlbase.ColumnDescriptor) {
+		ivarHelper.AppendSlot()
+		iv.cols = append(iv.cols, *col)
+		newCols := sqlbase.ResultColumnsFromColDescs(tableDesc.GetID(), []sqlbase.ColumnDescriptor{*col})
+		source.SourceColumns = append(source.SourceColumns, newCols...)
+	}
+
+	compExprIdx := 0
+	for i := range cols {
+		col := &cols[i]
+		if !col.IsComputed() {
+			computedExprs = append(computedExprs, tree.DNull)
+			if addingCols {
+				addColumnInfo(col)
+			}
+			continue
+		}
+		expr, err := sqlbase.ResolveNames(
+			exprs[compExprIdx], source, ivarHelper, evalCtx.SessionData.SearchPath)
+		if err != nil {
+			return nil, err
+		}
+
+		typedExpr, err := tree.TypeCheck(ctx, expr, semaCtx, col.Type)
+		if err != nil {
+			return nil, err
+		}
+		if typedExpr, err = txCtx.NormalizeExpr(evalCtx, typedExpr); err != nil {
+			return nil, err
+		}
+		computedExprs = append(computedExprs, typedExpr)
+		compExprIdx++
+		if addingCols {
+			addColumnInfo(col)
+		}
+	}
+	return computedExprs, nil
 }

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3097,11 +3097,8 @@ type EvalContext struct {
 
 	Tenant TenantOperator
 
-	// DistSQLTypeResolver is a type resolver used during execution of DistSQL
-	// flows. It is limited to only provide access to types via ID, meaning that
-	// it cannot perform resolution of qualified names into types. It will be nil
-	// when not in the context of a DistSQL flow.
-	DistSQLTypeResolver TypeReferenceResolver
+	// TypeResolver is a type resolver that can be used during execution.
+	TypeResolver TypeReferenceResolver
 
 	// The transaction in which the statement is executing.
 	Txn *kv.Txn

--- a/pkg/sql/sqlbase/computed_exprs.go
+++ b/pkg/sql/sqlbase/computed_exprs.go
@@ -11,12 +11,8 @@
 package sqlbase
 
 import (
-	"context"
-
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
@@ -55,122 +51,8 @@ func (*RowIndexedVarContainer) IndexedVarNodeFormatter(idx int) tree.NodeFormatt
 	return nil
 }
 
-// descContainer is a helper type that implements tree.IndexedVarContainer; it
-// is used to type check computed columns and does not support evaluation.
-type descContainer struct {
-	cols []ColumnDescriptor
-}
-
-func (j *descContainer) IndexedVarEval(idx int, ctx *tree.EvalContext) (tree.Datum, error) {
-	panic("unsupported")
-}
-
-func (j *descContainer) IndexedVarResolvedType(idx int) *types.T {
-	return j.cols[idx].Type
-}
-
-func (*descContainer) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	return nil
-}
-
 // CannotWriteToComputedColError constructs a write error for a computed column.
 func CannotWriteToComputedColError(colName string) error {
 	return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 		"cannot write directly to computed column %q", tree.ErrNameString(colName))
-}
-
-// MakeComputedExprs returns a slice of the computed expressions for the
-// slice of input column descriptors, or nil if none of the input column
-// descriptors have computed expressions.
-// The length of the result slice matches the length of the input column
-// descriptors. For every column that has no computed expression, a NULL
-// expression is reported.
-// addingCols indicates if the input column descriptors are being added
-// and allows type checking of the compute expressions to reference
-// input columns earlier in the slice.
-func MakeComputedExprs(
-	ctx context.Context,
-	cols []ColumnDescriptor,
-	tableDesc *ImmutableTableDescriptor,
-	tn *tree.TableName,
-	txCtx *transform.ExprTransformContext,
-	evalCtx *tree.EvalContext,
-	addingCols bool,
-) ([]tree.TypedExpr, error) {
-	// Check to see if any of the columns have computed expressions. If there
-	// are none, we don't bother with constructing the map as the expressions
-	// are all NULL.
-	haveComputed := false
-	for i := range cols {
-		if cols[i].IsComputed() {
-			haveComputed = true
-			break
-		}
-	}
-	if !haveComputed {
-		return nil, nil
-	}
-
-	// Build the computed expressions map from the parsed statement.
-	computedExprs := make([]tree.TypedExpr, 0, len(cols))
-	exprStrings := make([]string, 0, len(cols))
-	for i := range cols {
-		col := &cols[i]
-		if col.IsComputed() {
-			exprStrings = append(exprStrings, *col.ComputeExpr)
-		}
-	}
-	exprs, err := parser.ParseExprs(exprStrings)
-	if err != nil {
-		return nil, err
-	}
-
-	// We need an ivarHelper and sourceInfo, unlike DEFAULT, since computed
-	// columns can reference other columns and thus need to be able to resolve
-	// column names (at this stage they only need to resolve the types so that
-	// the expressions can be typechecked - we have no need to evaluate them).
-	iv := &descContainer{tableDesc.Columns}
-	ivarHelper := tree.MakeIndexedVarHelper(iv, len(tableDesc.Columns))
-
-	source := NewSourceInfoForSingleTable(*tn, ResultColumnsFromColDescs(tableDesc.GetID(), tableDesc.Columns))
-	semaCtx := tree.MakeSemaContext()
-	semaCtx.IVarContainer = iv
-
-	addColumnInfo := func(col *ColumnDescriptor) {
-		ivarHelper.AppendSlot()
-		iv.cols = append(iv.cols, *col)
-		newCols := ResultColumnsFromColDescs(tableDesc.GetID(), []ColumnDescriptor{*col})
-		source.SourceColumns = append(source.SourceColumns, newCols...)
-	}
-
-	compExprIdx := 0
-	for i := range cols {
-		col := &cols[i]
-		if !col.IsComputed() {
-			computedExprs = append(computedExprs, tree.DNull)
-			if addingCols {
-				addColumnInfo(col)
-			}
-			continue
-		}
-		expr, err := ResolveNames(
-			exprs[compExprIdx], source, ivarHelper, evalCtx.SessionData.SearchPath)
-		if err != nil {
-			return nil, err
-		}
-
-		typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, col.Type)
-		if err != nil {
-			return nil, err
-		}
-		if typedExpr, err = txCtx.NormalizeExpr(evalCtx, typedExpr); err != nil {
-			return nil, err
-		}
-		computedExprs = append(computedExprs, typedExpr)
-		compExprIdx++
-		if addingCols {
-			addColumnInfo(col)
-		}
-	}
-	return computedExprs, nil
 }

--- a/pkg/sql/sqlbase/default_exprs.go
+++ b/pkg/sql/sqlbase/default_exprs.go
@@ -29,6 +29,7 @@ func MakeDefaultExprs(
 	cols []ColumnDescriptor,
 	txCtx *transform.ExprTransformContext,
 	evalCtx *tree.EvalContext,
+	semaCtx *tree.SemaContext,
 ) ([]tree.TypedExpr, error) {
 	// Check to see if any of the columns have DEFAULT expressions. If there
 	// are no DEFAULT expressions, we don't bother with constructing the
@@ -59,7 +60,6 @@ func MakeDefaultExprs(
 	}
 
 	defExprIdx := 0
-	semaCtx := tree.MakeSemaContext()
 	for i := range cols {
 		col := &cols[i]
 		if col.DefaultExpr == nil {
@@ -67,7 +67,7 @@ func MakeDefaultExprs(
 			continue
 		}
 		expr := exprs[defExprIdx]
-		typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, col.Type)
+		typedExpr, err := tree.TypeCheck(ctx, expr, semaCtx, col.Type)
 		if err != nil {
 			return nil, err
 		}
@@ -88,11 +88,12 @@ func ProcessDefaultColumns(
 	tableDesc *ImmutableTableDescriptor,
 	txCtx *transform.ExprTransformContext,
 	evalCtx *tree.EvalContext,
+	semaCtx *tree.SemaContext,
 ) ([]ColumnDescriptor, []tree.TypedExpr, error) {
 	cols = processColumnSet(cols, tableDesc, func(col *ColumnDescriptor) bool {
 		return col.DefaultExpr != nil
 	})
-	defaultExprs, err := MakeDefaultExprs(ctx, cols, txCtx, evalCtx)
+	defaultExprs, err := MakeDefaultExprs(ctx, cols, txCtx, evalCtx, semaCtx)
 	return cols, defaultExprs, err
 }
 


### PR DESCRIPTION
Work for #48728.

This PR enables the use of column backfills on tables and columns that
have user defined types, including those that use default or computed
columns whose expressions also may contain user defined types.

Release note: None