### PR TITLE
opt: incorporate operator volatility

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1140,6 +1140,7 @@ EXECUTE e
 ----
 select
  ├── columns: k:1 str:2
+ ├── immutable
  ├── stats: [rows=333.333333]
  ├── cost: 1050.03
  ├── key: (1)
@@ -1153,7 +1154,7 @@ select
  │    ├── fd: (1)-->(2)
  │    └── prune: (1,2)
  └── filters
-      └── (k:1 % 2) = 1 [outer=(1)]
+      └── (k:1 % 2) = 1 [outer=(1), immutable]
 
 # Only root may use PREPARE AS OPT PLAN.
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -987,6 +987,7 @@ EXPLAIN (OPT, VERBOSE) SELECT * FROM tc WHERE a + 2 * b > 1 ORDER BY a*b
 ----
 sort
  ├── columns: a:1 b:2  [hidden: column4:4]
+ ├── immutable
  ├── stats: [rows=333.333333]
  ├── cost: 1179.25548
  ├── fd: (1,2)-->(4)
@@ -995,6 +996,7 @@ sort
  ├── interesting orderings: (+1)
  └── project
       ├── columns: column4:4 a:1 b:2
+      ├── immutable
       ├── stats: [rows=333.333333]
       ├── cost: 1116.70667
       ├── fd: (1,2)-->(4)
@@ -1002,6 +1004,7 @@ sort
       ├── interesting orderings: (+1)
       ├── select
       │    ├── columns: a:1 b:2
+      │    ├── immutable
       │    ├── stats: [rows=333.333333]
       │    ├── cost: 1110.03
       │    ├── interesting orderings: (+1)
@@ -1012,15 +1015,16 @@ sort
       │    │    ├── prune: (1,2)
       │    │    └── interesting orderings: (+1)
       │    └── filters
-      │         └── (a:1 + (b:2 * 2)) > 1 [outer=(1,2)]
+      │         └── (a:1 + (b:2 * 2)) > 1 [outer=(1,2), immutable]
       └── projections
-           └── a:1 * b:2 [as=column4:4, outer=(1,2)]
+           └── a:1 * b:2 [as=column4:4, outer=(1,2), immutable]
 
 query T
 EXPLAIN (OPT, TYPES) SELECT * FROM tc WHERE a + 2 * b > 1 ORDER BY a*b
 ----
 sort
  ├── columns: a:1(int) b:2(int)  [hidden: column4:4(int)]
+ ├── immutable
  ├── stats: [rows=333.333333]
  ├── cost: 1179.25548
  ├── fd: (1,2)-->(4)
@@ -1029,6 +1033,7 @@ sort
  ├── interesting orderings: (+1)
  └── project
       ├── columns: column4:4(int) a:1(int) b:2(int)
+      ├── immutable
       ├── stats: [rows=333.333333]
       ├── cost: 1116.70667
       ├── fd: (1,2)-->(4)
@@ -1036,6 +1041,7 @@ sort
       ├── interesting orderings: (+1)
       ├── select
       │    ├── columns: a:1(int) b:2(int)
+      │    ├── immutable
       │    ├── stats: [rows=333.333333]
       │    ├── cost: 1110.03
       │    ├── interesting orderings: (+1)
@@ -1046,7 +1052,7 @@ sort
       │    │    ├── prune: (1,2)
       │    │    └── interesting orderings: (+1)
       │    └── filters
-      │         └── gt [type=bool, outer=(1,2)]
+      │         └── gt [type=bool, outer=(1,2), immutable]
       │              ├── plus [type=int]
       │              │    ├── variable: a:1 [type=int]
       │              │    └── mult [type=int]
@@ -1054,7 +1060,7 @@ sort
       │              │         └── const: 2 [type=int]
       │              └── const: 1 [type=int]
       └── projections
-           └── mult [as=column4:4, type=int, outer=(1,2)]
+           └── mult [as=column4:4, type=int, outer=(1,2), immutable]
                 ├── variable: a:1 [type=int]
                 └── variable: b:2 [type=int]
 

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1372,6 +1372,9 @@ func BuildSharedProps(e opt.Expr, shared *props.Shared) {
 	case *DivExpr:
 		// Division by zero error is possible, unless the right-hand side is a
 		// non-zero constant.
+		//
+		// TODO(radu): this case should be removed (Div should be covered by the
+		// binary operator logic below).
 		var nonZero bool
 		if c, ok := t.Right.(*ConstExpr); ok {
 			switch v := c.Value.(type) {
@@ -1413,7 +1416,34 @@ func BuildSharedProps(e opt.Expr, shared *props.Shared) {
 		shared.VolatilitySet.Add(volatility)
 
 	default:
-		if opt.IsMutationOp(e) {
+		if opt.IsUnaryOp(e) {
+			inputType := e.Child(0).(opt.ScalarExpr).DataType()
+			o, ok := FindUnaryOverload(e.Op(), inputType)
+			if !ok {
+				panic(errors.AssertionFailedf("unary overload not found (%s, %s)", e.Op(), inputType))
+			}
+			shared.VolatilitySet.Add(o.Volatility)
+		} else if opt.IsComparisonOp(e) {
+			leftType := e.Child(0).(opt.ScalarExpr).DataType()
+			rightType := e.Child(1).(opt.ScalarExpr).DataType()
+			o, _, _, ok := FindComparisonOverload(e.Op(), leftType, rightType)
+			if !ok {
+				panic(errors.AssertionFailedf(
+					"comparison overload not found (%s, %s, %s)", e.Op(), leftType, rightType,
+				))
+			}
+			shared.VolatilitySet.Add(o.Volatility)
+		} else if opt.IsBinaryOp(e) {
+			leftType := e.Child(0).(opt.ScalarExpr).DataType()
+			rightType := e.Child(1).(opt.ScalarExpr).DataType()
+			o, ok := FindBinaryOverload(e.Op(), leftType, rightType)
+			if !ok {
+				panic(errors.AssertionFailedf(
+					"binary overload not found (%s, %s, %s)", e.Op(), leftType, rightType,
+				))
+			}
+			shared.VolatilitySet.Add(o.Volatility)
+		} else if opt.IsMutationOp(e) {
 			shared.CanHaveSideEffects = true
 			shared.CanMutate = true
 			shared.VolatilitySet.AddVolatile()

--- a/pkg/sql/opt/memo/testdata/format
+++ b/pkg/sql/opt/memo/testdata/format
@@ -7,6 +7,7 @@ SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a
 ----
 sort
  ├── columns: "?column?":5(int) min:4(int!null)  [hidden: t.public.t.a:1(int)]
+ ├── immutable
  ├── stats: [rows=98.1771622]
  ├── cost: 1097.87224
  ├── key: (1)
@@ -15,6 +16,7 @@ sort
  ├── prune: (1,4,5)
  └── project
       ├── columns: "?column?":5(int) t.public.t.a:1(int) min:4(int!null)
+      ├── immutable
       ├── stats: [rows=98.1771622]
       ├── cost: 1082.90531
       ├── key: (1)
@@ -23,6 +25,7 @@ sort
       ├── group-by
       │    ├── columns: t.public.t.a:1(int) min:4(int!null)
       │    ├── grouping columns: t.public.t.a:1(int)
+      │    ├── immutable
       │    ├── stats: [rows=98.1771622, distinct(1)=98.1771622, null(1)=1]
       │    ├── cost: 1080.93177
       │    ├── key: (1)
@@ -30,6 +33,7 @@ sort
       │    ├── prune: (4)
       │    ├── select
       │    │    ├── columns: t.public.t.a:1(int) t.public.t.b:2(int!null) t.public.t.k:3(int!null)
+      │    │    ├── immutable
       │    │    ├── stats: [rows=330, distinct(1)=98.1771622, null(1)=3.3, distinct(2)=100, null(2)=0]
       │    │    ├── cost: 1070.03
       │    │    ├── key: (3)
@@ -44,7 +48,7 @@ sort
       │    │    │    ├── prune: (1-3)
       │    │    │    └── interesting orderings: (+3)
       │    │    └── filters
-      │    │         └── lt [type=bool, outer=(1-3), constraints=(/2: (/NULL - ])]
+      │    │         └── lt [type=bool, outer=(1-3), immutable, constraints=(/2: (/NULL - ])]
       │    │              ├── variable: t.public.t.b:2 [type=int]
       │    │              └── plus [type=int]
       │    │                   ├── variable: t.public.t.k:3 [type=int]
@@ -53,7 +57,7 @@ sort
       │         └── min [as=min:4, type=int, outer=(2)]
       │              └── variable: t.public.t.b:2 [type=int]
       └── projections
-           └── plus [as="?column?":5, type=int, outer=(1)]
+           └── plus [as="?column?":5, type=int, outer=(1), immutable]
                 ├── variable: t.public.t.a:1 [type=int]
                 └── const: 1 [type=int]
 
@@ -101,23 +105,27 @@ SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a
 ----
 sort
  ├── columns: "?column?":5(int) min:4(int!null)  [hidden: a:1(int)]
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(4,5)
  ├── ordering: +1
  ├── prune: (1,4,5)
  └── project
       ├── columns: "?column?":5(int) a:1(int) min:4(int!null)
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(4,5)
       ├── prune: (1,4,5)
       ├── group-by
       │    ├── columns: a:1(int) min:4(int!null)
       │    ├── grouping columns: a:1(int)
+      │    ├── immutable
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
       │    ├── prune: (4)
       │    ├── select
       │    │    ├── columns: a:1(int) b:2(int!null) k:3(int!null)
+      │    │    ├── immutable
       │    │    ├── key: (3)
       │    │    ├── fd: (3)-->(1,2)
       │    │    ├── interesting orderings: (+3)
@@ -128,35 +136,39 @@ sort
       │    │    │    ├── prune: (1-3)
       │    │    │    └── interesting orderings: (+3)
       │    │    └── filters
-      │    │         └── b:2 < (k:3 + a:1) [type=bool, outer=(1-3), constraints=(/2: (/NULL - ])]
+      │    │         └── b:2 < (k:3 + a:1) [type=bool, outer=(1-3), immutable, constraints=(/2: (/NULL - ])]
       │    └── aggregations
       │         └── min [as=min:4, type=int, outer=(2)]
       │              └── b:2 [type=int]
       └── projections
-           └── a:1 + 1 [as="?column?":5, type=int, outer=(1)]
+           └── a:1 + 1 [as="?column?":5, type=int, outer=(1), immutable]
 
 opt format=(hide-stats,hide-cost,hide-qual,hide-scalars,hide-types)
 SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a
 ----
 sort
  ├── columns: "?column?":5 min:4!null  [hidden: a:1]
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(4,5)
  ├── ordering: +1
  ├── prune: (1,4,5)
  └── project
       ├── columns: "?column?":5 a:1 min:4!null
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(4,5)
       ├── prune: (1,4,5)
       ├── group-by
       │    ├── columns: a:1 min:4!null
       │    ├── grouping columns: a:1
+      │    ├── immutable
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
       │    ├── prune: (4)
       │    ├── select
       │    │    ├── columns: a:1 b:2!null k:3!null
+      │    │    ├── immutable
       │    │    ├── key: (3)
       │    │    ├── fd: (3)-->(1,2)
       │    │    ├── interesting orderings: (+3)
@@ -167,35 +179,39 @@ sort
       │    │    │    ├── prune: (1-3)
       │    │    │    └── interesting orderings: (+3)
       │    │    └── filters
-      │    │         └── b:2 < (k:3 + a:1) [outer=(1-3), constraints=(/2: (/NULL - ])]
+      │    │         └── b:2 < (k:3 + a:1) [outer=(1-3), immutable, constraints=(/2: (/NULL - ])]
       │    └── aggregations
       │         └── min [as=min:4, outer=(2)]
       │              └── b:2
       └── projections
-           └── a:1 + 1 [as="?column?":5, outer=(1)]
+           └── a:1 + 1 [as="?column?":5, outer=(1), immutable]
 
 opt format=(hide-stats,hide-cost,hide-qual,hide-scalars,hide-notnull)
 SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a
 ----
 sort
  ├── columns: "?column?":5(int) min:4(int)  [hidden: a:1(int)]
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(4,5)
  ├── ordering: +1
  ├── prune: (1,4,5)
  └── project
       ├── columns: "?column?":5(int) a:1(int) min:4(int)
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(4,5)
       ├── prune: (1,4,5)
       ├── group-by
       │    ├── columns: a:1(int) min:4(int)
       │    ├── grouping columns: a:1(int)
+      │    ├── immutable
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
       │    ├── prune: (4)
       │    ├── select
       │    │    ├── columns: a:1(int) b:2(int) k:3(int)
+      │    │    ├── immutable
       │    │    ├── key: (3)
       │    │    ├── fd: (3)-->(1,2)
       │    │    ├── interesting orderings: (+3)
@@ -206,35 +222,39 @@ sort
       │    │    │    ├── prune: (1-3)
       │    │    │    └── interesting orderings: (+3)
       │    │    └── filters
-      │    │         └── b:2 < (k:3 + a:1) [type=bool, outer=(1-3), constraints=(/2: (/NULL - ])]
+      │    │         └── b:2 < (k:3 + a:1) [type=bool, outer=(1-3), immutable, constraints=(/2: (/NULL - ])]
       │    └── aggregations
       │         └── min [as=min:4, type=int, outer=(2)]
       │              └── b:2 [type=int]
       └── projections
-           └── a:1 + 1 [as="?column?":5, type=int, outer=(1)]
+           └── a:1 + 1 [as="?column?":5, type=int, outer=(1), immutable]
 
 opt format=(hide-stats,hide-cost,hide-qual,hide-scalars,hide-types,hide-notnull)
 SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a
 ----
 sort
  ├── columns: "?column?":5 min:4  [hidden: a:1]
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(4,5)
  ├── ordering: +1
  ├── prune: (1,4,5)
  └── project
       ├── columns: "?column?":5 a:1 min:4
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(4,5)
       ├── prune: (1,4,5)
       ├── group-by
       │    ├── columns: a:1 min:4
       │    ├── grouping columns: a:1
+      │    ├── immutable
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
       │    ├── prune: (4)
       │    ├── select
       │    │    ├── columns: a:1 b:2 k:3
+      │    │    ├── immutable
       │    │    ├── key: (3)
       │    │    ├── fd: (3)-->(1,2)
       │    │    ├── interesting orderings: (+3)
@@ -245,12 +265,12 @@ sort
       │    │    │    ├── prune: (1-3)
       │    │    │    └── interesting orderings: (+3)
       │    │    └── filters
-      │    │         └── b:2 < (k:3 + a:1) [outer=(1-3), constraints=(/2: (/NULL - ])]
+      │    │         └── b:2 < (k:3 + a:1) [outer=(1-3), immutable, constraints=(/2: (/NULL - ])]
       │    └── aggregations
       │         └── min [as=min:4, outer=(2)]
       │              └── b:2
       └── projections
-           └── a:1 + 1 [as="?column?":5, outer=(1)]
+           └── a:1 + 1 [as="?column?":5, outer=(1), immutable]
 
 opt format=(hide-miscprops,hide-physprops,hide-columns)
 SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -167,6 +167,7 @@ SELECT * FROM a WHERE x > 1 AND x < 5 AND x + y = 5
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
+ ├── immutable
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── prune: (1,2)
@@ -179,7 +180,7 @@ select
       │         └── lt [type=bool]
       │              ├── variable: x:1 [type=int]
       │              └── const: 5 [type=int]
-      └── eq [type=bool, outer=(1,2)]
+      └── eq [type=bool, outer=(1,2), immutable]
            ├── plus [type=int]
            │    ├── variable: x:1 [type=int]
            │    └── variable: y:2 [type=int]
@@ -190,6 +191,7 @@ SELECT * FROM a WHERE x > 1 AND x + y >= 5 AND x + y <= 7
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
+ ├── immutable
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── prune: (1,2)
@@ -197,12 +199,12 @@ select
       ├── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
       │    ├── variable: x:1 [type=int]
       │    └── const: 1 [type=int]
-      ├── ge [type=bool, outer=(1,2)]
+      ├── ge [type=bool, outer=(1,2), immutable]
       │    ├── plus [type=int]
       │    │    ├── variable: x:1 [type=int]
       │    │    └── variable: y:2 [type=int]
       │    └── const: 5 [type=int]
-      └── le [type=bool, outer=(1,2)]
+      └── le [type=bool, outer=(1,2), immutable]
            ├── plus [type=int]
            │    ├── variable: x:1 [type=int]
            │    └── variable: y:2 [type=int]
@@ -357,11 +359,12 @@ SELECT * FROM a WHERE (x, y) > (1, 2)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
+ ├── immutable
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── prune: (1,2)
  └── filters
-      └── gt [type=bool, outer=(1,2), constraints=(/1/2: [/1/3 - ]; tight)]
+      └── gt [type=bool, outer=(1,2), immutable, constraints=(/1/2: [/1/3 - ]; tight)]
            ├── tuple [type=tuple{int, int}]
            │    ├── variable: x:1 [type=int]
            │    └── variable: y:2 [type=int]
@@ -374,11 +377,12 @@ SELECT * FROM a WHERE (x, y) >= (1, 2)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
+ ├── immutable
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── prune: (1,2)
  └── filters
-      └── ge [type=bool, outer=(1,2), constraints=(/1/2: [/1/2 - ]; tight)]
+      └── ge [type=bool, outer=(1,2), immutable, constraints=(/1/2: [/1/2 - ]; tight)]
            ├── tuple [type=tuple{int, int}]
            │    ├── variable: x:1 [type=int]
            │    └── variable: y:2 [type=int]
@@ -391,11 +395,12 @@ SELECT * FROM a WHERE (x, y) < (1, 2)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
+ ├── immutable
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── prune: (1,2)
  └── filters
-      └── lt [type=bool, outer=(1,2), constraints=(/1/2: (/NULL - /1/1]; tight)]
+      └── lt [type=bool, outer=(1,2), immutable, constraints=(/1/2: (/NULL - /1/1]; tight)]
            ├── tuple [type=tuple{int, int}]
            │    ├── variable: x:1 [type=int]
            │    └── variable: y:2 [type=int]
@@ -408,11 +413,12 @@ SELECT * FROM a WHERE (x, y) <= (1, 2)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
+ ├── immutable
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── prune: (1,2)
  └── filters
-      └── le [type=bool, outer=(1,2), constraints=(/1/2: (/NULL - /1/2]; tight)]
+      └── le [type=bool, outer=(1,2), immutable, constraints=(/1/2: (/NULL - /1/2]; tight)]
            ├── tuple [type=tuple{int, int}]
            │    ├── variable: x:1 [type=int]
            │    └── variable: y:2 [type=int]
@@ -426,11 +432,12 @@ SELECT * FROM a WHERE (x, y) >= (1, 2.5)
 ----
 select
  ├── columns: x:1(int) y:2(int)
+ ├── immutable
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── prune: (1,2)
  └── filters
-      └── ge [type=bool, outer=(1,2)]
+      └── ge [type=bool, outer=(1,2), immutable]
            ├── tuple [type=tuple{int, int}]
            │    ├── variable: x:1 [type=int]
            │    └── variable: y:2 [type=int]
@@ -444,11 +451,12 @@ SELECT * FROM a WHERE (x, y) >= (1, NULL)
 ----
 select
  ├── columns: x:1(int) y:2(int)
+ ├── immutable
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── prune: (1,2)
  └── filters
-      └── ge [type=bool, outer=(1,2)]
+      └── ge [type=bool, outer=(1,2), immutable]
            ├── tuple [type=tuple{int, int}]
            │    ├── variable: x:1 [type=int]
            │    └── variable: y:2 [type=int]
@@ -463,12 +471,13 @@ SELECT * FROM a WHERE (x, 1) >= (1, 2)
 ----
 select
  ├── columns: x:1(int) y:2(int)
+ ├── immutable
  ├── prune: (2)
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── prune: (1,2)
  └── filters
-      └── ge [type=bool, outer=(1)]
+      └── ge [type=bool, outer=(1), immutable]
            ├── tuple [type=tuple{int, int}]
            │    ├── variable: x:1 [type=int]
            │    └── const: 1 [type=int]
@@ -640,6 +649,7 @@ SELECT * FROM (SELECT (x, y) AS col FROM a) WHERE col > (1, 2)
 ----
 select
  ├── columns: col:4(tuple{int, int}!null)
+ ├── immutable
  ├── project
  │    ├── columns: col:4(tuple{int, int})
  │    ├── prune: (4)
@@ -651,7 +661,7 @@ select
  │              ├── variable: x:1 [type=int]
  │              └── variable: y:2 [type=int]
  └── filters
-      └── gt [type=bool, outer=(4), constraints=(/4: [/(1, 3) - ]; tight)]
+      └── gt [type=bool, outer=(4), immutable, constraints=(/4: [/(1, 3) - ]; tight)]
            ├── variable: col:4 [type=tuple{int, int}]
            └── tuple [type=tuple{int, int}]
                 ├── const: 1 [type=int]
@@ -812,6 +822,7 @@ SELECT * FROM c WHERE (v, u + v) IN ((1, 2), (3, 50), (5, 100))
 ----
 select
  ├── columns: k:1(int!null) u:2(int) v:3(int!null)
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── prune: (1)
@@ -827,7 +838,7 @@ select
  │    ├── prune: (1-3)
  │    └── interesting orderings: (+1) (+3,+2,+1)
  └── filters
-      └── in [type=bool, outer=(2,3), constraints=(/3: [/1 - /1] [/3 - /3] [/5 - /5])]
+      └── in [type=bool, outer=(2,3), immutable, constraints=(/3: [/1 - /1] [/3 - /3] [/5 - /5])]
            ├── tuple [type=tuple{int, int}]
            │    ├── variable: v:3 [type=int]
            │    └── plus [type=int]
@@ -1251,11 +1262,12 @@ SELECT * FROM a WHERE (x, y) < (1, 2) OR (x, y) > (3, 4)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
+ ├── immutable
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── prune: (1,2)
  └── filters
-      └── or [type=bool, outer=(1,2), constraints=(/1/2: (/NULL - /1/1] [/3/5 - ]; tight)]
+      └── or [type=bool, outer=(1,2), immutable, constraints=(/1/2: (/NULL - /1/1] [/3/5 - ]; tight)]
            ├── lt [type=bool]
            │    ├── tuple [type=tuple{int, int}]
            │    │    ├── variable: x:1 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/index-join
+++ b/pkg/sql/opt/memo/testdata/logprops/index-join
@@ -27,6 +27,7 @@ SELECT * FROM a WHERE s = 'foo' AND x + y = 10
 ----
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null)
+ ├── immutable
  ├── key: (1)
  ├── fd: ()-->(3), (1)-->(2,4), (4)-->(1,2), (2,3)~~>(1,4)
  ├── prune: (4)
@@ -44,7 +45,7 @@ select
  │         ├── prune: (1,3,4)
  │         └── interesting orderings: (+1) (-3,+4,+1)
  └── filters
-      └── eq [type=bool, outer=(1,2)]
+      └── eq [type=bool, outer=(1,2), immutable]
            ├── plus [type=int]
            │    ├── variable: x:1 [type=int]
            │    └── variable: y:2 [type=int]
@@ -55,9 +56,11 @@ SELECT y FROM a WHERE s = 'foo' AND x + y = 10
 ----
 project
  ├── columns: y:2(int)
+ ├── immutable
  ├── prune: (2)
  └── select
       ├── columns: x:1(int!null) y:2(int) s:3(string!null)
+      ├── immutable
       ├── key: (1)
       ├── fd: ()-->(3), (1)-->(2), (2,3)~~>(1)
       ├── interesting orderings: (+1) (-3)
@@ -74,7 +77,7 @@ project
       │         ├── prune: (1,3)
       │         └── interesting orderings: (+1) (-3)
       └── filters
-           └── eq [type=bool, outer=(1,2)]
+           └── eq [type=bool, outer=(1,2), immutable]
                 ├── plus [type=int]
                 │    ├── variable: x:1 [type=int]
                 │    └── variable: y:2 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/insert
+++ b/pkg/sql/opt/memo/testdata/logprops/insert
@@ -71,7 +71,7 @@ insert abcde
       │         └── cast: INT8 [as=column12:12, type=int, immutable]
       │              └── null [type=unknown]
       └── projections
-           └── plus [as=column13:13, type=int, outer=(8,10)]
+           └── plus [as=column13:13, type=int, outer=(8,10), immutable]
                 ├── plus [type=int]
                 │    ├── variable: y:8 [type=int]
                 │    └── variable: column10:10 [type=int]
@@ -139,7 +139,7 @@ project
            │         └── cast: INT8 [as=column12:12, type=int, immutable]
            │              └── null [type=unknown]
            └── projections
-                └── plus [as=column13:13, type=int, outer=(8,10)]
+                └── plus [as=column13:13, type=int, outer=(8,10), immutable]
                      ├── plus [type=int]
                      │    ├── variable: y:8 [type=int]
                      │    └── variable: column10:10 [type=int]
@@ -190,7 +190,7 @@ project
            │         └── cast: INT8 [as=column12:12, type=int, immutable]
            │              └── null [type=unknown]
            └── projections
-                └── plus [as=column13:13, type=int, outer=(8,10)]
+                └── plus [as=column13:13, type=int, outer=(8,10), immutable]
                      ├── plus [type=int]
                      │    ├── variable: y:8 [type=int]
                      │    └── variable: column10:10 [type=int]
@@ -242,7 +242,7 @@ insert abcde
       │         └── cast: INT8 [as=column11:11, type=int, immutable]
       │              └── null [type=unknown]
       └── projections
-           └── plus [as=column12:12, type=int, outer=(8,9)]
+           └── plus [as=column12:12, type=int, outer=(8,9), immutable]
                 ├── plus [type=int]
                 │    ├── variable: column2:8 [type=int]
                 │    └── variable: column9:9 [type=int]
@@ -310,7 +310,7 @@ project
            │         └── cast: INT8 [as=column13:13, type=int, immutable]
            │              └── null [type=unknown]
            └── projections
-                └── plus [as=column14:14, type=int, outer=(10,11)]
+                └── plus [as=column14:14, type=int, outer=(10,11), immutable]
                      ├── plus [type=int]
                      │    ├── variable: int8:10 [type=int]
                      │    └── variable: column11:11 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -1989,6 +1989,7 @@ SELECT * FROM mn LEFT JOIN xysd ON y = (n * 2)
 ----
 project
  ├── columns: m:1(int!null) n:2(int) x:3(int) y:4(int) s:5(string) d:6(decimal)
+ ├── immutable
  ├── key: (1,3)
  ├── fd: (1)-->(2), (2)~~>(1), (3)-->(4-6), (5,6)~~>(3,4)
  ├── prune: (1-6)
@@ -1997,6 +1998,7 @@ project
  └── left-join (hash)
       ├── columns: m:1(int!null) n:2(int) x:3(int) y:4(int) s:5(string) d:6(decimal) column7:7(int)
       ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+      ├── immutable
       ├── key: (1,3)
       ├── fd: (1)-->(2), (2)~~>(1), (2)-->(7), (3)-->(4-6), (5,6)~~>(3,4)
       ├── prune: (1-3,5,6)
@@ -2004,6 +2006,7 @@ project
       ├── interesting orderings: (+1) (+2,+1) (+3) (-5,+6,+3)
       ├── project
       │    ├── columns: column7:7(int) m:1(int!null) n:2(int)
+      │    ├── immutable
       │    ├── key: (1)
       │    ├── fd: (1)-->(2), (2)~~>(1), (2)-->(7)
       │    ├── prune: (1,2,7)
@@ -2017,7 +2020,7 @@ project
       │    │    ├── interesting orderings: (+1) (+2,+1)
       │    │    └── unfiltered-cols: (1,2)
       │    └── projections
-      │         └── mult [as=column7:7, type=int, outer=(2)]
+      │         └── mult [as=column7:7, type=int, outer=(2), immutable]
       │              ├── variable: n:2 [type=int]
       │              └── const: 2 [type=int]
       ├── scan xysd

--- a/pkg/sql/opt/memo/testdata/logprops/project
+++ b/pkg/sql/opt/memo/testdata/logprops/project
@@ -15,6 +15,7 @@ SELECT y, x+1 AS a, 1 AS b, x FROM xysd
 ----
 project
  ├── columns: y:2(int) a:5(int!null) b:6(int!null) x:1(int!null)
+ ├── immutable
  ├── key: (1)
  ├── fd: ()-->(6), (1)-->(2,5)
  ├── prune: (1,2,5,6)
@@ -26,7 +27,7 @@ project
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-3,+4,+1)
  └── projections
-      ├── plus [as=a:5, type=int, outer=(1)]
+      ├── plus [as=a:5, type=int, outer=(1), immutable]
       │    ├── variable: x:1 [type=int]
       │    └── const: 1 [type=int]
       └── const: 1 [as=b:6, type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/scalar
+++ b/pkg/sql/opt/memo/testdata/logprops/scalar
@@ -67,7 +67,7 @@ project
       │         ├── function: length [type=int]
       │         │    └── const: 'foo' [type=string]
       │         └── variable: y:2 [type=int]
-      └── mult [as=b:7, type=int, outer=(1,5)]
+      └── mult [as=b:7, type=int, outer=(1,5), immutable]
            ├── variable: rowid:5 [type=int]
            └── variable: x:1 [type=int]
 

--- a/pkg/sql/opt/memo/testdata/logprops/set
+++ b/pkg/sql/opt/memo/testdata/logprops/set
@@ -102,6 +102,7 @@ SELECT * FROM xy WHERE (SELECT x, u FROM uv UNION SELECT y, v FROM uv) = (1, 2)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── interesting orderings: (+1)
@@ -112,7 +113,7 @@ select
  │    ├── prune: (1,2)
  │    └── interesting orderings: (+1)
  └── filters
-      └── eq [type=bool, outer=(1,2), correlated-subquery]
+      └── eq [type=bool, outer=(1,2), immutable, correlated-subquery]
            ├── subquery [type=tuple{int, int}]
            │    └── max1-row
            │         ├── columns: column13:13(tuple{int, int})

--- a/pkg/sql/opt/memo/testdata/logprops/update
+++ b/pkg/sql/opt/memo/testdata/logprops/update
@@ -31,6 +31,7 @@ update abcde
  ├── volatile, side-effects, mutations
  └── project
       ├── columns: column15:15(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) b_new:13(int!null) column14:14(int!null)
+      ├── immutable
       ├── key: (11)
       ├── fd: ()-->(7,13,14), (11)-->(8-10,12), (9)-->(15)
       ├── prune: (7-15)
@@ -75,7 +76,7 @@ update abcde
       │    └── projections
       │         └── const: 0 [as=column14:14, type=int]
       └── projections
-           └── plus [as=column15:15, type=int, outer=(9,13)]
+           └── plus [as=column15:15, type=int, outer=(9,13), immutable]
                 ├── plus [type=int]
                 │    ├── variable: b_new:13 [type=int]
                 │    └── variable: c:9 [type=int]
@@ -102,6 +103,7 @@ project
       ├── fd: ()-->(1,2), (5)-->(3,4), (3)-->(4)
       └── project
            ├── columns: column15:15(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) b_new:13(int!null) column14:14(int!null)
+           ├── immutable
            ├── key: (11)
            ├── fd: ()-->(7,13,14), (11)-->(8-10,12), (9)-->(15)
            ├── prune: (7-15)
@@ -146,7 +148,7 @@ project
            │    └── projections
            │         └── const: 0 [as=column14:14, type=int]
            └── projections
-                └── plus [as=column15:15, type=int, outer=(9,13)]
+                └── plus [as=column15:15, type=int, outer=(9,13), immutable]
                      ├── plus [type=int]
                      │    ├── variable: b_new:13 [type=int]
                      │    └── variable: c:9 [type=int]
@@ -177,6 +179,7 @@ project
       └── project
            ├── columns: column15:15(int!null) a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) b_new:13(int!null) column14:14(int!null)
            ├── cardinality: [0 - 1]
+           ├── immutable
            ├── key: ()
            ├── fd: ()-->(7-15)
            ├── prune: (7-15)
@@ -224,7 +227,7 @@ project
            │    └── projections
            │         └── const: 0 [as=column14:14, type=int]
            └── projections
-                └── plus [as=column15:15, type=int, outer=(9,13)]
+                └── plus [as=column15:15, type=int, outer=(9,13), immutable]
                      ├── plus [type=int]
                      │    ├── variable: b_new:13 [type=int]
                      │    └── variable: c:9 [type=int]
@@ -251,6 +254,7 @@ project
       ├── fd: ()-->(1), (2)==(3), (3)==(2), (5)-->(2-4), (2)-->(4)
       └── project
            ├── columns: column15:15(int!null) a:7(int!null) b:8(int!null) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int) a_new:13(int!null) column14:14(int!null)
+           ├── immutable
            ├── key: (11)
            ├── fd: ()-->(13,14), (11)-->(7-10,12), (8)==(9), (9)==(8), (8,9)-->(15)
            ├── prune: (7-15)
@@ -295,7 +299,7 @@ project
            │    └── projections
            │         └── const: 0 [as=column14:14, type=int]
            └── projections
-                └── plus [as=column15:15, type=int, outer=(8,9)]
+                └── plus [as=column15:15, type=int, outer=(8,9), immutable]
                      ├── plus [type=int]
                      │    ├── variable: b:8 [type=int]
                      │    └── variable: c:9 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -129,7 +129,7 @@ project
            │    │    │    │    │    │    └── projections
            │    │    │    │    │    │         └── function: unique_rowid [as=column8:8, type=int, volatile, side-effects]
            │    │    │    │    │    └── projections
-           │    │    │    │    │         └── plus [as=column9:9, type=int, outer=(6)]
+           │    │    │    │    │         └── plus [as=column9:9, type=int, outer=(6), immutable]
            │    │    │    │    │              ├── variable: y:6 [type=int]
            │    │    │    │    │              └── const: 1 [type=int]
            │    │    │    │    └── aggregations
@@ -158,11 +158,11 @@ project
            │    │    │              └── variable: c:12 [type=int]
            │    │    └── projections
            │    │         ├── const: 1 [as=a_new:14, type=int]
-           │    │         └── plus [as=b_new:15, type=int, outer=(6,12)]
+           │    │         └── plus [as=b_new:15, type=int, outer=(6,12), immutable]
            │    │              ├── variable: y:6 [type=int]
            │    │              └── variable: c:12 [type=int]
            │    └── projections
-           │         └── plus [as=column16:16, type=int, outer=(15)]
+           │         └── plus [as=column16:16, type=int, outer=(15), immutable]
            │              ├── variable: b_new:15 [type=int]
            │              └── const: 1 [type=int]
            └── projections
@@ -340,7 +340,7 @@ project
            │         │    │    │         │    │    │         │    │    │    └── projections
            │         │    │    │         │    │    │         │    │    │         └── function: unique_rowid [as=column8:8, type=int, volatile, side-effects]
            │         │    │    │         │    │    │         │    │    └── projections
-           │         │    │    │         │    │    │         │    │         └── plus [as=column9:9, type=int, outer=(6)]
+           │         │    │    │         │    │    │         │    │         └── plus [as=column9:9, type=int, outer=(6), immutable]
            │         │    │    │         │    │    │         │    │              ├── variable: y:6 [type=int]
            │         │    │    │         │    │    │         │    │              └── const: 1 [type=int]
            │         │    │    │         │    │    │         │    ├── scan abc
@@ -514,7 +514,7 @@ project
  │         │    │    │    │    │         ├── const: 10 [as=column6:6, type=int]
  │         │    │    │    │    │         └── function: unique_rowid [as=column7:7, type=int, volatile, side-effects]
  │         │    │    │    │    └── projections
- │         │    │    │    │         └── plus [as=column8:8, type=int, outer=(6)]
+ │         │    │    │    │         └── plus [as=column8:8, type=int, outer=(6), immutable]
  │         │    │    │    │              ├── variable: column6:6 [type=int]
  │         │    │    │    │              └── const: 1 [type=int]
  │         │    │    │    └── aggregations
@@ -541,7 +541,7 @@ project
  │         │    │              ├── variable: column7:7 [type=int]
  │         │    │              └── variable: rowid:12 [type=int]
  │         │    └── projections
- │         │         └── plus [as=column13:13, type=int, outer=(10)]
+ │         │         └── plus [as=column13:13, type=int, outer=(10), immutable]
  │         │              ├── variable: b:10 [type=int]
  │         │              └── const: 1 [type=int]
  │         └── projections
@@ -570,7 +570,7 @@ project
  │                   │    └── variable: column7:7 [type=int]
  │                   └── variable: rowid:12 [type=int]
  └── projections
-      └── plus [as="?column?":17, type=int, outer=(2,3)]
+      └── plus [as="?column?":17, type=int, outer=(2,3), immutable]
            ├── variable: b:2 [type=int]
            └── variable: c:3 [type=int]
 
@@ -672,7 +672,7 @@ upsert abc
       │    │    │    │    │    │         ├── const: 10 [as=column8:8, type=int]
       │    │    │    │    │    │         └── function: unique_rowid [as=column9:9, type=int, volatile, side-effects]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── plus [as=column10:10, type=int, outer=(8)]
+      │    │    │    │    │         └── plus [as=column10:10, type=int, outer=(8), immutable]
       │    │    │    │    │              ├── variable: column8:8 [type=int]
       │    │    │    │    │              └── const: 1 [type=int]
       │    │    │    │    └── aggregations
@@ -701,7 +701,7 @@ upsert abc
       │    │    └── projections
       │    │         └── const: 2 [as=b_new:15, type=int]
       │    └── projections
-      │         └── plus [as=column16:16, type=int, outer=(15)]
+      │         └── plus [as=column16:16, type=int, outer=(15), immutable]
       │              ├── variable: b_new:15 [type=int]
       │              └── const: 1 [type=int]
       └── projections

--- a/pkg/sql/opt/memo/testdata/logprops/values
+++ b/pkg/sql/opt/memo/testdata/logprops/values
@@ -64,6 +64,7 @@ SELECT (VALUES (x), (y+1)) FROM xy
 ----
 project
  ├── columns: column1:4(int)
+ ├── immutable
  ├── prune: (4)
  ├── scan xy
  │    ├── columns: x:1(int!null) y:2(int)
@@ -72,18 +73,20 @@ project
  │    ├── prune: (1,2)
  │    └── interesting orderings: (+1)
  └── projections
-      └── subquery [as=column1:4, type=int, outer=(1,2), correlated-subquery]
+      └── subquery [as=column1:4, type=int, outer=(1,2), immutable, correlated-subquery]
            └── max1-row
                 ├── columns: column1:3(int)
                 ├── error: "more than one row returned by a subquery used as an expression"
                 ├── outer: (1,2)
                 ├── cardinality: [1 - 1]
+                ├── immutable
                 ├── key: ()
                 ├── fd: ()-->(3)
                 └── values
                      ├── columns: column1:3(int)
                      ├── outer: (1,2)
                      ├── cardinality: [2 - 2]
+                     ├── immutable
                      ├── prune: (3)
                      ├── tuple [type=tuple{int}]
                      │    └── variable: x:1 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/window
+++ b/pkg/sql/opt/memo/testdata/logprops/window
@@ -90,6 +90,7 @@ SELECT k, (SELECT rank() OVER () + x FROM (SELECT k AS x)) FROM kv
 ----
 project
  ├── columns: k:1(int!null) "?column?":11(int)
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(11)
  ├── prune: (1,11)
@@ -101,18 +102,20 @@ project
  │    ├── prune: (1-7)
  │    └── interesting orderings: (+1)
  └── projections
-      └── subquery [as="?column?":11, type=int, outer=(1), correlated-subquery]
+      └── subquery [as="?column?":11, type=int, outer=(1), immutable, correlated-subquery]
            └── max1-row
                 ├── columns: "?column?":10(int)
                 ├── error: "more than one row returned by a subquery used as an expression"
                 ├── outer: (1)
                 ├── cardinality: [1 - 1]
+                ├── immutable
                 ├── key: ()
                 ├── fd: ()-->(10)
                 └── project
                      ├── columns: "?column?":10(int)
                      ├── outer: (1)
                      ├── cardinality: [1 - 1]
+                     ├── immutable
                      ├── key: ()
                      ├── fd: ()-->(10)
                      ├── prune: (10)
@@ -139,7 +142,7 @@ project
                      │    └── windows
                      │         └── rank [as=rank:9, type=int]
                      └── projections
-                          └── plus [as="?column?":10, type=int, outer=(8,9)]
+                          └── plus [as="?column?":10, type=int, outer=(8,9), immutable]
                                ├── variable: rank:9 [type=int]
                                └── variable: x:8 [type=int]
 

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -58,7 +58,7 @@ limit
  │         │                   │    └── variable: a.x:1 [type=int]
  │         │                   └── variable: b.x:3 [type=string]
  │         └── projections
- │              └── plus [as=c:5, type=int, outer=(2)]
+ │              └── plus [as=c:5, type=int, outer=(2), immutable]
  │                   ├── variable: y:2 [type=int]
  │                   └── const: 1 [type=int]
  └── const: 10 [type=int]
@@ -117,7 +117,7 @@ project
  │    │    └── filters (true)
  │    └── const: 10 [type=int]
  └── projections
-      └── plus [as=c:6, type=int, outer=(2)]
+      └── plus [as=c:6, type=int, outer=(2), immutable]
            ├── variable: y:2 [type=int]
            └── const: 1 [type=int]
 

--- a/pkg/sql/opt/memo/testdata/stats/groupby
+++ b/pkg/sql/opt/memo/testdata/stats/groupby
@@ -186,6 +186,7 @@ SELECT sum(x), s FROM a GROUP BY s HAVING sum(x) = 5
 ----
 select
  ├── columns: sum:5(decimal!null) s:4(string)
+ ├── immutable
  ├── stats: [rows=1, distinct(5)=1, null(5)=0]
  ├── key: (4)
  ├── fd: ()-->(5)
@@ -209,7 +210,7 @@ select
  │         └── sum [as=sum:5, type=decimal, outer=(1)]
  │              └── x:1 [type=int]
  └── filters
-      └── sum:5 = 5 [type=bool, outer=(5), constraints=(/5: [/5 - /5]; tight), fd=()-->(5)]
+      └── sum:5 = 5 [type=bool, outer=(5), immutable, constraints=(/5: [/5 - /5]; tight), fd=()-->(5)]
 
 # Scalar GroupBy.
 build
@@ -431,6 +432,7 @@ SELECT sum(x), s FROM a GROUP BY s HAVING sum(x) = 5
 ----
 select
  ├── columns: sum:5(decimal!null) s:4(string)
+ ├── immutable
  ├── stats: [rows=1, distinct(5)=1, null(5)=0]
  ├── key: (4)
  ├── fd: ()-->(5)
@@ -454,7 +456,7 @@ select
  │         └── sum [as=sum:5, type=decimal, outer=(1)]
  │              └── x:1 [type=int]
  └── filters
-      └── sum:5 = 5 [type=bool, outer=(5), constraints=(/5: [/5 - /5]; tight), fd=()-->(5)]
+      └── sum:5 = 5 [type=bool, outer=(5), immutable, constraints=(/5: [/5 - /5]; tight), fd=()-->(5)]
 
 # Regression test for #36442.
 norm

--- a/pkg/sql/opt/memo/testdata/stats/index-join
+++ b/pkg/sql/opt/memo/testdata/stats/index-join
@@ -39,15 +39,18 @@ SELECT count(*) FROM (SELECT * FROM a WHERE s = 'foo' AND x + y = 10) GROUP BY s
 ----
 project
  ├── columns: count:5(int!null)
+ ├── immutable
  ├── stats: [rows=49.2384513]
  └── group-by
       ├── columns: y:2(int) count_rows:5(int!null)
       ├── grouping columns: y:2(int)
+      ├── immutable
       ├── stats: [rows=49.2384513, distinct(2)=49.2384513, null(2)=0]
       ├── key: (2)
       ├── fd: (2)-->(5)
       ├── select
       │    ├── columns: x:1(int!null) y:2(int) s:3(string!null)
+      │    ├── immutable
       │    ├── stats: [rows=66.6666667, distinct(2)=49.2384513, null(2)=0, distinct(3)=1, null(3)=0]
       │    ├── key: (1)
       │    ├── fd: ()-->(3), (1)-->(2)
@@ -63,7 +66,7 @@ project
       │    │         ├── key: (1)
       │    │         └── fd: ()-->(3)
       │    └── filters
-      │         └── (x:1 + y:2) = 10 [type=bool, outer=(1,2)]
+      │         └── (x:1 + y:2) = 10 [type=bool, outer=(1,2), immutable]
       └── aggregations
            └── count-rows [as=count_rows:5, type=int]
 
@@ -72,6 +75,7 @@ SELECT * FROM a WHERE s = 'foo' AND x + y = 10
 ----
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null)
+ ├── immutable
  ├── stats: [rows=66.6666667, distinct(1)=66.6666667, null(1)=0, distinct(2)=49.2384513, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=57.5057212, null(4)=0, distinct(1-3)=66.6666667, null(1-3)=0]
  ├── key: (1)
  ├── fd: ()-->(3), (1)-->(2,4), (4)-->(1,2)
@@ -87,7 +91,7 @@ select
  │         ├── key: (1)
  │         └── fd: ()-->(3), (1)-->(4), (4)-->(1)
  └── filters
-      └── (x:1 + y:2) = 10 [type=bool, outer=(1,2)]
+      └── (x:1 + y:2) = 10 [type=bool, outer=(1,2), immutable]
 
 opt colstat=1 colstat=2 colstat=3 colstat=(1,2,3)
 SELECT * FROM a WHERE s = 'foo'
@@ -180,6 +184,7 @@ SELECT * FROM a WHERE s = 'foo' AND x + y = 10
 ----
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null)
+ ├── immutable
  ├── stats: [rows=33.3333333, distinct(1)=33.3333333, null(1)=0, distinct(2)=28.5927601, null(2)=16.6666667, distinct(3)=1, null(3)=0, distinct(4)=30.9412676, null(4)=0, distinct(1-3)=33.3333333, null(1-3)=0]
  ├── key: (1)
  ├── fd: ()-->(3), (1)-->(2,4), (4)-->(1,2)
@@ -195,7 +200,7 @@ select
  │         ├── key: (1)
  │         └── fd: ()-->(3), (1)-->(4), (4)-->(1)
  └── filters
-      └── (x:1 + y:2) = 10 [type=bool, outer=(1,2)]
+      └── (x:1 + y:2) = 10 [type=bool, outer=(1,2), immutable]
 
 opt colstat=1 colstat=2 colstat=3 colstat=(1,2,3)
 SELECT * FROM a WHERE s = 'foo'

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -382,6 +382,7 @@ SELECT * FROM xysd JOIN uv ON x=u AND y+v=5 AND y > 0 AND y < 300
 inner-join (hash)
  ├── columns: x:1(int!null) y:2(int!null) s:3(string) d:4(decimal!null) u:5(int!null) v:6(int!null)
  ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+ ├── immutable
  ├── stats: [rows=3333.33333, distinct(1)=500, null(1)=0, distinct(5)=500, null(5)=0]
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (1)==(5), (5)==(1)
  ├── select
@@ -401,7 +402,7 @@ inner-join (hash)
  │    └── stats: [rows=10000, distinct(5)=500, null(5)=0, distinct(6)=100, null(6)=0]
  └── filters
       ├── x:1 = u:5 [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
-      └── (y:2 + v:6) = 5 [type=bool, outer=(2,6)]
+      └── (y:2 + v:6) = 5 [type=bool, outer=(2,6), immutable]
 
 # Force column statistics calculation for semi-join.
 norm
@@ -411,15 +412,18 @@ GROUP BY y
 ----
 project
  ├── columns: count:8(int!null)
+ ├── immutable
  ├── stats: [rows=138.170075]
  └── group-by
       ├── columns: y:2(int) count_rows:8(int!null)
       ├── grouping columns: y:2(int)
+      ├── immutable
       ├── stats: [rows=138.170075, distinct(2)=138.170075, null(2)=0]
       ├── key: (2)
       ├── fd: (2)-->(8)
       ├── semi-join (hash)
       │    ├── columns: x:1(int!null) y:2(int)
+      │    ├── immutable
       │    ├── stats: [rows=166.666667, distinct(1)=166.666667, null(1)=0, distinct(2)=138.170075, null(2)=0]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2)
@@ -433,7 +437,7 @@ project
       │    │    └── stats: [rows=10000, distinct(5)=500, null(5)=0, distinct(6)=100, null(6)=0]
       │    └── filters
       │         ├── x:1 = u:5 [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
-      │         └── (y:2 + v:6) = 5 [type=bool, outer=(2,6)]
+      │         └── (y:2 + v:6) = 5 [type=bool, outer=(2,6), immutable]
       └── aggregations
            └── count-rows [as=count_rows:8, type=int]
 
@@ -445,15 +449,18 @@ GROUP BY y
 ----
 project
  ├── columns: count:8(int!null)
+ ├── immutable
  ├── stats: [rows=400]
  └── group-by
       ├── columns: y:2(int) count_rows:8(int!null)
       ├── grouping columns: y:2(int)
+      ├── immutable
       ├── stats: [rows=400, distinct(2)=400, null(2)=0]
       ├── key: (2)
       ├── fd: (2)-->(8)
       ├── anti-join (hash)
       │    ├── columns: x:1(int!null) y:2(int)
+      │    ├── immutable
       │    ├── stats: [rows=4833.33333, distinct(2)=400, null(2)=0]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2)
@@ -467,7 +474,7 @@ project
       │    │    └── stats: [rows=10000, distinct(5)=500, null(5)=0, distinct(6)=100, null(6)=0]
       │    └── filters
       │         ├── x:1 = u:5 [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
-      │         └── (y:2 + v:6) = 5 [type=bool, outer=(2,6)]
+      │         └── (y:2 + v:6) = 5 [type=bool, outer=(2,6), immutable]
       └── aggregations
            └── count-rows [as=count_rows:8, type=int]
 
@@ -479,16 +486,19 @@ GROUP BY y
 ----
 project
  ├── columns: count:8(int!null)
+ ├── immutable
  ├── stats: [rows=400]
  └── group-by
       ├── columns: y:2(int) count_rows:8(int!null)
       ├── grouping columns: y:2(int)
+      ├── immutable
       ├── stats: [rows=400, distinct(2)=400, null(2)=0]
       ├── key: (2)
       ├── fd: (2)-->(8)
       ├── left-join (hash)
       │    ├── columns: x:1(int!null) y:2(int) u:5(int) v:6(int)
       │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+      │    ├── immutable
       │    ├── stats: [rows=5000, distinct(2)=400, null(2)=0, distinct(5)=500, null(5)=1666.66667]
       │    ├── fd: (1)-->(2)
       │    ├── scan xysd
@@ -501,7 +511,7 @@ project
       │    │    └── stats: [rows=10000, distinct(5)=500, null(5)=0]
       │    └── filters
       │         ├── x:1 = u:5 [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
-      │         └── (y:2 + v:6) = 5 [type=bool, outer=(2,6)]
+      │         └── (y:2 + v:6) = 5 [type=bool, outer=(2,6), immutable]
       └── aggregations
            └── count-rows [as=count_rows:8, type=int]
 
@@ -513,16 +523,19 @@ GROUP BY y
 ----
 project
  ├── columns: count:8(int!null)
+ ├── immutable
  ├── stats: [rows=399.903879]
  └── group-by
       ├── columns: y:2(int) count_rows:8(int!null)
       ├── grouping columns: y:2(int)
+      ├── immutable
       ├── stats: [rows=399.903879, distinct(2)=399.903879, null(2)=1]
       ├── key: (2)
       ├── fd: (2)-->(8)
       ├── left-join (hash)
       │    ├── columns: x:1(int) y:2(int) u:5(int) v:6(int!null)
       │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+      │    ├── immutable
       │    ├── stats: [rows=10000, distinct(1)=500, null(1)=6666.66667, distinct(2)=399.903879, null(2)=6666.66667]
       │    ├── fd: (1)-->(2)
       │    ├── scan uv
@@ -535,7 +548,7 @@ project
       │    │    └── fd: (1)-->(2)
       │    └── filters
       │         ├── x:1 = u:5 [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
-      │         └── (y:2 + v:6) = 5 [type=bool, outer=(2,6)]
+      │         └── (y:2 + v:6) = 5 [type=bool, outer=(2,6), immutable]
       └── aggregations
            └── count-rows [as=count_rows:8, type=int]
 
@@ -547,16 +560,19 @@ GROUP BY y
 ----
 project
  ├── columns: count:8(int!null)
+ ├── immutable
  ├── stats: [rows=400]
  └── group-by
       ├── columns: y:2(int) count_rows:8(int!null)
       ├── grouping columns: y:2(int)
+      ├── immutable
       ├── stats: [rows=400, distinct(2)=400, null(2)=1]
       ├── key: (2)
       ├── fd: (2)-->(8)
       ├── full-join (hash)
       │    ├── columns: x:1(int) y:2(int) u:5(int) v:6(int)
       │    ├── multiplicity: left-rows(one-or-more), right-rows(exactly-one)
+      │    ├── immutable
       │    ├── stats: [rows=11666.6667, distinct(2)=400, null(2)=6666.66667]
       │    ├── fd: (1)-->(2)
       │    ├── scan xysd
@@ -569,7 +585,7 @@ project
       │    │    └── stats: [rows=10000, distinct(5)=500, null(5)=0]
       │    └── filters
       │         ├── x:1 = u:5 [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
-      │         └── (y:2 + v:6) = 5 [type=bool, outer=(2,6)]
+      │         └── (y:2 + v:6) = 5 [type=bool, outer=(2,6), immutable]
       └── aggregations
            └── count-rows [as=count_rows:8, type=int]
 

--- a/pkg/sql/opt/memo/testdata/stats/project
+++ b/pkg/sql/opt/memo/testdata/stats/project
@@ -135,9 +135,11 @@ SELECT * FROM (SELECT y + 3 AS v FROM a) WHERE v >= 1 AND v <= 100
 ----
 select
  ├── columns: v:5(int!null)
+ ├── immutable
  ├── stats: [rows=1000, distinct(5)=100, null(5)=0]
  ├── project
  │    ├── columns: v:5(int)
+ │    ├── immutable
  │    ├── stats: [rows=2000, distinct(5)=200, null(5)=0]
  │    ├── scan a
  │    │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
@@ -145,7 +147,7 @@ select
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    └── projections
- │         └── y:2 + 3 [as=v:5, type=int, outer=(2)]
+ │         └── y:2 + 3 [as=v:5, type=int, outer=(2), immutable]
  └── filters
       └── (v:5 >= 1) AND (v:5 <= 100) [type=bool, outer=(5), constraints=(/5: [/1 - /100]; tight)]
 

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -202,6 +202,7 @@ SELECT * FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND d > 5
 ----
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null) b:5(bool)
+ ├── immutable
  ├── stats: [rows=650, distinct(3)=1, null(3)=0, distinct(4)=650, null(4)=0, distinct(3,4)=650, null(3,4)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-5), (3,4)-->(1,2,5)
@@ -212,13 +213,14 @@ select
  │    └── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
  └── filters
       ├── ((s:3 >= 'bar') AND (s:3 <= 'foo')) OR (s:3 >= 'foobar') [type=bool, outer=(3), constraints=(/3: [/'bar' - /'foo'] [/'foobar' - ]; tight)]
-      └── d:4 > 5.0 [type=bool, outer=(4), constraints=(/4: (/5.0 - ]; tight)]
+      └── d:4 > 5.0 [type=bool, outer=(4), immutable, constraints=(/4: (/5.0 - ]; tight)]
 
 opt
 SELECT * FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND d <= 5.0 AND s IS NOT NULL
 ----
 select
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null) b:5(bool)
+ ├── immutable
  ├── stats: [rows=650, distinct(3)=1, null(3)=0, distinct(4)=650, null(4)=0, distinct(3,4)=650, null(3,4)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-5), (3,4)-->(1,2,5)
@@ -229,7 +231,7 @@ select
  │    └── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
  └── filters
       ├── (((s:3 >= 'bar') AND (s:3 <= 'foo')) OR (s:3 >= 'foobar')) AND (s:3 IS NOT NULL) [type=bool, outer=(3), constraints=(/3: [/'bar' - /'foo'] [/'foobar' - ]; tight)]
-      └── d:4 <= 5.0 [type=bool, outer=(4), constraints=(/4: (/NULL - /5.0]; tight)]
+      └── d:4 <= 5.0 [type=bool, outer=(4), immutable, constraints=(/4: (/NULL - /5.0]; tight)]
 
 # Bump up null counts.
 
@@ -359,11 +361,13 @@ SELECT * FROM a WHERE ((s >= 'bar' AND s <= 'foo') OR (s >= 'foobar')) AND d <= 
 ----
 index-join a
  ├── columns: x:1(int!null) y:2(int) s:3(string!null) d:4(decimal!null) b:5(bool)
+ ├── immutable
  ├── stats: [rows=333.333333, distinct(3)=1, null(3)=0, distinct(4)=100, null(4)=0, distinct(3,4)=100, null(3,4)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-5), (3,4)-->(1,2,5)
  └── select
       ├── columns: x:1(int!null) s:3(string!null) d:4(decimal!null)
+      ├── immutable
       ├── stats: [rows=333.333333, distinct(4)=98.265847, null(4)=0]
       ├── key: (1)
       ├── fd: (1)-->(3,4), (3,4)-->(1)
@@ -376,7 +380,7 @@ index-join a
       │    ├── key: (1)
       │    └── fd: (1)-->(3,4), (3,4)-->(1)
       └── filters
-           └── d:4 <= 5.0 [type=bool, outer=(4), constraints=(/4: (/NULL - /5.0]; tight)]
+           └── d:4 <= 5.0 [type=bool, outer=(4), immutable, constraints=(/4: (/NULL - /5.0]; tight)]
 
 exec-ddl
 CREATE TABLE abcde (
@@ -720,6 +724,7 @@ SELECT * FROM hist WHERE c = 20 OR (c < 10)
 ----
 index-join hist
  ├── columns: a:1(int) b:2(date) c:3(decimal!null) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
+ ├── immutable
  ├── stats: [rows=110, distinct(3)=10, null(3)=0]
  │   histogram(3)=  0  0  90  0   0  20
  │                <--- 0 ---- 10 --- 20
@@ -739,6 +744,7 @@ SELECT * FROM hist WHERE c = 20 OR (c <= 10)
 ----
 index-join hist
  ├── columns: a:1(int) b:2(date) c:3(decimal!null) d:4(float) e:5(timestamp) f:6(timestamptz) g:7(string)
+ ├── immutable
  ├── stats: [rows=120, distinct(3)=11, null(3)=0]
  │   histogram(3)=  0  0  90  10  0  20
  │                <--- 0 ---- 10 --- 20

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -96,6 +96,7 @@ SELECT * FROM a WHERE x + y < 10
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
+ ├── immutable
  ├── stats: [rows=1333.33333]
  ├── key: (1)
  ├── fd: (1)-->(2)
@@ -105,7 +106,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── filters
-      └── (x:1 + y:2) < 10 [type=bool, outer=(1,2)]
+      └── (x:1 + y:2) < 10 [type=bool, outer=(1,2), immutable]
 
 # Remaining filter.
 norm
@@ -538,6 +539,7 @@ SELECT * FROM order_history WHERE item_id = order_id AND customer_id % 2 = 0
 ----
 select
  ├── columns: order_id:1(int!null) item_id:2(int!null) customer_id:3(int) year:4(int)
+ ├── immutable
  ├── stats: [rows=3.267, distinct(1)=3.267, null(1)=0, distinct(2)=3.267, null(2)=0]
  ├── fd: (1)==(2), (2)==(1)
  ├── scan order_history
@@ -545,7 +547,7 @@ select
  │    └── stats: [rows=1000, distinct(1)=100, null(1)=10, distinct(2)=100, null(2)=10]
  └── filters
       ├── item_id:2 = order_id:1 [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
-      └── (customer_id:3 % 2) = 0 [type=bool, outer=(3)]
+      └── (customer_id:3 % 2) = 0 [type=bool, outer=(3), immutable]
 
 exec-ddl
 CREATE TABLE c (x INT, z INT NOT NULL, UNIQUE INDEX x_idx (x))
@@ -840,6 +842,7 @@ SELECT * FROM tjson WHERE b @> '{"a":"b"}'
 ----
 index-join tjson
  ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
+ ├── immutable
  ├── stats: [rows=555.555556]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
@@ -858,6 +861,7 @@ inner-join (lookup tjson)
  ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
  ├── key columns: [1] = [1]
  ├── lookup columns are key
+ ├── immutable
  ├── stats: [rows=61.7283951]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
@@ -869,7 +873,7 @@ inner-join (lookup tjson)
  │    ├── stats: [rows=61.7283951, distinct(1)=61.7283951, null(1)=0]
  │    └── filters (true)
  └── filters
-      └── b:2 @> '{"a": "b", "c": "d"}' [type=bool, outer=(2)]
+      └── b:2 @> '{"a": "b", "c": "d"}' [type=bool, outer=(2), immutable]
 
 # Should generate a select on the table with a JSON filter, since c does not
 # have an inverted index.
@@ -878,6 +882,7 @@ SELECT * FROM tjson WHERE c @> '{"a":"b"}'
 ----
 select
  ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
+ ├── immutable
  ├── stats: [rows=555.555556]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
@@ -887,7 +892,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3)
  └── filters
-      └── c:3 @> '{"a": "b"}' [type=bool, outer=(3)]
+      └── c:3 @> '{"a": "b"}' [type=bool, outer=(3), immutable]
 
 # Should have a lower row count than the above case, due to a containment query
 # on 2 json paths.
@@ -896,6 +901,7 @@ SELECT * FROM tjson WHERE c @> '{"a":"b", "c":"d"}'
 ----
 select
  ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
+ ├── immutable
  ├── stats: [rows=61.7283951]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
@@ -905,7 +911,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3)
  └── filters
-      └── c:3 @> '{"a": "b", "c": "d"}' [type=bool, outer=(3)]
+      └── c:3 @> '{"a": "b", "c": "d"}' [type=bool, outer=(3), immutable]
 
 # Bump up null counts.
 exec-ddl
@@ -999,6 +1005,7 @@ SELECT * FROM a WHERE x + y < 10
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
+ ├── immutable
  ├── stats: [rows=1666.66667]
  ├── key: (1)
  ├── fd: (1)-->(2)
@@ -1008,7 +1015,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── filters
-      └── (x:1 + y:2) < 10 [type=bool, outer=(1,2)]
+      └── (x:1 + y:2) < 10 [type=bool, outer=(1,2), immutable]
 
 # Remaining filter.
 norm

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -639,6 +639,7 @@ scalar-group-by
  ├── save-table-name: consistency_01_scalar_group_by_1
  ├── columns: count:22(int!null)
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── stats: [rows=1, distinct(22)=1, null(22)=0]
  ├── key: ()
  ├── fd: ()-->(22)
@@ -647,6 +648,7 @@ scalar-group-by
  │    ├── columns: w_id:1(int!null) w_ytd:9(decimal!null) d_w_id:11(int!null) sum:21(decimal!null)
  │    ├── left ordering: +1
  │    ├── right ordering: +11
+ │    ├── immutable
  │    ├── stats: [rows=3.33333333, distinct(1)=3.33333333, null(1)=0, distinct(9)=1, null(9)=0, distinct(11)=3.33333333, null(11)=0, distinct(21)=3.33333333, null(21)=0]
  │    ├── key: (11)
  │    ├── fd: (1)-->(9), (11)-->(21), (1)==(11), (11)==(1)
@@ -678,7 +680,7 @@ scalar-group-by
  │    │         └── sum [as=sum:21, type=decimal, outer=(19)]
  │    │              └── d_ytd:19 [type=decimal]
  │    └── filters
- │         └── w_ytd:9 != sum:21 [type=bool, outer=(9,21), constraints=(/9: (/NULL - ]; /21: (/NULL - ])]
+ │         └── w_ytd:9 != sum:21 [type=bool, outer=(9,21), immutable, constraints=(/9: (/NULL - ]; /21: (/NULL - ])]
  └── aggregations
       └── count-rows [as=count_rows:22, type=int]
 
@@ -819,12 +821,14 @@ scalar-group-by
  ├── save-table-name: consistency_05_scalar_group_by_1
  ├── columns: count:8(int!null)
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── stats: [rows=1, distinct(8)=1, null(8)=0]
  ├── key: ()
  ├── fd: ()-->(8)
  ├── select
  │    ├── save-table-name: consistency_05_select_2
  │    ├── columns: no_d_id:2(int!null) no_w_id:3(int!null) max:4(int!null) min:5(int!null) count_rows:6(int!null)
+ │    ├── immutable
  │    ├── stats: [rows=33.3333333, distinct(2)=9.8265847, null(2)=0, distinct(3)=9.8265847, null(3)=0, distinct(4)=33.3333333, null(4)=0, distinct(5)=33.3333333, null(5)=0, distinct(6)=33.3333333, null(6)=0]
  │    ├── key: (2,3)
  │    ├── fd: (2,3)-->(4-6)
@@ -851,7 +855,7 @@ scalar-group-by
  │    │         │    └── no_o_id:1 [type=int]
  │    │         └── count-rows [as=count_rows:6, type=int]
  │    └── filters
- │         └── ((max:4 - min:5) - count_rows:6) != -1 [type=bool, outer=(4-6)]
+ │         └── ((max:4 - min:5) - count_rows:6) != -1 [type=bool, outer=(4-6), immutable]
  └── aggregations
       └── count-rows [as=count_rows:8, type=int]
 

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q01
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q01
@@ -43,6 +43,7 @@ ORDER BY
 sort
  ├── save-table-name: q1_sort_1
  ├── columns: l_returnflag:9(char!null) l_linestatus:10(char!null) sum_qty:17(float!null) sum_base_price:18(float!null) sum_disc_price:20(float!null) sum_charge:22(float!null) avg_qty:23(float!null) avg_price:24(float!null) avg_disc:25(float!null) count_order:26(int!null)
+ ├── immutable
  ├── stats: [rows=6, distinct(9)=3, null(9)=0, distinct(10)=2, null(10)=0, distinct(17)=6, null(17)=0, distinct(18)=6, null(18)=0, distinct(20)=6, null(20)=0, distinct(22)=6, null(22)=0, distinct(23)=6, null(23)=0, distinct(24)=6, null(24)=0, distinct(25)=6, null(25)=0, distinct(26)=6, null(26)=0, distinct(9,10)=6, null(9,10)=0]
  ├── key: (9,10)
  ├── fd: (9,10)-->(17,18,20,22-26)
@@ -51,12 +52,14 @@ sort
       ├── save-table-name: q1_group_by_2
       ├── columns: l_returnflag:9(char!null) l_linestatus:10(char!null) sum:17(float!null) sum:18(float!null) sum:20(float!null) sum:22(float!null) avg:23(float!null) avg:24(float!null) avg:25(float!null) count_rows:26(int!null)
       ├── grouping columns: l_returnflag:9(char!null) l_linestatus:10(char!null)
+      ├── immutable
       ├── stats: [rows=6, distinct(9)=3, null(9)=0, distinct(10)=2, null(10)=0, distinct(17)=6, null(17)=0, distinct(18)=6, null(18)=0, distinct(20)=6, null(20)=0, distinct(22)=6, null(22)=0, distinct(23)=6, null(23)=0, distinct(24)=6, null(24)=0, distinct(25)=6, null(25)=0, distinct(26)=6, null(26)=0, distinct(9,10)=6, null(9,10)=0]
       ├── key: (9,10)
       ├── fd: (9,10)-->(17,18,20,22-26)
       ├── project
       │    ├── save-table-name: q1_project_3
       │    ├── columns: column19:19(float!null) column21:21(float!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null)
+      │    ├── immutable
       │    ├── stats: [rows=5925056.21, distinct(5)=50, null(5)=0, distinct(6)=925955, null(6)=0, distinct(7)=11, null(7)=0, distinct(9)=3, null(9)=0, distinct(10)=2, null(10)=0, distinct(19)=5925056.21, null(19)=0, distinct(21)=5925056.21, null(21)=0, distinct(9,10)=6, null(9,10)=0]
       │    ├── select
       │    │    ├── save-table-name: q1_select_4
@@ -73,8 +76,8 @@ sort
       │    │    └── filters
       │    │         └── l_shipdate:11 <= '1998-09-02' [type=bool, outer=(11), constraints=(/11: (/NULL - /'1998-09-02']; tight)]
       │    └── projections
-      │         ├── l_extendedprice:6 * (1.0 - l_discount:7) [as=column19:19, type=float, outer=(6,7)]
-      │         └── (l_extendedprice:6 * (1.0 - l_discount:7)) * (l_tax:8 + 1.0) [as=column21:21, type=float, outer=(6-8)]
+      │         ├── l_extendedprice:6 * (1.0 - l_discount:7) [as=column19:19, type=float, outer=(6,7), immutable]
+      │         └── (l_extendedprice:6 * (1.0 - l_discount:7)) * (l_tax:8 + 1.0) [as=column21:21, type=float, outer=(6-8), immutable]
       └── aggregations
            ├── sum [as=sum:17, type=float, outer=(5)]
            │    └── l_quantity:5 [type=float]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q03
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q03
@@ -45,6 +45,7 @@ limit
  ├── columns: l_orderkey:18(int!null) revenue:35(float!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
  ├── internal-ordering: -35,+13
  ├── cardinality: [0 - 10]
+ ├── immutable
  ├── stats: [rows=10, distinct(13)=10, null(13)=0, distinct(16)=10, null(16)=0, distinct(18)=10, null(18)=0, distinct(35)=10, null(35)=0]
  ├── key: (18)
  ├── fd: (18)-->(13,16,35)
@@ -52,6 +53,7 @@ limit
  ├── sort
  │    ├── save-table-name: q3_sort_2
  │    ├── columns: o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null) sum:35(float!null)
+ │    ├── immutable
  │    ├── stats: [rows=359560.406, distinct(13)=359560.406, null(13)=0, distinct(16)=359560.406, null(16)=0, distinct(18)=359560.406, null(18)=0, distinct(35)=359560.406, null(35)=0]
  │    ├── key: (18)
  │    ├── fd: (18)-->(13,16,35)
@@ -61,12 +63,14 @@ limit
  │         ├── save-table-name: q3_group_by_3
  │         ├── columns: o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null) sum:35(float!null)
  │         ├── grouping columns: l_orderkey:18(int!null)
+ │         ├── immutable
  │         ├── stats: [rows=359560.406, distinct(13)=359560.406, null(13)=0, distinct(16)=359560.406, null(16)=0, distinct(18)=359560.406, null(18)=0, distinct(35)=359560.406, null(35)=0]
  │         ├── key: (18)
  │         ├── fd: (18)-->(13,16,35)
  │         ├── project
  │         │    ├── save-table-name: q3_project_4
  │         │    ├── columns: column34:34(float!null) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null)
+ │         │    ├── immutable
  │         │    ├── stats: [rows=493779.215, distinct(13)=1169, null(13)=0, distinct(16)=1, null(16)=0, distinct(18)=359560.406, null(18)=0, distinct(34)=410295.908, null(34)=0]
  │         │    ├── fd: (18)-->(13,16)
  │         │    ├── inner-join (lookup lineitem)
@@ -125,7 +129,7 @@ limit
  │         │    │    └── filters
  │         │    │         └── l_shipdate:28 > '1995-03-15' [type=bool, outer=(28), constraints=(/28: [/'1995-03-16' - ]; tight)]
  │         │    └── projections
- │         │         └── l_extendedprice:23 * (1.0 - l_discount:24) [as=column34:34, type=float, outer=(23,24)]
+ │         │         └── l_extendedprice:23 * (1.0 - l_discount:24) [as=column34:34, type=float, outer=(23,24), immutable]
  │         └── aggregations
  │              ├── sum [as=sum:35, type=float, outer=(34)]
  │              │    └── column34:34 [type=float]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q05
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q05
@@ -50,6 +50,7 @@ ORDER BY
 sort
  ├── save-table-name: q5_sort_1
  ├── columns: n_name:42(char!null) revenue:49(float!null)
+ ├── immutable
  ├── stats: [rows=5, distinct(42)=5, null(42)=0, distinct(49)=5, null(49)=0]
  ├── key: (42)
  ├── fd: (42)-->(49)
@@ -58,12 +59,14 @@ sort
       ├── save-table-name: q5_group_by_2
       ├── columns: n_name:42(char!null) sum:49(float!null)
       ├── grouping columns: n_name:42(char!null)
+      ├── immutable
       ├── stats: [rows=5, distinct(42)=5, null(42)=0, distinct(49)=5, null(49)=0]
       ├── key: (42)
       ├── fd: (42)-->(49)
       ├── project
       │    ├── save-table-name: q5_project_3
       │    ├── columns: column48:48(float!null) n_name:42(char!null)
+      │    ├── immutable
       │    ├── stats: [rows=13445.4933, distinct(42)=5, null(42)=0, distinct(48)=13135.9517, null(48)=0]
       │    ├── inner-join (hash)
       │    │    ├── save-table-name: q5_inner_join_4
@@ -171,7 +174,7 @@ sort
       │    │         ├── c_custkey:1 = o_custkey:10 [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
       │    │         └── c_nationkey:4 = s_nationkey:37 [type=bool, outer=(4,37), constraints=(/4: (/NULL - ]; /37: (/NULL - ]), fd=(4)==(37), (37)==(4)]
       │    └── projections
-      │         └── l_extendedprice:23 * (1.0 - l_discount:24) [as=column48:48, type=float, outer=(23,24)]
+      │         └── l_extendedprice:23 * (1.0 - l_discount:24) [as=column48:48, type=float, outer=(23,24), immutable]
       └── aggregations
            └── sum [as=sum:49, type=float, outer=(48)]
                 └── column48:48 [type=float]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q06
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q06
@@ -34,12 +34,14 @@ scalar-group-by
  ├── save-table-name: q6_scalar_group_by_1
  ├── columns: revenue:18(float)
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── stats: [rows=1, distinct(18)=1, null(18)=0]
  ├── key: ()
  ├── fd: ()-->(18)
  ├── project
  │    ├── save-table-name: q6_project_2
  │    ├── columns: column17:17(float!null)
+ │    ├── immutable
  │    ├── stats: [rows=34745.8339, distinct(17)=34745.8339, null(17)=0]
  │    ├── select
  │    │    ├── save-table-name: q6_select_3
@@ -66,7 +68,7 @@ scalar-group-by
  │    │         ├── (l_discount:7 >= 0.05) AND (l_discount:7 <= 0.07) [type=bool, outer=(7), constraints=(/7: [/0.05 - /0.07]; tight)]
  │    │         └── l_quantity:5 < 24.0 [type=bool, outer=(5), constraints=(/5: (/NULL - /23.999999999999996]; tight)]
  │    └── projections
- │         └── l_extendedprice:6 * l_discount:7 [as=column17:17, type=float, outer=(6,7)]
+ │         └── l_extendedprice:6 * l_discount:7 [as=column17:17, type=float, outer=(6,7), immutable]
  └── aggregations
       └── sum [as=sum:18, type=float, outer=(17)]
            └── column17:17 [type=float]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q07
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q07
@@ -149,7 +149,7 @@ sort
       │    │         └── s_nationkey:4 = n1.n_nationkey:41 [type=bool, outer=(4,41), constraints=(/4: (/NULL - ]; /41: (/NULL - ]), fd=(4)==(41), (41)==(4)]
       │    └── projections
       │         ├── extract('year', l_shipdate:18) [as=l_year:49, type=float, outer=(18), immutable]
-      │         └── l_extendedprice:13 * (1.0 - l_discount:14) [as=volume:50, type=float, outer=(13,14)]
+      │         └── l_extendedprice:13 * (1.0 - l_discount:14) [as=volume:50, type=float, outer=(13,14), immutable]
       └── aggregations
            └── sum [as=sum:51, type=float, outer=(50)]
                 └── volume:50 [type=float]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q08
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q08
@@ -246,7 +246,7 @@ sort
       │    │    │    │         └── p_partkey:1 = l_partkey:18 [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
       │    │    │    └── projections
       │    │    │         ├── extract('year', o_orderdate:37) [as=o_year:61, type=float, outer=(37), immutable]
-      │    │    │         └── l_extendedprice:22 * (1.0 - l_discount:23) [as=volume:62, type=float, outer=(22,23)]
+      │    │    │         └── l_extendedprice:22 * (1.0 - l_discount:23) [as=volume:62, type=float, outer=(22,23), immutable]
       │    │    └── projections
       │    │         └── CASE WHEN n2.n_name:55 = 'BRAZIL' THEN volume:62 ELSE 0.0 END [as=column63:63, type=float, outer=(55,62)]
       │    └── aggregations

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q09
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q09
@@ -159,7 +159,7 @@ sort
       │    │         └── p_name:2 LIKE '%green%' [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
       │    └── projections
       │         ├── extract('year', o_orderdate:42) [as=o_year:51, type=float, outer=(42), immutable]
-      │         └── (l_extendedprice:22 * (1.0 - l_discount:23)) - (ps_supplycost:36 * l_quantity:21) [as=amount:52, type=float, outer=(21-23,36)]
+      │         └── (l_extendedprice:22 * (1.0 - l_discount:23)) - (ps_supplycost:36 * l_quantity:21) [as=amount:52, type=float, outer=(21-23,36), immutable]
       └── aggregations
            └── sum [as=sum:53, type=float, outer=(52)]
                 └── amount:52 [type=float]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q10
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q10
@@ -57,6 +57,7 @@ limit
  ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) revenue:39(float!null) c_acctbal:6(float!null) n_name:35(char!null) c_address:3(varchar!null) c_phone:5(char!null) c_comment:8(varchar!null)
  ├── internal-ordering: -39
  ├── cardinality: [0 - 20]
+ ├── immutable
  ├── stats: [rows=20, distinct(1)=20, null(1)=0, distinct(2)=20, null(2)=0, distinct(3)=20, null(3)=0, distinct(5)=20, null(5)=0, distinct(6)=20, null(6)=0, distinct(8)=20, null(8)=0, distinct(35)=20, null(35)=0, distinct(39)=20, null(39)=0]
  ├── key: (1)
  ├── fd: (1)-->(2,3,5,6,8,35,39)
@@ -64,6 +65,7 @@ limit
  ├── sort
  │    ├── save-table-name: q10_sort_2
  │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) n_name:35(char!null) sum:39(float!null)
+ │    ├── immutable
  │    ├── stats: [rows=42917.9526, distinct(1)=42917.9526, null(1)=0, distinct(2)=42917.9526, null(2)=0, distinct(3)=42917.9526, null(3)=0, distinct(5)=42917.9526, null(5)=0, distinct(6)=42917.9526, null(6)=0, distinct(8)=42917.9526, null(8)=0, distinct(35)=42917.9526, null(35)=0, distinct(39)=42917.9526, null(39)=0]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3,5,6,8,35,39)
@@ -73,12 +75,14 @@ limit
  │         ├── save-table-name: q10_group_by_3
  │         ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) n_name:35(char!null) sum:39(float!null)
  │         ├── grouping columns: c_custkey:1(int!null)
+ │         ├── immutable
  │         ├── stats: [rows=42917.9526, distinct(1)=42917.9526, null(1)=0, distinct(2)=42917.9526, null(2)=0, distinct(3)=42917.9526, null(3)=0, distinct(5)=42917.9526, null(5)=0, distinct(6)=42917.9526, null(6)=0, distinct(8)=42917.9526, null(8)=0, distinct(35)=42917.9526, null(35)=0, distinct(39)=42917.9526, null(39)=0]
  │         ├── key: (1)
  │         ├── fd: (1)-->(2,3,5,6,8,35,39)
  │         ├── project
  │         │    ├── save-table-name: q10_project_4
  │         │    ├── columns: column38:38(float!null) c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) n_name:35(char!null)
+ │         │    ├── immutable
  │         │    ├── stats: [rows=91240.8317, distinct(1)=42917.9526, null(1)=0, distinct(2)=68356.4353, null(2)=0, distinct(3)=68348.5807, null(3)=0, distinct(5)=68356.4353, null(5)=0, distinct(6)=67126.327, null(6)=0, distinct(8)=68271.7501, null(8)=0, distinct(35)=25, null(35)=0, distinct(38)=88236.775, null(38)=0]
  │         │    ├── fd: (1)-->(2,3,5,6,8,35)
  │         │    ├── inner-join (hash)
@@ -143,7 +147,7 @@ limit
  │         │    │    └── filters
  │         │    │         └── c_nationkey:4 = n_nationkey:34 [type=bool, outer=(4,34), constraints=(/4: (/NULL - ]; /34: (/NULL - ]), fd=(4)==(34), (34)==(4)]
  │         │    └── projections
- │         │         └── l_extendedprice:23 * (1.0 - l_discount:24) [as=column38:38, type=float, outer=(23,24)]
+ │         │         └── l_extendedprice:23 * (1.0 - l_discount:24) [as=column38:38, type=float, outer=(23,24), immutable]
  │         └── aggregations
  │              ├── sum [as=sum:39, type=float, outer=(38)]
  │              │    └── column38:38 [type=float]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q11
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q11
@@ -188,7 +188,7 @@ sort
                           │         └── sum [as=sum:36, type=float, outer=(35)]
                           │              └── column35:35 [type=float]
                           └── projections
-                               └── sum:36 * 0.0001 [as="?column?":37, type=float, outer=(36)]
+                               └── sum:36 * 0.0001 [as="?column?":37, type=float, outer=(36), immutable]
 
 stats table=q11_sort_1
 ----

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q14
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q14
@@ -42,12 +42,14 @@ project
  │    ├── save-table-name: q14_scalar_group_by_2
  │    ├── columns: sum:27(float) sum:29(float)
  │    ├── cardinality: [1 - 1]
+ │    ├── immutable
  │    ├── stats: [rows=1, distinct(27)=1, null(27)=0, distinct(29)=1, null(29)=0, distinct(27,29)=1, null(27,29)=0]
  │    ├── key: ()
  │    ├── fd: ()-->(27,29)
  │    ├── project
  │    │    ├── save-table-name: q14_project_3
  │    │    ├── columns: column26:26(float!null) column28:28(float!null)
+ │    │    ├── immutable
  │    │    ├── stats: [rows=82726.8788, distinct(26)=82726.8788, null(26)=0, distinct(28)=52210.2591, null(28)=0]
  │    │    ├── inner-join (hash)
  │    │    │    ├── save-table-name: q14_inner_join_4
@@ -83,8 +85,8 @@ project
  │    │    │    └── filters
  │    │    │         └── l_partkey:2 = p_partkey:17 [type=bool, outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ]), fd=(2)==(17), (17)==(2)]
  │    │    └── projections
- │    │         ├── CASE WHEN p_type:21 LIKE 'PROMO%' THEN l_extendedprice:6 * (1.0 - l_discount:7) ELSE 0.0 END [as=column26:26, type=float, outer=(6,7,21)]
- │    │         └── l_extendedprice:6 * (1.0 - l_discount:7) [as=column28:28, type=float, outer=(6,7)]
+ │    │         ├── CASE WHEN p_type:21 LIKE 'PROMO%' THEN l_extendedprice:6 * (1.0 - l_discount:7) ELSE 0.0 END [as=column26:26, type=float, outer=(6,7,21), immutable]
+ │    │         └── l_extendedprice:6 * (1.0 - l_discount:7) [as=column28:28, type=float, outer=(6,7), immutable]
  │    └── aggregations
  │         ├── sum [as=sum:27, type=float, outer=(26)]
  │         │    └── column26:26 [type=float]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q15
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q15
@@ -53,6 +53,7 @@ ORDER BY
 project
  ├── save-table-name: q15_project_1
  ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_phone:5(char!null) total_revenue:25(float!null)
+ ├── immutable
  ├── stats: [rows=3333.33333, distinct(1)=3306.66667, null(1)=0, distinct(2)=2834.3606, null(2)=0, distinct(3)=2834.80729, null(3)=0, distinct(5)=2834.80729, null(5)=0, distinct(25)=2100.04396, null(25)=0]
  ├── key: (1)
  ├── fd: (1)-->(2,3,5,25)
@@ -62,6 +63,7 @@ project
       ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_phone:5(char!null) l_suppkey:10(int!null) sum:25(float!null)
       ├── left ordering: +1
       ├── right ordering: +10
+      ├── immutable
       ├── stats: [rows=3333.33333, distinct(1)=3306.66667, null(1)=0, distinct(2)=2834.3606, null(2)=0, distinct(3)=2834.80729, null(3)=0, distinct(5)=2834.80729, null(5)=0, distinct(10)=3306.66667, null(10)=0, distinct(25)=2100.04396, null(25)=0]
       ├── key: (10)
       ├── fd: (1)-->(2,3,5), (10)-->(25), (1)==(10), (10)==(1)
@@ -78,6 +80,7 @@ project
       ├── sort
       │    ├── save-table-name: q15_sort_4
       │    ├── columns: l_suppkey:10(int!null) sum:25(float!null)
+      │    ├── immutable
       │    ├── stats: [rows=3306.66667, distinct(10)=3306.66667, null(10)=0, distinct(25)=3306.66667, null(25)=0]
       │    ├── key: (10)
       │    ├── fd: (10)-->(25)
@@ -85,6 +88,7 @@ project
       │    └── select
       │         ├── save-table-name: q15_select_5
       │         ├── columns: l_suppkey:10(int!null) sum:25(float!null)
+      │         ├── immutable
       │         ├── stats: [rows=3306.66667, distinct(10)=3306.66667, null(10)=0, distinct(25)=3306.66667, null(25)=0]
       │         ├── key: (10)
       │         ├── fd: (10)-->(25)
@@ -92,12 +96,14 @@ project
       │         │    ├── save-table-name: q15_group_by_6
       │         │    ├── columns: l_suppkey:10(int!null) sum:25(float!null)
       │         │    ├── grouping columns: l_suppkey:10(int!null)
+      │         │    ├── immutable
       │         │    ├── stats: [rows=9920, distinct(10)=9920, null(10)=0, distinct(25)=9920, null(25)=0]
       │         │    ├── key: (10)
       │         │    ├── fd: (10)-->(25)
       │         │    ├── project
       │         │    │    ├── save-table-name: q15_project_7
       │         │    │    ├── columns: column24:24(float!null) l_suppkey:10(int!null)
+      │         │    │    ├── immutable
       │         │    │    ├── stats: [rows=259635.063, distinct(10)=9920, null(10)=0, distinct(24)=259635.063, null(24)=0]
       │         │    │    ├── index-join lineitem
       │         │    │    │    ├── save-table-name: q15_index_join_8
@@ -117,18 +123,19 @@ project
       │         │    │    │         ├── key: (8,11)
       │         │    │    │         └── fd: (8,11)-->(18)
       │         │    │    └── projections
-      │         │    │         └── l_extendedprice:13 * (1.0 - l_discount:14) [as=column24:24, type=float, outer=(13,14)]
+      │         │    │         └── l_extendedprice:13 * (1.0 - l_discount:14) [as=column24:24, type=float, outer=(13,14), immutable]
       │         │    └── aggregations
       │         │         └── sum [as=sum:25, type=float, outer=(24)]
       │         │              └── column24:24 [type=float]
       │         └── filters
-      │              └── eq [type=bool, outer=(25), subquery, constraints=(/25: (/NULL - ])]
+      │              └── eq [type=bool, outer=(25), immutable, subquery, constraints=(/25: (/NULL - ])]
       │                   ├── sum:25 [type=float]
       │                   └── subquery [type=float]
       │                        └── scalar-group-by
       │                             ├── save-table-name: q15_scalar_group_by_10
       │                             ├── columns: max:44(float)
       │                             ├── cardinality: [1 - 1]
+      │                             ├── immutable
       │                             ├── stats: [rows=1, distinct(44)=1, null(44)=0]
       │                             ├── key: ()
       │                             ├── fd: ()-->(44)
@@ -136,12 +143,14 @@ project
       │                             │    ├── save-table-name: q15_group_by_11
       │                             │    ├── columns: l_suppkey:28(int!null) sum:43(float!null)
       │                             │    ├── grouping columns: l_suppkey:28(int!null)
+      │                             │    ├── immutable
       │                             │    ├── stats: [rows=9920, distinct(28)=9920, null(28)=0, distinct(43)=9920, null(43)=0]
       │                             │    ├── key: (28)
       │                             │    ├── fd: (28)-->(43)
       │                             │    ├── project
       │                             │    │    ├── save-table-name: q15_project_12
       │                             │    │    ├── columns: column42:42(float!null) l_suppkey:28(int!null)
+      │                             │    │    ├── immutable
       │                             │    │    ├── stats: [rows=259635.063, distinct(28)=9920, null(28)=0, distinct(42)=259635.063, null(42)=0]
       │                             │    │    ├── index-join lineitem
       │                             │    │    │    ├── save-table-name: q15_index_join_13
@@ -161,7 +170,7 @@ project
       │                             │    │    │         ├── key: (26,29)
       │                             │    │    │         └── fd: (26,29)-->(36)
       │                             │    │    └── projections
-      │                             │    │         └── l_extendedprice:31 * (1.0 - l_discount:32) [as=column42:42, type=float, outer=(31,32)]
+      │                             │    │         └── l_extendedprice:31 * (1.0 - l_discount:32) [as=column42:42, type=float, outer=(31,32), immutable]
       │                             │    └── aggregations
       │                             │         └── sum [as=sum:43, type=float, outer=(42)]
       │                             │              └── column42:42 [type=float]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q17
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q17
@@ -43,6 +43,7 @@ project
  ├── save-table-name: q17_project_1
  ├── columns: avg_yearly:45(float)
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── stats: [rows=1, distinct(45)=1, null(45)=0]
  ├── key: ()
  ├── fd: ()-->(45)
@@ -50,6 +51,7 @@ project
  │    ├── save-table-name: q17_scalar_group_by_2
  │    ├── columns: sum:44(float)
  │    ├── cardinality: [1 - 1]
+ │    ├── immutable
  │    ├── stats: [rows=1, distinct(44)=1, null(44)=0]
  │    ├── key: ()
  │    ├── fd: ()-->(44)
@@ -58,18 +60,21 @@ project
  │    │    ├── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) p_partkey:17(int!null) "?column?":43(float!null)
  │    │    ├── key columns: [1 4] = [1 4]
  │    │    ├── lookup columns are key
+ │    │    ├── immutable
  │    │    ├── stats: [rows=2008.02163, distinct(2)=199.999619, null(2)=0, distinct(5)=50, null(5)=0, distinct(6)=2005.84759, null(6)=0, distinct(17)=199.999619, null(17)=0, distinct(43)=199.999619, null(43)=0]
  │    │    ├── fd: (17)-->(43), (2)==(17), (17)==(2)
  │    │    ├── inner-join (lookup lineitem@l_pk)
  │    │    │    ├── save-table-name: q17_lookup_join_4
  │    │    │    ├── columns: l_orderkey:1(int!null) l_partkey:2(int!null) l_linenumber:4(int!null) p_partkey:17(int!null) "?column?":43(float)
  │    │    │    ├── key columns: [17] = [2]
+ │    │    │    ├── immutable
  │    │    │    ├── stats: [rows=6024.06489, distinct(1)=6012.21509, null(1)=0, distinct(2)=199.999619, null(2)=0, distinct(4)=7, null(4)=0, distinct(17)=199.999619, null(17)=0, distinct(43)=199.999619, null(43)=0]
  │    │    │    ├── key: (1,4)
  │    │    │    ├── fd: (17)-->(43), (1,4)-->(2), (2)==(17), (17)==(2)
  │    │    │    ├── project
  │    │    │    │    ├── save-table-name: q17_project_5
  │    │    │    │    ├── columns: "?column?":43(float) p_partkey:17(int!null)
+ │    │    │    │    ├── immutable
  │    │    │    │    ├── stats: [rows=199.999619, distinct(17)=199.999619, null(17)=0, distinct(43)=199.999619, null(43)=0]
  │    │    │    │    ├── key: (17)
  │    │    │    │    ├── fd: (17)-->(43)
@@ -122,7 +127,7 @@ project
  │    │    │    │    │         └── avg [as=avg:42, type=float, outer=(30)]
  │    │    │    │    │              └── l_quantity:30 [type=float]
  │    │    │    │    └── projections
- │    │    │    │         └── avg:42 * 0.2 [as="?column?":43, type=float, outer=(42)]
+ │    │    │    │         └── avg:42 * 0.2 [as="?column?":43, type=float, outer=(42), immutable]
  │    │    │    └── filters (true)
  │    │    └── filters
  │    │         └── l_quantity:5 < "?column?":43 [type=bool, outer=(5,43), constraints=(/5: (/NULL - ]; /43: (/NULL - ])]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q19
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q19
@@ -57,12 +57,14 @@ scalar-group-by
  ├── save-table-name: q19_scalar_group_by_1
  ├── columns: revenue:27(float)
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── stats: [rows=1, distinct(27)=1, null(27)=0]
  ├── key: ()
  ├── fd: ()-->(27)
  ├── project
  │    ├── save-table-name: q19_project_2
  │    ├── columns: column26:26(float!null)
+ │    ├── immutable
  │    ├── stats: [rows=71.4087386, distinct(26)=71.402791, null(26)=0]
  │    ├── inner-join (hash)
  │    │    ├── save-table-name: q19_inner_join_3
@@ -104,7 +106,7 @@ scalar-group-by
  │    │         ├── p_partkey:17 = l_partkey:2 [type=bool, outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ]), fd=(2)==(17), (17)==(2)]
  │    │         └── ((((((p_brand:20 = 'Brand#12') AND (p_container:23 IN ('SM BOX', 'SM CASE', 'SM PACK', 'SM PKG'))) AND (l_quantity:5 >= 1.0)) AND (l_quantity:5 <= 11.0)) AND (p_size:22 <= 5)) OR (((((p_brand:20 = 'Brand#23') AND (p_container:23 IN ('MED BAG', 'MED BOX', 'MED PACK', 'MED PKG'))) AND (l_quantity:5 >= 10.0)) AND (l_quantity:5 <= 20.0)) AND (p_size:22 <= 10))) OR (((((p_brand:20 = 'Brand#34') AND (p_container:23 IN ('LG BOX', 'LG CASE', 'LG PACK', 'LG PKG'))) AND (l_quantity:5 >= 20.0)) AND (l_quantity:5 <= 30.0)) AND (p_size:22 <= 15)) [type=bool, outer=(5,20,22,23), constraints=(/5: [/1.0 - /30.0]; /20: [/'Brand#12' - /'Brand#12'] [/'Brand#23' - /'Brand#23'] [/'Brand#34' - /'Brand#34']; /22: (/NULL - /15]; /23: [/'LG BOX' - /'LG BOX'] [/'LG CASE' - /'LG CASE'] [/'LG PACK' - /'LG PACK'] [/'LG PKG' - /'LG PKG'] [/'MED BAG' - /'MED BAG'] [/'MED BOX' - /'MED BOX'] [/'MED PACK' - /'MED PACK'] [/'MED PKG' - /'MED PKG'] [/'SM BOX' - /'SM BOX'] [/'SM CASE' - /'SM CASE'] [/'SM PACK' - /'SM PACK'] [/'SM PKG' - /'SM PKG'])]
  │    └── projections
- │         └── l_extendedprice:6 * (1.0 - l_discount:7) [as=column26:26, type=float, outer=(6,7)]
+ │         └── l_extendedprice:6 * (1.0 - l_discount:7) [as=column26:26, type=float, outer=(6,7), immutable]
  └── aggregations
       └── sum [as=sum:27, type=float, outer=(26)]
            └── column26:26 [type=float]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q20
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q20
@@ -60,22 +60,26 @@ ORDER BY
 sort
  ├── save-table-name: q20_sort_1
  ├── columns: s_name:2(char!null) s_address:3(varchar!null)
+ ├── immutable
  ├── stats: [rows=392.749612, distinct(2)=392.742232, null(2)=0, distinct(3)=392.749612, null(3)=0]
  ├── ordering: +2
  └── project
       ├── save-table-name: q20_project_2
       ├── columns: s_name:2(char!null) s_address:3(varchar!null)
+      ├── immutable
       ├── stats: [rows=392.749612, distinct(2)=392.742232, null(2)=0, distinct(3)=392.749612, null(3)=0]
       └── inner-join (hash)
            ├── save-table-name: q20_inner_join_3
            ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null) n_nationkey:8(int!null) n_name:9(char!null)
            ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+           ├── immutable
            ├── stats: [rows=392.749612, distinct(1)=392.685411, null(1)=0, distinct(2)=392.742232, null(2)=0, distinct(3)=392.749612, null(3)=0, distinct(4)=1, null(4)=0, distinct(8)=1, null(8)=0, distinct(9)=1, null(9)=0]
            ├── key: (1)
            ├── fd: ()-->(9), (1)-->(2-4), (4)==(8), (8)==(4)
            ├── semi-join (hash)
            │    ├── save-table-name: q20_semi_join_4
            │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null)
+           │    ├── immutable
            │    ├── stats: [rows=9818.7403, distinct(1)=9740.19038, null(1)=0, distinct(2)=9809.64703, null(2)=0, distinct(3)=9818.7403, null(3)=0, distinct(4)=25, null(4)=0]
            │    ├── key: (1)
            │    ├── fd: (1)-->(2-4)
@@ -92,11 +96,13 @@ sort
            │    ├── project
            │    │    ├── save-table-name: q20_project_6
            │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null)
+           │    │    ├── immutable
            │    │    ├── stats: [rows=36952.1991, distinct(12)=22217.3354, null(12)=0, distinct(13)=9740.19038, null(13)=0]
            │    │    ├── key: (12,13)
            │    │    └── project
            │    │         ├── save-table-name: q20_project_7
            │    │         ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) p_partkey:17(int!null)
+           │    │         ├── immutable
            │    │         ├── stats: [rows=36960.327, distinct(12)=22217.3354, null(12)=0, distinct(13)=9681.00153, null(13)=0, distinct(17)=22217.3354, null(17)=0]
            │    │         ├── key: (13,17)
            │    │         ├── fd: (12)==(17), (17)==(12)
@@ -104,12 +110,14 @@ sort
            │    │              ├── save-table-name: q20_inner_join_8
            │    │              ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) ps_availqty:14(int!null) p_partkey:17(int!null) p_name:18(varchar!null) sum:42(float)
            │    │              ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+           │    │              ├── immutable
            │    │              ├── stats: [rows=36960.327, distinct(12)=22217.3354, null(12)=0, distinct(13)=9681.00153, null(13)=0, distinct(14)=34508.432, null(14)=0, distinct(17)=22217.3354, null(17)=0, distinct(18)=17907.1379, null(18)=0, distinct(42)=34508.432, null(42)=0]
            │    │              ├── key: (13,17)
            │    │              ├── fd: (12,13)-->(14,42), (17)-->(18), (12)==(17), (17)==(12)
            │    │              ├── select
            │    │              │    ├── save-table-name: q20_select_9
            │    │              │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) ps_availqty:14(int!null) sum:42(float)
+           │    │              │    ├── immutable
            │    │              │    ├── stats: [rows=266100.667, distinct(12)=159991.77, null(12)=0, distinct(13)=9920, null(13)=0, distinct(14)=266100.667, null(14)=0, distinct(42)=266100.667, null(42)=0]
            │    │              │    ├── key: (12,13)
            │    │              │    ├── fd: (12,13)-->(14,42)
@@ -161,7 +169,7 @@ sort
            │    │              │    │         └── const-agg [as=ps_availqty:14, type=int, outer=(14)]
            │    │              │    │              └── ps_availqty:14 [type=int]
            │    │              │    └── filters
-           │    │              │         └── ps_availqty:14 > (sum:42 * 0.5) [type=bool, outer=(14,42), constraints=(/14: (/NULL - ])]
+           │    │              │         └── ps_availqty:14 > (sum:42 * 0.5) [type=bool, outer=(14,42), immutable, constraints=(/14: (/NULL - ])]
            │    │              ├── select
            │    │              │    ├── save-table-name: q20_select_15
            │    │              │    ├── columns: p_partkey:17(int!null) p_name:18(varchar!null)

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -386,6 +386,7 @@ SELECT * FROM a WHERE NOT(s ~ 'foo') AND NOT(s !~ 'foo') AND NOT(s ~* 'foo') AND
 ----
 select
  ├── columns: k:1!null i:2 f:3 s:4!null j:5
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
@@ -393,10 +394,10 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      ├── s:4 !~ 'foo' [outer=(4), constraints=(/4: (/NULL - ])]
-      ├── s:4 ~ 'foo' [outer=(4), constraints=(/4: (/NULL - ])]
-      ├── s:4 !~* 'foo' [outer=(4), constraints=(/4: (/NULL - ])]
-      └── s:4 ~* 'foo' [outer=(4), constraints=(/4: (/NULL - ])]
+      ├── s:4 !~ 'foo' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+      ├── s:4 ~ 'foo' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+      ├── s:4 !~* 'foo' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+      └── s:4 ~* 'foo' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
 norm expect-not=NegateComparison
 SELECT * FROM a WHERE
@@ -408,6 +409,7 @@ SELECT * FROM a WHERE
 ----
 select
  ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
@@ -415,12 +417,12 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      ├── NOT ('[1, 2]' @> j:5) [outer=(5)]
-      ├── NOT ('[3, 4]' @> j:5) [outer=(5)]
-      ├── NOT (j:5 ? 'foo') [outer=(5)]
-      ├── NOT (j:5 ?| ARRAY['foo']) [outer=(5)]
-      ├── NOT (j:5 ?& ARRAY['foo']) [outer=(5)]
-      └── NOT (ARRAY[i:2] && ARRAY[1]) [outer=(2)]
+      ├── NOT ('[1, 2]' @> j:5) [outer=(5), immutable]
+      ├── NOT ('[3, 4]' @> j:5) [outer=(5), immutable]
+      ├── NOT (j:5 ? 'foo') [outer=(5), immutable]
+      ├── NOT (j:5 ?| ARRAY['foo']) [outer=(5), immutable]
+      ├── NOT (j:5 ?& ARRAY['foo']) [outer=(5), immutable]
+      └── NOT (ARRAY[i:2] && ARRAY[1]) [outer=(2), immutable]
 
 # --------------------------------------------------
 # EliminateNot
@@ -476,6 +478,7 @@ SELECT * FROM a WHERE NOT (k >= i OR i < f OR k + i < f)
 ----
 select
  ├── columns: k:1!null i:2!null f:3!null s:4 j:5
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
@@ -485,7 +488,7 @@ select
  └── filters
       ├── k:1 < i:2 [outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
       ├── i:2 >= f:3 [outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ])]
-      └── f:3 <= (k:1 + i:2) [outer=(1-3), constraints=(/3: (/NULL - ])]
+      └── f:3 <= (k:1 + i:2) [outer=(1-3), immutable, constraints=(/3: (/NULL - ])]
 
 norm expect=(NegateOr,NegateComparison)
 SELECT * FROM a WHERE NOT (k >= i OR i < f OR (i > 10 OR i < 5 OR f > 1))

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -25,8 +25,10 @@ Initial expression
 ================================================================================
   project
    ├── columns: s:4
+   ├── immutable
    └── inner-join (cross)
         ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6!null y:7
+        ├── immutable
         ├── key: (1,6)
         ├── fd: (1)-->(2-5), (3,4)~~>(1,2,5), (6)-->(7)
         ├── scan a
@@ -38,16 +40,18 @@ Initial expression
         │    ├── key: (6)
         │    └── fd: (6)-->(7)
         └── filters
-             └── (k:1 = x:6) AND ((i:2 + 1) = 10) [outer=(1,2,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+             └── (k:1 = x:6) AND ((i:2 + 1) = 10) [outer=(1,2,6), immutable, constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
 ================================================================================
 NormalizeCmpPlusConst
   Cost: 15470.07
 ================================================================================
    project
     ├── columns: s:4
+    ├── immutable
     └── inner-join (cross)
   -      ├── columns: k:1!null i:2 f:3 s:4 j:5 x:6!null y:7
   +      ├── columns: k:1!null i:2!null f:3 s:4 j:5 x:6!null y:7
+         ├── immutable
          ├── key: (1,6)
          ├── fd: (1)-->(2-5), (3,4)~~>(1,2,5), (6)-->(7)
          ├── scan a
@@ -59,16 +63,18 @@ NormalizeCmpPlusConst
          │    ├── key: (6)
          │    └── fd: (6)-->(7)
          └── filters
-  -           └── (k:1 = x:6) AND ((i:2 + 1) = 10) [outer=(1,2,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
-  +           └── (k:1 = x:6) AND (i:2 = (10 - 1)) [outer=(1,2,6), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /6: (/NULL - ])]
+  -           └── (k:1 = x:6) AND ((i:2 + 1) = 10) [outer=(1,2,6), immutable, constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+  +           └── (k:1 = x:6) AND (i:2 = (10 - 1)) [outer=(1,2,6), immutable, constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /6: (/NULL - ])]
 ================================================================================
 FoldBinary
   Cost: 12203.40
 ================================================================================
    project
     ├── columns: s:4
+  - ├── immutable
     └── inner-join (cross)
          ├── columns: k:1!null i:2!null f:3 s:4 j:5 x:6!null y:7
+  -      ├── immutable
          ├── key: (1,6)
   -      ├── fd: (1)-->(2-5), (3,4)~~>(1,2,5), (6)-->(7)
   +      ├── fd: ()-->(2), (1)-->(3-5), (3,4)~~>(1,5), (6)-->(7)
@@ -81,7 +87,7 @@ FoldBinary
          │    ├── key: (6)
          │    └── fd: (6)-->(7)
          └── filters
-  -           └── (k:1 = x:6) AND (i:2 = (10 - 1)) [outer=(1,2,6), constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /6: (/NULL - ])]
+  -           └── (k:1 = x:6) AND (i:2 = (10 - 1)) [outer=(1,2,6), immutable, constraints=(/1: (/NULL - ]; /2: (/NULL - ]; /6: (/NULL - ])]
   +           └── (k:1 = x:6) AND (i:2 = 9) [outer=(1,2,6), constraints=(/1: (/NULL - ]; /2: [/9 - /9]; /6: (/NULL - ]), fd=()-->(2)]
 ================================================================================
 SimplifyJoinFilters

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -13,6 +13,7 @@ SELECT * FROM a WHERE 1+i<k AND k-1<=i AND i*i>k AND k/2>=i
 ----
 select
  ├── columns: k:1!null i:2!null f:3 s:4 j:5 d:6
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan a
@@ -20,9 +21,9 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      ├── k:1 > (i:2 + 1) [outer=(1,2), constraints=(/1: (/NULL - ])]
-      ├── i:2 >= (k:1 - 1) [outer=(1,2), constraints=(/2: (/NULL - ])]
-      ├── k:1 < (i:2 * i:2) [outer=(1,2), constraints=(/1: (/NULL - ])]
+      ├── k:1 > (i:2 + 1) [outer=(1,2), immutable, constraints=(/1: (/NULL - ])]
+      ├── i:2 >= (k:1 - 1) [outer=(1,2), immutable, constraints=(/2: (/NULL - ])]
+      ├── k:1 < (i:2 * i:2) [outer=(1,2), immutable, constraints=(/1: (/NULL - ])]
       └── i:2 <= (k:1 / 2) [outer=(1,2), constraints=(/2: (/NULL - ])]
 
 # --------------------------------------------------
@@ -33,6 +34,7 @@ SELECT * FROM a WHERE 5+1<i+k AND 5*5/3<=i*2 AND 5>i AND 'foo'>=s
 ----
 select
  ├── columns: k:1!null i:2!null f:3 s:4!null j:5 d:6
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan a
@@ -40,8 +42,8 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      ├── (i:2 + k:1) > 6 [outer=(1,2)]
-      ├── (i:2 * 2) >= 8.3333333333333333333 [outer=(2)]
+      ├── (i:2 + k:1) > 6 [outer=(1,2), immutable]
+      ├── (i:2 * 2) >= 8.3333333333333333333 [outer=(2), immutable]
       ├── i:2 < 5 [outer=(2), constraints=(/2: (/NULL - /4]; tight)]
       └── s:4 <= 'foo' [outer=(4), constraints=(/4: (/NULL - /'foo']; tight)]
 
@@ -50,6 +52,7 @@ SELECT * FROM a WHERE length('foo')+1<i+k AND length('bar')<=i*2
 ----
 select
  ├── columns: k:1!null i:2 f:3 s:4 j:5 d:6
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan a
@@ -57,8 +60,8 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      ├── (i:2 + k:1) > 4 [outer=(1,2)]
-      └── (i:2 * 2) >= 3 [outer=(2)]
+      ├── (i:2 + k:1) > 4 [outer=(1,2), immutable]
+      └── (i:2 * 2) >= 3 [outer=(2), immutable]
 
 # Impure function should not be considered constant.
 norm expect-not=CommuteConstInequality
@@ -102,7 +105,7 @@ select
  └── filters
       ├── (i:2 >= 2) AND (i:2 > 6) [outer=(2), constraints=(/2: [/7 - ]; tight)]
       ├── k:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
-      ├── (f:3 + f:3) < 3.0 [outer=(3)]
+      ├── (f:3 + f:3) < 3.0 [outer=(3), immutable]
       └── i:2::INTERVAL >= '01:00:00' [outer=(2), immutable]
 
 # Try case that should not match pattern because Minus overload is not defined.
@@ -148,7 +151,7 @@ select
  └── filters
       ├── (i:2 >= 4) AND (i:2 < 14) [outer=(2), constraints=(/2: [/4 - /13]; tight)]
       ├── k:1 = 3 [outer=(1), constraints=(/1: [/3 - /3]; tight), fd=()-->(1)]
-      ├── (f:3 + f:3) < 7.0 [outer=(3)]
+      ├── (f:3 + f:3) < 7.0 [outer=(3), immutable]
       ├── (f:3 + i:2::FLOAT8) >= 110.0 [outer=(2,3), immutable]
       └── d:6 >= '2018-09-30' [outer=(6), constraints=(/6: [/'2018-09-30' - ]; tight)]
 
@@ -194,7 +197,7 @@ select
  └── filters
       ├── (i:2 >= -2) AND (i:2 > 10) [outer=(2), constraints=(/2: [/11 - ]; tight)]
       ├── k:1 = -1 [outer=(1), constraints=(/1: [/-1 - /-1]; tight), fd=()-->(1)]
-      ├── (f:3 + f:3) > -3.0 [outer=(3)]
+      ├── (f:3 + f:3) > -3.0 [outer=(3), immutable]
       └── (f:3 + i:2::FLOAT8) <= -90.0 [outer=(2,3), immutable]
 
 # Try case that should not match pattern because Minus overload is not defined.
@@ -203,6 +206,7 @@ SELECT * FROM a WHERE '[1, 2]'::json - i = '[1]'
 ----
 select
  ├── columns: k:1!null i:2 f:3 s:4 j:5 d:6
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan a
@@ -210,7 +214,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      └── ('[1, 2]' - i:2) = '[1]' [outer=(2)]
+      └── ('[1, 2]' - i:2) = '[1]' [outer=(2), immutable]
 
 # --------------------------------------------------
 # NormalizeTupleEquality

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -1051,18 +1051,22 @@ SELECT i*i/5=ANY(SELECT y FROM xy WHERE x=k) AS r FROM a
 ----
 project
  ├── columns: r:8
+ ├── immutable
  ├── group-by
  │    ├── columns: k:1!null scalar:9 bool_or:11
  │    ├── grouping columns: k:1!null
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(9,11)
  │    ├── left-join (hash)
  │    │    ├── columns: k:1!null x:6 y:7 scalar:9 notnull:10
  │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    │    ├── immutable
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(6,7,9,10), (6)-->(7), (7)~~>(10)
  │    │    ├── project
  │    │    │    ├── columns: scalar:9 k:1!null
+ │    │    │    ├── immutable
  │    │    │    ├── key: (1)
  │    │    │    ├── fd: (1)-->(9)
  │    │    │    ├── scan a
@@ -1070,7 +1074,7 @@ project
  │    │    │    │    ├── key: (1)
  │    │    │    │    └── fd: (1)-->(2)
  │    │    │    └── projections
- │    │    │         └── (i:2 * i:2) / 5 [as=scalar:9, outer=(2)]
+ │    │    │         └── (i:2 * i:2) / 5 [as=scalar:9, outer=(2), immutable]
  │    │    ├── project
  │    │    │    ├── columns: notnull:10!null x:6!null y:7
  │    │    │    ├── key: (6)
@@ -1090,7 +1094,7 @@ project
  │         └── const-agg [as=scalar:9, outer=(9)]
  │              └── scalar:9
  └── projections
-      └── CASE WHEN bool_or:11 AND (scalar:9 IS NOT NULL) THEN true WHEN bool_or:11 IS NULL THEN false END [as=r:8, outer=(9,11)]
+      └── CASE WHEN bool_or:11 AND (scalar:9 IS NOT NULL) THEN true WHEN bool_or:11 IS NULL THEN false END [as=r:8, outer=(9,11), immutable]
 
 # --------------------------------------------------
 # TryDecorrelateProject
@@ -1197,9 +1201,11 @@ WHERE EXISTS
 ----
 project
  ├── columns: k:1!null
+ ├── immutable
  ├── key: (1)
  └── semi-join-apply
       ├── columns: k:1!null i:2
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2)
       ├── scan a
@@ -1210,12 +1216,14 @@ project
       │    ├── columns: x:6!null plus:10
       │    ├── outer: (2)
       │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+      │    ├── immutable
       │    ├── scan xy
       │    │    ├── columns: x:6!null
       │    │    └── key: (6)
       │    ├── project
       │    │    ├── columns: plus:10!null
       │    │    ├── outer: (2)
+      │    │    ├── immutable
       │    │    ├── select
       │    │    │    ├── columns: u:8!null
       │    │    │    ├── outer: (2)
@@ -1226,7 +1234,7 @@ project
       │    │    │    └── filters
       │    │    │         └── i:2 = 5 [outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
       │    │    └── projections
-      │    │         └── u:8 + 1 [as=plus:10, outer=(8)]
+      │    │         └── u:8 + 1 [as=plus:10, outer=(8), immutable]
       │    └── filters
       │         └── x:6 = plus:10 [outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
       └── filters (true)
@@ -1241,9 +1249,11 @@ WHERE EXISTS
 ----
 project
  ├── columns: k:1!null
+ ├── immutable
  ├── key: (1)
  └── semi-join-apply
       ├── columns: k:1!null i:2
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2)
       ├── scan a
@@ -1254,12 +1264,14 @@ project
       │    ├── columns: x:6 plus:10
       │    ├── outer: (2)
       │    ├── multiplicity: left-rows(one-or-more), right-rows(exactly-one)
+      │    ├── immutable
       │    ├── scan xy
       │    │    ├── columns: x:6!null
       │    │    └── key: (6)
       │    ├── project
       │    │    ├── columns: plus:10!null
       │    │    ├── outer: (2)
+      │    │    ├── immutable
       │    │    ├── select
       │    │    │    ├── columns: u:8!null
       │    │    │    ├── outer: (2)
@@ -1270,7 +1282,7 @@ project
       │    │    │    └── filters
       │    │    │         └── i:2 = 5 [outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
       │    │    └── projections
-      │    │         └── u:8 + 1 [as=plus:10, outer=(8)]
+      │    │         └── u:8 + 1 [as=plus:10, outer=(8), immutable]
       │    └── filters
       │         └── x:6 = plus:10 [outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
       └── filters (true)
@@ -1283,14 +1295,17 @@ SELECT (SELECT sum(y + v) FROM xy, uv WHERE x=u AND x=k) FROM a
 ----
 project
  ├── columns: sum:12
+ ├── immutable
  ├── group-by
  │    ├── columns: k:1!null sum:11
  │    ├── grouping columns: k:1!null
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(11)
  │    ├── left-join (hash)
  │    │    ├── columns: k:1!null x:6 column10:10
  │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    │    ├── immutable
  │    │    ├── key: (1)
  │    │    ├── fd: (6)-->(10), (1)-->(6,10)
  │    │    ├── scan a
@@ -1298,6 +1313,7 @@ project
  │    │    │    └── key: (1)
  │    │    ├── project
  │    │    │    ├── columns: column10:10 x:6!null
+ │    │    │    ├── immutable
  │    │    │    ├── key: (6)
  │    │    │    ├── fd: (6)-->(10)
  │    │    │    ├── inner-join (hash)
@@ -1316,7 +1332,7 @@ project
  │    │    │    │    └── filters
  │    │    │    │         └── x:6 = u:8 [outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
  │    │    │    └── projections
- │    │    │         └── y:7 + v:9 [as=column10:10, outer=(7,9)]
+ │    │    │         └── y:7 + v:9 [as=column10:10, outer=(7,9), immutable]
  │    │    └── filters
  │    │         └── x:6 = k:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    └── aggregations
@@ -4075,18 +4091,22 @@ SELECT i*i/100 < ALL(SELECT y FROM xy WHERE x=k) AS r, s FROM a
 ----
 project
  ├── columns: r:8 s:4
+ ├── immutable
  ├── group-by
  │    ├── columns: k:1!null s:4 scalar:9 bool_or:11
  │    ├── grouping columns: k:1!null
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(4,9,11)
  │    ├── left-join (hash)
  │    │    ├── columns: k:1!null s:4 x:6 y:7 scalar:9 notnull:10
  │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    │    ├── immutable
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(4,6,7,9,10), (6)-->(7), (7)~~>(10)
  │    │    ├── project
  │    │    │    ├── columns: scalar:9 k:1!null s:4
+ │    │    │    ├── immutable
  │    │    │    ├── key: (1)
  │    │    │    ├── fd: (1)-->(4,9)
  │    │    │    ├── scan a
@@ -4094,7 +4114,7 @@ project
  │    │    │    │    ├── key: (1)
  │    │    │    │    └── fd: (1)-->(2,4)
  │    │    │    └── projections
- │    │    │         └── (i:2 * i:2) / 100 [as=scalar:9, outer=(2)]
+ │    │    │         └── (i:2 * i:2) / 100 [as=scalar:9, outer=(2), immutable]
  │    │    ├── project
  │    │    │    ├── columns: notnull:10!null x:6!null y:7
  │    │    │    ├── key: (6)
@@ -4116,7 +4136,7 @@ project
  │         └── const-agg [as=scalar:9, outer=(9)]
  │              └── scalar:9
  └── projections
-      └── NOT CASE WHEN bool_or:11 AND (scalar:9 IS NOT NULL) THEN true WHEN bool_or:11 IS NULL THEN false END [as=r:8, outer=(9,11)]
+      └── NOT CASE WHEN bool_or:11 AND (scalar:9 IS NOT NULL) THEN true WHEN bool_or:11 IS NULL THEN false END [as=r:8, outer=(9,11), immutable]
 
 # Regress issue #32270: Panic when expression contains both correlated and
 # uncorrelated subquery.
@@ -4458,8 +4478,10 @@ SELECT i, y FROM a INNER JOIN xy ON (SELECT k+1) = x
 ----
 project
  ├── columns: i:2 y:7
+ ├── immutable
  └── inner-join-apply
       ├── columns: k:1!null i:2 x:6!null y:7 "?column?":8
+      ├── immutable
       ├── key: (1,6)
       ├── fd: (1)-->(2), (1,6)-->(7,8), (6)==(8), (8)==(6)
       ├── scan a
@@ -4470,6 +4492,7 @@ project
       │    ├── columns: x:6!null y:7 "?column?":8
       │    ├── outer: (1)
       │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+      │    ├── immutable
       │    ├── key: (6)
       │    ├── fd: ()-->(8), (6)-->(7)
       │    ├── scan xy
@@ -4480,6 +4503,7 @@ project
       │    │    ├── columns: "?column?":8
       │    │    ├── outer: (1)
       │    │    ├── cardinality: [1 - 1]
+      │    │    ├── immutable
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(8)
       │    │    └── (k:1 + 1,)
@@ -4608,14 +4632,17 @@ SELECT (VALUES ((SELECT i+1 AS r)), (10), ((SELECT k+1 AS s))) FROM a
 ----
 project
  ├── columns: column1:9
+ ├── immutable
  ├── ensure-distinct-on
  │    ├── columns: k:1!null column1:8
  │    ├── grouping columns: k:1!null
  │    ├── error: "more than one row returned by a subquery used as an expression"
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(8)
  │    ├── inner-join-apply
  │    │    ├── columns: k:1!null i:2 r:6 s:7 column1:8
+ │    │    ├── immutable
  │    │    ├── fd: (1)-->(2)
  │    │    ├── scan a
  │    │    │    ├── columns: k:1!null i:2
@@ -4625,18 +4652,21 @@ project
  │    │    │    ├── columns: r:6 s:7 column1:8
  │    │    │    ├── outer: (1,2)
  │    │    │    ├── cardinality: [3 - 3]
+ │    │    │    ├── immutable
  │    │    │    ├── fd: ()-->(6,7)
  │    │    │    ├── inner-join (cross)
  │    │    │    │    ├── columns: r:6 s:7
  │    │    │    │    ├── outer: (1,2)
  │    │    │    │    ├── cardinality: [1 - 1]
  │    │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
+ │    │    │    │    ├── immutable
  │    │    │    │    ├── key: ()
  │    │    │    │    ├── fd: ()-->(6,7)
  │    │    │    │    ├── values
  │    │    │    │    │    ├── columns: r:6
  │    │    │    │    │    ├── outer: (2)
  │    │    │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    │    │    ├── immutable
  │    │    │    │    │    ├── key: ()
  │    │    │    │    │    ├── fd: ()-->(6)
  │    │    │    │    │    └── (i:2 + 1,)
@@ -4644,6 +4674,7 @@ project
  │    │    │    │    │    ├── columns: s:7
  │    │    │    │    │    ├── outer: (1)
  │    │    │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    │    │    ├── immutable
  │    │    │    │    │    ├── key: ()
  │    │    │    │    │    ├── fd: ()-->(7)
  │    │    │    │    │    └── (k:1 + 1,)

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -243,6 +243,7 @@ SELECT 9223372036854775800::INT + 9223372036854775800::INT
 values
  ├── columns: "?column?":1
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(1)
  └── (9223372036854775800 + 9223372036854775800,)
@@ -265,6 +266,7 @@ SELECT (-9223372036854775800)::INT - 9223372036854775800::INT
 values
  ├── columns: "?column?":1
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(1)
  └── (-9223372036854775800 - 9223372036854775800,)
@@ -287,6 +289,7 @@ SELECT 9223372036854775800::INT * 9223372036854775800::INT
 values
  ├── columns: "?column?":1
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(1)
  └── (9223372036854775800 * 9223372036854775800,)
@@ -332,6 +335,7 @@ SELECT B'01' # B'11001001010101'
 values
  ├── columns: "?column?":1
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(1)
  └── (B'01' # B'11001001010101',)
@@ -354,6 +358,7 @@ SELECT B'01' | B'11001001010101'
 values
  ├── columns: "?column?":1
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(1)
  └── (B'01' | B'11001001010101',)
@@ -455,6 +460,7 @@ SELECT -((-9223372036854775808)::int)
 values
  ├── columns: "?column?":1(int)
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── stats: [rows=1]
  ├── cost: 0.02
  ├── key: ()
@@ -845,10 +851,11 @@ SELECT ARRAY[i, i + 1][2] FROM a
 ----
 project
  ├── columns: array:7
+ ├── immutable
  ├── scan a
  │    └── columns: i:2
  └── projections
-      └── i:2 + 1 [as=array:7, outer=(2)]
+      └── i:2 + 1 [as=array:7, outer=(2), immutable]
 
 # Fold when input is a DArray constant.
 norm expect=FoldIndirection

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -700,26 +700,30 @@ SELECT (SELECT y FROM xy WHERE x+y=k) FROM a
 ----
 project
  ├── columns: y:8
+ ├── immutable
  ├── ensure-distinct-on
  │    ├── columns: k:1!null xy.y:7
  │    ├── grouping columns: k:1!null
  │    ├── error: "more than one row returned by a subquery used as an expression"
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(7)
  │    ├── left-join (hash)
  │    │    ├── columns: k:1!null xy.y:7 column9:9
  │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+ │    │    ├── immutable
  │    │    ├── scan a
  │    │    │    ├── columns: k:1!null
  │    │    │    └── key: (1)
  │    │    ├── project
  │    │    │    ├── columns: column9:9 xy.y:7
+ │    │    │    ├── immutable
  │    │    │    ├── scan xy
  │    │    │    │    ├── columns: x:6!null xy.y:7
  │    │    │    │    ├── key: (6)
  │    │    │    │    └── fd: (6)-->(7)
  │    │    │    └── projections
- │    │    │         └── x:6 + xy.y:7 [as=column9:9, outer=(6,7)]
+ │    │    │         └── x:6 + xy.y:7 [as=column9:9, outer=(6,7), immutable]
  │    │    └── filters
  │    │         └── k:1 = column9:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
  │    └── aggregations
@@ -857,18 +861,21 @@ SELECT min(s) FROM (SELECT i+1 AS i2, s FROM a) GROUP BY i2
 ----
 project
  ├── columns: min:7!null
+ ├── immutable
  └── group-by
       ├── columns: i2:6!null min:7!null
       ├── grouping columns: i2:6!null
+      ├── immutable
       ├── key: (6)
       ├── fd: (6)-->(7)
       ├── project
       │    ├── columns: i2:6!null s:4!null
+      │    ├── immutable
       │    ├── scan a
       │    │    ├── columns: i:2!null s:4!null
       │    │    └── key: (2,4)
       │    └── projections
-      │         └── i:2 + 1 [as=i2:6, outer=(2)]
+      │         └── i:2 + 1 [as=i2:6, outer=(2), immutable]
       └── aggregations
            └── min [as=min:7, outer=(4)]
                 └── s:4
@@ -1925,6 +1932,7 @@ WHERE x > 100 OR b > 100
 ----
 project
  ├── columns: x:1!null y:2!null z:3!null a:4 b:5 c:6 "?column?":7!null
+ ├── immutable
  ├── fd: (1)-->(7)
  ├── select
  │    ├── columns: column1:1!null column2:2!null column3:3!null a:4 b:5 c:6
@@ -1947,7 +1955,7 @@ project
  │    └── filters
  │         └── (column1:1 > 100) OR (b:5 > 100) [outer=(1,5)]
  └── projections
-      └── column1:1 + 1 [as="?column?":7, outer=(1)]
+      └── column1:1 + 1 [as="?column?":7, outer=(1), immutable]
 
 # Right input of left join does not have a key, so left side may have dups.
 norm expect-not=EliminateDistinctOnValues
@@ -2025,11 +2033,13 @@ distinct-on
  ├── columns: x:1!null y:2!null
  ├── grouping columns: y:2!null
  ├── cardinality: [1 - 2]
+ ├── immutable
  ├── key: (2)
  ├── fd: (1)-->(2), (2)-->(1)
  ├── project
  │    ├── columns: y:2!null column1:1!null
  │    ├── cardinality: [2 - 2]
+ │    ├── immutable
  │    ├── fd: (1)-->(2)
  │    ├── values
  │    │    ├── columns: column1:1!null
@@ -2037,7 +2047,7 @@ distinct-on
  │    │    ├── (1,)
  │    │    └── (2,)
  │    └── projections
- │         └── column1:1 + 1 [as=y:2, outer=(1)]
+ │         └── column1:1 + 1 [as=y:2, outer=(1), immutable]
  └── aggregations
       └── first-agg [as=column1:1, outer=(1)]
            └── column1:1

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -103,7 +103,7 @@ select
  │    ├── (0.00,)
  │    └── (0.000,)
  └── filters
-      ├── column1:1 = 0 [outer=(1), constraints=(/1: [/0 - /0]; tight), fd=()-->(1)]
+      ├── column1:1 = 0 [outer=(1), immutable, constraints=(/1: [/0 - /0]; tight), fd=()-->(1)]
       └── column1:1::STRING = '0.00' [outer=(1), immutable]
 
 # The rule should trigger, but not inline the composite type.
@@ -122,7 +122,7 @@ select
  │    ├── (0.00, 'b')
  │    └── (0.000, 'b')
  └── filters
-      ├── column1:1 = 0 [outer=(1), constraints=(/1: [/0 - /0]; tight), fd=()-->(1)]
+      ├── column1:1 = 0 [outer=(1), immutable, constraints=(/1: [/0 - /0]; tight), fd=()-->(1)]
       ├── column1:1::STRING = '0.00' [outer=(1), immutable]
       └── column2:2 = 'b' [outer=(2), constraints=(/2: [/'b' - /'b']; tight), fd=()-->(2)]
 
@@ -196,7 +196,7 @@ SELECT one+two+three+four FROM (VALUES (1, $1:::int, 2, $2:::int)) AS t(one, two
 project
  ├── columns: "?column?":5
  ├── cardinality: [1 - 1]
- ├── has-placeholder
+ ├── immutable, has-placeholder
  ├── key: ()
  ├── fd: ()-->(5)
  ├── values
@@ -207,7 +207,7 @@ project
  │    ├── fd: ()-->(2,4)
  │    └── ($1, $2)
  └── projections
-      └── column4:4 + ((column2:2 + 1) + 2) [as="?column?":5, outer=(2,4)]
+      └── column4:4 + ((column2:2 + 1) + 2) [as="?column?":5, outer=(2,4), immutable]
 
 # Multiple constant columns, multiple refs to each, interspersed with other
 # columns.
@@ -258,13 +258,14 @@ SELECT one+two FROM (VALUES (1, 2), (3, 4)) AS t(one, two)
 project
  ├── columns: "?column?":3!null
  ├── cardinality: [2 - 2]
+ ├── immutable
  ├── values
  │    ├── columns: column1:1!null column2:2!null
  │    ├── cardinality: [2 - 2]
  │    ├── (1, 2)
  │    └── (3, 4)
  └── projections
-      └── column1:1 + column2:2 [as="?column?":3, outer=(1,2)]
+      └── column1:1 + column2:2 [as="?column?":3, outer=(1,2), immutable]
 
 # --------------------------------------------------
 # InlineSelectConstants
@@ -456,16 +457,18 @@ SELECT * FROM (SELECT k*2+1 AS expr FROM a) a WHERE expr > 10
 ----
 project
  ├── columns: expr:6!null
+ ├── immutable
  ├── select
  │    ├── columns: k:1!null
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── scan a
  │    │    ├── columns: k:1!null
  │    │    └── key: (1)
  │    └── filters
- │         └── (k:1 * 2) > 9 [outer=(1)]
+ │         └── (k:1 * 2) > 9 [outer=(1), immutable]
  └── projections
-      └── (k:1 * 2) + 1 [as=expr:6, outer=(1)]
+      └── (k:1 * 2) + 1 [as=expr:6, outer=(1), immutable]
 
 # Inline boolean logic.
 norm expect=PushSelectIntoInlinableProject
@@ -505,14 +508,16 @@ SELECT * FROM (SELECT f+1 AS expr FROM a) a WHERE expr=expr
 ----
 project
  ├── columns: expr:6
+ ├── immutable
  ├── select
  │    ├── columns: f:3
+ │    ├── immutable
  │    ├── scan a
  │    │    └── columns: f:3
  │    └── filters
- │         └── (f:3 + 1.0) IS DISTINCT FROM CAST(NULL AS FLOAT8) [outer=(3)]
+ │         └── (f:3 + 1.0) IS DISTINCT FROM CAST(NULL AS FLOAT8) [outer=(3), immutable]
  └── projections
-      └── f:3 + 1.0 [as=expr:6, outer=(3)]
+      └── f:3 + 1.0 [as=expr:6, outer=(3), immutable]
 
 # Use outer references in both inlined expression and in referencing expression.
 norm expect=PushSelectIntoInlinableProject
@@ -520,6 +525,7 @@ SELECT * FROM a WHERE EXISTS(SELECT * FROM (SELECT (x-i) AS expr FROM xy) WHERE 
 ----
 semi-join (cross)
  ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
@@ -530,7 +536,7 @@ semi-join (cross)
  │    ├── columns: x:6!null
  │    └── key: (6)
  └── filters
-      └── (x:6 - i:2) > (i:2 * i:2) [outer=(2,6)]
+      └── (x:6 - i:2) > (i:2 * i:2) [outer=(2,6), immutable]
 
 exec-ddl
 CREATE TABLE crdb_internal.zones (
@@ -596,13 +602,14 @@ project
       │    ├── limit hint: 107.00
       │    ├── project
       │    │    ├── columns: c0:6!null c1:7!null
+      │    │    ├── immutable
       │    │    ├── limit hint: 321.00
       │    │    ├── scan crdb_internal.public.zones
       │    │    │    ├── columns: crdb_internal.public.zones.zone_id:1!null
       │    │    │    └── limit hint: 321.00
       │    │    └── projections
-      │    │         ├── crdb_internal.public.zones.zone_id:1 + 1 [as=c0:6, outer=(1)]
-      │    │         └── crdb_internal.public.zones.zone_id:1 + 2 [as=c1:7, outer=(1)]
+      │    │         ├── crdb_internal.public.zones.zone_id:1 + 1 [as=c0:6, outer=(1), immutable]
+      │    │         └── crdb_internal.public.zones.zone_id:1 + 2 [as=c1:7, outer=(1), immutable]
       │    └── filters
       │         └── le [outer=(6,7), stable+volatile, side-effects, correlated-subquery]
       │              ├── case
@@ -636,13 +643,14 @@ SELECT NOT(expr), i+1 AS r FROM (SELECT k=1 AS expr, i FROM a)
 ----
 project
  ├── columns: "?column?":7!null r:8
+ ├── immutable
  ├── scan a
  │    ├── columns: k:1!null i:2
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── projections
       ├── k:1 != 1 [as="?column?":7, outer=(1)]
-      └── i:2 + 1 [as=r:8, outer=(2)]
+      └── i:2 + 1 [as=r:8, outer=(2), immutable]
 
 # Multiple synthesized column references to same inner passthrough column
 # (should still inline).
@@ -651,14 +659,15 @@ SELECT x+1, x+2, y1+2 FROM (SELECT x, y+1 AS y1 FROM xy)
 ----
 project
  ├── columns: "?column?":4!null "?column?":5!null "?column?":6
+ ├── immutable
  ├── scan xy
  │    ├── columns: x:1!null y:2
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── projections
-      ├── x:1 + 1 [as="?column?":4, outer=(1)]
-      ├── x:1 + 2 [as="?column?":5, outer=(1)]
-      └── (y:2 + 1) + 2 [as="?column?":6, outer=(2)]
+      ├── x:1 + 1 [as="?column?":4, outer=(1), immutable]
+      ├── x:1 + 2 [as="?column?":5, outer=(1), immutable]
+      └── (y:2 + 1) + 2 [as="?column?":6, outer=(2), immutable]
 
 # Synthesized and passthrough references to same inner passthrough column
 # (should still inline).
@@ -667,6 +676,7 @@ SELECT x+y1 FROM (SELECT x, y+1 AS y1 FROM xy) ORDER BY x
 ----
 project
  ├── columns: "?column?":4  [hidden: x:1!null]
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(4)
  ├── ordering: +1
@@ -676,7 +686,7 @@ project
  │    ├── fd: (1)-->(2)
  │    └── ordering: +1
  └── projections
-      └── x:1 + (y:2 + 1) [as="?column?":4, outer=(1,2)]
+      └── x:1 + (y:2 + 1) [as="?column?":4, outer=(1,2), immutable]
 
 # Inline multiple expressions.
 norm expect=InlineProjectInProject
@@ -684,13 +694,14 @@ SELECT expr+1 AS r, i, expr2 || 'bar' AS s FROM (SELECT k+1 AS expr, s || 'foo' 
 ----
 project
  ├── columns: r:8!null i:2 s:9
+ ├── immutable
  ├── scan a
  │    ├── columns: k:1!null i:2 a.s:4
  │    ├── key: (1)
  │    └── fd: (1)-->(2,4)
  └── projections
-      ├── (k:1 + 1) + 1 [as=r:8, outer=(1)]
-      └── (a.s:4 || 'foo') || 'bar' [as=s:9, outer=(4)]
+      ├── (k:1 + 1) + 1 [as=r:8, outer=(1), immutable]
+      └── (a.s:4 || 'foo') || 'bar' [as=s:9, outer=(4), immutable]
 
 # Don't inline when there are multiple references.
 norm expect-not=InlineProjectInProject
@@ -698,16 +709,18 @@ SELECT expr, expr*2 AS r FROM (SELECT k+1 AS expr FROM a)
 ----
 project
  ├── columns: expr:6!null r:7!null
+ ├── immutable
  ├── fd: (6)-->(7)
  ├── project
  │    ├── columns: expr:6!null
+ │    ├── immutable
  │    ├── scan a
  │    │    ├── columns: k:1!null
  │    │    └── key: (1)
  │    └── projections
- │         └── k:1 + 1 [as=expr:6, outer=(1)]
+ │         └── k:1 + 1 [as=expr:6, outer=(1), immutable]
  └── projections
-      └── expr:6 * 2 [as=r:7, outer=(6)]
+      └── expr:6 * 2 [as=r:7, outer=(6), immutable]
 
 # Uncorrelated subquery should not block inlining.
 norm expect=InlineProjectInProject
@@ -715,6 +728,7 @@ SELECT EXISTS(SELECT * FROM xy WHERE x=1 OR x=2), expr*2 AS r FROM (SELECT k+1 A
 ----
 project
  ├── columns: exists:9 r:10!null
+ ├── immutable
  ├── fd: ()-->(9)
  ├── scan a
  │    ├── columns: k:1!null
@@ -740,7 +754,7 @@ project
       │         │    └── filters
       │         │         └── (x:7 = 1) OR (x:7 = 2) [outer=(7), constraints=(/7: [/1 - /1] [/2 - /2]; tight)]
       │         └── 1
-      └── (k:1 + 1) * 2 [as=r:10, outer=(1)]
+      └── (k:1 + 1) * 2 [as=r:10, outer=(1), immutable]
 
 # Correlated subquery should be hoisted as usual.
 norm expect=InlineProjectInProject
@@ -748,26 +762,31 @@ SELECT EXISTS(SELECT * FROM xy WHERE expr<0) FROM (SELECT k+1 AS expr FROM a)
 ----
 project
  ├── columns: exists:9!null
+ ├── immutable
  ├── group-by
  │    ├── columns: true_agg:11 rownum:13!null
  │    ├── grouping columns: rownum:13!null
+ │    ├── immutable
  │    ├── key: (13)
  │    ├── fd: (13)-->(11)
  │    ├── left-join (cross)
  │    │    ├── columns: expr:6!null true:10 rownum:13!null
  │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+ │    │    ├── immutable
  │    │    ├── fd: (13)-->(6)
  │    │    ├── ordinality
  │    │    │    ├── columns: expr:6!null rownum:13!null
+ │    │    │    ├── immutable
  │    │    │    ├── key: (13)
  │    │    │    ├── fd: (13)-->(6)
  │    │    │    └── project
  │    │    │         ├── columns: expr:6!null
+ │    │    │         ├── immutable
  │    │    │         ├── scan a
  │    │    │         │    ├── columns: k:1!null
  │    │    │         │    └── key: (1)
  │    │    │         └── projections
- │    │    │              └── k:1 + 1 [as=expr:6, outer=(1)]
+ │    │    │              └── k:1 + 1 [as=expr:6, outer=(1), immutable]
  │    │    ├── project
  │    │    │    ├── columns: true:10!null
  │    │    │    ├── fd: ()-->(10)
@@ -788,6 +807,7 @@ SELECT c FROM (SELECT k+2 AS c FROM a) AS t WHERE c > 2;
 ----
 project
  ├── columns: c:6!null
+ ├── immutable
  ├── select
  │    ├── columns: k:1!null
  │    ├── key: (1)
@@ -797,4 +817,4 @@ project
  │    └── filters
  │         └── k:1 > 0 [outer=(1), constraints=(/1: [/1 - ]; tight)]
  └── projections
-      └── k:1 + 2 [as=c:6, outer=(1)]
+      └── k:1 + 2 [as=c:6, outer=(1), immutable]

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -346,10 +346,12 @@ SELECT * FROM a INNER JOIN b ON a.k=b.x AND a.k + b.y > 5 AND b.x * a.i = 3
 inner-join (hash)
  ├── columns: k:1!null i:2 f:3!null s:4 j:5 x:6!null y:7
  ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ ├── immutable
  ├── key: (6)
  ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
  ├── select
  │    ├── columns: k:1!null i:2 f:3!null s:4 j:5
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
  │    ├── scan a
@@ -357,9 +359,10 @@ inner-join (hash)
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2-5)
  │    └── filters
- │         └── (k:1 * i:2) = 3 [outer=(1,2)]
+ │         └── (k:1 * i:2) = 3 [outer=(1,2), immutable]
  ├── select
  │    ├── columns: x:6!null y:7
+ │    ├── immutable
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
  │    ├── scan b
@@ -367,7 +370,7 @@ inner-join (hash)
  │    │    ├── key: (6)
  │    │    └── fd: (6)-->(7)
  │    └── filters
- │         └── (x:6 + y:7) > 5 [outer=(6,7)]
+ │         └── (x:6 + y:7) > 5 [outer=(6,7), immutable]
  └── filters
       └── k:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
@@ -415,10 +418,12 @@ SELECT * FROM a WHERE EXISTS(
 ----
 semi-join (hash)
  ├── columns: k:1!null i:2 f:3!null s:4 j:5
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── select
  │    ├── columns: k:1!null i:2 f:3!null s:4 j:5
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
  │    ├── scan a
@@ -426,9 +431,10 @@ semi-join (hash)
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2-5)
  │    └── filters
- │         └── (k:1 * i:2) = 3 [outer=(1,2)]
+ │         └── (k:1 * i:2) = 3 [outer=(1,2), immutable]
  ├── select
  │    ├── columns: x:6!null y:7
+ │    ├── immutable
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
  │    ├── scan b
@@ -436,7 +442,7 @@ semi-join (hash)
  │    │    ├── key: (6)
  │    │    └── fd: (6)-->(7)
  │    └── filters
- │         └── (x:6 + y:7) > 5 [outer=(6,7)]
+ │         └── (x:6 + y:7) > 5 [outer=(6,7), immutable]
  └── filters
       └── k:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
@@ -480,6 +486,7 @@ SELECT * FROM a LEFT JOIN b ON a.k=b.x AND a.k + b.y > 5 AND b.x * a.i = 3
 left-join (hash)
  ├── columns: k:1!null i:2 f:3!null s:4 j:5 x:6 y:7
  ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-7), (6)-->(7)
  ├── scan a
@@ -488,6 +495,7 @@ left-join (hash)
  │    └── fd: (1)-->(2-5)
  ├── select
  │    ├── columns: x:6!null y:7
+ │    ├── immutable
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
  │    ├── scan b
@@ -495,10 +503,10 @@ left-join (hash)
  │    │    ├── key: (6)
  │    │    └── fd: (6)-->(7)
  │    └── filters
- │         └── (x:6 + y:7) > 5 [outer=(6,7)]
+ │         └── (x:6 + y:7) > 5 [outer=(6,7), immutable]
  └── filters
       ├── k:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-      └── (x:6 * i:2) = 3 [outer=(2,6)]
+      └── (x:6 * i:2) = 3 [outer=(2,6), immutable]
 
 norm expect=MapFilterIntoJoinRight expect-not=PushFilterIntoJoinLeftAndRight
 SELECT * FROM a LEFT JOIN b ON a.k=b.x AND a.k > 5 AND b.x IN (3, 7, 10)
@@ -533,6 +541,7 @@ SELECT * FROM a FULL JOIN b ON a.k=b.x AND a.k + b.y > 5 AND b.x * a.i = 3
 full-join (hash)
  ├── columns: k:1 i:2 f:3 s:4 j:5 x:6 y:7
  ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
+ ├── immutable
  ├── key: (1,6)
  ├── fd: (1)-->(2-5), (6)-->(7)
  ├── scan a
@@ -545,8 +554,8 @@ full-join (hash)
  │    └── fd: (6)-->(7)
  └── filters
       ├── k:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-      ├── (k:1 + y:7) > 5 [outer=(1,7)]
-      └── (x:6 * i:2) = 3 [outer=(2,6)]
+      ├── (k:1 + y:7) > 5 [outer=(1,7), immutable]
+      └── (x:6 * i:2) = 3 [outer=(2,6), immutable]
 
 norm expect-not=(PushFilterIntoJoinLeftAndRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
 SELECT * FROM a FULL JOIN b ON a.k=b.x AND a.k > 5 AND b.x IN (3, 7, 10)
@@ -577,6 +586,7 @@ SELECT * FROM a WHERE NOT EXISTS(
 ----
 anti-join (hash)
  ├── columns: k:1!null i:2 f:3!null s:4 j:5
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
@@ -585,6 +595,7 @@ anti-join (hash)
  │    └── fd: (1)-->(2-5)
  ├── select
  │    ├── columns: x:6!null y:7
+ │    ├── immutable
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
  │    ├── scan b
@@ -592,10 +603,10 @@ anti-join (hash)
  │    │    ├── key: (6)
  │    │    └── fd: (6)-->(7)
  │    └── filters
- │         └── (x:6 + y:7) > 5 [outer=(6,7)]
+ │         └── (x:6 + y:7) > 5 [outer=(6,7), immutable]
  └── filters
       ├── k:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-      └── (x:6 * i:2) = 3 [outer=(2,6)]
+      └── (x:6 * i:2) = 3 [outer=(2,6), immutable]
 
 norm expect=MapFilterIntoJoinRight expect-not=PushFilterIntoJoinLeftAndRight
 SELECT * FROM a WHERE NOT EXISTS(
@@ -629,10 +640,12 @@ SELECT * FROM a JOIN b ON a.k = b.x AND b.x * a.i = (SELECT min(b.x) FROM b)
 inner-join (hash)
  ├── columns: k:1!null i:2 f:3!null s:4 j:5 x:6!null y:7
  ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ ├── immutable
  ├── key: (6)
  ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
  ├── select
  │    ├── columns: k:1!null i:2 f:3!null s:4 j:5
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-5)
  │    ├── scan a
@@ -640,7 +653,7 @@ inner-join (hash)
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2-5)
  │    └── filters
- │         └── eq [outer=(1,2), subquery]
+ │         └── eq [outer=(1,2), immutable, subquery]
  │              ├── k:1 * i:2
  │              └── subquery
  │                   └── scalar-group-by
@@ -667,10 +680,12 @@ SELECT * FROM a JOIN b ON a.k = b.x AND b.x * a.i = (SELECT a.k * b.y FROM b)
 ----
 project
  ├── columns: k:1!null i:2 f:3!null s:4 j:5 x:6!null y:7
+ ├── immutable
  ├── key: (6)
  ├── fd: (1)-->(2-5), (1,6)-->(7), (1)==(6), (6)==(1)
  └── inner-join-apply
       ├── columns: k:1!null i:2 f:3!null s:4 j:5 x:6!null y:7 "?column?":10
+      ├── immutable
       ├── key: (6)
       ├── fd: (1)-->(2-5), (1,6)-->(7,10), (1)==(6), (6)==(1)
       ├── scan a
@@ -682,12 +697,14 @@ project
       │    ├── grouping columns: x:6!null
       │    ├── error: "more than one row returned by a subquery used as an expression"
       │    ├── outer: (1)
+      │    ├── immutable
       │    ├── key: (6)
       │    ├── fd: (6)-->(7,10)
       │    ├── left-join (cross)
       │    │    ├── columns: x:6!null y:7 "?column?":10
       │    │    ├── outer: (1)
       │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+      │    │    ├── immutable
       │    │    ├── fd: (6)-->(7)
       │    │    ├── scan b
       │    │    │    ├── columns: x:6!null y:7
@@ -696,10 +713,11 @@ project
       │    │    ├── project
       │    │    │    ├── columns: "?column?":10
       │    │    │    ├── outer: (1)
+      │    │    │    ├── immutable
       │    │    │    ├── scan b
       │    │    │    │    └── columns: y:9
       │    │    │    └── projections
-      │    │    │         └── k:1 * y:9 [as="?column?":10, outer=(1,9)]
+      │    │    │         └── k:1 * y:9 [as="?column?":10, outer=(1,9), immutable]
       │    │    └── filters (true)
       │    └── aggregations
       │         ├── const-agg [as=y:7, outer=(7)]
@@ -708,7 +726,7 @@ project
       │              └── "?column?":10
       └── filters
            ├── k:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-           └── "?column?":10 = (x:6 * i:2) [outer=(2,6,10), constraints=(/10: (/NULL - ])]
+           └── "?column?":10 = (x:6 * i:2) [outer=(2,6,10), immutable, constraints=(/10: (/NULL - ])]
 
 # Ensure that we do not map filters for types with composite key encoding.
 norm expect-not=(PushFilterIntoJoinLeftAndRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
@@ -737,7 +755,7 @@ inner-join (hash)
  │    ├── (1.00,)
  │    └── (2.00,)
  └── filters
-      └── column1:1 = column1:2 [outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
+      └── column1:1 = column1:2 [outer=(1,2), immutable, constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
 
 # Optimization does not apply if equality is only on one side.
 norm expect-not=(PushFilterIntoJoinLeftAndRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
@@ -745,6 +763,7 @@ SELECT * FROM a INNER JOIN b ON b.y=b.x AND a.k=a.i AND a.k + b.y > 5 AND b.x * 
 ----
 inner-join (cross)
  ├── columns: k:1!null i:2!null f:3!null s:4 j:5 x:6!null y:7!null
+ ├── immutable
  ├── key: (1,6)
  ├── fd: (1)-->(3-5), (1)==(2), (2)==(1), (6)==(7), (7)==(6)
  ├── select
@@ -768,8 +787,8 @@ inner-join (cross)
  │    └── filters
  │         └── y:7 = x:6 [outer=(6,7), constraints=(/6: (/NULL - ]; /7: (/NULL - ]), fd=(6)==(7), (7)==(6)]
  └── filters
-      ├── (k:1 + y:7) > 5 [outer=(1,7)]
-      └── (x:6 * i:2) = 3 [outer=(2,6)]
+      ├── (k:1 + y:7) > 5 [outer=(1,7), immutable]
+      └── (x:6 * i:2) = 3 [outer=(2,6), immutable]
 
 # Ensure that MapFilterIntoJoinRight doesn't cause cycle with decorrelation.
 norm expect=MapFilterIntoJoinRight
@@ -783,14 +802,17 @@ FROM c
 ----
 project
  ├── columns: x:13
+ ├── immutable
  ├── ensure-distinct-on
  │    ├── columns: c.x:1!null b.x:4
  │    ├── grouping columns: c.x:1!null
  │    ├── error: "more than one row returned by a subquery used as an expression"
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(4)
  │    ├── left-join-apply
  │    │    ├── columns: c.x:1!null b.x:4 k:8
+ │    │    ├── immutable
  │    │    ├── fd: (4)==(8), (8)==(4)
  │    │    ├── scan c
  │    │    │    ├── columns: c.x:1!null
@@ -799,6 +821,7 @@ project
  │    │    │    ├── columns: b.x:4!null k:8!null
  │    │    │    ├── outer: (1)
  │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │    │    ├── immutable
  │    │    │    ├── fd: (4)==(8), (8)==(4)
  │    │    │    ├── full-join (cross)
  │    │    │    │    ├── columns: b.x:4
@@ -812,12 +835,13 @@ project
  │    │    │    │         └── c.x:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
  │    │    │    ├── select
  │    │    │    │    ├── columns: k:8!null
+ │    │    │    │    ├── immutable
  │    │    │    │    ├── key: (8)
  │    │    │    │    ├── scan a
  │    │    │    │    │    ├── columns: k:8!null
  │    │    │    │    │    └── key: (8)
  │    │    │    │    └── filters
- │    │    │    │         └── (k:8 + k:8) < 5 [outer=(8)]
+ │    │    │    │         └── (k:8 + k:8) < 5 [outer=(8), immutable]
  │    │    │    └── filters
  │    │    │         └── k:8 = b.x:4 [outer=(4,8), constraints=(/4: (/NULL - ]; /8: (/NULL - ]), fd=(4)==(8), (8)==(4)]
  │    │    └── filters (true)
@@ -838,14 +862,17 @@ FROM c
 ----
 project
  ├── columns: x:13
+ ├── immutable
  ├── ensure-distinct-on
  │    ├── columns: c.x:1!null b.x:9
  │    ├── grouping columns: c.x:1!null
  │    ├── error: "more than one row returned by a subquery used as an expression"
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(9)
  │    ├── left-join-apply
  │    │    ├── columns: c.x:1!null k:4 b.x:9
+ │    │    ├── immutable
  │    │    ├── fd: (4)==(9), (9)==(4)
  │    │    ├── scan c
  │    │    │    ├── columns: c.x:1!null
@@ -854,15 +881,17 @@ project
  │    │    │    ├── columns: k:4!null b.x:9!null
  │    │    │    ├── outer: (1)
  │    │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+ │    │    │    ├── immutable
  │    │    │    ├── fd: (4)==(9), (9)==(4)
  │    │    │    ├── select
  │    │    │    │    ├── columns: k:4!null
+ │    │    │    │    ├── immutable
  │    │    │    │    ├── key: (4)
  │    │    │    │    ├── scan a
  │    │    │    │    │    ├── columns: k:4!null
  │    │    │    │    │    └── key: (4)
  │    │    │    │    └── filters
- │    │    │    │         └── (k:4 + k:4) < 5 [outer=(4)]
+ │    │    │    │         └── (k:4 + k:4) < 5 [outer=(4), immutable]
  │    │    │    ├── full-join (cross)
  │    │    │    │    ├── columns: b.x:9
  │    │    │    │    ├── outer: (1)
@@ -897,7 +926,7 @@ SELECT * FROM t1, t2 WHERE a = b AND age(b, TIMESTAMPTZ '2017-01-01') > INTERVAL
 ----
 inner-join (cross)
  ├── columns: a:1!null b:3!null
- ├── immutable, side-effects
+ ├── stable, side-effects
  ├── fd: (1)==(3), (3)==(1)
  ├── scan t1
  │    └── columns: a:1
@@ -909,7 +938,7 @@ inner-join (cross)
  │    └── filters
  │         └── age(b:3, '2017-01-01 00:00:00+00:00') > '1 day' [outer=(3), immutable, side-effects]
  └── filters
-      └── a:1 = b:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+      └── a:1 = b:3 [outer=(1,3), stable, constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
 
 # Regression for issue 28818. Try to trigger undetectable cycle between the
 # PushFilterIntoJoinLeftAndRight and TryDecorrelateSelect rules.
@@ -1891,10 +1920,12 @@ SELECT * FROM a WHERE (SELECT sum(column1) FROM (VALUES (k), (1))) = 1
 ----
 project
  ├── columns: k:1!null i:2 f:3!null s:4 j:5
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  └── select
       ├── columns: k:1!null i:2 f:3!null s:4 j:5 sum:7!null
+      ├── immutable
       ├── key: (1)
       ├── fd: ()-->(7), (1)-->(2-5)
       ├── group-by
@@ -1928,7 +1959,7 @@ project
       │         └── const-agg [as=j:5, outer=(5)]
       │              └── j:5
       └── filters
-           └── sum:7 = 1 [outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+           └── sum:7 = 1 [outer=(7), immutable, constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
 
 # Don't simplify left join
 norm expect-not=SimplifyRightJoin
@@ -2092,6 +2123,7 @@ SELECT * FROM a FULL JOIN (SELECT k+1 AS k FROM a) AS a2 ON a.k=a2.k
 full-join (hash)
  ├── columns: k:1 i:2 f:3 s:4 j:5 k:11
  ├── multiplicity: left-rows(one-or-more), right-rows(exactly-one)
+ ├── immutable
  ├── fd: (1)-->(2-5)
  ├── scan a
  │    ├── columns: a.k:1!null i:2 f:3!null s:4 j:5
@@ -2099,11 +2131,12 @@ full-join (hash)
  │    └── fd: (1)-->(2-5)
  ├── project
  │    ├── columns: k:11!null
+ │    ├── immutable
  │    ├── scan a
  │    │    ├── columns: a.k:6!null
  │    │    └── key: (6)
  │    └── projections
- │         └── a.k:6 + 1 [as=k:11, outer=(6)]
+ │         └── a.k:6 + 1 [as=k:11, outer=(6), immutable]
  └── filters
       └── a.k:1 = k:11 [outer=(1,11), constraints=(/1: (/NULL - ]; /11: (/NULL - ]), fd=(1)==(11), (11)==(1)]
 
@@ -2591,6 +2624,7 @@ inner-join (hash)
  │         └── i:2 > 0 [outer=(2), constraints=(/2: [/1 - ]; tight)]
  ├── project
  │    ├── columns: z:8!null x:6!null y:7!null
+ │    ├── immutable
  │    ├── key: (6)
  │    ├── fd: (6)-->(7), (7)-->(8)
  │    ├── select
@@ -2604,7 +2638,7 @@ inner-join (hash)
  │    │    └── filters
  │    │         └── y:7 > 10 [outer=(7), constraints=(/7: [/11 - ]; tight)]
  │    └── projections
- │         └── y:7 + 1 [as=z:8, outer=(7)]
+ │         └── y:7 + 1 [as=z:8, outer=(7), immutable]
  └── filters
       ├── f:3 >= z:8::FLOAT8 [outer=(3,8), immutable, constraints=(/3: (/NULL - ])]
       ├── f:3 >= z:8::FLOAT8 [outer=(3,8), immutable, constraints=(/3: (/NULL - ])]
@@ -2640,15 +2674,18 @@ SELECT * FROM xy JOIN uv ON x+y=u
 ----
 project
  ├── columns: x:1!null y:2 u:3!null v:4
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2), (1,2)-->(3,4), (3)-->(4)
  └── inner-join (hash)
       ├── columns: x:1!null y:2 u:3!null v:4 column5:5!null
       ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2), (1,2)-->(5), (3)-->(4), (3)==(5), (5)==(3)
       ├── project
       │    ├── columns: column5:5 x:1!null y:2
+      │    ├── immutable
       │    ├── key: (1)
       │    ├── fd: (1)-->(2), (1,2)-->(5)
       │    ├── scan xy
@@ -2656,7 +2693,7 @@ project
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(2)
       │    └── projections
-      │         └── x:1 + y:2 [as=column5:5, outer=(1,2)]
+      │         └── x:1 + y:2 [as=column5:5, outer=(1,2), immutable]
       ├── scan uv
       │    ├── columns: u:3!null v:4
       │    ├── key: (3)
@@ -2669,15 +2706,18 @@ SELECT * FROM xy JOIN uv ON u=x+y
 ----
 project
  ├── columns: x:1!null y:2 u:3!null v:4
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2), (1,2)-->(3,4), (3)-->(4)
  └── inner-join (hash)
       ├── columns: x:1!null y:2 u:3!null v:4 column5:5!null
       ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2), (1,2)-->(5), (3)-->(4), (3)==(5), (5)==(3)
       ├── project
       │    ├── columns: column5:5 x:1!null y:2
+      │    ├── immutable
       │    ├── key: (1)
       │    ├── fd: (1)-->(2), (1,2)-->(5)
       │    ├── scan xy
@@ -2685,7 +2725,7 @@ project
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(2)
       │    └── projections
-      │         └── x:1 + y:2 [as=column5:5, outer=(1,2)]
+      │         └── x:1 + y:2 [as=column5:5, outer=(1,2), immutable]
       ├── scan uv
       │    ├── columns: u:3!null v:4
       │    ├── key: (3)
@@ -2698,11 +2738,13 @@ SELECT * FROM xy JOIN uv ON x=u+v
 ----
 project
  ├── columns: x:1!null y:2 u:3!null v:4
+ ├── immutable
  ├── key: (3)
  ├── fd: (1)-->(2), (3)-->(4), (3,4)-->(1,2)
  └── inner-join (hash)
       ├── columns: x:1!null y:2 u:3!null v:4 column5:5!null
       ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+      ├── immutable
       ├── key: (3)
       ├── fd: (1)-->(2), (3)-->(4), (3,4)-->(5), (1)==(5), (5)==(1)
       ├── scan xy
@@ -2711,6 +2753,7 @@ project
       │    └── fd: (1)-->(2)
       ├── project
       │    ├── columns: column5:5 u:3!null v:4
+      │    ├── immutable
       │    ├── key: (3)
       │    ├── fd: (3)-->(4), (3,4)-->(5)
       │    ├── scan uv
@@ -2718,7 +2761,7 @@ project
       │    │    ├── key: (3)
       │    │    └── fd: (3)-->(4)
       │    └── projections
-      │         └── u:3 + v:4 [as=column5:5, outer=(3,4)]
+      │         └── u:3 + v:4 [as=column5:5, outer=(3,4), immutable]
       └── filters
            └── x:1 = column5:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
 
@@ -2727,11 +2770,13 @@ SELECT * FROM xy JOIN uv ON u+v=x
 ----
 project
  ├── columns: x:1!null y:2 u:3!null v:4
+ ├── immutable
  ├── key: (3)
  ├── fd: (1)-->(2), (3)-->(4), (3,4)-->(1,2)
  └── inner-join (hash)
       ├── columns: x:1!null y:2 u:3!null v:4 column5:5!null
       ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+      ├── immutable
       ├── key: (3)
       ├── fd: (1)-->(2), (3)-->(4), (3,4)-->(5), (1)==(5), (5)==(1)
       ├── scan xy
@@ -2740,6 +2785,7 @@ project
       │    └── fd: (1)-->(2)
       ├── project
       │    ├── columns: column5:5 u:3!null v:4
+      │    ├── immutable
       │    ├── key: (3)
       │    ├── fd: (3)-->(4), (3,4)-->(5)
       │    ├── scan uv
@@ -2747,7 +2793,7 @@ project
       │    │    ├── key: (3)
       │    │    └── fd: (3)-->(4)
       │    └── projections
-      │         └── u:3 + v:4 [as=column5:5, outer=(3,4)]
+      │         └── u:3 + v:4 [as=column5:5, outer=(3,4), immutable]
       └── filters
            └── x:1 = column5:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
 
@@ -2756,14 +2802,17 @@ SELECT * FROM xy JOIN uv ON x+y=u+v
 ----
 project
  ├── columns: x:1!null y:2 u:3!null v:4
+ ├── immutable
  ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4)
  └── inner-join (hash)
       ├── columns: x:1!null y:2 u:3!null v:4 column5:5!null column6:6!null
+      ├── immutable
       ├── key: (1,3)
       ├── fd: (1)-->(2), (1,2)-->(5), (3)-->(4), (3,4)-->(6), (5)==(6), (6)==(5)
       ├── project
       │    ├── columns: column5:5 x:1!null y:2
+      │    ├── immutable
       │    ├── key: (1)
       │    ├── fd: (1)-->(2), (1,2)-->(5)
       │    ├── scan xy
@@ -2771,9 +2820,10 @@ project
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(2)
       │    └── projections
-      │         └── x:1 + y:2 [as=column5:5, outer=(1,2)]
+      │         └── x:1 + y:2 [as=column5:5, outer=(1,2), immutable]
       ├── project
       │    ├── columns: column6:6 u:3!null v:4
+      │    ├── immutable
       │    ├── key: (3)
       │    ├── fd: (3)-->(4), (3,4)-->(6)
       │    ├── scan uv
@@ -2781,7 +2831,7 @@ project
       │    │    ├── key: (3)
       │    │    └── fd: (3)-->(4)
       │    └── projections
-      │         └── u:3 + v:4 [as=column6:6, outer=(3,4)]
+      │         └── u:3 + v:4 [as=column6:6, outer=(3,4), immutable]
       └── filters
            └── column5:5 = column6:6 [outer=(5,6), constraints=(/5: (/NULL - ]; /6: (/NULL - ]), fd=(5)==(6), (6)==(5)]
 
@@ -2791,15 +2841,18 @@ SELECT * FROM xy JOIN uv ON x+y=u AND x=u+v AND x*y+1=u*v+2
 ----
 project
  ├── columns: x:1!null y:2 u:3!null v:4
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2), (1,2)-->(3,4), (3)-->(4), (3,4)-->(1,2)
  └── inner-join (hash)
       ├── columns: x:1!null y:2 u:3!null v:4 column5:5!null column6:6!null column7:7!null column8:8!null
       ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2), (1,2)-->(5,7), (3)-->(4), (3,4)-->(6,8), (3)==(5), (5)==(3), (1)==(6), (6)==(1), (7)==(8), (8)==(7)
       ├── project
       │    ├── columns: column7:7 column5:5 x:1!null y:2
+      │    ├── immutable
       │    ├── key: (1)
       │    ├── fd: (1)-->(2), (1,2)-->(5,7)
       │    ├── scan xy
@@ -2807,10 +2860,11 @@ project
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(2)
       │    └── projections
-      │         ├── (x:1 * y:2) + 1 [as=column7:7, outer=(1,2)]
-      │         └── x:1 + y:2 [as=column5:5, outer=(1,2)]
+      │         ├── (x:1 * y:2) + 1 [as=column7:7, outer=(1,2), immutable]
+      │         └── x:1 + y:2 [as=column5:5, outer=(1,2), immutable]
       ├── project
       │    ├── columns: column8:8 column6:6 u:3!null v:4
+      │    ├── immutable
       │    ├── key: (3)
       │    ├── fd: (3)-->(4), (3,4)-->(6,8)
       │    ├── scan uv
@@ -2818,8 +2872,8 @@ project
       │    │    ├── key: (3)
       │    │    └── fd: (3)-->(4)
       │    └── projections
-      │         ├── (u:3 * v:4) + 2 [as=column8:8, outer=(3,4)]
-      │         └── u:3 + v:4 [as=column6:6, outer=(3,4)]
+      │         ├── (u:3 * v:4) + 2 [as=column8:8, outer=(3,4), immutable]
+      │         └── u:3 + v:4 [as=column6:6, outer=(3,4), immutable]
       └── filters
            ├── column5:5 = u:3 [outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ]), fd=(3)==(5), (5)==(3)]
            ├── x:1 = column6:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
@@ -2831,15 +2885,18 @@ SELECT * FROM xy JOIN uv ON x+y=u AND x+u=v
 ----
 project
  ├── columns: x:1!null y:2 u:3!null v:4!null
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2), (1,2)-->(3,4), (3)-->(4)
  └── inner-join (hash)
       ├── columns: x:1!null y:2 u:3!null v:4!null column5:5!null
       ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2), (1,2)-->(5), (3)-->(4), (3)==(5), (5)==(3)
       ├── project
       │    ├── columns: column5:5 x:1!null y:2
+      │    ├── immutable
       │    ├── key: (1)
       │    ├── fd: (1)-->(2), (1,2)-->(5)
       │    ├── scan xy
@@ -2847,13 +2904,13 @@ project
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(2)
       │    └── projections
-      │         └── x:1 + y:2 [as=column5:5, outer=(1,2)]
+      │         └── x:1 + y:2 [as=column5:5, outer=(1,2), immutable]
       ├── scan uv
       │    ├── columns: u:3!null v:4
       │    ├── key: (3)
       │    └── fd: (3)-->(4)
       └── filters
-           ├── v:4 = (x:1 + u:3) [outer=(1,3,4), constraints=(/4: (/NULL - ])]
+           ├── v:4 = (x:1 + u:3) [outer=(1,3,4), immutable, constraints=(/4: (/NULL - ])]
            └── column5:5 = u:3 [outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ]), fd=(3)==(5), (5)==(3)]
 
 # Cases with non-extractable equality.
@@ -2882,6 +2939,7 @@ SELECT * FROM xy FULL OUTER JOIN uv ON x+y=1
 full-join (cross)
  ├── columns: x:1 y:2 u:3 v:4
  ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
+ ├── immutable
  ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4)
  ├── scan xy
@@ -2893,7 +2951,7 @@ full-join (cross)
  │    ├── key: (3)
  │    └── fd: (3)-->(4)
  └── filters
-      └── (x:1 + y:2) = 1 [outer=(1,2)]
+      └── (x:1 + y:2) = 1 [outer=(1,2), immutable]
 
 norm expect-not=ExtractJoinEqualities
 SELECT * FROM xy FULL OUTER JOIN uv ON 1=u+v
@@ -2901,6 +2959,7 @@ SELECT * FROM xy FULL OUTER JOIN uv ON 1=u+v
 full-join (cross)
  ├── columns: x:1 y:2 u:3 v:4
  ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
+ ├── immutable
  ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4)
  ├── scan xy
@@ -2912,7 +2971,7 @@ full-join (cross)
  │    ├── key: (3)
  │    └── fd: (3)-->(4)
  └── filters
-      └── (u:3 + v:4) = 1 [outer=(3,4)]
+      └── (u:3 + v:4) = 1 [outer=(3,4), immutable]
 
 norm expect-not=ExtractJoinEqualities
 SELECT * FROM xy INNER JOIN uv ON (SELECT k FROM a WHERE i=x)=u

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -169,6 +169,7 @@ SELECT k, f*2.0 AS r FROM a LIMIT 5
 project
  ├── columns: k:1!null r:6
  ├── cardinality: [0 - 5]
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(6)
  ├── limit
@@ -183,7 +184,7 @@ project
  │    │    └── limit hint: 5.00
  │    └── 5
  └── projections
-      └── f:3 * 2.0 [as=r:6, outer=(3)]
+      └── f:3 * 2.0 [as=r:6, outer=(3), immutable]
 
 norm expect=PushLimitIntoProject
 SELECT k, f*2.0 AS r FROM a ORDER BY k LIMIT 5
@@ -191,6 +192,7 @@ SELECT k, f*2.0 AS r FROM a ORDER BY k LIMIT 5
 project
  ├── columns: k:1!null r:6
  ├── cardinality: [0 - 5]
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(6)
  ├── ordering: +1
@@ -209,7 +211,7 @@ project
  │    │    └── limit hint: 5.00
  │    └── 5
  └── projections
-      └── f:3 * 2.0 [as=r:6, outer=(3)]
+      └── f:3 * 2.0 [as=r:6, outer=(3), immutable]
 
 # Don't push the limit through project when the ordering is on a
 # synthesized column.
@@ -220,17 +222,20 @@ limit
  ├── columns: k:1!null r:6
  ├── internal-ordering: +6
  ├── cardinality: [0 - 5]
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(6)
  ├── ordering: +6
  ├── sort
  │    ├── columns: k:1!null r:6
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(6)
  │    ├── ordering: +6
  │    ├── limit hint: 5.00
  │    └── project
  │         ├── columns: r:6 k:1!null
+ │         ├── immutable
  │         ├── key: (1)
  │         ├── fd: (1)-->(6)
  │         ├── scan a
@@ -238,7 +243,7 @@ limit
  │         │    ├── key: (1)
  │         │    └── fd: (1)-->(3)
  │         └── projections
- │              └── f:3 * 2.0 [as=r:6, outer=(3)]
+ │              └── f:3 * 2.0 [as=r:6, outer=(3), immutable]
  └── 5
 
 
@@ -249,6 +254,7 @@ SELECT f, f+1.1 AS r FROM (SELECT f, i FROM a GROUP BY f, i) a ORDER BY f LIMIT 
 project
  ├── columns: f:3 r:6
  ├── cardinality: [0 - 5]
+ ├── immutable
  ├── ordering: +3
  ├── limit
  │    ├── columns: i:2 f:3
@@ -270,7 +276,7 @@ project
  │    │              └── columns: i:2 f:3
  │    └── 5
  └── projections
-      └── f:3 + 1.1 [as=r:6, outer=(3)]
+      └── f:3 + 1.1 [as=r:6, outer=(3), immutable]
 
 # Don't push negative limit into Scan.
 norm
@@ -297,6 +303,7 @@ SELECT k, f*2.0 AS r FROM a OFFSET 5
 ----
 project
  ├── columns: k:1!null r:6
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(6)
  ├── offset
@@ -309,13 +316,14 @@ project
  │    │    └── fd: (1)-->(3)
  │    └── 5
  └── projections
-      └── f:3 * 2.0 [as=r:6, outer=(3)]
+      └── f:3 * 2.0 [as=r:6, outer=(3), immutable]
 
 norm expect=PushOffsetIntoProject
 SELECT k, f*2.0 AS r FROM a ORDER BY k OFFSET 5
 ----
 project
  ├── columns: k:1!null r:6
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(6)
  ├── ordering: +1
@@ -332,7 +340,7 @@ project
  │    │    └── ordering: +1
  │    └── 5
  └── projections
-      └── f:3 * 2.0 [as=r:6, outer=(3)]
+      └── f:3 * 2.0 [as=r:6, outer=(3), immutable]
 
 # Don't push the offset through project when the ordering is on a
 # synthesized column.
@@ -342,16 +350,19 @@ SELECT k, f*2.0 AS r FROM a ORDER BY r OFFSET 5
 offset
  ├── columns: k:1!null r:6
  ├── internal-ordering: +6
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(6)
  ├── ordering: +6
  ├── sort
  │    ├── columns: k:1!null r:6
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(6)
  │    ├── ordering: +6
  │    └── project
  │         ├── columns: r:6 k:1!null
+ │         ├── immutable
  │         ├── key: (1)
  │         ├── fd: (1)-->(6)
  │         ├── scan a
@@ -359,7 +370,7 @@ offset
  │         │    ├── key: (1)
  │         │    └── fd: (1)-->(3)
  │         └── projections
- │              └── f:3 * 2.0 [as=r:6, outer=(3)]
+ │              └── f:3 * 2.0 [as=r:6, outer=(3), immutable]
  └── 5
 
 # Detect PushOffsetIntoProject and FilterUnusedOffsetCols dependency cycle.
@@ -368,6 +379,7 @@ SELECT f, f+1.1 AS r FROM (SELECT f, i FROM a GROUP BY f, i) a ORDER BY f OFFSET
 ----
 project
  ├── columns: f:3 r:6
+ ├── immutable
  ├── ordering: +3
  ├── offset
  │    ├── columns: i:2 f:3
@@ -386,7 +398,7 @@ project
  │    │              └── columns: i:2 f:3
  │    └── 5
  └── projections
-      └── f:3 + 1.1 [as=r:6, outer=(3)]
+      └── f:3 + 1.1 [as=r:6, outer=(3), immutable]
 
 # --------------------------------------------------
 # PushLimitIntoProject + PushOffsetIntoProject
@@ -397,6 +409,7 @@ SELECT k, f*2.0 AS r FROM a OFFSET 5 LIMIT 10
 project
  ├── columns: k:1!null r:6
  ├── cardinality: [0 - 10]
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(6)
  ├── offset
@@ -417,7 +430,7 @@ project
  │    │    └── 15
  │    └── 5
  └── projections
-      └── f:3 * 2.0 [as=r:6, outer=(3)]
+      └── f:3 * 2.0 [as=r:6, outer=(3), immutable]
 
 norm expect=(PushLimitIntoProject,PushOffsetIntoProject)
 SELECT f, f+1.1 AS r FROM (SELECT f, i FROM a GROUP BY f, i) a ORDER BY f OFFSET 5 LIMIT 10
@@ -425,6 +438,7 @@ SELECT f, f+1.1 AS r FROM (SELECT f, i FROM a GROUP BY f, i) a ORDER BY f OFFSET
 project
  ├── columns: f:3 r:6
  ├── cardinality: [0 - 10]
+ ├── immutable
  ├── ordering: +3
  ├── offset
  │    ├── columns: i:2 f:3
@@ -453,7 +467,7 @@ project
  │    │    └── 15
  │    └── 5
  └── projections
-      └── f:3 + 1.1 [as=r:6, outer=(3)]
+      └── f:3 + 1.1 [as=r:6, outer=(3), immutable]
 
 # --------------------------------------------------
 # PushLimitIntoOffset

--- a/pkg/sql/opt/norm/testdata/rules/numeric
+++ b/pkg/sql/opt/norm/testdata/rules/numeric
@@ -16,15 +16,16 @@ FROM a
 ----
 project
  ├── columns: r:6 s:7 t:8 u:9 v:10 w:11
+ ├── immutable
  ├── scan a
  │    └── columns: i:2 f:3 d:4
  └── projections
-      ├── i:2 + i:2 [as=r:6, outer=(2)]
-      ├── i:2 + i:2 [as=s:7, outer=(2)]
-      ├── f:3 + f:3 [as=t:8, outer=(3)]
-      ├── f:3 + f:3 [as=u:9, outer=(3)]
-      ├── d:4 + d:4 [as=v:10, outer=(4)]
-      └── d:4 + d:4 [as=w:11, outer=(4)]
+      ├── i:2 + i:2 [as=r:6, outer=(2), immutable]
+      ├── i:2 + i:2 [as=s:7, outer=(2), immutable]
+      ├── f:3 + f:3 [as=t:8, outer=(3), immutable]
+      ├── f:3 + f:3 [as=u:9, outer=(3), immutable]
+      ├── d:4 + d:4 [as=v:10, outer=(4), immutable]
+      └── d:4 + d:4 [as=w:11, outer=(4), immutable]
 
 
 # Regression test for #35113.
@@ -64,12 +65,13 @@ FROM a
 ----
 project
  ├── columns: r:6 s:7 t:8
+ ├── immutable
  ├── scan a
  │    └── columns: i:2 f:3 d:4
  └── projections
-      ├── i:2 + i:2 [as=r:6, outer=(2)]
-      ├── f:3 + f:3 [as=s:7, outer=(3)]
-      └── d:4 + d:4 [as=t:8, outer=(4)]
+      ├── i:2 + i:2 [as=r:6, outer=(2), immutable]
+      ├── f:3 + f:3 [as=s:7, outer=(3), immutable]
+      └── d:4 + d:4 [as=t:8, outer=(4), immutable]
 
 # Regression test for #35113.
 norm expect=FoldMinusZero
@@ -108,15 +110,16 @@ FROM a
 ----
 project
  ├── columns: r:6 s:7 t:8 u:9 v:10 w:11
+ ├── immutable
  ├── scan a
  │    └── columns: i:2 f:3 d:4
  └── projections
-      ├── i:2 + i:2 [as=r:6, outer=(2)]
-      ├── i:2 + i:2 [as=s:7, outer=(2)]
-      ├── f:3 + f:3 [as=t:8, outer=(3)]
-      ├── f:3 + f:3 [as=u:9, outer=(3)]
-      ├── d:4 + d:4 [as=v:10, outer=(4)]
-      └── d:4 + d:4 [as=w:11, outer=(4)]
+      ├── i:2 + i:2 [as=r:6, outer=(2), immutable]
+      ├── i:2 + i:2 [as=s:7, outer=(2), immutable]
+      ├── f:3 + f:3 [as=t:8, outer=(3), immutable]
+      ├── f:3 + f:3 [as=u:9, outer=(3), immutable]
+      ├── d:4 + d:4 [as=v:10, outer=(4), immutable]
+      └── d:4 + d:4 [as=w:11, outer=(4), immutable]
 
 # Regression test for #35113.
 norm expect=FoldMultOne
@@ -197,12 +200,13 @@ FROM a
 ----
 project
  ├── columns: r:6 s:7 t:8
+ ├── immutable
  ├── scan a
  │    └── columns: i:2 f:3 d:4 a.t:5
  └── projections
-      ├── f:3 - f:3 [as=r:6, outer=(3)]
-      ├── i:2 - d:4 [as=s:7, outer=(2,4)]
-      └── a.t:5 - a.t:5 [as=t:8, outer=(5)]
+      ├── f:3 - f:3 [as=r:6, outer=(3), immutable]
+      ├── i:2 - d:4 [as=s:7, outer=(2,4), immutable]
+      └── a.t:5 - a.t:5 [as=t:8, outer=(5), immutable]
 
 # --------------------------------------------------
 # EliminateUnaryMinus

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -209,20 +209,23 @@ EXPLAIN SELECT b, b+1 AS plus, c FROM abcde ORDER BY b, plus, c
 ----
 explain
  ├── columns: tree:7 field:8 description:9
+ ├── immutable
  └── sort
       ├── columns: b:2 plus:6 c:3
+      ├── immutable
       ├── lax-key: (2,3)
       ├── fd: (2)-->(6)
       ├── ordering: +2,+3
       └── project
            ├── columns: plus:6 b:2 c:3
+           ├── immutable
            ├── lax-key: (2,3)
            ├── fd: (2)-->(6)
            ├── scan abcde
            │    ├── columns: b:2 c:3
            │    └── lax-key: (2,3)
            └── projections
-                └── b:2 + 1 [as=plus:6, outer=(2)]
+                └── b:2 + 1 [as=plus:6, outer=(2), immutable]
 
 # Regression: Explain a statement having constant column, but with no ordering.
 norm

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -86,11 +86,12 @@ SELECT 1+b.x FROM b LEFT JOIN a ON b.x = a.x
 ----
 project
  ├── columns: "?column?":7!null
+ ├── immutable
  ├── scan b
  │    ├── columns: b.x:1!null
  │    └── key: (1)
  └── projections
-      └── b.x:1 + 1 [as="?column?":7, outer=(1)]
+      └── b.x:1 + 1 [as="?column?":7, outer=(1), immutable]
 
 # Case with no references to the left side.
 norm expect=EliminateJoinUnderProjectLeft
@@ -124,6 +125,7 @@ SELECT b.x, b.z, 1+a.x FROM b LEFT JOIN a ON b.x = a.x
 ----
 project
  ├── columns: x:1!null z:2 "?column?":7
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2,7)
  ├── left-join (hash)
@@ -141,7 +143,7 @@ project
  │    └── filters
  │         └── b.x:1 = a.x:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
  └── projections
-      └── a.x:3 + 1 [as="?column?":7, outer=(3)]
+      └── a.x:3 + 1 [as="?column?":7, outer=(3), immutable]
 
 # No-op case because r2 is nullable, and therefore rows may not match despite
 # the fact that it is a foreign key.
@@ -306,6 +308,7 @@ SELECT y+1 AS r FROM (SELECT a.y FROM a, b WHERE a.x=b.x) a
 ----
 project
  ├── columns: r:7
+ ├── immutable
  ├── inner-join (hash)
  │    ├── columns: a.x:1!null y:2 b.x:5!null
  │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
@@ -321,7 +324,7 @@ project
  │    └── filters
  │         └── a.x:1 = b.x:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
  └── projections
-      └── y:2 + 1 [as=r:7, outer=(2)]
+      └── y:2 + 1 [as=r:7, outer=(2), immutable]
 
 # Outer and inner projections have synthesized columns.
 norm expect=MergeProjects
@@ -329,11 +332,12 @@ SELECT y1, f+1 FROM (SELECT y+1 AS y1, f FROM a)
 ----
 project
  ├── columns: y1:5 "?column?":6
+ ├── immutable
  ├── scan a
  │    └── columns: y:2 f:3
  └── projections
-      ├── f:3 + 1.0 [as="?column?":6, outer=(3)]
-      └── y:2 + 1 [as=y1:5, outer=(2)]
+      ├── f:3 + 1.0 [as="?column?":6, outer=(3), immutable]
+      └── y:2 + 1 [as=y1:5, outer=(2), immutable]
 
 # Multiple synthesized columns in both outer and inner projections.
 norm expect=MergeProjects
@@ -341,15 +345,16 @@ SELECT y1, f+1, x2, s||'foo' FROM (SELECT y+1 AS y1, f, s, x*2 AS x2 FROM a)
 ----
 project
  ├── columns: y1:5 "?column?":7 x2:6!null "?column?":8
+ ├── immutable
  ├── scan a
  │    ├── columns: x:1!null y:2 f:3 s:4
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4)
  └── projections
-      ├── f:3 + 1.0 [as="?column?":7, outer=(3)]
-      ├── s:4 || 'foo' [as="?column?":8, outer=(4)]
-      ├── y:2 + 1 [as=y1:5, outer=(2)]
-      └── x:1 * 2 [as=x2:6, outer=(1)]
+      ├── f:3 + 1.0 [as="?column?":7, outer=(3), immutable]
+      ├── s:4 || 'foo' [as="?column?":8, outer=(4), immutable]
+      ├── y:2 + 1 [as=y1:5, outer=(2), immutable]
+      └── x:1 * 2 [as=x2:6, outer=(1), immutable]
 
 # Outer project selects subset of inner columns.
 norm expect=MergeProjects
@@ -357,10 +362,11 @@ SELECT y1 FROM (SELECT y+1 AS y1, f*2 AS f2 FROM a)
 ----
 project
  ├── columns: y1:5
+ ├── immutable
  ├── scan a
  │    └── columns: y:2
  └── projections
-      └── y:2 + 1 [as=y1:5, outer=(2)]
+      └── y:2 + 1 [as=y1:5, outer=(2), immutable]
 
 # Don't merge, since outer depends on inner.
 norm expect-not=MergeProjects
@@ -368,14 +374,16 @@ SELECT y1*2, y1/2 FROM (SELECT y+1 AS y1 FROM a)
 ----
 project
  ├── columns: "?column?":6 "?column?":7
+ ├── immutable
  ├── project
  │    ├── columns: y1:5
+ │    ├── immutable
  │    ├── scan a
  │    │    └── columns: y:2
  │    └── projections
- │         └── y:2 + 1 [as=y1:5, outer=(2)]
+ │         └── y:2 + 1 [as=y1:5, outer=(2), immutable]
  └── projections
-      ├── y1:5 * 2 [as="?column?":6, outer=(5)]
+      ├── y1:5 * 2 [as="?column?":6, outer=(5), immutable]
       └── y1:5 / 2 [as="?column?":7, outer=(5)]
 
 # Discard all inner columns.
@@ -459,7 +467,7 @@ project
  │    ├── fd: ()-->(1)
  │    └── ($1::INT8,)
  └── projections
-      ├── column1:1 + 1 [as="?column?":3, outer=(1)]
+      ├── column1:1 + 1 [as="?column?":3, outer=(1), immutable]
       └── 3 [as="?column?":4]
 
 # --------------------------------------------------
@@ -525,16 +533,19 @@ SELECT (SELECT (tup).@1 * x FROM b) FROM (VALUES ((1,2)), ((3,4))) AS v(tup)
 project
  ├── columns: "?column?":5
  ├── cardinality: [1 - ]
+ ├── immutable
  ├── ensure-distinct-on
  │    ├── columns: "?column?":4 rownum:8!null
  │    ├── grouping columns: rownum:8!null
  │    ├── error: "more than one row returned by a subquery used as an expression"
  │    ├── cardinality: [1 - ]
+ │    ├── immutable
  │    ├── key: (8)
  │    ├── fd: (8)-->(4)
  │    ├── left-join-apply
  │    │    ├── columns: "?column?":4 column1_1:6!null rownum:8!null
  │    │    ├── cardinality: [2 - ]
+ │    │    ├── immutable
  │    │    ├── fd: (8)-->(6)
  │    │    ├── ordinality
  │    │    │    ├── columns: column1_1:6!null rownum:8!null
@@ -549,11 +560,12 @@ project
  │    │    ├── project
  │    │    │    ├── columns: "?column?":4
  │    │    │    ├── outer: (6)
+ │    │    │    ├── immutable
  │    │    │    ├── scan b
  │    │    │    │    ├── columns: x:2!null
  │    │    │    │    └── key: (2)
  │    │    │    └── projections
- │    │    │         └── x:2 * column1_1:6 [as="?column?":4, outer=(2,6)]
+ │    │    │         └── x:2 * column1_1:6 [as="?column?":4, outer=(2,6), immutable]
  │    │    └── filters (true)
  │    └── aggregations
  │         └── const-agg [as="?column?":4, outer=(4)]
@@ -838,6 +850,7 @@ SELECT x*1, x+1 FROM (VALUES (1), (2)) f(x)
 project
  ├── columns: "?column?":2!null "?column?":3!null
  ├── cardinality: [2 - 2]
+ ├── immutable
  ├── fd: (2)-->(3)
  ├── values
  │    ├── columns: "?column?":2!null
@@ -845,7 +858,7 @@ project
  │    ├── (1,)
  │    └── (2,)
  └── projections
-      └── "?column?":2 + 1 [as="?column?":3, outer=(2)]
+      └── "?column?":2 + 1 [as="?column?":3, outer=(2), immutable]
 
 # Case with a subquery reference to a remapped column.
 norm expect=PushColumnRemappingIntoValues

--- a/pkg/sql/opt/norm/testdata/rules/project_set
+++ b/pkg/sql/opt/norm/testdata/rules/project_set
@@ -192,8 +192,10 @@ SELECT unnest(ARRAY[x,y]), unnest(ARRAY[1,x*100]) FROM xy
 ----
 project
  ├── columns: unnest:4 unnest:5
+ ├── immutable
  └── inner-join-apply
       ├── columns: x:1!null y:2 unnest:4 unnest:5
+      ├── immutable
       ├── fd: (1)-->(2)
       ├── scan xy
       │    ├── columns: x:1!null y:2
@@ -203,6 +205,7 @@ project
       │    ├── columns: unnest:4 unnest:5
       │    ├── outer: (1,2)
       │    ├── cardinality: [2 - 2]
+      │    ├── immutable
       │    ├── (x:1, 1)
       │    └── (y:2, x:1 * 100)
       └── filters (true)

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -53,11 +53,12 @@ SELECT k1*2 FROM (SELECT k+1 AS k1, i+1 FROM a) a
 ----
 project
  ├── columns: "?column?":7!null
+ ├── immutable
  ├── scan a
  │    ├── columns: k:1!null
  │    └── key: (1)
  └── projections
-      └── (k:1 + 1) * 2 [as="?column?":7, outer=(1)]
+      └── (k:1 + 1) * 2 [as="?column?":7, outer=(1), immutable]
 
 # Use column values within computed column.
 norm expect=PruneProjectCols
@@ -94,7 +95,7 @@ project
  │    └── projections
  │         └── length(s:4) [as=l:5, outer=(4), immutable]
  └── projections
-      └── l:5 * 2 [as="?column?":6, outer=(5)]
+      └── l:5 * 2 [as="?column?":6, outer=(5), immutable]
 
 # Compute column based on another computed column.
 norm expect=PruneProjectCols
@@ -117,7 +118,7 @@ project
  │    └── projections
  │         └── length(s:4) [as=l:5, outer=(4), immutable]
  └── projections
-      └── l:5 * l:5 [as=r:6, outer=(5)]
+      └── l:5 * l:5 [as=r:6, outer=(5), immutable]
 
 # --------------------------------------------------
 # PruneScanCols
@@ -137,6 +138,7 @@ SELECT k, k+1 AS r, i+1 AS s FROM a
 ----
 project
  ├── columns: k:1!null r:5!null s:6
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(5,6)
  ├── scan a
@@ -144,8 +146,8 @@ project
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── projections
-      ├── k:1 + 1 [as=r:5, outer=(1)]
-      └── i:2 + 1 [as=s:6, outer=(2)]
+      ├── k:1 + 1 [as=r:5, outer=(1), immutable]
+      └── i:2 + 1 [as=s:6, outer=(2), immutable]
 
 # Use columns only in computed columns.
 norm expect=PruneScanCols
@@ -153,12 +155,13 @@ SELECT k+i AS r FROM a
 ----
 project
  ├── columns: r:5
+ ├── immutable
  ├── scan a
  │    ├── columns: k:1!null i:2
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── projections
-      └── k:1 + i:2 [as=r:5, outer=(1,2)]
+      └── k:1 + i:2 [as=r:5, outer=(1,2), immutable]
 
 # Use no scan columns.
 norm expect=PruneScanCols
@@ -232,8 +235,10 @@ SELECT i-1 AS r, k*k AS t FROM a WHERE k+1<5 AND s||'o'='foo'
 ----
 project
  ├── columns: r:5 t:6!null
+ ├── immutable
  ├── select
  │    ├── columns: k:1!null i:2 s:4
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,4)
  │    ├── scan a
@@ -242,10 +247,10 @@ project
  │    │    └── fd: (1)-->(2,4)
  │    └── filters
  │         ├── k:1 < 4 [outer=(1), constraints=(/1: (/NULL - /3]; tight)]
- │         └── (s:4 || 'o') = 'foo' [outer=(4)]
+ │         └── (s:4 || 'o') = 'foo' [outer=(4), immutable]
  └── projections
-      ├── i:2 - 1 [as=r:5, outer=(2)]
-      └── k:1 * k:1 [as=t:6, outer=(1)]
+      ├── i:2 - 1 [as=r:5, outer=(2), immutable]
+      └── k:1 * k:1 [as=t:6, outer=(1), immutable]
 
 # Select nested in select.
 norm expect=PruneSelectCols
@@ -290,8 +295,10 @@ SELECT f, f+1.1 AS r FROM (SELECT f, k FROM a GROUP BY f, k HAVING sum(k)=100) a
 ----
 project
  ├── columns: f:3 r:6
+ ├── immutable
  ├── select
  │    ├── columns: k:1!null f:3 sum:5!null
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: ()-->(5), (1)-->(3)
  │    ├── group-by
@@ -309,9 +316,9 @@ project
  │    │         └── const-agg [as=f:3, outer=(3)]
  │    │              └── f:3
  │    └── filters
- │         └── sum:5 = 100 [outer=(5), constraints=(/5: [/100 - /100]; tight), fd=()-->(5)]
+ │         └── sum:5 = 100 [outer=(5), immutable, constraints=(/5: [/100 - /100]; tight), fd=()-->(5)]
  └── projections
-      └── f:3 + 1.1 [as=r:6, outer=(3)]
+      └── f:3 + 1.1 [as=r:6, outer=(3), immutable]
 
 # --------------------------------------------------
 # PruneLimitCols
@@ -416,6 +423,7 @@ SELECT f, f*2.0 AS r FROM (SELECT f, s FROM a GROUP BY f, s LIMIT 5) a
 project
  ├── columns: f:3 r:5
  ├── cardinality: [0 - 5]
+ ├── immutable
  ├── limit
  │    ├── columns: f:3 s:4
  │    ├── cardinality: [0 - 5]
@@ -430,7 +438,7 @@ project
  │    │         └── limit hint: 6.02
  │    └── 5
  └── projections
-      └── f:3 * 2.0 [as=r:5, outer=(3)]
+      └── f:3 * 2.0 [as=r:5, outer=(3), immutable]
 
 # --------------------------------------------------
 # PruneOffsetCols
@@ -657,6 +665,7 @@ SELECT f, f*2.0 AS r FROM (SELECT f, s FROM a GROUP BY f, s OFFSET 5 LIMIT 5) a
 project
  ├── columns: f:3 r:5
  ├── cardinality: [0 - 5]
+ ├── immutable
  ├── offset
  │    ├── columns: f:3 s:4
  │    ├── cardinality: [0 - 5]
@@ -676,7 +685,7 @@ project
  │    │    └── 10
  │    └── 5
  └── projections
-      └── f:3 * 2.0 [as=r:5, outer=(3)]
+      └── f:3 * 2.0 [as=r:5, outer=(3), immutable]
 
 # --------------------------------------------------
 # PruneJoinLeftCols
@@ -733,6 +742,7 @@ SELECT a.k+1 AS r, xy.* FROM a FULL JOIN xy ON True
 ----
 project
  ├── columns: r:7 x:5 y:6
+ ├── immutable
  ├── fd: (5)-->(6)
  ├── full-join (cross)
  │    ├── columns: k:1 x:5 y:6
@@ -748,7 +758,7 @@ project
  │    │    └── fd: (5)-->(6)
  │    └── filters (true)
  └── projections
-      └── k:1 + 1 [as=r:7, outer=(1)]
+      └── k:1 + 1 [as=r:7, outer=(1), immutable]
 
 # No columns needed from left side of join.
 norm expect=PruneJoinLeftCols
@@ -770,18 +780,22 @@ SELECT a.k+1 AS r, a.i/2 AS s, xy.* FROM a INNER JOIN xy ON a.k*a.k=xy.x AND a.s
 ----
 project
  ├── columns: r:8!null s:9 x:5!null y:6
+ ├── immutable
  ├── fd: (5)-->(6)
  ├── inner-join (hash)
  │    ├── columns: k:1!null i:2 x:5!null y:6 column7:7!null
  │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,7), (5)-->(6), (5)==(7), (7)==(5)
  │    ├── project
  │    │    ├── columns: column7:7!null k:1!null i:2
+ │    │    ├── immutable
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2,7)
  │    │    ├── select
  │    │    │    ├── columns: k:1!null i:2 a.s:4
+ │    │    │    ├── immutable
  │    │    │    ├── key: (1)
  │    │    │    ├── fd: (1)-->(2,4)
  │    │    │    ├── scan a
@@ -789,9 +803,9 @@ project
  │    │    │    │    ├── key: (1)
  │    │    │    │    └── fd: (1)-->(2,4)
  │    │    │    └── filters
- │    │    │         └── (a.s:4 || 'o') = 'foo' [outer=(4)]
+ │    │    │         └── (a.s:4 || 'o') = 'foo' [outer=(4), immutable]
  │    │    └── projections
- │    │         └── k:1 * k:1 [as=column7:7, outer=(1)]
+ │    │         └── k:1 * k:1 [as=column7:7, outer=(1), immutable]
  │    ├── scan xy
  │    │    ├── columns: x:5!null y:6
  │    │    ├── key: (5)
@@ -799,7 +813,7 @@ project
  │    └── filters
  │         └── column7:7 = x:5 [outer=(5,7), constraints=(/5: (/NULL - ]; /7: (/NULL - ]), fd=(5)==(7), (7)==(5)]
  └── projections
-      ├── k:1 + 1 [as=r:8, outer=(1)]
+      ├── k:1 + 1 [as=r:8, outer=(1), immutable]
       └── i:2 / 2 [as=s:9, outer=(2)]
 
 # Join that is nested in another join.
@@ -849,20 +863,24 @@ WHERE (SELECT k+1 AS r FROM xy WHERE y=k) = 1
 ----
 project
  ├── columns: k:1!null i:2
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2)
  └── select
       ├── columns: k:1!null i:2 r:7!null
+      ├── immutable
       ├── key: (1)
       ├── fd: ()-->(7), (1)-->(2)
       ├── ensure-distinct-on
       │    ├── columns: k:1!null i:2 r:7
       │    ├── grouping columns: k:1!null
       │    ├── error: "more than one row returned by a subquery used as an expression"
+      │    ├── immutable
       │    ├── key: (1)
       │    ├── fd: (1)-->(2,7)
       │    ├── left-join-apply
       │    │    ├── columns: k:1!null i:2 y:6 r:7
+      │    │    ├── immutable
       │    │    ├── fd: (1)-->(2)
       │    │    ├── scan a
       │    │    │    ├── columns: k:1!null i:2
@@ -871,11 +889,12 @@ project
       │    │    ├── project
       │    │    │    ├── columns: r:7 y:6
       │    │    │    ├── outer: (1)
+      │    │    │    ├── immutable
       │    │    │    ├── fd: ()-->(7)
       │    │    │    ├── scan xy
       │    │    │    │    └── columns: y:6
       │    │    │    └── projections
-      │    │    │         └── k:1 + 1 [as=r:7, outer=(1)]
+      │    │    │         └── k:1 + 1 [as=r:7, outer=(1), immutable]
       │    │    └── filters
       │    │         └── y:6 = k:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       │    └── aggregations
@@ -1012,6 +1031,7 @@ SELECT xy.*, a.k+1 AS r FROM xy FULL JOIN a ON True
 ----
 project
  ├── columns: x:1 y:2 r:7
+ ├── immutable
  ├── fd: (1)-->(2)
  ├── full-join (cross)
  │    ├── columns: x:1 y:2 k:3
@@ -1027,7 +1047,7 @@ project
  │    │    └── key: (3)
  │    └── filters (true)
  └── projections
-      └── k:3 + 1 [as=r:7, outer=(3)]
+      └── k:3 + 1 [as=r:7, outer=(3), immutable]
 
 # No columns needed from right side of join.
 norm expect=PruneJoinRightCols
@@ -1049,10 +1069,12 @@ SELECT xy.*, a.k+1 AS r, a.i/2 AS s FROM xy INNER JOIN a ON xy.x=a.k*a.k AND a.s
 ----
 project
  ├── columns: x:1!null y:2 r:8!null s:9
+ ├── immutable
  ├── fd: (1)-->(2)
  ├── inner-join (hash)
  │    ├── columns: x:1!null y:2 k:3!null i:4 column7:7!null
  │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+ │    ├── immutable
  │    ├── key: (3)
  │    ├── fd: (1)-->(2), (3)-->(4,7), (1)==(7), (7)==(1)
  │    ├── scan xy
@@ -1061,10 +1083,12 @@ project
  │    │    └── fd: (1)-->(2)
  │    ├── project
  │    │    ├── columns: column7:7!null k:3!null i:4
+ │    │    ├── immutable
  │    │    ├── key: (3)
  │    │    ├── fd: (3)-->(4,7)
  │    │    ├── select
  │    │    │    ├── columns: k:3!null i:4 a.s:6
+ │    │    │    ├── immutable
  │    │    │    ├── key: (3)
  │    │    │    ├── fd: (3)-->(4,6)
  │    │    │    ├── scan a
@@ -1072,13 +1096,13 @@ project
  │    │    │    │    ├── key: (3)
  │    │    │    │    └── fd: (3)-->(4,6)
  │    │    │    └── filters
- │    │    │         └── (a.s:6 || 'o') = 'foo' [outer=(6)]
+ │    │    │         └── (a.s:6 || 'o') = 'foo' [outer=(6), immutable]
  │    │    └── projections
- │    │         └── k:3 * k:3 [as=column7:7, outer=(3)]
+ │    │         └── k:3 * k:3 [as=column7:7, outer=(3), immutable]
  │    └── filters
  │         └── x:1 = column7:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
  └── projections
-      ├── k:3 + 1 [as=r:8, outer=(3)]
+      ├── k:3 + 1 [as=r:8, outer=(3), immutable]
       └── i:4 / 2 [as=s:9, outer=(4)]
 
 # Join that is nested in another join.
@@ -1144,6 +1168,7 @@ SELECT a.k, xy.x, a.k+xy.x AS r FROM a LEFT JOIN xy ON a.k=xy.x
 ----
 project
  ├── columns: k:1!null x:5 r:7
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(5), (1,5)-->(7)
  ├── left-join (hash)
@@ -1160,7 +1185,7 @@ project
  │    └── filters
  │         └── k:1 = x:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
  └── projections
-      └── k:1 + x:5 [as=r:7, outer=(1,5)]
+      └── k:1 + x:5 [as=r:7, outer=(1,5), immutable]
 
 # --------------------------------------------------
 # PruneAggCols
@@ -1344,6 +1369,7 @@ SELECT s, i+1 AS r FROM a GROUP BY i, s, s||'foo'
 ----
 project
  ├── columns: s:4 r:6
+ ├── immutable
  ├── distinct-on
  │    ├── columns: i:2 s:4
  │    ├── grouping columns: i:2 s:4
@@ -1351,7 +1377,7 @@ project
  │    └── scan a
  │         └── columns: i:2 s:4
  └── projections
-      └── i:2 + 1 [as=r:6, outer=(2)]
+      └── i:2 + 1 [as=r:6, outer=(2), immutable]
 
 # Groupby a groupby.
 norm expect=PruneGroupByCols
@@ -1400,14 +1426,16 @@ SELECT icnt FROM (SELECT count(i+1) AS icnt, count(k+1) FROM a);
 scalar-group-by
  ├── columns: icnt:6!null
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(6)
  ├── project
  │    ├── columns: column5:5
+ │    ├── immutable
  │    ├── scan a
  │    │    └── columns: i:2
  │    └── projections
- │         └── i:2 + 1 [as=column5:5, outer=(2)]
+ │         └── i:2 + 1 [as=column5:5, outer=(2), immutable]
  └── aggregations
       └── count [as=count:6, outer=(5)]
            └── column5:5
@@ -1499,9 +1527,11 @@ SELECT k FROM (SELECT k, min(s) FROM a GROUP BY k HAVING sum(i) > 5)
 ----
 project
  ├── columns: k:1!null
+ ├── immutable
  ├── key: (1)
  └── select
       ├── columns: k:1!null sum:6!null
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(6)
       ├── group-by
@@ -1517,7 +1547,7 @@ project
       │         └── sum [as=sum:6, outer=(2)]
       │              └── i:2
       └── filters
-           └── sum:6 > 5 [outer=(6), constraints=(/6: (/5 - ]; tight)]
+           └── sum:6 > 5 [outer=(6), immutable, constraints=(/6: (/5 - ]; tight)]
 
 # --------------------------------------------------
 # PruneOrdinalityCols
@@ -1822,16 +1852,19 @@ delete a
       ├── columns: k:5!null column9:9!null
       ├── internal-ordering: +9
       ├── cardinality: [0 - 10]
+      ├── immutable
       ├── key: (5)
       ├── fd: (5)-->(9)
       ├── sort
       │    ├── columns: k:5!null column9:9!null
+      │    ├── immutable
       │    ├── key: (5)
       │    ├── fd: (5)-->(9)
       │    ├── ordering: +9
       │    ├── limit hint: 10.00
       │    └── project
       │         ├── columns: column9:9!null k:5!null
+      │         ├── immutable
       │         ├── key: (5)
       │         ├── fd: (5)-->(9)
       │         ├── select
@@ -1845,7 +1878,7 @@ delete a
       │         │    └── filters
       │         │         └── i:6 > 0 [outer=(6), constraints=(/6: [/1 - ]; tight)]
       │         └── projections
-      │              └── i:6 * 2 [as=column9:9, outer=(6)]
+      │              └── i:6 * 2 [as=column9:9, outer=(6), immutable]
       └── 10
 
 # Prune when a secondary index is present on the table.
@@ -1931,6 +1964,7 @@ update "family"
  ├── volatile, side-effects, mutations
  └── project
       ├── columns: a_new:11!null a:6!null b:7 c:8 d:9 e:10
+      ├── immutable
       ├── key: (6)
       ├── fd: (6)-->(7-11)
       ├── select
@@ -1944,7 +1978,7 @@ update "family"
       │    └── filters
       │         └── a:6 > 100 [outer=(6), constraints=(/6: [/101 - ]; tight)]
       └── projections
-           └── a:6 + 1 [as=a_new:11, outer=(6)]
+           └── a:6 + 1 [as=a_new:11, outer=(6), immutable]
 
 # Do not prune columns that must be returned.
 norm expect=(PruneMutationFetchCols, PruneMutationReturnCols)
@@ -1963,6 +1997,7 @@ project
       ├── fd: (1)-->(2)
       └── project
            ├── columns: c_new:11 a:6!null b:7 c:8 d:9
+           ├── immutable
            ├── key: (6)
            ├── fd: (6)-->(7-9), (8)-->(11)
            ├── scan "family"
@@ -1970,7 +2005,7 @@ project
            │    ├── key: (6)
            │    └── fd: (6)-->(7-9)
            └── projections
-                └── c:8 + 1 [as=c_new:11, outer=(8)]
+                └── c:8 + 1 [as=c_new:11, outer=(8), immutable]
 
 # Prune unused upsert columns.
 norm expect=PruneMutationInputCols
@@ -1992,6 +2027,7 @@ upsert a
  └── project
       ├── columns: upsert_i:15 column1:5!null column2:6!null column7:7 column8:8 k:9 i:10 f:11 s:12
       ├── cardinality: [1 - 1]
+      ├── immutable
       ├── key: ()
       ├── fd: ()-->(5-12,15)
       ├── left-join (cross)
@@ -2019,7 +2055,7 @@ upsert a
       │    │         └── k:9 = 1 [outer=(9), constraints=(/9: [/1 - /1]; tight), fd=()-->(9)]
       │    └── filters (true)
       └── projections
-           └── CASE WHEN k:9 IS NULL THEN column7:7 ELSE i:10 + 1 END [as=upsert_i:15, outer=(7,9,10)]
+           └── CASE WHEN k:9 IS NULL THEN column7:7 ELSE i:10 + 1 END [as=upsert_i:15, outer=(7,9,10), immutable]
 
 # Prune update columns replaced by upsert columns.
 # TODO(andyk): Need to also prune output columns.
@@ -2049,6 +2085,7 @@ upsert a
  └── project
       ├── columns: upsert_k:14 upsert_i:15 upsert_f:16 upsert_s:17 column1:5!null column2:6!null column7:7 column8:8 k:9 i:10 f:11 s:12
       ├── cardinality: [1 - 1]
+      ├── immutable
       ├── key: ()
       ├── fd: ()-->(5-12,14-17)
       ├── left-join (cross)
@@ -2077,7 +2114,7 @@ upsert a
       │    └── filters (true)
       └── projections
            ├── CASE WHEN k:9 IS NULL THEN column1:5 ELSE k:9 END [as=upsert_k:14, outer=(5,9)]
-           ├── CASE WHEN k:9 IS NULL THEN column7:7 ELSE i:10 + 1 END [as=upsert_i:15, outer=(7,9,10)]
+           ├── CASE WHEN k:9 IS NULL THEN column7:7 ELSE i:10 + 1 END [as=upsert_i:15, outer=(7,9,10), immutable]
            ├── CASE WHEN k:9 IS NULL THEN column8:8 ELSE f:11 END [as=upsert_f:16, outer=(8,9,11)]
            └── CASE WHEN k:9 IS NULL THEN column2:6 ELSE s:12 END [as=upsert_s:17, outer=(6,9,12)]
 
@@ -2326,6 +2363,7 @@ project
       ├── fd: (8)-->(1-7)
       └── project
            ├── columns: a_new:17 a:9 b:10 c:11 d:12 e:13 f:14 g:15 rowid:16!null
+           ├── immutable
            ├── key: (16)
            ├── fd: (16)-->(9-15), (9)~~>(10-16), (9)-->(17)
            ├── scan returning_test
@@ -2333,7 +2371,7 @@ project
            │    ├── key: (16)
            │    └── fd: (16)-->(9-15), (9)~~>(10-16)
            └── projections
-                └── a:9 + 1 [as=a_new:17, outer=(9)]
+                └── a:9 + 1 [as=a_new:17, outer=(9), immutable]
 
 
 # Fetch all the columns in the (d, e, f, g) family as d is being set.
@@ -2355,6 +2393,7 @@ project
       ├── fd: (8)-->(1,4), (1)~~>(4,8)
       └── project
            ├── columns: d_new:17 a:9 d:12 e:13 f:14 g:15 rowid:16!null
+           ├── immutable
            ├── key: (16)
            ├── fd: (16)-->(9,12-15), (9)~~>(12-16), (9,12)-->(17)
            ├── scan returning_test
@@ -2362,7 +2401,7 @@ project
            │    ├── key: (16)
            │    └── fd: (16)-->(9,12-15), (9)~~>(12-16)
            └── projections
-                └── a:9 + d:12 [as=d_new:17, outer=(9,12)]
+                └── a:9 + d:12 [as=d_new:17, outer=(9,12), immutable]
 
 # Fetch only whats being updated (not the (d, e, f, g) family).
 norm
@@ -2381,6 +2420,7 @@ project
       ├── fd: (8)-->(1)
       └── project
            ├── columns: a_new:17 a:9 rowid:16!null
+           ├── immutable
            ├── key: (16)
            ├── fd: (16)-->(9,17), (9)~~>(16,17)
            ├── scan returning_test
@@ -2388,7 +2428,7 @@ project
            │    ├── key: (16)
            │    └── fd: (16)-->(9,12), (9)~~>(12,16)
            └── projections
-                └── a:9 + d:12 [as=a_new:17, outer=(9,12)]
+                └── a:9 + d:12 [as=a_new:17, outer=(9,12), immutable]
 
 # We only fetch the minimal set of columns which is (a, b, c, rowid).
 norm
@@ -2410,6 +2450,7 @@ project
       ├── fd: (8)-->(1-3), (2)~~>(1,3,8)
       └── project
            ├── columns: a_new:17 a:9 b:10 c:11 rowid:16!null
+           ├── immutable
            ├── key: (16)
            ├── fd: (16)-->(9-11), (9)~~>(10,11,16), (9,10)-->(17)
            ├── scan returning_test
@@ -2417,7 +2458,7 @@ project
            │    ├── key: (16)
            │    └── fd: (16)-->(9-11), (9)~~>(10,11,16)
            └── projections
-                └── a:9 + b:10 [as=a_new:17, outer=(9,10)]
+                └── a:9 + b:10 [as=a_new:17, outer=(9,10), immutable]
 
 
 # We apply the PruneMutationReturnCols rule multiple times, to get
@@ -2442,6 +2483,7 @@ with &1
  │         ├── fd: (8)-->(1-3)
  │         └── project
  │              ├── columns: a_new:17 returning_test.a:9 returning_test.b:10 returning_test.c:11 rowid:16!null
+ │              ├── immutable
  │              ├── key: (16)
  │              ├── fd: (16)-->(9-11), (9)~~>(10,11,16), (9)-->(17)
  │              ├── scan returning_test
@@ -2449,7 +2491,7 @@ with &1
  │              │    ├── key: (16)
  │              │    └── fd: (16)-->(9-11), (9)~~>(10,11,16)
  │              └── projections
- │                   └── returning_test.a:9 + 1 [as=a_new:17, outer=(9)]
+ │                   └── returning_test.a:9 + 1 [as=a_new:17, outer=(9), immutable]
  └── project
       ├── columns: a:21
       ├── with-scan &1
@@ -2482,6 +2524,7 @@ with &1
  │         ├── fd: (8)-->(1-3)
  │         └── project
  │              ├── columns: a_new:17 returning_test.a:9 returning_test.b:10 returning_test.c:11 rowid:16!null
+ │              ├── immutable
  │              ├── key: (16)
  │              ├── fd: (16)-->(9-11), (9)~~>(10,11,16), (9)-->(17)
  │              ├── scan returning_test
@@ -2489,7 +2532,7 @@ with &1
  │              │    ├── key: (16)
  │              │    └── fd: (16)-->(9-11), (9)~~>(10,11,16)
  │              └── projections
- │                   └── returning_test.a:9 + 1 [as=a_new:17, outer=(9)]
+ │                   └── returning_test.a:9 + 1 [as=a_new:17, outer=(9), immutable]
  └── project
       ├── columns: a:21!null
       ├── select
@@ -2528,6 +2571,7 @@ with &2
  │         ├── fd: (18)-->(11-13)
  │         └── project
  │              ├── columns: a_new:27 returning_test.a:19 returning_test.b:20 returning_test.c:21 rowid:26!null
+ │              ├── immutable
  │              ├── key: (26)
  │              ├── fd: (26)-->(19-21), (19)~~>(20,21,26), (19)-->(27)
  │              ├── scan returning_test
@@ -2535,7 +2579,7 @@ with &2
  │              │    ├── key: (26)
  │              │    └── fd: (26)-->(19-21), (19)~~>(20,21,26)
  │              └── projections
- │                   └── returning_test.a:19 + 1 [as=a_new:27, outer=(19)]
+ │                   └── returning_test.a:19 + 1 [as=a_new:27, outer=(19), immutable]
  └── inner-join (cross)
       ├── columns: a:9 b:10 a:31!null b:32
       ├── fd: (9)~~>(10)
@@ -2633,7 +2677,7 @@ project
            │    │         └── a:14 = 1 [outer=(14), constraints=(/14: [/1 - /1]; tight), fd=()-->(14)]
            │    └── filters (true)
            └── projections
-                ├── CASE WHEN rowid:21 IS NULL THEN column1:9 ELSE column1:9 + a:14 END [as=upsert_a:23, outer=(9,14,21)]
+                ├── CASE WHEN rowid:21 IS NULL THEN column1:9 ELSE column1:9 + a:14 END [as=upsert_a:23, outer=(9,14,21), immutable]
                 ├── CASE WHEN rowid:21 IS NULL THEN column2:10 ELSE b:15 END [as=upsert_b:24, outer=(10,15,21)]
                 ├── CASE WHEN rowid:21 IS NULL THEN column3:11 ELSE c:16 END [as=upsert_c:25, outer=(11,16,21)]
                 └── CASE WHEN rowid:21 IS NULL THEN column13:13 ELSE rowid:21 END [as=upsert_rowid:30, outer=(13,21)]
@@ -2654,6 +2698,7 @@ project
       ├── fd: (8)-->(1,2,4), (1)-->(2,4,8)
       └── select
            ├── columns: a:9!null b:10 d:12 rowid:16!null
+           ├── immutable
            ├── key: (16)
            ├── fd: (16)-->(9,10,12), (9)-->(10,12,16)
            ├── scan returning_test
@@ -2661,7 +2706,7 @@ project
            │    ├── key: (16)
            │    └── fd: (16)-->(9,10,12), (9)~~>(10,12,16)
            └── filters
-                └── a:9 < (b:10 + d:12) [outer=(9,10,12), constraints=(/9: (/NULL - ])]
+                └── a:9 < (b:10 + d:12) [outer=(9,10,12), immutable, constraints=(/9: (/NULL - ])]
 
 norm
 UPSERT INTO returning_test (a, b, c) VALUES (1, 2, 'c') RETURNING a, b, c, d
@@ -2811,6 +2856,7 @@ SELECT a, b, c FROM abcde WHERE EXISTS (SELECT * FROM family WHERE abcde.a=famil
 ----
 semi-join (hash)
  ├── columns: a:1!null b:2 c:3
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2,3), (2,3)~~>(1)
  ├── scan abcde
@@ -2823,7 +2869,7 @@ semi-join (hash)
  │    └── fd: (6)-->(7,8)
  └── filters
       ├── abcde.a:1 = "family".a:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-      └── abcde.b:2 > ("family".b:7 + "family".c:8) [outer=(2,7,8), constraints=(/2: (/NULL - ])]
+      └── abcde.b:2 > ("family".b:7 + "family".c:8) [outer=(2,7,8), immutable, constraints=(/2: (/NULL - ])]
 
 norm expect=PruneSemiAntiJoinRightCols
 SELECT a, b, c FROM abcde WHERE NOT EXISTS (SELECT * FROM family WHERE abcde.a=family.a)

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -256,9 +256,11 @@ HAVING sum(DISTINCT y)=1
 ----
 project
  ├── columns: sum:7!null
+ ├── immutable
  ├── fd: ()-->(7)
  └── select
       ├── columns: k:1!null sum:7!null
+      ├── immutable
       ├── key: (1)
       ├── fd: ()-->(7)
       ├── group-by
@@ -283,7 +285,7 @@ project
       │              └── sum
       │                   └── y:6
       └── filters
-           └── sum:7 = 1 [outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+           └── sum:7 = 1 [outer=(7), immutable, constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
 
 # Single max aggregate function without grouping columns.
 norm expect=RejectNullsGroupBy
@@ -651,18 +653,22 @@ HAVING string_agg(s || 'bar', ',')='foo'
 ----
 project
  ├── columns: string_agg:9!null
+ ├── immutable
  ├── fd: ()-->(9)
  └── select
       ├── columns: k:3 string_agg:9!null
+      ├── immutable
       ├── key: (3)
       ├── fd: ()-->(9)
       ├── group-by
       │    ├── columns: k:3 string_agg:9
       │    ├── grouping columns: k:3
+      │    ├── immutable
       │    ├── key: (3)
       │    ├── fd: (3)-->(9)
       │    ├── project
       │    │    ├── columns: column7:7 column8:8!null k:3
+      │    │    ├── immutable
       │    │    ├── fd: ()-->(8), (3)-->(7)
       │    │    ├── left-join (cross)
       │    │    │    ├── columns: k:3 s:6
@@ -675,7 +681,7 @@ project
       │    │    │    │    └── fd: (3)-->(6)
       │    │    │    └── filters (true)
       │    │    └── projections
-      │    │         ├── s:6 || 'bar' [as=column7:7, outer=(6)]
+      │    │         ├── s:6 || 'bar' [as=column7:7, outer=(6), immutable]
       │    │         └── ',' [as=column8:8]
       │    └── aggregations
       │         └── string-agg [as=string_agg:9, outer=(7,8)]
@@ -716,15 +722,18 @@ exprnorm
 select
  ├── columns: sum:6!null
  ├── cardinality: [0 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(6)
  ├── scalar-group-by
  │    ├── columns: sum:6
  │    ├── cardinality: [1 - 1]
+ │    ├── immutable
  │    ├── key: ()
  │    ├── fd: ()-->(6)
  │    ├── inner-join-apply
  │    │    ├── columns: x:1!null u:3!null z:5
+ │    │    ├── immutable
  │    │    ├── key: (1,3)
  │    │    ├── fd: (1,3)-->(5)
  │    │    ├── scan xy
@@ -733,6 +742,7 @@ select
  │    │    ├── left-join-apply
  │    │    │    ├── columns: u:3!null z:5
  │    │    │    ├── outer: (1)
+ │    │    │    ├── immutable
  │    │    │    ├── key: (3)
  │    │    │    ├── fd: (3)-->(5)
  │    │    │    ├── scan uv
@@ -742,6 +752,7 @@ select
  │    │    │    │    ├── columns: z:5
  │    │    │    │    ├── outer: (1,3)
  │    │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    │    ├── immutable
  │    │    │    │    ├── key: ()
  │    │    │    │    ├── fd: ()-->(5)
  │    │    │    │    └── (x:1 + u:3,)

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -28,20 +28,21 @@ FROM a
 ----
 project
  ├── columns: r:7 s:8 t:9!null u:10!null v:11 w:12 x:13 y:14 z:15
+ ├── immutable
  ├── scan a
  │    ├── columns: k:1!null i:2
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── projections
-      ├── k:1 = (i:2 + 1) [as=r:7, outer=(1,2)]
-      ├── i:2 != (2 - k:1) [as=s:8, outer=(1,2)]
-      ├── k:1 IS NOT DISTINCT FROM (i:2 + 1) [as=t:9, outer=(1,2)]
-      ├── k:1 IS DISTINCT FROM (i:2 - 1) [as=u:10, outer=(1,2)]
-      ├── k:1 + (i:2 * 2) [as=v:11, outer=(1,2)]
-      ├── k:1 * (i:2 + 2) [as=w:12, outer=(1,2)]
-      ├── k:1 & (i:2 ^ 2) [as=x:13, outer=(1,2)]
-      ├── k:1 | (i:2 ^ 2) [as=y:14, outer=(1,2)]
-      └── k:1 # (i:2 * i:2) [as=z:15, outer=(1,2)]
+      ├── k:1 = (i:2 + 1) [as=r:7, outer=(1,2), immutable]
+      ├── i:2 != (2 - k:1) [as=s:8, outer=(1,2), immutable]
+      ├── k:1 IS NOT DISTINCT FROM (i:2 + 1) [as=t:9, outer=(1,2), immutable]
+      ├── k:1 IS DISTINCT FROM (i:2 - 1) [as=u:10, outer=(1,2), immutable]
+      ├── k:1 + (i:2 * 2) [as=v:11, outer=(1,2), immutable]
+      ├── k:1 * (i:2 + 2) [as=w:12, outer=(1,2), immutable]
+      ├── k:1 & (i:2 ^ 2) [as=x:13, outer=(1,2), immutable]
+      ├── k:1 | (i:2 ^ 2) [as=y:14, outer=(1,2), immutable]
+      └── k:1 # (i:2 * i:2) [as=z:15, outer=(1,2), immutable]
 
 # --------------------------------------------------
 # CommuteConst
@@ -62,20 +63,21 @@ FROM a
 ----
 project
  ├── columns: r:7 s:8 t:9!null u:10!null v:11 w:12 x:13 y:14 z:15!null
+ ├── immutable
  ├── scan a
  │    ├── columns: k:1!null i:2 f:3
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3)
  └── projections
-      ├── (i:2 + k:1) = 4 [as=r:7, outer=(1,2)]
-      ├── (i:2 * 2) != 3 [as=s:8, outer=(2)]
-      ├── (1 - k:1) IS NOT DISTINCT FROM 5 [as=t:9, outer=(1)]
+      ├── (i:2 + k:1) = 4 [as=r:7, outer=(1,2), immutable]
+      ├── (i:2 * 2) != 3 [as=s:8, outer=(2), immutable]
+      ├── (1 - k:1) IS NOT DISTINCT FROM 5 [as=t:9, outer=(1), immutable]
       ├── k:1 IS DISTINCT FROM 11 [as=u:10, outer=(1)]
-      ├── f:3 + 1.0 [as=v:11, outer=(3)]
-      ├── (i:2 * i:2) * 15 [as=w:12, outer=(2)]
-      ├── (i:2 + i:2) & 10000 [as=x:13, outer=(2)]
-      ├── (i:2 + i:2) | 4 [as=y:14, outer=(2)]
-      └── (k:1 ^ 2) # -2 [as=z:15, outer=(1)]
+      ├── f:3 + 1.0 [as=v:11, outer=(3), immutable]
+      ├── (i:2 * i:2) * 15 [as=w:12, outer=(2), immutable]
+      ├── (i:2 + i:2) & 10000 [as=x:13, outer=(2), immutable]
+      ├── (i:2 + i:2) | 4 [as=y:14, outer=(2), immutable]
+      └── (k:1 ^ 2) # -2 [as=z:15, outer=(1), immutable]
 
 # --------------------------------------------------
 # EliminateCoalesce
@@ -119,10 +121,11 @@ SELECT COALESCE(NULL, NULL, s, s || 'foo') FROM a
 ----
 project
  ├── columns: coalesce:7
+ ├── immutable
  ├── scan a
  │    └── columns: s:4
  └── projections
-      └── COALESCE(s:4, s:4 || 'foo') [as=coalesce:7, outer=(4)]
+      └── COALESCE(s:4, s:4 || 'foo') [as=coalesce:7, outer=(4), immutable]
 
 # Trailing null can't be removed.
 norm
@@ -247,6 +250,7 @@ SELECT
 values
  ├── columns: "?column?":1
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(1)
  └── (true IN (NULL, NULL, ('201.249.149.90/18' & '97a7:3650:3dd8:d4e9:35fe:6cfb:a714:1c17/61') << 'e22f:2067:2ed2:7b07:b167:206f:f17b:5b7d/82'),)
@@ -581,6 +585,7 @@ SELECT * FROM a WHERE j->'a' = '"b"'::JSON
 ----
 select
  ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan a
@@ -588,13 +593,14 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      └── j:5 @> '{"a": "b"}' [outer=(5)]
+      └── j:5 @> '{"a": "b"}' [outer=(5), immutable]
 
 norm expect=NormalizeJSONFieldAccess
 SELECT * FROM a WHERE j->'a'->'x' = '"b"'::JSON
 ----
 select
  ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan a
@@ -602,7 +608,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      └── j:5 @> '{"a": {"x": "b"}}' [outer=(5)]
+      └── j:5 @> '{"a": {"x": "b"}}' [outer=(5), immutable]
 
 # The transformation is not valid in this case.
 norm expect-not=NormalizeJSONFieldAccess
@@ -610,6 +616,7 @@ SELECT * FROM a WHERE j->2 = '"b"'::JSON
 ----
 select
  ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan a
@@ -617,7 +624,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      └── (j:5->2) = '"b"' [outer=(5)]
+      └── (j:5->2) = '"b"' [outer=(5), immutable]
 
 # The transformation is not valid in this case, since j->'a' could be an array.
 norm expect-not=NormalizeJSONFieldAccess
@@ -625,6 +632,7 @@ SELECT * FROM a WHERE j->'a' @> '"b"'::JSON
 ----
 select
  ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan a
@@ -632,7 +640,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      └── (j:5->'a') @> '"b"' [outer=(5)]
+      └── (j:5->'a') @> '"b"' [outer=(5), immutable]
 
 # The transformation is not valid in this case, since containment doesn't imply
 # equality for non-scalars.
@@ -641,11 +649,12 @@ SELECT j->'a' = '["b"]'::JSON, j->'a' = '{"b": "c"}'::JSON FROM a
 ----
 project
  ├── columns: "?column?":7 "?column?":8
+ ├── immutable
  ├── scan a
  │    └── columns: j:5
  └── projections
-      ├── (j:5->'a') = '["b"]' [as="?column?":7, outer=(5)]
-      └── (j:5->'a') = '{"b": "c"}' [as="?column?":8, outer=(5)]
+      ├── (j:5->'a') = '["b"]' [as="?column?":7, outer=(5), immutable]
+      └── (j:5->'a') = '{"b": "c"}' [as="?column?":8, outer=(5), immutable]
 
 # --------------------------------------------------
 # NormalizeJSONContains
@@ -656,6 +665,7 @@ SELECT * FROM a WHERE j->'a' @> '{"x": "b"}'::JSON
 ----
 select
  ├── columns: k:1!null i:2 f:3 s:4 j:5 arr:6
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan a
@@ -663,7 +673,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      └── j:5 @> '{"a": {"x": "b"}}' [outer=(5)]
+      └── j:5 @> '{"a": {"x": "b"}}' [outer=(5), immutable]
 
 # --------------------------------------------------
 # SimplifyCaseWhenConstValue
@@ -1072,9 +1082,11 @@ SELECT k FROM e WHERE tz > '2017-11-12 07:35:01+00:00'::TIMESTAMP
 ----
 project
  ├── columns: k:1!null
+ ├── stable
  ├── key: (1)
  └── select
       ├── columns: k:1!null tz:4!null
+      ├── stable
       ├── key: (1)
       ├── fd: (1)-->(4)
       ├── scan e
@@ -1082,7 +1094,7 @@ project
       │    ├── key: (1)
       │    └── fd: (1)-->(4)
       └── filters
-           └── tz:4 > '2017-11-12 07:35:01+00:00' [outer=(4), constraints=(/4: (/NULL - ])]
+           └── tz:4 > '2017-11-12 07:35:01+00:00' [outer=(4), stable, constraints=(/4: (/NULL - ])]
 
 norm expect=UnifyComparisonTypes
 SELECT k FROM e WHERE tz > '2017-11-12 07:35:01+00:00'::TIMESTAMP
@@ -1127,9 +1139,11 @@ SELECT k FROM e WHERE d > '2018-07-01' AND d < '2018-07-01'::DATE + '1w1s'::INTE
 ----
 project
  ├── columns: k:1!null
+ ├── immutable
  ├── key: (1)
  └── select
       ├── columns: k:1!null d:5!null
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(5)
       ├── scan e
@@ -1138,7 +1152,7 @@ project
       │    └── fd: (1)-->(5)
       └── filters
            ├── d:5 > '2018-07-01' [outer=(5), constraints=(/5: [/'2018-07-02' - ]; tight)]
-           └── d:5 < '2018-07-08 00:00:01+00:00' [outer=(5), constraints=(/5: (/NULL - ])]
+           └── d:5 < '2018-07-08 00:00:01+00:00' [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 # NULL value.
 norm
@@ -1190,12 +1204,13 @@ SELECT k FROM a WHERE k IN (VALUES ((SELECT k*i FROM a)), (2), (3))
 ----
 select
  ├── columns: k:1!null
+ ├── immutable
  ├── key: (1)
  ├── scan a
  │    ├── columns: k:1!null
  │    └── key: (1)
  └── filters
-      └── in [outer=(1), subquery]
+      └── in [outer=(1), immutable, subquery]
            ├── k:1
            └── tuple
                 ├── subquery
@@ -1203,16 +1218,18 @@ select
                 │         ├── columns: "?column?":13
                 │         ├── error: "more than one row returned by a subquery used as an expression"
                 │         ├── cardinality: [0 - 1]
+                │         ├── immutable
                 │         ├── key: ()
                 │         ├── fd: ()-->(13)
                 │         └── project
                 │              ├── columns: "?column?":13
+                │              ├── immutable
                 │              ├── scan a
                 │              │    ├── columns: k:7!null i:8
                 │              │    ├── key: (7)
                 │              │    └── fd: (7)-->(8)
                 │              └── projections
-                │                   └── k:7 * i:8 [as="?column?":13, outer=(7,8)]
+                │                   └── k:7 * i:8 [as="?column?":13, outer=(7,8), immutable]
                 ├── 2
                 └── 3
 
@@ -1245,9 +1262,11 @@ SELECT k FROM a WHERE (k, i) IN (SELECT b, a FROM (VALUES (1, 1), (2, 2), (3, 3)
 ----
 project
  ├── columns: k:1!null
+ ├── immutable
  ├── key: (1)
  └── semi-join (hash)
       ├── columns: k:1!null column10:10
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(10)
       ├── project
@@ -1272,7 +1291,7 @@ project
       │    └── projections
       │         └── (column2:8, column1:7) [as=column9:9, outer=(7,8)]
       └── filters
-           └── column10:10 = column9:9 [outer=(9,10), constraints=(/9: (/NULL - ]; /10: (/NULL - ]), fd=(9)==(10), (10)==(9)]
+           └── column10:10 = column9:9 [outer=(9,10), immutable, constraints=(/9: (/NULL - ]; /10: (/NULL - ]), fd=(9)==(10), (10)==(9)]
 
 # --------------------------------------------------
 # SimplifyEqualsAnyTuple

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -270,9 +270,11 @@ SELECT k FROM e WHERE d > '2018-07-01' AND d < '2018-07-01'::DATE + '1w1s'::INTE
 ----
 project
  ├── columns: k:1!null
+ ├── immutable
  ├── key: (1)
  └── select
       ├── columns: k:1!null d:5!null
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(5)
       ├── scan e
@@ -281,7 +283,7 @@ project
       │    └── fd: (1)-->(5)
       └── filters
            ├── d:5 > '2018-07-01' [outer=(5), constraints=(/5: [/'2018-07-02' - ]; tight)]
-           └── d:5 < '2018-07-08 00:00:01+00:00' [outer=(5), constraints=(/5: (/NULL - ])]
+           └── d:5 < '2018-07-08 00:00:01+00:00' [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 # Ranges can be merged with other filters to create new ranges.
 norm expect=ConsolidateSelectFilters disable=InlineConstVar
@@ -533,6 +535,7 @@ SELECT * FROM (SELECT i, i+1 AS r, f FROM a) a WHERE f=10.0
 ----
 project
  ├── columns: i:2 r:6 f:3!null
+ ├── immutable
  ├── fd: ()-->(3), (2)-->(6)
  ├── select
  │    ├── columns: i:2 f:3!null
@@ -542,7 +545,7 @@ project
  │    └── filters
  │         └── f:3 = 10.0 [outer=(3), constraints=(/3: [/10.0 - /10.0]; tight), fd=()-->(3)]
  └── projections
-      └── i:2 + 1 [as=r:6, outer=(2)]
+      └── i:2 + 1 [as=r:6, outer=(2), immutable]
 
 # Don't push down select if it depends on computed column that can't be inlined.
 norm expect-not=PushSelectIntoProject
@@ -550,6 +553,7 @@ SELECT * FROM (SELECT i, i/2 div, f FROM a) a WHERE div=2
 ----
 select
  ├── columns: i:2 div:6!null f:3
+ ├── immutable
  ├── fd: ()-->(6)
  ├── project
  │    ├── columns: div:6 i:2 f:3
@@ -559,7 +563,7 @@ select
  │    └── projections
  │         └── i:2 / 2 [as=div:6, outer=(2)]
  └── filters
-      └── div:6 = 2 [outer=(6), constraints=(/6: [/2 - /2]; tight), fd=()-->(6)]
+      └── div:6 = 2 [outer=(6), immutable, constraints=(/6: [/2 - /2]; tight), fd=()-->(6)]
 
 # Push down some conjuncts, but not others.
 norm expect=PushSelectIntoProject
@@ -567,6 +571,7 @@ SELECT * FROM (SELECT i, i/2 div, f FROM a) a WHERE 10.0=f AND 2=div AND i=1
 ----
 select
  ├── columns: i:2!null div:6!null f:3!null
+ ├── immutable
  ├── fd: ()-->(2,3,6)
  ├── project
  │    ├── columns: div:6!null i:2!null f:3!null
@@ -582,7 +587,7 @@ select
  │    └── projections
  │         └── i:2 / 2 [as=div:6, outer=(2)]
  └── filters
-      └── div:6 = 2 [outer=(6), constraints=(/6: [/2 - /2]; tight), fd=()-->(6)]
+      └── div:6 = 2 [outer=(6), immutable, constraints=(/6: [/2 - /2]; tight), fd=()-->(6)]
 
 # Detect PushSelectIntoProject and FilterUnusedSelectCols dependency cycle.
 norm
@@ -590,6 +595,7 @@ SELECT f, f+1.1 AS r FROM (SELECT f, i FROM a GROUP BY f, i HAVING sum(f)=10.0) 
 ----
 project
  ├── columns: f:3 r:7
+ ├── immutable
  ├── select
  │    ├── columns: i:2 f:3 sum:6!null
  │    ├── key: (2,3)
@@ -607,7 +613,7 @@ project
  │    └── filters
  │         └── sum:6 = 10.0 [outer=(6), constraints=(/6: [/10.0 - /10.0]; tight), fd=()-->(6)]
  └── projections
-      └── f:3 + 1.1 [as=r:7, outer=(3)]
+      └── f:3 + 1.1 [as=r:7, outer=(3), immutable]
 
 # --------------------------------------
 # PushSelectCondLeftIntoJoinLeftAndRight
@@ -1395,9 +1401,11 @@ SELECT k FROM b WHERE i+k IS NOT NULL
 ----
 project
  ├── columns: k:1!null
+ ├── immutable
  ├── key: (1)
  └── select
       ├── columns: k:1!null i:2
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2)
       ├── scan b
@@ -1405,7 +1413,7 @@ project
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
       └── filters
-           └── (i:2 + k:1) IS NOT NULL [outer=(1,2)]
+           └── (i:2 + k:1) IS NOT NULL [outer=(1,2), immutable]
 
 # --------------------------------------------------
 # DetectSelectContradiction

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -137,6 +137,7 @@ WITH foo AS (SELECT 1), bar AS (SELECT 2) SELECT (SELECT * FROM foo) + (SELECT *
 values
  ├── columns: "?column?":5
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(5)
  └── tuple
@@ -162,6 +163,7 @@ WITH foo AS (SELECT 1), bar AS (SELECT 2) SELECT (SELECT * FROM foo) + (SELECT *
 with &2 (bar)
  ├── columns: "?column?":6
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(6)
  ├── values
@@ -173,6 +175,7 @@ with &2 (bar)
  └── values
       ├── columns: "?column?":6
       ├── cardinality: [1 - 1]
+      ├── immutable
       ├── key: ()
       ├── fd: ()-->(6)
       └── tuple
@@ -647,6 +650,7 @@ with &2 (cte)
       ├── left columns: c:7(int)
       ├── right columns: "?column?":9(int)
       ├── cardinality: [1 - 2]
+      ├── immutable
       ├── stats: [rows=2, distinct(10)=2, null(10)=0]
       ├── cost: 0.1
       ├── key: (10)
@@ -663,6 +667,7 @@ with &2 (cte)
       └── project
            ├── columns: "?column?":9(int!null)
            ├── cardinality: [1 - 1]
+           ├── immutable
            ├── stats: [rows=1, distinct(9)=1, null(9)=0]
            ├── cost: 0.04
            ├── key: ()
@@ -679,7 +684,7 @@ with &2 (cte)
            │    ├── fd: ()-->(8)
            │    └── prune: (8)
            └── projections
-                └── plus [as="?column?":9, type=int, outer=(8)]
+                └── plus [as="?column?":9, type=int, outer=(8), immutable]
                      ├── variable: c:8 [type=int]
                      └── const: 1 [type=int]
 
@@ -800,6 +805,7 @@ with &2 (t)
  ├── columns: sum:6
  ├── materialized
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(6)
  ├── recursive-c-t-e
@@ -808,6 +814,7 @@ with &2 (t)
  │    ├── initial columns: column1:1
  │    ├── recursive columns: "?column?":4
  │    ├── cardinality: [1 - ]
+ │    ├── immutable
  │    ├── values
  │    │    ├── columns: column1:1!null
  │    │    ├── cardinality: [1 - 1]
@@ -816,6 +823,7 @@ with &2 (t)
  │    │    └── (1,)
  │    └── project
  │         ├── columns: "?column?":4!null
+ │         ├── immutable
  │         ├── select
  │         │    ├── columns: n:3!null
  │         │    ├── with-scan &1 (t)
@@ -826,7 +834,7 @@ with &2 (t)
  │         │    └── filters
  │         │         └── n:3 < 100 [outer=(3), constraints=(/3: (/NULL - /99]; tight)]
  │         └── projections
- │              └── n:3 + 1 [as="?column?":4, outer=(3)]
+ │              └── n:3 + 1 [as="?column?":4, outer=(3), immutable]
  └── scalar-group-by
       ├── columns: sum:6
       ├── cardinality: [1 - 1]
@@ -848,17 +856,20 @@ WITH RECURSIVE t(n) AS NOT MATERIALIZED (VALUES (1) UNION ALL SELECT n+1 FROM t 
 scalar-group-by
  ├── columns: sum:6
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(6)
  ├── project
  │    ├── columns: n:5
  │    ├── cardinality: [1 - ]
+ │    ├── immutable
  │    ├── recursive-c-t-e
  │    │    ├── columns: n:2
  │    │    ├── working table binding: &1
  │    │    ├── initial columns: column1:1
  │    │    ├── recursive columns: "?column?":4
  │    │    ├── cardinality: [1 - ]
+ │    │    ├── immutable
  │    │    ├── values
  │    │    │    ├── columns: column1:1!null
  │    │    │    ├── cardinality: [1 - 1]
@@ -867,6 +878,7 @@ scalar-group-by
  │    │    │    └── (1,)
  │    │    └── project
  │    │         ├── columns: "?column?":4!null
+ │    │         ├── immutable
  │    │         ├── select
  │    │         │    ├── columns: n:3!null
  │    │         │    ├── with-scan &1 (t)
@@ -877,7 +889,7 @@ scalar-group-by
  │    │         │    └── filters
  │    │         │         └── n:3 < 100 [outer=(3), constraints=(/3: (/NULL - /99]; tight)]
  │    │         └── projections
- │    │              └── n:3 + 1 [as="?column?":4, outer=(3)]
+ │    │              └── n:3 + 1 [as="?column?":4, outer=(3), immutable]
  │    └── projections
  │         └── n:2 [as=n:5, outer=(2)]
  └── aggregations

--- a/pkg/sql/opt/optgen/exprgen/testdata/join
+++ b/pkg/sql/opt/optgen/exprgen/testdata/join
@@ -115,6 +115,7 @@ expr
 ----
 inner-join-apply
  ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int) t.public.abc.c:3(int) t.public.def.d:5(int) t.public.def.e:6(int) t.public.def.f:7(int)
+ ├── immutable
  ├── stats: [rows=333333.333]
  ├── cost: 5611.39451
  ├── prune: (7)
@@ -129,6 +130,7 @@ inner-join-apply
  ├── select
  │    ├── columns: t.public.def.d:5(int) t.public.def.e:6(int) t.public.def.f:7(int)
  │    ├── outer: (1)
+ │    ├── immutable
  │    ├── stats: [rows=333.333333, distinct(1)=1, null(1)=0]
  │    ├── cost: 1080.03
  │    ├── prune: (7)
@@ -138,7 +140,7 @@ inner-join-apply
  │    │    ├── cost: 1070.02
  │    │    └── prune: (5-7)
  │    └── filters
- │         └── eq [type=bool, outer=(1,5,6), constraints=(/1: (/NULL - ])]
+ │         └── eq [type=bool, outer=(1,5,6), immutable, constraints=(/1: (/NULL - ])]
  │              ├── variable: t.public.abc.a:1 [type=int]
  │              └── plus [type=int]
  │                   ├── variable: t.public.def.d:5 [type=int]

--- a/pkg/sql/opt/optgen/exprgen/testdata/values
+++ b/pkg/sql/opt/optgen/exprgen/testdata/values
@@ -33,6 +33,7 @@ expr
 project
  ├── columns: y:2(int!null) x:1(int!null)
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── stats: [rows=1]
  ├── cost: 0.05
  ├── key: ()
@@ -49,6 +50,6 @@ project
  │    └── tuple [type=tuple{int}]
  │         └── const: 1 [type=int]
  └── projections
-      └── plus [as=y:2, type=int, outer=(1)]
+      └── plus [as=y:2, type=int, outer=(1), immutable]
            ├── variable: x:1 [type=int]
            └── const: 10 [type=int]

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -11,12 +11,14 @@ SELECT k, x FROM a INNER JOIN b ON k=x WHERE d=1.0
 ----
 project
  ├── columns: k:1!null x:5!null
+ ├── immutable
  ├── stats: [rows=99]
  ├── cost: 2124.725
  ├── fd: (1)==(5), (5)==(1)
  └── inner-join (hash)
       ├── columns: k:1!null d:4!null x:5!null
       ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      ├── immutable
       ├── stats: [rows=99, distinct(1)=10, null(1)=0, distinct(5)=10, null(5)=0]
       ├── cost: 2123.725
       ├── fd: ()-->(4), (1)==(5), (5)==(1)
@@ -26,6 +28,7 @@ project
       │    └── cost: 1040.02
       ├── select
       │    ├── columns: k:1!null d:4!null
+      │    ├── immutable
       │    ├── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(4)=1, null(4)=0]
       │    ├── cost: 1070.03
       │    ├── key: (1)
@@ -37,7 +40,7 @@ project
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(4)
       │    └── filters
-      │         └── d:4 = 1.0 [outer=(4), constraints=(/4: [/1.0 - /1.0]; tight), fd=()-->(4)]
+      │         └── d:4 = 1.0 [outer=(4), immutable, constraints=(/4: [/1.0 - /1.0]; tight), fd=()-->(4)]
       └── filters
            └── k:1 = x:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
 

--- a/pkg/sql/opt/xform/testdata/coster/project
+++ b/pkg/sql/opt/xform/testdata/coster/project
@@ -7,6 +7,7 @@ SELECT k, i, s || 'foo' FROM a
 ----
 project
  ├── columns: k:1!null i:2 "?column?":5
+ ├── immutable
  ├── stats: [rows=1000]
  ├── cost: 1090.03
  ├── key: (1)
@@ -18,13 +19,14 @@ project
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3)
  └── projections
-      └── s:3 || 'foo' [as="?column?":5, outer=(3)]
+      └── s:3 || 'foo' [as="?column?":5, outer=(3), immutable]
 
 opt
 SELECT k, k+2, i*d FROM a
 ----
 project
  ├── columns: k:1!null "?column?":5!null "?column?":6
+ ├── immutable
  ├── stats: [rows=1000]
  ├── cost: 1100.03
  ├── key: (1)
@@ -36,5 +38,5 @@ project
  │    ├── key: (1)
  │    └── fd: (1)-->(2,4)
  └── projections
-      ├── k:1 + 2 [as="?column?":5, outer=(1)]
-      └── i:2 * d:4 [as="?column?":6, outer=(2,4)]
+      ├── k:1 + 2 [as="?column?":5, outer=(1), immutable]
+      └── i:2 * d:4 [as="?column?":6, outer=(2,4), immutable]

--- a/pkg/sql/opt/xform/testdata/coster/scan
+++ b/pkg/sql/opt/xform/testdata/coster/scan
@@ -104,6 +104,7 @@ SELECT id FROM speed_test@primary WHERE id BETWEEN 1 AND 1000 AND ((id % 16) = 0
 select
  ├── columns: id:1!null
  ├── cardinality: [0 - 1000]
+ ├── immutable
  ├── stats: [rows=333.333333, distinct(1)=333.333333, null(1)=0]
  ├── cost: 1030.02
  ├── key: (1)
@@ -116,7 +117,7 @@ select
  │    ├── cost: 1020.01
  │    └── key: (1)
  └── filters
-      └── (id:1 % 16) = 0 [outer=(1)]
+      └── (id:1 % 16) = 0 [outer=(1), immutable]
 
 opt
 SELECT id FROM speed_test@primary WHERE id BETWEEN 1 AND 2000 AND ((id % 16) = 0)
@@ -124,6 +125,7 @@ SELECT id FROM speed_test@primary WHERE id BETWEEN 1 AND 2000 AND ((id % 16) = 0
 select
  ├── columns: id:1!null
  ├── cardinality: [0 - 2000]
+ ├── immutable
  ├── stats: [rows=333.333333, distinct(1)=333.333333, null(1)=0]
  ├── cost: 1030.02
  ├── key: (1)
@@ -136,4 +138,4 @@ select
  │    ├── cost: 1020.01
  │    └── key: (1)
  └── filters
-      └── (id:1 % 16) = 0 [outer=(1)]
+      └── (id:1 % 16) = 0 [outer=(1), immutable]

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -232,12 +232,14 @@ LIMIT 50
 project
  ├── columns: score:9!null expires_at:15!null  [hidden: updated_at_inverse:14!null]
  ├── cardinality: [0 - 50]
+ ├── immutable
  ├── fd: ()-->(15)
  ├── ordering: -9,-14 opt(15) [actual: -9,-14]
  └── scan leaderboard_record@test_idx,rev
       ├── columns: id:1!null leaderboard_id:2!null score:9!null updated_at_inverse:14!null expires_at:15!null
       ├── constraint: /2/15/9/14/1/3: [/'\x74657374'/0 - /'\x74657374'/0/100/500/'\x736f6d655f6964')
       ├── limit: 50(rev)
+      ├── immutable
       ├── key: (1)
       ├── fd: ()-->(2,15), (1)-->(9,14)
       └── ordering: -9,-14 opt(2,15) [actual: -9,-14]
@@ -569,5 +571,5 @@ project
  │    │    └── filters (true)
  │    └── filters (true)
  └── projections
-      ├── value:4->>'secondary_id' [as=secondary_id:6, outer=(4)]
+      ├── value:4->>'secondary_id' [as=secondary_id:6, outer=(4), immutable]
       └── data:3 || jsonb_build_object('primary_id', primary_id:1) [as="?column?":7, outer=(1,3), stable]

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -1988,18 +1988,22 @@ WHERE
 ----
 project
  ├── columns: customer1_1_0_:1!null ordernum2_1_0_:2!null orderdat3_1_0_:3!null formula101_0_:18 customer1_2_1_:4 ordernum2_2_1_:5 producti3_2_1_:6 customer1_2_2_:4 ordernum2_2_2_:5 producti3_2_2_:6 quantity4_2_2_:7
+ ├── immutable
  ├── key: (6)
  ├── fd: ()-->(1-3), (6)-->(4,5,7,18)
  ├── group-by
  │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:4 lineitems1_.ordernumber:5 lineitems1_.productid:6 lineitems1_.quantity:7 sum:17
  │    ├── grouping columns: lineitems1_.productid:6
+ │    ├── immutable
  │    ├── key: (6)
  │    ├── fd: ()-->(1-3), (6)-->(1-5,7,17)
  │    ├── right-join (hash)
  │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:4 lineitems1_.ordernumber:5 lineitems1_.productid:6 lineitems1_.quantity:7 li.customerid:8 li.ordernumber:9 column16:16
+ │    │    ├── immutable
  │    │    ├── fd: ()-->(1-3), (6)-->(4,5,7)
  │    │    ├── project
  │    │    │    ├── columns: column16:16 li.customerid:8!null li.ordernumber:9!null
+ │    │    │    ├── immutable
  │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: li.customerid:8!null li.ordernumber:9!null li.productid:10!null li.quantity:11 p.productid:12!null cost:14
  │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -2016,7 +2020,7 @@ project
  │    │    │    │    └── filters
  │    │    │    │         └── li.productid:10 = p.productid:12 [outer=(10,12), constraints=(/10: (/NULL - ]; /12: (/NULL - ]), fd=(10)==(12), (12)==(10)]
  │    │    │    └── projections
- │    │    │         └── li.quantity:11 * cost:14 [as=column16:16, outer=(11,14)]
+ │    │    │         └── li.quantity:11 * cost:14 [as=column16:16, outer=(11,14), immutable]
  │    │    ├── left-join (merge)
  │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:4 lineitems1_.ordernumber:5 lineitems1_.productid:6 lineitems1_.quantity:7
  │    │    │    ├── left ordering: +1,+2
@@ -2110,25 +2114,30 @@ FROM
 ----
 project
  ├── columns: customer1_0_0_:1!null customer1_1_1_:4 ordernum2_1_1_:5 customer1_2_2_:7 ordernum2_2_2_:8 producti3_2_2_:9 producti1_3_3_:11 name2_0_0_:2!null address3_0_0_:3!null orderdat3_1_1_:6 formula103_1_:30 customer1_1_0__:4 ordernum2_1_0__:5 ordernum2_0__:5 quantity4_2_2_:10 customer1_2_1__:7 ordernum2_2_1__:8 producti3_2_1__:9 descript2_3_3_:12 cost3_3_3_:13 numberav4_3_3_:14 formula104_3_:31
+ ├── immutable
  ├── key: (1,4,5,7-9)
  ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9)-->(2,3,6,10-14,30,31)
  ├── group-by
  │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null orders1_.customerid:4 orders1_.ordernumber:5 orderdate:6 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9 lineitems2_.quantity:10 product3_.productid:11 product3_.description:12 product3_.cost:13 product3_.numberavailable:14 sum:24 sum:29
  │    ├── grouping columns: customer0_.customerid:1!null orders1_.customerid:4 orders1_.ordernumber:5 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9
+ │    ├── immutable
  │    ├── key: (1,4,5,7-9)
  │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9)-->(2,3,6,10-14,24,29)
  │    ├── left-join (hash)
  │    │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null orders1_.customerid:4 orders1_.ordernumber:5 orderdate:6 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9 lineitems2_.quantity:10 product3_.productid:11 product3_.description:12 product3_.cost:13 product3_.numberavailable:14 sum:24 li.productid:27 li.quantity:28
  │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+ │    │    ├── immutable
  │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9)-->(2,3,6,10-14,24)
  │    │    ├── group-by
  │    │    │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null orders1_.customerid:4 orders1_.ordernumber:5 orderdate:6 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9 lineitems2_.quantity:10 product3_.productid:11 product3_.description:12 product3_.cost:13 product3_.numberavailable:14 sum:24
  │    │    │    ├── grouping columns: customer0_.customerid:1!null orders1_.customerid:4 orders1_.ordernumber:5 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9
+ │    │    │    ├── immutable
  │    │    │    ├── key: (1,4,5,7-9)
  │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9)-->(2,3,6,10-14,24)
  │    │    │    ├── left-join (hash)
  │    │    │    │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null orders1_.customerid:4 orders1_.ordernumber:5 orderdate:6 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9 lineitems2_.quantity:10 product3_.productid:11 product3_.description:12 product3_.cost:13 product3_.numberavailable:14 li.customerid:15 li.ordernumber:16 column23:23
  │    │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+ │    │    │    │    ├── immutable
  │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9)-->(11-14)
  │    │    │    │    ├── left-join (hash)
  │    │    │    │    │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null orders1_.customerid:4 orders1_.ordernumber:5 orderdate:6 lineitems2_.customerid:7 lineitems2_.ordernumber:8 lineitems2_.productid:9 lineitems2_.quantity:10 product3_.productid:11 product3_.description:12 product3_.cost:13 product3_.numberavailable:14
@@ -2172,6 +2181,7 @@ project
  │    │    │    │    │         └── lineitems2_.productid:9 = product3_.productid:11 [outer=(9,11), constraints=(/9: (/NULL - ]; /11: (/NULL - ]), fd=(9)==(11), (11)==(9)]
  │    │    │    │    ├── project
  │    │    │    │    │    ├── columns: column23:23 li.customerid:15!null li.ordernumber:16!null
+ │    │    │    │    │    ├── immutable
  │    │    │    │    │    ├── inner-join (hash)
  │    │    │    │    │    │    ├── columns: li.customerid:15!null li.ordernumber:16!null li.productid:17!null li.quantity:18 p.productid:19!null p.cost:21
  │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -2188,7 +2198,7 @@ project
  │    │    │    │    │    │    └── filters
  │    │    │    │    │    │         └── li.productid:17 = p.productid:19 [outer=(17,19), constraints=(/17: (/NULL - ]; /19: (/NULL - ]), fd=(17)==(19), (19)==(17)]
  │    │    │    │    │    └── projections
- │    │    │    │    │         └── li.quantity:18 * p.cost:21 [as=column23:23, outer=(18,21)]
+ │    │    │    │    │         └── li.quantity:18 * p.cost:21 [as=column23:23, outer=(18,21), immutable]
  │    │    │    │    └── filters
  │    │    │    │         ├── li.customerid:15 = orders1_.customerid:4 [outer=(4,15), constraints=(/4: (/NULL - ]; /15: (/NULL - ]), fd=(4)==(15), (15)==(4)]
  │    │    │    │         └── li.ordernumber:16 = orders1_.ordernumber:5 [outer=(5,16), constraints=(/5: (/NULL - ]; /16: (/NULL - ]), fd=(5)==(16), (16)==(5)]
@@ -2274,18 +2284,22 @@ WHERE
 ----
 project
  ├── columns: customer1_1_0_:1!null ordernum2_1_0_:2!null orderdat3_1_0_:3!null formula105_0_:18 customer1_2_1_:4 ordernum2_2_1_:5 producti3_2_1_:6 customer1_2_2_:4 ordernum2_2_2_:5 producti3_2_2_:6 quantity4_2_2_:7
+ ├── immutable
  ├── key: (6)
  ├── fd: ()-->(1-3), (6)-->(4,5,7,18)
  ├── group-by
  │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:4 lineitems1_.ordernumber:5 lineitems1_.productid:6 lineitems1_.quantity:7 sum:17
  │    ├── grouping columns: lineitems1_.productid:6
+ │    ├── immutable
  │    ├── key: (6)
  │    ├── fd: ()-->(1-3), (6)-->(1-5,7,17)
  │    ├── right-join (hash)
  │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:4 lineitems1_.ordernumber:5 lineitems1_.productid:6 lineitems1_.quantity:7 li.customerid:8 li.ordernumber:9 column16:16
+ │    │    ├── immutable
  │    │    ├── fd: ()-->(1-3), (6)-->(4,5,7)
  │    │    ├── project
  │    │    │    ├── columns: column16:16 li.customerid:8!null li.ordernumber:9!null
+ │    │    │    ├── immutable
  │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: li.customerid:8!null li.ordernumber:9!null li.productid:10!null li.quantity:11 p.productid:12!null cost:14
  │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -2302,7 +2316,7 @@ project
  │    │    │    │    └── filters
  │    │    │    │         └── li.productid:10 = p.productid:12 [outer=(10,12), constraints=(/10: (/NULL - ]; /12: (/NULL - ]), fd=(10)==(12), (12)==(10)]
  │    │    │    └── projections
- │    │    │         └── li.quantity:11 * cost:14 [as=column16:16, outer=(11,14)]
+ │    │    │         └── li.quantity:11 * cost:14 [as=column16:16, outer=(11,14), immutable]
  │    │    ├── left-join (merge)
  │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:4 lineitems1_.ordernumber:5 lineitems1_.productid:6 lineitems1_.quantity:7
  │    │    │    ├── left ordering: +1,+2
@@ -2363,16 +2377,19 @@ FROM
 ----
 project
  ├── columns: customer1_10_:1!null ordernum2_10_:2!null orderdat3_10_:3!null formula273_:14
+ ├── immutable
  ├── key: (1,2)
  ├── fd: (1,2)-->(3,14)
  ├── group-by
  │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null sum:13
  │    ├── grouping columns: order0_.customerid:1!null order0_.ordernumber:2!null
+ │    ├── immutable
  │    ├── key: (1,2)
  │    ├── fd: (1,2)-->(3,13)
  │    ├── left-join (hash)
  │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null li.customerid:4 li.ordernumber:5 column12:12
  │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+ │    │    ├── immutable
  │    │    ├── fd: (1,2)-->(3)
  │    │    ├── scan order0_
  │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null
@@ -2380,6 +2397,7 @@ project
  │    │    │    └── fd: (1,2)-->(3)
  │    │    ├── project
  │    │    │    ├── columns: column12:12 li.customerid:4!null li.ordernumber:5!null
+ │    │    │    ├── immutable
  │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: li.customerid:4!null li.ordernumber:5!null li.productid:6!null quantity:7 p.productid:8!null cost:10
  │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -2396,7 +2414,7 @@ project
  │    │    │    │    └── filters
  │    │    │    │         └── li.productid:6 = p.productid:8 [outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
  │    │    │    └── projections
- │    │    │         └── quantity:7 * cost:10 [as=column12:12, outer=(7,10)]
+ │    │    │         └── quantity:7 * cost:10 [as=column12:12, outer=(7,10), immutable]
  │    │    └── filters
  │    │         ├── li.customerid:4 = order0_.customerid:1 [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
  │    │         └── li.ordernumber:5 = order0_.ordernumber:2 [outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ]), fd=(2)==(5), (5)==(2)]

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -39,6 +39,7 @@ project
       └── project
            ├── columns: d_next_o_id_new:23 d_id:12!null d_w_id:13!null d_name:14 d_street_1:15 d_street_2:16 d_city:17 d_state:18 d_zip:19 d_tax:20 d_ytd:21 d_next_o_id:22
            ├── cardinality: [0 - 1]
+           ├── immutable
            ├── key: ()
            ├── fd: ()-->(12-23)
            ├── scan district
@@ -48,7 +49,7 @@ project
            │    ├── key: ()
            │    └── fd: ()-->(12-22)
            └── projections
-                └── d_next_o_id:22 + 1 [as=d_next_o_id_new:23, outer=(22)]
+                └── d_next_o_id:22 + 1 [as=d_next_o_id_new:23, outer=(22), immutable]
 
 opt format=hide-qual
 SELECT w_tax FROM warehouse WHERE w_id = 10
@@ -585,7 +586,7 @@ project
  │         └── projections
  │              ├── crdb_internal.round_decimal_values(customer.c_balance:38 - 3860.61, 2) [as=c_balance:47, outer=(38), immutable]
  │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:39 + 3860.61, 2) [as=c_ytd_payment:48, outer=(39), immutable]
- │              ├── c_payment_cnt:40 + 1 [as=c_payment_cnt_new:45, outer=(40)]
+ │              ├── c_payment_cnt:40 + 1 [as=c_payment_cnt_new:45, outer=(40), immutable]
  │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42, 500) ELSE c_data:42 END [as=c_data_new:46, outer=(22-24,35,42), immutable]
  └── projections
       └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:49, outer=(14,21), immutable]
@@ -906,7 +907,7 @@ update customer
       │    └── fd: ()-->(24), (22,23)-->(25-42)
       └── projections
            ├── crdb_internal.round_decimal_values(customer.c_balance:38 + CASE c_d_id:23 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 END, 2) [as=c_balance:45, outer=(23,38), immutable]
-           └── c_delivery_cnt:41 + 1 [as=c_delivery_cnt_new:43, outer=(41)]
+           └── c_delivery_cnt:41 + 1 [as=c_delivery_cnt_new:43, outer=(41), immutable]
 
 opt format=hide-qual
 DELETE FROM new_order
@@ -1071,12 +1072,14 @@ WHERE w_ytd != sum_d_ytd
 scalar-group-by
  ├── columns: count:22!null
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(22)
  ├── inner-join (merge)
  │    ├── columns: w_id:1!null w_ytd:9!null d_w_id:11!null sum:21!null
  │    ├── left ordering: +1
  │    ├── right ordering: +11
+ │    ├── immutable
  │    ├── key: (11)
  │    ├── fd: (1)-->(9), (11)-->(21), (1)==(11), (11)==(1)
  │    ├── scan warehouse
@@ -1097,7 +1100,7 @@ scalar-group-by
  │    │         └── sum [as=sum:21, outer=(19)]
  │    │              └── d_ytd:19
  │    └── filters
- │         └── w_ytd:9 != sum:21 [outer=(9,21), constraints=(/9: (/NULL - ]; /21: (/NULL - ])]
+ │         └── w_ytd:9 != sum:21 [outer=(9,21), immutable, constraints=(/9: (/NULL - ]; /21: (/NULL - ])]
  └── aggregations
       └── count-rows [as=count_rows:22]
 
@@ -1165,10 +1168,12 @@ WHERE nod != -1
 scalar-group-by
  ├── columns: count:8!null
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(8)
  ├── select
  │    ├── columns: no_d_id:2!null no_w_id:3!null max:4!null min:5!null count_rows:6!null
+ │    ├── immutable
  │    ├── key: (2,3)
  │    ├── fd: (2,3)-->(4-6)
  │    ├── group-by
@@ -1188,7 +1193,7 @@ scalar-group-by
  │    │         │    └── no_o_id:1
  │    │         └── count-rows [as=count_rows:6]
  │    └── filters
- │         └── ((max:4 - min:5) - count_rows:6) != -1 [outer=(4-6)]
+ │         └── ((max:4 - min:5) - count_rows:6) != -1 [outer=(4-6), immutable]
  └── aggregations
       └── count-rows [as=count_rows:8]
 

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -42,6 +42,7 @@ project
       └── project
            ├── columns: d_next_o_id_new:23 d_id:12!null d_w_id:13!null d_name:14 d_street_1:15 d_street_2:16 d_city:17 d_state:18 d_zip:19 d_tax:20 d_ytd:21 d_next_o_id:22
            ├── cardinality: [0 - 1]
+           ├── immutable
            ├── key: ()
            ├── fd: ()-->(12-23)
            ├── scan district
@@ -51,7 +52,7 @@ project
            │    ├── key: ()
            │    └── fd: ()-->(12-22)
            └── projections
-                └── d_next_o_id:22 + 1 [as=d_next_o_id_new:23, outer=(22)]
+                └── d_next_o_id:22 + 1 [as=d_next_o_id_new:23, outer=(22), immutable]
 
 opt format=hide-qual
 SELECT w_tax FROM warehouse WHERE w_id = 10
@@ -588,7 +589,7 @@ project
  │         └── projections
  │              ├── crdb_internal.round_decimal_values(customer.c_balance:38 - 3860.61, 2) [as=c_balance:47, outer=(38), immutable]
  │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:39 + 3860.61, 2) [as=c_ytd_payment:48, outer=(39), immutable]
- │              ├── c_payment_cnt:40 + 1 [as=c_payment_cnt_new:45, outer=(40)]
+ │              ├── c_payment_cnt:40 + 1 [as=c_payment_cnt_new:45, outer=(40), immutable]
  │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42, 500) ELSE c_data:42 END [as=c_data_new:46, outer=(22-24,35,42), immutable]
  └── projections
       └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:49, outer=(14,21), immutable]
@@ -909,7 +910,7 @@ update customer
       │    └── fd: ()-->(24), (22,23)-->(25-42)
       └── projections
            ├── crdb_internal.round_decimal_values(customer.c_balance:38 + CASE c_d_id:23 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 END, 2) [as=c_balance:45, outer=(23,38), immutable]
-           └── c_delivery_cnt:41 + 1 [as=c_delivery_cnt_new:43, outer=(41)]
+           └── c_delivery_cnt:41 + 1 [as=c_delivery_cnt_new:43, outer=(41), immutable]
 
 opt format=hide-qual
 DELETE FROM new_order
@@ -1073,12 +1074,14 @@ WHERE w_ytd != sum_d_ytd
 scalar-group-by
  ├── columns: count:22!null
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(22)
  ├── inner-join (merge)
  │    ├── columns: w_id:1!null w_ytd:9!null d_w_id:11!null sum:21!null
  │    ├── left ordering: +1
  │    ├── right ordering: +11
+ │    ├── immutable
  │    ├── key: (11)
  │    ├── fd: (1)-->(9), (11)-->(21), (1)==(11), (11)==(1)
  │    ├── scan warehouse
@@ -1099,7 +1102,7 @@ scalar-group-by
  │    │         └── sum [as=sum:21, outer=(19)]
  │    │              └── d_ytd:19
  │    └── filters
- │         └── w_ytd:9 != sum:21 [outer=(9,21), constraints=(/9: (/NULL - ]; /21: (/NULL - ])]
+ │         └── w_ytd:9 != sum:21 [outer=(9,21), immutable, constraints=(/9: (/NULL - ]; /21: (/NULL - ])]
  └── aggregations
       └── count-rows [as=count_rows:22]
 
@@ -1167,10 +1170,12 @@ WHERE nod != -1
 scalar-group-by
  ├── columns: count:8!null
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(8)
  ├── select
  │    ├── columns: no_d_id:2!null no_w_id:3!null max:4!null min:5!null count_rows:6!null
+ │    ├── immutable
  │    ├── key: (2,3)
  │    ├── fd: (2,3)-->(4-6)
  │    ├── group-by
@@ -1190,7 +1195,7 @@ scalar-group-by
  │    │         │    └── no_o_id:1
  │    │         └── count-rows [as=count_rows:6]
  │    └── filters
- │         └── ((max:4 - min:5) - count_rows:6) != -1 [outer=(4-6)]
+ │         └── ((max:4 - min:5) - count_rows:6) != -1 [outer=(4-6), immutable]
  └── aggregations
       └── count-rows [as=count_rows:8]
 

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -36,6 +36,7 @@ project
       └── project
            ├── columns: d_next_o_id_new:23 d_id:12!null d_w_id:13!null d_name:14 d_street_1:15 d_street_2:16 d_city:17 d_state:18 d_zip:19 d_tax:20 d_ytd:21 d_next_o_id:22
            ├── cardinality: [0 - 1]
+           ├── immutable
            ├── key: ()
            ├── fd: ()-->(12-23)
            ├── scan district
@@ -45,7 +46,7 @@ project
            │    ├── key: ()
            │    └── fd: ()-->(12-22)
            └── projections
-                └── d_next_o_id:22 + 1 [as=d_next_o_id_new:23, outer=(22)]
+                └── d_next_o_id:22 + 1 [as=d_next_o_id_new:23, outer=(22), immutable]
 
 opt format=hide-qual
 SELECT w_tax FROM warehouse WHERE w_id = 10
@@ -582,7 +583,7 @@ project
  │         └── projections
  │              ├── crdb_internal.round_decimal_values(customer.c_balance:38 - 3860.61, 2) [as=c_balance:47, outer=(38), immutable]
  │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:39 + 3860.61, 2) [as=c_ytd_payment:48, outer=(39), immutable]
- │              ├── c_payment_cnt:40 + 1 [as=c_payment_cnt_new:45, outer=(40)]
+ │              ├── c_payment_cnt:40 + 1 [as=c_payment_cnt_new:45, outer=(40), immutable]
  │              └── CASE c_credit:35 WHEN 'BC' THEN left((((((c_id:22::STRING || c_d_id:23::STRING) || c_w_id:24::STRING) || '5') || '10') || '3860.61') || c_data:42, 500) ELSE c_data:42 END [as=c_data_new:46, outer=(22-24,35,42), immutable]
  └── projections
       └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:49, outer=(14,21), immutable]
@@ -907,7 +908,7 @@ update customer
       │    └── fd: ()-->(24), (22,23)-->(25-42)
       └── projections
            ├── crdb_internal.round_decimal_values(customer.c_balance:38 + CASE c_d_id:23 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 END, 2) [as=c_balance:45, outer=(23,38), immutable]
-           └── c_delivery_cnt:41 + 1 [as=c_delivery_cnt_new:43, outer=(41)]
+           └── c_delivery_cnt:41 + 1 [as=c_delivery_cnt_new:43, outer=(41), immutable]
 
 opt format=hide-qual
 DELETE FROM new_order
@@ -1071,12 +1072,14 @@ WHERE w_ytd != sum_d_ytd
 scalar-group-by
  ├── columns: count:22!null
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(22)
  ├── inner-join (lookup warehouse)
  │    ├── columns: w_id:1!null w_ytd:9!null d_w_id:11!null sum:21!null
  │    ├── key columns: [11] = [1]
  │    ├── lookup columns are key
+ │    ├── immutable
  │    ├── key: (11)
  │    ├── fd: (1)-->(9), (11)-->(21), (1)==(11), (11)==(1)
  │    ├── group-by
@@ -1092,7 +1095,7 @@ scalar-group-by
  │    │         └── sum [as=sum:21, outer=(19)]
  │    │              └── d_ytd:19
  │    └── filters
- │         └── w_ytd:9 != sum:21 [outer=(9,21), constraints=(/9: (/NULL - ]; /21: (/NULL - ])]
+ │         └── w_ytd:9 != sum:21 [outer=(9,21), immutable, constraints=(/9: (/NULL - ]; /21: (/NULL - ])]
  └── aggregations
       └── count-rows [as=count_rows:22]
 
@@ -1160,10 +1163,12 @@ WHERE nod != -1
 scalar-group-by
  ├── columns: count:8!null
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(8)
  ├── select
  │    ├── columns: no_d_id:2!null no_w_id:3!null max:4!null min:5!null count_rows:6!null
+ │    ├── immutable
  │    ├── key: (2,3)
  │    ├── fd: (2,3)-->(4-6)
  │    ├── group-by
@@ -1183,7 +1188,7 @@ scalar-group-by
  │    │         │    └── no_o_id:1
  │    │         └── count-rows [as=count_rows:6]
  │    └── filters
- │         └── ((max:4 - min:5) - count_rows:6) != -1 [outer=(4-6)]
+ │         └── ((max:4 - min:5) - count_rows:6) != -1 [outer=(4-6), immutable]
  └── aggregations
       └── count-rows [as=count_rows:8]
 

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -42,16 +42,19 @@ ORDER BY
 ----
 sort
  ├── columns: l_returnflag:9!null l_linestatus:10!null sum_qty:17!null sum_base_price:18!null sum_disc_price:20!null sum_charge:22!null avg_qty:23!null avg_price:24!null avg_disc:25!null count_order:26!null
+ ├── immutable
  ├── key: (9,10)
  ├── fd: (9,10)-->(17,18,20,22-26)
  ├── ordering: +9,+10
  └── group-by
       ├── columns: l_returnflag:9!null l_linestatus:10!null sum:17!null sum:18!null sum:20!null sum:22!null avg:23!null avg:24!null avg:25!null count_rows:26!null
       ├── grouping columns: l_returnflag:9!null l_linestatus:10!null
+      ├── immutable
       ├── key: (9,10)
       ├── fd: (9,10)-->(17,18,20,22-26)
       ├── project
       │    ├── columns: column19:19!null column21:21!null l_quantity:5!null l_extendedprice:6!null l_discount:7!null l_returnflag:9!null l_linestatus:10!null
+      │    ├── immutable
       │    ├── select
       │    │    ├── columns: l_quantity:5!null l_extendedprice:6!null l_discount:7!null l_tax:8!null l_returnflag:9!null l_linestatus:10!null l_shipdate:11!null
       │    │    ├── scan lineitem
@@ -59,8 +62,8 @@ sort
       │    │    └── filters
       │    │         └── l_shipdate:11 <= '1998-09-02' [outer=(11), constraints=(/11: (/NULL - /'1998-09-02']; tight)]
       │    └── projections
-      │         ├── l_extendedprice:6 * (1.0 - l_discount:7) [as=column19:19, outer=(6,7)]
-      │         └── (l_extendedprice:6 * (1.0 - l_discount:7)) * (l_tax:8 + 1.0) [as=column21:21, outer=(6-8)]
+      │         ├── l_extendedprice:6 * (1.0 - l_discount:7) [as=column19:19, outer=(6,7), immutable]
+      │         └── (l_extendedprice:6 * (1.0 - l_discount:7)) * (l_tax:8 + 1.0) [as=column21:21, outer=(6-8), immutable]
       └── aggregations
            ├── sum [as=sum:17, outer=(5)]
            │    └── l_quantity:5
@@ -342,11 +345,13 @@ limit
  ├── columns: l_orderkey:18!null revenue:35!null o_orderdate:13!null o_shippriority:16!null
  ├── internal-ordering: -35,+13
  ├── cardinality: [0 - 10]
+ ├── immutable
  ├── key: (18)
  ├── fd: (18)-->(13,16,35)
  ├── ordering: -35,+13
  ├── sort
  │    ├── columns: o_orderdate:13!null o_shippriority:16!null l_orderkey:18!null sum:35!null
+ │    ├── immutable
  │    ├── key: (18)
  │    ├── fd: (18)-->(13,16,35)
  │    ├── ordering: -35,+13
@@ -354,10 +359,12 @@ limit
  │    └── group-by
  │         ├── columns: o_orderdate:13!null o_shippriority:16!null l_orderkey:18!null sum:35!null
  │         ├── grouping columns: l_orderkey:18!null
+ │         ├── immutable
  │         ├── key: (18)
  │         ├── fd: (18)-->(13,16,35)
  │         ├── project
  │         │    ├── columns: column34:34!null o_orderdate:13!null o_shippriority:16!null l_orderkey:18!null
+ │         │    ├── immutable
  │         │    ├── fd: (18)-->(13,16)
  │         │    ├── inner-join (lookup lineitem)
  │         │    │    ├── columns: c_custkey:1!null c_mktsegment:7!null o_orderkey:9!null o_custkey:10!null o_orderdate:13!null o_shippriority:16!null l_orderkey:18!null l_extendedprice:23!null l_discount:24!null l_shipdate:28!null
@@ -393,7 +400,7 @@ limit
  │         │    │    └── filters
  │         │    │         └── l_shipdate:28 > '1995-03-15' [outer=(28), constraints=(/28: [/'1995-03-16' - ]; tight)]
  │         │    └── projections
- │         │         └── l_extendedprice:23 * (1.0 - l_discount:24) [as=column34:34, outer=(23,24)]
+ │         │         └── l_extendedprice:23 * (1.0 - l_discount:24) [as=column34:34, outer=(23,24), immutable]
  │         └── aggregations
  │              ├── sum [as=sum:35, outer=(34)]
  │              │    └── column34:34
@@ -516,16 +523,19 @@ ORDER BY
 ----
 sort
  ├── columns: n_name:42!null revenue:49!null
+ ├── immutable
  ├── key: (42)
  ├── fd: (42)-->(49)
  ├── ordering: -49
  └── group-by
       ├── columns: n_name:42!null sum:49!null
       ├── grouping columns: n_name:42!null
+      ├── immutable
       ├── key: (42)
       ├── fd: (42)-->(49)
       ├── project
       │    ├── columns: column48:48!null n_name:42!null
+      │    ├── immutable
       │    ├── inner-join (hash)
       │    │    ├── columns: c_custkey:1!null c_nationkey:4!null o_orderkey:9!null o_custkey:10!null o_orderdate:13!null l_orderkey:18!null l_suppkey:20!null l_extendedprice:23!null l_discount:24!null s_suppkey:34!null s_nationkey:37!null n_nationkey:41!null n_name:42!null n_regionkey:43!null r_regionkey:45!null r_name:46!null
       │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -588,7 +598,7 @@ sort
       │    │         ├── c_custkey:1 = o_custkey:10 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
       │    │         └── c_nationkey:4 = s_nationkey:37 [outer=(4,37), constraints=(/4: (/NULL - ]; /37: (/NULL - ]), fd=(4)==(37), (37)==(4)]
       │    └── projections
-      │         └── l_extendedprice:23 * (1.0 - l_discount:24) [as=column48:48, outer=(23,24)]
+      │         └── l_extendedprice:23 * (1.0 - l_discount:24) [as=column48:48, outer=(23,24), immutable]
       └── aggregations
            └── sum [as=sum:49, outer=(48)]
                 └── column48:48
@@ -622,10 +632,12 @@ WHERE
 scalar-group-by
  ├── columns: revenue:18
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(18)
  ├── project
  │    ├── columns: column17:17!null
+ │    ├── immutable
  │    ├── select
  │    │    ├── columns: l_quantity:5!null l_extendedprice:6!null l_discount:7!null l_shipdate:11!null
  │    │    ├── index-join lineitem
@@ -639,7 +651,7 @@ scalar-group-by
  │    │         ├── (l_discount:7 >= 0.05) AND (l_discount:7 <= 0.07) [outer=(7), constraints=(/7: [/0.05 - /0.07]; tight)]
  │    │         └── l_quantity:5 < 24.0 [outer=(5), constraints=(/5: (/NULL - /23.999999999999996]; tight)]
  │    └── projections
- │         └── l_extendedprice:6 * l_discount:7 [as=column17:17, outer=(6,7)]
+ │         └── l_extendedprice:6 * l_discount:7 [as=column17:17, outer=(6,7), immutable]
  └── aggregations
       └── sum [as=sum:18, outer=(17)]
            └── column17:17
@@ -759,7 +771,7 @@ sort
       │    │         └── s_nationkey:4 = n1.n_nationkey:41 [outer=(4,41), constraints=(/4: (/NULL - ]; /41: (/NULL - ]), fd=(4)==(41), (41)==(4)]
       │    └── projections
       │         ├── extract('year', l_shipdate:18) [as=l_year:49, outer=(18), immutable]
-      │         └── l_extendedprice:13 * (1.0 - l_discount:14) [as=volume:50, outer=(13,14)]
+      │         └── l_extendedprice:13 * (1.0 - l_discount:14) [as=volume:50, outer=(13,14), immutable]
       └── aggregations
            └── sum [as=sum:51, outer=(50)]
                 └── volume:50
@@ -934,7 +946,7 @@ sort
       │    │    │    │         └── p_partkey:1 = l_partkey:18 [outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
       │    │    │    └── projections
       │    │    │         ├── extract('year', o_orderdate:37) [as=o_year:61, outer=(37), immutable]
-      │    │    │         └── l_extendedprice:22 * (1.0 - l_discount:23) [as=volume:62, outer=(22,23)]
+      │    │    │         └── l_extendedprice:22 * (1.0 - l_discount:23) [as=volume:62, outer=(22,23), immutable]
       │    │    └── projections
       │    │         └── CASE WHEN n2.n_name:55 = 'BRAZIL' THEN volume:62 ELSE 0.0 END [as=column63:63, outer=(55,62)]
       │    └── aggregations
@@ -1060,7 +1072,7 @@ sort
       │    │         └── p_name:2 LIKE '%green%' [outer=(2), constraints=(/2: (/NULL - ])]
       │    └── projections
       │         ├── extract('year', o_orderdate:42) [as=o_year:51, outer=(42), immutable]
-      │         └── (l_extendedprice:22 * (1.0 - l_discount:23)) - (ps_supplycost:36 * l_quantity:21) [as=amount:52, outer=(21-23,36)]
+      │         └── (l_extendedprice:22 * (1.0 - l_discount:23)) - (ps_supplycost:36 * l_quantity:21) [as=amount:52, outer=(21-23,36), immutable]
       └── aggregations
            └── sum [as=sum:53, outer=(52)]
                 └── amount:52
@@ -1117,11 +1129,13 @@ limit
  ├── columns: c_custkey:1!null c_name:2!null revenue:39!null c_acctbal:6!null n_name:35!null c_address:3!null c_phone:5!null c_comment:8!null
  ├── internal-ordering: -39
  ├── cardinality: [0 - 20]
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2,3,5,6,8,35,39)
  ├── ordering: -39
  ├── sort
  │    ├── columns: c_custkey:1!null c_name:2!null c_address:3!null c_phone:5!null c_acctbal:6!null c_comment:8!null n_name:35!null sum:39!null
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3,5,6,8,35,39)
  │    ├── ordering: -39
@@ -1129,10 +1143,12 @@ limit
  │    └── group-by
  │         ├── columns: c_custkey:1!null c_name:2!null c_address:3!null c_phone:5!null c_acctbal:6!null c_comment:8!null n_name:35!null sum:39!null
  │         ├── grouping columns: c_custkey:1!null
+ │         ├── immutable
  │         ├── key: (1)
  │         ├── fd: (1)-->(2,3,5,6,8,35,39)
  │         ├── project
  │         │    ├── columns: column38:38!null c_custkey:1!null c_name:2!null c_address:3!null c_phone:5!null c_acctbal:6!null c_comment:8!null n_name:35!null
+ │         │    ├── immutable
  │         │    ├── fd: (1)-->(2,3,5,6,8,35)
  │         │    ├── inner-join (hash)
  │         │    │    ├── columns: c_custkey:1!null c_name:2!null c_address:3!null c_nationkey:4!null c_phone:5!null c_acctbal:6!null c_comment:8!null o_orderkey:9!null o_custkey:10!null o_orderdate:13!null l_orderkey:18!null l_extendedprice:23!null l_discount:24!null l_returnflag:26!null n_nationkey:34!null n_name:35!null
@@ -1170,7 +1186,7 @@ limit
  │         │    │    └── filters
  │         │    │         └── c_nationkey:4 = n_nationkey:34 [outer=(4,34), constraints=(/4: (/NULL - ]; /34: (/NULL - ]), fd=(4)==(34), (34)==(4)]
  │         │    └── projections
- │         │         └── l_extendedprice:23 * (1.0 - l_discount:24) [as=column38:38, outer=(23,24)]
+ │         │         └── l_extendedprice:23 * (1.0 - l_discount:24) [as=column38:38, outer=(23,24), immutable]
  │         └── aggregations
  │              ├── sum [as=sum:39, outer=(38)]
  │              │    └── column38:38
@@ -1334,7 +1350,7 @@ sort
                           │         └── sum [as=sum:36, outer=(35)]
                           │              └── column35:35
                           └── projections
-                               └── sum:36 * 0.0001 [as="?column?":37, outer=(36)]
+                               └── sum:36 * 0.0001 [as="?column?":37, outer=(36), immutable]
 
 # --------------------------------------------------
 # Q12
@@ -1527,10 +1543,12 @@ project
  ├── scalar-group-by
  │    ├── columns: sum:27 sum:29
  │    ├── cardinality: [1 - 1]
+ │    ├── immutable
  │    ├── key: ()
  │    ├── fd: ()-->(27,29)
  │    ├── project
  │    │    ├── columns: column26:26!null column28:28!null
+ │    │    ├── immutable
  │    │    ├── inner-join (hash)
  │    │    │    ├── columns: l_partkey:2!null l_extendedprice:6!null l_discount:7!null l_shipdate:11!null p_partkey:17!null p_type:21!null
  │    │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(exactly-one)
@@ -1549,8 +1567,8 @@ project
  │    │    │    └── filters
  │    │    │         └── l_partkey:2 = p_partkey:17 [outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ]), fd=(2)==(17), (17)==(2)]
  │    │    └── projections
- │    │         ├── CASE WHEN p_type:21 LIKE 'PROMO%' THEN l_extendedprice:6 * (1.0 - l_discount:7) ELSE 0.0 END [as=column26:26, outer=(6,7,21)]
- │    │         └── l_extendedprice:6 * (1.0 - l_discount:7) [as=column28:28, outer=(6,7)]
+ │    │         ├── CASE WHEN p_type:21 LIKE 'PROMO%' THEN l_extendedprice:6 * (1.0 - l_discount:7) ELSE 0.0 END [as=column26:26, outer=(6,7,21), immutable]
+ │    │         └── l_extendedprice:6 * (1.0 - l_discount:7) [as=column28:28, outer=(6,7), immutable]
  │    └── aggregations
  │         ├── sum [as=sum:27, outer=(26)]
  │         │    └── column26:26
@@ -1607,6 +1625,7 @@ ORDER BY
 ----
 project
  ├── columns: s_suppkey:1!null s_name:2!null s_address:3!null s_phone:5!null total_revenue:25!null
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2,3,5,25)
  ├── ordering: +1
@@ -1614,6 +1633,7 @@ project
       ├── columns: s_suppkey:1!null s_name:2!null s_address:3!null s_phone:5!null l_suppkey:10!null sum:25!null
       ├── left ordering: +1
       ├── right ordering: +10
+      ├── immutable
       ├── key: (10)
       ├── fd: (1)-->(2,3,5), (10)-->(25), (1)==(10), (10)==(1)
       ├── ordering: +(1|10) [actual: +1]
@@ -1624,20 +1644,24 @@ project
       │    └── ordering: +1
       ├── sort
       │    ├── columns: l_suppkey:10!null sum:25!null
+      │    ├── immutable
       │    ├── key: (10)
       │    ├── fd: (10)-->(25)
       │    ├── ordering: +10
       │    └── select
       │         ├── columns: l_suppkey:10!null sum:25!null
+      │         ├── immutable
       │         ├── key: (10)
       │         ├── fd: (10)-->(25)
       │         ├── group-by
       │         │    ├── columns: l_suppkey:10!null sum:25!null
       │         │    ├── grouping columns: l_suppkey:10!null
+      │         │    ├── immutable
       │         │    ├── key: (10)
       │         │    ├── fd: (10)-->(25)
       │         │    ├── project
       │         │    │    ├── columns: column24:24!null l_suppkey:10!null
+      │         │    │    ├── immutable
       │         │    │    ├── index-join lineitem
       │         │    │    │    ├── columns: l_suppkey:10!null l_extendedprice:13!null l_discount:14!null l_shipdate:18!null
       │         │    │    │    └── scan lineitem@l_sd
@@ -1646,26 +1670,29 @@ project
       │         │    │    │         ├── key: (8,11)
       │         │    │    │         └── fd: (8,11)-->(18)
       │         │    │    └── projections
-      │         │    │         └── l_extendedprice:13 * (1.0 - l_discount:14) [as=column24:24, outer=(13,14)]
+      │         │    │         └── l_extendedprice:13 * (1.0 - l_discount:14) [as=column24:24, outer=(13,14), immutable]
       │         │    └── aggregations
       │         │         └── sum [as=sum:25, outer=(24)]
       │         │              └── column24:24
       │         └── filters
-      │              └── eq [outer=(25), subquery, constraints=(/25: (/NULL - ])]
+      │              └── eq [outer=(25), immutable, subquery, constraints=(/25: (/NULL - ])]
       │                   ├── sum:25
       │                   └── subquery
       │                        └── scalar-group-by
       │                             ├── columns: max:44
       │                             ├── cardinality: [1 - 1]
+      │                             ├── immutable
       │                             ├── key: ()
       │                             ├── fd: ()-->(44)
       │                             ├── group-by
       │                             │    ├── columns: l_suppkey:28!null sum:43!null
       │                             │    ├── grouping columns: l_suppkey:28!null
+      │                             │    ├── immutable
       │                             │    ├── key: (28)
       │                             │    ├── fd: (28)-->(43)
       │                             │    ├── project
       │                             │    │    ├── columns: column42:42!null l_suppkey:28!null
+      │                             │    │    ├── immutable
       │                             │    │    ├── index-join lineitem
       │                             │    │    │    ├── columns: l_suppkey:28!null l_extendedprice:31!null l_discount:32!null l_shipdate:36!null
       │                             │    │    │    └── scan lineitem@l_sd
@@ -1674,7 +1701,7 @@ project
       │                             │    │    │         ├── key: (26,29)
       │                             │    │    │         └── fd: (26,29)-->(36)
       │                             │    │    └── projections
-      │                             │    │         └── l_extendedprice:31 * (1.0 - l_discount:32) [as=column42:42, outer=(31,32)]
+      │                             │    │         └── l_extendedprice:31 * (1.0 - l_discount:32) [as=column42:42, outer=(31,32), immutable]
       │                             │    └── aggregations
       │                             │         └── sum [as=sum:43, outer=(42)]
       │                             │              └── column42:42
@@ -1820,25 +1847,30 @@ WHERE
 project
  ├── columns: avg_yearly:45
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(45)
  ├── scalar-group-by
  │    ├── columns: sum:44
  │    ├── cardinality: [1 - 1]
+ │    ├── immutable
  │    ├── key: ()
  │    ├── fd: ()-->(44)
  │    ├── inner-join (lookup lineitem)
  │    │    ├── columns: l_partkey:2!null l_quantity:5!null l_extendedprice:6!null p_partkey:17!null "?column?":43!null
  │    │    ├── key columns: [1 4] = [1 4]
  │    │    ├── lookup columns are key
+ │    │    ├── immutable
  │    │    ├── fd: (17)-->(43), (2)==(17), (17)==(2)
  │    │    ├── inner-join (lookup lineitem@l_pk)
  │    │    │    ├── columns: l_orderkey:1!null l_partkey:2!null l_linenumber:4!null p_partkey:17!null "?column?":43
  │    │    │    ├── key columns: [17] = [2]
+ │    │    │    ├── immutable
  │    │    │    ├── key: (1,4)
  │    │    │    ├── fd: (17)-->(43), (1,4)-->(2), (2)==(17), (17)==(2)
  │    │    │    ├── project
  │    │    │    │    ├── columns: "?column?":43 p_partkey:17!null
+ │    │    │    │    ├── immutable
  │    │    │    │    ├── key: (17)
  │    │    │    │    ├── fd: (17)-->(43)
  │    │    │    │    ├── group-by
@@ -1878,7 +1910,7 @@ project
  │    │    │    │    │         └── avg [as=avg:42, outer=(30)]
  │    │    │    │    │              └── l_quantity:30
  │    │    │    │    └── projections
- │    │    │    │         └── avg:42 * 0.2 [as="?column?":43, outer=(42)]
+ │    │    │    │         └── avg:42 * 0.2 [as="?column?":43, outer=(42), immutable]
  │    │    │    └── filters (true)
  │    │    └── filters
  │    │         └── l_quantity:5 < "?column?":43 [outer=(5,43), constraints=(/5: (/NULL - ]; /43: (/NULL - ])]
@@ -2067,10 +2099,12 @@ WHERE
 scalar-group-by
  ├── columns: revenue:27
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(27)
  ├── project
  │    ├── columns: column26:26!null
+ │    ├── immutable
  │    ├── inner-join (hash)
  │    │    ├── columns: l_partkey:2!null l_quantity:5!null l_extendedprice:6!null l_discount:7!null l_shipinstruct:14!null l_shipmode:15!null p_partkey:17!null p_brand:20!null p_size:22!null p_container:23!null
  │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -2097,7 +2131,7 @@ scalar-group-by
  │    │         ├── p_partkey:17 = l_partkey:2 [outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ]), fd=(2)==(17), (17)==(2)]
  │    │         └── ((((((p_brand:20 = 'Brand#12') AND (p_container:23 IN ('SM BOX', 'SM CASE', 'SM PACK', 'SM PKG'))) AND (l_quantity:5 >= 1.0)) AND (l_quantity:5 <= 11.0)) AND (p_size:22 <= 5)) OR (((((p_brand:20 = 'Brand#23') AND (p_container:23 IN ('MED BAG', 'MED BOX', 'MED PACK', 'MED PKG'))) AND (l_quantity:5 >= 10.0)) AND (l_quantity:5 <= 20.0)) AND (p_size:22 <= 10))) OR (((((p_brand:20 = 'Brand#34') AND (p_container:23 IN ('LG BOX', 'LG CASE', 'LG PACK', 'LG PKG'))) AND (l_quantity:5 >= 20.0)) AND (l_quantity:5 <= 30.0)) AND (p_size:22 <= 15)) [outer=(5,20,22,23), constraints=(/5: [/1.0 - /30.0]; /20: [/'Brand#12' - /'Brand#12'] [/'Brand#23' - /'Brand#23'] [/'Brand#34' - /'Brand#34']; /22: (/NULL - /15]; /23: [/'LG BOX' - /'LG BOX'] [/'LG CASE' - /'LG CASE'] [/'LG PACK' - /'LG PACK'] [/'LG PKG' - /'LG PKG'] [/'MED BAG' - /'MED BAG'] [/'MED BOX' - /'MED BOX'] [/'MED PACK' - /'MED PACK'] [/'MED PKG' - /'MED PKG'] [/'SM BOX' - /'SM BOX'] [/'SM CASE' - /'SM CASE'] [/'SM PACK' - /'SM PACK'] [/'SM PKG' - /'SM PKG'])]
  │    └── projections
- │         └── l_extendedprice:6 * (1.0 - l_discount:7) [as=column26:26, outer=(6,7)]
+ │         └── l_extendedprice:6 * (1.0 - l_discount:7) [as=column26:26, outer=(6,7), immutable]
  └── aggregations
       └── sum [as=sum:27, outer=(26)]
            └── column26:26
@@ -2157,16 +2191,20 @@ ORDER BY
 ----
 sort
  ├── columns: s_name:2!null s_address:3!null
+ ├── immutable
  ├── ordering: +2
  └── project
       ├── columns: s_name:2!null s_address:3!null
+      ├── immutable
       └── inner-join (hash)
            ├── columns: s_suppkey:1!null s_name:2!null s_address:3!null s_nationkey:4!null n_nationkey:8!null n_name:9!null
            ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+           ├── immutable
            ├── key: (1)
            ├── fd: ()-->(9), (1)-->(2-4), (4)==(8), (8)==(4)
            ├── semi-join (hash)
            │    ├── columns: s_suppkey:1!null s_name:2!null s_address:3!null s_nationkey:4!null
+           │    ├── immutable
            │    ├── key: (1)
            │    ├── fd: (1)-->(2-4)
            │    ├── scan supplier
@@ -2175,18 +2213,22 @@ sort
            │    │    └── fd: (1)-->(2-4)
            │    ├── project
            │    │    ├── columns: ps_partkey:12!null ps_suppkey:13!null
+           │    │    ├── immutable
            │    │    ├── key: (12,13)
            │    │    └── project
            │    │         ├── columns: ps_partkey:12!null ps_suppkey:13!null p_partkey:17!null
+           │    │         ├── immutable
            │    │         ├── key: (13,17)
            │    │         ├── fd: (12)==(17), (17)==(12)
            │    │         └── inner-join (hash)
            │    │              ├── columns: ps_partkey:12!null ps_suppkey:13!null ps_availqty:14!null p_partkey:17!null p_name:18!null sum:42
            │    │              ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+           │    │              ├── immutable
            │    │              ├── key: (13,17)
            │    │              ├── fd: (12,13)-->(14,42), (17)-->(18), (12)==(17), (17)==(12)
            │    │              ├── select
            │    │              │    ├── columns: ps_partkey:12!null ps_suppkey:13!null ps_availqty:14!null sum:42
+           │    │              │    ├── immutable
            │    │              │    ├── key: (12,13)
            │    │              │    ├── fd: (12,13)-->(14,42)
            │    │              │    ├── group-by
@@ -2217,7 +2259,7 @@ sort
            │    │              │    │         └── const-agg [as=ps_availqty:14, outer=(14)]
            │    │              │    │              └── ps_availqty:14
            │    │              │    └── filters
-           │    │              │         └── ps_availqty:14 > (sum:42 * 0.5) [outer=(14,42), constraints=(/14: (/NULL - ])]
+           │    │              │         └── ps_availqty:14 > (sum:42 * 0.5) [outer=(14,42), immutable, constraints=(/14: (/NULL - ])]
            │    │              ├── select
            │    │              │    ├── columns: p_partkey:17!null p_name:18!null
            │    │              │    ├── key: (17)

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -40,14 +40,17 @@ ORDER BY
 group-by
  ├── columns: l_returnflag:9!null l_linestatus:10!null sum_qty:17!null sum_base_price:18!null sum_disc_price:20!null sum_charge:22!null avg_qty:23!null avg_price:24!null avg_disc:25!null count_order:26!null
  ├── grouping columns: l_returnflag:9!null l_linestatus:10!null
+ ├── immutable
  ├── key: (9,10)
  ├── fd: (9,10)-->(17,18,20,22-26)
  ├── ordering: +9,+10
  ├── sort
  │    ├── columns: l_quantity:5!null l_extendedprice:6!null l_discount:7!null l_returnflag:9!null l_linestatus:10!null column19:19!null column21:21!null
+ │    ├── immutable
  │    ├── ordering: +9,+10
  │    └── project
  │         ├── columns: column19:19!null column21:21!null l_quantity:5!null l_extendedprice:6!null l_discount:7!null l_returnflag:9!null l_linestatus:10!null
+ │         ├── immutable
  │         ├── select
  │         │    ├── columns: l_quantity:5!null l_extendedprice:6!null l_discount:7!null l_tax:8!null l_returnflag:9!null l_linestatus:10!null l_shipdate:11!null
  │         │    ├── scan lineitem
@@ -55,8 +58,8 @@ group-by
  │         │    └── filters
  │         │         └── l_shipdate:11 <= '1998-09-02' [outer=(11), constraints=(/11: (/NULL - /'1998-09-02']; tight)]
  │         └── projections
- │              ├── l_extendedprice:6 * (1.0 - l_discount:7) [as=column19:19, outer=(6,7)]
- │              └── (l_extendedprice:6 * (1.0 - l_discount:7)) * (l_tax:8 + 1.0) [as=column21:21, outer=(6-8)]
+ │              ├── l_extendedprice:6 * (1.0 - l_discount:7) [as=column19:19, outer=(6,7), immutable]
+ │              └── (l_extendedprice:6 * (1.0 - l_discount:7)) * (l_tax:8 + 1.0) [as=column21:21, outer=(6-8), immutable]
  └── aggregations
       ├── sum [as=sum:17, outer=(5)]
       │    └── l_quantity:5
@@ -339,11 +342,13 @@ limit
  ├── columns: l_orderkey:18!null revenue:35!null o_orderdate:13!null o_shippriority:16!null
  ├── internal-ordering: -35,+13
  ├── cardinality: [0 - 10]
+ ├── immutable
  ├── key: (18)
  ├── fd: (18)-->(13,16,35)
  ├── ordering: -35,+13
  ├── sort
  │    ├── columns: o_orderdate:13!null o_shippriority:16!null l_orderkey:18!null sum:35!null
+ │    ├── immutable
  │    ├── key: (18)
  │    ├── fd: (18)-->(13,16,35)
  │    ├── ordering: -35,+13
@@ -351,10 +356,12 @@ limit
  │    └── group-by
  │         ├── columns: o_orderdate:13!null o_shippriority:16!null l_orderkey:18!null sum:35!null
  │         ├── grouping columns: l_orderkey:18!null
+ │         ├── immutable
  │         ├── key: (18)
  │         ├── fd: (18)-->(13,16,35)
  │         ├── project
  │         │    ├── columns: column34:34!null o_orderdate:13!null o_shippriority:16!null l_orderkey:18!null
+ │         │    ├── immutable
  │         │    ├── fd: (18)-->(13,16)
  │         │    ├── inner-join (hash)
  │         │    │    ├── columns: c_custkey:1!null c_mktsegment:7!null o_orderkey:9!null o_custkey:10!null o_orderdate:13!null o_shippriority:16!null l_orderkey:18!null l_extendedprice:23!null l_discount:24!null l_shipdate:28!null
@@ -393,7 +400,7 @@ limit
  │         │    │    └── filters
  │         │    │         └── l_orderkey:18 = o_orderkey:9 [outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ]), fd=(9)==(18), (18)==(9)]
  │         │    └── projections
- │         │         └── l_extendedprice:23 * (1.0 - l_discount:24) [as=column34:34, outer=(23,24)]
+ │         │         └── l_extendedprice:23 * (1.0 - l_discount:24) [as=column34:34, outer=(23,24), immutable]
  │         └── aggregations
  │              ├── sum [as=sum:35, outer=(34)]
  │              │    └── column34:34
@@ -520,16 +527,19 @@ ORDER BY
 ----
 sort
  ├── columns: n_name:42!null revenue:49!null
+ ├── immutable
  ├── key: (42)
  ├── fd: (42)-->(49)
  ├── ordering: -49
  └── group-by
       ├── columns: n_name:42!null sum:49!null
       ├── grouping columns: n_name:42!null
+      ├── immutable
       ├── key: (42)
       ├── fd: (42)-->(49)
       ├── project
       │    ├── columns: column48:48!null n_name:42!null
+      │    ├── immutable
       │    ├── inner-join (hash)
       │    │    ├── columns: c_custkey:1!null c_nationkey:4!null o_orderkey:9!null o_custkey:10!null o_orderdate:13!null l_orderkey:18!null l_suppkey:20!null l_extendedprice:23!null l_discount:24!null s_suppkey:34!null s_nationkey:37!null n_nationkey:41!null n_name:42!null n_regionkey:43!null r_regionkey:45!null r_name:46!null
       │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -600,7 +610,7 @@ sort
       │    │         ├── c_custkey:1 = o_custkey:10 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
       │    │         └── c_nationkey:4 = s_nationkey:37 [outer=(4,37), constraints=(/4: (/NULL - ]; /37: (/NULL - ]), fd=(4)==(37), (37)==(4)]
       │    └── projections
-      │         └── l_extendedprice:23 * (1.0 - l_discount:24) [as=column48:48, outer=(23,24)]
+      │         └── l_extendedprice:23 * (1.0 - l_discount:24) [as=column48:48, outer=(23,24), immutable]
       └── aggregations
            └── sum [as=sum:49, outer=(48)]
                 └── column48:48
@@ -634,10 +644,12 @@ WHERE
 scalar-group-by
  ├── columns: revenue:18
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(18)
  ├── project
  │    ├── columns: column17:17!null
+ │    ├── immutable
  │    ├── select
  │    │    ├── columns: l_quantity:5!null l_extendedprice:6!null l_discount:7!null l_shipdate:11!null
  │    │    ├── scan lineitem
@@ -647,7 +659,7 @@ scalar-group-by
  │    │         ├── (l_shipdate:11 >= '1994-01-01') AND (l_shipdate:11 < '1995-01-01') [outer=(11), constraints=(/11: [/'1994-01-01' - /'1994-12-31']; tight)]
  │    │         └── l_quantity:5 < 24.0 [outer=(5), constraints=(/5: (/NULL - /23.999999999999996]; tight)]
  │    └── projections
- │         └── l_extendedprice:6 * l_discount:7 [as=column17:17, outer=(6,7)]
+ │         └── l_extendedprice:6 * l_discount:7 [as=column17:17, outer=(6,7), immutable]
  └── aggregations
       └── sum [as=sum:18, outer=(17)]
            └── column17:17
@@ -780,7 +792,7 @@ group-by
  │         │         └── s_nationkey:4 = n1.n_nationkey:41 [outer=(4,41), constraints=(/4: (/NULL - ]; /41: (/NULL - ]), fd=(4)==(41), (41)==(4)]
  │         └── projections
  │              ├── extract('year', l_shipdate:18) [as=l_year:49, outer=(18), immutable]
- │              └── l_extendedprice:13 * (1.0 - l_discount:14) [as=volume:50, outer=(13,14)]
+ │              └── l_extendedprice:13 * (1.0 - l_discount:14) [as=volume:50, outer=(13,14), immutable]
  └── aggregations
       └── sum [as=sum:51, outer=(50)]
            └── volume:50
@@ -943,7 +955,7 @@ sort
       │    │    │    │         └── p_type:5 = 'ECONOMY ANODIZED STEEL' [outer=(5), constraints=(/5: [/'ECONOMY ANODIZED STEEL' - /'ECONOMY ANODIZED STEEL']; tight), fd=()-->(5)]
       │    │    │    └── projections
       │    │    │         ├── extract('year', o_orderdate:37) [as=o_year:61, outer=(37), immutable]
-      │    │    │         └── l_extendedprice:22 * (1.0 - l_discount:23) [as=volume:62, outer=(22,23)]
+      │    │    │         └── l_extendedprice:22 * (1.0 - l_discount:23) [as=volume:62, outer=(22,23), immutable]
       │    │    └── projections
       │    │         └── CASE WHEN n2.n_name:55 = 'BRAZIL' THEN volume:62 ELSE 0.0 END [as=column63:63, outer=(55,62)]
       │    └── aggregations
@@ -1069,7 +1081,7 @@ sort
       │    │         └── p_name:2 LIKE '%green%' [outer=(2), constraints=(/2: (/NULL - ])]
       │    └── projections
       │         ├── extract('year', o_orderdate:42) [as=o_year:51, outer=(42), immutable]
-      │         └── (l_extendedprice:22 * (1.0 - l_discount:23)) - (ps_supplycost:36 * l_quantity:21) [as=amount:52, outer=(21-23,36)]
+      │         └── (l_extendedprice:22 * (1.0 - l_discount:23)) - (ps_supplycost:36 * l_quantity:21) [as=amount:52, outer=(21-23,36), immutable]
       └── aggregations
            └── sum [as=sum:53, outer=(52)]
                 └── amount:52
@@ -1126,11 +1138,13 @@ limit
  ├── columns: c_custkey:1!null c_name:2!null revenue:39!null c_acctbal:6!null n_name:35!null c_address:3!null c_phone:5!null c_comment:8!null
  ├── internal-ordering: -39
  ├── cardinality: [0 - 20]
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2,3,5,6,8,35,39)
  ├── ordering: -39
  ├── sort
  │    ├── columns: c_custkey:1!null c_name:2!null c_address:3!null c_phone:5!null c_acctbal:6!null c_comment:8!null n_name:35!null sum:39!null
+ │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3,5,6,8,35,39)
  │    ├── ordering: -39
@@ -1138,10 +1152,12 @@ limit
  │    └── group-by
  │         ├── columns: c_custkey:1!null c_name:2!null c_address:3!null c_phone:5!null c_acctbal:6!null c_comment:8!null n_name:35!null sum:39!null
  │         ├── grouping columns: c_custkey:1!null
+ │         ├── immutable
  │         ├── key: (1)
  │         ├── fd: (1)-->(2,3,5,6,8,35,39)
  │         ├── project
  │         │    ├── columns: column38:38!null c_custkey:1!null c_name:2!null c_address:3!null c_phone:5!null c_acctbal:6!null c_comment:8!null n_name:35!null
+ │         │    ├── immutable
  │         │    ├── fd: (1)-->(2,3,5,6,8,35)
  │         │    ├── inner-join (lookup nation)
  │         │    │    ├── columns: c_custkey:1!null c_name:2!null c_address:3!null c_nationkey:4!null c_phone:5!null c_acctbal:6!null c_comment:8!null o_orderkey:9!null o_custkey:10!null o_orderdate:13!null l_orderkey:18!null l_extendedprice:23!null l_discount:24!null l_returnflag:26!null n_nationkey:34!null n_name:35!null
@@ -1170,7 +1186,7 @@ limit
  │         │    │    │    └── filters (true)
  │         │    │    └── filters (true)
  │         │    └── projections
- │         │         └── l_extendedprice:23 * (1.0 - l_discount:24) [as=column38:38, outer=(23,24)]
+ │         │         └── l_extendedprice:23 * (1.0 - l_discount:24) [as=column38:38, outer=(23,24), immutable]
  │         └── aggregations
  │              ├── sum [as=sum:39, outer=(38)]
  │              │    └── column38:38
@@ -1328,7 +1344,7 @@ sort
                           │         └── sum [as=sum:36, outer=(35)]
                           │              └── column35:35
                           └── projections
-                               └── sum:36 * 0.0001 [as="?column?":37, outer=(36)]
+                               └── sum:36 * 0.0001 [as="?column?":37, outer=(36), immutable]
 
 # --------------------------------------------------
 # Q12
@@ -1518,10 +1534,12 @@ project
  ├── scalar-group-by
  │    ├── columns: sum:27 sum:29
  │    ├── cardinality: [1 - 1]
+ │    ├── immutable
  │    ├── key: ()
  │    ├── fd: ()-->(27,29)
  │    ├── project
  │    │    ├── columns: column26:26!null column28:28!null
+ │    │    ├── immutable
  │    │    ├── inner-join (hash)
  │    │    │    ├── columns: l_partkey:2!null l_extendedprice:6!null l_discount:7!null l_shipdate:11!null p_partkey:17!null p_type:21!null
  │    │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(exactly-one)
@@ -1539,8 +1557,8 @@ project
  │    │    │    └── filters
  │    │    │         └── l_partkey:2 = p_partkey:17 [outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ]), fd=(2)==(17), (17)==(2)]
  │    │    └── projections
- │    │         ├── CASE WHEN p_type:21 LIKE 'PROMO%' THEN l_extendedprice:6 * (1.0 - l_discount:7) ELSE 0.0 END [as=column26:26, outer=(6,7,21)]
- │    │         └── l_extendedprice:6 * (1.0 - l_discount:7) [as=column28:28, outer=(6,7)]
+ │    │         ├── CASE WHEN p_type:21 LIKE 'PROMO%' THEN l_extendedprice:6 * (1.0 - l_discount:7) ELSE 0.0 END [as=column26:26, outer=(6,7,21), immutable]
+ │    │         └── l_extendedprice:6 * (1.0 - l_discount:7) [as=column28:28, outer=(6,7), immutable]
  │    └── aggregations
  │         ├── sum [as=sum:27, outer=(26)]
  │         │    └── column26:26
@@ -1597,30 +1615,36 @@ ORDER BY
 ----
 sort
  ├── columns: s_suppkey:1!null s_name:2!null s_address:3!null s_phone:5!null total_revenue:25!null
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2,3,5,25)
  ├── ordering: +1
  └── project
       ├── columns: s_suppkey:1!null s_name:2!null s_address:3!null s_phone:5!null sum:25!null
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2,3,5,25)
       └── inner-join (lookup supplier)
            ├── columns: s_suppkey:1!null s_name:2!null s_address:3!null s_phone:5!null l_suppkey:10!null sum:25!null
            ├── key columns: [10] = [1]
            ├── lookup columns are key
+           ├── immutable
            ├── key: (10)
            ├── fd: (1)-->(2,3,5), (10)-->(25), (1)==(10), (10)==(1)
            ├── select
            │    ├── columns: l_suppkey:10!null sum:25!null
+           │    ├── immutable
            │    ├── key: (10)
            │    ├── fd: (10)-->(25)
            │    ├── group-by
            │    │    ├── columns: l_suppkey:10!null sum:25!null
            │    │    ├── grouping columns: l_suppkey:10!null
+           │    │    ├── immutable
            │    │    ├── key: (10)
            │    │    ├── fd: (10)-->(25)
            │    │    ├── project
            │    │    │    ├── columns: column24:24!null l_suppkey:10!null
+           │    │    │    ├── immutable
            │    │    │    ├── select
            │    │    │    │    ├── columns: l_suppkey:10!null l_extendedprice:13!null l_discount:14!null l_shipdate:18!null
            │    │    │    │    ├── scan lineitem
@@ -1628,26 +1652,29 @@ sort
            │    │    │    │    └── filters
            │    │    │    │         └── (l_shipdate:18 >= '1996-01-01') AND (l_shipdate:18 < '1996-04-01') [outer=(18), constraints=(/18: [/'1996-01-01' - /'1996-03-31']; tight)]
            │    │    │    └── projections
-           │    │    │         └── l_extendedprice:13 * (1.0 - l_discount:14) [as=column24:24, outer=(13,14)]
+           │    │    │         └── l_extendedprice:13 * (1.0 - l_discount:14) [as=column24:24, outer=(13,14), immutable]
            │    │    └── aggregations
            │    │         └── sum [as=sum:25, outer=(24)]
            │    │              └── column24:24
            │    └── filters
-           │         └── eq [outer=(25), subquery, constraints=(/25: (/NULL - ])]
+           │         └── eq [outer=(25), immutable, subquery, constraints=(/25: (/NULL - ])]
            │              ├── sum:25
            │              └── subquery
            │                   └── scalar-group-by
            │                        ├── columns: max:44
            │                        ├── cardinality: [1 - 1]
+           │                        ├── immutable
            │                        ├── key: ()
            │                        ├── fd: ()-->(44)
            │                        ├── group-by
            │                        │    ├── columns: l_suppkey:28!null sum:43!null
            │                        │    ├── grouping columns: l_suppkey:28!null
+           │                        │    ├── immutable
            │                        │    ├── key: (28)
            │                        │    ├── fd: (28)-->(43)
            │                        │    ├── project
            │                        │    │    ├── columns: column42:42!null l_suppkey:28!null
+           │                        │    │    ├── immutable
            │                        │    │    ├── select
            │                        │    │    │    ├── columns: l_suppkey:28!null l_extendedprice:31!null l_discount:32!null l_shipdate:36!null
            │                        │    │    │    ├── scan lineitem
@@ -1655,7 +1682,7 @@ sort
            │                        │    │    │    └── filters
            │                        │    │    │         └── (l_shipdate:36 >= '1996-01-01') AND (l_shipdate:36 < '1996-04-01') [outer=(36), constraints=(/36: [/'1996-01-01' - /'1996-03-31']; tight)]
            │                        │    │    └── projections
-           │                        │    │         └── l_extendedprice:31 * (1.0 - l_discount:32) [as=column42:42, outer=(31,32)]
+           │                        │    │         └── l_extendedprice:31 * (1.0 - l_discount:32) [as=column42:42, outer=(31,32), immutable]
            │                        │    └── aggregations
            │                        │         └── sum [as=sum:43, outer=(42)]
            │                        │              └── column42:42
@@ -1795,25 +1822,30 @@ WHERE
 project
  ├── columns: avg_yearly:45
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(45)
  ├── scalar-group-by
  │    ├── columns: sum:44
  │    ├── cardinality: [1 - 1]
+ │    ├── immutable
  │    ├── key: ()
  │    ├── fd: ()-->(44)
  │    ├── inner-join (lookup lineitem)
  │    │    ├── columns: l_partkey:2!null l_quantity:5!null l_extendedprice:6!null p_partkey:17!null "?column?":43!null
  │    │    ├── key columns: [1 4] = [1 4]
  │    │    ├── lookup columns are key
+ │    │    ├── immutable
  │    │    ├── fd: (17)-->(43), (2)==(17), (17)==(2)
  │    │    ├── inner-join (lookup lineitem@l_pk)
  │    │    │    ├── columns: l_orderkey:1!null l_partkey:2!null l_linenumber:4!null p_partkey:17!null "?column?":43
  │    │    │    ├── key columns: [17] = [2]
+ │    │    │    ├── immutable
  │    │    │    ├── key: (1,4)
  │    │    │    ├── fd: (17)-->(43), (1,4)-->(2), (2)==(17), (17)==(2)
  │    │    │    ├── project
  │    │    │    │    ├── columns: "?column?":43 p_partkey:17!null
+ │    │    │    │    ├── immutable
  │    │    │    │    ├── key: (17)
  │    │    │    │    ├── fd: (17)-->(43)
  │    │    │    │    ├── group-by
@@ -1853,7 +1885,7 @@ project
  │    │    │    │    │         └── avg [as=avg:42, outer=(30)]
  │    │    │    │    │              └── l_quantity:30
  │    │    │    │    └── projections
- │    │    │    │         └── avg:42 * 0.2 [as="?column?":43, outer=(42)]
+ │    │    │    │         └── avg:42 * 0.2 [as="?column?":43, outer=(42), immutable]
  │    │    │    └── filters (true)
  │    │    └── filters
  │    │         └── l_quantity:5 < "?column?":43 [outer=(5,43), constraints=(/5: (/NULL - ]; /43: (/NULL - ])]
@@ -2048,10 +2080,12 @@ WHERE
 scalar-group-by
  ├── columns: revenue:27
  ├── cardinality: [1 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(27)
  ├── project
  │    ├── columns: column26:26!null
+ │    ├── immutable
  │    ├── inner-join (lookup part)
  │    │    ├── columns: l_partkey:2!null l_quantity:5!null l_extendedprice:6!null l_discount:7!null l_shipinstruct:14!null l_shipmode:15!null p_partkey:17!null p_brand:20!null p_size:22!null p_container:23!null
  │    │    ├── key columns: [2] = [17]
@@ -2069,7 +2103,7 @@ scalar-group-by
  │    │         ├── ((((((p_brand:20 = 'Brand#12') AND (p_container:23 IN ('SM BOX', 'SM CASE', 'SM PACK', 'SM PKG'))) AND (l_quantity:5 >= 1.0)) AND (l_quantity:5 <= 11.0)) AND (p_size:22 <= 5)) OR (((((p_brand:20 = 'Brand#23') AND (p_container:23 IN ('MED BAG', 'MED BOX', 'MED PACK', 'MED PKG'))) AND (l_quantity:5 >= 10.0)) AND (l_quantity:5 <= 20.0)) AND (p_size:22 <= 10))) OR (((((p_brand:20 = 'Brand#34') AND (p_container:23 IN ('LG BOX', 'LG CASE', 'LG PACK', 'LG PKG'))) AND (l_quantity:5 >= 20.0)) AND (l_quantity:5 <= 30.0)) AND (p_size:22 <= 15)) [outer=(5,20,22,23), constraints=(/5: [/1.0 - /30.0]; /20: [/'Brand#12' - /'Brand#12'] [/'Brand#23' - /'Brand#23'] [/'Brand#34' - /'Brand#34']; /22: (/NULL - /15]; /23: [/'LG BOX' - /'LG BOX'] [/'LG CASE' - /'LG CASE'] [/'LG PACK' - /'LG PACK'] [/'LG PKG' - /'LG PKG'] [/'MED BAG' - /'MED BAG'] [/'MED BOX' - /'MED BOX'] [/'MED PACK' - /'MED PACK'] [/'MED PKG' - /'MED PKG'] [/'SM BOX' - /'SM BOX'] [/'SM CASE' - /'SM CASE'] [/'SM PACK' - /'SM PACK'] [/'SM PKG' - /'SM PKG'])]
  │    │         └── p_size:22 >= 1 [outer=(22), constraints=(/22: [/1 - ]; tight)]
  │    └── projections
- │         └── l_extendedprice:6 * (1.0 - l_discount:7) [as=column26:26, outer=(6,7)]
+ │         └── l_extendedprice:6 * (1.0 - l_discount:7) [as=column26:26, outer=(6,7), immutable]
  └── aggregations
       └── sum [as=sum:27, outer=(26)]
            └── column26:26
@@ -2129,37 +2163,46 @@ ORDER BY
 ----
 sort
  ├── columns: s_name:2!null s_address:3!null
+ ├── immutable
  ├── ordering: +2
  └── project
       ├── columns: s_name:2!null s_address:3!null
+      ├── immutable
       └── inner-join (lookup nation)
            ├── columns: s_suppkey:1!null s_name:2!null s_address:3!null s_nationkey:4!null n_nationkey:8!null n_name:9!null
            ├── key columns: [4] = [8]
            ├── lookup columns are key
+           ├── immutable
            ├── key: (1)
            ├── fd: ()-->(9), (1)-->(2-4), (4)==(8), (8)==(4)
            ├── project
            │    ├── columns: s_suppkey:1!null s_name:2!null s_address:3!null s_nationkey:4!null
+           │    ├── immutable
            │    ├── key: (1)
            │    ├── fd: (1)-->(2-4)
            │    └── inner-join (lookup supplier)
            │         ├── columns: s_suppkey:1!null s_name:2!null s_address:3!null s_nationkey:4!null ps_suppkey:13!null
            │         ├── key columns: [13] = [1]
            │         ├── lookup columns are key
+           │         ├── immutable
            │         ├── key: (13)
            │         ├── fd: (1)-->(2-4), (1)==(13), (13)==(1)
            │         ├── distinct-on
            │         │    ├── columns: ps_suppkey:13!null
            │         │    ├── grouping columns: ps_suppkey:13!null
+           │         │    ├── immutable
            │         │    ├── key: (13)
            │         │    └── semi-join (hash)
            │         │         ├── columns: ps_partkey:12!null ps_suppkey:13!null
+           │         │         ├── immutable
            │         │         ├── key: (12,13)
            │         │         ├── project
            │         │         │    ├── columns: ps_partkey:12!null ps_suppkey:13!null
+           │         │         │    ├── immutable
            │         │         │    ├── key: (12,13)
            │         │         │    └── select
            │         │         │         ├── columns: ps_partkey:12!null ps_suppkey:13!null ps_availqty:14!null sum:42
+           │         │         │         ├── immutable
            │         │         │         ├── key: (12,13)
            │         │         │         ├── fd: (12,13)-->(14,42)
            │         │         │         ├── group-by
@@ -2190,7 +2233,7 @@ sort
            │         │         │         │         └── const-agg [as=ps_availqty:14, outer=(14)]
            │         │         │         │              └── ps_availqty:14
            │         │         │         └── filters
-           │         │         │              └── ps_availqty:14 > (sum:42 * 0.5) [outer=(14,42), constraints=(/14: (/NULL - ])]
+           │         │         │              └── ps_availqty:14 > (sum:42 * 0.5) [outer=(14,42), immutable, constraints=(/14: (/NULL - ])]
            │         │         ├── select
            │         │         │    ├── columns: p_partkey:17!null p_name:18!null
            │         │         │    ├── key: (17)

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -549,6 +549,7 @@ FROM CardsView WHERE Version > 1584421773604892000.0000000000
 ----
 project
  ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null buyprice:9!null sellprice:10!null desiredinventory:12!null actualinventory:13!null version:15!null discount:11!null maxinventory:14!null
+ ├── immutable
  ├── stats: [rows=1]
  ├── key: (15)
  ├── fd: (1)-->(2-6,9-15), (2,4,5)~~>(1,3,6), (15)-->(1-6,9-14)
@@ -556,11 +557,13 @@ project
       ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null dealerid:7!null cardid:8!null buyprice:9!null sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null version:15!null
       ├── key columns: [8] = [1]
       ├── lookup columns are key
+      ├── immutable
       ├── stats: [rows=1, distinct(1)=0.0201621393, null(1)=0, distinct(8)=0.0201621393, null(8)=0]
       ├── key: (8)
       ├── fd: ()-->(7), (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(9-15), (15)-->(8-14), (1)==(8), (8)==(1)
       ├── index-join cardsinfo
       │    ├── columns: dealerid:7!null cardid:8!null buyprice:9!null sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null version:15!null
+      │    ├── immutable
       │    ├── stats: [rows=0.0201621426, distinct(7)=0.0201621426, null(7)=0, distinct(8)=0.0201621393, null(8)=0, distinct(9)=0.02016214, null(9)=0, distinct(10)=0.02016214, null(10)=0, distinct(11)=0.02016214, null(11)=0, distinct(12)=0.02016214, null(12)=0, distinct(13)=0.02016214, null(13)=0, distinct(14)=0.02016214, null(14)=0, distinct(15)=0.0201621426, null(15)=0, distinct(7,15)=0.0201621426, null(7,15)=0]
       │    │   histogram(15)=  0                0                 0.020162           0
       │    │                 <--- 1584421773604892000.0000000000 ---------- 1584421778604892000
@@ -735,6 +738,7 @@ LIMIT 50
 project
  ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null buyprice:9!null sellprice:10!null desiredinventory:12!null actualinventory:13!null version:15!null discount:11!null maxinventory:14!null twodaysales:25
  ├── cardinality: [0 - 50]
+ ├── immutable
  ├── stats: [rows=50]
  ├── key: (15,25)
  ├── fd: (1)-->(2-6,9-15), (2,4,5)~~>(1,3,6), (15)-->(1-6,9-14)
@@ -743,12 +747,14 @@ project
  │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.cardid:8!null cardsinfo.buyprice:9!null cardsinfo.sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null cardsinfo.version:15!null sum:24
  │    ├── internal-ordering: +2,+4,+5
  │    ├── cardinality: [0 - 50]
+ │    ├── immutable
  │    ├── stats: [rows=50]
  │    ├── key: (8)
  │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(1-6,9-15,24), (15)-->(8-14), (1)==(8), (8)==(1)
  │    ├── ordering: +2,+4,+5
  │    ├── sort
  │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.cardid:8!null cardsinfo.buyprice:9!null cardsinfo.sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null cardsinfo.version:15!null sum:24
+ │    │    ├── immutable
  │    │    ├── stats: [rows=19000, distinct(8)=19000, null(8)=0]
  │    │    ├── key: (8)
  │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(1-6,9-15,24), (15)-->(8-14), (1)==(8), (8)==(1)
@@ -757,11 +763,13 @@ project
  │    │    └── group-by
  │    │         ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.cardid:8!null cardsinfo.buyprice:9!null cardsinfo.sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null cardsinfo.version:15!null sum:24
  │    │         ├── grouping columns: cardsinfo.cardid:8!null
+ │    │         ├── immutable
  │    │         ├── stats: [rows=19000, distinct(8)=19000, null(8)=0]
  │    │         ├── key: (8)
  │    │         ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(1-6,9-15,24), (15)-->(8-14), (1)==(8), (8)==(1)
  │    │         ├── right-join (hash)
  │    │         │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:7!null cardsinfo.cardid:8!null cardsinfo.buyprice:9!null cardsinfo.sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null cardsinfo.version:15!null transactiondetails.dealerid:16 isbuy:17 transactiondate:18 transactiondetails.cardid:19 quantity:20
+ │    │         │    ├── immutable
  │    │         │    ├── stats: [rows=5523583.18, distinct(8)=19000, null(8)=0, distinct(19)=19000, null(19)=0]
  │    │         │    ├── key: (8,18-20)
  │    │         │    ├── fd: ()-->(7), (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(9-15), (15)-->(8-14), (1)==(8), (8)==(1), (8,18-20)-->(16,17)
@@ -775,11 +783,13 @@ project
  │    │         │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:7!null cardsinfo.cardid:8!null cardsinfo.buyprice:9!null cardsinfo.sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null cardsinfo.version:15!null
  │    │         │    │    ├── left ordering: +1
  │    │         │    │    ├── right ordering: +8
+ │    │         │    │    ├── immutable
  │    │         │    │    ├── stats: [rows=29618.4611, distinct(1)=19000, null(1)=0, distinct(2)=11668.1409, null(2)=0, distinct(5)=829, null(5)=0, distinct(6)=5572.85686, null(6)=0, distinct(7)=1, null(7)=0, distinct(8)=19000, null(8)=0, distinct(9)=21037.9959, null(9)=0, distinct(10)=21037.9959, null(10)=0, distinct(11)=21037.9959, null(11)=0, distinct(12)=21037.9959, null(12)=0, distinct(13)=21037.9959, null(13)=0, distinct(14)=21037.9959, null(14)=0, distinct(15)=23225.5851, null(15)=0]
  │    │         │    │    ├── key: (8)
  │    │         │    │    ├── fd: ()-->(7), (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(9-15), (15)-->(8-14), (1)==(8), (8)==(1)
  │    │         │    │    ├── select
  │    │         │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
+ │    │         │    │    │    ├── immutable
  │    │         │    │    │    ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0, distinct(5)=829, null(5)=0, distinct(6)=5601.15328, null(6)=0]
  │    │         │    │    │    ├── key: (1)
  │    │         │    │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6)
@@ -791,7 +801,7 @@ project
  │    │         │    │    │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6)
  │    │         │    │    │    │    └── ordering: +1
  │    │         │    │    │    └── filters
- │    │         │    │    │         └── (name:2, setname:4, number:5) > ('Shock', '7E', 248) [outer=(2,4,5), constraints=(/2/4/5: [/'Shock'/'7E'/249 - ]; tight)]
+ │    │         │    │    │         └── (name:2, setname:4, number:5) > ('Shock', '7E', 248) [outer=(2,4,5), immutable, constraints=(/2/4/5: [/'Shock'/'7E'/249 - ]; tight)]
  │    │         │    │    ├── scan cardsinfo
  │    │         │    │    │    ├── columns: cardsinfo.dealerid:7!null cardsinfo.cardid:8!null cardsinfo.buyprice:9!null cardsinfo.sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null cardsinfo.version:15!null
  │    │         │    │    │    ├── constraint: /7/8: [/1 - /1]
@@ -942,9 +952,9 @@ sort
       │    │    └── filters
       │    │         └── id:16 = transactiondetails.cardid:4 [outer=(4,16), constraints=(/4: (/NULL - ]; /16: (/NULL - ]), fd=(4)==(16), (16)==(4)]
       │    └── projections
-      │         ├── transactiondetails.sellprice:6 * quantity:5 [as=column31:31, outer=(5,6)]
-      │         ├── transactiondetails.buyprice:7 * quantity:5 [as=column33:33, outer=(5,7)]
-      │         ├── quantity:5 * (transactiondetails.sellprice:6 - transactiondetails.buyprice:7) [as=column35:35, outer=(5-7)]
+      │         ├── transactiondetails.sellprice:6 * quantity:5 [as=column31:31, outer=(5,6), immutable]
+      │         ├── transactiondetails.buyprice:7 * quantity:5 [as=column33:33, outer=(5,7), immutable]
+      │         ├── quantity:5 * (transactiondetails.sellprice:6 - transactiondetails.buyprice:7) [as=column35:35, outer=(5-7), immutable]
       │         └── extract('day', transactiondate:3) [as=column37:37, outer=(3), stable]
       └── aggregations
            ├── sum [as=sum:32, outer=(31)]

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -557,6 +557,7 @@ FROM CardsView WHERE Version > 1584421773604892000.0000000000
 ----
 project
  ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null buyprice:9!null sellprice:10!null desiredinventory:12!null actualinventory:13!null version:15!null discount:11!null maxinventory:14!null
+ ├── immutable
  ├── stats: [rows=1]
  ├── key: (15)
  ├── fd: (1)-->(2-6,9-15), (2,4,5)~~>(1,3,6), (15)-->(1-6,9-14)
@@ -564,11 +565,13 @@ project
       ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null dealerid:7!null cardid:8!null buyprice:9!null sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null version:15!null
       ├── key columns: [8] = [1]
       ├── lookup columns are key
+      ├── immutable
       ├── stats: [rows=1, distinct(1)=6.35833333e-05, null(1)=0, distinct(8)=6.35833333e-05, null(8)=0]
       ├── key: (8)
       ├── fd: ()-->(7), (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(9-15), (15)-->(8-14), (1)==(8), (8)==(1)
       ├── index-join cardsinfo
       │    ├── columns: dealerid:7!null cardid:8!null buyprice:9!null sellprice:10!null discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null version:15!null
+      │    ├── immutable
       │    ├── stats: [rows=6.35833333e-05, distinct(7)=6.35833333e-05, null(7)=0, distinct(8)=6.35833333e-05, null(8)=0, distinct(9)=6.35833333e-05, null(9)=0, distinct(10)=6.35833333e-05, null(10)=0, distinct(11)=6.35833333e-05, null(11)=0, distinct(12)=6.35833333e-05, null(12)=0, distinct(13)=6.35833333e-05, null(13)=0, distinct(14)=6.35833333e-05, null(14)=0, distinct(15)=6.35833333e-05, null(15)=0, distinct(7,15)=6.35833333e-05, null(7,15)=0]
       │    │   histogram(15)=
       │    ├── key: (8)
@@ -739,6 +742,7 @@ LIMIT 50
 project
  ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null buyprice:9!null sellprice:10!null desiredinventory:12!null actualinventory:13!null version:15!null discount:11!null maxinventory:14!null twodaysales:31
  ├── cardinality: [0 - 50]
+ ├── immutable
  ├── stats: [rows=50]
  ├── key: (15,31)
  ├── fd: (1)-->(2-6,9-15), (2,4,5)~~>(1,3,6), (15)-->(1-6,9-14)
@@ -747,12 +751,14 @@ project
  │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.cardid:8!null cardsinfo.buyprice:9!null cardsinfo.sellprice:10!null cardsinfo.discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null cardsinfo.version:15!null sum:30
  │    ├── internal-ordering: +2,+4,+5
  │    ├── cardinality: [0 - 50]
+ │    ├── immutable
  │    ├── stats: [rows=50]
  │    ├── key: (8)
  │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(1-6,9-15,30), (15)-->(8-14), (1)==(8), (8)==(1)
  │    ├── ordering: +2,+4,+5
  │    ├── sort
  │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.cardid:8!null cardsinfo.buyprice:9!null cardsinfo.sellprice:10!null cardsinfo.discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null cardsinfo.version:15!null sum:30
+ │    │    ├── immutable
  │    │    ├── stats: [rows=19000, distinct(8)=19000, null(8)=0]
  │    │    ├── key: (8)
  │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(1-6,9-15,30), (15)-->(8-14), (1)==(8), (8)==(1)
@@ -761,11 +767,13 @@ project
  │    │    └── group-by
  │    │         ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.cardid:8!null cardsinfo.buyprice:9!null cardsinfo.sellprice:10!null cardsinfo.discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null cardsinfo.version:15!null sum:30
  │    │         ├── grouping columns: cardsinfo.cardid:8!null
+ │    │         ├── immutable
  │    │         ├── stats: [rows=19000, distinct(8)=19000, null(8)=0]
  │    │         ├── key: (8)
  │    │         ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(1-6,9-15,30), (15)-->(8-14), (1)==(8), (8)==(1)
  │    │         ├── right-join (hash)
  │    │         │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:7!null cardsinfo.cardid:8!null cardsinfo.buyprice:9!null cardsinfo.sellprice:10!null cardsinfo.discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null cardsinfo.version:15!null transactiondetails.dealerid:20 isbuy:21 transactiondate:22 transactiondetails.cardid:23 quantity:24
+ │    │         │    ├── immutable
  │    │         │    ├── stats: [rows=5523583.18, distinct(8)=19000, null(8)=0, distinct(23)=19000, null(23)=0]
  │    │         │    ├── key: (8,22-24)
  │    │         │    ├── fd: ()-->(7), (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(9-15), (15)-->(8-14), (1)==(8), (8)==(1), (8,22-24)-->(20,21)
@@ -779,11 +787,13 @@ project
  │    │         │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:7!null cardsinfo.cardid:8!null cardsinfo.buyprice:9!null cardsinfo.sellprice:10!null cardsinfo.discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null cardsinfo.version:15!null
  │    │         │    │    ├── left ordering: +1
  │    │         │    │    ├── right ordering: +8
+ │    │         │    │    ├── immutable
  │    │         │    │    ├── stats: [rows=29618.4611, distinct(1)=19000, null(1)=0, distinct(2)=11668.1409, null(2)=0, distinct(5)=829, null(5)=0, distinct(6)=5572.85686, null(6)=0, distinct(7)=1, null(7)=0, distinct(8)=19000, null(8)=0, distinct(9)=21037.9959, null(9)=0, distinct(10)=21037.9959, null(10)=0, distinct(11)=21037.9959, null(11)=0, distinct(12)=21037.9959, null(12)=0, distinct(13)=21037.9959, null(13)=0, distinct(14)=21037.9959, null(14)=0, distinct(15)=23225.5851, null(15)=0]
  │    │         │    │    ├── key: (8)
  │    │         │    │    ├── fd: ()-->(7), (1)-->(2-6), (2,4,5)~~>(1,3,6), (8)-->(9-15), (15)-->(8-14), (1)==(8), (8)==(1)
  │    │         │    │    ├── select
  │    │         │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
+ │    │         │    │    │    ├── immutable
  │    │         │    │    │    ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0, distinct(5)=829, null(5)=0, distinct(6)=5601.15328, null(6)=0]
  │    │         │    │    │    ├── key: (1)
  │    │         │    │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6)
@@ -795,7 +805,7 @@ project
  │    │         │    │    │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6)
  │    │         │    │    │    │    └── ordering: +1
  │    │         │    │    │    └── filters
- │    │         │    │    │         └── (name:2, setname:4, number:5) > ('Shock', '7E', 248) [outer=(2,4,5), constraints=(/2/4/5: [/'Shock'/'7E'/249 - ]; tight)]
+ │    │         │    │    │         └── (name:2, setname:4, number:5) > ('Shock', '7E', 248) [outer=(2,4,5), immutable, constraints=(/2/4/5: [/'Shock'/'7E'/249 - ]; tight)]
  │    │         │    │    ├── scan cardsinfo
  │    │         │    │    │    ├── columns: cardsinfo.dealerid:7!null cardsinfo.cardid:8!null cardsinfo.buyprice:9!null cardsinfo.sellprice:10!null cardsinfo.discount:11!null desiredinventory:12!null actualinventory:13!null maxinventory:14!null cardsinfo.version:15!null
  │    │         │    │    │    ├── constraint: /7/8: [/1 - /1]
@@ -946,9 +956,9 @@ sort
       │    │    └── filters
       │    │         └── id:20 = transactiondetails.cardid:4 [outer=(4,20), constraints=(/4: (/NULL - ]; /20: (/NULL - ]), fd=(4)==(20), (20)==(4)]
       │    └── projections
-      │         ├── transactiondetails.sellprice:6 * quantity:5 [as=column39:39, outer=(5,6)]
-      │         ├── transactiondetails.buyprice:7 * quantity:5 [as=column41:41, outer=(5,7)]
-      │         ├── quantity:5 * (transactiondetails.sellprice:6 - transactiondetails.buyprice:7) [as=column43:43, outer=(5-7)]
+      │         ├── transactiondetails.sellprice:6 * quantity:5 [as=column39:39, outer=(5,6), immutable]
+      │         ├── transactiondetails.buyprice:7 * quantity:5 [as=column41:41, outer=(5,7), immutable]
+      │         ├── quantity:5 * (transactiondetails.sellprice:6 - transactiondetails.buyprice:7) [as=column43:43, outer=(5-7), immutable]
       │         └── extract('day', transactiondate:3) [as=column45:45, outer=(3), stable]
       └── aggregations
            ├── sum [as=sum:40, outer=(39)]

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -130,6 +130,7 @@ SELECT x+1 AS r, y FROM a ORDER BY x, y DESC
 ----
 project
  ├── columns: r:5!null y:2!null  [hidden: x:1!null]
+ ├── immutable
  ├── key: (1,2)
  ├── fd: (1)-->(5)
  ├── ordering: +1,-2
@@ -138,7 +139,7 @@ project
  │    ├── key: (1,2)
  │    └── ordering: +1,-2
  └── projections
-      └── x:1 + 1 [as=r:5, outer=(1)]
+      └── x:1 + 1 [as=r:5, outer=(1), immutable]
 
 # Pass through ordering to scan operator that can't support it.
 opt
@@ -146,11 +147,13 @@ SELECT y, x, z+1 AS r FROM a ORDER BY x, y
 ----
 sort (segmented)
  ├── columns: y:2!null x:1!null r:5
+ ├── immutable
  ├── key: (1,2)
  ├── fd: (1,2)-->(5)
  ├── ordering: +1,+2
  └── project
       ├── columns: r:5 x:1!null y:2!null
+      ├── immutable
       ├── key: (1,2)
       ├── fd: (1,2)-->(5)
       ├── ordering: +1
@@ -160,7 +163,7 @@ sort (segmented)
       │    ├── fd: (1,2)-->(3)
       │    └── ordering: +1
       └── projections
-           └── z:3 + 1 [as=r:5, outer=(3)]
+           └── z:3 + 1 [as=r:5, outer=(3), immutable]
 
 # Ordering cannot be passed through because it includes computed column.
 opt
@@ -168,11 +171,13 @@ SELECT x, y+1 AS computed, y FROM a ORDER BY x, computed
 ----
 sort (segmented)
  ├── columns: x:1!null computed:5!null y:2!null
+ ├── immutable
  ├── key: (1,2)
  ├── fd: (1,2)-->(5)
  ├── ordering: +1,+5
  └── project
       ├── columns: computed:5!null x:1!null y:2!null
+      ├── immutable
       ├── key: (1,2)
       ├── fd: (1,2)-->(5)
       ├── ordering: +1
@@ -181,7 +186,7 @@ sort (segmented)
       │    ├── key: (1,2)
       │    └── ordering: +1
       └── projections
-           └── y:2 + 1.0 [as=computed:5, outer=(2)]
+           └── y:2 + 1.0 [as=computed:5, outer=(2), immutable]
 
 # Ordering on an expression that gets constant-folded to a simple variable.
 # Example from #43360: a boolean (possibly a placeholder) indicates the sort
@@ -243,6 +248,7 @@ SELECT y, x-1 AS z FROM a WHERE x>y ORDER BY x, y DESC
 ----
 project
  ├── columns: y:2!null z:5!null  [hidden: x:1!null]
+ ├── immutable
  ├── key: (1,2)
  ├── fd: (1)-->(5)
  ├── ordering: +1,-2
@@ -257,7 +263,7 @@ project
  │    └── filters
  │         └── x:1 > y:2 [outer=(1,2)]
  └── projections
-      └── x:1 - 1 [as=z:5, outer=(1)]
+      └── x:1 - 1 [as=z:5, outer=(1), immutable]
 
 memo
 SELECT y, x-1 AS z FROM a WHERE x>y ORDER BY x, y DESC
@@ -990,10 +996,12 @@ limit
  ├── columns: a:1!null b:2!null c:3!null
  ├── internal-ordering: +1,+2
  ├── cardinality: [0 - 10]
+ ├── immutable
  ├── key: (1-3)
  ├── ordering: +1,+2
  ├── select
  │    ├── columns: a:1!null b:2!null c:3!null
+ │    ├── immutable
  │    ├── key: (1-3)
  │    ├── ordering: +1,+2
  │    ├── limit hint: 10.00
@@ -1003,7 +1011,7 @@ limit
  │    │    ├── ordering: +1,+2
  │    │    └── limit hint: 30.00
  │    └── filters
- │         └── c:3 < (a:1 + b:2) [outer=(1-3)]
+ │         └── c:3 < (a:1 + b:2) [outer=(1-3), immutable]
  └── 10
 
 opt
@@ -1043,15 +1051,18 @@ SELECT * FROM (SELECT * FROM abc WHERE a+b>c ORDER BY a, b LIMIT 10) ORDER BY b
 sort
  ├── columns: a:1!null b:2!null c:3!null
  ├── cardinality: [0 - 10]
+ ├── immutable
  ├── key: (1-3)
  ├── ordering: +2
  └── limit
       ├── columns: a:1!null b:2!null c:3!null
       ├── internal-ordering: +1,+2
       ├── cardinality: [0 - 10]
+      ├── immutable
       ├── key: (1-3)
       ├── select
       │    ├── columns: a:1!null b:2!null c:3!null
+      │    ├── immutable
       │    ├── key: (1-3)
       │    ├── ordering: +1,+2
       │    ├── limit hint: 10.00
@@ -1061,7 +1072,7 @@ sort
       │    │    ├── ordering: +1,+2
       │    │    └── limit hint: 30.00
       │    └── filters
-      │         └── c:3 < (a:1 + b:2) [outer=(1-3)]
+      │         └── c:3 < (a:1 + b:2) [outer=(1-3), immutable]
       └── 10
 
 opt
@@ -1101,10 +1112,12 @@ limit
  ├── columns: a:1!null b:2!null c:3!null
  ├── internal-ordering: +1,+2
  ├── cardinality: [0 - 10]
+ ├── immutable
  ├── key: (1-3)
  ├── ordering: +1
  ├── select
  │    ├── columns: a:1!null b:2!null c:3!null
+ │    ├── immutable
  │    ├── key: (1-3)
  │    ├── ordering: +1,+2
  │    ├── limit hint: 10.00
@@ -1114,7 +1127,7 @@ limit
  │    │    ├── ordering: +1,+2
  │    │    └── limit hint: 30.00
  │    └── filters
- │         └── c:3 < (a:1 + b:2) [outer=(1-3)]
+ │         └── c:3 < (a:1 + b:2) [outer=(1-3), immutable]
  └── 10
 
 opt
@@ -1150,10 +1163,12 @@ limit
  ├── columns: a:1!null b:2!null c:3!null
  ├── internal-ordering: +1,+2
  ├── cardinality: [0 - 10]
+ ├── immutable
  ├── key: (1-3)
  ├── ordering: +1,+2,+3
  ├── select
  │    ├── columns: a:1!null b:2!null c:3!null
+ │    ├── immutable
  │    ├── key: (1-3)
  │    ├── ordering: +1,+2,+3
  │    ├── limit hint: 10.00
@@ -1163,7 +1178,7 @@ limit
  │    │    ├── ordering: +1,+2,+3
  │    │    └── limit hint: 30.00
  │    └── filters
- │         └── c:3 < (a:1 + b:2) [outer=(1-3)]
+ │         └── c:3 < (a:1 + b:2) [outer=(1-3), immutable]
  └── 10
 
 opt
@@ -1665,6 +1680,7 @@ sort
       │         └── project
       │              ├── columns: b_new:11 abcd.a:6 abcd.b:7 abcd.c:8 abcd.d:9 rowid:10!null
       │              ├── cardinality: [0 - 10]
+      │              ├── immutable
       │              ├── key: (10)
       │              ├── fd: (10)-->(6-9), (7)-->(11)
       │              ├── scan abcd@cd
@@ -1673,7 +1689,7 @@ sort
       │              │    ├── key: (10)
       │              │    └── fd: (10)-->(6-9)
       │              └── projections
-      │                   └── abcd.b:7 + 1 [as=b_new:11, outer=(7)]
+      │                   └── abcd.b:7 + 1 [as=b_new:11, outer=(7), immutable]
       └── with-scan &1
            ├── columns: a:12 b:13 c:14 d:15
            ├── mapping:
@@ -1718,6 +1734,7 @@ sort
       │         └── project
       │              ├── columns: b_new:11 abcd.a:6 abcd.b:7 abcd.c:8 abcd.d:9 rowid:10!null
       │              ├── cardinality: [0 - 10]
+      │              ├── immutable
       │              ├── key: (10)
       │              ├── fd: (10)-->(6-9), (7)-->(11)
       │              ├── scan abcd@cd
@@ -1726,7 +1743,7 @@ sort
       │              │    ├── key: (10)
       │              │    └── fd: (10)-->(6-9)
       │              └── projections
-      │                   └── abcd.b:7 + 1 [as=b_new:11, outer=(7)]
+      │                   └── abcd.b:7 + 1 [as=b_new:11, outer=(7), immutable]
       └── select
            ├── columns: a:12 b:13!null c:14!null d:15
            ├── cardinality: [0 - 10]

--- a/pkg/sql/opt/xform/testdata/physprops/presentation
+++ b/pkg/sql/opt/xform/testdata/physprops/presentation
@@ -36,6 +36,7 @@ SELECT 1+a.y AS plus, a.x FROM a
 ----
 project
  ├── columns: plus:3 x:1!null
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(3)
  ├── scan a
@@ -43,7 +44,7 @@ project
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── projections
-      └── y:2 + 1 [as=plus:3, outer=(2)]
+      └── y:2 + 1 [as=plus:3, outer=(2), immutable]
 
 # Join operator.
 opt

--- a/pkg/sql/opt/xform/testdata/rules/computed
+++ b/pkg/sql/opt/xform/testdata/rules/computed
@@ -81,8 +81,10 @@ SELECT k_int FROM t_mult WHERE (k_int, k_int_2) > (1, 2)
 ----
 project
  ├── columns: k_int:1!null
+ ├── immutable
  └── select
       ├── columns: k_int:1!null k_int_2:2
+      ├── immutable
       ├── scan t_mult
       │    ├── columns: k_int:1 k_int_2:2
       │    └── computed column expressions
@@ -93,7 +95,7 @@ project
       │         └── c_mult_2:5
       │              └── k_int:1 + 1
       └── filters
-           └── (k_int:1, k_int_2:2) > (1, 2) [outer=(1,2), constraints=(/1/2: [/1/3 - ]; tight)]
+           └── (k_int:1, k_int_2:2) > (1, 2) [outer=(1,2), immutable, constraints=(/1/2: [/1/3 - ]; tight)]
 
 # Don't constrain when filter has multiple spans.
 opt

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -766,6 +766,7 @@ SELECT v + 1, min(w), v FROM kuvw WHERE v = 5 AND w IS NOT NULL GROUP BY v
 project
  ├── columns: "?column?":6!null min:5!null v:3!null
  ├── cardinality: [0 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(3,5,6)
  ├── project
@@ -782,7 +783,7 @@ project
  │    └── projections
  │         └── w:4 [as=min:5, outer=(4)]
  └── projections
-      └── v:3 + 1 [as="?column?":6, outer=(3)]
+      └── v:3 + 1 [as="?column?":6, outer=(3), immutable]
 
 # Add const_agg function, as well as max function.
 opt expect=ReplaceMaxWithLimit
@@ -791,6 +792,7 @@ SELECT v + 1, max(w), v FROM kuvw WHERE v = 5 GROUP BY v
 project
  ├── columns: "?column?":6!null max:5 v:3!null
  ├── cardinality: [0 - 1]
+ ├── immutable
  ├── key: ()
  ├── fd: ()-->(3,5,6)
  ├── project
@@ -807,7 +809,7 @@ project
  │    └── projections
  │         └── w:4 [as=max:5, outer=(4)]
  └── projections
-      └── v:3 + 1 [as="?column?":6, outer=(3)]
+      └── v:3 + 1 [as="?column?":6, outer=(3), immutable]
 
 # Use multiple grouping columns with min function.
 opt expect=ReplaceMinWithLimit

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -2271,6 +2271,7 @@ SELECT b,a FROM t5 WHERE b @> '{"a":1}'
 ----
 index-join t5
  ├── columns: b:2 a:1!null
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2)
  └── scan t5@b_idx
@@ -2283,6 +2284,7 @@ SELECT b,a FROM t5 WHERE b @> '{"a":[[{"b":{"c":[{"d":"e"}]}}]]}'
 ----
 index-join t5
  ├── columns: b:2 a:1!null
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2)
  └── scan t5@b_idx
@@ -2298,6 +2300,7 @@ inner-join (lookup t5)
  ├── columns: b:2 a:1!null
  ├── key columns: [1] = [1]
  ├── lookup columns are key
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── inner-join (zigzag t5@b_idx t5@b_idx)
@@ -2307,7 +2310,7 @@ inner-join (lookup t5)
  │    ├── right fixed columns: [2] = ['{"c": 2}']
  │    └── filters (true)
  └── filters
-      └── b:2 @> '{"a": 1, "c": 2}' [outer=(2)]
+      └── b:2 @> '{"a": 1, "c": 2}' [outer=(2), immutable]
 
 memo
 SELECT a FROM t5 WHERE b @> '{"a":1, "c":2}'
@@ -2352,6 +2355,7 @@ inner-join (lookup t5)
  ├── columns: b:2 a:1!null
  ├── key columns: [1] = [1]
  ├── lookup columns are key
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── inner-join (zigzag t5@b_idx t5@b_idx)
@@ -2361,7 +2365,7 @@ inner-join (lookup t5)
  │    ├── right fixed columns: [2] = ['{"a": [{"d": 3}]}']
  │    └── filters (true)
  └── filters
-      └── b:2 @> '{"a": [{"b": "c", "d": 3}, 5]}' [outer=(2)]
+      └── b:2 @> '{"a": [{"b": "c", "d": 3}, 5]}' [outer=(2), immutable]
 
 # Regression test for issue where zero-column expressions could exist multiple
 # times in the tree, causing collisions.
@@ -2878,7 +2882,7 @@ select
  │         ├── volatile, side-effects
  │         └── key: (1)
  └── filters
-      └── b:2 @> '{"a": 1, "c": 2}' [outer=(2)]
+      └── b:2 @> '{"a": 1, "c": 2}' [outer=(2), immutable]
 
 # --------------------------------------------------
 # AssociateJoin

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -494,6 +494,7 @@ SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1
 select
  ├── columns: k:1!null u:2 v:3!null j:4
  ├── cardinality: [0 - 10]
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)-->(1,2,4)
  ├── index-join b
@@ -508,7 +509,7 @@ select
  │         ├── key: (1)
  │         └── fd: (1)-->(3), (3)-->(1)
  └── filters
-      └── (k:1 + u:2) = 1 [outer=(1,2)]
+      └── (k:1 + u:2) = 1 [outer=(1,2), immutable]
 
 memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1
@@ -550,6 +551,7 @@ SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1 AND k > 5
 select
  ├── columns: k:1!null u:2 v:3!null j:4
  ├── cardinality: [0 - 10]
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)-->(1,2,4)
  ├── index-join b
@@ -571,7 +573,7 @@ select
  │         └── filters
  │              └── k:1 > 5 [outer=(1), constraints=(/1: [/6 - ]; tight)]
  └── filters
-      └── (k:1 + u:2) = 1 [outer=(1,2)]
+      └── (k:1 + u:2) = 1 [outer=(1,2), immutable]
 
 memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1 AND k > 5
@@ -625,6 +627,7 @@ SELECT * FROM b WHERE (u, k, v) > (1, 2, 3) AND (u, k, v) < (8, 9, 10)
 ----
 select
  ├── columns: k:1!null u:2!null v:3 j:4
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
  ├── index-join b
@@ -637,8 +640,8 @@ select
  │         ├── key: (1)
  │         └── fd: (1)-->(2)
  └── filters
-      ├── (u:2, k:1, v:3) > (1, 2, 3) [outer=(1-3), constraints=(/2/1/3: [/1/2/4 - ]; tight)]
-      └── (u:2, k:1, v:3) < (8, 9, 10) [outer=(1-3), constraints=(/2/1/3: (/NULL - /8/9/9]; tight)]
+      ├── (u:2, k:1, v:3) > (1, 2, 3) [outer=(1-3), immutable, constraints=(/2/1/3: [/1/2/4 - ]; tight)]
+      └── (u:2, k:1, v:3) < (8, 9, 10) [outer=(1-3), immutable, constraints=(/2/1/3: (/NULL - /8/9/9]; tight)]
 
 memo
 SELECT * FROM b WHERE (u, k, v) > (1, 2, 3) AND (u, k, v) < (8, 9, 10)
@@ -734,7 +737,7 @@ select
  │         ├── key: (1)
  │         └── fd: (1)-->(3), (3)-->(1)
  └── filters
-      └── (k:1 + u:2) = 1 [outer=(1,2)]
+      └── (k:1 + u:2) = 1 [outer=(1,2), immutable]
 
 # --------------------------------------------------
 # GenerateInvertedIndexScans
@@ -746,9 +749,11 @@ SELECT k FROM b WHERE j @> '{"a": "b"}'
 ----
 project
  ├── columns: k:1!null
+ ├── immutable
  ├── key: (1)
  └── index-join b
       ├── columns: k:1!null j:4
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(4)
       └── scan b@inv_idx
@@ -789,11 +794,13 @@ SELECT k FROM b WHERE j @> '{"a": "b", "c": "d"}'
 ----
 project
  ├── columns: k:1!null
+ ├── immutable
  ├── key: (1)
  └── inner-join (lookup b)
       ├── columns: k:1!null j:4
       ├── key columns: [1] = [1]
       ├── lookup columns are key
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(4)
       ├── inner-join (zigzag b@inv_idx b@inv_idx)
@@ -803,7 +810,7 @@ project
       │    ├── right fixed columns: [4] = ['{"c": "d"}']
       │    └── filters (true)
       └── filters
-           └── j:4 @> '{"a": "b", "c": "d"}' [outer=(4)]
+           └── j:4 @> '{"a": "b", "c": "d"}' [outer=(4), immutable]
 
 # Query requiring an index join with no remaining filter.
 opt
@@ -811,10 +818,12 @@ SELECT u, k FROM b WHERE j @> '{"a": "b"}'
 ----
 project
  ├── columns: u:2 k:1!null
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2)
  └── index-join b
       ├── columns: k:1!null u:2 j:4
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2,4)
       └── scan b@inv_idx
@@ -827,6 +836,7 @@ SELECT j, k FROM b WHERE j @> '{"a": "b"}'
 ----
 index-join b
  ├── columns: j:4 k:1!null
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(4)
  └── scan b@inv_idx
@@ -839,6 +849,7 @@ SELECT * FROM b WHERE j @> '{"a": "b"}'
 ----
 index-join b
  ├── columns: k:1!null u:2 v:3 j:4
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
  └── scan b@inv_idx
@@ -855,6 +866,7 @@ inner-join (lookup b)
  ├── columns: j:4 k:1!null
  ├── key columns: [1] = [1]
  ├── lookup columns are key
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(4)
  ├── inner-join (zigzag b@inv_idx b@inv_idx)
@@ -864,7 +876,7 @@ inner-join (lookup b)
  │    ├── right fixed columns: [4] = ['{"c": "d"}']
  │    └── filters (true)
  └── filters
-      └── j:4 @> '{"a": "b", "c": "d"}' [outer=(4)]
+      └── j:4 @> '{"a": "b", "c": "d"}' [outer=(4), immutable]
 
 opt
 SELECT * FROM b WHERE j @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
@@ -873,6 +885,7 @@ inner-join (lookup b)
  ├── columns: k:1!null u:2 v:3 j:4
  ├── key columns: [1] = [1]
  ├── lookup columns are key
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
  ├── inner-join (zigzag b@inv_idx b@inv_idx)
@@ -882,13 +895,14 @@ inner-join (lookup b)
  │    ├── right fixed columns: [4] = ['{"a": {"d": "e"}}']
  │    └── filters (true)
  └── filters
-      └── j:4 @> '{"a": {"b": "c", "d": "e"}, "f": "g"}' [outer=(4)]
+      └── j:4 @> '{"a": {"b": "c", "d": "e"}, "f": "g"}' [outer=(4), immutable]
 
 opt
 SELECT * FROM b WHERE j @> '{}'
 ----
 select
  ├── columns: k:1!null u:2 v:3 j:4
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
  ├── scan b
@@ -896,13 +910,14 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3)~~>(1,2,4)
  └── filters
-      └── j:4 @> '{}' [outer=(4)]
+      └── j:4 @> '{}' [outer=(4), immutable]
 
 opt
 SELECT * FROM b WHERE j @> '[]'
 ----
 select
  ├── columns: k:1!null u:2 v:3 j:4
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
  ├── scan b
@@ -910,13 +925,14 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3)~~>(1,2,4)
  └── filters
-      └── j:4 @> '[]' [outer=(4)]
+      └── j:4 @> '[]' [outer=(4), immutable]
 
 opt
 SELECT * FROM b WHERE j @> '2'
 ----
 index-join b
  ├── columns: k:1!null u:2 v:3 j:4
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
  └── scan b@inv_idx
@@ -931,6 +947,7 @@ SELECT * FROM b WHERE j @> '[{}]'
 ----
 select
  ├── columns: k:1!null u:2 v:3 j:4
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
  ├── scan b
@@ -938,13 +955,14 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3)~~>(1,2,4)
  └── filters
-      └── j:4 @> '[{}]' [outer=(4)]
+      └── j:4 @> '[{}]' [outer=(4), immutable]
 
 opt
 SELECT * FROM b WHERE j @> '{"a": {}}'
 ----
 select
  ├── columns: k:1!null u:2 v:3 j:4
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
  ├── scan b
@@ -952,13 +970,14 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3)~~>(1,2,4)
  └── filters
-      └── j:4 @> '{"a": {}}' [outer=(4)]
+      └── j:4 @> '{"a": {}}' [outer=(4), immutable]
 
 opt
 SELECT * FROM b WHERE j @> '{"a": []}'
 ----
 select
  ├── columns: k:1!null u:2 v:3 j:4
+ ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
  ├── scan b
@@ -966,7 +985,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3)~~>(1,2,4)
  └── filters
-      └── j:4 @> '{"a": []}' [outer=(4)]
+      └── j:4 @> '{"a": []}' [outer=(4), immutable]
 
 # GenerateInvertedIndexScans propagates row-level locking information.
 opt
@@ -994,9 +1013,11 @@ SELECT k FROM c WHERE a @> ARRAY[1]
 ----
 project
  ├── columns: k:1!null
+ ├── immutable
  ├── key: (1)
  └── index-join c
       ├── columns: k:1!null a:2
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2)
       └── scan c@inv_idx
@@ -1009,11 +1030,13 @@ SELECT k FROM c WHERE a @> ARRAY[1,3,1,5]
 ----
 project
  ├── columns: k:1!null
+ ├── immutable
  ├── key: (1)
  └── inner-join (lookup c)
       ├── columns: k:1!null a:2
       ├── key columns: [1] = [1]
       ├── lookup columns are key
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2)
       ├── inner-join (zigzag c@inv_idx c@inv_idx)
@@ -1023,16 +1046,18 @@ project
       │    ├── right fixed columns: [2] = [ARRAY[3]]
       │    └── filters (true)
       └── filters
-           └── a:2 @> ARRAY[1,3,1,5] [outer=(2)]
+           └── a:2 @> ARRAY[1,3,1,5] [outer=(2), immutable]
 
 opt
 SELECT k FROM c WHERE a @> ARRAY[]::INT[]
 ----
 project
  ├── columns: k:1!null
+ ├── immutable
  ├── key: (1)
  └── select
       ├── columns: k:1!null a:2
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2)
       ├── scan c
@@ -1040,7 +1065,7 @@ project
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
       └── filters
-           └── a:2 @> ARRAY[] [outer=(2)]
+           └── a:2 @> ARRAY[] [outer=(2), immutable]
 
 opt
 SELECT k FROM c WHERE a IS NULL
@@ -1328,16 +1353,19 @@ SELECT k FROM b WHERE k = 1 OR j @> '{"foo": "bar"}'
 ----
 project
  ├── columns: k:1!null
+ ├── immutable
  ├── key: (1)
  └── distinct-on
       ├── columns: k:1!null j:4
       ├── grouping columns: k:1!null
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(4)
       ├── union-all
       │    ├── columns: k:1!null j:4
       │    ├── left columns: k:1!null j:4
       │    ├── right columns: k:5 j:8
+      │    ├── immutable
       │    ├── scan b
       │    │    ├── columns: k:1!null j:4
       │    │    ├── constraint: /1: [/1 - /1]
@@ -1346,6 +1374,7 @@ project
       │    │    └── fd: ()-->(1,4)
       │    └── index-join b
       │         ├── columns: k:5!null j:8
+      │         ├── immutable
       │         ├── key: (5)
       │         ├── fd: (5)-->(8)
       │         └── scan b@inv_idx
@@ -1362,16 +1391,19 @@ SELECT k FROM c WHERE k = 1 OR a @> ARRAY[2]
 ----
 project
  ├── columns: k:1!null
+ ├── immutable
  ├── key: (1)
  └── distinct-on
       ├── columns: k:1!null a:2
       ├── grouping columns: k:1!null
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2)
       ├── union-all
       │    ├── columns: k:1!null a:2
       │    ├── left columns: k:1!null a:2
       │    ├── right columns: k:4 a:5
+      │    ├── immutable
       │    ├── scan c
       │    │    ├── columns: k:1!null a:2
       │    │    ├── constraint: /1: [/1 - /1]
@@ -1380,6 +1412,7 @@ project
       │    │    └── fd: ()-->(1,2)
       │    └── index-join c
       │         ├── columns: k:4!null a:5
+      │         ├── immutable
       │         ├── key: (4)
       │         ├── fd: (4)-->(5)
       │         └── scan c@inv_idx
@@ -2299,15 +2332,18 @@ SELECT u, j FROM b WHERE u = 1 OR j @> '{"foo": "bar"}'
 ----
 project
  ├── columns: u:2 j:4
+ ├── immutable
  └── distinct-on
       ├── columns: k:1!null u:2 j:4
       ├── grouping columns: k:1!null
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2,4)
       ├── union-all
       │    ├── columns: k:1!null u:2 j:4
       │    ├── left columns: k:1!null u:2 j:4
       │    ├── right columns: k:5 u:6 j:8
+      │    ├── immutable
       │    ├── index-join b
       │    │    ├── columns: k:1!null u:2!null j:4
       │    │    ├── key: (1)
@@ -2319,6 +2355,7 @@ project
       │    │         └── fd: ()-->(2)
       │    └── index-join b
       │         ├── columns: k:5!null u:6 j:8
+      │         ├── immutable
       │         ├── key: (5)
       │         ├── fd: (5)-->(6,8)
       │         └── scan b@inv_idx
@@ -2337,15 +2374,18 @@ SELECT u, a FROM c WHERE u = 1 OR a @> ARRAY[2]
 ----
 project
  ├── columns: u:3 a:2
+ ├── immutable
  └── distinct-on
       ├── columns: k:1!null a:2 u:3
       ├── grouping columns: k:1!null
+      ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2,3)
       ├── union-all
       │    ├── columns: k:1!null a:2 u:3
       │    ├── left columns: k:1!null a:2 u:3
       │    ├── right columns: k:4 a:5 u:6
+      │    ├── immutable
       │    ├── index-join c
       │    │    ├── columns: k:1!null a:2 u:3!null
       │    │    ├── key: (1)
@@ -2357,6 +2397,7 @@ project
       │    │         └── fd: ()-->(3)
       │    └── index-join c
       │         ├── columns: k:4!null a:5 u:6
+      │         ├── immutable
       │         ├── key: (4)
       │         ├── fd: (4)-->(5,6)
       │         └── scan c@inv_idx


### PR DESCRIPTION
Incorporate volatility of operators (unary, binary, comparison) into the
VolatilitySet property.

Unfortunately, this modifies most plans as pretty much everything is
"immutable". Perhaps once this work is behind us we will want to hide this
information from plans in most cases.

Release note: None