### PR TITLE
opt: refactor and test the JoinMultiplicity library

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -957,7 +957,7 @@ inner-join (hash)
  │    ├── cost: 1100.02
  │    ├── prune: (1,2)
  │    ├── interesting orderings: (+1)
- │    └── unfiltered-cols: (1,2)
+ │    └── unfiltered-cols: (1-3)
  ├── scan t
  │    ├── columns: k:4 v:5
  │    ├── stats: [rows=1000, distinct(4)=1000, null(4)=0]

--- a/pkg/sql/opt/memo/multiplicity_builder_test.go
+++ b/pkg/sql/opt/memo/multiplicity_builder_test.go
@@ -1,0 +1,398 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package memo
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
+)
+
+func TestGetJoinMultiplicity(t *testing.T) {
+	ob := makeOpBuilder(t)
+
+	const createTableStatements = `
+	CREATE TABLE xy (
+		x INT PRIMARY KEY,
+		y INT
+	);
+	
+	CREATE TABLE uv (
+		u INT PRIMARY KEY,
+		v INT
+	);
+	
+	CREATE TABLE fk_tab (
+		r1 INT NOT NULL REFERENCES xy(x),
+		r2 INT REFERENCES xy(x),
+		r3 INT NOT NULL REFERENCES xy(x)
+	);
+	
+	CREATE TABLE abc (
+		a INT,
+		b INT,
+		c INT,
+		PRIMARY KEY (a, b, c)
+	);
+	
+	CREATE TABLE not_null_multi_col_fk_tab (
+		r1 INT NOT NULL,
+		r2 INT NOT NULL,
+		r3 INT NOT NULL,
+		FOREIGN KEY (r1, r2, r3) REFERENCES abc(a, b, c)
+	);
+	
+	CREATE TABLE one_null_multi_col_fk_tab (
+		r1 INT NOT NULL,
+		r2 INT,
+		r3 INT NOT NULL,
+		FOREIGN KEY (r1, r2, r3) REFERENCES abc(a, b, c)
+	);
+	`
+	ob.createTables(createTableStatements)
+
+	xyScan, xyCols := ob.xyScan()
+	xyScan2, xyCols2 := ob.xyScan()
+	uvScan, uvCols := ob.uvScan()
+	fkScan, fkCols := ob.fkScan()
+	abcScan, abcCols := ob.abcScan()
+	notNullMultiColFKScan, notNullMultiColFKCols := ob.notNullMultiColFKScan()
+	oneNullMultiColFKScan, oneNullMultiColFKCols := ob.oneNullMultiColFKScan()
+
+	testCases := []struct {
+		joinOp   opt.Operator
+		left     RelExpr
+		right    RelExpr
+		on       FiltersExpr
+		expected string
+	}{
+		{ // 0
+			// SELECT * FROM fk_tab INNER JOIN xy ON True;
+			joinOp:   opt.InnerJoinOp,
+			left:     fkScan,
+			right:    xyScan,
+			on:       TrueFilter,
+			expected: "left-rows(one-or-more), right-rows(zero-or-more)",
+		},
+		{ // 1
+			// SELECT * FROM xy LEFT JOIN fk_tab ON True;
+			joinOp:   opt.LeftJoinOp,
+			left:     xyScan,
+			right:    fkScan,
+			on:       TrueFilter,
+			expected: "left-rows(one-or-more), right-rows(one-or-more)",
+		},
+		{ // 2
+			// SELECT * FROM xy LEFT JOIN uv ON True;
+			joinOp:   opt.LeftJoinOp,
+			left:     xyScan,
+			right:    uvScan,
+			on:       ob.makeFilters(ob.makeEquality(xyCols[0], uvCols[0])),
+			expected: "left-rows(exactly-one), right-rows(zero-or-one)",
+		},
+		{ // 3
+			// SELECT * FROM uv FULL JOIN xy ON True;
+			joinOp:   opt.FullJoinOp,
+			left:     uvScan,
+			right:    xyScan,
+			on:       TrueFilter,
+			expected: "left-rows(one-or-more), right-rows(one-or-more)",
+		},
+		{ // 4
+			// SELECT * FROM fk_tab INNER JOIN xy ON r1 = x;
+			joinOp:   opt.InnerJoinOp,
+			left:     fkScan,
+			right:    xyScan,
+			on:       ob.makeFilters(ob.makeEquality(fkCols[0], xyCols[0])),
+			expected: "left-rows(exactly-one), right-rows(zero-or-more)",
+		},
+		{ // 5
+			// SELECT * FROM fk_tab INNER JOIN xy ON r2 = x;
+			joinOp:   opt.InnerJoinOp,
+			left:     fkScan,
+			right:    xyScan,
+			on:       ob.makeFilters(ob.makeEquality(fkCols[1], xyCols[0])),
+			expected: "left-rows(zero-or-one), right-rows(zero-or-more)",
+		},
+		{ // 6
+			// SELECT * FROM fk_tab INNER JOIN xy ON r1 = x AND r3 = x;
+			joinOp: opt.InnerJoinOp,
+			left:   fkScan,
+			right:  xyScan,
+			on: ob.makeFilters(
+				ob.makeEquality(fkCols[0], xyCols[0]),
+				ob.makeEquality(fkCols[2], xyCols[0]),
+			),
+			expected: "left-rows(zero-or-one), right-rows(zero-or-more)",
+		},
+		{ // 7
+			// SELECT * FROM xy INNER JOIN xy AS xy2 ON True;
+			joinOp:   opt.InnerJoinOp,
+			left:     xyScan,
+			right:    xyScan2,
+			on:       TrueFilter,
+			expected: "",
+		},
+		{ // 8
+			// SELECT * FROM xy INNER JOIN xy AS xy2 ON xy.x = xy2.x;
+			joinOp:   opt.InnerJoinOp,
+			left:     xyScan,
+			right:    xyScan2,
+			on:       ob.makeFilters(ob.makeEquality(xyCols[0], xyCols2[0])),
+			expected: "left-rows(exactly-one), right-rows(exactly-one)",
+		},
+		{ // 9
+			// SELECT * FROM xy LEFT JOIN uv ON x = u;
+			joinOp:   opt.LeftJoinOp,
+			left:     xyScan,
+			right:    uvScan,
+			on:       ob.makeFilters(ob.makeEquality(xyCols[0], uvCols[0])),
+			expected: "left-rows(exactly-one), right-rows(zero-or-one)",
+		},
+		{ // 10
+			// SELECT *
+			// FROM not_null_multi_col_fk_tab
+			// INNER JOIN abc
+			// ON (r1, r2, r3) = (a, b, c);
+			joinOp: opt.InnerJoinOp,
+			left:   notNullMultiColFKScan,
+			right:  abcScan,
+			on: ob.makeFilters(
+				ob.makeEquality(notNullMultiColFKCols[0], abcCols[0]),
+				ob.makeEquality(notNullMultiColFKCols[1], abcCols[1]),
+				ob.makeEquality(notNullMultiColFKCols[2], abcCols[2]),
+			),
+			expected: "left-rows(exactly-one), right-rows(zero-or-more)",
+		},
+		{ // 11
+			// SELECT *
+			// FROM one_null_multi_col_fk_tab
+			// INNER JOIN abc
+			// ON (r1, r2, r3) = (a, b, c);
+			joinOp: opt.InnerJoinOp,
+			left:   oneNullMultiColFKScan,
+			right:  abcScan,
+			on: ob.makeFilters(
+				ob.makeEquality(oneNullMultiColFKCols[0], abcCols[0]),
+				ob.makeEquality(oneNullMultiColFKCols[1], abcCols[1]),
+				ob.makeEquality(oneNullMultiColFKCols[2], abcCols[2]),
+			),
+			expected: "left-rows(zero-or-one), right-rows(zero-or-more)",
+		},
+		{ // 12
+			// SELECT * FROM not_null_multi_col_fk_tab INNER JOIN abc ON r1 = a;
+			joinOp:   opt.InnerJoinOp,
+			left:     notNullMultiColFKScan,
+			right:    abcScan,
+			on:       ob.makeFilters(ob.makeEquality(notNullMultiColFKCols[0], abcCols[0])),
+			expected: "left-rows(one-or-more), right-rows(zero-or-more)",
+		},
+		{ // 13
+			// SELECT * FROM one_null_multi_col_fk_tab INNER JOIN abc ON r1 = a;
+			joinOp:   opt.InnerJoinOp,
+			left:     oneNullMultiColFKScan,
+			right:    abcScan,
+			on:       ob.makeFilters(ob.makeEquality(oneNullMultiColFKCols[0], abcCols[0])),
+			expected: "",
+		},
+		{ // 14
+			// SELECT * FROM not_null_multi_col_fk_tab INNER JOIN abc ON r2 = a;
+			joinOp:   opt.InnerJoinOp,
+			left:     notNullMultiColFKScan,
+			right:    abcScan,
+			on:       ob.makeFilters(ob.makeEquality(notNullMultiColFKCols[1], abcCols[0])),
+			expected: "",
+		},
+		{ // 15
+			// SELECT *
+			// FROM fk_tab
+			// INNER JOIN (SELECT * FROM xy INNER JOIN xy AS xy2 ON xy.x = xy2.x)
+			// ON True;
+			joinOp: opt.InnerJoinOp,
+			left:   fkScan,
+			right: ob.makeInnerJoin(
+				xyScan,
+				xyScan2,
+				ob.makeFilters(ob.makeEquality(xyCols[0], xyCols2[0])),
+			),
+			on:       TrueFilter,
+			expected: "left-rows(one-or-more), right-rows(zero-or-more)",
+		},
+		{ // 16
+			// SELECT *
+			// FROM fk_tab
+			// INNER JOIN (SELECT * FROM xy LEFT JOIN uv ON x = u)
+			// ON r1 = x;
+			joinOp: opt.InnerJoinOp,
+			left:   fkScan,
+			right: ob.makeLeftJoin(
+				xyScan,
+				uvScan,
+				ob.makeFilters(ob.makeEquality(xyCols[0], uvCols[0])),
+			),
+			on:       ob.makeFilters(ob.makeEquality(fkCols[0], xyCols[0])),
+			expected: "left-rows(exactly-one), right-rows(zero-or-more)",
+		},
+		{ // 17
+			// SELECT *
+			// FROM fk_tab
+			// INNER JOIN (SELECT * FROM xy INNER JOIN uv ON x = u)
+			// ON r1 = x;
+			joinOp: opt.InnerJoinOp,
+			left:   fkScan,
+			right: ob.makeInnerJoin(
+				xyScan,
+				uvScan,
+				ob.makeFilters(ob.makeEquality(xyCols[0], uvCols[0])),
+			),
+			on:       ob.makeFilters(ob.makeEquality(fkCols[0], xyCols[0])),
+			expected: "left-rows(zero-or-one), right-rows(zero-or-more)",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Test case %d", i), func(t *testing.T) {
+			join := ob.makeJoin(tc.joinOp, tc.left, tc.right, tc.on)
+			joinWithMult, _ := join.(joinWithMultiplicity)
+			multiplicity := joinWithMult.getMultiplicity()
+			if multiplicity.String() != tc.expected {
+				t.Fatalf("\nexpected: %s\nactual:   %s", tc.expected, multiplicity.String())
+			}
+		})
+	}
+}
+
+type testOpBuilder struct {
+	t   *testing.T
+	ctx *tree.EvalContext
+	mem *Memo
+	cat *testcat.Catalog
+}
+
+func makeOpBuilder(t *testing.T) testOpBuilder {
+	ctx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	var mem Memo
+	mem.Init(&ctx)
+	ob := testOpBuilder{
+		t:   t,
+		ctx: &ctx,
+		mem: &mem,
+		cat: testcat.New(),
+	}
+	return ob
+}
+
+func (ob *testOpBuilder) createTable(createTableStmt string) {
+	if _, err := ob.cat.ExecuteDDL(
+		createTableStmt,
+	); err != nil {
+		ob.t.Fatal(err)
+	}
+}
+
+func (ob *testOpBuilder) createTables(stmts string) {
+	last := 0
+	for {
+		pos, ok := parser.SplitFirstStatement(stmts[last:])
+		if !ok {
+			break
+		}
+		ob.createTable(stmts[last : last+pos])
+		last += pos
+	}
+}
+
+func (ob *testOpBuilder) makeScan(tableName tree.Name) (scan RelExpr, vars []*VariableExpr) {
+	tn := tree.NewUnqualifiedTableName(tableName)
+	tab := ob.cat.Table(tn)
+	tabID := ob.mem.Metadata().AddTable(tab, tn)
+	var cols opt.ColSet
+	for i := 0; i < tab.ColumnCount(); i++ {
+		col := tabID.ColumnID(i)
+		cols.Add(col)
+		newVar := ob.mem.MemoizeVariable(col)
+		vars = append(vars, newVar)
+	}
+	return ob.mem.MemoizeScan(&ScanPrivate{Table: tabID, Cols: cols}), vars
+}
+
+func (ob *testOpBuilder) xyScan() (scan RelExpr, vars []*VariableExpr) {
+	return ob.makeScan("xy")
+}
+
+func (ob *testOpBuilder) uvScan() (scan RelExpr, vars []*VariableExpr) {
+	return ob.makeScan("uv")
+}
+
+func (ob *testOpBuilder) fkScan() (scan RelExpr, vars []*VariableExpr) {
+	return ob.makeScan("fk_tab")
+}
+
+func (ob *testOpBuilder) abcScan() (scan RelExpr, vars []*VariableExpr) {
+	return ob.makeScan("abc")
+}
+
+func (ob *testOpBuilder) notNullMultiColFKScan() (scan RelExpr, vars []*VariableExpr) {
+	return ob.makeScan("not_null_multi_col_fk_tab")
+}
+
+func (ob *testOpBuilder) oneNullMultiColFKScan() (scan RelExpr, vars []*VariableExpr) {
+	return ob.makeScan("one_null_multi_col_fk_tab")
+}
+
+func (ob *testOpBuilder) makeInnerJoin(left, right RelExpr, on FiltersExpr) RelExpr {
+	return ob.mem.MemoizeInnerJoin(left, right, on, EmptyJoinPrivate)
+}
+
+func (ob *testOpBuilder) makeLeftJoin(left, right RelExpr, on FiltersExpr) RelExpr {
+	return ob.mem.MemoizeLeftJoin(left, right, on, EmptyJoinPrivate)
+}
+
+func (ob *testOpBuilder) makeFullJoin(left, right RelExpr, on FiltersExpr) RelExpr {
+	return ob.mem.MemoizeFullJoin(left, right, on, EmptyJoinPrivate)
+}
+
+func (ob *testOpBuilder) makeJoin(
+	joinOp opt.Operator, left, right RelExpr, on FiltersExpr,
+) RelExpr {
+	switch joinOp {
+	case opt.InnerJoinOp:
+		return ob.makeInnerJoin(left, right, on)
+
+	case opt.LeftJoinOp:
+		return ob.makeLeftJoin(left, right, on)
+
+	case opt.FullJoinOp:
+		return ob.makeFullJoin(left, right, on)
+
+	default:
+		panic(errors.AssertionFailedf("invalid operator type: %v", joinOp.String()))
+	}
+}
+
+func (ob *testOpBuilder) makeEquality(left, right *VariableExpr) opt.ScalarExpr {
+	return ob.mem.MemoizeEq(left, right)
+}
+
+func (ob *testOpBuilder) makeFilters(conditions ...opt.ScalarExpr) (filters FiltersExpr) {
+	for i := range conditions {
+		filtersItem := FiltersItem{Condition: conditions[i]}
+		filtersItem.PopulateProps(ob.mem)
+		filters = append(filters, filtersItem)
+	}
+	return filters
+}

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -162,13 +162,13 @@ project
       │    │    │    ├── scan uv
       │    │    │    │    ├── columns: v:6(int!null)
       │    │    │    │    ├── prune: (6)
