### PR TITLE
release-20.1: backupccl: fix bug when backing up dropped tables with revision history

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -2431,6 +2431,70 @@ func TestRestoreAsOfSystemTime(t *testing.T) {
 			latestBackup,
 		)
 	})
+
+	t.Run("create-backup-drop-backup", func(t *testing.T) {
+		var tsBefore string
+		backupPath := "nodelocal://0/drop_table_db"
+
+		sqlDB.Exec(t, "CREATE DATABASE drop_table_db")
+		sqlDB.Exec(t, "CREATE DATABASE drop_table_db_restore")
+		sqlDB.Exec(t, "CREATE TABLE drop_table_db.a (k int, v string)")
+		sqlDB.Exec(t, `BACKUP DATABASE drop_table_db TO $1 WITH revision_history`, backupPath)
+		sqlDB.Exec(t, "INSERT INTO drop_table_db.a VALUES (1, 'foo')")
+		sqlDB.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&tsBefore)
+		sqlDB.Exec(t, "DROP TABLE drop_table_db.a")
+		sqlDB.Exec(t, `BACKUP DATABASE drop_table_db TO $1 WITH revision_history`, backupPath)
+		restoreQuery := fmt.Sprintf(
+			"RESTORE drop_table_db.* FROM $1 AS OF SYSTEM TIME %s WITH into_db='drop_table_db_restore'", tsBefore)
+		sqlDB.Exec(t, restoreQuery, backupPath)
+
+		restoredTableQuery := "SELECT * FROM drop_table_db_restore.a"
+		backedUpTableQuery := fmt.Sprintf("SELECT * FROM drop_table_db.a AS OF SYSTEM TIME %s", tsBefore)
+		sqlDB.CheckQueryResults(t, backedUpTableQuery, sqlDB.QueryStr(t, restoredTableQuery))
+	})
+
+	t.Run("backup-create-drop-backup", func(t *testing.T) {
+		var tsBefore string
+		backupPath := "nodelocal://0/create_and_drop"
+
+		sqlDB.Exec(t, "CREATE DATABASE create_and_drop")
+		sqlDB.Exec(t, "CREATE DATABASE create_and_drop_restore")
+		sqlDB.Exec(t, `BACKUP DATABASE create_and_drop TO $1 WITH revision_history`, backupPath)
+		sqlDB.Exec(t, "CREATE TABLE create_and_drop.a (k int, v string)")
+		sqlDB.Exec(t, "INSERT INTO create_and_drop.a VALUES (1, 'foo')")
+		sqlDB.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&tsBefore)
+		sqlDB.Exec(t, "DROP TABLE create_and_drop.a")
+		sqlDB.Exec(t, `BACKUP DATABASE create_and_drop TO $1 WITH revision_history`, backupPath)
+		restoreQuery := fmt.Sprintf(
+			"RESTORE create_and_drop.* FROM $1 AS OF SYSTEM TIME %s WITH into_db='create_and_drop_restore'", tsBefore)
+		sqlDB.Exec(t, restoreQuery, backupPath)
+
+		restoredTableQuery := "SELECT * FROM create_and_drop_restore.a"
+		backedUpTableQuery := fmt.Sprintf("SELECT * FROM create_and_drop.a AS OF SYSTEM TIME %s", tsBefore)
+		sqlDB.CheckQueryResults(t, backedUpTableQuery, sqlDB.QueryStr(t, restoredTableQuery))
+	})
+
+	// This is a regression test for #49707.
+	t.Run("ignore-dropped-table", func(t *testing.T) {
+		backupPath := "nodelocal://0/ignore_dropped_table"
+
+		sqlDB.Exec(t, "CREATE DATABASE ignore_dropped_table")
+		sqlDB.Exec(t, "CREATE TABLE ignore_dropped_table.a (k int, v string)")
+		sqlDB.Exec(t, "CREATE TABLE ignore_dropped_table.b (k int, v string)")
+		sqlDB.Exec(t, "DROP TABLE ignore_dropped_table.a")
+		sqlDB.Exec(t, `BACKUP DATABASE ignore_dropped_table TO $1 WITH revision_history`, backupPath)
+		// Make a backup without any changes to the schema. This ensures that table
+		// "a" is not included in the span for this incremental backup.
+		sqlDB.Exec(t, `BACKUP DATABASE ignore_dropped_table TO $1 WITH revision_history`, backupPath)
+		// Edit the schemas to back up to ensure there are revisions generated.
+		// Table a should not be considered part of the span of the next backup.
+		sqlDB.Exec(t, "CREATE TABLE ignore_dropped_table.c (k int, v string)")
+		sqlDB.Exec(t, `BACKUP DATABASE ignore_dropped_table TO $1 WITH revision_history`, backupPath)
+
+		// Ensure it can be restored.
+		sqlDB.Exec(t, "DROP DATABASE ignore_dropped_table")
+		sqlDB.Exec(t, "RESTORE DATABASE ignore_dropped_table FROM $1", backupPath)
+	})
 }
 
 func TestRestoreAsOfSystemTimeGCBounds(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #49776.

/cc @cockroachdb/release

---

When performing an incremental backup with revision history, we want to
include all spans that were public at any point during the latest
interval under consideration (the time between the last backup and when
you are performing the incremental backup).

However, consider a table that was dropped before the interval started.
The table's descriptor may still be visible (in the DROPPED state). We
should not be interested in the spans for this database. So, when going
through the list of revisions to table descriptors, we should make sure
that the table in question was not DROPPED at some point during this
interval.

To see why this is needed, consider the following scenario (all backups
are assumed to be taken with revision_history):
- Create table mydb.a
- Create table mydb.b
- Drop table mydb.a
- Take a backup of mydb (full)
- Take an incremental backup (inc) of mydb
- Create table mydb.c
- Take another incremental backup (inc2) of mydb

The backup "inc" and "inc2" should not be considered as backing up table
"mydb.a", since it has been dropped at that point. Note that since "inc"
does not see any descriptor changes, only "mydb.b" is included in its
backup. However, previously, "inc2" would see a table descriptor for
"mydb.a" (even though it is dropped) and include it in the set of spans
included in "inc2". This is an issue since "inc" did not include this
span, and thus there is a gap in the coverage for this dropped table.

Fixes #49707.

Release note (bug fix): There was a bug where when performing
incremental backups with revision history on a database (or full
cluster) and a table in the database you were backing up was dropped and
then other tables were lated create the backup would return an error.
This is now fixed.
