### PR TITLE
release-20.1: sql,sqlbase: use system table cache in LookupPublicTableID

### DIFF
--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -290,7 +290,9 @@ func allocateTableRewrites(
 				}
 				// Check that the table name is _not_ in use.
 				// This would fail the CPut later anyway, but this yields a prettier error.
-				if err := CheckTableExists(ctx, txn, parentID, table.Name); err != nil {
+				if err := CheckTableExists(
+					ctx, p.ExecCfg().Settings, txn, parentID, table.Name,
+				); err != nil {
 					return err
 				}
 

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -608,8 +609,10 @@ func lookupDatabaseID(ctx context.Context, txn *kv.Txn, name string) (sqlbase.ID
 
 // CheckTableExists returns an error if a table already exists with given
 // parent and name.
-func CheckTableExists(ctx context.Context, txn *kv.Txn, parentID sqlbase.ID, name string) error {
-	found, _, err := sqlbase.LookupPublicTableID(ctx, txn, parentID, name)
+func CheckTableExists(
+	ctx context.Context, settings *cluster.Settings, txn *kv.Txn, parentID sqlbase.ID, name string,
+) error {
+	found, _, err := sqlbase.LookupPublicTableID(ctx, settings, txn, parentID, name)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -852,7 +852,9 @@ func prepareNewTableDescsForIngestion(
 ) ([]*sqlbase.TableDescriptor, error) {
 	var tableDescs []*sqlbase.TableDescriptor
 	for _, i := range tables {
-		if err := backupccl.CheckTableExists(ctx, txn, parentID, i.Desc.Name); err != nil {
+		if err := backupccl.CheckTableExists(
+			ctx, p.ExecCfg().Settings, txn, parentID, i.Desc.Name,
+		); err != nil {
 			return nil, err
 		}
 		tableDescs = append(tableDescs, i.Desc)

--- a/pkg/sql/logictest/testdata/logic_test/namespace_migration
+++ b/pkg/sql/logictest/testdata/logic_test/namespace_migration
@@ -10,3 +10,11 @@ parentID name id
 
 statement ok
 SELECT * FROM crdb_internal.zones
+
+# The below code reproduces a bug which led to the data distribution admin ui
+# page not rendering. The code for `SHOW ZONE CONFIGURATION` for a specific
+# entity is distinct from showing all of them.
+# See issue https://github.com/cockroachdb/cockroach/issues/49882
+
+statement ok
+SHOW ZONE CONFIGURATION FOR TABLE system.namespace2

--- a/pkg/sql/logictest/testdata/logic_test/system_namespace_deprecated
+++ b/pkg/sql/logictest/testdata/logic_test/system_namespace_deprecated
@@ -17,7 +17,6 @@ SELECT * FROM system.namespace
 1  lease                            11
 1  locations                        21
 1  namespace                        2
-1  namespace2                       30
 1  protected_ts_meta                31
 1  protected_ts_records             32
 1  rangelog                         13

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -145,7 +145,7 @@ func (n *renameTableNode) startExec(params runParams) error {
 	}
 
 	exists, _, err := sqlbase.LookupPublicTableID(
-		params.ctx, params.p.txn, targetDbDesc.ID, newTn.Table(),
+		params.ctx, p.execCfg.Settings, params.p.txn, targetDbDesc.ID, newTn.Table(),
 	)
 	if err == nil && exists {
 		return sqlbase.NewRelationAlreadyExistsError(newTn.Table())

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -358,7 +358,7 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 		// resolveZone determines the ID of the target object of the zone
 		// specifier. This ought to succeed regardless of whether there is
 		// already a zone config for the target object.
-		targetID, err := resolveZone(params.ctx, params.p.txn, &zs)
+		targetID, err := resolveZone(params.ctx, params.ExecCfg().Settings, params.p.txn, &zs)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/show_zone_config.go
+++ b/pkg/sql/show_zone_config.go
@@ -113,7 +113,7 @@ func getShowZoneConfigRow(
 		}
 	}
 
-	targetID, err := resolveZone(ctx, p.txn, &zoneSpecifier)
+	targetID, err := resolveZone(ctx, p.execCfg.Settings, p.txn, &zoneSpecifier)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -259,11 +260,13 @@ func (p *planner) resolveTableForZone(
 // specifier points to a table, index or partition, the table part
 // must be properly normalized already. It is the caller's
 // responsibility to do this using e.g .resolveTableForZone().
-func resolveZone(ctx context.Context, txn *kv.Txn, zs *tree.ZoneSpecifier) (sqlbase.ID, error) {
+func resolveZone(
+	ctx context.Context, settings *cluster.Settings, txn *kv.Txn, zs *tree.ZoneSpecifier,
+) (sqlbase.ID, error) {
 	errMissingKey := errors.New("missing key")
 	id, err := zonepb.ResolveZoneSpecifier(zs,
 		func(parentID uint32, name string) (uint32, error) {
-			found, id, err := sqlbase.LookupPublicTableID(ctx, txn, sqlbase.ID(parentID), name)
+			found, id, err := sqlbase.LookupPublicTableID(ctx, settings, txn, sqlbase.ID(parentID), name)
 			if err != nil {
 				return 0, err
 			}


### PR DESCRIPTION
The function `sqlbase.LookupPublicTableID()` is only really utilized for
looking up zone configs and in rename. Normally we map names to descriptor
IDs through the `UncachedPhysicalAccessor` which always checks the system
table cache before consulting the kv. That check is super important to
support the migration of `namespace` to support schemas. In particular,
the new `namespace` table internally happens to be called `namespace2`.
We cache that name in our system cache but we don't store that in the
deprecated namespace table.

Interestingly, and perhaps unintentionally, we store `namespace2` in
the namespace table (both the new and the old) when we bootstrap 20.1
clusters, thus they'll have the entry. In 19.2 cluster which get upgraded
however, we don't have a `namespace2` entry in the old namespace table
and we won't add it to the new one. This is an important thing to keep
in mind as we think towards later versions. Anyway, this usually didn't
matter because we usually don't try to lookup either `system.namespace`
or `system.namespace2` because of this in-memory cache of system tables
we tend to utilize.

Release note (bug fix): Fixes a bug which breaks the data distribution page
in the admin ui on cluster upgraded from 19.2 to 20.1.

Fixes #49882.