### PR TITLE
opt: add volatility info for Unknown to Tuple cast

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/scalar
+++ b/pkg/sql/opt/memo/testdata/logprops/scalar
@@ -348,3 +348,23 @@ project
                           ├── fd: (3)-->(1,2)
                           ├── prune: (1-3)
                           └── interesting orderings: (+3)
+
+# Regression test for #50258: cast from unknown to tuple.
+expr
+(Values
+  [
+    (Tuple [ (Cast (Null "unknown") "tuple{string}") ] "tuple{string}" )
+  ]
+  [ (Cols [ (NewColumn "a" "tuple{string}") ]) ]
+)
+----
+values
+ ├── columns: a:1(tuple{string})
+ ├── cardinality: [1 - 1]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── prune: (1)
+ └── tuple [type=tuple{string}]
+      └── cast:  [type=tuple{string}]
+           └── null [type=unknown]

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -283,6 +283,9 @@ var validCasts = []castInfo{
 	{from: types.StringFamily, to: types.EnumFamily, volatility: VolatilityImmutable},
 	{from: types.EnumFamily, to: types.EnumFamily, volatility: VolatilityImmutable},
 	{from: types.BytesFamily, to: types.EnumFamily, volatility: VolatilityImmutable},
+
+	// Casts to TupleFamily.
+	{from: types.UnknownFamily, to: types.TupleFamily, volatility: VolatilityImmutable},
 }
 
 type castsMapKey struct {

--- a/pkg/sql/sem/tree/casts_test.go
+++ b/pkg/sql/sem/tree/casts_test.go
@@ -130,3 +130,22 @@ func TestCastsVolatilityMatchesPostgres(t *testing.T) {
 		}
 	}
 }
+
+// TestCastsFromUnknown verifies that there is a cast from Unknown defined for
+// all type families.
+func TestCastsFromUnknown(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for v := range types.Family_name {
+		switch fam := types.Family(v); fam {
+		case types.UnknownFamily, types.AnyFamily:
+			// These type families are exceptions.
+
+		default:
+			cast := lookupCast(types.UnknownFamily, fam)
+			if cast == nil {
+				t.Errorf("cast from Unknown to %s does not exist", fam)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Casts from Unknown to any type are allowed as a special case, but we had no cast
defined from Unknown to Tuple (leading to an assertion error). This change adds
this missing information. I checked that now all type families define a cast
from Unknown.

Fixes #50258.

Release note (bug fix): fix recently introduced "no volatility for cast
unknown::tuple" error.