### PR TITLE
sql: fix lookup join predicate in EXPLAIN

### DIFF
--- a/pkg/sql/execinfra/expr.go
+++ b/pkg/sql/execinfra/expr.go
@@ -175,7 +175,7 @@ func (eh *ExprHelper) Init(
 	if expr.LocalExpr != nil {
 		eh.Expr = expr.LocalExpr
 		// Bind IndexedVars to our eh.Vars.
-		eh.Vars.Rebind(eh.Expr, true /* alsoReset */, false /* normalizeToNonNil */)
+		eh.Vars.Rebind(eh.Expr)
 		return nil
 	}
 	var err error

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -69,9 +69,7 @@ type joinPredicate struct {
 
 // makePredicate constructs a joinPredicate object for joins. The equality
 // columns / on condition must be initialized separately.
-func makePredicate(
-	joinType sqlbase.JoinType, left, right sqlbase.ResultColumns,
-) (*joinPredicate, error) {
+func makePredicate(joinType sqlbase.JoinType, left, right sqlbase.ResultColumns) *joinPredicate {
 	// For anti and semi joins, the right columns are omitted from the output (but
 	// they must be available internally for the ON condition evaluation).
 	omitRightColumns := joinType == sqlbase.LeftSemiJoin || joinType == sqlbase.LeftAntiJoin
@@ -100,7 +98,7 @@ func makePredicate(
 	pred.curRow = make(tree.Datums, len(left)+len(right))
 	pred.iVarHelper = tree.MakeIndexedVarHelper(pred, len(pred.curRow))
 
-	return pred, nil
+	return pred
 }
 
 // IndexedVarEval implements the tree.IndexedVarContainer interface.

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -334,48 +334,6 @@ scan  ·             ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
 ----
-·                 distribution           local                                ·       ·
-·                 vectorized             true                                 ·       ·
-lookup-join       ·                      ·                                    (a, b)  ·
- │                table                  d@primary                            ·       ·
- │                type                   inner                                ·       ·
- │                equality               (a) = (a)                            ·       ·
- │                equality cols are key  ·                                    ·       ·
- │                parallel               ·                                    ·       ·
- │                pred                   @2 @> '{"a": {"b": "c"}, "f": "g"}'  ·       ·
- └── zigzag-join  ·                      ·                                    (a)     ·
-      │           type                   inner                                ·       ·
-      ├── scan    ·                      ·                                    (a)     ·
-      │           table                  d@foo_inv                            ·       ·
-      │           fixedvals              1 column                             ·       ·
-      └── scan    ·                      ·                                    ()      ·
-·                 table                  d@foo_inv                            ·       ·
-·                 fixedvals              1 column                             ·       ·
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
-----
-·                 distribution           local                                          ·       ·
-·                 vectorized             true                                           ·       ·
-lookup-join       ·                      ·                                              (a, b)  ·
- │                table                  d@primary                                      ·       ·
- │                type                   inner                                          ·       ·
- │                equality               (a) = (a)                                      ·       ·
- │                equality cols are key  ·                                              ·       ·
- │                parallel               ·                                              ·       ·
- │                pred                   @2 @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
- └── zigzag-join  ·                      ·                                              (a)     ·
-      │           type                   inner                                          ·       ·
-      ├── scan    ·                      ·                                              (a)     ·
-      │           table                  d@foo_inv                                      ·       ·
-      │           fixedvals              1 column                                       ·       ·
-      └── scan    ·                      ·                                              ()      ·
-·                 table                  d@foo_inv                                      ·       ·
-·                 fixedvals              1 column                                       ·       ·
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
-----
 ·                 distribution           local                               ·       ·
 ·                 vectorized             true                                ·       ·
 lookup-join       ·                      ·                                   (a, b)  ·
@@ -384,7 +342,7 @@ lookup-join       ·                      ·                                   (
  │                equality               (a) = (a)                           ·       ·
  │                equality cols are key  ·                                   ·       ·
  │                parallel               ·                                   ·       ·
- │                pred                   @2 @> '[{"a": {"b": [[2]]}}, "d"]'  ·       ·
+ │                pred                   b @> '{"a": {"b": "c"}, "f": "g"}'  ·       ·
  └── zigzag-join  ·                      ·                                   (a)     ·
       │           type                   inner                               ·       ·
       ├── scan    ·                      ·                                   (a)     ·
@@ -393,6 +351,48 @@ lookup-join       ·                      ·                                   (
       └── scan    ·                      ·                                   ()      ·
 ·                 table                  d@foo_inv                           ·       ·
 ·                 fixedvals              1 column                            ·       ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
+----
+·                 distribution           local                                         ·       ·
+·                 vectorized             true                                          ·       ·
+lookup-join       ·                      ·                                             (a, b)  ·
+ │                table                  d@primary                                     ·       ·
+ │                type                   inner                                         ·       ·
+ │                equality               (a) = (a)                                     ·       ·
+ │                equality cols are key  ·                                             ·       ·
+ │                parallel               ·                                             ·       ·
+ │                pred                   b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
+ └── zigzag-join  ·                      ·                                             (a)     ·
+      │           type                   inner                                         ·       ·
+      ├── scan    ·                      ·                                             (a)     ·
+      │           table                  d@foo_inv                                     ·       ·
+      │           fixedvals              1 column                                      ·       ·
+      └── scan    ·                      ·                                             ()      ·
+·                 table                  d@foo_inv                                     ·       ·
+·                 fixedvals              1 column                                      ·       ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
+----
+·                 distribution           local                              ·       ·
+·                 vectorized             true                               ·       ·
+lookup-join       ·                      ·                                  (a, b)  ·
+ │                table                  d@primary                          ·       ·
+ │                type                   inner                              ·       ·
+ │                equality               (a) = (a)                          ·       ·
+ │                equality cols are key  ·                                  ·       ·
+ │                parallel               ·                                  ·       ·
+ │                pred                   b @> '[{"a": {"b": [[2]]}}, "d"]'  ·       ·
+ └── zigzag-join  ·                      ·                                  (a)     ·
+      │           type                   inner                              ·       ·
+      ├── scan    ·                      ·                                  (a)     ·
+      │           table                  d@foo_inv                          ·       ·
+      │           fixedvals              1 column                           ·       ·
+      └── scan    ·                      ·                                  ()      ·
+·                 table                  d@foo_inv                          ·       ·
+·                 fixedvals              1 column                           ·       ·
 
 statement ok
 SET enable_zigzag_join = true
@@ -400,48 +400,6 @@ SET enable_zigzag_join = true
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
 ----
-·                 distribution           local                                ·       ·
-·                 vectorized             true                                 ·       ·
-lookup-join       ·                      ·                                    (a, b)  ·
- │                table                  d@primary                            ·       ·
- │                type                   inner                                ·       ·
- │                equality               (a) = (a)                            ·       ·
- │                equality cols are key  ·                                    ·       ·
- │                parallel               ·                                    ·       ·
- │                pred                   @2 @> '{"a": {"b": "c"}, "f": "g"}'  ·       ·
- └── zigzag-join  ·                      ·                                    (a)     ·
-      │           type                   inner                                ·       ·
-      ├── scan    ·                      ·                                    (a)     ·
-      │           table                  d@foo_inv                            ·       ·
-      │           fixedvals              1 column                             ·       ·
-      └── scan    ·                      ·                                    ()      ·
-·                 table                  d@foo_inv                            ·       ·
-·                 fixedvals              1 column                             ·       ·
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
-----
-·                 distribution           local                                          ·       ·
-·                 vectorized             true                                           ·       ·
-lookup-join       ·                      ·                                              (a, b)  ·
- │                table                  d@primary                                      ·       ·
- │                type                   inner                                          ·       ·
- │                equality               (a) = (a)                                      ·       ·
- │                equality cols are key  ·                                              ·       ·
- │                parallel               ·                                              ·       ·
- │                pred                   @2 @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
- └── zigzag-join  ·                      ·                                              (a)     ·
-      │           type                   inner                                          ·       ·
-      ├── scan    ·                      ·                                              (a)     ·
-      │           table                  d@foo_inv                                      ·       ·
-      │           fixedvals              1 column                                       ·       ·
-      └── scan    ·                      ·                                              ()      ·
-·                 table                  d@foo_inv                                      ·       ·
-·                 fixedvals              1 column                                       ·       ·
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
-----
 ·                 distribution           local                               ·       ·
 ·                 vectorized             true                                ·       ·
 lookup-join       ·                      ·                                   (a, b)  ·
@@ -450,7 +408,7 @@ lookup-join       ·                      ·                                   (
  │                equality               (a) = (a)                           ·       ·
  │                equality cols are key  ·                                   ·       ·
  │                parallel               ·                                   ·       ·
- │                pred                   @2 @> '[{"a": {"b": [[2]]}}, "d"]'  ·       ·
+ │                pred                   b @> '{"a": {"b": "c"}, "f": "g"}'  ·       ·
  └── zigzag-join  ·                      ·                                   (a)     ·
       │           type                   inner                               ·       ·
       ├── scan    ·                      ·                                   (a)     ·
@@ -459,6 +417,48 @@ lookup-join       ·                      ·                                   (
       └── scan    ·                      ·                                   ()      ·
 ·                 table                  d@foo_inv                           ·       ·
 ·                 fixedvals              1 column                            ·       ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
+----
+·                 distribution           local                                         ·       ·
+·                 vectorized             true                                          ·       ·
+lookup-join       ·                      ·                                             (a, b)  ·
+ │                table                  d@primary                                     ·       ·
+ │                type                   inner                                         ·       ·
+ │                equality               (a) = (a)                                     ·       ·
+ │                equality cols are key  ·                                             ·       ·
+ │                parallel               ·                                             ·       ·
+ │                pred                   b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
+ └── zigzag-join  ·                      ·                                             (a)     ·
+      │           type                   inner                                         ·       ·
+      ├── scan    ·                      ·                                             (a)     ·
+      │           table                  d@foo_inv                                     ·       ·
+      │           fixedvals              1 column                                      ·       ·
+      └── scan    ·                      ·                                             ()      ·
+·                 table                  d@foo_inv                                     ·       ·
+·                 fixedvals              1 column                                      ·       ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
+----
+·                 distribution           local                              ·       ·
+·                 vectorized             true                               ·       ·
+lookup-join       ·                      ·                                  (a, b)  ·
+ │                table                  d@primary                          ·       ·
+ │                type                   inner                              ·       ·
+ │                equality               (a) = (a)                          ·       ·
+ │                equality cols are key  ·                                  ·       ·
+ │                parallel               ·                                  ·       ·
+ │                pred                   b @> '[{"a": {"b": [[2]]}}, "d"]'  ·       ·
+ └── zigzag-join  ·                      ·                                  (a)     ·
+      │           type                   inner                              ·       ·
+      ├── scan    ·                      ·                                  (a)     ·
+      │           table                  d@foo_inv                          ·       ·
+      │           fixedvals              1 column                           ·       ·
+      └── scan    ·                      ·                                  ()      ·
+·                 table                  d@foo_inv                          ·       ·
+·                 fixedvals              1 column                           ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": 2}'
@@ -540,44 +540,44 @@ scan  ·             ·          (a, b)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1,2]
 ----
-·                 distribution           local             ·       ·
-·                 vectorized             true              ·       ·
-lookup-join       ·                      ·                 (a, b)  ·
- │                table                  e@primary         ·       ·
- │                type                   inner             ·       ·
- │                equality               (a) = (a)         ·       ·
- │                equality cols are key  ·                 ·       ·
- │                parallel               ·                 ·       ·
- │                pred                   @2 @> ARRAY[1,2]  ·       ·
- └── zigzag-join  ·                      ·                 (a)     ·
-      │           type                   inner             ·       ·
-      ├── scan    ·                      ·                 (a)     ·
-      │           table                  e@e_b_idx         ·       ·
-      │           fixedvals              1 column          ·       ·
-      └── scan    ·                      ·                 ()      ·
-·                 table                  e@e_b_idx         ·       ·
-·                 fixedvals              1 column          ·       ·
+·                 distribution           local            ·       ·
+·                 vectorized             true             ·       ·
+lookup-join       ·                      ·                (a, b)  ·
+ │                table                  e@primary        ·       ·
+ │                type                   inner            ·       ·
+ │                equality               (a) = (a)        ·       ·
+ │                equality cols are key  ·                ·       ·
+ │                parallel               ·                ·       ·
+ │                pred                   b @> ARRAY[1,2]  ·       ·
+ └── zigzag-join  ·                      ·                (a)     ·
+      │           type                   inner            ·       ·
+      ├── scan    ·                      ·                (a)     ·
+      │           table                  e@e_b_idx        ·       ·
+      │           fixedvals              1 column         ·       ·
+      └── scan    ·                      ·                ()      ·
+·                 table                  e@e_b_idx        ·       ·
+·                 fixedvals              1 column         ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from e where b @> ARRAY[1] AND b @> ARRAY[2]
 ----
-·                 distribution           local                                  ·       ·
-·                 vectorized             true                                   ·       ·
-lookup-join       ·                      ·                                      (a, b)  ·
- │                table                  e@primary                              ·       ·
- │                type                   inner                                  ·       ·
- │                equality               (a) = (a)                              ·       ·
- │                equality cols are key  ·                                      ·       ·
- │                parallel               ·                                      ·       ·
- │                pred                   (@2 @> ARRAY[1]) AND (@2 @> ARRAY[2])  ·       ·
- └── zigzag-join  ·                      ·                                      (a)     ·
-      │           type                   inner                                  ·       ·
-      ├── scan    ·                      ·                                      (a)     ·
-      │           table                  e@e_b_idx                              ·       ·
-      │           fixedvals              1 column                               ·       ·
-      └── scan    ·                      ·                                      ()      ·
-·                 table                  e@e_b_idx                              ·       ·
-·                 fixedvals              1 column                               ·       ·
+·                 distribution           local                                ·       ·
+·                 vectorized             true                                 ·       ·
+lookup-join       ·                      ·                                    (a, b)  ·
+ │                table                  e@primary                            ·       ·
+ │                type                   inner                                ·       ·
+ │                equality               (a) = (a)                            ·       ·
+ │                equality cols are key  ·                                    ·       ·
+ │                parallel               ·                                    ·       ·
+ │                pred                   (b @> ARRAY[1]) AND (b @> ARRAY[2])  ·       ·
+ └── zigzag-join  ·                      ·                                    (a)     ·
+      │           type                   inner                                ·       ·
+      ├── scan    ·                      ·                                    (a)     ·
+      │           table                  e@e_b_idx                            ·       ·
+      │           fixedvals              1 column                             ·       ·
+      └── scan    ·                      ·                                    ()      ·
+·                 table                  e@e_b_idx                            ·       ·
+·                 fixedvals              1 column                             ·       ·
 
 # Ensure that an inverted index with a composite primary key still encodes
 # the primary key data in the composite value.

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -1604,7 +1604,7 @@ lookup-join       ·                      ·
  │                equality               (a) = (a)
  │                equality cols are key  ·
  │                parallel               ·
- │                pred                   @4 > 4.0
+ │                pred                   d > 4.0
  └── zigzag-join  ·                      ·
       │           type                   inner
       │           pred                   (@2 = 5) AND (@3 = 6.0)

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -68,7 +68,7 @@ lookup-join  ·             ·            (a, b, c, d, e, f)  ·
  │           table         def@primary  ·                   ·
  │           type          inner        ·                   ·
  │           equality      (b) = (f)    ·                   ·
- │           pred          @5 > 1       ·                   ·
+ │           pred          e > 1        ·                   ·
  └── scan    ·             ·            (a, b, c)           ·
 ·            table         abc@primary  ·                   ·
 ·            spans         /2-          ·                   ·
@@ -83,7 +83,7 @@ lookup-join  ·             ·            (a, b, c, d, e, f)  ·
  │           table         def@primary  ·                   ·
  │           type          inner        ·                   ·
  │           equality      (a) = (f)    ·                   ·
- │           pred          @6 > 1       ·                   ·
+ │           pred          f > 1        ·                   ·
  └── scan    ·             ·            (a, b, c)           ·
 ·            table         abc@primary  ·                   ·
 ·            spans         /2-          ·                   ·
@@ -98,7 +98,7 @@ lookup-join  ·             ·            (a, b, c, d, e, f)  ·
  │           table         def@primary  ·                   ·
  │           type          inner        ·                   ·
  │           equality      (b) = (f)    ·                   ·
- │           pred          @1 >= @5     ·                   ·
+ │           pred          a >= e       ·                   ·
  └── scan    ·             ·            (a, b, c)           ·
 ·            table         abc@primary  ·                   ·
 ·            spans         FULL SCAN    ·                   ·
@@ -113,7 +113,7 @@ lookup-join  ·             ·            (a, b, c, d, e, f)  ·
  │           table         def@primary  ·                   ·
  │           type          inner        ·                   ·
  │           equality      (b) = (f)    ·                   ·
- │           pred          @1 >= @5     ·                   ·
+ │           pred          a >= e       ·                   ·
  └── scan    ·             ·            (a, b, c)           ·
 ·            table         abc@primary  ·                   ·
 ·            spans         FULL SCAN    ·                   ·
@@ -176,7 +176,7 @@ render            ·                      ·                            (a, b, c
       │           equality               (a, b, c, d) = (a, b, c, d)  ·                         ·
       │           equality cols are key  ·                            ·                         ·
       │           parallel               ·                            ·                         ·
-      │           pred                   @7 > 0                       ·                         ·
+      │           pred                   c > 0                        ·                         ·
       └── scan    ·                      ·                            (a, b, c, d)              ·
 ·                 table                  data@primary                 ·                         ·
 ·                 spans                  FULL SCAN                    ·                         ·
@@ -231,7 +231,7 @@ distinct               ·             ·                  (title)               
            │           table         books2@primary     ·                             ·
            │           type          inner              ·                             ·
            │           equality      (title) = (title)  ·                             ·
-           │           pred          @2 != @4           ·                             ·
+           │           pred          shelf != shelf     ·                             ·
            └── scan    ·             ·                  (title, shelf)                +title
 ·                      table         books@primary      ·                             ·
 ·                      spans         FULL SCAN          ·                             ·
@@ -263,7 +263,7 @@ distinct                  ·             ·                  (name)             
            │              table         books2@primary     ·                                         ·
            │              type          inner              ·                                         ·
            │              equality      (title) = (title)  ·                                         ·
-           │              pred          @4 != @6           ·                                         ·
+           │              pred          shelf != shelf     ·                                         ·
            └── hash-join  ·             ·                  (name, book, title, shelf)                ·
                 │         type          inner              ·                                         ·
                 │         equality      (book) = (title)   ·                                         ·
@@ -444,7 +444,7 @@ render            ·             ·              (a, b)     +a
       │           table         large@primary  ·          ·
       │           type          left outer     ·          ·
       │           equality      (a) = (a)      ·          ·
-      │           pred          (@3 % 6) = 0   ·          ·
+      │           pred          (b % 6) = 0    ·          ·
       └── scan    ·             ·              (a)        +a
 ·                 table         small@primary  ·          ·
 ·                 spans         FULL SCAN      ·          ·
@@ -507,7 +507,7 @@ render            ·             ·              (c, c)     ·
       │           table         large@bc       ·          ·
       │           type          left outer     ·          ·
       │           equality      (c) = (b)      ·          ·
-      │           pred          @3 < 20        ·          ·
+      │           pred          c < 20         ·          ·
       └── scan    ·             ·              (c)        ·
 ·                 table         small@primary  ·          ·
 ·                 spans         FULL SCAN      ·          ·
@@ -584,7 +584,7 @@ render            ·                      ·          (a)              ·
       │           equality               (d) = (d)  ·                ·
       │           equality cols are key  ·          ·                ·
       │           parallel               ·          ·                ·
-      │           pred                   @1 = @4    ·                ·
+      │           pred                   a = a      ·                ·
       └── scan    ·                      ·          (a, d, e)        ·
 ·                 table                  t@primary  ·                ·
 ·                 spans                  FULL SCAN  ·                ·
@@ -654,7 +654,7 @@ render            ·             ·          (a)              ·
       │           table         u@idx      ·                ·
       │           type          inner      ·                ·
       │           equality      (d) = (d)  ·                ·
-      │           pred          @1 = @4    ·                ·
+      │           pred          a = a      ·                ·
       └── scan    ·             ·          (a, d, e)        ·
 ·                 table         t@primary  ·                ·
 ·                 spans         FULL SCAN  ·                ·
@@ -775,30 +775,30 @@ lookup-join  ·                      ·                (a, b, c)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=f AND d+b>1)
 ----
-·            distribution  full           ·          ·
-·            vectorized    true           ·          ·
-lookup-join  ·             ·              (a, b, c)  ·
- │           table         def@primary    ·          ·
- │           type          semi           ·          ·
- │           equality      (a) = (f)      ·          ·
- │           pred          (@4 + @2) > 1  ·          ·
- └── scan    ·             ·              (a, b, c)  ·
-·            table         abc@primary    ·          ·
-·            spans         FULL SCAN      ·          ·
+·            distribution  full         ·          ·
+·            vectorized    true         ·          ·
+lookup-join  ·             ·            (a, b, c)  ·
+ │           table         def@primary  ·          ·
+ │           type          semi         ·          ·
+ │           equality      (a) = (f)    ·          ·
+ │           pred          (d + b) > 1  ·          ·
+ └── scan    ·             ·            (a, b, c)  ·
+·            table         abc@primary  ·          ·
+·            spans         FULL SCAN    ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=f AND d+b>1)
 ----
-·            distribution  full           ·          ·
-·            vectorized    true           ·          ·
-lookup-join  ·             ·              (a, b, c)  ·
- │           table         def@primary    ·          ·
- │           type          anti           ·          ·
- │           equality      (a) = (f)      ·          ·
- │           pred          (@4 + @2) > 1  ·          ·
- └── scan    ·             ·              (a, b, c)  ·
-·            table         abc@primary    ·          ·
-·            spans         FULL SCAN      ·          ·
+·            distribution  full         ·          ·
+·            vectorized    true         ·          ·
+lookup-join  ·             ·            (a, b, c)  ·
+ │           table         def@primary  ·          ·
+ │           type          anti         ·          ·
+ │           equality      (a) = (f)    ·          ·
+ │           pred          (d + b) > 1  ·          ·
+ └── scan    ·             ·            (a, b, c)  ·
+·            table         abc@primary  ·          ·
+·            spans         FULL SCAN    ·          ·
 
 query T
 SELECT url FROM [ EXPLAIN (DISTSQL)
@@ -1439,14 +1439,14 @@ limit                                               ·                      ·
                      │                              equality               (l_orderkey) = (o_orderkey)
                      │                              equality cols are key  ·
                      │                              parallel               ·
-                     │                              pred                   @11 = 'F'
+                     │                              pred                   o_orderstatus = 'F'
                      └── lookup-join                ·                      ·
                           │                         table                  nation@primary
                           │                         type                   inner
                           │                         equality               (s_nationkey) = (n_nationkey)
                           │                         equality cols are key  ·
                           │                         parallel               ·
-                          │                         pred                   @9 = 'SAUDI ARABIA'
+                          │                         pred                   n_name = 'SAUDI ARABIA'
                           └── lookup-join           ·                      ·
                                │                    table                  supplier@primary
                                │                    type                   inner
@@ -1457,7 +1457,7 @@ limit                                               ·                      ·
                                     │               table                  lineitem@primary
                                     │               type                   semi
                                     │               equality               (l_orderkey) = (l_orderkey)
-                                    │               pred                   @6 != @2
+                                    │               pred                   l_suppkey != l_suppkey
                                     └── merge-join  ·                      ·
                                          │          type                   anti
                                          │          equality               (l_orderkey) = (l_orderkey)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -229,7 +229,7 @@ func (ef *execFactory) ConstructFilter(
 	// Push the filter into the scanNode. We cannot do this if the scanNode has a
 	// limit (it would make the limit apply AFTER the filter).
 	if s, ok := n.(*scanNode); ok && s.filter == nil && s.hardLimit == 0 {
-		s.filter = s.filterVars.Rebind(filter, true /* alsoReset */, false /* normalizeToNonNil */)
+		s.filter = s.filterVars.Rebind(filter)
 		// Note: if the filter statically evaluates to true, s.filter stays nil.
 		s.reqOrdering = ReqOrdering(reqOrdering)
 		return s, nil
@@ -240,7 +240,7 @@ func (ef *execFactory) ConstructFilter(
 		source: src,
 	}
 	f.ivarHelper = tree.MakeIndexedVarHelper(f, len(src.columns))
-	f.filter = f.ivarHelper.Rebind(filter, true /* alsoReset */, false /* normalizeToNonNil */)
+	f.filter = f.ivarHelper.Rebind(filter)
 	if f.filter == nil {
 		// Filter statically evaluates to true. Just return the input plan.
 		return n, nil
@@ -330,8 +330,7 @@ func (ef *execFactory) ConstructRender(
 	var rb renderBuilder
 	rb.init(n, reqOrdering)
 	for i, expr := range exprs {
-		expr = rb.r.ivarHelper.Rebind(expr, false /* alsoReset */, true /* normalizeToNonNil */)
-		exprs[i] = expr
+		exprs[i] = rb.r.ivarHelper.Rebind(expr)
 	}
 	rb.setOutput(exprs, columns)
 	return rb.res, nil
@@ -380,9 +379,7 @@ func (ef *execFactory) ConstructHashJoin(
 	pred.leftEqKey = leftEqColsAreKey
 	pred.rightEqKey = rightEqColsAreKey
 
-	pred.onCond = pred.iVarHelper.Rebind(
-		extraOnCond, false /* alsoReset */, false, /* normalizeToNonNil */
-	)
+	pred.onCond = pred.iVarHelper.Rebind(extraOnCond)
 
 	return p.makeJoinNode(leftSrc, rightSrc, pred), nil
 }
@@ -400,9 +397,7 @@ func (ef *execFactory) ConstructApplyJoin(
 	if err != nil {
 		return nil, err
 	}
-	pred.onCond = pred.iVarHelper.Rebind(
-		onCond, false /* alsoReset */, false, /* normalizeToNonNil */
-	)
+	pred.onCond = pred.iVarHelper.Rebind(onCond)
 	return newApplyJoinNode(joinType, leftSrc, rightColumns, pred, planRightSideFn)
 }
 
@@ -422,9 +417,7 @@ func (ef *execFactory) ConstructMergeJoin(
 	if err != nil {
 		return nil, err
 	}
-	pred.onCond = pred.iVarHelper.Rebind(
-		onCond, false /* alsoReset */, false, /* normalizeToNonNil */
-	)
+	pred.onCond = pred.iVarHelper.Rebind(onCond)
 	pred.leftEqKey = leftEqColsAreKey
 	pred.rightEqKey = rightEqColsAreKey
 
@@ -755,9 +748,7 @@ func (ef *execFactory) constructVirtualTableLookupJoin(
 	if err != nil {
 		return nil, err
 	}
-	pred.onCond = pred.iVarHelper.Rebind(
-		onCond, false /* alsoReset */, false, /* normalizeToNonNil */
-	)
+	pred.onCond = pred.iVarHelper.Rebind(onCond)
 	n := &vTableLookupJoinNode{
 		input:             input.(planNode),
 		joinType:          joinType,

--- a/pkg/sql/sem/tree/indexed_vars.go
+++ b/pkg/sql/sem/tree/indexed_vars.go
@@ -216,30 +216,10 @@ func (h *IndexedVarHelper) GetIndexedVars() []IndexedVar {
 	return h.vars
 }
 
-// Reset re-initializes an IndexedVarHelper structure with the same
-// number of slots. After a helper has been reset, all the expressions
-// that were linked to the helper before it was reset must be
-// re-bound, e.g. using Rebind(). Resetting is useful to ensure that
-// the helper's knowledge of which IndexedVars are actually used by
-// linked expressions is up to date, especially after
-// optimizations/transforms which eliminate sub-expressions. The
-// optimizations performed by setNeededColumns() work then best.
-//
-// TODO(knz): groupNode and windowNode hold on to IndexedVar's after a Reset().
-func (h *IndexedVarHelper) Reset() {
-	h.vars = make([]IndexedVar, len(h.vars))
-}
-
-// Rebind collects all the IndexedVars in the given expression
-// and re-binds them to this helper.
-func (h *IndexedVarHelper) Rebind(expr TypedExpr, alsoReset, normalizeToNonNil bool) TypedExpr {
-	if alsoReset {
-		h.Reset()
-	}
-	if expr == nil || expr == DBoolTrue {
-		if normalizeToNonNil {
-			return DBoolTrue
-		}
+// Rebind collects all the IndexedVars in the given expression and re-binds them
+// to this helper.
+func (h *IndexedVarHelper) Rebind(expr TypedExpr) TypedExpr {
+	if expr == nil {
 		return nil
 	}
 	ret, _ := WalkExpr(h, expr)


### PR DESCRIPTION
#### sql: clean up Rebind

Clean up the indexed var container Rebind interface. We no longer need
the functionality of the flags (wherever they were true, they were
misused).

#### sql: fix lookup join predicate in EXPLAIN

Lookup join predicates don't show proper column names in EXPLAIN. Fix
this by biding the ON condition to a proper indexed var container,
like all other joins.

Fixes #49268.

Release note (bug fix): lookup join predicate now shows proper column
names in EXPLAIN.