### PR TITLE
colexec: add support for LShift and RShift operators

### DIFF
--- a/pkg/sql/colexec/execgen/supported_bin_cmp_ops.go
+++ b/pkg/sql/colexec/execgen/supported_bin_cmp_ops.go
@@ -26,6 +26,8 @@ var BinaryOpName = map[tree.BinaryOperator]string{
 	tree.Mod:          "Mod",
 	tree.Pow:          "Pow",
 	tree.Concat:       "Concat",
+	tree.LShift:       "LShift",
+	tree.RShift:       "RShift",
 	tree.JSONFetchVal: "JSONFetchVal",
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
@@ -297,6 +297,49 @@ NULL
 11
 1111
 
+query T
+EXPLAIN (VEC) SELECT _int << 1 FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projLShiftInt64Int64ConstOp
+    └ *colexec.colBatchScan
+
+query T
+EXPLAIN (VEC) SELECT _int >> 1 FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projRShiftInt64Int64ConstOp
+    └ *colexec.colBatchScan
+
+query I rowsort
+SELECT _int2 >> 1 FROM many_types
+----
+NULL
+61
+228
+
+query I rowsort
+SELECT _int4 >> 3 FROM many_types
+----
+NULL
+15
+57
+
+statement error shift argument out of range
+SELECT _int << 64 FROM many_types
+
+statement error shift argument out of range
+SELECT _int << -10 FROM many_types
+
+query I rowsort
+SELECT _int >> 63 FROM many_types
+----
+NULL
+0
+0
+
 statement ok
 INSERT
   INTO many_types
@@ -318,8 +361,97 @@ VALUES (
         NULL,
         '[1, "hello", {"a": ["foo", {"b": 3}]}]',
         NULL,
-        NULL
+        B'11010'
        )
+
+query T
+EXPLAIN (VEC) SELECT _varbit << 4 FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projLShiftDatumInt64ConstOp
+    └ *colexec.colBatchScan
+
+query T
+EXPLAIN (VEC) SELECT _varbit << _int2 FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projLShiftDatumInt16Op
+    └ *colexec.colBatchScan
+
+query T
+EXPLAIN (VEC) SELECT _varbit << _int4 FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projLShiftDatumInt32Op
+    └ *colexec.colBatchScan
+
+query T
+EXPLAIN (VEC) SELECT _varbit << _int FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projLShiftDatumInt64Op
+    └ *colexec.colBatchScan
+
+
+query T
+EXPLAIN (VEC) SELECT _varbit >> 4 FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projRShiftDatumInt64ConstOp
+    └ *colexec.colBatchScan
+
+query T
+EXPLAIN (VEC) SELECT _varbit >> _int2 FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projRShiftDatumInt16Op
+    └ *colexec.colBatchScan
+
+query T
+EXPLAIN (VEC) SELECT _varbit >> _int4 FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projRShiftDatumInt32Op
+    └ *colexec.colBatchScan
+
+query T
+EXPLAIN (VEC) SELECT _varbit >> _int FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projRShiftDatumInt64Op
+    └ *colexec.colBatchScan
+
+query T
+SELECT _varbit >> 1 FROM many_types
+----
+NULL
+0
+01
+01101
+
+query T
+SELECT _varbit << 1 FROM many_types
+----
+NULL
+0
+10
+10100
+
+query T
+SELECT _varbit << 3 FROM many_types
+----
+NULL
+0
+00
+10000
 
 query T
 EXPLAIN (VEC) SELECT _json -> _int2 FROM many_types

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -56,6 +56,9 @@ var (
 	ErrDivByZero       = pgerror.New(pgcode.DivisionByZero, "division by zero")
 	errSqrtOfNegNumber = pgerror.New(pgcode.InvalidArgumentForPowerFunction, "cannot take square root of a negative number")
 
+	// ErrShiftArgOutOfRange is reported when a shift argument is out of range.
+	ErrShiftArgOutOfRange = pgerror.New(pgcode.InvalidParameterValue, "shift argument out of range")
+
 	big10E6  = big.NewInt(1e6)
 	big10E10 = big.NewInt(1e10)
 )
@@ -1627,7 +1630,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				rval := MustBeDInt(right)
 				if rval < 0 || rval >= 64 {
 					telemetry.Inc(sqltelemetry.LargeLShiftArgumentCounter)
-					return nil, pgerror.Newf(pgcode.InvalidParameterValue, "shift argument out of range")
+					return nil, ErrShiftArgOutOfRange
 				}
 				return NewDInt(MustBeDInt(left) << uint(rval)), nil
 			},
@@ -1668,7 +1671,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				rval := MustBeDInt(right)
 				if rval < 0 || rval >= 64 {
 					telemetry.Inc(sqltelemetry.LargeRShiftArgumentCounter)
-					return nil, pgerror.Newf(pgcode.InvalidParameterValue, "shift argument out of range")
+					return nil, ErrShiftArgOutOfRange
 				}
 				return NewDInt(MustBeDInt(left) >> uint(rval)), nil
 			},


### PR DESCRIPTION
Previously, there was no support for LShift (<<) and RShift (>>) in the vectorized engine.
This commit implements these operators.

Fixes #49467.
Fixes #49468.

Release note (sql change): Vectorized execution engine now supports binary shift (>> and <<) operators.