### PR TITLE
sql: implement ConstructRender and ConstructSimpleProject in the new factory

### DIFF
--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -70,7 +70,11 @@ func distBackup(
 		return nil
 	}
 
-	var p sql.PhysicalPlan
+	gatewayNodeID, err := evalCtx.ExecCfg.NodeID.OptionalNodeIDErr(47970)
+	if err != nil {
+		return err
+	}
+	p := sql.MakePhysicalPlan(gatewayNodeID)
 
 	// Setup a one-stage plan with one proc per input spec.
 	corePlacement := make([]physicalplan.ProcessorCorePlacement, len(backupSpecs))

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -127,30 +127,23 @@ func distChangefeedFlow(
 		}
 	}
 
-	changeAggregatorProcs := make([]physicalplan.Processor, 0, len(spanPartitions))
-	for _, sp := range spanPartitions {
+	corePlacement := make([]physicalplan.ProcessorCorePlacement, len(spanPartitions))
+	for i, sp := range spanPartitions {
 		// TODO(dan): Merge these watches with the span-level resolved
 		// timestamps from the job progress.
 		watches := make([]execinfrapb.ChangeAggregatorSpec_Watch, len(sp.Spans))
-		for i, nodeSpan := range sp.Spans {
-			watches[i] = execinfrapb.ChangeAggregatorSpec_Watch{
+		for watchIdx, nodeSpan := range sp.Spans {
+			watches[watchIdx] = execinfrapb.ChangeAggregatorSpec_Watch{
 				Span:            nodeSpan,
 				InitialResolved: initialHighWater,
 			}
 		}
 
-		changeAggregatorProcs = append(changeAggregatorProcs, physicalplan.Processor{
-			Node: sp.Node,
-			Spec: execinfrapb.ProcessorSpec{
-				Core: execinfrapb.ProcessorCoreUnion{
-					ChangeAggregator: &execinfrapb.ChangeAggregatorSpec{
-						Watches: watches,
-						Feed:    details,
-					},
-				},
-				Output: []execinfrapb.OutputRouterSpec{{Type: execinfrapb.OutputRouterSpec_PASS_THROUGH}},
-			},
-		})
+		corePlacement[i].NodeID = sp.Node
+		corePlacement[i].Core.ChangeAggregator = &execinfrapb.ChangeAggregatorSpec{
+			Watches: watches,
+			Feed:    details,
+		}
 	}
 	// NB: This SpanFrontier processor depends on the set of tracked spans being
 	// static. Currently there is no way for them to change after the changefeed
@@ -163,15 +156,7 @@ func distChangefeedFlow(
 	}
 
 	var p sql.PhysicalPlan
-
-	stageID := p.NewStageID()
-	p.ResultRouters = make([]physicalplan.ProcessorIdx, len(changeAggregatorProcs))
-	for i, proc := range changeAggregatorProcs {
-		proc.Spec.StageID = stageID
-		pIdx := p.AddProcessor(proc)
-		p.ResultRouters[i] = pIdx
-	}
-
+	p.AddNoInputStage(corePlacement, execinfrapb.PostProcessSpec{}, []*types.T{}, execinfrapb.Ordering{})
 	p.AddSingleGroupStage(
 		gatewayNodeID,
 		execinfrapb.ProcessorCoreUnion{ChangeFrontier: &changeFrontierSpec},
@@ -179,7 +164,6 @@ func distChangefeedFlow(
 		changefeedResultTypes,
 	)
 
-	p.ResultTypes = changefeedResultTypes
 	p.PlanToStreamColMap = []int{1, 2, 3}
 	dsp.FinalizePlan(planCtx, &p)
 

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -155,7 +155,7 @@ func distChangefeedFlow(
 		JobID:        jobID,
 	}
 
-	var p sql.PhysicalPlan
+	p := sql.MakePhysicalPlan(gatewayNodeID)
 	p.AddNoInputStage(corePlacement, execinfrapb.PostProcessSpec{}, []*types.T{}, execinfrapb.Ordering{})
 	p.AddSingleGroupStage(
 		gatewayNodeID,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1419,7 +1419,7 @@ func (s *Server) Start(ctx context.Context) error {
 		s.cfg.NodeAttributes,
 		s.cfg.Locality,
 		s.cfg.LocalityAddresses,
-		s.sqlServer.execCfg.DistSQLPlanner.SetNodeDesc,
+		s.sqlServer.execCfg.DistSQLPlanner.SetNodeInfo,
 	); err != nil {
 		return err
 	}

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -398,8 +398,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 			ctx,
 			execinfra.Version,
 			cfg.Settings,
-			// The node descriptor will be set later, once it is initialized.
-			roachpb.NodeDescriptor{},
+			roachpb.NodeID(cfg.nodeIDContainer.SQLInstanceID()),
 			cfg.rpcContext,
 			distSQLServer,
 			cfg.distSender,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -646,7 +646,7 @@ func StartTenant(
 	// the tenant from crashing.
 	//
 	// NB: this NodeID is actually used by the DistSQL planner.
-	s.execCfg.DistSQLPlanner.SetNodeDesc(roachpb.NodeDescriptor{NodeID: fakeNodeID})
+	s.execCfg.DistSQLPlanner.SetNodeInfo(roachpb.NodeDescriptor{NodeID: fakeNodeID})
 
 	connManager := netutil.MakeServer(
 		args.stopper,

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -759,7 +759,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	ex.sessionTracing.TracePlanCheckStart(ctx)
 	distributePlan := getPlanDistribution(
 		ctx, planner.execCfg.NodeID, ex.sessionData.DistSQLMode, planner.curPlan.main,
-	).willDistribute()
+	).WillDistribute()
 	ex.sessionTracing.TracePlanCheckEnd(ctx, nil, distributePlan)
 
 	if ex.server.cfg.TestingKnobs.BeforeExecute != nil {
@@ -775,7 +775,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		panic(fmt.Sprintf("query %d not in registry", stmt.queryID))
 	}
 	queryMeta.phase = executing
-	// TODO(yuzefovich): introduce ternary planDistribution into queryMeta.
+	// TODO(yuzefovich): introduce ternary PlanDistribution into queryMeta.
 	queryMeta.isDistributed = distributePlan
 	progAtomic := &queryMeta.progressAtomic
 	ex.mu.Unlock()

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -262,7 +262,7 @@ func startConnExecutor(
 		},
 		Codec: keys.SystemSQLCodec,
 		DistSQLPlanner: NewDistSQLPlanner(
-			ctx, execinfra.Version, st, roachpb.NodeDescriptor{NodeID: 1},
+			ctx, execinfra.Version, st, roachpb.NodeID(1),
 			nil, /* rpcCtx */
 			distsql.NewServer(ctx, execinfra.ServerConfig{
 				AmbientContext: testutils.MakeAmbientCtx(),

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -814,12 +814,12 @@ func TestPartitionSpans(t *testing.T) {
 
 			gw := gossip.MakeExposedGossip(mockGossip)
 			dsp := DistSQLPlanner{
-				planVersion:  execinfra.Version,
-				st:           cluster.MakeTestingClusterSettings(),
-				nodeDesc:     *tsp.nodes[tc.gatewayNode-1],
-				stopper:      stopper,
-				spanResolver: tsp,
-				gossip:       gw,
+				planVersion:   execinfra.Version,
+				st:            cluster.MakeTestingClusterSettings(),
+				gatewayNodeID: tsp.nodes[tc.gatewayNode-1].NodeID,
+				stopper:       stopper,
+				spanResolver:  tsp,
+				gossip:        gw,
 				nodeHealth: distSQLNodeHealth{
 					gossip: gw,
 					connHealth: func(node roachpb.NodeID, _ rpc.ConnectionClass) error {
@@ -1001,12 +1001,12 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 
 			gw := gossip.MakeExposedGossip(mockGossip)
 			dsp := DistSQLPlanner{
-				planVersion:  tc.planVersion,
-				st:           cluster.MakeTestingClusterSettings(),
-				nodeDesc:     *tsp.nodes[gatewayNode-1],
-				stopper:      stopper,
-				spanResolver: tsp,
-				gossip:       gw,
+				planVersion:   tc.planVersion,
+				st:            cluster.MakeTestingClusterSettings(),
+				gatewayNodeID: tsp.nodes[gatewayNode-1].NodeID,
+				stopper:       stopper,
+				spanResolver:  tsp,
+				gossip:        gw,
 				nodeHealth: distSQLNodeHealth{
 					gossip: gw,
 					connHealth: func(roachpb.NodeID, rpc.ConnectionClass) error {
@@ -1099,12 +1099,12 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 
 	gw := gossip.MakeExposedGossip(mockGossip)
 	dsp := DistSQLPlanner{
-		planVersion:  execinfra.Version,
-		st:           cluster.MakeTestingClusterSettings(),
-		nodeDesc:     *tsp.nodes[gatewayNode-1],
-		stopper:      stopper,
-		spanResolver: tsp,
-		gossip:       gw,
+		planVersion:   execinfra.Version,
+		st:            cluster.MakeTestingClusterSettings(),
+		gatewayNodeID: tsp.nodes[gatewayNode-1].NodeID,
+		stopper:       stopper,
+		spanResolver:  tsp,
+		gossip:        gw,
 		nodeHealth: distSQLNodeHealth{
 			gossip: gw,
 			connHealth: func(node roachpb.NodeID, _ rpc.ConnectionClass) error {

--- a/pkg/sql/distsql_plan_backfill.go
+++ b/pkg/sql/distsql_plan_backfill.go
@@ -67,7 +67,7 @@ func (dsp *DistSQLPlanner) createBackfiller(
 		return PhysicalPlan{}, err
 	}
 
-	p := MakePhysicalPlan(dsp.nodeDesc.NodeID)
+	p := MakePhysicalPlan(dsp.gatewayNodeID)
 	p.ResultRouters = make([]physicalplan.ProcessorIdx, len(spanPartitions))
 	for i, sp := range spanPartitions {
 		ib := &execinfrapb.BackfillerSpec{}

--- a/pkg/sql/distsql_plan_backfill.go
+++ b/pkg/sql/distsql_plan_backfill.go
@@ -67,7 +67,7 @@ func (dsp *DistSQLPlanner) createBackfiller(
 		return PhysicalPlan{}, err
 	}
 
-	var p PhysicalPlan
+	p := MakePhysicalPlan(dsp.nodeDesc.NodeID)
 	p.ResultRouters = make([]physicalplan.ProcessorIdx, len(spanPartitions))
 	for i, sp := range spanPartitions {
 		ib := &execinfrapb.BackfillerSpec{}

--- a/pkg/sql/distsql_plan_bulk.go
+++ b/pkg/sql/distsql_plan_bulk.go
@@ -37,7 +37,7 @@ func (dsp *DistSQLPlanner) SetupAllNodesPlanning(
 	// planCtx.NodeStatuses map ourselves. CheckNodeHealthAndVersion() will
 	// populate it.
 	for _, node := range resp.Nodes {
-		_ /* NodeStautus */ = dsp.CheckNodeHealthAndVersion(planCtx, node.Desc.NodeID)
+		_ /* NodeStatus */ = dsp.CheckNodeHealthAndVersion(planCtx, node.Desc.NodeID)
 	}
 	nodes := make([]roachpb.NodeID, 0, len(planCtx.NodeStatuses))
 	for nodeID := range planCtx.NodeStatuses {

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -195,7 +195,11 @@ func DistIngest(
 
 	inputSpecs := makeImportReaderSpecs(job, tables, from, format, nodes, walltime)
 
-	var p PhysicalPlan
+	gatewayNodeID, err := evalCtx.ExecCfg.NodeID.OptionalNodeIDErr(47970)
+	if err != nil {
+		return roachpb.BulkOpSummary{}, err
+	}
+	p := MakePhysicalPlan(gatewayNodeID)
 
 	// Setup a one-stage plan with one proc per input spec.
 	corePlacement := make([]physicalplan.ProcessorCorePlacement, len(inputSpecs))

--- a/pkg/sql/distsql_plan_ctas.go
+++ b/pkg/sql/distsql_plan_ctas.go
@@ -46,7 +46,6 @@ func PlanAndRunCTAS(
 
 	// The bulk row writers will emit a binary encoded BulkOpSummary.
 	physPlan.PlanToStreamColMap = []int{0}
-	physPlan.ResultTypes = rowexec.CTASPlanResultTypes
 
 	// Make copy of evalCtx as Run might modify it.
 	evalCtxCopy := planner.ExtendedEvalContextCopy()

--- a/pkg/sql/distsql_plan_join.go
+++ b/pkg/sql/distsql_plan_join.go
@@ -163,11 +163,10 @@ func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 		ancsIdx, descIdx = 1, 0
 	}
 
-	stageID := plan.NewStageID()
-
 	// We provision a separate InterleavedReaderJoiner per node that has
 	// rows from either table.
-	for _, nodeID := range nodes {
+	corePlacement := make([]physicalplan.ProcessorCorePlacement, len(nodes))
+	for i, nodeID := range nodes {
 		// Find the relevant span from each table for this node.
 		// Note it is possible that either set of spans can be empty
 		// (but not both).
@@ -208,32 +207,20 @@ func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 			Type:              joinType,
 		}
 
-		proc := physicalplan.Processor{
-			Node: nodeID,
-			Spec: execinfrapb.ProcessorSpec{
-				Core:    execinfrapb.ProcessorCoreUnion{InterleavedReaderJoiner: irj},
-				Post:    post,
-				Output:  []execinfrapb.OutputRouterSpec{{Type: execinfrapb.OutputRouterSpec_PASS_THROUGH}},
-				StageID: stageID,
-			},
-		}
-
-		plan.Processors = append(plan.Processors, proc)
+		corePlacement[i].NodeID = nodeID
+		corePlacement[i].Core.InterleavedReaderJoiner = irj
 	}
 
-	// Each result router correspond to each of the processors we appended.
-	plan.ResultRouters = make([]physicalplan.ProcessorIdx, len(nodes))
-	for i := 0; i < len(nodes); i++ {
-		plan.ResultRouters[i] = physicalplan.ProcessorIdx(i)
-	}
-
-	plan.PlanToStreamColMap = joinToStreamColMap
-	plan.ResultTypes, err = getTypesForPlanResult(n, joinToStreamColMap)
+	resultTypes, err := getTypesForPlanResult(n, joinToStreamColMap)
 	if err != nil {
 		return nil, false, err
 	}
+	plan.AddNoInputStage(
+		corePlacement, post, resultTypes, dsp.convertOrdering(n.reqOrdering, joinToStreamColMap),
+	)
 
-	plan.SetMergeOrdering(dsp.convertOrdering(n.reqOrdering, plan.PlanToStreamColMap))
+	plan.PlanToStreamColMap = joinToStreamColMap
+
 	return plan, true, nil
 }
 

--- a/pkg/sql/distsql_plan_join.go
+++ b/pkg/sql/distsql_plan_join.go
@@ -215,6 +215,10 @@ func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 	if err != nil {
 		return nil, false, err
 	}
+	plan.GatewayNodeID, err = planCtx.ExtendedEvalCtx.ExecCfg.NodeID.OptionalNodeIDErr(50050)
+	if err != nil {
+		return nil, false, err
+	}
 	plan.AddNoInputStage(
 		corePlacement, post, resultTypes, dsp.convertOrdering(n.reqOrdering, joinToStreamColMap),
 	)

--- a/pkg/sql/distsql_plan_scrub_physical.go
+++ b/pkg/sql/distsql_plan_scrub_physical.go
@@ -53,7 +53,7 @@ func (dsp *DistSQLPlanner) createScrubPhysicalCheck(
 		corePlacement[i].Core.TableReader = tr
 	}
 
-	var p PhysicalPlan
+	p := MakePhysicalPlan(dsp.nodeDesc.NodeID)
 	p.AddNoInputStage(corePlacement, execinfrapb.PostProcessSpec{}, rowexec.ScrubTypes, execinfrapb.Ordering{})
 	p.PlanToStreamColMap = identityMapInPlace(make([]int, len(rowexec.ScrubTypes)))
 

--- a/pkg/sql/distsql_plan_scrub_physical.go
+++ b/pkg/sql/distsql_plan_scrub_physical.go
@@ -53,7 +53,7 @@ func (dsp *DistSQLPlanner) createScrubPhysicalCheck(
 		corePlacement[i].Core.TableReader = tr
 	}
 
-	p := MakePhysicalPlan(dsp.nodeDesc.NodeID)
+	p := MakePhysicalPlan(dsp.gatewayNodeID)
 	p.AddNoInputStage(corePlacement, execinfrapb.PostProcessSpec{}, rowexec.ScrubTypes, execinfrapb.Ordering{})
 	p.PlanToStreamColMap = identityMapInPlace(make([]int, len(rowexec.ScrubTypes)))
 

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -202,7 +202,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 		RowsExpected:     rowsExpected,
 	}
 	// Plan the SampleAggregator on the gateway, unless we have a single Sampler.
-	node := dsp.nodeDesc.NodeID
+	node := dsp.gatewayNodeID
 	if len(p.ResultRouters) == 1 {
 		node = p.Processors[p.ResultRouters[0]].Node
 	}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -879,7 +879,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	if maybeDistribute {
 		distributeSubquery = getPlanDistribution(
 			ctx, planner.execCfg.NodeID, planner.SessionData().DistSQLMode, subqueryPlan.plan,
-		).willDistribute()
+		).WillDistribute()
 	}
 	subqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner.txn, distributeSubquery)
 	subqueryPlanCtx.planner = planner
@@ -1183,7 +1183,7 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	if maybeDistribute {
 		distributePostquery = getPlanDistribution(
 			ctx, planner.execCfg.NodeID, planner.SessionData().DistSQLMode, postqueryPlan,
-		).willDistribute()
+		).WillDistribute()
 	}
 	postqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner.txn, distributePostquery)
 	postqueryPlanCtx.planner = planner

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -126,7 +126,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 	localState distsql.LocalState,
 	vectorizeThresholdMet bool,
 ) (context.Context, flowinfra.Flow, error) {
-	thisNodeID := dsp.nodeDesc.NodeID
+	thisNodeID := dsp.gatewayNodeID
 	_, ok := flows[thisNodeID]
 	if !ok {
 		return nil, nil, errors.AssertionFailedf("missing gateway flow")
@@ -320,8 +320,8 @@ func (dsp *DistSQLPlanner) Run(
 		leafInputState = &tis
 	}
 
-	flows := plan.GenerateFlowSpecs(dsp.nodeDesc.NodeID /* gateway */)
-	if _, ok := flows[dsp.nodeDesc.NodeID]; !ok {
+	flows := plan.GenerateFlowSpecs()
+	if _, ok := flows[dsp.gatewayNodeID]; !ok {
 		recv.SetError(errors.Errorf("expected to find gateway flow"))
 		return func() {}
 	}

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -213,45 +213,70 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	return planMaybePhysical{physPlan: &p}, err
 }
 
-func (e *distSQLSpecExecFactory) ConstructFilter(
-	n exec.Node, filter tree.TypedExpr, reqOrdering exec.OutputOrdering,
-) (exec.Node, error) {
-	plan := n.(planMaybePhysical)
-	physPlan := plan.physPlan
-	physPlan.SetMergeOrdering(e.dsp.convertOrdering(ReqOrdering(reqOrdering), physPlan.PlanToStreamColMap))
-	// We recommend for filter's distribution to be the same as the last stage
+// checkExprsAndMaybeMergeLastStage is a helper method that returns a
+// recommendation about exprs' distribution. If one of the expressions cannot
+// be distributed, then all expressions cannot be distributed either. In such
+// case if the last stage is distributed, this method takes care of merging the
+// streams on the gateway node.
+func (e *distSQLSpecExecFactory) checkExprsAndMaybeMergeLastStage(
+	physPlan *PhysicalPlan, exprs tree.TypedExprs,
+) distRecommendation {
+	// We recommend for exprs' distribution to be the same as the last stage
 	// of processors.
 	recommendation := shouldNotDistribute
 	if physPlan.IsLastStageDistributed() {
 		recommendation = shouldDistribute
 	}
-	if err := checkExpr(filter); err != nil {
-		recommendation = cannotDistribute
-		if physPlan.IsLastStageDistributed() {
-			// The last stage has been distributed, but filter expression
-			// cannot be distributed, so we need to merge the streams on a
-			// single node. We could do so on one of the nodes that streams
-			// originate from, but for now we choose the gateway.
-			physPlan.AddSingleGroupStage(
-				e.gatewayNodeID,
-				execinfrapb.ProcessorCoreUnion{Noop: &execinfrapb.NoopCoreSpec{}},
-				execinfrapb.PostProcessSpec{},
-				physPlan.ResultTypes,
-			)
+	for _, expr := range exprs {
+		if err := checkExpr(expr); err != nil {
+			recommendation = cannotDistribute
+			// The filter expression cannot be distributed, so we need to make
+			// sure that there is a single stream on a node. We could do so on
+			// one of the nodes that streams originate from, but for now we
+			// choose the gateway.
+			physPlan.EnsureSingleStreamOnGateway()
+			break
 		}
 	}
+	return recommendation
+}
+
+func (e *distSQLSpecExecFactory) ConstructFilter(
+	n exec.Node, filter tree.TypedExpr, reqOrdering exec.OutputOrdering,
+) (exec.Node, error) {
+	plan := n.(planMaybePhysical)
+	physPlan := plan.physPlan
+	recommendation := e.checkExprsAndMaybeMergeLastStage(physPlan, []tree.TypedExpr{filter})
 	// AddFilter will attempt to push the filter into the last stage of
 	// processors.
 	if err := physPlan.AddFilter(filter, e.getPlanCtx(recommendation), physPlan.PlanToStreamColMap); err != nil {
 		return nil, err
 	}
+	physPlan.SetMergeOrdering(e.dsp.convertOrdering(ReqOrdering(reqOrdering), physPlan.PlanToStreamColMap))
 	return plan, nil
 }
 
 func (e *distSQLSpecExecFactory) ConstructSimpleProject(
 	n exec.Node, cols []exec.NodeColumnOrdinal, colNames []string, reqOrdering exec.OutputOrdering,
 ) (exec.Node, error) {
-	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+	plan := n.(planMaybePhysical)
+	physPlan := plan.physPlan
+	projection := make([]uint32, len(cols))
+	for i := range cols {
+		projection[i] = uint32(cols[i])
+	}
+	physPlan.AddProjection(projection)
+	physPlan.ResultColumns = getResultColumnsForSimpleProject(cols, colNames, physPlan.ResultTypes, physPlan.ResultColumns)
+	physPlan.PlanToStreamColMap = identityMap(physPlan.PlanToStreamColMap, len(cols))
+	if reqOrdering == nil {
+		// When reqOrdering is nil, we're adding a top-level (i.e. "final")
+		// projection. In such scenario we need to be careful to not simply
+		// reset the merge ordering that is currently set on the plan - we do
+		// so by merging the streams on the gateway node.
+		physPlan.EnsureSingleStreamOnGateway()
+	}
+	physPlan.SetMergeOrdering(e.dsp.convertOrdering(ReqOrdering(reqOrdering), physPlan.PlanToStreamColMap))
+	return plan, nil
 }
 
 func (e *distSQLSpecExecFactory) ConstructRender(
@@ -260,7 +285,18 @@ func (e *distSQLSpecExecFactory) ConstructRender(
 	exprs tree.TypedExprs,
 	reqOrdering exec.OutputOrdering,
 ) (exec.Node, error) {
-	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
+	plan := n.(planMaybePhysical)
+	physPlan := plan.physPlan
+	recommendation := e.checkExprsAndMaybeMergeLastStage(physPlan, exprs)
+	if err := physPlan.AddRendering(
+		exprs, e.getPlanCtx(recommendation), physPlan.PlanToStreamColMap, getTypesFromResultColumns(columns),
+	); err != nil {
+		return nil, err
+	}
+	physPlan.ResultColumns = columns
+	physPlan.PlanToStreamColMap = identityMap(physPlan.PlanToStreamColMap, len(exprs))
+	physPlan.SetMergeOrdering(e.dsp.convertOrdering(ReqOrdering(reqOrdering), physPlan.PlanToStreamColMap))
+	return plan, nil
 }
 
 func (e *distSQLSpecExecFactory) ConstructApplyJoin(

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -51,7 +51,7 @@ func newDistSQLSpecExecFactory(p *planner) exec.Factory {
 		planner:       p,
 		dsp:           p.extendedEvalCtx.DistSQLPlanner,
 		singleTenant:  p.execCfg.Codec.ForSystemTenant(),
-		gatewayNodeID: roachpb.NodeID(p.execCfg.NodeID.SQLInstanceID()),
+		gatewayNodeID: p.extendedEvalCtx.DistSQLPlanner.gatewayNodeID,
 	}
 }
 

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -14,7 +14,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -243,9 +242,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 		}
 		diagram.AddSpans(spans)
 	} else {
-		// TODO(asubiotto): This cast from SQLInstanceID to NodeID is temporary:
-		//  https://github.com/cockroachdb/cockroach/issues/49596
-		flows := physPlan.GenerateFlowSpecs(roachpb.NodeID(params.extendedEvalCtx.NodeID.SQLInstanceID()))
+		flows := physPlan.GenerateFlowSpecs()
 		showInputTypes := n.options.Flags[tree.ExplainFlagTypes]
 		diagram, err = execinfrapb.GeneratePlanDiagram(params.p.stmt.String(), flows, showInputTypes)
 		if err != nil {

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -65,7 +66,7 @@ type distSQLExplainable interface {
 	newPlanForExplainDistSQL(*PlanningCtx, *DistSQLPlanner) (*PhysicalPlan, error)
 }
 
-// getPlanDistributionForExplainPurposes returns the planDistribution that plan
+// getPlanDistributionForExplainPurposes returns the PlanDistribution that plan
 // will have. It is similar to getPlanDistribution but also pays attention to
 // whether the logical plan will be handled as a distributed job. It should
 // *only* be used in EXPLAIN variants.
@@ -74,22 +75,22 @@ func getPlanDistributionForExplainPurposes(
 	nodeID *base.SQLIDContainer,
 	distSQLMode sessiondata.DistSQLExecMode,
 	plan planMaybePhysical,
-) planDistribution {
+) physicalplan.PlanDistribution {
 	if plan.isPhysicalPlan() {
-		return plan.distribution
+		return plan.physPlan.Distribution
 	}
 	switch p := plan.planNode.(type) {
 	case *explainDistSQLNode:
 		if p.plan.main.isPhysicalPlan() {
-			return p.plan.main.distribution
+			return p.plan.main.physPlan.Distribution
 		}
 	case *explainVecNode:
 		if p.plan.isPhysicalPlan() {
-			return p.plan.distribution
+			return p.plan.physPlan.Distribution
 		}
 	case *explainPlanNode:
 		if p.plan.main.isPhysicalPlan() {
-			return p.plan.main.distribution
+			return p.plan.main.physPlan.Distribution
 		}
 	}
 	if _, ok := plan.planNode.(distSQLExplainable); ok {
@@ -97,7 +98,7 @@ func getPlanDistributionForExplainPurposes(
 		// but are represented using local plan nodes (for example, "create
 		// statistics" is handled by the jobs framework which is responsible
 		// for setting up the correct DistSQL infrastructure).
-		return fullyDistributedPlan
+		return physicalplan.FullyDistributedPlan
 	}
 	return getPlanDistribution(ctx, nodeID, distSQLMode, plan)
 }
@@ -108,7 +109,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 		params.ctx, params.extendedEvalCtx.ExecCfg.NodeID,
 		params.extendedEvalCtx.SessionData.DistSQLMode, n.plan.main,
 	)
-	willDistribute := distribution.willDistribute()
+	willDistribute := distribution.WillDistribute()
 	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx, params.p.txn, willDistribute)
 	planCtx.ignoreClose = true
 	planCtx.planner = params.p

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -204,9 +204,7 @@ func populateExplain(
 		// There might be an issue making the physical plan, but that should not
 		// cause an error or panic, so swallow the error. See #40677 for example.
 		distSQLPlanner.FinalizePlan(planCtx, physicalPlan)
-		// TODO(asubiotto): This cast from SQLInstanceID to NodeID is temporary:
-		//  https://github.com/cockroachdb/cockroach/issues/49596
-		flows := physicalPlan.GenerateFlowSpecs(roachpb.NodeID(params.extendedEvalCtx.NodeID.SQLInstanceID()))
+		flows := physicalPlan.GenerateFlowSpecs()
 		flowCtx := newFlowCtxForExplainPurposes(planCtx, params)
 		flowCtx.Cfg.ClusterID = &distSQLPlanner.rpcCtx.ClusterID
 

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -193,7 +193,7 @@ func populateExplain(
 		params.ctx, params.extendedEvalCtx.ExecCfg.NodeID,
 		params.extendedEvalCtx.SessionData.DistSQLMode, plan.main,
 	)
-	willDistribute := distribution.willDistribute()
+	willDistribute := distribution.WillDistribute()
 	outerSubqueries := params.p.curPlan.subqueryPlans
 	planCtx := newPlanningCtxForExplainPurposes(distSQLPlanner, params, stmtType, plan.subqueryPlans, distribution)
 	defer func() {

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -59,7 +60,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 		params.ctx, params.extendedEvalCtx.ExecCfg.NodeID,
 		params.extendedEvalCtx.SessionData.DistSQLMode, n.plan,
 	)
-	willDistribute := distribution.willDistribute()
+	willDistribute := distribution.WillDistribute()
 	outerSubqueries := params.p.curPlan.subqueryPlans
 	planCtx := newPlanningCtxForExplainPurposes(distSQLPlanner, params, n.stmtType, n.subqueryPlans, distribution)
 	defer func() {
@@ -142,9 +143,9 @@ func newPlanningCtxForExplainPurposes(
 	params runParams,
 	stmtType tree.StatementType,
 	subqueryPlans []subquery,
-	distribution planDistribution,
+	distribution physicalplan.PlanDistribution,
 ) *PlanningCtx {
-	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx, params.p.txn, distribution.willDistribute())
+	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx, params.p.txn, distribution.WillDistribute())
 	planCtx.ignoreClose = true
 	planCtx.planner = params.p
 	planCtx.stmtType = stmtType

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colflow"
-	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
@@ -76,11 +75,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 	}
 
 	distSQLPlanner.FinalizePlan(planCtx, physPlan)
-	nodeID, err := params.extendedEvalCtx.NodeID.OptionalNodeIDErr(distsql.MultiTenancyIssueNo)
-	if err != nil {
-		return err
-	}
-	flows := physPlan.GenerateFlowSpecs(nodeID)
+	flows := physPlan.GenerateFlowSpecs()
 	flowCtx := newFlowCtxForExplainPurposes(planCtx, params)
 	flowCtx.Cfg.ClusterID = &distSQLPlanner.rpcCtx.ClusterID
 

--- a/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning
+++ b/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning
@@ -41,13 +41,19 @@ v
 1
 2
 
-# Projections are not yet supported.
-statement error pq: unimplemented: experimental opt-driven distsql planning
+query II rowsort
 SELECT v, k FROM kv
+----
+1  1
+1  2
+2  3
 
-# Renders are not yet supported.
-statement error pq: unimplemented: experimental opt-driven distsql planning
-SELECT k + v FROM kv
+query III rowsort
+SELECT k, v, k + v FROM kv
+----
+1  1  2
+2  1  3
+3  2  5
 
 query II rowsort
 SELECT * FROM kv WHERE k > v

--- a/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning_5node
+++ b/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning_5node
@@ -109,3 +109,36 @@ EXPLAIN (VEC) SELECT * FROM kv WHERE k::REGCLASS IS NOT NULL
 
 statement ok
 SET experimental_distsql_planning = always
+
+# Check that plan is partially distributed (due to DOid type in a render
+# expression which is not supported by DistSQL).
+query T
+EXPLAIN (VEC) SELECT k::REGCLASS FROM kv
+----
+│
+├ Node 1
+│ └ *colexec.castOp
+│   └ *colexec.ParallelUnorderedSynchronizer
+│     ├ *colexec.colBatchScan
+│     ├ *colrpc.Inbox
+│     ├ *colrpc.Inbox
+│     ├ *colrpc.Inbox
+│     └ *colrpc.Inbox
+├ Node 2
+│ └ *colrpc.Outbox
+│   └ *colexec.colBatchScan
+├ Node 3
+│ └ *colrpc.Outbox
+│   └ *colexec.colBatchScan
+├ Node 4
+│ └ *colrpc.Outbox
+│   └ *colexec.colBatchScan
+└ Node 5
+  └ *colrpc.Outbox
+    └ *colexec.colBatchScan
+
+query TTT
+EXPLAIN SELECT k::REGCLASS FROM kv
+----
+·  distribution  partial
+·  vectorized    true

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -288,22 +288,18 @@ func (ef *execFactory) ConstructSimpleProject(
 	rb.init(n, reqOrdering)
 
 	exprs := make(tree.TypedExprs, len(cols))
-	resultCols := make(sqlbase.ResultColumns, len(cols))
 	for i, col := range cols {
-		v := rb.r.ivarHelper.IndexedVar(int(col))
-		if colNames == nil {
-			resultCols[i] = inputCols[col]
-			// If we have a SimpleProject, we should clear the hidden bit on any
-			// column since it indicates it's been explicitly selected.
-			resultCols[i].Hidden = false
-		} else {
-			resultCols[i] = sqlbase.ResultColumn{
-				Name: colNames[i],
-				Typ:  v.ResolvedType(),
-			}
-		}
-		exprs[i] = v
+		exprs[i] = rb.r.ivarHelper.IndexedVar(int(col))
 	}
+	var resultTypes []*types.T
+	if colNames != nil {
+		// We will need updated result types.
+		resultTypes = make([]*types.T, len(cols))
+		for i := range exprs {
+			resultTypes[i] = exprs[i].ResolvedType()
+		}
+	}
+	resultCols := getResultColumnsForSimpleProject(cols, colNames, resultTypes, inputCols)
 	rb.setOutput(exprs, resultCols)
 	return rb.res, nil
 }

--- a/pkg/sql/physicalplan/physical_plan.go
+++ b/pkg/sql/physicalplan/physical_plan.go
@@ -915,9 +915,7 @@ func (p *PhysicalPlan) PopulateEndpoints() {
 // set of FlowSpecs (one per node involved in the plan).
 //
 // gateway is the current node's NodeID.
-func (p *PhysicalPlan) GenerateFlowSpecs(
-	gateway roachpb.NodeID,
-) map[roachpb.NodeID]*execinfrapb.FlowSpec {
+func (p *PhysicalPlan) GenerateFlowSpecs() map[roachpb.NodeID]*execinfrapb.FlowSpec {
 	// Only generate a flow ID for a remote plan because it will need to be
 	// referenced by remote nodes when connecting streams. This id generation is
 	// skipped for performance reasons on local flows.
@@ -930,7 +928,7 @@ func (p *PhysicalPlan) GenerateFlowSpecs(
 	for _, proc := range p.Processors {
 		flowSpec, ok := flows[proc.Node]
 		if !ok {
-			flowSpec = NewFlowSpec(flowID, gateway)
+			flowSpec = NewFlowSpec(flowID, p.GatewayNodeID)
 			flows[proc.Node] = flowSpec
 		}
 		flowSpec.Processors = append(flowSpec.Processors, proc.Spec)

--- a/pkg/sql/physicalplan/physical_plan_test.go
+++ b/pkg/sql/physicalplan/physical_plan_test.go
@@ -314,6 +314,7 @@ func TestProjectionAndRendering(t *testing.T) {
 				{Spec: execinfrapb.ProcessorSpec{Post: tc.post}},
 			},
 			ResultRouters: []ProcessorIdx{0, 1},
+			Distribution:  LocalPlan,
 		}
 
 		if tc.ordering != "" {

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -318,9 +318,6 @@ type planMaybePhysical struct {
 	// physPlan (when non-nil) contains the physical plan that has not yet
 	// been finalized.
 	physPlan *PhysicalPlan
-	// distribution (when physPlan is non-nil) is the indicator of the
-	// distribution of the physical plan.
-	distribution planDistribution
 }
 
 func (p planMaybePhysical) isPhysicalPlan() bool {

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -268,7 +268,7 @@ func (sc *SchemaChanger) maybeBackfillCreateTableAs(
 			ctx, localPlanner.execCfg.NodeID,
 			localPlanner.extendedEvalCtx.SessionData.DistSQLMode,
 			localPlanner.curPlan.main,
-		).willDistribute()
+		).WillDistribute()
 		var planAndRunErr error
 		localPlanner.runWithOptions(resolveFlags{skipCache: true}, func() {
 			// Resolve subqueries before running the queries' physical plan.

--- a/pkg/util/errorutil/tenant_deprecated_wrapper.go
+++ b/pkg/util/errorutil/tenant_deprecated_wrapper.go
@@ -69,7 +69,7 @@ func (w TenantSQLDeprecatedWrapper) Deprecated(issueNo int) interface{} {
 // is desired.
 //
 // Optional functionality should be used sparingly as it increases the
-// maintenance and testing burden. It is prefererable to use use OptionalErr()
+// maintenance and testing burden. It is preferable to use OptionalErr()
 // (and return the error) where possible.
 func (w TenantSQLDeprecatedWrapper) Optional() (interface{}, bool) {
 	if !w.exposed {


### PR DESCRIPTION
**sql,ccl: clean up adding "no input" stage of processors**

This commit adds a helper method `PhysicalPlan.AddNoInputStage` that
plans a new stage of the processors that don't have any input streams
with the specified cores on the corresponding nodes, and then it
reuses it in several places simplifying the code a bit.

Release note: None

**sql: move distribution info into `physicalplan.PhysicalPlan`**

This commit moves the information about plan distribution from
`planMaybePhysical` into `physicalplan.PhysicalPlan`. This allows us to
simplify the logic that updates the distribution info - the update can
be done whenever a new stage of the processors is added.

However, there is a complication that `NewStage` method needs to know
whether the new stage has at least one remote processor - simply
checking whether there is more than one node participating is not
sufficient because when we have a single processor planned on a remote
node, such stage is still considered "distributed". This commit adds the
plumbing to be able to figure this out.

Release note: None

**sql,server: minor cleanup around the gateway node ID in DistSQLPlanner**

This commit makes a tiny step towards removing a dependency of
`DistSQLPlanner` on node descriptor - by switching to using
`roachpb.NodeID` instead.

It also changes `distSQLSpecExecFactory` to use
`DistSQLPlanner.gatewayNodeID` field so that tests on `3node-tenant`
config are happy.

Release note: None

**sql: implement ConstructRender and ConstructSimpleProject in the new factory**

This commit adds implementations of `ConstructRender` and
`ConstructSimpleProject` methods to the new factory. One thing worth
calling out is the way the new factory handles updating the merge
ordering when `reqOrdering` is `nil` (which is the case when we have a
top-level projection) - we're merging all streams of the plan according
to the old merge ordering on the gateway node. This comes from the fact
that we cannot simply reset the merge ordering that is currently set on
the plan.

Release note: None