-      │    │    │    │    └── unfiltered-cols: (6)
+      │    │    │    │    └── unfiltered-cols: (5-7)
       │    │    │    ├── scan mn
       │    │    │    │    ├── columns: n:9(int)
       │    │    │    │    ├── lax-key: (9)
       │    │    │    │    ├── prune: (9)
       │    │    │    │    ├── interesting orderings: (+9)
-      │    │    │    │    └── unfiltered-cols: (9)
+      │    │    │    │    └── unfiltered-cols: (8,9)
       │    │    │    └── filters
       │    │    │         └── eq [type=bool, outer=(6,9), constraints=(/6: (/NULL - ]; /9: (/NULL - ]), fd=(6)==(9), (9)==(6)]
       │    │    │              ├── variable: n:9 [type=int]
@@ -226,13 +226,13 @@ project
       │    │    │    ├── scan uv
       │    │    │    │    ├── columns: v:6(int!null)
       │    │    │    │    ├── prune: (6)
-      │    │    │    │    └── unfiltered-cols: (6)
+      │    │    │    │    └── unfiltered-cols: (5-7)
       │    │    │    ├── scan mn
       │    │    │    │    ├── columns: m:8(int!null)
       │    │    │    │    ├── key: (8)
       │    │    │    │    ├── prune: (8)
       │    │    │    │    ├── interesting orderings: (+8)
