### PR TITLE
kv: delay range merges after load based splits

### DIFF
--- a/pkg/kv/kvserver/replica_split_load.go
+++ b/pkg/kv/kvserver/replica_split_load.go
@@ -12,6 +12,7 @@ package kvserver
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -31,6 +32,13 @@ var SplitByLoadQPSThreshold = settings.RegisterPublicIntSetting(
 	"kv.range_split.load_qps_threshold",
 	"the QPS over which, the range becomes a candidate for load based splitting",
 	2500, // 2500 req/s
+)
+
+// SplitByLoadMergeDelay wraps "kv.range_split.by_load_merge_delay".
+var SplitByLoadMergeDelay = settings.RegisterNonNegativeDurationSetting(
+	"kv.range_split.by_load_merge_delay",
+	"the delay that range splits created due to load will wait before considering being merged away",
+	5*time.Minute,
 )
 
 // SplitByLoadQPSThreshold returns the QPS request rate for a given replica.


### PR DESCRIPTION
Fixes #41317.

In #41317, we saw that we are currently very aggressive about merging
away split points due to load-based splitting immediately after the load
is shut off. This can be an issue for benchmarking because splits
created during a ramp-up period are often merged away before the
workload begins running. This means that the system is not immediately
ready for the workload when it does begin running. I'm seeing this again
while automating the YCSB benchmark suite.

While it would be nice to maintain some load history for each range and
use that to avoid merging split points created due to load, that doesn't
seem like something we intend to do anytime soon. Meanwhile, we have
since fully stabilized the "sticky bit" on range descriptors, which
allows us to arbitrarily delay merges of a split point.

To make some progress here (~80% of the way), we introduce a new
`kv.range_split.by_load_merge_delay` cluster setting which controls he
delay that range splits created due to load will wait before considering
being merged away. This setting used to set the ExpirationTime on
load-based splits. Its value defaults to 5 minutes.

Release note (performance improvement): Range merges are now delays for
a short amount of time after load-based splitting to prevent load-based
split points from being merged away immediately after load is removed.