### PR TITLE
colexec: optimize aggregate functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -830,11 +830,8 @@ DOCGEN_TARGETS := bin/.docgen_bnfs bin/.docgen_functions docs/generated/redact_s
 EXECGEN_TARGETS = \
   pkg/col/coldata/vec.eg.go \
   pkg/sql/colexec/and_or_projection.eg.go \
-  pkg/sql/colexec/avg_agg.eg.go \
-  pkg/sql/colexec/bool_and_or_agg.eg.go \
   pkg/sql/colexec/cast.eg.go \
   pkg/sql/colexec/const.eg.go \
-  pkg/sql/colexec/count_agg.eg.go \
   pkg/sql/colexec/distinct.eg.go \
   pkg/sql/colexec/hashjoiner.eg.go \
   pkg/sql/colexec/hashtable_distinct.eg.go \
@@ -842,6 +839,12 @@ EXECGEN_TARGETS = \
   pkg/sql/colexec/hashtable_full_deleting.eg.go \
   pkg/sql/colexec/hash_aggregator.eg.go \
   pkg/sql/colexec/hash_any_not_null_agg.eg.go \
+  pkg/sql/colexec/hash_avg_agg.eg.go \
+  pkg/sql/colexec/hash_bool_and_or_agg.eg.go \
+  pkg/sql/colexec/hash_count_agg.eg.go \
+  pkg/sql/colexec/hash_min_max_agg.eg.go \
+  pkg/sql/colexec/hash_sum_agg.eg.go \
+  pkg/sql/colexec/hash_sum_int_agg.eg.go \
   pkg/sql/colexec/hash_utils.eg.go \
   pkg/sql/colexec/like_ops.eg.go \
   pkg/sql/colexec/mergejoinbase.eg.go \
@@ -853,8 +856,13 @@ EXECGEN_TARGETS = \
   pkg/sql/colexec/mergejoiner_leftouter.eg.go \
   pkg/sql/colexec/mergejoiner_leftsemi.eg.go \
   pkg/sql/colexec/mergejoiner_rightouter.eg.go \
-  pkg/sql/colexec/min_max_agg.eg.go \
   pkg/sql/colexec/ordered_any_not_null_agg.eg.go \
+  pkg/sql/colexec/ordered_avg_agg.eg.go \
+  pkg/sql/colexec/ordered_bool_and_or_agg.eg.go \
+  pkg/sql/colexec/ordered_count_agg.eg.go \
+  pkg/sql/colexec/ordered_min_max_agg.eg.go \
+  pkg/sql/colexec/ordered_sum_agg.eg.go \
+  pkg/sql/colexec/ordered_sum_int_agg.eg.go \
   pkg/sql/colexec/ordered_synchronizer.eg.go \
   pkg/sql/colexec/overloads_test_utils.eg.go \
   pkg/sql/colexec/proj_const_left_ops.eg.go \
@@ -869,8 +877,6 @@ EXECGEN_TARGETS = \
   pkg/sql/colexec/select_in.eg.go \
   pkg/sql/colexec/sort.eg.go \
   pkg/sql/colexec/substring.eg.go \
-  pkg/sql/colexec/sum_agg.eg.go \
-  pkg/sql/colexec/sum_int_agg.eg.go \
   pkg/sql/colexec/values_differ.eg.go \
   pkg/sql/colexec/vec_comparators.eg.go \
   pkg/sql/colexec/window_peer_grouper.eg.go

--- a/Makefile
+++ b/Makefile
@@ -830,7 +830,6 @@ DOCGEN_TARGETS := bin/.docgen_bnfs bin/.docgen_functions docs/generated/redact_s
 EXECGEN_TARGETS = \
   pkg/col/coldata/vec.eg.go \
   pkg/sql/colexec/and_or_projection.eg.go \
-  pkg/sql/colexec/any_not_null_agg.eg.go \
   pkg/sql/colexec/avg_agg.eg.go \
   pkg/sql/colexec/bool_and_or_agg.eg.go \
   pkg/sql/colexec/cast.eg.go \
@@ -842,6 +841,7 @@ EXECGEN_TARGETS = \
   pkg/sql/colexec/hashtable_full_default.eg.go \
   pkg/sql/colexec/hashtable_full_deleting.eg.go \
   pkg/sql/colexec/hash_aggregator.eg.go \
+  pkg/sql/colexec/hash_any_not_null_agg.eg.go \
   pkg/sql/colexec/hash_utils.eg.go \
   pkg/sql/colexec/like_ops.eg.go \
   pkg/sql/colexec/mergejoinbase.eg.go \
@@ -854,6 +854,7 @@ EXECGEN_TARGETS = \
   pkg/sql/colexec/mergejoiner_leftsemi.eg.go \
   pkg/sql/colexec/mergejoiner_rightouter.eg.go \
   pkg/sql/colexec/min_max_agg.eg.go \
+  pkg/sql/colexec/ordered_any_not_null_agg.eg.go \
   pkg/sql/colexec/ordered_synchronizer.eg.go \
   pkg/sql/colexec/overloads_test_utils.eg.go \
   pkg/sql/colexec/proj_const_left_ops.eg.go \

