### PR TITLE
build/deploy: docker build changes for geospatial

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -44,6 +44,7 @@ usual fashion. To be more specific, the steps to do this are:
 ```
 go/src/github.com/cockroachdb/cockroach $ ./build/builder.sh mkrelease linux-gnu
 go/src/github.com/cockroachdb/cockroach $ cp ./cockroach-linux-2.6.32-gnu-amd64 build/deploy/cockroach
+go/src/github.com/cockroachdb/cockroach $ cp -L $GOPATH/native/x86_64-unknown-linux-gnu/geos/lib/libgeos_c.so $GOPATH/native/x86_64-unknown-linux-gnu/geos/lib/libgeos.so build/deploy/
 go/src/github.com/cockroachdb/cockroach $ cd build/deploy && docker build -t cockroachdb/cockroach .
 ```
 

--- a/build/deploy/.gitignore
+++ b/build/deploy/.gitignore
@@ -1,3 +1,4 @@
 # Do not add environment-specific entries here (see the top-level .gitignore
 # for reasoning and alternatives).
 cockroach
+libgeos*.so*

--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update && \
 
 RUN mkdir -p /cockroach
 COPY cockroach.sh cockroach /cockroach/
+COPY libgeos*.so* /usr/local/lib/
+
 # Set working directory so that relative paths
 # are resolved appropriately when passed as args.
 WORKDIR /cockroach/
@@ -20,7 +22,7 @@ WORKDIR /cockroach/
 # to make it easier to invoke commands
 # via Docker
 ENV PATH=/cockroach:$PATH
-
+ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 ENV COCKROACH_CHANNEL=official-docker
 
 EXPOSE 26257 8080


### PR DESCRIPTION
Release note (general change): Added the GEOS library to the Docker
image, allowing the use of certain geospatial operators by default on
docker.