### PR TITLE
release-20.1: cdc: Treat node draining errors as retryable.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -11,6 +11,7 @@ package changefeedccl
 import (
 	"context"
 	"encoding/hex"
+	"fmt"
 	"math/rand"
 	"net/url"
 	"sort"
@@ -29,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -568,6 +570,16 @@ func (b *changefeedResumer) Resume(
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
+
+			if flowinfra.IsFlowRetryableError(err) {
+				// We don't want to retry flowinfra retryable error in the retry loop above.
+				// This error currently indicates that this node is being drained.  As such,
+				// retries will not help.
+				// Instead, we want to make sure that the changefeed job is not marked failed
+				// due to a transient, retryable error.
+				err = jobs.NewRetryJobError(fmt.Sprintf("retryable flow error: %+v", err))
+			}
+
 			log.Warningf(ctx, `CHANGEFEED job %d returning with error: %+v`, jobID, err)
 			return err
 		}

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -2806,4 +2807,92 @@ func TestChangefeedRestartDuringBackfill(t *testing.T) {
 
 	// Only the enterprise version uses jobs.
 	t.Run(`enterprise`, enterpriseTest(testFn))
+}
+
+func TestChangefeedHandlesDrainingNodes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	flushCh := make(chan struct{}, 1)
+	defer close(flushCh)
+
+	if util.RaceEnabled {
+		t.Skip("takes too long with race enabled")
+	}
+
+	shouldDrain := true
+	knobs := base.TestingKnobs{DistSQL: &execinfra.TestingKnobs{
+		DrainFast: true,
+		Changefeed: &TestingKnobs{
+			AfterSinkFlush: func() error {
+				select {
+				case flushCh <- struct{}{}:
+				default:
+				}
+				return nil
+			},
+		},
+		Flowinfra: &flowinfra.TestingKnobs{
+			FlowRegistryDraining: func() bool {
+				if shouldDrain {
+					shouldDrain = false
+					return true
+				}
+				return false
+			},
+		},
+	}}
+
+	sinkDir, cleanupFn := testutils.TempDir(t)
+	defer cleanupFn()
+
+	tc := serverutils.StartTestCluster(t, 4, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			UseDatabase:   "test",
+			Knobs:         knobs,
+			ExternalIODir: sinkDir,
+		}})
+	defer tc.Stopper().Stop(context.Background())
+
+	db := tc.ServerConn(1)
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms'`)
+
+	sqlutils.CreateTable(
+		t, db, "foo",
+		"k INT PRIMARY KEY, v INT",
+		10,
+		sqlutils.ToRowFn(sqlutils.RowIdxFn, sqlutils.RowModuloFn(2)),
+	)
+
+	// Introduce 4 splits to get 5 ranges.  We need multiple ranges in order to run distributed
+	// flow.
+	sqlDB.Exec(t, "ALTER TABLE test.foo SPLIT AT (SELECT i*2 FROM generate_series(1, 4) AS g(i))")
+	sqlDB.Exec(t, "ALTER TABLE test.foo SCATTER")
+
+	// Create a factory which executes the CREATE CHANGEFEED statement on server 0.
+	// This statement should fail, but the job itself ought to be creaated.
+	// After some time, that job should be adopted by another node, and executed successfully.
+	f := cdctest.MakeCloudFeedFactory(tc.Server(1), tc.ServerConn(0), sinkDir, flushCh)
+
+	feed := feed(t, f, "CREATE CHANGEFEED FOR foo")
+	defer closeFeed(t, feed)
+
+	// At this point, the job created by feed will fail to start running on node 0 due to draining
+	// registry.  However, this job will be retried, and it should succeeded.
+	// Note: This test is a bit unrealistic in that if the registry is draining, that
+	// means that the server is draining (i.e being shut down).  We don't do a full shutdown
+	// here, but we are simulating a restart by failing to start a flow the first time around.
+	assertPayloads(t, feed, []string{
+		`foo: [1]->{"after": {"k": 1, "v": 1}}`,
+		`foo: [2]->{"after": {"k": 2, "v": 0}}`,
+		`foo: [3]->{"after": {"k": 3, "v": 1}}`,
+		`foo: [4]->{"after": {"k": 4, "v": 0}}`,
+		`foo: [5]->{"after": {"k": 5, "v": 1}}`,
+		`foo: [6]->{"after": {"k": 6, "v": 0}}`,
+		`foo: [7]->{"after": {"k": 7, "v": 1}}`,
+		`foo: [8]->{"after": {"k": 8, "v": 0}}`,
+		`foo: [9]->{"after": {"k": 9, "v": 1}}`,
+		`foo: [10]->{"after": {"k": 10, "v": 0}}`,
+	})
 }

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -234,6 +234,9 @@ type TestingKnobs struct {
 	// Changefeed contains testing knobs specific to the changefeed system.
 	Changefeed base.ModuleTestingKnobs
 
+	// Flowinfra contains testing knobs specific to the flowinfra system
+	Flowinfra base.ModuleTestingKnobs
+
 	// EnableVectorizedInvariantsChecker, if enabled, will allow for planning
 	// the invariant checkers between all columnar operators.
 	EnableVectorizedInvariantsChecker bool

--- a/pkg/sql/flowinfra/flow_registry.go
+++ b/pkg/sql/flowinfra/flow_registry.go
@@ -23,8 +23,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 	"github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
 )
 
 var errNoInboundStreamConnection = errors.New("no inbound stream connection")

