### PR TITLE
cli: new flag `--self` for `decommission`/`recommission`

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -972,6 +972,12 @@ When no node ID is specified, also lists all nodes that have been decommissioned
 in the history of the cluster.`,
 	}
 
+	NodeDecommissionSelf = FlagInfo{
+		Name: "self",
+		Description: `Use the node ID of the node connected to via --host
+as target of the decommissioning or recommissioning command.`,
+	}
+
 	SQLFmtLen = FlagInfo{
 		Name: "print-width",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -389,6 +389,7 @@ func setQuitContextDefaults() {
 // See below for defaults.
 var nodeCtx struct {
 	nodeDecommissionWait   nodeDecommissionWaitType
+	nodeDecommissionSelf   bool
 	statusShowRanges       bool
 	statusShowStats        bool
 	statusShowDecommission bool

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -581,6 +581,12 @@ func init() {
 	// Decommission command.
 	varFlag(decommissionNodeCmd.Flags(), &nodeCtx.nodeDecommissionWait, cliflags.Wait)
 
+	// Decommission and recommission share --self.
+	for _, cmd := range []*cobra.Command{decommissionNodeCmd, recommissionNodeCmd} {
+		f := cmd.Flags()
+		boolFlag(f, &nodeCtx.nodeDecommissionSelf, cliflags.NodeDecommissionSelf)
+	}
+
 	// Quit and node drain commands.
 	for _, cmd := range []*cobra.Command{quitCmd, drainNodeCmd} {
 		f := cmd.Flags()


### PR DESCRIPTION
Fixes #49583

Requested by community: it's hard/inconvenient to program
orchestration with the `node decommission` command because
the orchestrator is not aware of crdb node IDs -- only pod
addresses. Therefore, it is useful to make these node commands operate
"on the node they are connected to".

Release note (cli change): The commands `cockroach node decommission`
and `recommission` now recognize a new flag `--self`. This can be
passed *in lieu* of an explicit list of node IDs, and indicates
that the operation targets the node the command is connected to
(either via `--host` if specified, or `localhost`).