### PR TITLE
changefeedccl: add tests for changefeeds on enum types

### DIFF
--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -232,8 +232,8 @@ func createBenchmarkChangefeed(
 		NeedsInitialScan: needsInitialScan,
 	}
 
-	rowsFn := kvsToRows(s.ExecutorConfig().(sql.ExecutorConfig).Codec,
-		s.LeaseManager().(*lease.Manager), details, buf.Get)
+	cfg := s.ExecutorConfig().(sql.ExecutorConfig)
+	rowsFn := kvsToRows(ctx, cfg.Codec, cfg.Settings, cfg.DB, cfg.LeaseManager, details, buf.Get)
 	sf := span.MakeFrontier(spans...)
 	tickFn := emitEntries(s.ClusterSettings(), details, hlc.Timestamp{}, sf,
 		encoder, sink, rowsFn, TestingKnobs{}, metrics)

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -54,13 +54,16 @@ type emitEntry struct {
 // returns a closure that may be repeatedly called to advance the changefeed.
 // The returned closure is not threadsafe.
 func kvsToRows(
+	ctx context.Context,
 	codec keys.SQLCodec,
+	settings *cluster.Settings,
+	db *kv.DB,
 	leaseMgr *lease.Manager,
 	details jobspb.ChangefeedDetails,
 	inputFn func(context.Context) (kvfeed.Event, error),
 ) func(context.Context) ([]emitEntry, error) {
 	_, withDiff := details.Opts[changefeedbase.OptDiff]
-	rfCache := newRowFetcherCache(codec, leaseMgr)
+	rfCache := newRowFetcherCache(ctx, codec, settings, leaseMgr, db)
 
 	var kvs row.SpanKVFetcher
 	appendEmitEntryForKV := func(

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -205,7 +205,7 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 	_, withDiff := ca.spec.Feed.Opts[changefeedbase.OptDiff]
 	kvfeedCfg := makeKVFeedCfg(ca.flowCtx.Cfg, leaseMgr, ca.kvFeedMemMon, ca.spec,
 		spans, withDiff, buf, metrics)
-	rowsFn := kvsToRows(ca.flowCtx.Codec(), leaseMgr, ca.spec.Feed, buf.Get)
+	rowsFn := kvsToRows(ctx, ca.flowCtx.Codec(), ca.FlowCtx.Cfg.Settings, ca.FlowCtx.Cfg.DB, leaseMgr, ca.spec.Feed, buf.Get)
 	ca.tickFn = emitEntries(ca.flowCtx.Cfg.Settings, ca.spec.Feed,
 		kvfeedCfg.InitialHighWater, sf, ca.encoder, ca.sink, rowsFn, knobs, metrics)
 	ca.startKVFeed(ctx, kvfeedCfg)

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -420,6 +420,56 @@ func TestChangefeedInitialScan(t *testing.T) {
 	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
+func TestChangefeedUserDefinedTypes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		// Set up a type and table.
+		sqlDB.Exec(t, `SET experimental_enable_enums = true`)
+		sqlDB.Exec(t, `CREATE TYPE t AS ENUM ('hello', 'howdy', 'hi')`)
+		sqlDB.Exec(t, `CREATE TABLE tt (x INT PRIMARY KEY, y t)`)
+		sqlDB.Exec(t, `INSERT INTO tt VALUES (0, 'hello')`)
+
+		// Open up the changefeed.
+		cf := feed(t, f, `CREATE CHANGEFEED FOR tt`)
+		defer closeFeed(t, cf)
+
+		assertPayloads(t, cf, []string{
+			`tt: [0]->{"after": {"x": 0, "y": "hello"}}`,
+		})
+
+		sqlDB.Exec(t, `INSERT INTO tt VALUES (1, 'howdy'), (2, 'hi')`)
+		assertPayloads(t, cf, []string{
+			`tt: [1]->{"after": {"x": 1, "y": "howdy"}}`,
+			`tt: [2]->{"after": {"x": 2, "y": "hi"}}`,
+		})
+
+		// Alter the type and insert a new value.
+		sqlDB.Exec(t, `ALTER TYPE t ADD VALUE 'hiya'`)
+		sqlDB.Exec(t, `INSERT INTO tt VALUES (3, 'hiya')`)
+		assertPayloads(t, cf, []string{
+			`tt: [3]->{"after": {"x": 3, "y": "hiya"}}`,
+		})
+
+		// If we create a new type and add that type to tt, it should be picked
+		// up by the schema feed.
+		sqlDB.Exec(t, `CREATE TYPE t2 AS ENUM ('bye', 'cya')`)
+		sqlDB.Exec(t, `ALTER TABLE tt ADD COLUMN z t2 DEFAULT 'bye'`)
+		sqlDB.Exec(t, `INSERT INTO tt VALUES (4, 'hello', 'cya')`)
+
+		assertPayloads(t, cf, []string{
+			`tt: [0]->{"after": {"x": 0, "y": "hello", "z": "bye"}}`,
+			`tt: [1]->{"after": {"x": 1, "y": "howdy", "z": "bye"}}`,
+			`tt: [2]->{"after": {"x": 2, "y": "hi", "z": "bye"}}`,
+			`tt: [3]->{"after": {"x": 3, "y": "hiya", "z": "bye"}}`,
+			`tt: [4]->{"after": {"x": 4, "y": "hello", "z": "cya"}}`,
+		})
+	}
+
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
+}
+
 // Test how Changefeeds react to schema changes that do not require a backfill
 // operation.
 func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {

--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -12,12 +12,16 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -33,6 +37,9 @@ type rowFetcherCache struct {
 	leaseMgr *lease.Manager
 	fetchers map[idVersion]*row.Fetcher
 
+	collection *descs.Collection
+	db         *kv.DB
+
 	a rowenc.DatumAlloc
 }
 
@@ -41,11 +48,19 @@ type idVersion struct {
 	version descpb.DescriptorVersion
 }
 
-func newRowFetcherCache(codec keys.SQLCodec, leaseMgr *lease.Manager) *rowFetcherCache {
+func newRowFetcherCache(
+	ctx context.Context,
+	codec keys.SQLCodec,
+	settings *cluster.Settings,
+	leaseMgr *lease.Manager,
+	db *kv.DB,
+) *rowFetcherCache {
 	return &rowFetcherCache{
-		codec:    codec,
-		leaseMgr: leaseMgr,
-		fetchers: make(map[idVersion]*row.Fetcher),
+		codec:      codec,
+		leaseMgr:   leaseMgr,
+		collection: descs.NewCollection(ctx, settings, leaseMgr),
+		db:         db,
+		fetchers:   make(map[idVersion]*row.Fetcher),
 	}
 }
 
@@ -62,20 +77,25 @@ func (c *rowFetcherCache) TableDescForKey(
 		if err != nil {
 			return nil, err
 		}
-		// No caching of these are attempted, since the lease manager does its
-		// own caching.
-		desc, _, err := c.leaseMgr.Acquire(ctx, ts, tableID)
-		if err != nil {
+
+		// Retrieve the target TableDesc. We open a txn here, but only because
+		// the descs.Collection needs one. Internally, the descs.Collection just
+		// uses the txn to grab a read timestamp, which we set to ts here.
+		if err := c.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			txn.SetFixedTimestamp(ctx, ts)
+			var err error
+			// No caching of these are attempted, since the lease manager does its
+			// own caching.
+			tableDesc, err = c.collection.GetTableVersionByID(ctx, txn, tableID, tree.ObjectLookupFlagsWithRequired())
+			return err
+		}); err != nil {
 			// Manager can return all kinds of errors during chaos, but based on
 			// its usage, none of them should ever be terminal.
 			return nil, MarkRetryableError(err)
 		}
-		tableDesc = desc.(*tabledesc.Immutable)
 		// Immediately release the lease, since we only need it for the exact
 		// timestamp requested.
-		if err := c.leaseMgr.Release(tableDesc); err != nil {
-			return nil, err
-		}
+		c.collection.ReleaseAll(ctx)
 
 		// Skip over the column data.
 		for ; skippedCols < len(tableDesc.PrimaryIndex.ColumnIDs); skippedCols++ {
@@ -100,7 +120,13 @@ func (c *rowFetcherCache) RowFetcherForTableDesc(
 	tableDesc *tabledesc.Immutable,
 ) (*row.Fetcher, error) {
 	idVer := idVersion{id: tableDesc.ID, version: tableDesc.Version}
-	if rf, ok := c.fetchers[idVer]; ok {
+	// Ensure that all user defined types are up to date with the cached
+	// version and the desired version to use the cache. It is safe to use
+	// UserDefinedTypeColsHaveSameVersion if we have a hit because we are
+	// guaranteed that the tables have the same version. Additionally, these
+	// fetchers are always initialized with a single tabledesc.Immutable.
+	if rf, ok := c.fetchers[idVer]; ok &&
+		tableDesc.UserDefinedTypeColsHaveSameVersion(rf.GetTables()[0].(*tabledesc.Immutable)) {
 		return rf, nil
 	}
 	// TODO(dan): Allow for decoding a subset of the columns.

--- a/pkg/sql/catalog/descpb/descriptor.go
+++ b/pkg/sql/catalog/descpb/descriptor.go
@@ -232,3 +232,12 @@ func TableFromDescriptor(desc *Descriptor, ts hlc.Timestamp) *TableDescriptor {
 	}
 	return t
 }
+
+// TypeFromDescriptor is the same thign as TableFromDescriptor, but for types.
+func TypeFromDescriptor(desc *Descriptor, ts hlc.Timestamp) *TypeDescriptor {
+	t := desc.GetType()
+	if t != nil {
+		MaybeSetDescriptorModificationTimeFromMVCCTimestamp(context.TODO(), desc, ts)
+	}
+	return t
+}

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -2532,6 +2532,12 @@ func (desc *Immutable) ContainsUserDefinedTypes() bool {
 	return len(desc.columnsWithUDTs) > 0
 }
 
+// GetColumnOrdinalsWithUserDefinedTypes returns a slice of column ordinals
+// of columns that contain user defined types.
+func (desc *Immutable) GetColumnOrdinalsWithUserDefinedTypes() []int {
+	return desc.columnsWithUDTs
+}
+
 // UserDefinedTypeColsHaveSameVersion returns whether this descriptor's columns
 // with user defined type metadata have the same versions of metadata as in the
 // other descriptor. Note that this function is only valid on two descriptors

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -481,6 +481,15 @@ func (rf *Fetcher) Init(
 	return nil
 }
 
+// GetTables returns all tables that this Fetcher was initialized with.
+func (rf *Fetcher) GetTables() []catalog.Descriptor {
+	ret := make([]catalog.Descriptor, len(rf.tables))
+	for i := range rf.tables {
+		ret[i] = rf.tables[i].desc
+	}
+	return ret
+}
+
 // StartScan initializes and starts the key-value scan. Can be used multiple
 // times.
 func (rf *Fetcher) StartScan(


### PR DESCRIPTION
Work for #49981.

This PR adds a basic test for a changefeed on a table with an enum type.

Release note: None