### PR TITLE
sql: fix bug where type annotation was lost after `SET DEFAULT`

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -825,7 +825,7 @@ func applyColumnMutation(
 			if err != nil {
 				return err
 			}
-			s := tree.Serialize(t.Default)
+			s := tree.Serialize(expr)
 			col.DefaultExpr = &s
 
 			// Add references to the sequence descriptors this column is now using.

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2564,3 +2564,24 @@ UPDATE pg_catalog.pg_tables SET a = 'abc'
 statement error pg_tables is a system catalog
 TRUNCATE TABLE pg_catalog.pg_tables
 
+# Regression for #47285.
+statement ok
+CREATE TABLE t47285 (x STRING DEFAULT 'hello');
+ALTER TABLE t47285 ALTER COLUMN x SET DEFAULT 'howdy'
+
+query T
+SELECT
+  pg_get_expr(d.adbin, d.adrelid)
+FROM
+  pg_attribute AS a
+  LEFT JOIN pg_attrdef AS d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
+  LEFT JOIN pg_type AS t ON a.atttypid = t.oid
+  LEFT JOIN pg_collation AS c ON
+    a.attcollation = c.oid AND a.attcollation != t.typcollation
+WHERE
+  a.attrelid = 't47285'::REGCLASS
+  AND a.attnum > 0
+  AND NOT a.attisdropped
+  AND attname = 'x'
+----
+'howdy'::STRING


### PR DESCRIPTION
Fixes #47285.

This PR fixes a small bug where changing the default value of a column
would cause it to lose the type annotation it had in the pg_attrdef
catalog table.

Release note: None