### PR TITLE
opt: allow cardinality to use JoinMultiplicity

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -28,6 +28,7 @@ RETURNING *
 ----
 project
  ├── columns: a:1(int!null) b:2(int) c:3(int)
+ ├── cardinality: [0 - 1]
  ├── volatile, side-effects, mutations
  ├── prune: (1-3)
  └── upsert abc
@@ -48,9 +49,11 @@ project
       │    ├── upsert_b:18 => b:2
       │    ├── upsert_c:19 => c:3
       │    └── upsert_rowid:20 => rowid:4
+      ├── cardinality: [0 - 1]
       ├── volatile, side-effects, mutations
       └── project
            ├── columns: upsert_a:17(int!null) upsert_b:18(int) upsert_c:19(int) upsert_rowid:20(int) x:5(int!null) y:6(int!null) column8:8(int) column9:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int) a_new:14(int!null) b_new:15(int) column16:16(int)
+           ├── cardinality: [0 - 1]
            ├── volatile, side-effects
            ├── key: (13)
            ├── fd: ()-->(5,6,8,9,14), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13), (12)-->(15), (15)-->(16), (13)-->(17), (13,15)-->(18), (13,16)-->(19), (13)-->(20)
@@ -59,6 +62,7 @@ project
            ├── interesting orderings: (+13) (+10) (+11,+12,+13)
            ├── project
            │    ├── columns: column16:16(int) x:5(int!null) y:6(int!null) column8:8(int) column9:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int) a_new:14(int!null) b_new:15(int)
+           │    ├── cardinality: [0 - 1]
            │    ├── volatile, side-effects
            │    ├── key: (13)
            │    ├── fd: ()-->(5,6,8,9,14), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13), (12)-->(15), (15)-->(16)
@@ -67,6 +71,7 @@ project
            │    ├── interesting orderings: (+13) (+10) (+11,+12,+13)
            │    ├── project
            │    │    ├── columns: a_new:14(int!null) b_new:15(int) x:5(int!null) y:6(int!null) column8:8(int) column9:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int)
+           │    │    ├── cardinality: [0 - 1]
            │    │    ├── volatile, side-effects
            │    │    ├── key: (13)
            │    │    ├── fd: ()-->(5,6,8,9,14), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13), (12)-->(15)
@@ -75,6 +80,7 @@ project
            │    │    ├── interesting orderings: (+13) (+10) (+11,+12,+13)
            │    │    ├── left-join (hash)
            │    │    │    ├── columns: x:5(int!null) y:6(int!null) column8:8(int) column9:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int)
+           │    │    │    ├── cardinality: [0 - 1]
            │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
            │    │    │    ├── volatile, side-effects
            │    │    │    ├── key: (13)
@@ -432,7 +438,7 @@ UPSERT INTO abc (a) VALUES (1), (2) RETURNING b+c
 ----
 project
  ├── columns: "?column?":17(int)
- ├── cardinality: [1 - ]
+ ├── cardinality: [1 - 2]
  ├── volatile, side-effects, mutations
  ├── prune: (17)
  ├── upsert abc
@@ -452,11 +458,11 @@ project
  │    │    ├── upsert_b:14 => b:2
  │    │    ├── upsert_c:15 => c:3
  │    │    └── upsert_rowid:16 => rowid:4
- │    ├── cardinality: [1 - ]
+ │    ├── cardinality: [1 - 2]
  │    ├── volatile, side-effects, mutations
  │    └── project
  │         ├── columns: upsert_b:14(int) upsert_c:15(int) upsert_rowid:16(int) column1:5(int!null) column6:6(int!null) column7:7(int) column8:8(int!null) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int)
- │         ├── cardinality: [1 - ]
+ │         ├── cardinality: [1 - 2]
  │         ├── volatile, side-effects
  │         ├── lax-key: (7,12)
  │         ├── fd: ()-->(6,8), (7)~~>(5), (12)-->(9-11), (9)-->(10-12), (10,11)~~>(9,12), (10)-->(13), (10,12)-->(14), (12,13)-->(15), (7,12)-->(16)
@@ -465,7 +471,7 @@ project
  │         ├── interesting orderings: (+12) (+9) (+10,+11,+12)
  │         ├── project
  │         │    ├── columns: column13:13(int) column1:5(int!null) column6:6(int!null) column7:7(int) column8:8(int!null) a:9(int) b:10(int) c:11(int) rowid:12(int)
- │         │    ├── cardinality: [1 - ]
+ │         │    ├── cardinality: [1 - 2]
  │         │    ├── volatile, side-effects
  │         │    ├── lax-key: (7,12)
  │         │    ├── fd: ()-->(6,8), (7)~~>(5), (12)-->(9-11), (9)-->(10-12), (10,11)~~>(9,12), (10)-->(13)
@@ -474,7 +480,7 @@ project
  │         │    ├── interesting orderings: (+12) (+9) (+10,+11,+12)
  │         │    ├── left-join (hash)
  │         │    │    ├── columns: column1:5(int!null) column6:6(int!null) column7:7(int) column8:8(int!null) a:9(int) b:10(int) c:11(int) rowid:12(int)
- │         │    │    ├── cardinality: [1 - ]
+ │         │    │    ├── cardinality: [1 - 2]
  │         │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
  │         │    │    ├── volatile, side-effects
  │         │    │    ├── lax-key: (7,12)

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -102,20 +102,20 @@ upsert xy
  ├── return-mapping:
  │    ├── upsert_x:9 => x:1
  │    └── upsert_y:10 => y:2
- ├── cardinality: [2 - ]
+ ├── cardinality: [2 - 2]
  ├── volatile, side-effects, mutations
  └── project
       ├── columns: upsert_x:9 upsert_y:10 column1:3!null column2:4!null x:5 y:6
-      ├── cardinality: [2 - ]
+      ├── cardinality: [2 - 2]
       ├── fd: (5)-->(6)
       ├── left-join (hash)
       │    ├── columns: column1:3!null column2:4!null x:5 y:6 u:7 v:8
