### PR TITLE
sql: populate spatial_ref_sys table with projection entries

### DIFF
--- a/pkg/geo/geoprojbase/geoprojbase.go
+++ b/pkg/geo/geoprojbase/geoprojbase.go
@@ -27,8 +27,13 @@ type Proj4Text struct {
 // MakeProj4Text returns a new Proj4Text with spec based on the given string.
 func MakeProj4Text(str string) Proj4Text {
 	return Proj4Text{
-		cStr: []byte(str + `\0`),
+		cStr: []byte(str + "\u0000"),
 	}
+}
+
+// String returns the string representation of the given proj text.
+func (p *Proj4Text) String() string {
+	return string(p.cStr[:len(p.cStr)-1])
 }
 
 // Bytes returns the raw bytes for the given proj text.
@@ -62,6 +67,6 @@ type ProjInfo struct {
 // Projection returns the ProjInfo identifier for the given SRID, as well as an bool
 // indicating whether the projection exists.
 func Projection(srid geopb.SRID) (ProjInfo, bool) {
-	p, exists := projections[srid]
+	p, exists := Projections[srid]
 	return p, exists
 }

--- a/pkg/geo/geoprojbase/projections.go
+++ b/pkg/geo/geoprojbase/projections.go
@@ -12,9 +12,10 @@ package geoprojbase
 
 import "github.com/cockroachdb/cockroach/pkg/geo/geopb"
 
-// projections is a mapping of SRID to projections.
+// Projections is a mapping of SRID to projections.
+// Use the `Projection` function to obtain one.
 // This file is not spell checked.
-var projections = map[geopb.SRID]ProjInfo{
+var Projections = map[geopb.SRID]ProjInfo{
 	4326: {
 		SRID:      4326,
 		AuthName:  "EPSG",

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -1551,43 +1551,6 @@ MULTIPOINT (0 0, 1 1)
 statement error st_segmentize\(\): maximum segment length must be positive
 SELECT ST_Segmentize('POLYGON ((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0))'::geometry, -1)
 
-subtest pg_extension
-
-statement ok
-CREATE TABLE pg_extension_test (
-  a geography(point, 4326),
-  b geometry(linestring, 3857),
-  c geometry,
-  d geography
-)
-
-query TTTTIIT rowsort
-SELECT * FROM pg_extension.geography_columns WHERE f_table_name = 'pg_extension_test'
-----
-test  public  pg_extension_test  a  2     4326  POINT
-test  public  pg_extension_test  d  NULL  0     GEOMETRY
-
-query TTTTIIT rowsort
-SELECT * FROM pg_extension.geometry_columns WHERE f_table_name = 'pg_extension_test'
-----
-test  public  pg_extension_test  b  2  3857  LINESTRING
-test  public  pg_extension_test  c  2  0     GEOMETRY
-
-query TTTTIIT rowsort
-SELECT * FROM geography_columns WHERE f_table_name = 'pg_extension_test'
-----
-test  public  pg_extension_test  a  2     4326  POINT
-test  public  pg_extension_test  d  NULL  0     GEOMETRY
-
-query TTTTIIT rowsort
-SELECT * FROM geometry_columns WHERE f_table_name = 'pg_extension_test'
-----
-test  public  pg_extension_test  b  2  3857  LINESTRING
-test  public  pg_extension_test  c  2  0     GEOMETRY
-
-statement error not yet implemented
-SELECT * FROM pg_extension.spatial_ref_sys ORDER BY srid ASC
-
 subtest st_srid
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/pg_extension
+++ b/pkg/sql/logictest/testdata/logic_test/pg_extension
@@ -1,0 +1,43 @@
+statement ok
+CREATE TABLE pg_extension_test (
+  a geography(point, 4326),
+  b geometry(linestring, 3857),
+  c geometry,
+  d geography
+)
+
+query TTTTIIT rowsort
+SELECT * FROM pg_extension.geography_columns WHERE f_table_name = 'pg_extension_test'
+----
+test  public  pg_extension_test  a  2     4326  POINT
+test  public  pg_extension_test  d  NULL  0     GEOMETRY
+
+query TTTTIIT rowsort
+SELECT * FROM pg_extension.geometry_columns WHERE f_table_name = 'pg_extension_test'
+----
+test  public  pg_extension_test  b  2  3857  LINESTRING
+test  public  pg_extension_test  c  2  0     GEOMETRY
+
+query TTTTIIT rowsort
+SELECT * FROM geography_columns WHERE f_table_name = 'pg_extension_test'
+----
+test  public  pg_extension_test  a  2     4326  POINT
+test  public  pg_extension_test  d  NULL  0     GEOMETRY
+
+query TTTTIIT rowsort
+SELECT * FROM geometry_columns WHERE f_table_name = 'pg_extension_test'
+----
+test  public  pg_extension_test  b  2  3857  LINESTRING
+test  public  pg_extension_test  c  2  0     GEOMETRY
+
+query ITITT
+SELECT * FROM pg_extension.spatial_ref_sys WHERE srid IN (3857, 4326) ORDER BY srid ASC
+----
+3857  EPSG  3857  PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]  +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs
+4326  EPSG  4326  GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]                                                                                                                                                                                                                                                                                                                                                                                                                                      +proj=longlat +datum=WGS84 +no_defs
+
+query ITITT
+SELECT * FROM spatial_ref_sys WHERE srid IN (3857, 4326) ORDER BY srid ASC
+----
+3857  EPSG  3857  PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]  +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs
+4326  EPSG  4326  GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]                                                                                                                                                                                                                                                                                                                                                                                                                                      +proj=longlat +datum=WGS84 +no_defs

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1079,6 +1079,7 @@ func TestLint(t *testing.T) {
 			stream.GrepNot(`^storage\/rocksdb_error_dict\.go$`),
 			stream.GrepNot(`^workload/tpcds/tpcds.go$`),
 			stream.GrepNot(`^geo/geoprojbase/projections.go$`),
+			stream.GrepNot(`^sql/logictest/testdata/logic_test/pg_extension$`),
 			stream.Map(func(s string) string {
 				return filepath.Join(pkgDir, s)
 			}),


### PR DESCRIPTION
Also fixed a bug where `\0` didn't actually output a NULL terminator (no
idea why it worked).

Release note (sql change): Populate the spatial_ref_sys table with
support SRID entries for geospatial data types.