### PR TITLE
make jobs.retention_time a public=true cluster setting

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -13,6 +13,7 @@
 <tr><td><code>enterprise.license</code></td><td>string</td><td><code></code></td><td>the encoded cluster license</td></tr>
 <tr><td><code>external.graphite.endpoint</code></td><td>string</td><td><code></code></td><td>if nonempty, push server metrics to the Graphite or Carbon server at the specified host:port</td></tr>
 <tr><td><code>external.graphite.interval</code></td><td>duration</td><td><code>10s</code></td><td>the interval at which metrics are pushed to Graphite (if enabled)</td></tr>
+<tr><td><code>jobs.retention_time</code></td><td>duration</td><td><code>336h0m0s</code></td><td>the amount of time to retain records for completed jobs before</td></tr>
 <tr><td><code>kv.allocator.load_based_lease_rebalancing.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to enable rebalancing of range leases based on load and latency</td></tr>
 <tr><td><code>kv.allocator.load_based_rebalancing</code></td><td>enumeration</td><td><code>leases and replicas</code></td><td>whether to rebalance based on the distribution of QPS across stores [off = 0, leases = 1, leases and replicas = 2]</td></tr>
 <tr><td><code>kv.allocator.qps_rebalance_threshold</code></td><td>float</td><td><code>0.25</code></td><td>minimum fraction away from the mean a store's QPS (such as queries per second) can be before it is considered overfull or underfull</td></tr>

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -58,7 +58,7 @@ var (
 		"jobs.registry.leniency",
 		"the amount of time to defer any attempts to reschedule a job",
 		defaultLeniencySetting)
-	gcSetting = settings.RegisterDurationSetting(
+	gcSetting = settings.RegisterPublicDurationSetting(
 		"jobs.retention_time",
 		"the amount of time to retain records for completed jobs before",
 		time.Hour*24*14)


### PR DESCRIPTION
This PR is replacing this old one: https://github.com/cockroachdb/cockroach/pull/50244

**Classify jobs.retention_time as public cluster setting**
Inspired by both of these issues [Missing jobs cluster setting doc](https://github.com/cockroachdb/docs/issues/7334) and [cluster setting mentioned on one page and not another](https://github.com/cockroachdb/docs/issues/7452), it's been concluded that jobs.retention_time cluster setting should be public. In our public docs, [it's been updated](https://github.com/cockroachdb/docs/pull/7511).

However, it's still listed as non-public when querying SHOW ALL CLUSTER SETTINGS; in the SQL Client.

This change follows the patterns when we first [classified cluster settings as public and non-public](https://github.com/cockroachdb/cockroach/pull/42520/commits).

**Testing:**
Environment:
<img width="450" alt="Screen Shot 2020-06-15 at 4 09 09 PM" src="https://user-images.githubusercontent.com/1663752/84701248-a0381400-af22-11ea-9ac4-241fd0c86c7b.png">

cockroach demo

1. When running SHOW ALL CLUSTER SETTINGS;
Expected: in the "public column," it should show as "true"
Actual: it appears as true
2. When running "SHOW CLUSTER SETTINGS;
Expected: it should be listed
Actual: it's listed

**Output:**
jobs.retention_time                                              | 336h0m0s                                  | d            |  true  | the amount of time to retain records for completed jobs before