### PR TITLE
sql: handle ColumnConversionValidate conversions for alter column type

### DIFF
--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -113,7 +113,7 @@ func AlterColumnType(
 			col.Type.SQLString(), typ.SQLString())
 	case schemachange.ColumnConversionTrivial:
 		col.Type = typ
-	case schemachange.ColumnConversionGeneral:
+	case schemachange.ColumnConversionGeneral, schemachange.ColumnConversionValidate:
 		if err := alterColumnTypeGeneral(ctx, tableDesc, col, typ, t.Using, params, cmds); err != nil {
 			return err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -17,13 +17,13 @@ some string  short  0000-01-01 20:16:27 +0000 UTC  2018-05-23 20:16:27.658082 +0
 
 # Not using TIMETZ until #26074 and #25224 are resolved.
 statement ok
-ALTER TABLE t ALTER s TYPE BYTES, ALTER sl TYPE STRING(6), ALTER ts TYPE TIMESTAMPTZ
+ALTER TABLE t ALTER s TYPE STRING, ALTER sl TYPE STRING(6), ALTER ts TYPE TIMESTAMPTZ
 
 query TTBTTTB colnames
 SHOW COLUMNS FROM t
 ----
 column_name  data_type    is_nullable  column_default  generation_expression  indices    is_hidden
-s            BYTES        true         NULL            ·                      {}         false
+s            STRING       true         NULL            ·                      {}         false
 sl           STRING(6)    true         NULL            ·                      {}         false
 t            TIME         true         NULL            ·                      {}         false
 ts           TIMESTAMPTZ  true         NULL            ·                      {}         false
@@ -523,3 +523,27 @@ SELECT x FROM t28 ORDER BY x
 5
 10
 15
+
+# Regression 50277, ensure ColumnConversionValidate type conversion doesn't
+# error before running the online schema change.
+statement ok
+CREATE TABLE t29 (x INT8);
+INSERT INTO t29 VALUES (1), (2), (3);
+ALTER TABLE t29 ALTER COLUMN x TYPE INT4;
+
+query I
+SELECT x FROM t29 ORDER BY x
+----
+1
+2
+3
+
+# ColumnConversionValidate should error out if the conversion is not valid.
+# STRING -> BYTES is a ColumnConversionValidate type conversion, it should
+# try the conversion and error out if the cast cannot be applied.
+statement ok
+CREATE TABLE t30 (x STRING);
+INSERT INTO t30 VALUES (e'a\\01');
+
+statement error pq: could not parse "a\\\\01" as type bytes: bytea encoded value ends with incomplete escape sequence
+ALTER TABLE t30 ALTER COLUMN x TYPE BYTES

--- a/pkg/sql/schemachange/alter_column_type.go
+++ b/pkg/sql/schemachange/alter_column_type.go
@@ -95,20 +95,8 @@ var classifiers = map[types.Family]map[types.Family]classifier{
 		},
 	},
 	types.StringFamily: {
-		// If we want to convert string -> bytes, we need to know that the
-		// bytes type has an unlimited width or that we have at least
-		// 4x the number of bytes as known-maximum characters.
 		types.BytesFamily: func(s *types.T, b *types.T) ColumnConversionKind {
-			switch {
-			case b.Width() == 0:
-				return ColumnConversionTrivial
-			case s.Width() == 0:
-				return ColumnConversionValidate
-			case b.Width() >= s.Width()*4:
-				return ColumnConversionTrivial
-			default:
-				return ColumnConversionValidate
-			}
+			return ColumnConversionValidate
 		},
 		types.StringFamily: classifierWidth,
 	},

--- a/pkg/sql/schemachange/alter_column_type_test.go
+++ b/pkg/sql/schemachange/alter_column_type_test.go
@@ -93,10 +93,10 @@ func TestColumnConversions(t *testing.T) {
 
 		"STRING": {
 			"BIT":   ColumnConversionGeneral,
-			"BYTES": ColumnConversionTrivial,
+			"BYTES": ColumnConversionValidate,
 		},
 		"STRING(5)": {
-			"BYTES": ColumnConversionTrivial,
+			"BYTES": ColumnConversionValidate,
 		},
 
 		"TIME": {


### PR DESCRIPTION
Perform online schema change for ALTER COLUMN TYPE ColumnConversionValidate

Fixes #50277

Was missing a switch statement case for ColumnConversionValidate causing the code
to reach the default case of unknown conversion.

Release note (sql change): Fix error for ALTER COLUMN TYPE for certain conversions
where a the data matches byte for byte but we have to perform a validation. Ie
INT8 -> INT4. Previously this conversion would error out.