### PR TITLE
kv: Replace multiTestContext with TestCluster in consistency_queue_test

### DIFF
--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
@@ -34,8 +33,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,29 +43,42 @@ import (
 // process ranges whose replicas are not all live.
 func TestConsistencyQueueRequiresLive(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sc := kvserver.TestStoreConfig(nil)
-	sc.Clock = nil // manual clock
-	mtc := &multiTestContext{storeConfig: &sc}
-	defer mtc.Stop()
-	mtc.Start(t, 3)
+	manualClock := hlc.NewManualClock(timeutil.Now().UnixNano())
+	clock := hlc.NewClock(manualClock.UnixNano, 10)
+	interval := time.Second * 5
+	live := true
+	testStart := clock.Now()
 
-	// Replicate the range to three nodes.
-	repl := mtc.stores[0].LookupReplica(roachpb.RKeyMin)
-	rangeID := repl.RangeID
-	mtc.replicateRange(rangeID, 1, 2)
+	// Move time by the interval, so we run the job again.
+	manualClock.Increment(interval.Nanoseconds())
 
-	// Verify that queueing is immediately possible.
-	if shouldQ, priority := mtc.stores[0].ConsistencyQueueShouldQueue(
-		context.Background(), mtc.clock().Now(), repl, config.NewSystemConfig(sc.DefaultZoneConfig)); !shouldQ {
+	desc := &roachpb.RangeDescriptor{
+		InternalReplicas: []roachpb.ReplicaDescriptor{
+			{NodeID: 1, StoreID: 1, ReplicaID: 1},
+			{NodeID: 2, StoreID: 1, ReplicaID: 2},
+			{NodeID: 3, StoreID: 1, ReplicaID: 3},
+		},
+	}
+
+	getQueueLastProcessed := func(ctx context.Context) (hlc.Timestamp, error) {
+		return testStart, nil
+	}
+
+	isNodeLive := func(nodeID roachpb.NodeID) (bool, error) {
+		return live, nil
+	}
+
+	if shouldQ, priority := kvserver.ConsistencyQueueShouldQueue(
+		context.Background(), clock.Now(), desc, getQueueLastProcessed, isNodeLive,
+		false, interval); !shouldQ {
 		t.Fatalf("expected shouldQ true; got %t, %f", shouldQ, priority)
 	}
 
-	// Stop a node and expire leases.
-	mtc.stopStore(2)
-	mtc.advanceClock(context.Background())
+	live = false
 
-	if shouldQ, priority := mtc.stores[0].ConsistencyQueueShouldQueue(
-		context.Background(), mtc.clock().Now(), repl, config.NewSystemConfig(sc.DefaultZoneConfig)); shouldQ {
+	if shouldQ, priority := kvserver.ConsistencyQueueShouldQueue(
+		context.Background(), clock.Now(), desc, getQueueLastProcessed, isNodeLive,
+		false, interval); shouldQ {
 		t.Fatalf("expected shouldQ false; got %t, %f", shouldQ, priority)
 	}
 }
@@ -77,16 +89,22 @@ func TestConsistencyQueueRequiresLive(t *testing.T) {
 func TestCheckConsistencyMultiStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	const numStores = 3
-	mtc := &multiTestContext{}
-	defer mtc.Stop()
-	mtc.Start(t, numStores)
-	// Setup replication of range 1 on store 0 to stores 1 and 2.
-	mtc.replicateRange(1, 1, 2)
+	tc := testcluster.StartTestCluster(t, 3,
+		base.TestClusterArgs{
+			ReplicationMode: base.ReplicationAuto,
+		},
+	)
+
+	defer tc.Stopper().Stop(context.Background())
+	ts := tc.Servers[0]
+	store, pErr := ts.Stores().GetStore(ts.GetFirstStoreID())
+	if pErr != nil {
+		t.Fatal(pErr)
+	}
 
 	// Write something to the DB.
 	putArgs := putArgs([]byte("a"), []byte("b"))
-	if _, err := kv.SendWrapped(context.Background(), mtc.stores[0].TestSender(), putArgs); err != nil {
+	if _, err := kv.SendWrapped(context.Background(), store.TestSender(), putArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -98,8 +116,8 @@ func TestCheckConsistencyMultiStore(t *testing.T) {
 			EndKey: []byte("aa"),
 		},
 	}
-	if _, err := kv.SendWrappedWith(context.Background(), mtc.stores[0].TestSender(), roachpb.Header{
-		Timestamp: mtc.stores[0].Clock().Now(),
+	if _, err := kv.SendWrappedWith(context.Background(), store.TestSender(), roachpb.Header{
+		Timestamp: store.Clock().Now(),
 	}, &checkArgs); err != nil {
 		t.Fatal(err)
 	}
@@ -122,13 +140,10 @@ func TestCheckConsistencyReplay(t *testing.T) {
 	}
 	state.applies = map[applyKey]int{}
 
-	var mtc *multiTestContext
-	ctx := context.Background()
-	storeCfg := kvserver.TestStoreConfig(nil /* clock */)
-
+	testKnobs := kvserver.StoreTestingKnobs{}
 	// Arrange to count the number of times each checksum command applies to each
 	// store.
-	storeCfg.TestingKnobs.TestingApplyFilter = func(args kvserverbase.ApplyFilterArgs) (int, *roachpb.Error) {
+	testKnobs.TestingApplyFilter = func(args kvserverbase.ApplyFilterArgs) (int, *roachpb.Error) {
 		state.Lock()
 		defer state.Unlock()
 		if ccr := args.ComputeChecksum; ccr != nil {
@@ -138,31 +153,45 @@ func TestCheckConsistencyReplay(t *testing.T) {
 	}
 
 	// Arrange to trigger a retry when a ComputeChecksum request arrives.
-	storeCfg.TestingKnobs.TestingResponseFilter = func(
+	testKnobs.TestingResponseFilter = func(
 		ctx context.Context, ba roachpb.BatchRequest, br *roachpb.BatchResponse,
 	) *roachpb.Error {
 		state.Lock()
 		defer state.Unlock()
 		if ba.IsSingleComputeChecksumRequest() && !state.forcedRetry {
 			state.forcedRetry = true
-			return roachpb.NewError(errors.New(magicMultiTestContextKVTransportError))
+			// We need to return a retryable error from the perspective of the sender
+			return roachpb.NewError(&roachpb.NotLeaseHolderError{})
 		}
 		return nil
 	}
 
-	mtc = &multiTestContext{storeConfig: &storeCfg}
-	defer mtc.Stop()
-	mtc.Start(t, 2)
+	tc := testcluster.StartTestCluster(t, 2,
+		base.TestClusterArgs{
+			ReplicationMode: base.ReplicationAuto,
+			ServerArgs: base.TestServerArgs{
+				Knobs: base.TestingKnobs{
+					Store: &testKnobs,
+				},
+			},
+		},
+	)
 
-	mtc.replicateRange(roachpb.RangeID(1), 1)
+	defer tc.Stopper().Stop(context.Background())
 
+	ts := tc.Servers[0]
+	store, pErr := ts.Stores().GetStore(ts.GetFirstStoreID())
+	if pErr != nil {
+		t.Fatal(pErr)
+	}
 	checkArgs := roachpb.CheckConsistencyRequest{
 		RequestHeader: roachpb.RequestHeader{
 			Key:    []byte("a"),
 			EndKey: []byte("b"),
 		},
 	}
-	if _, err := kv.SendWrapped(ctx, mtc.Store(0).TestSender(), &checkArgs); err != nil {
+
+	if _, err := kv.SendWrapped(context.Background(), store.TestSender(), &checkArgs); err != nil {
 		t.Fatal(err)
 	}
 	// Check that the request was evaluated twice (first time when forcedRetry was
@@ -182,46 +211,24 @@ func TestCheckConsistencyReplay(t *testing.T) {
 func TestCheckConsistencyInconsistent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	sc := kvserver.TestStoreConfig(nil)
-	sc.Clock = nil // manual clock
-	mtc := &multiTestContext{
-		storeConfig: &sc,
-		// This test was written before the multiTestContext started creating many
-		// system ranges at startup, and hasn't been update to take that into
-		// account.
-		startWithSingleRange: true,
-	}
-
 	const numStores = 3
+	testKnobs := kvserver.StoreTestingKnobs{}
 
-	dir, cleanup := testutils.TempDir(t)
-	defer cleanup()
-	cache := storage.NewRocksDBCache(1 << 20)
-	defer cache.Release()
-
-	// Use on-disk stores because we want to take a RocksDB checkpoint and be
-	// able to find it.
-	for i := 0; i < numStores; i++ {
-		eng, err := storage.NewRocksDB(storage.RocksDBConfig{
-			StorageConfig: base.StorageConfig{
-				Dir: filepath.Join(dir, fmt.Sprintf("%d", i)),
-			},
-		}, cache)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer eng.Close()
-		mtc.engines = append(mtc.engines, eng)
-	}
+	var tc *testcluster.TestCluster
 
 	// s1 will report a diff with inconsistent key "e", and only s2 has that
 	// write (s3 agrees with s1).
 	diffKey := []byte("e")
 	var diffTimestamp hlc.Timestamp
 	notifyReportDiff := make(chan struct{}, 1)
-	sc.TestingKnobs.ConsistencyTestingKnobs.BadChecksumReportDiff =
+	testKnobs.ConsistencyTestingKnobs.BadChecksumReportDiff =
 		func(s roachpb.StoreIdent, diff kvserver.ReplicaSnapshotDiffSlice) {
-			if s != *mtc.Store(0).Ident {
+			ts := tc.Servers[0]
+			store, pErr := ts.Stores().GetStore(ts.GetFirstStoreID())
+			if pErr != nil {
+				t.Fatal(pErr)
+			}
+			if s != *store.Ident {
 				t.Errorf("BadChecksumReportDiff called from follower (StoreIdent = %v)", s)
 				return
 			}
@@ -234,7 +241,8 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 				t.Errorf("diff = %v", d)
 			}
 
-			diff[0].Timestamp.Logical = 987 // mock this out for a consistent string below
+			// mock this out for a consistent string below.
+			diff[0].Timestamp = hlc.Timestamp{Logical: 987, WallTime: 123}
 
 			act := diff.String()
 
@@ -254,26 +262,58 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 		}
 	// s2 (index 1) will panic.
 	notifyFatal := make(chan struct{}, 1)
-	sc.TestingKnobs.ConsistencyTestingKnobs.OnBadChecksumFatal = func(s roachpb.StoreIdent) {
-		if s != *mtc.Store(1).Ident {
+	testKnobs.ConsistencyTestingKnobs.OnBadChecksumFatal = func(s roachpb.StoreIdent) {
+		ts := tc.Servers[1]
+		store, pErr := ts.Stores().GetStore(ts.GetFirstStoreID())
+		if pErr != nil {
+			t.Fatal(pErr)
+		}
+		if s != *store.Ident {
 			t.Errorf("OnBadChecksumFatal called from %v", s)
 			return
 		}
 		notifyFatal <- struct{}{}
 	}
 
-	defer mtc.Stop()
-	mtc.Start(t, numStores)
-	// Setup replication of range 1 on store 0 to stores 1 and 2.
-	mtc.replicateRange(1, 1, 2)
+	dir, cleanup := testutils.TempDir(t)
+	defer cleanup()
 
+	serverArgsPerNode := make(map[int]base.TestServerArgs)
+	for i := 0; i < numStores; i++ {
+		testServerArgs := base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Store: &testKnobs,
+			},
+			StoreSpecs: []base.StoreSpec{
+				{
+					Path:     filepath.Join(dir, fmt.Sprintf("%d", i)),
+					InMemory: false,
+				},
+			},
+		}
+		serverArgsPerNode[i] = testServerArgs
+	}
+
+	tc = testcluster.StartTestCluster(t, numStores,
+		base.TestClusterArgs{
+			ReplicationMode:   base.ReplicationAuto,
+			ServerArgsPerNode: serverArgsPerNode,
+		},
+	)
+	defer tc.Stopper().Stop(context.Background())
+
+	ts := tc.Servers[0]
+	store, pErr := ts.Stores().GetStore(ts.GetFirstStoreID())
+	if pErr != nil {
+		t.Fatal(pErr)
+	}
 	// Write something to the DB.
 	pArgs := putArgs([]byte("a"), []byte("b"))
-	if _, err := kv.SendWrapped(context.Background(), mtc.stores[0].TestSender(), pArgs); err != nil {
+	if _, err := kv.SendWrapped(context.Background(), store.TestSender(), pArgs); err != nil {
 		t.Fatal(err)
 	}
 	pArgs = putArgs([]byte("c"), []byte("d"))
-	if _, err := kv.SendWrapped(context.Background(), mtc.stores[0].TestSender(), pArgs); err != nil {
+	if _, err := kv.SendWrapped(context.Background(), store.TestSender(), pArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -286,7 +326,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 			},
 			Mode: roachpb.ChecksumMode_CHECK_VIA_QUEUE,
 		}
-		resp, err := kv.SendWrapped(context.Background(), mtc.stores[0].TestSender(), &checkArgs)
+		resp, err := kv.SendWrapped(context.Background(), store.TestSender(), &checkArgs)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -294,7 +334,12 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 	}
 
 	checkpoints := func(nodeIdx int) []string {
-		pat := filepath.Join(mtc.engines[nodeIdx].GetAuxiliaryDir(), "checkpoints") + "/*"
+		testServer := tc.Servers[nodeIdx]
+		testStore, pErr := testServer.Stores().GetStore(testServer.GetFirstStoreID())
+		if pErr != nil {
+			t.Fatal(pErr)
+		}
+		pat := filepath.Join(testStore.Engine().GetAuxiliaryDir(), "checkpoints") + "/*"
 		m, err := filepath.Glob(pat)
 		assert.NoError(t, err)
 		return m
@@ -318,11 +363,16 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 	}
 
 	// Write some arbitrary data only to store 1. Inconsistent key "e"!
+	ts1 := tc.Servers[1]
+	store1, pErr := ts1.Stores().GetStore(ts1.GetFirstStoreID())
+	if pErr != nil {
+		t.Fatal(pErr)
+	}
 	var val roachpb.Value
 	val.SetInt(42)
-	diffTimestamp = mtc.stores[1].Clock().Now()
+	diffTimestamp = ts.Clock().Now()
 	if err := storage.MVCCPut(
-		context.Background(), mtc.stores[1].Engine(), nil, diffKey, diffTimestamp, val, nil,
+		context.Background(), store1.Engine(), nil, diffKey, diffTimestamp, val, nil,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -345,11 +395,12 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 	for i := 0; i < numStores; i++ {
 		cps := checkpoints(i)
 		assert.Len(t, cps, 1)
-		cpEng, err := storage.NewRocksDB(storage.RocksDBConfig{
-			StorageConfig: base.StorageConfig{
+		cpEng, err := storage.NewDefaultEngine(
+			1<<20,
+			base.StorageConfig{
 				Dir: cps[0],
 			},
-		}, cache)
+		)
 		assert.NoError(t, err)
 		defer cpEng.Close()
 
@@ -368,7 +419,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 	assert.Contains(t, resp.Result[0].Detail, `stats`)
 
 	// A death rattle should have been written on s2 (store index 1).
-	eng := mtc.stores[1].Engine()
+	eng := store1.Engine()
 	f, err := eng.Open(base.PreventedStartupFile(eng.GetAuxiliaryDir()))
 	require.NoError(t, err)
 	b, err := ioutil.ReadAll(f)


### PR DESCRIPTION
Makes progress on #8299

multiTestContext is legacy construct that is deprecated in favor of running tests via TestCluster. This is one PR out of many to remove the usage of multiTestContext in the consistency_queue test cases.

Release note : None