### PR TITLE
.github: add geospatial code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,8 @@
 /pkg/sql/distsql_plan_csv.go @cockroachdb/bulk-prs
 /pkg/cli/dump.go             @cockroachdb/bulk-prs
 
+/pkg/geo                     @cockroachdb/geospatial
+
 /pkg/ui/                     @cockroachdb/admin-ui-prs
 /pkg/ui/embedded.go
 /pkg/ui/src/js/protos.d.ts


### PR DESCRIPTION
Release note: None