-      │    ├── cardinality: [2 - ]
+      │    ├── cardinality: [2 - 2]
       │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
       │    ├── fd: (5)-->(6), (7)-->(8)
       │    ├── left-join (hash)
       │    │    ├── columns: column1:3!null column2:4!null x:5 y:6
-      │    │    ├── cardinality: [2 - ]
+      │    │    ├── cardinality: [2 - 2]
       │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
       │    │    ├── fd: (5)-->(6)
       │    │    ├── values
@@ -362,13 +362,16 @@ FROM
 ----
 project
  ├── columns: x:1!null row_number:7 i:3
+ ├── cardinality: [0 - 3]
  ├── fd: (1)-->(3)
  └── window partition=(8)
       ├── columns: column1:1!null k:2!null i:3 row_number:7 rownum:8!null
+      ├── cardinality: [0 - 3]
       ├── key: (8)
       ├── fd: (8)-->(1), (2)-->(3), (1)==(2), (2)==(1)
       ├── inner-join (hash)
       │    ├── columns: column1:1!null k:2!null i:3 rownum:8!null
+      │    ├── cardinality: [0 - 3]
       │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
       │    ├── key: (8)
       │    ├── fd: (8)-->(1), (2)-->(3), (1)==(2), (2)==(1)
@@ -444,17 +447,21 @@ FROM
 ----
 project
  ├── columns: x:1!null row_number:7 i:3
+ ├── cardinality: [0 - 3]
  ├── fd: (1)-->(3)
  └── window partition=(9)
       ├── columns: column1:1!null i:3 row_number:7 rownum:9!null
+      ├── cardinality: [0 - 3]
       ├── key: (9)
       ├── fd: (9)-->(1), (1)-->(3)
       ├── project
       │    ├── columns: column1:1!null i:3 rownum:9!null
+      │    ├── cardinality: [0 - 3]
       │    ├── key: (9)
       │    ├── fd: (9)-->(1), (1)-->(3)
       │    └── inner-join (hash)
       │         ├── columns: column1:1!null k:2!null i:3 rownum:9!null
+      │         ├── cardinality: [0 - 3]
       │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
       │         ├── key: (9)
       │         ├── fd: (9)-->(1), (2)-->(3), (1)==(2), (2)==(1)
@@ -487,17 +494,21 @@ FROM
 ----
 project
  ├── columns: x:1!null y:2!null row_number:8 i:4
+ ├── cardinality: [0 - 3]
  ├── fd: (1)-->(4)
  └── window partition=(11)
       ├── columns: column1:1!null column2:2!null i:4 row_number:8 rownum:11!null
+      ├── cardinality: [0 - 3]
       ├── key: (11)
       ├── fd: (11)-->(1,2), (1)-->(4)
       ├── project
       │    ├── columns: column1:1!null column2:2!null i:4 rownum:11!null
+      │    ├── cardinality: [0 - 3]
       │    ├── key: (11)
       │    ├── fd: (11)-->(1,2), (1)-->(4)
       │    └── inner-join (hash)
       │         ├── columns: column1:1!null column2:2!null k:3!null i:4 rownum:11!null
+      │         ├── cardinality: [0 - 3]
       │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
       │         ├── key: (11)
       │         ├── fd: (11)-->(1,2), (3)-->(4), (1)==(3), (3)==(1)

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -1932,13 +1932,15 @@ WHERE x > 100 OR b > 100
 ----
 project
  ├── columns: x:1!null y:2!null z:3!null a:4 b:5 c:6 "?column?":7!null
+ ├── cardinality: [0 - 2]
  ├── immutable
  ├── fd: (1)-->(7)
  ├── select
  │    ├── columns: column1:1!null column2:2!null column3:3!null a:4 b:5 c:6
+ │    ├── cardinality: [0 - 2]
  │    ├── left-join (hash)
  │    │    ├── columns: column1:1!null column2:2!null column3:3!null a:4 b:5 c:6
- │    │    ├── cardinality: [2 - ]
+ │    │    ├── cardinality: [2 - 2]
  │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
  │    │    ├── values
  │    │    │    ├── columns: column1:1!null column2:2!null column3:3!null
@@ -2206,13 +2208,15 @@ insert a
  ├── volatile, side-effects, mutations
  └── project
       ├── columns: column1:6!null column2:7 column3:8 column9:9 column10:10
+      ├── cardinality: [0 - 2]
       ├── fd: ()-->(9,10)
       └── select
            ├── columns: column1:6!null column2:7 column3:8 column9:9 column10:10 i:12 s:14
+           ├── cardinality: [0 - 2]
            ├── fd: ()-->(9,10,14)
            ├── left-join (hash)
            │    ├── columns: column1:6!null column2:7 column3:8 column9:9 column10:10 i:12 s:14
-           │    ├── cardinality: [2 - ]
+           │    ├── cardinality: [2 - 2]
            │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
            │    ├── fd: ()-->(9,10)
            │    ├── project
@@ -2257,11 +2261,11 @@ upsert a
  ├── volatile, side-effects, mutations
  └── project
       ├── columns: upsert_f:19 column1:6!null column2:7 column3:8 column9:9 column10:10 k:11 i:12 f:13 s:14 j:15
-      ├── cardinality: [2 - ]
+      ├── cardinality: [2 - 2]
       ├── fd: ()-->(9,10), (11)-->(12-15), (12,14)-->(11,13,15), (12,13)~~>(11,14,15)
       ├── left-join (hash)
       │    ├── columns: column1:6!null column2:7 column3:8 column9:9 column10:10 k:11 i:12 f:13 s:14 j:15
-      │    ├── cardinality: [2 - ]
+      │    ├── cardinality: [2 - 2]
       │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
       │    ├── fd: ()-->(9,10), (11)-->(12-15), (12,14)-->(11,13,15), (12,13)~~>(11,14,15)
       │    ├── project
@@ -2307,12 +2311,12 @@ upsert a
  ├── volatile, side-effects, mutations
  └── project
       ├── columns: upsert_f:19 column1:6!null column2:7!null column3:8!null column9:9 column10:10 k:11 i:12 f:13 s:14 j:15
