### PR TITLE
sql: add more enums test coverage

### DIFF
--- a/pkg/internal/sqlsmith/alter.go
+++ b/pkg/internal/sqlsmith/alter.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	alters               = append(altersTableExistence, altersExistingTable...)
+	alters               = append(append(altersTableExistence, altersExistingTable...), altersTypeExistence...)
 	altersTableExistence = []statementWeight{
 		{10, makeCreateTable},
 		{1, makeDropTable},
@@ -35,6 +35,9 @@ var (
 		{10, makeCreateIndex},
 		{1, makeDropIndex},
 		{5, makeRenameIndex},
+	}
+	altersTypeExistence = []statementWeight{
+		{5, makeCreateType},
 	}
 )
 
@@ -320,4 +323,9 @@ func makeRenameIndex(s *Smither) (tree.Statement, bool) {
 		Index:   tin,
 		NewName: tree.UnrestrictedName(s.name("idx")),
 	}, ok
+}
+
+func makeCreateType(s *Smither) (tree.Statement, bool) {
+	name := s.name("typ")
+	return sqlbase.RandCreateType(s.rnd, string(name), letters), true
 }

--- a/pkg/internal/sqlsmith/random.go
+++ b/pkg/internal/sqlsmith/random.go
@@ -10,6 +10,8 @@
 
 package sqlsmith
 
+import "github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+
 func (s *Smither) coin() bool {
 	return s.rnd.Intn(2) == 0
 }
@@ -67,9 +69,5 @@ const letters = "abcdefghijklmnopqrstuvwxyz"
 // randString generates a random string with a target length using characters
 // from the input alphabet string.
 func (s *Smither) randString(length int, alphabet string) string {
-	buf := make([]byte, length)
-	for i := range buf {
-		buf[i] = alphabet[s.rnd.Intn(len(alphabet))]
-	}
-	return string(buf)
+	return sqlbase.RandString(s.rnd, length, alphabet)
 }

--- a/pkg/internal/sqlsmith/setup.go
+++ b/pkg/internal/sqlsmith/setup.go
@@ -11,6 +11,7 @@
 package sqlsmith
 
 import (
+	"fmt"
 	"math/rand"
 	"sort"
 	"strings"
@@ -62,14 +63,25 @@ func randTables(r *rand.Rand) string {
 	sb.WriteString(`
 		SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;
 		SET CLUSTER SETTING sql.stats.histogram_collection.enabled = false;
+		SET experimental_enable_enums = true;
 	`)
 
+	// Create the random tables.
 	stmts := sqlbase.RandCreateTables(r, "table", r.Intn(5)+1,
 		mutations.ForeignKeyMutator,
 		mutations.StatisticsMutator,
 	)
 
 	for _, stmt := range stmts {
+		sb.WriteString(stmt.String())
+		sb.WriteString(";\n")
+	}
+
+	// Create some random types as well.
+	numTypes := r.Intn(5) + 1
+	for i := 0; i < numTypes; i++ {
+		name := fmt.Sprintf("rand_typ_%d", i)
+		stmt := sqlbase.RandCreateType(r, name, letters)
 		sb.WriteString(stmt.String())
 		sb.WriteString(";\n")
 	}

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -1545,3 +1545,33 @@ func MakeRepeatedIntRows(n int, numRows int, numCols int) EncDatumRows {
 	}
 	return rows
 }
+
+// RandString generates a random string of the desired length from the
+// input alphaget.
+func RandString(rng *rand.Rand, length int, alphabet string) string {
+	buf := make([]byte, length)
+	for i := range buf {
+		buf[i] = alphabet[rng.Intn(len(alphabet))]
+	}
+	return string(buf)
+}
+
+// RandCreateType creates a random CREATE TYPE statement. The resulting
+// type's name will be name, and if the type is an enum, the members will
+// be random strings generated from alphabet.
+func RandCreateType(rng *rand.Rand, name, alphabet string) tree.Statement {
+	numLabels := rng.Intn(6) + 1
+	labels := make([]string, numLabels)
+	for i := 0; i < numLabels; i++ {
+		labels[i] = RandString(rng, rng.Intn(6)+1, alphabet)
+	}
+	un, err := tree.NewUnresolvedObjectName(1, [3]string{name}, 0)
+	if err != nil {
+		panic(err)
+	}
+	return &tree.CreateType{
+		TypeName:   un,
+		Variety:    tree.Enum,
+		EnumLabels: labels,
+	}
+}


### PR DESCRIPTION
Fixes #49916.

This PR adds some random enum creation to the `rand-tables` SQLSmith
setup, and adds a statement hook for generation of a random `CREATE
TYPE` statement.

Release note: None