### PR TITLE
build: add build that simply compiles CRDB on supported platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1671,6 +1671,7 @@ bins = \
   bin/benchmark \
   bin/cockroach-oss \
   bin/cockroach-short \
+  bin/compile-builds \
   bin/docgen \
   bin/execgen \
   bin/fuzz \

--- a/build/teamcity-compile-builds.sh
+++ b/build/teamcity-compile-builds.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+export BUILDER_HIDE_GOPATH_SRC=1
+
+build/builder.sh go install ./pkg/cmd/compile-builds
+build/builder.sh env \
+  compile-builds

--- a/pkg/cmd/compile-builds/main.go
+++ b/pkg/cmd/compile-builds/main.go
@@ -1,0 +1,36 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// compile-builds attempts to compile all CRDB builds we support.
+
+package main
+
+import (
+	"go/build"
+	"log"
+
+	"github.com/cockroachdb/cockroach/pkg/release"
+)
+
+func main() {
+	pkg, err := build.Import("github.com/cockroachdb/cockroach", "", build.FindOnly)
+	if err != nil {
+		log.Fatalf("unable to locate CRDB directory: %s", err)
+	}
+
+	for _, target := range release.SupportedTargets {
+		if err := release.MakeRelease(
+			target,
+			pkg.Dir,
+		); err != nil {
+			log.Fatal(err)
+		}
+	}
+}

--- a/pkg/cmd/publish-artifacts/main.go
+++ b/pkg/cmd/publish-artifacts/main.go
@@ -13,7 +13,6 @@ package main
 import (
 	"archive/tar"
 	"archive/zip"
-	"bufio"
 	"bytes"
 	"compress/gzip"
 	"flag"
@@ -31,6 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/cockroachdb/cockroach/pkg/release"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/kr/pretty"
 )
@@ -55,20 +55,6 @@ var testableS3 = func() (s3putter, error) {
 	}
 	return s3.New(sess), nil
 }
-
-var libsRe = func() *regexp.Regexp {
-	libs := strings.Join([]string{
-		regexp.QuoteMeta("linux-vdso.so."),
-		regexp.QuoteMeta("librt.so."),
-		regexp.QuoteMeta("libpthread.so."),
-		regexp.QuoteMeta("libdl.so."),
-		regexp.QuoteMeta("libm.so."),
-		regexp.QuoteMeta("libc.so."),
-		regexp.QuoteMeta("libresolv.so."),
-		strings.Replace(regexp.QuoteMeta("ld-linux-ARCH.so."), "ARCH", ".*", -1),
-	}, "|")
-	return regexp.MustCompile(libs)
-}()
 
 var osVersionRe = regexp.MustCompile(`\d+(\.\d+)*-`)
 
@@ -157,17 +143,7 @@ func main() {
 		})
 	}
 