-      ├── cardinality: [1 - ]
+      ├── cardinality: [1 - 3]
       ├── key: (7,8)
       ├── fd: ()-->(9,10), (7,8)-->(6,11-15,19), (11)-->(12-15), (12,14)-->(11,13,15), (12,13)~~>(11,14,15)
       ├── left-join (hash)
       │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10 k:11 i:12 f:13 s:14 j:15
-      │    ├── cardinality: [1 - ]
+      │    ├── cardinality: [1 - 3]
       │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
       │    ├── key: (7,8)
       │    ├── fd: ()-->(9,10), (7,8)-->(6,11-15), (11)-->(12-15), (12,14)-->(11,13,15), (12,13)~~>(11,14,15)
@@ -2370,27 +2374,33 @@ insert a
  ├── volatile, side-effects, mutations
  └── project
       ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null column10:10
+      ├── cardinality: [0 - 3]
       ├── fd: ()-->(10)
       └── select
            ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null column10:10 k:11 i:17 s:19 i:22 f:23
+           ├── cardinality: [0 - 3]
            ├── fd: ()-->(10,11,19,22)
            ├── left-join (hash)
            │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null column10:10 k:11 i:17 s:19 i:22 f:23
+           │    ├── cardinality: [0 - 3]
            │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
            │    ├── fd: ()-->(10,11,19)
            │    ├── select
            │    │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null column10:10 k:11 i:17 s:19
+           │    │    ├── cardinality: [0 - 3]
            │    │    ├── fd: ()-->(10,11,19)
            │    │    ├── left-join (hash)
            │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null column10:10 k:11 i:17 s:19
+           │    │    │    ├── cardinality: [0 - 3]
            │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
            │    │    │    ├── fd: ()-->(10,11)
            │    │    │    ├── select
            │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null column10:10 k:11
+           │    │    │    │    ├── cardinality: [0 - 3]
            │    │    │    │    ├── fd: ()-->(10,11)
            │    │    │    │    ├── left-join (hash)
            │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column4:9!null column10:10 k:11
-           │    │    │    │    │    ├── cardinality: [3 - ]
+           │    │    │    │    │    ├── cardinality: [3 - 3]
            │    │    │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
            │    │    │    │    │    ├── fd: ()-->(10)
            │    │    │    │    │    ├── project
@@ -2448,35 +2458,42 @@ insert a
  └── upsert-distinct-on
       ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10
       ├── grouping columns: column3:8!null column9:9
+      ├── cardinality: [0 - 3]
       ├── lax-key: (8,9)
       ├── fd: ()-->(9,10), (7,9)~~>(6,8), (8,9)~~>(6,7,10)
       ├── select
       │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10 i:22 f:23
+      │    ├── cardinality: [0 - 3]
       │    ├── lax-key: (7,9,22,23)
       │    ├── fd: ()-->(9,10,22), (7,9)~~>(6,8)
       │    ├── left-join (hash)
       │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10 i:22 f:23
+      │    │    ├── cardinality: [0 - 3]
       │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
       │    │    ├── lax-key: (7,9,22,23)
       │    │    ├── fd: ()-->(9,10), (7,9)~~>(6,8)
       │    │    ├── upsert-distinct-on
       │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10
       │    │    │    ├── grouping columns: column2:7!null column9:9
+      │    │    │    ├── cardinality: [0 - 3]
       │    │    │    ├── lax-key: (7,9)
       │    │    │    ├── fd: ()-->(9,10), (7,9)~~>(6,8,10)
       │    │    │    ├── select
       │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10 k:11 i:17 s:19
+      │    │    │    │    ├── cardinality: [0 - 3]
       │    │    │    │    ├── fd: ()-->(9-11,19)
       │    │    │    │    ├── left-join (hash)
       │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10 k:11 i:17 s:19
+      │    │    │    │    │    ├── cardinality: [0 - 3]
       │    │    │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
       │    │    │    │    │    ├── fd: ()-->(9-11)
       │    │    │    │    │    ├── select
       │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10 k:11
+      │    │    │    │    │    │    ├── cardinality: [0 - 3]
       │    │    │    │    │    │    ├── fd: ()-->(9-11)
       │    │    │    │    │    │    ├── left-join (hash)
       │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 column10:10 k:11
-      │    │    │    │    │    │    │    ├── cardinality: [3 - ]
+      │    │    │    │    │    │    │    ├── cardinality: [3 - 3]
       │    │    │    │    │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
       │    │    │    │    │    │    │    ├── fd: ()-->(9,10)
       │    │    │    │    │    │    │    ├── project
@@ -2549,26 +2566,31 @@ insert a
  ├── volatile, side-effects, mutations
  └── project
       ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10
+      ├── cardinality: [0 - 2]
       ├── volatile, side-effects
       ├── fd: ()-->(10), (6)~~>(7-9)
       └── select
            ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 i:17 s:19 i:22 f:23
+           ├── cardinality: [0 - 2]
            ├── volatile, side-effects
            ├── lax-key: (6,17,19,22,23)
            ├── fd: ()-->(10,19,22), (6)~~>(7-9)
            ├── left-join (hash)
            │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 i:17 s:19 i:22 f:23
+           │    ├── cardinality: [0 - 2]
            │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
            │    ├── volatile, side-effects
            │    ├── lax-key: (6,17,19,22,23)
            │    ├── fd: ()-->(10,19), (6)~~>(7-9)
            │    ├── select
            │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 i:17 s:19
+           │    │    ├── cardinality: [0 - 2]
            │    │    ├── volatile, side-effects
            │    │    ├── lax-key: (6,17,19)
            │    │    ├── fd: ()-->(10,19), (6)~~>(7-9)
            │    │    ├── left-join (hash)
            │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 i:17 s:19
+           │    │    │    ├── cardinality: [0 - 2]
            │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
            │    │    │    ├── volatile, side-effects
            │    │    │    ├── lax-key: (6,17,19)
@@ -2576,16 +2598,18 @@ insert a
            │    │    │    ├── upsert-distinct-on
            │    │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10
            │    │    │    │    ├── grouping columns: column1:6
