### PR TITLE
sql: fix unicode string truncation when casting

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -169,6 +169,11 @@ SELECT '{hello}'::VARCHAR(2)[]
 ----
 {he}
 
+query T
+SELECT '{hello, a🐛b🏠c}'::VARCHAR(2)[]
+----
+{he,a🐛}
+
 # array casting
 
 query T

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -263,6 +263,11 @@ SELECT 'a' COLLATE en::STRING || 'b'
 ----
 ab
 
+query T
+SELECT 'a🐛b🏠c' COLLATE en::VARCHAR(3)
+----
+a🐛b
+
 query B
 SELECT 't' COLLATE en::BOOLEAN
 ----

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
@@ -624,14 +625,14 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 			// If the string type specifies a limit we truncate to that limit:
 			//   'hello'::CHAR(2) -> 'he'
 			// This is true of all the string type variants.
-			if t.Width() > 0 && int(t.Width()) < len(s) {
-				s = s[:t.Width()]
+			if t.Width() > 0 {
+				s = util.TruncateString(s, int(t.Width()))
 			}
 			return NewDString(s), nil
 		case types.CollatedStringFamily:
 			// Ditto truncation like for TString.
-			if t.Width() > 0 && int(t.Width()) < len(s) {
-				s = s[:t.Width()]
+			if t.Width() > 0 {
+				s = util.TruncateString(s, int(t.Width()))
 			}
 			return NewDCollatedString(s, t.Locale(), &ctx.CollationEnv)
 		}

--- a/pkg/sql/sem/tree/testdata/eval/cast
+++ b/pkg/sql/sem/tree/testdata/eval/cast
@@ -378,6 +378,11 @@ eval
 'he'
 
 eval
+'a🐛b🏠c'::char(3)
+----
+e'a\U0001F41Bb'
+
+eval
 'hello'::bytes
 ----
 '\x68656c6c6f'
@@ -1043,6 +1048,11 @@ eval
 ARRAY['hello','world']::char(2)[]
 ----
 ARRAY['he','wo']
+
+eval
+ARRAY['a🐛b🏠c','def']::char(2)[]
+----
+ARRAY[e'a\U0001F41B','de']
 
 # regression for #45850
 eval

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -31,11 +31,36 @@ func GetSingleRune(s string) (rune, error) {
 	return r, nil
 }
 
-// ToLowerSingleByte returns the the lowercase of a given single ASCII byte.
+// ToLowerSingleByte returns the lowercase of a given single ASCII byte.
 // A non ASCII byte is returned unchanged.
 func ToLowerSingleByte(b byte) byte {
 	if b >= 'A' && b <= 'Z' {
 		return 'a' + (b - 'A')
 	}
 	return b
+}
+
+// TruncateString truncates a string to a given number of runes.
+func TruncateString(s string, maxRunes int) string {
+	// This is a fast path (len(s) is an upper bound for RuneCountInString).
+	if len(s) <= maxRunes {
+		return s
+	}
+	n := utf8.RuneCountInString(s)
+	if n <= maxRunes {
+		return s
+	}
+	// Fast path for ASCII strings.
+	if len(s) == n {
+		return s[:maxRunes]
+	}
+	i := 0
+	for pos := range s {
+		if i == maxRunes {
+			return s[:pos]
+		}
+		i++
+	}
+	// This code should be unreachable.
+	return s
 }

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -61,3 +61,29 @@ func TestToLowerSingleByte(t *testing.T) {
 		})
 	}
 }
+
+func TestTruncateString(t *testing.T) {
+	testCases := []struct {
+		s string
+		// res stores the expected results for maxRunes=0,1,2,3,etc.
+		res []string
+	}{
+		{"", []string{"", ""}},
+		{"abcd", []string{"", "a", "ab", "abc", "abcd", "abcd", "abcd"}},
+		{"🐛🏠", []string{"", "🐛", "🐛🏠", "🐛🏠", "🐛🏠"}},
+		{"a🐛b🏠c", []string{"", "a", "a🐛", "a🐛b", "a🐛b🏠", "a🐛b🏠c", "a🐛b🏠c"}},
+		{
+			// Test with an invalid UTF-8 sequence.
+			"\xf0\x90\x28\xbc",
+			[]string{"", "\xf0", "\xf0\x90", "\xf0\x90\x28", "\xf0\x90\x28\xbc", "\xf0\x90\x28\xbc"},
+		},
+	}
+
+	for _, tc := range testCases {
+		for i := range tc.res {
+			if r := TruncateString(tc.s, i); r != tc.res[i] {
+				t.Errorf("TruncateString(\"%q\", %d) = \"%q\"; expected \"%q\"", tc.s, i, r, tc.res[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
When casting to a width-limited string like `VARCHAR(2)`, we were truncating to
the given number of bytes. This is not correct for unicode strings - the
postgres semantics are to truncate to the given number of runes, not bytes.

This change fixes these casts.

Release note (bug fix): casting to width-limited strings now works correctly for
strings containing Unicode characters.