### PR TITLE
opt: fix infinite loop caused by limit push-down

### DIFF
--- a/pkg/sql/opt/norm/rules/limit.opt
+++ b/pkg/sql/opt/norm/rules/limit.opt
@@ -127,9 +127,10 @@ $input
 # LeftJoin when rows from the left input are guaranteed to be preserved by the
 # join. Since the join creates an output row for each left input row, we only
 # need that many rows from that input. We can only do this if the limit ordering
-# refers only to the left input columns. We also check that the cardinality of
-# the left input is more than the limit, to prevent repeated applications of the
-# rule.
+# refers only to the left input columns. We check that the cardinality of the
+# left input is more than the limit, to prevent repeated applications of the
+# rule. We also check that the left input has no outer columns to avoid
+# interfering with decorrelation.
 #
 # Why can we only match InnerJoins and LeftJoins (e.g. not FullJoins)?
 #
@@ -150,7 +151,7 @@ $input
 [PushLimitIntoJoinLeft, Normalize]
 (Limit
     $input:(InnerJoin | LeftJoin
-            $left:*
+            $left:* & ^(HasOuterCols $left)
             $right:*
             $on:*
             $private:*
@@ -180,7 +181,12 @@ $input
 # PushLimitIntoJoinRight mirrors PushLimitIntoJoinLeft.
 [PushLimitIntoJoinRight, Normalize]
 (Limit
-    $input:(InnerJoin $left:* $right:* $on:* $private:*) &
+    $input:(InnerJoin
+            $left:*
+            $right:* & ^(HasOuterCols $right)
+            $on:*
+            $private:*
+        ) &
         (JoinPreservesRightRows $input)
     $limitExpr:(Const $limit:*) &
         (IsPositiveInt $limit) &

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -1464,3 +1464,70 @@ limit
  │    └── filters
  │         └── a = y
  └── 10
+
+# No-op case because the left input has outer columns.
+norm expect-not=(AssociateLimitJoinsLeft,AssociateLimitJoinsRight) disable=(TryDecorrelateProject,PushLimitIntoProject) format=hide-all
+SELECT *
+FROM uv
+LEFT JOIN LATERAL (
+  SELECT *
+  FROM (SELECT a*u FROM ab)
+  INNER JOIN (VALUES (1))
+  ON True
+  LIMIT 1
+)
+ON True
+----
+distinct-on
+ ├── left-join-apply
+ │    ├── scan uv
+ │    ├── inner-join (cross)
+ │    │    ├── project
+ │    │    │    ├── scan ab
+ │    │    │    └── projections
+ │    │    │         └── a * u
+ │    │    ├── values
+ │    │    │    └── (1,)
+ │    │    └── filters (true)
+ │    └── filters (true)
+ └── aggregations
+      ├── const-agg
+      │    └── v
+      ├── first-agg
+      │    └── "?column?"
+      └── first-agg
+           └── column1
+
+# No-op case because the right input has outer columns. An infinite loop will
+# occur if the limit is pushed down. Regression test for #50355.
+norm expect-not=(AssociateLimitJoinsLeft,AssociateLimitJoinsRight) disable=(TryDecorrelateProject,PushLimitIntoProject) format=hide-all
+SELECT *
+FROM uv
+LEFT JOIN LATERAL (
+  SELECT *
+  FROM (VALUES (1))
+  INNER JOIN (SELECT a*u FROM ab)
+  ON True
+  LIMIT 1
+)
+ON True
+----
+distinct-on
+ ├── left-join-apply
+ │    ├── scan uv
+ │    ├── inner-join (cross)
+ │    │    ├── values
+ │    │    │    └── (1,)
+ │    │    ├── project
+ │    │    │    ├── scan ab
+ │    │    │    └── projections
+ │    │    │         └── a * u
+ │    │    └── filters (true)
+ │    └── filters (true)
+ └── aggregations
+      ├── const-agg
+      │    └── v
+      ├── first-agg
+      │    └── column1
+      └── first-agg
+           └── "?column?"


### PR DESCRIPTION
Previously, PushLimitIntoJoinRight did not check to ensure that
the right input of a join has no outer columns. This caused the
rule to interfere with decorrelation and create infinite loops in
certain queries.

This patch adds a check in the PushLimitIntoJoinLeft and
PushLimitIntoJoinRight rules that ensures that the the left or
right inputs respectively have no outer columns.

Fixes #50355

Release note: None