### PR TITLE
sql: update the `SHOW RANGE FOR ROW` command to just take index cols

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -390,7 +390,7 @@ start_key                          start_pretty                   end_key       
 # of the show ranges from database command. The test below just ensures that
 # the command gets parsed and evaluated correctly.
 
-# regression tests for #40450
+# Regression tests for #40450.
 statement ok
 CREATE DATABASE "show ranges"
 
@@ -457,17 +457,17 @@ statement ok
 ALTER INDEX range_for_row@i SPLIT AT VALUES (3, 4), (3, 5)
 
 query TT
-SELECT start_key, end_key FROM [SHOW RANGE FROM TABLE range_for_row FOR ROW (1, 2, 1, 2)]
+SELECT start_key, end_key FROM [SHOW RANGE FROM TABLE range_for_row FOR ROW (1, 2)]
 ----
 /1/2 /1/3
 
 query TT
-SELECT start_key, end_key FROM [SHOW RANGE FROM TABLE range_for_row FOR ROW (1, 3, 1, 2)]
+SELECT start_key, end_key FROM [SHOW RANGE FROM TABLE range_for_row FOR ROW (1, 3)]
 ----
 /1/3 NULL
 
 query TT
-SELECT start_key, end_key FROM [SHOW RANGE FROM TABLE range_for_row FOR ROW (1, 1, 1, 2)]
+SELECT start_key, end_key FROM [SHOW RANGE FROM TABLE range_for_row FOR ROW (1, 1)]
 ----
 NULL /1/2
 
