### PR TITLE
util/quotapool: enhance QuotaPool for use as a rate limiter

### DIFF
--- a/pkg/util/quotapool/config.go
+++ b/pkg/util/quotapool/config.go
@@ -68,8 +68,28 @@ type optionFunc func(cfg *config)
 
 func (f optionFunc) apply(cfg *config) { f(cfg) }
 
+// WithTimeSource is used to configure a quotapool to use the provided
+// TimeSource.
+func WithTimeSource(ts TimeSource) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.timeSource = ts
+	})
+}
+
 type config struct {
 	onAcquisition            AcquisitionFunc
 	onSlowAcquisition        SlowAcquisitionFunc
 	slowAcquisitionThreshold time.Duration
+	timeSource               TimeSource
+}
+
+var defaultConfig = config{
+	timeSource: defaultTimeSource{},
+}
+
+func initializeConfig(cfg *config, options ...Option) {
+	*cfg = defaultConfig
+	for _, opt := range options {
+		opt.apply(cfg)
+	}
 }

--- a/pkg/util/quotapool/int_rate_impl_test.go
+++ b/pkg/util/quotapool/int_rate_impl_test.go
@@ -1,0 +1,195 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package quotapool
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// Limit defines a rate in terms of quota per second.
+type Limit float64
+
+// RateLimiter implements a token-bucket style rate limiter.
+// It has the added feature that quota acquired from the pool can be returned
+// in the case that they end up not getting used.
+type RateLimiter struct {
+	qp *QuotaPool
+
+	// TODO(ajwerner): synchronization around changing limits.
+	burst     int64
+	rateLimit Limit
+}
+
+// NewRateLimiter defines a new RateLimiter. The limiter is implemented as a
+// token bucket which has a maximum capacity of burst. If a request attempts to
+// acquire more than burst, it will block until the bucket is full and then
+// put the token bucket in debt.
+func NewRateLimiter(name string, rate Limit, burst int64, options ...Option) *RateLimiter {
+	rl := &RateLimiter{rateLimit: rate, burst: burst}
+	bucket := rateBucket{
+		p:           rl,
+		cur:         float64(burst),
+		lastUpdated: timeutil.Now(),
+	}
+	rl.qp = New(name, &bucket, options...)
+	bucket.lastUpdated = rl.qp.timeSource.Now()
+	return rl
+}
+
+// Acquire acquires n quota from the RateLimiter. This acquired quota may be
+// released back into the token bucket or it may be consumed.
+func (rl *RateLimiter) Acquire(ctx context.Context, n int64) (*RateAlloc, error) {
+	if err := rl.WaitN(ctx, n); err != nil {
+		return nil, err
+	}
+	return (*RateAlloc)(rl.newRateAlloc(n)), nil
+}
+
+// WaitN acquires n quota from the RateLimiter. This acquisition cannot be
+// released.
+func (rl *RateLimiter) WaitN(ctx context.Context, n int64) error {
+	if n == 0 {
+		// Special case 0 acquisition.
+		return nil
+	}
+	r := rl.newRateRequest(n)
+	defer rl.putRateRequest(r)
+	if err := rl.qp.Acquire(ctx, r); err != nil {
+		return err
+	}
+	return nil
+}
+
+// rateBucket is the implementation of Resource which remains in the quotapool
+// for a RateLimiter.
+type rateBucket struct {
+	p           *RateLimiter
+	cur         float64
+	lastUpdated time.Time
+}
+
+var _ Resource = (*rateBucket)(nil)
+
+func (i *rateBucket) Merge(val interface{}) {
+	v := val.(*rateAlloc)
+	i.cur += float64(v.alloc)
+	v.rl.putRateAlloc(v)
+
+	if i.cur > float64(i.p.burst) {
+		i.cur = float64(i.p.burst)
+	}
+}
+
+// RateAlloc is an allocated quantity of quota which can be released back into
+// the token-bucket RateLimiter.
+type RateAlloc struct {
+	alloc int64
+	rl    *RateLimiter
+}
+
+// Return returns the RateAlloc to the RateLimiter. It is not safe to call any
+// methods on the RateAlloc after this call.
+func (ra *RateAlloc) Return() {
+	ra.rl.qp.Add((*rateAlloc)(ra))
+}
+
+// Consume destroys the RateAlloc. It is not safe to call any methods on the
+// RateAlloc after this call.
+func (ra *RateAlloc) Consume() {
+	ra.rl.putRateAlloc((*rateAlloc)(ra))
+}
+
+// rateAlloc is the internal implementation of Resource used by the RateLimiter.
+type rateAlloc RateAlloc
+
+type rateRequest struct {
+	want int64
+}
+
+var rateRequestSyncPool = sync.Pool{
+	New: func() interface{} { return new(rateRequest) },
+}
+
+// newRateRequest allocates a rateRequest from the sync.Pool.
+// It should be returned with putRateRequest.
+func (rl *RateLimiter) newRateRequest(v int64) *rateRequest {
+	r := rateRequestSyncPool.Get().(*rateRequest)
+	*r = rateRequest{want: v}
+	return r
+}
+
+func (rl *RateLimiter) putRateRequest(r *rateRequest) {
+	*r = rateRequest{}
+	rateRequestSyncPool.Put(r)
+}
+
+func (i *rateRequest) Acquire(
+	ctx context.Context, res Resource,
+) (fulfilled bool, tryAgainAfter time.Duration) {
+	r := res.(*rateBucket)
+	now := r.p.qp.timeSource.Now()
+
+	// TODO(ajwerner): Consider instituting a minimum update frequency to avoid
+	// spinning too fast on timers for tons of tiny allocations at a fast rate.
+	if since := now.Sub(r.lastUpdated); since > 0 {
+		r.cur += float64(r.p.rateLimit) * since.Seconds()
+		if r.cur > float64(r.p.burst) {
+			r.cur = float64(r.p.burst)
+		}
+		r.lastUpdated = now
+	}
+
+	// Deal with the case where the allocation is larger than the burst size.
+	// In this case we'll allow the acquisition to complete if the current value
+	// is equal to the burst. If the acquisition succeeds, it will put the limiter
+	// into debt.
+	want := float64(i.want)
+	if i.want > r.p.burst {
+		want = float64(r.p.burst)
+	}
+	if delta := want - r.cur; delta > 0 {
+		// Compute the time it will take for r.cur to get to the needed capacity.
+		timeDelta := time.Duration((delta * float64(time.Second)) / float64(r.p.rateLimit))
+
+		// Deal with the exceedingly edge case that timeDelta, as a floating point
+		// number, is less than 1ns by returning 1ns and looping back around.
+		if timeDelta == 0 {
+			timeDelta++
+		}
+
+		return false, timeDelta
+	}
+	r.cur -= float64(i.want)
+	return true, 0
+}
+
+func (i *rateRequest) ShouldWait() bool {
+	return true
+}
+
+var rateAllocSyncPool = sync.Pool{
+	New: func() interface{} { return new(rateAlloc) },
+}
+
+func (rl *RateLimiter) newRateAlloc(v int64) *rateAlloc {
+	a := rateAllocSyncPool.Get().(*rateAlloc)
+	*a = rateAlloc{alloc: v, rl: rl}
+	return a
+}
+
+func (rl *RateLimiter) putRateAlloc(a *rateAlloc) {
+	*a = rateAlloc{}
+	rateAllocSyncPool.Put(a)
+}

