### PR TITLE
sql/catalog/lease: add backoff to rangefeed loop

### DIFF
--- a/pkg/kv/kvclient/kvcoord/range_cache.go
+++ b/pkg/kv/kvclient/kvcoord/range_cache.go
@@ -240,6 +240,9 @@ func (et EvictionToken) Empty() bool {
 // Desc returns the RangeDescriptor that was retrieved from the cache. The
 // result is to be considered immutable.
 func (et EvictionToken) Desc() *roachpb.RangeDescriptor {
+	if et.entry == nil {
+		return nil
+	}
 	return &et.entry.Desc
 }
 

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"regexp"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -28,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
@@ -50,6 +53,7 @@ import (
 	"github.com/cockroachdb/logtags"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
 type leaseTest struct {
@@ -2360,4 +2364,70 @@ func TestRangefeedUpdatesHandledProperlyInTheFaceOfRaces(t *testing.T) {
 	// Ensure that the new schema is in use on n2.
 	var i, j int
 	require.Equal(t, gosql.ErrNoRows, db2.QueryRow("SELECT i, j FROM foo").Scan(&i, &j))
+}
+
+// TestBackoffOnRangefeedFailure ensures that the backoff occurs when a
+// rangefeed fails. It observes this indirectly by looking at logs.
+func TestBackoffOnRangefeedFailure(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var called int64
+	const timesToFail = 3
+	rpcKnobs := rpc.ContextTestingKnobs{
+		StreamClientInterceptor: func(
+			target string, class rpc.ConnectionClass,
+		) grpc.StreamClientInterceptor {
+			return func(
+				ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn,
+				method string, streamer grpc.Streamer, opts ...grpc.CallOption,
+			) (stream grpc.ClientStream, err error) {
+				if strings.Contains(method, "RangeFeed") &&
+					atomic.AddInt64(&called, 1) <= timesToFail {
+					return nil, errors.Errorf("boom")
+				}
+				return streamer(ctx, desc, cc, method, opts...)
+			}
+		},
+	}
+	ctx := context.Background()
+	var seen struct {
+		syncutil.Mutex
+		entries []log.Entry
+	}
+	restartingRE := regexp.MustCompile("restarting rangefeed.*after.*")
+	log.Intercept(ctx, func(entry log.Entry) {
+		if !restartingRE.MatchString(entry.Message) {
+			return
+		}
+		seen.Lock()
+		defer seen.Unlock()
+		seen.entries = append(seen.entries, entry)
+	})
+	defer log.Intercept(ctx, nil)
+	tc := testcluster.StartTestCluster(t, 2, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Server: &server.TestingKnobs{
+					ContextTestingKnobs: rpcKnobs,
+				},
+			},
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+	testutils.SucceedsSoon(t, func() error {
+		seen.Lock()
+		defer seen.Unlock()
+		if len(seen.entries) < timesToFail {
+			return errors.Errorf("seen %d, waiting for %d", len(seen.entries), timesToFail)
+		}
+		return nil
+	})
+	seen.Lock()
+	defer seen.Unlock()
+	minimumBackoff := 85 * time.Millisecond // initialBackoff less jitter
+	var totalBackoff time.Duration
+	for i := 1; i < len(seen.entries); i++ {
+		totalBackoff += time.Duration(seen.entries[i].Time - seen.entries[i-1].Time)
+	}
+	require.Greater(t, totalBackoff.Nanoseconds(), (3 * minimumBackoff).Nanoseconds())
 }


### PR DESCRIPTION
In this release we added logic to watch for changes to the schema using
rangefeeds instead of the gossip notification. In that change a loop was
added to restart the changefeed in the face of failure. This commit enhances
that loop to backoff in the face of failure preventing extremely rapid
retries. It additionally adds a log.Every to avoid logging on every failure.

Fixes #50264.

Release note: None