### PR TITLE
cli/interactive_tests: remove SIGSEGV as an out of memory signal

### DIFF
--- a/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
+++ b/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
@@ -83,9 +83,6 @@ expect {
     "cannot allocate memory" {}
     "std::bad_alloc" {}
     "Resource temporarily unavailable" {}
-    # TODO(peter): Pebble's behavior is to segfault on failed manual
-    # allocations. We should provide a cleaner signal.
-    "signal SIGSEGV" {}
     timeout { handle_timeout "memory allocation error" }
 }
 # Stop the tail command.


### PR DESCRIPTION
As of #49078, Pebble uses the standard Go "out of memory" panic when
manual memory allocation fails. So we no longer need to consider
`SIGSEGV` as an out of memory signal.

Release note: None