### PR TITLE
sql: disable arrays in forward indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -1333,10 +1333,17 @@ SELECT x, y FROM t ORDER BY (x, y)
 
 subtest array_indexes
 
-# Create indexes on arrays.
+# TODO(mjibson): Fix #50659 and revert all removed tests from #50622.
+
+# Indexes not yet supported for arrays, see #50659.
 statement ok
-DROP TABLE IF EXISTS t;
+DROP TABLE IF EXISTS t
+
+statement error column x is of type int\[\] and thus is not indexable
 CREATE TABLE t (x INT[] PRIMARY KEY)
+
+statement ok
+CREATE TABLE t (x INT[])
 
 statement ok
 INSERT INTO t VALUES
@@ -1350,8 +1357,9 @@ INSERT INTO t VALUES
   (ARRAY[NULL, NULL, NULL])
 
 # Test that the unique index rejects bad inserts.
-statement error pq: duplicate key value \(x\)=\(ARRAY\[1,NULL,10\]\) violates unique constraint "primary"
-INSERT INTO t VALUES (ARRAY[1, NULL, 10])
+# Disabled until #50659 is resolved.
+#statement error pq: duplicate key value \(x\)=\(ARRAY\[1,NULL,10\]\) violates unique constraint "primary"
+#INSERT INTO t VALUES (ARRAY[1, NULL, 10])
 
 query T
 SELECT x FROM t ORDER BY x
@@ -1413,18 +1421,20 @@ SELECT x FROM t WHERE x > ARRAY[NULL, NULL]:::INT[] ORDER BY x
 {5}
 
 # Test some operations on a descending index.
-statement ok
+statement error column x is of type int\[\] and thus is not indexable
 CREATE INDEX i ON t(x DESC)
 
+# Add "t@i" index annotation once #50659 is fixed.
 query T
-SELECT x FROM t@i WHERE x <= ARRAY[1] ORDER BY x DESC
+SELECT x FROM t WHERE x <= ARRAY[1] ORDER BY x DESC
 ----
 {1}
 {NULL,NULL,NULL}
 {NULL}
 
+# Add "t@i" index annotation once #50659 is fixed.
 query T
-SELECT x FROM t@i WHERE x > ARRAY[1] ORDER BY x
+SELECT x FROM t WHERE x > ARRAY[1] ORDER BY x
 ----
 {1,NULL,10}
 {1,4,5}
@@ -1470,13 +1480,15 @@ SELECT x FROM t ORDER BY x DESC
 {NULL,NULL,NULL}
 {NULL}
 
+# Enable index creation once #50659 is fixed.
 statement ok
-CREATE INDEX i ON t (x);
+--CREATE INDEX i ON t (x);
 INSERT INTO t VALUES (NULL), (NULL)
 
 # Test that NULL's are differentiated from {NULL}.
+# Add "t@i" index annotation once #50659 is fixed.
 query T
-SELECT x FROM t@i WHERE x IS NOT NULL ORDER BY x
+SELECT x FROM t WHERE x IS NOT NULL ORDER BY x
 ----
 {NULL}
 {NULL,NULL,NULL}
@@ -1492,8 +1504,9 @@ statement error pq: unimplemented: column x is of type geography\[\] and thus is
 CREATE TABLE tbad (x GEOGRAPHY[] PRIMARY KEY)
 
 # Test arrays of composite types.
+# Add x to PRIMARY KEY once #50659 is fixed.
 statement ok
-CREATE TABLE tarray(x DECIMAL[] PRIMARY KEY);
+CREATE TABLE tarray(x DECIMAL[]);
 INSERT INTO tarray VALUES (ARRAY[1.00]), (ARRAY[1.501])
 
 # Ensure these are round tripped correctly.
@@ -1504,9 +1517,10 @@ SELECT x FROM tarray ORDER BY x
 {1.501}
 
 # Test indexes on multiple columns with arrays.
+# Add multicolumn INDEX i (x, y, z) once #50659 is fixed.
 statement ok
 DROP TABLE t;
-CREATE TABLE t (x INT, y INT[], z INT, INDEX i (x, y, z));
+CREATE TABLE t (x INT, y INT[], z INT);
 INSERT INTO t VALUES
   (1, ARRAY[1, 2, 3], 3),
   (NULL, ARRAY[1, NULL, 3], NULL),
