### PR TITLE
release-20.1: vendor: Bump pebble to 6c5e6ce917e124c3d8b50387b998686dc3766dae

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -464,7 +464,7 @@
 
 [[projects]]
   branch = "crl-release-20.1"
-  digest = "1:7375996ea1c70381aea661d772e7624fb73ddb765a3ef92913c0c1e0e247027e"
+  digest = "1:3c028a8223f4376735f42e4365ac248e1cbfaee73ba4d024864930a1e7e91099"
   name = "github.com/cockroachdb/pebble"
   packages = [
     ".",
@@ -490,7 +490,7 @@
     "vfs",
   ]
   pruneopts = "UT"
-  revision = "7928b15b5c541dfae551945ea91f03e7cfba71fa"
+  revision = "6c5e6ce917e124c3d8b50387b998686dc3766dae"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
Changes pulled in:
 - 25e83e93536da50490a4ff90400053f2ae3217e1 db: wake all waiters on cleaner.cond on state transitions
 - 6681936b9aa427e7c4f5a8405d634392e0a37aa8 internal/record: Handle ErrUnexpectedEOFs like invalid records

Release note (bug fix): Fix a bug where restarting cockroach with
the pebble storage engine after a crash during write-ahead logging
could, in some rare cases, return an "unexpected EOF" error.