### PR TITLE
roachtest: adjust tpchvec and tpcdsvec

### DIFF
--- a/pkg/cmd/roachtest/tpc_utils.go
+++ b/pkg/cmd/roachtest/tpc_utils.go
@@ -110,3 +110,15 @@ func createStatsFromTables(t *test, conn *gosql.DB, tableNames []string) {
 		}
 	}
 }
+
+// disableVectorizeRowCountThresholdHeuristic sets
+// 'vectorize_row_count_threshold' cluster setting to zero so that the test
+// would use the vectorized engine with 'vectorize=on' regardless of the
+// fact whether the stats are present or not (if we don't set it, then when
+// the stats are not present, we fallback to row-by-row engine even with
+// `vectorize=on` set).
+func disableVectorizeRowCountThresholdHeuristic(t *test, conn *gosql.DB) {
+	if _, err := conn.Exec("SET CLUSTER SETTING sql.defaults.vectorize_row_count_threshold=0"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/cmd/roachtest/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tpcdsvec.go
@@ -96,6 +96,7 @@ func registerTPCDSVec(r *testRegistry) {
 
 		clusterConn := c.Conn(ctx, 1)
 		disableAutoStats(t, clusterConn)
+		disableVectorizeRowCountThresholdHeuristic(t, clusterConn)
 		t.Status("restoring TPCDS dataset for Scale Factor 1")
 		if _, err := clusterConn.Exec(
 			`RESTORE DATABASE tpcds FROM 'gs://cockroach-fixtures/workload/tpcds/scalefactor=1/backup';`,

--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -29,10 +29,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-const (
-	tpchVecNodeCount = 3
-)
-
 type crdbVersion int
 
 const (
@@ -155,8 +151,8 @@ func (b tpchVecTestCaseBase) postTestRunHook(_ *test, _ *gosql.DB, _ crdbVersion
 
 const (
 	tpchPerfTestNumRunsPerQuery = 3
-	tpchPerfTestVecOnConfigIdx  = 0
-	tpchPerfTestVecOffConfigIdx = 1
+	tpchPerfTestVecOnConfigIdx  = 1
+	tpchPerfTestVecOffConfigIdx = 0
 )
 
 type tpchVecPerfTest struct {
@@ -177,7 +173,7 @@ func newTpchVecPerfTest(disableStatsCreation bool) *tpchVecPerfTest {
 func (p tpchVecPerfTest) vectorizeOptions() []bool {
 	// Since this is a performance test, each query should be run with both
 	// vectorize modes.
-	return []bool{true, false}
+	return []bool{false, true}
 }
 
 func (p tpchVecPerfTest) numRunsPerQuery() int {
@@ -372,8 +368,8 @@ func baseTestRun(
 			}
 			vectorizeSetting := vectorizeOptionToSetting(vectorize, version)
 			cmd := fmt.Sprintf("./workload run tpch --concurrency=1 --db=tpch "+
-				"--max-ops=%d --queries=%d --vectorize=%s {pgurl:1-%d}",
-				tc.numRunsPerQuery(), queryNum, vectorizeSetting, tpchVecNodeCount)
+				"--max-ops=%d --queries=%d --vectorize=%s {pgurl:1}",
+				tc.numRunsPerQuery(), queryNum, vectorizeSetting)
 			workloadOutput, err := c.RunWithBuffer(ctx, t.l, firstNode, cmd)
 			t.l.Printf("\n" + string(workloadOutput))
 			if err != nil {
@@ -479,6 +475,8 @@ func runTPCHVec(
 	testRun(ctx, t, c, version, testCase)
 	testCase.postTestRunHook(t, conn, version)
 }
+
+const tpchVecNodeCount = 3
 
 func registerTPCHVec(r *testRegistry) {
 	r.Add(testSpec{


### PR DESCRIPTION
**roachtest: add new tpchvec config**

This commit adds a new `tpchvec/perf_no_stats` config that is the same
as `tpchvec/perf` except for the fact that stats creation is disabled.
The plans without stats are likely to be different, so it gives us an
easy way to get more test coverage. One caveat here is that query
9 without stats takes insanely long to run, so some new plumbing has
been added to skip that query.

Additionally, `tpcdsvec` has been adjusted. The test runs all queries
with and without stats present with `on` and `off` vectorize options.
However, when stats are not present, `on` config will be reduced to
`off` because of `vectorize_row_count_threshold` heuristic. This commit
disables that heuristic.

Release note: None

**roachtest: switch the config order in tpchvec/perf**

Let's see whether it makes difference to occasional failures of
`tpchvec/perf` which are very hard to explain.

This commit also changes the workload command for `perf` config to run
only against node 1, thus, eliminating one possible source of
"randomness" for the failures.

Addresses: #49955.

Release note: None