### PR TITLE
colexec: use new execgen directives on several colexec boolean templates

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/and_or_projection_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/and_or_projection_gen.go
@@ -36,8 +36,6 @@ func genAndOrProjectionOps(inputFileContents string, wr io.Writer) error {
 	)
 	s := r.Replace(inputFileContents)
 
-	addTupleForRight := makeFunctionRegex("_ADD_TUPLE_FOR_RIGHT", 1)
-	s = addTupleForRight.ReplaceAllString(s, `{{template "addTupleForRight" buildDict "Global" $ "lHasNulls" $1}}`)
 	setValues := makeFunctionRegex("_SET_VALUES", 3)
 	s = setValues.ReplaceAllString(s, `{{template "setValues" buildDict "Global" $ "IsOr" $1 "lHasNulls" $2 "rHasNulls" $3}}`)
 	setSingleValue := makeFunctionRegex("_SET_SINGLE_VALUE", 3)

--- a/pkg/sql/colexec/execgen/cmd/execgen/any_not_null_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/any_not_null_agg_gen.go
@@ -31,9 +31,6 @@ func genAnyNotNullAgg(inputFileContents string, wr io.Writer) error {
 	)
 	s := r.Replace(inputFileContents)
 
-	findAnyNotNull := makeFunctionRegex("_FIND_ANY_NOT_NULL", 4)
-	s = findAnyNotNull.ReplaceAllString(s, `{{template "findAnyNotNull" buildDict "Global" . "HasNulls" $4}}`)
-
 	s = replaceManipulationFuncs(s)
 
 	tmpl, err := template.New("any_not_null_agg").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)

