### PR TITLE
sql/catalog: generalize the lease manager to lease all descriptors

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -78,21 +78,21 @@ const (
 	// liveness record would be eagerly renewed after 2 seconds.
 	livenessRenewalFraction = 0.5
 
-	// DefaultTableDescriptorLeaseDuration is the default mean duration a
+	// DefaultDescriptorLeaseDuration is the default mean duration a
 	// lease will be acquired for. The actual duration is jittered using
 	// the jitter fraction. Jittering is done to prevent multiple leases
 	// from being renewed simultaneously if they were all acquired
 	// simultaneously.
-	DefaultTableDescriptorLeaseDuration = 5 * time.Minute
+	DefaultDescriptorLeaseDuration = 5 * time.Minute
 
-	// DefaultTableDescriptorLeaseJitterFraction is the default factor
+	// DefaultDescriptorLeaseJitterFraction is the default factor
 	// that we use to randomly jitter the lease duration when acquiring a
 	// new lease and the lease renewal timeout.
-	DefaultTableDescriptorLeaseJitterFraction = 0.05
+	DefaultDescriptorLeaseJitterFraction = 0.05
 
-	// DefaultTableDescriptorLeaseRenewalTimeout is the default time
+	// DefaultDescriptorLeaseRenewalTimeout is the default time
 	// before a lease expires when acquisition to renew the lease begins.
-	DefaultTableDescriptorLeaseRenewalTimeout = time.Minute
+	DefaultDescriptorLeaseRenewalTimeout = time.Minute
 )
 
 // DefaultHistogramWindowInterval returns the default rotation window for
@@ -549,27 +549,27 @@ func TempStorageConfigFromEnv(
 	}
 }
 
-// LeaseManagerConfig holds table lease manager parameters.
+// LeaseManagerConfig holds lease manager parameters.
 type LeaseManagerConfig struct {
-	// TableDescriptorLeaseDuration is the mean duration a lease will be
+	// DescriptorLeaseDuration is the mean duration a lease will be
 	// acquired for.
-	TableDescriptorLeaseDuration time.Duration
+	DescriptorLeaseDuration time.Duration
 
-	// TableDescriptorLeaseJitterFraction is the factor that we use to
+	// DescriptorLeaseJitterFraction is the factor that we use to
 	// randomly jitter the lease duration when acquiring a new lease and
 	// the lease renewal timeout.
-	TableDescriptorLeaseJitterFraction float64
+	DescriptorLeaseJitterFraction float64
 
-	// DefaultTableDescriptorLeaseRenewalTimeout is the default time
+	// DefaultDescriptorLeaseRenewalTimeout is the default time
 	// before a lease expires when acquisition to renew the lease begins.
-	TableDescriptorLeaseRenewalTimeout time.Duration
+	DescriptorLeaseRenewalTimeout time.Duration
 }
 
 // NewLeaseManagerConfig initializes a LeaseManagerConfig with default values.
 func NewLeaseManagerConfig() *LeaseManagerConfig {
 	return &LeaseManagerConfig{
-		TableDescriptorLeaseDuration:       DefaultTableDescriptorLeaseDuration,
-		TableDescriptorLeaseJitterFraction: DefaultTableDescriptorLeaseJitterFraction,
-		TableDescriptorLeaseRenewalTimeout: DefaultTableDescriptorLeaseRenewalTimeout,
+		DescriptorLeaseDuration:       DefaultDescriptorLeaseDuration,
+		DescriptorLeaseJitterFraction: DefaultDescriptorLeaseJitterFraction,
+		DescriptorLeaseRenewalTimeout: DefaultDescriptorLeaseRenewalTimeout,
 	}
 }

--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -62,12 +62,13 @@ func (c *rowFetcherCache) TableDescForKey(
 		}
 		// No caching of these are attempted, since the lease manager does its
 		// own caching.
