### PR TITLE
cli: show client-server latency on startup of interactive sql connection

### DIFF
--- a/pkg/cli/nodelocal.go
+++ b/pkg/cli/nodelocal.go
@@ -112,7 +112,7 @@ func uploadFile(conn *sqlConn, reader io.Reader, destination string) error {
 		return err
 	}
 
-	nodeID, _, _, err := conn.getServerMetadata()
+	nodeID, _, _, _, err := conn.getServerMetadata()
 	if err != nil {
 		return errors.Wrap(err, "unable to get node id")
 	}


### PR DESCRIPTION
Previously, we did not show client-server latency for interactive sql
connections. Now, a line is printed at the top when an interactive sql
session begins which prints the client-server latency. Latency is
measured by the time it takes the "get cluster version" query to return.

Addresses #49450

Release note (cli change): cli now prints the client-server latency on
startup.