### PR TITLE
tree: add a case for enums in AsJSON

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1059,3 +1059,8 @@ query T
 SELECT * FROM enum_data_type
 ----
 hello
+
+query T
+SELECT to_json('hello'::greeting)
+----
+"hello"

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -2980,6 +2980,8 @@ func AsJSON(d Datum, loc *time.Location) (json.JSON, error) {
 		return json.FromString(string(*t)), nil
 	case *DCollatedString:
 		return json.FromString(t.Contents), nil
+	case *DEnum:
+		return json.FromString(t.LogicalRep), nil
 	case *DJSON:
 		return t.JSON, nil
 	case *DArray:


### PR DESCRIPTION
Fixes #50524.

This commit fixes an assertion failure by adding a case for enum types
in the `tree.AsJSON` function.

Release note: None