### PR TITLE
release-19.1: build: Upgrade base image to deployment dockerfile

### DIFF
--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9.8-slim
+FROM debian:9.12-slim
 
 # For deployment, we need
 # libc6 - dynamically linked by cockroach binary


### PR DESCRIPTION
Backport 1/1 commits from #49593.

/cc @cockroachdb/release

---

This change updates the deployment base image from Debian 9.8 to 9.12.

Fixes: #41390

Release note (build change): Release Docker images are now built on
Debian 9.12.
