### PR TITLE
logictest: introduce new configs for experimental distsql planning

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -412,6 +412,8 @@ type testClusterConfig struct {
 	overrideVectorize string
 	// if non-empty, overrides the default automatic statistics mode.
 	overrideAutoStats string
+	// if non-empty, overrides the default experimental DistSQL planning mode.
+	overrideExperimentalDistSQLPlanning string
 	// if set, queries using distSQL processors or vectorized operators that can
 	// fall back to disk do so immediately, using only their disk-based
 	// implementation.
@@ -468,13 +470,6 @@ var logicTestConfigs = []testClusterConfig{
 		overrideVectorize: "201auto",
 	},
 	{
-		name:                "fakedist",
-		numNodes:            3,
-		useFakeSpanResolver: true,
-		overrideDistSQLMode: "on",
-		overrideAutoStats:   "false",
-	},
-	{
 		name:                "local-mixed-19.2-20.1",
 		numNodes:            1,
 		overrideDistSQLMode: "off",
@@ -482,6 +477,20 @@ var logicTestConfigs = []testClusterConfig{
 		bootstrapVersion:    roachpb.Version{Major: 19, Minor: 2},
 		binaryVersion:       roachpb.Version{Major: 20, Minor: 1},
 		disableUpgrade:      true,
+	},
+	{
+		name:                                "local-spec-planning",
+		numNodes:                            1,
+		overrideDistSQLMode:                 "off",
+		overrideAutoStats:                   "false",
+		overrideExperimentalDistSQLPlanning: "on",
+	},
+	{
+		name:                "fakedist",
+		numNodes:            3,
+		useFakeSpanResolver: true,
+		overrideDistSQLMode: "on",
+		overrideAutoStats:   "false",
 	},
 	{
 		name:                "fakedist-vec-off",
@@ -528,6 +537,14 @@ var logicTestConfigs = []testClusterConfig{
 		skipShort:           true,
 	},
 	{
+		name:                                "fakedist-spec-planning",
+		numNodes:                            3,
+		useFakeSpanResolver:                 true,
+		overrideDistSQLMode:                 "on",
+		overrideAutoStats:                   "false",
+		overrideExperimentalDistSQLPlanning: "on",
+	},
+	{
 		name:                "5node",
 		numNodes:            5,
 		overrideDistSQLMode: "on",
@@ -564,6 +581,13 @@ var logicTestConfigs = []testClusterConfig{
 		overrideAutoStats:   "false",
 		sqlExecUseDisk:      true,
 		skipShort:           true,
+	},
+	{
+		name:                                "5node-spec-planning",
+		numNodes:                            5,
+		overrideDistSQLMode:                 "on",
+		overrideAutoStats:                   "false",
+		overrideExperimentalDistSQLPlanning: "on",
 	},
 	{
 		name:     "3node-tenant",
@@ -618,6 +642,7 @@ var (
 		"5node-vec-disk-auto",
 		"5node-metadata",
 		"5node-disk",
+		"5node-spec-planning",
 	}
 	defaultConfig         = parseTestConfig(defaultConfigNames)
 	fiveNodeDefaultConfig = parseTestConfig(fiveNodeDefaultConfigNames)
@@ -1345,6 +1370,14 @@ func (t *logicTest) setup(cfg testClusterConfig, serverArgs TestServerArgs) {
 			// See #37751 for details.
 			if _, err := conn.Exec(
 				"SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false",
+			); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if cfg.overrideExperimentalDistSQLPlanning != "" {
+			if _, err := conn.Exec(
+				"SET CLUSTER SETTING sql.defaults.experimental_distsql_planning = $1::string", cfg.overrideExperimentalDistSQLPlanning,
 			); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -1,4 +1,4 @@
-# LogicTest: local local-vec-off local-vec-auto
+# LogicTest: local local-vec-off local-vec-auto local-spec-planning
 
 statement ok
 CREATE TABLE t (a INT PRIMARY KEY)

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze_plans
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze_plans
@@ -1,4 +1,4 @@
-# LogicTest: 5node
+# LogicTest: 5node 5node-spec-planning
 
 # These tests are different from explain_analyze because they require manual
 # data placement.


### PR DESCRIPTION
This commit adds three new configurations `local-exp-planning`,
`fakedist-exp-planning`, and `5node-exp-planning` which override
`experimental_distsql_planning` cluster setting to `on`. The
corresponding config is included in `5node-defaults` list. And once
the new factory is significantly implemented, it will probably make
sense to add the configs to `default-configs`.

Release note: None