### PR TITLE
sql: track fine-grained view dependencies

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -321,14 +321,6 @@ ALTER TABLE t DROP COLUMN y
 statement error cannot drop column "e" because view "v" depends on it
 ALTER TABLE t DROP COLUMN e
 
-# TODO(knz): this statement should succeed after #17269 is fixed.
-statement error cannot drop column "d" because view "v" depends on it
-ALTER TABLE t DROP COLUMN d
-
-# TODO(knz): remove the following once the test above succeeds.
-statement ok
-ALTER TABLE t DROP COLUMN d CASCADE
-
 statement ok
 ALTER TABLE t DROP COLUMN e CASCADE
 

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -96,7 +96,7 @@ descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  de
 53             test_kv          NULL      54               fk                 NULL                   NULL               NULL
 53             test_kv          NULL      55               fk                 NULL                   NULL               NULL
 53             test_kv          NULL      56               fk                 NULL                   NULL               NULL
-53             test_kv          NULL      59               view               0                      NULL               Columns: [1 2 3]
+53             test_kv          NULL      59               view               0                      NULL               Columns: [2]
 53             test_kv          1         57               interleave         1                      NULL               SharedPrefixLen: 0
 53             test_kv          1         58               interleave         2                      NULL               SharedPrefixLen: 0
 59             test_v1          NULL      60               view               0                      NULL               Columns: [1]
@@ -116,7 +116,7 @@ query ITIITITT colnames
 SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name LIKE 'moretest_%' ORDER BY descriptor_id, index_id, dependedonby_type, dependedonby_id, dependedonby_index_id
 ----
 descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
-61             moretest_t       NULL      62               view               0                      NULL               Columns: [1 2 3]
+61             moretest_t       NULL      62               view               0                      NULL               Columns: [2]
 
 # Check sequence dependencies.
 

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -688,3 +688,33 @@ statement ok
 CREATE OR REPLACE VIEW tview AS SELECT x AS x, x+1 AS x1, x+2 AS x2, x+3 AS x3 FROM t2
 
 user root
+
+# Ensure a view that contains a table that is referenced multiple times with
+# different column sets depends on the correct columns.
+# Depended on columns should not be droppable.
+
+# Only column a should be depended on in this case.
+statement ok
+DROP TABLE ab CASCADE;
+CREATE TABLE ab (a INT, b INT);
+CREATE VIEW vab (x) AS SELECT ab.a FROM ab, ab AS ab2
+
+statement ok
+ALTER TABLE ab DROP COLUMN b
+
+statement error pq: cannot drop column "a" because view "vab" depends on it
+ALTER TABLE ab DROP COLUMN a
+
+statement ok
+CREATE TABLE abc (a INT, b INT, c INT);
+CREATE VIEW vabc AS SELECT abc.a, abc2.b, abc3.c FROM abc, abc AS abc2, abc AS abc3
+
+# All three columns a,b,c should not be droppable.
+statement error pq: cannot drop column "a" because view "vabc" depends on it
+ALTER TABLE abc DROP COLUMN a
+
+statement error pq: cannot drop column "b" because view "vabc" depends on it
+ALTER TABLE abc DROP COLUMN b
+
+statement error pq: cannot drop column "c" because view "vabc" depends on it
+ALTER TABLE abc DROP COLUMN c

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -552,8 +552,15 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			if dep.SpecificIndex {
 				fmt.Fprintf(f.Buffer, "@%s", dep.DataSource.(cat.Table).Index(dep.Index).Name())
 			}
