### PR TITLE
security: add CA and client certs for tenant usage

### DIFF
--- a/pkg/security/certificate_manager.go
+++ b/pkg/security/certificate_manager.go
@@ -195,6 +195,18 @@ func (cm *CertificateManager) CACertPath() string {
 // CACertFilename returns the expected file name for the CA certificate.
 func CACertFilename() string { return "ca" + certExtension }
 
+// TenantCACertPath returns the expected file path for the Tenant CA
+// certificate.
+func (cm *CertificateManager) TenantCACertPath() string {
+	return filepath.Join(cm.certsDir, TenantCACertFilename())
+}
+
+// TenantCACertFilename returns the expected file name for the Tenant CA
+// certificate.
+func TenantCACertFilename() string {
+	return "ca-tenant" + certExtension
+}
+
 // ClientCACertPath returns the expected file path for the CA certificate
 // used to verify client certificates.
 func (cm *CertificateManager) ClientCACertPath() string {
@@ -209,12 +221,22 @@ func (cm *CertificateManager) UICACertPath() string {
 
 // NodeCertPath returns the expected file path for the node certificate.
 func (cm *CertificateManager) NodeCertPath() string {
-	return filepath.Join(cm.certsDir, "node"+certExtension)
+	return filepath.Join(cm.certsDir, NodeCertFilename())
+}
+
+// NodeCertFilename returns the expected file name for the node certificate.
+func NodeCertFilename() string {
+	return "node" + certExtension
 }
 
 // NodeKeyPath returns the expected file path for the node key.
 func (cm *CertificateManager) NodeKeyPath() string {
-	return filepath.Join(cm.certsDir, "node"+keyExtension)
+	return filepath.Join(cm.certsDir, NodeKeyFilename())
+}
+
+// NodeKeyFilename returns the expected file name for the node key.
+func NodeKeyFilename() string {
+	return "node" + keyExtension
 }
 
 // UICertPath returns the expected file path for the UI certificate.
@@ -225,6 +247,26 @@ func (cm *CertificateManager) UICertPath() string {
 // UIKeyPath returns the expected file path for the UI key.
 func (cm *CertificateManager) UIKeyPath() string {
 	return filepath.Join(cm.certsDir, "ui"+keyExtension)
+}
+
+// TenantClientCertPath returns the expected file path for the user's certificate.
+func (cm *CertificateManager) TenantClientCertPath(tenantIdentifier string) string {
+	return filepath.Join(cm.certsDir, TenantClientCertFilename(tenantIdentifier))
+}
+
+// TenantClientCertFilename returns the expected file name for the user's certificate.
+func TenantClientCertFilename(tenantIdentifier string) string {
+	return "tenant." + tenantIdentifier + certExtension
+}
+
+// TenantClientKeyPath returns the expected file path for the tenant's key.
+func (cm *CertificateManager) TenantClientKeyPath(tenantIdentifier string) string {
+	return filepath.Join(cm.certsDir, TenantClientKeyFilename(tenantIdentifier))
+}
+
+// TenantClientKeyFilename returns the expected file name for the user's key.
+func TenantClientKeyFilename(tenantIdentifier string) string {
+	return "tenant." + tenantIdentifier + keyExtension
 }
 
 // ClientCertPath returns the expected file path for the user's certificate.

--- a/pkg/security/certs_tenant_test.go
+++ b/pkg/security/certs_tenant_test.go
@@ -1,0 +1,128 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package security_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTenantCertificates creates a tenant CA and from it client certificates
+// for a tenant. It then sets up a smoke test that verifies that the tenant
+// can use its client certificates to connect to a https server that trusts
+// the tenant CA.
+//
+// This foreshadows upcoming work on multi-tenancy, see:
+// https://github.com/cockroachdb/cockroach/issues/49105
+// https://github.com/cockroachdb/cockroach/issues/47898
+func TestTenantCertificates(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Don't mock assets in this test, we're creating our own one-off certs.
+	security.ResetAssetLoader()
+	defer ResetTest()
+
+	certsDir, cleanup := tempDir(t)
+	defer cleanup()
+
+	// Make certs for the tenant CA (= auth broker). In production, these would be
+	// given to a dedicated service.
+	tenantCAKey := filepath.Join(certsDir, "tenant-ca-name-irrelevant.key")
+	require.NoError(t, security.CreateTenantCAPair(
+		certsDir,
+		tenantCAKey,
+		2048,
+		100000*time.Hour, // basically long-lived
+		false,            // allowKeyReuse
+		false,            // overwrite
+	))
+
+	// That dedicated service can make client certs for a tenant as follows:
+	const tenant = "gromphadorhina-portentosa"
+	tenantCerts, err := security.CreateTenantClientPair(
+		certsDir, tenantCAKey, testKeySize, 48*time.Hour, tenant,
+	)
+	require.NoError(t, err)
+	// We write the certs to disk, though in production this would not necessarily
+	// happen (it may be enough to just have them in-mem, we will see).
+	require.NoError(t, security.WriteTenantClientPair(certsDir, tenantCerts, false /* overwrite */))
+
+	// To make this example work we also need certs that the server can use. We
+	// need something here that the tenant will trust. We just make node certs
+	// out of convenience. In production, these would be auxiliary certs.
+	dummyCAKeyPath := filepath.Join(certsDir, "name-does-not-matter-too.key")
+	require.NoError(t, security.CreateCAPair(
+		certsDir, dummyCAKeyPath, testKeySize, 1000*time.Hour, false, false,
+	))
+	require.NoError(t, security.CreateNodePair(
+		certsDir, dummyCAKeyPath, testKeySize, 500*time.Hour, false, []string{"127.0.0.1"}))
+
+	dummyCACertPath := filepath.Join(certsDir, security.CACertFilename())
+
+	// Now set up the config a server would use. The client will trust it based on
+	// the dummy CA and dummy node certs, and it will validate incoming
+	// connections based on the tenant CA.
+	serverTLSConfig, err := security.LoadServerTLSConfig(
+		dummyCACertPath,
+		filepath.Join(certsDir, security.TenantCACertFilename()),
+		filepath.Join(certsDir, security.NodeCertFilename()),
+		filepath.Join(certsDir, security.NodeKeyFilename()),
+	)
+	require.NoError(t, err)
+
+	// The client in turn trusts the dummy CA and presents its tenant certs to the
+	// server (which will validate them using the tenant CA).
+	clientTLSConfig, err := security.LoadClientTLSConfig(
+		dummyCACertPath,
+		filepath.Join(certsDir, security.TenantClientCertFilename(tenant)),
+		filepath.Join(certsDir, security.TenantClientKeyFilename(tenant)),
+	)
+	require.NoError(t, err)
+
+	// Set up a HTTPS server using server TLS config, set up a http client using the
+	// client TLS config, make a request.
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	httpServer := http.Server{
+		Addr:      ln.Addr().String(),
+		TLSConfig: serverTLSConfig,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			fmt.Fprint(w, "hello, tenant ", req.TLS.PeerCertificates[0].Subject.CommonName)
+		}),
+	}
+	defer func() { _ = httpServer.Close() }()
+	go func() {
+		_ = httpServer.ServeTLS(ln, "", "")
+	}()
+
+	httpClient := http.Client{Transport: &http.Transport{
+		TLSClientConfig: clientTLSConfig,
+	}}
+	defer httpClient.CloseIdleConnections()
+
+	resp, err := httpClient.Get("https://" + ln.Addr().String())
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "hello, tenant "+tenant, string(b))
+}

--- a/pkg/security/x509.go
+++ b/pkg/security/x509.go
@@ -130,13 +130,7 @@ func GenerateServerCert(
 
 	// Both server and client authentication are allowed (for inter-node RPC).
 	template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
-	for _, h := range hosts {
-		if ip := net.ParseIP(h); ip != nil {
-			template.IPAddresses = append(template.IPAddresses, ip)
-		} else {
-			template.DNSNames = append(template.DNSNames, h)
-		}
-	}
+	addHostsToTemplate(template, hosts)
 
 	certBytes, err := x509.CreateCertificate(rand.Reader, template, caCert, nodePublicKey, caPrivateKey)
 	if err != nil {
@@ -144,6 +138,16 @@ func GenerateServerCert(
 	}
 
 	return certBytes, nil
+}
+
+func addHostsToTemplate(template *x509.Certificate, hosts []string) {
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
 }
 
 // GenerateUIServerCert generates a server certificate for the Admin UI and returns the cert bytes.
@@ -169,13 +173,7 @@ func GenerateUIServerCert(
 
 	// Only server authentication is allowed.
 	template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
-	for _, h := range hosts {
-		if ip := net.ParseIP(h); ip != nil {
-			template.IPAddresses = append(template.IPAddresses, ip)
-		} else {
-			template.DNSNames = append(template.DNSNames, h)
-		}
-	}
+	addHostsToTemplate(template, hosts)
 
 	certBytes, err := x509.CreateCertificate(rand.Reader, template, caCert, certPublicKey, caPrivateKey)
 	if err != nil {
@@ -188,6 +186,9 @@ func GenerateUIServerCert(
 // GenerateClientCert generates a client certificate and returns the cert bytes.
 // Takes in the CA cert and private key, the client public key, the certificate lifetime,
 // and the username.
+//
+// This is used both for vanilla CockroachDB user client certs as well as for the
+// multi-tenancy KV auth broker (in which case the user is a SQL tenant).
 func GenerateClientCert(
 	caCert *x509.Certificate,
 	caPrivateKey crypto.PrivateKey,
@@ -201,7 +202,7 @@ func GenerateClientCert(
 		return nil, errors.Errorf("user cannot be empty")
 	}
 
-	// Create template for "user".
+	// Create template for user.
 	template, err := newTemplate(user, lifetime)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit introduces methods that create a CA certificate for use with
the auth broker envisioned in #49105 and, from that CA, client
certificates for use in #47898. They are not exposed through the cli
(yet), though the certificate loader already supports them.

Touches #49105.
Touches #47898.

Release note: None