### PR TITLE
sql: add support for hash and merge joins in the new factory

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2131,25 +2131,6 @@ func (dsp *DistSQLPlanner) createPlanForJoin(
 		}
 	}
 
-	// Outline of the planning process for joins:
-	//
-	//  - We create PhysicalPlans for the left and right side. Each plan has a set
-	//    of output routers with result that will serve as input for the join.
-	//
-	//  - We merge the list of processors and streams into a single plan. We keep
-	//    track of the output routers for the left and right results.
-	//
-	//  - We add a set of joiner processors (say K of them).
-	//
-	//  - We configure the left and right output routers to send results to
-	//    these joiners, distributing rows by hash (on the join equality columns).
-	//    We are thus breaking up all input rows into K buckets such that rows
-	//    that match on the equality columns end up in the same bucket. If there
-	//    are no equality columns, we cannot distribute rows so we use a single
-	//    joiner.
-	//
-	//  - The routers of the joiner processors are the result routers of the plan.
-
 	leftPlan, err := dsp.createPhysPlanForPlanNode(planCtx, n.left.plan)
 	if err != nil {
 		return nil, err
@@ -2172,32 +2153,71 @@ func (dsp *DistSQLPlanner) createPlanForJoin(
 		return nil, err
 	}
 
-	// Nodes where we will run the join processors.
-	var nodes []roachpb.NodeID
-
 	// We initialize these properties of the joiner. They will then be used to
 	// fill in the processor spec. See descriptions for HashJoinerSpec.
-	var leftEqCols, rightEqCols []uint32
-	var leftMergeOrd, rightMergeOrd execinfrapb.Ordering
-	joinType := n.joinType
+	// Set up the equality columns and the merge ordering.
+	leftEqCols := eqCols(n.pred.leftEqualityIndices, leftMap)
+	rightEqCols := eqCols(n.pred.rightEqualityIndices, rightMap)
+	leftMergeOrd := distsqlOrdering(n.mergeJoinOrdering, leftEqCols)
+	rightMergeOrd := distsqlOrdering(n.mergeJoinOrdering, rightEqCols)
 
-	// Figure out the left and right types.
-	leftTypes := leftPlan.ResultTypes
-	rightTypes := rightPlan.ResultTypes
-
-	// Set up the equality columns.
-	if numEq := len(n.pred.leftEqualityIndices); numEq != 0 {
-		leftEqCols = eqCols(n.pred.leftEqualityIndices, leftMap)
-		rightEqCols = eqCols(n.pred.rightEqualityIndices, rightMap)
+	joinResultTypes, err := getTypesForPlanResult(n, joinToStreamColMap)
+	if err != nil {
+		return nil, err
 	}
+
+	return dsp.planJoiners(&joinPlanningInfo{
+		leftPlan:           leftPlan,
+		rightPlan:          rightPlan,
+		joinType:           n.joinType,
+		joinResultTypes:    joinResultTypes,
+		onExpr:             onExpr,
+		post:               post,
+		joinToStreamColMap: joinToStreamColMap,
+		leftEqCols:         leftEqCols,
+		rightEqCols:        rightEqCols,
+		leftEqColsAreKey:   n.pred.leftEqKey,
+		rightEqColsAreKey:  n.pred.rightEqKey,
+		leftMergeOrd:       leftMergeOrd,
+		rightMergeOrd:      rightMergeOrd,
+		// In the old execFactory we can only have either local or fully
+		// distributed plans, so checking the last stage is sufficient to get
+		// the distribution of the whole plans.
+		leftPlanDistribution:  leftPlan.GetLastStageDistribution(),
+		rightPlanDistribution: rightPlan.GetLastStageDistribution(),
+	}, n.reqOrdering), nil
+}
+
+func (dsp *DistSQLPlanner) planJoiners(
+	info *joinPlanningInfo, reqOrdering ReqOrdering,
+) *PhysicalPlan {
+	// Outline of the planning process for joins when given PhysicalPlans for
+	// the left and right side (with each plan having a set of output routers
+	// with result that will serve as input for the join).
+	//
+	//  - We merge the list of processors and streams into a single plan. We keep
+	//    track of the output routers for the left and right results.
+	//
+	//  - We add a set of joiner processors (say K of them).
+	//
+	//  - We configure the left and right output routers to send results to
+	//    these joiners, distributing rows by hash (on the join equality columns).
+	//    We are thus breaking up all input rows into K buckets such that rows
+	//    that match on the equality columns end up in the same bucket. If there
+	//    are no equality columns, we cannot distribute rows so we use a single
+	//    joiner.
+	//
+	//  - The routers of the joiner processors are the result routers of the plan.
 
 	p := MakePhysicalPlan(dsp.gatewayNodeID)
 	leftRouters, rightRouters := physicalplan.MergePlans(
-		&p.PhysicalPlan, &leftPlan.PhysicalPlan, &rightPlan.PhysicalPlan,
+		&p.PhysicalPlan, &info.leftPlan.PhysicalPlan, &info.rightPlan.PhysicalPlan,
+		info.leftPlanDistribution, info.rightPlanDistribution,
 	)
 
-	// Set up the output columns.
-	if numEq := len(n.pred.leftEqualityIndices); numEq != 0 {
+	// Nodes where we will run the join processors.
+	var nodes []roachpb.NodeID
+	if numEq := len(info.leftEqCols); numEq != 0 {
 		nodes = findJoinProcessorNodes(leftRouters, rightRouters, p.Processors)
 	} else {
 		// Without column equality, we cannot distribute the join. Run a
@@ -2213,48 +2233,21 @@ func (dsp *DistSQLPlanner) createPlanForJoin(
 		}
 	}
 
-	// Create the Core spec.
-	var core execinfrapb.ProcessorCoreUnion
-	if len(n.mergeJoinOrdering) == 0 {
-		core.HashJoiner = &execinfrapb.HashJoinerSpec{
-			LeftEqColumns:        leftEqCols,
-			RightEqColumns:       rightEqCols,
-			OnExpr:               onExpr,
-			Type:                 joinType,
-			LeftEqColumnsAreKey:  n.pred.leftEqKey,
-			RightEqColumnsAreKey: n.pred.rightEqKey,
-		}
-	} else {
-		leftMergeOrd = distsqlOrdering(n.mergeJoinOrdering, leftEqCols)
-		rightMergeOrd = distsqlOrdering(n.mergeJoinOrdering, rightEqCols)
-		core.MergeJoiner = &execinfrapb.MergeJoinerSpec{
-			LeftOrdering:         leftMergeOrd,
-			RightOrdering:        rightMergeOrd,
-			OnExpr:               onExpr,
-			Type:                 joinType,
-			LeftEqColumnsAreKey:  n.pred.leftEqKey,
-			RightEqColumnsAreKey: n.pred.rightEqKey,
-		}
-	}
-
 	p.AddJoinStage(
-		nodes, core, post, leftEqCols, rightEqCols, leftTypes, rightTypes,
-		leftMergeOrd, rightMergeOrd, leftRouters, rightRouters,
+		nodes, info.makeCoreSpec(), info.post,
+		info.leftEqCols, info.rightEqCols,
+		info.leftPlan.ResultTypes, info.rightPlan.ResultTypes,
+		info.leftMergeOrd, info.rightMergeOrd,
+		leftRouters, rightRouters,
 	)
 
-	p.PlanToStreamColMap = joinToStreamColMap
-	p.ResultTypes, err = getTypesForPlanResult(n, joinToStreamColMap)
-	if err != nil {
-		return nil, err
-	}
+	p.PlanToStreamColMap = info.joinToStreamColMap
+	p.ResultTypes = info.joinResultTypes
 
 	// Joiners may guarantee an ordering to outputs, so we ensure that
 	// ordering is propagated through the input synchronizer of the next stage.
-	// We can propagate the ordering from either side, we use the left side here.
-	// Note that n.props only has a non-empty ordering for inner joins, where it
-	// uses the mergeJoinOrdering.
-	p.SetMergeOrdering(dsp.convertOrdering(n.reqOrdering, p.PlanToStreamColMap))
-	return &p, nil
+	p.SetMergeOrdering(dsp.convertOrdering(reqOrdering, p.PlanToStreamColMap))
+	return &p
 }
 
 func (dsp *DistSQLPlanner) createPhysPlan(
@@ -2938,6 +2931,11 @@ func (dsp *DistSQLPlanner) createPlanForSetOp(
 	// Merge processors, streams, result routers, and stage counter.
 	leftRouters, rightRouters := physicalplan.MergePlans(
 		&p.PhysicalPlan, &leftPlan.PhysicalPlan, &rightPlan.PhysicalPlan,
+		// In the old execFactory we can only have either local or fully
+		// distributed plans, so checking the last stage is sufficient to get
+		// the distribution of the whole plans.
+		leftPlan.GetLastStageDistribution(),
+		rightPlan.GetLastStageDistribution(),
 	)
 
 	if n.unionType == tree.UnionOp {
@@ -2992,13 +2990,6 @@ func (dsp *DistSQLPlanner) createPlanForSetOp(
 		copy(post.OutputColumns, streamCols)
 
 		// Create the Core spec.
-		//
-		// TODO(radu): we currently only use merge joins when we have an ordering on
-		// all equality columns. We should relax this by either:
-		//  - implementing a hybrid hash/merge processor which implements merge
-		//    logic on the columns we have an ordering on, and within each merge
-		//    group uses a hashmap on the remaining columns
-		//  - or: adding a sort processor to complete the order
 		var core execinfrapb.ProcessorCoreUnion
 		if len(mergeOrdering.Columns) < len(streamCols) {
 			core.HashJoiner = &execinfrapb.HashJoinerSpec{

--- a/pkg/sql/distsql_plan_join.go
+++ b/pkg/sql/distsql_plan_join.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -56,7 +57,7 @@ func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 	var totalLimitHint int64
 	for i, t := range []struct {
 		scan      *scanNode
-		eqIndices []int
+		eqIndices []exec.NodeColumnOrdinal
 	}{
 		{
 			scan:      leftScan,
@@ -105,8 +106,15 @@ func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 
 	joinType := n.joinType
 
-	post, joinToStreamColMap := joinOutColumns(n, plans[0].PlanToStreamColMap, plans[1].PlanToStreamColMap)
-	onExpr, err := remapOnExpr(planCtx, n, plans[0].PlanToStreamColMap, plans[1].PlanToStreamColMap)
+	leftMap, rightMap := plans[0].PlanToStreamColMap, plans[1].PlanToStreamColMap
+	helper := &joinPlanningHelper{
+		numLeftCols:             n.pred.numLeftCols,
+		numRightCols:            n.pred.numRightCols,
+		leftPlanToStreamColMap:  leftMap,
+		rightPlanToStreamColMap: rightMap,
+	}
+	post, joinToStreamColMap := helper.joinOutColumns(n.joinType, n.columns)
+	onExpr, err := helper.remapOnExpr(planCtx, n.pred.onCond)
 	if err != nil {
 		return nil, false, err
 	}
@@ -228,10 +236,17 @@ func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 	return plan, true, nil
 }
 
-func joinOutColumns(
-	n *joinNode, leftPlanToStreamColMap, rightPlanToStreamColMap []int,
+// joinPlanningHelper is a utility struct that helps with the physical planning
+// of joins.
+type joinPlanningHelper struct {
+	numLeftCols, numRightCols                       int
+	leftPlanToStreamColMap, rightPlanToStreamColMap []int
+}
+
+func (h *joinPlanningHelper) joinOutColumns(
+	joinType sqlbase.JoinType, columns sqlbase.ResultColumns,
 ) (post execinfrapb.PostProcessSpec, joinToStreamColMap []int) {
-	joinToStreamColMap = makePlanToStreamColMap(len(n.columns))
+	joinToStreamColMap = makePlanToStreamColMap(len(columns))
 	post.Projection = true
 
 	// addOutCol appends to post.OutputColumns and returns the index
@@ -245,14 +260,14 @@ func joinOutColumns(
 	// The join columns are in two groups:
 	//  - the columns on the left side (numLeftCols)
 	//  - the columns on the right side (numRightCols)
-	for i := 0; i < n.pred.numLeftCols; i++ {
-		joinToStreamColMap[i] = addOutCol(uint32(leftPlanToStreamColMap[i]))
+	for i := 0; i < h.numLeftCols; i++ {
+		joinToStreamColMap[i] = addOutCol(uint32(h.leftPlanToStreamColMap[i]))
 	}
 
-	if n.pred.joinType != sqlbase.LeftSemiJoin && n.pred.joinType != sqlbase.LeftAntiJoin {
-		for i := 0; i < n.pred.numRightCols; i++ {
-			joinToStreamColMap[n.pred.numLeftCols+i] = addOutCol(
-				uint32(n.pred.numLeftCols + rightPlanToStreamColMap[i]),
+	if joinType != sqlbase.LeftSemiJoin && joinType != sqlbase.LeftAntiJoin {
+		for i := 0; i < h.numRightCols; i++ {
+			joinToStreamColMap[h.numLeftCols+i] = addOutCol(
+				uint32(h.numLeftCols + h.rightPlanToStreamColMap[i]),
 			)
 		}
 	}
@@ -263,29 +278,29 @@ func joinOutColumns(
 // remapOnExpr remaps ordinal references in the on condition (which refer to the
 // join columns as described above) to values that make sense in the joiner (0
 // to N-1 for the left input columns, N to N+M-1 for the right input columns).
-func remapOnExpr(
-	planCtx *PlanningCtx, n *joinNode, leftPlanToStreamColMap, rightPlanToStreamColMap []int,
+func (h *joinPlanningHelper) remapOnExpr(
+	planCtx *PlanningCtx, onCond tree.TypedExpr,
 ) (execinfrapb.Expression, error) {
-	if n.pred.onCond == nil {
+	if onCond == nil {
 		return execinfrapb.Expression{}, nil
 	}
 
-	joinColMap := make([]int, n.pred.numLeftCols+n.pred.numRightCols)
+	joinColMap := make([]int, h.numLeftCols+h.numRightCols)
 	idx := 0
 	leftCols := 0
-	for i := 0; i < n.pred.numLeftCols; i++ {
-		joinColMap[idx] = leftPlanToStreamColMap[i]
-		if leftPlanToStreamColMap[i] != -1 {
+	for i := 0; i < h.numLeftCols; i++ {
+		joinColMap[idx] = h.leftPlanToStreamColMap[i]
+		if h.leftPlanToStreamColMap[i] != -1 {
 			leftCols++
 		}
 		idx++
 	}
-	for i := 0; i < n.pred.numRightCols; i++ {
-		joinColMap[idx] = leftCols + rightPlanToStreamColMap[i]
+	for i := 0; i < h.numRightCols; i++ {
+		joinColMap[idx] = leftCols + h.rightPlanToStreamColMap[i]
 		idx++
 	}
 
-	return physicalplan.MakeExpression(n.pred.onCond, planCtx, joinColMap)
+	return physicalplan.MakeExpression(onCond, planCtx, joinColMap)
 }
 
 // eqCols produces a slice of ordinal references for the plan columns specified
@@ -293,7 +308,7 @@ func remapOnExpr(
 // That is: eqIndices contains a slice of plan column indexes and planToColMap
 // maps the plan column indexes to the ordinal references (index of the
 // intermediate row produced).
-func eqCols(eqIndices, planToColMap []int) []uint32 {
+func eqCols(eqIndices []exec.NodeColumnOrdinal, planToColMap []int) []uint32 {
 	eqCols := make([]uint32, len(eqIndices))
 	for i, planCol := range eqIndices {
 		eqCols[i] = uint32(planToColMap[planCol])
@@ -343,8 +358,8 @@ func useInterleavedJoin(n *joinNode) bool {
 		return false
 	}
 
-	var ancestorEqIndices []int
-	var descendantEqIndices []int
+	var ancestorEqIndices []exec.NodeColumnOrdinal
+	var descendantEqIndices []exec.NodeColumnOrdinal
 	// We are guaranteed that both of the sources are scan nodes from
 	// n.interleavedNodes().
 	if ancestor == n.left.plan.(*scanNode) {
@@ -377,8 +392,8 @@ func useInterleavedJoin(n *joinNode) bool {
 		// the index in scanNode.resultColumns. To convert the colID
 		// from the index descriptor, we can use the map provided by
 		// colIdxMap.
-		if ancestorEqIndices[info.ColIdx] != ancestor.colIdxMap[colID] ||
-			descendantEqIndices[info.ColIdx] != descendant.colIdxMap[colID] {
+		if int(ancestorEqIndices[info.ColIdx]) != ancestor.colIdxMap[colID] ||
+			int(descendantEqIndices[info.ColIdx]) != descendant.colIdxMap[colID] {
 			// The column in the ordering does not correspond to
 			// the column in the interleave prefix.
 			// We should not try to do an interleaved join.

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -76,7 +76,6 @@ func getJoinResultColumns(
 	// they must be available internally for the ON condition evaluation).
 	omitRightColumns := joinType == sqlbase.LeftSemiJoin || joinType == sqlbase.LeftAntiJoin
 
-	// Prepare the metadata for the result columns.
 	// The structure of the join data source results is like this:
 	// - all the left columns,
 	// - then all the right columns (except for anti/semi join).

--- a/pkg/sql/logictest/testdata/logic_test/distsql_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_join
@@ -54,8 +54,3 @@ query III
 SELECT pk, a, b FROM tab0 WHERE a < 10 AND b = 2 ORDER BY a DESC, pk;
 ----
 0 1 2
-
-query T
-SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.exec.query.is-distributed' AND usage_count > 0
-----
-sql.exec.query.is-distributed

--- a/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning
+++ b/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning
@@ -60,3 +60,15 @@ SELECT * FROM kv WHERE k > v
 ----
 2 1
 3 2
+
+statement ok
+INSERT INTO kv VALUES (4, NULL), (5, 3)
+
+query I
+SELECT v FROM kv ORDER BY k
+----
+1
+1
+2
+NULL
+3

--- a/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning_5node
+++ b/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning_5node
@@ -142,3 +142,23 @@ EXPLAIN SELECT k::REGCLASS FROM kv
 ----
 ·  distribution  partial
 ·  vectorized    true
+
+# Check that hash join is supported by the new factory.
+query II rowsort
+SELECT kv.k, v FROM kv, kw WHERE v = w
+----
+1  1
+2  2
+3  3
+4  4
+5  5
+
+# Check that merge join is supported by the new factory.
+query I
+SELECT kv.k FROM kv, kw WHERE kv.k = kw.k ORDER BY 1
+----
+1
+2
+3
+4
+5

--- a/pkg/sql/logictest/testdata/logic_test/hash_join
+++ b/pkg/sql/logictest/testdata/logic_test/hash_join
@@ -1,3 +1,5 @@
+# LogicTest: default-configs local-spec-planning fakedist-spec-planning
+
 statement ok
 CREATE TABLE  t1 (k INT PRIMARY KEY, v INT)
 

--- a/pkg/sql/logictest/testdata/logic_test/hash_join_dist
+++ b/pkg/sql/logictest/testdata/logic_test/hash_join_dist
@@ -66,3 +66,8 @@ SELECT small.b, large.d FROM large RIGHT HASH JOIN small ON small.b = large.c AN
 9   NULL
 12  24
 15  NULL
+
+query T
+SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.exec.query.is-distributed' AND usage_count > 0
+----
+sql.exec.query.is-distributed

--- a/pkg/sql/logictest/testdata/logic_test/merge_join
+++ b/pkg/sql/logictest/testdata/logic_test/merge_join
@@ -1,3 +1,5 @@
+# LogicTest: default-configs local-spec-planning fakedist-spec-planning
+
 # Basic tables, no nulls
 
 statement ok

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -355,17 +355,13 @@ func (ef *execFactory) ConstructHashJoin(
 	pred := makePredicate(joinType, leftSrc.columns, rightSrc.columns)
 
 	numEqCols := len(leftEqCols)
-	// Save some allocations by putting both sides in the same slice.
-	intBuf := make([]int, 2*numEqCols)
-	pred.leftEqualityIndices = intBuf[:numEqCols:numEqCols]
-	pred.rightEqualityIndices = intBuf[numEqCols:]
+	pred.leftEqualityIndices = leftEqCols
+	pred.rightEqualityIndices = rightEqCols
 	nameBuf := make(tree.NameList, 2*numEqCols)
 	pred.leftColNames = nameBuf[:numEqCols:numEqCols]
 	pred.rightColNames = nameBuf[numEqCols:]
 
 	for i := range leftEqCols {
-		pred.leftEqualityIndices[i] = int(leftEqCols[i])
-		pred.rightEqualityIndices[i] = int(rightEqCols[i])
 		pred.leftColNames[i] = tree.Name(leftSrc.columns[leftEqCols[i]].Name)
 		pred.rightColNames[i] = tree.Name(rightSrc.columns[rightEqCols[i]].Name)
 	}
@@ -412,14 +408,14 @@ func (ef *execFactory) ConstructMergeJoin(
 	if n == 0 || len(rightOrdering) != n {
 		return nil, errors.Errorf("orderings from the left and right side must be the same non-zero length")
 	}
-	pred.leftEqualityIndices = make([]int, n)
-	pred.rightEqualityIndices = make([]int, n)
+	pred.leftEqualityIndices = make([]exec.NodeColumnOrdinal, n)
+	pred.rightEqualityIndices = make([]exec.NodeColumnOrdinal, n)
 	pred.leftColNames = make(tree.NameList, n)
 	pred.rightColNames = make(tree.NameList, n)
 	for i := 0; i < n; i++ {
 		leftColIdx, rightColIdx := leftOrdering[i].ColIdx, rightOrdering[i].ColIdx
-		pred.leftEqualityIndices[i] = leftColIdx
-		pred.rightEqualityIndices[i] = rightColIdx
+		pred.leftEqualityIndices[i] = exec.NodeColumnOrdinal(leftColIdx)
+		pred.rightEqualityIndices[i] = exec.NodeColumnOrdinal(rightColIdx)
 		pred.leftColNames[i] = tree.Name(leftSrc.columns[leftColIdx].Name)
 		pred.rightColNames[i] = tree.Name(rightSrc.columns[rightColIdx].Name)
 	}


### PR DESCRIPTION
**sql: minor cleanup of joiner planning**

`joinNode.mergeJoinOrdering` is now set to non-zero length by the
optimizer only when we can use a merge join (meaning that number of
equality columns is non-zero and equals the length of the ordering we
have). This allows us to slightly simplify the setup up of the merge
joiners.

Additionally, this commit switching to using `[]exec.NodeColumnOrdinal`
instead of `int` for equality columns in `joinPredicate` which allows us
to remove one conversion step when planning hash joiners.

Also we introduce a small helper that will be reused by the follow-up
work.

Release note: None

**sql: add support for hash and merge joins in the new factory**

This commit adds implementation of `ConstructHashJoin` and
`ConstructMergeJoin` in the new factory by mostly refactoring and
reusing already existing code in the physical planner. Notably,
interleaved joins are not supported yet.

Fixes: #50291.
Addresses: #47473.

Release note: None