@@ -477,12 +477,12 @@ SELECT start_key, end_key FROM [SHOW RANGE FROM INDEX range_for_row@i FOR ROW (1
 NULL /3/4
 
 query TT
-SELECT start_key, end_key FROM [SHOW RANGE FROM INDEX range_for_row@i FOR ROW (1, 2, 3, 4)]
+SELECT start_key, end_key FROM [SHOW RANGE FROM INDEX range_for_row@i FOR ROW (3, 4, 1, 2)]
 ----
 /3/4 /3/5
 
 query TT
-SELECT start_key, end_key FROM [SHOW RANGE FROM INDEX range_for_row@i FOR ROW (1, 2, 3, 5)]
+SELECT start_key, end_key FROM [SHOW RANGE FROM INDEX range_for_row@i FOR ROW (3, 5, 1, 2)]
 ----
 /3/5 NULL
 
@@ -515,7 +515,7 @@ statement ok
 ALTER INDEX range_for_row_nulls@i SPLIT AT VALUES (NULL)
 
 query TT
-SELECT start_key, end_key from [SHOW RANGE FROM INDEX range_for_row_nulls@i FOR ROW (1, NULL)]
+SELECT start_key, end_key from [SHOW RANGE FROM INDEX range_for_row_nulls@i FOR ROW (NULL, 1)]
 ----
 /NULL NULL
 
@@ -533,7 +533,7 @@ CREATE INDEX i3 on t42456 (x)
 query T
 SELECT crdb_internal.pretty_key(crdb_internal.encode_key(70, 4, (1, )), 0)
 ----
-/70/4/1/0
+/70/4/1
 
 # Regression test for #44326. SHOW RANGES on a virtual table should cause
 # an error, not a panic.
@@ -542,3 +542,11 @@ SHOW RANGES FROM TABLE crdb_internal.tables
 
 query error SHOW RANGE FOR ROW may not be called on a virtual table
 SHOW RANGE FROM TABLE crdb_internal.tables FOR ROW (0, 0)
+
+# Test that SHOW RANGE FOR ROW returns a nice error message for hidden columns
+# in a secondary index.
+statement ok
+CREATE TABLE err_msg (x INT, y INT, z INT, PRIMARY KEY (x, y), INDEX i (z))
+
+statement error HINT: columns \[x y\] are implicitly part of index "i"'s key, include columns \[z x y\] in this order
+SHOW RANGE FROM INDEX err_msg@i FOR ROW (1)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -48,7 +48,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/ipaddr"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
@@ -3287,32 +3286,86 @@ may increase either contention or retry errors, or both.`,
 				indexID := int(tree.MustBeDInt(args[1]))
 				rowDatums, ok := tree.AsDTuple(args[2])
 				if !ok {
-					return nil, pgerror.Newf(pgcode.DatatypeMismatch, "expected tuple argument for row_tuple, found %s", args[2])
+					return nil, pgerror.Newf(
+						pgcode.DatatypeMismatch,
+						"expected tuple argument for row_tuple, found %s",
+						args[2],
+					)
 				}
 
+				// Get the referenced table and index.
 				tableDesc, err := sqlbase.GetTableDescFromID(ctx.Context, ctx.Txn, ctx.Codec, sqlbase.ID(tableID))
 				if err != nil {
 					return nil, err
 				}
-
-				if len(rowDatums.D) != len(tableDesc.Columns) {
-					return nil, pgerror.Newf(pgcode.Syntax, "number of values provided must equal number of columns in table")
+				indexDesc, err := tableDesc.FindIndexByID(sqlbase.IndexID(indexID))
+				if err != nil {
+					return nil, err
 				}
-				// Check that all the input datums have types that line up with the columns.
+
+				// Collect the index columns. If the index is a non-unique secondary
+				// index, it might have some extra key columns.
+				indexColIDs := indexDesc.ColumnIDs
+				if indexDesc.ID != tableDesc.PrimaryIndex.ID && !indexDesc.Unique {
+					indexColIDs = append(indexColIDs, indexDesc.ExtraColumnIDs...)
+				}
+
+				// Ensure that the input tuple length equals the number of index cols.
+				if len(rowDatums.D) != len(indexColIDs) {
+					err := errors.Newf(
+						"number of values must equal number of columns in index %q",
+						indexDesc.Name,
+					)
+					// If the index has some extra key columns, then output an error
+					// message with some extra information to explain the subtlety.
+					if indexDesc.ID != tableDesc.PrimaryIndex.ID && !indexDesc.Unique && len(indexDesc.ExtraColumnIDs) > 0 {
+						var extraColNames []string
+						for _, id := range indexDesc.ExtraColumnIDs {
+							col, colErr := tableDesc.FindColumnByID(id)
+							if colErr != nil {
+								return nil, errors.CombineErrors(err, colErr)
+							}
+							extraColNames = append(extraColNames, col.Name)
+						}
+						var allColNames []string
+						for _, id := range indexColIDs {
+							col, colErr := tableDesc.FindColumnByID(id)
+							if colErr != nil {
+								return nil, errors.CombineErrors(err, colErr)
+							}
+							allColNames = append(allColNames, col.Name)
+						}
+						return nil, errors.WithHintf(
+							err,
+							"columns %v are implicitly part of index %q's key, include columns %v in this order",
+							extraColNames,
+							indexDesc.Name,
+							allColNames,
+						)
+					}
+					return nil, err
+				}
+
+				// Check that the input datums are typed as the index columns types.
 				var datums tree.Datums
 				for i, d := range rowDatums.D {
-					// We try to perform a cast here rather than a typecheck because the individual datums
-					// already have a fixed type, and not information is known at typechecking time for those
-					// datums to line up with the column types of the input table. Instead we try to cast the
-					// parsed datums into the types of the table's columns.
+					// We perform a cast here rather than a type check because datums
+					// already have a fixed type, and not enough information is known at
+					// typechecking time to ensure that the datums are typed with the
+					// types of the index columns. So, try to cast the input datums to
+					// the types of the index columns here.
 					var newDatum tree.Datum
+					col, err := tableDesc.FindColumnByID(indexColIDs[i])
+					if err != nil {
+						return nil, err
+					}
 					if d.ResolvedType() == types.Unknown {
-						if !tableDesc.Columns[i].Nullable {
+						if !col.Nullable {
 							return nil, pgerror.Newf(pgcode.NotNullViolation, "NULL provided as a value for a non-nullable column")
 						}
 						newDatum = tree.DNull
 					} else {
-						expectedTyp := tableDesc.Columns[i].DatumType()
+						expectedTyp := col.DatumType()
 						newDatum, err = tree.PerformCast(ctx, d, expectedTyp)
 						if err != nil {
 							return nil, errors.WithHint(err, "try to explicitly cast each value to the corresponding column type")
@@ -3321,36 +3374,19 @@ may increase either contention or retry errors, or both.`,
 					datums = append(datums, newDatum)
 				}
 
-				indexDesc, err := tableDesc.FindIndexByID(sqlbase.IndexID(indexID))
-				if err != nil {
-					return nil, err
-				}
-
-				// Create a column id to row index map. In this case, each column ID just maps to the i'th ordinal.
+				// Create a column id to row index map. In this case, each column ID
+				// just maps to the i'th ordinal.
 				colMap := make(map[sqlbase.ColumnID]int)
-				for i := range tableDesc.Columns {
-					colMap[tableDesc.Columns[i].ID] = i
+				for i, id := range indexColIDs {
+					colMap[id] = i
 				}
-
-				if indexDesc.ID == tableDesc.PrimaryIndex.ID {
-					keyPrefix := sqlbase.MakeIndexKeyPrefix(ctx.Codec, tableDesc, indexDesc.ID)
-					res, _, err := sqlbase.EncodeIndexKey(tableDesc, indexDesc, colMap, datums, keyPrefix)
-					if err != nil {
-						return nil, err
-					}
-					return tree.NewDBytes(tree.DBytes(res)), err
-				}
-				// We have a secondary index.
-				res, err := sqlbase.EncodeSecondaryIndex(ctx.Codec, tableDesc, indexDesc, colMap, datums, true /* includeEmpty */)
+				// Finally, encode the index key using the provided datums.
+				keyPrefix := sqlbase.MakeIndexKeyPrefix(ctx.Codec, tableDesc, indexDesc.ID)
+				res, _, err := sqlbase.EncodePartialIndexKey(tableDesc, indexDesc, len(datums), colMap, datums, keyPrefix)
 				if err != nil {
 					return nil, err
 				}
-				// If EncodeSecondaryIndex returns more than one element then we have an inverted index,
-				// which this command does not support right now.
-				if indexDesc.Type == sqlbase.IndexDescriptor_INVERTED {
-					return nil, unimplemented.NewWithIssue(41232, "inverted indexes not supported right now")
-				}
-				return tree.NewDBytes(tree.DBytes(res[0].Key)), err
+				return tree.NewDBytes(tree.DBytes(res)), err
 			},
 			Info:       "Generate the key for a row on a particular table and index.",
 			Volatility: tree.VolatilityStable,


### PR DESCRIPTION
Fixes #41421.

The SHOW RANGE FOR ROW command was difficult to use because it required
the user to input all of the columns in a particular row. This PR
changes the command to only require inputting the index columns now.

Release note (backward-incompatible change): The SHOW RANGE FOR ROW
command has been changed to take in a tuple of the row's index columns,
rather than the full column set of the row.