--- a/pkg/util/quotapool/int_rate_test.go
+++ b/pkg/util/quotapool/int_rate_test.go
@@ -1,0 +1,173 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package quotapool_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRateLimiterBasic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	t0 := time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+	mt := quotapool.NewManualTime(t0)
+	rl := quotapool.NewRateLimiter("test", 10, 20,
+		quotapool.WithTimeSource(mt))
+	ctx := context.Background()
+
+	// Consume all of the burst over a number of requests.
+	require.NoError(t, rl.WaitN(ctx, 1))
+	require.NoError(t, rl.WaitN(ctx, 3))
+	require.NoError(t, rl.WaitN(ctx, 4))
+	require.NoError(t, rl.WaitN(ctx, 4))
+	require.NoError(t, rl.WaitN(ctx, 8))
+
+	// Set up some tools for the below scenarios.
+	var (
+		done   = make(chan struct{}, 1)
+		doWait = func(n int64) {
+			require.NoError(t, rl.WaitN(ctx, n))
+			done <- struct{}{}
+		}
+		waitForTimers = func() {
+			testutils.SucceedsSoon(t, func() error {
+				if len(mt.Timers()) == 0 {
+					return errors.Errorf("no timers found")
+				}
+				return nil
+			})
+		}
+		ensureNotDone = func() {
+			waitForTimers()
+			select {
+			case <-done:
+				t.Fatalf("expected not yet done")
+			case <-time.After(time.Microsecond):
+			}
+		}
+	)
+	{
+		go doWait(5)
+		ensureNotDone()
+		mt.Advance(499 * time.Millisecond)
+		ensureNotDone()
+		mt.Advance(time.Millisecond)
+		<-done
+	}
+	{
+		go doWait(5)
+		ensureNotDone()
+		mt.Advance(499 * time.Millisecond)
+		ensureNotDone()
+		mt.Advance(500 * time.Microsecond)
+		ensureNotDone()
+		mt.Advance(1 * time.Millisecond)
+		<-done
+	}
+	{
+		// Fill the bucket all the way up.
+		mt.Advance(2 * time.Second)
+		go doWait(5)
+		<-done
+		go doWait(16)
+		ensureNotDone()
+		mt.Advance(99 * time.Millisecond)
+		ensureNotDone()
+		mt.Advance(1 * time.Millisecond)
+		<-done
+	}
+	{
+		// Fill the bucket all the way up.
+		mt.Advance(2 * time.Second)
+		acq3, err := rl.Acquire(ctx, 3)
+		require.NoError(t, err)
+		acq7, err := rl.Acquire(ctx, 7)
+		require.NoError(t, err)
+		go doWait(16)
+		go doWait(14)
+		mt.Advance(300 * time.Millisecond)
+		ensureNotDone()
+		acq3.Return()
+		<-done
+		acq7.Consume()
+		ensureNotDone()
+		mt.Advance(1399 * time.Millisecond)
+		ensureNotDone()
+		mt.Advance(time.Millisecond)
+		<-done
+	}
+	{
+		// Fill the bucket all the way up.
+		mt.Advance(2 * time.Second)
+
+		// Consume a small amount.
+		go doWait(2)
+		<-done
+
+		// Attempt to consume more than the burst and observe blocking waiting for
+		// the bucket to be full.
+		go doWait(30)
+		ensureNotDone()
+		mt.Advance(199 * time.Millisecond)
+		ensureNotDone()
+		mt.Advance(time.Millisecond)
+		<-done
+
+		// Advance time and demonstrate the acquisition put the limiter into debt.
+		// The limiter should be in debt by 10 so it will take 2s for there to be
+		// enough quota.
+		go doWait(10)
+		ensureNotDone()
+		mt.Advance(1999 * time.Millisecond)
+		ensureNotDone()
+		mt.Advance(2 * time.Millisecond)
+		<-done
+	}
+}
+
+// TestRateLimitWithVerySmallDelta ensures that in cases where the delta is
+// very small relative to the rate that nothing bad happens. In particular the
+// concern arises when the delta/rate is less than nanosecond/second.
+func TestRateLimiterWithVerySmallDelta(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	t0 := time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+	mt := quotapool.NewManualTime(t0)
+	rl := quotapool.NewRateLimiter("test", 2e9, 1e10,
+		quotapool.WithTimeSource(mt))
+	ctx := context.Background()
+	require.NoError(t, rl.WaitN(ctx, 1))
+	errCh := make(chan error)
+	// Attempt to acquire the entire quota, we should be 1 short.
+	// That means we need to acquire 1 and the rate is 2e9 so it'll happen in
+	// half a nanosecond.
+	go func() { errCh <- rl.WaitN(ctx, 1e10) }()
+
+	// Ensure that we indeed block on a timer.
+	testutils.SucceedsSoon(t, func() error {
+		if len(mt.Timers()) == 0 {
+			return errors.Errorf("no timers found")
+		}
+		return nil
+	})
+
+	// Advance the clock by the nanosecond and ensure that we get notified.
+	mt.Advance(time.Nanosecond)
+	require.NoError(t, <-errCh)
+}