+           │    │    │    │    ├── cardinality: [0 - 2]
            │    │    │    │    ├── volatile, side-effects
            │    │    │    │    ├── lax-key: (6)
            │    │    │    │    ├── fd: ()-->(10), (6)~~>(7-10)
            │    │    │    │    ├── select
            │    │    │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 k:11
+           │    │    │    │    │    ├── cardinality: [0 - 2]
            │    │    │    │    │    ├── volatile, side-effects
            │    │    │    │    │    ├── fd: ()-->(10,11)
            │    │    │    │    │    ├── left-join (hash)
            │    │    │    │    │    │    ├── columns: column1:6 column2:7!null column3:8!null column4:9!null column10:10 k:11
-           │    │    │    │    │    │    ├── cardinality: [2 - ]
+           │    │    │    │    │    │    ├── cardinality: [2 - 2]
            │    │    │    │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
            │    │    │    │    │    │    ├── volatile, side-effects
            │    │    │    │    │    │    ├── fd: ()-->(10)

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -741,192 +741,160 @@ limit
 norm expect=PushLimitIntoJoinLeft
 SELECT * FROM kvr_fk INNER JOIN uv ON r = u LIMIT 10
 ----
-limit
+inner-join (hash)
  ├── columns: k:1!null v:2 r:3!null u:4!null v:5
  ├── cardinality: [0 - 10]
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
  ├── key: (1)
  ├── fd: (1)-->(2,3), (4)-->(5), (3)==(4), (4)==(3)
- ├── inner-join (hash)
- │    ├── columns: k:1!null kvr_fk.v:2 r:3!null u:4!null uv.v:5
- │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ ├── limit
+ │    ├── columns: k:1!null kvr_fk.v:2 r:3!null
+ │    ├── cardinality: [0 - 10]
  │    ├── key: (1)
- │    ├── fd: (1)-->(2,3), (4)-->(5), (3)==(4), (4)==(3)
- │    ├── limit hint: 10.00
- │    ├── limit
+ │    ├── fd: (1)-->(2,3)
+ │    ├── scan kvr_fk
  │    │    ├── columns: k:1!null kvr_fk.v:2 r:3!null
- │    │    ├── cardinality: [0 - 10]
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2,3)
- │    │    ├── scan kvr_fk
- │    │    │    ├── columns: k:1!null kvr_fk.v:2 r:3!null
- │    │    │    ├── key: (1)
- │    │    │    ├── fd: (1)-->(2,3)
- │    │    │    └── limit hint: 10.00
- │    │    └── 10
- │    ├── scan uv
- │    │    ├── columns: u:4!null uv.v:5
- │    │    ├── key: (4)
- │    │    └── fd: (4)-->(5)
- │    └── filters
- │         └── r:3 = u:4 [outer=(3,4), constraints=(/3: (/NULL - ]; /4: (/NULL - ]), fd=(3)==(4), (4)==(3)]
- └── 10
+ │    │    └── limit hint: 10.00
+ │    └── 10
+ ├── scan uv
+ │    ├── columns: u:4!null uv.v:5
+ │    ├── key: (4)
+ │    └── fd: (4)-->(5)
+ └── filters
+      └── r:3 = u:4 [outer=(3,4), constraints=(/3: (/NULL - ]; /4: (/NULL - ]), fd=(3)==(4), (4)==(3)]
 
 # LeftJoin case.
 norm expect=PushLimitIntoJoinLeft
 SELECT * FROM ab LEFT JOIN uv ON a = u LIMIT 10
 ----
-limit
+left-join (hash)
  ├── columns: a:1!null b:2 u:3 v:4
  ├── cardinality: [0 - 10]
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)-->(4)
- ├── left-join (hash)
- │    ├── columns: a:1!null b:2 u:3 v:4
- │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ ├── limit
+ │    ├── columns: a:1!null b:2
+ │    ├── cardinality: [0 - 10]
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-4), (3)-->(4)
- │    ├── limit hint: 10.00
- │    ├── limit
+ │    ├── fd: (1)-->(2)
+ │    ├── scan ab
  │    │    ├── columns: a:1!null b:2
- │    │    ├── cardinality: [0 - 10]
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2)
- │    │    ├── scan ab
- │    │    │    ├── columns: a:1!null b:2
- │    │    │    ├── key: (1)
- │    │    │    ├── fd: (1)-->(2)
- │    │    │    └── limit hint: 10.00
- │    │    └── 10
- │    ├── scan uv
- │    │    ├── columns: u:3!null v:4
- │    │    ├── key: (3)
- │    │    └── fd: (3)-->(4)
- │    └── filters
- │         └── a:1 = u:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
- └── 10
+ │    │    └── limit hint: 10.00
+ │    └── 10
+ ├── scan uv
+ │    ├── columns: u:3!null v:4
+ │    ├── key: (3)
+ │    └── fd: (3)-->(4)
+ └── filters
+      └── a:1 = u:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
 
 # InnerJoin case for PushLimitIntoJoinRight.
 norm expect=PushLimitIntoJoinRight
 SELECT * FROM uv INNER JOIN kvr_fk ON u = r LIMIT 10
 ----
-limit
+inner-join (hash)
  ├── columns: u:1!null v:2 k:3!null v:4 r:5!null
  ├── cardinality: [0 - 10]
+ ├── multiplicity: left-rows(zero-or-more), right-rows(exactly-one)
  ├── key: (3)
  ├── fd: (1)-->(2), (3)-->(4,5), (1)==(5), (5)==(1)
- ├── inner-join (hash)
- │    ├── columns: u:1!null uv.v:2 k:3!null kvr_fk.v:4 r:5!null
- │    ├── multiplicity: left-rows(zero-or-more), right-rows(exactly-one)
+ ├── scan uv
+ │    ├── columns: u:1!null uv.v:2
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ ├── limit
+ │    ├── columns: k:3!null kvr_fk.v:4 r:5!null
+ │    ├── cardinality: [0 - 10]
  │    ├── key: (3)
