### PR TITLE
sql: implement the CREATE SCHEMA command

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -72,6 +72,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>20.1-7</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>20.1-8</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -67,6 +67,7 @@ const (
 	VersionAlterColumnTypeGeneral
 	VersionAlterSystemJobsAddCreatedByColumns
 	VersionAddScheduledJobsTable
+	VersionUserDefinedSchemas
 
 	// Add new versions here (step one of two).
 )
@@ -510,6 +511,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// VersionAddScheduledJobsTable is a version which adds system.scheduled_jobs table.
 		Key:     VersionAddScheduledJobsTable,
 		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 7},
+	},
+	{
+		// VersionUserDefinedSchemas enables the creation of user defined schemas.
+		Key:     VersionUserDefinedSchemas,
+		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 8},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/clusterversion/versionkey_string.go
+++ b/pkg/clusterversion/versionkey_string.go
@@ -43,11 +43,12 @@ func _() {
 	_ = x[VersionAlterColumnTypeGeneral-32]
 	_ = x[VersionAlterSystemJobsAddCreatedByColumns-33]
 	_ = x[VersionAddScheduledJobsTable-34]
+	_ = x[VersionUserDefinedSchemas-35]
 }
 
-const _VersionKey_name = "Version19_1VersionStart19_2VersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDsVersionHashShardedIndexesVersionCreateRolePrivilegeVersionStatementDiagnosticsSystemTablesVersionSchemaChangeJobVersionSavepointsVersionTimeTZTypeVersionTimePrecisionVersion20_1VersionStart20_2VersionGeospatialTypeVersionEnumsVersionRangefeedLeasesVersionAlterColumnTypeGeneralVersionAlterSystemJobsAddCreatedByColumnsVersionAddScheduledJobsTable"
+const _VersionKey_name = "Version19_1VersionStart19_2VersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDsVersionHashShardedIndexesVersionCreateRolePrivilegeVersionStatementDiagnosticsSystemTablesVersionSchemaChangeJobVersionSavepointsVersionTimeTZTypeVersionTimePrecisionVersion20_1VersionStart20_2VersionGeospatialTypeVersionEnumsVersionRangefeedLeasesVersionAlterColumnTypeGeneralVersionAlterSystemJobsAddCreatedByColumnsVersionAddScheduledJobsTableVersionUserDefinedSchemas"
 
