### PR TITLE
backupccl: fix bug when restoring cluster with empty db as highest id

### DIFF
--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -221,6 +221,13 @@ func allocateDescriptorRewrites(
 		}
 	}
 
+	// Include the database descriptors when calculating the max ID.
+	for _, database := range databasesByID {
+		if int64(database.ID) > maxDescIDInBackup {
+			maxDescIDInBackup = int64(database.ID)
+		}
+	}
+
 	// Include the type descriptors when calculating the max ID.
 	for _, typ := range typesByID {
 		if int64(typ.ID) > maxDescIDInBackup {


### PR DESCRIPTION
Previously, there was a bug where cluster restore would fail when the
largest descriptor in the backup was a database. This commit fixes the
bug.

Fixes #50561.

Release note (bug fix): Previously, there was a bug where cluster
restore would fail when the largest descriptor in the backup was a
database. This is typically seen when the last action in backing up
cluster was a database creation.