### PR TITLE
ui: Fix icons aligning for Timeframe navigation buttons

### DIFF
--- a/pkg/ui/src/views/cluster/components/controls/controls.styl
+++ b/pkg/ui/src/views/cluster/components/controls/controls.styl
@@ -47,6 +47,7 @@
       padding 0
       display flex
       justify-content center
+      align-items center
       &:first-child
         margin-left 0px
       &:hover


### PR DESCRIPTION
Resolves: #49862

Time frame navigation buttons had icons which
weren't aligned vertically before.
Now, the content of navigation buttons is centered.

Before:
<img width="1427" alt="overview-before" src="https://user-images.githubusercontent.com/3106437/84146313-302e1780-aa64-11ea-932a-51d1f2d34039.png">
<img width="1421" alt="metrics-before" src="https://user-images.githubusercontent.com/3106437/84146319-33290800-aa64-11ea-875b-6f42d5e29e8d.png">

After:
<img width="1242" alt="metrics-after" src="https://user-images.githubusercontent.com/3106437/84146348-3f14ca00-aa64-11ea-988b-3bd430134322.png">
<img width="1423" alt="overview-after" src="https://user-images.githubusercontent.com/3106437/84146360-4340e780-aa64-11ea-832a-4d0ad8b4d0e2.png">
