### PR TITLE
leaktest: add an out of band skip mechanism

### DIFF
--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -89,6 +89,9 @@ var leakDetectorDisabled uint32
 // function to be run at the end of tests to see whether any
 // goroutines leaked.
 func AfterTest(t testing.TB) func() {
+	if reason, ok := skipList[t.Name()]; ok {
+		t.Skip(reason)
+	}
 	if atomic.LoadUint32(&leakDetectorDisabled) != 0 {
 		return func() {}
 	}

--- a/pkg/util/leaktest/main.go
+++ b/pkg/util/leaktest/main.go
@@ -1,0 +1,40 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package leaktest
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+)
+
+// COCKROACH_SKIP can contain the name of a file which contains a JSON map
+// of tests to skip. The schema of the JSON map looks like this:
+//
+// {
+//    "SkippedTests": {"test1": "#issue",
+//                     "test2/subtest": "#issue"}
+// }
+
+var skipList map[string]string
+
+func init() {
+	if f, ok := os.LookupEnv("COCKROACH_SKIP"); ok {
+		if dat, err := ioutil.ReadFile(f); err == nil {
+			m := struct {
+				SkippedTests map[string]string
+			}{}
+			if err := json.Unmarshal(dat, &m); err == nil {
+				skipList = m.SkippedTests
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is a work in progress straw man for #50412.

All tests already have a mandatory call to leaktest. This is a way to
inject a skip map that's injected from something that isn't the code
into the test framework.

We could rename leaktest if we wanted, but this is just a proof of
concept.

Release note: None