### PR TITLE
deps: bump cockroachdb/datadriven

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -395,11 +395,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2a4fe07643192397583d0396b63624a437f7bea7062f2c1bd131483164e7b523"
+  digest = "1:872416532429d7e352f0ba769a7e20c6ded7ae43cb2be64e0fa2ab83e984f7ba"
   name = "github.com/cockroachdb/datadriven"
   packages = ["."]
   pruneopts = "UT"
-  revision = "aca09668cb243672cb82f3cbeec73b3871e13cc9"
+  revision = "b5d7f6a2fbab9ae3817b80096e5810c89a076042"
 
 [[projects]]
   branch = "master"

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -370,7 +370,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 		ot.evalCtx.SessionData.ReorderJoinsLimit = ot.Flags.JoinLimit
 	}
 
-	ot.Flags.Verbose = testing.Verbose()
+	ot.Flags.Verbose = datadriven.Verbose()
 	ot.evalCtx.TestingKnobs.OptimizerCostPerturbation = ot.Flags.PerturbCost
 	ot.evalCtx.Locality = ot.Flags.Locality
 	ot.evalCtx.SessionData.SaveTablesPrefix = ot.Flags.SaveTablesPrefix


### PR DESCRIPTION
This automatically reduces the size of the build log in CI by 20MB+ due to opt/memo.

Also, use datadriven.Verbose() (the new `-datadriven-trace` flag) to initialize the opttester's Verbose flag to shave off a couple more megabytes.



Release note: None