### PR TITLE
gcjob: skip table if descriptor doesn't exist

### DIFF
--- a/pkg/sql/gcjob/table_garbage_collection.go
+++ b/pkg/sql/gcjob/table_garbage_collection.go
@@ -48,6 +48,15 @@ func gcTables(
 			table, err = sqlbase.GetTableDescFromID(ctx, txn, execCfg.Codec, droppedTable.ID)
 			return err
 		}); err != nil {
+			if errors.Is(err, sqlbase.ErrDescriptorNotFound) {
+				// This can happen if another GC job created for the same table got to
+				// the table first. See #50344.
+				log.Warningf(ctx, "table descriptor %d not found while attempting to GC, skipping", droppedTable.ID)
+				// Update the details payload to indicate that the table was dropped.
+				markTableGCed(ctx, droppedTable.ID, progress)
+				didGC = true
+				continue
+			}
 			return false, errors.Wrapf(err, "fetching table %d", droppedTable.ID)
 		}
 


### PR DESCRIPTION
Previously, the GC job would fail if a descriptor for a table to be
dropped did not exist. This can happen in cases where multiple GC jobs
are created for the same table, and one job deletes the table descriptor
first.

The existence of multiple GC jobs for the same table is itself
undesirable, but it's possible when some schema change job other than
the one created when dropping the table sees that the table is in the
dropped state and tries to drop the table anyway.

This PR mitigates the problem by skipping the table and marking it
internally as GC'ed if the descriptor doesn't exist.

Touches #50344.

Release note (bug fix): Fixes a bug affecting some `DROP DATABASE`
schema changes where multiple GC jobs are created, causing the GC job
for the database to fail. GC jobs will no longer fail upon failing to
find a table descriptor already deleted by a different GC job.