### PR TITLE
opt: add rule to fold JSON field access into Values operator

### DIFF
--- a/pkg/sql/opt/norm/project_funcs.go
+++ b/pkg/sql/opt/norm/project_funcs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/errors"
 )
 
@@ -98,43 +99,29 @@ func (c *CustomFuncs) MergeProjectWithValues(
 	})
 }
 
-// CanUnnestTuplesFromValues returns true if the Values operator has a single
-// column containing tuples that can be unfolded into multiple columns.
-//
+// CanUnnestTuplesFromValues returns true if the given single-column Values
+// operator has tuples that can be unfolded into multiple columns.
 // This is the case if:
-//
-// 	1. The Values operator has exactly one output column.
-//
-// 	2. The single output column is of type tuple.
-//
-// 	3. There is at least one row.
-//
-// 	4. All tuples in the single column are either TupleExpr's or ConstExpr's
+// 	1. The single output column is of type tuple.
+// 	2. All tuples in the single column are either TupleExpr's or ConstExpr's
 //     that wrap DTuples, as opposed to dynamically generated tuples.
-//
 func (c *CustomFuncs) CanUnnestTuplesFromValues(expr memo.RelExpr) bool {
 	values := expr.(*memo.ValuesExpr)
-	if !c.HasOneCol(expr) {
-		return false
-	}
 	colTypeFam := c.mem.Metadata().ColumnMeta(values.Cols[0]).Type.Family()
 	if colTypeFam != types.TupleFamily {
 		return false
 	}
-	if len(values.Rows) < 1 {
-		return false
-	}
-	for _, row := range values.Rows {
-		if !c.IsStaticTuple(row.(*memo.TupleExpr).Elems[0]) {
+	for i := range values.Rows {
+		if !c.IsStaticTuple(values.Rows[i].(*memo.TupleExpr).Elems[0]) {
 			return false
 		}
 	}
 	return true
 }
 
-// OnlyTupleColumnsAccessed ensures that the input ProjectionsExpr contains no
+// HasNoDirectTupleReferences ensures that the input ProjectionsExpr contains no
 // direct references to the tuple represented by the given ColumnID.
-func (c *CustomFuncs) OnlyTupleColumnsAccessed(
+func (c *CustomFuncs) HasNoDirectTupleReferences(
 	projections memo.ProjectionsExpr, tupleCol opt.ColumnID,
 ) bool {
 	var check func(expr opt.Expr) bool
@@ -217,8 +204,8 @@ func (c *CustomFuncs) UnnestTuplesFromValues(
 		case *memo.ConstExpr:
 			dTuple := t.Value.(*tree.DTuple)
 			tupleVals := make(memo.ScalarListExpr, len(dTuple.D))
-			for i, v := range dTuple.D {
-				val := c.f.ConstructConstVal(v, tupleType.TupleContents()[i])
+			for i := range dTuple.D {
+				val := c.f.ConstructConstVal(dTuple.D[i], tupleType.TupleContents()[i])
 				tupleVals[i] = val
 			}
 			outTuples[i] = c.f.ConstructTuple(tupleVals, tupleType)
@@ -263,6 +250,279 @@ func (c *CustomFuncs) FoldTupleColumnAccess(
 			replace(projection.Element).(opt.ScalarExpr), projection.Col)
 	}
 	return newProjections
+}
+
+// CanUnnestJSONFromValues returns true if the Values operator has a single
+// column containing JSON expressions that can be unfolded into multiple
+// columns. This is the case if:
+//  1. The projections don't directly reference the JSON itself. Only fields
+//     within the JSON object can be referenced.
+//  2. All JSON keys referenced by the projections are present in the first row.
+//  3. All JSON keys present in the first row are present in all other rows.
+// CanUnnestJSONFromValues should only be called if the Values operator has a
+// single column and at least one row.
+//
+// Note: technically we only need to check that the JSON fields referenced by
+// the projections exist in all the rows. For simplicity, we instead check that
+// (1) all references exist in the first row and (2) that all keys from the
+// first row also exist in all other rows.
+func (c *CustomFuncs) CanUnnestJSONFromValues(
+	relExpr memo.RelExpr, projections memo.ProjectionsExpr, jsonCol opt.ColumnID,
+) bool {
+	values := relExpr.(*memo.ValuesExpr)
+	colTypeFam := c.mem.Metadata().ColumnMeta(values.Cols[0]).Type.Family()
+	if colTypeFam != types.JsonFamily {
+		return false
+	}
+	// Retrieve the JSON expression from the first row.
+	constExpr, ok := values.Rows[0].(*memo.TupleExpr).Elems[0].(*memo.ConstExpr)
+	if !ok {
+		// The contents of the JSON expression can't be statically determined. (This
+		// can happen when the row contains a reference to a JSON table column).
+		return false
+	}
+	firstJSON, ok := constExpr.Value.(*tree.DJSON)
+	if !ok {
+		return false
+	}
+	if !(firstJSON.Type() == json.ObjectJSONType) {
+		// The JSON expression must be a JSON object with key-value pairs referenced
+		// by the projections.
+		return false
+	}
+
+	// Recursively traverses an expression, looking for direct references to
+	// jsonCol. Also ensures that any references to JSON fields are part of the
+	// first row's schema. For example, this query is valid:
+	//
+	//    SELECT j->'x'
+	//    FROM
+	//    (VALUES
+	//        ('{"x": "one"}'::JSON),
+	//        ('{"x": "two", "y": 2}'::JSON)
+	//    ) v(j);
+	//
+	// But these queries are not valid:
+	//
+	//    SELECT j
+	//    FROM
+	//    (VALUES
+	//        ('{"x": "one"}'::JSON),
+	//        ('{"x": "two", "y": 2}'::JSON)
+	//    ) v(j);
+	//
+	//    SELECT j->'x', j->'y'
+	//    FROM
+	//    (VALUES
+	//        ('{"x": "one"}'::JSON),
+	//        ('{"x": "two", "y": 2}'::JSON)
+	//    ) v(j);
+	//
+	var check func(expr opt.Expr) bool
+	check = func(expr opt.Expr) bool {
+		switch t := expr.(type) {
+		case *memo.FetchValExpr:
+			if v, ok := t.Json.(*memo.VariableExpr); ok {
+				if constExpr, ok := t.Index.(*memo.ConstExpr); ok {
+					if key, ok := constExpr.Value.(*tree.DString); ok {
+						if v.Col == jsonCol {
+							// Ensure that the key this projection is referencing exists in
+							// the first row.
+							exists, err := firstJSON.Exists(string(*key))
+							return exists && err == nil
+						}
+						return true
+					}
+				}
+			}
+			return false
+
+		case *memo.VariableExpr:
+			// Ensure that the JSON column itself is not referenced; only its fields
+			// can be referenced.
+			return t.Col != jsonCol
+		}
+		for i, n := 0, expr.ChildCount(); i < n; i++ {
+			if !check(expr.Child(i)) {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Traverse all ProjectionsItems.
+	for i := range projections {
+		if !check(projections[i].Element) {
+			return false
+		}
+	}
+
+	// Ensure that all Values rows are ConstExpr's that wrap DJSON datums. Also
+	// ensure that the DJSON datums have at least the keys from the first row.
+	// This check is performed after the projections are walked because there may
+	// be many Values rows.
+	for i := 1; i < len(values.Rows); i++ {
+		expr := values.Rows[i].(*memo.TupleExpr).Elems[0]
+		if !c.IsConstJSON(expr) {
+			// The contents of this JSON expression cannot be statically determined.
+			return false
+		}
+		currJSON := expr.(*memo.ConstExpr).Value.(*tree.DJSON)
+		iter, err := firstJSON.ObjectIter()
+		if err != nil {
+			return false
+		}
+		// Iterate through the keys of the first JSON object and ensure that they
+		// all exist in every other row. For example, these are a valid set of rows:
+		//
+		//    ('{"x": 1}'::JSON), ('{"x": 2, "y": 'two'}'::JSON)
+		//
+		// but these are not:
+		//
+		//    ('{"x": 2, "y": 'two'}'::JSON), ('{"x": 1}'::JSON)
+		//
+		for iter.Next() {
+			if exists, err := currJSON.Exists(iter.Key()); !exists || err != nil {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// UnnestJSONFromValues takes in a Values operator that has a single column
+// of JSON expressions and a ColList with columns corresponding to each JSON key
+// in the first row of the ValuesExpr. It returns a new Values operator with the
+// json fields expanded out into the Values rows.
+func (c *CustomFuncs) UnnestJSONFromValues(expr memo.RelExpr, newCols opt.ColList) memo.RelExpr {
+	values := expr.(*memo.ValuesExpr)
+	outTuples := make(memo.ScalarListExpr, len(values.Rows))
+	valTypes := make([]*types.T, len(newCols))
+	for i := range valTypes {
+		valTypes[i] = types.Jsonb
+	}
+	tupleType := types.MakeTuple(valTypes)
+
+	// Construct new rows with values corresponding to the keys from first row.
+	// As an example, given Values rows like the following:
+	//
+	//    ('{"x": 1, "y": 'one'}'::JSON), ('{"x": 2, "y": 'two', "z": 'zwei'}'::JSON)
+	//
+	// The output rows will be:
+	//
+	//    (1::JSON, 'one'::JSON), (2::JSON, 'two'::JSON)
+	//
+	// Any values corresponding to keys that are not present in the first row will
+	// be discarded.
+	firstJSON := values.Rows[0].(*memo.TupleExpr).Elems[0].(*memo.ConstExpr).Value.(*tree.DJSON)
+	for i := range values.Rows {
+		rowExpr := values.Rows[i].(*memo.TupleExpr).Elems[0]
+		tupleVals := make(memo.ScalarListExpr, len(newCols))
+		iter, err := firstJSON.ObjectIter()
+		if err != nil {
+			panic(errors.AssertionFailedf("failed to retrieve ObjectIter: %v", err))
+		}
+		// Iterate through the keys of the first row and use them to get the values
+		// from the current row. Add these values to the new Values rows.
+		idx := 0
+		for iter.Next() {
+			jsonVal, err := rowExpr.(*memo.ConstExpr).Value.(*tree.DJSON).FetchValKey(iter.Key())
+			if err != nil {
+				panic(errors.AssertionFailedf("FetchValKey failed: %v", err))
+			}
+			dJSON := tree.NewDJSON(jsonVal)
+			tupleVals[idx] = c.f.ConstructConstVal(dJSON, types.Jsonb)
+			idx++
+		}
+		outTuples[i] = c.f.ConstructTuple(tupleVals, tupleType)
+	}
+
+	// Construct ValuesExpr with the new rows.
+	valuesPrivate := &memo.ValuesPrivate{Cols: newCols, ID: c.mem.Metadata().NextUniqueID()}
+	return c.f.ConstructValues(outTuples, valuesPrivate)
+}
+
+// FoldJSONFieldAccess constructs a new ProjectionsExpr from the old one with
+// any FetchVal operators that refer to the original JSON column (oldColID)
+// replaced by new Variables wrapping columns from the output of the given
+// ValuesExpr. Example:
+//
+//    SELECT j->'a' AS j_a FROM ...
+// =>
+//    SELECT j_a FROM ...
+//
+func (c *CustomFuncs) FoldJSONFieldAccess(
+	projections memo.ProjectionsExpr,
+	newCols opt.ColList,
+	oldColID opt.ColumnID,
+	oldInput memo.RelExpr,
+) memo.ProjectionsExpr {
+	newProjections := make(memo.ProjectionsExpr, len(projections))
+	oldValues := oldInput.(*memo.ValuesExpr)
+
+	// Create a mapping from JSON keys to the new columns that were created for
+	// them.
+	keysToCols := make(map[string]opt.ColumnID)
+	firstJSON := oldValues.Rows[0].(*memo.TupleExpr).Elems[0].(*memo.ConstExpr).Value.(*tree.DJSON)
+	iter, err := firstJSON.ObjectIter()
+	if err != nil {
+		panic(errors.AssertionFailedf("failed to retrieve ObjectIter: %v", err))
+	}
+	idx := 0
+	for iter.Next() {
+		keysToCols[iter.Key()] = newCols[idx]
+		idx++
+	}
+
+	// Recursively traverses a ProjectionsItem element and replaces references to
+	// json fields with one of the newly constructed columns.
+	var replace ReplaceFunc
+	replace = func(nd opt.Expr) opt.Expr {
+		if fetchVal, ok := nd.(*memo.FetchValExpr); ok {
+			if variable, ok := fetchVal.Json.(*memo.VariableExpr); ok {
+				// Skip past references to columns other than the input tuple column.
+				if variable.Col == oldColID {
+					// Replace this reference to a JSON field with the column that was
+					// created to replace it.
+					key := string(*fetchVal.Index.(*memo.ConstExpr).Value.(*tree.DString))
+					return c.f.ConstructVariable(keysToCols[key])
+				}
+			}
+		}
+		return c.f.Replace(nd, replace)
+	}
+
+	// Construct and return a new ProjectionsExpr using the new ColumnIDs.
+	for i := range projections {
+		projection := &projections[i]
+		newProjections[i] = c.f.ConstructProjectionsItem(
+			replace(projection.Element).(opt.ScalarExpr), projection.Col)
+	}
+	return newProjections
+}
+
+// MakeColsForUnnestJSON creates a new column for each key in the first row of
+// the given ValuesExpr, and returns a ColList with those columns. The columns
+// will be in the same order as the corresponding keys from the first row.
+func (c *CustomFuncs) MakeColsForUnnestJSON(input memo.RelExpr, jsonCol opt.ColumnID) opt.ColList {
+	values := input.(*memo.ValuesExpr)
+	dJSON := values.Rows[0].(*memo.TupleExpr).Elems[0].(*memo.ConstExpr).Value.(*tree.DJSON)
+	mem := c.mem.Metadata()
+	jsonAlias := mem.ColumnMeta(jsonCol).Alias
+
+	// Create a new column for each JSON key found in dJSON.
+	iter, err := dJSON.ObjectIter()
+	if err != nil {
+		panic(errors.AssertionFailedf("failed to retrieve ObjectIter: %v", err))
+	}
+	newColIDs := make(opt.ColList, 0, dJSON.Len())
+	for iter.Next() {
+		newAlias := fmt.Sprintf("%s_%s", jsonAlias, iter.Key())
+		newColID := mem.AddColumn(newAlias, types.Jsonb)
+		newColIDs = append(newColIDs, newColID)
+	}
+	return newColIDs
 }
 
 // CanPushColumnRemappingIntoValues returns true if there is at least one

--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -379,7 +379,9 @@ $left
 # one-row operator's columns are never used.
 [EliminateJoinNoColsLeft, Normalize]
 (InnerJoin | InnerJoinApply
-    $left:* & (HasNoCols $left) & (HasOneRow $left)
+    $left:* &
+        (ColsAreEmpty (OutputCols $left)) &
+        (HasOneRow $left)
     $right:*
     $on:*
 )
@@ -392,7 +394,9 @@ $left
 [EliminateJoinNoColsRight, Normalize]
 (InnerJoin | InnerJoinApply
     $left:*
-    $right:* & (HasNoCols $right) & (HasOneRow $right)
+    $right:* &
+        (ColsAreEmpty (OutputCols $right)) &
+        (HasOneRow $right)
     $on:*
 )
 =>

--- a/pkg/sql/opt/norm/rules/project.opt
+++ b/pkg/sql/opt/norm/rules/project.opt
@@ -143,12 +143,12 @@ $input
 =>
 (PushColumnRemappingIntoValues $input $projections $passthrough)
 
-# FoldTupleAccessIntoValues replaces a Values with a single column that
-# references a column of tuples with a new Values that has a column for each
-# tuple index. This works as long as the surrounding Project does not reference
-# the original tuple column itself, since then it would be invalid to eliminate
-# that reference. However, references to fields within the tuple are allowed,
-# and are translated to the new unnested Values columns.
+# FoldTupleAccessIntoValues replaces a Values that has a single tuple column and
+# at least one row with a new Values that has a column for each tuple index.
+# This works as long as the surrounding Project does not reference the original
+# tuple column itself, since then it would be invalid to eliminate that
+# reference. However, references to fields within the tuple are allowed, and are
+# translated to the new unnested Values columns.
 #
 # This rule simplifies access to the Values operator in hopes of allowing other
 # rules to fire.
@@ -161,9 +161,11 @@ $input
 #
 [FoldTupleAccessIntoValues, Normalize]
 (Project
-    $input:(Values) & (CanUnnestTuplesFromValues $input)
+    $input:(Values [ * ... ]) &
+        (ColsAreLenOne (OutputCols $input)) &
+        (CanUnnestTuplesFromValues $input)
     $projections:* &
-        (OnlyTupleColumnsAccessed
+        (HasNoDirectTupleReferences
             $projections
             $col:(SingleColFromSet (OutputCols $input))
         )
@@ -173,8 +175,61 @@ $input
 (Project
     (UnnestTuplesFromValues
         $input
-        $tuplecols:(MakeColsForUnnestTuples $col)
+        $tupleCols:(MakeColsForUnnestTuples $col)
     )
-    (FoldTupleColumnAccess $projections $tuplecols $col)
+    (FoldTupleColumnAccess $projections $tupleCols $col)
+    $passthrough
+)
+
+# FoldJSONAccessIntoValues replaces a Values operator that has a single JSON
+# column and at least one row with a new Values operator that has a column for
+# each JSON key. This works as long as the surrounding Project does not
+# reference the original JSON column itself, since then it would be invalid to
+# eliminate that reference. However, references to fields within the JSON are
+# allowed, and are translated to the new unnested Values columns. The rule only
+# fires if all referenced JSON keys exist the first row, and if all JSON keys
+# from the first row also exist in all other rows.
+#
+# FoldJSONAccessIntoValues has the side affect of pruning any keys that are not
+# present in the first Values row (since they are unreferenced).
+#
+# This rule simplifies access to the Values operator in hopes of allowing other
+# rules to fire.
+#
+# Example:
+#
+#   SELECT cust->'id' AS id, cust->'name' AS name
+#   FROM (VALUES
+#      ('{"id": 1, "name": 'Drew'}'::JSON),
+#      ('{"id": 2, "name": 'Radu'}'::JSON),
+#      ('{"id": 3, "name": 'Rebecca'}'::JSON)
+#   ) v(cust)
+#   =>
+#   SELECT id, name
+#   FROM (VALUES
+#      (1::JSON, 'Drew'::JSON),
+#      (2::JSON, 'Radu'::JSON),
+#      (3::JSON, 'Rebecca'::JSON)
+#   ) v(id, name)
+#
+[FoldJSONAccessIntoValues, Normalize]
+(Project
+    $input:(Values [ * ... ]) &
+        (ColsAreLenOne (OutputCols $input))
+    $projections:* &
+        (CanUnnestJSONFromValues
+            $input
+            $projections
+            $col:(SingleColFromSet (OutputCols $input))
+        )
+    $passthrough:* & (ColsAreEmpty $passthrough)
+)
+=>
+(Project
+    (UnnestJSONFromValues
+        $input
+        $jsonCols:(MakeColsForUnnestJSON $input $col)
+    )
+    (FoldJSONFieldAccess $projections $jsonCols $col $input)
     $passthrough
 )

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -3,7 +3,7 @@ CREATE TABLE a (x INT PRIMARY KEY, y INT, f FLOAT, s STRING)
 ----
 
 exec-ddl
-CREATE TABLE b (x INT PRIMARY KEY, z INT)
+CREATE TABLE b (x INT PRIMARY KEY, z INT, j JSON)
 ----
 
 exec-ddl
@@ -85,65 +85,65 @@ norm expect=EliminateJoinUnderProjectLeft
 SELECT 1+b.x FROM b LEFT JOIN a ON b.x = a.x
 ----
 project
- ├── columns: "?column?":7!null
+ ├── columns: "?column?":8!null
  ├── immutable
  ├── scan b
  │    ├── columns: b.x:1!null
  │    └── key: (1)
  └── projections
-      └── b.x:1 + 1 [as="?column?":7, outer=(1), immutable]
+      └── b.x:1 + 1 [as="?column?":8, outer=(1), immutable]
 
 # Case with no references to the left side.
 norm expect=EliminateJoinUnderProjectLeft
 SELECT 1 FROM b LEFT JOIN a ON b.x = a.x
 ----
 project
- ├── columns: "?column?":7!null
- ├── fd: ()-->(7)
+ ├── columns: "?column?":8!null
+ ├── fd: ()-->(8)
  ├── scan b
  └── projections
-      └── 1 [as="?column?":7]
+      └── 1 [as="?column?":8]
 
 # No-op case because the cross join may duplicate left rows.
 norm expect-not=EliminateJoinUnderProjectLeft
 SELECT 1 FROM b LEFT JOIN a ON True
 ----
 project
- ├── columns: "?column?":7!null
- ├── fd: ()-->(7)
+ ├── columns: "?column?":8!null
+ ├── fd: ()-->(8)
  ├── left-join (cross)
  │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    ├── scan b
  │    ├── scan a
  │    └── filters (true)
  └── projections
-      └── 1 [as="?column?":7]
+      └── 1 [as="?column?":8]
 
 # No-op case with a projection that references the right input.
 norm expect-not=EliminateJoinUnderProjectLeft
 SELECT b.x, b.z, 1+a.x FROM b LEFT JOIN a ON b.x = a.x
 ----
 project
- ├── columns: x:1!null z:2 "?column?":7
+ ├── columns: x:1!null z:2 "?column?":8
  ├── immutable
  ├── key: (1)
- ├── fd: (1)-->(2,7)
+ ├── fd: (1)-->(2,8)
  ├── left-join (hash)
- │    ├── columns: b.x:1!null z:2 a.x:3
+ │    ├── columns: b.x:1!null z:2 a.x:4
  │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2,3)
+ │    ├── fd: (1)-->(2,4)
  │    ├── scan b
  │    │    ├── columns: b.x:1!null z:2
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2)
  │    ├── scan a
- │    │    ├── columns: a.x:3!null
- │    │    └── key: (3)
+ │    │    ├── columns: a.x:4!null
+ │    │    └── key: (4)
  │    └── filters
- │         └── b.x:1 = a.x:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+ │         └── b.x:1 = a.x:4 [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
  └── projections
-      └── a.x:3 + 1 [as="?column?":7, outer=(3), immutable]
+      └── a.x:4 + 1 [as="?column?":8, outer=(4), immutable]
 
 # No-op case because r2 is nullable, and therefore rows may not match despite
 # the fact that it is a foreign key.
@@ -220,9 +220,9 @@ norm expect=EliminateJoinUnderProjectRight
 SELECT b1.x, b1.z FROM b INNER JOIN b AS b1 ON b.x = b1.x
 ----
 scan b1
- ├── columns: x:3!null z:4
- ├── key: (3)
- └── fd: (3)-->(4)
+ ├── columns: x:4!null z:5
+ ├── key: (4)
+ └── fd: (4)-->(5)
 
 # InnerJoin case with not-null foreign key.
 norm expect=EliminateJoinUnderProjectRight
@@ -239,18 +239,18 @@ norm expect-not=EliminateJoinUnderProjectRight
 SELECT b.x, b1.x FROM b LEFT JOIN b AS b1 ON b.x = b1.x
 ----
 inner-join (hash)
- ├── columns: x:1!null x:3!null
+ ├── columns: x:1!null x:4!null
  ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
- ├── key: (3)
- ├── fd: (1)==(3), (3)==(1)
+ ├── key: (4)
+ ├── fd: (1)==(4), (4)==(1)
  ├── scan b
  │    ├── columns: b.x:1!null
  │    └── key: (1)
  ├── scan b1
- │    ├── columns: b1.x:3!null
- │    └── key: (3)
+ │    ├── columns: b1.x:4!null
+ │    └── key: (4)
  └── filters
-      └── b.x:1 = b1.x:3 [outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+      └── b.x:1 = b1.x:4 [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
 
 # --------------------------------------------------
 # EliminateProject
@@ -307,7 +307,7 @@ norm expect=MergeProjects
 SELECT y+1 AS r FROM (SELECT a.y FROM a, b WHERE a.x=b.x) a
 ----
 project
- ├── columns: r:7
+ ├── columns: r:8
  ├── immutable
  ├── inner-join (hash)
  │    ├── columns: a.x:1!null y:2 b.x:5!null
@@ -324,7 +324,7 @@ project
  │    └── filters
  │         └── a.x:1 = b.x:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
  └── projections
-      └── y:2 + 1 [as=r:7, outer=(2), immutable]
+      └── y:2 + 1 [as=r:8, outer=(2), immutable]
 
 # Outer and inner projections have synthesized columns.
 norm expect=MergeProjects
@@ -531,47 +531,47 @@ norm expect=FoldTupleAccessIntoValues
 SELECT (SELECT (tup).@1 * x FROM b) FROM (VALUES ((1,2)), ((3,4))) AS v(tup)
 ----
 project
- ├── columns: "?column?":5
+ ├── columns: "?column?":6
  ├── cardinality: [1 - ]
  ├── immutable
  ├── ensure-distinct-on
- │    ├── columns: "?column?":4 rownum:8!null
- │    ├── grouping columns: rownum:8!null
+ │    ├── columns: "?column?":5 rownum:9!null
+ │    ├── grouping columns: rownum:9!null
  │    ├── error: "more than one row returned by a subquery used as an expression"
  │    ├── cardinality: [1 - ]
  │    ├── immutable
- │    ├── key: (8)
- │    ├── fd: (8)-->(4)
+ │    ├── key: (9)
+ │    ├── fd: (9)-->(5)
  │    ├── left-join-apply
- │    │    ├── columns: "?column?":4 column1_1:6!null rownum:8!null
+ │    │    ├── columns: "?column?":5 column1_1:7!null rownum:9!null
  │    │    ├── cardinality: [2 - ]
  │    │    ├── immutable
- │    │    ├── fd: (8)-->(6)
+ │    │    ├── fd: (9)-->(7)
  │    │    ├── ordinality
- │    │    │    ├── columns: column1_1:6!null rownum:8!null
+ │    │    │    ├── columns: column1_1:7!null rownum:9!null
  │    │    │    ├── cardinality: [2 - 2]
- │    │    │    ├── key: (8)
- │    │    │    ├── fd: (8)-->(6)
+ │    │    │    ├── key: (9)
+ │    │    │    ├── fd: (9)-->(7)
  │    │    │    └── values
- │    │    │         ├── columns: column1_1:6!null
+ │    │    │         ├── columns: column1_1:7!null
  │    │    │         ├── cardinality: [2 - 2]
  │    │    │         ├── (1,)
  │    │    │         └── (3,)
  │    │    ├── project
- │    │    │    ├── columns: "?column?":4
- │    │    │    ├── outer: (6)
+ │    │    │    ├── columns: "?column?":5
+ │    │    │    ├── outer: (7)
  │    │    │    ├── immutable
  │    │    │    ├── scan b
  │    │    │    │    ├── columns: x:2!null
  │    │    │    │    └── key: (2)
  │    │    │    └── projections
- │    │    │         └── x:2 * column1_1:6 [as="?column?":4, outer=(2,6), immutable]
+ │    │    │         └── x:2 * column1_1:7 [as="?column?":5, outer=(2,7), immutable]
  │    │    └── filters (true)
  │    └── aggregations
- │         └── const-agg [as="?column?":4, outer=(4)]
- │              └── "?column?":4
+ │         └── const-agg [as="?column?":5, outer=(5)]
+ │              └── "?column?":5
  └── projections
-      └── "?column?":4 [as="?column?":5, outer=(4)]
+      └── "?column?":5 [as="?column?":6, outer=(5)]
 
 # Case where columns are unnested and then pruned away because the surrounding
 # project only references an outer column.
@@ -701,31 +701,31 @@ norm expect-not=FoldTupleAccessIntoValues
 SELECT (tup).@1, (tup).@2 FROM (VALUES ((3,4)), ((SELECT (x, z) FROM b))) AS v(tup)
 ----
 project
- ├── columns: "?column?":5 "?column?":6
+ ├── columns: "?column?":6 "?column?":7
  ├── cardinality: [2 - 2]
  ├── values
- │    ├── columns: column1:4
+ │    ├── columns: column1:5
  │    ├── cardinality: [2 - 2]
  │    ├── ((3, 4),)
  │    └── tuple
  │         └── subquery
  │              └── max1-row
- │                   ├── columns: "?column?":3
+ │                   ├── columns: "?column?":4
  │                   ├── error: "more than one row returned by a subquery used as an expression"
  │                   ├── cardinality: [0 - 1]
  │                   ├── key: ()
- │                   ├── fd: ()-->(3)
+ │                   ├── fd: ()-->(4)
  │                   └── project
- │                        ├── columns: "?column?":3
+ │                        ├── columns: "?column?":4
  │                        ├── scan b
  │                        │    ├── columns: x:1!null z:2
  │                        │    ├── key: (1)
  │                        │    └── fd: (1)-->(2)
  │                        └── projections
- │                             └── (x:1, z:2) [as="?column?":3, outer=(1,2)]
+ │                             └── (x:1, z:2) [as="?column?":4, outer=(1,2)]
  └── projections
-      ├── (column1:4).@1 [as="?column?":5, outer=(4)]
-      └── (column1:4).@2 [as="?column?":6, outer=(4)]
+      ├── (column1:5).@1 [as="?column?":6, outer=(5)]
+      └── (column1:5).@2 [as="?column?":7, outer=(5)]
 
 # No-op case because the tuple itself is referenced rather than just its fields.
 norm expect-not=FoldTupleAccessIntoValues
@@ -824,7 +824,7 @@ norm expect=PushColumnRemappingIntoValues
 WITH a AS (SELECT v FROM (VALUES (1), ((SELECT z FROM b WHERE z=1))) f(v)) SELECT v FROM a
 ----
 values
- ├── columns: v:4
+ ├── columns: v:5
  ├── cardinality: [2 - 2]
  ├── (1,)
  └── tuple
@@ -1033,3 +1033,450 @@ project
  │         └── (3,)
  └── projections
       └── x:5 [as=x:7, outer=(5)]
+
+# --------------------------------------------------
+# FoldJSONAccessIntoValues
+# --------------------------------------------------
+
+# Basic case: all rows have the same single key.
+norm expect=FoldJSONAccessIntoValues
+SELECT j->'x' AS x
+FROM
+(VALUES
+    ('{"x": "one"}'::JSON),
+    ('{"x": "two"}'::JSON),
+    ('{"x": "three"}'::JSON)
+) v(j)
+----
+values
+ ├── columns: x:2!null
+ ├── cardinality: [3 - 3]
+ ├── ('"one"',)
+ ├── ('"two"',)
+ └── ('"three"',)
+
+# Case with three fields and all rows have the same schema; order of key-value
+# pairs does not matter.
+norm expect=FoldJSONAccessIntoValues
+SELECT j->'x' AS x, j->'y' AS y, j->'z' AS z
+FROM
+(VALUES
+    ('{"y": "red", "z": 1, "x": "one"}'::JSON),
+    ('{"z": 2, "y": "yellow", "x": "two"}'::JSON),
+    ('{"x": "three", "y": "blue", "z": 3}'::JSON)
+) v(j)
+----
+values
+ ├── columns: x:2!null y:3!null z:4!null
+ ├── cardinality: [3 - 3]
+ ├── ('"one"', '"red"', '1')
+ ├── ('"two"', '"yellow"', '2')
+ └── ('"three"', '"blue"', '3')
+
+# Case where not all first row fields are referenced. The unreferenced columns
+# are later pruned away by a different rule.
+norm expect=FoldJSONAccessIntoValues
+SELECT j->'x' AS x
+FROM
+(VALUES
+    ('{"y": "red", "z": 1, "x": "one"}'::JSON),
+    ('{"z": 2, "y": "yellow", "x": "two"}'::JSON),
+    ('{"x": "three", "y": "blue", "z": 3}'::JSON)
+) v(j)
+----
+values
+ ├── columns: x:2!null
+ ├── cardinality: [3 - 3]
+ ├── ('"one"',)
+ ├── ('"two"',)
+ └── ('"three"',)
+
+# Case with various value types.
+norm expect=FoldJSONAccessIntoValues
+SELECT j->'x' AS x
+FROM
+(VALUES
+    ('{"x": 1}'::JSON),
+    ('{"x": [1,2,3]}'::JSON),
+    ('{"x": {"a": "three"}}'::JSON),
+    ('{"x": [{"b": 1}, {"b": 2}]}'::JSON),
+    ('{"x": null}'::JSON)
+) v(j)
+----
+values
+ ├── columns: x:2!null
+ ├── cardinality: [5 - 5]
+ ├── ('1',)
+ ├── ('[1, 2, 3]',)
+ ├── ('{"a": "three"}',)
+ ├── ('[{"b": 1}, {"b": 2}]',)
+ └── ('null',)
+
+# Case where fields that are not present in the first row are filtered out.
+norm expect=FoldJSONAccessIntoValues
+SELECT j->'x' AS x
+FROM
+(VALUES
+    ('{"x": "one"}'::JSON),
+    ('{"z": "2", "y": "yellow", "x": "two"}'::JSON),
+    ('{"x": "three", "y": "blue", "z": "3"}'::JSON)
+) v(j)
+----
+values
+ ├── columns: x:2!null
+ ├── cardinality: [3 - 3]
+ ├── ('"one"',)
+ ├── ('"two"',)
+ └── ('"three"',)
+
+# Case with one projection referencing an outer JSON column (j) that should not
+# be folded and the other referencing an inner column (c) that should be folded.
+norm expect=FoldJSONAccessIntoValues
+SELECT *
+FROM b
+INNER JOIN LATERAL
+(
+    SELECT j->'x' AS x, c->'x'
+    FROM
+    (VALUES
+        ('{"x": "zero"}'::JSON),
+        ('{"x": "one"}'::JSON)
+    ) v(c)
+)
+ON True
+----
+project
+ ├── columns: x:1!null z:2 j:3 x:5 "?column?":6!null
+ ├── immutable
+ ├── fd: (1)-->(2,3), (3)-->(5)
+ ├── inner-join (cross)
+ │    ├── columns: b.x:1!null z:2 j:3 "?column?":6!null
+ │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── scan b
+ │    │    ├── columns: b.x:1!null z:2 j:3
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2,3)
+ │    ├── values
+ │    │    ├── columns: "?column?":6!null
+ │    │    ├── cardinality: [2 - 2]
+ │    │    ├── ('"zero"',)
+ │    │    └── ('"one"',)
+ │    └── filters (true)
+ └── projections
+      └── j:3->'x' [as=x:5, outer=(3), immutable]
+
+# Rule fires harmlessly when none of the JSON fields are accessed; the columns
+# are later pruned away by PruneValuesCols.
+norm expect=FoldJSONAccessIntoValues
+SELECT
+    (
+        SELECT j->'x'
+        FROM
+        (VALUES
+            ('{"x": "zero"}'::JSON),
+            ('{"x": "one"}'::JSON)
+        ) v(c)
+    )
+FROM b
+----
+project
+ ├── columns: "?column?":7
+ ├── immutable
+ ├── ensure-distinct-on
+ │    ├── columns: x:1!null "?column?":5
+ │    ├── grouping columns: x:1!null
+ │    ├── error: "more than one row returned by a subquery used as an expression"
+ │    ├── immutable
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(5)
+ │    ├── project
+ │    │    ├── columns: "?column?":5 x:1!null
+ │    │    ├── immutable
+ │    │    ├── fd: (1)-->(5)
+ │    │    ├── inner-join (cross)
+ │    │    │    ├── columns: x:1!null j:3
+ │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+ │    │    │    ├── fd: (1)-->(3)
+ │    │    │    ├── scan b
+ │    │    │    │    ├── columns: x:1!null j:3
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    └── fd: (1)-->(3)
+ │    │    │    ├── values
+ │    │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    │    ├── ()
+ │    │    │    │    └── ()
+ │    │    │    └── filters (true)
+ │    │    └── projections
+ │    │         └── j:3->'x' [as="?column?":5, outer=(3), immutable]
+ │    └── aggregations
+ │         └── const-agg [as="?column?":5, outer=(5)]
+ │              └── "?column?":5
+ └── projections
+      └── "?column?":5 [as="?column?":7, outer=(5)]
+
+# No-op case because the Values column contains strings, not JSON expressions.
+norm expect-not=FoldJSONAccessIntoValues
+SELECT j::JSON->'x' AS x
+FROM
+(VALUES
+    ('{"x": "one"}'),
+    ('{"x": "two"}'),
+    ('{"x": "three"}')
+) v(j)
+----
+project
+ ├── columns: x:2
+ ├── cardinality: [3 - 3]
+ ├── immutable
+ ├── values
+ │    ├── columns: column1:1!null
+ │    ├── cardinality: [3 - 3]
+ │    ├── ('{"x": "one"}',)
+ │    ├── ('{"x": "two"}',)
+ │    └── ('{"x": "three"}',)
+ └── projections
+      └── column1:1::JSONB->'x' [as=x:2, outer=(1), immutable]
+
+# No-op case with SQL null row.
+norm expect-not=FoldJSONAccessIntoValues
+SELECT j->'x' AS x
+FROM
+(VALUES
+    ('{"x": "two"}'::JSON),
+    (NULL::JSON),
+    ('{"x": "three"}'::JSON)
+) v(j)
+----
+project
+ ├── columns: x:2
+ ├── cardinality: [3 - 3]
+ ├── immutable
+ ├── values
+ │    ├── columns: column1:1
+ │    ├── cardinality: [3 - 3]
+ │    ├── ('{"x": "two"}',)
+ │    ├── (NULL,)
+ │    └── ('{"x": "three"}',)
+ └── projections
+      └── column1:1->'x' [as=x:2, outer=(1), immutable]
+
+# No-op case with JSON null row.
+norm expect-not=FoldJSONAccessIntoValues
+SELECT j->'x' As x
+FROM
+(VALUES
+    ('null'::JSON),
+    ('{"x": "two"}'::JSON),
+    ('{"x": "three"}'::JSON)
+) v(j)
+----
+project
+ ├── columns: x:2
+ ├── cardinality: [3 - 3]
+ ├── immutable
+ ├── values
+ │    ├── columns: column1:1!null
+ │    ├── cardinality: [3 - 3]
+ │    ├── ('null',)
+ │    ├── ('{"x": "two"}',)
+ │    └── ('{"x": "three"}',)
+ └── projections
+      └── column1:1->'x' [as=x:2, outer=(1), immutable]
+
+# No-op case because the Values operator has more than one column.
+norm expect-not=FoldJSONAccessIntoValues
+SELECT j1->'x' AS x1, j2->'x' AS x2
+FROM
+(VALUES
+    ('{"x": "one"}'::JSON, '{"x": "two"}'::JSON),
+    ('{"x": "three"}'::JSON, '{"x": "four"}'::JSON)
+) v(j1, j2)
+----
+project
+ ├── columns: x1:3 x2:4
+ ├── cardinality: [2 - 2]
+ ├── immutable
+ ├── values
+ │    ├── columns: column1:1!null column2:2!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── ('{"x": "one"}', '{"x": "two"}')
+ │    └── ('{"x": "three"}', '{"x": "four"}')
+ └── projections
+      ├── column1:1->'x' [as=x1:3, outer=(1), immutable]
+      └── column2:2->'x' [as=x2:4, outer=(2), immutable]
+
+# No-op case because the JSON column is directly referenced.
+norm expect-not=FoldJSONAccessIntoValues
+SELECT j->'x' AS x, j
+FROM
+(VALUES
+    ('{"x": "one"}'::JSON),
+    ('{"x": "two"}'::JSON)
+) v(j)
+----
+project
+ ├── columns: x:2 j:1!null
+ ├── cardinality: [2 - 2]
+ ├── immutable
+ ├── fd: (1)-->(2)
+ ├── values
+ │    ├── columns: column1:1!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── ('{"x": "one"}',)
+ │    └── ('{"x": "two"}',)
+ └── projections
+      └── column1:1->'x' [as=x:2, outer=(1), immutable]
+
+# No-op case because one of the Values rows is a reference to an outer column.
+norm expect-not=FoldJSONAccessIntoValues
+SELECT j->'x' AS x
+FROM
+(VALUES
+    ('{"x": "one"}'::JSON),
+    ((SELECT j FROM b))
+) v(j)
+----
+project
+ ├── columns: x:5
+ ├── cardinality: [2 - 2]
+ ├── immutable
+ ├── values
+ │    ├── columns: column1:4
+ │    ├── cardinality: [2 - 2]
+ │    ├── ('{"x": "one"}',)
+ │    └── tuple
+ │         └── subquery
+ │              └── max1-row
+ │                   ├── columns: j:3
+ │                   ├── error: "more than one row returned by a subquery used as an expression"
+ │                   ├── cardinality: [0 - 1]
+ │                   ├── key: ()
+ │                   ├── fd: ()-->(3)
+ │                   └── scan b
+ │                        └── columns: j:3
+ └── projections
+      └── column1:4->'x' [as=x:5, outer=(4), immutable]
+
+# No-op case because the key being used to access JSON fields is not a constant
+# string.
+norm expect-not=FoldJSONAccessIntoValues
+SELECT
+    (
+        SELECT v.j->a.s
+        FROM
+        (VALUES
+           ('{"x": "one"}'::JSON),
+           ('{"x": "two"}'::JSON)
+        ) v(j)
+    )
+FROM a
+----
+project
+ ├── columns: "?column?":7
+ ├── immutable
+ ├── ensure-distinct-on
+ │    ├── columns: x:1!null "?column?":6
+ │    ├── grouping columns: x:1!null
+ │    ├── error: "more than one row returned by a subquery used as an expression"
+ │    ├── immutable
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(6)
+ │    ├── project
+ │    │    ├── columns: "?column?":6 x:1!null
+ │    │    ├── immutable
+ │    │    ├── inner-join (cross)
+ │    │    │    ├── columns: x:1!null s:4 column1:5!null
+ │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+ │    │    │    ├── fd: (1)-->(4)
+ │    │    │    ├── scan a
+ │    │    │    │    ├── columns: x:1!null s:4
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    └── fd: (1)-->(4)
+ │    │    │    ├── values
+ │    │    │    │    ├── columns: column1:5!null
+ │    │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    │    ├── ('{"x": "one"}',)
+ │    │    │    │    └── ('{"x": "two"}',)
+ │    │    │    └── filters (true)
+ │    │    └── projections
+ │    │         └── column1:5->s:4 [as="?column?":6, outer=(4,5), immutable]
+ │    └── aggregations
+ │         └── const-agg [as="?column?":6, outer=(6)]
+ │              └── "?column?":6
+ └── projections
+      └── "?column?":6 [as="?column?":7, outer=(6)]
+
+# No-op case because one of the projections attempts to access a key that is not
+# in any of the rows.
+norm expect-not=FoldJSONAccessIntoValues
+SELECT j::JSON->'x' AS x, j::JSON->'y' AS y
+FROM
+(VALUES
+    ('{"x": "one"}'),
+    ('{"x": "two"}'),
+    ('{"x": "three"}')
+) v(j)
+----
+project
+ ├── columns: x:2 y:3
+ ├── cardinality: [3 - 3]
+ ├── immutable
+ ├── values
+ │    ├── columns: column1:1!null
+ │    ├── cardinality: [3 - 3]
+ │    ├── ('{"x": "one"}',)
+ │    ├── ('{"x": "two"}',)
+ │    └── ('{"x": "three"}',)
+ └── projections
+      ├── column1:1::JSONB->'x' [as=x:2, outer=(1), immutable]
+      └── column1:1::JSONB->'y' [as=y:3, outer=(1), immutable]
+
+# No-op case because one of the projections attempts to access a key that is not
+# in the first row.
+norm expect-not=FoldJSONAccessIntoValues
+SELECT j::JSON->'x' AS x, j::JSON->'y' AS y
+FROM
+(VALUES
+    ('{"x": "one"}'),
+    ('{"x": "two", "y": "blue"}'),
+    ('{"x": "three", "y": "red"}')
+) v(j)
+----
+project
+ ├── columns: x:2 y:3
+ ├── cardinality: [3 - 3]
+ ├── immutable
+ ├── values
+ │    ├── columns: column1:1!null
+ │    ├── cardinality: [3 - 3]
+ │    ├── ('{"x": "one"}',)
+ │    ├── ('{"x": "two", "y": "blue"}',)
+ │    └── ('{"x": "three", "y": "red"}',)
+ └── projections
+      ├── column1:1::JSONB->'x' [as=x:2, outer=(1), immutable]
+      └── column1:1::JSONB->'y' [as=y:3, outer=(1), immutable]
+
+# No-op case because one of the rows does not have all the keys that are present
+# in the first row.
+norm expect-not=FoldJSONAccessIntoValues
+SELECT j::JSON->'x' AS x
+FROM
+(VALUES
+    ('{"x": "one"}'),
+    ('{"x": "two"}'),
+    ('{"y": "three"}')
+) v(j)
+----
+project
+ ├── columns: x:2
+ ├── cardinality: [3 - 3]
+ ├── immutable
+ ├── values
+ │    ├── columns: column1:1!null
+ │    ├── cardinality: [3 - 3]
+ │    ├── ('{"x": "one"}',)
+ │    ├── ('{"x": "two"}',)
+ │    └── ('{"y": "three"}',)
+ └── projections
+      └── column1:1::JSONB->'x' [as=x:2, outer=(1), immutable]

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1262,13 +1262,13 @@ upsert transactiondetails
  ├── cardinality: [0 - 0]
  ├── stable+volatile, side-effects, mutations
  ├── project
- │    ├── columns: upsert_dealerid:31 upsert_isbuy:32 upsert_transactiondate:33 upsert_cardid:34 sellprice:29 buyprice:30 "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15 column18:18 transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondate:23 cardid:24 quantity:25 transactiondetails.sellprice:26 transactiondetails.buyprice:27 transactiondetails.version:28
+ │    ├── columns: upsert_dealerid:31 upsert_isbuy:32 upsert_transactiondate:33 upsert_cardid:34 sellprice:29 buyprice:30 "?column?":11!null bool:12!null current_timestamp:13 int8:14!null int8:15!null column18:18 transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondate:23 cardid:24 quantity:25 transactiondetails.sellprice:26 transactiondetails.buyprice:27 transactiondetails.version:28
  │    ├── cardinality: [1 - 2]
  │    ├── stable+volatile, side-effects
  │    ├── lax-key: (13-15,21-25)
  │    ├── fd: ()-->(11,12), (13-15)~~>(18), (21-25)-->(26-28), (21)-->(31), (21,22)-->(32), (13,21,23)-->(33), (14,21,24)-->(34), (13-15,21-25)~~>(18,29,30)
  │    ├── left-join (lookup transactiondetails)
- │    │    ├── columns: "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15 column18:18 sellprice:19 buyprice:20 transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondate:23 cardid:24 quantity:25 transactiondetails.sellprice:26 transactiondetails.buyprice:27 transactiondetails.version:28
+ │    │    ├── columns: "?column?":11!null bool:12!null current_timestamp:13 int8:14!null int8:15!null column18:18 sellprice:19 buyprice:20 transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondate:23 cardid:24 quantity:25 transactiondetails.sellprice:26 transactiondetails.buyprice:27 transactiondetails.version:28
  │    │    ├── key columns: [11 12 13 14 15] = [21 22 23 24 25]
  │    │    ├── lookup columns are key
  │    │    ├── cardinality: [1 - 2]
@@ -1276,32 +1276,32 @@ upsert transactiondetails
  │    │    ├── lax-key: (13-15,21-25)
  │    │    ├── fd: ()-->(11,12), (13-15)~~>(18-20), (21-25)-->(26-28)
  │    │    ├── ensure-upsert-distinct-on
- │    │    │    ├── columns: "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15 column18:18 sellprice:19 buyprice:20
- │    │    │    ├── grouping columns: current_timestamp:13 int8:14 int8:15
+ │    │    │    ├── columns: "?column?":11!null bool:12!null current_timestamp:13 int8:14!null int8:15!null column18:18 sellprice:19 buyprice:20
+ │    │    │    ├── grouping columns: current_timestamp:13 int8:14!null int8:15!null
  │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
  │    │    │    ├── cardinality: [1 - 2]
  │    │    │    ├── stable+volatile, side-effects
  │    │    │    ├── lax-key: (13-15)
  │    │    │    ├── fd: ()-->(11,12), (13-15)~~>(11,12,18-20)
  │    │    │    ├── project
- │    │    │    │    ├── columns: sellprice:19 buyprice:20 column18:18 "?column?":11!null bool:12!null current_timestamp:13 int8:14 int8:15
+ │    │    │    │    ├── columns: sellprice:19 buyprice:20 column18:18 "?column?":11!null bool:12!null current_timestamp:13 int8:14!null int8:15!null
  │    │    │    │    ├── cardinality: [2 - 2]
  │    │    │    │    ├── stable+volatile, side-effects
  │    │    │    │    ├── fd: ()-->(11,12)
  │    │    │    │    ├── values
- │    │    │    │    │    ├── columns: detail:10!null
+ │    │    │    │    │    ├── columns: detail_b:54!null detail_c:55!null detail_q:56!null detail_s:57!null
  │    │    │    │    │    ├── cardinality: [2 - 2]
- │    │    │    │    │    ├── ('{"b": 2.29, "c": 49833, "q": 4, "s": 2.89}',)
- │    │    │    │    │    └── ('{"b": 17.59, "c": 29483, "q": 2, "s": 18.93}',)
+ │    │    │    │    │    ├── ('2.29', '49833', '4', '2.89')
+ │    │    │    │    │    └── ('17.59', '29483', '2', '18.93')
  │    │    │    │    └── projections
- │    │    │    │         ├── crdb_internal.round_decimal_values((detail:10->'s')::STRING::DECIMAL(10,4), 4) [as=sellprice:19, outer=(10), immutable]
- │    │    │    │         ├── crdb_internal.round_decimal_values((detail:10->'b')::STRING::DECIMAL(10,4), 4) [as=buyprice:20, outer=(10), immutable]
+ │    │    │    │         ├── crdb_internal.round_decimal_values(detail_s:57::STRING::DECIMAL(10,4), 4) [as=sellprice:19, outer=(57), immutable]
+ │    │    │    │         ├── crdb_internal.round_decimal_values(detail_b:54::STRING::DECIMAL(10,4), 4) [as=buyprice:20, outer=(54), immutable]
  │    │    │    │         ├── cluster_logical_timestamp() [as=column18:18, volatile, side-effects]
  │    │    │    │         ├── 1 [as="?column?":11]
  │    │    │    │         ├── false [as=bool:12]
  │    │    │    │         ├── current_timestamp() [as=current_timestamp:13, stable, side-effects]
- │    │    │    │         ├── (detail:10->'c')::STRING::INT8 [as=int8:14, outer=(10), immutable]
- │    │    │    │         └── (detail:10->'q')::STRING::INT8 [as=int8:15, outer=(10), immutable]
+ │    │    │    │         ├── detail_c:55::STRING::INT8 [as=int8:14, outer=(55), immutable]
+ │    │    │    │         └── detail_q:56::STRING::INT8 [as=int8:15, outer=(56), immutable]
  │    │    │    └── aggregations
  │    │    │         ├── first-agg [as=sellprice:19, outer=(19)]
  │    │    │         │    └── sellprice:19

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1271,13 +1271,13 @@ upsert transactiondetails
  ├── cardinality: [0 - 0]
  ├── stable+volatile, side-effects, mutations
  ├── project
- │    ├── columns: upsert_dealerid:38 upsert_isbuy:39 upsert_transactiondate:40 upsert_cardid:41 upsert_discount:44 sellprice:35 buyprice:36 "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17 column20:20 discount:24!null transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondate:27 cardid:28 quantity:29 transactiondetails.sellprice:30 transactiondetails.buyprice:31 transactiondetails.version:32 transactiondetails.discount:33 transactiondetails.extra:34
+ │    ├── columns: upsert_dealerid:38 upsert_isbuy:39 upsert_transactiondate:40 upsert_cardid:41 upsert_discount:44 sellprice:35 buyprice:36 "?column?":13!null bool:14!null current_timestamp:15 int8:16!null int8:17!null column20:20 discount:24!null transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondate:27 cardid:28 quantity:29 transactiondetails.sellprice:30 transactiondetails.buyprice:31 transactiondetails.version:32 transactiondetails.discount:33 transactiondetails.extra:34
  │    ├── cardinality: [1 - 2]
  │    ├── stable+volatile, side-effects
  │    ├── lax-key: (15-17,25-29)
  │    ├── fd: ()-->(13,14,24), (15-17)~~>(20), (25-29)-->(30-34), (25)-->(38), (25,26)-->(39), (15,25,27)-->(40), (16,25,28)-->(41), (15-17,25-29)~~>(20,35,36,44)
  │    ├── left-join (lookup transactiondetails)
- │    │    ├── columns: "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17 column20:20 sellprice:22 buyprice:23 discount:24!null transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondate:27 cardid:28 quantity:29 transactiondetails.sellprice:30 transactiondetails.buyprice:31 transactiondetails.version:32 transactiondetails.discount:33 transactiondetails.extra:34
+ │    │    ├── columns: "?column?":13!null bool:14!null current_timestamp:15 int8:16!null int8:17!null column20:20 sellprice:22 buyprice:23 discount:24!null transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondate:27 cardid:28 quantity:29 transactiondetails.sellprice:30 transactiondetails.buyprice:31 transactiondetails.version:32 transactiondetails.discount:33 transactiondetails.extra:34
  │    │    ├── key columns: [13 14 15 16 17] = [25 26 27 28 29]
  │    │    ├── lookup columns are key
  │    │    ├── cardinality: [1 - 2]
@@ -1285,33 +1285,33 @@ upsert transactiondetails
  │    │    ├── lax-key: (15-17,25-29)
  │    │    ├── fd: ()-->(13,14,24), (15-17)~~>(20,22,23), (25-29)-->(30-34)
  │    │    ├── ensure-upsert-distinct-on
- │    │    │    ├── columns: "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17 column20:20 sellprice:22 buyprice:23 discount:24!null
- │    │    │    ├── grouping columns: current_timestamp:15 int8:16 int8:17
+ │    │    │    ├── columns: "?column?":13!null bool:14!null current_timestamp:15 int8:16!null int8:17!null column20:20 sellprice:22 buyprice:23 discount:24!null
+ │    │    │    ├── grouping columns: current_timestamp:15 int8:16!null int8:17!null
  │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
  │    │    │    ├── cardinality: [1 - 2]
  │    │    │    ├── stable+volatile, side-effects
  │    │    │    ├── lax-key: (15-17)
  │    │    │    ├── fd: ()-->(13,14,24), (15-17)~~>(13,14,20,22-24)
  │    │    │    ├── project
- │    │    │    │    ├── columns: sellprice:22 buyprice:23 discount:24!null column20:20 "?column?":13!null bool:14!null current_timestamp:15 int8:16 int8:17
+ │    │    │    │    ├── columns: sellprice:22 buyprice:23 discount:24!null column20:20 "?column?":13!null bool:14!null current_timestamp:15 int8:16!null int8:17!null
  │    │    │    │    ├── cardinality: [2 - 2]
  │    │    │    │    ├── stable+volatile, side-effects
  │    │    │    │    ├── fd: ()-->(13,14,24)
  │    │    │    │    ├── values
- │    │    │    │    │    ├── columns: detail:12!null
+ │    │    │    │    │    ├── columns: detail_b:64!null detail_c:65!null detail_q:66!null detail_s:67!null
  │    │    │    │    │    ├── cardinality: [2 - 2]
- │    │    │    │    │    ├── ('{"b": 2.29, "c": 49833, "q": 4, "s": 2.89}',)
- │    │    │    │    │    └── ('{"b": 17.59, "c": 29483, "q": 2, "s": 18.93}',)
+ │    │    │    │    │    ├── ('2.29', '49833', '4', '2.89')
+ │    │    │    │    │    └── ('17.59', '29483', '2', '18.93')
  │    │    │    │    └── projections
- │    │    │    │         ├── crdb_internal.round_decimal_values((detail:12->'s')::STRING::DECIMAL(10,4), 4) [as=sellprice:22, outer=(12), immutable]
- │    │    │    │         ├── crdb_internal.round_decimal_values((detail:12->'b')::STRING::DECIMAL(10,4), 4) [as=buyprice:23, outer=(12), immutable]
+ │    │    │    │         ├── crdb_internal.round_decimal_values(detail_s:67::STRING::DECIMAL(10,4), 4) [as=sellprice:22, outer=(67), immutable]
+ │    │    │    │         ├── crdb_internal.round_decimal_values(detail_b:64::STRING::DECIMAL(10,4), 4) [as=buyprice:23, outer=(64), immutable]
  │    │    │    │         ├── 0.0000 [as=discount:24]
  │    │    │    │         ├── cluster_logical_timestamp() [as=column20:20, volatile, side-effects]
  │    │    │    │         ├── 1 [as="?column?":13]
  │    │    │    │         ├── false [as=bool:14]
  │    │    │    │         ├── current_timestamp() [as=current_timestamp:15, stable, side-effects]
- │    │    │    │         ├── (detail:12->'c')::STRING::INT8 [as=int8:16, outer=(12), immutable]
- │    │    │    │         └── (detail:12->'q')::STRING::INT8 [as=int8:17, outer=(12), immutable]
+ │    │    │    │         ├── detail_c:65::STRING::INT8 [as=int8:16, outer=(65), immutable]
+ │    │    │    │         └── detail_q:66::STRING::INT8 [as=int8:17, outer=(66), immutable]
  │    │    │    └── aggregations
  │    │    │         ├── first-agg [as=sellprice:22, outer=(22)]
  │    │    │         │    └── sellprice:22


### PR DESCRIPTION
Previously, the optimizer didn't fold JSON field access over an input
Values operator.

This patch adds a rule that constructs a new Values operator with columns
corresponding to each referenced field in the JSON expression. It replaces
the surrounding Project operator with a new one that references the new
columns and takes the new Values as input. Example:
```
SELECT cust->'id' AS id, cust->'name' AS name
FROM (VALUES
   ('{"id": 1, "name": 'Drew'}'::JSON),
   ('{"id": 2, "name": 'Radu'}'::JSON),
   ('{"id": 3, "name": 'Rebecca'}'::JSON)
) v(cust)
=>
SELECT id, name
FROM (VALUES
   (1::JSON, 'Drew'::JSON),
   (2::JSON, 'Radu'::JSON),
   (3::JSON, 'Rebecca'::JSON)
) v(id, name)
```
Release note: None