### PR TITLE
sql: allow for dropping indexes in use in outbound fk

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -72,6 +72,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>20.1-8</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>20.1-9</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -68,6 +68,7 @@ const (
 	VersionAlterSystemJobsAddCreatedByColumns
 	VersionAddScheduledJobsTable
 	VersionUserDefinedSchemas
+	VersionNoOriginFKIndexes
 
 	// Add new versions here (step one of two).
 )
@@ -516,6 +517,12 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// VersionUserDefinedSchemas enables the creation of user defined schemas.
 		Key:     VersionUserDefinedSchemas,
 		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 8},
+	},
+	{
+		// VersionNoOriginFKIndexes allows for foreign keys to no longer need
+		// indexes on the origin side of the relationship.
+		Key:     VersionNoOriginFKIndexes,
+		Version: roachpb.Version{Major: 20, Minor: 1, Unstable: 9},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/clusterversion/versionkey_string.go
+++ b/pkg/clusterversion/versionkey_string.go
@@ -44,11 +44,12 @@ func _() {
 	_ = x[VersionAlterSystemJobsAddCreatedByColumns-33]
 	_ = x[VersionAddScheduledJobsTable-34]
 	_ = x[VersionUserDefinedSchemas-35]
+	_ = x[VersionNoOriginFKIndexes-36]
 }
 
-const _VersionKey_name = "Version19_1VersionStart19_2VersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDsVersionHashShardedIndexesVersionCreateRolePrivilegeVersionStatementDiagnosticsSystemTablesVersionSchemaChangeJobVersionSavepointsVersionTimeTZTypeVersionTimePrecisionVersion20_1VersionStart20_2VersionGeospatialTypeVersionEnumsVersionRangefeedLeasesVersionAlterColumnTypeGeneralVersionAlterSystemJobsAddCreatedByColumnsVersionAddScheduledJobsTableVersionUserDefinedSchemas"
+const _VersionKey_name = "Version19_1VersionStart19_2VersionLearnerReplicasVersionTopLevelForeignKeysVersionAtomicChangeReplicasTriggerVersionAtomicChangeReplicasVersionTableDescModificationTimeFromMVCCVersionPartitionedBackupVersion19_2VersionStart20_1VersionContainsEstimatesCounterVersionChangeReplicasDemotionVersionSecondaryIndexColumnFamiliesVersionNamespaceTableWithSchemasVersionProtectedTimestampsVersionPrimaryKeyChangesVersionAuthLocalAndTrustRejectMethodsVersionPrimaryKeyColumnsOutOfFamilyZeroVersionRootPasswordVersionNoExplicitForeignKeyIndexIDsVersionHashShardedIndexesVersionCreateRolePrivilegeVersionStatementDiagnosticsSystemTablesVersionSchemaChangeJobVersionSavepointsVersionTimeTZTypeVersionTimePrecisionVersion20_1VersionStart20_2VersionGeospatialTypeVersionEnumsVersionRangefeedLeasesVersionAlterColumnTypeGeneralVersionAlterSystemJobsAddCreatedByColumnsVersionAddScheduledJobsTableVersionUserDefinedSchemasVersionNoOriginFKIndexes"
 
-var _VersionKey_index = [...]uint16{0, 11, 27, 49, 75, 109, 136, 176, 200, 211, 227, 258, 287, 322, 354, 380, 404, 441, 480, 499, 534, 559, 585, 624, 646, 663, 680, 700, 711, 727, 748, 760, 782, 811, 852, 880, 905}
+var _VersionKey_index = [...]uint16{0, 11, 27, 49, 75, 109, 136, 176, 200, 211, 227, 258, 287, 322, 354, 380, 404, 441, 480, 499, 534, 559, 585, 624, 646, 663, 680, 700, 711, 727, 748, 760, 782, 811, 852, 880, 905, 929}
 
 func (i VersionKey) String() string {
 	if i < 0 || i >= VersionKey(len(_VersionKey_index)-1) {

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -16,6 +16,7 @@ import (
 	gojson "encoding/json"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -457,9 +458,6 @@ func (n *alterTableNode) startExec(params runParams) error {
 			}
 
 			// Drop check constraints which reference the column.
-			// Note that foreign key constraints are dropped as part of dropping
-			// indexes on the column. In the future, when FKs no longer depend on
-			// indexes in the same way, FKs will have to be dropped separately here.
 			validChecks := n.tableDesc.Checks[:0]
 			for _, check := range n.tableDesc.AllActiveAndInactiveChecks() {
 				if used, err := check.UsesColumn(n.tableDesc.TableDesc(), colToDrop.ID); err != nil {
@@ -484,6 +482,26 @@ func (n *alterTableNode) startExec(params runParams) error {
 			}
 			if err := params.p.removeColumnComment(params.ctx, n.tableDesc.ID, colToDrop.ID); err != nil {
 				return err
+			}
+
+			// Since we are able to drop indexes used by foreign keys on the origin side,
+			// the drop index codepaths aren't going to remove dependent FKs, so we
+			// need to do that here.
+			if params.p.ExecCfg().Settings.Version.IsActive(params.ctx, clusterversion.VersionNoOriginFKIndexes) {
+				// We update the FK's slice in place here.
+				sliceIdx := 0
+				for i := range n.tableDesc.OutboundFKs {
+					n.tableDesc.OutboundFKs[sliceIdx] = n.tableDesc.OutboundFKs[i]
+					sliceIdx++
+					fk := &n.tableDesc.OutboundFKs[i]
+					if sqlbase.ColumnIDs(fk.OriginColumnIDs).Contains(colToDrop.ID) {
+						sliceIdx--
+						if err := params.p.removeFKBackReference(params.ctx, n.tableDesc, fk); err != nil {
+							return err
+						}
+					}
+				}
+				n.tableDesc.OutboundFKs = n.tableDesc.OutboundFKs[:sliceIdx]
 			}
 
 			found := false

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -356,29 +356,34 @@ func (p *planner) dropIndexByName(
 		return err
 	}
 
+	// If the we aren't at a high enough version to drop indexes on the origin
+	// side then we have to attempt to delete them.
+	if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.VersionNoOriginFKIndexes) {
+		// Index for updating the FK slices in place when removing FKs.
+		sliceIdx := 0
+		for i := range tableDesc.OutboundFKs {
+			tableDesc.OutboundFKs[sliceIdx] = tableDesc.OutboundFKs[i]
+			sliceIdx++
+			fk := &tableDesc.OutboundFKs[i]
+			canReplace := func(idx *sqlbase.IndexDescriptor) bool {
+				return idx.IsValidOriginIndex(fk.OriginColumnIDs)
+			}
+			// The index being deleted could be used as the origin index for this foreign key.
+			if idx.IsValidOriginIndex(fk.OriginColumnIDs) && !indexHasReplacementCandidate(canReplace) {
+				if behavior != tree.DropCascade && constraintBehavior != ignoreIdxConstraint {
+					return errors.Errorf("index %q is in use as a foreign key constraint", idx.Name)
+				}
+				sliceIdx--
+				if err := p.removeFKBackReference(ctx, tableDesc, fk); err != nil {
+					return err
+				}
+			}
+		}
+		tableDesc.OutboundFKs = tableDesc.OutboundFKs[:sliceIdx]
+	}
+
 	// Index for updating the FK slices in place when removing FKs.
 	sliceIdx := 0
-	for i := range tableDesc.OutboundFKs {
-		tableDesc.OutboundFKs[sliceIdx] = tableDesc.OutboundFKs[i]
-		sliceIdx++
-		fk := &tableDesc.OutboundFKs[i]
-		canReplace := func(idx *sqlbase.IndexDescriptor) bool {
-			return idx.IsValidOriginIndex(fk.OriginColumnIDs)
-		}
-		// The index being deleted could be used as the origin index for this foreign key.
-		if idx.IsValidOriginIndex(fk.OriginColumnIDs) && !indexHasReplacementCandidate(canReplace) {
-			if behavior != tree.DropCascade && constraintBehavior != ignoreIdxConstraint {
-				return errors.Errorf("index %q is in use as a foreign key constraint", idx.Name)
-			}
-			sliceIdx--
-			if err := p.removeFKBackReference(ctx, tableDesc, fk); err != nil {
-				return err
-			}
-		}
-	}
-	tableDesc.OutboundFKs = tableDesc.OutboundFKs[:sliceIdx]
-
-	sliceIdx = 0
 	for i := range tableDesc.InboundFKs {
 		tableDesc.InboundFKs[sliceIdx] = tableDesc.InboundFKs[i]
 		sliceIdx++

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -259,9 +259,6 @@ INSERT INTO t (a, d) VALUES (23, 24)
 statement error foreign key
 INSERT INTO t VALUES (31, 7, 32)
 
-statement error in use as a foreign key constraint
-DROP INDEX t@t_f_idx
-
 statement ok
 ALTER TABLE t DROP CONSTRAINT fk_f_ref_other
 
@@ -1354,3 +1351,19 @@ CREATE TABLE d.public.t50069_a (x INT);
 
 statement error pq: no data source matches prefix: d.public.t50069_a in this context
 ALTER TABLE t50069_a ADD COLUMN y INT AS (d.public.t50069_a.x + 1) STORED
+
+# Dropping a column with a foreign key should delete the column and the FK.
+statement ok
+DROP TABLE IF EXISTS parent, child;
+CREATE TABLE parent (p INT PRIMARY KEY);
+CREATE TABLE child (c INT PRIMARY KEY, p INT REFERENCES parent(p), FAMILY (c, p));
+ALTER TABLE child DROP COLUMN p
+
+query TT
+SHOW CREATE child
+----
+child  CREATE TABLE child (
+       c INT8 NOT NULL,
+       CONSTRAINT "primary" PRIMARY KEY (c ASC),
+       FAMILY fam_0_c_p (c)
+)

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -269,23 +269,9 @@ DROP INDEX tu_a
 # Test that we have more relaxed restrictions on dropping indexes referenced by fks.
 subtest fk_drop
 
-# Ensure that we can drop an index used by a foreign key if there is another
-# index that can take its place.
-statement ok
-CREATE TABLE fk1 (x INT);
-CREATE TABLE fk2 (x INT PRIMARY KEY);
-ALTER TABLE fk1 ADD CONSTRAINT fk1 FOREIGN KEY (x) REFERENCES fk2 (x);
-CREATE INDEX i ON fk1 (x);
-DROP INDEX fk1_auto_index_fk1
-
-statement error pq: index "i" is in use as a foreign key constraint
-DROP INDEX fk1@i
-
 # Ensure that DROP INDEX CASCADE does not delete the foreign key when
 # there is another index that can satisfy the foreign key constraint.
 statement ok
-DROP TABLE fk1;
-DROP TABLE fk2;
 CREATE TABLE fk1 (x int);
 CREATE TABLE fk2 (x int PRIMARY KEY);
 CREATE INDEX i ON fk1 (x);
@@ -300,18 +286,6 @@ fk1  CREATE TABLE fk1 (
      x INT8 NULL,
      CONSTRAINT fk1 FOREIGN KEY (x) REFERENCES fk2(x),
      INDEX i2 (x ASC),
-     FAMILY "primary" (x, rowid)
-)
-
-# Ensure that now the cascade deletes the foreign key constraint.
-statement ok
-DROP INDEX fk1@i2 CASCADE
-
-query TT
-SHOW CREATE fk1
-----
-fk1  CREATE TABLE fk1 (
-     x INT8 NULL,
      FAMILY "primary" (x, rowid)
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -655,12 +655,6 @@ ALTER TABLE delivery DROP COLUMN "item"
 statement ok
 DROP INDEX products@products_upc_key CASCADE
 
-statement error index "orders_product_idx" is in use as a foreign key constraint
-DROP INDEX orders@orders_product_idx
-
-statement error index "orders_product_idx" is in use as a foreign key constraint
-DROP INDEX orders@orders_product_idx RESTRICT
-
 statement error "products" is referenced by foreign key from table "orders"
 DROP TABLE products
 
@@ -713,14 +707,8 @@ INSERT INTO child VALUES (2, 2)
 statement error pgcode 23503 foreign key 
 INSERT INTO grandchild VALUES (1, 1)
 
-statement error in use as a foreign key constraint
+statement ok
 DROP INDEX grandchild@grandchild_parent_id_idx
-
-statement ok
-DROP INDEX grandchild@grandchild_parent_id_idx CASCADE
-
-statement ok
-INSERT INTO grandchild VALUES (1, 1)
 
 statement ok
 DROP TABLE grandchild

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1543,7 +1543,8 @@ COMMIT
 query TTTTB
 SHOW CONSTRAINTS FROM y
 ----
-y  primary  PRIMARY KEY  PRIMARY KEY (a ASC)  true
+y  fk_b_ref_x  FOREIGN KEY  FOREIGN KEY (b) REFERENCES x(b)  true
+y  primary     PRIMARY KEY  PRIMARY KEY (a ASC)              true
 
 # Also test dropping the index on the referenced side
 statement ok

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":505,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":510,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -102,6 +102,16 @@ func (c ColumnIDs) Equals(input ColumnIDs) bool {
 	return true
 }
 
+// Contains returns whether this list contains the input ID.
+func (c ColumnIDs) Contains(i ColumnID) bool {
+	for _, id := range c {
+		if i == id {
+			return true
+		}
+	}
+	return false
+}
+
 // FamilyID is a custom type for ColumnFamilyDescriptor IDs.
 type FamilyID uint32
 

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -373,7 +373,7 @@ func (desc *TableDescriptor) collectConstraintInfo(
 ) (map[string]ConstraintDetail, error) {
 	info := make(map[string]ConstraintDetail)
 
-	// Indexes provide PK, Unique and FK constraints.
+	// Indexes provide PK and Unique constraints.
 	indexes := desc.AllNonDropIndexes()
 	for _, index := range indexes {
 		if index.ID == desc.PrimaryIndex.ID {


### PR DESCRIPTION
Fixes #50592.

Release note (sql change): This PR enables the use of dropping indexes
used in outbound foreign key relationships.