### PR TITLE
[DNM] sql,ccl: clean up adding "no input" stage of processors

### DIFF
--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -15,7 +15,6 @@ import (
 	roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
-	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	hlc "github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -73,27 +72,17 @@ func distBackup(
 	var p sql.PhysicalPlan
 
 	// Setup a one-stage plan with one proc per input spec.
-	stageID := p.NewStageID()
-	p.ResultRouters = make([]physicalplan.ProcessorIdx, len(backupSpecs))
-	i := 0
+	nodes := make([]roachpb.NodeID, 0, len(backupSpecs))
+	cores := make([]execinfrapb.ProcessorCoreUnion, 0, len(backupSpecs))
 	for node, spec := range backupSpecs {
-		proc := physicalplan.Processor{
-			Node: node,
-			Spec: execinfrapb.ProcessorSpec{
-				Core:    execinfrapb.ProcessorCoreUnion{BackupData: spec},
-				Output:  []execinfrapb.OutputRouterSpec{{Type: execinfrapb.OutputRouterSpec_PASS_THROUGH}},
-				StageID: stageID,
-			},
-		}
-		pIdx := p.AddProcessor(proc)
-		p.ResultRouters[i] = pIdx
-		i++
+		nodes = append(nodes, node)
+		cores = append(cores, execinfrapb.ProcessorCoreUnion{BackupData: spec})
 	}
 
 	// All of the progress information is sent through the metadata stream, so we
 	// have an empty result stream.
+	p.AddNoInputStage(nodes, cores, execinfrapb.PostProcessSpec{}, []*types.T{}, execinfrapb.Ordering{})
 	p.PlanToStreamColMap = []int{}
-	p.ResultTypes = []*types.T{}
 
 	dsp.FinalizePlan(planCtx, &p)
 

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1158,13 +1158,8 @@ func (dsp *DistSQLPlanner) planTableReaders(
 		spanPartitions = []SpanPartition{{nodeID, info.spans}}
 	}
 
-	stageID := p.NewStageID()
-
-	p.ResultRouters = make([]physicalplan.ProcessorIdx, len(spanPartitions))
-	p.Processors = make([]physicalplan.Processor, 0, len(spanPartitions))
-
-	returnMutations := info.scanVisibility == execinfra.ScanVisibilityPublicAndNotPublic
-
+	nodes := make([]roachpb.NodeID, 0, len(spanPartitions))
+	cores := make([]execinfrapb.ProcessorCoreUnion, 0, len(spanPartitions))
 	for i, sp := range spanPartitions {
 		var tr *execinfrapb.TableReaderSpec
 		if i == 0 {
@@ -1190,29 +1185,11 @@ func (dsp *DistSQLPlanner) planTableReaders(
 			p.MaxEstimatedRowCount = info.estimatedRowCount
 		}
 
-		proc := physicalplan.Processor{
-			Node: sp.Node,
-			Spec: execinfrapb.ProcessorSpec{
-				Core:    execinfrapb.ProcessorCoreUnion{TableReader: tr},
-				Output:  []execinfrapb.OutputRouterSpec{{Type: execinfrapb.OutputRouterSpec_PASS_THROUGH}},
-				StageID: stageID,
-			},
-		}
-
-		pIdx := p.AddProcessor(proc)
-		p.ResultRouters[i] = pIdx
+		nodes = append(nodes, sp.Node)
+		cores = append(cores, execinfrapb.ProcessorCoreUnion{TableReader: tr})
 	}
 
-	if len(p.ResultRouters) > 1 && len(info.reqOrdering) > 0 {
-		// Make a note of the fact that we have to maintain a certain ordering
-		// between the parallel streams.
-		//
-		// This information is taken into account by the AddProjection call below:
-		// specifically, it will make sure these columns are kept even if they are
-		// not in the projection (e.g. "SELECT v FROM kv ORDER BY k").
-		p.SetMergeOrdering(dsp.convertOrdering(info.reqOrdering, info.colsToTableOrdrinalMap))
-	}
-
+	returnMutations := info.scanVisibility == execinfra.ScanVisibilityPublicAndNotPublic
 	var typs []*types.T
 	if returnMutations {
 		typs = make([]*types.T, 0, len(info.desc.Columns)+len(info.desc.MutationColumns()))
@@ -1227,7 +1204,10 @@ func (dsp *DistSQLPlanner) planTableReaders(
 			typs = append(typs, col.Type)
 		}
 	}
-	p.SetLastStagePost(info.post, typs)
+
+	p.AddNoInputStage(
+		nodes, cores, info.post, typs, dsp.convertOrdering(info.reqOrdering, info.colsToTableOrdrinalMap),
+	)
 
 	outCols := getOutputColumnsFromColsForScan(info.cols, info.colsToTableOrdrinalMap)
 	planToStreamColMap := make([]int, len(info.cols))
@@ -2109,15 +2089,6 @@ func (dsp *DistSQLPlanner) createPlanForZigzagJoin(
 		colOffset += len(side.scan.desc.Columns)
 	}
 
-	// Figure out the node where this zigzag joiner goes.
-	//
-	// TODO(itsbilal): Add support for restricting the Zigzag joiner
-	// to a certain set of spans (similar to the InterleavedReaderJoiner)
-	// on one side. Once that's done, we can split this processor across
-	// multiple nodes here. Until then, schedule on the current node.
-	nodeID := dsp.nodeDesc.NodeID
-
-	stageID := plan.NewStageID()
 	// Set the ON condition.
 	if n.onCond != nil {
 		// Note that the ON condition refers to the *internal* columns of the
@@ -2134,24 +2105,17 @@ func (dsp *DistSQLPlanner) createPlanForZigzagJoin(
 		}
 	}
 
-	// Build the PhysicalPlan.
-	proc := physicalplan.Processor{
-		Node: nodeID,
-		Spec: execinfrapb.ProcessorSpec{
-			Core:    execinfrapb.ProcessorCoreUnion{ZigzagJoiner: &zigzagJoinerSpec},
-			Post:    post,
-			Output:  []execinfrapb.OutputRouterSpec{{Type: execinfrapb.OutputRouterSpec_PASS_THROUGH}},
-			StageID: stageID,
-		},
-	}
+	// Figure out the node where this zigzag joiner goes.
+	//
+	// TODO(itsbilal): Add support for restricting the Zigzag joiner
+	// to a certain set of spans (similar to the InterleavedReaderJoiner)
+	// on one side. Once that's done, we can split this processor across
+	// multiple nodes here. Until then, schedule on the current node.
+	nodes := []roachpb.NodeID{dsp.nodeDesc.NodeID}
+	cores := []execinfrapb.ProcessorCoreUnion{{ZigzagJoiner: &zigzagJoinerSpec}}
 
-	plan.Processors = append(plan.Processors, proc)
-
-	// Each result router correspond to each of the processors we appended.
-	plan.ResultRouters = []physicalplan.ProcessorIdx{physicalplan.ProcessorIdx(0)}
-
+	plan.AddNoInputStage(nodes, cores, post, types, execinfrapb.Ordering{})
 	plan.PlanToStreamColMap = planToStreamColMap
-	plan.ResultTypes = types
 
 	return plan, nil
 }

--- a/pkg/sql/distsql_plan_join.go
+++ b/pkg/sql/distsql_plan_join.go
@@ -163,10 +163,9 @@ func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 		ancsIdx, descIdx = 1, 0
 	}
 
