### PR TITLE
cmd/roachtest: remove the use of runtime.Goexit

### DIFF
--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"runtime"
 	"testing"
 	"time"
 
@@ -243,10 +242,9 @@ func TestClusterMonitor(t *testing.T) {
 			// In reality t.Fatal adds text that is returned when the test fails,
 			// so the failing goroutine will be referenced (not like in the expected
 			// error below, where all you see is the other one being canceled).
-			runtime.Goexit()
-			return errors.New("unreachable")
+			panic(errTestFatal)
 		})
-		expectedErr := regexp.QuoteMeta(`Goexit() was called`)
+		expectedErr := regexp.QuoteMeta(`t.Fatal() was called`)
 		if err := m.wait("sleep", "100"); !testutils.IsError(err, expectedErr) {
 			t.Logf("error details: %+v", err)
 			t.Error(err)

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -234,22 +234,22 @@ func (t *test) WorkerProgress(frac float64) {
 	t.progress(goid.Get(), frac)
 }
 
-// Skip records msg into t.spec.Skip and calls runtime.Goexit() - thus
+// Skip records msg into t.spec.Skip and calls panic(errTestFatal) - thus
 // interrupting the running of the test.
 func (t *test) Skip(msg string, details string) {
 	t.spec.Skip = msg
 	t.spec.SkipDetails = details
-	runtime.Goexit()
+	panic(errTestFatal)
 }
 
 // Fatal marks the test as failed, prints the args to t.l, and calls
-// runtime.GoExit(). It can be called multiple times.
+// panic(errTestFatal). It can be called multiple times.
 //
 // If the only argument is an error, it is formatted by "%+v", so it will show
 // stack traces and such.
 //
-// ATTENTION: Since this calls runtime.GoExit(), it should only be called from a
-// test's closure. The test runner itself should never call this.
+// ATTENTION: Since this calls panic(errTestFatal), it should only be called
+// from a test's closure. The test runner itself should never call this.
 func (t *test) Fatal(args ...interface{}) {
 	t.fatalfInner("" /* format */, args...)
 }
@@ -276,7 +276,7 @@ func (t *test) fatalfInner(format string, args ...interface{}) {
 	} else {
 		t.printAndFail(2 /* skip */, args...)
 	}
-	runtime.Goexit()
+	panic(errTestFatal)
 }
 
 // FatalIfErr calls t.Fatal() if err != nil.

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -593,7 +593,9 @@ func (r *testRunner) runTest(
 	defer func() {
 		t.end = timeutil.Now()
 
-		if err := recover(); err != nil {
+		// We only have to record panics if the panic'd value is not the sentinel
+		// produced by t.Fatal*().
+		if err := recover(); err != nil && err != errTestFatal {
 			t.mu.Lock()
 			t.mu.failed = true
 			t.mu.output = append(t.mu.output, t.decorate(0 /* skip */, fmt.Sprint(err))...)
@@ -744,7 +746,9 @@ func (r *testRunner) runTest(
 
 		// This is the call to actually run the test.
 		defer func() {
-			if r := recover(); r != nil {
+			// We only have to record panics if the panic'd value is not the sentinel
+			// produced by t.Fatal*().
+			if r := recover(); r != nil && r != errTestFatal {
 				// TODO(andreimatei): prevent the cluster from being reused.
 				t.Fatalf("test panicked: %v", r)
 			}


### PR DESCRIPTION
We were abusing `runtime.Goexit` to kill a goroutine when `test.Fatal`
was called, but then transforming then aborting the resulting panic into
a `panic(errGoexit)`. This abuse of `runtime.Goexit` was broken by
go1.14 which makes the panic generated by `Goexit` truly
unrecoverable (previously it was only documented as so). Now we simply
`panic(errGoexit)` from the get-go. This opens up the possibility that a
roachtest may recover from this panic, but no current roachtests call
`recover()`.

See #48737

Release note: None