--- a/pkg/sql/colexec/execgen/cmd/execgen/hash_utils_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hash_utils_gen.go
@@ -29,12 +29,9 @@ func genHashUtils(inputFileContents string, wr io.Writer) error {
 	s := r.Replace(inputFileContents)
 
 	assignHash := makeFunctionRegex("_ASSIGN_HASH", 4)
-	s = assignHash.ReplaceAllString(s, makeTemplateFunctionCall("Global.UnaryAssign", 4))
+	s = assignHash.ReplaceAllString(s, makeTemplateFunctionCall("UnaryAssign", 4))
 
-	rehash := makeFunctionRegex("_REHASH_BODY", 8)
-	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "HasSel" $7 "HasNulls" $8}}`)
-
-	s = replaceManipulationFuncsAmbiguous(".Global", s)
+	s = replaceManipulationFuncs(s)
 
 	tmpl, err := template.New("hash_utils").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
 	if err != nil {

--- a/pkg/sql/colexec/execgen/cmd/execgen/hashjoiner_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hashjoiner_gen.go
@@ -20,21 +20,6 @@ const hashJoinerTmpl = "pkg/sql/colexec/hashjoiner_tmpl.go"
 func genHashJoiner(inputFileContents string, wr io.Writer) error {
 	s := inputFileContents
 
-	distinctCollectRightOuter := makeFunctionRegex("_DISTINCT_COLLECT_PROBE_OUTER", 3)
-	s = distinctCollectRightOuter.ReplaceAllString(s, `{{template "distinctCollectProbeOuter" buildDict "Global" . "UseSel" $3}}`)
-
-	distinctCollectNoOuter := makeFunctionRegex("_DISTINCT_COLLECT_PROBE_NO_OUTER", 4)
-	s = distinctCollectNoOuter.ReplaceAllString(s, `{{template "distinctCollectProbeNoOuter" buildDict "Global" . "UseSel" $4}}`)
-
-	collectRightOuter := makeFunctionRegex("_COLLECT_PROBE_OUTER", 5)
-	s = collectRightOuter.ReplaceAllString(s, `{{template "collectProbeOuter" buildDict "Global" . "UseSel" $5}}`)
-
-	collectNoOuter := makeFunctionRegex("_COLLECT_PROBE_NO_OUTER", 5)
-	s = collectNoOuter.ReplaceAllString(s, `{{template "collectProbeNoOuter" buildDict "Global" . "UseSel" $5}}`)
-
-	collectAnti := makeFunctionRegex("_COLLECT_ANTI", 5)
-	s = collectAnti.ReplaceAllString(s, `{{template "collectAnti" buildDict "Global" . "UseSel" $5}}`)
-
 	tmpl, err := template.New("hashjoiner_op").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
 	if err != nil {
 		return err

--- a/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
@@ -120,11 +120,6 @@ func genHashTable(inputFileContents string, wr io.Writer, htm hashTableMode) err
 		`{{template "checkBody" buildDict "Global" . "SelectSameTuples" $1 "DeletingProbeMode" $2}}`,
 	)
 
-	updateSelBody := makeFunctionRegex("_UPDATE_SEL_BODY", 1)
-	s = updateSelBody.ReplaceAllString(s,
-		`{{template "updateSelBody" buildDict "Global" . "UseSel" $1}}`,
-	)
-
 	tmpl, err := template.New("hashtable").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
 	if err != nil {
 		return err

--- a/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
@@ -115,11 +115,6 @@ func genHashTable(inputFileContents string, wr io.Writer, htm hashTableMode) err
 		`{{template "checkColForDistinctWithNulls" buildDict "Global" . "UseProbeSel" $1}}`,
 	)
 
-	checkBody := makeFunctionRegex("_CHECK_BODY", 2)
-	s = checkBody.ReplaceAllString(s,
-		`{{template "checkBody" buildDict "Global" . "SelectSameTuples" $1 "DeletingProbeMode" $2}}`,
-	)
-
 	tmpl, err := template.New("hashtable").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
 	if err != nil {
 		return err

--- a/pkg/sql/colexec/execgen/cmd/execgen/main.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/main.go
@@ -47,6 +47,7 @@ type execgenTool struct {
 
 	// cmdLine stores the set of flags used to invoke the Execgen tool.
 	cmdLine *flag.FlagSet
+	verbose bool
 }
 
 // generator is a func that, given an input file's contents as a string,
@@ -74,6 +75,7 @@ func (g *execgenTool) run(args ...string) bool {
 	g.cmdLine.SetOutput(g.stdErr)
 	g.cmdLine.Usage = g.usage
 	g.cmdLine.BoolVar(&g.useGoFmt, "useGoFmt", true, "run go fmt on generated code")
+	g.cmdLine.BoolVar(&g.verbose, "verbose", false, "print out debug information to stderr")
 	g.cmdLine.BoolVar(&printDeps, "M", false, "print the dependency list")
 	err := g.cmdLine.Parse(args)
 	if err != nil {
@@ -126,10 +128,15 @@ func (g *execgenTool) generate(path string, entry entry) error {
 		if err != nil {
 			return err
 		}
-		// Inline functions with // execgen:inline.
-		inputFileContents, err = execgen.InlineFuncs(string(inputFileBytes))
+		inputFileContents, err = execgen.Generate(string(inputFileBytes))
 		if err != nil {
 			return err
+		}
+		if g.verbose {
+			fmt.Fprintln(os.Stderr, "generated code before text/template runs")
+			fmt.Fprintln(os.Stderr, "-----------------------------------")
+			fmt.Fprintln(os.Stderr, inputFileContents)
+			fmt.Fprintln(os.Stderr, "-----------------------------------")
 		}
 	}
 

--- a/pkg/sql/colexec/execgen/execgen.go
+++ b/pkg/sql/colexec/execgen/execgen.go
@@ -1,0 +1,39 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package execgen
+
+import (
+	"go/parser"
+	"go/token"
+	"strings"
+
+	"github.com/dave/dst/decorator"
+)
+
+// Generate transforms the string contents of an input execgen template by
+// processing all supported // execgen annotations.
+func Generate(inputFileContents string) (string, error) {
+	f, err := decorator.ParseFile(token.NewFileSet(), "", inputFileContents, parser.ParseComments)
+	if err != nil {
+		return "", err
+	}
+
+	// Generate template variants: // execgen:template
+	expandTemplates(f)
+
+	// Inline functions: // execgen:inline
+	inlineFuncs(f)
+
+	// Produce output string.
+	var sb strings.Builder
+	_ = decorator.Fprint(&sb, f)
+	return sb.String(), nil
+}

--- a/pkg/sql/colexec/execgen/inline.go
+++ b/pkg/sql/colexec/execgen/inline.go
@@ -28,7 +28,9 @@ func inlineFuncs(f *dst.File) {
 
 	// Do a second pass over the AST, this time replacing calls to the inlined
 	// functions with the inlined function itself.
+	var funcIdx int
 	dstutil.Apply(f, func(cursor *dstutil.Cursor) bool {
+		cursor.Index()
 		n := cursor.Node()
 		// There are two cases. AssignStmt, which are like:
 		// a = foo()
@@ -119,7 +121,7 @@ func inlineFuncs(f *dst.File) {
 			// Make a copy of the function to inline, and walk through it, replacing
 			// return statements at the end of the body with assignments to the return
 			// value declarations we made first.
-			body = replaceReturnStatements(decl.Name.Name, body, func(stmt *dst.ReturnStmt) dst.Stmt {
+			body = replaceReturnStatements(decl.Name.Name, funcIdx, body, func(stmt *dst.ReturnStmt) dst.Stmt {
 				returnAssignmentSpecs := make([]dst.Stmt, len(retValNames))
 				for i := range retValNames {
 					returnAssignmentSpecs[i] = &dst.AssignStmt{
@@ -171,12 +173,15 @@ func inlineFuncs(f *dst.File) {
 
 			// Remove return values if there are any, since we're ignoring returns
 			// as a raw function call.
-			body = replaceReturnStatements(decl.Name.Name, body, nil)
+			body = replaceReturnStatements(decl.Name.Name, funcIdx, body, nil)
 			// Add the inlined function body to the block.
 			funcBlock.List = append(funcBlock.List, body.List...)
 
 			cursor.Replace(funcBlock)
+		default:
+			return true
 		}
+		funcIdx++
 		return true
 	}, nil)
 }
@@ -333,17 +338,34 @@ func getFormalParamReassignments(decl *dst.FuncDecl, callExpr *dst.CallExpr) dst
 // It will panic if any return statements are not in the final position of the
 // input block.
 func replaceReturnStatements(
-	funcName string, stmt *dst.BlockStmt, returnModifier func(*dst.ReturnStmt) dst.Stmt,
+	funcName string, funcIdx int, stmt *dst.BlockStmt, returnModifier func(*dst.ReturnStmt) dst.Stmt,
 ) *dst.BlockStmt {
-	// Remove return values if there are any, since we're ignoring returns
-	// as a raw function call.
-	var seenReturn bool
-	return dstutil.Apply(stmt, func(cursor *dstutil.Cursor) bool {
-		if seenReturn {
-			panic(fmt.Errorf("can't inline function %s: return not at end of body (found %s)", funcName, cursor.Node()))
-		}
+	if len(stmt.List) == 0 {
+		return stmt
+	}
+	// Insert an explicit return at the end if there isn't one.
+	// We'll need to edit this later to make early returns work properly.
+	lastStmt := stmt.List[len(stmt.List)-1]
+	if _, ok := lastStmt.(*dst.ReturnStmt); !ok {
+		ret := &dst.ReturnStmt{}
+		stmt.List = append(stmt.List, ret)
+		lastStmt = ret
+	}
+	retStmt := lastStmt.(*dst.ReturnStmt)
+	if returnModifier == nil {
+		stmt.List[len(stmt.List)-1] = &dst.EmptyStmt{}
+	} else {
+		stmt.List[len(stmt.List)-1] = returnModifier(retStmt)
+	}
+
+	label := dst.NewIdent(fmt.Sprintf("%s_return_%d", funcName, funcIdx))
+
+	// Find returns that weren't at the end of the function and replace them with
+	// labeled gotos.
+	var foundInlineReturn bool
+	stmt = dstutil.Apply(stmt, func(cursor *dstutil.Cursor) bool {
 		n := cursor.Node()
-		switch t := n.(type) {
+		switch n := n.(type) {
 		case *dst.FuncLit:
 			// A FuncLit is a function literal, like:
 			// x := func() int { return 3 }
@@ -351,16 +373,31 @@ func replaceReturnStatements(
 			// they contain aren't relevant to the inliner.
 			return false
 		case *dst.ReturnStmt:
-			seenReturn = true
-			if returnModifier == nil {
-				cursor.Delete()
-				return false
+			foundInlineReturn = true
+			gotoStmt := &dst.BranchStmt{
+				Tok:   token.GOTO,
+				Label: dst.Clone(label).(*dst.Ident),
 			}
-			cursor.Replace(returnModifier(t))
+			if returnModifier != nil {
+				cursor.Replace(returnModifier(n))
+				cursor.InsertAfter(gotoStmt)
+			} else {
+				cursor.Replace(gotoStmt)
+			}
 			return false
 		}
 		return true
 	}, nil).(*dst.BlockStmt)
+
+	if foundInlineReturn {
+		// Add the label at the end.
+		stmt.List = append(stmt.List,
+			&dst.LabeledStmt{
+				Label: label,
+				Stmt:  &dst.EmptyStmt{Implicit: true},
+			})
+	}
+	return stmt
 }
 
 // getInlinedFunc returns the corresponding FuncDecl for a CallExpr from the

--- a/pkg/sql/colexec/execgen/inline.go
+++ b/pkg/sql/colexec/execgen/inline.go
@@ -11,34 +11,24 @@
 package execgen
 
 import (
-	"bytes"
 	"fmt"
-	"go/parser"
 	"go/token"
 
 	"github.com/cockroachdb/errors"
 	"github.com/dave/dst"
-	"github.com/dave/dst/decorator"
 	"github.com/dave/dst/dstutil"
 )
 
-// InlineFuncs takes an input file's contents and inlines all functions
+// inlineFuncs takes an input file's contents and inlines all functions
 // annotated with // execgen:inline into their callsites via AST manipulation.
-func InlineFuncs(inputFileContents string) (string, error) {
-	f, err := decorator.ParseFile(token.NewFileSet(), "", inputFileContents, parser.ParseComments)
-	if err != nil {
-		return "", err
-	}
-
-	templateFuncMap := make(map[string]*dst.FuncDecl)
-
+func inlineFuncs(f *dst.File) {
 	// First, run over the input file, searching for functions that are annotated
 	// with execgen:inline.
-	n := extractInlineFuncDecls(f, templateFuncMap)
+	inlineFuncMap := extractInlineFuncDecls(f)
 
 	// Do a second pass over the AST, this time replacing calls to the inlined
 	// functions with the inlined function itself.
-	dstutil.Apply(n, func(cursor *dstutil.Cursor) bool {
+	dstutil.Apply(f, func(cursor *dstutil.Cursor) bool {
 		n := cursor.Node()
 		// There are two cases. AssignStmt, which are like:
 		// a = foo()
@@ -54,8 +44,8 @@ func InlineFuncs(inputFileContents string) (string, error) {
 			if !ok {
 				return true
 			}
-			decl := getTemplateFunc(templateFuncMap, callExpr)
-			if decl == nil {
+			funcInfo := getInlinedFunc(inlineFuncMap, callExpr)
+			if funcInfo == nil {
 				return true
 			}
 			if len(n.Rhs) > 1 {
@@ -88,6 +78,7 @@ func InlineFuncs(inputFileContents string) (string, error) {
 			// Now we've got a callExpr. We need to inline the function call, and
 			// convert the result into the assignment variable.
 
+			decl := funcInfo.decl
 			// Produce declarations for each return value of the function to inline.
 			retValDeclStmt, retValNames := extractReturnValues(decl)
 			// inlinedStatements is a BlockStmt (a set of statements within curly
@@ -122,12 +113,12 @@ func InlineFuncs(inputFileContents string) (string, error) {
 			inlinedStatements := &dst.BlockStmt{
 				List: []dst.Stmt{retValDeclStmt},
 			}
+			body := dst.Clone(decl.Body).(*dst.BlockStmt)
 
 			// Replace return statements with assignments to the return values.
 			// Make a copy of the function to inline, and walk through it, replacing
 			// return statements at the end of the body with assignments to the return
 			// value declarations we made first.
-			body := dst.Clone(decl.Body).(*dst.BlockStmt)
 			body = replaceReturnStatements(decl.Name.Name, body, func(stmt *dst.ReturnStmt) dst.Stmt {
 				returnAssignmentSpecs := make([]dst.Stmt, len(retValNames))
 				for i := range retValNames {
@@ -162,10 +153,11 @@ func InlineFuncs(inputFileContents string) (string, error) {
 			if !ok {
 				return true
 			}
-			decl := getTemplateFunc(templateFuncMap, callExpr)
-			if decl == nil {
+			funcInfo := getInlinedFunc(inlineFuncMap, callExpr)
+			if funcInfo == nil {
 				return true
 			}
+			decl := funcInfo.decl
 
 			reassignments := getFormalParamReassignments(decl, callExpr)
 
@@ -187,17 +179,14 @@ func InlineFuncs(inputFileContents string) (string, error) {
 		}
 		return true
 	}, nil)
-
-	b := bytes.Buffer{}
-	_ = decorator.Fprint(&b, f)
-	return b.String(), nil
 }
 
 // extractInlineFuncDecls searches the input file for functions that are
 // annotated with execgen:inline, extracts them into templateFuncMap, and
 // deletes them from the AST.
-func extractInlineFuncDecls(f *dst.File, templateFuncMap map[string]*dst.FuncDecl) dst.Node {
-	return dstutil.Apply(f, func(cursor *dstutil.Cursor) bool {
+func extractInlineFuncDecls(f *dst.File) map[string]funcInfo {
+	ret := make(map[string]funcInfo)
+	dstutil.Apply(f, func(cursor *dstutil.Cursor) bool {
 		n := cursor.Node()
 		switch n := n.(type) {
 		case *dst.FuncDecl:
@@ -205,7 +194,6 @@ func extractInlineFuncDecls(f *dst.File, templateFuncMap map[string]*dst.FuncDec
 			for _, dec := range n.Decorations().Start.All() {
 				if dec == "// execgen:inline" {
 					mustInline = true
-					break
 				}
 			}
 			if !mustInline {
@@ -214,11 +202,18 @@ func extractInlineFuncDecls(f *dst.File, templateFuncMap map[string]*dst.FuncDec
 			}
 			for _, p := range n.Type.Params.List {
 				if len(p.Names) > 1 {
+					// If we have a definition like this:
+					// func a (a, b int) int
+					// We're just giving up for now out of complete laziness.
 					panic("can't currently deal with multiple names per type in decls")
 				}
 			}
+
+			var info funcInfo
+			info.decl = dst.Clone(n).(*dst.FuncDecl)
 			// Store the function in a map.
-			templateFuncMap[n.Name.Name] = n
+			ret[n.Name.Name] = info
+
 			// Replace the function textually with a fake constant, such as:
 			// `const _ = "inlined_blahFunc"`. We do this instead
 			// of completely deleting it to prevent "important comments" above the
@@ -246,6 +241,7 @@ func extractInlineFuncDecls(f *dst.File, templateFuncMap map[string]*dst.FuncDec
 		}
 		return true
 	}, nil)
+	return ret
 }
 
 // extractReturnValues generates return value variables. It will produce one
@@ -367,23 +363,24 @@ func replaceReturnStatements(
 	}, nil).(*dst.BlockStmt)
 }
 
-// getTemplateFunc returns the corresponding FuncDecl for a CallExpr from the
+// getInlinedFunc returns the corresponding FuncDecl for a CallExpr from the
 // map, using the CallExpr's name to look up the FuncDecl from templateFuncs.
-func getTemplateFunc(templateFuncs map[string]*dst.FuncDecl, n *dst.CallExpr) *dst.FuncDecl {
+func getInlinedFunc(templateFuncs map[string]funcInfo, n *dst.CallExpr) *funcInfo {
 	ident, ok := n.Fun.(*dst.Ident)
 	if !ok {
 		return nil
 	}
 
-	decl, ok := templateFuncs[ident.Name]
+	info, ok := templateFuncs[ident.Name]
 	if !ok {
 		return nil
 	}
-	if decl.Type.Params.NumFields() != len(n.Args) {
+	decl := info.decl
+	if decl.Type.Params.NumFields()+len(info.templateParams) != len(n.Args) {
 		panic(errors.Newf(
 			"%s expected %d arguments, found %d",
 			decl.Name, decl.Type.Params.NumFields(), len(n.Args)),
 		)
 	}
-	return decl
+	return &info
 }

--- a/pkg/sql/colexec/execgen/template.go
+++ b/pkg/sql/colexec/execgen/template.go
@@ -1,0 +1,360 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package execgen
+
+import (
+	"fmt"
+	"go/token"
+	"regexp"
+	"strings"
+
+	"github.com/dave/dst"
+	"github.com/dave/dst/dstutil"
+)
+
+type templateParamInfo struct {
+	fieldOrdinal int
+	field        *dst.Field
+}
+
+type funcInfo struct {
+	decl           *dst.FuncDecl
+	templateParams []templateParamInfo
+}
+
+// Match // execgen:template<foo, bar>
+var templateRe = regexp.MustCompile(`\/\/ execgen:template<((?:(?:\w+),?\W*)+)>`)
+
+// replaceTemplateVars removes the template arguments from a callsite of a
+// templated function. It returns the template arguments that were used, and a
+// new CallExpr that doesn't have the template arguments.
+func replaceTemplateVars(
+	info *funcInfo, call *dst.CallExpr,
+) (templateArgs []dst.Expr, newCall *dst.CallExpr) {
+	if len(info.templateParams) == 0 {
+		return nil, call
+	}
+	templateArgs = make([]dst.Expr, len(info.templateParams))
+	// Collect template arguments.
+	for i, param := range info.templateParams {
+		templateArgs[i] = dst.Clone(call.Args[param.fieldOrdinal]).(dst.Expr)
+	}
+	// Remove template vars from callsite.
+	newArgs := make([]dst.Expr, 0, len(call.Args)-len(info.templateParams))
+	for i := range call.Args {
+		skip := false
+		for _, p := range info.templateParams {
+			if p.fieldOrdinal == i {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			newArgs = append(newArgs, call.Args[i])
+		}
+	}
+	ret := dst.Clone(call).(*dst.CallExpr)
+	ret.Args = newArgs
+	return templateArgs, ret
+}
+
+// monomorphizeTemplate produces a variant of the input function body, given the
+// definition of the function in funcInfo, and the concrete, template-time values
+// that the function is being invoked with. It will try to find conditional
+// statements that use the template variables and output only the branches that
+// match.
+//
+// Currently, this only works on booleans :)
+//
+// For example, given the function:
+// // execgen:inline
+// // execgen:template<t>
+// func b(t bool) int {
+//   if t {
+//     x = 3
+//   } else {
+//     x = 4
+//   }
+//   return x
+// }
+//
+// and a caller
+//   b(true)
+// this function will generate
+//   x = 3
+//   return x
+func monomorphizeTemplate(n dst.Node, info *funcInfo, args []dst.Expr) dst.Node {
+	return dstutil.Apply(n, func(cursor *dstutil.Cursor) bool {
+		n := cursor.Node()
+		switch n := n.(type) {
+		case *dst.IfStmt:
+			switch c := n.Cond.(type) {
+			case *dst.Ident:
+				for i, p := range info.templateParams {
+					if ident, ok := p.field.Type.(*dst.Ident); !ok || ident.Name != "bool" {
+						// Can only template bool types right now.
+						continue
+					}
+					if c.Name == p.field.Names[0].Name {
+						if ident, ok := args[i].(*dst.Ident); ok {
+							if ident.Name == "true" {
+								newBody := monomorphizeTemplate(n.Body, info, args).(*dst.BlockStmt)
+								for _, stmt := range newBody.List {
+									cursor.InsertBefore(stmt)
+								}
+								cursor.Delete()
+								return true
+							} else if n.Else != nil {
+								newElse := monomorphizeTemplate(n.Else, info, args)
+								switch e := newElse.(type) {
+								case *dst.BlockStmt:
+									for _, stmt := range e.List {
+										cursor.InsertBefore(stmt)
+									}
+									cursor.Delete()
+								default:
+									cursor.Replace(newElse)
+								}
+								return true
+							} else {
+								cursor.Delete()
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return true
+	}, nil)
+}
+
+// createTemplateFuncVariants, given an AST, finds all functions annotated with
+// execgen:template<foo,bar>, and produces all of the necessary variants for
+// every combination of possible values for the type of each template argument.
+//
+// For example, given a template function:
+//
+// // execgen:template<b>
+// func foo (a int, b bool) {
+//   if b {
+//     return a
+//   } else {
+//     return a + 1
+//   }
+// }
+//
+// This function will add 2 new func decls to the AST:
+//
+// func foo_true(a int) {
+//   return a
+// }
+//
+// func foo_false(a int) {
+//   return a + 1
+// }
+func createTemplateFuncVariants(f *dst.File) map[string]*funcInfo {
+	ret := make(map[string]*funcInfo)
+
+	dstutil.Apply(f, func(cursor *dstutil.Cursor) bool {
+		n := cursor.Node()
+		switch n := n.(type) {
+		case *dst.FuncDecl:
+			var templateVars []string
+			var templateDecPosition int
+			for i, dec := range n.Decorations().Start.All() {
+				if matches := templateRe.FindStringSubmatch(dec); matches != nil {
+					match := matches[1]
+					// Match now looks like foo, bar
+					templateVars = strings.Split(match, ",")
+					for i, v := range templateVars {
+						templateVars[i] = strings.TrimSpace(v)
+					}
+					templateDecPosition = i
+					break
+				}
+			}
+			if templateVars == nil {
+				return false
+			}
+			// Remove the template decoration.
+			n.Decs.Start = append(
+				n.Decs.Start[:templateDecPosition],
+				n.Decs.Start[templateDecPosition+1:]...)
+
+			// Process template funcs: find template params from runtime definition
+			// and save in funcInfo.
+			info := &funcInfo{}
+			for _, v := range templateVars {
+				var found bool
+				for i, f := range n.Type.Params.List {
+					// We can safely 0-index here because fields always have at least
+					// one name, and we've already banned the case where they have more
+					// than one. (e.g. func a (a int, b int, c, d int))
+					if f.Names[0].Name == v {
+						if ident, ok := f.Type.(*dst.Ident); !ok || ident.Name != "bool" {
+							panic("can't currently handle non-boolean template variables :)")
+						}
+						info.templateParams = append(info.templateParams, templateParamInfo{
+							fieldOrdinal: i,
+							field:        dst.Clone(f).(*dst.Field),
+						})
+						found = true
+						break
+					}
+				}
+				if !found {
+					panic(fmt.Errorf("template var %s not found", v))
+				}
+			}
+			info.decl = n
+
+			// Delete template params from runtime definition.
+			newParamList := make([]*dst.Field, 0, len(n.Type.Params.List)-len(info.templateParams))
+			for i, field := range n.Type.Params.List {
+				var skip bool
+				for _, p := range info.templateParams {
+					if i == p.fieldOrdinal {
+						skip = true
+						break
+					}
+				}
+				if !skip {
+					newParamList = append(newParamList, field)
+				}
+			}
+			n.Type.Params.List = newParamList
+
+			// Now, make variants for every possible combination of allowed values of
+			// the template variables.
+			argsPossibilities := generateAllTemplateArgs(info.templateParams)
+
+			funcDecs := info.decl.Decs
+			// Replace the template function with a const marker, just so we can keep
+			// the comments above the template function available.
+			cursor.InsertBefore(&dst.GenDecl{
+				Tok: token.CONST,
+				Specs: []dst.Spec{
+					&dst.ValueSpec{
+						Names: []*dst.Ident{dst.NewIdent("_")},
+						Values: []dst.Expr{
+							&dst.BasicLit{
+								Kind:  token.STRING,
+								Value: fmt.Sprintf(`"template_%s"`, n.Name.Name),
+							},
+						},
+					},
+				},
+				Decs: dst.GenDeclDecorations{
+					NodeDecs: funcDecs.NodeDecs,
+				},
+			})
+
+			// Extract the remaining execgen directives.
+			directives := make([]string, 0)
+			for _, s := range funcDecs.Start {
+				if strings.HasPrefix(s, "// execgen") {
+					directives = append(directives, s)
+				}
+			}
+
+			for _, args := range argsPossibilities {
+				newBody := monomorphizeTemplate(dst.Clone(n.Body).(*dst.BlockStmt), info, args).(*dst.BlockStmt)
+				newName := getTemplateVariantName(info, args)
+				cursor.InsertAfter(&dst.FuncDecl{
+					Name: newName,
+					Type: dst.Clone(info.decl.Type).(*dst.FuncType),
+					Body: newBody,
+					Decs: dst.FuncDeclDecorations{
+						NodeDecs: dst.NodeDecs{
+							Before: dst.EmptyLine,
+							Start:  directives,
+						},
+					},
+				})
+			}
+			ret[info.decl.Name.Name] = info
+			cursor.Delete()
+			return false
+		}
+
+		return true
+	}, nil)
+	return ret
+}
+
+func getTemplateVariantName(info *funcInfo, args []dst.Expr) *dst.Ident {
+	var newName strings.Builder
+	newName.WriteString(info.decl.Name.Name)
+	for j := range args {
+		newName.WriteByte('_')
+		newName.WriteString(prettyPrintExprs(args[j]))
+	}
+	return dst.NewIdent(newName.String())
+}
+
+// generateAllTemplateArgs returns every possible combination of values for the
+// list of parameter types passed in.
+func generateAllTemplateArgs(paramInfos []templateParamInfo) [][]dst.Expr {
+	if len(paramInfos) == 0 {
+		return [][]dst.Expr{nil}
+	}
+	if ident, ok := paramInfos[0].field.Type.(*dst.Ident); !ok || ident.Name != "bool" {
+		panic("can't deal with non-boolean template arguments right now")
+	}
+
+	inner := generateAllTemplateArgs(paramInfos[:len(paramInfos)-1])
+
+	result := make([][]dst.Expr, 0)
+	for _, b := range []bool{true, false} {
+		for _, s := range inner {
+			// s here should be the list of possible arguments of the first n-1 types.
+			s = append(s[:], dst.NewIdent(fmt.Sprintf("%t", b)))
+			result = append(result, s)
+		}
+	}
+
+	return result
+}
+
+// replaceTemplateCallSites finds all CallExprs in the input AST that are calling
+// the functions that had been annotated with // execgen:template that are
+// passed in via the templateFuncInfos map.
+func replaceTemplateCallSites(f *dst.File, templateFuncInfos map[string]*funcInfo) dst.Node {
+	return dstutil.Apply(f, func(cursor *dstutil.Cursor) bool {
+		n := cursor.Node()
+		switch n := n.(type) {
+		case *dst.CallExpr:
+			ident, ok := n.Fun.(*dst.Ident)
+			if !ok {
+				return true
+			}
+			info, ok := templateFuncInfos[ident.Name]
+			if !ok {
+				// Nothing to do, it's not a templated function.
+				return true
+			}
+			templateArgs, newCall := replaceTemplateVars(info, n)
+			newCall.Fun = getTemplateVariantName(info, templateArgs)
+			cursor.Replace(newCall)
+			return false
+		}
+		return true
+	}, nil)
+}
+
+// expandTemplates is the main entry point to the templater. Given a dst.File,
+// it modifies the dst.File to include all expanded template functions, and
+// edits call sites to call the newly expanded functions.
+func expandTemplates(f *dst.File) {
+	funcInfos := createTemplateFuncVariants(f)
+	replaceTemplateCallSites(f, funcInfos)
+}

--- a/pkg/sql/colexec/execgen/template_test.go
+++ b/pkg/sql/colexec/execgen/template_test.go
@@ -1,0 +1,41 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package execgen
+
+import (
+	"testing"
+
+	"github.com/dave/dst"
+)
+
+func TestGenerateAllTemplateArgs(t *testing.T) {
+	params := make([]templateParamInfo, 3)
+	for i := range params {
+		params[i] = templateParamInfo{
+			field: &dst.Field{Type: dst.NewIdent("bool")},
+		}
+	}
+
+	res := generateAllTemplateArgs(params)
+
+	argsMap := map[string]struct{}{}
+	for _, args := range res {
+		argsStr := prettyPrintExprs(args...)
+		if _, ok := argsMap[argsStr]; ok {
+			t.Fatalf("duplicate template args %s", argsStr)
+		}
+		argsMap[argsStr] = struct{}{}
+	}
+
+	if len(res) != 8 {
+		t.Fatalf("wrong number of template arg set, expected 8, found %d", len(res))
+	}
+}

--- a/pkg/sql/colexec/execgen/testdata/inline
+++ b/pkg/sql/colexec/execgen/testdata/inline
@@ -89,6 +89,10 @@ func b(a int, b int, c int) (int, int) {
 package main
 
 func a() {
+	var (
+		ret1 int
+		ret2 int
+	)
 	{
 		var (
 			__retval_0 int
@@ -105,11 +109,15 @@ func a() {
 				__retval_1 = c
 			}
 		}
-		ret1, ret2 := __retval_0, __retval_1
+		ret1, ret2 = __retval_0, __retval_1
 	}
 }
 
 func c() {
+	var (
+		ret3 int
+		ret4 int
+	)
 	{
 		var (
 			__retval_0 int
@@ -126,7 +134,7 @@ func c() {
 				__retval_1 = c
 			}
 		}
-		ret3, ret4 := __retval_0, __retval_1
+		ret3, ret4 = __retval_0, __retval_1
 	}
 }
 

--- a/pkg/sql/colexec/execgen/testdata/inline
+++ b/pkg/sql/colexec/execgen/testdata/inline
@@ -152,3 +152,61 @@ func d() {
 const _ = "inlined_b"
 ----
 ----
+
+# Test early returns.
+inline
+package main
+
+func a() {
+  b()
+  x = b()
+}
+
+// execgen:inline
+func b() int {
+  foo = bar
+  if foo {
+      return 2
+  }
+  foo = false
+  return 3
+}
+----
+----
+package main
+
+func a() {
+	{
+		foo = bar
+		if foo {
+			goto b_return_0
+		}
+		foo = false
+	b_return_0:
+		;
+	}
+	{
+		var __retval_0 int
+		{
+			foo = bar
+			if foo {
+				{
+					__retval_0 = 2
+				}
+				goto b_return_1
+			}
+			foo = false
+			{
+				__retval_0 = 3
+			}
+		b_return_1:
+			;
+		}
+		x = __retval_0
+	}
+}
+
+// execgen:inline
+const _ = "inlined_b"
+----
+----

--- a/pkg/sql/colexec/execgen/testdata/template
+++ b/pkg/sql/colexec/execgen/testdata/template
@@ -1,0 +1,110 @@
+template
+package main
+
+func a() {
+  x := b(true)
+  x = b(false)
+}
+
+
+// execgen:template<t>
+func b(t bool) int {
+  if t {
+    x = 3
+  } else {
+    x = 4
+  }
+  return x
+}
+----
+----
+package main
+
+func a() {
+	x := b_true()
+	x = b_false()
+}
+
+const _ = "template_b"
+
+func b_false() int {
+	x = 4
+	return x
+}
+
+func b_true() int {
+	x = 3
+	return x
+}
+----
+----
+
+template
+package main
+
+func a() {
+  x := b(3, true, true)
+  x = b(6, true, false)
+  b(4, false, true)
+  b(5, false, false)
+}
+
+
+// execgen:inline
+// execgen:template<t, u>
+func b(a int, t bool, u bool) int {
+  var x int
+  if t {
+    x = 3
+  } else {
+    x = 4
+    if u {
+      x += 1
+    }
+  }
+  return x
+}
+----
+----
+package main
+
+func a() {
+	x := b_true_true(3)
+	x = b_true_false(6)
+	b_false_true(4)
+	b_false_false(5)
+}
+
+// execgen:inline
+const _ = "template_b"
+
+// execgen:inline
+func b_false_false(a int) int {
+	var x int
+	x = 4
+	return x
+}
+
+// execgen:inline
+func b_true_false(a int) int {
+	var x int
+	x = 3
+	return x
+}
+
+// execgen:inline
+func b_false_true(a int) int {
+	var x int
+	x = 4
+	x += 1
+	return x
+}
+
+// execgen:inline
+func b_true_true(a int) int {
+	var x int
+	x = 3
+	return x
+}
+----
+----

--- a/pkg/sql/colexec/execgen/util.go
+++ b/pkg/sql/colexec/execgen/util.go
@@ -1,0 +1,54 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package execgen
+
+import (
+	"strings"
+
+	"github.com/dave/dst"
+	"github.com/dave/dst/decorator"
+)
+
+func prettyPrintStmts(stmts ...dst.Stmt) string {
+	if len(stmts) == 0 {
+		return ""
+	}
+	f := &dst.File{
+		Name: dst.NewIdent("main"),
+		Decls: []dst.Decl{
+			&dst.FuncDecl{
+				Name: dst.NewIdent("test"),
+				Type: &dst.FuncType{},
+				Body: &dst.BlockStmt{
+					List: stmts,
+				},
+			},
+		},
+	}
+	var ret strings.Builder
+	_ = decorator.Fprint(&ret, f)
+	prelude := `package main
+
+func test() {
+`
+	postlude := `}
+`
+	s := ret.String()
+	return strings.TrimSpace(s[len(prelude) : len(s)-len(postlude)])
+}
+
+func prettyPrintExprs(exprs ...dst.Expr) string {
+	stmts := make([]dst.Stmt, len(exprs))
+	for i := range exprs {
+		stmts[i] = &dst.ExprStmt{X: exprs[i]}
+	}
+	return prettyPrintStmts(stmts...)
+}

--- a/pkg/sql/colexec/execgen/util_test.go
+++ b/pkg/sql/colexec/execgen/util_test.go
@@ -12,39 +12,10 @@ package execgen
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/dave/dst"
 	"github.com/dave/dst/decorator"
 )
-
-func prettyPrintStmts(stmts ...dst.Stmt) string {
-	if len(stmts) == 0 {
-		return ""
-	}
-	f := &dst.File{
-		Name: dst.NewIdent("main"),
-		Decls: []dst.Decl{
-			&dst.FuncDecl{
-				Name: dst.NewIdent("test"),
-				Type: &dst.FuncType{},
-				Body: &dst.BlockStmt{
-					List: stmts,
-				},
-			},
-		},
-	}
-	var ret strings.Builder
-	_ = decorator.Fprint(&ret, f)
-	prelude := `package main
-
-func test() {
-`
-	postlude := `}
-`
-	s := ret.String()
-	return strings.TrimSpace(s[len(prelude) : len(s)-len(postlude)])
-}
 
 func parseStmts(stmts string) []dst.Stmt {
 	inputStr := fmt.Sprintf(`package main

