### PR TITLE
opt: add new operator for InvertedFilter

### DIFF
--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -17,11 +17,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/invertedexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/span"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/errors"
 )
 
 type distSQLSpecExecFactory struct {
@@ -88,6 +90,7 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	index cat.Index,
 	needed exec.TableColumnOrdinalSet,
 	indexConstraint *constraint.Constraint,
+	invertedConstraint invertedexpr.InvertedSpans,
 	hardLimit int64,
 	softLimit int64,
 	reverse bool,
@@ -141,6 +144,11 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	if err != nil {
 		return nil, err
 	}
+	// TODO(rytaft, sumeerbhola): Add support for inverted constraints.
+	if invertedConstraint != nil {
+		return nil, errors.Errorf("Geospatial constrained scans are not yet supported")
+	}
+
 	isFullTableScan := len(spans) == 1 && spans[0].EqualValue(
 		tabDesc.IndexSpan(e.planner.ExecCfg().Codec, indexDesc.ID),
 	)
@@ -252,6 +260,14 @@ func (e *distSQLSpecExecFactory) ConstructFilter(
 	}
 	physPlan.SetMergeOrdering(e.dsp.convertOrdering(ReqOrdering(reqOrdering), physPlan.PlanToStreamColMap))
 	return plan, nil
+}
+
+// ConstructInvertedFilter is part of the exec.Factory interface.
+func (e *distSQLSpecExecFactory) ConstructInvertedFilter(
+	n exec.Node, invFilter *invertedexpr.SpanExpression, invColumn exec.NodeColumnOrdinal,
+) (exec.Node, error) {
+	// TODO(rytaft, sumeerbhola): Fill this in.
+	return nil, errors.Errorf("Inverted filters are not yet supported")
 }
 
 func (e *distSQLSpecExecFactory) ConstructSimpleProject(

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/invertedexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -35,6 +36,7 @@ func (f *stubFactory) ConstructScan(
 	index cat.Index,
 	needed exec.TableColumnOrdinalSet,
 	indexConstraint *constraint.Constraint,
+	invertedConstraint invertedexpr.InvertedSpans,
 	hardLimit int64,
 	softLimit int64,
 	reverse bool,
@@ -48,6 +50,12 @@ func (f *stubFactory) ConstructScan(
 
 func (f *stubFactory) ConstructFilter(
 	n exec.Node, filter tree.TypedExpr, reqOrdering exec.OutputOrdering,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructInvertedFilter(
+	n exec.Node, invFilter *invertedexpr.SpanExpression, invColumn exec.NodeColumnOrdinal,
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/invertedexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -55,8 +56,9 @@ type Factory interface {
 	// ConstructScan returns a node that represents a scan of the given index on
 	// the given table.
 	//   - Only the given set of needed columns are part of the result.
-	//   - If indexConstraint is not nil, the scan is restricted to the spans in
-	//     in the constraint.
+	//   - If indexConstraint or invertedConstraint are not nil, the scan is
+	//     restricted to the spans in in the constraint. Only one of the two may
+	//     be non-nil.
 	//   - If hardLimit > 0, then the scan returns only up to hardLimit rows.
 	//   - If softLimit > 0, then the scan may be required to return up to all
 	//     of its rows (or up to the hardLimit if it is set), but can be optimized
@@ -70,6 +72,7 @@ type Factory interface {
 		index cat.Index,
 		needed TableColumnOrdinalSet,
 		indexConstraint *constraint.Constraint,
+		invertedConstraint invertedexpr.InvertedSpans,
 		hardLimit int64,
 		softLimit int64,
 		reverse bool,
@@ -82,6 +85,14 @@ type Factory interface {
 	// ConstructFilter returns a node that applies a filter on the results of
 	// the given input node.
 	ConstructFilter(n Node, filter tree.TypedExpr, reqOrdering OutputOrdering) (Node, error)
+
+	// ConstructInvertedFilter returns a node that applies a span expression on
+	// the results of the given input node.
+	ConstructInvertedFilter(
+		n Node,
+		invFilter *invertedexpr.SpanExpression,
+		invColumn NodeColumnOrdinal,
+	) (Node, error)
 
 	// ConstructSimpleProject returns a node that applies a "simple" projection on the
 	// results of the given input node. A simple projection is one that does not

--- a/pkg/sql/opt/invertedexpr/expression_test.go
+++ b/pkg/sql/opt/invertedexpr/expression_test.go
@@ -68,7 +68,7 @@ func getSpan(t *testing.T, d *datadriven.TestData) InvertedSpan {
 		d.Fatalf(t, "incorrect span format: %s", str)
 		return InvertedSpan{}
 	} else if len(parts) == 2 {
-		return InvertedSpan{start: []byte(parts[0]), end: []byte(parts[1])}
+		return InvertedSpan{Start: []byte(parts[0]), End: []byte(parts[1])}
 	} else {
 		return MakeSingleInvertedValSpan([]byte(parts[0]))
 	}
@@ -116,7 +116,7 @@ func getExprCopy(
 
 func toString(expr InvertedExpression) string {
 	tp := treeprinter.New()
-	formatExpression(tp, expr)
+	formatExpression(tp, expr, true /* includeSpansToRead */)
 	return tp.String()
 }
 
@@ -186,7 +186,7 @@ func TestExpression(t *testing.T) {
 }
 
 func span(start, end string) InvertedSpan {
-	return InvertedSpan{start: []byte(start), end: []byte(end)}
+	return InvertedSpan{Start: []byte(start), End: []byte(end)}
 }
 
 func single(start string) InvertedSpan {
@@ -196,8 +196,8 @@ func single(start string) InvertedSpan {
 func checkEqual(t *testing.T, expected, actual []InvertedSpan) {
 	require.Equal(t, len(expected), len(actual))
 	for i := range expected {
-		require.Equal(t, expected[i].start, actual[i].start)
-		require.Equal(t, expected[i].end, actual[i].end)
+		require.Equal(t, expected[i].Start, actual[i].Start)
+		require.Equal(t, expected[i].End, actual[i].End)
 	}
 }
 

--- a/pkg/sql/opt/invertedexpr/geo_expression.go
+++ b/pkg/sql/opt/invertedexpr/geo_expression.go
@@ -42,8 +42,8 @@ func geoKeyToEncInvertedVal(k geoindex.Key, end bool) EncInvertedVal {
 
 func geoToSpan(span geoindex.KeySpan) InvertedSpan {
 	return InvertedSpan{
-		start: geoKeyToEncInvertedVal(span.Start, false),
-		end:   geoKeyToEncInvertedVal(span.End, true),
+		Start: geoKeyToEncInvertedVal(span.Start, false),
+		End:   geoKeyToEncInvertedVal(span.End, true),
 	}
 }
 

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -386,7 +386,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 				b.WriteString(fmt.Sprintf("%d", t.Table.ColumnID(idx.Column(i).Ordinal)))
 			}
 			n := tp.Childf("inverted constraint: %s", b.String())
-			ic.Format(n)
+			ic.Format(n, "spans")
 		}
 		if t.HardLimit.IsSet() {
 			tp.Childf("limit: %s", t.HardLimit)
@@ -434,6 +434,13 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			}
 			tp.Childf("locking: %s%s", strength, wait)
 		}
+
+	case *InvertedFilterExpr:
+		var b strings.Builder
+		b.WriteRune('/')
+		b.WriteString(fmt.Sprintf("%d", t.InvertedColumn))
+		n := tp.Childf("inverted expression: %s", b.String())
+		t.InvertedExpression.Format(n, false /* includeSpansToRead */)
 
 	case *LookupJoinExpr:
 		if !t.Flags.Empty() {

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/invertedexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -560,6 +561,14 @@ func (h *hasher) HashLockingItem(val *tree.LockingItem) {
 	}
 }
 
+func (h *hasher) HashInvertedSpans(val invertedexpr.InvertedSpans) {
+	for i := range val {
+		span := &val[i]
+		h.HashBytes(span.Start)
+		h.HashBytes(span.End)
+	}
+}
+
 func (h *hasher) HashRelExpr(val RelExpr) {
 	h.HashUint64(uint64(reflect.ValueOf(val).Pointer()))
 }
@@ -899,6 +908,10 @@ func (h *hasher) IsLockingItemEqual(l, r *tree.LockingItem) bool {
 		return l == r
 	}
 	return l.Strength == r.Strength && l.WaitPolicy == r.WaitPolicy
+}
+
+func (h *hasher) IsInvertedSpansEqual(l, r invertedexpr.InvertedSpans) bool {
+	return l.Equals(r)
 }
 
 func (h *hasher) IsPointerEqual(l, r unsafe.Pointer) bool {

--- a/pkg/sql/opt/memo/interner_test.go
+++ b/pkg/sql/opt/memo/interner_test.go
@@ -19,6 +19,7 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/invertedexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -148,6 +149,16 @@ func TestInterner(t *testing.T) {
 		Function:           RankSingleton,
 		WindowsItemPrivate: WindowsItemPrivate{Col: 0, Frame: frame2},
 	}}
+
+	invSpan1 := invertedexpr.MakeSingleInvertedValSpan([]byte("abc"))
+	invSpan2 := invertedexpr.MakeSingleInvertedValSpan([]byte("abc"))
+	invSpan3 := invertedexpr.InvertedSpan{Start: []byte("abc"), End: []byte("def")}
+	invSpans1 := invertedexpr.InvertedSpans{invSpan1}
+	invSpans2 := invertedexpr.InvertedSpans{invSpan2}
+	invSpans3 := invertedexpr.InvertedSpans{invSpan3}
+	invSpans4 := invertedexpr.InvertedSpans{invSpan1, invSpan2}
+	invSpans5 := invertedexpr.InvertedSpans{invSpan2, invSpan1}
+	invSpans6 := invertedexpr.InvertedSpans{invSpan1, invSpan3}
 
 	type testVariation struct {
 		val1  interface{}
@@ -502,6 +513,14 @@ func TestInterner(t *testing.T) {
 			{val1: wins2, val2: wins3, equal: false},
 			{val1: wins3, val2: wins4, equal: false},
 			{val1: wins1, val2: wins5, equal: false},
+		}},
+
+		{hashFn: in.hasher.HashInvertedSpans, eqFn: in.hasher.IsInvertedSpansEqual, variations: []testVariation{
+			{val1: invSpans1, val2: invSpans2, equal: true},
+			{val1: invSpans1, val2: invSpans3, equal: false},
+			{val1: invSpans2, val2: invSpans4, equal: false},
+			{val1: invSpans4, val2: invSpans5, equal: true},
+			{val1: invSpans5, val2: invSpans6, equal: false},
 		}},
 	}
 

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -265,6 +265,55 @@ func (b *logicalPropsBuilder) buildProjectProps(prj *ProjectExpr, rel *props.Rel
 	}
 }
 
+func (b *logicalPropsBuilder) buildInvertedFilterProps(
+	invFilter *InvertedFilterExpr, rel *props.Relational,
+) {
+	BuildSharedProps(invFilter, &rel.Shared)
+
+	inputProps := invFilter.Input.Relational()
+
+	// Output Columns
+	// --------------
+	// Inherit output columns from input, but remove the inverted column.
+	rel.OutputCols = inputProps.OutputCols
+	rel.OutputCols.Remove(invFilter.InvertedColumn)
+
+	// Not Null Columns
+	// ----------------
+	rel.NotNullCols.UnionWith(inputProps.NotNullCols)
+	rel.NotNullCols.IntersectionWith(rel.OutputCols)
+
+	// Outer Columns
+	// -------------
+	// Outer columns were derived by BuildSharedProps; remove any that are bound
+	// by input columns.
+	rel.OuterCols.DifferenceWith(inputProps.OutputCols)
+
+	// Functional Dependencies
+	// -----------------------
+	// Start with copy of FuncDepSet from input, add FDs from the outer columns,
+	// modify with any additional not-null columns, then possibly simplify by
+	// calling ProjectCols.
+	rel.FuncDeps.CopyFrom(&inputProps.FuncDeps)
+	addOuterColsToFuncDep(rel.OuterCols, &rel.FuncDeps)
+	rel.FuncDeps.MakeNotNull(rel.NotNullCols)
+	rel.FuncDeps.ProjectCols(rel.OutputCols)
+
+	// Cardinality
+	// -----------
+	// Inverted filter can filter any or all rows.
+	rel.Cardinality = inputProps.Cardinality.AsLowAs(0)
+	if rel.FuncDeps.HasMax1Row() {
+		rel.Cardinality = rel.Cardinality.Limit(1)
+	}
+
+	// Statistics
+	// ----------
+	if !b.disableStats {
+		b.sb.buildInvertedFilter(invFilter, rel)
+	}
+}
+
 func (b *logicalPropsBuilder) buildInnerJoinProps(join *InnerJoinExpr, rel *props.Relational) {
 	b.buildJoinProps(join, rel)
 }

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -268,7 +268,7 @@ memo (optimized, ~5KB, required=[presentation: x:1])
 memo 
 SELECT x, y FROM a UNION SELECT x+1, y+1 FROM a
 ----
-memo (optimized, ~4KB, required=[presentation: x:7,y:8])
+memo (optimized, ~5KB, required=[presentation: x:7,y:8])
  ├── G1: (union G2 G3)
  │    └── [presentation: x:7,y:8]
  │         ├── best: (union G2 G3)

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -54,8 +54,8 @@ define ScanPrivate {
     Constraint Constraint
 
     # If set, the scan is a constrained scan of an inverted index; the
-    # SpanExpression contains the spans that need to be scanned.
-    InvertedConstraint SpanExpression
+    # InvertedConstraint contains the spans that need to be scanned.
+    InvertedConstraint InvertedSpans
 
     # HardLimit specifies the maximum number of rows that the scan can return
     # (after applying any constraint), as well as the required scan direction.
@@ -157,6 +157,32 @@ define Project {
     # internalFuncDeps are the functional dependencies between all columns
     # (input or synthesized).
     internalFuncDeps FuncDepSet
+}
+
+# InvertedFilter filters rows from its input result set, based on the
+# InvertedExpression predicate (which is defined in InvertedFilterPrivate).
+# Rows which do not match the filter are discarded. The input should be a
+# constrained scan of an inverted index, possibly wrapped in other operators
+# such as Select.
+[Relational]
+define InvertedFilter {
+    Input RelExpr
+    _ InvertedFilterPrivate
+}
+
+[Private]
+define InvertedFilterPrivate {
+    # InvertedExpression represents the set operations (UNION or INTERSECTION)
+    # that should be executed on the inverted spans retrieved from the input.
+    # The input should already be filtered based on SpansToRead from the
+    # SpanExpression, but this InvertedExpression serves to filter the rows
+    # further by applying set operations on the primary key columns.
+    InvertedExpression SpanExpression
+
+    # The InvertedColumn is the id of the inverted column in the input. It is
+    # used during execution to map rows from the input to their corresponding
+    # spans in the SpanExpression.
+    InvertedColumn ColumnID
 }
 
 # InnerJoin creates a result set that combines columns from its left and right

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -234,6 +234,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"LockingItem":       {fullName: "tree.LockingItem", isPointer: true},
 		"MaterializeClause": {fullName: "tree.MaterializeClause", passByVal: true},
 		"SpanExpression":    {fullName: "invertedexpr.SpanExpression", isPointer: true, usePointerIntern: true},
+		"InvertedSpans":     {fullName: "invertedexpr.InvertedSpans", passByVal: true},
 	}
 
 	// Add types of generated op and private structs.

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -968,20 +968,22 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 	// Iterate over all inverted indexes.
 	iter := makeScanIndexIter(c.e.mem, scanPrivate, rejectNonInvertedIndexes)
 	for iter.Next() {
-		var invertedConstraint *invertedexpr.SpanExpression
+		var spanExpr *invertedexpr.SpanExpression
+		var spansToRead invertedexpr.InvertedSpans
 		var constraint *constraint.Constraint
 		var remaining memo.FiltersExpr
 		var geoOk, nonGeoOk bool
 
 		// Check whether the filter can constrain the index.
-		// TODO(rytaft): Unify these two cases so both return an invertedConstraint.
-		invertedConstraint, geoOk = tryConstrainGeoIndex(
+		// TODO(rytaft): Unify these two cases so both return a spanExpr.
+		spanExpr, geoOk = tryConstrainGeoIndex(
 			c.e.evalCtx.Context, filters, scanPrivate.Table, iter.Index(),
 		)
 		if geoOk {
 			// Geo index scans can never be tight, so remaining filters is always the
 			// same as filters.
 			remaining = filters
+			spansToRead = spanExpr.SpansToRead
 		} else {
 			constraint, remaining, nonGeoOk = c.tryConstrainIndex(
 				filters,
@@ -995,16 +997,23 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 			}
 		}
 
+		invertedCol := scanPrivate.Table.ColumnID(iter.Index().Column(0).Ordinal)
+
 		// Construct new ScanOpDef with the new index and constraint.
 		newScanPrivate := *scanPrivate
 		newScanPrivate.Index = iter.IndexOrdinal()
 		newScanPrivate.Constraint = constraint
-		newScanPrivate.InvertedConstraint = invertedConstraint
+		newScanPrivate.InvertedConstraint = spansToRead
 
-		// Though the index is marked as containing the JSONB column being
-		// indexed, it doesn't actually, and it's only valid to extract the
-		// primary key columns from it.
-		newScanPrivate.Cols = sb.primaryKeyCols()
+		// Though the index is marked as containing the column being indexed, it
+		// doesn't actually, and it's only valid to extract the primary key columns
+		// from it. However, the inverted key column is still needed if there is an
+		// inverted filter.
+		pkCols := sb.primaryKeyCols()
+		newScanPrivate.Cols = pkCols.Copy()
+		if spanExpr != nil {
+			newScanPrivate.Cols.Add(invertedCol)
+		}
 
 		// The Scan operator always goes in a new group, since it's always nested
 		// underneath the IndexJoin. The IndexJoin may also go into its own group,
@@ -1013,9 +1022,12 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 		// correct columns, but it's difficult to tell at this point.
 		sb.setScan(&newScanPrivate)
 
+		// Add an inverted filter if it exists.
+		sb.addInvertedFilter(spanExpr, invertedCol)
+
 		// If remaining filter exists, split it into one part that can be pushed
 		// below the IndexJoin, and one part that needs to stay above.
-		remaining = sb.addSelectAfterSplit(remaining, newScanPrivate.Cols)
+		remaining = sb.addSelectAfterSplit(remaining, pkCols)
 		sb.addIndexJoin(scanPrivate.Cols)
 		sb.addSelect(remaining)
 

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -1185,7 +1185,7 @@ memo (optimized, ~6KB, required=[presentation: sum:5])
 memo
 SELECT sum(w) FROM kuvw GROUP BY v
 ----
-memo (optimized, ~5KB, required=[presentation: sum:5])
+memo (optimized, ~6KB, required=[presentation: sum:5])
  ├── G1: (project G2 G3 sum)
  │    └── [presentation: sum:5]
  │         ├── best: (project G2 G3 sum)
@@ -1210,7 +1210,7 @@ memo (optimized, ~5KB, required=[presentation: sum:5])
 memo
 SELECT array_agg(w) FROM (SELECT * FROM kuvw ORDER BY u,w) GROUP BY v
 ----
-memo (optimized, ~5KB, required=[presentation: array_agg:5])
+memo (optimized, ~6KB, required=[presentation: array_agg:5])
  ├── G1: (project G2 G3 array_agg)
  │    └── [presentation: array_agg:5]
  │         ├── best: (project G2 G3 array_agg)
@@ -1470,7 +1470,7 @@ memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4])
 memo
 SELECT DISTINCT ON (u) u, v, w FROM kuvw
 ----
-memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
+memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(2)) (distinct-on G2 G3 cols=(2),ordering=+2)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +2]" G3 cols=(2),ordering=+2)
@@ -1492,7 +1492,7 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
 memo
 SELECT DISTINCT ON (v) u, v, w FROM kuvw
 ----
-memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
+memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(3)) (distinct-on G2 G3 cols=(3),ordering=+3)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +3]" G3 cols=(3),ordering=+3)
@@ -1514,7 +1514,7 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
 memo
 SELECT DISTINCT ON (w) u, v, w FROM kuvw
 ----
-memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
+memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(4)) (distinct-on G2 G3 cols=(4),ordering=+4)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +4]" G3 cols=(4),ordering=+4)
@@ -1536,7 +1536,7 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
 memo
 SELECT DISTINCT ON (u) u, v, w FROM kuvw ORDER BY u, w
 ----
-memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
+memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
  ├── G1: (distinct-on G2 G3 cols=(2),ordering=+4 opt(2)) (distinct-on G2 G3 cols=(2),ordering=+4)
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +2]
  │    │    ├── best: (sort G1)
@@ -1859,7 +1859,7 @@ memo (optimized, ~19KB, required=[])
 memo
 INSERT INTO xyz SELECT v, w, 1.0 FROM kuvw ON CONFLICT (x) DO UPDATE SET z=2.0
 ----
-memo (optimized, ~19KB, required=[])
+memo (optimized, ~20KB, required=[])
  ├── G1: (upsert G2 G3 xyz)
  │    └── []
  │         ├── best: (upsert G2 G3 xyz)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1790,7 +1790,7 @@ inner-join (zigzag pqr@q pqr@r)
 memo
 SELECT q,r FROM pqr WHERE q = 1 AND r = 2
 ----
-memo (optimized, ~13KB, required=[presentation: q:2,r:3])
+memo (optimized, ~14KB, required=[presentation: q:2,r:3])
  ├── G1: (select G2 G3) (zigzag-join G3 pqr@q pqr@r) (select G4 G5) (select G6 G7) (select G8 G7)
  │    └── [presentation: q:2,r:3]
  │         ├── best: (zigzag-join G3 pqr@q pqr@r)
