### PR TITLE
workload/ycsb: correctly populate columns during import

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -267,7 +267,7 @@ func TestDeterministicInitialData(t *testing.T) {
 		`startrek`:   0xa0249fbdf612734c,
 		`tpcc`:       0xab32e4f5e899eb2f,
 		`tpch`:       0xdd952207e22aa577,
-		`ycsb`:       0x85dd34d8c07fd808,
+		`ycsb`:       0x1244ea1c29ef67f6,
 	}
 
 	var a bufalloc.ByteAllocator

--- a/pkg/workload/ycsb/skewed_latest_generator.go
+++ b/pkg/workload/ycsb/skewed_latest_generator.go
@@ -11,9 +11,8 @@
 package ycsb
 
 import (
-	"math/rand"
-
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"golang.org/x/exp/rand"
 )
 
 // SkewedLatestGenerator is a random number generator that generates numbers in

--- a/pkg/workload/ycsb/uniform_generator.go
+++ b/pkg/workload/ycsb/uniform_generator.go
@@ -11,9 +11,8 @@
 package ycsb
 
 import (
-	"math/rand"
-
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"golang.org/x/exp/rand"
 )
 
 // UniformGenerator is a random number generator that generates draws from a

--- a/pkg/workload/ycsb/ycsb.go
+++ b/pkg/workload/ycsb/ycsb.go
@@ -19,17 +19,20 @@ import (
 	"hash"
 	"hash/fnv"
 	"math"
-	"math/rand"
+	"strconv"
 	"strings"
 	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach-go/crdb"
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/pflag"
+	"golang.org/x/exp/rand"
 )
 
 const (
@@ -84,7 +87,7 @@ type ycsb struct {
 	flags     workload.Flags
 	connFlags *workload.ConnFlags
 
-	seed        int64
+	seed        uint64
 	insertStart int
 	insertCount int
 	recordCount int
@@ -115,7 +118,7 @@ var ycsbMeta = workload.Meta{
 		g.flags.Meta = map[string]workload.FlagMeta{
 			`workload`: {RuntimeOnly: true},
 		}
-		g.flags.Int64Var(&g.seed, `seed`, 1, `Key hash seed.`)
+		g.flags.Uint64Var(&g.seed, `seed`, 1, `Key hash seed.`)
 		g.flags.IntVar(&g.insertStart, `insert-start`, 0, `Key to start initial sequential insertions from. (default 0)`)
 		g.flags.IntVar(&g.insertCount, `insert-count`, 10000, `Number of rows to sequentially insert before beginning workload.`)
 		g.flags.IntVar(&g.recordCount, `record-count`, 0, `Key to start workload insertions from. Must be >= insert-start + insert-count. (Default: insert-start + insert-count)`)
@@ -285,31 +288,69 @@ func (g *ycsb) Tables() []workload.Table {
 			},
 		),
 	}
-	usertableInitialRowsFn := func(rowIdx int) []interface{} {
-		w := ycsbWorker{config: g, hashFunc: fnv.New64()}
-		key := w.buildKeyName(uint64(g.insertStart + rowIdx))
-		if g.json {
-			return []interface{}{key, "{}"}
-		}
-		return []interface{}{key, "", "", "", "", "", "", "", "", "", ""}
-	}
 	if g.json {
 		usertable.Schema = usertableSchemaJSON
 		usertable.InitialRows = workload.Tuples(
 			g.insertCount,
-			usertableInitialRowsFn,
-		)
+			func(rowIdx int) []interface{} {
+				w := ycsbWorker{
+					config:   g,
+					hashFunc: fnv.New64(),
+				}
+				key := w.buildKeyName(uint64(g.insertStart + rowIdx))
+				// TODO(peter): Need to fill in FIELD here, rather than an empty JSONB
+				// value.
+				return []interface{}{key, "{}"}
+			})
 	} else {
 		if g.families {
 			usertable.Schema = usertableSchemaRelationalWithFamilies
 		} else {
 			usertable.Schema = usertableSchemaRelational
 		}
-		usertable.InitialRows = workload.TypedTuples(
-			g.insertCount,
-			usertableTypes,
-			usertableInitialRowsFn,
-		)
+
+		const batchSize = 1000
+		usertable.InitialRows = workload.BatchedTuples{
+			NumBatches: (g.insertCount + batchSize - 1) / batchSize,
+			FillBatch: func(batchIdx int, cb coldata.Batch, _ *bufalloc.ByteAllocator) {
+				rowBegin, rowEnd := batchIdx*batchSize, (batchIdx+1)*batchSize
+				if rowEnd > g.insertCount {
+					rowEnd = g.insertCount
+				}
+				cb.Reset(usertableTypes, rowEnd-rowBegin, coldata.StandardColumnFactory)
+
+				key := cb.ColVec(0).Bytes()
+				// coldata.Bytes only allows appends so we have to reset it.
+				key.Reset()
+
+				var fields [numTableFields]*coldata.Bytes
+				for i := range fields {
+					fields[i] = cb.ColVec(i + 1).Bytes()
+					// coldata.Bytes only allows appends so we have to reset it.
+					fields[i].Reset()
+				}
+
+				w := ycsbWorker{
+					config:   g,
+					hashFunc: fnv.New64(),
+				}
+				rng := rand.NewSource(g.seed + uint64(batchIdx))
+
+				var tmpbuf [fieldLength]byte
+				for rowIdx := rowBegin; rowIdx < rowEnd; rowIdx++ {
+					rowOffset := rowIdx - rowBegin
+
+					copy(tmpbuf[:], "user")
+					k := strconv.AppendUint(tmpbuf[:4], w.hashKey(uint64(rowIdx)), 10)
+					key.Set(rowOffset, k)
+
+					for i := range fields {
+						randStringLetters(rng, tmpbuf[:])
+						fields[i].Set(rowOffset, tmpbuf[:])
+					}
+				}
+			},
+		}
 	}
 	return []workload.Table{usertable}
 }
