### PR TITLE
ui: fix a bug with DistSQL info on Statements page

### DIFF
--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -268,7 +268,7 @@ export class StatementDetails extends React.Component<StatementDetailsProps, Sta
     if (!this.props.statement) {
       return null;
     }
-    const { stats, statement, app, opt, failed, implicit_txn } = this.props.statement;
+    const { stats, statement, app, distSQL, opt, failed, implicit_txn } = this.props.statement;
 
     if (!stats) {
       const sourceApp = getMatchParamByName(this.props.match, appAttr);
@@ -351,7 +351,7 @@ export class StatementDetails extends React.Component<StatementDetailsProps, Sta
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
                   <h4 className={summaryCardStylesCx("summary--card__item--label")}>Distributed execution?</h4>
-                  <p className={summaryCardStylesCx("summary--card__item--value")}>{ renderBools(opt) }</p>
+                  <p className={summaryCardStylesCx("summary--card__item--value")}>{ renderBools(distSQL) }</p>
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
                   <h4 className={summaryCardStylesCx("summary--card__item--label")}>Used cost-based optimizer?</h4>


### PR DESCRIPTION
Release note (bug fix): Statements page of Admin UI previously was
incorrectly displaying the information about whether the statement was
distributed or not (it was always `Yes`).