### PR TITLE
util/log: clean up and document the handling of stderr

### DIFF
--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -8,12 +8,10 @@ spawn /bin/bash
 send "PS1=':''/# '\r"
 eexpect ":/# "
 
-start_test "Check that a server encountering a fatal error when not logging to stderr shows the fatal error."
+start_test "Check that a server encountering a fatal error when not logging to stderr exits with the right code."
 send "$argv start-single-node -s=path=logs/db --insecure\r"
 eexpect "CockroachDB node starting"
 system "$argv sql --insecure -e \"select crdb_internal.force_log_fatal('helloworld')\" || true"
-eexpect "\r\nF"
-eexpect "helloworld"
 eexpect ":/# "
 send "echo \$?\r"
 eexpect "255"
@@ -36,7 +34,7 @@ eexpect ":/# "
 # is only reported on the logger which is writing first after stderr
 # is has been broken, and that may be the secondary logger.
 send "tail -F `find logs/db/logs -type l`\r"
-eexpect "log: exiting because of error: write /dev/stderr: broken pipe"
+eexpect "error: write /dev/stderr: broken pipe"
 interrupt
 eexpect ":/# "
 end_test

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -3025,7 +3025,10 @@ func TestDecommission(t *testing.T) {
 	admin := serverpb.NewAdminClient(cc)
 	// Decommission the first node, which holds most of the leases.
 	_, err = admin.Decommission(
-		ctx, &serverpb.DecommissionRequest{Decommissioning: true},
+		ctx, &serverpb.DecommissionRequest{
+			NodeIDs:         []roachpb.NodeID{1},
+			Decommissioning: true,
+		},
 	)
 	require.NoError(t, err)
 
@@ -3059,7 +3062,10 @@ func TestDecommission(t *testing.T) {
 	ts := timeutil.Now()
 
 	_, err = admin.Decommission(
-		ctx, &serverpb.DecommissionRequest{NodeIDs: []roachpb.NodeID{2}, Decommissioning: true},
+		ctx, &serverpb.DecommissionRequest{
+			NodeIDs:         []roachpb.NodeID{2},
+			Decommissioning: true,
+		},
 	)
 	require.NoError(t, err)
 
@@ -3084,7 +3090,10 @@ func TestDecommission(t *testing.T) {
 	// Decommission two more nodes. Only n5 is left; getting the replicas there
 	// can't use atomic replica swaps because the leaseholder can't be removed.
 	_, err = admin.Decommission(
-		ctx, &serverpb.DecommissionRequest{NodeIDs: []roachpb.NodeID{3, 4}, Decommissioning: true},
+		ctx, &serverpb.DecommissionRequest{
+			NodeIDs:         []roachpb.NodeID{3, 4},
+			Decommissioning: true,
+		},
 	)
 	require.NoError(t, err)
 

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1714,6 +1714,10 @@ func (s *adminServer) Decommission(
 ) (*serverpb.DecommissionStatusResponse, error) {
 	nodeIDs := req.NodeIDs
 
+	if len(nodeIDs) == 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "no node ID specified")
+	}
+
 	// Mark the target nodes as decommissioning. They'll find out as they
 	// heartbeat their liveness.
 	if err := s.server.Decommission(ctx, req.Decommissioning, nodeIDs); err != nil {

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -90,8 +90,11 @@ func setFlags() {
 	ResetExitFunc()
 	mainLog.mu.Lock()
 	defer mainLog.mu.Unlock()
-	mainLog.noStderrRedirect = false
-	logging.stderrThreshold = Severity_ERROR
+	// Make the internal stderr writes go to the stderr log file.
+	stderrLog.noRedirectInternalStderrWrites = false
+	// Make all logged errors go to the external stderr, in addition to
+	// the log file.
+	mainLog.stderrThreshold = Severity_ERROR
 }
 
 // Test that Info works as advertised.
@@ -568,7 +571,7 @@ func TestFatalStacktraceStderr(t *testing.T) {
 	defer s.Close(t)
 
 	setFlags()
-	logging.stderrThreshold = Severity_NONE
+	mainLog.stderrThreshold = Severity_NONE
 	SetExitFunc(false /* hideStack */, func(int) {})
 
 	defer setFlags()
@@ -606,7 +609,7 @@ func TestRedirectStderr(t *testing.T) {
 	defer s.Close(t)
 
 	setFlags()
-	logging.stderrThreshold = Severity_NONE
+	mainLog.stderrThreshold = Severity_NONE
 
 	Infof(context.Background(), "test")
 

--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -108,20 +108,31 @@ var Safe = errors.Safe
 func ReportPanic(ctx context.Context, sv *settings.Values, r interface{}, depth int) {
 	Shout(ctx, Severity_ERROR, "a panic has occurred!")
 
-	if mainLog.stderrRedirected() {
-		// We do not use Shout() to print the panic details here, because
-		// if stderr is not redirected (e.g. when logging to file is
-		// disabled) Shout() would copy its argument to stderr
-		// unconditionally, and we don't want that: Go's runtime system
-		// already unconditonally copies the panic details to stderr.
-		// Instead, we copy manually the details to stderr, only when stderr
-		// is redirected to a file otherwise.
-		fmt.Fprintf(OrigStderr, "%v\n\n%s\n", r, debug.Stack())
+	if stderrLog.redirectInternalStderrWrites() {
+		// If we decided that the internal stderr writes performed by the
+		// Go runtime are going to our file, that's also where the panic
+		// details will go automatically when the runtime processes the
+		// uncaught panic.
+		// This means the panic details won't get copied to
+		// the process' external stderr stream automatically
+		// any more.
+		// Now, if the user asked that fatal errors be copied
+		// to the external stderr as well, we'll take that
+		// as an indication they also want to see panic details
+		// there. Do it here.
+		if LoggingToStderr(Severity_FATAL) {
+			// TODO(knz): Produce a log entry header to get a timestamp
+			// here.
+			fmt.Fprintf(OrigStderr, "%v\n\n%s\n", r, debug.Stack())
+		}
 	} else {
-		// If stderr is not redirected, then Go's runtime will only print
-		// out the panic details to the original stderr, and we'll miss a copy
-		// in the log file. Produce it here.
-		mainLog.printPanicToFile(r)
+		// If we are not redirecting internal stderr writes, then the
+		// details printed by the Go runtime won't automatically reach our
+		// log file and instead go to the process' external stderr.
+		//
+		// However, we actually want to persist these details. So print
+		// them in the log file ourselves.
+		stderrLog.printPanicToFile(r)
 	}
 
 	sendCrashReport(ctx, sv, PanicAsError(depth+1, r), ReportTypePanic)

--- a/pkg/util/log/exit_override.go
+++ b/pkg/util/log/exit_override.go
@@ -14,6 +14,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/cockroachdb/cockroach/pkg/util/caller"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 // SetExitFunc allows setting a function that will be called to exit
@@ -74,10 +77,21 @@ func (l *loggerT) exitLocked(err error) {
 
 // reportErrorEverywhereLocked writes the error details to both the
 // process' original stderr and the log file if configured.
-//
-// TODO(knz): Create a log entry header for this error, to get a
-// timestamp and later a redactable marker.
 func (l *loggerT) reportErrorEverywhereLocked(err error) {
+	// Make a valid log entry for this error.
+	file, line, _ := caller.Lookup(1)
+	entry := MakeEntry(Severity_ERROR, timeutil.Now().UnixNano(), file, line,
+		fmt.Sprintf("logging error: %v", err))
+
+	// Format the entry for output below. Note how this formatting is
+	// done just once here for both the stderr and file outputs below,
+	// and thus misses out on TTY colors if configured. We afford this
+	// simplification because we only arrive here in case of
+	// likely-unrecoverable error, and there's not much incentive to be
+	// overly aesthetic in this case.
+	buf := logging.formatLogEntry(entry, nil /*stacks*/, nil /*color profile*/)
+	defer putBuffer(buf)
+
 	// Either stderr or our log file is broken. Try writing the error to both
 	// streams in the hope that one still works or else the user will have no idea
 	// why we crashed.
@@ -94,7 +108,9 @@ func (l *loggerT) reportErrorEverywhereLocked(err error) {
 		if w == nil {
 			continue
 		}
-		fmt.Fprintf(w, "log: exiting because of error: %s\n", err)
+		// We're already in error. If an additional error is encountered
+		// here, we can't do anything but raise our hands in the air.
+		_, _ = w.Write(buf.Bytes())
 	}
 	l.flushAndSync(true /*doSync*/)
 }

--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -18,14 +18,14 @@ import (
 
 func init() {
 	logflags.InitFlags(
-		&mainLog.noStderrRedirect,
+		&stderrLog.noRedirectInternalStderrWrites,
 		&mainLog.logDir, &showLogs, &noColor,
 		&logging.vmoduleConfig.mu.vmodule,
 		&LogFileMaxSize, &LogFilesCombinedMaxSize,
 	)
 	// We define these flags here because they have the type Severity
 	// which we can't pass to logflags without creating an import cycle.
-	flag.Var(&logging.stderrThreshold,
+	flag.Var(&mainLog.stderrThreshold,
 		logflags.LogToStderrName, "logs at or above this threshold go to stderr")
 	flag.Var(&mainLog.fileThreshold,
 		logflags.LogFileVerbosityThresholdName, "minimum verbosity of messages written to the log file")

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -60,7 +60,10 @@ func Shoutf(ctx context.Context, sev Severity, format string, args ...interface{
 		})
 		defer t.Stop()
 	}
-	if mainLog.stderrRedirected() {
+	if !LoggingToStderr(sev) {
+		// The logging call below would not otherwise appear on stderr;
+		// however this is what the Shout() contract guarantees, so we do
+		// it here.
 		fmt.Fprintf(OrigStderr, "*\n* %s: %s\n*\n", sev.String(),
 			strings.Replace(MakeMessage(ctx, format, args), "\n", "\n* ", -1))
 	}

--- a/pkg/util/log/log_gc_test.go
+++ b/pkg/util/log/log_gc_test.go
@@ -75,9 +75,13 @@ func testLogGC(
 
 	const newLogFiles = 20
 
-	// Prevent writes to stderr from being sent to log files which would screw up
-	// the expected number of log file calculation below.
-	mainLog.noStderrRedirect = true
+	// Prevent direct writes to fd 2 from being sent to log
+	// files which would screw up the expected number of log file
+	// calculation below.
+	//
+	// TODO(knz): I suspect this is not needed. Investigate and perhaps
+	// remove.
+	stderrLog.noRedirectInternalStderrWrites = true
 
 	// Ensure the main log has at least one entry. This serves two
 	// purposes. One is to serve as baseline for the file size. The

--- a/pkg/util/log/secondary_log.go
+++ b/pkg/util/log/secondary_log.go
@@ -66,11 +66,12 @@ func NewSecondaryLogger(
 	}
 	l := &SecondaryLogger{
 		logger: loggerT{
-			logDir:           DirName{name: dir},
-			prefix:           program + "-" + fileNamePrefix,
-			fileThreshold:    Severity_INFO,
-			noStderrRedirect: true,
-			gcNotify:         make(chan struct{}, 1),
+			logDir:                         DirName{name: dir},
+			prefix:                         program + "-" + fileNamePrefix,
+			fileThreshold:                  Severity_INFO,
+			stderrThreshold:                mainLog.stderrThreshold.get(),
+			noRedirectInternalStderrWrites: true,
+			gcNotify:                       make(chan struct{}, 1),
 		},
 		forceSyncWrites: forceSyncWrites,
 		enableMsgCount:  enableMsgCount,

--- a/pkg/util/log/secondary_log_test.go
+++ b/pkg/util/log/secondary_log_test.go
@@ -79,7 +79,7 @@ func TestRedirectStderrWithSecondaryLoggersActive(t *testing.T) {
 	defer s.Close(t)
 
 	setFlags()
-	logging.stderrThreshold = Severity_NONE
+	mainLog.stderrThreshold = Severity_NONE
 
 	// Ensure that the main log is initialized. This should take over
 	// stderr.

--- a/pkg/util/log/stderr_redirect.go
+++ b/pkg/util/log/stderr_redirect.go
@@ -23,23 +23,19 @@ var OrigStderr = func() *os.File {
 }()
 
 // LoggingToStderr returns true if log messages of the given severity
-// sent to the main logger are also visible on stderr.
+// sent to the main logger are also visible on stderr. This is used
+// e.g. by the startup code to announce server details both on the
+// external stderr and to the log file.
+//
+// This is also the logic used by Shout calls.
 func LoggingToStderr(s Severity) bool {
-	return s >= logging.stderrThreshold.get()
-}
-
-// stderrRedirected returns true if and only if logging to this logger
-// captures stderr output to the log file. This is used e.g. by
-// Shout() to determine whether to report to standard error in
-// addition to logs.
-func (l *loggerT) stderrRedirected() bool {
-	return logging.stderrThreshold > Severity_INFO && !l.noStderrRedirect
+	return s >= mainLog.stderrThreshold.get()
 }
 
 // hijackStderr replaces stderr with the given file descriptor.
 //
-// A client that wishes to use the original stderr must use
-// OrigStderr defined above.
+// A client that wishes to use the original stderr (the process'
+// external stderr stream) must use OrigStderr defined above.
 func hijackStderr(f *os.File) error {
 	return redirectStderr(f)
 }

--- a/pkg/util/log/stderr_redirect_windows.go
+++ b/pkg/util/log/stderr_redirect_windows.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// dupFD is used to initialize OrigStderr (see stderr_redirect.go).
 func dupFD(fd uintptr) (uintptr, error) {
 	// Adapted from https://github.com/golang/go/blob/go1.8/src/syscall/exec_windows.go#L303.
 	p, err := windows.GetCurrentProcess()
@@ -26,7 +27,17 @@ func dupFD(fd uintptr) (uintptr, error) {
 	return uintptr(h), windows.DuplicateHandle(p, windows.Handle(fd), p, &h, 0, true, windows.DUPLICATE_SAME_ACCESS)
 }
 
+// redirectStderr is used to redirect internal writes to the error
+// handle to the specified file. This is needed to ensure that
+// harcoded writes to the error handle by e.g. the Go runtime are
+// redirected to a log file of our choosing.
+//
+// We also override os.Stderr for those other parts of Go which use
+// that and not fd 2 directly.
 func redirectStderr(f *os.File) error {
+	if err := windows.SetStdHandle(windows.STD_ERROR_HANDLE, windows.Handle(f.Fd())); err != nil {
+		return err
+	}
 	os.Stderr = f
-	return windows.SetStdHandle(windows.STD_ERROR_HANDLE, windows.Handle(f.Fd()))
+	return nil
 }

--- a/pkg/util/log/sync_buffer.go
+++ b/pkg/util/log/sync_buffer.go
@@ -92,11 +92,12 @@ func (sb *syncBuffer) rotateFile(now time.Time) error {
 		return err
 	}
 
-	// Redirect stderr to the current INFO log file in order to capture panic
-	// stack traces that are written by the Go runtime to stderr. Note that if
-	// --logtostderr is true we'll never enter this code path and panic stack
-	// traces will go to the original stderr as you would expect.
-	if sb.logger.stderrRedirected() {
+	// If this logger is responsible for capturing direct writes to the
+	// process' file descriptor 2, then do it here.
+	//
+	// This captures e.g. all writes performed by internal
+	// assertions in the Go runtime.
+	if sb.logger.redirectInternalStderrWrites() {
 		// NB: any concurrent output to stderr may straddle the old and new
 		// files. This doesn't apply to log messages as we won't reach this code
 		// unless we're not logging to stderr.

--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -83,17 +83,20 @@ func ScopeWithoutShowLogs(t tShim) *TestLogScope {
 func enableLogFileOutput(dir string, stderrSeverity Severity) (func(), error) {
 	mainLog.mu.Lock()
 	defer mainLog.mu.Unlock()
-	oldStderrThreshold := logging.stderrThreshold.get()
-	oldNoStderrRedirect := mainLog.noStderrRedirect
+	oldStderrThreshold := mainLog.stderrThreshold.get()
+	oldNoStderrRedirect := stderrLog.noRedirectInternalStderrWrites
 
 	undo := func() {
 		mainLog.mu.Lock()
 		defer mainLog.mu.Unlock()
-		logging.stderrThreshold.set(oldStderrThreshold)
-		mainLog.noStderrRedirect = oldNoStderrRedirect
+		mainLog.stderrThreshold.set(oldStderrThreshold)
+		stderrLog.noRedirectInternalStderrWrites = oldNoStderrRedirect
 	}
-	logging.stderrThreshold.set(stderrSeverity)
-	mainLog.noStderrRedirect = true
+	mainLog.stderrThreshold.set(stderrSeverity)
+	stderrLog.noRedirectInternalStderrWrites = true
+	// TODO(knz): if/when stderrLog becomes different from mainLog,
+	// ensure that the stderrLog file output gets re-opened
+	// and os.Stderr gets redirected at this point.
 	return undo, mainLog.logDir.Set(dir)
 }
 


### PR DESCRIPTION
Required by #48051

Previous work in this area of the code introduced a confusion between
two orthogonal concepts:

- each logger might copy its log entries to the process' external
  stderr stream (e.g. the terminal during interactive use), as
  set by its "stderrThreshold" variable.

- direct writes by Go code to process-wide file descriptor 2 (such
  as done by the Go runtime)  or `os.Stderr` (such as done
  by 3rd party packages when doing their own ad-hoc logging)
  can be redirected to a logger's output file.

The confusion (mostly mine - @knz) was to mix the two kinds of
"stderr" and mistakenly conflating "entries submitted to this logger
via API calls" and "direct writes to fd 2 by other go code without
looking at the logging API". These are actually completely separate
and independent concepts/mechanisms.

The code clarifies the situation as follows:

- the process' external stderr stream is always available via
  `log.OrigStderr` and this is meant to never change throughout
  execution.

- the external stderr stream is the sink for `Shout()` API calls
  and also the copy of log entries whose severity
  exceed the "stderrThreshold" variable.

- separately, *at most one logger* may redirect internal writes to fd
  2 and os.Stderr to its log file. This is determined by
  its variable "noRedirectInternalStderrWrites" (previously
  named "noRedirectStderr").

Beyond this, this commit fixes 3 bugs.

1. the code was intending to both redirect the standard stderr file
   descriptor (fd 2 on unix, error handle on windows) and also
   `os.Stderr` separately, but failing to do so on unix build targets.
   It was done correctly for windows. This is now corrected so that
   `os.Stderr` gets assigned on all targets.

   (The separate assignment of `os.Stderr` is necessary because
   although Go intializes this to be equivalent to the standard
   file descriptor upon process startup, other Go code can
   assign `os.Stderr` after initialization.)

2. upon encountering a write error to its output file, a logger
   would previously report that write error twice to the
   process' external stderr. This has been corrected
   so that the write error is only reported once.

3. previously, upon a log.Fatal performed while configuration would not
   otherwise cause a copy the F entry go to the process external stderr,
   the code would override the configuration and force a copy of the
   entry to the external stderr stream.

   There is no good reason for this - either the user wants F entries
   on the external stderr and signal this desire via
   `--logtostderr=FATAL` or lower, or they don't want F entries there
   at all via `--logtostderr=NONE`. There is no reason for an
   override and the code should honor the configuration.

   (I introduced the bug together with the confusion mentioned
   at the beginning.)

Release note: None