### PR TITLE
geo/geogfn: use spheroid defined by SRID for geog calculations

### DIFF
--- a/pkg/geo/geogfn/distance.go
+++ b/pkg/geo/geogfn/distance.go
@@ -38,7 +38,10 @@ func Distance(
 	if err != nil {
 		return 0, err
 	}
-	spheroid := geographiclib.WGS84Spheroid
+	spheroid, err := a.Spheroid()
+	if err != nil {
+		return 0, err
+	}
 	return distanceGeographyRegions(spheroid, useSphereOrSpheroid, aRegions, bRegions, 0)
 }
 

--- a/pkg/geo/geogfn/distance_test.go
+++ b/pkg/geo/geogfn/distance_test.go
@@ -41,6 +41,13 @@ var distanceTestCases = []struct {
 		9124665.27317673,
 	},
 	{
+		"POINT to POINT (CDG to LAX) SRID=4004",
+		"SRID=4004;POINT(-118.4079 33.9434)",
+		"SRID=4004;POINT(2.5559 49.0083)",
+		9102062.53966977,
+		9123572.72696577,
+	},
+	{
 		"LINESTRING to POINT where POINT is on vertex",
 		"LINESTRING(2.0 2.0, 3.0 3.0)",
 		"POINT(3.0 3.0)",

--- a/pkg/geo/geogfn/dwithin.go
+++ b/pkg/geo/geogfn/dwithin.go
@@ -12,7 +12,6 @@ package geogfn
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/geo"
-	"github.com/cockroachdb/cockroach/pkg/geo/geographiclib"
 	"github.com/cockroachdb/errors"
 )
 
@@ -42,7 +41,10 @@ func DWithin(
 		}
 		return false, err
 	}
-	spheroid := geographiclib.WGS84Spheroid
+	spheroid, err := a.Spheroid()
+	if err != nil {
+		return false, err
+	}
 	maybeClosestDistance, err := distanceGeographyRegions(spheroid, useSphereOrSpheroid, aRegions, bRegions, distance)
 	if err != nil {
 		return false, err

--- a/pkg/geo/geogfn/segmentize.go
+++ b/pkg/geo/geogfn/segmentize.go
@@ -14,7 +14,6 @@ import (
 	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/geo"
-	"github.com/cockroachdb/cockroach/pkg/geo/geographiclib"
 	"github.com/cockroachdb/cockroach/pkg/geo/geosegmentize"
 	"github.com/cockroachdb/errors"
 	"github.com/golang/geo/s2"
@@ -37,7 +36,10 @@ func Segmentize(geography *geo.Geography, segmentMaxLength float64) (*geo.Geogra
 		if segmentMaxLength <= 0 {
 			return nil, errors.Newf("maximum segment length must be positive")
 		}
-		spheroid := geographiclib.WGS84Spheroid
+		spheroid, err := geography.Spheroid()
+		if err != nil {
+			return nil, err
+		}
 		// Convert segmentMaxLength to Angle with respect to earth sphere as
 		// further calculation is done considering segmentMaxLength as Angle.
 		segmentMaxAngle := segmentMaxLength / spheroid.SphereRadius

--- a/pkg/geo/geogfn/unary_operators_test.go
+++ b/pkg/geo/geogfn/unary_operators_test.go
@@ -55,6 +55,26 @@ var unaryOperatorTestCases = []struct {
 		},
 	},
 	{
+		wkt: "SRID=4004;LINESTRING(1.0 1.0, 2.0 2.0, 3.0 3.0)",
+		sphere: unaryOperatorExpectedResult{
+			expectedLength: 314367.99984330626,
+		},
+		spheroid: unaryOperatorExpectedResult{
+			expectedLength: 313672.2213232639,
+		},
+	},
+	{
+		wkt: "SRID=4004;POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 0.0))",
+		sphere: unaryOperatorExpectedResult{
+			expectedArea:      6181093937.160788,
+			expectedPerimeter: 379596.9916332415,
+		},
+		spheroid: unaryOperatorExpectedResult{
+			expectedArea:      6153550906.915973,
+			expectedPerimeter: 378753.30454341066,
+		},
+	},
+	{
 		wkt: "POLYGON((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 0.0), (0.1 0.1, 0.2 0.1, 0.2 0.2, 0.1 0.1))",
 		sphere: unaryOperatorExpectedResult{
 			expectedArea:      6120665080.445181,
@@ -225,17 +245,24 @@ func TestLength(t *testing.T) {
 func TestProject(t *testing.T) {
 	var testCases = []struct {
 		desc      string
-		point     *geom.Point
+		point     *geo.Geography
 		distance  float64
 		azimuth   float64
-		projected *geom.Point
+		projected *geo.Geography
 	}{
 		{
 			"POINT(0 0), 100000, radians(45)",
-			geom.NewPointFlat(geom.XY, []float64{0, 0}),
+			geo.MustNewGeographyFromGeom(geom.NewPointFlat(geom.XY, []float64{0, 0}).SetSRID(4326)),
 			100000,
 			45 * math.Pi / 180.0,
-			geom.NewPointFlat(geom.XY, []float64{0.6352310291255374, 0.6394723347291977}),
+			geo.MustNewGeographyFromGeom(geom.NewPointFlat(geom.XY, []float64{0.6352310291255374, 0.6394723347291977}).SetSRID(4326)),
+		},
+		{
+			"SRID=4004;POINT(0 0), 100000, radians(45)",
+			geo.MustNewGeographyFromGeom(geom.NewPointFlat(geom.XY, []float64{0, 0}).SetSRID(4004)),
+			100000,
+			45 * math.Pi / 180.0,
+			geo.MustNewGeographyFromGeom(geom.NewPointFlat(geom.XY, []float64{0.635304728143855, 0.6395336363116583}).SetSRID(4004)),
 		},
 	}
 
@@ -249,7 +276,8 @@ func TestProject(t *testing.T) {
 				projected,
 				"expected %f, found %f",
 				&tc.projected,
-				projected)
+				projected,
+			)
 		})
 	}
 }

--- a/pkg/geo/geoproj/geoproj.go
+++ b/pkg/geo/geoproj/geoproj.go
@@ -55,10 +55,10 @@ func GetProjMetadata(b geoprojbase.Proj4Text) (bool, *geographiclib.Spheroid, er
 	); err != nil {
 		return false, nil, errors.Newf("error from PROJ: %s", string(err))
 	}
-	// flattening = e^2 / 1 + sqrt(1+e^2).
+	// flattening = e^2 / 1 + sqrt(1-e^2).
 	// See: https://en.wikipedia.org/wiki/Eccentricity_(mathematics), derived from
 	// e = sqrt(f(2-f))
-	flattening := float64(eccentricitySquared) / (1 + math.Sqrt(float64(eccentricitySquared)))
+	flattening := float64(eccentricitySquared) / (1 + math.Sqrt(1-float64(eccentricitySquared)))
 	return isLatLng != 0, geographiclib.NewSpheroid(float64(majorAxis), flattening), nil
 }
 

