### PR TITLE
opt: adds partialidx package for testing predicate implication

### DIFF
--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -230,6 +230,22 @@ func (n *FiltersExpr) Deduplicate() {
 	*n = dedup
 }
 
+// RemoveFiltersItem returns a new list that is a copy of the given list, except
+// that it does not contain the given FiltersItem. If the list contains the item
+// multiple times, then only the first instance is removed. If the list does not
+// contain the item, then the method panics.
+func (n FiltersExpr) RemoveFiltersItem(search *FiltersItem) FiltersExpr {
+	newFilters := make(FiltersExpr, len(n)-1)
+	for i := range n {
+		if search == &n[i] {
+			copy(newFilters, n[:i])
+			copy(newFilters[i:], n[i+1:])
+			return newFilters
+		}
+	}
+	panic(errors.AssertionFailedf("item to remove is not in the list: %v", search))
+}
+
 // RemoveCommonFilters removes the filters found in other from n.
 func (n *FiltersExpr) RemoveCommonFilters(other FiltersExpr) {
 	// TODO(ridwanmsharif): Faster intersection using a map

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -628,15 +628,7 @@ func (c *CustomFuncs) ConcatFilters(left, right memo.FiltersExpr) memo.FiltersEx
 func (c *CustomFuncs) RemoveFiltersItem(
 	filters memo.FiltersExpr, search *memo.FiltersItem,
 ) memo.FiltersExpr {
-	newFilters := make(memo.FiltersExpr, len(filters)-1)
-	for i := range filters {
-		if search == &filters[i] {
-			copy(newFilters, filters[:i])
-			copy(newFilters[i:], filters[i+1:])
-			return newFilters
-		}
-	}
-	panic(errors.AssertionFailedf("item to remove is not in the list: %v", search))
+	return filters.RemoveFiltersItem(search)
 }
 
 // ReplaceFiltersItem returns a new list that is a copy of the given list,

--- a/pkg/sql/opt/partialidx/predicate.go
+++ b/pkg/sql/opt/partialidx/predicate.go
@@ -1,0 +1,66 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package partialidx
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+)
+
+// FiltersImplyPredicate attempts to prove that a partial index predicate is
+// implied by the given filters. If implication is proven, the function returns
+// the remaining filters that don't match the predicate expression and true. If
+// implication cannot be proven, nil and false are returned. Note that this
+// "proof" of implication is not mathematically formal or rigorous. For the sake
+// of efficiency and reduced complexity this proof is a best-effort attempt and
+// false-negatives are possible.
+//
+// The remaining filters are identical to the input filters except that any
+// parts that exactly match the predicate expression are removed. When the
+// remaining filters are applied on top of a scan of a partial index with the
+// given predicate, the resulting expression is equivalent to the original
+// expression. This reduces the complexity of the filters and allows any columns
+// that are referenced only in the filters to be pruned from the query plan.
+//
+// If implication is proven, the input filters cannot always be reduced. As an
+// example, the filter "a > 10" implies the predicate "a > 5", but the filter
+// must remain in order to further filter out values between 6 and 10 that would
+// be returned from a partial index scan.
+//
+// The logic for testing implication of ScalarExprs with conjunctions,
+// disjunctions, and atoms (anything that is not an AND or OR) is the same as
+// Postgres's predtest library.
+//
+// The logic is as follows, where "=>" means "implies":
+//
+//   atom A => atom B iff:          A contains B
+//   atom A => AND-expr B iff:      A => each of B's children
+//   atom A => OR-expr B iff:       A => any of B's children
+//
+//   AND-expr A => atom B iff:      any of A's children => B
+//   AND-expr A => AND-expr B iff:  A => each of B's children
+//   AND-expr A => OR-expr B iff:   A => any of B's children OR
+//                                   any of A's children => B
+//
+//   OR-expr A => atom B iff:       each of A's children => B
+//   OR-expr A => AND-expr B iff:   A => each of B's children
+//   OR-expr A => OR-expr B iff:    each of A's children => any of B's children
+//
+// TODO(mgartner): Implement more advanced proofs for implication. We only
+// support simple "atom => atom" and "AND-expr => atom" currently.
+func FiltersImplyPredicate(filters memo.FiltersExpr, pred opt.ScalarExpr) (memo.FiltersExpr, bool) {
+	for i := range filters {
+		if pred == filters[i].Condition {
+			return filters.RemoveFiltersItem(&filters[i]), true
+		}
+	}
+	return nil, false
+}

--- a/pkg/sql/opt/partialidx/testdata/predicate/exact-atom
+++ b/pkg/sql/opt/partialidx/testdata/predicate/exact-atom
@@ -1,0 +1,95 @@
+# Tests for filters that contain expressions that exactly match atom
+# predicates.
+
+# Booleans
+
+predtest vars=(bool)
+@1
+=>
+@1
+----
+true
+└── remaining filters: none
+
+predtest vars=(bool)
+NOT @1
+=>
+@1
+----
+false
+
+# Equalities
+
+predtest vars=(string)
+@1 = 'foo'
+=>
+@1 = 'foo'
+----
+true
+└── remaining filters: none
+
+predtest vars=(string)
+@1 = 'foo'
+=>
+@1 = 'bar'
+----
+false
+
+# Inequalities
+
+predtest vars=(int)
+@1 > 10
+=>
+@1 > 10
+----
+true
+└── remaining filters: none
+
+predtest vars=(int)
+@1 > 10
+=>
+@1 > 15
+----
+false
+
+# IN expressions
+
+predtest vars=(int)
+@1 IN (1, 2, 3)
+=>
+@1 IN (1, 2, 3)
+----
+true
+└── remaining filters: none
+
+predtest vars=(int)
+@1 IN (1, 2, 3)
+=>
+@1 IN (1, 2)
+----
+false
+
+# Conjunctions
+
+predtest vars=(bool, int)
+@1 AND @2 > 20
+=>
+@1
+----
+true
+└── remaining filters: @2 > 20
+
+predtest vars=(bool, int)
+@1 AND @2 > 20
+=>
+@2 > 20
+----
+true
+└── remaining filters: @1
+
+predtest vars=(bool, int)
+@1 AND @2 > 15
+=>
+@2 > 20
+----
+false


### PR DESCRIPTION
This commit adds a new package, `partialidx`, and a function
`FiltersImplyPredicate` which is responsible for determining if a
`FiltersExpr` implies a partial index's predicate `ScalarExpr`.

For now, the logic for proving implication is very simple. It can only
prove implication when a single `FiltersItem` is an exact match to the
predicate. In predicate implication nomenclature, this means that it
only supports `atom => atom` when the atoms are identical and `AND-expr
=> atom` when the `AND-expr` is at the root of the filters and one of
its children is identical to the atom. (An atom is any expression that
is not an AND or OR).

Release note: None