### PR TITLE
kv/kvserver: disable compactor for Pebble

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -1883,11 +1883,6 @@ func TestClearRange(t *testing.T) {
 	// Verify that a ClearRange request from [lg1, lg3) removes lg1 and lg2.
 	clearRange(lg1, lg3)
 	verifyKeysWithPrefix(lg, []roachpb.Key{lg3})
-
-	// Verify that only the large ClearRange request used a range deletion
-	// tombstone by checking for the presence of a suggested compaction.
-	verifyKeysWithPrefix(keys.LocalStoreSuggestedCompactionsMin,
-		[]roachpb.Key{keys.StoreSuggestedCompactionKey(lg1, lg3)})
 }
 
 // TestLeaseTransferInSnapshotUpdatesTimestampCache prevents a regression of

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -385,7 +385,7 @@ func (r *Replica) handleNoRaftLogDeltaResult(ctx context.Context) {
 func (r *Replica) handleSuggestedCompactionsResult(
 	ctx context.Context, scs []kvserverpb.SuggestedCompaction,
 ) {
-	// TODO(itsbilal): Remove this check once Pebble supports GetSSTables
+	// Pebble Stores don't use a compactor.
 	if r.store.compactor == nil {
 		return
 	}

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -98,7 +98,7 @@ func (r *Replica) postDestroyRaftMuLocked(ctx context.Context, ms enginepb.MVCCS
 	//
 	// TODO(benesch): we would ideally atomically suggest the compaction with
 	// the deletion of the data itself.
-	if ms != (enginepb.MVCCStats{}) {
+	if ms != (enginepb.MVCCStats{}) && r.store.compactor != nil {
 		desc := r.Desc()
 		r.store.compactor.Suggest(ctx, kvserverpb.SuggestedCompaction{
 			StartKey: roachpb.Key(desc.StartKey),


### PR DESCRIPTION
Disable the compactor queue for Stores configured to use Pebble.
Pebble's compaction picking is aware of range deletions and will
prioritize reclamation of disk space, which obviates the need for the
compactor queue.

In practice with the clearrange workload, it doesn't look like there's
any need for special flush handling.

With this change:
![Screen Shot 2020-06-22 at 6 54 15 PM](https://user-images.githubusercontent.com/867352/85343053-f0cae680-b4b9-11ea-8772-c06453f6d874.png)
![Screen Shot 2020-06-22 at 6 54 23 PM](https://user-images.githubusercontent.com/867352/85343304-82d2ef00-b4ba-11ea-8e83-6fc4a308b048.png)
![Screen Shot 2020-06-22 at 6 53 45 PM](https://user-images.githubusercontent.com/867352/85343334-99794600-b4ba-11ea-9b81-cabbd64f0ea3.png)

----
With queue enabled:

![Screen Shot 2020-06-22 at 4 05 37 PM](https://user-images.githubusercontent.com/867352/85415451-5612ec00-b53b-11ea-8dfc-e89c35bd1ded.png)
![Screen Shot 2020-06-22 at 4 06 06 PM](https://user-images.githubusercontent.com/867352/85415456-5612ec00-b53b-11ea-9980-117db5881fea.png)
![Screen Shot 2020-06-22 at 4 06 25 PM](https://user-images.githubusercontent.com/867352/85415541-6cb94300-b53b-11ea-96fc-c31484304715.png)
