### PR TITLE
sql: use nicer apd.Decimal.SetInt64 in the code base

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -437,8 +437,8 @@ func (c intCustomizer) getBinOpAssignFunc() assignFunc {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
 				}
 				leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
-				leftTmpDec.SetFinite(int64({{.Left}}), 0)
-				rightTmpDec.SetFinite(int64({{.Right}}), 0)
+				leftTmpDec.SetInt64(int64({{.Left}}))
+				rightTmpDec.SetInt64(int64({{.Right}}))
 				if _, err := tree.{{.Ctx}}.Quo(&{{.Target}}, leftTmpDec, rightTmpDec); err != nil {
 					colexecerror.ExpectedError(err)
 				}
@@ -487,7 +487,7 @@ func (c decimalIntCustomizer) getBinOpAssignFunc() assignFunc {
 				}
 				{{end}}
 				tmpDec := &_overloadHelper.tmpDec1
-				tmpDec.SetFinite(int64({{.Right}}), 0)
+				tmpDec.SetInt64(int64({{.Right}}))
 				if _, err := tree.{{.Ctx}}.{{.Op}}(&{{.Target}}, &{{.Left}}, tmpDec); err != nil {
 					colexecerror.ExpectedError(err)
 				}
@@ -520,7 +520,7 @@ func (c intDecimalCustomizer) getBinOpAssignFunc() assignFunc {
 				}
 				{{end}}
 				tmpDec := &_overloadHelper.tmpDec1
