### PR TITLE
colexec: add benchmark of hash aggregator against wrapped processor

### DIFF
--- a/pkg/sql/colexec/op_creation.go
+++ b/pkg/sql/colexec/op_creation.go
@@ -68,6 +68,9 @@ type NewColOperatorArgs struct {
 		// are opened/closed, which ensures that the number of open files never
 		// exceeds what is expected.
 		DelegateFDAcquisitions bool
+		// MustWrapCore can be set to indicate that a particular processor core
+		// must be wrapped (meaning it disables vectorization of that core).
+		MustWrapCore *execinfrapb.ProcessorCoreUnion
 	}
 }
 


### PR DESCRIPTION
The benchmark shows that it is actually faster to use the wrapped
aggregator processor with the group sizes up to 64 elements or so.

Release note: None