### PR TITLE
roachtest: install pinned pgx version

### DIFF
--- a/pkg/cmd/roachtest/pgx.go
+++ b/pkg/cmd/roachtest/pgx.go
@@ -49,7 +49,7 @@ func registerPgx(r *testRegistry) {
 
 		t.Status("installing pgx")
 		if err := repeatRunE(
-			ctx, c, node, "install pgx", "go get -u github.com/jackc/pgx",
+			ctx, c, node, "install pgx", fmt.Sprintf("go get -u github.com/jackc/pgx@%s", supportedTag),
 		); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Previously, the latest version of pgx would always be installed. Now the
supported version is used instead.

fixes #50741

Release note: None