### PR TITLE
geos: dlopen libgeos.so before libgeos_c.so

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -134,7 +134,7 @@ func initCLIDefaults() {
 	startCtx.listeningURLFile = ""
 	startCtx.pidFile = ""
 	startCtx.inBackground = false
-	startCtx.geoLibsDir = "/usr/local/lib"
+	startCtx.geoLibsDir = "/usr/local/lib/cockroach"
 
 	quitCtx.drainWait = 10 * time.Minute
 
@@ -174,7 +174,7 @@ func initCLIDefaults() {
 	demoCtx.disableLicenseAcquisition = false
 	demoCtx.transientCluster = nil
 	demoCtx.insecure = false
-	demoCtx.geoLibsDir = "/usr/local/lib"
+	demoCtx.geoLibsDir = "/usr/local/lib/cockroach"
 
 	authCtx.validityPeriod = 1 * time.Hour
 

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -268,7 +268,7 @@ func runDemo(cmd *cobra.Command, gen workload.Generator) (err error) {
 	if err != nil {
 		log.Infof(ctx, "could not initialize GEOS - geospatial functions may not be available: %v", err)
 	} else {
-		log.Infof(ctx, "GEOS initialized at %s", loc)
+		log.Infof(ctx, "GEOS loaded from directory %s", loc)
 	}
 
 	c, err := setupTransientCluster(ctx, cmd, gen)

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -694,7 +694,7 @@ If problems persist, please see %s.`
 	if err != nil {
 		log.Infof(ctx, "could not initialize GEOS - geospatial functions may not be available: %v", err)
 	} else {
-		log.Infof(ctx, "GEOS initialized at %s", loc)
+		log.Infof(ctx, "GEOS loaded from directory %s", loc)
 	}
 
 	// Beyond this point, the configuration is set and the server is

--- a/pkg/geo/geos/geos.h
+++ b/pkg/geo/geos/geos.h
@@ -56,7 +56,7 @@ typedef struct CR_GEOS CR_GEOS;
 // must be convertible to a NUL character terminated C string.
 // The CR_GEOS object will be stored in lib.
 // The error returned does not need to be freed (see comment for CR_GEOS_Slice).
-CR_GEOS_Slice CR_GEOS_Init(CR_GEOS_Slice loc, CR_GEOS** lib);
+CR_GEOS_Slice CR_GEOS_Init(CR_GEOS_Slice geoscLoc, CR_GEOS_Slice geosLoc, CR_GEOS** lib);
 
 // CR_GEOS_WKTToWKB converts a given WKT into it's EWKB form. The wkt slice must be
 // convertible to a NUL character terminated C string.

--- a/pkg/geo/geos/geos_test.go
+++ b/pkg/geo/geos/geos_test.go
@@ -29,7 +29,7 @@ func TestInitGEOS(t *testing.T) {
 	})
 
 	t.Run("test valid initGEOS paths", func(t *testing.T) {
-		ret, loc, err := initGEOS(findGEOSLocations(""))
+		ret, loc, err := initGEOS(findLibraryDirectories(""))
 		require.NoError(t, err)
 		require.NotEmpty(t, loc)
 		require.NotNil(t, ret)


### PR DESCRIPTION
We need to dlopen libgeos.so before libgeos_c.so when copying the
libraries directly to be copied into a tarball.

Also change the default location for these .so files to be
`/usr/local/lib/cockroach`, which is in line with other example
libraries seen (e.g. `/usr/local/lib/postgres`).

This PR is in preparation for a Docker update and making GEOS work with
roachprod utilities.

Release note (general change): The docker image that is
available with CockroachDB will also include the GEOS files necessary to
work with Geospatial types in CockroachDB.