-      │    │    │    │    └── unfiltered-cols: (8)
+      │    │    │    │    └── unfiltered-cols: (8,9)
       │    │    │    └── filters (true)
       │    │    ├── scan xysd
       │    │    │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
@@ -331,7 +331,7 @@ project
       │    │    ├── scan uv
       │    │    │    ├── columns: u:5(int)
       │    │    │    ├── prune: (5)
-      │    │    │    └── unfiltered-cols: (5)
+      │    │    │    └── unfiltered-cols: (5-7)
       │    │    └── filters
       │    │         └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
       │    │              ├── variable: u:5 [type=int]
@@ -431,7 +431,7 @@ project
       │    └── scan uv
       │         ├── columns: u:5(int)
       │         ├── prune: (5)
-      │         └── unfiltered-cols: (5)
+      │         └── unfiltered-cols: (5-7)
       └── filters (true)
 
 # Semi-join-apply.
@@ -491,13 +491,13 @@ semi-join-apply
  │    ├── scan uv
  │    │    ├── columns: v:6(int!null)
  │    │    ├── prune: (6)
- │    │    └── unfiltered-cols: (6)
+ │    │    └── unfiltered-cols: (5-7)
  │    ├── scan mn
  │    │    ├── columns: m:8(int!null)
  │    │    ├── key: (8)
  │    │    ├── prune: (8)
  │    │    ├── interesting orderings: (+8)
