### PR TITLE
execgen: restore empty comment stripping

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/main.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/main.go
@@ -159,8 +159,6 @@ func (g *execgenTool) generate(path string, entry entry) error {
 			b = oldB
 			err = errors.Wrap(err, "Code formatting failed with Go parse error")
 		}
-	} else {
-		b = buf.Bytes()
 	}
 
 	// Ignore any write error if another error already occurred.


### PR DESCRIPTION
A previous commit accidentally removed empty comment stripping.

Release note: None