@@ -436,7 +477,7 @@ func (g *ycsb) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, 
 
 	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
 	for i := 0; i < g.connFlags.Concurrency; i++ {
-		rng := rand.New(rand.NewSource(g.seed + int64(i)))
+		rng := rand.New(rand.NewSource(g.seed + uint64(i)))
 		w := &ycsbWorker{
 			config:                  g,
 			hists:                   reg.GetHandle(),
@@ -595,6 +636,29 @@ func (yw *ycsbWorker) randString(length int) string {
 		str[i] = letters[yw.rng.Intn(len(letters))]
 	}
 	return string(str)
+}
+
+// NOTE: The following is intentionally duplicated with the ones in
+// workload/tpcc/generate.go. They're a very hot path in restoring a fixture and
+// hardcoding the consts seems to trigger some compiler optimizations that don't
+// happen if those things are params. Don't modify these without consulting
+// BenchmarkRandStringFast.
+
+func randStringLetters(rng rand.Source, buf []byte) {
+	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	const lettersLen = uint64(len(letters))
+	const lettersCharsPerRand = uint64(11) // floor(log(math.MaxUint64)/log(lettersLen))
+
+	var r, charsLeft uint64
+	for i := 0; i < len(buf); i++ {
+		if charsLeft == 0 {
+			r = rng.Uint64()
+			charsLeft = lettersCharsPerRand
+		}
+		buf[i] = letters[r%lettersLen]
+		r = r / lettersLen
+		charsLeft--
+	}
 }
 
 func (yw *ycsbWorker) insertRow(ctx context.Context) error {

--- a/pkg/workload/ycsb/zipfgenerator.go
+++ b/pkg/workload/ycsb/zipfgenerator.go
@@ -17,10 +17,10 @@ package ycsb
 import (
 	"fmt"
 	"math"
-	"math/rand"
 
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
+	"golang.org/x/exp/rand"
 )
 
 const (

--- a/pkg/workload/ycsb/zipfgenerator_test.go
+++ b/pkg/workload/ycsb/zipfgenerator_test.go
@@ -13,12 +13,12 @@ package ycsb
 import (
 	"fmt"
 	"math"
-	"math/rand"
 	"sort"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"golang.org/x/exp/rand"
 )
 
 type params struct {
@@ -34,7 +34,7 @@ var gens = []params{
 func TestCreateZipfGenerator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	for _, gen := range gens {
-		rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+		rng := rand.New(rand.NewSource(uint64(timeutil.Now().UnixNano())))
 		_, err := NewZipfGenerator(rng, gen.iMin, gen.iMax, gen.theta, false)
 		if err != nil {
 			t.Fatal(err)
@@ -110,7 +110,7 @@ func TestZetaIncrementally(t *testing.T) {
 
 func runZipfGenerators(t *testing.T, withIncrements bool) {
 	gen := gens[0]
-	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+	rng := rand.New(rand.NewSource(uint64(timeutil.Now().UnixNano())))
 	z, err := NewZipfGenerator(rng, gen.iMin, gen.iMax, gen.theta, false)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Fix `fixtures import ycsb` to import correctly size values instead of
empty values.

Switch to using `golang.org/x/exp/rand` from `math/rand` which is faster
and lower memory overhead. This follows the path blazed by other
workloads such as `tpcc`.

Release note: None