### PR TITLE
ui: fix styles for Custom Charts page

### DIFF
--- a/pkg/ui/src/views/reports/containers/customChart/customChart.styl
+++ b/pkg/ui/src/views/reports/containers/customChart/customChart.styl
@@ -35,6 +35,15 @@
     &:hover
       background-color $dropdown-hover-color
 
+    .Select-menu-outer
+      margin-top $spacing-base
+
+  .Select-control
+    width 100%!important
+
+  .Select-placeholder
+    padding-left 10px!important
+
 button.edit-button
   padding 12px 24px
   margin 0px 9px
@@ -67,3 +76,7 @@ button.edit-button
   &__cell
     text-align center
 
+.custom-metric__chart-controls-container
+  display flex
+  flex-direction row
+  margin-bottom $spacing-medium

--- a/pkg/ui/src/views/reports/containers/customChart/customMetric.tsx
+++ b/pkg/ui/src/views/reports/containers/customChart/customMetric.tsx
@@ -289,13 +289,15 @@ export class CustomChartTable extends React.Component<CustomChartTableProps> {
 
     return (
       <div>
-        <Dropdown
-          title="Units"
-          selected={this.currentAxisUnits().toString()}
-          options={axisUnitsOptions}
-          onChange={this.changeAxisUnits}
-        />
-        <button className="edit-button chart-edit-button chart-edit-button--remove" onClick={this.removeChart}>Remove Chart</button>
+        <div className="custom-metric__chart-controls-container">
+          <Dropdown
+            title="Units"
+            selected={this.currentAxisUnits().toString()}
+            options={axisUnitsOptions}
+            onChange={this.changeAxisUnits}
+          />
+          <button className="edit-button chart-edit-button chart-edit-button--remove" onClick={this.removeChart}>Remove Chart</button>
+        </div>
         { table }
         <button className="edit-button metric-edit-button metric-edit-button--add" onClick={this.addMetric}>Add Metric</button>
       </div>


### PR DESCRIPTION
Resolves #42891

Styles for `react-select` component are globally redefined in
`shame.styl` styles and recent changes affected dropdown component
on Custom Charts page.

Current changes introduce local fixes to Custom Chart page only to
avoid global changes (in shame.styl file). !important attribute is
still required to override the same styles from shame.styl file.

Release note (admin ui change): Aligned Units selector and
`Remove Chart` buttons on the same line. Search input for metric name
properly shows search term.

**Before**
<img width="1183" alt="before" src="https://user-images.githubusercontent.com/3106437/84902792-f25d6e80-b0b5-11ea-9d03-83f1b7f79368.png">

**After**
<img width="1191" alt="after" src="https://user-images.githubusercontent.com/3106437/84902813-f7bab900-b0b5-11ea-87c3-5feb8d9c2ee2.png">
