### PR TITLE
colexec: call DrainMeta and Next from single goroutine

### DIFF
--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -416,9 +416,9 @@ func (s *externalSorter) IdempotentClose(ctx context.Context) error {
 func (s *externalSorter) createMergerForPartitions(
 	firstIdx, numPartitions int,
 ) (colexecbase.Operator, error) {
-	syncInputs := make([]colexecbase.Operator, numPartitions)
+	syncInputs := make([]SynchronizerInput, numPartitions)
 	for i := range syncInputs {
-		syncInputs[i] = newPartitionerToOperator(
+		syncInputs[i].Op = newPartitionerToOperator(
 			s.unlimitedAllocator, s.inputTypes, s.partitioner, firstIdx+i,
 		)
 	}

--- a/pkg/sql/colexec/ordered_synchronizer_test.go
+++ b/pkg/sql/colexec/ordered_synchronizer_test.go
@@ -144,7 +144,7 @@ func TestOrderedSync(t *testing.T) {
 			typs[i] = types.Int
 		}
 		runTests(t, tc.sources, tc.expected, orderedVerifier, func(inputs []colexecbase.Operator) (colexecbase.Operator, error) {
-			return NewOrderedSynchronizer(testAllocator, inputs, typs, tc.ordering)
+			return NewOrderedSynchronizer(testAllocator, operatorsToSynchronizerInputs(inputs), typs, tc.ordering)
 		})
 	}
 }
@@ -179,9 +179,9 @@ func TestOrderedSyncRandomInput(t *testing.T) {
 		}
 		sources[sourceIdx] = append(sources[sourceIdx], t)
 	}
-	inputs := make([]colexecbase.Operator, numInputs)
+	inputs := make([]SynchronizerInput, numInputs)
 	for i := range inputs {
-		inputs[i] = newOpTestInput(batchSize, sources[i], typs)
+		inputs[i].Op = newOpTestInput(batchSize, sources[i], typs)
 	}
 	ordering := sqlbase.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
 	op, err := NewOrderedSynchronizer(testAllocator, inputs, typs, ordering)
@@ -208,9 +208,9 @@ func BenchmarkOrderedSynchronizer(b *testing.B) {
 		batch.ColVec(0).Int64()[i/numInputs] = i
 	}
 
