### PR TITLE
opt: track regclass dependencies in views

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -717,3 +717,48 @@ ALTER TABLE abc DROP COLUMN b
 
 statement error pq: cannot drop column "c" because view "vabc" depends on it
 ALTER TABLE abc DROP COLUMN c
+
+# RegClass objects used in expressions should be added to view dependencies.
+statement ok
+CREATE TABLE toreg();
+CREATE VIEW vregclass AS SELECT 'toreg'::regclass
+
+statement error pq: cannot drop relation "toreg" because view "vregclass" depends on it
+DROP TABLE toreg;
+
+statement ok
+DROP VIEW vregclass;
+CREATE VIEW vregclass AS SELECT x FROM (SELECT CAST('toreg' AS regclass) AS x)
+
+statement error pq: cannot drop relation "toreg" because view "vregclass" depends on it
+DROP TABLE toreg;
+
+statement ok
+DROP VIEW vregclass;
+CREATE SEQUENCE s_reg;
+CREATE VIEW vregclass AS SELECT x FROM [SELECT 's_reg'::REGCLASS AS x]
+
+statement error pq: cannot drop sequence s_reg because other objects depend on it
+DROP SEQUENCE s_reg
+
+# RegClass dependencies should not be added if the RegClass expression contains
+# a variable.
+statement ok
+DROP VIEW vregclass;
+CREATE VIEW vregclass AS SELECT x::regclass FROM (SELECT 's_reg' AS x);
+DROP SEQUENCE s_reg;
+
+statement ok
+DROP VIEW vregclass;
+CREATE VIEW vregclass AS SELECT x::regclass FROM (SELECT 'does_not_exist' AS x);
+
+statement error pq: relation "does_not_exist" does not exist
+SELECT * FROM vregclass
+
+statement ok
+DROP VIEW vregclass;
+CREATE table tregclass();
+CREATE VIEW vregclass AS SELECT 1 FROM (SELECT 1) AS foo WHERE 'tregclass'::regclass = 'tregclass'::regclass;
+
+statement error pq: cannot drop relation "tregclass" because view "vregclass" depends on it
+DROP TABLE tregclass

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/exprgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
@@ -350,6 +351,28 @@ func (b *Builder) trackReferencedColumnForViews(col *scopeColumn) {
 				dep.ColumnOrdinals.Add(ord)
 			}
 			b.viewDeps[i] = dep
+		}
+	}
+}
+
+func (b *Builder) maybeTrackRegclassDependenciesForViews(texpr tree.TypedExpr) {
+	if b.trackViewDeps {
+		if texpr.ResolvedType() == types.RegClass {
+			// We do not add a dependency if the RegClass Expr contains variables,
+			// we cannot resolve the variables in this context. This matches Postgres
+			// behavior.
+			if !tree.ContainsVars(texpr) {
+				regclass, err := texpr.Eval(b.evalCtx)
+				if err != nil {
+					panic(err)
+				}
+				tn := tree.MakeUnqualifiedTableName(tree.Name(regclass.String()))
+				ds, _ := b.resolveDataSource(&tn, privilege.SELECT)
+
+				b.viewDeps = append(b.viewDeps, opt.ViewDep{
+					DataSource: ds,
+				})
+			}
 		}
 	}
 }

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -220,6 +220,8 @@ func (b *Builder) getColName(expr tree.SelectExpr) string {
 func (b *Builder) finishBuildScalar(
 	texpr tree.TypedExpr, scalar opt.ScalarExpr, inScope, outScope *scope, outCol *scopeColumn,
 ) (out opt.ScalarExpr) {
+	b.maybeTrackRegclassDependenciesForViews(texpr)
+
 	if outScope == nil {
 		return scalar
 	}


### PR DESCRIPTION
sql: Add logic for tracking regclass dependencies in views when used in scalar expressions.

Release note (sql change): RegClass expressions are now tracked as dependencies in views.
For example CREATE VIEW v AS SELECT 't'::regclass; will now add a dependency on table t for view v.