### PR TITLE
colexectest: finiteChunksOp doesnt allocate anymore

### DIFF
--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -278,11 +278,12 @@ func BenchmarkDistinct(b *testing.B) {
 							func(b *testing.B) {
 								b.SetBytes(int64(8 * nBatches * coldata.BatchSize() * nCols))
 								b.ResetTimer()
+								source := newFiniteChunksSource(batch, typs, nBatches, nCols)
 								for n := 0; n < b.N; n++ {
+									source.Reset()
 									// Note that the source will be ordered on all nCols so that the
 									// number of distinct tuples doesn't vary between different
 									// distinct operator variations.
-									source := newFiniteChunksSource(batch, typs, nBatches, nCols)
 									distinct, err := distinctConstructor(testAllocator, source, distinctCols, numOrderedCols, typs)
 									if err != nil {
 										b.Fatal(err)

--- a/pkg/sql/colexec/routers_test.go
+++ b/pkg/sql/colexec/routers_test.go
@@ -300,7 +300,7 @@ func TestRouterOutputNext(t *testing.T) {
 				out := newOpTestOutput(batches, tc.expected)
 				for {
 					b := <-batchChan
-					batches.Add(b, typs)
+					batches.Add(b)
 					if b.Length() == 0 {
 						break
 					}
@@ -546,7 +546,7 @@ func TestRouterOutputRandom(t *testing.T) {
 				go func() {
 					for {
 						b := o.Next(ctx)
-						actual.Add(coldatatestutils.CopyBatch(b, typs, testColumnFactory), typs)
+						actual.Add(coldatatestutils.CopyBatch(b, typs, testColumnFactory))
 						if b.Length() == 0 {
 							wg.Done()
 							return

--- a/pkg/sql/colexec/sort_chunks_test.go
+++ b/pkg/sql/colexec/sort_chunks_test.go
@@ -288,8 +288,9 @@ func BenchmarkSortChunks(b *testing.B) {
 									}
 								}
 								b.ResetTimer()
+								source := newFiniteChunksSource(batch, typs, nBatches, matchLen)
 								for n := 0; n < b.N; n++ {
-									source := newFiniteChunksSource(batch, typs, nBatches, matchLen)
+									source.Reset()
 									sorter, err := sorterConstructor(testAllocator, source, typs, ordCols, matchLen)
 									if err != nil {
 										b.Fatal(err)

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -286,7 +286,7 @@ func TestOutboxInbox(t *testing.T) {
 				// Accumulate batches to check for correctness.
 				// Copy batch since it's not safe to reuse after calling Next.
 				if outputBatch == coldata.ZeroBatch {
-					outputBatches.Add(coldata.ZeroBatch, typs)
+					outputBatches.Add(coldata.ZeroBatch)
 				} else {
 					batchCopy := testAllocator.NewMemBatchWithSize(typs, outputBatch.Length())
 					testAllocator.PerformOperation(batchCopy.ColVecs(), func() {
@@ -300,7 +300,7 @@ func TestOutboxInbox(t *testing.T) {
 						}
 					})
 					batchCopy.SetLength(outputBatch.Length())
-					outputBatches.Add(batchCopy, typs)
+					outputBatches.Add(batchCopy)
 				}
 			}
 			if outputBatch.Length() == 0 {

--- a/pkg/sql/colflow/colrpc/outbox_test.go
+++ b/pkg/sql/colflow/colrpc/outbox_test.go
@@ -115,7 +115,7 @@ func TestOutboxDrainsMetadataSources(t *testing.T) {
 
 		b := testAllocator.NewMemBatch(typs)
 		b.SetLength(0)
-		input.Add(b, typs)
+		input.Add(b)
 
 		// Close the csChan to unblock the Recv goroutine (we don't need it for this
 		// test).


### PR DESCRIPTION
Some of the benchmarks (distinct benchmark in particular) were getting
badly skewed by the amount of work that the finiteChunkSourceOp was
doing at runtime. This commit changes that operator to be a buffered op
that does its calculation up front, leading to benchmarks that are again
just benchmarking the expected operators.

Release note: None