### PR TITLE
geo: enforce valid SRID for Geography and Geometry types

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -181,7 +181,7 @@ func columnDescToAvroSchema(colDesc *sqlbase.ColumnDescriptor) (*avroSchemaField
 			return []byte(d.(*tree.DGeography).EWKB()), nil
 		}
 		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			g, err := geo.ParseGeographyFromEWKBRaw(geopb.EWKB(x.([]byte)))
+			g, err := geo.ParseGeographyFromEWKBUnsafe(geopb.EWKB(x.([]byte)))
 			if err != nil {
 				return nil, err
 			}
@@ -193,7 +193,7 @@ func columnDescToAvroSchema(colDesc *sqlbase.ColumnDescriptor) (*avroSchemaField
 			return []byte(d.(*tree.DGeometry).EWKB()), nil
 		}
 		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			g, err := geo.ParseGeometryFromEWKBRaw(geopb.EWKB(x.([]byte)))
+			g, err := geo.ParseGeometryFromEWKBUnsafe(geopb.EWKB(x.([]byte)))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/geo/bbox_test.go
+++ b/pkg/geo/bbox_test.go
@@ -44,8 +44,7 @@ func TestBoundingBoxFromGeom(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%#v", tc.g), func(t *testing.T) {
-			bbox, err := BoundingBoxFromGeom(tc.g)
-			require.NoError(t, err)
+			bbox := boundingBoxFromGeom(tc.g)
 			require.Equal(t, tc.expected, bbox)
 		})
 	}

