### PR TITLE
opt: add partial index implication logic for conjunctions in predicate

### DIFF
--- a/pkg/sql/opt/partialidx/predicate.go
+++ b/pkg/sql/opt/partialidx/predicate.go
@@ -13,6 +13,7 @@ package partialidx
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
 )
 
 // FiltersImplyPredicate attempts to prove that a partial index predicate is
@@ -48,19 +49,224 @@ import (
 //   AND-expr A => atom B iff:      any of A's children => B
 //   AND-expr A => AND-expr B iff:  A => each of B's children
 //   AND-expr A => OR-expr B iff:   A => any of B's children OR
-//                                   any of A's children => B
+//                                    any of A's children => B
 //
 //   OR-expr A => atom B iff:       each of A's children => B
 //   OR-expr A => AND-expr B iff:   A => each of B's children
 //   OR-expr A => OR-expr B iff:    each of A's children => any of B's children
 //
-// TODO(mgartner): Implement more advanced proofs for implication. We only
-// support simple "atom => atom" and "AND-expr => atom" currently.
-func FiltersImplyPredicate(filters memo.FiltersExpr, pred opt.ScalarExpr) (memo.FiltersExpr, bool) {
+func FiltersImplyPredicate(
+	filters memo.FiltersExpr, pred opt.ScalarExpr, f *norm.Factory,
+) (remainingFilters memo.FiltersExpr, ok bool) {
+
+	// First, check for exact matches at the root FiltersExpr. This check is not
+	// necessary for correctness because the recursive approach below handles
+	// all cases. However, this is a faster path for common cases where
+	// expressions in filters are exact matches to the entire predicate.
 	for i := range filters {
-		if pred == filters[i].Condition {
+		c := filters[i].Condition
+
+		// If the FiltersItem's condition is an exact match to the predicate,
+		// remove the FilterItem from the remaining filters and return true.
+		if c == pred {
 			return filters.RemoveFiltersItem(&filters[i]), true
 		}
+
+		// If the FiltersItem's condition is a RangeExpr, unbox it and check for
+		// an exact match. RangeExprs are only created in the
+		// ConsolidateSelectFilters normalization rule and only exist as direct
+		// children of a FiltersItem. The predicate will not contain a
+		// RangeExpr, but the predicate may be an exact match to a RangeExpr's
+		// child.
+		if r, ok := c.(*memo.RangeExpr); ok {
+			if r.And == pred {
+				return filters.RemoveFiltersItem(&filters[i]), true
+			}
+		}
 	}
+
+	// If no exact match was found, recursively check the sub-expressions of the
+	// filters and predicate. Use exactMatches to keep track of expressions in
+	// filters that exactly matches expressions in pred, so that the can be
+	// removed from the remaining filters.
+	exactMatches := make(map[opt.Expr]struct{})
+	if scalarExprImpliesPredicate(&filters, pred, exactMatches) {
+		remainingFilters = simplifyFiltersExpr(filters, exactMatches, f)
+		return remainingFilters, true
+	}
+
 	return nil, false
+}
+
+// exprImpliesPredicate returns true if the expression e implies the ScalarExpr
+// pred. If e or any of its encountered sub-expressions are exact matches to
+// expressions within pred, they are added to the exactMatches set.
+//
+// Note that exprImpliesPredicate short-circuits when e is proven to imply pred,
+// and is not guaranteed to traverse either expression tree entirely. Therefore,
+// there may be expressions in both trees that match exactly but are not added
+// to exactMatches.
+func scalarExprImpliesPredicate(
+	e opt.ScalarExpr, pred opt.ScalarExpr, exactMatches map[opt.Expr]struct{},
+) bool {
+	// If the expressions are an exact match, then e implies pred.
+	if e == pred {
+		exactMatches[e] = struct{}{}
+		return true
+	}
+
+	switch t := e.(type) {
+	case *memo.FiltersExpr:
+		return filtersExprImpliesPredicate(t, pred, exactMatches)
+
+	case *memo.RangeExpr:
+		and := t.And.(*memo.AndExpr)
+		return andExprImpliesPredicate(and, pred, exactMatches)
+
+	case *memo.AndExpr:
+		return andExprImpliesPredicate(t, pred, exactMatches)
+
+	case *memo.OrExpr:
+		// TODO(mgartner): Handle OR filters.
+		return false
+
+	default:
+		return atomImpliesPredicate(e, pred, exactMatches)
+	}
+}
+
+// filtersExprImpliesPredicate returns true if the FiltersExpr e implies the
+// ScalarExpr pred.
+func filtersExprImpliesPredicate(
+	e *memo.FiltersExpr, pred opt.ScalarExpr, exactMatches map[opt.Expr]struct{},
+) bool {
+	switch pt := pred.(type) {
+	case *memo.AndExpr:
+		// AND-expr A => AND-expr B iff A => each of B's children.
+		leftPredImplied := filtersExprImpliesPredicate(e, pt.Left, exactMatches)
+		if leftPredImplied {
+			return filtersExprImpliesPredicate(e, pt.Right, exactMatches)
+		}
+		return false
+
+	case *memo.OrExpr:
+		// AND-expr A => OR-expr B iff A => any of B's children OR
+		// any of A's children => B.
+		// TODO(mgartner): Handle OR predicates.
+		return false
+
+	default:
+		// AND-pred A => atom B iff any of A's children => B.
+		for i := range *e {
+			if scalarExprImpliesPredicate((*e)[i].Condition, pred, exactMatches) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// andExprImpliesPredicate returns true if the AndExpr e implies the ScalarExpr
+// pred. This function transforms e into an equivalent FiltersExpr that is
+// passed to filtersExprImpliesPredicate to prevent duplicating logic for both
+// types of conjunctions.
+func andExprImpliesPredicate(
+	e *memo.AndExpr, pred opt.ScalarExpr, exactMatches map[opt.Expr]struct{},
+) bool {
+	f := make(memo.FiltersExpr, 2)
+	f[0] = memo.FiltersItem{Condition: e.Left}
+	f[1] = memo.FiltersItem{Condition: e.Right}
+	return filtersExprImpliesPredicate(&f, pred, exactMatches)
+}
+
+// atomImpliedPredicate returns true if the atom expression e implies the
+// ScalarExpr pred. The atom e cannot be an AndExpr, OrExpr, RangeExpr, or
+// FiltersExpr.
+func atomImpliesPredicate(
+	e opt.ScalarExpr, pred opt.ScalarExpr, exactMatches map[opt.Expr]struct{},
+) bool {
+	switch pt := pred.(type) {
+	case *memo.AndExpr:
+		// atom A => AND-expr B iff A => each of B's children.
+		leftPredImplied := atomImpliesPredicate(e, pt.Left, exactMatches)
+		rightPredImplied := atomImpliesPredicate(e, pt.Right, exactMatches)
+		return leftPredImplied && rightPredImplied
+
+	case *memo.OrExpr:
+		// atom A => OR-expr B iff A => any of B's children.
+		// TODO(mgartner): Handle OR predicates.
+		return false
+
+	default:
+		// atom A => atom B iff A contains B.
+		// TODO(mgartner): Handle inexact atom matches.
+		return false
+	}
+}
+
+// simplifyFiltersExpr returns a new FiltersExpr with any expressions in e that
+// exist in exactMatches removed.
+//
+// If a FiltersItem at the root exists in exactMatches, the entire FiltersItem
+// is omitted from the returned FiltersItem. If not, the FiltersItem is
+// recursively searched. See simplifyScalarExpr for more details.
+func simplifyFiltersExpr(
+	e memo.FiltersExpr, exactMatches map[opt.Expr]struct{}, f *norm.Factory,
+) memo.FiltersExpr {
+	filters := make(memo.FiltersExpr, 0, len(e))
+
+	for i := range e {
+		// If an entire FiltersItem exists in exactMatches, don't add it to the
+		// output filters.
+		if _, ok := exactMatches[e[i].Condition]; ok {
+			continue
+		}
+
+		// Otherwise, attempt to recursively simplify the FilterItem's Condition
+		// and append the result to the filters.
+		s := simplifyScalarExpr(e[i].Condition, exactMatches, f)
+
+		// If the scalar expression was reduced to True, don't add it to the
+		// filters.
+		if s != memo.TrueSingleton {
+			filters = append(filters, f.ConstructFiltersItem(s))
+		}
+	}
+
+	return filters
+}
+
+// simplifyScalarExpr simplifies combinations of RangeExprs and AndExprs by
+// "removing" any expressions present in exactMatches. Note that expressions
+// cannot simply be removed because RangeExprs and AndExprs are not lists of
+// expressions. Instead, expressions in exactMatches are replaced with other
+// expressions that are logically equivalent to removal of the expression.
+func simplifyScalarExpr(
+	e opt.ScalarExpr, exactMatches map[opt.Expr]struct{}, f *norm.Factory,
+) opt.ScalarExpr {
+
+	switch t := e.(type) {
+	case *memo.RangeExpr:
+		and := simplifyScalarExpr(t.And, exactMatches, f)
+		return f.ConstructRange(and)
+
+	case *memo.AndExpr:
+		_, leftIsExactMatch := exactMatches[t.Left]
+		_, rightIsExactMatch := exactMatches[t.Right]
+		if leftIsExactMatch && rightIsExactMatch {
+			return memo.TrueSingleton
+		}
+		if leftIsExactMatch {
+			return simplifyScalarExpr(t.Right, exactMatches, f)
+		}
+		if rightIsExactMatch {
+			return simplifyScalarExpr(t.Left, exactMatches, f)
+		}
+		left := simplifyScalarExpr(t.Left, exactMatches, f)
+		right := simplifyScalarExpr(t.Right, exactMatches, f)
+		return f.ConstructAnd(left, right)
+
+	default:
+		return e
+	}
 }

--- a/pkg/sql/opt/partialidx/testdata/predicate/and-expr
+++ b/pkg/sql/opt/partialidx/testdata/predicate/and-expr
@@ -1,0 +1,130 @@
+# Tests for predicates with AND expressions.
+
+# Atom filters
+
+predtest vars=(bool)
+@1
+=>
+@1 AND @1
+----
+true
+└── remaining filters: none
+
+predtest vars=(bool)
+NOT @1
+=>
+@1 AND @1
+----
+false
+
+predtest vars=(bool, bool)
+@1
+=>
+@1 AND @2
+----
+false
+
+
+# Conjunction filters
+
+predtest vars=(bool, bool)
+@1 AND @2
+=>
+@1 AND @1
+----
+true
+└── remaining filters: @2
+
+predtest vars=(bool, bool)
+@1 AND @2
+=>
+@1 AND @2
+----
+true
+└── remaining filters: none
+
+predtest vars=(bool, bool)
+@1 AND @2
+=>
+@2 AND @1
+----
+true
+└── remaining filters: none
+
+predtest vars=(bool, bool, bool)
+@1 AND @2 AND @3
+=>
+@1 AND @2
+----
+true
+└── remaining filters: @3
+
+predtest vars=(bool, bool, bool)
+@1 AND @2 AND @3
+=>
+@1 AND @3
+----
+true
+└── remaining filters: @2
+
+predtest vars=(bool, bool, bool)
+@1 AND @2 AND @3
+=>
+@3 AND @1 AND @2
+----
+true
+└── remaining filters: none
+
+predtest vars=(bool, bool)
+@1 AND NOT @2
+=>
+@1 AND @2
+----
+false
+
+predtest vars=(bool, bool, bool)
+@1 AND @2
+=>
+@1 AND @3
+----
+false
+
+# Range filters
+
+predtest vars=(int)
+@1 > 10 AND @1 < 100
+=>
+@1 > 10 AND @1 < 100
+----
+true
+└── remaining filters: none
+
+predtest vars=(int)
+@1 > 10 AND @1 < 100
+=>
+@1 < 100 AND @1 > 10
+----
+true
+└── remaining filters: none
+
+predtest vars=(int, bool)
+@1 > 10 AND @2 AND @1 < 100
+=>
+@1 > 10 AND @1 < 100
+----
+true
+└── remaining filters: @2
+
+predtest vars=(int)
+@1 > 10 AND @1 < 90
+=>
+@1 > 0 AND @1 < 100
+----
+false
+
+predtest vars=(int, bool)
+@1 > 10 AND NOT @2 AND @1 < 100
+=>
+@1 > 10 AND @1 < 100 AND @2
+----
+false

--- a/pkg/sql/opt/partialidx/testdata/predicate/exact-atom
+++ b/pkg/sql/opt/partialidx/testdata/predicate/exact-atom
@@ -1,7 +1,7 @@
 # Tests for filters that contain expressions that exactly match atom
 # predicates.
 
-# Booleans
+# Boolean filters
 
 predtest vars=(bool)
 @1
@@ -14,16 +14,32 @@ true
 predtest vars=(bool)
 NOT @1
 =>
+NOT @1
+----
+true
+└── remaining filters: none
+
+predtest vars=(bool)
+NOT @1
+=>
 @1
 ----
 false
 
-# Equalities
+# Equality filters
 
 predtest vars=(string)
 @1 = 'foo'
 =>
 @1 = 'foo'
+----
+true
+└── remaining filters: none
+
+predtest vars=(int)
+@1 = 10
+=>
+@1 = 10
 ----
 true
 └── remaining filters: none
@@ -35,7 +51,14 @@ predtest vars=(string)
 ----
 false
 
-# Inequalities
+predtest vars=(int)
+@1 = 1
+=>
+@1 > 1
+----
+false
+
+# Inequality filters
 
 predtest vars=(int)
 @1 > 10
@@ -52,7 +75,14 @@ predtest vars=(int)
 ----
 false
 
-# IN expressions
+predtest vars=(int)
+@1 > 1
+=>
+@1 = 1
+----
+false
+
+# IN filters
 
 predtest vars=(int)
 @1 IN (1, 2, 3)
@@ -69,27 +99,60 @@ predtest vars=(int)
 ----
 false
 
-# Conjunctions
+# Conjunction filters
 
-predtest vars=(bool, int)
-@1 AND @2 > 20
+predtest vars=(bool, bool)
+@1 AND @2
 =>
 @1
 ----
 true
-└── remaining filters: @2 > 20
+└── remaining filters: @2
 
-predtest vars=(bool, int)
-@1 AND @2 > 20
+predtest vars=(bool, bool)
+@1 AND @2
 =>
-@2 > 20
+@2
 ----
 true
 └── remaining filters: @1
 
-predtest vars=(bool, int)
-@1 AND @2 > 15
+predtest vars=(bool, bool)
+@1 AND @1 AND @2
 =>
-@2 > 20
+@1
+----
+true
+└── remaining filters: @2
+
+predtest vars=(bool, bool)
+@1 AND NOT @2
+=>
+@2
+----
+false
+
+# Range filters
+
+predtest vars=(int)
+@1 > 10 AND @1 < 100
+=>
+@1 > 10
+----
+true
+└── remaining filters: @1 < 100
+
+predtest vars=(int, bool)
+@1 > 10 AND @2 AND @1 < 100
+=>
+@2
+----
+true
+└── remaining filters: (@1 > 10) AND (@1 < 100)
+
+predtest vars=(int)
+@1 > 15 AND @1 < 100
+=>
+@1 > 10
 ----
 false

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -201,7 +201,7 @@ func (c *CustomFuncs) GeneratePartialIndexScans(
 	iter := makeScanIndexIter(c.e.mem, scanPrivate, rejectNonPartialIndexes)
 	for iter.Next() {
 		pred := tabMeta.PartialIndexPredicates[iter.IndexOrdinal()]
-		remainingFilters, ok := partialidx.FiltersImplyPredicate(filters, pred)
+		remainingFilters, ok := partialidx.FiltersImplyPredicate(filters, pred, c.e.f)
 		if !ok {
 			// The filters do not imply the predicate, so the partial index
 			// cannot be used.
@@ -328,7 +328,7 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 	iter := makeScanIndexIter(c.e.mem, scanPrivate, rejectInvertedIndexes|rejectPartialIndexes)
 	for iter.Next() {
 		// TODO(mgartner): Generate constrained scans for partial indexes if
-		//  they are implied by the filter.
+		// they are implied by the filter.
 
 		// We only consider the partition values when a particular index can otherwise
 		// not be constrained. For indexes that are constrained, the partitioned values


### PR DESCRIPTION
This commit extends the filter/predicate implication logic in the
`partialidx` package. Now the optimizer can determine when filters imply
predicates that contain AND expressions.

This commit also adds a benchmark for predicate implication to help
reveal performance regressions and aid in determining the benefits of
future optimizations. These benchmarks also show how the performance
scales with respect to the number of columns in the filter and
predicate.

Below are the current results as a baseline.

    BenchmarkPredicateImplication/single-exact-match-16                           51.0 ns/op
    BenchmarkPredicateImplication/range-exact-match-16                            51.8 ns/op
    BenchmarkPredicateImplication/range-exact-match-reverse-16                    51.0 ns/op
    BenchmarkPredicateImplication/single-exact-match-extra-filters-16              266 ns/op
    BenchmarkPredicateImplication/single-exact-match-extra-filters-with-range-16  3659 ns/op
    BenchmarkPredicateImplication/range-exact-match-extra-filters-16               256 ns/op
    BenchmarkPredicateImplication/multi-column-exact-match-16                      295 ns/op
    BenchmarkPredicateImplication/multi-column-exact-match-reverse-16              296 ns/op
    BenchmarkPredicateImplication/multi-column-exact-match-extra-filters-16       2332 ns/op
    BenchmarkPredicateImplication/filters-do-not-imply-pred-16                    89.3 ns/op
    BenchmarkPredicateImplication/many-columns-10-16                              2213 ns/op
    BenchmarkPredicateImplication/many-columns-100-16                            63065 ns/op

Future work includes supporting disjunctions and inexact atoms, for
example proving that `a > 10` implies `a > 0`.

Informs #50218 

Release note: None