-	for _, target := range []struct {
-		buildType string
-		suffix    string
-	}{
-		// TODO(tamird): consider shifting this information into the builder
-		// image; it's conceivable that we'll want to target multiple versions
-		// of a given triple.
-		{buildType: "darwin", suffix: ".darwin-10.9-amd64"},
-		{buildType: "linux-gnu", suffix: ".linux-2.6.32-gnu-amd64"},
-		{buildType: "windows", suffix: ".windows-6.2-amd64.exe"},
-	} {
+	for _, target := range release.SupportedTargets {
 		for i, extraArgs := range []struct {
 			goflags string
 			suffix  string
@@ -188,9 +164,9 @@ func main() {
 			o.VersionStr = versionStr
 			o.BucketName = bucketName
 			o.Branch = branch
-			o.BuildType = target.buildType
+			o.BuildType = target.BuildType
 			o.GoFlags = extraArgs.goflags
-			o.Suffix = extraArgs.suffix + target.suffix
+			o.Suffix = extraArgs.suffix + target.Suffix
 			o.Tags = extraArgs.tags
 
 			log.Printf("building %s", pretty.Sprint(o))
@@ -256,58 +232,30 @@ func buildArchive(svc s3putter, o opts) {
 }
 
 func buildOneCockroach(svc s3putter, o opts) {
+	log.Printf("building cockroach %s", pretty.Sprint(o))
 	defer func() {
 		log.Printf("done building cockroach: %s", pretty.Sprint(o))
 	}()
 
-	{
-		args := []string{o.BuildType}
-		args = append(args, fmt.Sprintf("%s=%s", "GOFLAGS", o.GoFlags))
-		args = append(args, fmt.Sprintf("%s=%s", "SUFFIX", o.Suffix))
-		args = append(args, fmt.Sprintf("%s=%s", "TAGS", o.Tags))
-		args = append(args, fmt.Sprintf("%s=%s", "BUILDCHANNEL", "official-binary"))
-		if *isRelease {
-			args = append(args, fmt.Sprintf("%s=%s", "BUILD_TAGGED_RELEASE", "true"))
-		}
-		cmd := exec.Command("mkrelease", args...)
-		cmd.Dir = o.PkgDir
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		log.Printf("%s %s", cmd.Env, cmd.Args)
-		if err := cmd.Run(); err != nil {
-			log.Fatalf("%s: %s", cmd.Args, err)
-		}
+	opts := []release.MakeReleaseOption{
+		release.WithMakeReleaseOptionBuildArg(fmt.Sprintf("%s=%s", "GOFLAGS", o.GoFlags)),
+		release.WithMakeReleaseOptionBuildArg(fmt.Sprintf("%s=%s", "SUFFIX", o.Suffix)),
+		release.WithMakeReleaseOptionBuildArg(fmt.Sprintf("%s=%s", "TAGS", o.Tags)),
+		release.WithMakeReleaseOptionBuildArg(fmt.Sprintf("%s=%s", "BUILDCHANNEL", "official-binary")),
+	}
+	if *isRelease {
+		opts = append(opts, release.WithMakeReleaseOptionBuildArg(fmt.Sprintf("%s=%s", "BUILD_TAGGED_RELEASE", "true")))
 	}
 
-	if strings.Contains(o.BuildType, "linux") {
-		binaryName := "./cockroach" + o.Suffix
-
-		cmd := exec.Command(binaryName, "version")
-		cmd.Dir = o.PkgDir
-		cmd.Env = append(cmd.Env, "MALLOC_CONF=prof:true")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		log.Printf("%s %s", cmd.Env, cmd.Args)
-		if err := cmd.Run(); err != nil {
-			log.Fatalf("%s %s: %s", cmd.Env, cmd.Args, err)
-		}
-
-		cmd = exec.Command("ldd", binaryName)
-		cmd.Dir = o.PkgDir
-		log.Printf("%s %s", cmd.Env, cmd.Args)
-		out, err := cmd.Output()
-		if err != nil {
-			log.Fatalf("%s: out=%q err=%s", cmd.Args, out, err)
-		}
-		scanner := bufio.NewScanner(bytes.NewReader(out))
-		for scanner.Scan() {
-			if line := scanner.Text(); !libsRe.MatchString(line) {
-				log.Fatalf("%s is not properly statically linked:\n%s", binaryName, out)
-			}
-		}
-		if err := scanner.Err(); err != nil {
-			log.Fatal(err)
-		}
+	if err := release.MakeRelease(
+		release.SupportedTarget{
+			BuildType: o.BuildType,
+			Suffix:    o.Suffix,
+		},
+		o.PkgDir,
+		opts...,
+	); err != nil {
+		log.Fatal(err)
 	}
 
 	o.Base = "cockroach" + o.Suffix

--- a/pkg/cmd/publish-provisional-artifacts/main_test.go
+++ b/pkg/cmd/publish-provisional-artifacts/main_test.go
@@ -21,6 +21,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/cockroachdb/cockroach/pkg/release"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
@@ -227,7 +228,7 @@ func TestBless(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var s3 mockS3
-			var execFn execRunner // bless shouldn't exec anything
+			var execFn release.ExecFn // bless shouldn't exec anything
 			run(&s3, execFn, test.flags)
 			require.Equal(t, test.expectedGets, s3.gets)
 			require.Equal(t, test.expectedPuts, s3.puts)

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -1,0 +1,144 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package release contains utilities for assisting with the release process.
+// This is intended for use for the release commands.
+package release
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// linuxStaticLibsRe returns the regexp of all static libraries.
+var linuxStaticLibsRe = func() *regexp.Regexp {
+	libs := strings.Join([]string{
+		regexp.QuoteMeta("linux-vdso.so."),
+		regexp.QuoteMeta("librt.so."),
+		regexp.QuoteMeta("libpthread.so."),
+		regexp.QuoteMeta("libdl.so."),
+		regexp.QuoteMeta("libm.so."),
+		regexp.QuoteMeta("libc.so."),
+		regexp.QuoteMeta("libresolv.so."),
+		strings.Replace(regexp.QuoteMeta("ld-linux-ARCH.so."), "ARCH", ".*", -1),
+	}, "|")
+	return regexp.MustCompile(libs)
+}()
+
+// SupportedTarget contains metadata about a supported target.
+type SupportedTarget struct {
+	BuildType string
+	Suffix    string
+}
+
+// SupportedTargets contains the supported targets that we build.
+var SupportedTargets = []SupportedTarget{
+	{BuildType: "darwin", Suffix: ".darwin-10.9-amd64"},
+	{BuildType: "linux-gnu", Suffix: ".linux-2.6.32-gnu-amd64"},
+	{BuildType: "windows", Suffix: ".windows-6.2-amd64.exe"},
+}
+
+// makeReleaseAndVerifyOptions are options for MakeRelease.
+type makeReleaseAndVerifyOptions struct {
+	args   []string
+	execFn ExecFn
+}
+
+// ExecFn is a mockable wrapper that executes the given command.
+type ExecFn func(*exec.Cmd) ([]byte, error)
+
+// DefaultExecFn is the default exec function.
+var DefaultExecFn ExecFn = func(c *exec.Cmd) ([]byte, error) {
+	if c.Stdout != nil {
+		return nil, errors.New("exec: Stdout already set")
+	}
+	var stdout bytes.Buffer
+	c.Stdout = io.MultiWriter(&stdout, os.Stdout)
+	err := c.Run()
+	return stdout.Bytes(), err
+}
+
+// MakeReleaseOption as an option for the MakeRelease function.
+type MakeReleaseOption func(makeReleaseAndVerifyOptions) makeReleaseAndVerifyOptions
+
+// WithMakeReleaseOptionBuildArg adds a build argument to release.
+func WithMakeReleaseOptionBuildArg(arg string) MakeReleaseOption {
+	return func(m makeReleaseAndVerifyOptions) makeReleaseAndVerifyOptions {
+		m.args = append(m.args, arg)
+		return m
+	}
+}
+
+// WithMakeReleaseOptionExecFn changes the exec function of the given execFn.
+func WithMakeReleaseOptionExecFn(r ExecFn) MakeReleaseOption {
+	return func(m makeReleaseAndVerifyOptions) makeReleaseAndVerifyOptions {
+		m.execFn = r
+		return m
+	}
+}
+
+// MakeRelease makes the release binary.
+func MakeRelease(b SupportedTarget, pkgDir string, opts ...MakeReleaseOption) error {
+	params := makeReleaseAndVerifyOptions{
+		execFn: DefaultExecFn,
+	}
+	for _, opt := range opts {
+		params = opt(params)
+	}
+
+	{
+		args := append([]string{b.BuildType}, params.args...)
+		cmd := exec.Command("mkrelease", args...)
+		cmd.Dir = pkgDir
+		cmd.Stderr = os.Stderr
+		log.Printf("%s %s", cmd.Env, cmd.Args)
+		if out, err := params.execFn(cmd); err != nil {
+			return errors.Newf("%s %s: %s\n\n%s", cmd.Env, cmd.Args, err, out)
+		}
+	}
+	if strings.Contains(b.BuildType, "linux") {
+		binaryName := "./cockroach" + b.Suffix
+
+		cmd := exec.Command(binaryName, "version")
+		cmd.Dir = pkgDir
+		cmd.Env = append(cmd.Env, "MALLOC_CONF=prof:true")
+		cmd.Stderr = os.Stderr
+		log.Printf("%s %s", cmd.Env, cmd.Args)
+		if out, err := params.execFn(cmd); err != nil {
+			return errors.Newf("%s %s: %s\n\n%s", cmd.Env, cmd.Args, err, out)
+		}
+
+		cmd = exec.Command("ldd", binaryName)
+		cmd.Dir = pkgDir
+		log.Printf("%s %s", cmd.Env, cmd.Args)
+		out, err := params.execFn(cmd)
+		if err != nil {
+			log.Fatalf("%s: out=%q err=%s", cmd.Args, out, err)
+		}
+		scanner := bufio.NewScanner(bytes.NewReader(out))
+		for scanner.Scan() {
+			if line := scanner.Text(); !linuxStaticLibsRe.MatchString(line) {
+				return errors.Newf("%s is not properly statically linked:\n%s", binaryName, out)
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1290,7 +1290,7 @@ func TestLint(t *testing.T) {
 			stream.GrepNot(`cockroach/pkg/testutils/lint: log$`),
 			stream.GrepNot(`cockroach/pkg/util/sysutil: syscall$`),
 			stream.GrepNot(`cockroach/pkg/util/log: github\.com/pkg/errors$`),
-			stream.GrepNot(`cockroach/pkg/(base|security|util/(log|randutil|stop)): log$`),
+			stream.GrepNot(`cockroach/pkg/(base|release|security|util/(log|randutil|stop)): log$`),
 			stream.GrepNot(`cockroach/pkg/(server/serverpb|ts/tspb): github\.com/golang/protobuf/proto$`),
 
 			stream.GrepNot(`cockroach/pkg/util/uuid: github\.com/satori/go\.uuid$`),


### PR DESCRIPTION
Abstract away the process of building from
`./pkg/cmd/publish-*-artifacts`, and use this in
`./pkg/cmd/compile-builds`. This is intended to become a CI job for
TeamCity.

Build: https://teamcity.cockroachdb.com/admin/editBuild.html?id=buildType:Cockroach_UnitTests_CompileBuilds

Release note: None

