### PR TITLE
builtins: add non ST_ prefixed geospatial builtin functions

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -691,6 +691,41 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><a name="addgeometrycolumn"></a><code>addgeometrycolumn(table_name: <a href="string.html">string</a>, column_name: <a href="string.html">string</a>, srid: <a href="int.html">int</a>, type: <a href="string.html">string</a>, dimension: <a href="int.html">int</a>, use_typmod: <a href="bool.html">bool</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Adds a new geometry column to an existing table and returns metadata about the column created.</p>
 </span></td></tr>
+<tr><td><a name="geometrytype"></a><code>geometrytype(geometry: geometry) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the type of geometry as a string.</p>
+<p>This function utilizes the GEOS module.</p>
+</span></td></tr>
+<tr><td><a name="postgis_addbbox"></a><code>postgis_addbbox(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. This does not perform any operation on the Geometry.</p>
+</span></td></tr>
+<tr><td><a name="postgis_dropbbox"></a><code>postgis_dropbbox(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. This does not perform any operation on the Geometry.</p>
+</span></td></tr>
+<tr><td><a name="postgis_extensions_upgrade"></a><code>postgis_extensions_upgrade() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. Returns a fixed string based on PostGIS 3.0.1, with minor edits.</p>
+</span></td></tr>
+<tr><td><a name="postgis_full_version"></a><code>postgis_full_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. Returns a fixed string based on PostGIS 3.0.1, with minor edits.</p>
+</span></td></tr>
+<tr><td><a name="postgis_geos_version"></a><code>postgis_geos_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. Returns a fixed string based on PostGIS 3.0.1, with minor edits.</p>
+</span></td></tr>
+<tr><td><a name="postgis_hasbbox"></a><code>postgis_hasbbox(geometry: geometry) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether a given Geometry has a bounding box. False for points and empty geometries; always true otherwise.</p>
+</span></td></tr>
+<tr><td><a name="postgis_lib_build_date"></a><code>postgis_lib_build_date() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. Returns a fixed string based on PostGIS 3.0.1, with minor edits.</p>
+</span></td></tr>
+<tr><td><a name="postgis_lib_version"></a><code>postgis_lib_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. Returns a fixed string based on PostGIS 3.0.1, with minor edits.</p>
+</span></td></tr>
+<tr><td><a name="postgis_liblwgeom_version"></a><code>postgis_liblwgeom_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. Returns a fixed string based on PostGIS 3.0.1, with minor edits.</p>
+</span></td></tr>
+<tr><td><a name="postgis_libxml_version"></a><code>postgis_libxml_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. Returns a fixed string based on PostGIS 3.0.1, with minor edits.</p>
+</span></td></tr>
+<tr><td><a name="postgis_proj_version"></a><code>postgis_proj_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. Returns a fixed string based on PostGIS 3.0.1, with minor edits.</p>
+</span></td></tr>
+<tr><td><a name="postgis_scripts_build_date"></a><code>postgis_scripts_build_date() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. Returns a fixed string based on PostGIS 3.0.1, with minor edits.</p>
+</span></td></tr>
+<tr><td><a name="postgis_scripts_installed"></a><code>postgis_scripts_installed() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. Returns a fixed string based on PostGIS 3.0.1, with minor edits.</p>
+</span></td></tr>
+<tr><td><a name="postgis_scripts_released"></a><code>postgis_scripts_released() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. Returns a fixed string based on PostGIS 3.0.1, with minor edits.</p>
+</span></td></tr>
+<tr><td><a name="postgis_version"></a><code>postgis_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. Returns a fixed string based on PostGIS 3.0.1, with minor edits.</p>
+</span></td></tr>
+<tr><td><a name="postgis_wagyu_version"></a><code>postgis_wagyu_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Compatibility placeholder function with PostGIS. Returns a fixed string based on PostGIS 3.0.1, with minor edits.</p>
+</span></td></tr>
 <tr><td><a name="st_area"></a><code>st_area(geography: geography) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the area of the given geography in meters^2. Uses a spheroid to perform the operation.</p>
 <p>This function utilizes the GeographicLib library for spheroid calculations.</p>
 </span></td></tr>
@@ -945,7 +980,7 @@ given Geometry.</p>
 </span></td></tr>
 <tr><td><a name="st_geometryn"></a><code>st_geometryn(geometry: geometry, n: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the n-th Geometry (1-indexed). Returns NULL if out of bounds.</p>
 </span></td></tr>
-<tr><td><a name="st_geometrytype"></a><code>st_geometrytype(geometry: geometry) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the type of geometry as a string.</p>
+<tr><td><a name="st_geometrytype"></a><code>st_geometrytype(geometry: geometry) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the type of geometry as a string prefixed with <code>ST_</code>.</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td></tr>
 <tr><td><a name="st_geomfromewkb"></a><code>st_geomfromewkb(val: <a href="bytes.html">bytes</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the Geometry from an EWKB representation.</p>

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -29,6 +29,17 @@ SELECT 'SRID=404;POINT(1.0 2.0)'::geography
 statement error SRID 3857 cannot be used for geography as it is not in a lon/lat coordinate system
 SELECT 'SRID=3857;POINT(1.0 2.0)'::geography
 
+query BTT
+SELECT
+  PostGIS_HasBBox(geom),
+  PostGIS_AddBBox(geom),
+  PostGIS_DropBBox(geom)
+FROM geo_table
+ORDER BY id ASC
+----
+false  010100000000000000000000400000000000000040  010100000000000000000000400000000000000040
+false  0101000000000000000000F03F000000000000F03F  0101000000000000000000F03F000000000000F03F
+
 query ITTT rowsort
 SELECT * FROM geo_table
 ----
@@ -1462,30 +1473,49 @@ Square overlapping left and right square  Square (right)                        
 Square overlapping left and right square  Square overlapping left and right square  2FFF1FFF2  false
 
 # basic metadata
-query TTIIITTT
+query TTTIII
 SELECT
   a.dsc,
+  GeometryType(a.geom),
   ST_GeometryType(a.geom),
   ST_NDims(a.geom),
   ST_NPoints(a.geom),
-  ST_NumGeometries(a.geom),
-  ST_GeometryN(a.geom, 0),
-  ST_GeometryN(a.geom, 1),
-  ST_GeometryN(a.geom, 2)
+  ST_NumGeometries(a.geom)
 FROM geom_operators_test a
 ORDER BY a.dsc
 ----
-Empty GeometryCollection                  ST_GeometryCollection  0     0     0     NULL  NULL                                                                                                                                                                                        NULL
-Empty LineString                          ST_LineString          2     0     0     NULL  010200000000000000                                                                                                                                                                          NULL
-Empty Point                               ST_Point               2     0     0     NULL  0101000000000000000000F87F000000000000F87F                                                                                                                                                  NULL
-Faraway point                             ST_Point               2     1     1     NULL  010100000000000000000014400000000000001440                                                                                                                                                  NULL
-Line going through left and right square  ST_LineString          2     2     1     NULL  010200000002000000000000000000E0BF000000000000E03F000000000000E03F000000000000E03F                                                                                                          NULL
-NULL                                      NULL                   NULL  NULL  NULL  NULL  NULL                                                                                                                                                                                        NULL
-Point middle of Left Square               ST_Point               2     1     1     NULL  0101000000000000000000E0BF000000000000E03F                                                                                                                                                  NULL
-Point middle of Right Square              ST_Point               2     1     1     NULL  0101000000000000000000E03F000000000000E03F                                                                                                                                                  NULL
-Square (left)                             ST_Polygon             2     5     1     NULL  01030000000100000005000000000000000000F0BF0000000000000000000000000000000000000000000000000000000000000000000000000000F03F000000000000F0BF000000000000F03F000000000000F0BF0000000000000000  NULL
-Square (right)                            ST_Polygon             2     5     1     NULL  0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000  NULL
-Square overlapping left and right square  ST_Polygon             2     5     1     NULL  010300000001000000050000009A9999999999B9BF0000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F9A9999999999B9BF000000000000F03F9A9999999999B9BF0000000000000000  NULL
+Empty GeometryCollection                  GeometryCollection  ST_GeometryCollection  0     0     0
+Empty LineString                          LineString          ST_LineString          2     0     0
+Empty Point                               Point               ST_Point               2     0     0
+Faraway point                             Point               ST_Point               2     1     1
+Line going through left and right square  LineString          ST_LineString          2     2     1
+NULL                                      NULL                NULL                   NULL  NULL  NULL
+Point middle of Left Square               Point               ST_Point               2     1     1
+Point middle of Right Square              Point               ST_Point               2     1     1
+Square (left)                             Polygon             ST_Polygon             2     5     1
+Square (right)                            Polygon             ST_Polygon             2     5     1
+Square overlapping left and right square  Polygon             ST_Polygon             2     5     1
+
+query TTTT
+SELECT
+  a.dsc,
+  ST_AsEWKT(ST_GeometryN(a.geom, 0)),
+  ST_AsEWKT(ST_GeometryN(a.geom, 1)),
+  ST_AsEWKT(ST_GeometryN(a.geom, 2))
+FROM geom_operators_test a
+ORDER BY a.dsc
+----
+Empty GeometryCollection                  NULL  NULL                                          NULL
+Empty LineString                          NULL  LINESTRING EMPTY                              NULL
+Empty Point                               NULL  POINT EMPTY                                   NULL
+Faraway point                             NULL  POINT (5 5)                                   NULL
+Line going through left and right square  NULL  LINESTRING (-0.5 0.5, 0.5 0.5)                NULL
+NULL                                      NULL  NULL                                          NULL
+Point middle of Left Square               NULL  POINT (-0.5 0.5)                              NULL
+Point middle of Right Square              NULL  POINT (0.5 0.5)                               NULL
+Square (left)                             NULL  POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))        NULL
+Square (right)                            NULL  POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))           NULL
+Square overlapping left and right square  NULL  POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))  NULL
 
 # Point specific operations
 query RR

