### PR TITLE
opt: add partial index implication logic for disjunctions

### DIFF
--- a/pkg/sql/opt/partialidx/predicate.go
+++ b/pkg/sql/opt/partialidx/predicate.go
@@ -18,29 +18,24 @@ import (
 
 // FiltersImplyPredicate attempts to prove that a partial index predicate is
 // implied by the given filters. If implication is proven, the function returns
-// the remaining filters that don't match the predicate expression and true. If
-// implication cannot be proven, nil and false are returned. Note that this
-// "proof" of implication is not mathematically formal or rigorous. For the sake
+// the remaining filters (see "Remaining Filters" below) and true. If
+// implication cannot be proven, nil and false are returned.
+//
+// I. Proving Implication
+//
+// Filters "imply" a predicate expression if truthful evaluation of the filters
+// guarantees truthful evaluation of the predicate. As a simple example, the
+// expression "a > 10" implies "a > 0" because all values that satisfy "a > 10"
+// also satisfy "a > 0". Note that implication is not symmetrical; "a > 0" does
+// not imply "a > 10".
+//
+// We use the same logic as Postgres's predtest library to prove implication.
+// Note that this "proof" is not mathematically formal or rigorous. For the sake
 // of efficiency and reduced complexity this proof is a best-effort attempt and
 // false-negatives are possible.
 //
-// The remaining filters are identical to the input filters except that any
-// parts that exactly match the predicate expression are removed. When the
-// remaining filters are applied on top of a scan of a partial index with the
-// given predicate, the resulting expression is equivalent to the original
-// expression. This reduces the complexity of the filters and allows any columns
-// that are referenced only in the filters to be pruned from the query plan.
-//
-// If implication is proven, the input filters cannot always be reduced. As an
-// example, the filter "a > 10" implies the predicate "a > 5", but the filter
-// must remain in order to further filter out values between 6 and 10 that would
-// be returned from a partial index scan.
-//
-// The logic for testing implication of ScalarExprs with conjunctions,
-// disjunctions, and atoms (anything that is not an AND or OR) is the same as
-// Postgres's predtest library.
-//
-// The logic is as follows, where "=>" means "implies":
+// The logic is as follows, where "=>" means "implies" and an "atom" is any
+// expression that is not a logical conjunction or disjunction.
 //
 //   atom A => atom B iff:          A contains B
 //   atom A => AND-expr B iff:      A => each of B's children
@@ -55,6 +50,71 @@ import (
 //   OR-expr A => AND-expr B iff:   A => each of B's children
 //   OR-expr A => OR-expr B iff:    each of A's children => any of B's children
 //
+// II. Remaining Filters
+//
+// The remaining filters that are returned upon a proof of implication are
+// identical to the input filters except that unnecessary expressions are
+// removed. When the remaining filters are applied on top of a scan of a partial
+// index with the given predicate, the resulting expression is equivalent to the
+// original expression.
+//
+// Removing unnecessary filter expressions reduces the complexity of the filters
+// and allows any columns that are referenced only in the filters to be pruned
+// from the query plan.
+//
+// We can safely remove an expression from the filters if all of the following
+// are true:
+//
+//   1. The expression exactly matches an expression in the predicate. This
+//   prevents returning empty remaining filters for the implication below. The
+//   original filters must be applied on top of a partial index scan with the
+//   a > 0 predicate to filter out rows where a is between 0 and 10.
+//
+//     a > 10
+//     =>
+//     a > 0
+//
+//   2. The expression does not reside within a disjunction in the predicate.
+//   This prevents the function from returning empty remaining filters for the
+//   implication below. The original filters must be applied on top of a partial
+//   index scan with the predicate to filter out rows where a > 0 but
+//   b != 'foo'.
+//
+//     b = 'foo'
+//     =>
+//     a > 0 OR b = 'foo'
+//
+//   3. The expression does not reside within a disjunction in the filters. This
+//   prevents the function from incorrectly reducing the filters for the
+//   implication below. The original filters must be applied in this case to
+//   filter out rows where a is false and c is true, but b is false.
+//
+//     a OR (b AND c)
+//     =>
+//     a OR c
+//
+// An unfortunate side-effect of these three rules is that they prevent reducing
+// the remaining filters in some cases in which it is theoretically possible to
+// simplify the filters. For example, consider the implication below.
+//
+//   a OR b
+//   =>
+//   b OR a
+//
+// In this case, the remaining filters could be empty, but they are not, because
+// of the asymmetry of the expressions. Individually a and b are exact matches
+// in both the filters and the predicate, but rule #2 and rule #3 prevent this
+// function from traversing the OR expressions and removing a and b from the
+// remaining filters. It would be difficult to support this case without
+// breaking the other cases prevented by each of the three rules.
+//
+// A set of opt.Expr keeps track of exact matches encountered while exploring
+// the filters and predicate expressions. If implication is proven, the filters
+// expression is traversed and the expressions in the opt.Expr set are removed.
+// While proving implication this set is not passed to recursive calls when a
+// disjunction is encountered in the predicate (rule #2), and disjunctions in
+// the filters are never traversed when searching for exact matches to remove
+// (rule #3).
 func FiltersImplyPredicate(
 	filters memo.FiltersExpr, pred opt.ScalarExpr, f *norm.Factory,
 ) (remainingFilters memo.FiltersExpr, ok bool) {
@@ -98,20 +158,27 @@ func FiltersImplyPredicate(
 	return nil, false
 }
 
-// exprImpliesPredicate returns true if the expression e implies the ScalarExpr
-// pred. If e or any of its encountered sub-expressions are exact matches to
-// expressions within pred, they are added to the exactMatches set.
+// scalarExprImpliesPredicate returns true if the expression e implies the
+// ScalarExpr pred. If e or any of its encountered sub-expressions are exact
+// matches to expressions within pred, they are added to the exactMatches set
+// (except any expressions under an OrExpr).
 //
-// Note that exprImpliesPredicate short-circuits when e is proven to imply pred,
-// and is not guaranteed to traverse either expression tree entirely. Therefore,
-// there may be expressions in both trees that match exactly but are not added
-// to exactMatches.
+// Note that scalarExprImpliesPredicate short-circuits when e is proven to imply
+// pred, and is not guaranteed to traverse either expression tree entirely.
+// Therefore, there may be expressions in both trees that match exactly but are
+// not added to exactMatches.
+//
+// Also note that exactMatches is optional, and nil can be passed when it is not
+// necessary to keep track of exactly matching expressions.
 func scalarExprImpliesPredicate(
 	e opt.ScalarExpr, pred opt.ScalarExpr, exactMatches map[opt.Expr]struct{},
 ) bool {
+
 	// If the expressions are an exact match, then e implies pred.
 	if e == pred {
-		exactMatches[e] = struct{}{}
+		if exactMatches != nil {
+			exactMatches[e] = struct{}{}
+		}
 		return true
 	}
 
@@ -127,8 +194,7 @@ func scalarExprImpliesPredicate(
 		return andExprImpliesPredicate(t, pred, exactMatches)
 
 	case *memo.OrExpr:
-		// TODO(mgartner): Handle OR filters.
-		return false
+		return orExprImpliesPredicate(t, pred)
 
 	default:
 		return atomImpliesPredicate(e, pred, exactMatches)
@@ -143,27 +209,42 @@ func filtersExprImpliesPredicate(
 	switch pt := pred.(type) {
 	case *memo.AndExpr:
 		// AND-expr A => AND-expr B iff A => each of B's children.
-		leftPredImplied := filtersExprImpliesPredicate(e, pt.Left, exactMatches)
-		if leftPredImplied {
-			return filtersExprImpliesPredicate(e, pt.Right, exactMatches)
-		}
-		return false
+		return filtersExprImpliesPredicate(e, pt.Left, exactMatches) &&
+			filtersExprImpliesPredicate(e, pt.Right, exactMatches)
 
 	case *memo.OrExpr:
-		// AND-expr A => OR-expr B iff A => any of B's children OR
-		// any of A's children => B.
-		// TODO(mgartner): Handle OR predicates.
-		return false
-
-	default:
-		// AND-pred A => atom B iff any of A's children => B.
-		for i := range *e {
-			if scalarExprImpliesPredicate((*e)[i].Condition, pred, exactMatches) {
-				return true
-			}
+		// The logic for proving that an AND implies an OR is:
+		//
+		//   AND-expr A => OR-expr B iff A => any of B's children OR
+		//   any of A's children => B
+		//
+		// Here we handle the first part, checking if A implies any of B's
+		// children. The second part is logically equivalent AND => atom
+		// implication, and is handled after the switch statement.
+		//
+		// Do not pass exactMatches to the recursive call with pt.Left or
+		// pt.Right, because matching expressions below a disjunction in a
+		// predicate cannot be removed from the remaining filters. See
+		// FiltersImplyPredicate (rule #2) for more details.
+		if filtersExprImpliesPredicate(e, pt.Left, nil /* exactMatches */) {
+			return true
 		}
-		return false
+		if filtersExprImpliesPredicate(e, pt.Right, nil /* exactMatches */) {
+			return true
+		}
 	}
+
+	// If the above cases have not proven or disproven implication, there are
+	// two more cases to consider, both handled by the same code path:
+	//
+	//   AND-expr A => OR-expr B if any of A's children => B
+	//   AND-pred A => atom B iff any of A's children => B
+	for i := range *e {
+		if scalarExprImpliesPredicate((*e)[i].Condition, pred, exactMatches) {
+			return true
+		}
+	}
+	return false
 }
 
 // andExprImpliesPredicate returns true if the AndExpr e implies the ScalarExpr
@@ -179,7 +260,48 @@ func andExprImpliesPredicate(
 	return filtersExprImpliesPredicate(&f, pred, exactMatches)
 }
 
-// atomImpliedPredicate returns true if the atom expression e implies the
+// orExprImpliesPredicate returns true if the FiltersExpr e implies the
+// ScalarExpr pred.
+//
+// Note that in all recursive calls within this function, we do not pass
+// exactMatches. See FiltersImplyPredicate (rule #3) for more details.
+func orExprImpliesPredicate(e *memo.OrExpr, pred opt.ScalarExpr) bool {
+	switch pt := pred.(type) {
+	case *memo.AndExpr:
+		// OR-expr A => AND-expr B iff A => each of B's children.
+		return orExprImpliesPredicate(e, pt.Left) &&
+			orExprImpliesPredicate(e, pt.Right)
+
+	case *memo.OrExpr:
+		// OR-expr A => OR-expr B iff each of A's children => any of B's
+		// children.
+		//
+		// We must flatten all adjacent ORs in order to handle cases such as:
+		//   (a OR b) => ((a OR b) OR c)
+		eFlat := flattenOrExpr(e)
+		predFlat := flattenOrExpr(pt)
+		for i := range eFlat {
+			eChildImpliesAnyPredChild := false
+			for j := range predFlat {
+				if scalarExprImpliesPredicate(eFlat[i], predFlat[j], nil /* exactMatches */) {
+					eChildImpliesAnyPredChild = true
+					break
+				}
+			}
+			if !eChildImpliesAnyPredChild {
+				return false
+			}
+		}
+		return true
+
+	default:
+		// OR-expr A => atom B iff each of A's children => B.
+		return scalarExprImpliesPredicate(e.Left, pred, nil /* exactMatches */) &&
+			scalarExprImpliesPredicate(e.Right, pred, nil /* exactMatches */)
+	}
+}
+
+// atomImpliesPredicate returns true if the atom expression e implies the
 // ScalarExpr pred. The atom e cannot be an AndExpr, OrExpr, RangeExpr, or
 // FiltersExpr.
 func atomImpliesPredicate(
@@ -194,8 +316,10 @@ func atomImpliesPredicate(
 
 	case *memo.OrExpr:
 		// atom A => OR-expr B iff A => any of B's children.
-		// TODO(mgartner): Handle OR predicates.
-		return false
+		if atomImpliesPredicate(e, pt.Left, exactMatches) {
+			return true
+		}
+		return atomImpliesPredicate(e, pt.Right, exactMatches)
 
 	default:
 		// atom A => atom B iff A contains B.
@@ -241,6 +365,9 @@ func simplifyFiltersExpr(
 // cannot simply be removed because RangeExprs and AndExprs are not lists of
 // expressions. Instead, expressions in exactMatches are replaced with other
 // expressions that are logically equivalent to removal of the expression.
+//
+// Also note that we do not attempt to traverse OrExprs. See
+// FiltersImplyPredicate (rule #3) for more details.
 func simplifyScalarExpr(
 	e opt.ScalarExpr, exactMatches map[opt.Expr]struct{}, f *norm.Factory,
 ) opt.ScalarExpr {
@@ -269,4 +396,32 @@ func simplifyScalarExpr(
 	default:
 		return e
 	}
+}
+
+// flattenOrExpr returns a list of ScalarExprs that are all adjacent via
+// disjunctions to the input OrExpr.
+//
+// For example, the input:
+//
+//   a OR (b AND c) OR (d OR e)
+//
+// Results in:
+//
+//  [a, (b AND c), d, e]
+//
+func flattenOrExpr(or *memo.OrExpr) []opt.ScalarExpr {
+	ors := make([]opt.ScalarExpr, 0, 2)
+
+	var collect func(e opt.ScalarExpr)
+	collect = func(e opt.ScalarExpr) {
+		if and, ok := e.(*memo.OrExpr); ok {
+			collect(and.Left)
+			collect(and.Right)
+		} else {
+			ors = append(ors, e)
+		}
+	}
+	collect(or)
+
+	return ors
 }

--- a/pkg/sql/opt/partialidx/predicate_test.go
+++ b/pkg/sql/opt/partialidx/predicate_test.go
@@ -170,28 +170,52 @@ func BenchmarkPredicateImplication(b *testing.B) {
 			pred:     "@3 >= 10 AND @3 <= 100",
 		},
 		{
-			name:     "multi-column-exact-match",
+			name:     "multi-column-and-exact-match",
 			varTypes: "int, string",
 			filters:  "@1 >= 10 AND @2 = 'foo'",
 			pred:     "@1 >= 10 AND @2 = 'foo'",
 		},
 		{
-			name:     "multi-column-exact-match-reverse",
+			name:     "multi-column-or-exact-match",
+			varTypes: "int, string",
+			filters:  "@1 >= 10 OR @2 = 'foo'",
+			pred:     "@1 >= 10 OR @2 = 'foo'",
+		},
+		{
+			name:     "multi-column-and-exact-match-reverse",
 			varTypes: "int, string",
 			filters:  "@1 >= 10 AND @2 = 'foo'",
 			pred:     "@2 = 'foo' AND @1 >= 10",
 		},
 		{
-			name:     "multi-column-exact-match-extra-filters",
+			name:     "multi-column-and-exact-match-reverse",
+			varTypes: "int, string",
+			filters:  "@1 >= 10 OR @2 = 'foo'",
+			pred:     "@2 = 'foo' OR @1 >= 10",
+		},
+		{
+			name:     "multi-column-and-exact-match-extra-filters",
 			varTypes: "int, int, int, int, string",
 			filters:  "@1 < 0 AND @2 > 0 AND @3 >= 10 AND @4 = 4 AND @5 = 'foo'",
 			pred:     "@2 > 0 AND @5 = 'foo'",
 		},
 		{
-			name:     "filters-do-not-imply-pred",
+			name:     "multi-column-or-exact-match-extra-predicate",
+			varTypes: "int, int, int, int, string",
+			filters:  "@2 > 0 OR @5 = 'foo'",
+			pred:     "@1 < 0 OR @2 > 0 OR @3 >= 10 OR @4 = 4 OR @5 = 'foo'",
+		},
+		{
+			name:     "and-filters-do-not-imply-pred",
 			varTypes: "int, int, int, int, string",
 			filters:  "@1 < 0 AND @2 > 10 AND @3 >= 10 AND @4 = 4 AND @5 = 'foo'",
 			pred:     "@2 > 0 AND @5 = 'foo'",
+		},
+		{
+			name:     "or-filters-do-not-imply-pred",
+			varTypes: "int, int, int, int, string",
+			filters:  "@1 < 0 OR @2 > 10 OR @3 >= 10 OR @4 = 4 OR @5 = 'foo'",
+			pred:     "@2 > 0 OR @5 = 'foo'",
 		},
 	}
 	// Generate a few test cases with many columns to show how performance

--- a/pkg/sql/opt/partialidx/testdata/predicate/and-expr
+++ b/pkg/sql/opt/partialidx/testdata/predicate/and-expr
@@ -128,3 +128,27 @@ predtest vars=(int, bool)
 @1 > 10 AND @1 < 100 AND @2
 ----
 false
+
+# Disjunction Filters
+
+predtest vars=(bool)
+@1 OR @1
+=>
+@1 AND @1
+----
+true
+└── remaining filters: none
+
+predtest vars=(bool, bool)
+@1 OR @2
+=>
+@1 AND @2
+----
+false
+
+predtest vars=(bool, bool)
+@1 OR @2
+=>
+@2 AND @1
+----
+false

--- a/pkg/sql/opt/partialidx/testdata/predicate/exact-atom
+++ b/pkg/sql/opt/partialidx/testdata/predicate/exact-atom
@@ -156,3 +156,20 @@ predtest vars=(int)
 @1 > 10
 ----
 false
+
+# Disjunction filters
+
+predtest vars=(bool)
+@1 OR @1
+=>
+@1
+----
+true
+└── remaining filters: none
+
+predtest vars=(bool, bool)
+@1 OR @2
+=>
+@2
+----
+false

--- a/pkg/sql/opt/partialidx/testdata/predicate/or-expr
+++ b/pkg/sql/opt/partialidx/testdata/predicate/or-expr
@@ -1,0 +1,231 @@
+# Tests for predicates with OR expressions.
+
+# Atom filters
+
+predtest vars=(bool)
+@1
+=>
+@1 OR @1
+----
+true
+└── remaining filters: none
+
+predtest vars=(bool, bool)
+@1
+=>
+@1 OR @2
+----
+true
+└── remaining filters: @1
+
+predtest vars=(bool, bool)
+@2
+=>
+@1 OR @2
+----
+true
+└── remaining filters: @2
+
+predtest vars=(bool, bool)
+NOT @2
+=>
+@1 OR @2
+----
+false
+
+# Conjunction filters
+
+predtest vars=(bool, bool)
+@1 AND @2
+=>
+@1 OR @1
+----
+true
+└── remaining filters: @2
+
+predtest vars=(bool, bool)
+@1 AND @2
+=>
+@1 OR @2
+----
+true
+└── remaining filters: @1 AND @2
+
+predtest vars=(bool, bool)
+@1 AND @2
+=>
+@2 OR @1
+----
+true
+└── remaining filters: @1 AND @2
+
+predtest vars=(bool, bool, bool)
+@1 AND @2 AND @3
+=>
+@1 OR @3
+----
+true
+└── remaining filters: (@1 AND @2) AND @3
+
+predtest vars=(bool, bool, bool)
+@1 AND @2 AND @3
+=>
+@1 OR @2
+----
+true
+└── remaining filters: (@1 AND @2) AND @3
+
+predtest vars=(bool, bool, bool)
+@1 AND @2 AND @3
+=>
+@3 OR @1 OR @2
+----
+true
+└── remaining filters: (@1 AND @2) AND @3
+
+predtest vars=(bool, bool)
+@1 AND @2
+=>
+NOT @1 OR NOT @2
+----
+false
+
+predtest vars=(bool, bool, bool)
+@1 AND @2
+=>
+NOT @1 OR @3
+----
+false
+
+# Range filters
+
+predtest vars=(int)
+@1 > 10 AND @1 < 100
+=>
+@1 > 10 OR @1 < 100
+----
+true
+└── remaining filters: (@1 > 10) AND (@1 < 100)
+
+predtest vars=(int)
+@1 > 10 AND @1 < 100
+=>
+@1 < 100 OR @1 > 10
+----
+true
+└── remaining filters: (@1 > 10) AND (@1 < 100)
+
+predtest vars=(int, bool)
+@1 > 10 AND @2 AND @1 < 100
+=>
+@1 > 10 OR @1 < 100
+----
+true
+└── remaining filters: ((@1 > 10) AND (@1 < 100)) AND @2
+
+# Disjunction filters
+
+predtest vars=(bool)
+@1 OR @1
+=>
+@1 OR @1
+----
+true
+└── remaining filters: none
+
+predtest vars=(bool, bool)
+@1 OR @2
+=>
+@1 OR @2
+----
+true
+└── remaining filters: none
+
+# These filters could, in theory, be reduced to "none". However, doing so is
+# difficult because we don't remove exact expression matches inside Or
+# expressions in the predicate or filters. See the docs for
+# FilterImpliesPredicate for more details.
+predtest vars=(bool, bool)
+@1 OR @2
+=>
+@2 OR @1
+----
+true
+└── remaining filters: @1 OR @2
+
+predtest vars=(bool, bool, bool)
+@1 OR @2
+=>
+@1 OR @2 OR @3
+----
+true
+└── remaining filters: @1 OR @2
+
+predtest vars=(bool, bool, bool)
+@1 OR @2
+=>
+@3 OR @1 OR @2
+----
+true
+└── remaining filters: @1 OR @2
+
+predtest vars=(bool, bool, bool)
+@1 OR @2
+=>
+@1 OR @3
+----
+false
+
+# Combination conjunction and disjunction filters
+
+predtest vars=(int)
+(@1 > 10 OR @1 < 0) AND (@1 > 11 OR @1 < 0)
+=>
+@1 > 10 OR @1 < 0
+----
+true
+└── remaining filters: (@1 > 11) OR (@1 < 0)
+
+predtest vars=(bool, bool, bool)
+@1 OR (@2 AND @3)
+=>
+@1 OR @3
+----
+true
+└── remaining filters: @1 OR (@2 AND @3)
+
+predtest vars=(bool, bool, bool)
+(@1 OR @2) AND @3
+=>
+@1 OR @2
+----
+true
+└── remaining filters: @3
+
+predtest vars=(bool, bool, bool)
+(@1 OR @2) AND (@1 OR @3)
+=>
+@1 OR @2
+----
+true
+└── remaining filters: @1 OR @3
+
+# These filters could, in theory, be reduced to "@1 OR @3". However, doing so is
+# difficult because we don't remove exact expression matches inside Or
+# expressions in the predicate or filters. See the docs for
+# FilterImpliesPredicate for more details.
+predtest vars=(bool, bool, bool)
+(@2 OR @1) AND (@1 OR @3)
+=>
+@1 OR @2
+----
+true
+└── remaining filters: (@2 OR @1) AND (@1 OR @3)
+
+predtest vars=(bool, bool, bool, bool)
+@1 OR (@2 AND @3) OR @4
+=>
+@1 OR @3 OR @4
+----
+true
+└── remaining filters: (@1 OR (@2 AND @3)) OR @4


### PR DESCRIPTION
This commit extends the `partialidx` package to support proving
implication for filters and predicates with OR expressions.

Determining the correct remaining filters is more difficult for
disjunctions than for conjunctions. As a result, there are some cases in
which the remaining filters are not simplified, even though it is
possible to do so in theory. This is deliberate in order to ensure
correctness of query results (incorrect remaining filters can cause
correctness bugs) and to keep complexity low. See the documentation for
`partialidx.FiltersImplyPredicate` for a detailed desciption of how the
remaining filters are determined.

Informs #50218

Release note: None