### PR TITLE
geo/geomfn: Implements ST_ShortestLine

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1171,6 +1171,9 @@ Negative azimuth values and values greater than 2π (360 degrees) are supported.
 </span></td></tr>
 <tr><td><a name="st_setsrid"></a><code>st_setsrid(geometry: geometry, srid: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Sets a Geometry to a new SRID without transforming the coordinates.</p>
 </span></td></tr>
+<tr><td><a name="st_shortestline"></a><code>st_shortestline(geometry_a: geometry, geometry_b: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the LineString corresponds to the minimum distance across every pair of points comprising the given geometries.</p>
+<p>Note if geometries are the same, it will return the LineString with the minimum distance between the geometry’s vertexes. The function will return the shortest line that was discovered first when comparing minimum distances if more than one is found.</p>
+</span></td></tr>
 <tr><td><a name="st_srid"></a><code>st_srid(geography: geography) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the Spatial Reference Identifier (SRID) for the ST_Geography as defined in spatial_ref_sys table.</p>
 </span></td></tr>
 <tr><td><a name="st_srid"></a><code>st_srid(geometry: geometry) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the Spatial Reference Identifier (SRID) for the ST_Geometry as defined in spatial_ref_sys table.</p>

--- a/pkg/geo/geogfn/distance.go
+++ b/pkg/geo/geogfn/distance.go
@@ -159,8 +159,10 @@ type s2GeodistEdgeCrosser struct {
 var _ geodist.EdgeCrosser = (*s2GeodistEdgeCrosser)(nil)
 
 // ChainCrossing implements geodist.EdgeCrosser.
-func (c *s2GeodistEdgeCrosser) ChainCrossing(p geodist.Point) bool {
-	return c.EdgeCrosser.ChainCrossingSign(p.(*s2GeodistPoint).Point) != s2.DoNotCross
+func (c *s2GeodistEdgeCrosser) ChainCrossing(p geodist.Point) (bool, geodist.Point) {
+	// Returns nil for the intersection point as we don't require the intersection
+	// point as we do not have to implement ShortestLine in geography.
+	return c.EdgeCrosser.ChainCrossingSign(p.(*s2GeodistPoint).Point) != s2.DoNotCross, nil
 }
 
 // distanceGeographyRegions calculates the distance between two sets of regions.
@@ -284,7 +286,7 @@ func (u *geographyMinDistanceUpdater) Update(
 }
 
 // OnIntersects implements the geodist.DistanceUpdater interface.
-func (u *geographyMinDistanceUpdater) OnIntersects() bool {
+func (u *geographyMinDistanceUpdater) OnIntersects(p geodist.Point) bool {
 	u.minD = 0
 	return true
 }

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -675,116 +675,117 @@ Square overlapping left and right square  Square (left)                         
 Square overlapping left and right square  Square (right)                            0                 1.48660687473185
 Square overlapping left and right square  Square overlapping left and right square  0                 1.48660687473185
 
-# ST_LongestLine
-query TTT
+# ST_LongestLine, ST_ShortestLine
+query TTTT
 SELECT
   a.dsc,
   b.dsc,
-  ST_AsText(ST_LongestLine(a.geom, b.geom))
+  ST_AsText(ST_LongestLine(a.geom, b.geom)),
+  ST_AsText(ST_ShortestLine(a.geom, b.geom))
 FROM geom_operators_test a
 JOIN geom_operators_test b ON (1=1)
 ORDER BY a.dsc, b.dsc
 ----
-Empty GeometryCollection                  Empty GeometryCollection                  NULL
-Empty GeometryCollection                  Empty LineString                          NULL
-Empty GeometryCollection                  Faraway point                             NULL
-Empty GeometryCollection                  Line going through left and right square  NULL
-Empty GeometryCollection                  NULL                                      NULL
-Empty GeometryCollection                  Point middle of Left Square               NULL
-Empty GeometryCollection                  Point middle of Right Square              NULL
-Empty GeometryCollection                  Square (left)                             NULL
-Empty GeometryCollection                  Square (right)                            NULL
-Empty GeometryCollection                  Square overlapping left and right square  NULL
-Empty LineString                          Empty GeometryCollection                  NULL
-Empty LineString                          Empty LineString                          NULL
-Empty LineString                          Faraway point                             NULL
-Empty LineString                          Line going through left and right square  NULL
-Empty LineString                          NULL                                      NULL
-Empty LineString                          Point middle of Left Square               NULL
-Empty LineString                          Point middle of Right Square              NULL
-Empty LineString                          Square (left)                             NULL
-Empty LineString                          Square (right)                            NULL
-Empty LineString                          Square overlapping left and right square  NULL
-Faraway point                             Empty GeometryCollection                  NULL
-Faraway point                             Empty LineString                          NULL
-Faraway point                             Faraway point                             LINESTRING (5 5, 5 5)
-Faraway point                             Line going through left and right square  LINESTRING (5 5, -0.5 0.5)
-Faraway point                             NULL                                      NULL
-Faraway point                             Point middle of Left Square               LINESTRING (5 5, -0.5 0.5)
-Faraway point                             Point middle of Right Square              LINESTRING (5 5, 0.5 0.5)
-Faraway point                             Square (left)                             LINESTRING (5 5, -1 0)
-Faraway point                             Square (right)                            LINESTRING (5 5, 0 0)
-Faraway point                             Square overlapping left and right square  LINESTRING (5 5, -0.1 0)
-Line going through left and right square  Empty GeometryCollection                  NULL
-Line going through left and right square  Empty LineString                          NULL
-Line going through left and right square  Faraway point                             LINESTRING (-0.5 0.5, 5 5)
-Line going through left and right square  Line going through left and right square  LINESTRING (-0.5 0.5, 0.5 0.5)
-Line going through left and right square  NULL                                      NULL
-Line going through left and right square  Point middle of Left Square               LINESTRING (0.5 0.5, -0.5 0.5)
-Line going through left and right square  Point middle of Right Square              LINESTRING (-0.5 0.5, 0.5 0.5)
-Line going through left and right square  Square (left)                             LINESTRING (0.5 0.5, -1 0)
-Line going through left and right square  Square (right)                            LINESTRING (-0.5 0.5, 1 0)
-Line going through left and right square  Square overlapping left and right square  LINESTRING (-0.5 0.5, 1 0)
-NULL                                      Empty GeometryCollection                  NULL
-NULL                                      Empty LineString                          NULL
-NULL                                      Faraway point                             NULL
-NULL                                      Line going through left and right square  NULL
-NULL                                      NULL                                      NULL
-NULL                                      Point middle of Left Square               NULL
-NULL                                      Point middle of Right Square              NULL
-NULL                                      Square (left)                             NULL
-NULL                                      Square (right)                            NULL
-NULL                                      Square overlapping left and right square  NULL
-Point middle of Left Square               Empty GeometryCollection                  NULL
-Point middle of Left Square               Empty LineString                          NULL
-Point middle of Left Square               Faraway point                             LINESTRING (-0.5 0.5, 5 5)
-Point middle of Left Square               Line going through left and right square  LINESTRING (-0.5 0.5, 0.5 0.5)
-Point middle of Left Square               NULL                                      NULL
-Point middle of Left Square               Point middle of Left Square               LINESTRING (-0.5 0.5, -0.5 0.5)
-Point middle of Left Square               Point middle of Right Square              LINESTRING (-0.5 0.5, 0.5 0.5)
-Point middle of Left Square               Square (left)                             LINESTRING (-0.5 0.5, 0 0)
-Point middle of Left Square               Square (right)                            LINESTRING (-0.5 0.5, 1 0)
-Point middle of Left Square               Square overlapping left and right square  LINESTRING (-0.5 0.5, 1 0)
-Point middle of Right Square              Empty GeometryCollection                  NULL
-Point middle of Right Square              Empty LineString                          NULL
-Point middle of Right Square              Faraway point                             LINESTRING (0.5 0.5, 5 5)
-Point middle of Right Square              Line going through left and right square  LINESTRING (0.5 0.5, -0.5 0.5)
-Point middle of Right Square              NULL                                      NULL
-Point middle of Right Square              Point middle of Left Square               LINESTRING (0.5 0.5, -0.5 0.5)
-Point middle of Right Square              Point middle of Right Square              LINESTRING (0.5 0.5, 0.5 0.5)
-Point middle of Right Square              Square (left)                             LINESTRING (0.5 0.5, -1 1)
-Point middle of Right Square              Square (right)                            LINESTRING (0.5 0.5, 1 0)
-Point middle of Right Square              Square overlapping left and right square  LINESTRING (0.5 0.5, -0.1 1)
-Square (left)                             Empty GeometryCollection                  NULL
-Square (left)                             Empty LineString                          NULL
-Square (left)                             Faraway point                             LINESTRING (-1 0, 5 5)
-Square (left)                             Line going through left and right square  LINESTRING (-1 0, 0.5 0.5)
-Square (left)                             NULL                                      NULL
-Square (left)                             Point middle of Left Square               LINESTRING (0 0, -0.5 0.5)
-Square (left)                             Point middle of Right Square              LINESTRING (-1 1, 0.5 0.5)
-Square (left)                             Square (left)                             LINESTRING (-1 0, 0 1)
-Square (left)                             Square (right)                            LINESTRING (-1 0, 1 1)
-Square (left)                             Square overlapping left and right square  LINESTRING (-1 0, 1 1)
-Square (right)                            Empty GeometryCollection                  NULL
-Square (right)                            Empty LineString                          NULL
-Square (right)                            Faraway point                             LINESTRING (0 0, 5 5)
-Square (right)                            Line going through left and right square  LINESTRING (1 0, -0.5 0.5)
-Square (right)                            NULL                                      NULL
-Square (right)                            Point middle of Left Square               LINESTRING (1 0, -0.5 0.5)
-Square (right)                            Point middle of Right Square              LINESTRING (1 0, 0.5 0.5)
-Square (right)                            Square (left)                             LINESTRING (1 0, -1 1)
-Square (right)                            Square (right)                            LINESTRING (0 0, 1 1)
-Square (right)                            Square overlapping left and right square  LINESTRING (1 0, -0.1 1)
-Square overlapping left and right square  Empty GeometryCollection                  NULL
-Square overlapping left and right square  Empty LineString                          NULL
-Square overlapping left and right square  Faraway point                             LINESTRING (-0.1 0, 5 5)
-Square overlapping left and right square  Line going through left and right square  LINESTRING (1 0, -0.5 0.5)
-Square overlapping left and right square  NULL                                      NULL
-Square overlapping left and right square  Point middle of Left Square               LINESTRING (1 0, -0.5 0.5)
-Square overlapping left and right square  Point middle of Right Square              LINESTRING (-0.1 1, 0.5 0.5)
-Square overlapping left and right square  Square (left)                             LINESTRING (1 0, -1 1)
-Square overlapping left and right square  Square (right)                            LINESTRING (-0.1 0, 1 1)
-Square overlapping left and right square  Square overlapping left and right square  LINESTRING (-0.1 0, 1 1)
+Empty GeometryCollection                  Empty GeometryCollection                  NULL                             NULL
+Empty GeometryCollection                  Empty LineString                          NULL                             NULL
+Empty GeometryCollection                  Faraway point                             NULL                             NULL
+Empty GeometryCollection                  Line going through left and right square  NULL                             NULL
+Empty GeometryCollection                  NULL                                      NULL                             NULL
+Empty GeometryCollection                  Point middle of Left Square               NULL                             NULL
+Empty GeometryCollection                  Point middle of Right Square              NULL                             NULL
+Empty GeometryCollection                  Square (left)                             NULL                             NULL
+Empty GeometryCollection                  Square (right)                            NULL                             NULL
+Empty GeometryCollection                  Square overlapping left and right square  NULL                             NULL
+Empty LineString                          Empty GeometryCollection                  NULL                             NULL
+Empty LineString                          Empty LineString                          NULL                             NULL
+Empty LineString                          Faraway point                             NULL                             NULL
+Empty LineString                          Line going through left and right square  NULL                             NULL
+Empty LineString                          NULL                                      NULL                             NULL
+Empty LineString                          Point middle of Left Square               NULL                             NULL
+Empty LineString                          Point middle of Right Square              NULL                             NULL
+Empty LineString                          Square (left)                             NULL                             NULL
+Empty LineString                          Square (right)                            NULL                             NULL
+Empty LineString                          Square overlapping left and right square  NULL                             NULL
+Faraway point                             Empty GeometryCollection                  NULL                             NULL
+Faraway point                             Empty LineString                          NULL                             NULL
+Faraway point                             Faraway point                             LINESTRING (5 5, 5 5)            LINESTRING (5 5, 5 5)
+Faraway point                             Line going through left and right square  LINESTRING (5 5, -0.5 0.5)       LINESTRING (5 5, 0.5 0.5)
+Faraway point                             NULL                                      NULL                             NULL
+Faraway point                             Point middle of Left Square               LINESTRING (5 5, -0.5 0.5)       LINESTRING (5 5, -0.5 0.5)
+Faraway point                             Point middle of Right Square              LINESTRING (5 5, 0.5 0.5)        LINESTRING (5 5, 0.5 0.5)
+Faraway point                             Square (left)                             LINESTRING (5 5, -1 0)           LINESTRING (5 5, 0 1)
+Faraway point                             Square (right)                            LINESTRING (5 5, 0 0)            LINESTRING (5 5, 1 1)
+Faraway point                             Square overlapping left and right square  LINESTRING (5 5, -0.1 0)         LINESTRING (5 5, 1 1)
+Line going through left and right square  Empty GeometryCollection                  NULL                             NULL
+Line going through left and right square  Empty LineString                          NULL                             NULL
+Line going through left and right square  Faraway point                             LINESTRING (-0.5 0.5, 5 5)       LINESTRING (0.5 0.5, 5 5)
+Line going through left and right square  Line going through left and right square  LINESTRING (-0.5 0.5, 0.5 0.5)   LINESTRING (-0.5 0.5, -0.5 0.5)
+Line going through left and right square  NULL                                      NULL                             NULL
+Line going through left and right square  Point middle of Left Square               LINESTRING (0.5 0.5, -0.5 0.5)   LINESTRING (-0.5 0.5, -0.5 0.5)
+Line going through left and right square  Point middle of Right Square              LINESTRING (-0.5 0.5, 0.5 0.5)   LINESTRING (0.5 0.5, 0.5 0.5)
+Line going through left and right square  Square (left)                             LINESTRING (0.5 0.5, -1 0)       LINESTRING (-0.5 0.5, -0.5 0.5)
+Line going through left and right square  Square (right)                            LINESTRING (-0.5 0.5, 1 0)       LINESTRING (0 0.5, 0 0.5)
+Line going through left and right square  Square overlapping left and right square  LINESTRING (-0.5 0.5, 1 0)       LINESTRING (-0.1 0.5, -0.1 0.5)
+NULL                                      Empty GeometryCollection                  NULL                             NULL
+NULL                                      Empty LineString                          NULL                             NULL
+NULL                                      Faraway point                             NULL                             NULL
+NULL                                      Line going through left and right square  NULL                             NULL
+NULL                                      NULL                                      NULL                             NULL
+NULL                                      Point middle of Left Square               NULL                             NULL
+NULL                                      Point middle of Right Square              NULL                             NULL
+NULL                                      Square (left)                             NULL                             NULL
+NULL                                      Square (right)                            NULL                             NULL
+NULL                                      Square overlapping left and right square  NULL                             NULL
+Point middle of Left Square               Empty GeometryCollection                  NULL                             NULL
+Point middle of Left Square               Empty LineString                          NULL                             NULL
+Point middle of Left Square               Faraway point                             LINESTRING (-0.5 0.5, 5 5)       LINESTRING (-0.5 0.5, 5 5)
+Point middle of Left Square               Line going through left and right square  LINESTRING (-0.5 0.5, 0.5 0.5)   LINESTRING (-0.5 0.5, -0.5 0.5)
+Point middle of Left Square               NULL                                      NULL                             NULL
+Point middle of Left Square               Point middle of Left Square               LINESTRING (-0.5 0.5, -0.5 0.5)  LINESTRING (-0.5 0.5, -0.5 0.5)
+Point middle of Left Square               Point middle of Right Square              LINESTRING (-0.5 0.5, 0.5 0.5)   LINESTRING (-0.5 0.5, 0.5 0.5)
+Point middle of Left Square               Square (left)                             LINESTRING (-0.5 0.5, 0 0)       LINESTRING (-0.5 0.5, -0.5 0.5)
+Point middle of Left Square               Square (right)                            LINESTRING (-0.5 0.5, 1 0)       LINESTRING (-0.5 0.5, 0 0.5)
+Point middle of Left Square               Square overlapping left and right square  LINESTRING (-0.5 0.5, 1 0)       LINESTRING (-0.5 0.5, -0.1 0.5)
+Point middle of Right Square              Empty GeometryCollection                  NULL                             NULL
+Point middle of Right Square              Empty LineString                          NULL                             NULL
+Point middle of Right Square              Faraway point                             LINESTRING (0.5 0.5, 5 5)        LINESTRING (0.5 0.5, 5 5)
+Point middle of Right Square              Line going through left and right square  LINESTRING (0.5 0.5, -0.5 0.5)   LINESTRING (0.5 0.5, 0.5 0.5)
+Point middle of Right Square              NULL                                      NULL                             NULL
+Point middle of Right Square              Point middle of Left Square               LINESTRING (0.5 0.5, -0.5 0.5)   LINESTRING (0.5 0.5, -0.5 0.5)
+Point middle of Right Square              Point middle of Right Square              LINESTRING (0.5 0.5, 0.5 0.5)    LINESTRING (0.5 0.5, 0.5 0.5)
+Point middle of Right Square              Square (left)                             LINESTRING (0.5 0.5, -1 1)       LINESTRING (0.5 0.5, 0 0.5)
+Point middle of Right Square              Square (right)                            LINESTRING (0.5 0.5, 1 0)        LINESTRING (0.5 0.5, 0.5 0.5)
+Point middle of Right Square              Square overlapping left and right square  LINESTRING (0.5 0.5, -0.1 1)     LINESTRING (0.5 0.5, 0.5 0.5)
+Square (left)                             Empty GeometryCollection                  NULL                             NULL
+Square (left)                             Empty LineString                          NULL                             NULL
+Square (left)                             Faraway point                             LINESTRING (-1 0, 5 5)           LINESTRING (0 1, 5 5)
+Square (left)                             Line going through left and right square  LINESTRING (-1 0, 0.5 0.5)       LINESTRING (-0.5 0.5, -0.5 0.5)
+Square (left)                             NULL                                      NULL                             NULL
+Square (left)                             Point middle of Left Square               LINESTRING (0 0, -0.5 0.5)       LINESTRING (-0.5 0.5, -0.5 0.5)
+Square (left)                             Point middle of Right Square              LINESTRING (-1 1, 0.5 0.5)       LINESTRING (0 0.5, 0.5 0.5)
+Square (left)                             Square (left)                             LINESTRING (-1 0, 0 1)           LINESTRING (-1 0, -1 0)
+Square (left)                             Square (right)                            LINESTRING (-1 0, 1 1)           LINESTRING (0 0, 0 0)
+Square (left)                             Square overlapping left and right square  LINESTRING (-1 0, 1 1)           LINESTRING (-0.1 0, -0.1 0)
+Square (right)                            Empty GeometryCollection                  NULL                             NULL
+Square (right)                            Empty LineString                          NULL                             NULL
+Square (right)                            Faraway point                             LINESTRING (0 0, 5 5)            LINESTRING (1 1, 5 5)
+Square (right)                            Line going through left and right square  LINESTRING (1 0, -0.5 0.5)       LINESTRING (0 0.5, 0 0.5)
+Square (right)                            NULL                                      NULL                             NULL
+Square (right)                            Point middle of Left Square               LINESTRING (1 0, -0.5 0.5)       LINESTRING (0 0.5, -0.5 0.5)
+Square (right)                            Point middle of Right Square              LINESTRING (1 0, 0.5 0.5)        LINESTRING (0.5 0.5, 0.5 0.5)
+Square (right)                            Square (left)                             LINESTRING (1 0, -1 1)           LINESTRING (0 0, 0 0)
+Square (right)                            Square (right)                            LINESTRING (0 0, 1 1)            LINESTRING (0 0, 0 0)
+Square (right)                            Square overlapping left and right square  LINESTRING (1 0, -0.1 1)         LINESTRING (0 0, 0 0)
+Square overlapping left and right square  Empty GeometryCollection                  NULL                             NULL
+Square overlapping left and right square  Empty LineString                          NULL                             NULL
+Square overlapping left and right square  Faraway point                             LINESTRING (-0.1 0, 5 5)         LINESTRING (1 1, 5 5)
+Square overlapping left and right square  Line going through left and right square  LINESTRING (1 0, -0.5 0.5)       LINESTRING (-0.1 0.5, -0.1 0.5)
+Square overlapping left and right square  NULL                                      NULL                             NULL
+Square overlapping left and right square  Point middle of Left Square               LINESTRING (1 0, -0.5 0.5)       LINESTRING (-0.1 0.5, -0.5 0.5)
+Square overlapping left and right square  Point middle of Right Square              LINESTRING (-0.1 1, 0.5 0.5)     LINESTRING (0.5 0.5, 0.5 0.5)
+Square overlapping left and right square  Square (left)                             LINESTRING (1 0, -1 1)           LINESTRING (-0.1 0, -0.1 0)
+Square overlapping left and right square  Square (right)                            LINESTRING (-0.1 0, 1 1)         LINESTRING (0 0, 0 0)
+Square overlapping left and right square  Square overlapping left and right square  LINESTRING (-0.1 0, 1 1)         LINESTRING (-0.1 0, -0.1 0)
 
 # Binary predicates
 query TTBBBBBBBBBB

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -1891,6 +1891,31 @@ Note if geometries are the same, it will return the LineString with the maximum 
 			tree.VolatilityImmutable,
 		),
 	),
+	"st_shortestline": makeBuiltin(
+		defProps(),
+		geometryOverload2(
+			func(ctx *tree.EvalContext, a, b *tree.DGeometry) (tree.Datum, error) {
+				shortestLineString, err := geomfn.ShortestLineString(a.Geometry, b.Geometry)
+				if err != nil {
+					if geo.IsEmptyGeometryError(err) {
+						return tree.DNull, nil
+					}
+					return nil, err
+				}
+				return tree.NewDGeometry(shortestLineString), nil
+			},
+			types.Geometry,
+			infoBuilder{
+				info: `Returns the LineString corresponds to the minimum distance across every pair of points comprising ` +
+					`the given geometries. 
+
+Note if geometries are the same, it will return the LineString with the minimum distance between the geometry's ` +
+					`vertexes. The function will return the shortest line that was discovered first when comparing minimum ` +
+					`distances if more than one is found.`,
+			},
+			tree.VolatilityImmutable,
+		),
+	),
 
 	//
 	// Binary Predicates


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/49035

This PR implements ST_ShortestLine({geometry, geometry}) builtin
function. Which allow us to find the LineString corresponds to
the minimum distance between given two geometrical objects.

Release note (sql change): This PR implements ST_ShortestLine({geometry,
geometry}) builtin function.