### PR TITLE
sql: use a separate type for pgcodes

### DIFF
--- a/pkg/ccl/importccl/client_import_test.go
+++ b/pkg/ccl/importccl/client_import_test.go
@@ -88,7 +88,7 @@ func TestDropDatabaseCascadeDuringImportsFails(t *testing.T) {
 		` database `+dbName, err)
 	pgErr := new(pq.Error)
 	require.True(t, errors.As(err, &pgErr))
-	require.Equal(t, pgcode.ObjectNotInPrerequisiteState, string(pgErr.Code))
+	require.Equal(t, pgcode.ObjectNotInPrerequisiteState, pgcode.MakeCode(string(pgErr.Code)))
 
 	close(allowResponse)
 	require.NoError(t, <-importErrCh)

--- a/pkg/ccl/importccl/read_import_base.go
+++ b/pkg/ccl/importccl/read_import_base.go
@@ -336,13 +336,15 @@ func isMultiTableFormat(format roachpb.IOFileFormat_FileFormat) bool {
 	return false
 }
 
-func makeRowErr(_ string, row int64, code, format string, args ...interface{}) error {
+func makeRowErr(_ string, row int64, code pgcode.Code, format string, args ...interface{}) error {
 	err := pgerror.NewWithDepthf(1, code, format, args...)
 	err = errors.WrapWithDepthf(1, err, "row %d", row)
 	return err
 }
 
-func wrapRowErr(err error, _ string, row int64, code, format string, args ...interface{}) error {
+func wrapRowErr(
+	err error, _ string, row int64, code pgcode.Code, format string, args ...interface{},
+) error {
 	if format != "" || len(args) > 0 {
 		err = errors.WrapWithDepthf(1, err, format, args...)
 	}

--- a/pkg/cli/error_test.go
+++ b/pkg/cli/error_test.go
@@ -40,10 +40,10 @@ func TestOutputError(t *testing.T) {
 		// Check the basic with/without severity.
 		{errBase, false, false, "woo"},
 		{errBase, true, false, "ERROR: woo"},
-		{pgerror.WithCandidateCode(errBase, pgcode.Syntax), false, false, "woo\nSQLSTATE: " + pgcode.Syntax},
+		{pgerror.WithCandidateCode(errBase, pgcode.Syntax), false, false, "woo\nSQLSTATE: " + pgcode.Syntax.String()},
 		// Check the verbose output. This includes the uncategorized sqlstate.
-		{errBase, false, true, "woo\nSQLSTATE: " + pgcode.Uncategorized + "\nLOCATION: " + refLoc},
-		{errBase, true, true, "ERROR: woo\nSQLSTATE: " + pgcode.Uncategorized + "\nLOCATION: " + refLoc},
+		{errBase, false, true, "woo\nSQLSTATE: " + pgcode.Uncategorized.String() + "\nLOCATION: " + refLoc},
+		{errBase, true, true, "ERROR: woo\nSQLSTATE: " + pgcode.Uncategorized.String() + "\nLOCATION: " + refLoc},
 		// Check the same over pq.Error objects.
 		{&pq.Error{Message: "woo"}, false, false, "woo"},
 		{&pq.Error{Message: "woo"}, true, false, "ERROR: woo"},
@@ -54,7 +54,7 @@ func TestOutputError(t *testing.T) {
 		// Check hint printed after message.
 		{errors.WithHint(errBase, "hello"), false, false, "woo\nHINT: hello"},
 		// Check sqlstate printed before hint, location after hint.
-		{errors.WithHint(errBase, "hello"), false, true, "woo\nSQLSTATE: " + pgcode.Uncategorized + "\nHINT: hello\nLOCATION: " + refLoc},
+		{errors.WithHint(errBase, "hello"), false, true, "woo\nSQLSTATE: " + pgcode.Uncategorized.String() + "\nHINT: hello\nLOCATION: " + refLoc},
 		// Check detail printed after message.
 		{errors.WithDetail(errBase, "hello"), false, false, "woo\nDETAIL: hello"},
 		// Check hint/detail collection, hint printed after detail.
@@ -71,7 +71,7 @@ func TestOutputError(t *testing.T) {
 		// Check sqlstate printed before detail, location after hint.
 		{errors.WithDetail(
 			errors.WithHint(errBase, "a"), "b"),
-			false, true, "woo\nSQLSTATE: " + pgcode.Uncategorized + "\nDETAIL: b\nHINT: a\nLOCATION: " + refLoc},
+			false, true, "woo\nSQLSTATE: " + pgcode.Uncategorized.String() + "\nDETAIL: b\nHINT: a\nLOCATION: " + refLoc},
 	}
 
 	for _, tc := range testData {

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -1571,7 +1572,7 @@ func (c *cliState) serverSideParse(sql string) (helpText string, err error) {
 		}
 		// In any case report that there was an error while parsing.
 		err := errors.Newf("%s", message)
-		err = pgerror.WithCandidateCode(err, code)
+		err = pgerror.WithCandidateCode(err, pgcode.MakeCode(code))
 		if hint != "" {
 			err = errors.WithHint(err, hint)
 		}

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -724,7 +724,7 @@ func dumpTableDataForZip(
 				// Not a SQL error. Nothing to retry.
 				break
 			}
-			if pqErr.Code != pgcode.SerializationFailure {
+			if pgcode.MakeCode(string(pqErr.Code)) != pgcode.SerializationFailure {
 				// A non-retry error. We've printed the error, and
 				// there's nothing to retry. Stop here.
 				break

--- a/pkg/cmd/roachtest/tpc_utils.go
+++ b/pkg/cmd/roachtest/tpc_utils.go
@@ -38,7 +38,7 @@ func loadTPCHDataset(
 		if err := db.QueryRowContext(
 			ctx, `SELECT count(*) FROM tpch.supplier`,
 		).Scan(&supplierCardinality); err != nil {
-			if pqErr := (*pq.Error)(nil); !(errors.As(err, &pqErr) && pqErr.Code == pgcode.UndefinedTable) {
+			if pqErr := (*pq.Error)(nil); !(errors.As(err, &pqErr) && pgcode.MakeCode(string(pqErr.Code)) == pgcode.UndefinedTable) {
 				return err
 			}
 			// Table does not exist. Set cardinality to 0.
@@ -62,7 +62,7 @@ func loadTPCHDataset(
 		c.Start(ctx, t, roachNodes)
 		m.ResetDeaths()
 	} else if pqErr := (*pq.Error)(nil); !(errors.As(err, &pqErr) &&
-		string(pqErr.Code) == pgcode.InvalidCatalogName) {
+		pgcode.MakeCode(string(pqErr.Code)) == pgcode.InvalidCatalogName) {
 		return err
 	}
 

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -604,7 +604,7 @@ func loadTPCCBench(
 		c.Wipe(ctx, roachNodes)
 		c.Start(ctx, t, append(b.startOpts(), roachNodes)...)
 	} else if pqErr := (*pq.Error)(nil); !(errors.As(err, &pqErr) &&
-		string(pqErr.Code) == pgcode.InvalidCatalogName) {
+		pgcode.MakeCode(string(pqErr.Code)) == pgcode.InvalidCatalogName) {
 		return err
 	}
 

--- a/pkg/server/server_sql_test.go
+++ b/pkg/server/server_sql_test.go
@@ -67,5 +67,5 @@ func TestTenantCannotSetClusterSetting(t *testing.T) {
 	var pqErr *pq.Error
 	ok := errors.As(err, &pqErr)
 	require.True(t, ok, "expected err to be a *pq.Error but is of type %T. error is: %v", err)
-	require.Equal(t, pq.ErrorCode(pgcode.InsufficientPrivilege), pqErr.Code, "err %v has unexpected code", err)
+	require.Equal(t, pq.ErrorCode(pgcode.InsufficientPrivilege.String()), pqErr.Code, "err %v has unexpected code", err)
 }

--- a/pkg/server/telemetry/features.go
+++ b/pkg/server/telemetry/features.go
@@ -227,7 +227,7 @@ func RecordError(err error) {
 	}
 
 	code := pgerror.GetPGCode(err)
-	Count("errorcodes." + code)
+	Count("errorcodes." + code.String())
 
 	tkeys := errors.GetTelemetryKeys(err)
 	if len(tkeys) > 0 {
@@ -238,7 +238,7 @@ func RecordError(err error) {
 		case pgcode.Internal:
 			prefix = "internalerror."
 		default:
-			prefix = "othererror." + code + "."
+			prefix = "othererror." + code.String() + "."
 		}
 
 		for _, tk := range tkeys {

--- a/pkg/sql/ambiguous_commit_test.go
+++ b/pkg/sql/ambiguous_commit_test.go
@@ -175,7 +175,7 @@ func TestAmbiguousCommit(t *testing.T) {
 
 		if _, err := sqlDB.Exec(`INSERT INTO test.t (v) VALUES (1)`); ambiguousSuccess {
 			if pqErr := (*pq.Error)(nil); errors.As(err, &pqErr) {
-				if pqErr.Code != pgcode.StatementCompletionUnknown {
+				if pgcode.MakeCode(string(pqErr.Code)) != pgcode.StatementCompletionUnknown {
 					t.Errorf("expected code %q, got %q (err: %s)",
 						pgcode.StatementCompletionUnknown, pqErr.Code, err)
 				}

--- a/pkg/sql/builtin_mem_usage_test.go
+++ b/pkg/sql/builtin_mem_usage_test.go
@@ -84,7 +84,7 @@ func TestAggregatesMonitorMemory(t *testing.T) {
 		}
 
 		_, err := sqlDB.Exec(statement)
-		if pqErr := (*pq.Error)(nil); !errors.As(err, &pqErr) || pqErr.Code != pgcode.OutOfMemory {
+		if pqErr := (*pq.Error)(nil); !errors.As(err, &pqErr) || pgcode.MakeCode(string(pqErr.Code)) != pgcode.OutOfMemory {
 			t.Fatalf("Expected \"%s\" to consume too much memory", statement)
 		}
 	}
@@ -110,7 +110,7 @@ func TestEvaluatedMemoryIsChecked(t *testing.T) {
 			_, err := sqlDB.Exec(
 				statement,
 			)
-			if pqErr := (*pq.Error)(nil); !errors.As(err, &pqErr) || pqErr.Code != pgcode.ProgramLimitExceeded {
+			if pqErr := (*pq.Error)(nil); !errors.As(err, &pqErr) || pgcode.MakeCode(string(pqErr.Code)) != pgcode.ProgramLimitExceeded {
 				t.Errorf("Expected \"%s\" to OOM, but it didn't", statement)
 			}
 		})

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -1010,7 +1010,7 @@ INSERT INTO t.kv VALUES ('a', 'b');
 
 	checkDeadlineErr := func(err error, t *testing.T) {
 		var pqe (*pq.Error)
-		if !errors.As(err, &pqe) || pqe.Code != pgcode.SerializationFailure ||
+		if !errors.As(err, &pqe) || pgcode.MakeCode(string(pqe.Code)) != pgcode.SerializationFailure ||
 			!testutils.IsError(err, "RETRY_COMMIT_DEADLINE_EXCEEDED") {
 			t.Fatalf("expected deadline exceeded, got: %v", err)
 		}

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -749,7 +749,7 @@ func TestErrorDuringPrepareInExplicitTransactionPropagates(t *testing.T) {
 		err)
 	var pgErr pgx.PgError
 	require.True(t, errors.As(err, &pgErr))
-	require.Equal(t, pgcode.SerializationFailure, pgErr.Code)
+	require.Equal(t, pgcode.SerializationFailure, pgcode.MakeCode(pgErr.Code))
 
 	// Clear the error producing filter, restart the transaction, and run it to
 	// completion.

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -408,7 +408,7 @@ VALUES ($1, 'StatusRunning', repeat('a', $2)::BYTES, repeat('a', $2)::BYTES)`, i
 			t.Fatalf("Expected \"%s\" to consume too much memory, found no error", statement)
 		}
 		if pErr := (*pq.Error)(nil); !(errors.As(err, &pErr) &&
-			pErr.Code == pgcode.OutOfMemory) {
+			pgcode.MakeCode(string(pErr.Code)) == pgcode.OutOfMemory) {
 			t.Fatalf("Expected \"%s\" to consume too much memory, found unexpected error %+v", statement, pErr)
 		}
 	})

--- a/pkg/sql/create_role_test.go
+++ b/pkg/sql/create_role_test.go
@@ -27,22 +27,22 @@ func TestUserName(t *testing.T) {
 		username   string
 		normalized string
 		err        string
-		sqlstate   string
+		sqlstate   pgcode.Code
 	}{
-		{"Abc123", "abc123", "", ""},
-		{"0123121132", "0123121132", "", ""},
-		{"HeLlO", "hello", "", ""},
-		{"Ομηρος", "ομηρος", "", ""},
-		{"_HeLlO", "_hello", "", ""},
-		{"a-BC-d", "a-bc-d", "", ""},
-		{"A.Bcd", "a.bcd", "", ""},
-		{"WWW.BIGSITE.NET", "www.bigsite.net", "", ""},
+		{"Abc123", "abc123", "", pgcode.Code{}},
+		{"0123121132", "0123121132", "", pgcode.Code{}},
+		{"HeLlO", "hello", "", pgcode.Code{}},
+		{"Ομηρος", "ομηρος", "", pgcode.Code{}},
+		{"_HeLlO", "_hello", "", pgcode.Code{}},
+		{"a-BC-d", "a-bc-d", "", pgcode.Code{}},
+		{"A.Bcd", "a.bcd", "", pgcode.Code{}},
+		{"WWW.BIGSITE.NET", "www.bigsite.net", "", pgcode.Code{}},
 		{"", "", `username "" invalid`, pgcode.InvalidName},
 		{"-ABC", "", `username "-abc" invalid`, pgcode.InvalidName},
 		{".ABC", "", `username ".abc" invalid`, pgcode.InvalidName},
 		{"*.wildcard", "", `username "\*.wildcard" invalid`, pgcode.InvalidName},
 		{"foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoof", "", `username "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoof" is too long`, pgcode.NameTooLong},
-		{"M", "m", "", ""},
+		{"M", "m", "", pgcode.Code{}},
 		{".", "", `username "." invalid`, pgcode.InvalidName},
 	}
 

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2152,7 +2152,7 @@ func (t *logicTest) verifyError(
 	if err != nil {
 		if pqErr := (*pq.Error)(nil); errors.As(err, &pqErr) &&
 			strings.HasPrefix(string(pqErr.Code), "XX" /* internal error, corruption, etc */) &&
-			string(pqErr.Code) != pgcode.Uncategorized /* this is also XX but innocuous */ {
+			pgcode.MakeCode(string(pqErr.Code)) != pgcode.Uncategorized /* this is also XX but innocuous */ {
 			if expectErrCode != string(pqErr.Code) {
 				return false, errors.Errorf(
 					"%s: %s: serious error with code %q occurred; if expected, must use 'error pgcode %s ...' in test:\n%s",
@@ -2193,7 +2193,7 @@ func formatErr(err error) string {
 		if pqErr.Detail != "" {
 			fmt.Fprintf(&buf, "\nDETAIL: %s", pqErr.Detail)
 		}
-		if pqErr.Code == pgcode.Internal {
+		if pgcode.MakeCode(string(pqErr.Code)) == pgcode.Internal {
 			fmt.Fprintln(&buf, "\nNOTE: internal errors may have more details in logs. Use -show-logs.")
 		}
 		return buf.String()

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -397,7 +397,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			}
 			pgerr := pgerror.Flatten(err)
 			text := strings.TrimSpace(pgerr.Error())
-			if pgerr.Code != pgcode.Uncategorized {
+			if pgcode.MakeCode(pgerr.Code) != pgcode.Uncategorized {
 				// Output Postgres error code if it's available.
 				return fmt.Sprintf("error (%s): %s\n", pgerr.Code, text)
 			}
@@ -414,7 +414,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			}
 			pgerr := pgerror.Flatten(err)
 			text := strings.TrimSpace(pgerr.Error())
-			if pgerr.Code != pgcode.Uncategorized {
+			if pgcode.MakeCode(pgerr.Code) != pgcode.Uncategorized {
 				// Output Postgres error code if it's available.
 				return fmt.Sprintf("error (%s): %s\n", pgerr.Code, text)
 			}

--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -407,7 +407,7 @@ func fmtErr(err error) string {
 		errStr := ""
 		if pqErr := (*pq.Error)(nil); errors.As(err, &pqErr) {
 			errStr = pqErr.Message
-			if pqErr.Code != pgcode.Uncategorized {
+			if pgcode.MakeCode(string(pqErr.Code)) != pgcode.Uncategorized {
 				errStr += fmt.Sprintf(" (SQLSTATE %s)", pqErr.Code)
 			}
 			if pqErr.Hint != "" {

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -543,7 +543,7 @@ func expectExecPortal(
 }
 
 func expectSendError(
-	ctx context.Context, t *testing.T, pgErrCode string, rd *sql.StmtBufReader, c *conn,
+	ctx context.Context, t *testing.T, pgErrCode pgcode.Code, rd *sql.StmtBufReader, c *conn,
 ) {
 	t.Helper()
 	cmd, err := rd.CurCmd()

--- a/pkg/sql/pgwire/pgcode/codes.go
+++ b/pkg/sql/pgwire/pgcode/codes.go
@@ -10,305 +10,325 @@
 
 package pgcode
 
+// Code is a wrapper around a string to ensure that pgcodes are used in
+// different pgerror functions by avoiding accidental string input.
+type Code struct {
+	code string
+}
+
+// MakeCode converts a string into a Code.
+func MakeCode(s string) Code {
+	return Code{code: s}
+}
+
+// String returns the underlying pgcode string.
+func (c Code) String() string {
+	return c.code
+}
+
 // PG error codes from: http://www.postgresql.org/docs/9.5/static/errcodes-appendix.html.
 // Specifically, errcodes.txt is copied from from Postgres' src/backend/utils/errcodes.txt.
 //
 // The error definitions were generated using the generate.sh script,
 // with a bit of manual tweaking performed afterwards.
-const (
-	// Class 00 - Successful Completion
-	SuccessfulCompletion = "00000"
-	// Class 01 - Warning
-	Warning                                 = "01000"
-	WarningDynamicResultSetsReturned        = "0100C"
-	WarningImplicitZeroBitPadding           = "01008"
-	WarningNullValueEliminatedInSetFunction = "01003"
-	WarningPrivilegeNotGranted              = "01007"
-	WarningPrivilegeNotRevoked              = "01006"
-	WarningStringDataRightTruncation        = "01004"
-	WarningDeprecatedFeature                = "01P01"
-	// Class 02 - No Data (this is also a warning class per the SQL standard)
-	NoData                                = "02000"
-	NoAdditionalDynamicResultSetsReturned = "02001"
-	// Class 03 - SQL Statement Not Yet Complete
-	SQLStatementNotYetComplete = "03000"
-	// Class 08 - Connection Exception
-	ConnectionException                           = "08000"
-	ConnectionDoesNotExist                        = "08003"
-	ConnectionFailure                             = "08006"
-	SQLclientUnableToEstablishSQLconnection       = "08001"
-	SQLserverRejectedEstablishmentOfSQLconnection = "08004"
-	TransactionResolutionUnknown                  = "08007"
-	ProtocolViolation                             = "08P01"
-	// Class 09 - Triggered Action Exception
-	TriggeredActionException = "09000"
-	// Class 0A - Feature Not Supported
-	FeatureNotSupported = "0A000"
-	// Class 0B - Invalid Transaction Initiation
-	InvalidTransactionInitiation = "0B000"
-	// Class 0F - Locator Exception
-	LocatorException            = "0F000"
-	InvalidLocatorSpecification = "0F001"
-	// Class 0L - Invalid Grantor
-	InvalidGrantor        = "0L000"
-	InvalidGrantOperation = "0LP01"
-	// Class 0P - Invalid Role Specification
-	InvalidRoleSpecification = "0P000"
-	// Class 0Z - Diagnostics Exception
-	DiagnosticsException                           = "0Z000"
-	StackedDiagnosticsAccessedWithoutActiveHandler = "0Z002"
-	// Class 20 - Case Not Found
-	CaseNotFound = "20000"
-	// Class 21 - Cardinality Violation
-	CardinalityViolation = "21000"
-	// Class 22 - Data Exception
-	DataException                         = "22000"
-	ArraySubscript                        = "2202E"
-	CharacterNotInRepertoire              = "22021"
-	DatetimeFieldOverflow                 = "22008"
-	DivisionByZero                        = "22012"
-	InvalidWindowFrameOffset              = "22013"
-	ErrorInAssignment                     = "22005"
-	EscapeCharacterConflict               = "2200B"
-	IndicatorOverflow                     = "22022"
-	IntervalFieldOverflow                 = "22015"
-	InvalidArgumentForLogarithm           = "2201E"
-	InvalidArgumentForNtileFunction       = "22014"
-	InvalidArgumentForNthValueFunction    = "22016"
-	InvalidArgumentForPowerFunction       = "2201F"
-	InvalidArgumentForWidthBucketFunction = "2201G"
-	InvalidCharacterValueForCast          = "22018"
-	InvalidDatetimeFormat                 = "22007"
-	InvalidEscapeCharacter                = "22019"
-	InvalidEscapeOctet                    = "2200D"
-	InvalidEscapeSequence                 = "22025"
-	NonstandardUseOfEscapeCharacter       = "22P06"
-	InvalidIndicatorParameterValue        = "22010"
-	InvalidParameterValue                 = "22023"
-	InvalidRegularExpression              = "2201B"
-	InvalidRowCountInLimitClause          = "2201W"
-	InvalidRowCountInResultOffsetClause   = "2201X"
-	InvalidTimeZoneDisplacementValue      = "22009"
-	InvalidUseOfEscapeCharacter           = "2200C"
-	MostSpecificTypeMismatch              = "2200G"
-	NullValueNotAllowed                   = "22004"
-	NullValueNoIndicatorParameter         = "22002"
-	NumericValueOutOfRange                = "22003"
-	SequenceGeneratorLimitExceeded        = "2200H"
-	StringDataLengthMismatch              = "22026"
-	StringDataRightTruncation             = "22001"
-	Substring                             = "22011"
-	Trim                                  = "22027"
-	UnterminatedCString                   = "22024"
-	ZeroLengthCharacterString             = "2200F"
-	FloatingPointException                = "22P01"
-	InvalidTextRepresentation             = "22P02"
-	InvalidBinaryRepresentation           = "22P03"
-	BadCopyFileFormat                     = "22P04"
-	UntranslatableCharacter               = "22P05"
-	NotAnXMLDocument                      = "2200L"
-	InvalidXMLDocument                    = "2200M"
-	InvalidXMLContent                     = "2200N"
-	InvalidXMLComment                     = "2200S"
-	InvalidXMLProcessingInstruction       = "2200T"
-	// Class 23 - Integrity Constraint Violation
-	IntegrityConstraintViolation = "23000"
-	RestrictViolation            = "23001"
-	NotNullViolation             = "23502"
-	ForeignKeyViolation          = "23503"
-	UniqueViolation              = "23505"
-	CheckViolation               = "23514"
-	ExclusionViolation           = "23P01"
-	// Class 24 - Invalid Cursor State
-	InvalidCursorState = "24000"
-	// Class 25 - Invalid Transaction State
-	InvalidTransactionState                         = "25000"
-	ActiveSQLTransaction                            = "25001"
-	BranchTransactionAlreadyActive                  = "25002"
-	HeldCursorRequiresSameIsolationLevel            = "25008"
-	InappropriateAccessModeForBranchTransaction     = "25003"
-	InappropriateIsolationLevelForBranchTransaction = "25004"
-	NoActiveSQLTransactionForBranchTransaction      = "25005"
-	ReadOnlySQLTransaction                          = "25006"
-	SchemaAndDataStatementMixingNotSupported        = "25007"
-	NoActiveSQLTransaction                          = "25P01"
-	InFailedSQLTransaction                          = "25P02"
-	// Class 26 - Invalid SQL Statement Name
-	InvalidSQLStatementName = "26000"
-	// Class 27 - Triggered Data Change Violation
-	TriggeredDataChangeViolation = "27000"
-	// Class 28 - Invalid Authorization Specification
-	InvalidAuthorizationSpecification = "28000"
-	InvalidPassword                   = "28P01"
-	// Class 2B - Dependent Privilege Descriptors Still Exist
-	DependentPrivilegeDescriptorsStillExist = "2B000"
-	DependentObjectsStillExist              = "2BP01"
-	// Class 2D - Invalid Transaction Termination
-	InvalidTransactionTermination = "2D000"
-	// Class 2F - SQL Routine Exception
-	SQLRoutineException                               = "2F000"
-	RoutineExceptionFunctionExecutedNoReturnStatement = "2F005"
-	RoutineExceptionModifyingSQLDataNotPermitted      = "2F002"
-	RoutineExceptionProhibitedSQLStatementAttempted   = "2F003"
-	RoutineExceptionReadingSQLDataNotPermitted        = "2F004"
-	// Class 34 - Invalid Cursor Name
-	InvalidCursorName = "34000"
-	// Class 38 - External Routine Exception
-	ExternalRoutineException                       = "38000"
-	ExternalRoutineContainingSQLNotPermitted       = "38001"
-	ExternalRoutineModifyingSQLDataNotPermitted    = "38002"
-	ExternalRoutineProhibitedSQLStatementAttempted = "38003"
-	ExternalRoutineReadingSQLDataNotPermitted      = "38004"
-	// Class 39 - External Routine Invocation Exception
-	ExternalRoutineInvocationException     = "39000"
-	ExternalRoutineInvalidSQLstateReturned = "39001"
-	ExternalRoutineNullValueNotAllowed     = "39004"
-	ExternalRoutineTriggerProtocolViolated = "39P01"
-	ExternalRoutineSrfProtocolViolated     = "39P02"
-	// Class 3B - Savepoint Exception
-	SavepointException            = "3B000"
-	InvalidSavepointSpecification = "3B001"
-	// Class 3D - Invalid Catalog Name
-	InvalidCatalogName = "3D000"
-	// Class 3F - Invalid Schema Name
-	InvalidSchemaName = "3F000"
-	// Class 40 - Transaction Rollback
-	TransactionRollback                     = "40000"
-	TransactionIntegrityConstraintViolation = "40002"
-	SerializationFailure                    = "40001"
-	StatementCompletionUnknown              = "40003"
-	DeadlockDetected                        = "40P01"
-	// Class 42 - Syntax  or Access Rule Violation
-	SyntaxErrorOrAccessRuleViolation   = "42000"
-	Syntax                             = "42601"
-	InsufficientPrivilege              = "42501"
-	CannotCoerce                       = "42846"
-	Grouping                           = "42803"
-	Windowing                          = "42P20"
-	InvalidRecursion                   = "42P19"
-	InvalidForeignKey                  = "42830"
-	InvalidName                        = "42602"
-	NameTooLong                        = "42622"
-	ReservedName                       = "42939"
-	DatatypeMismatch                   = "42804"
-	IndeterminateDatatype              = "42P18"
-	CollationMismatch                  = "42P21"
-	IndeterminateCollation             = "42P22"
-	WrongObjectType                    = "42809"
-	UndefinedColumn                    = "42703"
-	UndefinedFunction                  = "42883"
-	UndefinedTable                     = "42P01"
-	UndefinedParameter                 = "42P02"
-	UndefinedObject                    = "42704"
-	DuplicateColumn                    = "42701"
-	DuplicateCursor                    = "42P03"
-	DuplicateDatabase                  = "42P04"
-	DuplicateFunction                  = "42723"
-	DuplicatePreparedStatement         = "42P05"
-	DuplicateSchema                    = "42P06"
-	DuplicateRelation                  = "42P07"
-	DuplicateAlias                     = "42712"
-	DuplicateObject                    = "42710"
-	AmbiguousColumn                    = "42702"
-	AmbiguousFunction                  = "42725"
-	AmbiguousParameter                 = "42P08"
-	AmbiguousAlias                     = "42P09"
-	InvalidColumnReference             = "42P10"
-	InvalidColumnDefinition            = "42611"
-	InvalidCursorDefinition            = "42P11"
-	InvalidDatabaseDefinition          = "42P12"
-	InvalidFunctionDefinition          = "42P13"
-	InvalidPreparedStatementDefinition = "42P14"
-	InvalidSchemaDefinition            = "42P15"
-	InvalidTableDefinition             = "42P16"
-	InvalidObjectDefinition            = "42P17"
-	FileAlreadyExists                  = "42C01"
-	// Class 44 - WITH CHECK OPTION Violation
-	WithCheckOptionViolation = "44000"
-	// Class 53 - Insufficient Resources
-	InsufficientResources      = "53000"
-	DiskFull                   = "53100"
-	OutOfMemory                = "53200"
-	TooManyConnections         = "53300"
-	ConfigurationLimitExceeded = "53400"
-	// Class 54 - Program Limit Exceeded
-	ProgramLimitExceeded = "54000"
-	StatementTooComplex  = "54001"
-	TooManyColumns       = "54011"
-	TooManyArguments     = "54023"
-	// Class 55 - Object Not In Prerequisite State
-	ObjectNotInPrerequisiteState = "55000"
-	ObjectInUse                  = "55006"
-	CantChangeRuntimeParam       = "55P02"
-	LockNotAvailable             = "55P03"
-	// Class 57 - Operator Intervention
-	OperatorIntervention = "57000"
-	QueryCanceled        = "57014"
-	AdminShutdown        = "57P01"
-	CrashShutdown        = "57P02"
-	CannotConnectNow     = "57P03"
-	DatabaseDropped      = "57P04"
-	// Class 58 - System
-	System        = "58000"
-	Io            = "58030"
-	UndefinedFile = "58P01"
-	DuplicateFile = "58P02"
-	// Class F0 - Configuration File Error
-	ConfigFile     = "F0000"
-	LockFileExists = "F0001"
-	// Class HV - Foreign Data Wrapper  (SQL/MED)
-	Fdw                                  = "HV000"
-	FdwColumnNameNotFound                = "HV005"
-	FdwDynamicParameterValueNeeded       = "HV002"
-	FdwFunctionSequence                  = "HV010"
-	FdwInconsistentDescriptorInformation = "HV021"
-	FdwInvalidAttributeValue             = "HV024"
-	FdwInvalidColumnName                 = "HV007"
-	FdwInvalidColumnNumber               = "HV008"
-	FdwInvalidDataType                   = "HV004"
-	FdwInvalidDataTypeDescriptors        = "HV006"
-	FdwInvalidDescriptorFieldIdentifier  = "HV091"
-	FdwInvalidHandle                     = "HV00B"
-	FdwInvalidOptionIndex                = "HV00C"
-	FdwInvalidOptionName                 = "HV00D"
-	FdwInvalidStringLengthOrBufferLength = "HV090"
-	FdwInvalidStringFormat               = "HV00A"
-	FdwInvalidUseOfNullPointer           = "HV009"
-	FdwTooManyHandles                    = "HV014"
-	FdwOutOfMemory                       = "HV001"
-	FdwNoSchemas                         = "HV00P"
-	FdwOptionNameNotFound                = "HV00J"
-	FdwReplyHandle                       = "HV00K"
-	FdwSchemaNotFound                    = "HV00Q"
-	FdwTableNotFound                     = "HV00R"
-	FdwUnableToCreateExecution           = "HV00L"
-	FdwUnableToCreateReply               = "HV00M"
-	FdwUnableToEstablishConnection       = "HV00N"
-	// Class P0 - PL/pgSQL Error
-	PLpgSQL        = "P0000"
-	RaiseException = "P0001"
-	NoDataFound    = "P0002"
-	TooManyRows    = "P0003"
-	// Class XX - Internal Error
-	Internal       = "XX000"
-	DataCorrupted  = "XX001"
-	IndexCorrupted = "XX002"
+var (
+	// Section: Class 00 - Successful Completion
+	SuccessfulCompletion = MakeCode("00000")
+	// Section: Class 01 - Warning
+	Warning                                 = MakeCode("01000")
+	WarningDynamicResultSetsReturned        = MakeCode("0100C")
+	WarningImplicitZeroBitPadding           = MakeCode("01008")
+	WarningNullValueEliminatedInSetFunction = MakeCode("01003")
+	WarningPrivilegeNotGranted              = MakeCode("01007")
+	WarningPrivilegeNotRevoked              = MakeCode("01006")
+	WarningStringDataRightTruncation        = MakeCode("01004")
+	WarningDeprecatedFeature                = MakeCode("01P01")
+	// Section: Class 02 - No Data (this is also a warning class per the SQL standard)
+	NoData                                = MakeCode("02000")
+	NoAdditionalDynamicResultSetsReturned = MakeCode("02001")
+	// Section: Class 03 - SQL Statement Not Yet Complete
+	SQLStatementNotYetComplete = MakeCode("03000")
+	// Section: Class 08 - Connection Exception
+	ConnectionException                           = MakeCode("08000")
+	ConnectionDoesNotExist                        = MakeCode("08003")
+	ConnectionFailure                             = MakeCode("08006")
+	SQLclientUnableToEstablishSQLconnection       = MakeCode("08001")
+	SQLserverRejectedEstablishmentOfSQLconnection = MakeCode("08004")
+	TransactionResolutionUnknown                  = MakeCode("08007")
+	ProtocolViolation                             = MakeCode("08P01")
+	// Section: Class 09 - Triggered Action Exception
+	TriggeredActionException = MakeCode("09000")
+	// Section: Class 0A - Feature Not Supported
+	FeatureNotSupported = MakeCode("0A000")
+	// Section: Class 0B - Invalid Transaction Initiation
+	InvalidTransactionInitiation = MakeCode("0B000")
+	// Section: Class 0F - Locator Exception
+	LocatorException            = MakeCode("0F000")
+	InvalidLocatorSpecification = MakeCode("0F001")
+	// Section: Class 0L - Invalid Grantor
+	InvalidGrantor        = MakeCode("0L000")
+	InvalidGrantOperation = MakeCode("0LP01")
+	// Section: Class 0P - Invalid Role Specification
+	InvalidRoleSpecification = MakeCode("0P000")
+	// Section: Class 0Z - Diagnostics Exception
+	DiagnosticsException                           = MakeCode("0Z000")
+	StackedDiagnosticsAccessedWithoutActiveHandler = MakeCode("0Z002")
+	// Section: Class 20 - Case Not Found
+	CaseNotFound = MakeCode("20000")
+	// Section: Class 21 - Cardinality Violation
+	CardinalityViolation = MakeCode("21000")
+	// Section: Class 22 - Data Exception
+	DataException                         = MakeCode("22000")
+	ArraySubscript                        = MakeCode("2202E")
+	CharacterNotInRepertoire              = MakeCode("22021")
+	DatetimeFieldOverflow                 = MakeCode("22008")
+	DivisionByZero                        = MakeCode("22012")
+	InvalidWindowFrameOffset              = MakeCode("22013")
+	ErrorInAssignment                     = MakeCode("22005")
+	EscapeCharacterConflict               = MakeCode("2200B")
+	IndicatorOverflow                     = MakeCode("22022")
+	IntervalFieldOverflow                 = MakeCode("22015")
+	InvalidArgumentForLogarithm           = MakeCode("2201E")
+	InvalidArgumentForNtileFunction       = MakeCode("22014")
+	InvalidArgumentForNthValueFunction    = MakeCode("22016")
+	InvalidArgumentForPowerFunction       = MakeCode("2201F")
+	InvalidArgumentForWidthBucketFunction = MakeCode("2201G")
+	InvalidCharacterValueForCast          = MakeCode("22018")
+	InvalidDatetimeFormat                 = MakeCode("22007")
+	InvalidEscapeCharacter                = MakeCode("22019")
+	InvalidEscapeOctet                    = MakeCode("2200D")
+	InvalidEscapeSequence                 = MakeCode("22025")
+	NonstandardUseOfEscapeCharacter       = MakeCode("22P06")
+	InvalidIndicatorParameterValue        = MakeCode("22010")
+	InvalidParameterValue                 = MakeCode("22023")
+	InvalidRegularExpression              = MakeCode("2201B")
+	InvalidRowCountInLimitClause          = MakeCode("2201W")
+	InvalidRowCountInResultOffsetClause   = MakeCode("2201X")
+	InvalidTimeZoneDisplacementValue      = MakeCode("22009")
+	InvalidUseOfEscapeCharacter           = MakeCode("2200C")
+	MostSpecificTypeMismatch              = MakeCode("2200G")
+	NullValueNotAllowed                   = MakeCode("22004")
+	NullValueNoIndicatorParameter         = MakeCode("22002")
+	NumericValueOutOfRange                = MakeCode("22003")
+	SequenceGeneratorLimitExceeded        = MakeCode("2200H")
+	StringDataLengthMismatch              = MakeCode("22026")
+	StringDataRightTruncation             = MakeCode("22001")
+	Substring                             = MakeCode("22011")
+	Trim                                  = MakeCode("22027")
+	UnterminatedCString                   = MakeCode("22024")
+	ZeroLengthCharacterString             = MakeCode("2200F")
+	FloatingPointException                = MakeCode("22P01")
+	InvalidTextRepresentation             = MakeCode("22P02")
+	InvalidBinaryRepresentation           = MakeCode("22P03")
+	BadCopyFileFormat                     = MakeCode("22P04")
+	UntranslatableCharacter               = MakeCode("22P05")
+	NotAnXMLDocument                      = MakeCode("2200L")
+	InvalidXMLDocument                    = MakeCode("2200M")
+	InvalidXMLContent                     = MakeCode("2200N")
+	InvalidXMLComment                     = MakeCode("2200S")
+	InvalidXMLProcessingInstruction       = MakeCode("2200T")
+	// Section: Class 23 - Integrity Constraint Violation
+	IntegrityConstraintViolation = MakeCode("23000")
+	RestrictViolation            = MakeCode("23001")
+	NotNullViolation             = MakeCode("23502")
+	ForeignKeyViolation          = MakeCode("23503")
+	UniqueViolation              = MakeCode("23505")
+	CheckViolation               = MakeCode("23514")
+	ExclusionViolation           = MakeCode("23P01")
+	// Section: Class 24 - Invalid Cursor State
+	InvalidCursorState = MakeCode("24000")
+	// Section: Class 25 - Invalid Transaction State
+	InvalidTransactionState                         = MakeCode("25000")
+	ActiveSQLTransaction                            = MakeCode("25001")
+	BranchTransactionAlreadyActive                  = MakeCode("25002")
+	HeldCursorRequiresSameIsolationLevel            = MakeCode("25008")
+	InappropriateAccessModeForBranchTransaction     = MakeCode("25003")
+	InappropriateIsolationLevelForBranchTransaction = MakeCode("25004")
+	NoActiveSQLTransactionForBranchTransaction      = MakeCode("25005")
+	ReadOnlySQLTransaction                          = MakeCode("25006")
+	SchemaAndDataStatementMixingNotSupported        = MakeCode("25007")
+	NoActiveSQLTransaction                          = MakeCode("25P01")
+	InFailedSQLTransaction                          = MakeCode("25P02")
+	// Section: Class 26 - Invalid SQL Statement Name
+	InvalidSQLStatementName = MakeCode("26000")
+	// Section: Class 27 - Triggered Data Change Violation
+	TriggeredDataChangeViolation = MakeCode("27000")
+	// Section: Class 28 - Invalid Authorization Specification
+	InvalidAuthorizationSpecification = MakeCode("28000")
+	InvalidPassword                   = MakeCode("28P01")
+	// Section: Class 2B - Dependent Privilege Descriptors Still Exist
+	DependentPrivilegeDescriptorsStillExist = MakeCode("2B000")
+	DependentObjectsStillExist              = MakeCode("2BP01")
+	// Section: Class 2D - Invalid Transaction Termination
+	InvalidTransactionTermination = MakeCode("2D000")
+	// Section: Class 2F - SQL Routine Exception
+	RoutineExceptionFunctionExecutedNoReturnStatement = MakeCode("2F005")
+	RoutineExceptionModifyingSQLDataNotPermitted      = MakeCode("2F002")
+	RoutineExceptionProhibitedSQLStatementAttempted   = MakeCode("2F003")
+	RoutineExceptionReadingSQLDataNotPermitted        = MakeCode("2F004")
+	// Section: Class 34 - Invalid Cursor Name
+	InvalidCursorName = MakeCode("34000")
+	// Section: Class 38 - External Routine Exception
+	ExternalRoutineException                       = MakeCode("38000")
+	ExternalRoutineContainingSQLNotPermitted       = MakeCode("38001")
+	ExternalRoutineModifyingSQLDataNotPermitted    = MakeCode("38002")
+	ExternalRoutineProhibitedSQLStatementAttempted = MakeCode("38003")
+	ExternalRoutineReadingSQLDataNotPermitted      = MakeCode("38004")
+	// Section: Class 39 - External Routine Invocation Exception
+	ExternalRoutineInvocationException     = MakeCode("39000")
+	ExternalRoutineInvalidSQLstateReturned = MakeCode("39001")
+	ExternalRoutineNullValueNotAllowed     = MakeCode("39004")
+	ExternalRoutineTriggerProtocolViolated = MakeCode("39P01")
+	ExternalRoutineSrfProtocolViolated     = MakeCode("39P02")
+	// Section: Class 3B - Savepoint Exception
+	SavepointException            = MakeCode("3B000")
+	InvalidSavepointSpecification = MakeCode("3B001")
+	// Section: Class 3D - Invalid Catalog Name
+	InvalidCatalogName = MakeCode("3D000")
+	// Section: Class 3F - Invalid Schema Name
+	InvalidSchemaName = MakeCode("3F000")
+	// Section: Class 40 - Transaction Rollback
+	TransactionRollback                     = MakeCode("40000")
+	TransactionIntegrityConstraintViolation = MakeCode("40002")
+	SerializationFailure                    = MakeCode("40001")
+	StatementCompletionUnknown              = MakeCode("40003")
+	DeadlockDetected                        = MakeCode("40P01")
+	// Section: Class 42 - Syntax Error or Access Rule Violation
+	SyntaxErrorOrAccessRuleViolation   = MakeCode("42000")
+	Syntax                             = MakeCode("42601")
+	InsufficientPrivilege              = MakeCode("42501")
+	CannotCoerce                       = MakeCode("42846")
+	Grouping                           = MakeCode("42803")
+	Windowing                          = MakeCode("42P20")
+	InvalidRecursion                   = MakeCode("42P19")
+	InvalidForeignKey                  = MakeCode("42830")
+	InvalidName                        = MakeCode("42602")
+	NameTooLong                        = MakeCode("42622")
+	ReservedName                       = MakeCode("42939")
+	DatatypeMismatch                   = MakeCode("42804")
+	IndeterminateDatatype              = MakeCode("42P18")
+	CollationMismatch                  = MakeCode("42P21")
+	IndeterminateCollation             = MakeCode("42P22")
+	WrongObjectType                    = MakeCode("42809")
+	UndefinedColumn                    = MakeCode("42703")
+	UndefinedCursor                    = MakeCode("34000")
+	UndefinedDatabase                  = MakeCode("3D000")
+	UndefinedFunction                  = MakeCode("42883")
+	UndefinedPreparedStatement         = MakeCode("26000")
+	UndefinedSchema                    = MakeCode("3F000")
+	UndefinedTable                     = MakeCode("42P01")
+	UndefinedParameter                 = MakeCode("42P02")
+	UndefinedObject                    = MakeCode("42704")
+	DuplicateColumn                    = MakeCode("42701")
+	DuplicateCursor                    = MakeCode("42P03")
+	DuplicateDatabase                  = MakeCode("42P04")
+	DuplicateFunction                  = MakeCode("42723")
+	DuplicatePreparedStatement         = MakeCode("42P05")
+	DuplicateSchema                    = MakeCode("42P06")
+	DuplicateRelation                  = MakeCode("42P07")
+	DuplicateAlias                     = MakeCode("42712")
+	DuplicateObject                    = MakeCode("42710")
+	AmbiguousColumn                    = MakeCode("42702")
+	AmbiguousFunction                  = MakeCode("42725")
+	AmbiguousParameter                 = MakeCode("42P08")
+	AmbiguousAlias                     = MakeCode("42P09")
+	InvalidColumnReference             = MakeCode("42P10")
+	InvalidColumnDefinition            = MakeCode("42611")
+	InvalidCursorDefinition            = MakeCode("42P11")
+	InvalidDatabaseDefinition          = MakeCode("42P12")
+	InvalidFunctionDefinition          = MakeCode("42P13")
+	InvalidPreparedStatementDefinition = MakeCode("42P14")
+	InvalidSchemaDefinition            = MakeCode("42P15")
+	InvalidTableDefinition             = MakeCode("42P16")
+	InvalidObjectDefinition            = MakeCode("42P17")
+	FileAlreadyExists                  = MakeCode("42C01")
+	// Section: Class 44 - WITH CHECK OPTION Violation
+	WithCheckOptionViolation = MakeCode("44000")
+	// Section: Class 53 - Insufficient Resources
+	InsufficientResources      = MakeCode("53000")
+	DiskFull                   = MakeCode("53100")
+	OutOfMemory                = MakeCode("53200")
+	TooManyConnections         = MakeCode("53300")
+	ConfigurationLimitExceeded = MakeCode("53400")
+	// Section: Class 54 - Program Limit Exceeded
+	ProgramLimitExceeded = MakeCode("54000")
+	StatementTooComplex  = MakeCode("54001")
+	TooManyColumns       = MakeCode("54011")
+	TooManyArguments     = MakeCode("54023")
+	// Section: Class 55 - Object Not In Prerequisite State
+	ObjectNotInPrerequisiteState = MakeCode("55000")
+	ObjectInUse                  = MakeCode("55006")
+	CantChangeRuntimeParam       = MakeCode("55P02")
+	LockNotAvailable             = MakeCode("55P03")
+	// Section: Class 57 - Operator Intervention
+	OperatorIntervention = MakeCode("57000")
+	QueryCanceled        = MakeCode("57014")
+	AdminShutdown        = MakeCode("57P01")
+	CrashShutdown        = MakeCode("57P02")
+	CannotConnectNow     = MakeCode("57P03")
+	DatabaseDropped      = MakeCode("57P04")
+	// Section: Class 58 - System Error
+	System        = MakeCode("58000")
+	Io            = MakeCode("58030")
+	UndefinedFile = MakeCode("58P01")
+	DuplicateFile = MakeCode("58P02")
+	// Section: Class F0 - Configuration File Error
+	ConfigFile     = MakeCode("F0000")
+	LockFileExists = MakeCode("F0001")
+	// Section: Class HV - Foreign Data Wrapper Error (SQL/MED)
+	FdwError                             = MakeCode("HV000")
+	FdwColumnNameNotFound                = MakeCode("HV005")
+	FdwDynamicParameterValueNeeded       = MakeCode("HV002")
+	FdwFunctionSequenceError             = MakeCode("HV010")
+	FdwInconsistentDescriptorInformation = MakeCode("HV021")
+	FdwInvalidAttributeValue             = MakeCode("HV024")
+	FdwInvalidColumnName                 = MakeCode("HV007")
+	FdwInvalidColumnNumber               = MakeCode("HV008")
+	FdwInvalidDataType                   = MakeCode("HV004")
+	FdwInvalidDataTypeDescriptors        = MakeCode("HV006")
+	FdwInvalidDescriptorFieldIdentifier  = MakeCode("HV091")
+	FdwInvalidHandle                     = MakeCode("HV00B")
+	FdwInvalidOptionIndex                = MakeCode("HV00C")
+	FdwInvalidOptionName                 = MakeCode("HV00D")
+	FdwInvalidStringLengthOrBufferLength = MakeCode("HV090")
+	FdwInvalidStringFormat               = MakeCode("HV00A")
+	FdwInvalidUseOfNullPointer           = MakeCode("HV009")
+	FdwTooManyHandles                    = MakeCode("HV014")
+	FdwOutOfMemory                       = MakeCode("HV001")
+	FdwNoSchemas                         = MakeCode("HV00P")
+	FdwOptionNameNotFound                = MakeCode("HV00J")
+	FdwReplyHandle                       = MakeCode("HV00K")
+	FdwSchemaNotFound                    = MakeCode("HV00Q")
+	FdwTableNotFound                     = MakeCode("HV00R")
+	FdwUnableToCreateExecution           = MakeCode("HV00L")
+	FdwUnableToCreateReply               = MakeCode("HV00M")
+	FdwUnableToEstablishConnection       = MakeCode("HV00N")
+	// Section: Class P0 - PL/pgSQL Error
+	PLpgSQL        = MakeCode("P0000")
+	RaiseException = MakeCode("P0001")
+	NoDataFound    = MakeCode("P0002")
+	TooManyRows    = MakeCode("P0003")
+	AssertFailure  = MakeCode("P0004")
+	// Section: Class XX - Internal Error
+	Internal       = MakeCode("XX000")
+	DataCorrupted  = MakeCode("XX001")
+	IndexCorrupted = MakeCode("XX002")
 )
 
 // The following errors are CockroachDB-specific.
 
-const (
+var (
 	// Uncategorized is used for errors that flow out to a client
 	// when there's no code known yet.
-	Uncategorized = "XXUUU"
+	Uncategorized = MakeCode("XXUUU")
 
 	// CCLRequired signals that a CCL binary is required to complete this
 	// task.
-	CCLRequired = "XXC01"
+	CCLRequired = MakeCode("XXC01")
 
 	// CCLValidLicenseRequired signals that a valid CCL license is
 	// required to complete this task.
-	CCLValidLicenseRequired = "XXC02"
+	CCLValidLicenseRequired = MakeCode("XXC02")
 
 	// TransactionCommittedWithSchemaChangeFailure signals that the
 	// non-DDL payload of a transaction was committed successfully but
@@ -327,7 +347,7 @@ const (
 	//   that:
 	//       serious error with code "XXA00" occurred; if expected,
 	//       must use 'error pgcode XXA00 ...'
-	TransactionCommittedWithSchemaChangeFailure = "XXA00"
+	TransactionCommittedWithSchemaChangeFailure = MakeCode("XXA00")
 
 	// Class 22C - Semantic errors in the structure of a SQL statement.
 
@@ -335,7 +355,7 @@ const (
 	// operator or built-in function was used that requires a full session
 	// context and thus cannot be run in a background job or away from the SQL
 	// gateway.
-	ScalarOperationCannotRunWithoutFullSessionContext = "22C01"
+	ScalarOperationCannotRunWithoutFullSessionContext = MakeCode("22C01")
 
 	// Class 55C - Object Not In Prerequisite State (Cockroach extension)
 
@@ -343,25 +363,25 @@ const (
 	// CHANGEFEED has lead to its termination. If this error code is received
 	// the CHANGEFEED will have previously emitted a resolved timestamp which
 	// precedes the hlc timestamp of the relevant DDL transaction.
-	SchemaChangeOccurred = "55C01"
+	SchemaChangeOccurred = MakeCode("55C01")
 
 	// NoPrimaryKey signals that a table descriptor is invalid because the table
 	// does not have a primary key.
-	NoPrimaryKey = "55C02"
+	NoPrimaryKey = MakeCode("55C02")
 
 	// Class 58C - System errors related to CockroachDB node problems.
 
 	// RangeUnavailable signals that some data from the cluster cannot be
 	// accessed (e.g. because all replicas awol).
-	RangeUnavailable = "58C00"
+	RangeUnavailable = MakeCode("58C00")
 	// DeprecatedRangeUnavailable is code that we used for RangeUnavailable until 19.2.
 	// 20.1 needs to recognize it coming from 19.2 nodes.
 	// TODO(andrei): remove in 20.2.
-	DeprecatedRangeUnavailable = "XXC00"
+	DeprecatedRangeUnavailable = MakeCode("XXC00")
 
 	// InternalConnectionFailure refers to a networking error encountered
 	// internally on a connection between different Cockroach nodes.
-	InternalConnectionFailure = "58C01"
+	InternalConnectionFailure = MakeCode("58C01")
 	// DeprecatedInternalConnectionFailure is code that we used for
 	// InternalConnectionFailure until 19.2.
 	// 20.1 needs to recognize it coming from 19.2 nodes.

--- a/pkg/sql/pgwire/pgcode/generate.sh
+++ b/pkg/sql/pgwire/pgcode/generate.sh
@@ -9,7 +9,7 @@ set -eu
 sed '/^\s*$/d' errcodes.txt |
 sed '/^#.*$/d' |
 sed -E 's|^(Section.*)$|// \1|' |
-sed -E 's|^([A-Z0-9]{5})    .    ERRCODE_([A-Z_]+).*$|\2 = "\1"|' |
+sed -E 's|^([A-Z0-9]{5})    .    ERRCODE_([A-Z_]+).*$|\2 = MakeCode("\1")|' |
 # Postgres uses class 58 just for external errors, but we've extended it with some errors
 # internal to the cluster (inspired by DB2).
 sed -E 's|// Section: Class 58 - System Error \(errors external to PostgreSQL itself\)|// Section: Class 58 - System Error|' |

--- a/pkg/sql/pgwire/pgerror/errors.go
+++ b/pkg/sql/pgwire/pgerror/errors.go
@@ -65,21 +65,21 @@ func formatMsgHintDetail(prefix, msg, hint, detail string) string {
 
 // NewWithDepthf creates an error with a pg code and extracts the context
 // information at the specified depth level.
-func NewWithDepthf(depth int, code string, format string, args ...interface{}) error {
+func NewWithDepthf(depth int, code pgcode.Code, format string, args ...interface{}) error {
 	err := errors.NewWithDepthf(1+depth, format, args...)
 	err = WithCandidateCode(err, code)
 	return err
 }
 
 // New creates an error with a code.
-func New(code string, msg string) error {
+func New(code pgcode.Code, msg string) error {
 	err := errors.NewWithDepth(1, msg)
 	err = WithCandidateCode(err, code)
 	return err
 }
 
 // Newf creates an Error with a format string.
-func Newf(code string, format string, args ...interface{}) error {
+func Newf(code pgcode.Code, format string, args ...interface{}) error {
 	err := errors.NewWithDepthf(1, format, args...)
 	err = WithCandidateCode(err, code)
 	return err

--- a/pkg/sql/pgwire/pgerror/errors_test.go
+++ b/pkg/sql/pgwire/pgerror/errors_test.go
@@ -16,15 +16,16 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 )
 
 func TestPGError(t *testing.T) {
 	const msg = "err"
-	const code = "abc"
+	var code = pgcode.MakeCode("abc")
 
 	checkErr := func(pErr *pgerror.Error, errMsg string) {
-		if pErr.Code != code {
+		if pgcode.MakeCode(pErr.Code) != code {
 			t.Fatalf("got: %q\nwant: %q", pErr.Code, code)
 		}
 		if pErr.Message != errMsg {

--- a/pkg/sql/pgwire/pgerror/flatten.go
+++ b/pkg/sql/pgwire/pgerror/flatten.go
@@ -37,7 +37,7 @@ func Flatten(err error) *Error {
 		return nil
 	}
 	resErr := &Error{
-		Code:     GetPGCode(err),
+		Code:     GetPGCode(err).String(),
 		Message:  err.Error(),
 		Severity: GetSeverity(err),
 	}
@@ -53,7 +53,7 @@ func Flatten(err error) *Error {
 
 	// Add a useful error prefix if not already there.
 	switch resErr.Code {
-	case pgcode.Internal:
+	case pgcode.Internal.String():
 		// The string "internal error" clarifies the nature of the error
 		// to users, and is also introduced for compatibility with
 		// previous CockroachDB versions.
@@ -67,7 +67,7 @@ func Flatten(err error) *Error {
 		// append the innermost stack trace.
 		resErr.Detail += getInnerMostStackTraceAsDetail(err)
 
-	case pgcode.SerializationFailure:
+	case pgcode.SerializationFailure.String():
 		// The string "restart transaction" is asserted by test code. This
 		// can be changed if/when test code learns to use the 40001 code
 		// (or the errors library) instead.
@@ -110,6 +110,6 @@ const InternalErrorPrefix = "internal error"
 const TxnRetryMsgPrefix = "restart transaction"
 
 // GetPGCode retrieves the error code for an error.
-func GetPGCode(err error) string {
+func GetPGCode(err error) pgcode.Code {
 	return GetPGCodeInternal(err, ComputeDefaultCode)
 }

--- a/pkg/sql/pgwire/pgerror/flatten_test.go
+++ b/pkg/sql/pgwire/pgerror/flatten_test.go
@@ -33,7 +33,7 @@ func TestFlatten(t *testing.T) {
 			func(t testutils.T, e *pgerror.Error) {
 				t.CheckEqual(e.Message, "woo")
 				// Errors without code flatten to Uncategorized.
-				t.CheckEqual(e.Code, pgcode.Uncategorized)
+				t.CheckEqual(pgcode.MakeCode(e.Code), pgcode.Uncategorized)
 				t.CheckEqual(e.Severity, "ERROR")
 			},
 		},
@@ -41,7 +41,7 @@ func TestFlatten(t *testing.T) {
 			pgerror.WithCandidateCode(baseErr, pgcode.Syntax),
 			func(t testutils.T, e *pgerror.Error) {
 				t.CheckEqual(e.Message, "woo")
-				t.CheckEqual(e.Code, pgcode.Syntax)
+				t.CheckEqual(pgcode.MakeCode(e.Code), pgcode.Syntax)
 			},
 		},
 		{
@@ -68,7 +68,7 @@ func TestFlatten(t *testing.T) {
 		{
 			unimplemented.New("woo", "woo"),
 			func(t testutils.T, e *pgerror.Error) {
-				t.CheckEqual(e.Code, pgcode.FeatureNotSupported)
+				t.CheckEqual(pgcode.MakeCode(e.Code), pgcode.FeatureNotSupported)
 				t.CheckRegexpEqual(e.Hint, "You have attempted to use a feature that is not yet implemented")
 				t.CheckRegexpEqual(e.Hint, "support form")
 			},
@@ -76,7 +76,7 @@ func TestFlatten(t *testing.T) {
 		{
 			errors.AssertionFailedf("woo"),
 			func(t testutils.T, e *pgerror.Error) {
-				t.CheckEqual(e.Code, pgcode.Internal)
+				t.CheckEqual(pgcode.MakeCode(e.Code), pgcode.Internal)
 				t.CheckRegexpEqual(e.Hint, "You have encountered an unexpected error")
 				t.CheckRegexpEqual(e.Hint, "support form")
 			},
@@ -85,14 +85,14 @@ func TestFlatten(t *testing.T) {
 			errors.Wrap(&roachpb.TransactionRetryWithProtoRefreshError{Msg: "woo"}, ""),
 			func(t testutils.T, e *pgerror.Error) {
 				t.CheckRegexpEqual(e.Message, "restart transaction: .* woo")
-				t.CheckEqual(e.Code, pgcode.SerializationFailure)
+				t.CheckEqual(pgcode.MakeCode(e.Code), pgcode.SerializationFailure)
 			},
 		},
 		{
 			errors.Wrap(&roachpb.AmbiguousResultError{Message: "woo"}, ""),
 			func(t testutils.T, e *pgerror.Error) {
 				t.CheckRegexpEqual(e.Message, "result is ambiguous.*woo")
-				t.CheckEqual(e.Code, pgcode.StatementCompletionUnknown)
+				t.CheckEqual(pgcode.MakeCode(e.Code), pgcode.StatementCompletionUnknown)
 			},
 		},
 	}

--- a/pkg/sql/pgwire/pgerror/internal_errors_test.go
+++ b/pkg/sql/pgwire/pgerror/internal_errors_test.go
@@ -82,7 +82,7 @@ func TestInternalError(t *testing.T) {
 				// Verify that the information is captured.
 				{"basefields", func(t *testing.T, e *Error) {
 					eq(t, e.Message, ie+"woo waa")
-					eq(t, e.Code, pgcode.Internal)
+					eq(t, e.Code, pgcode.Internal.String())
 					m(t, e.Source.File, ".*internal_errors_test.go")
 					eq(t, e.Source.Function, "TestInternalError")
 					ml(t, e.Detail, []string{"stack trace:",
@@ -109,7 +109,7 @@ func TestInternalError(t *testing.T) {
 			[]pred{
 				{"basefields", func(t *testing.T, e *Error) {
 					eq(t, e.Message, "syn %s")
-					eq(t, e.Code, pgcode.Syntax)
+					eq(t, e.Code, pgcode.Syntax.String())
 					m(t, e.Source.File, ".*internal_errors_test.go")
 					eq(t, e.Source.Function, "TestInternalError")
 				}},
@@ -120,7 +120,7 @@ func TestInternalError(t *testing.T) {
 			Wrap(errors.Wrap(makeNormal(), "wrapA"), pgcode.Syntax, "wrapB"),
 			[]pred{
 				{"basefields", func(t *testing.T, e *Error) {
-					eq(t, e.Code, pgcode.Syntax)
+					eq(t, e.Code, pgcode.Syntax.String())
 					eq(t, e.Message, "wrapB: wrapA: syn")
 					// Source info is stored.
 					m(t, e.Source.File, ".*internal_errors_test.go")
@@ -133,7 +133,7 @@ func TestInternalError(t *testing.T) {
 			Wrap(errors.Wrap(makeBoo(), "wrapA"), pgcode.Syntax, "wrapB"),
 			[]pred{
 				{"basefields", func(t *testing.T, e *Error) {
-					eq(t, e.Code, pgcode.Internal)
+					eq(t, e.Code, pgcode.Internal.String())
 					eq(t, e.Message, ie+"wrapB: wrapA: boo")
 					// Source info is stored.
 					m(t, e.Source.File, ".*internal_errors_test.go")
@@ -156,7 +156,7 @@ func TestInternalError(t *testing.T) {
 					// Wrap adds a prefix to the message.
 					eq(t, e.Message, "wrap waa: syn foo")
 					// Original code is preserved.
-					eq(t, e.Code, pgcode.Syntax)
+					eq(t, e.Code, pgcode.Syntax.String())
 					// Source info is stored.
 					m(t, e.Source.File, ".*internal_errors_test.go")
 					eq(t, e.Source.Function, "TestInternalError")
@@ -171,7 +171,7 @@ func TestInternalError(t *testing.T) {
 					// Wrap adds a prefix to the message.
 					eq(t, e.Message, "wrap waa: fmt err")
 					// New code was added.
-					eq(t, e.Code, pgcode.AdminShutdown)
+					eq(t, e.Code, pgcode.AdminShutdown.String())
 					// Source info is stored.
 					m(t, e.Source.File, ".*internal_errors_test.go")
 					eq(t, e.Source.Function, "TestInternalError")
@@ -186,7 +186,7 @@ func TestInternalError(t *testing.T) {
 					// Wrap adds a prefix to the message.
 					eq(t, e.Message, "wrapx waa: fmt err")
 					// New code was added.
-					eq(t, e.Code, pgcode.AdminShutdown)
+					eq(t, e.Code, pgcode.AdminShutdown.String())
 					// Source info is stored.
 					m(t, e.Source.File, ".*internal_errors_test.go")
 					eq(t, e.Source.Function, "TestInternalError")
@@ -204,7 +204,7 @@ func TestInternalError(t *testing.T) {
 					// Wrap adds a prefix to the message.
 					eq(t, e.Message, "wrap2 waa: wrap1: fmt")
 					// New code was added.
-					eq(t, e.Code, pgcode.AdminShutdown)
+					eq(t, e.Code, pgcode.AdminShutdown.String())
 					// Source info is stored.
 					m(t, e.Source.File, ".*internal_errors_test.go")
 					eq(t, e.Source.Function, "TestInternalError")
@@ -223,7 +223,7 @@ func TestInternalError(t *testing.T) {
 					// Wrap adds a prefix to the message.
 					eq(t, e.Message, ie+"wrap woo: boo")
 					// Internal error was preserved.
-					eq(t, e.Code, pgcode.Internal)
+					eq(t, e.Code, pgcode.Internal.String())
 					// Source info is preserved from original error.
 					m(t, e.Source.File, ".*internal_errors_test.go")
 					eq(t, e.Source.Function, "makeBoo")
@@ -250,7 +250,7 @@ func TestInternalError(t *testing.T) {
 					// Wrap adds a prefix to the message.
 					eq(t, e.Message, ie+"iewrap waa: syn err")
 					// Internal error was preserved.
-					eq(t, e.Code, pgcode.Internal)
+					eq(t, e.Code, pgcode.Internal.String())
 					// Source info is preserved from original error.
 					m(t, e.Source.File, ".*internal_errors_test.go")
 					eq(t, e.Source.Function, "TestInternalError")
@@ -278,7 +278,7 @@ func TestInternalError(t *testing.T) {
 					// Ensure the "internal error" prefix only occurs once.
 					eq(t, e.Message, ie+"iewrap2 waa: boo")
 					// Internal error was preserved.
-					eq(t, e.Code, pgcode.Internal)
+					eq(t, e.Code, pgcode.Internal.String())
 					// Source info is preserved from original error.
 					m(t, e.Source.File, ".*internal_errors_test.go")
 					// The original cause is masked by the barrier.

--- a/pkg/sql/pgwire/pgerror/pgcode_test.go
+++ b/pkg/sql/pgwire/pgerror/pgcode_test.go
@@ -26,18 +26,18 @@ func TestPGCode(t *testing.T) {
 	tt := testutils.T{T: t}
 
 	testData := []struct {
-		outerCode    string
-		innerCode    string
+		outerCode    pgcode.Code
+		innerCode    pgcode.Code
 		innerErr     error
-		expectedCode string
+		expectedCode pgcode.Code
 	}{
-		{"foo", "bar", errors.New("world"), "bar"},
-		{"foo", pgcode.Uncategorized, errors.New("world"), "foo"},
-		{pgcode.Uncategorized, "foo", errors.New("world"), "foo"},
-		{"foo", "bar", errors.WithAssertionFailure(errors.New("world")), pgcode.Internal},
-		{"foo", "bar", errors.UnimplementedError(errors.IssueLink{}, "world"), pgcode.FeatureNotSupported},
-		{"foo", pgcode.Internal, errors.New("world"), pgcode.Internal},
-		{pgcode.Internal, "foo", errors.New("world"), pgcode.Internal},
+		{pgcode.MakeCode("foo"), pgcode.MakeCode("bar"), errors.New("world"), pgcode.MakeCode("bar")},
+		{pgcode.MakeCode("foo"), pgcode.Uncategorized, errors.New("world"), pgcode.MakeCode("foo")},
+		{pgcode.Uncategorized, pgcode.MakeCode("foo"), errors.New("world"), pgcode.MakeCode("foo")},
+		{pgcode.MakeCode("foo"), pgcode.MakeCode("bar"), errors.WithAssertionFailure(errors.New("world")), pgcode.Internal},
+		{pgcode.MakeCode("foo"), pgcode.MakeCode("bar"), errors.UnimplementedError(errors.IssueLink{}, "world"), pgcode.FeatureNotSupported},
+		{pgcode.MakeCode("foo"), pgcode.Internal, errors.New("world"), pgcode.Internal},
+		{pgcode.Internal, pgcode.MakeCode("foo"), errors.New("world"), pgcode.Internal},
 	}
 
 	for _, t := range testData {
@@ -57,8 +57,8 @@ func TestPGCode(t *testing.T) {
 					tt.CheckEqual(code, t.expectedCode)
 
 					errV := fmt.Sprintf("%+v", err)
-					tt.Check(strings.Contains(errV, "code: "+t.innerCode))
-					tt.Check(strings.Contains(errV, "code: "+t.outerCode))
+					tt.Check(strings.Contains(errV, "code: "+t.innerCode.String()))
+					tt.Check(strings.Contains(errV, "code: "+t.outerCode.String()))
 				}
 
 				tt.Run("local", func(tt testutils.T) { theTest(tt, origErr) })

--- a/pkg/sql/pgwire/pgerror/with_candidate_code.go
+++ b/pkg/sql/pgwire/pgerror/with_candidate_code.go
@@ -51,7 +51,7 @@ func (w *withCandidateCode) FormatError(p errors.Printer) (next error) {
 func decodeWithCandidateCode(
 	_ context.Context, cause error, _ string, details []string, _ proto.Message,
 ) error {
-	code := pgcode.Uncategorized
+	code := pgcode.Uncategorized.String()
 	if len(details) > 0 {
 		code = details[0]
 	}

--- a/pkg/sql/pgwire/pgerror/wrap.go
+++ b/pkg/sql/pgwire/pgerror/wrap.go
@@ -10,18 +10,23 @@
 
 package pgerror
 
-import "github.com/cockroachdb/errors"
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/errors"
+)
 
 // Wrapf wraps an error and adds a pg error code. See
 // the doc on WrapWithDepthf for details.
-func Wrapf(err error, code, format string, args ...interface{}) error {
+func Wrapf(err error, code pgcode.Code, format string, args ...interface{}) error {
 	return WrapWithDepthf(1, err, code, format, args...)
 }
 
 // WrapWithDepthf wraps an error. It also annotates the provided
 // pg code as new candidate code, to be used if the underlying
 // error does not have one already.
-func WrapWithDepthf(depth int, err error, code, format string, args ...interface{}) error {
+func WrapWithDepthf(
+	depth int, err error, code pgcode.Code, format string, args ...interface{},
+) error {
 	err = errors.WrapWithDepthf(1+depth, err, format, args...)
 	err = WithCandidateCode(err, code)
 	return err
@@ -29,7 +34,7 @@ func WrapWithDepthf(depth int, err error, code, format string, args ...interface
 
 // Wrap wraps an error and adds a pg error code. Only the code
 // is added if the message is empty.
-func Wrap(err error, code, msg string) error {
+func Wrap(err error, code pgcode.Code, msg string) error {
 	if msg == "" {
 		return WithCandidateCode(err, code)
 	}

--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -354,7 +354,7 @@ func TestCancelIfExists(t *testing.T) {
 
 func isClientsideQueryCanceledErr(err error) bool {
 	if pqErr := (*pq.Error)(nil); errors.As(err, &pqErr) {
-		return pqErr.Code == pgcode.QueryCanceled
+		return pgcode.MakeCode(string(pqErr.Code)) == pgcode.QueryCanceled
 	}
 	return pgerror.GetPGCode(err) == pgcode.QueryCanceled
 }

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3367,7 +3367,7 @@ may increase either contention or retry errors, or both.`,
 				if errCode == "" {
 					return nil, errors.Newf("%s", msg)
 				}
-				return nil, pgerror.Newf(errCode, "%s", msg)
+				return nil, pgerror.Newf(pgcode.MakeCode(errCode), "%s", msg)
 			},
 			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
 			Volatility: tree.VolatilityVolatile,

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3446,7 +3446,7 @@ type regTypeInfo struct {
 	// objName is a human-readable name describing the objects in the table.
 	objName string
 	// errType is the pg error code in case the object does not exist.
-	errType string
+	errType pgcode.Code
 }
 
 // regTypeInfos maps an oid.Oid to a regTypeInfo that describes the pg_catalog
@@ -3742,7 +3742,7 @@ func (expr *IfErrExpr) Eval(ctx *EvalContext) (Datum, error) {
 			return nil, evalErr
 		}
 		errpatStr := string(MustBeDString(errpat))
-		if code := pgerror.GetPGCode(evalErr); code != errpatStr {
+		if code := pgerror.GetPGCode(evalErr); code != pgcode.MakeCode(errpatStr) {
 			return nil, evalErr
 		}
 	}

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -775,7 +775,7 @@ func NewInvalidNestedSRFError(context string) error {
 // NewInvalidFunctionUsageError creates a rejection for a special function.
 func NewInvalidFunctionUsageError(class FunctionClass, context string) error {
 	var cat string
-	var code string
+	var code pgcode.Code
 	switch class {
 	case AggregateClass:
 		cat = "aggregate"

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -207,7 +207,7 @@ func IsUndefinedRelationError(err error) bool {
 	return errHasCode(err, pgcode.UndefinedTable)
 }
 
-func errHasCode(err error, code ...string) bool {
+func errHasCode(err error, code ...pgcode.Code) bool {
 	pgCode := pgerror.GetPGCode(err)
 	for _, c := range code {
 		if pgCode == c {

--- a/pkg/sql/sqltelemetry/pgwire.go
+++ b/pkg/sql/sqltelemetry/pgwire.go
@@ -35,7 +35,7 @@ var BinaryDecimalInfinityCounter = telemetry.GetCounterOnce("pgwire.#32489.binar
 
 // UncategorizedErrorCounter is to be incremented every time an error
 // flows to the client without having been decorated with a pg error.
-var UncategorizedErrorCounter = telemetry.GetCounterOnce("othererror." + pgcode.Uncategorized)
+var UncategorizedErrorCounter = telemetry.GetCounterOnce("othererror." + pgcode.Uncategorized.String())
 
 // InterleavedPortalRequestCounter is to be incremented every time an open
 // portal attempts to interleave work with another portal.

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -137,7 +137,7 @@ func (db *verifyFormatDB) exec(ctx context.Context, sql string) error {
 		if err != nil {
 			if pqerr := (*pq.Error)(nil); errors.As(err, &pqerr) {
 				// Output Postgres error code if it's available.
-				if pqerr.Code == pgcode.CrashShutdown {
+				if pgcode.MakeCode(string(pqerr.Code)) == pgcode.CrashShutdown {
 					return &crasher{
 						sql:    sql,
 						err:    err,

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1446,7 +1446,7 @@ func TestLint(t *testing.T) {
 				// even if it might not be used again.
 				stream.GrepNot(`pkg/sql/parser/sql.go:.*this value of sqlDollar is never used`),
 				// Generated file containing many unused postgres error codes.
-				stream.GrepNot(`pkg/sql/pgwire/pgcode/codes.go:.* const .* is unused`),
+				stream.GrepNot(`pkg/sql/pgwire/pgcode/codes.go:.* var .* is unused`),
 				// The methods in exprgen.customFuncs are used via reflection.
 				stream.GrepNot(`pkg/sql/opt/optgen/exprgen/custom_funcs.go:.* func .* is unused`),
 				// Using deprecated method to COPY.


### PR DESCRIPTION
Fixes #49694.

This PR uses a separate wrapped type for pgcodes to ensure that
arbitrary strings are not passed to the pgerror functions in place of
pgcodes.

Release note: None