### PR TITLE
colexec: adjust the distribution of randomized batch size

### DIFF
--- a/pkg/sql/colexec/main_test.go
+++ b/pkg/sql/colexec/main_test.go
@@ -90,7 +90,21 @@ func generateBatchSize() int {
 	randomizeBatchSize := envutil.EnvOrDefaultBool("COCKROACH_RANDOMIZE_BATCH_SIZE", true)
 	if randomizeBatchSize {
 		rng, _ := randutil.NewPseudoRand()
-		return minBatchSize + rng.Intn(coldata.MaxBatchSize-minBatchSize)
+		// sizesToChooseFrom specifies some predetermined and one random sizes
+		// that we will choose from. Such distribution is chosen due to the
+		// fact that most of our unit tests don't have a lot of data, so in
+		// order to exercise the multi-batch behavior we favor really small
+		// batch sizes. On the other hand, we also want to occasionally
+		// exercise that we handle batch sizes larger than default one
+		// correctly.
+		var sizesToChooseFrom = []int{
+			minBatchSize,
+			minBatchSize + 1,
+			minBatchSize + 2,
+			coldata.BatchSize(),
+			minBatchSize + rng.Intn(coldata.MaxBatchSize-minBatchSize),
+		}
+		return sizesToChooseFrom[rng.Intn(len(sizesToChooseFrom))]
 	}
 	return coldata.BatchSize()
 }


### PR DESCRIPTION
This commit adjusts the distribution of randomized batch size to favor
the small sizes yet keeps the possibility of larger sizes as well. Such
distribution is chosen due to the fact that most of our unit tests
don't have a lot of data, so in order to exercise the multi-batch
behavior we favor really small batch sizes. On the other hand, we also
want to occasionally exercise that we handle batch sizes larger than
default one correctly.

Release note: None