### PR TITLE
base,rpc: move transport handling to rpcContext

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -12,10 +12,7 @@ package base
 
 import (
 	"context"
-	"crypto/tls"
-	"net/http"
 	"net/url"
-	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -24,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
-	"github.com/cockroachdb/errors"
 )
 
 // Base config defaults.
@@ -145,18 +141,6 @@ var (
 		"COCKROACH_RAFT_MAX_INFLIGHT_MSGS", 128)
 )
 
-type lazyHTTPClient struct {
-	once       sync.Once
-	httpClient http.Client
-	err        error
-}
-
-type lazyCertificateManager struct {
-	once sync.Once
-	cm   *security.CertificateManager
-	err  error
-}
-
 // Config is embedded by server.Config. A base config is not meant to be used
 // directly, but embedding configs should call cfg.InitDefaults().
 type Config struct {
@@ -216,12 +200,6 @@ type Config struct {
 	// This is computed from HTTPAddr if specified otherwise Addr.
 	HTTPAdvertiseAddr string
 
-	// The certificate manager. Must be accessed through GetCertificateManager.
-	certificateManager lazyCertificateManager
-
-	// httpClient uses the client TLS config. It is initialized lazily.
-	httpClient lazyHTTPClient
-
 	// RPCHeartbeatInterval controls how often a Ping request is sent on peer
 	// connections to determine connection health and update the local view
 	// of remote clocks.
@@ -250,16 +228,6 @@ func (*Config) HistogramWindowInterval() time.Duration {
 	return DefaultHistogramWindowInterval()
 }
 
-func wrapError(err error) error {
-	if !errors.HasType(err, (*security.Error)(nil)) {
-		return &security.Error{
-			Message: "problem using security settings",
-			Err:     err,
-		}
-	}
-	return err
-}
-
 // InitDefaults sets up the default values for a config.
 // This is also used in tests to reset global objects.
 func (cfg *Config) InitDefaults() {
@@ -274,7 +242,6 @@ func (cfg *Config) InitDefaults() {
 	cfg.SQLAddr = defaultSQLAddr
 	cfg.SQLAdvertiseAddr = cfg.SQLAddr
 	cfg.SSLCertsDir = DefaultCertsDirectory
-	cfg.certificateManager = lazyCertificateManager{}
 	cfg.RPCHeartbeatInterval = defaultRPCHeartbeatInterval
 	cfg.ClusterName = ""
 	cfg.DisableClusterNameVerification = false
@@ -296,206 +263,6 @@ func (cfg *Config) AdminURL() *url.URL {
 		Scheme: cfg.HTTPRequestScheme(),
 		Host:   cfg.HTTPAdvertiseAddr,
 	}
-}
-
-// getClientCertPaths returns the paths to the client cert and key.
-func (cfg *Config) getClientCertPaths(user string) (string, string, error) {
-	cm, err := cfg.GetCertificateManager()
-	if err != nil {
-		return "", "", err
-	}
-	return cm.GetClientCertPaths(user)
-}
-
-// getCACertPath returns the path to the CA certificate.
-func (cfg *Config) getCACertPath() (string, error) {
-	cm, err := cfg.GetCertificateManager()
-	if err != nil {
-		return "", err
-	}
-	return cm.GetCACertPath()
-}
-
-// LoadSecurityOptions extends a url.Values with SSL settings suitable for
-// the given server config. It returns true if and only if the URL
-// already contained SSL config options.
-func (cfg *Config) LoadSecurityOptions(options url.Values, username string) error {
-	if cfg.Insecure {
-		options.Set("sslmode", "disable")
-		options.Del("sslrootcert")
-		options.Del("sslcert")
-		options.Del("sslkey")
-	} else {
-		sslMode := options.Get("sslmode")
-		if sslMode == "" || sslMode == "disable" {
-			options.Set("sslmode", "verify-full")
-		}
-
-		if sslMode != "require" {
-			// verify-ca and verify-full need a CA certificate.
-			if options.Get("sslrootcert") == "" {
-				// Fetch CA cert. This is required.
-				caCertPath, err := cfg.getCACertPath()
-				if err != nil {
-					return wrapError(err)
-				}
-				options.Set("sslrootcert", caCertPath)
-			}
-		} else {
-			// require does not check the CA.
-			options.Del("sslrootcert")
-		}
-
-		// Fetch certs, but don't fail, we may be using a password.
-		certPath, keyPath, err := cfg.getClientCertPaths(username)
-		if err == nil {
-			if options.Get("sslcert") == "" {
-				options.Set("sslcert", certPath)
-			}
-			if options.Get("sslkey") == "" {
-				options.Set("sslkey", keyPath)
-			}
-		}
-	}
-	return nil
-}
-
-// PGURL constructs a URL for the postgres endpoint, given a server
-// config. There is no default database set.
-func (cfg *Config) PGURL(user *url.Userinfo) (*url.URL, error) {
-	options := url.Values{}
-	if err := cfg.LoadSecurityOptions(options, user.Username()); err != nil {
-		return nil, err
-	}
-	return &url.URL{
-		Scheme:   "postgresql",
-		User:     user,
-		Host:     cfg.SQLAdvertiseAddr,
-		RawQuery: options.Encode(),
-	}, nil
-}
-
-// GetCertificateManager returns the certificate manager, initializing it
-// on the first call.
-func (cfg *Config) GetCertificateManager() (*security.CertificateManager, error) {
-	cfg.certificateManager.once.Do(func() {
-		cfg.certificateManager.cm, cfg.certificateManager.err =
-			security.NewCertificateManager(cfg.SSLCertsDir)
-		if cfg.certificateManager.err == nil && !cfg.Insecure {
-			infos, err := cfg.certificateManager.cm.ListCertificates()
-			if err != nil {
-				cfg.certificateManager.err = err
-			} else if len(infos) == 0 {
-				// If we know there should be certificates (we're in secure mode)
-				// but there aren't any, this likely indicates that the certs dir
-				// was misconfigured.
-				cfg.certificateManager.err = errors.New("no certificates found; does certs dir exist?")
-			}
-		}
-	})
-	return cfg.certificateManager.cm, cfg.certificateManager.err
-}
-
-// GetClientTLSConfig returns the client TLS config, initializing it if needed.
-// If Insecure is true, return a nil config, otherwise ask the certificate
-// manager for a TLS config using certs for the config.User.
-// This TLSConfig might **NOT** be suitable to talk to the Admin UI, use GetUIClientTLSConfig instead.
-func (cfg *Config) GetClientTLSConfig() (*tls.Config, error) {
-	// Early out.
-	if cfg.Insecure {
-		return nil, nil
-	}
-
-	cm, err := cfg.GetCertificateManager()
-	if err != nil {
-		return nil, wrapError(err)
-	}
-
-	tlsCfg, err := cm.GetClientTLSConfig(cfg.User)
-	if err != nil {
-		return nil, wrapError(err)
-	}
-	return tlsCfg, nil
-}
-
-// getUIClientTLSConfig returns the client TLS config for Admin UI clients, initializing it if needed.
-// If Insecure is true, return a nil config, otherwise ask the certificate
-// manager for a TLS config configured to talk to the Admin UI.
-// This TLSConfig is **NOT** suitable to talk to the GRPC or SQL servers, use GetClientTLSConfig instead.
-func (cfg *Config) getUIClientTLSConfig() (*tls.Config, error) {
-	// Early out.
-	if cfg.Insecure {
-		return nil, nil
-	}
-
-	cm, err := cfg.GetCertificateManager()
-	if err != nil {
-		return nil, wrapError(err)
-	}
-
-	tlsCfg, err := cm.GetUIClientTLSConfig()
-	if err != nil {
-		return nil, wrapError(err)
-	}
-	return tlsCfg, nil
-}
-
-// GetServerTLSConfig returns the server TLS config, initializing it if needed.
-// If Insecure is true, return a nil config, otherwise ask the certificate
-// manager for a server TLS config.
-func (cfg *Config) GetServerTLSConfig() (*tls.Config, error) {
-	// Early out.
-	if cfg.Insecure {
-		return nil, nil
-	}
-
-	cm, err := cfg.GetCertificateManager()
-	if err != nil {
-		return nil, wrapError(err)
-	}
-
-	tlsCfg, err := cm.GetServerTLSConfig()
-	if err != nil {
-		return nil, wrapError(err)
-	}
-	return tlsCfg, nil
-}
-
-// GetUIServerTLSConfig returns the server TLS config for the Admin UI, initializing it if needed.
-// If Insecure is true, return a nil config, otherwise ask the certificate
-// manager for a server UI TLS config.
-//
-// TODO(peter): This method is only used by `server.NewServer` and
-// `Server.Start`. Move it.
-func (cfg *Config) GetUIServerTLSConfig() (*tls.Config, error) {
-	// Early out.
-	if cfg.Insecure || cfg.DisableTLSForHTTP {
-		return nil, nil
-	}
-
-	cm, err := cfg.GetCertificateManager()
-	if err != nil {
-		return nil, wrapError(err)
-	}
-
-	tlsCfg, err := cm.GetUIServerTLSConfig()
-	if err != nil {
-		return nil, wrapError(err)
-	}
-	return tlsCfg, nil
-}
-
-// GetHTTPClient returns the http client, initializing it
-// if needed. It uses the client TLS config.
-func (cfg *Config) GetHTTPClient() (http.Client, error) {
-	cfg.httpClient.once.Do(func() {
-		cfg.httpClient.httpClient.Timeout = 10 * time.Second
-		var transport http.Transport
-		cfg.httpClient.httpClient.Transport = &transport
-		transport.TLSClientConfig, cfg.httpClient.err = cfg.getUIClientTLSConfig()
-	})
-
-	return cfg.httpClient.httpClient, cfg.httpClient.err
 }
 
 // RaftConfig holds raft tuning parameters.

--- a/pkg/cli/client_url.go
+++ b/pkg/cli/client_url.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
@@ -350,7 +351,10 @@ func (cliCtx *cliContext) makeClientConnURL() (url.URL, error) {
 		if userName == "" {
 			userName = security.RootUser
 		}
-		if err := cliCtx.LoadSecurityOptions(opts, userName); err != nil {
+		sCtx := rpc.MakeSecurityContext(cliCtx.Config)
+		if err := sCtx.LoadSecurityOptions(
+			opts, userName,
+		); err != nil {
 			return url.URL{}, err
 		}
 	}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -637,7 +637,8 @@ func runStart(cmd *cobra.Command, args []string, disableReplication bool) error 
 			// (Re-)compute the client connection URL. We cannot do this
 			// earlier (e.g. above, in the runStart function) because
 			// at this time the address and port have not been resolved yet.
-			pgURL, err := serverCfg.PGURL(url.User(security.RootUser))
+			sCtx := rpc.MakeSecurityContext(serverCfg.Config)
+			pgURL, err := sCtx.PGURL(url.User(security.RootUser))
 			if err != nil {
 				log.Errorf(ctx, "failed computing the URL: %v", err)
 				return
@@ -809,7 +810,8 @@ If problems persist, please see %s.`
 			// (Re-)compute the client connection URL. We cannot do this
 			// earlier (e.g. above, in the runStart function) because
 			// at this time the address and port have not been resolved yet.
-			pgURL, err := serverCfg.PGURL(url.User(security.RootUser))
+			sCtx := rpc.MakeSecurityContext(serverCfg.Config)
+			pgURL, err := sCtx.PGURL(url.User(security.RootUser))
 			if err != nil {
 				log.Errorf(ctx, "failed computing the URL: %v", err)
 				return err

--- a/pkg/gossip/simulation/network.go
+++ b/pkg/gossip/simulation/network.go
@@ -79,7 +79,7 @@ func NewNetwork(
 		Settings:   cluster.MakeTestingClusterSettings(),
 	})
 	var err error
-	n.tlsConfig, err = n.RPCContext.Config.GetServerTLSConfig()
+	n.tlsConfig, err = n.RPCContext.GetServerTLSConfig()
 	if err != nil {
 		log.Fatalf(context.TODO(), "%v", err)
 	}

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -77,7 +77,7 @@ func (ctx *Context) AddTestingDialOpts(opts ...grpc.DialOption) {
 }
 
 func newTestServer(t testing.TB, ctx *Context, extraOpts ...grpc.ServerOption) *grpc.Server {
-	tlsConfig, err := ctx.Config.GetServerTLSConfig()
+	tlsConfig, err := ctx.GetServerTLSConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -481,7 +481,7 @@ func TestHeartbeatHealthTransport(t *testing.T) {
 	const serverNodeID = 1
 	serverCtx.NodeID.Set(context.Background(), serverNodeID)
 	// newTestServer with a custom listener.
-	tlsConfig, err := serverCtx.Config.GetServerTLSConfig()
+	tlsConfig, err := serverCtx.GetServerTLSConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1026,7 +1026,7 @@ func grpcRunKeepaliveTestCase(testCtx context.Context, c grpcKeepaliveTestCase) 
 	serverCtx := newTestContext(clusterID, clock, stopper)
 	const serverNodeID = 1
 	serverCtx.NodeID.Set(context.Background(), serverNodeID)
-	tlsConfig, err := serverCtx.Config.GetServerTLSConfig()
+	tlsConfig, err := serverCtx.GetServerTLSConfig()
 	if err != nil {
 		return err
 	}

--- a/pkg/rpc/pg.go
+++ b/pkg/rpc/pg.go
@@ -1,0 +1,85 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rpc
+
+import (
+	"net/url"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+)
+
+// LoadSecurityOptions extends a url.Values with SSL settings suitable for
+// the given server config.
+func (ctx *SecurityContext) LoadSecurityOptions(options url.Values, username string) error {
+	if ctx.config.Insecure {
+		options.Set("sslmode", "disable")
+		options.Del("sslrootcert")
+		options.Del("sslcert")
+		options.Del("sslkey")
+	} else {
+		sslMode := options.Get("sslmode")
+		if sslMode == "" || sslMode == "disable" {
+			options.Set("sslmode", "verify-full")
+		}
+
+		if sslMode != "require" {
+			// verify-ca and verify-full need a CA certificate.
+			if options.Get("sslrootcert") == "" {
+				// Fetch CA cert. This is required to exist, so try to load it. We use
+				// the fact that GetCertificateManager checks that "some certs" exist
+				// and want to return "its error" here since we test it in
+				// test_url_db_override.tcl.
+				if _, err := ctx.GetCertificateManager(); err != nil {
+					return wrapError(err)
+				}
+				options.Set("sslrootcert", ctx.CACertPath())
+			}
+		} else {
+			// require does not check the CA.
+			options.Del("sslrootcert")
+		}
+
+		// Fetch certs, but don't fail if they're absent, we may be using a
+		// password.
+		certPath, keyPath := ctx.getClientCertPaths(username)
+		var missing bool // certs found on file system?
+		loader := security.GetAssetLoader()
+		for _, f := range []string{certPath, keyPath} {
+			if _, err := loader.Stat(f); err != nil {
+				missing = true
+			}
+		}
+		if !missing {
+			if options.Get("sslcert") == "" {
+				options.Set("sslcert", certPath)
+			}
+			if options.Get("sslkey") == "" {
+				options.Set("sslkey", keyPath)
+			}
+		}
+	}
+	return nil
+}
+
+// PGURL constructs a URL for the postgres endpoint, given a server
+// config. There is no default database set.
+func (ctx *SecurityContext) PGURL(user *url.Userinfo) (*url.URL, error) {
+	options := url.Values{}
+	if err := ctx.LoadSecurityOptions(options, user.Username()); err != nil {
+		return nil, err
+	}
+	return &url.URL{
+		Scheme:   "postgresql",
+		User:     user,
+		Host:     ctx.config.SQLAdvertiseAddr,
+		RawQuery: options.Encode(),
+	}, nil
+}

--- a/pkg/rpc/tls.go
+++ b/pkg/rpc/tls.go
@@ -1,0 +1,308 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rpc
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+)
+
+type lazyHTTPClient struct {
+	sync.Once
+	httpClient http.Client
+	err        error
+}
+
+type lazyCertificateManager struct {
+	sync.Once
+	cm  *security.CertificateManager
+	err error
+}
+
+func wrapError(err error) error {
+	if !errors.HasType(err, (*security.Error)(nil)) {
+		return &security.Error{
+			Message: "problem using security settings",
+			Err:     err,
+		}
+	}
+	return err
+}
+
+// SecurityContext is a wrapper providing transport security helpers such as
+// the certificate manager.
+type SecurityContext struct {
+	security.CertsLocator
+	config *base.Config
+	lazy   struct {
+		// The certificate manager. Must be accessed through GetCertificateManager.
+		certificateManager lazyCertificateManager
+		// httpClient uses the client TLS config. It is initialized lazily.
+		httpClient lazyHTTPClient
+	}
+}
+
+// MakeSecurityContext makes a SecurityContext.
+//
+// TODO(tbg): don't take a whole Config. This can be trimmed down significantly.
+func MakeSecurityContext(cfg *base.Config) SecurityContext {
+	return SecurityContext{
+		CertsLocator: security.MakeCertsLocator(cfg.SSLCertsDir),
+		config:       cfg,
+	}
+}
+
+// GetCertificateManager returns the certificate manager, initializing it
+// on the first call. If certificates should be used but none are found,
+// fails eagerly.
+func (ctx *SecurityContext) GetCertificateManager() (*security.CertificateManager, error) {
+	ctx.lazy.certificateManager.Do(func() {
+		ctx.lazy.certificateManager.cm, ctx.lazy.certificateManager.err =
+			security.NewCertificateManager(ctx.config.SSLCertsDir)
+		if ctx.lazy.certificateManager.err == nil && !ctx.config.Insecure {
+			infos, err := ctx.lazy.certificateManager.cm.ListCertificates()
+			if err != nil {
+				ctx.lazy.certificateManager.err = err
+			} else if len(infos) == 0 {
+				// If we know there should be certificates (we're in secure mode)
+				// but there aren't any, this likely indicates that the certs dir
+				// was misconfigured.
+				ctx.lazy.certificateManager.err = errors.New("no certificates found; does certs dir exist?")
+			}
+		}
+	})
+	return ctx.lazy.certificateManager.cm, ctx.lazy.certificateManager.err
+}
+
+// GetServerTLSConfig returns the server TLS config, initializing it if needed.
+// If Insecure is true, return a nil config, otherwise ask the certificate
+// manager for a server TLS config.
+func (ctx *SecurityContext) GetServerTLSConfig() (*tls.Config, error) {
+	// Early out.
+	if ctx.config.Insecure {
+		return nil, nil
+	}
+
+	cm, err := ctx.GetCertificateManager()
+	if err != nil {
+		return nil, wrapError(err)
+	}
+
+	tlsCfg, err := cm.GetServerTLSConfig()
+	if err != nil {
+		return nil, wrapError(err)
+	}
+	return tlsCfg, nil
+}
+
+// GetClientTLSConfig returns the client TLS config, initializing it if needed.
+// If Insecure is true, return a nil config, otherwise ask the certificate
+// manager for a TLS config using certs for the config.User.
+// This TLSConfig might **NOT** be suitable to talk to the Admin UI, use GetUIClientTLSConfig instead.
+func (ctx *SecurityContext) GetClientTLSConfig() (*tls.Config, error) {
+	// Early out.
+	if ctx.config.Insecure {
+		return nil, nil
+	}
+
+	cm, err := ctx.GetCertificateManager()
+	if err != nil {
+		return nil, wrapError(err)
+	}
+
+	tlsCfg, err := cm.GetClientTLSConfig(ctx.config.User)
+	if err != nil {
+		return nil, wrapError(err)
+	}
+	return tlsCfg, nil
+}
+
+// getUIClientTLSConfig returns the client TLS config for Admin UI clients, initializing it if needed.
+// If Insecure is true, return a nil config, otherwise ask the certificate
+// manager for a TLS config configured to talk to the Admin UI.
+// This TLSConfig is **NOT** suitable to talk to the GRPC or SQL servers, use GetClientTLSConfig instead.
+func (ctx *SecurityContext) getUIClientTLSConfig() (*tls.Config, error) {
+	// Early out.
+	if ctx.config.Insecure {
+		return nil, nil
+	}
+
+	cm, err := ctx.GetCertificateManager()
+	if err != nil {
+		return nil, wrapError(err)
+	}
+
+	tlsCfg, err := cm.GetUIClientTLSConfig()
+	if err != nil {
+		return nil, wrapError(err)
+	}
+	return tlsCfg, nil
+}
+
+// GetUIServerTLSConfig returns the server TLS config for the Admin UI, initializing it if needed.
+// If Insecure is true, return a nil config, otherwise ask the certificate
+// manager for a server UI TLS config.
+//
+// TODO(peter): This method is only used by `server.NewServer` and
+// `Server.Start`. Move it.
+func (ctx *SecurityContext) GetUIServerTLSConfig() (*tls.Config, error) {
+	// Early out.
+	if ctx.config.Insecure || ctx.config.DisableTLSForHTTP {
+		return nil, nil
+	}
+
+	cm, err := ctx.GetCertificateManager()
+	if err != nil {
+		return nil, wrapError(err)
+	}
+
+	tlsCfg, err := cm.GetUIServerTLSConfig()
+	if err != nil {
+		return nil, wrapError(err)
+	}
+	return tlsCfg, nil
+}
+
+// GetHTTPClient returns the http client, initializing it
+// if needed. It uses the client TLS config.
+func (ctx *SecurityContext) GetHTTPClient() (http.Client, error) {
+	ctx.lazy.httpClient.Do(func() {
+		ctx.lazy.httpClient.httpClient.Timeout = 10 * time.Second
+		var transport http.Transport
+		ctx.lazy.httpClient.httpClient.Transport = &transport
+		transport.TLSClientConfig, ctx.lazy.httpClient.err = ctx.getUIClientTLSConfig()
+	})
+
+	return ctx.lazy.httpClient.httpClient, ctx.lazy.httpClient.err
+}
+
+// getClientCertPaths returns the paths to the client cert and key. This uses
+// the node certs for the NodeUser, and the actual client certs for all others.
+func (ctx *SecurityContext) getClientCertPaths(user string) (string, string) {
+	if user == security.NodeUser {
+		return ctx.NodeCertPath(), ctx.NodeKeyPath()
+	}
+	return ctx.ClientCertPath(user), ctx.ClientKeyPath(user)
+}
+
+// CheckCertificateAddrs validates the addresses inside the configured
+// certificates to be compatible with the configured listen and
+// advertise addresses. This is an advisory function (to inform/educate
+// the user) and not a requirement for security.
+// This must also be called after ValidateAddrs() and after
+// the certificate manager was initialized.
+func (ctx *SecurityContext) CheckCertificateAddrs(cctx context.Context) {
+	if ctx.config.Insecure {
+		return
+	}
+
+	// By now the certificate manager must be initialized.
+	cm, _ := ctx.GetCertificateManager()
+
+	// Verify that the listen and advertise addresses are compatible
+	// with the provided certificate.
+	certInfo := cm.NodeCert()
+	if certInfo.Error != nil {
+		log.Shoutf(cctx, log.Severity_ERROR,
+			"invalid node certificate: %v", certInfo.Error)
+	} else {
+		cert := certInfo.ParsedCertificates[0]
+		addrInfo := certAddrs(cert)
+
+		// Log the certificate details in any case. This will aid during troubleshooting.
+		log.Infof(cctx, "server certificate addresses: %s", addrInfo)
+
+		var msg bytes.Buffer
+		// Verify the compatibility. This requires that ValidateAddrs() has
+		// been called already.
+		host, _, err := net.SplitHostPort(ctx.config.AdvertiseAddr)
+		if err != nil {
+			panic("programming error: call ValidateAddrs() first")
+		}
+		if err := cert.VerifyHostname(host); err != nil {
+			fmt.Fprintf(&msg, "advertise address %q not in node certificate (%s)\n", host, addrInfo)
+		}
+		host, _, err = net.SplitHostPort(ctx.config.SQLAdvertiseAddr)
+		if err != nil {
+			panic("programming error: call ValidateAddrs() first")
+		}
+		if err := cert.VerifyHostname(host); err != nil {
+			fmt.Fprintf(&msg, "advertise SQL address %q not in node certificate (%s)\n", host, addrInfo)
+		}
+		if msg.Len() > 0 {
+			log.Shoutf(cctx, log.Severity_WARNING,
+				"%s"+
+					"Secure client connections are likely to fail.\n"+
+					"Consider extending the node certificate or tweak --listen-addr/--advertise-addr/--sql-addr/--advertise-sql-addr.",
+				msg.String())
+		}
+	}
+
+	// Verify that the http listen and advertise addresses are
+	// compatible with the provided certificate.
+	certInfo = cm.UICert()
+	if certInfo == nil {
+		// A nil UI cert means use the node cert instead;
+		// see details in (*CertificateManager) getEmbeddedUIServerTLSConfig()
+		// and (*CertificateManager) getUICertLocked().
+		certInfo = cm.NodeCert()
+	}
+	if certInfo.Error != nil {
+		log.Shoutf(cctx, log.Severity_ERROR,
+			"invalid UI certificate: %v", certInfo.Error)
+	} else {
+		cert := certInfo.ParsedCertificates[0]
+		addrInfo := certAddrs(cert)
+
+		// Log the certificate details in any case. This will aid during
+		// troubleshooting.
+		log.Infof(cctx, "web UI certificate addresses: %s", addrInfo)
+	}
+}
+
+// HTTPRequestScheme returns "http" or "https" based on the value of
+// Insecure and DisableTLSForHTTP.
+func (ctx *SecurityContext) HTTPRequestScheme() string {
+	return ctx.config.HTTPRequestScheme()
+}
+
+// certAddrs formats the list of addresses included in a certificate for
+// printing in an error message.
+func certAddrs(cert *x509.Certificate) string {
+	// If an IP address was specified as listen/adv address, the
+	// hostname validation will only use the IPAddresses field. So this
+	// needs to be printed in all cases.
+	addrs := make([]string, len(cert.IPAddresses))
+	for i, ip := range cert.IPAddresses {
+		addrs[i] = ip.String()
+	}
+	// For names, the hostname validation will use DNSNames if
+	// the Subject Alt Name is present in the cert, otherwise
+	// it will use the common name. We can't parse the
+	// extensions here so we print both.
+	return fmt.Sprintf("IP=%s; DNS=%s; CN=%s",
+		strings.Join(addrs, ","),
+		strings.Join(cert.DNSNames, ","),
+		cert.Subject.CommonName)
+}

--- a/pkg/security/certificate_loader.go
+++ b/pkg/security/certificate_loader.go
@@ -55,6 +55,11 @@ var defaultAssetLoader = AssetLoader{
 // assetLoaderImpl is used to list/read/stat security assets.
 var assetLoaderImpl = defaultAssetLoader
 
+// GetAssetLoader returns the active asset loader.
+func GetAssetLoader() AssetLoader {
+	return assetLoaderImpl
+}
+
 // SetAssetLoader overrides the asset loader with the passed-in one.
 func SetAssetLoader(al AssetLoader) {
 	assetLoaderImpl = al

--- a/pkg/security/certs_rotation_test.go
+++ b/pkg/security/certs_rotation_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -98,7 +99,8 @@ func TestRotateCerts(t *testing.T) {
 	// Test client with the same certs.
 	clientContext := testutils.NewNodeTestBaseContext()
 	clientContext.SSLCertsDir = certsDir
-	firstClient, err := clientContext.GetHTTPClient()
+	firstSCtx := rpc.MakeSecurityContext(clientContext)
+	firstClient, err := firstSCtx.GetHTTPClient()
 	if err != nil {
 		t.Fatalf("could not create http client: %v", err)
 	}
@@ -128,7 +130,9 @@ func TestRotateCerts(t *testing.T) {
 	// Fails on crypto errors.
 	clientContext = testutils.NewNodeTestBaseContext()
 	clientContext.SSLCertsDir = certsDir
-	secondClient, err := clientContext.GetHTTPClient()
+
+	secondSCtx := rpc.MakeSecurityContext(clientContext)
+	secondClient, err := secondSCtx.GetHTTPClient()
 	if err != nil {
 		t.Fatalf("could not create http client: %v", err)
 	}
@@ -196,7 +200,8 @@ func TestRotateCerts(t *testing.T) {
 	// This is HTTP and succeeds because we do not ask for or verify client certificates.
 	clientContext = testutils.NewNodeTestBaseContext()
 	clientContext.SSLCertsDir = certsDir
-	thirdClient, err := clientContext.GetHTTPClient()
+	thirdSCtx := rpc.MakeSecurityContext(clientContext)
+	thirdClient, err := thirdSCtx.GetHTTPClient()
 	if err != nil {
 		t.Fatalf("could not create http client: %v", err)
 	}

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -381,7 +382,8 @@ func TestUseCerts(t *testing.T) {
 	// Insecure mode.
 	clientContext := testutils.NewNodeTestBaseContext()
 	clientContext.Insecure = true
-	httpClient, err := clientContext.GetHTTPClient()
+	sCtx := rpc.MakeSecurityContext(clientContext)
+	httpClient, err := sCtx.GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -399,7 +401,10 @@ func TestUseCerts(t *testing.T) {
 	// New client. With certs this time.
 	clientContext = testutils.NewNodeTestBaseContext()
 	clientContext.SSLCertsDir = certsDir
-	httpClient, err = clientContext.GetHTTPClient()
+	{
+		secondSCtx := rpc.MakeSecurityContext(clientContext)
+		httpClient, err = secondSCtx.GetHTTPClient()
+	}
 	if err != nil {
 		t.Fatalf("Expected success, got %v", err)
 	}
@@ -467,7 +472,8 @@ func TestUseSplitCACerts(t *testing.T) {
 	// Insecure mode.
 	clientContext := testutils.NewNodeTestBaseContext()
 	clientContext.Insecure = true
-	httpClient, err := clientContext.GetHTTPClient()
+	sCtx := rpc.MakeSecurityContext(clientContext)
+	httpClient, err := sCtx.GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -485,7 +491,10 @@ func TestUseSplitCACerts(t *testing.T) {
 	// New client. With certs this time.
 	clientContext = testutils.NewNodeTestBaseContext()
 	clientContext.SSLCertsDir = certsDir
-	httpClient, err = clientContext.GetHTTPClient()
+	{
+		secondSCtx := rpc.MakeSecurityContext(clientContext)
+		httpClient, err = secondSCtx.GetHTTPClient()
+	}
 	if err != nil {
 		t.Fatalf("Expected success, got %v", err)
 	}
@@ -587,7 +596,8 @@ func TestUseWrongSplitCACerts(t *testing.T) {
 	// Insecure mode.
 	clientContext := testutils.NewNodeTestBaseContext()
 	clientContext.Insecure = true
-	httpClient, err := clientContext.GetHTTPClient()
+	sCtx := rpc.MakeSecurityContext(clientContext)
+	httpClient, err := sCtx.GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -605,7 +615,10 @@ func TestUseWrongSplitCACerts(t *testing.T) {
 	// New client with certs, but the UI CA is gone, we have no way to verify the Admin UI cert.
 	clientContext = testutils.NewNodeTestBaseContext()
 	clientContext.SSLCertsDir = certsDir
-	httpClient, err = clientContext.GetHTTPClient()
+	{
+		secondCtx := rpc.MakeSecurityContext(clientContext)
+		httpClient, err = secondCtx.GetHTTPClient()
+	}
 	if err != nil {
 		t.Fatalf("Expected success, got %v", err)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -251,27 +251,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		stopper.AddCloser(tr)
 	}
 
-	// Attempt to load TLS configs right away, failures are permanent.
-	if !cfg.Insecure {
-		// TODO(peter): Call methods on CertificateManager directly. Need to call
-		// base.wrapError or similar on the resulting error.
-		if _, err := cfg.GetServerTLSConfig(); err != nil {
-			return nil, err
-		}
-		if _, err := cfg.GetUIServerTLSConfig(); err != nil {
-			return nil, err
-		}
-		if _, err := cfg.GetClientTLSConfig(); err != nil {
-			return nil, err
-		}
-		cm, err := cfg.GetCertificateManager()
-		if err != nil {
-			return nil, err
-		}
-		cm.RegisterSignalHandler(stopper)
-		registry.AddMetricStruct(cm.Metrics())
-	}
-
 	// Add a dynamic log tag value for the node ID.
 	//
 	// We need to pass an ambient context to the various server components, but we
@@ -324,6 +303,27 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		}
 	}
 	registry.AddMetricStruct(rpcContext.Metrics())
+
+	// Attempt to load TLS configs right away, failures are permanent.
+	if !cfg.Insecure {
+		// TODO(peter): Call methods on CertificateManager directly. Need to call
+		// base.wrapError or similar on the resulting error.
+		if _, err := cfg.GetServerTLSConfig(); err != nil {
+			return nil, err
+		}
+		if _, err := cfg.GetUIServerTLSConfig(); err != nil {
+			return nil, err
+		}
+		if _, err := cfg.GetClientTLSConfig(); err != nil {
+			return nil, err
+		}
+		cm, err := cfg.GetCertificateManager()
+		if err != nil {
+			return nil, err
+		}
+		cm.RegisterSignalHandler(stopper)
+		registry.AddMetricStruct(cm.Metrics())
+	}
 
 	grpcServer := newGRPCServer(rpcContext)
 

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -353,7 +353,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*sqlServer, error) {
 
 	nodeInfo := sql.NodeInfo{
 		AdminURL:  cfg.AdminURL,
-		PGURL:     cfg.PGURL,
+		PGURL:     cfg.rpcContext.PGURL,
 		ClusterID: cfg.rpcContext.ClusterID.Get,
 		NodeID:    cfg.nodeIDContainer,
 	}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -559,7 +559,7 @@ func (s *statusServer) Certificates(
 		return status.Certificates(ctx, req)
 	}
 
-	cm, err := s.cfg.GetCertificateManager()
+	cm, err := s.rpcCtx.GetCertificateManager()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -804,7 +804,7 @@ func (ts *TestServer) AdminURL() string {
 
 // GetHTTPClient implements TestServerInterface.
 func (ts *TestServer) GetHTTPClient() (http.Client, error) {
-	return ts.Cfg.GetHTTPClient()
+	return ts.Server.rpcContext.GetHTTPClient()
 }
 
 const authenticatedUserName = "authentic_user"
@@ -865,7 +865,7 @@ func (ts *TestServer) getAuthenticatedHTTPClientAndCookie(
 			}
 			cookieJar.SetCookies(url, []*http.Cookie{cookie})
 			// Create an httpClient and attach the cookie jar to the client.
-			authClient.httpClient, err = ts.Cfg.GetHTTPClient()
+			authClient.httpClient, err = ts.rpcContext.GetHTTPClient()
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -722,7 +722,7 @@ func (s *Server) maybeUpgradeToSecureConn(
 	// connection to use TLS/SSL.
 
 	// Do we have a TLS configuration?
-	tlsConfig, serverErr := s.cfg.GetServerTLSConfig()
+	tlsConfig, serverErr := s.execCfg.RPCContext.GetServerTLSConfig()
 	if serverErr != nil {
 		return
 	}


### PR DESCRIPTION
This commit moves the TLS-related functionaliy that has piled up on
`*base.Config` onto a dedicated helper that lives in the `rpc` package.

This isn't perfect yet, but a good step forward - it is now possible to
reason about the certificate names and locations without having to set
up a full `CertificateManager`, and `*base.Config` has lost much of the
mutable state it once had and is much closer to being an actual
"config".

Release note: None