### PR TITLE
logictest: remove 3node-tenant blocklist from some tests

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -43,7 +43,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -2400,7 +2399,9 @@ CREATE TABLE crdb_internal.zones (
 `,
 	populate: func(ctx context.Context, p *planner, _ *sqlbase.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		if !p.ExecCfg().Codec.ForSystemTenant() {
-			return errorutil.UnsupportedWithMultiTenancy()
+			// Don't try to populate crdb_internal.zones if running in a multitenant
+			// configuration.
+			return nil
 		}
 
 		namespace, err := p.getAllNames(ctx)

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 subtest other
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/alias_types
+++ b/pkg/sql/logictest/testdata/logic_test/alias_types
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 statement ok
 CREATE TABLE aliases (
     a OID,

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 # A basic sanity check to demonstrate column type changes.
 subtest SanityCheck
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 
 statement ok
 CREATE TABLE other (b INT PRIMARY KEY)

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 # pg arrays must preserve control characters when converted to string,
 # but their direct representation as string does not escape the
 # control characters. In order for the test file to remain valid

--- a/pkg/sql/logictest/testdata/logic_test/bit
+++ b/pkg/sql/logictest/testdata/logic_test/bit
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 query TTT
 SELECT B'1000101'::BIT(4)::STRING,
        B'1000101'::BIT(4),

--- a/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
+++ b/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 # Case sensitivity of database names
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 #### column CHECK constraints
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 statement error pq: invalid locale bad_locale: language: subtag "locale" is well-formed but unknown
 SELECT 'a' COLLATE bad_locale
 

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 statement ok
 CREATE TABLE with_no_column_refs (
   a INT,

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 statement ok
 CREATE TABLE stock (item, quantity) AS VALUES ('cups', 10), ('plates', 15), ('forks', 30)
 

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 statement ok
 CREATE TABLE t (
   a INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 subtest regression_42858
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 statement ok
 SET experimental_enable_hash_sharded_indexes = true
 

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 statement error pgcode 42P01 relation "kv" does not exist
 INSERT INTO kv VALUES ('a', 'b')
 

--- a/pkg/sql/logictest/testdata/logic_test/int_size
+++ b/pkg/sql/logictest/testdata/logic_test/int_size
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 subtest defaults
 
 query T

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 statement ok
 CREATE TABLE t (
   a INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/name_escapes
+++ b/pkg/sql/logictest/testdata/logic_test/name_escapes
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 # Check that the various things in a table definition are properly escaped when
 # printed out.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/ordinality
+++ b/pkg/sql/logictest/testdata/logic_test/ordinality
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 query TI colnames
 SELECT * FROM (VALUES ('a'), ('b')) WITH ORDINALITY AS x(name, i)
 ----

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 #### Partial Indexes
 
 # TODO(mgartner): remove this once partial indexes are fully supported.

--- a/pkg/sql/logictest/testdata/logic_test/partial_txn_commit
+++ b/pkg/sql/logictest/testdata/logic_test/partial_txn_commit
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 # This test exercises the presence of an explanatory hint when a transaction
 # ends up partially committed and partially aborted.
 

--- a/pkg/sql/logictest/testdata/logic_test/privileges_table
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_table
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 # Disable automatic stats to avoid flakiness.
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false

--- a/pkg/sql/logictest/testdata/logic_test/rename_constraint
+++ b/pkg/sql/logictest/testdata/logic_test/rename_constraint
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 statement ok
 CREATE TABLE t (
   x INT, y INT,

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_retry
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_retry
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 # This test reproduces https://github.com/cockroachdb/cockroach/issues/23979
 
 # Schema changes that experienced retriable errors in RELEASE

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 # see also files `drop_sequence`, `alter_sequence`, `rename_sequence`
 
 # USING THE `lastval` FUNCTION

--- a/pkg/sql/logictest/testdata/logic_test/serial
+++ b/pkg/sql/logictest/testdata/logic_test/serial
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 subtest serial_rowid
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/show_create
+++ b/pkg/sql/logictest/testdata/logic_test/show_create
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 statement ok
 CREATE TABLE c (
 	a INT NOT NULL,

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 # Tests for subqueries (SELECT statements which are part of a bigger statement).
 
 query I

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 statement ok
 SET DATABASE = ""
 

--- a/pkg/sql/logictest/testdata/logic_test/tenant_unsupported
+++ b/pkg/sql/logictest/testdata/logic_test/tenant_unsupported
@@ -68,8 +68,10 @@ SELECT * FROM crdb_internal.kv_node_status
 
 # Cannot manipulate zone configurations
 
-statement error operation is unsupported
+# Selecting from crdb_internal.zones is allowed but no data is returned.
+query IITTTTTTTTTTT
 SELECT * FROM crdb_internal.zones
+----
 
 statement error operation is unsupported
 SHOW ZONE CONFIGURATION FOR TABLE kv

--- a/pkg/sql/logictest/testdata/logic_test/truncate
+++ b/pkg/sql/logictest/testdata/logic_test/truncate
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 subtest strict
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1,4 +1,3 @@
-# LogicTest: !3node-tenant
 # NOTE: Keep this table at the beginning of the file to ensure that its numeric
 #       reference is 53 (the numeric reference of the first table). If the
 #       numbering scheme in cockroach changes, this test will break.


### PR DESCRIPTION
The big change here is returning nil in `crdb_internal.zones.populate`. It makes sense to me to do so in the spirit of making zone configs "optional" for phase 2 (#49445) although I'm not 100% sure this won't break anything.