### PR TITLE
kvserver: skip TestClosedTimestampCanServeWithConflictingIntent

### DIFF
--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -182,6 +182,8 @@ func TestClosedTimestampCanServeThroughoutLeaseTransfer(t *testing.T) {
 func TestClosedTimestampCanServeWithConflictingIntent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	t.Skip("https://github.com/cockroachdb/cockroach/issues/50091")
+
 	ctx := context.Background()
 	tc, _, desc, repls := setupTestClusterForClosedTimestampTesting(ctx, t, testingTargetDuration)
 	defer tc.Stopper().Stop(ctx)


### PR DESCRIPTION
See https://github.com/cockroachdb/cockroach/issues/50091.

Release note: None