### PR TITLE
geo: correctly handle negative SRIDs

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2280,8 +2280,8 @@ const_geo ::=
 	| 'GEOMETRY'
 	| 'GEOMETRY' '(' geo_shape ')'
 	| 'GEOGRAPHY' '(' geo_shape ')'
-	| 'GEOMETRY' '(' geo_shape ',' iconst32 ')'
-	| 'GEOGRAPHY' '(' geo_shape ',' iconst32 ')'
+	| 'GEOMETRY' '(' geo_shape ',' signed_iconst ')'
+	| 'GEOGRAPHY' '(' geo_shape ',' signed_iconst ')'
 
 opt_varying ::=
 	'VARYING'
@@ -2477,6 +2477,10 @@ geo_shape ::=
 	| 'MULTIPOINT'
 	| 'GEOMETRY'
 
+signed_iconst ::=
+	'ICONST'
+	| only_signed_iconst
+
 char_aliases ::=
 	'CHAR'
 	| 'CHARACTER'
@@ -2494,10 +2498,6 @@ join_outer ::=
 
 rowsfrom_item ::=
 	func_expr_windowless
-
-signed_iconst ::=
-	'ICONST'
-	| only_signed_iconst
 
 create_as_col_qualification_elem ::=
 	'PRIMARY' 'KEY'

