### PR TITLE
release-20.1: sql: remove sequence ownership dependency when dropping sequences

### DIFF
--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -106,6 +106,9 @@ func (p *planner) dropSequenceImpl(
 	jobDesc string,
 	behavior tree.DropBehavior,
 ) error {
+	if err := removeSequenceOwnerIfExists(ctx, p, seqDesc.ID, seqDesc.GetSequenceOpts()); err != nil {
+		return err
+	}
 	return p.initiateDropTable(ctx, seqDesc, queueJob, jobDesc, true /* drainName */)
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1071,3 +1071,17 @@ DROP TABLE b;
 
 statement ok
 DROP TABLE a;
+
+subtest regression_50649
+
+statement ok
+CREATE TABLE t_50649(a INT PRIMARY KEY)
+
+statement ok
+CREATE SEQUENCE seq_50649 OWNED BY t_50649.a
+
+statement ok
+DROP SEQUENCE seq_50649
+
+statement ok
+DROP TABLE t_50649


### PR DESCRIPTION
Backport 1/1 commits from #50665.

/cc @cockroachdb/release

---

Previously, when a sequence that was owned by a column was being
dropped, we would not remove the sequence ID from the column descriptor
of the column that owned it. As a result, there was a bug where if the
sequence was dropped manually before the table, it would be impossible
to drop the table.

This patch addresses this problem by removing the ownership dependency
on sequence drops.

Fixes #50649

Release note (bug fix): there was a bug previously where if a user
created a sequence owned by a table's column and dropped the sequence,
it would become impossible to drop the table after. This is now fixed.
See attached issue for repro steps.