--- a/pkg/sql/flowinfra/flow_registry.go
+++ b/pkg/sql/flowinfra/flow_registry.go
@@ -165,6 +165,20 @@ func (fr *FlowRegistry) releaseEntryLocked(id execinfrapb.FlowID) {
 	}
 }
 
+type flowRetryableError struct {
+	cause error
+}
+
+func (e *flowRetryableError) Error() string {
+	return fmt.Sprintf("flow retryable error: %+v", e.cause)
+}
+
+// IsFlowRetryableError returns true if an error represents a retryable
+// flow error.
+func IsFlowRetryableError(e error) bool {
+	return errors.HasType(e, (*flowRetryableError)(nil))
+}
+
 // RegisterFlow makes a flow accessible to ConnectInboundStream. Any concurrent
 // ConnectInboundStream calls that are waiting for this flow are woken up.
 //
@@ -194,12 +208,19 @@ func (fr *FlowRegistry) RegisterFlow(
 			}
 		}
 	}()
-	if fr.draining {
-		return errors.Errorf(
-			"could not register flowID %d on node %d because the registry is draining",
+
+	draining := fr.draining
+	if f.Cfg != nil {
+		if knobs, ok := f.Cfg.TestingKnobs.Flowinfra.(*TestingKnobs); ok && knobs != nil && knobs.FlowRegistryDraining != nil {
+			draining = knobs.FlowRegistryDraining()
+		}
+	}
+
+	if draining {
+		return &flowRetryableError{cause: errors.Errorf(
+			"could not register flowID %d because the registry is draining",
 			id,
-			fr.nodeID,
-		)
+		)}
 	}
 	entry := fr.getEntryLocked(id)
 	if entry.flow != nil {

--- a/pkg/sql/flowinfra/testing_knobs.go
+++ b/pkg/sql/flowinfra/testing_knobs.go
@@ -1,0 +1,20 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package flowinfra
+
+// TestingKnobs are the testing knobs for flowinfra.
+type TestingKnobs struct {
+	// FlowRegistryDraining overrides draining state of the registry.
+	FlowRegistryDraining func() bool
+}
+
+// ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
+func (*TestingKnobs) ModuleTestingKnobs() {}


### PR DESCRIPTION
Backport 1/1 commits from #49743.

/cc @cockroachdb/release

---

Fixes #46515
Fixes #43771

Handle flow registration errors due to draining node as retryable.

Release notes (reliability): Treat errors due to draining nodes
as retryable when starting CDC.
