### PR TITLE
tree: compare Geometry/Geography types using protobuf bytes

### DIFF
--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -12,11 +12,13 @@
 package geo
 
 import (
+	"bytes"
 	"encoding/binary"
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geographiclib"
 	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/geo/geoprojbase"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 	"github.com/golang/geo/s2"
 	"github.com/twpayne/go-geom"
@@ -637,4 +639,18 @@ func shapeFromGeom(t geom.T) (geopb.Shape, error) {
 	default:
 		return geopb.Shape_Unset, errors.Newf("unknown shape: %T", t)
 	}
+}
+
+// CompareSpatialObject compares the SpatialObject.
+// This must match the byte ordering that is be produced by encoding.EncodeGeoAscending.
+func CompareSpatialObject(lhs geopb.SpatialObject, rhs geopb.SpatialObject) int {
+	marshalledLHS, err := protoutil.Marshal(&lhs)
+	if err != nil {
+		panic(err)
+	}
+	marshalledRHS, err := protoutil.Marshal(&rhs)
+	if err != nil {
+		panic(err)
+	}
+	return bytes.Compare(marshalledLHS, marshalledRHS)
 }

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -2744,7 +2744,7 @@ func (d *DGeography) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	return bytes.Compare(d.EWKB(), other.(*DGeography).EWKB())
+	return geo.CompareSpatialObject(d.Geography.SpatialObject(), other.(*DGeography).SpatialObject())
 }
 
 // Prev implements the Datum interface.
@@ -2852,7 +2852,7 @@ func (d *DGeometry) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	return bytes.Compare(d.EWKB(), other.(*DGeometry).EWKB())
+	return geo.CompareSpatialObject(d.Geometry.SpatialObject(), other.(*DGeometry).SpatialObject())
 }
 
 // Prev implements the Datum interface.


### PR DESCRIPTION
We previously used EWKB() to compare protobuf bytes, but we are looking
to move away from storing EWKB as the backing store for performance
reasons.

As such, change the comparisons to use protobuf compares.

Release note: None