### PR TITLE
geos: set RPATH to /usr/local/lib/cockroach and update docker image

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -44,6 +44,8 @@ usual fashion. To be more specific, the steps to do this are:
 ```
 go/src/github.com/cockroachdb/cockroach $ ./build/builder.sh mkrelease linux-gnu
 go/src/github.com/cockroachdb/cockroach $ cp ./cockroach-linux-2.6.32-gnu-amd64 build/deploy/cockroach
+# optional step to make geospatial operations work.
+go/src/github.com/cockroachdb/cockroach $ cp -L $GOPATH/native/x86_64-unknown-linux-gnu/geos/lib/libgeos_c.so $GOPATH/native/x86_64-unknown-linux-gnu/geos/lib/libgeos.so.3.8.1 build/deploy/
 go/src/github.com/cockroachdb/cockroach $ cd build/deploy && docker build -t cockroachdb/cockroach .
 ```
 

--- a/build/deploy/.gitignore
+++ b/build/deploy/.gitignore
@@ -1,3 +1,4 @@
 # Do not add environment-specific entries here (see the top-level .gitignore
 # for reasoning and alternatives).
 cockroach
+libgeos*.so*

--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -10,6 +10,10 @@ RUN apt-get update && \
 	apt-get install -y libc6 ca-certificates tzdata && \
 	rm -rf /var/lib/apt/lists/*
 
+# Install GEOS libraries.
+RUN mkdir /usr/local/lib/cockroach
+COPY libgeos.so.3.8.1 libgeos_c.so /usr/local/lib/cockroach/
+
 RUN mkdir -p /cockroach
 COPY cockroach.sh cockroach /cockroach/
 # Set working directory so that relative paths

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -134,7 +134,7 @@ func initCLIDefaults() {
 	startCtx.listeningURLFile = ""
 	startCtx.pidFile = ""
 	startCtx.inBackground = false
-	startCtx.geoLibsDir = "/usr/local/lib"
+	startCtx.geoLibsDir = "/usr/local/lib/cockroach"
 
 	quitCtx.drainWait = 10 * time.Minute
 
@@ -174,7 +174,7 @@ func initCLIDefaults() {
 	demoCtx.disableLicenseAcquisition = false
 	demoCtx.transientCluster = nil
 	demoCtx.insecure = false
-	demoCtx.geoLibsDir = "/usr/local/lib"
+	demoCtx.geoLibsDir = "/usr/local/lib/cockroach"
 
 	authCtx.validityPeriod = 1 * time.Hour
 

--- a/pkg/geo/geos/geos.go
+++ b/pkg/geo/geos/geos.go
@@ -26,7 +26,7 @@ import (
 )
 
 // #cgo CXXFLAGS: -std=c++14
-// #cgo !windows LDFLAGS: -ldl
+// #cgo !windows LDFLAGS: -ldl -Wl,-rpath,/usr/local/lib/cockroach
 //
 // #include "geos.h"
 import "C"


### PR DESCRIPTION
Set the RPATH to /usr/local/lib/cockroach (postgres does
/usr/local/lib/postgres) that becomes the default location to look for
CRDB binaries. This avoids needing to set the `LD_LIBRARY_PATH` to make
the shared libraries for GEOS to work when copy pasting our copies.

Also update the docker deploy container to initialize this directory and
install the shared images.

Release note (general change): Reconfigured the cockroach binary to set
the RPATH to /usr/local/lib/cockroach. The docker image that is
available with CockroachDB will also include the GEOS files necessary to
work with Geospatial types in CockroachDB.