### PR TITLE
colexec: make binary operations on integers always return INT8

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/sum_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/sum_agg_gen.go
@@ -106,10 +106,10 @@ func genSumAgg(inputFileContents string, wr io.Writer, isSumInt bool) error {
 	} else {
 		supportedTypes = []*types.T{types.Int2, types.Int4, types.Int, types.Decimal, types.Float, types.Interval}
 	}
-	getAddOverload := func(inputType, retType *types.T) assignFunc {
+	getAddOverload := func(inputType *types.T) assignFunc {
 		if isSumInt {
-			var c intCustomizer
-			return c.getBinOpAssignFuncWithPromotedReturnType(retType)
+			c := intCustomizer{width: anyWidth}
+			return c.getBinOpAssignFunc()
 		}
 		return getSumAddOverload(inputType)
 	}
@@ -137,7 +137,7 @@ func genSumAgg(inputFileContents string, wr io.Writer, isSumInt bool) error {
 			InputVecMethod: toVecMethod(inputType.Family(), inputType.Width()),
 			RetGoType:      toPhysicalRepresentation(retType.Family(), retType.Width()),
 			RetVecMethod:   toVecMethod(retType.Family(), retType.Width()),
-			addOverload:    getAddOverload(inputType, retType),
+			addOverload:    getAddOverload(inputType),
 		})
 	}
 	return tmpl.Execute(wr, struct {

--- a/pkg/sql/colexec/overloads_test.go
+++ b/pkg/sql/colexec/overloads_test.go
@@ -26,40 +26,40 @@ func TestIntegerAddition(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// The addition overload is the same for all integer widths, so we only test
 	// one of them.
-	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performPlusInt16Int16(1, math.MaxInt16) }), tree.ErrIntOutOfRange))
-	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performPlusInt16Int16(-1, math.MinInt16) }), tree.ErrIntOutOfRange))
-	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performPlusInt16Int16(math.MaxInt16, 1) }), tree.ErrIntOutOfRange))
-	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performPlusInt16Int16(math.MinInt16, -1) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performPlusInt64Int64(1, math.MaxInt64) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performPlusInt64Int64(-1, math.MinInt64) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performPlusInt64Int64(math.MaxInt64, 1) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performPlusInt64Int64(math.MinInt64, -1) }), tree.ErrIntOutOfRange))
 
-	require.Equal(t, int16(math.MaxInt16), performPlusInt16Int16(1, math.MaxInt16-1))
-	require.Equal(t, int16(math.MinInt16), performPlusInt16Int16(-1, math.MinInt16+1))
-	require.Equal(t, int16(math.MaxInt16-1), performPlusInt16Int16(-1, math.MaxInt16))
-	require.Equal(t, int16(math.MinInt16+1), performPlusInt16Int16(1, math.MinInt16))
+	require.Equal(t, int64(math.MaxInt64), performPlusInt64Int64(1, math.MaxInt64-1))
+	require.Equal(t, int64(math.MinInt64), performPlusInt64Int64(-1, math.MinInt64+1))
+	require.Equal(t, int64(math.MaxInt64-1), performPlusInt64Int64(-1, math.MaxInt64))
+	require.Equal(t, int64(math.MinInt64+1), performPlusInt64Int64(1, math.MinInt64))
 
-	require.Equal(t, int16(22), performPlusInt16Int16(10, 12))
-	require.Equal(t, int16(-22), performPlusInt16Int16(-10, -12))
-	require.Equal(t, int16(2), performPlusInt16Int16(-10, 12))
-	require.Equal(t, int16(-2), performPlusInt16Int16(10, -12))
+	require.Equal(t, int64(22), performPlusInt64Int64(10, 12))
+	require.Equal(t, int64(-22), performPlusInt64Int64(-10, -12))
+	require.Equal(t, int64(2), performPlusInt64Int64(-10, 12))
+	require.Equal(t, int64(-2), performPlusInt64Int64(10, -12))
 }
 
 func TestIntegerSubtraction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// The subtraction overload is the same for all integer widths, so we only
 	// test one of them.
