### PR TITLE
kvserver: unskip a bunch of closedts tests under testrace

### DIFF
--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -44,13 +44,6 @@ import (
 func TestClosedTimestampCanServe(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	if util.RaceEnabled {
-		// Limiting how long transactions can run does not work
-		// well with race unless we're extremely lenient, which
-		// drives up the test duration.
-		t.Skip("skipping under race")
-	}
-
 	ctx := context.Background()
 	tc, db0, desc, repls := setupTestClusterForClosedTimestampTesting(ctx, t, testingTargetDuration)
 	defer tc.Stopper().Stop(ctx)
@@ -105,12 +98,6 @@ func TestClosedTimestampCanServe(t *testing.T) {
 func TestClosedTimestampCanServeThroughoutLeaseTransfer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	if util.RaceEnabled {
-		// Limiting how long transactions can run does not work
-		// well with race unless we're extremely lenient, which
-		// drives up the test duration.
-		t.Skip("skipping under race")
-	}
 	ctx := context.Background()
 	tc, db0, desc, repls := setupTestClusterForClosedTimestampTesting(ctx, t, testingTargetDuration)
 	defer tc.Stopper().Stop(ctx)
@@ -257,12 +244,6 @@ func TestClosedTimestampCanServeWithConflictingIntent(t *testing.T) {
 func TestClosedTimestampCanServeAfterSplitAndMerges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	if util.RaceEnabled {
-		// Limiting how long transactions can run does not work
-		// well with race unless we're extremely lenient, which
-		// drives up the test duration.
-		t.Skip("skipping under race")
-	}
 	ctx := context.Background()
 	tc, db0, desc, repls := setupTestClusterForClosedTimestampTesting(ctx, t, testingTargetDuration)
 	// Disable the automatic merging.
@@ -335,13 +316,6 @@ func getTableID(db *gosql.DB, dbName, tableName string) (tableID sqlbase.ID, err
 func TestClosedTimestampCantServeBasedOnMaxTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	if util.RaceEnabled {
-		// Limiting how long transactions can run does not work
-		// well with race unless we're extremely lenient, which
-		// drives up the test duration.
-		t.Skip("skipping under race")
-	}
-
 	ctx := context.Background()
 	// Set up the target duration to be very long and rely on lease transfers to
 	// drive MaxClosed.
@@ -375,13 +349,6 @@ func TestClosedTimestampCantServeBasedOnMaxTimestamp(t *testing.T) {
 func TestClosedTimestampCantServeForWritingTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	if util.RaceEnabled {
-		// Limiting how long transactions can run does not work
-		// well with race unless we're extremely lenient, which
-		// drives up the test duration.
-		t.Skip("skipping under race")
-	}
-
 	ctx := context.Background()
 	tc, db0, desc, repls := setupTestClusterForClosedTimestampTesting(ctx, t, testingTargetDuration)
 	defer tc.Stopper().Stop(ctx)
@@ -408,13 +375,6 @@ func TestClosedTimestampCantServeForWritingTransaction(t *testing.T) {
 
 func TestClosedTimestampCantServeForNonTransactionalReadRequest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
-	if util.RaceEnabled {
-		// Limiting how long transactions can run does not work
-		// well with race unless we're extremely lenient, which
-		// drives up the test duration.
-		t.Skip("skipping under race")
-	}
 
 	ctx := context.Background()
 	tc, db0, desc, repls := setupTestClusterForClosedTimestampTesting(ctx, t, testingTargetDuration)


### PR DESCRIPTION
A bunch of related tests using
setupTestClusterForClosedTimestampTesting() were skipped under testrace
because the transaction limits set for these TestClusters don't go well
with testrace and loaded machines. This was done inconsistently (not all
such tests were skipped). The relevant limits have been tweaked
in #50294, so these tests should be good now.

Release note: None