### PR TITLE
geo: fix bounding box for negative values

### DIFF
--- a/pkg/geo/bbox_test.go
+++ b/pkg/geo/bbox_test.go
@@ -24,8 +24,11 @@ func TestBoundingBoxFromGeom(t *testing.T) {
 		g        geom.T
 		expected *geopb.BoundingBox
 	}{
+		{geom.NewPointFlat(geom.XY, []float64{-15, -20}), &geopb.BoundingBox{MinX: -15, MaxX: -15, MinY: -20, MaxY: -20}},
+		{geom.NewPointFlat(geom.XY, []float64{0, 0}), &geopb.BoundingBox{MinX: 0, MaxX: 0, MinY: 0, MaxY: 0}},
 		{testGeomPoint, &geopb.BoundingBox{MinX: 1, MaxX: 1, MinY: 2, MaxY: 2}},
 		{testGeomLineString, &geopb.BoundingBox{MinX: 1, MaxX: 2, MinY: 1, MaxY: 2}},
+		{geom.NewLineStringFlat(geom.XY, []float64{-15, -20, -30, -40}), &geopb.BoundingBox{MinX: -30, MaxX: -15, MinY: -40, MaxY: -20}},
 		{testGeomPolygon, &geopb.BoundingBox{MinX: 1, MaxX: 2, MinY: 1, MaxY: 2}},
 		{testGeomMultiPoint, &geopb.BoundingBox{MinX: 1, MaxX: 2, MinY: 1, MaxY: 2}},
 		{testGeomMultiLineString, &geopb.BoundingBox{MinX: 1, MaxX: 4, MinY: 1, MaxY: 4}},

--- a/pkg/geo/geopb/bbox.go
+++ b/pkg/geo/geopb/bbox.go
@@ -16,9 +16,9 @@ import "math"
 func NewBoundingBox() *BoundingBox {
 	return &BoundingBox{
 		MinX: math.MaxFloat64,
-		MaxX: math.SmallestNonzeroFloat64,
+		MaxX: -math.MaxFloat64,
 		MinY: math.MaxFloat64,
-		MaxY: math.SmallestNonzeroFloat64,
+		MaxY: -math.MaxFloat64,
 	}
 }
 


### PR DESCRIPTION
Thought `math.SmallestNonzeroFloat64` was the smallest int, evidently I
was wrong. Missed a test case with 0 or negative numbers, so it seems.

Guess we're also missing a lot of test cases with negatives. We'll
probably rely on randomisation to do that going forwards...

Release note: None