### PR TITLE
kv: Skipping a flaky consistency queue test until the underlying issue is resolved

### DIFF
--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -391,6 +391,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 // The upreplication here is immaterial and serves only to add realism to the test.
 func TestConsistencyQueueRecomputeStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("Skip until #48251 is fixed")
 	testutils.RunTrueAndFalse(t, "hadEstimates", testConsistencyQueueRecomputeStatsImpl)
 }
 


### PR DESCRIPTION
Informs #48251

This PR skips the TestConsistencyQueueRecomputeStats test until we have time to investigate the underlying issue and fix it. This will unblock master builds until in the meantime.

Release note: None