### PR TITLE
opt: add rules to reorder InnerJoin and LeftJoin under Limit

### DIFF
--- a/pkg/sql/opt/norm/rules/limit.opt
+++ b/pkg/sql/opt/norm/rules/limit.opt
@@ -221,3 +221,119 @@ $input
 )
 =>
 (Limit $innerInput $outerLimitExpr $innerOrdering)
+
+# AssociateLimitJoinsLeft reorders an InnerJoin and LeftJoin under a Limit if:
+# 1. The InnerJoin does not preserve rows from its left input.
+# 2. The InnerJoin's ON condition does not reference the right side of the
+#    LeftJoin (because the reordering would be invalid).
+# 3. Neither join has join hints.
+#
+# Why condition #1? If the InnerJoin preserves left rows, the limit can already
+# be pushed down into the LeftJoin, so there's no need to reorder the joins.
+#
+# Here's the transformation:
+#
+#   SELECT *
+#   FROM (SELECT * FROM xy LEFT JOIN uv ON u = x)
+#   INNER JOIN ab
+#   ON a = y
+#   LIMIT 10
+# =>
+#   SELECT *
+#   FROM (SELECT * FROM xy INNER JOIN ab ON a = y)
+#   LEFT JOIN uv
+#   ON u = x
+#   LIMIT 10
+#
+# Citations: [1] (See identity (6) in section 2.2)
+[AssociateLimitJoinsLeft, Normalize, LowPriority]
+(Limit
+    $limitInput:(InnerJoin
+            $outsideLeft:(LeftJoin
+                $insideLeft:*
+                $insideRight:*
+                $insideOn:*
+                $insidePrivate:* & (NoJoinHints $insidePrivate)
+            )
+            $outsideRight:*
+            $outsideOn:* &
+                ^(ColsIntersect
+                    (FilterOuterCols $outsideOn)
+                    (OutputCols $insideRight)
+                )
+            $outsidePrivate:* & (NoJoinHints $outsidePrivate)
+        ) &
+        ^(JoinPreservesLeftRows $limitInput)
+    $limitValue:*
+    $limitOrdering:*
+)
+=>
+(Limit
+    (LeftJoin
+        (InnerJoin
+            $insideLeft
+            $outsideRight
+            $outsideOn
+            (EmptyJoinPrivate)
+        )
+        $insideRight
+        $insideOn
+        (EmptyJoinPrivate)
+    )
+    $limitValue
+    $limitOrdering
+)
+
+# AssociateLimitJoinsRight mirrors AssociateLimitJoinsLeft (it matches when the
+# LeftJoin is the right input of the InnerJoin, as opposed to the left input).
+# Here's the transformation:
+#
+#   SELECT *
+#   FROM ab
+#   INNER JOIN (SELECT * FROM xy LEFT JOIN uv ON u = x)
+#   ON a = y
+#   LIMIT 10
+# =>
+#   SELECT *
+#   FROM (SELECT * FROM xy INNER JOIN ab ON a = y)
+#   LEFT JOIN uv
+#   ON u = x
+#   LIMIT 10
+#
+[AssociateLimitJoinsRight, Normalize, LowPriority]
+(Limit
+    $limitInput:(InnerJoin
+            $outsideLeft:*
+            $outsideRight:(LeftJoin
+                $insideLeft:*
+                $insideRight:*
+                $insideOn:*
+                $insidePrivate:* & (NoJoinHints $insidePrivate)
+            )
+            $outsideOn:* &
+                ^(ColsIntersect
+                    (FilterOuterCols $outsideOn)
+                    (OutputCols $insideRight)
+                )
+            $outsidePrivate:* & (NoJoinHints $outsidePrivate)
+        ) &
+        ^(JoinPreservesRightRows $limitInput)
+    $limitValue:*
+    $limitOrdering:*
+)
+=>
+(Limit
+    (LeftJoin
+        (InnerJoin
+            $insideLeft
+            $outsideLeft
+            $outsideOn
+            (EmptyJoinPrivate)
+        )
+        $insideRight
+        $insideOn
+        (EmptyJoinPrivate)
+    )
+    $limitValue
+    $limitOrdering
+)

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -1358,3 +1358,109 @@ limit
  │         │         └── fd: (1)-->(2-5)
  │         └── 10
  └── 5
