### PR TITLE
sql: add a view dep on sequence string arguments

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1072,3 +1072,13 @@ DROP TABLE b;
 
 statement ok
 DROP TABLE a;
+
+# A dependency on a sequence should be added if the sequence is used in a
+# currval call. (Regression #50033)
+
+statement ok
+CREATE SEQUENCE currval_dep_test;
+CREATE TABLE c(a INT DEFAULT(currval('currval_dep_test')))
+
+statement error pq: cannot drop sequence currval_dep_test because other objects depend on it
+DROP SEQUENCE currval_dep_test

--- a/pkg/sql/opt/optbuilder/testdata/create_view
+++ b/pkg/sql/opt/optbuilder/testdata/create_view
@@ -323,3 +323,32 @@ create-view t.public.v21
  ├── columns: sum:5
  └── dependencies
       └── abc [columns: a b c]
+
+# Sequence dependency should be added when a sequence is referred to as a string
+# argument to a sequence builtin function.
+build
+CREATE VIEW v22 AS SELECT nextval('s')
+----
+create-view t.public.v22
+ ├── SELECT nextval('s':::STRING)
+ ├── columns: nextval:1
+ └── dependencies
+      └── s
+
+build
+CREATE VIEW v23 AS SELECT t.x FROM (SELECT currval('s') AS x) AS t
+----
+create-view t.public.v23
+ ├── SELECT t.x FROM (SELECT currval('s':::STRING) AS x) AS t
+ ├── columns: x:1
+ └── dependencies
+      └── s
+
+build
+CREATE VIEW v24 AS SELECT setval('s', 20, false)
+----
+create-view t.public.v24
+ ├── SELECT setval('s':::STRING, 20:::INT8, false)
+ ├── columns: setval:1
+ └── dependencies
+      └── s

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/sequence"
 	"github.com/cockroachdb/errors"
 )
 
@@ -251,7 +252,7 @@ func isAllowedDependentDescInRenameDatabase(
 		if err != nil {
 			return false, "", err
 		}
-		seqNames, err := getUsedSequenceNames(typedExpr)
+		seqNames, err := sequence.GetUsedSequenceNames(typedExpr)
 		if err != nil {
 			return false, "", err
 		}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -69,6 +69,9 @@ var (
 		"input value must be <= %d (maximum Unicode code point)", utf8.MaxRune)
 	errStringTooLarge = pgerror.Newf(pgcode.ProgramLimitExceeded,
 		"requested length too large, exceeds %s", humanizeutil.IBytes(maxAllocatedStringSize))
+	// SequenceNameArg represents the name of sequence (string) arguments in
+	// builtin functions.
+	SequenceNameArg = "sequence_name"
 )
 
 const maxAllocatedStringSize = 128 * 1024 * 1024