--- a/pkg/util/quotapool/intpool_test.go
+++ b/pkg/util/quotapool/intpool_test.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -812,4 +813,69 @@ func TestFreezeUnavailableCapacityPanics(t *testing.T) {
 	require.Panics(t, func() {
 		acq.Freeze()
 	})
+}
+
+// TestLogSlowAcquisition tests that logging that occur only after a specified
+// period indeed does occur after that period.
+func TestLogSlowAcquisition(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	t0 := time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+	mt := quotapool.NewManualTime(t0)
+	var called, calledAfter int64
+	qp := quotapool.NewIntPool("test", 10,
+		quotapool.OnSlowAcquisition(time.Second, func(
+			ctx context.Context, poolName string, r quotapool.Request, start time.Time,
+		) (onAcquire func()) {
+			atomic.AddInt64(&called, 1)
+			return func() {
+				atomic.AddInt64(&calledAfter, 1)
+			}
+		}),
+		quotapool.WithTimeSource(mt))
+	defer qp.Close("")
+	ctx := context.Background()
+	waitFor1 := func(t *testing.T, p *int64) {
+		testutils.SucceedsSoon(t, func() error {
+			switch got := atomic.LoadInt64(p); got {
+			case 0:
+				return errors.Errorf("not yet called")
+			case 1:
+				return nil
+			default:
+				t.Fatal("expected to be called once")
+				return nil // unreachable
+			}
+		})
+	}
+	acq1, err := qp.Acquire(ctx, 1)
+	acq2, err := qp.Acquire(ctx, 8)
+	require.NoError(t, err)
+	var newAck *quotapool.IntAlloc
+	errCh := make(chan error, 1)
+	acquireFuncCalled := make(chan struct{}, 1)
+	go func() {
+		newAck, err = qp.AcquireFunc(ctx, func(ctx context.Context, p quotapool.PoolInfo) (took uint64, err error) {
+			select {
+			case acquireFuncCalled <- struct{}{}:
+			default:
+			}
+			if p.Available < 10 {
+				return 0, quotapool.ErrNotEnoughQuota
+			}
+			return 10, nil
+		})
+		defer newAck.Release()
+		errCh <- err
+	}()
+	// For the fast path.
+	<-acquireFuncCalled
+	acq1.Release()
+	<-acquireFuncCalled
+	mt.Advance(time.Minute)
+	waitFor1(t, &called)
+	require.Equal(t, int64(0), atomic.LoadInt64(&calledAfter))
+	acq2.Release()
+	require.NoError(t, <-errCh)
+	require.Equal(t, int64(1), atomic.LoadInt64(&calledAfter))
 }

