### PR TITLE
release-20.1: opt: fix error caused by recursive CTE with zero rows on left side

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/with
+++ b/pkg/sql/opt/memo/testdata/stats/with
@@ -153,3 +153,52 @@ with &1 (t0)
            │    └── filters (true)
            └── projections
                 └── NULL [as="?column?":27, type=unknown]
+
+exec-ddl
+CREATE TABLE test (
+  id string
+)
+----
+
+# Regression test for #49911. Make sure there is no error if the left side of
+# a recursive CTE has cardinality=0.
+norm
+WITH RECURSIVE hierarchy(id) as
+  (SELECT id FROM test WHERE id = 'foo' AND 1 != 1 UNION ALL SELECT c.id FROM test AS c, hierarchy AS p WHERE c.id = 'bar')
+SELECT * FROM hierarchy
+----
+project
+ ├── columns: id:7(string)
+ ├── stats: [rows=10]
+ ├── recursive-c-t-e
+ │    ├── columns: id:3(string)
+ │    ├── working table binding: &1
+ │    ├── initial columns: test.id:1(string)
+ │    ├── recursive columns: c.id:4(string)
+ │    ├── stats: [rows=10]
+ │    ├── values
+ │    │    ├── columns: test.id:1(string!null)
+ │    │    ├── cardinality: [0 - 0]
+ │    │    ├── stats: [rows=0]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(1)
+ │    └── inner-join (cross)
+ │         ├── columns: c.id:4(string!null)
+ │         ├── stats: [rows=10]
+ │         ├── fd: ()-->(4)
+ │         ├── select
+ │         │    ├── columns: c.id:4(string!null)
+ │         │    ├── stats: [rows=10, distinct(4)=1, null(4)=0]
+ │         │    ├── fd: ()-->(4)
+ │         │    ├── scan c
+ │         │    │    ├── columns: c.id:4(string)
+ │         │    │    └── stats: [rows=1000, distinct(4)=100, null(4)=10]
+ │         │    └── filters
+ │         │         └── c.id:4 = 'bar' [type=bool, outer=(4), constraints=(/4: [/'bar' - /'bar']; tight), fd=()-->(4)]
+ │         ├── with-scan &1 (hierarchy)
+ │         │    ├── mapping:
+ │         │    ├── cardinality: [1 - ]
+ │         │    └── stats: [rows=1]
+ │         └── filters (true)
+ └── projections
+      └── id:3 [as=id:7, type=string, outer=(3)]

--- a/pkg/sql/opt/optbuilder/with.go
+++ b/pkg/sql/opt/optbuilder/with.go
@@ -127,6 +127,11 @@ func (b *Builder) buildCTE(
 	// We don't really know the input row count, except for the first time we run
 	// the recursive query. We don't have anything better though.
 	bindingProps.Stats.RowCount = initialScope.expr.Relational().Stats.RowCount
+	// Row count must be greater than 0 or the stats code will throw an error.
+	// Set it to 1 to match the cardinality.
+	if bindingProps.Stats.RowCount < 1 {
+		bindingProps.Stats.RowCount = 1
+	}
 	cteSrc.bindingProps = bindingProps
 
 	cteSrc.cols = b.getCTECols(initialScope, cte.Name)


### PR DESCRIPTION
Backport 1/1 commits from #49961.

/cc @cockroachdb/release

---

Prior to this commit, a recursive CTE in which the cardinality of
the left side of the `UNION ALL` expression was zero would cause an
error in the statistics code, "estimated row count must be non-zero".
This was happening because the cardinality of the recursive CTE binding
props was set to be non-zero, but the row count, which came from the
left side expression, was not updated accordingly. The stats code only
allows the row count to be zero if the cardinality is also zero.

This commit fixes the problem by setting the row count of the binding
props to 1 if the estimated row count of the left side is less than 1.

Fixes #49911

Release note (bug fix): Fixed an internal planning error that occured
for recursive CTEs (WITH RECURSIVE expressions) in which the left side
of the UNION ALL query used in the CTE definition produced zero rows.
