### PR TITLE
sql: fix ALTER COLUMN TYPE USING EXPRESSION for same type conversion

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -509,3 +509,17 @@ ALTER TABLE t26 ALTER COLUMN x TYPE BOOL USING (y > 0);
 
 # statement ok
 # ALTER TABLE t27 ALTER COLUMN x TYPE STRING USING (x::STRING)
+
+# Ensure ALTER COLUMN TYPE ... USING EXPRESSION does not perform a no-op when
+# converting to the same type.
+statement ok
+CREATE TABLE t28(x INT);
+INSERT INTO t28 VALUES (1), (2), (3);
+ALTER TABLE t28 ALTER COLUMN x TYPE INT USING (x * 5)
+
+query I
+SELECT x FROM t28 ORDER BY x
+----
+5
+10
+15

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1024,6 +1024,22 @@ SELECT * FROM enum_data_type
 hello
 howdy
 
+# Convert an enum type into another with USING.
+statement ok
+DROP TABLE enum_data_type;
+CREATE TABLE enum_data_type (x greeting);
+INSERT INTO enum_data_type VALUES ('hello'), ('hi')
+
+statement ok
+ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE dbs USING
+  (CASE WHEN x = 'hello' THEN 'cockroach' ELSE 'postgres' END)
+
+query T rowsort
+SELECT * FROM enum_data_type
+----
+cockroach
+postgres
+
 # Test when the conversion of string -> enum should fail.
 statement ok
 DROP TABLE enum_data_type;


### PR DESCRIPTION
sql: fixed a bug where alter column type using expression would sometimes not perform a backfill with a USING expression. This could be caused when the type change was happening between two trivially convertible types, or two types that can't be casted in the standard way

Left the release note as none since bug is not out in prod.

Release note: None