### PR TITLE
geo: fix GeoJSON and allow options in ST_AsGeoJSON

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1615,7 +1615,7 @@
   version = "v1.4.0"
 
 [[projects]]
-  digest = "1:c8fafded0eb90c84e4ef05b9e1ff2a5c8fb2aaf5009ba11b91f6bed2ef680aae"
+  digest = "1:5b7e59f9330bbc88c3aa7b62d92d1d29bb6ccbc176b731986de70345f3522dd7"
   name = "github.com/twpayne/go-geom"
   packages = [
     ".",
@@ -1636,8 +1636,8 @@
     "xy/orientation",
   ]
   pruneopts = "UT"
-  revision = "078e8ab21d838b07c627dc1d704f1f80688b1b90"
-  version = "v1.1.0"
+  revision = "62c03a64717d682dd89319176fd7247944f0c518"
+  version = "v1.2.1"
 
 [[projects]]
   digest = "1:43e0db2b113d1aee4bb68745598c135511976a44fb380ebd701cd0c14a77c303"

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -720,9 +720,33 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="st_asewkt"></a><code>st_asewkt(geometry: geometry) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the EWKT representation of a given Geometry.</p>
 </span></td></tr>
-<tr><td><a name="st_asgeojson"></a><code>st_asgeojson(geography: geography) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the GeoJSON representation of a given Geography.</p>
+<tr><td><a name="st_asgeojson"></a><code>st_asgeojson(geography: geography) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the GeoJSON representation of a given Geography. Coordinates have a maximum of 9 decimal digits.</p>
 </span></td></tr>
