### PR TITLE
build: upgrade to Go 1.14

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -66,10 +66,14 @@ which may or may not work (and are not officially supported).
 Please copy this checklist (based on [Basic Process](#basic-process)) into the relevant commit message, with a link
 back to this document and perform these steps:
 
+* [ ] Adjust the Pebble tests to run in 1.14.
 * [ ] Adjust version in Docker image ([source](./builder/Dockerfile#L199-L200)).
-* [ ] Rebuild the Docker image and bump the `version` in `builder.sh` accordingly ([source](./builder.sh#L6)).
+* [ ] Rebuild and push the Docker image (following [Basic Process](#basic-process))
+* [ ] Bump the version in `builder.sh` accordingly ([source](./builder.sh#L6)).
 * [ ] Bump the version in `go-version-check.sh` ([source](./go-version-check.sh)), unless bumping to a new patch release.
+* [ ] Bump the go version in `go.mod`. You may also need to rerun `make vendor_rebuild` if vendoring has changed.
 * [ ] Bump the default installed version of Go in `bootstrap-debian.sh` ([source](./bootstrap/bootstrap-debian.sh#L40-42)).
+* [ ] Replace other mentions of the older version of go (grep for `golang:<old_version>` and `go<old_version>`).
 * [ ] Update the `builder.dockerImage` parameter in the TeamCity [`Cockroach`](https://teamcity.cockroachdb.com/admin/editProject.html?projectId=Cockroach&tab=projectParams) and [`Internal`](https://teamcity.cockroachdb.com/admin/editProject.html?projectId=Internal&tab=projectParams) projects.
 
 You can test the new builder image in TeamCity by using the custom parameters
@@ -94,14 +98,14 @@ When updating a dependency, you should run `go mod tidy` after `go get` to ensur
 are removed from go.sum.
 
 You must then run `make vendor_rebuild` to ensure the modules are installed. These changes must
-then be committed in the submodule directory (see Working with Submodules).
+then be committed in the submodule directory (see [Working with Submodules](#working-with-submodules)).
 
 Programs can then be run using `go build -mod=vendor ...` or `go test -mod=vendor ...`.
 
 ### Removing a dependency
 
-When a dependency has been removed, run `go mod tidy` and then `make vendor_rebuild`. Then follow
-the Working with Submodules steps below.
+When a dependency has been removed, run `go mod tidy` and then `make vendor_rebuild`.
+Then follow the [Working with Submodules](#working-with-submodules) steps.
 
 ### Requiring a new tool
 

--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -46,9 +46,9 @@ sudo tar -C /usr -zxf /tmp/cmake.tgz && rm /tmp/cmake.tgz
 
 # Install Go.
 trap 'rm -f /tmp/go.tgz' EXIT
-curl -fsSL https://dl.google.com/go/go1.13.9.linux-amd64.tar.gz > /tmp/go.tgz
+curl -fsSL https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz > /tmp/go.tgz
 sha256sum -c - <<EOF
-f4ad8180dd0aaf7d7cda7e2b0a2bf27e84131320896d376549a7d849ecf237d7  /tmp/go.tgz
+7011af3bbc2ac108d1b82ea8abb87b2e63f78844f0259be20cde4d42c5c40584 /tmp/go.tgz
 EOF
 sudo tar -C /usr/local -zxf /tmp/go.tgz && rm /tmp/go.tgz
 

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20200421-180956
+version=20200625-145628
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -197,8 +197,8 @@ RUN curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.17.0/cmake-
 # releases of Go will no longer be run in CI once it is changed. Consider
 # bumping the minimum allowed version of Go in /build/go-version-chech.sh.
 RUN apt-get install -y --no-install-recommends golang \
- && curl -fsSL https://storage.googleapis.com/golang/go1.13.9.src.tar.gz -o golang.tar.gz \
- && echo '34bb19d806e0bc4ad8f508ae24bade5e9fedfa53d09be63b488a9314d2d4f31d golang.tar.gz' | sha256sum -c - \
+ && curl -fsSL https://storage.googleapis.com/golang/go1.14.4.src.tar.gz -o golang.tar.gz \
+ && echo '7011af3bbc2ac108d1b82ea8abb87b2e63f78844f0259be20cde4d42c5c40584 golang.tar.gz' | sha256sum -c - \
  && tar -C /usr/local -xzf golang.tar.gz \
  && rm golang.tar.gz \
  && cd /usr/local/go/src \

--- a/build/go-version-check.sh
+++ b/build/go-version-check.sh
@@ -6,8 +6,7 @@
 # To bump the required version of Go, edit the appropriate variables:
 
 required_version_major=1
-minimum_version_minor=13
-minimum_version_13_patch=4
+minimum_version_minor=14
 
 go=${1-go}
 

--- a/build/teamcity-acceptance.sh
+++ b/build/teamcity-acceptance.sh
@@ -33,6 +33,6 @@ run cd pkg/acceptance
 ln -s ../../artifacts artifacts
 # NB: json has to be enabled when building the test binary,
 # which makes this harder to get right than is worth it.
-run_text_test github.com/cockroachdb/cockroach/pkg/acceptance env TZ=America/New_York stdbuf -eL -oL ./acceptance.test -l "$TMPDIR" -test.v -test.timeout 30m
+run_text_test github.com/cockroachdb/cockroach/pkg/acceptance env TZ=America/New_York GOROOT=/home/agent/work/.go stdbuf -eL -oL ./acceptance.test -l "$TMPDIR" -test.v -test.timeout 30m
 run cd ../..
 tc_end_block "Run acceptance tests"

--- a/build/teamcity-verify-archive.sh
+++ b/build/teamcity-verify-archive.sh
@@ -32,7 +32,7 @@ run docker run \
   --rm \
   --volume="$(cd "$(dirname "$0")" && pwd):/work:ro" \
   --workdir="/work" \
-  golang:1.13-buster ./verify-archive.sh
+  golang:1.14-buster ./verify-archive.sh
 tc_end_block "Test archive"
 
 tc_start_block "Clean up"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cockroachdb/cockroach
 
-go 1.13
+go 1.14
 
 require (
 	cloud.google.com/go v0.34.0

--- a/pkg/acceptance/compose/gss/psql/Dockerfile
+++ b/pkg/acceptance/compose/gss/psql/Dockerfile
@@ -1,5 +1,5 @@
 # Build the test binary in a multistage build.
-FROM golang:1.13 AS builder
+FROM golang:1.14 AS builder
 WORKDIR /workspace
 COPY . .
 RUN go get -d -t -tags gss_compose

--- a/pkg/ccl/storageccl/engineccl/rocksdb.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb.go
@@ -130,7 +130,7 @@ func cStringToGoString(s C.DBString) string {
 		return ""
 	}
 	// Reinterpret the string as a slice, then cast to string which does a copy.
-	result := string(cSliceToUnsafeGoBytes(C.DBSlice{s.data, s.len}))
+	result := string(cSliceToUnsafeGoBytes(C.DBSlice(s)))
 	C.free(unsafe.Pointer(s.data))
 	return result
 }

--- a/pkg/cmd/roachprod/docker/Dockerfile
+++ b/pkg/cmd/roachprod/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13
+FROM golang:1.14
 WORKDIR /build
 COPY . .
 RUN ["/build/build.sh"]

--- a/pkg/storage/enginepb/mvcc3.pb.go
+++ b/pkg/storage/enginepb/mvcc3.pb.go
@@ -4207,7 +4207,9 @@ var (
 	ErrIntOverflowMvcc3   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("storage/enginepb/mvcc3.proto", fileDescriptor_mvcc3_9bc532bf92053320) }
+func init() {
+	proto.RegisterFile("storage/enginepb/mvcc3.proto", fileDescriptor_mvcc3_9bc532bf92053320)
+}
 
 var fileDescriptor_mvcc3_9bc532bf92053320 = []byte{
 	// 1165 bytes of a gzipped FileDescriptorProto

--- a/pkg/storage/rocksdb.go
+++ b/pkg/storage/rocksdb.go
@@ -2409,7 +2409,7 @@ func cStringToGoString(s C.DBString) string {
 		return ""
 	}
 	// Reinterpret the string as a slice, then cast to string which does a copy.
-	result := string(cSliceToUnsafeGoBytes(C.DBSlice{s.data, s.len}))
+	result := string(cSliceToUnsafeGoBytes(C.DBSlice(s)))
 	C.free(unsafe.Pointer(s.data))
 	return result
 }
@@ -2591,7 +2591,7 @@ func dbGetProto(
 		// Make a byte slice that is backed by result.data. This slice
 		// cannot live past the lifetime of this method, but we're only
 		// using it to unmarshal the roachpb.
-		data := cSliceToUnsafeGoBytes(C.DBSlice{data: result.data, len: result.len})
+		data := cSliceToUnsafeGoBytes(C.DBSlice(result))
 		err = protoutil.Unmarshal(data, msg)
 	}
 	C.free(unsafe.Pointer(result.data))

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -119,7 +119,7 @@ func vetCmd(t *testing.T, dir, name string, args []string, filters []stream.Filt
 func TestLint(t *testing.T) {
 	crdb, err := build.Import(cockroachDB, "", build.FindOnly)
 	if err != nil {
-		t.Skip(err)
+		t.Fatal(err)
 	}
 	pkgDir := filepath.Join(crdb.Dir, "pkg")
 

--- a/pkg/util/hlc/timestamp.pb.go
+++ b/pkg/util/hlc/timestamp.pb.go
@@ -435,7 +435,9 @@ var (
 	ErrIntOverflowTimestamp   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("util/hlc/timestamp.proto", fileDescriptor_timestamp_7743fc20d6f93748) }
+func init() {
+	proto.RegisterFile("util/hlc/timestamp.proto", fileDescriptor_timestamp_7743fc20d6f93748)
+}
 
 var fileDescriptor_timestamp_7743fc20d6f93748 = []byte{
 	// 191 bytes of a gzipped FileDescriptorProto


### PR DESCRIPTION
Minor fixes required:
* Upgrade go.mod to prevent build.Import errors.
* Updated instructions to upgrade Go.
* Updated .pb.go files - these are tied with the gofmt of the
  environment and we cannot fix this.
* Update storage use cast DBSlice to DBString or it fails S1016 of
  staticcheck.
* Make lint fail if the import directory is not found.
* Fix acceptance test to include GOROOT or else build.Import fails from
  within the acceptance tests. The acceptance test is weirdly set up to
  run a Go binary from the outside container.

Checklist:
* [x] Adjust version in Docker image ([source](./builder/Dockerfile#L199-L200)).
* [x] Rebuild the Docker image and bump the `version` in `builder.sh` accordingly ([source](./builder.sh#L6)).
* [x] Bump the version in `go-version-check.sh` ([source](./go-version-check.sh)), unless bumping to a new patch release.
* [x] Bump the default installed version of Go in `bootstrap-debian.sh` ([source](./bootstrap/bootstrap-debian.sh#L40-42)).
* [ ] Update the `builder.dockerImage` parameter in the TeamCity [`Cockroach`](https://teamcity.cockroachdb.com/admin/editProject.html?projectId=Cockroach&tab=projectParams) and [`Internal`](https://teamcity.cockroachdb.com/admin/editProject.html?projectId=Internal&tab=projectParams) projects.

(I will do the last step after this has merged)

Resolves #48737.

Release note (general change): Bump the Go version to 1.14.

