### PR TITLE
rowexec: temporarily skip failing test

### DIFF
--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -624,6 +624,8 @@ func TestDrainingProcessorSwallowsUncertaintyError(t *testing.T) {
 			}
 			vectorizeMode := "off"
 			if vectorize {
+				// TODO(yuzefovich): once #50299 is resolved, unskip this.
+				t.Skip("#50299")
 				vectorizeMode = "on"
 			}
 


### PR DESCRIPTION
Addresses: #50299.

Release note: None