- │    ├── fd: (1)-->(2), (3)-->(4,5), (1)==(5), (5)==(1)
- │    ├── limit hint: 10.00
- │    ├── scan uv
- │    │    ├── columns: u:1!null uv.v:2
- │    │    ├── key: (1)
- │    │    └── fd: (1)-->(2)
- │    ├── limit
+ │    ├── fd: (3)-->(4,5)
+ │    ├── scan kvr_fk
  │    │    ├── columns: k:3!null kvr_fk.v:4 r:5!null
- │    │    ├── cardinality: [0 - 10]
  │    │    ├── key: (3)
  │    │    ├── fd: (3)-->(4,5)
- │    │    ├── scan kvr_fk
- │    │    │    ├── columns: k:3!null kvr_fk.v:4 r:5!null
- │    │    │    ├── key: (3)
- │    │    │    ├── fd: (3)-->(4,5)
- │    │    │    └── limit hint: 10.00
- │    │    └── 10
- │    └── filters
- │         └── u:1 = r:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
- └── 10
+ │    │    └── limit hint: 10.00
+ │    └── 10
+ └── filters
+      └── u:1 = r:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
 
 # Ordering can be pushed down.
 norm expect=PushLimitIntoJoinLeft
 SELECT * FROM ab LEFT JOIN uv ON a = u ORDER BY a LIMIT 10
 ----
-limit
+sort
  ├── columns: a:1!null b:2 u:3 v:4
- ├── internal-ordering: +1
  ├── cardinality: [0 - 10]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)-->(4)
  ├── ordering: +1
- ├── sort
- │    ├── columns: a:1!null b:2 u:3 v:4
- │    ├── key: (1)
- │    ├── fd: (1)-->(2-4), (3)-->(4)
- │    ├── ordering: +1
- │    ├── limit hint: 10.00
- │    └── left-join (hash)
- │         ├── columns: a:1!null b:2 u:3 v:4
- │         ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
- │         ├── key: (1)
- │         ├── fd: (1)-->(2-4), (3)-->(4)
- │         ├── limit
- │         │    ├── columns: a:1!null b:2
- │         │    ├── internal-ordering: +1
- │         │    ├── cardinality: [0 - 10]
- │         │    ├── key: (1)
- │         │    ├── fd: (1)-->(2)
- │         │    ├── scan ab
- │         │    │    ├── columns: a:1!null b:2
- │         │    │    ├── key: (1)
- │         │    │    ├── fd: (1)-->(2)
- │         │    │    ├── ordering: +1
- │         │    │    └── limit hint: 10.00
- │         │    └── 10
- │         ├── scan uv
- │         │    ├── columns: u:3!null v:4
- │         │    ├── key: (3)
- │         │    └── fd: (3)-->(4)
- │         └── filters
- │              └── a:1 = u:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
- └── 10
+ └── left-join (hash)
+      ├── columns: a:1!null b:2 u:3 v:4
+      ├── cardinality: [0 - 10]
+      ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+      ├── key: (1)
+      ├── fd: (1)-->(2-4), (3)-->(4)
+      ├── limit
+      │    ├── columns: a:1!null b:2
+      │    ├── internal-ordering: +1
+      │    ├── cardinality: [0 - 10]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2)
+      │    ├── scan ab
+      │    │    ├── columns: a:1!null b:2
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2)
+      │    │    ├── ordering: +1
+      │    │    └── limit hint: 10.00
+      │    └── 10
+      ├── scan uv
+      │    ├── columns: u:3!null v:4
+      │    ├── key: (3)
+      │    └── fd: (3)-->(4)
+      └── filters
+           └── a:1 = u:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
 
 norm expect=PushLimitIntoJoinLeft
 SELECT * FROM ab LEFT JOIN uv ON a = u ORDER BY b LIMIT 10
 ----
-limit
+sort
  ├── columns: a:1!null b:2 u:3 v:4
- ├── internal-ordering: +2
  ├── cardinality: [0 - 10]
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)-->(4)
  ├── ordering: +2
- ├── sort
- │    ├── columns: a:1!null b:2 u:3 v:4
- │    ├── key: (1)
- │    ├── fd: (1)-->(2-4), (3)-->(4)
- │    ├── ordering: +2
- │    ├── limit hint: 10.00
- │    └── left-join (hash)
- │         ├── columns: a:1!null b:2 u:3 v:4
- │         ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
- │         ├── key: (1)
- │         ├── fd: (1)-->(2-4), (3)-->(4)
- │         ├── limit
- │         │    ├── columns: a:1!null b:2
- │         │    ├── internal-ordering: +2
- │         │    ├── cardinality: [0 - 10]
- │         │    ├── key: (1)
- │         │    ├── fd: (1)-->(2)
- │         │    ├── sort
- │         │    │    ├── columns: a:1!null b:2
- │         │    │    ├── key: (1)
- │         │    │    ├── fd: (1)-->(2)
- │         │    │    ├── ordering: +2
- │         │    │    ├── limit hint: 10.00
- │         │    │    └── scan ab
- │         │    │         ├── columns: a:1!null b:2
- │         │    │         ├── key: (1)
- │         │    │         └── fd: (1)-->(2)
- │         │    └── 10
- │         ├── scan uv
- │         │    ├── columns: u:3!null v:4
- │         │    ├── key: (3)
- │         │    └── fd: (3)-->(4)
- │         └── filters
- │              └── a:1 = u:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
- └── 10
+ └── left-join (hash)
+      ├── columns: a:1!null b:2 u:3 v:4
+      ├── cardinality: [0 - 10]
+      ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+      ├── key: (1)
+      ├── fd: (1)-->(2-4), (3)-->(4)
+      ├── limit
+      │    ├── columns: a:1!null b:2
+      │    ├── internal-ordering: +2
+      │    ├── cardinality: [0 - 10]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2)
+      │    ├── sort
+      │    │    ├── columns: a:1!null b:2
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2)
+      │    │    ├── ordering: +2
+      │    │    ├── limit hint: 10.00
+      │    │    └── scan ab
+      │    │         ├── columns: a:1!null b:2
+      │    │         ├── key: (1)
+      │    │         └── fd: (1)-->(2)
+      │    └── 10
+      ├── scan uv
+      │    ├── columns: u:3!null v:4
+      │    ├── key: (3)
+      │    └── fd: (3)-->(4)
+      └── filters
+           └── a:1 = u:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
 
 # Ordering on u is not equivalent to ordering on a because of NULLs; it cannot
 # be pushed down.