-	stageID := plan.NewStageID()
-
 	// We provision a separate InterleavedReaderJoiner per node that has
 	// rows from either table.
+	cores := make([]execinfrapb.ProcessorCoreUnion, 0, len(nodes))
 	for _, nodeID := range nodes {
 		// Find the relevant span from each table for this node.
 		// Note it is possible that either set of spans can be empty
@@ -208,32 +207,19 @@ func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 			Type:              joinType,
 		}
 
-		proc := physicalplan.Processor{
-			Node: nodeID,
-			Spec: execinfrapb.ProcessorSpec{
-				Core:    execinfrapb.ProcessorCoreUnion{InterleavedReaderJoiner: irj},
-				Post:    post,
-				Output:  []execinfrapb.OutputRouterSpec{{Type: execinfrapb.OutputRouterSpec_PASS_THROUGH}},
-				StageID: stageID,
-			},
-		}
-
-		plan.Processors = append(plan.Processors, proc)
+		cores = append(cores, execinfrapb.ProcessorCoreUnion{InterleavedReaderJoiner: irj})
 	}
 
-	// Each result router correspond to each of the processors we appended.
-	plan.ResultRouters = make([]physicalplan.ProcessorIdx, len(nodes))
-	for i := 0; i < len(nodes); i++ {
-		plan.ResultRouters[i] = physicalplan.ProcessorIdx(i)
-	}
-
-	plan.PlanToStreamColMap = joinToStreamColMap
-	plan.ResultTypes, err = getTypesForPlanResult(n, joinToStreamColMap)
+	resultTypes, err := getTypesForPlanResult(n, joinToStreamColMap)
 	if err != nil {
 		return nil, false, err
 	}
