### PR TITLE
opt: bugfix to virtual table scans

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/orms
+++ b/pkg/sql/logictest/testdata/logic_test/orms
@@ -284,3 +284,57 @@ FROM
 			AS t_pk ON i.table_name = t_pk.table_name
 GROUP BY
 	t_pk.table_primary_key_columns
+
+# Regression test for pgcli's foreign key query.
+query TTTTTT
+SELECT
+  s_p.nspname AS parentschema,
+  t_p.relname AS parenttable,
+  unnest(
+    (
+      SELECT
+        array_agg(attname ORDER BY i)
+      FROM
+        (
+          SELECT
+            unnest(confkey) AS attnum,
+            generate_subscripts(confkey, 1) AS i
+        )
+          AS x
+        JOIN pg_catalog.pg_attribute AS c USING (attnum)
+      WHERE
+        c.attrelid = fk.confrelid
+    )
+  )
+    AS parentcolumn,
+  s_c.nspname AS childschema,
+  t_c.relname AS childtable,
+  unnest(
+    (
+      SELECT
+        array_agg(attname ORDER BY i)
+      FROM
+        (
+          SELECT
+            unnest(conkey) AS attnum,
+            generate_subscripts(conkey, 1) AS i
+        )
+          AS x
+        JOIN pg_catalog.pg_attribute AS c USING (attnum)
+      WHERE
+        c.attrelid = fk.conrelid
+    )
+  )
+    AS childcolumn
+FROM
+  pg_catalog.pg_constraint AS fk
+  JOIN pg_catalog.pg_class AS t_p ON t_p.oid = fk.confrelid
+  JOIN pg_catalog.pg_namespace AS s_p ON
+      s_p.oid = t_p.relnamespace
+  JOIN pg_catalog.pg_class AS t_c ON t_c.oid = fk.conrelid
+  JOIN pg_catalog.pg_namespace AS s_c ON
+      s_c.oid = t_c.relnamespace
+WHERE
+  fk.contype = 'f';
+----
+public  a  id  public  b  a_id

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -74,7 +74,7 @@ type Table interface {
 	// Public indexes are not currently being added or dropped from the table.
 	// This method should be used when mutation columns can be ignored (the common
 	// case). The returned indexes include the primary index, so the count is
-	// always >= 1 (except for virtual tables, which have no indexes).
+	// always >= 1.
 	IndexCount() int
 
 	// WritableIndexCount returns the number of public and write-only indexes
@@ -88,12 +88,12 @@ type Table interface {
 	// >= WritableIndexCount.
 	DeletableIndexCount() int
 
-	// Index returns the ith index, where i < DeletableIndexCount. Except for
-	// virtual tables, the table's primary index is always the 0th index, and is
-	// always present (use cat.PrimaryIndex to select it). The primary index
-	// corresponds to the table's primary key. If a primary key was not
-	// explicitly specified, then the system implicitly creates one based on a
-	// hidden rowid column.
+	// Index returns the ith index, where i < DeletableIndexCount. The table's
+	// primary index is always the 0th index, and is always present (use
+	// cat.PrimaryIndex to select it). The primary index corresponds to the
+	// table's primary key. If a primary key was not explicitly specified, then
+	// the system implicitly creates one based on a hidden rowid column. For
+	// virtual tables, the primary index contains a single, synthesized column.
 	Index(i IndexOrdinal) Index
 
 	// StatisticCount returns the number of statistics available for the table.

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -14,6 +14,7 @@ import (
 	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -1523,6 +1524,11 @@ func MakeTableFuncDep(md *opt.Metadata, tabID opt.TableID) *props.FuncDepSet {
 
 		if index.IsInverted() {
 			// Skip inverted indexes for now.
+			continue
+		}
+		if tab.IsVirtualTable() && i == cat.PrimaryIndex {
+			// Don't advertise any functional dependencies for virtual table primary
+			// keys, since they are composed of a fake, unusable column.
 			continue
 		}
 

--- a/pkg/sql/opt/memo/testdata/logprops/virtual-scan
+++ b/pkg/sql/opt/memo/testdata/logprops/virtual-scan
@@ -10,7 +10,7 @@ project
  └── left-join (cross)
       ├── columns: catalog_name:2(string!null) schema_name:3(string!null) default_character_set_name:4(string) sql_path:5(string) information_schema.tables.crdb_internal_vtable_pk:6(int) table_catalog:7(string) table_schema:8(string) table_name:9(string) table_type:10(string) is_insertable_into:11(string) version:12(int)
       ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
-      ├── fd: ()-->(3), (6)-->(7-12)
+      ├── fd: ()-->(3)
       ├── prune: (4-6,9-12)
       ├── reject-nulls: (6-12)
       ├── interesting orderings: (+6)
@@ -20,14 +20,11 @@ project
       │    ├── prune: (2-5)
       │    └── select
       │         ├── columns: information_schema.schemata.crdb_internal_vtable_pk:1(int!null) catalog_name:2(string!null) schema_name:3(string!null) default_character_set_name:4(string) sql_path:5(string)
-      │         ├── key: (1)
-      │         ├── fd: ()-->(3), (1)-->(2,4,5)
+      │         ├── fd: ()-->(3)
       │         ├── prune: (1,2,4,5)
       │         ├── interesting orderings: (+1)
       │         ├── scan information_schema.schemata
       │         │    ├── columns: information_schema.schemata.crdb_internal_vtable_pk:1(int!null) catalog_name:2(string!null) schema_name:3(string!null) default_character_set_name:4(string) sql_path:5(string)
-      │         │    ├── key: (1)
-      │         │    ├── fd: (1)-->(2-5)
       │         │    ├── prune: (1-5)
       │         │    └── interesting orderings: (+1)
       │         └── filters
@@ -36,8 +33,6 @@ project
       │                   └── const: 'public' [type=string]
       ├── scan information_schema.tables
       │    ├── columns: information_schema.tables.crdb_internal_vtable_pk:6(int!null) table_catalog:7(string!null) table_schema:8(string!null) table_name:9(string!null) table_type:10(string!null) is_insertable_into:11(string!null) version:12(int)
-      │    ├── key: (6)
-      │    ├── fd: (6)-->(7-12)
       │    ├── prune: (6-12)
       │    ├── interesting orderings: (+6)
       │    └── unfiltered-cols: (6-12)


### PR DESCRIPTION
Previously, the optimizer exposed the hidden virtual table primary key
column from scans, even though this column has no value and is not
usable. This caused issues with some complex metadata queries.

Now, the optimizer doesn't advertise this column, resolving the issue.

Closes #50157.

Release note (bug fix): some pg_catalog queries that previously returned
an error like "crdb_internal_vtable_pk column not allowed" now work
again.