### PR TITLE
scripts: update release notes docker command

### DIFF
--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -856,7 +856,7 @@ if not hidedownloads:
 
 {% include copy-clipboard.html %}
 ~~~shell
-$ docker pull cockroachdb/cockroach""" + ("-unstable:" if "-" in current_version else ":") + current_version + """
+$ docker pull {{page.release_info.docker_image}}:{{page.release_info.version}}
 ~~~
 """)
     print()


### PR DESCRIPTION
Previously, the `release-notes.py` script had logic to generate a
`docker pull` command for release notes based on the current version of
CockroachDB.

However, this is not necessary because the docs website build process
already has templating logic that builds the appropriate `docker pull`
command by pulling the correct values from the file
`cockroachdb/docs/_config_base.yml`.

Therefore, this patch removes the script's logic that builds the `docker
pull` command entirely, and replaces it with the templating syntax used
by the docs website (which is just a string).

Release note: None