### PR TITLE
roachprod: support persistent disk creation on Google

### DIFF
--- a/pkg/cmd/roachprod/vm/gce/gcloud.go
+++ b/pkg/cmd/roachprod/vm/gce/gcloud.go
@@ -178,6 +178,7 @@ type providerOpts struct {
 	projects       []string
 	ServiceAccount string
 	MachineType    string
+	MinCPUPlatform string
 	Zones          []string
 	Image          string
 	SSDCount       int
@@ -270,6 +271,8 @@ func (o *providerOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 
 	flags.StringVar(&o.MachineType, ProviderName+"-machine-type", "n1-standard-4",
 		"Machine type (see https://cloud.google.com/compute/docs/machine-types)")
+	flags.StringVar(&o.MinCPUPlatform, ProviderName+"-min-cpu-platform", "",
+		"Minimum CPU platform (see https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform)")
 	flags.StringVar(&o.Image, ProviderName+"-image", "ubuntu-1604-xenial-v20200129",
 		"Image to use to create the vm, ubuntu-1904-disco-v20191008 is a more modern image")
 
@@ -430,6 +433,9 @@ func (p *Provider) Create(names []string, opts vm.CreateOpts) error {
 	}()
 
 	args = append(args, "--machine-type", p.opts.MachineType)
+	if p.opts.MinCPUPlatform != "" {
+		args = append(args, "--min-cpu-platform", p.opts.MinCPUPlatform)
+	}
 	args = append(args, "--labels", fmt.Sprintf("lifetime=%s", opts.Lifetime))
 
 	args = append(args, "--metadata-from-file", fmt.Sprintf("startup-script=%s", filename))

--- a/pkg/cmd/roachprod/vm/gce/utils.go
+++ b/pkg/cmd/roachprod/vm/gce/utils.go
@@ -37,8 +37,9 @@ var Subdomain = func() string {
 	return "roachprod.crdb.io"
 }()
 
-// Startup script used to find/format/mount all local SSDs in GCE.
-// Each disk is mounted to /mnt/data<disknum> and chmoded to all users.
+// Startup script used to find/format/mount all local SSDs and (non-boot)
+// persistent disks in GCE. Each disk is mounted to /mnt/data<disknum> and
+// chmoded to all users.
 //
 // This is a template because the instantiator needs to optionally configure the
 // mounting options. The script cannot take arguments since it is to be invoked
@@ -49,8 +50,9 @@ const gceLocalSSDStartupScriptTemplate = `#!/usr/bin/env bash
 mount_opts="discard,defaults"
 {{if .ExtraMountOpts}}mount_opts="${mount_opts},{{.ExtraMountOpts}}"{{end}}
 
+# ignore the boot disk: /dev/disk/by-id/google-persistent-disk-0.
 disknum=0
-for d in $(ls /dev/disk/by-id/google-local-*); do
+for d in $(ls /dev/disk/by-id/google-local-* /dev/disk/by-id/google-persistent-disk-[1-9]); do
   let "disknum++"
   grep -e "${d}" /etc/fstab > /dev/null
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
This PR adds two new flags to `roachprod create --cloud=gce`:
- `--gce-pd-volume-type`
- `--gce-pd-volume-size`

These mirror the corresponding flags for AWS and EBS volumes: `--aws-ebs-volume-type` and `--aws-ebs-volume-size`.

Also, while here, support min CPU platofrm specification on Google. Pinning the min CPU platform (#45476) didn't work in practice because various platforms have various restrictions in terms of zone availability and general quota. This commit abandons this approach and simply adds a new `--gce-min-cpu-platform` that passes the optional value down through the `--min-cpu-platform` flag when creating instances.
