### PR TITLE
colexec: introduce native type slice types

### DIFF
--- a/pkg/col/coldata/native_types.go
+++ b/pkg/col/coldata/native_types.go
@@ -1,0 +1,42 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package coldata
+
+import (
+	"time"
+
+	"github.com/cockroachdb/apd/v2"
+	"github.com/cockroachdb/cockroach/pkg/util/duration"
+)
+
+// Bools is a slice of bool.
+type Bools []bool
+
+// Int16s is a slice of int16.
+type Int16s []int16
+
+// Int32s is a slice of int32.
+type Int32s []int32
+
+// Int64s is a slice of int64.
+type Int64s []int64
+
+// Float64s is a slice of float64.
+type Float64s []float64
+
+// Decimals is a slice of apd.Decimal.
+type Decimals []apd.Decimal
+
+// Times is a slice of time.Time.
+type Times []time.Time
+
+// Durations is a slice of duration.Duration.
+type Durations []duration.Duration

--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -12,12 +12,9 @@ package coldata
 
 import (
 	"fmt"
-	"time"
 
-	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
 // Column is an interface that represents a raw array of a Go native type.
@@ -62,26 +59,24 @@ type Vec interface {
 	// this Vec.
 	CanonicalTypeFamily() types.Family
 
-	// TODO(jordan): is a bitmap or slice of bools better?
 	// Bool returns a bool list.
-	Bool() []bool
+	Bool() Bools
 	// Int16 returns an int16 slice.
-	Int16() []int16
+	Int16() Int16s
 	// Int32 returns an int32 slice.
-	Int32() []int32
+	Int32() Int32s
 	// Int64 returns an int64 slice.
-	Int64() []int64
+	Int64() Int64s
 	// Float64 returns a float64 slice.
-	Float64() []float64
+	Float64() Float64s
 	// Bytes returns a flat Bytes representation.
 	Bytes() *Bytes
-	// TODO(jordan): should this be [][]byte?
 	// Decimal returns an apd.Decimal slice.
-	Decimal() []apd.Decimal
+	Decimal() Decimals
 	// Timestamp returns a time.Time slice.
-	Timestamp() []time.Time
+	Timestamp() Times
 	// Interval returns a duration.Duration slice.
-	Interval() []duration.Duration
+	Interval() Durations
 	// Datum returns a vector of Datums.
 	Datum() DatumVec
 
@@ -166,28 +161,28 @@ var StandardColumnFactory ColumnFactory = &defaultColumnFactory{}
 func (cf *defaultColumnFactory) MakeColumn(t *types.T, n int) Column {
 	switch canonicalTypeFamily := typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()); canonicalTypeFamily {
 	case types.BoolFamily:
-		return make([]bool, n)
+		return make(Bools, n)
 	case types.BytesFamily:
 		return NewBytes(n)
 	case types.IntFamily:
 		switch t.Width() {
 		case 16:
-			return make([]int16, n)
+			return make(Int16s, n)
 		case 32:
-			return make([]int32, n)
+			return make(Int32s, n)
 		case 0, 64:
-			return make([]int64, n)
+			return make(Int64s, n)
 		default:
 			panic(fmt.Sprintf("unexpected integer width: %d", t.Width()))
 		}
 	case types.FloatFamily:
-		return make([]float64, n)
+		return make(Float64s, n)
 	case types.DecimalFamily:
-		return make([]apd.Decimal, n)
+		return make(Decimals, n)
 	case types.TimestampTZFamily:
-		return make([]time.Time, n)
+		return make(Times, n)
 	case types.IntervalFamily:
-		return make([]duration.Duration, n)
+		return make(Durations, n)
 	default:
 		panic(fmt.Sprintf("StandardColumnFactory doesn't support %s", t))
 	}
@@ -216,40 +211,40 @@ func (m *memColumn) SetCol(col interface{}) {
 	m.col = col
 }
 
-func (m *memColumn) Bool() []bool {
-	return m.col.([]bool)
+func (m *memColumn) Bool() Bools {
+	return m.col.(Bools)
 }
 
-func (m *memColumn) Int16() []int16 {
-	return m.col.([]int16)
+func (m *memColumn) Int16() Int16s {
+	return m.col.(Int16s)
 }
 
-func (m *memColumn) Int32() []int32 {
-	return m.col.([]int32)
+func (m *memColumn) Int32() Int32s {
+	return m.col.(Int32s)
 }
 
-func (m *memColumn) Int64() []int64 {
-	return m.col.([]int64)
+func (m *memColumn) Int64() Int64s {
+	return m.col.(Int64s)
 }
 
-func (m *memColumn) Float64() []float64 {
-	return m.col.([]float64)
+func (m *memColumn) Float64() Float64s {
+	return m.col.(Float64s)
 }
 
 func (m *memColumn) Bytes() *Bytes {
 	return m.col.(*Bytes)
 }
 
-func (m *memColumn) Decimal() []apd.Decimal {
-	return m.col.([]apd.Decimal)
+func (m *memColumn) Decimal() Decimals {
+	return m.col.(Decimals)
 }
 
-func (m *memColumn) Timestamp() []time.Time {
-	return m.col.([]time.Time)
+func (m *memColumn) Timestamp() Times {
+	return m.col.(Times)
 }
 
-func (m *memColumn) Interval() []duration.Duration {
-	return m.col.([]duration.Duration)
+func (m *memColumn) Interval() Durations {
+	return m.col.(Durations)
 }
 
 func (m *memColumn) Datum() DatumVec {
@@ -279,28 +274,28 @@ func (m *memColumn) SetNulls(n *Nulls) {
 func (m *memColumn) Length() int {
 	switch m.CanonicalTypeFamily() {
 	case types.BoolFamily:
-		return len(m.col.([]bool))
+		return len(m.col.(Bools))
 	case types.BytesFamily:
 		return m.Bytes().Len()
 	case types.IntFamily:
 		switch m.t.Width() {
 		case 16:
-			return len(m.col.([]int16))
+			return len(m.col.(Int16s))
 		case 32:
-			return len(m.col.([]int32))
+			return len(m.col.(Int32s))
 		case 0, 64:
-			return len(m.col.([]int64))
+			return len(m.col.(Int64s))
 		default:
 			panic(fmt.Sprintf("unexpected int width: %d", m.t.Width()))
 		}
 	case types.FloatFamily:
-		return len(m.col.([]float64))
+		return len(m.col.(Float64s))
 	case types.DecimalFamily:
-		return len(m.col.([]apd.Decimal))
+		return len(m.col.(Decimals))
 	case types.TimestampTZFamily:
-		return len(m.col.([]time.Time))
+		return len(m.col.(Times))
 	case types.IntervalFamily:
-		return len(m.col.([]duration.Duration))
+		return len(m.col.(Durations))
 	case typeconv.DatumVecCanonicalTypeFamily:
 		return m.col.(DatumVec).Len()
 	default:
@@ -311,28 +306,28 @@ func (m *memColumn) Length() int {
 func (m *memColumn) SetLength(l int) {
 	switch m.CanonicalTypeFamily() {
 	case types.BoolFamily:
-		m.col = m.col.([]bool)[:l]
+		m.col = m.col.(Bools)[:l]
 	case types.BytesFamily:
 		m.Bytes().SetLength(l)
 	case types.IntFamily:
 		switch m.t.Width() {
 		case 16:
-			m.col = m.col.([]int16)[:l]
+			m.col = m.col.(Int16s)[:l]
 		case 32:
-			m.col = m.col.([]int32)[:l]
+			m.col = m.col.(Int32s)[:l]
 		case 0, 64:
-			m.col = m.col.([]int64)[:l]
+			m.col = m.col.(Int64s)[:l]
 		default:
 			panic(fmt.Sprintf("unexpected int width: %d", m.t.Width()))
 		}
 	case types.FloatFamily:
-		m.col = m.col.([]float64)[:l]
+		m.col = m.col.(Float64s)[:l]
 	case types.DecimalFamily:
-		m.col = m.col.([]apd.Decimal)[:l]
+		m.col = m.col.(Decimals)[:l]
 	case types.TimestampTZFamily:
-		m.col = m.col.([]time.Time)[:l]
+		m.col = m.col.(Times)[:l]
 	case types.IntervalFamily:
-		m.col = m.col.([]duration.Duration)[:l]
+		m.col = m.col.(Durations)[:l]
 	case typeconv.DatumVecCanonicalTypeFamily:
 		m.col.(DatumVec).SetLength(l)
 	default:
@@ -343,28 +338,28 @@ func (m *memColumn) SetLength(l int) {
 func (m *memColumn) Capacity() int {
 	switch m.CanonicalTypeFamily() {
 	case types.BoolFamily:
-		return cap(m.col.([]bool))
+		return cap(m.col.(Bools))
 	case types.BytesFamily:
 		panic("Capacity should not be called on Vec of Bytes type")
 	case types.IntFamily:
 		switch m.t.Width() {
 		case 16:
-			return cap(m.col.([]int16))
+			return cap(m.col.(Int16s))
 		case 32:
-			return cap(m.col.([]int32))
+			return cap(m.col.(Int32s))
 		case 0, 64:
-			return cap(m.col.([]int64))
+			return cap(m.col.(Int64s))
 		default:
 			panic(fmt.Sprintf("unexpected int width: %d", m.t.Width()))
 		}
 	case types.FloatFamily:
-		return cap(m.col.([]float64))
+		return cap(m.col.(Float64s))
 	case types.DecimalFamily:
-		return cap(m.col.([]apd.Decimal))
+		return cap(m.col.(Decimals))
 	case types.TimestampTZFamily:
-		return cap(m.col.([]time.Time))
+		return cap(m.col.(Times))
 	case types.IntervalFamily:
-		return cap(m.col.([]duration.Duration))
+		return cap(m.col.(Durations))
 	case typeconv.DatumVecCanonicalTypeFamily:
 		return m.col.(DatumVec).Cap()
 	default:

--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -366,22 +366,22 @@ func (c *ArrowBatchConverter) ArrowToBatch(data []*array.Data, b coldata.Batch) 
 				switch typ.Width() {
 				case 16:
 					intArr := array.NewInt16Data(d)
-					col = intArr.Int16Values()
+					col = coldata.Int16s(intArr.Int16Values())
 					arr = intArr
 				case 32:
 					intArr := array.NewInt32Data(d)
-					col = intArr.Int32Values()
+					col = coldata.Int32s(intArr.Int32Values())
 					arr = intArr
 				case 0, 64:
 					intArr := array.NewInt64Data(d)
-					col = intArr.Int64Values()
+					col = coldata.Int64s(intArr.Int64Values())
 					arr = intArr
 				default:
 					panic(fmt.Sprintf("unexpected int width: %d", typ.Width()))
 				}
 			case types.FloatFamily:
 				floatArr := array.NewFloat64Data(d)
-				col = floatArr.Float64Values()
+				col = coldata.Float64s(floatArr.Float64Values())
 				arr = floatArr
 			default:
 				panic(

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
@@ -414,26 +414,36 @@ func (o *lastArgWidthOverload) UnaryAssign(targetElem, vElem, targetCol, vVec st
 
 func goTypeSliceName(canonicalTypeFamily types.Family, width int32) string {
 	switch canonicalTypeFamily {
+	case types.BoolFamily:
+		return "coldata.Bools"
 	case types.BytesFamily:
 		return "*coldata.Bytes"
+	case types.DecimalFamily:
+		return "coldata.Decimals"
 	case types.IntFamily:
 		switch width {
 		case 16:
-			return "[]int16"
+			return "coldata.Int16s"
 		case 32:
-			return "[]int32"
+			return "coldata.Int32s"
 		case 64, anyWidth:
-			return "[]int64"
+			return "coldata.Int64s"
 		default:
 			colexecerror.InternalError(fmt.Sprintf("unexpected int width %d", width))
 			// This code is unreachable, but the compiler cannot infer that.
 			return ""
 		}
+	case types.IntervalFamily:
+		return "coldata.Durations"
+	case types.FloatFamily:
+		return "coldata.Float64s"
+	case types.TimestampTZFamily:
+		return "coldata.Times"
 	case typeconv.DatumVecCanonicalTypeFamily:
 		return "coldata.DatumVec"
-	default:
-		return "[]" + toPhysicalRepresentation(canonicalTypeFamily, width)
 	}
+	colexecerror.InternalError(fmt.Sprintf("unsupported canonical type family %s", canonicalTypeFamily))
+	return ""
 }
 
 func (b *argWidthOverloadBase) GoTypeSliceName() string {

--- a/pkg/sql/colexec/hash_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/hash_any_not_null_agg.eg.go
@@ -88,7 +88,7 @@ func newAnyNotNullHashAggAlloc(
 type anyNotNullBoolHashAgg struct {
 	allocator                   *colmem.Allocator
 	vec                         coldata.Vec
-	col                         []bool
+	col                         coldata.Bools
 	nulls                       *coldata.Nulls
 	curIdx                      int
 	curAgg                      bool
@@ -432,7 +432,7 @@ func (a *anyNotNullBytesHashAggAlloc) newAggFunc() aggregateFunc {
 type anyNotNullDecimalHashAgg struct {
 	allocator                   *colmem.Allocator
 	vec                         coldata.Vec
-	col                         []apd.Decimal
+	col                         coldata.Decimals
 	nulls                       *coldata.Nulls
 	curIdx                      int
 	curAgg                      apd.Decimal
@@ -604,7 +604,7 @@ func (a *anyNotNullDecimalHashAggAlloc) newAggFunc() aggregateFunc {
 type anyNotNullInt16HashAgg struct {
 	allocator                   *colmem.Allocator
 	vec                         coldata.Vec
-	col                         []int16
+	col                         coldata.Int16s
 	nulls                       *coldata.Nulls
 	curIdx                      int
 	curAgg                      int16
@@ -776,7 +776,7 @@ func (a *anyNotNullInt16HashAggAlloc) newAggFunc() aggregateFunc {
 type anyNotNullInt32HashAgg struct {
 	allocator                   *colmem.Allocator
 	vec                         coldata.Vec
-	col                         []int32
+	col                         coldata.Int32s
 	nulls                       *coldata.Nulls
 	curIdx                      int
 	curAgg                      int32
@@ -948,7 +948,7 @@ func (a *anyNotNullInt32HashAggAlloc) newAggFunc() aggregateFunc {
 type anyNotNullInt64HashAgg struct {
 	allocator                   *colmem.Allocator
 	vec                         coldata.Vec
-	col                         []int64
+	col                         coldata.Int64s
 	nulls                       *coldata.Nulls
 	curIdx                      int
 	curAgg                      int64
@@ -1120,7 +1120,7 @@ func (a *anyNotNullInt64HashAggAlloc) newAggFunc() aggregateFunc {
 type anyNotNullFloat64HashAgg struct {
 	allocator                   *colmem.Allocator
 	vec                         coldata.Vec
-	col                         []float64
+	col                         coldata.Float64s
 	nulls                       *coldata.Nulls
 	curIdx                      int
 	curAgg                      float64
@@ -1292,7 +1292,7 @@ func (a *anyNotNullFloat64HashAggAlloc) newAggFunc() aggregateFunc {
 type anyNotNullTimestampHashAgg struct {
 	allocator                   *colmem.Allocator
 	vec                         coldata.Vec
-	col                         []time.Time
+	col                         coldata.Times
 	nulls                       *coldata.Nulls
 	curIdx                      int
 	curAgg                      time.Time
@@ -1464,7 +1464,7 @@ func (a *anyNotNullTimestampHashAggAlloc) newAggFunc() aggregateFunc {
 type anyNotNullIntervalHashAgg struct {
 	allocator                   *colmem.Allocator
 	vec                         coldata.Vec
-	col                         []duration.Duration
+	col                         coldata.Durations
 	nulls                       *coldata.Nulls
 	curIdx                      int
 	curAgg                      duration.Duration

--- a/pkg/sql/colexec/hash_min_max_agg.eg.go
+++ b/pkg/sql/colexec/hash_min_max_agg.eg.go
@@ -99,7 +99,7 @@ type minBoolHashAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg bool
 	// col points to the output vector we are updating.
-	col []bool
+	col coldata.Bools
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -537,7 +537,7 @@ type minDecimalHashAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg apd.Decimal
 	// col points to the output vector we are updating.
-	col []apd.Decimal
+	col coldata.Decimals
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -738,7 +738,7 @@ type minInt16HashAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -983,7 +983,7 @@ type minInt32HashAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -1228,7 +1228,7 @@ type minInt64HashAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -1473,7 +1473,7 @@ type minFloat64HashAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg float64
 	// col points to the output vector we are updating.
-	col []float64
+	col coldata.Float64s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -1750,7 +1750,7 @@ type minTimestampHashAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg time.Time
 	// col points to the output vector we are updating.
-	col []time.Time
+	col coldata.Times
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -1979,7 +1979,7 @@ type minIntervalHashAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg duration.Duration
 	// col points to the output vector we are updating.
-	col []duration.Duration
+	col coldata.Durations
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -2389,7 +2389,7 @@ type maxBoolHashAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg bool
 	// col points to the output vector we are updating.
-	col []bool
+	col coldata.Bools
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -2827,7 +2827,7 @@ type maxDecimalHashAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg apd.Decimal
 	// col points to the output vector we are updating.
-	col []apd.Decimal
+	col coldata.Decimals
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -3028,7 +3028,7 @@ type maxInt16HashAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -3273,7 +3273,7 @@ type maxInt32HashAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -3518,7 +3518,7 @@ type maxInt64HashAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -3763,7 +3763,7 @@ type maxFloat64HashAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg float64
 	// col points to the output vector we are updating.
-	col []float64
+	col coldata.Float64s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -4040,7 +4040,7 @@ type maxTimestampHashAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg time.Time
 	// col points to the output vector we are updating.
-	col []time.Time
+	col coldata.Times
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -4269,7 +4269,7 @@ type maxIntervalHashAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg duration.Duration
 	// col points to the output vector we are updating.
-	col []duration.Duration
+	col coldata.Durations
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.

--- a/pkg/sql/colexec/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/mergejoiner_exceptall.eg.go
@@ -35773,7 +35773,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -35903,7 +35903,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -35967,7 +35967,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -36028,7 +36028,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -36090,7 +36090,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -36155,7 +36155,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -36220,7 +36220,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -36285,7 +36285,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -36421,7 +36421,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -36545,7 +36545,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -36606,7 +36606,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -36664,7 +36664,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -36723,7 +36723,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -36785,7 +36785,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -36847,7 +36847,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -36909,7 +36909,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -37041,7 +37041,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -37169,7 +37169,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -37232,7 +37232,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -37292,7 +37292,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -37353,7 +37353,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -37417,7 +37417,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -37481,7 +37481,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -37545,7 +37545,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -37679,7 +37679,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -37801,7 +37801,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -37861,7 +37861,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -37918,7 +37918,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -37976,7 +37976,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -38037,7 +38037,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -38098,7 +38098,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -38159,7 +38159,7 @@ func (o *mergeJoinExceptAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -39050,7 +39050,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -39186,7 +39186,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -39253,7 +39253,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -39317,7 +39317,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -39382,7 +39382,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -39450,7 +39450,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -39518,7 +39518,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -39586,7 +39586,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -39728,7 +39728,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -39860,7 +39860,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -39925,7 +39925,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -39987,7 +39987,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -40050,7 +40050,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -40116,7 +40116,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -40182,7 +40182,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -40248,7 +40248,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -40388,7 +40388,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -40524,7 +40524,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -40591,7 +40591,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -40655,7 +40655,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -40720,7 +40720,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -40788,7 +40788,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -40856,7 +40856,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -40924,7 +40924,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -41066,7 +41066,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -41198,7 +41198,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -41263,7 +41263,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -41325,7 +41325,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -41388,7 +41388,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -41454,7 +41454,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -41520,7 +41520,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -41586,7 +41586,7 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}

--- a/pkg/sql/colexec/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/mergejoiner_fullouter.eg.go
@@ -41957,7 +41957,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -42087,7 +42087,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -42151,7 +42151,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -42212,7 +42212,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -42274,7 +42274,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -42339,7 +42339,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -42404,7 +42404,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -42469,7 +42469,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -42605,7 +42605,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -42729,7 +42729,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -42790,7 +42790,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -42848,7 +42848,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -42907,7 +42907,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -42969,7 +42969,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -43031,7 +43031,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -43093,7 +43093,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -43225,7 +43225,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -43353,7 +43353,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -43416,7 +43416,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -43476,7 +43476,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -43537,7 +43537,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -43601,7 +43601,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -43665,7 +43665,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -43729,7 +43729,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -43863,7 +43863,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -43985,7 +43985,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -44045,7 +44045,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -44102,7 +44102,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -44160,7 +44160,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -44221,7 +44221,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -44282,7 +44282,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -44343,7 +44343,7 @@ func (o *mergeJoinFullOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -45084,7 +45084,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -45224,7 +45224,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -45293,7 +45293,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -45359,7 +45359,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -45426,7 +45426,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -45496,7 +45496,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -45566,7 +45566,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -45636,7 +45636,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -45782,7 +45782,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -45918,7 +45918,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -45985,7 +45985,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -46049,7 +46049,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -46114,7 +46114,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -46182,7 +46182,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -46250,7 +46250,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -46318,7 +46318,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -46462,7 +46462,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -46602,7 +46602,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -46671,7 +46671,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -46737,7 +46737,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -46804,7 +46804,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -46874,7 +46874,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -46944,7 +46944,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -47014,7 +47014,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -47160,7 +47160,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -47296,7 +47296,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -47363,7 +47363,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -47427,7 +47427,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -47492,7 +47492,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -47560,7 +47560,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -47628,7 +47628,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -47696,7 +47696,7 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}

--- a/pkg/sql/colexec/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/mergejoiner_inner.eg.go
@@ -26309,7 +26309,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -26433,7 +26433,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -26494,7 +26494,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -26552,7 +26552,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -26611,7 +26611,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -26673,7 +26673,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -26735,7 +26735,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -26797,7 +26797,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -26927,7 +26927,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -27045,7 +27045,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -27103,7 +27103,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -27158,7 +27158,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -27214,7 +27214,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -27273,7 +27273,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -27332,7 +27332,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -27391,7 +27391,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -27517,7 +27517,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -27639,7 +27639,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -27699,7 +27699,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -27756,7 +27756,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -27814,7 +27814,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -27875,7 +27875,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -27936,7 +27936,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -27997,7 +27997,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -28125,7 +28125,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -28241,7 +28241,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -28298,7 +28298,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -28352,7 +28352,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -28407,7 +28407,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -28465,7 +28465,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -28523,7 +28523,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -28581,7 +28581,7 @@ func (o *mergeJoinInnerOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -29316,7 +29316,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -29452,7 +29452,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -29519,7 +29519,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -29583,7 +29583,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -29648,7 +29648,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -29716,7 +29716,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -29784,7 +29784,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -29852,7 +29852,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -29994,7 +29994,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -30126,7 +30126,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -30191,7 +30191,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -30253,7 +30253,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -30316,7 +30316,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -30382,7 +30382,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -30448,7 +30448,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -30514,7 +30514,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -30654,7 +30654,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -30790,7 +30790,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -30857,7 +30857,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -30921,7 +30921,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -30986,7 +30986,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -31054,7 +31054,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -31122,7 +31122,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -31190,7 +31190,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -31332,7 +31332,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -31464,7 +31464,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -31529,7 +31529,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -31591,7 +31591,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -31654,7 +31654,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -31720,7 +31720,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -31786,7 +31786,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -31852,7 +31852,7 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}

--- a/pkg/sql/colexec/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/mergejoiner_intersectall.eg.go
@@ -27309,7 +27309,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -27433,7 +27433,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -27494,7 +27494,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -27552,7 +27552,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -27611,7 +27611,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -27673,7 +27673,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -27735,7 +27735,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -27797,7 +27797,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -27927,7 +27927,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -28045,7 +28045,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -28103,7 +28103,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -28158,7 +28158,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -28214,7 +28214,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -28273,7 +28273,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -28332,7 +28332,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -28391,7 +28391,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -28517,7 +28517,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -28639,7 +28639,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -28699,7 +28699,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -28756,7 +28756,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -28814,7 +28814,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -28875,7 +28875,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -28936,7 +28936,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -28997,7 +28997,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -29125,7 +29125,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -29241,7 +29241,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -29298,7 +29298,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -29352,7 +29352,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -29407,7 +29407,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -29465,7 +29465,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -29523,7 +29523,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -29581,7 +29581,7 @@ func (o *mergeJoinIntersectAllOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -30466,7 +30466,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -30602,7 +30602,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -30669,7 +30669,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -30733,7 +30733,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -30798,7 +30798,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -30866,7 +30866,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -30934,7 +30934,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -31002,7 +31002,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -31144,7 +31144,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -31276,7 +31276,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -31341,7 +31341,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -31403,7 +31403,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -31466,7 +31466,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -31532,7 +31532,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -31598,7 +31598,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -31664,7 +31664,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -31804,7 +31804,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -31940,7 +31940,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -32007,7 +32007,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -32071,7 +32071,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -32136,7 +32136,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -32204,7 +32204,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -32272,7 +32272,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -32340,7 +32340,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -32482,7 +32482,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -32614,7 +32614,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -32679,7 +32679,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -32741,7 +32741,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -32804,7 +32804,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -32870,7 +32870,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -32936,7 +32936,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -33002,7 +33002,7 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}

--- a/pkg/sql/colexec/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/mergejoiner_leftanti.eg.go
@@ -34133,7 +34133,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -34263,7 +34263,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -34327,7 +34327,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -34388,7 +34388,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -34450,7 +34450,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -34515,7 +34515,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -34580,7 +34580,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -34645,7 +34645,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -34781,7 +34781,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -34905,7 +34905,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -34966,7 +34966,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -35024,7 +35024,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -35083,7 +35083,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -35145,7 +35145,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -35207,7 +35207,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -35269,7 +35269,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -35401,7 +35401,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -35529,7 +35529,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -35592,7 +35592,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -35652,7 +35652,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -35713,7 +35713,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -35777,7 +35777,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -35841,7 +35841,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -35905,7 +35905,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -36039,7 +36039,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -36161,7 +36161,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -36221,7 +36221,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -36278,7 +36278,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -36336,7 +36336,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -36397,7 +36397,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -36458,7 +36458,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -36519,7 +36519,7 @@ func (o *mergeJoinLeftAntiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -37260,7 +37260,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -37396,7 +37396,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -37463,7 +37463,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -37527,7 +37527,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -37592,7 +37592,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -37660,7 +37660,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -37728,7 +37728,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -37796,7 +37796,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -37938,7 +37938,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -38070,7 +38070,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -38135,7 +38135,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -38197,7 +38197,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -38260,7 +38260,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -38326,7 +38326,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -38392,7 +38392,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -38458,7 +38458,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -38598,7 +38598,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -38734,7 +38734,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -38801,7 +38801,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -38865,7 +38865,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -38930,7 +38930,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -38998,7 +38998,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -39066,7 +39066,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -39134,7 +39134,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -39276,7 +39276,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -39408,7 +39408,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -39473,7 +39473,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -39535,7 +39535,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -39598,7 +39598,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -39664,7 +39664,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -39730,7 +39730,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -39796,7 +39796,7 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}

--- a/pkg/sql/colexec/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/mergejoiner_leftouter.eg.go
@@ -34293,7 +34293,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -34417,7 +34417,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -34478,7 +34478,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -34536,7 +34536,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -34595,7 +34595,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -34657,7 +34657,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -34719,7 +34719,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -34781,7 +34781,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -34911,7 +34911,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -35029,7 +35029,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -35087,7 +35087,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -35142,7 +35142,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -35198,7 +35198,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -35257,7 +35257,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -35316,7 +35316,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -35375,7 +35375,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -35501,7 +35501,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -35623,7 +35623,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -35683,7 +35683,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -35740,7 +35740,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -35798,7 +35798,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -35859,7 +35859,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -35920,7 +35920,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -35981,7 +35981,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -36109,7 +36109,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -36225,7 +36225,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -36282,7 +36282,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -36336,7 +36336,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -36391,7 +36391,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -36449,7 +36449,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -36507,7 +36507,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -36565,7 +36565,7 @@ func (o *mergeJoinLeftOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -37300,7 +37300,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -37440,7 +37440,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -37509,7 +37509,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -37575,7 +37575,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -37642,7 +37642,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -37712,7 +37712,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -37782,7 +37782,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -37852,7 +37852,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -37998,7 +37998,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -38134,7 +38134,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -38201,7 +38201,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -38265,7 +38265,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -38330,7 +38330,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -38398,7 +38398,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -38466,7 +38466,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -38534,7 +38534,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -38678,7 +38678,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -38818,7 +38818,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -38887,7 +38887,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -38953,7 +38953,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -39020,7 +39020,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -39090,7 +39090,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -39160,7 +39160,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -39230,7 +39230,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -39376,7 +39376,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -39512,7 +39512,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -39579,7 +39579,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -39643,7 +39643,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -39708,7 +39708,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -39776,7 +39776,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -39844,7 +39844,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -39912,7 +39912,7 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}

--- a/pkg/sql/colexec/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/mergejoiner_leftsemi.eg.go
@@ -26149,7 +26149,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -26273,7 +26273,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -26334,7 +26334,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -26392,7 +26392,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -26451,7 +26451,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -26513,7 +26513,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -26575,7 +26575,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -26637,7 +26637,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -26767,7 +26767,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -26885,7 +26885,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -26943,7 +26943,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -26998,7 +26998,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -27054,7 +27054,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -27113,7 +27113,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -27172,7 +27172,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -27231,7 +27231,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -27357,7 +27357,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -27479,7 +27479,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -27539,7 +27539,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -27596,7 +27596,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -27654,7 +27654,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -27715,7 +27715,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -27776,7 +27776,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -27837,7 +27837,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -27965,7 +27965,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -28081,7 +28081,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -28138,7 +28138,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -28192,7 +28192,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -28247,7 +28247,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -28305,7 +28305,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -28363,7 +28363,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -28421,7 +28421,7 @@ func (o *mergeJoinLeftSemiOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -29156,7 +29156,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -29292,7 +29292,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -29359,7 +29359,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -29423,7 +29423,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -29488,7 +29488,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -29556,7 +29556,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -29624,7 +29624,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -29692,7 +29692,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -29834,7 +29834,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -29966,7 +29966,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -30031,7 +30031,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -30093,7 +30093,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -30156,7 +30156,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -30222,7 +30222,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -30288,7 +30288,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -30354,7 +30354,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -30494,7 +30494,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -30630,7 +30630,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -30697,7 +30697,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -30761,7 +30761,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -30826,7 +30826,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -30894,7 +30894,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -30962,7 +30962,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -31030,7 +31030,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -31172,7 +31172,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -31304,7 +31304,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -31369,7 +31369,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -31431,7 +31431,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -31494,7 +31494,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -31560,7 +31560,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -31626,7 +31626,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -31692,7 +31692,7 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}

--- a/pkg/sql/colexec/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/mergejoiner_rightouter.eg.go
@@ -33973,7 +33973,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -34103,7 +34103,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -34167,7 +34167,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -34228,7 +34228,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -34290,7 +34290,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -34355,7 +34355,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -34420,7 +34420,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -34485,7 +34485,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -34621,7 +34621,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -34745,7 +34745,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -34806,7 +34806,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -34864,7 +34864,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -34923,7 +34923,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -34985,7 +34985,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -35047,7 +35047,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -35109,7 +35109,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -35241,7 +35241,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -35369,7 +35369,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -35432,7 +35432,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -35492,7 +35492,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -35553,7 +35553,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -35617,7 +35617,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -35681,7 +35681,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -35745,7 +35745,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -35879,7 +35879,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -36001,7 +36001,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -36061,7 +36061,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -36118,7 +36118,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 								}
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -36176,7 +36176,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 								o.builderState.left.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -36237,7 +36237,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -36298,7 +36298,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -36359,7 +36359,7 @@ func (o *mergeJoinRightOuterOp) buildLeftGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -37100,7 +37100,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -37236,7 +37236,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -37303,7 +37303,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -37367,7 +37367,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -37432,7 +37432,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -37500,7 +37500,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -37568,7 +37568,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -37636,7 +37636,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -37778,7 +37778,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -37910,7 +37910,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -37975,7 +37975,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -38037,7 +38037,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -38100,7 +38100,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -38166,7 +38166,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -38232,7 +38232,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -38298,7 +38298,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -38438,7 +38438,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -38574,7 +38574,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -38641,7 +38641,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -38705,7 +38705,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -38770,7 +38770,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -38838,7 +38838,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -38906,7 +38906,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -38974,7 +38974,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}
@@ -39116,7 +39116,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []bool
+								var srcCol coldata.Bools
 								if src != nil {
 									srcCol = src.Bool()
 								}
@@ -39248,7 +39248,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []apd.Decimal
+								var srcCol coldata.Decimals
 								if src != nil {
 									srcCol = src.Decimal()
 								}
@@ -39313,7 +39313,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 						case types.IntFamily:
 							switch input.sourceTypes[colIdx].Width() {
 							case 16:
-								var srcCol []int16
+								var srcCol coldata.Int16s
 								if src != nil {
 									srcCol = src.Int16()
 								}
@@ -39375,7 +39375,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 								}
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case 32:
-								var srcCol []int32
+								var srcCol coldata.Int32s
 								if src != nil {
 									srcCol = src.Int32()
 								}
@@ -39438,7 +39438,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 								o.builderState.right.groupsIdx = zeroMJCPGroupsIdx
 							case -1:
 							default:
-								var srcCol []int64
+								var srcCol coldata.Int64s
 								if src != nil {
 									srcCol = src.Int64()
 								}
@@ -39504,7 +39504,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []float64
+								var srcCol coldata.Float64s
 								if src != nil {
 									srcCol = src.Float64()
 								}
@@ -39570,7 +39570,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []time.Time
+								var srcCol coldata.Times
 								if src != nil {
 									srcCol = src.Timestamp()
 								}
@@ -39636,7 +39636,7 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 							switch input.sourceTypes[colIdx].Width() {
 							case -1:
 							default:
-								var srcCol []duration.Duration
+								var srcCol coldata.Durations
 								if src != nil {
 									srcCol = src.Interval()
 								}

--- a/pkg/sql/colexec/ordered_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/ordered_any_not_null_agg.eg.go
@@ -89,7 +89,7 @@ type anyNotNullBoolOrderedAgg struct {
 	allocator                   *colmem.Allocator
 	groups                      []bool
 	vec                         coldata.Vec
-	col                         []bool
+	col                         coldata.Bools
 	nulls                       *coldata.Nulls
 	curIdx                      int
 	curAgg                      bool
@@ -487,7 +487,7 @@ type anyNotNullDecimalOrderedAgg struct {
 	allocator                   *colmem.Allocator
 	groups                      []bool
 	vec                         coldata.Vec
-	col                         []apd.Decimal
+	col                         coldata.Decimals
 	nulls                       *coldata.Nulls
 	curIdx                      int
 	curAgg                      apd.Decimal
@@ -686,7 +686,7 @@ type anyNotNullInt16OrderedAgg struct {
 	allocator                   *colmem.Allocator
 	groups                      []bool
 	vec                         coldata.Vec
-	col                         []int16
+	col                         coldata.Int16s
 	nulls                       *coldata.Nulls
 	curIdx                      int
 	curAgg                      int16
@@ -885,7 +885,7 @@ type anyNotNullInt32OrderedAgg struct {
 	allocator                   *colmem.Allocator
 	groups                      []bool
 	vec                         coldata.Vec
-	col                         []int32
+	col                         coldata.Int32s
 	nulls                       *coldata.Nulls
 	curIdx                      int
 	curAgg                      int32
@@ -1084,7 +1084,7 @@ type anyNotNullInt64OrderedAgg struct {
 	allocator                   *colmem.Allocator
 	groups                      []bool
 	vec                         coldata.Vec
-	col                         []int64
+	col                         coldata.Int64s
 	nulls                       *coldata.Nulls
 	curIdx                      int
 	curAgg                      int64
@@ -1283,7 +1283,7 @@ type anyNotNullFloat64OrderedAgg struct {
 	allocator                   *colmem.Allocator
 	groups                      []bool
 	vec                         coldata.Vec
-	col                         []float64
+	col                         coldata.Float64s
 	nulls                       *coldata.Nulls
 	curIdx                      int
 	curAgg                      float64
@@ -1482,7 +1482,7 @@ type anyNotNullTimestampOrderedAgg struct {
 	allocator                   *colmem.Allocator
 	groups                      []bool
 	vec                         coldata.Vec
-	col                         []time.Time
+	col                         coldata.Times
 	nulls                       *coldata.Nulls
 	curIdx                      int
 	curAgg                      time.Time
@@ -1681,7 +1681,7 @@ type anyNotNullIntervalOrderedAgg struct {
 	allocator                   *colmem.Allocator
 	groups                      []bool
 	vec                         coldata.Vec
-	col                         []duration.Duration
+	col                         coldata.Durations
 	nulls                       *coldata.Nulls
 	curIdx                      int
 	curAgg                      duration.Duration

--- a/pkg/sql/colexec/ordered_min_max_agg.eg.go
+++ b/pkg/sql/colexec/ordered_min_max_agg.eg.go
@@ -100,7 +100,7 @@ type minBoolOrderedAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg bool
 	// col points to the output vector we are updating.
-	col []bool
+	col coldata.Bools
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -638,7 +638,7 @@ type minDecimalOrderedAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg apd.Decimal
 	// col points to the output vector we are updating.
-	col []apd.Decimal
+	col coldata.Decimals
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -889,7 +889,7 @@ type minInt16OrderedAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -1184,7 +1184,7 @@ type minInt32OrderedAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -1479,7 +1479,7 @@ type minInt64OrderedAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -1774,7 +1774,7 @@ type minFloat64OrderedAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg float64
 	// col points to the output vector we are updating.
-	col []float64
+	col coldata.Float64s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -2101,7 +2101,7 @@ type minTimestampOrderedAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg time.Time
 	// col points to the output vector we are updating.
-	col []time.Time
+	col coldata.Times
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -2380,7 +2380,7 @@ type minIntervalOrderedAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg duration.Duration
 	// col points to the output vector we are updating.
-	col []duration.Duration
+	col coldata.Durations
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -2890,7 +2890,7 @@ type maxBoolOrderedAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg bool
 	// col points to the output vector we are updating.
-	col []bool
+	col coldata.Bools
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -3428,7 +3428,7 @@ type maxDecimalOrderedAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg apd.Decimal
 	// col points to the output vector we are updating.
-	col []apd.Decimal
+	col coldata.Decimals
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -3679,7 +3679,7 @@ type maxInt16OrderedAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -3974,7 +3974,7 @@ type maxInt32OrderedAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -4269,7 +4269,7 @@ type maxInt64OrderedAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -4564,7 +4564,7 @@ type maxFloat64OrderedAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg float64
 	// col points to the output vector we are updating.
-	col []float64
+	col coldata.Float64s
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -4891,7 +4891,7 @@ type maxTimestampOrderedAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg time.Time
 	// col points to the output vector we are updating.
-	col []time.Time
+	col coldata.Times
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.
@@ -5170,7 +5170,7 @@ type maxIntervalOrderedAgg struct {
 	// NOTE: if foundNonNullForCurrentGroup is false, curAgg is undefined.
 	curAgg duration.Duration
 	// col points to the output vector we are updating.
-	col []duration.Duration
+	col coldata.Durations
 	// vec is the same as col before conversion from coldata.Vec.
 	vec coldata.Vec
 	// nulls points to the output null vector that we are updating.

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -13,9 +13,7 @@ import (
 	"container/heap"
 	"context"
 	"fmt"
-	"time"
 
-	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
@@ -25,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 )
 
@@ -54,15 +51,15 @@ type OrderedSynchronizer struct {
 	outNulls    []*coldata.Nulls
 	// In order to reduce the number of interface conversions, we will get access
 	// to the underlying slice for the output vectors and will use them directly.
-	outBoolCols      [][]bool
+	outBoolCols      []coldata.Bools
 	outBytesCols     []*coldata.Bytes
-	outDecimalCols   [][]apd.Decimal
-	outInt16Cols     [][]int16
-	outInt32Cols     [][]int32
-	outInt64Cols     [][]int64
-	outFloat64Cols   [][]float64
-	outTimestampCols [][]time.Time
-	outIntervalCols  [][]duration.Duration
+	outDecimalCols   []coldata.Decimals
+	outInt16Cols     []coldata.Int16s
+	outInt32Cols     []coldata.Int32s
+	outInt64Cols     []coldata.Int64s
+	outFloat64Cols   []coldata.Float64s
+	outTimestampCols []coldata.Times
+	outIntervalCols  []coldata.Durations
 	outDatumCols     []coldata.DatumVec
 	// outColsMap contains the positions of the corresponding vectors in the
 	// slice for the same types. For example, if we have an output batch with

--- a/pkg/sql/colexec/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/proj_const_left_ops.eg.go
@@ -48,7 +48,7 @@ func (p projBitandInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -133,7 +133,7 @@ func (p projBitandInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -218,7 +218,7 @@ func (p projBitandInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -303,7 +303,7 @@ func (p projBitandInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -388,7 +388,7 @@ func (p projBitandInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -473,7 +473,7 @@ func (p projBitandInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -558,7 +558,7 @@ func (p projBitandInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -643,7 +643,7 @@ func (p projBitandInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -728,7 +728,7 @@ func (p projBitandInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -914,7 +914,7 @@ func (p projBitorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -999,7 +999,7 @@ func (p projBitorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1084,7 +1084,7 @@ func (p projBitorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1169,7 +1169,7 @@ func (p projBitorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1254,7 +1254,7 @@ func (p projBitorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1339,7 +1339,7 @@ func (p projBitorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1424,7 +1424,7 @@ func (p projBitorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1509,7 +1509,7 @@ func (p projBitorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1594,7 +1594,7 @@ func (p projBitorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1780,7 +1780,7 @@ func (p projBitxorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1865,7 +1865,7 @@ func (p projBitxorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1950,7 +1950,7 @@ func (p projBitxorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2035,7 +2035,7 @@ func (p projBitxorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2120,7 +2120,7 @@ func (p projBitxorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2205,7 +2205,7 @@ func (p projBitxorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2290,7 +2290,7 @@ func (p projBitxorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2375,7 +2375,7 @@ func (p projBitxorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2460,7 +2460,7 @@ func (p projBitxorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2646,7 +2646,7 @@ func (p projPlusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2759,7 +2759,7 @@ func (p projPlusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2872,7 +2872,7 @@ func (p projPlusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2985,7 +2985,7 @@ func (p projPlusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -3094,7 +3094,7 @@ func (p projPlusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -3203,7 +3203,7 @@ func (p projPlusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -3312,7 +3312,7 @@ func (p projPlusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -3421,7 +3421,7 @@ func (p projPlusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -3663,7 +3663,7 @@ func (p projPlusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -3772,7 +3772,7 @@ func (p projPlusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -3881,7 +3881,7 @@ func (p projPlusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -3990,7 +3990,7 @@ func (p projPlusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -4232,7 +4232,7 @@ func (p projPlusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -4341,7 +4341,7 @@ func (p projPlusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -4450,7 +4450,7 @@ func (p projPlusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -4559,7 +4559,7 @@ func (p projPlusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -4801,7 +4801,7 @@ func (p projPlusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -4898,7 +4898,7 @@ func (p projPlusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Batc
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -4975,7 +4975,7 @@ func (p projPlusIntervalConstTimestampOp) Next(ctx context.Context) coldata.Batc
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []time.Time
+	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -5052,7 +5052,7 @@ func (p projPlusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -5254,7 +5254,7 @@ func (p projPlusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -5371,7 +5371,7 @@ func (p projPlusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -5488,7 +5488,7 @@ func (p projPlusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -5605,7 +5605,7 @@ func (p projPlusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -5722,7 +5722,7 @@ func (p projMinusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -5835,7 +5835,7 @@ func (p projMinusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -5948,7 +5948,7 @@ func (p projMinusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -6061,7 +6061,7 @@ func (p projMinusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -6170,7 +6170,7 @@ func (p projMinusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -6279,7 +6279,7 @@ func (p projMinusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -6388,7 +6388,7 @@ func (p projMinusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -6497,7 +6497,7 @@ func (p projMinusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -6739,7 +6739,7 @@ func (p projMinusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -6848,7 +6848,7 @@ func (p projMinusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -6957,7 +6957,7 @@ func (p projMinusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -7066,7 +7066,7 @@ func (p projMinusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -7308,7 +7308,7 @@ func (p projMinusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -7417,7 +7417,7 @@ func (p projMinusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -7526,7 +7526,7 @@ func (p projMinusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -7635,7 +7635,7 @@ func (p projMinusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -7877,7 +7877,7 @@ func (p projMinusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -7974,7 +7974,7 @@ func (p projMinusTimestampConstTimestampOp) Next(ctx context.Context) coldata.Ba
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []time.Time
+	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -8063,7 +8063,7 @@ func (p projMinusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Bat
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -8140,7 +8140,7 @@ func (p projMinusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batc
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -8443,7 +8443,7 @@ func (p projMinusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -8681,7 +8681,7 @@ func (p projMinusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -8798,7 +8798,7 @@ func (p projMinusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -8915,7 +8915,7 @@ func (p projMinusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -9032,7 +9032,7 @@ func (p projMultDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -9145,7 +9145,7 @@ func (p projMultDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -9258,7 +9258,7 @@ func (p projMultDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -9371,7 +9371,7 @@ func (p projMultDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -9480,7 +9480,7 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -9577,7 +9577,7 @@ func (p projMultInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -9718,7 +9718,7 @@ func (p projMultInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -9859,7 +9859,7 @@ func (p projMultInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -10000,7 +10000,7 @@ func (p projMultInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -10117,7 +10117,7 @@ func (p projMultInt16ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -10194,7 +10194,7 @@ func (p projMultInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -10335,7 +10335,7 @@ func (p projMultInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -10476,7 +10476,7 @@ func (p projMultInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -10617,7 +10617,7 @@ func (p projMultInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -10734,7 +10734,7 @@ func (p projMultInt32ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -10811,7 +10811,7 @@ func (p projMultInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -10952,7 +10952,7 @@ func (p projMultInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11093,7 +11093,7 @@ func (p projMultInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11234,7 +11234,7 @@ func (p projMultInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11351,7 +11351,7 @@ func (p projMultInt64ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11428,7 +11428,7 @@ func (p projMultFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11525,7 +11525,7 @@ func (p projMultFloat64ConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11602,7 +11602,7 @@ func (p projMultIntervalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11679,7 +11679,7 @@ func (p projMultIntervalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11756,7 +11756,7 @@ func (p projMultIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11833,7 +11833,7 @@ func (p projMultIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11910,7 +11910,7 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -12007,7 +12007,7 @@ func (p projDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -12136,7 +12136,7 @@ func (p projDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -12265,7 +12265,7 @@ func (p projDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -12394,7 +12394,7 @@ func (p projDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -12519,7 +12519,7 @@ func (p projDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -12644,7 +12644,7 @@ func (p projDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -12769,7 +12769,7 @@ func (p projDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -12894,7 +12894,7 @@ func (p projDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -13027,7 +13027,7 @@ func (p projDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -13152,7 +13152,7 @@ func (p projDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -13277,7 +13277,7 @@ func (p projDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -13402,7 +13402,7 @@ func (p projDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -13535,7 +13535,7 @@ func (p projDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -13660,7 +13660,7 @@ func (p projDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -13785,7 +13785,7 @@ func (p projDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -13910,7 +13910,7 @@ func (p projDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -14043,7 +14043,7 @@ func (p projDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -14156,7 +14156,7 @@ func (p projDivIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -14249,7 +14249,7 @@ func (p projDivIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -14342,7 +14342,7 @@ func (p projFloorDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -14471,7 +14471,7 @@ func (p projFloorDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -14600,7 +14600,7 @@ func (p projFloorDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -14729,7 +14729,7 @@ func (p projFloorDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Bat
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -14854,7 +14854,7 @@ func (p projFloorDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -14959,7 +14959,7 @@ func (p projFloorDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -15064,7 +15064,7 @@ func (p projFloorDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -15169,7 +15169,7 @@ func (p projFloorDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -15302,7 +15302,7 @@ func (p projFloorDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -15407,7 +15407,7 @@ func (p projFloorDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -15512,7 +15512,7 @@ func (p projFloorDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -15617,7 +15617,7 @@ func (p projFloorDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -15750,7 +15750,7 @@ func (p projFloorDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -15855,7 +15855,7 @@ func (p projFloorDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -15960,7 +15960,7 @@ func (p projFloorDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -16065,7 +16065,7 @@ func (p projFloorDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -16198,7 +16198,7 @@ func (p projFloorDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Bat
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -16311,7 +16311,7 @@ func (p projModDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -16440,7 +16440,7 @@ func (p projModDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -16569,7 +16569,7 @@ func (p projModDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -16698,7 +16698,7 @@ func (p projModDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -16823,7 +16823,7 @@ func (p projModInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -16928,7 +16928,7 @@ func (p projModInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -17033,7 +17033,7 @@ func (p projModInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -17138,7 +17138,7 @@ func (p projModInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -17271,7 +17271,7 @@ func (p projModInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -17376,7 +17376,7 @@ func (p projModInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -17481,7 +17481,7 @@ func (p projModInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -17586,7 +17586,7 @@ func (p projModInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -17719,7 +17719,7 @@ func (p projModInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -17824,7 +17824,7 @@ func (p projModInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -17929,7 +17929,7 @@ func (p projModInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -18034,7 +18034,7 @@ func (p projModInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -18167,7 +18167,7 @@ func (p projModFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -18280,7 +18280,7 @@ func (p projPowDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -18393,7 +18393,7 @@ func (p projPowDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -18506,7 +18506,7 @@ func (p projPowDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -18619,7 +18619,7 @@ func (p projPowDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -18728,7 +18728,7 @@ func (p projPowInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -18861,7 +18861,7 @@ func (p projPowInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -18994,7 +18994,7 @@ func (p projPowInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -19127,7 +19127,7 @@ func (p projPowInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -19244,7 +19244,7 @@ func (p projPowInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -19377,7 +19377,7 @@ func (p projPowInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -19510,7 +19510,7 @@ func (p projPowInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -19643,7 +19643,7 @@ func (p projPowInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -19760,7 +19760,7 @@ func (p projPowInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -19893,7 +19893,7 @@ func (p projPowInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -20026,7 +20026,7 @@ func (p projPowInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -20159,7 +20159,7 @@ func (p projPowInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -20276,7 +20276,7 @@ func (p projPowFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -20583,7 +20583,7 @@ func (p projLShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -20692,7 +20692,7 @@ func (p projLShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -20801,7 +20801,7 @@ func (p projLShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -20910,7 +20910,7 @@ func (p projLShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -21019,7 +21019,7 @@ func (p projLShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -21128,7 +21128,7 @@ func (p projLShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -21237,7 +21237,7 @@ func (p projLShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -21346,7 +21346,7 @@ func (p projLShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -21455,7 +21455,7 @@ func (p projLShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -21564,7 +21564,7 @@ func (p projLShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -21681,7 +21681,7 @@ func (p projLShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -21798,7 +21798,7 @@ func (p projLShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -21915,7 +21915,7 @@ func (p projRShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -22024,7 +22024,7 @@ func (p projRShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -22133,7 +22133,7 @@ func (p projRShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -22242,7 +22242,7 @@ func (p projRShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -22351,7 +22351,7 @@ func (p projRShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -22460,7 +22460,7 @@ func (p projRShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -22569,7 +22569,7 @@ func (p projRShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -22678,7 +22678,7 @@ func (p projRShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -22787,7 +22787,7 @@ func (p projRShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -22896,7 +22896,7 @@ func (p projRShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -23013,7 +23013,7 @@ func (p projRShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -23130,7 +23130,7 @@ func (p projRShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -23368,7 +23368,7 @@ func (p projJSONFetchValDatumConstInt16Op) Next(ctx context.Context) coldata.Bat
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -23485,7 +23485,7 @@ func (p projJSONFetchValDatumConstInt32Op) Next(ctx context.Context) coldata.Bat
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -23602,7 +23602,7 @@ func (p projJSONFetchValDatumConstInt64Op) Next(ctx context.Context) coldata.Bat
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -23719,7 +23719,7 @@ func (p projEQBoolConstBoolOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []bool
+	var col coldata.Bools
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -23957,7 +23957,7 @@ func (p projEQDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -24082,7 +24082,7 @@ func (p projEQDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -24207,7 +24207,7 @@ func (p projEQDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -24332,7 +24332,7 @@ func (p projEQDecimalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -24465,7 +24465,7 @@ func (p projEQDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -24566,7 +24566,7 @@ func (p projEQInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -24711,7 +24711,7 @@ func (p projEQInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -24856,7 +24856,7 @@ func (p projEQInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -25001,7 +25001,7 @@ func (p projEQInt16ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -25178,7 +25178,7 @@ func (p projEQInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -25303,7 +25303,7 @@ func (p projEQInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -25448,7 +25448,7 @@ func (p projEQInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -25593,7 +25593,7 @@ func (p projEQInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -25738,7 +25738,7 @@ func (p projEQInt32ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -25915,7 +25915,7 @@ func (p projEQInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -26040,7 +26040,7 @@ func (p projEQInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -26185,7 +26185,7 @@ func (p projEQInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -26330,7 +26330,7 @@ func (p projEQInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -26475,7 +26475,7 @@ func (p projEQInt64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -26652,7 +26652,7 @@ func (p projEQInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -26777,7 +26777,7 @@ func (p projEQFloat64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -26954,7 +26954,7 @@ func (p projEQFloat64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -27131,7 +27131,7 @@ func (p projEQFloat64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -27308,7 +27308,7 @@ func (p projEQFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -27485,7 +27485,7 @@ func (p projEQFloat64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -27618,7 +27618,7 @@ func (p projEQTimestampConstTimestampOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []time.Time
+	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -27747,7 +27747,7 @@ func (p projEQIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -27957,7 +27957,7 @@ func (p projNEBoolConstBoolOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []bool
+	var col coldata.Bools
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -28195,7 +28195,7 @@ func (p projNEDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -28320,7 +28320,7 @@ func (p projNEDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -28445,7 +28445,7 @@ func (p projNEDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -28570,7 +28570,7 @@ func (p projNEDecimalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -28703,7 +28703,7 @@ func (p projNEDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -28804,7 +28804,7 @@ func (p projNEInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -28949,7 +28949,7 @@ func (p projNEInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -29094,7 +29094,7 @@ func (p projNEInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -29239,7 +29239,7 @@ func (p projNEInt16ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -29416,7 +29416,7 @@ func (p projNEInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -29541,7 +29541,7 @@ func (p projNEInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -29686,7 +29686,7 @@ func (p projNEInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -29831,7 +29831,7 @@ func (p projNEInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -29976,7 +29976,7 @@ func (p projNEInt32ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -30153,7 +30153,7 @@ func (p projNEInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -30278,7 +30278,7 @@ func (p projNEInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -30423,7 +30423,7 @@ func (p projNEInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -30568,7 +30568,7 @@ func (p projNEInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -30713,7 +30713,7 @@ func (p projNEInt64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -30890,7 +30890,7 @@ func (p projNEInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -31015,7 +31015,7 @@ func (p projNEFloat64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -31192,7 +31192,7 @@ func (p projNEFloat64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -31369,7 +31369,7 @@ func (p projNEFloat64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -31546,7 +31546,7 @@ func (p projNEFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -31723,7 +31723,7 @@ func (p projNEFloat64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -31856,7 +31856,7 @@ func (p projNETimestampConstTimestampOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []time.Time
+	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -31985,7 +31985,7 @@ func (p projNEIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -32195,7 +32195,7 @@ func (p projLTBoolConstBoolOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []bool
+	var col coldata.Bools
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -32433,7 +32433,7 @@ func (p projLTDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -32558,7 +32558,7 @@ func (p projLTDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -32683,7 +32683,7 @@ func (p projLTDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -32808,7 +32808,7 @@ func (p projLTDecimalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -32941,7 +32941,7 @@ func (p projLTDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -33042,7 +33042,7 @@ func (p projLTInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -33187,7 +33187,7 @@ func (p projLTInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -33332,7 +33332,7 @@ func (p projLTInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -33477,7 +33477,7 @@ func (p projLTInt16ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -33654,7 +33654,7 @@ func (p projLTInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -33779,7 +33779,7 @@ func (p projLTInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -33924,7 +33924,7 @@ func (p projLTInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -34069,7 +34069,7 @@ func (p projLTInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -34214,7 +34214,7 @@ func (p projLTInt32ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -34391,7 +34391,7 @@ func (p projLTInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -34516,7 +34516,7 @@ func (p projLTInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -34661,7 +34661,7 @@ func (p projLTInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -34806,7 +34806,7 @@ func (p projLTInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -34951,7 +34951,7 @@ func (p projLTInt64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -35128,7 +35128,7 @@ func (p projLTInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -35253,7 +35253,7 @@ func (p projLTFloat64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -35430,7 +35430,7 @@ func (p projLTFloat64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -35607,7 +35607,7 @@ func (p projLTFloat64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -35784,7 +35784,7 @@ func (p projLTFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -35961,7 +35961,7 @@ func (p projLTFloat64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -36094,7 +36094,7 @@ func (p projLTTimestampConstTimestampOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []time.Time
+	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -36223,7 +36223,7 @@ func (p projLTIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -36433,7 +36433,7 @@ func (p projLEBoolConstBoolOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []bool
+	var col coldata.Bools
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -36671,7 +36671,7 @@ func (p projLEDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -36796,7 +36796,7 @@ func (p projLEDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -36921,7 +36921,7 @@ func (p projLEDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -37046,7 +37046,7 @@ func (p projLEDecimalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -37179,7 +37179,7 @@ func (p projLEDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -37280,7 +37280,7 @@ func (p projLEInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -37425,7 +37425,7 @@ func (p projLEInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -37570,7 +37570,7 @@ func (p projLEInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -37715,7 +37715,7 @@ func (p projLEInt16ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -37892,7 +37892,7 @@ func (p projLEInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -38017,7 +38017,7 @@ func (p projLEInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -38162,7 +38162,7 @@ func (p projLEInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -38307,7 +38307,7 @@ func (p projLEInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -38452,7 +38452,7 @@ func (p projLEInt32ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -38629,7 +38629,7 @@ func (p projLEInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -38754,7 +38754,7 @@ func (p projLEInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -38899,7 +38899,7 @@ func (p projLEInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -39044,7 +39044,7 @@ func (p projLEInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -39189,7 +39189,7 @@ func (p projLEInt64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -39366,7 +39366,7 @@ func (p projLEInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -39491,7 +39491,7 @@ func (p projLEFloat64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -39668,7 +39668,7 @@ func (p projLEFloat64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -39845,7 +39845,7 @@ func (p projLEFloat64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -40022,7 +40022,7 @@ func (p projLEFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -40199,7 +40199,7 @@ func (p projLEFloat64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -40332,7 +40332,7 @@ func (p projLETimestampConstTimestampOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []time.Time
+	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -40461,7 +40461,7 @@ func (p projLEIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -40671,7 +40671,7 @@ func (p projGTBoolConstBoolOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []bool
+	var col coldata.Bools
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -40909,7 +40909,7 @@ func (p projGTDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -41034,7 +41034,7 @@ func (p projGTDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -41159,7 +41159,7 @@ func (p projGTDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -41284,7 +41284,7 @@ func (p projGTDecimalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -41417,7 +41417,7 @@ func (p projGTDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -41518,7 +41518,7 @@ func (p projGTInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -41663,7 +41663,7 @@ func (p projGTInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -41808,7 +41808,7 @@ func (p projGTInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -41953,7 +41953,7 @@ func (p projGTInt16ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -42130,7 +42130,7 @@ func (p projGTInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -42255,7 +42255,7 @@ func (p projGTInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -42400,7 +42400,7 @@ func (p projGTInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -42545,7 +42545,7 @@ func (p projGTInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -42690,7 +42690,7 @@ func (p projGTInt32ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -42867,7 +42867,7 @@ func (p projGTInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -42992,7 +42992,7 @@ func (p projGTInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -43137,7 +43137,7 @@ func (p projGTInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -43282,7 +43282,7 @@ func (p projGTInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -43427,7 +43427,7 @@ func (p projGTInt64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -43604,7 +43604,7 @@ func (p projGTInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -43729,7 +43729,7 @@ func (p projGTFloat64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -43906,7 +43906,7 @@ func (p projGTFloat64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -44083,7 +44083,7 @@ func (p projGTFloat64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -44260,7 +44260,7 @@ func (p projGTFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -44437,7 +44437,7 @@ func (p projGTFloat64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -44570,7 +44570,7 @@ func (p projGTTimestampConstTimestampOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []time.Time
+	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -44699,7 +44699,7 @@ func (p projGTIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -44909,7 +44909,7 @@ func (p projGEBoolConstBoolOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []bool
+	var col coldata.Bools
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -45147,7 +45147,7 @@ func (p projGEDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -45272,7 +45272,7 @@ func (p projGEDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -45397,7 +45397,7 @@ func (p projGEDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -45522,7 +45522,7 @@ func (p projGEDecimalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -45655,7 +45655,7 @@ func (p projGEDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -45756,7 +45756,7 @@ func (p projGEInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -45901,7 +45901,7 @@ func (p projGEInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -46046,7 +46046,7 @@ func (p projGEInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -46191,7 +46191,7 @@ func (p projGEInt16ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -46368,7 +46368,7 @@ func (p projGEInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -46493,7 +46493,7 @@ func (p projGEInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -46638,7 +46638,7 @@ func (p projGEInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -46783,7 +46783,7 @@ func (p projGEInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -46928,7 +46928,7 @@ func (p projGEInt32ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -47105,7 +47105,7 @@ func (p projGEInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -47230,7 +47230,7 @@ func (p projGEInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -47375,7 +47375,7 @@ func (p projGEInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -47520,7 +47520,7 @@ func (p projGEInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -47665,7 +47665,7 @@ func (p projGEInt64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -47842,7 +47842,7 @@ func (p projGEInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -47967,7 +47967,7 @@ func (p projGEFloat64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -48144,7 +48144,7 @@ func (p projGEFloat64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -48321,7 +48321,7 @@ func (p projGEFloat64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -48498,7 +48498,7 @@ func (p projGEFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -48675,7 +48675,7 @@ func (p projGEFloat64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -48808,7 +48808,7 @@ func (p projGETimestampConstTimestampOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []time.Time
+	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -48937,7 +48937,7 @@ func (p projGEIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {

--- a/pkg/sql/colexec/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/proj_const_right_ops.eg.go
@@ -48,7 +48,7 @@ func (p projBitandInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -133,7 +133,7 @@ func (p projBitandInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -218,7 +218,7 @@ func (p projBitandInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -303,7 +303,7 @@ func (p projBitandInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -388,7 +388,7 @@ func (p projBitandInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -473,7 +473,7 @@ func (p projBitandInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -558,7 +558,7 @@ func (p projBitandInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -643,7 +643,7 @@ func (p projBitandInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -728,7 +728,7 @@ func (p projBitandInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -914,7 +914,7 @@ func (p projBitorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -999,7 +999,7 @@ func (p projBitorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1084,7 +1084,7 @@ func (p projBitorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1169,7 +1169,7 @@ func (p projBitorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1254,7 +1254,7 @@ func (p projBitorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1339,7 +1339,7 @@ func (p projBitorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1424,7 +1424,7 @@ func (p projBitorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1509,7 +1509,7 @@ func (p projBitorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1594,7 +1594,7 @@ func (p projBitorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1780,7 +1780,7 @@ func (p projBitxorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1865,7 +1865,7 @@ func (p projBitxorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -1950,7 +1950,7 @@ func (p projBitxorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2035,7 +2035,7 @@ func (p projBitxorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2120,7 +2120,7 @@ func (p projBitxorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2205,7 +2205,7 @@ func (p projBitxorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2290,7 +2290,7 @@ func (p projBitxorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2375,7 +2375,7 @@ func (p projBitxorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2460,7 +2460,7 @@ func (p projBitxorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2646,7 +2646,7 @@ func (p projPlusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2759,7 +2759,7 @@ func (p projPlusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2872,7 +2872,7 @@ func (p projPlusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -2985,7 +2985,7 @@ func (p projPlusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -3094,7 +3094,7 @@ func (p projPlusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -3203,7 +3203,7 @@ func (p projPlusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -3312,7 +3312,7 @@ func (p projPlusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -3421,7 +3421,7 @@ func (p projPlusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -3538,7 +3538,7 @@ func (p projPlusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -3663,7 +3663,7 @@ func (p projPlusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -3772,7 +3772,7 @@ func (p projPlusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -3881,7 +3881,7 @@ func (p projPlusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -3990,7 +3990,7 @@ func (p projPlusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -4107,7 +4107,7 @@ func (p projPlusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -4232,7 +4232,7 @@ func (p projPlusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -4341,7 +4341,7 @@ func (p projPlusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -4450,7 +4450,7 @@ func (p projPlusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -4559,7 +4559,7 @@ func (p projPlusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -4676,7 +4676,7 @@ func (p projPlusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -4801,7 +4801,7 @@ func (p projPlusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -4898,7 +4898,7 @@ func (p projPlusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Batc
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []time.Time
+	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -4975,7 +4975,7 @@ func (p projPlusIntervalTimestampConstOp) Next(ctx context.Context) coldata.Batc
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -5052,7 +5052,7 @@ func (p projPlusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -5129,7 +5129,7 @@ func (p projPlusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -5722,7 +5722,7 @@ func (p projMinusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -5835,7 +5835,7 @@ func (p projMinusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -5948,7 +5948,7 @@ func (p projMinusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -6061,7 +6061,7 @@ func (p projMinusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -6170,7 +6170,7 @@ func (p projMinusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -6279,7 +6279,7 @@ func (p projMinusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -6388,7 +6388,7 @@ func (p projMinusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -6497,7 +6497,7 @@ func (p projMinusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -6614,7 +6614,7 @@ func (p projMinusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -6739,7 +6739,7 @@ func (p projMinusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -6848,7 +6848,7 @@ func (p projMinusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -6957,7 +6957,7 @@ func (p projMinusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -7066,7 +7066,7 @@ func (p projMinusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -7183,7 +7183,7 @@ func (p projMinusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -7308,7 +7308,7 @@ func (p projMinusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -7417,7 +7417,7 @@ func (p projMinusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -7526,7 +7526,7 @@ func (p projMinusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -7635,7 +7635,7 @@ func (p projMinusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -7752,7 +7752,7 @@ func (p projMinusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -7877,7 +7877,7 @@ func (p projMinusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch 
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -7974,7 +7974,7 @@ func (p projMinusTimestampTimestampConstOp) Next(ctx context.Context) coldata.Ba
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []time.Time
+	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -8063,7 +8063,7 @@ func (p projMinusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Bat
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []time.Time
+	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -8140,7 +8140,7 @@ func (p projMinusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batc
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -8217,7 +8217,7 @@ func (p projMinusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -9028,7 +9028,7 @@ func (p projMultDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -9141,7 +9141,7 @@ func (p projMultDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -9254,7 +9254,7 @@ func (p projMultDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -9367,7 +9367,7 @@ func (p projMultDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -9476,7 +9476,7 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -9573,7 +9573,7 @@ func (p projMultInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -9714,7 +9714,7 @@ func (p projMultInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -9855,7 +9855,7 @@ func (p projMultInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -9996,7 +9996,7 @@ func (p projMultInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -10113,7 +10113,7 @@ func (p projMultInt16IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -10190,7 +10190,7 @@ func (p projMultInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -10331,7 +10331,7 @@ func (p projMultInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -10472,7 +10472,7 @@ func (p projMultInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -10613,7 +10613,7 @@ func (p projMultInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -10730,7 +10730,7 @@ func (p projMultInt32IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -10807,7 +10807,7 @@ func (p projMultInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -10948,7 +10948,7 @@ func (p projMultInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11089,7 +11089,7 @@ func (p projMultInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11230,7 +11230,7 @@ func (p projMultInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11347,7 +11347,7 @@ func (p projMultInt64IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11424,7 +11424,7 @@ func (p projMultFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11521,7 +11521,7 @@ func (p projMultFloat64IntervalConstOp) Next(ctx context.Context) coldata.Batch 
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11598,7 +11598,7 @@ func (p projMultIntervalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11675,7 +11675,7 @@ func (p projMultIntervalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11752,7 +11752,7 @@ func (p projMultIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11829,7 +11829,7 @@ func (p projMultIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch 
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -11906,7 +11906,7 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -12003,7 +12003,7 @@ func (p projDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -12132,7 +12132,7 @@ func (p projDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -12261,7 +12261,7 @@ func (p projDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -12390,7 +12390,7 @@ func (p projDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -12515,7 +12515,7 @@ func (p projDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -12640,7 +12640,7 @@ func (p projDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -12765,7 +12765,7 @@ func (p projDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -12890,7 +12890,7 @@ func (p projDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -13023,7 +13023,7 @@ func (p projDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -13148,7 +13148,7 @@ func (p projDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -13273,7 +13273,7 @@ func (p projDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -13398,7 +13398,7 @@ func (p projDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -13531,7 +13531,7 @@ func (p projDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -13656,7 +13656,7 @@ func (p projDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -13781,7 +13781,7 @@ func (p projDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -13906,7 +13906,7 @@ func (p projDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -14039,7 +14039,7 @@ func (p projDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -14152,7 +14152,7 @@ func (p projDivIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -14245,7 +14245,7 @@ func (p projDivIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -14338,7 +14338,7 @@ func (p projFloorDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -14467,7 +14467,7 @@ func (p projFloorDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -14596,7 +14596,7 @@ func (p projFloorDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -14725,7 +14725,7 @@ func (p projFloorDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Bat
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -14850,7 +14850,7 @@ func (p projFloorDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -14955,7 +14955,7 @@ func (p projFloorDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -15060,7 +15060,7 @@ func (p projFloorDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -15165,7 +15165,7 @@ func (p projFloorDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -15298,7 +15298,7 @@ func (p projFloorDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -15403,7 +15403,7 @@ func (p projFloorDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -15508,7 +15508,7 @@ func (p projFloorDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -15613,7 +15613,7 @@ func (p projFloorDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -15746,7 +15746,7 @@ func (p projFloorDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -15851,7 +15851,7 @@ func (p projFloorDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -15956,7 +15956,7 @@ func (p projFloorDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -16061,7 +16061,7 @@ func (p projFloorDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -16194,7 +16194,7 @@ func (p projFloorDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Bat
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -16307,7 +16307,7 @@ func (p projModDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -16436,7 +16436,7 @@ func (p projModDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -16565,7 +16565,7 @@ func (p projModDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -16694,7 +16694,7 @@ func (p projModDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -16819,7 +16819,7 @@ func (p projModInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -16924,7 +16924,7 @@ func (p projModInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -17029,7 +17029,7 @@ func (p projModInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -17134,7 +17134,7 @@ func (p projModInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -17267,7 +17267,7 @@ func (p projModInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -17372,7 +17372,7 @@ func (p projModInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -17477,7 +17477,7 @@ func (p projModInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -17582,7 +17582,7 @@ func (p projModInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -17715,7 +17715,7 @@ func (p projModInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -17820,7 +17820,7 @@ func (p projModInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -17925,7 +17925,7 @@ func (p projModInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -18030,7 +18030,7 @@ func (p projModInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -18163,7 +18163,7 @@ func (p projModFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -18276,7 +18276,7 @@ func (p projPowDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -18389,7 +18389,7 @@ func (p projPowDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -18502,7 +18502,7 @@ func (p projPowDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -18615,7 +18615,7 @@ func (p projPowDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -18724,7 +18724,7 @@ func (p projPowInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -18857,7 +18857,7 @@ func (p projPowInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -18990,7 +18990,7 @@ func (p projPowInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -19123,7 +19123,7 @@ func (p projPowInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -19240,7 +19240,7 @@ func (p projPowInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -19373,7 +19373,7 @@ func (p projPowInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -19506,7 +19506,7 @@ func (p projPowInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -19639,7 +19639,7 @@ func (p projPowInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -19756,7 +19756,7 @@ func (p projPowInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -19889,7 +19889,7 @@ func (p projPowInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -20022,7 +20022,7 @@ func (p projPowInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -20155,7 +20155,7 @@ func (p projPowInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -20272,7 +20272,7 @@ func (p projPowFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -20579,7 +20579,7 @@ func (p projLShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -20688,7 +20688,7 @@ func (p projLShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -20797,7 +20797,7 @@ func (p projLShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -20906,7 +20906,7 @@ func (p projLShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -21015,7 +21015,7 @@ func (p projLShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -21124,7 +21124,7 @@ func (p projLShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -21233,7 +21233,7 @@ func (p projLShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -21342,7 +21342,7 @@ func (p projLShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -21451,7 +21451,7 @@ func (p projLShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -21911,7 +21911,7 @@ func (p projRShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -22020,7 +22020,7 @@ func (p projRShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -22129,7 +22129,7 @@ func (p projRShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -22238,7 +22238,7 @@ func (p projRShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -22347,7 +22347,7 @@ func (p projRShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -22456,7 +22456,7 @@ func (p projRShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -22565,7 +22565,7 @@ func (p projRShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -22674,7 +22674,7 @@ func (p projRShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -22783,7 +22783,7 @@ func (p projRShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -23711,7 +23711,7 @@ func (p projEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []bool
+	var col coldata.Bools
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -23949,7 +23949,7 @@ func (p projEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -24074,7 +24074,7 @@ func (p projEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -24199,7 +24199,7 @@ func (p projEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -24324,7 +24324,7 @@ func (p projEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -24457,7 +24457,7 @@ func (p projEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -24558,7 +24558,7 @@ func (p projEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -24703,7 +24703,7 @@ func (p projEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -24848,7 +24848,7 @@ func (p projEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -24993,7 +24993,7 @@ func (p projEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -25170,7 +25170,7 @@ func (p projEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -25295,7 +25295,7 @@ func (p projEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -25440,7 +25440,7 @@ func (p projEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -25585,7 +25585,7 @@ func (p projEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -25730,7 +25730,7 @@ func (p projEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -25907,7 +25907,7 @@ func (p projEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -26032,7 +26032,7 @@ func (p projEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -26177,7 +26177,7 @@ func (p projEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -26322,7 +26322,7 @@ func (p projEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -26467,7 +26467,7 @@ func (p projEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -26644,7 +26644,7 @@ func (p projEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -26769,7 +26769,7 @@ func (p projEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -26946,7 +26946,7 @@ func (p projEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -27123,7 +27123,7 @@ func (p projEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -27300,7 +27300,7 @@ func (p projEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -27477,7 +27477,7 @@ func (p projEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -27610,7 +27610,7 @@ func (p projEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []time.Time
+	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -27739,7 +27739,7 @@ func (p projEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -27949,7 +27949,7 @@ func (p projNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []bool
+	var col coldata.Bools
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -28187,7 +28187,7 @@ func (p projNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -28312,7 +28312,7 @@ func (p projNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -28437,7 +28437,7 @@ func (p projNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -28562,7 +28562,7 @@ func (p projNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -28695,7 +28695,7 @@ func (p projNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -28796,7 +28796,7 @@ func (p projNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -28941,7 +28941,7 @@ func (p projNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -29086,7 +29086,7 @@ func (p projNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -29231,7 +29231,7 @@ func (p projNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -29408,7 +29408,7 @@ func (p projNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -29533,7 +29533,7 @@ func (p projNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -29678,7 +29678,7 @@ func (p projNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -29823,7 +29823,7 @@ func (p projNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -29968,7 +29968,7 @@ func (p projNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -30145,7 +30145,7 @@ func (p projNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -30270,7 +30270,7 @@ func (p projNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -30415,7 +30415,7 @@ func (p projNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -30560,7 +30560,7 @@ func (p projNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -30705,7 +30705,7 @@ func (p projNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -30882,7 +30882,7 @@ func (p projNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -31007,7 +31007,7 @@ func (p projNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -31184,7 +31184,7 @@ func (p projNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -31361,7 +31361,7 @@ func (p projNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -31538,7 +31538,7 @@ func (p projNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -31715,7 +31715,7 @@ func (p projNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -31848,7 +31848,7 @@ func (p projNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []time.Time
+	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -31977,7 +31977,7 @@ func (p projNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -32187,7 +32187,7 @@ func (p projLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []bool
+	var col coldata.Bools
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -32425,7 +32425,7 @@ func (p projLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -32550,7 +32550,7 @@ func (p projLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -32675,7 +32675,7 @@ func (p projLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -32800,7 +32800,7 @@ func (p projLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -32933,7 +32933,7 @@ func (p projLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -33034,7 +33034,7 @@ func (p projLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -33179,7 +33179,7 @@ func (p projLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -33324,7 +33324,7 @@ func (p projLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -33469,7 +33469,7 @@ func (p projLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -33646,7 +33646,7 @@ func (p projLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -33771,7 +33771,7 @@ func (p projLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -33916,7 +33916,7 @@ func (p projLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -34061,7 +34061,7 @@ func (p projLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -34206,7 +34206,7 @@ func (p projLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -34383,7 +34383,7 @@ func (p projLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -34508,7 +34508,7 @@ func (p projLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -34653,7 +34653,7 @@ func (p projLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -34798,7 +34798,7 @@ func (p projLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -34943,7 +34943,7 @@ func (p projLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -35120,7 +35120,7 @@ func (p projLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -35245,7 +35245,7 @@ func (p projLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -35422,7 +35422,7 @@ func (p projLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -35599,7 +35599,7 @@ func (p projLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -35776,7 +35776,7 @@ func (p projLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -35953,7 +35953,7 @@ func (p projLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -36086,7 +36086,7 @@ func (p projLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []time.Time
+	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -36215,7 +36215,7 @@ func (p projLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -36425,7 +36425,7 @@ func (p projLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []bool
+	var col coldata.Bools
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -36663,7 +36663,7 @@ func (p projLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -36788,7 +36788,7 @@ func (p projLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -36913,7 +36913,7 @@ func (p projLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -37038,7 +37038,7 @@ func (p projLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -37171,7 +37171,7 @@ func (p projLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -37272,7 +37272,7 @@ func (p projLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -37417,7 +37417,7 @@ func (p projLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -37562,7 +37562,7 @@ func (p projLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -37707,7 +37707,7 @@ func (p projLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -37884,7 +37884,7 @@ func (p projLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -38009,7 +38009,7 @@ func (p projLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -38154,7 +38154,7 @@ func (p projLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -38299,7 +38299,7 @@ func (p projLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -38444,7 +38444,7 @@ func (p projLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -38621,7 +38621,7 @@ func (p projLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -38746,7 +38746,7 @@ func (p projLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -38891,7 +38891,7 @@ func (p projLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -39036,7 +39036,7 @@ func (p projLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -39181,7 +39181,7 @@ func (p projLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -39358,7 +39358,7 @@ func (p projLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -39483,7 +39483,7 @@ func (p projLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -39660,7 +39660,7 @@ func (p projLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -39837,7 +39837,7 @@ func (p projLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -40014,7 +40014,7 @@ func (p projLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -40191,7 +40191,7 @@ func (p projLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -40324,7 +40324,7 @@ func (p projLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []time.Time
+	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -40453,7 +40453,7 @@ func (p projLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -40663,7 +40663,7 @@ func (p projGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []bool
+	var col coldata.Bools
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -40901,7 +40901,7 @@ func (p projGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -41026,7 +41026,7 @@ func (p projGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -41151,7 +41151,7 @@ func (p projGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -41276,7 +41276,7 @@ func (p projGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -41409,7 +41409,7 @@ func (p projGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -41510,7 +41510,7 @@ func (p projGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -41655,7 +41655,7 @@ func (p projGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -41800,7 +41800,7 @@ func (p projGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -41945,7 +41945,7 @@ func (p projGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -42122,7 +42122,7 @@ func (p projGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -42247,7 +42247,7 @@ func (p projGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -42392,7 +42392,7 @@ func (p projGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -42537,7 +42537,7 @@ func (p projGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -42682,7 +42682,7 @@ func (p projGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -42859,7 +42859,7 @@ func (p projGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -42984,7 +42984,7 @@ func (p projGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -43129,7 +43129,7 @@ func (p projGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -43274,7 +43274,7 @@ func (p projGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -43419,7 +43419,7 @@ func (p projGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -43596,7 +43596,7 @@ func (p projGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -43721,7 +43721,7 @@ func (p projGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -43898,7 +43898,7 @@ func (p projGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -44075,7 +44075,7 @@ func (p projGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -44252,7 +44252,7 @@ func (p projGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -44429,7 +44429,7 @@ func (p projGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -44562,7 +44562,7 @@ func (p projGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []time.Time
+	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -44691,7 +44691,7 @@ func (p projGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -44901,7 +44901,7 @@ func (p projGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []bool
+	var col coldata.Bools
 	col = vec.Bool()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -45139,7 +45139,7 @@ func (p projGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -45264,7 +45264,7 @@ func (p projGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -45389,7 +45389,7 @@ func (p projGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -45514,7 +45514,7 @@ func (p projGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -45647,7 +45647,7 @@ func (p projGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []apd.Decimal
+	var col coldata.Decimals
 	col = vec.Decimal()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -45748,7 +45748,7 @@ func (p projGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -45893,7 +45893,7 @@ func (p projGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -46038,7 +46038,7 @@ func (p projGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -46183,7 +46183,7 @@ func (p projGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -46360,7 +46360,7 @@ func (p projGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int16
+	var col coldata.Int16s
 	col = vec.Int16()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -46485,7 +46485,7 @@ func (p projGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -46630,7 +46630,7 @@ func (p projGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -46775,7 +46775,7 @@ func (p projGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -46920,7 +46920,7 @@ func (p projGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -47097,7 +47097,7 @@ func (p projGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int32
+	var col coldata.Int32s
 	col = vec.Int32()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -47222,7 +47222,7 @@ func (p projGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -47367,7 +47367,7 @@ func (p projGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -47512,7 +47512,7 @@ func (p projGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -47657,7 +47657,7 @@ func (p projGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -47834,7 +47834,7 @@ func (p projGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []int64
+	var col coldata.Int64s
 	col = vec.Int64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -47959,7 +47959,7 @@ func (p projGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -48136,7 +48136,7 @@ func (p projGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -48313,7 +48313,7 @@ func (p projGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -48490,7 +48490,7 @@ func (p projGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -48667,7 +48667,7 @@ func (p projGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []float64
+	var col coldata.Float64s
 	col = vec.Float64()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -48800,7 +48800,7 @@ func (p projGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []time.Time
+	var col coldata.Times
 	col = vec.Timestamp()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {
@@ -48929,7 +48929,7 @@ func (p projGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		return coldata.ZeroBatch
 	}
 	vec := batch.ColVec(p.colIdx)
-	var col []duration.Duration
+	var col coldata.Durations
 	col = vec.Interval()
 	projVec := batch.ColVec(p.outputIdx)
 	if projVec.MaybeHasNulls() {

--- a/pkg/sql/colexec/select_in.eg.go
+++ b/pkg/sql/colexec/select_in.eg.go
@@ -413,7 +413,7 @@ func fillDatumRowBool(t *types.T, datumTuple *tree.DTuple) ([]bool, bool, error)
 }
 
 func cmpInBool(
-	targetElem bool, targetCol []bool, filterRow []bool, hasNulls bool,
+	targetElem bool, targetCol coldata.Bools, filterRow []bool, hasNulls bool,
 ) comparisonResult {
 	for i := range filterRow {
 		var cmp bool
@@ -883,7 +883,7 @@ func fillDatumRowDecimal(t *types.T, datumTuple *tree.DTuple) ([]apd.Decimal, bo
 }
 
 func cmpInDecimal(
-	targetElem apd.Decimal, targetCol []apd.Decimal, filterRow []apd.Decimal, hasNulls bool,
+	targetElem apd.Decimal, targetCol coldata.Decimals, filterRow []apd.Decimal, hasNulls bool,
 ) comparisonResult {
 	for i := range filterRow {
 		var cmp bool
@@ -1112,7 +1112,7 @@ func fillDatumRowInt16(t *types.T, datumTuple *tree.DTuple) ([]int16, bool, erro
 }
 
 func cmpInInt16(
-	targetElem int16, targetCol []int16, filterRow []int16, hasNulls bool,
+	targetElem int16, targetCol coldata.Int16s, filterRow []int16, hasNulls bool,
 ) comparisonResult {
 	for i := range filterRow {
 		var cmp bool
@@ -1352,7 +1352,7 @@ func fillDatumRowInt32(t *types.T, datumTuple *tree.DTuple) ([]int32, bool, erro
 }
 
 func cmpInInt32(
-	targetElem int32, targetCol []int32, filterRow []int32, hasNulls bool,
+	targetElem int32, targetCol coldata.Int32s, filterRow []int32, hasNulls bool,
 ) comparisonResult {
 	for i := range filterRow {
 		var cmp bool
@@ -1592,7 +1592,7 @@ func fillDatumRowInt64(t *types.T, datumTuple *tree.DTuple) ([]int64, bool, erro
 }
 
 func cmpInInt64(
-	targetElem int64, targetCol []int64, filterRow []int64, hasNulls bool,
+	targetElem int64, targetCol coldata.Int64s, filterRow []int64, hasNulls bool,
 ) comparisonResult {
 	for i := range filterRow {
 		var cmp bool
@@ -1832,7 +1832,7 @@ func fillDatumRowFloat64(t *types.T, datumTuple *tree.DTuple) ([]float64, bool, 
 }
 
 func cmpInFloat64(
-	targetElem float64, targetCol []float64, filterRow []float64, hasNulls bool,
+	targetElem float64, targetCol coldata.Float64s, filterRow []float64, hasNulls bool,
 ) comparisonResult {
 	for i := range filterRow {
 		var cmp bool
@@ -2080,7 +2080,7 @@ func fillDatumRowTimestamp(t *types.T, datumTuple *tree.DTuple) ([]time.Time, bo
 }
 
 func cmpInTimestamp(
-	targetElem time.Time, targetCol []time.Time, filterRow []time.Time, hasNulls bool,
+	targetElem time.Time, targetCol coldata.Times, filterRow []time.Time, hasNulls bool,
 ) comparisonResult {
 	for i := range filterRow {
 		var cmp bool
@@ -2316,7 +2316,7 @@ func fillDatumRowInterval(t *types.T, datumTuple *tree.DTuple) ([]duration.Durat
 }
 
 func cmpInInterval(
-	targetElem duration.Duration, targetCol []duration.Duration, filterRow []duration.Duration, hasNulls bool,
+	targetElem duration.Duration, targetCol coldata.Durations, filterRow []duration.Duration, hasNulls bool,
 ) comparisonResult {
 	for i := range filterRow {
 		var cmp bool

--- a/pkg/sql/colexec/sort.eg.go
+++ b/pkg/sql/colexec/sort.eg.go
@@ -14,9 +14,7 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"time"
 
-	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
@@ -24,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
 func isSorterSupported(t *types.T, dir execinfrapb.Ordering_Column_Direction) bool {
@@ -380,7 +377,7 @@ func newSingleSorter(
 }
 
 type sortBoolAscWithNullsOp struct {
-	sortCol       []bool
+	sortCol       coldata.Bools
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -528,7 +525,7 @@ func (s *sortBytesAscWithNullsOp) Len() int {
 }
 
 type sortDecimalAscWithNullsOp struct {
-	sortCol       []apd.Decimal
+	sortCol       coldata.Decimals
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -598,7 +595,7 @@ func (s *sortDecimalAscWithNullsOp) Len() int {
 }
 
 type sortInt16AscWithNullsOp struct {
-	sortCol       []int16
+	sortCol       coldata.Int16s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -679,7 +676,7 @@ func (s *sortInt16AscWithNullsOp) Len() int {
 }
 
 type sortInt32AscWithNullsOp struct {
-	sortCol       []int32
+	sortCol       coldata.Int32s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -760,7 +757,7 @@ func (s *sortInt32AscWithNullsOp) Len() int {
 }
 
 type sortInt64AscWithNullsOp struct {
-	sortCol       []int64
+	sortCol       coldata.Int64s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -841,7 +838,7 @@ func (s *sortInt64AscWithNullsOp) Len() int {
 }
 
 type sortFloat64AscWithNullsOp struct {
-	sortCol       []float64
+	sortCol       coldata.Float64s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -930,7 +927,7 @@ func (s *sortFloat64AscWithNullsOp) Len() int {
 }
 
 type sortTimestampAscWithNullsOp struct {
-	sortCol       []time.Time
+	sortCol       coldata.Times
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -1007,7 +1004,7 @@ func (s *sortTimestampAscWithNullsOp) Len() int {
 }
 
 type sortIntervalAscWithNullsOp struct {
-	sortCol       []duration.Duration
+	sortCol       coldata.Durations
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -1149,7 +1146,7 @@ func (s *sortDatumAscWithNullsOp) Len() int {
 }
 
 type sortBoolDescWithNullsOp struct {
-	sortCol       []bool
+	sortCol       coldata.Bools
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -1297,7 +1294,7 @@ func (s *sortBytesDescWithNullsOp) Len() int {
 }
 
 type sortDecimalDescWithNullsOp struct {
-	sortCol       []apd.Decimal
+	sortCol       coldata.Decimals
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -1367,7 +1364,7 @@ func (s *sortDecimalDescWithNullsOp) Len() int {
 }
 
 type sortInt16DescWithNullsOp struct {
-	sortCol       []int16
+	sortCol       coldata.Int16s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -1448,7 +1445,7 @@ func (s *sortInt16DescWithNullsOp) Len() int {
 }
 
 type sortInt32DescWithNullsOp struct {
-	sortCol       []int32
+	sortCol       coldata.Int32s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -1529,7 +1526,7 @@ func (s *sortInt32DescWithNullsOp) Len() int {
 }
 
 type sortInt64DescWithNullsOp struct {
-	sortCol       []int64
+	sortCol       coldata.Int64s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -1610,7 +1607,7 @@ func (s *sortInt64DescWithNullsOp) Len() int {
 }
 
 type sortFloat64DescWithNullsOp struct {
-	sortCol       []float64
+	sortCol       coldata.Float64s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -1699,7 +1696,7 @@ func (s *sortFloat64DescWithNullsOp) Len() int {
 }
 
 type sortTimestampDescWithNullsOp struct {
-	sortCol       []time.Time
+	sortCol       coldata.Times
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -1776,7 +1773,7 @@ func (s *sortTimestampDescWithNullsOp) Len() int {
 }
 
 type sortIntervalDescWithNullsOp struct {
-	sortCol       []duration.Duration
+	sortCol       coldata.Durations
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -1918,7 +1915,7 @@ func (s *sortDatumDescWithNullsOp) Len() int {
 }
 
 type sortBoolAscOp struct {
-	sortCol       []bool
+	sortCol       coldata.Bools
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -2046,7 +2043,7 @@ func (s *sortBytesAscOp) Len() int {
 }
 
 type sortDecimalAscOp struct {
-	sortCol       []apd.Decimal
+	sortCol       coldata.Decimals
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -2106,7 +2103,7 @@ func (s *sortDecimalAscOp) Len() int {
 }
 
 type sortInt16AscOp struct {
-	sortCol       []int16
+	sortCol       coldata.Int16s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -2177,7 +2174,7 @@ func (s *sortInt16AscOp) Len() int {
 }
 
 type sortInt32AscOp struct {
-	sortCol       []int32
+	sortCol       coldata.Int32s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -2248,7 +2245,7 @@ func (s *sortInt32AscOp) Len() int {
 }
 
 type sortInt64AscOp struct {
-	sortCol       []int64
+	sortCol       coldata.Int64s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -2319,7 +2316,7 @@ func (s *sortInt64AscOp) Len() int {
 }
 
 type sortFloat64AscOp struct {
-	sortCol       []float64
+	sortCol       coldata.Float64s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -2398,7 +2395,7 @@ func (s *sortFloat64AscOp) Len() int {
 }
 
 type sortTimestampAscOp struct {
-	sortCol       []time.Time
+	sortCol       coldata.Times
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -2465,7 +2462,7 @@ func (s *sortTimestampAscOp) Len() int {
 }
 
 type sortIntervalAscOp struct {
-	sortCol       []duration.Duration
+	sortCol       coldata.Durations
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -2587,7 +2584,7 @@ func (s *sortDatumAscOp) Len() int {
 }
 
 type sortBoolDescOp struct {
-	sortCol       []bool
+	sortCol       coldata.Bools
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -2715,7 +2712,7 @@ func (s *sortBytesDescOp) Len() int {
 }
 
 type sortDecimalDescOp struct {
-	sortCol       []apd.Decimal
+	sortCol       coldata.Decimals
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -2775,7 +2772,7 @@ func (s *sortDecimalDescOp) Len() int {
 }
 
 type sortInt16DescOp struct {
-	sortCol       []int16
+	sortCol       coldata.Int16s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -2846,7 +2843,7 @@ func (s *sortInt16DescOp) Len() int {
 }
 
 type sortInt32DescOp struct {
-	sortCol       []int32
+	sortCol       coldata.Int32s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -2917,7 +2914,7 @@ func (s *sortInt32DescOp) Len() int {
 }
 
 type sortInt64DescOp struct {
-	sortCol       []int64
+	sortCol       coldata.Int64s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -2988,7 +2985,7 @@ func (s *sortInt64DescOp) Len() int {
 }
 
 type sortFloat64DescOp struct {
-	sortCol       []float64
+	sortCol       coldata.Float64s
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -3067,7 +3064,7 @@ func (s *sortFloat64DescOp) Len() int {
 }
 
 type sortTimestampDescOp struct {
-	sortCol       []time.Time
+	sortCol       coldata.Times
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker
@@ -3134,7 +3131,7 @@ func (s *sortTimestampDescOp) Len() int {
 }
 
 type sortIntervalDescOp struct {
-	sortCol       []duration.Duration
+	sortCol       coldata.Durations
 	nulls         *coldata.Nulls
 	order         []int
 	cancelChecker CancelChecker

--- a/pkg/sql/colexec/vec_comparators.eg.go
+++ b/pkg/sql/colexec/vec_comparators.eg.go
@@ -13,16 +13,13 @@ import (
 	"bytes"
 	"fmt"
 	"math"
-	"time"
 
-	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
 
 // vecComparator is a helper for the ordered synchronizer. It stores multiple
@@ -45,7 +42,7 @@ type vecComparator interface {
 }
 
 type BoolVecComparator struct {
-	vecs  [][]bool
+	vecs  []coldata.Bools
 	nulls []*coldata.Nulls
 }
 
@@ -132,7 +129,7 @@ func (c *BytesVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 }
 
 type DecimalVecComparator struct {
-	vecs  [][]apd.Decimal
+	vecs  []coldata.Decimals
 	nulls []*coldata.Nulls
 }
 
@@ -169,7 +166,7 @@ func (c *DecimalVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int)
 }
 
 type Int16VecComparator struct {
-	vecs  [][]int16
+	vecs  []coldata.Int16s
 	nulls []*coldata.Nulls
 }
 
@@ -217,7 +214,7 @@ func (c *Int16VecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 }
 
 type Int32VecComparator struct {
-	vecs  [][]int32
+	vecs  []coldata.Int32s
 	nulls []*coldata.Nulls
 }
 
@@ -265,7 +262,7 @@ func (c *Int32VecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 }
 
 type Int64VecComparator struct {
-	vecs  [][]int64
+	vecs  []coldata.Int64s
 	nulls []*coldata.Nulls
 }
 
@@ -313,7 +310,7 @@ func (c *Int64VecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 }
 
 type Float64VecComparator struct {
-	vecs  [][]float64
+	vecs  []coldata.Float64s
 	nulls []*coldata.Nulls
 }
 
@@ -369,7 +366,7 @@ func (c *Float64VecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int)
 }
 
 type TimestampVecComparator struct {
-	vecs  [][]time.Time
+	vecs  []coldata.Times
 	nulls []*coldata.Nulls
 }
 
@@ -413,7 +410,7 @@ func (c *TimestampVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx in
 }
 
 type IntervalVecComparator struct {
-	vecs  [][]duration.Duration
+	vecs  []coldata.Durations
 	nulls []*coldata.Nulls
 }
 
@@ -495,7 +492,7 @@ func GetVecComparator(t *types.T, numVecs int) vecComparator {
 		case -1:
 		default:
 			return &BoolVecComparator{
-				vecs:  make([][]bool, numVecs),
+				vecs:  make([]coldata.Bools, numVecs),
 				nulls: make([]*coldata.Nulls, numVecs),
 			}
 		}
@@ -513,7 +510,7 @@ func GetVecComparator(t *types.T, numVecs int) vecComparator {
 		case -1:
 		default:
 			return &DecimalVecComparator{
-				vecs:  make([][]apd.Decimal, numVecs),
+				vecs:  make([]coldata.Decimals, numVecs),
 				nulls: make([]*coldata.Nulls, numVecs),
 			}
 		}
@@ -521,18 +518,18 @@ func GetVecComparator(t *types.T, numVecs int) vecComparator {
 		switch t.Width() {
 		case 16:
 			return &Int16VecComparator{
-				vecs:  make([][]int16, numVecs),
+				vecs:  make([]coldata.Int16s, numVecs),
 				nulls: make([]*coldata.Nulls, numVecs),
 			}
 		case 32:
 			return &Int32VecComparator{
-				vecs:  make([][]int32, numVecs),
+				vecs:  make([]coldata.Int32s, numVecs),
 				nulls: make([]*coldata.Nulls, numVecs),
 			}
 		case -1:
 		default:
 			return &Int64VecComparator{
-				vecs:  make([][]int64, numVecs),
+				vecs:  make([]coldata.Int64s, numVecs),
 				nulls: make([]*coldata.Nulls, numVecs),
 			}
 		}
@@ -541,7 +538,7 @@ func GetVecComparator(t *types.T, numVecs int) vecComparator {
 		case -1:
 		default:
 			return &Float64VecComparator{
-				vecs:  make([][]float64, numVecs),
+				vecs:  make([]coldata.Float64s, numVecs),
 				nulls: make([]*coldata.Nulls, numVecs),
 			}
 		}
@@ -550,7 +547,7 @@ func GetVecComparator(t *types.T, numVecs int) vecComparator {
 		case -1:
 		default:
 			return &TimestampVecComparator{
-				vecs:  make([][]time.Time, numVecs),
+				vecs:  make([]coldata.Times, numVecs),
 				nulls: make([]*coldata.Nulls, numVecs),
 			}
 		}
@@ -559,7 +556,7 @@ func GetVecComparator(t *types.T, numVecs int) vecComparator {
 		case -1:
 		default:
 			return &IntervalVecComparator{
-				vecs:  make([][]duration.Duration, numVecs),
+				vecs:  make([]coldata.Durations, numVecs),
 				nulls: make([]*coldata.Nulls, numVecs),
 			}
 		}


### PR DESCRIPTION
This commit adds named types for all colexec physical type slices. This
opens to the door to putting "real methods" on all of the type slices.

Release note: None