### PR TITLE
execinfra: adjust handling of trailing metadata

### DIFF
--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -474,6 +474,10 @@ type ProcessorBase struct {
 	// trace.
 	FinishTrace func()
 
+	// runningErr (when non-nil) is the error that the processor transitioned
+	// into StateDraining with. It has the highest priority and is returned as
+	// metadata first by DrainHelper.
+	runningErr error
 	// trailingMetaCallback, if set, will be called by moveToTrailingMeta(). The
 	// callback is expected to close all inputs, do other cleanup on the processor
 	// (including calling InternalClose()) and generate the trailing meta that
@@ -488,7 +492,7 @@ type ProcessorBase struct {
 	// specified.
 	trailingMetaCallback func(context.Context) []execinfrapb.ProducerMetadata
 	// trailingMeta is scratch space where metadata is stored to be returned
-	// later.
+	// later, when in StateTrailingMeta.
 	trailingMeta []execinfrapb.ProducerMetadata
 
 	// inputsToDrain, if not empty, contains inputs to be drained by
@@ -571,7 +575,7 @@ const (
 // returned from now on. In this state, the processor is expected to drain its
 // inputs (commonly by using DrainHelper()).
 //
-// If the processor has no input (ProcStateOpts.intputToDrain was not specified
+// If the processor has no input (ProcStateOpts.inputsToDrain was not specified
 // at init() time), then we move straight to the StateTrailingMeta.
 //
 // An error can be optionally passed. It will be the first piece of metadata
@@ -589,9 +593,7 @@ func (pb *ProcessorBase) MoveToDraining(err error) {
 		return
 	}
 
-	if err != nil {
-		pb.trailingMeta = append(pb.trailingMeta, execinfrapb.ProducerMetadata{Err: err})
-	}
+	pb.runningErr = err
 	if len(pb.inputsToDrain) > 0 {
 		// We go to StateDraining here. DrainHelper() will transition to
 		// StateTrailingMeta when the inputs are drained (including if the inputs
@@ -605,6 +607,21 @@ func (pb *ProcessorBase) MoveToDraining(err error) {
 	}
 }
 
+// shouldSwallowMetaWhenDraining returns whether the passed-in meta should be
+// swallowed when in StateDraining or StateTrailingMeta.
+func shouldSwallowMetaWhenDraining(meta *execinfrapb.ProducerMetadata) bool {
+	if meta != nil && meta.Err != nil {
+		// We only look for UnhandledRetryableErrors. Local reads (which would
+		// be transformed by the Root TxnCoordSender into
+		// TransactionRetryWithProtoRefreshErrors) don't have any uncertainty.
+		if ure := (*roachpb.UnhandledRetryableError)(nil); errors.As(meta.Err, &ure) {
+			uncertain := ure.PErr.Detail.GetReadWithinUncertaintyInterval()
+			return uncertain != nil
+		}
+	}
+	return false
+}
+
 // DrainHelper is supposed to be used in states draining and trailingMetadata.
 // It deals with optionally draining an input and returning trailing meta. It
 // also moves from StateDraining to StateTrailingMeta when appropriate.
@@ -613,56 +630,44 @@ func (pb *ProcessorBase) DrainHelper() *execinfrapb.ProducerMetadata {
 		log.Fatal(pb.Ctx, "drain helper called in StateRunning")
 	}
 
-	// trailingMeta always has priority; it seems like a good idea because it
-	// causes metadata to be sent quickly after it is produced (e.g. the error
-	// passed to MoveToDraining()).
-	if len(pb.trailingMeta) > 0 {
-		return pb.popTrailingMeta()
+	if err := pb.runningErr; err != nil {
+		pb.runningErr = nil
+		return &execinfrapb.ProducerMetadata{Err: err}
 	}
 
-	if pb.State != StateDraining {
-		return nil
-	}
+	if pb.State == StateDraining {
+		// Ignore all rows; only return meta.
+		for {
+			input := pb.inputsToDrain[0]
 
-	// Ignore all rows; only return meta.
-	for {
-		input := pb.inputsToDrain[0]
-
-		row, meta := input.Next()
-		if row == nil && meta == nil {
-			pb.inputsToDrain = pb.inputsToDrain[1:]
-			if len(pb.inputsToDrain) == 0 {
-				pb.moveToTrailingMeta()
-				return pb.popTrailingMeta()
-			}
-			continue
-		}
-		if meta != nil {
-			// Swallow ReadWithinUncertaintyIntervalErrors. See comments on
-			// StateDraining.
-			if err := meta.Err; err != nil {
-				// We only look for UnhandledRetryableErrors. Local reads (which would
-				// be transformed by the Root TxnCoordSender into
-				// TransactionRetryWithProtoRefreshErrors) don't have any uncertainty.
-				if ure := (*roachpb.UnhandledRetryableError)(nil); errors.As(err, &ure) {
-					uncertain := ure.PErr.Detail.GetReadWithinUncertaintyInterval()
-					if uncertain != nil {
-						continue
-					}
+			row, meta := input.Next()
+			if row == nil && meta == nil {
+				pb.inputsToDrain = pb.inputsToDrain[1:]
+				if len(pb.inputsToDrain) == 0 {
+					pb.moveToTrailingMeta()
+					break
 				}
+				continue
 			}
-			return meta
+			if meta != nil && !shouldSwallowMetaWhenDraining(meta) {
+				return meta
+			}
 		}
 	}
+
+	return pb.popTrailingMeta()
 }
 
-// popTrailingMeta peels off one piece of trailing metadata or advances to
-// StateExhausted if there's no more trailing metadata.
+// popTrailingMeta peels off one piece of trailing metadata (checking whether
+// it doesn't need to be swallowed) or advances to StateExhausted if there's no
+// more trailing metadata.
 func (pb *ProcessorBase) popTrailingMeta() *execinfrapb.ProducerMetadata {
-	if len(pb.trailingMeta) > 0 {
+	for len(pb.trailingMeta) > 0 {
 		meta := &pb.trailingMeta[0]
 		pb.trailingMeta = pb.trailingMeta[1:]
-		return meta
+		if !shouldSwallowMetaWhenDraining(meta) {
+			return meta
+		}
 	}
 	pb.State = StateExhausted
 	return nil

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -624,8 +624,6 @@ func TestDrainingProcessorSwallowsUncertaintyError(t *testing.T) {
 			}
 			vectorizeMode := "off"
 			if vectorize {
-				// TODO(yuzefovich): once #50299 is resolved, unskip this.
-				t.Skip("#50299")
 				vectorizeMode = "on"
 			}
 


### PR DESCRIPTION
We have a special "read within uncertainty interval" error that needs to
be swallowed when the processor is in draining state. Previously, this
was checked only for metadata coming from the inputs being drained.
However, we also need to check the trailing metadata coming from
`trailingMetadataCallback` and possibly swallow it as well because that
metadata originates after the processor transitions into the draining
state.

However, there is one special piece of metadata that previously lived in
`trailingMeta` - the error that `MoveToDraining` method is called with.
That error is actually a "running" metadata, not "trailing", and this
commit separates it out.

The problem of not swallowing the error from trailing meta has been
recently exposed by the change to parallel unordered synchronizer:
previously, in the unit test when forced RWUI error occurred, it was
propagated via `colexecerror.InternalError` which was caught by the
materializer which then moved to draining (making the error that special
piece of metadata described above); however, with the change to the
synchronizer, the error is now propagated as trailing meta and should be
swallowed in some cases (when the materializer is the in draining state).

Fixes: #50299.

Release note: None