### PR TITLE
cli/start: make SIGTERM idempotent

### DIFF
--- a/pkg/cli/interactive_tests/test_server_sig.tcl
+++ b/pkg/cli/interactive_tests/test_server_sig.tcl
@@ -9,7 +9,7 @@ send "PS1='\\h:''/# '\r"
 eexpect ":/# "
 
 start_test "Check that the server shuts down upon receiving SIGTERM"
-send "$argv start-single-node --insecure --pid-file=server_pid --log-dir=logs \r"
+send "$argv start-single-node --insecure --pid-file=server_pid --log-dir=logs -s=path=logs/db \r"
 eexpect "initialized"
 
 system "kill `cat server_pid`"
@@ -25,7 +25,7 @@ eexpect ":/# "
 end_test
 
 start_test "Check that the server shuts down upon receiving Ctrl+C."
-send "$argv start-single-node --insecure --pid-file=server_pid --log-dir=logs \r"
+send "$argv start-single-node --insecure --pid-file=server_pid --log-dir=logs -s=path=logs/db \r"
 eexpect "restarted"
 
 interrupt
@@ -43,7 +43,7 @@ end_test
 start_test "Check that the server shuts down fast upon receiving Ctrl+C twice."
 
 # Start a server via the shell
-send "$argv start-single-node --insecure --pid-file=server_pid --log-dir=logs \r"
+send "$argv start-single-node --insecure --pid-file=server_pid --log-dir=logs -s=path=logs/db \r"
 eexpect "restarted"
 
 # Make a client open a connection and keep using it with an open txn.
@@ -64,8 +64,8 @@ send "\003"
 set interrupted false
 expect {
     "hard shutdown" {
-	global interrupted
-	set interrupted true
+        global interrupted
+        set interrupted true
     }
     "shutdown completed" {}
     timeout { handle_timeout "server shutdown message" }
@@ -86,7 +86,40 @@ set spawn_id $client_spawn_id
 send "\\q\r"
 eexpect eof
 
-# terminate the shell
+start_test "Check that the server shuts keeps gracefully shutting down upon receiving SIGTERM twice."
+
+# Start a server via the shell
+set spawn_id $shell_spawn_id
+send "$argv start-single-node --insecure --pid-file=server_pid --log-dir=logs -s=path=logs/db \r"
+eexpect "restarted"
+
+# Make a client open a connection and keep using it with an open txn.
+spawn $argv sql
+set client_spawn_id $spawn_id
+eexpect root@
+send "begin;\r\rselect 1;\r"
+eexpect "1 row"
+eexpect root@
+
+# Now interrupt the server twice.
+set spawn_id $shell_spawn_id
+system "kill `cat server_pid`"
+eexpect "graceful shutdown"
+system "kill `cat server_pid`"
+# There's still a very small chance the server could finish draining
+# before the second signal is sent, but oh well.
+expect {
+    "shutdown completed" {}
+    "hard shutdown" {
+        report "unexpected hard shutdown"
+        exit 1
+    }
+    timeout { handle_timeout "server shutdown message" }
+}
+eexpect ":/# "
+end_test
+
+# Terminate the SQL shell.
 set spawn_id $shell_spawn_id
 send "exit\r"
 eexpect eof

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1041,6 +1041,14 @@ If problems persist, please see %s.`
 	const hardShutdownHint = " - node may take longer to restart & clients may need to wait for leases to expire"
 	select {
 	case sig := <-signalCh:
+		switch sig {
+		case quitSignal:
+			// A SIGQUIT is received during the "graceful shutdown" phase
+			// initiated by another signal. Take this as a request to get
+			// the stacks at this point.
+			log.DumpStacks(shutdownCtx)
+		}
+
 		// This new signal is not welcome, as it interferes with the graceful
 		// shutdown process.
 		log.Shoutf(shutdownCtx, log.Severity_ERROR,

--- a/pkg/cli/start_unix.go
+++ b/pkg/cli/start_unix.go
@@ -32,6 +32,10 @@ import (
 // must terminate the process.
 var drainSignals = []os.Signal{unix.SIGINT, unix.SIGTERM, unix.SIGQUIT}
 
+// termSignal is the signal that causes an idempotent graceful
+// shutdown (i.e. second occurrence does not incur hard shutdown).
+var termSignal os.Signal = unix.SIGTERM
+
 // quitSignal is the signal to recognize to dump Go stacks.
 var quitSignal os.Signal = unix.SIGQUIT
 

--- a/pkg/cli/start_windows.go
+++ b/pkg/cli/start_windows.go
@@ -15,6 +15,10 @@ import "os"
 // drainSignals are the signals that will cause the server to drain and exit.
 var drainSignals = []os.Signal{os.Interrupt}
 
+// termSignal is the signal that causes an idempotent graceful
+// shutdown (i.e. second occurrence does not incur hard shutdown).
+var termSignal os.Signal = nil
+
 // quitSignal is the signal to recognize to dump Go stacks.
 var quitSignal os.Signal = nil
 


### PR DESCRIPTION
First commit from #50538.
Fixes #48070.

Prior to this patch, if SIGTERM was received a 2nd time, the server
would expedite shutdown.

This is inconvenient in practice because if an operator mistakenly
issues a shutdown without being aware that a shutdown is already in
progress, they will get a hard shutdown while expecting a graceful
shutdown. This can incur undesired downtime.

Release note (backward-incompatible change): A node will not any
more proceed to a hard shutdown upon receiving SIGTERM a second time,
or upon receiving SIGTERM after another signal. Instead, the first
SIGTERM initiates a graceful shutdown and further occurrences of
SIGTERM are ignored. To initiate a hard shutdown, the user can issue
SIGINT two times (or SIGINT once after SIGTERM) instead.