### PR TITLE
sql: extract reqOrdering in ConstructSimpleProject from the input node

### DIFF
--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -258,7 +258,7 @@ func (e *distSQLSpecExecFactory) ConstructFilter(
 }
 
 func (e *distSQLSpecExecFactory) ConstructSimpleProject(
-	n exec.Node, cols []exec.NodeColumnOrdinal, colNames []string, reqOrdering exec.OutputOrdering,
+	n exec.Node, cols []exec.NodeColumnOrdinal, colNames []string,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning")
 }

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -54,7 +54,7 @@ func (f *stubFactory) ConstructFilter(
 }
 
 func (f *stubFactory) ConstructSimpleProject(
-	n exec.Node, cols []exec.NodeColumnOrdinal, colNames []string, reqOrdering exec.OutputOrdering,
+	n exec.Node, cols []exec.NodeColumnOrdinal, colNames []string,
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -54,7 +54,7 @@ func (b *Builder) buildMutationInput(
 		}
 	}
 
-	input, err = b.ensureColumns(input, colList, nil, inputExpr.ProvidedPhysical().Ordering)
+	input, err = b.ensureColumns(input, colList, nil /* colNames */)
 	if err != nil {
 		return execPlan{}, err
 	}

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -41,7 +41,7 @@ func (b *Builder) buildCreateTable(ct *memo.CreateTableExpr) (execPlan, error) {
 			colList[i] = ct.InputCols[i].ID
 			colNames[i] = ct.InputCols[i].Alias
 		}
-		input, err = b.ensureColumns(input, colList, colNames, nil /* provided */)
+		input, err = b.ensureColumns(input, colList, colNames)
 		if err != nil {
 			return execPlan{}, err
 		}

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -764,7 +764,7 @@ EXPLAIN (TYPES) SELECT min(v) FROM opt_test WHERE k <> 4
 group                ·             ·                             (min int)       ·
  │                   aggregate 0   any_not_null(v)               ·               ·
  │                   scalar        ·                             ·               ·
- └── render          ·             ·                             (v int)         ·
+ └── render          ·             ·                             (v int)         +v
       │              render 0      (v)[int]                      ·               ·
       └── limit      ·             ·                             (k int, v int)  +v
            │         count         (1)[int]                      ·               ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct
@@ -149,7 +149,7 @@ EXPLAIN (VERBOSE) SELECT DISTINCT 1 AS z, d, b FROM abcd ORDER BY d, b
 ----
 ·          distribution  local              ·          ·
 ·          vectorized    true               ·          ·
-render     ·             ·                  (z, d, b)  ·
+render     ·             ·                  (z, d, b)  +d,+b
  │         render 0      1                  ·          ·
  │         render 1      d                  ·          ·
  │         render 2      b                  ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -129,7 +129,7 @@ EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, x) pk1, x FROM xyz ORDER BY pk1
 ----
 ·               distribution  local        ·         ·
 ·               vectorized    true         ·         ·
-render          ·             ·            (pk1, x)  ·
+render          ·             ·            (pk1, x)  +pk1
  │              render 0      pk1          ·         ·
  │              render 1      x            ·         ·
  └── distinct   ·             ·            (x, pk1)  +pk1
@@ -229,7 +229,7 @@ EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, z) y, z, x FROM xyz ORDER BY z
 ----
 ·                    distribution  local        ·          ·
 ·                    vectorized    true         ·          ·
-render               ·             ·            (y, z, x)  ·
+render               ·             ·            (y, z, x)  +z
  │                   render 0      y            ·          ·
  │                   render 1      z            ·          ·
  │                   render 2      x            ·          ·
@@ -247,7 +247,7 @@ EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC
 ----
 ·                    distribution  local        ·          ·
 ·                    vectorized    true         ·          ·
-render               ·             ·            (y, z, x)  ·
+render               ·             ·            (y, z, x)  +x
  │                   render 0      y            ·          ·
  │                   render 1      z            ·          ·
  │                   render 2      x            ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
