### PR TITLE
build/packer: Fix user issues in TeamCity Agent Packer image build script

### DIFF
--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -41,6 +41,9 @@ apt-get install --yes \
 # Installing gnome-keyring prevents the error described in
 # https://github.com/moby/moby/issues/34048
 
+# Add a user for the TeamCity agent if it doesn't exist already.
+id -u agent &>/dev/null 2>&1 || adduser agent --disabled-password
+
 # Give the user for the TeamCity agent Docker rights.
 usermod -a -G docker agent
 


### PR DESCRIPTION
Building the TeamCity Agent image with Packer at `build/packer/teamcity-agent.sh` results in the error message:
```
==> googlecompute: + usermod -a -G docker agent
==> googlecompute: usermod: user ‘agent’ does not exist
```
The `agent` user needs to be created for the install script to work properly.
The script first checks if the `agent` user exists, and if not, adds the user.