### PR TITLE
ui: node name label update

### DIFF
--- a/pkg/ui/src/redux/nodes.spec.ts
+++ b/pkg/ui/src/redux/nodes.spec.ts
@@ -59,10 +59,10 @@ describe("node data selectors", function() {
 
       const addressesByID = nodeDisplayNameByIDSelector(state);
       assert.deepEqual(addressesByID, {
-        1: "addressA (n1)",
-        2: "addressB (n2)",
-        3: "addressC (n3)",
-        4: "addressD (n4)",
+        1: "(n1) addressA",
+        2: "(n2) addressB",
+        3: "(n3) addressC",
+        4: "(n4) addressD",
       });
     });
 
@@ -79,13 +79,13 @@ describe("node data selectors", function() {
 
       const addressesByID = nodeDisplayNameByIDSelector(state);
       assert.deepEqual(addressesByID, {
-        1: "addressA (n1)",
-        2: "addressB (n2)",
-        3: "addressC (n3)",
-        4: "addressD (n4)",
-        5: "addressA (n5)",
-        6: "addressC (n6)",
-        7: "addressA (n7)",
+        1: "(n1) addressA",
+        2: "(n2) addressB",
+        3: "(n3) addressC",
+        4: "(n4) addressD",
+        5: "(n5) addressA",
+        6: "(n6) addressC",
+        7: "(n7) addressA",
       });
     });
 
@@ -103,17 +103,17 @@ describe("node data selectors", function() {
       );
 
       const addressesByID = nodeDisplayNameByIDSelector(state);
-      assert.equal(addressesByID[1], "[decommissioned] addressA (n1)");
+      assert.equal(addressesByID[1], "[decommissioned] (n1) addressA");
       assert.deepEqual(addressesByID, {
-        1: "[decommissioned] addressA (n1)",
-        2: "addressB (n2)",
-        3: "[decommissioned] addressC (n3)",
-        4: "addressD (n4)",
-        5: "[decommissioned] addressA (n5)",
-        6: "addressC (n6)",
-        7: "addressA (n7)",
-        8: "addressE (n8)",
-        9: "addressF (n9)",
+        1: "[decommissioned] (n1) addressA",
+        2: "(n2) addressB",
+        3: "[decommissioned] (n3) addressC",
+        4: "(n4) addressD",
+        5: "[decommissioned] (n5) addressA",
+        6: "(n6) addressC",
+        7: "(n7) addressA",
+        8: "(n8) addressE",
+        9: "(n9) addressF",
       });
     });
 

--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -240,10 +240,10 @@ export function getDisplayName(node: INodeStatus | NoConnection, livenessStatus 
     : "";
 
   if (isNoConnection(node)) {
-    return `${decommissionedString} (n${node.from.nodeID})`;
+    return `${decommissionedString}(n${node.from.nodeID})`;
   }
   // as the only other type possible right now is INodeStatus we don't have a type guard for that
-  return `${decommissionedString}${node.desc.address.address_field} (n${node.desc.node_id})`;
+  return `${decommissionedString}(n${node.desc.node_id}) ${node.desc.address.address_field}`;
 }
 
 function isNoConnection(node: INodeStatus | NoConnection): node is NoConnection {


### PR DESCRIPTION
on chart legends, node id is cut off, so we put it before ip address as it is more important information

Resolves: #45105

Release note(ui): updated node label in chart legends to make node id visible.

before:
![Screenshot 2020-06-19 at 17 29 29](https://user-images.githubusercontent.com/12850886/85143548-8cf2b480-b252-11ea-9b69-2152f88335d8.png)

after:
![Screenshot 2020-06-19 at 17 30 38](https://user-images.githubusercontent.com/12850886/85143589-9bd96700-b252-11ea-9680-f9d28f9f7e5a.png)