### PR TITLE
colexec: add support for Pow binary operator

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -31,11 +31,13 @@ var binaryOpDecMethod = map[tree.BinaryOperator]string{
 	tree.Div:      "Quo",
 	tree.FloorDiv: "QuoInteger",
 	tree.Mod:      "Rem",
+	tree.Pow:      "Pow",
 }
 
 var binaryOpFloatMethod = map[tree.BinaryOperator]string{
 	tree.FloorDiv: "math.Trunc",
 	tree.Mod:      "math.Mod",
+	tree.Pow:      "math.Pow",
 }
 
 var binaryOpDecCtx = map[tree.BinaryOperator]string{
@@ -45,6 +47,7 @@ var binaryOpDecCtx = map[tree.BinaryOperator]string{
 	tree.Div:      "DecimalCtx",
 	tree.FloorDiv: "HighPrecisionCtx",
 	tree.Mod:      "HighPrecisionCtx",
+	tree.Pow:      "DecimalCtx",
 }
 
 var compatibleCanonicalTypeFamilies = map[types.Family][]types.Family{
@@ -155,7 +158,7 @@ func registerBinOpOutputTypes() {
 	binOpOutputTypes[tree.Plus][typePair{types.IntervalFamily, anyWidth, types.TimestampTZFamily, anyWidth}] = types.TimestampTZ
 
 	// Other arithmetic binary operators.
-	for _, binOp := range []tree.BinaryOperator{tree.FloorDiv, tree.Mod} {
+	for _, binOp := range []tree.BinaryOperator{tree.FloorDiv, tree.Mod, tree.Pow} {
 		binOpOutputTypes[binOp] = make(map[typePair]*types.T)
 		populateBinOpIntOutputTypeOnIntArgs(binOp)
 		binOpOutputTypes[binOp][typePair{types.FloatFamily, anyWidth, types.FloatFamily, anyWidth}] = types.Float
@@ -301,7 +304,7 @@ func (c floatCustomizer) getBinOpAssignFunc() assignFunc {
 		switch binOp {
 		case tree.FloorDiv:
 			computeBinOp = fmt.Sprintf("%s(float64(%s) / float64(%s))", binaryOpFloatMethod[binOp], leftElem, rightElem)
-		case tree.Mod:
+		case tree.Mod, tree.Pow:
 			computeBinOp = fmt.Sprintf("%s(float64(%s), float64(%s))", binaryOpFloatMethod[binOp], leftElem, rightElem)
 		default:
 			computeBinOp = fmt.Sprintf("float64(%s) %s float64(%s)", leftElem, binOp, rightElem)
@@ -425,7 +428,24 @@ func (c intCustomizer) getBinOpAssignFunc() assignFunc {
 				}
 			}
 		`))
+		case tree.Pow:
+			args["Ctx"] = binaryOpDecCtx[binOp]
 
+			t = template.Must(template.New("").Parse(`
+			{
+				leftTmpDec, rightTmpDec := &_overloadHelper.tmpDec1, &_overloadHelper.tmpDec2
+				leftTmpDec.SetInt64(int64({{.Left}}))
+				rightTmpDec.SetInt64(int64({{.Right}}))
+				if _, err := tree.{{.Ctx}}.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+					colexecerror.ExpectedError(err)
+				}
+				resultInt, err := leftTmpDec.Int64()
+				if err != nil {
+					colexecerror.ExpectedError(tree.ErrIntOutOfRange)
+				}
+				{{.Target}} = resultInt
+			}
+			`))
 		case tree.FloorDiv, tree.Mod:
 			// Note that these operators have integer result.
 			t = template.Must(template.New("").Parse(fmt.Sprintf(`

--- a/pkg/sql/colexec/execgen/supported_bin_cmp_ops.go
+++ b/pkg/sql/colexec/execgen/supported_bin_cmp_ops.go
@@ -24,6 +24,7 @@ var BinaryOpName = map[tree.BinaryOperator]string{
 	tree.Div:          "Div",
 	tree.FloorDiv:     "FloorDiv",
 	tree.Mod:          "Mod",
+	tree.Pow:          "Pow",
 	tree.Concat:       "Concat",
 	tree.JSONFetchVal: "JSONFetchVal",
 }

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
@@ -109,6 +109,52 @@ EXPLAIN (VEC) SELECT _inet - _int2 FROM many_types
   └ *colexec.projMinusDatumInt16Op
     └ *colexec.colBatchScan
 
+query T
+EXPLAIN (VEC) SELECT _int2^_int4 FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projPowInt16Int32Op
+    └ *colexec.colBatchScan
+
+query T
+EXPLAIN (VEC) SELECT _int2^_int FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projPowInt16Int64Op
+    └ *colexec.colBatchScan
+
+query T
+EXPLAIN (VEC) SELECT _float^_float FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projPowFloat64Float64Op
+    └ *colexec.colBatchScan
+
+query T
+EXPLAIN (VEC) SELECT _decimal^_int4 FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projPowDecimalInt32Op
+    └ *colexec.colBatchScan
+
+query R rowsort
+SELECT _float^_float FROM many_types
+----
+NULL
+1.28998092100128
+1011.29924392386
+
+query R rowsort
+SELECT _int^_decimal FROM many_types
+----
+NULL
+372.03456145999677855
+1333152042999.6318928
+
 query T rowsort
 SELECT _inet - _int2 FROM many_types
 ----
@@ -282,6 +328,24 @@ EXPLAIN (VEC) SELECT _json -> _int2 FROM many_types
 └ Node 1
   └ *colexec.projJSONFetchValDatumInt16Op
     └ *colexec.colBatchScan
+
+query I rowsort
+SELECT _int2^_int FROM many_types WHERE _int2 < 10 AND _int < 10
+----
+4
+
+query I rowsort
+SELECT _int2^_int2 FROM many_types WHERE _int2 < 10
+----
+4
+
+statement error integer out of range
+SELECT _int2^_int2 FROM many_types
+
+query I rowsort
+SELECT _int2^_int4 FROM many_types WHERE _int2 < 10 AND _int4 < 10
+----
+4
 
 query T
 SELECT _json -> _int2 FROM many_types


### PR DESCRIPTION
This commit resolves: #49465

Previously, there was no support for Pow (**) in vectorized engine.
This commit adds Pow operator. I added Pow to binaryOpMethods
and registered inputs/outputs for this operator.

Release note (sql change): Vectorized engine now support Pow operator.