### PR TITLE
execgen: simplify monomorphization

### DIFF
--- a/pkg/sql/colexec/execgen/testdata/template
+++ b/pkg/sql/colexec/execgen/testdata/template
@@ -108,3 +108,168 @@ func b_true_true(a int) int {
 }
 ----
 ----
+
+# Test templates calling each other.
+template
+package main
+
+func main() {
+  a(1, true)
+  a(1, false)
+}
+
+// execgen:inline
+// execgen:template<y>
+func a(x int, y bool) {
+  b(x, y, true)
+  b(x, y, false)
+}
+
+
+// execgen:inline
+// execgen:template<y, z>
+func b(x int, y bool, z bool) int {
+  if y {
+    if z {
+      fmt.Println("y and z")
+    } else {
+      fmt.Println("y not z")
+    }
+  } else {
+    if z {
+      fmt.Println("not y and z")
+    } else {
+      fmt.Println("not y not z")
+    }
+  }
+}
+----
+----
+package main
+
+func main() {
+	a_true(1)
+	a_false(1)
+}
+
+// execgen:inline
+const _ = "template_a"
+
+// execgen:inline
+func a_false(x int) {
+	b_false_true(x)
+	b_false_false(x)
+}
+
+// execgen:inline
+func a_true(x int) {
+	b_true_true(x)
+	b_true_false(x)
+}
+
+// execgen:inline
+const _ = "template_b"
+
+// execgen:inline
+func b_false_false(x int) int {
+	fmt.Println("not y not z")
+}
+
+// execgen:inline
+func b_true_false(x int) int {
+	fmt.Println("y not z")
+}
+
+// execgen:inline
+func b_false_true(x int) int {
+	fmt.Println("not y and z")
+}
+
+// execgen:inline
+func b_true_true(x int) int {
+	fmt.Println("y and z")
+}
+----
+----
+
+# Test templates calling each other in reverse order.
+template
+package main
+
+func main() {
+  a(1, true)
+  a(1, false)
+}
+
+// execgen:inline
+// execgen:template<y, z>
+func b(x int, y bool, z bool) int {
+  if y {
+    if z {
+      fmt.Println("y and z")
+    } else {
+      fmt.Println("y not z")
+    }
+  } else {
+    if z {
+      fmt.Println("not y and z")
+    } else {
+      fmt.Println("not y not z")
+    }
+  }
+}
+
+// execgen:inline
+// execgen:template<y>
+func a(x int, y bool) {
+  b(x, y, true)
+  b(x, y, false)
+}
+----
+----
+package main
+
+func main() {
+	a_true(1)
+	a_false(1)
+}
+
+// execgen:inline
+const _ = "template_b"
+
+// execgen:inline
+func b_false_false(x int) int {
+	fmt.Println("not y not z")
+}
+
+// execgen:inline
+func b_true_false(x int) int {
+	fmt.Println("y not z")
+}
+
+// execgen:inline
+func b_false_true(x int) int {
+	fmt.Println("not y and z")
+}
+
+// execgen:inline
+func b_true_true(x int) int {
+	fmt.Println("y and z")
+}
+
+// execgen:inline
+const _ = "template_a"
+
+// execgen:inline
+func a_false(x int) {
+	b_false_true(x)
+	b_false_false(x)
+}
+
+// execgen:inline
+func a_true(x int) {
+	b_true_true(x)
+	b_true_false(x)
+}
+----
+----


### PR DESCRIPTION
The Go compiler already does elision of if/else and switch branches that
are statically falsifiable, and it can do so better than we can.

This commit changes the monomorphization method to be simple lexical
replacement. This makes the generated code less concise (it includes all
branches even those that are statically falsifiable), but it also will
capture more cases by delegating to Go's more sophisticated constant
folding.

For example, Go has the machinery to statically evaluate cases like
`true && false`, or `switch x { case x: ...`, and so on. We could add
this, but it seems like a good amount of work to get it right.

This also has the benefit of immediately enabling the "mid-stack
templating" that was missing before, which is a nice side effect.

We preserve the conditional folding as a second phase, just to clean up
the generated code, but it won't work in all cases - the Go compiler can
clean up those cases.

Release note: None