- │    │    └── unfiltered-cols: (8)
+ │    │    └── unfiltered-cols: (8,9)
  │    └── filters
  │         ├── eq [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
  │         │    ├── variable: x:1 [type=int]
@@ -527,7 +527,7 @@ anti-join (hash)
  ├── scan uv
  │    ├── columns: u:5(int)
  │    ├── prune: (5)
- │    └── unfiltered-cols: (5)
+ │    └── unfiltered-cols: (5-7)
  └── filters
       └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
            ├── variable: x:1 [type=int]
@@ -769,7 +769,7 @@ anti-join (hash)
  ├── scan uv
  │    ├── columns: u:2(int)
  │    ├── prune: (2)
- │    └── unfiltered-cols: (2)
+ │    └── unfiltered-cols: (2-4)
  └── filters
       └── eq [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
            ├── variable: u:2 [type=int]
@@ -1661,7 +1661,7 @@ inner-join (hash)
  ├── scan uv
  │    ├── columns: u:5(int) v:6(int!null)
  │    ├── prune: (5,6)
- │    └── unfiltered-cols: (5,6)
+ │    └── unfiltered-cols: (5-7)
  └── filters
       └── eq [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
            ├── variable: x:1 [type=int]
@@ -1944,7 +1944,7 @@ INNER JOIN (SELECT * FROM xysd INNER JOIN xysd AS a ON xysd.x = a.x) f(x) ON r1 
 ----
 inner-join (hash)
  ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int) x:5(int!null) y:6(int) s:7(string) d:8(decimal!null) x:9(int!null) y:10(int) s:11(string) d:12(decimal!null)
- ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
  ├── key: (1)
  ├── fd: (1)-->(2-4), (5)-->(6-8), (7,8)~~>(5,6), (9)-->(10-12), (11,12)~~>(9,10), (5)==(3,9), (9)==(3,5), (3)==(5,9)
  ├── prune: (1,2,4,6-8,10-12)
@@ -1986,6 +1986,52 @@ inner-join (hash)
       └── eq [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ]), fd=(3)==(5), (5)==(3)]
            ├── variable: r1:3 [type=int]
            └── variable: xysd.x:5 [type=int]
