### PR TITLE
kv: decompose roles of Gossip dependency in DistSender

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -196,7 +196,7 @@ func NewKeyNotPresentError(key string) error {
 }
 
 // AddressResolver is a thin wrapper around gossip's GetNodeIDAddress
-// that allows it to be used as a nodedialer.AddressResolver
+// that allows it to be used as a nodedialer.AddressResolver.
 func AddressResolver(gossip *Gossip) nodedialer.AddressResolver {
 	return func(nodeID roachpb.NodeID) (net.Addr, error) {
 		return gossip.GetNodeIDAddress(nodeID)
@@ -274,7 +274,7 @@ type Gossip struct {
 	resolverAddrs  map[util.UnresolvedAddr]resolver.Resolver
 	bootstrapAddrs map[util.UnresolvedAddr]roachpb.NodeID
 
-	localityTierMap map[string]struct{}
+	locality roachpb.Locality
 
 	lastConnectivity redact.RedactableString
 
@@ -320,13 +320,10 @@ func New(
 		storeMap:          make(map[roachpb.StoreID]roachpb.NodeID),
 		resolverAddrs:     map[util.UnresolvedAddr]resolver.Resolver{},
 		bootstrapAddrs:    map[util.UnresolvedAddr]roachpb.NodeID{},
-		localityTierMap:   map[string]struct{}{},
+		locality:          locality,
 		defaultZoneConfig: defaultZoneConfig,
 	}
 
-	for _, loc := range locality.Tiers {
-		g.localityTierMap[loc.String()] = struct{}{}
-	}
 	stopper.AddCloser(stop.CloserFn(g.server.AmbientContext.FinishEventLog))
 
 	registry.AddMetric(g.outgoing.gauge)
@@ -980,19 +977,12 @@ func (g *Gossip) getNodeIDAddressLocked(nodeID roachpb.NodeID) (*util.Unresolved
 	if err != nil {
 		return nil, err
 	}
-	for i := range nd.LocalityAddress {
-		locality := &nd.LocalityAddress[i]
-		if _, ok := g.localityTierMap[locality.LocalityTier.String()]; ok {
-			return &locality.Address, nil
-		}
-	}
-	return &nd.Address, nil
+	return nd.AddressForLocality(g.locality), nil
 }
 
-// getNodeIDAddressLocked looks up the SQL address of the node by ID. The mutex is
-// assumed held by the caller. This method is called externally via
-// GetNodeIDSQLAddress or internally when looking up a "distant" node address to
-// connect directly to.
+// getNodeIDAddressLocked looks up the SQL address of the node by ID. The mutex
+// is assumed held by the caller. This method is called externally via
+// GetNodeIDSQLAddress.
 func (g *Gossip) getNodeIDSQLAddressLocked(nodeID roachpb.NodeID) (*util.UnresolvedAddr, error) {
 	nd, err := g.getNodeDescriptorLocked(nodeID)
 	if err != nil {

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1609,6 +1609,38 @@ func (g *Gossip) findClient(match func(*client) bool) *client {
 	return nil
 }
 
+// A firstRangeMissingError indicates that the first range has not yet
+// been gossiped. This will be the case for a node which hasn't yet
+// joined the gossip network.
+type firstRangeMissingError struct{}
+
+// Error is part of the error interface.
+func (f firstRangeMissingError) Error() string {
+	return "the descriptor for the first range is not available via gossip"
+}
+
+// GetFirstRangeDescriptor implements kvcoord.FirstRangeProvider.
+func (g *Gossip) GetFirstRangeDescriptor() (*roachpb.RangeDescriptor, error) {
+	desc := &roachpb.RangeDescriptor{}
+	if err := g.GetInfoProto(KeyFirstRangeDescriptor, desc); err != nil {
+		return nil, firstRangeMissingError{}
+	}
+	return desc, nil
+}
+
+// OnFirstRangeChanged implements kvcoord.FirstRangeProvider.
+func (g *Gossip) OnFirstRangeChanged(cb func(*roachpb.RangeDescriptor)) {
+	g.RegisterCallback(KeyFirstRangeDescriptor, func(_ string, value roachpb.Value) {
+		ctx := context.Background()
+		desc := &roachpb.RangeDescriptor{}
+		if err := value.GetProto(desc); err != nil {
+			log.Errorf(ctx, "unable to parse gossiped first range descriptor: %s", err)
+		} else {
+			cb(desc)
+		}
+	})
+}
+
 // MakeExposedGossip initializes a DeprecatedGossip instance which exposes a
 // wrapped Gossip instance via Optional(). This is used on SQL servers running
 // inside of a KV server (i.e. single-tenant deployments).

--- a/pkg/gossip/keys.go
+++ b/pkg/gossip/keys.go
@@ -28,27 +28,27 @@ const separator = ":"
 // Constants for gossip keys.
 const (
 	// KeyClusterID is the unique UUID for this Cockroach cluster.
-	// The value is a string UUID for the cluster.  The cluster ID is
+	// The value is a string UUID for the cluster. The cluster ID is
 	// gossiped by all nodes that contain a replica of the first range,
 	// and it serves as a check for basic gossip connectivity. The
 	// Gossip.Connected channel is closed when we see this key.
 	KeyClusterID = "cluster-id"
 
 	// KeyStorePrefix is the key prefix for gossiping stores in the network.
-	// The suffix is a store ID and the value is roachpb.StoreDescriptor.
+	// The suffix is a store ID and the value is a roachpb.StoreDescriptor.
 	KeyStorePrefix = "store"
 
-	// KeyNodeIDPrefix is the key prefix for gossiping node id
-	// addresses. The actual key is suffixed with the decimal
-	// representation of the node id and the value is the host:port
-	// string address of the node. E.g. node:1 => 127.0.0.1:24001
+	// KeyNodeIDPrefix is the key prefix for gossiping node id addresses.
+	// The actual key is suffixed with the decimal representation of the
+	// node id (e.g. 'node:1') and the value is a roachpb.NodeDescriptor.
 	KeyNodeIDPrefix = "node"
 
-	// KeyHealthAlertPrefix is the key prefix for gossiping health alerts. The
-	// value is a proto of type HealthCheckResult.
+	// KeyHealthAlertPrefix is the key prefix for gossiping health alerts.
+	// The value is a proto of type HealthCheckResult.
 	KeyNodeHealthAlertPrefix = "health-alert"
 
-	// KeyNodeLivenessPrefix is the key prefix for gossiping node liveness info.
+	// KeyNodeLivenessPrefix is the key prefix for gossiping node liveness
+	// info.
 	KeyNodeLivenessPrefix = "liveness"
 
 	// KeySentinel is a key for gossip which must not expire or
@@ -57,10 +57,9 @@ const (
 	// the range lease for the first range.
 	KeySentinel = "sentinel"
 
-	// KeyFirstRangeDescriptor is the descriptor for the "first"
-	// range. The "first" range contains the meta1 key range, the first
-	// level of the bi-level key addressing scheme. The value is a slice
-	// of storage.Replica structs.
+	// KeyFirstRangeDescriptor is the descriptor for the "first" range. The
+	// "first" range contains the meta1 key range, the first level of the
+	// bi-level key addressing scheme. The value is a roachpb.RangeDescriptor.
 	KeyFirstRangeDescriptor = "first-range"
 
 	// KeySystemConfig is the gossip key for the system DB span.

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -259,11 +259,10 @@ type DistSenderConfig struct {
 // defaults will be used.
 func NewDistSender(cfg DistSenderConfig, g *gossip.Gossip) *DistSender {
 	ds := &DistSender{
-		st:         cfg.Settings,
-		clock:      cfg.Clock,
-		gossip:     g,
-		metrics:    makeDistSenderMetrics(),
-		nodeDialer: cfg.NodeDialer,
+		st:      cfg.Settings,
+		clock:   cfg.Clock,
+		gossip:  g,
+		metrics: makeDistSenderMetrics(),
 	}
 	if ds.st == nil {
 		ds.st = cluster.MakeTestingClusterSettings()
@@ -299,11 +298,11 @@ func NewDistSender(cfg DistSenderConfig, g *gossip.Gossip) *DistSender {
 		panic("no RPCContext set in DistSenderConfig")
 	}
 	ds.rpcContext = cfg.RPCContext
+	ds.nodeDialer = cfg.NodeDialer
 	if ds.rpcRetryOptions.Closer == nil {
 		ds.rpcRetryOptions.Closer = ds.rpcContext.Stopper.ShouldQuiesce()
 	}
 	ds.clusterID = &cfg.RPCContext.ClusterID
-	ds.nodeDialer = cfg.NodeDialer
 	ds.asyncSenderSem = quotapool.NewIntPool("DistSender async concurrency",
 		uint64(senderConcurrencyLimit.Get(&cfg.Settings.SV)))
 	senderConcurrencyLimit.SetOnChange(&cfg.Settings.SV, func() {

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -230,7 +230,7 @@ func (ds *DistSender) singleRangeFeed(
 	if ds.rpcContext != nil {
 		latencyFn = ds.rpcContext.RemoteClocks.Latency
 	}
-	replicas, err := NewReplicaSlice(ctx, ds.gossip, desc)
+	replicas, err := NewReplicaSlice(ctx, ds.nodeDescs, desc)
 	if err != nil {
 		return args.Timestamp, err
 	}

--- a/pkg/kv/kvclient/kvcoord/local_test_cluster_util.go
+++ b/pkg/kv/kvclient/kvcoord/local_test_cluster_util.go
@@ -83,13 +83,15 @@ func NewDistSenderForLocalTestCluster(
 	rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
 	senderTransportFactory := SenderTransportFactory(tracer, stores)
 	return NewDistSender(DistSenderConfig{
-		AmbientCtx:      log.AmbientContext{Tracer: st.Tracer},
-		Settings:        st,
-		Clock:           clock,
-		RPCContext:      rpcContext,
-		RPCRetryOptions: &retryOpts,
-		nodeDescriptor:  nodeDesc,
-		NodeDialer:      nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+		AmbientCtx:         log.AmbientContext{Tracer: st.Tracer},
+		Settings:           st,
+		Clock:              clock,
+		NodeDescs:          g,
+		RPCContext:         rpcContext,
+		RPCRetryOptions:    &retryOpts,
+		nodeDescriptor:     nodeDesc,
+		NodeDialer:         nodedialer.New(rpcContext, gossip.AddressResolver(g)),
+		FirstRangeProvider: g,
 		TestingKnobs: ClientTestingKnobs{
 			TransportFactory: func(
 				opts SendOptions,
@@ -103,5 +105,5 @@ func NewDistSenderForLocalTestCluster(
 				return &localTestClusterTransport{transport, latency}, nil
 			},
 		},
-	}, g)
+	})
 }

--- a/pkg/kv/kvclient/kvcoord/node_store.go
+++ b/pkg/kv/kvclient/kvcoord/node_store.go
@@ -1,0 +1,42 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvcoord
+
+import (
+	"net"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
+)
+
+// NodeDescStore stores a collection of NodeDescriptors.
+//
+// Implementations of the interface are expected to be threadsafe.
+type NodeDescStore interface {
+	// GetNodeDescriptor looks up the descriptor of the node by ID.
+	// It returns an error if the node is not known by the store.
+	GetNodeDescriptor(roachpb.NodeID) (*roachpb.NodeDescriptor, error)
+}
+
+// AddressResolver wraps a NodeDescStore and a Locality and allows the pair to
+// be used as a nodedialer.AddressResolver.
+func AddressResolver(ns NodeDescStore, loc roachpb.Locality) nodedialer.AddressResolver {
+	return func(nodeID roachpb.NodeID) (net.Addr, error) {
+		nd, err := ns.GetNodeDescriptor(nodeID)
+		if err != nil {
+			return nil, err
+		}
+		return nd.AddressForLocality(loc), nil
+	}
+}
+
+// Silence unused warning.
+var _ = AddressResolver

--- a/pkg/kv/kvclient/kvcoord/range_iter_test.go
+++ b/pkg/kv/kvclient/kvcoord/range_iter_test.go
@@ -62,10 +62,11 @@ func TestRangeIterForward(t *testing.T) {
 	ds := NewDistSender(DistSenderConfig{
 		AmbientCtx:        log.AmbientContext{Tracer: tracing.NewTracer()},
 		Clock:             clock,
+		NodeDescs:         g,
 		RPCContext:        rpcContext,
 		RangeDescriptorDB: alphaRangeDescriptorDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
-	}, g)
+	})
 
 	ctx := context.Background()
 
@@ -97,10 +98,11 @@ func TestRangeIterSeekForward(t *testing.T) {
 	ds := NewDistSender(DistSenderConfig{
 		AmbientCtx:        log.AmbientContext{Tracer: tracing.NewTracer()},
 		Clock:             clock,
+		NodeDescs:         g,
 		RPCContext:        rpcContext,
 		RangeDescriptorDB: alphaRangeDescriptorDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
-	}, g)
+	})
 
 	ctx := context.Background()
 
@@ -135,10 +137,11 @@ func TestRangeIterReverse(t *testing.T) {
 	ds := NewDistSender(DistSenderConfig{
 		AmbientCtx:        log.AmbientContext{Tracer: tracing.NewTracer()},
 		Clock:             clock,
+		NodeDescs:         g,
 		RPCContext:        rpcContext,
 		RangeDescriptorDB: alphaRangeDescriptorDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
-	}, g)
+	})
 
 	ctx := context.Background()
 
@@ -170,10 +173,11 @@ func TestRangeIterSeekReverse(t *testing.T) {
 	ds := NewDistSender(DistSenderConfig{
 		AmbientCtx:        log.AmbientContext{Tracer: tracing.NewTracer()},
 		Clock:             clock,
+		NodeDescs:         g,
 		RPCContext:        rpcContext,
 		RangeDescriptorDB: alphaRangeDescriptorDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
-	}, g)
+	})
 
 	ctx := context.Background()
 

--- a/pkg/kv/kvclient/kvcoord/replica_slice.go
+++ b/pkg/kv/kvclient/kvcoord/replica_slice.go
@@ -46,11 +46,7 @@ type ReplicaSlice []ReplicaInfo
 // If there's no info in gossip for any of the nodes in the descriptor, a
 // sendError is returned.
 func NewReplicaSlice(
-	ctx context.Context,
-	gossip interface {
-		GetNodeDescriptor(roachpb.NodeID) (*roachpb.NodeDescriptor, error)
-	},
-	desc *roachpb.RangeDescriptor,
+	ctx context.Context, nodeDescs NodeDescStore, desc *roachpb.RangeDescriptor,
 ) (ReplicaSlice, error) {
 	// Learner replicas won't serve reads/writes, so we'll send only to the
 	// `Voters` replicas. This is just an optimization to save a network hop,
@@ -58,7 +54,7 @@ func NewReplicaSlice(
 	voters := desc.Replicas().Voters()
 	rs := make(ReplicaSlice, 0, len(voters))
 	for _, r := range voters {
-		nd, err := gossip.GetNodeDescriptor(r.NodeID)
+		nd, err := nodeDescs.GetNodeDescriptor(r.NodeID)
 		if err != nil {
 			if log.V(1) {
 				log.Infof(ctx, "node %d is not gossiped: %v", r.NodeID, err)

--- a/pkg/kv/kvclient/kvcoord/send_test.go
+++ b/pkg/kv/kvclient/kvcoord/send_test.go
@@ -287,14 +287,16 @@ func sendBatch(
 	}
 
 	ds := NewDistSender(DistSenderConfig{
-		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
-		RPCContext: rpcContext,
+		AmbientCtx:         log.AmbientContext{Tracer: tracing.NewTracer()},
+		Settings:           cluster.MakeTestingClusterSettings(),
+		NodeDescs:          g,
+		RPCContext:         rpcContext,
+		NodeDialer:         nodeDialer,
+		FirstRangeProvider: g,
 		TestingKnobs: ClientTestingKnobs{
 			TransportFactory: transportFactory,
 		},
-		Settings:   cluster.MakeTestingClusterSettings(),
-		NodeDialer: nodeDialer,
-	}, g)
+	})
 
 	return ds.sendToReplicas(ctx, roachpb.BatchRequest{}, desc, false /* withCommit */)
 }

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -221,19 +221,17 @@ func TestTxnCoordSenderCondenseLockSpans(t *testing.T) {
 		return resp, nil
 	}
 	ambient := log.AmbientContext{Tracer: tracing.NewTracer()}
-	ds := NewDistSender(
-		DistSenderConfig{
-			AmbientCtx: ambient,
-			Clock:      s.Clock,
-			RPCContext: s.Cfg.RPCContext,
-			TestingKnobs: ClientTestingKnobs{
-				TransportFactory: adaptSimpleTransport(sendFn),
-			},
-			RangeDescriptorDB: descDB,
-			Settings:          cluster.MakeTestingClusterSettings(),
+	ds := NewDistSender(DistSenderConfig{
+		AmbientCtx: ambient,
+		Clock:      s.Clock,
+		NodeDescs:  s.Gossip,
+		RPCContext: s.Cfg.RPCContext,
+		TestingKnobs: ClientTestingKnobs{
+			TransportFactory: adaptSimpleTransport(sendFn),
 		},
-		s.Gossip,
-	)
+		RangeDescriptorDB: descDB,
+		Settings:          cluster.MakeTestingClusterSettings(),
+	})
 	tsf := NewTxnCoordSenderFactory(
 		TxnCoordSenderFactoryConfig{
 			AmbientCtx: ambient,

--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -156,15 +156,17 @@ func createTestStoreWithOpts(
 	retryOpts := base.DefaultRetryOptions()
 	retryOpts.Closer = stopper.ShouldQuiesce()
 	distSender := kvcoord.NewDistSender(kvcoord.DistSenderConfig{
-		AmbientCtx: ac,
-		Clock:      storeCfg.Clock,
-		Settings:   storeCfg.Settings,
-		RPCContext: rpcContext,
+		AmbientCtx:         ac,
+		Settings:           storeCfg.Settings,
+		Clock:              storeCfg.Clock,
+		NodeDescs:          storeCfg.Gossip,
+		RPCContext:         rpcContext,
+		RPCRetryOptions:    &retryOpts,
+		FirstRangeProvider: storeCfg.Gossip,
 		TestingKnobs: kvcoord.ClientTestingKnobs{
 			TransportFactory: kvcoord.SenderTransportFactory(tracer, stores),
 		},
-		RPCRetryOptions: &retryOpts,
-	}, storeCfg.Gossip)
+	})
 
 	tcsFactory := kvcoord.NewTxnCoordSenderFactory(
 		kvcoord.TxnCoordSenderFactoryConfig{
@@ -793,6 +795,7 @@ func (m *multiTestContext) populateDB(idx int, st *cluster.Settings, stopper *st
 	m.distSenders[idx] = kvcoord.NewDistSender(kvcoord.DistSenderConfig{
 		AmbientCtx: ambient,
 		Clock:      m.clocks[idx],
+		NodeDescs:  m.gossips[idx],
 		RPCContext: m.rpcContext,
 		RangeDescriptorDB: mtcRangeDescriptorDB{
 			multiTestContext: m,
@@ -803,7 +806,7 @@ func (m *multiTestContext) populateDB(idx int, st *cluster.Settings, stopper *st
 			TransportFactory: m.kvTransportFactory,
 		},
 		RPCRetryOptions: &retryOpts,
-	}, m.gossips[idx])
+	})
 	tcsFactory := kvcoord.NewTxnCoordSenderFactory(
 		kvcoord.TxnCoordSenderFactoryConfig{
 			AmbientCtx: ambient,

--- a/pkg/roachpb/metadata_test.go
+++ b/pkg/roachpb/metadata_test.go
@@ -16,8 +16,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/redact"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPercentilesFromData(t *testing.T) {
@@ -108,6 +110,53 @@ func TestRangeDescriptorMissingReplica(t *testing.T) {
 	}
 	if (r != ReplicaDescriptor{}) {
 		t.Fatalf("unexpectedly got nontrivial return: %s", r)
+	}
+}
+
+func TestNodeDescriptorAddressForLocality(t *testing.T) {
+	addr := func(name string) util.UnresolvedAddr {
+		return util.UnresolvedAddr{NetworkField: name}
+	}
+	desc := NodeDescriptor{
+		Address: addr("1"),
+		LocalityAddress: []LocalityAddress{
+			{Address: addr("2"), LocalityTier: Tier{Key: "region", Value: "east"}},
+			{Address: addr("3"), LocalityTier: Tier{Key: "zone", Value: "a"}},
+		},
+	}
+	for _, tc := range []struct {
+		locality Locality
+		expected util.UnresolvedAddr
+	}{
+		{
+			locality: Locality{},
+			expected: addr("1"),
+		},
+		{
+			locality: Locality{Tiers: []Tier{
+				{Key: "region", Value: "west"},
+				{Key: "zone", Value: "b"},
+			}},
+			expected: addr("1"),
+		},
+		{
+			locality: Locality{Tiers: []Tier{
+				{Key: "region", Value: "east"},
+				{Key: "zone", Value: "b"},
+			}},
+			expected: addr("2"),
+		},
+		{
+			locality: Locality{Tiers: []Tier{
+				{Key: "region", Value: "west"},
+				{Key: "zone", Value: "a"},
+			}},
+			expected: addr("3"),
+		},
+	} {
+		t.Run(tc.locality.String(), func(t *testing.T) {
+			require.Equal(t, tc.expected, *desc.AddressForLocality(tc.locality))
+		})
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -316,15 +316,17 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	}
 	retryOpts.Closer = stopper.ShouldQuiesce()
 	distSenderCfg := kvcoord.DistSenderConfig{
-		AmbientCtx:      cfg.AmbientCtx,
-		Settings:        st,
-		Clock:           clock,
-		RPCContext:      rpcContext,
-		RPCRetryOptions: &retryOpts,
-		TestingKnobs:    clientTestingKnobs,
-		NodeDialer:      nodeDialer,
+		AmbientCtx:         cfg.AmbientCtx,
+		Settings:           st,
+		Clock:              clock,
+		NodeDescs:          g,
+		RPCContext:         rpcContext,
+		RPCRetryOptions:    &retryOpts,
+		NodeDialer:         nodeDialer,
+		FirstRangeProvider: g,
+		TestingKnobs:       clientTestingKnobs,
 	}
-	distSender := kvcoord.NewDistSender(distSenderCfg, g)
+	distSender := kvcoord.NewDistSender(distSenderCfg)
 	registry.AddMetricStruct(distSender.Metrics())
 
 	txnMetrics := kvcoord.MakeTxnMetrics(cfg.HistogramWindowInterval())

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -498,16 +498,18 @@ func makeSQLServerArgs(
 		gossip.AddressResolver(g), // TODO(nvb): break gossip dep
 	)
 	dsCfg := kvcoord.DistSenderConfig{
-		AmbientCtx:        baseCfg.AmbientCtx,
-		Settings:          st,
-		Clock:             clock,
-		RPCRetryOptions:   &rpcRetryOptions,
-		RPCContext:        rpcContext,
-		RangeDescriptorDB: nil, // use DistSender itself
-		NodeDialer:        nodeDialer,
-		TestingKnobs:      dsKnobs,
+		AmbientCtx:         baseCfg.AmbientCtx,
+		Settings:           st,
+		Clock:              clock,
+		NodeDescs:          g,
+		RPCRetryOptions:    &rpcRetryOptions,
+		RPCContext:         rpcContext,
+		NodeDialer:         nodeDialer,
+		RangeDescriptorDB:  nil, // use DistSender itself
+		FirstRangeProvider: g,
+		TestingKnobs:       dsKnobs,
 	}
-	ds := kvcoord.NewDistSender(dsCfg, g)
+	ds := kvcoord.NewDistSender(dsCfg)
 
 	var clientKnobs kvcoord.ClientTestingKnobs
 	if p, ok := baseCfg.TestingKnobs.KVClient.(*kvcoord.ClientTestingKnobs); ok {

--- a/pkg/sql/physicalplan/replicaoracle/oracle.go
+++ b/pkg/sql/physicalplan/replicaoracle/oracle.go
@@ -133,7 +133,7 @@ func (o *randomOracle) Oracle(_ *kv.Txn) Oracle {
 func (o *randomOracle) ChoosePreferredReplica(
 	ctx context.Context, desc *roachpb.RangeDescriptor, _ QueryState,
 ) (roachpb.ReplicaDescriptor, error) {
-	replicas, err := replicaSliceOrErr(desc, o.gossip)
+	replicas, err := replicaSliceOrErr(ctx, desc, o.gossip)
 	if err != nil {
 		return roachpb.ReplicaDescriptor{}, err
 	}
@@ -163,7 +163,7 @@ func (o *closestOracle) Oracle(_ *kv.Txn) Oracle {
 func (o *closestOracle) ChoosePreferredReplica(
 	ctx context.Context, desc *roachpb.RangeDescriptor, _ QueryState,
 ) (roachpb.ReplicaDescriptor, error) {
-	replicas, err := replicaSliceOrErr(desc, o.gossip)
+	replicas, err := replicaSliceOrErr(ctx, desc, o.gossip)
 	if err != nil {
 		return roachpb.ReplicaDescriptor{}, err
 	}
@@ -229,7 +229,7 @@ func (o *binPackingOracle) ChoosePreferredReplica(
 		}
 	}
 
-	replicas, err := replicaSliceOrErr(desc, o.gossip)
+	replicas, err := replicaSliceOrErr(ctx, desc, o.gossip)
 	if err != nil {
 		return roachpb.ReplicaDescriptor{}, err
 	}
@@ -259,9 +259,9 @@ func (o *binPackingOracle) ChoosePreferredReplica(
 // is available in gossip. If no nodes are available, a RangeUnavailableError is
 // returned.
 func replicaSliceOrErr(
-	desc *roachpb.RangeDescriptor, gsp gossip.DeprecatedOracleGossip,
+	ctx context.Context, desc *roachpb.RangeDescriptor, gsp gossip.DeprecatedOracleGossip,
 ) (kvcoord.ReplicaSlice, error) {
-	replicas, err := kvcoord.NewReplicaSlice(context.TODO(), gsp, desc)
+	replicas, err := kvcoord.NewReplicaSlice(ctx, gsp, desc)
 	if err != nil {
 		return kvcoord.ReplicaSlice{}, sqlbase.NewRangeUnavailableError(desc.RangeID, err)
 	}


### PR DESCRIPTION
This change decomposes the roles of Gossip as a dependency in DistSender into that of a NodeDescStore, a source of node descriptors, and that of a FirstRangeProvider, a provider of information on the first range in a cluster.

This decomposition will be used to address #47909 by:
1. replacing Gossip with a TenantService as a NodeDescStore
2. providing a custom RangeDescriptorDB (also backed by a TenantService) instead of a FirstRangeProvider.

Together, these changes will allow us to remove DistSender's dependency on Gossip for SQL-only tenant processes.

The next step after this will be to introduce a TenantService that can satisfy these two dependencies (NodeDescStore and RangeDescriptorDB) and also use the new NodeDescStore-to-AddressResolver binding to replace the use of Gossip with the TenantService in nodedialer instances.