### PR TITLE
sql: handle deletes for partial indexes

### DIFF
--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -143,26 +143,28 @@ func (r *insertRun) processSourceRow(params runParams, rowVals tree.Datums) erro
 	// to when they are partial indexes and the row does not satisfy the
 	// predicate. This set is passed as a parameter to tableInserter.row below.
 	var ignoreIndexes util.FastIntSet
-	indexPredicateVals := rowVals[len(r.insertCols)+r.checkOrds.Len():]
+	partialIndexPutVals := rowVals[len(r.insertCols)+r.checkOrds.Len():]
 	colIdx := 0
 	indexes := r.ti.tableDesc().Indexes
 	for i := range indexes {
-		if colIdx >= len(indexPredicateVals) {
-			break
-		}
-
 		index := indexes[i]
 		if index.IsPartial() {
-			val, err := tree.GetBool(indexPredicateVals[colIdx])
+			val, err := tree.GetBool(partialIndexPutVals[colIdx])
 			if err != nil {
 				return err
 			}
+
 			if !val {
 				// If the value of the column for the index predicate expression
 				// is false, the row should not be added to the partial index.
 				ignoreIndexes.Add(int(index.ID))
 			}
+
 			colIdx++
+			if colIdx >= len(partialIndexPutVals) {
+				break
+			}
+
 		}
 	}
 

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -78,10 +78,10 @@ func (b *Builder) buildInsert(ins *memo.InsertExpr) (execPlan, error) {
 	}
 	// Construct list of columns that only contains columns that need to be
 	// inserted (e.g. delete-only mutation columns don't need to be inserted).
-	colList := make(opt.ColList, 0, len(ins.InsertCols)+len(ins.CheckCols)+len(ins.IndexPredicateCols))
+	colList := make(opt.ColList, 0, len(ins.InsertCols)+len(ins.CheckCols)+len(ins.PartialIndexPutCols))
 	colList = appendColsWhenPresent(colList, ins.InsertCols)
 	colList = appendColsWhenPresent(colList, ins.CheckCols)
-	colList = appendColsWhenPresent(colList, ins.IndexPredicateCols)
+	colList = appendColsWhenPresent(colList, ins.PartialIndexPutCols)
 	input, err := b.buildMutationInput(ins, ins.Input, colList, &ins.MutationPrivate)
 	if err != nil {
 		return execPlan{}, err
@@ -219,10 +219,10 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 		}
 	}
 
-	colList := make(opt.ColList, 0, len(ins.InsertCols)+len(ins.CheckCols)+len(ins.IndexPredicateCols))
+	colList := make(opt.ColList, 0, len(ins.InsertCols)+len(ins.CheckCols)+len(ins.PartialIndexPutCols))
 	colList = appendColsWhenPresent(colList, ins.InsertCols)
 	colList = appendColsWhenPresent(colList, ins.CheckCols)
