### PR TITLE
backupccl: properly clean up after failing to restore system data

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -14,9 +14,14 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
 )
 
 // Large test to ensure that all of the system table data is being restored in
@@ -352,4 +357,70 @@ func TestCreateDBAndTableIncrementalFullClusterBackup(t *testing.T) {
 
 	// Ensure that the new backup succeeds.
 	sqlDB.Exec(t, `BACKUP TO $1`, LocalFoo)
+}
+
+// TestClusterRestoreFailCleanup tests that a failed RESTORE is cleaned up.
+func TestClusterRestoreFailCleanup(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	params := base.TestServerArgs{}
+	// Disable GC job so that the final check of crdb_internal.tables is
+	// guaranteed to not be cleaned up. Although this was never observed by a
+	// stress test, it is here for safety.
+	blockCh := make(chan struct{})
+	defer close(blockCh)
+	params.Knobs.GCJob = &sql.GCJobTestingKnobs{
+		RunBeforeResume: func(_ int64) error { <-blockCh; return nil },
+	}
+
+	const numAccounts = 1000
+	_, _, sqlDB, tempDir, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitNone)
+	_, tcRestore, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(
+		t, singleNode, tempDir, InitNone,
+	)
+	defer cleanupFn()
+	defer cleanupEmptyCluster()
+
+	// Setup the system systemTablesToVerify to ensure that they are copied to the new cluster.
+	// Populate system.users.
+	for i := 0; i < 1000; i++ {
+		sqlDB.Exec(t, fmt.Sprintf("CREATE USER maxroach%d", i))
+	}
+	sqlDB.Exec(t, `BACKUP TO $1`, LocalFoo)
+
+	// Bugger the backup by injecting a failure while restoring the system data.
+	for _, server := range tcRestore.Servers {
+		registry := server.JobRegistry().(*jobs.Registry)
+		registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
+			jobspb.TypeRestore: func(raw jobs.Resumer) jobs.Resumer {
+				r := raw.(*restoreResumer)
+				r.testingKnobs.duringSystemTableRestoration = func() error {
+					return errors.New("injected error")
+				}
+				return r
+			},
+		}
+	}
+
+	sqlDBRestore.ExpectErr(
+		t, "injected error",
+		`RESTORE FROM $1`, LocalFoo,
+	)
+	// Verify the failed RESTORE added some DROP tables.
+	// Note that the system tables here correspond to the temporary tables
+	// imported, not the system tables themselves.
+	sqlDBRestore.CheckQueryResults(t,
+		`SELECT name FROM crdb_internal.tables WHERE state = 'DROP' ORDER BY name`,
+		[][]string{
+			{"bank"},
+			{"comments"},
+			{"jobs"},
+			{"locations"},
+			{"role_members"},
+			{"settings"},
+			{"ui"},
+			{"users"},
+			{"zones"},
+		},
+	)
 }

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -795,6 +795,13 @@ type restoreResumer struct {
 	descriptorCoverage tree.DescriptorCoverage
 	latestStats        []*stats.TableStatisticProto
 	execCfg            *sql.ExecutorConfig
+
+	testingKnobs struct {
+		// duringSystemTableResotration is called once for every system table we
+		// restore. It is used to simulate any errors that we may face at this point
+		// of the restore.
+		duringSystemTableRestoration func() error
+	}
 }
 
 // remapRelevantStatistics changes the table ID references in the stats
@@ -1011,6 +1018,9 @@ func (r *restoreResumer) Resume(
 		return err
 	}
 
+	// TODO(pbardea): This was part of the original design where full cluster
+	// restores were a special case, but really we should be making only the
+	// temporary system tables public before we restore all the system table data.
 	if r.descriptorCoverage == tree.AllDescriptors {
 		if err := r.restoreSystemTables(ctx, p.ExecCfg().DB); err != nil {
 			return err
@@ -1085,6 +1095,7 @@ func (r *restoreResumer) publishTables(ctx context.Context) error {
 		// Write the new TableDescriptors and flip state over to public so they can be
 		// accessed.
 		b := txn.NewBatch()
+		newTables := make([]*sqlbase.TableDescriptor, 0, len(details.TableDescs))
 		for _, tbl := range r.tables {
 			newTableDesc := sqlbase.NewMutableExistingTableDescriptor(*tbl.TableDesc())
 			newTableDesc.Version++
@@ -1105,6 +1116,7 @@ func (r *restoreResumer) publishTables(ctx context.Context) error {
 				newTableDesc.DescriptorProto(),
 				existingDescVal,
 			)
+			newTables = append(newTables, newTableDesc.TableDesc())
 		}
 
 		if err := txn.Run(ctx, b); err != nil {
@@ -1113,6 +1125,7 @@ func (r *restoreResumer) publishTables(ctx context.Context) error {
 
 		// Update and persist the state of the job.
 		details.TablesPublished = true
+		details.TableDescs = newTables
 		if err := r.job.WithTxn(txn).SetDetails(ctx, details); err != nil {
 			for _, newJob := range newSchemaChangeJobs {
 				if cleanupErr := newJob.CleanupOnRollback(ctx); cleanupErr != nil {
@@ -1275,6 +1288,12 @@ func (r *restoreResumer) restoreSystemTables(ctx context.Context, db *kv.DB) err
 			return nil
 		}); err != nil {
 			return err
+		}
+
+		if fn := r.testingKnobs.duringSystemTableRestoration; fn != nil {
+			if err := fn(); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Previously, if full cluster restore failed while restoring the system
table data, it would not clean up after itself properly and would leave
some temporary tables public and not dropped.

The job maintained a list of descriptors, and when dropping the tables
it ensures that the table descriptors have not been changed in the
meantime. However, restore did not update it's view of these tables when
it marks the tables public. This means that if there is a failure after
marking the table publics it will be surprised to find the table
descriptors have changed. This change ensures that the job updates its
internal tracking of the table descriptors when it makes them public.


Fixes #49921.


Release note (bug fix): Previously, if full cluster restore failed while
restoring the system table data, it would not clean up after itself
properly and would leave some temporary tables public and not dropped.