### PR TITLE
roachtest/clock: be resilient to conn resets after cluster restart

### DIFF
--- a/pkg/cmd/roachtest/clock_util.go
+++ b/pkg/cmd/roachtest/clock_util.go
@@ -19,11 +19,17 @@ import (
 
 // isAlive returns whether the node queried by db is alive.
 func isAlive(db *gosql.DB, l *logger) bool {
-	_, err := db.Exec("SHOW DATABASES")
-	if err != nil {
-		l.Printf("isAlive returned err=%v\n", err)
+	// The cluster might have just restarted, in which case the first call to db
+	// might return an error. In fact, the first db.Ping() reliably returns an
+	// error (but a db.Exec() only seldom returns an error). So, we're gonna
+	// Ping() twice to allow connections to be re-established.
+	_ = db.Ping()
+	if err := db.Ping(); err != nil {
+		l.Printf("isAlive returned err=%v (%T)", err, err)
+	} else {
+		return true
 	}
-	return err == nil
+	return false
 }
 
 // dbUnixEpoch returns the current time in db.


### PR DESCRIPTION
Before this patch, a query run after a restart would sometimes fail when
run on a db created before the cluster restart. This must be due to how
a client only becomes aware of a closed conn at certain times (e.g. when
attempting to run a query). This patch tolerates connections being
re-established.

Got one error out of 50 before, zero in 150 after.

Fixes #50328

Release note: None