--- a/pkg/sql/logictest/testdata/logic_test/geospatial_meta
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_meta
@@ -1,0 +1,66 @@
+# meta statements (e.g. version numbers) tests go here
+
+query T
+SELECT PostGIS_Extensions_Upgrade()
+----
+Upgrade completed, run SELECT postgis_full_version(); for details
+
+query T
+SELECT PostGIS_Full_Version()
+----
+POSTGIS="3.0.1 ec2a9aa" [EXTENSION] PGSQL="120" GEOS="3.8.1-CAPI-1.13.3" PROJ="4.9.3" LIBXML="2.9.10" LIBJSON="0.13.1" LIBPROTOBUF="1.4.2" WAGYU="0.4.3 (Internal)"
+
+query T
+SELECT PostGIS_GEOS_Version()
+----
+3.8.1-CAPI-1.13.3
+
+query T
+SELECT PostGIS_LibXML_Version()
+----
+2.9.10
+
+query T
+SELECT PostGIS_Lib_Build_Date()
+----
+2020-03-06 18:23:24
+
+query T
+SELECT PostGIS_Lib_Version()
+----
+3.0.1
+
+query T
+SELECT PostGIS_Liblwgeom_Version()
+----
+3.0.1 ec2a9aa
+
+query T
+SELECT PostGIS_PROJ_Version()
+----
+4.9.3
+
+query T
+SELECT PostGIS_Scripts_Build_Date()
+----
+2020-02-24 13:54:19
+
+query T
+SELECT PostGIS_Scripts_Installed()
+----
+3.0.1 ec2a9aa
+
+query T
+SELECT PostGIS_Scripts_Released()
+----
+3.0.1 ec2a9aa
+
+query T
+SELECT PostGIS_Version()
+----
+3.0 USE_GEOS=1 USE_PROJ=1 USE_STATS=1
+
+query T
+SELECT PostGIS_Wagyu_Version()
+----
+0.4.3 (Internal)

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -371,6 +371,72 @@ func fitMaxDecimalDigitsToBounds(maxDecimalDigits int) int {
 
 var geoBuiltins = map[string]builtinDefinition{
 	//
+	// Meta builtins.
+	//
+	"postgis_addbbox": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				return g, nil
+			},
+			types.Geometry,
+			infoBuilder{
+				info: "Compatibility placeholder function with PostGIS. This does not perform any operation on the Geometry.",
+			},
+			tree.VolatilityImmutable,
+		),
+	),
+	"postgis_dropbbox": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				return g, nil
+			},
+			types.Geometry,
+			infoBuilder{
+				info: "Compatibility placeholder function with PostGIS. This does not perform any operation on the Geometry.",
+			},
+			tree.VolatilityImmutable,
+		),
+	),
+	"postgis_hasbbox": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(_ *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				if g.Geometry.Empty() {
+					return tree.DBoolFalse, nil
+				}
+				if g.Geometry.Shape() == geopb.Shape_Point {
+					return tree.DBoolFalse, nil
+				}
+				return tree.DBoolTrue, nil
+			},
+			types.Bool,
+			infoBuilder{
+				info: "Returns whether a given Geometry has a bounding box. False for points and empty geometries; always true otherwise.",
+			},
+			tree.VolatilityImmutable,
+		),
+	),
+	"postgis_extensions_upgrade": returnCompatibilityFixedStringBuiltin(
+		"Upgrade completed, run SELECT postgis_full_version(); for details",
+	),
+	"postgis_full_version": returnCompatibilityFixedStringBuiltin(
+		`POSTGIS="3.0.1 ec2a9aa" [EXTENSION] PGSQL="120" GEOS="3.8.1-CAPI-1.13.3" PROJ="4.9.3" LIBXML="2.9.10" LIBJSON="0.13.1" LIBPROTOBUF="1.4.2" WAGYU="0.4.3 (Internal)"`,
+	),
+	"postgis_geos_version":       returnCompatibilityFixedStringBuiltin("3.8.1-CAPI-1.13.3"),
+	"postgis_libxml_version":     returnCompatibilityFixedStringBuiltin("2.9.10"),
+	"postgis_lib_build_date":     returnCompatibilityFixedStringBuiltin("2020-03-06 18:23:24"),
+	"postgis_lib_version":        returnCompatibilityFixedStringBuiltin("3.0.1"),
+	"postgis_liblwgeom_version":  returnCompatibilityFixedStringBuiltin("3.0.1 ec2a9aa"),
+	"postgis_proj_version":       returnCompatibilityFixedStringBuiltin("4.9.3"),
+	"postgis_scripts_build_date": returnCompatibilityFixedStringBuiltin("2020-02-24 13:54:19"),
+	"postgis_scripts_installed":  returnCompatibilityFixedStringBuiltin("3.0.1 ec2a9aa"),
+	"postgis_scripts_released":   returnCompatibilityFixedStringBuiltin("3.0.1 ec2a9aa"),
+	"postgis_version":            returnCompatibilityFixedStringBuiltin("3.0 USE_GEOS=1 USE_PROJ=1 USE_STATS=1"),
+	"postgis_wagyu_version":      returnCompatibilityFixedStringBuiltin("0.4.3 (Internal)"),
+
+	//
 	// Input (Geometry)
 	//
 
