### PR TITLE
config/kv/storage: teach split queue / merge queue about tenant boundaries

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -335,7 +335,7 @@ func splitAndScatter(
 			// TODO(dan): Really, this should be splitting the Key of the first
 			// entry in the _next_ chunk.
 			log.VEventf(restoreCtx, 1, "presplitting chunk %d of %d", idx, len(importSpanChunks))
-			if err := db.AdminSplit(ctx, chunkKey, chunkKey, expirationTime); err != nil {
+			if err := db.AdminSplit(ctx, chunkKey, expirationTime); err != nil {
 				return err
 			}
 
@@ -391,7 +391,7 @@ func splitAndScatter(
 					// TODO(dan): Really, this should be splitting the Key of
 					// the _next_ entry.
 					log.VEventf(restoreCtx, 1, "presplitting %d of %d", idx, len(importSpans))
-					if err := db.AdminSplit(ctx, newSpanKey, newSpanKey, expirationTime); err != nil {
+					if err := db.AdminSplit(ctx, newSpanKey, expirationTime); err != nil {
 						return err
 					}
 

--- a/pkg/ccl/importccl/bench_test.go
+++ b/pkg/ccl/importccl/bench_test.go
@@ -129,7 +129,7 @@ func benchmarkAddSSTable(b *testing.B, dir string, tables []tableSSTable) {
 		}}
 		s, _, kvDB := serverutils.StartServer(b, args)
 		for _, t := range tables {
-			if err := kvDB.AdminSplit(ctx, t.span.Key, t.span.Key, hlc.Timestamp{} /* expirationTime */); err != nil {
+			if err := kvDB.AdminSplit(ctx, t.span.Key, hlc.Timestamp{} /* expirationTime */); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -315,10 +315,10 @@ func runTestImport(t *testing.T, init func(*cluster.Settings)) {
 				t.Fatalf("failed to rewrite key: %s", reqMidKey2)
 			}
 
-			if err := kvDB.AdminSplit(ctx, reqMidKey1, reqMidKey1, hlc.MaxTimestamp /* expirationTime */); err != nil {
+			if err := kvDB.AdminSplit(ctx, reqMidKey1, hlc.MaxTimestamp /* expirationTime */); err != nil {
 				t.Fatal(err)
 			}
-			if err := kvDB.AdminSplit(ctx, reqMidKey2, reqMidKey2, hlc.MaxTimestamp /* expirationTime */); err != nil {
+			if err := kvDB.AdminSplit(ctx, reqMidKey2, hlc.MaxTimestamp /* expirationTime */); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -176,14 +176,19 @@ func (s *SystemConfig) get(key roachpb.Key) *roachpb.KeyValue {
 
 // GetIndex searches the kv list for 'key' and returns its index if found.
 func (s *SystemConfig) GetIndex(key roachpb.Key) (int, bool) {
-	l := len(s.Values)
-	i := sort.Search(l, func(i int) bool {
-		return key.Compare(s.Values[i].Key) <= 0
-	})
-	if i == l || !key.Equal(s.Values[i].Key) {
+	i := s.getIndexBound(key)
+	if i == len(s.Values) || !key.Equal(s.Values[i].Key) {
 		return 0, false
 	}
 	return i, true
+}
+
+// getIndexBound searches the kv list for 'key' and returns its index if found
+// or the index it would be placed at if not found.
+func (s *SystemConfig) getIndexBound(key roachpb.Key) int {
+	return sort.Search(len(s.Values), func(i int) bool {
+		return key.Compare(s.Values[i].Key) <= 0
+	})
 }
 
 // GetLargestObjectID returns the largest object ID found in the config which is
@@ -200,16 +205,14 @@ func (s *SystemConfig) GetLargestObjectID(
 		return hook(maxID), nil
 	}
 
-	// Search for the descriptor table entries within the SystemConfig.
-	highBound := keys.SystemSQLCodec.TablePrefix(keys.DescriptorTableID + 1)
-	highIndex := sort.Search(len(s.Values), func(i int) bool {
-		return bytes.Compare(s.Values[i].Key, highBound) >= 0
-	})
+	// Search for the descriptor table entries within the SystemConfig. lowIndex
+	// (in s.Values) is the first and highIndex one past the last KV pair in the
+	// descriptor table.
 	lowBound := keys.SystemSQLCodec.TablePrefix(keys.DescriptorTableID)
-	lowIndex := sort.Search(len(s.Values), func(i int) bool {
-		return bytes.Compare(s.Values[i].Key, lowBound) >= 0
-	})
-	if highIndex == lowIndex {
+	lowIndex := s.getIndexBound(lowBound)
+	highBound := keys.SystemSQLCodec.TablePrefix(keys.DescriptorTableID + 1)
+	highIndex := s.getIndexBound(highBound)
+	if lowIndex == highIndex {
 		return 0, fmt.Errorf("descriptor table not found in system config of %d values", len(s.Values))
 	}
 
@@ -561,7 +564,7 @@ func (s *SystemConfig) systemTenantTableBoundarySplitKey(
 	if startID <= keys.MaxReservedDescID {
 		endID, err := s.GetLargestObjectID(keys.MaxReservedDescID, keys.PseudoTableIDs)
 		if err != nil {
-			log.Errorf(context.TODO(), "unable to determine largest reserved object ID from system config: %s", err)
+			log.Errorf(ctx, "unable to determine largest reserved object ID from system config: %s", err)
 			return nil
 		}
 		if splitKey := findSplitKey(startID, endID); splitKey != nil {
@@ -573,7 +576,7 @@ func (s *SystemConfig) systemTenantTableBoundarySplitKey(
 	// Find the split key in the system tenant's user space.
 	endID, err := s.GetLargestObjectID(0, keys.PseudoTableIDs)
 	if err != nil {
-		log.Errorf(context.TODO(), "unable to determine largest object ID from system config: %s", err)
+		log.Errorf(ctx, "unable to determine largest object ID from system config: %s", err)
 		return nil
 	}
 	return findSplitKey(startID, endID)
@@ -582,8 +585,86 @@ func (s *SystemConfig) systemTenantTableBoundarySplitKey(
 func (s *SystemConfig) tenantBoundarySplitKey(
 	ctx context.Context, startKey, endKey roachpb.RKey,
 ) roachpb.RKey {
-	// TODO(nvanbenschoten): implement this logic. Tracked in #48774.
-	return nil
+	// Bail early if there's no overlap with the secondary tenant keyspace.
+	searchSpan := roachpb.Span{Key: startKey.AsRawKey(), EndKey: endKey.AsRawKey()}
+	tenantSpan := roachpb.Span{Key: keys.TenantTableDataMin, EndKey: keys.TenantTableDataMax}
+	if !searchSpan.Overlaps(tenantSpan) {
+		return nil
+	}
+
+	// Determine tenant ID range being searched: [lowTenID, highTenID].
+	var lowTenID, highTenID roachpb.TenantID
+	if searchSpan.Key.Compare(tenantSpan.Key) < 0 {
+		// startKey before tenant keyspace.
+		lowTenID = roachpb.MinTenantID
+	} else {
+		// MakeTenantPrefix(lowTenIDExcl) is either the start key of this key
+		// range or is outside of this key range. We're only searching for split
+		// points within the specified key range, so the first tenant ID that we
+		// would consider splitting on is the following ID.
+		_, lowTenIDExcl, err := keys.DecodeTenantPrefix(searchSpan.Key)
+		if err != nil {
+			log.Errorf(ctx, "unable to decode tenant ID from start key: %s", err)
+			return nil
+		}
+		if lowTenIDExcl == roachpb.MaxTenantID {
+			// MaxTenantID already split or outside range.
+			return nil
+		}
+		lowTenID = roachpb.MakeTenantID(lowTenIDExcl.ToUint64() + 1)
+	}
+	if searchSpan.EndKey.Compare(tenantSpan.EndKey) >= 0 {
+		// endKey after tenant keyspace.
+		highTenID = roachpb.MaxTenantID
+	} else {
+		rem, highTenIDExcl, err := keys.DecodeTenantPrefix(searchSpan.EndKey)
+		if err != nil {
+			log.Errorf(ctx, "unable to decode tenant ID from end key: %s", err)
+			return nil
+		}
+		if len(rem) == 0 {
+			// MakeTenantPrefix(highTenIDExcl) is the end key of this key range.
+			// The key range is exclusive but we're looking for an inclusive
+			// range of tenant IDs, so the last tenant ID that we would consider
+			// splitting on is the previous ID.
+			//
+			// Unlike with searchSpan.Key and MaxTenantID, there is no exception
+			// for DecodeTenantPrefix(searchSpan.EndKey) == MinTenantID. This is
+			// because tenantSpan.Key is set to MakeTenantPrefix(MinTenantID),
+			// so we would have already returned early in that case.
+			highTenID = roachpb.MakeTenantID(highTenIDExcl.ToUint64() - 1)
+		} else {
+			highTenID = highTenIDExcl
+		}
+	}
+
+	// Bail if there is no chance of any tenant boundaries between these IDs.
+	if lowTenID.ToUint64() > highTenID.ToUint64() {
+		return nil
+	}
+
+	// Search for the tenants table entries in the SystemConfig within the
+	// desired tenant ID range.
+	lowBound := keys.SystemSQLCodec.TenantMetadataKey(lowTenID)
+	lowIndex := s.getIndexBound(lowBound)
+	if lowIndex == len(s.Values) {
+		// No keys within range found.
+		return nil
+	}
+
+	// Choose the first key in this range. Extract its tenant ID and check
+	// whether its within the desired tenant ID range.
+	splitKey := s.Values[lowIndex].Key
+	splitTenID, err := keys.SystemSQLCodec.DecodeTenantMetadataID(splitKey)
+	if err != nil {
+		log.Errorf(ctx, "unable to decode tenant ID from system config: %s", err)
+		return nil
+	}
+	if splitTenID.ToUint64() > highTenID.ToUint64() {
+		// No keys within range found.
+		return nil
+	}
+	return roachpb.RKey(keys.MakeTenantPrefix(splitTenID))
 }
 
 // NeedsSplit returns whether the range [startKey, endKey) needs a split due

--- a/pkg/config/system_test.go
+++ b/pkg/config/system_test.go
@@ -11,6 +11,7 @@
 package config_test
 
 import (
+	"context"
 	"math"
 	"sort"
 	"testing"
@@ -320,7 +321,7 @@ func TestComputeSplitKeySystemRanges(t *testing.T) {
 		Values: kvs,
 	}
 	for tcNum, tc := range testCases {
-		splitKey := cfg.ComputeSplitKey(tc.start, tc.end)
+		splitKey := cfg.ComputeSplitKey(context.Background(), tc.start, tc.end)
 		expected := roachpb.RKey(tc.split)
 		if !splitKey.Equal(expected) {
 			t.Errorf("#%d: bad split:\ngot: %v\nexpected: %v", tcNum, splitKey, expected)
@@ -431,7 +432,7 @@ func TestComputeSplitKeyTableIDs(t *testing.T) {
 	cfg := config.NewSystemConfig(zonepb.DefaultZoneConfigRef())
 	for tcNum, tc := range testCases {
 		cfg.Values = tc.values
-		splitKey := cfg.ComputeSplitKey(tc.start, tc.end)
+		splitKey := cfg.ComputeSplitKey(context.Background(), tc.start, tc.end)
 		if !splitKey.Equal(tc.split) {
 			t.Errorf("#%d: bad split:\ngot: %v\nexpected: %v", tcNum, splitKey, tc.split)
 		}

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -343,6 +343,7 @@ const (
 	DescriptorTablePrimaryKeyIndexID  = 1
 	DescriptorTableDescriptorColID    = 2
 	DescriptorTableDescriptorColFamID = 2
+	TenantsTablePrimaryKeyIndexID     = 1
 
 	// Reserved IDs for other system tables. Note that some of these IDs refer
 	// to "Ranges" instead of a Table - these IDs are needed to store custom

--- a/pkg/kv/batch.go
+++ b/pkg/kv/batch.go
@@ -645,12 +645,7 @@ func (b *Batch) adminMerge(key interface{}) {
 
 // adminSplit is only exported on DB. It is here for symmetry with the
 // other operations.
-func (b *Batch) adminSplit(spanKeyIn, splitKeyIn interface{}, expirationTime hlc.Timestamp) {
-	spanKey, err := marshalKey(spanKeyIn)
-	if err != nil {
-		b.initResult(0, 0, notRaw, err)
-		return
-	}
+func (b *Batch) adminSplit(splitKeyIn interface{}, expirationTime hlc.Timestamp) {
 	splitKey, err := marshalKey(splitKeyIn)
 	if err != nil {
 		b.initResult(0, 0, notRaw, err)
@@ -658,7 +653,7 @@ func (b *Batch) adminSplit(spanKeyIn, splitKeyIn interface{}, expirationTime hlc
 	}
 	req := &roachpb.AdminSplitRequest{
 		RequestHeader: roachpb.RequestHeader{
-			Key: spanKey,
+			Key: splitKey,
 		},
 		SplitKey:       splitKey,
 		ExpirationTime: expirationTime,

--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -151,10 +151,10 @@ func runTestImport(t *testing.T, batchSizeValue int64) {
 				return encoding.EncodeStringAscending(append([]byte{}, prefix...), fmt.Sprintf("k%d", i))
 			}
 
-			if err := kvDB.AdminSplit(ctx, key(split1), key(split1), hlc.MaxTimestamp /* expirationTime */); err != nil {
+			if err := kvDB.AdminSplit(ctx, key(split1), hlc.MaxTimestamp /* expirationTime */); err != nil {
 				t.Fatal(err)
 			}
-			if err := kvDB.AdminSplit(ctx, key(split2), key(split2), hlc.MaxTimestamp /* expirationTime */); err != nil {
+			if err := kvDB.AdminSplit(ctx, key(split2), hlc.MaxTimestamp /* expirationTime */); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -126,7 +126,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 func setupMultipleRanges(ctx context.Context, db *kv.DB, splitAt ...string) error {
 	// Split the keyspace at the given keys.
 	for _, key := range splitAt {
-		if err := db.AdminSplit(ctx, key /* spanKey */, key /* splitKey */, hlc.MaxTimestamp /* expirationTime */); err != nil {
+		if err := db.AdminSplit(ctx, key /* splitKey */, hlc.MaxTimestamp /* expirationTime */); err != nil {
 			return err
 		}
 	}
@@ -1261,7 +1261,7 @@ func TestParallelSender(t *testing.T) {
 	// Split into multiple ranges.
 	splitKeys := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}
 	for _, key := range splitKeys {
-		if err := db.AdminSplit(context.Background(), key, key, hlc.MaxTimestamp /* expirationTime */); err != nil {
+		if err := db.AdminSplit(context.Background(), key, hlc.MaxTimestamp /* expirationTime */); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1306,7 +1306,7 @@ func initReverseScanTestEnv(s serverutils.TestServerInterface, t *testing.T) *kv
 	// ["", "b"),["b", "e") ,["e", "g") and ["g", "\xff\xff").
 	for _, key := range []string{"b", "e", "g"} {
 		// Split the keyspace at the given key.
-		if err := db.AdminSplit(context.Background(), key, key, hlc.MaxTimestamp /* expirationTime */); err != nil {
+		if err := db.AdminSplit(context.Background(), key, hlc.MaxTimestamp /* expirationTime */); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1404,7 +1404,7 @@ func TestBatchPutWithConcurrentSplit(t *testing.T) {
 	// Split first using the default client and scan to make sure that
 	// the range descriptor cache reflects the split.
 	for _, key := range []string{"b", "f"} {
-		if err := db.AdminSplit(context.Background(), key, key, hlc.MaxTimestamp /* expirationTime */); err != nil {
+		if err := db.AdminSplit(context.Background(), key, hlc.MaxTimestamp /* expirationTime */); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1460,7 +1460,7 @@ func TestReverseScanWithSplitAndMerge(t *testing.T) {
 
 	// Case 1: An encounter with a range split.
 	// Split the range ["b", "e") at "c".
-	if err := db.AdminSplit(context.Background(), "c", "c", hlc.MaxTimestamp /* expirationTime */); err != nil {
+	if err := db.AdminSplit(context.Background(), "c", hlc.MaxTimestamp /* expirationTime */); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kv/kvclient/kvcoord/split_test.go
+++ b/pkg/kv/kvclient/kvcoord/split_test.go
@@ -108,7 +108,7 @@ func TestRangeSplitMeta(t *testing.T) {
 	for _, splitRKey := range splitKeys {
 		splitKey := roachpb.Key(splitRKey)
 		log.Infof(ctx, "starting split at key %q...", splitKey)
-		if err := s.DB.AdminSplit(ctx, splitKey, splitKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
+		if err := s.DB.AdminSplit(ctx, splitKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
 			t.Fatal(err)
 		}
 		log.Infof(ctx, "split at key %q complete", splitKey)
@@ -154,7 +154,7 @@ func TestRangeSplitsWithConcurrentTxns(t *testing.T) {
 			<-txnChannel
 		}
 		log.Infof(ctx, "starting split at key %q...", splitKey)
-		if pErr := s.DB.AdminSplit(context.Background(), splitKey, splitKey, hlc.MaxTimestamp /* expirationTime */); pErr != nil {
+		if pErr := s.DB.AdminSplit(context.Background(), splitKey, hlc.MaxTimestamp /* expirationTime */); pErr != nil {
 			t.Error(pErr)
 		}
 		log.Infof(ctx, "split at key %q complete", splitKey)
@@ -247,11 +247,11 @@ func TestRangeSplitsWithSameKeyTwice(t *testing.T) {
 
 	splitKey := roachpb.Key("aa")
 	log.Infof(ctx, "starting split at key %q...", splitKey)
-	if err := s.DB.AdminSplit(ctx, splitKey, splitKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
+	if err := s.DB.AdminSplit(ctx, splitKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
 		t.Fatal(err)
 	}
 	log.Infof(ctx, "split at key %q first time complete", splitKey)
-	if err := s.DB.AdminSplit(ctx, splitKey, splitKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
+	if err := s.DB.AdminSplit(ctx, splitKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -275,7 +275,7 @@ func TestRangeSplitsStickyBit(t *testing.T) {
 	descKey := keys.RangeDescriptorKey(splitKey)
 
 	// Splitting range.
-	if err := s.DB.AdminSplit(ctx, splitKey.AsRawKey(), splitKey.AsRawKey(), hlc.MaxTimestamp /* expirationTime */); err != nil {
+	if err := s.DB.AdminSplit(ctx, splitKey.AsRawKey(), hlc.MaxTimestamp /* expirationTime */); err != nil {
 		t.Fatal(err)
 	}
 
@@ -295,7 +295,7 @@ func TestRangeSplitsStickyBit(t *testing.T) {
 	}
 
 	// Splitting range.
-	if err := s.DB.AdminSplit(ctx, splitKey.AsRawKey(), splitKey.AsRawKey(), hlc.MaxTimestamp /* expirationTime */); err != nil {
+	if err := s.DB.AdminSplit(ctx, splitKey.AsRawKey(), hlc.MaxTimestamp /* expirationTime */); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -294,7 +294,7 @@ func TestTxnCoordSenderHeartbeat(t *testing.T) {
 	keyA := roachpb.Key("a")
 	keyC := roachpb.Key("c")
 	splitKey := roachpb.Key("b")
-	if err := s.DB.AdminSplit(ctx, splitKey /* spanKey */, splitKey /* splitKey */, hlc.MaxTimestamp /* expirationTimestamp */); err != nil {
+	if err := s.DB.AdminSplit(ctx, splitKey /* splitKey */, hlc.MaxTimestamp /* expirationTimestamp */); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -408,7 +408,7 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 		}
 		s.Manual.Increment(time.Second.Nanoseconds())
 		// Split range by keyB.
-		if err := s.DB.AdminSplit(context.Background(), splitKey, splitKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
+		if err := s.DB.AdminSplit(context.Background(), splitKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
 			t.Fatal(err)
 		}
 		// Wait till split complete.

--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -72,7 +72,7 @@ func applyOp(ctx context.Context, db *kv.DB, op *Operation) {
 	case *GetOperation, *PutOperation, *BatchOperation:
 		applyClientOp(ctx, db, op)
 	case *SplitOperation:
-		err := db.AdminSplit(ctx, o.Key, o.Key, hlc.MaxTimestamp)
+		err := db.AdminSplit(ctx, o.Key, hlc.MaxTimestamp)
 		o.Result = resultError(ctx, err)
 	case *MergeOperation:
 		err := db.AdminMerge(ctx, o.Key)

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -2840,7 +2840,7 @@ func TestChangeReplicasLeaveAtomicRacesWithMerge(t *testing.T) {
 		err = db.AdminMerge(ctx, lhs)
 		require.NoError(t, err)
 		if resplit {
-			require.NoError(t, db.AdminSplit(ctx, lhs, rhs, hlc.Timestamp{WallTime: math.MaxInt64}))
+			require.NoError(t, db.AdminSplit(ctx, rhs, hlc.Timestamp{WallTime: math.MaxInt64}))
 			err = tc.WaitForSplitAndInitialization(rhs)
 			require.NoError(t, err)
 		}

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -455,7 +455,7 @@ func testConsistencyQueueRecomputeStatsImpl(t *testing.T, hadEstimates bool) {
 		// Split off a range so that we get away from the timeseries writes, which
 		// pollute the stats with ContainsEstimates=true. Note that the split clears
 		// the right hand side (which is what we operate on) from that flag.
-		if err := db0.AdminSplit(ctx, key, key, hlc.MaxTimestamp /* expirationTime */); err != nil {
+		if err := db0.AdminSplit(ctx, key, hlc.MaxTimestamp /* expirationTime */); err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/kv/kvserver/log_test.go
+++ b/pkg/kv/kvserver/log_test.go
@@ -54,7 +54,7 @@ func TestLogSplits(t *testing.T) {
 	initialSplits := countSplits()
 
 	// Generate an explicit split event.
-	if err := kvDB.AdminSplit(ctx, "splitkey", "splitkey", hlc.MaxTimestamp /* expirationTime */); err != nil {
+	if err := kvDB.AdminSplit(ctx, "splitkey", hlc.MaxTimestamp /* expirationTime */); err != nil {
 		t.Fatal(err)
 	}
 
@@ -175,10 +175,10 @@ func TestLogMerges(t *testing.T) {
 	}
 
 	// Create two ranges, then merge them.
-	if err := kvDB.AdminSplit(ctx, "a", "a", hlc.MaxTimestamp /* expirationTime */); err != nil {
+	if err := kvDB.AdminSplit(ctx, "a", hlc.MaxTimestamp /* expirationTime */); err != nil {
 		t.Fatal(err)
 	}
-	if err := kvDB.AdminSplit(ctx, "b", "b", hlc.MaxTimestamp /* expirationTime */); err != nil {
+	if err := kvDB.AdminSplit(ctx, "b", hlc.MaxTimestamp /* expirationTime */); err != nil {
 		t.Fatal(err)
 	}
 	if err := kvDB.AdminMerge(ctx, "a"); err != nil {

--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -142,7 +142,7 @@ func (mq *mergeQueue) shouldQueue(
 		return false, 0
 	}
 
-	if sysCfg.NeedsSplit(desc.StartKey, desc.EndKey.Next()) {
+	if sysCfg.NeedsSplit(ctx, desc.StartKey, desc.EndKey.Next()) {
 		// This range would need to be split if it extended just one key further.
 		// There is thus no possible right-hand neighbor that it could be merged
 		// with.
@@ -245,7 +245,7 @@ func (mq *mergeQueue) process(
 	// in a situation where we keep merging ranges that would be split soon after
 	// by a small increase in load.
 	conservativeLoadBasedSplitThreshold := 0.5 * lhsRepl.SplitByLoadQPSThreshold()
-	shouldSplit, _ := shouldSplitRange(mergedDesc, mergedStats,
+	shouldSplit, _ := shouldSplitRange(ctx, mergedDesc, mergedStats,
 		lhsRepl.GetMaxBytes(), lhsRepl.shouldBackpressureWrites(), sysCfg)
 	if shouldSplit || mergedQPS >= conservativeLoadBasedSplitThreshold {
 		log.VEventf(ctx, 2,

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -629,7 +629,7 @@ func (bq *baseQueue) maybeAdd(ctx context.Context, repl replicaInQueue, now hlc.
 		repl.maybeInitializeRaftGroup(ctx)
 	}
 
-	if cfg != nil && bq.requiresSplit(cfg, repl) {
+	if cfg != nil && bq.requiresSplit(ctx, cfg, repl) {
 		// Range needs to be split due to zone configs, but queue does
 		// not accept unsplit ranges.
 		if log.V(1) {
@@ -662,12 +662,14 @@ func (bq *baseQueue) maybeAdd(ctx context.Context, repl replicaInQueue, now hlc.
 	}
 }
 
-func (bq *baseQueue) requiresSplit(cfg *config.SystemConfig, repl replicaInQueue) bool {
+func (bq *baseQueue) requiresSplit(
+	ctx context.Context, cfg *config.SystemConfig, repl replicaInQueue,
+) bool {
 	if bq.acceptsUnsplitRanges {
 		return false
 	}
 	desc := repl.Desc()
-	return cfg.NeedsSplit(desc.StartKey, desc.EndKey)
+	return cfg.NeedsSplit(ctx, desc.StartKey, desc.EndKey)
 }
 
 // addInternal adds the replica the queue with specified priority. If
@@ -901,7 +903,7 @@ func (bq *baseQueue) processReplica(ctx context.Context, repl replicaInQueue) er
 		}
 	}
 
-	if cfg != nil && bq.requiresSplit(cfg, repl) {
+	if cfg != nil && bq.requiresSplit(ctx, cfg, repl) {
 		// Range needs to be split due to zone configs, but queue does
 		// not accept unsplit ranges.
 		log.VEventf(ctx, 3, "split needed; skipping")

--- a/pkg/kv/kvserver/queue_test.go
+++ b/pkg/kv/kvserver/queue_test.go
@@ -629,11 +629,11 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 		return nil
 	})
 	neverSplitsDesc := neverSplits.Desc()
-	if sysCfg.NeedsSplit(neverSplitsDesc.StartKey, neverSplitsDesc.EndKey) {
+	if sysCfg.NeedsSplit(ctx, neverSplitsDesc.StartKey, neverSplitsDesc.EndKey) {
 		t.Fatal("System config says range needs to be split")
 	}
 	willSplitDesc := willSplit.Desc()
-	if sysCfg.NeedsSplit(willSplitDesc.StartKey, willSplitDesc.EndKey) {
+	if sysCfg.NeedsSplit(ctx, willSplitDesc.StartKey, willSplitDesc.EndKey) {
 		t.Fatal("System config says range needs to be split")
 	}
 
@@ -665,11 +665,11 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 
 	// Check our config.
 	neverSplitsDesc = neverSplits.Desc()
-	if sysCfg.NeedsSplit(neverSplitsDesc.StartKey, neverSplitsDesc.EndKey) {
+	if sysCfg.NeedsSplit(ctx, neverSplitsDesc.StartKey, neverSplitsDesc.EndKey) {
 		t.Fatal("System config says range needs to be split")
 	}
 	willSplitDesc = willSplit.Desc()
-	if !sysCfg.NeedsSplit(willSplitDesc.StartKey, willSplitDesc.EndKey) {
+	if !sysCfg.NeedsSplit(ctx, willSplitDesc.StartKey, willSplitDesc.EndKey) {
 		t.Fatal("System config says range does not need to be split")
 	}
 

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -823,7 +823,8 @@ func (r *Replica) getImpliedGCThresholdRLocked(
 	return threshold
 }
 
-// isSystemRange returns true if r's key range precedes keys.UserTableDataMin.
+// isSystemRange returns true if r's key range precedes the start of user
+// structured data (SQL keys) for the range's tenant keyspace.
 func (r *Replica) isSystemRange() bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -831,7 +832,8 @@ func (r *Replica) isSystemRange() bool {
 }
 
 func (r *Replica) isSystemRangeRLocked() bool {
-	return r.mu.state.Desc.StartKey.Less(roachpb.RKey(keys.UserTableDataMin))
+	rem, _, err := keys.DecodeTenantPrefix(r.mu.state.Desc.StartKey.AsRawKey())
+	return err == nil && roachpb.Key(rem).Compare(keys.UserTableDataMin) < 0
 }
 
 // maxReplicaIDOfAny returns the maximum ReplicaID of any replica, including

--- a/pkg/kv/kvserver/replica_command_test.go
+++ b/pkg/kv/kvserver/replica_command_test.go
@@ -40,7 +40,7 @@ func TestRangeDescriptorUpdateProtoChangedAcrossVersions(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	bKey := roachpb.Key("b")
-	if err := kvDB.AdminSplit(ctx, bKey, bKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
+	if err := kvDB.AdminSplit(ctx, bKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
 		t.Fatal(err)
 	}
 
@@ -85,7 +85,7 @@ func TestRangeDescriptorUpdateProtoChangedAcrossVersions(t *testing.T) {
 	// merges and replica changes, but they all go through updateRangeDescriptor
 	// so it's unnecessary.
 	cKey := roachpb.Key("c")
-	if err := kvDB.AdminSplit(ctx, cKey, cKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
+	if err := kvDB.AdminSplit(ctx, cKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -8990,7 +8990,7 @@ func TestErrorInRaftApplicationClearsIntents(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 
 	splitKey := roachpb.Key("b")
-	if err := kvDB.AdminSplit(context.Background(), splitKey, splitKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
+	if err := kvDB.AdminSplit(context.Background(), splitKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kv/kvserver/split_queue_test.go
+++ b/pkg/kv/kvserver/split_queue_test.go
@@ -94,7 +94,7 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		// Testing using shouldSplitRange instead of shouldQueue to avoid using the splitFinder
 		// This tests the merge queue behavior too as a result. For splitFinder tests,
 		// see split/split_test.go.
-		shouldQ, priority := shouldSplitRange(repl.Desc(), repl.GetMVCCStats(),
+		shouldQ, priority := shouldSplitRange(ctx, repl.Desc(), repl.GetMVCCStats(),
 			repl.GetMaxBytes(), repl.ShouldBackpressureWrites(), cfg)
 		if shouldQ != test.shouldQ {
 			t.Errorf("%d: should queue expected %t; got %t", i, test.shouldQ, shouldQ)

--- a/pkg/kv/kvserver/ts_maintenance_queue_test.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue_test.go
@@ -268,7 +268,7 @@ func TestTimeSeriesMaintenanceQueueServer(t *testing.T) {
 
 	// Force a range split in between near past and far past. This guarantees
 	// that the pruning operation will issue a DeleteRange which spans ranges.
-	if err := db.AdminSplit(context.Background(), splitKey, splitKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
+	if err := db.AdminSplit(context.Background(), splitKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/server/intent_test.go
+++ b/pkg/server/intent_test.go
@@ -116,7 +116,7 @@ func TestIntentResolution(t *testing.T) {
 				Knobs: base.TestingKnobs{Store: &storeKnobs}})
 			defer s.Stopper().Stop(context.Background())
 			// Split the Range. This should not have any asynchronous intents.
-			if err := kvDB.AdminSplit(context.Background(), splitKey, splitKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
+			if err := kvDB.AdminSplit(context.Background(), splitKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -526,7 +526,7 @@ func TestNodeStatusWritten(t *testing.T) {
 	// ========================================
 
 	// Split the range.
-	if err := ts.db.AdminSplit(context.Background(), splitKey, splitKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
+	if err := ts.db.AdminSplit(context.Background(), splitKey, hlc.MaxTimestamp /* expirationTime */); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -343,7 +343,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	ts := s.(*TestServer)
 	tds := db.NonTransactionalSender()
 
-	if err := ts.node.storeCfg.DB.AdminSplit(ctx, "m", "m", hlc.MaxTimestamp /* expirationTime */); err != nil {
+	if err := ts.node.storeCfg.DB.AdminSplit(ctx, "m", hlc.MaxTimestamp /* expirationTime */); err != nil {
 		t.Fatal(err)
 	}
 	writes := []roachpb.Key{roachpb.Key("a"), roachpb.Key("z")}
@@ -442,7 +442,7 @@ func TestMultiRangeScanWithPagination(t *testing.T) {
 			tds := db.NonTransactionalSender()
 
 			for _, sk := range tc.splitKeys {
-				if err := ts.node.storeCfg.DB.AdminSplit(ctx, sk, sk, hlc.MaxTimestamp /* expirationTime */); err != nil {
+				if err := ts.node.storeCfg.DB.AdminSplit(ctx, sk, hlc.MaxTimestamp /* expirationTime */); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1291,7 +1291,7 @@ func (sc *SchemaChanger) backfillIndexes(
 	expirationTime := sc.db.Clock().Now().Add(time.Hour.Nanoseconds(), 0)
 
 	for _, span := range addingSpans {
-		if err := sc.db.AdminSplit(ctx, span.Key, span.Key, expirationTime); err != nil {
+		if err := sc.db.AdminSplit(ctx, span.Key, expirationTime); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -188,7 +188,7 @@ func presplitTableBoundaries(
 	expirationTime := cfg.DB.Clock().Now().Add(time.Hour.Nanoseconds(), 0)
 	for _, tbl := range tables {
 		for _, span := range tbl.Desc.AllIndexSpans(cfg.Codec) {
-			if err := cfg.DB.AdminSplit(ctx, span.Key, span.Key, expirationTime); err != nil {
+			if err := cfg.DB.AdminSplit(ctx, span.Key, expirationTime); err != nil {
 				return err
 			}
 

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -54,7 +54,7 @@ func (n *splitNode) Next(params runParams) (bool, error) {
 		return false, err
 	}
 
-	if err := params.ExecCfg().DB.AdminSplit(params.ctx, rowKey, rowKey, n.expirationTime); err != nil {
+	if err := params.ExecCfg().DB.AdminSplit(params.ctx, rowKey, n.expirationTime); err != nil {
 		return false, err
 	}
 

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -1782,7 +1782,6 @@ func addSystemDatabaseToSchema(
 	defaultSystemZoneConfig *zonepb.ZoneConfig,
 ) {
 	addSystemDescriptorsToSchema(target)
-	// TODO(nvanbenschoten): only do this for the system tenant. Tracked in #48774.
 	addSplitIDs(target)
 	addZoneConfigKVsToSchema(target, defaultZoneConfig, defaultSystemZoneConfig)
 }

--- a/pkg/sql/tests/testdata/initial_keys
+++ b/pkg/sql/tests/testdata/initial_keys
@@ -159,35 +159,8 @@ initial-keys tenant=5
  /Tenant/5/NamespaceTable/30/1/1/29/"ui"/4/1
  /Tenant/5/NamespaceTable/30/1/1/29/"users"/4/1
  /Tenant/5/NamespaceTable/30/1/1/29/"web_sessions"/4/1
-28 splits:
- /Tenant/5/Table/11
- /Tenant/5/Table/12
- /Tenant/5/Table/13
- /Tenant/5/Table/14
- /Tenant/5/Table/15
- /Tenant/5/Table/16
- /Tenant/5/Table/17
- /Tenant/5/Table/18
- /Tenant/5/Table/19
- /Tenant/5/Table/20
- /Tenant/5/Table/21
- /Tenant/5/Table/22
- /Tenant/5/Table/23
- /Tenant/5/Table/24
- /Tenant/5/Table/25
- /Tenant/5/Table/26
- /Tenant/5/Table/27
- /Tenant/5/Table/28
- /Tenant/5/Table/29
- /Tenant/5/NamespaceTable/30
- /Tenant/5/NamespaceTable/Max
- /Tenant/5/Table/32
- /Tenant/5/Table/33
- /Tenant/5/Table/34
- /Tenant/5/Table/35
- /Tenant/5/Table/36
- /Tenant/5/Table/37
- /Tenant/5/Table/38
+1 splits:
+ /Tenant/5
 
 initial-keys tenant=999
 ----
@@ -250,32 +223,5 @@ initial-keys tenant=999
  /Tenant/999/NamespaceTable/30/1/1/29/"ui"/4/1
  /Tenant/999/NamespaceTable/30/1/1/29/"users"/4/1
  /Tenant/999/NamespaceTable/30/1/1/29/"web_sessions"/4/1
-28 splits:
- /Tenant/999/Table/11
- /Tenant/999/Table/12
- /Tenant/999/Table/13
- /Tenant/999/Table/14
- /Tenant/999/Table/15
- /Tenant/999/Table/16
- /Tenant/999/Table/17
- /Tenant/999/Table/18
- /Tenant/999/Table/19
- /Tenant/999/Table/20
- /Tenant/999/Table/21
- /Tenant/999/Table/22
- /Tenant/999/Table/23
- /Tenant/999/Table/24
- /Tenant/999/Table/25
- /Tenant/999/Table/26
- /Tenant/999/Table/27
- /Tenant/999/Table/28
- /Tenant/999/Table/29
- /Tenant/999/NamespaceTable/30
- /Tenant/999/NamespaceTable/Max
- /Tenant/999/Table/32
- /Tenant/999/Table/33
- /Tenant/999/Table/34
- /Tenant/999/Table/35
- /Tenant/999/Table/36
- /Tenant/999/Table/37
- /Tenant/999/Table/38
+1 splits:
+ /Tenant/999

--- a/pkg/sqlmigrations/migrations_test.go
+++ b/pkg/sqlmigrations/migrations_test.go
@@ -710,7 +710,7 @@ func TestExpectedInitialRangeCount(t *testing.T) {
 			if err := rows.Scan(&rangeID, &startKey, &endKey); err != nil {
 				return err
 			}
-			if sysCfg.NeedsSplit(startKey, endKey) {
+			if sysCfg.NeedsSplit(ctx, startKey, endKey) {
 				return fmt.Errorf("range %d needs split", rangeID)
 			}
 			nranges++


### PR DESCRIPTION
Fixes #48774.

This PR updates `SystemConfig.NeedsSplit` and `SystemConfig.ComputeSplitKey` to take into account tenant rows in the `system.tenants` table and mandate split points at tenant keyspace boundaries. This ensures that the splitQueue will create splits between tenants and that the mergeQueue will avoid merging ranges for different tenants together.

It then updates the `crdb_internal.create_tenant` builtin function so that it splits ranges synchronously when creating a new tenant. The prior commit taught the split and merge queues about tenant boundaries, which means that split points will be created asynchronously when a new tenant is created. However, it is valuable from an isolation perspective to split off tenant ranges synchronously upon the creation of a new tenant.

Finally, the PR teaches MVCCFindSplitKey about tenant prefixes, ensuring that all split points that are chosen within secondary tenant keyspaces obey the same rules as those chosen within the system tenant keyspace. Namely, it ensures that splits are never performed between two column families in the same SQL row (this was already the case) and that we never split off an empty LHS range due to a first row that exceeds half of the range size (this is new).