-var _VersionKey_index = [...]uint16{0, 11, 27, 49, 75, 109, 136, 176, 200, 211, 227, 258, 287, 322, 354, 380, 404, 441, 480, 499, 534, 559, 585, 624, 646, 663, 680, 700, 711, 727, 748, 760, 782, 811, 852, 880}
+var _VersionKey_index = [...]uint16{0, 11, 27, 49, 75, 109, 136, 176, 200, 211, 227, 258, 287, 322, 354, 380, 404, 441, 480, 499, 534, 559, 585, 624, 646, 663, 680, 700, 711, 727, 748, 760, 782, 811, 852, 880, 905}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -13,10 +13,13 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
 type createSchemaNode struct {
@@ -24,25 +27,96 @@ type createSchemaNode struct {
 }
 
 func (n *createSchemaNode) startExec(params runParams) error {
-	var schemaExists bool
-	if n.n.Schema == tree.PublicSchema {
-		schemaExists = true
-	} else {
-		for _, virtualSchema := range virtualSchemas {
-			if n.n.Schema == virtualSchema.name {
-				schemaExists = true
-				break
-			}
+	return params.p.createUserDefinedSchema(params, n.n)
+}
+
+func (p *planner) schemaExists(
+	ctx context.Context, parentID sqlbase.ID, schema string,
+) (bool, error) {
+	// Check statically known schemas.
+	if schema == tree.PublicSchema {
+		return true, nil
+	}
+	for _, vs := range virtualSchemas {
+		if schema == vs.name {
+			return true, nil
 		}
 	}
-	if !schemaExists {
-		return unimplemented.NewWithIssuef(26443,
-			"new schemas are unsupported")
+	// Now lookup in the namespace for other schemas.
+	exists, _, err := sqlbase.LookupObjectID(ctx, p.txn, p.ExecCfg().Codec, parentID, keys.RootNamespaceID, schema)
+	if err != nil {
+		return false, err
 	}
-	if n.n.IfNotExists {
-		return nil
+	return exists, nil
+}
+
+func (p *planner) createUserDefinedSchema(params runParams, n *tree.CreateSchema) error {
+	// Users can't create a schema without being connected to a DB.
+	if p.CurrentDatabase() == "" {
+		return pgerror.New(pgcode.UndefinedDatabase,
+			"cannot create schema without being connected to a database")
 	}
-	return pgerror.Newf(pgcode.DuplicateSchema, "schema %q already exists", n.n.Schema)
+
+	db, err := p.ResolveUncachedDatabaseByName(params.ctx, p.CurrentDatabase(), true /* required */)
+	if err != nil {
+		return err
+	}
+
+	// Users cannot create schemas within the system database.
+	if db.ID == keys.SystemDatabaseID {
+		return pgerror.New(pgcode.InvalidObjectDefinition, "cannot create schemas in the system database")
+	}
+
+	// Ensure there aren't any name collisions.
+	exists, err := p.schemaExists(params.ctx, db.ID, n.Schema)
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		if n.IfNotExists {
+			return nil
+		}
+		return pgerror.Newf(pgcode.DuplicateSchema, "schema %q already exists", n.Schema)
+	}
+
+	// Ensure that the cluster version is high enough to create the schema.
+	if !params.p.ExecCfg().Settings.Version.IsActive(params.ctx, clusterversion.VersionUserDefinedSchemas) {
+		return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+			`creating schemas requires all nodes to be upgraded to %s`,
+			clusterversion.VersionByKey(clusterversion.VersionUserDefinedSchemas))
+	}
+
+	// Check that creation of schemas is enabled.
+	if !p.EvalContext().SessionData.UserDefinedSchemasEnabled {
+		return pgerror.Newf(pgcode.FeatureNotSupported,
+			"session variable experimental_enable_user_defined_schemas is set to false, cannot create a schema")
+	}
+
+	// Create the ID.
+	id, err := catalogkv.GenerateUniqueDescID(params.ctx, p.ExecCfg().DB, p.ExecCfg().Codec)
+	if err != nil {
+		return err
+	}
+
+	// Create the SchemaDescriptor.
+	desc := sqlbase.NewMutableCreatedSchemaDescriptor(sqlbase.SchemaDescriptor{
+		ParentID: db.ID,
+		Name:     n.Schema,
+		ID:       id,
+		// Inherit the parent privileges.
+		Privileges: db.GetPrivileges(),
+	})
+
+	// Finally create the schema on disk.
+	return p.createDescriptorWithID(
+		params.ctx,
+		sqlbase.NewSchemaKey(db.ID, n.Schema).Key(p.ExecCfg().Codec),
+		id,
+		desc,
+		params.ExecCfg().Settings,
+		tree.AsStringWithFQNames(n, params.Ann()),
+	)
 }
 
 func (*createSchemaNode) Next(runParams) (bool, error) { return false, nil }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -178,6 +178,12 @@ var enumsEnabledClusterMode = settings.RegisterBoolSetting(
 	false,
 )
 
+var userDefinedSchemasClusterMode = settings.RegisterBoolSetting(
+	"sql.defaults.experimental_user_defined_schemas.enabled",
+	"default value for experimental_enable_user_defined_schemas; allows for creation of user defined schemas",
+	false,
+)
+
 var zigzagJoinClusterMode = settings.RegisterBoolSetting(
 	"sql.defaults.zigzag_join.enabled",
 	"default value for enable_zigzag_join session setting; allows use of zig-zag join by default",
@@ -2008,6 +2014,10 @@ func (m *sessionDataMutator) SetZigzagJoinEnabled(val bool) {
 
 func (m *sessionDataMutator) SetEnumsEnabled(val bool) {
 	m.data.EnumsEnabled = val
+}
+
+func (m *sessionDataMutator) SetUserDefinedSchemasEnabled(val bool) {
+	m.data.UserDefinedSchemasEnabled = val
 }
 
 func (m *sessionDataMutator) SetExperimentalDistSQLPlanning(

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1736,6 +1736,7 @@ experimental_distsql_planning                  off                 NULL      NUL
 experimental_enable_enums                      on                  NULL      NULL        NULL        string
 experimental_enable_hash_sharded_indexes       off                 NULL      NULL        NULL        string
 experimental_enable_temp_tables                off                 NULL      NULL        NULL        string
+experimental_enable_user_defined_schemas       off                 NULL      NULL        NULL        string
 experimental_partial_indexes                   off                 NULL      NULL        NULL        string
 extra_float_digits                             0                   NULL      NULL        NULL        string
 force_savepoint_restart                        off                 NULL      NULL        NULL        string
@@ -1802,6 +1803,7 @@ experimental_distsql_planning                  off                 NULL  user   
 experimental_enable_enums                      on                  NULL  user     NULL      off                 off
 experimental_enable_hash_sharded_indexes       off                 NULL  user     NULL      off                 off
 experimental_enable_temp_tables                off                 NULL  user     NULL      off                 off
+experimental_enable_user_defined_schemas       off                 NULL  user     NULL      off                 off
 experimental_partial_indexes                   off                 NULL  user     NULL      off                 off
 extra_float_digits                             0                   NULL  user     NULL      0                   2
 force_savepoint_restart                        off                 NULL  user     NULL      off                 off
@@ -1864,6 +1866,7 @@ experimental_distsql_planning                  NULL    NULL     NULL     NULL   
 experimental_enable_enums                      NULL    NULL     NULL     NULL        NULL
 experimental_enable_hash_sharded_indexes       NULL    NULL     NULL     NULL        NULL
 experimental_enable_temp_tables                NULL    NULL     NULL     NULL        NULL
+experimental_enable_user_defined_schemas       NULL    NULL     NULL     NULL        NULL
 experimental_partial_indexes                   NULL    NULL     NULL     NULL        NULL
 extra_float_digits                             NULL    NULL     NULL     NULL        NULL
 force_savepoint_restart                        NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -1,4 +1,7 @@
 statement ok
+SET experimental_enable_user_defined_schemas = true
+
+statement ok
 CREATE SCHEMA IF NOT EXISTS public
 
 statement ok
@@ -10,10 +13,13 @@ CREATE SCHEMA IF NOT EXISTS pg_catalog
 statement ok
 CREATE SCHEMA IF NOT EXISTS information_schema
 
-statement error unimplemented: new schemas are unsupported
+statement ok
+CREATE SCHEMA derp
+
+statement ok
 CREATE SCHEMA IF NOT EXISTS derp
 
-statement error unimplemented: new schemas are unsupported
+statement error schema \"derp\" already exists
 CREATE SCHEMA derp
 
 statement error schema .* already exists

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -46,6 +46,7 @@ experimental_distsql_planning                  off
 experimental_enable_enums                      off
 experimental_enable_hash_sharded_indexes       off
 experimental_enable_temp_tables                off
+experimental_enable_user_defined_schemas       off
 experimental_partial_indexes                   off
 extra_float_digits                             0
 force_savepoint_restart                        off

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4506,7 +4506,7 @@ pause_stmt:
   }
 | PAUSE error // SHOW HELP: PAUSE JOBS
 
-// %Help: CREATE SCHEMA - create a new schema (not yet supported)
+// %Help: CREATE SCHEMA - create a new schema
 // %Category: DDL
 // %Text:
 // CREATE SCHEMA [IF NOT EXISTS] <schemaname>

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -43,6 +43,9 @@ type SessionData struct {
 	DistSQLMode DistSQLExecMode
 	// EnumsEnabled indicates whether use of ENUM types are allowed.
 	EnumsEnabled bool
+	// UserDefinedSchemasEnabled indicates whether use of user defined schemas
+	// are allowed.
+	UserDefinedSchemasEnabled bool
 	// ExperimentalDistSQLPlanningMode indicates whether the experimental
 	// DistSQL planning driven by the optimizer is enabled.
 	ExperimentalDistSQLPlanningMode ExperimentalDistSQLPlanningMode

--- a/pkg/sql/sqlbase/schema_desc.go
+++ b/pkg/sql/sqlbase/schema_desc.go
@@ -47,22 +47,21 @@ func NewImmutableSchemaDescriptor(desc SchemaDescriptor) *ImmutableSchemaDescrip
 	}
 }
 
+func makeImmutableSchemaDescriptor(desc SchemaDescriptor) ImmutableSchemaDescriptor {
+	return ImmutableSchemaDescriptor{SchemaDescriptor: desc}
+}
+
 // Reference these functions to defeat the linter.
 var (
 	_ = NewImmutableSchemaDescriptor
-	_ = NewInitialSchemaDescriptor
 )
 
-// NewInitialSchemaDescriptor constructs a new SchemaDescriptor for an
-// initial version from an id and name.
-func NewInitialSchemaDescriptor(id ID, name string) *ImmutableSchemaDescriptor {
-	return &ImmutableSchemaDescriptor{
-		SchemaDescriptor: SchemaDescriptor{
-			ID:         id,
-			Name:       name,
-			Version:    1,
-			Privileges: NewDefaultPrivilegeDescriptor(),
-		},
+// NewMutableCreatedSchemaDescriptor returns a MutableSchemaDescriptor from the
+// given SchemaDescriptor with the cluster version being the zero schema. This
+// is for a schema that is created within the current transaction.
+func NewMutableCreatedSchemaDescriptor(desc SchemaDescriptor) *MutableSchemaDescriptor {
+	return &MutableSchemaDescriptor{
+		ImmutableSchemaDescriptor: makeImmutableSchemaDescriptor(desc),
 	}
 }
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -423,6 +423,25 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`experimental_enable_user_defined_schemas`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`experimental_enable_user_defined_schemas`),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			b, err := parseBoolVar(`experimental_enable_user_defined_schemas`, s)
+			if err != nil {
+				return err
+			}
+			m.SetUserDefinedSchemasEnabled(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.UserDefinedSchemasEnabled)
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(userDefinedSchemasClusterMode.Get(sv))
+		},
+	},
+
+	// CockroachDB extension.
 	`enable_zigzag_join`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`enable_zigzag_join`),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {


### PR DESCRIPTION
Built off of #49523.

This PR adds the ability to create schemas. Note that we don't support
qualification in the `CREATE SCHEMA` statement, and this is in line with
Postgres.

Release note: None