### PR TITLE
roachtest: add a tpcc test that uses interleaved tables

### DIFF
--- a/pkg/cmd/roachtest/overload_tpcc_olap.go
+++ b/pkg/cmd/roachtest/overload_tpcc_olap.go
@@ -43,7 +43,10 @@ type tpccOLAPSpec struct {
 }
 
 func (s tpccOLAPSpec) run(ctx context.Context, t *test, c *cluster) {
-	crdbNodes, workloadNode := setupTPCC(ctx, t, c, s.Warehouses, nil /* versions */)
+	crdbNodes, workloadNode := setupTPCC(
+		ctx, t, c, tpccOptions{
+			Warehouses: s.Warehouses, SetupType: usingFixture,
+		})
 	const queryFileName = "queries.sql"
 	// querybench expects the entire query to be on a single line.
 	queryLine := `"` + strings.Replace(tpccOlapQuery, "\n", " ", -1) + `"`

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -303,7 +303,7 @@ func makeIndexAddTpccTest(spec clusterSpec, warehouses int, length time.Duration
 				Warehouses: warehouses,
 				// We limit the number of workers because the default results in a lot
 				// of connections which can lead to OOM issues (see #40566).
-				Extra: fmt.Sprintf("--wait=false --tolerate-errors --workers=%d", warehouses),
+				ExtraRunArgs: fmt.Sprintf("--wait=false --tolerate-errors --workers=%d", warehouses),
 				During: func(ctx context.Context) error {
 					return runAndLogStmts(ctx, t, c, "addindex", []string{
 						`CREATE UNIQUE INDEX ON tpcc.order (o_entry_d, o_w_id, o_d_id, o_carrier_id, o_id);`,
@@ -311,7 +311,8 @@ func makeIndexAddTpccTest(spec clusterSpec, warehouses int, length time.Duration
 						`CREATE INDEX ON tpcc.customer (c_last, c_first);`,
 					})
 				},
-				Duration: length,
+				Duration:  length,
+				SetupType: usingFixture,
 			})
 		},
 		MinVersion: "v19.1.0",
@@ -417,7 +418,7 @@ func makeSchemaChangeDuringTPCC(spec clusterSpec, warehouses int, length time.Du
 				Warehouses: warehouses,
 				// We limit the number of workers because the default results in a lot
 				// of connections which can lead to OOM issues (see #40566).
-				Extra: fmt.Sprintf("--wait=false --tolerate-errors --workers=%d", warehouses),
+				ExtraRunArgs: fmt.Sprintf("--wait=false --tolerate-errors --workers=%d", warehouses),
 				During: func(ctx context.Context) error {
 					if t.IsBuildVersion(`v19.2.0`) {
 						if err := runAndLogStmts(ctx, t, c, "during-schema-changes-19.2", []string{
@@ -455,7 +456,8 @@ func makeSchemaChangeDuringTPCC(spec clusterSpec, warehouses int, length time.Du
 						`DROP TABLE tpcc.readytodrop CASCADE;`,
 					})
 				},
-				Duration: length,
+				Duration:  length,
+				SetupType: usingFixture,
 			})
 		},
 		MinVersion: "v19.1.0",

--- a/pkg/cmd/roachtest/scrub.go
+++ b/pkg/cmd/roachtest/scrub.go
@@ -52,8 +52,8 @@ func makeScrubTPCCTest(
 		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
-				Warehouses: warehouses,
-				Extra:      "--wait=false --tolerate-errors",
+				Warehouses:   warehouses,
+				ExtraRunArgs: "--wait=false --tolerate-errors",
 				During: func(ctx context.Context) error {
 					if !c.isLocal() {
 						// Wait until tpcc has been running for a few minutes to start SCRUB checks
@@ -81,7 +81,8 @@ func makeScrubTPCCTest(
 					}
 					return nil
 				},
-				Duration: length,
+				Duration:  length,
+				SetupType: usingFixture,
 			})
 		},
 		MinVersion: "v19.1.0",

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -34,12 +34,21 @@ import (
 	"github.com/lib/pq"
 )
 