-	inputs := make([]colexecbase.Operator, len(batches))
+	inputs := make([]SynchronizerInput, len(batches))
 	for i := range batches {
-		inputs[i] = colexecbase.NewRepeatableBatchSource(testAllocator, batches[i], typs)
+		inputs[i].Op = colexecbase.NewRepeatableBatchSource(testAllocator, batches[i], typs)
 	}
 
 	ordering := sqlbase.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -55,7 +56,7 @@ const _TYPE_WIDTH = 0
 // stream are assumed to be ordered according to the same set of columns.
 type OrderedSynchronizer struct {
 	allocator             *colmem.Allocator
-	inputs                []colexecbase.Operator
+	inputs                []SynchronizerInput
 	ordering              sqlbase.ColumnOrdering
 	typs                  []*types.T
 	canonicalTypeFamilies []types.Family
@@ -104,13 +105,13 @@ func (o *OrderedSynchronizer) ChildCount(verbose bool) int {
 
 // Child implements the execinfrapb.OpNode interface.
 func (o *OrderedSynchronizer) Child(nth int, verbose bool) execinfra.OpNode {
-	return o.inputs[nth]
+	return o.inputs[nth].Op
 }
 
 // NewOrderedSynchronizer creates a new OrderedSynchronizer.
 func NewOrderedSynchronizer(
 	allocator *colmem.Allocator,
-	inputs []colexecbase.Operator,
+	inputs []SynchronizerInput,
 	typs []*types.T,
 	ordering sqlbase.ColumnOrdering,
 ) (*OrderedSynchronizer, error) {
@@ -129,7 +130,7 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 		o.inputBatches = make([]coldata.Batch, len(o.inputs))
 		o.heap = make([]int, 0, len(o.inputs))
 		for i := range o.inputs {
-			o.inputBatches[i] = o.inputs[i].Next(ctx)
+			o.inputBatches[i] = o.inputs[i].Op.Next(ctx)
 			o.updateComparators(i)
 			if o.inputBatches[i].Length() > 0 {
 				o.heap = append(o.heap, i)
@@ -181,7 +182,7 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 			if o.inputIndices[minBatch]+1 < o.inputBatches[minBatch].Length() {
 				o.inputIndices[minBatch]++
 			} else {
-				o.inputBatches[minBatch] = o.inputs[minBatch].Next(ctx)
+				o.inputBatches[minBatch] = o.inputs[minBatch].Op.Next(ctx)
 				o.inputIndices[minBatch] = 0
 				o.updateComparators(minBatch)
 			}
@@ -223,13 +224,21 @@ func (o *OrderedSynchronizer) Init() {
 		}
 	}
 	for i := range o.inputs {
-		o.inputs[i].Init()
+		o.inputs[i].Op.Init()
 	}
 	o.comparators = make([]vecComparator, len(o.ordering))
 	for i := range o.ordering {
 		typ := o.typs[o.ordering[i].ColIdx]
 		o.comparators[i] = GetVecComparator(typ, len(o.inputs))
 	}
+}
+
+func (o *OrderedSynchronizer) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
+	var bufferedMeta []execinfrapb.ProducerMetadata
+	for _, input := range o.inputs {
+		bufferedMeta = append(bufferedMeta, input.MetadataSources.DrainMeta(ctx)...)
+	}
+	return bufferedMeta
 }
 
 func (o *OrderedSynchronizer) compareRow(batchIdx1 int, batchIdx2 int) int {

--- a/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
@@ -12,6 +12,7 @@ package colexec
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -21,10 +22,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldatatestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,7 +46,7 @@ func TestParallelUnorderedSynchronizer(t *testing.T) {
 		numBatches = rng.Intn(maxBatches) + 1
 	)
 
-	inputs := make([]colexecbase.Operator, numInputs)
+	inputs := make([]SynchronizerInput, numInputs)
 	for i := range inputs {
 		source := colexecbase.NewRepeatableBatchSource(
 			testAllocator,
@@ -51,50 +54,90 @@ func TestParallelUnorderedSynchronizer(t *testing.T) {
 			typs,
 		)
 		source.ResetBatchesToReturn(numBatches)
-		inputs[i] = source
+		inputs[i].Op = source
+		inputIdx := i
+		inputs[i].MetadataSources = []execinfrapb.MetadataSource{
+			execinfrapb.CallbackMetadataSource{DrainMetaCb: func(_ context.Context) []execinfrapb.ProducerMetadata {
+				return []execinfrapb.ProducerMetadata{{Err: errors.Errorf("input %d test-induced metadata", inputIdx)}}
+			}},
+		}
 	}
 
 	var wg sync.WaitGroup
-	s := NewParallelUnorderedSynchronizer(inputs, typs, &wg)
+	s := NewParallelUnorderedSynchronizer(inputs, &wg)
 
 	ctx, cancelFn := context.WithCancel(context.Background())
-	var cancel bool
-	if rng.Float64() < 0.5 {
-		cancel = true
-	}
-	if cancel {
-		wg.Add(1)
-		sleepTime := time.Duration(rng.Intn(500)) * time.Microsecond
-		go func() {
-			time.Sleep(sleepTime)
-			cancelFn()
-			wg.Done()
-		}()
-	} else {
-		// Appease the linter complaining about context leaks.
-		defer cancelFn()
-	}
+	type synchronizerTerminationScenario int
+	const (
+		// synchronizerGracefulTermination is a termination scenario where the
+		// synchronizer terminates gracefully.
+		synchronizerGracefulTermination synchronizerTerminationScenario = iota
+		// synchronizerContextCanceled is a termination scenario where a
+		// cancellation requests that a synchronizer terminates.
+		synchronizerContextCanceled
+		// synchronizerPrematureDrainMeta is a termination scenario where DrainMeta
+		// is called prematurely on the synchronizer.
+		synchronizerPrematureDrainMeta
+		// synchronizerMaxTerminationScenario should be at the end of the
+		// termination scenario list so that it can be used as an upper bound to
+		// generate any other termination scenario.
+		synchronizerMaxTerminationScenario
+	)
+	terminationScenario := synchronizerTerminationScenario(rng.Intn(int(synchronizerMaxTerminationScenario)))
 
-	batchesReturned := 0
-	for {
-		var b coldata.Batch
-		if err := colexecerror.CatchVectorizedRuntimeError(func() { b = s.Next(ctx) }); err != nil {
-			if cancel {
-				require.True(t, testutils.IsError(err, "context canceled"), err)
-				break
-			} else {
-				t.Fatal(err)
+	t.Run(fmt.Sprintf("numInputs=%d/numBatches=%d/terminationScenario=%d", numInputs, numBatches, terminationScenario), func(t *testing.T) {
+		if terminationScenario == synchronizerContextCanceled {
+			wg.Add(1)
+			sleepTime := time.Duration(rng.Intn(500)) * time.Microsecond
+			go func() {
+				time.Sleep(sleepTime)
+				cancelFn()
+				wg.Done()
+			}()
+		} else {
+			// Appease the linter complaining about context leaks.
+			defer cancelFn()
+		}
+
+		batchesReturned := 0
+		expectedBatchesReturned := numInputs * numBatches
+		for {
+			expectZeroBatch := false
+			if terminationScenario == synchronizerPrematureDrainMeta && batchesReturned < expectedBatchesReturned {
+				// Call DrainMeta before the input is finished. Intentionally allow
+				// for Next to be called even though it's not technically supported to
+				// ensure that a zero-length batch is returned.
+				meta := s.DrainMeta(ctx)
+				require.Equal(t, len(inputs), len(meta), "metadata length mismatch, returned metadata is: %v", meta)
+				expectZeroBatch = true
 			}
+			var b coldata.Batch
+			if err := colexecerror.CatchVectorizedRuntimeError(func() { b = s.Next(ctx) }); err != nil {
+				if terminationScenario == synchronizerContextCanceled {
+					require.True(t, testutils.IsError(err, "context canceled"), err)
+					break
+				} else {
+					t.Fatal(err)
+				}
+			}
+			if b.Length() == 0 {
+				if terminationScenario == synchronizerGracefulTermination {
+					// Successful run, check that all inputs have returned metadata.
+					meta := s.DrainMeta(ctx)
+					require.Equal(t, len(inputs), len(meta), "metadata length mismatch, returned metadata is: %v", meta)
+				}
+				break
+			}
+			if expectZeroBatch {
+				t.Fatal("expected a zero batch to be returned after prematurely calling DrainMeta but that did not happen")
+			}
+			batchesReturned++
 		}
-		if b.Length() == 0 {
-			break
+		if terminationScenario != synchronizerContextCanceled && terminationScenario != synchronizerPrematureDrainMeta {
+			require.Equal(t, expectedBatchesReturned, batchesReturned)
 		}
-		batchesReturned++
-	}
-	if !cancel {
-		require.Equal(t, numInputs*numBatches, batchesReturned)
-	}
-	wg.Wait()
+		wg.Wait()
+	})
 }
 
 func TestUnorderedSynchronizerNoLeaksOnError(t *testing.T) {
@@ -102,14 +145,14 @@ func TestUnorderedSynchronizerNoLeaksOnError(t *testing.T) {
 
 	const expectedErr = "first input error"
 
-	inputs := make([]colexecbase.Operator, 6)
-	inputs[0] = &colexecbase.CallbackOperator{NextCb: func(context.Context) coldata.Batch {
+	inputs := make([]SynchronizerInput, 6)
+	inputs[0].Op = &colexecbase.CallbackOperator{NextCb: func(context.Context) coldata.Batch {
 		colexecerror.InternalError(expectedErr)
 		// This code is unreachable, but the compiler cannot infer that.
 		return nil
 	}}
 	for i := 1; i < len(inputs); i++ {
-		inputs[i] = &colexecbase.CallbackOperator{
+		inputs[i].Op = &colexecbase.CallbackOperator{
 			NextCb: func(ctx context.Context) coldata.Batch {
 				<-ctx.Done()
 				colexecerror.InternalError(ctx.Err())
@@ -123,7 +166,7 @@ func TestUnorderedSynchronizerNoLeaksOnError(t *testing.T) {
 		ctx = context.Background()
 		wg  sync.WaitGroup
 	)
-	s := NewParallelUnorderedSynchronizer(inputs, []*types.T{types.Int}, &wg)
+	s := NewParallelUnorderedSynchronizer(inputs, &wg)
 	err := colexecerror.CatchVectorizedRuntimeError(func() { _ = s.Next(ctx) })
 	// This is the crux of the test: assert that all inputs have finished.
 	require.Equal(t, len(inputs), int(atomic.LoadUint32(&s.numFinishedInputs)))
@@ -134,15 +177,15 @@ func BenchmarkParallelUnorderedSynchronizer(b *testing.B) {
 	const numInputs = 6
 
 	typs := []*types.T{types.Int}
-	inputs := make([]colexecbase.Operator, numInputs)
+	inputs := make([]SynchronizerInput, numInputs)
 	for i := range inputs {
 		batch := testAllocator.NewMemBatchWithSize(typs, coldata.BatchSize())
 		batch.SetLength(coldata.BatchSize())
-		inputs[i] = colexecbase.NewRepeatableBatchSource(testAllocator, batch, typs)
+		inputs[i].Op = colexecbase.NewRepeatableBatchSource(testAllocator, batch, typs)
 	}
 	var wg sync.WaitGroup
 	ctx, cancelFn := context.WithCancel(context.Background())
-	s := NewParallelUnorderedSynchronizer(inputs, typs, &wg)
+	s := NewParallelUnorderedSynchronizer(inputs, &wg)
 	b.SetBytes(8 * int64(coldata.BatchSize()))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/pkg/sql/colexec/routers_test.go
+++ b/pkg/sql/colexec/routers_test.go
@@ -14,6 +14,8 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -23,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldatatestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -32,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -148,7 +152,21 @@ func TestRouterOutputAddBatch(t *testing.T) {
 			t.Run(fmt.Sprintf("%s/memoryLimit=%s", tc.name, humanizeutil.IBytes(mtc.bytes)), func(t *testing.T) {
 				// Clear the testAllocator for use.
 				testAllocator.ReleaseMemory(testAllocator.Used())
-				o := newRouterOutputOpWithBlockedThresholdAndBatchSize(testAllocator, typs, unblockEventsChan, mtc.bytes, queueCfg, colexecbase.NewTestingSemaphore(2), tc.blockedThreshold, tc.outputBatchSize, testDiskAcc)
+				o := newRouterOutputOp(
+					routerOutputOpArgs{
+						types:               typs,
+						unlimitedAllocator:  testAllocator,
+						memoryLimit:         mtc.bytes,
+						diskAcc:             testDiskAcc,
+						cfg:                 queueCfg,
+						fdSemaphore:         colexecbase.NewTestingSemaphore(2),
+						unblockedEventsChan: unblockEventsChan,
+						testingKnobs: routerOutputOpTestingKnobs{
+							blockedThreshold: tc.blockedThreshold,
+							outputBatchSize:  tc.outputBatchSize,
+						},
+					},
+				)
 				in := newOpTestInput(tc.inputBatchSize, data, nil /* typs */)
 				out := newOpTestOutput(o, data[:len(tc.selection)])
 				in.Init()
@@ -241,7 +259,17 @@ func TestRouterOutputNext(t *testing.T) {
 				if queueCfg.FS == nil {
 					t.Fatal("FS was nil")
 				}
-				o := newRouterOutputOp(testAllocator, typs, unblockedEventsChan, mtc.bytes, queueCfg, colexecbase.NewTestingSemaphore(2), testDiskAcc)
+				o := newRouterOutputOp(
+					routerOutputOpArgs{
+						types:               typs,
+						unlimitedAllocator:  testAllocator,
+						memoryLimit:         mtc.bytes,
+						diskAcc:             testDiskAcc,
+						cfg:                 queueCfg,
+						fdSemaphore:         colexecbase.NewTestingSemaphore(2),
+						unblockedEventsChan: unblockedEventsChan,
+					},
+				)
 				in := newOpTestInput(coldata.BatchSize(), data, nil /* typs */)
 				in.Init()
 				wg.Add(1)
@@ -291,7 +319,17 @@ func TestRouterOutputNext(t *testing.T) {
 		}
 
 		t.Run(fmt.Sprintf("NextAfterZeroBatchDoesntBlock/memoryLimit=%s", humanizeutil.IBytes(mtc.bytes)), func(t *testing.T) {
-			o := newRouterOutputOp(testAllocator, typs, unblockedEventsChan, mtc.bytes, queueCfg, colexecbase.NewTestingSemaphore(2), testDiskAcc)
+			o := newRouterOutputOp(
+				routerOutputOpArgs{
+					types:               typs,
+					unlimitedAllocator:  testAllocator,
+					memoryLimit:         mtc.bytes,
+					diskAcc:             testDiskAcc,
+					cfg:                 queueCfg,
+					fdSemaphore:         colexecbase.NewTestingSemaphore(2),
+					unblockedEventsChan: unblockedEventsChan,
+				},
+			)
 			o.addBatch(ctx, coldata.ZeroBatch, fullSelection)
 			o.Next(ctx)
 			o.Next(ctx)
@@ -330,7 +368,20 @@ func TestRouterOutputNext(t *testing.T) {
 			}
 
 			ch := make(chan struct{}, 2)
-			o := newRouterOutputOpWithBlockedThresholdAndBatchSize(testAllocator, typs, ch, mtc.bytes, queueCfg, colexecbase.NewTestingSemaphore(2), blockThreshold, coldata.BatchSize(), testDiskAcc)
+			o := newRouterOutputOp(
+				routerOutputOpArgs{
+					types:               typs,
+					unlimitedAllocator:  testAllocator,
+					memoryLimit:         mtc.bytes,
+					diskAcc:             testDiskAcc,
+					cfg:                 queueCfg,
+					fdSemaphore:         colexecbase.NewTestingSemaphore(2),
+					unblockedEventsChan: ch,
+					testingKnobs: routerOutputOpTestingKnobs{
+						blockedThreshold: blockThreshold,
+					},
+				},
+			)
 			in := newOpTestInput(smallBatchSize, data, nil /* typs */)
 			out := newOpTestOutput(o, expected)
 			in.Init()
@@ -404,7 +455,21 @@ func TestRouterOutputRandom(t *testing.T) {
 			runTestsWithFn(t, []tuples{data}, nil /* typs */, func(t *testing.T, inputs []colexecbase.Operator) {
 				var wg sync.WaitGroup
 				unblockedEventsChans := make(chan struct{}, 2)
-				o := newRouterOutputOpWithBlockedThresholdAndBatchSize(testAllocator, typs, unblockedEventsChans, mtc.bytes, queueCfg, colexecbase.NewTestingSemaphore(2), blockedThreshold, outputSize, testDiskAcc)
+				o := newRouterOutputOp(
+					routerOutputOpArgs{
+						types:               typs,
+						unlimitedAllocator:  testAllocator,
+						memoryLimit:         mtc.bytes,
+						diskAcc:             testDiskAcc,
+						cfg:                 queueCfg,
+						fdSemaphore:         colexecbase.NewTestingSemaphore(2),
+						unblockedEventsChan: unblockedEventsChans,
+						testingKnobs: routerOutputOpTestingKnobs{
+							blockedThreshold: blockedThreshold,
+							outputBatchSize:  outputSize,
+						},
+					},
+				)
 				inputs[0].Init()
 
 				expected := make(tuples, 0, len(data))
@@ -515,8 +580,10 @@ type callbackRouterOutput struct {
 
 var _ routerOutput = callbackRouterOutput{}
 
+func (o callbackRouterOutput) initWithHashRouter(*HashRouter) {}
+
 func (o callbackRouterOutput) addBatch(
-	ctx context.Context, batch coldata.Batch, selection []int,
+	_ context.Context, batch coldata.Batch, selection []int,
 ) bool {
 	if o.addBatchCb != nil {
 		return o.addBatchCb(batch, selection)
@@ -528,10 +595,6 @@ func (o callbackRouterOutput) cancel(context.Context) {
 	if o.cancelCb != nil {
 		o.cancelCb()
 	}
-}
-
-func (o callbackRouterOutput) drain() []execinfrapb.ProducerMetadata {
-	return nil
 }
 
 func TestHashRouterComputesDestination(t *testing.T) {
@@ -592,7 +655,7 @@ func TestHashRouterComputesDestination(t *testing.T) {
 		}
 	}
 
-	r := newHashRouterWithOutputs(in, typs, []uint32{0}, nil /* ch */, outputs, nil /* toClose */)
+	r := newHashRouterWithOutputs(in, typs, []uint32{0}, nil /* ch */, outputs, nil /* toDrain */, nil /* toClose */)
 	for r.processNextBatch(ctx) {
 	}
 
@@ -631,10 +694,23 @@ func TestHashRouterCancellation(t *testing.T) {
 	in := colexecbase.NewRepeatableBatchSource(testAllocator, batch, typs)
 
 	unbufferedCh := make(chan struct{})
-	r := newHashRouterWithOutputs(in, typs, []uint32{0}, unbufferedCh, outputs, nil /* toClose */)
+	r := newHashRouterWithOutputs(in, typs, []uint32{0}, unbufferedCh, outputs, nil /* toDrain */, nil /* toClose */)
+	drainMeta := func(t *testing.T) []execinfrapb.ProducerMetadata {
+		var metadata []execinfrapb.ProducerMetadata
+		for range outputs {
+			if routerMeta := r.drainMeta(); routerMeta != nil {
+				if metadata != nil {
+					t.Fatal("HashRouter returned metadata more than once, only the last output to call drainMeta should have received metadata")
+				}
+				metadata = routerMeta
+			}
+		}
+		return metadata
+	}
 
 	t.Run("BeforeRun", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
+		r.resetForBenchmarks(ctx)
 		cancel()
 		r.Run(ctx)
 
@@ -646,7 +722,7 @@ func TestHashRouterCancellation(t *testing.T) {
 			t.Fatalf("detected %d addBatch calls but expected 0", numAddBatches)
 		}
 
-		meta := r.DrainMeta(ctx)
+		meta := drainMeta(t)
 		require.Equal(t, 1, len(meta))
 		require.True(t, testutils.IsError(meta[0].Err, "context canceled"), meta[0].Err)
 	})
@@ -671,6 +747,7 @@ func TestHashRouterCancellation(t *testing.T) {
 			numAddBatches = 0
 
 			ctx, cancel := context.WithCancel(context.Background())
+			r.resetForBenchmarks(ctx)
 
 			if tc.blocked {
 				r.numBlockedOutputs = len(outputs)
@@ -679,11 +756,10 @@ func TestHashRouterCancellation(t *testing.T) {
 				}()
 			}
 
-			routerMeta := make(chan []execinfrapb.ProducerMetadata)
+			doneCh := make(chan struct{})
 			go func() {
 				r.Run(ctx)
-				routerMeta <- r.DrainMeta(ctx)
-				close(routerMeta)
+				close(doneCh)
 			}()
 
 			time.Sleep(time.Millisecond)
@@ -694,13 +770,14 @@ func TestHashRouterCancellation(t *testing.T) {
 				}
 			}
 			select {
-			case <-routerMeta:
+			case <-doneCh:
 				t.Fatal("hash router goroutine unexpectedly done")
 			default:
 			}
 			cancel()
-			meta := <-routerMeta
-			require.Equal(t, 1, len(meta))
+			<-doneCh
+			meta := drainMeta(t)
+			require.Equal(t, 1, len(meta), "expected one metadata message but got: %v", meta)
 			require.True(t, testutils.IsError(meta[0].Err, "canceled"), meta[0].Err)
 
 			if numCancels != int64(len(outputs)) {
@@ -734,11 +811,7 @@ func TestHashRouterOneOutput(t *testing.T) {
 			testAllocator.ReleaseMemory(testAllocator.Used())
 			diskAcc := testDiskMonitor.MakeBoundAccount()
 			defer diskAcc.Close(ctx)
-			r, routerOutputs := NewHashRouter(
-				[]*colmem.Allocator{testAllocator}, newOpFixedSelTestInput(sel, len(sel), data, typs),
-				typs, []uint32{0}, mtc.bytes, queueCfg, colexecbase.NewTestingSemaphore(2),
-				[]*mon.BoundAccount{&diskAcc}, nil, /* toClose */
-			)
+			r, routerOutputs := NewHashRouter([]*colmem.Allocator{testAllocator}, newOpFixedSelTestInput(sel, len(sel), data, typs), typs, []uint32{0}, mtc.bytes, queueCfg, colexecbase.NewTestingSemaphore(2), []*mon.BoundAccount{&diskAcc}, nil /* toDrain */, nil /* toClose */)
 
 			if len(routerOutputs) != 1 {
 				t.Fatalf("expected 1 router output but got %d", len(routerOutputs))
@@ -762,9 +835,9 @@ func TestHashRouterOneOutput(t *testing.T) {
 			}
 			wg.Wait()
 			// Expect no metadata, this should be a successful run.
-			unexpectedMetadata := r.DrainMeta(ctx)
+			unexpectedMetadata := ro.DrainMeta(ctx)
 			if len(unexpectedMetadata) != 0 {
-				t.Fatalf("unexpected metadata when draining HashRouter: %+v", unexpectedMetadata)
+				t.Fatalf("unexpected metadata when draining HashRouter output: %+v", unexpectedMetadata)
 			}
 			if !mtc.skipExpSpillCheck {
 				// If len(sel) == 0, no items will have been enqueued so override an
@@ -808,20 +881,51 @@ func TestHashRouterRandom(t *testing.T) {
 		}
 	}
 
-	// cancel determines whether we test cancellation.
-	cancel := false
-	if rng.Float64() < 0.25 {
-		cancel = true
+	type hashRouterTerminationScenario int
+	const (
+		// hashRouterGracefulTermination is a normal termination scenario where the
+		// input stream is fully consumed and all outputs are drained normally.
+		hashRouterGracefulTermination hashRouterTerminationScenario = iota
+		// hashRouterPrematureDrainMeta is a termination scenario where one or more
+		// outputs are drained before all output is pushed to it.
+		hashRouterPrematureDrainMeta
+		// hashRouterContextCanceled is a termination scenario where the caller of
+		// Run suddenly cancels the provided context.
+		hashRouterContextCanceled
+		// hashRouterOutputErrorOnAddBatch is a termination scenario in which the
+		// router output encounters an error when a batch is pushed to it.
+		hashRouterOutputErrorOnAddBatch
+		// hashRouterOutputErrorOnNext is a termination scenario in which the
+		// router output encounters an error when a batch is read from it.
+		hashRouterOutputErrorOnNext
+		// hashRouterChaos is a fun scenario in which maybe a bit of everything
+		// happens.
+		hashRouterChaos
+		// hashRouterMaxTerminationScenario should be kept at the end of this list
+		// for the rng to generate a valid termination scenario.
+		hashRouterMaxTerminationScenario
+	)
+	terminationScenario := hashRouterTerminationScenario(rng.Intn(int(hashRouterMaxTerminationScenario)))
+	// isTerminationScenario is a helper function that returns true with a
+	// given probability if the termination scenario is equivalent to the given
+	// scenario. This can be used before performing any disruptive behavior in
+	// order to randomize its occurrence.
+	isTerminationScenario := func(rng *rand.Rand, probability float64, ts hashRouterTerminationScenario) bool {
+		return rng.Float64() < probability && (terminationScenario == ts || terminationScenario == hashRouterChaos)
 	}
+	const (
+		addBatchErrMsg = "test induced addBatch error"
+		nextErrMsg     = "test induced Next error"
+	)
 
 	testName := fmt.Sprintf(
-		"numOutputs=%d/blockedThreshold=%d/outputSize=%d/totalInputSize=%d/hashCols=%v/cancel=%t",
+		"numOutputs=%d/blockedThreshold=%d/outputSize=%d/totalInputSize=%d/hashCols=%v/terminationScenario=%d",
 		numOutputs,
 		blockedThreshold,
 		outputSize,
 		len(data),
 		hashCols,
-		cancel,
+		terminationScenario,
 	)
 
 	queueCfg, cleanup, memoryTestCases := getDiskQueueCfgAndMemoryTestCases(t, rng)
@@ -836,7 +940,7 @@ func TestHashRouterRandom(t *testing.T) {
 			runTestsWithFn(t, []tuples{data}, nil /* typs */, func(t *testing.T, inputs []colexecbase.Operator) {
 				unblockEventsChan := make(chan struct{}, 2*numOutputs)
 				outputs := make([]routerOutput, numOutputs)
-				outputsAsOps := make([]colexecbase.Operator, numOutputs)
+				outputsAsOps := make([]colexecbase.DrainableOperator, numOutputs)
 				memoryLimitPerOutput := mtc.bytes / int64(len(outputs))
 				for i := range outputs {
 					// Create separate monitoring infrastructure as well as
@@ -847,30 +951,105 @@ func TestHashRouterRandom(t *testing.T) {
 					diskAcc := testDiskMonitor.MakeBoundAccount()
 					defer diskAcc.Close(ctx)
 					allocator := colmem.NewAllocator(ctx, &acc, testColumnFactory)
-					op := newRouterOutputOpWithBlockedThresholdAndBatchSize(allocator, typs, unblockEventsChan, memoryLimitPerOutput, queueCfg, colexecbase.NewTestingSemaphore(len(outputs)*2), blockedThreshold, outputSize, &diskAcc)
+					op := newRouterOutputOp(
+						routerOutputOpArgs{
+							types:               typs,
+							unlimitedAllocator:  allocator,
+							memoryLimit:         memoryLimitPerOutput,
+							diskAcc:             &diskAcc,
+							cfg:                 queueCfg,
+							fdSemaphore:         colexecbase.NewTestingSemaphore(len(outputs) * 2),
+							unblockedEventsChan: unblockEventsChan,
+							testingKnobs: routerOutputOpTestingKnobs{
+								blockedThreshold: blockedThreshold,
+								outputBatchSize:  outputSize,
+							},
+						},
+					)
+
+					injectErrorScenario := terminationScenario
+					if terminationScenario == hashRouterChaos {
+						switch rng.Intn(2) {
+						case 0:
+							injectErrorScenario = hashRouterOutputErrorOnAddBatch
+						case 1:
+							injectErrorScenario = hashRouterOutputErrorOnNext
+						default:
+						}
+					}
+
+					switch injectErrorScenario {
+					case hashRouterOutputErrorOnAddBatch:
+						op.testingKnobs.addBatchTestInducedErrorCb = func() error {
+							addBatchRng, _ := randutil.NewPseudoRand()
+							// Sleep between 0 and ~5 milliseconds.
+							time.Sleep(time.Microsecond * time.Duration(addBatchRng.Intn(5000)))
+							return errors.New(addBatchErrMsg)
+						}
+					case hashRouterOutputErrorOnNext:
+						op.testingKnobs.nextTestInducedErrorCb = func() error {
+							nextRng, _ := randutil.NewPseudoRand()
+							// Sleep between 0 and ~5 milliseconds.
+							time.Sleep(time.Microsecond * time.Duration(nextRng.Intn(5000)))
+							return errors.New(nextErrMsg)
+						}
+					}
 					outputs[i] = op
 					outputsAsOps[i] = op
 				}
 
+				const hashRouterMetadataMsg = "hash router test metadata"
 				r := newHashRouterWithOutputs(
-					inputs[0], typs, hashCols, unblockEventsChan, outputs, nil, /* toClose */
+					inputs[0],
+					typs,
+					hashCols,
+					unblockEventsChan,
+					outputs,
+					[]execinfrapb.MetadataSource{
+						execinfrapb.CallbackMetadataSource{
+							DrainMetaCb: func(_ context.Context) []execinfrapb.ProducerMetadata {
+								return []execinfrapb.ProducerMetadata{{Err: errors.New(hashRouterMetadataMsg)}}
+							},
+						},
+					},
+					nil, /* toClose */
 				)
 
 				var (
 					results uint64
 					wg      sync.WaitGroup
 				)
-				resultsByOp := make([]int, len(outputsAsOps))
+				resultsByOp := make(
+					[]struct {
+						numResults int
+						err        error
+					},
+					len(outputsAsOps),
+				)
 				wg.Add(len(outputsAsOps))
+				metadataMu := struct {
+					syncutil.Mutex
+					metadata [][]execinfrapb.ProducerMetadata
+				}{}
 				for i := range outputsAsOps {
 					go func(i int) {
+						outputRng, _ := randutil.NewPseudoRand()
 						for {
-							b := outputsAsOps[i].Next(ctx)
-							if b.Length() == 0 {
+							var b coldata.Batch
+							err := colexecerror.CatchVectorizedRuntimeError(func() {
+								b = outputsAsOps[i].Next(ctx)
+							})
+							if err != nil || b.Length() == 0 || isTerminationScenario(outputRng, 0.5, hashRouterPrematureDrainMeta) {
+								resultsByOp[i].err = err
+								metadataMu.Lock()
+								if meta := outputsAsOps[i].DrainMeta(ctx); meta != nil {
+									metadataMu.metadata = append(metadataMu.metadata, meta)
+								}
+								metadataMu.Unlock()
 								break
 							}
 							atomic.AddUint64(&results, uint64(b.Length()))
-							resultsByOp[i] += b.Length()
+							resultsByOp[i].numResults += b.Length()
 						}
 						wg.Done()
 					}(i)
@@ -879,38 +1058,71 @@ func TestHashRouterRandom(t *testing.T) {
 				ctx, cancelFunc := context.WithCancel(context.Background())
 				wg.Add(1)
 				go func() {
+					if terminationScenario == hashRouterContextCanceled || terminationScenario == hashRouterChaos {
+						// cancel the context before using it so the HashRouter does not
+						// finish Run before it is canceled.
+						cancelFunc()
+					} else {
+						// Satisfy linter context leak error.
+						defer cancelFunc()
+					}
 					r.Run(ctx)
 					wg.Done()
 				}()
 
-				if cancel {
-					// Sleep between 0 and ~5 milliseconds.
-					time.Sleep(time.Microsecond * time.Duration(rng.Intn(5000)))
-					cancelFunc()
-				} else {
-					// Satisfy linter context leak error.
-					defer cancelFunc()
+				wg.Wait()
+				// The waitGroup protects metadataMu from concurrent access, so there's
+				// no need to lock the mutex here.
+				metadata := metadataMu.metadata
+				checkMetadata := func(t *testing.T, expectedErrMsgs []string) {
+					t.Helper()
+					require.Equal(t, 1, len(metadataMu.metadata), "one output (the last to exit) should return metadata")
+
+					require.Equal(t, len(expectedErrMsgs), len(metadata[0]), "unexpected number of metadata messages")
+					var actualErrMsgs []string
+					for _, meta := range metadata[0] {
+						require.NotNil(t, meta.Err)
+						actualErrMsgs = append(actualErrMsgs, meta.Err.Error())
+					}
+					sort.Strings(actualErrMsgs)
+					sort.Strings(expectedErrMsgs)
+					for i := range actualErrMsgs {
+						require.Contains(
+							t, actualErrMsgs[i], expectedErrMsgs[i], "expected and actual metadata mismatch at index %d: expected: %v actual: %v", i, expectedErrMsgs, actualErrMsgs,
+						)
+					}
+				}
+				requireNoErrors := func(t *testing.T) {
+					t.Helper()
+					for i := range resultsByOp {
+						require.NoError(t, resultsByOp[i].err)
+					}
 				}
 
-				// Ensure all goroutines end. If a test fails with a hang here it is most
-				// likely due to a cancellation bug.
-				wg.Wait()
-				if !cancel {
-					// Expect no metadata, this should be a successful run.
-					unexpectedMetadata := r.DrainMeta(ctx)
-					if len(unexpectedMetadata) != 0 {
-						t.Fatalf("unexpected metadata when draining HashRouter: %+v", unexpectedMetadata)
+				switch terminationScenario {
+				case hashRouterGracefulTermination, hashRouterPrematureDrainMeta:
+					requireNoErrors(t)
+					checkMetadata(t, []string{hashRouterMetadataMsg})
+
+					if terminationScenario == hashRouterPrematureDrainMeta {
+						// Don't check output results if an output is prematurely drained
+						// since they differ from run to run.
+						break
 					}
-					// Only do output verification if no cancellation happened.
+
+					// Do output verification.
 					if actualTotal := atomic.LoadUint64(&results); actualTotal != uint64(len(data)) {
 						t.Fatalf("unexpected number of results %d, expected %d", actualTotal, len(data))
 					}
 					if expectedDistribution == nil {
-						expectedDistribution = resultsByOp
+						expectedDistribution = make([]int, len(resultsByOp))
+						for i := range resultsByOp {
+							expectedDistribution[i] = resultsByOp[i].numResults
+						}
 						return
 					}
 					for i, numVals := range expectedDistribution {
-						if numVals != resultsByOp[i] {
+						if numVals != resultsByOp[i].numResults {
 							t.Fatalf(
 								"distribution of results changed compared to first run at output %d. expected: %v, actual: %v",
 								i,
@@ -919,6 +1131,56 @@ func TestHashRouterRandom(t *testing.T) {
 							)
 						}
 					}
+				case hashRouterContextCanceled:
+					// Outputs won't observe an error in this case, the cancellation error
+					// is propagated when/if the outputs are drained.
+					requireNoErrors(t)
+					checkMetadata(t, []string{hashRouterMetadataMsg, context.Canceled.Error()})
+				case hashRouterOutputErrorOnAddBatch:
+					requireNoErrors(t)
+					checkMetadata(t, []string{hashRouterMetadataMsg, addBatchErrMsg})
+				case hashRouterOutputErrorOnNext:
+					// If an error is encountered in Next, it is returned to the caller,
+					// not as metadata by the HashRouter.
+					checkMetadata(t, []string{hashRouterMetadataMsg})
+					numNextErrs := 0
+					for i := range resultsByOp {
+						if err := resultsByOp[i].err; err != nil {
+							require.Contains(t, err.Error(), nextErrMsg)
+							numNextErrs++
+						}
+					}
+					require.GreaterOrEqual(t, numNextErrs, 1, "expected at least one test-induced next error msg")
+				case hashRouterChaos:
+					// Metadata must contain at least the hashRouterMetadataMsg and may
+					// contain metadata from the other cases.
+					require.Equal(t, 1, len(metadataMu.metadata), "one output (the last to exit) should return metadata")
+					matchedHashRouterMetadataMsg := false
+					metadata := metadataMu.metadata[0]
+					for _, meta := range metadata {
+						require.NotNil(t, meta.Err)
+						if strings.Contains(meta.Err.Error(), hashRouterMetadataMsg) {
+							matchedHashRouterMetadataMsg = true
+							continue
+						}
+
+						matched := false
+						for _, errMsg := range []string{
+							context.Canceled.Error(),
+							addBatchErrMsg,
+							nextErrMsg,
+						} {
+							if strings.Contains(meta.Err.Error(), errMsg) {
+								matched = true
+								break
+							}
+						}
+						require.True(t, matched, "unexpected metadata: %v", meta.Err)
+					}
+
+					require.True(t, matchedHashRouterMetadataMsg, "hashRouterChaos metadata must contain hashRouterMetadataMsg")
+				default:
+					t.Fatalf("unhandled terminationScenario: %d", terminationScenario)
 				}
 			})
 		})
@@ -953,10 +1215,7 @@ func BenchmarkHashRouter(b *testing.B) {
 					diskAccounts[i] = &diskAcc
 					defer diskAcc.Close(ctx)
 				}
-				r, outputs := NewHashRouter(
-					allocators, input, typs, []uint32{0}, 64<<20,
-					queueCfg, &colexecbase.TestingSemaphore{}, diskAccounts, nil, /* toClose */
-				)
+				r, outputs := NewHashRouter(allocators, input, typs, []uint32{0}, 64<<20, queueCfg, &colexecbase.TestingSemaphore{}, diskAccounts, nil /* toDrain */, nil /* toClose */)
 				b.SetBytes(8 * int64(coldata.BatchSize()) * int64(numInputBatches))
 				// We expect distribution to not change. This is a sanity check that
 				// we're resetting properly.
@@ -976,6 +1235,7 @@ func BenchmarkHashRouter(b *testing.B) {
 								oBatch := outputs[j].Next(ctx)
 								actualDistribution[j] += oBatch.Length()
 								if oBatch.Length() == 0 {
+									_ = outputs[j].DrainMeta(ctx)
 									break
 								}
 							}

--- a/pkg/sql/colexec/serial_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer_test.go
@@ -17,9 +17,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldatatestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,18 +34,29 @@ func TestSerialUnorderedSynchronizer(t *testing.T) {
 	const numBatches = 4
 
 	typs := []*types.T{types.Int}
-	inputs := make([]colexecbase.Operator, numInputs)
+	inputs := make([]SynchronizerInput, numInputs)
 	for i := range inputs {
 		batch := coldatatestutils.RandomBatch(testAllocator, rng, typs, coldata.BatchSize(), 0 /* length */, rng.Float64())
 		source := colexecbase.NewRepeatableBatchSource(testAllocator, batch, typs)
 		source.ResetBatchesToReturn(numBatches)
-		inputs[i] = source
+		inputIdx := i
+		inputs[i] = SynchronizerInput{
+			Op: source,
+			MetadataSources: []execinfrapb.MetadataSource{
+				execinfrapb.CallbackMetadataSource{
+					DrainMetaCb: func(_ context.Context) []execinfrapb.ProducerMetadata {
+						return []execinfrapb.ProducerMetadata{{Err: errors.Errorf("input %d test-induced metadata", inputIdx)}}
+					},
+				},
+			},
+		}
 	}
-	s := NewSerialUnorderedSynchronizer(inputs, typs)
+	s := NewSerialUnorderedSynchronizer(inputs)
 	resultBatches := 0
 	for {
 		b := s.Next(ctx)
 		if b.Length() == 0 {
+			require.Equal(t, len(inputs), len(s.DrainMeta(ctx)))
 			break
 		}
 		resultBatches++

--- a/pkg/sql/colexec/simple_project_test.go
+++ b/pkg/sql/colexec/simple_project_test.go
@@ -110,7 +110,11 @@ func TestSimpleProjectOpWithUnorderedSynchronizer(t *testing.T) {
 	runTestsWithoutAllNullsInjection(t, inputTuples, [][]*types.T{inputTypes, inputTypes}, expected,
 		unorderedVerifier, func(inputs []colexecbase.Operator) (colexecbase.Operator, error) {
 			var input colexecbase.Operator
-			input = NewParallelUnorderedSynchronizer(inputs, inputTypes, &wg)
+			parallelUnorderedSynchronizerInputs := make([]SynchronizerInput, len(inputs))
+			for i := range parallelUnorderedSynchronizerInputs {
+				parallelUnorderedSynchronizerInputs[i].Op = inputs[i]
+			}
+			input = NewParallelUnorderedSynchronizer(parallelUnorderedSynchronizerInputs, &wg)
 			input = NewSimpleProjectOp(input, len(inputTypes), []uint32{0})
 			return NewConstOp(testAllocator, input, types.Int, constVal, 1)
 		})

--- a/pkg/sql/colexecbase/operator.go
+++ b/pkg/sql/colexecbase/operator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 )
 
 // Operator is a column vector operator that produces a Batch as output.
@@ -44,6 +45,13 @@ type Operator interface {
 	Next(context.Context) coldata.Batch
 
 	execinfra.OpNode
+}
+
+// DrainableOperator is an operator that also implements DrainMeta. Next and
+// DrainMeta may not be called concurrently.
+type DrainableOperator interface {
+	Operator
+	execinfrapb.MetadataSource
 }
 
 // ZeroInputNode is an execinfra.OpNode with no inputs.

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -677,9 +677,8 @@ func (s *vectorizedFlowCreator) setupInput(
 	input execinfrapb.InputSyncSpec,
 	opt flowinfra.FuseOpt,
 	factory coldata.ColumnFactory,
-) (op colexecbase.Operator, _ []execinfrapb.MetadataSource, _ error) {
-	inputStreamOps := make([]colexecbase.Operator, 0, len(input.Streams))
-	metaSources := make([]execinfrapb.MetadataSource, 0, len(input.Streams))
+) (colexecbase.Operator, []execinfrapb.MetadataSource, error) {
+	inputStreamOps := make([]colexec.SynchronizerInput, 0, len(input.Streams))
 	// Before we can safely use types we received over the wire in the
 	// operators, we need to make sure they are hydrated. In row execution
 	// engine it is done during the processor initialization, but operators
@@ -693,8 +692,10 @@ func (s *vectorizedFlowCreator) setupInput(
 		switch inputStream.Type {
 		case execinfrapb.StreamEndpointSpec_LOCAL:
 			in := s.streamIDToInputOp[inputStream.StreamID]
-			inputStreamOps = append(inputStreamOps, in.rootOperator)
-			metaSources = append(metaSources, in.metadataSources...)
+			inputStreamOps = append(inputStreamOps, colexec.SynchronizerInput{
+				Op:              in.rootOperator,
+				MetadataSources: in.metadataSources,
+			})
 		case execinfrapb.StreamEndpointSpec_REMOTE:
 			// If the input is remote, the input operator does not exist in
 			// streamIDToInputOp. Create an inbox.
@@ -709,8 +710,7 @@ func (s *vectorizedFlowCreator) setupInput(
 				return nil, nil, err
 			}
 			s.addStreamEndpoint(inputStream.StreamID, inbox, s.waitGroup)
-			metaSources = append(metaSources, inbox)
-			op = inbox
+			op := colexecbase.Operator(inbox)
 			if s.recordingStats {
 				op, err = s.wrapWithVectorizedStatsCollector(
 					inbox, nil /* inputs */, int32(inputStream.StreamID),
@@ -720,28 +720,34 @@ func (s *vectorizedFlowCreator) setupInput(
 					return nil, nil, err
 				}
 			}
-			inputStreamOps = append(inputStreamOps, op)
+			inputStreamOps = append(inputStreamOps, colexec.SynchronizerInput{Op: op, MetadataSources: []execinfrapb.MetadataSource{inbox}})
 		default:
 			return nil, nil, errors.Errorf("unsupported input stream type %s", inputStream.Type)
 		}
 	}
-	op = inputStreamOps[0]
+	op := inputStreamOps[0].Op
+	metaSources := inputStreamOps[0].MetadataSources
 	if len(inputStreamOps) > 1 {
-		var err error
 		statsInputs := inputStreamOps
 		if input.Type == execinfrapb.InputSyncSpec_ORDERED {
-			op, err = colexec.NewOrderedSynchronizer(
+			os, err := colexec.NewOrderedSynchronizer(
 				colmem.NewAllocator(ctx, s.newStreamingMemAccount(flowCtx), factory),
 				inputStreamOps, input.ColumnTypes, execinfrapb.ConvertToColumnOrdering(input.Ordering),
 			)
 			if err != nil {
 				return nil, nil, err
 			}
+			op = os
+			metaSources = []execinfrapb.MetadataSource{os}
 		} else {
 			if opt == flowinfra.FuseAggressively {
-				op = colexec.NewSerialUnorderedSynchronizer(inputStreamOps, input.ColumnTypes)
+				sync := colexec.NewSerialUnorderedSynchronizer(inputStreamOps)
+				op = sync
+				metaSources = []execinfrapb.MetadataSource{sync}
 			} else {
-				op = colexec.NewParallelUnorderedSynchronizer(inputStreamOps, input.ColumnTypes, s.waitGroup)
+				sync := colexec.NewParallelUnorderedSynchronizer(inputStreamOps, s.waitGroup)
+				op = sync
+				metaSources = []execinfrapb.MetadataSource{sync}
 				s.operatorConcurrency = true
 			}
 			// Don't use the unordered synchronizer's inputs for stats collection
@@ -750,10 +756,15 @@ func (s *vectorizedFlowCreator) setupInput(
 			statsInputs = nil
 		}
 		if s.recordingStats {
+			statsInputsAsOps := make([]colexecbase.Operator, len(statsInputs))
+			for i := range statsInputs {
+				statsInputsAsOps[i] = statsInputs[i].Op
+			}
 			// TODO(asubiotto): Once we have IDs for synchronizers, plumb them into
 			// this stats collector to display stats.
+			var err error
 			op, err = s.wrapWithVectorizedStatsCollector(
-				op, statsInputs, -1 /* id */, "" /* idTagKey */, nil, /* monitors */
+				op, statsInputsAsOps, -1 /* id */, "" /* idTagKey */, nil, /* monitors */
 			)
 			if err != nil {
 				return nil, nil, err

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -614,18 +614,12 @@ func (s *vectorizedFlowCreator) setupRouter(
 		limit = 1
 	}
 	diskMon, diskAccounts := s.createDiskAccounts(ctx, flowCtx, mmName, len(output.Streams))
-	router, outputs := colexec.NewHashRouter(
-		allocators, input, outputTyps, output.HashColumns, limit,
-		s.diskQueueCfg, s.fdSemaphore, diskAccounts, toClose,
-	)
+	router, outputs := colexec.NewHashRouter(allocators, input, outputTyps, output.HashColumns, limit, s.diskQueueCfg, s.fdSemaphore, diskAccounts, metadataSourcesQueue, toClose)
 	runRouter := func(ctx context.Context, _ context.CancelFunc) {
 		logtags.AddTag(ctx, "hashRouterID", mmName)
 		router.Run(ctx)
 	}
 	s.accumulateAsyncComponent(runRouter)
-
-	// Append the router to the metadata sources.
-	metadataSourcesQueue = append(metadataSourcesQueue, router)
 
 	foundLocalOutput := false
 	for i, op := range outputs {
@@ -637,19 +631,20 @@ func (s *vectorizedFlowCreator) setupRouter(
 			// Note that here we pass in nil 'toClose' slice because hash
 			// router is responsible for closing all of the idempotent closers.
 			if _, err := s.setupRemoteOutputStream(
-				ctx, flowCtx, op, outputTyps, stream, metadataSourcesQueue, nil /* toClose */, factory,
+				ctx, flowCtx, op, outputTyps, stream, []execinfrapb.MetadataSource{op}, nil /* toClose */, factory,
 			); err != nil {
 				return err
 			}
 		case execinfrapb.StreamEndpointSpec_LOCAL:
 			foundLocalOutput = true
+			localOp := colexecbase.Operator(op)
 			if s.recordingStats {
 				mons := []*mon.BytesMonitor{hashRouterMemMonitor, diskMon}
 				// Wrap local outputs with vectorized stats collectors when recording
 				// stats. This is mostly for compatibility but will provide some useful
 				// information (e.g. output stall time).
 				var err error
-				op, err = s.wrapWithVectorizedStatsCollector(
+				localOp, err = s.wrapWithVectorizedStatsCollector(
 					op, nil /* inputs */, int32(stream.StreamID),
 					execinfrapb.StreamIDTagKey, mons,
 				)
@@ -658,13 +653,9 @@ func (s *vectorizedFlowCreator) setupRouter(
 				}
 			}
 			s.streamIDToInputOp[stream.StreamID] = opDAGWithMetaSources{
-				rootOperator: op, metadataSources: metadataSourcesQueue, toClose: toClose,
+				rootOperator: localOp, metadataSources: []execinfrapb.MetadataSource{op}, toClose: toClose,
 			}
 		}
-		// Either the metadataSourcesQueue will be drained by an outbox or we
-		// created an opDAGWithMetaSources to pass along these metadataSources. We don't need to
-		// worry about metadata sources for following iterations of the loop.
-		metadataSourcesQueue = nil
 	}
 	if !foundLocalOutput {
 		// No local output means that our router is a leaf node.

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -178,9 +178,32 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					diskAccounts[i] = &diskAcc
 					defer diskAcc.Close(ctxRemote)
 				}
+				createMetadataSourceForID := func(id int) execinfrapb.MetadataSource {
+					return execinfrapb.CallbackMetadataSource{
+						DrainMetaCb: func(ctx context.Context) []execinfrapb.ProducerMetadata {
+							return []execinfrapb.ProducerMetadata{{Err: errors.Errorf("%d", id)}}
+						},
+					}
+				}
+				// The first numHashRouterOutputs streamIDs are allocated to the
+				// outboxes that drain these outputs. The outboxes will drain the router
+				// outputs which should in turn drain the HashRouter that will return
+				// this metadata.
+				toDrain := make([]execinfrapb.MetadataSource, numHashRouterOutputs)
+				for i := range toDrain {
+					toDrain[i] = createMetadataSourceForID(i)
+				}
 				hashRouter, hashRouterOutputs := colexec.NewHashRouter(
-					allocators, hashRouterInput, typs, []uint32{0}, 64<<20, /* 64 MiB */
-					queueCfg, &colexecbase.TestingSemaphore{}, diskAccounts, nil, /* toClose */
+					allocators,
+					hashRouterInput,
+					typs,
+					[]uint32{0},
+					64<<20,
+					queueCfg,
+					&colexecbase.TestingSemaphore{},
+					diskAccounts,
+					toDrain,
+					nil, /* toClose */
 				)
 				for i := 0; i < numInboxes; i++ {
 					inboxMemAccount := testMemMonitor.MakeBoundAccount()
@@ -214,18 +237,15 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					idToClosed.Lock()
 					idToClosed.mapping[id] = false
 					idToClosed.Unlock()
-					outbox, err := colrpc.NewOutbox(colmem.NewAllocator(ctx, outboxMemAcc, testColumnFactory), outboxInput, typs,
-						append(outboxMetadataSources, execinfrapb.CallbackMetadataSource{
-							DrainMetaCb: func(ctx context.Context) []execinfrapb.ProducerMetadata {
-								return []execinfrapb.ProducerMetadata{{Err: errors.Errorf("%d", id)}}
-							},
-						},
-						), []colexec.IdempotentCloser{callbackCloser{closeCb: func() error {
+					outbox, err := colrpc.NewOutbox(
+						colmem.NewAllocator(ctx, outboxMemAcc, testColumnFactory), outboxInput, typs, outboxMetadataSources,
+						[]colexec.IdempotentCloser{callbackCloser{closeCb: func() error {
 							idToClosed.Lock()
 							idToClosed.mapping[id] = true
 							idToClosed.Unlock()
 							return nil
-						}}})
+						}}},
+					)
 
 					require.NoError(t, err)
 					wg.Add(1)
@@ -253,22 +273,17 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					wg.Done()
 				}()
 				for i := 0; i < numInboxes; i++ {
-					var outboxMetadataSources []execinfrapb.MetadataSource
 					outboxMemAccount := testMemMonitor.MakeBoundAccount()
 					defer outboxMemAccount.Close(ctxRemote)
 					if i < numHashRouterOutputs {
-						if i == 0 {
-							// Only one outbox should drain the hash router.
-							outboxMetadataSources = append(outboxMetadataSources, hashRouter)
-						}
-						runOutboxInbox(ctxRemote, cancelRemote, &outboxMemAccount, hashRouterOutputs[i], inboxes[i], streamID, outboxMetadataSources)
+						runOutboxInbox(ctxRemote, cancelRemote, &outboxMemAccount, hashRouterOutputs[i], inboxes[i], streamID, []execinfrapb.MetadataSource{hashRouterOutputs[i]})
 					} else {
 						sourceMemAccount := testMemMonitor.MakeBoundAccount()
 						defer sourceMemAccount.Close(ctxRemote)
 						remoteAllocator := colmem.NewAllocator(ctxRemote, &sourceMemAccount, testColumnFactory)
 						batch := remoteAllocator.NewMemBatch(typs)
 						batch.SetLength(coldata.BatchSize())
-						runOutboxInbox(ctxRemote, cancelRemote, &outboxMemAccount, colexecbase.NewRepeatableBatchSource(remoteAllocator, batch, typs), inboxes[i], streamID, outboxMetadataSources)
+						runOutboxInbox(ctxRemote, cancelRemote, &outboxMemAccount, colexecbase.NewRepeatableBatchSource(remoteAllocator, batch, typs), inboxes[i], streamID, []execinfrapb.MetadataSource{createMetadataSourceForID(streamID)})
 					}
 					streamID++
 				}
@@ -287,7 +302,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					inboxes = append(inboxes, inbox)
 					outboxMemAccount := testMemMonitor.MakeBoundAccount()
 					defer outboxMemAccount.Close(ctxAnotherRemote)
-					runOutboxInbox(ctxAnotherRemote, cancelAnotherRemote, &outboxMemAccount, synchronizer, inbox, streamID, materializerMetadataSources)
+					runOutboxInbox(ctxAnotherRemote, cancelAnotherRemote, &outboxMemAccount, synchronizer, inbox, streamID, append(materializerMetadataSources, createMetadataSourceForID(streamID)))
 					streamID++
 					// There is now only a single Inbox on the "local" node which is the
 					// only metadata source.

--- a/pkg/sql/execinfrapb/data.go
+++ b/pkg/sql/execinfrapb/data.go
@@ -380,9 +380,23 @@ func LocalMetaToRemoteProducerMeta(
 type MetadataSource interface {
 	// DrainMeta returns all the metadata produced by the processor or operator.
 	// It will be called exactly once, usually, when the processor or operator
-	// has finished doing its computations.
+	// has finished doing its computations. This is a signal that the output
+	// requires no more rows to be returned.
 	// Implementers can choose what to do on subsequent calls (if such occur).
 	// TODO(yuzefovich): modify the contract to require returning nil on all
 	// calls after the first one.
 	DrainMeta(context.Context) []ProducerMetadata
+}
+
+// MetadataSources is a slice of MetadataSource.
+type MetadataSources []MetadataSource
+
+// DrainMeta calls DrainMeta on all MetadataSources and returns a single slice
+// with all the accumulated metadata.
+func (s MetadataSources) DrainMeta(ctx context.Context) []ProducerMetadata {
+	var result []ProducerMetadata
+	for _, src := range s {
+		result = append(result, src.DrainMeta(ctx)...)
+	}
+	return result
 }


### PR DESCRIPTION
Downstream operators would previously call DrainMeta on an operator whose Next method was called from a different goroutine, which was safe because the interface contract stipulates that these implementations handle concurrent calls to Next and DrainMeta. However, this led to complicated DrainMeta implementations (see `colrpc/inbox.go` and sometimes incorrect behavior (#48785).

This PR implements the MetadataSource interface in the two components that would create internal goroutines: HashRouter and ParallelUnorderedSynchronizer. Metadata is now safely passed between internal goroutines so that DrainMeta can be called on these components instead of fetching metadata directly from an operator running in another goroutine. This effectively pushes the synchronization overhead to these components, allowing us to simplify the DrainMeta contract and fixing bugs caused by the previous model.

Release note: None

Closes #48785
Fixes #49642 
Fixes #49741 