### PR TITLE
geo/geogfn: adding bounding box checks for geography

### DIFF
--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -438,6 +438,12 @@ func (g *Geography) AsS2(emptyBehavior EmptyBehavior) ([]s2.Region, error) {
 	return S2RegionsFromGeom(geomRepr, emptyBehavior)
 }
 
+// BoundingBoxIntersects returns whether the bounding box of the given geography
+// intersects with the other.
+func (g *Geography) BoundingBoxIntersects(o *Geography) bool {
+	return g.spatialObject.BoundingBox.Intersects(o.spatialObject.BoundingBox)
+}
+
 // isLinearRingCCW returns whether a given linear ring is counter clock wise.
 // See 2.07 of http://www.faqs.org/faqs/graphics/algorithms-faq/.
 // "Find the lowest vertex (or, if  there is more than one vertex with the same lowest coordinate,

--- a/pkg/geo/geogfn/covers.go
+++ b/pkg/geo/geogfn/covers.go
@@ -48,6 +48,10 @@ func Covers(a *geo.Geography, b *geo.Geography) (bool, error) {
 
 // covers is the internal calculation for Covers.
 func covers(a *geo.Geography, b *geo.Geography) (bool, error) {
+	if !a.BoundingBoxIntersects(b) {
+		return false, nil
+	}
+
 	// Ignore EMPTY regions in a.
 	aRegions, err := a.AsS2(geo.EmptyBehaviorOmit)
 	if err != nil {

--- a/pkg/geo/geogfn/intersects.go
+++ b/pkg/geo/geogfn/intersects.go
@@ -21,6 +21,9 @@ import (
 // This calculation is done on the sphere.
 // Precision of intersect measurements is up to 1cm.
 func Intersects(a *geo.Geography, b *geo.Geography) (bool, error) {
+	if !a.BoundingBoxIntersects(b) {
+		return false, nil
+	}
 	if a.SRID() != b.SRID() {
 		return false, geo.NewMismatchingSRIDsError(a, b)
 	}


### PR DESCRIPTION
Add bounding box intersection checks for geography builtins
(Covers/CoveredBy/Intersects). Thought we'd have to do some fancy math
for geography but judging by s2.Rect, I do not think that is the case.
Existing tests should cover whacky cases.

Release note: None