### PR TITLE
sql: add tests for SET DATATYPE with enum columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -989,3 +989,55 @@ INSERT INTO enum_referenced VALUES ('howdy')
 
 statement error pq: foreign key violation: "enum_origin" row x='hello' has no match in "enum_referenced"
 ALTER TABLE enum_origin ADD FOREIGN KEY (x) REFERENCES enum_referenced (x)
+
+# Tests for ALTER COLUMN SET DATA TYPE.
+statement ok
+SET enable_experimental_alter_column_type_general = true;
+CREATE TABLE enum_data_type (x STRING);
+INSERT INTO enum_data_type VALUES ('hello'), ('howdy');
+ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE greeting;
+INSERT INTO enum_data_type VALUES ('hi')
+
+query T rowsort
+SELECT * FROM enum_data_type
+----
+hello
+howdy
+hi
+
+statement ok
+DROP TABLE enum_data_type;
+CREATE TABLE enum_data_type (x greeting);
+INSERT INTO enum_data_type VALUES ('hello'), ('howdy')
+
+# Enum to the same enum is a noop.
+statement ok
+ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE greeting
+
+# Now, set it to string.
+statement ok
+ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE STRING
+
+query T rowsort
+SELECT * FROM enum_data_type
+----
+hello
+howdy
+
+# Test when the conversion of string -> enum should fail.
+statement ok
+DROP TABLE enum_data_type;
+CREATE TABLE enum_data_type (x STRING);
+INSERT INTO enum_data_type VALUES ('notagreeting')
+
+statement error pq: invalid input value for enum greeting: "notagreeting"
+ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE greeting
+
+statement ok
+ALTER TABLE enum_data_type
+  ALTER COLUMN x SET DATA TYPE greeting USING (CASE WHEN x = 'notagreeting' THEN 'hello' ELSE 'hi' END)
+
+query T
+SELECT * FROM enum_data_type
+----
+hello


### PR DESCRIPTION
Fixes #48728.

This PR adds tests for alter column set datatype on enum columns.

Release note: None