--- a/pkg/sql/colexec/aggregate_funcs.go
+++ b/pkg/sql/colexec/aggregate_funcs.go
@@ -117,13 +117,18 @@ func newAggregateFuncsAlloc(
 	aggTyps [][]*types.T,
 	aggFns []execinfrapb.AggregatorSpec_Func,
 	allocSize int64,
+	isHashAgg bool,
 ) (*aggregateFuncsAlloc, error) {
 	funcAllocs := make([]aggregateFuncAlloc, len(aggFns))
 	for i := range aggFns {
 		var err error
 		switch aggFns[i] {
 		case execinfrapb.AggregatorSpec_ANY_NOT_NULL:
-			funcAllocs[i], err = newAnyNotNullAggAlloc(allocator, aggTyps[i][0], allocSize)
+			if isHashAgg {
+				funcAllocs[i], err = newAnyNotNullHashAggAlloc(allocator, aggTyps[i][0], allocSize)
+			} else {
+				funcAllocs[i], err = newAnyNotNullOrderedAggAlloc(allocator, aggTyps[i][0], allocSize)
+			}
 		case execinfrapb.AggregatorSpec_AVG:
 			funcAllocs[i], err = newAvgAggAlloc(allocator, aggTyps[i][0], allocSize)
 		case execinfrapb.AggregatorSpec_SUM:

--- a/pkg/sql/colexec/aggregate_funcs.go
+++ b/pkg/sql/colexec/aggregate_funcs.go
@@ -38,16 +38,17 @@ var SupportedAggFns = []execinfrapb.AggregatorSpec_Func{
 // aggregateFunc is an aggregate function that performs computation on a batch
 // when Compute(batch) is called and writes the output to the Vec passed in
 // in Init. The aggregateFunc performs an aggregation per group and outputs the
-// aggregation once the end of the group is reached. If the end of the group is
-// not reached before the batch is finished, the aggregateFunc will store a
-// carry value that it will use next time Compute is called. Note that this
-// carry value is stored at the output index. Therefore if any memory
+// aggregation once the start of the new group is reached. If the end of the
+// group is not reached before the batch is finished, the aggregateFunc will
+// store a carry value that it will use next time Compute is called. Note that
+// this carry value is stored at the output index. Therefore if any memory
 // modification of the output vector is made, the caller *MUST* copy the value
 // at the current index inclusive for a correct aggregation.
 type aggregateFunc interface {
 	// Init sets the groups for the aggregation and the output vector. Each index
 	// in groups corresponds to a column value in the input batch. true represents
-	// the first value of a new group.
+	// the start of a new group. Note that the very first group in the whole
+	// input should *not* be marked as a start of a new group.
 	Init(groups []bool, vec coldata.Vec)
 
 	// Reset resets the aggregate function for another run. Primarily used for

--- a/pkg/sql/colexec/aggregate_funcs.go
+++ b/pkg/sql/colexec/aggregate_funcs.go
@@ -62,11 +62,7 @@ type aggregateFunc interface {
 	// computation.
 	CurrentOutputIndex() int
 	// SetOutputIndex sets the output index to write to. The value for the current
-	// index is carried over. Note that calling SetOutputIndex is a noop if
-	// CurrentOutputIndex returns a negative value (i.e. the aggregate function
-	// has not yet performed any computation). This method also has the side
-	// effect of clearing the NULLs bitmap of the output buffer past the given
-	// index.
+	// index is carried over.
 	SetOutputIndex(idx int)
 
 	// Compute computes the aggregation on the input batch.

--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -45,16 +45,17 @@ const _TYPE_WIDTH = 0
 
 // */}}
 
-func newAnyNotNullAggAlloc(
+func newAnyNotNull_AGGKINDAggAlloc(
 	allocator *colmem.Allocator, t *types.T, allocSize int64,
 ) (aggregateFuncAlloc, error) {
+	allocBase := aggAllocBase{allocator: allocator, allocSize: allocSize}
 	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
 	// {{range .}}
 	case _CANONICAL_TYPE_FAMILY:
 		switch t.Width() {
 		// {{range .WidthOverloads}}
 		case _TYPE_WIDTH:
-			return &anyNotNull_TYPEAggAlloc{allocator: allocator, allocSize: allocSize}, nil
+			return &anyNotNull_TYPE_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
 			// {{end}}
 		}
 		// {{end}}
@@ -65,11 +66,13 @@ func newAnyNotNullAggAlloc(
 // {{range .}}
 // {{range .WidthOverloads}}
 
-// anyNotNull_TYPEAgg implements the ANY_NOT_NULL aggregate, returning the
+// anyNotNull_TYPE_AGGKINDAgg implements the ANY_NOT_NULL aggregate, returning the
 // first non-null value in the input column.
-type anyNotNull_TYPEAgg struct {
-	allocator                   *colmem.Allocator
-	groups                      []bool
+type anyNotNull_TYPE_AGGKINDAgg struct {
+	allocator *colmem.Allocator
+	// {{if eq "_AGGKIND" "Ordered"}}
+	groups []bool
+	// {{end}}
 	vec                         coldata.Vec
 	col                         _GOTYPESLICE
 	nulls                       *coldata.Nulls
@@ -78,33 +81,44 @@ type anyNotNull_TYPEAgg struct {
 	foundNonNullForCurrentGroup bool
 }
 
-var _ aggregateFunc = &anyNotNull_TYPEAgg{}
+var _ aggregateFunc = &anyNotNull_TYPE_AGGKINDAgg{}
 
-const sizeOfAnyNotNull_TYPEAgg = int64(unsafe.Sizeof(anyNotNull_TYPEAgg{}))
+const sizeOfAnyNotNull_TYPE_AGGKINDAgg = int64(unsafe.Sizeof(anyNotNull_TYPE_AGGKINDAgg{}))
 
-func (a *anyNotNull_TYPEAgg) Init(groups []bool, vec coldata.Vec) {
+func (a *anyNotNull_TYPE_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
+	// {{if eq "_AGGKIND" "Ordered"}}
 	a.groups = groups
+	// {{end}}
 	a.vec = vec
 	a.col = vec.TemplateType()
 	a.nulls = vec.Nulls()
 	a.Reset()
 }
 
-func (a *anyNotNull_TYPEAgg) Reset() {
+func (a *anyNotNull_TYPE_AGGKINDAgg) Reset() {
 	a.curIdx = -1
 	a.foundNonNullForCurrentGroup = false
 	a.nulls.UnsetNulls()
 }
 
-func (a *anyNotNull_TYPEAgg) CurrentOutputIndex() int {
+func (a *anyNotNull_TYPE_AGGKINDAgg) CurrentOutputIndex() int {
 	return a.curIdx
 }
 
-func (a *anyNotNull_TYPEAgg) SetOutputIndex(idx int) {
+func (a *anyNotNull_TYPE_AGGKINDAgg) SetOutputIndex(idx int) {
 	a.curIdx = idx
 }
 
-func (a *anyNotNull_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
+func (a *anyNotNull_TYPE_AGGKINDAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
+	// {{if eq "_AGGKIND" "Hash"}}
+	if a.foundNonNullForCurrentGroup {
+		// We have already seen non-null for the current group, and since there
+		// is at most a single group when performing hash aggregation, we can
+		// finish computing.
+		return
+	}
+	// {{end}}
+
 	inputLen := b.Length()
 	vec, sel := b.ColVec(int(inputIdxs[0])), b.Selection()
 	col, nulls := vec.TemplateType(), vec.Nulls()
@@ -141,7 +155,7 @@ func (a *anyNotNull_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	)
 }
 
-func (a *anyNotNull_TYPEAgg) Flush() {
+func (a *anyNotNull_TYPE_AGGKINDAgg) Flush() {
 	// If we haven't found any non-nulls for this group so far, the output for
 	// this group should be null.
 	if !a.foundNonNullForCurrentGroup {
@@ -152,22 +166,21 @@ func (a *anyNotNull_TYPEAgg) Flush() {
 	a.curIdx++
 }
 
-func (a *anyNotNull_TYPEAgg) HandleEmptyInputScalar() {
+func (a *anyNotNull_TYPE_AGGKINDAgg) HandleEmptyInputScalar() {
 	a.nulls.SetNull(0)
 }
 
-type anyNotNull_TYPEAggAlloc struct {
-	allocator *colmem.Allocator
-	allocSize int64
-	aggFuncs  []anyNotNull_TYPEAgg
+type anyNotNull_TYPE_AGGKINDAggAlloc struct {
+	aggAllocBase
+	aggFuncs []anyNotNull_TYPE_AGGKINDAgg
 }
 
-var _ aggregateFuncAlloc = &anyNotNull_TYPEAggAlloc{}
+var _ aggregateFuncAlloc = &anyNotNull_TYPE_AGGKINDAggAlloc{}
 
-func (a *anyNotNull_TYPEAggAlloc) newAggFunc() aggregateFunc {
+func (a *anyNotNull_TYPE_AGGKINDAggAlloc) newAggFunc() aggregateFunc {
 	if len(a.aggFuncs) == 0 {
-		a.allocator.AdjustMemoryUsage(sizeOfAnyNotNull_TYPEAgg * a.allocSize)
-		a.aggFuncs = make([]anyNotNull_TYPEAgg, a.allocSize)
+		a.allocator.AdjustMemoryUsage(sizeOfAnyNotNull_TYPE_AGGKINDAgg * a.allocSize)
+		a.aggFuncs = make([]anyNotNull_TYPE_AGGKINDAgg, a.allocSize)
 	}
 	f := &a.aggFuncs[0]
 	f.allocator = a.allocator
@@ -183,9 +196,12 @@ func (a *anyNotNull_TYPEAggAlloc) newAggFunc() aggregateFunc {
 // row. If a non-null value was already found, then it does nothing. If this is
 // the first row of a new group, and no non-nulls have been found for the
 // current group, then the output for the current group is set to null.
-func _FIND_ANY_NOT_NULL(a *anyNotNull_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS bool) { // */}}
+func _FIND_ANY_NOT_NULL(
+	a *anyNotNull_TYPE_AGGKINDAgg, nulls *coldata.Nulls, i int, _HAS_NULLS bool,
+) { // */}}
 	// {{define "findAnyNotNull" -}}
 
+	// {{if eq "_AGGKIND" "Ordered"}}
 	if a.groups[i] {
 		// The `a.curIdx` check is necessary because for the first
 		// group in the result set there is no "current group."
@@ -203,6 +219,8 @@ func _FIND_ANY_NOT_NULL(a *anyNotNull_TYPEAgg, nulls *coldata.Nulls, i int, _HAS
 		a.curIdx++
 		a.foundNonNullForCurrentGroup = false
 	}
+	// {{end}}
+
 	var isNull bool
 	// {{if .HasNulls}}
 	isNull = nulls.NullAt(i)
@@ -211,13 +229,19 @@ func _FIND_ANY_NOT_NULL(a *anyNotNull_TYPEAgg, nulls *coldata.Nulls, i int, _HAS
 	// {{end}}
 	if !a.foundNonNullForCurrentGroup && !isNull {
 		// If we haven't seen any non-nulls for the current group yet, and the
-		// current value is non-null, then we can pick the current value to be the
-		// output.
+		// current value is non-null, then we can pick the current value to be
+		// the output.
 		// {{with .Global}}
 		val := execgen.UNSAFEGET(col, i)
 		execgen.COPYVAL(a.curAgg, val)
 		// {{end}}
 		a.foundNonNullForCurrentGroup = true
+		// {{if eq "_AGGKIND" "Hash"}}
+		// We have already seen non-null for the current group, and since there
+		// is at most a single group when performing hash aggregation, we can
+		// finish computing.
+		return
+		// {{end}}
 	}
 	// {{end}}
 

--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -101,10 +101,7 @@ func (a *anyNotNull_TYPEAgg) CurrentOutputIndex() int {
 }
 
 func (a *anyNotNull_TYPEAgg) SetOutputIndex(idx int) {
-	if a.curIdx != -1 {
-		a.curIdx = idx
-		a.nulls.UnsetNullsAfter(idx + 1)
-	}
+	a.curIdx = idx
 }
 
 func (a *anyNotNull_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {

--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -96,7 +96,7 @@ func (a *anyNotNull_TYPE_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
 }
 
 func (a *anyNotNull_TYPE_AGGKINDAgg) Reset() {
-	a.curIdx = -1
+	a.curIdx = 0
 	a.foundNonNullForCurrentGroup = false
 	a.nulls.UnsetNulls()
 }
@@ -203,18 +203,14 @@ func _FIND_ANY_NOT_NULL(
 
 	// {{if eq "_AGGKIND" "Ordered"}}
 	if a.groups[i] {
-		// The `a.curIdx` check is necessary because for the first
-		// group in the result set there is no "current group."
-		if a.curIdx >= 0 {
-			// If this is a new group, check if any non-nulls have been found for the
-			// current group.
-			if !a.foundNonNullForCurrentGroup {
-				a.nulls.SetNull(a.curIdx)
-			} else {
-				// {{with .Global}}
-				execgen.SET(a.col, a.curIdx, a.curAgg)
-				// {{end}}
-			}
+		// If this is a new group, check if any non-nulls have been found for the
+		// current group.
+		if !a.foundNonNullForCurrentGroup {
+			a.nulls.SetNull(a.curIdx)
+		} else {
+			// {{with .Global}}
+			execgen.SET(a.col, a.curIdx, a.curAgg)
+			// {{end}}
 		}
 		a.curIdx++
 		a.foundNonNullForCurrentGroup = false

--- a/pkg/sql/colexec/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/avg_agg_tmpl.go
@@ -99,10 +99,7 @@ func (a *avg_TYPEAgg) CurrentOutputIndex() int {
 }
 
 func (a *avg_TYPEAgg) SetOutputIndex(idx int) {
-	if a.scratch.curIdx != -1 {
-		a.scratch.curIdx = idx
-		a.scratch.nulls.UnsetNullsAfter(idx + 1)
-	}
+	a.scratch.curIdx = idx
 }
 
 func (a *avg_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {

--- a/pkg/sql/colexec/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/avg_agg_tmpl.go
@@ -119,7 +119,7 @@ func (a *avg_TYPE_AGGKINDAgg) Init(groups []bool, v coldata.Vec) {
 }
 
 func (a *avg_TYPE_AGGKINDAgg) Reset() {
-	a.scratch.curIdx = -1
+	a.scratch.curIdx = 0
 	a.scratch.curSum = zero_RET_TYPEValue
 	a.scratch.curCount = 0
 	a.scratch.foundNonNullForCurrentGroup = false
@@ -221,16 +221,13 @@ func _ACCUMULATE_AVG(a *_AGG_TYPE_AGGKINDAgg, nulls *coldata.Nulls, i int, _HAS_
 	// {{if eq "_AGGKIND" "Ordered"}}
 	if a.groups[i] {
 		// If we encounter a new group, and we haven't found any non-nulls for the
-		// current group, the output for this group should be null. If
-		// a.scratch.curIdx is negative, it means that this is the first group.
-		if a.scratch.curIdx >= 0 {
-			if !a.scratch.foundNonNullForCurrentGroup {
-				a.scratch.nulls.SetNull(a.scratch.curIdx)
-			} else {
-				// {{with .Global}}
-				_ASSIGN_DIV_INT64(a.scratch.vec[a.scratch.curIdx], a.scratch.curSum, a.scratch.curCount, a.scratch.vec, _, _)
-				// {{end}}
-			}
+		// current group, the output for this group should be null.
+		if !a.scratch.foundNonNullForCurrentGroup {
+			a.scratch.nulls.SetNull(a.scratch.curIdx)
+		} else {
+			// {{with .Global}}
+			_ASSIGN_DIV_INT64(a.scratch.vec[a.scratch.curIdx], a.scratch.curSum, a.scratch.curCount, a.scratch.vec, _, _)
+			// {{end}}
 		}
 		a.scratch.curIdx++
 		// {{with .Global}}

--- a/pkg/sql/colexec/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/avg_agg_tmpl.go
@@ -24,6 +24,9 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
 )
 
 // {{/*
@@ -44,10 +47,37 @@ func _ASSIGN_ADD(_, _, _, _, _, _ string) {
 
 // */}}
 
+func newAvg_AGGKINDAggAlloc(
+	allocator *colmem.Allocator, t *types.T, allocSize int64,
+) (aggregateFuncAlloc, error) {
+	allocBase := aggAllocBase{allocator: allocator, allocSize: allocSize}
+	switch t.Family() {
+	case types.IntFamily:
+		switch t.Width() {
+		case 16:
+			return &avgInt16_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
+		case 32:
+			return &avgInt32_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
+		default:
+			return &avgInt64_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
+		}
+	case types.DecimalFamily:
+		return &avgDecimal_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
+	case types.FloatFamily:
+		return &avgFloat64_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
+	case types.IntervalFamily:
+		return &avgInterval_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
+	default:
+		return nil, errors.Errorf("unsupported avg agg type %s", t.Name())
+	}
+}
+
 // {{range .}}
 
-type avg_TYPEAgg struct {
-	groups  []bool
+type avg_TYPE_AGGKINDAgg struct {
+	// {{if eq "_AGGKIND" "Ordered"}}
+	groups []bool
+	// {{end}}
 	scratch struct {
 		curIdx int
 		// curSum keeps track of the sum of elements belonging to the current group,
@@ -75,18 +105,20 @@ type avg_TYPEAgg struct {
 	// {{end}}
 }
 
-var _ aggregateFunc = &avg_TYPEAgg{}
+var _ aggregateFunc = &avg_TYPE_AGGKINDAgg{}
 
-const sizeOfAvg_TYPEAgg = int64(unsafe.Sizeof(avg_TYPEAgg{}))
+const sizeOfAvg_TYPE_AGGKINDAgg = int64(unsafe.Sizeof(avg_TYPE_AGGKINDAgg{}))
 
-func (a *avg_TYPEAgg) Init(groups []bool, v coldata.Vec) {
+func (a *avg_TYPE_AGGKINDAgg) Init(groups []bool, v coldata.Vec) {
+	// {{if eq "_AGGKIND" "Ordered"}}
 	a.groups = groups
+	// {{end}}
 	a.scratch.vec = v._RET_TYPE()
 	a.scratch.nulls = v.Nulls()
 	a.Reset()
 }
 
-func (a *avg_TYPEAgg) Reset() {
+func (a *avg_TYPE_AGGKINDAgg) Reset() {
 	a.scratch.curIdx = -1
 	a.scratch.curSum = zero_RET_TYPEValue
 	a.scratch.curCount = 0
@@ -94,15 +126,15 @@ func (a *avg_TYPEAgg) Reset() {
 	a.scratch.nulls.UnsetNulls()
 }
 
-func (a *avg_TYPEAgg) CurrentOutputIndex() int {
+func (a *avg_TYPE_AGGKINDAgg) CurrentOutputIndex() int {
 	return a.scratch.curIdx
 }
 
-func (a *avg_TYPEAgg) SetOutputIndex(idx int) {
+func (a *avg_TYPE_AGGKINDAgg) SetOutputIndex(idx int) {
 	a.scratch.curIdx = idx
 }
 
-func (a *avg_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
+func (a *avg_TYPE_AGGKINDAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	// {{if .NeedsHelper}}
 	// {{/*
 	// overloadHelper is used only when we perform the summation of integers
@@ -143,7 +175,7 @@ func (a *avg_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	}
 }
 
-func (a *avg_TYPEAgg) Flush() {
+func (a *avg_TYPE_AGGKINDAgg) Flush() {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// NULL.
@@ -155,21 +187,21 @@ func (a *avg_TYPEAgg) Flush() {
 	a.scratch.curIdx++
 }
 
-func (a *avg_TYPEAgg) HandleEmptyInputScalar() {
+func (a *avg_TYPE_AGGKINDAgg) HandleEmptyInputScalar() {
 	a.scratch.nulls.SetNull(0)
 }
 
-type avg_TYPEAggAlloc struct {
+type avg_TYPE_AGGKINDAggAlloc struct {
 	aggAllocBase
-	aggFuncs []avg_TYPEAgg
+	aggFuncs []avg_TYPE_AGGKINDAgg
 }
 
-var _ aggregateFuncAlloc = &avg_TYPEAggAlloc{}
+var _ aggregateFuncAlloc = &avg_TYPE_AGGKINDAggAlloc{}
 
-func (a *avg_TYPEAggAlloc) newAggFunc() aggregateFunc {
+func (a *avg_TYPE_AGGKINDAggAlloc) newAggFunc() aggregateFunc {
 	if len(a.aggFuncs) == 0 {
-		a.allocator.AdjustMemoryUsage(sizeOfAvg_TYPEAgg * a.allocSize)
-		a.aggFuncs = make([]avg_TYPEAgg, a.allocSize)
+		a.allocator.AdjustMemoryUsage(sizeOfAvg_TYPE_AGGKINDAgg * a.allocSize)
+		a.aggFuncs = make([]avg_TYPE_AGGKINDAgg, a.allocSize)
 	}
 	f := &a.aggFuncs[0]
 	a.aggFuncs = a.aggFuncs[1:]
@@ -183,9 +215,10 @@ func (a *avg_TYPEAggAlloc) newAggFunc() aggregateFunc {
 // of the ith row. If this is the first row of a new group, then the average is
 // computed for the current group. If no non-nulls have been found for the
 // current group, then the output for the current group is set to null.
-func _ACCUMULATE_AVG(a *_AGG_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS bool) { // */}}
-
+func _ACCUMULATE_AVG(a *_AGG_TYPE_AGGKINDAgg, nulls *coldata.Nulls, i int, _HAS_NULLS bool) { // */}}
 	// {{define "accumulateAvg"}}
+
+	// {{if eq "_AGGKIND" "Ordered"}}
 	if a.groups[i] {
 		// If we encounter a new group, and we haven't found any non-nulls for the
 		// current group, the output for this group should be null. If
@@ -213,6 +246,8 @@ func _ACCUMULATE_AVG(a *_AGG_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS bo
 		a.scratch.foundNonNullForCurrentGroup = false
 		// {{end}}
 	}
+	// {{end}}
+
 	var isNull bool
 	// {{if .HasNulls}}
 	isNull = nulls.NullAt(i)

--- a/pkg/sql/colexec/bool_and_or_agg_tmpl.go
+++ b/pkg/sql/colexec/bool_and_or_agg_tmpl.go
@@ -43,33 +43,40 @@ func _ASSIGN_BOOL_OP(_, _, _ string) {
 
 // {{range .}}
 
-func newBool_OP_TYPEAggAlloc(allocator *colmem.Allocator, allocSize int64) aggregateFuncAlloc {
-	return &bool_OP_TYPEAggAlloc{allocator: allocator, allocSize: allocSize}
+func newBool_OP_TYPE_AGGKINDAggAlloc(
+	allocator *colmem.Allocator, allocSize int64,
+) aggregateFuncAlloc {
+	return &bool_OP_TYPE_AGGKINDAggAlloc{aggAllocBase: aggAllocBase{
+		allocator: allocator,
+		allocSize: allocSize,
+	}}
 }
 
-type bool_OP_TYPEAgg struct {
+type bool_OP_TYPE_AGGKINDAgg struct {
 	sawNonNull bool
-
+	// {{if eq "_AGGKIND" "Ordered"}}
 	groups []bool
+	// {{end}}
 	vec    []bool
-
 	nulls  *coldata.Nulls
 	curIdx int
 	curAgg bool
 }
 
-var _ aggregateFunc = &bool_OP_TYPEAgg{}
+var _ aggregateFunc = &bool_OP_TYPE_AGGKINDAgg{}
 
-const sizeOfBool_OP_TYPEAgg = int64(unsafe.Sizeof(bool_OP_TYPEAgg{}))
+const sizeOfBool_OP_TYPE_AGGKINDAgg = int64(unsafe.Sizeof(bool_OP_TYPE_AGGKINDAgg{}))
 
-func (b *bool_OP_TYPEAgg) Init(groups []bool, vec coldata.Vec) {
+func (b *bool_OP_TYPE_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
+	// {{if eq "_AGGKIND" "Ordered"}}
 	b.groups = groups
+	// {{end}}
 	b.vec = vec.Bool()
 	b.nulls = vec.Nulls()
 	b.Reset()
 }
 
-func (b *bool_OP_TYPEAgg) Reset() {
+func (b *bool_OP_TYPE_AGGKINDAgg) Reset() {
 	b.curIdx = -1
 	b.nulls.UnsetNulls()
 	// _DEFAULT_VAL indicates whether we are doing an AND aggregate or OR aggregate.
@@ -77,15 +84,15 @@ func (b *bool_OP_TYPEAgg) Reset() {
 	b.curAgg = _DEFAULT_VAL
 }
 
-func (b *bool_OP_TYPEAgg) CurrentOutputIndex() int {
+func (b *bool_OP_TYPE_AGGKINDAgg) CurrentOutputIndex() int {
 	return b.curIdx
 }
 
-func (b *bool_OP_TYPEAgg) SetOutputIndex(idx int) {
+func (b *bool_OP_TYPE_AGGKINDAgg) SetOutputIndex(idx int) {
 	b.curIdx = idx
 }
 
-func (b *bool_OP_TYPEAgg) Compute(batch coldata.Batch, inputIdxs []uint32) {
+func (b *bool_OP_TYPE_AGGKINDAgg) Compute(batch coldata.Batch, inputIdxs []uint32) {
 	inputLen := batch.Length()
 	vec, sel := batch.ColVec(int(inputIdxs[0])), batch.Selection()
 	col, nulls := vec.Bool(), vec.Nulls()
@@ -102,7 +109,7 @@ func (b *bool_OP_TYPEAgg) Compute(batch coldata.Batch, inputIdxs []uint32) {
 	}
 }
 
-func (b *bool_OP_TYPEAgg) Flush() {
+func (b *bool_OP_TYPE_AGGKINDAgg) Flush() {
 	if !b.sawNonNull {
 		b.nulls.SetNull(b.curIdx)
 	} else {
@@ -111,22 +118,21 @@ func (b *bool_OP_TYPEAgg) Flush() {
 	b.curIdx++
 }
 
-func (b *bool_OP_TYPEAgg) HandleEmptyInputScalar() {
+func (b *bool_OP_TYPE_AGGKINDAgg) HandleEmptyInputScalar() {
 	b.nulls.SetNull(0)
 }
 
-type bool_OP_TYPEAggAlloc struct {
-	allocator *colmem.Allocator
-	allocSize int64
-	aggFuncs  []bool_OP_TYPEAgg
+type bool_OP_TYPE_AGGKINDAggAlloc struct {
+	aggAllocBase
+	aggFuncs []bool_OP_TYPE_AGGKINDAgg
 }
 
-var _ aggregateFuncAlloc = &bool_OP_TYPEAggAlloc{}
+var _ aggregateFuncAlloc = &bool_OP_TYPE_AGGKINDAggAlloc{}
 
-func (a *bool_OP_TYPEAggAlloc) newAggFunc() aggregateFunc {
+func (a *bool_OP_TYPE_AGGKINDAggAlloc) newAggFunc() aggregateFunc {
 	if len(a.aggFuncs) == 0 {
-		a.allocator.AdjustMemoryUsage(sizeOfBool_OP_TYPEAgg * a.allocSize)
-		a.aggFuncs = make([]bool_OP_TYPEAgg, a.allocSize)
+		a.allocator.AdjustMemoryUsage(sizeOfBool_OP_TYPE_AGGKINDAgg * a.allocSize)
+		a.aggFuncs = make([]bool_OP_TYPE_AGGKINDAgg, a.allocSize)
 	}
 	f := &a.aggFuncs[0]
 	a.aggFuncs = a.aggFuncs[1:]
@@ -137,8 +143,10 @@ func (a *bool_OP_TYPEAggAlloc) newAggFunc() aggregateFunc {
 
 // {{/*
 // _ACCUMULATE_BOOLEAN aggregates the boolean value at index i into the boolean aggregate.
-func _ACCUMULATE_BOOLEAN(b *bool_OP_TYPEAgg, nulls *coldata.Nulls, i int) { // */}}
+func _ACCUMULATE_BOOLEAN(b *bool_OP_TYPE_AGGKINDAgg, nulls *coldata.Nulls, i int) { // */}}
 	// {{define "accumulateBoolean" -}}
+
+	// {{if eq "_AGGKIND" "Ordered"}}
 	if b.groups[i] {
 		if b.curIdx >= 0 {
 			if !b.sawNonNull {
@@ -153,6 +161,9 @@ func _ACCUMULATE_BOOLEAN(b *bool_OP_TYPEAgg, nulls *coldata.Nulls, i int) { // *
 		// {{end}}
 		b.sawNonNull = false
 	}
+	// {{end}}
+
+	// TODO(yuzefovich): template out has nulls vs no nulls cases.
 	isNull := nulls.NullAt(i)
 	if !isNull {
 		// {{with .Global}}

--- a/pkg/sql/colexec/bool_and_or_agg_tmpl.go
+++ b/pkg/sql/colexec/bool_and_or_agg_tmpl.go
@@ -82,10 +82,7 @@ func (b *bool_OP_TYPEAgg) CurrentOutputIndex() int {
 }
 
 func (b *bool_OP_TYPEAgg) SetOutputIndex(idx int) {
-	if b.curIdx != -1 {
-		b.curIdx = idx
-		b.nulls.UnsetNullsAfter(idx)
-	}
+	b.curIdx = idx
 }
 
 func (b *bool_OP_TYPEAgg) Compute(batch coldata.Batch, inputIdxs []uint32) {

--- a/pkg/sql/colexec/bool_and_or_agg_tmpl.go
+++ b/pkg/sql/colexec/bool_and_or_agg_tmpl.go
@@ -77,7 +77,7 @@ func (b *bool_OP_TYPE_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
 }
 
 func (b *bool_OP_TYPE_AGGKINDAgg) Reset() {
-	b.curIdx = -1
+	b.curIdx = 0
 	b.nulls.UnsetNulls()
 	// _DEFAULT_VAL indicates whether we are doing an AND aggregate or OR aggregate.
 	// For bool_and the _DEFAULT_VAL is true and for bool_or the _DEFAULT_VAL is false.
@@ -148,12 +148,10 @@ func _ACCUMULATE_BOOLEAN(b *bool_OP_TYPE_AGGKINDAgg, nulls *coldata.Nulls, i int
 
 	// {{if eq "_AGGKIND" "Ordered"}}
 	if b.groups[i] {
-		if b.curIdx >= 0 {
-			if !b.sawNonNull {
-				b.nulls.SetNull(b.curIdx)
-			} else {
-				b.vec[b.curIdx] = b.curAgg
-			}
+		if !b.sawNonNull {
+			b.nulls.SetNull(b.curIdx)
+		} else {
+			b.vec[b.curIdx] = b.curAgg
 		}
 		b.curIdx++
 		// {{with .Global}}

--- a/pkg/sql/colexec/count_agg_tmpl.go
+++ b/pkg/sql/colexec/count_agg_tmpl.go
@@ -63,10 +63,7 @@ func (a *count_KINDAgg) CurrentOutputIndex() int {
 }
 
 func (a *count_KINDAgg) SetOutputIndex(idx int) {
-	if a.curIdx != -1 {
-		a.curIdx = idx
-		a.nulls.UnsetNullsAfter(idx + 1)
-	}
+	a.curIdx = idx
 }
 
 func (a *count_KINDAgg) Compute(b coldata.Batch, inputIdxs []uint32) {

--- a/pkg/sql/colexec/count_agg_tmpl.go
+++ b/pkg/sql/colexec/count_agg_tmpl.go
@@ -62,7 +62,7 @@ func (a *count_COUNTKIND_AGGKINDAgg) Init(groups []bool, vec coldata.Vec) {
 }
 
 func (a *count_COUNTKIND_AGGKINDAgg) Reset() {
-	a.curIdx = -1
+	a.curIdx = 0
 	a.curAgg = 0
 	a.nulls.UnsetNulls()
 }
@@ -146,9 +146,7 @@ func _ACCUMULATE_COUNT(a *countAgg, nulls *coldata.Nulls, i int, _COL_WITH_NULLS
 
 	// {{if eq "_AGGKIND" "Ordered"}}
 	if a.groups[i] {
-		if a.curIdx != -1 {
-			a.vec[a.curIdx] = a.curAgg
-		}
+		a.vec[a.curIdx] = a.curAgg
 		a.curIdx++
 		a.curAgg = int64(0)
 	}

--- a/pkg/sql/colexec/execgen/cmd/execgen/agg_gen_util.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/agg_gen_util.go
@@ -1,0 +1,42 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	// aggKindTmplVar specifies the template "variable" that describes the kind
+	// of aggregator using an aggregate function. It is replaced with either
+	// "Hash" or "Ordered" before executing the template.
+	aggKindTmplVar = "_AGGKIND"
+	hashAggKind    = "Hash"
+	orderedAggKind = "Ordered"
+)
+
+func registerAggGenerator(aggGen generator, filenameSuffix, dep string) {
+	aggGeneratorAdapter := func(aggKind string) generator {
+		return func(inputFileContents string, wr io.Writer) error {
+			inputFileContents = strings.ReplaceAll(inputFileContents, aggKindTmplVar, aggKind)
+			return aggGen(inputFileContents, wr)
+		}
+	}
+	for _, aggKind := range []string{hashAggKind, orderedAggKind} {
+		registerGenerator(
+			aggGeneratorAdapter(aggKind),
+			fmt.Sprintf("%s_%s", strings.ToLower(aggKind), filenameSuffix),
+			dep,
+		)
+	}
+}

--- a/pkg/sql/colexec/execgen/cmd/execgen/any_not_null_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/any_not_null_agg_gen.go
@@ -45,5 +45,5 @@ func genAnyNotNullAgg(inputFileContents string, wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genAnyNotNullAgg, "any_not_null_agg.eg.go", anyNotNullAggTmpl)
+	registerAggGenerator(genAnyNotNullAgg, "any_not_null_agg.eg.go", anyNotNullAggTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
@@ -123,5 +123,5 @@ func genAvgAgg(inputFileContents string, wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genAvgAgg, "avg_agg.eg.go", avgAggTmpl)
+	registerAggGenerator(genAvgAgg, "avg_agg.eg.go", avgAggTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/bool_and_or_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/bool_and_or_agg_gen.go
@@ -81,5 +81,5 @@ func genBooleanAgg(inputFileContents string, wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genBooleanAgg, "bool_and_or_agg.eg.go", boolAggTmpl)
+	registerAggGenerator(genBooleanAgg, "bool_and_or_agg.eg.go", boolAggTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/count_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/count_agg_gen.go
@@ -19,7 +19,7 @@ import (
 const countAggTmpl = "pkg/sql/colexec/count_agg_tmpl.go"
 
 func genCountAgg(inputFileContents string, wr io.Writer) error {
-	s := strings.ReplaceAll(inputFileContents, "_KIND", "{{.Kind}}")
+	s := strings.ReplaceAll(inputFileContents, "_COUNTKIND", "{{.CountKind}}")
 
 	accumulateSum := makeFunctionRegex("_ACCUMULATE_COUNT", 4)
 	s = accumulateSum.ReplaceAllString(s, `{{template "accumulateCount" buildDict "Global" . "ColWithNulls" $4}}`)
@@ -30,17 +30,17 @@ func genCountAgg(inputFileContents string, wr io.Writer) error {
 	}
 
 	return tmpl.Execute(wr, []struct {
-		Kind string
+		CountKind string
 	}{
 		// "Rows" count aggregate performs COUNT(*) aggregation, which counts
 		// every row in the result unconditionally.
-		{Kind: "Rows"},
+		{CountKind: "Rows"},
 		// "" ("pure") count aggregate performs COUNT(col) aggregation, which
 		// counts every row in the result where the value of col is not null.
-		{Kind: ""},
+		{CountKind: ""},
 	})
 }
 
 func init() {
-	registerGenerator(genCountAgg, "count_agg.eg.go", countAggTmpl)
+	registerAggGenerator(genCountAgg, "count_agg.eg.go", countAggTmpl)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/min_max_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/min_max_agg_gen.go
@@ -117,5 +117,5 @@ func genMinMaxAgg(inputFileContents string, wr io.Writer) error {
 }
 
 func init() {
-	registerGenerator(genMinMaxAgg, "min_max_agg.eg.go", minMaxAggTmpl)
+	registerAggGenerator(genMinMaxAgg, "min_max_agg.eg.go", minMaxAggTmpl)
 }

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -202,7 +202,7 @@ func NewHashAggregator(
 		groupTypes[i] = typs[colIdx]
 	}
 
-	aggFnsAlloc, err := newAggregateFuncsAlloc(allocator, aggTyps, aggFns, hashAggregatorAllocSize)
+	aggFnsAlloc, err := newAggregateFuncsAlloc(allocator, aggTyps, aggFns, hashAggregatorAllocSize, true /* isHashAgg */)
 
 	return &hashAggregator{
 		OneInputNode: NewOneInputNode(input),

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -23,9 +23,11 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
 // Remove unused warning.
@@ -49,12 +51,76 @@ func _COPYVAL_MAYBE_CAST(_, _ string) bool {
 
 // */}}
 
+func newMin_AGGKINDAggAlloc(
+	allocator *colmem.Allocator, t *types.T, allocSize int64,
+) aggregateFuncAlloc {
+	allocBase := aggAllocBase{allocator: allocator, allocSize: allocSize}
+	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
+	case types.BoolFamily:
+		return &minBool_AGGKINDAggAlloc{aggAllocBase: allocBase}
+	case types.BytesFamily:
+		return &minBytes_AGGKINDAggAlloc{aggAllocBase: allocBase}
+	case types.DecimalFamily:
+		return &minDecimal_AGGKINDAggAlloc{aggAllocBase: allocBase}
+	case types.IntFamily:
+		switch t.Width() {
+		case 16:
+			return &minInt16_AGGKINDAggAlloc{aggAllocBase: allocBase}
+		case 32:
+			return &minInt32_AGGKINDAggAlloc{aggAllocBase: allocBase}
+		default:
+			return &minInt64_AGGKINDAggAlloc{aggAllocBase: allocBase}
+		}
+	case types.FloatFamily:
+		return &minFloat64_AGGKINDAggAlloc{aggAllocBase: allocBase}
+	case types.TimestampTZFamily:
+		return &minTimestamp_AGGKINDAggAlloc{aggAllocBase: allocBase}
+	case types.IntervalFamily:
+		return &minInterval_AGGKINDAggAlloc{aggAllocBase: allocBase}
+	default:
+		return &minDatum_AGGKINDAggAlloc{aggAllocBase: allocBase}
+	}
+}
+
+func newMax_AGGKINDAggAlloc(
+	allocator *colmem.Allocator, t *types.T, allocSize int64,
+) aggregateFuncAlloc {
+	allocBase := aggAllocBase{allocator: allocator, allocSize: allocSize}
+	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
+	case types.BoolFamily:
+		return &maxBool_AGGKINDAggAlloc{aggAllocBase: allocBase}
+	case types.BytesFamily:
+		return &maxBytes_AGGKINDAggAlloc{aggAllocBase: allocBase}
+	case types.DecimalFamily:
+		return &maxDecimal_AGGKINDAggAlloc{aggAllocBase: allocBase}
+	case types.IntFamily:
+		switch t.Width() {
+		case 16:
+			return &maxInt16_AGGKINDAggAlloc{aggAllocBase: allocBase}
+		case 32:
+			return &maxInt32_AGGKINDAggAlloc{aggAllocBase: allocBase}
+		default:
+			return &maxInt64_AGGKINDAggAlloc{aggAllocBase: allocBase}
+		}
+	case types.FloatFamily:
+		return &maxFloat64_AGGKINDAggAlloc{aggAllocBase: allocBase}
+	case types.TimestampTZFamily:
+		return &maxTimestamp_AGGKINDAggAlloc{aggAllocBase: allocBase}
+	case types.IntervalFamily:
+		return &maxInterval_AGGKINDAggAlloc{aggAllocBase: allocBase}
+	default:
+		return &maxDatum_AGGKINDAggAlloc{aggAllocBase: allocBase}
+	}
+}
+
 // {{range .}}
 
-type _AGG_TYPEAgg struct {
+type _AGG_TYPE_AGGKINDAgg struct {
 	allocator *colmem.Allocator
-	groups    []bool
-	curIdx    int
+	// {{if eq "_AGGKIND" "Ordered"}}
+	groups []bool
+	// {{end}}
+	curIdx int
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
@@ -70,33 +136,35 @@ type _AGG_TYPEAgg struct {
 	foundNonNullForCurrentGroup bool
 }
 
-var _ aggregateFunc = &_AGG_TYPEAgg{}
+var _ aggregateFunc = &_AGG_TYPE_AGGKINDAgg{}
 
-const sizeOf_AGG_TYPEAgg = int64(unsafe.Sizeof(_AGG_TYPEAgg{}))
+const sizeOf_AGG_TYPE_AGGKINDAgg = int64(unsafe.Sizeof(_AGG_TYPE_AGGKINDAgg{}))
 
-func (a *_AGG_TYPEAgg) Init(groups []bool, v coldata.Vec) {
+func (a *_AGG_TYPE_AGGKINDAgg) Init(groups []bool, v coldata.Vec) {
+	// {{if eq "_AGGKIND" "Ordered"}}
 	a.groups = groups
+	// {{end}}
 	a.vec = v
 	a.col = v._RET_TYPE()
 	a.nulls = v.Nulls()
 	a.Reset()
 }
 
-func (a *_AGG_TYPEAgg) Reset() {
+func (a *_AGG_TYPE_AGGKINDAgg) Reset() {
 	a.curIdx = -1
 	a.foundNonNullForCurrentGroup = false
 	a.nulls.UnsetNulls()
 }
 
-func (a *_AGG_TYPEAgg) CurrentOutputIndex() int {
+func (a *_AGG_TYPE_AGGKINDAgg) CurrentOutputIndex() int {
 	return a.curIdx
 }
 
-func (a *_AGG_TYPEAgg) SetOutputIndex(idx int) {
+func (a *_AGG_TYPE_AGGKINDAgg) SetOutputIndex(idx int) {
 	a.curIdx = idx
 }
 
-func (a *_AGG_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
+func (a *_AGG_TYPE_AGGKINDAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	inputLen := b.Length()
 	vec, sel := b.ColVec(int(inputIdxs[0])), b.Selection()
 	col, nulls := vec._TYPE(), vec.Nulls()
@@ -132,7 +200,7 @@ func (a *_AGG_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	)
 }
 
-func (a *_AGG_TYPEAgg) Flush() {
+func (a *_AGG_TYPE_AGGKINDAgg) Flush() {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
@@ -144,21 +212,21 @@ func (a *_AGG_TYPEAgg) Flush() {
 	a.curIdx++
 }
 
-func (a *_AGG_TYPEAgg) HandleEmptyInputScalar() {
+func (a *_AGG_TYPE_AGGKINDAgg) HandleEmptyInputScalar() {
 	a.nulls.SetNull(0)
 }
 
-type _AGG_TYPEAggAlloc struct {
+type _AGG_TYPE_AGGKINDAggAlloc struct {
 	aggAllocBase
-	aggFuncs []_AGG_TYPEAgg
+	aggFuncs []_AGG_TYPE_AGGKINDAgg
 }
 
-var _ aggregateFuncAlloc = &_AGG_TYPEAggAlloc{}
+var _ aggregateFuncAlloc = &_AGG_TYPE_AGGKINDAggAlloc{}
 
-func (a *_AGG_TYPEAggAlloc) newAggFunc() aggregateFunc {
+func (a *_AGG_TYPE_AGGKINDAggAlloc) newAggFunc() aggregateFunc {
 	if len(a.aggFuncs) == 0 {
-		a.allocator.AdjustMemoryUsage(sizeOf_AGG_TYPEAgg * a.allocSize)
-		a.aggFuncs = make([]_AGG_TYPEAgg, a.allocSize)
+		a.allocator.AdjustMemoryUsage(sizeOf_AGG_TYPE_AGGKINDAgg * a.allocSize)
+		a.aggFuncs = make([]_AGG_TYPE_AGGKINDAgg, a.allocSize)
 	}
 	f := &a.aggFuncs[0]
 	f.allocator = a.allocator
@@ -173,9 +241,10 @@ func (a *_AGG_TYPEAggAlloc) newAggFunc() aggregateFunc {
 // the ith row if it is smaller/larger than the current result. If this is the
 // first row of a new group, and no non-nulls have been found for the current
 // group, then the output for the current group is set to null.
-func _ACCUMULATE_MINMAX(a *_AGG_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS bool) { // */}}
-
+func _ACCUMULATE_MINMAX(a *_AGG_TYPE_AGGKINDAgg, nulls *coldata.Nulls, i int, _HAS_NULLS bool) { // */}}
 	// {{define "accumulateMinMax"}}
+
+	// {{if eq "_AGGKIND" "Ordered"}}
 	if a.groups[i] {
 		// If we encounter a new group, and we haven't found any non-nulls for the
 		// current group, the output for this group should be null. If a.curIdx is
@@ -192,6 +261,8 @@ func _ACCUMULATE_MINMAX(a *_AGG_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS
 		a.curIdx++
 		a.foundNonNullForCurrentGroup = false
 	}
+	// {{end}}
+
 	var isNull bool
 	// {{if .HasNulls}}
 	isNull = nulls.NullAt(i)

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -93,10 +93,7 @@ func (a *_AGG_TYPEAgg) CurrentOutputIndex() int {
 }
 
 func (a *_AGG_TYPEAgg) SetOutputIndex(idx int) {
-	if a.curIdx != -1 {
-		a.curIdx = idx
-		a.nulls.UnsetNullsAfter(idx + 1)
-	}
+	a.curIdx = idx
 }
 
 func (a *_AGG_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -151,7 +151,7 @@ func (a *_AGG_TYPE_AGGKINDAgg) Init(groups []bool, v coldata.Vec) {
 }
 
 func (a *_AGG_TYPE_AGGKINDAgg) Reset() {
-	a.curIdx = -1
+	a.curIdx = 0
 	a.foundNonNullForCurrentGroup = false
 	a.nulls.UnsetNulls()
 }
@@ -247,16 +247,13 @@ func _ACCUMULATE_MINMAX(a *_AGG_TYPE_AGGKINDAgg, nulls *coldata.Nulls, i int, _H
 	// {{if eq "_AGGKIND" "Ordered"}}
 	if a.groups[i] {
 		// If we encounter a new group, and we haven't found any non-nulls for the
-		// current group, the output for this group should be null. If a.curIdx is
-		// negative, it means that this is the first group.
-		if a.curIdx >= 0 {
-			if !a.foundNonNullForCurrentGroup {
-				a.nulls.SetNull(a.curIdx)
-			} else {
-				// {{with .Global}}
-				execgen.SET(a.col, a.curIdx, a.curAgg)
-				// {{end}}
-			}
+		// current group, the output for this group should be null.
+		if !a.foundNonNullForCurrentGroup {
+			a.nulls.SetNull(a.curIdx)
+		} else {
+			// {{with .Global}}
+			execgen.SET(a.col, a.curIdx, a.curAgg)
+			// {{end}}
 		}
 		a.curIdx++
 		a.foundNonNullForCurrentGroup = false

--- a/pkg/sql/colexec/one_shot.go
+++ b/pkg/sql/colexec/one_shot.go
@@ -22,6 +22,7 @@ import (
 // first-Next initialization that has to happen in an operator.
 type oneShotOp struct {
 	OneInputNode
+	NonExplainable
 
 	outputSourceRef *colexecbase.Operator
 

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -227,6 +227,9 @@ func (a *orderedAggregator) Next(ctx context.Context) coldata.Batch {
 				// Now we need to restore the desired length for the Vec.
 				vec.SetLength(a.scratch.inputSize)
 				a.aggregateFuncs[i].SetOutputIndex(newResumeIdx)
+				// There might have been some NULLs set in the part that we
+				// have just copied over, so we need to unset the NULLs.
+				a.scratch.ColVec(i).Nulls().UnsetNullsAfter(newResumeIdx + 1)
 			}
 		})
 		a.scratch.resumeIdx = newResumeIdx

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -153,7 +153,7 @@ func NewOrderedAggregator(
 
 	// We will be reusing the same aggregate functions, so we use 1 as the
 	// allocation size.
-	funcsAlloc, err := newAggregateFuncsAlloc(a.allocator, aggTypes, aggFns, 1 /* allocSize */)
+	funcsAlloc, err := newAggregateFuncsAlloc(a.allocator, aggTypes, aggFns, 1 /* allocSize */, false /* isHashAgg */)
 	if err != nil {
 		return nil, errors.AssertionFailedf(
 			"this error should have been checked in isAggregateSupported\n%+v", err,

--- a/pkg/sql/colexec/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/sum_agg_tmpl.go
@@ -20,10 +20,14 @@
 package colexec
 
 import (
+	"strings"
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
 )
 
 // {{/*
@@ -37,10 +41,39 @@ func _ASSIGN_ADD(_, _, _, _, _, _ string) {
 
 // */}}
 
-// {{range .}}
+func newSum_SUMKIND_AGGKINDAggAlloc(
+	allocator *colmem.Allocator, t *types.T, allocSize int64,
+) (aggregateFuncAlloc, error) {
+	allocBase := aggAllocBase{allocator: allocator, allocSize: allocSize}
+	switch t.Family() {
+	case types.IntFamily:
+		switch t.Width() {
+		case 16:
+			return &sum_SUMKINDInt16_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
+		case 32:
+			return &sum_SUMKINDInt32_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
+		default:
+			return &sum_SUMKINDInt64_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
+		}
+	// {{if eq .SumKind ""}}
+	case types.DecimalFamily:
+		return &sumDecimal_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
+	case types.FloatFamily:
+		return &sumFloat64_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
+	case types.IntervalFamily:
+		return &sumInterval_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
+	// {{end}}
+	default:
+		return nil, errors.Errorf("unsupported sum %s agg type %s", strings.ToLower("_SUMKIND"), t.Name())
+	}
+}
 
-type sum_KIND_TYPEAgg struct {
-	groups  []bool
+// {{range .Infos}}
+
+type sum_SUMKIND_TYPE_AGGKINDAgg struct {
+	// {{if eq "_AGGKIND" "Ordered"}}
+	groups []bool
+	// {{end}}
 	scratch struct {
 		curIdx int
 		// curAgg holds the running total, so we can index into the slice once per
@@ -65,32 +98,34 @@ type sum_KIND_TYPEAgg struct {
 	// {{end}}
 }
 
-var _ aggregateFunc = &sum_KIND_TYPEAgg{}
+var _ aggregateFunc = &sum_SUMKIND_TYPE_AGGKINDAgg{}
 
-const sizeOfSum_KIND_TYPEAgg = int64(unsafe.Sizeof(sum_KIND_TYPEAgg{}))
+const sizeOfSum_SUMKIND_TYPE_AGGKINDAgg = int64(unsafe.Sizeof(sum_SUMKIND_TYPE_AGGKINDAgg{}))
 
-func (a *sum_KIND_TYPEAgg) Init(groups []bool, v coldata.Vec) {
+func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Init(groups []bool, v coldata.Vec) {
+	// {{if eq "_AGGKIND" "Ordered"}}
 	a.groups = groups
+	// {{end}}
 	a.scratch.vec = v._RET_TYPE()
 	a.scratch.nulls = v.Nulls()
 	a.Reset()
 }
 
-func (a *sum_KIND_TYPEAgg) Reset() {
+func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Reset() {
 	a.scratch.curIdx = -1
 	a.scratch.foundNonNullForCurrentGroup = false
 	a.scratch.nulls.UnsetNulls()
 }
 
-func (a *sum_KIND_TYPEAgg) CurrentOutputIndex() int {
+func (a *sum_SUMKIND_TYPE_AGGKINDAgg) CurrentOutputIndex() int {
 	return a.scratch.curIdx
 }
 
-func (a *sum_KIND_TYPEAgg) SetOutputIndex(idx int) {
+func (a *sum_SUMKIND_TYPE_AGGKINDAgg) SetOutputIndex(idx int) {
 	a.scratch.curIdx = idx
 }
 
-func (a *sum_KIND_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
+func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	// {{if .NeedsHelper}}
 	// {{/*
 	// overloadHelper is used only when we perform the summation of integers
@@ -132,7 +167,7 @@ func (a *sum_KIND_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	}
 }
 
-func (a *sum_KIND_TYPEAgg) Flush() {
+func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Flush() {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// null.
@@ -144,21 +179,21 @@ func (a *sum_KIND_TYPEAgg) Flush() {
 	a.scratch.curIdx++
 }
 
-func (a *sum_KIND_TYPEAgg) HandleEmptyInputScalar() {
+func (a *sum_SUMKIND_TYPE_AGGKINDAgg) HandleEmptyInputScalar() {
 	a.scratch.nulls.SetNull(0)
 }
 
-type sum_KIND_TYPEAggAlloc struct {
+type sum_SUMKIND_TYPE_AGGKINDAggAlloc struct {
 	aggAllocBase
-	aggFuncs []sum_KIND_TYPEAgg
+	aggFuncs []sum_SUMKIND_TYPE_AGGKINDAgg
 }
 
-var _ aggregateFuncAlloc = &sum_KIND_TYPEAggAlloc{}
+var _ aggregateFuncAlloc = &sum_SUMKIND_TYPE_AGGKINDAggAlloc{}
 
-func (a *sum_KIND_TYPEAggAlloc) newAggFunc() aggregateFunc {
+func (a *sum_SUMKIND_TYPE_AGGKINDAggAlloc) newAggFunc() aggregateFunc {
 	if len(a.aggFuncs) == 0 {
-		a.allocator.AdjustMemoryUsage(sizeOfSum_KIND_TYPEAgg * a.allocSize)
-		a.aggFuncs = make([]sum_KIND_TYPEAgg, a.allocSize)
+		a.allocator.AdjustMemoryUsage(sizeOfSum_SUMKIND_TYPE_AGGKINDAgg * a.allocSize)
+		a.aggFuncs = make([]sum_SUMKIND_TYPE_AGGKINDAgg, a.allocSize)
 	}
 	f := &a.aggFuncs[0]
 	a.aggFuncs = a.aggFuncs[1:]
@@ -172,9 +207,10 @@ func (a *sum_KIND_TYPEAggAlloc) newAggFunc() aggregateFunc {
 // group. If this is the first row of a new group, and no non-nulls have been
 // found for the current group, then the output for the current group is set to
 // null.
-func _ACCUMULATE_SUM(a *sum_KIND_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULLS bool) { // */}}
-
+func _ACCUMULATE_SUM(a *sum_SUMKIND_TYPE_AGGKINDAgg, nulls *coldata.Nulls, i int, _HAS_NULLS bool) { // */}}
 	// {{define "accumulateSum"}}
+
+	// {{if eq "_AGGKIND" "Ordered"}}
 	if a.groups[i] {
 		// If we encounter a new group, and we haven't found any non-nulls for the
 		// current group, the output for this group should be null. If
@@ -199,6 +235,8 @@ func _ACCUMULATE_SUM(a *sum_KIND_TYPEAgg, nulls *coldata.Nulls, i int, _HAS_NULL
 		a.scratch.foundNonNullForCurrentGroup = false
 		// {{end}}
 	}
+	// {{end}}
+
 	var isNull bool
 	// {{if .HasNulls}}
 	isNull = nulls.NullAt(i)

--- a/pkg/sql/colexec/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/sum_agg_tmpl.go
@@ -112,7 +112,7 @@ func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Init(groups []bool, v coldata.Vec) {
 }
 
 func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Reset() {
-	a.scratch.curIdx = -1
+	a.scratch.curIdx = 0
 	a.scratch.foundNonNullForCurrentGroup = false
 	a.scratch.nulls.UnsetNulls()
 }
@@ -213,14 +213,11 @@ func _ACCUMULATE_SUM(a *sum_SUMKIND_TYPE_AGGKINDAgg, nulls *coldata.Nulls, i int
 	// {{if eq "_AGGKIND" "Ordered"}}
 	if a.groups[i] {
 		// If we encounter a new group, and we haven't found any non-nulls for the
-		// current group, the output for this group should be null. If
-		// a.scratch.curIdx is negative, it means that this is the first group.
-		if a.scratch.curIdx >= 0 {
-			if !a.scratch.foundNonNullForCurrentGroup {
-				a.scratch.nulls.SetNull(a.scratch.curIdx)
-			} else {
-				a.scratch.vec[a.scratch.curIdx] = a.scratch.curAgg
-			}
+		// current group, the output for this group should be null.
+		if !a.scratch.foundNonNullForCurrentGroup {
+			a.scratch.nulls.SetNull(a.scratch.curIdx)
+		} else {
+			a.scratch.vec[a.scratch.curIdx] = a.scratch.curAgg
 		}
 		a.scratch.curIdx++
 		// {{with .Global}}

--- a/pkg/sql/colexec/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/sum_agg_tmpl.go
@@ -87,10 +87,7 @@ func (a *sum_KIND_TYPEAgg) CurrentOutputIndex() int {
 }
 
 func (a *sum_KIND_TYPEAgg) SetOutputIndex(idx int) {
-	if a.scratch.curIdx != -1 {
-		a.scratch.curIdx = idx
-		a.scratch.nulls.UnsetNullsAfter(idx + 1)
-	}
+	a.scratch.curIdx = idx
 }
 
 func (a *sum_KIND_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {

--- a/pkg/sql/logictest/testdata/logic_test/tpch_vec
+++ b/pkg/sql/logictest/testdata/logic_test/tpch_vec
@@ -634,10 +634,9 @@ EXPLAIN (VEC) SELECT sum(l_extendedprice * l_discount) AS revenue FROM lineitem 
 │
 └ Node 1
   └ *colexec.orderedAggregator
-    └ *colexec.oneShotOp
-      └ *colexec.distinctChainOps
-        └ *rowexec.indexJoiner
-          └ *colexec.colBatchScan
+    └ *colexec.distinctChainOps
+      └ *rowexec.indexJoiner
+        └ *colexec.colBatchScan
 
 # Query 7
 query T
@@ -798,22 +797,21 @@ EXPLAIN (VEC) SELECT 100.00 * sum(CASE WHEN p_type LIKE 'PROMO%' THEN l_extended
   └ *colexec.projDivFloat64Float64Op
     └ *colexec.projMultFloat64Float64ConstOp
       └ *colexec.orderedAggregator
-        └ *colexec.oneShotOp
-          └ *colexec.distinctChainOps
-            └ *colexec.projMultFloat64Float64Op
-              └ *colexec.projMinusFloat64ConstFloat64Op
-                └ *colexec.caseOp
-                  ├ *colexec.bufferOp
-                  │ └ *colexec.hashJoiner
-                  │   ├ *colexec.colBatchScan
-                  │   └ *rowexec.indexJoiner
-                  │     └ *colexec.colBatchScan
-                  ├ *colexec.projMultFloat64Float64Op
-                  │ └ *colexec.projMinusFloat64ConstFloat64Op
-                  │   └ *colexec.projPrefixBytesBytesConstOp
-                  │     └ *colexec.bufferOp
-                  └ *colexec.constFloat64Op
-                    └ *colexec.bufferOp
+        └ *colexec.distinctChainOps
+          └ *colexec.projMultFloat64Float64Op
+            └ *colexec.projMinusFloat64ConstFloat64Op
+              └ *colexec.caseOp
+                ├ *colexec.bufferOp
+                │ └ *colexec.hashJoiner
+                │   ├ *colexec.colBatchScan
+                │   └ *rowexec.indexJoiner
+                │     └ *colexec.colBatchScan
+                ├ *colexec.projMultFloat64Float64Op
+                │ └ *colexec.projMinusFloat64ConstFloat64Op
+                │   └ *colexec.projPrefixBytesBytesConstOp
+                │     └ *colexec.bufferOp
+                └ *colexec.constFloat64Op
+                  └ *colexec.bufferOp
 
 # Query 15
 statement ok
@@ -863,18 +861,17 @@ EXPLAIN (VEC) SELECT sum(l_extendedprice) / 7.0 AS avg_yearly FROM lineitem, par
 └ Node 1
   └ *colexec.projDivFloat64Float64ConstOp
     └ *colexec.orderedAggregator
-      └ *colexec.oneShotOp
-        └ *colexec.distinctChainOps
+      └ *colexec.distinctChainOps
+        └ *rowexec.joinReader
           └ *rowexec.joinReader
-            └ *rowexec.joinReader
-              └ *colexec.projMultFloat64Float64ConstOp
-                └ *colexec.orderedAggregator
-                  └ *colexec.distinctChainOps
+            └ *colexec.projMultFloat64Float64ConstOp
+              └ *colexec.orderedAggregator
+                └ *colexec.distinctChainOps
+                  └ *rowexec.joinReader
                     └ *rowexec.joinReader
-                      └ *rowexec.joinReader
+                      └ *colexec.selEQBytesBytesConstOp
                         └ *colexec.selEQBytesBytesConstOp
-                          └ *colexec.selEQBytesBytesConstOp
-                            └ *colexec.colBatchScan
+                          └ *colexec.colBatchScan
 
 # Query 18
 query T
@@ -903,52 +900,51 @@ EXPLAIN (VEC) SELECT sum(l_extendedprice* (1 - l_discount)) AS revenue FROM line
 │
 └ Node 1
   └ *colexec.orderedAggregator
-    └ *colexec.oneShotOp
-      └ *colexec.distinctChainOps
-        └ *colexec.projMultFloat64Float64Op
-          └ *colexec.projMinusFloat64ConstFloat64Op
-            └ *colexec.caseOp
-              ├ *colexec.bufferOp
-              │ └ *colexec.hashJoiner
-              │   ├ *colexec.selEQBytesBytesConstOp
-              │   │ └ *colexec.selectInOpBytes
-              │   │   └ *colexec.colBatchScan
-              │   └ *colexec.selGEInt64Int64ConstOp
-              │     └ *colexec.colBatchScan
-              ├ *colexec.constBoolOp
-              │ └ *colexec.orProjOp
-              │   ├ *colexec.bufferOp
-              │   ├ *colexec.andProjOp
-              │   │ ├ *colexec.andProjOp
-              │   │ │ ├ *colexec.andProjOp
-              │   │ │ │ ├ *colexec.andProjOp
-              │   │ │ │ │ ├ *colexec.projEQBytesBytesConstOp
-              │   │ │ │ │ └ *colexec.projectInOpBytes
-              │   │ │ │ └ *colexec.projGEFloat64Float64ConstOp
-              │   │ │ └ *colexec.projLEFloat64Float64ConstOp
-              │   │ └ *colexec.projLEInt64Int64ConstOp
-              │   └ *colexec.andProjOp
-              │     ├ *colexec.andProjOp
-              │     │ ├ *colexec.andProjOp
-              │     │ │ ├ *colexec.andProjOp
-              │     │ │ │ ├ *colexec.projEQBytesBytesConstOp
-              │     │ │ │ └ *colexec.projectInOpBytes
-              │     │ │ └ *colexec.projGEFloat64Float64ConstOp
-              │     │ └ *colexec.projLEFloat64Float64ConstOp
-              │     └ *colexec.projLEInt64Int64ConstOp
-              ├ *colexec.constBoolOp
-              │ └ *colexec.andProjOp
-              │   ├ *colexec.bufferOp
-              │   ├ *colexec.andProjOp
-              │   │ ├ *colexec.andProjOp
-              │   │ │ ├ *colexec.andProjOp
-              │   │ │ │ ├ *colexec.projEQBytesBytesConstOp
-              │   │ │ │ └ *colexec.projectInOpBytes
-              │   │ │ └ *colexec.projGEFloat64Float64ConstOp
-              │   │ └ *colexec.projLEFloat64Float64ConstOp
-              │   └ *colexec.projLEInt64Int64ConstOp
-              └ *colexec.constBoolOp
-                └ *colexec.bufferOp
+    └ *colexec.distinctChainOps
+      └ *colexec.projMultFloat64Float64Op
+        └ *colexec.projMinusFloat64ConstFloat64Op
+          └ *colexec.caseOp
+            ├ *colexec.bufferOp
+            │ └ *colexec.hashJoiner
+            │   ├ *colexec.selEQBytesBytesConstOp
+            │   │ └ *colexec.selectInOpBytes
+            │   │   └ *colexec.colBatchScan
+            │   └ *colexec.selGEInt64Int64ConstOp
+            │     └ *colexec.colBatchScan
+            ├ *colexec.constBoolOp
+            │ └ *colexec.orProjOp
+            │   ├ *colexec.bufferOp
+            │   ├ *colexec.andProjOp
+            │   │ ├ *colexec.andProjOp
+            │   │ │ ├ *colexec.andProjOp
+            │   │ │ │ ├ *colexec.andProjOp
+            │   │ │ │ │ ├ *colexec.projEQBytesBytesConstOp
+            │   │ │ │ │ └ *colexec.projectInOpBytes
+            │   │ │ │ └ *colexec.projGEFloat64Float64ConstOp
+            │   │ │ └ *colexec.projLEFloat64Float64ConstOp
+            │   │ └ *colexec.projLEInt64Int64ConstOp
+            │   └ *colexec.andProjOp
+            │     ├ *colexec.andProjOp
+            │     │ ├ *colexec.andProjOp
+            │     │ │ ├ *colexec.andProjOp
+            │     │ │ │ ├ *colexec.projEQBytesBytesConstOp
+            │     │ │ │ └ *colexec.projectInOpBytes
+            │     │ │ └ *colexec.projGEFloat64Float64ConstOp
+            │     │ └ *colexec.projLEFloat64Float64ConstOp
+            │     └ *colexec.projLEInt64Int64ConstOp
+            ├ *colexec.constBoolOp
+            │ └ *colexec.andProjOp
+            │   ├ *colexec.bufferOp
+            │   ├ *colexec.andProjOp
+            │   │ ├ *colexec.andProjOp
+            │   │ │ ├ *colexec.andProjOp
+            │   │ │ │ ├ *colexec.projEQBytesBytesConstOp
+            │   │ │ │ └ *colexec.projectInOpBytes
+            │   │ │ └ *colexec.projGEFloat64Float64ConstOp
+            │   │ └ *colexec.projLEFloat64Float64ConstOp
+            │   └ *colexec.projLEInt64Int64ConstOp
+            └ *colexec.constBoolOp
+              └ *colexec.bufferOp
 
 # Query 20
 query T

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -161,6 +161,5 @@ EXPLAIN (VEC) SELECT max(c) FROM a
 │
 └ Node 1
   └ *colexec.orderedAggregator
-    └ *colexec.oneShotOp
-      └ *colexec.distinctChainOps
-        └ *colexec.colBatchScan
+    └ *colexec.distinctChainOps
+      └ *colexec.colBatchScan


### PR DESCRIPTION
**colexec: simplify aggregateFunc interface a bit**

This commit simplifies `SetOutputIndex` to no longer be required to
unset nulls after the desired output index. The unsetting is only
necessary when we have "overflow" tuples in the ordered aggregator, so
it makes that it should be the one resetting the nulls.

Additionally, the implementation of `SetOutputIndex` no longer checks
whether `curIdx` is not -1 (meaning the function has already performed
some aggregation). I think this was an artifact from the past and is no
longer necessary.

This commit also makes a minor performance optimization to unwrap the
output batch in the ordered aggregator.

Release note: None

**colexec: optimize any_not_null func for hash aggregation**

When we're performing hash aggregation, we know that there will be
exactly one group. This insight allows us optimize the aggregate
functions, and this commit performs the optimization of any_not_null.
Now we will have two separate files for both aggregator kinds (hash and
ordered), and that part is handled by a preprocessing step that replaces
`_AGGKIND` template "variable" with the corresponding aggregator kind.

I looked into introducing some base struct for aggregates to reuse, but
it is rather complicated at the moment - some aggregate functions
iterate over `[]*oneArgOverload`, and we could flatten that out.
However, other functions operate with a custom "tmpl info" struct.
Furthermore, extending the struct to include `AggKind` variable would
require refactoring the templates themselves because we assume that `.`
(dot) of the template usually is at `lastArgWidthOverload` struct.
Probably in order to provide some "aggregate base tmpl info" struct that
would help with hash vs ordered aggregation generation we would need to
introduce an interface which custom tmpl infos will implement.

Release note: None

**colexec: optimize all aggregate funcs for hash**

This commit adds a simple optimization of omitting the check for a start
of a new group in all aggregate functions if we're performing hash
aggregation.

This change also allows us to slightly simplify the hash aggregator.

Release note: None

**colexec: optimize aggregateFunc contract a bit**

This commit adjusts the contract of `aggregateFunc.Init` method to
require that the very first tuple in the whole input should *not* have
a `true` value set in `groups` vector. This requirement allows us to
optimize all aggregate functions for the case of ordered aggregator. The
ordered aggregator has been adjusted accordingly to satisfy the
contract.

This commit also marks `oneShotOp` as `NonExplainable`.

Release note: None