### PR TITLE
kvserver: avoid test hang if teardown during consistency check

### DIFF
--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -425,9 +425,9 @@ func (r *Replica) getChecksum(ctx context.Context, id uuid.UUID) (ReplicaChecksu
 	r.mu.Unlock()
 	// Wait
 	select {
-	case <-r.store.Stopper().ShouldStop():
+	case <-r.store.Stopper().ShouldQuiesce():
 		return ReplicaChecksum{},
-			errors.Errorf("store has stopped while waiting for compute checksum (ID = %s)", id)
+			errors.Errorf("store quiescing while waiting for compute checksum (ID = %s)", id)
 	case <-ctx.Done():
 		return ReplicaChecksum{},
 			errors.Wrapf(ctx.Err(), "while waiting for compute checksum (ID = %s)", id)


### PR DESCRIPTION
multiTestContext first quiesces all nodes, *then* proceeds to call
`Stop()` on the nodes' stoppers. If a node was waiting for a checksum
from another node, this would not be interrupted during `Quiesce()` and
would thus deadlock (as the receiving node would only `Stop()` when the
checksum, which is wrapped in a stopper task on another node and thus
blocks its quiescing, returns.

Prior to #49763 this wouldn't lead to a deadlock but a 15s hang
since we had an extra context cancellation that would mask the
problem.

Now make sure that we bounce all clients waiting for checksums
the moment we quiesce.

Fixes #49879.

Release note: None