### PR TITLE
util: add test implementations for FastIntSet

### DIFF
--- a/pkg/util/fast_int_set.go
+++ b/pkg/util/fast_int_set.go
@@ -8,11 +8,11 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// +build !fast_int_set_small,!fast_int_set_large
+
 package util
 
 import (
-	"bytes"
-	"fmt"
 	"math/bits"
 
 	"golang.org/x/tools/container/intsets"
@@ -369,44 +369,4 @@ func (s *FastIntSet) Shift(delta int) FastIntSet {
 		result.Add(i + delta)
 	})
 	return result
-}
-
-// String returns a list representation of elements. Sequential runs of positive
-// numbers are shown as ranges. For example, for the set {0, 1, 2, 5, 6, 10},
-// the output is "(0-2,5,6,10)".
-func (s FastIntSet) String() string {
-	var buf bytes.Buffer
-	buf.WriteByte('(')
-	appendRange := func(start, end int) {
-		if buf.Len() > 1 {
-			buf.WriteByte(',')
-		}
-		if start == end {
-			fmt.Fprintf(&buf, "%d", start)
-		} else if start+1 == end {
-			fmt.Fprintf(&buf, "%d,%d", start, end)
-		} else {
-			fmt.Fprintf(&buf, "%d-%d", start, end)
-		}
-	}
-	rangeStart, rangeEnd := -1, -1
-	s.ForEach(func(i int) {
-		if i < 0 {
-			appendRange(i, i)
-			return
-		}
-		if rangeStart != -1 && rangeEnd == i-1 {
-			rangeEnd = i
-		} else {
-			if rangeStart != -1 {
-				appendRange(rangeStart, rangeEnd)
-			}
-			rangeStart, rangeEnd = i, i
-		}
-	})
-	if rangeStart != -1 {
-		appendRange(rangeStart, rangeEnd)
-	}
-	buf.WriteByte(')')
-	return buf.String()
 }

--- a/pkg/util/fast_int_set_large.go
+++ b/pkg/util/fast_int_set_large.go
@@ -1,0 +1,15 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build fast_int_set_large
+
+package util
+
+var fastIntSetAlwaysSmall = false

--- a/pkg/util/fast_int_set_small.go
+++ b/pkg/util/fast_int_set_small.go
@@ -1,0 +1,15 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build fast_int_set_small
+
+package util
+
+var fastIntSetAlwaysSmall = true

--- a/pkg/util/fast_int_set_str.go
+++ b/pkg/util/fast_int_set_str.go
@@ -1,0 +1,56 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package util
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// String returns a list representation of elements. Sequential runs of positive
+// numbers are shown as ranges. For example, for the set {0, 1, 2, 5, 6, 10},
+// the output is "(0-2,5,6,10)".
+func (s FastIntSet) String() string {
+	var buf bytes.Buffer
+	buf.WriteByte('(')
+	appendRange := func(start, end int) {
+		if buf.Len() > 1 {
+			buf.WriteByte(',')
+		}
+		if start == end {
+			fmt.Fprintf(&buf, "%d", start)
+		} else if start+1 == end {
+			fmt.Fprintf(&buf, "%d,%d", start, end)
+		} else {
+			fmt.Fprintf(&buf, "%d-%d", start, end)
+		}
+	}
+	rangeStart, rangeEnd := -1, -1
+	s.ForEach(func(i int) {
+		if i < 0 {
+			appendRange(i, i)
+			return
+		}
+		if rangeStart != -1 && rangeEnd == i-1 {
+			rangeEnd = i
+		} else {
+			if rangeStart != -1 {
+				appendRange(rangeStart, rangeEnd)
+			}
+			rangeStart, rangeEnd = i, i
+		}
+	})
+	if rangeStart != -1 {
+		appendRange(rangeStart, rangeEnd)
+	}
+	buf.WriteByte(')')
+	return buf.String()
+}