@@ -1527,20 +1541,24 @@ SELECT x, y, z FROM t WHERE x = 2 AND y < ARRAY[10] ORDER BY y
 2  {4,5}             7
 
 # Test that interleaving an array index doesn't lead to problems.
+# Add parent PRIMARY KEY (x, y DESC) once #50659 is fixed.
+# Add child PRIMARY KEY (x, y DESC, z) once #50659 is fixed.
+# Add INTERLEAVE IN PARENT parent (x, y) once #50659 is fixed.
+# Uncomment INSERT values once #50659 is fixed.
 statement ok
 DROP TABLE IF EXISTS parent, child CASCADE;
-CREATE TABLE parent (x INT, y INT[], PRIMARY KEY (x, y DESC));
-CREATE TABLE child (x INT, y INT[], z INT[], PRIMARY KEY (x, y DESC, z)) INTERLEAVE IN PARENT parent (x, y);
+CREATE TABLE parent (x INT, y INT[], PRIMARY KEY (x));
+CREATE TABLE child (x INT, y INT[], z INT[], PRIMARY KEY (x)) INTERLEAVE IN PARENT parent (x);
 INSERT INTO parent VALUES
   (1, ARRAY[1, 2, 3]),
-  (1, ARRAY[1, NULL]),
+--  (1, ARRAY[1, NULL]),
   (2, ARRAY[NULL]),
   (3, ARRAY[NULL, 1, NULL]);
 INSERT INTO child VALUES
   (1, ARRAY[1, 2, 3], ARRAY[4]),
-  (1, ARRAY[1, 2, 3, 4], ARRAY[5]),
-  (1, ARRAY[1, NULL], ARRAY[5]),
-  (1, ARRAY[1, NULL, NULL], ARRAY[10]),
+--  (1, ARRAY[1, 2, 3, 4], ARRAY[5]),
+--  (1, ARRAY[1, NULL], ARRAY[5]),
+--  (1, ARRAY[1, NULL, NULL], ARRAY[10]),
   (2, ARRAY[NULL], ARRAY[1]),
   (3, ARRAY[NULL, 1, NULL], ARRAY[3]);
 
@@ -1549,24 +1567,21 @@ query IT
 SELECT x, y FROM parent ORDER BY x, y DESC
 ----
 1  {1,2,3}
-1  {1,NULL}
 2  {NULL}
 3  {NULL,1,NULL}
 
 query ITT
 SELECT x, y, z FROM child ORDER BY x, y DESC, z
 ----
-1  {1,2,3,4}      {5}
 1  {1,2,3}        {4}
-1  {1,NULL,NULL}  {10}
-1  {1,NULL}       {5}
 2  {NULL}         {1}
 3  {NULL,1,NULL}  {3}
 
 # Test arrays of strings.
+# Add parent PRIMARY KEY (x) once #50659 is fixed.
 statement ok
 DROP TABLE t;
-CREATE TABLE t (x STRING[] PRIMARY KEY);
+CREATE TABLE t (x STRING[]);
 INSERT INTO t VALUES
   (ARRAY['']),
   (ARRAY['hello', 'hi\nthere']),
@@ -1588,9 +1603,10 @@ SELECT x FROM t WHERE x > ARRAY['hell'] AND x < ARRAY['i']
 
 # Test arrays of bytes, and insert some bytes that are used by the
 # array encoding itself.
+# Add parent PRIMARY KEY (x) once #50659 is fixed.
 statement ok
 DROP TABLE t;
-CREATE TABLE t (x BYTES[] PRIMARY KEY);
+CREATE TABLE t (x BYTES[]);
 INSERT INTO t VALUES
   (ARRAY[b'\xFF', b'\x00']),
   (ARRAY[NULL, b'\x01', b'\x01', NULL]),
@@ -1604,9 +1620,10 @@ SELECT x FROM t ORDER BY x
 {"\\xff","\\x00"}
 
 # Repeat the above test with a descending encoding.
+# Add parent PRIMARY KEY (x DESC) once #50659 is fixed.
 statement ok
 DROP TABLE t;
