### PR TITLE
ui: Managed navigation back for pages

### DIFF
--- a/pkg/ui/src/views/shared/hoc/withNavigationBack.spec.tsx
+++ b/pkg/ui/src/views/shared/hoc/withNavigationBack.spec.tsx
@@ -1,0 +1,98 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { assert } from "chai";
+import { mount } from "enzyme";
+import { createMemoryHistory, History, Location } from "history";
+import { spy } from "sinon";
+import { compose } from "redux";
+import { withRouter } from "react-router-dom";
+import { Router } from "react-router";
+
+import "src/enzymeInit";
+import { LocationState, withNavigationBack, WithNavigationBackProps } from "./withNavigationBack";
+
+const fallbackPath = "/fallbackPath";
+
+const TestComponent: React.FC<WithNavigationBackProps> = props => (
+  <div onClick={props.navigateBack}/>
+);
+
+describe("withNavigationBack", () => {
+  let history: History<LocationState>;
+
+  beforeEach(() => {
+    history = createMemoryHistory();
+  });
+
+  it("navigates to specified location in `from` state prop", () => {
+    const fromLocation: Location<LocationState> = {
+      ...history.location,
+      pathname: "/statements/(internal)",
+      search: "?q=delete",
+    };
+    history.location.state = {
+      from: fromLocation,
+    };
+    const pushSpy = spy(history, "push");
+
+    const Component = compose(
+      withRouter,
+      withNavigationBack(fallbackPath),
+    )(TestComponent);
+
+    const wrapper = mount(
+      <Router history={history}>
+        <Component />
+      </Router>,
+    );
+    wrapper.simulate("click");
+    assert.ok(wrapper);
+    assert.isTrue(pushSpy.calledOnceWith(fromLocation));
+  });
+
+  it("navigates back to fallback path if `from` state is not provided", () => {
+    const pushSpy: any = spy(history, "push");
+    const Component = compose(
+      withRouter,
+      withNavigationBack(fallbackPath),
+    )(TestComponent);
+
+    const wrapper = mount(
+      <Router history={history}>
+        <Component />
+      </Router>,
+    );
+    wrapper.simulate("click");
+    assert.ok(wrapper);
+    assert.isTrue(pushSpy.calledOnceWith(fallbackPath));
+  });
+
+  it("calls browser back action if both `from` state and fallback path are not provided", () => {
+    const goBackSpy = spy(history, "goBack");
+    const pushSpy = spy(history, "push");
+
+    const Component = compose(
+      withRouter,
+      withNavigationBack(),
+    )(TestComponent);
+
+    const wrapper = mount(
+      <Router history={history}>
+        <Component />
+      </Router>,
+    );
+    wrapper.simulate("click");
+    assert.ok(wrapper);
+    assert.isTrue(goBackSpy.calledOnce);
+    assert.isTrue(pushSpy.notCalled);
+  });
+});

--- a/pkg/ui/src/views/shared/hoc/withNavigationBack.tsx
+++ b/pkg/ui/src/views/shared/hoc/withNavigationBack.tsx
@@ -1,0 +1,49 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, { ComponentType } from "react";
+import { Location } from "history";
+import { StaticContext } from "react-router";
+import { RouteComponentProps } from "react-router-dom";
+
+export interface WithNavigationBackProps {
+  navigateBack: () => void;
+}
+
+export interface LocationState {
+  from?: Location;
+}
+
+export const withNavigationBack = (fallbackPath?: string) =>
+  <P extends RouteComponentProps<{}, StaticContext, LocationState>>(WrappedComponent: ComponentType<P & WithNavigationBackProps>) => {
+    return class extends React.Component<P> {
+      componentWillUnmount() {
+        const { location } = this.props.history;
+        if (location.state?.from) {
+          location.state.from = undefined;
+        }
+      }
+
+      navigateBack = () => {
+        const { push, location, goBack } = this.props.history;
+        if (location.state?.from) {
+          push(location.state.from);
+        } else if (fallbackPath) {
+          push(fallbackPath);
+        } else {
+          goBack();
+        }
+      }
+
+      render() {
+        return <WrappedComponent {...this.props} navigateBack={this.navigateBack} />;
+      }
+    };
+  };

--- a/pkg/ui/src/views/statements/statementDetails.fixture.ts
+++ b/pkg/ui/src/views/statements/statementDetails.fixture.ts
@@ -160,4 +160,5 @@ export const statementDetailsPropsFixture: StatementDetailsProps = {
   nodesSummary: undefined,
   refreshStatements: (() => {}) as (typeof refreshStatements),
   refreshStatementDiagnosticsRequests: (() => {}) as (typeof refreshStatementDiagnosticsRequests),
+  navigateBack: () => {},
 };

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -13,7 +13,9 @@ import _ from "lodash";
 import React, { ReactNode } from "react";
 import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
+import { compose } from "redux";
 import { Link, RouteComponentProps, match as Match, withRouter } from "react-router-dom";
