### PR TITLE
release-20.1: opt: fix selectivity estimation for multi-span index constraint

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -567,40 +567,100 @@ func (sb *statisticsBuilder) buildScan(scan *ScanExpr, relProps *props.Relationa
 	inputStats := sb.makeTableStatistics(scan.Table)
 	s.RowCount = inputStats.RowCount
 
-	if scan.Constraint != nil {
-		// Calculate distinct counts and histograms for constrained columns
-		// ----------------------------------------------------------------
-		var numUnappliedConjuncts float64
-		var constrainedCols, histCols opt.ColSet
-		// Inverted indexes are a special case; a constraint like:
-		// /1: [/'{"a": "b"}' - /'{"a": "b"}']
-		// does not necessarily mean there is only going to be one distinct
-		// value for column 1, if it is being applied to an inverted index.
-		// This is because inverted index keys could correspond to partial
-		// column values, such as one path-to-a-leaf through a JSON object.
+	if scan.Constraint != nil && scan.Constraint.Spans.Count() < 2 {
+		// This constraint has at most one span.
+		sb.constrainScan(scan, scan.Constraint, relProps, s)
+	} else if scan.Constraint != nil {
+		// There are multiple spans in this constraint. To calculate the row
+		// count and selectivity, split the spans up and apply each one
+		// separately, then union the result. This is important for correctly
+		// handling a constraint such as:
 		//
-		// For now, don't apply constraints on inverted index columns.
-		if sb.md.Table(scan.Table).Index(scan.Index).IsInverted() {
-			for i, n := 0, scan.Constraint.ConstrainedColumns(sb.evalCtx); i < n; i++ {
-				numUnappliedConjuncts += sb.numConjunctsInConstraint(scan.Constraint, i)
-			}
-		} else {
-			constrainedCols, histCols = sb.applyIndexConstraint(scan.Constraint, scan, relProps)
+		//   /a/b: [/5 - /5] [/NULL/5 - /NULL/5]
+		//
+		// If we didn't split the spans, the selectivity of column b would be
+		// completely ignored, and the calculated row count would be too high.
+
+		var spanStats, spanStatsUnion props.Statistics
+		var c constraint.Constraint
+		keyCtx := constraint.KeyContext{EvalCtx: sb.evalCtx, Columns: scan.Constraint.Columns}
+
+		// Make a copy of the stats so we don't modify the original.
+		spanStatsUnion.CopyFrom(s)
+
+		// Get the stats for each span and union them together.
+		c.InitSingleSpan(&keyCtx, scan.Constraint.Spans.Get(0))
+		sb.constrainScan(scan, &c, relProps, &spanStatsUnion)
+		for i, n := 1, scan.Constraint.Spans.Count(); i < n; i++ {
+			spanStats.CopyFrom(s)
+			c.InitSingleSpan(&keyCtx, scan.Constraint.Spans.Get(i))
+			sb.constrainScan(scan, &c, relProps, &spanStats)
+			spanStatsUnion.UnionWith(&spanStats)
 		}
 
-		// Set null counts to 0 for non-nullable columns
-		// ---------------------------------------------
-		sb.updateNullCountsFromProps(scan, relProps)
+		// Now that we have the correct row count, use the combined spans to get
+		// the correct column stats.
+		sb.constrainScan(scan, scan.Constraint, relProps, s)
 
-		// Calculate row count and selectivity
-		// -----------------------------------
-		s.ApplySelectivity(sb.selectivityFromHistograms(histCols, scan, s))
-		s.ApplySelectivity(sb.selectivityFromDistinctCounts(constrainedCols.Difference(histCols), scan, s))
-		s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(numUnappliedConjuncts))
-		s.ApplySelectivity(sb.selectivityFromNullsRemoved(scan, relProps, constrainedCols))
+		// Copy in the row count and selectivity that were calculated above, if
+		// less than the values calculated from the combined spans.
+		//
+		// We must take the minimum in case we used unknownFilterSelectivity for
+		// some of the spans. For example, if no histogram is available for the
+		// constraint /1: [/'a' - /'b'] [/'c' - /'d'] [/'e' - /'f'], we would
+		// calculate selectivity = 1/9 + 1/9 + 1/9 = 1/3 in spanStatsUnion, which
+		// is too high. Instead, we should use the value calculated from the
+		// combined spans, which in this case is simply 1/9.
+		s.Selectivity = min(s.Selectivity, spanStatsUnion.Selectivity)
+		s.RowCount = min(s.RowCount, spanStatsUnion.RowCount)
 	}
 
 	sb.finalizeFromCardinality(relProps)
+}
+
+// constrainScan is called from buildScan to calculate the stats for the scan
+// based on the given constraint.
+func (sb *statisticsBuilder) constrainScan(
+	scan *ScanExpr,
+	constraint *constraint.Constraint,
+	relProps *props.Relational,
+	s *props.Statistics,
+) {
+	// Calculate distinct counts and histograms for constrained columns
+	// ----------------------------------------------------------------
+	var numUnappliedConjuncts float64
+	var constrainedCols, histCols opt.ColSet
+	// Inverted indexes are a special case; a constraint like:
+	// /1: [/'{"a": "b"}' - /'{"a": "b"}']
+	// does not necessarily mean there is only going to be one distinct
+	// value for column 1, if it is being applied to an inverted index.
+	// This is because inverted index keys could correspond to partial
+	// column values, such as one path-to-a-leaf through a JSON object.
+	//
+	// For now, don't apply constraints on inverted index columns.
+	if sb.md.Table(scan.Table).Index(scan.Index).IsInverted() {
+		for i, n := 0, constraint.ConstrainedColumns(sb.evalCtx); i < n; i++ {
+			numUnappliedConjuncts += sb.numConjunctsInConstraint(constraint, i)
+		}
+	} else {
+		constrainedCols, histCols = sb.applyIndexConstraint(constraint, scan, relProps, s)
+	}
+
+	// Set null counts to 0 for non-nullable columns
+	// ---------------------------------------------
+	notNullCols := relProps.NotNullCols
+	if constraint != nil {
+		// Add any not-null columns from this constraint.
+		notNullCols = notNullCols.Union(constraint.ExtractNotNullCols(sb.evalCtx))
+	}
+	sb.updateNullCountsFromNotNullCols(scan, notNullCols, s)
+
+	// Calculate row count and selectivity
+	// -----------------------------------
+	s.ApplySelectivity(sb.selectivityFromHistograms(histCols, scan, s))
+	s.ApplySelectivity(sb.selectivityFromDistinctCounts(constrainedCols.Difference(histCols), scan, s))
+	s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(numUnappliedConjuncts))
+	s.ApplySelectivity(sb.selectivityFromNullsRemoved(scan, relProps, constrainedCols))
 }
 
 func (sb *statisticsBuilder) colStatScan(colSet opt.ColSet, scan *ScanExpr) *props.ColumnStatistic {
@@ -686,7 +746,7 @@ func (sb *statisticsBuilder) buildSelect(sel *SelectExpr, relProps *props.Relati
 
 	// Set null counts to 0 for non-nullable columns
 	// -------------------------------------------
-	sb.updateNullCountsFromProps(sel, relProps)
+	sb.updateNullCountsFromNotNullCols(sel, relProps.NotNullCols, s)
 
 	// Calculate selectivity and row count
 	// -----------------------------------
@@ -915,7 +975,7 @@ func (sb *statisticsBuilder) buildJoin(
 
 	// Set null counts to 0 for non-nullable columns
 	// ---------------------------------------------
-	sb.updateNullCountsFromProps(join, relProps)
+	sb.updateNullCountsFromNotNullCols(join, relProps.NotNullCols, s)
 
 	// Calculate selectivity and row count
 	// -----------------------------------
@@ -1021,7 +1081,7 @@ func (sb *statisticsBuilder) buildJoin(
 			rightSideCols,
 		)
 
-		// Update all null counts not zeroed out in updateNullCountsFromProps
+		// Update all null counts not zeroed out in updateNullCountsFromNotNullCols
 		// to equal the inner join count, instead of what it currently is (either
 		// leftNullCount or rightNullCount).
 		if colStat.NullCount != 0 {
@@ -1452,7 +1512,7 @@ func (sb *statisticsBuilder) buildZigzagJoin(
 
 	// Set null counts to 0 for non-nullable columns
 	// ---------------------------------------------
-	sb.updateNullCountsFromProps(zigzag, relProps)
+	sb.updateNullCountsFromNotNullCols(zigzag, relProps.NotNullCols, s)
 
 	// Calculate selectivity and row count
 	// -----------------------------------
@@ -2261,10 +2321,8 @@ func (sb *statisticsBuilder) copyColStatFromChild(
 // Then, ensureColStat sets the distinct count to the minimum of the existing
 // value and the new value.
 func (sb *statisticsBuilder) ensureColStat(
-	colSet opt.ColSet, maxDistinctCount float64, e RelExpr, relProps *props.Relational,
+	colSet opt.ColSet, maxDistinctCount float64, e RelExpr, s *props.Statistics,
 ) *props.ColumnStatistic {
-	s := &relProps.Stats
-
 	colStat, ok := s.ColStats.Lookup(colSet)
 	if !ok {
 		colStat, _ = sb.colStatFromInput(colSet, e)
@@ -2635,7 +2693,7 @@ func (sb *statisticsBuilder) applyFilter(
 // for the constrained columns in an index constraint. Returns the set of
 // constrained columns and the set of columns with a filtered histogram.
 func (sb *statisticsBuilder) applyIndexConstraint(
-	c *constraint.Constraint, e RelExpr, relProps *props.Relational,
+	c *constraint.Constraint, e RelExpr, relProps *props.Relational, s *props.Statistics,
 ) (constrainedCols, histCols opt.ColSet) {
 	// If unconstrained, then no constraint could be derived from the expression,
 	// so fall back to estimate.
@@ -2646,7 +2704,7 @@ func (sb *statisticsBuilder) applyIndexConstraint(
 	}
 
 	// Calculate distinct counts.
-	applied, lastColMinDistinct := sb.updateDistinctCountsFromConstraint(c, e, relProps)
+	applied, lastColMinDistinct := sb.updateDistinctCountsFromConstraint(c, e, s)
 	for i, n := 0, c.ConstrainedColumns(sb.evalCtx); i < n; i++ {
 		col := c.Columns.Get(i).ID()
 		constrainedCols.Add(col)
@@ -2665,7 +2723,7 @@ func (sb *statisticsBuilder) applyIndexConstraint(
 		if i == applied {
 			lowerBound = lastColMinDistinct
 		}
-		sb.updateDistinctCountFromUnappliedConjuncts(col, e, relProps, numConjuncts, lowerBound)
+		sb.updateDistinctCountFromUnappliedConjuncts(col, e, s, numConjuncts, lowerBound)
 	}
 
 	if !sb.shouldUseHistogram(relProps) {
@@ -2676,7 +2734,6 @@ func (sb *statisticsBuilder) applyIndexConstraint(
 	inputStat, _ := sb.colStatFromInput(constrainedCols, e)
 	inputHist := inputStat.Histogram
 	if inputHist != nil && inputHist.CanFilter(c) {
-		s := &relProps.Stats
 		if colStat, ok := s.ColStats.Lookup(constrainedCols); ok {
 			colStat.Histogram = inputHist.Filter(c)
 			histCols = constrainedCols
@@ -2707,7 +2764,7 @@ func (sb *statisticsBuilder) applyConstraintSet(
 		col := c.Columns.Get(0).ID()
 
 		// Calculate distinct counts.
-		applied, lastColMinDistinct := sb.updateDistinctCountsFromConstraint(c, e, relProps)
+		applied, lastColMinDistinct := sb.updateDistinctCountsFromConstraint(c, e, s)
 		if applied == 0 {
 			// If a constraint cannot be applied, it may represent an
 			// inequality like x < 1. As a result, distinctCounts does not fully
@@ -2718,7 +2775,7 @@ func (sb *statisticsBuilder) applyConstraintSet(
 
 			// Set the distinct count for the first column of the constraint
 			// according to unknownDistinctCountRatio.
-			sb.updateDistinctCountFromUnappliedConjuncts(col, e, relProps, numConjuncts, lastColMinDistinct)
+			sb.updateDistinctCountFromUnappliedConjuncts(col, e, s, numConjuncts, lastColMinDistinct)
 		}
 
 		if !tight {
@@ -2747,7 +2804,7 @@ func (sb *statisticsBuilder) applyConstraintSet(
 	return histCols
 }
 
-// updateNullCountsFromProps zeroes null counts for columns that cannot
+// updateNullCountsFromNotNullCols zeroes null counts for columns that cannot
 // have nulls in them, usually due to a column property or an application.
 // of a null-excluding filter. The actual determination of non-nullable
 // columns is done in the logical props builder.
@@ -2759,9 +2816,10 @@ func (sb *statisticsBuilder) applyConstraintSet(
 // The first constraint set filters nulls out of column a, and the
 // second constraint set filters nulls out of column c.
 //
-func (sb *statisticsBuilder) updateNullCountsFromProps(e RelExpr, relProps *props.Relational) {
-	s := &relProps.Stats
-	relProps.NotNullCols.ForEach(func(col opt.ColumnID) {
+func (sb *statisticsBuilder) updateNullCountsFromNotNullCols(
+	e RelExpr, notNullCols opt.ColSet, s *props.Statistics,
+) {
+	notNullCols.ForEach(func(col opt.ColumnID) {
 		colSet := opt.MakeColSet(col)
 		colStat, ok := s.ColStats.Lookup(colSet)
 		if ok {
@@ -2811,7 +2869,7 @@ func (sb *statisticsBuilder) updateNullCountsFromProps(e RelExpr, relProps *prop
 // are at least two distinct values (10 and 15). This lower bound will be
 // returned in the second return value, lastColMinDistinct.
 func (sb *statisticsBuilder) updateDistinctCountsFromConstraint(
-	c *constraint.Constraint, e RelExpr, relProps *props.Relational,
+	c *constraint.Constraint, e RelExpr, s *props.Statistics,
 ) (applied int, lastColMinDistinct float64) {
 	// All of the columns that are part of the prefix have a finite number of
 	// distinct values.
@@ -2906,7 +2964,7 @@ func (sb *statisticsBuilder) updateDistinctCountsFromConstraint(
 		}
 
 		colID := c.Columns.Get(col).ID()
-		sb.ensureColStat(opt.MakeColSet(colID), distinctCount, e, relProps)
+		sb.ensureColStat(opt.MakeColSet(colID), distinctCount, e, s)
 		applied = col + 1
 	}
 
@@ -2918,13 +2976,13 @@ func (sb *statisticsBuilder) updateDistinctCountsFromConstraint(
 // The provided lowerBound serves as a lower bound on the calculated distinct
 // count.
 func (sb *statisticsBuilder) updateDistinctCountFromUnappliedConjuncts(
-	colID opt.ColumnID, e RelExpr, relProps *props.Relational, numConjuncts, lowerBound float64,
+	colID opt.ColumnID, e RelExpr, s *props.Statistics, numConjuncts, lowerBound float64,
 ) {
 	colSet := opt.MakeColSet(colID)
 	inputStat, _ := sb.colStatFromInput(colSet, e)
 	distinctCount := inputStat.DistinctCount * math.Pow(unknownFilterSelectivity, numConjuncts)
 	distinctCount = max(distinctCount, lowerBound)
-	sb.ensureColStat(colSet, distinctCount, e, relProps)
+	sb.ensureColStat(colSet, distinctCount, e, s)
 }
 
 // updateDistinctCountFromHistogram updates the distinct count for the given

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -124,7 +124,7 @@ func TestGetStatsFromConstraint(t *testing.T) {
 		s.ApplySelectivity(sb.selectivityFromDistinctCounts(cols, sel, s))
 
 		// Update null counts.
-		sb.updateNullCountsFromProps(sel, relProps)
+		sb.updateNullCountsFromNotNullCols(sel, relProps.NotNullCols, s)
 
 		// Check if the statistics match the expected value.
 		testStats(t, s, expectedStats, expectedSelectivity)

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -874,3 +874,78 @@ select
  │         └── fd: (8)-->(2)
  └── filters
       └── (a:1 = 30) OR (a:1 = 40) [type=bool, outer=(1), constraints=(/1: [/30 - /30] [/40 - /40]; tight)]
+
+# Regression test for #50409.
+exec-ddl
+CREATE TABLE t (
+  x int primary key,
+  y int,
+  z int,
+  s string,
+  index (y),
+  index (s)
+)
+----
+
+exec-ddl
+ALTER TABLE t INJECT STATISTICS'[
+  {
+    "columns": ["x"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 1000
+  },
+  {
+    "columns": ["y"],
+    "created_at": "2018-01-01 1:30:00.00000+00:00",
+    "row_count": 1000,
+    "null_count": 500,
+    "distinct_count": 500
+  }
+]'
+----
+
+# The row count estimate of the scan should be approximately 2, to account for
+# the selectivity of the predicate on x. If the selectivity of x is ignored,
+# the row count estimate rises to 501 (and the index join is no longer chosen).
+opt
+SELECT * FROM t WHERE (y IS NULL AND x = 5) OR y = 5
+----
+index-join t
+ ├── columns: x:1(int!null) y:2(int) z:3(int) s:4(string)
+ ├── stats: [rows=167.000668, distinct(2)=2, null(2)=167.000668]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ └── select
+      ├── columns: x:1(int!null) y:2(int)
+      ├── stats: [rows=0.500668003, distinct(2)=0.500668003, null(2)=0.500668003]
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── scan t@secondary
+      │    ├── columns: x:1(int!null) y:2(int)
+      │    ├── constraint: /2/1
+      │    │    ├── [/NULL/5 - /NULL/5]
+      │    │    └── [/5 - /5]
+      │    ├── stats: [rows=1.50200401, distinct(1)=1.50200401, null(1)=0, distinct(2)=1.50200401, null(2)=1.50200401]
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           └── ((y:2 IS NULL) AND (x:1 = 5)) OR (y:2 = 5) [type=bool, outer=(1,2), constraints=(/2: [/NULL - /NULL] [/5 - /5])]
+
+opt
+SELECT * FROM t WHERE (s >= 'a' AND s <= 'b') OR  (s >= 'c' AND s <= 'd') OR (s >= 'e' AND s <= 'f')
+----
+index-join t
+ ├── columns: x:1(int!null) y:2(int) z:3(int) s:4(string!null)
+ ├── stats: [rows=111.111111, distinct(4)=11.1111111, null(4)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ └── scan t@secondary
+      ├── columns: x:1(int!null) s:4(string!null)
+      ├── constraint: /4/1
+      │    ├── [/'a' - /'b']
+      │    ├── [/'c' - /'d']
+      │    └── [/'e' - /'f']
+      ├── stats: [rows=111.111111, distinct(4)=11.1111111, null(4)=0]
+      ├── key: (1)
+      └── fd: (1)-->(4)

--- a/pkg/sql/opt/props/statistics.go
+++ b/pkg/sql/opt/props/statistics.go
@@ -87,13 +87,23 @@ func (s *Statistics) CopyFrom(other *Statistics) {
 }
 
 // ApplySelectivity applies a given selectivity to the statistics. RowCount and
-// Selectivity are updated. Note that DistinctCounts and NullCounts are not
-// updated.
-// See ColumnStatistic.ApplySelectivity for updating distinct counts and null
-// counts.
+// Selectivity are updated. Note that DistinctCounts, NullCounts, and
+// Histograms are not updated.
+// See ColumnStatistic.ApplySelectivity for updating distinct counts, null
+// counts, and histograms.
 func (s *Statistics) ApplySelectivity(selectivity float64) {
 	s.RowCount *= selectivity
 	s.Selectivity *= selectivity
+}
+
+// UnionWith unions this Statistics object with another Statistics object. It
+// updates the RowCount and Selectivity, and represents the result of unioning
+// two relational expressions with the given statistics. Note that
+// DistinctCounts, NullCounts, and Histograms are not updated.
+func (s *Statistics) UnionWith(other *Statistics) {
+	s.Available = s.Available && other.Available
+	s.RowCount += other.RowCount
+	s.Selectivity += other.Selectivity
 }
 
 func (s *Statistics) String() string {


### PR DESCRIPTION
Backport 1/1 commits from #50456.

/cc @cockroachdb/release

---

Prior to this commit, the optimizer was incorrectly estimating the
selectivity of some multi-span index constraints. For example, for
the constraint:
```
 /a/b: [/5 - /5] [/NULL/5 - /NULL/5]
```
the `statisticsBuilder` was estimating its selectivity to be equivalent
to:
```
 /a/b: [/5 - /5] [/NULL - /NULL]
```
Essentially, it was completely ignoring the selectivity of column `b`,
and therefore the estimated row count was too high.

This commit fixes the issue by splitting up the spans, calculating the
selectivity for each span individually, and then unioning the results.

Fixes #50409

Release note (performance improvement): Improved the optimizer's
estimation of the selectivity of some filters involving a disjunction
(OR) of predicates over multiple columns. This results in more accurate
cardinality estimation and enables the optimizer to choose better
query plans in some cases.