+
+norm
+SELECT * FROM fk
+INNER JOIN (SELECT xysd.x, a.x AS t FROM xysd INNER JOIN xysd AS a ON xysd.x = a.x) ON r1 = t
+----
+inner-join (hash)
+ ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int) x:5(int!null) t:9(int!null)
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (5)==(3,9), (9)==(3,5), (3)==(5,9)
+ ├── prune: (1,2,4)
+ ├── interesting orderings: (+1) (+3,+1) (+4,+1) (+5) (+9)
+ ├── scan fk
+ │    ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── prune: (1-4)
+ │    ├── interesting orderings: (+1) (+3,+1) (+4,+1)
+ │    └── unfiltered-cols: (1-4)
+ ├── inner-join (hash)
+ │    ├── columns: xysd.x:5(int!null) a.x:9(int!null)
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
+ │    ├── key: (9)
+ │    ├── fd: (5)==(9), (9)==(5)
+ │    ├── interesting orderings: (+5) (+9)
+ │    ├── unfiltered-cols: (5-12)
+ │    ├── scan xysd
+ │    │    ├── columns: xysd.x:5(int!null)
+ │    │    ├── key: (5)
+ │    │    ├── prune: (5)
+ │    │    ├── interesting orderings: (+5)
+ │    │    └── unfiltered-cols: (5-8)
+ │    ├── scan a
+ │    │    ├── columns: a.x:9(int!null)
+ │    │    ├── key: (9)
+ │    │    ├── prune: (9)
+ │    │    ├── interesting orderings: (+9)
+ │    │    └── unfiltered-cols: (9-12)
+ │    └── filters
+ │         └── eq [type=bool, outer=(5,9), constraints=(/5: (/NULL - ]; /9: (/NULL - ]), fd=(5)==(9), (9)==(5)]
+ │              ├── variable: xysd.x:5 [type=int]
+ │              └── variable: a.x:9 [type=int]
+ └── filters
+      └── eq [type=bool, outer=(3,9), constraints=(/3: (/NULL - ]; /9: (/NULL - ]), fd=(3)==(9), (9)==(3)]
+           ├── variable: r1:3 [type=int]
+           └── variable: a.x:9 [type=int]
 
 # Case with an equality with a synthesized column.
 norm
@@ -2180,7 +2226,7 @@ inner-join (hash)
  │    ├── columns: r1:1(int!null) r2:2(int) r3:3(int!null)
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+1,+2,+3)
- │    └── unfiltered-cols: (1-3)
+ │    └── unfiltered-cols: (1-4)
  ├── scan abc
  │    ├── columns: a:5(int!null) b:6(int!null) c:7(int!null)
  │    ├── key: (5-7)
@@ -2238,6 +2284,40 @@ inner-join (hash)
       └── eq [type=bool, outer=(3,7), constraints=(/3: (/NULL - ]; /7: (/NULL - ]), fd=(3)==(7), (7)==(3)]
            ├── variable: r3:3 [type=int]
            └── variable: c:7 [type=int]