-CREATE TABLE t (x BYTES[], PRIMARY KEY (x DESC));
+CREATE TABLE t (x BYTES[]);
 INSERT INTO t VALUES
   (ARRAY[b'\xFF', b'\x00']),
   (ARRAY[NULL, b'\x01', b'\x01', NULL]),
@@ -1620,9 +1637,10 @@ SELECT x FROM t ORDER BY x
 {"\\xff","\\x00"}
 
 # Test some indexes with multiple array columns.
+# Add parent PRIMARY KEY (x, y) once #50659 is fixed.
 statement ok
 DROP TABLE t;
-CREATE TABLE t (x INT[], y INT[], PRIMARY KEY (x, y));
+CREATE TABLE t (x INT[], y INT[]);
 INSERT INTO t VALUES
   (ARRAY[1, 2], ARRAY[3, 4]),
   (ARRAY[NULL, NULL], ARRAY[NULL, NULL]),
@@ -1646,29 +1664,31 @@ SELECT x, y FROM t WHERE x > ARRAY[NULL]:::INT[] ORDER BY y
 {1,2}        {3,4}
 
 # Test that we can create foreign key references on arrays.
-statement ok
-DROP TABLE IF EXISTS t1, t2 CASCADE;
-CREATE TABLE t1 (x INT[] PRIMARY KEY);
-CREATE TABLE t2 (x INT[] PRIMARY KEY);
-ALTER TABLE t2 ADD FOREIGN KEY (x) REFERENCES t1 (x)
+# Enable once #50659 is fixed.
+#statement ok
+#DROP TABLE IF EXISTS t1, t2 CASCADE;
+#CREATE TABLE t1 (x INT[] PRIMARY KEY);
+#CREATE TABLE t2 (x INT[] PRIMARY KEY);
+#ALTER TABLE t2 ADD FOREIGN KEY (x) REFERENCES t1 (x)
 
-statement ok
-INSERT INTO t1 VALUES (ARRAY[1, 2, NULL, 3])
+#statement ok
+#INSERT INTO t1 VALUES (ARRAY[1, 2, NULL, 3])
 
-statement error pq: insert on table "t2" violates foreign key constraint "fk_x_ref_t1"
-INSERT INTO t2 VALUES (ARRAY[1, 2])
+#statement error pq: insert on table "t2" violates foreign key constraint "fk_x_ref_t1"
+#INSERT INTO t2 VALUES (ARRAY[1, 2])
 
-statement ok
-INSERT INTO t2 VALUES (ARRAY[1, 2, NULL, 3])
+#statement ok
+#INSERT INTO t2 VALUES (ARRAY[1, 2, NULL, 3])
 
-statement error pq: delete on table "t1" violates foreign key constraint "fk_x_ref_t1" on table "t2"
-DELETE FROM t1 WHERE x > ARRAY[1]
+#statement error pq: delete on table "t1" violates foreign key constraint "fk_x_ref_t1" on table "t2"
+#DELETE FROM t1 WHERE x > ARRAY[1]
 
 # Test different joins on indexed arrays.
+# Add t1 and t2 PRIMARY KEY x once #50659 is fixed.
 statement ok
 DROP TABLE IF EXISTS t1, t2 CASCADE;
-CREATE TABLE t1 (x INT[] PRIMARY KEY);
-CREATE TABLE t2 (x INT[] PRIMARY KEY);
+CREATE TABLE t1 (x INT[]);
+CREATE TABLE t2 (x INT[]);
 INSERT INTO t1 VALUES
   (ARRAY[1, 2]),
   (ARRAY[NULL]),
@@ -1690,16 +1710,18 @@ SELECT t1.x FROM t1 INNER MERGE JOIN t2 ON t1.x = t2.x
 {NULL}
 {1,2}
 
-query T rowsort
-SELECT t1.x FROM t1 INNER LOOKUP JOIN t2 ON t1.x = t2.x
-----
-{NULL}
-{1,2}
+# Enable once #50659 is fixed.
+#query T rowsort
+#SELECT t1.x FROM t1 INNER LOOKUP JOIN t2 ON t1.x =# t2.x
+#----
+#{NULL}
+#{1,2}
 
 # Test that we can group by arrays.