-	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMinusInt16Int16(1, -math.MaxInt16) }), tree.ErrIntOutOfRange))
-	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMinusInt16Int16(-2, math.MaxInt16) }), tree.ErrIntOutOfRange))
-	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMinusInt16Int16(math.MaxInt16, -1) }), tree.ErrIntOutOfRange))
-	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMinusInt16Int16(math.MinInt16, 1) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMinusInt64Int64(1, -math.MaxInt64) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMinusInt64Int64(-2, math.MaxInt64) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMinusInt64Int64(math.MaxInt64, -1) }), tree.ErrIntOutOfRange))
+	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMinusInt64Int64(math.MinInt64, 1) }), tree.ErrIntOutOfRange))
 
-	require.Equal(t, int16(math.MaxInt16), performMinusInt16Int16(1, -math.MaxInt16+1))
-	require.Equal(t, int16(math.MinInt16), performMinusInt16Int16(-1, math.MaxInt16))
-	require.Equal(t, int16(math.MaxInt16-1), performMinusInt16Int16(-1, -math.MaxInt16))
-	require.Equal(t, int16(math.MinInt16+1), performMinusInt16Int16(0, math.MaxInt16))
+	require.Equal(t, int64(math.MaxInt64), performMinusInt64Int64(1, -math.MaxInt64+1))
+	require.Equal(t, int64(math.MinInt64), performMinusInt64Int64(-1, math.MaxInt64))
+	require.Equal(t, int64(math.MaxInt64-1), performMinusInt64Int64(-1, -math.MaxInt64))
+	require.Equal(t, int64(math.MinInt64+1), performMinusInt64Int64(0, math.MaxInt64))
 
-	require.Equal(t, int16(-2), performMinusInt16Int16(10, 12))
-	require.Equal(t, int16(2), performMinusInt16Int16(-10, -12))
-	require.Equal(t, int16(-22), performMinusInt16Int16(-10, 12))
-	require.Equal(t, int16(22), performMinusInt16Int16(10, -12))
+	require.Equal(t, int64(-2), performMinusInt64Int64(10, 12))
+	require.Equal(t, int64(2), performMinusInt64Int64(-10, -12))
+	require.Equal(t, int64(-22), performMinusInt64Int64(-10, 12))
+	require.Equal(t, int64(22), performMinusInt64Int64(10, -12))
 }
 
 func TestIntegerDivision(t *testing.T) {
@@ -92,35 +92,35 @@ func TestIntegerDivision(t *testing.T) {
 
 func TestIntegerMultiplication(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MaxInt16-1, 100) }), tree.ErrIntOutOfRange))
-	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MaxInt16-1, 3) }), tree.ErrIntOutOfRange))
-	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MinInt16+1, 3) }), tree.ErrIntOutOfRange))
-	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MinInt16+1, 100) }), tree.ErrIntOutOfRange))
+	require.Equal(t, 100*(int64(math.MaxInt16)-1), performMultInt16Int16(math.MaxInt16-1, 100))
+	require.Equal(t, 3*(int64(math.MaxInt16)-1), performMultInt16Int16(math.MaxInt16-1, 3))
+	require.Equal(t, 3*(int64(math.MinInt16)+1), performMultInt16Int16(math.MinInt16+1, 3))
+	require.Equal(t, 100*(int64(math.MinInt16)+1), performMultInt16Int16(math.MinInt16+1, 100))
 
-	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MaxInt32-1, 100) }), tree.ErrIntOutOfRange))
-	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MaxInt32-1, 3) }), tree.ErrIntOutOfRange))
-	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MinInt32+1, 3) }), tree.ErrIntOutOfRange))
-	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MinInt32+1, 100) }), tree.ErrIntOutOfRange))
+	require.Equal(t, 100*(int64(math.MaxInt32)-1), performMultInt32Int32(math.MaxInt32-1, 100))
+	require.Equal(t, 3*(int64(math.MaxInt32)-1), performMultInt32Int32(math.MaxInt32-1, 3))
+	require.Equal(t, 3*(int64(math.MinInt32)+1), performMultInt32Int32(math.MinInt32+1, 3))
+	require.Equal(t, 100*(int64(math.MinInt32)+1), performMultInt32Int32(math.MinInt32+1, 100))
 
 	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MaxInt64-1, 100) }), tree.ErrIntOutOfRange))
 	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MaxInt64-1, 3) }), tree.ErrIntOutOfRange))
 	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MinInt64+1, 3) }), tree.ErrIntOutOfRange))
 	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MinInt64+1, 100) }), tree.ErrIntOutOfRange))
 