--- a/pkg/util/quotapool/manual_time.go
+++ b/pkg/util/quotapool/manual_time.go
@@ -1,0 +1,175 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package quotapool
+
+import (
+	"container/heap"
+	"sort"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// ManualTime is a testing implementation of TimeSource.
+type ManualTime struct {
+	mu struct {
+		syncutil.Mutex
+		now    time.Time
+		timers manualTimerQueue
+	}
+}
+
+// NewManualTime constructs a new ManualTime.
+func NewManualTime(initialTime time.Time) *ManualTime {
+	mt := ManualTime{}
+	mt.mu.now = initialTime
+	mt.mu.timers = manualTimerQueue{
+		m: make(map[*manualTimer]int),
+	}
+	return &mt
+}
+
+var _ TimeSource = (*ManualTime)(nil)
+
+// Now returns the current time.
+func (m *ManualTime) Now() time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.mu.now
+}
+
+// NewTimer constructs a new Timer.
+func (m *ManualTime) NewTimer() Timer {
+	return &manualTimer{m: m}
+}
+
+// Advance forwards the current time by the given duration.
+func (m *ManualTime) Advance(duration time.Duration) {
+	m.AdvanceTo(m.Now().Add(duration))
+}
+
+// AdvanceTo advances the current time to t. If t is earlier than the current
+// time then AdvanceTo is a no-op.
+func (m *ManualTime) AdvanceTo(t time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !t.After(m.mu.now) {
+		return
+	}
+	m.mu.now = t
+	for m.mu.timers.Len() > 0 {
+		next := m.mu.timers.heap[0]
+		if next.at.After(m.mu.now) {
+			break
+		}
+		next.ch <- next.at
+		heap.Pop(&m.mu.timers)
+	}
+}
+
+func (m *ManualTime) add(mt *manualTimer) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !mt.at.After(m.mu.now) {
+		mt.ch <- mt.at
+	} else {
+		heap.Push(&m.mu.timers, mt)
+	}
+}
+
+func (m *ManualTime) remove(mt *manualTimer) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if idx, ok := m.mu.timers.m[mt]; ok {
+		heap.Remove(&m.mu.timers, idx)
+		return true
+	}
+	return false
+}
+
+// Timers returns a snapshot of the timestamps of the pending timers.
+func (m *ManualTime) Timers() []time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	timers := make([]time.Time, m.mu.timers.Len())
+	for i, t := range m.mu.timers.heap {
+		timers[i] = t.at
+	}
+	sort.Slice(timers, func(i, j int) bool {
+		return timers[i].Before(timers[j])
+	})
+	return timers
+}
+
+type manualTimerQueue struct {
+	// m maintains the index for a timer in heap.
+	m    map[*manualTimer]int
+	heap []*manualTimer
+}
+
+var _ heap.Interface = (*manualTimerQueue)(nil)
+
+func (m *manualTimerQueue) Len() int {
+	return len(m.heap)
+}
+
+func (m *manualTimerQueue) Less(i, j int) bool {
+	return m.heap[i].at.Before(m.heap[j].at)
+}
+
+func (m *manualTimerQueue) Swap(i, j int) {
+	m.heap[i], m.heap[j] = m.heap[j], m.heap[i]
+	m.m[m.heap[i]] = i
+	m.m[m.heap[j]] = j
+}
+
+func (m *manualTimerQueue) Push(x interface{}) {
+	mt := x.(*manualTimer)
+	m.m[mt] = len(m.heap)
+	m.heap = append(m.heap, mt)
+}
+
+func (m *manualTimerQueue) Pop() interface{} {
+	lastIdx := len(m.heap) - 1
+	ret := m.heap[lastIdx]
+	delete(m.m, ret)
+	m.heap = m.heap[:lastIdx]
+	return ret
+}
+
+type manualTimer struct {
+	m  *ManualTime
+	at time.Time
+	ch chan time.Time
+}
+
+var _ Timer = (*manualTimer)(nil)
+
+func (m *manualTimer) Reset(duration time.Duration) {
+	m.Stop()
+	m.at = m.m.Now().Add(duration)
+	m.ch = make(chan time.Time, 1)
+	m.m.add(m)
+}
+
+func (m *manualTimer) Stop() bool {
+	removed := m.m.remove(m)
+	m.ch = nil
+	m.at = time.Time{}
+	return removed
+}
+
+func (m *manualTimer) Ch() <-chan time.Time {
+	return m.ch
+}
+
+func (m *manualTimer) MarkRead() {}

