### PR TITLE
sql: Add 'DETACHED" option to the list of allowed BACKUP options

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -682,6 +682,7 @@ unreserved_keyword ::=
 	| 'DELETE'
 	| 'DEFAULTS'
 	| 'DEFERRED'
+	| 'DETACHED'
 	| 'DISCARD'
 	| 'DOMAIN'
 	| 'DOUBLE'
@@ -1419,6 +1420,7 @@ role_options ::=
 backup_options ::=
 	'ENCRYPTION_PASSPHRASE' '=' string_or_placeholder
 	| 'REVISION_HISTORY'
+	| 'DETACHED'
 
 changefeed_targets ::=
 	single_table_pattern_list

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1470,7 +1470,7 @@ func TestParse(t *testing.T) {
 		{`RESTORE DATABASE foo FROM ($1, $2), ($3, $4)`},
 		{`RESTORE DATABASE foo FROM ($1, $2), ($3, $4) AS OF SYSTEM TIME '1'`},
 
-		{`BACKUP TABLE foo TO 'bar' WITH revision_history`},
+		{`BACKUP TABLE foo TO 'bar' WITH revision_history, detached`},
 		{`RESTORE TABLE foo FROM 'bar' WITH key1, key2 = 'value'`},
 
 		{`IMPORT TABLE foo CREATE USING 'nodelocal://0/some/file' CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
@@ -2138,8 +2138,8 @@ $function$`,
 			`RESTORE TABLE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'`},
 		{`BACKUP foo TO 'bar' WITH ENCRYPTION_PASSPHRASE = 'secret', revision_history`,
 			`BACKUP TABLE foo TO 'bar' WITH revision_history, encryption_passphrase='secret'`},
-		{`BACKUP foo TO 'bar' WITH OPTIONS (ENCRYPTION_PASSPHRASE = 'secret', revision_history)`,
-			`BACKUP TABLE foo TO 'bar' WITH revision_history, encryption_passphrase='secret'`},
+		{`BACKUP foo TO 'bar' WITH OPTIONS (detached, ENCRYPTION_PASSPHRASE = 'secret', revision_history)`,
+			`BACKUP TABLE foo TO 'bar' WITH revision_history, encryption_passphrase='secret', detached`},
 		{`RESTORE foo FROM 'bar' WITH key1, key2 = 'value'`,
 			`RESTORE TABLE foo FROM 'bar' WITH key1, key2 = 'value'`},
 		{`CREATE CHANGEFEED FOR foo INTO 'sink'`, `CREATE CHANGEFEED FOR TABLE foo INTO 'sink'`},
@@ -2991,6 +2991,12 @@ HINT: try \h BACKUP`,
 DETAIL: source SQL:
 BACKUP foo TO 'bar' WITH revision_history, revision_history
                                            ^`,
+		},
+		{`BACKUP foo TO 'bar' WITH detached, revision_history, detached`,
+			`at or near "detached": syntax error: detached option specified multiple times
+DETAIL: source SQL:
+BACKUP foo TO 'bar' WITH detached, revision_history, detached
+                                                     ^`,
 		},
 	}
 	for _, d := range testData {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -566,7 +566,7 @@ func (u *sqlSymUnion) alterTypeAddValuePlacement() *tree.AlterTypeAddValuePlacem
 %token <str> CURRENT_USER CYCLE
 
 %token <str> DATA DATABASE DATABASES DATE DAY DEC DECIMAL DEFAULT DEFAULTS
-%token <str> DEALLOCATE DECLARE DEFERRABLE DEFERRED DELETE DESC
+%token <str> DEALLOCATE DECLARE DEFERRABLE DEFERRED DELETE DESC DETACHED
 %token <str> DISCARD DISTINCT DO DOMAIN DOUBLE DROP
 
 %token <str> ELSE ENCODING ENCRYPTION_PASSPHRASE END ENUM ESCAPE EXCEPT EXCLUDE EXCLUDING
@@ -2020,6 +2020,7 @@ alter_attribute_action:
 // Options:
 //    revision_history: enable revision history
 //    encryption_passphrase="secret": encrypt backups
+//    detached: execute backup job asynchronously, without waiting for its completion.
 //
 // %SeeAlso: RESTORE, WEBDOCS/backup.html
 backup_stmt:
@@ -2092,6 +2093,10 @@ backup_options:
 | REVISION_HISTORY
   {
     $$.val = &tree.BackupOptions{CaptureRevisionHistory: true}
+  }
+| DETACHED
+  {
+    $$.val = &tree.BackupOptions{Detached: true}
   }
 
 // %Help: RESTORE - restore data from external storage
@@ -10349,6 +10354,7 @@ unreserved_keyword:
 | DELETE
 | DEFAULTS
 | DEFERRED
+| DETACHED
 | DISCARD
 | DOMAIN
 | DOUBLE


### PR DESCRIPTION
Informs #47539

Add `DETACHED` option to the list of allowed BACKUP options.
This option requests the backup to run in detached mode: that is,
backup statement should not block, and instead simply return the job id.

Release Notes : None
