### PR TITLE
kvclient: assert against nonsensical protections on range mismatch err

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -945,10 +945,25 @@ func TestEvictCacheOnError(t *testing.T) {
 	// Currently lease holder and cached range descriptor are treated equally.
 	// TODO(bdarnell): refactor to cover different types of retryable errors.
 	const errString = "boom"
-	testDesc := roachpb.RangeDescriptor{
-		RangeID:  1,
-		StartKey: testMetaEndKey,
-		EndKey:   roachpb.RKeyMax,
+
+	// One of the subtests returns a RangeKeyMismatchError simulating the request
+	// falling on the lhs after a split, whereas the request wanted the rhs.
+	splitKey := roachpb.RKey("a")
+	lhs := roachpb.RangeDescriptor{
+		RangeID:  testUserRangeDescriptor.RangeID,
+		StartKey: testUserRangeDescriptor.StartKey,
+		EndKey:   splitKey,
+		InternalReplicas: []roachpb.ReplicaDescriptor{
+			{
+				NodeID:  1,
+				StoreID: 1,
+			},
+		},
+	}
+	rhs := roachpb.RangeDescriptor{
+		RangeID:  testUserRangeDescriptor.RangeID,
+		StartKey: splitKey,
+		EndKey:   testUserRangeDescriptor.EndKey,
 		InternalReplicas: []roachpb.ReplicaDescriptor{
 			{
 				NodeID:  1,
@@ -963,11 +978,14 @@ func TestEvictCacheOnError(t *testing.T) {
 		shouldClearLeaseHolder bool
 		shouldClearReplica     bool
 	}{
-		{false, errors.New(errString), false, false},                                     // non-retryable replica error
-		{false, &roachpb.RangeKeyMismatchError{MismatchedRange: testDesc}, false, false}, // RangeKeyMismatch replica error
-		{false, &roachpb.RangeNotFoundError{}, false, false},                             // RangeNotFound replica error
-		{false, nil, false, false},                                                       // RPC error
-		{true, nil, false, false},                                                        // canceled context
+		{false, errors.New(errString), false, false}, // non-retryable replica error
+		{false, &roachpb.RangeKeyMismatchError{
+			MismatchedRange: lhs,
+			SuggestedRange:  &rhs,
+		}, false, false}, // RangeKeyMismatch replica error
+		{false, &roachpb.RangeNotFoundError{}, false, false}, // RangeNotFound replica error
+		{false, nil, false, false},                           // RPC error
+		{true, nil, false, false},                            // canceled context
 	}
 
 	for i, tc := range testCases {
@@ -1021,7 +1039,7 @@ func TestEvictCacheOnError(t *testing.T) {
 			}
 			ds := NewDistSender(cfg, g)
 			ds.leaseHolderCache.Update(context.Background(), 1, leaseHolder.StoreID)
-			key := roachpb.Key("a")
+			key := roachpb.Key("b")
 			put := roachpb.NewPut(key, roachpb.MakeValueFromString("value"))
 
 			if _, pErr := kv.SendWrapped(ctx, ds, put); pErr != nil && !testutils.IsPError(pErr, errString) && !testutils.IsError(pErr.GoError(), ctx.Err().Error()) {

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -971,68 +971,70 @@ func TestEvictCacheOnError(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		stopper := stop.NewStopper()
-		defer stopper.Stop(context.Background())
+		t.Run("", func(t *testing.T) {
+			stopper := stop.NewStopper()
+			defer stopper.Stop(context.Background())
 
-		clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-		rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
-		g := makeGossip(t, stopper, rpcContext)
-		leaseHolder := roachpb.ReplicaDescriptor{
-			NodeID:  99,
-			StoreID: 999,
-		}
-		first := true
-
-		ctx, cancel := context.WithCancel(context.Background())
-
-		var testFn simpleSendFn = func(
-			ctx context.Context,
-			_ SendOptions,
-			_ ReplicaSlice,
-			args roachpb.BatchRequest,
-		) (*roachpb.BatchResponse, error) {
-			if !first {
-				return args.CreateReply(), nil
+			clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+			rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
+			g := makeGossip(t, stopper, rpcContext)
+			leaseHolder := roachpb.ReplicaDescriptor{
+				NodeID:  99,
+				StoreID: 999,
 			}
-			first = false
-			if tc.canceledCtx {
-				cancel()
-				return nil, ctx.Err()
-			}
-			if tc.replicaError == nil {
-				return nil, errors.New(errString)
-			}
-			reply := &roachpb.BatchResponse{}
-			reply.Error = roachpb.NewError(tc.replicaError)
-			return reply, nil
-		}
+			first := true
 
-		cfg := DistSenderConfig{
-			AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
-			Clock:      clock,
-			RPCContext: rpcContext,
-			TestingKnobs: ClientTestingKnobs{
-				TransportFactory: adaptSimpleTransport(testFn),
-			},
-			RangeDescriptorDB: defaultMockRangeDescriptorDB,
-			NodeDialer:        nodedialer.New(rpcContext, gossip.AddressResolver(g)),
-			Settings:          cluster.MakeTestingClusterSettings(),
-		}
-		ds := NewDistSender(cfg, g)
-		ds.leaseHolderCache.Update(context.Background(), 1, leaseHolder.StoreID)
-		key := roachpb.Key("a")
-		put := roachpb.NewPut(key, roachpb.MakeValueFromString("value"))
+			ctx, cancel := context.WithCancel(context.Background())
 
-		if _, pErr := kv.SendWrapped(ctx, ds, put); pErr != nil && !testutils.IsPError(pErr, errString) && !testutils.IsError(pErr.GoError(), ctx.Err().Error()) {
-			t.Errorf("put encountered unexpected error: %s", pErr)
-		}
-		if _, ok := ds.leaseHolderCache.Lookup(context.Background(), 1); ok != !tc.shouldClearLeaseHolder {
-			t.Errorf("%d: lease holder cache eviction: shouldClearLeaseHolder=%t, but value is %t", i, tc.shouldClearLeaseHolder, ok)
-		}
-		cachedDesc := ds.rangeCache.GetCachedRangeDescriptor(roachpb.RKey(key), false /* inverted */)
-		if cachedDesc == nil != tc.shouldClearReplica {
-			t.Errorf("%d: unexpected second replica lookup behavior: wanted=%t", i, tc.shouldClearReplica)
-		}
+			var testFn simpleSendFn = func(
+				ctx context.Context,
+				_ SendOptions,
+				_ ReplicaSlice,
+				args roachpb.BatchRequest,
+			) (*roachpb.BatchResponse, error) {
+				if !first {
+					return args.CreateReply(), nil
+				}
+				first = false
+				if tc.canceledCtx {
+					cancel()
+					return nil, ctx.Err()
+				}
+				if tc.replicaError == nil {
+					return nil, errors.New(errString)
+				}
+				reply := &roachpb.BatchResponse{}
+				reply.Error = roachpb.NewError(tc.replicaError)
+				return reply, nil
+			}
+
+			cfg := DistSenderConfig{
+				AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
+				Clock:      clock,
+				RPCContext: rpcContext,
+				TestingKnobs: ClientTestingKnobs{
+					TransportFactory: adaptSimpleTransport(testFn),
+				},
+				RangeDescriptorDB: defaultMockRangeDescriptorDB,
+				NodeDialer:        nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+				Settings:          cluster.MakeTestingClusterSettings(),
+			}
+			ds := NewDistSender(cfg, g)
+			ds.leaseHolderCache.Update(context.Background(), 1, leaseHolder.StoreID)
+			key := roachpb.Key("a")
+			put := roachpb.NewPut(key, roachpb.MakeValueFromString("value"))
+
+			if _, pErr := kv.SendWrapped(ctx, ds, put); pErr != nil && !testutils.IsPError(pErr, errString) && !testutils.IsError(pErr.GoError(), ctx.Err().Error()) {
+				t.Errorf("put encountered unexpected error: %s", pErr)
+			}
+			if _, ok := ds.leaseHolderCache.Lookup(context.Background(), 1); ok != !tc.shouldClearLeaseHolder {
+				t.Errorf("%d: lease holder cache eviction: shouldClearLeaseHolder=%t, but value is %t", i, tc.shouldClearLeaseHolder, ok)
+			}
+			cachedDesc := ds.rangeCache.GetCachedRangeDescriptor(roachpb.RKey(key), false /* inverted */)
+			if cachedDesc == nil != tc.shouldClearReplica {
+				t.Errorf("%d: unexpected second replica lookup behavior: wanted=%t", i, tc.shouldClearReplica)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
On receiving a RangeKeyMismatchErr, the DistSender had protections
against receiving a descriptor with the same keys as what it had used.
This doesn't make any sense - how could you have gotten a
RangeKeyMismatch if the server had the same key span? This patch turns
that protection into an assertion.
The patch also makes the DistSender insert descriptors in the cache
coming from this error. It used to have a includesFrontOfCurSpan()
check. As written, I don't think that protection would ever trigger, but
even if it did, it seems misguided. We should be inserting in the cache
whatever we got from the server, regardless what keys the respective
descriptors cover.

Release note: None