### PR TITLE
release-19.2: sql: fix cast from string to array with width

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -173,6 +173,17 @@ SELECT '{hello, a🐛b🏠c}'::VARCHAR(2)[]
 ----
 {he,a🐛}
 
+# Regression test for #50132.
+statement ok
+CREATE TABLE hello (s STRING);
+INSERT INTO hello VALUES ('{hello}'), ('{hello,a🐛b🏠c}')
+
+query T rowsort
+SELECT s::VARCHAR(2)[] FROM hello
+----
+{he}
+{he,a🐛}
+
 # array casting
 
 query T

--- a/pkg/sql/sem/tree/testdata/eval/cast
+++ b/pkg/sql/sem/tree/testdata/eval/cast
@@ -1008,3 +1008,14 @@ eval
 '-10'::interval::decimal
 ----
 -10.000000000
+
+eval
+'{hello,a🐛b🏠c}'::VARCHAR(2)[]
+----
+ARRAY['he',e'a\U0001F41B']
+
+# Test the same cast, but not with a literal constant (see #50132).
+eval
+('{he' || ',a🐛b🏠}')::VARCHAR(2)[]
+----
+ARRAY['he',e'a\U0001F41B']


### PR DESCRIPTION
Backport 1/1 commits from #50153.

/cc @cockroachdb/release

---

The code that performs a cast from string to array doesn't take into account the
width of the string type it is producing. This doesn't show up when the input is
a literal constant because the constant is first parsed as an array of (vanilla)
strings which is then subjected to a cast (to array of strings with width).

Fixes #50132.

Release note (bug fix): Fixed some cases of casting a string to a width-limited
string array.
