### PR TITLE
settings,sql: improve slow query log cluster settings

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -202,6 +202,7 @@ type WritableSetting interface {
 	Encoded(sv *Values) string
 	EncodedDefault() string
 	SetOnChange(sv *Values, fn func())
+	ErrorHint() (bool, string)
 }
 
 type extendedSetting interface {
@@ -282,6 +283,10 @@ func (i common) Visibility() Visibility {
 
 func (i common) isReportable() bool {
 	return !i.nonReportable
+}
+
+func (i *common) ErrorHint() (bool, string) {
+	return false, ""
 }
 
 // SetReportable indicates whether a setting's value can show up in SHOW ALL

--- a/pkg/settings/updater.go
+++ b/pkg/settings/updater.go
@@ -115,6 +115,12 @@ func (u updater) Set(key, rawValue string, vt string) error {
 			return err
 		}
 		return setting.set(u.sv, d)
+	case *DurationSettingWithExplicitUnit:
+		d, err := time.ParseDuration(rawValue)
+		if err != nil {
+			return err
+		}
+		return setting.set(u.sv, d)
 	case *StateMachineSetting:
 		return setting.set(u.sv, []byte(rawValue))
 	}

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -88,7 +88,7 @@ var logStatementsExecuteEnabled = settings.RegisterPublicBoolSetting(
 	false,
 )
 
-var slowQueryLogThreshold = settings.RegisterPublicDurationSetting(
+var slowQueryLogThreshold = settings.RegisterPublicNonNegativeDurationSettingWithExplicitUnit(
 	"sql.log.slow_query.latency_threshold",
 	"when set to non-zero, log statements whose service latency exceeds "+
 		"the threshold to a secondary logger on each node",

--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -1,0 +1,17 @@
+statement ok
+SET CLUSTER SETTING sql.log.slow_query.latency_threshold = '1ms'
+
+statement error pq: cannot set sql.log.slow_query.latency_threshold to a negative duration
+SET CLUSTER SETTING sql.log.slow_query.latency_threshold = '-1ms'
+
+statement error pq: invalid cluster setting argument type
+SET CLUSTER SETTING sql.log.slow_query.latency_threshold = '1'
+
+statement error pq: invalid cluster setting argument type
+SET CLUSTER SETTING sql.log.slow_query.latency_threshold = '-1'
+
+statement error pq: could not parse "true" as type interval: interval
+SET CLUSTER SETTING sql.log.slow_query.latency_threshold = 'true'
+
+statement error pq: invalid cluster setting argument type
+SET CLUSTER SETTING sql.log.slow_query.latency_threshold = true

--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -121,6 +121,8 @@ func (p *planner) ShowClusterSetting(
 		dType = types.Float
 	case *settings.DurationSetting:
 		dType = types.Interval
+	case *settings.DurationSettingWithExplicitUnit:
+		dType = types.Interval
 	default:
 		return nil, errors.Errorf("unknown setting type for %s: %s", name, val.Typ())
 	}
@@ -148,6 +150,8 @@ func (p *planner) ShowClusterSetting(
 			case *settings.FloatSetting:
 				d = tree.NewDFloat(tree.DFloat(s.Get(&st.SV)))
 			case *settings.DurationSetting:
+				d = &tree.DInterval{Duration: duration.MakeDuration(s.Get(&st.SV).Nanoseconds(), 0, 0)}
+			case *settings.DurationSettingWithExplicitUnit:
 				d = &tree.DInterval{Duration: duration.MakeDuration(s.Get(&st.SV).Nanoseconds(), 0, 0)}
 			case *settings.EnumSetting:
 				d = tree.NewDString(s.String(&st.SV))


### PR DESCRIPTION
Previously, the slow query log setting was of type
`PublicDurationSettings` which allowed a user to misconfigure it
(eg. by passing negative values). After this change, this is no longer
possible. Additionally, users must provide explicit units when
configuring `sql.log.slow_query.latency_threshold`.

This change involves the addition of a new duration setting type which
requires explicit units when being set. (eg. 1s works, 1 does not).

Fixes #50207

Release note (sql change): The `sql.log.slow_query.latency_threshold`
cluster setting requires an explicit unit when being set. (eg. 500ms for
 500 milliseconds, 5us for 5 nanoseconds, 5s for 5 seconds etc). An
error with a hint pops up if the user fails to provide units.