### PR TITLE
sql: implement ConstructFilter and ConstructExplain in the new factory

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -27,11 +27,11 @@ ALTER INDEX t@secondary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc1]
 query TTT retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        t@secondary
-·     spans        /10-/11
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         t@secondary
+·     spans         /10-/11
 
 query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
@@ -70,11 +70,11 @@ ALTER INDEX t@tertiary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc1]'
 query TTT retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        t@tertiary
-·     spans        /10-/11
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         t@tertiary
+·     spans         /10-/11
 
 query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
@@ -113,11 +113,11 @@ ALTER INDEX t@tertiary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc3]'
 query TTT retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        t@secondary
-·     spans        /10-/11
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         t@secondary
+·     spans         /10-/11
 
 # ------------------------------------------------------------------------------
 # Swap location of primary and secondary indexes and ensure that primary index
@@ -133,11 +133,11 @@ ALTER INDEX t@secondary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc2]
 query TTT retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        t@primary
-·     spans        /10-/10/#
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         t@primary
+·     spans         /10-/10/#
 
 query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
@@ -173,11 +173,11 @@ PREPARE p AS SELECT tree, field, description FROM [EXPLAIN SELECT k, v FROM t WH
 query TTT retry
 EXECUTE p
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        t@primary
-·     spans        /10-/10/#
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         t@primary
+·     spans         /10-/10/#
 
 statement ok
 ALTER TABLE t CONFIGURE ZONE USING constraints='[+region=test,+dc=dc2]'
@@ -188,11 +188,11 @@ ALTER INDEX t@secondary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc1]
 query TTT retry
 EXECUTE p
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        t@secondary
-·     spans        /10-/11
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         t@secondary
+·     spans         /10-/11
 
 statement ok
 DEALLOCATE p
@@ -213,11 +213,11 @@ USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
 query TTT retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        t@secondary
-·     spans        /10-/11
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         t@secondary
+·     spans         /10-/11
 
 # ------------------------------------------------------------------------------
 # Move secondary lease preference to dc3 and put tertiary lease preference in
@@ -235,11 +235,11 @@ USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
 query TTT retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        t@tertiary
-·     spans        /10-/11
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         t@tertiary
+·     spans         /10-/11
 
 query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
@@ -288,11 +288,11 @@ USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
 query TTT retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        t@secondary
-·     spans        /10-/11
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         t@secondary
+·     spans         /10-/11
 
 query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
@@ -331,11 +331,11 @@ PREPARE p AS SELECT tree, field, description FROM [EXPLAIN SELECT k, v FROM t WH
 query TTT retry
 EXECUTE p
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        t@secondary
-·     spans        /10-/11
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         t@secondary
+·     spans         /10-/11
 
 statement ok
 ALTER INDEX t@secondary CONFIGURE ZONE
@@ -344,11 +344,11 @@ USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc2]]'
 query TTT retry
 EXECUTE p
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        t@primary
-·     spans        /10-/10/#
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         t@primary
+·     spans         /10-/10/#
 
 statement ok
 DEALLOCATE p
@@ -374,11 +374,11 @@ ALTER INDEX t36642@secondary CONFIGURE ZONE USING constraints='[+region=test]', 
 query TTT retry
 EXPLAIN SELECT * FROM t36642 WHERE k=10
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        t36642@secondary
-·     spans        /10-/11
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         t36642@secondary
+·     spans         /10-/11
 
 statement ok
 ALTER INDEX t36642@tertiary CONFIGURE ZONE USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
@@ -389,11 +389,11 @@ ALTER INDEX t36642@secondary CONFIGURE ZONE USING constraints='[+region=test]', 
 query TTT retry
 EXPLAIN SELECT * FROM t36642 WHERE k=10
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        t36642@tertiary
-·     spans        /10-/11
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         t36642@tertiary
+·     spans         /10-/11
 
 query T retry
 EXPLAIN (OPT, CATALOG) SELECT * FROM t
@@ -443,11 +443,11 @@ CONFIGURE ZONE USING constraints='[+region=test]', lease_preferences='[[+dc=dc1]
 query TTT retry
 EXPLAIN SELECT * FROM t36644 WHERE k=10
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        t36644@secondary
-·     spans        /10-/11
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         t36644@secondary
+·     spans         /10-/11
 
 statement ok
 ALTER INDEX t36644@secondary CONFIGURE ZONE USING lease_preferences='[[+dc=dc3]]'
@@ -459,11 +459,11 @@ CONFIGURE ZONE USING constraints='[+region=test]', lease_preferences='[[+dc=dc1]
 query TTT retry
 EXPLAIN SELECT * FROM t36644 WHERE k=10
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        t36644@tertiary
-·     spans        /10-/11
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         t36644@tertiary
+·     spans         /10-/11
 
 subtest regression_35756
 

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1344,14 +1344,14 @@ func Example_misc_table() {
 	//     hai
 	// (1 row)
 	// sql --format=table -e explain select s, 'foo' from t.t
-	//     tree    |    field    | description
-	// ------------+-------------+--------------
-	//             | distributed | true
-	//             | vectorized  | false
-	//   render    |             |
-	//    └── scan |             |
-	//             | table       | t@primary
-	//             | spans       | FULL SCAN
+	//     tree    |    field     | description
+	// ------------+--------------+--------------
+	//             | distribution | full
+	//             | vectorized   | false
+	//   render    |              |
+	//    └── scan |              |
+	//             | table        | t@primary
+	//             | spans        | FULL SCAN
 	// (6 rows)
 }
 

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -757,9 +757,9 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	}
 
 	ex.sessionTracing.TracePlanCheckStart(ctx)
-	distributePlan := willDistributePlan(
+	distributePlan := getPlanDistribution(
 		ctx, planner.execCfg.NodeID, ex.sessionData.DistSQLMode, planner.curPlan.main,
-	)
+	).willDistribute()
 	ex.sessionTracing.TracePlanCheckEnd(ctx, nil, distributePlan)
 
 	if ex.server.cfg.TestingKnobs.BeforeExecute != nil {
@@ -775,6 +775,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		panic(fmt.Sprintf("query %d not in registry", stmt.queryID))
 	}
 	queryMeta.phase = executing
+	// TODO(yuzefovich): introduce ternary planDistribution into queryMeta.
 	queryMeta.isDistributed = distributePlan
 	progAtomic := &queryMeta.progressAtomic
 	ex.mu.Unlock()

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -864,9 +864,9 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 
 	var distributeSubquery bool
 	if maybeDistribute {
-		distributeSubquery = willDistributePlan(
+		distributeSubquery = getPlanDistribution(
 			ctx, planner.execCfg.NodeID, planner.SessionData().DistSQLMode, subqueryPlan.plan,
-		)
+		).willDistribute()
 	}
 	subqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner.txn, distributeSubquery)
 	subqueryPlanCtx.planner = planner
@@ -1168,9 +1168,9 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 
 	var distributePostquery bool
 	if maybeDistribute {
-		distributePostquery = willDistributePlan(
+		distributePostquery = getPlanDistribution(
 			ctx, planner.execCfg.NodeID, planner.SessionData().DistSQLMode, postqueryPlan,
-		)
+		).willDistribute()
 	}
 	postqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner.txn, distributePostquery)
 	postqueryPlanCtx.planner = planner

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -892,20 +892,22 @@ func shouldDistributeGivenRecAndMode(
 	panic(fmt.Sprintf("unhandled distsql mode %v", mode))
 }
 
-// willDistributePlan determines whether we will distribute the given logical
-// plan, based on the gateway's SQL ID and session settings, with physical
-// planning being handled by DistSQL physical planner.
-func willDistributePlan(
+// getPlanDistribution returns the planDistribution that plan will have. If
+// plan already has physical representation, then the stored planDistribution
+// is reused, but if plan has logical representation (i.e. it is a planNode
+// tree), then we traverse that tree in order to determine the distribution of
+// the plan.
+func getPlanDistribution(
 	ctx context.Context,
 	nodeID *base.SQLIDContainer,
 	distSQLMode sessiondata.DistSQLExecMode,
 	plan planMaybePhysical,
-) bool {
+) planDistribution {
 	if _, singleTenant := nodeID.OptionalNodeID(); !singleTenant {
-		return false
+		return localPlan
 	}
 	if distSQLMode == sessiondata.DistSQLOff {
-		return false
+		return localPlan
 	}
 
 	// Don't try to run empty nodes (e.g. SET commands) with distSQL.
@@ -915,30 +917,30 @@ func willDistributePlan(
 		if len(plan.physPlan.Processors) == 1 {
 			if valuesSpec := plan.physPlan.Processors[0].Spec.Core.Values; valuesSpec != nil {
 				if valuesSpec.NumRows == 0 {
-					return false
+					return localPlan
 				}
 			}
 		}
 	} else {
 		if _, ok := plan.planNode.(*zeroNode); ok {
-			return false
+			return localPlan
 		}
 	}
 
-	var rec distRecommendation
 	if plan.isPhysicalPlan() {
-		rec = plan.recommendation
-	} else {
-		var err error
-		rec, err = checkSupportForPlanNode(plan.planNode)
-		if err != nil {
-			// Don't use distSQL for this request.
-			log.VEventf(ctx, 1, "query not supported for distSQL: %s", err)
-			return false
-		}
+		return plan.distribution
+	}
+	rec, err := checkSupportForPlanNode(plan.planNode)
+	if err != nil {
+		// Don't use distSQL for this request.
+		log.VEventf(ctx, 1, "query not supported for distSQL: %s", err)
+		return localPlan
 	}
 
-	return shouldDistributeGivenRecAndMode(rec, distSQLMode)
+	if shouldDistributeGivenRecAndMode(rec, distSQLMode) {
+		return fullyDistributedPlan
+	}
+	return localPlan
 }
 
 // golangFillQueryArguments transforms Go values into datums.

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -75,14 +75,29 @@ func getPlanDistributionForExplainPurposes(
 	distSQLMode sessiondata.DistSQLExecMode,
 	plan planMaybePhysical,
 ) planDistribution {
-	if !plan.isPhysicalPlan() {
-		if _, ok := plan.planNode.(distSQLExplainable); ok {
-			// This is a special case for plans that will be actually distributed
-			// but are represented using local plan nodes (for example, "create
-			// statistics" is handled by the jobs framework which is responsible
-			// for setting up the correct DistSQL infrastructure).
-			return fullyDistributedPlan
+	if plan.isPhysicalPlan() {
+		return plan.distribution
+	}
+	switch p := plan.planNode.(type) {
+	case *explainDistSQLNode:
+		if p.plan.main.isPhysicalPlan() {
+			return p.plan.main.distribution
 		}
+	case *explainVecNode:
+		if p.plan.isPhysicalPlan() {
+			return p.plan.distribution
+		}
+	case *explainPlanNode:
+		if p.plan.main.isPhysicalPlan() {
+			return p.plan.main.distribution
+		}
+	}
+	if _, ok := plan.planNode.(distSQLExplainable); ok {
+		// This is a special case for plans that will be actually distributed
+		// but are represented using local plan nodes (for example, "create
+		// statistics" is handled by the jobs framework which is responsible
+		// for setting up the correct DistSQL infrastructure).
+		return fullyDistributedPlan
 	}
 	return getPlanDistribution(ctx, nodeID, distSQLMode, plan)
 }

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -65,35 +65,35 @@ type distSQLExplainable interface {
 	newPlanForExplainDistSQL(*PlanningCtx, *DistSQLPlanner) (*PhysicalPlan, error)
 }
 
-// willDistributePlanForExplainPurposes determines whether we will distribute
-// the given logical plan, based on the gateway's SQL ID and session settings.
-// It is similar to willDistributePlan but also pays attention to whether the
-// logical plan will be handled as a distributed job. It should *only* be used
-// in EXPLAIN variants.
-func willDistributePlanForExplainPurposes(
+// getPlanDistributionForExplainPurposes returns the planDistribution that plan
+// will have. It is similar to getPlanDistribution but also pays attention to
+// whether the logical plan will be handled as a distributed job. It should
+// *only* be used in EXPLAIN variants.
+func getPlanDistributionForExplainPurposes(
 	ctx context.Context,
 	nodeID *base.SQLIDContainer,
 	distSQLMode sessiondata.DistSQLExecMode,
 	plan planMaybePhysical,
-) bool {
+) planDistribution {
 	if !plan.isPhysicalPlan() {
 		if _, ok := plan.planNode.(distSQLExplainable); ok {
 			// This is a special case for plans that will be actually distributed
 			// but are represented using local plan nodes (for example, "create
 			// statistics" is handled by the jobs framework which is responsible
 			// for setting up the correct DistSQL infrastructure).
-			return true
+			return fullyDistributedPlan
 		}
 	}
-	return willDistributePlan(ctx, nodeID, distSQLMode, plan)
+	return getPlanDistribution(ctx, nodeID, distSQLMode, plan)
 }
 
 func (n *explainDistSQLNode) startExec(params runParams) error {
 	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
-	willDistribute := willDistributePlanForExplainPurposes(
+	distribution := getPlanDistributionForExplainPurposes(
 		params.ctx, params.extendedEvalCtx.ExecCfg.NodeID,
 		params.extendedEvalCtx.SessionData.DistSQLMode, n.plan.main,
 	)
+	willDistribute := distribution.willDistribute()
 	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx, params.p.txn, willDistribute)
 	planCtx.ignoreClose = true
 	planCtx.planner = params.p

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -254,8 +254,8 @@ func populateExplain(
 		return err
 	}
 
-	// First, emit the "distributed" and "vectorized" information rows.
-	if err := emitRow("", 0, "", "distributed", fmt.Sprintf("%t", willDistribute), "", ""); err != nil {
+	// First, emit the "distribution" and "vectorized" information rows.
+	if err := emitRow("", 0, "", "distribution", distribution.String(), "", ""); err != nil {
 		return err
 	}
 	if err := emitRow("", 0, "", "vectorized", fmt.Sprintf("%t", willVectorize), "", ""); err != nil {

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -187,14 +187,15 @@ func populateExplain(
 ) error {
 	// Determine the "distributed" and "vectorized" values, which we will emit as
 	// special rows.
-	var willDistribute, willVectorize bool
+	var willVectorize bool
 	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
-	willDistribute = willDistributePlanForExplainPurposes(
+	distribution := getPlanDistributionForExplainPurposes(
 		params.ctx, params.extendedEvalCtx.ExecCfg.NodeID,
 		params.extendedEvalCtx.SessionData.DistSQLMode, plan.main,
 	)
+	willDistribute := distribution.willDistribute()
 	outerSubqueries := params.p.curPlan.subqueryPlans
-	planCtx := newPlanningCtxForExplainPurposes(distSQLPlanner, params, stmtType, plan.subqueryPlans, willDistribute)
+	planCtx := newPlanningCtxForExplainPurposes(distSQLPlanner, params, stmtType, plan.subqueryPlans, distribution)
 	defer func() {
 		planCtx.planner.curPlan.subqueryPlans = outerSubqueries
 	}()

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -55,12 +55,13 @@ type flowWithNode struct {
 func (n *explainVecNode) startExec(params runParams) error {
 	n.run.values = make(tree.Datums, 1)
 	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
-	willDistribute := willDistributePlanForExplainPurposes(
+	distribution := getPlanDistributionForExplainPurposes(
 		params.ctx, params.extendedEvalCtx.ExecCfg.NodeID,
 		params.extendedEvalCtx.SessionData.DistSQLMode, n.plan,
 	)
+	willDistribute := distribution.willDistribute()
 	outerSubqueries := params.p.curPlan.subqueryPlans
-	planCtx := newPlanningCtxForExplainPurposes(distSQLPlanner, params, n.stmtType, n.subqueryPlans, willDistribute)
+	planCtx := newPlanningCtxForExplainPurposes(distSQLPlanner, params, n.stmtType, n.subqueryPlans, distribution)
 	defer func() {
 		planCtx.planner.curPlan.subqueryPlans = outerSubqueries
 	}()
@@ -141,9 +142,9 @@ func newPlanningCtxForExplainPurposes(
 	params runParams,
 	stmtType tree.StatementType,
 	subqueryPlans []subquery,
-	willDistribute bool,
+	distribution planDistribution,
 ) *PlanningCtx {
-	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx, params.p.txn, willDistribute)
+	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx, params.p.txn, distribution.willDistribute())
 	planCtx.ignoreClose = true
 	planCtx.planner = params.p
 	planCtx.stmtType = stmtType

--- a/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning
+++ b/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning
@@ -49,6 +49,8 @@ SELECT v, k FROM kv
 statement error pq: unimplemented: experimental opt-driven distsql planning
 SELECT k + v FROM kv
 
-# Filters are not yet supported.
-statement error pq: unimplemented: experimental opt-driven distsql planning
+query II rowsort
 SELECT * FROM kv WHERE k > v
+----
+2 1
+3 2

--- a/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning_5node
+++ b/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning_5node
@@ -1,0 +1,111 @@
+# LogicTest: 5node
+
+# This test file makes sure that experimental DistSQL planning actually plans
+# processors and other components correctly. In order to make the output
+# deterministic we place the data manually.
+
+statement ok
+CREATE TABLE kv (k INT PRIMARY KEY, v INT, FAMILY (k, v));
+INSERT INTO kv SELECT i, i FROM generate_series(1,5) AS g(i);
+CREATE TABLE kw (k INT PRIMARY KEY, w INT, FAMILY (k, w));
+INSERT INTO kw SELECT i, i FROM generate_series(1,5) AS g(i)
+
+# Split into 5 parts, each row from each table goes to one node.
+statement ok
+ALTER TABLE kv SPLIT AT SELECT i FROM generate_series(1,5) AS g(i);
+ALTER TABLE kw SPLIT AT SELECT i FROM generate_series(1,5) AS g(i);
+ALTER TABLE kv EXPERIMENTAL_RELOCATE SELECT ARRAY[i], i FROM generate_series(1, 5) as g(i);
+ALTER TABLE kw EXPERIMENTAL_RELOCATE SELECT ARRAY[i], i FROM generate_series(1, 5) as g(i)
+
+# Verify data placement.
+query TTTI colnames,rowsort
+SELECT start_key, end_key, replicas, lease_holder from [SHOW RANGES FROM TABLE kv]
+----
+start_key  end_key  replicas  lease_holder
+NULL       /1       {1}       1
+/1         /2       {1}       1
+/2         /3       {2}       2
+/3         /4       {3}       3
+/4         /5       {4}       4
+/5         NULL     {5}       5
+
+# Verify data placement.
+query TTTI colnames,rowsort
+SELECT start_key, end_key, replicas, lease_holder from [SHOW RANGES FROM TABLE kw]
+----
+start_key  end_key  replicas  lease_holder
+NULL       /1       {5}       5
+/1         /2       {1}       1
+/2         /3       {2}       2
+/3         /4       {3}       3
+/4         /5       {4}       4
+/5         NULL     {5}       5
+
+statement ok
+SET experimental_distsql_planning = always
+
+query TTT
+EXPLAIN SELECT * FROM kv
+----
+·  distribution  full
+·  vectorized    true
+
+
+query BT
+EXPLAIN (DISTSQL) SELECT * FROM kv
+----
+true  https://cockroachdb.github.io/distsqlplan/decode.html#eJyk0s9O4zAQBvD7PkX0nXZXjvJ_DzktgiJFKm1pekBCOYR4VEWkcbAdBKry7qjOobQqYOjR9nz-zUizhXpqkGJyt5heZDPn91WWr_Lb6R8nn0wnlyvnr3O9nN84j89gaAWnWbkhhfQeARhCMERgiMGQoGDopKhIKSF3JVsTyPgLUp-hbrte764LhkpIQrqFrnVDSLEqHxpaUslJej4YOOmybgzTyXpTytf_poG8K1uVOq4XohgYRK_3fypdrglpMLAP3D3Xt0JyksQPqGI40dlMuKLzkqPC03R4QAf2Iwdfj-yFrhdZDh3ay6GFHLlebClH9nJkIceul1jKsb0cW8iJ-4MFO-EuSXWiVWS1P_5uAYmvadxWJXpZ0UKKyjDjcW5y5oKT0uNrMB6y1jyZBt-Hg0_D_w7C_nE4PEeOzgnH54STb4WL4ddbAAAA__9oS6Od
+
+
+# Note that we want to test DistSQL physical planning and the obvious choice
+# would be to use EXPLAIN (DISTSQL). However, this explain variant doesn't have
+# a textual mode which is easier to verify, so we use EXPLAIN (VEC) instead.
+# TODO(yuzefovich): consider adding textual mode to EXPLAIN (DISTSQL) and
+# using it here.
+# TODO(yuzefovich): figure out how we would display plans that have distributed
+# stages followed by local ones followed by distributed stages.
+
+# An example of partially distributed plan (due to DOid type that is not
+# supported by DistSQL).
+
+query T
+EXPLAIN (VEC) SELECT * FROM kv WHERE k::REGCLASS IS NOT NULL
+----
+│
+├ Node 1
+│ └ *colexec.isNullSelOp
+│   └ *colexec.castOp
+│     └ *colexec.ParallelUnorderedSynchronizer
+│       ├ *colexec.colBatchScan
+│       ├ *colrpc.Inbox
+│       ├ *colrpc.Inbox
+│       ├ *colrpc.Inbox
+│       └ *colrpc.Inbox
+├ Node 2
+│ └ *colrpc.Outbox
+│   └ *colexec.colBatchScan
+├ Node 3
+│ └ *colrpc.Outbox
+│   └ *colexec.colBatchScan
+├ Node 4
+│ └ *colrpc.Outbox
+│   └ *colexec.colBatchScan
+└ Node 5
+  └ *colrpc.Outbox
+    └ *colexec.colBatchScan
+
+# Check that the plan is local when experimental DistSQL planning is disabled.
+statement ok
+SET experimental_distsql_planning = off
+
+query T
+EXPLAIN (VEC) SELECT * FROM kv WHERE k::REGCLASS IS NOT NULL
+----
+│
+└ Node 1
+  └ *colexec.isNullSelOp
+    └ *colexec.castOp
+      └ *colexec.colBatchScan
+
+statement ok
+SET experimental_distsql_planning = always

--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -120,9 +120,9 @@ species
 query TTT
 EXPLAIN ALTER TABLE users RENAME COLUMN species TO woo
 ----
-·            distributed  false
-·            vectorized   false
-alter table  ·            ·
+·            distribution  local
+·            vectorized    false
+alter table  ·             ·
 
 # Verify that EXPLAIN did not actually rename the column
 query T

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -162,9 +162,9 @@ v
 query TTT
 EXPLAIN ALTER DATABASE v RENAME TO x
 ----
-·                distributed  false
-·                vectorized   false
-rename database  ·            ·
+·                distribution  local
+·                vectorized    false
+rename database  ·             ·
 
 # Verify that the EXPLAIN above does not actually rename the database (#30543)
 query T colnames

--- a/pkg/sql/logictest/testdata/logic_test/rename_index
+++ b/pkg/sql/logictest/testdata/logic_test/rename_index
@@ -141,9 +141,9 @@ SELECT * FROM users@pk
 query TTT
 EXPLAIN ALTER INDEX users@bar RENAME TO woo
 ----
-·             distributed  false
-·             vectorized   false
-rename index  ·            ·
+·             distribution  local
+·             vectorized    false
+rename index  ·             ·
 
 # Verify that EXPLAIN did not actually rename the index (#30543)
 query T rowsort

--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -272,9 +272,9 @@ public  kv  table
 query TTT
 EXPLAIN ALTER TABLE kv RENAME TO kv2
 ----
-·             distributed  false
-·             vectorized   false
-rename table  ·            ·
+·             distribution  local
+·             vectorized    false
+rename table  ·             ·
 
 # Verify that the EXPLAIN above does not actually rename the table (#30543)
 query TTT

--- a/pkg/sql/logictest/testdata/logic_test/truncate
+++ b/pkg/sql/logictest/testdata/logic_test/truncate
@@ -176,9 +176,9 @@ CREATE TABLE tt AS SELECT 'foo'
 query TTT
 EXPLAIN TRUNCATE TABLE tt
 ----
-·         distributed  false
-·         vectorized   false
-truncate  ·            ·
+·         distribution  local
+·         vectorized    false
+truncate  ·             ·
 
 # Verify that EXPLAIN did not cause the truncate to be performed.
 query T

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
@@ -18,14 +18,14 @@ SET vectorize_row_count_threshold = 1000
 query TTT
 EXPLAIN SELECT count(*) from small
 ----
-·          distributed  true
-·          vectorized   false
-group      ·            ·
- │         aggregate 0  count_rows()
- │         scalar       ·
- └── scan  ·            ·
-·          table        small@primary
-·          spans        FULL SCAN
+·          distribution  full
+·          vectorized    false
+group      ·             ·
+ │         aggregate 0   count_rows()
+ │         scalar        ·
+ └── scan  ·             ·
+·          table         small@primary
+·          spans         FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 0
@@ -35,14 +35,14 @@ SET vectorize_row_count_threshold = 0
 query TTT
 EXPLAIN SELECT count(*) from small
 ----
-·          distributed  true
-·          vectorized   true
-group      ·            ·
- │         aggregate 0  count_rows()
- │         scalar       ·
- └── scan  ·            ·
-·          table        small@primary
-·          spans        FULL SCAN
+·          distribution  full
+·          vectorized    true
+group      ·             ·
+ │         aggregate 0   count_rows()
+ │         scalar        ·
+ └── scan  ·             ·
+·          table         small@primary
+·          spans         FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 1000
@@ -61,14 +61,14 @@ ALTER TABLE small INJECT STATISTICS '[
 query TTT
 EXPLAIN SELECT count(*) from small
 ----
-·          distributed  true
-·          vectorized   false
-group      ·            ·
- │         aggregate 0  count_rows()
- │         scalar       ·
- └── scan  ·            ·
-·          table        small@primary
-·          spans        FULL SCAN
+·          distribution  full
+·          vectorized    false
+group      ·             ·
+ │         aggregate 0   count_rows()
+ │         scalar        ·
+ └── scan  ·             ·
+·          table         small@primary
+·          spans         FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 1
@@ -78,14 +78,14 @@ SET vectorize_row_count_threshold = 1
 query TTT
 EXPLAIN SELECT count(*) from small
 ----
-·          distributed  true
-·          vectorized   true
-group      ·            ·
- │         aggregate 0  count_rows()
- │         scalar       ·
- └── scan  ·            ·
-·          table        small@primary
-·          spans        FULL SCAN
+·          distribution  full
+·          vectorized    true
+group      ·             ·
+ │         aggregate 0   count_rows()
+ │         scalar        ·
+ └── scan  ·             ·
+·          table         small@primary
+·          spans         FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 1000
@@ -107,14 +107,14 @@ ALTER TABLE large INJECT STATISTICS '[
 query TTT
 EXPLAIN SELECT count(*) from large
 ----
-·          distributed  true
-·          vectorized   true
-group      ·            ·
- │         aggregate 0  count_rows()
- │         scalar       ·
- └── scan  ·            ·
-·          table        large@primary
-·          spans        FULL SCAN
+·          distribution  full
+·          vectorized    true
+group      ·             ·
+ │         aggregate 0   count_rows()
+ │         scalar        ·
+ └── scan  ·             ·
+·          table         large@primary
+·          spans         FULL SCAN
 
 statement ok
 SET vectorize_row_count_threshold = 1000000
@@ -124,11 +124,11 @@ SET vectorize_row_count_threshold = 1000000
 query TTT
 EXPLAIN SELECT count(*) from large
 ----
-·          distributed  true
-·          vectorized   false
-group      ·            ·
- │         aggregate 0  count_rows()
- │         scalar       ·
- └── scan  ·            ·
-·          table        large@primary
-·          spans        FULL SCAN
+·          distribution  full
+·          vectorized    false
+group      ·             ·
+ │         aggregate 0   count_rows()
+ │         scalar        ·
+ └── scan  ·             ·
+·          table         large@primary
+·          spans         FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -11,7 +11,7 @@ CREATE TABLE kv (
 query TTTTT
 EXPLAIN (TYPES) SELECT min(1), max(1), count(NULL), sum_int(1), avg(1), sum(1), stddev(1), variance(1), bool_and(true), bool_or(false), xor_agg(b'\x01') FROM kv
 ----
-·               distributed   false               ·                                                                                                                                                   ·
+·               distribution  local               ·                                                                                                                                                   ·
 ·               vectorized    true                ·                                                                                                                                                   ·
 group           ·             ·                   (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, xor_agg bytes)  ·
  │              aggregate 0   min(column5)        ·                                                                                                                                                   ·
@@ -39,46 +39,46 @@ group           ·             ·                   (min int, max int, count int
 query TTTTT
 EXPLAIN (TYPES) SELECT min(v), max(v), count(v), sum_int(1), avg(v), sum(v), stddev(v), variance(v), bool_and(v = 1), bool_and(v = 1), xor_agg(s::bytes) FROM kv
 ----
-·                    distributed  false                        ·                                                                                                                                                    ·
-·                    vectorized   true                         ·                                                                                                                                                    ·
-render               ·            ·                            (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_and bool, xor_agg bytes)  ·
- │                   render 0     (min)[int]                   ·                                                                                                                                                    ·
- │                   render 1     (max)[int]                   ·                                                                                                                                                    ·
- │                   render 2     (count)[int]                 ·                                                                                                                                                    ·
- │                   render 3     (sum_int)[int]               ·                                                                                                                                                    ·
- │                   render 4     (avg)[decimal]               ·                                                                                                                                                    ·
- │                   render 5     (sum)[decimal]               ·                                                                                                                                                    ·
- │                   render 6     (stddev)[decimal]            ·                                                                                                                                                    ·
- │                   render 7     (variance)[decimal]          ·                                                                                                                                                    ·
- │                   render 8     (bool_and)[bool]             ·                                                                                                                                                    ·
- │                   render 9     (bool_and)[bool]             ·                                                                                                                                                    ·
- │                   render 10    (xor_agg)[bytes]             ·                                                                                                                                                    ·
- └── group           ·            ·                            (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, xor_agg bytes)                 ·
-      │              aggregate 0  min(v)                       ·                                                                                                                                                    ·
-      │              aggregate 1  max(v)                       ·                                                                                                                                                    ·
-      │              aggregate 2  count(v)                     ·                                                                                                                                                    ·
-      │              aggregate 3  sum_int(column8)             ·                                                                                                                                                    ·
-      │              aggregate 4  avg(v)                       ·                                                                                                                                                    ·
-      │              aggregate 5  sum(v)                       ·                                                                                                                                                    ·
-      │              aggregate 6  stddev(v)                    ·                                                                                                                                                    ·
-      │              aggregate 7  variance(v)                  ·                                                                                                                                                    ·
-      │              aggregate 8  bool_and(column14)           ·                                                                                                                                                    ·
-      │              aggregate 9  xor_agg(column16)            ·                                                                                                                                                    ·
-      │              scalar       ·                            ·                                                                                                                                                    ·
-      └── render     ·            ·                            (column8 int, column14 bool, column16 bytes, v int)                                                                                                  ·
-           │         render 0     (1)[int]                     ·                                                                                                                                                    ·
-           │         render 1     ((v)[int] = (1)[int])[bool]  ·                                                                                                                                                    ·
-           │         render 2     ((s)[string]::BYTES)[bytes]  ·                                                                                                                                                    ·
-           │         render 3     (v)[int]                     ·                                                                                                                                                    ·
-           └── scan  ·            ·                            (v int, s string)                                                                                                                                    ·
-·                    table        kv@primary                   ·                                                                                                                                                    ·
-·                    spans        FULL SCAN                    ·                                                                                                                                                    ·
+·                    distribution  local                        ·                                                                                                                                                    ·
+·                    vectorized    true                         ·                                                                                                                                                    ·
+render               ·             ·                            (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_and bool, xor_agg bytes)  ·
+ │                   render 0      (min)[int]                   ·                                                                                                                                                    ·
+ │                   render 1      (max)[int]                   ·                                                                                                                                                    ·
+ │                   render 2      (count)[int]                 ·                                                                                                                                                    ·
+ │                   render 3      (sum_int)[int]               ·                                                                                                                                                    ·
+ │                   render 4      (avg)[decimal]               ·                                                                                                                                                    ·
+ │                   render 5      (sum)[decimal]               ·                                                                                                                                                    ·
+ │                   render 6      (stddev)[decimal]            ·                                                                                                                                                    ·
+ │                   render 7      (variance)[decimal]          ·                                                                                                                                                    ·
+ │                   render 8      (bool_and)[bool]             ·                                                                                                                                                    ·
+ │                   render 9      (bool_and)[bool]             ·                                                                                                                                                    ·
+ │                   render 10     (xor_agg)[bytes]             ·                                                                                                                                                    ·
+ └── group           ·             ·                            (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, xor_agg bytes)                 ·
+      │              aggregate 0   min(v)                       ·                                                                                                                                                    ·
+      │              aggregate 1   max(v)                       ·                                                                                                                                                    ·
+      │              aggregate 2   count(v)                     ·                                                                                                                                                    ·
+      │              aggregate 3   sum_int(column8)             ·                                                                                                                                                    ·
+      │              aggregate 4   avg(v)                       ·                                                                                                                                                    ·
+      │              aggregate 5   sum(v)                       ·                                                                                                                                                    ·
+      │              aggregate 6   stddev(v)                    ·                                                                                                                                                    ·
+      │              aggregate 7   variance(v)                  ·                                                                                                                                                    ·
+      │              aggregate 8   bool_and(column14)           ·                                                                                                                                                    ·
+      │              aggregate 9   xor_agg(column16)            ·                                                                                                                                                    ·
+      │              scalar        ·                            ·                                                                                                                                                    ·
+      └── render     ·             ·                            (column8 int, column14 bool, column16 bytes, v int)                                                                                                  ·
+           │         render 0      (1)[int]                     ·                                                                                                                                                    ·
+           │         render 1      ((v)[int] = (1)[int])[bool]  ·                                                                                                                                                    ·
+           │         render 2      ((s)[string]::BYTES)[bytes]  ·                                                                                                                                                    ·
+           │         render 3      (v)[int]                     ·                                                                                                                                                    ·
+           └── scan  ·             ·                            (v int, s string)                                                                                                                                    ·
+·                    table         kv@primary                   ·                                                                                                                                                    ·
+·                    spans         FULL SCAN                    ·                                                                                                                                                    ·
 
 # Aggregate functions trigger aggregation and computation when there is no source.
 query TTTTT
 EXPLAIN (TYPES) SELECT min(1), count(NULL), max(1), sum_int(1), avg(1)::float, sum(1), stddev(1), variance(1), bool_and(true), bool_or(true), to_hex(xor_agg(b'\x01'))
 ----
-·                 distributed    false                               ·                                                                                                                                                   ·
+·                 distribution   local                               ·                                                                                                                                                   ·
 ·                 vectorized     false                               ·                                                                                                                                                   ·
 render            ·              ·                                   (min int, count int, max int, sum_int int, avg float, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, to_hex string)    ·
  │                render 0       (min)[int]                          ·                                                                                                                                                   ·
@@ -115,165 +115,165 @@ render            ·              ·                                   (min int,
 query TTTTT
 EXPLAIN (TYPES) SELECT count(*), k FROM kv GROUP BY 2
 ----
-·               distributed  false              ·                        ·
-·               vectorized   true               ·                        ·
-render          ·            ·                  (count int, k int)       ·
- │              render 0     (count_rows)[int]  ·                        ·
- │              render 1     (k)[int]           ·                        ·
- └── group      ·            ·                  (k int, count_rows int)  ·
-      │         aggregate 0  k                  ·                        ·
-      │         aggregate 1  count_rows()       ·                        ·
-      │         group by     k                  ·                        ·
-      │         ordered      +k                 ·                        ·
-      └── scan  ·            ·                  (k int)                  +k
-·               table        kv@primary         ·                        ·
-·               spans        FULL SCAN          ·                        ·
+·               distribution  local              ·                        ·
+·               vectorized    true               ·                        ·
+render          ·             ·                  (count int, k int)       ·
+ │              render 0      (count_rows)[int]  ·                        ·
+ │              render 1      (k)[int]           ·                        ·
+ └── group      ·             ·                  (k int, count_rows int)  ·
+      │         aggregate 0   k                  ·                        ·
+      │         aggregate 1   count_rows()       ·                        ·
+      │         group by      k                  ·                        ·
+      │         ordered       +k                 ·                        ·
+      └── scan  ·             ·                  (k int)                  +k
+·               table         kv@primary         ·                        ·
+·               spans         FULL SCAN          ·                        ·
 
 # Selecting and grouping on a more complex expression works.
 query TTTTT
 EXPLAIN (TYPES) SELECT count(*), k+v AS r FROM kv GROUP BY k+v
 ----
-·                    distributed  false                       ·                              ·
-·                    vectorized   true                        ·                              ·
-render               ·            ·                           (count int, r int)             ·
- │                   render 0     (count_rows)[int]           ·                              ·
- │                   render 1     (column6)[int]              ·                              ·
- └── group           ·            ·                           (column6 int, count_rows int)  ·
-      │              aggregate 0  column6                     ·                              ·
-      │              aggregate 1  count_rows()                ·                              ·
-      │              group by     column6                     ·                              ·
-      └── render     ·            ·                           (column6 int)                  ·
-           │         render 0     ((k)[int] + (v)[int])[int]  ·                              ·
-           └── scan  ·            ·                           (k int, v int)                 ·
-·                    table        kv@primary                  ·                              ·
-·                    spans        FULL SCAN                   ·                              ·
+·                    distribution  local                       ·                              ·
+·                    vectorized    true                        ·                              ·
+render               ·             ·                           (count int, r int)             ·
+ │                   render 0      (count_rows)[int]           ·                              ·
+ │                   render 1      (column6)[int]              ·                              ·
+ └── group           ·             ·                           (column6 int, count_rows int)  ·
+      │              aggregate 0   column6                     ·                              ·
+      │              aggregate 1   count_rows()                ·                              ·
+      │              group by      column6                     ·                              ·
+      └── render     ·             ·                           (column6 int)                  ·
+           │         render 0      ((k)[int] + (v)[int])[int]  ·                              ·
+           └── scan  ·             ·                           (k int, v int)                 ·
+·                    table         kv@primary                  ·                              ·
+·                    spans         FULL SCAN                   ·                              ·
 
 # Selecting a more complex expression, made up of things which are each grouped, works.
 query TTTTT
 EXPLAIN (TYPES) SELECT count(*), k+v AS r FROM kv GROUP BY k, v
 ----
-·               distributed  false                                  ·                                          ·
-·               vectorized   true                                   ·                                          ·
-render          ·            ·                                      (count int, r int)                         ·
- │              render 0     (count_rows)[int]                      ·                                          ·
- │              render 1     ((k)[int] + (any_not_null)[int])[int]  ·                                          ·
- └── group      ·            ·                                      (k int, count_rows int, any_not_null int)  ·
-      │         aggregate 0  k                                      ·                                          ·
-      │         aggregate 1  count_rows()                           ·                                          ·
-      │         aggregate 2  any_not_null(v)                        ·                                          ·
-      │         group by     k                                      ·                                          ·
-      │         ordered      +k                                     ·                                          ·
-      └── scan  ·            ·                                      (k int, v int)                             +k
-·               table        kv@primary                             ·                                          ·
-·               spans        FULL SCAN                              ·                                          ·
+·               distribution  local                                  ·                                          ·
+·               vectorized    true                                   ·                                          ·
+render          ·             ·                                      (count int, r int)                         ·
+ │              render 0      (count_rows)[int]                      ·                                          ·
+ │              render 1      ((k)[int] + (any_not_null)[int])[int]  ·                                          ·
+ └── group      ·             ·                                      (k int, count_rows int, any_not_null int)  ·
+      │         aggregate 0   k                                      ·                                          ·
+      │         aggregate 1   count_rows()                           ·                                          ·
+      │         aggregate 2   any_not_null(v)                        ·                                          ·
+      │         group by      k                                      ·                                          ·
+      │         ordered       +k                                     ·                                          ·
+      └── scan  ·             ·                                      (k int, v int)                             +k
+·               table         kv@primary                             ·                                          ·
+·               spans         FULL SCAN                              ·                                          ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT count(k) FROM kv
 ----
-·          distributed  false         ·            ·
-·          vectorized   true          ·            ·
-group      ·            ·             (count int)  ·
- │         aggregate 0  count_rows()  ·            ·
- │         scalar       ·             ·            ·
- └── scan  ·            ·             ()           ·
-·          table        kv@primary    ·            ·
-·          spans        FULL SCAN     ·            ·
+·          distribution  local         ·            ·
+·          vectorized    true          ·            ·
+group      ·             ·             (count int)  ·
+ │         aggregate 0   count_rows()  ·            ·
+ │         scalar        ·             ·            ·
+ └── scan  ·             ·             ()           ·
+·          table         kv@primary    ·            ·
+·          spans         FULL SCAN     ·            ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT count(k), sum(k), max(k) FROM kv
 ----
-·          distributed  false         ·                                  ·
-·          vectorized   true          ·                                  ·
-group      ·            ·             (count int, sum decimal, max int)  ·
- │         aggregate 0  count_rows()  ·                                  ·
- │         aggregate 1  sum(k)        ·                                  ·
- │         aggregate 2  max(k)        ·                                  ·
- │         scalar       ·             ·                                  ·
- └── scan  ·            ·             (k int)                            ·
-·          table        kv@primary    ·                                  ·
-·          spans        FULL SCAN     ·                                  ·
+·          distribution  local         ·                                  ·
+·          vectorized    true          ·                                  ·
+group      ·             ·             (count int, sum decimal, max int)  ·
+ │         aggregate 0   count_rows()  ·                                  ·
+ │         aggregate 1   sum(k)        ·                                  ·
+ │         aggregate 2   max(k)        ·                                  ·
+ │         scalar        ·             ·                                  ·
+ └── scan  ·             ·             (k int)                            ·
+·          table         kv@primary    ·                                  ·
+·          spans         FULL SCAN     ·                                  ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(v), count(DISTINCT v), sum(v), sum(DISTINCT v), min(v), min(DISTINCT v) FROM kv
 ----
-·          distributed  false              ·                                   ·
-·          vectorized   true               ·                                   ·
-group      ·            ·                  (count, count, sum, sum, min, min)  ·
- │         aggregate 0  count(v)           ·                                   ·
- │         aggregate 1  count(DISTINCT v)  ·                                   ·
- │         aggregate 2  sum(v)             ·                                   ·
- │         aggregate 3  sum(DISTINCT v)    ·                                   ·
- │         aggregate 4  min(v)             ·                                   ·
- │         aggregate 5  min(v)             ·                                   ·
- │         scalar       ·                  ·                                   ·
- └── scan  ·            ·                  (v)                                 ·
-·          table        kv@primary         ·                                   ·
-·          spans        FULL SCAN          ·                                   ·
+·          distribution  local              ·                                   ·
+·          vectorized    true               ·                                   ·
+group      ·             ·                  (count, count, sum, sum, min, min)  ·
+ │         aggregate 0   count(v)           ·                                   ·
+ │         aggregate 1   count(DISTINCT v)  ·                                   ·
+ │         aggregate 2   sum(v)             ·                                   ·
+ │         aggregate 3   sum(DISTINCT v)    ·                                   ·
+ │         aggregate 4   min(v)             ·                                   ·
+ │         aggregate 5   min(v)             ·                                   ·
+ │         scalar        ·                  ·                                   ·
+ └── scan  ·             ·                  (v)                                 ·
+·          table         kv@primary         ·                                   ·
+·          spans         FULL SCAN          ·                                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(DISTINCT a.*) FROM kv a, kv b
 ----
-·                          distributed  false                         ·             ·
-·                          vectorized   true                          ·             ·
-group                      ·            ·                             (count)       ·
- │                         aggregate 0  count(column9)                ·             ·
- │                         scalar       ·                             ·             ·
- └── distinct              ·            ·                             (column9)     ·
-      │                    distinct on  column9                       ·             ·
-      └── render           ·            ·                             (column9)     ·
-           │               render 0     ((k, v, w, s) AS k, v, w, s)  ·             ·
-           └── cross-join  ·            ·                             (k, v, w, s)  ·
-                │          type         cross                         ·             ·
-                ├── scan   ·            ·                             (k, v, w, s)  ·
-                │          table        kv@primary                    ·             ·
-                │          spans        FULL SCAN                     ·             ·
-                └── scan   ·            ·                             ()            ·
-·                          table        kv@primary                    ·             ·
-·                          spans        FULL SCAN                     ·             ·
+·                          distribution  local                         ·             ·
+·                          vectorized    true                          ·             ·
+group                      ·             ·                             (count)       ·
+ │                         aggregate 0   count(column9)                ·             ·
+ │                         scalar        ·                             ·             ·
+ └── distinct              ·             ·                             (column9)     ·
+      │                    distinct on   column9                       ·             ·
+      └── render           ·             ·                             (column9)     ·
+           │               render 0      ((k, v, w, s) AS k, v, w, s)  ·             ·
+           └── cross-join  ·             ·                             (k, v, w, s)  ·
+                │          type          cross                         ·             ·
+                ├── scan   ·             ·                             (k, v, w, s)  ·
+                │          table         kv@primary                    ·             ·
+                │          spans         FULL SCAN                     ·             ·
+                └── scan   ·             ·                             ()            ·
+·                          table         kv@primary                    ·             ·
+·                          spans         FULL SCAN                     ·             ·
 
 query TTT
 SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT min(b.k) FROM kv a, kv b GROUP BY a.*
 ]
 ----
-·                     distributed  false
-·                     vectorized   true
-render                ·            ·
- │                    render 0     min
- └── group            ·            ·
-      │               aggregate 0  k
-      │               aggregate 1  min(k)
-      │               group by     k
-      └── cross-join  ·            ·
-           │          type         cross
-           ├── scan   ·            ·
-           │          table        kv@primary
-           │          spans        FULL SCAN
-           └── scan   ·            ·
-·                     table        kv@primary
-·                     spans        FULL SCAN
+·                     distribution  local
+·                     vectorized    true
+render                ·             ·
+ │                    render 0      min
+ └── group            ·             ·
+      │               aggregate 0   k
+      │               aggregate 1   min(k)
+      │               group by      k
+      └── cross-join  ·             ·
+           │          type          cross
+           ├── scan   ·             ·
+           │          table         kv@primary
+           │          spans         FULL SCAN
+           └── scan   ·             ·
+·                     table         kv@primary
+·                     spans         FULL SCAN
 
 query TTT
 SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT min(b.k) FROM kv a, kv b GROUP BY (1, (a.*))
 ]
 ----
-·                     distributed  false
-·                     vectorized   true
-render                ·            ·
- │                    render 0     min
- └── group            ·            ·
-      │               aggregate 0  k
-      │               aggregate 1  min(k)
-      │               group by     k
-      └── cross-join  ·            ·
-           │          type         cross
-           ├── scan   ·            ·
-           │          table        kv@primary
-           │          spans        FULL SCAN
-           └── scan   ·            ·
-·                     table        kv@primary
-·                     spans        FULL SCAN
+·                     distribution  local
+·                     vectorized    true
+render                ·             ·
+ │                    render 0      min
+ └── group            ·             ·
+      │               aggregate 0   k
+      │               aggregate 1   min(k)
+      │               group by      k
+      └── cross-join  ·             ·
+           │          type          cross
+           ├── scan   ·             ·
+           │          table         kv@primary
+           │          spans         FULL SCAN
+           └── scan   ·             ·
+·                     table         kv@primary
+·                     spans         FULL SCAN
 
 # A useful optimization: naked tuple expansion in GROUP BY clause.
 query TTT
@@ -281,22 +281,22 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT min(b.k) FROM kv a, kv b GROUP BY (a.*)
 ]
 ----
-·                     distributed  false
-·                     vectorized   true
-render                ·            ·
- │                    render 0     min
- └── group            ·            ·
-      │               aggregate 0  k
-      │               aggregate 1  min(k)
-      │               group by     k
-      └── cross-join  ·            ·
-           │          type         cross
-           ├── scan   ·            ·
-           │          table        kv@primary
-           │          spans        FULL SCAN
-           └── scan   ·            ·
-·                     table        kv@primary
-·                     spans        FULL SCAN
+·                     distribution  local
+·                     vectorized    true
+render                ·             ·
+ │                    render 0      min
+ └── group            ·             ·
+      │               aggregate 0   k
+      │               aggregate 1   min(k)
+      │               group by      k
+      └── cross-join  ·             ·
+           │          type          cross
+           ├── scan   ·             ·
+           │          table         kv@primary
+           │          spans         FULL SCAN
+           └── scan   ·             ·
+·                     table         kv@primary
+·                     spans         FULL SCAN
 
 # Show reuse of renders expression inside an expansion.
 query TTT
@@ -304,20 +304,20 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT a.v FROM kv a, kv b GROUP BY a.v, a.w, a.s
 ]
 ----
-·                     distributed  false
-·                     vectorized   true
-render                ·            ·
- │                    render 0     v
- └── distinct         ·            ·
-      │               distinct on  v, w, s
-      └── cross-join  ·            ·
-           │          type         cross
-           ├── scan   ·            ·
-           │          table        kv@primary
-           │          spans        FULL SCAN
-           └── scan   ·            ·
-·                     table        kv@primary
-·                     spans        FULL SCAN
+·                     distribution  local
+·                     vectorized    true
+render                ·             ·
+ │                    render 0      v
+ └── distinct         ·             ·
+      │               distinct on   v, w, s
+      └── cross-join  ·             ·
+           │          type          cross
+           ├── scan   ·             ·
+           │          table         kv@primary
+           │          spans         FULL SCAN
+           └── scan   ·             ·
+·                     table         kv@primary
+·                     spans         FULL SCAN
 
 statement ok
 CREATE TABLE abc (
@@ -330,15 +330,15 @@ CREATE TABLE abc (
 query TTTTT
 EXPLAIN (TYPES) SELECT min(a) FROM abc
 ----
-·          distributed  false            ·           ·
-·          vectorized   true             ·           ·
-group      ·            ·                (min char)  ·
- │         aggregate 0  any_not_null(a)  ·           ·
- │         scalar       ·                ·           ·
- └── scan  ·            ·                (a char)    ·
-·          table        abc@primary      ·           ·
-·          spans        LIMITED SCAN     ·           ·
-·          limit        1                ·           ·
+·          distribution  local            ·           ·
+·          vectorized    true             ·           ·
+group      ·             ·                (min char)  ·
+ │         aggregate 0   any_not_null(a)  ·           ·
+ │         scalar        ·                ·           ·
+ └── scan  ·             ·                (a char)    ·
+·          table         abc@primary      ·           ·
+·          spans         LIMITED SCAN     ·           ·
+·          limit         1                ·           ·
 
 statement ok
 CREATE TABLE xyz (
@@ -358,113 +358,113 @@ INSERT INTO xyz VALUES (1, 2, 3.0), (4, 5, 6.0), (7, NULL, 8.0)
 query TTTTT
 EXPLAIN (TYPES) SELECT min(x) FROM xyz
 ----
-·          distributed  false            ·          ·
-·          vectorized   true             ·          ·
-group      ·            ·                (min int)  ·
- │         aggregate 0  any_not_null(x)  ·          ·
- │         scalar       ·                ·          ·
- └── scan  ·            ·                (x int)    ·
-·          table        xyz@xy           ·          ·
-·          spans        LIMITED SCAN     ·          ·
-·          limit        1                ·          ·
+·          distribution  local            ·          ·
+·          vectorized    true             ·          ·
+group      ·             ·                (min int)  ·
+ │         aggregate 0   any_not_null(x)  ·          ·
+ │         scalar        ·                ·          ·
+ └── scan  ·             ·                (x int)    ·
+·          table         xyz@xy           ·          ·
+·          spans         LIMITED SCAN     ·          ·
+·          limit         1                ·          ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT min(x) FROM xyz WHERE x in (0, 4, 7)
 ----
-·          distributed  false              ·          ·
-·          vectorized   true               ·          ·
-group      ·            ·                  (min int)  ·
- │         aggregate 0  any_not_null(x)    ·          ·
- │         scalar       ·                  ·          ·
- └── scan  ·            ·                  (x int)    ·
-·          table        xyz@xy             ·          ·
-·          spans        /0-/1 /4-/5 /7-/8  ·          ·
-·          limit        1                  ·          ·
+·          distribution  local              ·          ·
+·          vectorized    true               ·          ·
+group      ·             ·                  (min int)  ·
+ │         aggregate 0   any_not_null(x)    ·          ·
+ │         scalar        ·                  ·          ·
+ └── scan  ·             ·                  (x int)    ·
+·          table         xyz@xy             ·          ·
+·          spans         /0-/1 /4-/5 /7-/8  ·          ·
+·          limit         1                  ·          ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT max(x) FROM xyz
 ----
-·             distributed  false            ·          ·
-·             vectorized   true             ·          ·
-group         ·            ·                (max int)  ·
- │            aggregate 0  any_not_null(x)  ·          ·
- │            scalar       ·                ·          ·
- └── revscan  ·            ·                (x int)    ·
-·             table        xyz@xy           ·          ·
-·             spans        LIMITED SCAN     ·          ·
-·             limit        1                ·          ·
+·             distribution  local            ·          ·
+·             vectorized    true             ·          ·
+group         ·             ·                (max int)  ·
+ │            aggregate 0   any_not_null(x)  ·          ·
+ │            scalar        ·                ·          ·
+ └── revscan  ·             ·                (x int)    ·
+·             table         xyz@xy           ·          ·
+·             spans         LIMITED SCAN     ·          ·
+·             limit         1                ·          ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT min(y) FROM xyz WHERE x = 1
 ----
-·               distributed  false            ·               ·
-·               vectorized   true             ·               ·
-group           ·            ·                (min int)       ·
- │              aggregate 0  any_not_null(y)  ·               ·
- │              scalar       ·                ·               ·
- └── render     ·            ·                (y int)         ·
-      │         render 0     (y)[int]         ·               ·
-      └── scan  ·            ·                (x int, y int)  ·
-·               table        xyz@xy           ·               ·
-·               spans        /1/!NULL-/2      ·               ·
+·               distribution  local            ·               ·
+·               vectorized    true             ·               ·
+group           ·             ·                (min int)       ·
+ │              aggregate 0   any_not_null(y)  ·               ·
+ │              scalar        ·                ·               ·
+ └── render     ·             ·                (y int)         ·
+      │         render 0      (y)[int]         ·               ·
+      └── scan  ·             ·                (x int, y int)  ·
+·               table         xyz@xy           ·               ·
+·               spans         /1/!NULL-/2      ·               ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT max(y) FROM xyz WHERE x = 1
 ----
-·               distributed  false            ·               ·
-·               vectorized   true             ·               ·
-group           ·            ·                (max int)       ·
- │              aggregate 0  any_not_null(y)  ·               ·
- │              scalar       ·                ·               ·
- └── render     ·            ·                (y int)         ·
-      │         render 0     (y)[int]         ·               ·
-      └── scan  ·            ·                (x int, y int)  ·
-·               table        xyz@xy           ·               ·
-·               spans        /1/!NULL-/2      ·               ·
+·               distribution  local            ·               ·
+·               vectorized    true             ·               ·
+group           ·             ·                (max int)       ·
+ │              aggregate 0   any_not_null(y)  ·               ·
+ │              scalar        ·                ·               ·
+ └── render     ·             ·                (y int)         ·
+      │         render 0      (y)[int]         ·               ·
+      └── scan  ·             ·                (x int, y int)  ·
+·               table         xyz@xy           ·               ·
+·               spans         /1/!NULL-/2      ·               ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT min(y) FROM xyz WHERE z = 7
 ----
-·               distributed  false                        ·                 ·
-·               vectorized   true                         ·                 ·
-group           ·            ·                            (min int)         ·
- │              aggregate 0  any_not_null(y)              ·                 ·
- │              scalar       ·                            ·                 ·
- └── render     ·            ·                            (y int)           ·
-      │         render 0     (y)[int]                     ·                 ·
-      └── scan  ·            ·                            (y int, z float)  ·
-·               table        xyz@zyx                      ·                 ·
-·               spans        /7/!NULL-/7.000000000000001  ·                 ·
-·               limit        1                            ·                 ·
+·               distribution  local                        ·                 ·
+·               vectorized    true                         ·                 ·
+group           ·             ·                            (min int)         ·
+ │              aggregate 0   any_not_null(y)              ·                 ·
+ │              scalar        ·                            ·                 ·
+ └── render     ·             ·                            (y int)           ·
+      │         render 0      (y)[int]                     ·                 ·
+      └── scan  ·             ·                            (y int, z float)  ·
+·               table         xyz@zyx                      ·                 ·
+·               spans         /7/!NULL-/7.000000000000001  ·                 ·
+·               limit         1                            ·                 ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT max(y) FROM xyz WHERE z = 7
 ----
-·                  distributed  false                        ·                 ·
-·                  vectorized   true                         ·                 ·
-group              ·            ·                            (max int)         ·
- │                 aggregate 0  any_not_null(y)              ·                 ·
- │                 scalar       ·                            ·                 ·
- └── render        ·            ·                            (y int)           ·
-      │            render 0     (y)[int]                     ·                 ·
-      └── revscan  ·            ·                            (y int, z float)  ·
-·                  table        xyz@zyx                      ·                 ·
-·                  spans        /7/!NULL-/7.000000000000001  ·                 ·
-·                  limit        1                            ·                 ·
+·                  distribution  local                        ·                 ·
+·                  vectorized    true                         ·                 ·
+group              ·             ·                            (max int)         ·
+ │                 aggregate 0   any_not_null(y)              ·                 ·
+ │                 scalar        ·                            ·                 ·
+ └── render        ·             ·                            (y int)           ·
+      │            render 0      (y)[int]                     ·                 ·
+      └── revscan  ·             ·                            (y int, z float)  ·
+·                  table         xyz@zyx                      ·                 ·
+·                  spans         /7/!NULL-/7.000000000000001  ·                 ·
+·                  limit         1                            ·                 ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT min(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
-·               distributed  false      ·                        ·
-·               vectorized   true       ·                        ·
-group           ·            ·          (min int)                ·
- │              aggregate 0  min(x)     ·                        ·
- │              scalar       ·          ·                        ·
- └── render     ·            ·          (x int)                  ·
-      │         render 0     (x)[int]   ·                        ·
-      └── scan  ·            ·          (x int, y int, z float)  ·
-·               table        xyz@zyx    ·                        ·
-·               spans        /3/2-/3/3  ·                        ·
+·               distribution  local      ·                        ·
+·               vectorized    true       ·                        ·
+group           ·             ·          (min int)                ·
+ │              aggregate 0   min(x)     ·                        ·
+ │              scalar        ·          ·                        ·
+ └── render     ·             ·          (x int)                  ·
+      │         render 0      (x)[int]   ·                        ·
+      └── scan  ·             ·          (x int, y int, z float)  ·
+·               table         xyz@zyx    ·                        ·
+·               spans         /3/2-/3/3  ·                        ·
 
 statement ok
 SET tracing = on,kv,results; SELECT min(x) FROM xyz WHERE (y, z) = (2, 3.0); SET tracing = off
@@ -480,16 +480,16 @@ output row: [1]
 query TTTTT
 EXPLAIN (TYPES) SELECT max(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
-·               distributed  false      ·                        ·
-·               vectorized   true       ·                        ·
-group           ·            ·          (max int)                ·
- │              aggregate 0  max(x)     ·                        ·
- │              scalar       ·          ·                        ·
- └── render     ·            ·          (x int)                  ·
-      │         render 0     (x)[int]   ·                        ·
-      └── scan  ·            ·          (x int, y int, z float)  ·
-·               table        xyz@zyx    ·                        ·
-·               spans        /3/2-/3/3  ·                        ·
+·               distribution  local      ·                        ·
+·               vectorized    true       ·                        ·
+group           ·             ·          (max int)                ·
+ │              aggregate 0   max(x)     ·                        ·
+ │              scalar        ·          ·                        ·
+ └── render     ·             ·          (x int)                  ·
+      │         render 0      (x)[int]   ·                        ·
+      └── scan  ·             ·          (x int, y int, z float)  ·
+·               table         xyz@zyx    ·                        ·
+·               spans         /3/2-/3/3  ·                        ·
 
 # VARIANCE/STDDEV
 
@@ -514,14 +514,14 @@ output row: [9 4.5 6.33333333333333]
 query TTTTT
 EXPLAIN (TYPES) SELECT variance(x) FROM xyz WHERE x = 1
 ----
-·          distributed  false        ·                   ·
-·          vectorized   true         ·                   ·
-group      ·            ·            (variance decimal)  ·
- │         aggregate 0  variance(x)  ·                   ·
- │         scalar       ·            ·                   ·
- └── scan  ·            ·            (x int)             ·
-·          table        xyz@xy       ·                   ·
-·          spans        /1-/2        ·                   ·
+·          distribution  local        ·                   ·
+·          vectorized    true         ·                   ·
+group      ·             ·            (variance decimal)  ·
+ │         aggregate 0   variance(x)  ·                   ·
+ │         scalar        ·            ·                   ·
+ └── scan  ·             ·            (x int)             ·
+·          table         xyz@xy       ·                   ·
+·          spans         /1-/2        ·                   ·
 
 ## Tests for the single-row optimization.
 statement ok
@@ -585,72 +585,72 @@ INSERT INTO ab VALUES
 query TTTTT
 EXPLAIN (TYPES) SELECT v, count(k) FROM kv GROUP BY v ORDER BY count(k)
 ----
-·               distributed  false         ·                   ·
-·               vectorized   true          ·                   ·
-sort            ·            ·             (v int, count int)  +count
- │              order        +count        ·                   ·
- └── group      ·            ·             (v int, count int)  ·
-      │         aggregate 0  v             ·                   ·
-      │         aggregate 1  count_rows()  ·                   ·
-      │         group by     v             ·                   ·
-      └── scan  ·            ·             (v int)             ·
-·               table        kv@primary    ·                   ·
-·               spans        FULL SCAN     ·                   ·
+·               distribution  local         ·                   ·
+·               vectorized    true          ·                   ·
+sort            ·             ·             (v int, count int)  +count
+ │              order         +count        ·                   ·
+ └── group      ·             ·             (v int, count int)  ·
+      │         aggregate 0   v             ·                   ·
+      │         aggregate 1   count_rows()  ·                   ·
+      │         group by      v             ·                   ·
+      └── scan  ·             ·             (v int)             ·
+·               table         kv@primary    ·                   ·
+·               spans         FULL SCAN     ·                   ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT v, count(*) FROM kv GROUP BY v ORDER BY count(*)
 ----
-·               distributed  false         ·                   ·
-·               vectorized   true          ·                   ·
-sort            ·            ·             (v int, count int)  +count
- │              order        +count        ·                   ·
- └── group      ·            ·             (v int, count int)  ·
-      │         aggregate 0  v             ·                   ·
-      │         aggregate 1  count_rows()  ·                   ·
-      │         group by     v             ·                   ·
-      └── scan  ·            ·             (v int)             ·
-·               table        kv@primary    ·                   ·
-·               spans        FULL SCAN     ·                   ·
+·               distribution  local         ·                   ·
+·               vectorized    true          ·                   ·
+sort            ·             ·             (v int, count int)  +count
+ │              order         +count        ·                   ·
+ └── group      ·             ·             (v int, count int)  ·
+      │         aggregate 0   v             ·                   ·
+      │         aggregate 1   count_rows()  ·                   ·
+      │         group by      v             ·                   ·
+      └── scan  ·             ·             (v int)             ·
+·               table         kv@primary    ·                   ·
+·               spans         FULL SCAN     ·                   ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT v, count(NULL) FROM kv GROUP BY v ORDER BY count(1)
 ----
-·                         distributed  false            ·                                   ·
-·                         vectorized   true             ·                                   ·
-render                    ·            ·                (v int, count int)                  ·
- │                        render 0     (v)[int]         ·                                   ·
- │                        render 1     (count)[int]     ·                                   ·
- └── sort                 ·            ·                (v int, count int, count_rows int)  +count_rows
-      │                   order        +count_rows      ·                                   ·
-      └── group           ·            ·                (v int, count int, count_rows int)  ·
-           │              aggregate 0  v                ·                                   ·
-           │              aggregate 1  count(column5)   ·                                   ·
-           │              aggregate 2  count_rows()     ·                                   ·
-           │              group by     v                ·                                   ·
-           └── render     ·            ·                (column5 unknown, v int)            ·
-                │         render 0     (NULL)[unknown]  ·                                   ·
-                │         render 1     (v)[int]         ·                                   ·
-                └── scan  ·            ·                (v int)                             ·
-·                         table        kv@primary       ·                                   ·
-·                         spans        FULL SCAN        ·                                   ·
+·                         distribution  local            ·                                   ·
+·                         vectorized    true             ·                                   ·
+render                    ·             ·                (v int, count int)                  ·
+ │                        render 0      (v)[int]         ·                                   ·
+ │                        render 1      (count)[int]     ·                                   ·
+ └── sort                 ·             ·                (v int, count int, count_rows int)  +count_rows
+      │                   order         +count_rows      ·                                   ·
+      └── group           ·             ·                (v int, count int, count_rows int)  ·
+           │              aggregate 0   v                ·                                   ·
+           │              aggregate 1   count(column5)   ·                                   ·
+           │              aggregate 2   count_rows()     ·                                   ·
+           │              group by      v                ·                                   ·
+           └── render     ·             ·                (column5 unknown, v int)            ·
+                │         render 0      (NULL)[unknown]  ·                                   ·
+                │         render 1      (v)[int]         ·                                   ·
+                └── scan  ·             ·                (v int)                             ·
+·                         table         kv@primary       ·                                   ·
+·                         spans         FULL SCAN        ·                                   ·
 
 # Check that filters propagate through no-op aggregation.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT v, count(NULL) FROM kv GROUP BY v) WHERE v > 10
 ----
-·               distributed  false           ·             ·
-·               vectorized   true            ·             ·
-group           ·            ·               (v, count)    ·
- │              aggregate 0  v               ·             ·
- │              aggregate 1  count(column5)  ·             ·
- │              group by     v               ·             ·
- └── render     ·            ·               (column5, v)  ·
-      │         render 0     NULL            ·             ·
-      │         render 1     v               ·             ·
-      └── scan  ·            ·               (v)           ·
-·               table        kv@primary      ·             ·
-·               spans        FULL SCAN       ·             ·
-·               filter       v > 10          ·             ·
+·               distribution  local           ·             ·
+·               vectorized    true            ·             ·
+group           ·             ·               (v, count)    ·
+ │              aggregate 0   v               ·             ·
+ │              aggregate 1   count(column5)  ·             ·
+ │              group by      v               ·             ·
+ └── render     ·             ·               (column5, v)  ·
+      │         render 0      NULL            ·             ·
+      │         render 1      v               ·             ·
+      └── scan  ·             ·               (v)           ·
+·               table         kv@primary      ·             ·
+·               spans         FULL SCAN       ·             ·
+·               filter        v > 10          ·             ·
 
 # Verify that FILTER works.
 
@@ -665,75 +665,75 @@ CREATE TABLE filter_test (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(*) FILTER (WHERE k>5), max(k>5) FILTER(WHERE k>5) FROM filter_test GROUP BY v
 ----
-·                    distributed  false                                  ·                      ·
-·                    vectorized   true                                   ·                      ·
-render               ·            ·                                      (count, max)           ·
- │                   render 0     count                                  ·                      ·
- │                   render 1     max                                    ·                      ·
- └── group           ·            ·                                      (v, count, max)        ·
-      │              aggregate 0  v                                      ·                      ·
-      │              aggregate 1  count(column5) FILTER (WHERE column6)  ·                      ·
-      │              aggregate 2  max(column6) FILTER (WHERE column6)    ·                      ·
-      │              group by     v                                      ·                      ·
-      └── render     ·            ·                                      (column5, column6, v)  ·
-           │         render 0     true                                   ·                      ·
-           │         render 1     k > 5                                  ·                      ·
-           │         render 2     v                                      ·                      ·
-           └── scan  ·            ·                                      (k, v)                 ·
-·                    table        filter_test@primary                    ·                      ·
-·                    spans        FULL SCAN                              ·                      ·
+·                    distribution  local                                  ·                      ·
+·                    vectorized    true                                   ·                      ·
+render               ·             ·                                      (count, max)           ·
+ │                   render 0      count                                  ·                      ·
+ │                   render 1      max                                    ·                      ·
+ └── group           ·             ·                                      (v, count, max)        ·
+      │              aggregate 0   v                                      ·                      ·
+      │              aggregate 1   count(column5) FILTER (WHERE column6)  ·                      ·
+      │              aggregate 2   max(column6) FILTER (WHERE column6)    ·                      ·
+      │              group by      v                                      ·                      ·
+      └── render     ·             ·                                      (column5, column6, v)  ·
+           │         render 0      true                                   ·                      ·
+           │         render 1      k > 5                                  ·                      ·
+           │         render 2      v                                      ·                      ·
+           └── scan  ·             ·                                      (k, v)                 ·
+·                    table         filter_test@primary                    ·                      ·
+·                    spans         FULL SCAN                              ·                      ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(*) FILTER (WHERE k > 5) FROM filter_test GROUP BY v
 ----
-·                    distributed  false                                  ·                      ·
-·                    vectorized   true                                   ·                      ·
-render               ·            ·                                      (count)                ·
- │                   render 0     count                                  ·                      ·
- └── group           ·            ·                                      (v, count)             ·
-      │              aggregate 0  v                                      ·                      ·
-      │              aggregate 1  count(column5) FILTER (WHERE column6)  ·                      ·
-      │              group by     v                                      ·                      ·
-      └── render     ·            ·                                      (column5, column6, v)  ·
-           │         render 0     true                                   ·                      ·
-           │         render 1     k > 5                                  ·                      ·
-           │         render 2     v                                      ·                      ·
-           └── scan  ·            ·                                      (k, v)                 ·
-·                    table        filter_test@primary                    ·                      ·
-·                    spans        FULL SCAN                              ·                      ·
+·                    distribution  local                                  ·                      ·
+·                    vectorized    true                                   ·                      ·
+render               ·             ·                                      (count)                ·
+ │                   render 0      count                                  ·                      ·
+ └── group           ·             ·                                      (v, count)             ·
+      │              aggregate 0   v                                      ·                      ·
+      │              aggregate 1   count(column5) FILTER (WHERE column6)  ·                      ·
+      │              group by      v                                      ·                      ·
+      └── render     ·             ·                                      (column5, column6, v)  ·
+           │         render 0      true                                   ·                      ·
+           │         render 1      k > 5                                  ·                      ·
+           │         render 2      v                                      ·                      ·
+           └── scan  ·             ·                                      (k, v)                 ·
+·                    table         filter_test@primary                    ·                      ·
+·                    spans         FULL SCAN                              ·                      ·
 
 # Tests with * inside GROUP BY.
 query TTTTT
 EXPLAIN (TYPES) SELECT 1 a FROM kv GROUP BY kv.*;
 ----
-·          distributed  false       ·        ·
-·          vectorized   true        ·        ·
-render     ·            ·           (a int)  ·
- │         render 0     (1)[int]    ·        ·
- └── scan  ·            ·           ()       ·
-·          table        kv@primary  ·        ·
-·          spans        FULL SCAN   ·        ·
+·          distribution  local       ·        ·
+·          vectorized    true        ·        ·
+render     ·             ·           (a int)  ·
+ │         render 0      (1)[int]    ·        ·
+ └── scan  ·             ·           ()       ·
+·          table         kv@primary  ·        ·
+·          spans         FULL SCAN   ·        ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT sum(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
 ----
-·                     distributed  false                             ·                     ·
-·                     vectorized   true                              ·                     ·
-render                ·            ·                                 (sum decimal)         ·
- │                    render 0     (sum)[decimal]                    ·                     ·
- └── group            ·            ·                                 (k int, sum decimal)  ·
-      │               aggregate 0  k                                 ·                     ·
-      │               aggregate 1  sum(d)                            ·                     ·
-      │               group by     k                                 ·                     ·
-      └── cross-join  ·            ·                                 (k int, d decimal)    ·
-           │          type         inner                             ·                     ·
-           │          pred         ((k)[int] >= (d)[decimal])[bool]  ·                     ·
-           ├── scan   ·            ·                                 (k int)               ·
-           │          table        kv@primary                        ·                     ·
-           │          spans        FULL SCAN                         ·                     ·
-           └── scan   ·            ·                                 (d decimal)           ·
-·                     table        abc@primary                       ·                     ·
-·                     spans        FULL SCAN                         ·                     ·
+·                     distribution  local                             ·                     ·
+·                     vectorized    true                              ·                     ·
+render                ·             ·                                 (sum decimal)         ·
+ │                    render 0      (sum)[decimal]                    ·                     ·
+ └── group            ·             ·                                 (k int, sum decimal)  ·
+      │               aggregate 0   k                                 ·                     ·
+      │               aggregate 1   sum(d)                            ·                     ·
+      │               group by      k                                 ·                     ·
+      └── cross-join  ·             ·                                 (k int, d decimal)    ·
+           │          type          inner                             ·                     ·
+           │          pred          ((k)[int] >= (d)[decimal])[bool]  ·                     ·
+           ├── scan   ·             ·                                 (k int)               ·
+           │          table         kv@primary                        ·                     ·
+           │          spans         FULL SCAN                         ·                     ·
+           └── scan   ·             ·                                 (d decimal)           ·
+·                     table         abc@primary                       ·                     ·
+·                     spans         FULL SCAN                         ·                     ·
 
 # opt_test is used for tests around the single-row optimization for MIN/MAX.
 statement ok
@@ -743,15 +743,15 @@ CREATE TABLE opt_test (k INT PRIMARY KEY, v INT, INDEX v(v))
 query TTTTT
 EXPLAIN (TYPES) SELECT min(v) FROM opt_test
 ----
-·          distributed  false            ·          ·
-·          vectorized   true             ·          ·
-group      ·            ·                (min int)  ·
- │         aggregate 0  any_not_null(v)  ·          ·
- │         scalar       ·                ·          ·
- └── scan  ·            ·                (v int)    ·
-·          table        opt_test@v       ·          ·
-·          spans        /!NULL-          ·          ·
-·          limit        1                ·          ·
+·          distribution  local            ·          ·
+·          vectorized    true             ·          ·
+group      ·             ·                (min int)  ·
+ │         aggregate 0   any_not_null(v)  ·          ·
+ │         scalar        ·                ·          ·
+ └── scan  ·             ·                (v int)    ·
+·          table         opt_test@v       ·          ·
+·          spans         /!NULL-          ·          ·
+·          limit         1                ·          ·
 
 # Repeat test when there is an existing filter.
 # TODO(radu): the best plan for this would be to use index v; in this case the scan
@@ -759,52 +759,52 @@ group      ·            ·                (min int)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT min(v) FROM opt_test WHERE k <> 4
 ----
-·                    distributed  false                         ·               ·
-·                    vectorized   true                          ·               ·
-group                ·            ·                             (min int)       ·
- │                   aggregate 0  any_not_null(v)               ·               ·
- │                   scalar       ·                             ·               ·
- └── render          ·            ·                             (v int)         ·
-      │              render 0     (v)[int]                      ·               ·
-      └── limit      ·            ·                             (k int, v int)  +v
-           │         count        (1)[int]                      ·               ·
-           └── scan  ·            ·                             (k int, v int)  +v
-·                    table        opt_test@v                    ·               ·
-·                    spans        /!NULL-                       ·               ·
-·                    filter       ((k)[int] != (4)[int])[bool]  ·               ·
+·                    distribution  local                         ·               ·
+·                    vectorized    true                          ·               ·
+group                ·             ·                             (min int)       ·
+ │                   aggregate 0   any_not_null(v)               ·               ·
+ │                   scalar        ·                             ·               ·
+ └── render          ·             ·                             (v int)         ·
+      │              render 0      (v)[int]                      ·               ·
+      └── limit      ·             ·                             (k int, v int)  +v
+           │         count         (1)[int]                      ·               ·
+           └── scan  ·             ·                             (k int, v int)  +v
+·                    table         opt_test@v                    ·               ·
+·                    spans         /!NULL-                       ·               ·
+·                    filter        ((k)[int] != (4)[int])[bool]  ·               ·
 
 # Check that the optimization doesn't work when the argument is non-trivial (we
 # can't in general guarantee an ordering on a synthesized column).
 query TTTTT
 EXPLAIN (TYPES) SELECT min(v+1) FROM opt_test
 ----
-·               distributed  false                       ·              ·
-·               vectorized   true                        ·              ·
-group           ·            ·                           (min int)      ·
- │              aggregate 0  min(column3)                ·              ·
- │              scalar       ·                           ·              ·
- └── render     ·            ·                           (column3 int)  ·
-      │         render 0     ((v)[int] + (1)[int])[int]  ·              ·
-      └── scan  ·            ·                           (v int)        ·
-·               table        opt_test@primary            ·              ·
-·               spans        FULL SCAN                   ·              ·
+·               distribution  local                       ·              ·
+·               vectorized    true                        ·              ·
+group           ·             ·                           (min int)      ·
+ │              aggregate 0   min(column3)                ·              ·
+ │              scalar        ·                           ·              ·
+ └── render     ·             ·                           (column3 int)  ·
+      │         render 0      ((v)[int] + (1)[int])[int]  ·              ·
+      └── scan  ·             ·                           (v int)        ·
+·               table         opt_test@primary            ·              ·
+·               spans         FULL SCAN                   ·              ·
 
 # Verify that we don't use the optimization if there is a GROUP BY.
 query TTTTT
 EXPLAIN (TYPES) SELECT min(v) FROM opt_test GROUP BY k
 ----
-·               distributed  false             ·                 ·
-·               vectorized   true              ·                 ·
-render          ·            ·                 (min int)         ·
- │              render 0     (min)[int]        ·                 ·
- └── group      ·            ·                 (k int, min int)  ·
-      │         aggregate 0  k                 ·                 ·
-      │         aggregate 1  min(v)            ·                 ·
-      │         group by     k                 ·                 ·
-      │         ordered      +k                ·                 ·
-      └── scan  ·            ·                 (k int, v int)    +k
-·               table        opt_test@primary  ·                 ·
-·               spans        FULL SCAN         ·                 ·
+·               distribution  local             ·                 ·
+·               vectorized    true              ·                 ·
+render          ·             ·                 (min int)         ·
+ │              render 0      (min)[int]        ·                 ·
+ └── group      ·             ·                 (k int, min int)  ·
+      │         aggregate 0   k                 ·                 ·
+      │         aggregate 1   min(v)            ·                 ·
+      │         group by      k                 ·                 ·
+      │         ordered       +k                ·                 ·
+      └── scan  ·             ·                 (k int, v int)    +k
+·               table         opt_test@primary  ·                 ·
+·               spans         FULL SCAN         ·                 ·
 
 statement ok
 CREATE TABLE xy(x STRING, y STRING);
@@ -812,36 +812,36 @@ CREATE TABLE xy(x STRING, y STRING);
 query TTTTT
 EXPLAIN (TYPES) SELECT (b, a) r FROM ab GROUP BY (b, a)
 ----
-·          distributed  false                                    ·                    ·
-·          vectorized   true                                     ·                    ·
-render     ·            ·                                        (r tuple{int, int})  ·
- │         render 0     (((b)[int], (a)[int]))[tuple{int, int}]  ·                    ·
- └── scan  ·            ·                                        (a int, b int)       ·
-·          table        ab@primary                               ·                    ·
-·          spans        FULL SCAN                                ·                    ·
+·          distribution  local                                    ·                    ·
+·          vectorized    true                                     ·                    ·
+render     ·             ·                                        (r tuple{int, int})  ·
+ │         render 0      (((b)[int], (a)[int]))[tuple{int, int}]  ·                    ·
+ └── scan  ·             ·                                        (a int, b int)       ·
+·          table         ab@primary                               ·                    ·
+·          spans         FULL SCAN                                ·                    ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT min(y), (b, a) r FROM ab, xy GROUP BY (x, (a, b))
 ----
-·                     distributed  false                                               ·                                                ·
-·                     vectorized   true                                                ·                                                ·
-render                ·            ·                                                   (min string, r tuple{int, int})                  ·
- │                    render 0     (min)[string]                                       ·                                                ·
- │                    render 1     (((any_not_null)[int], (a)[int]))[tuple{int, int}]  ·                                                ·
- └── group            ·            ·                                                   (a int, x string, min string, any_not_null int)  ·
-      │               aggregate 0  a                                                   ·                                                ·
-      │               aggregate 1  x                                                   ·                                                ·
-      │               aggregate 2  min(y)                                              ·                                                ·
-      │               aggregate 3  any_not_null(b)                                     ·                                                ·
-      │               group by     a, x                                                ·                                                ·
-      └── cross-join  ·            ·                                                   (a int, b int, x string, y string)               ·
-           │          type         cross                                               ·                                                ·
-           ├── scan   ·            ·                                                   (a int, b int)                                   ·
-           │          table        ab@primary                                          ·                                                ·
-           │          spans        FULL SCAN                                           ·                                                ·
-           └── scan   ·            ·                                                   (x string, y string)                             ·
-·                     table        xy@primary                                          ·                                                ·
-·                     spans        FULL SCAN                                           ·                                                ·
+·                     distribution  local                                               ·                                                ·
+·                     vectorized    true                                                ·                                                ·
+render                ·             ·                                                   (min string, r tuple{int, int})                  ·
+ │                    render 0      (min)[string]                                       ·                                                ·
+ │                    render 1      (((any_not_null)[int], (a)[int]))[tuple{int, int}]  ·                                                ·
+ └── group            ·             ·                                                   (a int, x string, min string, any_not_null int)  ·
+      │               aggregate 0   a                                                   ·                                                ·
+      │               aggregate 1   x                                                   ·                                                ·
+      │               aggregate 2   min(y)                                              ·                                                ·
+      │               aggregate 3   any_not_null(b)                                     ·                                                ·
+      │               group by      a, x                                                ·                                                ·
+      └── cross-join  ·             ·                                                   (a int, b int, x string, y string)               ·
+           │          type          cross                                               ·                                                ·
+           ├── scan   ·             ·                                                   (a int, b int)                                   ·
+           │          table         ab@primary                                          ·                                                ·
+           │          spans         FULL SCAN                                           ·                                                ·
+           └── scan   ·             ·                                                   (x string, y string)                             ·
+·                     table         xy@primary                                          ·                                                ·
+·                     spans         FULL SCAN                                           ·                                                ·
 
 # Test that ordering on GROUP BY columns is maintained.
 # TODO(radu): Derive GROUP BY ordering in physicalPropsBuilder.
@@ -961,20 +961,20 @@ render                ·            ·                                          
 query TTTTT
 EXPLAIN (TYPES) SELECT 1 a FROM kv GROUP BY v, w::DECIMAL HAVING w::DECIMAL > 1;
 ----
-·                         distributed  false                                      ·                         ·
-·                         vectorized   true                                       ·                         ·
-render                    ·            ·                                          (a int)                   ·
- │                        render 0     (1)[int]                                   ·                         ·
- └── distinct             ·            ·                                          (column5 decimal, v int)  ·
-      │                   distinct on  column5, v                                 ·                         ·
-      └── filter          ·            ·                                          (column5 decimal, v int)  ·
-           │              filter       ((column5)[decimal] > (1)[decimal])[bool]  ·                         ·
-           └── render     ·            ·                                          (column5 decimal, v int)  ·
-                │         render 0     ((w)[int]::DECIMAL)[decimal]               ·                         ·
-                │         render 1     (v)[int]                                   ·                         ·
-                └── scan  ·            ·                                          (v int, w int)            ·
-·                         table        kv@primary                                 ·                         ·
-·                         spans        FULL SCAN                                  ·                         ·
+·                         distribution  local                                      ·                         ·
+·                         vectorized    true                                       ·                         ·
+render                    ·             ·                                          (a int)                   ·
+ │                        render 0      (1)[int]                                   ·                         ·
+ └── distinct             ·             ·                                          (column5 decimal, v int)  ·
+      │                   distinct on   column5, v                                 ·                         ·
+      └── filter          ·             ·                                          (column5 decimal, v int)  ·
+           │              filter        ((column5)[decimal] > (1)[decimal])[bool]  ·                         ·
+           └── render     ·             ·                                          (column5 decimal, v int)  ·
+                │         render 0      ((w)[int]::DECIMAL)[decimal]               ·                         ·
+                │         render 1      (v)[int]                                   ·                         ·
+                └── scan  ·             ·                                          (v int, w int)            ·
+·                         table         kv@primary                                 ·                         ·
+·                         spans         FULL SCAN                                  ·                         ·
 
 statement ok
 CREATE TABLE foo(a INT, b CHAR)
@@ -983,127 +983,127 @@ CREATE TABLE foo(a INT, b CHAR)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1
 ----
-·                    distributed  false        ·               ·
-·                    vectorized   true         ·               ·
-render               ·            ·            (m)             ·
- │                   render 0     min          ·               ·
- └── group           ·            ·            (column5, min)  ·
-      │              aggregate 0  column5      ·               ·
-      │              aggregate 1  min(a)       ·               ·
-      │              group by     column5      ·               ·
-      └── render     ·            ·            (column5, a)    ·
-           │         render 0     a            ·               ·
-           │         render 1     a            ·               ·
-           └── scan  ·            ·            (a)             ·
-·                    table        foo@primary  ·               ·
-·                    spans        FULL SCAN    ·               ·
+·                    distribution  local        ·               ·
+·                    vectorized    true         ·               ·
+render               ·             ·            (m)             ·
+ │                   render 0      min          ·               ·
+ └── group           ·             ·            (column5, min)  ·
+      │              aggregate 0   column5      ·               ·
+      │              aggregate 1   min(a)       ·               ·
+      │              group by      column5      ·               ·
+      └── render     ·             ·            (column5, a)    ·
+           │         render 0      a            ·               ·
+           │         render 1      a            ·               ·
+           └── scan  ·             ·            (a)             ·
+·                    table         foo@primary  ·               ·
+·                    spans         FULL SCAN    ·               ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2
 ----
-·                    distributed  false        ·               ·
-·                    vectorized   true         ·               ·
-render               ·            ·            (m)             ·
- │                   render 0     min          ·               ·
- └── group           ·            ·            (column5, min)  ·
-      │              aggregate 0  column5      ·               ·
-      │              aggregate 1  min(a)       ·               ·
-      │              group by     column5      ·               ·
-      └── render     ·            ·            (column5, a)    ·
-           │         render 0     b            ·               ·
-           │         render 1     a            ·               ·
-           └── scan  ·            ·            (a, b)          ·
-·                    table        foo@primary  ·               ·
-·                    spans        FULL SCAN    ·               ·
+·                    distribution  local        ·               ·
+·                    vectorized    true         ·               ·
+render               ·             ·            (m)             ·
+ │                   render 0      min          ·               ·
+ └── group           ·             ·            (column5, min)  ·
+      │              aggregate 0   column5      ·               ·
+      │              aggregate 1   min(a)       ·               ·
+      │              group by      column5      ·               ·
+      └── render     ·             ·            (column5, a)    ·
+           │         render 0      b            ·               ·
+           │         render 1      a            ·               ·
+           └── scan  ·             ·            (a, b)          ·
+·                    table         foo@primary  ·               ·
+·                    spans         FULL SCAN    ·               ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT array_agg(v) FROM (SELECT * FROM kv ORDER BY v)
 ----
-·               distributed  false         ·            ·
-·               vectorized   true          ·            ·
-group           ·            ·             (array_agg)  ·
- │              aggregate 0  array_agg(v)  ·            ·
- │              scalar       ·             ·            ·
- └── sort       ·            ·             (v)          +v
-      │         order        +v            ·            ·
-      └── scan  ·            ·             (v)          ·
-·               table        kv@primary    ·            ·
-·               spans        FULL SCAN     ·            ·
+·               distribution  local         ·            ·
+·               vectorized    true          ·            ·
+group           ·             ·             (array_agg)  ·
+ │              aggregate 0   array_agg(v)  ·            ·
+ │              scalar        ·             ·            ·
+ └── sort       ·             ·             (v)          +v
+      │         order         +v            ·            ·
+      └── scan  ·             ·             (v)          ·
+·               table         kv@primary    ·            ·
+·               spans         FULL SCAN     ·            ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY s
 ----
-·               distributed  false       ·       ·
-·               vectorized   true        ·       ·
-render          ·            ·           (k)     ·
- │              render 0     k           ·       ·
- └── sort       ·            ·           (k, s)  +s
-      │         order        +s          ·       ·
-      └── scan  ·            ·           (k, s)  ·
-·               table        kv@primary  ·       ·
-·               spans        FULL SCAN   ·       ·
+·               distribution  local       ·       ·
+·               vectorized    true        ·       ·
+render          ·             ·           (k)     ·
+ │              render 0      k           ·       ·
+ └── sort       ·             ·           (k, s)  +s
+      │         order         +s          ·       ·
+      └── scan  ·             ·           (k, s)  ·
+·               table         kv@primary  ·       ·
+·               spans         FULL SCAN   ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT concat_agg(s) FROM (SELECT s FROM kv ORDER BY k)
 ----
-·          distributed  false          ·             ·
-·          vectorized   true           ·             ·
-group      ·            ·              (concat_agg)  ·
- │         aggregate 0  concat_agg(s)  ·             ·
- │         scalar       ·              ·             ·
- └── scan  ·            ·              (k, s)        +k
-·          table        kv@primary     ·             ·
-·          spans        FULL SCAN      ·             ·
+·          distribution  local          ·             ·
+·          vectorized    true           ·             ·
+group      ·             ·              (concat_agg)  ·
+ │         aggregate 0   concat_agg(s)  ·             ·
+ │         scalar        ·              ·             ·
+ └── scan  ·             ·              (k, s)        +k
+·          table         kv@primary     ·             ·
+·          spans         FULL SCAN      ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT array_agg(k) FROM (SELECT k FROM kv ORDER BY s)
 ----
-·               distributed  false         ·            ·
-·               vectorized   true          ·            ·
-group           ·            ·             (array_agg)  ·
- │              aggregate 0  array_agg(k)  ·            ·
- │              scalar       ·             ·            ·
- └── sort       ·            ·             (k, s)       +s
-      │         order        +s            ·            ·
-      └── scan  ·            ·             (k, s)       ·
-·               table        kv@primary    ·            ·
-·               spans        FULL SCAN     ·            ·
+·               distribution  local         ·            ·
+·               vectorized    true          ·            ·
+group           ·             ·             (array_agg)  ·
+ │              aggregate 0   array_agg(k)  ·            ·
+ │              scalar        ·             ·            ·
+ └── sort       ·             ·             (k, s)       +s
+      │         order         +s            ·            ·
+      └── scan  ·             ·             (k, s)       ·
+·               table         kv@primary    ·            ·
+·               spans         FULL SCAN     ·            ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT string_agg(s, ',') FROM (SELECT s FROM kv ORDER BY k)
 ----
-·               distributed  false                   ·                ·
-·               vectorized   true                    ·                ·
-group           ·            ·                       (string_agg)     ·
- │              aggregate 0  string_agg(s, column5)  ·                ·
- │              scalar       ·                       ·                ·
- └── render     ·            ·                       (column5, k, s)  +k
-      │         render 0     ','                     ·                ·
-      │         render 1     k                       ·                ·
-      │         render 2     s                       ·                ·
-      └── scan  ·            ·                       (k, s)           +k
-·               table        kv@primary              ·                ·
-·               spans        FULL SCAN               ·                ·
+·               distribution  local                   ·                ·
+·               vectorized    true                    ·                ·
+group           ·             ·                       (string_agg)     ·
+ │              aggregate 0   string_agg(s, column5)  ·                ·
+ │              scalar        ·                       ·                ·
+ └── render     ·             ·                       (column5, k, s)  +k
+      │         render 0      ','                     ·                ·
+      │         render 1      k                       ·                ·
+      │         render 2      s                       ·                ·
+      └── scan  ·             ·                       (k, s)           +k
+·               table         kv@primary              ·                ·
+·               spans         FULL SCAN               ·                ·
 
 # Verify that we project away all input columns for count(*).
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(*) FROM xyz JOIN kv ON y=v
 ----
-·                    distributed  false         ·        ·
-·                    vectorized   true          ·        ·
-group                ·            ·             (count)  ·
- │                   aggregate 0  count_rows()  ·        ·
- │                   scalar       ·             ·        ·
- └── render          ·            ·             ()       ·
-      └── hash-join  ·            ·             (y, v)   ·
-           │         type         inner         ·        ·
-           │         equality     (y) = (v)     ·        ·
-           ├── scan  ·            ·             (y)      ·
-           │         table        xyz@xy        ·        ·
-           │         spans        FULL SCAN     ·        ·
-           └── scan  ·            ·             (v)      ·
-·                    table        kv@primary    ·        ·
-·                    spans        FULL SCAN     ·        ·
+·                    distribution  local         ·        ·
+·                    vectorized    true          ·        ·
+group                ·             ·             (count)  ·
+ │                   aggregate 0   count_rows()  ·        ·
+ │                   scalar        ·             ·        ·
+ └── render          ·             ·             ()       ·
+      └── hash-join  ·             ·             (y, v)   ·
+           │         type          inner         ·        ·
+           │         equality      (y) = (v)     ·        ·
+           ├── scan  ·             ·             (y)      ·
+           │         table         xyz@xy        ·        ·
+           │         spans         FULL SCAN     ·        ·
+           └── scan  ·             ·             (v)      ·
+·                    table         kv@primary    ·        ·
+·                    spans         FULL SCAN     ·        ·
 
 
 # Regression test for #31882: make sure we don't incorrectly advertise an
@@ -1114,32 +1114,32 @@ CREATE TABLE uvw (u INT, v INT, w INT, INDEX uvw(u, v, w))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u, v, array_agg(w) AS s FROM (SELECT * FROM uvw ORDER BY w) GROUP BY u, v
 ----
-·          distributed  false         ·          ·
-·          vectorized   true          ·          ·
-group      ·            ·             (u, v, s)  ·
- │         aggregate 0  u             ·          ·
- │         aggregate 1  v             ·          ·
- │         aggregate 2  array_agg(w)  ·          ·
- │         group by     u, v          ·          ·
- │         ordered      +u,+v         ·          ·
- └── scan  ·            ·             (u, v, w)  +u,+v,+w
-·          table        uvw@uvw       ·          ·
-·          spans        FULL SCAN     ·          ·
+·          distribution  local         ·          ·
+·          vectorized    true          ·          ·
+group      ·             ·             (u, v, s)  ·
+ │         aggregate 0   u             ·          ·
+ │         aggregate 1   v             ·          ·
+ │         aggregate 2   array_agg(w)  ·          ·
+ │         group by      u, v          ·          ·
+ │         ordered       +u,+v         ·          ·
+ └── scan  ·             ·             (u, v, w)  +u,+v,+w
+·          table         uvw@uvw       ·          ·
+·          spans         FULL SCAN     ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT string_agg(s, ', ') FROM kv
 ----
-·               distributed  false                   ·             ·
-·               vectorized   true                    ·             ·
-group           ·            ·                       (string_agg)  ·
- │              aggregate 0  string_agg(s, column5)  ·             ·
- │              scalar       ·                       ·             ·
- └── render     ·            ·                       (column5, s)  ·
-      │         render 0     ', '                    ·             ·
-      │         render 1     s                       ·             ·
-      └── scan  ·            ·                       (s)           ·
-·               table        kv@primary              ·             ·
-·               spans        FULL SCAN               ·             ·
+·               distribution  local                   ·             ·
+·               vectorized    true                    ·             ·
+group           ·             ·                       (string_agg)  ·
+ │              aggregate 0   string_agg(s, column5)  ·             ·
+ │              scalar        ·                       ·             ·
+ └── render     ·             ·                       (column5, s)  ·
+      │         render 0      ', '                    ·             ·
+      │         render 1      s                       ·             ·
+      └── scan  ·             ·                       (s)           ·
+·               table         kv@primary              ·             ·
+·               spans         FULL SCAN               ·             ·
 
 statement ok
 CREATE TABLE string_agg_test (
@@ -1159,21 +1159,21 @@ EXPLAIN (VERBOSE)
     ORDER BY
         company_id
 ----
-·                    distributed  false                          ·                                ·
-·                    vectorized   true                           ·                                ·
-sort                 ·            ·                              (company_id, string_agg)         +company_id
- │                   order        +company_id                    ·                                ·
- └── group           ·            ·                              (company_id, string_agg)         ·
-      │              aggregate 0  company_id                     ·                                ·
-      │              aggregate 1  string_agg(employee, column4)  ·                                ·
-      │              group by     company_id                     ·                                ·
-      └── render     ·            ·                              (column4, company_id, employee)  ·
-           │         render 0     ','                            ·                                ·
-           │         render 1     company_id                     ·                                ·
-           │         render 2     employee                       ·                                ·
-           └── scan  ·            ·                              (company_id, employee)           ·
-·                    table        string_agg_test@primary        ·                                ·
-·                    spans        FULL SCAN                      ·                                ·
+·                    distribution  local                          ·                                ·
+·                    vectorized    true                           ·                                ·
+sort                 ·             ·                              (company_id, string_agg)         +company_id
+ │                   order         +company_id                    ·                                ·
+ └── group           ·             ·                              (company_id, string_agg)         ·
+      │              aggregate 0   company_id                     ·                                ·
+      │              aggregate 1   string_agg(employee, column4)  ·                                ·
+      │              group by      company_id                     ·                                ·
+      └── render     ·             ·                              (column4, company_id, employee)  ·
+           │         render 0      ','                            ·                                ·
+           │         render 1      company_id                     ·                                ·
+           │         render 2      employee                       ·                                ·
+           └── scan  ·             ·                              (company_id, employee)           ·
+·                    table         string_agg_test@primary        ·                                ·
+·                    spans         FULL SCAN                      ·                                ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
@@ -1186,21 +1186,21 @@ EXPLAIN (VERBOSE)
     ORDER BY
         company_id
 ----
-·                    distributed  false                         ·                               ·
-·                    vectorized   true                          ·                               ·
-sort                 ·            ·                             (company_id, string_agg)        +company_id
- │                   order        +company_id                   ·                               ·
- └── group           ·            ·                             (company_id, string_agg)        ·
-      │              aggregate 0  company_id                    ·                               ·
-      │              aggregate 1  string_agg(column4, column5)  ·                               ·
-      │              group by     company_id                    ·                               ·
-      └── render     ·            ·                             (column4, column5, company_id)  ·
-           │         render 0     employee::BYTES               ·                               ·
-           │         render 1     '\x2c'                        ·                               ·
-           │         render 2     company_id                    ·                               ·
-           └── scan  ·            ·                             (company_id, employee)          ·
-·                    table        string_agg_test@primary       ·                               ·
-·                    spans        FULL SCAN                     ·                               ·
+·                    distribution  local                         ·                               ·
+·                    vectorized    true                          ·                               ·
+sort                 ·             ·                             (company_id, string_agg)        +company_id
+ │                   order         +company_id                   ·                               ·
+ └── group           ·             ·                             (company_id, string_agg)        ·
+      │              aggregate 0   company_id                    ·                               ·
+      │              aggregate 1   string_agg(column4, column5)  ·                               ·
+      │              group by      company_id                    ·                               ·
+      └── render     ·             ·                             (column4, column5, company_id)  ·
+           │         render 0      employee::BYTES               ·                               ·
+           │         render 1      '\x2c'                        ·                               ·
+           │         render 2      company_id                    ·                               ·
+           └── scan  ·             ·                             (company_id, employee)          ·
+·                    table         string_agg_test@primary       ·                               ·
+·                    spans         FULL SCAN                     ·                               ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
@@ -1213,21 +1213,21 @@ EXPLAIN (VERBOSE)
     ORDER BY
         company_id
 ----
-·                    distributed  false                          ·                                ·
-·                    vectorized   true                           ·                                ·
-sort                 ·            ·                              (company_id, string_agg)         +company_id
- │                   order        +company_id                    ·                                ·
- └── group           ·            ·                              (company_id, string_agg)         ·
-      │              aggregate 0  company_id                     ·                                ·
-      │              aggregate 1  string_agg(employee, column4)  ·                                ·
-      │              group by     company_id                     ·                                ·
-      └── render     ·            ·                              (column4, company_id, employee)  ·
-           │         render 0     NULL                           ·                                ·
-           │         render 1     company_id                     ·                                ·
-           │         render 2     employee                       ·                                ·
-           └── scan  ·            ·                              (company_id, employee)           ·
-·                    table        string_agg_test@primary        ·                                ·
-·                    spans        FULL SCAN                      ·                                ·
+·                    distribution  local                          ·                                ·
+·                    vectorized    true                           ·                                ·
+sort                 ·             ·                              (company_id, string_agg)         +company_id
+ │                   order         +company_id                    ·                                ·
+ └── group           ·             ·                              (company_id, string_agg)         ·
+      │              aggregate 0   company_id                     ·                                ·
+      │              aggregate 1   string_agg(employee, column4)  ·                                ·
+      │              group by      company_id                     ·                                ·
+      └── render     ·             ·                              (column4, company_id, employee)  ·
+           │         render 0      NULL                           ·                                ·
+           │         render 1      company_id                     ·                                ·
+           │         render 2      employee                       ·                                ·
+           └── scan  ·             ·                              (company_id, employee)           ·
+·                    table         string_agg_test@primary        ·                                ·
+·                    spans         FULL SCAN                      ·                                ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
@@ -1240,18 +1240,18 @@ EXPLAIN (VERBOSE)
     ORDER BY
         company_id
 ----
-·                    distributed  false                         ·                               ·
-·                    vectorized   true                          ·                               ·
-sort                 ·            ·                             (company_id, string_agg)        +company_id
- │                   order        +company_id                   ·                               ·
- └── group           ·            ·                             (company_id, string_agg)        ·
-      │              aggregate 0  company_id                    ·                               ·
-      │              aggregate 1  string_agg(column4, column5)  ·                               ·
-      │              group by     company_id                    ·                               ·
-      └── render     ·            ·                             (column4, column5, company_id)  ·
-           │         render 0     employee::BYTES               ·                               ·
-           │         render 1     NULL                          ·                               ·
-           │         render 2     company_id                    ·                               ·
-           └── scan  ·            ·                             (company_id, employee)          ·
-·                    table        string_agg_test@primary       ·                               ·
-·                    spans        FULL SCAN                     ·                               ·
+·                    distribution  local                         ·                               ·
+·                    vectorized    true                          ·                               ·
+sort                 ·             ·                             (company_id, string_agg)        +company_id
+ │                   order         +company_id                   ·                               ·
+ └── group           ·             ·                             (company_id, string_agg)        ·
+      │              aggregate 0   company_id                    ·                               ·
+      │              aggregate 1   string_agg(column4, column5)  ·                               ·
+      │              group by      company_id                    ·                               ·
+      └── render     ·             ·                             (column4, column5, company_id)  ·
+           │         render 0      employee::BYTES               ·                               ·
+           │         render 1      NULL                          ·                               ·
+           │         render 2      company_id                    ·                               ·
+           └── scan  ·             ·                             (company_id, employee)          ·
+·                    table         string_agg_test@primary       ·                               ·
+·                    spans         FULL SCAN                     ·                               ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/array
+++ b/pkg/sql/opt/exec/execbuilder/testdata/array
@@ -8,47 +8,47 @@ CREATE TABLE t (x INT[] PRIMARY KEY)
 query TTT
 EXPLAIN SELECT x FROM t WHERE x = ARRAY[1,4,6]
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        t@primary
-·     spans        /ARRAY[1,4,6]-/ARRAY[1,4,6]/#
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         t@primary
+·     spans         /ARRAY[1,4,6]-/ARRAY[1,4,6]/#
 
 query TTT
 EXPLAIN SELECT x FROM t WHERE x < ARRAY[1, 4, 3]
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        t@primary
-·     spans        -/ARRAY[1,4,3]
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         t@primary
+·     spans         -/ARRAY[1,4,3]
 
 query TTT
 EXPLAIN SELECT x FROM t WHERE x > ARRAY [1, NULL]
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        t@primary
-·     spans        /ARRAY[1,NULL,NULL]-
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         t@primary
+·     spans         /ARRAY[1,NULL,NULL]-
 
 query TTT
 EXPLAIN SELECT x FROM t WHERE x > ARRAY[1, 3] AND x < ARRAY[1, 4, 10] ORDER BY x
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        t@primary
-·     spans        /ARRAY[1,3,NULL]-/ARRAY[1,4,10]
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         t@primary
+·     spans         /ARRAY[1,3,NULL]-/ARRAY[1,4,10]
 
 query TTT
 EXPLAIN SELECT x FROM t WHERE x > ARRAY[1, 3] AND x < ARRAY[1, 4, 10] ORDER BY x DESC
 ----
-·        distributed  false
-·        vectorized   true
-revscan  ·            ·
-·        table        t@primary
-·        spans        /ARRAY[1,3,NULL]-/ARRAY[1,4,10]
+·        distribution  local
+·        vectorized    true
+revscan  ·             ·
+·        table         t@primary
+·        spans         /ARRAY[1,3,NULL]-/ARRAY[1,4,10]
 
 statement ok
 DROP TABLE t
@@ -59,11 +59,11 @@ CREATE TABLE t (x INT, y INT[], z INT, INDEX i (x, y, z))
 query TTT
 EXPLAIN SELECT x, y, z FROM t WHERE x = 2 AND y < ARRAY[10] ORDER BY y
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        t@i
-·     spans        /2/!NULL-/2/ARRAY[10]
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         t@i
+·     spans         /2/!NULL-/2/ARRAY[10]
 
 # Test span generation on interleaved tables.
 statement ok
@@ -73,29 +73,29 @@ CREATE TABLE child (x INT, y INT[], z INT[], PRIMARY KEY (x, y, z), FAMILY (x, y
 query TTT
 EXPLAIN SELECT x, y FROM parent WHERE x > 1 AND y > ARRAY[1, NULL]
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        parent@primary
-·     spans        /2/ARRAY[1,NULL,NULL]-
-·     filter       y > ARRAY[1,NULL]
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         parent@primary
+·     spans         /2/ARRAY[1,NULL,NULL]-
+·     filter        y > ARRAY[1,NULL]
 
 query TTT
 EXPLAIN SELECT y FROM parent WHERE x = 1 AND y = ARRAY[NULL, NULL]
 ----
-·          distributed  false
-·          vectorized   true
-render     ·            ·
- └── scan  ·            ·
-·          table        parent@primary
-·          spans        /1/ARRAY[NULL,NULL]-/1/ARRAY[NULL,NULL]/#
+·          distribution  local
+·          vectorized    true
+render     ·             ·
+ └── scan  ·             ·
+·          table         parent@primary
+·          spans         /1/ARRAY[NULL,NULL]-/1/ARRAY[NULL,NULL]/#
 
 query TTT
 EXPLAIN SELECT z FROM child WHERE x = 1 AND y = ARRAY[NULL, NULL]
 ----
-·          distributed  false
-·          vectorized   true
-render     ·            ·
- └── scan  ·            ·
-·          table        child@primary
-·          spans        /1/ARRAY[NULL,NULL]/#/56/1-/1/ARRAY[NULL,NULL]/#/56/2
+·          distribution  local
+·          vectorized    true
+render     ·             ·
+ └── scan  ·             ·
+·          table         child@primary
+·          spans         /1/ARRAY[NULL,NULL]/#/56/1-/1/ARRAY[NULL,NULL]/#/56/2

--- a/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
+++ b/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
@@ -21,34 +21,34 @@ CREATE TABLE t9 (
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE t9 SET b = b + 1 WHERE a = 5
 ----
-·                         distributed  false                      ·                              ·
-·                         vectorized   false                      ·                              ·
-count                     ·            ·                          ()                             ·
- └── update               ·            ·                          ()                             ·
-      │                   table        t9                         ·                              ·
-      │                   set          b                          ·                              ·
-      │                   strategy     updater                    ·                              ·
-      │                   auto commit  ·                          ·                              ·
-      └── render          ·            ·                          (a, b, b_new, check1, check2)  ·
-           │              render 0     a                          ·                              ·
-           │              render 1     b                          ·                              ·
-           │              render 2     b_new                      ·                              ·
-           │              render 3     a > b_new                  ·                              ·
-           │              render 4     d IS NULL                  ·                              ·
-           └── render     ·            ·                          (b_new, a, b, d)               ·
-                │         render 0     b + 1                      ·                              ·
-                │         render 1     a                          ·                              ·
-                │         render 2     b                          ·                              ·
-                │         render 3     d                          ·                              ·
-                └── scan  ·            ·                          (a, b, d)                      ·
-·                         table        t9@primary                 ·                              ·
-·                         spans        /5/0-/5/1/2 /5/3/1-/5/3/2  ·                              ·
-·                         parallel     ·                          ·                              ·
+·                         distribution  local                      ·                              ·
+·                         vectorized    false                      ·                              ·
+count                     ·             ·                          ()                             ·
+ └── update               ·             ·                          ()                             ·
+      │                   table         t9                         ·                              ·
+      │                   set           b                          ·                              ·
+      │                   strategy      updater                    ·                              ·
+      │                   auto commit   ·                          ·                              ·
+      └── render          ·             ·                          (a, b, b_new, check1, check2)  ·
+           │              render 0      a                          ·                              ·
+           │              render 1      b                          ·                              ·
+           │              render 2      b_new                      ·                              ·
+           │              render 3      a > b_new                  ·                              ·
+           │              render 4      d IS NULL                  ·                              ·
+           └── render     ·             ·                          (b_new, a, b, d)               ·
+                │         render 0      b + 1                      ·                              ·
+                │         render 1      a                          ·                              ·
+                │         render 2      b                          ·                              ·
+                │         render 3      d                          ·                              ·
+                └── scan  ·             ·                          (a, b, d)                      ·
+·                         table         t9@primary                 ·                              ·
+·                         spans         /5/0-/5/1/2 /5/3/1-/5/3/2  ·                              ·
+·                         parallel      ·                          ·                              ·
 
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE t9 SET a = 2 WHERE a = 5
 ----
-·                    distributed       false       ·                                       ·
+·                    distribution      local       ·                                       ·
 ·                    vectorized        false       ·                                       ·
 count                ·                 ·           ()                                      ·
  └── update          ·                 ·           ()                                      ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/ddl
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ddl
@@ -95,14 +95,14 @@ CREATE TABLE s (k1 INT, k2 INT, v INT, PRIMARY KEY (k1,k2))
 query TTTTT colnames
 EXPLAIN (VERBOSE) ALTER TABLE s SPLIT AT SELECT k1,k2 FROM s ORDER BY k1 LIMIT 3
 ----
-tree       field        description   columns                              ordering
-·          distributed  false         ·                                    ·
-·          vectorized   false         ·                                    ·
-split      ·            ·             (key, pretty, split_enforced_until)  ·
- └── scan  ·            ·             (k1, k2)                             +k1
-·          table        s@primary     ·                                    ·
-·          spans        LIMITED SCAN  ·                                    ·
-·          limit        3             ·                                    ·
+tree       field         description   columns                              ordering
+·          distribution  local         ·                                    ·
+·          vectorized    false         ·                                    ·
+split      ·             ·             (key, pretty, split_enforced_until)  ·
+ └── scan  ·             ·             (k1, k2)                             +k1
+·          table         s@primary     ·                                    ·
+·          spans         LIMITED SCAN  ·                                    ·
+·          limit         3             ·                                    ·
 
 statement ok
 DROP TABLE t; DROP TABLE other

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -60,59 +60,59 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
 query TTT colnames
 EXPLAIN DELETE FROM unindexed
 ----
-tree          field        description
-·             distributed  false
-·             vectorized   false
-delete range  ·            ·
-·             from         unindexed
-·             spans        FULL SCAN
+tree          field         description
+·             distribution  local
+·             vectorized    false
+delete range  ·             ·
+·             from          unindexed
+·             spans         FULL SCAN
 
 query TTT
 EXPLAIN DELETE FROM unindexed WHERE v = 7 ORDER BY v LIMIT 10
 ----
-·                         distributed  false
-·                         vectorized   false
-count                     ·            ·
- └── delete               ·            ·
-      │                   from         unindexed
-      │                   strategy     deleter
-      │                   auto commit  ·
-      └── render          ·            ·
-           └── limit      ·            ·
-                │         count        10
-                └── scan  ·            ·
-·                         table        unindexed@primary
-·                         spans        FULL SCAN
-·                         filter       v = 7
+·                         distribution  local
+·                         vectorized    false
+count                     ·             ·
+ └── delete               ·             ·
+      │                   from          unindexed
+      │                   strategy      deleter
+      │                   auto commit   ·
+      └── render          ·             ·
+           └── limit      ·             ·
+                │         count         10
+                └── scan  ·             ·
+·                         table         unindexed@primary
+·                         spans         FULL SCAN
+·                         filter        v = 7
 
 # Check DELETE with LIMIT clause (MySQL extension)
 query TTT
 EXPLAIN DELETE FROM unindexed WHERE v = 5 LIMIT 10
 ----
-·                         distributed  false
-·                         vectorized   false
-count                     ·            ·
- └── delete               ·            ·
-      │                   from         unindexed
-      │                   strategy     deleter
-      │                   auto commit  ·
-      └── render          ·            ·
-           └── limit      ·            ·
-                │         count        10
-                └── scan  ·            ·
-·                         table        unindexed@primary
-·                         spans        FULL SCAN
-·                         filter       v = 5
+·                         distribution  local
+·                         vectorized    false
+count                     ·             ·
+ └── delete               ·             ·
+      │                   from          unindexed
+      │                   strategy      deleter
+      │                   auto commit   ·
+      └── render          ·             ·
+           └── limit      ·             ·
+                │         count         10
+                └── scan  ·             ·
+·                         table         unindexed@primary
+·                         spans         FULL SCAN
+·                         filter        v = 5
 
 # Check fast DELETE.
 query TTT
 EXPLAIN DELETE FROM unindexed WHERE k > 0
 ----
-·             distributed  false
-·             vectorized   false
-delete range  ·            ·
-·             from         unindexed
-·             spans        /1-
+·             distribution  local
+·             vectorized    false
+delete range  ·             ·
+·             from          unindexed
+·             spans         /1-
 
 # Check fast DELETE with reverse scans (not supported by optimizer).
 query error DELETE statement requires LIMIT when ORDER BY is used
@@ -122,63 +122,63 @@ EXPLAIN DELETE FROM unindexed WHERE true ORDER BY k DESC
 query TTT
 EXPLAIN DELETE FROM unindexed WHERE k > 0 LIMIT 1
 ----
-·               distributed  false
-·               vectorized   false
-count           ·            ·
- └── delete     ·            ·
-      │         from         unindexed
-      │         strategy     deleter
-      │         auto commit  ·
-      └── scan  ·            ·
-·               table        unindexed@primary
-·               spans        /1-
-·               limit        1
+·               distribution  local
+·               vectorized    false
+count           ·             ·
+ └── delete     ·             ·
+      │         from          unindexed
+      │         strategy      deleter
+      │         auto commit   ·
+      └── scan  ·             ·
+·               table         unindexed@primary
+·               spans         /1-
+·               limit         1
 
 query TTT
 EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10
 ----
-·               distributed  false
-·               vectorized   false
-count           ·            ·
- └── delete     ·            ·
-      │         from         indexed
-      │         strategy     deleter
-      │         auto commit  ·
-      └── scan  ·            ·
-·               table        indexed@indexed_value_idx
-·               spans        /5-/6
-·               limit        10
+·               distribution  local
+·               vectorized    false
+count           ·             ·
+ └── delete     ·             ·
+      │         from          indexed
+      │         strategy      deleter
+      │         auto commit   ·
+      └── scan  ·             ·
+·               table         indexed@indexed_value_idx
+·               spans         /5-/6
+·               limit         10
 
 query TTT
 EXPLAIN DELETE FROM indexed LIMIT 10
 ----
-·               distributed  false
-·               vectorized   false
-count           ·            ·
- └── delete     ·            ·
-      │         from         indexed
-      │         strategy     deleter
-      │         auto commit  ·
-      └── scan  ·            ·
-·               table        indexed@indexed_value_idx
-·               spans        LIMITED SCAN
-·               limit        10
+·               distribution  local
+·               vectorized    false
+count           ·             ·
+ └── delete     ·             ·
+      │         from          indexed
+      │         strategy      deleter
+      │         auto commit   ·
+      └── scan  ·             ·
+·               table         indexed@indexed_value_idx
+·               spans         LIMITED SCAN
+·               limit         10
 
 # TODO(andyk): Prune columns so that index-join is not necessary.
 query TTT
 EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10 RETURNING id
 ----
-·               distributed  false
-·               vectorized   false
-run             ·            ·
- └── delete     ·            ·
-      │         from         indexed
-      │         strategy     deleter
-      │         auto commit  ·
-      └── scan  ·            ·
-·               table        indexed@indexed_value_idx
-·               spans        /5-/6
-·               limit        10
+·               distribution  local
+·               vectorized    false
+run             ·             ·
+ └── delete     ·             ·
+      │         from          indexed
+      │         strategy      deleter
+      │         auto commit   ·
+      └── scan  ·             ·
+·               table         indexed@indexed_value_idx
+·               spans         /5-/6
+·               limit         10
 
 # Ensure that index hints in DELETE statements force the choice of a specific index
 # as described in #38799.
@@ -188,16 +188,16 @@ CREATE TABLE t38799 (a INT PRIMARY KEY, b INT, c INT, INDEX foo(b))
 query TTTTT
 EXPLAIN (VERBOSE) DELETE FROM t38799@foo
 ----
-·               distributed  false       ·       ·
-·               vectorized   false       ·       ·
-count           ·            ·           ()      ·
- └── delete     ·            ·           ()      ·
-      │         from         t38799      ·       ·
-      │         strategy     deleter     ·       ·
-      │         auto commit  ·           ·       ·
-      └── scan  ·            ·           (a, b)  ·
-·               table        t38799@foo  ·       ·
-·               spans        FULL SCAN   ·       ·
+·               distribution  local       ·       ·
+·               vectorized    false       ·       ·
+count           ·             ·           ()      ·
+ └── delete     ·             ·           ()      ·
+      │         from          t38799      ·       ·
+      │         strategy      deleter     ·       ·
+      │         auto commit   ·           ·       ·
+      └── scan  ·             ·           (a, b)  ·
+·               table         t38799@foo  ·       ·
+·               spans         FULL SCAN   ·       ·
 
 # Tracing tests for fast delete.
 statement ok
@@ -245,11 +245,11 @@ CREATE TABLE parent (id INT PRIMARY KEY)
 query TTT
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·             distributed  false
-·             vectorized   false
-delete range  ·            ·
-·             from         parent
-·             spans        /11-
+·             distribution  local
+·             vectorized    false
+delete range  ·             ·
+·             from          parent
+·             spans         /11-
 
 statement ok
 CREATE TABLE child (
@@ -263,27 +263,27 @@ CREATE TABLE child (
 query TTT
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·             distributed  false
-·             vectorized   false
-delete range  ·            ·
-·             from         parent
-·             spans        /11-
+·             distribution  local
+·             vectorized    false
+delete range  ·             ·
+·             from          parent
+·             spans         /11-
 
 # Delete range should not be used when deleting from the child.
 query TTT
 EXPLAIN DELETE FROM child WHERE id > 10
 ----
-·               distributed  false
-·               vectorized   false
-count           ·            ·
- └── delete     ·            ·
-      │         from         child
-      │         strategy     deleter
-      │         auto commit  ·
-      └── scan  ·            ·
-·               table        child@primary
-·               spans        FULL SCAN
-·               filter       id > 10
+·               distribution  local
+·               vectorized    false
+count           ·             ·
+ └── delete     ·             ·
+      │         from          child
+      │         strategy      deleter
+      │         auto commit   ·
+      └── scan  ·             ·
+·               table         child@primary
+·               spans         FULL SCAN
+·               filter        id > 10
 
 statement ok
 CREATE TABLE sibling (
@@ -297,11 +297,11 @@ CREATE TABLE sibling (
 query TTT
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·             distributed  false
-·             vectorized   false
-delete range  ·            ·
-·             from         parent
-·             spans        /11-
+·             distribution  local
+·             vectorized    false
+delete range  ·             ·
+·             from          parent
+·             spans         /11-
 
 statement ok
 CREATE TABLE grandchild (
@@ -316,11 +316,11 @@ CREATE TABLE grandchild (
 query TTT
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·             distributed  false
-·             vectorized   false
-delete range  ·            ·
-·             from         parent
-·             spans        /11-
+·             distribution  local
+·             vectorized    false
+delete range  ·             ·
+·             from          parent
+·             spans         /11-
 
 statement ok
 CREATE TABLE external_ref (
@@ -334,24 +334,24 @@ CREATE TABLE external_ref (
 query TTT
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·                           distributed  false
-·                           vectorized   false
-root                        ·            ·
- ├── count                  ·            ·
- │    └── delete            ·            ·
- │         │                from         parent
- │         │                strategy     deleter
- │         └── buffer node  ·            ·
- │              │           label        buffer 1
- │              └── scan    ·            ·
- │                          table        parent@primary
- │                          spans        /11-
- ├── fk-cascade             ·            ·
- │                          fk           fk_pid_ref_parent
- │                          input        buffer 1
- └── fk-cascade             ·            ·
-·                           fk           fk_pid_ref_parent
-·                           input        buffer 1
+·                           distribution  local
+·                           vectorized    false
+root                        ·             ·
+ ├── count                  ·             ·
+ │    └── delete            ·             ·
+ │         │                from          parent
+ │         │                strategy      deleter
+ │         └── buffer node  ·             ·
+ │              │           label         buffer 1
+ │              └── scan    ·             ·
+ │                          table         parent@primary
+ │                          spans         /11-
+ ├── fk-cascade             ·             ·
+ │                          fk            fk_pid_ref_parent
+ │                          input         buffer 1
+ └── fk-cascade             ·             ·
+·                           fk            fk_pid_ref_parent
+·                           input         buffer 1
 
 statement ok
 DROP TABLE external_ref
@@ -370,7 +370,7 @@ CREATE TABLE child_with_index (
 query TTT
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·                                          distributed         false
+·                                          distribution        local
 ·                                          vectorized          false
 root                                       ·                   ·
  ├── count                                 ·                   ·
@@ -420,7 +420,7 @@ CREATE TABLE child_without_cascade (
 query TTT
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·                                          distributed         false
+·                                          distribution        local
 ·                                          vectorized          false
 root                                       ·                   ·
  ├── count                                 ·                   ·
@@ -469,24 +469,24 @@ CREATE TABLE child_without_fk (
 query TTT
 EXPLAIN DELETE FROM parent WHERE id > 10
 ----
-·                           distributed  false
-·                           vectorized   false
-root                        ·            ·
- ├── count                  ·            ·
- │    └── delete            ·            ·
- │         │                from         parent
- │         │                strategy     deleter
- │         └── buffer node  ·            ·
- │              │           label        buffer 1
- │              └── scan    ·            ·
- │                          table        parent@primary
- │                          spans        /11-
- ├── fk-cascade             ·            ·
- │                          fk           fk_pid_ref_parent
- │                          input        buffer 1
- └── fk-cascade             ·            ·
-·                           fk           fk_pid_ref_parent
-·                           input        buffer 1
+·                           distribution  local
+·                           vectorized    false
+root                        ·             ·
+ ├── count                  ·             ·
+ │    └── delete            ·             ·
+ │         │                from          parent
+ │         │                strategy      deleter
+ │         └── buffer node  ·             ·
+ │              │           label         buffer 1
+ │              └── scan    ·             ·
+ │                          table         parent@primary
+ │                          spans         /11-
+ ├── fk-cascade             ·             ·
+ │                          fk            fk_pid_ref_parent
+ │                          input         buffer 1
+ └── fk-cascade             ·             ·
+·                           fk            fk_pid_ref_parent
+·                           input         buffer 1
 
 statement ok
 DROP TABLE child_without_fk
@@ -508,18 +508,18 @@ CREATE TABLE abc (
 query TTT
 EXPLAIN DELETE FROM ab WHERE a = 1
 ----
-·                           distributed  false
-·                           vectorized   false
-root                        ·            ·
- ├── count                  ·            ·
- │    └── delete            ·            ·
- │         │                from         ab
- │         │                strategy     deleter
- │         └── buffer node  ·            ·
- │              │           label        buffer 1
- │              └── scan    ·            ·
- │                          table        ab@primary
- │                          spans        /1-/2
- └── fk-cascade             ·            ·
-·                           fk           fk_b_ref_ab
-·                           input        buffer 1
+·                           distribution  local
+·                           vectorized    false
+root                        ·             ·
+ ├── count                  ·             ·
+ │    └── delete            ·             ·
+ │         │                from          ab
+ │         │                strategy      deleter
+ │         └── buffer node  ·             ·
+ │              │           label         buffer 1
+ │              └── scan    ·             ·
+ │                          table         ab@primary
+ │                          spans         /1-/2
+ └── fk-cascade             ·             ·
+·                           fk            fk_b_ref_ab
+·                           input         buffer 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_union
@@ -9,41 +9,41 @@ CREATE TABLE uniontest (
 query TTT
 EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 ----
-·          distributed  true
-·          vectorized   true
-union      ·            ·
- ├── scan  ·            ·
- │         table        uniontest@primary
- │         spans        FULL SCAN
- └── scan  ·            ·
-·          table        uniontest@primary
-·          spans        FULL SCAN
+·          distribution  full
+·          vectorized    true
+union      ·             ·
+ ├── scan  ·             ·
+ │         table         uniontest@primary
+ │         spans         FULL SCAN
+ └── scan  ·             ·
+·          table         uniontest@primary
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
 ----
-·          distributed  true
-·          vectorized   true
-append     ·            ·
- ├── scan  ·            ·
- │         table        uniontest@primary
- │         spans        FULL SCAN
- └── scan  ·            ·
-·          table        uniontest@primary
-·          spans        FULL SCAN
+·          distribution  full
+·          vectorized    true
+append     ·             ·
+ ├── scan  ·             ·
+ │         table         uniontest@primary
+ │         spans         FULL SCAN
+ └── scan  ·             ·
+·          table         uniontest@primary
+·          spans         FULL SCAN
 
 # Check that EXPLAIN properly releases memory for virtual tables.
 query TTT
 EXPLAIN SELECT node_id FROM crdb_internal.node_build_info UNION VALUES(123)
 ----
-·                        distributed  false
-·                        vectorized   false
-union                    ·            ·
- ├── values              ·            ·
- │                       size         1 column, 1 row
- └── render              ·            ·
-      └── virtual table  ·            ·
-·                        source       node_build_info@primary
+·                        distribution  local
+·                        vectorized    false
+union                    ·             ·
+ ├── values              ·             ·
+ │                       size          1 column, 1 row
+ └── render              ·             ·
+      └── virtual table  ·             ·
+·                        source        node_build_info@primary
 
 statement ok
 CREATE TABLE abc (a INT, b INT, c INT)
@@ -51,27 +51,27 @@ CREATE TABLE abc (a INT, b INT, c INT)
 query TTTTT
 EXPLAIN (VERBOSE) (SELECT a FROM abc ORDER BY b) INTERSECT (SELECT a FROM abc ORDER BY c) ORDER BY a
 ----
-·                    distributed  true         ·       ·
-·                    vectorized   true         ·       ·
-sort                 ·            ·            (a)     +a
- │                   order        +a           ·       ·
- └── union           ·            ·            (a)     ·
-      ├── render     ·            ·            (a)     ·
-      │    │         render 0     a            ·       ·
-      │    └── scan  ·            ·            (a, c)  ·
-      │              table        abc@primary  ·       ·
-      │              spans        FULL SCAN    ·       ·
-      └── render     ·            ·            (a)     ·
-           │         render 0     a            ·       ·
-           └── scan  ·            ·            (a, b)  ·
-·                    table        abc@primary  ·       ·
-·                    spans        FULL SCAN    ·       ·
+·                    distribution  full         ·       ·
+·                    vectorized    true         ·       ·
+sort                 ·             ·            (a)     +a
+ │                   order         +a           ·       ·
+ └── union           ·             ·            (a)     ·
+      ├── render     ·             ·            (a)     ·
+      │    │         render 0      a            ·       ·
+      │    └── scan  ·             ·            (a, c)  ·
+      │              table         abc@primary  ·       ·
+      │              spans         FULL SCAN    ·       ·
+      └── render     ·             ·            (a)     ·
+           │         render 0      a            ·       ·
+           └── scan  ·             ·            (a, b)  ·
+·                    table         abc@primary  ·       ·
+·                    spans         FULL SCAN    ·       ·
 
 # Regression test for #32723.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM ((SELECT '' AS a , '') EXCEPT ALL (SELECT '', ''))
 ----
-·                      distributed    true             ·                         ·
+·                      distribution   full             ·                         ·
 ·                      vectorized     true             ·                         ·
 render                 ·              ·                (a)                       ·
  │                     render 0       a                ·                         ·
@@ -93,7 +93,7 @@ query TTTTT
 EXPLAIN (VERBOSE) ((SELECT '', '', 'x' WHERE false))
 UNION ALL ((SELECT '', '', 'x') EXCEPT (VALUES ('', '', 'x')))
 ----
-·                      distributed    true              ·                                     ·
+·                      distribution   full              ·                                     ·
 ·                      vectorized     true              ·                                     ·
 render                 ·              ·                 ("?column?", "?column?", "?column?")  ·
  │                     render 0       "?column?"        ·                                     ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct
@@ -11,128 +11,128 @@ CREATE TABLE xyz (
 query TTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz
 ----
-·          distributed  false
-·          vectorized   true
-distinct   ·            ·
- │         distinct on  y, z
- │         order key    y, z
- └── scan  ·            ·
-·          table        xyz@foo
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+distinct   ·             ·
+ │         distinct on   y, z
+ │         order key     y, z
+ └── scan  ·             ·
+·          table         xyz@foo
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY z
 ----
-·          distributed  false
-·          vectorized   true
-distinct   ·            ·
- │         distinct on  y, z
- │         order key    y, z
- └── scan  ·            ·
-·          table        xyz@foo
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+distinct   ·             ·
+ │         distinct on   y, z
+ │         order key     y, z
+ └── scan  ·             ·
+·          table         xyz@foo
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y
 ----
-·               distributed  false
-·               vectorized   true
-sort            ·            ·
- │              order        +y
- └── distinct   ·            ·
-      │         distinct on  y, z
-      │         order key    y, z
-      └── scan  ·            ·
-·               table        xyz@foo
-·               spans        FULL SCAN
+·               distribution  local
+·               vectorized    true
+sort            ·             ·
+ │              order         +y
+ └── distinct   ·             ·
+      │         distinct on   y, z
+      │         order key     y, z
+      └── scan  ·             ·
+·               table         xyz@foo
+·               spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y, z
 ----
-·               distributed  false
-·               vectorized   true
-sort            ·            ·
- │              order        +y,+z
- └── distinct   ·            ·
-      │         distinct on  y, z
-      │         order key    y, z
-      └── scan  ·            ·
-·               table        xyz@foo
-·               spans        FULL SCAN
+·               distribution  local
+·               vectorized    true
+sort            ·             ·
+ │              order         +y,+z
+ └── distinct   ·             ·
+      │         distinct on   y, z
+      │         order key     y, z
+      └── scan  ·             ·
+·               table         xyz@foo
+·               spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT DISTINCT y + z AS r FROM xyz ORDER BY y + z
 ----
-·                    distributed  false
-·                    vectorized   true
-distinct             ·            ·
- │                   distinct on  r
- │                   order key    r
- └── sort            ·            ·
-      │              order        +r
-      └── render     ·            ·
-           └── scan  ·            ·
-·                    table        xyz@primary
-·                    spans        FULL SCAN
+·                    distribution  local
+·                    vectorized    true
+distinct             ·             ·
+ │                   distinct on   r
+ │                   order key     r
+ └── sort            ·             ·
+      │              order         +r
+      └── render     ·             ·
+           └── scan  ·             ·
+·                    table         xyz@primary
+·                    spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT DISTINCT y AS w, z FROM xyz ORDER BY z
 ----
-·          distributed  false
-·          vectorized   true
-distinct   ·            ·
- │         distinct on  w, z
- │         order key    w, z
- └── scan  ·            ·
-·          table        xyz@foo
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+distinct   ·             ·
+ │         distinct on   w, z
+ │         order key     w, z
+ └── scan  ·             ·
+·          table         xyz@foo
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY y
 ----
-·               distributed  false
-·               vectorized   true
-sort            ·            ·
- │              order        +w
- └── distinct   ·            ·
-      │         distinct on  w
-      └── scan  ·            ·
-·               table        xyz@primary
-·               spans        FULL SCAN
+·               distribution  local
+·               vectorized    true
+sort            ·             ·
+ │              order         +w
+ └── distinct   ·             ·
+      │         distinct on   w
+      └── scan  ·             ·
+·               table         xyz@primary
+·               spans         FULL SCAN
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT x FROM xyz
 ----
-·     distributed  false        ·    ·
-·     vectorized   true         ·    ·
-scan  ·            ·            (x)  ·
-·     table        xyz@primary  ·    ·
-·     spans        FULL SCAN    ·    ·
+·     distribution  local        ·    ·
+·     vectorized    true         ·    ·
+scan  ·             ·            (x)  ·
+·     table         xyz@primary  ·    ·
+·     spans         FULL SCAN    ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT x, y, z FROM xyz
 ----
-·     distributed  false        ·          ·
-·     vectorized   true         ·          ·
-scan  ·            ·            (x, y, z)  ·
-·     table        xyz@primary  ·          ·
-·     spans        FULL SCAN    ·          ·
+·     distribution  local        ·          ·
+·     vectorized    true         ·          ·
+scan  ·             ·            (x, y, z)  ·
+·     table         xyz@primary  ·          ·
+·     spans         FULL SCAN    ·          ·
 
 # Test the case when the DistinctOn operator is projecting away a column.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT z FROM (SELECT y, z FROM xyz WHERE y > 1)
 ----
-·               distributed  false      ·       ·
-·               vectorized   true       ·       ·
-distinct        ·            ·          (z)     ·
- │              distinct on  z          ·       ·
- │              order key    z          ·       ·
- └── render     ·            ·          (z)     +z
-      │         render 0     z          ·       ·
-      └── scan  ·            ·          (y, z)  +z
-·               table        xyz@foo    ·       ·
-·               spans        FULL SCAN  ·       ·
-·               filter       y > 1      ·       ·
+·               distribution  local      ·       ·
+·               vectorized    true       ·       ·
+distinct        ·             ·          (z)     ·
+ │              distinct on   z          ·       ·
+ │              order key     z          ·       ·
+ └── render     ·             ·          (z)     +z
+      │         render 0      z          ·       ·
+      └── scan  ·             ·          (y, z)  +z
+·               table         xyz@foo    ·       ·
+·               spans         FULL SCAN  ·       ·
+·               filter        y > 1      ·       ·
 
 statement ok
 CREATE TABLE abcd (
@@ -147,45 +147,45 @@ CREATE TABLE abcd (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT 1 AS z, d, b FROM abcd ORDER BY d, b
 ----
-·          distributed  false              ·          ·
-·          vectorized   true               ·          ·
-render     ·            ·                  (z, d, b)  ·
- │         render 0     1                  ·          ·
- │         render 1     d                  ·          ·
- │         render 2     b                  ·          ·
- └── scan  ·            ·                  (b, d)     +d,+b
-·          table        abcd@abcd_d_b_key  ·          ·
-·          spans        FULL SCAN          ·          ·
+·          distribution  local              ·          ·
+·          vectorized    true               ·          ·
+render     ·             ·                  (z, d, b)  ·
+ │         render 0      1                  ·          ·
+ │         render 1      d                  ·          ·
+ │         render 2      b                  ·          ·
+ └── scan  ·             ·                  (b, d)     +d,+b
+·          table         abcd@abcd_d_b_key  ·          ·
+·          spans         FULL SCAN          ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT a, b FROM abcd
 ----
-·          distributed  false         ·       ·
-·          vectorized   true          ·       ·
-distinct   ·            ·             (a, b)  ·
- │         distinct on  a, b          ·       ·
- │         order key    a, b          ·       ·
- └── scan  ·            ·             (a, b)  +a,+b
-·          table        abcd@primary  ·       ·
-·          spans        FULL SCAN     ·       ·
+·          distribution  local         ·       ·
+·          vectorized    true          ·       ·
+distinct   ·             ·             (a, b)  ·
+ │         distinct on   a, b          ·       ·
+ │         order key     a, b          ·       ·
+ └── scan  ·             ·             (a, b)  +a,+b
+·          table         abcd@primary  ·       ·
+·          spans         FULL SCAN     ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT a, b, c FROM abcd
 ----
-·     distributed  false         ·          ·
-·     vectorized   true          ·          ·
-scan  ·            ·             (a, b, c)  ·
-·     table        abcd@primary  ·          ·
-·     spans        FULL SCAN     ·          ·
+·     distribution  local         ·          ·
+·     vectorized    true          ·          ·
+scan  ·             ·             (a, b, c)  ·
+·     table         abcd@primary  ·          ·
+·     spans         FULL SCAN     ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT a, b, c, d FROM abcd
 ----
-·     distributed  false         ·             ·
-·     vectorized   true          ·             ·
-scan  ·            ·             (a, b, c, d)  ·
-·     table        abcd@primary  ·             ·
-·     spans        FULL SCAN     ·             ·
+·     distribution  local         ·             ·
+·     vectorized    true          ·             ·
+scan  ·             ·             (a, b, c, d)  ·
+·     table         abcd@primary  ·             ·
+·     spans         FULL SCAN     ·             ·
 
 statement ok
 CREATE TABLE kv (k INT PRIMARY KEY, v INT, UNIQUE INDEX idx(v))
@@ -193,37 +193,37 @@ CREATE TABLE kv (k INT PRIMARY KEY, v INT, UNIQUE INDEX idx(v))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv
 ----
-·          distributed  false      ·    ·
-·          vectorized   true       ·    ·
-distinct   ·            ·          (v)  ·
- │         distinct on  v          ·    ·
- │         order key    v          ·    ·
- └── scan  ·            ·          (v)  +v
-·          table        kv@idx     ·    ·
-·          spans        FULL SCAN  ·    ·
+·          distribution  local      ·    ·
+·          vectorized    true       ·    ·
+distinct   ·             ·          (v)  ·
+ │         distinct on   v          ·    ·
+ │         order key     v          ·    ·
+ └── scan  ·             ·          (v)  +v
+·          table         kv@idx     ·    ·
+·          spans         FULL SCAN  ·    ·
 
 # Verify we don't incorrectly elide the distinct node when we only have a weak key (#19343).
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv@idx
 ----
-·          distributed  false      ·    ·
-·          vectorized   true       ·    ·
-distinct   ·            ·          (v)  ·
- │         distinct on  v          ·    ·
- │         order key    v          ·    ·
- └── scan  ·            ·          (v)  +v
-·          table        kv@idx     ·    ·
-·          spans        FULL SCAN  ·    ·
+·          distribution  local      ·    ·
+·          vectorized    true       ·    ·
+distinct   ·             ·          (v)  ·
+ │         distinct on   v          ·    ·
+ │         order key     v          ·    ·
+ └── scan  ·             ·          (v)  +v
+·          table         kv@idx     ·    ·
+·          spans         FULL SCAN  ·    ·
 
 # Here we can infer that v is not-NULL so eliding the node is correct.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv@idx WHERE v > 0
 ----
-·     distributed  false   ·    ·
-·     vectorized   true    ·    ·
-scan  ·            ·       (v)  ·
-·     table        kv@idx  ·    ·
-·     spans        /1-     ·    ·
+·     distribution  local   ·    ·
+·     vectorized    true    ·    ·
+scan  ·             ·       (v)  ·
+·     table         kv@idx  ·    ·
+·     spans         /1-     ·    ·
 
 statement ok
 CREATE TABLE kv2 (k INT PRIMARY KEY, v INT NOT NULL, UNIQUE INDEX idx(v))
@@ -232,8 +232,8 @@ CREATE TABLE kv2 (k INT PRIMARY KEY, v INT NOT NULL, UNIQUE INDEX idx(v))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv2@idx
 ----
-·     distributed  false      ·    ·
-·     vectorized   true       ·    ·
-scan  ·            ·          (v)  ·
-·     table        kv2@idx    ·    ·
-·     spans        FULL SCAN  ·    ·
+·     distribution  local      ·    ·
+·     vectorized    true       ·    ·
+scan  ·             ·          (v)  ·
+·     table         kv2@idx    ·    ·
+·     spans         FULL SCAN  ·    ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -27,61 +27,61 @@ CREATE TABLE abc (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) x, y, z FROM xyz
 ----
-·          distributed  false        ·          ·
-·          vectorized   true         ·          ·
-distinct   ·            ·            (x, y, z)  ·
- │         distinct on  x, y, z      ·          ·
- └── scan  ·            ·            (x, y, z)  ·
-·          table        xyz@primary  ·          ·
-·          spans        FULL SCAN    ·          ·
+·          distribution  local        ·          ·
+·          vectorized    true         ·          ·
+distinct   ·             ·            (x, y, z)  ·
+ │         distinct on   x, y, z      ·          ·
+ └── scan  ·             ·            (x, y, z)  ·
+·          table         xyz@primary  ·          ·
+·          spans         FULL SCAN    ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (z, x, y) x FROM xyz
 ----
-·               distributed  false        ·          ·
-·               vectorized   true         ·          ·
-render          ·            ·            (x)        ·
- │              render 0     x            ·          ·
- └── distinct   ·            ·            (x, y, z)  ·
-      │         distinct on  x, y, z      ·          ·
-      └── scan  ·            ·            (x, y, z)  ·
-·               table        xyz@primary  ·          ·
-·               spans        FULL SCAN    ·          ·
+·               distribution  local        ·          ·
+·               vectorized    true         ·          ·
+render          ·             ·            (x)        ·
+ │              render 0      x            ·          ·
+ └── distinct   ·             ·            (x, y, z)  ·
+      │         distinct on   x, y, z      ·          ·
+      └── scan  ·             ·            (x, y, z)  ·
+·               table         xyz@primary  ·          ·
+·               spans         FULL SCAN    ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (b, c, a) a, c, b FROM abc
 ----
-·          distributed  false        ·          ·
-·          vectorized   true         ·          ·
-render     ·            ·            (a, c, b)  ·
- │         render 0     a            ·          ·
- │         render 1     c            ·          ·
- │         render 2     b            ·          ·
- └── scan  ·            ·            (a, b, c)  ·
-·          table        abc@primary  ·          ·
-·          spans        FULL SCAN    ·          ·
+·          distribution  local        ·          ·
+·          vectorized    true         ·          ·
+render     ·             ·            (a, c, b)  ·
+ │         render 0      a            ·          ·
+ │         render 1      c            ·          ·
+ │         render 2      b            ·          ·
+ └── scan  ·             ·            (a, b, c)  ·
+·          table         abc@primary  ·          ·
+·          spans         FULL SCAN    ·          ·
 
 # Distinct node should be elided since we have a strong key.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (b, c, a) a FROM abc
 ----
-·     distributed  false        ·    ·
-·     vectorized   true         ·    ·
-scan  ·            ·            (a)  ·
-·     table        abc@primary  ·    ·
-·     spans        FULL SCAN    ·    ·
+·     distribution  local        ·    ·
+·     vectorized    true         ·    ·
+scan  ·             ·            (a)  ·
+·     table         abc@primary  ·    ·
+·     spans         FULL SCAN    ·    ·
 
 # Distinct node should be elided since we have a strong key.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (c, a, b) b FROM abc ORDER BY b
 ----
-·          distributed  false        ·    ·
-·          vectorized   true         ·    ·
-sort       ·            ·            (b)  +b
- │         order        +b           ·    ·
- └── scan  ·            ·            (b)  ·
-·          table        abc@primary  ·    ·
-·          spans        FULL SCAN    ·    ·
+·          distribution  local        ·    ·
+·          vectorized    true         ·    ·
+sort       ·             ·            (b)  +b
+ │         order         +b           ·    ·
+ └── scan  ·             ·            (b)  ·
+·          table         abc@primary  ·    ·
+·          spans         FULL SCAN    ·    ·
 
 
 # 2/3 columns
@@ -89,86 +89,86 @@ sort       ·            ·            (b)  +b
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y) y, x FROM xyz
 ----
-·               distributed  false        ·       ·
-·               vectorized   true         ·       ·
-render          ·            ·            (y, x)  ·
- │              render 0     y            ·       ·
- │              render 1     x            ·       ·
- └── distinct   ·            ·            (x, y)  ·
-      │         distinct on  x, y         ·       ·
-      └── scan  ·            ·            (x, y)  ·
-·               table        xyz@primary  ·       ·
-·               spans        FULL SCAN    ·       ·
+·               distribution  local        ·       ·
+·               vectorized    true         ·       ·
+render          ·             ·            (y, x)  ·
+ │              render 0      y            ·       ·
+ │              render 1      x            ·       ·
+ └── distinct   ·             ·            (x, y)  ·
+      │         distinct on   x, y         ·       ·
+      └── scan  ·             ·            (x, y)  ·
+·               table         xyz@primary  ·       ·
+·               spans         FULL SCAN    ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x) x FROM xyz
 ----
-·               distributed  false        ·       ·
-·               vectorized   true         ·       ·
-render          ·            ·            (x)     ·
- │              render 0     x            ·       ·
- └── distinct   ·            ·            (x, y)  ·
-      │         distinct on  x, y         ·       ·
-      └── scan  ·            ·            (x, y)  ·
-·               table        xyz@primary  ·       ·
-·               spans        FULL SCAN    ·       ·
+·               distribution  local        ·       ·
+·               vectorized    true         ·       ·
+render          ·             ·            (x)     ·
+ │              render 0      x            ·       ·
+ └── distinct   ·             ·            (x, y)  ·
+      │         distinct on   x, y         ·       ·
+      └── scan  ·             ·            (x, y)  ·
+·               table         xyz@primary  ·       ·
+·               spans         FULL SCAN    ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x, x, y, x) x, y FROM xyz
 ----
-·          distributed  false        ·       ·
-·          vectorized   true         ·       ·
-distinct   ·            ·            (x, y)  ·
- │         distinct on  x, y         ·       ·
- └── scan  ·            ·            (x, y)  ·
-·          table        xyz@primary  ·       ·
-·          spans        FULL SCAN    ·       ·
+·          distribution  local        ·       ·
+·          vectorized    true         ·       ·
+distinct   ·             ·            (x, y)  ·
+ │         distinct on   x, y         ·       ·
+ └── scan  ·             ·            (x, y)  ·
+·          table         xyz@primary  ·       ·
+·          spans         FULL SCAN    ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, x) pk1, x FROM xyz ORDER BY pk1
 ----
-·               distributed  false        ·         ·
-·               vectorized   true         ·         ·
-render          ·            ·            (pk1, x)  ·
- │              render 0     pk1          ·         ·
- │              render 1     x            ·         ·
- └── distinct   ·            ·            (x, pk1)  +pk1
-      │         distinct on  x, pk1       ·         ·
-      │         order key    pk1          ·         ·
-      └── scan  ·            ·            (x, pk1)  +pk1
-·               table        xyz@primary  ·         ·
-·               spans        FULL SCAN    ·         ·
+·               distribution  local        ·         ·
+·               vectorized    true         ·         ·
+render          ·             ·            (pk1, x)  ·
+ │              render 0      pk1          ·         ·
+ │              render 1      x            ·         ·
+ └── distinct   ·             ·            (x, pk1)  +pk1
+      │         distinct on   x, pk1       ·         ·
+      │         order key     pk1          ·         ·
+      └── scan  ·             ·            (x, pk1)  +pk1
+·               table         xyz@primary  ·         ·
+·               spans         FULL SCAN    ·         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, c) a, b FROM abc
 ----
-·               distributed  false        ·          ·
-·               vectorized   true         ·          ·
-render          ·            ·            (a, b)     ·
- │              render 0     a            ·          ·
- │              render 1     b            ·          ·
- └── distinct   ·            ·            (a, b, c)  ·
-      │         distinct on  a, c         ·          ·
-      │         order key    a            ·          ·
-      └── scan  ·            ·            (a, b, c)  +a
-·               table        abc@primary  ·          ·
-·               spans        FULL SCAN    ·          ·
+·               distribution  local        ·          ·
+·               vectorized    true         ·          ·
+render          ·             ·            (a, b)     ·
+ │              render 0      a            ·          ·
+ │              render 1      b            ·          ·
+ └── distinct   ·             ·            (a, b, c)  ·
+      │         distinct on   a, c         ·          ·
+      │         order key     a            ·          ·
+      └── scan  ·             ·            (a, b, c)  +a
+·               table         abc@primary  ·          ·
+·               spans         FULL SCAN    ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (c, a) b, c, a FROM abc
 ----
-·               distributed  false        ·          ·
-·               vectorized   true         ·          ·
-render          ·            ·            (b, c, a)  ·
- │              render 0     b            ·          ·
- │              render 1     c            ·          ·
- │              render 2     a            ·          ·
- └── distinct   ·            ·            (a, b, c)  ·
-      │         distinct on  a, c         ·          ·
-      │         order key    a            ·          ·
-      └── scan  ·            ·            (a, b, c)  +a
-·               table        abc@primary  ·          ·
-·               spans        FULL SCAN    ·          ·
+·               distribution  local        ·          ·
+·               vectorized    true         ·          ·
+render          ·             ·            (b, c, a)  ·
+ │              render 0      b            ·          ·
+ │              render 1      c            ·          ·
+ │              render 2      a            ·          ·
+ └── distinct   ·             ·            (a, b, c)  ·
+      │         distinct on   a, c         ·          ·
+      │         order key     a            ·          ·
+      └── scan  ·             ·            (a, b, c)  +a
+·               table         abc@primary  ·          ·
+·               spans         FULL SCAN    ·          ·
 
 
 # 1/3 columns
@@ -178,21 +178,21 @@ render          ·            ·            (b, c, a)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (pk1) pk1, pk2 FROM xyz
 ----
-·          distributed  false        ·           ·
-·          vectorized   true         ·           ·
-distinct   ·            ·            (pk1, pk2)  ·
- │         distinct on  pk1          ·           ·
- │         order key    pk1          ·           ·
- └── scan  ·            ·            (pk1, pk2)  +pk1
-·          table        xyz@primary  ·           ·
-·          spans        FULL SCAN    ·           ·
+·          distribution  local        ·           ·
+·          vectorized    true         ·           ·
+distinct   ·             ·            (pk1, pk2)  ·
+ │         distinct on   pk1          ·           ·
+ │         order key     pk1          ·           ·
+ └── scan  ·             ·            (pk1, pk2)  +pk1
+·          table         xyz@primary  ·           ·
+·          spans         FULL SCAN    ·           ·
 
 # Ensure the distinctNode advertises an a+ ordering.
 # TODO(radu): set the ordering in the render node to fix this.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
 ----
-·                    distributed      false        ·          ·
+·                    distribution     local        ·          ·
 ·                    vectorized       true         ·          ·
 render               ·                ·            (a, c)     +a
  │                   render 0         a            ·          ·
@@ -214,51 +214,51 @@ render               ·                ·            (a, c)     +a
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) x FROM xyz ORDER BY x DESC
 ----
-·               distributed  false        ·    ·
-·               vectorized   true         ·    ·
-sort            ·            ·            (x)  -x
- │              order        -x           ·    ·
- └── distinct   ·            ·            (x)  ·
-      │         distinct on  x            ·    ·
-      └── scan  ·            ·            (x)  ·
-·               table        xyz@primary  ·    ·
-·               spans        FULL SCAN    ·    ·
+·               distribution  local        ·    ·
+·               vectorized    true         ·    ·
+sort            ·             ·            (x)  -x
+ │              order         -x           ·    ·
+ └── distinct   ·             ·            (x)  ·
+      │         distinct on   x            ·    ·
+      └── scan  ·             ·            (x)  ·
+·               table         xyz@primary  ·    ·
+·               spans         FULL SCAN    ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, z) y, z, x FROM xyz ORDER BY z
 ----
-·                    distributed  false        ·          ·
-·                    vectorized   true         ·          ·
-render               ·            ·            (y, z, x)  ·
- │                   render 0     y            ·          ·
- │                   render 1     z            ·          ·
- │                   render 2     x            ·          ·
- └── distinct        ·            ·            (x, y, z)  +z
-      │              distinct on  x, z         ·          ·
-      │              order key    z            ·          ·
-      └── sort       ·            ·            (x, y, z)  +z
-           │         order        +z           ·          ·
-           └── scan  ·            ·            (x, y, z)  ·
-·                    table        xyz@primary  ·          ·
-·                    spans        FULL SCAN    ·          ·
+·                    distribution  local        ·          ·
+·                    vectorized    true         ·          ·
+render               ·             ·            (y, z, x)  ·
+ │                   render 0      y            ·          ·
+ │                   render 1      z            ·          ·
+ │                   render 2      x            ·          ·
+ └── distinct        ·             ·            (x, y, z)  +z
+      │              distinct on   x, z         ·          ·
+      │              order key     z            ·          ·
+      └── sort       ·             ·            (x, y, z)  +z
+           │         order         +z           ·          ·
+           └── scan  ·             ·            (x, y, z)  ·
+·                    table         xyz@primary  ·          ·
+·                    spans         FULL SCAN    ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC, y DESC
 ----
-·                    distributed  false        ·          ·
-·                    vectorized   true         ·          ·
-render               ·            ·            (y, z, x)  ·
- │                   render 0     y            ·          ·
- │                   render 1     z            ·          ·
- │                   render 2     x            ·          ·
- └── distinct        ·            ·            (x, y, z)  +x
-      │              distinct on  x            ·          ·
-      │              order key    x            ·          ·
-      └── sort       ·            ·            (x, y, z)  +x,-z,-y
-           │         order        +x,-z,-y     ·          ·
-           └── scan  ·            ·            (x, y, z)  ·
-·                    table        xyz@primary  ·          ·
-·                    spans        FULL SCAN    ·          ·
+·                    distribution  local        ·          ·
+·                    vectorized    true         ·          ·
+render               ·             ·            (y, z, x)  ·
+ │                   render 0      y            ·          ·
+ │                   render 1      z            ·          ·
+ │                   render 2      x            ·          ·
+ └── distinct        ·             ·            (x, y, z)  +x
+      │              distinct on   x            ·          ·
+      │              order key     x            ·          ·
+      └── sort       ·             ·            (x, y, z)  +x,-z,-y
+           │         order         +x,-z,-y     ·          ·
+           └── scan  ·             ·            (x, y, z)  ·
+·                    table         xyz@primary  ·          ·
+·                    spans         FULL SCAN    ·          ·
 
 #####################
 # With aggregations #
@@ -267,27 +267,27 @@ render               ·            ·            (y, z, x)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (max(y)) max(x) FROM xyz
 ----
-·          distributed  false        ·      ·
-·          vectorized   true         ·      ·
-group      ·            ·            (max)  ·
- │         aggregate 0  max(x)       ·      ·
- │         scalar       ·            ·      ·
- └── scan  ·            ·            (x)    ·
-·          table        xyz@primary  ·      ·
-·          spans        FULL SCAN    ·      ·
+·          distribution  local        ·      ·
+·          vectorized    true         ·      ·
+group      ·             ·            (max)  ·
+ │         aggregate 0   max(x)       ·      ·
+ │         scalar        ·            ·      ·
+ └── scan  ·             ·            (x)    ·
+·          table         xyz@primary  ·      ·
+·          spans         FULL SCAN    ·      ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(min(a), max(b), min(c)) max(a) FROM abc
 ----
-·             distributed  false            ·      ·
-·             vectorized   true             ·      ·
-group         ·            ·                (max)  ·
- │            aggregate 0  any_not_null(a)  ·      ·
- │            scalar       ·                ·      ·
- └── revscan  ·            ·                (a)    ·
-·             table        abc@primary      ·      ·
-·             spans        LIMITED SCAN     ·      ·
-·             limit        1                ·      ·
+·             distribution  local            ·      ·
+·             vectorized    true             ·      ·
+group         ·             ·                (max)  ·
+ │            aggregate 0   any_not_null(a)  ·      ·
+ │            scalar        ·                ·      ·
+ └── revscan  ·             ·                (a)    ·
+·             table         abc@primary      ·      ·
+·             spans         LIMITED SCAN     ·      ·
+·             limit         1                ·      ·
 
 #################
 # With GROUP BY #
@@ -297,36 +297,36 @@ group         ·            ·                (max)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) min(x) FROM xyz GROUP BY y
 ----
-·               distributed  false        ·         ·
-·               vectorized   true         ·         ·
-render          ·            ·            (min)     ·
- │              render 0     min          ·         ·
- └── group      ·            ·            (y, min)  ·
-      │         aggregate 0  y            ·         ·
-      │         aggregate 1  min(x)       ·         ·
-      │         group by     y            ·         ·
-      └── scan  ·            ·            (x, y)    ·
-·               table        xyz@primary  ·         ·
-·               spans        FULL SCAN    ·         ·
+·               distribution  local        ·         ·
+·               vectorized    true         ·         ·
+render          ·             ·            (min)     ·
+ │              render 0      min          ·         ·
+ └── group      ·             ·            (y, min)  ·
+      │         aggregate 0   y            ·         ·
+      │         aggregate 1   min(x)       ·         ·
+      │         group by      y            ·         ·
+      └── scan  ·             ·            (x, y)    ·
+·               table         xyz@primary  ·         ·
+·               spans         FULL SCAN    ·         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(min(x)) min(x) FROM xyz GROUP BY y HAVING min(x) = 1
 ----
-·                         distributed  false        ·         ·
-·                         vectorized   true         ·         ·
-render                    ·            ·            (min)     ·
- │                        render 0     min          ·         ·
- └── limit                ·            ·            (y, min)  ·
-      │                   count        1            ·         ·
-      └── filter          ·            ·            (y, min)  ·
-           │              filter       min = 1      ·         ·
-           └── group      ·            ·            (y, min)  ·
-                │         aggregate 0  y            ·         ·
-                │         aggregate 1  min(x)       ·         ·
-                │         group by     y            ·         ·
-                └── scan  ·            ·            (x, y)    ·
-·                         table        xyz@primary  ·         ·
-·                         spans        FULL SCAN    ·         ·
+·                         distribution  local        ·         ·
+·                         vectorized    true         ·         ·
+render                    ·             ·            (min)     ·
+ │                        render 0      min          ·         ·
+ └── limit                ·             ·            (y, min)  ·
+      │                   count         1            ·         ·
+      └── filter          ·             ·            (y, min)  ·
+           │              filter        min = 1      ·         ·
+           └── group      ·             ·            (y, min)  ·
+                │         aggregate 0   y            ·         ·
+                │         aggregate 1   min(x)       ·         ·
+                │         group by      y            ·         ·
+                └── scan  ·             ·            (x, y)    ·
+·                         table         xyz@primary  ·         ·
+·                         spans         FULL SCAN    ·         ·
 
 #########################
 # With window functions #
@@ -335,18 +335,18 @@ render                    ·            ·            (min)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(row_number() OVER()) y FROM xyz
 ----
-·                    distributed  false                                                                  ·                ·
-·                    vectorized   true                                                                   ·                ·
-render               ·            ·                                                                      (y)              ·
- │                   render 0     y                                                                      ·                ·
- └── distinct        ·            ·                                                                      (y, row_number)  ·
-      │              distinct on  row_number                                                             ·                ·
-      └── window     ·            ·                                                                      (y, row_number)  ·
-           │         window 0     row_number() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                ·
-           │         render 1     row_number() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                ·
-           └── scan  ·            ·                                                                      (y)              ·
-·                    table        xyz@primary                                                            ·                ·
-·                    spans        FULL SCAN                                                              ·                ·
+·                    distribution  local                                                                  ·                ·
+·                    vectorized    true                                                                   ·                ·
+render               ·             ·                                                                      (y)              ·
+ │                   render 0      y                                                                      ·                ·
+ └── distinct        ·             ·                                                                      (y, row_number)  ·
+      │              distinct on   row_number                                                             ·                ·
+      └── window     ·             ·                                                                      (y, row_number)  ·
+           │         window 0      row_number() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                ·
+           │         render 1      row_number() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                ·
+           └── scan  ·             ·                                                                      (y)              ·
+·                    table         xyz@primary                                                            ·                ·
+·                    spans         FULL SCAN                                                              ·                ·
 
 ###########################
 # With ordinal references #
@@ -355,23 +355,23 @@ render               ·            ·                                           
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (1) x, y, z FROM xyz
 ----
-·          distributed  false        ·          ·
-·          vectorized   true         ·          ·
-distinct   ·            ·            (x, y, z)  ·
- │         distinct on  x            ·          ·
- └── scan  ·            ·            (x, y, z)  ·
-·          table        xyz@primary  ·          ·
-·          spans        FULL SCAN    ·          ·
+·          distribution  local        ·          ·
+·          vectorized    true         ·          ·
+distinct   ·             ·            (x, y, z)  ·
+ │         distinct on   x            ·          ·
+ └── scan  ·             ·            (x, y, z)  ·
+·          table         xyz@primary  ·          ·
+·          spans         FULL SCAN    ·          ·
 
 # Distinct node elided because of strong key.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (1,2,3) a, b, c FROM abc
 ----
-·     distributed  false        ·          ·
-·     vectorized   true         ·          ·
-scan  ·            ·            (a, b, c)  ·
-·     table        abc@primary  ·          ·
-·     spans        FULL SCAN    ·          ·
+·     distribution  local        ·          ·
+·     vectorized    true         ·          ·
+scan  ·             ·            (a, b, c)  ·
+·     table         abc@primary  ·          ·
+·     spans         FULL SCAN    ·          ·
 
 #########################
 # With alias references #
@@ -381,25 +381,25 @@ scan  ·            ·            (a, b, c)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) x AS y, y AS x FROM xyz
 ----
-·          distributed  false        ·       ·
-·          vectorized   true         ·       ·
-distinct   ·            ·            (y, x)  ·
- │         distinct on  y            ·       ·
- └── scan  ·            ·            (y, x)  ·
-·          table        xyz@primary  ·       ·
-·          spans        FULL SCAN    ·       ·
+·          distribution  local        ·       ·
+·          vectorized    true         ·       ·
+distinct   ·             ·            (y, x)  ·
+ │         distinct on   y            ·       ·
+ └── scan  ·             ·            (y, x)  ·
+·          table         xyz@primary  ·       ·
+·          spans         FULL SCAN    ·       ·
 
 # Ignores the alias.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(x) x AS y FROM xyz
 ----
-·          distributed  false        ·    ·
-·          vectorized   true         ·    ·
-distinct   ·            ·            (y)  ·
- │         distinct on  y            ·    ·
- └── scan  ·            ·            (y)  ·
-·          table        xyz@primary  ·    ·
-·          spans        FULL SCAN    ·    ·
+·          distribution  local        ·    ·
+·          vectorized    true         ·    ·
+distinct   ·             ·            (y)  ·
+ │         distinct on   y            ·    ·
+ └── scan  ·             ·            (y)  ·
+·          table         xyz@primary  ·    ·
+·          spans         FULL SCAN    ·    ·
 
 ##################################
 # With nested parentheses/tuples #
@@ -408,13 +408,13 @@ distinct   ·            ·            (y)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(((x)), (x, y)) x, y FROM xyz
 ----
-·          distributed  false        ·       ·
-·          vectorized   true         ·       ·
-distinct   ·            ·            (x, y)  ·
- │         distinct on  x, y         ·       ·
- └── scan  ·            ·            (x, y)  ·
-·          table        xyz@primary  ·       ·
-·          spans        FULL SCAN    ·       ·
+·          distribution  local        ·       ·
+·          vectorized    true         ·       ·
+distinct   ·             ·            (x, y)  ·
+ │         distinct on   x, y         ·       ·
+ └── scan  ·             ·            (x, y)  ·
+·          table         xyz@primary  ·       ·
+·          spans         FULL SCAN    ·       ·
 
 ################################
 # Hybrid PK and non-PK queries #
@@ -424,59 +424,59 @@ distinct   ·            ·            (x, y)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, pk2, x, y) x, y, z FROM xyz ORDER BY x, y
 ----
-·          distributed  false        ·          ·
-·          vectorized   true         ·          ·
-sort       ·            ·            (x, y, z)  +x,+y
- │         order        +x,+y        ·          ·
- └── scan  ·            ·            (x, y, z)  ·
-·          table        xyz@primary  ·          ·
-·          spans        FULL SCAN    ·          ·
+·          distribution  local        ·          ·
+·          vectorized    true         ·          ·
+sort       ·             ·            (x, y, z)  +x,+y
+ │         order         +x,+y        ·          ·
+ └── scan  ·             ·            (x, y, z)  ·
+·          table         xyz@primary  ·          ·
+·          spans         FULL SCAN    ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) pk1 FROM xyz ORDER BY x
 ----
-·                    distributed  false        ·               ·
-·                    vectorized   true         ·               ·
-render               ·            ·            (pk1)           ·
- │                   render 0     pk1          ·               ·
- └── distinct        ·            ·            (x, y, z, pk1)  +x
-      │              distinct on  x, y, z      ·               ·
-      │              order key    x            ·               ·
-      └── sort       ·            ·            (x, y, z, pk1)  +x
-           │         order        +x           ·               ·
-           └── scan  ·            ·            (x, y, z, pk1)  ·
-·                    table        xyz@primary  ·               ·
-·                    spans        FULL SCAN    ·               ·
+·                    distribution  local        ·               ·
+·                    vectorized    true         ·               ·
+render               ·             ·            (pk1)           ·
+ │                   render 0      pk1          ·               ·
+ └── distinct        ·             ·            (x, y, z, pk1)  +x
+      │              distinct on   x, y, z      ·               ·
+      │              order key     x            ·               ·
+      └── sort       ·             ·            (x, y, z, pk1)  +x
+           │         order         +x           ·               ·
+           └── scan  ·             ·            (x, y, z, pk1)  ·
+·                    table         xyz@primary  ·               ·
+·                    spans         FULL SCAN    ·               ·
 
 # Regression tests for #34112: distinct on constant column.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) x, y FROM xyz WHERE x = 1 ORDER BY x, y
 ----
-·               distributed  false        ·       ·
-·               vectorized   true         ·       ·
-limit           ·            ·            (x, y)  +y
- │              count        1            ·       ·
- └── sort       ·            ·            (x, y)  +y
-      │         order        +y           ·       ·
-      └── scan  ·            ·            (x, y)  ·
-·               table        xyz@primary  ·       ·
-·               spans        FULL SCAN    ·       ·
-·               filter       x = 1        ·       ·
+·               distribution  local        ·       ·
+·               vectorized    true         ·       ·
+limit           ·             ·            (x, y)  +y
+ │              count         1            ·       ·
+ └── sort       ·             ·            (x, y)  +y
+      │         order         +y           ·       ·
+      └── scan  ·             ·            (x, y)  ·
+·               table         xyz@primary  ·       ·
+·               spans         FULL SCAN    ·       ·
+·               filter        x = 1        ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT count(*) FROM (SELECT DISTINCT ON (x) x, y FROM xyz WHERE x = 1 ORDER BY x, y)
 ----
-·                         distributed  false         ·        ·
-·                         vectorized   true          ·        ·
-group                     ·            ·             (count)  ·
- │                        aggregate 0  count_rows()  ·        ·
- │                        scalar       ·             ·        ·
- └── render               ·            ·             ()       ·
-      └── limit           ·            ·             (x, y)   +y
-           │              count        1             ·        ·
-           └── sort       ·            ·             (x, y)   +y
-                │         order        +y            ·        ·
-                └── scan  ·            ·             (x, y)   ·
-·                         table        xyz@primary   ·        ·
-·                         spans        FULL SCAN     ·        ·
-·                         filter       x = 1         ·        ·
+·                         distribution  local         ·        ·
+·                         vectorized    true          ·        ·
+group                     ·             ·             (count)  ·
+ │                        aggregate 0   count_rows()  ·        ·
+ │                        scalar        ·             ·        ·
+ └── render               ·             ·             ()       ·
+      └── limit           ·             ·             (x, y)   +y
+           │              count         1             ·        ·
+           └── sort       ·             ·             (x, y)   +y
+                │         order         +y            ·        ·
+                └── scan  ·             ·             (x, y)   ·
+·                         table         xyz@primary   ·        ·
+·                         spans         FULL SCAN     ·        ·
+·                         filter        x = 1         ·        ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
@@ -353,17 +353,17 @@ group-by
 query TTTTT
 EXPLAIN (verbose) SELECT b, count(*), corr(a, b) FROM data2 WHERE a=1 GROUP BY b
 ----
-·          distributed  true           ·                 ·
-·          vectorized   true           ·                 ·
-group      ·            ·              (b, count, corr)  ·
- │         aggregate 0  b              ·                 ·
- │         aggregate 1  count_rows()   ·                 ·
- │         aggregate 2  corr(a, b)     ·                 ·
- │         group by     b              ·                 ·
- │         ordered      +b             ·                 ·
- └── scan  ·            ·              (a, b)            +b
-·          table        data2@primary  ·                 ·
-·          spans        /1-/2          ·                 ·
+·          distribution  full           ·                 ·
+·          vectorized    true           ·                 ·
+group      ·             ·              (b, count, corr)  ·
+ │         aggregate 0   b              ·                 ·
+ │         aggregate 1   count_rows()   ·                 ·
+ │         aggregate 2   corr(a, b)     ·                 ·
+ │         group by      b              ·                 ·
+ │         ordered       +b             ·                 ·
+ └── scan  ·             ·              (a, b)            +b
+·          table         data2@primary  ·                 ·
+·          spans         /1-/2          ·                 ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT b, count(*) FROM data2 WHERE a=1 GROUP BY b];

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
@@ -67,13 +67,13 @@ NULL             /NULL/NULL/NULL  {5}       5
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz
 ----
-·          distributed  true         ·          ·
-·          vectorized   true         ·          ·
-distinct   ·            ·            (x, y, z)  ·
- │         distinct on  x, y, z      ·          ·
- └── scan  ·            ·            (x, y, z)  ·
-·          table        xyz@primary  ·          ·
-·          spans        FULL SCAN    ·          ·
+·          distribution  full         ·          ·
+·          vectorized    true         ·          ·
+distinct   ·             ·            (x, y, z)  ·
+ │         distinct on   x, y, z      ·          ·
+ └── scan  ·             ·            (x, y, z)  ·
+·          table         xyz@primary  ·          ·
+·          spans         FULL SCAN    ·          ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz]
@@ -84,16 +84,16 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJyslF1vmzAUhu_3K6xz1UpGYC
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz ORDER BY x
 ----
-·               distributed  true         ·          ·
-·               vectorized   true         ·          ·
-distinct        ·            ·            (x, y, z)  +x
- │              distinct on  x, y, z      ·          ·
- │              order key    x            ·          ·
- └── sort       ·            ·            (x, y, z)  +x
-      │         order        +x           ·          ·
-      └── scan  ·            ·            (x, y, z)  ·
-·               table        xyz@primary  ·          ·
-·               spans        FULL SCAN    ·          ·
+·               distribution  full         ·          ·
+·               vectorized    true         ·          ·
+distinct        ·             ·            (x, y, z)  +x
+ │              distinct on   x, y, z      ·          ·
+ │              order key     x            ·          ·
+ └── sort       ·             ·            (x, y, z)  +x
+      │         order         +x           ·          ·
+      └── scan  ·             ·            (x, y, z)  ·
+·               table         xyz@primary  ·          ·
+·               spans         FULL SCAN    ·          ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz ORDER BY x]
@@ -105,16 +105,16 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJy0lU2P2jwUhffvr7DuakavUX
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y) x, y FROM xyz ORDER BY y, x
 ----
-·               distributed  true         ·       ·
-·               vectorized   true         ·       ·
-distinct        ·            ·            (x, y)  +y
- │              distinct on  y            ·       ·
- │              order key    y            ·       ·
- └── sort       ·            ·            (x, y)  +y,+x
-      │         order        +y,+x        ·       ·
-      └── scan  ·            ·            (x, y)  ·
-·               table        xyz@primary  ·       ·
-·               spans        FULL SCAN    ·       ·
+·               distribution  full         ·       ·
+·               vectorized    true         ·       ·
+distinct        ·             ·            (x, y)  +y
+ │              distinct on   y            ·       ·
+ │              order key     y            ·       ·
+ └── sort       ·             ·            (x, y)  +y,+x
+      │         order         +y,+x        ·       ·
+      └── scan  ·             ·            (x, y)  ·
+·               table         xyz@primary  ·       ·
+·               spans         FULL SCAN    ·       ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (y) x, y FROM xyz ORDER BY y, x]
@@ -125,11 +125,11 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJyslV9v2jAUxd_3Kaz71KpGwU
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a,b,c) a, b, c FROM abc
 ----
-·     distributed  true         ·          ·
-·     vectorized   true         ·          ·
-scan  ·            ·            (a, b, c)  ·
-·     table        abc@primary  ·          ·
-·     spans        FULL SCAN    ·          ·
+·     distribution  full         ·          ·
+·     vectorized    true         ·          ·
+scan  ·             ·            (a, b, c)  ·
+·     table         abc@primary  ·          ·
+·     spans         FULL SCAN    ·          ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (a,b,c) a, b, c FROM abc]
@@ -139,17 +139,17 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJykk0-L2zAQxe_9FOKddkHG8Z
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, b) a, b FROM abc ORDER BY a, b, c
 ----
-·               distributed  true         ·          ·
-·               vectorized   true         ·          ·
-render          ·            ·            (a, b)     +a,+b
- │              render 0     a            ·          ·
- │              render 1     b            ·          ·
- └── distinct   ·            ·            (a, b, c)  +a,+b
-      │         distinct on  a, b         ·          ·
-      │         order key    a, b         ·          ·
-      └── scan  ·            ·            (a, b, c)  +a,+b,+c
-·               table        abc@primary  ·          ·
-·               spans        FULL SCAN    ·          ·
+·               distribution  full         ·          ·
+·               vectorized    true         ·          ·
+render          ·             ·            (a, b)     +a,+b
+ │              render 0      a            ·          ·
+ │              render 1      b            ·          ·
+ └── distinct   ·             ·            (a, b, c)  +a,+b
+      │         distinct on   a, b         ·          ·
+      │         order key     a, b         ·          ·
+      └── scan  ·             ·            (a, b, c)  +a,+b,+c
+·               table         abc@primary  ·          ·
+·               spans         FULL SCAN    ·          ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (a, b) a, b FROM abc ORDER BY a, b, c]

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
@@ -254,7 +254,7 @@ EXPLAIN SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
   OR pid1 >= 31 AND pid1 <= 33
   OR pa1 > 0
 ----
-·                distributed         true
+·                distribution        full
 ·                vectorized          true
 render           ·                   ·
  └── merge-join  ·                   ·
@@ -298,7 +298,7 @@ EXPLAIN
     OR child2.cid2 >= 12 AND child2.cid2 <= 14
     OR gcid2 >= 49 AND gcid2 <= 51
 ----
-·           distributed        true
+·           distribution       full
 ·           vectorized         true
 merge-join  ·                  ·
  │          type               inner

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
@@ -32,7 +32,7 @@ NULL       /1       {1}       1
 query TTTTT
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data) NATURAL JOIN (SELECT a,b FROM data AS data2))
 ----
-·                distributed     true               ·             ·
+·                distribution    full               ·             ·
 ·                vectorized      true               ·             ·
 render           ·               ·                  (a, b)        ·
  │               render 0        a                  ·             ·
@@ -112,19 +112,19 @@ render           ·               ·                  (a, b)        ·
 query TTTTT
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY b,a)
 ----
-·               distributed  true             ·             ·
-·               vectorized   true             ·             ·
-sort            ·            ·                (a, b, c, d)  +b,+a
- │              order        +b,+a            ·             ·
- └── hash-join  ·            ·                (a, b, c, d)  ·
-      │         type         inner            ·             ·
-      │         equality     (a, b) = (c, d)  ·             ·
-      ├── scan  ·            ·                (a, b)        ·
-      │         table        data@primary     ·             ·
-      │         spans        FULL SCAN        ·             ·
-      └── scan  ·            ·                (c, d)        ·
-·               table        data@primary     ·             ·
-·               spans        FULL SCAN        ·             ·
+·               distribution  full             ·             ·
+·               vectorized    true             ·             ·
+sort            ·             ·                (a, b, c, d)  +b,+a
+ │              order         +b,+a            ·             ·
+ └── hash-join  ·             ·                (a, b, c, d)  ·
+      │         type          inner            ·             ·
+      │         equality      (a, b) = (c, d)  ·             ·
+      ├── scan  ·             ·                (a, b)        ·
+      │         table         data@primary     ·             ·
+      │         spans         FULL SCAN        ·             ·
+      └── scan  ·             ·                (c, d)        ·
+·               table         data@primary     ·             ·
+·               spans         FULL SCAN        ·             ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY b,a)]

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
@@ -80,7 +80,7 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJy8lVGL4jwUhu-_XxHO1QxksG
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0
 ----
-·                distributed         true                 ·            ·
+·                distribution        full                 ·            ·
 ·                vectorized          true                 ·            ·
 render           ·                   ·                    (x, str)     ·
  │               render 0            x                    ·            ·
@@ -150,11 +150,11 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJyMUM0Ok0AQvvsUk_HSJtuw1P
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x FROM (SELECT x, 2*x, x+1 FROM NumToSquare)
 ----
-·     distributed  true                 ·    ·
-·     vectorized   true                 ·    ·
-scan  ·            ·                    (x)  ·
-·     table        numtosquare@primary  ·    ·
-·     spans        FULL SCAN            ·    ·
+·     distribution  full                 ·    ·
+·     vectorized    true                 ·    ·
+scan  ·             ·                    (x)  ·
+·     table         numtosquare@primary  ·    ·
+·     spans         FULL SCAN            ·    ·
 
 # Verifies that unused renders don't cause us to do rendering instead of a
 # simple projection.
@@ -166,42 +166,42 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJyMT01L80AYvL-_YplT-7pi43
 query TTTTT
 EXPLAIN (VERBOSE) SELECT y, str, repeat('test', y) AS res FROM NumToStr ORDER BY res
 ----
-·                    distributed  true               ·              ·
-·                    vectorized   true               ·              ·
-render               ·            ·                  (y, str, res)  ·
- │                   render 0     y                  ·              ·
- │                   render 1     str                ·              ·
- │                   render 2     res                ·              ·
- └── sort            ·            ·                  (res, y, str)  +res
-      │              order        +res               ·              ·
-      └── render     ·            ·                  (res, y, str)  ·
-           │         render 0     repeat('test', y)  ·              ·
-           │         render 1     y                  ·              ·
-           │         render 2     str                ·              ·
-           └── scan  ·            ·                  (y, str)       ·
-·                    table        numtostr@primary   ·              ·
-·                    spans        FULL SCAN          ·              ·
+·                    distribution  full               ·              ·
+·                    vectorized    true               ·              ·
+render               ·             ·                  (y, str, res)  ·
+ │                   render 0      y                  ·              ·
+ │                   render 1      str                ·              ·
+ │                   render 2      res                ·              ·
+ └── sort            ·             ·                  (res, y, str)  +res
+      │              order         +res               ·              ·
+      └── render     ·             ·                  (res, y, str)  ·
+           │         render 0      repeat('test', y)  ·              ·
+           │         render 1      y                  ·              ·
+           │         render 2      str                ·              ·
+           └── scan  ·             ·                  (y, str)       ·
+·                    table         numtostr@primary   ·              ·
+·                    spans         FULL SCAN          ·              ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT y, str, repeat('test', y) AS res FROM NumToStr ORDER BY res LIMIT 10
 ----
-·                         distributed  true               ·              ·
-·                         vectorized   true               ·              ·
-render                    ·            ·                  (y, str, res)  ·
- │                        render 0     y                  ·              ·
- │                        render 1     str                ·              ·
- │                        render 2     res                ·              ·
- └── limit                ·            ·                  (res, y, str)  +res
-      │                   count        10                 ·              ·
-      └── sort            ·            ·                  (res, y, str)  +res
-           │              order        +res               ·              ·
-           └── render     ·            ·                  (res, y, str)  ·
-                │         render 0     repeat('test', y)  ·              ·
-                │         render 1     y                  ·              ·
-                │         render 2     str                ·              ·
-                └── scan  ·            ·                  (y, str)       ·
-·                         table        numtostr@primary   ·              ·
-·                         spans        FULL SCAN          ·              ·
+·                         distribution  full               ·              ·
+·                         vectorized    true               ·              ·
+render                    ·             ·                  (y, str, res)  ·
+ │                        render 0      y                  ·              ·
+ │                        render 1      str                ·              ·
+ │                        render 2      res                ·              ·
+ └── limit                ·             ·                  (res, y, str)  +res
+      │                   count         10                 ·              ·
+      └── sort            ·             ·                  (res, y, str)  +res
+           │              order         +res               ·              ·
+           └── render     ·             ·                  (res, y, str)  ·
+                │         render 0      repeat('test', y)  ·              ·
+                │         render 1      y                  ·              ·
+                │         render 2      str                ·              ·
+                └── scan  ·             ·                  (y, str)       ·
+·                         table         numtostr@primary   ·              ·
+·                         spans         FULL SCAN          ·              ·
 
 # Regression test for #20481.
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_ordinality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_ordinality
@@ -33,12 +33,12 @@ NULL       /2       {1}       1
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x, y, z, ordinality FROM xyz WITH ORDINALITY
 ----
-·           distributed  false        ·                        ·
-·           vectorized   true         ·                        ·
-ordinality  ·            ·            (x, y, z, "ordinality")  ·
- └── scan   ·            ·            (x, y, z)                ·
-·           table        xyz@primary  ·                        ·
-·           spans        FULL SCAN    ·                        ·
+·           distribution  local        ·                        ·
+·           vectorized    true         ·                        ·
+ordinality  ·             ·            (x, y, z, "ordinality")  ·
+ └── scan   ·             ·            (x, y, z)                ·
+·           table         xyz@primary  ·                        ·
+·           spans         FULL SCAN    ·                        ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT x, y, z, ordinality FROM xyz WITH ORDINALITY]

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
@@ -135,93 +135,93 @@ NULL       /0         {1}       1
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE b <= 3
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        p1@b
-·     spans        -/4
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         p1@b
+·     spans         -/4
 
 # Partial predicate on primary key should not be tightened.
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= 3
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        p1@primary
-·     spans        -/4
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         p1@primary
+·     spans         -/4
 
 # Tighten end key if span contains full primary key.
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= 3 AND b <= 3
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        p1@primary
-·     spans        -/3/3/#
-·     filter       b <= 3
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         p1@primary
+·     spans         -/3/3/#
+·     filter        b <= 3
 
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= 3 AND b < 4
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        p1@primary
-·     spans        -/3/3/#
-·     filter       b < 4
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         p1@primary
+·     spans         -/3/3/#
+·     filter        b < 4
 
 # Mixed bounds.
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a >= 2 AND b <= 3
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        p1@primary
-·     spans        /2-
-·     filter       b <= 3
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         p1@primary
+·     spans         /2-
+·     filter        b <= 3
 
 # Edge cases.
 
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= 0 AND b <= 0
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        p1@primary
-·     spans        -/0/0/#
-·     filter       b <= 0
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         p1@primary
+·     spans         -/0/0/#
+·     filter        b <= 0
 
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= -1 AND b <= -1
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        p1@primary
-·     spans        -/-1/-1/#
-·     filter       b <= -1
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         p1@primary
+·     spans         -/-1/-1/#
+·     filter        b <= -1
 
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a = 1 AND b <= -9223372036854775808
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        p1@primary
-·     spans        /1-/1/-9223372036854775808/#
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         p1@primary
+·     spans         /1-/1/-9223372036854775808/#
 
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a = 1 AND b <= 9223372036854775807
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        p1@primary
-·     spans        /1-/1/9223372036854775807/#
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         p1@primary
+·     spans         /1-/1/9223372036854775807/#
 
 # Table c1 (interleaved table)
 
@@ -230,22 +230,22 @@ scan  ·            ·
 query TTT
 EXPLAIN SELECT * FROM c1 WHERE a <= 3
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        c1@primary
-·     spans        -/4
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         c1@primary
+·     spans         -/4
 
 # Tighten span on fully primary key.
 query TTT
 EXPLAIN SELECT * FROM c1 WHERE a <= 3 AND b <= 3
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        c1@primary
-·     spans        -/3/3/#/54/1/#
-·     filter       b <= 3
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         c1@primary
+·     spans         -/3/3/#/54/1/#
+·     filter        b <= 3
 
 # Table p2 with interleaved index.
 
@@ -255,22 +255,22 @@ scan  ·            ·
 query TTT
 EXPLAIN SELECT * FROM p2 WHERE i >= 2
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        p2@primary
-·     spans        /2-
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         p2@primary
+·     spans         /2-
 
 # Upper bound (i <= 5)
 
 query TTT
 EXPLAIN SELECT * FROM p2 WHERE i <= 5
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        p2@primary
-·     spans        -/5/#
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         p2@primary
+·     spans         -/5/#
 
 # From the interleaved index: no tightening at all.
 
@@ -280,91 +280,91 @@ scan  ·            ·
 query TTT
 EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d >= 2
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        p2@p2_id
-·     spans        /1/#/55/2/2-
-·     filter       d >= 2
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         p2@p2_id
+·     spans         /1/#/55/2/2-
+·     filter        d >= 2
 
 # Upper bound (i <= 6 AND d <= 5)
 
 query TTT
 EXPLAIN SELECT * FROM p2@p2_id WHERE i <= 6 AND d <= 5
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        p2@p2_id
-·     spans        -/6/#/55/2/6
-·     filter       d <= 5
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         p2@p2_id
+·     spans         -/6/#/55/2/6
+·     filter        d <= 5
 
 # IS NULL
 
 query TTT
 EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NULL
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        p2@p2_id
-·     spans        /1/#/55/2/NULL-
-·     filter       d IS NULL
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         p2@p2_id
+·     spans         /1/#/55/2/NULL-
+·     filter        d IS NULL
 
 # IS NOT NULL
 
 query TTT
 EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NOT NULL
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        p2@p2_id
-·     spans        /1/#/55/2/!NULL-
-·     filter       d IS NOT NULL
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         p2@p2_id
+·     spans         /1/#/55/2/!NULL-
+·     filter        d IS NOT NULL
 
 # String table
 
 query TTT colnames
 EXPLAIN SELECT * FROM bytes_t WHERE a = 'a'
 ----
-tree  field        description
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        bytes_t@primary
-·     spans        /"a"-/"a"/#
+tree  field         description
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         bytes_t@primary
+·     spans         /"a"-/"a"/#
 
 # No tightening.
 
 query TTT colnames
 EXPLAIN SELECT * FROM bytes_t WHERE a < 'aa'
 ----
-tree  field        description
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        bytes_t@primary
-·     spans        -/"aa"
+tree  field         description
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         bytes_t@primary
+·     spans         -/"aa"
 
 query TTT colnames
 EXPLAIN SELECT * FROM decimal_t WHERE a = 1.00
 ----
-tree  field        description
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        decimal_t@primary
-·     spans        /1-/1/#
+tree  field         description
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         decimal_t@primary
+·     spans         /1-/1/#
 
 # No tightening.
 
 query TTT colnames
 EXPLAIN SELECT * FROM decimal_t WHERE a < 2
 ----
-tree  field        description
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        decimal_t@primary
-·     spans        -/2
+tree  field         description
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         decimal_t@primary
+·     spans         -/2

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -3,35 +3,35 @@
 query TTT colnames
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE FALSE
 ----
-tree    field        description
-·       distributed  false
-·       vectorized   true
-norows  ·            ·
+tree    field         description
+·       distribution  local
+·       vectorized    true
+norows  ·             ·
 
 query TTT colnames
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE NULL
 ----
-tree    field        description
-·       distributed  false
-·       vectorized   true
-norows  ·            ·
+tree    field         description
+·       distribution  local
+·       vectorized    true
+norows  ·             ·
 
 query TTT colnames
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE TRUE
 ----
-tree       field        description
-·          distributed  false
-·          vectorized   true
-render     ·            ·
- └── scan  ·            ·
-·          table        jobs@jobs_status_created_idx
-·          spans        FULL SCAN
+tree       field         description
+·          distribution  local
+·          vectorized    true
+render     ·             ·
+ └── scan  ·             ·
+·          table         jobs@jobs_status_created_idx
+·          spans         FULL SCAN
 
 query TTTTT colnames
 EXPLAIN (PLAN, VERBOSE) SELECT 1 a
 ----
 tree    field          description      columns  ordering
-·       distributed    false            ·        ·
+·       distribution   local            ·        ·
 ·       vectorized     false            ·        ·
 values  ·              ·                (a)      ·
 ·       size           1 column, 1 row  ·        ·
@@ -41,7 +41,7 @@ query TTTTT colnames
 EXPLAIN (VERBOSE,PLAN) SELECT 1 a
 ----
 tree    field          description      columns  ordering
-·       distributed    false            ·        ·
+·       distribution   local            ·        ·
 ·       vectorized     false            ·        ·
 values  ·              ·                (a)      ·
 ·       size           1 column, 1 row  ·        ·
@@ -52,7 +52,7 @@ query TTTTT colnames
 EXPLAIN (TYPES) SELECT 1 a
 ----
 tree    field          description      columns  ordering
-·       distributed    false            ·        ·
+·       distribution   local            ·        ·
 ·       vectorized     false            ·        ·
 values  ·              ·                (a int)  ·
 ·       size           1 column, 1 row  ·        ·
@@ -84,16 +84,16 @@ EXPLAIN (TYPES) SELECT $1
 query TTT
 EXPLAIN CREATE DATABASE foo
 ----
-·                distributed  false
-·                vectorized   false
-create database  ·            ·
+·                distribution  local
+·                vectorized    false
+create database  ·             ·
 
 query TTT
 EXPLAIN CREATE TABLE foo (x INT)
 ----
-·             distributed  false
-·             vectorized   false
-create table  ·            ·
+·             distribution  local
+·             vectorized    false
+create table  ·             ·
 
 statement ok
 CREATE TABLE foo (x INT)
@@ -101,9 +101,9 @@ CREATE TABLE foo (x INT)
 query TTT
 EXPLAIN CREATE INDEX a ON foo(x)
 ----
-·             distributed  false
-·             vectorized   false
-create index  ·            ·
+·             distribution  local
+·             vectorized    false
+create index  ·             ·
 
 statement ok
 CREATE DATABASE foo
@@ -111,9 +111,9 @@ CREATE DATABASE foo
 query TTT
 EXPLAIN DROP DATABASE foo
 ----
-·              distributed  false
-·              vectorized   false
-drop database  ·            ·
+·              distribution  local
+·              vectorized    false
+drop database  ·             ·
 
 # explain SHOW JOBS - beware to test this before the CREATE INDEX
 # below, otherwise the result becomes non-deterministic.
@@ -121,17 +121,17 @@ drop database  ·            ·
 query TTT
 SELECT * FROM [EXPLAIN SHOW JOBS] WHERE field != 'size'
 ----
-·                                       distributed  false
-·                                       vectorized   false
-render                                  ·            ·
- └── sort                               ·            ·
-      │                                 order        -column18,-started
-      └── render                        ·            ·
-           └── filter                   ·            ·
-                │                       filter       ((job_type IS NULL) OR (job_type != 'AUTO CREATE STATS')) AND ((finished IS NULL) OR (finished > (now() - '12:00:00')))
-                └── render              ·            ·
-                     └── virtual table  ·            ·
-·                                       source       jobs@primary
+·                                       distribution  local
+·                                       vectorized    false
+render                                  ·             ·
+ └── sort                               ·             ·
+      │                                 order         -column18,-started
+      └── render                        ·             ·
+           └── filter                   ·             ·
+                │                       filter        ((job_type IS NULL) OR (job_type != 'AUTO CREATE STATS')) AND ((finished IS NULL) OR (finished > (now() - '12:00:00')))
+                └── render              ·             ·
+                     └── virtual table  ·             ·
+·                                       source        jobs@primary
 
 statement ok
 CREATE INDEX a ON foo(x)
@@ -139,21 +139,21 @@ CREATE INDEX a ON foo(x)
 query TTT
 EXPLAIN DROP INDEX foo@a
 ----
-·           distributed  false
-·           vectorized   false
-drop index  ·            ·
+·           distribution  local
+·           vectorized    false
+drop index  ·             ·
 
 query TTT
 EXPLAIN ALTER TABLE foo ADD COLUMN y INT
 ----
-·            distributed  false
-·            vectorized   false
-alter table  ·            ·
+·            distribution  local
+·            vectorized    false
+alter table  ·             ·
 
 query TTT
 SELECT tree, field, description FROM [EXPLAIN (VERBOSE) ALTER TABLE foo SPLIT AT VALUES (42)]
 ----
-·            distributed    false
+·            distribution   local
 ·            vectorized     false
 split        ·              ·
  └── values  ·              ·
@@ -163,238 +163,238 @@ split        ·              ·
 query TTT
 EXPLAIN DROP TABLE foo
 ----
-·           distributed  false
-·           vectorized   false
-drop table  ·            ·
+·           distribution  local
+·           vectorized    false
+drop table  ·             ·
 
 query TTT
 EXPLAIN SHOW DATABASES
 ----
-·                        distributed  false
-·                        vectorized   false
-sort                     ·            ·
- │                       order        +database_name
- └── render              ·            ·
-      └── virtual table  ·            ·
-·                        source       databases@primary
+·                        distribution  local
+·                        vectorized    false
+sort                     ·             ·
+ │                       order         +database_name
+ └── render              ·             ·
+      └── virtual table  ·             ·
+·                        source        databases@primary
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW TABLES] WHERE field != 'size'
 ----
-·                                            distributed  false
-·                                            vectorized   false
-render                                       ·            ·
- └── sort                                    ·            ·
-      │                                      order        +nspname,+relname
-      └── render                             ·            ·
-           └── hash-join                     ·            ·
-                │                            type         inner
-                │                            equality     (oid) = (relnamespace)
-                ├── filter                   ·            ·
-                │    │                       filter       nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog', 'pg_extension')
-                │    └── render              ·            ·
-                │         └── virtual table  ·            ·
-                │                            source       pg_namespace@primary
-                └── filter                   ·            ·
-                     │                       filter       relkind IN ('S', 'r', 'v')
-                     └── render              ·            ·
-                          └── virtual table  ·            ·
-·                                            source       pg_class@primary
+·                                            distribution  local
+·                                            vectorized    false
+render                                       ·             ·
+ └── sort                                    ·             ·
+      │                                      order         +nspname,+relname
+      └── render                             ·             ·
+           └── hash-join                     ·             ·
+                │                            type          inner
+                │                            equality      (oid) = (relnamespace)
+                ├── filter                   ·             ·
+                │    │                       filter        nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog', 'pg_extension')
+                │    └── render              ·             ·
+                │         └── virtual table  ·             ·
+                │                            source        pg_namespace@primary
+                └── filter                   ·             ·
+                     │                       filter        relkind IN ('S', 'r', 'v')
+                     └── render              ·             ·
+                          └── virtual table  ·             ·
+·                                            source        pg_class@primary
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW TABLES WITH COMMENT] WHERE field != 'size'
 ----
-·                                                 distributed  false
-·                                                 vectorized   false
-render                                            ·            ·
- └── sort                                         ·            ·
-      │                                           order        +nspname,+relname
-      └── render                                  ·            ·
-           └── hash-join                          ·            ·
-                │                                 type         left outer
-                │                                 equality     (oid) = (objoid)
-                ├── hash-join                     ·            ·
-                │    │                            type         inner
-                │    │                            equality     (oid) = (relnamespace)
-                │    ├── filter                   ·            ·
-                │    │    │                       filter       nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog', 'pg_extension')
-                │    │    └── render              ·            ·
-                │    │         └── virtual table  ·            ·
-                │    │                            source       pg_namespace@primary
-                │    └── filter                   ·            ·
-                │         │                       filter       relkind IN ('S', 'r', 'v')
-                │         └── render              ·            ·
-                │              └── virtual table  ·            ·
-                │                                 source       pg_class@primary
-                └── filter                        ·            ·
-                     │                            filter       objsubid = 0
-                     └── render                   ·            ·
-                          └── virtual table       ·            ·
-·                                                 source       pg_description@primary
+·                                                 distribution  local
+·                                                 vectorized    false
+render                                            ·             ·
+ └── sort                                         ·             ·
+      │                                           order         +nspname,+relname
+      └── render                                  ·             ·
+           └── hash-join                          ·             ·
+                │                                 type          left outer
+                │                                 equality      (oid) = (objoid)
+                ├── hash-join                     ·             ·
+                │    │                            type          inner
+                │    │                            equality      (oid) = (relnamespace)
+                │    ├── filter                   ·             ·
+                │    │    │                       filter        nspname NOT IN ('crdb_internal', 'information_schema', 'pg_catalog', 'pg_extension')
+                │    │    └── render              ·             ·
+                │    │         └── virtual table  ·             ·
+                │    │                            source        pg_namespace@primary
+                │    └── filter                   ·             ·
+                │         │                       filter        relkind IN ('S', 'r', 'v')
+                │         └── render              ·             ·
+                │              └── virtual table  ·             ·
+                │                                 source        pg_class@primary
+                └── filter                        ·             ·
+                     │                            filter        objsubid = 0
+                     └── render                   ·             ·
+                          └── virtual table       ·             ·
+·                                                 source        pg_description@primary
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW DATABASE] WHERE field != 'size'
 ----
-·                             distributed  false
-·                             vectorized   false
-render                        ·            ·
- └── filter                   ·            ·
-      │                       filter       variable = 'database'
-      └── render              ·            ·
-           └── virtual table  ·            ·
-·                             source       session_variables@primary
+·                             distribution  local
+·                             vectorized    false
+render                        ·             ·
+ └── filter                   ·             ·
+      │                       filter        variable = 'database'
+      └── render              ·             ·
+           └── virtual table  ·             ·
+·                             source        session_variables@primary
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW TIME ZONE] WHERE field != 'size'
 ----
-·                             distributed  false
-·                             vectorized   false
-render                        ·            ·
- └── filter                   ·            ·
-      │                       filter       variable = 'timezone'
-      └── render              ·            ·
-           └── virtual table  ·            ·
-·                             source       session_variables@primary
+·                             distribution  local
+·                             vectorized    false
+render                        ·             ·
+ └── filter                   ·             ·
+      │                       filter        variable = 'timezone'
+      └── render              ·             ·
+           └── virtual table  ·             ·
+·                             source        session_variables@primary
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION] WHERE field != 'size'
 ----
-·                             distributed  false
-·                             vectorized   false
-render                        ·            ·
- └── filter                   ·            ·
-      │                       filter       variable = 'default_transaction_isolation'
-      └── render              ·            ·
-           └── virtual table  ·            ·
-·                             source       session_variables@primary
+·                             distribution  local
+·                             vectorized    false
+render                        ·             ·
+ └── filter                   ·             ·
+      │                       filter        variable = 'default_transaction_isolation'
+      └── render              ·             ·
+           └── virtual table  ·             ·
+·                             source        session_variables@primary
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW DEFAULT_TRANSACTION_PRIORITY] WHERE field != 'size'
 ----
-·                             distributed  false
-·                             vectorized   false
-render                        ·            ·
- └── filter                   ·            ·
-      │                       filter       variable = 'default_transaction_priority'
-      └── render              ·            ·
-           └── virtual table  ·            ·
-·                             source       session_variables@primary
+·                             distribution  local
+·                             vectorized    false
+render                        ·             ·
+ └── filter                   ·             ·
+      │                       filter        variable = 'default_transaction_priority'
+      └── render              ·             ·
+           └── virtual table  ·             ·
+·                             source        session_variables@primary
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW TRANSACTION ISOLATION LEVEL] WHERE field != 'size'
 ----
-·                             distributed  false
-·                             vectorized   false
-render                        ·            ·
- └── filter                   ·            ·
-      │                       filter       variable = 'transaction_isolation'
-      └── render              ·            ·
-           └── virtual table  ·            ·
-·                             source       session_variables@primary
+·                             distribution  local
+·                             vectorized    false
+render                        ·             ·
+ └── filter                   ·             ·
+      │                       filter        variable = 'transaction_isolation'
+      └── render              ·             ·
+           └── virtual table  ·             ·
+·                             source        session_variables@primary
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW TRANSACTION PRIORITY] WHERE field != 'size'
 ----
-·                             distributed  false
-·                             vectorized   false
-render                        ·            ·
- └── filter                   ·            ·
-      │                       filter       variable = 'transaction_priority'
-      └── render              ·            ·
-           └── virtual table  ·            ·
-·                             source       session_variables@primary
+·                             distribution  local
+·                             vectorized    false
+render                        ·             ·
+ └── filter                   ·             ·
+      │                       filter        variable = 'transaction_priority'
+      └── render              ·             ·
+           └── virtual table  ·             ·
+·                             source        session_variables@primary
 
 query TTT
 EXPLAIN SHOW COLUMNS FROM foo
 ----
-·                                                 distributed  false
-·                                                 vectorized   false
-render                                            ·            ·
- └── group                                        ·            ·
-      │                                           aggregate 0  column_name
-      │                                           aggregate 1  ordinal_position
-      │                                           aggregate 2  column_default
-      │                                           aggregate 3  is_nullable
-      │                                           aggregate 4  generation_expression
-      │                                           aggregate 5  is_hidden
-      │                                           aggregate 6  crdb_sql_type
-      │                                           aggregate 7  array_agg(index_name)
-      │                                           group by     column_name, ordinal_position, column_default, is_nullable, generation_expression, is_hidden, crdb_sql_type
-      │                                           ordered      +ordinal_position
-      └── render                                  ·            ·
-           └── sort                               ·            ·
-                │                                 order        +ordinal_position
-                └── hash-join                     ·            ·
-                     │                            type         left outer
-                     │                            equality     (column_name) = (column_name)
-                     ├── filter                   ·            ·
-                     │    │                       filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
-                     │    └── render              ·            ·
-                     │         └── virtual table  ·            ·
-                     │                            source       columns@primary
-                     └── filter                   ·            ·
-                          │                       filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
-                          └── render              ·            ·
-                               └── virtual table  ·            ·
-·                                                 source       statistics@primary
+·                                                 distribution  local
+·                                                 vectorized    false
+render                                            ·             ·
+ └── group                                        ·             ·
+      │                                           aggregate 0   column_name
+      │                                           aggregate 1   ordinal_position
+      │                                           aggregate 2   column_default
+      │                                           aggregate 3   is_nullable
+      │                                           aggregate 4   generation_expression
+      │                                           aggregate 5   is_hidden
+      │                                           aggregate 6   crdb_sql_type
+      │                                           aggregate 7   array_agg(index_name)
+      │                                           group by      column_name, ordinal_position, column_default, is_nullable, generation_expression, is_hidden, crdb_sql_type
+      │                                           ordered       +ordinal_position
+      └── render                                  ·             ·
+           └── sort                               ·             ·
+                │                                 order         +ordinal_position
+                └── hash-join                     ·             ·
+                     │                            type          left outer
+                     │                            equality      (column_name) = (column_name)
+                     ├── filter                   ·             ·
+                     │    │                       filter        ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
+                     │    └── render              ·             ·
+                     │         └── virtual table  ·             ·
+                     │                            source        columns@primary
+                     └── filter                   ·             ·
+                          │                       filter        ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
+                          └── render              ·             ·
+                               └── virtual table  ·             ·
+·                                                 source        statistics@primary
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW GRANTS ON foo] WHERE field != 'size'
 ----
-·                                  distributed  false
-·                                  vectorized   false
-render                             ·            ·
- └── sort                          ·            ·
-      │                            order        +grantee,+privilege_type
-      └── filter                   ·            ·
-           │                       filter       (table_catalog, table_schema, table_name) IN (('test', 'public', 'foo'),)
-           └── render              ·            ·
-                └── virtual table  ·            ·
-·                                  source       table_privileges@primary
+·                                  distribution  local
+·                                  vectorized    false
+render                             ·             ·
+ └── sort                          ·             ·
+      │                            order         +grantee,+privilege_type
+      └── filter                   ·             ·
+           │                       filter        (table_catalog, table_schema, table_name) IN (('test', 'public', 'foo'),)
+           └── render              ·             ·
+                └── virtual table  ·             ·
+·                                  source        table_privileges@primary
 
 query TTT
 EXPLAIN SHOW INDEX FROM foo
 ----
-·                             distributed  false
-·                             vectorized   false
-render                        ·            ·
- └── filter                   ·            ·
-      │                       filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
-      └── render              ·            ·
-           └── virtual table  ·            ·
-·                             source       statistics@primary
+·                             distribution  local
+·                             vectorized    false
+render                        ·             ·
+ └── filter                   ·             ·
+      │                       filter        ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
+      └── render              ·             ·
+           └── virtual table  ·             ·
+·                             source        statistics@primary
 
 query TTT
 EXPLAIN SHOW CONSTRAINTS FROM foo
 ----
-·                                                 distributed  false
-·                                                 vectorized   false
-render                                            ·            ·
- └── sort                                         ·            ·
-      │                                           order        +conname
-      └── render                                  ·            ·
-           └── hash-join                          ·            ·
-                │                                 type         inner
-                │                                 equality     (oid) = (relnamespace)
-                ├── filter                        ·            ·
-                │    │                            filter       nspname = 'public'
-                │    └── render                   ·            ·
-                │         └── virtual table       ·            ·
-                │                                 source       pg_namespace@primary
-                └── virtual-table-lookup-join     ·            ·
-                     │                            table        pg_constraint@pg_constraint_conrelid_idx
-                     │                            type         inner
-                     │                            equality     (oid) = (conrelid)
-                     └── filter                   ·            ·
-                          │                       filter       relname = 'foo'
-                          └── render              ·            ·
-                               └── virtual table  ·            ·
-·                                                 source       pg_class@primary
+·                                                 distribution  local
+·                                                 vectorized    false
+render                                            ·             ·
+ └── sort                                         ·             ·
+      │                                           order         +conname
+      └── render                                  ·             ·
+           └── hash-join                          ·             ·
+                │                                 type          inner
+                │                                 equality      (oid) = (relnamespace)
+                ├── filter                        ·             ·
+                │    │                            filter        nspname = 'public'
+                │    └── render                   ·             ·
+                │         └── virtual table       ·             ·
+                │                                 source        pg_namespace@primary
+                └── virtual-table-lookup-join     ·             ·
+                     │                            table         pg_constraint@pg_constraint_conrelid_idx
+                     │                            type          inner
+                     │                            equality      (oid) = (conrelid)
+                     └── filter                   ·             ·
+                          │                       filter        relname = 'foo'
+                          └── render              ·             ·
+                               └── virtual table  ·             ·
+·                                                 source        pg_class@primary
 
 query TTT
 EXPLAIN SHOW USERS
 ----
-·                                                                  distributed        false
+·                                                                  distribution       local
 ·                                                                  vectorized         true
 render                                                             ·                  ·
  └── sort                                                          ·                  ·
@@ -442,20 +442,20 @@ CREATE SEQUENCE select_test
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM select_test
 ----
-tree             field        description  columns                           ordering
-·                distributed  false        ·                                 ·
-·                vectorized   false        ·                                 ·
-sequence select  ·            ·            (last_value, log_cnt, is_called)  ·
+tree             field         description  columns                           ordering
+·                distribution  local        ·                                 ·
+·                vectorized    false        ·                                 ·
+sequence select  ·             ·            (last_value, log_cnt, is_called)  ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT @1 FROM select_test
 ----
-tree                  field        description  columns                           ordering
-·                     distributed  false        ·                                 ·
-·                     vectorized   false        ·                                 ·
-render                ·            ·            ("?column?")                      ·
- │                    render 0     last_value   ·                                 ·
- └── sequence select  ·            ·            (last_value, log_cnt, is_called)  ·
+tree                  field         description  columns                           ordering
+·                     distribution  local        ·                                 ·
+·                     vectorized    false        ·                                 ·
+render                ·             ·            ("?column?")                      ·
+ │                    render 0      last_value   ·                                 ·
+ └── sequence select  ·             ·            (last_value, log_cnt, is_called)  ·
 
 statement ok
 CREATE TABLE t (
@@ -467,14 +467,14 @@ CREATE TABLE t (
 query TTT
 EXPLAIN INSERT INTO t VALUES (1, 2)
 ----
-·                      distributed  false
-·                      vectorized   false
-count                  ·            ·
- └── insert-fast-path  ·            ·
-·                      into         t(k, v)
-·                      strategy     inserter
-·                      auto commit  ·
-·                      size         2 columns, 1 row
+·                      distribution  local
+·                      vectorized    false
+count                  ·             ·
+ └── insert-fast-path  ·             ·
+·                      into          t(k, v)
+·                      strategy      inserter
+·                      auto commit   ·
+·                      size          2 columns, 1 row
 
 query I
 SELECT max(level) FROM [EXPLAIN (VERBOSE) INSERT INTO t VALUES (1, 2)]
@@ -487,30 +487,30 @@ INSERT INTO t VALUES (1, 2)
 query TTT
 EXPLAIN SELECT * FROM t
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        t@primary
-·     spans        FULL SCAN
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         t@primary
+·     spans         FULL SCAN
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t
 ----
-·     distributed  false      ·       ·
-·     vectorized   true       ·       ·
-scan  ·            ·          (k, v)  ·
-·     table        t@primary  ·       ·
-·     spans        FULL SCAN  ·       ·
+·     distribution  local      ·       ·
+·     vectorized    true       ·       ·
+scan  ·             ·          (k, v)  ·
+·     table         t@primary  ·       ·
+·     spans         FULL SCAN  ·       ·
 
 query TTT
 EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        t@primary
-·     spans        /1-/1/# /3-/3/#
-·     parallel     ·
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         t@primary
+·     spans         /1-/1/# /3-/3/#
+·     parallel      ·
 
 statement ok
 CREATE TABLE t2 (x INT PRIMARY KEY)
@@ -518,7 +518,7 @@ CREATE TABLE t2 (x INT PRIMARY KEY)
 query TTT
 EXPLAIN (PLAN) SELECT * FROM t INNER LOOKUP JOIN t2 ON t.k = t2.x
 ----
-·            distributed            false
+·            distribution           local
 ·            vectorized             true
 lookup-join  ·                      ·
  │           table                  t2@primary
@@ -533,67 +533,67 @@ lookup-join  ·                      ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE k % 2 = 0
 ----
-·     distributed  false        ·       ·
-·     vectorized   true         ·       ·
-scan  ·            ·            (k, v)  ·
-·     table        t@primary    ·       ·
-·     spans        FULL SCAN    ·       ·
-·     filter       (k % 2) = 0  ·       ·
+·     distribution  local        ·       ·
+·     vectorized    true         ·       ·
+scan  ·             ·            (k, v)  ·
+·     table         t@primary    ·       ·
+·     spans         FULL SCAN    ·       ·
+·     filter        (k % 2) = 0  ·       ·
 
 query TTT
 EXPLAIN VALUES (1, 2, 3), (4, 5, 6)
 ----
-·       distributed  false
-·       vectorized   false
-values  ·            ·
-·       size         3 columns, 2 rows
+·       distribution  local
+·       vectorized    false
+values  ·             ·
+·       size          3 columns, 2 rows
 
 query TTT
 EXPLAIN VALUES (1)
 ----
-·       distributed  false
-·       vectorized   false
-values  ·            ·
-·       size         1 column, 1 row
+·       distribution  local
+·       vectorized    false
+values  ·             ·
+·       size          1 column, 1 row
 
 query TTT
 SELECT tree, field, description FROM [EXPLAIN (VERBOSE) SELECT * FROM t WITH ORDINALITY LIMIT 1 OFFSET 1]
 ----
-·                distributed  false
-·                vectorized   true
-limit            ·            ·
- │               offset       1
- └── ordinality  ·            ·
-      └── scan   ·            ·
-·                table        t@primary
-·                spans        LIMITED SCAN
-·                limit        2
+·                distribution  local
+·                vectorized    true
+limit            ·             ·
+ │               offset        1
+ └── ordinality  ·             ·
+      └── scan   ·             ·
+·                table         t@primary
+·                spans         LIMITED SCAN
+·                limit         2
 
 query TTT
 EXPLAIN SELECT DISTINCT v FROM t
 ----
-·          distributed  false
-·          vectorized   true
-distinct   ·            ·
- │         distinct on  v
- └── scan  ·            ·
-·          table        t@primary
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+distinct   ·             ·
+ │         distinct on   v
+ └── scan  ·             ·
+·          table         t@primary
+·          spans         FULL SCAN
 
 query TTT
 SELECT tree, field, description FROM [EXPLAIN (VERBOSE) SELECT DISTINCT v FROM t LIMIT 1 OFFSET 1]
 ----
-·                    distributed  false
-·                    vectorized   true
-limit                ·            ·
- │                   offset       1
- └── limit           ·            ·
-      │              count        2
-      └── distinct   ·            ·
-           │         distinct on  v
-           └── scan  ·            ·
-·                    table        t@primary
-·                    spans        FULL SCAN
+·                    distribution  local
+·                    vectorized    true
+limit                ·             ·
+ │                   offset        1
+ └── limit           ·             ·
+      │              count         2
+      └── distinct   ·             ·
+           │         distinct on   v
+           └── scan  ·             ·
+·                    table         t@primary
+·                    spans         FULL SCAN
 
 statement ok
 CREATE TABLE tc (a INT, b INT, INDEX c(a), FAMILY "primary" (a, b, rowid))
@@ -601,22 +601,22 @@ CREATE TABLE tc (a INT, b INT, INDEX c(a), FAMILY "primary" (a, b, rowid))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM tc WHERE a = 10 ORDER BY b
 ----
-·                distributed  false       ·                   ·
-·                vectorized   true        ·                   ·
-sort             ·            ·           (a, b)              +b
- │               order        +b          ·                   ·
- └── index-join  ·            ·           (a, b)              ·
-      │          table        tc@primary  ·                   ·
-      │          key columns  rowid       ·                   ·
-      └── scan   ·            ·           (a, rowid[hidden])  ·
-·                table        tc@c        ·                   ·
-·                spans        /10-/11     ·                   ·
+·                distribution  local       ·                   ·
+·                vectorized    true        ·                   ·
+sort             ·             ·           (a, b)              +b
+ │               order         +b          ·                   ·
+ └── index-join  ·             ·           (a, b)              ·
+      │          table         tc@primary  ·                   ·
+      │          key columns   rowid       ·                   ·
+      └── scan   ·             ·           (a, rowid[hidden])  ·
+·                table         tc@c        ·                   ·
+·                spans         /10-/11     ·                   ·
 
 query TTTTT colnames
 EXPLAIN (TYPES) INSERT INTO t VALUES (1, 2)
 ----
 tree                   field          description       columns  ordering
-·                      distributed    false             ·        ·
+·                      distribution   local             ·        ·
 ·                      vectorized     false             ·        ·
 count                  ·              ·                 ()       ·
  └── insert-fast-path  ·              ·                 ()       ·
@@ -630,7 +630,7 @@ count                  ·              ·                 ()       ·
 query TTTTT
 EXPLAIN (TYPES) SELECT 42 AS a
 ----
-·       distributed    false            ·        ·
+·       distribution   local            ·        ·
 ·       vectorized     false            ·        ·
 values  ·              ·                (a int)  ·
 ·       size           1 column, 1 row  ·        ·
@@ -639,44 +639,44 @@ values  ·              ·                (a int)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM t
 ----
-·     distributed  false      ·               ·
-·     vectorized   true       ·               ·
-scan  ·            ·          (k int, v int)  ·
-·     table        t@primary  ·               ·
-·     spans        FULL SCAN  ·               ·
+·     distribution  local      ·               ·
+·     vectorized    true       ·               ·
+scan  ·             ·          (k int, v int)  ·
+·     table         t@primary  ·               ·
+·     spans         FULL SCAN  ·               ·
 
 query TTTTT
 EXPLAIN (TYPES,SYMVARS) SELECT k FROM t
 ----
-·     distributed  false      ·        ·
-·     vectorized   true       ·        ·
-scan  ·            ·          (k int)  ·
-·     table        t@primary  ·        ·
-·     spans        FULL SCAN  ·        ·
+·     distribution  local      ·        ·
+·     vectorized    true       ·        ·
+scan  ·             ·          (k int)  ·
+·     table         t@primary  ·        ·
+·     spans         FULL SCAN  ·        ·
 
 query TTTTT
 EXPLAIN (TYPES,VERBOSE) SELECT k FROM t
 ----
-·     distributed  false      ·        ·
-·     vectorized   true       ·        ·
-scan  ·            ·          (k int)  ·
-·     table        t@primary  ·        ·
-·     spans        FULL SCAN  ·        ·
+·     distribution  local      ·        ·
+·     vectorized    true       ·        ·
+scan  ·             ·          (k int)  ·
+·     table         t@primary  ·        ·
+·     spans         FULL SCAN  ·        ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM t WHERE v > 123
 ----
-·     distributed  false                          ·               ·
-·     vectorized   true                           ·               ·
-scan  ·            ·                              (k int, v int)  ·
-·     table        t@primary                      ·               ·
-·     spans        FULL SCAN                      ·               ·
-·     filter       ((v)[int] > (123)[int])[bool]  ·               ·
+·     distribution  local                          ·               ·
+·     vectorized    true                           ·               ·
+scan  ·             ·                              (k int, v int)  ·
+·     table         t@primary                      ·               ·
+·     spans         FULL SCAN                      ·               ·
+·     filter        ((v)[int] > (123)[int])[bool]  ·               ·
 
 query TTTTT
 EXPLAIN (TYPES) VALUES (1, 2, 3), (4, 5, 6)
 ----
-·       distributed    false              ·                                        ·
+·       distribution   local              ·                                        ·
 ·       vectorized     false              ·                                        ·
 values  ·              ·                  (column1 int, column2 int, column3 int)  ·
 ·       size           3 columns, 2 rows  ·                                        ·
@@ -690,54 +690,54 @@ values  ·              ·                  (column1 int, column2 int, column3 i
 query TTTTT
 EXPLAIN (TYPES) SELECT 2*count(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2 AND count(k)>1
 ----
-·            distributed  false     ·               ·
-·            vectorized   true      ·               ·
-render       ·            ·         (z int, v int)  ·
- │           render 0     (z)[int]  ·               ·
- │           render 1     (v)[int]  ·               ·
- └── norows  ·            ·         (v int, z int)  ·
+·            distribution  local     ·               ·
+·            vectorized    true      ·               ·
+render       ·             ·         (z int, v int)  ·
+ │           render 0      (z)[int]  ·               ·
+ │           render 1      (v)[int]  ·               ·
+ └── norows  ·             ·         (v int, z int)  ·
 
 query TTTTT
 EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
 ----
-·                    distributed  false                        ·               ·
-·                    vectorized   false                        ·               ·
-count                ·            ·                            ()              ·
- └── delete          ·            ·                            ()              ·
-      │              from         t                            ·               ·
-      │              strategy     deleter                      ·               ·
-      │              auto commit  ·                            ·               ·
-      └── render     ·            ·                            (k int)         ·
-           │         render 0     (k)[int]                     ·               ·
-           └── scan  ·            ·                            (k int, v int)  ·
-·                    table        t@primary                    ·               ·
-·                    spans        FULL SCAN                    ·               ·
-·                    filter       ((v)[int] > (1)[int])[bool]  ·               ·
+·                    distribution  local                        ·               ·
+·                    vectorized    false                        ·               ·
+count                ·             ·                            ()              ·
+ └── delete          ·             ·                            ()              ·
+      │              from          t                            ·               ·
+      │              strategy      deleter                      ·               ·
+      │              auto commit   ·                            ·               ·
+      └── render     ·             ·                            (k int)         ·
+           │         render 0      (k)[int]                     ·               ·
+           └── scan  ·             ·                            (k int, v int)  ·
+·                    table         t@primary                    ·               ·
+·                    spans         FULL SCAN                    ·               ·
+·                    filter        ((v)[int] > (1)[int])[bool]  ·               ·
 
 query TTTTT
 EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123
 ----
-·                    distributed  false                          ·                          ·
-·                    vectorized   false                          ·                          ·
-count                ·            ·                              ()                         ·
- └── update          ·            ·                              ()                         ·
-      │              table        t                              ·                          ·
-      │              set          v                              ·                          ·
-      │              strategy     updater                        ·                          ·
-      │              auto commit  ·                              ·                          ·
-      └── render     ·            ·                              (k int, v int, v_new int)  ·
-           │         render 0     (k)[int]                       ·                          ·
-           │         render 1     (v)[int]                       ·                          ·
-           │         render 2     ((k)[int] + (1)[int])[int]     ·                          ·
-           └── scan  ·            ·                              (k int, v int)             ·
-·                    table        t@primary                      ·                          ·
-·                    spans        FULL SCAN                      ·                          ·
-·                    filter       ((v)[int] > (123)[int])[bool]  ·                          ·
+·                    distribution  local                          ·                          ·
+·                    vectorized    false                          ·                          ·
+count                ·             ·                              ()                         ·
+ └── update          ·             ·                              ()                         ·
+      │              table         t                              ·                          ·
+      │              set           v                              ·                          ·
+      │              strategy      updater                        ·                          ·
+      │              auto commit   ·                              ·                          ·
+      └── render     ·             ·                              (k int, v int, v_new int)  ·
+           │         render 0      (k)[int]                       ·                          ·
+           │         render 1      (v)[int]                       ·                          ·
+           │         render 2      ((k)[int] + (1)[int])[int]     ·                          ·
+           └── scan  ·             ·                              (k int, v int)             ·
+·                    table         t@primary                      ·                          ·
+·                    spans         FULL SCAN                      ·                          ·
+·                    filter        ((v)[int] > (123)[int])[bool]  ·                          ·
 
 query TTTTT
 EXPLAIN (TYPES) VALUES (1) UNION VALUES (2)
 ----
-·            distributed    false            ·              ·
+·            distribution   local            ·              ·
 ·            vectorized     false            ·              ·
 union        ·              ·                (column1 int)  ·
  ├── values  ·              ·                (column1 int)  ·
@@ -750,32 +750,32 @@ union        ·              ·                (column1 int)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT DISTINCT k FROM t
 ----
-·     distributed  false      ·        ·
-·     vectorized   true       ·        ·
-scan  ·            ·          (k int)  ·
-·     table        t@primary  ·        ·
-·     spans        FULL SCAN  ·        ·
+·     distribution  local      ·        ·
+·     vectorized    true       ·        ·
+scan  ·             ·          (k int)  ·
+·     table         t@primary  ·        ·
+·     spans         FULL SCAN  ·        ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT v FROM t ORDER BY v
 ----
-·          distributed  false      ·        ·
-·          vectorized   true       ·        ·
-sort       ·            ·          (v int)  +v
- │         order        +v         ·        ·
- └── scan  ·            ·          (v int)  ·
-·          table        t@primary  ·        ·
-·          spans        FULL SCAN  ·        ·
+·          distribution  local      ·        ·
+·          vectorized    true       ·        ·
+sort       ·             ·          (v int)  +v
+ │         order         +v         ·        ·
+ └── scan  ·             ·          (v int)  ·
+·          table         t@primary  ·        ·
+·          spans         FULL SCAN  ·        ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT v FROM t LIMIT 1
 ----
-·     distributed  false         ·        ·
-·     vectorized   true          ·        ·
-scan  ·            ·             (v int)  ·
-·     table        t@primary     ·        ·
-·     spans        LIMITED SCAN  ·        ·
-·     limit        1             ·        ·
+·     distribution  local         ·        ·
+·     vectorized    true          ·        ·
+scan  ·             ·             (v int)  ·
+·     table         t@primary     ·        ·
+·     spans         LIMITED SCAN  ·        ·
+·     limit         1             ·        ·
 
 statement ok
 CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
@@ -783,12 +783,12 @@ CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
-·     distributed  false                                                                      ·               ·
-·     vectorized   true                                                                       ·               ·
-scan  ·            ·                                                                          (x int, y int)  ·
-·     table        tt@primary                                                                 ·               ·
-·     spans        FULL SCAN                                                                  ·               ·
-·     filter       ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]  ·               ·
+·     distribution  local                                                                      ·               ·
+·     vectorized    true                                                                       ·               ·
+scan  ·             ·                                                                          (x int, y int)  ·
+·     table         tt@primary                                                                 ·               ·
+·     spans         FULL SCAN                                                                  ·               ·
+·     filter        ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]  ·               ·
 
 # TODO(radu): we don't support placeholders with no values.
 #query TTTTT
@@ -801,7 +801,7 @@ scan  ·            ·                                                          
 query TTTTT
 EXPLAIN (TYPES) SELECT abs(2-3) AS a
 ----
-·       distributed    false            ·        ·
+·       distribution   local            ·        ·
 ·       vectorized     false            ·        ·
 values  ·              ·                (a int)  ·
 ·       size           1 column, 1 row  ·        ·
@@ -811,7 +811,7 @@ values  ·              ·                (a int)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT x[1] FROM (SELECT ARRAY[1,2,3] AS x)
 ----
-·       distributed    false            ·        ·
+·       distribution   local            ·        ·
 ·       vectorized     false            ·        ·
 values  ·              ·                (x int)  ·
 ·       size           1 column, 1 row  ·        ·
@@ -1067,23 +1067,23 @@ sort
 query TTT colnames
 EXPLAIN SELECT string_agg(x, y) FROM (VALUES ('foo', 'foo'), ('bar', 'bar')) t(x, y)
 ----
-tree         field        description
-·            distributed  false
-·            vectorized   false
-group        ·            ·
- │           aggregate 0  string_agg(column1, column2)
- │           scalar       ·
- └── values  ·            ·
-·            size         2 columns, 2 rows
+tree         field         description
+·            distribution  local
+·            vectorized    false
+group        ·             ·
+ │           aggregate 0   string_agg(column1, column2)
+ │           scalar        ·
+ └── values  ·             ·
+·            size          2 columns, 2 rows
 
 query TTT
 EXPLAIN SELECT corr(a, b) FROM tc;
 ----
-·          distributed  false
-·          vectorized   true
-group      ·            ·
- │         aggregate 0  corr(a, b)
- │         scalar       ·
- └── scan  ·            ·
-·          table        tc@primary
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+group      ·             ·
+ │         aggregate 0   corr(a, b)
+ │         scalar        ·
+ └── scan  ·             ·
+·          table         tc@primary
+·          spans         FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -34,7 +34,7 @@ WHERE
   t.z IS NULL
 ----
 tree                  field               description
-·                     distributed         false
+·                     distribution        local
 ·                     vectorized          true
 render                ·                   ·
  └── filter           ·                   ·
@@ -65,8 +65,8 @@ FROM
 WHERE
   t.z IS NULL
 ----
-tree         field        description
-·            distributed  false
-·            vectorized   true
-render       ·            ·
- └── norows  ·            ·
+tree         field         description
+·            distribution  local
+·            vectorized    true
+render       ·             ·
+ └── norows  ·             ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk_opt
@@ -18,7 +18,7 @@ CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p), FAMI
 query TTT
 EXPLAIN INSERT INTO child VALUES (1,1), (2,2)
 ----
-·                                          distributed            false
+·                                          distribution           local
 ·                                          vectorized             false
 root                                       ·                      ·
  ├── count                                 ·                      ·
@@ -48,7 +48,7 @@ CREATE TABLE xy (x INT, y INT)
 query TTT
 EXPLAIN INSERT INTO child SELECT x,y FROM xy
 ----
-·                                          distributed         false
+·                                          distribution        local
 ·                                          vectorized          false
 root                                       ·                   ·
  ├── count                                 ·                   ·
@@ -81,7 +81,7 @@ CREATE TABLE child_nullable (c INT PRIMARY KEY, p INT REFERENCES parent(p));
 query TTT
 EXPLAIN INSERT INTO child_nullable VALUES (100, 1), (200, NULL)
 ----
-·                                               distributed            false
+·                                               distribution           local
 ·                                               vectorized             false
 root                                            ·                      ·
  ├── count                                      ·                      ·
@@ -121,7 +121,7 @@ CREATE TABLE multi_col_child  (
 query TTT
 EXPLAIN INSERT INTO multi_col_child VALUES (2, NULL, 20, 20), (3, 20, NULL, 20)
 ----
-·                                               distributed            false
+·                                               distribution           local
 ·                                               vectorized             false
 root                                            ·                      ·
  ├── count                                      ·                      ·
@@ -165,7 +165,7 @@ CREATE TABLE multi_ref_child (
 query TTT
 EXPLAIN INSERT INTO multi_ref_child VALUES (1, NULL, NULL, NULL), (2, 3, 4, 5)
 ----
-·                                               distributed            false
+·                                               distribution           local
 ·                                               vectorized             false
 root                                            ·                      ·
  ├── count                                      ·                      ·
@@ -207,51 +207,51 @@ root                                            ·                      ·
 query TTT
 EXPLAIN INSERT INTO multi_ref_child VALUES (1, NULL, NULL, NULL)
 ----
-·                 distributed  false
-·                 vectorized   false
-count             ·            ·
- └── insert       ·            ·
-      │           into         multi_ref_child(k, a, b, c)
-      │           strategy     inserter
-      │           auto commit  ·
-      └── values  ·            ·
-·                 size         4 columns, 1 row
+·                 distribution  local
+·                 vectorized    false
+count             ·             ·
+ └── insert       ·             ·
+      │           into          multi_ref_child(k, a, b, c)
+      │           strategy      inserter
+      │           auto commit   ·
+      └── values  ·             ·
+·                 size          4 columns, 1 row
 
 # -- Tests with DELETE --
 
 query TTT
 EXPLAIN DELETE FROM parent WHERE p = 3
 ----
-·                                          distributed  false
-·                                          vectorized   false
-root                                       ·            ·
- ├── count                                 ·            ·
- │    └── delete                           ·            ·
- │         │                               from         parent
- │         │                               strategy     deleter
- │         └── buffer node                 ·            ·
- │              │                          label        buffer 1
- │              └── scan                   ·            ·
- │                                         table        parent@primary
- │                                         spans        /3-/3/#
- ├── fk-check                              ·            ·
- │    └── error if rows                    ·            ·
- │         └── lookup-join                 ·            ·
- │              │                          table        child@child_auto_index_fk_p_ref_parent
- │              │                          type         semi
- │              │                          equality     (p) = (p)
- │              └── render                 ·            ·
- │                   └── scan buffer node  ·            ·
- │                                         label        buffer 1
- └── fk-check                              ·            ·
-      └── error if rows                    ·            ·
-           └── lookup-join                 ·            ·
-                │                          table        child_nullable@child_nullable_auto_index_fk_p_ref_parent
-                │                          type         semi
-                │                          equality     (p) = (p)
-                └── render                 ·            ·
-                     └── scan buffer node  ·            ·
-·                                          label        buffer 1
+·                                          distribution  local
+·                                          vectorized    false
+root                                       ·             ·
+ ├── count                                 ·             ·
+ │    └── delete                           ·             ·
+ │         │                               from          parent
+ │         │                               strategy      deleter
+ │         └── buffer node                 ·             ·
+ │              │                          label         buffer 1
+ │              └── scan                   ·             ·
+ │                                         table         parent@primary
+ │                                         spans         /3-/3/#
+ ├── fk-check                              ·             ·
+ │    └── error if rows                    ·             ·
+ │         └── lookup-join                 ·             ·
+ │              │                          table         child@child_auto_index_fk_p_ref_parent
+ │              │                          type          semi
+ │              │                          equality      (p) = (p)
+ │              └── render                 ·             ·
+ │                   └── scan buffer node  ·             ·
+ │                                         label         buffer 1
+ └── fk-check                              ·             ·
+      └── error if rows                    ·             ·
+           └── lookup-join                 ·             ·
+                │                          table         child_nullable@child_nullable_auto_index_fk_p_ref_parent
+                │                          type          semi
+                │                          equality      (p) = (p)
+                └── render                 ·             ·
+                     └── scan buffer node  ·             ·
+·                                          label         buffer 1
 
 statement ok
 CREATE TABLE child2 (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(other))
@@ -259,45 +259,45 @@ CREATE TABLE child2 (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(other))
 query TTT
 EXPLAIN DELETE FROM parent WHERE p = 3
 ----
-·                                          distributed  false
-·                                          vectorized   false
-root                                       ·            ·
- ├── count                                 ·            ·
- │    └── delete                           ·            ·
- │         │                               from         parent
- │         │                               strategy     deleter
- │         └── buffer node                 ·            ·
- │              │                          label        buffer 1
- │              └── scan                   ·            ·
- │                                         table        parent@primary
- │                                         spans        /3-/3/#
- ├── fk-check                              ·            ·
- │    └── error if rows                    ·            ·
- │         └── lookup-join                 ·            ·
- │              │                          table        child@child_auto_index_fk_p_ref_parent
- │              │                          type         semi
- │              │                          equality     (p) = (p)
- │              └── render                 ·            ·
- │                   └── scan buffer node  ·            ·
- │                                         label        buffer 1
- ├── fk-check                              ·            ·
- │    └── error if rows                    ·            ·
- │         └── lookup-join                 ·            ·
- │              │                          table        child_nullable@child_nullable_auto_index_fk_p_ref_parent
- │              │                          type         semi
- │              │                          equality     (p) = (p)
- │              └── render                 ·            ·
- │                   └── scan buffer node  ·            ·
- │                                         label        buffer 1
- └── fk-check                              ·            ·
-      └── error if rows                    ·            ·
-           └── lookup-join                 ·            ·
-                │                          table        child2@child2_auto_index_fk_p_ref_parent
-                │                          type         semi
-                │                          equality     (other) = (p)
-                └── render                 ·            ·
-                     └── scan buffer node  ·            ·
-·                                          label        buffer 1
+·                                          distribution  local
+·                                          vectorized    false
+root                                       ·             ·
+ ├── count                                 ·             ·
+ │    └── delete                           ·             ·
+ │         │                               from          parent
+ │         │                               strategy      deleter
+ │         └── buffer node                 ·             ·
+ │              │                          label         buffer 1
+ │              └── scan                   ·             ·
+ │                                         table         parent@primary
+ │                                         spans         /3-/3/#
+ ├── fk-check                              ·             ·
+ │    └── error if rows                    ·             ·
+ │         └── lookup-join                 ·             ·
+ │              │                          table         child@child_auto_index_fk_p_ref_parent
+ │              │                          type          semi
+ │              │                          equality      (p) = (p)
+ │              └── render                 ·             ·
+ │                   └── scan buffer node  ·             ·
+ │                                         label         buffer 1
+ ├── fk-check                              ·             ·
+ │    └── error if rows                    ·             ·
+ │         └── lookup-join                 ·             ·
+ │              │                          table         child_nullable@child_nullable_auto_index_fk_p_ref_parent
+ │              │                          type          semi
+ │              │                          equality      (p) = (p)
+ │              └── render                 ·             ·
+ │                   └── scan buffer node  ·             ·
+ │                                         label         buffer 1
+ └── fk-check                              ·             ·
+      └── error if rows                    ·             ·
+           └── lookup-join                 ·             ·
+                │                          table         child2@child2_auto_index_fk_p_ref_parent
+                │                          type          semi
+                │                          equality      (other) = (p)
+                └── render                 ·             ·
+                     └── scan buffer node  ·             ·
+·                                          label         buffer 1
 
 statement ok
 CREATE TABLE doubleparent (p1 INT, p2 INT, other INT, PRIMARY KEY (p1, p2))
@@ -313,33 +313,33 @@ CREATE TABLE doublechild (
 query TTT
 EXPLAIN DELETE FROM doubleparent WHERE p1 = 10
 ----
-·                                     distributed  false
-·                                     vectorized   false
-root                                  ·            ·
- ├── count                            ·            ·
- │    └── delete                      ·            ·
- │         │                          from         doubleparent
- │         │                          strategy     deleter
- │         └── buffer node            ·            ·
- │              │                     label        buffer 1
- │              └── scan              ·            ·
- │                                    table        doubleparent@primary
- │                                    spans        /10-/11
- └── fk-check                         ·            ·
-      └── error if rows               ·            ·
-           └── lookup-join            ·            ·
-                │                     table        doublechild@doublechild_auto_index_fk_p1_ref_doubleparent
-                │                     type         semi
-                │                     equality     (p1, p2) = (p1, p2)
-                └── scan buffer node  ·            ·
-·                                     label        buffer 1
+·                                     distribution  local
+·                                     vectorized    false
+root                                  ·             ·
+ ├── count                            ·             ·
+ │    └── delete                      ·             ·
+ │         │                          from          doubleparent
+ │         │                          strategy      deleter
+ │         └── buffer node            ·             ·
+ │              │                     label         buffer 1
+ │              └── scan              ·             ·
+ │                                    table         doubleparent@primary
+ │                                    spans         /10-/11
+ └── fk-check                         ·             ·
+      └── error if rows               ·             ·
+           └── lookup-join            ·             ·
+                │                     table         doublechild@doublechild_auto_index_fk_p1_ref_doubleparent
+                │                     type          semi
+                │                     equality      (p1, p2) = (p1, p2)
+                └── scan buffer node  ·             ·
+·                                     label         buffer 1
 
 # -- Tests with UPDATE --
 
 query TTT
 EXPLAIN UPDATE child SET p = 4
 ----
-·                                          distributed         false
+·                                          distribution        local
 ·                                          vectorized          false
 root                                       ·                   ·
  ├── count                                 ·                   ·
@@ -370,7 +370,7 @@ root                                       ·                   ·
 query TTT
 EXPLAIN UPDATE child SET p = 4 WHERE c = 10
 ----
-·                                          distributed            false
+·                                          distribution           local
 ·                                          vectorized             false
 root                                       ·                      ·
  ├── count                                 ·                      ·
@@ -400,7 +400,7 @@ root                                       ·                      ·
 query TTT
 EXPLAIN UPDATE parent SET p = p+1
 ----
-·                                                    distributed         false
+·                                                    distribution        local
 ·                                                    vectorized          false
 root                                                 ·                   ·
  ├── count                                           ·                   ·
@@ -461,7 +461,7 @@ root                                                 ·                   ·
 query TTT
 EXPLAIN UPDATE parent SET p = p+1 WHERE other = 10
 ----
-·                                               distributed       false
+·                                               distribution      local
 ·                                               vectorized        false
 root                                            ·                 ·
  ├── count                                      ·                 ·
@@ -509,7 +509,7 @@ CREATE TABLE grandchild (g INT PRIMARY KEY, c INT NOT NULL REFERENCES child(c))
 query TTT
 EXPLAIN UPDATE child SET c = 4
 ----
-·                                                    distributed         false
+·                                                    distribution        local
 ·                                                    vectorized          false
 root                                                 ·                   ·
  ├── count                                           ·                   ·
@@ -550,7 +550,7 @@ root                                                 ·                   ·
 query TTT
 EXPLAIN UPDATE child SET p = 4
 ----
-·                                          distributed         false
+·                                          distribution        local
 ·                                          vectorized          false
 root                                       ·                   ·
  ├── count                                 ·                   ·
@@ -581,7 +581,7 @@ root                                       ·                   ·
 query TTT
 EXPLAIN UPDATE child SET p = p
 ----
-·                                          distributed         false
+·                                          distribution        local
 ·                                          vectorized          false
 root                                       ·                   ·
  ├── count                                 ·                   ·
@@ -612,7 +612,7 @@ root                                       ·                   ·
 query TTT
 EXPLAIN UPDATE child SET p = p+1, c = c+1
 ----
-·                                                    distributed         false
+·                                                    distribution        local
 ·                                                    vectorized          false
 root                                                 ·                   ·
  ├── count                                           ·                   ·
@@ -668,7 +668,7 @@ CREATE TABLE grandchild2 (g INT PRIMARY KEY, c INT NOT NULL REFERENCES child(c))
 query TTT
 EXPLAIN UPDATE child SET p = 4
 ----
-·                                          distributed         false
+·                                          distribution        local
 ·                                          vectorized          false
 root                                       ·                   ·
  ├── count                                 ·                   ·
@@ -702,7 +702,7 @@ CREATE TABLE self (x INT PRIMARY KEY, y INT NOT NULL REFERENCES self(x))
 query TTT
 EXPLAIN UPDATE self SET y = 3
 ----
-·                                          distributed         false
+·                                          distribution        local
 ·                                          vectorized          false
 root                                       ·                   ·
  ├── count                                 ·                   ·
@@ -733,7 +733,7 @@ root                                       ·                   ·
 query TTT
 EXPLAIN UPDATE self SET x = 3
 ----
-·                                                    distributed         false
+·                                                    distribution        local
 ·                                                    vectorized          false
 root                                                 ·                   ·
  ├── count                                           ·                   ·
@@ -778,7 +778,7 @@ SET enable_insert_fast_path = true
 query TTTTT
 EXPLAIN (VERBOSE) INSERT INTO child VALUES (1,1), (2,2)
 ----
-·                      distributed    false              ·   ·
+·                      distribution   local              ·   ·
 ·                      vectorized     false              ·   ·
 count                  ·              ·                  ()  ·
  └── insert-fast-path  ·              ·                  ()  ·
@@ -858,15 +858,15 @@ CREATE TABLE nonunique_idx_child (
 query TTT
 EXPLAIN INSERT INTO nonunique_idx_child VALUES (0, 1, 10)
 ----
-·                      distributed  false
-·                      vectorized   false
-count                  ·            ·
- └── insert-fast-path  ·            ·
-·                      into         nonunique_idx_child(k, ref1, ref2)
-·                      strategy     inserter
-·                      auto commit  ·
-·                      FK check     nonunique_idx_parent@nonunique_idx_parent_k2_idx
-·                      size         3 columns, 1 row
+·                      distribution  local
+·                      vectorized    false
+count                  ·             ·
+ └── insert-fast-path  ·             ·
+·                      into          nonunique_idx_child(k, ref1, ref2)
+·                      strategy      inserter
+·                      auto commit   ·
+·                      FK check      nonunique_idx_parent@nonunique_idx_parent_k2_idx
+·                      size          3 columns, 1 row
 
 # Regression test for #46397: upserter was looking at the incorrect ordinal for
 # the check because of an extra input column used by the FK check.
@@ -907,18 +907,18 @@ CREATE TABLE cascadechild (
 query TTTTT
 EXPLAIN (VERBOSE) DELETE FROM cascadeparent WHERE p > 1
 ----
-·                           distributed  false                   ·    ·
-·                           vectorized   false                   ·    ·
-root                        ·            ·                       ()   ·
- ├── count                  ·            ·                       ()   ·
- │    └── delete            ·            ·                       ()   ·
- │         │                from         cascadeparent           ·    ·
- │         │                strategy     deleter                 ·    ·
- │         └── buffer node  ·            ·                       (p)  ·
- │              │           label        buffer 1                ·    ·
- │              └── scan    ·            ·                       (p)  ·
- │                          table        cascadeparent@primary   ·    ·
- │                          spans        /2-                     ·    ·
- └── fk-cascade             ·            ·                       ·    ·
-·                           fk           fk_p_ref_cascadeparent  ·    ·
-·                           input        buffer 1                ·    ·
+·                           distribution  local                   ·    ·
+·                           vectorized    false                   ·    ·
+root                        ·             ·                       ()   ·
+ ├── count                  ·             ·                       ()   ·
+ │    └── delete            ·             ·                       ()   ·
+ │         │                from          cascadeparent           ·    ·
+ │         │                strategy      deleter                 ·    ·
+ │         └── buffer node  ·             ·                       (p)  ·
+ │              │           label         buffer 1                ·    ·
+ │              └── scan    ·             ·                       (p)  ·
+ │                          table         cascadeparent@primary   ·    ·
+ │                          spans         /2-                     ·    ·
+ └── fk-cascade             ·             ·                       ·    ·
+·                           fk            fk_p_ref_cascadeparent  ·    ·
+·                           input         buffer 1                ·    ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -9,7 +9,7 @@ CREATE TABLE sharded_primary (a INT PRIMARY KEY USING HASH WITH BUCKET_COUNT=11)
 query TTTTT
 EXPLAIN (VERBOSE) INSERT INTO sharded_primary (a) VALUES (1), (2)
 ----
-·                           distributed    false                                          ·                           ·
+·                           distribution   local                                          ·                           ·
 ·                           vectorized     false                                          ·                           ·
 count                       ·              ·                                              ()                          ·
  └── insert                 ·              ·                                              ()                          ·
@@ -34,7 +34,7 @@ CREATE TABLE sharded_secondary (a INT8, INDEX (a) USING HASH WITH BUCKET_COUNT=1
 query TTTTT
 EXPLAIN (VERBOSE) INSERT INTO sharded_secondary (a) VALUES (1), (2)
 ----
-·                           distributed    false                                                  ·                                    ·
+·                           distribution   local                                                  ·                                    ·
 ·                           vectorized     false                                                  ·                                    ·
 count                       ·              ·                                                      ()                                   ·
  └── insert                 ·              ·                                                      ()                                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/information_schema
+++ b/pkg/sql/opt/exec/execbuilder/testdata/information_schema
@@ -3,19 +3,19 @@
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM system.information_schema.schemata
 ----
-·              distributed  false             ·                                                                  ·
-·              vectorized   false             ·                                                                  ·
-virtual table  ·            ·                 (catalog_name, schema_name, default_character_set_name, sql_path)  ·
-·              source       schemata@primary  ·                                                                  ·
+·              distribution  local             ·                                                                  ·
+·              vectorized    false             ·                                                                  ·
+virtual table  ·             ·                 (catalog_name, schema_name, default_character_set_name, sql_path)  ·
+·              source        schemata@primary  ·                                                                  ·
 
 query TTT
 EXPLAIN SELECT * FROM system.information_schema.tables WHERE table_name='foo'
 ----
-·              distributed  false
-·              vectorized   false
-virtual table  ·            ·
-·              source       tables@tables_table_name_idx
-·              constraint   /4: [/'foo' - /'foo']
+·              distribution  local
+·              vectorized    false
+virtual table  ·             ·
+·              source        tables@tables_table_name_idx
+·              constraint    /4: [/'foo' - /'foo']
 
 statement error use of crdb_internal_vtable_pk column not allowed
 SELECT crdb_internal_vtable_pk FROM system.information_schema.schemata

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -307,24 +307,24 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) INSERT INTO insert_t TABLE select_t ORDER BY v DESC LIMIT 10
 ]
 ----
-·                              distributed  false
-·                              vectorized   false
-count                          ·            ·
- └── insert                    ·            ·
-      │                        into         insert_t(x, v, rowid)
-      │                        strategy     inserter
-      │                        auto commit  ·
-      └── render               ·            ·
-           │                   render 0     x
-           │                   render 1     v
-           │                   render 2     unique_rowid()
-           └── limit           ·            ·
-                │              count        10
-                └── sort       ·            ·
-                     │         order        -v
-                     └── scan  ·            ·
-·                              table        select_t@primary
-·                              spans        FULL SCAN
+·                              distribution  local
+·                              vectorized    false
+count                          ·             ·
+ └── insert                    ·             ·
+      │                        into          insert_t(x, v, rowid)
+      │                        strategy      inserter
+      │                        auto commit   ·
+      └── render               ·             ·
+           │                   render 0      x
+           │                   render 1      v
+           │                   render 2      unique_rowid()
+           └── limit           ·             ·
+                │              count         10
+                └── sort       ·             ·
+                     │         order         -v
+                     └── scan  ·             ·
+·                              table         select_t@primary
+·                              spans         FULL SCAN
 
 # Check that INSERT supports LIMIT (MySQL extension)
 query TTT
@@ -332,121 +332,121 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
 ]
 ----
-·                    distributed  false
-·                    vectorized   false
-count                ·            ·
- └── insert          ·            ·
-      │              into         insert_t(x, v, rowid)
-      │              strategy     inserter
-      │              auto commit  ·
-      └── render     ·            ·
-           │         render 0     x
-           │         render 1     v
-           │         render 2     unique_rowid()
-           └── scan  ·            ·
-·                    table        select_t@primary
-·                    spans        LIMITED SCAN
-·                    limit        1
+·                    distribution  local
+·                    vectorized    false
+count                ·             ·
+ └── insert          ·             ·
+      │              into          insert_t(x, v, rowid)
+      │              strategy      inserter
+      │              auto commit   ·
+      └── render     ·             ·
+           │         render 0      x
+           │         render 1      v
+           │         render 2      unique_rowid()
+           └── scan  ·             ·
+·                    table         select_t@primary
+·                    spans         LIMITED SCAN
+·                    limit         1
 
 # Check the grouping of LIMIT and ORDER BY
 query TTT
 EXPLAIN (PLAN) INSERT INTO insert_t VALUES (1,1), (2,2) LIMIT 1
 ----
-·                           distributed  false
-·                           vectorized   false
-count                       ·            ·
- └── insert                 ·            ·
-      │                     into         insert_t(x, v, rowid)
-      │                     strategy     inserter
-      │                     auto commit  ·
-      └── render            ·            ·
-           └── limit        ·            ·
-                │           count        1
-                └── values  ·            ·
-·                           size         2 columns, 2 rows
+·                           distribution  local
+·                           vectorized    false
+count                       ·             ·
+ └── insert                 ·             ·
+      │                     into          insert_t(x, v, rowid)
+      │                     strategy      inserter
+      │                     auto commit   ·
+      └── render            ·             ·
+           └── limit        ·             ·
+                │           count         1
+                └── values  ·             ·
+·                           size          2 columns, 2 rows
 
 query TTT
 EXPLAIN (PLAN) INSERT INTO insert_t VALUES (1,1), (2,2) ORDER BY 2 LIMIT 1
 ----
-·                                distributed  false
-·                                vectorized   false
-count                            ·            ·
- └── insert                      ·            ·
-      │                          into         insert_t(x, v, rowid)
-      │                          strategy     inserter
-      │                          auto commit  ·
-      └── render                 ·            ·
-           └── limit             ·            ·
-                │                count        1
-                └── sort         ·            ·
-                     │           order        +column2
-                     └── values  ·            ·
-·                                size         2 columns, 2 rows
+·                                distribution  local
+·                                vectorized    false
+count                            ·             ·
+ └── insert                      ·             ·
+      │                          into          insert_t(x, v, rowid)
+      │                          strategy      inserter
+      │                          auto commit   ·
+      └── render                 ·             ·
+           └── limit             ·             ·
+                │                count         1
+                └── sort         ·             ·
+                     │           order         +column2
+                     └── values  ·             ·
+·                                size          2 columns, 2 rows
 
 query TTT
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) ORDER BY 2) LIMIT 1
 ----
-·                                distributed  false
-·                                vectorized   false
-count                            ·            ·
- └── insert                      ·            ·
-      │                          into         insert_t(x, v, rowid)
-      │                          strategy     inserter
-      │                          auto commit  ·
-      └── render                 ·            ·
-           └── limit             ·            ·
-                │                count        1
-                └── sort         ·            ·
-                     │           order        +column2
-                     └── values  ·            ·
-·                                size         2 columns, 2 rows
+·                                distribution  local
+·                                vectorized    false
+count                            ·             ·
+ └── insert                      ·             ·
+      │                          into          insert_t(x, v, rowid)
+      │                          strategy      inserter
+      │                          auto commit   ·
+      └── render                 ·             ·
+           └── limit             ·             ·
+                │                count         1
+                └── sort         ·             ·
+                     │           order         +column2
+                     └── values  ·             ·
+·                                size          2 columns, 2 rows
 
 query TTT
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) ORDER BY 2 LIMIT 1)
 ----
-·                                distributed  false
-·                                vectorized   false
-count                            ·            ·
- └── insert                      ·            ·
-      │                          into         insert_t(x, v, rowid)
-      │                          strategy     inserter
-      │                          auto commit  ·
-      └── render                 ·            ·
-           └── limit             ·            ·
-                │                count        1
-                └── sort         ·            ·
-                     │           order        +column2
-                     └── values  ·            ·
-·                                size         2 columns, 2 rows
+·                                distribution  local
+·                                vectorized    false
+count                            ·             ·
+ └── insert                      ·             ·
+      │                          into          insert_t(x, v, rowid)
+      │                          strategy      inserter
+      │                          auto commit   ·
+      └── render                 ·             ·
+           └── limit             ·             ·
+                │                count         1
+                └── sort         ·             ·
+                     │           order         +column2
+                     └── values  ·             ·
+·                                size          2 columns, 2 rows
 
 # ORDER BY expression that's not inserted into table.
 query TTTTT
 EXPLAIN (VERBOSE)
 INSERT INTO insert_t (SELECT length(k), 2 FROM kv ORDER BY k || v LIMIT 10) RETURNING x+v
 ----
-·                                        distributed  false                  ·                              ·
-·                                        vectorized   false                  ·                              ·
-render                                   ·            ·                      ("?column?")                   ·
- │                                       render 0     x + v                  ·                              ·
- └── run                                 ·            ·                      (x, v, rowid[hidden])          ·
-      └── insert                         ·            ·                      (x, v, rowid[hidden])          ·
-           │                             into         insert_t(x, v, rowid)  ·                              ·
-           │                             strategy     inserter               ·                              ·
-           └── render                    ·            ·                      (length, "?column?", column9)  ·
-                │                        render 0     length                 ·                              ·
-                │                        render 1     "?column?"             ·                              ·
-                │                        render 2     unique_rowid()         ·                              ·
-                └── limit                ·            ·                      (length, "?column?", column8)  +column8
-                     │                   count        10                     ·                              ·
-                     └── sort            ·            ·                      (length, "?column?", column8)  +column8
-                          │              order        +column8               ·                              ·
-                          └── render     ·            ·                      (length, "?column?", column8)  ·
-                               │         render 0     length(k)              ·                              ·
-                               │         render 1     2                      ·                              ·
-                               │         render 2     k || v                 ·                              ·
-                               └── scan  ·            ·                      (k, v)                         ·
-·                                        table        kv@primary             ·                              ·
-·                                        spans        FULL SCAN              ·                              ·
+·                                        distribution  local                  ·                              ·
+·                                        vectorized    false                  ·                              ·
+render                                   ·             ·                      ("?column?")                   ·
+ │                                       render 0      x + v                  ·                              ·
+ └── run                                 ·             ·                      (x, v, rowid[hidden])          ·
+      └── insert                         ·             ·                      (x, v, rowid[hidden])          ·
+           │                             into          insert_t(x, v, rowid)  ·                              ·
+           │                             strategy      inserter               ·                              ·
+           └── render                    ·             ·                      (length, "?column?", column9)  ·
+                │                        render 0      length                 ·                              ·
+                │                        render 1      "?column?"             ·                              ·
+                │                        render 2      unique_rowid()         ·                              ·
+                └── limit                ·             ·                      (length, "?column?", column8)  +column8
+                     │                   count         10                     ·                              ·
+                     └── sort            ·             ·                      (length, "?column?", column8)  +column8
+                          │              order         +column8               ·                              ·
+                          └── render     ·             ·                      (length, "?column?", column8)  ·
+                               │         render 0      length(k)              ·                              ·
+                               │         render 1      2                      ·                              ·
+                               │         render 2      k || v                 ·                              ·
+                               └── scan  ·             ·                      (k, v)                         ·
+·                                        table         kv@primary             ·                              ·
+·                                        spans         FULL SCAN              ·                              ·
 
 # ------------------------------------------------------------------------------
 # Insert rows into table during schema changes.
@@ -462,7 +462,7 @@ BEGIN; ALTER TABLE mutation DROP COLUMN y
 query TTTTT
 EXPLAIN (VERBOSE) INSERT INTO mutation(x) VALUES (2) RETURNING *
 ----
-·                           distributed    false                  ·                   ·
+·                           distribution   local                  ·                   ·
 ·                           vectorized     false                  ·                   ·
 render                      ·              ·                      (x)                 ·
  │                          render 0       x                      ·                   ·
@@ -485,7 +485,7 @@ BEGIN; ALTER TABLE mutation ADD COLUMN z INT AS (x + y) STORED
 query TTTTT
 EXPLAIN (VERBOSE) INSERT INTO mutation(x, y) VALUES (2, 2)
 ----
-·                      distributed    false                  ·   ·
+·                      distribution   local                  ·   ·
 ·                      vectorized     false                  ·   ·
 count                  ·              ·                      ()  ·
  └── insert-fast-path  ·              ·                      ()  ·
@@ -511,7 +511,7 @@ CREATE TABLE xyz (x INT, y INT, z INT)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [INSERT INTO xyz SELECT a, b, c FROM abc RETURNING z] ORDER BY z
 ----
-·                                             distributed   false                                                ·                   ·
+·                                             distribution  local                                                ·                   ·
 ·                                             vectorized    false                                                ·                   ·
 root                                          ·             ·                                                    (z)                 +z
  ├── sort                                     ·             ·                                                    (z)                 +z

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -39,11 +39,11 @@ CREATE TABLE level4 (
 query TTT
 EXPLAIN SELECT * FROM level4
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        level4@primary
-·     spans        FULL SCAN
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         level4@primary
+·     spans         FULL SCAN
 
 # The span below ends at the end of the first index of table 53, and is not
 # constraining the value of k2 or k3. This is confusing on first glance because
@@ -52,39 +52,39 @@ scan  ·            ·
 query TTT
 EXPLAIN SELECT * FROM level4 WHERE k1 > 1 AND k1 < 3
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        level4@primary
-·     spans        /2/#/54/1/#/55/1-/2/#/54/1/#/55/2
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         level4@primary
+·     spans         /2/#/54/1/#/55/1-/2/#/54/1/#/55/2
 
 query TTT
 EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 > 10 AND k2 < 30
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        level4@primary
-·     spans        /2/#/54/1/#/55/1/11-/2/#/54/1/#/55/1/30
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         level4@primary
+·     spans         /2/#/54/1/#/55/1/11-/2/#/54/1/#/55/1/30
 
 query TTT
 EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 > 100 AND k3 < 300
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        level4@primary
-·     spans        /2/#/54/1/#/55/1/20/101/#/56/1-/2/#/54/1/#/55/1/20/299/#/56/1/#
-·     parallel     ·
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         level4@primary
+·     spans         /2/#/54/1/#/55/1/20/101/#/56/1-/2/#/54/1/#/55/1/20/299/#/56/1/#
+·     parallel      ·
 
 query TTT
 EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 = 200
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        level4@primary
-·     spans        /2/#/54/1/#/55/1/20/200/#/56/1-/2/#/54/1/#/55/1/20/200/#/56/1/#
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         level4@primary
+·     spans         /2/#/54/1/#/55/1/20/200/#/56/1-/2/#/54/1/#/55/1/20/200/#/56/1/#
 
 # ------------------------------------------------------------------------------
 # Trace of interleaved fetches from interesting interleaved hierarchy.

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -164,177 +164,177 @@ InitPut /Table/55/2/15/0/0 -> /BYTES/
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
 ----
-·           distributed  false                        ·       ·
-·           vectorized   true                         ·       ·
-index-join  ·            ·                            (a, b)  ·
- │          table        d@primary                    ·       ·
- │          key columns  a                            ·       ·
- └── scan   ·            ·                            (a)     ·
-·           table        d@foo_inv                    ·       ·
-·           spans        /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
+·           distribution  local                        ·       ·
+·           vectorized    true                         ·       ·
+index-join  ·             ·                            (a, b)  ·
+ │          table         d@primary                    ·       ·
+ │          key columns   a                            ·       ·
+ └── scan   ·             ·                            (a)     ·
+·           table         d@foo_inv                    ·       ·
+·           spans         /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": {"b": [1]}}'
 ----
-·           distributed  false                                    ·       ·
-·           vectorized   true                                     ·       ·
-index-join  ·            ·                                        (a, b)  ·
- │          table        d@primary                                ·       ·
- │          key columns  a                                        ·       ·
- └── scan   ·            ·                                        (a)     ·
-·           table        d@foo_inv                                ·       ·
-·           spans        /"a"/"b"/Arr/1-/"a"/"b"/Arr/1/PrefixEnd  ·       ·
+·           distribution  local                                    ·       ·
+·           vectorized    true                                     ·       ·
+index-join  ·             ·                                        (a, b)  ·
+ │          table         d@primary                                ·       ·
+ │          key columns   a                                        ·       ·
+ └── scan   ·             ·                                        (a)     ·
+·           table         d@foo_inv                                ·       ·
+·           spans         /"a"/"b"/Arr/1-/"a"/"b"/Arr/1/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": [[2]]}}';
 ----
-·           distributed  false                                            ·       ·
-·           vectorized   true                                             ·       ·
-index-join  ·            ·                                                (a, b)  ·
- │          table        d@primary                                        ·       ·
- │          key columns  a                                                ·       ·
- └── scan   ·            ·                                                (a)     ·
-·           table        d@foo_inv                                        ·       ·
-·           spans        /"a"/"b"/Arr/Arr/2-/"a"/"b"/Arr/Arr/2/PrefixEnd  ·       ·
+·           distribution  local                                            ·       ·
+·           vectorized    true                                             ·       ·
+index-join  ·             ·                                                (a, b)  ·
+ │          table         d@primary                                        ·       ·
+ │          key columns   a                                                ·       ·
+ └── scan   ·             ·                                                (a)     ·
+·           table         d@foo_inv                                        ·       ·
+·           spans         /"a"/"b"/Arr/Arr/2-/"a"/"b"/Arr/Arr/2/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b":true}}';
 ----
-·           distributed  false                         ·       ·
-·           vectorized   true                          ·       ·
-index-join  ·            ·                             (a, b)  ·
- │          table        d@primary                     ·       ·
- │          key columns  a                             ·       ·
- └── scan   ·            ·                             (a)     ·
-·           table        d@foo_inv                     ·       ·
-·           spans        /"a"/"b"/True-/"a"/"b"/False  ·       ·
+·           distribution  local                         ·       ·
+·           vectorized    true                          ·       ·
+index-join  ·             ·                             (a, b)  ·
+ │          table         d@primary                     ·       ·
+ │          key columns   a                             ·       ·
+ └── scan   ·             ·                             (a)     ·
+·           table         d@foo_inv                     ·       ·
+·           spans         /"a"/"b"/True-/"a"/"b"/False  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'[1]'
 ----
-·           distributed  false                    ·       ·
-·           vectorized   true                     ·       ·
-index-join  ·            ·                        (a, b)  ·
- │          table        d@primary                ·       ·
- │          key columns  a                        ·       ·
- └── scan   ·            ·                        (a)     ·
-·           table        d@foo_inv                ·       ·
-·           spans        /Arr/1-/Arr/1/PrefixEnd  ·       ·
+·           distribution  local                    ·       ·
+·           vectorized    true                     ·       ·
+index-join  ·             ·                        (a, b)  ·
+ │          table         d@primary                ·       ·
+ │          key columns   a                        ·       ·
+ └── scan   ·             ·                        (a)     ·
+·           table         d@foo_inv                ·       ·
+·           spans         /Arr/1-/Arr/1/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'[{"a": {"b": [1]}}]'
 ----
-·           distributed  false                                            ·       ·
-·           vectorized   true                                             ·       ·
-index-join  ·            ·                                                (a, b)  ·
- │          table        d@primary                                        ·       ·
- │          key columns  a                                                ·       ·
- └── scan   ·            ·                                                (a)     ·
-·           table        d@foo_inv                                        ·       ·
-·           spans        /Arr/"a"/"b"/Arr/1-/Arr/"a"/"b"/Arr/1/PrefixEnd  ·       ·
+·           distribution  local                                            ·       ·
+·           vectorized    true                                             ·       ·
+index-join  ·             ·                                                (a, b)  ·
+ │          table         d@primary                                        ·       ·
+ │          key columns   a                                                ·       ·
+ └── scan   ·             ·                                                (a)     ·
+·           table         d@foo_inv                                        ·       ·
+·           spans         /Arr/"a"/"b"/Arr/1-/Arr/"a"/"b"/Arr/1/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[]';
 ----
-·     distributed  false      ·       ·
-·     vectorized   true       ·       ·
-scan  ·            ·          (a, b)  ·
-·     table        d@primary  ·       ·
-·     spans        FULL SCAN  ·       ·
-·     filter       b @> '[]'  ·       ·
+·     distribution  local      ·       ·
+·     vectorized    true       ·       ·
+scan  ·             ·          (a, b)  ·
+·     table         d@primary  ·       ·
+·     spans         FULL SCAN  ·       ·
+·     filter        b @> '[]'  ·       ·
 
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{}';
 ----
-·     distributed  false      ·       ·
-·     vectorized   true       ·       ·
-scan  ·            ·          (a, b)  ·
-·     table        d@primary  ·       ·
-·     spans        FULL SCAN  ·       ·
-·     filter       b @> '{}'  ·       ·
+·     distribution  local      ·       ·
+·     vectorized    true       ·       ·
+scan  ·             ·          (a, b)  ·
+·     table         d@primary  ·       ·
+·     spans         FULL SCAN  ·       ·
+·     filter        b @> '{}'  ·       ·
 
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b->'a' = '"b"'
 ----
-·           distributed  false                        ·       ·
-·           vectorized   true                         ·       ·
-index-join  ·            ·                            (a, b)  ·
- │          table        d@primary                    ·       ·
- │          key columns  a                            ·       ·
- └── scan   ·            ·                            (a)     ·
-·           table        d@foo_inv                    ·       ·
-·           spans        /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
+·           distribution  local                        ·       ·
+·           vectorized    true                         ·       ·
+index-join  ·             ·                            (a, b)  ·
+ │          table         d@primary                    ·       ·
+ │          key columns   a                            ·       ·
+ └── scan   ·             ·                            (a)     ·
+·           table         d@foo_inv                    ·       ·
+·           spans         /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b->'a'->'c' = '"b"'
 ----
-·           distributed  false                                ·       ·
-·           vectorized   true                                 ·       ·
-index-join  ·            ·                                    (a, b)  ·
- │          table        d@primary                            ·       ·
- │          key columns  a                                    ·       ·
- └── scan   ·            ·                                    (a)     ·
-·           table        d@foo_inv                            ·       ·
-·           spans        /"a"/"c"/"b"-/"a"/"c"/"b"/PrefixEnd  ·       ·
+·           distribution  local                                ·       ·
+·           vectorized    true                                 ·       ·
+index-join  ·             ·                                    (a, b)  ·
+ │          table         d@primary                            ·       ·
+ │          key columns   a                                    ·       ·
+ └── scan   ·             ·                                    (a)     ·
+·           table         d@foo_inv                            ·       ·
+·           spans         /"a"/"c"/"b"-/"a"/"c"/"b"/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b->(NULL::STRING) = '"b"'
 ----
-·       distributed  false  ·       ·
-·       vectorized   true   ·       ·
-norows  ·            ·      (a, b)  ·
+·       distribution  local  ·       ·
+·       vectorized    true   ·       ·
+norows  ·             ·      (a, b)  ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where '"b"' = b->'a'
 ----
-·           distributed  false                        ·       ·
-·           vectorized   true                         ·       ·
-index-join  ·            ·                            (a, b)  ·
- │          table        d@primary                    ·       ·
- │          key columns  a                            ·       ·
- └── scan   ·            ·                            (a)     ·
-·           table        d@foo_inv                    ·       ·
-·           spans        /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
+·           distribution  local                        ·       ·
+·           vectorized    true                         ·       ·
+index-join  ·             ·                            (a, b)  ·
+ │          table         d@primary                    ·       ·
+ │          key columns   a                            ·       ·
+ └── scan   ·             ·                            (a)     ·
+·           table         d@foo_inv                    ·       ·
+·           spans         /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
 
 # Make sure that querying for NULL equality doesn't use the inverted index.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b IS NULL
 ----
-·     distributed  false      ·       ·
-·     vectorized   true       ·       ·
-scan  ·            ·          (a, b)  ·
-·     table        d@primary  ·       ·
-·     spans        FULL SCAN  ·       ·
-·     filter       b IS NULL  ·       ·
+·     distribution  local      ·       ·
+·     vectorized    true       ·       ·
+scan  ·             ·          (a, b)  ·
+·     table         d@primary  ·       ·
+·     spans         FULL SCAN  ·       ·
+·     filter        b IS NULL  ·       ·
 
 query TTT
 EXPLAIN SELECT * from d where b @> '{"a": []}' ORDER BY a;
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        d@primary
-·     spans        FULL SCAN
-·     filter       b @> '{"a": []}'
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         d@primary
+·     spans         FULL SCAN
+·     filter        b @> '{"a": []}'
 
 query TTT
 EXPLAIN SELECT * from d where b @> '{"a": {}}' ORDER BY a;
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        d@primary
-·     spans        FULL SCAN
-·     filter       b @> '{"a": {}}'
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         d@primary
+·     spans         FULL SCAN
+·     filter        b @> '{"a": {}}'
 
 # Multi-path contains queries. Should create zigzag joins.
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
 ----
-·                 distributed            false                                ·       ·
+·                 distribution           local                                ·       ·
 ·                 vectorized             true                                 ·       ·
 lookup-join       ·                      ·                                    (a, b)  ·
  │                table                  d@primary                            ·       ·
@@ -355,7 +355,7 @@ lookup-join       ·                      ·                                    
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
 ----
-·                 distributed            false                                          ·       ·
+·                 distribution           local                                          ·       ·
 ·                 vectorized             true                                           ·       ·
 lookup-join       ·                      ·                                              (a, b)  ·
  │                table                  d@primary                                      ·       ·
@@ -376,7 +376,7 @@ lookup-join       ·                      ·                                    
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
 ----
-·                 distributed            false                               ·       ·
+·                 distribution           local                               ·       ·
 ·                 vectorized             true                                ·       ·
 lookup-join       ·                      ·                                   (a, b)  ·
  │                table                  d@primary                           ·       ·
@@ -400,7 +400,7 @@ SET enable_zigzag_join = true
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
 ----
-·                 distributed            false                                ·       ·
+·                 distribution           local                                ·       ·
 ·                 vectorized             true                                 ·       ·
 lookup-join       ·                      ·                                    (a, b)  ·
  │                table                  d@primary                            ·       ·
@@ -421,7 +421,7 @@ lookup-join       ·                      ·                                    
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
 ----
-·                 distributed            false                                          ·       ·
+·                 distribution           local                                          ·       ·
 ·                 vectorized             true                                           ·       ·
 lookup-join       ·                      ·                                              (a, b)  ·
  │                table                  d@primary                                      ·       ·
@@ -442,7 +442,7 @@ lookup-join       ·                      ·                                    
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
 ----
-·                 distributed            false                               ·       ·
+·                 distribution           local                               ·       ·
 ·                 vectorized             true                                ·       ·
 lookup-join       ·                      ·                                   (a, b)  ·
  │                table                  d@primary                           ·       ·
@@ -463,26 +463,26 @@ lookup-join       ·                      ·                                   (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": 2}'
 ----
-·                distributed  false                     ·       ·
-·                vectorized   true                      ·       ·
-filter           ·            ·                         (a, b)  ·
- │               filter       b @> '{"a": {}, "b": 2}'  ·       ·
- └── index-join  ·            ·                         (a, b)  ·
-      │          table        d@primary                 ·       ·
-      │          key columns  a                         ·       ·
-      └── scan   ·            ·                         (a)     ·
-·                table        d@foo_inv                 ·       ·
-·                spans        /"b"/2-/"b"/2/PrefixEnd   ·       ·
+·                distribution  local                     ·       ·
+·                vectorized    true                      ·       ·
+filter           ·             ·                         (a, b)  ·
+ │               filter        b @> '{"a": {}, "b": 2}'  ·       ·
+ └── index-join  ·             ·                         (a, b)  ·
+      │          table         d@primary                 ·       ·
+      │          key columns   a                         ·       ·
+      └── scan   ·             ·                         (a)     ·
+·                table         d@foo_inv                 ·       ·
+·                spans         /"b"/2-/"b"/2/PrefixEnd   ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": {}}'
 ----
-·     distributed  false                      ·       ·
-·     vectorized   true                       ·       ·
-scan  ·            ·                          (a, b)  ·
-·     table        d@primary                  ·       ·
-·     spans        FULL SCAN                  ·       ·
-·     filter       b @> '{"a": {}, "b": {}}'  ·       ·
+·     distribution  local                      ·       ·
+·     vectorized    true                       ·       ·
+scan  ·             ·                          (a, b)  ·
+·     table         d@primary                  ·       ·
+·     spans         FULL SCAN                  ·       ·
+·     filter        b @> '{"a": {}, "b": {}}'  ·       ·
 
 subtest array
 
@@ -490,57 +490,57 @@ subtest array
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1]
 ----
-·           distributed  false      ·       ·
-·           vectorized   true       ·       ·
-index-join  ·            ·          (a, b)  ·
- │          table        e@primary  ·       ·
- │          key columns  a          ·       ·
- └── scan   ·            ·          (a)     ·
-·           table        e@e_b_idx  ·       ·
-·           spans        /1-/2      ·       ·
+·           distribution  local      ·       ·
+·           vectorized    true       ·       ·
+index-join  ·             ·          (a, b)  ·
+ │          table         e@primary  ·       ·
+ │          key columns   a          ·       ·
+ └── scan   ·             ·          (a)     ·
+·           table         e@e_b_idx  ·       ·
+·           spans         /1-/2      ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[]::INT[]
 ----
-·     distributed  false         ·       ·
-·     vectorized   true          ·       ·
-scan  ·            ·             (a, b)  ·
-·     table        e@primary     ·       ·
-·     spans        FULL SCAN     ·       ·
-·     filter       b @> ARRAY[]  ·       ·
+·     distribution  local         ·       ·
+·     vectorized    true          ·       ·
+scan  ·             ·             (a, b)  ·
+·     table         e@primary     ·       ·
+·     spans         FULL SCAN     ·       ·
+·     filter        b @> ARRAY[]  ·       ·
 
 # Test that searching for a NULL element using the inverted index.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[NULL]::INT[]
 ----
-·            distributed  false      ·       ·
-·            vectorized   true       ·       ·
-index-join   ·            ·          (a, b)  ·
- │           table        e@primary  ·       ·
- │           key columns  a          ·       ·
- └── norows  ·            ·          (a)     ·
+·            distribution  local      ·       ·
+·            vectorized    true       ·       ·
+index-join   ·             ·          (a, b)  ·
+ │           table         e@primary  ·       ·
+ │           key columns   a          ·       ·
+ └── norows  ·             ·          (a)     ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from e where b @> NULL
 ----
-·       distributed  false  ·       ·
-·       vectorized   true   ·       ·
-norows  ·            ·      (a, b)  ·
+·       distribution  local  ·       ·
+·       vectorized    true   ·       ·
+norows  ·             ·      (a, b)  ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from e where b IS NULL
 ----
-·     distributed  false      ·       ·
-·     vectorized   true       ·       ·
-scan  ·            ·          (a, b)  ·
-·     table        e@primary  ·       ·
-·     spans        FULL SCAN  ·       ·
-·     filter       b IS NULL  ·       ·
+·     distribution  local      ·       ·
+·     vectorized    true       ·       ·
+scan  ·             ·          (a, b)  ·
+·     table         e@primary  ·       ·
+·     spans         FULL SCAN  ·       ·
+·     filter        b IS NULL  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1,2]
 ----
-·                 distributed            false             ·       ·
+·                 distribution           local             ·       ·
 ·                 vectorized             true              ·       ·
 lookup-join       ·                      ·                 (a, b)  ·
  │                table                  e@primary         ·       ·
@@ -561,7 +561,7 @@ lookup-join       ·                      ·                 (a, b)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1] AND b @> ARRAY[2]
 ----
-·                 distributed            false                                  ·       ·
+·                 distribution           local                                  ·       ·
 ·                 vectorized             true                                   ·       ·
 lookup-join       ·                      ·                                      (a, b)  ·
  │                table                  e@primary                              ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -11,79 +11,79 @@ CREATE TABLE twocolumn (x INT, y INT); INSERT INTO twocolumn(x, y) VALUES (44,51
 query TTT
 EXPLAIN SELECT * FROM onecolumn JOIN twocolumn USING(x)
 ----
-·               distributed  false
-·               vectorized   true
-render          ·            ·
- └── hash-join  ·            ·
-      │         type         inner
-      │         equality     (x) = (x)
-      ├── scan  ·            ·
-      │         table        onecolumn@primary
-      │         spans        FULL SCAN
-      └── scan  ·            ·
-·               table        twocolumn@primary
-·               spans        FULL SCAN
+·               distribution  local
+·               vectorized    true
+render          ·             ·
+ └── hash-join  ·             ·
+      │         type          inner
+      │         equality      (x) = (x)
+      ├── scan  ·             ·
+      │         table         onecolumn@primary
+      │         spans         FULL SCAN
+      └── scan  ·             ·
+·               table         twocolumn@primary
+·               spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
 ----
-·          distributed  false
-·          vectorized   true
-hash-join  ·            ·
- │         type         inner
- │         equality     (x) = (y)
- ├── scan  ·            ·
- │         table        twocolumn@primary
- │         spans        FULL SCAN
- └── scan  ·            ·
-·          table        twocolumn@primary
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+hash-join  ·             ·
+ │         type          inner
+ │         equality      (x) = (y)
+ ├── scan  ·             ·
+ │         table         twocolumn@primary
+ │         spans         FULL SCAN
+ └── scan  ·             ·
+·          table         twocolumn@primary
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 ----
-·                distributed  false
-·                vectorized   true
-render           ·            ·
- └── cross-join  ·            ·
-      │          type         cross
-      ├── scan   ·            ·
-      │          table        twocolumn@primary
-      │          spans        FULL SCAN
-      └── scan   ·            ·
-·                table        twocolumn@primary
-·                spans        FULL SCAN
-·                filter       x = 44
+·                distribution  local
+·                vectorized    true
+render           ·             ·
+ └── cross-join  ·             ·
+      │          type          cross
+      ├── scan   ·             ·
+      │          table         twocolumn@primary
+      │          spans         FULL SCAN
+      └── scan   ·             ·
+·                table         twocolumn@primary
+·                spans         FULL SCAN
+·                filter        x = 44
 
 query TTT
 EXPLAIN SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
 ----
-·          distributed  false
-·          vectorized   true
-hash-join  ·            ·
- │         type         inner
- │         equality     (x) = (y)
- ├── scan  ·            ·
- │         table        onecolumn@primary
- │         spans        FULL SCAN
- └── scan  ·            ·
-·          table        twocolumn@primary
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+hash-join  ·             ·
+ │         type          inner
+ │         equality      (x) = (y)
+ ├── scan  ·             ·
+ │         table         onecolumn@primary
+ │         spans         FULL SCAN
+ └── scan  ·             ·
+·          table         twocolumn@primary
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
 ----
-·          distributed  false
-·          vectorized   true
-hash-join  ·            ·
- │         type         inner
- │         equality     (x) = (y)
- ├── scan  ·            ·
- │         table        onecolumn@primary
- │         spans        FULL SCAN
- └── scan  ·            ·
-·          table        twocolumn@primary
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+hash-join  ·             ·
+ │         type          inner
+ │         equality      (x) = (y)
+ ├── scan  ·             ·
+ │         table         onecolumn@primary
+ │         spans         FULL SCAN
+ └── scan  ·             ·
+·          table         twocolumn@primary
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM
@@ -93,129 +93,129 @@ EXPLAIN SELECT * FROM
   JOIN twocolumn AS c (d, e) ON a.b = c.d AND c.d = onecolumn.x
 LIMIT 1
 ----
-·                    distributed  false
-·                    vectorized   true
-limit                ·            ·
- │                   count        1
- └── hash-join       ·            ·
-      │              type         inner
-      │              equality     (x) = (x)
-      ├── hash-join  ·            ·
-      │    │         type         inner
-      │    │         equality     (x) = (x)
-      │    ├── scan  ·            ·
-      │    │         table        onecolumn@primary
-      │    │         spans        FULL SCAN
-      │    └── scan  ·            ·
-      │              table        twocolumn@primary
-      │              spans        FULL SCAN
-      └── hash-join  ·            ·
-           │         type         inner
-           │         equality     (x) = (x)
-           ├── scan  ·            ·
-           │         table        onecolumn@primary
-           │         spans        FULL SCAN
-           └── scan  ·            ·
-·                    table        twocolumn@primary
-·                    spans        FULL SCAN
+·                    distribution  local
+·                    vectorized    true
+limit                ·             ·
+ │                   count         1
+ └── hash-join       ·             ·
+      │              type          inner
+      │              equality      (x) = (x)
+      ├── hash-join  ·             ·
+      │    │         type          inner
+      │    │         equality      (x) = (x)
+      │    ├── scan  ·             ·
+      │    │         table         onecolumn@primary
+      │    │         spans         FULL SCAN
+      │    └── scan  ·             ·
+      │              table         twocolumn@primary
+      │              spans         FULL SCAN
+      └── hash-join  ·             ·
+           │         type          inner
+           │         equality      (x) = (x)
+           ├── scan  ·             ·
+           │         table         onecolumn@primary
+           │         spans         FULL SCAN
+           └── scan  ·             ·
+·                    table         twocolumn@primary
+·                    spans         FULL SCAN
 
 # The following queries verify that only the necessary columns are scanned.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 ----
-·           distributed  false              ·       ·
-·           vectorized   true               ·       ·
-cross-join  ·            ·                  (x, y)  ·
- │          type         cross              ·       ·
- ├── scan   ·            ·                  (x)     ·
- │          table        twocolumn@primary  ·       ·
- │          spans        FULL SCAN          ·       ·
- └── scan   ·            ·                  (y)     ·
-·           table        twocolumn@primary  ·       ·
-·           spans        FULL SCAN          ·       ·
+·           distribution  local              ·       ·
+·           vectorized    true               ·       ·
+cross-join  ·             ·                  (x, y)  ·
+ │          type          cross              ·       ·
+ ├── scan   ·             ·                  (x)     ·
+ │          table         twocolumn@primary  ·       ·
+ │          spans         FULL SCAN          ·       ·
+ └── scan   ·             ·                  (y)     ·
+·           table         twocolumn@primary  ·       ·
+·           spans         FULL SCAN          ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 ----
-·               distributed  false              ·          ·
-·               vectorized   true               ·          ·
-render          ·            ·                  (y)        ·
- │              render 0     y                  ·          ·
- └── hash-join  ·            ·                  (x, x, y)  ·
-      │         type         inner              ·          ·
-      │         equality     (x) = (x)          ·          ·
-      ├── scan  ·            ·                  (x)        ·
-      │         table        twocolumn@primary  ·          ·
-      │         spans        FULL SCAN          ·          ·
-      └── scan  ·            ·                  (x, y)     ·
-·               table        twocolumn@primary  ·          ·
-·               spans        FULL SCAN          ·          ·
+·               distribution  local              ·          ·
+·               vectorized    true               ·          ·
+render          ·             ·                  (y)        ·
+ │              render 0      y                  ·          ·
+ └── hash-join  ·             ·                  (x, x, y)  ·
+      │         type          inner              ·          ·
+      │         equality      (x) = (x)          ·          ·
+      ├── scan  ·             ·                  (x)        ·
+      │         table         twocolumn@primary  ·          ·
+      │         spans         FULL SCAN          ·          ·
+      └── scan  ·             ·                  (x, y)     ·
+·               table         twocolumn@primary  ·          ·
+·               spans         FULL SCAN          ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
 ----
-·               distributed  false              ·          ·
-·               vectorized   true               ·          ·
-render          ·            ·                  (y)        ·
- │              render 0     y                  ·          ·
- └── hash-join  ·            ·                  (x, x, y)  ·
-      │         type         inner              ·          ·
-      │         equality     (x) = (x)          ·          ·
-      ├── scan  ·            ·                  (x)        ·
-      │         table        twocolumn@primary  ·          ·
-      │         spans        FULL SCAN          ·          ·
-      └── scan  ·            ·                  (x, y)     ·
-·               table        twocolumn@primary  ·          ·
-·               spans        FULL SCAN          ·          ·
+·               distribution  local              ·          ·
+·               vectorized    true               ·          ·
+render          ·             ·                  (y)        ·
+ │              render 0      y                  ·          ·
+ └── hash-join  ·             ·                  (x, x, y)  ·
+      │         type          inner              ·          ·
+      │         equality      (x) = (x)          ·          ·
+      ├── scan  ·             ·                  (x)        ·
+      │         table         twocolumn@primary  ·          ·
+      │         spans         FULL SCAN          ·          ·
+      └── scan  ·             ·                  (x, y)     ·
+·               table         twocolumn@primary  ·          ·
+·               spans         FULL SCAN          ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
 ----
-·                distributed  false              ·       ·
-·                vectorized   true               ·       ·
-render           ·            ·                  (x)     ·
- │               render 0     x                  ·       ·
- └── cross-join  ·            ·                  (x, y)  ·
-      │          type         inner              ·       ·
-      │          pred         x < y              ·       ·
-      ├── scan   ·            ·                  (x)     ·
-      │          table        twocolumn@primary  ·       ·
-      │          spans        FULL SCAN          ·       ·
-      └── scan   ·            ·                  (y)     ·
-·                table        twocolumn@primary  ·       ·
-·                spans        FULL SCAN          ·       ·
+·                distribution  local              ·       ·
+·                vectorized    true               ·       ·
+render           ·             ·                  (x)     ·
+ │               render 0      x                  ·       ·
+ └── cross-join  ·             ·                  (x, y)  ·
+      │          type          inner              ·       ·
+      │          pred          x < y              ·       ·
+      ├── scan   ·             ·                  (x)     ·
+      │          table         twocolumn@primary  ·       ·
+      │          spans         FULL SCAN          ·       ·
+      └── scan   ·             ·                  (y)     ·
+·                table         twocolumn@primary  ·       ·
+·                spans         FULL SCAN          ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT x, 2 two FROM onecolumn) NATURAL FULL JOIN (SELECT x, y+1 plus1 FROM twocolumn)
 ----
-·                    distributed  false              ·                   ·
-·                    vectorized   true               ·                   ·
-render               ·            ·                  (x, two, plus1)     ·
- │                   render 0     COALESCE(x, x)     ·                   ·
- │                   render 1     two                ·                   ·
- │                   render 2     plus1              ·                   ·
- └── hash-join       ·            ·                  (two, x, plus1, x)  ·
-      │              type         full outer         ·                   ·
-      │              equality     (x) = (x)          ·                   ·
-      ├── render     ·            ·                  (two, x)            ·
-      │    │         render 0     2                  ·                   ·
-      │    │         render 1     x                  ·                   ·
-      │    └── scan  ·            ·                  (x)                 ·
-      │              table        onecolumn@primary  ·                   ·
-      │              spans        FULL SCAN          ·                   ·
-      └── render     ·            ·                  (plus1, x)          ·
-           │         render 0     y + 1              ·                   ·
-           │         render 1     x                  ·                   ·
-           └── scan  ·            ·                  (x, y)              ·
-·                    table        twocolumn@primary  ·                   ·
-·                    spans        FULL SCAN          ·                   ·
+·                    distribution  local              ·                   ·
+·                    vectorized    true               ·                   ·
+render               ·             ·                  (x, two, plus1)     ·
+ │                   render 0      COALESCE(x, x)     ·                   ·
+ │                   render 1      two                ·                   ·
+ │                   render 2      plus1              ·                   ·
+ └── hash-join       ·             ·                  (two, x, plus1, x)  ·
+      │              type          full outer         ·                   ·
+      │              equality      (x) = (x)          ·                   ·
+      ├── render     ·             ·                  (two, x)            ·
+      │    │         render 0      2                  ·                   ·
+      │    │         render 1      x                  ·                   ·
+      │    └── scan  ·             ·                  (x)                 ·
+      │              table         onecolumn@primary  ·                   ·
+      │              spans         FULL SCAN          ·                   ·
+      └── render     ·             ·                  (plus1, x)          ·
+           │         render 0      y + 1              ·                   ·
+           │         render 1      x                  ·                   ·
+           └── scan  ·             ·                  (x, y)              ·
+·                    table         twocolumn@primary  ·                   ·
+·                    spans         FULL SCAN          ·                   ·
 
 # Ensure that the ordering information for the result of joins is sane. (#12037)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u, k) ORDER BY k)
                   INNER JOIN (VALUES (1, 1), (2, 2)) AS b (k, w) USING (k) ORDER BY u
 ----
-·                           distributed    false                  ·                                     ·
+·                           distribution   local                  ·                                     ·
 ·                           vectorized     false                  ·                                     ·
 render                      ·              ·                      (k, u, w)                             ·
  │                          render 0       column2                ·                                     ·
@@ -312,7 +312,7 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
            pos.n
   ] WHERE node_type <> 'values' AND field <> 'size'
 ----
-0   ·              distributed         false
+0   ·              distribution        local
 0   ·              vectorized          false
 0   render         ·                   ·
 0   ·              render 0            pktable_cat
@@ -459,7 +459,7 @@ CREATE TABLE cards(id INT PRIMARY KEY, cust INT NOT NULL REFERENCES customers(id
 query TTT
 EXPLAIN SELECT * FROM cards LEFT OUTER JOIN customers ON customers.id = cards.cust
 ----
-·           distributed         false
+·           distribution        local
 ·           vectorized          true
 merge-join  ·                   ·
  │          type                inner
@@ -485,7 +485,7 @@ CREATE TABLE pairs (a INT, b INT)
 query TTT
 EXPLAIN SELECT * FROM pairs, square WHERE pairs.b = square.n
 ----
-·          distributed         false
+·          distribution        local
 ·          vectorized          true
 hash-join  ·                   ·
  │         type                inner
@@ -502,106 +502,106 @@ hash-join  ·                   ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.sq
 ----
-·                    distributed  false             ·                       ·
-·                    vectorized   true              ·                       ·
-render               ·            ·                 (a, b, n, sq)           ·
- │                   render 0     a                 ·                       ·
- │                   render 1     b                 ·                       ·
- │                   render 2     n                 ·                       ·
- │                   render 3     sq                ·                       ·
- └── hash-join       ·            ·                 (column6, a, b, n, sq)  ·
-      │              type         inner             ·                       ·
-      │              equality     (column6) = (sq)  ·                       ·
-      ├── render     ·            ·                 (column6, a, b)         ·
-      │    │         render 0     a + b             ·                       ·
-      │    │         render 1     a                 ·                       ·
-      │    │         render 2     b                 ·                       ·
-      │    └── scan  ·            ·                 (a, b)                  ·
-      │              table        pairs@primary     ·                       ·
-      │              spans        FULL SCAN         ·                       ·
-      └── scan       ·            ·                 (n, sq)                 ·
-·                    table        square@primary    ·                       ·
-·                    spans        FULL SCAN         ·                       ·
+·                    distribution  local             ·                       ·
+·                    vectorized    true              ·                       ·
+render               ·             ·                 (a, b, n, sq)           ·
+ │                   render 0      a                 ·                       ·
+ │                   render 1      b                 ·                       ·
+ │                   render 2      n                 ·                       ·
+ │                   render 3      sq                ·                       ·
+ └── hash-join       ·             ·                 (column6, a, b, n, sq)  ·
+      │              type          inner             ·                       ·
+      │              equality      (column6) = (sq)  ·                       ·
+      ├── render     ·             ·                 (column6, a, b)         ·
+      │    │         render 0      a + b             ·                       ·
+      │    │         render 1      a                 ·                       ·
+      │    │         render 2      b                 ·                       ·
+      │    └── scan  ·             ·                 (a, b)                  ·
+      │              table         pairs@primary     ·                       ·
+      │              spans         FULL SCAN         ·                       ·
+      └── scan       ·             ·                 (n, sq)                 ·
+·                    table         square@primary    ·                       ·
+·                    spans         FULL SCAN         ·                       ·
 
 # Query similar to the one above, but the filter refers to a rendered
 # expression and can't "break through".
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a, b, n, sq FROM (SELECT a, b, a * b / 2 AS div, n, sq FROM pairs, square) WHERE div = sq
 ----
-·                          distributed  false           ·                   ·
-·                          vectorized   true            ·                   ·
-render                     ·            ·               (a, b, n, sq)       ·
- │                         render 0     a               ·                   ·
- │                         render 1     b               ·                   ·
- │                         render 2     n               ·                   ·
- │                         render 3     sq              ·                   ·
- └── filter                ·            ·               (div, a, b, n, sq)  ·
-      │                    filter       div = sq        ·                   ·
-      └── render           ·            ·               (div, a, b, n, sq)  ·
-           │               render 0     (a * b) / 2     ·                   ·
-           │               render 1     a               ·                   ·
-           │               render 2     b               ·                   ·
-           │               render 3     n               ·                   ·
-           │               render 4     sq              ·                   ·
-           └── cross-join  ·            ·               (a, b, n, sq)       ·
-                │          type         cross           ·                   ·
-                ├── scan   ·            ·               (a, b)              ·
-                │          table        pairs@primary   ·                   ·
-                │          spans        FULL SCAN       ·                   ·
-                └── scan   ·            ·               (n, sq)             ·
-·                          table        square@primary  ·                   ·
-·                          spans        FULL SCAN       ·                   ·
+·                          distribution  local           ·                   ·
+·                          vectorized    true            ·                   ·
+render                     ·             ·               (a, b, n, sq)       ·
+ │                         render 0      a               ·                   ·
+ │                         render 1      b               ·                   ·
+ │                         render 2      n               ·                   ·
+ │                         render 3      sq              ·                   ·
+ └── filter                ·             ·               (div, a, b, n, sq)  ·
+      │                    filter        div = sq        ·                   ·
+      └── render           ·             ·               (div, a, b, n, sq)  ·
+           │               render 0      (a * b) / 2     ·                   ·
+           │               render 1      a               ·                   ·
+           │               render 2      b               ·                   ·
+           │               render 3      n               ·                   ·
+           │               render 4      sq              ·                   ·
+           └── cross-join  ·             ·               (a, b, n, sq)       ·
+                │          type          cross           ·                   ·
+                ├── scan   ·             ·               (a, b)              ·
+                │          table         pairs@primary   ·                   ·
+                │          spans         FULL SCAN       ·                   ·
+                └── scan   ·             ·               (n, sq)             ·
+·                          table         square@primary  ·                   ·
+·                          spans         FULL SCAN       ·                   ·
 
 # The filter expression must stay on top of the outer join.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq
 ----
-·                    distributed  false             ·                       ·
-·                    vectorized   true              ·                       ·
-render               ·            ·                 (a, b, n, sq)           ·
- │                   render 0     a                 ·                       ·
- │                   render 1     b                 ·                       ·
- │                   render 2     n                 ·                       ·
- │                   render 3     sq                ·                       ·
- └── hash-join       ·            ·                 (column6, a, b, n, sq)  ·
-      │              type         full outer        ·                       ·
-      │              equality     (column6) = (sq)  ·                       ·
-      ├── render     ·            ·                 (column6, a, b)         ·
-      │    │         render 0     a + b             ·                       ·
-      │    │         render 1     a                 ·                       ·
-      │    │         render 2     b                 ·                       ·
-      │    └── scan  ·            ·                 (a, b)                  ·
-      │              table        pairs@primary     ·                       ·
-      │              spans        FULL SCAN         ·                       ·
-      └── scan       ·            ·                 (n, sq)                 ·
-·                    table        square@primary    ·                       ·
-·                    spans        FULL SCAN         ·                       ·
+·                    distribution  local             ·                       ·
+·                    vectorized    true              ·                       ·
+render               ·             ·                 (a, b, n, sq)           ·
+ │                   render 0      a                 ·                       ·
+ │                   render 1      b                 ·                       ·
+ │                   render 2      n                 ·                       ·
+ │                   render 3      sq                ·                       ·
+ └── hash-join       ·             ·                 (column6, a, b, n, sq)  ·
+      │              type          full outer        ·                       ·
+      │              equality      (column6) = (sq)  ·                       ·
+      ├── render     ·             ·                 (column6, a, b)         ·
+      │    │         render 0      a + b             ·                       ·
+      │    │         render 1      a                 ·                       ·
+      │    │         render 2      b                 ·                       ·
+      │    └── scan  ·             ·                 (a, b)                  ·
+      │              table         pairs@primary     ·                       ·
+      │              spans         FULL SCAN         ·                       ·
+      └── scan       ·             ·                 (n, sq)                 ·
+·                    table         square@primary    ·                       ·
+·                    spans         FULL SCAN         ·                       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq WHERE pairs.b%2 <> square.sq%2
 ----
-·                         distributed  false                ·                       ·
-·                         vectorized   true                 ·                       ·
-render                    ·            ·                    (a, b, n, sq)           ·
- │                        render 0     a                    ·                       ·
- │                        render 1     b                    ·                       ·
- │                        render 2     n                    ·                       ·
- │                        render 3     sq                   ·                       ·
- └── filter               ·            ·                    (column6, a, b, n, sq)  ·
-      │                   filter       (b % 2) != (sq % 2)  ·                       ·
-      └── hash-join       ·            ·                    (column6, a, b, n, sq)  ·
-           │              type         full outer           ·                       ·
-           │              equality     (column6) = (sq)     ·                       ·
-           ├── render     ·            ·                    (column6, a, b)         ·
-           │    │         render 0     a + b                ·                       ·
-           │    │         render 1     a                    ·                       ·
-           │    │         render 2     b                    ·                       ·
-           │    └── scan  ·            ·                    (a, b)                  ·
-           │              table        pairs@primary        ·                       ·
-           │              spans        FULL SCAN            ·                       ·
-           └── scan       ·            ·                    (n, sq)                 ·
-·                         table        square@primary       ·                       ·
-·                         spans        FULL SCAN            ·                       ·
+·                         distribution  local                ·                       ·
+·                         vectorized    true                 ·                       ·
+render                    ·             ·                    (a, b, n, sq)           ·
+ │                        render 0      a                    ·                       ·
+ │                        render 1      b                    ·                       ·
+ │                        render 2      n                    ·                       ·
+ │                        render 3      sq                   ·                       ·
+ └── filter               ·             ·                    (column6, a, b, n, sq)  ·
+      │                   filter        (b % 2) != (sq % 2)  ·                       ·
+      └── hash-join       ·             ·                    (column6, a, b, n, sq)  ·
+           │              type          full outer           ·                       ·
+           │              equality      (column6) = (sq)     ·                       ·
+           ├── render     ·             ·                    (column6, a, b)         ·
+           │    │         render 0      a + b                ·                       ·
+           │    │         render 1      a                    ·                       ·
+           │    │         render 2      b                    ·                       ·
+           │    └── scan  ·             ·                    (a, b)                  ·
+           │              table         pairs@primary        ·                       ·
+           │              spans         FULL SCAN            ·                       ·
+           └── scan       ·             ·                    (n, sq)                 ·
+·                         table         square@primary       ·                       ·
+·                         spans         FULL SCAN            ·                       ·
 
 # Filter propagation through outer joins.
 
@@ -613,22 +613,22 @@ SELECT *
  WHERE b > 1 AND (n IS NULL OR n > 1) AND (n IS NULL OR a  < sq)
 ]
 ----
-·               distributed  false
-·               vectorized   true
-filter          ·            ·
- │              filter       ((n IS NULL) OR (n > 1)) AND ((n IS NULL) OR (a < sq))
- └── hash-join  ·            ·
-      │         type         left outer
-      │         equality     (b) = (sq)
-      │         pred         a > 1
-      ├── scan  ·            ·
-      │         table        pairs@primary
-      │         spans        FULL SCAN
-      │         filter       b > 1
-      └── scan  ·            ·
-·               table        square@primary
-·               spans        -/5/#
-·               filter       sq > 1
+·               distribution  local
+·               vectorized    true
+filter          ·             ·
+ │              filter        ((n IS NULL) OR (n > 1)) AND ((n IS NULL) OR (a < sq))
+ └── hash-join  ·             ·
+      │         type          left outer
+      │         equality      (b) = (sq)
+      │         pred          a > 1
+      ├── scan  ·             ·
+      │         table         pairs@primary
+      │         spans         FULL SCAN
+      │         filter        b > 1
+      └── scan  ·             ·
+·               table         square@primary
+·               spans         -/5/#
+·               filter        sq > 1
 
 query TTT
 SELECT tree, field, description FROM [
@@ -638,26 +638,26 @@ SELECT *
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
 ]
 ----
-·                    distributed  false
-·                    vectorized   true
-render               ·            ·
- │                   render 0     a
- │                   render 1     b
- │                   render 2     n
- │                   render 3     sq
- └── filter          ·            ·
-      │              filter       ((a IS NULL) OR (a > 2)) AND ((a IS NULL) OR (a < sq))
-      └── hash-join  ·            ·
-           │         type         left outer
-           │         equality     (sq) = (b)
-           │         pred         n < 6
-           ├── scan  ·            ·
-           │         table        square@primary
-           │         spans        /2-
-           └── scan  ·            ·
-·                    table        pairs@primary
-·                    spans        FULL SCAN
-·                    filter       a > 1
+·                    distribution  local
+·                    vectorized    true
+render               ·             ·
+ │                   render 0      a
+ │                   render 1      b
+ │                   render 2      n
+ │                   render 3      sq
+ └── filter          ·             ·
+      │              filter        ((a IS NULL) OR (a > 2)) AND ((a IS NULL) OR (a < sq))
+      └── hash-join  ·             ·
+           │         type          left outer
+           │         equality      (sq) = (b)
+           │         pred          n < 6
+           ├── scan  ·             ·
+           │         table         square@primary
+           │         spans         /2-
+           └── scan  ·             ·
+·                    table         pairs@primary
+·                    spans         FULL SCAN
+·                    filter        a > 1
 
 # The simpler plan for an inner join, to compare.
 query TTT
@@ -668,19 +668,19 @@ SELECT *
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
 ]
 ----
-·          distributed  false
-·          vectorized   true
-hash-join  ·            ·
- │         type         inner
- │         equality     (b) = (sq)
- ├── scan  ·            ·
- │         table        pairs@primary
- │         spans        FULL SCAN
- │         filter       ((a > 1) AND ((a IS NULL) OR (a > 2))) AND ((a IS NULL) OR (a < b))
- └── scan  ·            ·
-·          table        square@primary
-·          spans        /2-/5/#
-·          parallel     ·
+·          distribution  local
+·          vectorized    true
+hash-join  ·             ·
+ │         type          inner
+ │         equality      (b) = (sq)
+ ├── scan  ·             ·
+ │         table         pairs@primary
+ │         spans         FULL SCAN
+ │         filter        ((a > 1) AND ((a IS NULL) OR (a > 2))) AND ((a IS NULL) OR (a < b))
+ └── scan  ·             ·
+·          table         square@primary
+·          spans         /2-/5/#
+·          parallel      ·
 
 
 statement ok
@@ -692,19 +692,19 @@ CREATE TABLE t2 (col3 INT, y INT, x INT, col4 INT)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x FROM t1 NATURAL JOIN (SELECT * FROM t2)
 ----
-·               distributed  false            ·             ·
-·               vectorized   true             ·             ·
-render          ·            ·                (x)           ·
- │              render 0     x                ·             ·
- └── hash-join  ·            ·                (x, y, y, x)  ·
-      │         type         inner            ·             ·
-      │         equality     (x, y) = (x, y)  ·             ·
-      ├── scan  ·            ·                (x, y)        ·
-      │         table        t1@primary       ·             ·
-      │         spans        FULL SCAN        ·             ·
-      └── scan  ·            ·                (y, x)        ·
-·               table        t2@primary       ·             ·
-·               spans        FULL SCAN        ·             ·
+·               distribution  local            ·             ·
+·               vectorized    true             ·             ·
+render          ·             ·                (x)           ·
+ │              render 0      x                ·             ·
+ └── hash-join  ·             ·                (x, y, y, x)  ·
+      │         type          inner            ·             ·
+      │         equality      (x, y) = (x, y)  ·             ·
+      ├── scan  ·             ·                (x, y)        ·
+      │         table         t1@primary       ·             ·
+      │         spans         FULL SCAN        ·             ·
+      └── scan  ·             ·                (y, x)        ·
+·               table         t2@primary       ·             ·
+·               spans         FULL SCAN        ·             ·
 
 # Tests for merge join ordering information.
 statement ok
@@ -722,7 +722,7 @@ CREATE TABLE pkBAD (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a,d))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBA AS l JOIN pkBC AS r ON l.a = r.a AND l.b = r.b AND l.c = r.c
 ----
-·          distributed         false                  ·                         ·
+·          distribution        local                  ·                         ·
 ·          vectorized          true                   ·                         ·
 hash-join  ·                   ·                      (a, b, c, d, a, b, c, d)  ·
  │         type                inner                  ·                         ·
@@ -739,7 +739,7 @@ hash-join  ·                   ·                      (a, b, c, d, a, b, c, d)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBA NATURAL JOIN pkBAD
 ----
-·               distributed         false                        ·                         ·
+·               distribution        local                        ·                         ·
 ·               vectorized          true                         ·                         ·
 render          ·                   ·                            (a, b, c, d)              ·
  │              render 0            a                            ·                         ·
@@ -761,7 +761,7 @@ render          ·                   ·                            (a, b, c, d) 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAC AS r USING(a, b, c)
 ----
-·                distributed         false                       ·                         ·
+·                distribution        local                       ·                         ·
 ·                vectorized          true                        ·                         ·
 render           ·                   ·                           (a, b, c, d, d)           ·
  │               render 0            a                           ·                         ·
@@ -785,7 +785,7 @@ render           ·                   ·                           (a, b, c, d, 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a = r.a AND l.b = r.b
 ----
-·           distributed         false                       ·                         ·
+·           distribution        local                       ·                         ·
 ·           vectorized          true                        ·                         ·
 merge-join  ·                   ·                           (a, b, c, d, a, b, c, d)  ·
  │          type                inner                       ·                         ·
@@ -810,85 +810,85 @@ CREATE TABLE str2 (a INT PRIMARY KEY, s STRING COLLATE en_u_ks_level1)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 INNER JOIN str2 USING(s)
 ----
-·               distributed  false         ·          ·
-·               vectorized   true          ·          ·
-render          ·            ·             (s, s, s)  ·
- │              render 0     s             ·          ·
- │              render 1     s             ·          ·
- │              render 2     s             ·          ·
- └── hash-join  ·            ·             (s, s)     ·
-      │         type         inner         ·          ·
-      │         equality     (s) = (s)     ·          ·
-      ├── scan  ·            ·             (s)        ·
-      │         table        str1@primary  ·          ·
-      │         spans        FULL SCAN     ·          ·
-      └── scan  ·            ·             (s)        ·
-·               table        str2@primary  ·          ·
-·               spans        FULL SCAN     ·          ·
+·               distribution  local         ·          ·
+·               vectorized    true          ·          ·
+render          ·             ·             (s, s, s)  ·
+ │              render 0      s             ·          ·
+ │              render 1      s             ·          ·
+ │              render 2      s             ·          ·
+ └── hash-join  ·             ·             (s, s)     ·
+      │         type          inner         ·          ·
+      │         equality      (s) = (s)     ·          ·
+      ├── scan  ·             ·             (s)        ·
+      │         table         str1@primary  ·          ·
+      │         spans         FULL SCAN     ·          ·
+      └── scan  ·             ·             (s)        ·
+·               table         str2@primary  ·          ·
+·               spans         FULL SCAN     ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 LEFT OUTER JOIN str2 USING(s)
 ----
-·               distributed  false         ·          ·
-·               vectorized   true          ·          ·
-render          ·            ·             (s, s, s)  ·
- │              render 0     s             ·          ·
- │              render 1     s             ·          ·
- │              render 2     s             ·          ·
- └── hash-join  ·            ·             (s, s)     ·
-      │         type         left outer    ·          ·
-      │         equality     (s) = (s)     ·          ·
-      ├── scan  ·            ·             (s)        ·
-      │         table        str1@primary  ·          ·
-      │         spans        FULL SCAN     ·          ·
-      └── scan  ·            ·             (s)        ·
-·               table        str2@primary  ·          ·
-·               spans        FULL SCAN     ·          ·
+·               distribution  local         ·          ·
+·               vectorized    true          ·          ·
+render          ·             ·             (s, s, s)  ·
+ │              render 0      s             ·          ·
+ │              render 1      s             ·          ·
+ │              render 2      s             ·          ·
+ └── hash-join  ·             ·             (s, s)     ·
+      │         type          left outer    ·          ·
+      │         equality      (s) = (s)     ·          ·
+      ├── scan  ·             ·             (s)        ·
+      │         table         str1@primary  ·          ·
+      │         spans         FULL SCAN     ·          ·
+      └── scan  ·             ·             (s)        ·
+·               table         str2@primary  ·          ·
+·               spans         FULL SCAN     ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 RIGHT OUTER JOIN str2 USING(s)
 ----
-·               distributed  false           ·          ·
-·               vectorized   true            ·          ·
-render          ·            ·               (s, s, s)  ·
- │              render 0     COALESCE(s, s)  ·          ·
- │              render 1     s               ·          ·
- │              render 2     s               ·          ·
- └── hash-join  ·            ·               (s, s)     ·
-      │         type         left outer      ·          ·
-      │         equality     (s) = (s)       ·          ·
-      ├── scan  ·            ·               (s)        ·
-      │         table        str2@primary    ·          ·
-      │         spans        FULL SCAN       ·          ·
-      └── scan  ·            ·               (s)        ·
-·               table        str1@primary    ·          ·
-·               spans        FULL SCAN       ·          ·
+·               distribution  local           ·          ·
+·               vectorized    true            ·          ·
+render          ·             ·               (s, s, s)  ·
+ │              render 0      COALESCE(s, s)  ·          ·
+ │              render 1      s               ·          ·
+ │              render 2      s               ·          ·
+ └── hash-join  ·             ·               (s, s)     ·
+      │         type          left outer      ·          ·
+      │         equality      (s) = (s)       ·          ·
+      ├── scan  ·             ·               (s)        ·
+      │         table         str2@primary    ·          ·
+      │         spans         FULL SCAN       ·          ·
+      └── scan  ·             ·               (s)        ·
+·               table         str1@primary    ·          ·
+·               spans         FULL SCAN       ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 FULL OUTER JOIN str2 USING(s)
 ----
-·               distributed  false           ·          ·
-·               vectorized   true            ·          ·
-render          ·            ·               (s, s, s)  ·
- │              render 0     COALESCE(s, s)  ·          ·
- │              render 1     s               ·          ·
- │              render 2     s               ·          ·
- └── hash-join  ·            ·               (s, s)     ·
-      │         type         full outer      ·          ·
-      │         equality     (s) = (s)       ·          ·
-      ├── scan  ·            ·               (s)        ·
-      │         table        str1@primary    ·          ·
-      │         spans        FULL SCAN       ·          ·
-      └── scan  ·            ·               (s)        ·
-·               table        str2@primary    ·          ·
-·               spans        FULL SCAN       ·          ·
+·               distribution  local           ·          ·
+·               vectorized    true            ·          ·
+render          ·             ·               (s, s, s)  ·
+ │              render 0      COALESCE(s, s)  ·          ·
+ │              render 1      s               ·          ·
+ │              render 2      s               ·          ·
+ └── hash-join  ·             ·               (s, s)     ·
+      │         type          full outer      ·          ·
+      │         equality      (s) = (s)       ·          ·
+      ├── scan  ·             ·               (s)        ·
+      │         table         str1@primary    ·          ·
+      │         spans         FULL SCAN       ·          ·
+      └── scan  ·             ·               (s)        ·
+·               table         str2@primary    ·          ·
+·               spans         FULL SCAN       ·          ·
 
 # Verify that we resolve the merged column a to str2.a but use IFNULL for
 # column s which is a collated string.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM str1 RIGHT OUTER JOIN str2 USING(a, s)
 ----
-·               distributed         false            ·             ·
+·               distribution        local            ·             ·
 ·               vectorized          true             ·             ·
 render          ·                   ·                (a, s)        ·
  │              render 0            a                ·             ·
@@ -915,7 +915,7 @@ CREATE TABLE xyv (x INT, y INT, v INT, PRIMARY KEY(x,y,v))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv USING(x, y) WHERE x > 2
 ----
-·                distributed     false              ·                   ·
+·                distribution    local              ·                   ·
 ·                vectorized      true               ·                   ·
 render           ·               ·                  (x, y, u, v)        ·
  │               render 0        x                  ·                   ·
@@ -936,7 +936,7 @@ render           ·               ·                  (x, y, u, v)        ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-·                distributed     false              ·                   ·
+·                distribution    local              ·                   ·
 ·                vectorized      true               ·                   ·
 render           ·               ·                  (x, y, u, v)        ·
  │               render 0        x                  ·                   ·
@@ -957,7 +957,7 @@ render           ·               ·                  (x, y, u, v)        ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-·                distributed     false              ·                   ·
+·                distribution    local              ·                   ·
 ·                vectorized      true               ·                   ·
 render           ·               ·                  (x, y, u, v)        ·
  │               render 0        x                  ·                   ·
@@ -978,7 +978,7 @@ render           ·               ·                  (x, y, u, v)        ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu FULL OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-·                     distributed     false              ·                   ·
+·                     distribution    local              ·                   ·
 ·                     vectorized      true               ·                   ·
 filter                ·               ·                  (x, y, u, v)        ·
  │                    filter          x > 2              ·                   ·
@@ -1002,7 +1002,7 @@ filter                ·               ·                  (x, y, u, v)        �
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y WHERE xyu.x = 1 AND xyu.y < 10
 ----
-·           distributed     false              ·                   ·
+·           distribution    local              ·                   ·
 ·           vectorized      true               ·                   ·
 merge-join  ·               ·                  (x, y, u, x, y, v)  ·
  │          type            inner              ·                   ·
@@ -1018,7 +1018,7 @@ merge-join  ·               ·                  (x, y, u, x, y, v)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-·           distributed     false              ·                   ·
+·           distribution    local              ·                   ·
 ·           vectorized      true               ·                   ·
 merge-join  ·               ·                  (x, y, u, x, y, v)  ·
  │          type            inner              ·                   ·
@@ -1034,7 +1034,7 @@ merge-join  ·               ·                  (x, y, u, x, y, v)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-·           distributed     false              ·                   ·
+·           distribution    local              ·                   ·
 ·           vectorized      true               ·                   ·
 merge-join  ·               ·                  (x, y, u, x, y, v)  ·
  │          type            left outer         ·                   ·
@@ -1050,7 +1050,7 @@ merge-join  ·               ·                  (x, y, u, x, y, v)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-·                distributed     false              ·                   ·
+·                distribution    local              ·                   ·
 ·                vectorized      true               ·                   ·
 render           ·               ·                  (x, y, u, x, y, v)  ·
  │               render 0        x                  ·                   ·
@@ -1076,7 +1076,7 @@ render           ·               ·                  (x, y, u, x, y, v)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-·                distributed     false              ·                   ·
+·                distribution    local              ·                   ·
 ·                vectorized      true               ·                   ·
 render           ·               ·                  (x, y, u, v)        ·
  │               render 0        x                  ·                   ·
@@ -1097,7 +1097,7 @@ render           ·               ·                  (x, y, u, v)        ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-·                distributed     false              ·                   ·
+·                distribution    local              ·                   ·
 ·                vectorized      true               ·                   ·
 render           ·               ·                  (x, y, u, v)        ·
  │               render 0        x                  ·                   ·
@@ -1118,7 +1118,7 @@ render           ·               ·                  (x, y, u, v)        ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu FULL OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-·                     distributed     false              ·                   ·
+·                     distribution    local              ·                   ·
 ·                     vectorized      true               ·                   ·
 filter                ·               ·                  (x, y, u, v)        ·
  │                    filter          x > 2              ·                   ·
@@ -1141,7 +1141,7 @@ filter                ·               ·                  (x, y, u, v)        �
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-·           distributed     false              ·                   ·
+·           distribution    local              ·                   ·
 ·           vectorized      true               ·                   ·
 merge-join  ·               ·                  (x, y, u, x, y, v)  ·
  │          type            left outer         ·                   ·
@@ -1157,7 +1157,7 @@ merge-join  ·               ·                  (x, y, u, x, y, v)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-·                distributed     false              ·                   ·
+·                distribution    local              ·                   ·
 ·                vectorized      true               ·                   ·
 render           ·               ·                  (x, y, u, x, y, v)  ·
  │               render 0        x                  ·                   ·
@@ -1181,7 +1181,7 @@ render           ·               ·                  (x, y, u, x, y, v)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu JOIN xyv USING(x, y) WHERE (x, y, u) > (1, 2, 3)
 ----
-·                distributed     false              ·                   ·
+·                distribution    local              ·                   ·
 ·                vectorized      true               ·                   ·
 render           ·               ·                  (x, y, u, v)        ·
  │               render 0        x                  ·                   ·
@@ -1213,7 +1213,7 @@ CREATE TABLE r (a INT PRIMARY KEY, b2 INT, FAMILY (a))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r USING(a) WHERE a = 3;
 ----
-·                distributed         false       ·               ·
+·                distribution        local       ·               ·
 ·                vectorized          true        ·               ·
 render           ·                   ·           (a, b1, b2)     ·
  │               render 0            a           ·               ·
@@ -1235,7 +1235,7 @@ render           ·                   ·           (a, b1, b2)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r ON l.a = r.a WHERE l.a = 3;
 ----
-·           distributed         false       ·               ·
+·           distribution        local       ·               ·
 ·           vectorized          true        ·               ·
 merge-join  ·                   ·           (a, b1, a, b2)  ·
  │          type                left outer  ·               ·
@@ -1253,7 +1253,7 @@ merge-join  ·                   ·           (a, b1, a, b2)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l RIGHT OUTER JOIN r USING(a) WHERE a = 3;
 ----
-·                distributed         false       ·               ·
+·                distribution        local       ·               ·
 ·                vectorized          true        ·               ·
 render           ·                   ·           (a, b1, b2)     ·
  │               render 0            a           ·               ·
@@ -1275,7 +1275,7 @@ render           ·                   ·           (a, b1, b2)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l RIGHT OUTER JOIN r ON l.a = r.a WHERE r.a = 3;
 ----
-·                distributed         false       ·               ·
+·                distribution        local       ·               ·
 ·                vectorized          true        ·               ·
 render           ·                   ·           (a, b1, a, b2)  ·
  │               render 0            a           ·               ·
@@ -1318,7 +1318,7 @@ CREATE TABLE abg (
 query TTT
 EXPLAIN SELECT * FROM abcdef join (select * from abg) USING (a,b) WHERE ((a,b)>(1,2) OR ((a,b)=(1,2) AND c < 6) OR ((a,b,c)=(1,2,6) AND d > 8))
 ----
-·                distributed         false
+·                distribution        local
 ·                vectorized          true
 render           ·                   ·
  └── merge-join  ·                   ·
@@ -1356,23 +1356,23 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo NATURAL JOIN bar
 ]
 ----
-·               distributed  false
-·               vectorized   true
-render          ·            ·
- │              render 0     a
- │              render 1     b
- │              render 2     c
- │              render 3     d
- └── hash-join  ·            ·
-      │         type         inner
-      │         equality     (a, c) = (a, c)
-      │         pred         (b = b) AND (d = d)
-      ├── scan  ·            ·
-      │         table        foo@primary
-      │         spans        FULL SCAN
-      └── scan  ·            ·
-·               table        bar@primary
-·               spans        FULL SCAN
+·               distribution  local
+·               vectorized    true
+render          ·             ·
+ │              render 0      a
+ │              render 1      b
+ │              render 2      c
+ │              render 3      d
+ └── hash-join  ·             ·
+      │         type          inner
+      │         equality      (a, c) = (a, c)
+      │         pred          (b = b) AND (d = d)
+      ├── scan  ·             ·
+      │         table         foo@primary
+      │         spans         FULL SCAN
+      └── scan  ·             ·
+·               table         bar@primary
+·               spans         FULL SCAN
 
 # b can't be an equality column.
 query TTT
@@ -1380,25 +1380,25 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar USING (b)
 ]
 ----
-·                distributed  false
-·                vectorized   true
-render           ·            ·
- │               render 0     b
- │               render 1     a
- │               render 2     c
- │               render 3     d
- │               render 4     a
- │               render 5     c
- │               render 6     d
- └── cross-join  ·            ·
-      │          type         inner
-      │          pred         b = b
-      ├── scan   ·            ·
-      │          table        foo@primary
-      │          spans        FULL SCAN
-      └── scan   ·            ·
-·                table        bar@primary
-·                spans        FULL SCAN
+·                distribution  local
+·                vectorized    true
+render           ·             ·
+ │               render 0      b
+ │               render 1      a
+ │               render 2      c
+ │               render 3      d
+ │               render 4      a
+ │               render 5      c
+ │               render 6      d
+ └── cross-join  ·             ·
+      │          type          inner
+      │          pred          b = b
+      ├── scan   ·             ·
+      │          table         foo@primary
+      │          spans         FULL SCAN
+      └── scan   ·             ·
+·                table         bar@primary
+·                spans         FULL SCAN
 
 # Only a can be an equality column.
 query TTT
@@ -1406,25 +1406,25 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar USING (a, b)
 ]
 ----
-·               distributed  false
-·               vectorized   true
-render          ·            ·
- │              render 0     a
- │              render 1     b
- │              render 2     c
- │              render 3     d
- │              render 4     c
- │              render 5     d
- └── hash-join  ·            ·
-      │         type         inner
-      │         equality     (a) = (a)
-      │         pred         b = b
-      ├── scan  ·            ·
-      │         table        foo@primary
-      │         spans        FULL SCAN
-      └── scan  ·            ·
-·               table        bar@primary
-·               spans        FULL SCAN
+·               distribution  local
+·               vectorized    true
+render          ·             ·
+ │              render 0      a
+ │              render 1      b
+ │              render 2      c
+ │              render 3      d
+ │              render 4      c
+ │              render 5      d
+ └── hash-join  ·             ·
+      │         type          inner
+      │         equality      (a) = (a)
+      │         pred          b = b
+      ├── scan  ·             ·
+      │         table         foo@primary
+      │         spans         FULL SCAN
+      └── scan  ·             ·
+·               table         bar@primary
+·               spans         FULL SCAN
 
 # Only a and c can be equality columns.
 query TTT
@@ -1432,24 +1432,24 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar USING (a, b, c)
 ]
 ----
-·               distributed  false
-·               vectorized   true
-render          ·            ·
- │              render 0     a
- │              render 1     b
- │              render 2     c
- │              render 3     d
- │              render 4     d
- └── hash-join  ·            ·
-      │         type         inner
-      │         equality     (a, c) = (a, c)
-      │         pred         b = b
-      ├── scan  ·            ·
-      │         table        foo@primary
-      │         spans        FULL SCAN
-      └── scan  ·            ·
-·               table        bar@primary
-·               spans        FULL SCAN
+·               distribution  local
+·               vectorized    true
+render          ·             ·
+ │              render 0      a
+ │              render 1      b
+ │              render 2      c
+ │              render 3      d
+ │              render 4      d
+ └── hash-join  ·             ·
+      │         type          inner
+      │         equality      (a, c) = (a, c)
+      │         pred          b = b
+      ├── scan  ·             ·
+      │         table         foo@primary
+      │         spans         FULL SCAN
+      └── scan  ·             ·
+·               table         bar@primary
+·               spans         FULL SCAN
 
 # b can't be an equality column.
 query TTT
@@ -1457,17 +1457,17 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar ON foo.b = bar.b
 ]
 ----
-·           distributed  false
-·           vectorized   true
-cross-join  ·            ·
- │          type         inner
- │          pred         b = b
- ├── scan   ·            ·
- │          table        foo@primary
- │          spans        FULL SCAN
- └── scan   ·            ·
-·           table        bar@primary
-·           spans        FULL SCAN
+·           distribution  local
+·           vectorized    true
+cross-join  ·             ·
+ │          type          inner
+ │          pred          b = b
+ ├── scan   ·             ·
+ │          table         foo@primary
+ │          spans         FULL SCAN
+ └── scan   ·             ·
+·           table         bar@primary
+·           spans         FULL SCAN
 
 # Only a can be an equality column.
 query TTT
@@ -1475,35 +1475,35 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar ON foo.a = bar.a AND foo.b = bar.b
 ]
 ----
-·          distributed  false
-·          vectorized   true
-hash-join  ·            ·
- │         type         inner
- │         equality     (a) = (a)
- │         pred         b = b
- ├── scan  ·            ·
- │         table        foo@primary
- │         spans        FULL SCAN
- └── scan  ·            ·
-·          table        bar@primary
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+hash-join  ·             ·
+ │         type          inner
+ │         equality      (a) = (a)
+ │         pred          b = b
+ ├── scan  ·             ·
+ │         table         foo@primary
+ │         spans         FULL SCAN
+ └── scan  ·             ·
+·          table         bar@primary
+·          spans         FULL SCAN
 
 query TTT
 SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo, bar WHERE foo.b = bar.b
 ]
 ----
-·           distributed  false
-·           vectorized   true
-cross-join  ·            ·
- │          type         inner
- │          pred         b = b
- ├── scan   ·            ·
- │          table        foo@primary
- │          spans        FULL SCAN
- └── scan   ·            ·
-·           table        bar@primary
-·           spans        FULL SCAN
+·           distribution  local
+·           vectorized    true
+cross-join  ·             ·
+ │          type          inner
+ │          pred          b = b
+ ├── scan   ·             ·
+ │          table         foo@primary
+ │          spans         FULL SCAN
+ └── scan   ·             ·
+·           table         bar@primary
+·           spans         FULL SCAN
 
 # Only a can be an equality column.
 query TTT
@@ -1511,36 +1511,36 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo, bar WHERE foo.a = bar.a AND foo.b = bar.b
 ]
 ----
-·          distributed  false
-·          vectorized   true
-hash-join  ·            ·
- │         type         inner
- │         equality     (a) = (a)
- │         pred         b = b
- ├── scan  ·            ·
- │         table        foo@primary
- │         spans        FULL SCAN
- └── scan  ·            ·
-·          table        bar@primary
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+hash-join  ·             ·
+ │         type          inner
+ │         equality      (a) = (a)
+ │         pred          b = b
+ ├── scan  ·             ·
+ │         table         foo@primary
+ │         spans         FULL SCAN
+ └── scan  ·             ·
+·          table         bar@primary
+·          spans         FULL SCAN
 
 # Only a and c can be equality columns.
 query TTT
 EXPLAIN SELECT * FROM foo JOIN bar USING (a,b) WHERE foo.c = bar.c AND foo.d = bar.d
 ----
-·               distributed  false
-·               vectorized   true
-render          ·            ·
- └── hash-join  ·            ·
-      │         type         inner
-      │         equality     (a, c) = (a, c)
-      │         pred         (b = b) AND (d = d)
-      ├── scan  ·            ·
-      │         table        foo@primary
-      │         spans        FULL SCAN
-      └── scan  ·            ·
-·               table        bar@primary
-·               spans        FULL SCAN
+·               distribution  local
+·               vectorized    true
+render          ·             ·
+ └── hash-join  ·             ·
+      │         type          inner
+      │         equality      (a, c) = (a, c)
+      │         pred          (b = b) AND (d = d)
+      ├── scan  ·             ·
+      │         table         foo@primary
+      │         spans         FULL SCAN
+      └── scan  ·             ·
+·               table         bar@primary
+·               spans         FULL SCAN
 
 # Zigzag join tests.
 statement ok
@@ -1560,16 +1560,16 @@ SET enable_zigzag_join = false
 query TTT
 EXPLAIN SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0
 ----
-·                distributed  false
-·                vectorized   true
-filter           ·            ·
- │               filter       c = 6.0
- └── index-join  ·            ·
-      │          table        zigzag@primary
-      │          key columns  a
-      └── scan   ·            ·
-·                table        zigzag@b_idx
-·                spans        /5-/6
+·                distribution  local
+·                vectorized    true
+filter           ·             ·
+ │               filter        c = 6.0
+ └── index-join  ·             ·
+      │          table         zigzag@primary
+      │          key columns   a
+      └── scan   ·             ·
+·                table         zigzag@b_idx
+·                spans         /5-/6
 
 # Enable zigzag joins.
 statement ok
@@ -1579,24 +1579,24 @@ SET enable_zigzag_join = true
 query TTT
 EXPLAIN SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0
 ----
-·            distributed  false
-·            vectorized   true
-zigzag-join  ·            ·
- │           type         inner
- │           pred         (@2 = 5) AND (@3 = 6.0)
- ├── scan    ·            ·
- │           table        zigzag@b_idx
- │           fixedvals    1 column
- └── scan    ·            ·
-·            table        zigzag@c_idx
-·            fixedvals    1 column
+·            distribution  local
+·            vectorized    true
+zigzag-join  ·             ·
+ │           type          inner
+ │           pred          (@2 = 5) AND (@3 = 6.0)
+ ├── scan    ·             ·
+ │           table         zigzag@b_idx
+ │           fixedvals     1 column
+ └── scan    ·             ·
+·            table         zigzag@c_idx
+·            fixedvals     1 column
 
 
 # Zigzag join nested inside a lookup.
 query TTT
 EXPLAIN SELECT a,b,c,d FROM zigzag WHERE b = 5 AND c = 6.0
 ----
-·                 distributed            false
+·                 distribution           local
 ·                 vectorized             true
 lookup-join       ·                      ·
  │                table                  zigzag@primary
@@ -1618,7 +1618,7 @@ lookup-join       ·                      ·
 query TTT
 EXPLAIN SELECT a,b,c,d FROM zigzag WHERE b = 5 AND c = 6.0 AND d > 4
 ----
-·                 distributed            false
+·                 distribution           local
 ·                 vectorized             true
 lookup-join       ·                      ·
  │                table                  zigzag@primary
@@ -1654,22 +1654,22 @@ CREATE TABLE zigzag2 (
 query TTT
 EXPLAIN SELECT * FROM zigzag2 WHERE a = 1 AND b = 2 AND c IS NULL
 ----
-·                distributed  false
-·                vectorized   true
-filter           ·            ·
- │               filter       c IS NULL
- └── index-join  ·            ·
-      │          table        zigzag2@primary
-      │          key columns  rowid
-      └── scan   ·            ·
-·                table        zigzag2@a_b_idx
-·                spans        /1/2-/1/3
+·                distribution  local
+·                vectorized    true
+filter           ·             ·
+ │               filter        c IS NULL
+ └── index-join  ·             ·
+      │          table         zigzag2@primary
+      │          key columns   rowid
+      └── scan   ·             ·
+·                table         zigzag2@a_b_idx
+·                spans         /1/2-/1/3
 
 # Test that we can force a merge join.
 query TTT
 EXPLAIN SELECT * FROM onecolumn INNER MERGE JOIN twocolumn USING(x)
 ----
-·                    distributed     false
+·                    distribution    local
 ·                    vectorized      true
 render               ·               ·
  └── merge-join      ·               ·
@@ -1691,7 +1691,7 @@ render               ·               ·
 query TTT
 EXPLAIN SELECT * FROM onecolumn NATURAL INNER MERGE JOIN twocolumn
 ----
-·                    distributed     false
+·                    distribution    local
 ·                    vectorized      true
 render               ·               ·
  └── merge-join      ·               ·
@@ -1713,7 +1713,7 @@ render               ·               ·
 query TTT
 EXPLAIN SELECT * FROM onecolumn CROSS MERGE JOIN twocolumn WHERE onecolumn.x = twocolumn.x
 ----
-·               distributed     false
+·               distribution    local
 ·               vectorized      true
 merge-join      ·               ·
  │              type            inner
@@ -1743,7 +1743,7 @@ EXPLAIN SELECT * FROM onecolumn INNER MERGE JOIN twocolumn ON onecolumn.x > twoc
 query TTT
 EXPLAIN SELECT * FROM cards LEFT OUTER HASH JOIN customers ON customers.id = cards.cust
 ----
-·          distributed         false
+·          distribution        local
 ·          vectorized          true
 hash-join  ·                   ·
  │         type                inner

--- a/pkg/sql/opt/exec/execbuilder/testdata/join_order
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join_order
@@ -36,7 +36,7 @@ SET CLUSTER SETTING sql.defaults.reorder_joins_limit = -1
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc, bx, cy WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-·                     distributed         false            ·                         ·
+·                     distribution        local            ·                         ·
 ·                     vectorized          true             ·                         ·
 render                ·                   ·                (a, b, c, d, b, x, c, y)  ·
  │                    render 0            a                ·                         ·
@@ -70,7 +70,7 @@ SET reorder_joins_limit = 3
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc, bx, cy WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-·                      distributed            false        ·                         ·
+·                      distribution           local        ·                         ·
 ·                      vectorized             true         ·                         ·
 render                 ·                      ·            (a, b, c, d, b, x, c, y)  ·
  │                     render 0               a            ·                         ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -7,19 +7,19 @@ CREATE TABLE t (k INT PRIMARY KEY, v INT, w INT, INDEX(v))
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE v > 4 AND v < 8 AND w > 30 ORDER BY v LIMIT 2
 ----
-tree                  field        description  columns    ordering
-·                     distributed  false        ·          ·
-·                     vectorized   true         ·          ·
-limit                 ·            ·            (k, v, w)  +v
- │                    count        2            ·          ·
- └── filter           ·            ·            (k, v, w)  +v
-      │               filter       w > 30       ·          ·
-      └── index-join  ·            ·            (k, v, w)  +v
-           │          table        t@primary    ·          ·
-           │          key columns  k            ·          ·
-           └── scan   ·            ·            (k, v)     +v
-·                     table        t@t_v_idx    ·          ·
-·                     spans        /5-/8        ·          ·
+tree                  field         description  columns    ordering
+·                     distribution  local        ·          ·
+·                     vectorized    true         ·          ·
+limit                 ·             ·            (k, v, w)  +v
+ │                    count         2            ·          ·
+ └── filter           ·             ·            (k, v, w)  +v
+      │               filter        w > 30       ·          ·
+      └── index-join  ·             ·            (k, v, w)  +v
+           │          table         t@primary    ·          ·
+           │          key columns   k            ·          ·
+           └── scan   ·             ·            (k, v)     +v
+·                     table         t@t_v_idx    ·          ·
+·                     spans         /5-/8        ·          ·
 
 # This kind of query can be used to work around memory usage limits. We need to
 # choose the "hard" limit of 100 over the "soft" limit of 25 (with the hard
@@ -27,171 +27,171 @@ limit                 ·            ·            (k, v, w)  +v
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT w FROM (SELECT w FROM t ORDER BY w LIMIT 100) ORDER BY w LIMIT 25
 ----
-tree                      field        description  columns  ordering
-·                         distributed  false        ·        ·
-·                         vectorized   true         ·        ·
-limit                     ·            ·            (w)      +w
- │                        count        25           ·        ·
- └── distinct             ·            ·            (w)      +w
-      │                   distinct on  w            ·        ·
-      │                   order key    w            ·        ·
-      └── limit           ·            ·            (w)      +w
-           │              count        100          ·        ·
-           └── sort       ·            ·            (w)      +w
-                │         order        +w           ·        ·
-                └── scan  ·            ·            (w)      ·
-·                         table        t@primary    ·        ·
-·                         spans        FULL SCAN    ·        ·
+tree                      field         description  columns  ordering
+·                         distribution  local        ·        ·
+·                         vectorized    true         ·        ·
+limit                     ·             ·            (w)      +w
+ │                        count         25           ·        ·
+ └── distinct             ·             ·            (w)      +w
+      │                   distinct on   w            ·        ·
+      │                   order key     w            ·        ·
+      └── limit           ·             ·            (w)      +w
+           │              count         100          ·        ·
+           └── sort       ·             ·            (w)      +w
+                │         order         +w           ·        ·
+                └── scan  ·             ·            (w)      ·
+·                         table         t@primary    ·        ·
+·                         spans         FULL SCAN    ·        ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY k LIMIT 5
 ----
-·     distributed  false         ·       ·
-·     vectorized   true          ·       ·
-scan  ·            ·             (k, v)  +k
-·     table        t@primary     ·       ·
-·     spans        LIMITED SCAN  ·       ·
-·     limit        5             ·       ·
+·     distribution  local         ·       ·
+·     vectorized    true          ·       ·
+scan  ·             ·             (k, v)  +k
+·     table         t@primary     ·       ·
+·     spans         LIMITED SCAN  ·       ·
+·     limit         5             ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY k OFFSET 5
 ----
-·          distributed  false      ·       ·
-·          vectorized   true       ·       ·
-limit      ·            ·          (k, v)  +k
- │         offset       5          ·       ·
- └── scan  ·            ·          (k, v)  +k
-·          table        t@primary  ·       ·
-·          spans        FULL SCAN  ·       ·
+·          distribution  local      ·       ·
+·          vectorized    true       ·       ·
+limit      ·             ·          (k, v)  +k
+ │         offset        5          ·       ·
+ └── scan  ·             ·          (k, v)  +k
+·          table         t@primary  ·       ·
+·          spans         FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY v LIMIT (1+4) OFFSET 1
 ----
-·          distributed  false         ·       ·
-·          vectorized   true          ·       ·
-limit      ·            ·             (k, v)  +v
- │         offset       1             ·       ·
- └── scan  ·            ·             (k, v)  +v
-·          table        t@t_v_idx     ·       ·
-·          spans        LIMITED SCAN  ·       ·
-·          limit        6             ·       ·
+·          distribution  local         ·       ·
+·          vectorized    true          ·       ·
+limit      ·             ·             (k, v)  +v
+ │         offset        1             ·       ·
+ └── scan  ·             ·             (k, v)  +v
+·          table         t@t_v_idx     ·       ·
+·          spans         LIMITED SCAN  ·       ·
+·          limit         6             ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY v DESC LIMIT (1+4) OFFSET 1
 ----
-·             distributed  false         ·       ·
-·             vectorized   true          ·       ·
-limit         ·            ·             (k, v)  -v
- │            offset       1             ·       ·
- └── revscan  ·            ·             (k, v)  -v
-·             table        t@t_v_idx     ·       ·
-·             spans        LIMITED SCAN  ·       ·
-·             limit        6             ·       ·
+·             distribution  local         ·       ·
+·             vectorized    true          ·       ·
+limit         ·             ·             (k, v)  -v
+ │            offset        1             ·       ·
+ └── revscan  ·             ·             (k, v)  -v
+·             table         t@t_v_idx     ·       ·
+·             spans         LIMITED SCAN  ·       ·
+·             limit         6             ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT sum(w) FROM t GROUP BY k, v ORDER BY v DESC LIMIT 10
 ----
-·                         distributed  false            ·                       ·
-·                         vectorized   true             ·                       ·
-render                    ·            ·                (sum)                   ·
- │                        render 0     sum              ·                       ·
- └── limit                ·            ·                (k, sum, any_not_null)  -any_not_null
-      │                   count        10               ·                       ·
-      └── sort            ·            ·                (k, sum, any_not_null)  -any_not_null
-           │              order        -any_not_null    ·                       ·
-           └── group      ·            ·                (k, sum, any_not_null)  ·
-                │         aggregate 0  k                ·                       ·
-                │         aggregate 1  sum(w)           ·                       ·
-                │         aggregate 2  any_not_null(v)  ·                       ·
-                │         group by     k                ·                       ·
-                │         ordered      +k               ·                       ·
-                └── scan  ·            ·                (k, v, w)               +k
-·                         table        t@primary        ·                       ·
-·                         spans        FULL SCAN        ·                       ·
+·                         distribution  local            ·                       ·
+·                         vectorized    true             ·                       ·
+render                    ·             ·                (sum)                   ·
+ │                        render 0      sum              ·                       ·
+ └── limit                ·             ·                (k, sum, any_not_null)  -any_not_null
+      │                   count         10               ·                       ·
+      └── sort            ·             ·                (k, sum, any_not_null)  -any_not_null
+           │              order         -any_not_null    ·                       ·
+           └── group      ·             ·                (k, sum, any_not_null)  ·
+                │         aggregate 0   k                ·                       ·
+                │         aggregate 1   sum(w)           ·                       ·
+                │         aggregate 2   any_not_null(v)  ·                       ·
+                │         group by      k                ·                       ·
+                │         ordered       +k               ·                       ·
+                └── scan  ·             ·                (k, v, w)               +k
+·                         table         t@primary        ·                       ·
+·                         spans         FULL SCAN        ·                       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM (SELECT k, v FROM t ORDER BY v LIMIT 4)
 ----
-·          distributed  false         ·       ·
-·          vectorized   true          ·       ·
-render     ·            ·             (k)     ·
- │         render 0     k             ·       ·
- └── scan  ·            ·             (k, v)  ·
-·          table        t@t_v_idx     ·       ·
-·          spans        LIMITED SCAN  ·       ·
-·          limit        4             ·       ·
+·          distribution  local         ·       ·
+·          vectorized    true          ·       ·
+render     ·             ·             (k)     ·
+ │         render 0      k             ·       ·
+ └── scan  ·             ·             (k, v)  ·
+·          table         t@t_v_idx     ·       ·
+·          spans         LIMITED SCAN  ·       ·
+·          limit         4             ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM (SELECT k, v, w FROM t ORDER BY v LIMIT 4)
 ----
-·          distributed  false         ·       ·
-·          vectorized   true          ·       ·
-render     ·            ·             (k)     ·
- │         render 0     k             ·       ·
- └── scan  ·            ·             (k, v)  ·
-·          table        t@t_v_idx     ·       ·
-·          spans        LIMITED SCAN  ·       ·
-·          limit        4             ·       ·
+·          distribution  local         ·       ·
+·          vectorized    true          ·       ·
+render     ·             ·             (k)     ·
+ │         render 0      k             ·       ·
+ └── scan  ·             ·             (k, v)  ·
+·          table         t@t_v_idx     ·       ·
+·          spans         LIMITED SCAN  ·       ·
+·          limit         4             ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM (SELECT k FROM t LIMIT 5) WHERE k != 2
 ----
-·          distributed  false         ·    ·
-·          vectorized   true          ·    ·
-filter     ·            ·             (k)  ·
- │         filter       k != 2        ·    ·
- └── scan  ·            ·             (k)  ·
-·          table        t@t_v_idx     ·    ·
-·          spans        LIMITED SCAN  ·    ·
-·          limit        5             ·    ·
+·          distribution  local         ·    ·
+·          vectorized    true          ·    ·
+filter     ·             ·             (k)  ·
+ │         filter        k != 2        ·    ·
+ └── scan  ·             ·             (k)  ·
+·          table         t@t_v_idx     ·    ·
+·          spans         LIMITED SCAN  ·    ·
+·          limit         5             ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, w FROM t WHERE v >= 1 AND v <= 100 LIMIT 10
 ----
-·               distributed  false                    ·          ·
-·               vectorized   true                     ·          ·
-render          ·            ·                        (k, w)     ·
- │              render 0     k                        ·          ·
- │              render 1     w                        ·          ·
- └── limit      ·            ·                        (k, v, w)  ·
-      │         count        10                       ·          ·
-      └── scan  ·            ·                        (k, v, w)  ·
-·               table        t@primary                ·          ·
-·               spans        FULL SCAN                ·          ·
-·               filter       (v >= 1) AND (v <= 100)  ·          ·
+·               distribution  local                    ·          ·
+·               vectorized    true                     ·          ·
+render          ·             ·                        (k, w)     ·
+ │              render 0      k                        ·          ·
+ │              render 1      w                        ·          ·
+ └── limit      ·             ·                        (k, v, w)  ·
+      │         count         10                       ·          ·
+      └── scan  ·             ·                        (k, v, w)  ·
+·               table         t@primary                ·          ·
+·               spans         FULL SCAN                ·          ·
+·               filter        (v >= 1) AND (v <= 100)  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, w FROM t WHERE v >= 1 AND v <= 100 ORDER BY v LIMIT 10
 ----
-·                distributed  false      ·          ·
-·                vectorized   true       ·          ·
-render           ·            ·          (k, w)     ·
- │               render 0     k          ·          ·
- │               render 1     w          ·          ·
- └── index-join  ·            ·          (k, v, w)  +v
-      │          table        t@primary  ·          ·
-      │          key columns  k          ·          ·
-      └── scan   ·            ·          (k, v)     +v
-·                table        t@t_v_idx  ·          ·
-·                spans        /1-/101    ·          ·
-·                limit        10         ·          ·
+·                distribution  local      ·          ·
+·                vectorized    true       ·          ·
+render           ·             ·          (k, w)     ·
+ │               render 0      k          ·          ·
+ │               render 1      w          ·          ·
+ └── index-join  ·             ·          (k, v, w)  +v
+      │          table         t@primary  ·          ·
+      │          key columns   k          ·          ·
+      └── scan   ·             ·          (k, v)     +v
+·                table         t@t_v_idx  ·          ·
+·                spans         /1-/101    ·          ·
+·                limit         10         ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, w FROM (SELECT * FROM t WHERE v >= 1 AND v <= 100 ORDER BY k LIMIT 10) ORDER BY v
 ----
-·                    distributed  false                    ·          ·
-·                    vectorized   true                     ·          ·
-render               ·            ·                        (k, w)     ·
- │                   render 0     k                        ·          ·
- │                   render 1     w                        ·          ·
- └── sort            ·            ·                        (k, v, w)  +v
-      │              order        +v                       ·          ·
-      └── limit      ·            ·                        (k, v, w)  +k
-           │         count        10                       ·          ·
-           └── scan  ·            ·                        (k, v, w)  +k
-·                    table        t@primary                ·          ·
-·                    spans        FULL SCAN                ·          ·
-·                    filter       (v >= 1) AND (v <= 100)  ·          ·
+·                    distribution  local                    ·          ·
+·                    vectorized    true                     ·          ·
+render               ·             ·                        (k, w)     ·
+ │                   render 0      k                        ·          ·
+ │                   render 1      w                        ·          ·
+ └── sort            ·             ·                        (k, v, w)  +v
+      │              order         +v                       ·          ·
+      └── limit      ·             ·                        (k, v, w)  +k
+           │         count         10                       ·          ·
+           └── scan  ·             ·                        (k, v, w)  +k
+·                    table         t@primary                ·          ·
+·                    spans         FULL SCAN                ·          ·
+·                    filter        (v >= 1) AND (v <= 100)  ·          ·
 
 # Regression test for #47283: scan with both hard limit and soft limit.
 statement ok
@@ -201,13 +201,13 @@ CREATE TABLE t_47283(k INT PRIMARY KEY, a INT)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM t_47283 ORDER BY k LIMIT 4) WHERE a > 5 LIMIT 1
 ----
-·               distributed  false            ·       ·
-·               vectorized   true             ·       ·
-limit           ·            ·                (k, a)  ·
- │              count        1                ·       ·
- └── filter     ·            ·                (k, a)  ·
-      │         filter       a > 5            ·       ·
-      └── scan  ·            ·                (k, a)  ·
-·               table        t_47283@primary  ·       ·
-·               spans        LIMITED SCAN     ·       ·
-·               limit        4                ·       ·
+·               distribution  local            ·       ·
+·               vectorized    true             ·       ·
+limit           ·             ·                (k, a)  ·
+ │              count         1                ·       ·
+ └── filter     ·             ·                (k, a)  ·
+      │         filter        a > 5            ·       ·
+      └── scan  ·             ·                (k, a)  ·
+·               table         t_47283@primary  ·       ·
+·               spans         LIMITED SCAN     ·       ·
+·               limit         4                ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -31,22 +31,22 @@ ALTER TABLE def INJECT STATISTICS '[
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b
 ----
-tree         field        description  columns             ordering
-·            distributed  true         ·                   ·
-·            vectorized   true         ·                   ·
-lookup-join  ·            ·            (a, b, c, d, e, f)  ·
- │           table        def@primary  ·                   ·
- │           type         inner        ·                   ·
- │           equality     (b) = (f)    ·                   ·
- └── scan    ·            ·            (a, b, c)           ·
-·            table        abc@primary  ·                   ·
-·            spans        FULL SCAN    ·                   ·
+tree         field         description  columns             ordering
+·            distribution  full         ·                   ·
+·            vectorized    true         ·                   ·
+lookup-join  ·             ·            (a, b, c, d, e, f)  ·
+ │           table         def@primary  ·                   ·
+ │           type          inner        ·                   ·
+ │           equality      (b) = (f)    ·                   ·
+ └── scan    ·             ·            (a, b, c)           ·
+·            table         abc@primary  ·                   ·
+·            spans         FULL SCAN    ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b AND e = c
 ----
 tree         field                  description      columns             ordering
-·            distributed            true             ·                   ·
+·            distribution           full             ·                   ·
 ·            vectorized             true             ·                   ·
 lookup-join  ·                      ·                (a, b, c, d, e, f)  ·
  │           table                  def@primary      ·                   ·
@@ -61,62 +61,62 @@ lookup-join  ·                      ·                (a, b, c, d, e, f)  ·
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b WHERE a > 1 AND e > 1
 ----
-tree         field        description  columns             ordering
-·            distributed  true         ·                   ·
-·            vectorized   true         ·                   ·
-lookup-join  ·            ·            (a, b, c, d, e, f)  ·
- │           table        def@primary  ·                   ·
- │           type         inner        ·                   ·
- │           equality     (b) = (f)    ·                   ·
- │           pred         @5 > 1       ·                   ·
- └── scan    ·            ·            (a, b, c)           ·
-·            table        abc@primary  ·                   ·
-·            spans        /2-          ·                   ·
+tree         field         description  columns             ordering
+·            distribution  full         ·                   ·
+·            vectorized    true         ·                   ·
+lookup-join  ·             ·            (a, b, c, d, e, f)  ·
+ │           table         def@primary  ·                   ·
+ │           type          inner        ·                   ·
+ │           equality      (b) = (f)    ·                   ·
+ │           pred          @5 > 1       ·                   ·
+ └── scan    ·             ·            (a, b, c)           ·
+·            table         abc@primary  ·                   ·
+·            spans         /2-          ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = a WHERE f > 1
 ----
-tree         field        description  columns             ordering
-·            distributed  true         ·                   ·
-·            vectorized   true         ·                   ·
-lookup-join  ·            ·            (a, b, c, d, e, f)  ·
- │           table        def@primary  ·                   ·
- │           type         inner        ·                   ·
- │           equality     (a) = (f)    ·                   ·
- │           pred         @6 > 1       ·                   ·
- └── scan    ·            ·            (a, b, c)           ·
-·            table        abc@primary  ·                   ·
-·            spans        /2-          ·                   ·
+tree         field         description  columns             ordering
+·            distribution  full         ·                   ·
+·            vectorized    true         ·                   ·
+lookup-join  ·             ·            (a, b, c, d, e, f)  ·
+ │           table         def@primary  ·                   ·
+ │           type          inner        ·                   ·
+ │           equality      (a) = (f)    ·                   ·
+ │           pred          @6 > 1       ·                   ·
+ └── scan    ·             ·            (a, b, c)           ·
+·            table         abc@primary  ·                   ·
+·            spans         /2-          ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b WHERE a >= e
 ----
-tree         field        description  columns             ordering
-·            distributed  true         ·                   ·
-·            vectorized   true         ·                   ·
-lookup-join  ·            ·            (a, b, c, d, e, f)  ·
- │           table        def@primary  ·                   ·
- │           type         inner        ·                   ·
- │           equality     (b) = (f)    ·                   ·
- │           pred         @1 >= @5     ·                   ·
- └── scan    ·            ·            (a, b, c)           ·
-·            table        abc@primary  ·                   ·
-·            spans        FULL SCAN    ·                   ·
+tree         field         description  columns             ordering
+·            distribution  full         ·                   ·
+·            vectorized    true         ·                   ·
+lookup-join  ·             ·            (a, b, c, d, e, f)  ·
+ │           table         def@primary  ·                   ·
+ │           type          inner        ·                   ·
+ │           equality      (b) = (f)    ·                   ·
+ │           pred          @1 >= @5     ·                   ·
+ └── scan    ·             ·            (a, b, c)           ·
+·            table         abc@primary  ·                   ·
+·            spans         FULL SCAN    ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b AND a >= e
 ----
-tree         field        description  columns             ordering
-·            distributed  true         ·                   ·
-·            vectorized   true         ·                   ·
-lookup-join  ·            ·            (a, b, c, d, e, f)  ·
- │           table        def@primary  ·                   ·
- │           type         inner        ·                   ·
- │           equality     (b) = (f)    ·                   ·
- │           pred         @1 >= @5     ·                   ·
- └── scan    ·            ·            (a, b, c)           ·
-·            table        abc@primary  ·                   ·
-·            spans        FULL SCAN    ·                   ·
+tree         field         description  columns             ordering
+·            distribution  full         ·                   ·
+·            vectorized    true         ·                   ·
+lookup-join  ·             ·            (a, b, c, d, e, f)  ·
+ │           table         def@primary  ·                   ·
+ │           type          inner        ·                   ·
+ │           equality      (b) = (f)    ·                   ·
+ │           pred          @1 >= @5     ·                   ·
+ └── scan    ·             ·            (a, b, c)           ·
+·            table         abc@primary  ·                   ·
+·            spans         FULL SCAN    ·                   ·
 
 # Verify a distsql plan.
 statement ok
@@ -163,7 +163,7 @@ SELECT *
 FROM (SELECT * FROM data WHERE c = 1) AS l
 NATURAL JOIN (SELECT * FROM data WHERE c > 0) AS r
 ----
-·                 distributed            true                         ·                         ·
+·                 distribution           full                         ·                         ·
 ·                 vectorized             true                         ·                         ·
 render            ·                      ·                            (a, b, c, d)              ·
  │                render 0               a                            ·                         ·
@@ -219,22 +219,22 @@ ALTER TABLE books2 INJECT STATISTICS '[
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT b1.title FROM books as b1 JOIN books2 as b2 ON b1.title = b2.title WHERE b1.shelf <> b2.shelf
 ----
-tree                   field        description        columns                       ordering
-·                      distributed  true               ·                             ·
-·                      vectorized   true               ·                             ·
-distinct               ·            ·                  (title)                       ·
- │                     distinct on  title              ·                             ·
- │                     order key    title              ·                             ·
- └── render            ·            ·                  (title)                       +title
-      │                render 0     title              ·                             ·
-      └── lookup-join  ·            ·                  (title, shelf, title, shelf)  +title
-           │           table        books2@primary     ·                             ·
-           │           type         inner              ·                             ·
-           │           equality     (title) = (title)  ·                             ·
-           │           pred         @2 != @4           ·                             ·
-           └── scan    ·            ·                  (title, shelf)                +title
-·                      table        books@primary      ·                             ·
-·                      spans        FULL SCAN          ·                             ·
+tree                   field         description        columns                       ordering
+·                      distribution  full               ·                             ·
+·                      vectorized    true               ·                             ·
+distinct               ·             ·                  (title)                       ·
+ │                     distinct on   title              ·                             ·
+ │                     order key     title              ·                             ·
+ └── render            ·             ·                  (title)                       +title
+      │                render 0      title              ·                             ·
+      └── lookup-join  ·             ·                  (title, shelf, title, shelf)  +title
+           │           table         books2@primary     ·                             ·
+           │           type          inner              ·                             ·
+           │           equality      (title) = (title)  ·                             ·
+           │           pred          @2 != @4           ·                             ·
+           └── scan    ·             ·                  (title, shelf)                +title
+·                      table         books@primary      ·                             ·
+·                      spans         FULL SCAN          ·                             ·
 
 statement ok
 CREATE TABLE authors (name STRING, book STRING)
@@ -252,27 +252,27 @@ ALTER TABLE authors INJECT STATISTICS '[
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT authors.name FROM books AS b1, books2 AS b2, authors WHERE b1.title = b2.title AND authors.book = b1.title AND b1.shelf <> b2.shelf
 ----
-tree                      field        description        columns                                   ordering
-·                         distributed  true               ·                                         ·
-·                         vectorized   true               ·                                         ·
-distinct                  ·            ·                  (name)                                    ·
- │                        distinct on  name               ·                                         ·
- └── render               ·            ·                  (name)                                    ·
-      │                   render 0     name               ·                                         ·
-      └── lookup-join     ·            ·                  (name, book, title, shelf, title, shelf)  ·
-           │              table        books2@primary     ·                                         ·
-           │              type         inner              ·                                         ·
-           │              equality     (title) = (title)  ·                                         ·
-           │              pred         @4 != @6           ·                                         ·
-           └── hash-join  ·            ·                  (name, book, title, shelf)                ·
-                │         type         inner              ·                                         ·
-                │         equality     (book) = (title)   ·                                         ·
-                ├── scan  ·            ·                  (name, book)                              ·
-                │         table        authors@primary    ·                                         ·
-                │         spans        FULL SCAN          ·                                         ·
-                └── scan  ·            ·                  (title, shelf)                            ·
-·                         table        books@primary      ·                                         ·
-·                         spans        FULL SCAN          ·                                         ·
+tree                      field         description        columns                                   ordering
+·                         distribution  full               ·                                         ·
+·                         vectorized    true               ·                                         ·
+distinct                  ·             ·                  (name)                                    ·
+ │                        distinct on   name               ·                                         ·
+ └── render               ·             ·                  (name)                                    ·
+      │                   render 0      name               ·                                         ·
+      └── lookup-join     ·             ·                  (name, book, title, shelf, title, shelf)  ·
+           │              table         books2@primary     ·                                         ·
+           │              type          inner              ·                                         ·
+           │              equality      (title) = (title)  ·                                         ·
+           │              pred          @4 != @6           ·                                         ·
+           └── hash-join  ·             ·                  (name, book, title, shelf)                ·
+                │         type          inner              ·                                         ·
+                │         equality      (book) = (title)   ·                                         ·
+                ├── scan  ·             ·                  (name, book)                              ·
+                │         table         authors@primary    ·                                         ·
+                │         spans         FULL SCAN          ·                                         ·
+                └── scan  ·             ·                  (title, shelf)                            ·
+·                         table         books@primary      ·                                         ·
+·                         spans         FULL SCAN          ·                                         ·
 
 # Verify data placement.
 query TTTI colnames
@@ -289,43 +289,43 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJyck19v2jAQwN_3KW73lEhuIX
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT a.name FROM authors AS a JOIN books2 AS b2 ON a.book = b2.title ORDER BY a.name
 ----
-tree                 field        description       columns              ordering
-·                    distributed  true              ·                    ·
-·                    vectorized   true              ·                    ·
-render               ·            ·                 (name)               +name
- │                   render 0     name              ·                    ·
- └── lookup-join     ·            ·                 (name, book, title)  +name
-      │              table        books2@primary    ·                    ·
-      │              type         inner             ·                    ·
-      │              equality     (book) = (title)  ·                    ·
-      └── sort       ·            ·                 (name, book)         +name
-           │         order        +name             ·                    ·
-           └── scan  ·            ·                 (name, book)         ·
-·                    table        authors@primary   ·                    ·
-·                    spans        FULL SCAN         ·                    ·
+tree                 field         description       columns              ordering
+·                    distribution  full              ·                    ·
+·                    vectorized    true              ·                    ·
+render               ·             ·                 (name)               +name
+ │                   render 0      name              ·                    ·
+ └── lookup-join     ·             ·                 (name, book, title)  +name
+      │              table         books2@primary    ·                    ·
+      │              type          inner             ·                    ·
+      │              equality      (book) = (title)  ·                    ·
+      └── sort       ·             ·                 (name, book)         +name
+           │         order         +name             ·                    ·
+           └── scan  ·             ·                 (name, book)         ·
+·                    table         authors@primary   ·                    ·
+·                    spans         FULL SCAN         ·                    ·
 
 # Cross joins should not be planned as lookup joins.
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM books CROSS JOIN books2
 ----
-tree             field        description     columns                                         ordering
-·                distributed  true            ·                                               ·
-·                vectorized   true            ·                                               ·
-render           ·            ·               (title, edition, shelf, title, edition, shelf)  ·
- │               render 0     title           ·                                               ·
- │               render 1     edition         ·                                               ·
- │               render 2     shelf           ·                                               ·
- │               render 3     title           ·                                               ·
- │               render 4     edition         ·                                               ·
- │               render 5     shelf           ·                                               ·
- └── cross-join  ·            ·               (title, edition, shelf, title, edition, shelf)  ·
-      │          type         cross           ·                                               ·
-      ├── scan   ·            ·               (title, edition, shelf)                         ·
-      │          table        books2@primary  ·                                               ·
-      │          spans        FULL SCAN       ·                                               ·
-      └── scan   ·            ·               (title, edition, shelf)                         ·
-·                table        books@primary   ·                                               ·
-·                spans        FULL SCAN       ·                                               ·
+tree             field         description     columns                                         ordering
+·                distribution  full            ·                                               ·
+·                vectorized    true            ·                                               ·
+render           ·             ·               (title, edition, shelf, title, edition, shelf)  ·
+ │               render 0      title           ·                                               ·
+ │               render 1      edition         ·                                               ·
+ │               render 2      shelf           ·                                               ·
+ │               render 3      title           ·                                               ·
+ │               render 4      edition         ·                                               ·
+ │               render 5      shelf           ·                                               ·
+ └── cross-join  ·             ·               (title, edition, shelf, title, edition, shelf)  ·
+      │          type          cross           ·                                               ·
+      ├── scan   ·             ·               (title, edition, shelf)                         ·
+      │          table         books2@primary  ·                                               ·
+      │          spans         FULL SCAN       ·                                               ·
+      └── scan   ·             ·               (title, edition, shelf)                         ·
+·                table         books@primary   ·                                               ·
+·                spans         FULL SCAN       ·                                               ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM authors INNER JOIN books2 ON books2.edition = 1 WHERE books2.title = authors.book]
@@ -377,24 +377,24 @@ ALTER TABLE large INJECT STATISTICS '[
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.a, large.c FROM small JOIN large ON small.a = large.b
 ----
-·                 distributed  true           ·          ·
-·                 vectorized   true           ·          ·
-render            ·            ·              (a, c)     ·
- │                render 0     a              ·          ·
- │                render 1     c              ·          ·
- └── lookup-join  ·            ·              (a, b, c)  ·
-      │           table        large@bc       ·          ·
-      │           type         inner          ·          ·
-      │           equality     (a) = (b)      ·          ·
-      └── scan    ·            ·              (a)        ·
-·                 table        small@primary  ·          ·
-·                 spans        FULL SCAN      ·          ·
+·                 distribution  full           ·          ·
+·                 vectorized    true           ·          ·
+render            ·             ·              (a, c)     ·
+ │                render 0      a              ·          ·
+ │                render 1      c              ·          ·
+ └── lookup-join  ·             ·              (a, b, c)  ·
+      │           table         large@bc       ·          ·
+      │           type          inner          ·          ·
+      │           equality      (a) = (b)      ·          ·
+      └── scan    ·             ·              (a)        ·
+·                 table         small@primary  ·          ·
+·                 spans         FULL SCAN      ·          ·
 
 # Lookup join on non-covering secondary index
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.a, large.d FROM small JOIN large ON small.a = large.b
 ----
-·                      distributed            true             ·             ·
+·                      distribution           full             ·             ·
 ·                      vectorized             true             ·             ·
 render                 ·                      ·                (a, d)        ·
  │                     render 0               a                ·             ·
@@ -421,33 +421,33 @@ render                 ·                      ·                (a, d)        �
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.b, large.a FROM small LEFT JOIN large ON small.b = large.a
 ----
-·            distributed  true           ·       ·
-·            vectorized   true           ·       ·
-lookup-join  ·            ·              (b, a)  ·
- │           table        large@primary  ·       ·
- │           type         left outer     ·       ·
- │           equality     (b) = (a)      ·       ·
- └── scan    ·            ·              (b)     ·
-·            table        small@primary  ·       ·
-·            spans        FULL SCAN      ·       ·
+·            distribution  full           ·       ·
+·            vectorized    true           ·       ·
+lookup-join  ·             ·              (b, a)  ·
+ │           table         large@primary  ·       ·
+ │           type          left outer     ·       ·
+ │           equality      (b) = (a)      ·       ·
+ └── scan    ·             ·              (b)     ·
+·            table         small@primary  ·       ·
+·            spans         FULL SCAN      ·       ·
 
 # Left join should preserve input order.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT t1.a, t2.b FROM small t1 LEFT JOIN large t2 ON t1.a = t2.a AND t2.b % 6 = 0 ORDER BY t1.a
 ----
-·                 distributed  true           ·          ·
-·                 vectorized   true           ·          ·
-render            ·            ·              (a, b)     +a
- │                render 0     a              ·          ·
- │                render 1     b              ·          ·
- └── lookup-join  ·            ·              (a, a, b)  +a
-      │           table        large@primary  ·          ·
-      │           type         left outer     ·          ·
-      │           equality     (a) = (a)      ·          ·
-      │           pred         (@3 % 6) = 0   ·          ·
-      └── scan    ·            ·              (a)        +a
-·                 table        small@primary  ·          ·
-·                 spans        FULL SCAN      ·          ·
+·                 distribution  full           ·          ·
+·                 vectorized    true           ·          ·
+render            ·             ·              (a, b)     +a
+ │                render 0      a              ·          ·
+ │                render 1      b              ·          ·
+ └── lookup-join  ·             ·              (a, a, b)  +a
+      │           table         large@primary  ·          ·
+      │           type          left outer     ·          ·
+      │           equality      (a) = (a)      ·          ·
+      │           pred          (@3 % 6) = 0   ·          ·
+      └── scan    ·             ·              (a)        +a
+·                 table         small@primary  ·          ·
+·                 spans         FULL SCAN      ·          ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT t1.a, t2.b FROM small t1 LEFT JOIN large t2 ON t1.a = t2.a AND t2.b % 6 = 0 ORDER BY t1.a]
@@ -458,24 +458,24 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJzMlV9r2zAUxd_3KS4XBglT6s
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.c, large.c FROM small LEFT JOIN large ON small.c = large.b
 ----
-·                 distributed  true           ·          ·
-·                 vectorized   true           ·          ·
-render            ·            ·              (c, c)     ·
- │                render 0     c              ·          ·
- │                render 1     c              ·          ·
- └── lookup-join  ·            ·              (c, b, c)  ·
-      │           table        large@bc       ·          ·
-      │           type         left outer     ·          ·
-      │           equality     (c) = (b)      ·          ·
-      └── scan    ·            ·              (c)        ·
-·                 table        small@primary  ·          ·
-·                 spans        FULL SCAN      ·          ·
+·                 distribution  full           ·          ·
+·                 vectorized    true           ·          ·
+render            ·             ·              (c, c)     ·
+ │                render 0      c              ·          ·
+ │                render 1      c              ·          ·
+ └── lookup-join  ·             ·              (c, b, c)  ·
+      │           table         large@bc       ·          ·
+      │           type          left outer     ·          ·
+      │           equality      (c) = (b)      ·          ·
+      └── scan    ·             ·              (c)        ·
+·                 table         small@primary  ·          ·
+·                 spans         FULL SCAN      ·          ·
 
 # Left join against non-covering secondary index
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.c, large.d FROM small LEFT JOIN large ON small.c = large.b
 ----
-·                      distributed            true             ·             ·
+·                      distribution           full             ·             ·
 ·                      vectorized             true             ·             ·
 render                 ·                      ·                (c, d)        ·
  │                     render 0               c                ·             ·
@@ -498,19 +498,19 @@ render                 ·                      ·                (c, d)        �
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.c, large.c FROM small LEFT JOIN large ON small.c = large.b AND large.c < 20
 ----
-·                 distributed  true           ·          ·
-·                 vectorized   true           ·          ·
-render            ·            ·              (c, c)     ·
- │                render 0     c              ·          ·
- │                render 1     c              ·          ·
- └── lookup-join  ·            ·              (c, b, c)  ·
-      │           table        large@bc       ·          ·
-      │           type         left outer     ·          ·
-      │           equality     (c) = (b)      ·          ·
-      │           pred         @3 < 20        ·          ·
-      └── scan    ·            ·              (c)        ·
-·                 table        small@primary  ·          ·
-·                 spans        FULL SCAN      ·          ·
+·                 distribution  full           ·          ·
+·                 vectorized    true           ·          ·
+render            ·             ·              (c, c)     ·
+ │                render 0      c              ·          ·
+ │                render 1      c              ·          ·
+ └── lookup-join  ·             ·              (c, b, c)  ·
+      │           table         large@bc       ·          ·
+      │           type          left outer     ·          ·
+      │           equality      (c) = (b)      ·          ·
+      │           pred          @3 < 20        ·          ·
+      └── scan    ·             ·              (c)        ·
+·                 table         small@primary  ·          ·
+·                 spans         FULL SCAN      ·          ·
 
 # Left join with ON filter on non-covering index
 # TODO(radu): this doesn't use lookup join yet, the current rules don't cover
@@ -518,21 +518,21 @@ render            ·            ·              (c, c)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT small.c, large.d FROM small LEFT JOIN large ON small.c = large.b AND large.d < 30
 ----
-·               distributed  true           ·          ·
-·               vectorized   true           ·          ·
-render          ·            ·              (c, d)     ·
- │              render 0     c              ·          ·
- │              render 1     d              ·          ·
- └── hash-join  ·            ·              (b, d, c)  ·
-      │         type         right outer    ·          ·
-      │         equality     (b) = (c)      ·          ·
-      ├── scan  ·            ·              (b, d)     ·
-      │         table        large@primary  ·          ·
-      │         spans        FULL SCAN      ·          ·
-      │         filter       d < 30         ·          ·
-      └── scan  ·            ·              (c)        ·
-·               table        small@primary  ·          ·
-·               spans        FULL SCAN      ·          ·
+·               distribution  full           ·          ·
+·               vectorized    true           ·          ·
+render          ·             ·              (c, d)     ·
+ │              render 0      c              ·          ·
+ │              render 1      d              ·          ·
+ └── hash-join  ·             ·              (b, d, c)  ·
+      │         type          right outer    ·          ·
+      │         equality      (b) = (c)      ·          ·
+      ├── scan  ·             ·              (b, d)     ·
+      │         table         large@primary  ·          ·
+      │         spans         FULL SCAN      ·          ·
+      │         filter        d < 30         ·          ·
+      └── scan  ·             ·              (c)        ·
+·               table         small@primary  ·          ·
+·               spans         FULL SCAN      ·          ·
 
 ###########################################################
 #  LOOKUP JOINS ON IMPLICIT INDEX KEY COLUMNS             #
@@ -551,18 +551,18 @@ CREATE INDEX idx ON u (d)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e = 5
 ----
-·                 distributed  true             ·                ·
-·                 vectorized   true             ·                ·
-render            ·            ·                (a)              ·
- │                render 0     a                ·                ·
- └── lookup-join  ·            ·                (a, d, e, a, d)  ·
-      │           table        u@idx            ·                ·
-      │           type         inner            ·                ·
-      │           equality     (d, a) = (d, a)  ·                ·
-      └── scan    ·            ·                (a, d, e)        ·
-·                 table        t@primary        ·                ·
-·                 spans        FULL SCAN        ·                ·
-·                 filter       e = 5            ·                ·
+·                 distribution  full             ·                ·
+·                 vectorized    true             ·                ·
+render            ·             ·                (a)              ·
+ │                render 0      a                ·                ·
+ └── lookup-join  ·             ·                (a, d, e, a, d)  ·
+      │           table         u@idx            ·                ·
+      │           type          inner            ·                ·
+      │           equality      (d, a) = (d, a)  ·                ·
+      └── scan    ·             ·                (a, d, e)        ·
+·                 table         t@primary        ·                ·
+·                 spans         FULL SCAN        ·                ·
+·                 filter        e = 5            ·                ·
 
 # Test unique version of same index. (Lookup join should not use column a.)
 statement ok
@@ -574,7 +574,7 @@ CREATE UNIQUE INDEX idx ON u (d)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e = 5
 ----
-·                 distributed            true       ·                ·
+·                 distribution           full       ·                ·
 ·                 vectorized             true       ·                ·
 render            ·                      ·          (a)              ·
  │                render 0               a          ·                ·
@@ -600,18 +600,18 @@ CREATE INDEX idx ON u (d, a)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = u.b WHERE t.e = 5
 ----
-·                 distributed  true                   ·                      ·
-·                 vectorized   true                   ·                      ·
-render            ·            ·                      (a)                    ·
- │                render 0     a                      ·                      ·
- └── lookup-join  ·            ·                      (a, b, d, e, a, b, d)  ·
-      │           table        u@idx                  ·                      ·
-      │           type         inner                  ·                      ·
-      │           equality     (d, a, b) = (d, a, b)  ·                      ·
-      └── scan    ·            ·                      (a, b, d, e)           ·
-·                 table        t@primary              ·                      ·
-·                 spans        FULL SCAN              ·                      ·
-·                 filter       e = 5                  ·                      ·
+·                 distribution  full                   ·                      ·
+·                 vectorized    true                   ·                      ·
+render            ·             ·                      (a)                    ·
+ │                render 0      a                      ·                      ·
+ └── lookup-join  ·             ·                      (a, b, d, e, a, b, d)  ·
+      │           table         u@idx                  ·                      ·
+      │           type          inner                  ·                      ·
+      │           equality      (d, a, b) = (d, a, b)  ·                      ·
+      └── scan    ·             ·                      (a, b, d, e)           ·
+·                 table         t@primary              ·                      ·
+·                 spans         FULL SCAN              ·                      ·
+·                 filter        e = 5                  ·                      ·
 
 # Test index with middle primary key column explicit and the rest implicit.
 statement ok
@@ -623,18 +623,18 @@ CREATE INDEX idx ON u (d, b)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = u.b WHERE t.e = 5
 ----
-·                 distributed  true                   ·                      ·
-·                 vectorized   true                   ·                      ·
-render            ·            ·                      (a)                    ·
- │                render 0     a                      ·                      ·
- └── lookup-join  ·            ·                      (a, b, d, e, a, b, d)  ·
-      │           table        u@idx                  ·                      ·
-      │           type         inner                  ·                      ·
-      │           equality     (d, b, a) = (d, b, a)  ·                      ·
-      └── scan    ·            ·                      (a, b, d, e)           ·
-·                 table        t@primary              ·                      ·
-·                 spans        FULL SCAN              ·                      ·
-·                 filter       e = 5                  ·                      ·
+·                 distribution  full                   ·                      ·
+·                 vectorized    true                   ·                      ·
+render            ·             ·                      (a)                    ·
+ │                render 0      a                      ·                      ·
+ └── lookup-join  ·             ·                      (a, b, d, e, a, b, d)  ·
+      │           table         u@idx                  ·                      ·
+      │           type          inner                  ·                      ·
+      │           equality      (d, b, a) = (d, b, a)  ·                      ·
+      └── scan    ·             ·                      (a, b, d, e)           ·
+·                 table         t@primary              ·                      ·
+·                 spans         FULL SCAN              ·                      ·
+·                 filter        e = 5                  ·                      ·
 
 # Test index with last primary key column explicit and the rest implicit.
 statement ok
@@ -646,45 +646,45 @@ CREATE INDEX idx ON u (d, c)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.d = u.d WHERE t.e = 5
 ----
-·                 distributed  true       ·                ·
-·                 vectorized   true       ·                ·
-render            ·            ·          (a)              ·
- │                render 0     a          ·                ·
- └── lookup-join  ·            ·          (a, d, e, a, d)  ·
-      │           table        u@idx      ·                ·
-      │           type         inner      ·                ·
-      │           equality     (d) = (d)  ·                ·
-      │           pred         @1 = @4    ·                ·
-      └── scan    ·            ·          (a, d, e)        ·
-·                 table        t@primary  ·                ·
-·                 spans        FULL SCAN  ·                ·
-·                 filter       e = 5      ·                ·
+·                 distribution  full       ·                ·
+·                 vectorized    true       ·                ·
+render            ·             ·          (a)              ·
+ │                render 0      a          ·                ·
+ └── lookup-join  ·             ·          (a, d, e, a, d)  ·
+      │           table         u@idx      ·                ·
+      │           type          inner      ·                ·
+      │           equality      (d) = (d)  ·                ·
+      │           pred          @1 = @4    ·                ·
+      └── scan    ·             ·          (a, d, e)        ·
+·                 table         t@primary  ·                ·
+·                 spans         FULL SCAN  ·                ·
+·                 filter        e = 5      ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM def JOIN abc ON a=f ORDER BY a
 ----
-·                 distributed  true         ·                   ·
-·                 vectorized   true         ·                   ·
-render            ·            ·            (d, e, f, a, b, c)  ·
- │                render 0     d            ·                   ·
- │                render 1     e            ·                   ·
- │                render 2     f            ·                   ·
- │                render 3     a            ·                   ·
- │                render 4     b            ·                   ·
- │                render 5     c            ·                   ·
- └── lookup-join  ·            ·            (a, b, c, d, e, f)  +a
-      │           table        def@primary  ·                   ·
-      │           type         inner        ·                   ·
-      │           equality     (a) = (f)    ·                   ·
-      └── scan    ·            ·            (a, b, c)           +a
-·                 table        abc@primary  ·                   ·
-·                 spans        FULL SCAN    ·                   ·
+·                 distribution  full         ·                   ·
+·                 vectorized    true         ·                   ·
+render            ·             ·            (d, e, f, a, b, c)  ·
+ │                render 0      d            ·                   ·
+ │                render 1      e            ·                   ·
+ │                render 2      f            ·                   ·
+ │                render 3      a            ·                   ·
+ │                render 4      b            ·                   ·
+ │                render 5      c            ·                   ·
+ └── lookup-join  ·             ·            (a, b, c, d, e, f)  +a
+      │           table         def@primary  ·                   ·
+      │           type          inner        ·                   ·
+      │           equality      (a) = (f)    ·                   ·
+      └── scan    ·             ·            (a, b, c)           +a
+·                 table         abc@primary  ·                   ·
+·                 spans         FULL SCAN    ·                   ·
 
 # Test that we don't get a lookup join if we force a merge join.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM def INNER MERGE JOIN abc ON a=f ORDER BY a
 ----
-·           distributed     true         ·                   ·
+·           distribution    full         ·                   ·
 ·           vectorized      true         ·                   ·
 merge-join  ·               ·            (d, e, f, a, b, c)  +f
  │          type            inner        ·                   ·
@@ -701,51 +701,51 @@ merge-join  ·               ·            (d, e, f, a, b, c)  +f
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM def INNER HASH JOIN abc ON a=f ORDER BY a
 ----
-·               distributed  true         ·                   ·
-·               vectorized   true         ·                   ·
-sort            ·            ·            (d, e, f, a, b, c)  +f
- │              order        +f           ·                   ·
- └── hash-join  ·            ·            (d, e, f, a, b, c)  ·
-      │         type         inner        ·                   ·
-      │         equality     (f) = (a)    ·                   ·
-      ├── scan  ·            ·            (d, e, f)           ·
-      │         table        def@primary  ·                   ·
-      │         spans        FULL SCAN    ·                   ·
-      └── scan  ·            ·            (a, b, c)           ·
-·               table        abc@primary  ·                   ·
-·               spans        FULL SCAN    ·                   ·
+·               distribution  full         ·                   ·
+·               vectorized    true         ·                   ·
+sort            ·             ·            (d, e, f, a, b, c)  +f
+ │              order         +f           ·                   ·
+ └── hash-join  ·             ·            (d, e, f, a, b, c)  ·
+      │         type          inner        ·                   ·
+      │         equality      (f) = (a)    ·                   ·
+      ├── scan  ·             ·            (d, e, f)           ·
+      │         table         def@primary  ·                   ·
+      │         spans         FULL SCAN    ·                   ·
+      └── scan  ·             ·            (a, b, c)           ·
+·               table         abc@primary  ·                   ·
+·               spans         FULL SCAN    ·                   ·
 
 # Test lookup semi and anti join.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=f)
 ----
-·            distributed  true         ·          ·
-·            vectorized   true         ·          ·
-lookup-join  ·            ·            (a, b, c)  ·
- │           table        def@primary  ·          ·
- │           type         semi         ·          ·
- │           equality     (a) = (f)    ·          ·
- └── scan    ·            ·            (a, b, c)  ·
-·            table        abc@primary  ·          ·
-·            spans        FULL SCAN    ·          ·
+·            distribution  full         ·          ·
+·            vectorized    true         ·          ·
+lookup-join  ·             ·            (a, b, c)  ·
+ │           table         def@primary  ·          ·
+ │           type          semi         ·          ·
+ │           equality      (a) = (f)    ·          ·
+ └── scan    ·             ·            (a, b, c)  ·
+·            table         abc@primary  ·          ·
+·            spans         FULL SCAN    ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=f)
 ----
-·            distributed  true         ·          ·
-·            vectorized   true         ·          ·
-lookup-join  ·            ·            (a, b, c)  ·
- │           table        def@primary  ·          ·
- │           type         anti         ·          ·
- │           equality     (a) = (f)    ·          ·
- └── scan    ·            ·            (a, b, c)  ·
-·            table        abc@primary  ·          ·
-·            spans        FULL SCAN    ·          ·
+·            distribution  full         ·          ·
+·            vectorized    true         ·          ·
+lookup-join  ·             ·            (a, b, c)  ·
+ │           table         def@primary  ·          ·
+ │           type          anti         ·          ·
+ │           equality      (a) = (f)    ·          ·
+ └── scan    ·             ·            (a, b, c)  ·
+·            table         abc@primary  ·          ·
+·            spans         FULL SCAN    ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=f AND c=e)
 ----
-·            distributed            true             ·          ·
+·            distribution           full             ·          ·
 ·            vectorized             true             ·          ·
 lookup-join  ·                      ·                (a, b, c)  ·
  │           table                  def@primary      ·          ·
@@ -760,7 +760,7 @@ lookup-join  ·                      ·                (a, b, c)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=f AND c=e)
 ----
-·            distributed            true             ·          ·
+·            distribution           full             ·          ·
 ·            vectorized             true             ·          ·
 lookup-join  ·                      ·                (a, b, c)  ·
  │           table                  def@primary      ·          ·
@@ -775,30 +775,30 @@ lookup-join  ·                      ·                (a, b, c)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=f AND d+b>1)
 ----
-·            distributed  true           ·          ·
-·            vectorized   true           ·          ·
-lookup-join  ·            ·              (a, b, c)  ·
- │           table        def@primary    ·          ·
- │           type         semi           ·          ·
- │           equality     (a) = (f)      ·          ·
- │           pred         (@4 + @2) > 1  ·          ·
- └── scan    ·            ·              (a, b, c)  ·
-·            table        abc@primary    ·          ·
-·            spans        FULL SCAN      ·          ·
+·            distribution  full           ·          ·
+·            vectorized    true           ·          ·
+lookup-join  ·             ·              (a, b, c)  ·
+ │           table         def@primary    ·          ·
+ │           type          semi           ·          ·
+ │           equality      (a) = (f)      ·          ·
+ │           pred          (@4 + @2) > 1  ·          ·
+ └── scan    ·             ·              (a, b, c)  ·
+·            table         abc@primary    ·          ·
+·            spans         FULL SCAN      ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=f AND d+b>1)
 ----
-·            distributed  true           ·          ·
-·            vectorized   true           ·          ·
-lookup-join  ·            ·              (a, b, c)  ·
- │           table        def@primary    ·          ·
- │           type         anti           ·          ·
- │           equality     (a) = (f)      ·          ·
- │           pred         (@4 + @2) > 1  ·          ·
- └── scan    ·            ·              (a, b, c)  ·
-·            table        abc@primary    ·          ·
-·            spans        FULL SCAN      ·          ·
+·            distribution  full           ·          ·
+·            vectorized    true           ·          ·
+lookup-join  ·             ·              (a, b, c)  ·
+ │           table         def@primary    ·          ·
+ │           type          anti           ·          ·
+ │           equality      (a) = (f)      ·          ·
+ │           pred          (@4 + @2) > 1  ·          ·
+ └── scan    ·             ·              (a, b, c)  ·
+·            table         abc@primary    ·          ·
+·            spans         FULL SCAN      ·          ·
 
 query T
 SELECT url FROM [ EXPLAIN (DISTSQL)
@@ -833,19 +833,19 @@ INSERT INTO b VALUES(1)
 query TTT
 EXPLAIN SELECT count(*) FROM (SELECT * FROM b NATURAL INNER LOOKUP JOIN a)
 ----
-·                      distributed  true
-·                      vectorized   true
-group                  ·            ·
- │                     aggregate 0  count_rows()
- │                     scalar       ·
- └── render            ·            ·
-      └── lookup-join  ·            ·
-           │           table        a@primary
-           │           type         inner
-           │           equality     (a) = (a)
-           └── scan    ·            ·
-·                      table        b@primary
-·                      spans        FULL SCAN
+·                      distribution  full
+·                      vectorized    true
+group                  ·             ·
+ │                     aggregate 0   count_rows()
+ │                     scalar        ·
+ └── render            ·             ·
+      └── lookup-join  ·             ·
+           │           table         a@primary
+           │           type          inner
+           │           equality      (a) = (a)
+           └── scan    ·             ·
+·                      table         b@primary
+·                      spans         FULL SCAN
 
 statement ok
 SET tracing = on
@@ -1422,7 +1422,7 @@ GROUP BY s_name
 ORDER BY numwait DESC, s_name
    LIMIT 100;
 ----
-·                                                   distributed            true
+·                                                   distribution           full
 ·                                                   vectorized             true
 limit                                               ·                      ·
  │                                                  count                  100

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -11,199 +11,199 @@ CREATE TABLE t (
 query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY b
 ----
-·          distributed  false
-·          vectorized   true
-sort       ·            ·
- │         order        +b
- └── scan  ·            ·
-·          table        t@primary
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+sort       ·             ·
+ │         order         +b
+ └── scan  ·             ·
+·          table         t@primary
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY b DESC
 ----
-·          distributed  false
-·          vectorized   true
-sort       ·            ·
- │         order        -b
- └── scan  ·            ·
-·          table        t@primary
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+sort       ·             ·
+ │         order         -b
+ └── scan  ·             ·
+·          table         t@primary
+·          spans         FULL SCAN
 
 # TODO(radu): Should set "strategy top 2" on sort node
 query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY b LIMIT 2
 ----
-·               distributed  false
-·               vectorized   true
-limit           ·            ·
- │              count        2
- └── sort       ·            ·
-      │         order        +b
-      └── scan  ·            ·
-·               table        t@primary
-·               spans        FULL SCAN
+·               distribution  local
+·               vectorized    true
+limit           ·             ·
+ │              count         2
+ └── sort       ·             ·
+      │         order         +b
+      └── scan  ·             ·
+·               table         t@primary
+·               spans         FULL SCAN
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT c, b FROM t ORDER BY b LIMIT 2
 ----
-·                         distributed  false      ·       ·
-·                         vectorized   true       ·       ·
-render                    ·            ·          (c, b)  ·
- │                        render 0     c          ·       ·
- │                        render 1     b          ·       ·
- └── limit                ·            ·          (b, c)  +b
-      │                   count        2          ·       ·
-      └── sort            ·            ·          (b, c)  +b
-           │              order        +b         ·       ·
-           └── distinct   ·            ·          (b, c)  ·
-                │         distinct on  b, c       ·       ·
-                └── scan  ·            ·          (b, c)  ·
-·                         table        t@primary  ·       ·
-·                         spans        FULL SCAN  ·       ·
+·                         distribution  local      ·       ·
+·                         vectorized    true       ·       ·
+render                    ·             ·          (c, b)  ·
+ │                        render 0      c          ·       ·
+ │                        render 1      b          ·       ·
+ └── limit                ·             ·          (b, c)  +b
+      │                   count         2          ·       ·
+      └── sort            ·             ·          (b, c)  +b
+           │              order         +b         ·       ·
+           └── distinct   ·             ·          (b, c)  ·
+                │         distinct on   b, c       ·       ·
+                └── scan  ·             ·          (b, c)  ·
+·                         table         t@primary  ·       ·
+·                         spans         FULL SCAN  ·       ·
 
 query TTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC
 ----
-·             distributed  false
-·             vectorized   true
-render        ·            ·
- └── revscan  ·            ·
-·             table        t@primary
-·             spans        FULL SCAN
+·             distribution  local
+·             vectorized    true
+render        ·             ·
+ └── revscan  ·             ·
+·             table         t@primary
+·             spans         FULL SCAN
 
 # Check that LIMIT propagates past nosort nodes.
 query TTT
 EXPLAIN SELECT b FROM t ORDER BY a LIMIT 1
 ----
-·          distributed  false
-·          vectorized   true
-render     ·            ·
- └── scan  ·            ·
-·          table        t@primary
-·          spans        LIMITED SCAN
-·          limit        1
+·          distribution  local
+·          vectorized    true
+render     ·             ·
+ └── scan  ·             ·
+·          table         t@primary
+·          spans         LIMITED SCAN
+·          limit         1
 
 query TTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b ASC
 ----
-·             distributed  false
-·             vectorized   true
-render        ·            ·
- └── revscan  ·            ·
-·             table        t@primary
-·             spans        FULL SCAN
+·             distribution  local
+·             vectorized    true
+render        ·             ·
+ └── revscan  ·             ·
+·             table         t@primary
+·             spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b DESC
 ----
-·             distributed  false
-·             vectorized   true
-render        ·            ·
- └── revscan  ·            ·
-·             table        t@primary
-·             spans        FULL SCAN
+·             distribution  local
+·             vectorized    true
+render        ·             ·
+ └── revscan  ·             ·
+·             table         t@primary
+·             spans         FULL SCAN
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY (b, t.*)
 ----
-·          distributed  false      ·          ·
-·          vectorized   true       ·          ·
-sort       ·            ·          (a, b, c)  +b,+a
- │         order        +b,+a      ·          ·
- └── scan  ·            ·          (a, b, c)  ·
-·          table        t@primary  ·          ·
-·          spans        FULL SCAN  ·          ·
+·          distribution  local      ·          ·
+·          vectorized    true       ·          ·
+sort       ·             ·          (a, b, c)  +b,+a
+ │         order         +b,+a      ·          ·
+ └── scan  ·             ·          (a, b, c)  ·
+·          table         t@primary  ·          ·
+·          spans         FULL SCAN  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY (b, a), c
 ----
-·          distributed  false      ·          ·
-·          vectorized   true       ·          ·
-sort       ·            ·          (a, b, c)  +b,+a
- │         order        +b,+a      ·          ·
- └── scan  ·            ·          (a, b, c)  ·
-·          table        t@primary  ·          ·
-·          spans        FULL SCAN  ·          ·
+·          distribution  local      ·          ·
+·          vectorized    true       ·          ·
+sort       ·             ·          (a, b, c)  +b,+a
+ │         order         +b,+a      ·          ·
+ └── scan  ·             ·          (a, b, c)  ·
+·          table         t@primary  ·          ·
+·          spans         FULL SCAN  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY b, (a, c)
 ----
-·          distributed  false      ·          ·
-·          vectorized   true       ·          ·
-sort       ·            ·          (a, b, c)  +b,+a
- │         order        +b,+a      ·          ·
- └── scan  ·            ·          (a, b, c)  ·
-·          table        t@primary  ·          ·
-·          spans        FULL SCAN  ·          ·
+·          distribution  local      ·          ·
+·          vectorized    true       ·          ·
+sort       ·             ·          (a, b, c)  +b,+a
+ │         order         +b,+a      ·          ·
+ └── scan  ·             ·          (a, b, c)  ·
+·          table         t@primary  ·          ·
+·          spans         FULL SCAN  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY (b, (a, c))
 ----
-·          distributed  false      ·          ·
-·          vectorized   true       ·          ·
-sort       ·            ·          (a, b, c)  +b,+a
- │         order        +b,+a      ·          ·
- └── scan  ·            ·          (a, b, c)  ·
-·          table        t@primary  ·          ·
-·          spans        FULL SCAN  ·          ·
+·          distribution  local      ·          ·
+·          vectorized    true       ·          ·
+sort       ·             ·          (a, b, c)  +b,+a
+ │         order         +b,+a      ·          ·
+ └── scan  ·             ·          (a, b, c)  ·
+·          table         t@primary  ·          ·
+·          spans         FULL SCAN  ·          ·
 
 # Check that sort is skipped if the ORDER BY clause is constant.
 query TTT
 EXPLAIN SELECT * FROM t ORDER BY 1+2
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        t@primary
-·     spans        FULL SCAN
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         t@primary
+·     spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT 1, * FROM t ORDER BY 1
 ----
-·          distributed  false
-·          vectorized   true
-render     ·            ·
- └── scan  ·            ·
-·          table        t@primary
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+render     ·             ·
+ └── scan  ·             ·
+·          table         t@primary
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM t ORDER BY length('abc')
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        t@primary
-·     spans        FULL SCAN
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         t@primary
+·     spans         FULL SCAN
 
 # Check that the sort key reuses the existing render.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b+2 r FROM t ORDER BY b+2
 ----
-·               distributed  false      ·    ·
-·               vectorized   true       ·    ·
-sort            ·            ·          (r)  +r
- │              order        +r         ·    ·
- └── render     ·            ·          (r)  ·
-      │         render 0     b + 2      ·    ·
-      └── scan  ·            ·          (b)  ·
-·               table        t@primary  ·    ·
-·               spans        FULL SCAN  ·    ·
+·               distribution  local      ·    ·
+·               vectorized    true       ·    ·
+sort            ·             ·          (r)  +r
+ │              order         +r         ·    ·
+ └── render     ·             ·          (r)  ·
+      │         render 0      b + 2      ·    ·
+      └── scan  ·             ·          (b)  ·
+·               table         t@primary  ·    ·
+·               spans         FULL SCAN  ·    ·
 
 # Check that the sort picks up a renamed render properly.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b+2 AS y FROM t ORDER BY y
 ----
-·               distributed  false      ·    ·
-·               vectorized   true       ·    ·
-sort            ·            ·          (y)  +y
- │              order        +y         ·    ·
- └── render     ·            ·          (y)  ·
-      │         render 0     b + 2      ·    ·
-      └── scan  ·            ·          (b)  ·
-·               table        t@primary  ·    ·
-·               spans        FULL SCAN  ·    ·
+·               distribution  local      ·    ·
+·               vectorized    true       ·    ·
+sort            ·             ·          (y)  +y
+ │              order         +y         ·    ·
+ └── render     ·             ·          (y)  ·
+      │         render 0      b + 2      ·    ·
+      └── scan  ·             ·          (b)  ·
+·               table         t@primary  ·    ·
+·               spans         FULL SCAN  ·    ·
 
 statement ok
 CREATE TABLE abc (
@@ -254,17 +254,17 @@ output row: [4 5]
 query TTT
 EXPLAIN SELECT a, b, c FROM abc ORDER BY b, a, c
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        abc@ba
-·     spans        FULL SCAN
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         abc@ba
+·     spans         FULL SCAN
 
 # We use the WHERE condition to force the use of the index.
 query TTT
 EXPLAIN SELECT a, b, c FROM abc WHERE b > 10 AND b < 30 ORDER BY b, a, d
 ----
-·                     distributed      false
+·                     distribution     local
 ·                     vectorized       true
 render                ·                ·
  └── sort             ·                ·
@@ -281,15 +281,15 @@ render                ·                ·
 query TTT
 EXPLAIN SELECT a, b, c FROM abc WHERE b > 10 ORDER BY b, a, d
 ----
-·               distributed  false
-·               vectorized   true
-render          ·            ·
- └── sort       ·            ·
-      │         order        +b,+a,+d
-      └── scan  ·            ·
-·               table        abc@primary
-·               spans        FULL SCAN
-·               filter       b > 10
+·               distribution  local
+·               vectorized    true
+render          ·             ·
+ └── sort       ·             ·
+      │         order         +b,+a,+d
+      └── scan  ·             ·
+·               table         abc@primary
+·               spans         FULL SCAN
+·               filter        b > 10
 
 query III
 SELECT a, b, c FROM abc WHERE b > 4 ORDER BY b, a, d
@@ -306,56 +306,56 @@ SELECT a, b, c FROM abc WHERE b > 4 ORDER BY b, a, d
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a, b, c, d FROM abc WHERE b > 10 ORDER BY b, a, c, d
 ----
-·          distributed  false        ·             ·
-·          vectorized   true         ·             ·
-sort       ·            ·            (a, b, c, d)  +b,+a,+c
- │         order        +b,+a,+c     ·             ·
- └── scan  ·            ·            (a, b, c, d)  ·
-·          table        abc@primary  ·             ·
-·          spans        FULL SCAN    ·             ·
-·          filter       b > 10       ·             ·
+·          distribution  local        ·             ·
+·          vectorized    true         ·             ·
+sort       ·             ·            (a, b, c, d)  +b,+a,+c
+ │         order         +b,+a,+c     ·             ·
+ └── scan  ·             ·            (a, b, c, d)  ·
+·          table         abc@primary  ·             ·
+·          spans         FULL SCAN    ·             ·
+·          filter        b > 10       ·             ·
 
 query TTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c
 ----
-·          distributed  false
-·          vectorized   true
-render     ·            ·
- └── scan  ·            ·
-·          table        abc@bc
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+render     ·             ·
+ └── scan  ·             ·
+·          table         abc@bc
+·          spans         FULL SCAN
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a, b FROM abc ORDER BY b, c
 ----
-·          distributed  false      ·          ·
-·          vectorized   true       ·          ·
-render     ·            ·          (a, b)     ·
- │         render 0     a          ·          ·
- │         render 1     b          ·          ·
- └── scan  ·            ·          (a, b, c)  +b,+c
-·          table        abc@bc     ·          ·
-·          spans        FULL SCAN  ·          ·
+·          distribution  local      ·          ·
+·          vectorized    true       ·          ·
+render     ·             ·          (a, b)     ·
+ │         render 0      a          ·          ·
+ │         render 1      b          ·          ·
+ └── scan  ·             ·          (a, b, c)  +b,+c
+·          table         abc@bc     ·          ·
+·          spans         FULL SCAN  ·          ·
 
 query TTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a
 ----
-·          distributed  false
-·          vectorized   true
-render     ·            ·
- └── scan  ·            ·
-·          table        abc@bc
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+render     ·             ·
+ └── scan  ·             ·
+·          table         abc@bc
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a DESC
 ----
-·          distributed  false
-·          vectorized   true
-render     ·            ·
- └── scan  ·            ·
-·          table        abc@bc
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+render     ·             ·
+ └── scan  ·             ·
+·          table         abc@bc
+·          spans         FULL SCAN
 
 statement ok
 SET tracing = on,kv,results; SELECT b, c FROM abc ORDER BY b, c; SET tracing = off
@@ -401,44 +401,44 @@ output row: [1]
 query TTT
 EXPLAIN SELECT a FROM abc ORDER BY a DESC
 ----
-·        distributed  false
-·        vectorized   true
-revscan  ·            ·
-·        table        abc@primary
-·        spans        FULL SCAN
+·        distribution  local
+·        vectorized    true
+revscan  ·             ·
+·        table         abc@primary
+·        spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c
 ----
-·          distributed  false
-·          vectorized   true
-render     ·            ·
- └── scan  ·            ·
-·          table        abc@bc
-·          spans        /2-/3
+·          distribution  local
+·          vectorized    true
+render     ·             ·
+ └── scan  ·             ·
+·          table         abc@bc
+·          spans         /2-/3
 
 query TTT
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
 ----
-·             distributed  false
-·             vectorized   true
-render        ·            ·
- └── revscan  ·            ·
-·             table        abc@bc
-·             spans        /2-/3
+·             distribution  local
+·             vectorized    true
+render        ·             ·
+ └── revscan  ·             ·
+·             table         abc@bc
+·             spans         /2-/3
 
 # Verify that the ordering of the primary index is still used for the outer sort.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT b, c FROM abc WHERE a=1 ORDER BY a,b) ORDER BY b,c
 ----
-·          distributed  false        ·          ·
-·          vectorized   true         ·          ·
-render     ·            ·            (b, c)     +b,+c
- │         render 0     b            ·          ·
- │         render 1     c            ·          ·
- └── scan  ·            ·            (a, b, c)  +b,+c
-·          table        abc@primary  ·          ·
-·          spans        /1-/2        ·          ·
+·          distribution  local        ·          ·
+·          vectorized    true         ·          ·
+render     ·             ·            (b, c)     +b,+c
+ │         render 0      b            ·          ·
+ │         render 1      c            ·          ·
+ └── scan  ·             ·            (a, b, c)  +b,+c
+·          table         abc@primary  ·          ·
+·          spans         /1-/2        ·          ·
 
 statement ok
 CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz))
@@ -446,11 +446,11 @@ CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM bar ORDER BY baz, id
 ----
-·     distributed  false      ·          ·
-·     vectorized   true       ·          ·
-scan  ·            ·          (id, baz)  +baz,+id
-·     table        bar@i_bar  ·          ·
-·     spans        FULL SCAN  ·          ·
+·     distribution  local      ·          ·
+·     vectorized    true       ·          ·
+scan  ·             ·          (id, baz)  +baz,+id
+·     table         bar@i_bar  ·          ·
+·     spans         FULL SCAN  ·          ·
 
 statement ok
 CREATE TABLE abcd (
@@ -470,38 +470,38 @@ CREATE TABLE abcd (
 query TTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        abcd@abc
-·     spans        /1/4-/1/5
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         abcd@abc
+·     spans         /1/4-/1/5
 
 query TTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        abcd@abc
-·     spans        /1/4-/1/5
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         abcd@abc
+·     spans         /1/4-/1/5
 
 query TTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        abcd@abc
-·     spans        /1/4-/1/5
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         abcd@abc
+·     spans         /1/4-/1/5
 
 query TTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        abcd@abc
-·     spans        /1/4-/1/5
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         abcd@abc
+·     spans         /1/4-/1/5
 
 statement ok
 CREATE TABLE nan (id INT PRIMARY KEY, x REAL)
@@ -509,7 +509,7 @@ CREATE TABLE nan (id INT PRIMARY KEY, x REAL)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
 ----
-·       distributed    false             ·    ·
+·       distribution   local             ·    ·
 ·       vectorized     false             ·    ·
 values  ·              ·                 (x)  ·
 ·       size           1 column, 3 rows  ·    ·
@@ -520,27 +520,27 @@ values  ·              ·                 (x)  ·
 query TTT
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality ASC
 ----
-·            distributed  false
-·            vectorized   false
-ordinality   ·            ·
- └── values  ·            ·
-·            size         1 column, 3 rows
+·            distribution  local
+·            vectorized    false
+ordinality   ·             ·
+ └── values  ·             ·
+·            size          1 column, 3 rows
 
 query TTT
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality DESC
 ----
-·                 distributed  false
-·                 vectorized   false
-sort              ·            ·
- │                order        -"ordinality"
- └── ordinality   ·            ·
-      └── values  ·            ·
-·                 size         1 column, 3 rows
+·                 distribution  local
+·                 vectorized    false
+sort              ·             ·
+ │                order         -"ordinality"
+ └── ordinality   ·             ·
+      └── values  ·             ·
+·                 size          1 column, 3 rows
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY
 ----
-·            distributed    false             ·                  ·
+·            distribution   local             ·                  ·
 ·            vectorized     false             ·                  ·
 ordinality   ·              ·                 (x, "ordinality")  ·
  └── values  ·              ·                 (column1)          ·
@@ -552,7 +552,7 @@ ordinality   ·              ·                 (x, "ordinality")  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY
 ----
-·                 distributed    false             ·                  ·
+·                 distribution   local             ·                  ·
 ·                 vectorized     false             ·                  ·
 ordinality        ·              ·                 (x, "ordinality")  ·
  └── sort         ·              ·                 (column1)          +column1
@@ -567,7 +567,7 @@ ordinality        ·              ·                 (x, "ordinality")  ·
 query TTTTT
 EXPLAIN (VERBOSE) INSERT INTO t(a, b) SELECT * FROM (SELECT 1 AS x, 2 AS y) ORDER BY x RETURNING b
 ----
-·                           distributed    false               ·       ·
+·                           distribution   local               ·       ·
 ·                           vectorized     false               ·       ·
 render                      ·              ·                   (b)     ·
  │                          render 0       b                   ·       ·
@@ -584,23 +584,23 @@ render                      ·              ·                   (b)     ·
 query TTTTT
 EXPLAIN (VERBOSE) DELETE FROM t WHERE a = 3 RETURNING b
 ----
-·                    distributed  false      ·       ·
-·                    vectorized   false      ·       ·
-render               ·            ·          (b)     ·
- │                   render 0     b          ·       ·
- └── run             ·            ·          (a, b)  ·
-      └── delete     ·            ·          (a, b)  ·
-           │         from         t          ·       ·
-           │         strategy     deleter    ·       ·
-           │         auto commit  ·          ·       ·
-           └── scan  ·            ·          (a, b)  ·
-·                    table        t@primary  ·       ·
-·                    spans        /3-/3/#    ·       ·
+·                    distribution  local      ·       ·
+·                    vectorized    false      ·       ·
+render               ·             ·          (b)     ·
+ │                   render 0      b          ·       ·
+ └── run             ·             ·          (a, b)  ·
+      └── delete     ·             ·          (a, b)  ·
+           │         from          t          ·       ·
+           │         strategy      deleter    ·       ·
+           │         auto commit   ·          ·       ·
+           └── scan  ·             ·          (a, b)  ·
+·                    table         t@primary  ·       ·
+·                    spans         /3-/3/#    ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE t SET c = TRUE RETURNING b
 ----
-·                         distributed       false       ·                 ·
+·                         distribution      local       ·                 ·
 ·                         vectorized        false       ·                 ·
 render                    ·                 ·           (b)               ·
  │                        render 0          b           ·                 ·
@@ -637,15 +637,15 @@ CREATE TABLE uvwxyz (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT y, w, x FROM uvwxyz WHERE y = 1 ORDER BY w) ORDER BY w, x
 ----
-·          distributed  false        ·          ·
-·          vectorized   true         ·          ·
-render     ·            ·            (y, w, x)  ·
- │         render 0     y            ·          ·
- │         render 1     w            ·          ·
- │         render 2     x            ·          ·
- └── scan  ·            ·            (w, x, y)  +w,+x
-·          table        uvwxyz@ywxz  ·          ·
-·          spans        /1-/2        ·          ·
+·          distribution  local        ·          ·
+·          vectorized    true         ·          ·
+render     ·             ·            (y, w, x)  ·
+ │         render 0      y            ·          ·
+ │         render 1      w            ·          ·
+ │         render 2      x            ·          ·
+ └── scan  ·             ·            (w, x, y)  +w,+x
+·          table         uvwxyz@ywxz  ·          ·
+·          spans         /1-/2        ·          ·
 
 
 statement ok
@@ -666,17 +666,17 @@ CREATE TABLE blocks (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT block_id,writer_id,block_num,block_id FROM blocks ORDER BY block_id, writer_id, block_num LIMIT 1
 ----
-·          distributed  false           ·                                           ·
-·          vectorized   true            ·                                           ·
-render     ·            ·               (block_id, writer_id, block_num, block_id)  ·
- │         render 0     block_id        ·                                           ·
- │         render 1     writer_id       ·                                           ·
- │         render 2     block_num       ·                                           ·
- │         render 3     block_id        ·                                           ·
- └── scan  ·            ·               (block_id, writer_id, block_num)            ·
-·          table        blocks@primary  ·                                           ·
-·          spans        LIMITED SCAN    ·                                           ·
-·          limit        1               ·                                           ·
+·          distribution  local           ·                                           ·
+·          vectorized    true            ·                                           ·
+render     ·             ·               (block_id, writer_id, block_num, block_id)  ·
+ │         render 0      block_id        ·                                           ·
+ │         render 1      writer_id       ·                                           ·
+ │         render 2      block_num       ·                                           ·
+ │         render 3      block_id        ·                                           ·
+ └── scan  ·             ·               (block_id, writer_id, block_num)            ·
+·          table         blocks@primary  ·                                           ·
+·          spans         LIMITED SCAN    ·                                           ·
+·          limit         1               ·                                           ·
 
 statement ok
 CREATE TABLE foo(a INT, b CHAR)
@@ -685,38 +685,38 @@ CREATE TABLE foo(a INT, b CHAR)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b, a FROM foo ORDER BY @1
 ----
-·                    distributed  false        ·                ·
-·                    vectorized   true         ·                ·
-render               ·            ·            (b, a)           ·
- │                   render 0     b            ·                ·
- │                   render 1     a            ·                ·
- └── sort            ·            ·            (column4, a, b)  +a
-      │              order        +a           ·                ·
-      └── render     ·            ·            (column4, a, b)  ·
-           │         render 0     a            ·                ·
-           │         render 1     a            ·                ·
-           │         render 2     b            ·                ·
-           └── scan  ·            ·            (a, b)           ·
-·                    table        foo@primary  ·                ·
-·                    spans        FULL SCAN    ·                ·
+·                    distribution  local        ·                ·
+·                    vectorized    true         ·                ·
+render               ·             ·            (b, a)           ·
+ │                   render 0      b            ·                ·
+ │                   render 1      a            ·                ·
+ └── sort            ·             ·            (column4, a, b)  +a
+      │              order         +a           ·                ·
+      └── render     ·             ·            (column4, a, b)  ·
+           │         render 0      a            ·                ·
+           │         render 1      a            ·                ·
+           │         render 2      b            ·                ·
+           └── scan  ·             ·            (a, b)           ·
+·                    table         foo@primary  ·                ·
+·                    spans         FULL SCAN    ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b, a FROM foo ORDER BY @2
 ----
-·                    distributed  false        ·                ·
-·                    vectorized   true         ·                ·
-render               ·            ·            (b, a)           ·
- │                   render 0     b            ·                ·
- │                   render 1     a            ·                ·
- └── sort            ·            ·            (column4, a, b)  +b
-      │              order        +b           ·                ·
-      └── render     ·            ·            (column4, a, b)  ·
-           │         render 0     b            ·                ·
-           │         render 1     a            ·                ·
-           │         render 2     b            ·                ·
-           └── scan  ·            ·            (a, b)           ·
-·                    table        foo@primary  ·                ·
-·                    spans        FULL SCAN    ·                ·
+·                    distribution  local        ·                ·
+·                    vectorized    true         ·                ·
+render               ·             ·            (b, a)           ·
+ │                   render 0      b            ·                ·
+ │                   render 1      a            ·                ·
+ └── sort            ·             ·            (column4, a, b)  +b
+      │              order         +b           ·                ·
+      └── render     ·             ·            (column4, a, b)  ·
+           │         render 0      b            ·                ·
+           │         render 1      a            ·                ·
+           │         render 2      b            ·                ·
+           └── scan  ·             ·            (a, b)           ·
+·                    table         foo@primary  ·                ·
+·                    spans         FULL SCAN    ·                ·
 
 # ------------------------------------------------------------------------------
 # Check star expansion in ORDER BY.
@@ -729,26 +729,26 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM a ORDER BY a.*
 ]
 ----
-·          distributed  false
-·          vectorized   true
-sort       ·            ·
- │         order        +x,+y
- └── scan  ·            ·
-·          table        a@primary
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+sort       ·             ·
+ │         order         +x,+y
+ └── scan  ·             ·
+·          table         a@primary
+·          spans         FULL SCAN
 
 query TTT
 SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM a ORDER BY (a.*)
 ]
 ----
-·          distributed  false
-·          vectorized   true
-sort       ·            ·
- │         order        +x,+y
- └── scan  ·            ·
-·          table        a@primary
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+sort       ·             ·
+ │         order         +x,+y
+ └── scan  ·             ·
+·          table         a@primary
+·          spans         FULL SCAN
 
 # ------------------------------------------------------------------------------
 # ORDER BY INDEX test cases.
@@ -761,92 +761,92 @@ CREATE TABLE kv(k INT PRIMARY KEY, v INT); CREATE INDEX foo ON kv(v DESC)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT v FROM kv ORDER BY PRIMARY KEY kv
 ----
-·          distributed  false       ·       ·
-·          vectorized   true        ·       ·
-render     ·            ·           (v)     ·
- │         render 0     v           ·       ·
- └── scan  ·            ·           (k, v)  +k
-·          table        kv@primary  ·       ·
-·          spans        FULL SCAN   ·       ·
+·          distribution  local       ·       ·
+·          vectorized    true        ·       ·
+render     ·             ·           (v)     ·
+ │         render 0      v           ·       ·
+ └── scan  ·             ·           (k, v)  +k
+·          table         kv@primary  ·       ·
+·          spans         FULL SCAN   ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT v FROM kv ORDER BY PRIMARY KEY kv ASC
 ----
-·          distributed  false       ·       ·
-·          vectorized   true        ·       ·
-render     ·            ·           (v)     ·
- │         render 0     v           ·       ·
- └── scan  ·            ·           (k, v)  +k
-·          table        kv@primary  ·       ·
-·          spans        FULL SCAN   ·       ·
+·          distribution  local       ·       ·
+·          vectorized    true        ·       ·
+render     ·             ·           (v)     ·
+ │         render 0      v           ·       ·
+ └── scan  ·             ·           (k, v)  +k
+·          table         kv@primary  ·       ·
+·          spans         FULL SCAN   ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT v FROM kv ORDER BY PRIMARY KEY kv DESC
 ----
-·             distributed  false       ·       ·
-·             vectorized   true        ·       ·
-render        ·            ·           (v)     ·
- │            render 0     v           ·       ·
- └── revscan  ·            ·           (k, v)  -k
-·             table        kv@primary  ·       ·
-·             spans        FULL SCAN   ·       ·
+·             distribution  local       ·       ·
+·             vectorized    true        ·       ·
+render        ·             ·           (v)     ·
+ │            render 0      v           ·       ·
+ └── revscan  ·             ·           (k, v)  -k
+·             table         kv@primary  ·       ·
+·             spans         FULL SCAN   ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY v, PRIMARY KEY kv, v-2
 ----
-·               distributed  false       ·       ·
-·               vectorized   true        ·       ·
-render          ·            ·           (k)     ·
- │              render 0     k           ·       ·
- └── sort       ·            ·           (k, v)  +v,+k
-      │         order        +v,+k       ·       ·
-      └── scan  ·            ·           (k, v)  ·
-·               table        kv@primary  ·       ·
-·               spans        FULL SCAN   ·       ·
+·               distribution  local       ·       ·
+·               vectorized    true        ·       ·
+render          ·             ·           (k)     ·
+ │              render 0      k           ·       ·
+ └── sort       ·             ·           (k, v)  +v,+k
+      │         order         +v,+k       ·       ·
+      └── scan  ·             ·           (k, v)  ·
+·               table         kv@primary  ·       ·
+·               spans         FULL SCAN   ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo
 ----
-·          distributed  false      ·       ·
-·          vectorized   true       ·       ·
-render     ·            ·          (k)     ·
- │         render 0     k          ·       ·
- └── scan  ·            ·          (k, v)  -v,+k
-·          table        kv@foo     ·       ·
-·          spans        FULL SCAN  ·       ·
+·          distribution  local      ·       ·
+·          vectorized    true       ·       ·
+render     ·             ·          (k)     ·
+ │         render 0      k          ·       ·
+ └── scan  ·             ·          (k, v)  -v,+k
+·          table         kv@foo     ·       ·
+·          spans         FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo ASC
 ----
-·          distributed  false      ·       ·
-·          vectorized   true       ·       ·
-render     ·            ·          (k)     ·
- │         render 0     k          ·       ·
- └── scan  ·            ·          (k, v)  -v,+k
-·          table        kv@foo     ·       ·
-·          spans        FULL SCAN  ·       ·
+·          distribution  local      ·       ·
+·          vectorized    true       ·       ·
+render     ·             ·          (k)     ·
+ │         render 0      k          ·       ·
+ └── scan  ·             ·          (k, v)  -v,+k
+·          table         kv@foo     ·       ·
+·          spans         FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo DESC
 ----
-·             distributed  false      ·       ·
-·             vectorized   true       ·       ·
-render        ·            ·          (k)     ·
- │            render 0     k          ·       ·
- └── revscan  ·            ·          (k, v)  +v,-k
-·             table        kv@foo     ·       ·
-·             spans        FULL SCAN  ·       ·
+·             distribution  local      ·       ·
+·             vectorized    true       ·       ·
+render        ·             ·          (k)     ·
+ │            render 0      k          ·       ·
+ └── revscan  ·             ·          (k, v)  +v,-k
+·             table         kv@foo     ·       ·
+·             spans         FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo, k
 ----
-·          distributed  false      ·       ·
-·          vectorized   true       ·       ·
-render     ·            ·          (k)     ·
- │         render 0     k          ·       ·
- └── scan  ·            ·          (k, v)  -v,+k
-·          table        kv@foo     ·       ·
-·          spans        FULL SCAN  ·       ·
+·          distribution  local      ·       ·
+·          vectorized    true       ·       ·
+render     ·             ·          (k)     ·
+ │         render 0      k          ·       ·
+ └── scan  ·             ·          (k, v)  -v,+k
+·          table         kv@foo     ·       ·
+·          spans         FULL SCAN  ·       ·
 
 # Check the syntax can be used with joins.
 #
@@ -858,7 +858,7 @@ query TTTTT
 EXPLAIN (VERBOSE)
 SELECT k FROM kv JOIN (VALUES (1,2), (3,4)) AS z(a,b) ON kv.k = z.a ORDER BY INDEX kv@foo
 ----
-·                           distributed            false             ·                ·
+·                           distribution           local             ·                ·
 ·                           vectorized             false             ·                ·
 render                      ·                      ·                 (k)              ·
  │                          render 0               k                 ·                ·
@@ -881,7 +881,7 @@ render                      ·                      ·                 (k)      
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
 ----
-·                distributed         false              ·             ·
+·                distribution        local              ·             ·
 ·                vectorized          true               ·             ·
 render           ·                   ·                  (k)           ·
  │               render 0            k                  ·             ·
@@ -905,15 +905,15 @@ CREATE TABLE xyz (x INT, y INT, z INT, INDEX(z,y))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyz WHERE z=1 AND x=y ORDER BY x;
 ----
-·                     distributed  false            ·                      ·
-·                     vectorized   true             ·                      ·
-sort                  ·            ·                (x, y, z)              +x
- │                    order        +x               ·                      ·
- └── filter           ·            ·                (x, y, z)              ·
-      │               filter       x = y            ·                      ·
-      └── index-join  ·            ·                (x, y, z)              ·
-           │          table        xyz@primary      ·                      ·
-           │          key columns  rowid            ·                      ·
-           └── scan   ·            ·                (y, z, rowid[hidden])  ·
-·                     table        xyz@xyz_z_y_idx  ·                      ·
-·                     spans        /1/!NULL-/2      ·                      ·
+·                     distribution  local            ·                      ·
+·                     vectorized    true             ·                      ·
+sort                  ·             ·                (x, y, z)              +x
+ │                    order         +x               ·                      ·
+ └── filter           ·             ·                (x, y, z)              ·
+      │               filter        x = y            ·                      ·
+      └── index-join  ·             ·                (x, y, z)              ·
+           │          table         xyz@primary      ·                      ·
+           │          key columns   rowid            ·                      ·
+           └── scan   ·             ·                (y, z, rowid[hidden])  ·
+·                     table         xyz@xyz_z_y_idx  ·                      ·
+·                     spans         /1/!NULL-/2      ·                      ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/ordinality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ordinality
@@ -6,63 +6,63 @@ CREATE TABLE foo (x CHAR PRIMARY KEY); INSERT INTO foo(x) VALUES ('a'), ('b')
 query TTTTT
 EXPLAIN (VERBOSE) SELECT max(ordinality) FROM foo WITH ORDINALITY
 ----
-·                distributed  false            ·               ·
-·                vectorized   true             ·               ·
-group            ·            ·                (max)           ·
- │               aggregate 0  max(ordinality)  ·               ·
- │               scalar       ·                ·               ·
- └── ordinality  ·            ·                ("ordinality")  ·
-      └── scan   ·            ·                ()              ·
-·                table        foo@primary      ·               ·
-·                spans        FULL SCAN        ·               ·
+·                distribution  local            ·               ·
+·                vectorized    true             ·               ·
+group            ·             ·                (max)           ·
+ │               aggregate 0   max(ordinality)  ·               ·
+ │               scalar        ·                ·               ·
+ └── ordinality  ·             ·                ("ordinality")  ·
+      └── scan   ·             ·                ()              ·
+·                table         foo@primary      ·               ·
+·                spans         FULL SCAN        ·               ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM foo WITH ORDINALITY WHERE ordinality > 1 ORDER BY ordinality
 ----
-·                distributed  false             ·                  ·
-·                vectorized   true              ·                  ·
-filter           ·            ·                 (x, "ordinality")  +"ordinality"
- │               filter       "ordinality" > 1  ·                  ·
- └── ordinality  ·            ·                 (x, "ordinality")  ·
-      └── scan   ·            ·                 (x)                ·
-·                table        foo@primary       ·                  ·
-·                spans        FULL SCAN         ·                  ·
+·                distribution  local             ·                  ·
+·                vectorized    true              ·                  ·
+filter           ·             ·                 (x, "ordinality")  +"ordinality"
+ │               filter        "ordinality" > 1  ·                  ·
+ └── ordinality  ·             ·                 (x, "ordinality")  ·
+      └── scan   ·             ·                 (x)                ·
+·                table         foo@primary       ·                  ·
+·                spans         FULL SCAN         ·                  ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM foo WITH ORDINALITY WHERE ordinality > 1 ORDER BY ordinality DESC
 ----
-·                     distributed  false             ·                  ·
-·                     vectorized   true              ·                  ·
-sort                  ·            ·                 (x, "ordinality")  -"ordinality"
- │                    order        -"ordinality"     ·                  ·
- └── filter           ·            ·                 (x, "ordinality")  ·
-      │               filter       "ordinality" > 1  ·                  ·
-      └── ordinality  ·            ·                 (x, "ordinality")  ·
-           └── scan   ·            ·                 (x)                ·
-·                     table        foo@primary       ·                  ·
-·                     spans        FULL SCAN         ·                  ·
+·                     distribution  local             ·                  ·
+·                     vectorized    true              ·                  ·
+sort                  ·             ·                 (x, "ordinality")  -"ordinality"
+ │                    order         -"ordinality"     ·                  ·
+ └── filter           ·             ·                 (x, "ordinality")  ·
+      │               filter        "ordinality" > 1  ·                  ·
+      └── ordinality  ·             ·                 (x, "ordinality")  ·
+           └── scan   ·             ·                 (x)                ·
+·                     table         foo@primary       ·                  ·
+·                     spans         FULL SCAN         ·                  ·
 
 # Show that the primary key is used under ordinalityNode.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALITY
 ----
-·           distributed  false        ·                  ·
-·           vectorized   true         ·                  ·
-ordinality  ·            ·            (x, "ordinality")  ·
- └── scan   ·            ·            (x)                ·
-·           table        foo@primary  ·                  ·
-·           spans        /"a\x00"-    ·                  ·
+·           distribution  local        ·                  ·
+·           vectorized    true         ·                  ·
+ordinality  ·             ·            (x, "ordinality")  ·
+ └── scan   ·             ·            (x)                ·
+·           table         foo@primary  ·                  ·
+·           spans         /"a\x00"-    ·                  ·
 
 # Show that the primary key cannot be used with a PK predicate
 # outside of ordinalityNode.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM foo WITH ORDINALITY WHERE x > 'a'
 ----
-·                distributed  false        ·                  ·
-·                vectorized   true         ·                  ·
-filter           ·            ·            (x, "ordinality")  ·
- │               filter       x > 'a'      ·                  ·
- └── ordinality  ·            ·            (x, "ordinality")  ·
-      └── scan   ·            ·            (x)                ·
-·                table        foo@primary  ·                  ·
-·                spans        FULL SCAN    ·                  ·
+·                distribution  local        ·                  ·
+·                vectorized    true         ·                  ·
+filter           ·             ·            (x, "ordinality")  ·
+ │               filter        x > 'a'      ·                  ·
+ └── ordinality  ·             ·            (x, "ordinality")  ·
+      └── scan   ·             ·            (x)                ·
+·                table         foo@primary  ·                  ·
+·                spans         FULL SCAN    ·                  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -11,12 +11,12 @@ PREPARE change_index AS SELECT * FROM [EXPLAIN SELECT * FROM ab WHERE b=10]
 query TTT
 EXECUTE change_index
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        ab@primary
-·     spans        FULL SCAN
-·     filter       b = 10
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         ab@primary
+·     spans         FULL SCAN
+·     filter        b = 10
 
 statement ok
 CREATE INDEX bindex ON ab (b)
@@ -24,11 +24,11 @@ CREATE INDEX bindex ON ab (b)
 query TTT
 EXECUTE change_index
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        ab@bindex
-·     spans        /10-/11
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         ab@bindex
+·     spans         /10-/11
 
 statement ok
 DROP INDEX bindex
@@ -36,12 +36,12 @@ DROP INDEX bindex
 query TTT
 EXECUTE change_index
 ----
-·     distributed  true
-·     vectorized   true
-scan  ·            ·
-·     table        ab@primary
-·     spans        FULL SCAN
-·     filter       b = 10
+·     distribution  full
+·     vectorized    true
+scan  ·             ·
+·     table         ab@primary
+·     spans         FULL SCAN
+·     filter        b = 10
 
 ## Statistics change: Create statistics and ensure that the plan is recalculated.
 statement ok
@@ -53,7 +53,7 @@ PREPARE change_stats AS SELECT * FROM [EXPLAIN SELECT * FROM ab JOIN cd ON a=c]
 query TTT
 EXECUTE change_stats
 ----
-·           distributed         true
+·           distribution        full
 ·           vectorized          true
 merge-join  ·                   ·
  │          type                inner
@@ -77,7 +77,7 @@ CREATE STATISTICS s FROM ab
 query TTT retry
 EXECUTE change_stats
 ----
-·            distributed            true
+·            distribution           full
 ·            vectorized             true
 lookup-join  ·                      ·
  │           table                  cd@primary

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -10,7 +10,7 @@ CREATE TABLE t (a INT, b INT, c INT, d INT, j JSONB, s STRING)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 + 2 AS r
 ----
-·       distributed    false            ·    ·
+·       distribution   local            ·    ·
 ·       vectorized     false            ·    ·
 values  ·              ·                (r)  ·
 ·       size           1 column, 1 row  ·    ·
@@ -19,7 +19,7 @@ values  ·              ·                (r)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT true AS r
 ----
-·       distributed    false            ·    ·
+·       distribution   local            ·    ·
 ·       vectorized     false            ·    ·
 values  ·              ·                (r)  ·
 ·       size           1 column, 1 row  ·    ·
@@ -28,7 +28,7 @@ values  ·              ·                (r)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT false AS r
 ----
-·       distributed    false            ·    ·
+·       distribution   local            ·    ·
 ·       vectorized     false            ·    ·
 values  ·              ·                (r)  ·
 ·       size           1 column, 1 row  ·    ·
@@ -37,7 +37,7 @@ values  ·              ·                (r)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (1, 2) AS r
 ----
-·       distributed    false            ·    ·
+·       distribution   local            ·    ·
 ·       vectorized     false            ·    ·
 values  ·              ·                (r)  ·
 ·       size           1 column, 1 row  ·    ·
@@ -46,7 +46,7 @@ values  ·              ·                (r)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (true, false) AS r
 ----
-·       distributed    false            ·    ·
+·       distribution   local            ·    ·
 ·       vectorized     false            ·    ·
 values  ·              ·                (r)  ·
 ·       size           1 column, 1 row  ·    ·
@@ -55,333 +55,333 @@ values  ·              ·                (r)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 + 2 AS r FROM t
 ----
-·          distributed  false      ·    ·
-·          vectorized   true       ·    ·
-render     ·            ·          (r)  ·
- │         render 0     3          ·    ·
- └── scan  ·            ·          ()   ·
-·          table        t@primary  ·    ·
-·          spans        FULL SCAN  ·    ·
+·          distribution  local      ·    ·
+·          vectorized    true       ·    ·
+render     ·             ·          (r)  ·
+ │         render 0      3          ·    ·
+ └── scan  ·             ·          ()   ·
+·          table         t@primary  ·    ·
+·          spans         FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a + 2 AS r FROM t
 ----
-·          distributed  false      ·    ·
-·          vectorized   true       ·    ·
-render     ·            ·          (r)  ·
- │         render 0     a + 2      ·    ·
- └── scan  ·            ·          (a)  ·
-·          table        t@primary  ·    ·
-·          spans        FULL SCAN  ·    ·
+·          distribution  local      ·    ·
+·          vectorized    true       ·    ·
+render     ·             ·          (r)  ·
+ │         render 0      a + 2      ·    ·
+ └── scan  ·             ·          (a)  ·
+·          table         t@primary  ·    ·
+·          spans         FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a >= 5 AND b <= 10 AND c < 4 AS r FROM t
 ----
-·          distributed  false                                 ·          ·
-·          vectorized   true                                  ·          ·
-render     ·            ·                                     (r)        ·
- │         render 0     ((a >= 5) AND (b <= 10)) AND (c < 4)  ·          ·
- └── scan  ·            ·                                     (a, b, c)  ·
-·          table        t@primary                             ·          ·
-·          spans        FULL SCAN                             ·          ·
+·          distribution  local                                 ·          ·
+·          vectorized    true                                  ·          ·
+render     ·             ·                                     (r)        ·
+ │         render 0      ((a >= 5) AND (b <= 10)) AND (c < 4)  ·          ·
+ └── scan  ·             ·                                     (a, b, c)  ·
+·          table         t@primary                             ·          ·
+·          spans         FULL SCAN                             ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a >= 5 OR b <= 10 OR c < 4 AS r FROM t
 ----
-·          distributed  false                               ·          ·
-·          vectorized   true                                ·          ·
-render     ·            ·                                   (r)        ·
- │         render 0     ((a >= 5) OR (b <= 10)) OR (c < 4)  ·          ·
- └── scan  ·            ·                                   (a, b, c)  ·
-·          table        t@primary                           ·          ·
-·          spans        FULL SCAN                           ·          ·
+·          distribution  local                               ·          ·
+·          vectorized    true                                ·          ·
+render     ·             ·                                   (r)        ·
+ │         render 0      ((a >= 5) OR (b <= 10)) OR (c < 4)  ·          ·
+ └── scan  ·             ·                                   (a, b, c)  ·
+·          table         t@primary                           ·          ·
+·          spans         FULL SCAN                           ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT NOT (a = 5) AS r FROM t
 ----
-·          distributed  false      ·    ·
-·          vectorized   true       ·    ·
-render     ·            ·          (r)  ·
- │         render 0     a != 5     ·    ·
- └── scan  ·            ·          (a)  ·
-·          table        t@primary  ·    ·
-·          spans        FULL SCAN  ·    ·
+·          distribution  local      ·    ·
+·          vectorized    true       ·    ·
+render     ·             ·          (r)  ·
+ │         render 0      a != 5     ·    ·
+ └── scan  ·             ·          (a)  ·
+·          table         t@primary  ·    ·
+·          spans         FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT NOT (a > 5 AND b >= 10) AS r FROM t
 ----
-·          distributed  false                 ·       ·
-·          vectorized   true                  ·       ·
-render     ·            ·                     (r)     ·
- │         render 0     (a <= 5) OR (b < 10)  ·       ·
- └── scan  ·            ·                     (a, b)  ·
-·          table        t@primary             ·       ·
-·          spans        FULL SCAN             ·       ·
+·          distribution  local                 ·       ·
+·          vectorized    true                  ·       ·
+render     ·             ·                     (r)     ·
+ │         render 0      (a <= 5) OR (b < 10)  ·       ·
+ └── scan  ·             ·                     (a, b)  ·
+·          table         t@primary             ·       ·
+·          spans         FULL SCAN             ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (a >= 5 AND b <= 10) OR (a <= 10 AND c > 5) AS r FROM t
 ----
-·          distributed  false                                                ·          ·
-·          vectorized   true                                                 ·          ·
-render     ·            ·                                                    (r)        ·
- │         render 0     ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))  ·          ·
- └── scan  ·            ·                                                    (a, b, c)  ·
-·          table        t@primary                                            ·          ·
-·          spans        FULL SCAN                                            ·          ·
+·          distribution  local                                                ·          ·
+·          vectorized    true                                                 ·          ·
+render     ·             ·                                                    (r)        ·
+ │         render 0      ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))  ·          ·
+ └── scan  ·             ·                                                    (a, b, c)  ·
+·          table         t@primary                                            ·          ·
+·          spans         FULL SCAN                                            ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT NOT (a >= 5 OR b <= 10) AND NOT (c >= 10) AS r FROM t
 ----
-·          distributed  false                                ·          ·
-·          vectorized   true                                 ·          ·
-render     ·            ·                                    (r)        ·
- │         render 0     ((a < 5) AND (b > 10)) AND (c < 10)  ·          ·
- └── scan  ·            ·                                    (a, b, c)  ·
-·          table        t@primary                            ·          ·
-·          spans        FULL SCAN                            ·          ·
+·          distribution  local                                ·          ·
+·          vectorized    true                                 ·          ·
+render     ·             ·                                    (r)        ·
+ │         render 0      ((a < 5) AND (b > 10)) AND (c < 10)  ·          ·
+ └── scan  ·             ·                                    (a, b, c)  ·
+·          table         t@primary                            ·          ·
+·          spans         FULL SCAN                            ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, b) = (1, 2)  AS r FROM t
 ----
-·          distributed  false                ·       ·
-·          vectorized   true                 ·       ·
-render     ·            ·                    (r)     ·
- │         render 0     (a = 1) AND (b = 2)  ·       ·
- └── scan  ·            ·                    (a, b)  ·
-·          table        t@primary            ·       ·
-·          spans        FULL SCAN            ·       ·
+·          distribution  local                ·       ·
+·          vectorized    true                 ·       ·
+render     ·             ·                    (r)     ·
+ │         render 0      (a = 1) AND (b = 2)  ·       ·
+ └── scan  ·             ·                    (a, b)  ·
+·          table         t@primary            ·       ·
+·          spans         FULL SCAN            ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IN (1, 2) AS r FROM t
 ----
-·          distributed  false        ·    ·
-·          vectorized   true         ·    ·
-render     ·            ·            (r)  ·
- │         render 0     a IN (1, 2)  ·    ·
- └── scan  ·            ·            (a)  ·
-·          table        t@primary    ·    ·
-·          spans        FULL SCAN    ·    ·
+·          distribution  local        ·    ·
+·          vectorized    true         ·    ·
+render     ·             ·            (r)  ·
+ │         render 0      a IN (1, 2)  ·    ·
+ └── scan  ·             ·            (a)  ·
+·          table         t@primary    ·    ·
+·          spans         FULL SCAN    ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, b) IN ((1, 2), (3, 4)) AS r FROM t
 ----
-·          distributed  false                       ·       ·
-·          vectorized   true                        ·       ·
-render     ·            ·                           (r)     ·
- │         render 0     (a, b) IN ((1, 2), (3, 4))  ·       ·
- └── scan  ·            ·                           (a, b)  ·
-·          table        t@primary                   ·       ·
-·          spans        FULL SCAN                   ·       ·
+·          distribution  local                       ·       ·
+·          vectorized    true                        ·       ·
+render     ·             ·                           (r)     ·
+ │         render 0      (a, b) IN ((1, 2), (3, 4))  ·       ·
+ └── scan  ·             ·                           (a, b)  ·
+·          table         t@primary                   ·       ·
+·          spans         FULL SCAN                   ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, b + c, 5 + d * 2) = (b+c, 8, a - c)  AS r FROM t
 ----
-·          distributed  false                                                            ·             ·
-·          vectorized   true                                                             ·             ·
-render     ·            ·                                                                (r)           ·
- │         render 0     ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))  ·             ·
- └── scan  ·            ·                                                                (a, b, c, d)  ·
-·          table        t@primary                                                        ·             ·
-·          spans        FULL SCAN                                                        ·             ·
+·          distribution  local                                                            ·             ·
+·          vectorized    true                                                             ·             ·
+render     ·             ·                                                                (r)           ·
+ │         render 0      ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))  ·             ·
+ └── scan  ·             ·                                                                (a, b, c, d)  ·
+·          table         t@primary                                                        ·             ·
+·          spans         FULL SCAN                                                        ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ((a, b), (c, d)) = ((1, 2), (3, 4))  AS r FROM t
 ----
-·          distributed  false                                            ·             ·
-·          vectorized   true                                             ·             ·
-render     ·            ·                                                (r)           ·
- │         render 0     (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)  ·             ·
- └── scan  ·            ·                                                (a, b, c, d)  ·
-·          table        t@primary                                        ·             ·
-·          spans        FULL SCAN                                        ·             ·
+·          distribution  local                                            ·             ·
+·          vectorized    true                                             ·             ·
+render     ·             ·                                                (r)           ·
+ │         render 0      (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)  ·             ·
+ └── scan  ·             ·                                                (a, b, c, d)  ·
+·          table         t@primary                                        ·             ·
+·          spans         FULL SCAN                                        ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, (b, 'a'), (c, 'b', 5)) = (9, (a+c, s), (5, s, a)) AS r FROM t
 ----
-·          distributed  false                                                                                  ·             ·
-·          vectorized   true                                                                                   ·             ·
-render     ·            ·                                                                                      (r)           ·
- │         render 0     (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)  ·             ·
- └── scan  ·            ·                                                                                      (a, b, c, s)  ·
-·          table        t@primary                                                                              ·             ·
-·          spans        FULL SCAN                                                                              ·             ·
+·          distribution  local                                                                                  ·             ·
+·          vectorized    true                                                                                   ·             ·
+render     ·             ·                                                                                      (r)           ·
+ │         render 0      (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)  ·             ·
+ └── scan  ·             ·                                                                                      (a, b, c, s)  ·
+·          table         t@primary                                                                              ·             ·
+·          spans         FULL SCAN                                                                              ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS NULL AS r FROM t
 ----
-·          distributed  false      ·    ·
-·          vectorized   true       ·    ·
-render     ·            ·          (r)  ·
- │         render 0     a IS NULL  ·    ·
- └── scan  ·            ·          (a)  ·
-·          table        t@primary  ·    ·
-·          spans        FULL SCAN  ·    ·
+·          distribution  local      ·    ·
+·          vectorized    true       ·    ·
+render     ·             ·          (r)  ·
+ │         render 0      a IS NULL  ·    ·
+ └── scan  ·             ·          (a)  ·
+·          table         t@primary  ·    ·
+·          spans         FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS NOT DISTINCT FROM NULL AS r FROM t
 ----
-·          distributed  false      ·    ·
-·          vectorized   true       ·    ·
-render     ·            ·          (r)  ·
- │         render 0     a IS NULL  ·    ·
- └── scan  ·            ·          (a)  ·
-·          table        t@primary  ·    ·
-·          spans        FULL SCAN  ·    ·
+·          distribution  local      ·    ·
+·          vectorized    true       ·    ·
+render     ·             ·          (r)  ·
+ │         render 0      a IS NULL  ·    ·
+ └── scan  ·             ·          (a)  ·
+·          table         t@primary  ·    ·
+·          spans         FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, b) IS NULL AS r FROM t
 ----
-·          distributed  false           ·       ·
-·          vectorized   true            ·       ·
-render     ·            ·               (r)     ·
- │         render 0     (a, b) IS NULL  ·       ·
- └── scan  ·            ·               (a, b)  ·
-·          table        t@primary       ·       ·
-·          spans        FULL SCAN       ·       ·
+·          distribution  local           ·       ·
+·          vectorized    true            ·       ·
+render     ·             ·               (r)     ·
+ │         render 0      (a, b) IS NULL  ·       ·
+ └── scan  ·             ·               (a, b)  ·
+·          table         t@primary       ·       ·
+·          spans         FULL SCAN       ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, b) IS NOT DISTINCT FROM NULL AS r FROM t
 ----
-·          distributed  false                             ·       ·
-·          vectorized   true                              ·       ·
-render     ·            ·                                 (r)     ·
- │         render 0     (a, b) IS NOT DISTINCT FROM NULL  ·       ·
- └── scan  ·            ·                                 (a, b)  ·
-·          table        t@primary                         ·       ·
-·          spans        FULL SCAN                         ·       ·
+·          distribution  local                             ·       ·
+·          vectorized    true                              ·       ·
+render     ·             ·                                 (r)     ·
+ │         render 0      (a, b) IS NOT DISTINCT FROM NULL  ·       ·
+ └── scan  ·             ·                                 (a, b)  ·
+·          table         t@primary                         ·       ·
+·          spans         FULL SCAN                         ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS NOT DISTINCT FROM b AS r FROM t
 ----
-·          distributed  false                     ·       ·
-·          vectorized   true                      ·       ·
-render     ·            ·                         (r)     ·
- │         render 0     a IS NOT DISTINCT FROM b  ·       ·
- └── scan  ·            ·                         (a, b)  ·
-·          table        t@primary                 ·       ·
-·          spans        FULL SCAN                 ·       ·
+·          distribution  local                     ·       ·
+·          vectorized    true                      ·       ·
+render     ·             ·                         (r)     ·
+ │         render 0      a IS NOT DISTINCT FROM b  ·       ·
+ └── scan  ·             ·                         (a, b)  ·
+·          table         t@primary                 ·       ·
+·          spans         FULL SCAN                 ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS NOT NULL AS r FROM t
 ----
-·          distributed  false          ·    ·
-·          vectorized   true           ·    ·
-render     ·            ·              (r)  ·
- │         render 0     a IS NOT NULL  ·    ·
- └── scan  ·            ·              (a)  ·
-·          table        t@primary      ·    ·
-·          spans        FULL SCAN      ·    ·
+·          distribution  local          ·    ·
+·          vectorized    true           ·    ·
+render     ·             ·              (r)  ·
+ │         render 0      a IS NOT NULL  ·    ·
+ └── scan  ·             ·              (a)  ·
+·          table         t@primary      ·    ·
+·          spans         FULL SCAN      ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS DISTINCT FROM NULL AS r FROM t
 ----
-·          distributed  false          ·    ·
-·          vectorized   true           ·    ·
-render     ·            ·              (r)  ·
- │         render 0     a IS NOT NULL  ·    ·
- └── scan  ·            ·              (a)  ·
-·          table        t@primary      ·    ·
-·          spans        FULL SCAN      ·    ·
+·          distribution  local          ·    ·
+·          vectorized    true           ·    ·
+render     ·             ·              (r)  ·
+ │         render 0      a IS NOT NULL  ·    ·
+ └── scan  ·             ·              (a)  ·
+·          table         t@primary      ·    ·
+·          spans         FULL SCAN      ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, b) IS NOT NULL AS r FROM t
 ----
-·          distributed  false               ·       ·
-·          vectorized   true                ·       ·
-render     ·            ·                   (r)     ·
- │         render 0     (a, b) IS NOT NULL  ·       ·
- └── scan  ·            ·                   (a, b)  ·
-·          table        t@primary           ·       ·
-·          spans        FULL SCAN           ·       ·
+·          distribution  local               ·       ·
+·          vectorized    true                ·       ·
+render     ·             ·                   (r)     ·
+ │         render 0      (a, b) IS NOT NULL  ·       ·
+ └── scan  ·             ·                   (a, b)  ·
+·          table         t@primary           ·       ·
+·          spans         FULL SCAN           ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT (a, b) IS DISTINCT FROM NULL AS r FROM t
 ----
-·          distributed  false                         ·       ·
-·          vectorized   true                          ·       ·
-render     ·            ·                             (r)     ·
- │         render 0     (a, b) IS DISTINCT FROM NULL  ·       ·
- └── scan  ·            ·                             (a, b)  ·
-·          table        t@primary                     ·       ·
-·          spans        FULL SCAN                     ·       ·
+·          distribution  local                         ·       ·
+·          vectorized    true                          ·       ·
+render     ·             ·                             (r)     ·
+ │         render 0      (a, b) IS DISTINCT FROM NULL  ·       ·
+ └── scan  ·             ·                             (a, b)  ·
+·          table         t@primary                     ·       ·
+·          spans         FULL SCAN                     ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a IS DISTINCT FROM b AS r FROM t
 ----
-·          distributed  false                 ·       ·
-·          vectorized   true                  ·       ·
-render     ·            ·                     (r)     ·
- │         render 0     a IS DISTINCT FROM b  ·       ·
- └── scan  ·            ·                     (a, b)  ·
-·          table        t@primary             ·       ·
-·          spans        FULL SCAN             ·       ·
+·          distribution  local                 ·       ·
+·          vectorized    true                  ·       ·
+render     ·             ·                     (r)     ·
+ │         render 0      a IS DISTINCT FROM b  ·       ·
+ └── scan  ·             ·                     (a, b)  ·
+·          table         t@primary             ·       ·
+·          spans         FULL SCAN             ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT +a + (-b) AS r FROM t
 ----
-·          distributed  false      ·       ·
-·          vectorized   true       ·       ·
-render     ·            ·          (r)     ·
- │         render 0     a + (-b)   ·       ·
- └── scan  ·            ·          (a, b)  ·
-·          table        t@primary  ·       ·
-·          spans        FULL SCAN  ·       ·
+·          distribution  local      ·       ·
+·          vectorized    true       ·       ·
+render     ·             ·          (r)     ·
+ │         render 0      a + (-b)   ·       ·
+ └── scan  ·             ·          (a, b)  ·
+·          table         t@primary  ·       ·
+·          spans         FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END AS r FROM t
 ----
-·          distributed  false                                          ·    ·
-·          vectorized   true                                           ·    ·
-render     ·            ·                                              (r)  ·
- │         render 0     CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END  ·    ·
- └── scan  ·            ·                                              (a)  ·
-·          table        t@primary                                      ·    ·
-·          spans        FULL SCAN                                      ·    ·
+·          distribution  local                                          ·    ·
+·          vectorized    true                                           ·    ·
+render     ·             ·                                              (r)  ·
+ │         render 0      CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END  ·    ·
+ └── scan  ·             ·                                              (a)  ·
+·          table         t@primary                                      ·    ·
+·          spans         FULL SCAN                                      ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE WHEN a = 2 THEN 1 ELSE 2 END AS r FROM t
 ----
-·          distributed  false                              ·    ·
-·          vectorized   true                               ·    ·
-render     ·            ·                                  (r)  ·
- │         render 0     CASE WHEN a = 2 THEN 1 ELSE 2 END  ·    ·
- └── scan  ·            ·                                  (a)  ·
-·          table        t@primary                          ·    ·
-·          spans        FULL SCAN                          ·    ·
+·          distribution  local                              ·    ·
+·          vectorized    true                               ·    ·
+render     ·             ·                                  (r)  ·
+ │         render 0      CASE WHEN a = 2 THEN 1 ELSE 2 END  ·    ·
+ └── scan  ·             ·                                  (a)  ·
+·          table         t@primary                          ·    ·
+·          spans         FULL SCAN                          ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE a + 3 WHEN 5 * b THEN 1 % b WHEN 6 THEN 2 ELSE -1 END AS r FROM t
 ----
-·          distributed  false                                                       ·       ·
-·          vectorized   true                                                        ·       ·
-render     ·            ·                                                           (r)     ·
- │         render 0     CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END  ·       ·
- └── scan  ·            ·                                                           (a, b)  ·
-·          table        t@primary                                                   ·       ·
-·          spans        FULL SCAN                                                   ·       ·
+·          distribution  local                                                       ·       ·
+·          vectorized    true                                                        ·       ·
+render     ·             ·                                                           (r)     ·
+ │         render 0      CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END  ·       ·
+ └── scan  ·             ·                                                           (a, b)  ·
+·          table         t@primary                                                   ·       ·
+·          spans         FULL SCAN                                                   ·       ·
 
 # Tests for CASE with no ELSE statement
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE WHEN a = 2 THEN 1 END AS r FROM t
 ----
-·          distributed  false                       ·    ·
-·          vectorized   true                        ·    ·
-render     ·            ·                           (r)  ·
- │         render 0     CASE WHEN a = 2 THEN 1 END  ·    ·
- └── scan  ·            ·                           (a)  ·
-·          table        t@primary                   ·    ·
-·          spans        FULL SCAN                   ·    ·
+·          distribution  local                       ·    ·
+·          vectorized    true                        ·    ·
+render     ·             ·                           (r)  ·
+ │         render 0      CASE WHEN a = 2 THEN 1 END  ·    ·
+ └── scan  ·             ·                           (a)  ·
+·          table         t@primary                   ·    ·
+·          spans         FULL SCAN                   ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE a WHEN 2 THEN 1 END AS r FROM t
 ----
-·          distributed  false                     ·    ·
-·          vectorized   true                      ·    ·
-render     ·            ·                         (r)  ·
- │         render 0     CASE a WHEN 2 THEN 1 END  ·    ·
- └── scan  ·            ·                         (a)  ·
-·          table        t@primary                 ·    ·
-·          spans        FULL SCAN                 ·    ·
+·          distribution  local                     ·    ·
+·          vectorized    true                      ·    ·
+render     ·             ·                         (r)  ·
+ │         render 0      CASE a WHEN 2 THEN 1 END  ·    ·
+ └── scan  ·             ·                         (a)  ·
+·          table         t@primary                 ·    ·
+·          spans         FULL SCAN                 ·    ·
 
 # TODO(radu): IS OF not supported yet.
 #query TTTTT
@@ -396,152 +396,152 @@ render     ·            ·                         (r)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT length(s) FROM t
 ----
-·          distributed  false      ·         ·
-·          vectorized   true       ·         ·
-render     ·            ·          (length)  ·
- │         render 0     length(s)  ·         ·
- └── scan  ·            ·          (s)       ·
-·          table        t@primary  ·         ·
-·          spans        FULL SCAN  ·         ·
+·          distribution  local      ·         ·
+·          vectorized    true       ·         ·
+render     ·             ·          (length)  ·
+ │         render 0      length(s)  ·         ·
+ └── scan  ·             ·          (s)       ·
+·          table         t@primary  ·         ·
+·          spans         FULL SCAN  ·         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j @> '{"a": 1}' AS r FROM t
 ----
-·          distributed  false            ·    ·
-·          vectorized   true             ·    ·
-render     ·            ·                (r)  ·
- │         render 0     j @> '{"a": 1}'  ·    ·
- └── scan  ·            ·                (j)  ·
-·          table        t@primary        ·    ·
-·          spans        FULL SCAN        ·    ·
+·          distribution  local            ·    ·
+·          vectorized    true             ·    ·
+render     ·             ·                (r)  ·
+ │         render 0      j @> '{"a": 1}'  ·    ·
+ └── scan  ·             ·                (j)  ·
+·          table         t@primary        ·    ·
+·          spans         FULL SCAN        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT '{"a": 1}' <@ j AS r FROM t
 ----
-·          distributed  false            ·    ·
-·          vectorized   true             ·    ·
-render     ·            ·                (r)  ·
- │         render 0     j @> '{"a": 1}'  ·    ·
- └── scan  ·            ·                (j)  ·
-·          table        t@primary        ·    ·
-·          spans        FULL SCAN        ·    ·
+·          distribution  local            ·    ·
+·          vectorized    true             ·    ·
+render     ·             ·                (r)  ·
+ │         render 0      j @> '{"a": 1}'  ·    ·
+ └── scan  ·             ·                (j)  ·
+·          table         t@primary        ·    ·
+·          spans         FULL SCAN        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j->>'a' AS r FROM t
 ----
-·          distributed  false      ·    ·
-·          vectorized   true       ·    ·
-render     ·            ·          (r)  ·
- │         render 0     j->>'a'    ·    ·
- └── scan  ·            ·          (j)  ·
-·          table        t@primary  ·    ·
-·          spans        FULL SCAN  ·    ·
+·          distribution  local      ·    ·
+·          vectorized    true       ·    ·
+render     ·             ·          (r)  ·
+ │         render 0      j->>'a'    ·    ·
+ └── scan  ·             ·          (j)  ·
+·          table         t@primary  ·    ·
+·          spans         FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j->'a' AS r FROM t
 ----
-·          distributed  false      ·    ·
-·          vectorized   true       ·    ·
-render     ·            ·          (r)  ·
- │         render 0     j->'a'     ·    ·
- └── scan  ·            ·          (j)  ·
-·          table        t@primary  ·    ·
-·          spans        FULL SCAN  ·    ·
+·          distribution  local      ·    ·
+·          vectorized    true       ·    ·
+render     ·             ·          (r)  ·
+ │         render 0      j->'a'     ·    ·
+ └── scan  ·             ·          (j)  ·
+·          table         t@primary  ·    ·
+·          spans         FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j ? 'a' AS r FROM t
 ----
-·          distributed  false      ·    ·
-·          vectorized   true       ·    ·
-render     ·            ·          (r)  ·
- │         render 0     j ? 'a'    ·    ·
- └── scan  ·            ·          (j)  ·
-·          table        t@primary  ·    ·
-·          spans        FULL SCAN  ·    ·
+·          distribution  local      ·    ·
+·          vectorized    true       ·    ·
+render     ·             ·          (r)  ·
+ │         render 0      j ? 'a'    ·    ·
+ └── scan  ·             ·          (j)  ·
+·          table         t@primary  ·    ·
+·          spans         FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j ?| ARRAY['a', 'b', 'c'] AS r FROM t
 ----
-·          distributed  false                    ·    ·
-·          vectorized   true                     ·    ·
-render     ·            ·                        (r)  ·
- │         render 0     j ?| ARRAY['a','b','c']  ·    ·
- └── scan  ·            ·                        (j)  ·
-·          table        t@primary                ·    ·
-·          spans        FULL SCAN                ·    ·
+·          distribution  local                    ·    ·
+·          vectorized    true                     ·    ·
+render     ·             ·                        (r)  ·
+ │         render 0      j ?| ARRAY['a','b','c']  ·    ·
+ └── scan  ·             ·                        (j)  ·
+·          table         t@primary                ·    ·
+·          spans         FULL SCAN                ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j ?& ARRAY['a', 'b', 'c'] AS r FROM t
 ----
-·          distributed  false                    ·    ·
-·          vectorized   true                     ·    ·
-render     ·            ·                        (r)  ·
- │         render 0     j ?& ARRAY['a','b','c']  ·    ·
- └── scan  ·            ·                        (j)  ·
-·          table        t@primary                ·    ·
-·          spans        FULL SCAN                ·    ·
+·          distribution  local                    ·    ·
+·          vectorized    true                     ·    ·
+render     ·             ·                        (r)  ·
+ │         render 0      j ?& ARRAY['a','b','c']  ·    ·
+ └── scan  ·             ·                        (j)  ·
+·          table         t@primary                ·    ·
+·          spans         FULL SCAN                ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j#>ARRAY['a'] AS r FROM t
 ----
-·          distributed  false          ·    ·
-·          vectorized   true           ·    ·
-render     ·            ·              (r)  ·
- │         render 0     j#>ARRAY['a']  ·    ·
- └── scan  ·            ·              (j)  ·
-·          table        t@primary      ·    ·
-·          spans        FULL SCAN      ·    ·
+·          distribution  local          ·    ·
+·          vectorized    true           ·    ·
+render     ·             ·              (r)  ·
+ │         render 0      j#>ARRAY['a']  ·    ·
+ └── scan  ·             ·              (j)  ·
+·          table         t@primary      ·    ·
+·          spans         FULL SCAN      ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j#>>ARRAY['a'] AS r FROM t
 ----
-·          distributed  false           ·    ·
-·          vectorized   true            ·    ·
-render     ·            ·               (r)  ·
- │         render 0     j#>>ARRAY['a']  ·    ·
- └── scan  ·            ·               (j)  ·
-·          table        t@primary       ·    ·
-·          spans        FULL SCAN       ·    ·
+·          distribution  local           ·    ·
+·          vectorized    true            ·    ·
+render     ·             ·               (r)  ·
+ │         render 0      j#>>ARRAY['a']  ·    ·
+ └── scan  ·             ·               (j)  ·
+·          table         t@primary       ·    ·
+·          spans         FULL SCAN       ·    ·
 
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CAST(a AS string), b::float FROM t
 ----
-·          distributed  false      ·       ·
-·          vectorized   true       ·       ·
-render     ·            ·          (a, b)  ·
- │         render 0     a::STRING  ·       ·
- │         render 1     b::FLOAT8  ·       ·
- └── scan  ·            ·          (a, b)  ·
-·          table        t@primary  ·       ·
-·          spans        FULL SCAN  ·       ·
+·          distribution  local      ·       ·
+·          vectorized    true       ·       ·
+render     ·             ·          (a, b)  ·
+ │         render 0      a::STRING  ·       ·
+ │         render 1      b::FLOAT8  ·       ·
+ └── scan  ·             ·          (a, b)  ·
+·          table         t@primary  ·       ·
+·          spans         FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CAST(a + b + c AS string) FROM t
 ----
-·          distributed  false                  ·          ·
-·          vectorized   true                   ·          ·
-render     ·            ·                      (text)     ·
- │         render 0     (c + (a + b))::STRING  ·          ·
- └── scan  ·            ·                      (a, b, c)  ·
-·          table        t@primary              ·          ·
-·          spans        FULL SCAN              ·          ·
+·          distribution  local                  ·          ·
+·          vectorized    true                   ·          ·
+render     ·             ·                      (text)     ·
+ │         render 0      (c + (a + b))::STRING  ·          ·
+ └── scan  ·             ·                      (a, b, c)  ·
+·          table         t@primary              ·          ·
+·          spans         FULL SCAN              ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT s::VARCHAR(2) FROM t
 ----
-·          distributed  false          ·    ·
-·          vectorized   true           ·    ·
-render     ·            ·              (s)  ·
- │         render 0     s::VARCHAR(2)  ·    ·
- └── scan  ·            ·              (s)  ·
-·          table        t@primary      ·    ·
-·          spans        FULL SCAN      ·    ·
+·          distribution  local          ·    ·
+·          vectorized    true           ·    ·
+render     ·             ·              (s)  ·
+ │         render 0      s::VARCHAR(2)  ·    ·
+ └── scan  ·             ·              (s)  ·
+·          table         t@primary      ·    ·
+·          spans         FULL SCAN      ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT COALESCE(a, b) FROM (VALUES (1, 2), (3, NULL), (NULL, 4), (NULL, NULL)) AS v(a, b)
 ----
-·            distributed    false                       ·                   ·
+·            distribution   local                       ·                   ·
 ·            vectorized     false                       ·                   ·
 render       ·              ·                           ("coalesce")        ·
  │           render 0       COALESCE(column1, column2)  ·                   ·
@@ -559,7 +559,7 @@ render       ·              ·                           ("coalesce")        ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT COALESCE(a, b, c) FROM (VALUES (1, 2, 3), (NULL, 4, 5), (NULL, NULL, 6), (NULL, NULL, NULL)) AS v(a, b, c)
 ----
-·            distributed    false                                ·                            ·
+·            distribution   local                                ·                            ·
 ·            vectorized     false                                ·                            ·
 render       ·              ·                                    ("coalesce")                 ·
  │           render 0       COALESCE(column1, column2, column3)  ·                            ·
@@ -581,139 +581,139 @@ render       ·              ·                                    ("coalesce") 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE a BETWEEN b AND d
 ----
-·          distributed  false                  ·          ·
-·          vectorized   true                   ·          ·
-render     ·            ·                      (a)        ·
- │         render 0     a                      ·          ·
- └── scan  ·            ·                      (a, b, d)  ·
-·          table        t@primary              ·          ·
-·          spans        FULL SCAN              ·          ·
-·          filter       (a >= b) AND (a <= d)  ·          ·
+·          distribution  local                  ·          ·
+·          vectorized    true                   ·          ·
+render     ·             ·                      (a)        ·
+ │         render 0      a                      ·          ·
+ └── scan  ·             ·                      (a, b, d)  ·
+·          table         t@primary              ·          ·
+·          spans         FULL SCAN              ·          ·
+·          filter        (a >= b) AND (a <= d)  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE a NOT BETWEEN b AND d
 ----
-·          distributed  false               ·          ·
-·          vectorized   true                ·          ·
-render     ·            ·                   (a)        ·
- │         render 0     a                   ·          ·
- └── scan  ·            ·                   (a, b, d)  ·
-·          table        t@primary           ·          ·
-·          spans        FULL SCAN           ·          ·
-·          filter       (a < b) OR (a > d)  ·          ·
+·          distribution  local               ·          ·
+·          vectorized    true                ·          ·
+render     ·             ·                   (a)        ·
+ │         render 0      a                   ·          ·
+ └── scan  ·             ·                   (a, b, d)  ·
+·          table         t@primary           ·          ·
+·          spans         FULL SCAN           ·          ·
+·          filter        (a < b) OR (a > d)  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a BETWEEN SYMMETRIC b AND d AS r FROM t
 ----
-·          distributed  false                                               ·          ·
-·          vectorized   true                                                ·          ·
-render     ·            ·                                                   (r)        ·
- │         render 0     ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))  ·          ·
- └── scan  ·            ·                                                   (a, b, d)  ·
-·          table        t@primary                                           ·          ·
-·          spans        FULL SCAN                                           ·          ·
+·          distribution  local                                               ·          ·
+·          vectorized    true                                                ·          ·
+render     ·             ·                                                   (r)        ·
+ │         render 0      ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))  ·          ·
+ └── scan  ·             ·                                                   (a, b, d)  ·
+·          table         t@primary                                           ·          ·
+·          spans         FULL SCAN                                           ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a NOT BETWEEN SYMMETRIC b AND d AS r FROM t
 ----
-·          distributed  false                                          ·          ·
-·          vectorized   true                                           ·          ·
-render     ·            ·                                              (r)        ·
- │         render 0     ((a < b) OR (a > d)) AND ((a < d) OR (a > b))  ·          ·
- └── scan  ·            ·                                              (a, b, d)  ·
-·          table        t@primary                                      ·          ·
-·          spans        FULL SCAN                                      ·          ·
+·          distribution  local                                          ·          ·
+·          vectorized    true                                           ·          ·
+render     ·             ·                                              (r)        ·
+ │         render 0      ((a < b) OR (a > d)) AND ((a < d) OR (a > b))  ·          ·
+ └── scan  ·             ·                                              (a, b, d)  ·
+·          table         t@primary                                      ·          ·
+·          spans         FULL SCAN                                      ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY[]:::int[] FROM t
 ----
-·          distributed  false      ·          ·
-·          vectorized   true       ·          ·
-render     ·            ·          ("array")  ·
- │         render 0     ARRAY[]    ·          ·
- └── scan  ·            ·          ()         ·
-·          table        t@primary  ·          ·
-·          spans        FULL SCAN  ·          ·
+·          distribution  local      ·          ·
+·          vectorized    true       ·          ·
+render     ·             ·          ("array")  ·
+ │         render 0      ARRAY[]    ·          ·
+ └── scan  ·             ·          ()         ·
+·          table         t@primary  ·          ·
+·          spans         FULL SCAN  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY[1, 2, 3] FROM t
 ----
-·          distributed  false         ·          ·
-·          vectorized   true          ·          ·
-render     ·            ·             ("array")  ·
- │         render 0     ARRAY[1,2,3]  ·          ·
- └── scan  ·            ·             ()         ·
-·          table        t@primary     ·          ·
-·          spans        FULL SCAN     ·          ·
+·          distribution  local         ·          ·
+·          vectorized    true          ·          ·
+render     ·             ·             ("array")  ·
+ │         render 0      ARRAY[1,2,3]  ·          ·
+ └── scan  ·             ·             ()         ·
+·          table         t@primary     ·          ·
+·          spans         FULL SCAN     ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY[a + 1, 2, 3] FROM t
 ----
-·          distributed  false               ·          ·
-·          vectorized   true                ·          ·
-render     ·            ·                   ("array")  ·
- │         render 0     ARRAY[a + 1, 2, 3]  ·          ·
- └── scan  ·            ·                   (a)        ·
-·          table        t@primary           ·          ·
-·          spans        FULL SCAN           ·          ·
+·          distribution  local               ·          ·
+·          vectorized    true                ·          ·
+render     ·             ·                   ("array")  ·
+ │         render 0      ARRAY[a + 1, 2, 3]  ·          ·
+ └── scan  ·             ·                   (a)        ·
+·          table         t@primary           ·          ·
+·          spans         FULL SCAN           ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 > ANY ARRAY[a + 1, 2, 3] FROM t
 ----
-·          distributed  false                       ·             ·
-·          vectorized   true                        ·             ·
-render     ·            ·                           ("?column?")  ·
- │         render 0     1 > ANY ARRAY[a + 1, 2, 3]  ·             ·
- └── scan  ·            ·                           (a)           ·
-·          table        t@primary                   ·             ·
-·          spans        FULL SCAN                   ·             ·
+·          distribution  local                       ·             ·
+·          vectorized    true                        ·             ·
+render     ·             ·                           ("?column?")  ·
+ │         render 0      1 > ANY ARRAY[a + 1, 2, 3]  ·             ·
+ └── scan  ·             ·                           (a)           ·
+·          table         t@primary                   ·             ·
+·          spans         FULL SCAN                   ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 = ANY (1, 2, 3) FROM t
 ----
-·          distributed  false      ·             ·
-·          vectorized   true       ·             ·
-render     ·            ·          ("?column?")  ·
- │         render 0     true       ·             ·
- └── scan  ·            ·          ()            ·
-·          table        t@primary  ·             ·
-·          spans        FULL SCAN  ·             ·
+·          distribution  local      ·             ·
+·          vectorized    true       ·             ·
+render     ·             ·          ("?column?")  ·
+ │         render 0      true       ·             ·
+ └── scan  ·             ·          ()            ·
+·          table         t@primary  ·             ·
+·          spans         FULL SCAN  ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 = ANY () FROM t
 ----
-·          distributed  false      ·             ·
-·          vectorized   true       ·             ·
-render     ·            ·          ("?column?")  ·
- │         render 0     false      ·             ·
- └── scan  ·            ·          ()            ·
-·          table        t@primary  ·             ·
-·          spans        FULL SCAN  ·             ·
+·          distribution  local      ·             ·
+·          vectorized    true       ·             ·
+render     ·             ·          ("?column?")  ·
+ │         render 0      false      ·             ·
+ └── scan  ·             ·          ()            ·
+·          table         t@primary  ·             ·
+·          spans         FULL SCAN  ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT least(NULL, greatest(NULL, least(1, NULL), 2, 3), greatest(5, 6), a) FROM t
 ----
-·          distributed  false                 ·          ·
-·          vectorized   true                  ·          ·
-render     ·            ·                     ("least")  ·
- │         render 0     least(NULL, 3, 6, a)  ·          ·
- └── scan  ·            ·                     (a)        ·
-·          table        t@primary             ·          ·
-·          spans        FULL SCAN             ·          ·
+·          distribution  local                 ·          ·
+·          vectorized    true                  ·          ·
+render     ·             ·                     ("least")  ·
+ │         render 0      least(NULL, 3, 6, a)  ·          ·
+ └── scan  ·             ·                     (a)        ·
+·          table         t@primary             ·          ·
+·          spans         FULL SCAN             ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pg_attribute WHERE attrelid='t'::regclass
 ----
-·              distributed  false                                   ·                                                                                                                                                                                                                                              ·
-·              vectorized   false                                   ·                                                                                                                                                                                                                                              ·
-virtual table  ·            ·                                       (attrelid, attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions)  ·
-·              source       pg_attribute@pg_attribute_attrelid_idx  ·                                                                                                                                                                                                                                              ·
-·              constraint   /2: [/t - /t]                           ·                                                                                                                                                                                                                                              ·
+·              distribution  local                                   ·                                                                                                                                                                                                                                              ·
+·              vectorized    false                                   ·                                                                                                                                                                                                                                              ·
+virtual table  ·             ·                                       (attrelid, attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions)  ·
+·              source        pg_attribute@pg_attribute_attrelid_idx  ·                                                                                                                                                                                                                                              ·
+·              constraint    /2: [/t - /t]                           ·                                                                                                                                                                                                                                              ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE WHEN current_database() = 'test' THEN 42 ELSE 1/3 END
 ----
-·       distributed    false            ·         ·
+·       distribution   local            ·         ·
 ·       vectorized     false            ·         ·
 values  ·              ·                ("case")  ·
 ·       size           1 column, 1 row  ·         ·
@@ -723,7 +723,7 @@ values  ·              ·                ("case")  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT CASE WHEN current_database() = 'test' THEN 42 ELSE 1/0 END
 ----
-·       distributed    false                                  ·         ·
+·       distribution   local                                  ·         ·
 ·       vectorized     false                                  ·         ·
 values  ·              ·                                      ("case")  ·
 ·       size           1 column, 1 row                        ·         ·
@@ -733,7 +733,7 @@ values  ·              ·                                      ("case")  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT random(), current_database(), now()
 ----
-·       distributed    false             ·                                ·
+·       distribution   local             ·                                ·
 ·       vectorized     false             ·                                ·
 values  ·              ·                 (random, current_database, now)  ·
 ·       size           3 columns, 1 row  ·                                ·
@@ -746,19 +746,19 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT 1::FLOAT + length(upper(concat('a', 'b', 'c')))::FLOAT AS r1,
                          1::FLOAT + length(upper(concat('a', 'b', s)))::FLOAT AS r2 FROM t
 ----
-·          distributed  false                                             ·         ·
-·          vectorized   true                                              ·         ·
-render     ·            ·                                                 (r1, r2)  ·
- │         render 0     4.0                                               ·         ·
- │         render 1     length(upper(concat('a', 'b', s)))::FLOAT8 + 1.0  ·         ·
- └── scan  ·            ·                                                 (s)       ·
-·          table        t@primary                                         ·         ·
-·          spans        FULL SCAN                                         ·         ·
+·          distribution  local                                             ·         ·
+·          vectorized    true                                              ·         ·
+render     ·             ·                                                 (r1, r2)  ·
+ │         render 0      4.0                                               ·         ·
+ │         render 1      length(upper(concat('a', 'b', s)))::FLOAT8 + 1.0  ·         ·
+ └── scan  ·             ·                                                 (s)       ·
+·          table         t@primary                                         ·         ·
+·          spans         FULL SCAN                                         ·         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY(SELECT generate_series(1,10) ORDER BY 1 DESC)
 ----
-·                             distributed    false                                            ·                  ·
+·                             distribution   local                                            ·                  ·
 ·                             vectorized     false                                            ·                  ·
 root                          ·              ·                                                ("array")          ·
  ├── values                   ·              ·                                                ("array")          ·
@@ -777,7 +777,7 @@ root                          ·              ·                                
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY(SELECT a FROM t ORDER BY b)
 ----
-·                         distributed    false                         ·          ·
+·                         distribution   local                         ·          ·
 ·                         vectorized     false                         ·          ·
 root                      ·              ·                             ("array")  ·
  ├── values               ·              ·                             ("array")  ·
@@ -802,8 +802,8 @@ CREATE TABLE t0(c0 DECIMAL UNIQUE); INSERT INTO t0(c0) VALUES(0);
 query TTTTT
 EXPLAIN (VERBOSE) SELECT t0.c0 FROM t0 WHERE t0.c0 BETWEEN t0.c0 AND INTERVAL '-1'::DECIMAL
 ----
-·     distributed  false                 ·     ·
-·     vectorized   true                  ·     ·
-scan  ·            ·                     (c0)  ·
-·     table        t0@t0_c0_key          ·     ·
-·     spans        /!NULL-/-1/PrefixEnd  ·     ·
+·     distribution  local                 ·     ·
+·     vectorized    true                  ·     ·
+scan  ·             ·                     (c0)  ·
+·     table         t0@t0_c0_key          ·     ·
+·     spans         /!NULL-/-1/PrefixEnd  ·     ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
+++ b/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
@@ -258,11 +258,11 @@ Scan /Table/55/2/2.01/3.001/{0-1}, /Table/55/2/2.01/3.001/2/{1-2}
 query TTT
 EXPLAIN SELECT y, z, v FROM t@i WHERE y = 2.01 AND z = 3.001
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        t@i
-·     spans        /2.01/3.001/0-/2.01/3.001/1 /2.01/3.001/2/1-/2.01/3.001/2/2
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         t@i
+·     spans         /2.01/3.001/0-/2.01/3.001/1 /2.01/3.001/2/1-/2.01/3.001/2/2
 
 # Ensure that we always have a k/v in family 0.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -64,185 +64,185 @@ ALTER TABLE num_ref DROP COLUMN xx
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53 AS num_ref_alias]
 ----
-·     distributed  false            ·          ·
-·     vectorized   true             ·          ·
-scan  ·            ·                (p, d, c)  ·
-·     table        num_ref@primary  ·          ·
-·     spans        FULL SCAN        ·          ·
+·     distribution  local            ·          ·
+·     vectorized    true             ·          ·
+scan  ·             ·                (p, d, c)  ·
+·     table         num_ref@primary  ·          ·
+·     spans         FULL SCAN        ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]
 ----
-·     distributed  false            ·    ·
-·     vectorized   true             ·    ·
-scan  ·            ·                (c)  ·
-·     table        num_ref@primary  ·    ·
-·     spans        FULL SCAN        ·    ·
+·     distribution  local            ·    ·
+·     vectorized    true             ·    ·
+scan  ·             ·                (c)  ·
+·     table         num_ref@primary  ·    ·
+·     spans         FULL SCAN        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(1,4) AS num_ref_alias]
 ----
-·     distributed  false            ·       ·
-·     vectorized   true             ·       ·
-scan  ·            ·                (p, c)  ·
-·     table        num_ref@primary  ·       ·
-·     spans        FULL SCAN        ·       ·
+·     distribution  local            ·       ·
+·     vectorized    true             ·       ·
+scan  ·             ·                (p, c)  ·
+·     table         num_ref@primary  ·       ·
+·     spans         FULL SCAN        ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(1,3,4) AS num_ref_alias]
 ----
-·     distributed  false            ·          ·
-·     vectorized   true             ·          ·
-scan  ·            ·                (p, d, c)  ·
-·     table        num_ref@primary  ·          ·
-·     spans        FULL SCAN        ·          ·
+·     distribution  local            ·          ·
+·     vectorized    true             ·          ·
+scan  ·             ·                (p, d, c)  ·
+·     table         num_ref@primary  ·          ·
+·     spans         FULL SCAN        ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4,3,1) AS num_ref_alias]
 ----
-·          distributed  false            ·          ·
-·          vectorized   true             ·          ·
-render     ·            ·                (c, d, p)  ·
- │         render 0     c                ·          ·
- │         render 1     d                ·          ·
- │         render 2     p                ·          ·
- └── scan  ·            ·                (p, d, c)  ·
-·          table        num_ref@primary  ·          ·
-·          spans        FULL SCAN        ·          ·
+·          distribution  local            ·          ·
+·          vectorized    true             ·          ·
+render     ·             ·                (c, d, p)  ·
+ │         render 0      c                ·          ·
+ │         render 1      d                ·          ·
+ │         render 2      p                ·          ·
+ └── scan  ·             ·                (p, d, c)  ·
+·          table         num_ref@primary  ·          ·
+·          spans         FULL SCAN        ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4,3,1) AS num_ref_alias(col1,col2,col3)]
 ----
-·          distributed  false            ·                   ·
-·          vectorized   true             ·                   ·
-render     ·            ·                (col1, col2, col3)  ·
- │         render 0     c                ·                   ·
- │         render 1     d                ·                   ·
- │         render 2     p                ·                   ·
- └── scan  ·            ·                (p, d, c)           ·
-·          table        num_ref@primary  ·                   ·
-·          spans        FULL SCAN        ·                   ·
+·          distribution  local            ·                   ·
+·          vectorized    true             ·                   ·
+render     ·             ·                (col1, col2, col3)  ·
+ │         render 0      c                ·                   ·
+ │         render 1      d                ·                   ·
+ │         render 2      p                ·                   ·
+ └── scan  ·             ·                (p, d, c)           ·
+·          table         num_ref@primary  ·                   ·
+·          spans         FULL SCAN        ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4,3,1) AS num_ref_alias]@bc
 ----
-·          distributed  false       ·          ·
-·          vectorized   true        ·          ·
-render     ·            ·           (c, d, p)  ·
- │         render 0     c           ·          ·
- │         render 1     d           ·          ·
- │         render 2     p           ·          ·
- └── scan  ·            ·           (p, d, c)  ·
-·          table        num_ref@bc  ·          ·
-·          spans        FULL SCAN   ·          ·
+·          distribution  local       ·          ·
+·          vectorized    true        ·          ·
+render     ·             ·           (c, d, p)  ·
+ │         render 0      c           ·          ·
+ │         render 1      d           ·          ·
+ │         render 2      p           ·          ·
+ └── scan  ·             ·           (p, d, c)  ·
+·          table         num_ref@bc  ·          ·
+·          spans         FULL SCAN   ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@bc
 ----
-·     distributed  false       ·    ·
-·     vectorized   true        ·    ·
-scan  ·            ·           (c)  ·
-·     table        num_ref@bc  ·    ·
-·     spans        FULL SCAN   ·    ·
+·     distribution  local       ·    ·
+·     vectorized    true        ·    ·
+scan  ·             ·           (c)  ·
+·     table         num_ref@bc  ·    ·
+·     spans         FULL SCAN   ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@bc
 ----
-·     distributed  false       ·    ·
-·     vectorized   true        ·    ·
-scan  ·            ·           (d)  ·
-·     table        num_ref@bc  ·    ·
-·     spans        FULL SCAN   ·    ·
+·     distribution  local       ·    ·
+·     vectorized    true        ·    ·
+scan  ·             ·           (d)  ·
+·     table         num_ref@bc  ·    ·
+·     spans         FULL SCAN   ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@bc
 ----
-·     distributed  false       ·    ·
-·     vectorized   true        ·    ·
-scan  ·            ·           (p)  ·
-·     table        num_ref@bc  ·    ·
-·     spans        FULL SCAN   ·    ·
+·     distribution  local       ·    ·
+·     vectorized    true        ·    ·
+scan  ·             ·           (p)  ·
+·     table         num_ref@bc  ·    ·
+·     spans         FULL SCAN   ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@[1]
 ----
-·     distributed  false            ·    ·
-·     vectorized   true             ·    ·
-scan  ·            ·                (p)  ·
-·     table        num_ref@primary  ·    ·
-·     spans        FULL SCAN        ·    ·
+·     distribution  local            ·    ·
+·     vectorized    true             ·    ·
+scan  ·             ·                (p)  ·
+·     table         num_ref@primary  ·    ·
+·     spans         FULL SCAN        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(1) AS num_ref_alias]@[2]
 ----
-·     distributed  false       ·    ·
-·     vectorized   true        ·    ·
-scan  ·            ·           (p)  ·
-·     table        num_ref@bc  ·    ·
-·     spans        FULL SCAN   ·    ·
+·     distribution  local       ·    ·
+·     vectorized    true        ·    ·
+scan  ·             ·           (p)  ·
+·     table         num_ref@bc  ·    ·
+·     spans         FULL SCAN   ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@[1]
 ----
-·     distributed  false            ·    ·
-·     vectorized   true             ·    ·
-scan  ·            ·                (d)  ·
-·     table        num_ref@primary  ·    ·
-·     spans        FULL SCAN        ·    ·
+·     distribution  local            ·    ·
+·     vectorized    true             ·    ·
+scan  ·             ·                (d)  ·
+·     table         num_ref@primary  ·    ·
+·     spans         FULL SCAN        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(3) AS num_ref_alias]@[2]
 ----
-·     distributed  false       ·    ·
-·     vectorized   true        ·    ·
-scan  ·            ·           (d)  ·
-·     table        num_ref@bc  ·    ·
-·     spans        FULL SCAN   ·    ·
+·     distribution  local       ·    ·
+·     vectorized    true        ·    ·
+scan  ·             ·           (d)  ·
+·     table         num_ref@bc  ·    ·
+·     spans         FULL SCAN   ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@[1]
 ----
-·     distributed  false            ·    ·
-·     vectorized   true             ·    ·
-scan  ·            ·                (c)  ·
-·     table        num_ref@primary  ·    ·
-·     spans        FULL SCAN        ·    ·
+·     distribution  local            ·    ·
+·     vectorized    true             ·    ·
+scan  ·             ·                (c)  ·
+·     table         num_ref@primary  ·    ·
+·     spans         FULL SCAN        ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [53(4) AS num_ref_alias]@[2]
 ----
-·     distributed  false       ·    ·
-·     vectorized   true        ·    ·
-scan  ·            ·           (c)  ·
-·     table        num_ref@bc  ·    ·
-·     spans        FULL SCAN   ·    ·
+·     distribution  local       ·    ·
+·     vectorized    true        ·    ·
+scan  ·             ·           (c)  ·
+·     table         num_ref@bc  ·    ·
+·     spans         FULL SCAN   ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [54(1,3) AS num_ref_alias]
 ----
-·     distributed  false                   ·    ·
-·     vectorized   true                    ·    ·
-scan  ·            ·                       (a)  ·
-·     table        num_ref_hidden@primary  ·    ·
-·     spans        FULL SCAN               ·    ·
+·     distribution  local                   ·    ·
+·     vectorized    true                    ·    ·
+scan  ·             ·                       (a)  ·
+·     table         num_ref_hidden@primary  ·    ·
+·     spans         FULL SCAN               ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [54(3) AS num_ref_alias]
 ----
-·     distributed  false                   ·   ·
-·     vectorized   true                    ·   ·
-scan  ·            ·                       ()  ·
-·     table        num_ref_hidden@primary  ·   ·
-·     spans        FULL SCAN               ·   ·
+·     distribution  local                   ·   ·
+·     vectorized    true                    ·   ·
+scan  ·             ·                       ()  ·
+·     table         num_ref_hidden@primary  ·   ·
+·     spans         FULL SCAN               ·   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT rowid FROM [54(3) AS num_ref_alias]
 ----
-·     distributed  false                   ·                ·
-·     vectorized   true                    ·                ·
-scan  ·            ·                       (rowid[hidden])  ·
-·     table        num_ref_hidden@primary  ·                ·
-·     spans        FULL SCAN               ·                ·
+·     distribution  local                   ·                ·
+·     vectorized    true                    ·                ·
+scan  ·             ·                       (rowid[hidden])  ·
+·     table         num_ref_hidden@primary  ·                ·
+·     spans         FULL SCAN               ·                ·
 
 query error pq: \[666\(1\) AS num_ref_alias\]: relation \"\[666\]\" does not exist
 EXPLAIN (VERBOSE) SELECT * FROM [666(1) AS num_ref_alias]
@@ -274,107 +274,107 @@ CREATE TABLE a (x INT PRIMARY KEY, y INT, FAMILY (x, y));
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE x > 1
 ----
-·     distributed  false      ·       ·
-·     vectorized   true       ·       ·
-scan  ·            ·          (x, y)  ·
-·     table        a@primary  ·       ·
-·     spans        /2-        ·       ·
+·     distribution  local      ·       ·
+·     vectorized    true       ·       ·
+scan  ·             ·          (x, y)  ·
+·     table         a@primary  ·       ·
+·     spans         /2-        ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE y > 10
 ----
-·     distributed  false      ·       ·
-·     vectorized   true       ·       ·
-scan  ·            ·          (x, y)  ·
-·     table        a@primary  ·       ·
-·     spans        FULL SCAN  ·       ·
-·     filter       y > 10     ·       ·
+·     distribution  local      ·       ·
+·     vectorized    true       ·       ·
+scan  ·             ·          (x, y)  ·
+·     table         a@primary  ·       ·
+·     spans         FULL SCAN  ·       ·
+·     filter        y > 10     ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE x > 1 AND x < 3
 ----
-·     distributed  false      ·       ·
-·     vectorized   true       ·       ·
-scan  ·            ·          (x, y)  ·
-·     table        a@primary  ·       ·
-·     spans        /2-/2/#    ·       ·
+·     distribution  local      ·       ·
+·     vectorized    true       ·       ·
+scan  ·             ·          (x, y)  ·
+·     table         a@primary  ·       ·
+·     spans         /2-/2/#    ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE x > 1 AND y < 30
 ----
-·     distributed  false      ·       ·
-·     vectorized   true       ·       ·
-scan  ·            ·          (x, y)  ·
-·     table        a@primary  ·       ·
-·     spans        /2-        ·       ·
-·     filter       y < 30     ·       ·
+·     distribution  local      ·       ·
+·     vectorized    true       ·       ·
+scan  ·             ·          (x, y)  ·
+·     table         a@primary  ·       ·
+·     spans         /2-        ·       ·
+·     filter        y < 30     ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x + 1 AS r FROM a
 ----
-·          distributed  false      ·    ·
-·          vectorized   true       ·    ·
-render     ·            ·          (r)  ·
- │         render 0     x + 1      ·    ·
- └── scan  ·            ·          (x)  ·
-·          table        a@primary  ·    ·
-·          spans        FULL SCAN  ·    ·
+·          distribution  local      ·    ·
+·          vectorized    true       ·    ·
+render     ·             ·          (r)  ·
+ │         render 0      x + 1      ·    ·
+ └── scan  ·             ·          (x)  ·
+·          table         a@primary  ·    ·
+·          spans         FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x AS a, x + 1 AS b, y, y + 1 AS c, x + y AS d FROM a
 ----
-·          distributed  false      ·                ·
-·          vectorized   true       ·                ·
-render     ·            ·          (a, b, y, c, d)  ·
- │         render 0     x          ·                ·
- │         render 1     x + 1      ·                ·
- │         render 2     y          ·                ·
- │         render 3     y + 1      ·                ·
- │         render 4     x + y      ·                ·
- └── scan  ·            ·          (x, y)           ·
-·          table        a@primary  ·                ·
-·          spans        FULL SCAN  ·                ·
+·          distribution  local      ·                ·
+·          vectorized    true       ·                ·
+render     ·             ·          (a, b, y, c, d)  ·
+ │         render 0      x          ·                ·
+ │         render 1      x + 1      ·                ·
+ │         render 2      y          ·                ·
+ │         render 3      y + 1      ·                ·
+ │         render 4      x + y      ·                ·
+ └── scan  ·             ·          (x, y)           ·
+·          table         a@primary  ·                ·
+·          spans         FULL SCAN  ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT u * v + v AS r FROM (SELECT x + 3, y + 10 FROM a) AS foo(u, v)
 ----
-·               distributed  false                                   ·                         ·
-·               vectorized   true                                    ·                         ·
-render          ·            ·                                       (r)                       ·
- │              render 0     "?column?" + ("?column?" * "?column?")  ·                         ·
- └── render     ·            ·                                       ("?column?", "?column?")  ·
-      │         render 0     x + 3                                   ·                         ·
-      │         render 1     y + 10                                  ·                         ·
-      └── scan  ·            ·                                       (x, y)                    ·
-·               table        a@primary                               ·                         ·
-·               spans        FULL SCAN                               ·                         ·
+·               distribution  local                                   ·                         ·
+·               vectorized    true                                    ·                         ·
+render          ·             ·                                       (r)                       ·
+ │              render 0      "?column?" + ("?column?" * "?column?")  ·                         ·
+ └── render     ·             ·                                       ("?column?", "?column?")  ·
+      │         render 0      x + 3                                   ·                         ·
+      │         render 1      y + 10                                  ·                         ·
+      └── scan  ·             ·                                       (x, y)                    ·
+·               table         a@primary                               ·                         ·
+·               spans         FULL SCAN                               ·                         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x, x, y, x FROM a
 ----
-·          distributed  false      ·             ·
-·          vectorized   true       ·             ·
-render     ·            ·          (x, x, y, x)  ·
- │         render 0     x          ·             ·
- │         render 1     x          ·             ·
- │         render 2     y          ·             ·
- │         render 3     x          ·             ·
- └── scan  ·            ·          (x, y)        ·
-·          table        a@primary  ·             ·
-·          spans        FULL SCAN  ·             ·
+·          distribution  local      ·             ·
+·          vectorized    true       ·             ·
+render     ·             ·          (x, x, y, x)  ·
+ │         render 0      x          ·             ·
+ │         render 1      x          ·             ·
+ │         render 2      y          ·             ·
+ │         render 3      x          ·             ·
+ └── scan  ·             ·          (x, y)        ·
+·          table         a@primary  ·             ·
+·          spans         FULL SCAN  ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x + 1 AS a, x + y AS b FROM a WHERE x + y > 20
 ----
-·          distributed  false         ·       ·
-·          vectorized   true          ·       ·
-render     ·            ·             (a, b)  ·
- │         render 0     x + 1         ·       ·
- │         render 1     x + y         ·       ·
- └── scan  ·            ·             (x, y)  ·
-·          table        a@primary     ·       ·
-·          spans        FULL SCAN     ·       ·
-·          filter       (x + y) > 20  ·       ·
+·          distribution  local         ·       ·
+·          vectorized    true          ·       ·
+render     ·             ·             (a, b)  ·
+ │         render 0      x + 1         ·       ·
+ │         render 1      x + y         ·       ·
+ └── scan  ·             ·             (x, y)  ·
+·          table         a@primary     ·       ·
+·          spans         FULL SCAN     ·       ·
+·          filter        (x + y) > 20  ·       ·
 
 statement ok
 DROP TABLE a
@@ -388,20 +388,20 @@ CREATE TABLE b (x INT, y INT);
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM b
 ----
-·     distributed  false      ·       ·
-·     vectorized   true       ·       ·
-scan  ·            ·          (x, y)  ·
-·     table        b@primary  ·       ·
-·     spans        FULL SCAN  ·       ·
+·     distribution  local      ·       ·
+·     vectorized    true       ·       ·
+scan  ·             ·          (x, y)  ·
+·     table         b@primary  ·       ·
+·     spans         FULL SCAN  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x, y, rowid FROM b WHERE rowid > 0
 ----
-·     distributed  false      ·                      ·
-·     vectorized   true       ·                      ·
-scan  ·            ·          (x, y, rowid[hidden])  ·
-·     table        b@primary  ·                      ·
-·     spans        /1-        ·                      ·
+·     distribution  local      ·                      ·
+·     vectorized    true       ·                      ·
+scan  ·             ·          (x, y, rowid[hidden])  ·
+·     table         b@primary  ·                      ·
+·     spans         /1-        ·                      ·
 
 statement ok
 DROP TABLE b
@@ -522,11 +522,11 @@ CREATE INDEX i14601 ON t14601 (a) STORING (b)
 query TTT
 EXPLAIN SELECT a FROM t14601 ORDER BY a
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        t14601@i14601
-·     spans        FULL SCAN
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         t14601@i14601
+·     spans         FULL SCAN
 
 # Updates were broken too.
 
@@ -546,11 +546,11 @@ CREATE INDEX i14601a ON t14601a (a) STORING (b, c)
 query TTT
 EXPLAIN SELECT a, b FROM t14601a ORDER BY a
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        t14601a@i14601a
-·     spans        FULL SCAN
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         t14601a@i14601a
+·     spans         FULL SCAN
 
 statement ok
 DROP index i14601a
@@ -561,11 +561,11 @@ CREATE UNIQUE INDEX i14601a ON t14601a (a) STORING (b)
 query TTT
 EXPLAIN SELECT a, b FROM t14601a ORDER BY a
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        t14601a@i14601a
-·     spans        FULL SCAN
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         t14601a@i14601a
+·     spans         FULL SCAN
 
 statement ok
 DROP TABLE t; DROP TABLE t14601; DROP TABLE t14601a
@@ -579,11 +579,11 @@ CREATE TABLE c (n INT PRIMARY KEY, str STRING, INDEX str(str DESC));
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM c WHERE str >= 'moo'
 ----
-·     distributed  false              ·         ·
-·     vectorized   true               ·         ·
-scan  ·            ·                  (n, str)  ·
-·     table        c@str              ·         ·
-·     spans        -/"moo"/PrefixEnd  ·         ·
+·     distribution  local              ·         ·
+·     vectorized    true               ·         ·
+scan  ·             ·                  (n, str)  ·
+·     table         c@str              ·         ·
+·     spans         -/"moo"/PrefixEnd  ·         ·
 
 statement ok
 DROP TABLE c
@@ -597,13 +597,13 @@ CREATE TABLE nocols(x INT); ALTER TABLE nocols DROP COLUMN x
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 AS a, * FROM nocols
 ----
-·          distributed  false           ·    ·
-·          vectorized   true            ·    ·
-render     ·            ·               (a)  ·
- │         render 0     1               ·    ·
- └── scan  ·            ·               ()   ·
-·          table        nocols@primary  ·    ·
-·          spans        FULL SCAN       ·    ·
+·          distribution  local           ·    ·
+·          vectorized    true            ·    ·
+render     ·             ·               (a)  ·
+ │         render 0      1               ·    ·
+ └── scan  ·             ·               ()   ·
+·          table         nocols@primary  ·    ·
+·          spans         FULL SCAN       ·    ·
 
 statement ok
 DROP TABLE nocols
@@ -623,23 +623,23 @@ CREATE TABLE coll (
 query TTTTT
 EXPLAIN (TYPES) SELECT a, b FROM coll ORDER BY a, b
 ----
-·     distributed  false         ·                              ·
-·     vectorized   true          ·                              ·
-scan  ·            ·             (a collatedstring{da}, b int)  +a,+b
-·     table        coll@primary  ·                              ·
-·     spans        FULL SCAN     ·                              ·
+·     distribution  local         ·                              ·
+·     vectorized    true          ·                              ·
+scan  ·             ·             (a collatedstring{da}, b int)  +a,+b
+·     table         coll@primary  ·                              ·
+·     spans         FULL SCAN     ·                              ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT b, a FROM coll ORDER BY b, a
 ----
-·          distributed  false                    ·                              ·
-·          vectorized   true                     ·                              ·
-render     ·            ·                        (b int, a collatedstring{da})  ·
- │         render 0     (b)[int]                 ·                              ·
- │         render 1     (a)[collatedstring{da}]  ·                              ·
- └── scan  ·            ·                        (a collatedstring{da}, b int)  +b,+a
-·          table        coll@coll_b_a_idx        ·                              ·
-·          spans        FULL SCAN                ·                              ·
+·          distribution  local                    ·                              ·
+·          vectorized    true                     ·                              ·
+render     ·             ·                        (b int, a collatedstring{da})  ·
+ │         render 0      (b)[int]                 ·                              ·
+ │         render 1      (a)[collatedstring{da}]  ·                              ·
+ └── scan  ·             ·                        (a collatedstring{da}, b int)  +b,+a
+·          table         coll@coll_b_a_idx        ·                              ·
+·          spans         FULL SCAN                ·                              ·
 
 statement ok
 DROP TABLE coll
@@ -658,11 +658,11 @@ CREATE TABLE computed (
 query TTTTT
 EXPLAIN (TYPES) SELECT b FROM computed ORDER BY b
 ----
-·     distributed  false                    ·           ·
-·     vectorized   true                     ·           ·
-scan  ·            ·                        (b string)  +b
-·     table        computed@computed_b_idx  ·           ·
-·     spans        FULL SCAN                ·           ·
+·     distribution  local                    ·           ·
+·     vectorized    true                     ·           ·
+scan  ·             ·                        (b string)  +b
+·     table         computed@computed_b_idx  ·           ·
+·     spans         FULL SCAN                ·           ·
 
 statement ok
 DROP TABLE computed
@@ -738,30 +738,30 @@ CREATE TABLE dec (d decimal, v decimal(3, 1), primary key (d, v))
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM dec WHERE d IS NaN and v IS NaN
 ----
-·     distributed  false                ·                       ·
-·     vectorized   true                 ·                       ·
-scan  ·            ·                    (d decimal, v decimal)  ·
-·     table        dec@primary          ·                       ·
-·     spans        /NaN/NaN-/NaN/NaN/#  ·                       ·
+·     distribution  local                ·                       ·
+·     vectorized    true                 ·                       ·
+scan  ·             ·                    (d decimal, v decimal)  ·
+·     table         dec@primary          ·                       ·
+·     spans         /NaN/NaN-/NaN/NaN/#  ·                       ·
 
 # The NaN suffix is decimalNaNDesc, not decimalNaN(Asc).
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM dec WHERE d = 'Infinity' and v = 'Infinity'
 ----
-·     distributed  false                                    ·                       ·
-·     vectorized   true                                     ·                       ·
-scan  ·            ·                                        (d decimal, v decimal)  ·
-·     table        dec@primary                              ·                       ·
-·     spans        /Infinity/Infinity-/Infinity/Infinity/#  ·                       ·
+·     distribution  local                                    ·                       ·
+·     vectorized    true                                     ·                       ·
+scan  ·             ·                                        (d decimal, v decimal)  ·
+·     table         dec@primary                              ·                       ·
+·     spans         /Infinity/Infinity-/Infinity/Infinity/#  ·                       ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM dec WHERE d = '-Infinity' and v = '-Infinity'
 ----
-·     distributed  false                                        ·                       ·
-·     vectorized   true                                         ·                       ·
-scan  ·            ·                                            (d decimal, v decimal)  ·
-·     table        dec@primary                                  ·                       ·
-·     spans        /-Infinity/-Infinity-/-Infinity/-Infinity/#  ·                       ·
+·     distribution  local                                        ·                       ·
+·     vectorized    true                                         ·                       ·
+scan  ·             ·                                            (d decimal, v decimal)  ·
+·     table         dec@primary                                  ·                       ·
+·     spans         /-Infinity/-Infinity-/-Infinity/-Infinity/#  ·                       ·
 
 statement ok
 DROP TABLE dec
@@ -811,30 +811,30 @@ CREATE TABLE dec2 (d decimal null, index (d))
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM dec2 WHERE d IS NaN
 ----
-·     distributed  false            ·            ·
-·     vectorized   true             ·            ·
-scan  ·            ·                (d decimal)  ·
-·     table        dec2@dec2_d_idx  ·            ·
-·     spans        /NaN-/-Infinity  ·            ·
+·     distribution  local            ·            ·
+·     vectorized    true             ·            ·
+scan  ·             ·                (d decimal)  ·
+·     table         dec2@dec2_d_idx  ·            ·
+·     spans         /NaN-/-Infinity  ·            ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM dec2 WHERE d = 'NaN'
 ----
-·     distributed  false            ·            ·
-·     vectorized   true             ·            ·
-scan  ·            ·                (d decimal)  ·
-·     table        dec2@dec2_d_idx  ·            ·
-·     spans        /NaN-/-Infinity  ·            ·
+·     distribution  local            ·            ·
+·     vectorized    true             ·            ·
+scan  ·             ·                (d decimal)  ·
+·     table         dec2@dec2_d_idx  ·            ·
+·     spans         /NaN-/-Infinity  ·            ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM dec2 WHERE isnan(d)
 ----
-·     distributed  false                        ·            ·
-·     vectorized   true                         ·            ·
-scan  ·            ·                            (d decimal)  ·
-·     table        dec2@primary                 ·            ·
-·     spans        FULL SCAN                    ·            ·
-·     filter       (isnan((d)[decimal]))[bool]  ·            ·
+·     distribution  local                        ·            ·
+·     vectorized    true                         ·            ·
+scan  ·             ·                            (d decimal)  ·
+·     table         dec2@primary                 ·            ·
+·     spans         FULL SCAN                    ·            ·
+·     filter        (isnan((d)[decimal]))[bool]  ·            ·
 
 statement ok
 DROP TABLE dec2
@@ -851,30 +851,30 @@ CREATE TABLE flt (f float null, unique index (f))
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM flt WHERE f IS NaN
 ----
-·     distributed  false                ·          ·
-·     vectorized   true                 ·          ·
-scan  ·            ·                    (f float)  ·
-·     table        flt@flt_f_key        ·          ·
-·     spans        /NaN-/NaN/PrefixEnd  ·          ·
+·     distribution  local                ·          ·
+·     vectorized    true                 ·          ·
+scan  ·             ·                    (f float)  ·
+·     table         flt@flt_f_key        ·          ·
+·     spans         /NaN-/NaN/PrefixEnd  ·          ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM flt WHERE f = 'NaN'
 ----
-·     distributed  false                ·          ·
-·     vectorized   true                 ·          ·
-scan  ·            ·                    (f float)  ·
-·     table        flt@flt_f_key        ·          ·
-·     spans        /NaN-/NaN/PrefixEnd  ·          ·
+·     distribution  local                ·          ·
+·     vectorized    true                 ·          ·
+scan  ·             ·                    (f float)  ·
+·     table         flt@flt_f_key        ·          ·
+·     spans         /NaN-/NaN/PrefixEnd  ·          ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM flt WHERE isnan(f)
 ----
-·     distributed  false                      ·          ·
-·     vectorized   true                       ·          ·
-scan  ·            ·                          (f float)  ·
-·     table        flt@primary                ·          ·
-·     spans        FULL SCAN                  ·          ·
-·     filter       (isnan((f)[float]))[bool]  ·          ·
+·     distribution  local                      ·          ·
+·     vectorized    true                       ·          ·
+scan  ·             ·                          (f float)  ·
+·     table         flt@primary                ·          ·
+·     spans         FULL SCAN                  ·          ·
+·     filter        (isnan((f)[float]))[bool]  ·          ·
 
 statement ok
 DROP TABLE flt
@@ -899,38 +899,38 @@ CREATE TABLE num (
 query TTTTT
 EXPLAIN (TYPES) SELECT i FROM num WHERE i = -1:::INT
 ----
-·     distributed  false          ·        ·
-·     vectorized   true           ·        ·
-scan  ·            ·              (i int)  ·
-·     table        num@num_i_key  ·        ·
-·     spans        /-1-/0         ·        ·
+·     distribution  local          ·        ·
+·     vectorized    true           ·        ·
+scan  ·             ·              (i int)  ·
+·     table         num@num_i_key  ·        ·
+·     spans         /-1-/0         ·        ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT f FROM num WHERE f = -1:::FLOAT
 ----
-·     distributed  false              ·          ·
-·     vectorized   true               ·          ·
-scan  ·            ·                  (f float)  ·
-·     table        num@num_f_key      ·          ·
-·     spans        /-1-/-1/PrefixEnd  ·          ·
+·     distribution  local              ·          ·
+·     vectorized    true               ·          ·
+scan  ·             ·                  (f float)  ·
+·     table         num@num_f_key      ·          ·
+·     spans         /-1-/-1/PrefixEnd  ·          ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT d FROM num WHERE d = -1:::DECIMAL
 ----
-·     distributed  false              ·            ·
-·     vectorized   true               ·            ·
-scan  ·            ·                  (d decimal)  ·
-·     table        num@num_d_key      ·            ·
-·     spans        /-1-/-1/PrefixEnd  ·            ·
+·     distribution  local              ·            ·
+·     vectorized    true               ·            ·
+scan  ·             ·                  (d decimal)  ·
+·     table         num@num_d_key      ·            ·
+·     spans         /-1-/-1/PrefixEnd  ·            ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT n FROM num WHERE n = -'1h':::INTERVAL
 ----
-·     distributed  false                        ·             ·
-·     vectorized   true                         ·             ·
-scan  ·            ·                            (n interval)  ·
-·     table        num@num_n_key                ·             ·
-·     spans        /-01:00:00-/1 day -25:00:00  ·             ·
+·     distribution  local                        ·             ·
+·     vectorized    true                         ·             ·
+scan  ·             ·                            (n interval)  ·
+·     table         num@num_n_key                ·             ·
+·     spans         /-01:00:00-/1 day -25:00:00  ·             ·
 
 statement ok
 DROP TABLE num
@@ -1131,91 +1131,91 @@ CREATE TABLE abcd (a INT, b INT, c INT, d INT, PRIMARY KEY (a, b))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a + x FROM (SELECT a, b + c AS x FROM abcd) ORDER BY a
 ----
-·          distributed  false         ·             ·
-·          vectorized   true          ·             ·
-render     ·            ·             ("?column?")  ·
- │         render 0     a + (b + c)   ·             ·
- └── scan  ·            ·             (a, b, c)     +a
-·          table        abcd@primary  ·             ·
-·          spans        FULL SCAN     ·             ·
+·          distribution  local         ·             ·
+·          vectorized    true          ·             ·
+render     ·             ·             ("?column?")  ·
+ │         render 0      a + (b + c)   ·             ·
+ └── scan  ·             ·             (a, b, c)     +a
+·          table         abcd@primary  ·             ·
+·          spans         FULL SCAN     ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a + x FROM (SELECT a, b, a + b + c AS x FROM abcd) ORDER BY b
 ----
-·                    distributed  false              ·                ·
-·                    vectorized   true               ·                ·
-render               ·            ·                  ("?column?")     ·
- │                   render 0     "?column?"         ·                ·
- └── sort            ·            ·                  ("?column?", b)  +b
-      │              order        +b                 ·                ·
-      └── render     ·            ·                  ("?column?", b)  ·
-           │         render 0     a + (c + (a + b))  ·                ·
-           │         render 1     b                  ·                ·
-           └── scan  ·            ·                  (a, b, c)        ·
-·                    table        abcd@primary       ·                ·
-·                    spans        FULL SCAN          ·                ·
+·                    distribution  local              ·                ·
+·                    vectorized    true               ·                ·
+render               ·             ·                  ("?column?")     ·
+ │                   render 0      "?column?"         ·                ·
+ └── sort            ·             ·                  ("?column?", b)  +b
+      │              order         +b                 ·                ·
+      └── render     ·             ·                  ("?column?", b)  ·
+           │         render 0      a + (c + (a + b))  ·                ·
+           │         render 1      b                  ·                ·
+           └── scan  ·             ·                  (a, b, c)        ·
+·                    table         abcd@primary       ·                ·
+·                    spans         FULL SCAN          ·                ·
 
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a + x FROM (SELECT a, b, a + b + c AS x FROM abcd) ORDER BY a DESC, b DESC
 ----
-·             distributed  false              ·             ·
-·             vectorized   true               ·             ·
-render        ·            ·                  ("?column?")  ·
- │            render 0     a + (c + (a + b))  ·             ·
- └── revscan  ·            ·                  (a, b, c)     -a,-b
-·             table        abcd@primary       ·             ·
-·             spans        FULL SCAN          ·             ·
+·             distribution  local              ·             ·
+·             vectorized    true               ·             ·
+render        ·             ·                  ("?column?")  ·
+ │            render 0      a + (c + (a + b))  ·             ·
+ └── revscan  ·             ·                  (a, b, c)     -a,-b
+·             table         abcd@primary       ·             ·
+·             spans         FULL SCAN          ·             ·
 
 # Ensure that filter nodes (and filtered scan nodes) get populated with the correct ordering.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a > b ORDER BY a
 ----
-·     distributed  false         ·             ·
-·     vectorized   true          ·             ·
-scan  ·            ·             (a, b, c, d)  +a
-·     table        abcd@primary  ·             ·
-·     spans        FULL SCAN     ·             ·
-·     filter       a > b         ·             ·
+·     distribution  local         ·             ·
+·     vectorized    true          ·             ·
+scan  ·             ·             (a, b, c, d)  +a
+·     table         abcd@primary  ·             ·
+·     spans         FULL SCAN     ·             ·
+·     filter        a > b         ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a > b ORDER BY a DESC, b DESC
 ----
-·          distributed  false         ·             ·
-·          vectorized   true          ·             ·
-sort       ·            ·             (a, b, c, d)  -a,-b
- │         order        -a,-b         ·             ·
- └── scan  ·            ·             (a, b, c, d)  ·
-·          table        abcd@primary  ·             ·
-·          spans        FULL SCAN     ·             ·
-·          filter       a > b         ·             ·
+·          distribution  local         ·             ·
+·          vectorized    true          ·             ·
+sort       ·             ·             (a, b, c, d)  -a,-b
+ │         order         -a,-b         ·             ·
+ └── scan  ·             ·             (a, b, c, d)  ·
+·          table         abcd@primary  ·             ·
+·          spans         FULL SCAN     ·             ·
+·          filter        a > b         ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a, b FROM abcd LIMIT 10) WHERE a > b ORDER BY a
 ----
-·          distributed  false         ·       ·
-·          vectorized   true          ·       ·
-filter     ·            ·             (a, b)  +a
- │         filter       a > b         ·       ·
- └── scan  ·            ·             (a, b)  +a
-·          table        abcd@primary  ·       ·
-·          spans        LIMITED SCAN  ·       ·
-·          limit        10            ·       ·
+·          distribution  local         ·       ·
+·          vectorized    true          ·       ·
+filter     ·             ·             (a, b)  +a
+ │         filter        a > b         ·       ·
+ └── scan  ·             ·             (a, b)  +a
+·          table         abcd@primary  ·       ·
+·          spans         LIMITED SCAN  ·       ·
+·          limit         10            ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT a, a+b+c AS x FROM (SELECT * FROM abcd LIMIT 10)) WHERE x > 100 ORDER BY a
 ----
-·               distributed  false                ·          ·
-·               vectorized   true                 ·          ·
-render          ·            ·                    (a, x)     ·
- │              render 0     a                    ·          ·
- │              render 1     c + (a + b)          ·          ·
- └── filter     ·            ·                    (a, b, c)  +a
-      │         filter       (c + (a + b)) > 100  ·          ·
-      └── scan  ·            ·                    (a, b, c)  +a
-·               table        abcd@primary         ·          ·
-·               spans        LIMITED SCAN         ·          ·
-·               limit        10                   ·          ·
+·               distribution  local                ·          ·
+·               vectorized    true                 ·          ·
+render          ·             ·                    (a, x)     ·
+ │              render 0      a                    ·          ·
+ │              render 1      c + (a + b)          ·          ·
+ └── filter     ·             ·                    (a, b, c)  +a
+      │         filter        (c + (a + b)) > 100  ·          ·
+      └── scan  ·             ·                    (a, b, c)  +a
+·               table         abcd@primary         ·          ·
+·               spans         LIMITED SCAN         ·          ·
+·               limit         10                   ·          ·
 
 statement ok
 CREATE TABLE xyz (x INT, y INT, z INT, INDEX(x,y,z))
@@ -1224,14 +1224,14 @@ CREATE TABLE xyz (x INT, y INT, z INT, INDEX(x,y,z))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyz LIMIT 10) WHERE y = 1 ORDER BY x, y, z
 ----
-·          distributed  false              ·          ·
-·          vectorized   true               ·          ·
-filter     ·            ·                  (x, y, z)  +x,+z
- │         filter       y = 1              ·          ·
- └── scan  ·            ·                  (x, y, z)  +x,+y,+z
-·          table        xyz@xyz_x_y_z_idx  ·          ·
-·          spans        LIMITED SCAN       ·          ·
-·          limit        10                 ·          ·
+·          distribution  local              ·          ·
+·          vectorized    true               ·          ·
+filter     ·             ·                  (x, y, z)  +x,+z
+ │         filter        y = 1              ·          ·
+ └── scan  ·             ·                  (x, y, z)  +x,+y,+z
+·          table         xyz@xyz_x_y_z_idx  ·          ·
+·          spans         LIMITED SCAN       ·          ·
+·          limit         10                 ·          ·
 
 # ------------------------------------------------------
 # Verify that multi-span point lookups are parallelized.
@@ -1246,63 +1246,63 @@ CREATE TABLE b (a INT, b INT, c INT NULL, d INT NULL, PRIMARY KEY (a, b), FAMILY
 query TTT
 EXPLAIN SELECT * FROM a WHERE a = 10
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        a@primary
-·     spans        /10-/10/#
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         a@primary
+·     spans         /10-/10/#
 
 query TTT
 EXPLAIN SELECT * FROM a WHERE a = 10 OR a = 20
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        a@primary
-·     spans        /10-/10/# /20-/20/#
-·     parallel     ·
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         a@primary
+·     spans         /10-/10/# /20-/20/#
+·     parallel      ·
 
 query TTT
 EXPLAIN SELECT * FROM a WHERE a IN (10, 20)
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        a@primary
-·     spans        /10-/10/# /20-/20/#
-·     parallel     ·
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         a@primary
+·     spans         /10-/10/# /20-/20/#
+·     parallel      ·
 
 # Verify that consolidated point spans are still parallelized.
 query TTT
 EXPLAIN SELECT * FROM a WHERE a in (10, 11)
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        a@primary
-·     spans        /10-/11/#
-·     parallel     ·
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         a@primary
+·     spans         /10-/11/#
+·     parallel      ·
 
 query TTT
 EXPLAIN SELECT * FROM a WHERE a > 10 AND a < 20
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        a@primary
-·     spans        /11-/19/#
-·     parallel     ·
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         a@primary
+·     spans         /11-/19/#
+·     parallel      ·
 
 # This ticks all the boxes for parallelization apart from the fact that there
 # is no end key in the span.
 query TTT
 EXPLAIN SELECT * FROM a WHERE a > 10
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        a@primary
-·     spans        /11-
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         a@primary
+·     spans         /11-
 
 # Test non-int types.
 
@@ -1310,31 +1310,31 @@ scan  ·            ·
 query TTT
 EXPLAIN SELECT price FROM a WHERE item IN ('sock', 'ball')
 ----
-·                distributed  false
-·                vectorized   true
-render           ·            ·
- └── index-join  ·            ·
-      │          table        a@primary
-      │          key columns  a
-      └── scan   ·            ·
-·                table        a@item
-·                spans        /"ball"-/"ball"/PrefixEnd /"sock"-/"sock"/PrefixEnd
-·                parallel     ·
+·                distribution  local
+·                vectorized    true
+render           ·             ·
+ └── index-join  ·             ·
+      │          table         a@primary
+      │          key columns   a
+      └── scan   ·             ·
+·                table         a@item
+·                spans         /"ball"-/"ball"/PrefixEnd /"sock"-/"sock"/PrefixEnd
+·                parallel      ·
 
 # Range queries on non-int types are not parallel due to unbounded number of
 # results.
 query TTT
 EXPLAIN SELECT item FROM a WHERE price > 5 AND price < 10 OR price > 20 AND price < 40
 ----
-·                distributed  false
-·                vectorized   true
-render           ·            ·
- └── index-join  ·            ·
-      │          table        a@primary
-      │          key columns  a
-      └── scan   ·            ·
-·                table        a@p
-·                spans        /5.000000000000001-/9.999999999999998/PrefixEnd /20.000000000000004-/39.99999999999999/PrefixEnd
+·                distribution  local
+·                vectorized    true
+render           ·             ·
+ └── index-join  ·             ·
+      │          table         a@primary
+      │          key columns   a
+      └── scan   ·             ·
+·                table         a@p
+·                spans         /5.000000000000001-/9.999999999999998/PrefixEnd /20.000000000000004-/39.99999999999999/PrefixEnd
 
 statement ok
 SET CLUSTER SETTING sql.parallel_scans.enabled = false
@@ -1342,11 +1342,11 @@ SET CLUSTER SETTING sql.parallel_scans.enabled = false
 query TTT
 EXPLAIN SELECT * FROM a WHERE a IN (10, 20)
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        a@primary
-·     spans        /10-/10/# /20-/20/#
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         a@primary
+·     spans         /10-/10/# /20-/20/#
 
 statement ok
 SET CLUSTER SETTING sql.parallel_scans.enabled = true
@@ -1354,34 +1354,34 @@ SET CLUSTER SETTING sql.parallel_scans.enabled = true
 query TTT
 EXPLAIN SELECT * FROM b WHERE (a = 10 AND b = 10) OR (a = 20 AND b = 20)
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        b@primary
-·     spans        /10/10-/10/10/# /20/20-/20/20/#
-·     parallel     ·
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         b@primary
+·     spans         /10/10-/10/10/# /20/20-/20/20/#
+·     parallel      ·
 
 # This one isn't parallelizable because it's not a point lookup - only part of
 # the primary key is specified.
 query TTT
 EXPLAIN SELECT * FROM b WHERE a = 10 OR a = 20
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        b@primary
-·     spans        /10-/11 /20-/21
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         b@primary
+·     spans         /10-/11 /20-/21
 
 # This one isn't parallelizable because it has a LIMIT clause.
 query TTT
 EXPLAIN SELECT * FROM a WHERE a = 10 OR a = 20 LIMIT 1
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        a@primary
-·     spans        /10-/10/# /20-/20/#
-·     limit        1
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         a@primary
+·     spans         /10-/10/# /20-/20/#
+·     limit         1
 
 statement ok
 CREATE INDEX on b(b) STORING (c)
@@ -1390,11 +1390,11 @@ CREATE INDEX on b(b) STORING (c)
 query TTT
 EXPLAIN SELECT b FROM b WHERE b = 10 OR b = 20
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        b@b_b_idx
-·     spans        /10-/11 /20-/21
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         b@b_b_idx
+·     spans         /10-/11 /20-/21
 
 statement ok
 CREATE UNIQUE INDEX on b(c)
@@ -1404,21 +1404,21 @@ CREATE UNIQUE INDEX on b(c)
 query TTT
 EXPLAIN SELECT c FROM b WHERE c = 10 OR c = 20
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        b@b_c_key
-·     spans        /10-/11 /20-/21
-·     parallel     ·
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         b@b_c_key
+·     spans         /10-/11 /20-/21
+·     parallel      ·
 
 query TTT
 EXPLAIN SELECT c FROM b WHERE c = 10 OR c < 2
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        b@b_c_key
-·     spans        /!NULL-/2 /10-/11
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         b@b_c_key
+·     spans         /!NULL-/2 /10-/11
 
 statement ok
 CREATE UNIQUE INDEX on b(d DESC)
@@ -1428,11 +1428,11 @@ CREATE UNIQUE INDEX on b(d DESC)
 query TTT
 EXPLAIN SELECT d FROM b WHERE d = 10 OR d < 2
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        b@b_d_key
-·     spans        /10-/9 /1-/NULL
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         b@b_d_key
+·     spans         /10-/9 /1-/NULL
 
 statement ok
 CREATE UNIQUE INDEX ON b(c, d)
@@ -1442,12 +1442,12 @@ CREATE UNIQUE INDEX ON b(c, d)
 query TTT
 EXPLAIN SELECT d FROM b WHERE c = 10 AND d = 10 OR c IS NULL AND d > 0 AND d < 2
 ----
-·          distributed  false
-·          vectorized   true
-render     ·            ·
- └── scan  ·            ·
-·          table        b@b_c_d_key
-·          spans        /NULL/1-/NULL/2 /10/10-/10/11
+·          distribution  local
+·          vectorized    true
+render     ·             ·
+ └── scan  ·             ·
+·          table         b@b_c_d_key
+·          spans         /NULL/1-/NULL/2 /10/10-/10/11
 
 statement ok
 DROP INDEX b_b_idx
@@ -1459,12 +1459,12 @@ CREATE UNIQUE INDEX on b(b) STORING (c)
 query TTT
 EXPLAIN SELECT b FROM b WHERE b = 10 OR b = 20
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        b@b_b_key
-·     spans        /10-/11 /20-/21
-·     parallel     ·
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         b@b_b_key
+·     spans         /10-/11 /20-/21
+·     parallel      ·
 
 statement ok
 ALTER TABLE a SPLIT AT VALUES(5)
@@ -1501,20 +1501,20 @@ CREATE TABLE s (x INT PRIMARY KEY, y INT, z INT)
 query TTT
 EXPLAIN SELECT e.z, s.z, n FROM e, s, generate_series(0, s.z, 1000) as n WHERE e.y = s.y ORDER BY s.z LIMIT 10
 ----
-·                              distributed  false
-·                              vectorized   true
-render                         ·            ·
- └── limit                     ·            ·
-      │                        count        10
-      └── sort                 ·            ·
-           │                   order        +z
-           └── project set     ·            ·
-                └── hash-join  ·            ·
-                     │         type         inner
-                     │         equality     (y) = (y)
-                     ├── scan  ·            ·
-                     │         table        e@primary
-                     │         spans        FULL SCAN
-                     └── scan  ·            ·
-·                              table        s@primary
-·                              spans        FULL SCAN
+·                              distribution  local
+·                              vectorized    true
+render                         ·             ·
+ └── limit                     ·             ·
+      │                        count         10
+      └── sort                 ·             ·
+           │                   order         +z
+           └── project set     ·             ·
+                └── hash-join  ·             ·
+                     │         type          inner
+                     │         equality      (y) = (y)
+                     ├── scan  ·             ·
+                     │         table         e@primary
+                     │         spans         FULL SCAN
+                     └── scan  ·             ·
+·                              table         s@primary
+·                              spans         FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -16,7 +16,7 @@ CREATE VIEW v AS SELECT a FROM t AS t2
 query TTT
 EXPLAIN SELECT * FROM t FOR UPDATE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -26,7 +26,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t FOR NO KEY UPDATE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -36,7 +36,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t FOR SHARE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -46,7 +46,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t FOR KEY SHARE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -56,7 +56,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t FOR KEY SHARE FOR SHARE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -66,7 +66,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -76,7 +76,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -86,7 +86,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t FOR UPDATE OF t
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -99,7 +99,7 @@ EXPLAIN SELECT * FROM t FOR UPDATE OF t2
 query TTT
 EXPLAIN SELECT 1 FROM t FOR UPDATE OF t
 ----
-·          distributed       false
+·          distribution      local
 ·          vectorized        true
 render     ·                 ·
  └── scan  ·                 ·
@@ -110,7 +110,7 @@ render     ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t WHERE a = 1 FOR UPDATE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -120,7 +120,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t WHERE a = 1 FOR NO KEY UPDATE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -130,7 +130,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t WHERE a = 1 FOR SHARE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -140,7 +140,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -150,7 +150,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -160,7 +160,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -170,7 +170,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -180,7 +180,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t WHERE a = 1 FOR UPDATE OF t
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -193,7 +193,7 @@ EXPLAIN SELECT * FROM t WHERE a = 1 FOR UPDATE OF t2
 query TTT
 EXPLAIN SELECT 1 FROM t WHERE a = 1 FOR UPDATE OF t
 ----
-·          distributed       false
+·          distribution      local
 ·          vectorized        true
 render     ·                 ·
  └── scan  ·                 ·
@@ -208,7 +208,7 @@ render     ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t AS t2 FOR UPDATE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -221,7 +221,7 @@ EXPLAIN SELECT * FROM t AS t2 FOR UPDATE OF t
 query TTT
 EXPLAIN SELECT * FROM t AS t2 FOR UPDATE OF t2
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -236,7 +236,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM [53 AS t] FOR UPDATE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -246,7 +246,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM [53 AS t] FOR UPDATE OF t
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -263,7 +263,7 @@ EXPLAIN SELECT * FROM [53 AS t] FOR UPDATE OF t2
 query TTT
 EXPLAIN SELECT * FROM v FOR UPDATE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -273,7 +273,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM v FOR UPDATE OF v
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -296,7 +296,7 @@ EXPLAIN SELECT * FROM v FOR UPDATE OF t2
 query TTT
 EXPLAIN SELECT * FROM v AS v2 FOR UPDATE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -309,7 +309,7 @@ EXPLAIN SELECT * FROM v AS v2 FOR UPDATE OF v
 query TTT
 EXPLAIN SELECT * FROM v AS v2 FOR UPDATE OF v2
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -327,7 +327,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM (SELECT a FROM t) FOR UPDATE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -337,7 +337,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM (SELECT a FROM t FOR UPDATE)
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -347,7 +347,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM (SELECT a FROM t FOR NO KEY UPDATE) FOR KEY SHARE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -357,7 +357,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM (SELECT a FROM t FOR KEY SHARE) FOR NO KEY UPDATE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -370,7 +370,7 @@ EXPLAIN SELECT * FROM (SELECT a FROM t) FOR UPDATE OF t
 query TTT
 EXPLAIN SELECT * FROM (SELECT a FROM t FOR UPDATE OF t)
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -380,7 +380,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -390,7 +390,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM (SELECT a FROM t FOR UPDATE) AS r
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -403,7 +403,7 @@ EXPLAIN SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE OF t
 query TTT
 EXPLAIN SELECT * FROM (SELECT a FROM t FOR UPDATE OF t) AS r
 ----
-·     distributed       false
+·     distribution      local
 ·     vectorized        true
 scan  ·                 ·
 ·     table             t@primary
@@ -413,7 +413,7 @@ scan  ·                 ·
 query TTT
 EXPLAIN SELECT (SELECT a FROM t) FOR UPDATE
 ----
-·                    distributed   false
+·                    distribution  local
 ·                    vectorized    false
 root                 ·             ·
  ├── values          ·             ·
@@ -430,7 +430,7 @@ root                 ·             ·
 query TTT
 EXPLAIN SELECT (SELECT a FROM t FOR UPDATE)
 ----
-·                    distributed       false
+·                    distribution      local
 ·                    vectorized        false
 root                 ·                 ·
  ├── values          ·                 ·
@@ -451,7 +451,7 @@ EXPLAIN SELECT (SELECT a FROM t) FOR UPDATE OF t
 query TTT
 EXPLAIN SELECT (SELECT a FROM t FOR UPDATE OF t)
 ----
-·                    distributed       false
+·                    distribution      local
 ·                    vectorized        false
 root                 ·                 ·
  ├── values          ·                 ·
@@ -469,7 +469,7 @@ root                 ·                 ·
 query TTT
 EXPLAIN SELECT (SELECT a FROM t) AS r FOR UPDATE
 ----
-·                    distributed   false
+·                    distribution  local
 ·                    vectorized    false
 root                 ·             ·
  ├── values          ·             ·
@@ -486,7 +486,7 @@ root                 ·             ·
 query TTT
 EXPLAIN SELECT (SELECT a FROM t FOR UPDATE) AS r
 ----
-·                    distributed       false
+·                    distribution      local
 ·                    vectorized        false
 root                 ·                 ·
  ├── values          ·                 ·
@@ -507,7 +507,7 @@ EXPLAIN SELECT (SELECT a FROM t) AS r FOR UPDATE OF t
 query TTT
 EXPLAIN SELECT (SELECT a FROM t FOR UPDATE OF t) AS r
 ----
-·                    distributed       false
+·                    distribution      local
 ·                    vectorized        false
 root                 ·                 ·
  ├── values          ·                 ·
@@ -525,7 +525,7 @@ root                 ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t WHERE a IN (SELECT a FROM t) FOR UPDATE
 ----
-·           distributed         false
+·           distribution        local
 ·           vectorized          true
 merge-join  ·                   ·
  │          type                semi
@@ -544,7 +544,7 @@ merge-join  ·                   ·
 query TTT
 EXPLAIN SELECT * FROM t WHERE a IN (SELECT a FROM t FOR UPDATE)
 ----
-·           distributed         false
+·           distribution        local
 ·           vectorized          true
 merge-join  ·                   ·
  │          type                semi
@@ -563,7 +563,7 @@ merge-join  ·                   ·
 query TTT
 EXPLAIN SELECT * FROM t WHERE a IN (SELECT a FROM t) FOR UPDATE OF t
 ----
-·           distributed         false
+·           distribution        local
 ·           vectorized          true
 merge-join  ·                   ·
  │          type                semi
@@ -582,7 +582,7 @@ merge-join  ·                   ·
 query TTT
 EXPLAIN SELECT * FROM t WHERE a IN (SELECT a FROM t FOR UPDATE OF t)
 ----
-·           distributed         false
+·           distribution        local
 ·           vectorized          true
 merge-join  ·                   ·
  │          type                semi
@@ -612,27 +612,27 @@ merge-join  ·                   ·
 query TTT
 EXPLAIN SELECT * FROM [SELECT a FROM t] FOR UPDATE
 ----
-·          distributed  false
-·          vectorized   true
-render     ·            ·
- └── scan  ·            ·
-·          table        t@primary
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+render     ·             ·
+ └── scan  ·             ·
+·          table         t@primary
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN WITH cte AS (SELECT a FROM t) SELECT * FROM cte FOR UPDATE
 ----
-·          distributed  false
-·          vectorized   true
-render     ·            ·
- └── scan  ·            ·
-·          table        t@primary
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+render     ·             ·
+ └── scan  ·             ·
+·          table         t@primary
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM [SELECT a FROM t FOR UPDATE]
 ----
-·                      distributed       false
+·                      distribution      local
 ·                      vectorized        false
 root                   ·                 ·
  ├── scan buffer node  ·                 ·
@@ -651,7 +651,7 @@ root                   ·                 ·
 query TTT
 EXPLAIN WITH cte AS (SELECT a FROM t FOR UPDATE) SELECT * FROM cte
 ----
-·                      distributed       false
+·                      distribution      local
 ·                      vectorized        false
 root                   ·                 ·
  ├── scan buffer node  ·                 ·
@@ -673,7 +673,7 @@ query TTT
 EXPLAIN WITH sfu AS (SELECT a FROM t FOR UPDATE)
 SELECT c FROM u
 ----
-·                      distributed       false
+·                      distribution      local
 ·                      vectorized        true
 root                   ·                 ·
  ├── scan              ·                 ·
@@ -697,7 +697,7 @@ root                   ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t JOIN u USING (a) FOR UPDATE
 ----
-·                distributed         false
+·                distribution        local
 ·                vectorized          true
 render           ·                   ·
  └── merge-join  ·                   ·
@@ -718,7 +718,7 @@ render           ·                   ·
 query TTT
 EXPLAIN SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t
 ----
-·                distributed         false
+·                distribution        local
 ·                vectorized          true
 render           ·                   ·
  └── merge-join  ·                   ·
@@ -738,7 +738,7 @@ render           ·                   ·
 query TTT
 EXPLAIN SELECT * FROM t JOIN u USING (a) FOR UPDATE OF u
 ----
-·                distributed         false
+·                distribution        local
 ·                vectorized          true
 render           ·                   ·
  └── merge-join  ·                   ·
@@ -758,7 +758,7 @@ render           ·                   ·
 query TTT
 EXPLAIN SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t, u
 ----
-·                distributed         false
+·                distribution        local
 ·                vectorized          true
 render           ·                   ·
  └── merge-join  ·                   ·
@@ -779,7 +779,7 @@ render           ·                   ·
 query TTT
 EXPLAIN SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t FOR SHARE OF u
 ----
-·                distributed         false
+·                distribution        local
 ·                vectorized          true
 render           ·                   ·
  └── merge-join  ·                   ·
@@ -803,7 +803,7 @@ EXPLAIN SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t2 FOR SHARE OF u2
 query TTT
 EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2 FOR SHARE OF u2
 ----
-·                distributed         false
+·                distribution        local
 ·                vectorized          true
 render           ·                   ·
  └── merge-join  ·                   ·
@@ -824,7 +824,7 @@ render           ·                   ·
 query TTT
 EXPLAIN SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR UPDATE
 ----
-·                distributed         false
+·                distribution        local
 ·                vectorized          true
 render           ·                   ·
  └── merge-join  ·                   ·
@@ -845,7 +845,7 @@ render           ·                   ·
 query TTT
 EXPLAIN SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR NO KEY UPDATE OF t
 ----
-·                distributed         false
+·                distribution        local
 ·                vectorized          true
 render           ·                   ·
  └── merge-join  ·                   ·
@@ -866,7 +866,7 @@ render           ·                   ·
 query TTT
 EXPLAIN SELECT * FROM t JOIN u USING (a) FOR SHARE FOR NO KEY UPDATE OF t FOR UPDATE OF u
 ----
-·                distributed         false
+·                distribution        local
 ·                vectorized          true
 render           ·                   ·
  └── merge-join  ·                   ·
@@ -891,7 +891,7 @@ render           ·                   ·
 query TTT
 EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE
 ----
-·                distributed         false
+·                distribution        local
 ·                vectorized          true
 render           ·                   ·
  └── merge-join  ·                   ·
@@ -921,7 +921,7 @@ EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t, u
 query TTT
 EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2
 ----
-·                distributed         false
+·                distribution        local
 ·                vectorized          true
 render           ·                   ·
  └── merge-join  ·                   ·
@@ -941,7 +941,7 @@ render           ·                   ·
 query TTT
 EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF u2
 ----
-·                distributed         false
+·                distribution        local
 ·                vectorized          true
 render           ·                   ·
  └── merge-join  ·                   ·
@@ -961,7 +961,7 @@ render           ·                   ·
 query TTT
 EXPLAIN SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2, u2
 ----
-·                distributed         false
+·                distribution        local
 ·                vectorized          true
 render           ·                   ·
  └── merge-join  ·                   ·
@@ -986,7 +986,7 @@ render           ·                   ·
 query TTT
 EXPLAIN SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE
 ----
-·                distributed         false
+·                distribution        local
 ·                vectorized          true
 render           ·                   ·
  └── merge-join  ·                   ·
@@ -1016,7 +1016,7 @@ EXPLAIN SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF u2
 query TTT
 EXPLAIN SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF j
 ----
-·                distributed         false
+·                distribution        local
 ·                vectorized          true
 render           ·                   ·
  └── merge-join  ·                   ·
@@ -1041,7 +1041,7 @@ render           ·                   ·
 query TTT
 EXPLAIN SELECT * FROM t, u FOR UPDATE
 ----
-·           distributed       false
+·           distribution      local
 ·           vectorized        true
 cross-join  ·                 ·
  │          type              cross
@@ -1057,7 +1057,7 @@ cross-join  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t, u FOR UPDATE OF t
 ----
-·           distributed       false
+·           distribution      local
 ·           vectorized        true
 cross-join  ·                 ·
  │          type              cross
@@ -1072,7 +1072,7 @@ cross-join  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t, u FOR SHARE OF t FOR UPDATE OF u
 ----
-·           distributed       false
+·           distribution      local
 ·           vectorized        true
 cross-join  ·                 ·
  │          type              cross
@@ -1088,7 +1088,7 @@ cross-join  ·                 ·
 query TTT
 EXPLAIN SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE
 ----
-·           distributed       false
+·           distribution      local
 ·           vectorized        true
 cross-join  ·                 ·
  │          type              cross
@@ -1107,7 +1107,7 @@ EXPLAIN SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE OF u
 query TTT
 EXPLAIN SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE OF sub
 ----
-·           distributed       false
+·           distribution      local
 ·           vectorized        true
 cross-join  ·                 ·
  │          type              cross

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -195,7 +195,7 @@ output row: [2]
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t x JOIN t y USING(b) WHERE x.b = '3'
 ----
-·                     distributed     false                ·                         ·
+·                     distribution    local                ·                         ·
 ·                     vectorized      true                 ·                         ·
 render                ·               ·                    (b, a, c, d, a, c, d)     ·
  │                    render 0        b                    ·                         ·
@@ -265,9 +265,9 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
 query TTT
 EXPLAIN SELECT * FROM t WHERE a > 1 AND a < 2
 ----
-·       distributed  false
-·       vectorized   true
-norows  ·            ·
+·       distribution  local
+·       vectorized    true
+norows  ·             ·
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM t WHERE a = 1 AND 'a' < b AND 'c' > b; SET tracing = off
@@ -433,23 +433,23 @@ output row: [3 4]
 query TTT
 EXPLAIN SELECT * FROM t WHERE a = 1 AND false
 ----
-·       distributed  false
-·       vectorized   true
-norows  ·            ·
+·       distribution  local
+·       vectorized    true
+norows  ·             ·
 
 query TTT
 EXPLAIN SELECT * FROM t WHERE a = 1 AND NULL
 ----
-·       distributed  false
-·       vectorized   true
-norows  ·            ·
+·       distribution  local
+·       vectorized    true
+norows  ·             ·
 
 query TTT
 EXPLAIN SELECT * FROM t WHERE a = NULL AND a != NULL
 ----
-·       distributed  false
-·       vectorized   true
-norows  ·            ·
+·       distribution  local
+·       vectorized    true
+norows  ·             ·
 
 # Make sure that mixed type comparison operations are not used
 # for selecting indexes.
@@ -469,120 +469,120 @@ CREATE TABLE t (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c > 1
 ----
-·          distributed  false      ·       ·
-·          vectorized   true       ·       ·
-render     ·            ·          (a)     ·
- │         render 0     a          ·       ·
- └── scan  ·            ·          (a, c)  ·
-·          table        t@primary  ·       ·
-·          spans        FULL SCAN  ·       ·
-·          filter       c > 1      ·       ·
+·          distribution  local      ·       ·
+·          vectorized    true       ·       ·
+render     ·             ·          (a)     ·
+ │         render 0      a          ·       ·
+ └── scan  ·             ·          (a, c)  ·
+·          table         t@primary  ·       ·
+·          spans         FULL SCAN  ·       ·
+·          filter        c > 1      ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c < 1 AND b < 5
 ----
-·          distributed  false        ·          ·
-·          vectorized   true         ·          ·
-render     ·            ·            (a)        ·
- │         render 0     a            ·          ·
- └── scan  ·            ·            (a, b, c)  ·
-·          table        t@bc         ·          ·
-·          spans        /!NULL-/4/1  ·          ·
-·          filter       c < 1        ·          ·
+·          distribution  local        ·          ·
+·          vectorized    true         ·          ·
+render     ·             ·            (a)        ·
+ │         render 0      a            ·          ·
+ └── scan  ·             ·            (a, b, c)  ·
+·          table         t@bc         ·          ·
+·          spans         /!NULL-/4/1  ·          ·
+·          filter        c < 1        ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c > 1.0
 ----
-·          distributed  false      ·       ·
-·          vectorized   true       ·       ·
-render     ·            ·          (a)     ·
- │         render 0     a          ·       ·
- └── scan  ·            ·          (a, c)  ·
-·          table        t@primary  ·       ·
-·          spans        FULL SCAN  ·       ·
-·          filter       c > 1      ·       ·
+·          distribution  local      ·       ·
+·          vectorized    true       ·       ·
+render     ·             ·          (a)     ·
+ │         render 0      a          ·       ·
+ └── scan  ·             ·          (a, c)  ·
+·          table         t@primary  ·       ·
+·          spans         FULL SCAN  ·       ·
+·          filter        c > 1      ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c < 1.0
 ----
-·          distributed  false      ·       ·
-·          vectorized   true       ·       ·
-render     ·            ·          (a)     ·
- │         render 0     a          ·       ·
- └── scan  ·            ·          (a, c)  ·
-·          table        t@primary  ·       ·
-·          spans        FULL SCAN  ·       ·
-·          filter       c < 1      ·       ·
+·          distribution  local      ·       ·
+·          vectorized    true       ·       ·
+render     ·             ·          (a)     ·
+ │         render 0      a          ·       ·
+ └── scan  ·             ·          (a, c)  ·
+·          table         t@primary  ·       ·
+·          spans         FULL SCAN  ·       ·
+·          filter        c < 1      ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c > 1.0 AND b < 5
 ----
-·          distributed  false      ·          ·
-·          vectorized   true       ·          ·
-render     ·            ·          (a)        ·
- │         render 0     a          ·          ·
- └── scan  ·            ·          (a, b, c)  ·
-·          table        t@bc       ·          ·
-·          spans        /!NULL-/5  ·          ·
-·          filter       c > 1      ·          ·
+·          distribution  local      ·          ·
+·          vectorized    true       ·          ·
+render     ·             ·          (a)        ·
+ │         render 0      a          ·          ·
+ └── scan  ·             ·          (a, b, c)  ·
+·          table         t@bc       ·          ·
+·          spans         /!NULL-/5  ·          ·
+·          filter        c > 1      ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE b < 5.0 AND c < 1
 ----
-·          distributed  false        ·          ·
-·          vectorized   true         ·          ·
-render     ·            ·            (a)        ·
- │         render 0     a            ·          ·
- └── scan  ·            ·            (a, b, c)  ·
-·          table        t@bc         ·          ·
-·          spans        /!NULL-/4/1  ·          ·
-·          filter       c < 1        ·          ·
+·          distribution  local        ·          ·
+·          vectorized    true         ·          ·
+render     ·             ·            (a)        ·
+ │         render 0      a            ·          ·
+ └── scan  ·             ·            (a, b, c)  ·
+·          table         t@bc         ·          ·
+·          spans         /!NULL-/4/1  ·          ·
+·          filter        c < 1        ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE (b, c) = (5, 1)
 ----
-·          distributed  false      ·          ·
-·          vectorized   true       ·          ·
-render     ·            ·          (a)        ·
- │         render 0     a          ·          ·
- └── scan  ·            ·          (a, b, c)  ·
-·          table        t@bc       ·          ·
-·          spans        /5/1-/5/2  ·          ·
+·          distribution  local      ·          ·
+·          vectorized    true       ·          ·
+render     ·             ·          (a)        ·
+ │         render 0      a          ·          ·
+ └── scan  ·             ·          (a, b, c)  ·
+·          table         t@bc       ·          ·
+·          spans         /5/1-/5/2  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE (b, c) = (5.0, 1)
 ----
-·          distributed  false      ·          ·
-·          vectorized   true       ·          ·
-render     ·            ·          (a)        ·
- │         render 0     a          ·          ·
- └── scan  ·            ·          (a, b, c)  ·
-·          table        t@bc       ·          ·
-·          spans        /5/1-/5/2  ·          ·
+·          distribution  local      ·          ·
+·          vectorized    true       ·          ·
+render     ·             ·          (a)        ·
+ │         render 0      a          ·          ·
+ └── scan  ·             ·          (a, b, c)  ·
+·          table         t@bc       ·          ·
+·          spans         /5/1-/5/2  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE (b, c) = (5.1, 1)
 ----
-·          distributed  false                  ·          ·
-·          vectorized   true                   ·          ·
-render     ·            ·                      (a)        ·
- │         render 0     a                      ·          ·
- └── scan  ·            ·                      (a, b, c)  ·
-·          table        t@bc                   ·          ·
-·          spans        /!NULL-                ·          ·
-·          filter       (b = 5.1) AND (c = 1)  ·          ·
+·          distribution  local                  ·          ·
+·          vectorized    true                   ·          ·
+render     ·             ·                      (a)        ·
+ │         render 0      a                      ·          ·
+ └── scan  ·             ·                      (a, b, c)  ·
+·          table         t@bc                   ·          ·
+·          spans         /!NULL-                ·          ·
+·          filter        (b = 5.1) AND (c = 1)  ·          ·
 
 # Note the span is reversed because of #20203.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE b IN (5.0, 1)
 ----
-·          distributed  false        ·       ·
-·          vectorized   true         ·       ·
-render     ·            ·            (a)     ·
- │         render 0     a            ·       ·
- └── scan  ·            ·            (a, b)  ·
-·          table        t@b_desc     ·       ·
-·          spans        /5-/4 /1-/0  ·       ·
+·          distribution  local        ·       ·
+·          vectorized    true         ·       ·
+render     ·             ·            (a)     ·
+ │         render 0      a            ·       ·
+ └── scan  ·             ·            (a, b)  ·
+·          table         t@b_desc     ·       ·
+·          spans         /5-/4 /1-/0  ·       ·
 
 statement ok
 CREATE TABLE abcd (
@@ -599,24 +599,24 @@ CREATE TABLE abcd (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b FROM abcd WHERE (a, b) = (1, 4)
 ----
-·          distributed  false      ·       ·
-·          vectorized   true       ·       ·
-render     ·            ·          (b)     ·
- │         render 0     b          ·       ·
- └── scan  ·            ·          (a, b)  ·
-·          table        abcd@abcd  ·       ·
-·          spans        /1/4-/1/5  ·       ·
+·          distribution  local      ·       ·
+·          vectorized    true       ·       ·
+render     ·             ·          (b)     ·
+ │         render 0      b          ·       ·
+ └── scan  ·             ·          (a, b)  ·
+·          table         abcd@abcd  ·       ·
+·          spans         /1/4-/1/5  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT b FROM abcd WHERE (a, b) IN ((1, 4), (2, 9))
 ----
-·          distributed  false                 ·       ·
-·          vectorized   true                  ·       ·
-render     ·            ·                     (b)     ·
- │         render 0     b                     ·       ·
- └── scan  ·            ·                     (a, b)  ·
-·          table        abcd@abcd             ·       ·
-·          spans        /1/4-/1/5 /2/9-/2/10  ·       ·
+·          distribution  local                 ·       ·
+·          vectorized    true                  ·       ·
+render     ·             ·                     (b)     ·
+ │         render 0      b                     ·       ·
+ └── scan  ·             ·                     (a, b)  ·
+·          table         abcd@abcd             ·       ·
+·          spans         /1/4-/1/5 /2/9-/2/10  ·       ·
 
 statement ok
 CREATE TABLE ab (
@@ -627,15 +627,15 @@ CREATE TABLE ab (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT i, s FROM ab WHERE (i, s) < (1, 'c')
 ----
-·          distributed  false              ·       ·
-·          vectorized   true               ·       ·
-render     ·            ·                  (i, s)  ·
- │         render 0     i                  ·       ·
- │         render 1     s                  ·       ·
- └── scan  ·            ·                  (s, i)  ·
-·          table        ab@primary         ·       ·
-·          spans        FULL SCAN          ·       ·
-·          filter       (i, s) < (1, 'c')  ·       ·
+·          distribution  local              ·       ·
+·          vectorized    true               ·       ·
+render     ·             ·                  (i, s)  ·
+ │         render 0      i                  ·       ·
+ │         render 1      s                  ·       ·
+ └── scan  ·             ·                  (s, i)  ·
+·          table         ab@primary         ·       ·
+·          spans         FULL SCAN          ·       ·
+·          filter        (i, s) < (1, 'c')  ·       ·
 
 statement ok
 CREATE INDEX baz ON ab (i, s)
@@ -643,15 +643,15 @@ CREATE INDEX baz ON ab (i, s)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT i, s FROM ab@baz WHERE (i, s) < (1, 'c')
 ----
-·          distributed  false              ·       ·
-·          vectorized   true               ·       ·
-render     ·            ·                  (i, s)  ·
- │         render 0     i                  ·       ·
- │         render 1     s                  ·       ·
- └── scan  ·            ·                  (s, i)  ·
-·          table        ab@baz             ·       ·
-·          spans        /!NULL-/1/"c"      ·       ·
-·          filter       (i, s) < (1, 'c')  ·       ·
+·          distribution  local              ·       ·
+·          vectorized    true               ·       ·
+render     ·             ·                  (i, s)  ·
+ │         render 0      i                  ·       ·
+ │         render 1      s                  ·       ·
+ └── scan  ·             ·                  (s, i)  ·
+·          table         ab@baz             ·       ·
+·          spans         /!NULL-/1/"c"      ·       ·
+·          filter        (i, s) < (1, 'c')  ·       ·
 
 # Check that primary key definitions can indicate index ordering,
 # and this information is subsequently used during index selection
@@ -668,22 +668,22 @@ abz  abz_c_b_key  false  3  a  ASC   false  true
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM abz ORDER BY a DESC LIMIT 1
 ----
-·     distributed  false         ·    ·
-·     vectorized   true          ·    ·
-scan  ·            ·             (a)  ·
-·     table        abz@primary   ·    ·
-·     spans        LIMITED SCAN  ·    ·
-·     limit        1             ·    ·
+·     distribution  local         ·    ·
+·     vectorized    true          ·    ·
+scan  ·             ·             (a)  ·
+·     table         abz@primary   ·    ·
+·     spans         LIMITED SCAN  ·    ·
+·     limit         1             ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT c FROM abz ORDER BY c DESC LIMIT 1
 ----
-·     distributed  false            ·    ·
-·     vectorized   true             ·    ·
-scan  ·            ·                (c)  ·
-·     table        abz@abz_c_b_key  ·    ·
-·     spans        LIMITED SCAN     ·    ·
-·     limit        1                ·    ·
+·     distribution  local            ·    ·
+·     vectorized    true             ·    ·
+scan  ·             ·                (c)  ·
+·     table         abz@abz_c_b_key  ·    ·
+·     spans         LIMITED SCAN     ·    ·
+·     limit         1                ·    ·
 
 # Issue #14426: verify we don't have an internal filter that contains "a IN ()"
 # (which causes an error in DistSQL due to expression serialization).
@@ -697,14 +697,14 @@ CREATE TABLE tab0(
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM tab0 WHERE (a IN (6) AND a > 6) OR b >= 4
 ----
-·          distributed  false                                  ·          ·
-·          vectorized   true                                   ·          ·
-render     ·            ·                                      (k)        ·
- │         render 0     k                                      ·          ·
- └── scan  ·            ·                                      (k, a, b)  ·
-·          table        tab0@primary                           ·          ·
-·          spans        FULL SCAN                              ·          ·
-·          filter       ((a IN (6,)) AND (a > 6)) OR (b >= 4)  ·          ·
+·          distribution  local                                  ·          ·
+·          vectorized    true                                   ·          ·
+render     ·             ·                                      (k)        ·
+ │         render 0      k                                      ·          ·
+ └── scan  ·             ·                                      (k, a, b)  ·
+·          table         tab0@primary                           ·          ·
+·          spans         FULL SCAN                              ·          ·
+·          filter        ((a IN (6,)) AND (a > 6)) OR (b >= 4)  ·          ·
 
 # Check that no extraneous rows are fetched due to excessive batching (#15910)
 # The test is composed of three parts: populate a table, check
@@ -724,15 +724,15 @@ INSERT INTO test2(k)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM test2 WHERE k <= '100' ORDER BY k DESC LIMIT 20
 ----
-·             distributed  false                    ·           ·
-·             vectorized   true                     ·           ·
-index-join    ·            ·                        (id, k, v)  -k
- │            table        test2@primary            ·           ·
- │            key columns  id                       ·           ·
- └── revscan  ·            ·                        (id, k)     -k
-·             table        test2@test2_k_key        ·           ·
-·             spans        /!NULL-/"100"/PrefixEnd  ·           ·
-·             limit        20                       ·           ·
+·             distribution  local                    ·           ·
+·             vectorized    true                     ·           ·
+index-join    ·             ·                        (id, k, v)  -k
+ │            table         test2@primary            ·           ·
+ │            key columns   id                       ·           ·
+ └── revscan  ·             ·                        (id, k)     -k
+·             table         test2@test2_k_key        ·           ·
+·             spans         /!NULL-/"100"/PrefixEnd  ·           ·
+·             limit         20                       ·           ·
 
 # The result output of this test requires that vectorized execution
 # is not used, so it has been moved to select_index_vectorize_off.
@@ -781,18 +781,18 @@ AND   f1.resource_key IN ('ts', 'ts2', 'ts3')
 GROUP BY resource_key
 ORDER BY total DESC
 ----
-·                    distributed  false
-·                    vectorized   true
-sort                 ·            ·
- │                   order        -total
- └── group           ·            ·
-      │              aggregate 0  resource_key
-      │              aggregate 1  count_rows()
-      │              group by     resource_key
-      └── render     ·            ·
-           └── scan  ·            ·
-·                    table        favorites@favorites_glob_fav_idx
-·                    spans        /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts"/PrefixEnd /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts2"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts2"/PrefixEnd /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts3"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts3"/PrefixEnd
+·                    distribution  local
+·                    vectorized    true
+sort                 ·             ·
+ │                   order         -total
+ └── group           ·             ·
+      │              aggregate 0   resource_key
+      │              aggregate 1   count_rows()
+      │              group by      resource_key
+      └── render     ·             ·
+           └── scan  ·             ·
+·                    table         favorites@favorites_glob_fav_idx
+·                    spans         /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts"/PrefixEnd /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts2"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts2"/PrefixEnd /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts3"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts3"/PrefixEnd
 
 query TI rowsort
 SELECT
@@ -816,38 +816,38 @@ ts3 1
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL AND b > 5
 ----
-·     distributed  false           ·             ·
-·     vectorized   true            ·             ·
-scan  ·            ·               (a, b, c, d)  ·
-·     table        abcd@abcd       ·             ·
-·     spans        /NULL/6-/!NULL  ·             ·
+·     distribution  local           ·             ·
+·     vectorized    true            ·             ·
+scan  ·             ·               (a, b, c, d)  ·
+·     table         abcd@abcd       ·             ·
+·     spans         /NULL/6-/!NULL  ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL AND b < 5
 ----
-·     distributed  false                ·             ·
-·     vectorized   true                 ·             ·
-scan  ·            ·                    (a, b, c, d)  ·
-·     table        abcd@abcd            ·             ·
-·     spans        /NULL/!NULL-/NULL/5  ·             ·
+·     distribution  local                ·             ·
+·     vectorized    true                 ·             ·
+scan  ·             ·                    (a, b, c, d)  ·
+·     table         abcd@abcd            ·             ·
+·     spans         /NULL/!NULL-/NULL/5  ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL ORDER BY b
 ----
-·     distributed  false         ·             ·
-·     vectorized   true          ·             ·
-scan  ·            ·             (a, b, c, d)  +b
-·     table        abcd@abcd     ·             ·
-·     spans        /NULL-/!NULL  ·             ·
+·     distribution  local         ·             ·
+·     vectorized    true          ·             ·
+scan  ·             ·             (a, b, c, d)  +b
+·     table         abcd@abcd     ·             ·
+·     spans         /NULL-/!NULL  ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a = 1 AND b IS NULL AND c > 0 AND c < 10 ORDER BY c
 ----
-·     distributed  false                 ·             ·
-·     vectorized   true                  ·             ·
-scan  ·            ·                     (a, b, c, d)  +c
-·     table        abcd@abcd             ·             ·
-·     spans        /1/NULL/1-/1/NULL/10  ·             ·
+·     distribution  local                 ·             ·
+·     vectorized    true                  ·             ·
+scan  ·             ·                     (a, b, c, d)  +c
+·     table         abcd@abcd             ·             ·
+·     spans         /1/NULL/1-/1/NULL/10  ·             ·
 
 # Regression test for #3548: verify we create constraints on implicit columns
 # when they are part of the key (non-unique index).
@@ -857,13 +857,13 @@ CREATE TABLE abc (a INT, b INT, c INT, PRIMARY KEY(a,b), INDEX(c))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT c FROM abc WHERE c = 1 and a = 3
 ----
-·          distributed  false          ·       ·
-·          vectorized   true           ·       ·
-render     ·            ·              (c)     ·
- │         render 0     c              ·       ·
- └── scan  ·            ·              (a, c)  ·
-·          table        abc@abc_c_idx  ·       ·
-·          spans        /1/3-/1/4      ·       ·
+·          distribution  local          ·       ·
+·          vectorized    true           ·       ·
+render     ·             ·              (c)     ·
+ │         render 0      c              ·       ·
+ └── scan  ·             ·              (a, c)  ·
+·          table         abc@abc_c_idx  ·       ·
+·          spans         /1/3-/1/4      ·       ·
 
 # Verify we don't create constraints on implicit columns when they may be part
 # of the key (unique index on nullable column).
@@ -873,14 +873,14 @@ CREATE TABLE def (d INT, e INT, f INT, PRIMARY KEY(d,e), UNIQUE INDEX(f))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT f FROM def WHERE f = 1 and d = 3
 ----
-·          distributed  false          ·       ·
-·          vectorized   true           ·       ·
-render     ·            ·              (f)     ·
- │         render 0     f              ·       ·
- └── scan  ·            ·              (d, f)  ·
-·          table        def@def_f_key  ·       ·
-·          spans        /1-/2          ·       ·
-·          filter       d = 3          ·       ·
+·          distribution  local          ·       ·
+·          vectorized    true           ·       ·
+render     ·             ·              (f)     ·
+ │         render 0      f              ·       ·
+ └── scan  ·             ·              (d, f)  ·
+·          table         def@def_f_key  ·       ·
+·          spans         /1-/2          ·       ·
+·          filter        d = 3          ·       ·
 
 statement ok
 DROP TABLE def
@@ -893,24 +893,24 @@ CREATE TABLE def (d INT, e INT, f INT NOT NULL, PRIMARY KEY(d,e), UNIQUE INDEX(f
 query TTTTT
 EXPLAIN (VERBOSE) SELECT f FROM def WHERE f = 1 and d = 3
 ----
-·          distributed  false          ·       ·
-·          vectorized   true           ·       ·
-render     ·            ·              (f)     ·
- │         render 0     f              ·       ·
- └── scan  ·            ·              (d, f)  ·
-·          table        def@def_f_key  ·       ·
-·          spans        /1-/2          ·       ·
-·          filter       d = 3          ·       ·
+·          distribution  local          ·       ·
+·          vectorized    true           ·       ·
+render     ·             ·              (f)     ·
+ │         render 0      f              ·       ·
+ └── scan  ·             ·              (d, f)  ·
+·          table         def@def_f_key  ·       ·
+·          spans         /1-/2          ·       ·
+·          filter        d = 3          ·       ·
 
 # Regression test for #20504.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a, b FROM abc WHERE (a, b) BETWEEN (1, 2) AND (3, 4)
 ----
-·     distributed  false        ·       ·
-·     vectorized   true         ·       ·
-scan  ·            ·            (a, b)  ·
-·     table        abc@primary  ·       ·
-·     spans        /1/2-/3/4/#  ·       ·
+·     distribution  local        ·       ·
+·     vectorized    true         ·       ·
+scan  ·             ·            (a, b)  ·
+·     table         abc@primary  ·       ·
+·     spans         /1/2-/3/4/#  ·       ·
 
 # Regression test for #21831.
 statement ok
@@ -919,31 +919,31 @@ CREATE TABLE str (k INT PRIMARY KEY, v STRING, INDEX(v))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM str WHERE v LIKE 'ABC%'
 ----
-·     distributed  false          ·       ·
-·     vectorized   true           ·       ·
-scan  ·            ·              (k, v)  ·
-·     table        str@str_v_idx  ·       ·
-·     spans        /"ABC"-/"ABD"  ·       ·
+·     distribution  local          ·       ·
+·     vectorized    true           ·       ·
+scan  ·             ·              (k, v)  ·
+·     table         str@str_v_idx  ·       ·
+·     spans         /"ABC"-/"ABD"  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM str WHERE v LIKE 'ABC%Z'
 ----
-·     distributed  false           ·       ·
-·     vectorized   true            ·       ·
-scan  ·            ·               (k, v)  ·
-·     table        str@str_v_idx   ·       ·
-·     spans        /"ABC"-/"ABD"   ·       ·
-·     filter       v LIKE 'ABC%Z'  ·       ·
+·     distribution  local           ·       ·
+·     vectorized    true            ·       ·
+scan  ·             ·               (k, v)  ·
+·     table         str@str_v_idx   ·       ·
+·     spans         /"ABC"-/"ABD"   ·       ·
+·     filter        v LIKE 'ABC%Z'  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v FROM str WHERE v SIMILAR TO 'ABC_*'
 ----
-·     distributed  false                 ·       ·
-·     vectorized   true                  ·       ·
-scan  ·            ·                     (k, v)  ·
-·     table        str@str_v_idx         ·       ·
-·     spans        /"ABC"-/"ABD"         ·       ·
-·     filter       v SIMILAR TO 'ABC_*'  ·       ·
+·     distribution  local                 ·       ·
+·     vectorized    true                  ·       ·
+scan  ·             ·                     (k, v)  ·
+·     table         str@str_v_idx         ·       ·
+·     spans         /"ABC"-/"ABD"         ·       ·
+·     filter        v SIMILAR TO 'ABC_*'  ·       ·
 
 # Test that we generate spans for IS (NOT) DISTINCT FROM.
 statement ok
@@ -952,60 +952,60 @@ CREATE TABLE xy (x INT, y INT, INDEX (y))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM NULL
 ----
-·           distributed  false         ·                   ·
-·           vectorized   true          ·                   ·
-index-join  ·            ·             (x, y)              ·
- │          table        xy@primary    ·                   ·
- │          key columns  rowid         ·                   ·
- └── scan   ·            ·             (y, rowid[hidden])  ·
-·           table        xy@xy_y_idx   ·                   ·
-·           spans        /NULL-/!NULL  ·                   ·
+·           distribution  local         ·                   ·
+·           vectorized    true          ·                   ·
+index-join  ·             ·             (x, y)              ·
+ │          table         xy@primary    ·                   ·
+ │          key columns   rowid         ·                   ·
+ └── scan   ·             ·             (y, rowid[hidden])  ·
+·           table         xy@xy_y_idx   ·                   ·
+·           spans         /NULL-/!NULL  ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM 4
 ----
-·           distributed  false        ·                   ·
-·           vectorized   true         ·                   ·
-index-join  ·            ·            (x, y)              ·
- │          table        xy@primary   ·                   ·
- │          key columns  rowid        ·                   ·
- └── scan   ·            ·            (y, rowid[hidden])  ·
-·           table        xy@xy_y_idx  ·                   ·
-·           spans        /4-/5        ·                   ·
+·           distribution  local        ·                   ·
+·           vectorized    true         ·                   ·
+index-join  ·             ·            (x, y)              ·
+ │          table         xy@primary   ·                   ·
+ │          key columns   rowid        ·                   ·
+ └── scan   ·             ·            (y, rowid[hidden])  ·
+·           table         xy@xy_y_idx  ·                   ·
+·           spans         /4-/5        ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x FROM xy WHERE y > 0 AND y < 2 ORDER BY y
 ----
-·                distributed  false        ·                   ·
-·                vectorized   true         ·                   ·
-render           ·            ·            (x)                 ·
- │               render 0     x            ·                   ·
- └── index-join  ·            ·            (x, y)              ·
-      │          table        xy@primary   ·                   ·
-      │          key columns  rowid        ·                   ·
-      └── scan   ·            ·            (y, rowid[hidden])  ·
-·                table        xy@xy_y_idx  ·                   ·
-·                spans        /1-/2        ·                   ·
+·                distribution  local        ·                   ·
+·                vectorized    true         ·                   ·
+render           ·             ·            (x)                 ·
+ │               render 0      x            ·                   ·
+ └── index-join  ·             ·            (x, y)              ·
+      │          table         xy@primary   ·                   ·
+      │          key columns   rowid        ·                   ·
+      └── scan   ·             ·            (y, rowid[hidden])  ·
+·                table         xy@xy_y_idx  ·                   ·
+·                spans         /1-/2        ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM NULL
 ----
-·     distributed  false          ·       ·
-·     vectorized   true           ·       ·
-scan  ·            ·              (x, y)  ·
-·     table        xy@primary     ·       ·
-·     spans        FULL SCAN      ·       ·
-·     filter       y IS NOT NULL  ·       ·
+·     distribution  local          ·       ·
+·     vectorized    true           ·       ·
+scan  ·             ·              (x, y)  ·
+·     table         xy@primary     ·       ·
+·     spans         FULL SCAN      ·       ·
+·     filter        y IS NOT NULL  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM 4
 ----
-·     distributed  false                 ·       ·
-·     vectorized   true                  ·       ·
-scan  ·            ·                     (x, y)  ·
-·     table        xy@primary            ·       ·
-·     spans        FULL SCAN             ·       ·
-·     filter       y IS DISTINCT FROM 4  ·       ·
+·     distribution  local                 ·       ·
+·     vectorized    true                  ·       ·
+scan  ·             ·                     (x, y)  ·
+·     table         xy@primary            ·       ·
+·     spans         FULL SCAN             ·       ·
+·     filter        y IS DISTINCT FROM 4  ·       ·
 
 # Regression tests for #22670.
 statement ok
@@ -1017,20 +1017,20 @@ INSERT INTO xy VALUES (NULL, NULL), (1, NULL), (NULL, 1), (1, 1)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE x IN (NULL, 1, 2)
 ----
-·     distributed  false      ·       ·
-·     vectorized   true       ·       ·
-scan  ·            ·          (x, y)  ·
-·     table        xy@xy_idx  ·       ·
-·     spans        /1-/3      ·       ·
+·     distribution  local      ·       ·
+·     vectorized    true       ·       ·
+scan  ·             ·          (x, y)  ·
+·     table         xy@xy_idx  ·       ·
+·     spans         /1-/3      ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE (x, y) IN ((NULL, NULL), (1, NULL), (NULL, 1), (1, 1), (1, 2))
 ----
-·     distributed  false      ·       ·
-·     vectorized   true       ·       ·
-scan  ·            ·          (x, y)  ·
-·     table        xy@xy_idx  ·       ·
-·     spans        /1/1-/1/3  ·       ·
+·     distribution  local      ·       ·
+·     vectorized    true       ·       ·
+scan  ·             ·          (x, y)  ·
+·     table         xy@xy_idx  ·       ·
+·     spans         /1/1-/1/3  ·       ·
 
 # ------------------------------------------------------------------------------
 # Non-covering index
@@ -1055,14 +1055,14 @@ INSERT INTO noncover VALUES (1, 2, 3, 4), (5, 6, 7, 8)
 query TTT
 EXPLAIN SELECT * FROM noncover WHERE b = 2
 ----
-·           distributed  false
-·           vectorized   true
-index-join  ·            ·
- │          table        noncover@primary
- │          key columns  a
- └── scan   ·            ·
-·           table        noncover@b
-·           spans        /2-/3
+·           distribution  local
+·           vectorized    true
+index-join  ·             ·
+ │          table         noncover@primary
+ │          key columns   a
+ └── scan   ·             ·
+·           table         noncover@b
+·           spans         /2-/3
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM noncover WHERE b = 2; SET tracing = off
@@ -1082,14 +1082,14 @@ output row: [1 2 3 4]
 query TTT
 EXPLAIN SELECT * FROM noncover WHERE c = 6
 ----
-·           distributed  false
-·           vectorized   true
-index-join  ·            ·
- │          table        noncover@primary
- │          key columns  a
- └── scan   ·            ·
-·           table        noncover@c
-·           spans        /6-/7
+·           distribution  local
+·           vectorized    true
+index-join  ·             ·
+ │          table         noncover@primary
+ │          key columns   a
+ └── scan   ·             ·
+·           table         noncover@c
+·           spans         /6-/7
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM noncover WHERE c = 7; SET tracing = off
@@ -1109,36 +1109,36 @@ output row: [5 6 7 8]
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM noncover WHERE c > 0 ORDER BY c DESC
 ----
-·          distributed  false             ·             ·
-·          vectorized   true              ·             ·
-sort       ·            ·                 (a, b, c, d)  -c
- │         order        -c                ·             ·
- └── scan  ·            ·                 (a, b, c, d)  ·
-·          table        noncover@primary  ·             ·
-·          spans        FULL SCAN         ·             ·
-·          filter       c > 0             ·             ·
+·          distribution  local             ·             ·
+·          vectorized    true              ·             ·
+sort       ·             ·                 (a, b, c, d)  -c
+ │         order         -c                ·             ·
+ └── scan  ·             ·                 (a, b, c, d)  ·
+·          table         noncover@primary  ·             ·
+·          spans         FULL SCAN         ·             ·
+·          filter        c > 0             ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM noncover WHERE c > 0 ORDER BY c
 ----
-·          distributed  false             ·             ·
-·          vectorized   true              ·             ·
-sort       ·            ·                 (a, b, c, d)  +c
- │         order        +c                ·             ·
- └── scan  ·            ·                 (a, b, c, d)  ·
-·          table        noncover@primary  ·             ·
-·          spans        FULL SCAN         ·             ·
-·          filter       c > 0             ·             ·
+·          distribution  local             ·             ·
+·          vectorized    true              ·             ·
+sort       ·             ·                 (a, b, c, d)  +c
+ │         order         +c                ·             ·
+ └── scan  ·             ·                 (a, b, c, d)  ·
+·          table         noncover@primary  ·             ·
+·          spans         FULL SCAN         ·             ·
+·          filter        c > 0             ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM noncover WHERE c > 0 AND d = 8
 ----
-·     distributed  false                ·             ·
-·     vectorized   true                 ·             ·
-scan  ·            ·                    (a, b, c, d)  ·
-·     table        noncover@primary     ·             ·
-·     spans        FULL SCAN            ·             ·
-·     filter       (c > 0) AND (d = 8)  ·             ·
+·     distribution  local                ·             ·
+·     vectorized    true                 ·             ·
+scan  ·             ·                    (a, b, c, d)  ·
+·     table         noncover@primary     ·             ·
+·     spans         FULL SCAN            ·             ·
+·     filter        (c > 0) AND (d = 8)  ·             ·
 
 # The following testcases verify that when we have a small limit, we prefer an
 # order-matching index.
@@ -1146,41 +1146,41 @@ scan  ·            ·                    (a, b, c, d)  ·
 query TTT
 EXPLAIN SELECT * FROM noncover ORDER BY c
 ----
-·          distributed  false
-·          vectorized   true
-sort       ·            ·
- │         order        +c
- └── scan  ·            ·
-·          table        noncover@primary
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+sort       ·             ·
+ │         order         +c
+ └── scan  ·             ·
+·          table         noncover@primary
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM noncover ORDER BY c LIMIT 5
 ----
-·           distributed  false
-·           vectorized   true
-index-join  ·            ·
- │          table        noncover@primary
- │          key columns  a
- └── scan   ·            ·
-·           table        noncover@c
-·           spans        LIMITED SCAN
-·           limit        5
+·           distribution  local
+·           vectorized    true
+index-join  ·             ·
+ │          table         noncover@primary
+ │          key columns   a
+ └── scan   ·             ·
+·           table         noncover@c
+·           spans         LIMITED SCAN
+·           limit         5
 
 query TTT
 SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM noncover ORDER BY c OFFSET 5
 ]
 ----
-·               distributed  false
-·               vectorized   true
-limit           ·            ·
- │              offset       5
- └── sort       ·            ·
-      │         order        +c
-      └── scan  ·            ·
-·               table        noncover@primary
-·               spans        FULL SCAN
+·               distribution  local
+·               vectorized    true
+limit           ·             ·
+ │              offset        5
+ └── sort       ·             ·
+      │         order         +c
+      └── scan  ·             ·
+·               table         noncover@primary
+·               spans         FULL SCAN
 
 # TODO(radu): need to prefer the order-matching index when OFFSET is present.
 query TTT
@@ -1188,32 +1188,32 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM noncover ORDER BY c LIMIT 5 OFFSET 5
 ]
 ----
-·                distributed  false
-·                vectorized   true
-limit            ·            ·
- │               offset       5
- └── index-join  ·            ·
-      │          table        noncover@primary
-      │          key columns  a
-      └── scan   ·            ·
-·                table        noncover@c
-·                spans        LIMITED SCAN
-·                limit        10
+·                distribution  local
+·                vectorized    true
+limit            ·             ·
+ │               offset        5
+ └── index-join  ·             ·
+      │          table         noncover@primary
+      │          key columns   a
+      └── scan   ·             ·
+·                table         noncover@c
+·                spans         LIMITED SCAN
+·                limit         10
 
 query TTT
 SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM noncover ORDER BY c LIMIT 1000000
 ]
 ----
-·               distributed  false
-·               vectorized   true
-limit           ·            ·
- │              count        1000000
- └── sort       ·            ·
-      │         order        +c
-      └── scan  ·            ·
-·               table        noncover@primary
-·               spans        FULL SCAN
+·               distribution  local
+·               vectorized    true
+limit           ·             ·
+ │              count         1000000
+ └── sort       ·             ·
+      │         order         +c
+      └── scan  ·             ·
+·               table         noncover@primary
+·               spans         FULL SCAN
 
 # ------------------------------------------------------------------------------
 # These tests verify that while we are joining an index with the table, we
@@ -1261,15 +1261,15 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM t2 WHERE b = 2 AND c % 2 = 0
 ]
 ----
-·           distributed  false
-·           vectorized   true
-index-join  ·            ·
- │          table        t2@primary
- │          key columns  a
- └── scan   ·            ·
-·           table        t2@bc
-·           spans        /2-/3
-·           filter       (c % 2) = 0
+·           distribution  local
+·           vectorized    true
+index-join  ·             ·
+ │          table         t2@primary
+ │          key columns   a
+ └── scan   ·             ·
+·           table         t2@bc
+·           spans         /2-/3
+·           filter        (c % 2) = 0
 
 # We do NOT look up the table row for '21' and '23'.
 statement ok
@@ -1294,14 +1294,14 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM t2 WHERE b = 2 AND c != b
 ]
 ----
-·           distributed  false
-·           vectorized   true
-index-join  ·            ·
- │          table        t2@primary
- │          key columns  a
- └── scan   ·            ·
-·           table        t2@bc
-·           spans        /2/!NULL-/2/2 /2/3-/3
+·           distribution  local
+·           vectorized    true
+index-join  ·             ·
+ │          table         t2@primary
+ │          key columns   a
+ └── scan   ·             ·
+·           table         t2@bc
+·           spans         /2/!NULL-/2/2 /2/3-/3
 
 # We do NOT look up the table row for '22'.
 statement ok
@@ -1401,16 +1401,16 @@ output row: [9 3 3 '33']
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t2 WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s != 'a') OR (s = 'a')))
 ----
-·                distributed  false       ·          ·
-·                vectorized   true        ·          ·
-render           ·            ·           (a)        ·
- │               render 0     a           ·          ·
- └── index-join  ·            ·           (a, b, s)  ·
-      │          table        t2@primary  ·          ·
-      │          key columns  a           ·          ·
-      └── scan   ·            ·           (a, b)     ·
-·                table        t2@bc       ·          ·
-·                spans        /2-/3       ·          ·
+·                distribution  local       ·          ·
+·                vectorized    true        ·          ·
+render           ·             ·           (a)        ·
+ │               render 0      a           ·          ·
+ └── index-join  ·             ·           (a, b, s)  ·
+      │          table         t2@primary  ·          ·
+      │          key columns   a           ·          ·
+      └── scan   ·             ·           (a, b)     ·
+·                table         t2@bc       ·          ·
+·                spans         /2-/3       ·          ·
 
 statement ok
 CREATE TABLE t3 (k INT PRIMARY KEY, v INT, w INT, INDEX v(v))
@@ -1418,16 +1418,16 @@ CREATE TABLE t3 (k INT PRIMARY KEY, v INT, w INT, INDEX v(v))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT w FROM t3 WHERE v > 0 AND v < 10 ORDER BY v
 ----
-·                distributed  false       ·       ·
-·                vectorized   true        ·       ·
-render           ·            ·           (w)     ·
- │               render 0     w           ·       ·
- └── index-join  ·            ·           (v, w)  +v
-      │          table        t3@primary  ·       ·
-      │          key columns  k           ·       ·
-      └── scan   ·            ·           (k, v)  +v
-·                table        t3@v        ·       ·
-·                spans        /1-/10      ·       ·
+·                distribution  local       ·       ·
+·                vectorized    true        ·       ·
+render           ·             ·           (w)     ·
+ │               render 0      w           ·       ·
+ └── index-join  ·             ·           (v, w)  +v
+      │          table         t3@primary  ·       ·
+      │          key columns   k           ·       ·
+      └── scan   ·             ·           (k, v)  +v
+·                table         t3@v        ·       ·
+·                spans         /1-/10      ·       ·
 
 # ------------------------------------------------------------------------------
 # These tests are for the point lookup optimization: for single row lookups on
@@ -1456,12 +1456,12 @@ INSERT INTO t4 VALUES (10, 20, 30, 40, 50)
 query TTT
 EXPLAIN SELECT c FROM t4 WHERE a = 10 and b = 20
 ----
-·          distributed  false
-·          vectorized   true
-render     ·            ·
- └── scan  ·            ·
-·          table        t4@primary
-·          spans        /10/20/0-/10/20/1/2
+·          distribution  local
+·          vectorized    true
+render     ·             ·
+ └── scan  ·             ·
+·          table         t4@primary
+·          spans         /10/20/0-/10/20/1/2
 
 statement ok
 SET tracing = on,kv,results; SELECT c FROM t4 WHERE a = 10 and b = 20; SET tracing = off
@@ -1479,13 +1479,13 @@ output row: [30]
 query TTT
 EXPLAIN SELECT d FROM t4 WHERE a = 10 and b = 20
 ----
-·          distributed  false
-·          vectorized   true
-render     ·            ·
- └── scan  ·            ·
-·          table        t4@primary
-·          spans        /10/20/0-/10/20/1 /10/20/2/1-/10/20/2/2
-·          parallel     ·
+·          distribution  local
+·          vectorized    true
+render     ·             ·
+ └── scan  ·             ·
+·          table         t4@primary
+·          spans         /10/20/0-/10/20/1 /10/20/2/1-/10/20/2/2
+·          parallel      ·
 
 statement ok
 SET tracing = on,kv,results; SELECT d FROM t4 WHERE a = 10 and b = 20; SET tracing = off
@@ -1504,19 +1504,19 @@ output row: [40]
 query TTT
 EXPLAIN SELECT d, e FROM t4 WHERE a = 10 and b = 20
 ----
-·          distributed  false
-·          vectorized   true
-render     ·            ·
- └── scan  ·            ·
-·          table        t4@primary
-·          spans        /10/20/0-/10/20/1 /10/20/2/1-/10/20/3/2
-·          parallel     ·
+·          distribution  local
+·          vectorized    true
+render     ·             ·
+ └── scan  ·             ·
+·          table         t4@primary
+·          spans         /10/20/0-/10/20/1 /10/20/2/1-/10/20/3/2
+·          parallel      ·
 
 # Optimization should also be applied for updates.
 query TTT
 EXPLAIN UPDATE t4 SET c = 30 WHERE a = 10 and b = 20
 ----
-·                    distributed       false
+·                    distribution      local
 ·                    vectorized        false
 count                ·                 ·
  └── update          ·                 ·
@@ -1534,45 +1534,45 @@ count                ·                 ·
 query TTT
 EXPLAIN DELETE FROM t4 WHERE a = 10 and b = 20
 ----
-·             distributed  false
-·             vectorized   false
-delete range  ·            ·
-·             from         t4
-·             auto commit  ·
-·             spans        /10/20-/10/20/#
+·             distribution  local
+·             vectorized    false
+delete range  ·             ·
+·             from          t4
+·             auto commit   ·
+·             spans         /10/20-/10/20/#
 
 # Optimization should not be applied for non point lookups.
 query TTT
 EXPLAIN SELECT c FROM t4 WHERE a = 10 and b >= 20 and b < 22
 ----
-·          distributed  false
-·          vectorized   true
-render     ·            ·
- └── scan  ·            ·
-·          table        t4@primary
-·          spans        /10/20-/10/21/#
-·          parallel     ·
+·          distribution  local
+·          vectorized    true
+render     ·             ·
+ └── scan  ·             ·
+·          table         t4@primary
+·          spans         /10/20-/10/21/#
+·          parallel      ·
 
 # Optimization should not be applied for partial primary key filter.
 query TTT
 EXPLAIN SELECT c FROM t4 WHERE a = 10
 ----
-·          distributed  false
-·          vectorized   true
-render     ·            ·
- └── scan  ·            ·
-·          table        t4@primary
-·          spans        /10-/11
+·          distribution  local
+·          vectorized    true
+render     ·             ·
+ └── scan  ·             ·
+·          table         t4@primary
+·          spans         /10-/11
 
 # Regression test for #40890: a point lookup on a single column family of a
 # table should still work properly in the face of a constraint disjunction.
 query TTT
 EXPLAIN SELECT a FROM t4 WHERE a in (1, 5) and b in (1, 5)
 ----
-·          distributed  false
-·          vectorized   true
-render     ·            ·
- └── scan  ·            ·
-·          table        t4@primary
-·          spans        /1/1/0-/1/1/1 /1/5/0-/1/5/1 /5/1/0-/5/1/1 /5/5/0-/5/5/1
-·          parallel     ·
+·          distribution  local
+·          vectorized    true
+render     ·             ·
+ └── scan  ·             ·
+·          table         t4@primary
+·          spans         /1/1/0-/1/1/1 /1/5/0-/1/5/1 /5/1/0-/5/1/1 /5/5/0-/5/5/1
+·          parallel      ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
@@ -15,288 +15,288 @@ CREATE TABLE abcd (
 query TTT
 EXPLAIN SELECT * FROM abcd WHERE a >= 20 AND a <= 30
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        abcd@primary
-·     spans        /20-/30/#
-·     parallel     ·
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         abcd@primary
+·     spans         /20-/30/#
+·     parallel      ·
 
 # No hint, reverse scan.
 query TTT
 EXPLAIN SELECT * FROM abcd WHERE a >= 20 AND a <= 30 ORDER BY a DESC
 ----
-·        distributed  false
-·        vectorized   true
-revscan  ·            ·
-·        table        abcd@primary
-·        spans        /20-/30/#
-·        parallel     ·
+·        distribution  local
+·        vectorized    true
+revscan  ·             ·
+·        table         abcd@primary
+·        spans         /20-/30/#
+·        parallel      ·
 
 # Force primary
 query TTT
 EXPLAIN SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        abcd@primary
-·     spans        /20-/30/#
-·     parallel     ·
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         abcd@primary
+·     spans         /20-/30/#
+·     parallel      ·
 
 # Force primary, reverse scan.
 query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=primary,DESC} WHERE a >= 20 AND a <= 30
 ----
-·        distributed  false
-·        vectorized   true
-revscan  ·            ·
-·        table        abcd@primary
-·        spans        /20-/30/#
-·        parallel     ·
+·        distribution  local
+·        vectorized    true
+revscan  ·             ·
+·        table         abcd@primary
+·        spans         /20-/30/#
+·        parallel      ·
 
 # Force primary, allow reverse scan.
 query TTT
 EXPLAIN SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30 ORDER BY a DESC
 ----
-·        distributed  false
-·        vectorized   true
-revscan  ·            ·
-·        table        abcd@primary
-·        spans        /20-/30/#
-·        parallel     ·
+·        distribution  local
+·        vectorized    true
+revscan  ·             ·
+·        table         abcd@primary
+·        spans         /20-/30/#
+·        parallel      ·
 
 # Force primary, forward scan.
 query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=primary,ASC} WHERE a >= 20 AND a <= 30 ORDER BY a DESC
 ----
-·          distributed  false
-·          vectorized   true
-sort       ·            ·
- │         order        -a
- └── scan  ·            ·
-·          table        abcd@primary
-·          spans        /20-/30/#
-·          parallel     ·
+·          distribution  local
+·          vectorized    true
+sort       ·             ·
+ │         order         -a
+ └── scan  ·             ·
+·          table         abcd@primary
+·          spans         /20-/30/#
+·          parallel      ·
 
 # Force index b
 query TTT
 EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
-·                distributed  false
-·                vectorized   true
-filter           ·            ·
- │               filter       (a >= 20) AND (a <= 30)
- └── index-join  ·            ·
-      │          table        abcd@primary
-      │          key columns  a
-      └── scan   ·            ·
-·                table        abcd@b
-·                spans        FULL SCAN
+·                distribution  local
+·                vectorized    true
+filter           ·             ·
+ │               filter        (a >= 20) AND (a <= 30)
+ └── index-join  ·             ·
+      │          table         abcd@primary
+      │          key columns   a
+      └── scan   ·             ·
+·                table         abcd@b
+·                spans         FULL SCAN
 
 # Force index b, reverse scan.
 query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,DESC} WHERE a >= 20 AND a <= 30
 ----
-·                  distributed  false
-·                  vectorized   true
-filter             ·            ·
- │                 filter       (a >= 20) AND (a <= 30)
- └── index-join    ·            ·
-      │            table        abcd@primary
-      │            key columns  a
-      └── revscan  ·            ·
-·                  table        abcd@b
-·                  spans        FULL SCAN
+·                  distribution  local
+·                  vectorized    true
+filter             ·             ·
+ │                 filter        (a >= 20) AND (a <= 30)
+ └── index-join    ·             ·
+      │            table         abcd@primary
+      │            key columns   a
+      └── revscan  ·             ·
+·                  table         abcd@b
+·                  spans         FULL SCAN
 
 # Force index b, allowing reverse scan.
 query TTT
 EXPLAIN SELECT * FROM abcd@b ORDER BY b DESC LIMIT 5
 ----
-·             distributed  false
-·             vectorized   true
-index-join    ·            ·
- │            table        abcd@primary
- │            key columns  a
- └── revscan  ·            ·
-·             table        abcd@b
-·             spans        LIMITED SCAN
-·             limit        5
+·             distribution  local
+·             vectorized    true
+index-join    ·             ·
+ │            table         abcd@primary
+ │            key columns   a
+ └── revscan  ·             ·
+·             table         abcd@b
+·             spans         LIMITED SCAN
+·             limit         5
 
 # Force index b, reverse scan.
 query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,DESC} ORDER BY b DESC LIMIT 5
 ----
-·             distributed  false
-·             vectorized   true
-index-join    ·            ·
- │            table        abcd@primary
- │            key columns  a
- └── revscan  ·            ·
-·             table        abcd@b
-·             spans        LIMITED SCAN
-·             limit        5
+·             distribution  local
+·             vectorized    true
+index-join    ·             ·
+ │            table         abcd@primary
+ │            key columns   a
+ └── revscan  ·             ·
+·             table         abcd@b
+·             spans         LIMITED SCAN
+·             limit         5
 
 
 # Force index b, forward scan.
 query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,ASC} ORDER BY b DESC LIMIT 5
 ----
-·                     distributed  false
-·                     vectorized   true
-limit                 ·            ·
- │                    count        5
- └── sort             ·            ·
-      │               order        -b
-      └── index-join  ·            ·
-           │          table        abcd@primary
-           │          key columns  a
-           └── scan   ·            ·
-·                     table        abcd@b
-·                     spans        FULL SCAN
+·                     distribution  local
+·                     vectorized    true
+limit                 ·             ·
+ │                    count         5
+ └── sort             ·             ·
+      │               order         -b
+      └── index-join  ·             ·
+           │          table         abcd@primary
+           │          key columns   a
+           └── scan   ·             ·
+·                     table         abcd@b
+·                     spans         FULL SCAN
 
 # Force index cd
 query TTT
 EXPLAIN SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 ----
-·                distributed  false
-·                vectorized   true
-filter           ·            ·
- │               filter       (a >= 20) AND (a <= 30)
- └── index-join  ·            ·
-      │          table        abcd@primary
-      │          key columns  a
-      └── scan   ·            ·
-·                table        abcd@cd
-·                spans        FULL SCAN
+·                distribution  local
+·                vectorized    true
+filter           ·             ·
+ │               filter        (a >= 20) AND (a <= 30)
+ └── index-join  ·             ·
+      │          table         abcd@primary
+      │          key columns   a
+      └── scan   ·             ·
+·                table         abcd@cd
+·                spans         FULL SCAN
 
 # Force index bcd
 query TTT
 EXPLAIN SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        abcd@bcd
-·     spans        FULL SCAN
-·     filter       (a >= 20) AND (a <= 30)
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         abcd@bcd
+·     spans         FULL SCAN
+·     filter        (a >= 20) AND (a <= 30)
 
 # Force index b (covering)
 query TTT
 EXPLAIN SELECT b FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
-·          distributed  false
-·          vectorized   true
-render     ·            ·
- └── scan  ·            ·
-·          table        abcd@b
-·          spans        FULL SCAN
-·          filter       (a >= 20) AND (a <= 30)
+·          distribution  local
+·          vectorized    true
+render     ·             ·
+ └── scan  ·             ·
+·          table         abcd@b
+·          spans         FULL SCAN
+·          filter        (a >= 20) AND (a <= 30)
 
 # Force index b (non-covering due to WHERE clause)
 query TTT
 EXPLAIN SELECT b FROM abcd@b WHERE c >= 20 AND c <= 30
 ----
-·                     distributed  false
-·                     vectorized   true
-render                ·            ·
- └── filter           ·            ·
-      │               filter       (c >= 20) AND (c <= 30)
-      └── index-join  ·            ·
-           │          table        abcd@primary
-           │          key columns  a
-           └── scan   ·            ·
-·                     table        abcd@b
-·                     spans        FULL SCAN
+·                     distribution  local
+·                     vectorized    true
+render                ·             ·
+ └── filter           ·             ·
+      │               filter        (c >= 20) AND (c <= 30)
+      └── index-join  ·             ·
+           │          table         abcd@primary
+           │          key columns   a
+           └── scan   ·             ·
+·                     table         abcd@b
+·                     spans         FULL SCAN
 
 # No hint, should be using index cd
 query TTT
 EXPLAIN SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        abcd@cd
-·     spans        /20-/40
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         abcd@cd
+·     spans         /20-/40
 
 # Force primary index
 query TTT
 EXPLAIN SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        abcd@primary
-·     spans        FULL SCAN
-·     filter       (c >= 20) AND (c < 40)
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         abcd@primary
+·     spans         FULL SCAN
+·     filter        (c >= 20) AND (c < 40)
 
 # Force index b
 query TTT
 EXPLAIN SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 ----
-·                distributed  false
-·                vectorized   true
-filter           ·            ·
- │               filter       (c >= 20) AND (c < 40)
- └── index-join  ·            ·
-      │          table        abcd@primary
-      │          key columns  a
-      └── scan   ·            ·
-·                table        abcd@b
-·                spans        FULL SCAN
+·                distribution  local
+·                vectorized    true
+filter           ·             ·
+ │               filter        (c >= 20) AND (c < 40)
+ └── index-join  ·             ·
+      │          table         abcd@primary
+      │          key columns   a
+      └── scan   ·             ·
+·                table         abcd@b
+·                spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b} WHERE a >= 20 AND a <= 30
 ----
-·                distributed  false
-·                vectorized   true
-filter           ·            ·
- │               filter       (a >= 20) AND (a <= 30)
- └── index-join  ·            ·
-      │          table        abcd@primary
-      │          key columns  a
-      └── scan   ·            ·
-·                table        abcd@b
-·                spans        FULL SCAN
+·                distribution  local
+·                vectorized    true
+filter           ·             ·
+ │               filter        (a >= 20) AND (a <= 30)
+ └── index-join  ·             ·
+      │          table         abcd@primary
+      │          key columns   a
+      └── scan   ·             ·
+·                table         abcd@b
+·                spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd WHERE c = 10
 ----
-·           distributed  false
-·           vectorized   true
-index-join  ·            ·
- │          table        abcd@primary
- │          key columns  a
- └── scan   ·            ·
-·           table        abcd@cd
-·           spans        /10-/11
+·           distribution  local
+·           vectorized    true
+index-join  ·             ·
+ │          table         abcd@primary
+ │          key columns   a
+ └── scan   ·             ·
+·           table         abcd@cd
+·           spans         /10-/11
 
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd@{NO_INDEX_JOIN} WHERE c = 10
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        abcd@primary
-·     spans        FULL SCAN
-·     filter       c = 10
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         abcd@primary
+·     spans         FULL SCAN
+·     filter        c = 10
 
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=bcd} WHERE c = 10
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        abcd@bcd
-·     spans        FULL SCAN
-·     filter       c = 10
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         abcd@bcd
+·     spans         FULL SCAN
+·     filter        c = 10
 
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=primary} WHERE c = 10
 ----
-·     distributed  false
-·     vectorized   true
-scan  ·            ·
-·     table        abcd@primary
-·     spans        FULL SCAN
-·     filter       c = 10
+·     distribution  local
+·     vectorized    true
+scan  ·             ·
+·     table         abcd@primary
+·     spans         FULL SCAN
+·     filter        c = 10

--- a/pkg/sql/opt/exec/execbuilder/testdata/spool
+++ b/pkg/sql/opt/exec/execbuilder/testdata/spool
@@ -11,7 +11,7 @@ query TTT
 EXPLAIN WITH a AS (INSERT INTO t SELECT * FROM t2 RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-·                                   distributed   false
+·                                   distribution  local
 ·                                   vectorized    false
 root                                ·             ·
  ├── limit                          ·             ·
@@ -37,7 +37,7 @@ query TTT
 EXPLAIN WITH a AS (DELETE FROM t RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-·                                   distributed   false
+·                                   distribution  local
 ·                                   vectorized    false
 root                                ·             ·
  ├── limit                          ·             ·
@@ -64,7 +64,7 @@ query TTT
 EXPLAIN WITH a AS (UPDATE t SET x = x + 1 RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-·                                        distributed       false
+·                                        distribution      local
 ·                                        vectorized        false
 root                                     ·                 ·
  ├── limit                               ·                 ·
@@ -93,7 +93,7 @@ query TTT
 EXPLAIN WITH a AS (UPSERT INTO t VALUES (2), (3) RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-·                                     distributed   false
+·                                     distribution  local
 ·                                     vectorized    false
 root                                  ·             ·
  ├── limit                            ·             ·
@@ -118,7 +118,7 @@ root                                  ·             ·
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x] LIMIT 1
 ----
-·                                   distributed   false
+·                                   distribution  local
 ·                                   vectorized    false
 root                                ·             ·
  ├── limit                          ·             ·
@@ -143,7 +143,7 @@ root                                ·             ·
 query TTT
 EXPLAIN SELECT * FROM [DELETE FROM t RETURNING x] LIMIT 1
 ----
-·                                   distributed   false
+·                                   distribution  local
 ·                                   vectorized    false
 root                                ·             ·
  ├── limit                          ·             ·
@@ -168,7 +168,7 @@ root                                ·             ·
 query TTT
 EXPLAIN SELECT * FROM [UPDATE t SET x = x + 1 RETURNING x] LIMIT 1
 ----
-·                                        distributed       false
+·                                        distribution      local
 ·                                        vectorized        false
 root                                     ·                 ·
  ├── limit                               ·                 ·
@@ -196,7 +196,7 @@ root                                     ·                 ·
 query TTT
 EXPLAIN SELECT * FROM [UPSERT INTO t VALUES (2), (3) RETURNING x] LIMIT 1
 ----
-·                                     distributed   false
+·                                     distribution  local
 ·                                     vectorized    false
 root                                  ·             ·
  ├── limit                            ·             ·
@@ -221,7 +221,7 @@ root                                  ·             ·
 query TTT
 EXPLAIN SELECT count(*) FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ----
-·                                   distributed   false
+·                                   distribution  local
 ·                                   vectorized    false
 root                                ·             ·
  ├── group                          ·             ·
@@ -248,7 +248,7 @@ root                                ·             ·
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x], t
 ----
-·                                   distributed   false
+·                                   distribution  local
 ·                                   vectorized    false
 root                                ·             ·
  ├── cross-join                     ·             ·
@@ -281,7 +281,7 @@ EXPLAIN WITH a AS (INSERT INTO t SELECT * FROM t2 RETURNING x),
              b AS (INSERT INTO t SELECT x+1 FROM a RETURNING x)
         SELECT * FROM b LIMIT 1
 ----
-·                                                    distributed   false
+·                                                    distribution  local
 ·                                                    vectorized    false
 root                                                 ·             ·
  ├── limit                                           ·             ·
@@ -321,7 +321,7 @@ root                                                 ·             ·
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ----
-·                                   distributed   false
+·                                   distribution  local
 ·                                   vectorized    false
 root                                ·             ·
  ├── scan buffer node               ·             ·
@@ -346,7 +346,7 @@ root                                ·             ·
 query TTT
 EXPLAIN INSERT INTO t SELECT x+1 FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ----
-·                                     distributed   false
+·                                     distribution  local
 ·                                     vectorized    false
 root                                  ·             ·
  ├── count                            ·             ·
@@ -375,7 +375,7 @@ root                                  ·             ·
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x+10] WHERE @1 < 3 LIMIT 10
 ----
-·                                        distributed   false
+·                                        distribution  local
 ·                                        vectorized    false
 root                                     ·             ·
  ├── limit                               ·             ·
@@ -404,7 +404,7 @@ root                                     ·             ·
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x+10] WHERE @1 < 3
 ----
-·                                        distributed   false
+·                                        distribution  local
 ·                                        vectorized    false
 root                                     ·             ·
  ├── filter                              ·             ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
@@ -14,7 +14,7 @@ test.public.my_spatial_table.geom1 SRID:4326 TYPE:POINT DIMS:2
 query TTTTT
 EXPLAIN (VERBOSE) SELECT AddGeometryColumn ('test','public','my_spatial_table','geom1',4326,'POINT',2)
 ----
-·                           distributed    false                                                                               ·                    ·
+·                           distribution   local                                                                               ·                    ·
 ·                           vectorized     false                                                                               ·                    ·
 root                        ·              ·                                                                                   (addgeometrycolumn)  ·
  ├── values                 ·              ·                                                                                   (addgeometrycolumn)  ·
@@ -168,7 +168,7 @@ EXPLAIN (VERBOSE) SELECT
   AddGeometryColumn ('my_spatial_table','geom8',4326,'POINT',2)
 FROM other_table
 ----
-·                           distributed   false                                                               ·                                          ·
+·                           distribution  local                                                               ·                                          ·
 ·                           vectorized    true                                                                ·                                          ·
 root                        ·             ·                                                                   (k, addgeometrycolumn, addgeometrycolumn)  ·
  ├── render                 ·             ·                                                                   (k, addgeometrycolumn, addgeometrycolumn)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -5,38 +5,38 @@ subtest generate_series
 query TTT
 EXPLAIN SELECT * FROM generate_series(1, 3)
 ----
-·              distributed  false
-·              vectorized   true
-project set    ·            ·
- └── emptyrow  ·            ·
+·              distribution  local
+·              vectorized    true
+project set    ·             ·
+ └── emptyrow  ·             ·
 
 query TTT
 EXPLAIN SELECT * FROM generate_series(1, 2), generate_series(1, 2)
 ----
-·                   distributed  false
-·                   vectorized   true
-cross-join          ·            ·
- │                  type         cross
- ├── project set    ·            ·
- │    └── emptyrow  ·            ·
- └── project set    ·            ·
-      └── emptyrow  ·            ·
+·                   distribution  local
+·                   vectorized    true
+cross-join          ·             ·
+ │                  type          cross
+ ├── project set    ·             ·
+ │    └── emptyrow  ·             ·
+ └── project set    ·             ·
+      └── emptyrow  ·             ·
 
 query TTT
 EXPLAIN SELECT * FROM ROWS FROM (cos(1))
 ----
-·              distributed  false
-·              vectorized   true
-project set    ·            ·
- └── emptyrow  ·            ·
+·              distribution  local
+·              vectorized    true
+project set    ·             ·
+ └── emptyrow  ·             ·
 
 query TTT
 EXPLAIN SELECT generate_series(1, 3)
 ----
-·              distributed  false
-·              vectorized   true
-project set    ·            ·
- └── emptyrow  ·            ·
+·              distribution  local
+·              vectorized    true
+project set    ·             ·
+ └── emptyrow  ·             ·
 
 subtest multiple_SRFs
 # See #20511
@@ -44,10 +44,10 @@ subtest multiple_SRFs
 query TTT
 EXPLAIN SELECT generate_series(1, 2), generate_series(1, 2)
 ----
-·              distributed  false
-·              vectorized   true
-project set    ·            ·
- └── emptyrow  ·            ·
+·              distribution  local
+·              vectorized    true
+project set    ·             ·
+ └── emptyrow  ·             ·
 
 statement ok
 CREATE TABLE t (a string)
@@ -58,27 +58,27 @@ CREATE TABLE u (b string)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
 ----
-·                             distributed  false                  ·                                         ·
-·                             vectorized   true                   ·                                         ·
-render                        ·            ·                      (a, b, generate_series, generate_series)  ·
- │                            render 0     a                      ·                                         ·
- │                            render 1     b                      ·                                         ·
- │                            render 2     generate_series        ·                                         ·
- │                            render 3     generate_series        ·                                         ·
- └── cross-join               ·            ·                      (b, generate_series, generate_series, a)  ·
-      │                       type         cross                  ·                                         ·
-      ├── cross-join          ·            ·                      (b, generate_series, generate_series)     ·
-      │    │                  type         cross                  ·                                         ·
-      │    ├── scan           ·            ·                      (b)                                       ·
-      │    │                  table        u@primary              ·                                         ·
-      │    │                  spans        FULL SCAN              ·                                         ·
-      │    └── project set    ·            ·                      (generate_series, generate_series)        ·
-      │         │             render 0     generate_series(1, 2)  ·                                         ·
-      │         │             render 1     generate_series(3, 4)  ·                                         ·
-      │         └── emptyrow  ·            ·                      ()                                        ·
-      └── scan                ·            ·                      (a)                                       ·
-·                             table        t@primary              ·                                         ·
-·                             spans        FULL SCAN              ·                                         ·
+·                             distribution  local                  ·                                         ·
+·                             vectorized    true                   ·                                         ·
+render                        ·             ·                      (a, b, generate_series, generate_series)  ·
+ │                            render 0      a                      ·                                         ·
+ │                            render 1      b                      ·                                         ·
+ │                            render 2      generate_series        ·                                         ·
+ │                            render 3      generate_series        ·                                         ·
+ └── cross-join               ·             ·                      (b, generate_series, generate_series, a)  ·
+      │                       type          cross                  ·                                         ·
+      ├── cross-join          ·             ·                      (b, generate_series, generate_series)     ·
+      │    │                  type          cross                  ·                                         ·
+      │    ├── scan           ·             ·                      (b)                                       ·
+      │    │                  table         u@primary              ·                                         ·
+      │    │                  spans         FULL SCAN              ·                                         ·
+      │    └── project set    ·             ·                      (generate_series, generate_series)        ·
+      │         │             render 0      generate_series(1, 2)  ·                                         ·
+      │         │             render 1      generate_series(3, 4)  ·                                         ·
+      │         └── emptyrow  ·             ·                      ()                                        ·
+      └── scan                ·             ·                      (a)                                       ·
+·                             table         t@primary              ·                                         ·
+·                             spans         FULL SCAN              ·                                         ·
 
 subtest correlated_SRFs
 
@@ -88,15 +88,15 @@ CREATE TABLE data (a INT PRIMARY KEY)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a, generate_series(a, a + 1) FROM data ORDER BY 1, 2
 ----
-·                 distributed  false                        ·                     ·
-·                 vectorized   true                         ·                     ·
-sort              ·            ·                            (a, generate_series)  +a,+generate_series
- │                order        +a,+generate_series          ·                     ·
- └── project set  ·            ·                            (a, generate_series)  ·
-      │           render 0     generate_series(@1, @1 + 1)  ·                     ·
-      └── scan    ·            ·                            (a)                   ·
-·                 table        data@primary                 ·                     ·
-·                 spans        FULL SCAN                    ·                     ·
+·                 distribution  local                        ·                     ·
+·                 vectorized    true                         ·                     ·
+sort              ·             ·                            (a, generate_series)  +a,+generate_series
+ │                order         +a,+generate_series          ·                     ·
+ └── project set  ·             ·                            (a, generate_series)  ·
+      │           render 0      generate_series(@1, @1 + 1)  ·                     ·
+      └── scan    ·             ·                            (a)                   ·
+·                 table         data@primary                 ·                     ·
+·                 spans         FULL SCAN                    ·                     ·
 
 statement ok
 CREATE TABLE xy (x INT PRIMARY KEY, y INT)
@@ -108,7 +108,7 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT x, y, z, information_schema._pg_expandarray(ARRAY[x, y, z])
   FROM xy NATURAL JOIN xz WHERE y < z ORDER BY 1, 2, 3
 ----
-·                               distributed         false                                                  ·                                                ·
+·                               distribution        local                                                  ·                                                ·
 ·                               vectorized          true                                                   ·                                                ·
 render                          ·                   ·                                                      (x, y, z, "information_schema._pg_expandarray")  ·
  │                              render 0            x                                                      ·                                                ·
@@ -141,29 +141,29 @@ render                          ·                   ·                         
 query TTTTT
 EXPLAIN (VERBOSE) SELECT generate_series(x, z) FROM xz WHERE z < ANY(SELECT generate_series(x, y) FROM xy)
 ----
-·                           distributed  false                    ·                        ·
-·                           vectorized   true                     ·                        ·
-render                      ·            ·                        (generate_series)        ·
- │                          render 0     generate_series          ·                        ·
- └── project set            ·            ·                        (x, z, generate_series)  ·
-      │                     render 0     generate_series(@1, @2)  ·                        ·
-      └── cross-join        ·            ·                        (x, z)                   ·
-           │                type         semi                     ·                        ·
-           │                pred         z < generate_series      ·                        ·
-           ├── scan         ·            ·                        (x, z)                   ·
-           │                table        xz@primary               ·                        ·
-           │                spans        FULL SCAN                ·                        ·
-           └── project set  ·            ·                        (x, y, generate_series)  ·
-                │           render 0     generate_series(@1, @2)  ·                        ·
-                └── scan    ·            ·                        (x, y)                   ·
-·                           table        xy@primary               ·                        ·
-·                           spans        FULL SCAN                ·                        ·
+·                           distribution  local                    ·                        ·
+·                           vectorized    true                     ·                        ·
+render                      ·             ·                        (generate_series)        ·
+ │                          render 0      generate_series          ·                        ·
+ └── project set            ·             ·                        (x, z, generate_series)  ·
+      │                     render 0      generate_series(@1, @2)  ·                        ·
+      └── cross-join        ·             ·                        (x, z)                   ·
+           │                type          semi                     ·                        ·
+           │                pred          z < generate_series      ·                        ·
+           ├── scan         ·             ·                        (x, z)                   ·
+           │                table         xz@primary               ·                        ·
+           │                spans         FULL SCAN                ·                        ·
+           └── project set  ·             ·                        (x, y, generate_series)  ·
+                │           render 0      generate_series(@1, @2)  ·                        ·
+                └── scan    ·             ·                        (x, y)                   ·
+·                           table         xy@primary               ·                        ·
+·                           spans         FULL SCAN                ·                        ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT generate_subscripts(ARRAY[0, x, 1, 2]), generate_series(x, y), unnest(ARRAY[0, x, y, z]), y, z
   FROM xy NATURAL LEFT OUTER JOIN xz
 ----
-·                     distributed         false                                    ·                                                           ·
+·                     distribution        local                                    ·                                                           ·
 ·                     vectorized          true                                     ·                                                           ·
 render                ·                   ·                                        (generate_subscripts, generate_series, unnest, y, z)        ·
  │                    render 0            generate_subscripts                      ·                                                           ·
@@ -191,7 +191,7 @@ render                ·                   ·                                   
 query TTTTT
 EXPLAIN (VERBOSE) SELECT generate_series((SELECT unnest(ARRAY[x, y]) FROM xy), z) FROM xz
 ----
-·                               distributed   false                                 ·                     ·
+·                               distribution  local                                 ·                     ·
 ·                               vectorized    true                                  ·                     ·
 root                            ·             ·                                     (generate_series)     ·
  ├── render                     ·             ·                                     (generate_series)     ·
@@ -229,7 +229,7 @@ EXPLAIN (VERBOSE) SELECT
 FROM
   groups g
 ----
-·                                   distributed         false                     ·                                             ·
+·                                   distribution        local                     ·                                             ·
 ·                                   vectorized          true                      ·                                             ·
 render                              ·                   ·                         (group_name, jsonb_array_elements)            ·
  │                                  render 0            data->>'name'             ·                                             ·
@@ -264,11 +264,11 @@ render                              ·                   ·                     
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM ROWS FROM (IF(length('abc') = length('def'), 1, 0))
 ----
-·              distributed  false  ·       ·
-·              vectorized   true   ·       ·
-project set    ·            ·      ("if")  ·
- │             render 0     1      ·       ·
- └── emptyrow  ·            ·      ()      ·
+·              distribution  local  ·       ·
+·              vectorized    true   ·       ·
+project set    ·             ·      ("if")  ·
+ │             render 0      1      ·       ·
+ └── emptyrow  ·             ·      ()      ·
 
 statement ok
 CREATE TABLE articles (
@@ -292,40 +292,40 @@ ORDER BY a0.created_at
    LIMIT 10
   OFFSET 0;
 ----
-·                                     distributed  false                      ·                                                                                        ·
-·                                     vectorized   true                       ·                                                                                        ·
-limit                                 ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          +created_at
- │                                    count        10                         ·                                                                                        ·
- └── sort                             ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          +created_at
-      │                               order        +created_at                ·                                                                                        ·
-      └── group                       ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          ·
-           │                          aggregate 0  id                         ·                                                                                        ·
-           │                          aggregate 1  any_not_null(body)         ·                                                                                        ·
-           │                          aggregate 2  any_not_null(description)  ·                                                                                        ·
-           │                          aggregate 3  any_not_null(title)        ·                                                                                        ·
-           │                          aggregate 4  any_not_null(slug)         ·                                                                                        ·
-           │                          aggregate 5  any_not_null(tag_list)     ·                                                                                        ·
-           │                          aggregate 6  any_not_null(user_id)      ·                                                                                        ·
-           │                          aggregate 7  any_not_null(created_at)   ·                                                                                        ·
-           │                          aggregate 8  any_not_null(updated_at)   ·                                                                                        ·
-           │                          group by     id                         ·                                                                                        ·
-           └── render                 ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          ·
-                │                     render 0     id                         ·                                                                                        ·
-                │                     render 1     body                       ·                                                                                        ·
-                │                     render 2     description                ·                                                                                        ·
-                │                     render 3     title                      ·                                                                                        ·
-                │                     render 4     slug                       ·                                                                                        ·
-                │                     render 5     tag_list                   ·                                                                                        ·
-                │                     render 6     user_id                    ·                                                                                        ·
-                │                     render 7     created_at                 ·                                                                                        ·
-                │                     render 8     updated_at                 ·                                                                                        ·
-                └── filter            ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at, unnest)  ·
-                     │                filter       unnest = 'dragons'         ·                                                                                        ·
-                     └── project set  ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at, unnest)  ·
-                          │           render 0     unnest(@6)                 ·                                                                                        ·
-                          └── scan    ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          ·
-·                                     table        articles@primary           ·                                                                                        ·
-·                                     spans        FULL SCAN                  ·                                                                                        ·
+·                                     distribution  local                      ·                                                                                        ·
+·                                     vectorized    true                       ·                                                                                        ·
+limit                                 ·             ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          +created_at
+ │                                    count         10                         ·                                                                                        ·
+ └── sort                             ·             ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          +created_at
+      │                               order         +created_at                ·                                                                                        ·
+      └── group                       ·             ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          ·
+           │                          aggregate 0   id                         ·                                                                                        ·
+           │                          aggregate 1   any_not_null(body)         ·                                                                                        ·
+           │                          aggregate 2   any_not_null(description)  ·                                                                                        ·
+           │                          aggregate 3   any_not_null(title)        ·                                                                                        ·
+           │                          aggregate 4   any_not_null(slug)         ·                                                                                        ·
+           │                          aggregate 5   any_not_null(tag_list)     ·                                                                                        ·
+           │                          aggregate 6   any_not_null(user_id)      ·                                                                                        ·
+           │                          aggregate 7   any_not_null(created_at)   ·                                                                                        ·
+           │                          aggregate 8   any_not_null(updated_at)   ·                                                                                        ·
+           │                          group by      id                         ·                                                                                        ·
+           └── render                 ·             ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          ·
+                │                     render 0      id                         ·                                                                                        ·
+                │                     render 1      body                       ·                                                                                        ·
+                │                     render 2      description                ·                                                                                        ·
+                │                     render 3      title                      ·                                                                                        ·
+                │                     render 4      slug                       ·                                                                                        ·
+                │                     render 5      tag_list                   ·                                                                                        ·
+                │                     render 6      user_id                    ·                                                                                        ·
+                │                     render 7      created_at                 ·                                                                                        ·
+                │                     render 8      updated_at                 ·                                                                                        ·
+                └── filter            ·             ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at, unnest)  ·
+                     │                filter        unnest = 'dragons'         ·                                                                                        ·
+                     └── project set  ·             ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at, unnest)  ·
+                          │           render 0      unnest(@6)                 ·                                                                                        ·
+                          └── scan    ·             ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          ·
+·                                     table         articles@primary           ·                                                                                        ·
+·                                     spans         FULL SCAN                  ·                                                                                        ·
 
 # Regression test for #32723.
 query TTTTT
@@ -335,7 +335,7 @@ EXPLAIN (VERBOSE)
     FROM
         (SELECT a FROM ((SELECT 1 AS a, 1) EXCEPT ALL (SELECT 0, 0)))
 ----
-·                           distributed    false                            ·                         ·
+·                           distribution   local                            ·                         ·
 ·                           vectorized     false                            ·                         ·
 render                      ·              ·                                (generate_series)         ·
  │                          render 0       generate_series                  ·                         ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -22,12 +22,12 @@ set enable_zigzag_join = false
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-·     distributed  true         ·       ·
-·     vectorized   true         ·       ·
-scan  ·            ·            (u, v)  ·
-·     table        uv@uv_v_idx  ·       ·
-·     spans        /1-/2        ·       ·
-·     filter       u = 1        ·       ·
+·     distribution  full         ·       ·
+·     vectorized    true         ·       ·
+scan  ·             ·            (u, v)  ·
+·     table         uv@uv_v_idx  ·       ·
+·     spans         /1-/2        ·       ·
+·     filter        u = 1        ·       ·
 
 # Verify that injecting different statistics changes the plan.
 statement ok
@@ -49,12 +49,12 @@ ALTER TABLE uv INJECT STATISTICS '[
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-·     distributed  true         ·       ·
-·     vectorized   true         ·       ·
-scan  ·            ·            (u, v)  ·
-·     table        uv@uv_u_idx  ·       ·
-·     spans        /1-/2        ·       ·
-·     filter       v = 1        ·       ·
+·     distribution  full         ·       ·
+·     vectorized    true         ·       ·
+scan  ·             ·            (u, v)  ·
+·     table         uv@uv_u_idx  ·       ·
+·     spans         /1-/2        ·       ·
+·     filter        v = 1        ·       ·
 
 # Verify that injecting different statistics with null counts
 # changes the plan.
@@ -79,12 +79,12 @@ ALTER TABLE uv INJECT STATISTICS '[
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-·     distributed  true         ·       ·
-·     vectorized   true         ·       ·
-scan  ·            ·            (u, v)  ·
-·     table        uv@uv_u_idx  ·       ·
-·     spans        /1-/2        ·       ·
-·     filter       v = 1        ·       ·
+·     distribution  full         ·       ·
+·     vectorized    true         ·       ·
+scan  ·             ·            (u, v)  ·
+·     table         uv@uv_u_idx  ·       ·
+·     spans         /1-/2        ·       ·
+·     filter        v = 1        ·       ·
 
 statement ok
 ALTER TABLE uv INJECT STATISTICS '[
@@ -107,12 +107,12 @@ ALTER TABLE uv INJECT STATISTICS '[
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-·     distributed  true         ·       ·
-·     vectorized   true         ·       ·
-scan  ·            ·            (u, v)  ·
-·     table        uv@uv_v_idx  ·       ·
-·     spans        /1-/2        ·       ·
-·     filter       u = 1        ·       ·
+·     distribution  full         ·       ·
+·     vectorized    true         ·       ·
+scan  ·             ·            (u, v)  ·
+·     table         uv@uv_v_idx  ·       ·
+·     spans         /1-/2        ·       ·
+·     filter        u = 1        ·       ·
 
 statement ok
 ALTER TABLE uv INJECT STATISTICS '[

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -9,7 +9,7 @@ CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
 query TTT
 EXPLAIN ALTER TABLE abc SPLIT AT VALUES ((SELECT 42))
 ----
-·                 distributed   false
+·                 distribution  local
 ·                 vectorized    false
 root              ·             ·
  ├── split        ·             ·
@@ -28,7 +28,7 @@ ALTER TABLE abc SPLIT AT VALUES ((SELECT 1))
 query TTT
 EXPLAIN SELECT EXISTS (SELECT a FROM abc)
 ----
-·               distributed   false
+·               distribution  local
 ·               vectorized    false
 root            ·             ·
  ├── values     ·             ·
@@ -45,7 +45,7 @@ root            ·             ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE a = (SELECT max(a) FROM abc WHERE EXISTS(SELECT * FROM abc WHERE c=a+3))
 ----
-·                            distributed   false                                                                        ·               ·
+·                            distribution  local                                                                        ·               ·
 ·                            vectorized    true                                                                         ·               ·
 root                         ·             ·                                                                            (a, b, c)       ·
  ├── scan                    ·             ·                                                                            (a, b, c)       ·
@@ -80,7 +80,7 @@ root                         ·             ·                                  
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM abc WHERE a IN (SELECT a FROM abc)
 ----
-·           distributed         false        ·    ·
+·           distribution        local        ·    ·
 ·           vectorized          true         ·    ·
 merge-join  ·                   ·            (a)  ·
  │          type                semi         ·    ·
@@ -98,18 +98,18 @@ merge-join  ·                   ·            (a)  ·
 query TTT
 EXPLAIN SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS moo (moo1, moo2, moo3) ORDER BY moo2) as foo (foo1) ORDER BY foo1
 ----
-·            distributed  false
-·            vectorized   false
-sort         ·            ·
- │           order        +foo1
- └── values  ·            ·
-·            size         3 columns, 3 rows
+·            distribution  local
+·            vectorized    false
+sort         ·             ·
+ │           order         +foo1
+ └── values  ·             ·
+·            size          3 columns, 3 rows
 
 # the subquery's plan must be visible in EXPLAIN
 query TTT
 EXPLAIN VALUES (1), ((SELECT 2))
 ----
-·                 distributed   false
+·                 distribution  local
 ·                 vectorized    false
 root              ·             ·
  ├── values       ·             ·
@@ -139,17 +139,17 @@ WHERE
     OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27))
     AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
 ----
-·                distributed  false            ·                                  ·
-·                vectorized   true             ·                                  ·
-render           ·            ·                (col0)                             ·
- │               render 0     col0             ·                                  ·
- └── index-join  ·            ·                (col0, col3, col4, rowid[hidden])  ·
-      │          table        tab4@primary     ·                                  ·
-      │          key columns  rowid            ·                                  ·
-      └── scan   ·            ·                (col0, col4, rowid[hidden])        ·
-·                table        tab4@idx_tab4_0  ·                                  ·
-·                spans        /!NULL-/5.38/1   ·                                  ·
-·                filter       col0 <= 0        ·                                  ·
+·                distribution  local            ·                                  ·
+·                vectorized    true             ·                                  ·
+render           ·             ·                (col0)                             ·
+ │               render 0      col0             ·                                  ·
+ └── index-join  ·             ·                (col0, col3, col4, rowid[hidden])  ·
+      │          table         tab4@primary     ·                                  ·
+      │          key columns   rowid            ·                                  ·
+      └── scan   ·             ·                (col0, col4, rowid[hidden])        ·
+·                table         tab4@idx_tab4_0  ·                                  ·
+·                spans         /!NULL-/5.38/1   ·                                  ·
+·                filter        col0 <= 0        ·                                  ·
 
 # ------------------------------------------------------------------------------
 # Correlated subqueries.
@@ -161,7 +161,7 @@ CREATE TABLE b (x INT PRIMARY KEY, z INT);
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE a.x=b.x)
 ----
-·           distributed         false      ·       ·
+·           distribution        local      ·       ·
 ·           vectorized          true       ·       ·
 merge-join  ·                   ·          (x, y)  ·
  │          type                semi       ·       ·
@@ -179,7 +179,7 @@ merge-join  ·                   ·          (x, y)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE b.x-1 = a.x)
 ----
-·               distributed        false            ·          ·
+·               distribution       local            ·          ·
 ·               vectorized         true             ·          ·
 hash-join       ·                  ·                (x, y)     ·
  │              type               semi             ·          ·
@@ -197,7 +197,7 @@ hash-join       ·                  ·                (x, y)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM b WHERE b.x = a.x)
 ----
-·           distributed         false      ·       ·
+·           distribution        local      ·       ·
 ·           vectorized          true       ·       ·
 merge-join  ·                   ·          (x, y)  ·
  │          type                anti       ·       ·
@@ -215,7 +215,7 @@ merge-join  ·                   ·          (x, y)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM b WHERE NOT EXISTS(SELECT * FROM a WHERE x-1 = b.x)
 ----
-·               distributed        false            ·          ·
+·               distribution       local            ·          ·
 ·               vectorized         true             ·          ·
 hash-join       ·                  ·                (x, z)     ·
  │              type               anti             ·          ·
@@ -233,7 +233,7 @@ hash-join       ·                  ·                (x, z)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY(SELECT x FROM b)
 ----
-·               distributed    false              ·          ·
+·               distribution   local              ·          ·
 ·               vectorized     false              ·          ·
 root            ·              ·                  ("array")  ·
  ├── values     ·              ·                  ("array")  ·
@@ -251,14 +251,14 @@ root            ·              ·                  ("array")  ·
 query TTTTT
 EXPLAIN(verbose) SELECT * FROM abc WHERE EXISTS(SELECT * FROM (VALUES (a), (b)) WHERE column1=a)
 ----
-·           distributed  false        ·          ·
-·           vectorized   false        ·          ·
-apply-join  ·            ·            (a, b, c)  ·
- │          type         semi         ·          ·
- │          pred         column1 = a  ·          ·
- └── scan   ·            ·            (a, b, c)  ·
-·           table        abc@primary  ·          ·
-·           spans        FULL SCAN    ·          ·
+·           distribution  local        ·          ·
+·           vectorized    false        ·          ·
+apply-join  ·             ·            (a, b, c)  ·
+ │          type          semi         ·          ·
+ │          pred          column1 = a  ·          ·
+ └── scan   ·             ·            (a, b, c)  ·
+·           table         abc@primary  ·          ·
+·           spans         FULL SCAN    ·          ·
 
 # Case where the EXISTS subquery still has outer columns in the subquery
 # (regression test for #28816).

--- a/pkg/sql/opt/exec/execbuilder/testdata/tuple
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tuple
@@ -11,68 +11,68 @@ CREATE TABLE uvw (
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) >= (1, 2, 3) ORDER BY u, v, w
 ----
-·     distributed  false              ·          ·
-·     vectorized   true               ·          ·
-scan  ·            ·                  (u, v, w)  +u,+v,+w
-·     table        uvw@uvw_u_v_w_idx  ·          ·
-·     spans        /1/2/3-            ·          ·
+·     distribution  local              ·          ·
+·     vectorized    true               ·          ·
+scan  ·             ·                  (u, v, w)  +u,+v,+w
+·     table         uvw@uvw_u_v_w_idx  ·          ·
+·     spans         /1/2/3-            ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) > (2, 1, 1) ORDER BY u, v, w
 ----
-·     distributed  false              ·          ·
-·     vectorized   true               ·          ·
-scan  ·            ·                  (u, v, w)  +u,+v,+w
-·     table        uvw@uvw_u_v_w_idx  ·          ·
-·     spans        /2/1/2-            ·          ·
+·     distribution  local              ·          ·
+·     vectorized    true               ·          ·
+scan  ·             ·                  (u, v, w)  +u,+v,+w
+·     table         uvw@uvw_u_v_w_idx  ·          ·
+·     spans         /2/1/2-            ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) <= (2, 3, 1) ORDER BY u, v, w
 ----
-·     distributed  false                   ·          ·
-·     vectorized   true                    ·          ·
-scan  ·            ·                       (u, v, w)  +u,+v,+w
-·     table        uvw@uvw_u_v_w_idx       ·          ·
-·     spans        /!NULL-/2/3/2           ·          ·
-·     filter       (u, v, w) <= (2, 3, 1)  ·          ·
+·     distribution  local                   ·          ·
+·     vectorized    true                    ·          ·
+scan  ·             ·                       (u, v, w)  +u,+v,+w
+·     table         uvw@uvw_u_v_w_idx       ·          ·
+·     spans         /!NULL-/2/3/2           ·          ·
+·     filter        (u, v, w) <= (2, 3, 1)  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) < (2, 2, 2) ORDER BY u, v, w
 ----
-·     distributed  false                  ·          ·
-·     vectorized   true                   ·          ·
-scan  ·            ·                      (u, v, w)  +u,+v,+w
-·     table        uvw@uvw_u_v_w_idx      ·          ·
-·     spans        /!NULL-/2/2/2          ·          ·
-·     filter       (u, v, w) < (2, 2, 2)  ·          ·
+·     distribution  local                  ·          ·
+·     vectorized    true                   ·          ·
+scan  ·             ·                      (u, v, w)  +u,+v,+w
+·     table         uvw@uvw_u_v_w_idx      ·          ·
+·     spans         /!NULL-/2/2/2          ·          ·
+·     filter        (u, v, w) < (2, 2, 2)  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) != (1, 2, 3) ORDER BY u, v, w
 ----
-·     distributed  false                   ·          ·
-·     vectorized   true                    ·          ·
-scan  ·            ·                       (u, v, w)  +u,+v,+w
-·     table        uvw@uvw_u_v_w_idx       ·          ·
-·     spans        -/1/2/3 /1/2/4-         ·          ·
-·     filter       (u, v, w) != (1, 2, 3)  ·          ·
+·     distribution  local                   ·          ·
+·     vectorized    true                    ·          ·
+scan  ·             ·                       (u, v, w)  +u,+v,+w
+·     table         uvw@uvw_u_v_w_idx       ·          ·
+·     spans         -/1/2/3 /1/2/4-         ·          ·
+·     filter        (u, v, w) != (1, 2, 3)  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) >= (1, NULL, 3) ORDER BY u, v, w
 ----
-·     distributed  false              ·          ·
-·     vectorized   true               ·          ·
-scan  ·            ·                  (u, v, w)  +u,+v,+w
-·     table        uvw@uvw_u_v_w_idx  ·          ·
-·     spans        /2-                ·          ·
+·     distribution  local              ·          ·
+·     vectorized    true               ·          ·
+scan  ·             ·                  (u, v, w)  +u,+v,+w
+·     table         uvw@uvw_u_v_w_idx  ·          ·
+·     spans         /2-                ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) < (2, NULL, 3) ORDER BY u, v, w
 ----
-·     distributed  false              ·          ·
-·     vectorized   true               ·          ·
-scan  ·            ·                  (u, v, w)  +u,+v,+w
-·     table        uvw@uvw_u_v_w_idx  ·          ·
-·     spans        /!NULL-/2          ·          ·
+·     distribution  local              ·          ·
+·     vectorized    true               ·          ·
+scan  ·             ·                  (u, v, w)  +u,+v,+w
+·     table         uvw@uvw_u_v_w_idx  ·          ·
+·     spans         /!NULL-/2          ·          ·
 
 statement ok
 DROP TABLE uvw
@@ -84,16 +84,16 @@ CREATE TABLE abc (a INT, b INT, c INT, INDEX(a, b))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE (a, b, c) > (1, 2, 3) AND (a,b,c) < (8, 9, 10)
 ----
-·                distributed  false                                                 ·                      ·
-·                vectorized   true                                                  ·                      ·
-filter           ·            ·                                                     (a, b, c)              ·
- │               filter       ((a, b, c) > (1, 2, 3)) AND ((a, b, c) < (8, 9, 10))  ·                      ·
- └── index-join  ·            ·                                                     (a, b, c)              ·
-      │          table        abc@primary                                           ·                      ·
-      │          key columns  rowid                                                 ·                      ·
-      └── scan   ·            ·                                                     (a, b, rowid[hidden])  ·
-·                table        abc@abc_a_b_idx                                       ·                      ·
-·                spans        /1/2-/8/10                                            ·                      ·
+·                distribution  local                                                 ·                      ·
+·                vectorized    true                                                  ·                      ·
+filter           ·             ·                                                     (a, b, c)              ·
+ │               filter        ((a, b, c) > (1, 2, 3)) AND ((a, b, c) < (8, 9, 10))  ·                      ·
+ └── index-join  ·             ·                                                     (a, b, c)              ·
+      │          table         abc@primary                                           ·                      ·
+      │          key columns   rowid                                                 ·                      ·
+      └── scan   ·             ·                                                     (a, b, rowid[hidden])  ·
+·                table         abc@abc_a_b_idx                                       ·                      ·
+·                spans         /1/2-/8/10                                            ·                      ·
 
 statement ok
 DROP TABLE abc
@@ -104,12 +104,12 @@ CREATE TABLE abc (a INT, b INT, c INT, INDEX(a, b DESC, c))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE (a, b, c) > (1, 2, 3)
 ----
-·     distributed  false                  ·          ·
-·     vectorized   true                   ·          ·
-scan  ·            ·                      (a, b, c)  ·
-·     table        abc@abc_a_b_c_idx      ·          ·
-·     spans        /1-                    ·          ·
-·     filter       (a, b, c) > (1, 2, 3)  ·          ·
+·     distribution  local                  ·          ·
+·     vectorized    true                   ·          ·
+scan  ·             ·                      (a, b, c)  ·
+·     table         abc@abc_a_b_c_idx      ·          ·
+·     spans         /1-                    ·          ·
+·     filter        (a, b, c) > (1, 2, 3)  ·          ·
 
 statement ok
 DROP TABLE abc
@@ -122,28 +122,28 @@ CREATE TABLE kv (k INT PRIMARY KEY, v INT)
 query TTTTT
 EXPLAIN (VERBOSE, TYPES) SELECT x FROM (SELECT (row(v,v,v) AS a,b,c) AS x FROM kv)
 ----
-·          distributed  false                                                                               ·                                        ·
-·          vectorized   true                                                                                ·                                        ·
-render     ·            ·                                                                                   (x tuple{int AS a, int AS b, int AS c})  ·
- │         render 0     ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]  ·                                        ·
- └── scan  ·            ·                                                                                   (v int)                                  ·
-·          table        kv@primary                                                                          ·                                        ·
-·          spans        FULL SCAN                                                                           ·                                        ·
+·          distribution  local                                                                               ·                                        ·
+·          vectorized    true                                                                                ·                                        ·
+render     ·             ·                                                                                   (x tuple{int AS a, int AS b, int AS c})  ·
+ │         render 0      ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]  ·                                        ·
+ └── scan  ·             ·                                                                                   (v int)                                  ·
+·          table         kv@primary                                                                          ·                                        ·
+·          spans         FULL SCAN                                                                           ·                                        ·
 
 query TTTTT
 EXPLAIN (VERBOSE, TYPES) SELECT (x).a, (x).b, (x).c FROM (SELECT (row(v,v,v) AS a,b,c) AS x FROM kv)
 ----
-·               distributed  false                                                                               ·                                        ·
-·               vectorized   true                                                                                ·                                        ·
-render          ·            ·                                                                                   (a int, b int, c int)                    ·
- │              render 0     (((x)[tuple{int AS a, int AS b, int AS c}]).a)[int]                                 ·                                        ·
- │              render 1     (((x)[tuple{int AS a, int AS b, int AS c}]).b)[int]                                 ·                                        ·
- │              render 2     (((x)[tuple{int AS a, int AS b, int AS c}]).c)[int]                                 ·                                        ·
- └── render     ·            ·                                                                                   (x tuple{int AS a, int AS b, int AS c})  ·
-      │         render 0     ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]  ·                                        ·
-      └── scan  ·            ·                                                                                   (v int)                                  ·
-·               table        kv@primary                                                                          ·                                        ·
-·               spans        FULL SCAN                                                                           ·                                        ·
+·               distribution  local                                                                               ·                                        ·
+·               vectorized    true                                                                                ·                                        ·
+render          ·             ·                                                                                   (a int, b int, c int)                    ·
+ │              render 0      (((x)[tuple{int AS a, int AS b, int AS c}]).a)[int]                                 ·                                        ·
+ │              render 1      (((x)[tuple{int AS a, int AS b, int AS c}]).b)[int]                                 ·                                        ·
+ │              render 2      (((x)[tuple{int AS a, int AS b, int AS c}]).c)[int]                                 ·                                        ·
+ └── render     ·             ·                                                                                   (x tuple{int AS a, int AS b, int AS c})  ·
+      │         render 0      ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]  ·                                        ·
+      └── scan  ·             ·                                                                                   (v int)                                  ·
+·               table         kv@primary                                                                          ·                                        ·
+·               spans         FULL SCAN                                                                           ·                                        ·
 
 query TTTTT
 EXPLAIN (VERBOSE, TYPES) SELECT (x).e, (x).f, (x).g
@@ -151,7 +151,7 @@ FROM (
   SELECT ((1,'2',true) AS e,f,g) AS x
 )
 ----
-·       distributed    false             ·                          ·
+·       distribution   local             ·                          ·
 ·       vectorized     false             ·                          ·
 values  ·              ·                 (e int, f string, g bool)  ·
 ·       size           3 columns, 1 row  ·                          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -9,41 +9,41 @@ CREATE TABLE uniontest (
 query TTT
 EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 ----
-·          distributed  false
-·          vectorized   true
-union      ·            ·
- ├── scan  ·            ·
- │         table        uniontest@primary
- │         spans        FULL SCAN
- └── scan  ·            ·
-·          table        uniontest@primary
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+union      ·             ·
+ ├── scan  ·             ·
+ │         table         uniontest@primary
+ │         spans         FULL SCAN
+ └── scan  ·             ·
+·          table         uniontest@primary
+·          spans         FULL SCAN
 
 query TTT
 EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
 ----
-·          distributed  false
-·          vectorized   true
-append     ·            ·
- ├── scan  ·            ·
- │         table        uniontest@primary
- │         spans        FULL SCAN
- └── scan  ·            ·
-·          table        uniontest@primary
-·          spans        FULL SCAN
+·          distribution  local
+·          vectorized    true
+append     ·             ·
+ ├── scan  ·             ·
+ │         table         uniontest@primary
+ │         spans         FULL SCAN
+ └── scan  ·             ·
+·          table         uniontest@primary
+·          spans         FULL SCAN
 
 # Check that EXPLAIN properly releases memory for virtual tables.
 query TTT
 EXPLAIN SELECT node_id FROM crdb_internal.node_build_info UNION VALUES(123)
 ----
-·                        distributed  false
-·                        vectorized   false
-union                    ·            ·
- ├── values              ·            ·
- │                       size         1 column, 1 row
- └── render              ·            ·
-      └── virtual table  ·            ·
-·                        source       node_build_info@primary
+·                        distribution  local
+·                        vectorized    false
+union                    ·             ·
+ ├── values              ·             ·
+ │                       size          1 column, 1 row
+ └── render              ·             ·
+      └── virtual table  ·             ·
+·                        source        node_build_info@primary
 
 statement ok
 CREATE TABLE abc (a INT, b INT, c INT)
@@ -51,27 +51,27 @@ CREATE TABLE abc (a INT, b INT, c INT)
 query TTTTT
 EXPLAIN (VERBOSE) (SELECT a FROM abc ORDER BY b) INTERSECT (SELECT a FROM abc ORDER BY c) ORDER BY a
 ----
-·                    distributed  false        ·       ·
-·                    vectorized   true         ·       ·
-sort                 ·            ·            (a)     +a
- │                   order        +a           ·       ·
- └── union           ·            ·            (a)     ·
-      ├── render     ·            ·            (a)     ·
-      │    │         render 0     a            ·       ·
-      │    └── scan  ·            ·            (a, c)  ·
-      │              table        abc@primary  ·       ·
-      │              spans        FULL SCAN    ·       ·
-      └── render     ·            ·            (a)     ·
-           │         render 0     a            ·       ·
-           └── scan  ·            ·            (a, b)  ·
-·                    table        abc@primary  ·       ·
-·                    spans        FULL SCAN    ·       ·
+·                    distribution  local        ·       ·
+·                    vectorized    true         ·       ·
+sort                 ·             ·            (a)     +a
+ │                   order         +a           ·       ·
+ └── union           ·             ·            (a)     ·
+      ├── render     ·             ·            (a)     ·
+      │    │         render 0      a            ·       ·
+      │    └── scan  ·             ·            (a, c)  ·
+      │              table         abc@primary  ·       ·
+      │              spans         FULL SCAN    ·       ·
+      └── render     ·             ·            (a)     ·
+           │         render 0      a            ·       ·
+           └── scan  ·             ·            (a, b)  ·
+·                    table         abc@primary  ·       ·
+·                    spans         FULL SCAN    ·       ·
 
 # Regression test for #32723.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM ((SELECT '' AS a , '') EXCEPT ALL (SELECT '', ''))
 ----
-·                      distributed    false            ·                         ·
+·                      distribution   local            ·                         ·
 ·                      vectorized     false            ·                         ·
 render                 ·              ·                (a)                       ·
  │                     render 0       a                ·                         ·
@@ -93,7 +93,7 @@ query TTTTT
 EXPLAIN (VERBOSE) ((SELECT '', '', 'x' WHERE false))
 UNION ALL ((SELECT '', '', 'x') EXCEPT (VALUES ('', '', 'x')))
 ----
-·                      distributed    false             ·                                     ·
+·                      distribution   local             ·                                     ·
 ·                      vectorized     false             ·                                     ·
 render                 ·              ·                 ("?column?", "?column?", "?column?")  ·
  │                     render 0       "?column?"        ·                                     ·
@@ -118,19 +118,19 @@ query TTTTT
 EXPLAIN (VERBOSE)
 SELECT 1 FROM (SELECT k FROM uniontest WHERE k > 3 UNION ALL SELECT k FROM uniontest)
 ----
-·                    distributed  false              ·             ·
-·                    vectorized   true               ·             ·
-render               ·            ·                  ("?column?")  ·
- │                   render 0     1                  ·             ·
- └── append          ·            ·                  ()            ·
-      ├── scan       ·            ·                  ()            ·
-      │              table        uniontest@primary  ·             ·
-      │              spans        FULL SCAN          ·             ·
-      └── render     ·            ·                  ()            ·
-           └── scan  ·            ·                  (k)           ·
-·                    table        uniontest@primary  ·             ·
-·                    spans        FULL SCAN          ·             ·
-·                    filter       k > 3              ·             ·
+·                    distribution  local              ·             ·
+·                    vectorized    true               ·             ·
+render               ·             ·                  ("?column?")  ·
+ │                   render 0      1                  ·             ·
+ └── append          ·             ·                  ()            ·
+      ├── scan       ·             ·                  ()            ·
+      │              table         uniontest@primary  ·             ·
+      │              spans         FULL SCAN          ·             ·
+      └── render     ·             ·                  ()            ·
+           └── scan  ·             ·                  (k)           ·
+·                    table         uniontest@primary  ·             ·
+·                    spans         FULL SCAN          ·             ·
+·                    filter        k > 3              ·             ·
 
 statement ok
 CREATE TABLE a (a INT PRIMARY KEY)

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -101,7 +101,7 @@ CREATE TABLE xyz (
 query TTT
 EXPLAIN UPDATE xyz SET y = x
 ----
-·                    distributed       false
+·                    distribution      local
 ·                    vectorized        false
 count                ·                 ·
  └── update          ·                 ·
@@ -118,7 +118,7 @@ count                ·                 ·
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (1, 2)
 ----
-·                    distributed       false        ·                        ·
+·                    distribution      local        ·                        ·
 ·                    vectorized        false        ·                        ·
 count                ·                 ·            ()                       ·
  └── update          ·                 ·            ()                       ·
@@ -140,7 +140,7 @@ count                ·                 ·            ()                       �
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (y, x)
 ----
-·                    distributed       false        ·                ·
+·                    distribution      local        ·                ·
 ·                    vectorized        false        ·                ·
 count                ·                 ·            ()               ·
  └── update          ·                 ·            ()               ·
@@ -162,7 +162,7 @@ count                ·                 ·            ()               ·
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (2, 2)
 ----
-·                         distributed       false        ·                        ·
+·                         distribution      local        ·                        ·
 ·                         vectorized        false        ·                        ·
 count                     ·                 ·            ()                       ·
  └── update               ·                 ·            ()                       ·
@@ -232,28 +232,28 @@ CREATE TABLE kv (
 query TTT
 EXPLAIN UPDATE kv SET v = v + 1 ORDER BY v DESC LIMIT 10
 ----
-·                              distributed  false
-·                              vectorized   false
-count                          ·            ·
- └── update                    ·            ·
-      │                        table        kv
-      │                        set          v
-      │                        strategy     updater
-      │                        auto commit  ·
-      └── render               ·            ·
-           └── limit           ·            ·
-                │              count        10
-                └── sort       ·            ·
-                     │         order        -v
-                     └── scan  ·            ·
-·                              table        kv@primary
-·                              spans        FULL SCAN
+·                              distribution  local
+·                              vectorized    false
+count                          ·             ·
+ └── update                    ·             ·
+      │                        table         kv
+      │                        set           v
+      │                        strategy      updater
+      │                        auto commit   ·
+      └── render               ·             ·
+           └── limit           ·             ·
+                │              count         10
+                └── sort       ·             ·
+                     │         order         -v
+                     └── scan  ·             ·
+·                              table         kv@primary
+·                              spans         FULL SCAN
 
 # Use case for UPDATE ... ORDER BY: renumbering a PK without unique violation.
 query TTT
 EXPLAIN UPDATE kv SET v = v - 1 WHERE k < 3 LIMIT 1
 ----
-·                    distributed       false
+·                    distribution      local
 ·                    vectorized        false
 count                ·                 ·
  └── update          ·                 ·
@@ -281,7 +281,7 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) UPDATE tu SET c=c+1
 ]
 ----
-·                    distributed       false
+·                    distribution      local
 ·                    vectorized        false
 count                ·                 ·
  └── update          ·                 ·
@@ -339,7 +339,7 @@ CREATE TABLE abc (a INT, b INT, c INT, INDEX(c) STORING(a,b))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [ UPDATE abc SET a=c RETURNING a ] ORDER BY a
 ----
-·                                             distributed       false                             ·                         ·
+·                                             distribution      local                             ·                         ·
 ·                                             vectorized        false                             ·                         ·
 root                                          ·                 ·                                 (a)                       +a
  ├── sort                                     ·                 ·                                 (a)                       +a
@@ -402,27 +402,27 @@ CREATE TABLE t38799 (a INT PRIMARY KEY, b INT, c INT, INDEX foo(b), FAMILY "prim
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE t38799@foo SET c=2 WHERE a=1
 ----
-·                               distributed  false           ·                 ·
-·                               vectorized   false           ·                 ·
-count                           ·            ·               ()                ·
- └── update                     ·            ·               ()                ·
-      │                         table        t38799          ·                 ·
-      │                         set          c               ·                 ·
-      │                         strategy     updater         ·                 ·
-      │                         auto commit  ·               ·                 ·
-      └── render                ·            ·               (a, b, c, c_new)  ·
-           │                    render 0     a               ·                 ·
-           │                    render 1     b               ·                 ·
-           │                    render 2     c               ·                 ·
-           │                    render 3     2               ·                 ·
-           └── filter           ·            ·               (a, b, c)         ·
-                │               filter       a = 1           ·                 ·
-                └── index-join  ·            ·               (a, b, c)         ·
-                     │          table        t38799@primary  ·                 ·
-                     │          key columns  a               ·                 ·
-                     └── scan   ·            ·               (a, b)            ·
-·                               table        t38799@foo      ·                 ·
-·                               spans        FULL SCAN       ·                 ·
+·                               distribution  local           ·                 ·
+·                               vectorized    false           ·                 ·
+count                           ·             ·               ()                ·
+ └── update                     ·             ·               ()                ·
+      │                         table         t38799          ·                 ·
+      │                         set           c               ·                 ·
+      │                         strategy      updater         ·                 ·
+      │                         auto commit   ·               ·                 ·
+      └── render                ·             ·               (a, b, c, c_new)  ·
+           │                    render 0      a               ·                 ·
+           │                    render 1      b               ·                 ·
+           │                    render 2      c               ·                 ·
+           │                    render 3      2               ·                 ·
+           └── filter           ·             ·               (a, b, c)         ·
+                │               filter        a = 1           ·                 ·
+                └── index-join  ·             ·               (a, b, c)         ·
+                     │          table         t38799@primary  ·                 ·
+                     │          key columns   a               ·                 ·
+                     └── scan   ·             ·               (a, b)            ·
+·                               table         t38799@foo      ·                 ·
+·                               spans         FULL SCAN       ·                 ·
 
 # ------------------------------------------------------------------------------
 # Test without implicit SELECT FOR UPDATE.
@@ -432,7 +432,7 @@ count                           ·            ·               ()               
 query TTT
 EXPLAIN UPDATE kv SET v = 10 WHERE k = 3
 ----
-·                    distributed       false
+·                    distribution      local
 ·                    vectorized        false
 count                ·                 ·
  └── update          ·                 ·
@@ -449,7 +449,7 @@ count                ·                 ·
 query TTT
 EXPLAIN UPDATE kv SET v = k WHERE k > 1 AND k < 10
 ----
-·                    distributed       false
+·                    distribution      local
 ·                    vectorized        false
 count                ·                 ·
  └── update          ·                 ·
@@ -467,7 +467,7 @@ count                ·                 ·
 query TTT
 EXPLAIN UPDATE kv SET v = 10
 ----
-·                    distributed       false
+·                    distribution      local
 ·                    vectorized        false
 count                ·                 ·
  └── update          ·                 ·
@@ -493,7 +493,7 @@ CREATE TABLE kv3 (
 query TTT
 EXPLAIN UPDATE kv3 SET k = 3 WHERE v = 10
 ----
-·                          distributed       false
+·                          distribution      local
 ·                          vectorized        false
 count                      ·                 ·
  └── update                ·                 ·
@@ -513,7 +513,7 @@ count                      ·                 ·
 query TTT
 EXPLAIN UPDATE kv3 SET k = v WHERE v > 1 AND v < 10
 ----
-·                          distributed       false
+·                          distribution      local
 ·                          vectorized        false
 count                      ·                 ·
  └── update                ·                 ·
@@ -536,127 +536,127 @@ SET enable_implicit_select_for_update = false
 query TTT
 EXPLAIN UPDATE kv SET v = 10 WHERE k = 3
 ----
-·                    distributed  false
-·                    vectorized   false
-count                ·            ·
- └── update          ·            ·
-      │              table        kv
-      │              set          v
-      │              strategy     updater
-      │              auto commit  ·
-      └── render     ·            ·
-           └── scan  ·            ·
-·                    table        kv@primary
-·                    spans        /3-/3/#
+·                    distribution  local
+·                    vectorized    false
+count                ·             ·
+ └── update          ·             ·
+      │              table         kv
+      │              set           v
+      │              strategy      updater
+      │              auto commit   ·
+      └── render     ·             ·
+           └── scan  ·             ·
+·                    table         kv@primary
+·                    spans         /3-/3/#
 
 query TTT
 EXPLAIN UPDATE kv SET v = k WHERE k > 1 AND k < 10
 ----
-·                    distributed  false
-·                    vectorized   false
-count                ·            ·
- └── update          ·            ·
-      │              table        kv
-      │              set          v
-      │              strategy     updater
-      │              auto commit  ·
-      └── render     ·            ·
-           └── scan  ·            ·
-·                    table        kv@primary
-·                    spans        /2-/9/#
-·                    parallel     ·
+·                    distribution  local
+·                    vectorized    false
+count                ·             ·
+ └── update          ·             ·
+      │              table         kv
+      │              set           v
+      │              strategy      updater
+      │              auto commit   ·
+      └── render     ·             ·
+           └── scan  ·             ·
+·                    table         kv@primary
+·                    spans         /2-/9/#
+·                    parallel      ·
 
 query TTT
 EXPLAIN UPDATE kv SET v = 10
 ----
-·                    distributed  false
-·                    vectorized   false
-count                ·            ·
- └── update          ·            ·
-      │              table        kv
-      │              set          v
-      │              strategy     updater
-      │              auto commit  ·
-      └── render     ·            ·
-           └── scan  ·            ·
-·                    table        kv@primary
-·                    spans        FULL SCAN
+·                    distribution  local
+·                    vectorized    false
+count                ·             ·
+ └── update          ·             ·
+      │              table         kv
+      │              set           v
+      │              strategy      updater
+      │              auto commit   ·
+      └── render     ·             ·
+           └── scan  ·             ·
+·                    table         kv@primary
+·                    spans         FULL SCAN
 
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (1, 2)
 ----
-·                    distributed  false        ·                        ·
-·                    vectorized   false        ·                        ·
-count                ·            ·            ()                       ·
- └── update          ·            ·            ()                       ·
-      │              table        xyz          ·                        ·
-      │              set          x, y         ·                        ·
-      │              strategy     updater      ·                        ·
-      │              auto commit  ·            ·                        ·
-      └── render     ·            ·            (x, y, z, x_new, y_new)  ·
-           │         render 0     x            ·                        ·
-           │         render 1     y            ·                        ·
-           │         render 2     z            ·                        ·
-           │         render 3     1            ·                        ·
-           │         render 4     2            ·                        ·
-           └── scan  ·            ·            (x, y, z)                ·
-·                    table        xyz@primary  ·                        ·
-·                    spans        FULL SCAN    ·                        ·
+·                    distribution  local        ·                        ·
+·                    vectorized    false        ·                        ·
+count                ·             ·            ()                       ·
+ └── update          ·             ·            ()                       ·
+      │              table         xyz          ·                        ·
+      │              set           x, y         ·                        ·
+      │              strategy      updater      ·                        ·
+      │              auto commit   ·            ·                        ·
+      └── render     ·             ·            (x, y, z, x_new, y_new)  ·
+           │         render 0      x            ·                        ·
+           │         render 1      y            ·                        ·
+           │         render 2      z            ·                        ·
+           │         render 3      1            ·                        ·
+           │         render 4      2            ·                        ·
+           └── scan  ·             ·            (x, y, z)                ·
+·                    table         xyz@primary  ·                        ·
+·                    spans         FULL SCAN    ·                        ·
 
 query TTT
 EXPLAIN UPDATE kv SET v = v - 1 WHERE k < 3 LIMIT 1
 ----
-·                    distributed  false
-·                    vectorized   false
-count                ·            ·
- └── update          ·            ·
-      │              table        kv
-      │              set          v
-      │              strategy     updater
-      │              auto commit  ·
-      └── render     ·            ·
-           └── scan  ·            ·
-·                    table        kv@primary
-·                    spans        -/2/#
-·                    limit        1
+·                    distribution  local
+·                    vectorized    false
+count                ·             ·
+ └── update          ·             ·
+      │              table         kv
+      │              set           v
+      │              strategy      updater
+      │              auto commit   ·
+      └── render     ·             ·
+           └── scan  ·             ·
+·                    table         kv@primary
+·                    spans         -/2/#
+·                    limit         1
 
 query TTT
 EXPLAIN UPDATE kv3 SET k = 3 WHERE v = 10
 ----
-·                          distributed  false
-·                          vectorized   false
-count                      ·            ·
- └── update                ·            ·
-      │                    table        kv3
-      │                    set          k
-      │                    strategy     updater
-      │                    auto commit  ·
-      └── render           ·            ·
-           └── index-join  ·            ·
-                │          table        kv3@primary
-                │          key columns  k
-                └── scan   ·            ·
-·                          table        kv3@kv3_v_idx
-·                          spans        /10-/11
+·                          distribution  local
+·                          vectorized    false
+count                      ·             ·
+ └── update                ·             ·
+      │                    table         kv3
+      │                    set           k
+      │                    strategy      updater
+      │                    auto commit   ·
+      └── render           ·             ·
+           └── index-join  ·             ·
+                │          table         kv3@primary
+                │          key columns   k
+                └── scan   ·             ·
+·                          table         kv3@kv3_v_idx
+·                          spans         /10-/11
 
 query TTT
 EXPLAIN UPDATE kv3 SET k = v WHERE v > 1 AND v < 10
 ----
-·                          distributed  false
-·                          vectorized   false
-count                      ·            ·
- └── update                ·            ·
-      │                    table        kv3
-      │                    set          k
-      │                    strategy     updater
-      │                    auto commit  ·
-      └── render           ·            ·
-           └── index-join  ·            ·
-                │          table        kv3@primary
-                │          key columns  k
-                └── scan   ·            ·
-·                          table        kv3@kv3_v_idx
-·                          spans        /2-/10
+·                          distribution  local
+·                          vectorized    false
+count                      ·             ·
+ └── update                ·             ·
+      │                    table         kv3
+      │                    set           k
+      │                    strategy      updater
+      │                    auto commit   ·
+      └── render           ·             ·
+           └── index-join  ·             ·
+                │          table         kv3@primary
+                │          key columns   k
+                └── scan   ·             ·
+·                          table         kv3@kv3_v_idx
+·                          spans         /2-/10
 
 # Update single column family.
 query TTT
@@ -664,18 +664,18 @@ SELECT tree, field, description FROM [
 EXPLAIN UPDATE tu SET c=c+1
 ]
 ----
-·                    distributed  false
-·                    vectorized   false
-count                ·            ·
- └── update          ·            ·
-      │              table        tu
-      │              set          c
-      │              strategy     updater
-      │              auto commit  ·
-      └── render     ·            ·
-           └── scan  ·            ·
-·                    table        tu@primary
-·                    spans        FULL SCAN
+·                    distribution  local
+·                    vectorized    false
+count                ·             ·
+ └── update          ·             ·
+      │              table         tu
+      │              set           c
+      │              strategy      updater
+      │              auto commit   ·
+      └── render     ·             ·
+           └── scan  ·             ·
+·                    table         tu@primary
+·                    spans         FULL SCAN
 
 # Reset for rest of test.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_from
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_from
@@ -7,7 +7,7 @@ CREATE TABLE abc (a int primary key, b int, c int)
 query TTT
 EXPLAIN UPDATE abc SET b = other.b + 1, c = other.c + 1 FROM abc AS other WHERE abc.a = other.a
 ----
-·                          distributed         false
+·                          distribution        local
 ·                          vectorized          false
 count                      ·                   ·
  └── update                ·                   ·
@@ -36,7 +36,7 @@ CREATE TABLE new_abc (a int, b int, c int)
 query TTT
 EXPLAIN UPDATE abc SET b = other.b, c = other.c FROM new_abc AS other WHERE abc.a = other.a
 ----
-·                              distributed        false
+·                              distribution       local
 ·                              vectorized         false
 count                          ·                  ·
  └── update                    ·                  ·
@@ -70,7 +70,7 @@ WHERE
 RETURNING
   abc.a, abc.b AS new_b, old.b as old_b, abc.c as new_c, old.c as old_c
 ----
-·                               distributed         false
+·                               distribution        local
 ·                               vectorized          false
 render                          ·                   ·
  └── run                        ·                   ·
@@ -97,7 +97,7 @@ render                          ·                   ·
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE abc SET b = old.b + 1, c = old.c + 2 FROM abc AS old WHERE abc.a = old.a RETURNING *
 ----
-·                          distributed         false        ·                                 ·
+·                          distribution        local        ·                                 ·
 ·                          vectorized          false        ·                                 ·
 run                        ·                   ·            (a, b, c, a, b, c)                ·
  └── update                ·                   ·            (a, b, c, a, b, c)                ·
@@ -131,7 +131,7 @@ run                        ·                   ·            (a, b, c, a, b, c)
 query TTT
 EXPLAIN UPDATE abc SET b = other.b, c = other.c FROM (values (1, 2, 3), (2, 3, 4)) as other ("a", "b", "c") WHERE abc.a = other.a
 ----
-·                                distributed            false
+·                                distribution           local
 ·                                vectorized             false
 count                            ·                      ·
  └── update                      ·                      ·
@@ -161,7 +161,7 @@ CREATE TABLE ac (a INT, c INT)
 query TTT
 EXPLAIN UPDATE abc SET b = ab.b, c = ac.c FROM ab, ac WHERE abc.a = ab.a AND abc.a = ac.a
 ----
-·                                   distributed         false
+·                                   distribution        local
 ·                                   vectorized          false
 count                               ·                   ·
  └── update                         ·                   ·
@@ -202,7 +202,7 @@ WHERE
 RETURNING
   *
 ----
-·                                   distributed         false
+·                                   distribution        local
 ·                                   vectorized          false
 run                                 ·                   ·
  └── update                         ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -12,24 +12,24 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) UPSERT INTO kv TABLE kv ORDER BY v DESC LIMIT 2
 ]
 ----
-·                              distributed  false
-·                              vectorized   false
-count                          ·            ·
- └── upsert                    ·            ·
-      │                        into         kv(k, v)
-      │                        strategy     opt upserter
-      │                        auto commit  ·
-      └── render               ·            ·
-           │                   render 0     k
-           │                   render 1     v
-           │                   render 2     v
-           └── limit           ·            ·
-                │              count        2
-                └── sort       ·            ·
-                     │         order        -v
-                     └── scan  ·            ·
-·                              table        kv@primary
-·                              spans        FULL SCAN
+·                              distribution  local
+·                              vectorized    false
+count                          ·             ·
+ └── upsert                    ·             ·
+      │                        into          kv(k, v)
+      │                        strategy      opt upserter
+      │                        auto commit   ·
+      └── render               ·             ·
+           │                   render 0      k
+           │                   render 1      v
+           │                   render 2      v
+           └── limit           ·             ·
+                │              count         2
+                └── sort       ·             ·
+                     │         order         -v
+                     └── scan  ·             ·
+·                              table         kv@primary
+·                              spans         FULL SCAN
 
 # Use explicit target columns (which can use blind KV Put).
 query TTT
@@ -37,24 +37,24 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) UPSERT INTO kv (k, v) TABLE kv ORDER BY v DESC LIMIT 2
 ]
 ----
-·                              distributed  false
-·                              vectorized   false
-count                          ·            ·
- └── upsert                    ·            ·
-      │                        into         kv(k, v)
-      │                        strategy     opt upserter
-      │                        auto commit  ·
-      └── render               ·            ·
-           │                   render 0     k
-           │                   render 1     v
-           │                   render 2     v
-           └── limit           ·            ·
-                │              count        2
-                └── sort       ·            ·
-                     │         order        -v
-                     └── scan  ·            ·
-·                              table        kv@primary
-·                              spans        FULL SCAN
+·                              distribution  local
+·                              vectorized    false
+count                          ·             ·
+ └── upsert                    ·             ·
+      │                        into          kv(k, v)
+      │                        strategy      opt upserter
+      │                        auto commit   ·
+      └── render               ·             ·
+           │                   render 0      k
+           │                   render 1      v
+           │                   render 2      v
+           └── limit           ·             ·
+                │              count         2
+                └── sort       ·             ·
+                     │         order         -v
+                     └── scan  ·             ·
+·                              table         kv@primary
+·                              spans         FULL SCAN
 
 # Add RETURNING clause (should still use blind KV Put).
 query TTT
@@ -62,24 +62,24 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) UPSERT INTO kv (k, v) TABLE kv ORDER BY v DESC LIMIT 2 RETURNING *
 ]
 ----
-·                              distributed  false
-·                              vectorized   false
-run                            ·            ·
- └── upsert                    ·            ·
-      │                        into         kv(k, v)
-      │                        strategy     opt upserter
-      │                        auto commit  ·
-      └── render               ·            ·
-           │                   render 0     k
-           │                   render 1     v
-           │                   render 2     v
-           └── limit           ·            ·
-                │              count        2
-                └── sort       ·            ·
-                     │         order        -v
-                     └── scan  ·            ·
-·                              table        kv@primary
-·                              spans        FULL SCAN
+·                              distribution  local
+·                              vectorized    false
+run                            ·             ·
+ └── upsert                    ·             ·
+      │                        into          kv(k, v)
+      │                        strategy      opt upserter
+      │                        auto commit   ·
+      └── render               ·             ·
+           │                   render 0      k
+           │                   render 1      v
+           │                   render 2      v
+           └── limit           ·             ·
+                │              count         2
+                └── sort       ·             ·
+                     │         order         -v
+                     └── scan  ·             ·
+·                              table         kv@primary
+·                              spans         FULL SCAN
 
 # Use subset of explicit target columns (which cannot use blind KV Put).
 query TTT
@@ -87,7 +87,7 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) UPSERT INTO kv (k) SELECT k FROM kv ORDER BY v DESC LIMIT 2
 ]
 ----
-·                                             distributed            false
+·                                             distribution           local
 ·                                             vectorized             false
 count                                         ·                      ·
  └── upsert                                   ·                      ·
@@ -138,7 +138,7 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) UPSERT INTO indexed VALUES (1)
 ]
 ----
-·                                distributed    false
+·                                distribution   local
 ·                                vectorized     false
 count                            ·              ·
  └── upsert                      ·              ·
@@ -190,7 +190,7 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) UPSERT INTO indexed VALUES (1) RETURNING *
 ]
 ----
-·                      distributed    false
+·                      distribution   local
 ·                      vectorized     false
 run                    ·              ·
  └── upsert            ·              ·
@@ -349,7 +349,7 @@ CREATE TABLE xyz (x INT, y INT, z INT)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM [UPSERT INTO xyz SELECT a, b, c FROM abc RETURNING z] ORDER BY z
 ----
-·                                                  distributed   false                                                ·                            ·
+·                                                  distribution  local                                                ·                            ·
 ·                                                  vectorized    false                                                ·                            ·
 root                                               ·             ·                                                    (z)                          +z
  ├── sort                                          ·             ·                                                    (z)                          +z
@@ -432,7 +432,7 @@ BEGIN; ALTER TABLE table38627 ADD COLUMN c INT NOT NULL DEFAULT 5
 query TTTTT
 EXPLAIN (VERBOSE) UPSERT INTO table38627 SELECT * FROM table38627 WHERE a=1
 ----
-·                           distributed            false               ·                      ·
+·                           distribution           local               ·                      ·
 ·                           vectorized             false               ·                      ·
 count                       ·                      ·                   ()                     ·
  └── upsert                 ·                      ·                   ()                     ·
@@ -472,7 +472,7 @@ query TTTTT
 EXPLAIN (VERBOSE)
 INSERT INTO tdup VALUES (2, 2, 2), (3, 2, 2) ON CONFLICT (z, y) DO UPDATE SET z=1
 ----
-·                                     distributed            false                                        ·                                                  ·
+·                                     distribution           local                                        ·                                                  ·
 ·                                     vectorized             false                                        ·                                                  ·
 count                                 ·                      ·                                            ()                                                 ·
  └── upsert                           ·                      ·                                            ()                                                 ·
@@ -528,7 +528,7 @@ EXPLAIN (VERBOSE)
 INSERT INTO target SELECT x, y, z FROM source WHERE (y IS NULL OR y > 0) AND x <> 1
 ON CONFLICT (b, c) DO UPDATE SET b=5
 ----
-·                                   distributed         false                                  ·                                ·
+·                                   distribution        local                                  ·                                ·
 ·                                   vectorized          false                                  ·                                ·
 count                               ·                   ·                                      ()                               ·
  └── upsert                         ·                   ·                                      ()                               ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/values
+++ b/pkg/sql/opt/exec/execbuilder/testdata/values
@@ -4,7 +4,7 @@
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 a
 ----
-·       distributed    false            ·    ·
+·       distribution   local            ·    ·
 ·       vectorized     false            ·    ·
 values  ·              ·                (a)  ·
 ·       size           1 column, 1 row  ·    ·
@@ -13,7 +13,7 @@ values  ·              ·                (a)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 + 2 a
 ----
-·       distributed    false            ·    ·
+·       distribution   local            ·    ·
 ·       vectorized     false            ·    ·
 values  ·              ·                (a)  ·
 ·       size           1 column, 1 row  ·    ·
@@ -22,7 +22,7 @@ values  ·              ·                (a)  ·
 query TTTTT
 EXPLAIN (VERBOSE) VALUES (1, 2, 3), (4, 5, 6)
 ----
-·       distributed    false              ·                            ·
+·       distribution   local              ·                            ·
 ·       vectorized     false              ·                            ·
 values  ·              ·                  (column1, column2, column3)  ·
 ·       size           3 columns, 2 rows  ·                            ·
@@ -36,7 +36,7 @@ values  ·              ·                  (column1, column2, column3)  ·
 query TTTTT
 EXPLAIN (VERBOSE) VALUES (length('a')), (1 + length('a')), (length('abc')), (length('ab') * 2)
 ----
-·       distributed    false             ·          ·
+·       distribution   local             ·          ·
 ·       vectorized     false             ·          ·
 values  ·              ·                 (column1)  ·
 ·       size           1 column, 4 rows  ·          ·
@@ -48,7 +48,7 @@ values  ·              ·                 (column1)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a + b AS r FROM (VALUES (1, 2), (3, 4), (5, 6)) AS v(a, b)
 ----
-·            distributed    false              ·                   ·
+·            distribution   local              ·                   ·
 ·            vectorized     false              ·                   ·
 render       ·              ·                  (r)                 ·
  │           render 0       column1 + column2  ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -2,21 +2,21 @@
 query TTT
 EXPLAIN SELECT * FROM pg_catalog.pg_class WHERE oid = 50
 ----
-·              distributed  false
-·              vectorized   false
-virtual table  ·            ·
-·              source       pg_class@pg_class_oid_idx
-·              constraint   /2: [/50 - /50]
+·              distribution  local
+·              vectorized    false
+virtual table  ·             ·
+·              source        pg_class@pg_class_oid_idx
+·              constraint    /2: [/50 - /50]
 
 query TTT
 EXPLAIN SELECT * FROM pg_catalog.pg_class WHERE relname = 'blah'
 ----
-·                   distributed  false
-·                   vectorized   false
-filter              ·            ·
- │                  filter       relname = 'blah'
- └── virtual table  ·            ·
-·                   source       pg_class@primary
+·                   distribution  local
+·                   vectorized    false
+filter              ·             ·
+ │                  filter        relname = 'blah'
+ └── virtual table  ·             ·
+·                   source        pg_class@primary
 
 
 # We can push the filter into information_schema.tables, which has an index
@@ -24,11 +24,11 @@ filter              ·            ·
 query TTT
 EXPLAIN SELECT * FROM information_schema.tables WHERE table_name = 'blah'
 ----
-·              distributed  false
-·              vectorized   false
-virtual table  ·            ·
-·              source       tables@tables_table_name_idx
-·              constraint   /4: [/'blah' - /'blah']
+·              distribution  local
+·              vectorized    false
+virtual table  ·             ·
+·              source        tables@tables_table_name_idx
+·              constraint    /4: [/'blah' - /'blah']
 
 # Make sure that if we need an ordering on one of the virtual indexes we
 # provide it using a sortNode even though the optimizer expects the virtual
@@ -36,52 +36,52 @@ virtual table  ·            ·
 query TTT
 EXPLAIN SELECT * FROM information_schema.tables WHERE table_name > 'blah' ORDER BY table_name
 ----
-·                   distributed  false
-·                   vectorized   false
-sort                ·            ·
- │                  order        +table_name
- └── virtual table  ·            ·
-·                   source       tables@tables_table_name_idx
-·                   constraint   /4: [/e'blah\x00' - ]
+·                   distribution  local
+·                   vectorized    false
+sort                ·             ·
+ │                  order         +table_name
+ └── virtual table  ·             ·
+·                   source        tables@tables_table_name_idx
+·                   constraint    /4: [/e'blah\x00' - ]
 
 # Make sure that we properly push down just part of a filter on two columns
 # where only one of them is satisfied by the virtual index.
 query TTT
 EXPLAIN SELECT * FROM information_schema.tables WHERE table_name = 'blah' AND table_type = 'foo'
 ----
-·                   distributed  false
-·                   vectorized   false
-filter              ·            ·
- │                  filter       table_type = 'foo'
- └── virtual table  ·            ·
-·                   source       tables@tables_table_name_idx
-·                   constraint   /4: [/'blah' - /'blah']
+·                   distribution  local
+·                   vectorized    false
+filter              ·             ·
+ │                  filter        table_type = 'foo'
+ └── virtual table  ·             ·
+·                   source        tables@tables_table_name_idx
+·                   constraint    /4: [/'blah' - /'blah']
 
 # Lookup joins into virtual indexes.
 
 query TTT
 EXPLAIN SELECT * FROM pg_constraint INNER LOOKUP JOIN pg_class on conrelid=pg_class.oid
 ----
-·                          distributed  false
-·                          vectorized   false
-virtual-table-lookup-join  ·            ·
- │                         table        pg_class@pg_class_oid_idx
- │                         type         inner
- │                         equality     (conrelid) = (oid)
- └── virtual table         ·            ·
-·                          source       pg_constraint@primary
+·                          distribution  local
+·                          vectorized    false
+virtual-table-lookup-join  ·             ·
+ │                         table         pg_class@pg_class_oid_idx
+ │                         type          inner
+ │                         equality      (conrelid) = (oid)
+ └── virtual table         ·             ·
+·                          source        pg_constraint@primary
 
 query TTT
 EXPLAIN SELECT * FROM pg_constraint LEFT LOOKUP JOIN pg_class on conrelid=pg_class.oid
 ----
-·                          distributed  false
-·                          vectorized   false
-virtual-table-lookup-join  ·            ·
- │                         table        pg_class@pg_class_oid_idx
- │                         type         left outer
- │                         equality     (conrelid) = (oid)
- └── virtual table         ·            ·
-·                          source       pg_constraint@primary
+·                          distribution  local
+·                          vectorized    false
+virtual-table-lookup-join  ·             ·
+ │                         table         pg_class@pg_class_oid_idx
+ │                         type          left outer
+ │                         equality      (conrelid) = (oid)
+ └── virtual table         ·             ·
+·                          source        pg_constraint@primary
 
 # Can't lookup into a vtable with no index.
 query error could not produce
@@ -113,43 +113,43 @@ WHERE
 ORDER BY
         c.conname
 ----
-·                                                                          distributed  false
-·                                                                          vectorized   false
-render                                                                     ·            ·
- └── sort                                                                  ·            ·
-      │                                                                    order        +conname
-      └── render                                                           ·            ·
-           └── hash-join                                                   ·            ·
-                │                                                          type         inner
-                │                                                          equality     (oid) = (connamespace)
-                ├── filter                                                 ·            ·
-                │    │                                                     filter       nspname = ANY ARRAY['public']
-                │    └── render                                            ·            ·
-                │         └── virtual table                                ·            ·
-                │                                                          source       pg_namespace@primary
-                └── virtual-table-lookup-join                              ·            ·
-                     │                                                     table        pg_attribute@pg_attribute_attrelid_idx
-                     │                                                     type         inner
-                     │                                                     equality     (oid) = (attrelid)
-                     │                                                     pred         column131 = attnum
-                     └── render                                            ·            ·
-                          └── virtual-table-lookup-join                    ·            ·
-                               │                                           table        pg_attribute@pg_attribute_attrelid_idx
-                               │                                           type         inner
-                               │                                           equality     (oid) = (attrelid)
-                               │                                           pred         (column108 = attnum) AND (attrelid = 'b'::REGCLASS)
-                               └── render                                  ·            ·
-                                    └── virtual-table-lookup-join          ·            ·
-                                         │                                 table        pg_class@pg_class_oid_idx
-                                         │                                 type         inner
-                                         │                                 equality     (conrelid) = (oid)
-                                         │                                 pred         oid = 'b'::REGCLASS
-                                         └── virtual-table-lookup-join     ·            ·
-                                              │                            table        pg_class@pg_class_oid_idx
-                                              │                            type         inner
-                                              │                            equality     (confrelid) = (oid)
-                                              └── filter                   ·            ·
-                                                   │                       filter       (conrelid = 'b'::REGCLASS) AND (contype = 'f')
-                                                   └── render              ·            ·
-                                                        └── virtual table  ·            ·
-·                                                                          source       pg_constraint@primary
+·                                                                          distribution  local
+·                                                                          vectorized    false
+render                                                                     ·             ·
+ └── sort                                                                  ·             ·
+      │                                                                    order         +conname
+      └── render                                                           ·             ·
+           └── hash-join                                                   ·             ·
+                │                                                          type          inner
+                │                                                          equality      (oid) = (connamespace)
+                ├── filter                                                 ·             ·
+                │    │                                                     filter        nspname = ANY ARRAY['public']
+                │    └── render                                            ·             ·
+                │         └── virtual table                                ·             ·
+                │                                                          source        pg_namespace@primary
+                └── virtual-table-lookup-join                              ·             ·
+                     │                                                     table         pg_attribute@pg_attribute_attrelid_idx
+                     │                                                     type          inner
+                     │                                                     equality      (oid) = (attrelid)
+                     │                                                     pred          column131 = attnum
+                     └── render                                            ·             ·
+                          └── virtual-table-lookup-join                    ·             ·
+                               │                                           table         pg_attribute@pg_attribute_attrelid_idx
+                               │                                           type          inner
+                               │                                           equality      (oid) = (attrelid)
+                               │                                           pred          (column108 = attnum) AND (attrelid = 'b'::REGCLASS)
+                               └── render                                  ·             ·
+                                    └── virtual-table-lookup-join          ·             ·
+                                         │                                 table         pg_class@pg_class_oid_idx
+                                         │                                 type          inner
+                                         │                                 equality      (conrelid) = (oid)
+                                         │                                 pred          oid = 'b'::REGCLASS
+                                         └── virtual-table-lookup-join     ·             ·
+                                              │                            table         pg_class@pg_class_oid_idx
+                                              │                            type          inner
+                                              │                            equality      (confrelid) = (oid)
+                                              └── filter                   ·             ·
+                                                   │                       filter        (conrelid = 'b'::REGCLASS) AND (contype = 'f')
+                                                   └── render              ·             ·
+                                                        └── virtual table  ·             ·
+·                                                                          source        pg_constraint@primary

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -58,35 +58,35 @@ output row: [8 3.5355339059327376220]
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ntile(1) OVER () FROM kv
 ----
-·                    distributed  false                                                               ·                      ·
-·                    vectorized   true                                                                ·                      ·
-render               ·            ·                                                                   (ntile)                ·
- │                   render 0     ntile                                                               ·                      ·
- └── window          ·            ·                                                                   (ntile_1_arg1, ntile)  ·
-      │              window 0     ntile(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                      ·
-      │              render 1     ntile(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                      ·
-      └── render     ·            ·                                                                   (ntile_1_arg1)         ·
-           │         render 0     1                                                                   ·                      ·
-           └── scan  ·            ·                                                                   ()                     ·
-·                    table        kv@primary                                                          ·                      ·
-·                    spans        FULL SCAN                                                           ·                      ·
+·                    distribution  local                                                               ·                      ·
+·                    vectorized    true                                                                ·                      ·
+render               ·             ·                                                                   (ntile)                ·
+ │                   render 0      ntile                                                               ·                      ·
+ └── window          ·             ·                                                                   (ntile_1_arg1, ntile)  ·
+      │              window 0      ntile(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                      ·
+      │              render 1      ntile(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                      ·
+      └── render     ·             ·                                                                   (ntile_1_arg1)         ·
+           │         render 0      1                                                                   ·                      ·
+           └── scan  ·             ·                                                                   ()                     ·
+·                    table         kv@primary                                                          ·                      ·
+·                    spans         FULL SCAN                                                           ·                      ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT nth_value(1, 2) OVER () FROM kv
 ----
-·                    distributed  false                                                                       ·                                                ·
-·                    vectorized   true                                                                        ·                                                ·
-render               ·            ·                                                                           (nth_value)                                      ·
- │                   render 0     nth_value                                                                   ·                                                ·
- └── window          ·            ·                                                                           (nth_value_1_arg1, nth_value_1_arg2, nth_value)  ·
-      │              window 0     nth_value(@1, @2) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                                                ·
-      │              render 2     nth_value(@1, @2) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                                                ·
-      └── render     ·            ·                                                                           (nth_value_1_arg1, nth_value_1_arg2)             ·
-           │         render 0     1                                                                           ·                                                ·
-           │         render 1     2                                                                           ·                                                ·
-           └── scan  ·            ·                                                                           ()                                               ·
-·                    table        kv@primary                                                                  ·                                                ·
-·                    spans        FULL SCAN                                                                   ·                                                ·
+·                    distribution  local                                                                       ·                                                ·
+·                    vectorized    true                                                                        ·                                                ·
+render               ·             ·                                                                           (nth_value)                                      ·
+ │                   render 0      nth_value                                                                   ·                                                ·
+ └── window          ·             ·                                                                           (nth_value_1_arg1, nth_value_1_arg2, nth_value)  ·
+      │              window 0      nth_value(@1, @2) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                                                ·
+      │              render 2      nth_value(@1, @2) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                                                ·
+      └── render     ·             ·                                                                           (nth_value_1_arg1, nth_value_1_arg2)             ·
+           │         render 0      1                                                                           ·                                                ·
+           │         render 1      2                                                                           ·                                                ·
+           └── scan  ·             ·                                                                           ()                                               ·
+·                    table         kv@primary                                                                  ·                                                ·
+·                    spans         FULL SCAN                                                                   ·                                                ·
 
 statement error column "v" must appear in the GROUP BY clause or be used in an aggregate function
 EXPLAIN (VERBOSE) SELECT max(v) OVER (), min(v) FROM kv ORDER BY 1
@@ -94,200 +94,200 @@ EXPLAIN (VERBOSE) SELECT max(v) OVER (), min(v) FROM kv ORDER BY 1
 query TTT
 EXPLAIN SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
-·                         distributed  false
-·                         vectorized   true
-render                    ·            ·
- └── sort                 ·            ·
-      │                   order        +variance,+k
-      └── render          ·            ·
-           └── window     ·            ·
-                └── scan  ·            ·
-·                         table        kv@primary
-·                         spans        FULL SCAN
+·                         distribution  local
+·                         vectorized    true
+render                    ·             ·
+ └── sort                 ·             ·
+      │                   order         +variance,+k
+      └── render          ·             ·
+           └── window     ·             ·
+                └── scan  ·             ·
+·                         table         kv@primary
+·                         spans         FULL SCAN
 
 query TTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
-·                         distributed  false                                                                                                               ·                                                            ·
-·                         vectorized   true                                                                                                                ·                                                            ·
-render                    ·            ·                                                                                                                   (k int, stddev decimal)                                      ·
- │                        render 0     (k)[int]                                                                                                            ·                                                            ·
- │                        render 1     (stddev)[decimal]                                                                                                   ·                                                            ·
- └── sort                 ·            ·                                                                                                                   (k int, stddev decimal, variance decimal)                    +variance,+k
-      │                   order        +variance,+k                                                                                                        ·                                                            ·
-      └── render          ·            ·                                                                                                                   (k int, stddev decimal, variance decimal)                    ·
-           │              render 0     (k)[int]                                                                                                            ·                                                            ·
-           │              render 1     (stddev)[decimal]                                                                                                   ·                                                            ·
-           │              render 2     (variance)[decimal]                                                                                                 ·                                                            ·
-           └── window     ·            ·                                                                                                                   (k int, v int, d decimal, stddev decimal, variance decimal)  ·
-                │         window 0     (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
-                │         window 1     (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
-                │         render 3     (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
-                │         render 4     (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
-                └── scan  ·            ·                                                                                                                   (k int, v int, d decimal)                                    ·
-·                         table        kv@primary                                                                                                          ·                                                            ·
-·                         spans        FULL SCAN                                                                                                           ·                                                            ·
+·                         distribution  local                                                                                                               ·                                                            ·
+·                         vectorized    true                                                                                                                ·                                                            ·
+render                    ·             ·                                                                                                                   (k int, stddev decimal)                                      ·
+ │                        render 0      (k)[int]                                                                                                            ·                                                            ·
+ │                        render 1      (stddev)[decimal]                                                                                                   ·                                                            ·
+ └── sort                 ·             ·                                                                                                                   (k int, stddev decimal, variance decimal)                    +variance,+k
+      │                   order         +variance,+k                                                                                                        ·                                                            ·
+      └── render          ·             ·                                                                                                                   (k int, stddev decimal, variance decimal)                    ·
+           │              render 0      (k)[int]                                                                                                            ·                                                            ·
+           │              render 1      (stddev)[decimal]                                                                                                   ·                                                            ·
+           │              render 2      (variance)[decimal]                                                                                                 ·                                                            ·
+           └── window     ·             ·                                                                                                                   (k int, v int, d decimal, stddev decimal, variance decimal)  ·
+                │         window 0      (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
+                │         window 1      (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
+                │         render 3      (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
+                │         render 4      (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
+                └── scan  ·             ·                                                                                                                   (k int, v int, d decimal)                                    ·
+·                         table         kv@primary                                                                                                          ·                                                            ·
+·                         spans         FULL SCAN                                                                                                           ·                                                            ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-·                              distributed  false                                                                                                               ·                                                            ·
-·                              vectorized   true                                                                                                                ·                                                            ·
-render                         ·            ·                                                                                                                   (k int, stddev decimal)                                      ·
- │                             render 0     (k)[int]                                                                                                            ·                                                            ·
- │                             render 1     (stddev)[decimal]                                                                                                   ·                                                            ·
- └── sort                      ·            ·                                                                                                                   (k int, stddev decimal, variance decimal)                    +variance,+k
-      │                        order        +variance,+k                                                                                                        ·                                                            ·
-      └── render               ·            ·                                                                                                                   (k int, stddev decimal, variance decimal)                    ·
-           │                   render 0     (k)[int]                                                                                                            ·                                                            ·
-           │                   render 1     (stddev)[decimal]                                                                                                   ·                                                            ·
-           │                   render 2     (variance)[decimal]                                                                                                 ·                                                            ·
-           └── window          ·            ·                                                                                                                   (k int, v int, d decimal, stddev decimal, variance decimal)  ·
-                │              window 0     (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
-                │              render 4     (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
-                └── window     ·            ·                                                                                                                   (k int, v int, d decimal, stddev decimal)                    ·
-                     │         window 0     (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
-                     │         render 3     (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
-                     └── scan  ·            ·                                                                                                                   (k int, v int, d decimal)                                    ·
-·                              table        kv@primary                                                                                                          ·                                                            ·
-·                              spans        FULL SCAN                                                                                                           ·                                                            ·
+·                              distribution  local                                                                                                               ·                                                            ·
+·                              vectorized    true                                                                                                                ·                                                            ·
+render                         ·             ·                                                                                                                   (k int, stddev decimal)                                      ·
+ │                             render 0      (k)[int]                                                                                                            ·                                                            ·
+ │                             render 1      (stddev)[decimal]                                                                                                   ·                                                            ·
+ └── sort                      ·             ·                                                                                                                   (k int, stddev decimal, variance decimal)                    +variance,+k
+      │                        order         +variance,+k                                                                                                        ·                                                            ·
+      └── render               ·             ·                                                                                                                   (k int, stddev decimal, variance decimal)                    ·
+           │                   render 0      (k)[int]                                                                                                            ·                                                            ·
+           │                   render 1      (stddev)[decimal]                                                                                                   ·                                                            ·
+           │                   render 2      (variance)[decimal]                                                                                                 ·                                                            ·
+           └── window          ·             ·                                                                                                                   (k int, v int, d decimal, stddev decimal, variance decimal)  ·
+                │              window 0      (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
+                │              render 4      (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
+                └── window     ·             ·                                                                                                                   (k int, v int, d decimal, stddev decimal)                    ·
+                     │         window 0      (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
+                     │         render 3      (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
+                     └── scan  ·             ·                                                                                                                   (k int, v int, d decimal)                                    ·
+·                              table         kv@primary                                                                                                          ·                                                            ·
+·                              spans         FULL SCAN                                                                                                           ·                                                            ·
 
 query TTTTT
 EXPLAIN (TYPES,NONORMALIZE) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY k
 ----
-·                    distributed  false                                                                                                             ·                                          ·
-·                    vectorized   true                                                                                                              ·                                          ·
-sort                 ·            ·                                                                                                                 (k int, stddev decimal)                    +k
- │                   order        +k                                                                                                                ·                                          ·
- └── render          ·            ·                                                                                                                 (k int, stddev decimal)                    ·
-      │              render 0     (k)[int]                                                                                                          ·                                          ·
-      │              render 1     (stddev)[decimal]                                                                                                 ·                                          ·
-      └── window     ·            ·                                                                                                                 (k int, v int, d decimal, stddev decimal)  ·
-           │         window 0     (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                          ·
-           │         render 3     (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                          ·
-           └── scan  ·            ·                                                                                                                 (k int, v int, d decimal)                  ·
-·                    table        kv@primary                                                                                                        ·                                          ·
-·                    spans        FULL SCAN                                                                                                         ·                                          ·
+·                    distribution  local                                                                                                             ·                                          ·
+·                    vectorized    true                                                                                                              ·                                          ·
+sort                 ·             ·                                                                                                                 (k int, stddev decimal)                    +k
+ │                   order         +k                                                                                                                ·                                          ·
+ └── render          ·             ·                                                                                                                 (k int, stddev decimal)                    ·
+      │              render 0      (k)[int]                                                                                                          ·                                          ·
+      │              render 1      (stddev)[decimal]                                                                                                 ·                                          ·
+      └── window     ·             ·                                                                                                                 (k int, v int, d decimal, stddev decimal)  ·
+           │         window 0      (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                          ·
+           │         render 3      (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                          ·
+           └── scan  ·             ·                                                                                                                 (k int, v int, d decimal)                  ·
+·                    table         kv@primary                                                                                                        ·                                          ·
+·                    spans         FULL SCAN                                                                                                         ·                                          ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-·                              distributed  false                                                                                                               ·                                                            ·
-·                              vectorized   true                                                                                                                ·                                                            ·
-render                         ·            ·                                                                                                                   (k int, "?column?" decimal)                                  ·
- │                             render 0     (k)[int]                                                                                                            ·                                                            ·
- │                             render 1     ("?column?")[decimal]                                                                                               ·                                                            ·
- └── sort                      ·            ·                                                                                                                   ("?column?" decimal, k int, variance decimal)                +variance,+k
-      │                        order        +variance,+k                                                                                                        ·                                                            ·
-      └── render               ·            ·                                                                                                                   ("?column?" decimal, k int, variance decimal)                ·
-           │                   render 0     ((k)[int] + (stddev)[decimal])[decimal]                                                                             ·                                                            ·
-           │                   render 1     (k)[int]                                                                                                            ·                                                            ·
-           │                   render 2     (variance)[decimal]                                                                                                 ·                                                            ·
-           └── window          ·            ·                                                                                                                   (k int, v int, d decimal, stddev decimal, variance decimal)  ·
-                │              window 0     (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
-                │              render 4     (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
-                └── window     ·            ·                                                                                                                   (k int, v int, d decimal, stddev decimal)                    ·
-                     │         window 0     (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
-                     │         render 3     (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
-                     └── scan  ·            ·                                                                                                                   (k int, v int, d decimal)                                    ·
-·                              table        kv@primary                                                                                                          ·                                                            ·
-·                              spans        FULL SCAN                                                                                                           ·                                                            ·
+·                              distribution  local                                                                                                               ·                                                            ·
+·                              vectorized    true                                                                                                                ·                                                            ·
+render                         ·             ·                                                                                                                   (k int, "?column?" decimal)                                  ·
+ │                             render 0      (k)[int]                                                                                                            ·                                                            ·
+ │                             render 1      ("?column?")[decimal]                                                                                               ·                                                            ·
+ └── sort                      ·             ·                                                                                                                   ("?column?" decimal, k int, variance decimal)                +variance,+k
+      │                        order         +variance,+k                                                                                                        ·                                                            ·
+      └── render               ·             ·                                                                                                                   ("?column?" decimal, k int, variance decimal)                ·
+           │                   render 0      ((k)[int] + (stddev)[decimal])[decimal]                                                                             ·                                                            ·
+           │                   render 1      (k)[int]                                                                                                            ·                                                            ·
+           │                   render 2      (variance)[decimal]                                                                                                 ·                                                            ·
+           └── window          ·             ·                                                                                                                   (k int, v int, d decimal, stddev decimal, variance decimal)  ·
+                │              window 0      (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
+                │              render 4      (variance((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                            ·
+                └── window     ·             ·                                                                                                                   (k int, v int, d decimal, stddev decimal)                    ·
+                     │         window 0      (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
+                     │         render 3      (stddev((@3)[decimal]) OVER (PARTITION BY (@2)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                            ·
+                     └── scan  ·             ·                                                                                                                   (k int, v int, d decimal)                                    ·
+·                              table         kv@primary                                                                                                          ·                                                            ·
+·                              spans         FULL SCAN                                                                                                           ·                                                            ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT max(k), max(k) + stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY variance(d) OVER (PARTITION BY v, 100)
 ----
-·                                   distributed  false                                                                                                               ·                                                              ·
-·                                   vectorized   true                                                                                                                ·                                                              ·
-render                              ·            ·                                                                                                                   (max int, "?column?" decimal)                                  ·
- │                                  render 0     (max)[int]                                                                                                          ·                                                              ·
- │                                  render 1     ("?column?")[decimal]                                                                                               ·                                                              ·
- └── sort                           ·            ·                                                                                                                   ("?column?" decimal, max int, variance decimal)                +variance
-      │                             order        +variance                                                                                                           ·                                                              ·
-      └── render                    ·            ·                                                                                                                   ("?column?" decimal, max int, variance decimal)                ·
-           │                        render 0     ((max)[int] + (stddev)[decimal])[decimal]                                                                           ·                                                              ·
-           │                        render 1     (max)[int]                                                                                                          ·                                                              ·
-           │                        render 2     (variance)[decimal]                                                                                                 ·                                                              ·
-           └── window               ·            ·                                                                                                                   (v int, d decimal, max int, stddev decimal, variance decimal)  ·
-                │                   window 0     (variance((@2)[decimal]) OVER (PARTITION BY (@1)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                              ·
-                │                   render 4     (variance((@2)[decimal]) OVER (PARTITION BY (@1)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                              ·
-                └── window          ·            ·                                                                                                                   (v int, d decimal, max int, stddev decimal)                    ·
-                     │              window 0     (stddev((@2)[decimal]) OVER (PARTITION BY (@1)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                              ·
-                     │              render 3     (stddev((@2)[decimal]) OVER (PARTITION BY (@1)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                              ·
-                     └── group      ·            ·                                                                                                                   (v int, d decimal, max int)                                    ·
-                          │         aggregate 0  v                                                                                                                   ·                                                              ·
-                          │         aggregate 1  d                                                                                                                   ·                                                              ·
-                          │         aggregate 2  max(k)                                                                                                              ·                                                              ·
-                          │         group by     v, d                                                                                                                ·                                                              ·
-                          └── scan  ·            ·                                                                                                                   (k int, v int, d decimal)                                      ·
-·                                   table        kv@primary                                                                                                          ·                                                              ·
-·                                   spans        FULL SCAN                                                                                                           ·                                                              ·
+·                                   distribution  local                                                                                                               ·                                                              ·
+·                                   vectorized    true                                                                                                                ·                                                              ·
+render                              ·             ·                                                                                                                   (max int, "?column?" decimal)                                  ·
+ │                                  render 0      (max)[int]                                                                                                          ·                                                              ·
+ │                                  render 1      ("?column?")[decimal]                                                                                               ·                                                              ·
+ └── sort                           ·             ·                                                                                                                   ("?column?" decimal, max int, variance decimal)                +variance
+      │                             order         +variance                                                                                                           ·                                                              ·
+      └── render                    ·             ·                                                                                                                   ("?column?" decimal, max int, variance decimal)                ·
+           │                        render 0      ((max)[int] + (stddev)[decimal])[decimal]                                                                           ·                                                              ·
+           │                        render 1      (max)[int]                                                                                                          ·                                                              ·
+           │                        render 2      (variance)[decimal]                                                                                                 ·                                                              ·
+           └── window               ·             ·                                                                                                                   (v int, d decimal, max int, stddev decimal, variance decimal)  ·
+                │                   window 0      (variance((@2)[decimal]) OVER (PARTITION BY (@1)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                              ·
+                │                   render 4      (variance((@2)[decimal]) OVER (PARTITION BY (@1)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                                              ·
+                └── window          ·             ·                                                                                                                   (v int, d decimal, max int, stddev decimal)                    ·
+                     │              window 0      (stddev((@2)[decimal]) OVER (PARTITION BY (@1)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                              ·
+                     │              render 3      (stddev((@2)[decimal]) OVER (PARTITION BY (@1)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]    ·                                                              ·
+                     └── group      ·             ·                                                                                                                   (v int, d decimal, max int)                                    ·
+                          │         aggregate 0   v                                                                                                                   ·                                                              ·
+                          │         aggregate 1   d                                                                                                                   ·                                                              ·
+                          │         aggregate 2   max(k)                                                                                                              ·                                                              ·
+                          │         group by      v, d                                                                                                                ·                                                              ·
+                          └── scan  ·             ·                                                                                                                   (k int, v int, d decimal)                                      ·
+·                                   table         kv@primary                                                                                                          ·                                                              ·
+·                                   spans         FULL SCAN                                                                                                           ·                                                              ·
 
 query TTTTT
 EXPLAIN (TYPES) SELECT max(k), stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY 1
 ----
-·                         distributed  false                                                                                                             ·                                            ·
-·                         vectorized   true                                                                                                              ·                                            ·
-sort                      ·            ·                                                                                                                 (max int, stddev decimal)                    +max
- │                        order        +max                                                                                                              ·                                            ·
- └── render               ·            ·                                                                                                                 (max int, stddev decimal)                    ·
-      │                   render 0     (max)[int]                                                                                                        ·                                            ·
-      │                   render 1     (stddev)[decimal]                                                                                                 ·                                            ·
-      └── window          ·            ·                                                                                                                 (v int, d decimal, max int, stddev decimal)  ·
-           │              window 0     (stddev((@2)[decimal]) OVER (PARTITION BY (@1)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                            ·
-           │              render 3     (stddev((@2)[decimal]) OVER (PARTITION BY (@1)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                            ·
-           └── group      ·            ·                                                                                                                 (v int, d decimal, max int)                  ·
-                │         aggregate 0  v                                                                                                                 ·                                            ·
-                │         aggregate 1  d                                                                                                                 ·                                            ·
-                │         aggregate 2  max(k)                                                                                                            ·                                            ·
-                │         group by     v, d                                                                                                              ·                                            ·
-                └── scan  ·            ·                                                                                                                 (k int, v int, d decimal)                    ·
-·                         table        kv@primary                                                                                                        ·                                            ·
-·                         spans        FULL SCAN                                                                                                         ·                                            ·
+·                         distribution  local                                                                                                             ·                                            ·
+·                         vectorized    true                                                                                                              ·                                            ·
+sort                      ·             ·                                                                                                                 (max int, stddev decimal)                    +max
+ │                        order         +max                                                                                                              ·                                            ·
+ └── render               ·             ·                                                                                                                 (max int, stddev decimal)                    ·
+      │                   render 0      (max)[int]                                                                                                        ·                                            ·
+      │                   render 1      (stddev)[decimal]                                                                                                 ·                                            ·
+      └── window          ·             ·                                                                                                                 (v int, d decimal, max int, stddev decimal)  ·
+           │              window 0      (stddev((@2)[decimal]) OVER (PARTITION BY (@1)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                            ·
+           │              render 3      (stddev((@2)[decimal]) OVER (PARTITION BY (@1)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]  ·                                            ·
+           └── group      ·             ·                                                                                                                 (v int, d decimal, max int)                  ·
+                │         aggregate 0   v                                                                                                                 ·                                            ·
+                │         aggregate 1   d                                                                                                                 ·                                            ·
+                │         aggregate 2   max(k)                                                                                                            ·                                            ·
+                │         group by      v, d                                                                                                              ·                                            ·
+                └── scan  ·             ·                                                                                                                 (k int, v int, d decimal)                    ·
+·                         table         kv@primary                                                                                                        ·                                            ·
+·                         spans         FULL SCAN                                                                                                         ·                                            ·
 
 # Partition
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT lag(1) OVER (PARTITION BY 2), lead(2) OVER (PARTITION BY 1) FROM kv
 ----
-·                              distributed  false                                                                      ·                                                       ·
-·                              vectorized   true                                                                       ·                                                       ·
-render                         ·            ·                                                                          (lag, lead)                                             ·
- │                             render 0     lag                                                                        ·                                                       ·
- │                             render 1     lead                                                                       ·                                                       ·
- └── window                    ·            ·                                                                          (lag, lag_1_arg1, lag_1_arg3, lag_1_partition_1, lead)  ·
-      │                        window 0     lead(@4, @2, @3) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                                                       ·
-      │                        render 4     lead(@4, @2, @3) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                                                       ·
-      └── render               ·            ·                                                                          (lag, lag_1_arg1, lag_1_arg3, lag_1_partition_1)        ·
-           │                   render 0     lag                                                                        ·                                                       ·
-           │                   render 1     lag_1_arg1                                                                 ·                                                       ·
-           │                   render 2     lag_1_arg3                                                                 ·                                                       ·
-           │                   render 3     lag_1_partition_1                                                          ·                                                       ·
-           └── window          ·            ·                                                                          (lag_1_arg1, lag_1_arg3, lag_1_partition_1, lag)        ·
-                │              window 0     lag(@1, @1, @2) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)   ·                                                       ·
-                │              render 3     lag(@1, @1, @2) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)   ·                                                       ·
-                └── render     ·            ·                                                                          (lag_1_arg1, lag_1_arg3, lag_1_partition_1)             ·
-                     │         render 0     1                                                                          ·                                                       ·
-                     │         render 1     CAST(NULL AS INT8)                                                         ·                                                       ·
-                     │         render 2     2                                                                          ·                                                       ·
-                     └── scan  ·            ·                                                                          ()                                                      ·
-·                              table        kv@primary                                                                 ·                                                       ·
-·                              spans        FULL SCAN                                                                  ·                                                       ·
+·                              distribution  local                                                                      ·                                                       ·
+·                              vectorized    true                                                                       ·                                                       ·
+render                         ·             ·                                                                          (lag, lead)                                             ·
+ │                             render 0      lag                                                                        ·                                                       ·
+ │                             render 1      lead                                                                       ·                                                       ·
+ └── window                    ·             ·                                                                          (lag, lag_1_arg1, lag_1_arg3, lag_1_partition_1, lead)  ·
+      │                        window 0      lead(@4, @2, @3) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                                                       ·
+      │                        render 4      lead(@4, @2, @3) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·                                                       ·
+      └── render               ·             ·                                                                          (lag, lag_1_arg1, lag_1_arg3, lag_1_partition_1)        ·
+           │                   render 0      lag                                                                        ·                                                       ·
+           │                   render 1      lag_1_arg1                                                                 ·                                                       ·
+           │                   render 2      lag_1_arg3                                                                 ·                                                       ·
+           │                   render 3      lag_1_partition_1                                                          ·                                                       ·
+           └── window          ·             ·                                                                          (lag_1_arg1, lag_1_arg3, lag_1_partition_1, lag)        ·
+                │              window 0      lag(@1, @1, @2) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)   ·                                                       ·
+                │              render 3      lag(@1, @1, @2) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)   ·                                                       ·
+                └── render     ·             ·                                                                          (lag_1_arg1, lag_1_arg3, lag_1_partition_1)             ·
+                     │         render 0      1                                                                          ·                                                       ·
+                     │         render 1      CAST(NULL AS INT8)                                                         ·                                                       ·
+                     │         render 2      2                                                                          ·                                                       ·
+                     └── scan  ·             ·                                                                          ()                                                      ·
+·                              table         kv@primary                                                                 ·                                                       ·
+·                              spans         FULL SCAN                                                                  ·                                                       ·
 
 # Ordering
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, v, rank() OVER (ORDER BY k) FROM kv ORDER BY 1
 ----
-·               distributed  false                                                                            ·             ·
-·               vectorized   true                                                                             ·             ·
-sort            ·            ·                                                                                (k, v, rank)  +k
- │              order        +k                                                                               ·             ·
- └── window     ·            ·                                                                                (k, v, rank)  ·
-      │         window 0     rank() OVER (ORDER BY @1 ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·             ·
-      │         render 2     rank() OVER (ORDER BY @1 ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·             ·
-      └── scan  ·            ·                                                                                (k, v)        ·
-·               table        kv@primary                                                                       ·             ·
-·               spans        FULL SCAN                                                                        ·             ·
+·               distribution  local                                                                            ·             ·
+·               vectorized    true                                                                             ·             ·
+sort            ·             ·                                                                                (k, v, rank)  +k
+ │              order         +k                                                                               ·             ·
+ └── window     ·             ·                                                                                (k, v, rank)  ·
+      │         window 0      rank() OVER (ORDER BY @1 ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·             ·
+      │         render 2      rank() OVER (ORDER BY @1 ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·             ·
+      └── scan  ·             ·                                                                                (k, v)        ·
+·               table         kv@primary                                                                       ·             ·
+·               spans         FULL SCAN                                                                        ·             ·
 
 
 # Frames
@@ -295,44 +295,44 @@ sort            ·            ·                                                
 query TTTTT
 EXPLAIN (VERBOSE) SELECT avg(k) OVER () FROM kv
 ----
-·               distributed  false                                                             ·         ·
-·               vectorized   true                                                              ·         ·
-render          ·            ·                                                                 (avg)     ·
- │              render 0     avg                                                               ·         ·
- └── window     ·            ·                                                                 (k, avg)  ·
-      │         window 0     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
-      │         render 1     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
-      └── scan  ·            ·                                                                 (k)       ·
-·               table        kv@primary                                                        ·         ·
-·               spans        FULL SCAN                                                         ·         ·
+·               distribution  local                                                             ·         ·
+·               vectorized    true                                                              ·         ·
+render          ·             ·                                                                 (avg)     ·
+ │              render 0      avg                                                               ·         ·
+ └── window     ·             ·                                                                 (k, avg)  ·
+      │         window 0      avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
+      │         render 1      avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
+      └── scan  ·             ·                                                                 (k)       ·
+·               table         kv@primary                                                        ·         ·
+·               spans         FULL SCAN                                                         ·         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) FROM kv
 ----
-·               distributed  false                                                                     ·         ·
-·               vectorized   true                                                                      ·         ·
-render          ·            ·                                                                         (avg)     ·
- │              render 0     avg                                                                       ·         ·
- └── window     ·            ·                                                                         (k, avg)  ·
-      │         window 0     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)  ·         ·
-      │         render 1     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)  ·         ·
-      └── scan  ·            ·                                                                         (k)       ·
-·               table        kv@primary                                                                ·         ·
-·               spans        FULL SCAN                                                                 ·         ·
+·               distribution  local                                                                     ·         ·
+·               vectorized    true                                                                      ·         ·
+render          ·             ·                                                                         (avg)     ·
+ │              render 0      avg                                                                       ·         ·
+ └── window     ·             ·                                                                         (k, avg)  ·
+      │         window 0      avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)  ·         ·
+      │         render 1      avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)  ·         ·
+      └── scan  ·             ·                                                                         (k)       ·
+·               table         kv@primary                                                                ·         ·
+·               spans         FULL SCAN                                                                 ·         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT avg(k) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM kv
 ----
-·               distributed  false                                                             ·         ·
-·               vectorized   true                                                              ·         ·
-render          ·            ·                                                                 (avg)     ·
- │              render 0     avg                                                               ·         ·
- └── window     ·            ·                                                                 (k, avg)  ·
-      │         window 0     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
-      │         render 1     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
-      └── scan  ·            ·                                                                 (k)       ·
-·               table        kv@primary                                                        ·         ·
-·               spans        FULL SCAN                                                         ·         ·
+·               distribution  local                                                             ·         ·
+·               vectorized    true                                                              ·         ·
+render          ·             ·                                                                 (avg)     ·
+ │              render 0      avg                                                               ·         ·
+ └── window     ·             ·                                                                 (k, avg)  ·
+      │         window 0      avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
+      │         render 1      avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)  ·         ·
+      └── scan  ·             ·                                                                 (k)       ·
+·               table         kv@primary                                                        ·         ·
+·               spans         FULL SCAN                                                         ·         ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
@@ -352,50 +352,50 @@ EXPLAIN (VERBOSE)
     FROM
         kv
 ----
-·                    distributed  false                                                                                      ·                                                                ·
-·                    vectorized   true                                                                                       ·                                                                ·
-render               ·            ·                                                                                          (avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg)     ·
- │                   render 0     avg                                                                                        ·                                                                ·
- │                   render 1     avg                                                                                        ·                                                                ·
- │                   render 2     avg                                                                                        ·                                                                ·
- │                   render 3     avg                                                                                        ·                                                                ·
- │                   render 4     avg                                                                                        ·                                                                ·
- │                   render 5     avg                                                                                        ·                                                                ·
- │                   render 6     avg                                                                                        ·                                                                ·
- │                   render 7     avg                                                                                        ·                                                                ·
- │                   render 8     avg                                                                                        ·                                                                ·
- │                   render 9     avg                                                                                        ·                                                                ·
- │                   render 10    avg                                                                                        ·                                                                ·
- │                   render 11    avg                                                                                        ·                                                                ·
- └── window          ·            ·                                                                                          (k, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg)  ·
-      │              window 0     avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)  ·                                                                ·
-      │              window 1     avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)          ·                                                                ·
-      │              window 2     avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)          ·                                                                ·
-      │              window 3     avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN CURRENT ROW AND CURRENT ROW)                  ·                                                                ·
-      │              render 9     avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)  ·                                                                ·
-      │              render 10    avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)          ·                                                                ·
-      │              render 11    avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)          ·                                                                ·
-      │              render 12    avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN CURRENT ROW AND CURRENT ROW)                  ·                                                                ·
-      └── window     ·            ·                                                                                          (k, avg, avg, avg, avg, avg, avg, avg, avg)                      ·
-           │         window 0     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)                   ·                                                                ·
-           │         window 1     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                           ·                                                                ·
-           │         window 2     avg(@1) OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)                           ·                                                                ·
-           │         window 3     avg(@1) OVER (RANGE BETWEEN CURRENT ROW AND CURRENT ROW)                                   ·                                                                ·
-           │         window 4     avg(@1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)                    ·                                                                ·
-           │         window 5     avg(@1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                            ·                                                                ·
-           │         window 6     avg(@1) OVER (ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)                            ·                                                                ·
-           │         window 7     avg(@1) OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW)                                    ·                                                                ·
-           │         render 1     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)                   ·                                                                ·
-           │         render 2     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                           ·                                                                ·
-           │         render 3     avg(@1) OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)                           ·                                                                ·
-           │         render 4     avg(@1) OVER (RANGE BETWEEN CURRENT ROW AND CURRENT ROW)                                   ·                                                                ·
-           │         render 5     avg(@1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)                    ·                                                                ·
-           │         render 6     avg(@1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                            ·                                                                ·
-           │         render 7     avg(@1) OVER (ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)                            ·                                                                ·
-           │         render 8     avg(@1) OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW)                                    ·                                                                ·
-           └── scan  ·            ·                                                                                          (k)                                                              ·
-·                    table        kv@primary                                                                                 ·                                                                ·
-·                    spans        FULL SCAN                                                                                  ·                                                                ·
+·                    distribution  local                                                                                      ·                                                                ·
+·                    vectorized    true                                                                                       ·                                                                ·
+render               ·             ·                                                                                          (avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg)     ·
+ │                   render 0      avg                                                                                        ·                                                                ·
+ │                   render 1      avg                                                                                        ·                                                                ·
+ │                   render 2      avg                                                                                        ·                                                                ·
+ │                   render 3      avg                                                                                        ·                                                                ·
+ │                   render 4      avg                                                                                        ·                                                                ·
+ │                   render 5      avg                                                                                        ·                                                                ·
+ │                   render 6      avg                                                                                        ·                                                                ·
+ │                   render 7      avg                                                                                        ·                                                                ·
+ │                   render 8      avg                                                                                        ·                                                                ·
+ │                   render 9      avg                                                                                        ·                                                                ·
+ │                   render 10     avg                                                                                        ·                                                                ·
+ │                   render 11     avg                                                                                        ·                                                                ·
+ └── window          ·             ·                                                                                          (k, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg)  ·
+      │              window 0      avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)  ·                                                                ·
+      │              window 1      avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)          ·                                                                ·
+      │              window 2      avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)          ·                                                                ·
+      │              window 3      avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN CURRENT ROW AND CURRENT ROW)                  ·                                                                ·
+      │              render 9      avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)  ·                                                                ·
+      │              render 10     avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)          ·                                                                ·
+      │              render 11     avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)          ·                                                                ·
+      │              render 12     avg(@1) OVER (ORDER BY @1 ASC GROUPS BETWEEN CURRENT ROW AND CURRENT ROW)                  ·                                                                ·
+      └── window     ·             ·                                                                                          (k, avg, avg, avg, avg, avg, avg, avg, avg)                      ·
+           │         window 0      avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)                   ·                                                                ·
+           │         window 1      avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                           ·                                                                ·
+           │         window 2      avg(@1) OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)                           ·                                                                ·
+           │         window 3      avg(@1) OVER (RANGE BETWEEN CURRENT ROW AND CURRENT ROW)                                   ·                                                                ·
+           │         window 4      avg(@1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)                    ·                                                                ·
+           │         window 5      avg(@1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                            ·                                                                ·
+           │         window 6      avg(@1) OVER (ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)                            ·                                                                ·
+           │         window 7      avg(@1) OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW)                                    ·                                                                ·
+           │         render 1      avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)                   ·                                                                ·
+           │         render 2      avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                           ·                                                                ·
+           │         render 3      avg(@1) OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)                           ·                                                                ·
+           │         render 4      avg(@1) OVER (RANGE BETWEEN CURRENT ROW AND CURRENT ROW)                                   ·                                                                ·
+           │         render 5      avg(@1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)                    ·                                                                ·
+           │         render 6      avg(@1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                            ·                                                                ·
+           │         render 7      avg(@1) OVER (ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)                            ·                                                                ·
+           │         render 8      avg(@1) OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW)                                    ·                                                                ·
+           └── scan  ·             ·                                                                                          (k)                                                              ·
+·                    table         kv@primary                                                                                 ·                                                                ·
+·                    spans         FULL SCAN                                                                                  ·                                                                ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
@@ -409,7 +409,7 @@ EXPLAIN (VERBOSE)
     FROM
         kv
 ----
-·                    distributed   false                                                                      ·             ·
+·                    distribution  local                                                                      ·             ·
 ·                    vectorized    false                                                                      ·             ·
 root                 ·             ·                                                                          (avg)         ·
  ├── render          ·             ·                                                                          (avg)         ·
@@ -441,22 +441,22 @@ EXPLAIN (VERBOSE)
     FROM
         kv
 ----
-·               distributed  false                                                                                 ·                        ·
-·               vectorized   true                                                                                  ·                        ·
-render          ·            ·                                                                                     (avg, avg, avg, avg)     ·
- │              render 0     avg                                                                                   ·                        ·
- │              render 1     avg                                                                                   ·                        ·
- │              render 2     avg                                                                                   ·                        ·
- │              render 3     avg                                                                                   ·                        ·
- └── window     ·            ·                                                                                     (k, avg, avg, avg, avg)  ·
-      │         window 0     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW)  ·                        ·
-      │         window 1     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE GROUP)        ·                        ·
-      │         window 2     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)         ·                        ·
-      │         window 3     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                      ·                        ·
-      │         render 1     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW)  ·                        ·
-      │         render 2     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE GROUP)        ·                        ·
-      │         render 3     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)         ·                        ·
-      │         render 4     avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                      ·                        ·
-      └── scan  ·            ·                                                                                     (k)                      ·
-·               table        kv@primary                                                                            ·                        ·
-·               spans        FULL SCAN                                                                             ·                        ·
+·               distribution  local                                                                                 ·                        ·
+·               vectorized    true                                                                                  ·                        ·
+render          ·             ·                                                                                     (avg, avg, avg, avg)     ·
+ │              render 0      avg                                                                                   ·                        ·
+ │              render 1      avg                                                                                   ·                        ·
+ │              render 2      avg                                                                                   ·                        ·
+ │              render 3      avg                                                                                   ·                        ·
+ └── window     ·             ·                                                                                     (k, avg, avg, avg, avg)  ·
+      │         window 0      avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW)  ·                        ·
+      │         window 1      avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE GROUP)        ·                        ·
+      │         window 2      avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)         ·                        ·
+      │         window 3      avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                      ·                        ·
+      │         render 1      avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW)  ·                        ·
+      │         render 2      avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE GROUP)        ·                        ·
+      │         render 3      avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)         ·                        ·
+      │         render 4      avg(@1) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)                      ·                        ·
+      └── scan  ·             ·                                                                                     (k)                      ·
+·               table         kv@primary                                                                            ·                        ·
+·               spans         FULL SCAN                                                                             ·                        ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -10,7 +10,7 @@ query TTTTT
 EXPLAIN (VERBOSE)
   WITH t AS (SELECT a FROM y) SELECT * FROM t JOIN t AS q ON true
 ----
-·                           distributed   false            ·       ·
+·                           distribution  local            ·       ·
 ·                           vectorized    false            ·       ·
 root                        ·             ·                (a, a)  ·
  ├── cross-join             ·             ·                (a, a)  ·
@@ -33,19 +33,19 @@ query TTTTT
 EXPLAIN (VERBOSE)
   WITH t AS (SELECT a FROM y) SELECT * FROM t
 ----
-·          distributed  false      ·    ·
-·          vectorized   true       ·    ·
-render     ·            ·          (a)  ·
- │         render 0     a          ·    ·
- └── scan  ·            ·          (a)  ·
-·          table        y@primary  ·    ·
-·          spans        FULL SCAN  ·    ·
+·          distribution  local      ·    ·
+·          vectorized    true       ·    ·
+render     ·             ·          (a)  ·
+ │         render 0      a          ·    ·
+ └── scan  ·             ·          (a)  ·
+·          table         y@primary  ·    ·
+·          spans         FULL SCAN  ·    ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
   WITH t AS (INSERT INTO x VALUES (1) RETURNING a) SELECT * FROM t
 ----
-·                                          distributed    false                                 ·                   ·
+·                                          distribution   local                                 ·                   ·
 ·                                          vectorized     false                                 ·                   ·
 root                                       ·              ·                                     (a)                 ·
  ├── scan buffer node                      ·              ·                                     (a)                 ·
@@ -82,16 +82,16 @@ EXPLAIN (VERBOSE)
   FROM
     w, table39010
 ----
-·           distributed  false               ·      ·
-·           vectorized   true                ·      ·
-cross-join  ·            ·                   (col)  ·
- │          type         cross               ·      ·
- ├── scan   ·            ·                   ()     ·
- │          table        table39010@primary  ·      ·
- │          spans        FULL SCAN           ·      ·
- └── scan   ·            ·                   (col)  ·
-·           table        table39010@primary  ·      ·
-·           spans        FULL SCAN           ·      ·
+·           distribution  local               ·      ·
+·           vectorized    true                ·      ·
+cross-join  ·             ·                   (col)  ·
+ │          type          cross               ·      ·
+ ├── scan   ·             ·                   ()     ·
+ │          table         table39010@primary  ·      ·
+ │          spans         FULL SCAN           ·      ·
+ └── scan   ·             ·                   (col)  ·
+·           table         table39010@primary  ·      ·
+·           spans         FULL SCAN           ·      ·
 
 query TTTTT
 EXPLAIN (VERBOSE)
@@ -102,7 +102,7 @@ EXPLAIN (VERBOSE)
   )
   SELECT sum(n) FROM t
 ----
-·                             distributed    false               ·          ·
+·                             distribution   local               ·          ·
 ·                             vectorized     false               ·          ·
 group                         ·              ·                   (sum)      ·
  │                            aggregate 0    sum(n)              ·          ·

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1182,45 +1182,7 @@ func (ef *execFactory) ConstructExplainOpt(
 func (ef *execFactory) ConstructExplain(
 	options *tree.ExplainOptions, stmtType tree.StatementType, plan exec.Plan,
 ) (exec.Node, error) {
-	p := plan.(*planTop)
-
-	analyzeSet := options.Flags[tree.ExplainFlagAnalyze]
-
-	if options.Flags[tree.ExplainFlagEnv] {
-		return nil, errors.New("ENV only supported with (OPT) option")
-	}
-
-	switch options.Mode {
-	case tree.ExplainDistSQL:
-		return &explainDistSQLNode{
-			options:  options,
-			plan:     p.planComponents,
-			analyze:  analyzeSet,
-			stmtType: stmtType,
-		}, nil
-
-	case tree.ExplainVec:
-		return &explainVecNode{
-			options:       options,
-			plan:          p.main,
-			subqueryPlans: p.subqueryPlans,
-			stmtType:      stmtType,
-		}, nil
-
-	case tree.ExplainPlan:
-		if analyzeSet {
-			return nil, errors.New("EXPLAIN ANALYZE only supported with (DISTSQL) option")
-		}
-		return ef.planner.makeExplainPlanNodeWithPlan(
-			context.TODO(),
-			options,
-			&p.planComponents,
-			stmtType,
-		)
-
-	default:
-		panic(fmt.Sprintf("unsupported explain mode %v", options.Mode))
-	}
+	return constructExplainPlanNode(options, stmtType, plan.(*planTop), ef.planner)
 }
 
 // ConstructShowTrace is part of the exec.Factory interface.

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -727,7 +727,7 @@ func TestPGPreparedQuery(t *testing.T) {
 		// #14238
 		{"EXPLAIN SELECT 1", []preparedQueryTest{
 			baseTest.SetArgs().
-				Results("", "distributed", "false").
+				Results("", "distribution", "local").
 				Results("", "vectorized", "false").
 				Results("values", "", "").
 				Results("", "size", "1 column, 1 row"),

--- a/pkg/sql/physicalplan/physical_plan.go
+++ b/pkg/sql/physicalplan/physical_plan.go
@@ -1183,3 +1183,9 @@ func (p *PhysicalPlan) EnsureSingleStreamPerNode() {
 		p.ResultRouters[i] = mergedProcIdx
 	}
 }
+
+// IsLastStageDistributed returns whether the last stage of processors is
+// distributed.
+func (p *PhysicalPlan) IsLastStageDistributed() bool {
+	return len(p.ResultRouters) > 1
+}

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -318,13 +318,9 @@ type planMaybePhysical struct {
 	// physPlan (when non-nil) contains the physical plan that has not yet
 	// been finalized.
 	physPlan *PhysicalPlan
-	// recommendation (when physPlan is non-nil) is the recommendation about
-	// the distribution of the physical plan. Note that it is possible that
-	// the plan is "partially distributed" (meaning that some stages of the
-	// processors are distributed whereas other stages are not).
-	// TODO(yuzefovich): introduce ternary planDistribution to show that plans
-	// can be local, partially distributed, and fully distributed.
-	recommendation distRecommendation
+	// distribution (when physPlan is non-nil) is the indicator of the
+	// distribution of the physical plan.
+	distribution planDistribution
 }
 
 func (p planMaybePhysical) isPhysicalPlan() bool {

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -319,7 +319,11 @@ type planMaybePhysical struct {
 	// been finalized.
 	physPlan *PhysicalPlan
 	// recommendation (when physPlan is non-nil) is the recommendation about
-	// the distribution of the physical plan.
+	// the distribution of the physical plan. Note that it is possible that
+	// the plan is "partially distributed" (meaning that some stages of the
+	// processors are distributed whereas other stages are not).
+	// TODO(yuzefovich): introduce ternary planDistribution to show that plans
+	// can be local, partially distributed, and fully distributed.
 	recommendation distRecommendation
 }
 

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -202,6 +202,10 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 			}
 			// We will fallback to the old path.
 			bld = nil
+			// TODO(yuzefovich): make the logging conditional on the verbosity
+			// level once new DistSQL planning is no longer experimental.
+			log.Infof(ctx, "distSQLSpecExecFactory failed planning with %v, "+
+				"falling back to the old path", err)
 		}
 	}
 	if bld == nil {

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -264,11 +264,11 @@ func (sc *SchemaChanger) maybeBackfillCreateTableAs(
 		)
 		defer recv.Release()
 
-		willDistribute := willDistributePlan(
+		willDistribute := getPlanDistribution(
 			ctx, localPlanner.execCfg.NodeID,
 			localPlanner.extendedEvalCtx.SessionData.DistSQLMode,
 			localPlanner.curPlan.main,
-		)
+		).willDistribute()
 		var planAndRunErr error
 		localPlanner.runWithOptions(resolveFlags{skipCache: true}, func() {
 			// Resolve subqueries before running the queries' physical plan.

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -660,9 +660,23 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 		}
 
 	case *explainDistSQLNode:
+		// We check whether planNode is nil because the plan might be
+		// represented physically. We don't yet have a walker over such
+		// representation, so we simply short-circuit.
+		// TODO(yuzefovich): implement that walker and use it here.
+		if n.plan.main.planNode == nil {
+			return
+		}
 		n.plan.main.planNode = v.visit(n.plan.main.planNode)
 
 	case *explainVecNode:
+		// We check whether planNode is nil because the plan might be
+		// represented physically. We don't yet have a walker over such
+		// representation, so we simply short-circuit.
+		// TODO(yuzefovich): implement that walker and use it here.
+		if n.plan.planNode == nil {
+			return
+		}
 		n.plan.planNode = v.visit(n.plan.planNode)
 
 	case *ordinalityNode:
@@ -684,6 +698,13 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 		n.plan = v.visit(n.plan)
 
 	case *explainPlanNode:
+		// We check whether planNode is nil because the plan might be
+		// represented physically. We don't yet have a walker over such
+		// representation, so we simply short-circuit.
+		// TODO(yuzefovich): implement that walker and use it here.
+		if n.plan.main.planNode == nil {
+			return
+		}
 		n.plan.main.planNode = v.visit(n.plan.main.planNode)
 
 	case *cancelQueriesNode:


### PR DESCRIPTION
**sql: implement ConstructFilter in the new factory**

This commit implements `ConstructFilter` in the new factory by simply
reusing `AddFilter` function which attempts to push the filter into the
post-processing stage of the last stage of processors.

This commit does make an important decision: it introduces the notion of
"partially distributed" plans (meaning that some stages of the processors
can be distributed whereas other stages are not). As an example, if the
query contains a distsql-blacklisted function, the old code will not
distribute the whole plan, but with this approach we might distribute
scans, then bring the streams together to the gateway, and plan everything
after and including the blacklisted function locally. We will be taking
this even further eventually - if it is beneficial, we can plan a later
stage in distributed fashion (but the new factory doesn't yet implement
methods that would result in such behavior).

Release note: None

**sql: introduce ternary planDistribution struct**

In the previous commit we introduced a notion of "partially distributed"
plans, and this commit introduces a ternary `planDistribution` struct to
represent all possible plan distributions: "local", "partial", and
"full". `queryMeta` adjustment is left as TODO.

Release note: None

**sql: update 'distributed' field of EXPLAIN output**

In the previous commits we introduced a notion of "partially distributed"
plans, and this commit adjusts the EXPLAIN code accordingly.

Release note (sql change): The output of some EXPLAIN variants has been
changed so that "distributed" field is now named "distribution" and can
be of "local", "partial", and "full" states ("partial" is currently only
possible with experimental setting).

**sql: implement ConstructExplain in distSQLSpecExecFactory**

This commit adds an implementation of `ConstructExplain` to
`distSQLSpecExecFactory` that is shared with `execFactory`. This
introduces a notion of "partially physical" plan (meaning that we have
a `planNode` at the root and an already completely planned physically
leaf. The intention is to be able to test physical planning of the new
factory. As a result of this approach, `EXPLAIN (DISTSQL)` and `EXPLAIN
(VEC)` work well but "vanilla" `EXPLAIN` (plan) doesn't. The reason for
that is the vanilly explain walks over the plan and populates the
"attributes"; however, now we have a mixed planNode-spec representation
which existing walker doesn't support. I see two ways to address this:
either fully fall back to the old factory for the vanilla explain or
implement a separate walker on DistSQL specs. I'm leaning towards the
latter option which is left as TODO.

Release note: None