### PR TITLE
rpc: introduce ContextOptions

### DIFF
--- a/pkg/acceptance/localcluster/cluster.go
+++ b/pkg/acceptance/localcluster/cluster.go
@@ -271,8 +271,13 @@ func (c *Cluster) makeNode(ctx context.Context, nodeIdx int, cfg NodeConfig) (*N
 		User:     security.NodeUser,
 		Insecure: true,
 	}
-	rpcCtx := rpc.NewContext(log.AmbientContext{Tracer: tracing.NewTracer()}, baseCtx,
-		hlc.NewClock(hlc.UnixNano, 0), c.stopper, cluster.MakeTestingClusterSettings())
+	rpcCtx := rpc.NewContext(rpc.ContextOptions{
+		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
+		Config:     baseCtx,
+		Clock:      hlc.NewClock(hlc.UnixNano, 0),
+		Stopper:    c.stopper,
+		Settings:   cluster.MakeTestingClusterSettings(),
+	})
 
 	n := &Node{
 		Cfg:    cfg,

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1333,13 +1333,13 @@ func getClientGRPCConn(
 	// as that of nodes in the cluster.
 	clock := hlc.NewClock(hlc.UnixNano, 0)
 	stopper := stop.NewStopper()
-	rpcContext := rpc.NewContext(
-		log.AmbientContext{Tracer: cfg.Settings.Tracer},
-		cfg.Config,
-		clock,
-		stopper,
-		cfg.Settings,
-	)
+	rpcContext := rpc.NewContext(rpc.ContextOptions{
+		AmbientCtx: log.AmbientContext{Tracer: cfg.Settings.Tracer},
+		Config:     cfg.Config,
+		Clock:      clock,
+		Stopper:    stopper,
+		Settings:   cfg.Settings,
+	})
 	addr, err := addrWithDefaultHost(cfg.AdvertiseAddr)
 	if err != nil {
 		stopper.Stop(ctx)

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1580,7 +1580,7 @@ func (g *Gossip) startClientLocked(addr net.Addr) {
 	defer g.clientsMu.Unlock()
 	breaker, ok := g.clientsMu.breakers[addr.String()]
 	if !ok {
-		name := fmt.Sprintf("gossip %v->%v", g.rpcContext.Addr, addr)
+		name := fmt.Sprintf("gossip %v->%v", g.rpcContext.Config.Addr, addr)
 		breaker = g.rpcContext.NewBreaker(name)
 		g.clientsMu.breakers[addr.String()] = breaker
 	}

--- a/pkg/gossip/simulation/network.go
+++ b/pkg/gossip/simulation/network.go
@@ -71,15 +71,15 @@ func NewNetwork(
 		Nodes:   []*Node{},
 		Stopper: stopper,
 	}
-	n.RPCContext = rpc.NewContext(
-		log.AmbientContext{Tracer: tracing.NewTracer()},
-		&base.Config{Insecure: true},
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond),
-		n.Stopper,
-		cluster.MakeTestingClusterSettings(),
-	)
+	n.RPCContext = rpc.NewContext(rpc.ContextOptions{
+		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
+		Config:     &base.Config{Insecure: true},
+		Clock:      hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		Stopper:    n.Stopper,
+		Settings:   cluster.MakeTestingClusterSettings(),
+	})
 	var err error
-	n.tlsConfig, err = n.RPCContext.GetServerTLSConfig()
+	n.tlsConfig, err = n.RPCContext.Config.GetServerTLSConfig()
 	if err != nil {
 		log.Fatalf(context.TODO(), "%v", err)
 	}

--- a/pkg/kv/kvserver/allocator_test.go
+++ b/pkg/kv/kvserver/allocator_test.go
@@ -5569,13 +5569,13 @@ func TestAllocatorFullDisks(t *testing.T) {
 
 	// Model a set of stores in a cluster doing rebalancing, with ranges being
 	// randomly added occasionally.
-	rpcContext := rpc.NewContext(
-		log.AmbientContext{Tracer: st.Tracer},
-		&base.Config{Insecure: true},
-		clock,
-		stopper,
-		st,
-	)
+	rpcContext := rpc.NewContext(rpc.ContextOptions{
+		AmbientCtx: log.AmbientContext{Tracer: st.Tracer},
+		Config:     &base.Config{Insecure: true},
+		Clock:      clock,
+		Stopper:    stopper,
+		Settings:   st,
+	})
 	server := rpc.NewServer(rpcContext) // never started
 	g := gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 
@@ -5711,13 +5711,13 @@ func Example_rebalancing() {
 
 	// Model a set of stores in a cluster,
 	// adding / rebalancing ranges of random sizes.
-	rpcContext := rpc.NewContext(
-		log.AmbientContext{Tracer: st.Tracer},
-		&base.Config{Insecure: true},
-		clock,
-		stopper,
-		st,
-	)
+	rpcContext := rpc.NewContext(rpc.ContextOptions{
+		AmbientCtx: log.AmbientContext{Tracer: st.Tracer},
+		Config:     &base.Config{Insecure: true},
+		Clock:      clock,
+		Stopper:    stopper,
+		Settings:   st,
+	})
 	server := rpc.NewServer(rpcContext) // never started
 	g := gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 

--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -127,8 +127,13 @@ func createTestStoreWithOpts(
 	ac := log.AmbientContext{Tracer: tracer}
 	storeCfg.AmbientCtx = ac
 
-	rpcContext := rpc.NewContext(
-		ac, &base.Config{Insecure: true}, storeCfg.Clock, stopper, storeCfg.Settings)
+	rpcContext := rpc.NewContext(rpc.ContextOptions{
+		AmbientCtx: ac,
+		Config:     &base.Config{Insecure: true},
+		Clock:      storeCfg.Clock,
+		Stopper:    stopper,
+		Settings:   storeCfg.Settings,
+	})
 	// Ensure that tests using this test context and restart/shut down
 	// their servers do not inadvertently start talking to servers from
 	// unrelated concurrent tests.
@@ -364,8 +369,14 @@ func (m *multiTestContext) Start(t testing.TB, numStores int) {
 	}
 	st := cluster.MakeTestingClusterSettings()
 	if m.rpcContext == nil {
-		m.rpcContext = rpc.NewContextWithTestingKnobs(log.AmbientContext{Tracer: st.Tracer}, &base.Config{Insecure: true}, m.clock(),
-			m.transportStopper, st, m.rpcTestingKnobs)
+		m.rpcContext = rpc.NewContext(rpc.ContextOptions{
+			AmbientCtx: log.AmbientContext{Tracer: st.Tracer},
+			Config:     &base.Config{Insecure: true},
+			Clock:      m.clock(),
+			Stopper:    m.transportStopper,
+			Settings:   st,
+			Knobs:      m.rpcTestingKnobs,
+		})
 		// Ensure that tests using this test context and restart/shut down
 		// their servers do not inadvertently start talking to servers from
 		// unrelated concurrent tests.

--- a/pkg/kv/kvserver/queue_test.go
+++ b/pkg/kv/kvserver/queue_test.go
@@ -510,9 +510,13 @@ func TestNeedsSystemConfig(t *testing.T) {
 
 	// Use a gossip instance that won't have the system config available in it.
 	// bqNeedsSysCfg will not add the replica or process it without a system config.
-	rpcContext := rpc.NewContext(
-		tc.store.cfg.AmbientCtx, &base.Config{Insecure: true}, tc.store.cfg.Clock, stopper,
-		cluster.MakeTestingClusterSettings())
+	rpcContext := rpc.NewContext(rpc.ContextOptions{
+		AmbientCtx: tc.store.cfg.AmbientCtx,
+		Config:     &base.Config{Insecure: true},
+		Clock:      tc.store.cfg.Clock,
+		Stopper:    stopper,
+		Settings:   cluster.MakeTestingClusterSettings(),
+	})
 	emptyGossip := gossip.NewTest(
 		tc.gossip.NodeID.Get(), rpcContext, rpc.NewServer(rpcContext), stopper, tc.store.Registry(), zonepb.DefaultZoneConfigRef())
 	bqNeedsSysCfg := makeTestBaseQueue("test", testQueue, tc.store, emptyGossip, queueConfig{

--- a/pkg/kv/kvserver/raft_transport_test.go
+++ b/pkg/kv/kvserver/raft_transport_test.go
@@ -110,13 +110,13 @@ func newRaftTransportTestContext(t testing.TB) *raftTransportTestContext {
 		stopper:    stop.NewStopper(),
 		transports: map[roachpb.NodeID]*kvserver.RaftTransport{},
 	}
-	rttc.nodeRPCContext = rpc.NewContext(
-		log.AmbientContext{Tracer: tracing.NewTracer()},
-		testutils.NewNodeTestBaseContext(),
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond),
-		rttc.stopper,
-		cluster.MakeTestingClusterSettings(),
-	)
+	rttc.nodeRPCContext = rpc.NewContext(rpc.ContextOptions{
+		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
+		Config:     testutils.NewNodeTestBaseContext(),
+		Clock:      hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		Stopper:    rttc.stopper,
+		Settings:   cluster.MakeTestingClusterSettings(),
+	})
 	// Ensure that tests using this test context and restart/shut down
 	// their servers do not inadvertently start talking to servers from
 	// unrelated concurrent tests.

--- a/pkg/kv/kvserver/raft_transport_unit_test.go
+++ b/pkg/kv/kvserver/raft_transport_unit_test.go
@@ -42,8 +42,12 @@ func TestRaftTransportStartNewQueue(t *testing.T) {
 	defer stopper.Stop(ctx)
 
 	st := cluster.MakeTestingClusterSettings()
-	rpcC := rpc.NewContext(log.AmbientContext{}, &base.Config{Insecure: true},
-		hlc.NewClock(hlc.UnixNano, 500*time.Millisecond), stopper, st)
+	rpcC := rpc.NewContext(rpc.ContextOptions{
+		Config:   &base.Config{Insecure: true},
+		Clock:    hlc.NewClock(hlc.UnixNano, 500*time.Millisecond),
+		Stopper:  stopper,
+		Settings: st,
+	})
 	rpcC.ClusterID.Set(context.Background(), uuid.MakeV4())
 
 	// mrs := &dummyMultiRaftServer{}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -216,8 +216,13 @@ func (tc *testContext) StartWithStoreConfigAndVersion(
 	// Setup fake zone config handler.
 	config.TestingSetupZoneConfigHook(stopper)
 	if tc.gossip == nil {
-		rpcContext := rpc.NewContext(
-			cfg.AmbientCtx, &base.Config{Insecure: true}, cfg.Clock, stopper, cfg.Settings)
+		rpcContext := rpc.NewContext(rpc.ContextOptions{
+			AmbientCtx: cfg.AmbientCtx,
+			Config:     &base.Config{Insecure: true},
+			Clock:      cfg.Clock,
+			Stopper:    stopper,
+			Settings:   cfg.Settings,
+		})
 		server := rpc.NewServer(rpcContext) // never started
 		tc.gossip = gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry(), cfg.DefaultZoneConfig)
 	}

--- a/pkg/kv/kvserver/store_pool_test.go
+++ b/pkg/kv/kvserver/store_pool_test.go
@@ -100,8 +100,13 @@ func createTestStorePool(
 	mc := hlc.NewManualClock(123)
 	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 	st := cluster.MakeTestingClusterSettings()
-	rpcContext := rpc.NewContext(
-		log.AmbientContext{Tracer: st.Tracer}, &base.Config{Insecure: true}, clock, stopper, st)
+	rpcContext := rpc.NewContext(rpc.ContextOptions{
+		AmbientCtx: log.AmbientContext{Tracer: st.Tracer},
+		Config:     &base.Config{Insecure: true},
+		Clock:      clock,
+		Stopper:    stopper,
+		Settings:   st,
+	})
 	server := rpc.NewServer(rpcContext) // never started
 	g := gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 	mnl := newMockNodeLiveness(defaultNodeStatus)

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -206,9 +206,13 @@ func createTestStoreWithoutStart(
 	// Setup fake zone config handler.
 	config.TestingSetupZoneConfigHook(stopper)
 
-	rpcContext := rpc.NewContext(
-		cfg.AmbientCtx, &base.Config{Insecure: true}, cfg.Clock,
-		stopper, cfg.Settings)
+	rpcContext := rpc.NewContext(rpc.ContextOptions{
+		AmbientCtx: cfg.AmbientCtx,
+		Config:     &base.Config{Insecure: true},
+		Clock:      cfg.Clock,
+		Stopper:    stopper,
+		Settings:   cfg.Settings,
+	})
 	server := rpc.NewServer(rpcContext) // never started
 	cfg.Gossip = gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry(), cfg.DefaultZoneConfig)
 	cfg.StorePool = NewTestStorePool(*cfg)

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -176,8 +176,8 @@ func NewServerWithInterceptor(
 		// A stats handler to measure server network stats.
 		grpc.StatsHandler(&ctx.stats),
 	}
-	if !ctx.Insecure {
-		tlsConfig, err := ctx.GetServerTLSConfig()
+	if !ctx.Config.Insecure {
+		tlsConfig, err := ctx.Config.GetServerTLSConfig()
 		if err != nil {
 			panic(err)
 		}
@@ -243,7 +243,7 @@ func NewServerWithInterceptor(
 		}
 	}
 
-	if !ctx.Insecure {
+	if !ctx.Config.Insecure {
 		prevUnaryInterceptor := unaryInterceptor
 		unaryInterceptor = func(
 			ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
@@ -279,13 +279,13 @@ func NewServerWithInterceptor(
 
 	s := grpc.NewServer(opts...)
 	RegisterHeartbeatServer(s, &HeartbeatService{
-		clock:                                 ctx.LocalClock,
+		clock:                                 ctx.Clock,
 		remoteClockMonitor:                    ctx.RemoteClocks,
-		clusterName:                           ctx.clusterName,
-		disableClusterNameVerification:        ctx.disableClusterNameVerification,
+		clusterName:                           ctx.ClusterName(),
+		disableClusterNameVerification:        ctx.Config.DisableClusterNameVerification,
 		clusterID:                             &ctx.ClusterID,
 		nodeID:                                &ctx.NodeID,
-		settings:                              ctx.settings,
+		settings:                              ctx.Settings,
 		testingAllowNamedRPCToAnonymousServer: ctx.TestingAllowNamedRPCToAnonymousServer,
 	})
 	return s
@@ -370,18 +370,14 @@ func (c *Connection) Health() error {
 
 // Context contains the fields required by the rpc framework.
 type Context struct {
-	*base.Config
+	ContextOptions
 
-	AmbientCtx   log.AmbientContext
-	LocalClock   *hlc.Clock
 	breakerClock breakerClock
-	Stopper      *stop.Stopper
 	RemoteClocks *RemoteClockMonitor
 	masterCtx    context.Context
 
-	heartbeatInterval time.Duration
-	heartbeatTimeout  time.Duration
-	HeartbeatCB       func()
+	heartbeatTimeout time.Duration
+	HeartbeatCB      func()
 
 	rpcCompression bool
 
@@ -393,17 +389,12 @@ type Context struct {
 
 	ClusterID base.ClusterIDContainer
 	NodeID    base.NodeIDContainer
-	settings  *cluster.Settings
-
-	clusterName                    string
-	disableClusterNameVerification bool
 
 	metrics Metrics
 
 	// For unittesting.
 	BreakerFactory  func() *circuit.Breaker
 	testingDialOpts []grpc.DialOption
-	testingKnobs    ContextTestingKnobs
 
 	// For testing. See the comment on the same field in HeartbeatService.
 	TestingAllowNamedRPCToAnonymousServer bool
@@ -426,54 +417,59 @@ type connKey struct {
 	class      ConnectionClass
 }
 
-// NewContext creates an rpc Context with the supplied values.
-func NewContext(
-	ambient log.AmbientContext,
-	baseCtx *base.Config,
-	hlcClock *hlc.Clock,
-	stopper *stop.Stopper,
-	st *cluster.Settings,
-) *Context {
-	return NewContextWithTestingKnobs(ambient, baseCtx, hlcClock, stopper, st,
-		ContextTestingKnobs{})
+// ContextOptions are passed to NewContext to set up a new *Context.
+// All pointer fields are required.
+type ContextOptions struct {
+	AmbientCtx log.AmbientContext
+	Config     *base.Config
+	Clock      *hlc.Clock
+	Stopper    *stop.Stopper
+	Settings   *cluster.Settings
+	Knobs      ContextTestingKnobs
 }
 
-// NewContextWithTestingKnobs creates an rpc Context with the supplied values.
-func NewContextWithTestingKnobs(
-	ambient log.AmbientContext,
-	baseCtx *base.Config,
-	hlcClock *hlc.Clock,
-	stopper *stop.Stopper,
-	st *cluster.Settings,
-	knobs ContextTestingKnobs,
-) *Context {
-	if hlcClock == nil {
-		panic("nil clock is forbidden")
+func (c ContextOptions) validate() error {
+	if c.Config == nil {
+		return errors.New("Config must be set")
 	}
-	ctx := &Context{
-		AmbientCtx: ambient,
-		Config:     baseCtx,
-		LocalClock: hlcClock,
-		breakerClock: breakerClock{
-			clock: hlcClock,
-		},
-		rpcCompression:                 enableRPCCompression,
-		settings:                       st,
-		clusterName:                    baseCtx.ClusterName,
-		disableClusterNameVerification: baseCtx.DisableClusterNameVerification,
-		testingKnobs:                   knobs,
+	if c.Clock == nil {
+		return errors.New("Clock must be set")
 	}
-	var cancel context.CancelFunc
-	ctx.masterCtx, cancel = context.WithCancel(ambient.AnnotateCtx(context.Background()))
-	ctx.Stopper = stopper
-	ctx.heartbeatInterval = baseCtx.RPCHeartbeatInterval
-	ctx.RemoteClocks = newRemoteClockMonitor(
-		ctx.LocalClock, 10*ctx.heartbeatInterval, baseCtx.HistogramWindowInterval())
-	ctx.heartbeatTimeout = 2 * ctx.heartbeatInterval
-	ctx.metrics = makeMetrics()
+	if c.Stopper == nil {
+		return errors.New("Stopper must be set")
+	}
+	if c.Settings == nil {
+		return errors.New("Settings must be set")
+	}
+	return nil
+}
 
-	stopper.RunWorker(ctx.masterCtx, func(context.Context) {
-		<-stopper.ShouldQuiesce()
+// NewContext creates an rpc.Context with the supplied values.
+func NewContext(opts ContextOptions) *Context {
+	if err := opts.validate(); err != nil {
+		panic(err)
+	}
+
+	masterCtx, cancel := context.WithCancel(opts.AmbientCtx.AnnotateCtx(context.Background()))
+
+	ctx := &Context{
+		ContextOptions: opts,
+		breakerClock: breakerClock{
+			clock: opts.Clock,
+		},
+		RemoteClocks: newRemoteClockMonitor(
+			opts.Clock, 10*opts.Config.RPCHeartbeatInterval, opts.Config.HistogramWindowInterval()),
+		rpcCompression:   enableRPCCompression,
+		masterCtx:        masterCtx,
+		metrics:          makeMetrics(),
+		heartbeatTimeout: 2 * opts.Config.RPCHeartbeatInterval,
+	}
+	if id := opts.Knobs.ClusterID; id != nil {
+		ctx.ClusterID.Set(masterCtx, *id)
+	}
+
+	ctx.Stopper.RunWorker(ctx.masterCtx, func(context.Context) {
+		<-ctx.Stopper.ShouldQuiesce()
 
 		cancel()
 		ctx.conns.Range(func(k, v interface{}) bool {
@@ -490,9 +486,6 @@ func NewContextWithTestingKnobs(
 			return true
 		})
 	})
-	if knobs.ClusterID != nil {
-		ctx.ClusterID.Set(ctx.masterCtx, *knobs.ClusterID)
-	}
 	return ctx
 }
 
@@ -502,7 +495,7 @@ func (ctx *Context) ClusterName() string {
 		// This is used in tests.
 		return "<MISSING RPC CONTEXT>"
 	}
-	return ctx.clusterName
+	return ctx.Config.ClusterName
 }
 
 // GetStatsMap returns a map of network statistics maintained by the
@@ -522,7 +515,7 @@ func (ctx *Context) Metrics() *Metrics {
 func (ctx *Context) GetLocalInternalClientForAddr(
 	target string, nodeID roachpb.NodeID,
 ) roachpb.InternalClient {
-	if target == ctx.AdvertiseAddr && nodeID == ctx.NodeID.Get() {
+	if target == ctx.Config.AdvertiseAddr && nodeID == ctx.NodeID.Get() {
 		return ctx.localInternalClient
 	}
 	return nil
@@ -662,10 +655,10 @@ func (ctx *Context) grpcDialOptions(
 	target string, class ConnectionClass,
 ) ([]grpc.DialOption, error) {
 	var dialOpts []grpc.DialOption
-	if ctx.Insecure {
+	if ctx.Config.Insecure {
 		dialOpts = append(dialOpts, grpc.WithInsecure())
 	} else {
-		tlsConfig, err := ctx.GetClientTLSConfig()
+		tlsConfig, err := ctx.Config.GetClientTLSConfig()
 		if err != nil {
 			return nil, err
 		}
@@ -709,15 +702,15 @@ func (ctx *Context) grpcDialOptions(
 					span.SetTag("node", ctx.NodeID.String())
 				})))
 	}
-	if ctx.testingKnobs.UnaryClientInterceptor != nil {
-		testingUnaryInterceptor := ctx.testingKnobs.UnaryClientInterceptor(target, class)
+	if ctx.Knobs.UnaryClientInterceptor != nil {
+		testingUnaryInterceptor := ctx.Knobs.UnaryClientInterceptor(target, class)
 		if testingUnaryInterceptor != nil {
 			unaryInterceptors = append(unaryInterceptors, testingUnaryInterceptor)
 		}
 	}
 	dialOpts = append(dialOpts, grpc.WithChainUnaryInterceptor(unaryInterceptors...))
-	if ctx.testingKnobs.StreamClientInterceptor != nil {
-		testingStreamInterceptor := ctx.testingKnobs.StreamClientInterceptor(target, class)
+	if ctx.Knobs.StreamClientInterceptor != nil {
+		testingStreamInterceptor := ctx.Knobs.StreamClientInterceptor(target, class)
 		if testingStreamInterceptor != nil {
 			dialOpts = append(dialOpts, grpc.WithStreamInterceptor(testingStreamInterceptor))
 		}
@@ -913,8 +906,8 @@ func (ctx *Context) grpcDialRaw(
 		redialChan: make(chan struct{}),
 	}
 	dialerFunc := dialer.dial
-	if ctx.testingKnobs.ArtificialLatencyMap != nil {
-		latency := ctx.testingKnobs.ArtificialLatencyMap[target]
+	if ctx.Knobs.ArtificialLatencyMap != nil {
+		latency := ctx.Knobs.ArtificialLatencyMap[target]
 		log.VEventf(ctx.masterCtx, 1, "Connecting to node %s (%d) with simulated latency %dms", target, remoteNodeID,
 			latency)
 		dialer := artificialLatencyDialer{
@@ -1055,7 +1048,7 @@ func (ctx *Context) runHeartbeat(
 		updateHeartbeatState(&ctx.metrics, state, heartbeatNotRunning)
 		setInitialHeartbeatDone()
 	}()
-	maxOffset := ctx.LocalClock.MaxOffset()
+	maxOffset := ctx.Clock.MaxOffset()
 	maxOffsetNanos := maxOffset.Nanoseconds()
 
 	heartbeatClient := NewHeartbeatClient(conn.grpcConn)
@@ -1080,15 +1073,15 @@ func (ctx *Context) runHeartbeat(
 			// We re-mint the PingRequest to pick up any asynchronous update to clusterID.
 			clusterID := ctx.ClusterID.Get()
 			request := &PingRequest{
-				Addr:           ctx.Addr,
+				Addr:           ctx.Config.Addr,
 				MaxOffsetNanos: maxOffsetNanos,
 				ClusterID:      &clusterID,
 				NodeID:         conn.remoteNodeID,
-				ServerVersion:  ctx.settings.Version.BinaryVersion(),
+				ServerVersion:  ctx.Settings.Version.BinaryVersion(),
 			}
 
 			var response *PingResponse
-			sendTime := ctx.LocalClock.PhysicalTime()
+			sendTime := ctx.Clock.PhysicalTime()
 			ping := func(goCtx context.Context) (err error) {
 				// NB: We want the request to fail-fast (the default), otherwise we won't
 				// be notified of transport failures.
@@ -1109,27 +1102,27 @@ func (ctx *Context) runHeartbeat(
 				// new node in a cluster and mistakenly joins the wrong
 				// cluster gets a chance to see the error message on their
 				// management console.
-				if !ctx.disableClusterNameVerification && !response.DisableClusterNameVerification {
+				if !ctx.Config.DisableClusterNameVerification && !response.DisableClusterNameVerification {
 					err = errors.Wrap(
-						checkClusterName(ctx.clusterName, response.ClusterName),
+						checkClusterName(ctx.Config.ClusterName, response.ClusterName),
 						"cluster name check failed on ping response")
 				}
 			}
 
 			if err == nil {
 				err = errors.Wrap(
-					checkVersion(goCtx, ctx.settings, response.ServerVersion),
+					checkVersion(goCtx, ctx.Settings, response.ServerVersion),
 					"version compatibility check failed on ping response")
 			}
 
 			if err == nil {
 				everSucceeded = true
-				receiveTime := ctx.LocalClock.PhysicalTime()
+				receiveTime := ctx.Clock.PhysicalTime()
 
 				// Only update the clock offset measurement if we actually got a
 				// successful response from the server.
 				pingDuration := receiveTime.Sub(sendTime)
-				maxOffset := ctx.LocalClock.MaxOffset()
+				maxOffset := ctx.Clock.MaxOffset()
 				if pingDuration > maximumPingDurationMult*maxOffset {
 					request.Offset.Reset()
 				} else {
@@ -1162,6 +1155,6 @@ func (ctx *Context) runHeartbeat(
 			return err
 		}
 
-		heartbeatTimer.Reset(ctx.heartbeatInterval)
+		heartbeatTimer.Reset(ctx.Config.RPCHeartbeatInterval)
 	}
 }

--- a/pkg/rpc/context_testutils.go
+++ b/pkg/rpc/context_testutils.go
@@ -70,12 +70,12 @@ func NewInsecureTestingContextWithClusterID(
 func NewInsecureTestingContextWithKnobs(
 	clock *hlc.Clock, stopper *stop.Stopper, knobs ContextTestingKnobs,
 ) *Context {
-	return NewContextWithTestingKnobs(
-		log.AmbientContext{Tracer: tracing.NewTracer()},
-		&base.Config{Insecure: true},
-		clock,
-		stopper,
-		cluster.MakeTestingClusterSettings(),
-		knobs,
-	)
+	return NewContext(ContextOptions{
+		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
+		Config:     &base.Config{Insecure: true},
+		Clock:      clock,
+		Stopper:    stopper,
+		Settings:   cluster.MakeTestingClusterSettings(),
+		Knobs:      knobs,
+	})
 }

--- a/pkg/rpc/nodedialer/nodedialer_test.go
+++ b/pkg/rpc/nodedialer/nodedialer_test.go
@@ -285,13 +285,13 @@ func newTestContext(clock *hlc.Clock, stopper *stop.Stopper) *rpc.Context {
 	cfg := testutils.NewNodeTestBaseContext()
 	cfg.Insecure = true
 	cfg.RPCHeartbeatInterval = 10 * time.Millisecond
-	rctx := rpc.NewContext(
-		log.AmbientContext{Tracer: tracing.NewTracer()},
-		cfg,
-		clock,
-		stopper,
-		cluster.MakeTestingClusterSettings(),
-	)
+	rctx := rpc.NewContext(rpc.ContextOptions{
+		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
+		Config:     cfg,
+		Clock:      clock,
+		Stopper:    stopper,
+		Settings:   cluster.MakeTestingClusterSettings(),
+	})
 	// Ensure that tests using this test context and restart/shut down
 	// their servers do not inadvertently start talking to servers from
 	// unrelated concurrent tests.

--- a/pkg/rpc/stats_handler_test.go
+++ b/pkg/rpc/stats_handler_test.go
@@ -112,7 +112,7 @@ func TestStatsHandlerWithHeartbeats(t *testing.T) {
 		stopper:            stopper,
 		clock:              clock,
 		remoteClockMonitor: serverCtx.RemoteClocks,
-		settings:           serverCtx.settings,
+		settings:           serverCtx.Settings,
 		nodeID:             &serverCtx.NodeID,
 	}
 	RegisterHeartbeatServer(s, heartbeat)
@@ -125,7 +125,7 @@ func TestStatsHandlerWithHeartbeats(t *testing.T) {
 
 	clientCtx := newTestContext(clusterID, clock, stopper)
 	// Make the interval shorter to speed up the test.
-	clientCtx.heartbeatInterval = 1 * time.Millisecond
+	clientCtx.Config.RPCHeartbeatInterval = 1 * time.Millisecond
 	go func() { heartbeat.ready <- nil }()
 	if _, err := clientCtx.GRPCDialNode(remoteAddr, serverNodeID, DefaultClass).
 		Connect(context.Background()); err != nil {

--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -777,7 +777,7 @@ func TestGRPCAuthentication(t *testing.T) {
 		})
 	}
 
-	certManager, err := s.RPCContext().GetCertificateManager()
+	certManager, err := s.RPCContext().Config.GetCertificateManager()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/drain_test.go
+++ b/pkg/server/drain_test.go
@@ -233,10 +233,13 @@ func getAdminClientForServer(
 	// Retrieve some parameters to initialize the client RPC context.
 	cfg := tc.Server(0).RPCContext().Config
 	execCfg := tc.Server(0).ExecutorConfig().(sql.ExecutorConfig)
-	rpcContext := rpc.NewContext(
-		log.AmbientContext{Tracer: execCfg.Settings.Tracer},
-		cfg, execCfg.Clock, stopper, execCfg.Settings,
-	)
+	rpcContext := rpc.NewContext(rpc.ContextOptions{
+		AmbientCtx: log.AmbientContext{Tracer: execCfg.Settings.Tracer},
+		Config:     cfg,
+		Clock:      execCfg.Clock,
+		Stopper:    stopper,
+		Settings:   execCfg.Settings,
+	})
 	conn, err := rpcContext.GRPCUnvalidatedDial(tc.Server(serverIdx).ServingRPCAddr()).Connect(ctx)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -253,13 +253,22 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	var rpcContext *rpc.Context
 	if knobs := cfg.TestingKnobs.Server; knobs != nil {
 		serverKnobs := knobs.(*TestingKnobs)
-		rpcContext = rpc.NewContextWithTestingKnobs(
-			cfg.AmbientCtx, cfg.Config, clock, stopper, cfg.Settings,
-			serverKnobs.ContextTestingKnobs,
-		)
+		rpcContext = rpc.NewContext(rpc.ContextOptions{
+			AmbientCtx: cfg.AmbientCtx,
+			Config:     cfg.Config,
+			Clock:      clock,
+			Stopper:    stopper,
+			Settings:   cfg.Settings,
+			Knobs:      serverKnobs.ContextTestingKnobs,
+		})
 	} else {
-		rpcContext = rpc.NewContext(cfg.AmbientCtx, cfg.Config, clock, stopper,
-			cfg.Settings)
+		rpcContext = rpc.NewContext(rpc.ContextOptions{
+			AmbientCtx: cfg.AmbientCtx,
+			Config:     cfg.Config,
+			Clock:      clock,
+			Stopper:    stopper,
+			Settings:   cfg.Settings,
+		})
 	}
 	rpcContext.HeartbeatCB = func() {
 		if err := rpcContext.RemoteClocks.VerifyClockOffset(ctx); err != nil {

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -347,9 +347,13 @@ func startServer(t *testing.T) *TestServer {
 }
 
 func newRPCTestContext(ts *TestServer, cfg *base.Config) *rpc.Context {
-	rpcContext := rpc.NewContext(
-		log.AmbientContext{Tracer: ts.ClusterSettings().Tracer}, cfg, ts.Clock(), ts.Stopper(),
-		ts.ClusterSettings())
+	rpcContext := rpc.NewContext(rpc.ContextOptions{
+		AmbientCtx: log.AmbientContext{Tracer: ts.ClusterSettings().Tracer},
+		Config:     cfg,
+		Clock:      ts.Clock(),
+		Stopper:    ts.Stopper(),
+		Settings:   ts.ClusterSettings(),
+	})
 	// Ensure that the RPC client context validates the server cluster ID.
 	// This ensures that a test where the server is restarted will not let
 	// its test RPC client talk to a server started by an unrelated concurrent test.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -453,14 +453,14 @@ func makeSQLServerArgs(
 	if p, ok := baseCfg.TestingKnobs.Server.(*TestingKnobs); ok {
 		rpcTestingKnobs = p.ContextTestingKnobs
 	}
-	rpcContext := rpc.NewContextWithTestingKnobs(
-		baseCfg.AmbientCtx,
-		baseCfg.Config,
-		clock,
-		stopper,
-		st,
-		rpcTestingKnobs,
-	)
+	rpcContext := rpc.NewContext(rpc.ContextOptions{
+		AmbientCtx: baseCfg.AmbientCtx,
+		Config:     baseCfg.Config,
+		Clock:      clock,
+		Stopper:    stopper,
+		Settings:   st,
+		Knobs:      rpcTestingKnobs,
+	})
 
 	// TODO(tbg): expose this registry via prometheus. See:
 	// https://github.com/cockroachdb/cockroach/issues/47905

--- a/pkg/sql/alter_role.go
+++ b/pkg/sql/alter_role.go
@@ -137,7 +137,7 @@ func (n *alterRoleNode) startExec(params runParams) error {
 			)
 		}
 
-		if len(hashedPassword) > 0 && params.extendedEvalCtx.ExecCfg.RPCContext.Insecure {
+		if len(hashedPassword) > 0 && params.extendedEvalCtx.ExecCfg.RPCContext.Config.Insecure {
 			// We disallow setting a non-empty password in insecure mode
 			// because insecure means an observer may have MITM'ed the change
 			// and learned the password.

--- a/pkg/sql/create_role.go
+++ b/pkg/sql/create_role.go
@@ -117,7 +117,7 @@ func (n *CreateRoleNode) startExec(params runParams) error {
 			return err
 		}
 
-		if len(hashedPassword) > 0 && params.extendedEvalCtx.ExecCfg.RPCContext.Insecure {
+		if len(hashedPassword) > 0 && params.extendedEvalCtx.ExecCfg.RPCContext.Config.Insecure {
 			// We disallow setting a non-empty password in insecure mode
 			// because insecure means an observer may have MITM'ed the change
 			// and learned the password.

--- a/pkg/sql/execinfrapb/testutils.go
+++ b/pkg/sql/execinfrapb/testutils.go
@@ -42,13 +42,13 @@ func (s CallbackMetadataSource) DrainMeta(ctx context.Context) []ProducerMetadat
 }
 
 func newInsecureRPCContext(stopper *stop.Stopper) *rpc.Context {
-	return rpc.NewContext(
-		log.AmbientContext{Tracer: tracing.NewTracer()},
-		&base.Config{Insecure: true},
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond),
-		stopper,
-		cluster.MakeTestingClusterSettings(),
-	)
+	return rpc.NewContext(rpc.ContextOptions{
+		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
+		Config:     &base.Config{Insecure: true},
+		Clock:      hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		Stopper:    stopper,
+		Settings:   cluster.MakeTestingClusterSettings(),
+	})
 }
 
 // StartMockDistSQLServer starts a MockDistSQLServer and returns the address on

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -113,7 +113,13 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 
 	ltc.tester = t
 	ltc.Stopper = stop.NewStopper()
-	cfg.RPCContext = rpc.NewContext(ambient, baseCtx, ltc.Clock, ltc.Stopper, cfg.Settings)
+	cfg.RPCContext = rpc.NewContext(rpc.ContextOptions{
+		AmbientCtx: ambient,
+		Config:     baseCtx,
+		Clock:      ltc.Clock,
+		Stopper:    ltc.Stopper,
+		Settings:   cfg.Settings,
+	})
 	cfg.RPCContext.NodeID.Set(ambient.AnnotateCtx(context.Background()), nodeID)
 	c := &cfg.RPCContext.ClusterID
 	server := rpc.NewServer(cfg.RPCContext) // never started

--- a/pkg/testutils/testcluster/testcluster_test.go
+++ b/pkg/testutils/testcluster/testcluster_test.go
@@ -202,11 +202,13 @@ func TestStopServer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rpcContext := rpc.NewContext(
-		log.AmbientContext{Tracer: tc.Server(0).ClusterSettings().Tracer},
-		tc.Server(1).RPCContext().Config, tc.Server(1).Clock(), tc.Stopper(),
-		tc.Server(1).ClusterSettings(),
-	)
+	rpcContext := rpc.NewContext(rpc.ContextOptions{
+		AmbientCtx: log.AmbientContext{Tracer: tc.Server(0).ClusterSettings().Tracer},
+		Config:     tc.Server(1).RPCContext().Config,
+		Clock:      tc.Server(1).Clock(),
+		Stopper:    tc.Stopper(),
+		Settings:   tc.Server(1).ClusterSettings(),
+	})
 	conn, err := rpcContext.GRPCDialNode(server1.ServingRPCAddr(), server1.NodeID(),
 		rpc.DefaultClass).Connect(context.Background())
 	if err != nil {


### PR DESCRIPTION
`rpc.NewContext` was one of these methods that could use one, especially
since it's about to pick up a TenantID.

Release note: None