--- a/pkg/sql/colexec/hashjoiner_tmpl.go
+++ b/pkg/sql/colexec/hashjoiner_tmpl.go
@@ -24,17 +24,17 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
-// {{/*
-
-func _COLLECT_PROBE_OUTER(
-	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, _USE_SEL bool,
-) int { // */}}
-	// {{define "collectProbeOuter" -}}
+// execgen:inline
+// execgen:template<useSel>
+func collectProbeOuter(
+	hj *hashJoiner, sel []int, batchSize int, batch coldata.Batch, useSel bool,
+) int {
+	var nResults int
 	// Early bounds checks.
 	_ = hj.ht.probeScratch.headID[batchSize-1]
-	// {{if .UseSel}}
-	_ = sel[batchSize-1]
-	// {{end}}
+	if useSel {
+		_ = sel[batchSize-1]
+	}
 	for i := hj.probeState.prevBatchResumeIdx; i < batchSize; i++ {
 		currentID := hj.ht.probeScratch.headID[i]
 
@@ -55,11 +55,11 @@ func _COLLECT_PROBE_OUTER(
 				// without paying attention to probeRowUnmatched.
 				hj.probeState.buildIdx[nResults] = 0
 			}
-			// {{if .UseSel}}
-			hj.probeState.probeIdx[nResults] = sel[i]
-			// {{else}}
-			hj.probeState.probeIdx[nResults] = i
-			// {{end}}
+			if useSel {
+				hj.probeState.probeIdx[nResults] = sel[i]
+			} else {
+				hj.probeState.probeIdx[nResults] = i
+			}
 			currentID = hj.ht.same[currentID]
 			hj.ht.probeScratch.headID[i] = currentID
 			nResults++
@@ -69,21 +69,21 @@ func _COLLECT_PROBE_OUTER(
 			}
 		}
 	}
-	// {{end}}
-	// {{/*
-	// Dummy return value that is never used.
-	return 0
+
+	return nResults
 }
 
