### PR TITLE
opt: update docs for TableMeta.ColumnID and TableMeta.ColumnOrdinal

### DIFF
--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -32,9 +32,7 @@ const (
 )
 
 // ColumnID returns the metadata id of the column at the given ordinal position
-// in the table. This is equivalent to calling:
-//
-//   md.TableMeta(t).ColumnMeta(ord).MetaID
+// in the table.
 //
 // NOTE: This method cannot do bounds checking, so it's up to the caller to
 //       ensure that a column really does exist at this ordinal position.
@@ -43,9 +41,7 @@ func (t TableID) ColumnID(ord int) ColumnID {
 }
 
 // ColumnOrdinal returns the ordinal position of the given column in its base
-// table. This is equivalent to calling:
-//
-//   md.ColumnMeta(id).Ordinal()
+// table.
 //
 // NOTE: This method cannot do complete bounds checking, so it's up to the
 //       caller to ensure that this column is really in the given base table.


### PR DESCRIPTION
This commit updates the docs for `TableMeta.ColumnID` and
`TableMeta.ColumnOrdinal` so that the no longer reference functions that
don't exist.

Release note: None