### PR TITLE
sqlbase: collect types in table expressions for backup

### DIFF
--- a/pkg/ccl/backupccl/targets_test.go
+++ b/pkg/ccl/backupccl/targets_test.go
@@ -49,6 +49,8 @@ func TestDescriptorsMatchingTargets(t *testing.T) {
 		mkTyp := func(desc typDesc) sqlbase.Descriptor {
 			return *sqlbase.NewImmutableTypeDescriptor(desc).DescriptorProto()
 		}
+		typeExpr := "'hello'::@15 = 'hello'::@15"
+		typeArrExpr := "'hello'::@16 = 'hello'::@16"
 		descriptors = []sqlbase.Descriptor{
 			mkDB(0, "system"),
 			mkTable(tbDesc{ID: 1, Name: "foo", ParentID: 0}),
@@ -59,12 +61,84 @@ func TestDescriptorsMatchingTargets(t *testing.T) {
 			mkDB(5, "empty"),
 			// Create some user defined types and tables that reference them.
 			mkDB(7, "udts"),
+			// Type descriptors represent different kinds of types. ENUM means
+			// that the type descriptor references an enum type. ALIAS means that
+			// the descriptor is a type alias for an existing type. ALIAS is only
+			// used for managing the implicit array type for each user defined type.
+			// Every user defined type also has an ALIAS type that represents an
+			// array of the user defined type, and that is tracked by the ArrayTypeID
+			// field on the type descriptor.
 			mkTyp(sqlbase.TypeDescriptor{ParentID: 7, ID: 8, Name: "enum1", ArrayTypeID: 9, Kind: sqlbase.TypeDescriptor_ENUM}),
 			mkTyp(sqlbase.TypeDescriptor{ParentID: 7, ID: 9, Name: "_enum1", Kind: sqlbase.TypeDescriptor_ALIAS, Alias: types.MakeEnum(8, 9)}),
 			mkTable(sqlbase.TableDescriptor{ParentID: 7, ID: 10, Name: "enum_tbl", Columns: []sqlbase.ColumnDescriptor{{ID: 0, Type: types.MakeEnum(8, 9)}}}),
 			mkTable(sqlbase.TableDescriptor{ParentID: 7, ID: 11, Name: "enum_arr_tbl", Columns: []sqlbase.ColumnDescriptor{{ID: 0, Type: types.MakeArray(types.MakeEnum(8, 9))}}}),
 			mkTyp(sqlbase.TypeDescriptor{ParentID: 7, ID: 12, Name: "enum2", ArrayTypeID: 13, Kind: sqlbase.TypeDescriptor_ENUM}),
 			mkTyp(sqlbase.TypeDescriptor{ParentID: 7, ID: 13, Name: "_enum2", Kind: sqlbase.TypeDescriptor_ALIAS, Alias: types.MakeEnum(12, 13)}),
+			// Create some user defined types that are used in table expressions.
+			mkDB(14, "udts_expr"),
+			mkTyp(sqlbase.TypeDescriptor{ParentID: 14, ID: 15, Name: "enum1", ArrayTypeID: 16, Kind: sqlbase.TypeDescriptor_ENUM}),
+			mkTyp(sqlbase.TypeDescriptor{ParentID: 14, ID: 16, Name: "_enum1", Kind: sqlbase.TypeDescriptor_ALIAS, Alias: types.MakeEnum(15, 16)}),
+			// Create a table with a default expression.
+			mkTable(tbDesc{
+				ID:       17,
+				Name:     "def",
+				ParentID: 14,
+				Columns: []sqlbase.ColumnDescriptor{
+					{
+						Name:        "a",
+						DefaultExpr: &typeExpr,
+						Type:        types.Bool,
+					},
+				},
+			}),
+			// Create a table with a computed column.
+			mkTable(tbDesc{
+				ID:       18,
+				Name:     "comp",
+				ParentID: 14,
+				Columns: []sqlbase.ColumnDescriptor{
+					{
+						Name:        "a",
+						DefaultExpr: &typeExpr,
+						Type:        types.Bool,
+					},
+				},
+			}),
+			// Create a table with a partial index.
+			mkTable(tbDesc{
+				ID:       19,
+				Name:     "pi",
+				ParentID: 14,
+				Indexes: []sqlbase.IndexDescriptor{
+					{
+						Name:      "idx",
+						Predicate: typeExpr,
+					},
+				},
+			}),
+			// Create a table with a check expression.
+			mkTable(tbDesc{
+				ID:       20,
+				Name:     "checks",
+				ParentID: 14,
+				Checks: []*sqlbase.TableDescriptor_CheckConstraint{
+					{
+						Expr: typeExpr,
+					},
+				},
+			}),
+			mkTable(tbDesc{
+				ID:       21,
+				Name:     "def_arr",
+				ParentID: 14,
+				Columns: []sqlbase.ColumnDescriptor{
+					{
+						Name:        "a",
+						DefaultExpr: &typeArrExpr,
+						Type:        types.Bool,
+					},
+				},
+			}),
 		}
 	}
 
@@ -140,6 +214,12 @@ func TestDescriptorsMatchingTargets(t *testing.T) {
 		{"", "TABLE udts.enum_tbl", []string{"udts", "enum1", "_enum1", "enum_tbl"}, nil, ``},
 		// Backing up enum_arr_tbl should also pull in both the enum and its array type.
 		{"", "TABLE udts.enum_arr_tbl", []string{"udts", "enum1", "_enum1", "enum_arr_tbl"}, nil, ``},
+		// Test collecting expressions that are present in table expressions.
+		{"", "TABLE udts_expr.def", []string{"udts_expr", "enum1", "_enum1", "def"}, nil, ``},
+		{"", "TABLE udts_expr.def_arr", []string{"udts_expr", "enum1", "_enum1", "def_arr"}, nil, ``},
+		{"", "TABLE udts_expr.comp", []string{"udts_expr", "enum1", "_enum1", "comp"}, nil, ``},
+		{"", "TABLE udts_expr.pi", []string{"udts_expr", "enum1", "_enum1", "pi"}, nil, ``},
+		{"", "TABLE udts_expr.checks", []string{"udts_expr", "enum1", "_enum1", "checks"}, nil, ``},
 	}
 	searchPath := sessiondata.MakeSearchPath([]string{"public", "pg_catalog"})
 	for i, test := range tests {

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1197,19 +1197,139 @@ func (desc *TableDescriptor) maybeUpgradeToFamilyFormatVersion() bool {
 	return true
 }
 
+// ForEachExprStringInTableDesc runs a closure for each expression string
+// within a TableDescriptor. The closure takes in a string pointer so that
+// it can mutate the TableDescriptor if desired.
+func ForEachExprStringInTableDesc(desc *TableDescriptor, f func(expr *string) error) error {
+	// Helpers for each schema element type that can contain an expression.
+	doCol := func(c *ColumnDescriptor) error {
+		if c.HasDefault() {
+			if err := f(c.DefaultExpr); err != nil {
+				return err
+			}
+		}
+		if c.IsComputed() {
+			if err := f(c.ComputeExpr); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	doIndex := func(i *IndexDescriptor) error {
+		if i.IsPartial() {
+			return f(&i.Predicate)
+		}
+		return nil
+	}
+	doCheck := func(c *TableDescriptor_CheckConstraint) error {
+		return f(&c.Expr)
+	}
+
+	// Process columns.
+	for i := range desc.Columns {
+		if err := doCol(&desc.Columns[i]); err != nil {
+			return err
+		}
+	}
+
+	// Process indexes.
+	if err := doIndex(&desc.PrimaryIndex); err != nil {
+		return err
+	}
+	for i := range desc.Indexes {
+		if err := doIndex(&desc.Indexes[i]); err != nil {
+			return err
+		}
+	}
+
+	// Process checks.
+	for i := range desc.Checks {
+		if err := doCheck(desc.Checks[i]); err != nil {
+			return err
+		}
+	}
+
+	// Process all mutations.
+	for _, mut := range desc.Mutations {
+		if c := mut.GetColumn(); c != nil {
+			if err := doCol(c); err != nil {
+				return err
+			}
+		}
+		if i := mut.GetIndex(); i != nil {
+			if err := doIndex(i); err != nil {
+				return err
+			}
+		}
+		if c := mut.GetConstraint(); c != nil &&
+			c.ConstraintType == ConstraintToUpdate_CHECK {
+			if err := doCheck(&c.Check); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // GetAllReferencedTypeIDs returns all user defined type descriptor IDs that
-// this table references.
-func (desc *TableDescriptor) GetAllReferencedTypeIDs() IDs {
-	var result IDs
-	for _, c := range desc.Columns {
-		result = append(result, GetTypeDescriptorClosure(c.Type)...)
+// this table references. It takes in a function that returns the TypeDescriptor
+// with the desired ID.
+func (desc *TableDescriptor) GetAllReferencedTypeIDs(
+	getType func(ID) (*TypeDescriptor, error),
+) (IDs, error) {
+	// All serialized expressions within a table descriptor are serialized
+	// with type annotations as ID's, so this visitor will collect them all.
+	visitor := &tree.TypeCollectorVisitor{
+		IDs: make(map[uint32]struct{}),
+	}
+
+	addIDsInExpr := func(exprStr *string) error {
+		expr, err := parser.ParseExpr(*exprStr)
+		if err != nil {
+			return err
+		}
+		expr.Walk(visitor)
+		return nil
+	}
+
+	if err := ForEachExprStringInTableDesc(desc, addIDsInExpr); err != nil {
+		return nil, err
+	}
+
+	// For each of the collected type IDs in the table descriptor expressions,
+	// collect the closure of ID's referenced.
+	ids := make(map[ID]struct{})
+	for id := range visitor.IDs {
+		typDesc, err := getType(ID(id))
+		if err != nil {
+			return nil, err
+		}
+		for child := range typDesc.GetIDClosure() {
+			ids[child] = struct{}{}
+		}
+	}
+
+	// Now add all of the column types in the table.
+	addIDsInColumn := func(c *ColumnDescriptor) {
+		for id := range GetTypeDescriptorClosure(c.Type) {
+			ids[id] = struct{}{}
+		}
+	}
+	for i := range desc.Columns {
+		addIDsInColumn(&desc.Columns[i])
 	}
 	for _, mut := range desc.Mutations {
 		if c := mut.GetColumn(); c != nil {
-			result = append(result, GetTypeDescriptorClosure(c.Type)...)
+			addIDsInColumn(c)
 		}
 	}
-	return result
+
+	// Construct the output.
+	result := make(IDs, 0, len(ids))
+	for id := range ids {
+		result = append(result, id)
+	}
+	return result, nil
 }
 
 func (desc *MutableTableDescriptor) initIDs() {


### PR DESCRIPTION
This PR ensures that user defined types within table descriptors are
included within backups. Specifically, the case where a user defined
types is used in an expression, but is not the resulting type of the
expression is fixed here.

Release note: None