+type tpccSetupType int
+
+const (
+	usingFixture tpccSetupType = iota
+	usingInit
+)
+
 type tpccOptions struct {
-	Warehouses int
-	Extra      string
-	Chaos      func() Chaos                // for late binding of stopper
-	During     func(context.Context) error // for running a function during the test
-	Duration   time.Duration
+	Warehouses     int
+	ExtraRunArgs   string
+	ExtraSetupArgs string
+	Chaos          func() Chaos                // for late binding of stopper
+	During         func(context.Context) error // for running a function during the test
+	Duration       time.Duration
+	SetupType      tpccSetupType
 
 	// The CockroachDB versions to deploy. The first one indicates the first node,
 	// etc. To use the main binary, specify "". When Versions is nil, it defaults
@@ -87,23 +96,23 @@ func tpccFixturesCmd(t *test, cloud string, warehouses int, extraArgs string) st
 }
 
 func setupTPCC(
-	ctx context.Context, t *test, c *cluster, warehouses int, versions []string,
+	ctx context.Context, t *test, c *cluster, opts tpccOptions,
 ) (crdbNodes, workloadNode nodeListOption) {
 	crdbNodes = c.Range(1, c.spec.NodeCount-1)
 	workloadNode = c.Node(c.spec.NodeCount)
 	if c.isLocal() {
-		warehouses = 1
+		opts.Warehouses = 1
 	}
 
-	if n := len(versions); n == 0 {
-		versions = make([]string, c.spec.NodeCount-1)
+	if n := len(opts.Versions); n == 0 {
+		opts.Versions = make([]string, c.spec.NodeCount-1)
 	} else if n != c.spec.NodeCount-1 {
-		t.Fatalf("must specify Versions for all %d nodes: %v", c.spec.NodeCount-1, versions)
+		t.Fatalf("must specify Versions for all %d nodes: %v", c.spec.NodeCount-1, opts.Versions)
 	}
 
 	{
 		var regularNodes []option
-		for i, v := range versions {
+		for i, v := range opts.Versions {
 			if v == "" {
 				regularNodes = append(regularNodes, c.Node(i+1))
 			} else {
@@ -132,8 +141,18 @@ func setupTPCC(
 		defer db.Close()
 		c.Start(ctx, t, crdbNodes, startArgsDontEncrypt)
 		waitForFullReplication(t, c.Conn(ctx, crdbNodes[0]))
-		t.Status("loading fixture")
-		c.Run(ctx, workloadNode, tpccFixturesCmd(t, cloud, warehouses, ""))
+		switch opts.SetupType {
+		case usingFixture:
+			t.Status("loading fixture")
+			c.Run(ctx, workloadNode, tpccFixturesCmd(t, cloud, opts.Warehouses, opts.ExtraSetupArgs))
+		case usingInit:
+			t.Status("initializing tables")
+			cmd := fmt.Sprintf("./workload init tpcc --warehouses=%d %s {pgurl:1}",
+				opts.Warehouses, opts.ExtraSetupArgs)
+			c.Run(ctx, workloadNode, cmd)
+		default:
+			t.Fatal("unknown tpcc setup type")
+		}
 		t.Status("")
 	}()
 	return crdbNodes, workloadNode
@@ -146,14 +165,14 @@ func runTPCC(ctx context.Context, t *test, c *cluster, opts tpccOptions) {
 		opts.Duration = time.Minute
 		rampDuration = 30 * time.Second
 	}
-	crdbNodes, workloadNode := setupTPCC(ctx, t, c, opts.Warehouses, opts.Versions)
+	crdbNodes, workloadNode := setupTPCC(ctx, t, c, opts)
 	t.Status("waiting")
 	m := newMonitor(ctx, c, crdbNodes)
 	m.Go(func(ctx context.Context) error {
 		t.WorkerStatus("running tpcc")
 		cmd := fmt.Sprintf(
 			"./workload run tpcc --warehouses=%d --histograms="+perfArtifactsDir+"/stats.json "+
-				opts.Extra+" --ramp=%s --duration=%s {pgurl:1-%d}",
+				opts.ExtraRunArgs+" --ramp=%s --duration=%s {pgurl:1-%d}",
 			opts.Warehouses, rampDuration, opts.Duration, c.spec.NodeCount-1)
 		c.Run(ctx, workloadNode, cmd)
 		return nil
@@ -234,6 +253,7 @@ func registerTPCC(r *testRegistry) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: headroomWarehouses,
 				Duration:   120 * time.Minute,
+				SetupType:  usingFixture,
 			})
 		},
 	})
@@ -267,6 +287,7 @@ func registerTPCC(r *testRegistry) {
 				Warehouses: headroomWarehouses,
 				Duration:   120 * time.Minute,
 				Versions:   []string{oldV, "", oldV, ""},
+				SetupType:  usingFixture,
 			})
 			// TODO(tbg): run another TPCC with the final binaries here and
 			// teach TPCC to re-use the dataset (seems easy enough) to at least
@@ -280,9 +301,10 @@ func registerTPCC(r *testRegistry) {
 		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
-				Warehouses: 1,
-				Duration:   10 * time.Minute,
-				Extra:      "--wait=false",
+				Warehouses:   1,
+				Duration:     10 * time.Minute,
+				ExtraRunArgs: "--wait=false",
+				SetupType:    usingFixture,
 			})
 		},
 	})
