### PR TITLE
sql: remove type annotations from computed cols in information_schema

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -393,7 +393,7 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 					if err != nil {
 						return err
 					}
-					colComputed = tree.NewDString(tree.SerializeForDisplay(colExpr))
+					colComputed = tree.NewDString(tree.AsString(colExpr))
 				}
 				crdbSQLType := column.Type.SQLString()
 				if column.Type.UserDefined() {

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -653,7 +653,7 @@ SELECT generation_expression FROM information_schema.columns
 WHERE table_name = 'x' and column_name = 'b'
 ----
 generation_expression
-a * 2:::INT8
+a * 2
 
 query I
 SELECT count(*) FROM information_schema.columns

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -553,7 +553,8 @@ enum_computed  CREATE TABLE enum_computed (
                FAMILY fam_0_x_y_z_w_rowid (x, y, z, w, rowid)
 )
 
-# Test information_schema.columns.
+# Test information_schema.columns. generation_expression should not be
+# formatted with type annotations.
 query TT
 SELECT
   column_name, generation_expression
@@ -564,8 +565,8 @@ WHERE
 ORDER BY
   column_name
 ----
-y  'hello':::public.greeting
-z  w = 'howdy':::public.greeting
+y  'hello'
+z  w = 'howdy'
 
 # Test check constraints with enum values.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -1417,7 +1417,7 @@ WHERE table_schema = 'public' AND table_name = 'computed'
 ----
 column_name  is_generated  generation_expression  is_updatable
 a            NO            ·                      YES
-b            YES           a + 1:::INT8           NO
+b            YES           a + 1                  NO
 rowid        NO            ·                      YES
 
 statement ok


### PR DESCRIPTION
Fixes #50499.

No release note since this was introduced this release.

Release note: None