-		tableDesc, _, err = c.leaseMgr.Acquire(ctx, ts, tableID)
+		desc, _, err := c.leaseMgr.Acquire(ctx, ts, tableID)
 		if err != nil {
 			// Manager can return all kinds of errors during chaos, but based on
 			// its usage, none of them should ever be terminal.
 			return nil, MarkRetryableError(err)
 		}
+		tableDesc = desc.(*sqlbase.ImmutableTableDescriptor)
 		// Immediately release the lease, since we only need it for the exact
 		// timestamp requested.
 		if err := c.leaseMgr.Release(tableDesc); err != nil {

--- a/pkg/sql/catalog/catalog.go
+++ b/pkg/sql/catalog/catalog.go
@@ -18,6 +18,21 @@ import (
 // Descriptor is an interface for retrieved catalog descriptors.
 type Descriptor = sqlbase.DescriptorInterface
 
+// MutableDescriptor represents a descriptor undergoing in-memory mutations
+// as part of a schema change.
+type MutableDescriptor interface {
+	Descriptor
+	// MaybeIncrementVersion sets the version of the descriptor to
+	// ClusterVersion.Version + 1.
+	// TODO (lucy): It's not a good idea to have callers handle incrementing the
+	// version manually. Find a better API for this. Maybe creating a new mutable
+	// descriptor should increment the version on the mutable copy from the
+	// outset.
+	MaybeIncrementVersion()
+	// Immutable returns an immutable copy of this descriptor.
+	Immutable() Descriptor
+}
+
 // VirtualSchemas is a collection of VirtualSchemas.
 type VirtualSchemas interface {
 	GetVirtualSchema(schemaName string) (VirtualSchema, bool)

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -360,7 +360,7 @@ func (tc *Collection) GetTableVersion(
 	// continue to use N to refer to X even if N is renamed during the
 	// transaction.
 	for _, table := range tc.leasedTables {
-		if lease.NameMatchesTable(&table.TableDescriptor, dbID, schemaID, tn.Table()) {
+		if lease.NameMatchesDescriptor(table, dbID, schemaID, tn.Table()) {
 			log.VEventf(ctx, 2, "found table in table collection for table '%s'", tn)
 			return table, nil
 		}
@@ -694,8 +694,8 @@ func (tc *Collection) getUncommittedTable(
 		}
 
 		// Do we know about a table with this name?
-		if lease.NameMatchesTable(
-			&mutTbl.TableDescriptor,
+		if lease.NameMatchesDescriptor(
+			mutTbl,
 			dbID,
 			schemaID,
 			tn.Table(),

--- a/pkg/sql/catalog/lease/helpers_test.go
+++ b/pkg/sql/catalog/lease/helpers_test.go
@@ -103,7 +103,7 @@ func (m *Manager) ExpireLeases(clock *hlc.Clock) {
 	past := clock.Now().GoTime().Add(-time.Millisecond)
 
 	m.tableNames.mu.Lock()
-	for _, table := range m.tableNames.tables {
+	for _, table := range m.tableNames.descriptors {
 		table.expiration = hlc.Timestamp{WallTime: past.UnixNano()}
 	}
 	m.tableNames.mu.Unlock()

--- a/pkg/sql/catalog/lease/helpers_test.go
+++ b/pkg/sql/catalog/lease/helpers_test.go
@@ -102,9 +102,9 @@ func (w *LeaseRemovalTracker) LeaseRemovedNotification(
 func (m *Manager) ExpireLeases(clock *hlc.Clock) {
 	past := clock.Now().GoTime().Add(-time.Millisecond)
 
-	m.tableNames.mu.Lock()
-	for _, table := range m.tableNames.descriptors {
+	m.names.mu.Lock()
+	for _, table := range m.names.descriptors {
 		table.expiration = hlc.Timestamp{WallTime: past.UnixNano()}
 	}
-	m.tableNames.mu.Unlock()
+	m.names.mu.Unlock()
 }

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -435,9 +435,7 @@ func (m *Manager) PublishMultiple(
 						descsToUpdate[id].Version, versions[id])
 				}
 
-				if err := descsToUpdate[id].MaybeIncrementVersion(ctx, txn, m.storage.settings); err != nil {
-					return err
-				}
+				descsToUpdate[id].MaybeIncrementVersion()
 				if err := descsToUpdate[id].ValidateTable(); err != nil {
 					return err
 				}

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -819,7 +820,7 @@ func TestLeaseAcquireAndReleaseConcurrently(t *testing.T) {
 								}
 							}
 						},
-						LeaseAcquiredEvent: func(_ sqlbase.TableDescriptor, _ error) {
+						LeaseAcquiredEvent: func(_ catalog.Descriptor, _ error) {
 							atomic.AddInt32(&leasesAcquiredCount, 1)
 							<-acquisitionBlock
 						},

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -129,7 +129,7 @@ func TestPurgeOldVersions(t *testing.T) {
 	serverParams := base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			SQLLeaseManager: &ManagerTestingKnobs{
-				TestingTableUpdateEvent: func(t *sqlbase.TableDescriptor) error {
+				TestingDescriptorUpdateEvent: func(_ *sqlbase.Descriptor) error {
 					gossipSem <- struct{}{}
 					<-gossipSem
 					return nil

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -499,9 +499,9 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 }
 
 // Test that there's no deadlock between AcquireByName and Release.
-// We used to have one due to lock inversion between the tableNameCache lock and
+// We used to have one due to lock inversion between the nameCache lock and
 // the descriptorVersionState lock, triggered when the same lease was Release()d after the
-// table had been dropped (which means it's removed from the tableNameCache) and
+// table had been dropped (which means it's removed from the nameCache) and
 // AcquireByName()d at the same time.
 func TestReleaseAcquireByNameDeadlock(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -531,7 +531,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	ctx := context.Background()
 	table, _, err := leaseManager.AcquireByName(
 		ctx,
-		leaseManager.clock.Now(),
+		leaseManager.storage.clock.Now(),
 		tableDesc.ParentID,
 		tableDesc.GetParentSchemaID(),
 		"test",
@@ -557,7 +557,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	}()
 
 	for i := 0; i < 50; i++ {
-		timestamp := leaseManager.clock.Now()
+		timestamp := leaseManager.storage.clock.Now()
 		ctx := context.Background()
 		table, _, err := leaseManager.AcquireByName(
 			ctx,
@@ -749,7 +749,7 @@ func TestLeaseAcquireAndReleaseConcurrently(t *testing.T) {
 		m *Manager,
 		acquireChan chan Result,
 	) {
-		table, e, err := m.Acquire(ctx, m.clock.Now(), descID)
+		table, e, err := m.Acquire(ctx, m.storage.clock.Now(), descID)
 		acquireChan <- Result{err: err, exp: e, table: table}
 	}
 

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -1199,7 +1199,7 @@ INSERT INTO t.timestamp VALUES ('a', 'b');
 
 // BenchmarkLeaseAcquireByNameCached benchmarks the AcquireByName
 // acquisition code path if a valid lease exists and is contained in
-// tableNameCache. In particular this benchmark is done with
+// nameCache. In particular this benchmark is done with
 // parallelism, which is important to also benchmark locking.
 func BenchmarkLeaseAcquireByNameCached(b *testing.B) {
 	defer leaktest.AfterTest(b)()
@@ -1220,7 +1220,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	tableName := tableDesc.Name
 	leaseManager := t.node(1)
 
-	// Acquire the lease so it is put into the tableNameCache.
+	// Acquire the lease so it is put into the nameCache.
 	_, _, err := leaseManager.AcquireByName(
 		context.Background(),
 		t.server.Clock().Now(),
@@ -2315,7 +2315,7 @@ func TestRangefeedUpdatesHandledProperlyInTheFaceOfRaces(t *testing.T) {
 	tdb1 := sqlutils.MakeSQLRunner(db1)
 	db2 := tc.ServerConn(1)
 
-	// Create a couple of tables.
+	// Create a couple of descriptors.
 	tdb1.Exec(t, "CREATE TABLE foo (i INT PRIMARY KEY)")
 
 	// Find the table ID for the table we'll be mucking with.

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
@@ -415,17 +416,17 @@ CREATE TABLE crdb_internal.leases (
 		ctx context.Context, p *planner, _ *sqlbase.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error,
 	) (err error) {
 		nodeID := tree.NewDInt(tree.DInt(int64(p.execCfg.NodeID.Get())))
-		p.LeaseMgr().VisitLeases(func(desc sqlbase.TableDescriptor, dropped bool, _ int, expiration tree.DTimestamp) (wantMore bool) {
-			if p.CheckAnyPrivilege(ctx, sqlbase.NewImmutableTableDescriptor(desc)) != nil {
+		p.LeaseMgr().VisitLeases(func(desc catalog.Descriptor, dropped bool, _ int, expiration tree.DTimestamp) (wantMore bool) {
+			if p.CheckAnyPrivilege(ctx, desc) != nil {
 				// TODO(ajwerner): inspect what type of error got returned.
 				return true
 			}
 
 			err = addRow(
 				nodeID,
-				tree.NewDInt(tree.DInt(int64(desc.ID))),
-				tree.NewDString(desc.Name),
-				tree.NewDInt(tree.DInt(int64(desc.ParentID))),
+				tree.NewDInt(tree.DInt(int64(desc.GetID()))),
+				tree.NewDString(desc.GetName()),
+				tree.NewDInt(tree.DInt(int64(desc.GetParentID()))),
 				&expiration,
 				tree.MakeDBool(tree.DBool(dropped)),
 			)

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -34,7 +34,8 @@ func (p *planner) renameDatabase(
 	ctx context.Context, oldDesc *sqlbase.ImmutableDatabaseDescriptor, newName string,
 ) error {
 	oldName := oldDesc.GetName()
-	newDesc := sqlbase.NewMutableDatabaseDescriptor(*oldDesc.DatabaseDesc())
+	newDesc := sqlbase.NewMutableExistingDatabaseDescriptor(*oldDesc.DatabaseDesc())
+	newDesc.Version++
 	newDesc.SetName(newName)
 	if err := newDesc.Validate(); err != nil {
 		return err

--- a/pkg/sql/gcjob/descriptor_utils.go
+++ b/pkg/sql/gcjob/descriptor_utils.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
@@ -29,7 +30,8 @@ func updateDescriptorGCMutations(
 ) error {
 	log.Infof(ctx, "updating GCMutations for table %d after removing index %d", table.ID, garbageCollectedIndexID)
 	// Remove the mutation from the table descriptor.
-	updateTableMutations := func(tbl *sqlbase.MutableTableDescriptor) error {
+	updateTableMutations := func(desc catalog.MutableDescriptor) error {
+		tbl := desc.(*sqlbase.MutableTableDescriptor)
 		for i := 0; i < len(tbl.GCMutations); i++ {
 			other := tbl.GCMutations[i]
 			if other.IndexID == garbageCollectedIndexID {

--- a/pkg/sql/pgwire_internal_test.go
+++ b/pkg/sql/pgwire_internal_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -73,9 +74,9 @@ func TestPGWireConnectionCloseReleasesLeases(t *testing.T) {
 	// table.
 	var leases int
 	lm.VisitLeases(func(
-		desc sqlbase.TableDescriptor, dropped bool, refCount int, expiration tree.DTimestamp,
+		desc catalog.Descriptor, dropped bool, refCount int, expiration tree.DTimestamp,
 	) (wantMore bool) {
-		if desc.ID == tableDesc.ID {
+		if desc.GetID() == tableDesc.ID {
 			leases++
 		}
 		return true
@@ -88,9 +89,9 @@ func TestPGWireConnectionCloseReleasesLeases(t *testing.T) {
 	testutils.SucceedsSoon(t, func() error {
 		var totalRefCount int
 		lm.VisitLeases(func(
-			desc sqlbase.TableDescriptor, dropped bool, refCount int, expiration tree.DTimestamp,
+			desc catalog.Descriptor, dropped bool, refCount int, expiration tree.DTimestamp,
 		) (wantMore bool) {
-			if desc.ID == tableDesc.ID {
+			if desc.GetID() == tableDesc.ID {
 				totalRefCount += refCount
 			}
 			return true

--- a/pkg/sql/rename_test.go
+++ b/pkg/sql/rename_test.go
@@ -209,9 +209,9 @@ CREATE TABLE test.t (a INT PRIMARY KEY);
 
 	var foundLease bool
 	s.LeaseManager().(*lease.Manager).VisitLeases(func(
-		desc sqlbase.TableDescriptor, dropped bool, refCount int, expiration tree.DTimestamp,
+		desc catalog.Descriptor, dropped bool, refCount int, expiration tree.DTimestamp,
 	) (wantMore bool) {
-		if desc.ID == tableDesc.ID && desc.Name == "t" {
+		if desc.GetID() == tableDesc.ID && desc.GetName() == "t" {
 			foundLease = true
 		}
 		return true

--- a/pkg/sql/rename_test.go
+++ b/pkg/sql/rename_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -122,14 +123,14 @@ func TestTxnCanStillResolveOldName(t *testing.T) {
 	// leases using the old name (an update with the new name but the original
 	// version is ignored by the leasing refresh mechanism).
 	renamed := make(chan interface{})
-	lmKnobs.TestingTableRefreshedEvent =
-		func(table *sqlbase.TableDescriptor) {
+	lmKnobs.TestingDescriptorRefreshedEvent =
+		func(descriptor *sqlbase.Descriptor) {
 			mu.Lock()
 			defer mu.Unlock()
-			if waitTableID != table.ID {
+			if waitTableID != descriptor.GetID() {
 				return
 			}
-			if table.Name == "t2" && table.Version == 2 {
+			if descriptor.GetName() == "t2" && descriptor.GetVersion() == 2 {
 				close(renamed)
 				waitTableID = 0
 			}

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/gcjob"
@@ -1335,7 +1336,8 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	upTableVersion = func() {
 		leaseMgr := s.LeaseManager().(*lease.Manager)
 		var version sqlbase.DescriptorVersion
-		if _, err := leaseMgr.Publish(ctx, id, func(table *sqlbase.MutableTableDescriptor) error {
+		if _, err := leaseMgr.Publish(ctx, id, func(desc catalog.MutableDescriptor) error {
+			table := desc.(*sqlbase.MutableTableDescriptor)
 			// Publish nothing; only update the version.
 			version = table.Version
 			return nil

--- a/pkg/sql/sqlbase/database_desc.go
+++ b/pkg/sql/sqlbase/database_desc.go
@@ -13,6 +13,7 @@ package sqlbase
 import (
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
@@ -104,6 +105,16 @@ func (desc *DatabaseDescriptor) TableDesc() *TableDescriptor {
 // TypeDesc implements the ObjectDescriptor interface.
 func (desc *DatabaseDescriptor) TypeDesc() *TypeDescriptor {
 	return nil
+}
+
+// GetParentID implements the BaseDescriptorInterface interface.
+func (desc *ImmutableDatabaseDescriptor) GetParentID() ID {
+	return keys.RootNamespaceID
+}
+
+// GetParentSchemaID implements the BaseDescriptorInterface interface.
+func (desc *ImmutableDatabaseDescriptor) GetParentSchemaID() ID {
+	return keys.RootNamespaceID
 }
 
 // NameResolutionResult implements the ObjectDescriptor interface.

--- a/pkg/sql/sqlbase/database_desc.go
+++ b/pkg/sql/sqlbase/database_desc.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
@@ -37,7 +38,7 @@ type ImmutableDatabaseDescriptor struct {
 type MutableDatabaseDescriptor struct {
 	ImmutableDatabaseDescriptor
 
-	ClusterVersion *DatabaseDescriptor
+	ClusterVersion *ImmutableDatabaseDescriptor
 }
 
 // NewInitialDatabaseDescriptor constructs a new DatabaseDescriptor for an
@@ -60,26 +61,24 @@ func NewInitialDatabaseDescriptorWithPrivileges(
 	})
 }
 
-func makeImmutableDatabaseDesc(desc DatabaseDescriptor) ImmutableDatabaseDescriptor {
+func makeImmutableDatabaseDescriptor(desc DatabaseDescriptor) ImmutableDatabaseDescriptor {
 	return ImmutableDatabaseDescriptor{DatabaseDescriptor: desc}
 }
 
 // NewImmutableDatabaseDescriptor makes a new database descriptor.
 func NewImmutableDatabaseDescriptor(desc DatabaseDescriptor) *ImmutableDatabaseDescriptor {
-	ret := makeImmutableDatabaseDesc(desc)
+	ret := makeImmutableDatabaseDescriptor(desc)
 	return &ret
 }
 
-// NewMutableDatabaseDescriptor creates a new MutableDatabaseDescriptor. The
-// version of the returned descriptor will be the successor of the descriptor
-// from which it was constructed.
-func NewMutableDatabaseDescriptor(mutationOf DatabaseDescriptor) *MutableDatabaseDescriptor {
-	mut := &MutableDatabaseDescriptor{
-		ImmutableDatabaseDescriptor: makeImmutableDatabaseDesc(*protoutil.Clone(&mutationOf).(*DatabaseDescriptor)),
-		ClusterVersion:              &mutationOf,
+// NewMutableExistingDatabaseDescriptor returns a MutableDatabaseDescriptor from the
+// given database descriptor with the cluster version also set to the descriptor.
+// This is for databases that already exist.
+func NewMutableExistingDatabaseDescriptor(desc DatabaseDescriptor) *MutableDatabaseDescriptor {
+	return &MutableDatabaseDescriptor{
+		ImmutableDatabaseDescriptor: makeImmutableDatabaseDescriptor(*protoutil.Clone(&desc).(*DatabaseDescriptor)),
+		ClusterVersion:              NewImmutableDatabaseDescriptor(desc),
 	}
-	mut.Version++
-	return mut
 }
 
 // TypeName returns the plain type of this descriptor.
@@ -158,4 +157,21 @@ func (desc *ImmutableDatabaseDescriptor) Validate() error {
 
 	// Validate the privilege descriptor.
 	return desc.Privileges.Validate(desc.GetID())
+}
+
+// MaybeIncrementVersion implements the MutableDescriptor interface.
+func (desc *MutableDatabaseDescriptor) MaybeIncrementVersion() {
+	// Already incremented, no-op.
+	if desc.Version == desc.ClusterVersion.Version+1 {
+		return
+	}
+	desc.Version++
+	desc.ModificationTime = hlc.Timestamp{}
+}
+
+// Immutable implements the MutableDescriptor interface.
+func (desc *MutableDatabaseDescriptor) Immutable() DescriptorInterface {
+	// TODO (lucy): Should the immutable descriptor constructors always make a
+	// copy, so we don't have to do it here?
+	return NewImmutableDatabaseDescriptor(*protoutil.Clone(desc.DatabaseDesc()).(*DatabaseDescriptor))
 }

--- a/pkg/sql/sqlbase/descriptor.go
+++ b/pkg/sql/sqlbase/descriptor.go
@@ -10,7 +10,10 @@
 
 package sqlbase
 
-import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
 
 // DescriptorInterface provides table information for results from a name
 // lookup.
@@ -44,10 +47,16 @@ type DescriptorInterface interface {
 type BaseDescriptorInterface interface {
 	tree.NameResolutionResult
 
-	GetPrivileges() *PrivilegeDescriptor
 	GetID() ID
-	TypeName() string
 	GetName() string
+
+	// Metadata for descriptor leasing.
+	GetVersion() DescriptorVersion
+	GetModificationTime() hlc.Timestamp
+	GetDrainingNames() []NameInfo
+
+	GetPrivileges() *PrivilegeDescriptor
+	TypeName() string
 	GetAuditMode() TableDescriptor_AuditMode
 
 	// DescriptorProto prepares this descriptor for serialization.

--- a/pkg/sql/sqlbase/descriptor.go
+++ b/pkg/sql/sqlbase/descriptor.go
@@ -49,6 +49,8 @@ type BaseDescriptorInterface interface {
 
 	GetID() ID
 	GetName() string
+	GetParentID() ID
+	GetParentSchemaID() ID
 
 	// Metadata for descriptor leasing.
 	GetVersion() DescriptorVersion

--- a/pkg/sql/sqlbase/schema_desc.go
+++ b/pkg/sql/sqlbase/schema_desc.go
@@ -10,7 +10,11 @@
 
 package sqlbase
 
-import "github.com/cockroachdb/cockroach/pkg/keys"
+import (
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+)
 
 // SchemaDescriptorInterface will eventually be called dbdesc.Descriptor.
 // It is implemented by ImmutableSchemaDescriptor.
@@ -42,11 +46,20 @@ type MutableSchemaDescriptor struct {
 	ClusterVersion *ImmutableSchemaDescriptor
 }
 
+// NewMutableExistingSchemaDescriptor returns a MutableSchemaDescriptor from the
+// given schema descriptor with the cluster version also set to the descriptor.
+// This is for schemas that already exist.
+func NewMutableExistingSchemaDescriptor(desc SchemaDescriptor) *MutableSchemaDescriptor {
+	return &MutableSchemaDescriptor{
+		ImmutableSchemaDescriptor: makeImmutableSchemaDescriptor(*protoutil.Clone(&desc).(*SchemaDescriptor)),
+		ClusterVersion:            NewImmutableSchemaDescriptor(desc),
+	}
+}
+
 // NewImmutableSchemaDescriptor makes a new Schema descriptor.
 func NewImmutableSchemaDescriptor(desc SchemaDescriptor) *ImmutableSchemaDescriptor {
-	return &ImmutableSchemaDescriptor{
-		SchemaDescriptor: desc,
-	}
+	m := makeImmutableSchemaDescriptor(desc)
+	return &m
 }
 
 func makeImmutableSchemaDescriptor(desc SchemaDescriptor) ImmutableSchemaDescriptor {
@@ -113,3 +126,20 @@ func (desc *ImmutableSchemaDescriptor) DescriptorProto() *Descriptor {
 
 // NameResolutionResult implements the ObjectDescriptor interface.
 func (desc *ImmutableSchemaDescriptor) NameResolutionResult() {}
+
+// MaybeIncrementVersion implements the MutableDescriptor interface.
+func (desc *MutableSchemaDescriptor) MaybeIncrementVersion() {
+	// Already incremented, no-op.
+	if desc.Version == desc.ClusterVersion.Version+1 {
+		return
+	}
+	desc.Version++
+	desc.ModificationTime = hlc.Timestamp{}
+}
+
+// Immutable implements the MutableDescriptor interface.
+func (desc *MutableSchemaDescriptor) Immutable() DescriptorInterface {
+	// TODO (lucy): Should the immutable descriptor constructors always make a
+	// copy, so we don't have to do it here?
+	return NewImmutableSchemaDescriptor(*protoutil.Clone(desc.SchemaDesc()).(*SchemaDescriptor))
+}

--- a/pkg/sql/sqlbase/schema_desc.go
+++ b/pkg/sql/sqlbase/schema_desc.go
@@ -10,6 +10,8 @@
 
 package sqlbase
 
+import "github.com/cockroachdb/cockroach/pkg/keys"
+
 // SchemaDescriptorInterface will eventually be called dbdesc.Descriptor.
 // It is implemented by ImmutableSchemaDescriptor.
 type SchemaDescriptorInterface interface {
@@ -63,6 +65,11 @@ func NewMutableCreatedSchemaDescriptor(desc SchemaDescriptor) *MutableSchemaDesc
 	return &MutableSchemaDescriptor{
 		ImmutableSchemaDescriptor: makeImmutableSchemaDescriptor(desc),
 	}
+}
+
+// GetParentSchemaID implements the BaseDescriptorInterface interface.
+func (desc *ImmutableSchemaDescriptor) GetParentSchemaID() ID {
+	return keys.RootNamespaceID
 }
 
 // GetAuditMode implements the DescriptorProto interface.

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1690,13 +1690,11 @@ func (desc *MutableTableDescriptor) allocateColumnFamilyIDs(columnNames map[stri
 	}
 }
 
-// MaybeIncrementVersion increments the version of a descriptor if necessary.
-func (desc *MutableTableDescriptor) MaybeIncrementVersion(
-	ctx context.Context, txn *kv.Txn, settings *cluster.Settings,
-) error {
+// MaybeIncrementVersion implements the MutableDescriptor interface.
+func (desc *MutableTableDescriptor) MaybeIncrementVersion() {
 	// Already incremented, no-op.
 	if desc.Version == desc.ClusterVersion.Version+1 {
-		return nil
+		return
 	}
 	desc.Version++
 
@@ -1704,9 +1702,6 @@ func (desc *MutableTableDescriptor) MaybeIncrementVersion(
 	// the version, and then, upon reading, use the MVCC timestamp to populate
 	// the ModificationTime.
 	desc.ModificationTime = hlc.Timestamp{}
-	log.Infof(ctx, "publish: descID=%d (%s) version=%d",
-		desc.ID, desc.Name, desc.Version)
-	return nil
 }
 
 // Validate validates that the table descriptor is well formed. Checks include

--- a/pkg/sql/sqlbase/table_desc.go
+++ b/pkg/sql/sqlbase/table_desc.go
@@ -23,7 +23,6 @@ var _ TableDescriptorInterface = (*MutableTableDescriptor)(nil)
 type TableDescriptorInterface interface {
 	BaseDescriptorInterface
 
-	GetParentID() ID
 	TableDesc() *TableDescriptor
 	FindColumnByName(name tree.Name) (*ColumnDescriptor, bool, error)
 }

--- a/pkg/sql/sqlbase/table_desc.go
+++ b/pkg/sql/sqlbase/table_desc.go
@@ -10,7 +10,10 @@
 
 package sqlbase
 
-import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+)
 
 var _ TableDescriptorInterface = (*ImmutableTableDescriptor)(nil)
 var _ TableDescriptorInterface = (*MutableTableDescriptor)(nil)
@@ -25,4 +28,11 @@ type TableDescriptorInterface interface {
 
 	TableDesc() *TableDescriptor
 	FindColumnByName(name tree.Name) (*ColumnDescriptor, bool, error)
+}
+
+// Immutable implements the MutableDescriptor interface.
+func (desc *MutableTableDescriptor) Immutable() DescriptorInterface {
+	// TODO (lucy): Should the immutable descriptor constructors always make a
+	// copy, so we don't have to do it here?
+	return NewImmutableTableDescriptor(*protoutil.Clone(desc.TableDesc()).(*TableDescriptor))
 }

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -266,9 +266,7 @@ func (p *planner) writeTableDescToBatch(
 		}
 	} else {
 		// Only increment the table descriptor version once in this transaction.
-		if err := tableDesc.MaybeIncrementVersion(ctx, p.txn, p.execCfg.Settings); err != nil {
-			return err
-		}
+		tableDesc.MaybeIncrementVersion()
 	}
 
 	if err := tableDesc.ValidateTable(); err != nil {

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -1130,7 +1130,7 @@ SELECT * from t.test WHERE k = 'test_key';
 func TestReacquireLeaseOnRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	advancement := 2 * base.DefaultTableDescriptorLeaseDuration
+	advancement := 2 * base.DefaultDescriptorLeaseDuration
 
 	var cmdFilters tests.CommandFilters
 	cmdFilters.AppendFilter(tests.CheckEndTxnTrigger, true)


### PR DESCRIPTION
This PR extends the lease manager to lease `catalog.Descriptors` in general. Details are in individual commits.