--- a/pkg/util/quotapool/manual_time_test.go
+++ b/pkg/util/quotapool/manual_time_test.go
@@ -1,0 +1,105 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package quotapool_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManualTime(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	t0 := time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(1 * time.Second)
+	t2 := t0.Add(2 * time.Second)
+	t3 := t0.Add(3 * time.Second)
+	t5 := t0.Add(5 * time.Second)
+
+	t.Run("Advance", func(t *testing.T) {
+		mt := quotapool.NewManualTime(t0)
+		require.Equal(t, t0, mt.Now())
+		mt.Advance(time.Second)
+		require.Equal(t, t1, mt.Now())
+	})
+	t.Run("AdvanceTo", func(t *testing.T) {
+		mt := quotapool.NewManualTime(t0)
+		mt.AdvanceTo(t2)
+		require.Equal(t, t2, mt.Now())
+		mt.AdvanceTo(t1)
+		require.Equal(t, t2, mt.Now())
+	})
+	t.Run("Timer.Stop on unset", func(t *testing.T) {
+		mt := quotapool.NewManualTime(t0)
+		timer := mt.NewTimer()
+		require.False(t, timer.Stop())
+	})
+	ensureDontSend := func(t *testing.T, timers ...quotapool.Timer) {
+		for _, timer := range timers {
+			select {
+			case <-timer.Ch():
+				t.Fatalf("expected not to receive")
+			case <-time.After(time.Nanosecond):
+			}
+		}
+	}
+	ensureSends := func(t *testing.T, timer quotapool.Timer) {
+		select {
+		case <-timer.Ch():
+		default:
+			t.Fatalf("expected to receive from tm0")
+		}
+	}
+	t.Run("Timer basics", func(t *testing.T) {
+		mt := quotapool.NewManualTime(t0)
+		mkTimer := func(d time.Duration) quotapool.Timer {
+			timer := mt.NewTimer()
+			timer.Reset(d)
+			return timer
+		}
+		timers := []quotapool.Timer{
+			mkTimer(0 * time.Second),
+			mkTimer(1 * time.Second),
+			mkTimer(2 * time.Second),
+			mkTimer(3 * time.Second),
+			mkTimer(4 * time.Second),
+			mkTimer(5 * time.Second),
+		}
+		ensureSends(t, timers[0])
+		require.Len(t, timers[1:], len(mt.Timers()))
+		ensureDontSend(t, timers[1:]...)
+
+		mt.AdvanceTo(t1.Add(-time.Millisecond))
+		ensureDontSend(t, timers[1:]...)
+
+		// Advance to t1 and ensure it sends.
+		mt.Advance(time.Millisecond)
+		ensureSends(t, timers[1])
+
+		// Stop timers[3] and ensure it stops successfully.
+		require.True(t, timers[3].Stop())
+
+		// Advance past t3 and ensure that timers[2] sends and timers[3:] don't
+		// because we stopped 3 and the rest haven't come due just yet.
+		mt.AdvanceTo(t3.Add(time.Millisecond))
+		ensureSends(t, timers[2])
+		ensureDontSend(t, timers[3:]...)
+		require.Len(t, timers[4:], len(mt.Timers()))
+
+		// Advance to t5 and ensure that timers[4] and timers[5] send.
+		mt.AdvanceTo(t5)
+		require.Len(t, timers[6:], len(mt.Timers()))
+	})
+}

