### PR TITLE
importccl: Improve PGCOPY import peformance by using parallelImporter

### DIFF
--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -179,11 +179,13 @@ func makeInputConverter(
 			singleTable, singleTableTargetCols, evalCtx), nil
 	case roachpb.IOFileFormat_MysqlOutfile:
 		return newMysqloutfileReader(
-			spec.Format.MysqlOut, kvCh, spec.WalltimeNanos, int(spec.ReaderParallelism), singleTable, evalCtx)
+			spec.Format.MysqlOut, kvCh, spec.WalltimeNanos,
+			int(spec.ReaderParallelism), singleTable, evalCtx)
 	case roachpb.IOFileFormat_Mysqldump:
 		return newMysqldumpReader(ctx, kvCh, spec.Tables, evalCtx)
 	case roachpb.IOFileFormat_PgCopy:
-		return newPgCopyReader(ctx, kvCh, spec.Format.PgCopy, singleTable, evalCtx)
+		return newPgCopyReader(spec.Format.PgCopy, kvCh, spec.WalltimeNanos,
+			int(spec.ReaderParallelism), singleTable, evalCtx)
 	case roachpb.IOFileFormat_PgDump:
 		return newPgDumpReader(ctx, kvCh, spec.Format.PgDump, spec.Tables, evalCtx)
 	case roachpb.IOFileFormat_Avro:

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -2911,6 +2911,108 @@ func BenchmarkDelimitedConvertRecord(b *testing.B) {
 	b.ReportAllocs()
 }
 
