### PR TITLE
release-20.1: errorutil/unimplemented: use redirect server for Github links

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -3322,7 +3322,7 @@ func TestUnimplementedSyntax(t *testing.T) {
 					t.Errorf("%s: expected %q in telemetry keys, got %+v", d.sql, exp, tkeys)
 				}
 
-				exp2 := fmt.Sprintf("issues/%d", d.issue)
+				exp2 := fmt.Sprintf("issue/%d", d.issue)
 				found = false
 				hints := errors.GetAllHints(err)
 				for _, h := range hints {

--- a/pkg/util/errorutil/unimplemented/unimplemented.go
+++ b/pkg/util/errorutil/unimplemented/unimplemented.go
@@ -109,5 +109,5 @@ func unimplementedInternal(
 
 // MakeURL produces a URL to a CockroachDB issue.
 func MakeURL(issue int) string {
-	return fmt.Sprintf("https://github.com/cockroachdb/cockroach/issues/%d", issue)
+	return fmt.Sprintf("https://go.crdb.dev/issue/%d", issue)
 }


### PR DESCRIPTION
Backport 1/1 commits from #49836.

/cc @cockroachdb/release

---

closes #45504

This will allow us to capture telemetry such as click counts for each
unimplemented error that is returned.

Release note (general change): Links that are returned in error messages
to point to unimplemented issues now use the CockroachLabs
redirect/short-link server.
