### PR TITLE
vendor: bump Pebble to feb930

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -458,7 +458,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:01f450f2b42cdd2e3eac4a0ff01e0eccc287b5e6c590dbb592b3a320cd29cce0"
+  digest = "1:085203aa725af444d832f6f0e38511e7a2a7bf7d630f618257e467fb043ea109"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -484,7 +484,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "4887c526300055e1c30635c53fd16b3fe9d9e132"
+  revision = "feb93032c41f991845506cd423f1771618edf2b0"
 
 [[projects]]
   branch = "master"
@@ -2146,6 +2146,7 @@
     "github.com/apache/arrow/go/arrow/memory",
     "github.com/armon/circbuf",
     "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/awserr",
     "github.com/aws/aws-sdk-go/aws/credentials",
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/s3",


### PR DESCRIPTION
```
feb930 db: close tableCache on open error
660b76 internal/record: bump LogWriter pending queue size
a9b799 db: remove table loading goroutine
d18729 db: add a per-tableCacheShard table closing goroutine
9687c6 internal/manifest: add Level type
```

Includes cockroachdb/pebble#722, which partially addresses #49750:
```
name                                    old ops/sec  new ops/sec  delta
kv0/enc=false/nodes=3/cpu=32/size=64kb     641 ± 7%    1158 ± 3%  +80.80%  (p=0.016 n=4+5)

name                                    old p50      new p50      delta
kv0/enc=false/nodes=3/cpu=32/size=64kb     177 ±34%      67 ±31%  -62.13%  (p=0.016 n=4+5)

name                                    old p95      new p95      delta
kv0/enc=false/nodes=3/cpu=32/size=64kb     990 ±15%     584 ± 3%  -41.02%  (p=0.000 n=4+5)

name                                    old p99      new p99      delta
kv0/enc=false/nodes=3/cpu=32/size=64kb   1.34k ±10%   0.79k ± 6%  -41.00%  (p=0.016 n=4+5)
```

Release note: None