### PR TITLE
sql: fix potential nil dereference in parseandrequirestring

### DIFF
--- a/pkg/sql/sem/tree/parse_string.go
+++ b/pkg/sql/sem/tree/parse_string.go
@@ -52,7 +52,10 @@ func ParseAndRequireString(t *types.T, s string, ctx ParseTimeContext) (Datum, e
 		return ParseDJSON(s)
 	case types.OidFamily:
 		i, err := ParseDInt(s)
-		return NewDOid(*i), err
+		if err != nil {
+			return nil, err
+		}
+		return NewDOid(*i), nil
 	case types.StringFamily:
 		// If the string type specifies a limit we truncate to that limit:
 		//   'hello'::CHAR(2) -> 'he'


### PR DESCRIPTION
Previously, 'ParseAndRequireString' directly dereferenced pointer
without checking when parsing string as OID type, which may leaded to nil
pointer dereference if parsing is failed

This commit fixed this issue.

Fix: #50463
Release note: None