### PR TITLE
vendor: Bump pebble to a08efa805781318782db494653e33dc209ffd622

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -458,7 +458,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:665236f7991150b141031c126d67cacac579828d16ab846580484f587b558065"
+  digest = "1:24207c7f05140155c561ea047edef7b51194b4cd94b4a8c7352a50e3167490d6"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -484,7 +484,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "4c37272d4965433ad5dc8430ab9ebf55a81997d4"
+  revision = "a08efa805781318782db494653e33dc209ffd622"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
Changes pulled in:
 - 223327f23e83e69f18ad1ba45d931ed0b20f7627 internal/record: Handle ErrUnexpectedEOFs like invalid records
 - c1719779831f5ce6094b6366c0afe28c31b7a2c2 db: wake all waiters on cleaner.cond on state transitions
 - b893bb26369d8124ee11c3e0cff97a41c68022ca internal/manifest: Don't error when intra-L0 seed file is compacting
 - d656faf2c4567d5b23dbf079daa46d6b13d8cc29 db: tweak the compaction concurrency heuristics
 - f550e81e347485b8309cf8b221c67285b89d777b db: fix mergingIter corner case surrounding range tombstones
 - ca93fc7b74b4c87d82fe358ba3c740df16906a63 internal/metamorphic: fail tests on calls to Fatalf
 - bf0653a8f1b07c364b9ff91ee55da3023aed968a docs: add doc on Linux I/O profiling tools
 - cb9c3090f41715ddb29ff52f15562143c1a7f390 *: Add error.Wrap() call to errors from wal/manifest record reader
 - 330d079d4e334db1045fc932beb0fcd21c859a30 *: consistently capitalize Sublevels
 - fc886eca19e6b55105e609f47132699592e9d9c9 *: Enable flush splits in L0

Fixes #49747.

Release note (bug fix): Fix a bug where an "unexpected EOF" error would
be returned at startup with the pebble storage engine, if the last instance
of cockroach crashed in a rare case of the write-ahead log being written to.