### PR TITLE
cli: Ensures unique test files are used by parallel runs of the `nodelocal upload` CLI tests

### DIFF
--- a/pkg/cli/nodelocal_test.go
+++ b/pkg/cli/nodelocal_test.go
@@ -126,11 +126,15 @@ func TestNodeLocalFileUpload(t *testing.T) {
 }
 
 func createTestFile(name, content string) (string, func()) {
-	err := ioutil.WriteFile(name, []byte(content), 0666)
+	tmpDir, err := ioutil.TempDir("", "")
+	tmpFile := filepath.Join(tmpDir, testTempFilePrefix+name)
+	if err == nil {
+		err = ioutil.WriteFile(tmpFile, []byte(content), 0666)
+	}
 	if err != nil {
 		return "", func() {}
 	}
-	return name, func() {
-		_ = os.Remove(name)
+	return tmpFile, func() {
+		_ = os.RemoveAll(tmpDir)
 	}
 }


### PR DESCRIPTION
Fixes #47505

Previously, the test created `test.csv` and attempted to upload
the file to different nodelocal paths. On completion, the test
would delete `test.csv`. Parallel executions of this test via
`make stress` would get into a state where one process would
delete `test.csv` on completion, thereby making it unavailable
to `nodelocal upload` statements being executed by parallel processes,

To fix this, `test.csv` is now created within a unique temp dir.
Given that the expected output of a CLI test is defined via a
static comment, we cannot compare full file paths. Logic was
added to trim the file path and extract only the file name
when comparing expected vs got.

Release note: None