### PR TITLE
sql: make error message for invalid id type reference better

### DIFF
--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -290,6 +290,13 @@ func ResolveTypeDescByID(
 	if err != nil {
 		return nil, nil, err
 	}
+	if desc == nil {
+		if lookupFlags.Required {
+			return nil, nil, pgerror.Newf(
+				pgcode.UndefinedObject, "type with ID %d does not exist", id)
+		}
+		return nil, nil, nil
+	}
 	if desc.TypeDesc() == nil {
 		return nil, nil, errors.AssertionFailedf("%s was not a type descriptor", desc)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/numeric_references
+++ b/pkg/sql/logictest/testdata/logic_test/numeric_references
@@ -215,3 +215,6 @@ DELETE FROM [$num_ref_id AS t]
 
 statement error pq: user testuser does not have UPDATE privilege on relation num_ref
 UPDATE [$num_ref_id AS t] SET d=1
+
+statement error pq: type with ID 15210 does not exist
+SELECT 1::@15210

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -184,7 +184,15 @@ func (p *planner) ResolveType(
 
 // ResolveTypeByID implements the tree.TypeResolver interface.
 func (p *planner) ResolveTypeByID(ctx context.Context, id uint32) (*types.T, error) {
-	name, desc, err := resolver.ResolveTypeDescByID(ctx, p.txn, p.ExecCfg().Codec, sqlbase.ID(id), tree.ObjectLookupFlags{})
+	name, desc, err := resolver.ResolveTypeDescByID(
+		ctx,
+		p.txn,
+		p.ExecCfg().Codec,
+		sqlbase.ID(id),
+		tree.ObjectLookupFlags{
+			CommonLookupFlags: tree.CommonLookupFlags{Required: true},
+		},
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #50276.

Release note (bug fix): Fix an internal error from being thrown when
referencing a type that does not exist by ID.