### PR TITLE
vendor: bump pebble to 3b86a4009c3b

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -93,14 +93,14 @@ Run `go get -u <dependency>`. To get a specific version, run `go get -u <depende
 When updating a dependency, you should run `go mod tidy` after `go get` to ensure the old entries
 are removed from go.sum.
 
-You must then run `make -k vendor_rebuild` to ensure the modules are installed. These changes must
+You must then run `make vendor_rebuild` to ensure the modules are installed. These changes must
 then be committed in the submodule directory (see Working with Submodules).
 
 Programs can then be run using `go build -mod=vendor ...` or `go test -mod=vendor ...`.
 
 ### Removing a dependency
 
-When a dependency has been removed, run `go mod tidy` and then `make -k vendor_rebuild`. Then follow
+When a dependency has been removed, run `go mod tidy` and then `make vendor_rebuild`. Then follow
 the Working with Submodules steps below.
 
 ### Requiring a new tool
@@ -159,7 +159,7 @@ ref remains reachable and thus is never garbage collected.
 The canonical linearization of history is always the main repo. In the event
 of concurrent changes to `vendor`, the first should cause the second to see a
 conflict on the `vendor` submodule pointer. When resolving that conflict, it
-is important to re-run `go mod tidy `and `make -k vendor_rebuild`
+is important to re-run `go mod tidy `and `make vendor_rebuild`
 against the fetched, updated `vendor` ref, thus generating a new commit in
 the submodule that has as its parent the one from the earlier change.
 

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20200624214307-560ed0b8a18c
+	github.com/cockroachdb/pebble v0.0.0-20200626145914-3b86a4009c3b
 	github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2
@@ -149,7 +149,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20190115181402-5dab4167f31c
 	golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-	golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4
+	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae
 	golang.org/x/text v0.3.2
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	golang.org/x/tools v0.0.0-20200509030707-2212a7e161a5

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20200624214307-560ed0b8a18c h1:MQVYGjMEPj6TRGTi05ct75tDhbBKKFoJ0yKvvEZzIZw=
-github.com/cockroachdb/pebble v0.0.0-20200624214307-560ed0b8a18c/go.mod h1:crLnbSFbwAcQNs9FPfI1avHb5BqVgqZcr4r+IzpJ5FM=
+github.com/cockroachdb/pebble v0.0.0-20200626145914-3b86a4009c3b h1:b5RgMeYJLTpUIDQiqD2sVnH50coTiT2fWFAWzl8nH9c=
+github.com/cockroachdb/pebble v0.0.0-20200626145914-3b86a4009c3b/go.mod h1:crLnbSFbwAcQNs9FPfI1avHb5BqVgqZcr4r+IzpJ5FM=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3 h1:2+dpIJzYMSbLi0587YXpi8tOJT52qCOI/1I0UNThc/I=
 github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd h1:KFOt5I9nEKZgCnOSmy8r4Oykh8BYQO8bFOTgHDS8YZA=
@@ -713,8 +713,8 @@ golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 h1:DYfZAGf2WMFjMxbgTjaC+2HC7NkNAQs+6Q8b9WEB/F4=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4 h1:5/PjkGUjvEU5Gl6BxmvKRPpqo2uNMv4rcHBMwzk/st8=
-golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
+golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=


### PR DESCRIPTION
* sstable: don't skip over errored blocks during iteration
* db: avoid go1.14 unsafe pointer conversion violations
* db: refactor compaction startLevel, outputLevel
* db: allow multiple levels in CompactionInfo.Input

Release note (bug fix): Fix a bug where Pebble iteration would skip over 
blocks which failed checksum verification rather than propagating the error
to the caller.