+
+// goos: darwin
+// goarch: amd64
+// pkg: github.com/cockroachdb/cockroach/pkg/ccl/importccl
+// BenchmarkPgCopyConvertRecord-16    	   88598	     13374 ns/op	   8.97 MB/s
+// BenchmarkPgCopyConvertRecord-16    	   88972	     13221 ns/op	   9.08 MB/s
+// BenchmarkPgCopyConvertRecord-16    	   91716	     13242 ns/op	   9.06 MB/s
+// BenchmarkPgCopyConvertRecord-16    	   90674	     13375 ns/op	   8.97 MB/s
+// BenchmarkPgCopyConvertRecord-16    	   89626	     13265 ns/op	   9.05 MB/s
+// BenchmarkPgCopyConvertRecord-16    	   90408	     13303 ns/op	   9.02 MB/s
+// BenchmarkPgCopyConvertRecord-16    	   90818	     13374 ns/op	   8.97 MB/s
+// BenchmarkPgCopyConvertRecord-16    	   90483	     13290 ns/op	   9.03 MB/s
+// BenchmarkPgCopyConvertRecord-16    	   85894	     13447 ns/op	   8.92 MB/s
+// BenchmarkPgCopyConvertRecord-16    	   87988	     13227 ns/op	   9.07 MB/s
+func BenchmarkPgCopyConvertRecord(b *testing.B) {
+	ctx := context.Background()
+
+	tpchLineItemDataRows := [][]string{
+		{"1", "155190", "7706", "1", "17", "21168.23", "0.04", "0.02", "N", "O", "1996-03-13", "1996-02-12", "1996-03-22", "DELIVER IN PERSON", "TRUCK", "egular courts above the"},
+		{"1", "67310", "7311", "2", "36", "45983.16", "0.09", "0.06", "N", "O", "1996-04-12", "1996-02-28", "1996-04-20", "TAKE BACK RETURN", "MAIL", "ly final dependencies: slyly bold "},
+		{"1", "63700", "3701", "3", "8", "13309.60", "0.10", "0.02", "N", "O", "1996-01-29", "1996-03-05", "1996-01-31", "TAKE BACK RETURN", "REG AIR", "riously. regular, express dep"},
+		{"1", "2132", "4633", "4", "28", "28955.64", "0.09", "0.06", "N", "O", "1996-04-21", "1996-03-30", "1996-05-16", "NONE", "AIR", "lites. fluffily even de"},
+		{"1", "24027", "1534", "5", "24", "22824.48", "0.10", "0.04", "N", "O", "1996-03-30", "1996-03-14", "1996-04-01", "NONE", "FOB", " pending foxes. slyly re"},
+		{"1", "15635", "638", "6", "32", "49620.16", "0.07", "0.02", "N", "O", "1996-01-30", "1996-02-07", "1996-02-03", "DELIVER IN PERSON", "MAIL", "arefully slyly ex"},
+		{"2", "106170", "1191", "1", "38", "44694.46", "0.00", "0.05", "N", "O", "1997-01-28", "1997-01-14", "1997-02-02", "TAKE BACK RETURN", "RAIL", "ven requests. deposits breach a"},
+		{"3", "4297", "1798", "1", "45", "54058.05", "0.06", "0.00", "R", "F", "1994-02-02", "1994-01-04", "1994-02-23", "NONE", "AIR", "ongside of the furiously brave acco"},
+		{"3", "19036", "6540", "2", "49", "46796.47", "0.10", "0.00", "R", "F", "1993-11-09", "1993-12-20", "1993-11-24", "TAKE BACK RETURN", "RAIL", " unusual accounts. eve"},
+		{"3", "128449", "3474", "3", "27", "39890.88", "0.06", "0.07", "A", "F", "1994-01-16", "1993-11-22", "1994-01-23", "DELIVER IN PERSON", "SHIP", "nal foxes wake."},
+	}
+	b.SetBytes(120) // Raw input size. With 8 indexes, expect more on output side.
+
+	stmt, err := parser.ParseOne(`CREATE TABLE lineitem (
+		l_orderkey      INT8 NOT NULL,
+		l_partkey       INT8 NOT NULL,
+		l_suppkey       INT8 NOT NULL,
+		l_linenumber    INT8 NOT NULL,
+		l_quantity      DECIMAL(15,2) NOT NULL,
+		l_extendedprice DECIMAL(15,2) NOT NULL,
+		l_discount      DECIMAL(15,2) NOT NULL,
+		l_tax           DECIMAL(15,2) NOT NULL,
+		l_returnflag    CHAR(1) NOT NULL,
+		l_linestatus    CHAR(1) NOT NULL,
+		l_shipdate      DATE NOT NULL,
+		l_commitdate    DATE NOT NULL,
+		l_receiptdate   DATE NOT NULL,
+		l_shipinstruct  CHAR(25) NOT NULL,
+		l_shipmode      CHAR(10) NOT NULL,
+		l_comment       VARCHAR(44) NOT NULL,
+		PRIMARY KEY     (l_orderkey, l_linenumber),
+		INDEX l_ok      (l_orderkey ASC),
+		INDEX l_pk      (l_partkey ASC),
+		INDEX l_sk      (l_suppkey ASC),
+		INDEX l_sd      (l_shipdate ASC),
+		INDEX l_cd      (l_commitdate ASC),
+		INDEX l_rd      (l_receiptdate ASC),
+		INDEX l_pk_sk   (l_partkey ASC, l_suppkey ASC),
+		INDEX l_sk_pk   (l_suppkey ASC, l_partkey ASC)
+	)`)
+	if err != nil {
+		b.Fatal(err)
+	}
+	create := stmt.AST.(*tree.CreateTable)
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+
+	tableDesc, err := MakeSimpleTableDescriptor(ctx, st, create, sqlbase.ID(100), sqlbase.ID(100), NoFKs, 1)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	kvCh := make(chan row.KVBatch)
+	// no-op drain kvs channel.
+	go func() {
+		for range kvCh {
+		}
+	}()
+
+	descr := tableDesc.TableDesc()
+	cols := make(tree.NameList, len(descr.Columns))
+	for i, col := range descr.Columns {
+		cols[i] = tree.Name(col.Name)
+	}
+	r, err := newPgCopyReader(ctx, kvCh, roachpb.PgCopyOptions{
+		Delimiter:   '\t',
+		Null: `\N`,
+		MaxRowSize: 4096,
+	}, descr, &evalCtx)
+	require.NoError(b, err)
+
+	producer := &csvBenchmarkStream{
+		n:    b.N,
+		pos:  0,
+		data: tpchLineItemDataRows,
+	}
+
+	pgCopyInput := &fileReader{Reader: producer}
+	b.ResetTimer()
+	require.NoError(b, r.readFile(ctx,pgCopyInput,0, 0, nil))
+	close(kvCh)
+	b.ReportAllocs()
+}
+
 // TestImportControlJob tests that PAUSE JOB, RESUME JOB, and CANCEL JOB
 // work as intended on import jobs.
 func TestImportControlJob(t *testing.T) {

--- a/pkg/ccl/importccl/read_import_pgcopy.go
+++ b/pkg/ccl/importccl/read_import_pgcopy.go
@@ -18,7 +18,6 @@ import (
 	"unicode"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -32,25 +31,28 @@ import (
 const defaultScanBuffer = 1024 * 1024 * 4
 
 type pgCopyReader struct {
-	conv row.DatumRowConverter
-	opts roachpb.PgCopyOptions
+	importCtx *parallelImportContext
+	opts      roachpb.PgCopyOptions
 }
 
 var _ inputConverter = &pgCopyReader{}
 
 func newPgCopyReader(
-	ctx context.Context,
-	kvCh chan row.KVBatch,
 	opts roachpb.PgCopyOptions,
+	kvCh chan row.KVBatch,
+	walltime int64,
+	parallelism int,
 	tableDesc *sqlbase.TableDescriptor,
 	evalCtx *tree.EvalContext,
 ) (*pgCopyReader, error) {
-	conv, err := row.NewDatumRowConverter(ctx, tableDesc, nil /* targetColNames */, evalCtx, kvCh)
-	if err != nil {
-		return nil, err
-	}
 	return &pgCopyReader{
-		conv: *conv,
+		importCtx: &parallelImportContext{
+			walltime:   walltime,
+			numWorkers: parallelism,
+			evalCtx:    evalCtx,
+			tableDesc:  tableDesc,
+			kvCh:       kvCh,
+		},
 		opts: opts,
 	}, nil
 }
@@ -254,6 +256,83 @@ func (c copyData) String() string {
 	return buf.String()
 }
 
+type pgCopyProducer struct {
+	importCtx  *parallelImportContext
+	opts       *roachpb.PgCopyOptions
+	input      *fileReader
+	copyStream *postgreStreamCopy
+	row        copyData
+	err        error
+}
+
+var _ importRowProducer = &pgCopyProducer{}
+
+// Scan implements importRowProducer
+func (p *pgCopyProducer) Scan() bool {
+	p.row, p.err = p.copyStream.Next()
+	if p.err == io.EOF {
+		p.err = nil
+		return false
+	}
+
+	return p.err == nil
+}
+
+// Err implements importRowProducer
+func (p *pgCopyProducer) Err() error {
+	return p.err
+}
+
+// Skip implements importRowProducer
+func (p *pgCopyProducer) Skip() error {
+	return nil // no-op
+}
+
+// Row implements importRowProducer
+func (p *pgCopyProducer) Row() (interface{}, error) {
+	return p.row, p.err
+}
+
+// Progress implements importRowProducer
+func (p *pgCopyProducer) Progress() float32 {
+	return p.input.ReadFraction()
+}
+
+type pgCopyConsumer struct {
+	opts *roachpb.PgCopyOptions
+}
+
+var _ importRowConsumer = &pgCopyConsumer{}
+
+// FillDatums implements importRowConsumer
+func (p *pgCopyConsumer) FillDatums(
+	row interface{}, rowNum int64, conv *row.DatumRowConverter,
+) error {
+	data := row.(copyData)
+	var err error
+
+	if len(data) != len(conv.VisibleColTypes) {
+		return newImportRowError(fmt.Errorf(
+			"unexpected number of columns, expected %d values, got %d",
+			len(conv.VisibleColTypes), len(data)), data.String(), rowNum)
+	}
+
+	for i, s := range data {
+		if s == nil {
+			conv.Datums[i] = tree.DNull
+		} else {
+			conv.Datums[i], err = sqlbase.ParseDatumStringAs(conv.VisibleColTypes[i], *s, conv.EvalCtx)
+			if err != nil {
+				col := conv.VisibleCols[i]
+				return newImportRowError(fmt.Errorf(
+					"encountered error %s when attempting to parse %q as %s",
+					err.Error(), col.Name, col.Type.SQLString()), data.String(), rowNum)
+			}
+		}
+	}
+	return nil
+}
+
 func (d *pgCopyReader) readFile(
 	ctx context.Context, input *fileReader, inputIdx int32, resumePos int64, rejected chan string,
 ) error {
@@ -265,47 +344,23 @@ func (d *pgCopyReader) readFile(
 		d.opts.Delimiter,
 		d.opts.Null,
 	)
-	d.conv.KvBatch.Source = inputIdx
-	d.conv.FractionFn = input.ReadFraction
-	count := int64(1)
-	d.conv.CompletedRowFn = func() int64 {
-		return count
+
+	producer := &pgCopyProducer{
+		importCtx:  d.importCtx,
+		opts:       &d.opts,
+		input:      input,
+		copyStream: c,
 	}
 
-	for ; ; count++ {
-		row, err := c.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return wrapRowErr(err, "", count, pgcode.Uncategorized, "")
-		}
-
-		if count <= resumePos {
-			continue
-		}
-
-		if len(row) != len(d.conv.VisibleColTypes) {
-			return makeRowErr("", count, pgcode.Syntax,
-				"expected %d values, got %d", len(d.conv.VisibleColTypes), len(row))
-		}
-		for i, s := range row {
-			if s == nil {
-				d.conv.Datums[i] = tree.DNull
-			} else {
-				d.conv.Datums[i], err = sqlbase.ParseDatumStringAs(d.conv.VisibleColTypes[i], *s, d.conv.EvalCtx)
-				if err != nil {
-					col := d.conv.VisibleCols[i]
-					return wrapRowErr(err, "", count, pgcode.Syntax,
-						"parse %q as %s", col.Name, col.Type.SQLString())
-				}
-			}
-		}
-
-		if err := d.conv.Row(ctx, inputIdx, count); err != nil {
-			return wrapRowErr(err, "", count, pgcode.Uncategorized, "")
-		}
+	consumer := &pgCopyConsumer{
+		opts: &d.opts,
 	}
 
-	return d.conv.SendBatch(ctx)
+	fileCtx := &importFileContext{
+		source:   inputIdx,
+		skip:     resumePos,
+		rejected: rejected,
+	}
+
+	return runParallelImport(ctx, d.importCtx, fileCtx, producer, consumer)
 }


### PR DESCRIPTION
This change parallelizes PGCOPY import by switching to the
`parallelImporter` which is currently used by mysqlout, csv and avro
imports.  Benchmark runs show a ~3.5x improvement in performance as a
result of this change.

Release note (performance improvement): PGCOPY import was made ~3.5x
faster by parallelizing the conversion of raw input data to Datums.