### PR TITLE
kv: clarify which requests do not check for pending merges

### DIFF
--- a/docs/tech-notes/range-merges.md
+++ b/docs/tech-notes/range-merges.md
@@ -362,11 +362,6 @@ only reads one key and writes no keys, but it forces synchronization with all
 latches in the span latch manager, as no other commands can possibly execute in
 parallel with a command that claims to write all keys.
 
-**TODO(benesch,nvanbenschoten):** Actually, concurrent reads at lower timestamps
-are permitted. Is this a problem? Maybe. Answering this question is difficult
-and requires reasoning about the causal chain established by the sequence of
-requests sent by the merge transaction.
-
 It provides promise 2 by flipping [a bit][merge-bit] on the replica that
 indicates that a subsumption is in progress. When the bit is active, the
 replica blocks processing of all requests.

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1108,6 +1108,11 @@ func (r *Replica) checkExecutionCanProceed(
 		// Only check for a pending merge if latches are held and the Range
 		// lease is held by this Replica. Without both of these conditions,
 		// checkForPendingMergeRLocked could return false negatives.
+		//
+		// In practice, this means that follower reads or any request where
+		// concurrency.shouldAcquireLatches() == false (e.g. lease requests)
+		// will not check for a pending merge before executing and, as such,
+		// can execute while a range is in a merge's critical phase.
 		return r.checkForPendingMergeRLocked(ba)
 	}
 	return nil


### PR DESCRIPTION
Relates to #44878.

Also, clean up a TODO in `docs/tech-notes/range-merges.md` that's no
longer needed now that we acquire non-MVCC latches for SubsumeRequest.