### PR TITLE
*: rename full cluster backup to cluster backup

### DIFF
--- a/docs/RFCS/20191202_cluster_backup_restore.md
+++ b/docs/RFCS/20191202_cluster_backup_restore.md
@@ -1,4 +1,4 @@
-- Feature Name: Full Cluster Backup/Restore
+- Feature Name: Cluster Backup/Restore*
 - Status: completed
 - Start Date: 2019-12-02
 - Authors: Paul Bardea
@@ -357,7 +357,7 @@ can assume that all system tables included in those backups are safe to restore
   interface for the user to provide these mappings.
 
 - Include `system.eventlog` in a full cluster backup. One reason for not doing
-  this initially is that some event logs may be non-sensical if the table is
+  this initially is that some event logs may be nonsensical if the table is
   restored in a cluster with a different number of nodes.
 
 - Additionally, one further improvement would be allow the restoration of a set
@@ -378,7 +378,7 @@ can assume that all system tables included in those backups are safe to restore
   failure in the middle of the backup. It will clean up the data following the
   normal backup procedures. In the case that there is a failure while updating
   the system tables, the cluster should be started up again. Since we enforce
-  that the cluster we are restoring to has no user data, this is acceptible.
+  that the cluster we are restoring to has no user data, this is acceptable.
 
 # Drawbacks
 
@@ -389,4 +389,7 @@ a full cluster restore when this assumption is violated.
 
 
 [1] Offline tables can however be references when setting zone configs. See
-#40285.
+\#40285.
+
+* This feature was previously named "Full Cluster Backup/Restore", but due to
+* avoid confusion with full backups, was renamed.

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -54,8 +54,8 @@ const (
 )
 
 // TODO(pbardea): We should move to a model of having the system tables opt-
