### PR TITLE
cli/start: ensure that SIGQUIT dumps stacks even during graceful term

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1041,6 +1041,14 @@ If problems persist, please see %s.`
 	const hardShutdownHint = " - node may take longer to restart & clients may need to wait for leases to expire"
 	select {
 	case sig := <-signalCh:
+		switch sig {
+		case quitSignal:
+			// A SIGQUIT is received during the "graceful shutdown" phase
+			// initiated by another signal. Take this as a request to get
+			// the stacks at this point.
+			log.DumpStacks(shutdownCtx)
+		}
+
 		// This new signal is not welcome, as it interferes with the graceful
 		// shutdown process.
 		log.Shoutf(shutdownCtx, log.Severity_ERROR,


### PR DESCRIPTION
Release note (bug fix): A server node now properly dumps Go stacks
to its log file for troubleshooting upon receiving SIGQUIT during
node shutdown. Previously SIGQUIT was only recognized for this
purpose while the node had not started shutting down already.