### PR TITLE
ui: Generate demo metrics data

### DIFF
--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -115,6 +115,7 @@
     "rimraf": "^2.6.1",
     "sinon": "^7.5.0",
     "source-map-loader": "^0.2.0",
+    "string-replace-webpack-plugin": "^0.1.3",
     "style-loader": "^1.1.2",
     "stylint": "^1.5.9",
     "stylus": "^0.54.5",

--- a/pkg/ui/src/redux/metrics.ts
+++ b/pkg/ui/src/redux/metrics.ts
@@ -38,7 +38,7 @@ export const FETCH_COMPLETE = "cockroachui/metrics/FETCH_COMPLETE";
  * WithID is a convenient interface for associating arbitrary data structures
  * with a component ID.
  */
-interface WithID<T> {
+export interface WithID<T> {
   id: string;
   data: T;
 }
@@ -46,7 +46,7 @@ interface WithID<T> {
 /**
  * A request/response pair.
  */
-interface RequestWithResponse {
+export interface RequestWithResponse {
   request: TSRequest;
   response: TSResponse;
 }

--- a/pkg/ui/src/test-utils/fakeMetricsDataGenerationMiddleware.ts
+++ b/pkg/ui/src/test-utils/fakeMetricsDataGenerationMiddleware.ts
@@ -1,0 +1,71 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {Store, Action, Dispatch} from "redux";
+import Long from "long";
+import {clone} from "lodash";
+import {AdminUIState} from "src/redux/state";
+import {RECEIVE, RequestWithResponse, WithID} from "src/redux/metrics";
+import {PayloadAction} from "src/interfaces/action";
+import {cockroach} from "src/js/protos";
+import ITimeSeriesDatapoint = cockroach.ts.tspb.ITimeSeriesDatapoint;
+
+function fakeTimeSeriesDatapoint(): ITimeSeriesDatapoint {
+  return {
+    timestamp_nanos: Long.fromNumber(Date.now() * 1000000),
+    value: Math.ceil(Math.random() * 100),
+  };
+}
+
+/**
+ * @summary Redux Middleware which intercepts RESPONSE actions with requrested metrics data
+ * and populates datapoints for entire requested date period.
+ * @example Display datapoints for 2 months period even if cluster was created today and
+ * there is no available data for requested period, then missing datapoints will be randomly generated.
+ * Note: it is only for testing purposes only.
+ */
+export const fakeMetricsDataGenerationMiddleware = (_store: Store<AdminUIState>) => (next: Dispatch<Action, AdminUIState>) =>
+  (action: Action) => {
+    if (action.type === RECEIVE) {
+      const originalAction = action as PayloadAction<WithID<RequestWithResponse>>;
+      const {start_nanos, end_nanos, sample_nanos} = originalAction.payload.data.request;
+      const {results} = originalAction.payload.data.response;
+      const expectedDatapointsCount = end_nanos.sub(start_nanos).divide(sample_nanos).toNumber();
+
+      const nextResults = results.map(res => {
+        const actualDatapointsCount = res.datapoints.length;
+
+        if (actualDatapointsCount >= expectedDatapointsCount) {
+          return res;
+        }
+
+        const samplePoint = actualDatapointsCount > 0 ? clone(res.datapoints[0]) : fakeTimeSeriesDatapoint();
+
+        const datapoints = Array(expectedDatapointsCount - actualDatapointsCount)
+          .fill(1)
+          .map<ITimeSeriesDatapoint>((_, idx) => ({
+            ...samplePoint,
+            timestamp_nanos: samplePoint.timestamp_nanos.subtract(sample_nanos.multiply(idx + 1)),
+          }))
+          .reverse()
+          .concat(...res.datapoints);
+
+        return {
+          ...res,
+          datapoints,
+        };
+      });
+
+      originalAction.payload.data.response.results = nextResults;
+      return next(originalAction);
+    } else {
+      return next(action);
+    }
+  };

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -3327,6 +3327,11 @@ async@^2.0.0, async@^2.1.4, async@^2.6.2:
   dependencies:
     lodash "^4.17.14"
 
+async@~0.2.10:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
+  integrity sha1-trvgsGdLnXGXCMo43owjfLUmw9E=
+
 atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
@@ -4863,6 +4868,15 @@ css-animation@1.x, css-animation@^1.3.2, css-animation@^1.5.0:
     babel-runtime "6.x"
     component-classes "^1.2.5"
 
+css-loader@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.9.1.tgz#2e1aa00ce7e30ef2c6a7a4b300a080a7c979e0dc"
+  integrity sha1-LhqgDOfjDvLGp6SzAKCAp8l54Nw=
+  dependencies:
+    csso "1.3.x"
+    loader-utils "~0.2.2"
+    source-map "~0.1.38"
+
 css-loader@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-2.1.1.tgz#d8254f72e412bb2238bb44dd674ffbef497333ea"
@@ -4947,6 +4961,11 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+csso@1.3.x:
+  version "1.3.12"
+  resolved "https://registry.yarnpkg.com/csso/-/csso-1.3.12.tgz#fc628694a2d38938aaac4996753218fd311cdb9e"
+  integrity sha1-/GKGlKLTiTiqrEmWdTIY/TEc254=
 
 csso@^4.0.2:
   version "4.0.2"
@@ -6088,6 +6107,13 @@ file-loader@4.0.0:
   dependencies:
     loader-utils "^1.2.2"
     schema-utils "^1.0.0"
+
+file-loader@^0.8.1:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-0.8.5.tgz#9275d031fe780f27d47f5f4af02bd43713cc151b"
+  integrity sha1-knXQMf54DyfUf19K8CvUNxPMFRs=
+  dependencies:
+    loader-utils "~0.2.5"
 
 file-loader@^3.0.1:
   version "3.0.1"
@@ -7958,15 +7984,7 @@ loader-utils@1.2.3, loader-utils@^1.0.0, loader-utils@^1.0.2, loader-utils@^1.2.
     emojis-list "^2.0.0"
     json5 "^1.0.1"
 
-loader-utils@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
-  dependencies:
-    big.js "^3.1.3"
-    emojis-list "^2.0.0"
-    json5 "^0.5.0"
-
-loader-utils@~0.2.2:
+loader-utils@^0.2.5, loader-utils@~0.2.2, loader-utils@~0.2.3, loader-utils@~0.2.5:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
   dependencies:
@@ -7974,6 +7992,14 @@ loader-utils@~0.2.2:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
     object-assign "^4.0.1"
+
+loader-utils@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -11630,7 +11656,7 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
-source-map@0.1.x, source-map@~0.1.33:
+source-map@0.1.x, source-map@~0.1.33, source-map@~0.1.38:
   version "0.1.43"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
   dependencies:
@@ -11817,6 +11843,18 @@ string-convert@^0.2.0:
   resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
   integrity sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c=
 
+string-replace-webpack-plugin@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/string-replace-webpack-plugin/-/string-replace-webpack-plugin-0.1.3.tgz#73c657e759d66cfe80ae1e0cf091aa256d0e715c"
+  integrity sha1-c8ZX51nWbP6Arh4M8JGqJW0OcVw=
+  dependencies:
+    async "~0.2.10"
+    loader-utils "~0.2.3"
+  optionalDependencies:
+    css-loader "^0.9.1"
+    file-loader "^0.8.1"
+    style-loader "^0.8.3"
+
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -11975,6 +12013,13 @@ style-loader@^0.23.1:
   dependencies:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
+
+style-loader@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.8.3.tgz#f4f92eb7db63768748f15065cd6700f5a1c85357"
+  integrity sha1-9Pkut9tjdodI8VBlzWcA9aHIU1c=
+  dependencies:
+    loader-utils "^0.2.5"
 
 style-loader@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Resolves: #49645
Depends on: https://github.com/cockroachdb/yarn-vendored/pull/21

How to run: add SIMULATE_METRICS_LOAD=true env variable  
```SIMULATE_METRICS_LOAD=true make ui-watch ...```

It is necessary to be able to test metrics charts with
data older than a day or two. And Demo clusters (like Movr)
don't provide metrics data generated in the past (week or month ago).

To accomplish this, the following approach is implemented:
- intercept redux action METRIC RESPONSE which might or might not
contain data points for requested date range;
- if data range filled with all datapoints then it is nothing to
change and do not change action payload.
- if some data point is missing - they are fulfilled (by duplicating
most recent data point).

The implementation is not straight-forward because the main goal was to
avoid any impact on a production build. It means that there is
no test modules are imported with default build.

All changes in Webpack is isolated under `SIMULATE_METRICS_LOAD` env variable,
where all magic happens. With help of `StringReplacePlugin` we modify
`src/redux/state.ts` file:
- import statement is added for `fakeMetricsDataGenerationMiddleware`
module;
- added middleware to intercept redux actions.

Release note: none