-// {in,out} of being included in a full cluster backup. See #43781.
-var fullClusterSystemTables = []string{
+// {in,out} of being included in a cluster backup. See #43781.
+var clusterSystemTables = []string{
 	// System config tables.
 	sqlbase.UsersTable.Name,
 	sqlbase.ZonesTable.Name,
@@ -486,7 +486,7 @@ func backupPlanHook(
 
 				if m.DescriptorCoverage == tree.AllDescriptors &&
 					backupStmt.DescriptorCoverage != tree.AllDescriptors {
-					return errors.Errorf("cannot append a backup of specific tables or databases to a full-cluster backup")
+					return errors.Errorf("cannot append a backup of specific tables or databases to a cluster backup")
 				}
 
 				for i := range prev {
@@ -738,6 +738,7 @@ func backupPlanHook(
 				telemetry.Count("backup.encrypted")
 			}
 			if backupStmt.DescriptorCoverage == tree.AllDescriptors {
+				// Note: cluster backup used to be called "full cluster backup".
 				telemetry.Count("backup.targets.full_cluster")
 			}
 		}

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -2809,7 +2809,7 @@ func TestBackupEncrypted(t *testing.T) {
 	sqlDB.Exec(t, `CREATE USER neverappears`)
 	sqlDB.Exec(t, `SET CLUSTER SETTING cluster.organization = 'neverappears'`)
 
-	// Full cluster-backup to capture all possible metadata.
+	// Cluster backup to capture all possible metadata.
 	backupLoc1 := localFoo + "/x?COCKROACH_LOCALITY=default"
 	backupLoc2 := localFoo + "/x2?COCKROACH_LOCALITY=" + url.QueryEscape("dc=dc1")
 	backupLoc1inc := localFoo + "/inc1/x?COCKROACH_LOCALITY=default"

--- a/pkg/ccl/backupccl/cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/cluster_backup_restore_test.go
@@ -68,7 +68,7 @@ func createEmptyCluster(
 
 // Large test to ensure that all of the system table data is being restored in
 // the new cluster. Ensures that all the moving pieces are working together.
-func TestFullClusterBackup(t *testing.T) {
+func TestClusterBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const numAccounts = 10
@@ -210,9 +210,8 @@ func TestFullClusterBackup(t *testing.T) {
 
 	t.Run("ensure that jobs are restored", func(t *testing.T) {
 		// Ensure that the jobs in the RESTORE cluster is a superset of the jobs
-		// that were in the BACKUP cluster (before the full cluster BACKUP job was
-		// run). There may be more jobs now because the restore can run jobs of
-		// its own.
+		// that were in the BACKUP cluster (before the cluster BACKUP job was run).
+		// There may be more jobs now because the restore can run jobs of its own.
 		newJobs := sqlDBRestore.QueryStr(t, "SELECT * FROM system.jobs")
 		for _, oldJob := range preBackupJobs {
 			present := false
@@ -251,7 +250,7 @@ func TestFullClusterBackup(t *testing.T) {
 	})
 }
 
-func TestFullClusterBackupDroppedTables(t *testing.T) {
+func TestClusterBackupDroppedTables(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const numAccounts = 10
@@ -271,7 +270,7 @@ func TestFullClusterBackupDroppedTables(t *testing.T) {
 	}
 }
 
-func TestIncrementalFullClusterBackup(t *testing.T) {
+func TestIncrementalClusterBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const numAccounts = 10
@@ -291,9 +290,9 @@ func TestIncrementalFullClusterBackup(t *testing.T) {
 	sqlDBRestore.CheckQueryResults(t, checkQuery, sqlDB.QueryStr(t, checkQuery))
 }
 
-// TestEmptyFullClusterResotre ensures that we can backup and restore a full
+// TestEmptyClusterRestore ensures that we can backup and restore a full
 // cluster backup with only metadata (no user data). Regression test for #49573.
-func TestEmptyFullClusterRestore(t *testing.T) {
+func TestEmptyClusterRestore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	sqlDB, tempDir, cleanupFn := createEmptyCluster(t, singleNode)
@@ -310,7 +309,7 @@ func TestEmptyFullClusterRestore(t *testing.T) {
 	sqlDBRestore.CheckQueryResults(t, checkQuery, sqlDB.QueryStr(t, checkQuery))
 }
 
-func TestDisallowFullClusterRestoreOnNonFreshCluster(t *testing.T) {
+func TestDisallowClusterRestoreOnNonFreshCluster(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const numAccounts = 10
@@ -322,12 +321,12 @@ func TestDisallowFullClusterRestoreOnNonFreshCluster(t *testing.T) {
 	sqlDB.Exec(t, `BACKUP TO $1`, localFoo)
 	sqlDBRestore.Exec(t, `CREATE DATABASE foo`)
 	sqlDBRestore.ExpectErr(
-		t, "pq: full cluster restore can only be run on a cluster with no tables or databases but found 1 descriptors",
+		t, "pq: cluster restore can only be run on a cluster with no tables or databases but found 1 descriptors",
 		`RESTORE FROM $1`, localFoo,
 	)
 }
 
-func TestDisallowFullClusterRestoreOfNonFullBackup(t *testing.T) {
+func TestDisallowClusterRestoreOfNonFullBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const numAccounts = 10
@@ -338,12 +337,12 @@ func TestDisallowFullClusterRestoreOfNonFullBackup(t *testing.T) {
 
 	sqlDB.Exec(t, `BACKUP data.bank TO $1`, localFoo)
 	sqlDBRestore.ExpectErr(
-		t, "pq: full cluster RESTORE can only be used on full cluster BACKUP files",
+		t, "pq: cluster RESTORE can only be used on cluster BACKUP files",
 		`RESTORE FROM $1`, localFoo,
 	)
 }
 
-func TestAllowNonFullClusterRestoreOfFullBackup(t *testing.T) {
+func TestAllowNonClusterRestoreOfFullBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const numAccounts = 10
@@ -358,7 +357,7 @@ func TestAllowNonFullClusterRestoreOfFullBackup(t *testing.T) {
 	sqlDB.CheckQueryResults(t, checkResults, sqlDB.QueryStr(t, checkResults))
 }
 
-func TestResotreDatabaseFromFullClusterBackup(t *testing.T) {
+func TestResotreDatabaseFromClusterBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const numAccounts = 10
@@ -372,7 +371,7 @@ func TestResotreDatabaseFromFullClusterBackup(t *testing.T) {
 	sqlDB.CheckQueryResults(t, "SELECT count(*) FROM data.bank", [][]string{{"10"}})
 }
 
-func TestRestoreSystemTableFromFullClusterBackup(t *testing.T) {
+func TestRestoreSystemTableFromClusterBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const numAccounts = 10
@@ -387,7 +386,7 @@ func TestRestoreSystemTableFromFullClusterBackup(t *testing.T) {
 	sqlDB.CheckQueryResults(t, "SELECT * FROM temp_sys.users", sqlDB.QueryStr(t, "SELECT * FROM system.users"))
 }
 
-func TestCreateDBAndTableIncrementalFullClusterBackup(t *testing.T) {
+func TestCreateDBAndTableIncrementalClusterBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	_, _, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, 0, initNone)

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -442,9 +442,9 @@ func WriteTableDescs(
 		b := txn.NewBatch()
 		wroteDBs := make(map[sqlbase.ID]*sqlbase.ImmutableDatabaseDescriptor)
 		for _, desc := range databases {
-			// If the restore is not a full cluster restore we cannot know that
-			// the users on the restoring cluster match the ones that were on the
-			// cluster that was backed up. So we wipe the priviledges on the database.
+			// If the restore is not a cluster restore we cannot know that the users
+			// on the restoring cluster match the ones that were on the cluster that
+			// was backed up. So we wipe the priviledges on the database.
 			if descCoverage != tree.AllDescriptors {
 				desc.Privileges = sqlbase.NewDefaultPrivilegeDescriptor()
 			}
@@ -460,7 +460,7 @@ func WriteTableDescs(
 		}
 		for i := range tables {
 			table := tables[i].TableDesc()
-			// For full cluster restore, keep privileges as they were.
+			// For cluster restore, keep privileges as they were.
 			if wrote, ok := wroteDBs[table.ParentID]; ok {
 				// Leave the privileges of the temp system tables as
 				// the default.
@@ -475,7 +475,7 @@ func WriteTableDescs(
 				}
 				// We don't check priv's here since we checked them during job planning.
 
-				// On full cluster restore, keep the privs as they are in the backup.
+				// On cluster restore, keep the privs as they are in the backup.
 				if descCoverage != tree.AllDescriptors {
 					// Default is to copy privs from restoring parent db, like CREATE TABLE.
 					// TODO(dt): Make this more configurable.
@@ -1255,7 +1255,7 @@ func (r *restoreResumer) dropTables(ctx context.Context, jr *jobs.Registry, txn 
 func (r *restoreResumer) restoreSystemTables(ctx context.Context) error {
 	executor := r.execCfg.InternalExecutor
 	var err error
-	for _, systemTable := range fullClusterSystemTables {
+	for _, systemTable := range clusterSystemTables {
 		systemTxn := r.execCfg.DB.NewTxn(ctx, "system-restore-txn")
 		txnDebugName := fmt.Sprintf("restore-system-systemTable-%s", systemTable)
 		// Don't clear the jobs table as to not delete the jobs that are performing

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -249,7 +249,7 @@ func allocateTableRewrites(
 				}
 
 				if table.ParentID == sqlbase.SystemDB.GetID() {
-					// For full cluster backups, put the system tables in the temporary
+					// For cluster backups, put the system tables in the temporary
 					// system table.
 					targetDB = restoreTempSystemDB
 					tableRewrites[table.ID] = &jobspb.RestoreDetails_TableRewrite{ParentID: tempSysDBID}
@@ -348,9 +348,9 @@ func allocateTableRewrites(
 	}
 
 	// tablesToRemap usually contains all tables that are being restored. In a
-	// full cluster restore this should only include the system tables that need
-	// to be remapped to the temporary table. All other tables in a full cluster
-	// backup should have the same ID as they do in the backup.
+	// cluster restore this should only include the system tables that need to be
+	// remapped to the temporary table. All other tables in a cluster backup
+	// should have the same ID as they do in the backup.
 	tablesToRemap := make([]*sqlbase.TableDescriptor, 0, len(tablesByID))
 	for _, table := range tablesByID {
 		if descriptorCoverage == tree.AllDescriptors {
@@ -706,13 +706,13 @@ func doRestorePlan(
 	}
 
 	// Validate that the table coverage of the backup matches that of the restore.
-	// This prevents FULL CLUSTER backups to be restored as anything but full
-	// cluster restores and vice-versa.
+	// This prevents cluster backups to be restored as anything but cluster
+	// restores and vice-versa.
 	if restoreStmt.DescriptorCoverage == tree.AllDescriptors && mainBackupManifests[0].DescriptorCoverage == tree.RequestedDescriptors {
-		return errors.Errorf("full cluster RESTORE can only be used on full cluster BACKUP files")
+		return errors.Errorf("cluster RESTORE can only be used on cluster BACKUP files")
 	}
 
-	// Ensure that no user table descriptors exist for a full cluster restore.
+	// Ensure that no user table descriptors exist for a cluster restore.
 	txn := p.ExecCfg().DB.NewTxn(ctx, "count-user-descs")
 	descCount, err := catalogkv.CountUserDescriptors(ctx, txn, p.ExecCfg().Codec)
 	if err != nil {
@@ -720,7 +720,7 @@ func doRestorePlan(
 	}
 	if descCount != 0 && restoreStmt.DescriptorCoverage == tree.AllDescriptors {
 		return errors.Errorf(
-			"full cluster restore can only be run on a cluster with no tables or databases but found %d descriptors",
+			"cluster restore can only be run on a cluster with no tables or databases but found %d descriptors",
 			descCount,
 		)
 	}

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -170,7 +170,7 @@ func backupShowerHeaders(showSchemas bool, opts map[string]string) sqlbase.Resul
 		{Name: "end_time", Typ: types.Timestamp},
 		{Name: "size_bytes", Typ: types.Int},
 		{Name: "rows", Typ: types.Int},
-		{Name: "is_full_cluster", Typ: types.Bool},
+		{Name: "is_cluster_backup", Typ: types.Bool},
 	}
 	if showSchemas {
 		baseHeaders = append(baseHeaders, sqlbase.ResultColumn{Name: "create_statement", Typ: types.String})

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -25,7 +25,7 @@ const (
 	RequestedDescriptors DescriptorCoverage = iota
 	// AllDescriptors table coverage means that backup is guaranteed to have all the
 	// relevant data in the cluster. These can only be created by running a
-	// full cluster backup with `BACKUP TO`.
+	// cluster backup with `BACKUP TO`.
 	AllDescriptors
 )
 


### PR DESCRIPTION
The name full cluster backup can easily become confusing when also
talking about full vs incremental backups. The "full" modifier isn't
adding anything and was primarily left over from how we started talking
about the feature - and was never re-evaluated.

In an attempt to correct my wrongs, I replaced most references of "full
cluster backup" with just "cluster backup". The term "entire cluster" is
used when we are collecting all descriptors in the entire cluster. I
renamed the RFC title and file so that people searching for it for
reference have a consistent name. I did leave, at least for now, all
other cases of "full cluster" in the RFC and added a note that this
feature has been renamed.

Release note: None