+
+# ----------------------------------------------------
+# AssociateLimitJoinsLeft and AssociateLimitJoinsRight
+# ----------------------------------------------------
+
+norm expect=AssociateLimitJoinsLeft format=hide-all
+SELECT *
+FROM (SELECT * FROM b LEFT JOIN uv ON x = u)
+INNER JOIN ab
+ON a = y
+LIMIT 10
+----
+left-join (hash)
+ ├── limit
+ │    ├── inner-join (hash)
+ │    │    ├── scan b
+ │    │    ├── scan ab
+ │    │    └── filters
+ │    │         └── a = y
+ │    └── 10
+ ├── scan uv
+ └── filters
+      └── x = u
+
+norm expect=AssociateLimitJoinsRight format=hide-all
+SELECT *
+FROM ab
+INNER JOIN (SELECT * FROM b LEFT JOIN uv ON x = u)
+ON a = y
+LIMIT 10
+----
+left-join (hash)
+ ├── limit
+ │    ├── inner-join (hash)
+ │    │    ├── scan b
+ │    │    ├── scan ab
+ │    │    └── filters
+ │    │         └── a = y
+ │    └── 10
+ ├── scan uv
+ └── filters
+      └── x = u
+
+norm expect=AssociateLimitJoinsRight format=hide-all
+SELECT *
+FROM kvr_fk
+INNER JOIN (SELECT * FROM uv LEFT JOIN ab ON v = b)
+ON r = u
+LIMIT 10
+----
+limit
+ ├── left-join (hash)
+ │    ├── inner-join (hash)
+ │    │    ├── scan uv
+ │    │    ├── limit
+ │    │    │    ├── scan kvr_fk
+ │    │    │    └── 10
+ │    │    └── filters
+ │    │         └── r = u
+ │    ├── scan ab
+ │    └── filters
+ │         └── uv.v = b
+ └── 10
+
+# No-op case because the InnerJoin filter references columns from the right side
+# of the LeftJoin.
+norm expect-not=(AssociateLimitJoinsLeft,AssociateLimitJoinsRight) format=hide-all
+SELECT *
+FROM (SELECT * FROM b LEFT JOIN uv ON x = u)
+INNER JOIN ab
+ON a = y AND b = v
+LIMIT 10
+----
+limit
+ ├── inner-join (hash)
+ │    ├── left-join (hash)
+ │    │    ├── scan b
+ │    │    ├── scan uv
+ │    │    └── filters
+ │    │         └── x = u
+ │    ├── scan ab
+ │    └── filters
+ │         ├── a = y
+ │         └── b = v
+ └── 10
+
+# No-op case because one of the joins has a join hint.
+norm expect-not=(AssociateLimitJoinsLeft,AssociateLimitJoinsRight) format=hide-all
+SELECT *
+FROM (SELECT * FROM b LEFT JOIN uv ON x = u)
+INNER MERGE JOIN ab
+ON a = y
+LIMIT 10
+----
+limit
+ ├── inner-join (hash)
+ │    ├── flags: force merge join
+ │    ├── left-join (hash)
+ │    │    ├── scan b
+ │    │    ├── scan uv
+ │    │    └── filters
+ │    │         └── x = u
+ │    ├── scan ab
+ │    └── filters
+ │         └── a = y
+ └── 10


### PR DESCRIPTION
This patch adds two rules that reorder an InnerJoin and a LeftJoin
under a Limit when the InnerJoin does not preserve rows from either
of its inputs. This allows the limit to be pushed through the
LeftJoin by limit push-down rules. As an example:
```
SELECT *
FROM (SELECT * FROM xy LEFT JOIN uv ON x = u)
INNER JOIN ab
ON a = y
LIMIT 10
=>
SELECT *
FROM (SELECT * FROM xy INNER JOIN ab ON a = y LIMIT 10)
LEFT JOIN uv
ON x = u
LIMIT 10
```

Fixes #49884

Release note: None