@@ -1871,7 +1871,7 @@ inner-join (lookup pqr)
 memo
 SELECT q,r,s FROM pqr WHERE q = 1 AND r = 2
 ----
-memo (optimized, ~15KB, required=[presentation: q:2,r:3,s:4])
+memo (optimized, ~16KB, required=[presentation: q:2,r:3,s:4])
  ├── G1: (select G2 G3) (lookup-join G4 G5 pqr,keyCols=[1],outCols=(2-4)) (select G6 G7) (select G8 G9) (select G10 G9)
  │    └── [presentation: q:2,r:3,s:4]
  │         ├── best: (lookup-join G4 G5 pqr,keyCols=[1],outCols=(2-4))
@@ -1990,7 +1990,7 @@ inner-join (zigzag pqr@rs pqr@ts)
 memo
 SELECT r,t FROM pqr WHERE r = 1 AND t = 'foo'
 ----
-memo (optimized, ~13KB, required=[presentation: r:3,t:5])
+memo (optimized, ~14KB, required=[presentation: r:3,t:5])
  ├── G1: (select G2 G3) (zigzag-join G3 pqr@rs pqr@ts) (select G4 G5) (select G6 G5) (select G7 G8)
  │    └── [presentation: r:3,t:5]
  │         ├── best: (zigzag-join G3 pqr@rs pqr@ts)