-			if !dep.ColumnOrdinals.Empty() {
-				fmt.Fprintf(f.Buffer, " [columns: %s]", dep.ColumnOrdinals)
+			colNames, isTable := dep.GetColumnNames()
+			if len(colNames) > 0 {
+				fmt.Fprintf(f.Buffer, " [columns:")
+				for _, colName := range colNames {
+					fmt.Fprintf(f.Buffer, " %s", colName)
+				}
+				fmt.Fprintf(f.Buffer, "]")
+			} else if isTable {
+				fmt.Fprintf(f.Buffer, " [no columns]")
 			}
 			n.Child(f.Buffer.String())
 		}

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -338,3 +338,18 @@ func (b *Builder) allocScope() *scope {
 	r.builder = b
 	return r
 }
+
+// trackReferencedColumnForViews is used to add a column to the view's
+// dependencies. This should be called whenever a column reference is made in a
+// view query.
+func (b *Builder) trackReferencedColumnForViews(col *scopeColumn) {
+	if b.trackViewDeps {
+		for i := range b.viewDeps {
+			dep := b.viewDeps[i]
+			if ord, ok := dep.ColumnIDToOrd[col.id]; ok {
+				dep.ColumnOrdinals.Add(ord)
+			}
+			b.viewDeps[i] = dep
+		}
+	}
+}

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -340,6 +340,8 @@ func (jb *usingJoinBuilder) buildUsingJoin(using *tree.UsingJoinCond) {
 			jb.raiseUndefinedColError(name, "right")
 		}
 
+		jb.b.trackReferencedColumnForViews(leftCol)
+		jb.b.trackReferencedColumnForViews(rightCol)
 		jb.addEqualityCondition(leftCol, rightCol)
 	}
 
@@ -370,6 +372,8 @@ func (jb *usingJoinBuilder) buildNaturalJoin(natural tree.NaturalJoinCond) {
 
 		rightCol := jb.findUsingColumn(jb.rightScope.cols, leftCol.name, "right table")
 		if rightCol != nil {
+			jb.b.trackReferencedColumnForViews(leftCol)
+			jb.b.trackReferencedColumnForViews(rightCol)
 			jb.addEqualityCondition(leftCol, rightCol)
 		}
 	}

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -225,7 +225,9 @@ func (b *Builder) finishBuildScalar(
 	}
 
 	// Avoid synthesizing a new column if possible.