-	colList = appendColsWhenPresent(colList, ins.IndexPredicateCols)
+	colList = appendColsWhenPresent(colList, ins.PartialIndexPutCols)
 	if !colList.Equals(values.Cols) {
 		// We have a Values input, but the columns are not in the right order. For
 		// example:
@@ -429,8 +429,9 @@ func (b *Builder) buildDelete(del *memo.DeleteExpr) (execPlan, error) {
 	//
 	// TODO(andyk): Using ensureColumns here can result in an extra Render.
 	// Upgrade execution engine to not require this.
-	colList := make(opt.ColList, 0, len(del.FetchCols))
+	colList := make(opt.ColList, 0, len(del.FetchCols)+len(del.PartialIndexDelCols))
 	colList = appendColsWhenPresent(colList, del.FetchCols)
+	colList = appendColsWhenPresent(colList, del.PartialIndexDelCols)
 
 	input, err := b.buildMutationInput(del, del.Input, colList, &del.MutationPrivate)
 	if err != nil {

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -35,6 +35,30 @@ CPut /Table/53/1/12/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
 InitPut /Table/53/2/11/12/0 -> /BYTES/
 InitPut /Table/53/3/"foo"/12/0 -> /BYTES/
 
+# Deleted row matches no partial index.
+query T kvtrace
+DELETE FROM t WHERE a = 5
+----
+Scan /Table/53/1/5{-/#}
+Del /Table/53/1/5/0
+
+# Deleted row matches the first partial index.
+query T kvtrace
+DELETE FROM t WHERE a = 6
+----
+Scan /Table/53/1/6{-/#}
+Del /Table/53/2/11/6/0
+Del /Table/53/1/6/0
+
+# Deleted row matches both partial indexes.
+query T kvtrace
+DELETE FROM t WHERE a = 12
+----
+Scan /Table/53/1/12{-/#}
+Del /Table/53/2/11/12/0
+Del /Table/53/3/"foo"/12/0
+Del /Table/53/1/12/0
+
 # EXPLAIN output shows the partial index label on scans over partial indexes.
 query TTT
 EXPLAIN SELECT b FROM t WHERE b > 10

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -498,7 +498,8 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			}
 			f.formatMutationCols(e, tp, "insert-mapping:", t.InsertCols, t.Table)
 			f.formatColList(e, tp, "check columns:", t.CheckCols)
-			f.formatColList(e, tp, "partial index pred columns:", t.IndexPredicateCols)
+			f.formatColList(e, tp, "partial index put columns:", t.PartialIndexPutCols)
+			f.formatColList(e, tp, "partial index del columns:", t.PartialIndexDelCols)
 			f.formatMutationCommon(tp, &t.MutationPrivate)
 		}
 

--- a/pkg/sql/opt/norm/prune_cols_funcs.go
+++ b/pkg/sql/opt/norm/prune_cols_funcs.go
@@ -60,7 +60,8 @@ func (c *CustomFuncs) NeededMutationCols(
 	addCols(private.FetchCols)
 	addCols(private.UpdateCols)
 	addCols(private.CheckCols)
-	addCols(private.IndexPredicateCols)
+	addCols(private.PartialIndexPutCols)
+	addCols(private.PartialIndexDelCols)
 	addCols(private.ReturnCols)
 	addCols(private.PassthroughCols)
 	if private.CanaryCol != 0 {

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -43,6 +43,16 @@ CREATE TABLE family (
 )
 ----
 
+exec-ddl
+CREATE TABLE partial_indexes (
+    a INT PRIMARY KEY,
+    b INT,
+    c STRING,
+    INDEX (b) WHERE c = 'foo',
+    INDEX (c) WHERE a > b AND c = 'bar'
+)
+----
+
 # --------------------------------------------------
 # PruneProjectCols
 # --------------------------------------------------
@@ -1928,6 +1938,31 @@ delete a
       ├── columns: k:5!null s:8
       ├── key: (5)
       └── fd: (5)-->(8)
+
+# Do not prune columns that are required for evaluating partial index
+# predicates.
+norm expect-not=(PruneMutationFetchCols,PruneMutationInputCols)
+DELETE FROM partial_indexes RETURNING a
+----
+delete partial_indexes
+ ├── columns: a:1!null
+ ├── fetch columns: a:4 b:5 c:6
+ ├── volatile, mutations
+ ├── key: (1)
+ └── project
+      ├── columns: partial_index_del1:7 partial_index_del2:8 a:4!null b:5 c:6
+      ├── key: (4)
+      ├── fd: (4)-->(5,6,8), (6)-->(7)
+      ├── scan partial_indexes
+      │    ├── columns: a:4!null b:5 c:6
+      │    ├── partial index predicates
+      │    │    ├── secondary: c:6 = 'foo'
+      │    │    └── secondary: (a:4 > b:5) AND (c:6 = 'bar')
+      │    ├── key: (4)
+      │    └── fd: (4)-->(5,6)
+      └── projections
+           ├── c:6 = 'foo' [as=partial_index_del1:7, outer=(6)]
+           └── (a:4 > b:5) AND (c:6 = 'bar') [as=partial_index_del2:8, outer=(4-6)]
 
 # Prune secondary family column not needed for the update.
 norm expect=(PruneMutationFetchCols,PruneMutationInputCols)

--- a/pkg/sql/opt/ops/mutation.opt
+++ b/pkg/sql/opt/ops/mutation.opt
@@ -104,7 +104,7 @@ define MutationPrivate {
     # TODO(radu): we don't actually implement this optimization currently.
     CheckCols ColList
 
-    # IndexPredicateCols are columns from the Input expression containing the
+    # PartialIndexPutCols are columns from the Input expression containing the
     # results of evaluating each partial index predicate from the target table
     # for the mutation. Evaluating a partial index predicate produces a boolean
     # value which is projected as a column and used during execution to
@@ -123,8 +123,14 @@ define MutationPrivate {
     # the predicate expression of the index on a. The second is the result of
     # evaluating the predicate of the index on c. The index on b is not a
     # partial index, because it has no predicate, so it is not included in
-    # IndexPredicateCols.
-    IndexPredicateCols ColList
+    # PartialIndexPutCols.
+    PartialIndexPutCols ColList
+
+    # PartialIndexDelCols is similar to PartialIndexPutCols, but instead
+    # indicates when the previous version of a row must be deleted from a
+    # partial index during updates or deletes in order to maintain the state of
+    # the index.
+    PartialIndexDelCols ColList
 
     # CanaryCol is used only with the Upsert operator. It identifies the column
     # that the execution engine uses to decide whether to insert or to update.

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -74,6 +74,13 @@ func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope
 // buildDelete constructs a Delete operator, possibly wrapped by a Project
 // operator that corresponds to the given RETURNING clause.
 func (mb *mutationBuilder) buildDelete(returning tree.ReturningExprs) {
+	// Disambiguate names so that references in any expressions, such as a
+	// partial index predicate, refer to the correct columns.
+	mb.disambiguateColumns()
+
+	// Add partial index boolean columns to the input.
+	mb.addPartialIndexDelCols()
+
 	mb.buildFKChecksAndCascadesForDelete()
 
 	private := mb.makeMutationPrivate(returning != nil)

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -640,7 +640,7 @@ func (mb *mutationBuilder) buildInsert(returning tree.ReturningExprs) {
 	mb.addCheckConstraintCols()
 
 	// Add any partial index boolean columns to the input.
-	mb.addPartialIndexPredicateCols()
+	mb.addPartialIndexPutCols()
 
 	mb.buildFKChecksForInsert()
 

--- a/pkg/sql/opt/optbuilder/testdata/delete
+++ b/pkg/sql/opt/optbuilder/testdata/delete
@@ -437,3 +437,35 @@ build
 DELETE FROM mutation ORDER BY p LIMIT 2
 ----
 error (42P10): column "p" is being backfilled
+
+# ------------------------------------------------------------------------------
+# Test partial index column values.
+# ------------------------------------------------------------------------------
+
+exec-ddl
+CREATE TABLE partial_indexes (
+    a INT PRIMARY KEY,
+    b INT,
+    c STRING,
+    INDEX (b),
+    INDEX (b) WHERE c = 'foo',
+    INDEX (c) WHERE a > b AND c = 'bar'
+)
+----
+
+build
+DELETE FROM partial_indexes
+----
+delete partial_indexes
+ ├── columns: <none>
+ ├── fetch columns: a:4 b:5 c:6
+ └── project
+      ├── columns: partial_index_del1:7 partial_index_del2:8 a:4!null b:5 c:6
+      ├── scan partial_indexes
+      │    ├── columns: a:4!null b:5 c:6
+      │    └── partial index predicates
+      │         ├── secondary: c:6 = 'foo'
+      │         └── secondary: (a:4 > b:5) AND (c:6 = 'bar')
+      └── projections
+           ├── c:6 = 'foo' [as=partial_index_del1:7]
+           └── (a:4 > b:5) AND (c:6 = 'bar') [as=partial_index_del2:8]

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -1258,12 +1258,12 @@ insert partial_indexes
  │    ├── column1:4 => a:1
  │    ├── column2:5 => b:2
  │    └── column3:6 => c:3
- ├── partial index pred columns: indexpred1:7 indexpred2:8
+ ├── partial index put columns: partial_index_put1:7 partial_index_put2:8
  └── project
-      ├── columns: indexpred1:7!null indexpred2:8!null column1:4!null column2:5!null column3:6!null
+      ├── columns: partial_index_put1:7!null partial_index_put2:8!null column1:4!null column2:5!null column3:6!null
       ├── values
       │    ├── columns: column1:4!null column2:5!null column3:6!null
       │    └── (2, 1, 'bar')
       └── projections
-           ├── column3:6 = 'foo' [as=indexpred1:7]
-           └── (column1:4 > column2:5) AND (column3:6 = 'bar') [as=indexpred2:8]
+           ├── column3:6 = 'foo' [as=partial_index_put1:7]
+           └── (column1:4 > column2:5) AND (column3:6 = 'bar') [as=partial_index_put2:8]

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1588,7 +1588,8 @@ func (ef *execFactory) ConstructDelete(
 	*del = deleteNode{
 		source: input.(planNode),
 		run: deleteRun{
-			td: tableDeleter{rd: rd, alloc: ef.planner.alloc},
+			td:                        tableDeleter{rd: rd, alloc: ef.planner.alloc},
+			partialIndexDelValsOffset: len(rd.FetchCols),
 		},
 	}
 

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -390,12 +390,12 @@ func (ru *Updater) UpdateRow(
 	}
 
 	if rowPrimaryKeyChanged {
-		if err := ru.rd.DeleteRow(ctx, batch, oldValues, traceKV); err != nil {
-			return nil, err
-		}
 		// TODO(mgartner): Add partial index IDs to ignoreIndexes that we should
 		// not write entries to.
 		var ignoreIndexes util.FastIntSet
+		if err := ru.rd.DeleteRow(ctx, batch, oldValues, ignoreIndexes, traceKV); err != nil {
+			return nil, err
+		}
 		if err := ru.ri.InsertRow(
 			ctx, batch, ru.newValues, ignoreIndexes, false /* ignoreConflicts */, traceKV,
 		); err != nil {

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -67,7 +67,7 @@ func (td *tableDeleter) row(
 	ctx context.Context, values tree.Datums, ignoreIndexes util.FastIntSet, traceKV bool,
 ) error {
 	td.batchSize++
-	return td.rd.DeleteRow(ctx, td.b, values, traceKV)
+	return td.rd.DeleteRow(ctx, td.b, values, ignoreIndexes, traceKV)
 }
 
 // deleteAllRows runs the kv operations necessary to delete all sql rows in the


### PR DESCRIPTION
This commit makes `DELETE`s only attempt to remove entries from partial
indexes when the row exists in the partial index. For `DELETE`s, the
optimizer now synthesizes a boolean column for each partial index on the
table. This column evaluates to true if the partial index predicate
evaluates to true for the row being deleted, signifying that it exists
within the partial index and should be deleted.

There are now two sets of columns synthesized for partial index
mutations, PUT columns and DEL columns. The PUT columns communicate when
rows should be added to partial indexes. These are currently used by
`INSERT` and in the future will be used by `UPDATE` and `UPSERT`. The
DEL columns communicate when rows shold be removed from partial indexes.
These are currently used by `DELETE`, and in the future will be used by
`UPDATE` and `UPSERT`.

Release note: None