@@ -2953,7 +2953,7 @@ inner-join (merge)
 memo expect=AssociateJoin
 SELECT * FROM abc, stu, xyz WHERE abc.a=stu.s AND stu.s=xyz.x
 ----
-memo (optimized, ~37KB, required=[presentation: a:1,b:2,c:3,s:5,t:6,u:7,x:8,y:9,z:10])
+memo (optimized, ~38KB, required=[presentation: a:1,b:2,c:3,s:5,t:6,u:7,x:8,y:9,z:10])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+5) (merge-join G3 G2 G5 inner-join,+5,+1) (lookup-join G3 G5 abc@ab,keyCols=[5],outCols=(1-3,5-10)) (inner-join G6 G7 G8) (inner-join G9 G10 G11) (inner-join G7 G6 G8) (merge-join G6 G7 G5 inner-join,+5,+1) (inner-join G10 G9 G11) (merge-join G9 G10 G5 inner-join,+8,+5) (merge-join G7 G6 G5 inner-join,+1,+5) (lookup-join G7 G5 stu,keyCols=[1],outCols=(1-3,5-10)) (inner-join G9 G12 G13) (merge-join G10 G9 G5 inner-join,+5,+8) (lookup-join G10 G5 xyz@xy,keyCols=[5],outCols=(1-3,5-10)) (inner-join G12 G9 G13) (merge-join G9 G12 G5 inner-join,+8,+1) (merge-join G12 G9 G5 inner-join,+1,+8) (lookup-join G12 G5 xyz@xy,keyCols=[1],outCols=(1-3,5-10))
  │    └── [presentation: a:1,b:2,c:3,s:5,t:6,u:7,x:8,y:9,z:10]
  │         ├── best: (merge-join G6="[ordering: +5]" G7="[ordering: +(1|8)]" G5 inner-join,+5,+1)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -317,7 +317,7 @@ inner-join (cross)
 memo join-limit=1
 SELECT * FROM bx, cy, dz, abc WHERE a = 1
 ----