@@ -1734,12 +1737,13 @@ CockroachDB supports the following flags:
 
 	"nextval": makeBuiltin(
 		tree.FunctionProperties{
-			Category:         categorySequences,
-			DistsqlBlocklist: true,
-			Impure:           true,
+			Category:             categorySequences,
+			DistsqlBlocklist:     true,
+			Impure:               true,
+			HasSequenceArguments: true,
 		},
 		tree.Overload{
-			Types:      tree.ArgTypes{{"sequence_name", types.String}},
+			Types:      tree.ArgTypes{{SequenceNameArg, types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
@@ -1760,12 +1764,13 @@ CockroachDB supports the following flags:
 
 	"currval": makeBuiltin(
 		tree.FunctionProperties{
-			Category:         categorySequences,
-			DistsqlBlocklist: true,
-			Impure:           true,
+			Category:             categorySequences,
+			DistsqlBlocklist:     true,
+			Impure:               true,
+			HasSequenceArguments: true,
 		},
 		tree.Overload{
-			Types:      tree.ArgTypes{{"sequence_name", types.String}},
+			Types:      tree.ArgTypes{{SequenceNameArg, types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
@@ -1808,12 +1813,13 @@ CockroachDB supports the following flags:
 	// See https://github.com/cockroachdb/cockroach/issues/21564
 	"setval": makeBuiltin(
 		tree.FunctionProperties{
-			Category:         categorySequences,
-			DistsqlBlocklist: true,
-			Impure:           true,
+			Category:             categorySequences,
+			DistsqlBlocklist:     true,
+			Impure:               true,
+			HasSequenceArguments: true,
 		},
 		tree.Overload{
-			Types:      tree.ArgTypes{{"sequence_name", types.String}, {"value", types.Int}},
+			Types:      tree.ArgTypes{{SequenceNameArg, types.String}, {"value", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
@@ -1835,7 +1841,7 @@ CockroachDB supports the following flags:
 		},
 		tree.Overload{
 			Types: tree.ArgTypes{
-				{"sequence_name", types.String}, {"value", types.Int}, {"is_called", types.Bool},
+				{SequenceNameArg, types.String}, {"value", types.Int}, {"is_called", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -96,6 +96,13 @@ type FunctionProperties struct {
 	// the Postgres ones at test time.
 	// This should be used with caution.
 	IgnoreVolatilityCheck bool
+
+	// HasSequenceArguments is true if the builtin function takes in a sequence
+	// name (string) and can be used in a scalar expression.
+	// TODO(richardjcai): When implicit casting is supported, these builtins
+	// should take RegClass as the arg type for the sequence name instead of
+	// string, we will add a dependency on all RegClass types used in a view.
+	HasSequenceArguments bool
 }
 
 // ShouldDocument returns whether the built-in function should be included in

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -25,9 +25,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/cockroach/pkg/util/sequence"
 	"github.com/cockroachdb/errors"
 )
 
@@ -410,7 +410,7 @@ func maybeAddSequenceDependencies(
 	expr tree.TypedExpr,
 	backrefs map[sqlbase.ID]*sqlbase.MutableTableDescriptor,
 ) ([]*MutableTableDescriptor, error) {
-	seqNames, err := getUsedSequenceNames(expr)
+	seqNames, err := sequence.GetUsedSequenceNames(expr)
 	if err != nil {
 		return nil, err
 	}
@@ -547,37 +547,4 @@ func (p *planner) removeSequenceDependencies(
 	// Remove the reference from the column descriptor to the sequence descriptor.
 	col.UsesSequenceIds = []sqlbase.ID{}
 	return nil
-}
-
-// getUsedSequenceNames returns the name of the sequence passed to
-// a call to nextval in the given expression, or nil if there is
-// no call to nextval.
-// e.g. nextval('foo') => "foo"; <some other expression> => nil
-func getUsedSequenceNames(defaultExpr tree.TypedExpr) ([]string, error) {
-	searchPath := sessiondata.SearchPath{}
-	var names []string
-	_, err := tree.SimpleVisit(
-		defaultExpr,
-		func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
-			switch t := expr.(type) {
-			case *tree.FuncExpr:
-				def, err := t.Func.Resolve(searchPath)
-				if err != nil {
-					return false, expr, err
-				}
-				if def.Name == "nextval" {
-					arg := t.Exprs[0]
-					switch a := arg.(type) {
-					case *tree.DString:
-						names = append(names, string(*a))
-					}
-				}
-			}
-			return true, expr, nil
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-	return names, nil
 }

--- a/pkg/util/sequence/sequence.go
+++ b/pkg/util/sequence/sequence.go
@@ -1,0 +1,98 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sequence
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+)
+
+// GetSequenceFromFunc extracts a sequence name from a FuncExpr if the function
+// takes a sequence name as an arg. Returns the name of the sequence or nil
+// if no sequence was found.
+func GetSequenceFromFunc(funcExpr *tree.FuncExpr) (*string, error) {
+	searchPath := sessiondata.SearchPath{}
+
+	// Resolve doesn't use the searchPath for resolving FunctionDefinitions
+	// so we can pass in an empty SearchPath.
+	def, err := funcExpr.Func.Resolve(searchPath)
+	if err != nil {
+		return nil, err
+	}
+
+	fnProps, overloads := builtins.GetBuiltinProperties(def.Name)
+	if fnProps != nil && fnProps.HasSequenceArguments {
+		found := false
+		for _, overload := range overloads {
+			// Find the overload that matches funcExpr.
+			if funcExpr.ResolvedOverload().Types.Match(overload.Types.Types()) {
+				found = true
+				argTypes, ok := overload.Types.(tree.ArgTypes)
+				if !ok {
+					panic(pgerror.Newf(
+						pgcode.InvalidFunctionDefinition,
+						"%s has invalid argument types", funcExpr.Func.String(),
+					))
+				}
+				for i := 0; i < overload.Types.Length(); i++ {
+					// Find the sequence name arg.
+					argName := argTypes[i].Name
+					if argName == builtins.SequenceNameArg {
+						arg := funcExpr.Exprs[i]
+						switch a := arg.(type) {
+						case *tree.DString:
+							seqName := string(*a)
+							return &seqName, nil
+						}
+					}
+				}
+			}
+		}
+		if !found {
+			panic(pgerror.New(
+				pgcode.DatatypeMismatch,
+				"could not find matching function overload for given arguments",
+			))
+		}
+	}
+	return nil, nil
+}
+
+// GetUsedSequenceNames returns the name of the sequence passed to
+// a call to sequence function in the given expression or nil if no sequence
+// names are found.
+// e.g. nextval('foo') => "foo"; <some other expression> => nil
+func GetUsedSequenceNames(defaultExpr tree.TypedExpr) ([]string, error) {
+	var names []string
+	_, err := tree.SimpleVisit(
+		defaultExpr,
+		func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+			switch t := expr.(type) {
+			case *tree.FuncExpr:
+				name, err := GetSequenceFromFunc(t)
+				if err != nil {
+					return false, nil, err
+				}
+				if name != nil {
+					names = append(names, *name)
+				}
+			}
+			return true, expr, nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return names, nil
+}


### PR DESCRIPTION
Add a dependency on sequences that are used via string argument when creating a view.

Also fixed minor bug where column dependencies were not being added when a sequence is referred to in a currval call.

Fixes (part of) #24556 and #50033

Release note (sql change): Sequences passed as a string argument into views
are now tracked as a dependency. Example: CREATE VIEW v AS SELECT nextval('s')
will now add a dependency on sequence s.