+
+# Case with a not-null multi-column foreign key and an equality on only one of
+# the foreign key columns.
+norm
+SELECT *
+FROM (SELECT r2 FROM ref WHERE r2 IS NOT NULL)
+INNER JOIN abc
+ON r2 = b
+----
+inner-join (hash)
+ ├── columns: r2:2(int!null) a:5(int!null) b:6(int!null) c:7(int!null)
+ ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+ ├── fd: (2)==(6), (6)==(2)
+ ├── prune: (5,7)
+ ├── interesting orderings: (+5,+6,+7)
+ ├── select
+ │    ├── columns: r2:2(int!null)
+ │    ├── scan ref
+ │    │    ├── columns: r2:2(int)
+ │    │    └── prune: (2)
+ │    └── filters
+ │         └── is-not [type=bool, outer=(2), constraints=(/2: (/NULL - ]; tight)]
+ │              ├── variable: r2:2 [type=int]
+ │              └── null [type=unknown]
+ ├── scan abc
+ │    ├── columns: a:5(int!null) b:6(int!null) c:7(int!null)
+ │    ├── key: (5-7)
+ │    ├── prune: (5-7)
+ │    ├── interesting orderings: (+5,+6,+7)
+ │    └── unfiltered-cols: (5-7)
+ └── filters
+      └── eq [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+           ├── variable: r2:2 [type=int]
+           └── variable: b:6 [type=int]
 
 exec-ddl
 CREATE TABLE trade_type (tt_id INT PRIMARY KEY)
@@ -2354,7 +2434,7 @@ limit
  │    │    ├── columns: t_st_id:1(int!null) t_tt_id:2(int!null) t_s_symb:3(int!null)
  │    │    ├── prune: (1-3)
  │    │    ├── interesting orderings: (+1) (+2) (+3)
- │    │    └── unfiltered-cols: (1-3)
+ │    │    └── unfiltered-cols: (1-4)
  │    └── filters
  │         ├── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
  │         │    ├── variable: st_id:5 [type=int]
@@ -2366,3 +2446,45 @@ limit
  │              ├── variable: s_symb:7 [type=int]
  │              └── variable: t_s_symb:3 [type=int]
  └── const: 50 [type=int]
+
+# Regression test for #50059.
+exec-ddl
+CREATE TABLE parent (a INT NOT NULL UNIQUE, b INT NOT NULL UNIQUE)
+----
+
+exec-ddl
+CREATE TABLE child (
+  r_a INT NOT NULL REFERENCES parent(a),
+  r_b INT NOT NULL REFERENCES parent(b)
+)
+----
+
+# LeftJoin shouldn't be simplified.
+norm
+SELECT * FROM child LEFT JOIN parent ON r_a = a AND r_b = b
+----
+left-join (hash)
+ ├── columns: r_a:1(int!null) r_b:2(int!null) a:4(int) b:5(int)
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ ├── fd: (4)-->(5), (5)-->(4)
+ ├── reject-nulls: (4,5)
+ ├── interesting orderings: (+1) (+2) (+4) (+5)
+ ├── scan child
+ │    ├── columns: r_a:1(int!null) r_b:2(int!null)
+ │    ├── prune: (1,2)
+ │    ├── interesting orderings: (+1) (+2)
+ │    └── unfiltered-cols: (1-3)
+ ├── scan parent
+ │    ├── columns: a:4(int!null) b:5(int!null)
+ │    ├── key: (5)
+ │    ├── fd: (4)-->(5), (5)-->(4)
+ │    ├── prune: (4,5)
+ │    ├── interesting orderings: (+4) (+5)
+ │    └── unfiltered-cols: (4-6)
+ └── filters
+      ├── eq [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+      │    ├── variable: r_a:1 [type=int]
+      │    └── variable: a:4 [type=int]
+      └── eq [type=bool, outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ]), fd=(2)==(5), (5)==(2)]
+           ├── variable: r_b:2 [type=int]
+           └── variable: b:5 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/lookup-join
+++ b/pkg/sql/opt/memo/testdata/logprops/lookup-join
@@ -37,7 +37,7 @@ inner-join (lookup abcd)
  │    ├── scan small
  │    │    ├── columns: m:1(int) n:2(int)
  │    │    ├── prune: (1,2)
- │    │    └── unfiltered-cols: (1,2)
+ │    │    └── unfiltered-cols: (1-3)
  │    └── filters (true)
  └── filters (true)
 
@@ -87,7 +87,7 @@ inner-join (lookup abcd)
  │    ├── scan small
  │    │    ├── columns: m:1(int) n:2(int)
  │    │    ├── prune: (1,2)
- │    │    └── unfiltered-cols: (1,2)
+ │    │    └── unfiltered-cols: (1-3)
  │    └── filters
  │         └── gt [type=bool, outer=(5), constraints=(/5: [/3 - ]; tight)]
  │              ├── variable: b:5 [type=int]
@@ -111,7 +111,7 @@ inner-join (lookup abcd)
  │    ├── scan small
  │    │    ├── columns: m:1(int) n:2(int)
  │    │    ├── prune: (1,2)
- │    │    └── unfiltered-cols: (1,2)
+ │    │    └── unfiltered-cols: (1-3)
  │    └── filters (true)
  └── filters
       └── gt [type=bool, outer=(6), constraints=(/6: [/3 - ]; tight)]
@@ -134,7 +134,7 @@ inner-join (lookup abcd)
  │    ├── scan small
  │    │    ├── columns: m:1(int) n:2(int)
  │    │    ├── prune: (1,2)
