### PR TITLE
docs: enhance the contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,25 @@
 # Contributing to Cockroach
 
-Our contributor guidelines are available on the public wiki here:
-https://wiki.crdb.io/wiki/spaces/CRDB/pages/73204033/Contributing+to+CockroachDB
+Our contributor guidelines are available on [the public wiki at
+**wiki.crdb.io**](https://wiki.crdb.io/wiki/spaces/CRDB/pages/73204033/Contributing+to+CockroachDB).
 
+At this location, we share our team guidelines and knowledge base
+regarding:
+
+- repository layout
+- how to build from source
+- how to organize your code change
+- commenting guidelines
+- commit message guidelines
+- code style guidelines
+- how to write and run tests
+- how to write release notes
+- how to submit a change for review
+- how to use continuous integration (CI)
+- how to troubleshoot certain issues
+
+as well as many other practical topics.
+
+If you have any questions, hop into our [CockroachDB Community
+Slack](https://cockroa.ch/slack), in particular the **#contributors**
+channel where you can ask questions to the CockroachDB team directly.

--- a/README.md
+++ b/README.md
@@ -75,14 +75,20 @@ CockroachDB supports the PostgreSQL wire protocol, so you can use any available 
 - For filing bugs, suggesting improvements, or requesting new features, help us out by
   [opening an issue](https://github.com/cockroachdb/cockroach/issues/new).
 
+## Building from source
+
+See [our wiki](https://wiki.crdb.io/wiki/spaces/CRDB/pages/181338446/Getting+and+building+from+source) for more details.
+
 ## Contributing
 
 We welcome your contributions! If you're looking for issues to work on, try
 looking at the [good first issue](https://github.com/cockroachdb/cockroach/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
 list. We do our best to tag issues suitable for new external contributors with
-that label, so it's a great way to find something you can help with! See our
-[Wiki](https://wiki.crdb.io/wiki/spaces/CRDB/pages/73204033/Contributing+to+CockroachDB)
-for more details. 
+that label, so it's a great way to find something you can help with!
+
+See [our
+wiki](https://wiki.crdb.io/wiki/spaces/CRDB/pages/73204033/Contributing+to+CockroachDB)
+for more details.
 
 Engineering discussion takes place on our public mailing list,
 [cockroach-db@googlegroups.com](https://groups.google.com/forum/#!forum/cockroach-db),


### PR DESCRIPTION
The contributor guide only contained a URL to the wiki, and was
missing searchable keywords.

This patch adds that, as well as a link to the community slack.

Release note: None