@@ -1068,69 +1036,57 @@ limit
 norm expect-not=PushLimitIntoJoinLeft
 SELECT * FROM (SELECT * FROM ab LIMIT 5) LEFT JOIN uv ON a = u LIMIT 10
 ----
-limit
+left-join (hash)
  ├── columns: a:1!null b:2 u:3 v:4
- ├── cardinality: [0 - 10]
+ ├── cardinality: [0 - 5]
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)-->(4)
- ├── left-join (hash)
- │    ├── columns: a:1!null b:2 u:3 v:4
- │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ ├── limit
+ │    ├── columns: a:1!null b:2
+ │    ├── cardinality: [0 - 5]
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-4), (3)-->(4)
- │    ├── limit hint: 10.00
- │    ├── limit
+ │    ├── fd: (1)-->(2)
+ │    ├── scan ab
  │    │    ├── columns: a:1!null b:2
- │    │    ├── cardinality: [0 - 5]
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2)
- │    │    ├── scan ab
- │    │    │    ├── columns: a:1!null b:2
- │    │    │    ├── key: (1)
- │    │    │    ├── fd: (1)-->(2)
- │    │    │    └── limit hint: 5.00
- │    │    └── 5
- │    ├── scan uv
- │    │    ├── columns: u:3!null v:4
- │    │    ├── key: (3)
- │    │    └── fd: (3)-->(4)
- │    └── filters
- │         └── a:1 = u:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
- └── 10
+ │    │    └── limit hint: 5.00
+ │    └── 5
+ ├── scan uv
+ │    ├── columns: u:3!null v:4
+ │    ├── key: (3)
+ │    └── fd: (3)-->(4)
+ └── filters
+      └── a:1 = u:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
 
 # Push the limit even if the input is already limited (but with a higher limit).
 norm expect=PushLimitIntoJoinLeft
 SELECT * FROM (SELECT * FROM ab LIMIT 20) LEFT JOIN uv ON a = u LIMIT 10
 ----
-limit
+left-join (hash)
  ├── columns: a:1!null b:2 u:3 v:4
  ├── cardinality: [0 - 10]
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)-->(4)
- ├── left-join (hash)
- │    ├── columns: a:1!null b:2 u:3 v:4
- │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ ├── limit
+ │    ├── columns: a:1!null b:2
+ │    ├── cardinality: [0 - 10]
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-4), (3)-->(4)
- │    ├── limit hint: 10.00
- │    ├── limit
+ │    ├── fd: (1)-->(2)
+ │    ├── scan ab
  │    │    ├── columns: a:1!null b:2
- │    │    ├── cardinality: [0 - 10]
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2)
- │    │    ├── scan ab
- │    │    │    ├── columns: a:1!null b:2
- │    │    │    ├── key: (1)
- │    │    │    ├── fd: (1)-->(2)
- │    │    │    └── limit hint: 10.00
- │    │    └── 10
- │    ├── scan uv
- │    │    ├── columns: u:3!null v:4
- │    │    ├── key: (3)
- │    │    └── fd: (3)-->(4)
- │    └── filters
- │         └── a:1 = u:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
- └── 10
+ │    │    └── limit hint: 10.00
+ │    └── 10
+ ├── scan uv
+ │    ├── columns: u:3!null v:4
+ │    ├── key: (3)
+ │    └── fd: (3)-->(4)
+ └── filters
+      └── a:1 = u:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
 
 # Don't push negative limits (or we would enter an infinite loop).
 norm expect-not=PushLimitIntoJoinLeft

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1263,7 +1263,7 @@ upsert transactiondetails
  ├── stable+volatile, side-effects, mutations
  ├── project
  │    ├── columns: upsert_dealerid:31 upsert_isbuy:32 upsert_transactiondate:33 upsert_cardid:34 sellprice:29 buyprice:30 "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15 column18:18 transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondate:23 cardid:24 quantity:25 transactiondetails.sellprice:26 transactiondetails.buyprice:27 transactiondetails.version:28
- │    ├── cardinality: [1 - ]
+ │    ├── cardinality: [1 - 2]
  │    ├── stable+volatile, side-effects
  │    ├── lax-key: (13-15,21-25)
  │    ├── fd: ()-->(11,12), (13-15)~~>(18), (21-25)-->(26-28), (21)-->(31), (21,22)-->(32), (13,21,23)-->(33), (14,21,24)-->(34), (13-15,21-25)~~>(18,29,30)
@@ -1271,7 +1271,7 @@ upsert transactiondetails
  │    │    ├── columns: "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15 column18:18 sellprice:19 buyprice:20 transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondate:23 cardid:24 quantity:25 transactiondetails.sellprice:26 transactiondetails.buyprice:27 transactiondetails.version:28
  │    │    ├── key columns: [11 12 13 14 15] = [21 22 23 24 25]
  │    │    ├── lookup columns are key
- │    │    ├── cardinality: [1 - ]
+ │    │    ├── cardinality: [1 - 2]
  │    │    ├── stable+volatile, side-effects
  │    │    ├── lax-key: (13-15,21-25)
  │    │    ├── fd: ()-->(11,12), (13-15)~~>(18-20), (21-25)-->(26-28)
@@ -1327,24 +1327,26 @@ upsert transactiondetails
       │         ├── columns: upsert_dealerid:37 upsert_isbuy:38 upsert_transactiondate:39
       │         ├── key columns: [37 38 39] = [40 41 42]
       │         ├── lookup columns are key
