### PR TITLE
colexec: fix binary operators with const datum on the left

### DIFF
--- a/pkg/col/coldataext/datum_vec.go
+++ b/pkg/col/coldataext/datum_vec.go
@@ -54,10 +54,11 @@ func newDatumVec(t *types.T, n int, evalCtx *tree.EvalContext) coldata.DatumVec 
 }
 
 // BinFn evaluates the provided binary function between the receiver and other.
-// dVec is the datumVec that stores either d or other (it doesn't matter which
-// one because it is used only to supply the eval context).
-func (d *Datum) BinFn(binFn *tree.BinOp, dVec, other interface{}) (tree.Datum, error) {
-	return binFn.Fn(dVec.(*datumVec).evalCtx, d.Datum, maybeUnwrapDatum(other))
+// other can either be nil, tree.Datum, or *Datum.
+func (d *Datum) BinFn(
+	binFn *tree.BinOp, evalCtx *tree.EvalContext, other interface{},
+) (tree.Datum, error) {
+	return binFn.Fn(evalCtx, d.Datum, maybeUnwrapDatum(other))
 }
 
 // CompareDatum returns the comparison between d and other. The other is

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -1489,8 +1489,7 @@ func planSelectionOperators(
 				return op, resultIdx, ct, internalMemUsedLeft, err
 			}
 			op, err := colexec.GetSelectionConstOperator(
-				lTyp, t.TypedRight().ResolvedType(), cmpOp, leftOp, leftIdx,
-				constArg, nil,
+				lTyp, t.TypedRight().ResolvedType(), cmpOp, leftOp, leftIdx, constArg, nil, /* binFn */
 			)
 			return op, resultIdx, ct, internalMemUsedLeft, err
 		}
@@ -1501,8 +1500,7 @@ func planSelectionOperators(
 			return nil, resultIdx, ct, internalMemUsed, err
 		}
 		op, err := colexec.GetSelectionOperator(
-			lTyp, ct[rightIdx], cmpOp, rightOp, leftIdx, rightIdx,
-			nil,
+			lTyp, ct[rightIdx], cmpOp, rightOp, leftIdx, rightIdx, nil, /* binFn */
 		)
 		return op, resultIdx, ct, internalMemUsedLeft + internalMemUsedRight, err
 	default:
@@ -1815,7 +1813,7 @@ func planProjectionExpr(
 		// to the input batch.
 		op, err = colexec.GetProjectionLConstOperator(
 			colmem.NewAllocator(ctx, acc, factory), left.ResolvedType(), typs[rightIdx], outputType,
-			projOp, input, rightIdx, lConstArg, resultIdx, binFn,
+			projOp, input, rightIdx, lConstArg, resultIdx, binFn, evalCtx,
 		)
 	} else {
 		var (
@@ -1863,7 +1861,7 @@ func planProjectionExpr(
 			} else {
 				op, err = colexec.GetProjectionRConstOperator(
 					colmem.NewAllocator(ctx, acc, factory), typs[leftIdx], right.ResolvedType(), outputType,
-					projOp, input, leftIdx, rConstArg, resultIdx, binFn,
+					projOp, input, leftIdx, rConstArg, resultIdx, binFn, evalCtx,
 				)
 			}
 		} else {
@@ -1882,7 +1880,7 @@ func planProjectionExpr(
 			resultIdx = len(typs)
 			op, err = colexec.GetProjectionOperator(
 				colmem.NewAllocator(ctx, acc, factory), typs[leftIdx], typs[rightIdx], outputType,
-				projOp, input, leftIdx, rightIdx, resultIdx, binFn,
+				projOp, input, leftIdx, rightIdx, resultIdx, binFn, evalCtx,
 			)
 		}
 	}

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
@@ -923,20 +923,3 @@ func toPhysicalRepresentation(canonicalTypeFamily types.Family, width int32) str
 	// This code is unreachable, but the compiler cannot infer that.
 	return ""
 }
-
-// getDatumVecVariableName returns the variable name for a datumVec given
-// leftCol and rightCol (either of which could be "_" - meaning there is no
-// vector in scope for the corresponding side).
-// - preferRightSide determines whether we prefer the right side.
-func getDatumVecVariableName(leftCol, rightCol string, preferRightSide bool) string {
-	preferredSide, otherSide := leftCol, rightCol
-	if preferRightSide {
-		preferredSide, otherSide = rightCol, leftCol
-	}
-	switch preferredSide {
-	case "_":
-		return otherSide
-	default:
-		return preferredSide
-	}
-}

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -127,13 +127,6 @@ func registerBinOpOutputTypes() {
 			binOpOutputTypes[binOp][typePair{types.DecimalFamily, anyWidth, types.IntFamily, intWidth}] = types.Decimal
 			binOpOutputTypes[binOp][typePair{types.IntFamily, intWidth, types.DecimalFamily, anyWidth}] = types.Decimal
 		}
