### PR TITLE
ui: remove compactor queue graphs

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
@@ -29,7 +29,6 @@ export default function (props: GraphDashboardProps) {
         <Metric name="cr.store.queue.raftlog.process.failure" title="Raft Log" nonNegativeRate />
         <Metric name="cr.store.queue.raftsnapshot.process.failure" title="Raft Snapshot" nonNegativeRate />
         <Metric name="cr.store.queue.tsmaintenance.process.failure" title="Time Series Maintenance" nonNegativeRate />
-        <Metric name="cr.store.compactor.compactions.failure" title="Compaction" nonNegativeRate />
       </Axis>
     </LineGraph>,
 
@@ -43,7 +42,6 @@ export default function (props: GraphDashboardProps) {
         <Metric name="cr.store.queue.raftlog.processingnanos" title="Raft Log" nonNegativeRate />
         <Metric name="cr.store.queue.raftsnapshot.processingnanos" title="Raft Snapshot" nonNegativeRate />
         <Metric name="cr.store.queue.tsmaintenance.processingnanos" title="Time Series Maintenance" nonNegativeRate />
-        <Metric name="cr.store.compactor.compactingnanos" title="Compaction" nonNegativeRate />
       </Axis>
     </LineGraph>,
 
@@ -118,17 +116,6 @@ export default function (props: GraphDashboardProps) {
       <Axis units={AxisUnits.Count} label="actions">
         <Metric name="cr.store.queue.tsmaintenance.process.success" title="Successful Actions / sec" nonNegativeRate />
         <Metric name="cr.store.queue.tsmaintenance.pending" title="Pending Actions" downsampleMax />
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Compaction Queue"
-      sources={storeSources}
-      tooltip={`The completed (or estimated) bytes of storage that were (or could be) reclaimed by forcing compactions.`}
-    >
-      <Axis units={AxisUnits.Bytes} label="bytes">
-        <Metric name="cr.store.compactor.suggestionbytes.compacted" title="Bytes compacted / sec" nonNegativeRate />
-        <Metric name="cr.store.compactor.suggestionbytes.queued" title="Queued bytes" downsampleMax />
       </Axis>
     </LineGraph>,
   ];


### PR DESCRIPTION
Remove the compactor queue graphs from the Admin UI. They were commonly
confused with storage-engine level compactions, and the compactor queue
itself will (after future work) no longer be used for Pebble
storage engines at all.

I left the underlying metrics, assuming they'll still be useful for
diangosing problems on nodes running with RocksDB.

Release note (admin ui change): The 'Queues' dashboard in the Admin UI
no longer shows a 'Compaction Queue' graph and the 'Queue Processing
Failures' and 'Queue Processing Times' graphs no longer include the
'Compaction' queue metrics because these were commonly confused.