### PR TITLE
release-20.1: storage: remove compaction-debt based ingestion backpressure

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -62,6 +62,8 @@ var retiredSettings = map[string]struct{}{
 	// removed as of 20.1.
 	"schemachanger.lease.duration":       {},
 	"schemachanger.lease.renew_fraction": {},
+	// removes as of 20.2.
+	"rocksdb.ingest_backpressure.pending_compaction_threshold": {},
 }
 
 // register adds a setting to the registry.

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1138,9 +1138,6 @@ func TestIngestDelayLimit(t *testing.T) {
 		{ramp, Stats{L0FileCount: 21}},
 		{ramp * 2, Stats{L0FileCount: 22}},
 		{max, Stats{L0FileCount: 55}},
-		{0, Stats{PendingCompactionBytesEstimate: (2 << 30) - 1}},
-		{max, Stats{L0FileCount: 25, PendingCompactionBytesEstimate: 80 << 30}},
-		{max, Stats{L0FileCount: 35, PendingCompactionBytesEstimate: 20 << 30}},
 	} {
 		require.Equal(t, tc.exp, calculatePreIngestDelay(s, &tc.stats))
 	}


### PR DESCRIPTION
Backport 1/1 commits from #49726.

/cc @cockroachdb/release

---

Fixes #49716

Release note: Remove compaction-debt based sstable ingestion
backpressure which was artificially slowing down IMPORTs and RESTOREs on
Pebble and not providing any utility on RocksDB. Removed the private
"rocksdb.ingest_backpressure.pending_compaction_threshold" cluster
setting.