+      │         ├── cardinality: [0 - 2]
       │         ├── with-scan &2
       │         │    ├── columns: upsert_dealerid:37 upsert_isbuy:38 upsert_transactiondate:39
       │         │    ├── mapping:
       │         │    │    ├──  upsert_dealerid:31 => upsert_dealerid:37
       │         │    │    ├──  upsert_isbuy:32 => upsert_isbuy:38
       │         │    │    └──  upsert_transactiondate:33 => upsert_transactiondate:39
-      │         │    └── cardinality: [1 - ]
+      │         │    └── cardinality: [1 - 2]
       │         └── filters (true)
       └── f-k-checks-item: transactiondetails(cardid) -> cards(id)
            └── anti-join (lookup cards)
                 ├── columns: upsert_cardid:47
                 ├── key columns: [47] = [48]
                 ├── lookup columns are key
+                ├── cardinality: [0 - 2]
                 ├── with-scan &2
                 │    ├── columns: upsert_cardid:47
                 │    ├── mapping:
                 │    │    └──  upsert_cardid:34 => upsert_cardid:47
-                │    └── cardinality: [1 - ]
+                │    └── cardinality: [1 - 2]
                 └── filters (true)
 
 # Delete inventory detail rows to reflect card transfers.
@@ -1404,17 +1406,20 @@ update ci
       │    │    ├── fd: ()-->(15), (16)-->(17-25), (23)-->(16-22), (16)==(24), (24)==(16)
       │    │    ├── project
       │    │    │    ├── columns: "project_const_col_@26":37!null ci.dealerid:15!null ci.cardid:16!null buyprice:17!null sellprice:18!null discount:19!null desiredinventory:20!null actualinventory:21!null maxinventory:22!null ci.version:23!null c:24!null q:25!null
+      │    │    │    ├── cardinality: [0 - 2]
       │    │    │    ├── key: (16)
       │    │    │    ├── fd: ()-->(15,37), (16)-->(17-25), (23)-->(16-22), (16)==(24), (24)==(16)
       │    │    │    ├── distinct-on
       │    │    │    │    ├── columns: ci.dealerid:15!null ci.cardid:16!null buyprice:17!null sellprice:18!null discount:19!null desiredinventory:20!null actualinventory:21!null maxinventory:22!null ci.version:23!null c:24!null q:25!null
       │    │    │    │    ├── grouping columns: ci.cardid:16!null
+      │    │    │    │    ├── cardinality: [0 - 2]
       │    │    │    │    ├── key: (16)
       │    │    │    │    ├── fd: ()-->(15), (16)-->(15,17-25), (23)-->(16-22), (16)==(24), (24)==(16)
       │    │    │    │    ├── inner-join (lookup cardsinfo)
       │    │    │    │    │    ├── columns: ci.dealerid:15!null ci.cardid:16!null buyprice:17!null sellprice:18!null discount:19!null desiredinventory:20!null actualinventory:21!null maxinventory:22!null ci.version:23!null c:24!null q:25!null
       │    │    │    │    │    ├── key columns: [34 24] = [15 16]
       │    │    │    │    │    ├── lookup columns are key
+      │    │    │    │    │    ├── cardinality: [0 - 2]
       │    │    │    │    │    ├── fd: ()-->(15), (16)-->(17-23), (23)-->(16-22), (16)==(24), (24)==(16)
       │    │    │    │    │    ├── project
       │    │    │    │    │    │    ├── columns: "project_const_col_@15":34!null c:24!null q:25!null

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1272,7 +1272,7 @@ upsert transactiondetails
  ├── stable+volatile, side-effects, mutations
  ├── project
  │    ├── columns: upsert_dealerid:38 upsert_isbuy:39 upsert_transactiondate:40 upsert_cardid:41 upsert_discount:44 sellprice:35 buyprice:36 "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17 column20:20 discount:24!null transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondate:27 cardid:28 quantity:29 transactiondetails.sellprice:30 transactiondetails.buyprice:31 transactiondetails.version:32 transactiondetails.discount:33 transactiondetails.extra:34
- │    ├── cardinality: [1 - ]
+ │    ├── cardinality: [1 - 2]
  │    ├── stable+volatile, side-effects
  │    ├── lax-key: (15-17,25-29)
  │    ├── fd: ()-->(13,14,24), (15-17)~~>(20), (25-29)-->(30-34), (25)-->(38), (25,26)-->(39), (15,25,27)-->(40), (16,25,28)-->(41), (15-17,25-29)~~>(20,35,36,44)
@@ -1280,7 +1280,7 @@ upsert transactiondetails
  │    │    ├── columns: "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17 column20:20 sellprice:22 buyprice:23 discount:24!null transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondate:27 cardid:28 quantity:29 transactiondetails.sellprice:30 transactiondetails.buyprice:31 transactiondetails.version:32 transactiondetails.discount:33 transactiondetails.extra:34
  │    │    ├── key columns: [13 14 15 16 17] = [25 26 27 28 29]
  │    │    ├── lookup columns are key
- │    │    ├── cardinality: [1 - ]
+ │    │    ├── cardinality: [1 - 2]
  │    │    ├── stable+volatile, side-effects
  │    │    ├── lax-key: (15-17,25-29)
  │    │    ├── fd: ()-->(13,14,24), (15-17)~~>(20,22,23), (25-29)-->(30-34)
@@ -1340,24 +1340,26 @@ upsert transactiondetails
       │         ├── columns: upsert_dealerid:45 upsert_isbuy:46 upsert_transactiondate:47
       │         ├── key columns: [45 46 47] = [48 49 50]
       │         ├── lookup columns are key
+      │         ├── cardinality: [0 - 2]
       │         ├── with-scan &2
       │         │    ├── columns: upsert_dealerid:45 upsert_isbuy:46 upsert_transactiondate:47
       │         │    ├── mapping:
       │         │    │    ├──  upsert_dealerid:38 => upsert_dealerid:45
       │         │    │    ├──  upsert_isbuy:39 => upsert_isbuy:46
       │         │    │    └──  upsert_transactiondate:40 => upsert_transactiondate:47