-func _COLLECT_PROBE_NO_OUTER(
-	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, _USE_SEL bool,
-) int { // */}}
-	// {{define "collectProbeNoOuter" -}}
+// execgen:inline
+// execgen:template<useSel>
+func collectProbeNoOuter(
+	hj *hashJoiner, sel []int, batchSize int, batch coldata.Batch, useSel bool,
+) int {
+	var nResults int
 	// Early bounds checks.
 	_ = hj.ht.probeScratch.headID[batchSize-1]
-	// {{if .UseSel}}
-	_ = sel[batchSize-1]
-	// {{end}}
+	if useSel {
+		_ = sel[batchSize-1]
+	}
 	for i := hj.probeState.prevBatchResumeIdx; i < batchSize; i++ {
 		currentID := hj.ht.probeScratch.headID[i]
 		for currentID != 0 {
@@ -94,63 +94,59 @@ func _COLLECT_PROBE_NO_OUTER(
 			}
 
 			hj.probeState.buildIdx[nResults] = int(currentID - 1)
-			// {{if .UseSel}}
-			hj.probeState.probeIdx[nResults] = sel[i]
-			// {{else}}
-			hj.probeState.probeIdx[nResults] = i
-			// {{end}}
+			if useSel {
+				hj.probeState.probeIdx[nResults] = sel[i]
+			} else {
+				hj.probeState.probeIdx[nResults] = i
+			}
 			currentID = hj.ht.same[currentID]
 			hj.ht.probeScratch.headID[i] = currentID
 			nResults++
 		}
 	}
-	// {{end}}
-	// {{/*
-	// Dummy return value that is never used.
-	return 0
+	return nResults
 }
 
 // This code snippet collects the "matches" for LEFT ANTI and EXCEPT ALL joins.
 // "Matches" are in quotes because we're actually interested in non-matches
 // from the left side.
-func _COLLECT_ANTI(
-	hj *hashJoiner, batchSize int, nResults int, batch coldata.Batch, _USE_SEL bool,
-) int { // */}}
-	// {{define "collectAnti" -}}
+// execgen:inline
+// execgen:template<useSel>
+func collectAnti(
+	hj *hashJoiner, sel []int, batchSize int, nResults int, batch coldata.Batch, useSel bool,
+) int {
 	// Early bounds checks.
 	_ = hj.ht.probeScratch.headID[batchSize-1]
-	// {{if .UseSel}}
-	_ = sel[batchSize-1]
-	// {{end}}
+	if useSel {
+		_ = sel[batchSize-1]
+	}
 	for i := int(0); i < batchSize; i++ {
 		currentID := hj.ht.probeScratch.headID[i]
 		if currentID == 0 {
 			// currentID of 0 indicates that ith probing row didn't have a match, so
 			// we include it into the output.
-			// {{if .UseSel}}
-			hj.probeState.probeIdx[nResults] = sel[i]
-			// {{else}}
-			hj.probeState.probeIdx[nResults] = i
-			// {{end}}
+			if useSel {
+				hj.probeState.probeIdx[nResults] = sel[i]
+			} else {
+				hj.probeState.probeIdx[nResults] = i
+			}
 			nResults++
 		}
 	}
-	// {{end}}
-	// {{/*
-	// Dummy return value that is never used.
-	return 0
+	return nResults
 }
 
-func _DISTINCT_COLLECT_PROBE_OUTER(hj *hashJoiner, batchSize int, _USE_SEL bool) { // */}}
-	// {{define "distinctCollectProbeOuter" -}}
+// execgen:inline
+// execgen:template<useSel>
+func distinctCollectProbeOuter(hj *hashJoiner, sel []int, batchSize int, useSel bool) {
 	// Early bounds checks.
 	_ = hj.ht.probeScratch.groupID[batchSize-1]
 	_ = hj.probeState.probeRowUnmatched[batchSize-1]
 	_ = hj.probeState.buildIdx[batchSize-1]
 	_ = hj.probeState.probeIdx[batchSize-1]
-	// {{if .UseSel}}
-	_ = sel[batchSize-1]
-	// {{end}}
+	if useSel {
+		_ = sel[batchSize-1]
+	}
 	for i := int(0); i < batchSize; i++ {
 		// Index of keys and outputs in the hash table is calculated as ID - 1.
 		id := hj.ht.probeScratch.groupID[i]
@@ -159,69 +155,66 @@ func _DISTINCT_COLLECT_PROBE_OUTER(hj *hashJoiner, batchSize int, _USE_SEL bool)
 		if !rowUnmatched {
 			hj.probeState.buildIdx[i] = int(id - 1)
 		}
-		// {{if .UseSel}}
-		hj.probeState.probeIdx[i] = sel[i]
-		// {{else}}
-		hj.probeState.probeIdx[i] = i
-		// {{end}}
+		if useSel {
+			hj.probeState.probeIdx[i] = sel[i]
+		} else {
+			hj.probeState.probeIdx[i] = i
+		}
 	}
-	// {{end}}
-	// {{/*
 }
 
-func _DISTINCT_COLLECT_PROBE_NO_OUTER(hj *hashJoiner, batchSize int, nResults int, _USE_SEL bool) { // */}}
-	// {{define "distinctCollectProbeNoOuter" -}}
+// execgen:inline
+// execgen:template<useSel>
+func distinctCollectProbeNoOuter(hj *hashJoiner, sel []int, batchSize int, useSel bool) int {
+	var nResults int
 	// Early bounds checks.
 	_ = hj.ht.probeScratch.groupID[batchSize-1]
 	_ = hj.probeState.buildIdx[batchSize-1]
 	_ = hj.probeState.probeIdx[batchSize-1]
-	// {{if .UseSel}}
-	_ = sel[batchSize-1]
-	// {{end}}
+	if useSel {
+		_ = sel[batchSize-1]
+	}
 	for i := int(0); i < batchSize; i++ {
 		if hj.ht.probeScratch.groupID[i] != 0 {
 			// Index of keys and outputs in the hash table is calculated as ID - 1.
 			hj.probeState.buildIdx[nResults] = int(hj.ht.probeScratch.groupID[i] - 1)
-			// {{if .UseSel}}
-			hj.probeState.probeIdx[nResults] = sel[i]
-			// {{else}}
-			hj.probeState.probeIdx[nResults] = i
-			// {{end}}
+			if useSel {
+				hj.probeState.probeIdx[nResults] = sel[i]
+			} else {
+				hj.probeState.probeIdx[nResults] = i
+			}
 			nResults++
 		}
 	}
-	// {{end}}
-	// {{/*
+	return nResults
 }
-
-// */}}
 
 // collect prepares the buildIdx and probeIdx arrays where the buildIdx and
 // probeIdx at each index are joined to make an output row. The total number of
 // resulting rows is returned.
 func (hj *hashJoiner) collect(batch coldata.Batch, batchSize int, sel []int) int {
-	nResults := int(0)
+	var nResults int
 
 	if hj.spec.left.outer {
 		if sel != nil {
-			_COLLECT_PROBE_OUTER(hj, batchSize, nResults, batch, true)
+			nResults = collectProbeOuter(hj, sel, batchSize, batch, true)
 		} else {
-			_COLLECT_PROBE_OUTER(hj, batchSize, nResults, batch, false)
+			nResults = collectProbeOuter(hj, sel, batchSize, batch, false)
 		}
 	} else {
 		if sel != nil {
 			switch hj.spec.joinType {
 			case sqlbase.LeftAntiJoin, sqlbase.ExceptAllJoin:
-				_COLLECT_ANTI(hj, batchSize, nResults, batch, true)
+				nResults = collectAnti(hj, sel, batchSize, nResults, batch, true)
 			default:
-				_COLLECT_PROBE_NO_OUTER(hj, batchSize, nResults, batch, true)
+				nResults = collectProbeNoOuter(hj, sel, batchSize, batch, true)
 			}
 		} else {
 			switch hj.spec.joinType {
 			case sqlbase.LeftAntiJoin, sqlbase.ExceptAllJoin:
-				_COLLECT_ANTI(hj, batchSize, nResults, batch, false)
+				nResults = collectAnti(hj, sel, batchSize, nResults, batch, false)
 			default:
-				_COLLECT_PROBE_NO_OUTER(hj, batchSize, nResults, batch, false)
+				nResults = collectProbeNoOuter(hj, sel, batchSize, batch, false)
 			}
 		}
 	}
@@ -233,15 +226,15 @@ func (hj *hashJoiner) collect(batch coldata.Batch, batchSize int, sel []int) int
 // row index for each probe row is given in the groupID slice. This function
 // requires assumes a N-1 hash join.
 func (hj *hashJoiner) distinctCollect(batch coldata.Batch, batchSize int, sel []int) int {
-	nResults := int(0)
+	var nResults int
 
 	if hj.spec.left.outer {
 		nResults = batchSize
 
 		if sel != nil {
-			_DISTINCT_COLLECT_PROBE_OUTER(hj, batchSize, true)
+			distinctCollectProbeOuter(hj, sel, batchSize, true)
 		} else {
-			_DISTINCT_COLLECT_PROBE_OUTER(hj, batchSize, false)
+			distinctCollectProbeOuter(hj, sel, batchSize, false)
 		}
 	} else {
 		if sel != nil {
@@ -250,9 +243,9 @@ func (hj *hashJoiner) distinctCollect(batch coldata.Batch, batchSize int, sel []
 				// {{/* For LEFT ANTI and EXCEPT ALL joins we don't care whether the build
 				// (right) side was distinct, so we only have single variation of COLLECT
 				// method. */}}
-				_COLLECT_ANTI(hj, batchSize, nResults, batch, true)
+				nResults = collectAnti(hj, sel, batchSize, nResults, batch, true)
 			default:
-				_DISTINCT_COLLECT_PROBE_NO_OUTER(hj, batchSize, nResults, true)
+				nResults = distinctCollectProbeNoOuter(hj, sel, batchSize, true)
 			}
 		} else {
 			switch hj.spec.joinType {
@@ -260,12 +253,11 @@ func (hj *hashJoiner) distinctCollect(batch coldata.Batch, batchSize int, sel []
 				// {{/* For LEFT ANTI and EXCEPT ALL joins we don't care whether the build
 				// (right) side was distinct, so we only have single variation of COLLECT
 				// method. */}}
-				_COLLECT_ANTI(hj, batchSize, nResults, batch, false)
+				nResults = collectAnti(hj, sel, batchSize, nResults, batch, false)
 			default:
-				_DISTINCT_COLLECT_PROBE_NO_OUTER(hj, batchSize, nResults, false)
+				nResults = distinctCollectProbeNoOuter(hj, sel, batchSize, false)
 			}
 		}
 	}
-
 	return nResults
 }


### PR DESCRIPTION
Based on #49939.

This PR uses the new // execgen:template and // execgen:inline directives on a bunch of colexec templates that need boolean templating.