### PR TITLE
log: add a mutex for stderr redirection

### DIFF
--- a/pkg/util/log/stderr_redirect.go
+++ b/pkg/util/log/stderr_redirect.go
@@ -10,7 +10,11 @@
 
 package log
 
-import "os"
+import (
+	"os"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
 
 // OrigStderr points to the original stderr stream.
 var OrigStderr = func() *os.File {
@@ -44,3 +48,7 @@ func hijackStderr(f *os.File) error {
 func restoreStderr() error {
 	return redirectStderr(OrigStderr)
 }
+
+// osStderrMu ensures that concurrent redirects of stderr don't
+// overwrite each other.
+var osStderrMu syncutil.Mutex

--- a/pkg/util/log/stderr_redirect_unix.go
+++ b/pkg/util/log/stderr_redirect_unix.go
@@ -47,6 +47,8 @@ func dupFD(fd uintptr) (uintptr, error) {
 // We also override os.Stderr for those other parts of Go which use
 // that and not fd 2 directly.
 func redirectStderr(f *os.File) error {
+	osStderrMu.Lock()
+	defer osStderrMu.Unlock()
 	if err := unix.Dup2(int(f.Fd()), unix.Stderr); err != nil {
 		return err
 	}

--- a/pkg/util/log/stderr_redirect_windows.go
+++ b/pkg/util/log/stderr_redirect_windows.go
@@ -35,6 +35,8 @@ func dupFD(fd uintptr) (uintptr, error) {
 // We also override os.Stderr for those other parts of Go which use
 // that and not fd 2 directly.
 func redirectStderr(f *os.File) error {
+	osStderrMu.Lock()
+	defer osStderrMu.Unlock()
 	if err := windows.SetStdHandle(windows.STD_ERROR_HANDLE, windows.Handle(f.Fd())); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #49930

The `TestLogScope` infrastructure is meant to force-configure logging
to go to a temporary directory. It was designed with the assumption it
would be used "outside" of server initialization, i.e.
non-concurrently with `log` API calls.

However, at least one test (`TestHBAAuthenticationRules`) violates the
assumption and switches the output directory while a server is running.

After checking it appears that the behavior is sound, but there was
one racy access remaining: the write to `os.Stderr` during the
redirect.

This had been racy ever since TestLogScope was introduced; however
it was only visible on windows because the unix builds were missing
the assignment to `os.Stderr`. A recent fix to make the builds
consistent revealed the race to our CI checker.

This patch fixes it by adding the missing mutex.

Release note: None