### PR TITLE
release-20.1: backupccl: handle retry errors during system table restoration

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1004,7 +1004,7 @@ func (r *restoreResumer) Resume(
 	}
 
 	if r.descriptorCoverage == tree.AllDescriptors {
-		if err := r.restoreSystemTables(ctx); err != nil {
+		if err := r.restoreSystemTables(ctx, p.ExecCfg().DB); err != nil {
 			return err
 		}
 	}
@@ -1244,29 +1244,30 @@ func (r *restoreResumer) dropTables(ctx context.Context, jr *jobs.Registry, txn 
 
 // restoreSystemTables atomically replaces the contents of the system tables
 // with the data from the restored system tables.
-func (r *restoreResumer) restoreSystemTables(ctx context.Context) error {
+func (r *restoreResumer) restoreSystemTables(ctx context.Context, db *kv.DB) error {
 	executor := r.execCfg.InternalExecutor
 	var err error
 	for _, systemTable := range fullClusterSystemTables {
-		systemTxn := r.execCfg.DB.NewTxn(ctx, "system-restore-txn")
-		txnDebugName := fmt.Sprintf("restore-system-systemTable-%s", systemTable)
-		// Don't clear the jobs table as to not delete the jobs that are performing
-		// the restore.
-		if systemTable != sqlbase.JobsTable.Name {
-			deleteQuery := fmt.Sprintf("DELETE FROM system.%s WHERE true;", systemTable)
-			_, err = executor.Exec(ctx, txnDebugName+"-data-deletion", systemTxn, deleteQuery)
-			if err != nil {
-				return errors.Wrapf(err, "restoring system.%s", systemTable)
+		if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			txn.SetDebugName("system-restore-txn")
+			stmtDebugName := fmt.Sprintf("restore-system-systemTable-%s", systemTable)
+			// Don't clear the jobs table as to not delete the jobs that are performing
+			// the restore.
+			if systemTable != sqlbase.JobsTable.Name {
+				deleteQuery := fmt.Sprintf("DELETE FROM system.%s WHERE true;", systemTable)
+				_, err = executor.Exec(ctx, stmtDebugName+"-data-deletion", txn, deleteQuery)
+				if err != nil {
+					return errors.Wrapf(err, "deleting data from system.%s", systemTable)
+				}
 			}
-		}
-		restoreQuery := fmt.Sprintf("INSERT INTO system.%s (SELECT * FROM %s.%s);", systemTable, restoreTempSystemDB, systemTable)
-		_, err = executor.Exec(ctx, txnDebugName+"-data-insert", systemTxn, restoreQuery)
-		if err != nil {
-			return errors.Wrap(err, "restoring system tables")
-		}
-		err = systemTxn.Commit(ctx)
-		if err != nil {
-			return errors.Wrap(err, "committing system systemTable restoration")
+			restoreQuery := fmt.Sprintf("INSERT INTO system.%s (SELECT * FROM %s.%s);", systemTable, restoreTempSystemDB, systemTable)
+			_, err = executor.Exec(ctx, stmtDebugName+"-data-insert", txn, restoreQuery)
+			if err != nil {
+				return errors.Wrapf(err, "inserting data to system.%s", systemTable)
+			}
+			return nil
+		}); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #49950.

/cc @cockroachdb/release

---

Previously, if the transaction which restored the system table data
returned a retry exception, the job would fail and the entire restore
would need to be restarted. This change automatically retries restoring
the system table data.

Release note (enterprise change): Full cluster restore is now more
resilient to transient transaction retry errors while it restores.