@@ -1685,6 +1751,20 @@ Note ST_Perimeter is only valid for Polygon - use ST_Length for LineString.`,
 			tree.VolatilityImmutable,
 		),
 	),
+	"geometrytype": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				return tree.NewDString(g.Shape().String()), nil
+			},
+			types.String,
+			infoBuilder{
+				info:         "Returns the type of geometry as a string.",
+				libraryUsage: usesGEOS,
+			},
+			tree.VolatilityImmutable,
+		),
+	),
 	"st_geometrytype": makeBuiltin(
 		defProps(),
 		geometryOverload1(
@@ -1693,7 +1773,7 @@ Note ST_Perimeter is only valid for Polygon - use ST_Length for LineString.`,
 			},
 			types.String,
 			infoBuilder{
-				info:         "Returns the type of geometry as a string.",
+				info:         "Returns the type of geometry as a string prefixed with `ST_`.",
 				libraryUsage: usesGEOS,
 			},
 			tree.VolatilityImmutable,
@@ -3045,6 +3125,26 @@ The calculations are done on a sphere.`,
 			Volatility: tree.VolatilityVolatile,
 		},
 	),
+}
+
+// returnCompatibilityFixedStringBuiltin is an overload that takes in 0 arguments
+// and returns the given fixed string.
+// It is assumed to be fully immutable.
+func returnCompatibilityFixedStringBuiltin(ret string) builtinDefinition {
+	return makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(_ *tree.EvalContext, _ tree.Datums) (tree.Datum, error) {
+				return tree.NewDString(ret), nil
+			},
+			Info: infoBuilder{
+				info: fmt.Sprintf("Compatibility placeholder function with PostGIS. Returns a fixed string based on PostGIS 3.0.1, with minor edits."),
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	)
 }
 
 // geometryOverload1 hides the boilerplate for builtins operating on one geometry.


### PR DESCRIPTION
Refs: cockroachdb/django-cockroachdb#148



Release note (sql change): Implements the following builtins:
* GeometryType
* PostGIS_AddBBox
* PostGIS_DropBBox
* PostGIS_Extensions_Upgrade
* PostGIS_Full_Version
* PostGIS_GEOS_Version
* PostGIS_HasBBox
* PostGIS_LibXML_Version
* PostGIS_Lib_Build_Date
* PostGIS_Lib_Version
* PostGIS_Liblwgeom_Version
* PostGIS_PROJ_Version
* PostGIS_Scripts_Build_Date
* PostGIS_Scripts_Installed
* PostGIS_Scripts_Released
* PostGIS_Version
* PostGIS_Wagyu_Version