- │    │    └── unfiltered-cols: (1,2)
+ │    │    └── unfiltered-cols: (1-3)
  │    └── filters (true)
  └── filters
       └── gt [type=bool, outer=(6), constraints=(/6: [/3 - ]; tight)]

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -320,7 +320,7 @@ project
            │         │    │    │         │    │    │         │    │    ├── fd: (5)-->(6,8), (6)-->(9)
            │         │    │    │         │    │    │         │    │    ├── prune: (5,6,8,9)
            │         │    │    │         │    │    │         │    │    ├── interesting orderings: (+5) (+6)
-           │         │    │    │         │    │    │         │    │    ├── unfiltered-cols: (5,6)
+           │         │    │    │         │    │    │         │    │    ├── unfiltered-cols: (5-7)
            │         │    │    │         │    │    │         │    │    ├── project
            │         │    │    │         │    │    │         │    │    │    ├── columns: column8:8(int) x:5(int!null) y:6(int)
            │         │    │    │         │    │    │         │    │    │    ├── volatile, side-effects
@@ -328,14 +328,14 @@ project
            │         │    │    │         │    │    │         │    │    │    ├── fd: (5)-->(6,8)
            │         │    │    │         │    │    │         │    │    │    ├── prune: (5,6,8)
            │         │    │    │         │    │    │         │    │    │    ├── interesting orderings: (+5) (+6)
-           │         │    │    │         │    │    │         │    │    │    ├── unfiltered-cols: (5,6)
+           │         │    │    │         │    │    │         │    │    │    ├── unfiltered-cols: (5-7)
            │         │    │    │         │    │    │         │    │    │    ├── project
            │         │    │    │         │    │    │         │    │    │    │    ├── columns: x:5(int!null) y:6(int)
            │         │    │    │         │    │    │         │    │    │    │    ├── key: (5)
            │         │    │    │         │    │    │         │    │    │    │    ├── fd: (5)-->(6)
            │         │    │    │         │    │    │         │    │    │    │    ├── prune: (5,6)
            │         │    │    │         │    │    │         │    │    │    │    ├── interesting orderings: (+5) (+6)
-           │         │    │    │         │    │    │         │    │    │    │    ├── unfiltered-cols: (5,6)
+           │         │    │    │         │    │    │         │    │    │    │    ├── unfiltered-cols: (5-7)
            │         │    │    │         │    │    │         │    │    │    │    └── scan xyz
            │         │    │    │         │    │    │         │    │    │    │         ├── columns: x:5(int!null) y:6(int) z:7(int)
            │         │    │    │         │    │    │         │    │    │    │         ├── key: (5)

--- a/pkg/sql/opt/memo/testdata/logprops/with
+++ b/pkg/sql/opt/memo/testdata/logprops/with
@@ -194,7 +194,9 @@ project
  ├── prune: (7)
  ├── inner-join (cross)
  │    ├── scan t40930
+ │    │    └── unfiltered-cols: (4,5)
  │    ├── scan tab_10102
+ │    │    └── unfiltered-cols: (1,2)
  │    └── filters (true)
  └── projections
       └── null [as="?column?":7, type=unknown]

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -280,30 +280,15 @@ group-by
       └── max [as=max:7, outer=(2)]
            └── y:2
 
-# Currently a no-op case even though we could hypothetically remove the join,
-# since the presence of a not-null foreign key in fks implies that either both
-# tables will have a cardinality of at least one, or both will have a
-# cardinality of zero.
-norm expect-not=EliminateJoinUnderGroupByLeft
+# Cross join case where neither the foreign key column nor its referenced column
+# are output columns.
+norm expect=EliminateJoinUnderGroupByLeft
 SELECT DISTINCT ON (k) k, v FROM fks INNER JOIN xy ON True
 ----
-distinct-on
+scan fks
  ├── columns: k:1!null v:2
- ├── grouping columns: k:1!null
  ├── key: (1)
- ├── fd: (1)-->(2)
- ├── inner-join (cross)
- │    ├── columns: k:1!null v:2
- │    ├── fd: (1)-->(2)
- │    ├── scan fks
- │    │    ├── columns: k:1!null v:2
- │    │    ├── key: (1)
- │    │    └── fd: (1)-->(2)
- │    ├── scan xy
- │    └── filters (true)
- └── aggregations
-      └── first-agg [as=v:2, outer=(2)]
-           └── v:2
+ └── fd: (1)-->(2)
 
 # No-op case because the InnerJoin will return no rows if fks is empty.
 norm expect-not=EliminateJoinUnderGroupByLeft
@@ -338,7 +323,7 @@ distinct-on
  ├── fd: (1)-->(2,3)
  ├── left-join (cross)
  │    ├── columns: x:1!null y:2 k:3
- │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+ │    ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  │    ├── key: (1,3)
  │    ├── fd: (1)-->(2)
  │    ├── scan xy