@@ -168,7 +168,7 @@ EXPLAIN (VERBOSE) SELECT y, str, repeat('test', y) AS res FROM NumToStr ORDER BY
 ----
 ·                    distribution  full               ·              ·
 ·                    vectorized    true               ·              ·
-render               ·             ·                  (y, str, res)  ·
+render               ·             ·                  (y, str, res)  +res
  │                   render 0      y                  ·              ·
  │                   render 1      str                ·              ·
  │                   render 2      res                ·              ·
@@ -187,7 +187,7 @@ EXPLAIN (VERBOSE) SELECT y, str, repeat('test', y) AS res FROM NumToStr ORDER BY
 ----
 ·                         distribution  full               ·              ·
 ·                         vectorized    true               ·              ·
-render                    ·             ·                  (y, str, res)  ·
+render                    ·             ·                  (y, str, res)  +res
  │                        render 0      y                  ·              ·
  │                        render 1      str                ·              ·
  │                        render 2      res                ·              ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -218,7 +218,7 @@ EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u, 
 ----
 ·                           distribution   local                  ·                                     ·
 ·                           vectorized     false                  ·                                     ·
-render                      ·              ·                      (k, u, w)                             ·
+render                      ·              ·                      (k, u, w)                             +u
  │                          render 0       column2                ·                                     ·
  │                          render 1       column1                ·                                     ·
  │                          render 2       column2                ·                                     ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -665,7 +665,7 @@ EXPLAIN (VERBOSE) SELECT * FROM def JOIN abc ON a=f ORDER BY a
 ----
 ·                 distribution  full         ·                   ·
 ·                 vectorized    true         ·                   ·
-render            ·             ·            (d, e, f, a, b, c)  ·
+render            ·             ·            (d, e, f, a, b, c)  +a
  │                render 0      d            ·                   ·
  │                render 1      e            ·                   ·
  │                render 2      f            ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -49,7 +49,7 @@ EXPLAIN (VERBOSE) SELECT DISTINCT c, b FROM t ORDER BY b LIMIT 2
 ----
 ·                         distribution  local      ·       ·
 ·                         vectorized    true       ·       ·
-render                    ·             ·          (c, b)  ·
+render                    ·             ·          (c, b)  +b
  │                        render 0      c          ·       ·
  │                        render 1      b          ·       ·
  └── limit                ·             ·          (b, c)  +b
@@ -330,7 +330,7 @@ EXPLAIN (VERBOSE) SELECT a, b FROM abc ORDER BY b, c
 ----
 ·          distribution  local      ·          ·
 ·          vectorized    true       ·          ·
-render     ·             ·          (a, b)     ·
+render     ·             ·          (a, b)     +b
  │         render 0      a          ·          ·
  │         render 1      b          ·          ·
  └── scan  ·             ·          (a, b, c)  +b,+c
