### PR TITLE
release-20.1: pgdate: parse infinity/-infinity as max/min supported timestamp

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -1692,3 +1692,11 @@ select count(1) from date_test where date_test.date_val = '2019-01-15'::date
 
 statement ok
 SET TIME ZONE 0
+
+subtest infinity_time
+
+# TODO(#41564): this should display "infinity", "-infinity".
+query TT
+SELECT 'infinity'::timestamp, '-infinity'::timestamptz
+----
+294276-12-31 23:59:59.999999 +0000 +0000  -4713-11-24 00:00:00 +0000 +0000

--- a/pkg/util/timeutil/pgdate/parsing.go
+++ b/pkg/util/timeutil/pgdate/parsing.go
@@ -11,7 +11,6 @@
 package pgdate
 
 import (
-	"math"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -63,9 +62,21 @@ var (
 // These are sentinel values for handling special values:
 // https://www.postgresql.org/docs/10/static/datatype-datetime.html#DATATYPE-DATETIME-SPECIAL-TABLE
 var (
-	TimeEpoch            = timeutil.Unix(0, 0)
-	TimeInfinity         = timeutil.Unix(math.MaxInt64, math.MaxInt64)
-	TimeNegativeInfinity = timeutil.Unix(math.MinInt64, math.MinInt64)
+	TimeEpoch = timeutil.Unix(0, 0)
+	// TimeInfinity represents the "highest" possible time.
+	// TODO (#41564): this should actually behave as infinity, i.e. any operator
+	// leaves this as infinity. This time should always be greater than any other time.
+	// We should probably use the next microsecond after this value, i.e. timeutil.Unix(9224318016000, 0).
+	// Postgres uses math.MaxInt64 microseconds as the infinity value.
+	// See: https://github.com/postgres/postgres/blob/42aa1f0ab321fd43cbfdd875dd9e13940b485900/src/include/datatype/timestamp.h#L107.
+	TimeInfinity = timeutil.Unix(9224318016000-1, 999999000)
+	// TimeNegativeInfinity represents the "lowest" possible time.
+	// TODO (#41564): this should actually behave as -infinity, i.e. any operator
+	// leaves this as -infinity. This time should always be less than any other time.
+	// We should probably use the next microsecond before this value, i.e. timeutil.Unix(9224318016000-1, 999999000).
+	// Postgres uses math.MinInt64 microseconds as the -infinity value.
+	// See: https://github.com/postgres/postgres/blob/42aa1f0ab321fd43cbfdd875dd9e13940b485900/src/include/datatype/timestamp.h#L107.
+	TimeNegativeInfinity = timeutil.Unix(-210866803200, 0)
 )
 
 //go:generate stringer -type=ParseMode


### PR DESCRIPTION
Backport 1/1 commits from #50311.

/cc @cockroachdb/release

---

Refs: #41564

----

This is a stop gap measure to support people evaluating to a super high
or super low timestamp, e.g. `CREATE USER ... VALID UNTIL 'infinity'`.
As we don't support infinity proper yet, make `infinity`/`-infinity` as
a timestamp evaluate to the highest/lowest supported value.

Release note (sql change): Using `infinity` previously
evaluated to a negative, i.e. "-292277022365-05-08T08:17:07Z".
This has been fixed to be the maximum supported timestamp in Postgres
that is not infinity. Likewise, `-infinity` is the smallest supported
value. Note this does currently does not behave exactly like `infinity`
in Postgres (this is a work in progress and may be resolved later).
