### PR TITLE
rpc/nodedialer: remove redundant ConnectionReady check in dial

### DIFF
--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -175,7 +175,6 @@ func (n *Dialer) dial(
 	// Check to see if the connection is in the transient failure state. This can
 	// happen if the connection already existed, but a recent heartbeat has
 	// failed and we haven't yet torn down the connection.
-	err = grpcutil.ConnectionReady(conn)
 	if err := grpcutil.ConnectionReady(conn); err != nil {
 		err = errors.Wrapf(err, "failed to check for ready connection to n%d at %v", nodeID, addr)
 		if breaker != nil {


### PR DESCRIPTION
This was accidentally added in 66683d5.