### PR TITLE
testutils: fix rotten comment "storage" to "kvserver"

### DIFF
--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -149,7 +149,7 @@ type TestServerInterface interface {
 	GetFirstStoreID() roachpb.StoreID
 
 	// GetStores returns the collection of stores from this TestServer's node.
-	// The return value is of type *storage.Stores.
+	// The return value is of type *kvserver.Stores.
 	GetStores() interface{}
 
 	// ClusterSettings returns the ClusterSettings shared by all components of


### PR DESCRIPTION
Release note: None