--- a/pkg/geo/encode_test.go
+++ b/pkg/geo/encode_test.go
@@ -25,7 +25,7 @@ func TestEWKBToWKT(t *testing.T) {
 	}{
 		{"POINT(1.01 1.01)", 15, "POINT (1.01 1.01)"},
 		{"POINT(1.01 1.01)", 1, "POINT (1 1)"},
-		{"SRID=4;POINT(1.0 1.0)", 15, "POINT (1 1)"},
+		{"SRID=4004;POINT(1.0 1.0)", 15, "POINT (1 1)"},
 	}
 
 	for _, tc := range testCases {
@@ -47,7 +47,7 @@ func TestEWKBToEWKT(t *testing.T) {
 	}{
 		{"POINT(1.01 1.01)", 15, "POINT (1.01 1.01)"},
 		{"POINT(1.01 1.01)", 1, "POINT (1 1)"},
-		{"SRID=4;POINT(1.0 1.0)", 15, "SRID=4;POINT (1 1)"},
+		{"SRID=4004;POINT(1.0 1.0)", 15, "SRID=4004;POINT (1 1)"},
 	}
 
 	for _, tc := range testCases {
@@ -67,7 +67,7 @@ func TestEWKBToWKB(t *testing.T) {
 		expected geopb.WKB
 	}{
 		{"POINT(1.0 1.0)", []byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f")},
-		{"SRID=4;POINT(1.0 1.0)", []byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f")},
+		{"SRID=4004;POINT(1.0 1.0)", []byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f")},
 	}
 
 	for _, tc := range testCases {
@@ -121,7 +121,7 @@ func TestEWKBToWKBHex(t *testing.T) {
 		expected string
 	}{
 		{"POINT(1.0 1.0)", "0101000000000000000000F03F000000000000F03F"},
-		{"SRID=4;POINT(1.0 1.0)", "0101000000000000000000F03F000000000000F03F"},
+		{"SRID=4004;POINT(1.0 1.0)", "0101000000000000000000F03F000000000000F03F"},
 	}
 
 	for _, tc := range testCases {
@@ -142,7 +142,7 @@ func TestEWKBToKML(t *testing.T) {
 	}{
 		{"POINT(1.0 1.0)", `<?xml version="1.0" encoding="UTF-8"?>
 <Point><coordinates>1,1</coordinates></Point>`},
-		{"SRID=4;POINT(1.0 1.0)", `<?xml version="1.0" encoding="UTF-8"?>
+		{"SRID=4004;POINT(1.0 1.0)", `<?xml version="1.0" encoding="UTF-8"?>
 <Point><coordinates>1,1</coordinates></Point>`},
 	}
 

--- a/pkg/geo/geogfn/unary_operators.go
+++ b/pkg/geo/geogfn/unary_operators.go
@@ -127,7 +127,7 @@ func Project(point *geom.Point, distance float64, azimuth s1.Angle) (*geom.Point
 			float64(projected.Lng.Normalized()) * 180.0 / math.Pi,
 			normalizeLatitude(float64(projected.Lat)) * 180.0 / math.Pi,
 		},
-	), nil
+	).SetSRID(point.SRID()), nil
 }
 
 // length returns the sum of the lengtsh and perimeters in the shapes of the Geography.

--- a/pkg/geo/geoindex/s2_geometry_index.go
+++ b/pkg/geo/geoindex/s2_geometry_index.go
@@ -156,7 +156,7 @@ func (s *s2GeometryIndex) convertToGeomTAndTryClip(g *geo.Geometry) (geom.T, boo
 		}
 		gt = nil
 		if clippedEWKB != nil {
-			g, err = geo.ParseGeometryFromEWKBRaw(clippedEWKB)
+			g, err = geo.ParseGeometryFromEWKBUnsafe(clippedEWKB)
 			if err != nil {
 				return nil, false, err
 			}

--- a/pkg/geo/geoindex/testdata/clip
+++ b/pkg/geo/geoindex/testdata/clip
@@ -1,14 +1,14 @@
 geometry
-SRID=4;MULTIPOINT((1.0 5.0), (3.0 4.0))
+SRID=4004;MULTIPOINT((1.0 5.0), (3.0 4.0))
 ----
 
 clip xmin=10 ymin=10 xmax=20 ymax=20
 ----
-55 => 13 (srid: 4)
+55 => 13 (srid: 4004)
 
 clip xmin=0 ymin=0 xmax=10 ymax=10
 ----
-55 => 55 (srid: 4)
+55 => 55 (srid: 4004)
 
 geometry
 MULTIPOINT((1.0 5.0), (3.0 4.0))

--- a/pkg/geo/summary.go
+++ b/pkg/geo/summary.go
@@ -155,10 +155,7 @@ func summaryFlag(t geom.T, isGeography bool) (f string, err error) {
 		f += "Z"
 	}
 
-	bbox, err := BoundingBoxFromGeom(t)
-	if err != nil {
-		return "", err
-	}
+	bbox := boundingBoxFromGeom(t)
 
 	if bbox != nil {
 		f += "B"

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -20,6 +20,15 @@ statement error type LineString does not match column type Point
 INSERT INTO geo_table (id, geom) VALUES
   (3, 'SRID=4004;LINESTRING(0.0 0.0, 1.0 2.0)')
 
+statement error unknown SRID for Geometry: 404
+SELECT 'SRID=404;POINT(1.0 2.0)'::geometry
+
+statement error unknown SRID for Geography: 404
+SELECT 'SRID=404;POINT(1.0 2.0)'::geography
+
+statement error SRID 3857 cannot be used for geography as it is not in a lon/lat coordinate system
+SELECT 'SRID=3857;POINT(1.0 2.0)'::geography
+
 query ITTT rowsort
 SELECT * FROM geo_table
 ----

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -812,7 +812,7 @@ values
  └── (NULL,)
 
 norm expect=FoldFunction
-SELECT ST_Length(ST_GeomFromText('LINESTRING(743238 2967416,743238 2967450)', 2249));
+SELECT ST_Length(ST_GeomFromText('LINESTRING(743238 2967416,743238 2967450)', 4326));
 ----
 values
  ├── columns: st_length:1!null

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -722,7 +722,11 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 			); err != nil {
 				return nil, err
 			}
-			return &DGeometry{d.AsGeometry()}, nil
+			g, err := d.AsGeometry()
+			if err != nil {
+				return nil, err
+			}
+			return &DGeometry{g}, nil
 		}
 
 	case types.DateFamily:

--- a/pkg/sql/sem/tree/testutils.go
+++ b/pkg/sql/sem/tree/testutils.go
@@ -81,9 +81,9 @@ func SampleDatum(t *types.T) Datum {
 	case types.OidFamily:
 		return NewDOid(DInt(1009))
 	case types.GeographyFamily:
-		return NewDGeography(geo.MustParseGeographyFromEWKBRaw([]byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f")))
+		return NewDGeography(geo.MustParseGeographyFromEWKB([]byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f")))
 	case types.GeometryFamily:
-		return NewDGeometry(geo.MustParseGeometryFromEWKBRaw([]byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f")))
+		return NewDGeometry(geo.MustParseGeometryFromEWKB([]byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f")))
 	default:
 		panic(fmt.Sprintf("SampleDatum not implemented for %s", t))
 	}

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -171,12 +171,12 @@ func RandDatumWithNullChance(rng *rand.Rand, typ *types.T, nullChance int) tree.
 	case types.GeographyFamily:
 		// TODO(otan): generate fake data properly.
 		return tree.NewDGeography(
-			geo.MustParseGeographyFromEWKBRaw([]byte("\x01\x01\x00\x00\x20\xe6\x10\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f")),
+			geo.MustParseGeographyFromEWKB([]byte("\x01\x01\x00\x00\x20\xe6\x10\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f")),
 		)
 	case types.GeometryFamily:
 		// TODO(otan): generate fake data properly.
 		return tree.NewDGeometry(
-			geo.MustParseGeometryFromEWKBRaw([]byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f")),
+			geo.MustParseGeometryFromEWKB([]byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f")),
 		)
 	case types.DecimalFamily:
 		d := &tree.DDecimal{}

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -1158,7 +1158,7 @@ func TestEncodeDecodeGeo(t *testing.T) {
 				t.Run(fmt.Sprintf("dir:%d", dir), func(t *testing.T) {
 					parsed, err := geo.ParseGeometry(tc)
 					require.NoError(t, err)
-					spatialObject := parsed.SpatialObject
+					spatialObject := parsed.SpatialObject()
 
 					var b []byte
 					var decoded geopb.SpatialObject


### PR DESCRIPTION
Enforce that SRIDs are valid for Geometry/Geometry types, as well as
that they are lat/lng systems for Geography types.

This involved privatising the SpatialObject field for Geometry/Geography
types so that all operations must go through `NewGeo*`. There is an
unsafe option when we trust the object (when it is from the database).

Release note: None