### PR TITLE
sql: Switch BACKUP statement to use allowed options

### DIFF
--- a/docs/generated/sql/bnf/backup.bnf
+++ b/docs/generated/sql/bnf/backup.bnf
@@ -1,25 +1,5 @@
 backup_stmt ::=
-	'BACKUP' 'TO' partitioned_backup as_of_clause 'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 'WITH' kv_option_list
-	| 'BACKUP' 'TO' partitioned_backup as_of_clause 'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' 'TO' partitioned_backup as_of_clause 'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' 'TO' partitioned_backup as_of_clause  'WITH' kv_option_list
-	| 'BACKUP' 'TO' partitioned_backup as_of_clause  
-	| 'BACKUP' 'TO' partitioned_backup as_of_clause  
-	| 'BACKUP' 'TO' partitioned_backup  'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 'WITH' kv_option_list
-	| 'BACKUP' 'TO' partitioned_backup  'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' 'TO' partitioned_backup  'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' 'TO' partitioned_backup   'WITH' kv_option_list
-	| 'BACKUP' 'TO' partitioned_backup   
-	| 'BACKUP' 'TO' partitioned_backup   
-	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' partitioned_backup as_of_clause 'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 'WITH' kv_option_list
-	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' partitioned_backup as_of_clause 'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' partitioned_backup as_of_clause 'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' partitioned_backup as_of_clause  'WITH' kv_option_list
-	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' partitioned_backup as_of_clause  
-	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' partitioned_backup as_of_clause  
-	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' partitioned_backup  'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 'WITH' kv_option_list
-	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' partitioned_backup  'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' partitioned_backup  'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' partitioned_backup   'WITH' kv_option_list
-	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' partitioned_backup   
-	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' partitioned_backup   
+	'BACKUP' opt_backup_( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' partitioned_backup as_of_clause 'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) opt_with_backup_options
+	| 'BACKUP' opt_backup_( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' partitioned_backup as_of_clause  opt_with_backup_options
+	| 'BACKUP' opt_backup_( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' partitioned_backup  'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) opt_with_backup_options
+	| 'BACKUP' opt_backup_( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' partitioned_backup   opt_with_backup_options

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -104,8 +104,7 @@ alter_stmt ::=
 	| alter_role_stmt
 
 backup_stmt ::=
-	'BACKUP' 'TO' partitioned_backup opt_as_of_clause opt_incremental opt_with_options
-	| 'BACKUP' targets 'TO' partitioned_backup opt_as_of_clause opt_incremental opt_with_options
+	'BACKUP' opt_backup_targets 'TO' partitioned_backup opt_as_of_clause opt_incremental opt_with_backup_options
 
 cancel_stmt ::=
 	cancel_jobs_stmt
@@ -313,6 +312,9 @@ alter_role_stmt ::=
 	'ALTER' role_or_group_or_user string_or_placeholder opt_role_options
 	| 'ALTER' role_or_group_or_user 'IF' 'EXISTS' string_or_placeholder opt_role_options
 
+opt_backup_targets ::=
+	targets
+
 partitioned_backup ::=
 	string_or_placeholder
 	| '(' string_or_placeholder_list ')'
@@ -323,6 +325,11 @@ opt_as_of_clause ::=
 
 opt_incremental ::=
 	'INCREMENTAL' 'FROM' string_or_placeholder_list
+	| 
+
+opt_with_backup_options ::=
+	'WITH' backup_options_list
+	| 'WITH' 'OPTIONS' '(' backup_options_list ')'
 	| 
 
 cancel_jobs_stmt ::=
@@ -680,6 +687,7 @@ unreserved_keyword ::=
 	| 'DOUBLE'
 	| 'DROP'
 	| 'ENCODING'
+	| 'ENCRYPTION_PASSPHRASE'
 	| 'ENUM'
 	| 'ESCAPE'
 	| 'EXCLUDE'
@@ -806,6 +814,7 @@ unreserved_keyword ::=
 	| 'RESTORE'
 	| 'RESTRICT'
 	| 'RESUME'
+	| 'REVISION_HISTORY'
 	| 'REVOKE'
 	| 'ROLE'
 	| 'ROLES'
@@ -1024,6 +1033,9 @@ opt_role_options ::=
 
 as_of_clause ::=
 	'AS' 'OF' 'SYSTEM' 'TIME' a_expr
+
+backup_options_list ::=
+	( backup_options ) ( ( ',' backup_options ) )*
 
 create_changefeed_stmt ::=
 	'CREATE' 'CHANGEFEED' 'FOR' changefeed_targets opt_changefeed_sink opt_with_options
@@ -1403,6 +1415,10 @@ opt_with ::=
 
 role_options ::=
 	( role_option ) ( ( role_option ) )*
+
+backup_options ::=
+	'ENCRYPTION_PASSPHRASE' '=' string_or_placeholder
+	| 'REVISION_HISTORY'
 
 changefeed_targets ::=
 	single_table_pattern_list

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -73,11 +73,6 @@ var useTBI = settings.RegisterBoolSetting(
 	true,
 )
 
-var backupOptionExpectValues = map[string]sql.KVStringOptValidate{
-	backupOptRevisionHistory: sql.KVStringOptRequireNoValue,
-	backupOptEncPassphrase:   sql.KVStringOptRequireValue,
-}
-
 type tableAndIndex struct {
 	tableID sqlbase.ID
 	indexID sqlbase.IndexID
@@ -230,15 +225,11 @@ func getURIsByLocalityKV(to []string, appendPath string) (string, map[string]str
 }
 
 func backupJobDescription(
-	p sql.PlanHookState,
-	backup *tree.Backup,
-	to []string,
-	incrementalFrom []string,
-	opts map[string]string,
+	p sql.PlanHookState, backup *tree.Backup, to []string, incrementalFrom []string,
 ) (string, error) {
 	b := &tree.Backup{
 		AsOf:    backup.AsOf,
-		Options: optsToKVOptions(opts),
+		Options: backup.Options,
 		Targets: backup.Targets,
 	}
 
@@ -279,9 +270,14 @@ func backupPlanHook(
 	if err != nil {
 		return nil, nil, nil, false, err
 	}
-	optsFn, err := p.TypeAsStringOpts(ctx, backupStmt.Options, backupOptionExpectValues)
-	if err != nil {
-		return nil, nil, nil, false, err
+
+	var pwFn func() (string, error)
+	if backupStmt.Options.EncryptionPassphrase != nil {
+		fn, err := p.TypeAsString(ctx, backupStmt.Options.EncryptionPassphrase, "BACKUP")
+		if err != nil {
+			return nil, nil, nil, false, err
+		}
+		pwFn = fn
 	}
 
 	header := sqlbase.ResultColumns{
@@ -334,13 +330,8 @@ func backupPlanHook(
 			}
 		}
 
-		opts, err := optsFn()
-		if err != nil {
-			return err
-		}
-
 		mvccFilter := MVCCFilter_Latest
-		if _, ok := opts[backupOptRevisionHistory]; ok {
+		if backupStmt.Options.CaptureRevisionHistory {
 			mvccFilter = MVCCFilter_All
 		}
 
@@ -380,8 +371,12 @@ func backupPlanHook(
 		makeCloudStorage := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI
 
 		var encryptionPassphrase []byte
-		if passphrase, ok := opts[backupOptEncPassphrase]; ok {
-			encryptionPassphrase = []byte(passphrase)
+		if pwFn != nil {
+			pw, err := pwFn()
+			if err != nil {
+				return err
+			}
+			encryptionPassphrase = []byte(pw)
 		}
 
 		defaultURI, urisByLocalityKV, err := getURIsByLocalityKV(to, "")
@@ -625,7 +620,7 @@ func backupPlanHook(
 			return err
 		}
 
-		description, err := backupJobDescription(p, backupStmt, to, incrementalFrom, opts)
+		description, err := backupJobDescription(p, backupStmt, to, incrementalFrom)
 		if err != nil {
 			return err
 		}

--- a/pkg/internal/sqlsmith/bulkio.go
+++ b/pkg/internal/sqlsmith/bulkio.go
@@ -106,20 +106,11 @@ func makeBackup(s *Smither) (tree.Statement, bool) {
 	s.bulkBackups[name] = targets
 	s.lock.Unlock()
 
-	var opts tree.KVOptions
-	if s.coin() {
-		opts = tree.KVOptions{
-			tree.KVOption{
-				Key: "revision_history",
-			},
-		}
-	}
-
 	return &tree.Backup{
 		Targets: targets,
 		To:      tree.PartitionedBackup{tree.NewStrVal(name)},
 		AsOf:    makeAsOf(s),
-		Options: opts,
+		Options: tree.BackupOptions{CaptureRevisionHistory: s.coin()},
 	}, true
 }
 

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -1941,7 +1941,7 @@ func (node *Backup) doc(p *PrettyCfg) pretty.Doc {
 	if node.IncrementalFrom != nil {
 		items = append(items, p.row("INCREMENTAL FROM", p.Doc(&node.IncrementalFrom)))
 	}
-	if node.Options != nil {
+	if !node.Options.IsDefault() {
 		items = append(items, p.row("WITH", p.Doc(&node.Options)))
 	}
 	return p.rlTable(items...)

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -760,7 +760,6 @@ func walkReturningClause(v Visitor, clause ReturningClause) (ReturningClause, bo
 func (stmt *Backup) copyNode() *Backup {
 	stmtCopy := *stmt
 	stmtCopy.IncrementalFrom = append(Exprs(nil), stmt.IncrementalFrom...)
-	stmtCopy.Options = append(KVOptions(nil), stmt.Options...)
 	return &stmtCopy
 }
 
@@ -794,13 +793,13 @@ func (stmt *Backup) walkStmt(v Visitor) Statement {
 			ret.IncrementalFrom[i] = e
 		}
 	}
-	{
-		opts, changed := walkKVOptions(v, stmt.Options)
+	if stmt.Options.EncryptionPassphrase != nil {
+		pw, changed := WalkExpr(v, stmt.Options.EncryptionPassphrase)
 		if changed {
 			if ret == stmt {
 				ret = stmt.copyNode()
 			}
-			ret.Options = opts
+			ret.Options.EncryptionPassphrase = pw
 		}
 	}
 	return ret


### PR DESCRIPTION
Informs #47539

Modify BACKUP statements "WITH" clause to only accept allowed
explicit options.

This change replaces the "WITH" clause implementation that used
to accept any set of key/value pairs with the one that only
accepts options allowed by the BACKUP statement.

This change does not introduce any new options.
However, this change does introduce two changes on how
we parse those options:
  1. We now check to make sure that each option is specified only once
     and produce error message if the option is specified multiple
     times (which is a mistake that could not have been detected prior
     to this change).
  2. We now disallow quoted option name.


Release Notes (usability): Improve WITH option parsing for backup.
When BACKUP statement is used incorrectly with the same
option specified multiple times inside the WITH clause, we now
produce useful error message.
In addition, we now disallow quoted option names.  This is
a backward incompatible change.