-				tmpDec.SetFinite(int64({{.Left}}), 0)
+				tmpDec.SetInt64(int64({{.Left}}))
 				_, err := tree.{{.Ctx}}.{{.Op}}(&{{.Target}}, tmpDec, &{{.Right}})
 				if err != nil {
 					colexecerror.ExpectedError(err)

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_cmp.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_cmp.go
@@ -242,7 +242,7 @@ func (c decimalIntCustomizer) getCmpOpCompareFunc() compareFunc {
 		t := template.Must(template.New("").Parse(`
 			{
 				tmpDec := &_overloadHelper.tmpDec1
-				tmpDec.SetFinite(int64({{.Right}}), 0)
+				tmpDec.SetInt64(int64({{.Right}}))
 				{{.Target}} = tree.CompareDecimals(&{{.Left}}, tmpDec)
 			}
 		`))
@@ -280,7 +280,7 @@ func (c intDecimalCustomizer) getCmpOpCompareFunc() compareFunc {
 		t := template.Must(template.New("").Parse(`
 			{
 				tmpDec := &_overloadHelper.tmpDec1
-				tmpDec.SetFinite(int64({{.Left}}), 0)
+				tmpDec.SetInt64(int64({{.Left}}))
 				{{.Target}} = tree.CompareDecimals(tmpDec, &{{.Right}})
 			}
 		`))

--- a/pkg/sql/colexec/overloads_test.go
+++ b/pkg/sql/colexec/overloads_test.go
@@ -68,11 +68,11 @@ func TestIntegerDivision(t *testing.T) {
 	var res apd.Decimal
 
 	res = performDivInt16Int16(math.MinInt16, -1)
-	require.Equal(t, 0, res.Cmp(d.SetFinite(-math.MinInt16, 0)))
+	require.Equal(t, 0, res.Cmp(d.SetInt64(-math.MinInt16)))
 	res = performDivInt32Int32(math.MinInt32, -1)
-	require.Equal(t, 0, res.Cmp(d.SetFinite(-math.MinInt32, 0)))
+	require.Equal(t, 0, res.Cmp(d.SetInt64(-math.MinInt32)))
 	res = performDivInt64Int64(math.MinInt64, -1)
-	d.SetFinite(math.MinInt64, 0)
+	d.SetInt64(math.MinInt64)
 	if _, err := tree.DecimalCtx.Neg(d, d); err != nil {
 		t.Error(err)
 	}
@@ -83,11 +83,11 @@ func TestIntegerDivision(t *testing.T) {
 	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performDivInt64Int64(10, 0) }), tree.ErrDivByZero))
 
 	res = performDivInt16Int16(math.MaxInt16, -1)
-	require.Equal(t, 0, res.Cmp(d.SetFinite(-math.MaxInt16, 0)))
+	require.Equal(t, 0, res.Cmp(d.SetInt64(-math.MaxInt16)))
 	res = performDivInt32Int32(math.MaxInt32, -1)
-	require.Equal(t, 0, res.Cmp(d.SetFinite(-math.MaxInt32, 0)))
+	require.Equal(t, 0, res.Cmp(d.SetInt64(-math.MaxInt32)))
 	res = performDivInt64Int64(math.MaxInt64, -1)
-	require.Equal(t, 0, res.Cmp(d.SetFinite(-math.MaxInt64, 0)))
+	require.Equal(t, 0, res.Cmp(d.SetInt64(-math.MaxInt64)))
 }
 
 func TestIntegerMultiplication(t *testing.T) {
@@ -145,20 +145,20 @@ func TestMixedTypeInteger(t *testing.T) {
 	var res apd.Decimal
 
 	res = performDivInt16Int32(4, 2)
-	require.Equal(t, 0, res.Cmp(d.SetFinite(2, 0)))
+	require.Equal(t, 0, res.Cmp(d.SetInt64(2)))
 	res = performDivInt16Int64(6, 2)
-	require.Equal(t, 0, res.Cmp(d.SetFinite(3, 0)))
+	require.Equal(t, 0, res.Cmp(d.SetInt64(3)))
 	res = performDivInt64Int32(12, 3)
-	require.Equal(t, 0, res.Cmp(d.SetFinite(4, 0)))
+	require.Equal(t, 0, res.Cmp(d.SetInt64(4)))
 	res = performDivInt64Int16(20, 4)
-	require.Equal(t, 0, res.Cmp(d.SetFinite(5, 0)))
+	require.Equal(t, 0, res.Cmp(d.SetInt64(5)))
 }
 
 func TestDecimalDivByZero(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	nonZeroDec, zeroDec := apd.Decimal{}, apd.Decimal{}
-	nonZeroDec.SetFinite(4, 0)
-	zeroDec.SetFinite(0, 0)
+	nonZeroDec.SetInt64(4)
+	zeroDec.SetInt64(0)
 
 	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performDivDecimalInt16(nonZeroDec, 0) }), tree.ErrDivByZero))
 	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performDivDecimalInt32(nonZeroDec, 0) }), tree.ErrDivByZero))

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -1717,12 +1717,12 @@ func (a *intSumAggregate) Add(ctx context.Context, datum tree.Datum, _ ...tree.D
 				// And overflow was detected; go to large integers, but keep the
 				// sum computed so far.
 				a.large = true
-				a.decSum.SetFinite(a.intSum, 0)
+				a.decSum.SetInt64(a.intSum)
 			}
 		}
 
 		if a.large {
-			a.tmpDec.SetFinite(t, 0)
+			a.tmpDec.SetInt64(t)
 			_, err := tree.ExactCtx.Add(&a.decSum, &a.decSum, &a.tmpDec)
 			if err != nil {
 				return err
@@ -1745,7 +1745,7 @@ func (a *intSumAggregate) Result() (tree.Datum, error) {
 	if a.large {
 		dd.Set(&a.decSum)
 	} else {
-		dd.SetFinite(a.intSum, 0)
+		dd.SetInt64(a.intSum)
 	}
 	return dd, nil
 }
@@ -1815,7 +1815,7 @@ func (a *decimalSumAggregate) Result() (tree.Datum, error) {
 
 // Reset implements tree.AggregateFunc interface.
 func (a *decimalSumAggregate) Reset(ctx context.Context) {
-	a.sum.SetFinite(0, 0)
+	a.sum.SetInt64(0)
 	a.sawNonNull = false
 	a.reset(ctx)
 }
@@ -1951,7 +1951,7 @@ func (a *intSqrDiffAggregate) Add(ctx context.Context, datum tree.Datum, _ ...tr
 		return nil
 	}
 
-	a.tmpDec.SetFinite(int64(tree.MustBeDInt(datum)), 0)
+	a.tmpDec.SetInt64(int64(tree.MustBeDInt(datum)))
 	return a.agg.Add(ctx, &a.tmpDec)
 }
 
@@ -2121,9 +2121,9 @@ func (a *decimalSqrDiffAggregate) Result() (tree.Datum, error) {
 
 // Reset implements tree.AggregateFunc interface.
 func (a *decimalSqrDiffAggregate) Reset(ctx context.Context) {
-	a.count.SetFinite(0, 0)
-	a.mean.SetFinite(0, 0)
-	a.sqrDiff.SetFinite(0, 0)
+	a.count.SetInt64(0)
+	a.mean.SetInt64(0)
+	a.sqrDiff.SetInt64(0)
 	a.reset(ctx)
 }
 
@@ -2317,9 +2317,9 @@ func (a *decimalSumSqrDiffsAggregate) Result() (tree.Datum, error) {
 
 // Reset implements tree.AggregateFunc interface.
 func (a *decimalSumSqrDiffsAggregate) Reset(ctx context.Context) {
-	a.count.SetFinite(0, 0)
-	a.mean.SetFinite(0, 0)
-	a.sqrDiff.SetFinite(0, 0)
+	a.count.SetInt64(0)
+	a.mean.SetInt64(0)
+	a.sqrDiff.SetInt64(0)
 	a.reset(ctx)
 }
 

--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -463,7 +463,7 @@ var mathBuiltins = map[string]builtinDefinition{
 			"negative.", tree.VolatilityImmutable),
 		decimalOverload1(func(x *apd.Decimal) (tree.Datum, error) {
 			d := &tree.DDecimal{}
-			d.Decimal.SetFinite(int64(x.Sign()), 0)
+			d.Decimal.SetInt64(int64(x.Sign()))
 			return d, nil
 		}, "Determines the sign of `val`: **1** for positive; **0** for 0 values; **-1** for "+
 			"negative.", tree.VolatilityImmutable),

--- a/pkg/sql/sem/builtins/window_frame_builtins.go
+++ b/pkg/sql/sem/builtins/window_frame_builtins.go
@@ -403,7 +403,7 @@ func (w *avgWindowFunc) Compute(
 		return &avg, err
 	case *tree.DInt:
 		dd := tree.DDecimal{}
-		dd.SetFinite(int64(*t), 0)
+		dd.SetInt64(int64(*t))
 		var avg tree.DDecimal
 		count := apd.New(int64(frameSize), 0)
 		_, err := tree.DecimalCtx.Quo(&avg.Decimal, &dd.Decimal, count)

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -510,16 +510,16 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 		switch v := d.(type) {
 		case *DBool:
 			if *v {
-				dd.SetFinite(1, 0)
+				dd.SetInt64(1)
 			}
 		case *DInt:
-			dd.SetFinite(int64(*v), 0)
+			dd.SetInt64(int64(*v))
 		case *DDate:
 			// TODO(mjibson): This cast is unsupported by postgres. Should we remove ours?
 			if !v.IsFinite() {
 				return nil, errDecOutOfRange
 			}
-			dd.SetFinite(v.UnixEpochDays(), 0)
+			dd.SetInt64(v.UnixEpochDays())
 		case *DFloat:
 			_, err = dd.SetFloat64(float64(*v))
 		case *DDecimal:

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -971,7 +971,7 @@ func (d *DDecimal) Compare(ctx *EvalContext, other Datum) int {
 	case *DDecimal:
 		v = &t.Decimal
 	case *DInt:
-		v.SetFinite(int64(*t), 0)
+		v.SetInt64(int64(*t))
 	case *DFloat:
 		if _, err := v.SetFloat64(float64(*t)); err != nil {
 			panic(errors.NewAssertionErrorWithWrappedErrf(err, "decimal compare, unexpected error"))

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -593,7 +593,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				l := &left.(*DDecimal).Decimal
 				r := MustBeDInt(right)
 				dd := &DDecimal{}
-				dd.SetFinite(int64(r), 0)
+				dd.SetInt64(int64(r))
 				_, err := ExactCtx.Add(&dd.Decimal, l, &dd.Decimal)
 				return dd, err
 			},
@@ -607,7 +607,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				l := MustBeDInt(left)
 				r := &right.(*DDecimal).Decimal
 				dd := &DDecimal{}
-				dd.SetFinite(int64(l), 0)
+				dd.SetInt64(int64(l))
 				_, err := ExactCtx.Add(&dd.Decimal, &dd.Decimal, r)
 				return dd, err
 			},
@@ -888,7 +888,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				l := &left.(*DDecimal).Decimal
 				r := MustBeDInt(right)
 				dd := &DDecimal{}
-				dd.SetFinite(int64(r), 0)
+				dd.SetInt64(int64(r))
 				_, err := ExactCtx.Sub(&dd.Decimal, l, &dd.Decimal)
 				return dd, err
 			},
@@ -902,7 +902,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				l := MustBeDInt(left)
 				r := &right.(*DDecimal).Decimal
 				dd := &DDecimal{}
-				dd.SetFinite(int64(l), 0)
+				dd.SetInt64(int64(l))
 				_, err := ExactCtx.Sub(&dd.Decimal, &dd.Decimal, r)
 				return dd, err
 			},
@@ -1213,7 +1213,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				l := &left.(*DDecimal).Decimal
 				r := MustBeDInt(right)
 				dd := &DDecimal{}
-				dd.SetFinite(int64(r), 0)
+				dd.SetInt64(int64(r))
 				_, err := ExactCtx.Mul(&dd.Decimal, l, &dd.Decimal)
 				return dd, err
 			},
@@ -1227,7 +1227,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				l := MustBeDInt(left)
 				r := &right.(*DDecimal).Decimal
 				dd := &DDecimal{}
-				dd.SetFinite(int64(l), 0)
+				dd.SetInt64(int64(l))
 				_, err := ExactCtx.Mul(&dd.Decimal, &dd.Decimal, r)
 				return dd, err
 			},
@@ -1311,9 +1311,9 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				if rInt == 0 {
 					return nil, ErrDivByZero
 				}
-				div := ctx.getTmpDec().SetFinite(int64(rInt), 0)
+				div := ctx.getTmpDec().SetInt64(int64(rInt))
 				dd := &DDecimal{}
-				dd.SetFinite(int64(MustBeDInt(left)), 0)
+				dd.SetInt64(int64(MustBeDInt(left)))
 				_, err := DecimalCtx.Quo(&dd.Decimal, &dd.Decimal, div)
 				return dd, err
 			},
@@ -1359,7 +1359,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 					return nil, ErrDivByZero
 				}
 				dd := &DDecimal{}
