### PR TITLE
build: avoid run_text_test in teamcity-acceptance.sh

### DIFF
--- a/build/teamcity-acceptance.sh
+++ b/build/teamcity-acceptance.sh
@@ -16,6 +16,8 @@ mkdir -p "$TMPDIR"
 type=$(GOFLAGS=; go env GOOS)
 tc_end_block "Prepare environment for acceptance tests"
 
+# TODO(tbg): this is unnecessary, just use the "compile test binary" build step artifact. See:
+# https://github.com/cockroachdb/dev-inf/issues/128
 tc_start_block "Compile CockroachDB"
 # Buffer noisy output and only print it on failure.
 run pkg/acceptance/prepare.sh &> artifacts/acceptance-compile.log || (cat artifacts/acceptance-compile.log && false)
@@ -23,16 +25,21 @@ rm artifacts/acceptance-compile.log
 run ln -s cockroach-linux-2.6.32-gnu-amd64 cockroach  # For the tests that run without Docker.
 tc_end_block "Compile CockroachDB"
 
+# We need to compile the test binary because we can't invoke it in builder.sh (recursive use of Docker, though
+# actually it might just work - I think I remember "privileged mode" was the sticking point in the past).
 tc_start_block "Compile acceptance tests"
 run build/builder.sh mkrelease "$type" -Otarget testbuild TAGS=acceptance PKG=./pkg/acceptance
 tc_end_block "Compile acceptance tests"
 
 tc_start_block "Run acceptance tests"
-run cd pkg/acceptance
-# run_text_test needs ./artifacts to be the artifacts folder.
-ln -s ../../artifacts artifacts
-# NB: json has to be enabled when building the test binary,
-# which makes this harder to get right than is worth it.
-run_text_test github.com/cockroachdb/cockroach/pkg/acceptance env TZ=America/New_York GOROOT=/home/agent/work/.go stdbuf -eL -oL ./acceptance.test -l "$TMPDIR" -test.v -test.timeout 30m
-run cd ../..
+# Note the trick here - we're running `go test` but it won't actually invoke the test binary it
+# built itself, but the one we built with the acceptance tag. We do this to avoid invoking
+# `make` outside of the builder. At the same time, we need to go through `go test` because that
+# is the only way to get sane `-json` behavior (test2json has various shortcomings when tests
+# time out, etc). So we have it build `emptypkg` (which has no deps, duh) but really will run
+# the thing we care about, 'acceptance.test'.
+run_json_test env TZ=America/New_York stdbuf -eL -oL go test \
+  -mod=vendor -json -timeout 30m -v \
+	-exec "../../../build/teamcity-go-test-precompiled.sh ./pkg/acceptance/acceptance.test" ./pkg/testutils/emptypkg \
+	-l "$TMPDIR"
 tc_end_block "Run acceptance tests"

--- a/build/teamcity-compose.sh
+++ b/build/teamcity-compose.sh
@@ -22,9 +22,7 @@ run build/builder.sh mkrelease "$type" -Otarget testbuild PKG=./pkg/compose TAGS
 tc_end_block "Compile compose tests"
 
 tc_start_block "Run compose tests"
-run cd pkg/compose
-# run_text_test needs ./artifacts to be the artifacts folder.
-ln -s ../../artifacts artifacts
-run_text_test github.com/cockroachdb/cockroach/pkg/compose ./compose.test -test.v -test.timeout 30m
-run cd ../..
+# NB: we're cheating go test into invoking our `compose.test` over the one it
+# builds itself.
+run_json_test go test -json -v -timeout 30m -exec ../../build/teamcity-go-test-precompiled.sh ./compose.test ./pkg/compose
 tc_end_block "Run compose tests"

--- a/build/teamcity-go-test-precompiled.sh
+++ b/build/teamcity-go-test-precompiled.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script can be used as the `-exec` value of a `go test` invocation when
+# we have a precompiled pkg.test binary that we want to run through `go test`.
+# Usually the reason is wanting to use `go test -json` in a situation where
+# we are forced to operate outside of the builder image (for docker reasons).
+
+# Change from anywhere to repo root.
+cd "$(dirname $0)/.."
+
+actual=$1
+
+# Change to directory the test binary is in.
+# For example, ./pkg/acceptance/acceptance.test --> cd ./pkg/acceptance
+cd "$(dirname "${actual}")"
+
+# Throw path to script away.
+shift
+# Throw `go test`s binary away.
+shift
+
+# Following the example, invoke `./acceptance.test`.
+GOROOT=/home/agent/work/.go "./$(basename "$actual")" "$@"
+

--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -106,16 +106,6 @@ function run_json_test() {
   return $status
 }
 
-# Takes a package name and remaining args that produce `go test` text output
-# for the given package.
-function run_text_test() {
-  pkg=$1
-  shift
-  echo "# ${pkg}"
-  echo "$@"
-  "$@" 2>&1 | go tool test2json -t -p "${pkg}" | run_json_test cat
-}
-
 function maybe_stress() {
   # Don't stressrace on the release branches; we only want that to happen on the
   # PRs. There's no need in making master flakier than it needs to be; nightly

--- a/pkg/testutils/emptypkg/emptypkg.go
+++ b/pkg/testutils/emptypkg/emptypkg.go
@@ -1,0 +1,13 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package emptypkg is empty. This is useful as a workaround, see build/teamcity-acceptance.sh for
+// an example.
+package emptypkg

--- a/pkg/testutils/emptypkg/emptypkg_test.go
+++ b/pkg/testutils/emptypkg/emptypkg_test.go
@@ -1,0 +1,11 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package emptypkg


### PR DESCRIPTION
I figured out how to do this properly. Let's get rid of run_text_test.

Release note: None