### PR TITLE
Script for the MakeAndPublishBuild TC build configuration

### DIFF
--- a/build/release/teamcity-compile-and-publish-prerelease-build.sh
+++ b/build/release/teamcity-compile-and-publish-prerelease-build.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-echo "Implement me!"
-

--- a/build/release/teamcity-make-and-publish-build.sh
+++ b/build/release/teamcity-make-and-publish-build.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+source "$(dirname "${0}")/teamcity-support.sh"
+
+tc_start_block "Variable Setup"
+export BUILDER_HIDE_GOPATH_SRC=1
+
+build/builder.sh make .buildinfo/tag
+build_name="${TAG_NAME:-$(cat .buildinfo/tag)}"
+release_branch="$(echo "$build_name" | grep -Eo "^v[0-9]+\.[0-9]+")"
+
+bucket="${BUCKET-cockroach-builds}"
+
+google_credentials=$GOOGLE_COCKROACH_CLOUD_IMAGES_CREDENTIALS
+tc_end_block "Variable Setup"
+
+
+tc_start_block "Tag the release"
+git tag "$build_name"
+tc_end_block "Tag the release"
+
+
+tc_start_block "Compile publish-provisional-artifacts"
+build/builder.sh go install ./pkg/cmd/publish-provisional-artifacts
+tc_end_block "Compile publish-provisional-artifacts"
+
+
+tc_start_block "Compile and publish S3 artifacts"
+build/builder.sh env \
+  AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+  AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+  TC_BUILD_BRANCH="$build_name" \
+  publish-provisional-artifacts -provisional -release -bucket "$bucket"
+tc_end_block "Compile and publish S3 artifacts"
+
+
+tc_start_block "Make and push docker image"
+configure_docker_creds
+
+gcr_hostname="us.gcr.io"
+docker_login_with_google
+
+gcr_repository="us.gcr.io/cockroach-cloud-images/cockroach"
+
+# TODO: update publish-provisional-artifacts with option to leave one or more cockroach binaries in the local filesystem
+curl -f -s -S -o- "https://${bucket}.s3.amazonaws.com/cockroach-${build_name}.linux-amd64.tgz" | tar xfz - --strip-components 1
+cp cockroach build/deploy/cockroach
+
+docker build --no-cache --tag="${gcr_repository}:${build_name}" build/deploy
+docker push "${gcr_repository}:${build_name}"
+tc_end_block "Make and push docker image"
+
+
+tc_start_block "Push release tag to github.com/cockroachdb/cockroach"
+github_ssh_key="${GITHUB_COCKROACH_TEAMCITY_PRIVATE_SSH_KEY}"
+configure_git_ssh_key
+push_to_git ssh://git@github.com/cockroachlabs/release-staging.git "$build_name"
+tc_end_block "Push release tag to github.com/cockroachdb/cockroach"
+
+
+tc_start_block "Tag docker image as latest-build"
+# Only tag the image as "latest-vX.Y-build" if the tag is on a release branch
+# (or master for the alphas for the next major release).
+if [[ -n "${release_branch}" ]] ; then
+  log_into_gcloud
+  gcloud container images add-tag "${gcr_repository}:${build_name}" "${gcr_repository}:latest-${release_branch}-build"
+fi
+tc_end_block "Tag docker image as latest-build"

--- a/build/release/teamcity-support.sh
+++ b/build/release/teamcity-support.sh
@@ -1,12 +1,10 @@
 # Common helpers for teamcity-*.sh scripts.
 
-# root is the absolute path to the root directory of the repository.
-root=$(cd "$(dirname "$0")/.." && pwd)
-
-run() {
-  echo "$@"
-  "$@"
+remove_files_on_exit() {
+  rm .google-credentials.json
+  rm .cockroach-teamcity-key
 }
+trap remove_files_on_exit EXIT
 
 tc_start_block() {
   echo "##teamcity[blockOpened name='$1']"
@@ -14,4 +12,52 @@ tc_start_block() {
 
 tc_end_block() {
   echo "##teamcity[blockClosed name='$1']"
+}
+
+log_into_gcloud() {
+  if [[ "${google_credentials}" ]]; then
+    echo "${google_credentials}" > .google-credentials.json
+    gcloud auth activate-service-account --key-file=.google-credentials.json
+  else
+    echo 'warning: `google_credentials` not set' >&2
+  fi
+}
+
+docker_login_with_google() {
+  # https://cloud.google.com/container-registry/docs/advanced-authentication#json-key
+  echo "${google_credentials}" | docker login -u _json_key --password-stdin "https://${gcr_hostname}"
+}
+
+docker_login() {
+  echo "${DOCKER_AUTH}" | docker login --username "${DOCKER_ID}" --password-stdin
+}
+
+configure_docker_creds() {
+  # Work around headless d-bus problem by forcing docker to use
+  # plain-text credentials for dockerhub.
+  # https://github.com/docker/docker-credential-helpers/issues/105#issuecomment-420480401
+  mkdir -p ~/.docker
+  cat << EOF > ~/.docker/config.json
+{
+  "credsStore" : "",
+  "auths": {
+    "https://index.docker.io/v1/" : {
+    }
+  }
+}
+EOF
+}
+
+configure_git_ssh_key() {
+  # Write a private key file and populate known_hosts
+  touch .cockroach-teamcity-key
+  chmod 600 .cockroach-teamcity-key
+  echo "${github_ssh_key}" > .cockroach-teamcity-key
+
+  mkdir -p "$HOME/.ssh"
+  ssh-keyscan github.com > "$HOME/.ssh/known_hosts"
+}
+
+push_to_git() {
+  GIT_SSH_COMMAND="ssh -i .cockroach-teamcity-key" git push $1 $2
 }


### PR DESCRIPTION
Before: the script wasn't implemented.

Now:

Part of the new release process, this script:

- tags the selected SHA to the contents of `.buildinfo/tag`
- compiles the binaries and archive and uploads them to S3 as the tagged
  name
- makes and uploads the docker image to our internal GCR repository
- pushes the git tag to the cockroachlabs/release-staging repo
- pushes the latest-vX.Y-build docker image tag to GCR

Release note: None