### PR TITLE
server: add ./cockroach mt start-sql

### DIFF
--- a/pkg/cli/cliflags/flags_mt.go
+++ b/pkg/cli/cliflags/flags_mt.go
@@ -1,0 +1,26 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cliflags
+
+// Flags specific to multi-tenancy commands.
+var (
+	TenantID = FlagInfo{
+		Name:        "tenant-id",
+		EnvVar:      "COCKROACH_TENANT_ID",
+		Description: `The tenant ID under which to start the SQL server.`,
+	}
+
+	KVAddrs = FlagInfo{
+		Name:        "kv-addrs",
+		EnvVar:      "COCKROACH_KV_ADDRS",
+		Description: `A comma-separated list of KV endpoints (load balancers allowed).`,
+	}
+)

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -109,18 +109,19 @@ func initCLIDefaults() {
 	debugCtx.maxResults = 0
 	debugCtx.ballastSize = base.SizeSpec{InBytes: 1000000000}
 
-	serverCfg.GoroutineDumpDirName = ""
-	serverCfg.HeapProfileDirName = ""
-	serverCfg.ReadyFn = nil
-	serverCfg.DelayedBootstrapFn = nil
-	serverCfg.SocketFile = ""
-	serverCfg.JoinList = nil
-	serverCfg.JoinPreferSRVRecords = false
-	serverCfg.DefaultZoneConfig = zonepb.DefaultZoneConfig()
-	serverCfg.DefaultSystemZoneConfig = zonepb.DefaultSystemZoneConfig()
+	serverCfg.KVConfig.GoroutineDumpDirName = ""
+	serverCfg.KVConfig.HeapProfileDirName = ""
+	serverCfg.KVConfig.ReadyFn = nil
+	serverCfg.KVConfig.DelayedBootstrapFn = nil
+	serverCfg.SQLConfig.SocketFile = ""
+	serverCfg.KVConfig.JoinList = nil
+	serverCfg.TenantKVAddrs = []string{"127.0.0.1:26257"}
+	serverCfg.KVConfig.JoinPreferSRVRecords = false
+	serverCfg.BaseConfig.DefaultZoneConfig = zonepb.DefaultZoneConfig()
+	serverCfg.KVConfig.DefaultSystemZoneConfig = zonepb.DefaultSystemZoneConfig()
 	// Attempt to default serverCfg.MemoryPoolSize to 25% if possible.
 	if bytes, _ := memoryPercentResolver(25); bytes != 0 {
-		serverCfg.MemoryPoolSize = bytes
+		serverCfg.SQLConfig.MemoryPoolSize = bytes
 	}
 
 	startCtx.serverInsecure = baseCfg.Insecure

--- a/pkg/cli/mt.go
+++ b/pkg/cli/mt.go
@@ -1,0 +1,31 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import "github.com/spf13/cobra"
+
+func init() {
+	cockroachCmd.AddCommand(mtCmd)
+	mtCmd.AddCommand(mtStartSQLCmd)
+}
+
+// mtCmd is the base command for functionality related to multi-tenancy.
+var mtCmd = &cobra.Command{
+	Use:   "mt [command]",
+	Short: "commands related to multi-tenancy",
+	Long: `
+Commands related to multi-tenancy.
+
+This functionality is **experimental** and for internal use only.
+`,
+	RunE:   usageAndErr,
+	Hidden: true,
+}

--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -1,0 +1,88 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"context"
+	"os"
+	"os/signal"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+)
+
+var mtStartSQLCmd = &cobra.Command{
+	Use:   "start-sql",
+	Short: "start a standalone SQL server",
+	Long: `
+Start a standalone SQL server.
+
+This functionality is **experimental** and for internal use only.
+`,
+	Args: cobra.NoArgs,
+	RunE: MaybeDecorateGRPCError(runStartSQL),
+}
+
+func runStartSQL(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	const clusterName = ""
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	st := serverCfg.BaseConfig.Settings
+
+	// TODO(tbg): this has to be passed in. See the upgrade strategy in:
+	// https://github.com/cockroachdb/cockroach/issues/47919
+	if err := clusterversion.Initialize(ctx, st.Version.BinaryVersion(), &st.SV); err != nil {
+		return err
+	}
+
+	tempStorageMaxSizeBytes := int64(base.DefaultInMemTempStorageMaxSizeBytes)
+	if err := diskTempStorageSizeValue.Resolve(
+		&tempStorageMaxSizeBytes, memoryPercentResolver,
+	); err != nil {
+		return err
+	}
+
+	serverCfg.SQLConfig.TempStorageConfig = base.TempStorageConfigFromEnv(
+		ctx,
+		st,
+		base.StoreSpec{InMemory: true},
+		"", // parentDir
+		tempStorageMaxSizeBytes,
+	)
+
+	addr, err := server.StartTenant(
+		ctx,
+		stopper,
+		clusterName,
+		serverCfg.BaseConfig,
+		serverCfg.SQLConfig,
+	)
+	if err != nil {
+		return err
+	}
+	log.Infof(ctx, "SQL server for tenant %s listening at %s", serverCfg.SQLConfig.TenantID, addr)
+
+	// TODO(tbg): make the other goodies in `./cockroach start` reusable, such as
+	// logging to files, periodic memory output, heap and goroutine dumps, debug
+	// server, graceful drain. Then use them here.
+
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, drainSignals...)
+	sig := <-ch
+	return errors.Newf("received signal %v", sig)
+}

