### PR TITLE
kv/concurrency: clear lock holder in tryFreeLockOnReplicatedAcquire

### DIFF
--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_dropped
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_dropped
@@ -127,3 +127,74 @@ new: state=waitForDistinguished txn=txn1 key="a" held=true guard-access=read
 guard-state r=reqContendWriter
 ----
 new: state=waitFor txn=txn1 key="a" held=true guard-access=write
+
+clear
+----
+global: num=0
+local: num=0
+
+# ---------------------------------------------------------------------------------
+# Upgrading from unreplicated to replicated for an uncontended lock. The lockState
+# should be emptied and ignored by requests that have it in their tree snapshots.
+# Regression test against bug described in #50173.
+#
+# To test this, we sequence a read such that it blocks on a lock at key "a" first.
+# We then upgrade a key "b" from unreplicated to replicated, which should cause the
+# lock to be removed from the lock table. We release the lock at key "a" and watch
+# whether the read starts waiting on key "b". If it did, it would get stranded and
+# stall indefinitely.
+# ---------------------------------------------------------------------------------
+
+acquire r=req1 k=a durability=u
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [2]
+local: num=0
+
+new-txn txn=txn2 ts=10 epoch=0 seq=0
+----
+
+new-request r=req2 txn=txn2 ts=10 spans=w@b
+----
+
+acquire r=req2 k=b durability=u
+----
+global: num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [2]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+new-request r=req3 txn=none ts=10 spans=r@a,c
+----
+
+scan r=req3
+----
+start-waiting: true
+
+guard-state r=req3
+----
+new: state=waitForDistinguished txn=txn1 key="a" held=true guard-access=read
+
+acquire r=req2 k=b durability=r
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 0.000000010,0, info: unrepl epoch: 0, seqs: [2]
+   waiting readers:
+    req: 3, txn: none
+   distinguished req: 3
+local: num=0
+
+release txn=txn1 span=a
+----
+global: num=0
+local: num=0
+
+# Before the fix in #50173, this used to enter the following state:
+#  new: state=waitForDistinguished txn=txn2 key="b" held=true guard-access=read
+guard-state r=req3
+----
+new: state=doneWaiting


### PR DESCRIPTION
This commit fixes a fairly bad bug introduced by #49980. The bug was
that we were not clearing `lockState.holder` while under lock in
`tryFreeLockOnReplicatedAcquire`, so the lock was never marked as
"empty" (see `isEmptyLock`). This meant that even though we held the
`tree.mu` in `AcquireLock` continuously between the calls to
`tryFreeLockOnReplicatedAcquire` and `tree.Delete`, it was possible for
requests with existing snapshots of the tree to begin waiting on the
partially cleared **but not empty** `lockState`. We would then remove
the `lockState` from the lock table's main tree, abandoning any waiter
that managed to slip in and begin waiting on the removed `lockState`.
These waiters would eventually push the original holder of the lock, but
even after their push succeeded and they resolved the corresponding
intent, they would not receive any update on their lockTableGuard's
channel.

This should have been caught by some of the YCSB roachtests, but they
haven't actually run for the past week due to various CI flakes. It would
have also been caught by the new assertion the commit adds to
`lockState.lockIsFree`.