### PR TITLE
cli: don't pull liveness twice

### DIFF
--- a/pkg/cli/testdata/zip/partial1_excluded
+++ b/pkg/cli/testdata/zip/partial1_excluded
@@ -8,7 +8,6 @@ using SQL connection URL: postgresql://...
 writing /dev/null
 requesting data for debug/events... writing: debug/events.json
 requesting data for debug/rangelog... writing: debug/rangelog.json
-requesting data for debug/liveness... writing: debug/liveness.json
 requesting data for debug/settings... writing: debug/settings.json
 requesting data for debug/reports/problemranges... writing: debug/reports/problemranges.json
 retrieving SQL data for crdb_internal.cluster_queries... writing: debug/crdb_internal.cluster_queries.txt

--- a/pkg/cli/testdata/zip/partial2
+++ b/pkg/cli/testdata/zip/partial2
@@ -8,7 +8,6 @@ using SQL connection URL: postgresql://...
 writing /dev/null
 requesting data for debug/events... writing: debug/events.json
 requesting data for debug/rangelog... writing: debug/rangelog.json
-requesting data for debug/liveness... writing: debug/liveness.json
 requesting data for debug/settings... writing: debug/settings.json
 requesting data for debug/reports/problemranges... writing: debug/reports/problemranges.json
 retrieving SQL data for crdb_internal.cluster_queries... writing: debug/crdb_internal.cluster_queries.txt

--- a/pkg/cli/testdata/zip/testzip
+++ b/pkg/cli/testdata/zip/testzip
@@ -8,7 +8,6 @@ using SQL connection URL: postgresql://...
 writing /dev/null
 requesting data for debug/events... writing: debug/events.json
 requesting data for debug/rangelog... writing: debug/rangelog.json
-requesting data for debug/liveness... writing: debug/liveness.json
 requesting data for debug/settings... writing: debug/settings.json
 requesting data for debug/reports/problemranges... writing: debug/reports/problemranges.json
 retrieving SQL data for crdb_internal.cluster_queries... writing: debug/crdb_internal.cluster_queries.txt

--- a/pkg/cli/testdata/zip/unavailable
+++ b/pkg/cli/testdata/zip/unavailable
@@ -10,7 +10,6 @@ requesting data for debug/events... writing: debug/events.json.err.txt
   ^- resulted in ...
 requesting data for debug/rangelog... writing: debug/rangelog.json.err.txt
   ^- resulted in ...
-requesting data for debug/liveness... writing: debug/liveness.json
 requesting data for debug/settings... writing: debug/settings.json
 requesting data for debug/reports/problemranges... writing: debug/reports/problemranges.json
 retrieving SQL data for crdb_internal.cluster_queries... writing: debug/crdb_internal.cluster_queries.txt

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -294,6 +294,8 @@ func runDebugZip(cmd *cobra.Command, args []string) (retErr error) {
 		return z.createJSONOrError(r.pathName+".json", data, err)
 	}
 
+	// NB: we intentionally omit liveness since it's already pulled manually (we
+	// act on the output to special case decommissioned nodes).
 	for _, r := range []zipRequest{
 		{
 			fn: func(ctx context.Context) (interface{}, error) {
@@ -306,12 +308,6 @@ func runDebugZip(cmd *cobra.Command, args []string) (retErr error) {
 				return admin.RangeLog(ctx, &serverpb.RangeLogRequest{})
 			},
 			pathName: rangelogName,
-		},
-		{
-			fn: func(ctx context.Context) (interface{}, error) {
-				return admin.Liveness(ctx, &serverpb.LivenessRequest{})
-			},
-			pathName: livenessName,
 		},
 		{
 			fn: func(ctx context.Context) (interface{}, error) {
@@ -371,7 +367,7 @@ func runDebugZip(cmd *cobra.Command, args []string) (retErr error) {
 			lresponse, err = admin.Liveness(ctx, &serverpb.LivenessRequest{})
 			return err
 		})
-		if cErr := z.createJSONOrError(base+"/liveness.json", nodes, err); cErr != nil {
+		if cErr := z.createJSONOrError(livenessName+".json", nodes, err); cErr != nil {
 			return cErr
 		}
 		livenessByNodeID := map[roachpb.NodeID]kvserverpb.NodeLivenessStatus{}


### PR DESCRIPTION
Fixes #49520

Noticed this since on OSX `unzip` asks me whether to overwrite `liveness.json`
This seems harmless other than that though.

Release note: None