+	plan.AddNoInputStage(
+		nodes, cores, post, resultTypes, dsp.convertOrdering(n.reqOrdering, joinToStreamColMap),
+	)
 
-	plan.SetMergeOrdering(dsp.convertOrdering(n.reqOrdering, plan.PlanToStreamColMap))
+	plan.PlanToStreamColMap = joinToStreamColMap
+
 	return plan, true, nil
 }
 

--- a/pkg/sql/distsql_plan_scrub_physical.go
+++ b/pkg/sql/distsql_plan_scrub_physical.go
@@ -11,8 +11,8 @@
 package sql
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
-	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -40,9 +40,8 @@ func (dsp *DistSQLPlanner) createScrubPhysicalCheck(
 		return PhysicalPlan{}, err
 	}
 
-	var p PhysicalPlan
-	stageID := p.NewStageID()
-	p.ResultRouters = make([]physicalplan.ProcessorIdx, len(spanPartitions))
+	nodes := make([]roachpb.NodeID, len(spanPartitions))
+	cores := make([]execinfrapb.ProcessorCoreUnion, len(spanPartitions))
 	for i, sp := range spanPartitions {
 		tr := &execinfrapb.TableReaderSpec{}
 		*tr = *spec
@@ -51,21 +50,12 @@ func (dsp *DistSQLPlanner) createScrubPhysicalCheck(
 			tr.Spans[j].Span = sp.Spans[j]
 		}
 
-		proc := physicalplan.Processor{
-			Node: sp.Node,
-			Spec: execinfrapb.ProcessorSpec{
-				Core:    execinfrapb.ProcessorCoreUnion{TableReader: tr},
-				Output:  []execinfrapb.OutputRouterSpec{{Type: execinfrapb.OutputRouterSpec_PASS_THROUGH}},
-				StageID: stageID,
-			},
-		}
-
-		pIdx := p.AddProcessor(proc)
-		p.ResultRouters[i] = pIdx
+		nodes[i] = sp.Node
+		cores[i] = execinfrapb.ProcessorCoreUnion{TableReader: tr}
 	}
 
-	// Set the plan's result types to be ScrubTypes.
-	p.ResultTypes = rowexec.ScrubTypes
+	var p PhysicalPlan
+	p.AddNoInputStage(nodes, cores, execinfrapb.PostProcessSpec{}, rowexec.ScrubTypes, execinfrapb.Ordering{})
 	p.PlanToStreamColMap = identityMapInPlace(make([]int, len(rowexec.ScrubTypes)))
 
 	dsp.FinalizePlan(planCtx, &p)


### PR DESCRIPTION
This commit adds a helper method `PhysicalPlan.AddNoInputStage` that
plans a new stage of the processors with the specified cores on the
corresponding nodes, and then it reuses it in several places simplifying
the code a bit.

Release note: None