@@ -639,7 +639,7 @@ EXPLAIN (VERBOSE) SELECT * FROM (SELECT y, w, x FROM uvwxyz WHERE y = 1 ORDER BY
 ----
 ·          distribution  local        ·          ·
 ·          vectorized    true         ·          ·
-render     ·             ·            (y, w, x)  ·
+render     ·             ·            (y, w, x)  +w,+x
  │         render 0      y            ·          ·
  │         render 1      w            ·          ·
  │         render 2      x            ·          ·
@@ -687,7 +687,7 @@ EXPLAIN (VERBOSE) SELECT b, a FROM foo ORDER BY @1
 ----
 ·                    distribution  local        ·                ·
 ·                    vectorized    true         ·                ·
-render               ·             ·            (b, a)           ·
+render               ·             ·            (b, a)           +a
  │                   render 0      b            ·                ·
  │                   render 1      a            ·                ·
  └── sort            ·             ·            (column4, a, b)  +a
@@ -705,7 +705,7 @@ EXPLAIN (VERBOSE) SELECT b, a FROM foo ORDER BY @2
 ----
 ·                    distribution  local        ·                ·
 ·                    vectorized    true         ·                ·
-render               ·             ·            (b, a)           ·
+render               ·             ·            (b, a)           +b
  │                   render 0      b            ·                ·
  │                   render 1      a            ·                ·
  └── sort            ·             ·            (column4, a, b)  +b
@@ -796,7 +796,7 @@ EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY v, PRIMARY KEY kv, v-2
 ----
 ·               distribution  local       ·       ·
 ·               vectorized    true        ·       ·
-render          ·             ·           (k)     ·
+render          ·             ·           (k)     +k
  │              render 0      k           ·       ·
  └── sort       ·             ·           (k, v)  +v,+k
       │         order         +v,+k       ·       ·
@@ -809,7 +809,7 @@ EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo
 ----
 ·          distribution  local      ·       ·
 ·          vectorized    true       ·       ·
-render     ·             ·          (k)     ·
+render     ·             ·          (k)     +k
  │         render 0      k          ·       ·
  └── scan  ·             ·          (k, v)  -v,+k
 ·          table         kv@foo     ·       ·
@@ -820,7 +820,7 @@ EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo ASC
 ----
 ·          distribution  local      ·       ·
 ·          vectorized    true       ·       ·
-render     ·             ·          (k)     ·
+render     ·             ·          (k)     +k
  │         render 0      k          ·       ·
  └── scan  ·             ·          (k, v)  -v,+k
 ·          table         kv@foo     ·       ·
@@ -831,7 +831,7 @@ EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo DESC
 ----
 ·             distribution  local      ·       ·
 ·             vectorized    true       ·       ·
-render        ·             ·          (k)     ·
+render        ·             ·          (k)     -k
  │            render 0      k          ·       ·
  └── revscan  ·             ·          (k, v)  +v,-k
 ·             table         kv@foo     ·       ·
@@ -842,7 +842,7 @@ EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo, k
 ----
 ·          distribution  local      ·       ·
 ·          vectorized    true       ·       ·
-render     ·             ·          (k)     ·
+render     ·             ·          (k)     +k
  │         render 0      k          ·       ·
  └── scan  ·             ·          (k, v)  -v,+k
 ·          table         kv@foo     ·       ·
@@ -860,7 +860,7 @@ SELECT k FROM kv JOIN (VALUES (1,2), (3,4)) AS z(a,b) ON kv.k = z.a ORDER BY IND
 ----
 ·                           distribution           local             ·                ·
 ·                           vectorized             false             ·                ·
-render                      ·                      ·                 (k)              ·
+render                      ·                      ·                 (k)              +k
  │                          render 0               k                 ·                ·
  └── sort                   ·                      ·                 (k, v)           -v,+k
       │                     order                  -v,+k             ·                ·
@@ -883,7 +883,7 @@ EXPLAIN (VERBOSE) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
 ----
 ·                distribution        local              ·             ·
 ·                vectorized          true               ·             ·
-render           ·                   ·                  (k)           ·
+render           ·                   ·                  (k)           +k
  │               render 0            k                  ·             ·
  └── merge-join  ·                   ·                  (k, v, k, v)  -v,+k
       │          type                inner              ·             ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -634,7 +634,7 @@ EXPLAIN (TYPES) SELECT b, a FROM coll ORDER BY b, a
 ----
 ·          distribution  local                    ·                              ·
 ·          vectorized    true                     ·                              ·
-render     ·             ·                        (b int, a collatedstring{da})  ·
+render     ·             ·                        (b int, a collatedstring{da})  +b,+a
  │         render 0      (b)[int]                 ·                              ·
  │         render 1      (a)[collatedstring{da}]  ·                              ·
  └── scan  ·             ·                        (a collatedstring{da}, b int)  +b,+a
@@ -1207,7 +1207,7 @@ EXPLAIN (VERBOSE) SELECT * FROM (SELECT a, a+b+c AS x FROM (SELECT * FROM abcd L
 ----
 ·               distribution  local                ·          ·
 ·               vectorized    true                 ·          ·
-render          ·             ·                    (a, x)     ·
+render          ·             ·                    (a, x)     +a
  │              render 0      a                    ·          ·
  │              render 1      c + (a + b)          ·          ·
  └── filter     ·             ·                    (a, b, c)  +a

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -110,7 +110,7 @@ EXPLAIN (VERBOSE) SELECT x, y, z, information_schema._pg_expandarray(ARRAY[x, y,
 ----
 ·                               distribution        local                                                  ·                                                ·
 ·                               vectorized          true                                                   ·                                                ·
-render                          ·                   ·                                                      (x, y, z, "information_schema._pg_expandarray")  ·
+render                          ·                   ·                                                      (x, y, z, "information_schema._pg_expandarray")  +x
  │                              render 0            x                                                      ·                                                ·
  │                              render 1            y                                                      ·                                                ·
  │                              render 2            z                                                      ·                                                ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -110,7 +110,7 @@ EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) 
 ----
 ·                         distribution  local                                                                                                               ·                                                            ·
 ·                         vectorized    true                                                                                                                ·                                                            ·
-render                    ·             ·                                                                                                                   (k int, stddev decimal)                                      ·
+render                    ·             ·                                                                                                                   (k int, stddev decimal)                                      +k
  │                        render 0      (k)[int]                                                                                                            ·                                                            ·
  │                        render 1      (stddev)[decimal]                                                                                                   ·                                                            ·
  └── sort                 ·             ·                                                                                                                   (k int, stddev decimal, variance decimal)                    +variance,+k
@@ -133,7 +133,7 @@ EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY 
 ----
 ·                              distribution  local                                                                                                               ·                                                            ·
 ·                              vectorized    true                                                                                                                ·                                                            ·
-render                         ·             ·                                                                                                                   (k int, stddev decimal)                                      ·
+render                         ·             ·                                                                                                                   (k int, stddev decimal)                                      +k
  │                             render 0      (k)[int]                                                                                                            ·                                                            ·
  │                             render 1      (stddev)[decimal]                                                                                                   ·                                                            ·
  └── sort                      ·             ·                                                                                                                   (k int, stddev decimal, variance decimal)                    +variance,+k
@@ -174,7 +174,7 @@ EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER
 ----
 ·                              distribution  local                                                                                                               ·                                                            ·
 ·                              vectorized    true                                                                                                                ·                                                            ·
-render                         ·             ·                                                                                                                   (k int, "?column?" decimal)                                  ·
+render                         ·             ·                                                                                                                   (k int, "?column?" decimal)                                  +k
  │                             render 0      (k)[int]                                                                                                            ·                                                            ·
  │                             render 1      ("?column?")[decimal]                                                                                               ·                                                            ·
  └── sort                      ·             ·                                                                                                                   ("?column?" decimal, k int, variance decimal)                +variance,+k

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -90,9 +90,7 @@ type Factory interface {
 	// more efficient version of ConstructRender.
 	// The colNames argument is optional; if it is nil, the names of the
 	// corresponding input columns are kept.
-	ConstructSimpleProject(
-		n Node, cols []NodeColumnOrdinal, colNames []string, reqOrdering OutputOrdering,
-	) (Node, error)
+	ConstructSimpleProject(n Node, cols []NodeColumnOrdinal, colNames []string) (Node, error)
 
 	// ConstructRender returns a node that applies a projection on the results of
 	// the given input node. The projection can contain new expressions. The input


### PR DESCRIPTION
Previously, `ConstructSimpleProject` method of the factory was taking in
`reqOrdering` argument. However, a "simple projection" should not be
modifying the ordering property of the streams of data because it is
a mere rearrangement of columns. Now the method extracts the required
ordering property from the input node and updates it according to the
new projection.

Release note: None