### PR TITLE
kvserver: detail the range ID and replica details upon lease error

### DIFF
--- a/pkg/kv/kvserver/client_closed_timestamp_test.go
+++ b/pkg/kv/kvserver/client_closed_timestamp_test.go
@@ -96,7 +96,7 @@ func TestClosedTimestampWorksWhenRequestsAreSentToNonLeaseHolders(t *testing.T) 
 		target := tc.Target(serverIdx)
 		transferLease(repl.Desc(), target)
 		testutils.SucceedsSoon(t, func() error {
-			if !repl.OwnsValidLease(db1.Clock().Now()) {
+			if !repl.OwnsValidLease(ctx, db1.Clock().Now()) {
 				return errors.Errorf("don't yet have the lease")
 			}
 			return nil

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -443,7 +443,7 @@ func mergeCheckingTimestampCaches(t *testing.T, disjointLeaseholders bool) {
 			if err != nil {
 				return err
 			}
-			if !rhsRepl.OwnsValidLease(mtc.clock().Now()) {
+			if !rhsRepl.OwnsValidLease(ctx, mtc.clock().Now()) {
 				return errors.New("rhs store does not own valid lease for rhs range")
 			}
 			return nil
@@ -655,7 +655,7 @@ func TestStoreRangeMergeTimestampCacheCausality(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if !lhsRepl1.OwnsValidLease(mtc.clocks[1].Now()) {
+		if !lhsRepl1.OwnsValidLease(ctx, mtc.clocks[1].Now()) {
 			return errors.New("s2 does not own valid lease for lhs range")
 		}
 		return nil
@@ -2021,7 +2021,7 @@ func TestStoreRangeMergeSlowUnabandonedFollower_WithSplit(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if !rhsRepl.OwnsValidLease(mtc.clock().Now()) {
+		if !rhsRepl.OwnsValidLease(ctx, mtc.clock().Now()) {
 			return errors.New("rhs store does not own valid lease for rhs range")
 		}
 		return nil
@@ -2244,7 +2244,7 @@ func TestStoreRangeMergeAbandonedFollowersAutomaticallyGarbageCollected(t *testi
 		if err != nil {
 			return err
 		}
-		if !rhsRepl.OwnsValidLease(mtc.clock().Now()) {
+		if !rhsRepl.OwnsValidLease(ctx, mtc.clock().Now()) {
 			return errors.New("store2 does not own valid lease for rhs range")
 		}
 		return nil

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -2639,7 +2639,7 @@ func TestStoreCapacityAfterSplit(t *testing.T) {
 			cfg:                    &cfg},
 		stopper)
 
-	cap, err := s.Capacity(false /* useCached */)
+	cap, err := s.Capacity(context.Background(), false /* useCached */)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2666,7 +2666,7 @@ func TestStoreCapacityAfterSplit(t *testing.T) {
 		t.Fatal(pErr)
 	}
 
-	cap, err = s.Capacity(false /* useCached */)
+	cap, err = s.Capacity(context.Background(), false /* useCached */)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2704,7 +2704,7 @@ func TestStoreCapacityAfterSplit(t *testing.T) {
 		t.Fatal(pErr)
 	}
 
-	cap, err = s.Capacity(false /* useCached */)
+	cap, err = s.Capacity(context.Background(), false /* useCached */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/kvserver/protectedts/ptreconcile/reconciler.go
+++ b/pkg/kv/kvserver/protectedts/ptreconcile/reconciler.go
@@ -133,7 +133,7 @@ func (r *Reconciler) run(ctx context.Context, stopper *stop.Stopper) {
 }
 
 func (r *Reconciler) isMeta1Leaseholder(ctx context.Context, now hlc.Timestamp) (bool, error) {
-	return r.localStores.IsMeta1Leaseholder(now)
+	return r.localStores.IsMeta1Leaseholder(ctx, now)
 }
 
 func (r *Reconciler) reconcile(ctx context.Context) {

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -242,7 +242,7 @@ type replicaInQueue interface {
 	Desc() *roachpb.RangeDescriptor
 	maybeInitializeRaftGroup(context.Context)
 	redirectOnOrAcquireLease(context.Context) (kvserverpb.LeaseStatus, *roachpb.Error)
-	IsLeaseValid(roachpb.Lease, hlc.Timestamp) bool
+	IsLeaseValid(context.Context, roachpb.Lease, hlc.Timestamp) bool
 	GetLease() (roachpb.Lease, roachpb.Lease)
 }
 
@@ -643,7 +643,7 @@ func (bq *baseQueue) maybeAdd(ctx context.Context, repl replicaInQueue, now hlc.
 	if bq.needsLease {
 		// Check to see if either we own the lease or do not know who the lease
 		// holder is.
-		if lease, _ := repl.GetLease(); repl.IsLeaseValid(lease, now) &&
+		if lease, _ := repl.GetLease(); repl.IsLeaseValid(ctx, lease, now) &&
 			!lease.OwnedBy(repl.StoreID()) {
 			if log.V(1) {
 				log.Infof(ctx, "needs lease; not adding: %+v", lease)

--- a/pkg/kv/kvserver/queue_concurrency_test.go
+++ b/pkg/kv/kvserver/queue_concurrency_test.go
@@ -174,7 +174,7 @@ func (fr *fakeReplica) redirectOnOrAcquireLease(
 	// baseQueue only checks that the returned error is nil.
 	return kvserverpb.LeaseStatus{}, nil
 }
-func (fr *fakeReplica) IsLeaseValid(roachpb.Lease, hlc.Timestamp) bool { return true }
+func (fr *fakeReplica) IsLeaseValid(context.Context, roachpb.Lease, hlc.Timestamp) bool { return true }
 func (fr *fakeReplica) GetLease() (roachpb.Lease, roachpb.Lease) {
 	return roachpb.Lease{}, roachpb.Lease{}
 }

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1128,7 +1128,7 @@ func (r *Replica) checkExecutionCanProceedForRangeFeed(
 	now := r.Clock().Now()
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	status := r.leaseStatus(*r.mu.state.Lease, now, r.mu.minLeaseProposedTS)
+	status := r.leaseStatus(ctx, *r.mu.state.Lease, now, r.mu.minLeaseProposedTS)
 	if _, err := r.isDestroyedRLocked(); err != nil {
 		return err
 	} else if err := r.checkSpanInRangeRLocked(ctx, rSpan); err != nil {
@@ -1513,7 +1513,7 @@ func (r *Replica) maybeTransferRaftLeadershipLocked(ctx context.Context) {
 		return
 	}
 	lease := *r.mu.state.Lease
-	if lease.OwnedBy(r.StoreID()) || !r.isLeaseValidRLocked(lease, r.Clock().Now()) {
+	if lease.OwnedBy(r.StoreID()) || !r.isLeaseValidRLocked(ctx, lease, r.Clock().Now()) {
 		return
 	}
 	raftStatus := r.raftStatusRLocked()

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2381,7 +2381,7 @@ func (r *Replica) adminScatter(
 	// queue would do on its own (#17341), do so after the replicate queue is
 	// done by transferring the lease to any of the given N replicas with
 	// probability 1/N of choosing each.
-	if args.RandomizeLeases && r.OwnsValidLease(r.store.Clock().Now()) {
+	if args.RandomizeLeases && r.OwnsValidLease(ctx, r.store.Clock().Now()) {
 		desc := r.Desc()
 		// Learner replicas aren't allowed to become the leaseholder or raft leader,
 		// so only consider the `Voters` replicas.

--- a/pkg/kv/kvserver/replica_gossip.go
+++ b/pkg/kv/kvserver/replica_gossip.go
@@ -55,8 +55,8 @@ func (r *Replica) gossipFirstRange(ctx context.Context) {
 // shouldGossip returns true if this replica should be gossiping. Gossip is
 // inherently inconsistent and asynchronous, we're using the lease as a way to
 // ensure that only one node gossips at a time.
-func (r *Replica) shouldGossip() bool {
-	return r.OwnsValidLease(r.store.Clock().Now())
+func (r *Replica) shouldGossip(ctx context.Context) bool {
+	return r.OwnsValidLease(ctx, r.store.Clock().Now())
 }
 
 // MaybeGossipSystemConfig scans the entire SystemConfig span and gossips it.
@@ -86,7 +86,7 @@ func (r *Replica) MaybeGossipSystemConfig(ctx context.Context) error {
 			"not gossiping system config because the replica doesn't contain the system config's start key")
 		return nil
 	}
-	if !r.shouldGossip() {
+	if !r.shouldGossip(ctx) {
 		log.VEventf(ctx, 2, "not gossiping system config because the replica doesn't hold the lease")
 		return nil
 	}
@@ -143,7 +143,7 @@ func (r *Replica) MaybeGossipNodeLiveness(ctx context.Context, span roachpb.Span
 		return nil
 	}
 
-	if !r.ContainsKeyRange(span.Key, span.EndKey) || !r.shouldGossip() {
+	if !r.ContainsKeyRange(span.Key, span.EndKey) || !r.shouldGossip(ctx) {
 		return nil
 	}
 

--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -53,7 +53,7 @@ func (r *Replica) Metrics(
 ) ReplicaMetrics {
 	r.mu.RLock()
 	raftStatus := r.raftStatusRLocked()
-	leaseStatus := r.leaseStatus(*r.mu.state.Lease, now, r.mu.minLeaseProposedTS)
+	leaseStatus := r.leaseStatus(ctx, *r.mu.state.Lease, now, r.mu.minLeaseProposedTS)
 	quiescent := r.mu.quiescent || r.mu.internalRaftGroup == nil
 	desc := r.mu.state.Desc
 	zone := r.mu.zone

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -403,14 +403,14 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease, pe
 	// Gossip the first range whenever its lease is acquired. We check to make
 	// sure the lease is active so that a trailing replica won't process an old
 	// lease request and attempt to gossip the first range.
-	if leaseChangingHands && iAmTheLeaseHolder && r.IsFirstRange() && r.IsLeaseValid(newLease, r.store.Clock().Now()) {
+	if leaseChangingHands && iAmTheLeaseHolder && r.IsFirstRange() && r.IsLeaseValid(ctx, newLease, r.store.Clock().Now()) {
 		r.gossipFirstRange(ctx)
 	}
 
 	// Whenever we first acquire an expiration-based lease, notify the lease
 	// renewer worker that we want it to keep proactively renewing the lease
 	// before it expires.
-	if leaseChangingHands && iAmTheLeaseHolder && expirationBasedLease && r.IsLeaseValid(newLease, r.store.Clock().Now()) {
+	if leaseChangingHands && iAmTheLeaseHolder && expirationBasedLease && r.IsLeaseValid(ctx, newLease, r.store.Clock().Now()) {
 		r.store.renewableLeases.Store(int64(r.RangeID), unsafe.Pointer(r))
 		select {
 		case r.store.renewableLeasesSignal <- struct{}{}:

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1469,7 +1469,7 @@ func (r *Replica) maybeCampaignOnWakeLocked(ctx context.Context) {
 		return
 	}
 
-	leaseStatus := r.leaseStatus(*r.mu.state.Lease, r.store.Clock().Now(), r.mu.minLeaseProposedTS)
+	leaseStatus := r.leaseStatus(ctx, *r.mu.state.Lease, r.store.Clock().Now(), r.mu.minLeaseProposedTS)
 	raftStatus := r.mu.internalRaftGroup.Status()
 	if shouldCampaignOnWake(leaseStatus, *r.mu.state.Lease, r.store.StoreID(), raftStatus) {
 		log.VEventf(ctx, 3, "campaigning")

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -167,7 +167,7 @@ type quiescer interface {
 	hasRaftReadyRLocked() bool
 	hasPendingProposalsRLocked() bool
 	hasPendingProposalQuotaRLocked() bool
-	ownsValidLeaseRLocked(ts hlc.Timestamp) bool
+	ownsValidLeaseRLocked(ctx context.Context, ts hlc.Timestamp) bool
 	mergeInProgressRLocked() bool
 	isDestroyedRLocked() (DestroyReason, error)
 }
@@ -254,7 +254,7 @@ func shouldReplicaQuiesce(
 	// Only quiesce if this replica is the leaseholder as well;
 	// otherwise the replica which is the valid leaseholder may have
 	// pending commands which it's waiting on this leader to propose.
-	if !q.ownsValidLeaseRLocked(now) {
+	if !q.ownsValidLeaseRLocked(ctx, now) {
 		if log.V(4) {
 			log.Infof(ctx, "not quiescing: not leaseholder")
 		}

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -242,7 +242,7 @@ func (rq *replicateQueue) shouldQueue(
 	}
 
 	// If the lease is valid, check to see if we should transfer it.
-	if lease, _ := repl.GetLease(); repl.IsLeaseValid(lease, now) {
+	if lease, _ := repl.GetLease(); repl.IsLeaseValid(ctx, lease, now) {
 		if rq.canTransferLease() &&
 			rq.allocator.ShouldTransferLease(
 				ctx, zone, voterReplicas, lease.Replica.StoreID, repl.leaseholderStats) {

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -734,8 +734,8 @@ func (s *Store) sendQueuedHeartbeats(ctx context.Context) {
 	s.metrics.RaftCoalescedHeartbeatsPending.Update(int64(beatsSent))
 }
 
-func (s *Store) updateCapacityGauges() error {
-	desc, err := s.Descriptor(false /* useCached */)
+func (s *Store) updateCapacityGauges(ctx context.Context) error {
+	desc, err := s.Descriptor(ctx, false /* useCached */)
 	if err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -622,7 +622,7 @@ func shouldNotMoveAway(
 	now hlc.Timestamp,
 	minQPS float64,
 ) bool {
-	if !replWithStats.repl.OwnsValidLease(now) {
+	if !replWithStats.repl.OwnsValidLease(ctx, now) {
 		log.VEventf(ctx, 3, "store doesn't own the lease for r%d", replWithStats.repl.RangeID)
 		return true
 	}

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -667,8 +667,8 @@ func (s *Store) checkSnapshotOverlapLocked(
 				// leader of the range stops sending this replica heartbeats.
 				lease, pendingLease := r.GetLease()
 				now := s.Clock().Now()
-				return !r.IsLeaseValid(lease, now) &&
-					(pendingLease.Empty() || !r.IsLeaseValid(pendingLease, now))
+				return !r.IsLeaseValid(ctx, lease, now) &&
+					(pendingLease.Empty() || !r.IsLeaseValid(ctx, pendingLease, now))
 			}
 			// We unconditionally send this replica through the GC queue. It's
 			// reasonably likely that the GC queue will do nothing because the replica

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -3207,7 +3207,7 @@ func TestReserveSnapshotFullnessLimit(t *testing.T) {
 
 	ctx := context.Background()
 
-	desc, err := s.Descriptor(false /* useCached */)
+	desc, err := s.Descriptor(ctx, false /* useCached */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -61,7 +61,7 @@ func NewStores(ambient log.AmbientContext, clock *hlc.Clock) *Stores {
 
 // IsMeta1Leaseholder returns whether the specified stores owns
 // the meta1 lease. Returns an error if any.
-func (ls *Stores) IsMeta1Leaseholder(now hlc.Timestamp) (bool, error) {
+func (ls *Stores) IsMeta1Leaseholder(ctx context.Context, now hlc.Timestamp) (bool, error) {
 	repl, _, err := ls.GetReplicaForRangeID(1)
 	if roachpb.IsRangeNotFoundError(err) {
 		return false, nil
@@ -69,7 +69,7 @@ func (ls *Stores) IsMeta1Leaseholder(now hlc.Timestamp) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return repl.OwnsValidLease(now), nil
+	return repl.OwnsValidLease(ctx, now), nil
 }
 
 // GetStoreCount returns the number of stores this node is exporting.

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -444,7 +444,7 @@ func TestNodeStatusWritten(t *testing.T) {
 
 	expectedStoreStatuses := make(map[roachpb.StoreID]statuspb.StoreStatus)
 	if err := ts.node.stores.VisitStores(func(s *kvserver.Store) error {
-		desc, err := s.Descriptor(false /* useCached */)
+		desc, err := s.Descriptor(ctx, false /* useCached */)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -585,7 +585,7 @@ func TestStartNodeWithLocality(t *testing.T) {
 		}
 
 		if err := s.GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
-			desc, err := store.Descriptor(false /* useCached */)
+			desc, err := store.Descriptor(ctx, false /* useCached */)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -115,7 +115,7 @@ type sqlServerOptionalArgs struct {
 	// Used by executorConfig.
 	recorder *status.MetricsRecorder
 	// For the temporaryObjectCleaner.
-	isMeta1Leaseholder func(hlc.Timestamp) (bool, error)
+	isMeta1Leaseholder func(context.Context, hlc.Timestamp) (bool, error)
 	// DistSQL, lease management, and others want to know the node they're on.
 	nodeIDContainer *base.SQLIDContainer
 

--- a/pkg/server/server_systemlog_gc.go
+++ b/pkg/server/server_systemlog_gc.go
@@ -78,7 +78,7 @@ func (s *Server) gcSystemLog(
 		return timestampLowerBound, 0, err
 	}
 
-	if !repl.IsFirstRange() || !repl.OwnsValidLease(s.clock.Now()) {
+	if !repl.IsFirstRange() || !repl.OwnsValidLease(ctx, s.clock.Now()) {
 		return timestampLowerBound, 0, nil
 	}
 

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -368,7 +368,7 @@ func (s *statusServer) Allocator(
 						}
 						return true, err
 					}
-					if !rep.OwnsValidLease(store.Clock().Now()) {
+					if !rep.OwnsValidLease(ctx, store.Clock().Now()) {
 						return false, nil
 					}
 					allocatorSpans, err := store.AllocatorDryRun(ctx, rep)
@@ -391,7 +391,7 @@ func (s *statusServer) Allocator(
 				// Not found: continue.
 				continue
 			}
-			if !rep.OwnsValidLease(store.Clock().Now()) {
+			if !rep.OwnsValidLease(ctx, store.Clock().Now()) {
 				continue
 			}
 			allocatorSpans, err := store.AllocatorDryRun(ctx, rep)

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -79,7 +79,7 @@ var recordHistogramQuantiles = []quantile{
 // directly in order to simplify testing.
 type storeMetrics interface {
 	StoreID() roachpb.StoreID
-	Descriptor(bool) (*roachpb.StoreDescriptor, error)
+	Descriptor(context.Context, bool) (*roachpb.StoreDescriptor, error)
 	Registry() *metric.Registry
 }
 
@@ -457,7 +457,7 @@ func (mr *MetricsRecorder) GenerateNodeStatus(ctx context.Context) *statuspb.Nod
 		})
 
 		// Gather descriptor from store.
-		descriptor, err := mr.mu.stores[storeID].Descriptor(false /* useCached */)
+		descriptor, err := mr.mu.stores[storeID].Descriptor(ctx, false /* useCached */)
 		if err != nil {
 			log.Errorf(ctx, "Could not record status summaries: Store %d could not return descriptor, error: %s", storeID, err)
 			continue

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -89,7 +89,7 @@ func (fs fakeStore) StoreID() roachpb.StoreID {
 	return fs.storeID
 }
 
-func (fs fakeStore) Descriptor(_ bool) (*roachpb.StoreDescriptor, error) {
+func (fs fakeStore) Descriptor(_ context.Context, _ bool) (*roachpb.StoreDescriptor, error) {
 	return &fs.desc, nil
 }
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -575,7 +575,7 @@ func makeSQLServerArgs(
 			nodeDialer:   nodeDialer,
 			grpcServer:   dummyRPCServer,
 			recorder:     dummyRecorder,
-			isMeta1Leaseholder: func(timestamp hlc.Timestamp) (bool, error) {
+			isMeta1Leaseholder: func(_ context.Context, timestamp hlc.Timestamp) (bool, error) {
 				return false, errors.New("isMeta1Leaseholder is not available to secondary tenants")
 			},
 			nodeIDContainer: idContainer,

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -364,7 +364,7 @@ func cleanupSchemaObjects(
 }
 
 // isMeta1LeaseholderFunc helps us avoid an import into pkg/storage.
-type isMeta1LeaseholderFunc func(hlc.Timestamp) (bool, error)
+type isMeta1LeaseholderFunc func(context.Context, hlc.Timestamp) (bool, error)
 
 // TemporaryObjectCleaner is a background thread job that periodically
 // cleans up orphaned temporary objects by sessions which did not close
@@ -458,7 +458,7 @@ func (c *TemporaryObjectCleaner) doTemporaryObjectCleanup(
 
 	// We only want to perform the cleanup if we are holding the meta1 lease.
 	// This ensures only one server can perform the job at a time.
-	isLeaseholder, err := c.isMeta1LeaseholderFunc(c.db.Clock().Now())
+	isLeaseholder, err := c.isMeta1LeaseholderFunc(ctx, c.db.Clock().Now())
 	if err != nil {
 		return err
 	}

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -672,7 +672,7 @@ func (tc *TestCluster) FindRangeLeaseHolder(
 	if err != nil {
 		return roachpb.ReplicationTarget{}, err
 	}
-	if !replica.IsLeaseValid(lease, now) {
+	if !replica.IsLeaseValid(context.TODO(), lease, now) {
 		return roachpb.ReplicationTarget{}, errors.New("no valid lease")
 	}
 	replicaDesc := lease.Replica


### PR DESCRIPTION
This logging if it had been present, would have simplified the investigation on https://github.com/cockroachlabs/support/issues/482


Release note: None