### PR TITLE
sql: remove Impure flag

### DIFF
--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -81,7 +81,7 @@ func parseValues(tableDesc *sqlbase.TableDescriptor, values string) ([]sqlbase.E
 		for colIdx, expr := range rowTuple {
 			col := &tableDesc.Columns[colIdx]
 			typedExpr, err := sqlbase.SanitizeVarFreeExpr(
-				ctx, expr, col.Type, "avro", &semaCtx, false /* allowImpure */)
+				ctx, expr, col.Type, "avro", &semaCtx, tree.VolatilityStable)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -379,6 +379,11 @@ CREATE TABLE t (a TIMESTAMP PRIMARY KEY) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (uuid_v4() || 'foo')
 )
 
+statement error PARTITION p1: 'now'::TIMESTAMP: partition values must be constant
+CREATE TABLE t (a TIMESTAMP PRIMARY KEY) PARTITION BY LIST (a) (
+    PARTITION p1 VALUES IN ('now')
+)
+
 statement ok
 CREATE TABLE ok1 (
   a INT, b INT, c INT,

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -369,12 +369,12 @@ CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN ((SELECT 1))
 )
 
-statement error PARTITION p1: now\(\): impure functions are not allowed in partition
+statement error PARTITION p1: now\(\): context-dependent functions are not allowed in partition
 CREATE TABLE t (a TIMESTAMP PRIMARY KEY) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (now())
 )
 