-				dd.SetFinite(int64(r), 0)
+				dd.SetInt64(int64(r))
 				_, err := DecimalCtx.Quo(&dd.Decimal, l, &dd.Decimal)
 				return dd, err
 			},
@@ -1376,7 +1376,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 					return nil, ErrDivByZero
 				}
 				dd := &DDecimal{}
-				dd.SetFinite(int64(l), 0)
+				dd.SetInt64(int64(l))
 				_, err := DecimalCtx.Quo(&dd.Decimal, &dd.Decimal, r)
 				return dd, err
 			},
@@ -1465,7 +1465,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 					return nil, ErrDivByZero
 				}
 				dd := &DDecimal{}
-				dd.SetFinite(int64(r), 0)
+				dd.SetInt64(int64(r))
 				_, err := HighPrecisionCtx.QuoInteger(&dd.Decimal, l, &dd.Decimal)
 				return dd, err
 			},
@@ -1482,7 +1482,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 					return nil, ErrDivByZero
 				}
 				dd := &DDecimal{}
-				dd.SetFinite(int64(l), 0)
+				dd.SetInt64(int64(l))
 				_, err := HighPrecisionCtx.QuoInteger(&dd.Decimal, &dd.Decimal, r)
 				return dd, err
 			},
@@ -1545,7 +1545,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 					return nil, ErrDivByZero
 				}
 				dd := &DDecimal{}
