### PR TITLE
sql: test for consistency among key/value encoding functions

### DIFF
--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1344,7 +1344,7 @@ func MustBeValueEncoded(semanticType *types.T) bool {
 		default:
 			return MustBeValueEncoded(semanticType.ArrayContents())
 		}
-	case types.JsonFamily, types.TupleFamily, types.GeographyFamily, types.GeometryFamily:
+	case types.JsonFamily, types.TupleFamily:
 		return true
 	}
 	return false


### PR DESCRIPTION
EncodeTableKey, DecodeTableKey, and MustBeValueEncoded previously did
not agree on which types must be key encoded. Add a test that verifies
this. There is an unfortunate carve-out for tuples due to the hash row
container needing them to be key-encodable, even though they don't have
a decoding and we aren't sure their encoding is correct.

See #49975.

Release note: None