### PR TITLE
release-20.1: kv/concurrency: avoid redundant txn pushes and batch intent resolution

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -632,6 +632,11 @@ type lockTableWaiter interface {
 	// and, in turn, remove this method. This will likely fall out of pulling
 	// all replicated locks into the lockTable.
 	WaitOnLock(context.Context, Request, *roachpb.Intent) *Error
+
+	// ClearCaches wipes all caches maintained by the lockTableWaiter. This is
+	// primarily used to recover memory when a replica loses a lease. However,
+	// it is also used in tests to reset the state of the lockTableWaiter.
+	ClearCaches()
 }
 
 // txnWaitQueue holds a collection of wait-queues for transaction records.

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -72,7 +72,8 @@ func (c *Config) initDefaults() {
 // NewManager creates a new concurrency Manager structure.
 func NewManager(cfg Config) Manager {
 	cfg.initDefaults()
-	return &managerImpl{
+	m := new(managerImpl)
+	*m = managerImpl{
 		// TODO(nvanbenschoten): move pkg/storage/spanlatch to a new
 		// pkg/storage/concurrency/latch package. Make it implement the
 		// latchManager interface directly, if possible.
@@ -89,6 +90,7 @@ func NewManager(cfg Config) Manager {
 			st:                cfg.Settings,
 			stopper:           cfg.Stopper,
 			ir:                cfg.IntentResolver,
+			lm:                m,
 			disableTxnPushing: cfg.DisableTxnPushing,
 		},
 		// TODO(nvanbenschoten): move pkg/storage/txnwait to a new
@@ -102,6 +104,7 @@ func NewManager(cfg Config) Manager {
 			Knobs:     cfg.TxnWaitKnobs,
 		}),
 	}
+	return m
 }
 
 // SequenceReq implements the RequestSequencer interface.
@@ -342,6 +345,9 @@ func (m *managerImpl) OnRangeLeaseUpdated(isLeaseholder bool) {
 		const disable = true
 		m.lt.Clear(disable)
 		m.twq.Clear(disable)
+		// Also clear caches, since they won't be needed any time soon and
+		// consume memory.
+		m.ltw.ClearCaches()
 	}
 }
 

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -529,22 +529,22 @@ func (c *cluster) makeConfig() concurrency.Config {
 // PushTransaction implements the concurrency.IntentResolver interface.
 func (c *cluster) PushTransaction(
 	ctx context.Context, pushee *enginepb.TxnMeta, h roachpb.Header, pushType roachpb.PushTxnType,
-) (roachpb.Transaction, *roachpb.Error) {
+) (*roachpb.Transaction, *roachpb.Error) {
 	pusheeRecord, err := c.getTxnRecord(pushee.ID)
 	if err != nil {
-		return roachpb.Transaction{}, roachpb.NewError(err)
+		return nil, roachpb.NewError(err)
 	}
 	var pusherRecord *txnRecord
 	if h.Txn != nil {
 		pusherID := h.Txn.ID
 		pusherRecord, err = c.getTxnRecord(pusherID)
 		if err != nil {
-			return roachpb.Transaction{}, roachpb.NewError(err)
+			return nil, roachpb.NewError(err)
 		}
 
 		push, err := c.registerPush(ctx, pusherID, pushee.ID)
 		if err != nil {
-			return roachpb.Transaction{}, roachpb.NewError(err)
+			return nil, roachpb.NewError(err)
 		}
 		defer c.unregisterPush(push)
 	}
@@ -558,7 +558,7 @@ func (c *cluster) PushTransaction(
 		case roachpb.PUSH_ABORT:
 			pushed = pusheeTxn.Status.IsFinalized()
 		default:
-			return roachpb.Transaction{}, roachpb.NewErrorf("unexpected push type: %s", pushType)
+			return nil, roachpb.NewErrorf("unexpected push type: %s", pushType)
 		}
 		if pushed {
 			return pusheeTxn, nil
@@ -566,12 +566,12 @@ func (c *cluster) PushTransaction(
 		// Or the pusher aborted?
 		var pusherRecordSig chan struct{}
 		if pusherRecord != nil {
-			var pusherTxn roachpb.Transaction
+			var pusherTxn *roachpb.Transaction
 			pusherTxn, pusherRecordSig = pusherRecord.asTxn()
 			if pusherTxn.Status == roachpb.ABORTED {
 				log.Eventf(ctx, "detected pusher aborted")
 				err := roachpb.NewTransactionAbortedError(roachpb.ABORT_REASON_PUSHER_ABORTED)
-				return roachpb.Transaction{}, roachpb.NewError(err)
+				return nil, roachpb.NewError(err)
 			}
 		}
 		// Wait until either record is updated.
@@ -579,7 +579,7 @@ func (c *cluster) PushTransaction(
 		case <-pusheeRecordSig:
 		case <-pusherRecordSig:
 		case <-ctx.Done():
-			return roachpb.Transaction{}, roachpb.NewError(ctx.Err())
+			return nil, roachpb.NewError(ctx.Err())
 		}
 	}
 }
@@ -649,10 +649,10 @@ func (c *cluster) updateTxnRecord(
 	return nil
 }
 
-func (r *txnRecord) asTxn() (roachpb.Transaction, chan struct{}) {
+func (r *txnRecord) asTxn() (*roachpb.Transaction, chan struct{}) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	txn := *r.txn
+	txn := r.txn.Clone()
 	if r.updatedStatus > txn.Status {
 		txn.Status = r.updatedStatus
 	}

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -228,21 +228,35 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 					d.Fatalf(t, "unknown request: %s", reqName)
 				}
 
-				var txnName string
-				d.ScanArgs(t, "txn", &txnName)
-				txn, ok := c.txnsByName[txnName]
-				if !ok {
-					d.Fatalf(t, "unknown txn %s", txnName)
-				}
+				// Each roachpb.Intent is provided on an indented line.
+				var intents []roachpb.Intent
+				singleReqLines := strings.Split(d.Input, "\n")
+				for _, line := range singleReqLines {
+					var err error
+					d.Cmd, d.CmdArgs, err = datadriven.ParseLine(line)
+					if err != nil {
+						d.Fatalf(t, "error parsing single intent: %v", err)
+					}
+					if d.Cmd != "intent" {
+						d.Fatalf(t, "expected \"intent\", found %s", d.Cmd)
+					}
 
-				var key string
-				d.ScanArgs(t, "key", &key)
+					var txnName string
+					d.ScanArgs(t, "txn", &txnName)
+					txn, ok := c.txnsByName[txnName]
+					if !ok {
+						d.Fatalf(t, "unknown txn %s", txnName)
+					}
+
+					var key string
+					d.ScanArgs(t, "key", &key)
+
+					intents = append(intents, roachpb.MakeIntent(&txn.TxnMeta, roachpb.Key(key)))
+				}
 
 				opName := fmt.Sprintf("handle write intent error %s", reqName)
 				mon.runAsync(opName, func(ctx context.Context) {
-					wiErr := &roachpb.WriteIntentError{Intents: []roachpb.Intent{
-						roachpb.MakeIntent(&txn.TxnMeta, roachpb.Key(key)),
-					}}
+					wiErr := &roachpb.WriteIntentError{Intents: intents}
 					guard, err := m.HandleWriterIntentError(ctx, prev, wiErr)
 					if err != nil {
 						log.Eventf(ctx, "handled %v, returned error: %v", wiErr, err)
@@ -576,6 +590,19 @@ func (c *cluster) ResolveIntent(
 ) *roachpb.Error {
 	log.Eventf(ctx, "resolving intent %s for txn %s with %s status", intent.Key, intent.Txn.ID.Short(), intent.Status)
 	c.m.OnLockUpdated(ctx, &intent)
+	return nil
+}
+
+// ResolveIntents implements the concurrency.IntentResolver interface.
+func (c *cluster) ResolveIntents(
+	ctx context.Context, intents []roachpb.LockUpdate, opts intentresolver.ResolveOptions,
+) *roachpb.Error {
+	log.Eventf(ctx, "resolving a batch of %d intent(s)", len(intents))
+	for _, intent := range intents {
+		if err := c.ResolveIntent(ctx, intent, opts); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -12,6 +12,8 @@ package concurrency
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/intentresolver"
@@ -23,14 +25,17 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
 
 type mockIntentResolver struct {
-	pushTxn       func(context.Context, *enginepb.TxnMeta, roachpb.Header, roachpb.PushTxnType) (roachpb.Transaction, *Error)
-	resolveIntent func(context.Context, roachpb.LockUpdate) *Error
+	pushTxn        func(context.Context, *enginepb.TxnMeta, roachpb.Header, roachpb.PushTxnType) (roachpb.Transaction, *Error)
+	resolveIntent  func(context.Context, roachpb.LockUpdate) *Error
+	resolveIntents func(context.Context, []roachpb.LockUpdate) *Error
 }
 
+// mockIntentResolver implements the IntentResolver interface.
 func (m *mockIntentResolver) PushTransaction(
 	ctx context.Context, txn *enginepb.TxnMeta, h roachpb.Header, pushType roachpb.PushTxnType,
 ) (roachpb.Transaction, *Error) {
@@ -43,12 +48,19 @@ func (m *mockIntentResolver) ResolveIntent(
 	return m.resolveIntent(ctx, intent)
 }
 
+func (m *mockIntentResolver) ResolveIntents(
+	ctx context.Context, intents []roachpb.LockUpdate, opts intentresolver.ResolveOptions,
+) *Error {
+	return m.resolveIntents(ctx, intents)
+}
+
 type mockLockTableGuard struct {
 	state         waitingState
 	signal        chan struct{}
 	stateObserved chan struct{}
 }
 
+// mockLockTableGuard implements the lockTableGuard interface.
 func (g *mockLockTableGuard) ShouldWait() bool            { return true }
 func (g *mockLockTableGuard) NewStateChan() chan struct{} { return g.signal }
 func (g *mockLockTableGuard) CurState() waitingState {
@@ -60,18 +72,30 @@ func (g *mockLockTableGuard) CurState() waitingState {
 }
 func (g *mockLockTableGuard) notify() { g.signal <- struct{}{} }
 
+// mockLockTableGuard implements the LockManager interface.
+func (g *mockLockTableGuard) OnLockAcquired(_ context.Context, _ *roachpb.LockUpdate) {
+	panic("unimplemented")
+}
+func (g *mockLockTableGuard) OnLockUpdated(_ context.Context, up *roachpb.LockUpdate) {
+	if g.state.held && g.state.txn.ID == up.Txn.ID && g.state.key.Equal(up.Key) {
+		g.state = waitingState{stateKind: doneWaiting}
+		g.notify()
+	}
+}
+
 func setupLockTableWaiterTest() (*lockTableWaiterImpl, *mockIntentResolver, *mockLockTableGuard) {
 	ir := &mockIntentResolver{}
 	st := cluster.MakeTestingClusterSettings()
 	LockTableLivenessPushDelay.Override(&st.SV, 0)
 	LockTableDeadlockDetectionPushDelay.Override(&st.SV, 0)
+	guard := &mockLockTableGuard{
+		signal: make(chan struct{}, 1),
+	}
 	w := &lockTableWaiterImpl{
 		st:      st,
 		stopper: stop.NewStopper(),
 		ir:      ir,
-	}
-	guard := &mockLockTableGuard{
-		signal: make(chan struct{}, 1),
+		lm:      guard,
 	}
 	return w, ir, guard
 }
@@ -393,4 +417,111 @@ func TestLockTableWaiterIntentResolverError(t *testing.T) {
 			require.Equal(t, err2, err)
 		}
 	})
+}
+
+// TestLockTableWaiterDeferredIntentResolverError tests that the lockTableWaiter
+// propagates errors from its intent resolver when it resolves intent batches.
+func TestLockTableWaiterDeferredIntentResolverError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	w, ir, g := setupLockTableWaiterTest()
+	defer w.stopper.Stop(ctx)
+
+	txn := makeTxnProto("request")
+	req := Request{
+		Txn:       &txn,
+		Timestamp: txn.ReadTimestamp,
+	}
+	keyA := roachpb.Key("keyA")
+	pusheeTxn := makeTxnProto("pushee")
+
+	// Add the conflicting txn to the finalizedTxnCache so that the request
+	// avoids the transaction record push and defers the intent resolution.
+	pusheeTxn.Status = roachpb.ABORTED
+	w.finalizedTxnCache.add(&pusheeTxn)
+
+	g.state = waitingState{
+		stateKind:   waitForDistinguished,
+		txn:         &pusheeTxn.TxnMeta,
+		key:         keyA,
+		held:        true,
+		guardAccess: spanset.SpanReadWrite,
+	}
+	g.notify()
+
+	// Errors are propagated when observed while resolving batches of intents.
+	err1 := roachpb.NewErrorf("error1")
+	ir.resolveIntents = func(_ context.Context, intents []roachpb.LockUpdate) *Error {
+		require.Len(t, intents, 1)
+		require.Equal(t, keyA, intents[0].Key)
+		require.Equal(t, pusheeTxn.ID, intents[0].Txn.ID)
+		require.Equal(t, roachpb.ABORTED, intents[0].Status)
+		return err1
+	}
+	err := w.WaitOn(ctx, req, g)
+	require.Equal(t, err1, err)
+}
+
+func TestTxnCache(t *testing.T) {
+	var c txnCache
+	const overflow = 4
+	var txns [len(c.txns) + overflow]roachpb.Transaction
+	for i := range txns {
+		txns[i] = makeTxnProto(fmt.Sprintf("txn %d", i))
+	}
+
+	// Add each txn to the cache. Observe LRU eviction policy.
+	for i := range txns {
+		txn := &txns[i]
+		c.add(txn)
+		for j, txnInCache := range c.txns {
+			if j <= i {
+				require.Equal(t, &txns[i-j], txnInCache)
+			} else {
+				require.Nil(t, txnInCache)
+			}
+		}
+	}
+
+	// Access each txn in the cache in reverse order.
+	// Should reverse the order of the cache because of LRU policy.
+	for i := len(txns) - 1; i >= 0; i-- {
+		txn := &txns[i]
+		txnInCache, ok := c.get(txn.ID)
+		if i < overflow {
+			// Expect overflow.
+			require.Nil(t, txnInCache)
+			require.False(t, ok)
+		} else {
+			// Should be in cache.
+			require.Equal(t, txn, txnInCache)
+			require.True(t, ok)
+		}
+	}
+
+	// Cache should be in order again.
+	for i, txnInCache := range c.txns {
+		require.Equal(t, &txns[i+overflow], txnInCache)
+	}
+}
+
+func BenchmarkTxnCache(b *testing.B) {
+	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+	var c txnCache
+	var txns [len(c.txns) + 4]roachpb.Transaction
+	for i := range txns {
+		txns[i] = makeTxnProto(fmt.Sprintf("txn %d", i))
+	}
+	txnOps := make([]*roachpb.Transaction, b.N)
+	for i := range txnOps {
+		txnOps[i] = &txns[rng.Intn(len(txns))]
+	}
+	b.ResetTimer()
+	for i, txnOp := range txnOps {
+		if i%2 == 0 {
+			c.add(txnOp)
+		} else {
+			_, _ = c.get(txnOp.ID)
+		}
+	}
 }

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 type mockIntentResolver struct {
-	pushTxn        func(context.Context, *enginepb.TxnMeta, roachpb.Header, roachpb.PushTxnType) (roachpb.Transaction, *Error)
+	pushTxn        func(context.Context, *enginepb.TxnMeta, roachpb.Header, roachpb.PushTxnType) (*roachpb.Transaction, *Error)
 	resolveIntent  func(context.Context, roachpb.LockUpdate) *Error
 	resolveIntents func(context.Context, []roachpb.LockUpdate) *Error
 }
@@ -38,7 +38,7 @@ type mockIntentResolver struct {
 // mockIntentResolver implements the IntentResolver interface.
 func (m *mockIntentResolver) PushTransaction(
 	ctx context.Context, txn *enginepb.TxnMeta, h roachpb.Header, pushType roachpb.PushTxnType,
-) (roachpb.Transaction, *Error) {
+) (*roachpb.Transaction, *Error) {
 	return m.pushTxn(ctx, txn, h, pushType)
 }
 
@@ -291,7 +291,7 @@ func testWaitPush(t *testing.T, k stateKind, makeReq func() Request, expPushTS h
 				pusheeArg *enginepb.TxnMeta,
 				h roachpb.Header,
 				pushType roachpb.PushTxnType,
-			) (roachpb.Transaction, *Error) {
+			) (*roachpb.Transaction, *Error) {
 				require.Equal(t, &pusheeTxn.TxnMeta, pusheeArg)
 				require.Equal(t, req.Txn, h.Txn)
 				require.Equal(t, expPushTS, h.Timestamp)
@@ -301,7 +301,7 @@ func testWaitPush(t *testing.T, k stateKind, makeReq func() Request, expPushTS h
 					require.Equal(t, roachpb.PUSH_TIMESTAMP, pushType)
 				}
 
-				resp := roachpb.Transaction{TxnMeta: *pusheeArg, Status: roachpb.ABORTED}
+				resp := &roachpb.Transaction{TxnMeta: *pusheeArg, Status: roachpb.ABORTED}
 
 				// If the lock is held, we'll try to resolve it now that
 				// we know the holder is ABORTED. Otherwide, immediately
@@ -396,8 +396,8 @@ func TestLockTableWaiterIntentResolverError(t *testing.T) {
 		g.notify()
 		ir.pushTxn = func(
 			_ context.Context, _ *enginepb.TxnMeta, _ roachpb.Header, _ roachpb.PushTxnType,
-		) (roachpb.Transaction, *Error) {
-			return roachpb.Transaction{}, err1
+		) (*roachpb.Transaction, *Error) {
+			return nil, err1
 		}
 		err := w.WaitOn(ctx, req, g)
 		require.Equal(t, err1, err)
@@ -407,8 +407,8 @@ func TestLockTableWaiterIntentResolverError(t *testing.T) {
 			g.notify()
 			ir.pushTxn = func(
 				_ context.Context, _ *enginepb.TxnMeta, _ roachpb.Header, _ roachpb.PushTxnType,
-			) (roachpb.Transaction, *Error) {
-				return roachpb.Transaction{}, nil
+			) (*roachpb.Transaction, *Error) {
+				return &pusheeTxn, nil
 			}
 			ir.resolveIntent = func(_ context.Context, intent roachpb.LockUpdate) *Error {
 				return err2

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/acquire_wrong_txn_race
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/acquire_wrong_txn_race
@@ -120,7 +120,8 @@ sequence req=req3
 [4] sequence req3: acquiring latches
 [4] sequence req3: blocked on select in spanlatch.(*Manager).waitForSignal
 
-handle-write-intent-error req=req2 txn=txn1 key=k
+handle-write-intent-error req=req2
+  intent txn=txn1 key=k
 ----
 [3] sequence reqRes1: sequencing complete, returned guard
 [5] handle write intent error req2: handled conflicting intents on "k", released latches

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
@@ -1,0 +1,259 @@
+# -------------------------------------------------------------
+# A scan finds 10 abandoned intents from same txn
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=10,1 epoch=0
+----
+
+new-request name=req1 txn=txn1 ts=10,1
+  scan key=a endkey=z
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1
+  intent txn=txn2 key=a
+  intent txn=txn2 key=b
+  intent txn=txn2 key=c
+  intent txn=txn2 key=d
+  intent txn=txn2 key=e
+  intent txn=txn2 key=f
+  intent txn=txn2 key=g
+  intent txn=txn2 key=h
+  intent txn=txn2 key=i
+  intent txn=txn2 key=j
+----
+[2] handle write intent error req1: handled conflicting intents on "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", released latches
+
+debug-lock-table
+----
+global: num=10
+ lock: "a"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+ lock: "b"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+ lock: "d"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+ lock: "e"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+ lock: "f"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+ lock: "g"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+ lock: "h"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+ lock: "i"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+ lock: "j"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+local: num=0
+
+sequence req=req1
+----
+[3] sequence req1: re-sequencing request
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: pushing timestamp of txn 00000002 above 0.000000010,1
+[3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+debug-lock-table
+----
+global: num=10
+ lock: "a"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+   waiting readers:
+    req: 1, txn: 00000001-0000-0000-0000-000000000000
+   distinguished req: 1
+ lock: "b"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+ lock: "d"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+ lock: "e"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+ lock: "f"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+ lock: "g"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+ lock: "h"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+ lock: "i"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+ lock: "j"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+local: num=0
+
+# txn1 is the distinguished waiter on key "a". It will push txn2, notice that it
+# is aborted, and then resolve key "a". Once txn2 is in the finalizedTxnCache,
+# txn1 will create a batch to resolve all other keys together.
+on-txn-updated txn=txn2 status=aborted
+----
+[-] update txn: aborting txn2
+[3] sequence req1: resolving intent "a" for txn 00000002 with ABORTED status
+[3] sequence req1: resolving a batch of 9 intent(s)
+[3] sequence req1: resolving intent "b" for txn 00000002 with ABORTED status
+[3] sequence req1: resolving intent "c" for txn 00000002 with ABORTED status
+[3] sequence req1: resolving intent "d" for txn 00000002 with ABORTED status
+[3] sequence req1: resolving intent "e" for txn 00000002 with ABORTED status
+[3] sequence req1: resolving intent "f" for txn 00000002 with ABORTED status
+[3] sequence req1: resolving intent "g" for txn 00000002 with ABORTED status
+[3] sequence req1: resolving intent "h" for txn 00000002 with ABORTED status
+[3] sequence req1: resolving intent "i" for txn 00000002 with ABORTED status
+[3] sequence req1: resolving intent "j" for txn 00000002 with ABORTED status
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: sequencing complete, returned guard
+
+debug-lock-table
+----
+global: num=0
+local: num=0
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+reset namespace
+----
+
+# -------------------------------------------------------------
+# A series of 3 puts find 1 abandoned intent each from same txn
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=10,1 epoch=0
+----
+
+new-request name=req1 txn=txn1 ts=10,1
+  put key=a value=v1
+  put key=b value=v2
+  put key=c value=v3
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1
+  intent txn=txn2 key=a
+----
+[2] handle write intent error req1: handled conflicting intents on "a", released latches
+
+debug-lock-table
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+   queued writers:
+    active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
+local: num=0
+
+sequence req=req1
+----
+[3] sequence req1: re-sequencing request
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: pushing txn 00000002 to abort
+[3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+on-txn-updated txn=txn2 status=committed
+----
+[-] update txn: committing txn2
+[3] sequence req1: resolving intent "a" for txn 00000002 with COMMITTED status
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1
+  intent txn=txn2 key=b
+----
+[4] handle write intent error req1: handled conflicting intents on "b", released latches
+
+debug-lock-table
+----
+global: num=2
+ lock: "a"
+  res: req: 2, txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, seq: 0
+ lock: "b"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+   queued writers:
+    active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
+local: num=0
+
+sequence req=req1
+----
+[5] sequence req1: re-sequencing request
+[5] sequence req1: acquiring latches
+[5] sequence req1: scanning lock table for conflicting locks
+[5] sequence req1: waiting in lock wait-queues
+[5] sequence req1: resolving a batch of 1 intent(s)
+[5] sequence req1: resolving intent "b" for txn 00000002 with COMMITTED status
+[5] sequence req1: acquiring latches
+[5] sequence req1: scanning lock table for conflicting locks
+[5] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1
+  intent txn=txn2 key=c
+----
+[6] handle write intent error req1: handled conflicting intents on "c", released latches
+
+debug-lock-table
+----
+global: num=3
+ lock: "a"
+  res: req: 2, txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, seq: 0
+ lock: "b"
+  res: req: 2, txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, seq: 0
+ lock: "c"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 0.000000010,1, info: repl epoch: 0, seqs: [0]
+   queued writers:
+    active: false req: 2, txn: 00000001-0000-0000-0000-000000000000
+local: num=0
+
+sequence req=req1
+----
+[7] sequence req1: re-sequencing request
+[7] sequence req1: acquiring latches
+[7] sequence req1: scanning lock table for conflicting locks
+[7] sequence req1: waiting in lock wait-queues
+[7] sequence req1: resolving a batch of 1 intent(s)
+[7] sequence req1: resolving intent "c" for txn 00000002 with COMMITTED status
+[7] sequence req1: acquiring latches
+[7] sequence req1: scanning lock table for conflicting locks
+[7] sequence req1: sequencing complete, returned guard
+
+debug-lock-table
+----
+global: num=3
+ lock: "a"
+  res: req: 2, txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, seq: 0
+ lock: "b"
+  res: req: 2, txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, seq: 0
+ lock: "c"
+  res: req: 2, txn: 00000001-0000-0000-0000-000000000000, ts: 0.000000010,1, seq: 0
+local: num=0
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+reset namespace
+----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
@@ -20,7 +20,8 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 txn=txn1 key=k
+handle-write-intent-error req=req1
+  intent txn=txn1 key=k
 ----
 [2] handle write intent error req1: handled conflicting intents on "k", released latches
 
@@ -82,7 +83,8 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 txn=txn1 key=k
+handle-write-intent-error req=req1
+  intent txn=txn1 key=k
 ----
 [2] handle write intent error req1: pushing timestamp of txn 00000001 above 0.000000012,1
 [2] handle write intent error req1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -139,7 +141,8 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 txn=txn1 key=k
+handle-write-intent-error req=req1
+  intent txn=txn1 key=k
 ----
 [2] handle write intent error req1: pushing txn 00000001 to abort
 [2] handle write intent error req1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -197,7 +200,8 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 txn=txn1 key=k
+handle-write-intent-error req=req1
+  intent txn=txn1 key=k
 ----
 [2] handle write intent error req1: pushing timestamp of txn 00000001 above 0.000000012,1
 [2] handle write intent error req1: blocked on select in concurrency_test.(*cluster).PushTransaction

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -119,7 +119,8 @@ debug-lock-table
 global: num=0
 local: num=0
 
-handle-write-intent-error req=req2 txn=txn1 key=k
+handle-write-intent-error req=req2
+  intent txn=txn1 key=k
 ----
 [3] handle write intent error req2: pushing txn 00000001 to abort
 [3] handle write intent error req2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -142,7 +143,8 @@ sequence req=req2
 [4] sequence req2: scanning lock table for conflicting locks
 [4] sequence req2: sequencing complete, returned guard
 
-handle-write-intent-error req=req2 txn=txn1 key=k2
+handle-write-intent-error req=req2
+  intent txn=txn1 key=k2
 ----
 [5] handle write intent error req2: pushing timestamp of txn 00000001 above 0.000000010,1
 [5] handle write intent error req2: resolving intent "k2" for txn 00000001 with COMMITTED status
@@ -190,7 +192,8 @@ sequence req=req3
 [7] sequence req3: scanning lock table for conflicting locks
 [7] sequence req3: sequencing complete, returned guard
 
-handle-write-intent-error req=req3 txn=txn2 key=k
+handle-write-intent-error req=req3
+  intent txn=txn2 key=k
 ----
 [8] handle write intent error req3: handled conflicting intents on "k", released latches
 
@@ -357,7 +360,8 @@ debug-lock-table
 global: num=0
 local: num=0
 
-handle-write-intent-error req=req2 txn=txn1 key=k
+handle-write-intent-error req=req2
+  intent txn=txn1 key=k
 ----
 [3] handle write intent error req2: handled conflicting intents on "k", released latches
 
@@ -526,7 +530,8 @@ debug-lock-table
 global: num=0
 local: num=0
 
-handle-write-intent-error req=req2 txn=txn1 key=k
+handle-write-intent-error req=req2
+  intent txn=txn1 key=k
 ----
 [3] handle write intent error req2: pushing txn 00000001 to abort
 [3] handle write intent error req2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -549,7 +554,8 @@ sequence req=req2
 [4] sequence req2: scanning lock table for conflicting locks
 [4] sequence req2: sequencing complete, returned guard
 
-handle-write-intent-error req=req2 txn=txn1 key=k2
+handle-write-intent-error req=req2
+  intent txn=txn1 key=k2
 ----
 [5] handle write intent error req2: pushing timestamp of txn 00000001 above 0.000000010,1
 [5] handle write intent error req2: resolving intent "k2" for txn 00000001 with COMMITTED status
@@ -672,7 +678,8 @@ debug-lock-table
 global: num=0
 local: num=0
 
-handle-write-intent-error req=req2 txn=txn1 key=k
+handle-write-intent-error req=req2
+  intent txn=txn1 key=k
 ----
 [3] handle write intent error req2: handled conflicting intents on "k", released latches
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -22,7 +22,8 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 txn=txn1 key=k
+handle-write-intent-error req=req1
+  intent txn=txn1 key=k
 ----
 [2] handle write intent error req1: handled conflicting intents on "k", released latches
 
@@ -82,7 +83,8 @@ sequence req=req1
 [1] sequence req1: scanning lock table for conflicting locks
 [1] sequence req1: sequencing complete, returned guard
 
-handle-write-intent-error req=req1 txn=txn1 key=k
+handle-write-intent-error req=req1
+  intent txn=txn1 key=k
 ----
 [2] handle write intent error req1: handled conflicting intents on "k", released latches
 

--- a/pkg/kv/kvserver/rangefeed/task.go
+++ b/pkg/kv/kvserver/rangefeed/task.go
@@ -116,10 +116,10 @@ func (s *initResolvedTSScan) Cancel() {
 type TxnPusher interface {
 	// PushTxns attempts to push the specified transactions to a new
 	// timestamp. It returns the resulting transaction protos.
-	PushTxns(context.Context, []enginepb.TxnMeta, hlc.Timestamp) ([]roachpb.Transaction, error)
+	PushTxns(context.Context, []enginepb.TxnMeta, hlc.Timestamp) ([]*roachpb.Transaction, error)
 	// CleanupTxnIntentsAsync asynchronously cleans up intents owned
 	// by the specified transactions.
-	CleanupTxnIntentsAsync(context.Context, []roachpb.Transaction) error
+	CleanupTxnIntentsAsync(context.Context, []*roachpb.Transaction) error
 }
 
 // txnPushAttempt pushes all old transactions that have unresolved intents on
@@ -176,7 +176,7 @@ func (a *txnPushAttempt) pushOldTxns(ctx context.Context) error {
 
 	// Inform the Processor of the results of the push for each transaction.
 	ops := make([]enginepb.MVCCLogicalOp, len(pushedTxns))
-	var toCleanup []roachpb.Transaction
+	var toCleanup []*roachpb.Transaction
 	for i, txn := range pushedTxns {
 		switch txn.Status {
 		case roachpb.PENDING, roachpb.STAGING:

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -71,7 +71,7 @@ type rangefeedTxnPusher struct {
 // transactions.
 func (tp *rangefeedTxnPusher) PushTxns(
 	ctx context.Context, txns []enginepb.TxnMeta, ts hlc.Timestamp,
-) ([]roachpb.Transaction, error) {
+) ([]*roachpb.Transaction, error) {
 	pushTxnMap := make(map[uuid.UUID]*enginepb.TxnMeta, len(txns))
 	for i := range txns {
 		txn := &txns[i]
@@ -94,7 +94,7 @@ func (tp *rangefeedTxnPusher) PushTxns(
 		return nil, pErr.GoError()
 	}
 
-	pushedTxns := make([]roachpb.Transaction, 0, len(pushedTxnMap))
+	pushedTxns := make([]*roachpb.Transaction, 0, len(pushedTxnMap))
 	for _, txn := range pushedTxnMap {
 		pushedTxns = append(pushedTxns, txn)
 	}
@@ -103,11 +103,11 @@ func (tp *rangefeedTxnPusher) PushTxns(
 
 // CleanupTxnIntentsAsync is part of the rangefeed.TxnPusher interface.
 func (tp *rangefeedTxnPusher) CleanupTxnIntentsAsync(
-	ctx context.Context, txns []roachpb.Transaction,
+	ctx context.Context, txns []*roachpb.Transaction,
 ) error {
 	endTxns := make([]result.EndTxnIntents, len(txns))
-	for i := range txns {
-		endTxns[i].Txn = &txns[i]
+	for i, txn := range txns {
+		endTxns[i].Txn = txn
 		endTxns[i].Poison = true
 	}
 	return tp.ir.CleanupTxnIntentsAsync(ctx, tp.r.RangeID, endTxns, true /* allowSyncProcessing */)


### PR DESCRIPTION
Backport 2/2 commits from #49218.

/cc @cockroachdb/release

---

Fixes #48790.
Informs #36876.
Closes #31664.

This commit adds a per-Range LRU cache of transactions that are known to be aborted or committed. We use this cache in the lockTableWaiter for two purposes:
1. when we see a lock held by a known-finalized txn, we neither wait out the `kv.lock_table.coordinator_liveness_push_delay` (10 ms) nor push the transactions record (RPC to leaseholder of pushee's txn record range).
2. we use the existence of a transaction in the cache as an indication that it may have abandoned multiple intents, perhaps due to a failure of the transaction coordinator node, so we begin deferring intent resolution to enable batching.

Together, these two changes make us much more effective as cleaning up after failed transactions that have abandoned a large number of intents. The following example demonstrates this:
```sql
--- BEFORE

CREATE TABLE keys (k BIGINT NOT NULL PRIMARY KEY);
BEGIN; INSERT INTO keys SELECT generate_series(1, 10000); ROLLBACK;
SELECT * FROM keys;

  k
-----
(0 rows)

Time: 2m50.801304266s


CREATE TABLE keys2 (k BIGINT NOT NULL PRIMARY KEY);
BEGIN; INSERT INTO keys2 SELECT generate_series(1, 10000); ROLLBACK;
INSERT INTO keys2 SELECT generate_series(1, 10000);

INSERT 10000

Time: 3m26.874571045s



--- AFTER

CREATE TABLE keys (k BIGINT NOT NULL PRIMARY KEY);
BEGIN; INSERT INTO keys SELECT generate_series(1, 10000); ROLLBACK;
SELECT * FROM keys;

  k
-----
(0 rows)

Time: 5.138220753s


CREATE TABLE keys2 (k BIGINT NOT NULL PRIMARY KEY);
BEGIN; INSERT INTO keys2 SELECT generate_series(1, 10000); ROLLBACK;
INSERT INTO keys2 SELECT generate_series(1, 10000);

INSERT 10000

Time: 48.763541138s
```

Notice that we are still not as fast at cleaning up intents on the insertion path as we are at doing so on the retrieval path. This is because we only batch the resolution of intents observed by a single request at a time. For the scanning case, a single ScanRequest notices all 10,000 intents and cleans them all up together. For the insertion case, each of the 10,000 PutRequests notices a single intent, and each intent is cleaned up individually. So this case is only benefited by the first part of this change (no liveness delay or txn record push) and not the second part of this change (intent resolution batching).

For this reason, we still haven't solved all of #36876. To completely address that, we'll need to defer propagation of `WriteIntentError` during batch evaluation, as we do for `WriteTooOldError`s. Or we can wait out the future LockTable changes - once we remove all cases where an intent is not "discovered", the changes here will effectively address #36876.

This was a partial regression in v20.1, so we'll want to backport this to that release branch. This change is on the larger side, but I feel ok about it because the mechanics aren't too tricky. I'll wait a week before backporting just to see if anything falls out.

Release note (bug fix): Abandoned intents due to failed transaction coordinators are now cleaned up much faster. This resolves a regression in v20.1.0 compared to prior releases.

@irfansharif I'm adding you as a reviewer because there's not really anyone else on KV that knows this code, so we should change that.
