### PR TITLE
ui: Typo for std deviation labels on Network Latency page

### DIFF
--- a/pkg/ui/src/views/reports/containers/network/legend/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/legend/index.tsx
@@ -15,6 +15,7 @@ import { getDisplayName } from "src/redux/nodes";
 import React from "react";
 import { NoConnection } from "..";
 import "./legend.styl";
+import { Text, TextTypes } from "src/components";
 
 interface ILegendProps {
   stddevMinus2: number;
@@ -48,35 +49,47 @@ export const Legend: React.SFC <ILegendProps> = ({
               title={`${stddevMinus2.toFixed(2)}ms`}
               type="green"
             />
-            <p>{`< -2`}</p>
+            <span className="Legend--container__body--label">
+              <Text textType={TextTypes.BodyStrong}>{`-2`}</Text>&nbsp;
+              <Text textType={TextTypes.Body} className="Legend--container__body--label-suffix">std dev</Text>
+            </span>
           </div>
           <div className="Legend--container__body--element">
             <Chip
               title={`${stddevMinus1.toFixed(2)}ms`}
               type="lightgreen"
             />
-            <p>{`< -1`}</p>
+            <span className="Legend--container__body--label">
+              <Text textType={TextTypes.BodyStrong}>{`-1`}</Text>&nbsp;
+              <Text textType={TextTypes.Body} className="Legend--container__body--label-suffix">std dev</Text>
+            </span>
           </div>
           <div className="Legend--container__body--element">
              <Chip
               title={`${mean.toFixed(2)}ms`}
               type="grey"
             />
-            <p>MEAN</p>
+            <Text textType={TextTypes.BodyStrong} className="Legend--container__body--label">Mean</Text>
           </div>
           <div className="Legend--container__body--element">
             <Chip
               title={`${stddevPlus1.toFixed(2)}ms`}
               type="lightblue"
             />
-            <p>{`< +1`}</p>
+            <span className="Legend--container__body--label">
+              <Text textType={TextTypes.BodyStrong}>{`+1`}</Text>&nbsp;
+              <Text textType={TextTypes.Body} className="Legend--container__body--label-suffix">std dev</Text>
+            </span>
           </div>
           <div className="Legend--container__body--element">
             <Chip
               title={`${stddevPlus2.toFixed(2)}ms`}
               type="blue"
             />
-            <p>{`< +2`}</p>
+            <span className="Legend--container__body--label">
+              <Text textType={TextTypes.BodyStrong}>{`+2`}</Text>&nbsp;
+              <Text textType={TextTypes.Body} className="Legend--container__body--label-suffix">std dev</Text>
+            </span>
           </div>
         </div>
       </div>

--- a/pkg/ui/src/views/reports/containers/network/legend/legend.styl
+++ b/pkg/ui/src/views/reports/containers/network/legend/legend.styl
@@ -45,14 +45,13 @@
         flex-direction column
         align-items center
         margin-right 6px
-        p
-          margin-top 9px
-          text-transform uppercase
-          font-family SourceSansPro-SemiBold
-          font-size 12px
-          color $colors--neutral-6
-          line-height 1.17
-          letter-spacing 1.5px
+      &--label
+        display flex
+        flex-direction row
+        margin-top $spacing-xx-small
+        margin-bottom 1em
+      &--label-suffix
+        color $colors--neutral-5
 
 .noConnections__table
   width 100%


### PR DESCRIPTION
Resolves #48742

Fixed typo for std deviation labels on Network Latency page.

Release note (admin ui change): Changed label for std deviation
from < to > for positive values.

**Before**
<img width="920" alt="Screenshot 2020-06-17 at 18 11 59" src="https://user-images.githubusercontent.com/3106437/84916021-36f10600-b0c6-11ea-9097-5d991c58a3c4.png">

**After**
<img width="945" alt="Screenshot 2020-06-17 at 18 11 26" src="https://user-images.githubusercontent.com/3106437/84916064-42443180-b0c6-11ea-981e-f36feff8cd1e.png">