-	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMultInt16Int16(math.MinInt16, -1) }), tree.ErrIntOutOfRange))
-	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMultInt32Int32(math.MinInt32, -1) }), tree.ErrIntOutOfRange))
+	require.Equal(t, -int64(math.MinInt16), performMultInt16Int16(math.MinInt16, -1))
+	require.Equal(t, -int64(math.MinInt32), performMultInt32Int32(math.MinInt32, -1))
 	require.True(t, errors.Is(colexecerror.CatchVectorizedRuntimeError(func() { performMultInt64Int64(math.MinInt64, -1) }), tree.ErrIntOutOfRange))
 
-	require.Equal(t, int16(-math.MaxInt16), performMultInt16Int16(math.MaxInt16, -1))
-	require.Equal(t, int32(-math.MaxInt32), performMultInt32Int32(math.MaxInt32, -1))
+	require.Equal(t, int64(-math.MaxInt16), performMultInt16Int16(math.MaxInt16, -1))
+	require.Equal(t, int64(-math.MaxInt32), performMultInt32Int32(math.MaxInt32, -1))
 	require.Equal(t, int64(-math.MaxInt64), performMultInt64Int64(math.MaxInt64, -1))
 
-	require.Equal(t, int16(0), performMultInt16Int16(math.MinInt16, 0))
-	require.Equal(t, int32(0), performMultInt32Int32(math.MinInt32, 0))
+	require.Equal(t, int64(0), performMultInt16Int16(math.MinInt16, 0))
+	require.Equal(t, int64(0), performMultInt32Int32(math.MinInt32, 0))
 	require.Equal(t, int64(0), performMultInt64Int64(math.MinInt64, 0))
 
-	require.Equal(t, int16(120), performMultInt16Int16(-10, -12))
-	require.Equal(t, int32(-120), performMultInt32Int32(-12, 10))
+	require.Equal(t, int64(120), performMultInt16Int16(-10, -12))
+	require.Equal(t, int64(-120), performMultInt32Int32(-12, 10))
 	require.Equal(t, int64(-120), performMultInt64Int64(12, -10))
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -163,3 +163,29 @@ EXPLAIN (VEC) SELECT max(c) FROM a
   └ *colexec.orderedAggregator
     └ *colexec.distinctChainOps
       └ *colexec.colBatchScan
+
+# Verify that binary operations on integers of any width return INT8.
+statement ok
+CREATE TABLE ints (_int2 INT2, _int4 INT4, _int8 INT8);
+INSERT INTO ints VALUES (1, 1, 1), (2, 2, 2)
+
+query T
+SELECT pg_typeof(_int2 - _int2) FROM ints LIMIT 1
+----
+bigint
+
+query T
+EXPLAIN (VEC) SELECT _int2 * _int2 FROM ints WHERE _int4 + _int4 = _int8 + 2
+----
+│
+└ Node 1
+  └ *colexec.projMultInt16Int16Op
+    └ *colexec.selEQInt64Int64Op
+      └ *colexec.projPlusInt64Int64ConstOp
+        └ *colexec.projPlusInt32Int32Op
+          └ *colexec.colBatchScan
+
+query I
+SELECT _int2 * _int2 FROM ints WHERE _int4 + _int4 = _int8 + 2
+----
+4


### PR DESCRIPTION
This commit makes all binary operations on integers return `INT8`
regardless of the widths of the arguments. This aligns the vectorized
engine with the type-checking code. The change allows us to remove
a cast that was previously planned as a "synchronization" mechanism
between the actual physical and the expected logical types.

This change additionally allows us to remove
`getBinOpWithPromotedReturnType` method of `intCustomizer` since now
`Plus` operation always returns `INT8` which is desirable for `sum_int`
aggregate function.

Also it fixes a bug with incorrect population of output types for
"integer times `Interval`" multiplication.

Fixes: #50288.

Release note: None