### PR TITLE
roachtest: skip rotten cancel/tpcc test

### DIFF
--- a/pkg/cmd/roachtest/cancel.go
+++ b/pkg/cmd/roachtest/cancel.go
@@ -35,6 +35,7 @@ import (
 func registerCancel(r *testRegistry) {
 	runCancel := func(ctx context.Context, t *test, c *cluster,
 		queries []string, warehouses int, useDistsql bool) {
+		t.Skip("skipping flaky cancel/tpcc test", "test needs to be updated see https://github.com/cockroachdb/cockroach/issues/42103")
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Put(ctx, workload, "./workload", c.All())
 		c.Start(ctx, t, c.All())


### PR DESCRIPTION
This test is pretty flaky due to a number of reasons. It fails pretty noisiliy
so skip it until we fix the underlying causes. Fixing this test is tracked in
https://github.com/cockroachdb/cockroach/issues/42103

Release note: None