### PR TITLE
[WIP] Makefile: fix bin/docgen in cross compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -553,7 +553,7 @@ $(BASE_CGO_FLAGS_FILES): Makefile build/defs.mk.sig | bin/.submodules-initialize
 	@echo >> $@
 	@echo 'package $(if $($(@D)-package),$($(@D)-package),$(notdir $(@D)))' >> $@
 	@echo >> $@
-	@echo '// #cgo CPPFLAGS: $(addprefix -I,$(JEMALLOC_DIR)/include $(KRB_CPPFLAGS) $(GEOS_DIR)/capi $(PROJ_DIR)/lib)' >> $@
+	@echo '// #cgo CPPFLAGS: $(addprefix -I,$(JEMALLOC_DIR)/include $(KRB_CPPFLAGS))' >> $@
 	@echo '// #cgo LDFLAGS: $(addprefix -L,$(CRYPTOPP_DIR) $(PROTOBUF_DIR) $(JEMALLOC_DIR)/lib $(SNAPPY_DIR) $(LIBEDIT_DIR)/src/.libs $(ROCKSDB_DIR) $(LIBROACH_DIR) $(KRB_DIR) $(PROJ_DIR)/lib)' >> $@
 	@echo 'import "C"' >> $@
 
@@ -1671,7 +1671,6 @@ bins = \
   bin/benchmark \
   bin/cockroach-oss \
   bin/cockroach-short \
-  bin/docgen \
   bin/execgen \
   bin/fuzz \
   bin/generate-binary \
@@ -1734,6 +1733,12 @@ $(testbins): bin/%: bin/%.d | bin/prereqs $(SUBMODULES_TARGET)
 bin/prereqs: ./pkg/cmd/prereqs/*.go | bin/.submodules-initialized
 	@echo go install -v ./pkg/cmd/prereqs
 	@$(GO_INSTALL) -v ./pkg/cmd/prereqs
+
+bin/docgen: ./pkg/cmd/docgen/*.go | bin/prereqs bin/.submodules-initialized
+	@echo go install -v ./pkg/cmd/docgen
+	bin/prereqs ./pkg/cmd/docgen > $@.d.tmp
+	mv -f $@.d.tmp $@.d
+	@$(GO_INSTALL) -i -tags 'go_install' -v ./pkg/cmd/docgen
 
 .PHONY: fuzz
 fuzz: ## Run fuzz tests.

--- a/pkg/geo/geoproj/geoproj.go
+++ b/pkg/geo/geoproj/geoproj.go
@@ -9,11 +9,15 @@
 // licenses/APL.txt.
 
 // Package geoproj contains functions that interface with the PROJ library.
+//
+// Note this package is installed differently depending on the presence of a
+// "go_install" flag. This is because when cross compiling, it will
+// attempt to compile against the wrong PROJ library and fail out.
 package geoproj
 
 // #cgo CXXFLAGS: -std=c++14
 // #cgo CPPFLAGS: -I../../../c-deps/proj/src
-// #cgo LDFLAGS: -lproj
+// #cgo !go_install LDFLAGS: -lproj
 // #cgo linux LDFLAGS: -lrt -lm -lpthread
 // #cgo windows LDFLAGS: -lshlwapi -lrpcrt4
 //

--- a/pkg/geo/geoproj/proj.cc
+++ b/pkg/geo/geoproj/proj.cc
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// +build !go_install
+
 #include "proj.h"
 #include <cstring>
 #include <proj_api.h>

--- a/pkg/geo/geoproj/proj_no_goinstall.cc
+++ b/pkg/geo/geoproj/proj_no_goinstall.cc
@@ -1,0 +1,21 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build go_install
+
+// All stub functions in this file will error out.
+
+#include "proj.h"
+#include <assert.h>
+
+CR_PROJ_Status CR_PROJ_Transform(char* fromSpec, char* toSpec, long point_count, double* x,
+                                 double* y, double* z) {
+  assert(0);
+}


### PR DESCRIPTION

`bin/docgen` imports builtins, which imports `geoproj`, which imports a
C library. Unfortunately, we try to install docgen in the Makefile but
will error as it is incompatible with the host system during cross
compilation. Hence, we special case some hacky fixes around to cover
these cases.

Also removed unnecessary imports in the zcgo_flags.go for GEOS and PROJ
in the CPP flags.

Release note: None

