### PR TITLE
ui: Hide Network Latency nav link for single node cluster

### DIFF
--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -402,3 +402,8 @@ export const partitionedStatuses = createSelector(
     );
   },
 );
+
+export const isSingleNodeCluster = createSelector(
+  nodeStatusesSelector,
+  nodeStatuses => nodeStatuses && nodeStatuses.length === 1,
+);

--- a/pkg/ui/src/views/app/components/layoutSidebar/layoutSidebar.spec.tsx
+++ b/pkg/ui/src/views/app/components/layoutSidebar/layoutSidebar.spec.tsx
@@ -1,0 +1,52 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { shallow } from "enzyme";
+import { createMemoryHistory, History } from "history";
+import { match as Match } from "react-router";
+import { assert } from "chai";
+import "src/enzymeInit";
+import { Sidebar } from "./index";
+
+describe("LayoutSidebar", () => {
+  let history: History;
+  let match: Match;
+
+  beforeEach(() => {
+    history = createMemoryHistory();
+    match = {
+      isExact: true,
+      params: {},
+      path: "/reports/network",
+      url: "",
+    };
+  });
+
+  it("does not show Network Latency link for single node cluster", () => {
+    const wrapper = shallow(<Sidebar
+      history={history}
+      match={match}
+      location={history.location}
+      isSingleNodeCluster={true}
+    />);
+    assert.isFalse(wrapper.findWhere(w => w.prop("to") === "/reports/network").exists());
+  });
+
+  it("shows Network Latency link for multi node cluster", () => {
+    const wrapper = shallow(<Sidebar
+      history={history}
+      match={match}
+      location={history.location}
+      isSingleNodeCluster={false}
+    />);
+    assert.isTrue(wrapper.findWhere(w => w.prop("to") === "/reports/network").exists());
+  });
+});


### PR DESCRIPTION
Resolves #46327

Network Latency page is useful when cluster has more than one node.
In case it is single node cluster - link to Network Latency page
can be hidden.

Before, Network Latency link has been available, and now it is
hidden in case only one node in cluster.

Release note (admin ui change): Sidebar navigation panel doesn't have
Network Latency menu for single node cluster.

![84775088-6bda5b80-afe7-11ea-9dce-884918bf1e60](https://user-images.githubusercontent.com/3106437/84918140-e7f8a000-b0c8-11ea-99fc-0792f6b765f8.gif)
