### PR TITLE
sql: avoid copying ColumnDescriptors in initColsForScan

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -920,7 +920,7 @@ func tableOrdinal(
 // toTableOrdinals returns a mapping from column ordinals in cols to table
 // reader column ordinals.
 func toTableOrdinals(
-	cols []sqlbase.ColumnDescriptor,
+	cols []*sqlbase.ColumnDescriptor,
 	desc *sqlbase.ImmutableTableDescriptor,
 	visibility execinfrapb.ScanVisibility,
 ) []int {
@@ -934,17 +934,17 @@ func toTableOrdinals(
 // getOutputColumnsFromColsForScan returns the indices of the columns that are
 // returned by a scanNode or a tableReader.
 // If remap is not nil, the column ordinals are remapped accordingly.
-func getOutputColumnsFromColsForScan(cols []sqlbase.ColumnDescriptor, remap []int) []uint32 {
-	outputColumns := make([]uint32, 0, len(cols))
+func getOutputColumnsFromColsForScan(cols []*sqlbase.ColumnDescriptor, remap []int) []uint32 {
+	outputColumns := make([]uint32, len(cols))
 	// TODO(radu): if we have a scan with a filter, cols will include the
 	// columns needed for the filter, even if they aren't needed for the next
 	// stage.
-	for i := 0; i < len(cols); i++ {
+	for i := range outputColumns {
 		colIdx := i
 		if remap != nil {
 			colIdx = remap[i]
 		}
-		outputColumns = append(outputColumns, uint32(colIdx))
+		outputColumns[i] = uint32(colIdx)
 	}
 	return outputColumns
 }
@@ -1085,7 +1085,7 @@ type tableReaderPlanningInfo struct {
 	maxResults             uint64
 	estimatedRowCount      uint64
 	reqOrdering            ReqOrdering
-	cols                   []sqlbase.ColumnDescriptor
+	cols                   []*sqlbase.ColumnDescriptor
 	colsToTableOrdrinalMap []int
 }
 

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -123,7 +123,7 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	if err != nil {
 		return nil, err
 	}
-	p.ResultColumns = sqlbase.ResultColumnsFromColDescs(tabDesc.GetID(), cols)
+	p.ResultColumns = sqlbase.ResultColumnsFromColDescPtrs(tabDesc.GetID(), cols)
 
 	if indexConstraint != nil && indexConstraint.IsContradiction() {
 		// TODO(yuzefovich): once ConstructValues is implemented, consider


### PR DESCRIPTION
This change switches `scanNode` from constructing and passing around a `[]ColumnDescriptor` to constructing and passing around a `[]*ColumnDescriptor` which references the existing `ColumnDescriptor`s in the `TableDescriptor`. This is in response to seeing the allocation in `initColsForScan` pop up as the single largest source of total heap allocations by size (`alloc_space`, the heap profile sample that most closely measures GC pressure) while running TPC-E. The allocation in `initColsForScan` was responsible for **4.1%** of the `alloc_space` profile after a 30 minute run of the workload.

In general, this indicates that we should move away from copying around these ColumnDescriptors by value. They are currently 120 bytes large, which isn't huge, but also isn't small. Furthermore, unlike TableDescriptors, we almost never pass around only a single ColumnDescriptor. Instead, we're usually operating on every column touched by a query, so this 120 bytes can blow up fast. For instance, if we estimate that the average TPC-E query touches somewhere between 8 and 10 columns then a single copy of all of these descriptors during the execution of a query (like we were doing in initColsForScan) requires allocating and copying over 1KB of memory.

Yahor, I'm assigning you for two reasons. One, because you seem to be working most closely to this code and likely have a good idea for how disruptive this kind of change will be. I don't want to split the world into functions that work with []ColumnDescriptor and functions that work with []*ColumnDescriptor. I also figured you'd be interested to know that I was running this using an older SHA and the second and third largest sources of allocations were in `createTableReaders` (**3.54%**) and `ColumnTypesWithMutations` (**2.60%**). Both had to do with constructing slices of `types.T` and both appear to have been fixed by c06277e. So nice job with that change!