### PR TITLE
cloud: Add FileTableReadWriter to interface with user scoped blob tables

### DIFF
--- a/pkg/storage/cloud/filetable/file_table_read_writer.go
+++ b/pkg/storage/cloud/filetable/file_table_read_writer.go
@@ -1,0 +1,499 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package filetable
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/errors"
+)
+
+var fileTableNamePrefix = "upload_files_"
+var payloadTableNamePrefix = "upload_payload_"
+
+// FileToTableSystem can be used to store, retrieve and delete the blobs and
+// metadata of files, from user scoped tables. Access to these tables is
+// restricted to the root/admin user and the user responsible for triggering
+// table creation in the first place.
+// All methods operate within the scope of the provided database db, as the user
+// with the provided username.
+//
+// Refer to the method headers for more details about the user scoped tables.
+type FileToTableSystem struct {
+	databaseName string
+	ie           *sql.InternalExecutor
+	db           *kv.DB
+	username     string
+}
+
+// FileTable which contains records for every uploaded file.
+const fileTableSchema = `CREATE TABLE %s (filename STRING PRIMARY KEY, 
+file_size INT NOT NULL, 
+username STRING NOT NULL, 
+upload_time TIMESTAMP DEFAULT now())`
+
+// PayloadTable contains the chunked payloads of each file.
+// The Payload table is interleaved in the File table to prevent repetition
+// of filename for every chunk at the KV level.
+const payloadTableSchema = `CREATE TABLE %s (filename STRING, 
+byte_offset INT, 
+payload BYTES, 
+PRIMARY KEY(filename, byte_offset)) 
+INTERLEAVE IN PARENT %s(filename)`
+
+// NewFileToTableSystem returns a FileToTableSystem object. It creates the File
+// and Payload user tables, grants the current user all read/edit privileges on
+// the tables and revokes access of every other user and role (except
+// root/admin).
+func NewFileToTableSystem(
+	ctx context.Context, databaseName string, ie *sql.InternalExecutor, db *kv.DB, username string,
+) (*FileToTableSystem, error) {
+	f := FileToTableSystem{
+		databaseName: databaseName, ie: ie, db: db, username: username,
+	}
+
+	fileTableName := fileTableNamePrefix + f.username
+	payloadTableName := payloadTableNamePrefix + f.username
+	if err := f.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		// TODO(adityamaru): Handle scenario where the user has already created
+		// tables with the same names not via the FileToTableSystem object. Not sure
+		// if we want to error out or work around it.
+		tablesExist, err := f.checkIfFileAndPayloadTableExist(ctx, fileTableName, payloadTableName)
+		if err != nil {
+			return err
+		}
+
+		if !tablesExist {
+			if err := f.createFileAndPayloadTables(ctx, txn, fileTableName, payloadTableName); err != nil {
+				return err
+			}
+
+			if err := f.grantCurrentUserTablePrivileges(ctx, fileTableName, payloadTableName,
+				txn); err != nil {
+				return err
+			}
+
+			if err := f.revokeOtherUserTablePrivileges(ctx, fileTableName, payloadTableName,
+				txn); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return &f, nil
+}
+
+// FileSize returns the size of the filename blob in bytes.
+func (f *FileToTableSystem) FileSize(ctx context.Context, filename string) (int64, error) {
+	fileTableName := fileTableNamePrefix + f.username
+
+	getFileSizeQuery := fmt.Sprintf(`SELECT file_size FROM %s WHERE filename='%s'`,
+		fileTableName, filename)
+	rows, err := f.ie.QueryRowEx(ctx, "payload-table-storage-size", nil,
+		sqlbase.InternalExecutorSessionDataOverride{User: f.username, Database: f.databaseName},
+		getFileSizeQuery)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to get size of file from the payload table")
+	}
+
+	return int64(tree.MustBeDInt(rows[0])), nil
+}
+
+// ListFiles returns a list of all the files which are currently stored in the
+// user scoped tables.
+func (f *FileToTableSystem) ListFiles(ctx context.Context) ([]string, error) {
+	var files []string
+	fileTableName := fileTableNamePrefix + f.username
+	listFilesQuery := fmt.Sprintf(`SELECT filename FROM %s ORDER BY filename`, fileTableName)
+	rows, err := f.ie.QueryEx(ctx, "file-table-storage-list", nil,
+		sqlbase.InternalExecutorSessionDataOverride{User: f.username, Database: f.databaseName},
+		listFilesQuery)
+	if err != nil {
+		return files, errors.Wrap(err, "failed to list files from file table")
+	}
+
+	// Verify that all the filenames are strings and aggregate them.
+	for _, row := range rows {
+		files = append(files, string(tree.MustBeDString(row[0])))
+	}
+
+	return files, nil
+}
+
+// DestroyUserFileSystem drops the user scoped tables effectively deleting the
+// blobs and metadata of every file.
+// The FileToTableSystem object is unusable after this method returns.
+func DestroyUserFileSystem(ctx context.Context, f *FileToTableSystem) error {
+	if err := f.db.Txn(ctx,
+		func(ctx context.Context, txn *kv.Txn) error {
+			payloadTableName := payloadTableNamePrefix + f.username
+			dropPayloadTableQuery := fmt.Sprintf(`DROP TABLE %s`, payloadTableName)
+			_, err := f.ie.QueryEx(ctx, "drop-payload-table", txn,
+				sqlbase.InternalExecutorSessionDataOverride{User: f.username, Database: f.databaseName},
+				dropPayloadTableQuery)
+			if err != nil {
+				return errors.Wrap(err, "failed to drop payload table")
+			}
+
+			fileTableName := fileTableNamePrefix + f.username
+			dropFileTableQuery := fmt.Sprintf(`DROP TABLE %s CASCADE`, fileTableName)
+			_, err = f.ie.QueryEx(ctx, "drop-file-table", txn,
+				sqlbase.InternalExecutorSessionDataOverride{User: f.username, Database: f.databaseName},
+				dropFileTableQuery)
+			if err != nil {
+				return errors.Wrap(err, "failed to drop file table")
+			}
+
+			return nil
+		}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteFile deletes the blobs and metadata of filename from the user scoped
+// tables.
+func (f *FileToTableSystem) DeleteFile(ctx context.Context, filename string) error {
+	if err := f.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		fileTableName := fileTableNamePrefix + f.username
+		deleteFileQuery := fmt.Sprintf(`DELETE FROM %s WHERE filename='%s'`, fileTableName, filename)
+		_, err := f.ie.QueryEx(ctx, "delete-file-table", txn,
+			sqlbase.InternalExecutorSessionDataOverride{User: f.username, Database: f.databaseName},
+			deleteFileQuery)
+		if err != nil {
+			return errors.Wrap(err, "failed to delete from the file table")
+		}
+
+		payloadTableName := payloadTableNamePrefix + f.username
+		deletePayloadQuery := fmt.Sprintf(`DELETE FROM %s WHERE filename='%s'`, payloadTableName, filename)
+		_, err = f.ie.QueryEx(ctx, "delete-payload-table", txn,
+			sqlbase.InternalExecutorSessionDataOverride{User: f.username, Database: f.databaseName},
+			deletePayloadQuery)
+		if err != nil {
+			return errors.Wrap(err, "failed to delete from the payload table")
+		}
+
+		return nil
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// payloadWriter is responsible for writing the file data (payload) to the user
+// Payload table. It implements the io.Writer interface.
+type payloadWriter struct {
+	filename                string
+	ie                      *sql.InternalExecutor
+	ctx                     context.Context
+	txn                     *kv.Txn
+	byteOffset              int
+	execSessionDataOverride sqlbase.InternalExecutorSessionDataOverride
+}
+
+var _ io.Writer = &payloadWriter{}
+
+// Write implements the io.Writer interface by inserting a single row into the
+// Payload table.
+func (p *payloadWriter) Write(buf []byte) (int, error) {
+	payloadTableName := payloadTableNamePrefix + p.execSessionDataOverride.User
+	insertChunkQuery := fmt.Sprintf(`INSERT INTO %s VALUES ($1, $2, $3)`, payloadTableName)
+	_, err := p.ie.QueryEx(p.ctx, "insert-file-chunk", p.txn, p.execSessionDataOverride,
+		insertChunkQuery, p.filename, p.byteOffset, buf)
+	if err != nil {
+		p.txn.CleanupOnError(p.ctx, err)
+		return 0, err
+	}
+
+	bytesWritten := len(buf)
+	p.byteOffset += bytesWritten
+
+	return bytesWritten, nil
+}
+
+// chunkWriter is responsible for buffering chunk of chunkSize and passing them
+// on to the underlying payloadWriter to be written to the Payload table.
+// On Close() chunkWriter inserts a file metadata entry in the File table once
+// all the chunks have been written.
+type chunkWriter struct {
+	buf                     *bytes.Buffer
+	pw                      *payloadWriter
+	execSessionDataOverride sqlbase.InternalExecutorSessionDataOverride
+}
+
+var _ io.WriteCloser = &chunkWriter{}
+
+func newChunkWriter(
+	ctx context.Context,
+	chunkSize int,
+	filename, username, database string,
+	ie *sql.InternalExecutor,
+	txn *kv.Txn,
+) *chunkWriter {
+	execSessionDataOverride := sqlbase.InternalExecutorSessionDataOverride{User: username,
+		Database: database}
+	pw := &payloadWriter{
+		filename, ie, ctx, txn, 0, execSessionDataOverride}
+	bytesBuffer := bytes.NewBuffer(make([]byte, 0, chunkSize))
+	return &chunkWriter{
+		bytesBuffer, pw, execSessionDataOverride,
+	}
+}
+
+// fillAvailableBufferSpace fills the remaining space in the bytes buffer with
+// data from payload, and returns the remainder of payload which has not been
+// buffered.
+func (w *chunkWriter) fillAvailableBufferSpace(payload []byte) ([]byte, error) {
+	available := w.buf.Cap() - w.buf.Len()
+	if available > len(payload) {
+		available = len(payload)
+	}
+	if _, err := w.buf.Write(payload[:available]); err != nil {
+		return nil, err
+	}
+	return payload[available:], nil
+}
+
+// Write is responsible for filling up the bytes buffer upto chunkSize, and
+// then forwarding the bytes to the payloadWriter to be written into the SQL
+// tables.
+// Any bytes remaining in the bytes buffer at the end of Write() will be flushed
+// in Close().
+func (w *chunkWriter) Write(buf []byte) (int, error) {
+	bufLen := len(buf)
+	for len(buf) > 0 {
+		var err error
+		buf, err = w.fillAvailableBufferSpace(buf)
+		if err != nil {
+			return 0, err
+		}
+
+		// If the buffer has been filled to capacity, write the chunk.
+		if w.buf.Len() == w.buf.Cap() {
+			if n, err := w.pw.Write(w.buf.Bytes()); err != nil || n != w.buf.Len() {
+				return 0, err
+			}
+			w.buf.Reset()
+		}
+	}
+
+	return bufLen, nil
+}
+
+// Close implements the io.Closer interface by flushing the underlying writer
+// thereby writing remaining data to the Payload table. It also inserts a file
+// metadata entry into the File table.
+//
+// The chunkWriter must be Close()'d, and the error returned should be checked
+// to ensure that the buffer has been flushed and the txn committed. Not
+// handling the error could lead to unexpected behavior.
+func (w *chunkWriter) Close() error {
+	// If an error is encountered when writing the final chunk in the
+	// payloadWriter Write() method, then the txn is aborted and the error is
+	// propagated here.
+	if w.buf.Len() > 0 {
+		if n, err := w.pw.Write(w.buf.Bytes()); err != nil || n != w.buf.Len() {
+			w.pw.txn.CleanupOnError(w.pw.ctx, err)
+			return err
+		}
+	}
+
+	// Insert file metadata entry into File table.
+	fileTableName := fileTableNamePrefix + w.execSessionDataOverride.User
+	fileNameQuery := fmt.Sprintf(`INSERT INTO %s VALUES ($1, $2, $3)`, fileTableName)
+
+	_, err := w.pw.ie.QueryEx(w.pw.ctx, "insert-file-name", w.pw.txn,
+		w.execSessionDataOverride, fileNameQuery, w.pw.filename, w.pw.byteOffset,
+		w.execSessionDataOverride.User)
+	if err != nil {
+		w.pw.txn.CleanupOnError(w.pw.ctx, err)
+		return err
+	}
+
+	// Commit the txn after all the payload bytes have been written and the
+	// metadata entry has been inserted.
+	return w.pw.txn.CommitOrCleanup(w.pw.ctx)
+}
+
+// fileReader reads the file payload from the underlying Payload table.
+type fileReader struct {
+	io.Reader
+}
+
+var _ io.ReadCloser = &fileReader{}
+
+// Close implements the io.Closer interface.
+func (f *fileReader) Close() error {
+	return nil
+}
+
+func newFileReader(
+	ctx context.Context, filename, username, database string, ie *sql.InternalExecutor,
+) (io.ReadCloser, error) {
+	fileTableReader, err := newFileTableReader(ctx, filename, username, database, ie)
+	if err != nil {
+		return nil, err
+	}
+	return &fileReader{fileTableReader}, nil
+}
+
+func newFileTableReader(
+	ctx context.Context, filename, username, database string, ie *sql.InternalExecutor,
+) (io.Reader, error) {
+	payloadTableName := payloadTableNamePrefix + username
+	query := fmt.Sprintf(`SELECT payload FROM %s WHERE filename='%s'`, payloadTableName, filename)
+	rows, err := ie.QueryEx(
+		ctx, "get-filename-payload", nil, /* txn */
+		sqlbase.InternalExecutorSessionDataOverride{User: username, Database: database}, query,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify that all the payloads are bytes and assemble bytes of filename.
+	var fileBytes []byte
+	for _, row := range rows {
+		fileBytes = append(fileBytes, []byte(tree.MustBeDBytes(row[0]))...)
+	}
+
+	return bufio.NewReader(bytes.NewBuffer(fileBytes)), nil
+}
+
+// ReadFile returns the blob for filename using a FileTableReader.
+// TODO(adityamaru): Reading currently involves aggregating all chunks of a
+// file from the Payload table. In the future we might want to implement a pull
+// x rows system, or a scan based interface.
+func (f *FileToTableSystem) ReadFile(ctx context.Context, filename string) (io.ReadCloser, error) {
+	var reader, err = newFileReader(ctx, filename, f.username, f.databaseName, f.ie)
+	return reader, err
+}
+
+func (f *FileToTableSystem) checkIfFileAndPayloadTableExist(
+	ctx context.Context, fileTableName,
+	payloadTableName string,
+) (bool, error) {
+	tableExistenceQuery := fmt.Sprintf(`SELECT table_name FROM [SHOW TABLES] WHERE table_name='%s' OR table_name='%s'`,
+		fileTableName, payloadTableName)
+	rows, err := f.ie.QueryEx(ctx, "tables-exist", nil,
+		sqlbase.InternalExecutorSessionDataOverride{User: f.username, Database: f.databaseName},
+		tableExistenceQuery)
+	if err != nil {
+		return false, err
+	}
+
+	if len(rows) == 1 {
+		return false, errors.New("expected both File and Payload tables to exist, " +
+			"but one of them has been dropped")
+	}
+	return len(rows) == 2, nil
+}
+
+func (f *FileToTableSystem) createFileAndPayloadTables(
+	ctx context.Context, txn *kv.Txn, fileTableName, payloadTableName string,
+) error {
+	// Create the File and Payload tables to hold the file chunks.
+	fileTableCreateQuery := fmt.Sprintf(fileTableSchema, fileTableName)
+	_, err := f.ie.QueryEx(ctx, "create-file-table", txn,
+		sqlbase.InternalExecutorSessionDataOverride{User: f.username, Database: f.databaseName},
+		fileTableCreateQuery)
+	if err != nil {
+		return errors.Wrap(err, "failed to create file table to store uploaded file names")
+	}
+
+	payloadTableCreateQuery := fmt.Sprintf(payloadTableSchema, payloadTableName, fileTableName)
+	_, err = f.ie.QueryEx(ctx, "create-payload-table", txn,
+		sqlbase.InternalExecutorSessionDataOverride{User: f.username, Database: f.databaseName},
+		payloadTableCreateQuery)
+	if err != nil {
+		return errors.Wrap(err, "failed to create interleaved table to store chunks of uploaded files")
+	}
+
+	return nil
+}
+
+// Grant the current user all read/edit privileges for the file and payload
+// tables.
+func (f *FileToTableSystem) grantCurrentUserTablePrivileges(
+	ctx context.Context, fileTableName,
+	payloadTableName string, txn *kv.Txn,
+) error {
+	grantQuery := fmt.Sprintf(`GRANT SELECT, INSERT, DROP, DELETE ON TABLE %s, %s TO %s`,
+		fileTableName, payloadTableName, f.username)
+	_, err := f.ie.QueryEx(ctx, "grant-user-file-payload-table-access", txn,
+		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser, Database: f.databaseName},
+		grantQuery)
+	if err != nil {
+		return errors.Wrap(err, "failed to grant access privileges to file and payload tables")
+	}
+
+	return nil
+}
+
+// Revoke all privileges from every user and role except root/admin and the
+// current user.
+func (f *FileToTableSystem) revokeOtherUserTablePrivileges(
+	ctx context.Context, fileTableName,
+	payloadTableName string, txn *kv.Txn,
+) error {
+	getUsersQuery := fmt.Sprintf(`SELECT username FROM system.
+users WHERE NOT "username" = 'root' AND NOT "username" = 'admin' AND NOT "username" = '%s'`,
+		f.username)
+	rows, err := f.ie.QueryEx(
+		ctx, "get-users", txn,
+		sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser},
+		getUsersQuery,
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to get all the users of the cluster")
+	}
+
+	var users []string
+	for _, row := range rows {
+		users = append(users, string(tree.MustBeDString(row[0])))
+	}
+
+	for _, user := range users {
+		revokeQuery := fmt.Sprintf(`REVOKE ALL ON TABLE %s, %s FROM %s`,
+			fileTableName, payloadTableName, user)
+		_, err = f.ie.QueryEx(ctx, "revoke-user-privileges", txn,
+			sqlbase.InternalExecutorSessionDataOverride{User: security.RootUser, Database: f.databaseName},
+			revokeQuery)
+		if err != nil {
+			return errors.Wrap(err, "failed to revoke privileges")
+		}
+	}
+
+	return nil
+}
+
+// NewFileWriter returns a io.WriteCloser which can be used to write files to
+// the user File and Payload tables. The io.WriteCloser must be closed to flush
+// the last chunk and commit the txn within which all writes occur.
+// An error at any point of the write aborts the txn.
+func (f *FileToTableSystem) NewFileWriter(
+	ctx context.Context, filename string, chunkSize int,
+) (io.WriteCloser, error) {
+	return newChunkWriter(ctx, chunkSize, filename, f.username, f.databaseName, f.ie,
+		f.db.NewTxn(ctx, f.databaseName)), nil
+}

--- a/pkg/storage/cloud/filetable/file_table_read_writer_test.go
+++ b/pkg/storage/cloud/filetable/file_table_read_writer_test.go
@@ -1,0 +1,534 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+package filetable
+
+import (
+	"bytes"
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/url"
+	"sort"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/require"
+)
+
+const database = "defaultdb"
+
+// uploadFile generates random data and copies it to the FileTableSystem via
+// the FileWriter.
+func uploadFile(
+	ctx context.Context, filename string, fileSize, chunkSize int, ft *FileToTableSystem,
+) ([]byte, error) {
+	data := make([]byte, fileSize)
+	randGen, _ := randutil.NewPseudoRand()
+	randutil.ReadTestdataBytes(randGen, data)
+
+	writer, err := ft.NewFileWriter(ctx, filename, chunkSize)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = io.Copy(writer, bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+
+	err = writer.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// Checks that filename has been divided into the expected number of chunks
+// before being written to the Payload table.
+func checkNumberOfPayloadChunks(
+	ctx context.Context,
+	t *testing.T,
+	filename, username string,
+	expectedNumChunks int,
+	sqlDB *gosql.DB,
+) {
+	payloadTableName := payloadTableNamePrefix + username
+	var count int
+	err := sqlDB.QueryRowContext(ctx, fmt.Sprintf(`SELECT count(*) FROM %s WHERE filename='%s'`,
+		payloadTableName, filename)).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, expectedNumChunks, count)
+}
+
+// Checks that a metadata entry exists for the given filename in the File table.
+func checkMetadataEntryExists(
+	ctx context.Context, t *testing.T, filename, username string, sqlDB *gosql.DB,
+) {
+	fileTableName := fileTableNamePrefix + username
+	var count int
+	err := sqlDB.QueryRowContext(ctx, fmt.Sprintf(`SELECT count(*) FROM %s WHERE filename='%s'`,
+		fileTableName, filename)).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, count, 1)
+}
+
+func TestListAndDeleteFiles(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	params, _ := tests.CreateTestServerParams()
+	params.UseDatabase = database
+	s, _, kvDB := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	fileTableReadWriter, err := NewFileToTableSystem(ctx, database,
+		s.InternalExecutor().(*sql.InternalExecutor), kvDB,
+		"root")
+	require.NoError(t, err)
+
+	// Create first test file with multiple chunks.
+	const size = 1024
+	const chunkSize = 8
+	_, err = uploadFile(ctx, "file1", size, chunkSize, fileTableReadWriter)
+	require.NoError(t, err)
+
+	// Create second test file with multiple chunks.
+	_, err = uploadFile(ctx, "file2", size, chunkSize, fileTableReadWriter)
+	require.NoError(t, err)
+
+	// Create third test file with multiple chunks.
+	_, err = uploadFile(ctx, "file3", size, chunkSize, fileTableReadWriter)
+	require.NoError(t, err)
+
+	// List files before delete.
+	files, err := fileTableReadWriter.ListFiles(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []string{"file1", "file2", "file3"}, files)
+
+	// Delete file1.
+	require.NoError(t, fileTableReadWriter.DeleteFile(ctx, "file1"))
+
+	// List files.
+	files, err = fileTableReadWriter.ListFiles(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, []string{"file2", "file3"}, files)
+
+	// Destroy the filesystem.
+	require.NoError(t, DestroyUserFileSystem(ctx, fileTableReadWriter))
+
+	// Attempt to write after the user system has been destroyed.
+	_, err = uploadFile(ctx, "file4", size, chunkSize, fileTableReadWriter)
+	require.Error(t, err)
+}
+
+func TestReadWriteFile(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	params, _ := tests.CreateTestServerParams()
+	params.UseDatabase = database
+	s, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	fileTableReadWriter, err := NewFileToTableSystem(ctx, database,
+		s.InternalExecutor().(*sql.InternalExecutor), kvDB,
+		"root")
+	require.NoError(t, err)
+
+	testFileName := "testfile"
+
+	isContentEqual := func(filename string, expected []byte, ft *FileToTableSystem) bool {
+		reader, err := fileTableReadWriter.ReadFile(ctx, filename)
+		require.NoError(t, err)
+		got, err := ioutil.ReadAll(reader)
+		require.NoError(t, err)
+		return bytes.Equal(got, expected)
+	}
+
+	testCases := []struct {
+		name      string
+		fileSize  int
+		chunkSize int
+	}{
+		{"empty-file", 0, 1024},
+		{"single-byte-chunk", 1024, 1},
+		{"file-size-chunk", 1024, 1024},
+		{"large-file", 1024 * 1024, 1024},
+		{"one-extra-chunk", 11, 2},
+	}
+
+	for _, testCase := range testCases {
+		expected, err := uploadFile(ctx, testFileName, testCase.fileSize, testCase.chunkSize,
+			fileTableReadWriter)
+		require.NoError(t, err)
+
+		// Check size.
+		size, err := fileTableReadWriter.FileSize(ctx, testFileName)
+		require.NoError(t, err)
+		require.Equal(t, size, int64(testCase.fileSize))
+
+		// Check content.
+		require.True(t, isContentEqual(testFileName, expected, fileTableReadWriter))
+
+		// Check chunking and metadata entry.
+		checkMetadataEntryExists(ctx, t, testFileName, "root", sqlDB)
+		expectedNumChunks := (testCase.fileSize / testCase.chunkSize) +
+			(testCase.fileSize % testCase.chunkSize)
+		checkNumberOfPayloadChunks(ctx, t, testFileName, "root",
+			expectedNumChunks, sqlDB)
+
+		// Delete file.
+		require.NoError(t, fileTableReadWriter.DeleteFile(ctx, testFileName))
+	}
+
+	t.Run("file-already-exists", func(t *testing.T) {
+		_, err = uploadFile(ctx, testFileName, 11, 2, fileTableReadWriter)
+		require.NoError(t, err)
+		_, err := fileTableReadWriter.NewFileWriter(ctx, testFileName, 2)
+		require.NoError(t, err)
+
+		// Upload the same file again, and expect a PK violation.
+		_, err = uploadFile(ctx, testFileName, 11, 2, fileTableReadWriter)
+		require.Error(t, err)
+
+		require.NoError(t, fileTableReadWriter.DeleteFile(ctx, testFileName))
+	})
+
+	t.Run("write-delete-write", func(t *testing.T) {
+		write1, err := uploadFile(ctx, testFileName, 11, 2, fileTableReadWriter)
+		require.NoError(t, err)
+		require.True(t, isContentEqual(testFileName, write1, fileTableReadWriter))
+
+		require.NoError(t, fileTableReadWriter.DeleteFile(ctx, testFileName))
+
+		// Write same file name but different size configuration.
+		write2, err := uploadFile(ctx, testFileName, 1024, 4, fileTableReadWriter)
+		require.NoError(t, err)
+		require.True(t, isContentEqual(testFileName, write2, fileTableReadWriter))
+		require.NoError(t, fileTableReadWriter.DeleteFile(ctx, testFileName))
+	})
+
+	t.Run("call-write-many-times", func(t *testing.T) {
+		chunkSize := 4
+		fileSize := 1024
+
+		data := make([]byte, fileSize)
+		randGen, _ := randutil.NewPseudoRand()
+		randutil.ReadTestdataBytes(randGen, data)
+
+		writer, err := fileTableReadWriter.NewFileWriter(ctx, testFileName, chunkSize)
+		require.NoError(t, err)
+
+		// Write two 1 Kib files using the same writer.
+		for i := 0; i < 2; i++ {
+			_, err = io.Copy(writer, bytes.NewReader(data))
+			require.NoError(t, err)
+		}
+
+		require.NoError(t, writer.Close())
+
+		// Check content.
+		expectedContent := append(data, data...)
+		require.True(t, isContentEqual(testFileName, expectedContent, fileTableReadWriter))
+
+		// Check chunking and metadata entry.
+		expectedFileSize := fileSize * 2
+		checkMetadataEntryExists(ctx, t, testFileName, "root", sqlDB)
+		expectedNumChunks := (expectedFileSize / chunkSize) +
+			(expectedFileSize % chunkSize)
+		checkNumberOfPayloadChunks(ctx, t, testFileName, "root",
+			expectedNumChunks, sqlDB)
+
+		require.NoError(t, fileTableReadWriter.DeleteFile(ctx, testFileName))
+	})
+}
+
+// TestUserGrants tests that a new user with only CREATE privileges can use all
+// the FileToTableSystem methods after creating the FileToTableSystem, which is
+// responsible for granting SELECT, INSERT, DELETE and DROP privileges on the
+// file and payload tables.
+func TestUserGrants(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	params, _ := tests.CreateTestServerParams()
+	params.UseDatabase = database
+	s, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	conn, err := sqlDB.Conn(ctx)
+	require.NoError(t, err)
+
+	// Create non-admin user with only CREATE privilege on the database.
+	_, err = sqlDB.Exec("CREATE USER john")
+	require.NoError(t, err)
+	_, err = sqlDB.Exec(fmt.Sprintf("GRANT CREATE ON DATABASE %s TO john", database))
+	require.NoError(t, err)
+
+	// Switch to non-admin user.
+	pgURL, cleanupGoDB := sqlutils.PGUrlWithOptionalClientCerts(
+		t, s.ServingSQLAddr(), "notAdmin", url.User("john"), false, /* withCerts */
+	)
+	defer cleanupGoDB()
+	pgURL.RawQuery = "sslmode=disable"
+	userDB, err := gosql.Open("postgres", pgURL.String())
+	require.NoError(t, err)
+	defer userDB.Close()
+
+	fileTableReadWriter, err := NewFileToTableSystem(ctx, database,
+		s.InternalExecutor().(*sql.InternalExecutor), kvDB,
+		"john")
+	require.NoError(t, err)
+
+	// Upload a file to test INSERT privilege.
+	expected, err := uploadFile(ctx, "file1", 1024, 1, fileTableReadWriter)
+	require.NoError(t, err)
+
+	// Read file to test SELECT privilege.
+	reader, err := fileTableReadWriter.ReadFile(ctx, "file1")
+	require.NoError(t, err)
+	got, err := ioutil.ReadAll(reader)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(got, expected))
+
+	// Delete file to test DELETE privilege.
+	require.NoError(t, fileTableReadWriter.DeleteFile(ctx, "file1"))
+
+	// Delete all files to test DROP privilege.
+	require.NoError(t, DestroyUserFileSystem(ctx, fileTableReadWriter))
+
+	// Check that there are no grantees on the File and Payload tables as they
+	// should have been dropped above.
+	fileTableName := fileTableNamePrefix + "john"
+	payloadTableName := payloadTableNamePrefix + "john"
+	_, err = getTableGrantees(ctx, fileTableName, conn)
+	require.Error(t, err)
+
+	_, err = getTableGrantees(ctx, payloadTableName, conn)
+	require.Error(t, err)
+}
+
+func getTableGrantees(ctx context.Context, tablename string, conn *gosql.Conn) ([]string, error) {
+	rows, err := conn.QueryContext(ctx, fmt.Sprintf(`SELECT grantee FROM [SHOW GRANTS ON %s]`,
+		tablename))
+	if err != nil {
+		return nil, err
+	}
+
+	var grantees []string
+	for rows.Next() {
+		var grantee string
+		err = rows.Scan(&grantee)
+		if err != nil {
+			return nil, err
+		}
+		grantees = append(grantees, grantee)
+	}
+
+	sort.Strings(grantees)
+	return grantees, nil
+}
+
+// TestDifferentUserDisallowed tests that a user who does not own the file and
+// payload tables but has ALL privileges on the database cannot access the
+// tables once they have been created/written to.
+func TestDifferentUserDisallowed(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	params, _ := tests.CreateTestServerParams()
+	params.UseDatabase = database
+	s, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	conn, err := sqlDB.Conn(ctx)
+	require.NoError(t, err)
+
+	// Create non-admin user with only CREATE privilege on the database.
+	_, err = sqlDB.Exec("CREATE USER john")
+	require.NoError(t, err)
+	_, err = sqlDB.Exec(fmt.Sprintf("GRANT CREATE ON DATABASE %s TO john", database))
+	require.NoError(t, err)
+
+	// Create non-admin user with ALL privileges on the database.
+	_, err = sqlDB.Exec("CREATE USER doe")
+	require.NoError(t, err)
+	_, err = sqlDB.Exec(fmt.Sprintf("GRANT ALL ON DATABASE %s TO doe", database))
+	require.NoError(t, err)
+
+	// Switch to non-admin user john.
+	pgURL, cleanupGoDB := sqlutils.PGUrlWithOptionalClientCerts(
+		t, s.ServingSQLAddr(), "notAdmin", url.User("john"), false, /* withCerts */
+	)
+	defer cleanupGoDB()
+	pgURL.RawQuery = "sslmode=disable"
+	userDB, err := gosql.Open("postgres", pgURL.String())
+	require.NoError(t, err)
+	defer userDB.Close()
+
+	fileTableReadWriter, err := NewFileToTableSystem(ctx, database,
+		s.InternalExecutor().(*sql.InternalExecutor), kvDB,
+		"john")
+	require.NoError(t, err)
+
+	_, err = uploadFile(ctx, "file1", 1024, 10, fileTableReadWriter)
+	require.NoError(t, err)
+
+	// Switch to non-admin user doe who should not have access to john's tables.
+	pgURL, cleanupGoDB = sqlutils.PGUrlWithOptionalClientCerts(
+		t, s.ServingSQLAddr(), "notAdmin", url.User("doe"), false, /* withCerts */
+	)
+	defer cleanupGoDB()
+	pgURL.RawQuery = "sslmode=disable"
+	userDB, err = gosql.Open("postgres", pgURL.String())
+	require.NoError(t, err)
+	defer userDB.Close()
+
+	// Under normal circumstances Doe should have ALL privileges on the file and
+	// payload tables created by john above. FileToTableSystem should have
+	// revoked these privileges.
+	fileTableName := fileTableNamePrefix + "john"
+	payloadTableName := payloadTableNamePrefix + "john"
+
+	// Only grantees on the table should be admin, root and john (5 privileges).
+	grantees, err := getTableGrantees(ctx, fileTableName, conn)
+	require.NoError(t, err)
+	require.Equal(t, []string{"admin", "john", "john", "john", "john", "john", "root"}, grantees)
+
+	grantees, err = getTableGrantees(ctx, payloadTableName, conn)
+	require.NoError(t, err)
+	require.Equal(t, []string{"admin", "john", "john", "john", "john", "john", "root"}, grantees)
+}
+
+// TestDifferentRoleDisallowed tests that a user who does not own the file and
+// payload tables but has a role with ALL privileges on the database cannot
+// access the tables once they have been created/written to.
+func TestDifferentRoleDisallowed(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	params, _ := tests.CreateTestServerParams()
+	params.UseDatabase = database
+	s, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	conn, err := sqlDB.Conn(ctx)
+	require.NoError(t, err)
+
+	// Create non-admin user with only CREATE privilege on the database.
+	_, err = sqlDB.Exec("CREATE USER john")
+	require.NoError(t, err)
+	_, err = sqlDB.Exec(fmt.Sprintf("GRANT CREATE ON DATABASE %s TO john", database))
+	require.NoError(t, err)
+
+	// Create role with ALL privileges on the database.
+	_, err = sqlDB.Exec("CREATE ROLE allprivilege")
+	require.NoError(t, err)
+	_, err = sqlDB.Exec(fmt.Sprintf("GRANT ALL ON DATABASE %s TO allprivilege", database))
+	require.NoError(t, err)
+
+	// Create non-admin user and assign above role.
+	_, err = sqlDB.Exec("CREATE USER doe")
+	require.NoError(t, err)
+	_, err = sqlDB.Exec(`GRANT allprivilege TO doe`)
+	require.NoError(t, err)
+
+	// Switch to non-admin user john.
+	pgURL, cleanupGoDB := sqlutils.PGUrlWithOptionalClientCerts(
+		t, s.ServingSQLAddr(), "notAdmin", url.User("john"), false, /* withCerts */
+	)
+	defer cleanupGoDB()
+	pgURL.RawQuery = "sslmode=disable"
+	userDB, err := gosql.Open("postgres", pgURL.String())
+	require.NoError(t, err)
+	defer userDB.Close()
+
+	fileTableReadWriter, err := NewFileToTableSystem(ctx, database,
+		s.InternalExecutor().(*sql.InternalExecutor), kvDB,
+		"john")
+	require.NoError(t, err)
+
+	_, err = uploadFile(ctx, "file1", 1024, 10, fileTableReadWriter)
+	require.NoError(t, err)
+
+	// Switch to non-admin user doe.
+	pgURL, cleanupGoDB = sqlutils.PGUrlWithOptionalClientCerts(
+		t, s.ServingSQLAddr(), "notAdmin", url.User("doe"), false, /* withCerts */
+	)
+	defer cleanupGoDB()
+	pgURL.RawQuery = "sslmode=disable"
+	userDB, err = gosql.Open("postgres", pgURL.String())
+	require.NoError(t, err)
+	defer userDB.Close()
+
+	// Under normal circumstances Doe should have ALL privileges on the file and
+	// payload tables created by john above. FileToTableSystem should have
+	// revoked these privileges.
+	fileTableName := fileTableNamePrefix + "john"
+	payloadTableName := payloadTableNamePrefix + "john"
+
+	// Only grantees on the table should be admin, root and john (5 privileges).
+	grantees, err := getTableGrantees(ctx, fileTableName, conn)
+	require.NoError(t, err)
+	require.Equal(t, []string{"admin", "john", "john", "john", "john", "john", "root"}, grantees)
+
+	grantees, err = getTableGrantees(ctx, payloadTableName, conn)
+	require.NoError(t, err)
+	require.Equal(t, []string{"admin", "john", "john", "john", "john", "john", "root"}, grantees)
+}
+
+// TestDatabaseScope tests that the FileToTableSystem executes all of its
+// internal queries wrt the database it is given.
+func TestDatabaseScope(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	params, _ := tests.CreateTestServerParams()
+	params.UseDatabase = database
+	s, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	fileTableReadWriter, err := NewFileToTableSystem(ctx, database,
+		s.InternalExecutor().(*sql.InternalExecutor), kvDB,
+		"root")
+	require.NoError(t, err)
+
+	// Verify defaultdb has the file we wrote.
+	uploadedContent, err := uploadFile(ctx, "file1", 1024, 10, fileTableReadWriter)
+	require.NoError(t, err)
+	oldDBReader, err := fileTableReadWriter.ReadFile(ctx, "file1")
+	require.NoError(t, err)
+	oldDBContent, err := ioutil.ReadAll(oldDBReader)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(uploadedContent, oldDBContent))
+
+	// Switch database and attempt to read the file.
+	_, err = sqlDB.Exec(`CREATE DATABASE newdb`)
+	require.NoError(t, err)
+	newFileTableReadWriter, err := NewFileToTableSystem(ctx, "newdb",
+		s.InternalExecutor().(*sql.InternalExecutor), kvDB,
+		"root")
+	require.NoError(t, err)
+	reader, err := newFileTableReadWriter.ReadFile(ctx, "file1")
+	require.NoError(t, err)
+	newDBContent, err := ioutil.ReadAll(reader)
+	require.NoError(t, err)
+	require.Empty(t, newDBContent)
+}

--- a/pkg/storage/cloud/filetable/main_test.go
+++ b/pkg/storage/cloud/filetable/main_test.go
@@ -1,0 +1,33 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package filetable
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+//go:generate ../../../util/leaktest/add-leaktest.sh *_test.go
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
This is a building block for supporting user scoped file upload and
download to and from a cluster, details of which are being discussed
in #47211.

FileTableReadWriter can be used to store, retrieve and delete blobs and
metadata of files, from user scoped tables. Access to these tables is
restricted to the root/admin user and the user responsible for
triggering table creation in the first place.

Under-the-hood FileTableReadWriter operates on user specific File and
Payload tables. The File table stores the metadata, while the Payload
table stores the contents of the file as chunks of a configurable size.

Release note: None