--- a/pkg/util/fast_int_set_test.go
+++ b/pkg/util/fast_int_set_test.go
@@ -68,6 +68,7 @@ func TestFastIntSet(t *testing.T) {
 					t.Fatalf("set built with Next doesn't match Ordered: %v vs %v", vals, o)
 				}
 				assertSame := func(orig, copy FastIntSet) {
+					t.Helper()
 					if !orig.Equals(copy) || !copy.Equals(orig) {
 						t.Fatalf("expected equality: %v, %v", orig, copy)
 					}

--- a/pkg/util/fast_int_set_testonly.go
+++ b/pkg/util/fast_int_set_testonly.go
@@ -1,0 +1,220 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// +build fast_int_set_small fast_int_set_large
+
+// This file implements two variants of FastIntSet used for testing which always
+// behaves like in either the "small" or "large" case (depending on
+// fastIntSetAlwaysSmall). Tests that exhibit a difference when using one of
+// these variants indicates a bug.
+
+package util
+
+import "golang.org/x/tools/container/intsets"
+
+// FastIntSet keeps track of a set of integers. It does not perform any
+// allocations when the values are small. It is not thread-safe.
+type FastIntSet struct {
+	// Used to keep the size of the struct the same.
+	_ uint64
+	s *intsets.Sparse
+}
+
+// MakeFastIntSet returns a set initialized with the given values.
+func MakeFastIntSet(vals ...int) FastIntSet {
+	var res FastIntSet
+	for _, v := range vals {
+		res.Add(v)
+	}
+	return res
+}
+
+func (s *FastIntSet) prepareForMutation() {
+	if s.s == nil {
+		s.s = &intsets.Sparse{}
+	} else if fastIntSetAlwaysSmall {
+		// We always make a full copy to prevent any aliasing; this simulates the
+		// semantics of the "small" regime of FastIntSet.
+		*s = s.Copy()
+	}
+}
+
+// Add adds a value to the set. No-op if the value is already in the set.
+func (s *FastIntSet) Add(i int) {
+	s.prepareForMutation()
+	s.s.Insert(i)
+}
+
+// AddRange adds values 'from' up to 'to' (inclusively) to the set.
+// E.g. AddRange(1,5) adds the values 1, 2, 3, 4, 5 to the set.
+// 'to' must be >= 'from'.
+// AddRange is always more efficient than individual Adds.
+func (s *FastIntSet) AddRange(from, to int) {
+	s.prepareForMutation()
+	for i := from; i <= to; i++ {
+		s.s.Insert(i)
+	}
+}
+
+// Remove removes a value from the set. No-op if the value is not in the set.
+func (s *FastIntSet) Remove(i int) {
+	s.prepareForMutation()
+	s.s.Remove(i)
+}
+
+// Contains returns true if the set contains the value.
+func (s FastIntSet) Contains(i int) bool {
+	return s.s != nil && s.s.Has(i)
+}
+
+// Empty returns true if the set is empty.
+func (s FastIntSet) Empty() bool {
+	return s.s == nil || s.s.IsEmpty()
+}
+
+// Len returns the number of the elements in the set.
+func (s FastIntSet) Len() int {
+	if s.s == nil {
+		return 0
+	}
+	return s.s.Len()
+}
+
+// Next returns the first value in the set which is >= startVal. If there is no
+// value, the second return value is false.
+func (s FastIntSet) Next(startVal int) (int, bool) {
+	if s.s == nil {
+		return intsets.MaxInt, false
+	}
+	res := s.s.LowerBound(startVal)
+	return res, res != intsets.MaxInt
+}
+
+// ForEach calls a function for each value in the set (in increasing order).
+func (s FastIntSet) ForEach(f func(i int)) {
+	if s.s == nil {
+		return
+	}
+	for x := s.s.Min(); x != intsets.MaxInt; x = s.s.LowerBound(x + 1) {
+		f(x)
+	}
+}
+
+// Ordered returns a slice with all the integers in the set, in increasing order.
+func (s FastIntSet) Ordered() []int {
+	if s.Empty() {
+		return nil
+	}
+	return s.s.AppendTo([]int(nil))
+}
+
+// Copy returns a copy of s which can be modified independently.
+func (s FastIntSet) Copy() FastIntSet {
+	n := &intsets.Sparse{}
+	if s.s != nil {
+		n.Copy(s.s)
+	}
+	return FastIntSet{s: n}
+}
+
+// CopyFrom sets the receiver to a copy of other, which can then be modified
+// independently.
+func (s *FastIntSet) CopyFrom(other FastIntSet) {
+	*s = other.Copy()
+}
+
+// UnionWith adds all the elements from rhs to this set.
+func (s *FastIntSet) UnionWith(rhs FastIntSet) {
+	if rhs.s == nil {
+		return
+	}
+	s.prepareForMutation()
+	s.s.UnionWith(rhs.s)
+}
+
+// Union returns the union of s and rhs as a new set.
+func (s FastIntSet) Union(rhs FastIntSet) FastIntSet {
+	r := s.Copy()
+	r.UnionWith(rhs)
+	return r
+}
+
+// IntersectionWith removes any elements not in rhs from this set.
+func (s *FastIntSet) IntersectionWith(rhs FastIntSet) {
+	if rhs.s == nil {
+		*s = FastIntSet{}
+		return
+	}
+	s.prepareForMutation()
+	s.s.IntersectionWith(rhs.s)
+}
+
+// Intersection returns the intersection of s and rhs as a new set.
+func (s FastIntSet) Intersection(rhs FastIntSet) FastIntSet {
+	r := s.Copy()
+	r.IntersectionWith(rhs)
+	return r
+}
+
+// Intersects returns true if s has any elements in common with rhs.
+func (s FastIntSet) Intersects(rhs FastIntSet) bool {
+	if s.s == nil || rhs.s == nil {
+		return false
+	}
+	return s.s.Intersects(rhs.s)
+}
+
+// DifferenceWith removes any elements in rhs from this set.
+func (s *FastIntSet) DifferenceWith(rhs FastIntSet) {
+	if rhs.s == nil {
+		return
+	}
+	s.prepareForMutation()
+	s.s.DifferenceWith(rhs.s)
+}
+
+// Difference returns the elements of s that are not in rhs as a new set.
+func (s FastIntSet) Difference(rhs FastIntSet) FastIntSet {
+	r := s.Copy()
+	r.DifferenceWith(rhs)
+	return r
+}
+
+// Equals returns true if the two sets are identical.
+func (s FastIntSet) Equals(rhs FastIntSet) bool {
+	if s.Empty() || rhs.Empty() {
+		return s.Empty() == rhs.Empty()
+	}
+	return s.s.Equals(rhs.s)
+}
+
+// SubsetOf returns true if rhs contains all the elements in s.
+func (s FastIntSet) SubsetOf(rhs FastIntSet) bool {
+	if s.Empty() {
+		return true
+	}
+	if rhs.s == nil {
+		return false
+	}
+	return s.s.SubsetOf(rhs.s)
+}
+
+// Shift generates a new set which contains elements i+delta for elements i in
+// the original set.
+func (s *FastIntSet) Shift(delta int) FastIntSet {
+	n := &intsets.Sparse{}
+	s.ForEach(func(i int) {
+		n.Insert(i + delta)
+	})
+	return FastIntSet{s: n}
+}
+
+// This is defined to allow the test to build.
+const smallCutoff = 10


### PR DESCRIPTION
FastIntSet has different aliasing behavior when copied by value
depending if it is operating in the "small" or "large" regime. If the
API is misused, some bugs only show up in one of the regimes.

Traditionally, we ran all tests with smallCutoff=2 before each
release. However, this does not catch bugs where existing tests were
already operating in the "large" regime (such a case was uncovered
recently).

This commit adds two test-only implementations, which make the set
always operate in either the small or large regime. They can be used
by passing `TAGS=fast_int_set_small` or `TAGS=fast_int_set_large`.

Release note: None