### PR TITLE
sql: enable adding check constraints that use enums

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -661,7 +661,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 						"constraint %q in the middle of being added, try again later", t.Constraint)
 				}
 				if err := validateCheckInTxn(
-					params.ctx, params.p.LeaseMgr(), params.EvalContext(), n.tableDesc, params.EvalContext().Txn, name,
+					params.ctx, params.p.LeaseMgr(), &params.p.semaCtx, params.EvalContext(), n.tableDesc, params.EvalContext().Txn, name,
 				); err != nil {
 					return err
 				}

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -173,7 +173,7 @@ func (r *insertRun) processSourceRow(params runParams, rowVals tree.Datums) erro
 	// Verify the CHECK constraint results, if any.
 	if !r.checkOrds.Empty() {
 		checkVals := rowVals[len(r.insertCols):]
-		if err := checkMutationInput(r.ti.tableDesc(), r.checkOrds, checkVals); err != nil {
+		if err := checkMutationInput(params.ctx, &params.p.semaCtx, r.ti.tableDesc(), r.checkOrds, checkVals); err != nil {
 			return err
 		}
 		rowVals = rowVals[:len(r.insertCols)]

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -586,6 +586,47 @@ enum_checks  CREATE TABLE enum_checks (
              CONSTRAINT "check" CHECK ('hello':::test.public.greeting = 'hello':::test.public.greeting)
 )
 
+# Ensure that we can add check constraints to tables with enums.
+statement ok
+DROP TABLE enum_checks;
+CREATE TABLE enum_checks (x greeting);
+INSERT INTO enum_checks VALUES ('hi'), ('howdy');
+ALTER TABLE enum_checks ADD CHECK (x > 'hello')
+
+# Ensure that checks are validated on insert.
+statement error pq: failed to satisfy CHECK constraint \(x > 'hello':::test.public.greeting\)
+INSERT INTO enum_checks VALUES ('hello')
+
+# Try adding a check that fails validation.
+statement error pq: validation of CHECK "x = 'hello':::test.public.greeting" failed
+ALTER TABLE enum_checks ADD CHECK (x = 'hello')
+
+# Check the above cases, but in a transaction.
+statement ok
+DROP TABLE enum_checks;
+BEGIN;
+CREATE TABLE enum_checks (x greeting);
+INSERT INTO enum_checks VALUES ('hi'), ('howdy');
+ALTER TABLE enum_checks ADD CHECK (x > 'hello')
+
+statement error pq: failed to satisfy CHECK constraint \(x > 'hello':::test.public.greeting\)
+INSERT INTO enum_checks VALUES ('hello')
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN;
+CREATE TABLE enum_checks (x greeting);
+INSERT INTO enum_checks VALUES ('hi'), ('howdy');
+
+# Try adding a check that fails validation.
+statement error pq: validation of CHECK "x = 'hello':::test.public.greeting" failed
+ALTER TABLE enum_checks ADD CHECK (x = 'hello')
+
+statement ok
+ROLLBACK
+
 subtest schema_changes
 
 # Ensure that we can drop and create indexes on user defined type columns,

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -300,7 +300,7 @@ func (u *updateNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	// contain the results of evaluation.
 	if !u.run.checkOrds.Empty() {
 		checkVals := sourceVals[len(u.run.tu.ru.FetchCols)+len(u.run.tu.ru.UpdateCols)+u.run.numPassthrough:]
-		if err := checkMutationInput(u.run.tu.tableDesc(), u.run.checkOrds, checkVals); err != nil {
+		if err := checkMutationInput(params.ctx, &params.p.semaCtx, u.run.tu.tableDesc(), u.run.checkOrds, checkVals); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -161,7 +161,7 @@ func (n *upsertNode) processSourceRow(params runParams, rowVals tree.Datums) err
 			ord++
 		}
 		checkVals := rowVals[ord:]
-		if err := checkMutationInput(n.run.tw.tableDesc(), n.run.checkOrds, checkVals); err != nil {
+		if err := checkMutationInput(params.ctx, &params.p.semaCtx, n.run.tw.tableDesc(), n.run.checkOrds, checkVals); err != nil {
 			return err
 		}
 		rowVals = rowVals[:ord]


### PR DESCRIPTION
Work for #48728.

This PR ensures that check constraints that use enums can be added and
validated. It also updates the sites where check validations fail to
ensure that the displayed error message has been deserialized from the
internal representation.

Release note: None