### PR TITLE
[WIP] concurrency,etc: separated lock table changes

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -155,7 +155,20 @@ var (
 	// (storage/engine/rocksdb/db.cc).
 	LocalTransactionSuffix = roachpb.RKey("txn-")
 
-	// 4. Store local keys
+	// 4. Lock table keys
+	//
+	// LocalRangeLockTablePrefix specifies the key prefix for the lock
+	// table. The additional detail is the transaction id.
+	//
+	// We add the lock strength to the key suffix, since we want the locks for a
+	// particular user key to be contiguous in the key space, and different lock
+	// strengths may use different protos. In particular, only the exclusive
+	// strength will use MVCCMetadata since it has to do double duty as a
+	// reference to a provisional MVCC value.
+	LocalRangeLockTablePrefix             = roachpb.Key(makeKey(localPrefix, roachpb.RKey("l")))
+	LocalRangeLockTableExclusiveTxnSuffix = roachpb.RKey("exc-")
+
+	// 5. Store local keys
 	//
 	// localStorePrefix is the prefix identifying per-store data.
 	localStorePrefix = makeKey(localPrefix, roachpb.Key("s"))

--- a/pkg/keys/doc.go
+++ b/pkg/keys/doc.go
@@ -155,8 +155,8 @@ package keys
 var _ = [...]interface{}{
 	MinKey,
 
-	// There are four types of local key data enumerated below: replicated
-	// range-ID, unreplicated range-ID, range local, and store-local keys.
+	// There are five types of local key data enumerated below: replicated
+	// range-ID, unreplicated range-ID, range local, range lock, and store-local keys.
 	// Local keys are constructed using a prefix, an optional infix, and a
 	// suffix. The prefix and infix are used to disambiguate between the four
 	// types of local keys listed above, and determines inter-group ordering.
@@ -167,12 +167,13 @@ var _ = [...]interface{}{
 	// 	  - RangeID unreplicated keys all share `LocalRangeIDPrefix` and
 	// 		`localRangeIDUnreplicatedInfix`.
 	// 	  - Range local keys all share `LocalRangePrefix`.
+	//    - Range lock (which are also local keys) all share `LocalRangeLockTablePrefix`.
 	//	  - Store keys all share `localStorePrefix`.
 	//
-	// `LocalRangeIDPrefix`, `localRangePrefix` and `localStorePrefix` all in
-	// turn share `localPrefix`. `localPrefix` was chosen arbitrarily. Local
-	// keys would work just as well with a different prefix, like 0xff, or even
-	// with a suffix.
+	// `LocalRangeIDPrefix`, `LocalRangePrefix`, `LocalRangeLockTablePrefix` and
+	// `localStorePrefix` all in turn share `localPrefix`. `localPrefix` was
+	// chosen arbitrarily. Local keys would work just as well with a different
+	// prefix, like 0xff, or even with a suffix.
 
 	//   1. Replicated range-ID local keys: These store metadata pertaining to a
 	//   range as a whole. Though they are replicated, they are unaddressable.
@@ -205,6 +206,13 @@ var _ = [...]interface{}{
 	RangeDescriptorJointKey, // "rdjt"
 	RangeDescriptorKey,      // "rdsc"
 	TransactionKey,          // "txn-"
+
+	//   4. Range lock keys for all replicated locks. Currently only exclusive
+	//   locks are supported which use a LocalRangeLockTableExclusiveTxnSuffix
+	//   before the txn id. All range locks share LocalRangeLockTablePrefix. Locks
+	//   can be acquired on global keys and on range local keys. The exclusive
+	//   locks additionally function as pointers to the provisional MVCC values.
+	LockTableKeyExclusive,
 
 	//   4. Store local keys: These contain metadata about an individual store.
 	//   They are unreplicated and unaddressable. The typical example is the

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -390,6 +390,70 @@ func TransactionKey(key roachpb.Key, txnID uuid.UUID) roachpb.Key {
 	return MakeRangeKey(rk, LocalTransactionSuffix, roachpb.RKey(txnID.GetBytes()))
 }
 
+// MakeLockTableKey creates a lock table key based on the key being locked,
+// metadata key suffix, and optional detail (always the transaction ID).
+func MakeLockTableKey(key roachpb.Key, suffix, detail roachpb.RKey) roachpb.Key {
+	if len(suffix) != localSuffixLength {
+		panic(fmt.Sprintf("suffix len(%q) != %d", suffix, localSuffixLength))
+	}
+	buf := MakeLockTableKeyPrefix(key)
+	buf = append(buf, suffix...)
+	buf = append(buf, detail...)
+	return buf
+}
+
+// MakeRangeLockTablePrefix creates a key prefix under which all lock table keys
+// for key can be found.
+// For a scan [start, end) the corresponding lock table scan is [MLTKP(start), MLTKP(end)).
+func MakeLockTableKeyPrefix(key roachpb.Key) roachpb.Key {
+	// Don't unwrap any local prefix on key using Addr(key). This allow for
+	// doubly-local lock table keys. For example, local range descriptor keys can
+	// be locked during split and merge transactions.
+	buf := make(roachpb.Key, 0, len(LocalRangeLockTablePrefix)+len(key)+1)
+	buf = append(buf, LocalRangeLockTablePrefix...)
+	buf = encoding.EncodeBytesAscending(buf, key)
+	return buf
+}
+
+// DecodeLockTableKey decodes the range key into locked key,
+// suffix and detail.
+func DecodeLockTableKey(
+	key roachpb.Key,
+) (lockedKey, suffix roachpb.Key, txnID uuid.UUID, err error) {
+	if !bytes.HasPrefix(key, LocalRangeLockTablePrefix) {
+		return nil, nil, uuid.UUID{}, errors.Errorf("key %q does not have %q prefix",
+			key, LocalRangeLockTablePrefix)
+	}
+	// Cut the prefix.
+	b := key[len(LocalRangeLockTablePrefix):]
+	b, lockedKey, err = encoding.DecodeBytesAscending(b, nil)
+	if err != nil {
+		return nil, nil, uuid.UUID{}, err
+	}
+	if len(b) < localSuffixLength {
+		return nil, nil, uuid.UUID{}, errors.Errorf("key %q does not have suffix of length %d",
+			key, localSuffixLength)
+	}
+	// Cut the suffix.
+	suffix = b[:localSuffixLength]
+	detail := b[localSuffixLength:]
+	if len(detail) != uuid.Size {
+		return nil, nil, uuid.UUID{},
+			errors.Errorf("key %q does not have txnID, since length is incorrect %d", len(detail))
+	}
+	copy(txnID[:], detail)
+	return
+}
+
+// LockTableKeyExclusive returns a lock table key for replicated exclusive locks, based on the
+// provided key being locked and transaction ID.
+func LockTableKeyExclusive(key roachpb.Key, txnID uuid.UUID) roachpb.Key {
+	// Don't unwrap any local prefix on key using Addr(key). This allow for
+	// doubly-local lock table keys. For example, local range descriptor keys can
+	// be locked during split and merge transactions.
+	return MakeLockTableKey(key, LocalRangeLockTableExclusiveTxnSuffix, txnID.GetBytes())
+}
+
 // QueueLastProcessedKey returns a range-local key for last processed
 // timestamps for the named queue. These keys represent per-range last
 // processed times.

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -553,6 +553,12 @@ type lockTable interface {
 	//     txn.WriteTimestamp.
 	UpdateLocks(*roachpb.LockUpdate) error
 
+	// Informs the lock table that a transaction is finalized. This is used
+	// by the lock table in a best-effort manner to avoid waiting on locks
+	// of finalized transactions and telling the caller via
+	// lockTableGuard.ResolveBeforeEvaluation to resolve a batch of intents.
+	TransactionIsFinalized(*roachpb.Transaction)
+
 	// String returns a debug string representing the state of the lockTable.
 	String() string
 }
@@ -574,6 +580,10 @@ type lockTableGuard interface {
 
 	// CurState returns the latest waiting state.
 	CurState() waitingState
+
+	// When ShouldWait() returns false, this method must be called to get
+	// list of locks to resolve before evaluation.
+	ResolveBeforeEvaluation() []roachpb.LockUpdate
 }
 
 // lockTableWaiter is concerned with waiting in lock wait-queues for locks held
@@ -632,11 +642,6 @@ type lockTableWaiter interface {
 	// and, in turn, remove this method. This will likely fall out of pulling
 	// all replicated locks into the lockTable.
 	WaitOnLock(context.Context, Request, *roachpb.Intent) *Error
-
-	// ClearCaches wipes all caches maintained by the lockTableWaiter. This is
-	// primarily used to recover memory when a replica loses a lease. However,
-	// it is also used in tests to reset the state of the lockTableWaiter.
-	ClearCaches()
 }
 
 // txnWaitQueue holds a collection of wait-queues for transaction records.

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -73,6 +73,9 @@ func (c *Config) initDefaults() {
 func NewManager(cfg Config) Manager {
 	cfg.initDefaults()
 	m := new(managerImpl)
+	lt := &lockTableImpl{
+		maxLocks: cfg.MaxLockTableSize,
+	}
 	*m = managerImpl{
 		// TODO(nvanbenschoten): move pkg/storage/spanlatch to a new
 		// pkg/storage/concurrency/latch package. Make it implement the
@@ -83,14 +86,13 @@ func NewManager(cfg Config) Manager {
 				cfg.SlowLatchGauge,
 			),
 		},
-		lt: &lockTableImpl{
-			maxLocks: cfg.MaxLockTableSize,
-		},
+		lt: lt,
 		ltw: &lockTableWaiterImpl{
 			st:                cfg.Settings,
 			stopper:           cfg.Stopper,
 			ir:                cfg.IntentResolver,
 			lm:                m,
+			lt:                lt,
 			disableTxnPushing: cfg.DisableTxnPushing,
 		},
 		// TODO(nvanbenschoten): move pkg/storage/txnwait to a new
@@ -345,9 +347,6 @@ func (m *managerImpl) OnRangeLeaseUpdated(isLeaseholder bool) {
 		const disable = true
 		m.lt.Clear(disable)
 		m.twq.Clear(disable)
-		// Also clear caches, since they won't be needed any time soon and
-		// consume memory.
-		m.ltw.ClearCaches()
 	}
 }
 

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -180,6 +181,9 @@ type lockTableImpl struct {
 	locks [spanset.NumSpanScope]treeMu
 
 	maxLocks int64
+
+	rw                storage.ReadWriter
+	finalizedTxnCache txnCache
 }
 
 var _ lockTable = &lockTableImpl{}
@@ -249,8 +253,10 @@ var _ lockTable = &lockTableImpl{}
 // - The doneWaiting state is used to indicate that the request should make
 //   another call to ScanAndEnqueue() (that next call is more likely to return a
 //   lockTableGuard that returns false from StartWaiting()).
+type lockKeySpaceSpans [spanset.NumSpanAccess][spanset.NumSpanScope][]spanset.Span
 type lockTableGuardImpl struct {
 	seqNum uint64
+	lt     *lockTableImpl
 
 	// Information about this request.
 	txn     *enginepb.TxnMeta
@@ -276,6 +282,13 @@ type lockTableGuardImpl struct {
 	// is comparable in system throughput, one can eliminate the above anomalies.
 	//
 	tableSnapshot [spanset.NumSpanScope]btree
+
+	storageIt storage.Iterator
+	lockSpans lockKeySpaceSpans
+	lockedKey roachpb.Key
+	lockedVal enginepb.MVCCMetadata
+	// Only valid when lockedKey != nil
+	lockedKeyCmp int
 
 	// A request whose startWait is set to true in ScanAndEnqueue is actively
 	// waiting at a particular key. This is the first key encountered when
@@ -327,6 +340,8 @@ type lockTableGuardImpl struct {
 		// (proportional to number of waiters).
 		mustFindNextLockAfter bool
 	}
+
+	toResolve []roachpb.LockUpdate
 }
 
 var _ lockTableGuard = &lockTableGuardImpl{}
@@ -357,6 +372,10 @@ func releaseLockTableGuardImpl(g *lockTableGuardImpl) {
 	select {
 	case <-signal:
 	default:
+	}
+	if g.storageIt != nil {
+		g.storageIt.Close()
+		g.storageIt = nil
 	}
 	if len(locks) != 0 {
 		panic("lockTableGuardImpl.mu.locks not empty after Dequeue")
@@ -395,6 +414,10 @@ func (g *lockTableGuardImpl) CurState() waitingState {
 	return g.mu.state
 }
 
+func (g *lockTableGuardImpl) ResolveBeforeEvaluation() []roachpb.LockUpdate {
+	return g.toResolve
+}
+
 func (g *lockTableGuardImpl) notify() {
 	select {
 	case g.mu.signal <- struct{}{}:
@@ -424,20 +447,70 @@ func (g *lockTableGuardImpl) isSameTxnAsReservation(ws waitingState) bool {
 	return !ws.held && g.isSameTxn(ws.txn)
 }
 
+func (g *lockTableGuardImpl) seekToLockSpan() error {
+	span := g.lockSpans[g.sa][g.ss][g.index]
+	g.storageIt.SetUpperBound(span.EndKey)
+	// TODO: When g.spans[g.sa][g.ss][g.index].EndKey == nil, we should be
+	// using SeekPrefixGE, but it is not currently exposed as a per-seek
+	// option in the engine.Iterator interface.
+	g.storageIt.SeekGE(storage.MVCCKey{Key: span.Key})
+	return g.extractLockedKey()
+}
+
+func (g *lockTableGuardImpl) extractLockedKey() error {
+	g.lockedKey = nil
+	if valid, err := g.storageIt.Valid(); err != nil || !valid {
+		return err
+	}
+	var err error
+	if g.lockedKey, _, _, err = keys.DecodeLockTableKey(g.storageIt.UnsafeKey().Key); err != nil {
+		return err
+	}
+	if err := g.storageIt.ValueProto(&g.lockedVal); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (g *lockTableGuardImpl) nextInLockSpan() error {
+	if g.lockedKey == nil {
+		return nil
+	}
+	if g.lockedKeyCmp > 0 {
+		return nil
+	}
+	g.storageIt.Next()
+	return g.extractLockedKey()
+}
+
 // Finds the next lock, after the current one, to actively wait at. If it
 // finds the next lock the request starts actively waiting there, else it is
-// told that it is done waiting.
+// told that it is done waiting. When notify is true,
+// lockTableImpl.finalizedTxnCache is used to accumulate intents to resolve.
 // Acquires g.mu.
 func (g *lockTableGuardImpl) findNextLockAfter(notify bool) {
+	var finalizedTxnCache *txnCache
+	if notify {
+		finalizedTxnCache = &g.lt.finalizedTxnCache
+	}
 	spans := g.spans.GetSpans(g.sa, g.ss)
 	var span *spanset.Span
+	var err error
 	resumingInSameSpan := false
 	if g.index == -1 || len(spans[g.index].EndKey) == 0 {
-		span = stepToNextSpan(g)
+		if span, err = stepToNextSpan(g); err != nil {
+			// TODO: propagate error
+			panic(err)
+		}
 	} else {
 		span = &spans[g.index]
 		resumingInSameSpan = true
+		if err := g.nextInLockSpan(); err != nil {
+			// TODO: propagate error
+			panic(err)
+		}
 	}
+	var toResolve []roachpb.LockUpdate
 	for span != nil {
 		startKey := span.Key
 		if resumingInSameSpan {
@@ -452,28 +525,102 @@ func (g *lockTableGuardImpl) findNextLockAfter(notify bool) {
 		// that the lock is not the same as our exclusive start key and only need
 		// to do that check once -- for the first lock.
 		ltRange := &lockState{key: startKey, endKey: span.EndKey}
-		for iter.FirstOverlap(ltRange); iter.Valid(); iter.NextOverlap(ltRange) {
-			l := iter.Cur()
+		for iter.FirstOverlap(ltRange); iter.Valid() || g.lockedKey != nil; {
+			g.lockedKeyCmp = +1
+			if g.lockedKey != nil {
+				if iter.Valid() {
+					g.lockedKeyCmp = g.lockedKey.Compare(iter.Cur().key)
+				} else {
+					g.lockedKeyCmp = -1
+				}
+			}
 			if resumingInSameSpan {
 				resumingInSameSpan = false
-				if l.key.Equal(startKey) {
-					// This lock is where it stopped waiting.
-					continue
+				if iter.Valid() {
+					if iter.Cur().key.Equal(startKey) {
+						// This lock is where it stopped waiting.
+						iter.NextOverlap(ltRange)
+						continue
+					}
 				}
 				// Else, past the lock where it stopped waiting. We may not
 				// encounter that lock since it may have been garbage collected.
 			}
-			if l.tryActiveWait(g, g.sa, notify) {
+			if g.lockedKeyCmp <= 0 {
+				// The lockState does not exist in the snapshot, or it exists in the snapshot
+				// but may not have information about this replicated lock.
+				if mayWait(g, g.sa, &g.lockedVal) {
+					var l *lockState
+					// It may wait on this lock
+					tree := &g.lt.locks[g.ss]
+					// Add information about this replicated lock to the lockTable if
+					// not already added, and ensure the lockState knows about the
+					// replicated lock.
+					addLockInfoFunc := func() {
+						tree.mu.Lock()
+						defer tree.mu.Unlock()
+						iter := tree.MakeIter()
+						iter.FirstOverlap(&lockState{key: g.lockedKey})
+						if !iter.Valid() {
+							l = &lockState{id: tree.nextLockSeqNum(), key: g.lockedKey, ss: g.ss}
+							l.queuedWriters.Init()
+							l.waitingReaders.Init()
+							tree.Set(l)
+							atomic.AddInt64(&tree.numLocks, 1)
+						} else {
+							l = iter.Cur()
+						}
+						// TODO: propagate error
+						if err := l.ensureReplicatedState(
+							g.lockedVal.Txn, hlc.Timestamp(g.lockedVal.Timestamp)); err != nil {
+							panic(err)
+						}
+					}
+					addLockInfoFunc()
+					// This wait is potentially happening on a lockState that is not
+					// in the snapshot.
+					wait, resolve := l.tryActiveWait(g, g.sa, notify, finalizedTxnCache)
+					if wait {
+						return
+					}
+					if notify {
+						toResolve = append(toResolve, resolve...)
+					}
+				}
+				g.nextInLockSpan()
+				continue
+			}
+			// g.lockedKeyCmp > 0
+			l := iter.Cur()
+			wait, resolve := l.tryActiveWait(g, g.sa, notify, finalizedTxnCache)
+			if wait {
 				return
 			}
+			if notify {
+				// Full scan. We don't give the caller a list of LockUpdates for the
+				// case of a resumed scan, to reduce having multiple requests trying
+				// to resolve these locks. The full scan caller holds latches, and
+				// ScanAndEnqueue can return with startWait equal to true, so it drops
+				// latches, and then processes this list if populated, and then sees
+				// that it has transitioned to doneWaiting.
+				toResolve = append(toResolve, resolve...)
+			}
+			iter.NextOverlap(ltRange)
 		}
 		resumingInSameSpan = false
-		span = stepToNextSpan(g)
+		if span, err = stepToNextSpan(g); err != nil {
+			// TODO: propagate error
+			panic(err)
+		}
 	}
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.mu.state = waitingState{kind: doneWaiting}
 	if notify {
+		g.toResolve = toResolve
+		if len(toResolve) > 0 {
+			g.mu.startWait = true
+		}
 		g.notify()
 	}
 }
@@ -983,6 +1130,13 @@ func (l *lockState) getLockerInfo() (*enginepb.TxnMeta, hlc.Timestamp) {
 	return l.holder.holder[index].txn, l.holder.holder[index].ts
 }
 
+func mayWait(g *lockTableGuardImpl, sa spanset.SpanAccess, lockMeta *enginepb.MVCCMetadata) bool {
+	if sa == spanset.SpanReadOnly && g.readTS.Less(hlc.Timestamp(lockMeta.Timestamp)) {
+		return false
+	}
+	return g.isSameTxn(lockMeta.Txn)
+}
+
 // Decides whether the request g with access sa should actively wait at this
 // lock and if yes, adjusts the data-structures appropriately. The notify
 // parameter is true iff the request's new state channel should be notified --
@@ -992,30 +1146,32 @@ func (l *lockState) getLockerInfo() (*enginepb.TxnMeta, hlc.Timestamp) {
 // happens later in lockTableGuard.CurState(). The return value is true iff
 // it is actively waiting.
 // Acquires l.mu, g.mu.
-func (l *lockState) tryActiveWait(g *lockTableGuardImpl, sa spanset.SpanAccess, notify bool) bool {
+func (l *lockState) tryActiveWait(
+	g *lockTableGuardImpl, sa spanset.SpanAccess, notify bool, finalizedTxnCache *txnCache,
+) (bool, []roachpb.LockUpdate) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	// It is possible that this lock is empty and has not yet been deleted.
 	if l.isEmptyLock() {
-		return false
+		return false, nil
 	}
 
 	// Lock is not empty.
 	lockHolderTxn, lockHolderTS := l.getLockerInfo()
 	if lockHolderTxn != nil && g.isSameTxn(lockHolderTxn) {
 		// Already locked by this txn.
-		return false
+		return false, nil
 	}
 
 	if sa == spanset.SpanReadOnly {
 		if lockHolderTxn == nil {
 			// Reads only care about locker, not a reservation.
-			return false
+			return false, nil
 		}
 		// Locked by some other txn.
 		if g.readTS.Less(lockHolderTS) {
-			return false
+			return false, nil
 		}
 		g.mu.Lock()
 		_, alsoHasStrongerAccess := g.mu.locks[l]
@@ -1034,18 +1190,30 @@ func (l *lockState) tryActiveWait(g *lockTableGuardImpl, sa spanset.SpanAccess, 
 		// timestamp that is not compatible with this request and it will wait
 		// here -- there is no correctness issue with doing that.
 		if alsoHasStrongerAccess {
-			return false
+			return false, nil
 		}
 	}
 
 	waitForState := waitingState{kind: waitFor, key: l.key}
 	if lockHolderTxn != nil {
+		if finalizedTxnCache != nil {
+			if finalizedTxn, ok := finalizedTxnCache.get(lockHolderTxn.ID); ok {
+				if l.holder.holder[lock.Replicated].txn == nil {
+					// Only held unreplicated. Release immediately. We don't expect the
+					// caller to GC this lockState and instead will GC it in tryUpdateLock.
+					l.lockIsFree()
+					return false, nil
+				}
+				resolve := roachpb.MakeLockUpdate(finalizedTxn, roachpb.Span{Key: l.key})
+				return false, []roachpb.LockUpdate{resolve}
+			}
+		}
 		waitForState.txn = lockHolderTxn
 		waitForState.held = true
 	} else {
 		if l.reservation == g {
 			// Already reserved by this request.
-			return false
+			return false, nil
 		}
 		// A non-transactional write request never makes or breaks reservations,
 		// and only waits for a reservation if the reservation has a lower
@@ -1054,7 +1222,7 @@ func (l *lockState) tryActiveWait(g *lockTableGuardImpl, sa spanset.SpanAccess, 
 		if g.txn == nil && l.reservation.seqNum > g.seqNum {
 			// Reservation is held by a request with a higher seqNum and g is a
 			// non-transactional request. Ignore the reservation.
-			return false
+			return false, nil
 		}
 		waitForState.txn = l.reservation.txn
 	}
@@ -1070,7 +1238,7 @@ func (l *lockState) tryActiveWait(g *lockTableGuardImpl, sa spanset.SpanAccess, 
 		// reservations. And the set of active queuedWriters has not changed, but
 		// they do need to be told about the change in who they are waiting for.
 		l.informActiveWaiters()
-		return false
+		return false, nil
 	}
 
 	// Need to wait.
@@ -1138,7 +1306,7 @@ func (l *lockState) tryActiveWait(g *lockTableGuardImpl, sa spanset.SpanAccess, 
 	if notify {
 		g.notify()
 	}
-	return true
+	return true, nil
 }
 
 // Acquires this lock. Returns the list of guards that are done actively
@@ -1270,6 +1438,26 @@ func (l *lockState) acquireLock(
 
 	// Inform active waiters since lock has transitioned to held.
 	l.informActiveWaiters()
+	return nil
+}
+
+func (l *lockState) ensureReplicatedState(txn *enginepb.TxnMeta, ts hlc.Timestamp) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.holder.locked {
+		if !l.isLockedBy(txn.ID) {
+			return errors.Errorf("caller violated contract: " +
+				"discovered lock by different transaction than existing lock")
+		}
+	} else {
+		l.holder.locked = true
+	}
+	holder := &l.holder.holder[lock.Replicated]
+	if holder.txn == nil {
+		holder.txn = txn
+		holder.ts = ts
+		holder.seqs = append(holder.seqs, txn.Sequence)
+	}
 	return nil
 }
 
@@ -1472,6 +1660,11 @@ func removeIgnored(
 func (l *lockState) tryUpdateLock(up *roachpb.LockUpdate) (gc bool, err error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	if txn, _ := l.getLockerInfo(); txn == nil && l.reservation == nil {
+		// Already free. This can happen when a lock held by a finalized txn is
+		// removed early due to the finalizedTxnCache.
+		return true, nil
+	}
 	if !l.isLockedBy(up.Txn.ID) {
 		return false, nil
 	}
@@ -1715,14 +1908,25 @@ func (t *lockTableImpl) ScanAndEnqueue(req Request, guard lockTableGuard) lockTa
 	if guard == nil {
 		g = newLockTableGuardImpl()
 		g.seqNum = atomic.AddUint64(&t.seqNum, 1)
+		g.lt = t
 		g.txn = req.txnMeta()
 		g.spans = req.LockSpans
 		g.readTS = req.readConflictTimestamp()
 		g.writeTS = req.writeConflictTimestamp()
+		if t.rw != nil {
+			g.storageIt = t.rw.NewIterator(storage.IterOptions{})
+			g.lockSpans = getLockKeySpaceSpans(g.spans)
+		}
 		g.sa = spanset.NumSpanAccess - 1
 		g.index = -1
 	} else {
 		g = guard.(*lockTableGuardImpl)
+		if t.rw != nil {
+			if g.storageIt != nil {
+				g.storageIt.Close()
+			}
+			g.storageIt = t.rw.NewIterator(storage.IterOptions{})
+		}
 		g.key = nil
 		g.sa = spanset.NumSpanAccess - 1
 		g.ss = spanset.SpanScope(0)
@@ -1870,6 +2074,26 @@ func (t *lockTableImpl) AcquireLock(
 	return err
 }
 
+func getLockKeySpaceSpans(spanSet *spanset.SpanSet) lockKeySpaceSpans {
+	var lSpans lockKeySpaceSpans
+	for sa := spanset.SpanAccess(0); sa < spanset.NumSpanAccess; sa++ {
+		for ss := spanset.SpanScope(0); ss < spanset.NumSpanScope; ss++ {
+			spans := spanSet.GetSpans(sa, ss)
+			ls := make([]spanset.Span, len(spans))
+			for i := 0; i < len(ls); i++ {
+				ls[i].Key = keys.MakeLockTableKeyPrefix(spans[i].Key)
+				if spans[i].EndKey == nil {
+					ls[i].EndKey = ls[i].Key.Next()
+				} else {
+					ls[i].EndKey = keys.MakeLockTableKeyPrefix(spans[i].EndKey)
+				}
+			}
+			lSpans[sa][ss] = ls
+		}
+	}
+	return lSpans
+}
+
 // If force is false, removes all locks, except for those that are held with
 // replicated durability and have no distinguished waiter, and tells those
 // waiters to wait elsewhere or that they are done waiting. A replicated lock
@@ -1997,24 +2221,32 @@ func (t *lockTableImpl) UpdateLocks(up *roachpb.LockUpdate) error {
 	return err
 }
 
+func (t *lockTableImpl) TransactionIsFinalized(txn *roachpb.Transaction) {
+	t.finalizedTxnCache.add(txn)
+}
+
 // Iteration helper for findNextLockAfter. Returns the next span to search
 // over, or nil if the iteration is done.
 // REQUIRES: g.mu is locked.
-func stepToNextSpan(g *lockTableGuardImpl) *spanset.Span {
+func stepToNextSpan(g *lockTableGuardImpl) (*spanset.Span, error) {
 	g.index++
 	for ; g.ss < spanset.NumSpanScope; g.ss++ {
 		for ; g.sa >= 0; g.sa-- {
 			spans := g.spans.GetSpans(g.sa, g.ss)
 			if g.index < len(spans) {
 				span := &spans[g.index]
-				g.key = span.Key
-				return span
+				if g.storageIt != nil {
+					if err := g.seekToLockSpan(); err != nil {
+						return nil, err
+					}
+				}
+				return span, nil
 			}
 			g.index = 0
 		}
 		g.sa = spanset.NumSpanAccess - 1
 	}
-	return nil
+	return nil, nil
 }
 
 // Enable implements the lockTable interface.
@@ -2043,6 +2275,7 @@ func (t *lockTableImpl) Clear(disable bool) {
 		t.enabled = false
 	}
 	t.tryClearLocks(true /* force */)
+	t.finalizedTxnCache.clear()
 }
 
 // For tests.

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -86,17 +86,7 @@ type lockTableWaiterImpl struct {
 	stopper *stop.Stopper
 	ir      IntentResolver
 	lm      LockManager
-
-	// finalizedTxnCache is a small LRU cache that tracks transactions that
-	// were pushed and found to be finalized (COMMITTED or ABORTED). It is
-	// used as an optimization to avoid repeatedly pushing the transaction
-	// record when cleaning up the intents of an abandoned transaction.
-	//
-	// NOTE: it probably makes sense to maintain a single finalizedTxnCache
-	// across all Ranges on a Store instead of an individual cache per
-	// Range. For now, we don't do this because we don't share any state
-	// between separate concurrency.Manager instances.
-	finalizedTxnCache txnCache
+	lt      lockTable
 
 	// When set, WriteIntentError are propagated instead of pushing
 	// conflicting transactions.
@@ -126,6 +116,10 @@ type IntentResolver interface {
 func (w *lockTableWaiterImpl) WaitOn(
 	ctx context.Context, req Request, guard lockTableGuard,
 ) (err *Error) {
+	toResolve := guard.ResolveBeforeEvaluation()
+	if len(toResolve) > 0 {
+		w.resolveDeferredIntents(ctx, &err, &toResolve)
+	}
 	newStateC := guard.NewStateChan()
 	ctxDoneC := ctx.Done()
 	shouldQuiesceC := w.stopper.ShouldQuiesce()
@@ -189,54 +183,6 @@ func (w *lockTableWaiterImpl) WaitOn(
 				// reason, continue waiting.
 				if !livenessPush && !deadlockPush {
 					continue
-				}
-
-				// If we know that a lock holder is already finalized (COMMITTED
-				// or ABORTED), there's no reason to push it again. Instead, we
-				// can skip directly to intent resolution.
-				//
-				// As an optimization, we defer the intent resolution until the
-				// we're done waiting on all conflicting locks in this function.
-				// This allows us to accumulate a group of intents to resolve
-				// and send them together as a batch.
-				//
-				// Remember that if the lock is held, there will be at least one
-				// waiter with livenessPush = true (the distinguished waiter),
-				// so at least one request will enter this branch and perform
-				// the cleanup on behalf of all other waiters.
-				if livenessPush {
-					if pusheeTxn, ok := w.finalizedTxnCache.get(state.txn.ID); ok {
-						resolve := roachpb.MakeLockUpdate(pusheeTxn, roachpb.Span{Key: state.key})
-						deferredResolution = append(deferredResolution, resolve)
-
-						// Inform the LockManager that the lock has been updated with a
-						// finalized status so that it gets removed from the lockTable
-						// and we are allowed to proceed.
-						//
-						// For unreplicated locks, this is all that is needed - the
-						// lockTable is the source of truth so, once removed, the
-						// unreplicated lock is gone. It is perfectly valid for us to
-						// instruct the lock to be released because we know that the
-						// lock's owner is finalized.
-						//
-						// For replicated locks, this is a bit of a lie. The lock hasn't
-						// actually been updated yet, but we will be conducting intent
-						// resolution in the future (before we observe the corresponding
-						// MVCC state). This is safe because we already handle cases
-						// where locks exist only in the MVCC keyspace and not in the
-						// lockTable.
-						//
-						// In the future, we'd like to make this more explicit.
-						// Specifically, we'd like to augment the lockTable with an
-						// understanding of finalized but not yet resolved locks. These
-						// locks will allow conflicting transactions to proceed with
-						// evaluation without the need to first remove all traces of
-						// them via a round of replication. This is discussed in more
-						// detail in #41720. Specifically, see mention of "contention
-						// footprint" and COMMITTED_BUT_NOT_REMOVABLE.
-						w.lm.OnLockUpdated(ctx, &deferredResolution[len(deferredResolution)-1])
-						continue
-					}
 				}
 
 				// The request should push to detect abandoned locks due to
@@ -387,11 +333,6 @@ func (w *lockTableWaiterImpl) WaitOnLock(
 	})
 }
 
-// ClearCaches implements the lockTableWaiter interface.
-func (w *lockTableWaiterImpl) ClearCaches() {
-	w.finalizedTxnCache.clear()
-}
-
 // pushLockTxn pushes the holder of the provided lock.
 //
 // The method blocks until the lock holder transaction experiences a state
@@ -433,7 +374,7 @@ func (w *lockTableWaiterImpl) pushLockTxn(
 	// avoids needing to push it again if we find another one of its locks and
 	// allows for batching of intent resolution.
 	if pusheeTxn.Status.IsFinalized() {
-		w.finalizedTxnCache.add(pusheeTxn)
+		w.lt.TransactionIsFinalized(pusheeTxn)
 	}
 
 	// If the push succeeded then the lock holder transaction must have

--- a/pkg/kv/kvserver/concurrency/mvcc_readwriter.go
+++ b/pkg/kv/kvserver/concurrency/mvcc_readwriter.go
@@ -1,0 +1,831 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package concurrency
+
+import (
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
+)
+
+// Implements a reader-writer for use by a request that operates on MVCC key-values.
+// It hides MVCCMetadata from the request processing, and updating of MVCCStats.
+// It assumes no conflicting locks can be found since the lockTable has already
+// been used for concurrency control.
+// It replaces most of the complex code in the storage package, in mvcc.go and
+// pebble_mvcc_scanner.go. And the code duplication across the various functions
+// in those files is also eliminated -- callers doing a get, scan or put will
+// all use MVCCReadWriter both for iterating and when needed a Put. The caller
+// needs to obey a contract when doing Put: the iterator must be positioned at
+// the most recent version of the key being Put, if the key has any version.
+//
+// The following interface is not for intent resolution which is also currently
+// implemented in mvcc.go. There is not any simplification possible there since
+// the complexity there is in handling of epochs, changing the timestamp of
+// the provisional value, handling savepoint rollbacks. We'll simply lift that
+// implementation out of mvcc.go and into the lockTable.
+type MVCCReadWriter interface {
+	// SeekGE advances the iterator to the first key which is >= the provided
+	// key.
+	SeekGE(key roachpb.Key)
+	// SeekLT advances the iterator to the first key which is < the provided key.
+	SeekLT(key roachpb.Key)
+	// Valid must be called after any call to SeekGE(), SeekLT(), Next(),
+	// Prev(). It returns (true, nil) if the iterator points to a valid key. It
+	// returns (false, nil) if the iterator has moved past the end of the valid
+	// range, or (false, err) if an error has occurred. Valid() will never
+	// return true with a non-nil error.
+	Valid() (bool, error)
+	// NextKey advances the iterator to the next key/value in the
+	// iteration. After this call, Valid() will be true if the
+	// iterator was not previously positioned at the last key.
+	NextKey()
+	// PrevKey moves the iterator backward to the previous key/value
+	// in the iteration. After this call, Valid() will be true if the
+	// iterator was not previously positioned at the first key.
+	PrevKey()
+	// UnsafeKey returns the Key, but the memory is invalidated on
+	// the next call to {NextKey,PrevKey,SeekGE,SeekLT,Close}.
+	UnsafeKey() storage.MVCCKey
+	// UnsafeValue returns the same value as Value, but the memory is
+	// invalidated on the next call to {NextKey,PrevKey,SeekGE,SeekLT,Close}.
+	UnsafeValue() []byte
+	// IsMyKeyValue() returns true iff the key-value that is being returned by
+	// Unsafe{Key, Value} was written by the transaction that is using this
+	// MVCCReadWriter.
+	IsMyKeyValue() bool
+	// SetUpperBound installs a new upper bound for this iterator.
+	SetUpperBound(roachpb.Key)
+
+	// Put sets the given key to the value provided. The caller must have
+	// positioned the iterator at the most recent version of key.key, if there
+	// are any versions. And SetUpperBound() must have been called to ensure
+	// the iterator is invalid if there was no version.
+	// Note that the most recent version can be an uncommitted version from the
+	// same txn.
+	// If there is a most recent version the caller must set key.Timestamp to:
+	// - !IsMyKeyValue(): > UnsafeKey().Timestamp
+	// - IsMyKeyValue(): >= UnsafeKey().Timestamp.
+	// The txnMeta parameter must be consistent with this Put.
+	//
+	// It is safe to modify the contents of the arguments after Put returns.
+	Put(key storage.MVCCKey, value []byte, txnMeta *enginepb.TxnMeta) error
+
+	// This closes the MVCCReadWriter. It does not commit anything written to
+	// the storage.ReadWriter that the MVCCReadWriter was initialized with. It
+	// is the caller's responsibility to commit if it wishes to.
+	Close()
+}
+
+// TODO: implement itersBeforeSeek optimization
+// TODO: implement Reverse iteration.
+// TODO: add call to storage.Writer.LogLogicalOp in Put
+// TODO: implement an optional optimistic mode when intentAwareReadWriter.readOnly
+// is true. Will need to create intentIter even in the request is non-transactional
+// and return a distinguishable error that the caller can use to retry
+// pessimistically.
+
+// Implementation of MVCCReadWriter.
+//
+// - It currently does not interact directly with lockTable, since we do not
+//   allow multiple intents to exist for the same key in the lockTable. This
+//   will eventually change, and this implementation will use the lockTable's
+//   in-memory state of intents that are committed to also adjust the
+//   timestamps of the provisional values from other transactions that have
+//   committed but whose intents have not yet been removed. We do not expect
+//   this implementation will inform the lockTable of new intents it is adding
+//   since those intents have not yet being committed via state machine
+//   replication.
+// -
+type intentAwareReadWriter struct {
+	lowerBound roachpb.Key
+	upperBound roachpb.Key
+
+	writer storage.Writer
+	// Non-nil for a transactional read or write.
+	txn *roachpb.Transaction
+	// The stats to update for a Put. nil when readOnly is true.
+	ms *enginepb.MVCCStats
+	// Set to true, if there will never be a Put.
+	readOnly bool
+	// If txn != nil, this is equal to txn.ReadTimestamp.
+	// NB: There is no configured writeTimestamp. As mentioned earlier,
+	// it is the caller's responsibility to set an appropriate
+	// timestamp in the Put call.
+	readTimestamp hlc.Timestamp
+	// Set when readOnly && txn != nil && readTimestamp < txn.MaxTimestamp
+	checkUncertainty bool
+	// Set when !readOnly or forceFindMostRecent, so that the iterator is
+	// positioned at the most recent committed value when this txn does not
+	// already have an intent. Note that for !readOnly, and when this txn
+	// already has an intent, it is the caller's responsibility to ensure that
+	// rw.txn.Sequence < rw.curMeta.Txn.Sequence since earlier seqs of the txn
+	// should not be executing after later seqs.
+	findMostRecent bool
+
+	// The iterator in the key-value space.
+	valueIter                 storage.Iterator
+	valueIterAlreadyAtNextKey bool
+	// The iterator in the lock space for reading replicated exclusive locks
+	// that also function as intents.
+	intentIter storage.Iterator
+	// When the intentIter is valid, the decoded key, from the key-value
+	// space is placed in lockedKey. Depending on the iteration direction, this
+	// key is equal to or ahead of the key at which valueIter is positioned (when
+	// !valueIterAlreadyAtNextKey).
+	lockedKey       roachpb.Key
+	lockedKeyIsMine bool
+	// True when intentIter and valueIter are at the same key.
+	itersAreEqual bool
+	// True iff itersAreEqual and the intent is for the same transaction.
+	posOnOwnIntent bool
+	// When posOnOwnIntent is true, the MVCCMetadata is decoded into curMeta
+	curMeta enginepb.MVCCMetadata
+	// If posOnOwnIntent && valueFromIntent, the caller has read an older version
+	// written by this txn. That value is placed in intentValue.
+	// If posOnOwnIntent && !valueFromIntent, the valueIterValueIsMine represents
+	// whether the value at which valueIter is positioned is written by this
+	// txn.
+	valueFromIntent      bool
+	intentValue          []byte
+	valueIterValueIsMine bool
+
+	// notValid is true when the iterator is no longer positioned at
+	// a valid entry. err != nil implies notValid, but the reverse is not
+	// true, since the caller can change direction or seek again.
+	notValid bool
+	err      error
+
+	keyBuf          []byte
+	metaBuf         []byte
+	implicitOldMeta enginepb.MVCCMetadata
+	newMeta         enginepb.MVCCMetadata
+}
+
+var _ MVCCReadWriter = &intentAwareReadWriter{}
+
+// intentAwareReadWriter is only for request processing.
+// Do not set opts.{Min, Max}TimestampHint -- they are not supported. For time
+// bound iterators, which are request agnostic, there will be a different
+// interface and implementation that uses the fact that the lockTable has already
+// been used to confirm that there are no intents below the MaxTimestampHint.
+func CreateMVCCReadWriter(
+	reader storage.Reader,
+	writer storage.Writer,
+	opts storage.IterOptions,
+	txn *roachpb.Transaction,
+	ms *enginepb.MVCCStats,
+	readTimestamp hlc.Timestamp,
+	forceFindMostRecent bool,
+) *intentAwareReadWriter {
+	if opts.LowerBound == nil || opts.UpperBound == nil {
+		panic("we need bounds to not traverse into non-MVCC parts of the key space")
+	}
+	var intentIter storage.Iterator
+	if txn != nil {
+		intentOpts := opts
+		intentOpts.LowerBound = keys.MakeLockTableKeyPrefix(opts.LowerBound)
+		intentOpts.UpperBound = keys.MakeLockTableKeyPrefix(opts.UpperBound)
+		intentIter = reader.NewIterator(intentOpts)
+	}
+	mvccRW := &intentAwareReadWriter{
+		writer:           writer,
+		txn:              txn,
+		ms:               ms,
+		readOnly:         ms == nil,
+		readTimestamp:    readTimestamp,
+		checkUncertainty: ms == nil && txn != nil && readTimestamp.Less(txn.MaxTimestamp),
+		findMostRecent:   ms != nil || forceFindMostRecent,
+		valueIter:        reader.NewIterator(opts),
+		intentIter:       intentIter,
+	}
+	return mvccRW
+}
+
+func (rw *intentAwareReadWriter) SeekGE(key roachpb.Key) {
+	rw.notValid = false
+	if rw.txn != nil {
+		// Position the intentIter.
+		intentSeekKey := keys.LockTableKeyExclusive(key, rw.txn.ID)
+		// It is odd to use an interface that expects an MVCCKey when we are
+		// seeking in a key space that is not MVCC
+		rw.intentIter.SeekGE(storage.MVCCKey{Key: intentSeekKey})
+		if err := rw.tryDecodeLockedKey(); err != nil {
+			return
+		}
+	}
+	// Position at the youngest version of key.
+	rw.valueIter.SeekGE(storage.MVCCKey{Key: key})
+	valid, err := rw.valueIter.Valid()
+	if err != nil || !valid {
+		rw.err = err
+		rw.notValid = true
+		return
+	}
+	rw.itersAreEqual = false
+	rw.posOnOwnIntent = false
+	rw.valueIterAlreadyAtNextKey = false
+	// Iterate forward until we have extracted a value or there is an error
+	// or nothing left to read.
+	for !rw.extractValue() && rw.nextKey() {
+	}
+}
+
+// Must be called with a valid valueIter.
+// Returns true when successful, or done (due to error or nothing to read).
+// Returns false if stepped to the next key without finding a version to extract.
+func (rw *intentAwareReadWriter) extractValue() bool {
+	rw.valueFromIntent = false
+	rw.valueIterValueIsMine = false
+	rw.itersAreEqual = rw.lockedKey != nil && rw.lockedKey.Equal(rw.valueIter.UnsafeKey().Key)
+	// Find existing intent for this txn, if any.
+	if rw.txn != nil {
+		if !rw.itersAreEqual || !rw.lockedKeyIsMine {
+			// No intent, or not my intent. If it is not my intent, we've already dealt
+			// with it in lockTable, with one of two cases:
+			// - this must be a non-locking read-only request and the intent must be at
+			//   a higher timestamp.
+			// - read-only requests that are acquiring unreplicated locks set
+			//   forceFindMostRecent but they have seen conflicting intents.
+			return rw.extractOtherFromValueIter()
+		}
+		// Found our own intent.
+		if err := rw.intentIter.ValueProto(&rw.curMeta); err != nil {
+			rw.err = err
+			rw.notValid = true
+			return true
+		}
+		rw.posOnOwnIntent = true
+		// Don't need to check uncertainty, or find more recent.
+		if rw.txn.Epoch < rw.curMeta.Txn.Epoch {
+			// We're reading our own txn's intent but the current txn has
+			// an earlier epoch than the intent. Return an error so that the
+			// earlier incarnation of our transaction aborts (presumably
+			// this is some operation that was retried).
+			rw.err = errors.Errorf("failed to read with epoch %d due to a write intent with epoch %d",
+				rw.txn.Epoch, rw.curMeta.Txn.Epoch)
+			rw.notValid = true
+			return true
+		}
+		if rw.txn.Epoch == rw.curMeta.Txn.Epoch {
+			if rw.txn.Sequence >= rw.curMeta.Txn.Sequence && !enginepb.TxnSeqIsIgnored(rw.curMeta.Txn.Sequence, rw.txn.IgnoredSeqNums) {
+				// We're reading our own txn's intent at an equal or higher sequence.
+				// Note that we read at the intent timestamp, not at our read timestamp
+				// as the intent timestamp may have been pushed forward by another
+				// transaction. Txn's always need to read their own writes.
+				rw.extractOwnFromValueIter(hlc.Timestamp(rw.curMeta.Timestamp))
+				return true
+			}
+			// We're reading our own txn's intent at a lower sequence than is
+			// currently present in the provisional value. This means the intent
+			// we're seeing was written at a higher sequence than the read and that
+			// there may or may not be earlier versions of the intent (with lower
+			// sequence numbers) that we should read. If there exists a value in the
+			// intent history that has a sequence number equal to or less than the
+			// read sequence, read that value.
+			if found := rw.getFromIntentHistory(); found {
+				return true
+			}
+			// If no value in the intent history has a sequence number equal to
+			// or less than the read, we must ignore the intents laid down by the
+			// transaction all together. We ignore the intent by insisting that the
+			// timestamp we're reading at is a historical timestamp < the intent
+			// timestamp.
+			return rw.extractOtherUsingTsFromValueIter(hlc.Timestamp(rw.curMeta.Timestamp).Prev())
+		}
+		// We're reading our own txn's intent but the current txn has a
+		// later epoch than the intent. This can happen if the txn was
+		// restarted and an earlier iteration wrote the value we're now
+		// reading. In this case, we ignore the intent and read the
+		// previous value as if the transaction were starting fresh.
+		return rw.extractOtherUsingTsFromValueIter(hlc.Timestamp(rw.curMeta.Timestamp).Prev())
+	}
+	// There is no intent.
+	return rw.extractOtherFromValueIter()
+}
+
+// Must be called with a valid valueIter. Returns true if successful or
+// iterator is done (due to error or nothing to read). Return false if
+// could not find a version to read and the iterator is not done.
+func (rw *intentAwareReadWriter) extractOtherFromValueIter() bool {
+	if rw.findMostRecent {
+		// Already positioned at latest version
+		return true
+	}
+	copiedToKeyBuf := false
+	if rw.checkUncertainty {
+		for {
+			valueTS := rw.valueIter.UnsafeKey().Timestamp
+			if rw.txn.MaxTimestamp.Less(valueTS) {
+				if !copiedToKeyBuf {
+					copiedToKeyBuf = true
+					rw.keyBuf = append(rw.keyBuf[:0], rw.valueIter.UnsafeKey().Key...)
+				}
+				if !rw.nextVersionValueIter() {
+					return rw.notValid
+				}
+			} else if valueTS.LessEq(rw.txn.MaxTimestamp) && rw.readTimestamp.Less(valueTS) {
+				rw.err = roachpb.NewReadWithinUncertaintyIntervalError(
+					rw.readTimestamp, valueTS, rw.txn)
+				rw.notValid = true
+				return true
+			} else {
+				break
+			}
+		}
+	}
+	for rw.readTimestamp.Less(rw.valueIter.UnsafeKey().Timestamp) {
+		if !copiedToKeyBuf {
+			copiedToKeyBuf = true
+			rw.keyBuf = append(rw.keyBuf[:0], rw.valueIter.UnsafeKey().Key...)
+		}
+		if !rw.nextVersionValueIter() {
+			return rw.notValid
+		}
+	}
+	return true
+}
+
+// Returns false if there is an error, or there are no more versions of the key.
+// rw.keyBuf must already contain a saved version of the current key.
+func (rw *intentAwareReadWriter) nextVersionValueIter() bool {
+	rw.valueIter.Next()
+	valid, err := rw.valueIter.Valid()
+	if err != nil || !valid {
+		rw.err = err
+		rw.notValid = true
+		return false
+	}
+	if !rw.valueIter.UnsafeKey().Key.Equal(rw.keyBuf) {
+		rw.valueIterAlreadyAtNextKey = true
+		return false
+	}
+	return true
+}
+
+// It is an error if there is no value at ts.
+func (rw *intentAwareReadWriter) extractOwnFromValueIter(ts hlc.Timestamp) {
+	// The intent ts must be the most recent version, which we are already it.
+	if rw.valueIter.UnsafeKey().Timestamp != ts {
+		rw.err = errors.Errorf("corruption or bug: found ts %s instead of expected %s",
+			rw.valueIter.UnsafeKey().Timestamp, ts)
+		rw.notValid = true
+	}
+	rw.valueIterValueIsMine = true
+	return
+}
+
+// Returns true when successful, or done (due to error or nothing to read).
+// Returns false if stepped to the next key without finding a version to extract.
+func (rw *intentAwareReadWriter) extractOtherUsingTsFromValueIter(ts hlc.Timestamp) bool {
+	copiedToKeyBuf := false
+	for {
+		valueTS := rw.valueIter.UnsafeKey().Timestamp
+		if valueTS.LessEq(ts) {
+			return true
+		}
+		if !copiedToKeyBuf {
+			copiedToKeyBuf = true
+			rw.keyBuf = append(rw.keyBuf[:0], rw.valueIter.UnsafeKey().Key...)
+		}
+		if !rw.nextVersionValueIter() {
+			return rw.notValid
+		}
+	}
+}
+
+func (rw *intentAwareReadWriter) getFromIntentHistory() bool {
+	intentHistory := rw.curMeta.IntentHistory
+	// upIdx is the index of the first intent in intentHistory with a sequence
+	// number greater than our transaction's sequence number. Subtract 1 from it
+	// to get the index of the intent with the highest sequence number that is
+	// still less than or equal to p.txnSeq.
+	upIdx := sort.Search(len(intentHistory), func(i int) bool {
+		return intentHistory[i].Sequence > rw.txn.Sequence
+	})
+	// If the candidate intent has a sequence number that is ignored by this txn,
+	// iterate backward along the sorted intent history until we come across an
+	// intent which isn't ignored.
+	//
+	// TODO(itsbilal): Explore if this iteration can be improved through binary
+	// search.
+	for upIdx > 0 && enginepb.TxnSeqIsIgnored(
+		rw.curMeta.IntentHistory[upIdx-1].Sequence, rw.txn.IgnoredSeqNums) {
+		upIdx--
+	}
+	if upIdx == 0 {
+		// It is possible that no intent exists such that the sequence is less
+		// than the read sequence, and is not ignored by this transaction.
+		// In this case, we cannot read a value from the intent history.
+		return false
+	}
+	intent := &rw.curMeta.IntentHistory[upIdx-1]
+	rw.valueFromIntent = true
+	rw.intentValue = intent.Value
+	return true
+}
+
+func (rw *intentAwareReadWriter) NextKey() {
+	success := rw.nextKey()
+	for success && !rw.extractValue() {
+		success = rw.nextKey()
+	}
+}
+
+// Moves to the next key. Returns true if successful, and false if there is an
+// error or nothing left to read.
+func (rw *intentAwareReadWriter) nextKey() bool {
+	if !rw.valueIterAlreadyAtNextKey {
+		rw.valueIter.NextKey()
+	} else {
+		rw.valueIterAlreadyAtNextKey = false
+	}
+	valid, err := rw.valueIter.Valid()
+	if err != nil || !valid {
+		rw.err = err
+		rw.notValid = true
+		return false
+	}
+	if rw.itersAreEqual {
+		rw.intentIter.Next()
+		rw.itersAreEqual = false
+		rw.posOnOwnIntent = false
+		if err := rw.tryDecodeLockedKey(); err != nil {
+			return false
+		}
+	}
+	// Else the intentIter was already ahead of the valueIter, so nothing
+	// to do.
+	return true
+}
+
+func (rw *intentAwareReadWriter) tryDecodeLockedKey() error {
+	valid, err := rw.intentIter.Valid()
+	if err != nil {
+		rw.err = err
+		rw.notValid = true
+		return err
+	}
+	if !valid {
+		rw.lockedKey = nil
+		return nil
+	}
+	var txnID uuid.UUID
+	rw.lockedKey, _, txnID, err = keys.DecodeLockTableKey(rw.intentIter.UnsafeKey().Key)
+	if err != nil {
+		rw.err = err
+		rw.notValid = true
+		return err
+	}
+	rw.lockedKeyIsMine = rw.txn != nil && txnID == rw.txn.ID
+	return nil
+}
+
+func (rw *intentAwareReadWriter) Valid() (bool, error) {
+	return rw.notValid, rw.err
+}
+
+func (rw *intentAwareReadWriter) UnsafeKey() storage.MVCCKey {
+	if rw.valueFromIntent {
+		return storage.MVCCKey{
+			Key:       rw.intentIter.Key().Key,
+			Timestamp: hlc.Timestamp(rw.curMeta.Timestamp),
+		}
+	}
+	return rw.valueIter.Key()
+}
+
+func (rw *intentAwareReadWriter) UnsafeValue() []byte {
+	if rw.valueFromIntent {
+		return rw.intentValue
+	}
+	return rw.valueIter.UnsafeValue()
+}
+
+func (rw *intentAwareReadWriter) IsMyKeyValue() bool {
+	return rw.valueFromIntent || rw.valueIterValueIsMine
+}
+
+func (rw *intentAwareReadWriter) SetUpperBound(key roachpb.Key) {
+	rw.valueIter.SetUpperBound(key)
+	if rw.txn != nil {
+		rw.valueIter.SetUpperBound(keys.LockTableKeyExclusive(key, rw.txn.ID))
+	}
+}
+
+func (rw *intentAwareReadWriter) Put(
+	key storage.MVCCKey, value []byte, txnMeta *enginepb.TxnMeta,
+) error {
+	rw.newMeta = enginepb.MVCCMetadata{}
+	if rw.posOnOwnIntent && txnMeta.Epoch == rw.curMeta.Txn.Epoch {
+		rw.newMeta.IntentHistory = rw.curMeta.IntentHistory
+	}
+	if rw.valueIterValueIsMine {
+		// Latest value is not rolled back in a savepoint rollback.
+		rw.newMeta.AddToIntentHistory(rw.curMeta.Txn.Sequence, rw.valueIter.UnsafeValue())
+	}
+	rw.newMeta.Txn = txnMeta
+	rw.newMeta.Timestamp = hlc.LegacyTimestamp(key.Timestamp)
+	rw.newMeta.KeyBytes = storage.MVCCVersionTimestampSize
+	rw.newMeta.ValBytes = int64(len(value))
+	rw.newMeta.Deleted = value == nil
+	var metaKeySize, metaValSize int64
+	fakeMetaKey := storage.MVCCKey{Key: key.Key}
+	if rw.newMeta.Txn != nil {
+		if err := rw.marshalMeta(&rw.newMeta); err != nil {
+			return err
+		}
+		var metaKey storage.MVCCKey
+		if rw.posOnOwnIntent {
+			metaKey = rw.intentIter.Key()
+		} else {
+			metaKey = storage.MVCCKey{Key: keys.LockTableKeyExclusive(key.Key, rw.txn.ID)}
+		}
+		if err := rw.writer.Put(metaKey, rw.metaBuf); err != nil {
+			return err
+		}
+		metaKeySize = int64(fakeMetaKey.EncodedSize())
+		metaValSize = int64(len(rw.metaBuf))
+	} else {
+		// Per-key stats count the full-key once and MVCCVersionTimestampSize for
+		// each versioned value. We maintain that accounting even when the MVCC
+		// metadata is implicit.
+		metaKeySize = int64(fakeMetaKey.EncodedSize())
+	}
+
+	// Write the mvcc value.
+	if rw.posOnOwnIntent && hlc.Timestamp(rw.curMeta.Timestamp) != key.Timestamp {
+		if err := rw.writer.Clear(
+			storage.MVCCKey{Key: key.Key, Timestamp: hlc.Timestamp(rw.curMeta.Timestamp)}); err != nil {
+			return err
+		}
+	}
+	if err := rw.writer.Put(key, value); err != nil {
+		return err
+	}
+
+	// Update MVCC stats.
+	if rw.ms != nil {
+		var oldMeta *enginepb.MVCCMetadata
+		var prevValSize, origMetaKeySize, origMetaValSize int64
+		origMetaKeySize = int64(fakeMetaKey.EncodedSize())
+		if rw.posOnOwnIntent {
+			oldMeta = &rw.curMeta
+			// We are replacing our own write intent. If we are not writing at the
+			// same timestamp we must take care with MVCCStats: If the older write
+			// intent has a version underneath it, we need to read its size because
+			// its GCBytesAge contribution may change as we move the intent above
+			// it. A similar phenomenon occurs in intent resolution.
+			if hlc.Timestamp(oldMeta.Timestamp).Less(key.Timestamp) {
+				if !rw.valueFromIntent && !rw.valueIterValueIsMine {
+					// We already tried to read the previous value written by a
+					// different transaction.
+					if !rw.notValid {
+						prevValSize = int64(len(rw.valueIter.UnsafeValue()))
+					}
+				} else {
+					// rw.valueFroIntent || rw.valueIterValueIsMine.
+					// The valueIter is positioned at our provisional value.
+					if rw.nextVersionValueIter() {
+						prevValSize = int64(len(rw.valueIter.UnsafeValue()))
+					}
+				}
+			}
+			origMetaValSize = int64(len(rw.intentIter.UnsafeValue()))
+		} else {
+			rw.initImplicitOldMeta()
+			oldMeta = &rw.implicitOldMeta
+			origMetaValSize = 0
+		}
+		rw.ms.Add(updateStatsOnPut(key.Key, prevValSize, origMetaKeySize, origMetaValSize,
+			metaKeySize, metaValSize, oldMeta, &rw.newMeta))
+	}
+	return nil
+}
+
+func (rw *intentAwareReadWriter) initImplicitOldMeta() {
+	rw.implicitOldMeta.Reset()
+	// For values, the size of keys is always accounted for as
+	// MVCCVersionTimestampSize. The size of the metadata key is
+	// accounted for separately.
+	if valid, _ := rw.Valid(); valid {
+		rw.implicitOldMeta.KeyBytes = storage.MVCCVersionTimestampSize
+		rw.implicitOldMeta.ValBytes = int64(len(rw.UnsafeValue()))
+		rw.implicitOldMeta.Timestamp = hlc.LegacyTimestamp(rw.UnsafeKey().Timestamp)
+	}
+	rw.implicitOldMeta.Deleted = rw.implicitOldMeta.ValBytes == 0
+}
+
+func (rw *intentAwareReadWriter) marshalMeta(meta *enginepb.MVCCMetadata) error {
+	size := meta.Size()
+	if cap(rw.metaBuf) < size {
+		rw.metaBuf = make([]byte, size)
+	} else {
+		rw.metaBuf = rw.metaBuf[:size]
+	}
+	_, err := protoutil.MarshalTo(meta, rw.metaBuf)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// isSysLocal returns whether the whether the key is system-local.
+func isSysLocal(key roachpb.Key) bool {
+	return key.Compare(keys.LocalMax) < 0
+}
+
+// This is copied from mvcc.go. This is too complicated and I am
+// inclined towards changing how stats are kept, but I am unclear
+// on compatibility issues that may arise
+//
+// updateStatsOnPut updates stat counters for a newly put value,
+// including both the metadata key & value bytes and the mvcc
+// versioned value's key & value bytes. If the value is not a
+// deletion tombstone, updates the live stat counters as well.
+// If this value is an intent, updates the intent counters.
+func updateStatsOnPut(
+	key roachpb.Key,
+	prevValSize int64,
+	origMetaKeySize, origMetaValSize, metaKeySize, metaValSize int64,
+	orig, meta *enginepb.MVCCMetadata,
+) enginepb.MVCCStats {
+	var ms enginepb.MVCCStats
+
+	if isSysLocal(key) {
+		// Handling system-local keys is straightforward because
+		// we don't track ageable quantities for them (we
+		// could, but don't). Remove the contributions from the
+		// original, if any, and add in the new contributions.
+		if orig != nil {
+			ms.SysBytes -= origMetaKeySize + origMetaValSize
+			if orig.Txn != nil {
+				// If the original value was an intent, we're replacing the
+				// intent. Note that since it's a system key, it doesn't affect
+				// IntentByte, IntentCount, and correspondingly, IntentAge.
+				ms.SysBytes -= orig.KeyBytes + orig.ValBytes
+			}
+			ms.SysCount--
+		}
+		ms.SysBytes += meta.KeyBytes + meta.ValBytes + metaKeySize + metaValSize
+		ms.SysCount++
+		return ms
+	}
+
+	// Handle non-sys keys. This follows the same scheme: if there was a previous
+	// value, perhaps even an intent, subtract its contributions, and then add the
+	// new contributions. The complexity here is that we need to properly update
+	// GCBytesAge and IntentAge, which don't follow the same semantics. The difference
+	// between them is that an intent accrues IntentAge from its own timestamp on,
+	// while GCBytesAge is accrued by versions according to the following rules:
+	// 1. a (non-tombstone) value that is shadowed by a newer write accrues age at
+	// 	  the point in time at which it is shadowed (i.e. the newer write's timestamp).
+	// 2. a tombstone value accrues age at its own timestamp (note that this means
+	//    the tombstone's own contribution only -- the actual write that was deleted
+	//    is then shadowed by this tombstone, and will thus also accrue age from
+	//    the tombstone's value on, as per 1).
+	//
+	// This seems relatively straightforward, but only because it omits pesky
+	// details, which have been relegated to the comments below.
+
+	// Remove current live counts for this key.
+	if orig != nil {
+		ms.KeyCount--
+
+		// Move the (so far empty) stats to the timestamp at which the
+		// previous entry was created, which is where we wish to reclassify
+		// its contributions.
+		ms.AgeTo(orig.Timestamp.WallTime)
+
+		// If the original metadata for this key was an intent, subtract
+		// its contribution from stat counters as it's being replaced.
+		if orig.Txn != nil {
+			// Subtract counts attributable to intent we're replacing.
+			ms.ValCount--
+			ms.IntentBytes -= (orig.KeyBytes + orig.ValBytes)
+			ms.IntentCount--
+		}
+
+		// If the original intent is a deletion, we're removing the intent. This
+		// means removing its contribution at the *old* timestamp because it has
+		// accrued GCBytesAge that we need to offset (rule 2).
+		//
+		// Note that there is a corresponding block for the case of a non-deletion
+		// (rule 1) below, at meta.Timestamp.
+		if orig.Deleted {
+			ms.KeyBytes -= origMetaKeySize
+			ms.ValBytes -= origMetaValSize
+
+			if orig.Txn != nil {
+				ms.KeyBytes -= orig.KeyBytes
+				ms.ValBytes -= orig.ValBytes
+			}
+		}
+
+		// Rule 1 implies that sometimes it's not only the old meta and the new meta
+		// that matter, but also the version below both of them. For example, take
+		// a version at t=1 and an intent over it at t=2 that is now being replaced
+		// (t=3). Then orig.Timestamp will be 2, and meta.Timestamp will be 3, but
+		// rule 1 tells us that for the interval [2,3) we have already accrued
+		// GCBytesAge for the version at t=1 that is now moot, because the intent
+		// at t=2 is moving to t=3; we have to emit a GCBytesAge offset to that effect.
+		//
+		// The code below achieves this by making the old version live again at
+		// orig.Timestamp, and then marking it as shadowed at meta.Timestamp below.
+		// This only happens when that version wasn't a tombstone, in which case it
+		// contributes from its own timestamp on anyway, and doesn't need adjustment.
+		//
+		// Note that when meta.Timestamp equals orig.Timestamp, the computation is
+		// moot, which is something our callers may exploit (since retrieving the
+		// previous version is not for free).
+		prevIsValue := prevValSize > 0
+
+		if prevIsValue {
+			// If the previous value (exists and) was not a deletion tombstone, make it
+			// live at orig.Timestamp. We don't have to do anything if there is a
+			// previous value that is a tombstone: according to rule two its age
+			// contributions are anchored to its own timestamp, so moving some values
+			// higher up doesn't affect the contributions tied to that key.
+			ms.LiveBytes += storage.MVCCVersionTimestampSize + prevValSize
+		}
+
+		// Note that there is an interesting special case here: it's possible that
+		// meta.Timestamp.WallTime < orig.Timestamp.WallTime. This wouldn't happen
+		// outside of tests (due to our semantics of txn.ReadTimestamp, which never
+		// decreases) but it sure does happen in randomized testing. An earlier
+		// version of the code used `Forward` here, which is incorrect as it would be
+		// a no-op and fail to subtract out the intent bytes/GC age incurred due to
+		// removing the meta entry at `orig.Timestamp` (when `orig != nil`).
+		ms.AgeTo(meta.Timestamp.WallTime)
+
+		if prevIsValue {
+			// Make the previous non-deletion value non-live again, as explained in the
+			// sibling block above.
+			ms.LiveBytes -= storage.MVCCVersionTimestampSize + prevValSize
+		}
+
+		// If the original version wasn't a deletion, it becomes non-live at meta.Timestamp
+		// as this is where it is shadowed.
+		if !orig.Deleted {
+			ms.LiveBytes -= orig.KeyBytes + orig.ValBytes
+			ms.LiveBytes -= origMetaKeySize + origMetaValSize
+			ms.LiveCount--
+
+			ms.KeyBytes -= origMetaKeySize
+			ms.ValBytes -= origMetaValSize
+
+			if orig.Txn != nil {
+				ms.KeyBytes -= orig.KeyBytes
+				ms.ValBytes -= orig.ValBytes
+			}
+		}
+	} else {
+		ms.AgeTo(meta.Timestamp.WallTime)
+	}
+
+	// If the new version isn't a deletion tombstone, add it to live counters.
+	if !meta.Deleted {
+		ms.LiveBytes += meta.KeyBytes + meta.ValBytes + metaKeySize + metaValSize
+		ms.LiveCount++
+	}
+	ms.KeyBytes += meta.KeyBytes + metaKeySize
+	ms.ValBytes += meta.ValBytes + metaValSize
+	ms.KeyCount++
+	ms.ValCount++
+	if meta.Txn != nil {
+		ms.IntentBytes += meta.KeyBytes + meta.ValBytes
+		ms.IntentCount++
+	}
+
+	return ms
+}
+
+func (rw *intentAwareReadWriter) Close() {
+	rw.valueIter.Close()
+	if rw.txn != nil {
+		rw.intentIter.Close()
+	}
+}
+
+func (rw *intentAwareReadWriter) SeekLT(key roachpb.Key) {
+	// TODO
+}
+
+func (rw *intentAwareReadWriter) PrevKey() {
+	// TODO
+}

--- a/pkg/kv/kvserver/mvcc/mvcc2.go
+++ b/pkg/kv/kvserver/mvcc/mvcc2.go
@@ -1,0 +1,149 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package mvcc
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/pkg/errors"
+)
+
+// Replacement for mvcc.go. Incomplete.
+// This assumes the lockTable has already dealt with conflicting locks, though errors
+// can still happen due to uncertainty etc.
+// We don't need to remove mvcc.go in one-shot since the code there to deal with
+// conflicting intents is harmless. We can transition callers one at a time and
+// incrementally remove dead code from mvcc.go
+
+func MVCCPut2(
+	ctx context.Context,
+	rw concurrency.MVCCReadWriter,
+	key roachpb.Key,
+	timestamp hlc.Timestamp,
+	value []byte,
+	txn *roachpb.Transaction,
+) error {
+	rw.SeekGE(key)
+	var err error
+	var valid bool
+	if valid, err = rw.Valid(); err != nil {
+		return err
+	}
+	writeTimestamp := timestamp
+	if txn != nil {
+		writeTimestamp = txn.WriteTimestamp
+	}
+	if valid {
+		prevKey := rw.UnsafeKey()
+		if rw.IsMyKeyValue() {
+			if writeTimestamp.Less(prevKey.Timestamp) {
+				writeTimestamp = prevKey.Timestamp
+			}
+		} else if writeTimestamp.LessEq(prevKey.Timestamp) {
+			writeTimestamp = prevKey.Timestamp.Next()
+			err = roachpb.NewWriteTooOldError(timestamp, writeTimestamp)
+		}
+	}
+	if err2 := rw.Put(storage.MVCCKey{Key: key, Timestamp: writeTimestamp}, value, &txn.TxnMeta); err2 != nil {
+		return err2
+	}
+	return err
+}
+
+func MVCCGet2(
+	ctx context.Context, reader concurrency.MVCCReadWriter, key roachpb.Key,
+) (*roachpb.Value, error) {
+	reader.SeekGE(key)
+	if valid, err := reader.Valid(); err != nil || !valid {
+		return nil, err
+	}
+	value := &roachpb.Value{
+		RawBytes:  append([]byte(nil), reader.UnsafeValue()...),
+		Timestamp: reader.UnsafeKey().Timestamp,
+	}
+	return value, nil
+}
+
+type MVCCScanOptions2 struct {
+	Reverse          bool
+	FailOnMoreRecent bool
+	// MaxKeys is the maximum number of kv pairs returned from this operation.
+	// The zero value represents an unbounded scan. If the limit stops the scan,
+	// a corresponding ResumeSpan is returned. As a special case, the value -1
+	// returns no keys in the result (returning the first key via the
+	// ResumeSpan).
+	MaxKeys int64
+	// TargetBytes is a byte threshold to limit the amount of data pulled into
+	// memory during a Scan operation. Once the target is satisfied (i.e. met or
+	// exceeded) by the emitted emitted KV pairs, iteration stops (with a
+	// ResumeSpan as appropriate). In particular, at least one kv pair is
+	// returned (when one exists).
+	//
+	// The number of bytes a particular kv pair accrues depends on internal data
+	// structures, but it is guaranteed to exceed that of the bytes stored in
+	// the key and value itself.
+	//
+	// The zero value indicates no limit.
+	TargetBytes int64
+}
+
+func MVCCScan2(
+	ctx context.Context,
+	reader concurrency.MVCCReadWriter,
+	timestamp hlc.Timestamp,
+	endKey roachpb.Key,
+	opts MVCCScanOptions2,
+) (storage.MVCCScanResult, error) {
+	// TODO: implement opts.Reverse
+	var res storage.MVCCScanResult
+	for {
+		if valid, err := reader.Valid(); err != nil || !valid {
+			return res, err
+		}
+		if opts.FailOnMoreRecent && !reader.IsMyKeyValue() && timestamp.Less(reader.UnsafeKey().Timestamp) {
+			return res, errors.Errorf("todo")
+		}
+		if (opts.MaxKeys != 0 && opts.MaxKeys <= res.NumKeys) ||
+			(opts.TargetBytes != 0 && opts.TargetBytes <= res.NumBytes) {
+			break
+		}
+		kv := roachpb.KeyValue{
+			Key: append([]byte(nil), reader.UnsafeKey().Key...),
+			Value: roachpb.Value{
+				RawBytes:  append([]byte(nil), reader.UnsafeValue()...),
+				Timestamp: reader.UnsafeKey().Timestamp,
+			},
+		}
+		res.KVs = append(res.KVs, kv)
+		res.NumKeys++
+		res.NumBytes += int64(len(reader.UnsafeValue()))
+	}
+	res.ResumeSpan = &roachpb.Span{
+		Key:    append(roachpb.Key(nil), reader.UnsafeKey().Key...),
+		EndKey: endKey,
+	}
+	return res, nil
+}
+
+func MVCCScan2ToBytes(
+	ctx context.Context,
+	reader concurrency.MVCCReadWriter,
+	timestamp hlc.Timestamp,
+	endKey roachpb.Key,
+	opts MVCCScanOptions2,
+) (storage.MVCCScanResult, error) {
+	// TODO
+	return storage.MVCCScanResult{}, nil
+}

--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -43,11 +43,13 @@ type ReplicaDataIterator struct {
 
 // MakeAllKeyRanges returns all key ranges for the given Range.
 func MakeAllKeyRanges(d *roachpb.RangeDescriptor) []KeyRange {
-	return []KeyRange{
+	ranges := []KeyRange{
 		MakeRangeIDLocalKeyRange(d.RangeID, false /* replicatedOnly */),
 		MakeRangeLocalKeyRange(d),
 		MakeUserKeyRange(d),
 	}
+	ranges = append(ranges, MakeRangeLockTableKeyRanges(d)...)
+	return ranges
 }
 
 // MakeReplicatedKeyRanges returns all key ranges that are fully Raft
@@ -60,11 +62,13 @@ func MakeAllKeyRanges(d *roachpb.RangeDescriptor) []KeyRange {
 // 2. Range-local key range
 // 3. User key range
 func MakeReplicatedKeyRanges(d *roachpb.RangeDescriptor) []KeyRange {
-	return []KeyRange{
+	ranges := []KeyRange{
 		MakeRangeIDLocalKeyRange(d.RangeID, true /* replicatedOnly */),
 		MakeRangeLocalKeyRange(d),
 		MakeUserKeyRange(d),
 	}
+	ranges = append(ranges, MakeRangeLockTableKeyRanges(d)...)
+	return ranges
 }
 
 // MakeRangeIDLocalKeyRange returns the range-id local key range. If
@@ -92,6 +96,23 @@ func MakeRangeLocalKeyRange(d *roachpb.RangeDescriptor) KeyRange {
 	return KeyRange{
 		Start: storage.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(d.StartKey)),
 		End:   storage.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(d.EndKey)),
+	}
+}
+
+func MakeRangeLockTableKeyRanges(d *roachpb.RangeDescriptor) []KeyRange {
+	return []KeyRange{
+		{
+			Start: storage.MakeMVCCMetadataKey(keys.MakeLockTableKeyPrefix(roachpb.Key(d.StartKey))),
+			End:   storage.MakeMVCCMetadataKey(keys.MakeLockTableKeyPrefix(roachpb.Key(d.EndKey))),
+		},
+		// Need to handle doubly-local lock table keys since RangeDescriptorKey
+		// is a range local key that can have a replicated lock acquired on it.
+		{
+			Start: storage.MakeMVCCMetadataKey(keys.MakeLockTableKeyPrefix(
+				keys.MakeRangeKeyPrefix(d.StartKey))),
+			End: storage.MakeMVCCMetadataKey(keys.MakeLockTableKeyPrefix(
+				keys.MakeRangeKeyPrefix(d.EndKey))),
+		},
 	}
 }
 

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -997,11 +997,12 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 	subsumedRepls []*Replica,
 	subsumedNextReplicaID roachpb.ReplicaID,
 ) error {
-	getKeyRanges := func(desc *roachpb.RangeDescriptor) [2]rditer.KeyRange {
-		return [...]rditer.KeyRange{
-			rditer.MakeRangeLocalKeyRange(desc),
-			rditer.MakeUserKeyRange(desc),
-		}
+	getKeyRanges := func(desc *roachpb.RangeDescriptor) []rditer.KeyRange {
+		ranges := make([]rditer.KeyRange, 0, 4)
+		ranges = append(ranges, rditer.MakeRangeLocalKeyRange(desc))
+		ranges = append(ranges, rditer.MakeRangeLockTableKeyRanges(desc)...)
+		ranges = append(ranges, rditer.MakeUserKeyRange(desc))
+		return ranges
 	}
 	keyRanges := getKeyRanges(desc)
 	totalKeyRanges := append([]rditer.KeyRange(nil), keyRanges[:]...)


### PR DESCRIPTION
for issue 41720

The change to the separated lock table will happen in the following
stages. The code here sketches out parts of stage 2 (some
of this is usable in earlier stages too) so that we can better
judge whether we are going down a good path. This is incomplete,
has no tests (therefore bugs) -- it just builds.

- Stage 1: intents can be either interleaved with the MVCC values
  or in the separate lock table key space. When reading and writing
  true MVCC keys (not inline), the implementation of storage.Reader
  will make the intents in the lock table key space appear as
  interleaved, and the implementation of storage.Writer will take
  a write to an interleaved intent and place it instead in the lock
  table key space. The lockTable will work in two modes
  - non-optimistic requests: will look for conflicting locks in the
    lock table key space.
  - optimistic requests (limited scans): will ignore conflicting
    locks since they will be discovered in the MVCCScan later.

- Stage 2: intents are only in the separate lock table key space.
  - non-optimistic requests: will sequence with lockTable and then
    use mvccReadWriter to interact with MVCC kvs. The mvccReadWriter
    will only care about the requests own intents.
  - optimistic requests: will register with lockTable for later
    checking and use mvccReadWriter which also will also look at
    intents of other transactions to check for a read trying to
    read a provisional value of another transaction (issue 49973)

- Stage 3 and beyond misc improvements: N intents for a key where
  at least (N-1) are for STAGING transactions that are known to be
  commmitted; Optimistic latching along with optimistic locking
  (issue 9521); Intent resolution without latching; Replacing
  MVCCMetadata with something cleaner for intents and possibly
  migrating earlier versions from the same transaction into the
  MVCC key space.

Also, we are assuming that there is no RocksDB, so these changes
only need to work for Pebble.

The specific changes here are:
- add local range lock table key space
  - change ReplicaDataIterator to account for this new part of the
    key space

- move finalizedTxnCache into lockTableImpl. When doing ScanAndEnqueue
  if an unreplicated lock is encountered that is held by a txn in this
  cache, it is immediately removed. If a replicated lock is encountered
  a LockUpdate is created and the caller does not wait on that lock. At
  the end of ScanAndEnqueue if there are no locks to wait on, the
  caller is given this list of LockUpdates that it must resolve,
  and lockTableGuard.ShouldWait returns true. The caller will release
  latches, resolve these locks and then do another scan. Compared to
  the current batching of resolution that can only batch for a single
  span, this can batch across all spans of the request.

- change lockTable to wait on locks that are found by the
  storage.Iterator.

- add MVCCReadWriter interface and implementation intentAwareReadWriter.
  This is for processing a request that reads/writes MVCC values (not
  inline values). It is initialized with info about the request, such
  as the roachpb.Transaction, and handles checking uncertainty, finding
  the most recent writes (when used for Put), and updating the
  MVCCStats. It hides MVCCMetada from the MVCC code.
  The MVCCStats code is mostly copied from mvcc.go.

- I have not changed mvcc.go, but there is some integration demonstrated
  via changes to cmd_{put,get,scan}.go to use mvcc2.go.
  In stage 2 we can incrementally code move functionality from mvcc.go
  to the simpler mvcc2.go. Functionality that has not yet been moved
  to mvcc2.go will work as follows:
  - non-optimistic request evaluation: the storage.Reader/Writer will
    only see intents from the same transaction. Conflicting intents
    have already been dealt with in the lockTable.
  - optimistic request evaluation: the storage.Reader/Writer will
    see intents from all transactions.
  Also pebble_mvcc_scanner.go will go away since everything will work
  through the iteration interface of MVCCReadWriter.

- Changes to MVCCIncrementalIterator. It uses intentInterleavingIter
  to allow it to continue working in its current way. This is a
  hack -- there is a TODO in the code stating what we should really
  do here.

Release note: None