### PR TITLE
errorutil/unimplemented: use redirect server for Github links

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -316,7 +316,7 @@ ALTER TABLE t10 ALTER COLUMN y TYPE STRING
 statement ok
 CREATE TABLE t11 (x INT)
 
-statement error pq: unimplemented: ALTER COLUMN TYPE USING EXPRESSION is not supported\nHINT: You have attempted to use a feature that is not yet implemented.\nSee: https://github.com/cockroachdb/cockroach/issues/47706
+statement error pq: unimplemented: ALTER COLUMN TYPE USING EXPRESSION is not supported\nHINT: You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue/47706
 ALTER TABLE t11 ALTER COLUMN x TYPE STRING USING CAST(x AS STRING)
 
 # Ensure ALTER COLUMN TYPE is disallowed if the column has a constraint.

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -3416,7 +3416,7 @@ func TestUnimplementedSyntax(t *testing.T) {
 					t.Errorf("%s: expected %q in telemetry keys, got %+v", d.sql, exp, tkeys)
 				}
 
-				exp2 := fmt.Sprintf("issues/%d", d.issue)
+				exp2 := fmt.Sprintf("issue/%d", d.issue)
 				found = false
 				hints := errors.GetAllHints(err)
 				for _, h := range hints {

--- a/pkg/util/errorutil/unimplemented/unimplemented.go
+++ b/pkg/util/errorutil/unimplemented/unimplemented.go
@@ -100,5 +100,5 @@ func unimplementedInternal(
 
 // MakeURL produces a URL to a CockroachDB issue.
 func MakeURL(issue int) string {
-	return fmt.Sprintf("https://github.com/cockroachdb/cockroach/issues/%d", issue)
+	return fmt.Sprintf("https://go.crdb.dev/issue/%d", issue)
 }


### PR DESCRIPTION
closes #45504

This will allow us to capture telemetry such as click counts for each
unimplemented error that is returned.

Release note (general change): Links that are returned in error messages
to point to unimplemented issues now use the CockroachLabs
redirect/short-link server.