### PR TITLE
sql/tests: fix GenerateRandomArg for CollatedStrings

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -288,7 +288,14 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 		switch ft := nb.builtin.Types.(type) {
 		case tree.ArgTypes:
 			for _, arg := range ft {
-				args = append(args, r.GenerateRandomArg(arg.Typ))
+				// CollatedString's default has no Locale, and so GenerateRandomArg will panic
+				// on RandDatumWithNilChance. Copy the typ and fake a locale.
+				typ := *arg.Typ
+				if typ.Locale() == "" && typ.Family() == types.CollatedStringFamily {
+					locale := "en_US"
+					typ.InternalType.Locale = &locale
+				}
+				args = append(args, r.GenerateRandomArg(&typ))
 			}
 		case tree.HomogeneousType:
 			for i := r.Intn(5); i > 0; i-- {


### PR DESCRIPTION
The type definition for CollatedString by default has no locale. In
GenerateRandomArg, which calls RandDatumWithNilChance, having no locale
causes a panic. This is problematic for TestRandomSyntaxFunctions, which
iterates over all builtins, which in the case of "min" and "max" has a
CollatedString argument which causes the panic.

Rectify this by faking a locale for CollatedString in
`TestRandomSyntaxFunctions`.

Example: https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_RandomSyntaxTests/2006383

Release note: None