### PR TITLE
release-20.1: gcjob: skip table if descriptor doesn't exist

### DIFF
--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -1290,3 +1290,92 @@ CREATE VIEW test.acol(a) AS SELECT a FROM test.t;
 		return err
 	})
 }
+
+// TestDropDatabaseWithForeignKeys tests that databases containing tables with
+// foreign key relationships can be dropped and GC'ed. This is a regression test
+// for #50344, which is a bug ultimately caused by the fact that when we remove
+// foreign keys as part of DROP DATABASE CASCADE, we create schema change jobs
+// as part of updating the referenced tables. Those jobs, when running, will
+// detect that the table is in a dropped state and queue an extraneous GC job.
+// We test that those GC jobs don't interfere with the main GC job for the
+// entire database.
+func TestDropDatabaseWithForeignKeys(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	params, _ := tests.CreateTestServerParams()
+	s, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.Background())
+	ctx := context.Background()
+
+	defer disableGCTTLStrictEnforcement(t, sqlDB)()
+
+	_, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.parent(k INT PRIMARY KEY);
+CREATE TABLE t.child(k INT PRIMARY KEY REFERENCES t.parent);
+`)
+	require.NoError(t, err)
+
+	dbNameKey := sqlbase.NewDatabaseKey("t").Key()
+	r, err := kvDB.Get(ctx, dbNameKey)
+	require.NoError(t, err)
+	require.True(t, r.Exists())
+	dbID := sqlbase.ID(r.ValueInt())
+
+	parentNameKey := sqlbase.NewPublicTableKey(dbID, "parent").Key()
+	r, err = kvDB.Get(ctx, parentNameKey)
+	require.NoError(t, err)
+	require.True(t, r.Exists())
+	parentID := sqlbase.ID(r.ValueInt())
+
+	parentDescKey := sqlbase.MakeDescMetadataKey(parentID)
+	desc := &sqlbase.Descriptor{}
+	ts, err := kvDB.GetProtoTs(ctx, parentDescKey, desc)
+	require.NoError(t, err)
+	parentDesc := desc.Table(ts)
+
+	childNameKey := sqlbase.NewPublicTableKey(dbID, "child").Key()
+	r, err = kvDB.Get(ctx, childNameKey)
+	require.NoError(t, err)
+	require.True(t, r.Exists())
+	childID := sqlbase.ID(r.ValueInt())
+
+	childDescKey := sqlbase.MakeDescMetadataKey(childID)
+	desc = &sqlbase.Descriptor{}
+	ts, err = kvDB.GetProtoTs(ctx, childDescKey, desc)
+	require.NoError(t, err)
+	childDesc := desc.Table(ts)
+
+	_, err = sqlDB.Exec(`DROP DATABASE t CASCADE;`)
+	require.NoError(t, err)
+
+	// Push a new zone config for the table with TTL=0 so the data is
+	// deleted immediately.
+	_, err = addImmediateGCZoneConfig(sqlDB, dbID)
+	require.NoError(t, err)
+
+	// Ensure the main GC job for the whole database succeeds.
+	sqlRun := sqlutils.MakeSQLRunner(sqlDB)
+	testutils.SucceedsSoon(t, func() error {
+		var count int
+		sqlRun.QueryRow(t, `SELECT count(*) FROM [SHOW JOBS] WHERE description = 'GC for DROP DATABASE t CASCADE' AND status = 'succeeded'`).Scan(&count)
+		if count != 1 {
+			return errors.Errorf("expected 1 result, got %d", count)
+		}
+		return nil
+	})
+	// Ensure the extra GC job that also gets queued succeeds. Currently this job
+	// has a nonsensical description due to the fact that the original job queued
+	// for updating the referenced table has an empty description.
+	testutils.SucceedsSoon(t, func() error {
+		var count int
+		sqlRun.QueryRow(t, `SELECT count(*) FROM [SHOW JOBS] WHERE description = 'GC for ' AND status = 'succeeded'`).Scan(&count)
+		if count != 1 {
+			return errors.Errorf("expected 1 result, got %d", count)
+		}
+		return nil
+	})
+
+	// Check that the data was cleaned up.
+	tests.CheckKeyCount(t, kvDB, parentDesc.TableSpan(), 0)
+	tests.CheckKeyCount(t, kvDB, childDesc.TableSpan(), 0)
+}


### PR DESCRIPTION
Backport 1/1 commits from #50411.

/cc @cockroachdb/release

---

Previously, the GC job would fail if a descriptor for a table to be
dropped did not exist. This can happen in cases where multiple GC jobs
are created for the same table, and one job deletes the table descriptor
first.

The existence of multiple GC jobs for the same table is itself
undesirable, but it's possible when some schema change job other than
the one created when dropping the table sees that the table is in the
dropped state and tries to drop the table anyway.

This PR mitigates the problem by skipping the table and marking it
internally as GC'ed if the descriptor doesn't exist.

Touches #50344.

Release note (bug fix): Fixes a bug affecting some `DROP DATABASE`
schema changes where multiple GC jobs are created, causing the GC job
for the database to fail. GC jobs will no longer fail upon failing to
find a table descriptor already deleted by a different GC job.
