### PR TITLE
roachpb: get rid of BootstrapLease()

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -291,7 +291,7 @@ func (tc *testContext) StartWithStoreConfigAndVersion(
 				tc.store.Engine(),
 				enginepb.MVCCStats{},
 				*testDesc,
-				roachpb.BootstrapLease(),
+				roachpb.Lease{},
 				hlc.Timestamp{},
 				stateloader.TruncatedStateUnreplicated,
 			); err != nil {
@@ -6036,7 +6036,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	// The initial stats contain no lease, but there will be an initial
 	// nontrivial lease requested with the first write below.
 	baseStats.Add(enginepb.MVCCStats{
-		SysBytes: 24,
+		SysBytes: 28,
 	})
 
 	// Our clock might not be set to zero.

--- a/pkg/kv/kvserver/stats_test.go
+++ b/pkg/kv/kvserver/stats_test.go
@@ -27,7 +27,7 @@ import (
 // writeInitialState().
 func initialStats() enginepb.MVCCStats {
 	return enginepb.MVCCStats{
-		SysBytes: 70,
+		SysBytes: 66,
 		SysCount: 2,
 	}
 }

--- a/pkg/kv/kvserver/store_bootstrap.go
+++ b/pkg/kv/kvserver/store_bootstrap.go
@@ -215,7 +215,7 @@ func WriteInitialClusterData(
 		}
 
 		truncStateType := stateloader.TruncatedStateUnreplicated
-		lease := roachpb.BootstrapLease()
+		lease := roachpb.Lease{}
 		_, err := stateloader.WriteInitialState(
 			ctx, batch,
 			enginepb.MVCCStats{},

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1724,17 +1724,6 @@ func (l Lease) String() string {
 	return fmt.Sprintf("repl=%s seq=%s start=%s epo=%d%s", l.Replica, l.Sequence, l.Start, l.Epoch, proposedSuffix)
 }
 
-// BootstrapLease returns the lease to persist for the range of a freshly bootstrapped store. The
-// returned lease is morally "empty" but has a few fields set to non-nil zero values because some
-// used to be non-nullable and we now fuzz their nullability in tests. As a consequence, it's better
-// to always use zero fields here so that the initial stats are constant.
-func BootstrapLease() Lease {
-	return Lease{
-		Expiration:            &hlc.Timestamp{},
-		DeprecatedStartStasis: &hlc.Timestamp{},
-	}
-}
-
 // OwnedBy returns whether the given store is the lease owner.
 func (l Lease) OwnedBy(storeID StoreID) bool {
 	return l.Replica.StoreID == storeID


### PR DESCRIPTION
BootstrapLease() was a vestigial utility creating a lease with some
empty, but not-nil, values. This comes from the time of a fuzzer we were
using on protos to catch code that doesn't handle fields whose
nilability has changed. That fuzzer was removed in #48238.
This patch removes this utility and replaces it with Lease{}. We already
seem to have various code that compares leases with Lease{}, and I want
to introduce more, so I think we just need to be careful with field
nilability changes.

Release note: None