### PR TITLE
sqlbase: fix rand enum generation

### DIFF
--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -1562,8 +1562,15 @@ func RandString(rng *rand.Rand, length int, alphabet string) string {
 func RandCreateType(rng *rand.Rand, name, alphabet string) tree.Statement {
 	numLabels := rng.Intn(6) + 1
 	labels := make([]string, numLabels)
-	for i := 0; i < numLabels; i++ {
-		labels[i] = RandString(rng, rng.Intn(6)+1, alphabet)
+	labelsMap := make(map[string]struct{})
+	i := 0
+	for i < numLabels {
+		s := RandString(rng, rng.Intn(6)+1, alphabet)
+		if _, ok := labelsMap[s]; !ok {
+			labels[i] = s
+			labelsMap[s] = struct{}{}
+			i++
+		}
 	}
 	un, err := tree.NewUnresolvedObjectName(1, [3]string{name}, 0)
 	if err != nil {


### PR DESCRIPTION
Fixes #50407.

Fixes the create statements to not contain duplicates.

Release note: None