### PR TITLE
opt: add partial index predicates to TableMeta

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1268,3 +1268,26 @@ with &1
                           │         └──  xyzw.w:7 => w:11
                           └── projections
                                └── a:1 + x:8 [as="?column?":12]
+
+# Populates table metadata with partial index predicates.
+exec-ddl
+CREATE TABLE partial_index (
+    k INT PRIMARY KEY,
+    u INT,
+    v INT,
+    INDEX u (u) WHERE u = 1,
+    INDEX uv (u, v),
+    INDEX v (v) WHERE v > 100 AND v < 200 AND u > 50
+)
+----
+
+build
+SELECT k FROM partial_index
+----
+project
+ ├── columns: k:1!null
+ └── scan partial_index
+      ├── columns: k:1!null u:2 v:3
+      └── partial index predicates
+           ├── u: u:2 = 1
+           └── v: ((v:3 > 100) AND (v:3 < 200)) AND (u:2 > 50)

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -149,6 +149,12 @@ type TableMeta struct {
 	// more detail.
 	ComputedCols map[ColumnID]ScalarExpr
 
+	// PartialIndexPredicates is a map from an index ordinal on the table to
+	// a ScalarExpr representing the predicate on the corresponding partial
+	// index. If an index is not a partial index, it will not have an entry in
+	// the map.
+	PartialIndexPredicates map[cat.IndexOrdinal]ScalarExpr
+
 	// anns annotates the table metadata with arbitrary data.
 	anns [maxTableAnnIDCount]interface{}
 }
@@ -200,6 +206,15 @@ func (tm *TableMeta) AddComputedCol(colID ColumnID, computedCol ScalarExpr) {
 		tm.ComputedCols = make(map[ColumnID]ScalarExpr)
 	}
 	tm.ComputedCols[colID] = computedCol
+}
+
+// AddPartialIndexPredicate adds a partial index predicate to the table's
+// metadata.
+func (tm *TableMeta) AddPartialIndexPredicate(ord cat.IndexOrdinal, pred ScalarExpr) {
+	if tm.PartialIndexPredicates == nil {
+		tm.PartialIndexPredicates = make(map[cat.IndexOrdinal]ScalarExpr)
+	}
+	tm.PartialIndexPredicates[ord] = pred
 }
 
 // TableAnnotation returns the given annotation that is associated with the


### PR DESCRIPTION
With this commit, `optbuilder` now adds partial index predicates of a
table, as a `map[cat.IndexOrdinal]ScalarExpr`, to `TableMeta` when
building SELECT queries. These predicates will be necessary in order to
determine if a partial index can be used to satisfy a query.

Release note: None