### PR TITLE
[wip] server: ensure settings are up-to-date

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1397,7 +1397,8 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 	s.replicationReporter.Start(ctx, s.stopper)
 
-	s.refreshSettings()
+	// TODO(tbg): pass an initial slice of settings KVs here.
+	s.refreshSettings(nil)
 
 	sentry.ConfigureScope(func(scope *sentry.Scope) {
 		scope.SetTags(map[string]string{

--- a/pkg/server/settingsworker.go
+++ b/pkg/server/settingsworker.go
@@ -21,20 +21,23 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
-// RefreshSettings starts a settings-changes listener.
-func (s *Server) refreshSettings() {
-	tbl := sqlbase.SettingsTable.TableDesc()
-
+func processSystemConfigKVs(
+	ctx context.Context, kvs []roachpb.KeyValue, u settings.Updater, eng storage.Engine,
+) {
 	a := &sqlbase.DatumAlloc{}
 	codec := keys.TODOSQLCodec
+
+	tbl := sqlbase.SettingsTable.TableDesc()
 	settingsTablePrefix := codec.TablePrefix(uint32(tbl.ID))
 	colIdxMap := row.ColIDtoRowIndexFromCols(tbl.Columns)
 
+	var settingsKVs []roachpb.KeyValue
 	processKV := func(ctx context.Context, kv roachpb.KeyValue, u settings.Updater) error {
 		if !bytes.HasPrefix(kv.Key, settingsTablePrefix) {
 			return nil
@@ -96,12 +99,31 @@ func (s *Server) refreshSettings() {
 				}
 			}
 		}
+		settingsKVs = append(settingsKVs, kv)
 
 		if err := u.Set(k, v, t); err != nil {
 			log.Warningf(ctx, "setting %q to %q failed: %+v", k, v, err)
 		}
 		return nil
 	}
+	ok := true
+	for _, kv := range kvs {
+		if err := processKV(ctx, kv, u); err != nil {
+			log.Warningf(ctx, `error decoding settings data: %+v
+								this likely indicates the settings table structure or encoding has been altered;
+								skipping settings updates`, err)
+			ok = false
+			break
+		}
+	}
+	if ok {
+		storeSettingsKVs(eng)
+		u.ResetRemaining()
+	}
+}
+
+// RefreshSettings starts a settings-changes listener.
+func (s *Server) refreshSettings(initialSettingKVs []roachpb.KeyValue) {
 
 	ctx := s.AnnotateCtx(context.Background())
 	s.stopper.RunWorker(ctx, func(ctx context.Context) {
@@ -112,19 +134,9 @@ func (s *Server) refreshSettings() {
 			case <-gossipUpdateC:
 				cfg := s.gossip.GetSystemConfig()
 				u := s.st.MakeUpdater()
-				ok := true
-				for _, kv := range cfg.Values {
-					if err := processKV(ctx, kv, u); err != nil {
-						log.Warningf(ctx, `error decoding settings data: %+v
-								this likely indicates the settings table structure or encoding has been altered;
-								skipping settings updates`, err)
-						ok = false
-						break
-					}
-				}
-				if ok {
-					u.ResetRemaining()
-				}
+				// TODO(tbg): make sure s.engines[0] is initialized. Or rather, allow
+				// picking an initialized engine here.
+				processSystemConfigKVs(ctx, cfg.Values, u, s.engines[0])
 			case <-s.stopper.ShouldStop():
 				return
 			}


### PR DESCRIPTION
In an ideal world a KV node would not declare itself as ready until
it has received the current cluster settings.

However, we cannot indiscriminately block on that because of the
chicken-and-egg problem that comes up when the node currently starting
is needed for quorum on the system config range. For example, if a three
node cluster is completely down, at least two of the nodes must be
online before current settings are received.

Instead do the following:

1. persist the settings locally on the first store whenever they are
received, so that restarting nodes can come up with settings that are no
staler than the ones they had when they went down.
2. if a new node joins the cluster, we can wait for the settings to show
up (since the node is just joining, it is not required for any quorum).

Fixes #48005.

Release note: None