### PR TITLE
sql: populate role valid until fields in pg_catalog tables

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"time"
 	"unicode/utf8"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -1817,11 +1818,13 @@ func forEachColumnInIndex(
 }
 
 func forEachRole(
-	ctx context.Context, p *planner, fn func(username string, isRole bool, noLogin bool) error,
+	ctx context.Context,
+	p *planner,
+	fn func(username string, isRole bool, noLogin bool, rolValidUntil *time.Time) error,
 ) error {
 	query := `
 SELECT
-	username,
+	u.username,
 	"isRole",
 	EXISTS(
 		SELECT
@@ -1831,9 +1834,13 @@ SELECT
 		WHERE
 			r.username = u.username AND option = 'NOLOGIN'
 	)
-		AS nologin
+		AS nologin,
+	ro.value::TIMESTAMPTZ AS rolvaliduntil
 FROM
-	system.users AS u;
+	system.users AS u
+	LEFT JOIN system.role_options AS ro ON
+			ro.username = u.username
+			AND option = 'VALID UNTIL';
 `
 	rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.Query(
 		ctx, "read-roles", p.txn, query,
@@ -1851,9 +1858,16 @@ FROM
 		}
 		noLogin, ok := row[2].(*tree.DBool)
 		if !ok {
-			return errors.Errorf("noLogin should be a boolean value, found %s instead", row[1].ResolvedType())
+			return errors.Errorf("noLogin should be a boolean value, found %s instead", row[2].ResolvedType())
 		}
-		if err := fn(string(username), bool(*isRole), bool(*noLogin)); err != nil {
+		var rolValidUntil *time.Time
+		if rolValidUntilDatum, ok := row[3].(*tree.DTimestampTZ); ok {
+			rolValidUntil = &rolValidUntilDatum.Time
+		} else if row[3] != tree.DNull {
+			return errors.Errorf("rolValidUntil should be a timestamp or null value, found %s instead", row[3].ResolvedType())
+		}
+
+		if err := fn(string(username), bool(*isRole), bool(*noLogin), rolValidUntil); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2473,6 +2473,42 @@ SELECT rolcanlogin FROM pg_roles WHERE rolname = 'role_test_nologin';
 ----
 false
 
+subtest regression_49420
+statement ok
+CREATE USER role_test_with_date VALID UNTIL '2021-01-01';
+CREATE USER role_test_with_date_timezone VALID UNTIL '2021-01-01 00:00:00 +02:00';
+CREATE USER role_test_nodate;
+
+query T
+SELECT rolvaliduntil FROM pg_roles WHERE rolname = 'role_test_with_date';
+----
+2021-01-01 00:00:00 +0000 UTC
+
+query T
+SELECT rolvaliduntil FROM pg_roles WHERE rolname = 'role_test_with_date_timezone';
+----
+2020-12-31 22:00:00 +0000 UTC
+
+query T
+SELECT rolvaliduntil FROM pg_roles WHERE rolname = 'role_test_nodate';
+----
+NULL
+
+query T
+SELECT rolvaliduntil FROM pg_authid WHERE rolname = 'role_test_with_date';
+----
+2021-01-01 00:00:00 +0000 UTC
+
+query T
+SELECT rolvaliduntil FROM pg_authid WHERE rolname = 'role_test_with_date_timezone';
+----
+2020-12-31 22:00:00 +0000 UTC
+
+query T
+SELECT rolvaliduntil FROM pg_authid WHERE rolname = 'role_test_nodate';
+----
+NULL
+
 subtest mutations
 
 statement error pg_tables is a system catalog

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -552,10 +552,19 @@ CREATE TABLE pg_catalog.pg_authid (
 )`,
 	populate: func(ctx context.Context, p *planner, _ *sqlbase.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
-		return forEachRole(ctx, p, func(username string, isRole bool, noLogin bool) error {
+		return forEachRole(ctx, p, func(username string, isRole bool, noLogin bool, rolValidUntil *time.Time) error {
 			isRoot := tree.DBool(username == security.RootUser || username == sqlbase.AdminRole)
 			isRoleDBool := tree.DBool(isRole)
 			roleCanLogin := tree.DBool(!noLogin)
+			roleValidUntilValue := tree.DNull
+			if rolValidUntil != nil {
+				var err error
+				roleValidUntilValue, err = tree.MakeDTimestampTZ(*rolValidUntil, time.Second)
+				if err != nil {
+					return err
+				}
+			}
+
 			return addRow(
 				h.UserOid(username),          // oid
 				tree.NewDName(username),      // rolname
@@ -568,7 +577,7 @@ CREATE TABLE pg_catalog.pg_authid (
 				tree.DBoolFalse,              // rolbypassrls
 				negOneVal,                    // rolconnlimit
 				passwdStarString,             // rolpassword
-				tree.DNull,                   // rolvaliduntil
+				roleValidUntilValue,          // rolvaliduntil
 			)
 		})
 	},
@@ -2309,10 +2318,19 @@ CREATE TABLE pg_catalog.pg_roles (
 		// include sensitive information such as password hashes.
 		h := makeOidHasher()
 		return forEachRole(ctx, p,
-			func(username string, isRole bool, noLogin bool) error {
+			func(username string, isRole bool, noLogin bool, rolValidUntil *time.Time) error {
 				isRoot := tree.DBool(username == security.RootUser || username == sqlbase.AdminRole)
 				isRoleDBool := tree.DBool(isRole)
 				roleCanLogin := tree.DBool(!noLogin)
+				roleValidUntilValue := tree.DNull
+				if rolValidUntil != nil {
+					var err error
+					roleValidUntilValue, err = tree.MakeDTimestampTZ(*rolValidUntil, time.Second)
+					if err != nil {
+						return err
+					}
+				}
+
 				return addRow(
 					h.UserOid(username),          // oid
 					tree.NewDName(username),      // rolname
@@ -2325,7 +2343,7 @@ CREATE TABLE pg_catalog.pg_roles (
 					tree.DBoolFalse,              // rolreplication
 					negOneVal,                    // rolconnlimit
 					passwdStarString,             // rolpassword
-					tree.DNull,                   // rolvaliduntil
+					roleValidUntilValue,          // rolvaliduntil
 					tree.DBoolFalse,              // rolbypassrls
 					tree.DNull,                   // rolconfig
 				)
@@ -2777,7 +2795,7 @@ CREATE TABLE pg_catalog.pg_user (
 	populate: func(ctx context.Context, p *planner, _ *sqlbase.ImmutableDatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachRole(ctx, p,
-			func(username string, isRole bool, noLogin bool) error {
+			func(username string, isRole bool, noLogin bool, rolValidUntil *time.Time) error {
 				if isRole {
 					return nil
 				}


### PR DESCRIPTION
Fixes #49420.

Previously, the `rolvaliduntil` value was always `NULL` for `pg_roles` and `pg_authid`.

Release note (bug fix): Correctly populate rolvaliduntil value for roles in pg_roles and pg_authid.