-				dd.SetFinite(int64(r), 0)
+				dd.SetInt64(int64(r))
 				_, err := HighPrecisionCtx.Rem(&dd.Decimal, l, &dd.Decimal)
 				return dd, err
 			},
@@ -1562,7 +1562,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 					return nil, ErrDivByZero
 				}
 				dd := &DDecimal{}
-				dd.SetFinite(int64(l), 0)
+				dd.SetInt64(int64(l))
 				_, err := HighPrecisionCtx.Rem(&dd.Decimal, &dd.Decimal, r)
 				return dd, err
 			},
@@ -1741,7 +1741,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				l := &left.(*DDecimal).Decimal
 				r := MustBeDInt(right)
 				dd := &DDecimal{}
-				dd.SetFinite(int64(r), 0)
+				dd.SetInt64(int64(r))
 				_, err := DecimalCtx.Pow(&dd.Decimal, l, &dd.Decimal)
 				return dd, err
 			},
@@ -1755,7 +1755,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				l := MustBeDInt(left)
 				r := &right.(*DDecimal).Decimal
 				dd := &DDecimal{}
-				dd.SetFinite(int64(l), 0)
+				dd.SetInt64(int64(l))
 				_, err := DecimalCtx.Pow(&dd.Decimal, &dd.Decimal, r)
 				return dd, err
 			},

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -968,7 +968,7 @@ func ContainsVars(expr Expr) bool {
 var DecimalOne DDecimal
 
 func init() {
-	DecimalOne.SetFinite(1, 0)
+	DecimalOne.SetInt64(1)
 }
 
 // ReType ensures that the given numeric expression evaluates

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -942,14 +942,14 @@ func fromMap(v map[string]interface{}) (JSON, error) {
 // FromInt returns a JSON value given a int.
 func FromInt(v int) JSON {
 	dec := apd.Decimal{}
-	dec.SetFinite(int64(v), 0)
+	dec.SetInt64(int64(v))
 	return jsonNumber(dec)
 }
 
 // FromInt64 returns a JSON value given a int64.
 func FromInt64(v int64) JSON {
 	dec := apd.Decimal{}
-	dec.SetFinite(v, 0)
+	dec.SetInt64(v)
 	return jsonNumber(dec)
 }
 


### PR DESCRIPTION
This commit is automatic replacement of `apd.Decimal.SetFinite((.*), 0)`
into a nicer `apd.Decimal.SetInt64($1)` which are equivalent.

Release note: None