-	if col := outScope.findExistingCol(texpr, false /* allowSideEffects */); col != nil && col != outCol {
+	if col := outScope.findExistingCol(
+		texpr, false, /* allowSideEffects */
+	); col != nil && col != outCol {
 		outCol.id = col.id
 		outCol.scalar = scalar
 		return scalar
@@ -253,6 +255,8 @@ func (b *Builder) finishBuildScalar(
 func (b *Builder) finishBuildScalarRef(
 	col *scopeColumn, inScope, outScope *scope, outCol *scopeColumn, colRefs *opt.ColSet,
 ) (out opt.ScalarExpr) {
+
+	b.trackReferencedColumnForViews(col)
 	// Update the sets of column references and outer columns if needed.
 	if colRefs != nil {
 		colRefs.Add(col.id)

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -574,8 +574,14 @@ func findExistingColInList(
 // findExistingCol finds the given expression among the bound variables in this
 // scope. Returns nil if the expression is not found (or an expression is found
 // but it has side-effects and allowSideEffects is false).
+// If a column is found and we are tracking view dependencies, we add the column
+// to the view dependencies since it means this column is being referenced.
 func (s *scope) findExistingCol(expr tree.TypedExpr, allowSideEffects bool) *scopeColumn {
-	return findExistingColInList(expr, s.cols, allowSideEffects)
+	col := findExistingColInList(expr, s.cols, allowSideEffects)
+	if col != nil {
+		s.builder.trackReferencedColumnForViews(col)
+	}
+	return col
 }
 
 // startAggFunc is called when the builder starts building an aggregate

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -530,8 +530,11 @@ func (b *Builder) buildScan(
 
 		if b.trackViewDeps {
 			dep := opt.ViewDep{DataSource: tab}
-			for i := 0; i < colCount; i++ {
-				dep.ColumnOrdinals.Add(getOrdinal(i))
+			dep.ColumnIDToOrd = make(map[opt.ColumnID]int)
+			// We will track the ColumnID to Ord mapping so Ords can be added
+			// when a column is referenced.
+			for i, col := range outScope.cols {
+				dep.ColumnIDToOrd[col.id] = getOrdinal(i)
 			}
 			if private.Flags.ForceIndex {
 				dep.SpecificIndex = true
@@ -948,6 +951,7 @@ func (b *Builder) buildSelectClause(
 	inScope *scope,
 ) (outScope *scope) {
 	fromScope := b.buildFrom(sel.From, locking, inScope)
+
 	b.processWindowDefs(sel, fromScope)
 	b.buildWhere(sel.Where, fromScope)
 

--- a/pkg/sql/opt/optbuilder/testdata/create_view
+++ b/pkg/sql/opt/optbuilder/testdata/create_view
@@ -20,13 +20,13 @@ create-view t.public.v1
  └── dependencies
 
 build
-CREATE VIEW v1 AS SELECT a FROM ab 
+CREATE VIEW v1 AS SELECT a FROM ab
 ----
 create-view t.public.v1
  ├── SELECT a FROM t.public.ab
  ├── columns: a:1
  └── dependencies
-      └── ab [columns: (0,1)]
+      └── ab [columns: a]
 
 # Test dependency on specific index.
 build
@@ -36,7 +36,7 @@ create-view t.public.v1
  ├── SELECT a FROM t.public.ab@idx
  ├── columns: a:1
  └── dependencies
-      └── ab@idx [columns: (0,1)]
+      └── ab@idx [columns: a]
 
 build
 CREATE VIEW v1 AS SELECT a FROM ab@primary
@@ -45,7 +45,7 @@ create-view t.public.v1
  ├── SELECT a FROM t.public.ab@primary
  ├── columns: a:1
  └── dependencies
-      └── ab@primary [columns: (0,1)]
+      └── ab@primary [columns: a]
 
 # Test dependency on view.
 exec-ddl
@@ -53,13 +53,13 @@ CREATE VIEW av AS SELECT a FROM ab
 ----
 
 build
-CREATE VIEW v1 AS SELECT a FROM av 
+CREATE VIEW v1 AS SELECT a FROM av
 ----
 create-view t.public.v1
  ├── SELECT a FROM t.public.av
  ├── columns: a:1
  └── dependencies
-      └── av [columns: (0)]
+      └── av
 
 build
 CREATE VIEW v1 AS SELECT av.a, ab.a FROM av, ab
@@ -68,8 +68,8 @@ create-view t.public.v1
  ├── SELECT av.a, ab.a FROM t.public.av, t.public.ab
  ├── columns: a:1 a:3
  └── dependencies
-      ├── av [columns: (0)]
-      └── ab [columns: (0,1)]
+      ├── av
+      └── ab [columns: a]
 
 # Test that we don't report virtual table dependencies.
 build
@@ -79,7 +79,7 @@ create-view t.public.v1
  ├── SELECT a, table_schema FROM t.public.ab, "".information_schema.columns
  ├── columns: a:1 table_schema:5
  └── dependencies
-      └── ab [columns: (0,1)]
+      └── ab [columns: a]
 
 # Test cases with specified column names.
 build
@@ -89,9 +89,9 @@ create-view t.public.v2
  ├── SELECT ab.a FROM t.public.ab, t.public.ab AS ab2, t.public.cd
  ├── columns: x:1
  └── dependencies
-      ├── ab [columns: (0,1)]
-      ├── ab [columns: (0,1)]
-      └── cd [columns: (0,1)]
+      ├── ab [columns: a]
+      ├── ab [no columns]
+      └── cd [no columns]
 
 build
 CREATE VIEW v3 (x, y) AS SELECT a FROM ab
@@ -116,7 +116,7 @@ create-view t.public.v5
  ├── SELECT a FROM [53 AS t]
  ├── columns: a:1
  └── dependencies
-      └── ab [columns: (0,1)]
+      └── ab [columns: a]
 
 # Verify that we only depend on the specified column.
 build
@@ -126,7 +126,7 @@ create-view t.public.v6
  ├── SELECT a FROM [53(1) AS t]
  ├── columns: a:1
  └── dependencies
-      └── ab [columns: (0)]
+      └── ab [columns: a]
 
 # Verify dependency on sequence.
 build
@@ -148,7 +148,7 @@ create-view t.public.v8
  ├── WITH cd AS (SELECT a, b FROM t.public.ab) SELECT a + b FROM cd
  ├── columns: "?column?":5
  └── dependencies
-      └── ab [columns: (0,1)]
+      └── ab [columns: a b]
 
 # Verify that we disallow mutation statements.
 build
@@ -165,3 +165,161 @@ build
 CREATE VIEW v9 AS SELECT a,b FROM [DELETE FROM ab WHERE a>b RETURNING a, b]
 ----
 error (42601): DELETE cannot be used inside a view definition
+
+# Regression 29021.
+
+# Dependencies should be tracked in the group by clause.
+build
+CREATE VIEW v10 AS SELECT a FROM ab GROUP BY a,b
+----
+create-view t.public.v10
+ ├── SELECT a FROM t.public.ab GROUP BY a, b
+ ├── columns: a:1
+ └── dependencies
+      └── ab [columns: a b]
+
+# Dependencies should be tracked in the join on clause.
+build
+CREATE VIEW v10 as SELECT 1 FROM ab JOIN cd ON ab.a = cd.c
+----
+create-view t.public.v10
+ ├── SELECT 1 FROM t.public.ab JOIN t.public.cd ON ab.a = cd.c
+ ├── columns: "?column?":5
+ └── dependencies
+      ├── ab [columns: a]
+      └── cd [columns: c]
+
+exec-ddl
+CREATE TABLE ac (a INT, c INT)
+----
+
+# Dependencies should be tracked in a natural join clause.
+build
+CREATE VIEW v11 as SELECT 1 FROM ab NATURAL JOIN ac
+----
+create-view t.public.v11
+ ├── SELECT 1 FROM t.public.ab NATURAL JOIN t.public.ac
+ ├── columns: "?column?":6
+ └── dependencies
+      ├── ab [columns: a]
+      └── ac [columns: a]
+
+# Dependencies should be tracked in a using join clause.
+build
+CREATE VIEW v12 as SELECT 1 FROM ab JOIN ac USING (a)
+----
+create-view t.public.v12
+ ├── SELECT 1 FROM t.public.ab JOIN t.public.ac USING (a)
+ ├── columns: "?column?":6
+ └── dependencies
+      ├── ab [columns: a]
+      └── ac [columns: a]
+
+# Dependencies should be tracked in the where clause.
+build
+CREATE VIEW v13 AS SELECT a FROM ab WHERE b > 0
+----
+create-view t.public.v13
+ ├── SELECT a FROM t.public.ab WHERE b > 0
+ ├── columns: a:1
+ └── dependencies
+      └── ab [columns: a b]
+
+# Dependencies should be tracked in aggregate / window functions.
+build
+CREATE VIEW v14 AS SELECT sum(a) FROM ab;
+----
+create-view t.public.v14
+ ├── SELECT sum(a) FROM t.public.ab
+ ├── columns: sum:3
+ └── dependencies
+      └── ab [columns: a]
+
+# Dependencies should be tracked in partitions.
+build
+CREATE VIEW v15 AS SELECT sum(a) OVER (PARTITION by b) FROM ab;
+----
+create-view t.public.v15
+ ├── SELECT sum(a) OVER (PARTITION BY b) FROM t.public.ab
+ ├── columns: sum:3
+ └── dependencies
+      └── ab [columns: a b]
+
+# Dependencies should be tracked in subqueries.
+build
+CREATE VIEW v16 AS SELECT a FROM (SELECT a,b FROM ab);
+----
+create-view t.public.v16
+ ├── SELECT a FROM (SELECT a, b FROM t.public.ab)
+ ├── columns: a:1
+ └── dependencies
+      └── ab [columns: a b]
+
+# Dependencies should be tracked in the order by clause.
+build
+CREATE VIEW v16 AS SELECT a FROM ab ORDER BY b
+----
+create-view t.public.v16
+ ├── SELECT a FROM t.public.ab ORDER BY b
+ ├── columns: a:1
+ └── dependencies
+      └── ab [columns: a b]
+
+exec-ddl
+CREATE TABLE tf (f FLOAT)
+----
+
+# Dependencies should be tracked in ordered-set aggregate functions.
+build
+CREATE VIEW v17 AS SELECT percentile_cont(0.50) WITHIN GROUP (ORDER BY f) FROM tf
+----
+create-view t.public.v17
+ ├── SELECT percentile_cont(0.50) WITHIN GROUP (ORDER BY f) FROM t.public.tf
+ ├── columns: percentile_cont:4
+ └── dependencies
+      └── tf [columns: f]
+
+# Dependencies should be tracked with multiple table statements.
+build
+CREATE VIEW v18 AS SELECT ab.a, ab2.b FROM ab, ab as ab2
+----
+create-view t.public.v18
+ ├── SELECT ab.a, ab2.b FROM t.public.ab, t.public.ab AS ab2
+ ├── columns: a:1 b:4
+ └── dependencies
+      ├── ab [columns: a]
+      └── ab [columns: b]
+
+build
+CREATE VIEW v19 AS SELECT 1 FROM (SELECT a FROM ab) t1 JOIN (SELECT b FROM AB) t2 on t1.a = t2.b
+----
+create-view t.public.v19
+ ├── SELECT 1 FROM (SELECT a FROM t.public.ab) AS t1 JOIN (SELECT b FROM t.public.ab) AS t2 ON t1.a = t2.b
+ ├── columns: "?column?":5
+ └── dependencies
+      ├── ab [columns: a]
+      └── ab [columns: b]
+
+# Dependencies should be tracked if the column is used in a projection.
+build
+CREATE VIEW v20 AS SELECT a + b FROM ab
+----
+create-view t.public.v20
+ ├── SELECT a + b FROM t.public.ab
+ ├── columns: "?column?":3
+ └── dependencies
+      └── ab [columns: a b]
+
+exec-ddl
+CREATE TABLE abc (a INT, b INT, c INT)
+----
+
+# Dependencies should be tracked in an ORDER BY inside a partition.
+build
+CREATE VIEW v21 AS SELECT sum(a) OVER (PARTITION BY b ORDER BY c) FROM abc
+----
+create-view t.public.v21
+ ├── SELECT sum(a) OVER (PARTITION BY b ORDER BY c) FROM t.public.abc
+ ├── columns: sum:5
+ └── dependencies
+      └── abc [columns: a b c]

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -93,8 +93,8 @@ create-view t.public.v1
  ├── WITH t AS (SELECT a FROM t.public.y WHERE a < 3) SELECT 1 FROM t.public.x NATURAL JOIN t
  ├── columns: "?column?":7
  └── dependencies
-      ├── y [columns: (0,1)]
-      └── x [columns: (0-2)]
+      ├── y [columns: a]
+      └── x [columns: a]
 
 build
 CREATE TABLE t1 AS


### PR DESCRIPTION
Fixes #29021
Only create view dependencies on columns if the column is referenced in the view query.

Note: this does not fix the dependencies of old views.

Release note (sql change): Views now only create a dependency on a table's column if the
column is referenced in the view definition. Previously, all columns were added as a dependency
meaning if a table was referenced in a view, all columns regardless of if the column was actually
referenced would be added to the view's dependencies.