### PR TITLE
kvserver: improve store queue interface to surface no-ops

### DIFF
--- a/pkg/kv/kvserver/gc_queue_test.go
+++ b/pkg/kv/kvserver/gc_queue_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/kr/pretty"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/syncmap"
 )
@@ -569,9 +570,11 @@ func TestGCQueueProcess(t *testing.T) {
 
 	// Process through a scan queue.
 	gcQ := newGCQueue(tc.store, tc.gossip)
-	if err := gcQ.process(ctx, tc.repl, cfg); err != nil {
+	processed, err := gcQ.process(ctx, tc.repl, cfg)
+	if err != nil {
 		t.Fatal(err)
 	}
+	assert.True(t, processed, "queue not processed")
 
 	expKVs := []struct {
 		key roachpb.Key
@@ -804,9 +807,11 @@ func TestGCQueueTransactionTable(t *testing.T) {
 		t.Fatal("config not set")
 	}
 
-	if err := gcQ.process(ctx, tc.repl, cfg); err != nil {
+	processed, err := gcQ.process(ctx, tc.repl, cfg)
+	if err != nil {
 		t.Fatal(err)
 	}
+	assert.True(t, processed, "queue not processed")
 
 	testutils.SucceedsSoon(t, func() error {
 		for strKey, sp := range testCases {
@@ -934,9 +939,11 @@ func TestGCQueueIntentResolution(t *testing.T) {
 		t.Fatal("config not set")
 	}
 	gcQ := newGCQueue(tc.store, tc.gossip)
-	if err := gcQ.process(ctx, tc.repl, cfg); err != nil {
+	processed, err := gcQ.process(ctx, tc.repl, cfg)
+	if err != nil {
 		t.Fatal(err)
 	}
+	assert.True(t, processed, "queue not processed")
 
 	// Iterate through all values to ensure intents have been fully resolved.
 	// This must be done in a SucceedsSoon loop because intent resolution
@@ -993,9 +1000,11 @@ func TestGCQueueLastProcessedTimestamps(t *testing.T) {
 
 	// Process through a scan queue.
 	gcQ := newGCQueue(tc.store, tc.gossip)
-	if err := gcQ.process(ctx, tc.repl, cfg); err != nil {
+	processed, err := gcQ.process(ctx, tc.repl, cfg)
+	if err != nil {
 		t.Fatal(err)
 	}
+	assert.True(t, processed, "queue not processed")
 
 	// Verify GC.
 	testutils.SucceedsSoon(t, func() error {
@@ -1098,10 +1107,11 @@ func TestGCQueueChunkRequests(t *testing.T) {
 	}
 	tc.manualClock.Increment(int64(zone.GC.TTLSeconds)*1e9 + 1)
 	gcQ := newGCQueue(tc.store, tc.gossip)
-	if err := gcQ.process(ctx, tc.repl, cfg); err != nil {
+	processed, err := gcQ.process(ctx, tc.repl, cfg)
+	if err != nil {
 		t.Fatal(err)
 	}
-
+	assert.True(t, processed, "queue not processed")
 	// We wrote two batches worth of keys spread out, and two keys that
 	// each have enough old versions to fill a whole batch each in the
 	// first case, and two whole batches in the second, adding up to

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -166,7 +166,8 @@ func manualQueue(s *Store, q queueImpl, repl *Replica) error {
 		return fmt.Errorf("%s: system config not yet available", s)
 	}
 	ctx := repl.AnnotateCtx(context.Background())
-	return q.process(ctx, repl, cfg)
+	_, err := q.process(ctx, repl, cfg)
+	return err
 }
 
 // ManualGC processes the specified replica using the store's GC queue.

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -256,7 +256,9 @@ type queueImpl interface {
 
 	// process accepts a replica, and the system config and executes
 	// queue-specific work on it. The Replica is guaranteed to be initialized.
-	process(context.Context, *Replica, *config.SystemConfig) error
+	// We return a boolean to indicate if the Replica was processed successfully
+	// (vs. it being being a no-op or an error).
+	process(context.Context, *Replica, *config.SystemConfig) (processed bool, err error)
 
 	// timer returns a duration to wait between processing the next item
 	// from the queue. The duration of the last processing of a replica
@@ -953,11 +955,14 @@ func (bq *baseQueue) processReplica(ctx context.Context, repl replicaInQueue) er
 			// it may not be and shouldQueue will be passed a nil realRepl. These tests
 			// know what they're getting into so that's fine.
 			realRepl, _ := repl.(*Replica)
-			if err := bq.impl.process(ctx, realRepl, cfg); err != nil {
+			processed, err := bq.impl.process(ctx, realRepl, cfg)
+			if err != nil {
 				return err
 			}
-			log.VEventf(ctx, 3, "processing... done")
-			bq.successes.Inc(1)
+			if processed {
+				log.VEventf(ctx, 3, "processing... done")
+				bq.successes.Inc(1)
+			}
 			return nil
 		})
 }

--- a/pkg/kv/kvserver/queue_concurrency_test.go
+++ b/pkg/kv/kvserver/queue_concurrency_test.go
@@ -77,16 +77,16 @@ func TestBaseQueueConcurrent(t *testing.T) {
 
 	// Set up a queue impl that will return random results from processing.
 	impl := fakeQueueImpl{
-		pr: func(context.Context, *Replica, *config.SystemConfig) error {
+		pr: func(context.Context, *Replica, *config.SystemConfig) (bool, error) {
 			n := rand.Intn(4)
 			if n == 0 {
-				return nil
+				return true, nil
 			} else if n == 1 {
-				return errors.New("injected regular error")
+				return false, errors.New("injected regular error")
 			} else if n == 2 {
-				return &benignError{errors.New("injected benign error")}
+				return false, &benignError{errors.New("injected benign error")}
 			}
-			return &testPurgatoryError{}
+			return false, &testPurgatoryError{}
 		},
 	}
 	bq := newBaseQueue("test", impl, store, nil /* Gossip */, cfg)
@@ -127,7 +127,7 @@ func TestBaseQueueConcurrent(t *testing.T) {
 }
 
 type fakeQueueImpl struct {
-	pr func(context.Context, *Replica, *config.SystemConfig) error
+	pr func(context.Context, *Replica, *config.SystemConfig) (processed bool, err error)
 }
 
 func (fakeQueueImpl) shouldQueue(
@@ -138,7 +138,7 @@ func (fakeQueueImpl) shouldQueue(
 
 func (fq fakeQueueImpl) process(
 	ctx context.Context, repl *Replica, cfg *config.SystemConfig,
-) error {
+) (bool, error) {
 	return fq.pr(ctx, repl, cfg)
 }
 

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -568,10 +568,12 @@ func (rlq *raftLogQueue) shouldQueueImpl(
 // process truncates the raft log of the range if the replica is the raft
 // leader and if the total number of the range's raft log's stale entries
 // exceeds RaftLogQueueStaleThreshold.
-func (rlq *raftLogQueue) process(ctx context.Context, r *Replica, _ *config.SystemConfig) error {
+func (rlq *raftLogQueue) process(
+	ctx context.Context, r *Replica, _ *config.SystemConfig,
+) (processed bool, err error) {
 	decision, err := newTruncateDecision(ctx, r)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if _, recompute, _ := rlq.shouldQueueImpl(ctx, decision); recompute {
@@ -592,7 +594,7 @@ func (rlq *raftLogQueue) process(ctx context.Context, r *Replica, _ *config.Syst
 		r.raftMu.Unlock()
 
 		if err != nil {
-			return errors.Wrap(err, "recomputing raft log size")
+			return false, errors.Wrap(err, "recomputing raft log size")
 		}
 
 		log.VEventf(ctx, 2, "recomputed raft log size to %s", humanizeutil.IBytes(n))
@@ -600,31 +602,32 @@ func (rlq *raftLogQueue) process(ctx context.Context, r *Replica, _ *config.Syst
 		// Override the decision, now that an accurate log size is available.
 		decision, err = newTruncateDecision(ctx, r)
 		if err != nil {
-			return err
+			return false, err
 		}
 	}
 
 	// Can and should the raft logs be truncated?
-	if decision.ShouldTruncate() {
-		if n := decision.NumNewRaftSnapshots(); log.V(1) || n > 0 && rlq.logSnapshots.ShouldProcess(timeutil.Now()) {
-			log.Infof(ctx, "%v", log.Safe(decision.String()))
-		} else {
-			log.VEventf(ctx, 1, "%v", log.Safe(decision.String()))
-		}
-		b := &kv.Batch{}
-		b.AddRawRequest(&roachpb.TruncateLogRequest{
-			RequestHeader: roachpb.RequestHeader{Key: r.Desc().StartKey.AsRawKey()},
-			Index:         decision.NewFirstIndex,
-			RangeID:       r.RangeID,
-		})
-		if err := rlq.db.Run(ctx, b); err != nil {
-			return err
-		}
-		r.store.metrics.RaftLogTruncated.Inc(int64(decision.NumTruncatableIndexes()))
-	} else {
+	if !decision.ShouldTruncate() {
 		log.VEventf(ctx, 3, "%s", log.Safe(decision.String()))
+		return false, nil
 	}
-	return nil
+
+	if n := decision.NumNewRaftSnapshots(); log.V(1) || n > 0 && rlq.logSnapshots.ShouldProcess(timeutil.Now()) {
+		log.Infof(ctx, "%v", log.Safe(decision.String()))
+	} else {
+		log.VEventf(ctx, 1, "%v", log.Safe(decision.String()))
+	}
+	b := &kv.Batch{}
+	b.AddRawRequest(&roachpb.TruncateLogRequest{
+		RequestHeader: roachpb.RequestHeader{Key: r.Desc().StartKey.AsRawKey()},
+		Index:         decision.NewFirstIndex,
+		RangeID:       r.RangeID,
+	})
+	if err := rlq.db.Run(ctx, b); err != nil {
+		return false, err
+	}
+	r.store.metrics.RaftLogTruncated.Inc(int64(decision.NumTruncatableIndexes()))
+	return true, nil
 }
 
 // timer returns interval between processing successive queued truncations.

--- a/pkg/kv/kvserver/raft_snapshot_queue.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue.go
@@ -81,7 +81,7 @@ func (rq *raftSnapshotQueue) shouldQueue(
 
 func (rq *raftSnapshotQueue) process(
 	ctx context.Context, repl *Replica, _ *config.SystemConfig,
-) error {
+) (processed bool, err error) {
 	// If a follower requires a Raft snapshot, perform it.
 	if status := repl.RaftStatus(); status != nil {
 		// raft.Status.Progress is only populated on the Raft group leader.
@@ -91,12 +91,13 @@ func (rq *raftSnapshotQueue) process(
 					log.Infof(ctx, "sending raft snapshot")
 				}
 				if err := rq.processRaftSnapshot(ctx, repl, roachpb.ReplicaID(id)); err != nil {
-					return err
+					return false, err
 				}
+				processed = true
 			}
 		}
 	}
-	return nil
+	return processed, nil
 }
 
 func (rq *raftSnapshotQueue) processRaftSnapshot(

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -206,7 +206,7 @@ func replicaGCShouldQueueImpl(
 // still a member of the range.
 func (rgcq *replicaGCQueue) process(
 	ctx context.Context, repl *Replica, _ *config.SystemConfig,
-) error {
+) (processed bool, err error) {
 	// Note that the Replicas field of desc is probably out of date, so
 	// we should only use `desc` for its static fields like RangeID and
 	// StartKey (and avoid rng.GetReplica() for the same reason).
@@ -223,7 +223,7 @@ func (rgcq *replicaGCQueue) process(
 	rs, _, err := kv.RangeLookup(ctx, rgcq.db.NonTransactionalSender(), desc.StartKey.AsRawKey(),
 		roachpb.CONSISTENT, 0 /* prefetchNum */, false /* reverse */)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if len(rs) != 1 {
 		// Regardless of whether ranges were merged, we're guaranteed one answer.
@@ -231,7 +231,7 @@ func (rgcq *replicaGCQueue) process(
 		// TODO(knz): we should really have a separate type for assertion
 		// errors that trigger telemetry, like
 		// errors.AssertionFailedf() does.
-		return errors.Errorf("expected 1 range descriptor, got %d", len(rs))
+		return false, errors.Errorf("expected 1 range descriptor, got %d", len(rs))
 	}
 	replyDesc := rs[0]
 
@@ -249,9 +249,10 @@ func (rgcq *replicaGCQueue) process(
 		// event-driven additions.
 		log.VEventf(ctx, 1, "not gc'able, replica is still in range descriptor: %v", currentDesc)
 		if err := repl.setLastReplicaGCTimestamp(ctx, repl.store.Clock().Now()); err != nil {
-			return err
+			return false, err
 		}
-
+		// Nothing to do, so return without having processed anything.
+		//
 		// Note that we do not check the replicaID at this point. If our
 		// local replica ID is behind the one in the meta descriptor, we
 		// could safely delete our local copy, but this would just force
@@ -259,6 +260,7 @@ func (rgcq *replicaGCQueue) process(
 		// We don't normally expect to have a *higher* local replica ID
 		// than the one in the meta descriptor, but it's possible after
 		// recovering with unsafe-remove-dead-replicas.
+		return false, nil
 	} else if sameRange {
 		// We are no longer a member of this range, but the range still exists.
 		// Clean up our local data.
@@ -306,7 +308,7 @@ func (rgcq *replicaGCQueue) process(
 		if err := repl.store.RemoveReplica(ctx, repl, nextReplicaID, RemoveOptions{
 			DestroyData: true,
 		}); err != nil {
-			return err
+			return false, err
 		}
 	} else {
 		// This case is tricky. This range has been merged away, so it is likely
@@ -326,10 +328,10 @@ func (rgcq *replicaGCQueue) process(
 			rs, _, err := kv.RangeLookup(ctx, rgcq.db.NonTransactionalSender(), leftDesc.StartKey.AsRawKey(),
 				roachpb.CONSISTENT, 0 /* prefetchNum */, false /* reverse */)
 			if err != nil {
-				return err
+				return false, err
 			}
 			if len(rs) != 1 {
-				return errors.Errorf("expected 1 range descriptor, got %d", len(rs))
+				return false, errors.Errorf("expected 1 range descriptor, got %d", len(rs))
 			}
 			if leftReplyDesc := &rs[0]; !leftDesc.Equal(*leftReplyDesc) {
 				log.VEventf(ctx, 1, "left neighbor %s not up-to-date with meta descriptor %s; cannot safely GC range yet",
@@ -337,7 +339,7 @@ func (rgcq *replicaGCQueue) process(
 				// Chances are that the left replica needs to be GC'd. Since we don't
 				// have definitive proof, queue it with a low priority.
 				rgcq.AddAsync(ctx, leftRepl, replicaGCPriorityDefault)
-				return nil
+				return false, nil
 			}
 		}
 
@@ -347,10 +349,10 @@ func (rgcq *replicaGCQueue) process(
 		if err := repl.store.RemoveReplica(ctx, repl, mergedTombstoneReplicaID, RemoveOptions{
 			DestroyData: true,
 		}); err != nil {
-			return err
+			return false, err
 		}
 	}
-	return nil
+	return true, nil
 }
 
 func (*replicaGCQueue) timer(_ time.Duration) time.Duration {

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -9582,9 +9582,11 @@ func TestConsistenctQueueErrorFromCheckConsistency(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		// Do this twice because it used to deadlock. See #25456.
 		sysCfg := tc.store.Gossip().GetSystemConfig()
-		if err := tc.store.consistencyQueue.process(ctx, tc.repl, sysCfg); !testutils.IsError(err, "boom") {
+		processed, err := tc.store.consistencyQueue.process(ctx, tc.repl, sysCfg)
+		if !testutils.IsError(err, "boom") {
 			t.Fatal(err)
 		}
+		assert.False(t, processed)
 	}
 }
 

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -256,7 +256,7 @@ func (rq *replicateQueue) shouldQueue(
 
 func (rq *replicateQueue) process(
 	ctx context.Context, repl *Replica, sysCfg *config.SystemConfig,
-) error {
+) (processed bool, err error) {
 	retryOpts := retry.Options{
 		InitialBackoff: 50 * time.Millisecond,
 		MaxBackoff:     1 * time.Second,
@@ -282,24 +282,24 @@ func (rq *replicateQueue) process(
 			}
 
 			if err != nil {
-				return err
+				return false, err
 			}
 
 			if testingAggressiveConsistencyChecks {
-				if err := rq.store.consistencyQueue.process(ctx, repl, sysCfg); err != nil {
+				if _, err := rq.store.consistencyQueue.process(ctx, repl, sysCfg); err != nil {
 					log.Warningf(ctx, "%v", err)
 				}
 			}
 
 			if !requeue {
-				return nil
+				return true, nil
 			}
 
 			log.VEventf(ctx, 1, "re-processing")
 		}
 	}
 
-	return errors.Errorf("failed to replicate after %d retries", retryOpts.MaxRetries)
+	return false, errors.Errorf("failed to replicate after %d retries", retryOpts.MaxRetries)
 }
 
 func (rq *replicateQueue) processOneChange(

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2640,7 +2640,8 @@ func (s *Store) ManuallyEnqueue(
 	}
 
 	log.Eventf(ctx, "running %s.process", queueName)
-	processErr := queue.process(ctx, repl, sysCfg)
+	processed, processErr := queue.process(ctx, repl, sysCfg)
+	log.Eventf(ctx, "processed: %t", processed)
 	return collect(), processErr, nil
 }
 

--- a/pkg/kv/kvserver/ts_maintenance_queue.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue.go
@@ -145,7 +145,7 @@ func (q *timeSeriesMaintenanceQueue) shouldQueue(
 
 func (q *timeSeriesMaintenanceQueue) process(
 	ctx context.Context, repl *Replica, _ *config.SystemConfig,
-) error {
+) (processed bool, err error) {
 	desc := repl.Desc()
 	snap := repl.store.Engine().NewSnapshot()
 	now := repl.store.Clock().Now()
@@ -153,13 +153,13 @@ func (q *timeSeriesMaintenanceQueue) process(
 	if err := q.tsData.MaintainTimeSeries(
 		ctx, snap, desc.StartKey, desc.EndKey, q.db, &q.mem, TimeSeriesMaintenanceMemoryBudget, now,
 	); err != nil {
-		return err
+		return false, err
 	}
 	// Update the last processed time for this queue.
 	if err := repl.setQueueLastProcessed(ctx, q.name, now); err != nil {
 		log.VErrEventf(ctx, 2, "failed to update last processed time: %v", err)
 	}
-	return nil
+	return true, nil
 }
 
 func (q *timeSeriesMaintenanceQueue) timer(duration time.Duration) time.Duration {


### PR DESCRIPTION
Previously, even if a call to queueImpl.process() was a no-op, it was counted as a success by metrics dashboards (addresses issues like #36579, where this led to faux queue activity).

Now, queueImpl.process() returns a boolean parameter indicating whether or not there was any actually processing done to the given Replica, as opposed to it being no-op.

Fixes #36579