-memo (optimized, ~12KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10])
+memo (optimized, ~13KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4)
  │    └── [presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10]
  │         ├── best: (inner-join G3 G2 G4)

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -53,7 +53,7 @@ scan a,rev
 memo
 SELECT k,f FROM a ORDER BY k DESC LIMIT 10
 ----
-memo (optimized, ~3KB, required=[presentation: k:1,f:3] [ordering: -1])
+memo (optimized, ~4KB, required=[presentation: k:1,f:3] [ordering: -1])
  ├── G1: (limit G2 G3 ordering=-1) (scan a,rev,cols=(1,3),lim=10(rev))
  │    ├── [presentation: k:1,f:3] [ordering: -1]
  │    │    ├── best: (scan a,rev,cols=(1,3),lim=10(rev))

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -155,7 +155,7 @@ project
 memo expect=GeneratePartialIndexScans
 SELECT b FROM p WHERE s = 'foo'
 ----
-memo (optimized, ~6KB, required=[presentation: b:4])
+memo (optimized, ~7KB, required=[presentation: b:4])
  ├── G1: (project G2 G3 b)
  │    └── [presentation: b:4]
  │         ├── best: (project G2 G3 b)
@@ -456,7 +456,7 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND k = 5
 ----
-memo (optimized, ~7KB, required=[presentation: k:1])
+memo (optimized, ~8KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
@@ -1056,7 +1056,7 @@ project
 memo
 SELECT k FROM b WHERE j @> '{"a": "b"}'
 ----
-memo (optimized, ~6KB, required=[presentation: k:1])
+memo (optimized, ~7KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
@@ -1393,19 +1393,24 @@ project
       │    ├── columns: k:1!null geog:4
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
-      │    └── scan g@geog_idx
+      │    └── inverted-filter
       │         ├── columns: k:1!null
-      │         ├── inverted constraint: /4/1
+      │         ├── inverted expression: /4
       │         │    ├── tight: false
-      │         │    ├── to read
-      │         │    │    ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
-      │         │    │    ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
-      │         │    │    └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
       │         │    └── union spans
       │         │         ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
       │         │         ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
       │         │         └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
-      │         └── key: (1)
+      │         ├── key: (1)
+      │         └── scan g@geog_idx
+      │              ├── columns: k:1!null geog:4
+      │              ├── inverted constraint: /4/1
+      │              │    └── spans
+      │              │         ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
+      │              │         ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
+      │              │         └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
+      │              ├── key: (1)
+      │              └── fd: (1)-->(4)
       └── filters
            └── st_intersects('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4) [outer=(4), immutable]
 
@@ -1425,19 +1430,24 @@ project
       │    ├── columns: k:1!null geom:3
       │    ├── key: (1)
       │    ├── fd: (1)-->(3)
-      │    └── scan g@geom_idx
+      │    └── inverted-filter
       │         ├── columns: k:1!null
-      │         ├── inverted constraint: /3/1
+      │         ├── inverted expression: /3
       │         │    ├── tight: false
-      │         │    ├── to read
-      │         │    │    ├── ["\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
-      │         │    │    ├── ["\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
-      │         │    │    └── ["\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
       │         │    └── union spans
       │         │         ├── ["\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
       │         │         ├── ["\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
       │         │         └── ["\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
-      │         └── key: (1)
+      │         ├── key: (1)
+      │         └── scan g@geom_idx
+      │              ├── columns: k:1!null geom:3
+      │              ├── inverted constraint: /3/1
+      │              │    └── spans
+      │              │         ├── ["\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+      │              │         ├── ["\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+      │              │         └── ["\xfd\x11\x00\x00\x00\x00\x00\x00\x00", "\xfd\x11\x00\x00\x00\x00\x00\x00\x00"]
+      │              ├── key: (1)
+      │              └── fd: (1)-->(3)
       └── filters
            └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:3) [outer=(3), immutable]
 
@@ -1460,35 +1470,32 @@ project
       │    ├── columns: k:1!null geog:4
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
-      │    └── scan g@geog_idx
+      │    └── inverted-filter
       │         ├── columns: k:1!null
-      │         ├── inverted constraint: /4/1
+      │         ├── inverted expression: /4
       │         │    ├── tight: false
-      │         │    ├── to read
-      │         │    │    ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
-      │         │    │    ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
-      │         │    │    └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
       │         │    ├── union spans: ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
       │         │    └── INTERSECTION
       │         │         ├── span expression
       │         │         │    ├── tight: false
-      │         │         │    ├── to read
-      │         │         │    │    ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
-      │         │         │    │    ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
-      │         │         │    │    └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
       │         │         │    └── union spans
       │         │         │         ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
       │         │         │         └── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
       │         │         └── span expression
       │         │              ├── tight: false
-      │         │              ├── to read
-      │         │              │    ├── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
-      │         │              │    ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
-      │         │              │    └── ["\xfdO\x00\x00\x00\x00\x00\x00\x00", "\xfdO\x00\x00\x00\x00\x00\x00\x00"]
       │         │              └── union spans
       │         │                   ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
       │         │                   └── ["\xfdO\x00\x00\x00\x00\x00\x00\x00", "\xfdO\x00\x00\x00\x00\x00\x00\x00"]
-      │         └── key: (1)
+      │         ├── key: (1)
+      │         └── scan g@geog_idx
+      │              ├── columns: k:1!null geog:4
+      │              ├── inverted constraint: /4/1
+      │              │    └── spans
+      │              │         ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
+      │              │         ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
+      │              │         └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
+      │              ├── key: (1)
+      │              └── fd: (1)-->(4)
       └── filters
            ├── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4) [outer=(4), immutable]
            └── st_coveredby('0101000020E61000009279E40F061E44C0BEE36FD63B9D5140', geog:4) [outer=(4), immutable]
@@ -1511,19 +1518,24 @@ project
       │    ├── columns: k:1!null geog:4
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
-      │    └── scan g@geog_idx
+      │    └── inverted-filter
       │         ├── columns: k:1!null
-      │         ├── inverted constraint: /4/1
+      │         ├── inverted expression: /4
       │         │    ├── tight: false
-      │         │    ├── to read
-      │         │    │    ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
-      │         │    │    ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
-      │         │    │    └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
       │         │    └── union spans
       │         │         ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
       │         │         ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
       │         │         └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
-      │         └── key: (1)
+      │         ├── key: (1)
+      │         └── scan g@geog_idx
+      │              ├── columns: k:1!null geog:4
+      │              ├── inverted constraint: /4/1
+      │              │    └── spans
+      │              │         ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
+      │              │         ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
+      │              │         └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
+      │              ├── key: (1)
+      │              └── fd: (1)-->(4)
       └── filters
            └── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4) OR st_coveredby('0101000020E61000009279E40F061E44C0BEE36FD63B9D5140', geog:4) [outer=(4), immutable]
 
@@ -1546,14 +1558,10 @@ project
       │    ├── columns: k:1!null geog:4
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
-      │    └── scan g@geog_idx
+      │    └── inverted-filter
       │         ├── columns: k:1!null
-      │         ├── inverted constraint: /4/1
+      │         ├── inverted expression: /4
       │         │    ├── tight: false
-      │         │    ├── to read
-      │         │    │    ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
-      │         │    │    ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
-      │         │    │    └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
       │         │    ├── union spans
       │         │    │    ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
       │         │    │    ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
@@ -1561,40 +1569,36 @@ project
       │         │    └── INTERSECTION
       │         │         ├── span expression
       │         │         │    ├── tight: false
-      │         │         │    ├── to read
-      │         │         │    │    ├── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
-      │         │         │    │    ├── ["\xfdD\x00\x00\x00\x00\x00\x00\x00", "\xfdD\x00\x00\x00\x00\x00\x00\x00"]
-      │         │         │    │    ├── ["\xfdG\x00\x00\x00\x00\x00\x00\x00", "\xfdG\x00\x00\x00\x00\x00\x00\x00"]
-      │         │         │    │    ├── ["\x80\x90\x00\x00\x00\x00\x00\x00\x00", "\x80\x90\x00\x00\x00\x00\x00\x00\x00"]
-      │         │         │    │    ├── ["\x80\x84\x00\x00\x00\x00\x00\x00\x00", "\x80\x84\x00\x00\x00\x00\x00\x00\x00"]
-      │         │         │    │    └── ["\x80\x81\x00\x00\x00\x00\x00\x00\x00", "\x80\x81\x00\x00\x00\x00\x00\x00\x00"]
       │         │         │    ├── union spans: empty
       │         │         │    └── INTERSECTION
       │         │         │         ├── span expression
       │         │         │         │    ├── tight: false
-      │         │         │         │    ├── to read: empty
       │         │         │         │    └── union spans
       │         │         │         │         ├── ["\x80\x90\x00\x00\x00\x00\x00\x00\x00", "\x80\x90\x00\x00\x00\x00\x00\x00\x00"]
       │         │         │         │         ├── ["\x80\x84\x00\x00\x00\x00\x00\x00\x00", "\x80\x84\x00\x00\x00\x00\x00\x00\x00"]
       │         │         │         │         └── ["\x80\x81\x00\x00\x00\x00\x00\x00\x00", "\x80\x81\x00\x00\x00\x00\x00\x00\x00"]
       │         │         │         └── span expression
       │         │         │              ├── tight: false
-      │         │         │              ├── to read: empty
       │         │         │              └── union spans
       │         │         │                   ├── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
       │         │         │                   ├── ["\xfdD\x00\x00\x00\x00\x00\x00\x00", "\xfdD\x00\x00\x00\x00\x00\x00\x00"]
       │         │         │                   └── ["\xfdG\x00\x00\x00\x00\x00\x00\x00", "\xfdG\x00\x00\x00\x00\x00\x00\x00"]
       │         │         └── span expression
       │         │              ├── tight: false
-      │         │              ├── to read
-      │         │              │    ├── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
-      │         │              │    ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
-      │         │              │    └── ["\xfdO\x00\x00\x00\x00\x00\x00\x00", "\xfdO\x00\x00\x00\x00\x00\x00\x00"]
       │         │              └── union spans
       │         │                   ├── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
       │         │                   ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
       │         │                   └── ["\xfdO\x00\x00\x00\x00\x00\x00\x00", "\xfdO\x00\x00\x00\x00\x00\x00\x00"]
-      │         └── key: (1)
+      │         ├── key: (1)
+      │         └── scan g@geog_idx
+      │              ├── columns: k:1!null geog:4
+      │              ├── inverted constraint: /4/1
+      │              │    └── spans
+      │              │         ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
+      │              │         ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
+      │              │         └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
+      │              ├── key: (1)
+      │              └── fd: (1)-->(4)
       └── filters
            └── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4) OR (st_coveredby('0102000020E61000000200000075029A081B9A5DC0F085C954C1F840406DC5FEB27B720440454772F90F814840', geog:4) AND st_coveredby('0101000020E610000058569A94821E46C07BC7DFAC773A4E40', geog:4)) [outer=(4), immutable]
 
@@ -1617,13 +1621,18 @@ project
       │    ├── columns: k:1!null geom:3 geog:4
       │    ├── key: (1)
       │    ├── fd: (1)-->(3,4)
-      │    └── scan g@geom_idx
+      │    └── inverted-filter
       │         ├── columns: k:1!null
-      │         ├── inverted constraint: /3/1
+      │         ├── inverted expression: /3
       │         │    ├── tight: false
-      │         │    ├── to read: ["\x89", "\xfd ")
       │         │    └── union spans: ["\x89", "\xfd ")
-      │         └── key: (1)
+      │         ├── key: (1)
+      │         └── scan g@geom_idx
+      │              ├── columns: k:1!null geom:3
+      │              ├── inverted constraint: /3/1
+      │              │    └── spans: ["\x89", "\xfd ")
+      │              ├── key: (1)
+      │              └── fd: (1)-->(3)
       └── filters
            ├── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4) [outer=(4), immutable]
            └── st_overlaps('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', geom:3) [outer=(3), immutable]
@@ -1669,19 +1678,24 @@ project
       │    ├── columns: k:1!null geom:3 geog:4
       │    ├── key: (1)
       │    ├── fd: (1)-->(3,4)
-      │    └── scan g@geog_idx
+      │    └── inverted-filter
       │         ├── columns: k:1!null
-      │         ├── inverted constraint: /4/1
+      │         ├── inverted expression: /4
       │         │    ├── tight: false
-      │         │    ├── to read
-      │         │    │    ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
-      │         │    │    ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
-      │         │    │    └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
       │         │    └── union spans
       │         │         ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
       │         │         ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
       │         │         └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
-      │         └── key: (1)
+      │         ├── key: (1)
+      │         └── scan g@geog_idx
+      │              ├── columns: k:1!null geog:4
+      │              ├── inverted constraint: /4/1
+      │              │    └── spans
+      │              │         ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
+      │              │         ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
+      │              │         └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
+      │              ├── key: (1)
+      │              └── fd: (1)-->(4)
       └── filters
            └── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4) OR (st_intersects('0101000020E61000009279E40F061E44C0BEE36FD63B9D5140', geog:4) AND st_crosses('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', geom:3)) [outer=(3,4), immutable]
 
@@ -1704,24 +1718,30 @@ project
       │    ├── columns: k:1!null v:2 geog:4
       │    ├── key: (1)
       │    ├── fd: (1)-->(2,4)
-      │    └── select
+      │    └── inverted-filter
       │         ├── columns: k:1!null
+      │         ├── inverted expression: /4
+      │         │    ├── tight: false
+      │         │    └── union spans
+      │         │         ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
+      │         │         ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
+      │         │         └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
       │         ├── key: (1)
-      │         ├── scan g@geog_idx
-      │         │    ├── columns: k:1!null
-      │         │    ├── inverted constraint: /4/1
-      │         │    │    ├── tight: false
-      │         │    │    ├── to read
-      │         │    │    │    ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
-      │         │    │    │    ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
-      │         │    │    │    └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
-      │         │    │    └── union spans
-      │         │    │         ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
-      │         │    │         ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
-      │         │    │         └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
-      │         │    └── key: (1)
-      │         └── filters
-      │              └── k:1 > 100 [outer=(1), constraints=(/1: [/101 - ]; tight)]
+      │         └── select
+      │              ├── columns: k:1!null geog:4
+      │              ├── key: (1)
+      │              ├── fd: (1)-->(4)
+      │              ├── scan g@geog_idx
+      │              │    ├── columns: k:1!null geog:4
+      │              │    ├── inverted constraint: /4/1
+      │              │    │    └── spans
+      │              │    │         ├── ["\xfdN\x00\x00\x00\x00\x00\x00\x01", "\xfdP")
+      │              │    │         ├── ["\xfdL\x00\x00\x00\x00\x00\x00\x00", "\xfdL\x00\x00\x00\x00\x00\x00\x00"]
+      │              │    │         └── ["\xfdP\x00\x00\x00\x00\x00\x00\x00", "\xfdP\x00\x00\x00\x00\x00\x00\x00"]
+      │              │    ├── key: (1)
+      │              │    └── fd: (1)-->(4)
+      │              └── filters
+      │                   └── k:1 > 100 [outer=(1), constraints=(/1: [/101 - ]; tight)]
       └── filters
            ├── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4) [outer=(4), immutable]
            └── v:2 = 3 [outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/invertedexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -75,6 +76,7 @@ func (ef *execFactory) ConstructScan(
 	index cat.Index,
 	needed exec.TableColumnOrdinalSet,
 	indexConstraint *constraint.Constraint,
+	invertedConstraint invertedexpr.InvertedSpans,
 	hardLimit int64,
 	softLimit int64,
 	reverse bool,
@@ -125,6 +127,11 @@ func (ef *execFactory) ConstructScan(
 	if err != nil {
 		return nil, err
 	}
+	// TODO(rytaft, sumeerbhola): Add support for inverted constraints.
+	if invertedConstraint != nil {
+		return nil, errors.Errorf("Geospatial constrained scans are not yet supported")
+	}
+
 	scan.isFull = len(scan.spans) == 1 && scan.spans[0].EqualValue(
 		scan.desc.IndexSpan(ef.planner.ExecCfg().Codec, scan.index.ID),
 	)
@@ -253,6 +260,14 @@ func (ef *execFactory) ConstructFilter(
 		return spool, nil
 	}
 	return f, nil
+}
+
+// ConstructInvertedFilter is part of the exec.Factory interface.
+func (ef *execFactory) ConstructInvertedFilter(
+	n exec.Node, invFilter *invertedexpr.SpanExpression, invColumn exec.NodeColumnOrdinal,
+) (exec.Node, error) {
+	// TODO(rytaft, sumeerbhola): Fill this in.
+	return nil, errors.Errorf("Inverted filters are not yet supported")
 }
 
 // ConstructSimpleProject is part of the exec.Factory interface.


### PR DESCRIPTION
Prior to this commit, the optimizer `Scan` node was serving a dual purpose
for some constrained inverted index scans: If the scan was constrained with
a `SpanExpression`, the single optimizer `Scan` operator became two DistSQL
processors: `tableReader` and `invertedFilterer`.

This commit adds a new operator in the optimizer called `InvertedFilter`.
It maps 1:1 with the DistSQL processor `invertedFilterer`, and makes the
conversion from the optimizer plan to DistSQL plan nodes more straightforward.
It will also enable the optimizer to support rules for eliminating the
`InvertedFilter` when possible, and pushing other operators (e.g., `Select`)
between the `Scan` and `InvertedFilter`. It will also make plan costing and
cardinality estimation more accurate.

Release note: None