### PR TITLE
release-20.1: backupccl: properly clean up after failing to restore system data

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1330,7 +1330,13 @@ func TestRestoreFailCleanup(t *testing.T) {
 	// Disable GC job so that the final check of crdb_internal.tables is
 	// guaranteed to not be cleaned up. Although this was never observed by a
 	// stress test, it is here for safety.
-	params.Knobs.GCJob = &sql.GCJobTestingKnobs{RunBeforeResume: func(_ int64) error { select {} /* blocks forever */ }}
+	blockGC := make(chan struct{})
+	params.Knobs.GCJob = &sql.GCJobTestingKnobs{
+		RunBeforeResume: func(_ int64) error {
+			<-blockGC
+			return nil
+		},
+	}
 
 	const numAccounts = 1000
 	_, _, sqlDB, dir, cleanup := backupRestoreTestSetupWithParams(t, singleNode, numAccounts,


### PR DESCRIPTION
Backport 1/1 commits from #50003.

/cc @cockroachdb/release

---

Previously, if full cluster restore failed while restoring the system
table data, it would not clean up after itself properly and would leave
some temporary tables public and not dropped.

The job maintained a list of descriptors, and when dropping the tables
it ensures that the table descriptors have not been changed in the
meantime. However, restore did not update it's view of these tables when
it marks the tables public. This means that if there is a failure after
marking the table publics it will be surprised to find the table
descriptors have changed. This change ensures that the job updates its
internal tracking of the table descriptors when it makes them public.


Fixes #49921.


Release note (bug fix): Previously, if full cluster restore failed while
restoring the system table data, it would not clean up after itself
properly and would leave some temporary tables public and not dropped.
