### PR TITLE
cloud: Added support to all ExternalStorage ReadFile methods, to raise a sentinel ErrFileDoesNotExist error

### DIFF
--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -103,8 +103,10 @@ func readBackupManifestFromStore(
 func containsManifest(ctx context.Context, exportStore cloud.ExternalStorage) (bool, error) {
 	r, err := exportStore.ReadFile(ctx, BackupManifestName)
 	if err != nil {
-		//nolint:returnerrcheck
-		return false, nil /* TODO(dt): only silence non-exists errors */
+		if errors.Is(err, cloud.ErrFileDoesNotExist) {
+			return false, nil
+		}
+		return false, err
 	}
 	r.Close()
 	return true, nil
@@ -661,28 +663,30 @@ func VerifyUsableExportTarget(
 	readable string,
 	encryption *roachpb.FileEncryptionOptions,
 ) error {
-	if r, err := exportStore.ReadFile(ctx, BackupManifestName); err == nil {
-		// TODO(dt): If we audit exactly what not-exists error each ExternalStorage
-		// returns (and then wrap/tag them), we could narrow this check.
+	r, err := exportStore.ReadFile(ctx, BackupManifestName)
+	if err == nil {
 		r.Close()
 		return pgerror.Newf(pgcode.FileAlreadyExists,
 			"%s already contains a %s file",
 			readable, BackupManifestName)
 	}
-	if r, err := exportStore.ReadFile(ctx, BackupManifestName); err == nil {
-		// TODO(dt): If we audit exactly what not-exists error each ExternalStorage
-		// returns (and then wrap/tag them), we could narrow this check.
-		r.Close()
-		return pgerror.Newf(pgcode.FileAlreadyExists,
-			"%s already contains a %s file",
-			readable, BackupManifestName)
+
+	if !errors.Is(err, cloud.ErrFileDoesNotExist) {
+		return errors.Wrapf(err, "%s returned an unexpected error when checking for the existence of %s file", readable, BackupManifestName)
 	}
-	if r, err := exportStore.ReadFile(ctx, BackupManifestCheckpointName); err == nil {
+
+	r, err = exportStore.ReadFile(ctx, BackupManifestCheckpointName)
+	if err == nil {
 		r.Close()
 		return pgerror.Newf(pgcode.FileAlreadyExists,
 			"%s already contains a %s file (is another operation already in progress?)",
 			readable, BackupManifestCheckpointName)
 	}
+
+	if !errors.Is(err, cloud.ErrFileDoesNotExist) {
+		return errors.Wrapf(err, "%s returned an unexpected error when checking for the existence of %s file", readable, BackupManifestCheckpointName)
+	}
+
 	if err := writeBackupManifest(
 		ctx, settings, exportStore, BackupManifestCheckpointName, encryption, &BackupManifest{},
 	); err != nil {

--- a/pkg/storage/cloud/external_storage.go
+++ b/pkg/storage/cloud/external_storage.go
@@ -88,6 +88,11 @@ var redactedQueryParams = map[string]struct{}{
 // ErrListingUnsupported is a marker for indicating listing is unsupported.
 var ErrListingUnsupported = errors.New("listing is not supported")
 
+// ErrFileDoesNotExist is a sentinel error for indicating that a specified
+// bucket/object/key/file (depending on storage terminology) does not exist.
+// This error is raised by the ReadFile method.
+var ErrFileDoesNotExist = errors.New("external_storage: file doesn't exist")
+
 // ExternalStorageFactory describes a factory function for ExternalStorage.
 type ExternalStorageFactory func(ctx context.Context, dest roachpb.ExternalStorage) (ExternalStorage, error)
 
@@ -113,6 +118,8 @@ type ExternalStorage interface {
 	Conf() roachpb.ExternalStorage
 
 	// ReadFile should return a Reader for requested name.
+	// ErrFileDoesNotExist is raised if `basename` cannot be located in storage.
+	// This can be leveraged for an existence check.
 	ReadFile(ctx context.Context, basename string) (io.ReadCloser, error)
 
 	// WriteFile should write the content to requested name.

--- a/pkg/storage/cloud/gcs_storage_test.go
+++ b/pkg/storage/cloud/gcs_storage_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -76,7 +77,7 @@ func (c *antagonisticConn) Read(b []byte) (int, error) {
 func TestAntagonisticRead(t *testing.T) {
 	if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") == "" {
 		// This test requires valid GS credential file.
-		return
+		t.Skip("GOOGLE_APPLICATION_CREDENTIALS env var must be set")
 	}
 
 	rnd, _ := randutil.NewPseudoRand()
@@ -109,4 +110,42 @@ func TestAntagonisticRead(t *testing.T) {
 	defer stream.Close()
 	_, err = ioutil.ReadAll(stream)
 	require.NoError(t, err)
+}
+
+// TestFileDoesNotExist ensures that the ReadFile method of google cloud storage
+// returns a sentinel error when the `Bucket` or `Object` being read do not
+// exist.
+func TestFileDoesNotExist(t *testing.T) {
+	if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") == "" {
+		// This test requires valid GS credential file.
+		t.Skip("GOOGLE_APPLICATION_CREDENTIALS env var must be set")
+	}
+
+	{
+		// Invalid gsFile.
+		gsFile := "gs://cockroach-fixtures/tpch-csv/sf-1/invalid_region.tbl?AUTH=implicit"
+		conf, err := ExternalStorageConfFromURI(gsFile)
+		require.NoError(t, err)
+
+		s, err := MakeExternalStorage(
+			context.Background(), conf, base.ExternalIODirConfig{}, testSettings, nil)
+		require.NoError(t, err)
+		_, err = s.ReadFile(context.Background(), "")
+		require.Error(t, err, "")
+		require.True(t, errors.Is(err, ErrFileDoesNotExist))
+	}
+
+	{
+		// Invalid gsBucket.
+		gsFile := "gs://cockroach-fixtures-invalid/tpch-csv/sf-1/region.tbl?AUTH=implicit"
+		conf, err := ExternalStorageConfFromURI(gsFile)
+		require.NoError(t, err)
+
+		s, err := MakeExternalStorage(
+			context.Background(), conf, base.ExternalIODirConfig{}, testSettings, nil)
+		require.NoError(t, err)
+		_, err = s.ReadFile(context.Background(), "")
+		require.Error(t, err, "")
+		require.True(t, errors.Is(err, ErrFileDoesNotExist))
+	}
 }

--- a/pkg/storage/cloud/http_storage.go
+++ b/pkg/storage/cloud/http_storage.go
@@ -346,11 +346,15 @@ func (h *httpStorage) req(
 
 	switch resp.StatusCode {
 	case 200, 201, 204, 206:
-		// Pass.
+	// Pass.
 	default:
 		body, _ := ioutil.ReadAll(resp.Body)
 		_ = resp.Body.Close()
-		return nil, errors.Errorf("error response from server: %s %q", resp.Status, body)
+		err := errors.Errorf("error response from server: %s %q", resp.Status, body)
+		if err != nil && resp.StatusCode == 404 {
+			err = errors.Wrapf(ErrFileDoesNotExist, "http storage file does not exist: %s", err.Error())
+		}
+		return nil, err
 	}
 	return resp, nil
 }

--- a/pkg/storage/cloud/http_storage_test.go
+++ b/pkg/storage/cloud/http_storage_test.go
@@ -110,7 +110,7 @@ func TestPutHttp(t *testing.T) {
 		srv, files, cleanup := makeServer()
 		defer cleanup()
 		testExportStore(t, srv.String(), false)
-		if expected, actual := 13, files(); expected != actual {
+		if expected, actual := 14, files(); expected != actual {
 			t.Fatalf("expected %d files to be written to single http store, got %d", expected, actual)
 		}
 	})

--- a/pkg/storage/cloud/s3_storage.go
+++ b/pkg/storage/cloud/s3_storage.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
@@ -171,6 +172,13 @@ func (s *s3Storage) ReadFile(ctx context.Context, basename string) (io.ReadClose
 		Key:    aws.String(path.Join(s.prefix, basename)),
 	})
 	if err != nil {
+		if aerr := (awserr.Error)(nil); errors.As(err, &aerr) {
+			switch aerr.Code() {
+			// Relevant 404 errors reported by AWS.
+			case s3.ErrCodeNoSuchBucket, s3.ErrCodeNoSuchKey:
+				return nil, errors.Wrapf(ErrFileDoesNotExist, "s3 object does not exist: %s", err.Error())
+			}
+		}
 		return nil, errors.Wrap(err, "failed to get s3 object")
 	}
 	return out.Body, nil

--- a/pkg/storage/cloud/s3_storage_test.go
+++ b/pkg/storage/cloud/s3_storage_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -151,4 +152,57 @@ func TestS3DisallowImplicitCredentials(t *testing.T) {
 	require.Nil(t, s3)
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "implicit"))
+}
+
+// S3 has two "does not exist" errors - ErrCodeNoSuchBucket and ErrCodeNoSuchKey.
+// ErrCodeNoSuchKey is tested via the general test in external_storage_test.go.
+// This test attempts to ReadFile from a bucket which does not exist.
+func TestS3BucketDoesNotExist(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	q := make(url.Values)
+	expect := map[string]string{
+		"AWS_S3_ENDPOINT":        S3EndpointParam,
+		"AWS_S3_ENDPOINT_KEY":    S3AccessKeyParam,
+		"AWS_S3_ENDPOINT_REGION": S3RegionParam,
+		"AWS_S3_ENDPOINT_SECRET": S3SecretParam,
+	}
+	for env, param := range expect {
+		v := os.Getenv(env)
+		if v == "" {
+			t.Skipf("%s env var must be set", env)
+		}
+		q.Add(param, v)
+	}
+
+	bucket := "invalid-bucket"
+	u := url.URL{
+		Scheme:   "s3",
+		Host:     bucket,
+		Path:     "backup-test",
+		RawQuery: q.Encode(),
+	}
+
+	ctx := context.Background()
+
+	conf, err := ExternalStorageConfFromURI(u.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup a sink for the given args.
+	clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
+	s, err := MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, testSettings, clientFactory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	if readConf := s.Conf(); readConf != conf {
+		t.Fatalf("conf does not roundtrip: started with %+v, got back %+v", conf, readConf)
+	}
+
+	_, err = s.ReadFile(ctx, "")
+	require.Error(t, err, "")
+	require.True(t, errors.Is(err, ErrFileDoesNotExist))
 }


### PR DESCRIPTION
The `ReadFile` interface method is responsible for returning a `Reader`
which can be used to stream data from an external storage source.
There are also instances where we use this method to solely check for
the existence (or absence) of a particular file/object, by attempting
to open a stream. eg: checking for BackupManifest/BackupManifestCheckpoint
before exporting data. Previously, we would treat any error returned
by the storage vendor API as a signal for the file/object not existing.

This change adds logic to catch the native "file does not exist"
errors for each storage provider, and throw a sentinel error to users
of the `ReadFile` method. This allows for more careful error handling.

Relevant unit tests have also been added.

Release note: None