### PR TITLE
opt: add indexed var for inverted column when execbuilding inverted joins

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/geospatial
@@ -62,3 +62,20 @@ InitPut /Table/53/2/1153290940513779712/4/0 -> /BYTES/
 InitPut /Table/53/2/1154047404446580736/4/0 -> /BYTES/
 InitPut /Table/53/2/1154328879490400256/4/0 -> /BYTES/
 InitPut /Table/53/3/1152921510042997845/4/0 -> /BYTES/
+
+statement ok
+CREATE TABLE ltable(
+  k int primary key,
+  geom geometry
+)
+
+statement ok
+CREATE TABLE rtable(
+  k int primary key,
+  geom geometry,
+  INVERTED INDEX geom_index(geom)
+)
+
+query error Geospatial joins are not yet supported
+SELECT url FROM [EXPLAIN (DISTSQL)
+SELECT ltable.k, rtable.k FROM ltable JOIN rtable@geom_index ON ST_Intersects(ltable.geom, rtable.geom)]

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -249,8 +249,8 @@ type Factory interface {
 	//
 	// The node produces the columns in the input and (unless join type is
 	// LeftSemiJoin or LeftAntiJoin) the lookupCols, ordered by ordinal. The ON
-	// condition can refer to these using IndexedVars. Note that lookupCols does
-	// not include the inverted column.
+	// condition can refer to these using IndexedVars. Note that lookupCols
+	// includes the inverted column.
 	ConstructInvertedJoin(
 		joinType sqlbase.JoinType,
 		invertedExpr tree.TypedExpr,

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -361,6 +361,10 @@ define InvertedJoinPrivate {
     # the cat.Table.Index() method in order to fetch the cat.Index metadata.
     Index IndexOrdinal
 
+    # InvertedCol is the inverted column in the index that is referenced by
+    # InvertedExpr.
+    InvertedCol ColumnID
+
     # InputCol is the column (produced by the input) that will be bound to
     # InvertedExpr and used to determine the keys to scan in the inverted
     # index.

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -1935,6 +1935,7 @@ func (c *CustomFuncs) GenerateGeoLookupJoins(
 		lookupJoin.Table = scanPrivate.Table
 		lookupJoin.Index = iter.IndexOrdinal()
 		lookupJoin.InvertedExpr = function
+		lookupJoin.InvertedCol = indexGeoCol
 		lookupJoin.InputCol = inputGeoCol
 		lookupJoin.Cols = indexCols.Union(inputProps.OutputCols)
 


### PR DESCRIPTION
This commit fixes an issue identified in #50709 in which the `execbuilder`
code for building inverted joins was failing due to the lack of an indexed
var for the column indexed by the inverted index. The indexed var is
necessary since the inverted expression contains a reference to the inverted
column. This commit fixes the issue by including the column in the indexed var
helper.

This commit does not include a release note since this issue was introduced
a few days ago and has not been released.

Release note: None