### PR TITLE
kvserver: skip tests w/ aggressive closed timestamp under race

### DIFF
--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -539,6 +539,10 @@ func setupTestClusterForClosedTimestampTesting(
 	kvTableDesc roachpb.RangeDescriptor,
 	repls []*kvserver.Replica,
 ) {
+	if util.RaceEnabled {
+		// These tests run into infinite txn restarts under heavy load. See:
+		t.Skip("https://github.com/cockroachdb/cockroach/issues/50091")
+	}
 
 	tc = serverutils.StartTestCluster(t, numNodes, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{


### PR DESCRIPTION
It would be nice if these transactions could terminate (and we're
discusing the issues exposed here), but there is certainly no reason to
let these tests flake in the meantime.

See https://github.com/cockroachdb/cockroach/issues/50091.

Closes #50091.

Release note: None