-statement error PARTITION p1: uuid_v4\(\): impure functions are not allowed in partition
+statement error PARTITION p1: uuid_v4\(\): volatile functions are not allowed in partition
 CREATE TABLE t (a TIMESTAMP PRIMARY KEY) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (uuid_v4() || 'foo')
 )

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -93,7 +93,9 @@ func valueEncodePartitionTuple(
 
 		var semaCtx tree.SemaContext
 		typedExpr, err := sqlbase.SanitizeVarFreeExpr(evalCtx.Context, expr, cols[i].Type, "partition",
-			&semaCtx, false /* allowImpure */)
+			&semaCtx,
+			tree.VolatilityImmutable,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -341,7 +341,7 @@ func makeFunc(s *Smither, ctx Context, typ *types.T, refs colRefs) (tree.TypedEx
 		return nil, false
 	}
 	fn := fns[s.rnd.Intn(len(fns))]
-	if s.disableImpureFns && fn.def.Impure {
+	if s.disableImpureFns && fn.overload.Volatility > tree.VolatilityImmutable {
 		return nil, false
 	}
 	for _, ignore := range s.ignoreFNs {

--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -245,7 +245,7 @@ func alterColumnTypeGeneral(
 			toType,
 			"ALTER COLUMN TYPE USING EXPRESSION",
 			&params.p.semaCtx,
-			true, /* allowImpure */
+			tree.VolatilityVolatile,
 			tn,
 		)
 

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -826,7 +826,7 @@ func applyColumnMutation(
 		} else {
 			colDatumType := col.Type
 			expr, err := sqlbase.SanitizeVarFreeExpr(
-				params.ctx, t.Default, colDatumType, "DEFAULT", &params.p.semaCtx, true, /* allowImpure */
+				params.ctx, t.Default, colDatumType, "DEFAULT", &params.p.semaCtx, tree.VolatilityVolatile,
 			)
 			if err != nil {
 				return err

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -141,6 +141,11 @@ func verifyColOperator(args verifyColOperatorArgs) error {
 		StreamingMemAccount: &acc,
 		DiskQueueCfg:        colcontainer.DiskQueueCfg{FS: tempFS},
 		FDSemaphore:         colexecbase.NewTestingSemaphore(256),
+
+		// TODO(yuzefovich): adjust expression generator to not produce
+		// mixed-type timestamp-related expressions and then disallow the
+		// fallback again.
+		ProcessorConstructor: rowexec.NewProcessor,
 	}
 	var spilled bool
 	if args.forceDiskSpill {

--- a/pkg/sql/execute.go
+++ b/pkg/sql/execute.go
@@ -48,8 +48,8 @@ func fillInPlaceholders(
 			return nil, errors.AssertionFailedf("no type for placeholder %s", idx)
 		}
 		typedExpr, err := sqlbase.SanitizeVarFreeExpr(
-			ctx, e, typ, "EXECUTE parameter", /* context */
-			&semaCtx, true /* allowImpure */)
+			ctx, e, typ, "EXECUTE parameter" /* context */, &semaCtx, tree.VolatilityVolatile,
+		)
 		if err != nil {
 			return nil, pgerror.WithCandidateCode(err, pgcode.WrongObjectType)
 		}

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -289,14 +289,14 @@ CREATE TABLE y (
   b INT AS (a) STORED
 )
 
-statement error impure functions are not allowed in computed column
+statement error context-dependent functions are not allowed in computed column
 CREATE TABLE y (
   a TIMESTAMP AS (now()) STORED
 )
 
-statement error impure functions are not allowed in computed column
+statement error volatile functions are not allowed in computed column
 CREATE TABLE y (
-  a STRING AS (concat(now()::STRING, uuid_v4()::STRING)) STORED
+  a STRING AS (concat('foo', uuid_v4()::STRING)) STORED
 )
 
 statement error computed columns cannot reference other computed columns

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -26,8 +26,11 @@ CREATE TABLE error (a INT, INDEX (a) WHERE b = 3)
 
 # Don't allow mutable functions.
 # TODO(mgartner): The error code for this should be 42P17, not 0A000.
-statement error pgcode 0A000 impure functions are not allowed in index predicate
+statement error pgcode 0A000 context-dependent functions are not allowed in index predicate
 CREATE TABLE error (t TIMESTAMPTZ, INDEX (t) WHERE t < now())
+
+statement error pgcode 0A000 volatile functions are not allowed in index predicate
+CREATE TABLE error (t FLOAT, INDEX (t) WHERE t < random())
 
 # Don't allow variable subexpressions.
 statement error pgcode 42601 variable sub-expressions are not allowed in index predicate

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -512,7 +512,7 @@ func (h *harness) prepareUsingAPI(tb testing.TB) {
 			typ,
 			"", /* context */
 			&h.semaCtx,
-			true, /* allowImpure */
+			tree.VolatilityVolatile,
 		)
 		if err != nil {
 			tb.Fatalf("%v", err)

--- a/pkg/sql/opt/memo/testdata/stats/project
+++ b/pkg/sql/opt/memo/testdata/stats/project
@@ -87,12 +87,12 @@ SELECT * FROM (SELECT concat(s, y::string) FROM a) AS q(v) WHERE v = 'foo'
 ----
 select
  ├── columns: v:5(string!null)
- ├── stable
+ ├── immutable
  ├── stats: [rows=20, distinct(5)=1, null(5)=0]
  ├── fd: ()-->(5)
  ├── project
  │    ├── columns: concat:5(string)
- │    ├── stable
+ │    ├── immutable
  │    ├── stats: [rows=2000, distinct(5)=100, null(5)=0]
  │    ├── scan a
  │    │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
@@ -100,7 +100,7 @@ select
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    └── projections
- │         └── concat(s:3, y:2::STRING) [as=concat:5, type=string, outer=(2,3), stable]
+ │         └── concat(s:3, y:2::STRING) [as=concat:5, type=string, outer=(2,3), immutable]
  └── filters
       └── concat:5 = 'foo' [type=bool, outer=(5), constraints=(/5: [/'foo' - /'foo']; tight), fd=()-->(5)]
 
@@ -111,13 +111,13 @@ SELECT * FROM (SELECT concat(s, y::string), x FROM a) AS q(v, x) GROUP BY v, x
 group-by
  ├── columns: v:5(string) x:1(int!null)
  ├── grouping columns: x:1(int!null) concat:5(string)
- ├── stable
+ ├── immutable
  ├── stats: [rows=2000, distinct(1,5)=2000, null(1,5)=0]
  ├── key: (1)
  ├── fd: (1)-->(5)
  └── project
       ├── columns: concat:5(string) x:1(int!null)
-      ├── stable
+      ├── immutable
       ├── stats: [rows=2000, distinct(1,5)=2000, null(1,5)=0]
       ├── key: (1)
       ├── fd: (1)-->(5)
@@ -127,7 +127,7 @@ group-by
       │    ├── key: (1)
       │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
       └── projections
-           └── concat(s:3, y:2::STRING) [as=concat:5, type=string, outer=(2,3), stable]
+           └── concat(s:3, y:2::STRING) [as=concat:5, type=string, outer=(2,3), immutable]
 
 # No available stats for column y.
 build
@@ -250,12 +250,12 @@ SELECT * FROM (SELECT concat(s, y::string) FROM a) AS q(v) WHERE v = 'foo'
 ----
 select
  ├── columns: v:5(string!null)
- ├── stable
+ ├── immutable
  ├── stats: [rows=1, distinct(5)=1, null(5)=0]
  ├── fd: ()-->(5)
  ├── project
  │    ├── columns: concat:5(string)
- │    ├── stable
+ │    ├── immutable
  │    ├── stats: [rows=2000, distinct(5)=2000, null(5)=0]
  │    ├── scan a
  │    │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
@@ -263,7 +263,7 @@ select
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    └── projections
- │         └── concat(s:3, y:2::STRING) [as=concat:5, type=string, outer=(2,3), stable]
+ │         └── concat(s:3, y:2::STRING) [as=concat:5, type=string, outer=(2,3), immutable]
  └── filters
       └── concat:5 = 'foo' [type=bool, outer=(5), constraints=(/5: [/'foo' - /'foo']; tight), fd=()-->(5)]
 

--- a/pkg/sql/schemaexpr/check_constraint.go
+++ b/pkg/sql/schemaexpr/check_constraint.go
@@ -95,7 +95,7 @@ func (b *CheckConstraintBuilder) Build(
 		types.Bool,
 		"CHECK",
 		b.semaCtx,
-		true, /* allowImpure */
+		tree.VolatilityVolatile,
 		&b.tableName,
 	)
 	if err != nil {

--- a/pkg/sql/schemaexpr/computed_column.go
+++ b/pkg/sql/schemaexpr/computed_column.go
@@ -123,7 +123,7 @@ func (v *ComputedColumnValidator) Validate(d *tree.ColumnTableDef) error {
 		defType,
 		"computed column",
 		v.semaCtx,
-		false, /* allowImpure */
+		tree.VolatilityImmutable,
 		v.tableName,
 	)
 	if err != nil {

--- a/pkg/sql/schemaexpr/expr.go
+++ b/pkg/sql/schemaexpr/expr.go
@@ -60,7 +60,7 @@ func DequalifyAndValidateExpr(
 	typ *types.T,
 	op string,
 	semaCtx *tree.SemaContext,
-	allowImpure bool,
+	maxVolatility tree.Volatility,
 	tn *tree.TableName,
 ) (tree.TypedExpr, sqlbase.TableColSet, error) {
 	var colIDs sqlbase.TableColSet
@@ -88,7 +88,7 @@ func DequalifyAndValidateExpr(
 		typ,
 		op,
 		semaCtx,
-		allowImpure,
+		maxVolatility,
 	)
 
 	if err != nil {

--- a/pkg/sql/schemaexpr/partial_index.go
+++ b/pkg/sql/schemaexpr/partial_index.go
@@ -52,7 +52,7 @@ func NewIndexPredicateValidator(
 //   - It results in a boolean.
 //   - It refers only to columns in the table.
 //   - It does not include subqueries.
-//   - It does not include mutable, aggregate, window, or set returning
+//   - It does not include non-immutable, aggregate, window, or set returning
 //     functions.
 //
 func (v *IndexPredicateValidator) Validate(expr tree.Expr) (tree.Expr, error) {
@@ -63,7 +63,7 @@ func (v *IndexPredicateValidator) Validate(expr tree.Expr) (tree.Expr, error) {
 		types.Bool,
 		"index predicate",
 		v.semaCtx,
-		false, /* allowImpure */
+		tree.VolatilityImmutable,
 		&v.tableName,
 	)
 	if err != nil {

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -38,9 +38,6 @@ func initAggregateBuiltins() {
 			panic("duplicate builtin: " + k)
 		}
 
-		if !v.props.Impure {
-			panic(fmt.Sprintf("%s: aggregate functions should all be impure, found %v", k, v))
-		}
 		if v.props.Class != tree.AggregateClass {
 			panic(fmt.Sprintf("%s: aggregate functions should be marked with the tree.AggregateClass "+
 				"function class, found %v", k, v))
@@ -61,7 +58,7 @@ func initAggregateBuiltins() {
 }
 
 func aggProps() tree.FunctionProperties {
-	return tree.FunctionProperties{Class: tree.AggregateClass, Impure: true}
+	return tree.FunctionProperties{Class: tree.AggregateClass}
 }
 
 func aggPropsNullableArgs() tree.FunctionProperties {

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -493,7 +493,6 @@ var builtins = map[string]builtinDefinition{
 	"gen_random_uuid": makeBuiltin(
 		tree.FunctionProperties{
 			Category: categoryIDGeneration,
-			Impure:   true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{},
@@ -1714,9 +1713,7 @@ CockroachDB supports the following flags:
 	),
 
 	"random": makeBuiltin(
-		tree.FunctionProperties{
-			Impure: true,
-		},
+		tree.FunctionProperties{},
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Float),
@@ -1731,7 +1728,6 @@ CockroachDB supports the following flags:
 	"unique_rowid": makeBuiltin(
 		tree.FunctionProperties{
 			Category: categoryIDGeneration,
-			Impure:   true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{},
@@ -1754,7 +1750,6 @@ CockroachDB supports the following flags:
 		tree.FunctionProperties{
 			Category:             categorySequences,
 			DistsqlBlocklist:     true,
-			Impure:               true,
 			HasSequenceArguments: true,
 		},
 		tree.Overload{
@@ -1781,7 +1776,6 @@ CockroachDB supports the following flags:
 		tree.FunctionProperties{
 			Category:             categorySequences,
 			DistsqlBlocklist:     true,
-			Impure:               true,
 			HasSequenceArguments: true,
 		},
 		tree.Overload{
@@ -1807,7 +1801,6 @@ CockroachDB supports the following flags:
 	"lastval": makeBuiltin(
 		tree.FunctionProperties{
 			Category: categorySequences,
-			Impure:   true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{},
@@ -1830,7 +1823,6 @@ CockroachDB supports the following flags:
 		tree.FunctionProperties{
 			Category:             categorySequences,
 			DistsqlBlocklist:     true,
-			Impure:               true,
 			HasSequenceArguments: true,
 		},
 		tree.Overload{
@@ -1999,7 +1991,7 @@ CockroachDB supports the following flags:
 
 	// https://www.postgresql.org/docs/10/static/functions-datetime.html
 	"age": makeBuiltin(
-		tree.FunctionProperties{Impure: true},
+		tree.FunctionProperties{},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.TimestampTZ}},
 			ReturnType: tree.FixedReturnType(types.Interval),
@@ -2021,7 +2013,7 @@ CockroachDB supports the following flags:
 	),
 
 	"current_date": makeBuiltin(
-		tree.FunctionProperties{Impure: true},
+		tree.FunctionProperties{},
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Date),
@@ -2040,7 +2032,7 @@ CockroachDB supports the following flags:
 	"localtime":      txnTimeWithPrecisionBuiltin(false),
 
 	"statement_timestamp": makeBuiltin(
-		tree.FunctionProperties{Impure: true},
+		tree.FunctionProperties{},
 		tree.Overload{
 			Types:             tree.ArgTypes{},
 			ReturnType:        tree.FixedReturnType(types.TimestampTZ),
@@ -2063,7 +2055,7 @@ CockroachDB supports the following flags:
 	),
 
 	tree.FollowerReadTimestampFunctionName: makeBuiltin(
-		tree.FunctionProperties{Impure: true},
+		tree.FunctionProperties{},
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
@@ -2091,7 +2083,6 @@ return without an error.`,
 	"cluster_logical_timestamp": makeBuiltin(
 		tree.FunctionProperties{
 			Category: categorySystemInfo,
-			Impure:   true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{},
@@ -2111,7 +2102,7 @@ may increase either contention or retry errors, or both.`,
 	),
 
 	"clock_timestamp": makeBuiltin(
-		tree.FunctionProperties{Impure: true},
+		tree.FunctionProperties{},
 		tree.Overload{
 			Types:             tree.ArgTypes{},
 			ReturnType:        tree.FixedReturnType(types.TimestampTZ),
@@ -2134,7 +2125,7 @@ may increase either contention or retry errors, or both.`,
 	),
 
 	"timeofday": makeBuiltin(
-		tree.FunctionProperties{Category: categoryDateAndTime, Impure: true},
+		tree.FunctionProperties{Category: categoryDateAndTime},
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
@@ -3220,7 +3211,6 @@ may increase either contention or retry errors, or both.`,
 		tree.FunctionProperties{
 			Category:     categoryMultiTenancy,
 			Undocumented: true,
-			Impure:       true,
 		},
 		tree.Overload{
 			Types: tree.ArgTypes{
@@ -3266,7 +3256,6 @@ may increase either contention or retry errors, or both.`,
 		tree.FunctionProperties{
 			Category:     categoryMultiTenancy,
 			Undocumented: true,
-			Impure:       true,
 		},
 		tree.Overload{
 			Types: tree.ArgTypes{
@@ -3412,7 +3401,6 @@ may increase either contention or retry errors, or both.`,
 	"crdb_internal.force_error": makeBuiltin(
 		tree.FunctionProperties{
 			Category: categorySystemInfo,
-			Impure:   true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"errorCode", types.String}, {"msg", types.String}},
@@ -3435,7 +3423,6 @@ may increase either contention or retry errors, or both.`,
 	"crdb_internal.notice": makeBuiltin(
 		tree.FunctionProperties{
 			Category: categorySystemInfo,
-			Impure:   true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"msg", types.String}},
@@ -3466,7 +3453,6 @@ may increase either contention or retry errors, or both.`,
 	"crdb_internal.force_assertion_error": makeBuiltin(
 		tree.FunctionProperties{
 			Category: categorySystemInfo,
-			Impure:   true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"msg", types.String}},
@@ -3483,7 +3469,6 @@ may increase either contention or retry errors, or both.`,
 	"crdb_internal.force_panic": makeBuiltin(
 		tree.FunctionProperties{
 			Category: categorySystemInfo,
-			Impure:   true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"msg", types.String}},
@@ -3503,7 +3488,6 @@ may increase either contention or retry errors, or both.`,
 	"crdb_internal.force_log_fatal": makeBuiltin(
 		tree.FunctionProperties{
 			Category: categorySystemInfo,
-			Impure:   true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"msg", types.String}},
@@ -3529,7 +3513,6 @@ may increase either contention or retry errors, or both.`,
 	"crdb_internal.force_retry": makeBuiltin(
 		tree.FunctionProperties{
 			Category: categorySystemInfo,
-			Impure:   true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Interval}},
@@ -3580,7 +3563,6 @@ may increase either contention or retry errors, or both.`,
 	"crdb_internal.no_constant_folding": makeBuiltin(
 		tree.FunctionProperties{
 			Category: categorySystemInfo,
-			Impure:   true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.Any}},
@@ -3712,7 +3694,6 @@ may increase either contention or retry errors, or both.`,
 	"crdb_internal.set_vmodule": makeBuiltin(
 		tree.FunctionProperties{
 			Category: categorySystemInfo,
-			Impure:   true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"vmodule_string", types.String}},
@@ -4194,7 +4175,6 @@ func getSubstringFromIndexOfLength(str, errMsg string, start, length int) (strin
 var uuidV4Impl = makeBuiltin(
 	tree.FunctionProperties{
 		Category: categoryIDGeneration,
-		Impure:   true,
 	},
 	tree.Overload{
 		Types:      tree.ArgTypes{},
@@ -4314,7 +4294,6 @@ func txnTSImplBuiltin(preferTZOverload bool) builtinDefinition {
 	return makeBuiltin(
 		tree.FunctionProperties{
 			Category: categoryDateAndTime,
-			Impure:   true,
 		},
 		txnTSOverloads(preferTZOverload)...,
 	)
@@ -4324,7 +4303,6 @@ func txnTSWithPrecisionImplBuiltin(preferTZOverload bool) builtinDefinition {
 	return makeBuiltin(
 		tree.FunctionProperties{
 			Category: categoryDateAndTime,
-			Impure:   true,
 		},
 		txnTSWithPrecisionOverloads(preferTZOverload)...,
 	)
@@ -4333,7 +4311,7 @@ func txnTSWithPrecisionImplBuiltin(preferTZOverload bool) builtinDefinition {
 func txnTimeWithPrecisionBuiltin(preferTZOverload bool) builtinDefinition {
 	tzAdditionalDesc, noTZAdditionalDesc := getTimeAdditionalDesc(preferTZOverload)
 	return makeBuiltin(
-		tree.FunctionProperties{Impure: true},
+		tree.FunctionProperties{},
 		tree.Overload{
 			Types:             tree.ArgTypes{},
 			ReturnType:        tree.FixedReturnType(types.TimeTZ),

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -43,9 +43,6 @@ func initGeneratorBuiltins() {
 			panic("duplicate builtin: " + k)
 		}
 
-		if !v.props.Impure {
-			panic(fmt.Sprintf("generator functions should all be impure, found %v", v))
-		}
 		if v.props.Class != tree.GeneratorClass {
 			panic(fmt.Sprintf("generator functions should be marked with the tree.GeneratorClass "+
 				"function class, found %v", v))
@@ -57,7 +54,6 @@ func initGeneratorBuiltins() {
 
 func genProps() tree.FunctionProperties {
 	return tree.FunctionProperties{
-		Impure:   true,
 		Class:    tree.GeneratorClass,
 		Category: categoryGenerator,
 	}
@@ -65,7 +61,6 @@ func genProps() tree.FunctionProperties {
 
 func genPropsWithLabels(returnLabels []string) tree.FunctionProperties {
 	return tree.FunctionProperties{
-		Impure:       true,
 		Class:        tree.GeneratorClass,
 		Category:     categoryGenerator,
 		ReturnLabels: returnLabels,
@@ -265,7 +260,6 @@ var generators = map[string]builtinDefinition{
 
 	"crdb_internal.check_consistency": makeBuiltin(
 		tree.FunctionProperties{
-			Impure:   true,
 			Class:    tree.GeneratorClass,
 			Category: categorySystemInfo,
 		},

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -2889,7 +2889,6 @@ The calculations are done on a sphere.`,
 		tree.FunctionProperties{
 			Class:    tree.SQLClass,
 			Category: categoryGeospatial,
-			Impure:   true,
 		},
 		tree.Overload{
 			Types: tree.ArgTypes{

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1083,11 +1083,7 @@ SELECT description
 	),
 
 	"pg_sleep": makeBuiltin(
-		tree.FunctionProperties{
-			// pg_sleep is marked as impure so it doesn't get executed during
-			// normalization.
-			Impure: true,
-		},
+		tree.FunctionProperties{},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"seconds", types.Float}},
 			ReturnType: tree.FixedReturnType(types.Bool),
@@ -1744,7 +1740,6 @@ SELECT description
 		tree.FunctionProperties{
 			Category:         categorySystemInfo,
 			DistsqlBlocklist: true,
-			Impure:           true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"setting_name", types.String}, {"new_value", types.String}, {"is_local", types.Bool}},

--- a/pkg/sql/sem/builtins/window_builtins.go
+++ b/pkg/sql/sem/builtins/window_builtins.go
@@ -27,9 +27,6 @@ func initWindowBuiltins() {
 			panic("duplicate builtin: " + k)
 		}
 
-		if !v.props.Impure {
-			panic(fmt.Sprintf("%s: window functions should all be impure, found %v", k, v))
-		}
 		if v.props.Class != tree.WindowClass {
 			panic(fmt.Sprintf("%s: window functions should be marked with the tree.WindowClass "+
 				"function class, found %v", k, v))
@@ -46,8 +43,7 @@ func initWindowBuiltins() {
 
 func winProps() tree.FunctionProperties {
 	return tree.FunctionProperties{
-		Impure: true,
-		Class:  tree.WindowClass,
+		Class: tree.WindowClass,
 	}
 }
 

--- a/pkg/sql/sem/tree/datum_test.go
+++ b/pkg/sql/sem/tree/datum_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func prepareExpr(t *testing.T, datumExpr string) tree.TypedExpr {
+func prepareExpr(t *testing.T, datumExpr string) tree.Datum {
 	expr, err := parser.ParseExpr(datumExpr)
 	if err != nil {
 		t.Fatalf("%s: %v", datumExpr, err)
@@ -50,7 +50,11 @@ func prepareExpr(t *testing.T, datumExpr string) tree.TypedExpr {
 	if err != nil {
 		t.Fatalf("%s: %v", datumExpr, err)
 	}
-	return typedExpr
+	d, err := typedExpr.Eval(evalCtx)
+	if err != nil {
+		t.Fatalf("%s: %v", datumExpr, err)
+	}
+	return d
 }
 
 func TestDatumOrdering(t *testing.T) {
@@ -229,9 +233,8 @@ func TestDatumOrdering(t *testing.T) {
 	}
 	ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	for _, td := range testData {
-		expr := prepareExpr(t, td.datumExpr)
+		d := prepareExpr(t, td.datumExpr)
 
-		d := expr.(tree.Datum)
 		prevVal, hasPrev := d.Prev(ctx)
 		nextVal, hasNext := d.Next(ctx)
 		if td.prev == noPrev {

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1394,13 +1394,6 @@ func (node *FuncExpr) IsWindowFunctionApplication() bool {
 	return node.WindowDef != nil
 }
 
-// IsImpure returns whether the function application is impure, meaning that it
-// potentially returns a different value when called in the same statement with
-// the same parameters.
-func (node *FuncExpr) IsImpure() bool {
-	return node.fnProps != nil && node.fnProps.Impure
-}
-
 // IsDistSQLBlocklist returns whether the function is not supported by DistSQL.
 func (node *FuncExpr) IsDistSQLBlocklist() bool {
 	return node.fnProps != nil && node.fnProps.DistsqlBlocklist

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -57,14 +57,6 @@ type FunctionProperties struct {
 	// be NULL and should act accordingly.
 	NullableArgs bool
 
-	// Impure is set to true when a function potentially returns a
-	// different value when called in the same statement with the same
-	// parameters. e.g.: random(), clock_timestamp(). Some functions
-	// like now() return the same value in the same statement, but
-	// different values in separate statements, and should not be marked
-	// as impure.
-	Impure bool
-
 	// DistsqlBlocklist is set to true when a function depends on
 	// members of the EvalContext that are not marshaled by DistSQL
 	// (e.g. planner). Currently used for DistSQL to determine if


### PR DESCRIPTION
This set of commits changes all uses of Impure to use volatilities instead, and removes the flag altogether.

#### sql: use volatility when sanitizing expressions

As part of work toward removing the coarse (and unreliable) `Impure` flag, this
change modifies the expression sanitizers to take a `maxVolatility` argument
instead of an `allowImpure` boolean. Currently we only support either Stable or
Volatile as max-volatility. There are some TODO cases where we may want to
support Immutable (but note that we would have to check operators and casts as
well).

Release note: None

#### sql: use volatility in normalization / IsConst

Release note: None

#### sqlsmith: use volatility in sqlsmith check

Update the impure check in sqlsmith to check the Volatility. We want only
immutable functions so the results of any given query are consistent across
servers.

Release note: None

#### sql: remove Impure flag

Release note: None