### PR TITLE
colexec: remove execgen.RANGE

### DIFF
--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -126,28 +126,39 @@ func (a *anyNotNull_TYPE_AGGKINDAgg) Compute(b coldata.Batch, inputIdxs []uint32
 	a.allocator.PerformOperation(
 		[]coldata.Vec{a.vec},
 		func() {
+			// Capture col to force bounds check to work. See
+			// https://github.com/golang/go/issues/39756
+			col := col
+			_ = execgen.UNSAFEGET(col, inputLen-1)
+			// {{if eq "_AGGKIND" "Ordered"}}
+			groups := a.groups
+			// {{end}}
 			if nulls.MaybeHasNulls() {
 				if sel != nil {
 					sel = sel[:inputLen]
 					for _, i := range sel {
-						_FIND_ANY_NOT_NULL(a, nulls, i, true)
+						_FIND_ANY_NOT_NULL(a, groups, nulls, i, true)
 					}
 				} else {
-					col = execgen.SLICE(col, 0, inputLen)
+					// {{if eq "_AGGKIND" "Ordered"}}
+					_ = groups[inputLen-1]
+					// {{end}}
 					for i := 0; i < inputLen; i++ {
-						_FIND_ANY_NOT_NULL(a, nulls, i, true)
+						_FIND_ANY_NOT_NULL(a, groups, nulls, i, true)
 					}
 				}
 			} else {
 				if sel != nil {
 					sel = sel[:inputLen]
 					for _, i := range sel {
-						_FIND_ANY_NOT_NULL(a, nulls, i, false)
+						_FIND_ANY_NOT_NULL(a, groups, nulls, i, false)
 					}
 				} else {
-					col = execgen.SLICE(col, 0, inputLen)
+					// {{if eq "_AGGKIND" "Ordered"}}
+					_ = groups[inputLen-1]
+					// {{end}}
 					for i := 0; i < inputLen; i++ {
-						_FIND_ANY_NOT_NULL(a, nulls, i, false)
+						_FIND_ANY_NOT_NULL(a, groups, nulls, i, false)
 					}
 				}
 			}
@@ -197,12 +208,12 @@ func (a *anyNotNull_TYPE_AGGKINDAggAlloc) newAggFunc() aggregateFunc {
 // the first row of a new group, and no non-nulls have been found for the
 // current group, then the output for the current group is set to null.
 func _FIND_ANY_NOT_NULL(
-	a *anyNotNull_TYPE_AGGKINDAgg, nulls *coldata.Nulls, i int, _HAS_NULLS bool,
+	a *anyNotNull_TYPE_AGGKINDAgg, groups []bool, nulls *coldata.Nulls, i int, _HAS_NULLS bool,
 ) { // */}}
 	// {{define "findAnyNotNull" -}}
 
 	// {{if eq "_AGGKIND" "Ordered"}}
-	if a.groups[i] {
+	if groups[i] {
 		// If this is a new group, check if any non-nulls have been found for the
 		// current group.
 		if !a.foundNonNullForCurrentGroup {

--- a/pkg/sql/colexec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/any_not_null_agg_tmpl.go
@@ -134,7 +134,7 @@ func (a *anyNotNull_TYPE_AGGKINDAgg) Compute(b coldata.Batch, inputIdxs []uint32
 					}
 				} else {
 					col = execgen.SLICE(col, 0, inputLen)
-					for execgen.RANGE(i, col, 0, inputLen) {
+					for i := 0; i < inputLen; i++ {
 						_FIND_ANY_NOT_NULL(a, nulls, i, true)
 					}
 				}
@@ -146,7 +146,7 @@ func (a *anyNotNull_TYPE_AGGKINDAgg) Compute(b coldata.Batch, inputIdxs []uint32
 					}
 				} else {
 					col = execgen.SLICE(col, 0, inputLen)
-					for execgen.RANGE(i, col, 0, inputLen) {
+					for i := 0; i < inputLen; i++ {
 						_FIND_ANY_NOT_NULL(a, nulls, i, false)
 					}
 				}

--- a/pkg/sql/colexec/bool_vec_to_sel.go
+++ b/pkg/sql/colexec/bool_vec_to_sel.go
@@ -82,10 +82,11 @@ func (p *boolVecToSelOp) Next(ctx context.Context) coldata.Batch {
 		} else {
 			batch.SetSelection(true)
 			sel := batch.Selection()
-			for i := range outputCol[:n] {
+			col := outputCol[:n]
+			for i := range col {
 				var inc int
 				// Ditto above: replace a conditional with a data dependency.
-				if outputCol[i] {
+				if col[i] {
 					inc = 1
 				}
 				sel[idx] = i

--- a/pkg/sql/colexec/cast_test.go
+++ b/pkg/sql/colexec/cast_test.go
@@ -184,7 +184,7 @@ func BenchmarkCastOp(b *testing.B) {
 						}
 						selectivity := selectivity
 						if !useSel {
-							selectivity = 1.0
+							selectivity = 0
 						}
 						typs := []*types.T{typePair[0]}
 						batch := coldatatestutils.RandomBatchWithSel(

--- a/pkg/sql/colexec/cast_tmpl.go
+++ b/pkg/sql/colexec/cast_tmpl.go
@@ -64,6 +64,11 @@ func _L_UNSAFEGET(to, from interface{}) interface{} {
 	colexecerror.InternalError("")
 }
 
+// This will be replaced with execgen.UNSAFEGET.
+func _R_UNSAFEGET(to, from interface{}) interface{} {
+	colexecerror.InternalError("")
+}
+
 // This will be replaced with execgen.SET.
 func _R_SET(to, from interface{}) {
 	colexecerror.InternalError("")
@@ -108,7 +113,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								}
 							}
 						} else {
+							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = _L_SLICE(inputCol, 0, n)
+							_ = _L_UNSAFEGET(inputCol, n-1)
+							_ = _R_UNSAFEGET(outputCol, n-1)
 							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
@@ -130,7 +138,10 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 								_R_SET(outputCol, i, r)
 							}
 						} else {
+							// Remove bounds checks for inputCol[i] and outputCol[i].
 							inputCol = _L_SLICE(inputCol, 0, n)
+							_ = _L_UNSAFEGET(inputCol, n-1)
+							_ = _R_UNSAFEGET(outputCol, n-1)
 							for i := 0; i < n; i++ {
 								v := _L_UNSAFEGET(inputCol, i)
 								var r _R_GO_TYPE

--- a/pkg/sql/colexec/cast_tmpl.go
+++ b/pkg/sql/colexec/cast_tmpl.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
@@ -110,7 +109,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 							}
 						} else {
 							inputCol = _L_SLICE(inputCol, 0, n)
-							for execgen.RANGE(i, inputCol, 0, n) {
+							for i := 0; i < n; i++ {
 								if inputNulls.NullAt(i) {
 									outputNulls.SetNull(i)
 								} else {
@@ -132,7 +131,7 @@ func cast(inputVec, outputVec coldata.Vec, n int, sel []int) {
 							}
 						} else {
 							inputCol = _L_SLICE(inputCol, 0, n)
-							for execgen.RANGE(i, inputCol, 0, n) {
+							for i := 0; i < n; i++ {
 								v := _L_UNSAFEGET(inputCol, i)
 								var r _R_GO_TYPE
 								_CAST(r, v, inputCol)

--- a/pkg/sql/colexec/const_tmpl.go
+++ b/pkg/sql/colexec/const_tmpl.go
@@ -112,7 +112,7 @@ func (c const_TYPEOp) Next(ctx context.Context) coldata.Batch {
 				}
 			} else {
 				col = execgen.SLICE(col, 0, n)
-				for execgen.RANGE(i, col, 0, n) {
+				for i := 0; i < n; i++ {
 					execgen.SET(col, i, c.constVal)
 				}
 			}

--- a/pkg/sql/colexec/distinct_tmpl.go
+++ b/pkg/sql/colexec/distinct_tmpl.go
@@ -242,19 +242,24 @@ func (p *distinct_TYPEOp) Next(ctx context.Context) coldata.Batch {
 				lastVal, lastValNull = checkDistinctWithNulls(idx, idx, lastVal, nulls, lastValNull, col, outputCol)
 			}
 		} else {
+			// Eliminate bounds checks for outputCol[idx].
+			_ = outputCol[n-1]
+			// Eliminate bounds checks for col[idx].
+			_ = execgen.UNSAFEGET(col, n-1)
 			for _, idx := range sel {
 				lastVal = checkDistinct(idx, idx, lastVal, col, outputCol)
 			}
 		}
 	} else {
-		col = execgen.SLICE(col, 0, n)
-		outputCol = outputCol[:n]
-		_ = outputCol[n-1]
 		if nulls != nil {
 			for idx := 0; idx < n; idx++ {
 				lastVal, lastValNull = checkDistinctWithNulls(idx, idx, lastVal, nulls, lastValNull, col, outputCol)
 			}
 		} else {
+			// Eliminate bounds checks for outputCol[idx].
+			_ = outputCol[n-1]
+			// Eliminate bounds checks for col[idx].
+			_ = execgen.UNSAFEGET(col, n-1)
 			for idx := 0; idx < n; idx++ {
 				lastVal = checkDistinct(idx, idx, lastVal, col, outputCol)
 			}
@@ -286,6 +291,10 @@ func (p partitioner_TYPE) partitionWithOrder(
 	col := colVec.TemplateType()
 	col = execgen.SLICE(col, 0, n)
 	outputCol = outputCol[:n]
+	// Eliminate bounds checks for outputcol[outputIdx].
+	_ = outputCol[len(order)-1]
+	// Eliminate bounds checks for col[outputIdx].
+	_ = execgen.UNSAFEGET(col, len(order)-1)
 	outputCol[0] = true
 	if nulls != nil {
 		for outputIdx, checkIdx := range order {
@@ -309,8 +318,8 @@ func (p partitioner_TYPE) partition(colVec coldata.Vec, outputCol []bool, n int)
 	}
 
 	col := colVec.TemplateType()
-	col = execgen.SLICE(col, 0, n)
-	outputCol = outputCol[:n]
+	_ = execgen.UNSAFEGET(col, n-1)
+	_ = outputCol[n-1]
 	outputCol[0] = true
 	if nulls != nil {
 		for idx := 0; idx < n; idx++ {

--- a/pkg/sql/colexec/distinct_tmpl.go
+++ b/pkg/sql/colexec/distinct_tmpl.go
@@ -251,11 +251,11 @@ func (p *distinct_TYPEOp) Next(ctx context.Context) coldata.Batch {
 		outputCol = outputCol[:n]
 		_ = outputCol[n-1]
 		if nulls != nil {
-			for execgen.RANGE(idx, col, 0, n) {
+			for idx := 0; idx < n; idx++ {
 				lastVal, lastValNull = checkDistinctWithNulls(idx, idx, lastVal, nulls, lastValNull, col, outputCol)
 			}
 		} else {
-			for execgen.RANGE(idx, col, 0, n) {
+			for idx := 0; idx < n; idx++ {
 				lastVal = checkDistinct(idx, idx, lastVal, col, outputCol)
 			}
 		}
@@ -313,11 +313,11 @@ func (p partitioner_TYPE) partition(colVec coldata.Vec, outputCol []bool, n int)
 	outputCol = outputCol[:n]
 	outputCol[0] = true
 	if nulls != nil {
-		for execgen.RANGE(idx, col, 0, n) {
+		for idx := 0; idx < n; idx++ {
 			lastVal, lastValNull = checkDistinctWithNulls(idx, idx, lastVal, nulls, lastValNull, col, outputCol)
 		}
 	} else {
-		for execgen.RANGE(idx, col, 0, n) {
+		for idx := 0; idx < n; idx++ {
 			lastVal = checkDistinct(idx, idx, lastVal, col, outputCol)
 		}
 	}

--- a/pkg/sql/colexec/execgen/cmd/execgen/any_not_null_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/any_not_null_agg_gen.go
@@ -31,8 +31,8 @@ func genAnyNotNullAgg(inputFileContents string, wr io.Writer) error {
 	)
 	s := r.Replace(inputFileContents)
 
-	findAnyNotNull := makeFunctionRegex("_FIND_ANY_NOT_NULL", 4)
-	s = findAnyNotNull.ReplaceAllString(s, `{{template "findAnyNotNull" buildDict "Global" . "HasNulls" $4}}`)
+	findAnyNotNull := makeFunctionRegex("_FIND_ANY_NOT_NULL", 5)
+	s = findAnyNotNull.ReplaceAllString(s, `{{template "findAnyNotNull" buildDict "Global" . "HasNulls" $5}}`)
 
 	s = replaceManipulationFuncs(s)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/cast_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/cast_gen.go
@@ -37,6 +37,9 @@ func genCastOperators(inputFileContents string, wr io.Writer) error {
 	s = strings.ReplaceAll(s, "_L_UNSAFEGET", "execgen.UNSAFEGET")
 	s = replaceManipulationFuncsAmbiguous(".Left", s)
 
+	s = strings.ReplaceAll(s, "_R_UNSAFEGET", "execgen.UNSAFEGET")
+	s = replaceManipulationFuncsAmbiguous(".Right", s)
+
 	s = strings.ReplaceAll(s, "_R_SET", "execgen.SET")
 	s = replaceManipulationFuncsAmbiguous(".Right", s)
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/data_manipulation_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/data_manipulation_gen.go
@@ -70,11 +70,6 @@ var dataManipulationReplacementInfos = []dataManipulationReplacementInfo{
 		replaceWith:         "Len",
 	},
 	{
-		templatePlaceholder: "execgen.RANGE",
-		numArgs:             4,
-		replaceWith:         "Range",
-	},
-	{
 		templatePlaceholder: "execgen.WINDOW",
 		numArgs:             3,
 		replaceWith:         "Window",

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
@@ -605,15 +605,6 @@ func (b *argWidthOverloadBase) Len(target string) string {
 	return fmt.Sprintf("len(%s)", target)
 }
 
-// Range is a function that should only be used in templates.
-func (b *argWidthOverloadBase) Range(loopVariableIdent, target, start, end string) string {
-	switch b.CanonicalTypeFamily {
-	case types.BytesFamily, typeconv.DatumVecCanonicalTypeFamily:
-		return fmt.Sprintf("%[1]s := %[2]s; %[1]s < %[3]s; %[1]s++", loopVariableIdent, start, end)
-	}
-	return fmt.Sprintf("%[1]s := range %[2]s", loopVariableIdent, target)
-}
-
 // Window is a function that should only be used in templates.
 func (b *argWidthOverloadBase) Window(target, start, end string) string {
 	switch b.CanonicalTypeFamily {
@@ -642,7 +633,6 @@ var (
 	_    = awob.AppendSlice
 	_    = awob.AppendVal
 	_    = awob.Len
-	_    = awob.Range
 	_    = awob.Window
 )
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/selection_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/selection_ops_gen.go
@@ -37,6 +37,7 @@ func getSelectionOpsTmpl(inputFileContents string) (*template.Template, error) {
 	assignCmpRe := makeFunctionRegex("_ASSIGN_CMP", 6)
 	s = assignCmpRe.ReplaceAllString(s, makeTemplateFunctionCall("Right.Assign", 6))
 
+	s = strings.ReplaceAll(s, "_L_UNSAFEGET", "execgen.UNSAFEGET")
 	s = replaceManipulationFuncsAmbiguous(".Left", s)
 	s = strings.ReplaceAll(s, "_R_UNSAFEGET", "execgen.UNSAFEGET")
 	s = strings.ReplaceAll(s, "_R_SLICE", "execgen.SLICE")

--- a/pkg/sql/colexec/execgen/placeholders.go
+++ b/pkg/sql/colexec/execgen/placeholders.go
@@ -26,7 +26,6 @@ var (
 	_ = APPENDVAL
 	_ = LEN
 	_ = ZERO
-	_ = RANGE
 	_ = WINDOW
 )
 
@@ -93,12 +92,6 @@ func LEN(target interface{}) interface{} {
 // ZERO is a template function.
 func ZERO(target interface{}) {
 	colexecerror.InternalError(nonTemplatePanic)
-}
-
-// RANGE is a template function.
-func RANGE(loopVariableIdent, target, start, end interface{}) bool {
-	colexecerror.InternalError(nonTemplatePanic)
-	return false
 }
 
 // WINDOW is a template function.

--- a/pkg/sql/colexec/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/min_max_agg_tmpl.go
@@ -179,7 +179,7 @@ func (a *_AGG_TYPE_AGGKINDAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 					}
 				} else {
 					col = execgen.SLICE(col, 0, inputLen)
-					for execgen.RANGE(i, col, 0, inputLen) {
+					for i := 0; i < inputLen; i++ {
 						_ACCUMULATE_MINMAX(a, nulls, i, true)
 					}
 				}
@@ -191,7 +191,7 @@ func (a *_AGG_TYPE_AGGKINDAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 					}
 				} else {
 					col = execgen.SLICE(col, 0, inputLen)
-					for execgen.RANGE(i, col, 0, inputLen) {
+					for i := 0; i < inputLen; i++ {
 						_ACCUMULATE_MINMAX(a, nulls, i, false)
 					}
 				}

--- a/pkg/sql/colexec/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_const_ops_tmpl.go
@@ -136,7 +136,7 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 	} else {
 		col = execgen.SLICE(col, 0, n)
 		_ = _RETURN_UNSAFEGET(projCol, n-1)
-		for execgen.RANGE(i, col, 0, n) {
+		for i := 0; i < n; i++ {
 			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS)
 		}
 	}

--- a/pkg/sql/colexec/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_non_const_ops_tmpl.go
@@ -169,7 +169,7 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 		_ = _RETURN_UNSAFEGET(projCol, colLen-1)
 		_ = _R_UNSAFEGET(col2, colLen-1)
 		// {{end}}
-		for execgen.RANGE(i, col1, 0, n) {
+		for i := 0; i < n; i++ {
 			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS)
 		}
 	}

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -229,7 +229,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 				batch.SetSelection(true)
 				sel := batch.Selection()
 				col = execgen.SLICE(col, 0, n)
-				for execgen.RANGE(i, col, 0, n) {
+				for i := 0; i < n; i++ {
 					v := execgen.UNSAFEGET(col, i)
 					if !nulls.NullAt(i) && cmpIn_TYPE(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -251,7 +251,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 				batch.SetSelection(true)
 				sel := batch.Selection()
 				col = execgen.SLICE(col, 0, n)
-				for execgen.RANGE(i, col, 0, n) {
+				for i := 0; i < n; i++ {
 					v := execgen.UNSAFEGET(col, i)
 					if cmpIn_TYPE(v, col, si.filterRow, si.hasNulls) == compVal {
 						sel[idx] = i
@@ -312,7 +312,7 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = execgen.SLICE(col, 0, n)
-			for execgen.RANGE(i, col, 0, n) {
+			for i := 0; i < n; i++ {
 				if nulls.NullAt(i) {
 					projNulls.SetNull(i)
 				} else {
@@ -340,7 +340,7 @@ func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 			}
 		} else {
 			col = execgen.SLICE(col, 0, n)
-			for execgen.RANGE(i, col, 0, n) {
+			for i := 0; i < n; i++ {
 				v := execgen.UNSAFEGET(col, i)
 				cmpRes := cmpIn_TYPE(v, col, pi.filterRow, pi.hasNulls)
 				if cmpRes == siNull {

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -228,7 +228,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				col = execgen.SLICE(col, 0, n)
+				_ = execgen.UNSAFEGET(col, n-1)
 				for i := 0; i < n; i++ {
 					v := execgen.UNSAFEGET(col, i)
 					if !nulls.NullAt(i) && cmpIn_TYPE(v, col, si.filterRow, si.hasNulls) == compVal {
@@ -250,7 +250,7 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 			} else {
 				batch.SetSelection(true)
 				sel := batch.Selection()
-				col = execgen.SLICE(col, 0, n)
+				_ = execgen.UNSAFEGET(col, n-1)
 				for i := 0; i < n; i++ {
 					v := execgen.UNSAFEGET(col, i)
 					if cmpIn_TYPE(v, col, si.filterRow, si.hasNulls) == compVal {

--- a/pkg/sql/colexec/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/selection_ops_tmpl.go
@@ -80,7 +80,7 @@ func _SEL_CONST_LOOP(_HAS_NULLS bool) { // */}}
 		batch.SetSelection(true)
 		sel := batch.Selection()
 		col = execgen.SLICE(col, 0, n)
-		for execgen.RANGE(i, col, 0, n) {
+		for i := 0; i < n; i++ {
 			var cmp bool
 			arg := execgen.UNSAFEGET(col, i)
 			_ASSIGN_CMP(cmp, arg, p.constArg, _, col, _)
@@ -133,7 +133,7 @@ func _SEL_LOOP(_HAS_NULLS bool) { // */}}
 		col1Len := execgen.LEN(col1)
 		col2 = _R_SLICE(col2, 0, col1Len)
 		// {{end}}
-		for execgen.RANGE(i, col1, 0, n) {
+		for i := 0; i < n; i++ {
 			var cmp bool
 			arg1 := execgen.UNSAFEGET(col1, i)
 			arg2 := _R_UNSAFEGET(col2, i)

--- a/pkg/sql/colexec/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/selection_ops_tmpl.go
@@ -79,7 +79,7 @@ func _SEL_CONST_LOOP(_HAS_NULLS bool) { // */}}
 	} else {
 		batch.SetSelection(true)
 		sel := batch.Selection()
-		col = execgen.SLICE(col, 0, n)
+		_ = execgen.UNSAFEGET(col, n-1)
 		for i := 0; i < n; i++ {
 			var cmp bool
 			arg := execgen.UNSAFEGET(col, i)
@@ -109,7 +109,7 @@ func _SEL_LOOP(_HAS_NULLS bool) { // */}}
 		sel = sel[:n]
 		for _, i := range sel {
 			var cmp bool
-			arg1 := execgen.UNSAFEGET(col1, i)
+			arg1 := _L_UNSAFEGET(col1, i)
 			arg2 := _R_UNSAFEGET(col2, i)
 			_ASSIGN_CMP(cmp, arg1, arg2, _, col1, col2)
 			// {{if _HAS_NULLS}}
@@ -125,17 +125,11 @@ func _SEL_LOOP(_HAS_NULLS bool) { // */}}
 	} else {
 		batch.SetSelection(true)
 		sel := batch.Selection()
-		// {{if not (eq .Left.VecMethod "Bytes")}}
-		// {{/* Slice is a noop for Bytes type, so col1Len below might contain an
-		// incorrect value. In order to keep bounds check elimination for all other
-		// types, we simply omit this code snippet for Bytes. */}}
-		col1 = execgen.SLICE(col1, 0, n)
-		col1Len := execgen.LEN(col1)
-		col2 = _R_SLICE(col2, 0, col1Len)
-		// {{end}}
+		_ = _L_UNSAFEGET(col1, n-1)
+		_ = _R_UNSAFEGET(col2, n-1)
 		for i := 0; i < n; i++ {
 			var cmp bool
-			arg1 := execgen.UNSAFEGET(col1, i)
+			arg1 := _L_UNSAFEGET(col1, i)
 			arg2 := _R_UNSAFEGET(col2, i)
 			_ASSIGN_CMP(cmp, arg1, arg2, _, col1, col2)
 			// {{if _HAS_NULLS}}


### PR DESCRIPTION
execgen.RANGE is a complex beast - it either returns `i := range c` or `i := 0; i < n; i++` depending on the datatype. It's one of the trickier cases for `execgen`, since it's not really a proper statement, but a fragment of text.

The `range` statement is mainly useful to get rid of bounds checks. But we can manually get rid of bounds checks by doing early bounds checks against a column with `execgen.UNSAFEGET(col, n-1)`.

This PR removes `execgen.RANGE` and adds bounds checks to all of the users of `execgen.RANGE` that didn't already have them.