### PR TITLE
server: Apply cookie auth to /debug/ endponts

### DIFF
--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -161,7 +161,7 @@ func hbaRunTest(t *testing.T, insecure bool) {
 
 		pgServer := s.(*server.TestServer).PGServer()
 
-		httpClient, err := s.GetHTTPClient()
+		httpClient, err := s.GetAdminAuthenticatedHTTPClient()
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
These legacy endpoints were previously protected only by an IP-based
restriction to localhost.

Release note (security update): HTTP endpoints beginning with /debug/
now require a valid admin login session.