### PR TITLE
storage: Remove extra vars from runExportToSst

### DIFF
--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -95,7 +95,6 @@ func BenchmarkExportToSst(b *testing.B) {
 	numKeys := []int{64, 512, 1024, 8192, 65536}
 	numRevisions := []int{1, 10, 100}
 	exportAllRevisions := []bool{false, true}
-	contention := []bool{false, true}
 	engineMakers := []struct {
 		name   string
 		create engineMaker
@@ -111,12 +110,8 @@ func BenchmarkExportToSst(b *testing.B) {
 					for _, numRevision := range numRevisions {
 						b.Run(fmt.Sprintf("numRevisions=%d", numRevision), func(b *testing.B) {
 							for _, exportAllRevisionsVal := range exportAllRevisions {
-								b.Run(fmt.Sprintf("exportAllRevisions=%t", exportAllRevisions), func(b *testing.B) {
-									for _, contentionVal := range contention {
-										b.Run(fmt.Sprintf("contention=%t", contentionVal), func(b *testing.B) {
-											runExportToSst(context.Background(), b, engineImpl.create, numKey, numRevision, exportAllRevisionsVal, contentionVal)
-										})
-									}
+								b.Run(fmt.Sprintf("exportAllRevisions=%t", exportAllRevisionsVal), func(b *testing.B) {
+									runExportToSst(b, engineImpl.create, numKey, numRevision, exportAllRevisionsVal)
 								})
 							}
 						})

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -985,13 +985,7 @@ func runBatchApplyBatchRepr(
 }
 
 func runExportToSst(
-	ctx context.Context,
-	b *testing.B,
-	emk engineMaker,
-	numKeys int,
-	numRevisions int,
-	exportAllRevisions bool,
-	contention bool,
+	b *testing.B, emk engineMaker, numKeys int, numRevisions int, exportAllRevisions bool,
 ) {
 	dir, cleanup := testutils.TempDir(b)
 	defer cleanup()


### PR DESCRIPTION
A previous change (#49721) adding a benchmark for ExportToSst
left in some extra unused variables in a helper method. This
change cleans that up.

Release note: None.