--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -42,6 +42,11 @@ func registerAcceptance(r *testRegistry) {
 		{name: "gossip/restart", fn: runGossipRestart},
 		{name: "gossip/restart-node-one", fn: runGossipRestartNodeOne},
 		{name: "gossip/locality-address", fn: runCheckLocalityIPAddress},
+		{
+			name:       "multitenant",
+			minVersion: "v20.2.0", // multitenancy is introduced in this cycle
+			fn:         runAcceptanceMultitenant,
+		},
 		{name: "rapid-restart", fn: runRapidRestart},
 		{
 			name: "many-splits", fn: runManySplits,

--- a/pkg/cmd/roachtest/multitenant.go
+++ b/pkg/cmd/roachtest/multitenant.go
@@ -1,0 +1,75 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"context"
+	gosql "database/sql"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func runAcceptanceMultitenant(ctx context.Context, t *test, c *cluster) {
+	c.Put(ctx, cockroach, "./cockroach")
+	c.Start(ctx, t, c.All())
+
+	_, err := c.Conn(ctx, 1).Exec(`SELECT crdb_internal.create_tenant(123)`)
+	require.NoError(t, err)
+
+	kvAddrs := c.ExternalAddr(ctx, c.All())
+
+	errCh := make(chan error)
+	go func() {
+		errCh <- c.RunE(ctx, c.Node(1),
+			"./cockroach", "mt", "start-sql",
+			// TODO(tbg): make this test secure.
+			// "--certs-dir", "certs",
+			"--insecure",
+			"--tenant-id", "123",
+			"--kv-addrs", strings.Join(kvAddrs, ","),
+			// Don't bind to external interfaces when running locally.
+			"--sql-addr", ifLocal("127.0.0.1", "0.0.0.0")+":36257",
+		)
+	}()
+	u, err := url.Parse(c.ExternalPGUrl(ctx, c.Node(1))[0])
+	require.NoError(t, err)
+	u.Host = c.ExternalIP(ctx, c.Node(1))[0] + ":36257"
+	url := u.String()
+	c.l.Printf("sql server should be running at %s", url)
+
+	time.Sleep(time.Second)
+
+	select {
+	case err := <-errCh:
+		t.Fatal(err)
+	default:
+	}
+
+	db, err := gosql.Open("postgres", url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	_, err = db.Exec(`CREATE TABLE foo (id INT PRIMARY KEY, v STRING)`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`INSERT INTO foo VALUES($1, $2)`, 1, "bar")
+	require.NoError(t, err)
+
+	var id int
+	var v string
+	require.NoError(t, db.QueryRow(`SELECT * FROM foo LIMIT 1`).Scan(&id, &v))
+	require.Equal(t, 1, id)
+	require.Equal(t, "bar", v)
+}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -327,6 +327,11 @@ type SQLConfig struct {
 
 	// QueryCacheSize is the memory size (in bytes) of the query plan cache.
 	QueryCacheSize int64
+
+	// TenantKVAddrs are the entry points to the KV layer.
+	//
+	// Only applies when the SQL server is deployed individually.
+	TenantKVAddrs []string
 }
 
 // MakeSQLConfig returns a SQLConfig with default values.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -616,21 +616,21 @@ func (ts *TestServer) StartTenant(params base.TestTenantArgs) (pgAddr string, _ 
 			ClusterSettingsUpdater: st.MakeUpdater(),
 		}
 	}
-	return startTenant(
+	sqlCfg.TenantKVAddrs = []string{ts.RPCAddr()}
+	return StartTenant(
 		ctx,
 		ts.Stopper(),
 		ts.Cfg.ClusterName,
-		ts.RPCAddr(),
 		baseCfg,
 		sqlCfg,
 	)
 }
 
-func startTenant(
+// StartTenant starts a stand-alone SQL server against a KV backend.
+func StartTenant(
 	ctx context.Context,
 	stopper *stop.Stopper,
 	kvClusterName string, // NB: gone after https://github.com/cockroachdb/cockroach/issues/42519
-	tsRPCAddr string,
 	baseCfg BaseConfig,
 	sqlCfg SQLConfig,
 ) (pgAddr string, _ error) {
@@ -673,13 +673,17 @@ func startTenant(
 	orphanedLeasesTimeThresholdNanos := args.clock.Now().WallTime
 
 	{
-		rsvlr, err := resolver.NewResolver(tsRPCAddr)
-		if err != nil {
-			return "", err
+		rs := make([]resolver.Resolver, len(sqlCfg.TenantKVAddrs))
+		for i := range rs {
+			var err error
+			rs[i], err = resolver.NewResolver(sqlCfg.TenantKVAddrs[i])
+			if err != nil {
+				return "", err
+			}
 		}
 		// NB: gossip server is not bound to any address, so the advertise addr does
 		// not matter.
-		args.gossip.Start(pgL.Addr(), []resolver.Resolver{rsvlr})
+		args.gossip.Start(pgL.Addr(), rs)
 	}
 
 	if err := s.start(ctx,


### PR DESCRIPTION
This adds a CLI command to start a SQL tenant in a standalone process.

The tenant currently communicates with the KV layer "as a node"; this
will only change with #47898. As is, the tenant has full access to the
KV layer and so a few things may work that shouldn't as a result of
that.

Additionally, the tenant runs a Gossip client as a temporary stopgap
until we have removed the remaining dependencies on it (#49693 has
the details on what those are).

Apart from that, though, this is the real thing and can be used to
start setting up end-to-end testing of ORMs as well as the deploy-
ments.

A word on the choice of the `mt` command: `mt` is an abbreviation for
`multi-tenant` which was considered too long; just `tenant` was
considered misleading - there will be multiple additional subcommands
housing the other services required for running the whole infrastructure
including certs generation, the KV auth broker server, and the SQL
proxy. Should a lively bikeshed around naming break out we can rename
the commands later when consensus has been reached.

For those curious to try it out the following will be handy:

```bash
rm -rf ~/.cockroach-certs cockroach-data &&
killall -9 cockroach && \
export COCKROACH_CA_KEY=$HOME/.cockroach-certs/ca.key && \
./cockroach cert create-ca && \
./cockroach cert create-client root && \
./cockroach cert create-node 127.0.0.1 && \
./cockroach start --host 127.0.0.1 --background && \
./cockroach sql --host 127.0.0.1 -e 'select crdb_internal.create_tenant(123);'
./cockroach mt start-sql --tenant-id 123 --kv-addrs 127.0.0.1:26257 --sql-addr :5432 &
sleep 1 && \
./cockroach sql --host 127.0.0.1 --port 5432
```

This roughly matches what the newly introduced `acceptance/multitenant`
roachtest does as well.

cc @nvanbenschoten @asubiotto 

Release note: None