### PR TITLE
kvserver: add a timeout to getChecksum to fix a flaky test

### DIFF
--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -391,7 +391,6 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 // The upreplication here is immaterial and serves only to add realism to the test.
 func TestConsistencyQueueRecomputeStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("Skip until #48251 is fixed")
 	testutils.RunTrueAndFalse(t, "hadEstimates", testConsistencyQueueRecomputeStatsImpl)
 }
 

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -423,16 +423,21 @@ func (r *Replica) getChecksum(ctx context.Context, id uuid.UUID) (ReplicaChecksu
 		r.mu.checksums[id] = c
 	}
 	r.mu.Unlock()
-	// Wait
-	select {
-	case <-r.store.Stopper().ShouldQuiesce():
-		return ReplicaChecksum{},
-			errors.Errorf("store quiescing while waiting for compute checksum (ID = %s)", id)
-	case <-ctx.Done():
-		return ReplicaChecksum{},
-			errors.Wrapf(ctx.Err(), "while waiting for compute checksum (ID = %s)", id)
-	case <-c.notify:
+
+	// Wait for the checksum to compute or at least to start.
+	computed, err := r.checksumInitialWait(ctx, id, c.notify)
+	if err != nil {
+		return ReplicaChecksum{}, err
 	}
+	// If the checksum started, but has not completed commit
+	// to waiting the full deadline.
+	if !computed {
+		_, err = r.checksumWait(ctx, id, c.notify, nil)
+		if err != nil {
+			return ReplicaChecksum{}, err
+		}
+	}
+
 	if log.V(1) {
 		log.Infof(ctx, "waited for compute checksum for %s", timeutil.Since(now))
 	}
@@ -446,6 +451,61 @@ func (r *Replica) getChecksum(ctx context.Context, id uuid.UUID) (ReplicaChecksu
 		return ReplicaChecksum{}, errors.Errorf("no checksum found (ID = %s)", id)
 	}
 	return c, nil
+}
+
+// Waits for the checksum to be available or for the checksum to start computing.
+// If we waited for 10% of the deadline and it has not started, then it's
+// unlikely to start because this replica is most likely being restored from
+// snapshots.
+func (r *Replica) checksumInitialWait(
+	ctx context.Context, id uuid.UUID, notify chan struct{},
+) (bool, error) {
+	d, dOk := ctx.Deadline()
+	// The max wait time should be 5 seconds, so we dont end up waiting for
+	// minutes for a huge range.
+	maxInitialWait := 5 * time.Second
+	var initialWait <-chan time.Time
+	if dOk {
+		duration := time.Duration(timeutil.Until(d).Nanoseconds() / 10)
+		if duration > maxInitialWait {
+			duration = maxInitialWait
+		}
+		initialWait = time.After(duration)
+	} else {
+		initialWait = time.After(maxInitialWait)
+	}
+	return r.checksumWait(ctx, id, notify, initialWait)
+}
+
+// checksumWait waits for the checksum to be available or for the computation
+// to start  within the initialWait time. The bool return flag is used to
+// indicate if a checksum is available (true) or if the initial wait has expired
+// and the caller should wait more, since the checksum computation started.
+func (r *Replica) checksumWait(
+	ctx context.Context, id uuid.UUID, notify chan struct{}, initialWait <-chan time.Time,
+) (bool, error) {
+	// Wait
+	select {
+	case <-r.store.Stopper().ShouldQuiesce():
+		return false,
+			errors.Errorf("store quiescing while waiting for compute checksum (ID = %s)", id)
+	case <-ctx.Done():
+		return false,
+			errors.Wrapf(ctx.Err(), "while waiting for compute checksum (ID = %s)", id)
+	case <-initialWait:
+		{
+			r.mu.Lock()
+			started := r.mu.checksums[id].started
+			r.mu.Unlock()
+			if !started {
+				return false,
+					errors.Errorf("checksum computation did not start in time for (ID = %s)", id)
+			}
+			return false, nil
+		}
+	case <-notify:
+		return true, nil
+	}
 }
 
 // computeChecksumDone adds the computed checksum, sets a deadline for GCing the

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -13,6 +13,7 @@ package kvserver
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
@@ -55,4 +56,63 @@ func TestReplicaChecksumVersion(t *testing.T) {
 			require.NotNil(t, rc.Checksum)
 		}
 	})
+}
+
+func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
+	defer cancel()
+
+	tc := testContext{}
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	tc.Start(t, stopper)
+
+	id := uuid.FastMakeV4()
+	notify := make(chan struct{})
+	close(notify)
+
+	// Simple condition, the checksum is notified, but not computed.
+	tc.repl.mu.Lock()
+	tc.repl.mu.checksums[id] = ReplicaChecksum{notify: notify}
+	tc.repl.mu.Unlock()
+	rc, err := tc.repl.getChecksum(ctx, id)
+	if !testutils.IsError(err, "no checksum found") {
+		t.Fatal(err)
+	}
+	require.Nil(t, rc.Checksum)
+	// Next condition, the initial wait expires and checksum is not started,
+	// this will take 10ms.
+	id = uuid.FastMakeV4()
+	tc.repl.mu.Lock()
+	tc.repl.mu.checksums[id] = ReplicaChecksum{notify: make(chan struct{})}
+	tc.repl.mu.Unlock()
+	rc, err = tc.repl.getChecksum(ctx, id)
+	if !testutils.IsError(err, "checksum computation did not start") {
+		t.Fatal(err)
+	}
+	require.Nil(t, rc.Checksum)
+	// Next condition, initial wait expired and we found the started flag,
+	// so next step is for context deadline.
+	id = uuid.FastMakeV4()
+	tc.repl.mu.Lock()
+	tc.repl.mu.checksums[id] = ReplicaChecksum{notify: make(chan struct{}), started: true}
+	tc.repl.mu.Unlock()
+	rc, err = tc.repl.getChecksum(ctx, id)
+	if !testutils.IsError(err, "context deadline exceeded") {
+		t.Fatal(err)
+	}
+	require.Nil(t, rc.Checksum)
+
+	// Need to reset the context, since we deadlined it above.
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	// Next condition, node should quiesce.
+	tc.repl.store.Stopper().Quiesce(ctx)
+	rc, err = tc.repl.getChecksum(ctx, uuid.FastMakeV4())
+	if !testutils.IsError(err, "store quiescing") {
+		t.Fatal(err)
+	}
+	require.Nil(t, rc.Checksum)
 }


### PR DESCRIPTION
Fixes #48251

This change fixes an issue introduced in #49763. When a replica is being restored from a snapshot it does not compute checksums. This leads to a timeout on the whole check, resulting in a failure. A beter approach is to timeout the specific getChecksum request on a replica if we think it's not going to respond. The getChecksum() method will now wait a fraction of the whole deadline to see if a computeChecksum request is being computed and if one has not started in that time it will fail fast, instead of waiting the whole RPC deadline. We considered a number of alternative approaches, which either did not work or were unpalatable i.e. special casing LEARNER replicas in getChecksum, releasing getChecksum notify channel when we apply snapshots.

Release note : NONE