-
-		for _, compatibleFamily := range compatibleCanonicalTypeFamilies[typeconv.DatumVecCanonicalTypeFamily] {
-			for _, width := range supportedWidthsByCanonicalTypeFamily[compatibleFamily] {
-				binOpOutputTypes[binOp][typePair{typeconv.DatumVecCanonicalTypeFamily, anyWidth, compatibleFamily, width}] = types.Any
-				binOpOutputTypes[binOp][typePair{compatibleFamily, width, typeconv.DatumVecCanonicalTypeFamily, anyWidth}] = types.Any
-			}
-		}
 	}
 	// There is a special case for division with integers; it should have a
 	// decimal result.
@@ -156,6 +149,26 @@ func registerBinOpOutputTypes() {
 	binOpOutputTypes[tree.Plus][typePair{types.TimestampTZFamily, anyWidth, types.IntervalFamily, anyWidth}] = types.TimestampTZ
 	binOpOutputTypes[tree.Minus][typePair{types.TimestampTZFamily, anyWidth, types.IntervalFamily, anyWidth}] = types.TimestampTZ
 	binOpOutputTypes[tree.Plus][typePair{types.IntervalFamily, anyWidth, types.TimestampTZFamily, anyWidth}] = types.TimestampTZ
+	for _, compatibleFamily := range []types.Family{
+		types.IntFamily,      // types.Date + types.Time
+		types.IntervalFamily, // types.Time + types.Interval
+	} {
+		for _, width := range supportedWidthsByCanonicalTypeFamily[compatibleFamily] {
+			binOpOutputTypes[tree.Plus][typePair{typeconv.DatumVecCanonicalTypeFamily, anyWidth, compatibleFamily, width}] = types.Any
+			binOpOutputTypes[tree.Plus][typePair{compatibleFamily, width, typeconv.DatumVecCanonicalTypeFamily, anyWidth}] = types.Any
+		}
+	}
+	for _, compatibleFamily := range []types.Family{
+		typeconv.DatumVecCanonicalTypeFamily, // types.INet - types.INet
+		types.IntFamily,                      // types.Date - types.Time
+		types.IntervalFamily,                 // types.Time - types.Interval
+		types.BytesFamily,                    // types.Jsonb - types.String
+	} {
+		for _, width := range supportedWidthsByCanonicalTypeFamily[compatibleFamily] {
+			binOpOutputTypes[tree.Minus][typePair{typeconv.DatumVecCanonicalTypeFamily, anyWidth, compatibleFamily, width}] = types.Any
+			binOpOutputTypes[tree.Minus][typePair{compatibleFamily, width, typeconv.DatumVecCanonicalTypeFamily, anyWidth}] = types.Any
+		}
+	}
 
 	// Other arithmetic binary operators.
 	for _, binOp := range []tree.BinaryOperator{tree.FloorDiv, tree.Mod, tree.Pow} {

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_cmp.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_cmp.go
@@ -331,9 +331,19 @@ func (c intervalCustomizer) getCmpOpCompareFunc() compareFunc {
 	}
 }
 
+// getDatumVecVariableName returns the variable name for a datumVec given
+// leftCol and rightCol (either of which could be "_" - meaning there is no
+// vector in scope for the corresponding side).
+func getDatumVecVariableName(leftCol, rightCol string) string {
+	if leftCol == "_" {
+		return rightCol
+	}
+	return leftCol
+}
+
 func (c datumCustomizer) getCmpOpCompareFunc() compareFunc {
 	return func(targetElem, leftElem, rightElem, leftCol, rightCol string) string {
-		datumVecVariableName := getDatumVecVariableName(leftCol, rightCol, false /* preferRightSide */)
+		datumVecVariableName := getDatumVecVariableName(leftCol, rightCol)
 		return fmt.Sprintf(`
 			%s = %s.(*coldataext.Datum).CompareDatum(%s, %s)
 		`, targetElem, leftElem, datumVecVariableName, rightElem)

--- a/pkg/sql/colexec/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/proj_non_const_ops_tmpl.go
@@ -247,6 +247,7 @@ func GetProjectionOperator(
 	col2Idx int,
 	outputIdx int,
 	binFn *tree.BinOp,
+	evalCtx *tree.EvalContext,
 ) (colexecbase.Operator, error) {
 	input = newVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projOpBase := projOpBase{
@@ -255,7 +256,7 @@ func GetProjectionOperator(
 		col1Idx:        col1Idx,
 		col2Idx:        col2Idx,
 		outputIdx:      outputIdx,
-		overloadHelper: overloadHelper{binFn: binFn},
+		overloadHelper: overloadHelper{binFn: binFn, evalCtx: evalCtx},
 	}
 
 	switch op.(type) {

--- a/pkg/sql/colexec/projection_ops_test.go
+++ b/pkg/sql/colexec/projection_ops_test.go
@@ -165,8 +165,8 @@ func TestGetProjectionConstOperator(t *testing.T) {
 	constArg := tree.NewDFloat(tree.DFloat(constVal))
 	outputIdx := 5
 	op, err := GetProjectionRConstOperator(
-		testAllocator, types.Float, types.Float, types.Float,
-		binOp, input, colIdx, constArg, outputIdx, nil,
+		testAllocator, types.Float, types.Float, types.Float, binOp, input,
+		colIdx, constArg, outputIdx, nil /* binFn */, nil, /* evalCtx */
 	)
 	if err != nil {
 		t.Error(err)
@@ -194,8 +194,8 @@ func TestGetProjectionConstMixedTypeOperator(t *testing.T) {
 	constArg := tree.NewDInt(tree.DInt(constVal))
 	outputIdx := 5
 	op, err := GetProjectionRConstOperator(
-		testAllocator, types.Int, types.Int2, types.Int,
-		binOp, input, colIdx, constArg, outputIdx, nil,
+		testAllocator, types.Int, types.Int2, types.Int, binOp, input, colIdx,
+		constArg, outputIdx, nil /* binFn */, nil, /* evalCtx */
 	)
 	if err != nil {
 		t.Error(err)
@@ -319,8 +319,8 @@ func TestGetProjectionOperator(t *testing.T) {
 	col2Idx := 7
 	outputIdx := 9
 	op, err := GetProjectionOperator(
-		testAllocator, typ, typ, types.Int2,
-		binOp, input, col1Idx, col2Idx, outputIdx, nil,
+		testAllocator, typ, typ, types.Int2, binOp, input, col1Idx, col2Idx,
+		outputIdx, nil /* binFn */, nil, /* evalCtx */
 	)
 	if err != nil {
 		t.Error(err)

--- a/pkg/sql/colexec/utils.go
+++ b/pkg/sql/colexec/utils.go
@@ -47,6 +47,7 @@ var (
 type overloadHelper struct {
 	tmpDec1, tmpDec2 apd.Decimal
 	binFn            *tree.BinOp
+	evalCtx          *tree.EvalContext
 }
 
 // makeWindowIntoBatch updates windowedBatch so that it provides a "window"

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
@@ -561,3 +561,43 @@ EXPLAIN (VEC) SELECT _time + _date FROM many_types
 │
 └ Node 1
   └ *rowexec.tableReader
+
+# Regression #50261 (not handling constant datum-backed values on the left
+# correctly).
+statement error pq: cannot AND inet values of different sizes
+SELECT '18b5:7e2:b3b:6f35:c48:eb6a:d607:6c61/108':::INET::INET & broadcast('13.83.69.95/21':::INET::INET)::INET::INET FROM many_types WHERE _bool
+
+query T
+EXPLAIN (VEC) SELECT '[2, "hi", {"b": ["bar", {"c": 4}]}]'::jsonb -> _int FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projJSONFetchValDatumConstInt64Op
+    └ *colfetcher.colBatchScan
+
+query T rowsort
+SELECT '[2, "hi", {"b": ["bar", {"c": 4}]}]'::jsonb -> _int FROM many_types
+----
+NULL
+NULL
+NULL
+{"b": ["bar", {"c": 4}]}
+
+# Check that the comparison expressions with the constant on the left are
+# handled as well (such expressions are normalized so that the constant ends up
+# on the right side).
+query T
+EXPLAIN (VEC) SELECT B'11' <> _varbit FROM many_types
+----
+│
+└ Node 1
+  └ *colexec.projNEDatumDatumConstOp
+    └ *colfetcher.colBatchScan
+
+query B rowsort
+SELECT B'11' >= _varbit FROM many_types
+----
+NULL
+true
+true
+false


### PR DESCRIPTION
**colexec: clean up output types of binary operations on datum vecs**

Previously, for Plus, Minus, Mult, and Div binary operations we would
register an output type for datum-backed vector and all compatible types
on the right. This results in generating some dead code (for example,
datum-backed vector * boolean). This commit cleans up it by registering
the output types only for "real" type pairs. Note that we don't need to
do update the map of "compatible" type families since that is used to
register type customizers, and not declaring an output type for
a particular family-width pair is sufficient to stop the code generation
on that pair.

Release note: None

**colexec: fix binary operators with const datum on the left**

We have a hard-coded assumption that the left element of a binary or
comparison operation with datum-backed vector on the left is
`*coldataext.Datum`. However, this hasn't been the case previously when
we have a constant datum on the left. This commit fixes the issue by
performing a necessary conversion during the operator's creation time.

Additionally, it changes the way we propagate the eval context to
a binary operation - previously, we would use `datumVec` to do that, now
we use `overloadHelper`. The reason is that there is a scenario in which
there is no datum vector in the scope (namely, when we have a const
datum-backed value on the left and non-constant non-datum vector on the
right).

Fixes: #50261.

Release note: None (no stable release with this bug).