### PR TITLE
release-19.1: sql: fix bug which prevented RENAME after TRUNCATE

### DIFF
--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -190,7 +190,6 @@ func (p *planner) truncateTable(
 	if err != nil {
 		return err
 	}
-	tableDesc.DropJobID = dropJobID
 	newTableDesc := sqlbase.NewMutableCreatedTableDescriptor(tableDesc.TableDescriptor)
 	newTableDesc.ReplacementOf = sqlbase.TableDescriptor_Replacement{
 		ID: id, Time: p.txn.CommitTimestamp(),
@@ -222,6 +221,7 @@ func (p *planner) truncateTable(
 	}
 
 	// Drop table.
+	tableDesc.DropJobID = dropJobID
 	if err := p.initiateDropTable(ctx, tableDesc, false /* drainName */); err != nil {
 		return err
 	}

--- a/pkg/sql/truncate_test.go
+++ b/pkg/sql/truncate_test.go
@@ -1,0 +1,51 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTruncateDoesNotSetDropJobOnNewTable ensures that the new version of a
+// table after a TRUNCATE does not contain a DropJobID. This is a regression
+// test for #50587.
+func TestTruncateDoesNotSetDropJobOnNewTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+
+	getTableDescID := func(t *testing.T, tableName string) (id sqlbase.ID) {
+		tdb.QueryRow(t, `SELECT '`+tableName+`'::regclass::int`).Scan(&id)
+		return id
+	}
+
+	tdb.Exec(t, `CREATE TABLE foo (i INT PRIMARY KEY)`)
+	tdb.Exec(t, `INSERT INTO foo VALUES (1)`)
+	oldID := getTableDescID(t, "foo")
+	tdb.Exec(t, `TRUNCATE foo`)
+	newID := getTableDescID(t, "foo")
+	require.NotEqual(t, oldID, newID)
+	td, err := sqlbase.GetTableDescFromID(ctx, tc.Server(0).DB(), newID)
+	require.NoError(t, err)
+	require.Zero(t, td.DropJobID)
+}


### PR DESCRIPTION
Backport:
  * 1/1 commits from "sql: only set DropJobID on old table descriptor in TRUNCATE" (#50714)
  * 1/1 commits from "sql: repair bogus DropJobID on PUBLIC tables in drainNames" (#50756)

Please see individual PRs for details.

/cc @cockroachdb/release
