### PR TITLE
opt: avoid direct colset assignment when computing rejectnullcols

### DIFF
--- a/pkg/sql/opt/norm/reject_nulls_funcs.go
+++ b/pkg/sql/opt/norm/reject_nulls_funcs.go
@@ -93,17 +93,17 @@ func DeriveRejectNullCols(in memo.RelExpr) opt.ColSet {
 	case opt.RightJoinOp:
 		// Pass through null-rejection columns from right input, and request null-
 		// rejection on left columns.
-		relProps.Rule.RejectNullCols = in.Child(0).(memo.RelExpr).Relational().OutputCols
+		relProps.Rule.RejectNullCols.UnionWith(in.Child(0).(memo.RelExpr).Relational().OutputCols)
 		if in.Child(1).(memo.RelExpr).Relational().OuterCols.Empty() {
 			relProps.Rule.RejectNullCols.UnionWith(DeriveRejectNullCols(in.Child(1).(memo.RelExpr)))
 		}
 
 	case opt.FullJoinOp:
 		// Request null-rejection on all output columns.
-		relProps.Rule.RejectNullCols = relProps.OutputCols
+		relProps.Rule.RejectNullCols.UnionWith(relProps.OutputCols)
 
 	case opt.GroupByOp, opt.ScalarGroupByOp:
-		relProps.Rule.RejectNullCols = deriveGroupByRejectNullCols(in)
+		relProps.Rule.RejectNullCols.UnionWith(deriveGroupByRejectNullCols(in))
 
 	case opt.ProjectOp:
 		// Pass through all null-rejection columns that the Project passes through.

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -197,11 +197,11 @@ project
  │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null t.oid:32 spcname:33 i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72 indrelid:73 indisclustered:79
  │    │    │         │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,32,33), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73)
  │    │    │         │    │    │    ├── select
- │    │    │         │    │    │    │    ├── columns: i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72!null indrelid:73!null indisclustered:79!null
+ │    │    │         │    │    │    │    ├── columns: indexrelid:72!null indrelid:73!null indisclustered:79!null
  │    │    │         │    │    │    │    ├── key: (72)
  │    │    │         │    │    │    │    ├── fd: ()-->(79), (72)-->(73)
  │    │    │         │    │    │    │    ├── scan ind
- │    │    │         │    │    │    │    │    ├── columns: i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72!null indrelid:73!null indisclustered:79!null
+ │    │    │         │    │    │    │    │    ├── columns: indexrelid:72!null indrelid:73!null indisclustered:79!null
  │    │    │         │    │    │    │    │    ├── key: (72)
  │    │    │         │    │    │    │    │    └── fd: (72)-->(73,79)
  │    │    │         │    │    │    │    └── filters

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -201,11 +201,11 @@ sort
       │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:28!null n.nspname:29!null t.oid:32 spcname:33 i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72 indrelid:73 indisclustered:79
       │    │    │         │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,32,33), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73)
       │    │    │         │    │    │    ├── select
-      │    │    │         │    │    │    │    ├── columns: i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72!null indrelid:73!null indisclustered:79!null
+      │    │    │         │    │    │    │    ├── columns: indexrelid:72!null indrelid:73!null indisclustered:79!null
       │    │    │         │    │    │    │    ├── key: (72)
       │    │    │         │    │    │    │    ├── fd: ()-->(79), (72)-->(73)
       │    │    │         │    │    │    │    ├── scan ind
-      │    │    │         │    │    │    │    │    ├── columns: i.inhrelid:38 i.inhparent:39 c2.oid:41 c2.relname:42 c2.relnamespace:43 n2.oid:68 n2.nspname:69 indexrelid:72!null indrelid:73!null indisclustered:79!null
+      │    │    │         │    │    │    │    │    ├── columns: indexrelid:72!null indrelid:73!null indisclustered:79!null
       │    │    │         │    │    │    │    │    ├── key: (72)
       │    │    │         │    │    │    │    │    └── fd: (72)-->(73,79)
       │    │    │         │    │    │    │    └── filters


### PR DESCRIPTION
Previously, codes in DeriveRejectNullCols directly assign related
property of type ColSet in child expression to property RejectNullCols in father
expression, thus computation on RejectNullCols in father expression lead to
change in property in child expression if the property contains column
ID larger than 63.
This commit replace these direct assignments in DeriveRejectNullCols with
copying, eliminating this phenomenon.

Release note: None