--- a/pkg/geo/parse.go
+++ b/pkg/geo/parse.go
@@ -64,8 +64,7 @@ func parseEWKBHex(str string, defaultSRID geopb.SRID) (geopb.SpatialObject, erro
 	if err != nil {
 		return geopb.SpatialObject{}, err
 	}
-	// TODO(otan): check SRID is valid against spatial_ref_sys.
-	if defaultSRID != 0 && t.SRID() == 0 {
+	if (defaultSRID != 0 && t.SRID() == 0) || int32(t.SRID()) < 0 {
 		adjustGeomSRID(t, defaultSRID)
 	}
 	return spatialObjectFromGeom(t)
@@ -80,8 +79,7 @@ func parseEWKB(
 	if err != nil {
 		return geopb.SpatialObject{}, err
 	}
-	// TODO(otan): check SRID is valid against spatial_ref_sys.
-	if overwrite == DefaultSRIDShouldOverwrite || (defaultSRID != 0 && t.SRID() == 0) {
+	if overwrite == DefaultSRIDShouldOverwrite || (defaultSRID != 0 && t.SRID() == 0) || int32(t.SRID()) < 0 {
 		adjustGeomSRID(t, defaultSRID)
 	}
 	return spatialObjectFromGeom(t)
@@ -161,9 +159,9 @@ func parseEWKT(
 				if err != nil {
 					return geopb.SpatialObject{}, err
 				}
-				// Only use the parsed SRID if the parsed SRID is not zero and it was not
+				// Only use the parsed SRID if the parsed SRID is > 0 and it was not
 				// to be overwritten by the DefaultSRID parameter.
-				if sridInt64 != 0 {
+				if sridInt64 > 0 {
 					srid = geopb.SRID(sridInt64)
 				}
 			}

--- a/pkg/geo/parse_test.go
+++ b/pkg/geo/parse_test.go
@@ -81,6 +81,18 @@ func TestParseEWKB(t *testing.T) {
 			},
 		},
 		{
+			"SRID 4326 is hint; EWKB has -1",
+			[]byte("\x01\x01\x00\x00\x20\xFF\xFF\xFF\xFF\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),
+			4326,
+			DefaultSRIDIsHint,
+			geopb.SpatialObject{
+				EWKB:        []byte("\x01\x01\x00\x00\x20\xe6\x10\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),
+				SRID:        4326,
+				Shape:       geopb.Shape_Point,
+				BoundingBox: &geopb.BoundingBox{MinX: 1, MaxX: 1, MinY: 1, MaxY: 1},
+			},
+		},
+		{
 			"Overwrite SRID 4004 with 4326",
 			[]byte("\x01\x01\x00\x00\x20\xA4\x0F\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),
 			4326,
@@ -148,6 +160,30 @@ func TestParseEWKT(t *testing.T) {
 			},
 		},
 		{
+			"SRID 4326 is hint; SRID is negative",
+			"SRID=-1;POINT(1.0 1.0)",
+			4326,
+			DefaultSRIDIsHint,
+			geopb.SpatialObject{
+				EWKB:        []byte("\x01\x01\x00\x00\x20\xe6\x10\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),
+				SRID:        4326,
+				Shape:       geopb.Shape_Point,
+				BoundingBox: &geopb.BoundingBox{MinX: 1, MaxX: 1, MinY: 1, MaxY: 1},
+			},
+		},
+		{
+			"SRID 4326 is hint; SRID is 0",
+			"SRID=0;POINT(1.0 1.0)",
+			4326,
+			DefaultSRIDIsHint,
+			geopb.SpatialObject{
+				EWKB:        []byte("\x01\x01\x00\x00\x20\xe6\x10\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),
+				SRID:        4326,
+				Shape:       geopb.Shape_Point,
+				BoundingBox: &geopb.BoundingBox{MinX: 1, MaxX: 1, MinY: 1, MaxY: 1},
+			},
+		},
+		{
 			"Overwrite SRID 4004 with 4326",
 			"SRID=4004;POINT(1.0 1.0)",
 			4326,
@@ -194,6 +230,18 @@ func TestParseGeometry(t *testing.T) {
 				spatialObject: geopb.SpatialObject{
 					EWKB:        []byte("\x01\x01\x00\x00\x20\xe6\x10\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),
 					SRID:        4326,
+					Shape:       geopb.Shape_Point,
+					BoundingBox: &geopb.BoundingBox{MinX: 1, MaxX: 1, MinY: 1, MaxY: 1},
+				},
+			},
+			"",
+		},
+		{
+			"0101000020FFFFFFFF000000000000f03f000000000000f03f",
+			&Geometry{
+				spatialObject: geopb.SpatialObject{
+					EWKB:        []byte("\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),
+					SRID:        0,
 					Shape:       geopb.Shape_Point,
 					BoundingBox: &geopb.BoundingBox{MinX: 1, MaxX: 1, MinY: 1, MaxY: 1},
 				},
@@ -307,6 +355,18 @@ func TestParseGeography(t *testing.T) {
 		},
 		{
 			"0101000020E6100000000000000000F03F000000000000F03F",
+			&Geography{
+				spatialObject: geopb.SpatialObject{
+					EWKB:        []byte("\x01\x01\x00\x00\x20\xe6\x10\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),
+					SRID:        4326,
+					Shape:       geopb.Shape_Point,
+					BoundingBox: &geopb.BoundingBox{MinX: 1, MaxX: 1, MinY: 1, MaxY: 1},
+				},
+			},
+			"",
+		},
+		{
+			"0101000020FFFFFFFF000000000000f03f000000000000f03f",
 			&Geography{
 				spatialObject: geopb.SpatialObject{
 					EWKB:        []byte("\x01\x01\x00\x00\x20\xe6\x10\x00\x00\x00\x00\x00\x00\x00\x00\xf0\x3f\x00\x00\x00\x00\x00\x00\xf0\x3f"),

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -26,6 +26,32 @@ SELECT 'SRID=404;POINT(1.0 2.0)'::geometry
 statement error unknown SRID for Geography: 404
 SELECT 'SRID=404;POINT(1.0 2.0)'::geography
 
+statement ok
+CREATE TABLE geom_table_negative_values(
+  a geometry(geometry, -1)
+)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE geom_table_negative_values]
+----
+CREATE TABLE geom_table_negative_values (
+   a GEOMETRY(GEOMETRY) NULL,
+   FAMILY "primary" (a, rowid)
+)
+
+statement ok
+CREATE TABLE geog_table_negative_values(
+  a geography(geometry, -1)
+)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE geog_table_negative_values]
+----
+CREATE TABLE geog_table_negative_values (
+   a GEOGRAPHY(GEOMETRY) NULL,
+   FAMILY "primary" (a, rowid)
+)
+
 statement error SRID 3857 cannot be used for geography as it is not in a lon/lat coordinate system
 SELECT 'SRID=3857;POINT(1.0 2.0)'::geography
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -7699,13 +7699,21 @@ const_geo:
   {
     $$.val = types.MakeGeography($3.geoFigure(), 0)
   }
-| GEOMETRY '(' geo_shape ',' iconst32 ')'
+| GEOMETRY '(' geo_shape ',' signed_iconst ')'
   {
-    $$.val = types.MakeGeometry($3.geoFigure(), geopb.SRID($5.int32()))
+    val, err := $5.numVal().AsInt32()
+    if err != nil {
+      return setErr(sqllex, err)
+    }
+    $$.val = types.MakeGeometry($3.geoFigure(), geopb.SRID(val))
   }
-| GEOGRAPHY '(' geo_shape ',' iconst32 ')'
+| GEOGRAPHY '(' geo_shape ',' signed_iconst ')'
   {
-    $$.val = types.MakeGeography($3.geoFigure(), geopb.SRID($5.int32()))
+    val, err := $5.numVal().AsInt32()
+    if err != nil {
+      return setErr(sqllex, err)
+    }
+    $$.val = types.MakeGeography($3.geoFigure(), geopb.SRID(val))
   }
 
 // We have a separate const_typename to allow defaulting fixed-length types

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -842,6 +842,10 @@ func MakeTimeTZ(precision int32) *T {
 // MakeGeometry constructs a new instance of a GEOMETRY type (oid = T_geometry)
 // that has the given shape and SRID.
 func MakeGeometry(shape geopb.Shape, srid geopb.SRID) *T {
+	// Negative values are promoted to 0.
+	if srid < 0 {
+		srid = 0
+	}
 	return &T{InternalType: InternalType{
 		Family: GeometryFamily,
 		Oid:    oidext.T_geometry,
@@ -855,6 +859,10 @@ func MakeGeometry(shape geopb.Shape, srid geopb.SRID) *T {
 
 // MakeGeography constructs a new instance of a geography-related type.
 func MakeGeography(shape geopb.Shape, srid geopb.SRID) *T {
+	// Negative values are promoted to 0.
+	if srid < 0 {
+		srid = 0
+	}
 	return &T{InternalType: InternalType{
 		Family: GeographyFamily,
 		Oid:    oidext.T_geography,


### PR DESCRIPTION
Refs: https://github.com/cockroachdb/django-cockroachdb/issues/148

Negative SRIDs in PostGIS bounce around and become 0. Apply the same
logic to parsing as well as typmod logic.

Release note: None