--- a/pkg/geo/geoprojbase/projections.go
+++ b/pkg/geo/geoprojbase/projections.go
@@ -19,11 +19,11 @@ import (
 
 var (
 	spheroid1 = geographiclib.NewSpheroid(6.370997e+06, 0)
-	spheroid2 = geographiclib.NewSpheroid(6.378137e+06, 0.006188076572136892)
-	spheroid3 = geographiclib.NewSpheroid(6.378137e+06, 0.006188076601273604)
+	spheroid2 = geographiclib.NewSpheroid(6.378137e+06, 0.00335281066474748)
+	spheroid3 = geographiclib.NewSpheroid(6.378137e+06, 0.0033528106811823184)
 	spheroid4 = geographiclib.NewSpheroid(6.371228e+06, 0)
 	spheroid5 = geographiclib.NewSpheroid(6.378137e+06, 0)
-	spheroid6 = geographiclib.NewSpheroid(6.377397155e+06, 0.006170279914991346)
+	spheroid6 = geographiclib.NewSpheroid(6.377397155e+06, 0.003342773182174806)
 )
 
 // Projections is a mapping of SRID to projections.

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -1066,22 +1066,7 @@ Options is a flag that can be bitmasked. The options are:
 				distance := float64(*args[1].(*tree.DFloat))
 				azimuth := float64(*args[2].(*tree.DFloat))
 
-				geomT, err := g.AsGeomT()
-				if err != nil {
-					return nil, err
-				}
-
-				point, ok := geomT.(*geom.Point)
-				if !ok {
-					return nil, errors.Newf("ST_Project(geography) is only valid for point inputs")
-				}
-
-				projected, err := geogfn.Project(point, distance, s1.Angle(azimuth))
-				if err != nil {
-					return nil, err
-				}
-
-				geog, err := geo.NewGeographyFromGeom(projected)
+				geog, err := geogfn.Project(g.Geography, distance, s1.Angle(azimuth))
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
* Switch geo/geogfn functions to use the spheroid.
* Fixed the flattening generator - bug in my mathematics.

Release note: None