--- a/pkg/util/quotapool/quotapool.go
+++ b/pkg/util/quotapool/quotapool.go
@@ -54,7 +54,11 @@ type Request interface {
 	//
 	// If it is not fulfilled it must not modify or retain the passed alloc.
 	// If it is fulfilled, it should modify the Resource value accordingly.
-	Acquire(context.Context, Resource) (fulfilled bool)
+	//
+	// If tryAgainAfter is positive, acquisition will be attempted again after
+	// the specified duration. This is critical for the implementation of
+	// rate limiters on top of this package.
+	Acquire(context.Context, Resource) (fulfilled bool, tryAgainAfter time.Duration)
 
 	// ShouldWait indicates whether this request should be queued. If this method
 	// returns false and there is insufficient capacity in the pool when the
@@ -203,6 +207,7 @@ var chanSyncPool = sync.Pool{
 //
 // Safe for concurrent use.
 func (qp *QuotaPool) Acquire(ctx context.Context, r Request) (err error) {
+
 	// Set up onAcquisition if we have one.
 	start := qp.timeSource.Now()
 	if qp.config.onAcquisition != nil {
@@ -212,11 +217,13 @@ func (qp *QuotaPool) Acquire(ctx context.Context, r Request) (err error) {
 			}
 		}()
 	}
+
 	// Attempt to acquire quota on the fast path.
-	fulfilled, n, err := qp.acquireFastPath(ctx, r)
+	fulfilled, n, tryAgainAfter, err := qp.acquireFastPath(ctx, r)
 	if fulfilled || err != nil {
 		return err
 	}
+
 	// Set up the infrastructure to report slow requests.
 	var slowTimer Timer
 	var slowTimerC <-chan time.Time
@@ -228,6 +235,46 @@ func (qp *QuotaPool) Acquire(ctx context.Context, r Request) (err error) {
 		slowTimer.Reset(qp.slowAcquisitionThreshold)
 		slowTimerC = slowTimer.Ch()
 	}
+
+	// Set up the infrastructure to deal with rate-limiter style pools which
+	// retry after the passage of time.
+	var tryAgainTimer Timer
+	var tryAgainTimerC <-chan time.Time
+	stopTryAgainTimer := func() {
+		if tryAgainTimer == nil {
+			return
+		}
+		tryAgainTimer.Stop()
+		tryAgainTimerC = nil
+	}
+	resetTryAgainTimer := func() {
+		if tryAgainAfter <= 0 {
+			return
+		}
+		if tryAgainTimer == nil {
+			tryAgainTimer = qp.timeSource.NewTimer()
+		}
+		tryAgainTimer.Reset(tryAgainAfter)
+		tryAgainTimerC = tryAgainTimer.Ch()
+	}
+	tryAcquire := func() (fulfilled bool) {
+		stopTryAgainTimer()
+		fulfilled, tryAgainAfter = qp.tryAcquireOnNotify(ctx, r, n)
+		if fulfilled {
+			return true
+		}
+		resetTryAgainTimer()
+		return false
+	}
+
+	// If we have a non-zero tryAgain value, then we'll set the timer here.
+	// This will only happen if we're at the head of the queue because that's the
+	// only condition in which acquireFastPath will only return a non-zero
+	// tryAgainAfter.
+	resetTryAgainTimer()
+	defer stopTryAgainTimer()
+
+	// Loop until the front of the queue is either fulfilled or canceled.
 	for {
 		select {
 		case <-slowTimerC:
@@ -236,7 +283,7 @@ func (qp *QuotaPool) Acquire(ctx context.Context, r Request) (err error) {
 			defer qp.onSlowAcquisition(ctx, qp.name, r, start)()
 			continue
 		case <-n.c:
-			if fulfilled := qp.tryAcquireOnNotify(ctx, r, n); fulfilled {
+			if fulfilled := tryAcquire(); fulfilled {
 				return nil
 			}
 		case <-ctx.Done():
@@ -247,35 +294,44 @@ func (qp *QuotaPool) Acquire(ctx context.Context, r Request) (err error) {
 			// context is canceled. In fact, we want others waiters to only
 			// receive on qp.done and signaling them would work against that.
 			return qp.closeErr // always non-nil when qp.done is closed
+		case <-tryAgainTimerC:
+			tryAgainTimer.MarkRead()
+			if fulfilled := tryAcquire(); fulfilled {
+				return nil
+			}
 		}
 	}
 }
 
 // acquireFastPath attempts to acquire quota if nobody is waiting and returns a
-// notifyee if the request is not immediately fulfilled.
+// notifyee if the request is not immediately fulfilled. The returned
+// tryAgainAfter will only be non-zero if the notifyee is at the front of the
+// queue. This property ensures that only one tryAgainTimer in acquire exists
+// at a time.
 func (qp *QuotaPool) acquireFastPath(
 	ctx context.Context, r Request,
-) (fulfilled bool, _ *notifyee, _ error) {
+) (fulfilled bool, _ *notifyee, tryAgainAfter time.Duration, _ error) {
+
 	qp.mu.Lock()
 	defer qp.mu.Unlock()
 	if qp.mu.closed {
-		return false, nil, qp.closeErr
+		return false, nil, 0, qp.closeErr
 	}
 	if qp.mu.q.len == 0 {
-		if fulfilled := r.Acquire(ctx, qp.mu.quota); fulfilled {
-			return true, nil, nil
+		if fulfilled, tryAgainAfter = r.Acquire(ctx, qp.mu.quota); fulfilled {
+			return true, nil, tryAgainAfter, nil
 		}
 	}
 	if !r.ShouldWait() {
-		return false, nil, ErrNotEnoughQuota
+		return false, nil, 0, ErrNotEnoughQuota
 	}
 	c := chanSyncPool.Get().(chan struct{})
-	return false, qp.mu.q.enqueue(c), nil
+	return false, qp.mu.q.enqueue(c), tryAgainAfter, nil
 }
 
 func (qp *QuotaPool) tryAcquireOnNotify(
 	ctx context.Context, r Request, n *notifyee,
-) (fulfilled bool) {
+) (fulfilled bool, tryAgainAfter time.Duration) {
 	// Release the notify channel back into the sync pool if we're fulfilled.
 	// Capture nc's value because it's not safe to avoid a race accessing n after
 	// it has been released back to the notifyQueue.
@@ -292,11 +348,11 @@ func (qp *QuotaPool) tryAcquireOnNotify(
 	if len(n.c) > 0 {
 		<-n.c
 	}
-	if fulfilled = r.Acquire(ctx, qp.mu.quota); fulfilled {
+	if fulfilled, tryAgainAfter = r.Acquire(ctx, qp.mu.quota); fulfilled {
 		n.c = nil
 		qp.notifyNextLocked()
 	}
-	return fulfilled
+	return fulfilled, tryAgainAfter
 }
 
 func (qp *QuotaPool) cleanupOnCancel(n *notifyee) {

--- a/pkg/util/quotapool/time.go
+++ b/pkg/util/quotapool/time.go
@@ -1,0 +1,64 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package quotapool
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// TimeSource is used to interact with clocks and timers. Generally exposed for
+// testing.
+type TimeSource interface {
+	Now() time.Time
+	NewTimer() Timer
+}
+
+// Timer is an interface wrapping timeutil.Timer.
+type Timer interface {
+	Reset(duration time.Duration)
+	Stop() bool
+	Ch() <-chan time.Time
+	MarkRead()
+}
+
+type defaultTimeSource struct{}
+
+var _ TimeSource = defaultTimeSource{}
+
+func (defaultTimeSource) Now() time.Time {
+	return timeutil.Now()
+}
+
+func (d defaultTimeSource) NewTimer() Timer {
+	return (*timer)(timeutil.NewTimer())
+}
+
+type timer timeutil.Timer
+
+var _ Timer = (*timer)(nil)
+
+func (t *timer) Reset(duration time.Duration) {
+	(*timeutil.Timer)(t).Reset(duration)
+}
+
+func (t *timer) Stop() bool {
+	return (*timeutil.Timer)(t).Stop()
+}
+
+func (t *timer) Ch() <-chan time.Time {
+	return t.C
+}
+
+func (t *timer) MarkRead() {
+	t.Read = true
+}


### PR DESCRIPTION
This set of commits precedes work on #47906 where we want to provide rate-limiting. As a first step it extends the `QuotaPool` abstraction to be usable additionally for token-bucket style rate-limiting. This rate limiter differs from many token buckets as previously acquired quota can be returned in the case that the request cannot proceed.

This PR adds an example implementation of a rate limiter and basic testing.

There's a certain sense in which this is adding potentially more cruft to a potentially already cruft API. I'd love to hear more feedback there. Most of the cruft as I see it has to do with the attempts to avoid allocations. On the whole I'm reasonably happy with how these seems to feel as I move forward with the implementation of the tenant rate-limiter and its associated metrics. The hooks that already exist in the quotapool are quite handy.

