### PR TITLE
release-19.2: sql: only set DropJobID on old table descriptor in TRUNCATE

### DIFF
--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -186,7 +186,6 @@ func (p *planner) truncateTable(
 	if err != nil {
 		return err
 	}
-	tableDesc.DropJobID = dropJobID
 	newTableDesc := sqlbase.NewMutableCreatedTableDescriptor(tableDesc.TableDescriptor)
 	newTableDesc.ReplacementOf = sqlbase.TableDescriptor_Replacement{
 		ID: id,
@@ -224,6 +223,7 @@ func (p *planner) truncateTable(
 	}
 
 	// Drop table.
+	tableDesc.DropJobID = dropJobID
 	if err := p.initiateDropTable(ctx, tableDesc, false /* drainName */); err != nil {
 		return err
 	}

--- a/pkg/sql/truncate_test.go
+++ b/pkg/sql/truncate_test.go
@@ -1,0 +1,51 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTruncateDoesNotSetDropJobOnNewTable ensures that the new version of a
+// table after a TRUNCATE does not contain a DropJobID. This is a regression
+// test for #50587.
+func TestTruncateDoesNotSetDropJobOnNewTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+
+	getTableDescID := func(t *testing.T, tableName string) (id sqlbase.ID) {
+		tdb.QueryRow(t, `SELECT '`+tableName+`'::regclass::int`).Scan(&id)
+		return id
+	}
+
+	tdb.Exec(t, `CREATE TABLE foo (i INT PRIMARY KEY)`)
+	tdb.Exec(t, `INSERT INTO foo VALUES (1)`)
+	oldID := getTableDescID(t, "foo")
+	tdb.Exec(t, `TRUNCATE foo`)
+	newID := getTableDescID(t, "foo")
+	require.NotEqual(t, oldID, newID)
+	td, err := sqlbase.GetTableDescFromID(ctx, tc.Server(0).DB(), newID)
+	require.NoError(t, err)
+	require.Zero(t, td.DropJobID)
+}


### PR DESCRIPTION
Prior to this commit, we'd populate the DropJobID in both the new and old
tables when truncating a table. This causes problems later. Note that this
commit does not add robustness to clusters which have table descriptors with
a DropJobID due to this bug. That will come in a follow-up.

Touches #50587.

Release note (bug fix): Fixed a bug in TRUNCATE which could later leave
tables in a state where they cannot be renamed.