### PR TITLE
roachtest: fix django nightly test

### DIFF
--- a/pkg/cmd/roachtest/django.go
+++ b/pkg/cmd/roachtest/django.go
@@ -20,7 +20,7 @@ var djangoReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)\
 var djangoCockroachDBReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)$`)
 
 var djangoSupportedTag = "3.0.6"
-var djangoCockroachDBSupportedTag = "3.0"
+var djangoCockroachDBSupportedTag = "3.0.1"
 
 func registerDjango(r *testRegistry) {
 	runDjango := func(
@@ -112,9 +112,9 @@ func registerDjango(r *testRegistry) {
 			ctx,
 			t.l,
 			c,
-			"https://github.com/django/django/",
+			"https://github.com/timgraham/django/",
 			"/mnt/data1/django",
-			djangoSupportedTag,
+			"cockroach-3.0.x",
 			node,
 		); err != nil {
 			t.Fatal(err)
@@ -202,8 +202,7 @@ func registerDjango(r *testRegistry) {
 		results := newORMTestsResults()
 		results.parsePythonUnitTestOutput(fullTestResults, expectedFailureList, ignoredlist)
 		results.summarizeAll(
-			t, "django" /* ormName */, blocklistName,
-			expectedFailureList, version, djangoLatestTag,
+			t, "django" /* ormName */, blocklistName, expectedFailureList, version, djangoSupportedTag,
 		)
 	}
 

--- a/pkg/cmd/roachtest/django_blocklist.go
+++ b/pkg/cmd/roachtest/django_blocklist.go
@@ -15,8 +15,6 @@ package main
 // in alphabetical order. As more progress is made with adding compatibility,
 // more test apps should be added here to prevent against regression.
 var enabledDjangoTests = []string{
-	"app_loading",
-	"apps",
 	"admin_changelist",
 	"admin_custom_urls",
 	"admin_docs",
@@ -30,8 +28,6 @@ var enabledDjangoTests = []string{
 	"annotations",
 	"auth_tests",
 	"backends",
-	"base",
-	"bash_completion",
 	"basic",
 	"bulk_create",
 	"cache",


### PR DESCRIPTION
The test needs to be run against a fork of Django that has testing fixes
in order to work with versions <=19.2. Also, some of the tests that were
enabled are not actually expected to pass yet. Finally, version 3.0.1 of
the adapter is needed in order to correctly do table introspection for
v20.1.

Release note: None