### PR TITLE
jobs: fix flakey TestStartableJob

### DIFF
--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -2092,10 +2092,11 @@ func TestStartableJob(t *testing.T) {
 	}
 	t.Run("Start called more than once", func(t *testing.T) {
 		sj := createStartableJob(t)
-		_, err := sj.Start(ctx)
+		errCh, err := sj.Start(ctx)
 		require.NoError(t, err)
 		_, err = sj.Start(ctx)
 		require.Regexp(t, `StartableJob \d+ cannot be started more than once`, err)
+		require.NoError(t, <-errCh)
 	})
 	t.Run("Start called with active txn", func(t *testing.T) {
 		txn := db.NewTxn(ctx, "test")


### PR DESCRIPTION
The test that checks for an error on the second call to `Start` didn't
actually wait for the first call to finish. This meant that under stress
a later subtest may end up injecting a resumer for that test's job rather
than the intended job.

Fixes #48799

Release note: None