### PR TITLE
sql: disallow cross database type references

### DIFF
--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -1,0 +1,149 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemaexpr"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/errors"
+)
+
+// addColumnImpl performs the logic of adding a column within an ALTER TABLE.
+func (p *planner) addColumnImpl(
+	params runParams,
+	n *alterTableNode,
+	tn *tree.TableName,
+	desc *sqlbase.MutableTableDescriptor,
+	t *tree.AlterTableAddColumn,
+) error {
+	d := t.ColumnDef
+	version := params.ExecCfg().Settings.Version.ActiveVersionOrEmpty(params.ctx)
+	toType, err := tree.ResolveType(params.ctx, d.Type, params.p.semaCtx.GetTypeResolver())
+	if err != nil {
+		return err
+	}
+	if supported, err := isTypeSupportedInVersion(version, toType); err != nil {
+		return err
+	} else if !supported {
+		return pgerror.Newf(
+			pgcode.FeatureNotSupported,
+			"type %s is not supported until version upgrade is finalized",
+			toType.SQLString(),
+		)
+	}
+
+	newDef, seqDbDesc, seqName, seqOpts, err := params.p.processSerialInColumnDef(params.ctx, d, tn)
+	if err != nil {
+		return err
+	}
+	if seqName != nil {
+		if err := doCreateSequence(
+			params,
+			n.n.String(),
+			seqDbDesc,
+			n.tableDesc.GetParentSchemaID(),
+			seqName,
+			n.tableDesc.Temporary,
+			seqOpts,
+			tree.AsStringWithFQNames(n.n, params.Ann()),
+		); err != nil {
+			return err
+		}
+	}
+	d = newDef
+	incTelemetryForNewColumn(d)
+
+	col, idx, expr, err := sqlbase.MakeColumnDefDescs(params.ctx, d, &params.p.semaCtx, params.EvalContext())
+	if err != nil {
+		return err
+	}
+	// If the new column has a DEFAULT expression that uses a sequence, add references between
+	// its descriptor and this column descriptor.
+	if d.HasDefaultExpr() {
+		changedSeqDescs, err := maybeAddSequenceDependencies(
+			params.ctx, params.p, n.tableDesc, col, expr, nil,
+		)
+		if err != nil {
+			return err
+		}
+		for _, changedSeqDesc := range changedSeqDescs {
+			if err := params.p.writeSchemaChange(
+				params.ctx, changedSeqDesc, sqlbase.InvalidMutationID, tree.AsStringWithFQNames(n.n, params.Ann()),
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	// We're checking to see if a user is trying add a non-nullable column without a default to a
+	// non empty table by scanning the primary index span with a limit of 1 to see if any key exists.
+	if !col.Nullable && (col.DefaultExpr == nil && !col.IsComputed()) {
+		span := n.tableDesc.PrimaryIndexSpan(params.ExecCfg().Codec)
+		kvs, err := params.p.txn.Scan(params.ctx, span.Key, span.EndKey, 1)
+		if err != nil {
+			return err
+		}
+		if len(kvs) > 0 {
+			return sqlbase.NewNonNullViolationError(col.Name)
+		}
+	}
+	_, err = n.tableDesc.FindActiveColumnByName(string(d.Name))
+	if m := n.tableDesc.FindColumnMutationByName(d.Name); m != nil {
+		switch m.Direction {
+		case sqlbase.DescriptorMutation_ADD:
+			return pgerror.Newf(pgcode.DuplicateColumn,
+				"duplicate: column %q in the middle of being added, not yet public",
+				col.Name)
+		case sqlbase.DescriptorMutation_DROP:
+			return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+				"column %q being dropped, try again later", col.Name)
+		default:
+			if err != nil {
+				return errors.AssertionFailedf(
+					"mutation in state %s, direction %s, and no column descriptor",
+					errors.Safe(m.State), errors.Safe(m.Direction))
+			}
+		}
+	}
+	if err == nil {
+		if t.IfNotExists {
+			return nil
+		}
+		return sqlbase.NewColumnAlreadyExistsError(string(d.Name), n.tableDesc.Name)
+	}
+
+	n.tableDesc.AddColumnMutation(col, sqlbase.DescriptorMutation_ADD)
+	if idx != nil {
+		if err := n.tableDesc.AddIndexMutation(idx, sqlbase.DescriptorMutation_ADD); err != nil {
+			return err
+		}
+	}
+	if d.HasColumnFamily() {
+		err := n.tableDesc.AddColumnToFamilyMaybeCreate(
+			col.Name, string(d.Family.Name), d.Family.Create,
+			d.Family.IfNotExists)
+		if err != nil {
+			return err
+		}
+	}
+
+	if d.IsComputed() {
+		computedColValidator := schemaexpr.NewComputedColumnValidator(params.ctx, n.tableDesc, &params.p.semaCtx)
+		if err := computedColValidator.Validate(d); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -144,124 +144,13 @@ func (n *alterTableNode) startExec(params runParams) error {
 
 		switch t := cmd.(type) {
 		case *tree.AlterTableAddColumn:
-			d := t.ColumnDef
-			version := params.ExecCfg().Settings.Version.ActiveVersionOrEmpty(params.ctx)
-			toType, err := tree.ResolveType(params.ctx, d.Type, params.p.semaCtx.GetTypeResolver())
+			var err error
+			params.p.runWithOptions(resolveFlags{contextDatabaseID: n.tableDesc.ParentID}, func() {
+				err = params.p.addColumnImpl(params, n, tn, n.tableDesc, t)
+			})
 			if err != nil {
 				return err
 			}
-			if supported, err := isTypeSupportedInVersion(version, toType); err != nil {
-				return err
-			} else if !supported {
-				return pgerror.Newf(
-					pgcode.FeatureNotSupported,
-					"type %s is not supported until version upgrade is finalized",
-					toType.SQLString(),
-				)
-			}
-
-			newDef, seqDbDesc, seqName, seqOpts, err := params.p.processSerialInColumnDef(params.ctx, d, tn)
-			if err != nil {
-				return err
-			}
-			if seqName != nil {
-				if err := doCreateSequence(
-					params,
-					n.n.String(),
-					seqDbDesc,
-					n.tableDesc.GetParentSchemaID(),
-					seqName,
-					n.tableDesc.Temporary,
-					seqOpts,
-					tree.AsStringWithFQNames(n.n, params.Ann()),
-				); err != nil {
-					return err
-				}
-			}
-			d = newDef
-			incTelemetryForNewColumn(d)
-
-			col, idx, expr, err := sqlbase.MakeColumnDefDescs(params.ctx, d, &params.p.semaCtx, params.EvalContext())
-			if err != nil {
-				return err
-			}
-			// If the new column has a DEFAULT expression that uses a sequence, add references between
-			// its descriptor and this column descriptor.
-			if d.HasDefaultExpr() {
-				changedSeqDescs, err := maybeAddSequenceDependencies(
-					params.ctx, params.p, n.tableDesc, col, expr, nil,
-				)
-				if err != nil {
-					return err
-				}
-				for _, changedSeqDesc := range changedSeqDescs {
-					if err := params.p.writeSchemaChange(
-						params.ctx, changedSeqDesc, sqlbase.InvalidMutationID, tree.AsStringWithFQNames(n.n, params.Ann()),
-					); err != nil {
-						return err
-					}
-				}
-			}
-
-			// We're checking to see if a user is trying add a non-nullable column without a default to a
-			// non empty table by scanning the primary index span with a limit of 1 to see if any key exists.
-			if !col.Nullable && (col.DefaultExpr == nil && !col.IsComputed()) {
-				span := n.tableDesc.PrimaryIndexSpan(params.ExecCfg().Codec)
-				kvs, err := params.p.txn.Scan(params.ctx, span.Key, span.EndKey, 1)
-				if err != nil {
-					return err
-				}
-				if len(kvs) > 0 {
-					return sqlbase.NewNonNullViolationError(col.Name)
-				}
-			}
-			_, err = n.tableDesc.FindActiveColumnByName(string(d.Name))
-			if m := n.tableDesc.FindColumnMutationByName(d.Name); m != nil {
-				switch m.Direction {
-				case sqlbase.DescriptorMutation_ADD:
-					return pgerror.Newf(pgcode.DuplicateColumn,
-						"duplicate: column %q in the middle of being added, not yet public",
-						col.Name)
-				case sqlbase.DescriptorMutation_DROP:
-					return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
-						"column %q being dropped, try again later", col.Name)
-				default:
-					if err != nil {
-						return errors.AssertionFailedf(
-							"mutation in state %s, direction %s, and no column descriptor",
-							errors.Safe(m.State), errors.Safe(m.Direction))
-					}
-				}
-			}
-			if err == nil {
-				if t.IfNotExists {
-					continue
-				}
-				return sqlbase.NewColumnAlreadyExistsError(string(d.Name), n.tableDesc.Name)
-			}
-
-			n.tableDesc.AddColumnMutation(col, sqlbase.DescriptorMutation_ADD)
-			if idx != nil {
-				if err := n.tableDesc.AddIndexMutation(idx, sqlbase.DescriptorMutation_ADD); err != nil {
-					return err
-				}
-			}
-			if d.HasColumnFamily() {
-				err := n.tableDesc.AddColumnToFamilyMaybeCreate(
-					col.Name, string(d.Family.Name), d.Family.Create,
-					d.Family.IfNotExists)
-				if err != nil {
-					return err
-				}
-			}
-
-			if d.IsComputed() {
-				computedColValidator := schemaexpr.NewComputedColumnValidator(params.ctx, n.tableDesc, &params.p.semaCtx)
-				if err := computedColValidator.Validate(d); err != nil {
-					return err
-				}
-			}
-
 		case *tree.AlterTableAddConstraint:
 			switch d := t.ConstraintDef.(type) {
 			case *tree.UniqueConstraintTableDef:
@@ -315,24 +204,32 @@ func (n *alterTableNode) startExec(params runParams) error {
 				}
 
 			case *tree.CheckConstraintTableDef:
-				info, err := n.tableDesc.GetConstraintInfo(params.ctx, nil, params.ExecCfg().Codec)
+				var err error
+				params.p.runWithOptions(resolveFlags{contextDatabaseID: n.tableDesc.ParentID}, func() {
+					info, infoErr := n.tableDesc.GetConstraintInfo(params.ctx, nil, params.ExecCfg().Codec)
+					if err != nil {
+						err = infoErr
+						return
+					}
+					ckBuilder := schemaexpr.NewCheckConstraintBuilder(params.ctx, *tn, n.tableDesc, &params.p.semaCtx)
+					for k := range info {
+						ckBuilder.MarkNameInUse(k)
+					}
+					ck, buildErr := ckBuilder.Build(d)
+					if buildErr != nil {
+						err = buildErr
+						return
+					}
+					if t.ValidationBehavior == tree.ValidationDefault {
+						ck.Validity = sqlbase.ConstraintValidity_Validating
+					} else {
+						ck.Validity = sqlbase.ConstraintValidity_Unvalidated
+					}
+					n.tableDesc.AddCheckMutation(ck, sqlbase.DescriptorMutation_ADD)
+				})
 				if err != nil {
 					return err
 				}
-				ckBuilder := schemaexpr.NewCheckConstraintBuilder(params.ctx, *tn, n.tableDesc, &params.p.semaCtx)
-				for k := range info {
-					ckBuilder.MarkNameInUse(k)
-				}
-				ck, err := ckBuilder.Build(d)
-				if err != nil {
-					return err
-				}
-				if t.ValidationBehavior == tree.ValidationDefault {
-					ck.Validity = sqlbase.ConstraintValidity_Validating
-				} else {
-					ck.Validity = sqlbase.ConstraintValidity_Unvalidated
-				}
-				n.tableDesc.AddCheckMutation(ck, sqlbase.DescriptorMutation_ADD)
 
 			case *tree.ForeignKeyConstraintTableDef:
 				for _, colName := range d.FromCols {

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -54,7 +54,7 @@ func validateCheckExpr(
 	}
 	lim := &tree.Limit{Count: tree.NewDInt(1)}
 	stmt := &tree.Select{Select: sel, Limit: lim}
-	queryStr := tree.AsStringWithFlags(stmt, tree.FmtParsable)
+	queryStr := tree.AsStringWithFlags(stmt, tree.FmtSerializable)
 	log.Infof(ctx, "Validating check constraint %q with query %q", tree.SerializeForDisplay(expr), queryStr)
 
 	rows, err := ie.QueryRow(ctx, "validate check constraint", txn, queryStr)

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1097,7 +1097,7 @@ func getFinalSourceQuery(source *tree.Select, evalCtx *tree.EvalContext) string 
 	// We use tree.FormatNode merely as a traversal method; its output buffer is
 	// discarded immediately after the traversal because it is not needed
 	// further.
-	f := tree.NewFmtCtx(tree.FmtParsable)
+	f := tree.NewFmtCtx(tree.FmtSerializable)
 	f.SetReformatTableNames(
 		func(_ *tree.FmtCtx, tn *tree.TableName) {
 			// Persist the database prefix expansion.
@@ -1113,7 +1113,7 @@ func getFinalSourceQuery(source *tree.Select, evalCtx *tree.EvalContext) string 
 	f.Close()
 
 	// Substitute placeholders with their values.
-	ctx := tree.NewFmtCtx(tree.FmtParsable)
+	ctx := tree.NewFmtCtx(tree.FmtSerializable)
 	ctx.SetPlaceholderFormat(func(ctx *tree.FmtCtx, placeholder *tree.Placeholder) {
 		d, err := placeholder.Eval(evalCtx)
 		if err != nil {
@@ -1833,7 +1833,7 @@ func makeTableDesc(
 	// it needs to pull in descriptors from FK depended-on tables
 	// and interleaved parents using their current state in KV.
 	// See the comment at the start of MakeTableDesc() and resolveFK().
-	params.p.runWithOptions(resolveFlags{skipCache: true}, func() {
+	params.p.runWithOptions(resolveFlags{skipCache: true, contextDatabaseID: parentID}, func() {
 		ret, err = MakeTableDesc(
 			params.ctx,
 			params.p.txn,

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -395,7 +395,7 @@ query TT
 SHOW CREATE t1
 ----
 t1  CREATE TABLE t1 (
-    x test.public.greeting NULL,
+    x public.greeting NULL,
     INDEX i (x ASC),
     FAMILY "primary" (x, rowid)
 )
@@ -406,7 +406,7 @@ query T
 SELECT create_statement FROM crdb_internal.create_statements WHERE descriptor_name = 't1'
 ----
 CREATE TABLE t1 (
-   x test.public.greeting NULL,
+   x public.greeting NULL,
    INDEX i (x ASC),
    FAMILY "primary" (x, rowid)
 )
@@ -418,7 +418,7 @@ SELECT ARRAY['hello']::_greeting, ARRAY['hello'::greeting]
 {hello} {hello}
 
 # Test that we can't mix enums in an array.
-query error pq: expected 'cockroach'::test.public.dbs to be of type greeting, found type dbs
+query error pq: expected 'cockroach'::public.dbs to be of type greeting, found type dbs
 SELECT ARRAY['hello'::greeting, 'cockroach'::dbs]
 
 statement ok
@@ -434,7 +434,7 @@ SELECT * FROM enum_array
 query TTT
 SELECT pg_typeof(x), pg_typeof(x[1]), pg_typeof(ARRAY['hello']::_greeting) FROM enum_array LIMIT 1
 ----
-test.public.greeting[] test.public.greeting test.public.greeting[]
+public.greeting[]  public.greeting  public.greeting[]
 
 # Ensure that the implicitly created array type will tolerate collisions.
 # _collision will create __collision as its implicit array type, so the
@@ -492,8 +492,8 @@ SHOW CREATE enum_default
 ----
 enum_default  CREATE TABLE enum_default (
               x INT8 NULL,
-              y test.public.greeting NULL DEFAULT 'hello':::test.public.greeting,
-              z BOOL NULL DEFAULT 'hello':::test.public.greeting IS OF (test.public.greeting, test.public.greeting),
+              y public.greeting NULL DEFAULT 'hello':::public.greeting,
+              z BOOL NULL DEFAULT 'hello':::public.greeting IS OF (public.greeting, public.greeting),
               FAMILY fam_0_x_y_z_rowid (x, y, z, rowid)
 )
 
@@ -508,8 +508,8 @@ WHERE
 ORDER BY
   column_name
 ----
-y  'hello':::test.public.greeting
-z  'hello':::test.public.greeting IS OF (test.public.greeting, test.public.greeting)
+y  'hello':::public.greeting
+z  'hello':::public.greeting IS OF (public.greeting, public.greeting)
 
 # Test information_schema.columns.
 query TT
@@ -522,8 +522,8 @@ WHERE
 ORDER BY
   column_name
 ----
-y  'hello':::test.public.greeting
-z  'hello':::test.public.greeting IS OF (test.public.greeting, test.public.greeting)
+y  'hello':::public.greeting
+z  'hello':::public.greeting IS OF (public.greeting, public.greeting)
 
 # Test computed columns with enum values.
 statement ok
@@ -547,9 +547,9 @@ SHOW CREATE enum_computed
 ----
 enum_computed  CREATE TABLE enum_computed (
                x INT8 NULL,
-               y test.public.greeting NULL AS ('hello':::test.public.greeting) STORED,
-               z BOOL NULL AS (w = 'howdy':::test.public.greeting) STORED,
-               w test.public.greeting NULL,
+               y public.greeting NULL AS ('hello':::public.greeting) STORED,
+               z BOOL NULL AS (w = 'howdy':::public.greeting) STORED,
+               w public.greeting NULL,
                FAMILY fam_0_x_y_z_w_rowid (x, y, z, w, rowid)
 )
 
@@ -564,8 +564,8 @@ WHERE
 ORDER BY
   column_name
 ----
-y  'hello':::test.public.greeting
-z  w = 'howdy':::test.public.greeting
+y  'hello':::public.greeting
+z  w = 'howdy':::public.greeting
 
 # Test check constraints with enum values.
 statement ok
@@ -580,10 +580,10 @@ query TT
 SHOW CREATE enum_checks
 ----
 enum_checks  CREATE TABLE enum_checks (
-             x test.public.greeting NULL,
+             x public.greeting NULL,
              FAMILY "primary" (x, rowid),
-             CONSTRAINT check_x CHECK (x = 'hello':::test.public.greeting::test.public.greeting),
-             CONSTRAINT "check" CHECK ('hello':::test.public.greeting = 'hello':::test.public.greeting)
+             CONSTRAINT check_x CHECK (x = 'hello':::public.greeting::public.greeting),
+             CONSTRAINT "check" CHECK ('hello':::public.greeting = 'hello':::public.greeting)
 )
 
 # Ensure that we can add check constraints to tables with enums.
@@ -594,11 +594,11 @@ INSERT INTO enum_checks VALUES ('hi'), ('howdy');
 ALTER TABLE enum_checks ADD CHECK (x > 'hello')
 
 # Ensure that checks are validated on insert.
-statement error pq: failed to satisfy CHECK constraint \(x > 'hello':::test.public.greeting\)
+statement error pq: failed to satisfy CHECK constraint \(x > 'hello':::public.greeting\)
 INSERT INTO enum_checks VALUES ('hello')
 
 # Try adding a check that fails validation.
-statement error pq: validation of CHECK "x = 'hello':::test.public.greeting" failed
+statement error pq: validation of CHECK "x = 'hello':::public.greeting" failed
 ALTER TABLE enum_checks ADD CHECK (x = 'hello')
 
 # Check the above cases, but in a transaction.
@@ -609,7 +609,7 @@ CREATE TABLE enum_checks (x greeting);
 INSERT INTO enum_checks VALUES ('hi'), ('howdy');
 ALTER TABLE enum_checks ADD CHECK (x > 'hello')
 
-statement error pq: failed to satisfy CHECK constraint \(x > 'hello':::test.public.greeting\)
+statement error pq: failed to satisfy CHECK constraint \(x > 'hello':::public.greeting\)
 INSERT INTO enum_checks VALUES ('hello')
 
 statement ok
@@ -621,11 +621,51 @@ CREATE TABLE enum_checks (x greeting);
 INSERT INTO enum_checks VALUES ('hi'), ('howdy');
 
 # Try adding a check that fails validation.
-statement error pq: validation of CHECK "x = 'hello':::test.public.greeting" failed
+statement error pq: validation of CHECK "x = 'hello':::public.greeting" failed
 ALTER TABLE enum_checks ADD CHECK (x = 'hello')
 
 statement ok
 ROLLBACK
+
+# Test that cross database type references are disallowed.
+statement ok
+CREATE DATABASE other;
+CREATE TYPE other.t AS ENUM ('other')
+
+# We can still reference other databases types when creating objects
+# within those databases.
+statement ok
+CREATE TABLE other.tt (x other.t)
+
+# Referencing other databases in this database's objects will error.
+statement error pq: cross database type references are not supported: other.public.t
+CREATE TABLE cross_error (x other.t)
+
+# Test that we can't hide cross database references in expressions.
+statement error pq: cross database type references are not supported: other.public.t
+CREATE TABLE cross_error (x BOOL DEFAULT ('other':::other.t = 'other':::other.t))
+
+statement error pq: cross database type references are not supported: other.public.t
+CREATE TABLE cross_error (x BOOL AS ('other':::other.t = 'other':::other.t) STORED)
+
+statement error pq: cross database type references are not supported: other.public.t
+CREATE TABLE cross_error (x INT, CHECK ('other':::other.t = 'other':::other.t))
+
+# Test that we can't add columns or checks that use these either.
+statement ok
+CREATE TABLE cross_error (x INT)
+
+statement error pq: cross database type references are not supported: other.public.t
+ALTER TABLE cross_error ADD COLUMN y other.t
+
+statement error pq: cross database type references are not supported: other.public.t
+ALTER TABLE cross_error ADD COLUMN y BOOL DEFAULT ('other':::other.t = 'other':::other.t)
+
+statement error pq: cross database type references are not supported: other.public.t
+ALTER TABLE cross_error ADD COLUMN y BOOL AS ('other':::other.t = 'other':::other.t) STORED
+
+statement error pq: cross database type references are not supported: other.public.t
+ALTER TABLE cross_error ADD CHECK ('other':::other.t = 'other':::other.t)
 
 subtest schema_changes
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -197,6 +197,12 @@ type planner struct {
 	noticeSender noticeSender
 
 	queryCacheSession querycache.Session
+
+	// contextDatabaseID is the ID of a database. It is set during some name
+	// resolution processes to disallow cross database references. In particular,
+	// the type resolution steps will disallow resolution of types that have a
+	// parentID != contextDatabaseID when it is set.
+	contextDatabaseID sqlbase.ID
 }
 
 func (ctx *extendedEvalContext) setSessionID(sessionID ClusterWideID) {

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -148,7 +148,10 @@ const (
 	FmtPgwireText FmtFlags = fmtPgwireFormat | FmtFlags(lex.EncBareStrings)
 
 	// FmtParsable instructs the pretty-printer to produce a representation that
-	// can be parsed into an equivalent expression.
+	// can be parsed into an equivalent expression. If there is a chance that the
+	// formatted data will be stored durably on disk or sent to other nodes,
+	// then this formatting directive is not appropriate, and FmtSerializable
+	// should be used instead.
 	FmtParsable FmtFlags = fmtDisambiguateDatumTypes | FmtParsableNumerics
 
 	// FmtSerializable instructs the pretty-printer to produce a representation

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -241,8 +241,8 @@ func (u UserDefinedTypeName) Basename() string {
 // FQName returns the fully qualified name.
 func (u UserDefinedTypeName) FQName() string {
 	var sb strings.Builder
-	sb.WriteString(u.Catalog)
-	sb.WriteString(".")
+	// Note that cross-database type references are disabled, so we only
+	// format the qualified name with the schema.
 	sb.WriteString(u.Schema)
 	sb.WriteString(".")
 	sb.WriteString(u.Name)


### PR DESCRIPTION
Fixes #49809.

This PR disallows using types from other databases in tables. This makes
certain behavior (like `DROP TYPE`) more predictable in their effects,
as well as unblocking some work for supporting user defined types in
`cockroach dump`.

Release note (sql change): Referencing types across databases has been
disabled.