@@ -367,6 +352,7 @@ group-by
  ├── fd: (1)-->(7)
  ├── inner-join (cross)
  │    ├── columns: k:1!null r1:3!null
+ │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    ├── fd: (1)-->(3)
  │    ├── scan fks
  │    │    ├── columns: k:1!null r1:3!null
@@ -423,7 +409,7 @@ group-by
  │    ├── ordering: +1,+3
  │    └── left-join (cross)
  │         ├── columns: x:1!null y:2 k:3
- │         ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+ │         ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
  │         ├── key: (1,3)
  │         ├── fd: (1)-->(2)
  │         ├── scan xy

--- a/pkg/sql/opt/optgen/exprgen/testdata/join
+++ b/pkg/sql/opt/optgen/exprgen/testdata/join
@@ -27,13 +27,13 @@ inner-join (hash)
  │    ├── cost: 1070.02
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+1,+2)
- │    └── unfiltered-cols: (1-3)
+ │    └── unfiltered-cols: (1-4)
  ├── scan t.public.def
  │    ├── columns: t.public.def.d:5(int) t.public.def.e:6(int) t.public.def.f:7(int)
  │    ├── stats: [rows=1000, distinct(5)=100, null(5)=10]
  │    ├── cost: 1070.02
  │    ├── prune: (5-7)
- │    └── unfiltered-cols: (5-7)
+ │    └── unfiltered-cols: (5-8)
  └── filters
       └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
            ├── variable: t.public.abc.a:1 [type=int]

--- a/pkg/sql/opt/props/logical.go
+++ b/pkg/sql/opt/props/logical.go
@@ -334,11 +334,13 @@ type Relational struct {
 		// been set.
 		InterestingOrderings opt.OrderingSet
 
-		// UnfilteredCols is the set of output columns that have values for every
-		// row in their owner table. Rows may be duplicated, but no rows can be
-		// missing. For example, an unconstrained, unlimited Scan operator can
-		// add all of its output columns to this property, but a Select operator
-		// cannot add any columns, as it may have filtered rows.
+		// UnfilteredCols is the set of all columns for which rows from their base
+		// table are guaranteed not to have been filtered. Rows may be duplicated,
+		// but no rows can be missing. Even columns which are not output columns are
+		// included as long as table rows are guaranteed not filtered. For example,
+		// an unconstrained, unlimited Scan operator can add all columns from its
+		// table to this property, but a Select operator cannot add any columns, as
+		// it may have filtered rows.
 		//
 		// UnfilteredCols is lazily populated by GetJoinMultiplicityFromInputs. It
 		// is only valid once the Rule.Available.UnfilteredCols bit has been set.

--- a/pkg/sql/opt/xform/testdata/ruleprops/orderings
+++ b/pkg/sql/opt/xform/testdata/ruleprops/orderings
@@ -275,13 +275,13 @@ inner-join (hash)
  │    ├── fd: (3)~~>(1,2)
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+1,+2) (+3)
- │    └── unfiltered-cols: (1-3)
+ │    └── unfiltered-cols: (1-4)
  ├── scan xyz
  │    ├── columns: x:5 y:6 z:7
  │    ├── lax-key: (5-7)
  │    ├── fd: (5,6)~~>(7)
  │    ├── prune: (5-7)
  │    ├── interesting orderings: (+7) (+5,+6)
- │    └── unfiltered-cols: (5-7)
+ │    └── unfiltered-cols: (5-8)
  └── filters
       └── a:1 = x:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -2739,7 +2739,7 @@ semi-join (lookup def)
  │    ├── cost: 107.02
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+1,+2) (+2,+3)
- │    └── unfiltered-cols: (1-3)
+ │    └── unfiltered-cols: (1-4)
  └── filters (true)
 
 # TODO(rytaft): See stats/join tests. Since we don't collect the stats properly
@@ -2762,7 +2762,7 @@ semi-join (lookup def)
  │    ├── cost: 107.02
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+1,+2) (+2,+3)
- │    └── unfiltered-cols: (1-3)
+ │    └── unfiltered-cols: (1-4)
  └── filters (true)
 
 exec-ddl


### PR DESCRIPTION
Previously, the logic in the JoinMultiplicity library was complicated
and untested. Multiple bugs have been both found and introduced
during refactoring of the original JoinFiltersMatchAllLeftRows logic.

This patch refactors the code to make it easier to understand and
introduces unit testing for the library.
This patch also makes the following changes to the behavior of
multiplicity_builder:
1. Fixed an issue that caused filtersMatchAllLeftRows to return false
   positives.
2. Foreign key columns only invalidate a foreign key if they were
   nullable in the base table. Since we derive the foreign key
   from a left not-null column in the first place, we know that
   columns from this table haven't been null-extended, so a not-null
   column will stay not-null. This is useful when foreign key
   columns are not in the output set.
3. All columns from a table (including non-output columns) are
   added to the UnfilteredCols field. This allows foreign key
   relations to be validated even when the foreign key columns are
   not in the output set.

Fixes #50059

Release note: None