### PR TITLE
urlcheck: fix the reporting of errors

### DIFF
--- a/pkg/cmd/urlcheck/lib/urlcheck/urlcheck.go
+++ b/pkg/cmd/urlcheck/lib/urlcheck/urlcheck.go
@@ -255,7 +255,7 @@ func checkURLs(uniqueURLs map[string][]string) error {
 	if len(errs) > 0 {
 		var buf bytes.Buffer
 		for _, err := range errs {
-			fmt.Fprint(&buf, err)
+			fmt.Fprintln(&buf, err)
 		}
 		fmt.Fprintf(&buf, "%d errors\n", len(errs))
 		return errors.Newf("%s", buf.String())


### PR DESCRIPTION
Fixes  #50281

Prior to this patch, urlcheck would mash up checked URLs together when
generating an error report, for example:

```
nightly_lint_test.go:44: https://www.cockroachlabs.com/docs/v20.2/create-type.html : 404 Not Found
1219:  https://www.cockroachlabs.com/docs/v20.2/create-type.htmlhttps://www.cockroachlabs.com/docs/v20.2/drop-type.html : 404 Not Found
```

This patch adds the missing new line and corrects as follows:

```
nightly_lint_test.go:44: https://www.cockroachlabs.com/docs/v20.2/create-type.html : 404 Not Found
    798:  https://www.cockroachlabs.com/docs/v20.2/create-type.html
https://www.cockroachlabs.com/docs/v20.2/drop-type.html : 404 Not Found
    873:  https://www.cockroachlabs.com/docs/v20.2/drop-type.html
```

Release note: None