### PR TITLE
sql: ensure columns get dequalified for ALTER TABLE statements.

### DIFF
--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -139,7 +139,12 @@ func (p *planner) addColumnImpl(
 	}
 
 	if d.IsComputed() {
-		computedColValidator := schemaexpr.NewComputedColumnValidator(params.ctx, n.tableDesc, &params.p.semaCtx)
+		computedColValidator := schemaexpr.NewComputedColumnValidator(
+			params.ctx,
+			n.tableDesc,
+			&params.p.semaCtx,
+			tn,
+		)
 		if err := computedColValidator.Validate(d); err != nil {
 			return err
 		}

--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -58,6 +58,7 @@ func AlterColumnType(
 	t *tree.AlterTableAlterColumnType,
 	params runParams,
 	cmds tree.AlterTableCmds,
+	tn *tree.TableName,
 ) error {
 
 	typ, err := tree.ResolveType(ctx, t.ToType, params.p.semaCtx.GetTypeResolver())
@@ -114,7 +115,7 @@ func AlterColumnType(
 	case schemachange.ColumnConversionTrivial:
 		col.Type = typ
 	case schemachange.ColumnConversionGeneral, schemachange.ColumnConversionValidate:
-		if err := alterColumnTypeGeneral(ctx, tableDesc, col, typ, t.Using, params, cmds); err != nil {
+		if err := alterColumnTypeGeneral(ctx, tableDesc, col, typ, t.Using, params, cmds, tn); err != nil {
 			return err
 		}
 		if err := params.p.createOrUpdateSchemaChangeJob(params.ctx, tableDesc, tree.AsStringWithFQNames(t, params.Ann()), tableDesc.ClusterVersion.NextMutationID); err != nil {
@@ -139,6 +140,7 @@ func alterColumnTypeGeneral(
 	using tree.Expr,
 	params runParams,
 	cmds tree.AlterTableCmds,
+	tn *tree.TableName,
 ) error {
 	// Make sure that all nodes in the cluster are able to perform
 	// general alter column type conversions.
@@ -235,9 +237,8 @@ func alterColumnTypeGeneral(
 	// will fail until the old column is dropped.
 	var inverseExpr string
 	if using != nil {
-		// Ensure the USING EXPRESSION returns the new type.
-		// Replace column references with typed dummies to allow typechecking.
-		typedExpr, _, err := schemaexpr.ReplaceColumnVarsAndSanitizeExpr(
+		// Validate the provided using expr and ensure it has the correct type.
+		typedExpr, _, err := schemaexpr.DequalifyAndValidateExpr(
 			ctx,
 			tableDesc,
 			using,
@@ -245,6 +246,7 @@ func alterColumnTypeGeneral(
 			"ALTER COLUMN TYPE USING EXPRESSION",
 			&params.p.semaCtx,
 			true, /* allowImpure */
+			tn,
 		)
 
 		if err != nil {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1669,7 +1669,12 @@ func MakeTableDesc(
 
 	// Now that we have all the other columns set up, we can validate
 	// any computed columns.
-	computedColValidator := schemaexpr.NewComputedColumnValidator(ctx, &desc, semaCtx)
+	computedColValidator := schemaexpr.NewComputedColumnValidator(
+		ctx,
+		&desc,
+		semaCtx,
+		&n.Table,
+	)
 	for _, def := range n.Defs {
 		switch d := def.(type) {
 		case *tree.ColumnTableDef:

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -493,22 +493,21 @@ CREATE TABLE t27 (x INT);
 statement error pq: column "y" does not exist
 ALTER TABLE t26 ALTER COLUMN x TYPE BOOL USING (y > 0);
 
-# TODO(richardjcai): Enable these tests once #50069 is fixed.
 # Ensure USING EXPRESSION cannot reference other tables.
-# statement error pq: cannot reference column in table t26
-# ALTER TABLE t27 ALTER COLUMN x TYPE BOOL USING (t26.x > 0);
+statement error pq: no data source matches prefix: t26 in this context
+ALTER TABLE t27 ALTER COLUMN x TYPE BOOL USING (t26.x > 0);
 
 # Ensure USING EXPRESSION cannot reference columns with a database or column
 # specified.
 
-# statement error pq: cannot qualify columns in expression with database or schema
-# ALTER TABLE t27 ALTER COLUMN x TYPE STRING USING (db.schema.t.x::STRING)
+statement error pq: no data source matches prefix: db.schema.t in this context
+ALTER TABLE t27 ALTER COLUMN x TYPE STRING USING (db.schema.t.x::STRING)
 
-# statement error pq: cannot qualify columns in expression with database or schema
-# ALTER TABLE t27 ALTER COLUMN x TYPE STRING USING (schema.t.x::STRING)
+statement error pq: no data source matches prefix: schema.t in this context
+ALTER TABLE t27 ALTER COLUMN x TYPE STRING USING (schema.t.x::STRING)
 
-# statement ok
-# ALTER TABLE t27 ALTER COLUMN x TYPE STRING USING (x::STRING)
+statement ok
+ALTER TABLE t27 ALTER COLUMN x TYPE STRING USING (x::STRING)
 
 # Ensure ALTER COLUMN TYPE ... USING EXPRESSION does not perform a no-op when
 # converting to the same type.

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1338,3 +1338,19 @@ t2  CREATE TABLE t2 (
     UNIQUE INDEX t2_x_key (x ASC),
     FAMILY "primary" (y, rowid, x)
 )
+
+# Regression 50069, computed exprs must only refer to columns inside the
+# current table.
+statement ok
+CREATE TABLE t50069_a (x INT);
+CREATE TABLE t50069_b (x INT);
+
+statement error pq: no data source matches prefix: t50069_b in this context
+ALTER TABLE t50069_a ADD COLUMN y INT AS (t50069_b.x + 1) STORED
+
+statement ok
+CREATE DATABASE d;
+CREATE TABLE d.public.t50069_a (x INT);
+
+statement error pq: no data source matches prefix: d.public.t50069_a in this context
+ALTER TABLE t50069_a ADD COLUMN y INT AS (d.public.t50069_a.x + 1) STORED

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -21,7 +21,7 @@ statement error expected index predicate expression to have type bool, but '1' h
 CREATE TABLE error (a INT, INDEX (a) WHERE 1)
 
 # Don't allow columns not in table.
-statement error pgcode 42703 column "b" does not exist, referenced in "b = 3"
+statement error pgcode 42703 column "b" does not exist
 CREATE TABLE error (a INT, INDEX (a) WHERE b = 3)
 
 # Don't allow mutable functions.
@@ -113,15 +113,15 @@ SHOW CREATE TABLE t6
 ----
 t6  CREATE TABLE t6 (
     a INT8 NULL,
-    INDEX t6_a_idx (a ASC) WHERE a > 0,
-    INDEX t6_a_idx1 (a ASC) WHERE a > 1,
-    INDEX t6_a_idx2 (a DESC) WHERE a > 2,
-    UNIQUE INDEX t6_a_key (a ASC) WHERE a > 3,
-    UNIQUE INDEX t6_a_key1 (a ASC) WHERE a > 4,
-    UNIQUE INDEX t6_a_key2 (a DESC) WHERE a > 5,
-    INDEX t6i1 (a ASC) WHERE a > 6,
-    INDEX t6i2 (a ASC) WHERE a > 7,
-    INDEX t6i3 (a DESC) WHERE a > 8,
+    INDEX t6_a_idx (a ASC) WHERE a > 0:::INT8,
+    INDEX t6_a_idx1 (a ASC) WHERE a > 1:::INT8,
+    INDEX t6_a_idx2 (a DESC) WHERE a > 2:::INT8,
+    UNIQUE INDEX t6_a_key (a ASC) WHERE a > 3:::INT8,
+    UNIQUE INDEX t6_a_key1 (a ASC) WHERE a > 4:::INT8,
+    UNIQUE INDEX t6_a_key2 (a DESC) WHERE a > 5:::INT8,
+    INDEX t6i1 (a ASC) WHERE a > 6:::INT8,
+    INDEX t6i2 (a ASC) WHERE a > 7:::INT8,
+    INDEX t6i3 (a DESC) WHERE a > 8:::INT8,
     FAMILY "primary" (a, rowid)
 )
 
@@ -135,15 +135,15 @@ SHOW CREATE TABLE t6
 ----
 t6  CREATE TABLE t6 (
     b INT8 NULL,
-    INDEX t6_a_idx (b ASC) WHERE b > 0,
-    INDEX t6_a_idx1 (b ASC) WHERE b > 1,
-    INDEX t6_a_idx2 (b DESC) WHERE b > 2,
-    UNIQUE INDEX t6_a_key (b ASC) WHERE b > 3,
-    UNIQUE INDEX t6_a_key1 (b ASC) WHERE b > 4,
-    UNIQUE INDEX t6_a_key2 (b DESC) WHERE b > 5,
-    INDEX t6i1 (b ASC) WHERE b > 6,
-    INDEX t6i2 (b ASC) WHERE b > 7,
-    INDEX t6i3 (b DESC) WHERE b > 8,
+    INDEX t6_a_idx (b ASC) WHERE b > 0:::INT8,
+    INDEX t6_a_idx1 (b ASC) WHERE b > 1:::INT8,
+    INDEX t6_a_idx2 (b DESC) WHERE b > 2:::INT8,
+    UNIQUE INDEX t6_a_key (b ASC) WHERE b > 3:::INT8,
+    UNIQUE INDEX t6_a_key1 (b ASC) WHERE b > 4:::INT8,
+    UNIQUE INDEX t6_a_key2 (b DESC) WHERE b > 5:::INT8,
+    INDEX t6i1 (b ASC) WHERE b > 6:::INT8,
+    INDEX t6i2 (b ASC) WHERE b > 7:::INT8,
+    INDEX t6i3 (b DESC) WHERE b > 8:::INT8,
     FAMILY "primary" (b, rowid)
 )
 
@@ -157,14 +157,14 @@ SHOW CREATE TABLE t7
 ----
 t7  CREATE TABLE t7 (
     b INT8 NULL,
-    INDEX t6_a_idx (b ASC) WHERE b > 0,
-    INDEX t6_a_idx1 (b ASC) WHERE b > 1,
-    INDEX t6_a_idx2 (b DESC) WHERE b > 2,
-    UNIQUE INDEX t6_a_key (b ASC) WHERE b > 3,
-    UNIQUE INDEX t6_a_key1 (b ASC) WHERE b > 4,
-    UNIQUE INDEX t6_a_key2 (b DESC) WHERE b > 5,
-    INDEX t6i1 (b ASC) WHERE b > 6,
-    INDEX t6i2 (b ASC) WHERE b > 7,
-    INDEX t6i3 (b DESC) WHERE b > 8,
+    INDEX t6_a_idx (b ASC) WHERE b > 0:::INT8,
+    INDEX t6_a_idx1 (b ASC) WHERE b > 1:::INT8,
+    INDEX t6_a_idx2 (b DESC) WHERE b > 2:::INT8,
+    UNIQUE INDEX t6_a_key (b ASC) WHERE b > 3:::INT8,
+    UNIQUE INDEX t6_a_key1 (b ASC) WHERE b > 4:::INT8,
+    UNIQUE INDEX t6_a_key2 (b DESC) WHERE b > 5:::INT8,
+    INDEX t6i1 (b ASC) WHERE b > 6:::INT8,
+    INDEX t6i2 (b ASC) WHERE b > 7:::INT8,
+    INDEX t6i3 (b DESC) WHERE b > 8:::INT8,
     FAMILY "primary" (b, rowid)
 )

--- a/pkg/sql/opt/optbuilder/testdata/delete
+++ b/pkg/sql/opt/optbuilder/testdata/delete
@@ -289,7 +289,7 @@ with &1
 build
 DELETE FROM abcde AS foo WHERE a=abcde.b
 ----
-error (42P01): no data source matches prefix: abcde
+error (42P01): no data source matches prefix: abcde in this context
 
 # ORDER BY can only be used with LIMIT.
 build

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -754,12 +754,12 @@ project
 build
 SELECT x, a.x, b.y FROM (SELECT * FROM onecolumn AS a NATURAL JOIN twocolumn AS b) AS q
 ----
-error (42P01): no data source matches prefix: a
+error (42P01): no data source matches prefix: a in this context
 
 build
 SELECT x, a.x, b.y FROM (SELECT * FROM onecolumn AS a NATURAL JOIN twocolumn AS b)
 ----
-error (42P01): no data source matches prefix: a
+error (42P01): no data source matches prefix: a in this context
 
 
 ## Simple test cases for inner, left, right, and outer joins

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -386,7 +386,7 @@ error (42703): column "foo" does not exist
 build
 SELECT a FROM t ORDER BY a.b
 ----
-error (42P01): no data source matches prefix: a
+error (42P01): no data source matches prefix: a in this context
 
 build
 SELECT generate_series FROM generate_series(1, 100) ORDER BY ARRAY[generate_series]
@@ -924,7 +924,7 @@ project
 build
 SELECT a FROM abcd AS foo ORDER BY INDEX abcd@abc DESC
 ----
-error (42P01): no data source matches prefix: t.public.abcd
+error (42P01): no data source matches prefix: t.public.abcd in this context
 
 build
 SELECT a FROM abcd AS foo ORDER BY INDEX foo@abc DESC
@@ -985,7 +985,7 @@ sort
 build
 SELECT a FROM (SELECT a FROM abcd) ORDER BY INDEX abcd@bcd
 ----
-error (42P01): no data source matches prefix: t.public.abcd
+error (42P01): no data source matches prefix: t.public.abcd in this context
 
 # Drop previous table with same name, but different schema.
 exec-ddl

--- a/pkg/sql/opt/optbuilder/testdata/project
+++ b/pkg/sql/opt/optbuilder/testdata/project
@@ -205,7 +205,7 @@ error (42703): column "c" does not exist
 build fully-qualify-names
 SELECT t.kv.k FROM abc AS kv
 ----
-error (42P01): no data source matches prefix: t.kv
+error (42P01): no data source matches prefix: t.kv in this context
 
 exec-ddl
 CREATE TABLE kv (k INT PRIMARY KEY, v INT)

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -1305,7 +1305,7 @@ error (42P09): ambiguous source name: "kv"
 build fully-qualify-names
 SELECT (SELECT kv1.k) FROM db1.kv, kv
 ----
-error (42P01): no data source matches prefix: kv1
+error (42P01): no data source matches prefix: kv1 in this context
 
 build fully-qualify-names
 SELECT (SELECT kv1.k) FROM db1.kv AS kv1, kv

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -551,7 +551,7 @@ with &1
 build
 UPDATE abcde AS foo SET a=abcde.b
 ----
-error (42P01): no data source matches prefix: abcde
+error (42P01): no data source matches prefix: abcde in this context
 
 # ORDER BY can only be used with LIMIT.
 build

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -706,7 +706,7 @@ ON CONFLICT (x) DO
 UPDATE SET x=1
 RETURNING excluded.x
 ----
-error (42P01): no data source matches prefix: excluded
+error (42P01): no data source matches prefix: excluded in this context
 
 # Referencing column without "excluded" or "xyz" prefix is not allowed.
 build

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -566,7 +566,7 @@ error (42P10): source "t" has 1 columns available but 2 columns specified
 build
 WITH t AS (SELECT a FROM x) SELECT a, x.t FROM t
 ----
-error (42P01): no data source matches prefix: x
+error (42P01): no data source matches prefix: x in this context
 
 # Nested WITH, name shadowing
 build

--- a/pkg/sql/schemaexpr/check_constraint.go
+++ b/pkg/sql/schemaexpr/check_constraint.go
@@ -86,29 +86,17 @@ func (b *CheckConstraintBuilder) Build(
 		}
 	}
 
-	source := sqlbase.NewSourceInfoForSingleTable(
-		b.tableName, sqlbase.ResultColumnsFromColDescs(
-			b.desc.GetID(),
-			b.desc.TableDesc().AllNonDropColumns(),
-		),
-	)
-
-	// Strip the database and table names from any qualified column names.
-	expr, err := DequalifyColumnRefs(b.ctx, source, c.Expr)
-	if err != nil {
-		return nil, err
-	}
-
 	// Verify that the expression results in a boolean and does not use
 	// invalid functions.
-	typedExpr, colIDs, err := ReplaceColumnVarsAndSanitizeExpr(
+	typedExpr, colIDs, err := DequalifyAndValidateExpr(
 		b.ctx,
 		b.desc,
-		expr,
+		c.Expr,
 		types.Bool,
 		"CHECK",
 		b.semaCtx,
 		true, /* allowImpure */
+		&b.tableName,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/schemaexpr/column.go
+++ b/pkg/sql/schemaexpr/column.go
@@ -60,36 +60,6 @@ func DequalifyColumnRefs(
 	)
 }
 
-// DeserializeTableDescExpr takes in a serialized expression and a table, and
-// returns an expression that has all user defined types resolved for
-// formatting. It is intended to be used when displaying a serialized
-// expression within a TableDescriptor. For example, a DEFAULT expression
-// of a table containing a user defined type t with id 50 would have all
-// references to t replaced with the id 50. In order to display this expression
-// back to an end user, the serialized id 50 needs to be replaced back with t.
-// DeserializeTableDescExpr performs this logic, but only returns a
-// tree.Expr to be clear that these returned expressions are not safe to Eval.
-func DeserializeTableDescExpr(
-	ctx context.Context,
-	semaCtx *tree.SemaContext,
-	desc sqlbase.TableDescriptorInterface,
-	exprStr string,
-) (tree.Expr, error) {
-	expr, err := parser.ParseExpr(exprStr)
-	if err != nil {
-		return nil, err
-	}
-	expr, _, err = replaceVars(desc, expr)
-	if err != nil {
-		return nil, err
-	}
-	typed, err := expr.TypeCheck(ctx, semaCtx, types.Any)
-	if err != nil {
-		return nil, err
-	}
-	return typed, nil
-}
-
 // FormatColumnForDisplay formats a column descriptor as a SQL string, and displays
 // user defined types in serialized expressions with human friendly formatting.
 func FormatColumnForDisplay(
@@ -240,14 +210,14 @@ func (d *dummyColumn) ResolvedType() *types.T {
 	return d.typ
 }
 
-// replaceVars replaces the occurrences of column names in an expression with
+// replaceColumnVars replaces the occurrences of column names in an expression with
 // dummyColumns containing their type, so that they may be type-checked. It
 // returns this new expression tree alongside a set containing the ColumnID of
 // each column seen in the expression.
 //
 // If the expression references a column that does not exist in the table
-// descriptor, replaceVars errs with pgcode.UndefinedColumn.
-func replaceVars(
+// descriptor, replaceColumnVars errs with pgcode.UndefinedColumn.
+func replaceColumnVars(
 	desc sqlbase.TableDescriptorInterface, rootExpr tree.Expr,
 ) (tree.Expr, sqlbase.TableColSet, error) {
 	var colIDs sqlbase.TableColSet
@@ -281,40 +251,4 @@ func replaceVars(
 	})
 
 	return newExpr, colIDs, err
-}
-
-// ReplaceColumnVarsAndSanitizeExpr takes an expr and replaces all column
-// variables with a dummyColumn of the column's type and then verifies that the
-// expression is valid, has the correct type and contains no variable
-// expressions. It returns the type-checked and constant-folded expression.
-func ReplaceColumnVarsAndSanitizeExpr(
-	ctx context.Context,
-	desc sqlbase.TableDescriptorInterface,
-	expr tree.Expr,
-	types *types.T,
-	op string,
-	semaCtx *tree.SemaContext,
-	allowImpure bool,
-) (tree.TypedExpr, sqlbase.TableColSet, error) {
-	// Replace the column variables with dummyColumns so that they can be
-	// type-checked.
-	replacedExpr, colIDs, err := replaceVars(desc, expr)
-	if err != nil {
-		return nil, colIDs, err
-	}
-
-	typedExpr, err := sqlbase.SanitizeVarFreeExpr(
-		ctx,
-		replacedExpr,
-		types,
-		op,
-		semaCtx,
-		allowImpure,
-	)
-
-	if err != nil {
-		return nil, colIDs, err
-	}
-
-	return typedExpr, colIDs, nil
 }

--- a/pkg/sql/schemaexpr/expr.go
+++ b/pkg/sql/schemaexpr/expr.go
@@ -1,0 +1,99 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schemaexpr
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
+
+// DeserializeTableDescExpr takes in a serialized expression and a table, and
+// returns an expression that has all user defined types resolved for
+// formatting. It is intended to be used when displaying a serialized
+// expression within a TableDescriptor. For example, a DEFAULT expression
+// of a table containing a user defined type t with id 50 would have all
+// references to t replaced with the id 50. In order to display this expression
+// back to an end user, the serialized id 50 needs to be replaced back with t.
+// DeserializeTableDescExpr performs this logic, but only returns a
+// tree.Expr to be clear that these returned expressions are not safe to Eval.
+func DeserializeTableDescExpr(
+	ctx context.Context,
+	semaCtx *tree.SemaContext,
+	desc sqlbase.TableDescriptorInterface,
+	exprStr string,
+) (tree.Expr, error) {
+	expr, err := parser.ParseExpr(exprStr)
+	if err != nil {
+		return nil, err
+	}
+	expr, _, err = replaceColumnVars(desc, expr)
+	if err != nil {
+		return nil, err
+	}
+	typed, err := expr.TypeCheck(ctx, semaCtx, types.Any)
+	if err != nil {
+		return nil, err
+	}
+	return typed, nil
+}
+
+// DequalifyAndValidateExpr takes an expr de-qualifies the column names and
+// validates that expression is valid, has the correct type and
+// has no impure functions if allowImpure is false.
+// Returns the type-checked and constant-folded expression.
+func DequalifyAndValidateExpr(
+	ctx context.Context,
+	desc sqlbase.TableDescriptorInterface,
+	expr tree.Expr,
+	typ *types.T,
+	op string,
+	semaCtx *tree.SemaContext,
+	allowImpure bool,
+	tn *tree.TableName,
+) (tree.TypedExpr, sqlbase.TableColSet, error) {
+	var colIDs sqlbase.TableColSet
+	sourceInfo := sqlbase.NewSourceInfoForSingleTable(
+		*tn, sqlbase.ResultColumnsFromColDescs(
+			desc.GetID(),
+			desc.TableDesc().AllNonDropColumns(),
+		),
+	)
+	expr, err := DequalifyColumnRefs(ctx, sourceInfo, expr)
+	if err != nil {
+		return nil, colIDs, err
+	}
+
+	// Replace the column variables with dummyColumns so that they can be
+	// type-checked.
+	replacedExpr, colIDs, err := replaceColumnVars(desc, expr)
+	if err != nil {
+		return nil, colIDs, err
+	}
+
+	typedExpr, err := sqlbase.SanitizeVarFreeExpr(
+		ctx,
+		replacedExpr,
+		typ,
+		op,
+		semaCtx,
+		allowImpure,
+	)
+
+	if err != nil {
+		return nil, colIDs, err
+	}
+
+	return typedExpr, colIDs, nil
+}

--- a/pkg/sql/schemaexpr/expr_test.go
+++ b/pkg/sql/schemaexpr/expr_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
-func TestIndexPredicateValidator_Validate(t *testing.T) {
+func TestValidateExpr(t *testing.T) {
 	ctx := context.Background()
 	semaCtx := tree.MakeSemaContext()
 
@@ -37,50 +37,32 @@ func TestIndexPredicateValidator_Validate(t *testing.T) {
 		[]testCol{{"c", types.String}},
 	)
 
-	validator := NewIndexPredicateValidator(ctx, tn, &desc, &semaCtx)
-
 	testData := []struct {
 		expr          string
 		expectedValid bool
 		expectedExpr  string
+		typ           *types.T
+		allowImpure   bool
 	}{
-		// Allow expressions that result in a bool.
-		{"a", true, "a"},
-		{"b = 0", true, "b = 0:::INT8"},
-		{"a AND b = 0", true, "a AND (b = 0:::INT8)"},
-		{"a IS NULL", true, "a IS NULL"},
-		{"b IN (1, 2)", true, "b IN (1:::INT8, 2:::INT8)"},
-
-		// Allow immutable functions.
-		{"abs(b) > 0", true, "abs(b) > 0:::INT8"},
-		{"c || c = 'foofoo'", true, "(c || c) = 'foofoo':::STRING"},
-		{"lower(c) = 'bar'", true, "lower(c) = 'bar':::STRING"},
-
-		// Disallow references to columns not in the table.
-		{"d", false, ""},
-		{"t.a", false, ""},
-
-		// Disallow expressions that do not result in a bool.
-		{"b", false, ""},
-		{"abs(b)", false, ""},
-		{"lower(c)", false, ""},
-
-		// Disallow subqueries.
-		{"exists(select 1)", false, ""},
-		{"b IN (select 1)", false, ""},
-
-		// Disallow mutable, aggregate, window, and set returning functions.
-		{"b > random()", false, ""},
-		{"sum(b) > 10", false, ""},
-		{"row_number() OVER () > 1", false, ""},
-		{"generate_series(1, 1) > 2", false, ""},
-
 		// De-qualify column names.
-		{"bar.a", true, "a"},
-		{"foo.bar.a", true, "a"},
-		{"bar.b = 0", true, "b = 0:::INT8"},
-		{"foo.bar.b = 0", true, "b = 0:::INT8"},
-		{"bar.a AND foo.bar.b = 0", true, "a AND (b = 0:::INT8)"},
+		{"bar.a", true, "a", types.Bool, false},
+		{"foo.bar.a", true, "a", types.Bool, false},
+		{"bar.b = 0", true, "b = 0:::INT8", types.Bool, false},
+		{"foo.bar.b = 0", true, "b = 0:::INT8", types.Bool, false},
+		{"bar.a AND foo.bar.b = 0", true, "a AND (b = 0:::INT8)", types.Bool, false},
+
+		// Validates the type of the expression.
+		{"concat(c, c)", true, "concat(c, c)", types.String, false},
+		{"concat(c, c)", false, "", types.Int, false},
+		{"b + 1", true, "b + 1:::INT8", types.Int, false},
+		{"b + 1", false, "", types.Bool, false},
+
+		// Validates that the expression has no variable expressions.
+		{"$1", false, "", types.Any, false},
+
+		// Validates that impure functions are allowed or disallowed.
+		{"now()", true, "now():::TIMESTAMPTZ", types.TimestampTZ, true},
+		{"now()", false, "", types.Any, false},
 	}
 
 	for _, d := range testData {
@@ -90,7 +72,16 @@ func TestIndexPredicateValidator_Validate(t *testing.T) {
 				t.Fatalf("%s: unexpected error: %s", d.expr, err)
 			}
 
-			r, err := validator.Validate(expr)
+			expr, _, err = DequalifyAndValidateExpr(
+				ctx,
+				&desc,
+				expr,
+				d.typ,
+				"test-validate-expr",
+				&semaCtx,
+				d.allowImpure,
+				&tn,
+			)
 
 			if !d.expectedValid {
 				if err == nil {
@@ -105,7 +96,7 @@ func TestIndexPredicateValidator_Validate(t *testing.T) {
 				t.Fatalf("%s: expected valid expression, but found error: %s", d.expr, err)
 			}
 
-			s := tree.Serialize(r)
+			s := tree.Serialize(expr)
 			if s != d.expectedExpr {
 				t.Errorf("%s: expected %q, got %q", d.expr, d.expectedExpr, s)
 			}

--- a/pkg/sql/schemaexpr/partial_index.go
+++ b/pkg/sql/schemaexpr/partial_index.go
@@ -56,7 +56,7 @@ func NewIndexPredicateValidator(
 //     functions.
 //
 func (v *IndexPredicateValidator) Validate(expr tree.Expr) (tree.Expr, error) {
-	_, _, err := ReplaceColumnVarsAndSanitizeExpr(
+	expr, _, err := DequalifyAndValidateExpr(
 		v.ctx,
 		v.desc,
 		expr,
@@ -64,19 +64,11 @@ func (v *IndexPredicateValidator) Validate(expr tree.Expr) (tree.Expr, error) {
 		"index predicate",
 		v.semaCtx,
 		false, /* allowImpure */
+		&v.tableName,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	source := sqlbase.NewSourceInfoForSingleTable(
-		v.tableName, sqlbase.ResultColumnsFromColDescs(
-			v.desc.GetID(),
-			v.desc.TableDesc().AllNonDropColumns(),
-		),
-	)
-
-	// Dequalify column references so that they do not contain database or
-	// table names.
-	return DequalifyColumnRefs(v.ctx, source, expr)
+	return expr, nil
 }

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -232,7 +232,7 @@ func (c *ColumnItem) Resolve(
 		}
 	}
 	if res == NoResults {
-		return nil, newSourceNotFoundError("no data source matches prefix: %s", c.TableName)
+		return nil, newSourceNotFoundError("no data source matches prefix: %s in this context", c.TableName)
 	}
 	return r.Resolve(ctx, srcName, srcMeta, -1, colName)
 }


### PR DESCRIPTION
Notably alter table add column with a computed expr and alter column type using.

Moved the DequalifyColumnRefs call into ReplaceColumnVarsAndSanitizeExpr since
ReplaceColumnVarsAndSanitizeExpr is called to sanitize the expression in
all these cases.

Fixes #50069

Release note (bug fix): Previously performing ALTER TABLE ADD COLUMN with a computed
expression allowed you to provide a column in a different table or database if the column name
was the same. Similarly you could provide an expression referring to another table's
column when executing ALTER COLUMN TYPE USING EXPRESSION. This is no longer the case,
all columns must refer to the column in the table you're altering.