### PR TITLE
sql: truncate trailing spaces for char column types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -368,3 +368,37 @@ CREATE TABLE t46570(c0 BOOL, c1 STRING COLLATE en);
 CREATE INDEX ON t46570(rowid, c1 DESC);
 INSERT INTO t46570(c1, rowid) VALUES('' COLLATE en, 0);
 UPSERT INTO t46570(rowid) VALUES (0), (1)
+
+# Test trailing spaces are truncated for char types.
+subtest regression_50015
+
+query T
+SELECT
+	t
+FROM
+	(
+		VALUES
+			('hello '::CHAR(100) COLLATE en_US),
+			('hello t'::CHAR(100) COLLATE en_US),
+			('hello '::STRING::CHAR(100) COLLATE en_US),
+			('hello t'::STRING::CHAR(100) COLLATE en_US)
+	) g(t)
+----
+hello
+hello t
+hello
+hello t
+
+statement ok
+CREATE TABLE t50015(id int PRIMARY KEY, a char(100), b char(100) COLLATE en);
+INSERT INTO t50015 VALUES
+  (1, 'hello', 'hello' COLLATE en),
+  (2, 'hello ', 'hello ' COLLATE en),
+  (3, repeat('hello ', 2), repeat('hello ', 2) COLLATE en)
+
+query ITITI
+SELECT id, a, length(a), b, length(b::string) FROM t50015 ORDER BY id ASC
+----
+1  hello                                                                                                 5   hello        5
+2  hello                                                                                                 5   hello        5
+3  hello hello                                                                                           11  hello hello  11

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -625,6 +625,11 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 				return NewDName(s), nil
 			}
 
+			// bpchar types truncate trailing whitespace.
+			if t.Oid() == oid.T_bpchar {
+				s = strings.TrimRight(s, " ")
+			}
+
 			// If the string type specifies a limit we truncate to that limit:
 			//   'hello'::CHAR(2) -> 'he'
 			// This is true of all the string type variants.
@@ -633,6 +638,10 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 			}
 			return NewDString(s), nil
 		case types.CollatedStringFamily:
+			// bpchar types truncate trailing whitespace.
+			if t.Oid() == oid.T_bpchar {
+				s = strings.TrimRight(s, " ")
+			}
 			// Ditto truncation like for TString.
 			if t.Width() > 0 {
 				s = util.TruncateString(s, int(t.Width()))

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -537,6 +537,11 @@ func (expr *StrVal) ResolveAsType(
 		case types.UuidFamily:
 			return ParseDUuidFromBytes([]byte(expr.s))
 		case types.StringFamily:
+			// bpchar types truncate trailing whitespace.
+			if typ.Oid() == oid.T_bpchar {
+				expr.resString = DString(strings.TrimRight(expr.s, " "))
+				return &expr.resString, nil
+			}
 			expr.resString = DString(expr.s)
 			return &expr.resString, nil
 		}
@@ -549,6 +554,11 @@ func (expr *StrVal) ResolveAsType(
 		if typ.Oid() == oid.T_name {
 			expr.resString = DString(expr.s)
 			return NewDNameFromDString(&expr.resString), nil
+		}
+		// bpchar types truncate trailing whitespace.
+		if typ.Oid() == oid.T_bpchar {
+			expr.resString = DString(strings.TrimRight(expr.s, " "))
+			return &expr.resString, nil
 		}
 		expr.resString = DString(expr.s)
 		return &expr.resString, nil

--- a/pkg/sql/sem/tree/testdata/eval/cast
+++ b/pkg/sql/sem/tree/testdata/eval/cast
@@ -1111,3 +1111,24 @@ eval
 ('{he' || ',a🐛b🏠}')::VARCHAR(2)[]
 ----
 ARRAY['he',e'a\U0001F41B']
+
+# Chars should truncate trailing space characters.
+eval
+'hello '::char(100)
+----
+'hello'
+
+eval
+'hello t'::char(100)
+----
+'hello t'
+
+eval
+'hello '::string::char(100)
+----
+'hello'
+
+eval
+'hello t'::string::char(100)
+----
+'hello t'

--- a/pkg/sql/sqlbase/column_type_properties.go
+++ b/pkg/sql/sqlbase/column_type_properties.go
@@ -11,6 +11,7 @@
 package sqlbase
 
 import (
+	"strings"
 	"unicode/utf8"
 
 	"github.com/cockroachdb/apd"
@@ -51,10 +52,22 @@ func AdjustValueToColumnType(
 			sv = v.Contents
 		}
 
+		if typ.Oid() == oid.T_bpchar {
+			sv = strings.TrimRight(sv, " ")
+		}
+
 		if typ.Width() > 0 && utf8.RuneCountInString(sv) > int(typ.Width()) {
 			return nil, pgerror.Newf(pgcode.StringDataRightTruncation,
 				"value too long for type %s (column %q)",
 				typ.SQLString(), tree.ErrNameStringP(name))
+		}
+
+		if typ.Oid() == oid.T_bpchar {
+			if _, ok := tree.AsDString(inVal); ok {
+				return tree.NewDString(strings.TrimRight(sv, " ")), nil
+			} else if _, ok := inVal.(*tree.DCollatedString); ok {
+				return tree.NewDCollatedString(strings.TrimRight(sv, " "), typ.Locale(), &tree.CollationEnvironment{})
+			}
 		}
 	case types.IntFamily:
 		if v, ok := tree.AsDInt(inVal); ok {


### PR DESCRIPTION
Not sure if we we should merge this considering the backwards incompatibility, @solongordon / @rohany curious for your thoughts.

----

cc @arulajmani as peer programmer!

Resolves #50015

Release note (sql change, backward-incompatible change): The `CHAR`
column type will truncate the trailing space characters in line with Postgres.
This was previously not done. Existing stored `CHAR` entries with spaces at the
end of the char column type will no longer return rows with trailing space
characters - use the `LIKE` query to find and modify these rows.