-      │         │    └── cardinality: [1 - ]
+      │         │    └── cardinality: [1 - 2]
       │         └── filters (true)
       └── f-k-checks-item: transactiondetails(cardid) -> cards(id)
            └── anti-join (lookup cards)
                 ├── columns: upsert_cardid:57
                 ├── key columns: [57] = [58]
                 ├── lookup columns are key
+                ├── cardinality: [0 - 2]
                 ├── with-scan &2
                 │    ├── columns: upsert_cardid:57
                 │    ├── mapping:
                 │    │    └──  upsert_cardid:41 => upsert_cardid:57
-                │    └── cardinality: [1 - ]
+                │    └── cardinality: [1 - 2]
                 └── filters (true)
 
 # Delete inventory detail rows to reflect card transfers.
@@ -1421,17 +1423,20 @@ update ci
       │    │    ├── fd: ()-->(19), (20)-->(21-33), (27)-->(20-26,28-31), (20)==(32), (32)==(20)
       │    │    ├── project
       │    │    │    ├── columns: "project_const_col_@34":51!null ci.dealerid:19!null ci.cardid:20!null buyprice:21!null sellprice:22!null discount:23!null desiredinventory:24!null actualinventory:25!null maxinventory:26!null ci.version:27!null ci.discountbuyprice:28 notes:29 oldinventory:30 ci.extra:31 c:32!null q:33!null
+      │    │    │    ├── cardinality: [0 - 2]
       │    │    │    ├── key: (20)
       │    │    │    ├── fd: ()-->(19,51), (20)-->(21-33), (27)-->(20-26,28-31), (20)==(32), (32)==(20)
       │    │    │    ├── distinct-on
       │    │    │    │    ├── columns: ci.dealerid:19!null ci.cardid:20!null buyprice:21!null sellprice:22!null discount:23!null desiredinventory:24!null actualinventory:25!null maxinventory:26!null ci.version:27!null ci.discountbuyprice:28 notes:29 oldinventory:30 ci.extra:31 c:32!null q:33!null
       │    │    │    │    ├── grouping columns: ci.cardid:20!null
+      │    │    │    │    ├── cardinality: [0 - 2]
       │    │    │    │    ├── key: (20)
       │    │    │    │    ├── fd: ()-->(19), (20)-->(19,21-33), (27)-->(20-26,28-31), (20)==(32), (32)==(20)
       │    │    │    │    ├── inner-join (lookup cardsinfo)
       │    │    │    │    │    ├── columns: ci.dealerid:19!null ci.cardid:20!null buyprice:21!null sellprice:22!null discount:23!null desiredinventory:24!null actualinventory:25!null maxinventory:26!null ci.version:27!null ci.discountbuyprice:28 notes:29 oldinventory:30 ci.extra:31 c:32!null q:33!null
       │    │    │    │    │    ├── key columns: [48 32] = [19 20]
       │    │    │    │    │    ├── lookup columns are key
+      │    │    │    │    │    ├── cardinality: [0 - 2]
       │    │    │    │    │    ├── fd: ()-->(19), (20)-->(21-31), (27)-->(20-26,28-31), (20)==(32), (32)==(20)
       │    │    │    │    │    ├── project
       │    │    │    │    │    │    ├── columns: "project_const_col_@19":48!null c:32!null q:33!null

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1778,10 +1778,12 @@ ORDER BY b
 ----
 sort
  ├── columns: a:14!null b:15!null c:16!null
+ ├── cardinality: [0 - 2]
  ├── volatile, side-effects, mutations
  ├── ordering: +15
  └── with &1
       ├── columns: a:14!null b:15!null c:16!null
+      ├── cardinality: [0 - 2]
       ├── volatile, side-effects, mutations
       ├── upsert abc
       │    ├── columns: abc.a:1!null abc.b:2!null abc.c:3!null
@@ -1797,15 +1799,18 @@ sort
       │    │    ├── upsert_a:11 => abc.a:1
       │    │    ├── upsert_b:12 => abc.b:2
       │    │    └── upsert_c:13 => abc.c:3
+      │    ├── cardinality: [0 - 2]
       │    ├── volatile, side-effects, mutations
       │    └── project
       │         ├── columns: upsert_a:11!null upsert_b:12 upsert_c:13 x:4!null y:5!null z:6!null abc.a:7 abc.b:8 abc.c:9
+      │         ├── cardinality: [0 - 2]
       │         ├── key: (4-6)
       │         ├── fd: (4-6)-->(7-9), (4,7)-->(11), (5,7,8)-->(12), (6,7,9)-->(13)
       │         ├── left-join (lookup abc)
       │         │    ├── columns: x:4!null y:5!null z:6!null abc.a:7 abc.b:8 abc.c:9
       │         │    ├── key columns: [4 5 6] = [7 8 9]
       │         │    ├── lookup columns are key
+      │         │    ├── cardinality: [0 - 2]
       │         │    ├── key: (4-6)
       │         │    ├── fd: (4-6)-->(7-9)
       │         │    ├── ensure-upsert-distinct-on
@@ -1837,10 +1842,11 @@ sort
       │              └── CASE WHEN abc.a:7 IS NULL THEN z:6 ELSE abc.c:9 END [as=upsert_c:13, outer=(6,7,9)]
       └── with-scan &1
            ├── columns: a:14!null b:15!null c:16!null
-           └── mapping:
-                ├──  abc.a:1 => a:14
-                ├──  abc.b:2 => b:15
-                └──  abc.c:3 => c:16
+           ├── mapping:
+           │    ├──  abc.a:1 => a:14
+           │    ├──  abc.b:2 => b:15
+           │    └──  abc.c:3 => c:16
+           └── cardinality: [0 - 2]
 
 # --------------------------------------------------
 # Delete operator.


### PR DESCRIPTION
Previously, join cardinality could not take into account whether join
filters are guaranteed to match left or right rows at least once, or
whether they are guaranteed to match input rows at most once.

This patch adjusts join cardinality to reflect the join's
JoinMultiplicity field, if available. This provides tighter bounds on
cardinality in many cases.

Release note (sql change): Improve the optimizer's ability to put
bounds on the number of output rows for joins.