### PR TITLE
ui: Text for Stats by Node tooltip on Statements details page

### DIFF
--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -477,7 +477,7 @@ export class StatementDetails extends React.Component<StatementDetailsProps, Sta
             >
               Stats By Node
               <div className={cx("numeric-stats-table__tooltip")}>
-                <ToolTipWrapper text="text">
+                <ToolTipWrapper text="Execution statistics for this statement per gateway node.">
                   <div className={cx("numeric-stats-table__tooltip-hover-area")}>
                     <div className={cx("numeric-stats-table__info-icon")}>i</div>
                   </div>


### PR DESCRIPTION
Resolves #44768

Provide text for Stats by Node tooltip instead of stubbed text

<img width="1053" alt="Screenshot 2020-06-17 at 18 50 09" src="https://user-images.githubusercontent.com/3106437/84920113-6ce4b900-b0cb-11ea-8b27-abc8b3b0e9da.png">