@@ -298,6 +320,7 @@ func registerTPCC(r *testRegistry) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: warehouses,
 				Duration:   6 * 24 * time.Hour,
+				SetupType:  usingFixture,
 			})
 		},
 	})
@@ -310,9 +333,9 @@ func registerTPCC(r *testRegistry) {
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			duration := 30 * time.Minute
 			runTPCC(ctx, t, c, tpccOptions{
-				Warehouses: 100,
-				Duration:   duration,
-				Extra:      "--wait=false --tolerate-errors",
+				Warehouses:   100,
+				Duration:     duration,
+				ExtraRunArgs: "--wait=false --tolerate-errors",
 				Chaos: func() Chaos {
 					return Chaos{
 						Timer: Periodic{
@@ -324,6 +347,26 @@ func registerTPCC(r *testRegistry) {
 						DrainAndQuit: false,
 					}
 				},
+				SetupType: usingFixture,
+			})
+		},
+	})
+	r.Add(testSpec{
+		Name:       "tpcc/interleaved/nodes=3/cpu=16/w=500",
+		Owner:      OwnerKV,
+		Cluster:    makeClusterSpec(4, cpu(16)),
+		MinVersion: "v20.1.0",
+		Timeout:    3 * time.Hour,
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runTPCC(ctx, t, c, tpccOptions{
+				// Currently, we do not support import on interleaved tables which
+				// prohibits loading/importing a fixture. If/when this is supported the
+				// number of warehouses should be increased as we would no longer
+				// bottleneck on initialization which is significantly slower than import.
+				Warehouses:     500,
+				Duration:       time.Minute * 15,
+				ExtraSetupArgs: fmt.Sprintf("--interleaved=true"),
+				SetupType:      usingInit,
 			})
 		},
 	})


### PR DESCRIPTION
Added a new roachtest to run tpcc on a 3 node, 16 cpu, 500 warehouse
configuration that uses interleaved tables.

Unlike other tpcc roachtests, a dataset containing interleaved tables
can not be loaded/imported; instead it must be initialized in every
test run. This is because interleaved tables do not support `IMPORT`.
As initializing is significantly slower than importing fixtures,
the setup phase of this test is particularly long.

Release note: None