### PR TITLE
importccl: fix flakey TestProtectedTimestampsDuringImportInto

### DIFF
--- a/pkg/ccl/importccl/import_into_test.go
+++ b/pkg/ccl/importccl/import_into_test.go
@@ -54,7 +54,7 @@ func TestProtectedTimestampsDuringImportInto(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	args := base.TestClusterArgs{}
-	tc := testcluster.StartTestCluster(t, 3, args)
+	tc := testcluster.StartTestCluster(t, 1, args)
 	defer tc.Stopper().Stop(ctx)
 
 	tc.WaitForNodeLiveness(t)


### PR DESCRIPTION
This test flaked once in stressrace on May 11th. I've run it a bunch now
and found that just starting the testcluster in race is wildly slow. This
test doesn't rely on having multiple servers. This leads to a dramatic
difference in the rate of test completion for this test.

Fixes #48679.

Release note: None