### PR TITLE
opt: add rule to split a constrained scan under a limit into a union of scans

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -1195,6 +1195,40 @@ SELECT * FROM (SELECT x, max(y) FROM group_ord GROUP BY x) JOIN (SELECT z, min(y
 5  NULL  5  4
 3  4     3  2
 
+# Test max and min when agg column is the second column in an index.
+statement ok
+CREATE TABLE index_tab (
+  region STRING,
+  data INT NOT NULL,
+  INDEX (region, data)
+)
+
+statement ok
+INSERT INTO index_tab
+(VALUES
+  ('US_WEST', 3),
+  ('US_EAST', 23),
+  ('US_EAST', -14),
+  ('ASIA', 3294),
+  ('ASIA', -3),
+  ('US_WEST', 31),
+  ('EUROPE', 123),
+  ('US_EAST', -3000)
+)
+
+query I
+SELECT max(data) FROM index_tab WHERE region = 'US_WEST' OR region = 'US_EAST'
+----
+31
+
+query I
+SELECT min(data) FROM index_tab WHERE region = 'US_WEST' OR region = 'US_EAST'
+----
+-3000
+
+statement ok
+DROP TABLE index_tab
+
 # Regression test for #23798 until #10495 is fixed.
 statement error function reserved for internal use
 SELECT final_variance(1.2, 1.2, 123) FROM kv

--- a/pkg/sql/opt/constraint/columns.go
+++ b/pkg/sql/opt/constraint/columns.go
@@ -111,6 +111,19 @@ func (c *Columns) IsStrictSuffixOf(other *Columns) bool {
 	return true
 }
 
+// RemapColumns returns a new Columns object with all ColumnIDs remapped to
+// ones that come from the 'to' table. The old ColumnIDs must come from the
+// 'from' table.
+func (c *Columns) RemapColumns(from, to opt.TableID) Columns {
+	var newColumns Columns
+	newColumns.firstCol = c.firstCol.RemapColumn(from, to)
+	newColumns.otherCols = make([]opt.OrderingColumn, len(c.otherCols))
+	for i := range c.otherCols {
+		newColumns.otherCols[i] = c.otherCols[i].RemapColumn(from, to)
+	}
+	return newColumns
+}
+
 // ColSet returns the columns as a ColSet.
 func (c *Columns) ColSet() opt.ColSet {
 	var r opt.ColSet

--- a/pkg/sql/opt/constraint/columns_test.go
+++ b/pkg/sql/opt/constraint/columns_test.go
@@ -1,0 +1,52 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package constraint
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func TestColumns_RemapColumns(t *testing.T) {
+	var md opt.Metadata
+	catalog := testcat.New()
+	_, err := catalog.ExecuteDDL("CREATE TABLE tab (a INT PRIMARY KEY, b INT, c INT, d INT);")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tn := tree.NewUnqualifiedTableName("tab")
+	tab := catalog.Table(tn)
+
+	from := md.AddTable(tab, &tree.TableName{})
+	to := md.AddTable(tab, &tree.TableName{})
+
+	var originalColumns Columns
+	originalColumns.Init([]opt.OrderingColumn{
+		opt.MakeOrderingColumn(from.ColumnID(0), false /* descending */),
+		opt.MakeOrderingColumn(from.ColumnID(2), true /* descending */),
+		opt.MakeOrderingColumn(from.ColumnID(3), false /* descending */),
+	})
+
+	remappedColumns := originalColumns.RemapColumns(from, to)
+
+	expected := "/1/-3/4"
+	if originalColumns.String() != expected {
+		t.Errorf("\noriginal Columns were changed: %s", originalColumns.String())
+	}
+
+	expected = "/5/-7/8"
+	if remappedColumns.String() != expected {
+		t.Errorf("\nexpected: %s\nactual: %s\n", expected, remappedColumns.String())
+	}
+}

--- a/pkg/sql/opt/constraint/span.go
+++ b/pkg/sql/opt/constraint/span.go
@@ -313,6 +313,152 @@ func (sp *Span) CutFront(numCols int) {
 	sp.end = sp.end.CutFront(numCols)
 }
 
+// KeyCount returns the number of distinct keys contained in this span. Returns
+// zero and false if the operation is not possible. Requirements:
+//   1. The boundaries must be inclusive.
+//   2. The span must have a start and end key.
+//   3. Keys must be of the same length.
+//   4. Keys must have equivalent datums for all but the last column.
+//   5. The last columns are of the same type and either:
+//      a. are countable, or
+//      b. have the same value (in which case the distinct count is 1).
+//
+// Example:
+//
+//    [/'ASIA'/1 - /'ASIA'/2].KeyCount(keyCtx) => 2, true
+//
+func (sp *Span) KeyCount(keyCtx *KeyContext) (int64, bool) {
+	if sp.startBoundary == ExcludeBoundary || sp.endBoundary == ExcludeBoundary {
+		// Bounds must be inclusive.
+		return 0, false
+	}
+
+	startKey := sp.start
+	endKey := sp.end
+	if startKey.IsEmpty() || endKey.IsEmpty() {
+		// The span must have both start and end keys.
+		return 0, false
+	}
+
+	// Keys must be same length.
+	n := startKey.Length()
+	if n != endKey.Length() {
+		return 0, false
+	}
+
+	// All the datums up to the last one must be equal.
+	for i := 0; i < n-1; i++ {
+		if startKey.Value(i).ResolvedType() != endKey.Value(i).ResolvedType() {
+			// The datums must be of the same type.
+			return 0, false
+		}
+		if keyCtx.Compare(i, startKey.Value(i), endKey.Value(i)) != 0 {
+			// The datums must be equal.
+			return 0, false
+		}
+	}
+
+	thisVal := startKey.Value(startKey.Length() - 1)
+	otherVal := endKey.Value(endKey.Length() - 1)
+
+	if thisVal.ResolvedType() != otherVal.ResolvedType() {
+		// The last datums must be of the same type.
+		return 0, false
+	}
+	if keyCtx.Compare(n-1, thisVal, otherVal) == 0 {
+		// If the last datums are equal, the distinct count is 1.
+		return 1, true
+	}
+
+	// If the last columns are countable, return the distinct count between them.
+	var start, end int64
+
+	switch t := thisVal.(type) {
+	case *tree.DInt:
+		otherDInt, otherOk := tree.AsDInt(otherVal)
+		if otherOk {
+			start = int64(*t)
+			end = int64(otherDInt)
+		}
+
+	case *tree.DOid:
+		otherDOid, otherOk := tree.AsDOid(otherVal)
+		if otherOk {
+			start = int64((*t).DInt)
+			end = int64(otherDOid.DInt)
+		}
+
+	case *tree.DDate:
+		otherDDate, otherOk := otherVal.(*tree.DDate)
+		if otherOk {
+			if !t.IsFinite() || !otherDDate.IsFinite() {
+				// One of the DDates isn't finite, so we can't extract a distinct count.
+				return 0, false
+			}
+			start = int64((*t).PGEpochDays())
+			end = int64(otherDDate.PGEpochDays())
+		}
+
+	default:
+		// Uncountable type.
+		return 0, false
+	}
+
+	if keyCtx.Columns.Get(startKey.Length() - 1).Descending() {
+		// Normalize delta according to the key ordering.
+		start, end = end, start
+	}
+
+	if start > end {
+		// Incorrect ordering.
+		return 0, false
+	}
+
+	delta := end - start
+	if delta < 0 {
+		// Overflow or underflow.
+		return 0, false
+	}
+	return delta + 1, true
+}
+
+// Split returns a Spans object, with each span containing one key from the
+// original span. Returns nil and false if unsuccessful. The operation is
+// unsuccessful if the number of distinct keys in the span cannot be obtained or
+// the number of keys exceeds the limit. The boundaries are assumed to be
+// inclusive.
+//
+// Example:
+//
+//    [/'ASIA'/1 - /'ASIA'/2].Split(keyCtx, 10)
+//    =>
+//    ([/'ASIA'/1 - /'ASIA'/1], [/'ASIA'/2 - /'ASIA'/2]), true
+//
+func (sp *Span) Split(keyCtx *KeyContext, limit int64) (spans *Spans, ok bool) {
+	keyCount, ok := sp.KeyCount(keyCtx)
+	if !ok || keyCount > limit {
+		// The key count could not be determined, or the key count exceeds the
+		// limit.
+		return nil, false
+	}
+	spans = &Spans{}
+	spans.Alloc(int(keyCount))
+	currKey := sp.StartKey()
+	for i, ok := 0, true; i < int(keyCount); i++ {
+		if !ok {
+			return nil, false
+		}
+		spans.Append(&Span{
+			start:         currKey,
+			end:           currKey,
+			startBoundary: IncludeBoundary,
+			endBoundary:   IncludeBoundary,
+		})
+		currKey, ok = currKey.Next(keyCtx)
+	}
+	return spans, true
+}
+
 func (sp *Span) startExt() KeyExtension {
 	// Trivial cast of start boundary value:
 	//   IncludeBoundary (false) = ExtendLow (false)

--- a/pkg/sql/opt/constraint/span_test.go
+++ b/pkg/sql/opt/constraint/span_test.go
@@ -15,10 +15,12 @@ package constraint
 import (
 	"fmt"
 	"math"
+	"strconv"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
 func TestSpanSet(t *testing.T) {
@@ -660,6 +662,218 @@ func TestSpanPreferInclusive(t *testing.T) {
 			sp.PreferInclusive(keyCtx)
 			if sp.String() != tc.expected {
 				t.Errorf("expected: %s, actual: %s", tc.expected, sp.String())
+			}
+		})
+	}
+}
+
+func TestSpan_KeyCount(t *testing.T) {
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	kcAscAsc := testKeyContext(1, 2)
+	kcDescDesc := testKeyContext(-1, -2)
+
+	testCases := []struct {
+		keyCtx   *KeyContext
+		span     Span
+		expected string
+	}{
+		{ // 0
+			// Single key span with DString datum type.
+			keyCtx:   kcAscAsc,
+			span:     ParseSpan(&evalCtx, "[/US_WEST - /US_WEST]"),
+			expected: "1",
+		},
+		{ // 1
+			// Multiple key span with DInt datum type.
+			keyCtx:   kcAscAsc,
+			span:     ParseSpan(&evalCtx, "[/-5 - /5]"),
+			expected: "11",
+		},
+		{ // 2
+			// Multiple key span with DOid datum type.
+			keyCtx:   kcAscAsc,
+			span:     ParseSpan(&evalCtx, "[/-5 - /5]", types.OidFamily),
+			expected: "11",
+		},
+		{ // 3
+			// Multiple key span with DDate datum type.
+			keyCtx:   kcAscAsc,
+			span:     ParseSpan(&evalCtx, "[/2000-1-1 - /2000-1-2]", types.DateFamily),
+			expected: "2",
+		},
+		{ // 4
+			// Single-key span with multiple-column key.
+			keyCtx:   kcAscAsc,
+			span:     ParseSpan(&evalCtx, "[/US_WEST/item - /US_WEST/item]"),
+			expected: "1",
+		},
+		{ // 5
+			// Fails because the span is multiple-key and the type is not enumerable.
+			keyCtx:   kcAscAsc,
+			span:     ParseSpan(&evalCtx, "[/US_WEST/item - /US_WEST/object]"),
+			expected: "FAIL",
+		},
+		{ // 6
+			// Descending multiple-key span.
+			keyCtx:   kcDescDesc,
+			span:     ParseSpan(&evalCtx, "[/5 - /-5]"),
+			expected: "11",
+		},
+		{ // 7
+			// Descending multiple-key span with multiple-column keys.
+			keyCtx:   kcDescDesc,
+			span:     ParseSpan(&evalCtx, "[/US_WEST/5 - /US_WEST/-5]"),
+			expected: "11",
+		},
+		{ // 8
+			// Fails because the keys can only differ in the last column.
+			keyCtx:   kcAscAsc,
+			span:     ParseSpan(&evalCtx, "[/US_WEST/1 - /US_EAST/1]"),
+			expected: "FAIL",
+		},
+		{ // 9
+			// Fails because the keys must have the same length.
+			keyCtx:   kcAscAsc,
+			span:     ParseSpan(&evalCtx, "[/1/1 - /1]"),
+			expected: "FAIL",
+		},
+		{ // 10
+			// Fails because the keys must have the same length.
+			keyCtx:   kcAscAsc,
+			span:     ParseSpan(&evalCtx, "[/1 - /1/1]"),
+			expected: "FAIL",
+		},
+		{ // 11
+			// Fails because the keys must have the same length.
+			keyCtx:   kcAscAsc,
+			span:     ParseSpan(&evalCtx, "[/1 - ]"),
+			expected: "FAIL",
+		},
+		{ // 12
+			// Fails because of overflow.
+			keyCtx: kcAscAsc,
+			span: Span{
+				start:         MakeKey(tree.NewDInt(math.MinInt64)),
+				end:           MakeKey(tree.NewDInt(math.MaxInt64)),
+				startBoundary: false,
+				endBoundary:   false,
+			},
+			expected: "FAIL",
+		},
+		{ // 13
+			// Fails because of underflow.
+			keyCtx: kcDescDesc,
+			span: Span{
+				start:         MakeKey(tree.NewDInt(math.MaxInt64)),
+				end:           MakeKey(tree.NewDInt(math.MinInt64)),
+				startBoundary: false,
+				endBoundary:   false,
+			},
+			expected: "FAIL",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			toStr := func(cnt int64, ok bool) string {
+				if !ok {
+					return "FAIL"
+				}
+				return strconv.FormatInt(cnt, 10 /* base */)
+			}
+
+			if res := toStr(tc.span.KeyCount(tc.keyCtx)); res != tc.expected {
+				t.Errorf("expected: %s, actual: %s", tc.expected, res)
+			}
+		})
+	}
+}
+
+func TestSpan_SplitSpan(t *testing.T) {
+	const keyCountLimit = 10
+
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	kcAscAsc := testKeyContext(1, 2)
+	kcDescDesc := testKeyContext(-1, -2)
+
+	testCases := []struct {
+		keyCtx   *KeyContext
+		span     Span
+		expected string
+	}{
+		{ // 0
+			// Single-key span with multiple-column key.
+			keyCtx:   kcAscAsc,
+			span:     ParseSpan(&evalCtx, "[/US_WEST/item - /US_WEST/item]"),
+			expected: "[/'US_WEST'/'item' - /'US_WEST'/'item']",
+		},
+		{ // 1
+			// Fails because the datum type is not enumerable.
+			keyCtx:   kcAscAsc,
+			span:     ParseSpan(&evalCtx, "[/US_WEST/item - /US_WEST/object]"),
+			expected: "FAIL",
+		},
+		{ // 2
+			// Fails because only the last datums can differ, and only if they are
+			// enumerable.
+			keyCtx:   kcAscAsc,
+			span:     ParseSpan(&evalCtx, "[/US_EAST/item - /US_WEST/item]"),
+			expected: "FAIL",
+		},
+		{ // 3
+			// Ascending multiple-key span.
+			keyCtx:   kcAscAsc,
+			span:     ParseSpan(&evalCtx, "[/-1 - /1]"),
+			expected: "[/-1 - /-1] [/0 - /0] [/1 - /1]",
+		},
+		{ // 4
+			// Descending multiple-key span.
+			keyCtx:   kcDescDesc,
+			span:     ParseSpan(&evalCtx, "[/1 - /-1]"),
+			expected: "[/1 - /1] [/0 - /0] [/-1 - /-1]",
+		},
+		{ // 5
+			// Ascending multiple-key span with multiple-column keys.
+			keyCtx: kcAscAsc,
+			span:   ParseSpan(&evalCtx, "[/US_WEST/-1 - /US_WEST/1]"),
+			expected: "[/'US_WEST'/-1 - /'US_WEST'/-1] [/'US_WEST'/0 - /'US_WEST'/0] " +
+				"[/'US_WEST'/1 - /'US_WEST'/1]",
+		},
+		{ // 6
+			// Fails because the keys are different lengths.
+			keyCtx:   kcAscAsc,
+			span:     ParseSpan(&evalCtx, "[ - /'US_WEST']"),
+			expected: "FAIL",
+		},
+		{ // 7
+			// Single span with 10 keys (equal to maxKeyCount).
+			keyCtx: kcAscAsc,
+			span: ParseSpan(
+				&evalCtx,
+				"[/0 - /9]",
+			),
+			expected: "[/0 - /0] [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5] [/6 - /6] [/7 - /7] " +
+				"[/8 - /8] [/9 - /9]",
+		},
+		{ // 8
+			// Fails because the number of keys exceeds maxKeyCount.
+			keyCtx:   kcAscAsc,
+			span:     ParseSpan(&evalCtx, "[/-1 - /10]"),
+			expected: "FAIL",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			toStr := func(spans *Spans, ok bool) string {
+				if !ok {
+					return "FAIL"
+				}
+				return spans.String()
+			}
+
+			if res := toStr(tc.span.Split(tc.keyCtx, keyCountLimit)); res != tc.expected {
+				t.Errorf("expected: %s, actual: %s", tc.expected, res)
 			}
 		})
 	}

--- a/pkg/sql/opt/constraint/spans.go
+++ b/pkg/sql/opt/constraint/spans.go
@@ -149,6 +149,78 @@ func (s *Spans) SortAndMerge(keyCtx *KeyContext) {
 	s.Truncate(n + 1)
 }
 
+// KeyCount returns the number of distinct keys contained in the spans. See
+// span.KeyCount for conditions under which this is possible. Example:
+//
+//    KeyCount('[/'ASIA' - /'ASIA'] [/'EUROPE'/1 - /'EUROPE'/4]') == 5
+//
+func (s *Spans) KeyCount(keyCtx *KeyContext) (int64, bool) {
+	keyCount := int64(0)
+	for i, cnt := 0, s.Count(); i < cnt; i++ {
+		cnt, ok := s.Get(i).KeyCount(keyCtx)
+		if !ok {
+			return 0, false
+		}
+		keyCount += cnt
+		if keyCount < 0 {
+			// Overflow.
+			return 0, false
+		}
+	}
+	return keyCount, true
+}
+
+// ExtractSingleKeySpans returns a new Spans struct containing a span for each
+// key in the given spans. Returns nil and false if one of the following is
+// true:
+//   1. The number of new spans exceeds the given limit value.
+//   2. The spans don't all have the same key length (length as in
+//      length(/3/'two'/1) == 3).
+//   3. span.Split is unsuccessful for any of the spans.
+//
+// Example:
+//
+//    ExtractSingleKeySpans('[/'ASIA'/0 - /'ASIA'/0] [/'US'/1 - /'US'/4]')
+//    =>
+//    '[/'ASIA'/0 - /'ASIA'/0] [/'US'/1 - /'US'/1] [/'US'/2 - /'US'/2]
+//     [/'US'/3 - /'US'/3] [/'US'/4 - /'US'/4]'
+//
+func (s *Spans) ExtractSingleKeySpans(keyCtx *KeyContext, limit int64) (*Spans, bool) {
+	// Ensure that the number of keys in the spans does not exceed the limit.
+	keyCount, ok := s.KeyCount(keyCtx)
+	if !ok || keyCount > limit {
+		return nil, false
+	}
+
+	// Ensure that the key lengths are consistent between spans.
+	keyLength := -1
+	for i, spanCnt := 0, s.Count(); i < spanCnt; i++ {
+		span := s.Get(i)
+		if keyLength == -1 {
+			// Initialize keyLength.
+			keyLength = span.StartKey().Length()
+		}
+		if span.StartKey().Length() != keyLength {
+			// The spans don't all have the same key length.
+			return nil, false
+		}
+	}
+
+	// Construct the new single-key spans.
+	newSpans := Spans{}
+	for i, spanCnt := 0, s.Count(); i < spanCnt; i++ {
+		splitSpans, ok := s.Get(i).Split(keyCtx, limit-int64(newSpans.Count()))
+		if !ok {
+			// The span could not be split into single key spans.
+			return nil, false
+		}
+		for i, cnt := 0, splitSpans.Count(); i < cnt; i++ {
+			newSpans.Append(splitSpans.Get(i))
+		}
+	}
+	return &newSpans, true
+}
+
 type spanSorter struct {
 	keyCtx KeyContext
 	spans  *Spans

--- a/pkg/sql/opt/constraint/spans_test.go
+++ b/pkg/sql/opt/constraint/spans_test.go
@@ -13,8 +13,11 @@
 package constraint
 
 import (
+	"fmt"
+	"strconv"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
@@ -105,5 +108,187 @@ func TestSpansSortAndMerge(t *testing.T) {
 		if actual := spans.String(); actual != expected {
 			t.Fatalf("%s : expected  %s  got  %s", origStr, expected, actual)
 		}
+	}
+}
+
+func TestSpans_KeyCount(t *testing.T) {
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	kcAscAsc := testKeyContext(1, 2)
+	kcDescDesc := testKeyContext(-1, -2)
+
+	testCases := []struct {
+		s        Spans
+		keyCtx   *KeyContext
+		expected string
+	}{
+		{ // 0
+			// Single span with single key.
+			s:        parseSpans(&evalCtx, "[/1/0 - /1/0]"),
+			keyCtx:   kcAscAsc,
+			expected: "1",
+		},
+		{ // 1
+			// Two spans each with single key.
+			s:        parseSpans(&evalCtx, "[/1/0 - /1/0] [/1/2 - /1/2]"),
+			keyCtx:   kcAscAsc,
+			expected: "2",
+		},
+		{ // 2
+			// One span with 4 keys.
+			s:        parseSpans(&evalCtx, "[/1/1 - /1/4]"),
+			keyCtx:   kcAscAsc,
+			expected: "4",
+		},
+		{ // 3
+			// Descending span with 3 keys.
+			s:        parseSpans(&evalCtx, "[/1/1 - /1/-1]"),
+			keyCtx:   kcDescDesc,
+			expected: "3",
+		},
+		{ // 4
+			// Fails due to descending span with ascending columns.
+			s:        parseSpans(&evalCtx, "[/1/1 - /1/-1]"),
+			keyCtx:   kcAscAsc,
+			expected: "FAIL",
+		},
+		{ // 5
+			// One descending span with 3 keys and one single-key span. Spans are out
+			// of order.
+			s:        parseSpans(&evalCtx, "[/1/1 - /1/-1] [/1/2 - /1/2]"),
+			keyCtx:   kcDescDesc,
+			expected: "4",
+		},
+		{ // 6
+			// Fails because the keys are not all the same length within a span.
+			s:        parseSpans(&evalCtx, "[/2 - /2/1] [/3 - /3]"),
+			keyCtx:   kcAscAsc,
+			expected: "FAIL",
+		},
+		{ // 7
+			// Case where keys have different lengths between spans. (This is allowed
+			// by KeyCount, but not by ExtractSingleKeySpans).
+			s:        parseSpans(&evalCtx, "[/2 - /2] [/1/0 - /1/0]"),
+			keyCtx:   kcDescDesc,
+			expected: "2",
+		},
+		{ // 8
+			// Case with 3 spans with 4 keys each.
+			s:        parseSpans(&evalCtx, "[/1/1 - /1/4] [/2/1 - /2/4] [/3/1 - /3/4]"),
+			keyCtx:   kcAscAsc,
+			expected: "12",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			toStr := func(keyCount int64, ok bool) string {
+				if !ok {
+					return "FAIL"
+				}
+				return strconv.FormatInt(keyCount, 10 /* base */)
+			}
+
+			if res := toStr(tc.s.KeyCount(tc.keyCtx)); res != tc.expected {
+				t.Errorf("expected: %s, actual: %s", tc.expected, res)
+			}
+		})
+	}
+}
+
+func TestSpans_ExtractSingleKeySpans(t *testing.T) {
+	const maxKeyCount = 10
+
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	kcAscAsc := testKeyContext(1, 2)
+	kcDescDesc := testKeyContext(-1, -2)
+
+	testCases := []struct {
+		s        Spans
+		keyCtx   *KeyContext
+		expected string
+	}{
+		{ // 0
+			// Single span with single key; no-op.
+			s:        parseSpans(&evalCtx, "[/1/0 - /1/0]"),
+			keyCtx:   kcAscAsc,
+			expected: "[/1/0 - /1/0]",
+		},
+		{ // 1
+			// Two spans each with single key; no-op.
+			s:        parseSpans(&evalCtx, "[/1/0 - /1/0] [/1/2 - /1/2]"),
+			keyCtx:   kcAscAsc,
+			expected: "[/1/0 - /1/0] [/1/2 - /1/2]",
+		},
+		{ // 2
+			// One span with four keys.
+			s:        parseSpans(&evalCtx, "[/1/1 - /1/4]"),
+			keyCtx:   kcAscAsc,
+			expected: "[/1/1 - /1/1] [/1/2 - /1/2] [/1/3 - /1/3] [/1/4 - /1/4]",
+		},
+		{ // 3
+			// Descending span.
+			s:        parseSpans(&evalCtx, "[/1/1 - /1/-1]"),
+			keyCtx:   kcDescDesc,
+			expected: "[/1/1 - /1/1] [/1/0 - /1/0] [/1/-1 - /1/-1]",
+		},
+		{ // 4
+			// Fails due to descending span with ascending columns.
+			s:        parseSpans(&evalCtx, "[/1/1 - /1/-1]"),
+			keyCtx:   kcAscAsc,
+			expected: "FAIL",
+		},
+		{ // 5
+			// One descending span and one single-key span. Spans are out of order.
+			s:        parseSpans(&evalCtx, "[/1/1 - /1/-1] [/1/2 - /1/2]"),
+			keyCtx:   kcDescDesc,
+			expected: "[/1/1 - /1/1] [/1/0 - /1/0] [/1/-1 - /1/-1] [/1/2 - /1/2]",
+		},
+		{ // 6
+			// Fails because the keys are not all the same length.
+			s:        parseSpans(&evalCtx, "[/1/0 - /1/0] [/2 - /2]"),
+			keyCtx:   kcAscAsc,
+			expected: "FAIL",
+		},
+		{ // 7
+			// Fails because the keys are not all the same length.
+			s:        parseSpans(&evalCtx, "[/2 - /2] [/1/0 - /1/0]"),
+			keyCtx:   kcDescDesc,
+			expected: "FAIL",
+		},
+		{ // 8
+			// Fails because the span has 16 keys, which is greater than maxKeyCount.
+			s:        parseSpans(&evalCtx, "[/1/0 - /1/15]"),
+			keyCtx:   kcAscAsc,
+			expected: "FAIL",
+		},
+		{ // 9
+			// Fails because 3 spans with 4 keys each exceeds maxKeyCount.
+			s:        parseSpans(&evalCtx, "[/1/1 - /1/4] [/2/1 - /2/4] [/3/1 - /3/4]"),
+			keyCtx:   kcAscAsc,
+			expected: "FAIL",
+		},
+		{ // 10
+			// Fails because 11 spans exceed maxKeyCount.
+			s: parseSpans(&evalCtx, ""+
+				"[/0 - /0] [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5] "+
+				"[/6 - /6] [/7 - /7] [/8 - /8] [/9 - /9] [/10 - /10]"),
+			keyCtx:   kcAscAsc,
+			expected: "FAIL",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			toStr := func(spans *Spans, ok bool) string {
+				if !ok {
+					return "FAIL"
+				}
+				return spans.String()
+			}
+
+			if res := toStr(tc.s.ExtractSingleKeySpans(tc.keyCtx, maxKeyCount)); res != tc.expected {
+				t.Errorf("expected: %s, actual: %s", tc.expected, res)
+			}
+		})
 	}
 }

--- a/pkg/sql/opt/ordering.go
+++ b/pkg/sql/opt/ordering.go
@@ -49,6 +49,14 @@ func (c OrderingColumn) Descending() bool {
 	return c < 0
 }
 
+// RemapColumn returns a new OrderingColumn that uses a ColumnID from the 'to'
+// table. The original ColumnID must be from the 'from' table.
+func (c OrderingColumn) RemapColumn(from, to TableID) OrderingColumn {
+	ord := from.ColumnOrdinal(c.ID())
+	newColID := to.ColumnID(ord)
+	return MakeOrderingColumn(newColID, c.Descending())
+}
+
 func (c OrderingColumn) String() string {
 	var buf bytes.Buffer
 	c.Format(&buf)

--- a/pkg/sql/opt/props/physical/ordering_choice.go
+++ b/pkg/sql/opt/props/physical/ordering_choice.go
@@ -480,7 +480,7 @@ func (oc *OrderingChoice) AppendCol(id opt.ColumnID, descending bool) {
 // ordering column array.
 func (oc *OrderingChoice) Copy() OrderingChoice {
 	var other OrderingChoice
-	other.Optional = oc.Optional
+	other.Optional = oc.Optional.Copy()
 	other.Columns = make([]OrderingColumnChoice, len(oc.Columns))
 	copy(other.Columns, oc.Columns)
 	return other

--- a/pkg/sql/opt/props/physical/ordering_choice_test.go
+++ b/pkg/sql/opt/props/physical/ordering_choice_test.go
@@ -335,10 +335,11 @@ func TestOrderingChoice_MatchesAt(t *testing.T) {
 }
 
 func TestOrderingChoice_Copy(t *testing.T) {
-	ordering := physical.ParseOrderingChoice("+1,-(2|3) opt(4,5)")
+	ordering := physical.ParseOrderingChoice("+1,-(2|3) opt(4,5,100)")
 	copied := ordering.Copy()
 	col := physical.OrderingColumnChoice{Group: opt.MakeColSet(6, 7), Descending: true}
 	copied.Columns = append(copied.Columns, col)
+	copied.Optional.Remove(opt.ColumnID(100))
 
 	// ()-->(8)
 	// (3)==(9)
@@ -348,7 +349,7 @@ func TestOrderingChoice_Copy(t *testing.T) {
 	fd.AddEquivalency(3, 9)
 	copied.Simplify(&fd)
 
-	if ordering.String() != "+1,-(2|3) opt(4,5)" {
+	if ordering.String() != "+1,-(2|3) opt(4,5,100)" {
 		t.Errorf("original was modified: %s", ordering.String())
 	}
 

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -1465,6 +1465,185 @@ func (c *CustomFuncs) GenerateLimitedScans(
 	}
 }
 
+// ScanIsConstrained returns true if the scan operator with the given
+// ScanPrivate is constrained.
+func (c *CustomFuncs) ScanIsConstrained(sp *memo.ScanPrivate) bool {
+	return sp.Constraint != nil
+}
+
+// ScanIsLimited returns true if the scan operator with the given ScanPrivate is
+// limited.
+func (c *CustomFuncs) ScanIsLimited(sp *memo.ScanPrivate) bool {
+	return sp.HardLimit != 0
+}
+
+// SplitScanIntoUnionScans returns a Union of Scan operators with hard limits
+// that each scan over a single key from the original scan's constraints. This
+// is beneficial in cases where the original scan had to scan over many rows but
+// had relatively few keys to scan over.
+func (c *CustomFuncs) SplitScanIntoUnionScans(
+	limitOrdering physical.OrderingChoice, scan memo.RelExpr, sp *memo.ScanPrivate, limit tree.Datum,
+) memo.RelExpr {
+	const maxScanCount = 16
+	const threshold = 4
+
+	keyCtx := constraint.MakeKeyContext(&sp.Constraint.Columns, c.e.evalCtx)
+	limitVal := int(*limit.(*tree.DInt))
+	spans := sp.Constraint.Spans
+
+	// Retrieve the number of keys in the spans.
+	keyCount, ok := spans.KeyCount(&keyCtx)
+	if !ok {
+		return nil
+	}
+	if keyCount <= 1 {
+		// We need more than one key in order to split the existing Scan into
+		// multiple Scans.
+		return nil
+	}
+	if int(keyCount) > maxScanCount {
+		// The number of new Scans created would exceed maxScanCount.
+		return nil
+	}
+
+	// Check that the number of rows scanned by the new plan will be smaller than
+	// the number scanned by the old plan by at least a factor of "threshold".
+	if float64(int(keyCount)*limitVal*threshold) >= scan.Relational().Stats.RowCount {
+		// Splitting the scan may not be worth the overhead; creating a sequence of
+		// scans unioned together is expensive, so we don't want to create the plan
+		// only for the optimizer to use something else. We only want to create the
+		// plan if it is likely to be used.
+		return nil
+	}
+
+	// Retrieve the length of the keys. All keys are required to be the same
+	// length (this will be checked later) so we can simply use the length of the
+	// first key.
+	keyLength := spans.Get(0).StartKey().Length()
+
+	// If the index ordering has a prefix of columns of length keyLength followed
+	// by the limitOrdering columns, the scan can be split. Otherwise, return nil.
+	hasLimitOrderingSeq, reverse := indexHasOrderingSequence(
+		c.e.mem.Metadata(), scan, sp, limitOrdering, keyLength)
+	if !hasLimitOrderingSeq {
+		return nil
+	}
+
+	// Construct a hard limit for the new scans using the result of
+	// hasLimitOrderingSeq.
+	newHardLimit := memo.MakeScanLimit(int64(limitVal), reverse)
+
+	// Construct a new Spans object containing a new Span for each key in the
+	// original Scan's spans.
+	newSpans, ok := spans.ExtractSingleKeySpans(&keyCtx, maxScanCount)
+	if !ok {
+		// Single key spans could not be created.
+		return nil
+	}
+
+	// Construct a new ScanExpr for each span and union them all together. We
+	// output the old ColumnIDs from each union.
+	oldColList := opt.ColSetToList(scan.Relational().OutputCols)
+	last := c.makeNewScan(sp, newHardLimit, newSpans.Get(0))
+	for i, cnt := 1, newSpans.Count(); i < cnt; i++ {
+		newScan := c.makeNewScan(sp, newHardLimit, newSpans.Get(i))
+		last = c.e.f.ConstructUnion(last, newScan, &memo.SetPrivate{
+			LeftCols:  opt.ColSetToList(last.Relational().OutputCols),
+			RightCols: opt.ColSetToList(newScan.Relational().OutputCols),
+			OutCols:   oldColList,
+		})
+	}
+	return last
+}
+
+// indexHasOrderingSequence returns whether the scan can provide a given
+// ordering under the assumption that we are scanning a single-key span with the
+// given keyLength (and if so, whether we need to scan it in reverse).
+// For example:
+//
+// index: +1/-2/+3,
+// limitOrdering: -2/+3,
+// keyLength: 1,
+// =>
+// hasSequence: True, reverse: False
+//
+// index: +1/-2/+3,
+// limitOrdering: +2/-3,
+// keyLength: 1,
+// =>
+// hasSequence: True, reverse: True
+//
+// index: +1/-2/+3/+4,
+// limitOrdering: +3/+4,
+// keyLength: 1,
+// =>
+// hasSequence: False, reverse: False
+//
+func indexHasOrderingSequence(
+	md *opt.Metadata,
+	scan memo.RelExpr,
+	sp *memo.ScanPrivate,
+	limitOrdering physical.OrderingChoice,
+	keyLength int,
+) (hasSequence, reverse bool) {
+	tableMeta := md.TableMeta(sp.Table)
+	index := tableMeta.Table.Index(sp.Index)
+
+	if keyLength > index.ColumnCount() {
+		// The key contains more columns than the index. The limit ordering sequence
+		// cannot be part of the index ordering.
+		return false, false
+	}
+
+	// Create a copy of the Scan's FuncDepSet, and add the first 'keyCount'
+	// columns from the index as constant columns. The columns are constant
+	// because the span contains only a single key on those columns.
+	var fds props.FuncDepSet
+	fds.CopyFrom(&scan.Relational().FuncDeps)
+	prefixCols := opt.ColSet{}
+	for i := 0; i < keyLength; i++ {
+		col := sp.Table.ColumnID(index.Column(i).Ordinal)
+		prefixCols.Add(col)
+	}
+	fds.AddConstants(prefixCols)
+
+	// Use fds to simplify a copy of the limit ordering; the prefix columns will
+	// become part of the optional ColSet.
+	requiredOrdering := limitOrdering.Copy()
+	requiredOrdering.Simplify(&fds)
+
+	// If the ScanPrivate can satisfy requiredOrdering, it must return columns
+	// ordered by a prefix of length keyLength, followed by the columns of
+	// limitOrdering.
+	return ordering.ScanPrivateCanProvide(md, sp, &requiredOrdering)
+}
+
+// makeNewScan constructs a new Scan operator with a new TableID and the given
+// limit and span. All ColumnIDs and references to those ColumnIDs are
+// replaced with new ones from the new TableID. All other fields are simply
+// copied from the old ScanPrivate.
+func (c *CustomFuncs) makeNewScan(
+	sp *memo.ScanPrivate, newHardLimit memo.ScanLimit, span *constraint.Span,
+) memo.RelExpr {
+	newScanPrivate := c.DuplicateScanPrivate(sp)
+
+	// duplicateScanPrivate does not initialize the Constraint or HardLimit
+	// fields, so we do that now.
+	newScanPrivate.HardLimit = newHardLimit
+
+	// Construct the new Constraint field with the given span and remapped
+	// ordering columns.
+	var newSpans constraint.Spans
+	newSpans.InitSingleSpan(span)
+	newConstraint := &constraint.Constraint{
+		Columns: sp.Constraint.Columns.RemapColumns(sp.Table, newScanPrivate.Table),
+		Spans:   newSpans,
+	}
+	newScanPrivate.Constraint = newConstraint
+
+	return c.e.f.ConstructScan(newScanPrivate)
+}
+
 // ----------------------------------------------------------------------
 //
 // Join Rules
@@ -2981,31 +3160,27 @@ func (c *CustomFuncs) canMaybeConstrainIndexWithCols(sp *memo.ScanPrivate, cols 
 	return false
 }
 
-// DuplicateScanPrivate constructs a new ScanPrivate that is identical to the
-// input, but has new table and column IDs.
-//
-// DuplicateScanPrivate can only be called on canonical ScanPrivates because not
-// all scan properties are copied to the new ScanPrivate, e.g. constraints.
+// DuplicateScanPrivate constructs a new ScanPrivate with new table and column
+// IDs. Only the Index, Flags and Locking fields are copied from the old
+// ScanPrivate, so the new ScanPrivate will not have constraints even if the old
+// one did.
 func (c *CustomFuncs) DuplicateScanPrivate(sp *memo.ScanPrivate) *memo.ScanPrivate {
-	if !c.IsCanonicalScan(sp) {
-		panic(errors.AssertionFailedf("input ScanPrivate must be canonical: %v", sp))
-	}
-
 	md := c.e.mem.Metadata()
 	tabMeta := md.TableMeta(sp.Table)
-	dupTabID := md.AddTable(tabMeta.Table, &tabMeta.Alias)
+	newTableID := md.AddTable(tabMeta.Table, &tabMeta.Alias)
 
-	var dupTabColIDs opt.ColSet
+	var newColIDs opt.ColSet
 	cols := sp.Cols
-	for i, ok := cols.Next(0); ok; i, ok = cols.Next(i + 1) {
-		ord := tabMeta.MetaID.ColumnOrdinal(i)
-		dupColID := dupTabID.ColumnID(ord)
-		dupTabColIDs.Add(dupColID)
+	for col, ok := cols.Next(0); ok; col, ok = cols.Next(col + 1) {
+		ord := tabMeta.MetaID.ColumnOrdinal(col)
+		newColID := newTableID.ColumnID(ord)
+		newColIDs.Add(newColID)
 	}
 
 	return &memo.ScanPrivate{
-		Table:   dupTabID,
-		Cols:    dupTabColIDs,
+		Table:   newTableID,
+		Index:   sp.Index,
+		Cols:    newColIDs,
 		Flags:   sp.Flags,
 		Locking: sp.Locking,
 	}

--- a/pkg/sql/opt/xform/rules/limit.opt
+++ b/pkg/sql/opt/xform/rules/limit.opt
@@ -48,3 +48,42 @@
     (Scan (LimitScanPrivate $scanPrivate $limit $ordering))
     $indexJoinPrivate
 )
+
+# SplitScanIntoUnionScans splits a scan under a limit into a union of limited
+# scans. Example:
+#
+#    CREATE TABLE tab (region STRING, data INT NOT NULL, INDEX (region, data));
+#
+#    SELECT data
+#    FROM tab
+#    WHERE region='ASIA' OR region='EUROPE'
+#    ORDER BY data DESC
+#    LIMIT 1;
+#
+#    =>
+#
+#    SELECT data
+#    FROM (SELECT * FROM tab WHERE region='ASIA' ORDER BY data LIMIT 1)
+#    UNION ALL (SELECT * FROM tab WHERE region='EUROPE' ORDER BY data LIMIT 1)
+#    ORDER BY data
+#    LIMIT 1;
+#
+# See the SplitScanIntoUnionScans comment in xform/custom_funcs for details.
+[SplitScanIntoUnionScans, Explore]
+(Limit
+    $scan:(Scan $scanPrivate:*) &
+        (ScanIsConstrained $scanPrivate) &
+        ^(ScanIsLimited $scanPrivate)
+    $limitExpr:(Const $limit:*) & (IsPositiveInt $limit)
+    $ordering:* &
+        (Succeeded
+            $unionScans:(SplitScanIntoUnionScans
+                $ordering
+                $scan
+                $scanPrivate
+                $limit
+            )
+        )
+)
+=>
+(Limit $unionScans $limitExpr $ordering)

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -596,13 +596,72 @@ project
  │    ├── stats: [rows=1]
  │    ├── key: ()
  │    ├── fd: ()-->(30)
- │    ├── scan cardsinfo@cardsinfoversionindex
+ │    ├── limit
  │    │    ├── columns: dealerid:7!null version:15!null
- │    │    ├── constraint: /7/15: [/1 - /4]
- │    │    ├── stats: [rows=233333.333, distinct(7)=4, null(7)=0]
- │    │    └── key: (7,15)
+ │    │    ├── internal-ordering: -15
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── stats: [rows=1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(7,15)
+ │    │    ├── sort
+ │    │    │    ├── columns: dealerid:7!null version:15!null
+ │    │    │    ├── cardinality: [0 - 4]
+ │    │    │    ├── stats: [rows=4, distinct(7,15)=4, null(7,15)=0]
+ │    │    │    ├── key: (7,15)
+ │    │    │    ├── ordering: -15
+ │    │    │    ├── limit hint: 1.00
+ │    │    │    └── union
+ │    │    │         ├── columns: dealerid:7!null version:15!null
+ │    │    │         ├── left columns: dealerid:7!null version:15!null
+ │    │    │         ├── right columns: dealerid:59 version:67
+ │    │    │         ├── cardinality: [0 - 4]
+ │    │    │         ├── stats: [rows=4, distinct(7,15)=4, null(7,15)=0]
+ │    │    │         ├── key: (7,15)
+ │    │    │         ├── union
+ │    │    │         │    ├── columns: dealerid:7!null version:15!null
+ │    │    │         │    ├── left columns: dealerid:7!null version:15!null
+ │    │    │         │    ├── right columns: dealerid:50 version:58
+ │    │    │         │    ├── cardinality: [0 - 3]
+ │    │    │         │    ├── stats: [rows=3, distinct(7,15)=3, null(7,15)=0]
+ │    │    │         │    ├── key: (7,15)
+ │    │    │         │    ├── union
+ │    │    │         │    │    ├── columns: dealerid:7!null version:15!null
+ │    │    │         │    │    ├── left columns: dealerid:32 version:40
+ │    │    │         │    │    ├── right columns: dealerid:41 version:49
+ │    │    │         │    │    ├── cardinality: [0 - 2]
+ │    │    │         │    │    ├── stats: [rows=2, distinct(7,15)=2, null(7,15)=0]
+ │    │    │         │    │    ├── key: (7,15)
+ │    │    │         │    │    ├── scan cardsinfo@cardsinfoversionindex,rev
+ │    │    │         │    │    │    ├── columns: dealerid:32!null version:40!null
+ │    │    │         │    │    │    ├── constraint: /32/40: [/1 - /1]
+ │    │    │         │    │    │    ├── limit: 1(rev)
+ │    │    │         │    │    │    ├── stats: [rows=1, distinct(32)=1, null(32)=0, distinct(32,40)=1, null(32,40)=0]
+ │    │    │         │    │    │    ├── key: ()
+ │    │    │         │    │    │    └── fd: ()-->(32,40)
+ │    │    │         │    │    └── scan cardsinfo@cardsinfoversionindex,rev
+ │    │    │         │    │         ├── columns: dealerid:41!null version:49!null
+ │    │    │         │    │         ├── constraint: /41/49: [/2 - /2]
+ │    │    │         │    │         ├── limit: 1(rev)
+ │    │    │         │    │         ├── stats: [rows=1, distinct(41)=1, null(41)=0, distinct(41,49)=1, null(41,49)=0]
+ │    │    │         │    │         ├── key: ()
+ │    │    │         │    │         └── fd: ()-->(41,49)
+ │    │    │         │    └── scan cardsinfo@cardsinfoversionindex,rev
+ │    │    │         │         ├── columns: dealerid:50!null version:58!null
+ │    │    │         │         ├── constraint: /50/58: [/3 - /3]
+ │    │    │         │         ├── limit: 1(rev)
+ │    │    │         │         ├── stats: [rows=1, distinct(50)=1, null(50)=0, distinct(50,58)=1, null(50,58)=0]
+ │    │    │         │         ├── key: ()
+ │    │    │         │         └── fd: ()-->(50,58)
+ │    │    │         └── scan cardsinfo@cardsinfoversionindex,rev
+ │    │    │              ├── columns: dealerid:59!null version:67!null
+ │    │    │              ├── constraint: /59/67: [/4 - /4]
+ │    │    │              ├── limit: 1(rev)
+ │    │    │              ├── stats: [rows=1, distinct(59)=1, null(59)=0, distinct(59,67)=1, null(59,67)=0]
+ │    │    │              ├── key: ()
+ │    │    │              └── fd: ()-->(59,67)
+ │    │    └── 1
  │    └── aggregations
- │         └── max [as=max:30, outer=(15)]
+ │         └── const-agg [as=max:30, outer=(15)]
  │              └── version:15
  └── projections
       └── COALESCE(max:30, 0) [as=coalesce:31, outer=(30)]

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -602,13 +602,72 @@ project
  │    ├── stats: [rows=1]
  │    ├── key: ()
  │    ├── fd: ()-->(34)
- │    ├── scan cardsinfo@cardsinfoversionindex
+ │    ├── limit
  │    │    ├── columns: dealerid:7!null version:15!null
- │    │    ├── constraint: /7/15: [/1 - /4]
- │    │    ├── stats: [rows=233333.333, distinct(7)=4, null(7)=0]
- │    │    └── key: (7,15)
+ │    │    ├── internal-ordering: -15
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── stats: [rows=1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(7,15)
+ │    │    ├── sort
+ │    │    │    ├── columns: dealerid:7!null version:15!null
+ │    │    │    ├── cardinality: [0 - 4]
+ │    │    │    ├── stats: [rows=4, distinct(7,15)=4, null(7,15)=0]
+ │    │    │    ├── key: (7,15)
+ │    │    │    ├── ordering: -15
+ │    │    │    ├── limit hint: 1.00
+ │    │    │    └── union
+ │    │    │         ├── columns: dealerid:7!null version:15!null
+ │    │    │         ├── left columns: dealerid:7!null version:15!null
+ │    │    │         ├── right columns: dealerid:75 version:83
+ │    │    │         ├── cardinality: [0 - 4]
+ │    │    │         ├── stats: [rows=4, distinct(7,15)=4, null(7,15)=0]
+ │    │    │         ├── key: (7,15)
+ │    │    │         ├── union
+ │    │    │         │    ├── columns: dealerid:7!null version:15!null
+ │    │    │         │    ├── left columns: dealerid:7!null version:15!null
+ │    │    │         │    ├── right columns: dealerid:62 version:70
+ │    │    │         │    ├── cardinality: [0 - 3]
+ │    │    │         │    ├── stats: [rows=3, distinct(7,15)=3, null(7,15)=0]
+ │    │    │         │    ├── key: (7,15)
+ │    │    │         │    ├── union
+ │    │    │         │    │    ├── columns: dealerid:7!null version:15!null
+ │    │    │         │    │    ├── left columns: dealerid:36 version:44
+ │    │    │         │    │    ├── right columns: dealerid:49 version:57
+ │    │    │         │    │    ├── cardinality: [0 - 2]
+ │    │    │         │    │    ├── stats: [rows=2, distinct(7,15)=2, null(7,15)=0]
+ │    │    │         │    │    ├── key: (7,15)
+ │    │    │         │    │    ├── scan cardsinfo@cardsinfoversionindex,rev
+ │    │    │         │    │    │    ├── columns: dealerid:36!null version:44!null
+ │    │    │         │    │    │    ├── constraint: /36/44: [/1 - /1]
+ │    │    │         │    │    │    ├── limit: 1(rev)
+ │    │    │         │    │    │    ├── stats: [rows=1, distinct(36)=1, null(36)=0, distinct(36,44)=1, null(36,44)=0]
+ │    │    │         │    │    │    ├── key: ()
+ │    │    │         │    │    │    └── fd: ()-->(36,44)
+ │    │    │         │    │    └── scan cardsinfo@cardsinfoversionindex,rev
+ │    │    │         │    │         ├── columns: dealerid:49!null version:57!null
+ │    │    │         │    │         ├── constraint: /49/57: [/2 - /2]
+ │    │    │         │    │         ├── limit: 1(rev)
+ │    │    │         │    │         ├── stats: [rows=1, distinct(49)=1, null(49)=0, distinct(49,57)=1, null(49,57)=0]
+ │    │    │         │    │         ├── key: ()
+ │    │    │         │    │         └── fd: ()-->(49,57)
+ │    │    │         │    └── scan cardsinfo@cardsinfoversionindex,rev
+ │    │    │         │         ├── columns: dealerid:62!null version:70!null
+ │    │    │         │         ├── constraint: /62/70: [/3 - /3]
+ │    │    │         │         ├── limit: 1(rev)
+ │    │    │         │         ├── stats: [rows=1, distinct(62)=1, null(62)=0, distinct(62,70)=1, null(62,70)=0]
+ │    │    │         │         ├── key: ()
+ │    │    │         │         └── fd: ()-->(62,70)
+ │    │    │         └── scan cardsinfo@cardsinfoversionindex,rev
+ │    │    │              ├── columns: dealerid:75!null version:83!null
+ │    │    │              ├── constraint: /75/83: [/4 - /4]
+ │    │    │              ├── limit: 1(rev)
+ │    │    │              ├── stats: [rows=1, distinct(75)=1, null(75)=0, distinct(75,83)=1, null(75,83)=0]
+ │    │    │              ├── key: ()
+ │    │    │              └── fd: ()-->(75,83)
+ │    │    └── 1
  │    └── aggregations
- │         └── max [as=max:34, outer=(15)]
+ │         └── const-agg [as=max:34, outer=(15)]
  │              └── version:15
  └── projections
       └── COALESCE(max:34, 0) [as=coalesce:35, outer=(34)]

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -11,6 +11,64 @@ CREATE TABLE a
 )
 ----
 
+exec-ddl
+CREATE TABLE index_tab
+(
+    id INT PRIMARY KEY,
+    val INT,
+    region STRING,
+    latitude INT,
+    longitude INT,
+    data1 INT NOT NULL,
+    data2 INT NOT NULL,
+    INDEX a (id, data1, data2),
+    INDEX b (val, data1, data2),
+    INDEX c (region, data1, data2),
+    INDEX d (latitude, longitude, data1, data2)
+)
+----
+
+exec-ddl
+ALTER TABLE index_tab INJECT STATISTICS '[
+  {
+    "columns": ["val"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 100
+  },
+  {
+    "columns": ["region"],
+    "created_at": "2018-01-01 1:30:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 1000
+  },
+  {
+    "columns": ["latitude"],
+    "created_at": "2018-01-01 2:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 100
+  },
+  {
+    "columns": ["longitude"],
+    "created_at": "2018-01-01 2:30:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 100
+  },
+  {
+    "columns": ["data1"],
+    "created_at": "2018-01-01 3:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 100
+  },
+  {
+    "columns": ["data2"],
+    "created_at": "2018-01-01 3:30:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 100
+  }
+]'
+----
+
 # ---------------------------------------------------
 # GenerateLimitedScans / PushLimitIntoConstrainedScan
 # ---------------------------------------------------
@@ -555,3 +613,199 @@ index-join kuv
       ├── key: (1)
       ├── fd: (1)-->(2)
       └── ordering: +2
+
+# -------------------------
+# SplitScanIntoUnionScans
+# -------------------------
+
+# Case with limit 10.
+opt format=hide-all
+SELECT val, data1 FROM index_tab WHERE val > 0 AND val < 4 ORDER BY data1 LIMIT 10
+----
+limit
+ ├── sort
+ │    └── union
+ │         ├── union
+ │         │    ├── scan index_tab@b
+ │         │    │    ├── constraint: /9/13/14/8: [/1 - /1]
+ │         │    │    └── limit: 10
+ │         │    └── scan index_tab@b
+ │         │         ├── constraint: /16/20/21/15: [/2 - /2]
+ │         │         └── limit: 10
+ │         └── scan index_tab@b
+ │              ├── constraint: /23/27/28/22: [/3 - /3]
+ │              └── limit: 10
+ └── 10
+
+# Case with single-key spans.
+opt expect=SplitScanIntoUnionScans format=hide-all
+SELECT max(data1) FROM index_tab WHERE region = 'US_EAST' OR region = 'US_WEST'
+----
+scalar-group-by
+ ├── limit
+ │    ├── sort
+ │    │    └── union
+ │    │         ├── scan index_tab@c,rev
+ │    │         │    ├── constraint: /11/14/15/9: [/'US_EAST' - /'US_EAST']
+ │    │         │    └── limit: 1(rev)
+ │    │         └── scan index_tab@c,rev
+ │    │              ├── constraint: /18/21/22/16: [/'US_WEST' - /'US_WEST']
+ │    │              └── limit: 1(rev)
+ │    └── 1
+ └── aggregations
+      └── const-agg
+           └── data1
+
+# Case with multi-column keys in single-key spans.
+opt expect=SplitScanIntoUnionScans format=hide-all
+SELECT max(data1)
+FROM index_tab
+WHERE (latitude, longitude) = (1, 2) OR (latitude, longitude) = (4, 5)
+----
+scalar-group-by
+ ├── limit
+ │    ├── sort
+ │    │    └── union
+ │    │         ├── scan index_tab@d,rev
+ │    │         │    ├── constraint: /12/13/14/15/9: [/1/2 - /1/2]
+ │    │         │    └── limit: 1(rev)
+ │    │         └── scan index_tab@d,rev
+ │    │              ├── constraint: /19/20/21/22/16: [/4/5 - /4/5]
+ │    │              └── limit: 1(rev)
+ │    └── 1
+ └── aggregations
+      └── const-agg
+           └── data1
+
+# Case with countable multi-key spans.
+opt expect=SplitScanIntoUnionScans format=hide-all
+SELECT max(data1) FROM index_tab WHERE val > 0 AND val < 4
+----
+scalar-group-by
+ ├── limit
+ │    ├── sort
+ │    │    └── union
+ │    │         ├── union
+ │    │         │    ├── scan index_tab@b,rev
+ │    │         │    │    ├── constraint: /10/14/15/9: [/1 - /1]
+ │    │         │    │    └── limit: 1(rev)
+ │    │         │    └── scan index_tab@b,rev
+ │    │         │         ├── constraint: /17/21/22/16: [/2 - /2]
+ │    │         │         └── limit: 1(rev)
+ │    │         └── scan index_tab@b,rev
+ │    │              ├── constraint: /24/28/29/23: [/3 - /3]
+ │    │              └── limit: 1(rev)
+ │    └── 1
+ └── aggregations
+      └── const-agg
+           └── data1
+
+# Case with limit ordering on more than one column.
+opt expect=SplitScanIntoUnionScans format=hide-all
+SELECT region, data1, data2
+FROM index_tab
+WHERE region='US_WEST' OR region='US_EAST'
+ORDER BY data1, data2
+LIMIT 10
+----
+limit
+ ├── sort
+ │    └── union
+ │         ├── scan index_tab@c
+ │         │    ├── constraint: /10/13/14/8: [/'US_EAST' - /'US_EAST']
+ │         │    └── limit: 10
+ │         └── scan index_tab@c
+ │              ├── constraint: /17/20/21/15: [/'US_WEST' - /'US_WEST']
+ │              └── limit: 10
+ └── 10
+
+# No-op case because the multi-key span isn't countable.
+opt expect-not=SplitScanIntoUnionScans format=hide-all
+SELECT max(data1) FROM index_tab WHERE region > 'US_EAST' AND region < 'US_WEST'
+----
+scalar-group-by
+ ├── scan index_tab@c
+ │    └── constraint: /3/6/7/1: [/e'US_EAST\x00' - /'US_WEST')
+ └── aggregations
+      └── max
+           └── data1
+
+# No-op case because the number of keys exceeds maxScanCount.
+opt expect-not=SplitScanIntoUnionScans format=hide-all
+SELECT max(data1) FROM index_tab WHERE val > 0 AND val < 20
+----
+scalar-group-by
+ ├── scan index_tab@b
+ │    └── constraint: /2/6/7/1: [/1 - /19]
+ └── aggregations
+      └── max
+           └── data1
+
+# No-op case because the same number of rows would be scanned by the split-up
+# scans, as by the original.
+opt expect-not=SplitScanIntoUnionScans format=hide-all
+SELECT max(data1) FROM index_tab WHERE id > 0 AND id < 4
+----
+scalar-group-by
+ ├── scan index_tab@a
+ │    └── constraint: /1/6/7: [/1 - /3]
+ └── aggregations
+      └── max
+           └── data1
+
+# No-op case because the scan is already limited.
+opt expect-not=SplitScanIntoUnionScans format=hide-all
+SELECT max(data1)
+FROM (SELECT region, data1 FROM index_tab LIMIT 10)
+WHERE region='ASIA' OR region='AUSTRALIA'
+----
+scalar-group-by
+ ├── select
+ │    ├── scan index_tab@c
+ │    │    └── limit: 10
+ │    └── filters
+ │         └── (region = 'ASIA') OR (region = 'AUSTRALIA')
+ └── aggregations
+      └── max
+           └── data1
+
+# No-op case because the limit is negative.
+opt expect-not=SplitScanIntoUnionScans format=hide-all
+SELECT region, data1
+FROM index_tab
+WHERE region = 'ASIA' OR region = 'EUROPE' ORDER BY data1 LIMIT -1
+----
+limit
+ ├── sort
+ │    └── scan index_tab@c
+ │         └── constraint: /3/6/7/1
+ │              ├── [/'ASIA' - /'ASIA']
+ │              └── [/'EUROPE' - /'EUROPE']
+ └── -1
+
+# No-op case because scan is unconstrained.
+opt expect-not=SplitScanIntoUnionScans format=hide-all
+SELECT max(data1) FROM index_tab@b
+----
+scalar-group-by
+ ├── scan index_tab@b
+ │    └── flags: force-index=b
+ └── aggregations
+      └── max
+           └── data1
+
+# No-op case because the limit input is an index-join. TODO(drewk): modify
+# the rule to push limits through index joins.
+opt expect-not=SplitScanIntoUnionScans format=hide-all
+SELECT *
+FROM index_tab WHERE region = 'US_WEST' OR region = 'US_EAST'
+ORDER BY data1 LIMIT 10
+----
+limit
+ ├── sort
+ │    └── index-join index_tab
+ │         └── scan index_tab@c
+ │              └── constraint: /3/6/7/1
+ │                   ├── [/'US_EAST' - /'US_EAST']
+ │                   └── [/'US_WEST' - /'US_WEST']
+ └── 10


### PR DESCRIPTION
This patch adds a rule that replaces a constrained Scan under a limit
with a union of Scans with hard limits. Each new Scan scans over a
single key from the original constraint. For now, this rule only
matches when there are 16 or less keys in the original Scan constraint.

Making this replacement can lend a significant speedup to queries that
take a max or min over a column that is part of an index, but not the
first index column.

```
CREATE TABLE partitioned_data (
	region STRING,
	data INT NOT NULL,
	INDEX (region, data)
);
SELECT max(data) FROM partitioned_data WHERE region='US_WEST' OR region='US_EAST';
```
This query previously produced this plan:
```
scalar-group-by
 ├── scan partitioned_data@secondary
 │    └── constraint: /1/2/3
 │         ├── [/'US_EAST' - /'US_EAST']
 │         └── [/'US_WEST' - /'US_WEST']
 └── aggregations
      └── max
           └── data
```
In this example, the max value of "data" for any given "region" value
is located in the last row that has that "region" value. This rule
creates two scans, each of which would only scan a single row, which
would be the max for that "region" value. From there, the two rows
are sorted and and another limit grabs the row with the max value for
"data":
```
scalar-group-by
 ├── limit
 │    ├── sort
 │    │    └── union
 │    │         ├── scan partitioned_data@secondary
 │    │         │    ├── constraint: /1/2/3: (/'US_EAST' - /'US_EAST')
 │    │         │    └── limit: 1
 │    │         └── scan partitioned_data@secondary
 │    │              ├── constraint: /5/6/7: (/'US_WEST' - /'US_WEST')
 │    │              └── limit: 1
 │    └── 1
 └── aggregations
      └── const-agg
           └── data
```
This takes the query from potentially scanning thousands of rows to
only scanning two.

Release note: None