-<tr><td><a name="st_asgeojson"></a><code>st_asgeojson(geometry: geometry) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the GeoJSON representation of a given Geometry.</p>
+<tr><td><a name="st_asgeojson"></a><code>st_asgeojson(geography: geography, max_decimal_digits: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the GeoJSON representation of a given Geography with max_decimal_digits output for each coordinate value.</p>
+</span></td></tr>
+<tr><td><a name="st_asgeojson"></a><code>st_asgeojson(geography: geography, max_decimal_digits: <a href="int.html">int</a>, options: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the GeoJSON representation of a given Geography with max_decimal_digits output for each coordinate value.</p>
+<p>Options is a flag that can be bitmasked. The options are:</p>
+<ul>
+<li>0: no option (default for Geography)</li>
+<li>1: GeoJSON BBOX</li>
+<li>2: GeoJSON Short CRS (e.g EPSG:4326)</li>
+<li>4: GeoJSON Long CRS (e.g urn:ogc:def:crs:EPSG::4326)</li>
+<li>8: GeoJSON Short CRS if not EPSG:4326</li>
+</ul>
+</span></td></tr>
+<tr><td><a name="st_asgeojson"></a><code>st_asgeojson(geometry: geometry) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the GeoJSON representation of a given Geometry. Coordinates have a maximum of 9 decimal digits.</p>
+</span></td></tr>
+<tr><td><a name="st_asgeojson"></a><code>st_asgeojson(geometry: geometry, max_decimal_digits: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the GeoJSON representation of a given Geometry with max_decimal_digits output for each coordinate value.</p>
+</span></td></tr>
+<tr><td><a name="st_asgeojson"></a><code>st_asgeojson(geometry: geometry, max_decimal_digits: <a href="int.html">int</a>, options: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the GeoJSON representation of a given Geometry with max_decimal_digits output for each coordinate value.</p>
+<p>Options is a flag that can be bitmasked. The options are:</p>
+<ul>
+<li>0: no option</li>
+<li>1: GeoJSON BBOX</li>
+<li>2: GeoJSON Short CRS (e.g EPSG:4326)</li>
+<li>4: GeoJSON Long CRS (e.g urn:ogc:def:crs:EPSG::4326)</li>
+<li>8: GeoJSON Short CRS if not EPSG:4326 (default for Geometry)</li>
+</ul>
 </span></td></tr>
 <tr><td><a name="st_ashexewkb"></a><code>st_ashexewkb(geography: geography) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the EWKB representation in hex of a given Geography.</p>
 </span></td></tr>

--- a/pkg/geo/encode.go
+++ b/pkg/geo/encode.go
@@ -17,6 +17,9 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
+	"github.com/cockroachdb/cockroach/pkg/geo/geoprojbase"
+	"github.com/cockroachdb/errors"
+	"github.com/twpayne/go-geom"
 	"github.com/twpayne/go-geom/encoding/ewkb"
 	"github.com/twpayne/go-geom/encoding/geojson"
 	"github.com/twpayne/go-geom/encoding/kml"
@@ -71,17 +74,86 @@ func EWKBToWKB(b geopb.EWKB, byteOrder binary.ByteOrder) (geopb.WKB, error) {
 	return geopb.WKB(ret), err
 }
 
+// EWKBToGeoJSONFlag maps to the ST_AsGeoJSON flags for PostGIS.
+type EWKBToGeoJSONFlag int
+
+// These should be kept with ST_AsGeoJSON in PostGIS.
+// 0: means no option
+// 1: GeoJSON BBOX
+// 2: GeoJSON Short CRS (e.g EPSG:4326)
+// 4: GeoJSON Long CRS (e.g urn:ogc:def:crs:EPSG::4326)
+// 8: GeoJSON Short CRS if not EPSG:4326 (default)
+const (
+	EWKBToGeoJSONFlagIncludeBBox EWKBToGeoJSONFlag = 1 << (iota)
+	EWKBToGeoJSONFlagShortCRS
+	EWKBToGeoJSONFlagLongCRS
+	EWKBToGeoJSONFlagShortCRSIfNot4326
+
+	EWKBToGeoJSONFlagZero = 0
+)
+
+// geomToGeoJSONCRS converts a geom to its CRS GeoJSON form.
+func geomToGeoJSONCRS(t geom.T, long bool) (*geojson.CRS, error) {
+	projection, ok := geoprojbase.Projection(geopb.SRID(t.SRID()))
+	if !ok {
+		return nil, errors.Newf("unknown SRID: %d", t.SRID())
+	}
+	var prop string
+	if long {
+		prop = fmt.Sprintf("urn:ogc:def:crs:%s::%d", projection.AuthName, projection.AuthSRID)
+	} else {
+		prop = fmt.Sprintf("%s:%d", projection.AuthName, projection.AuthSRID)
+	}
+	crs := &geojson.CRS{
+		Type: "name",
+		Properties: map[string]interface{}{
+			"name": prop,
+		},
+	}
+	return crs, nil
+}
+
 // EWKBToGeoJSON transforms a given EWKB to GeoJSON.
-func EWKBToGeoJSON(b geopb.EWKB) ([]byte, error) {
+func EWKBToGeoJSON(b geopb.EWKB, maxDecimalDigits int, flag EWKBToGeoJSONFlag) ([]byte, error) {
 	t, err := ewkb.Unmarshal([]byte(b))
 	if err != nil {
 		return nil, err
 	}
-	f := geojson.Feature{
-		// TODO(otan): add features once we have spatial_ref_sys.
-		Geometry: t,
+	options := []geojson.EncodeGeometryOption{
+		geojson.EncodeGeometryWithMaxDecimalDigits(maxDecimalDigits),
 	}
-	return f.MarshalJSON()
+	if flag&EWKBToGeoJSONFlagIncludeBBox != 0 {
+		options = append(
+			options,
+			geojson.EncodeGeometryWithBBox(),
+		)
+	}
+	// Take CRS flag in order of precedence.
+	if t.SRID() != 0 {
+		if flag&EWKBToGeoJSONFlagLongCRS != 0 {
+			crs, err := geomToGeoJSONCRS(t, true /* long */)
+			if err != nil {
+				return nil, err
+			}
+			options = append(options, geojson.EncodeGeometryWithCRS(crs))
+		} else if flag&EWKBToGeoJSONFlagShortCRS != 0 {
+			crs, err := geomToGeoJSONCRS(t, false /* long */)
+			if err != nil {
+				return nil, err
+			}
+			options = append(options, geojson.EncodeGeometryWithCRS(crs))
+		} else if flag&EWKBToGeoJSONFlagShortCRSIfNot4326 != 0 {
+			if t.SRID() != 4326 {
+				crs, err := geomToGeoJSONCRS(t, false /* long */)
+				if err != nil {
+					return nil, err
+				}
+				options = append(options, geojson.EncodeGeometryWithCRS(crs))
+			}
+		}
+	}
+
+	return geojson.Marshal(t, options...)
 }
 
 // EWKBToWKBHex transforms a given EWKB to WKBHex.

--- a/pkg/geo/encode_test.go
+++ b/pkg/geo/encode_test.go
@@ -80,17 +80,31 @@ func TestEWKBToWKB(t *testing.T) {
 func TestEWKBToGeoJSON(t *testing.T) {
 	testCases := []struct {
 		ewkt     geopb.EWKT
+		flag     EWKBToGeoJSONFlag
 		expected string
 	}{
-		{"POINT(1.0 1.0)", `{"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":null}`},
-		{"SRID=4;POINT(1.0 1.0)", `{"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":null}`},
+		{"POINT(1.0 1.0)", EWKBToGeoJSONFlagZero, `{"type":"Point","coordinates":[1,1]}`},
+		{"POINT(1.0 1.0)", EWKBToGeoJSONFlagIncludeBBox, `{"type":"Point","bbox":[1,1,1,1],"coordinates":[1,1]}`},
+		{"POINT(1.0 1.0)", EWKBToGeoJSONFlagShortCRS | EWKBToGeoJSONFlagIncludeBBox, `{"type":"Point","bbox":[1,1,1,1],"coordinates":[1,1]}`},
+		{"POINT(1.0 1.0)", EWKBToGeoJSONFlagShortCRS, `{"type":"Point","coordinates":[1,1]}`},
+		{"POINT(1.0 1.0)", EWKBToGeoJSONFlagLongCRS, `{"type":"Point","coordinates":[1,1]}`},
+		{"POINT(1.0 1.0)", EWKBToGeoJSONFlagShortCRSIfNot4326, `{"type":"Point","coordinates":[1,1]}`},
+		{"POINT(1.1234567 1.9876543)", EWKBToGeoJSONFlagShortCRSIfNot4326, `{"type":"Point","coordinates":[1.123457,1.987654]}`},
+		{"SRID=4326;POINT(1.0 1.0)", EWKBToGeoJSONFlagZero, `{"type":"Point","coordinates":[1,1]}`},
+		{"SRID=4326;POINT(1.0 1.0)", EWKBToGeoJSONFlagIncludeBBox, `{"type":"Point","bbox":[1,1,1,1],"coordinates":[1,1]}`},
+		{"SRID=4326;POINT(1.0 1.0)", EWKBToGeoJSONFlagLongCRS, `{"type":"Point","crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"coordinates":[1,1]}`},
+		{"SRID=4326;POINT(1.0 1.0)", EWKBToGeoJSONFlagShortCRS, `{"type":"Point","crs":{"type":"name","properties":{"name":"EPSG:4326"}},"coordinates":[1,1]}`},
+		{"SRID=4004;POINT(1.0 1.0)", EWKBToGeoJSONFlagShortCRS, `{"type":"Point","crs":{"type":"name","properties":{"name":"EPSG:4004"}},"coordinates":[1,1]}`},
+		{"SRID=4004;POINT(1.0 1.0)", EWKBToGeoJSONFlagShortCRS | EWKBToGeoJSONFlagIncludeBBox, `{"type":"Point","bbox":[1,1,1,1],"crs":{"type":"name","properties":{"name":"EPSG:4004"}},"coordinates":[1,1]}`},
+		{"SRID=4326;POINT(1.0 1.0)", EWKBToGeoJSONFlagShortCRSIfNot4326, `{"type":"Point","coordinates":[1,1]}`},
+		{"SRID=4004;POINT(1.0 1.0)", EWKBToGeoJSONFlagShortCRSIfNot4326, `{"type":"Point","crs":{"type":"name","properties":{"name":"EPSG:4004"}},"coordinates":[1,1]}`},
 	}
 
 	for _, tc := range testCases {
 		t.Run(string(tc.ewkt), func(t *testing.T) {
 			so, err := parseEWKT(tc.ewkt, geopb.DefaultGeometrySRID, DefaultSRIDIsHint)
 			require.NoError(t, err)
-			encoded, err := EWKBToGeoJSON(so.EWKB)
+			encoded, err := EWKBToGeoJSON(so.EWKB, 6, tc.flag)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, string(encoded))
 		})

--- a/pkg/geo/parse.go
+++ b/pkg/geo/parse.go
@@ -99,12 +99,10 @@ func parseWKB(b []byte, defaultSRID geopb.SRID) (geopb.SpatialObject, error) {
 
 // parseGeoJSON takes given bytes assumed to be GeoJSON and transforms it into a SpatialObject.
 func parseGeoJSON(b []byte, defaultSRID geopb.SRID) (geopb.SpatialObject, error) {
-	var f geojson.Feature
-	if err := f.UnmarshalJSON(b); err != nil {
+	var t geom.T
+	if err := geojson.Unmarshal(b, &t); err != nil {
 		return geopb.SpatialObject{}, err
 	}
-	t := f.Geometry
-	// TODO(otan): check SRID from properties.
 	if defaultSRID != 0 && t.SRID() == 0 {
 		adjustGeomSRID(t, defaultSRID)
 	}

--- a/pkg/geo/parse_test.go
+++ b/pkg/geo/parse_test.go
@@ -225,7 +225,7 @@ func TestParseGeometry(t *testing.T) {
 			"",
 		},
 		{
-			`{ "type": "Feature", "geometry": { "type": "Point", "coordinates": [1.0, 1.0] }, "properties": { "name": "┳━┳ ヽ(ಠل͜ಠ)ﾉ" } }`,
+			`{ "type": "Point", "coordinates": [1.0, 1.0] }`,
 			&Geometry{
 				SpatialObject: geopb.SpatialObject{
 					EWKB:        []byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),
@@ -367,7 +367,7 @@ func TestParseGeography(t *testing.T) {
 			"",
 		},
 		{
-			`{ "type": "Feature", "geometry": { "type": "Point", "coordinates": [1.0, 1.0] }, "properties": { "name": "┳━┳ ヽ(ಠل͜ಠ)ﾉ" } }`,
+			`{ "type": "Point", "coordinates": [1.0, 1.0] }`,
 			&Geography{
 				SpatialObject: geopb.SpatialObject{
 					EWKB:        []byte("\x01\x01\x00\x00\x20\xe6\x10\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -196,8 +196,8 @@ INSERT INTO parse_test (geom, geog) VALUES
   (ST_GeomFromText('POINT(1.0 2.0)'), ST_GeogFromText('POINT(1.0 2.0)')),
   (ST_GeomFromText('SRID=4326;POINT(1.0 2.0)'), ST_GeogFromText('SRID=4326;POINT(1.0 2.0)')),
   (ST_GeometryFromText('SRID=4004;POINT(1.0 2.0)'), ST_GeographyFromText('POINT(1.0 2.0)')),
-  (ST_GeomFromGeoJSON('{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}'), ST_GeogFromGeoJSON('{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}')),
-  (ST_GeomFromGeoJSON('{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}'::jsonb), ST_GeogFromGeoJSON('{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}'::jsonb)),
+  (ST_GeomFromGeoJSON('{"type":"Point","coordinates":[1,2]}'), ST_GeogFromGeoJSON('{"type":"Point","coordinates":[1,2]}')),
+  (ST_GeomFromGeoJSON('{"type":"Point","coordinates":[1,2]}'::jsonb), ST_GeogFromGeoJSON('{"type":"Point","coordinates":[1,2]}'::jsonb)),
   (ST_GeomFromWKB(decode('0101000000000000000000F03F000000000000F03F', 'hex')), ST_GeogFromWKB(decode('0101000000000000000000F03F000000000000F03F', 'hex'))),
   (ST_GeomFromEWKB(decode('0101000000000000000000F03F000000000000F03F', 'hex')), ST_GeogFromEWKB(decode('0101000000000000000000F03F000000000000F03F', 'hex'))),
   (st_geomfromgeojson('null':::jsonb), st_geogfromgeojson('null':::jsonb))
@@ -209,7 +209,7 @@ SELECT
 ----
 true  true
 
-query TTTTTTTT
+query TTTTTTT
 SELECT
   ST_AsText(geom),
   ST_AsEWKT(geom),
@@ -217,25 +217,41 @@ SELECT
   ST_AsBinary(geom, 'ndr'),
   ST_AsBinary(geom, 'xdr'),
   ST_AsEWKB(geom),
-  ST_AsKML(geom),
-  ST_AsGeoJSON(geom)
+  ST_AsKML(geom)
 FROM parse_test ORDER BY id ASC
 ----
-POINT (1 2)                                    POINT (1 2)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
-<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
-<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 2)                                    SRID=4004;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 164 15 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
-<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 2)                                    POINT (1 2)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
-<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 2)                                    POINT (1 2)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
-<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 1)                                    POINT (1 1)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [0 0 0 0 1 63 240 0 0 0 0 0 0 63 240 0 0 0 0 0 0]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  <?xml version="1.0" encoding="UTF-8"?>
-<Point><coordinates>1,1</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":null}
-POINT (1 1)                                    POINT (1 1)                                                                           [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [0 0 0 0 1 63 240 0 0 0 0 0 0 63 240 0 0 0 0 0 0]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  <?xml version="1.0" encoding="UTF-8"?>
-<Point><coordinates>1,1</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":null}
-NULL                                           NULL                                                                                  NULL  NULL  NULL  NULL  NULL  NULL
+POINT (1 2)                                    POINT (1 2)  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>
+POINT (1 2)                                    SRID=4326;POINT (1 2)  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>
+POINT (1 2)                                    SRID=4004;POINT (1 2)  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 164 15 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>
+POINT (1 2)                                    POINT (1 2)  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>
+POINT (1 2)                                    POINT (1 2)  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>
+POINT (1 1)                                    POINT (1 1)  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [0 0 0 0 1 63 240 0 0 0 0 0 0 63 240 0 0 0 0 0 0]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,1</coordinates></Point>
+POINT (1 1)                                    POINT (1 1)  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [0 0 0 0 1 63 240 0 0 0 0 0 0 63 240 0 0 0 0 0 0]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,1</coordinates></Point>
+NULL                                           NULL  NULL  NULL  NULL  NULL  NULL
+
+
+query TTT
+SELECT
+  ST_AsGeoJSON(geom),
+  ST_AsGeoJSON(geom, 6, 8),
+  ST_AsGeoJSON(geom, 6, 5)
+FROM parse_test ORDER BY id ASC
+----
+{"type":"Point","coordinates":[1,2]}                                                          {"type":"Point","coordinates":[1,2]}                                                          {"type":"Point","bbox":[1,2,1,2],"coordinates":[1,2]}
+{"type":"Point","coordinates":[1,2]}                                                          {"type":"Point","coordinates":[1,2]}                                                          {"type":"Point","bbox":[1,2,1,2],"crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"coordinates":[1,2]}
+{"type":"Point","crs":{"type":"name","properties":{"name":"EPSG:4004"}},"coordinates":[1,2]}  {"type":"Point","crs":{"type":"name","properties":{"name":"EPSG:4004"}},"coordinates":[1,2]}  {"type":"Point","bbox":[1,2,1,2],"crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4004"}},"coordinates":[1,2]}
+{"type":"Point","coordinates":[1,2]}                                                          {"type":"Point","coordinates":[1,2]}                                                          {"type":"Point","bbox":[1,2,1,2],"coordinates":[1,2]}
+{"type":"Point","coordinates":[1,2]}                                                          {"type":"Point","coordinates":[1,2]}                                                          {"type":"Point","bbox":[1,2,1,2],"coordinates":[1,2]}
+{"type":"Point","coordinates":[1,1]}                                                          {"type":"Point","coordinates":[1,1]}                                                          {"type":"Point","bbox":[1,1,1,1],"coordinates":[1,1]}
+{"type":"Point","coordinates":[1,1]}                                                          {"type":"Point","coordinates":[1,1]}                                                          {"type":"Point","bbox":[1,1,1,1],"coordinates":[1,1]}
+NULL                                                                                          NULL                                                                                          NULL
 
 query TTTT
 SELECT
@@ -254,7 +270,7 @@ FROM parse_test ORDER BY id ASC
 0101000000000000000000F03F000000000000F03F  0101000000000000000000F03F000000000000F03F          0101000000000000000000F03F000000000000F03F          00000000013FF00000000000003FF0000000000000
 NULL                                        NULL                                                NULL                                                NULL
 
-query TTTTTTTT
+query TTTTTTT
 SELECT
   ST_AsText(geog),
   ST_AsEWKT(geog),
@@ -262,25 +278,40 @@ SELECT
   ST_AsBinary(geog, 'ndr'),
   ST_AsBinary(geog, 'xdr'),
   ST_AsEWKB(geog),
-  ST_AsKML(geog),
-  ST_AsGeoJSON(geog)
+  ST_AsKML(geog)
 FROM parse_test ORDER BY id ASC
 ----
-POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
-<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
-<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
-<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
-<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 2)                                    SRID=4326;POINT (1 2)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
-<Point><coordinates>1,2</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}
-POINT (1 1)                                    SRID=4326;POINT (1 1)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [0 0 0 0 1 63 240 0 0 0 0 0 0 63 240 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  <?xml version="1.0" encoding="UTF-8"?>
-<Point><coordinates>1,1</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":null}
-POINT (1 1)                                    SRID=4326;POINT (1 1)                                                                 [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [0 0 0 0 1 63 240 0 0 0 0 0 0 63 240 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  <?xml version="1.0" encoding="UTF-8"?>
-<Point><coordinates>1,1</coordinates></Point>  {"type":"Feature","geometry":{"type":"Point","coordinates":[1,1]},"properties":null}
-NULL                                           NULL                                                                                  NULL  NULL  NULL  NULL  NULL  NULL
+POINT (1 2)                                    SRID=4326;POINT (1 2)  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>
+POINT (1 2)                                    SRID=4326;POINT (1 2)  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>
+POINT (1 2)                                    SRID=4326;POINT (1 2)  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>
+POINT (1 2)                                    SRID=4326;POINT (1 2)  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>
+POINT (1 2)                                    SRID=4326;POINT (1 2)  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  [0 0 0 0 1 63 240 0 0 0 0 0 0 64 0 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 0 64]  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,2</coordinates></Point>
+POINT (1 1)                                    SRID=4326;POINT (1 1)  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [0 0 0 0 1 63 240 0 0 0 0 0 0 63 240 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,1</coordinates></Point>
+POINT (1 1)                                    SRID=4326;POINT (1 1)  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [1 1 0 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  [0 0 0 0 1 63 240 0 0 0 0 0 0 63 240 0 0 0 0 0 0]  [1 1 0 0 32 230 16 0 0 0 0 0 0 0 0 240 63 0 0 0 0 0 0 240 63]  <?xml version="1.0" encoding="UTF-8"?>
+<Point><coordinates>1,1</coordinates></Point>
+NULL                                           NULL  NULL  NULL  NULL  NULL  NULL
+
+query TTT
+SELECT
+  ST_AsGeoJSON(geog),
+  ST_AsGeoJSON(geog, 6, 8),
+  ST_AsGeoJSON(geog, 6, 5)
+FROM parse_test ORDER BY id ASC
+----
+{"type":"Point","coordinates":[1,2]}  {"type":"Point","coordinates":[1,2]}  {"type":"Point","bbox":[1,2,1,2],"crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"coordinates":[1,2]}
+{"type":"Point","coordinates":[1,2]}  {"type":"Point","coordinates":[1,2]}  {"type":"Point","bbox":[1,2,1,2],"crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"coordinates":[1,2]}
+{"type":"Point","coordinates":[1,2]}  {"type":"Point","coordinates":[1,2]}  {"type":"Point","bbox":[1,2,1,2],"crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"coordinates":[1,2]}
+{"type":"Point","coordinates":[1,2]}  {"type":"Point","coordinates":[1,2]}  {"type":"Point","bbox":[1,2,1,2],"crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"coordinates":[1,2]}
+{"type":"Point","coordinates":[1,2]}  {"type":"Point","coordinates":[1,2]}  {"type":"Point","bbox":[1,2,1,2],"crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"coordinates":[1,2]}
+{"type":"Point","coordinates":[1,1]}  {"type":"Point","coordinates":[1,1]}  {"type":"Point","bbox":[1,1,1,1],"crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"coordinates":[1,1]}
+{"type":"Point","coordinates":[1,1]}  {"type":"Point","coordinates":[1,1]}  {"type":"Point","bbox":[1,1,1,1],"crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::4326"}},"coordinates":[1,1]}
+NULL                                  NULL                                  NULL
 
 query TTTT
 SELECT


### PR DESCRIPTION
There was a bug in GeoJSON where we used the high level name:"Feature"
field, as opposed to the inner Geometry. This has been fixed.

We also support more options for ST_AsGeoJSON now that these changes are
in twpayne/go-geom.

Resolves https://github.com/cockroachdb/cockroach/issues/48381.

Release note (sql change): Implement ST_AsGeoJSON with options to show
bbox and CRS information.