### PR TITLE
storage: Wraps the ExternalStorage factory methods in an ExternalStorageBuilder

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -723,9 +723,9 @@ type TempStorageConfig struct {
 	Spec StoreSpec
 }
 
-// ExternalIODirConfig describes various configuration options pertaining
+// ExternalStorageConfig describes various configuration options pertaining
 // to external storage implementations.
-type ExternalIODirConfig struct {
+type ExternalStorageConfig struct {
 	// Disables the use of external HTTP endpoints.
 	// This turns off http:// external storage as well as any custom
 	// endpoints cloud storage implementations.

--- a/pkg/blobs/local_storage.go
+++ b/pkg/blobs/local_storage.go
@@ -32,7 +32,7 @@ type LocalStorage struct {
 // an error when we cannot take the absolute path of `externalIODir`.
 func NewLocalStorage(externalIODir string) (*LocalStorage, error) {
 	// An empty externalIODir indicates external IO is completely disabled.
-	// Returning a nil *LocalStorage in this case and then hanldling `nil` in the
+	// Returning a nil *LocalStorage in this case and then handling `nil` in the
 	// prependExternalIODir helper ensures that that is respected throughout the
 	// implementation (as a failure to do so would likely fail loudly with a
 	// nil-pointer dereference).

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -392,7 +392,7 @@ func backupPlanHook(
 			return err
 		}
 
-		makeCloudStorage := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI
+		externalStorageBuilder := p.ExecCfg().DistSQLSrv.ExternalStorageBuilder
 
 		var encryptionPassphrase []byte
 		if passphrase, ok := opts[backupOptEncPassphrase]; ok {
@@ -403,7 +403,7 @@ func backupPlanHook(
 		if err != nil {
 			return err
 		}
-		defaultStore, err := makeCloudStorage(ctx, defaultURI)
+		defaultStore, err := externalStorageBuilder.MakeExternalStorageFromURI(ctx, defaultURI)
 		if err != nil {
 			return err
 		}
@@ -419,7 +419,7 @@ func backupPlanHook(
 		g := ctxgroup.WithContext(ctx)
 		if len(incrementalFrom) > 0 {
 			if encryptionPassphrase != nil {
-				exportStore, err := makeCloudStorage(ctx, incrementalFrom[0])
+				exportStore, err := externalStorageBuilder.MakeExternalStorageFromURI(ctx, incrementalFrom[0])
 				if err != nil {
 					return err
 				}
@@ -444,7 +444,7 @@ func backupPlanHook(
 					// descriptors around.
 					uri := incrementalFrom[i]
 					desc, err := ReadBackupManifestFromURI(
-						ctx, uri, makeCloudStorage, encryption,
+						ctx, uri, externalStorageBuilder, encryption,
 					)
 					if err != nil {
 						return errors.Wrapf(err, "failed to read backup from %q", uri)
@@ -514,7 +514,7 @@ func backupPlanHook(
 				// Close the old store before overwriting the reference with the new
 				// subdir store.
 				defaultStore.Close()
-				defaultStore, err = makeCloudStorage(ctx, defaultURI)
+				defaultStore, err = externalStorageBuilder.MakeExternalStorageFromURI(ctx, defaultURI)
 				if err != nil {
 					return errors.Wrap(err, "re-opening layer-specific destination location")
 				}
@@ -652,7 +652,7 @@ func backupPlanHook(
 			if err != nil {
 				return err
 			}
-			exportStore, err := makeCloudStorage(ctx, defaultURI)
+			exportStore, err := externalStorageBuilder.MakeExternalStorageFromURI(ctx, defaultURI)
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -763,7 +763,8 @@ func loadBackupSQLDescs(
 	details jobspb.RestoreDetails,
 	encryption *roachpb.FileEncryptionOptions,
 ) ([]BackupManifest, BackupManifest, []sqlbase.Descriptor, error) {
-	backupManifests, err := loadBackupManifests(ctx, details.URIs, p.ExecCfg().DistSQLSrv.ExternalStorageFromURI, encryption)
+	backupManifests, err := loadBackupManifests(ctx, details.URIs, p.ExecCfg().DistSQLSrv.ExternalStorageBuilder,
+		encryption)
 	if err != nil {
 		return nil, BackupManifest{}, nil, err
 	}

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -680,7 +680,8 @@ func doRestorePlan(
 	}
 	baseStores := make([]cloud.ExternalStorage, len(from[0]))
 	for i := range from[0] {
-		store, err := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI(ctx, from[0][i])
+		store, err := p.ExecCfg().DistSQLSrv.ExternalStorageBuilder.MakeExternalStorageFromURI(ctx,
+			from[0][i])
 		if err != nil {
 			return errors.Wrapf(err, "failed to open backup storage location")
 		}
@@ -699,7 +700,7 @@ func doRestorePlan(
 	}
 
 	defaultURIs, mainBackupManifests, localityInfo, err := resolveBackupManifests(
-		ctx, baseStores, p.ExecCfg().DistSQLSrv.ExternalStorageFromURI, from, endTime, encryption,
+		ctx, baseStores, p.ExecCfg().DistSQLSrv.ExternalStorageBuilder, from, endTime, encryption,
 	)
 	if err != nil {
 		return err

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -86,7 +86,7 @@ func showBackupPlanHook(
 			return err
 		}
 
-		store, err := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI(ctx, str)
+		store, err := p.ExecCfg().DistSQLSrv.ExternalStorageBuilder.MakeExternalStorageFromURI(ctx, str)
 		if err != nil {
 			return errors.Wrapf(err, "make storage")
 		}

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -165,7 +165,7 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 
 	if ca.sink, err = getSink(
 		ctx, ca.spec.Feed.SinkURI, nodeID, ca.spec.Feed.Opts, ca.spec.Feed.Targets,
-		ca.flowCtx.Cfg.Settings, timestampOracle, ca.flowCtx.Cfg.ExternalStorageFromURI,
+		ca.flowCtx.Cfg.Settings, timestampOracle, ca.flowCtx.Cfg.ExternalStorageBuilder,
 	); err != nil {
 		err = MarkRetryableError(err)
 		// Early abort in the case that there is an error creating the sink.
@@ -554,7 +554,7 @@ func (cf *changeFrontier) Start(ctx context.Context) context.Context {
 	var nilOracle timestampLowerBoundOracle
 	if cf.sink, err = getSink(
 		ctx, cf.spec.Feed.SinkURI, nodeID, cf.spec.Feed.Opts, cf.spec.Feed.Targets,
-		cf.flowCtx.Cfg.Settings, nilOracle, cf.flowCtx.Cfg.ExternalStorageFromURI,
+		cf.flowCtx.Cfg.Settings, nilOracle, cf.flowCtx.Cfg.ExternalStorageBuilder,
 	); err != nil {
 		err = MarkRetryableError(err)
 		cf.MoveToDraining(err)

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -261,7 +261,7 @@ func changefeedPlanHook(
 			var nilOracle timestampLowerBoundOracle
 			canarySink, err := getSink(
 				ctx, details.SinkURI, nodeID, details.Opts, details.Targets,
-				settings, nilOracle, p.ExecCfg().DistSQLSrv.ExternalStorageFromURI,
+				settings, nilOracle, p.ExecCfg().DistSQLSrv.ExternalStorageBuilder,
 			)
 			if err != nil {
 				return MaybeStripRetryableErrorMarker(err)

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -76,7 +76,7 @@ func getSink(
 	targets jobspb.ChangefeedTargets,
 	settings *cluster.Settings,
 	timestampOracle timestampLowerBoundOracle,
-	makeExternalStorageFromURI cloud.ExternalStorageFromURIFactory,
+	externalStorageBuilder *cloud.ExternalStorageBuilder,
 ) (Sink, error) {
 	u, err := url.Parse(sinkURI)
 	if err != nil {
@@ -192,7 +192,7 @@ func getSink(
 		makeSink = func() (Sink, error) {
 			return makeCloudStorageSink(
 				ctx, u.String(), nodeID, fileSize, settings,
-				opts, timestampOracle, makeExternalStorageFromURI,
+				opts, timestampOracle, externalStorageBuilder,
 			)
 		}
 	case u.Scheme == changefeedbase.SinkSchemeExperimentalSQL:

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -304,7 +304,7 @@ func makeCloudStorageSink(
 	settings *cluster.Settings,
 	opts map[string]string,
 	timestampOracle timestampLowerBoundOracle,
-	makeExternalStorageFromURI cloud.ExternalStorageFromURIFactory,
+	externalStorageBuilder *cloud.ExternalStorageBuilder,
 ) (Sink, error) {
 	// Date partitioning is pretty standard, so no override for now, but we could
 	// plumb one down if someone needs it.
@@ -362,7 +362,7 @@ func makeCloudStorageSink(
 	}
 
 	var err error
-	if s.es, err = makeExternalStorageFromURI(ctx, baseURI); err != nil {
+	if s.es, err = externalStorageBuilder.MakeExternalStorageFromURI(ctx, baseURI); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ccl/cliccl/load.go
+++ b/pkg/ccl/cliccl/load.go
@@ -58,15 +58,17 @@ func runLoadShow(cmd *cobra.Command, args []string) error {
 		basepath = cloud.MakeLocalStorageURI(basepath)
 	}
 
-	externalStorageFromURI := func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
-		return cloud.ExternalStorageFromURI(ctx, uri, base.ExternalIODirConfig{},
-			cluster.NoSettings, blobs.TestEmptyBlobClientFactory)
+	builder := cloud.NewExternalStorageBuilder()
+	if err := builder.Init(base.ExternalStorageConfig{}, cluster.NoSettings,
+		blobs.TestEmptyBlobClientFactory, nil); err != nil {
+		return err
 	}
+
 	// This reads the raw backup descriptor (with table descriptors possibly not
 	// upgraded from the old FK representation, or even older formats). If more
 	// fields are added to the output, the table descriptors may need to be
 	// upgraded.
-	desc, err := backupccl.ReadBackupManifestFromURI(ctx, basepath, externalStorageFromURI, nil)
+	desc, err := backupccl.ReadBackupManifestFromURI(ctx, basepath, &builder, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -242,7 +242,7 @@ func (sp *csvWriter) Run(ctx context.Context) {
 			if err != nil {
 				return err
 			}
-			es, err := sp.flowCtx.Cfg.ExternalStorage(ctx, conf)
+			es, err := sp.flowCtx.Cfg.ExternalStorageBuilder.MakeExternalStorage(ctx, conf)
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -256,7 +256,7 @@ func importPlanHook(
 		} else {
 			for _, file := range filenamePatterns {
 				if cloud.URINeedsGlobExpansion(file) {
-					s, err := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI(ctx, file)
+					s, err := p.ExecCfg().DistSQLSrv.ExternalStorageBuilder.MakeExternalStorageFromURI(ctx, file)
 					if err != nil {
 						return err
 					}
@@ -606,7 +606,7 @@ func importPlanHook(
 			seqVals := make(map[sqlbase.ID]int64)
 
 			if importStmt.Bundle {
-				store, err := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI(ctx, files[0])
+				store, err := p.ExecCfg().DistSQLSrv.ExternalStorageBuilder.MakeExternalStorageFromURI(ctx, files[0])
 				if err != nil {
 					return err
 				}
@@ -660,7 +660,7 @@ func importPlanHook(
 					if err != nil {
 						return err
 					}
-					create, err = readCreateTableFromStore(ctx, filename, p.ExecCfg().DistSQLSrv.ExternalStorageFromURI)
+					create, err = readCreateTableFromStore(ctx, filename, p.ExecCfg().DistSQLSrv.ExternalStorageBuilder)
 					if err != nil {
 						return err
 					}
@@ -805,7 +805,7 @@ func parseAvroOptions(
 					"either %s or %s option must be set when importing avro record files", avroSchema, avroSchemaURI)
 			}
 
-			store, err := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI(ctx, uri)
+			store, err := p.ExecCfg().DistSQLSrv.ExternalStorageBuilder.MakeExternalStorageFromURI(ctx, uri)
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -39,9 +39,9 @@ const (
 )
 
 func readCreateTableFromStore(
-	ctx context.Context, filename string, externalStorageFromURI cloud.ExternalStorageFromURIFactory,
+	ctx context.Context, filename string, externalStorageBuilder *cloud.ExternalStorageBuilder,
 ) (*tree.CreateTable, error) {
-	store, err := externalStorageFromURI(ctx, filename)
+	store, err := externalStorageBuilder.MakeExternalStorageFromURI(ctx, filename)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -126,8 +126,13 @@ func Load(
 	if err != nil {
 		return backupccl.BackupManifest{}, err
 	}
-	dir, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{},
-		cluster.NoSettings, blobClientFactory)
+
+	builder := cloud.NewExternalStorageBuilder()
+	if err = builder.Init(base.ExternalStorageConfig{}, cluster.NoSettings, blobClientFactory,
+		nil); err != nil {
+		return backupccl.BackupManifest{}, err
+	}
+	dir, err := builder.MakeExternalStorage(ctx, conf)
 	if err != nil {
 		return backupccl.BackupManifest{}, errors.Wrap(err, "export storage from URI")
 	}

--- a/pkg/ccl/importccl/read_import_avro.go
+++ b/pkg/ccl/importccl/read_import_avro.go
@@ -473,9 +473,9 @@ func (a *avroInputReader) readFiles(
 	dataFiles map[int32]string,
 	resumePos map[int32]int64,
 	format roachpb.IOFileFormat,
-	makeExternalStorage cloud.ExternalStorageFactory,
+	externalStorageBuilder *cloud.ExternalStorageBuilder,
 ) error {
-	return readInputFiles(ctx, dataFiles, resumePos, format, a.readFile, makeExternalStorage)
+	return readInputFiles(ctx, dataFiles, resumePos, format, a.readFile, externalStorageBuilder)
 }
 
 func (a *avroInputReader) readFile(

--- a/pkg/ccl/importccl/read_import_base.go
+++ b/pkg/ccl/importccl/read_import_base.go
@@ -78,7 +78,7 @@ func runImport(
 			inputs = spec.Uri
 		}
 
-		return conv.readFiles(ctx, inputs, spec.ResumePos, spec.Format, flowCtx.Cfg.ExternalStorage)
+		return conv.readFiles(ctx, inputs, spec.ResumePos, spec.Format, flowCtx.Cfg.ExternalStorageBuilder)
 	})
 
 	// Ingest the KVs that the producer group emitted to the chan and the row result
@@ -127,7 +127,7 @@ func readInputFiles(
 	resumePos map[int32]int64,
 	format roachpb.IOFileFormat,
 	fileFunc readFileFunc,
-	makeExternalStorage cloud.ExternalStorageFactory,
+	externalStorageBuilder *cloud.ExternalStorageBuilder,
 ) error {
 	done := ctx.Done()
 
@@ -139,7 +139,7 @@ func readInputFiles(
 		if err != nil {
 			return err
 		}
-		es, err := makeExternalStorage(ctx, conf)
+		es, err := externalStorageBuilder.MakeExternalStorage(ctx, conf)
 		if err != nil {
 			return err
 		}
@@ -164,7 +164,7 @@ func readInputFiles(
 			if err != nil {
 				return err
 			}
-			es, err := makeExternalStorage(ctx, conf)
+			es, err := externalStorageBuilder.MakeExternalStorage(ctx, conf)
 			if err != nil {
 				return err
 			}
@@ -217,7 +217,7 @@ func readInputFiles(
 					if err != nil {
 						return err
 					}
-					rejectedStorage, err := makeExternalStorage(ctx, conf)
+					rejectedStorage, err := externalStorageBuilder.MakeExternalStorage(ctx, conf)
 					if err != nil {
 						return err
 					}
@@ -324,7 +324,7 @@ type inputConverter interface {
 		dataFiles map[int32]string,
 		resumePos map[int32]int64,
 		format roachpb.IOFileFormat,
-		makeExternalStorage cloud.ExternalStorageFactory,
+		externalStorageBuilder *cloud.ExternalStorageBuilder,
 	) error
 }
 

--- a/pkg/ccl/importccl/read_import_csv.go
+++ b/pkg/ccl/importccl/read_import_csv.go
@@ -60,9 +60,9 @@ func (c *csvInputReader) readFiles(
 	dataFiles map[int32]string,
 	resumePos map[int32]int64,
 	format roachpb.IOFileFormat,
-	makeExternalStorage cloud.ExternalStorageFactory,
+	externalStorageBuilder *cloud.ExternalStorageBuilder,
 ) error {
-	return readInputFiles(ctx, dataFiles, resumePos, format, c.readFile, makeExternalStorage)
+	return readInputFiles(ctx, dataFiles, resumePos, format, c.readFile, externalStorageBuilder)
 }
 
 func (c *csvInputReader) readFile(

--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -84,9 +84,9 @@ func (m *mysqldumpReader) readFiles(
 	dataFiles map[int32]string,
 	resumePos map[int32]int64,
 	format roachpb.IOFileFormat,
-	makeExternalStorage cloud.ExternalStorageFactory,
+	externalStorageBuilder *cloud.ExternalStorageBuilder,
 ) error {
-	return readInputFiles(ctx, dataFiles, resumePos, format, m.readFile, makeExternalStorage)
+	return readInputFiles(ctx, dataFiles, resumePos, format, m.readFile, externalStorageBuilder)
 }
 
 func (m *mysqldumpReader) readFile(

--- a/pkg/ccl/importccl/read_import_mysqlout.go
+++ b/pkg/ccl/importccl/read_import_mysqlout.go
@@ -59,9 +59,9 @@ func (d *mysqloutfileReader) readFiles(
 	dataFiles map[int32]string,
 	resumePos map[int32]int64,
 	format roachpb.IOFileFormat,
-	makeExternalStorage cloud.ExternalStorageFactory,
+	externalStorageBuilder *cloud.ExternalStorageBuilder,
 ) error {
-	return readInputFiles(ctx, dataFiles, resumePos, format, d.readFile, makeExternalStorage)
+	return readInputFiles(ctx, dataFiles, resumePos, format, d.readFile, externalStorageBuilder)
 }
 
 type delimitedProducer struct {

--- a/pkg/ccl/importccl/read_import_pgcopy.go
+++ b/pkg/ccl/importccl/read_import_pgcopy.go
@@ -65,9 +65,9 @@ func (d *pgCopyReader) readFiles(
 	dataFiles map[int32]string,
 	resumePos map[int32]int64,
 	format roachpb.IOFileFormat,
-	makeExternalStorage cloud.ExternalStorageFactory,
+	externalStorageBuilder *cloud.ExternalStorageBuilder,
 ) error {
-	return readInputFiles(ctx, dataFiles, resumePos, format, d.readFile, makeExternalStorage)
+	return readInputFiles(ctx, dataFiles, resumePos, format, d.readFile, externalStorageBuilder)
 }
 
 type postgreStreamCopy struct {

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -444,9 +444,9 @@ func (m *pgDumpReader) readFiles(
 	dataFiles map[int32]string,
 	resumePos map[int32]int64,
 	format roachpb.IOFileFormat,
-	makeExternalStorage cloud.ExternalStorageFactory,
+	externalStorageBuilder *cloud.ExternalStorageBuilder,
 ) error {
-	return readInputFiles(ctx, dataFiles, resumePos, format, m.readFile, makeExternalStorage)
+	return readInputFiles(ctx, dataFiles, resumePos, format, m.readFile, externalStorageBuilder)
 }
 
 func (m *pgDumpReader) readFile(

--- a/pkg/ccl/importccl/read_import_workload.go
+++ b/pkg/ccl/importccl/read_import_workload.go
@@ -115,7 +115,7 @@ func (w *workloadReader) readFiles(
 	dataFiles map[int32]string,
 	_ map[int32]int64,
 	_ roachpb.IOFileFormat,
-	_ cloud.ExternalStorageFactory,
+	_ *cloud.ExternalStorageBuilder,
 ) error {
 
 	wcs := make([]*WorkloadKVConverter, 0, len(dataFiles))

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -376,10 +376,10 @@ func init() {
 		BoolFlag(f, &startCtx.serverInsecure, cliflags.ServerInsecure, startCtx.serverInsecure)
 
 		// Enable/disable various external storage endpoints.
-		serverCfg.ExternalIODirConfig = base.ExternalIODirConfig{}
-		BoolFlag(f, &serverCfg.ExternalIODirConfig.DisableHTTP,
+		serverCfg.ExternalStorageConfig = base.ExternalStorageConfig{}
+		BoolFlag(f, &serverCfg.ExternalStorageConfig.DisableHTTP,
 			cliflags.ExternalIODisableHTTP, false)
-		BoolFlag(f, &serverCfg.ExternalIODirConfig.DisableImplicitCredentials,
+		BoolFlag(f, &serverCfg.ExternalStorageConfig.DisableImplicitCredentials,
 			cliflags.ExtenralIODisableImplicitCredentials, false)
 
 		// Certificates directory. Use a server-specific flag and value to ignore environment

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1600,14 +1600,14 @@ func EnableLeaseHistory(maxEntries int) func() {
 func (r *Replica) GetExternalStorage(
 	ctx context.Context, dest roachpb.ExternalStorage,
 ) (cloud.ExternalStorage, error) {
-	return r.store.cfg.ExternalStorage(ctx, dest)
+	return r.store.cfg.ExternalStorageBuilder.MakeExternalStorage(ctx, dest)
 }
 
 // GetExternalStorageFromURI returns an ExternalStorage object, based on the given URI.
 func (r *Replica) GetExternalStorageFromURI(
 	ctx context.Context, uri string,
 ) (cloud.ExternalStorage, error) {
-	return r.store.cfg.ExternalStorageFromURI(ctx, uri)
+	return r.store.cfg.ExternalStorageBuilder.MakeExternalStorageFromURI(ctx, uri)
 }
 
 func (r *Replica) markSystemConfigGossipSuccess() {

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -710,9 +710,8 @@ type StoreConfig struct {
 	// gossip immediately without waiting for the periodic gossip interval.
 	GossipWhenCapacityDeltaExceedsFraction float64
 
-	// ExternalStorage creates ExternalStorage objects which allows access to external files
-	ExternalStorage        cloud.ExternalStorageFactory
-	ExternalStorageFromURI cloud.ExternalStorageFromURIFactory
+	// ExternalStorageBuilder creates ExternalStorage objects which allows access to external files
+	ExternalStorageBuilder *cloud.ExternalStorageBuilder
 
 	// ProtectedTimestampCache maintains the state of the protected timestamp
 	// subsystem. It is queried during the GC process and in the handling of

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -310,9 +310,9 @@ type SQLConfig struct {
 	// ephemeral data when processing large queries.
 	TempStorageConfig base.TempStorageConfig
 
-	// ExternalIODirConfig is used to configure external storage
+	// ExternalStorageConfig is used to configure external storage
 	// access (http://, nodelocal://, etc)
-	ExternalIODirConfig base.ExternalIODirConfig
+	ExternalStorageConfig base.ExternalStorageConfig
 
 	// MemoryPoolSize is the amount of memory in bytes that can be
 	// used by SQL clients to store row data in server RAM.

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -120,8 +120,7 @@ type sqlServerOptionalArgs struct {
 	nodeIDContainer *base.SQLIDContainer
 
 	// Used by backup/restore.
-	externalStorage        cloud.ExternalStorageFactory
-	externalStorageFromURI cloud.ExternalStorageFromURIFactory
+	externalStorageBuilder *cloud.ExternalStorageBuilder
 }
 
 type sqlServerArgs struct {
@@ -324,8 +323,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 		NodeDialer:   cfg.nodeDialer,
 		LeaseManager: leaseMgr,
 
-		ExternalStorage:        cfg.externalStorage,
-		ExternalStorageFromURI: cfg.externalStorageFromURI,
+		ExternalStorageBuilder: cfg.externalStorageBuilder,
 	}
 	cfg.TempStorageConfig.Mon.SetMetrics(distSQLMetrics.CurDiskBytesCount, distSQLMetrics.MaxDiskBytesHist)
 	if distSQLTestingKnobs := cfg.TestingKnobs.DistSQL; distSQLTestingKnobs != nil {

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -563,6 +563,7 @@ func makeSQLServerArgs(
 	// writing): the blob service and DistSQL.
 	dummyRPCServer := rpc.NewServer(rpcContext)
 	noStatusServer := serverpb.MakeOptionalStatusServer(nil)
+	builder := cloud.NewExternalStorageBuilder()
 	return sqlServerArgs{
 		sqlServerOptionalArgs: sqlServerOptionalArgs{
 			rpcContext:   rpcContext,
@@ -577,12 +578,9 @@ func makeSQLServerArgs(
 				return false, errors.New("isMeta1Leaseholder is not available to secondary tenants")
 			},
 			nodeIDContainer: idContainer,
-			externalStorage: func(ctx context.Context, dest roachpb.ExternalStorage) (cloud.ExternalStorage, error) {
-				return nil, errors.New("external storage is not available to secondary tenants")
-			},
-			externalStorageFromURI: func(ctx context.Context, uri string) (cloud.ExternalStorage, error) {
-				return nil, errors.New("external uri storage is not available to secondary tenants")
-			},
+			// External storage is not available to secondary tenants. builder.Init()
+			// has never been invoked and all methods will return an error.
+			externalStorageBuilder: &builder,
 		},
 		SQLConfig:                &sqlCfg,
 		BaseConfig:               &baseCfg,

--- a/pkg/settings/cluster/cluster_settings.go
+++ b/pkg/settings/cluster/cluster_settings.go
@@ -38,7 +38,6 @@ type Settings struct {
 
 	Tracer        *tracing.Tracer
 	ExternalIODir string
-
 	// Set to 1 if a profile is active (if the profile is being grabbed through
 	// the `pprofui` server as opposed to the raw endpoint).
 	cpuProfiling int32 // atomic

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -152,8 +152,7 @@ type ServerConfig struct {
 	// required, so that users of ServerConfig don't have to care about them.
 	SessionBoundInternalExecutorFactory sqlutil.SessionBoundInternalExecutorFactory
 
-	ExternalStorage        cloud.ExternalStorageFactory
-	ExternalStorageFromURI cloud.ExternalStorageFromURIFactory
+	ExternalStorageBuilder *cloud.ExternalStorageBuilder
 
 	// ProtectedTimestampProvider maintains the state of the protected timestamp
 	// subsystem. It is queried during the GC process and in the handling of

--- a/pkg/storage/cloud/gcs_storage.go
+++ b/pkg/storage/cloud/gcs_storage.go
@@ -64,7 +64,7 @@ func (g *gcsStorage) Conf() roachpb.ExternalStorage {
 
 func makeGCSStorage(
 	ctx context.Context,
-	ioConf base.ExternalIODirConfig,
+	ioConf base.ExternalStorageConfig,
 	conf *roachpb.ExternalStorage_GCS,
 	settings *cluster.Settings,
 ) (ExternalStorage, error) {

--- a/pkg/storage/cloud/gcs_storage_test.go
+++ b/pkg/storage/cloud/gcs_storage_test.go
@@ -104,8 +104,13 @@ func TestAntagonisticRead(t *testing.T) {
 	conf, err := ExternalStorageConfFromURI(gsFile)
 	require.NoError(t, err)
 
-	s, err := MakeExternalStorage(
-		context.Background(), conf, base.ExternalIODirConfig{}, testSettings, nil)
+	var builder *ExternalStorageBuilder
+	if builder, err = ConstructExternalStorageBuilder(base.ExternalStorageConfig{},
+		nil); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := builder.MakeExternalStorage(context.Background(), conf)
 	require.NoError(t, err)
 	stream, err := s.ReadFile(context.Background(), "")
 	require.NoError(t, err)
@@ -123,14 +128,20 @@ func TestFileDoesNotExist(t *testing.T) {
 		t.Skip("GOOGLE_APPLICATION_CREDENTIALS env var must be set")
 	}
 
+	var builder *ExternalStorageBuilder
+	var err error
+	if builder, err = ConstructExternalStorageBuilder(base.ExternalStorageConfig{},
+		nil); err != nil {
+		t.Fatal(err)
+	}
+
 	{
 		// Invalid gsFile.
 		gsFile := "gs://cockroach-fixtures/tpch-csv/sf-1/invalid_region.tbl?AUTH=implicit"
 		conf, err := ExternalStorageConfFromURI(gsFile)
 		require.NoError(t, err)
 
-		s, err := MakeExternalStorage(
-			context.Background(), conf, base.ExternalIODirConfig{}, testSettings, nil)
+		s, err := builder.MakeExternalStorage(context.Background(), conf)
 		require.NoError(t, err)
 		_, err = s.ReadFile(context.Background(), "")
 		require.Error(t, err, "")
@@ -143,8 +154,7 @@ func TestFileDoesNotExist(t *testing.T) {
 		conf, err := ExternalStorageConfFromURI(gsFile)
 		require.NoError(t, err)
 
-		s, err := MakeExternalStorage(
-			context.Background(), conf, base.ExternalIODirConfig{}, testSettings, nil)
+		s, err := builder.MakeExternalStorage(context.Background(), conf)
 		require.NoError(t, err)
 		_, err = s.ReadFile(context.Background(), "")
 		require.Error(t, err, "")

--- a/pkg/storage/cloud/nodelocal_storage_test.go
+++ b/pkg/storage/cloud/nodelocal_storage_test.go
@@ -43,16 +43,21 @@ func TestLocalIOLimits(t *testing.T) {
 
 	clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
 
-	baseDir, err := ExternalStorageFromURI(
-		ctx, "nodelocal://0/", base.ExternalIODirConfig{}, testSettings, clientFactory)
+	var builder *ExternalStorageBuilder
+	var err error
+	if builder, err = ConstructExternalStorageBuilder(base.ExternalStorageConfig{},
+		clientFactory); err != nil {
+		t.Fatal(err)
+	}
+
+	baseDir, err := builder.MakeExternalStorageFromURI(ctx, "nodelocal://0/")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for dest, expected := range map[string]string{allowed: "", "/../../blah": "not allowed"} {
 		u := fmt.Sprintf("nodelocal://0%s", dest)
-		e, err := ExternalStorageFromURI(
-			ctx, u, base.ExternalIODirConfig{}, testSettings, clientFactory)
+		e, err := builder.MakeExternalStorageFromURI(ctx, u)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/storage/cloud/s3_storage.go
+++ b/pkg/storage/cloud/s3_storage.go
@@ -58,7 +58,7 @@ func s3QueryParams(conf *roachpb.ExternalStorage_S3) string {
 
 func makeS3Storage(
 	ctx context.Context,
-	ioConf base.ExternalIODirConfig,
+	ioConf base.ExternalStorageConfig,
 	conf *roachpb.ExternalStorage_S3,
 	settings *cluster.Settings,
 ) (ExternalStorage, error) {


### PR DESCRIPTION
Previously, the ExternalStorage factory methods were initialized on
creation of a NewServer(). These closures were then plumbed through
various componenets such as sqlServer, storeConfig etc. The closures
were invoked whenever an ExternalStorage object needed creation.

This refactor maintains the semantics of the ExternalStorage factory
methods, but introduces an ExternalStorageBuilder. This object
implements the factory methods and stores relevant configuration
parameters. The main goal of this refactor was to separate the
"creation" and "initialization" stages of the ExternalStorageBuilder.
While the object is created and plumbed on creation of a NewServer(),
certain config params (eg: storage.Engine) are only initialized on
server.Start(). The plumbing of an object pointer as compared to
closures allows us to cleanly configure the builder in server.Start()
and propagate this information for future use in the factory methods.

Using and plumbing a dedicated builder also seems like a design
improvement to bookkeeping closure variables. This lays the groundwork
for the user scoped storage which is being discussed in #47211.

Release note: None