+# Add INDEX (x) once #50659 is fixed.
 statement ok
 DROP TABLE t;
-CREATE TABLE t (x INT[], INDEX (x));
+CREATE TABLE t (x INT[]);
 INSERT INTO t VALUES
   (ARRAY[1, 2]),
   (ARRAY[1, 2]),

--- a/pkg/sql/mutations/mutations.go
+++ b/pkg/sql/mutations/mutations.go
@@ -420,7 +420,7 @@ func foreignKeyMutator(
 				for refI, refCol := range availCols {
 					fkColType := tree.MustBeStaticallyKnownType(fkCol.Type)
 					refColType := tree.MustBeStaticallyKnownType(refCol.Type)
-					if fkColType.Equivalent(refColType) {
+					if fkColType.Equivalent(refColType) && sqlbase.ColumnTypeIsIndexable(refColType) {
 						usingCols = append(usingCols, refCol)
 						availCols = append(availCols[:refI], availCols[refI+1:]...)
 						found = true

--- a/pkg/sql/opt/exec/execbuilder/testdata/array
+++ b/pkg/sql/opt/exec/execbuilder/testdata/array
@@ -1,7 +1,8 @@
 # LogicTest: local
 
+# Add x to PRIMARY KEY once #50659 is fixed.
 statement ok
-CREATE TABLE t (x INT[] PRIMARY KEY)
+CREATE TABLE t (x INT[])
 
 # Test some scans of constrained spans on arrays.
 
@@ -12,7 +13,8 @@ EXPLAIN SELECT x FROM t WHERE x = ARRAY[1,4,6]
 ·     vectorized    true
 scan  ·             ·
 ·     table         t@primary
-·     spans         /ARRAY[1,4,6]-/ARRAY[1,4,6]/#
+·     spans         FULL SCAN
+·     filter        x = ARRAY[1,4,6]
 
 query TTT
 EXPLAIN SELECT x FROM t WHERE x < ARRAY[1, 4, 3]
@@ -21,7 +23,8 @@ EXPLAIN SELECT x FROM t WHERE x < ARRAY[1, 4, 3]
 ·     vectorized    true
 scan  ·             ·
 ·     table         t@primary
-·     spans         -/ARRAY[1,4,3]
+·     spans         FULL SCAN
+·     filter        x < ARRAY[1,4,3]
 
 query TTT
 EXPLAIN SELECT x FROM t WHERE x > ARRAY [1, NULL]
@@ -30,45 +33,59 @@ EXPLAIN SELECT x FROM t WHERE x > ARRAY [1, NULL]
 ·     vectorized    true
 scan  ·             ·
 ·     table         t@primary
-·     spans         /ARRAY[1,NULL,NULL]-
+·     spans         FULL SCAN
+·     filter        x > ARRAY[1,NULL]
 
 query TTT
 EXPLAIN SELECT x FROM t WHERE x > ARRAY[1, 3] AND x < ARRAY[1, 4, 10] ORDER BY x
 ----
-·     distribution  local
-·     vectorized    true
-scan  ·             ·
-·     table         t@primary
-·     spans         /ARRAY[1,3,NULL]-/ARRAY[1,4,10]
+·          distribution  local
+·          vectorized    true
+sort       ·             ·
+ │         order         +x
+ └── scan  ·             ·
+·          table         t@primary
+·          spans         FULL SCAN
+·          filter        (x > ARRAY[1,3]) AND (x < ARRAY[1,4,10])
 
 query TTT
 EXPLAIN SELECT x FROM t WHERE x > ARRAY[1, 3] AND x < ARRAY[1, 4, 10] ORDER BY x DESC
 ----
-·        distribution  local
-·        vectorized    true
-revscan  ·             ·
-·        table         t@primary
-·        spans         /ARRAY[1,3,NULL]-/ARRAY[1,4,10]
+·          distribution  local
+·          vectorized    true
+sort       ·             ·
+ │         order         -x
+ └── scan  ·             ·
+·          table         t@primary
+·          spans         FULL SCAN
+·          filter        (x > ARRAY[1,3]) AND (x < ARRAY[1,4,10])
 
 statement ok
 DROP TABLE t
 
+# Add multicolumn INDEX i (x, y, z) once #50659 is fixed.
 statement ok
-CREATE TABLE t (x INT, y INT[], z INT, INDEX i (x, y, z))
+CREATE TABLE t (x INT, y INT[], z INT)
 
 query TTT
 EXPLAIN SELECT x, y, z FROM t WHERE x = 2 AND y < ARRAY[10] ORDER BY y
 ----
-·     distribution  local
-·     vectorized    true
-scan  ·             ·
-·     table         t@i
-·     spans         /2/!NULL-/2/ARRAY[10]
+·          distribution  local
+·          vectorized    true
+sort       ·             ·
+ │         order         +y
+ └── scan  ·             ·
+·          table         t@primary
+·          spans         FULL SCAN
+·          filter        (x = 2) AND (y < ARRAY[10])
 
 # Test span generation on interleaved tables.
+# Add x to parent PRIMARY KEY (x, y) once #50659 is fixed.
+# Add x to child PRIMARY KEY (x, y, z) once #50659 is fixed.
+# Add INTERLEAVE IN PARENT parent (x, y) once #50659 is fixed.
 statement ok
-CREATE TABLE parent (x INT, y INT[], PRIMARY KEY (x, y), FAMILY (x, y));
-CREATE TABLE child (x INT, y INT[], z INT[], PRIMARY KEY (x, y, z), FAMILY (x, y, z)) INTERLEAVE IN PARENT parent (x, y)
+CREATE TABLE parent (x INT, y INT[], PRIMARY KEY (x), FAMILY (x, y));
+CREATE TABLE child (x INT, y INT[], z INT[], PRIMARY KEY (x), FAMILY (x, y, z)) INTERLEAVE IN PARENT parent (x)
 
 query TTT
 EXPLAIN SELECT x, y FROM parent WHERE x > 1 AND y > ARRAY[1, NULL]
@@ -77,7 +94,7 @@ EXPLAIN SELECT x, y FROM parent WHERE x > 1 AND y > ARRAY[1, NULL]
 ·     vectorized    true
 scan  ·             ·
 ·     table         parent@primary
-·     spans         /2/ARRAY[1,NULL,NULL]-
+·     spans         /2-
 ·     filter        y > ARRAY[1,NULL]
 
 query TTT
@@ -88,7 +105,8 @@ EXPLAIN SELECT y FROM parent WHERE x = 1 AND y = ARRAY[NULL, NULL]
 render     ·             ·
  └── scan  ·             ·
 ·          table         parent@primary
-·          spans         /1/ARRAY[NULL,NULL]-/1/ARRAY[NULL,NULL]/#
+·          spans         /1-/1/#
+·          filter        y = ARRAY[NULL,NULL]
 
 query TTT
 EXPLAIN SELECT z FROM child WHERE x = 1 AND y = ARRAY[NULL, NULL]
@@ -98,4 +116,5 @@ EXPLAIN SELECT z FROM child WHERE x = 1 AND y = ARRAY[NULL, NULL]
 render     ·             ·
  └── scan  ·             ·
 ·          table         child@primary
-·          spans         /1/ARRAY[NULL,NULL]/#/56/1-/1/ARRAY[NULL,NULL]/#/56/2
+·          spans         /1/#/56/1-/1/#/56/1/#
+·          filter        y = ARRAY[NULL,NULL]

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2477,7 +2477,9 @@ func fitColumnToFamily(desc *MutableTableDescriptor, col ColumnDescriptor) (int,
 
 // ColumnTypeIsIndexable returns whether the type t is valid as an indexed column.
 func ColumnTypeIsIndexable(t *types.T) bool {
-	return !MustBeValueEncoded(t)
+	// Some inverted index types also have a key encoding, but we don't
+	// want to support those yet. See #50659.
+	return !MustBeValueEncoded(t) && !ColumnTypeIsInvertedIndexable(t)
 }
 
 // ColumnTypeIsInvertedIndexable returns whether the type t is valid to be indexed


### PR DESCRIPTION
There are some open questions about inverted index types being used in
forward indexes. Disable those for now.

Fixes #50656
See #50659
See #17154

Release note (sql change): disable arrays in non-inverted indexes.