### PR TITLE
physicalplan: preevaluate subqueries on LocalExprs and always set LocalExprs

### DIFF
--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -99,6 +99,7 @@ type NewColOperatorArgs struct {
 	ProcessorConstructor execinfra.ProcessorConstructor
 	DiskQueueCfg         colcontainer.DiskQueueCfg
 	FDSemaphore          semaphore.Semaphore
+	ExprHelper           ExprHelper
 	TestingKnobs         struct {
 		// UseStreamingMemAccountForBuffering specifies whether to use
 		// StreamingMemAccount when creating buffering operators and should only be
@@ -568,6 +569,9 @@ func NewColOperator(
 	streamingAllocator := colmem.NewAllocator(ctx, streamingMemAccount, factory)
 	useStreamingMemAccountForBuffering := args.TestingKnobs.UseStreamingMemAccountForBuffering
 	processorConstructor := args.ProcessorConstructor
+	if args.ExprHelper == nil {
+		args.ExprHelper = &defaultExprHelper{}
+	}
 
 	log.VEventf(ctx, 2, "planning col operator for spec %q", spec)
 
@@ -876,8 +880,9 @@ func NewColOperator(
 
 			if !core.HashJoiner.OnExpr.Empty() && core.HashJoiner.Type == sqlbase.InnerJoin {
 				if err =
-					result.planAndMaybeWrapOnExprAsFilter(ctx, flowCtx, core.HashJoiner.OnExpr,
-						streamingMemAccount, processorConstructor, factory); err != nil {
+					result.planAndMaybeWrapOnExprAsFilter(
+						ctx, flowCtx, core.HashJoiner.OnExpr, streamingMemAccount, processorConstructor, factory, args.ExprHelper,
+					); err != nil {
 					return result, err
 				}
 			}
@@ -938,8 +943,9 @@ func NewColOperator(
 			}
 
 			if onExpr != nil {
-				if err = result.planAndMaybeWrapOnExprAsFilter(ctx, flowCtx, *onExpr,
-					streamingMemAccount, processorConstructor, factory); err != nil {
+				if err = result.planAndMaybeWrapOnExprAsFilter(
+					ctx, flowCtx, *onExpr, streamingMemAccount, processorConstructor, factory, args.ExprHelper,
+				); err != nil {
 					return result, err
 				}
 			}
@@ -1093,7 +1099,7 @@ func NewColOperator(
 		Op:          result.Op,
 		ColumnTypes: result.ColumnTypes,
 	}
-	err = ppr.planPostProcessSpec(ctx, flowCtx, post, streamingMemAccount, factory)
+	err = ppr.planPostProcessSpec(ctx, flowCtx, post, streamingMemAccount, factory, args.ExprHelper)
 	// TODO(yuzefovich): update unit tests to remove panic-catcher when fallback
 	// to rowexec is not allowed.
 	if err != nil && processorConstructor == nil {
@@ -1149,6 +1155,7 @@ func (r *NewColOperatorResult) planAndMaybeWrapOnExprAsFilter(
 	streamingMemAccount *mon.BoundAccount,
 	processorConstructor execinfra.ProcessorConstructor,
 	factory coldata.ColumnFactory,
+	helper ExprHelper,
 ) error {
 	// We will plan other Operators on top of r.Op, so we need to account for the
 	// internal memory explicitly.
@@ -1160,7 +1167,7 @@ func (r *NewColOperatorResult) planAndMaybeWrapOnExprAsFilter(
 		ColumnTypes: r.ColumnTypes,
 	}
 	if err := ppr.planFilterExpr(
-		ctx, flowCtx.NewEvalCtx(), onExpr, streamingMemAccount, factory,
+		ctx, flowCtx.NewEvalCtx(), onExpr, streamingMemAccount, factory, helper,
 	); err != nil {
 		// ON expression planning failed. Fall back to planning the filter
 		// using row execution.
@@ -1210,10 +1217,11 @@ func (r *postProcessResult) planPostProcessSpec(
 	post *execinfrapb.PostProcessSpec,
 	streamingMemAccount *mon.BoundAccount,
 	factory coldata.ColumnFactory,
+	helper ExprHelper,
 ) error {
 	if !post.Filter.Empty() {
 		if err := r.planFilterExpr(
-			ctx, flowCtx.NewEvalCtx(), post.Filter, streamingMemAccount, factory,
+			ctx, flowCtx.NewEvalCtx(), post.Filter, streamingMemAccount, factory, helper,
 		); err != nil {
 			return err
 		}
@@ -1224,18 +1232,15 @@ func (r *postProcessResult) planPostProcessSpec(
 	} else if post.RenderExprs != nil {
 		log.VEventf(ctx, 2, "planning render expressions %+v", post.RenderExprs)
 		var renderedCols []uint32
-		for _, expr := range post.RenderExprs {
-			var (
-				helper            execinfra.ExprHelper
-				renderInternalMem int
-			)
-			err := helper.Init(expr, r.ColumnTypes, flowCtx.EvalCtx)
+		for _, renderExpr := range post.RenderExprs {
+			var renderInternalMem int
+			expr, err := helper.ProcessExpr(renderExpr, flowCtx.EvalCtx, r.ColumnTypes)
 			if err != nil {
 				return err
 			}
 			var outputIdx int
 			r.Op, outputIdx, r.ColumnTypes, renderInternalMem, err = planProjectionOperators(
-				ctx, flowCtx.NewEvalCtx(), helper.Expr, r.ColumnTypes, r.Op, streamingMemAccount, factory,
+				ctx, flowCtx.NewEvalCtx(), expr, r.ColumnTypes, r.Op, streamingMemAccount, factory,
 			)
 			if err != nil {
 				return errors.Wrapf(err, "unable to columnarize render expression %q", expr)
@@ -1364,16 +1369,14 @@ func (r *postProcessResult) planFilterExpr(
 	filter execinfrapb.Expression,
 	acc *mon.BoundAccount,
 	factory coldata.ColumnFactory,
+	helper ExprHelper,
 ) error {
-	var (
-		helper               execinfra.ExprHelper
-		selectionInternalMem int
-	)
-	err := helper.Init(filter, r.ColumnTypes, evalCtx)
+	var selectionInternalMem int
+	expr, err := helper.ProcessExpr(filter, evalCtx, r.ColumnTypes)
 	if err != nil {
 		return err
 	}
-	if helper.Expr == tree.DNull {
+	if expr == tree.DNull {
 		// The filter expression is tree.DNull meaning that it is always false, so
 		// we put a zero operator.
 		r.Op = NewZeroOp(r.Op)
@@ -1381,7 +1384,7 @@ func (r *postProcessResult) planFilterExpr(
 	}
 	var filterColumnTypes []*types.T
 	r.Op, _, filterColumnTypes, selectionInternalMem, err = planSelectionOperators(
-		ctx, evalCtx, helper.Expr, r.ColumnTypes, r.Op, acc, factory,
+		ctx, evalCtx, expr, r.ColumnTypes, r.Op, acc, factory,
 	)
 	if err != nil {
 		return errors.Wrapf(err, "unable to columnarize filter expression %q", filter.Expr)

--- a/pkg/sql/colexec/execplan.go
+++ b/pkg/sql/colexec/execplan.go
@@ -1387,7 +1387,7 @@ func (r *postProcessResult) planFilterExpr(
 		ctx, evalCtx, expr, r.ColumnTypes, r.Op, acc, factory,
 	)
 	if err != nil {
-		return errors.Wrapf(err, "unable to columnarize filter expression %q", filter.Expr)
+		return errors.Wrapf(err, "unable to columnarize filter expression %q", filter)
 	}
 	r.InternalMemUsage += selectionInternalMem
 	if len(filterColumnTypes) > len(r.ColumnTypes) {

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -214,7 +214,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	f := &flowinfra.FlowBase{FlowCtx: execinfra.FlowCtx{EvalCtx: &evalCtx, NodeID: base.TestingIDContainer}}
 	var wg sync.WaitGroup
-	vfc := newVectorizedFlowCreator(&vectorizedFlowCreatorHelper{f: f}, componentCreator, false, &wg, &execinfra.RowChannel{}, nil, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{}, nil)
+	vfc := newVectorizedFlowCreator(&vectorizedFlowCreatorHelper{f: f}, componentCreator, false, &wg, &execinfra.RowChannel{}, nil, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{}, nil, false /* forceExprDeserialization */)
 
 	_, err := vfc.setupFlow(ctx, &f.FlowCtx, procs, flowinfra.FuseNormally)
 	defer func() {

--- a/pkg/sql/execinfrapb/data.go
+++ b/pkg/sql/execinfrapb/data.go
@@ -160,8 +160,9 @@ type Expression struct {
 	// (@1, @2, @3 ..) used for "input" variables.
 	Expr string
 
-	// LocalExpr is an unserialized field that's used to pass expressions to local
-	// flows without serializing/deserializing them.
+	// LocalExpr is an unserialized field that's used to pass expressions to
+	// the gateway node without serializing/deserializing them. It is always
+	// set in non-test setup.
 	LocalExpr tree.TypedExpr
 }
 
@@ -172,13 +173,13 @@ func (e *Expression) Empty() bool {
 
 // String implements the Stringer interface.
 func (e Expression) String() string {
+	if e.Expr != "" {
+		return e.Expr
+	}
 	if e.LocalExpr != nil {
 		ctx := tree.NewFmtCtx(tree.FmtCheckEquivalence)
 		ctx.FormatNode(e.LocalExpr)
 		return ctx.CloseAndGetString()
-	}
-	if e.Expr != "" {
-		return e.Expr
 	}
 	return "none"
 }

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/colflow"
-	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -212,21 +211,17 @@ func populateExplain(
 
 		ctxSessionData := flowCtx.EvalCtx.SessionData
 		vectorizedThresholdMet := physicalPlan.MaxEstimatedRowCount >= ctxSessionData.VectorizeRowCountThreshold
-		willVectorize = true
 		if ctxSessionData.VectorizeMode == sessiondata.VectorizeOff {
 			willVectorize = false
 		} else if !vectorizedThresholdMet && (ctxSessionData.VectorizeMode == sessiondata.Vectorize201Auto || ctxSessionData.VectorizeMode == sessiondata.VectorizeOn) {
 			willVectorize = false
 		} else {
-			thisNodeID := distSQLPlanner.nodeDesc.NodeID
-			for nodeID, flow := range flows {
-				fuseOpt := flowinfra.FuseNormally
-				if nodeID == thisNodeID && !willDistribute {
-					fuseOpt = flowinfra.FuseAggressively
-				}
-				_, err := colflow.SupportsVectorized(params.ctx, flowCtx, flow.Processors, fuseOpt, nil /* output */)
-				willVectorize = willVectorize && (err == nil)
-				if !willVectorize {
+			willVectorize = true
+			thisNodeID, _ := params.extendedEvalCtx.NodeID.OptionalNodeID()
+			for scheduledOnNodeID, flow := range flows {
+				scheduledOnRemoteNode := scheduledOnNodeID != thisNodeID
+				if _, err := colflow.SupportsVectorized(params.ctx, flowCtx, flow.Processors, !willDistribute, nil /* output */, scheduledOnRemoteNode); err != nil {
+					willVectorize = false
 					break
 				}
 			}

--- a/pkg/sql/logictest/testdata/logic_test/tpch_vec
+++ b/pkg/sql/logictest/testdata/logic_test/tpch_vec
@@ -754,13 +754,15 @@ EXPLAIN (VEC) SELECT ps_partkey, sum(ps_supplycost * ps_availqty::float) AS valu
 │
 └ Node 1
   └ *colexec.sortOp
-    └ *rowexec.noopProcessor
-      └ *colexec.hashAggregator
-        └ *rowexec.joinReader
-          └ *rowexec.joinReader
+    └ *colexec.selGTFloat64Float64Op
+      └ *colexec.castOpNullAny
+        └ *colexec.constNullOp
+          └ *colexec.hashAggregator
             └ *rowexec.joinReader
-              └ *colexec.selEQBytesBytesConstOp
-                └ *colexec.colBatchScan
+              └ *rowexec.joinReader
+                └ *rowexec.joinReader
+                  └ *colexec.selEQBytesBytesConstOp
+                    └ *colexec.colBatchScan
 
 # Query 12
 query T
@@ -826,10 +828,12 @@ EXPLAIN (VEC) SELECT s_suppkey, s_name, s_address, s_phone, total_revenue FROM s
   └ *colexec.mergeJoinInnerOp
     ├ *colexec.colBatchScan
     └ *colexec.sortOp
-      └ *rowexec.noopProcessor
-        └ *colexec.hashAggregator
-          └ *rowexec.indexJoiner
-            └ *colexec.colBatchScan
+      └ *colexec.selEQFloat64Float64Op
+        └ *colexec.castOpNullAny
+          └ *colexec.constNullOp
+            └ *colexec.hashAggregator
+              └ *rowexec.indexJoiner
+                └ *colexec.colBatchScan
 
 statement ok
 DROP VIEW revenue0
@@ -1002,4 +1006,11 @@ EXPLAIN (VEC) SELECT cntrycode, count(*) AS numcust, sum(c_acctbal) AS totacctba
   └ *colexec.sortOp
     └ *colexec.hashAggregator
       └ *rowexec.joinReader
-        └ *rowexec.tableReader
+        └ *colexec.selGTFloat64Float64Op
+          └ *colexec.castOpNullAny
+            └ *colexec.constNullOp
+              └ *colexec.selectInOpBytes
+                └ *colexec.substringInt64Int64Operator
+                  └ *colexec.constInt64Op
+                    └ *colexec.constInt64Op
+                      └ *colexec.colBatchScan

--- a/pkg/sql/physicalplan/expression.go
+++ b/pkg/sql/physicalplan/expression.go
@@ -14,8 +14,6 @@
 package physicalplan
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -80,39 +78,31 @@ func MakeExpression(
 		evalCtx: evalCtx,
 	}
 
-	outExpr := expr.(tree.Expr)
 	if ctx.EvaluateSubqueries() {
-		outExpr, _ = tree.WalkExpr(subqueryVisitor, expr)
+		outExpr, _ := tree.WalkExpr(subqueryVisitor, expr)
 		if subqueryVisitor.err != nil {
 			return execinfrapb.Expression{}, subqueryVisitor.err
 		}
 		expr = outExpr.(tree.TypedExpr)
 	}
 
+	if indexVarMap != nil {
+		// Remap our indexed vars.
+		expr = sqlbase.RemapIVarsInTypedExpr(expr, indexVarMap)
+	}
+	expression := execinfrapb.Expression{LocalExpr: expr}
 	if ctx.IsLocal() {
-		if indexVarMap != nil {
-			// Remap our indexed vars.
-			expr = sqlbase.RemapIVarsInTypedExpr(expr, indexVarMap)
-		}
-		return execinfrapb.Expression{LocalExpr: expr}, nil
+		return expression, nil
 	}
 
-	// We format the expression using the IndexedVar and Placeholder formatting interceptors.
+	// Since the plan is not fully local, serialize the expression.
 	fmtCtx := execinfrapb.ExprFmtCtxBase(evalCtx)
-	if indexVarMap != nil {
-		fmtCtx.SetIndexedVarFormat(func(ctx *tree.FmtCtx, idx int) {
-			remappedIdx := indexVarMap[idx]
-			if remappedIdx < 0 {
-				panic(fmt.Sprintf("unmapped index %d", idx))
-			}
-			ctx.Printf("@%d", remappedIdx+1)
-		})
-	}
-	fmtCtx.FormatNode(outExpr)
+	fmtCtx.FormatNode(expr)
 	if log.V(1) {
-		log.Infof(evalCtx.Ctx(), "Expr %s:\n%s", fmtCtx.String(), tree.ExprDebugString(outExpr))
+		log.Infof(evalCtx.Ctx(), "Expr %s:\n%s", fmtCtx.String(), tree.ExprDebugString(expr))
 	}
-	return execinfrapb.Expression{Expr: fmtCtx.CloseAndGetString()}, nil
+	expression.Expr = fmtCtx.CloseAndGetString()
+	return expression, nil
 }
 
 type evalAndReplaceSubqueryVisitor struct {

--- a/pkg/sql/physicalplan/physical_plan_test.go
+++ b/pkg/sql/physicalplan/physical_plan_test.go
@@ -337,7 +337,16 @@ func TestProjectionAndRendering(t *testing.T) {
 
 		tc.action(&p)
 
-		if post := p.GetLastStagePost(); !reflect.DeepEqual(post, tc.expPost) {
+		post := p.GetLastStagePost()
+		// The actual planning always sets unserialized LocalExpr field on the
+		// expressions, however, we don't do that for the expected results. In
+		// order to be able to use the deep comparison below we manually unset
+		// that unserialized field.
+		post.Filter.LocalExpr = nil
+		for i := range post.RenderExprs {
+			post.RenderExprs[i].LocalExpr = nil
+		}
+		if !reflect.DeepEqual(post, tc.expPost) {
 			t.Errorf("%d: incorrect post:\n%s\nexpected:\n%s", testIdx, &post, &tc.expPost)
 		}
 		var resTypes []string

--- a/pkg/sql/rowexec/joinerbase.go
+++ b/pkg/sql/rowexec/joinerbase.go
@@ -63,7 +63,7 @@ func (jb *joinerBase) init(
 
 	if jb.joinType.IsSetOpJoin() {
 		if !onExpr.Empty() {
-			return errors.Errorf("expected empty onExpr, got %v", onExpr.Expr)
+			return errors.Errorf("expected empty onExpr, got %v", onExpr)
 		}
 	}
 


### PR DESCRIPTION
**physicalplan: preevaluate subqueries on LocalExprs**

When the plan is local, we do not serialize expressions. Previously, in
such a case we would also not preevaluate the subqueries in the
expressions which made `EXPLAIN (VEC)` return unexpected plan (there
would `tree.Subquery` in the expression which we don't support in the
vectorized, so we would wrap the plan). Now we will preevalute the
subqueries before storing in the processor spec. AFAICT it affects only
this explain variant and nothing else.

Release note: None

**colexec: improve expression parsing**

This commit introduces `colexec.ExprHelper` that helps with expression
processing. Previously, we were allocating a new `execinfra.ExprHelper`
and were calling `Init` on it in order to get the typed expression from
possibly serialized representation of each expression. Now, this new
expression helper is reused between all expressions in the flow on
a single node.

There is one caveat, however: we need to make sure that we force
deserialization of the expressions during `SupportsVectorized` check if
the flow is scheduled to be run on a remote node (different from the one
that is performing the check). This is necessary to make sure that the
remote nodes will be able to deserialize the expressions without
encountering errors (if we don't force the serialization during the
check, we will use `LocalExpr` - if available - and might not catch
things that we don't support).

Release note: None

**physicalplan: always store LocalExpr**

Previously, we would set either `LocalExpr` (unserialized expression,
only when we have the full plan on a single node) or `Expr` (serialized
expression, when we have distributed plan as well as in some tests).
However, we could be setting both and making best effort to reuse
unserialized `LocalExpr` on the gateway even if the plan is distributed.
And this commit adds such behavior.

Fixes: #49810.

Release note: None