+import { StaticContext } from "react-router";
 import { createSelector } from "reselect";
 
 import { refreshStatementDiagnosticsRequests, refreshStatements } from "src/redux/apiReducers";
@@ -53,6 +55,7 @@ import { trackSubnavSelection } from "src/util/analytics";
 import styles from "./statementDetails.module.styl";
 import sortableTableStyles from "src/views/shared/components/sortabletable/sortabletable.module.styl";
 import summaryCardStyles from "src/views/shared/components/summaryCard/summaryCard.module.styl";
+import { LocationState, withNavigationBack, WithNavigationBackProps } from "src/views/shared/hoc/withNavigationBack";
 
 const { TabPane } = Tabs;
 
@@ -107,7 +110,10 @@ interface StatementDetailsOwnProps {
   diagnosticsCount: number;
 }
 
-export type StatementDetailsProps = StatementDetailsOwnProps & RouteComponentProps;
+export type StatementDetailsProps =
+  StatementDetailsOwnProps
+  & RouteComponentProps<{}, StaticContext, LocationState>
+  & WithNavigationBackProps;
 
 interface StatementDetailsState {
   sortSetting: SortSetting;
@@ -216,7 +222,9 @@ export class StatementDetails extends React.Component<StatementDetailsProps, Sta
     this.props.refreshStatementDiagnosticsRequests();
   }
 
-  prevPage = () => this.props.history.goBack();
+  prevPage = () => {
+    this.props.navigateBack();
+  }
 
   onTabChange = (tabId: string) => {
     const { history } = this.props;
@@ -652,9 +660,10 @@ const mapDispatchToProps = {
 };
 
 // tslint:disable-next-line:variable-name
-const StatementDetailsConnected = withRouter(connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(StatementDetails));
+const StatementDetailsConnected = compose(
+  withNavigationBack("/statements"),
+  withRouter,
+  connect(mapStateToProps, mapDispatchToProps),
+)(StatementDetails);
 
 export default StatementDetailsConnected;

--- a/pkg/ui/src/views/statements/statementsTableContent.tsx
+++ b/pkg/ui/src/views/statements/statementsTableContent.tsx
@@ -9,16 +9,24 @@
 // licenses/APL.txt.
 
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import classNames from "classnames/bind";
+import { Location } from "history";
 import { Anchor, Tooltip } from "src/components";
-import { statementDiagnostics, statementsRetries, statementsSql, statementsTimeInterval, transactionalPipelining } from "src/util/docs";
+import {
+  statementDiagnostics,
+  statementsRetries,
+  statementsSql,
+  statementsTimeInterval,
+  transactionalPipelining,
+} from "src/util/docs";
 import getHighlightedText from "src/util/highlightedText";
 import { summarize } from "src/util/sql/summarize";
 import { ActivateDiagnosticsModalRef } from "./diagnostics/activateDiagnosticsModal";
 import { DiagnosticStatusBadge } from "./diagnostics/diagnosticStatusBadge";
 import { shortStatement } from "./statementsTable";
 import styles from "./statementsTableContent.module.styl";
+import { LocationState } from "src/views/shared/hoc/withNavigationBack";
 
 export type NodeNames = { [nodeId: string]: string };
 
@@ -216,10 +224,20 @@ export const StatementTableCell = {
 };
 
 export const StatementLink = (props: { statement: string, app: string, implicitTxn: boolean, search: string }) => {
+  const history = useHistory();
   const summary = summarize(props.statement);
   const base = props.app && props.app.length > 0 ? `/statements/${props.app}/${props.implicitTxn}` : `/statement/${props.implicitTxn}`;
+  const targetLocation: Location<LocationState> = {
+    pathname: `${base}/${encodeURIComponent(props.statement)}`,
+    state: {
+      from: history.location,
+    },
+    search: undefined,
+    hash: undefined,
+  };
+
   return (
-    <Link to={ `${base}/${encodeURIComponent(props.statement)}` }>
+    <Link to={targetLocation}>
       <div>
         <Tooltip
           placement="bottom"


### PR DESCRIPTION
Resolves #48240

Statement details page has `Back` button which has to navigate users
back to Statements page.

Initially, this functionality was implemented with browser history back
functionality and it could cause some unexpected behavior like:
- when user opens Statements details page directly and browser history
is empty so `Back` navigation leads to empty browser page.

To fix this issue, navigation back is implemented by tracking
history location of previous page and storing it in location.state
field which is preserved with navigation.

To make solution generic, logic is implemented as HOC so it can be
applied with other pages like (StatementsDetails).

`withNavigationBack` HOC handles three possible cases:
- navigate to location provided in `location.state.from` field if it is
defined;
- navigate to fallback path (which is defined per component) in case
`location.state.from` is not defined;
- and as a corner case use browser back navigation if both
`location.state.from` and fallback path is not provided;

Release note: none