### PR TITLE
sql: stop creating indexes on the origin side of an FK

### DIFF
--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -192,7 +192,6 @@ func TestShowBackup(t *testing.T) {
 				b INT8 NULL,
 				CONSTRAINT "primary" PRIMARY KEY (a ASC),
 				CONSTRAINT fk_b_ref_fksrc FOREIGN KEY (b) REFERENCES fksrc(a),
-				INDEX fkreftable_auto_index_fk_b_ref_fksrc (b ASC),
 				FAMILY "primary" (a, b)
 			)`
 		wantDiffDB := `CREATE TABLE fkreftable (
@@ -200,7 +199,6 @@ func TestShowBackup(t *testing.T) {
 				b INT8 NULL,
 				CONSTRAINT "primary" PRIMARY KEY (a ASC),
 				CONSTRAINT fk_b_ref_fksrc FOREIGN KEY (b) REFERENCES data.public.fksrc(a),
-				INDEX fkreftable_auto_index_fk_b_ref_fksrc (b ASC),
 				FAMILY "primary" (a, b)
 			)`
 
@@ -226,7 +224,6 @@ func TestShowBackup(t *testing.T) {
 				a INT8 NOT NULL,
 				b INT8 NULL,
 				CONSTRAINT "primary" PRIMARY KEY (a ASC),
-				INDEX fkreftable_auto_index_fk_b_ref_fksrc (b ASC),
 				FAMILY "primary" (a, b)
 			)`
 

--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -737,7 +737,6 @@ CREATE TABLE account (
 	person_id INT8 NULL,
 	accountno INT8 NOT NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	INDEX account_auto_index_fk_person_id_ref_person (person_id ASC),
 	FAMILY "primary" (id, person_id, accountno)
 );
 

--- a/pkg/cli/testdata/dump/reference_cycle
+++ b/pkg/cli/testdata/dump/reference_cycle
@@ -34,7 +34,6 @@ CREATE TABLE loop_b (
 	id INT8 NOT NULL,
 	a_id INT8 NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	INDEX loop_b_auto_index_fk_a_id_ref_loop_a (a_id ASC),
 	FAMILY "primary" (id, a_id)
 );
 
@@ -72,7 +71,6 @@ CREATE TABLE loop_b (
 	id INT8 NOT NULL,
 	a_id INT8 NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	INDEX loop_b_auto_index_fk_a_id_ref_loop_a (a_id ASC),
 	FAMILY "primary" (id, a_id)
 );
 

--- a/pkg/cli/testdata/dump/reference_order
+++ b/pkg/cli/testdata/dump/reference_order
@@ -43,7 +43,6 @@ CREATE TABLE b (
 
 CREATE TABLE a (
 	i INT8 NULL,
-	INDEX a_auto_index_fk_i_ref_b (i ASC),
 	FAMILY "primary" (i, rowid)
 );
 
@@ -63,7 +62,6 @@ CREATE TABLE f (
 	i INT8 NOT NULL,
 	g INT8 NULL,
 	CONSTRAINT "primary" PRIMARY KEY (i ASC),
-	INDEX f_auto_index_fk_g_ref_g (g ASC),
 	FAMILY "primary" (i, g)
 );
 
@@ -72,14 +70,11 @@ CREATE TABLE d (
 	e INT8 NULL,
 	f INT8 NULL,
 	CONSTRAINT "primary" PRIMARY KEY (i ASC),
-	INDEX d_auto_index_fk_e_ref_e (e ASC),
-	INDEX d_auto_index_fk_f_ref_f (f ASC),
 	FAMILY "primary" (i, e, f)
 );
 
 CREATE TABLE c (
 	i INT8 NULL,
-	INDEX c_auto_index_fk_i_ref_d (i ASC),
 	FAMILY "primary" (i, rowid)
 );
 
@@ -152,8 +147,6 @@ CREATE TABLE d (
 	e INT8 NULL,
 	f INT8 NULL,
 	CONSTRAINT "primary" PRIMARY KEY (i ASC),
-	INDEX d_auto_index_fk_e_ref_e (e ASC),
-	INDEX d_auto_index_fk_f_ref_f (f ASC),
 	FAMILY "primary" (i, e, f)
 );
 

--- a/pkg/cli/testdata/dump/reference_self
+++ b/pkg/cli/testdata/dump/reference_self
@@ -24,7 +24,6 @@ CREATE TABLE t (
 	id INT8 NOT NULL,
 	next_id INT8 NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	INDEX t_auto_index_fk_next_id_ref_t (next_id ASC),
 	FAMILY "primary" (id, next_id)
 );
 
@@ -52,7 +51,6 @@ CREATE TABLE t (
 	id INT8 NOT NULL,
 	next_id INT8 NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	INDEX t_auto_index_fk_next_id_ref_t (next_id ASC),
 	FAMILY "primary" (id, next_id)
 );
 
@@ -81,7 +79,6 @@ CREATE TABLE "table" (
 	id INT8 NOT NULL,
 	"'" INT8 NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	INDEX t_auto_index_fk_next_id_ref_t ("'" ASC),
 	FAMILY "primary" (id, "'")
 );
 
@@ -104,7 +101,6 @@ CREATE TABLE "table" (
 	id INT8 NOT NULL,
 	"'" INT8 NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	INDEX t_auto_index_fk_next_id_ref_t ("'" ASC),
 	FAMILY "primary" (id, "'")
 );
 

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -626,6 +626,7 @@ func ResolveFK(
 	evalCtx *tree.EvalContext,
 ) error {
 	originCols := make([]*sqlbase.ColumnDescriptor, len(d.FromCols))
+	originColMap := make(map[sqlbase.ColumnID]struct{}, len(d.FromCols))
 	for i, col := range d.FromCols {
 		col, err := tbl.FindActiveOrNewColumnByName(col)
 		if err != nil {
@@ -634,6 +635,12 @@ func ResolveFK(
 		if err := col.CheckCanBeFKRef(); err != nil {
 			return err
 		}
+		// Ensure that the origin columns don't have duplicates.
+		if _, ok := originColMap[col.ID]; ok {
+			return pgerror.Newf(pgcode.InvalidForeignKey,
+				"foreign key contains duplicate column %q", col.Name)
+		}
+		originColMap[col.ID] = struct{}{}
 		originCols[i] = col
 	}
 
@@ -727,6 +734,11 @@ func ResolveFK(
 		}
 	}
 
+	originColumnIDs := make(sqlbase.ColumnIDs, len(originCols))
+	for i, col := range originCols {
+		originColumnIDs[i] = col.ID
+	}
+
 	targetColIDs := make(sqlbase.ColumnIDs, len(referencedCols))
 	for i := range referencedCols {
 		targetColIDs[i] = referencedCols[i].ID
@@ -761,40 +773,41 @@ func ResolveFK(
 		}
 	}
 
-	originColumnIDs := make(sqlbase.ColumnIDs, len(originCols))
-	for i, col := range originCols {
-		originColumnIDs[i] = col.ID
-	}
-	// Search for an index on the origin table that matches. If one doesn't exist,
-	// we create one automatically if the table to alter is new or empty. We also
-	// search if an index for the set of columns was created in this transaction.
-	_, err = sqlbase.FindFKOriginIndexInTxn(tbl, originColumnIDs)
-	// If there was no error, we found a suitable index.
-	if err != nil {
-		// No existing suitable index was found.
-		if ts == NonEmptyTable {
-			var colNames bytes.Buffer
-			colNames.WriteString(`("`)
-			for i, id := range originColumnIDs {
-				if i != 0 {
-					colNames.WriteString(`", "`)
-				}
-				col, err := tbl.TableDesc().FindColumnByID(id)
-				if err != nil {
-					return err
-				}
-				colNames.WriteString(col.Name)
-			}
-			colNames.WriteString(`")`)
-			return pgerror.Newf(pgcode.ForeignKeyViolation,
-				"foreign key requires an existing index on columns %s", colNames.String())
-		}
-		_, err := addIndexForFK(tbl, originCols, constraintName, ts)
+	// Check if the version is high enough to stop creating origin indexes.
+	if evalCtx.Settings != nil &&
+		!evalCtx.Settings.Version.IsActive(ctx, clusterversion.VersionNoOriginFKIndexes) {
+		// Search for an index on the origin table that matches. If one doesn't exist,
+		// we create one automatically if the table to alter is new or empty. We also
+		// search if an index for the set of columns was created in this transaction.
+		_, err = sqlbase.FindFKOriginIndexInTxn(tbl, originColumnIDs)
+		// If there was no error, we found a suitable index.
 		if err != nil {
-			return err
+			// No existing suitable index was found.
+			if ts == NonEmptyTable {
+				var colNames bytes.Buffer
+				colNames.WriteString(`("`)
+				for i, id := range originColumnIDs {
+					if i != 0 {
+						colNames.WriteString(`", "`)
+					}
+					col, err := tbl.TableDesc().FindColumnByID(id)
+					if err != nil {
+						return err
+					}
+					colNames.WriteString(col.Name)
+				}
+				colNames.WriteString(`")`)
+				return pgerror.Newf(pgcode.ForeignKeyViolation,
+					"foreign key requires an existing index on columns %s", colNames.String())
+			}
+			_, err := addIndexForFK(tbl, originCols, constraintName, ts)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
+	// Ensure that there is an index on the referenced side to use.
 	_, err = sqlbase.FindFKReferencedIndex(target.TableDesc(), targetColIDs)
 	if err != nil {
 		return err

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -491,6 +491,15 @@ var logicTestConfigs = []testClusterConfig{
 		disableUpgrade:      true,
 	},
 	{
+		name:                "local-mixed-20.1-20.2",
+		numNodes:            1,
+		overrideDistSQLMode: "off",
+		overrideAutoStats:   "false",
+		bootstrapVersion:    roachpb.Version{Major: 20, Minor: 1},
+		binaryVersion:       roachpb.Version{Major: 20, Minor: 2},
+		disableUpgrade:      true,
+	},
+	{
 		name:                                "local-spec-planning",
 		numNodes:                            1,
 		overrideDistSQLMode:                 "off",

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1108,10 +1108,6 @@ INSERT INTO t2 VALUES (2, 2)
 statement ok
 INSERT INTO t2 VALUES (1, 1)
 
-# Error out trying to add a column with a foreign key on a non-empty table.
-statement error pq: foreign key requires an existing index on columns \("z"\)
-ALTER TABLE t2 ADD COLUMN z INT REFERENCES t1 (x)
-
 # Check that the foreign key was indeed added.
 query TT
 SHOW CREATE t2
@@ -1120,7 +1116,6 @@ t2  CREATE TABLE t2 (
     y INT8 NULL,
     x INT8 NULL,
     CONSTRAINT fk_x_ref_t1 FOREIGN KEY (x) REFERENCES t1(x),
-    INDEX t2_auto_index_fk_x_ref_t1 (x ASC),
     FAMILY "primary" (y, rowid, x)
 )
 
@@ -1162,14 +1157,6 @@ ROLLBACK
 statement ok
 INSERT INTO t2 VALUES (1, 2)
 
-statement error pq: foreign key requires an existing index on columns \("x"\)
-BEGIN;
-DROP INDEX t2@i;
-ALTER TABLE t2 ADD FOREIGN KEY (x) REFERENCES t1(x)
-
-statement ok
-ROLLBACK
-
 # Test using ADD COL REFERENCES in a self referencing constraint.
 statement ok
 DROP TABLE t1 CASCADE;
@@ -1184,7 +1171,6 @@ t1  CREATE TABLE t1 (
     x2 INT8 NULL,
     CONSTRAINT "primary" PRIMARY KEY (x ASC),
     CONSTRAINT fk_x2_ref_t1 FOREIGN KEY (x2) REFERENCES t1(x),
-    INDEX t1_auto_index_fk_x2_ref_t1 (x2 ASC),
     FAMILY "primary" (x, x2)
 )
 
@@ -1209,7 +1195,6 @@ t2  CREATE TABLE t2 (
     y INT8 NULL,
     x INT8 NULL,
     CONSTRAINT fk_x_ref_t1 FOREIGN KEY (x) REFERENCES t1(x),
-    INDEX t2_auto_index_fk_x_ref_t1 (x ASC),
     FAMILY "primary" (y, rowid, x)
 )
 
@@ -1232,7 +1217,6 @@ t2  CREATE TABLE t2 (
     y INT8 NULL,
     x INT8 NULL,
     CONSTRAINT fk_x_ref_t1 FOREIGN KEY (x) REFERENCES t1(x),
-    INDEX t2_auto_index_fk_x_ref_t1 (x ASC),
     FAMILY "primary" (y, rowid, x)
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -35,11 +35,9 @@ create_statement  create_nofks  alter_statements  validate_statements
 CREATE TABLE t (
    a INT8 NULL,
    CONSTRAINT fk_a_ref_t FOREIGN KEY (a) REFERENCES t(rowid),
-   INDEX t_auto_index_fk_a_ref_t (a ASC),
    FAMILY "primary" (a, rowid)
 )  CREATE TABLE t (
    a INT8 NULL,
-   INDEX t_auto_index_fk_a_ref_t (a ASC),
    FAMILY "primary" (a, rowid)
 )  {"ALTER TABLE t ADD CONSTRAINT fk_a_ref_t FOREIGN KEY (a) REFERENCES t(rowid)"}  {"ALTER TABLE t VALIDATE CONSTRAINT fk_a_ref_t"}
 CREATE TABLE v (
@@ -48,13 +46,11 @@ CREATE TABLE v (
    CONSTRAINT "fk_'_ref_t" FOREIGN KEY ("'") REFERENCES t(rowid),
    CONSTRAINT fk_s_ref_v FOREIGN KEY (s) REFERENCES v(s),
    UNIQUE INDEX v_s_key (s ASC),
-   INDEX "v_auto_index_fk_'_ref_t" ("'" ASC),
    FAMILY "primary" ("'", s, rowid)
 )  CREATE TABLE v (
    "'" INT8 NULL,
    s STRING NULL,
    UNIQUE INDEX v_s_key (s ASC),
-   INDEX "v_auto_index_fk_'_ref_t" ("'" ASC),
    FAMILY "primary" ("'", s, rowid)
 )  {"ALTER TABLE v ADD CONSTRAINT \"fk_'_ref_t\" FOREIGN KEY (\"'\") REFERENCES t(rowid)","ALTER TABLE v ADD CONSTRAINT fk_s_ref_v FOREIGN KEY (s) REFERENCES v(s)"}  {"ALTER TABLE v VALIDATE CONSTRAINT \"fk_'_ref_t\"","ALTER TABLE v VALIDATE CONSTRAINT fk_s_ref_v"}
 CREATE TABLE c (

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -299,8 +299,6 @@ SHOW INDEXES FROM unindexed
 ----
 table_name  index_name                                      non_unique  seq_in_index  column_name  direction  storing  implicit
 unindexed   primary                                         false       1             rowid        ASC        false    false
-unindexed   unindexed_auto_index_fk_customer_ref_customers  true        1             customer     ASC        false    false
-unindexed   unindexed_auto_index_fk_customer_ref_customers  true        2             rowid        ASC        false    true
 
 statement error there is no unique constraint matching given keys for referenced table products
 CREATE TABLE non_unique (product STRING REFERENCES products (vendor))
@@ -505,7 +503,6 @@ delivery  CREATE TABLE delivery (
           CONSTRAINT fk_order_ref_orders FOREIGN KEY ("order", shipment) REFERENCES orders(id, shipment),
           CONSTRAINT fk_item_ref_products FOREIGN KEY (item) REFERENCES products(upc),
           INDEX delivery_item_idx (item ASC),
-          INDEX delivery_auto_index_fk_order_ref_orders ("order" ASC, shipment ASC),
           FAMILY "primary" (ts, "order", shipment, item, rowid)
 )
 
@@ -664,10 +661,6 @@ DROP TABLE products RESTRICT
 statement error referenced by foreign key from table "customer reviews"
 DROP TABLE orders
 
-# reviews has a multi-col FK in which dropping one col is not allowed.
-statement error column "order" is referenced by existing index "customer reviews_auto_index_orderfk"
-ALTER TABLE "user content"."customer reviews" DROP COLUMN "order"
-
 statement ok
 ALTER TABLE "user content"."customer reviews" DROP COLUMN "order" CASCADE
 
@@ -779,9 +772,6 @@ refpairs_wrong_order  primary                                         false     
 refpairs_wrong_order  refpairs_wrong_order_b_a_idx                    true        1             b            ASC        false    false
 refpairs_wrong_order  refpairs_wrong_order_b_a_idx                    true        2             a            ASC        false    false
 refpairs_wrong_order  refpairs_wrong_order_b_a_idx                    true        3             rowid        ASC        false    true
-refpairs_wrong_order  refpairs_wrong_order_auto_index_fk_a_ref_pairs  true        1             a            ASC        false    false
-refpairs_wrong_order  refpairs_wrong_order_auto_index_fk_a_ref_pairs  true        2             b            ASC        false    false
-refpairs_wrong_order  refpairs_wrong_order_auto_index_fk_a_ref_pairs  true        3             rowid        ASC        false    true
 
 statement ok
 CREATE TABLE refpairs_c_between (a INT, b STRING, c INT, FOREIGN KEY (a, b) REFERENCES pairs (src, dest), INDEX (a, c, b))
@@ -795,9 +785,6 @@ refpairs_c_between  refpairs_c_between_a_c_b_idx                  true        1 
 refpairs_c_between  refpairs_c_between_a_c_b_idx                  true        2             c            ASC        false    false
 refpairs_c_between  refpairs_c_between_a_c_b_idx                  true        3             b            ASC        false    false
 refpairs_c_between  refpairs_c_between_a_c_b_idx                  true        4             rowid        ASC        false    true
-refpairs_c_between  refpairs_c_between_auto_index_fk_a_ref_pairs  true        1             a            ASC        false    false
-refpairs_c_between  refpairs_c_between_auto_index_fk_a_ref_pairs  true        2             b            ASC        false    false
-refpairs_c_between  refpairs_c_between_auto_index_fk_a_ref_pairs  true        3             rowid        ASC        false    true
 
 statement ok
 CREATE TABLE refpairs (
@@ -1035,7 +1022,6 @@ refers  CREATE TABLE refers (
         b INT8 NULL,
         CONSTRAINT fk_a_ref_referee FOREIGN KEY (a) REFERENCES referee(id),
         INDEX another_idx (b ASC),
-        INDEX refers_auto_index_fk_a_ref_referee (a ASC),
         INDEX foo (a ASC),
         FAMILY "primary" (a, b, rowid)
 )
@@ -2655,25 +2641,9 @@ INSERT INTO nonempty_b VALUES (1), (2), (3);
 statement ok
 INSERT INTO nonempty_a VALUES (1, NULL, 1)
 
-# Fails because self_id is not indexed, and an index will not be automatically created because the table is nonempty
-statement error foreign key requires an existing index on columns \("self_id"\)
-ALTER TABLE nonempty_a ADD CONSTRAINT fk_self_id FOREIGN KEY (self_id) REFERENCES nonempty_a;
-
-statement ok
-CREATE INDEX ON nonempty_a (self_id)
-
-# This now succeeds with the manually added index
 statement ok
 ALTER TABLE nonempty_a ADD CONSTRAINT fk_self_id FOREIGN KEY (self_id) REFERENCES nonempty_a;
 
-# Fails because b_id is not indexed, and an index will not be automatically created because the table is nonempty
-statement error foreign key requires an existing index on columns \("b_id"\)
-ALTER TABLE nonempty_a ADD CONSTRAINT fk_b FOREIGN KEY (b_id) REFERENCES nonempty_b;
-
-statement ok
-CREATE INDEX ON nonempty_a (b_id)
-
-# This now succeeds with the manually added index
 statement ok
 ALTER TABLE nonempty_a ADD CONSTRAINT fk_b FOREIGN KEY (b_id) REFERENCES nonempty_b;
 
@@ -2707,7 +2677,7 @@ statement ok
 CREATE TABLE child_duplicate_cols (id INT, parent_id INT, PRIMARY KEY (id))
 
 # The fk constraint is invalid because it has duplicate columns, so automatically adding the index fails
-statement error index \"child_duplicate_cols_auto_index_fk\" contains duplicate column \"parent_id\"
+statement error foreign key contains duplicate column \"parent_id\"
 ALTER TABLE child_duplicate_cols ADD CONSTRAINT fk FOREIGN KEY (parent_id, parent_id) references parent
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/fk-mixed-20.1-20.2
+++ b/pkg/sql/logictest/testdata/logic_test/fk-mixed-20.1-20.2
@@ -1,0 +1,34 @@
+# LogicTest: local-mixed-20.1-20.2
+
+# Ensure that we still create indexes on the origin side of foreign keys
+# in a mixed version cluster state.
+statement ok
+CREATE TABLE t1 (x INT);
+CREATE TABLE t2 (y INT PRIMARY KEY);
+ALTER TABLE t1 ADD FOREIGN KEY (x) REFERENCES t2 (y)
+
+query TT
+SHOW CREATE t1
+----
+t1  CREATE TABLE t1 (
+    x INT8 NULL,
+    CONSTRAINT fk_x_ref_t2 FOREIGN KEY (x) REFERENCES t2(y),
+    INDEX t1_auto_index_fk_x_ref_t2 (x ASC),
+    FAMILY "primary" (x, rowid)
+)
+
+# Ensure that we can't drop the origin index.
+statement error pq: index \"t1_auto_index_fk_x_ref_t2\" is in use as a foreign key constraint
+DROP INDEX t1@t1_auto_index_fk_x_ref_t2
+
+statement ok
+DROP TABLE t1, t2
+
+# Trying to add a foreign key on a non-empty table without an origin index will fail.
+statement ok
+CREATE TABLE t1 (x INT);
+CREATE TABLE t2 (y INT PRIMARY KEY);
+INSERT INTO t1 VALUES (1)
+
+statement error pq: foreign key requires an existing index on columns \(\"x\"\)
+ALTER TABLE t1 ADD FOREIGN KEY (x) REFERENCES t2 (y)

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -17,18 +17,11 @@ INSERT INTO test.parent values (1)
 statement ok
 CREATE TABLE test.child (id int primary key, parent_id int)
 
-# The index on parent_id is added automatically because test.child is empty
 statement ok
 ALTER TABLE test.child ADD CONSTRAINT fk_child_parent_id FOREIGN KEY (parent_id) REFERENCES test.parent (id);
 
 statement ok
 INSERT INTO test.child VALUES (1, 1)
-
-# Check that the auto-created index is visible
-query II rowsort
-SELECT * FROM test.child@child_auto_index_fk_child_parent_id
-----
-1 1
 
 statement ok
 COMMIT
@@ -68,7 +61,6 @@ CREATE TABLE test.child (id int primary key, parent_id int)
 statement ok
 BEGIN
 
-# The index on parent_id is added automatically because test.child is empty
 statement ok
 ALTER TABLE test.child ADD CONSTRAINT fk_child_parent_id FOREIGN KEY (parent_id) REFERENCES test.parent (id);
 
@@ -77,12 +69,6 @@ INSERT INTO test.child VALUES (1, 1)
 
 statement ok
 COMMIT
-
-# Check that the auto-created index is visible
-query II rowsort
-SELECT * FROM test.child@child_auto_index_fk_child_parent_id
-----
-1 1
 
 # Verify that the constraint is validated.
 query TTTTB
@@ -105,7 +91,6 @@ CREATE TABLE parent_composite_index (a_id INT NOT NULL, b_id INT NOT NULL, PRIMA
 statement ok
 CREATE TABLE child_composite_index (id SERIAL NOT NULL, parent_a_id INT, parent_b_id INT, PRIMARY KEY (id))
 
-# The (composite) index needed for the fk constraint is automatically added because the table is empty
 statement ok
 ALTER TABLE child_composite_index ADD CONSTRAINT fk_id FOREIGN KEY (parent_a_id, parent_b_id) REFERENCES parent_composite_index;
 
@@ -114,12 +99,6 @@ INSERT INTO parent_composite_index VALUES (100, 200)
 
 statement ok
 INSERT INTO child_composite_index VALUES (1, 100, 200)
-
-# Check that the auto-created index is visible
-query III rowsort
-SELECT * FROM child_composite_index@child_composite_index_auto_index_fk_id
-----
-1 100 200
 
 statement ok
 COMMIT
@@ -144,8 +123,7 @@ INSERT INTO nonempty_b VALUES (1), (2), (3);
 statement ok
 INSERT INTO nonempty_a VALUES (1, NULL, 1)
 
-# Fails because self_id is not indexed, and an index will not be automatically created because the table is nonempty
-statement error foreign key requires an existing index on columns \("self_id"\)
+statement ok
 ALTER TABLE nonempty_a ADD CONSTRAINT fk_self_id FOREIGN KEY (self_id) REFERENCES nonempty_a;
 
 statement ok
@@ -187,7 +165,7 @@ statement ok
 CREATE TABLE child_duplicate_cols (id INT, parent_id INT, PRIMARY KEY (id))
 
 # The fk constraint is invalid because it has duplicate columns, so automatically adding the index fails
-statement error index \"child_duplicate_cols_auto_index_fk\" contains duplicate column \"parent_id\"
+statement error foreign key contains duplicate column \"parent_id\"
 ALTER TABLE child_duplicate_cols ADD CONSTRAINT fk FOREIGN KEY (parent_id, parent_id) references parent
 
 statement ok
@@ -297,7 +275,6 @@ b  CREATE TABLE b (
    parent_id INT8 NULL,
    d INT8 NULL DEFAULT 23:::INT8,
    CONSTRAINT fk_parent_id_ref_parent FOREIGN KEY (parent_id) REFERENCES parent(id),
-   INDEX b_auto_index_fk_parent_id_ref_parent (parent_id ASC),
    INDEX foo (parent_id ASC),
    UNIQUE INDEX bar (parent_id ASC),
    FAMILY "primary" (parent_id, rowid, d)

--- a/pkg/sql/old_foreign_key_desc_test.go
+++ b/pkg/sql/old_foreign_key_desc_test.go
@@ -41,7 +41,7 @@ func TestOldForeignKeyRepresentationGetsUpgraded(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
-CREATE TABLE t.t1 (x INT);
+CREATE TABLE t.t1 (x INT, INDEX i (x));
 CREATE TABLE t.t2 (x INT, UNIQUE INDEX (x));
 ALTER TABLE t.t1 ADD CONSTRAINT fk1 FOREIGN KEY (x) REFERENCES t.t2 (x);
 CREATE INDEX ON t.t1 (x);
@@ -120,7 +120,7 @@ CREATE INDEX ON t.t1 (x);
 		t.Fatal(err)
 	}
 	// Run a DROP INDEX statement and ensure that the downgraded descriptor gets upgraded successfully.
-	if _, err := sqlDB.Exec(`DROP INDEX t.t1@t1_auto_index_fk1`); err != nil {
+	if _, err := sqlDB.Exec(`DROP INDEX t.t1@i`); err != nil {
 		t.Fatal(err)
 	}
 	desc = sqlbase.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "t2")

--- a/pkg/sql/opt/exec/execbuilder/testdata/autocommit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/autocommit
@@ -644,7 +644,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r34: sending batch 2 CPut, 2 InitPut to (n1,s1):1
+dist sender send  r34: sending batch 2 CPut to (n1,s1):1
 dist sender send  r34: sending batch 2 Scan to (n1,s1):1
 dist sender send  r34: sending batch 1 EndTxn to (n1,s1):1
 
@@ -668,7 +668,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND operation NOT LIKE '%async%'
 ----
 dist sender send  r34: sending batch 1 Scan to (n1,s1):1
-dist sender send  r34: sending batch 1 Put, 1 CPut, 1 Del to (n1,s1):1
+dist sender send  r34: sending batch 1 Put to (n1,s1):1
 dist sender send  r34: sending batch 1 Scan to (n1,s1):1
 dist sender send  r34: sending batch 1 EndTxn to (n1,s1):1
 
@@ -722,7 +722,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
 dist sender send  r34: sending batch 1 Scan to (n1,s1):1
 dist sender send  r34: sending batch 1 Del to (n1,s1):1
 dist sender send  r34: sending batch 1 Scan to (n1,s1):1
-dist sender send  r34: sending batch 2 Del, 1 EndTxn to (n1,s1):1
+dist sender send  r34: sending batch 1 Del, 1 EndTxn to (n1,s1):1
 
 # -----------------------
 # Multiple mutation tests

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -73,32 +73,20 @@ WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
 ----
 Del /Table/53/1/"a-pk1"/0
 executing cascade for constraint fk_delete_cascade_ref_a
-Del /Table/54/2/"a-pk1"/"b1-pk1"/0
 Del /Table/54/1/"b1-pk1"/0
-Del /Table/54/2/"a-pk1"/"b1-pk2"/0
 Del /Table/54/1/"b1-pk2"/0
 executing cascade for constraint fk_delete_cascade_ref_a
-Del /Table/55/2/"a-pk1"/"b2-pk1"/0
 Del /Table/55/1/"b2-pk1"/0
-Del /Table/55/2/"a-pk1"/"b2-pk2"/0
 Del /Table/55/1/"b2-pk2"/0
 executing cascade for constraint fk_delete_cascade_ref_b1
-Del /Table/56/2/"b1-pk1"/"c1-pk1-b1-pk1"/0
 Del /Table/56/1/"c1-pk1-b1-pk1"/0
-Del /Table/56/2/"b1-pk1"/"c1-pk2-b1-pk1"/0
 Del /Table/56/1/"c1-pk2-b1-pk1"/0
-Del /Table/56/2/"b1-pk2"/"c1-pk3-b1-pk2"/0
 Del /Table/56/1/"c1-pk3-b1-pk2"/0
-Del /Table/56/2/"b1-pk2"/"c1-pk4-b1-pk2"/0
 Del /Table/56/1/"c1-pk4-b1-pk2"/0
 executing cascade for constraint fk_delete_cascade_ref_b1
-Del /Table/57/2/"b1-pk1"/"c2-pk1-b1-pk1"/0
 Del /Table/57/1/"c2-pk1-b1-pk1"/0
-Del /Table/57/2/"b1-pk1"/"c2-pk2-b1-pk1"/0
 Del /Table/57/1/"c2-pk2-b1-pk1"/0
-Del /Table/57/2/"b1-pk2"/"c2-pk3-b1-pk2"/0
 Del /Table/57/1/"c2-pk3-b1-pk2"/0
-Del /Table/57/2/"b1-pk2"/"c2-pk4-b1-pk2"/0
 Del /Table/57/1/"c2-pk4-b1-pk2"/0
 executing cascade for constraint fk_id_ref_b2
 Del /Table/58/1/"b2-pk1"/0
@@ -192,23 +180,7 @@ executing cascade for constraint fk_update_cascade_ref_a
 Del /Table/61/2/"updated"/0
 CPut /Table/61/2/"updated2"/0 -> /BYTES/0x1262322d706b310001 (expecting does not exist)
 executing cascade for constraint fk_update_cascade_ref_b1
-Del /Table/62/2/"updated"/"c1-pk1"/0
-CPut /Table/62/2/"updated2"/"c1-pk1"/0 -> /BYTES/ (expecting does not exist)
-Del /Table/62/2/"updated"/"c1-pk2"/0
-CPut /Table/62/2/"updated2"/"c1-pk2"/0 -> /BYTES/ (expecting does not exist)
-Del /Table/62/2/"updated"/"c1-pk3"/0
-CPut /Table/62/2/"updated2"/"c1-pk3"/0 -> /BYTES/ (expecting does not exist)
-Del /Table/62/2/"updated"/"c1-pk4"/0
-CPut /Table/62/2/"updated2"/"c1-pk4"/0 -> /BYTES/ (expecting does not exist)
 executing cascade for constraint fk_update_cascade_ref_b1
-Del /Table/63/2/"updated"/"c2-pk1"/0
-CPut /Table/63/2/"updated2"/"c2-pk1"/0 -> /BYTES/ (expecting does not exist)
-Del /Table/63/2/"updated"/"c2-pk2"/0
-CPut /Table/63/2/"updated2"/"c2-pk2"/0 -> /BYTES/ (expecting does not exist)
-Del /Table/63/2/"updated"/"c2-pk3"/0
-CPut /Table/63/2/"updated2"/"c2-pk3"/0 -> /BYTES/ (expecting does not exist)
-Del /Table/63/2/"updated"/"c2-pk4"/0
-CPut /Table/63/2/"updated2"/"c2-pk4"/0 -> /BYTES/ (expecting does not exist)
 executing cascade for constraint fk_id_ref_b2
 Del /Table/64/1/"updated"/0
 CPut /Table/64/1/"updated2"/0 -> /TUPLE/
@@ -268,12 +240,8 @@ WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
 Del /Table/65/1/"delete_me"/0
 executing cascade for constraint fk_delete_set_null_ref_a
 executing cascade for constraint fk_delete_set_null_ref_a
-Del /Table/67/2/"delete_me"/"b2-pk2"/0
 executing cascade for constraint fk_delete_set_null_ref_a
-Del /Table/68/2/"delete_me"/"b3-pk1"/0
 executing cascade for constraint fk_delete_set_null_ref_a
-Del /Table/69/2/"delete_me"/"b4-pk1"/0
-Del /Table/69/2/"delete_me"/"b4-pk2"/0
 
 # Clean up after the test.
 statement ok
@@ -349,30 +317,14 @@ WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
 ----
 Del /Table/70/1/"a-pk1"/0
 executing cascade for constraint fk_delete_cascade_ref_a
-Del /Table/71/2/"a-pk1"/"b1-pk1"/0
 Del /Table/71/1/"b1-pk1"/0
-Del /Table/71/2/"a-pk1"/"b1-pk2"/0
 Del /Table/71/1/"b1-pk2"/0
 executing cascade for constraint fk_delete_cascade_ref_a
-Del /Table/72/2/"a-pk1"/"b2-pk1"/0
 Del /Table/72/1/"b2-pk1"/0
-Del /Table/72/2/"a-pk1"/"b2-pk2"/0
 Del /Table/72/1/"b2-pk2"/0
 executing cascade for constraint fk_delete_set_null_ref_b1
-Del /Table/73/2/"b1-pk1"/"c1-pk1-b1-pk1"/0
-Del /Table/73/2/"b1-pk1"/"c1-pk2-b1-pk1"/0
-Del /Table/73/2/"b1-pk2"/"c1-pk3-b1-pk2"/0
-Del /Table/73/2/"b1-pk2"/"c1-pk4-b1-pk2"/0
 executing cascade for constraint fk_delete_set_null_ref_b1
-Del /Table/74/2/"b1-pk1"/"c2-pk1-b1-pk1"/0
-Del /Table/74/2/"b1-pk1"/"c2-pk2-b1-pk1"/0
-Del /Table/74/2/"b1-pk2"/"c2-pk3-b1-pk2"/0
-Del /Table/74/2/"b1-pk2"/"c2-pk4-b1-pk2"/0
 executing cascade for constraint fk_delete_set_null_ref_b2
-Del /Table/75/2/"b2-pk1"/"c3-pk1-b2-pk1"/0
-Del /Table/75/2/"b2-pk1"/"c3-pk2-b2-pk1"/0
-Del /Table/75/2/"b2-pk2"/"c3-pk3-b2-pk2"/0
-Del /Table/75/2/"b2-pk2"/"c3-pk4-b2-pk2"/0
 
 # Clean up after the test.
 statement ok
@@ -430,15 +382,7 @@ Del /Table/76/1/"original"/0
 CPut /Table/76/1/"updated"/0 -> /TUPLE/
 executing cascade for constraint fk_update_set_null_ref_a
 executing cascade for constraint fk_update_set_null_ref_a
-Del /Table/78/2/"original"/"b2-pk2"/0
-CPut /Table/78/2/NULL/"b2-pk2"/0 -> /BYTES/ (expecting does not exist)
 executing cascade for constraint fk_update_set_null_ref_a
-Del /Table/79/2/"original"/"b3-pk1"/0
-CPut /Table/79/2/NULL/"b3-pk1"/0 -> /BYTES/ (expecting does not exist)
-Del /Table/79/2/"original"/"b4-pk1"/0
-CPut /Table/79/2/NULL/"b4-pk1"/0 -> /BYTES/ (expecting does not exist)
-Del /Table/79/2/"original"/"b4-pk2"/0
-CPut /Table/79/2/NULL/"b4-pk2"/0 -> /BYTES/ (expecting does not exist)
 executing cascade for constraint fk_update_set_null_ref_a
 
 # Clean up after the test.
@@ -524,20 +468,8 @@ executing cascade for constraint fk_update_cascade_ref_a
 Del /Table/83/2/"original"/0
 CPut /Table/83/2/"updated"/0 -> /BYTES/0x1262322d706b310001 (expecting does not exist)
 executing cascade for constraint fk_update_set_null_ref_b1
-Del /Table/84/2/"original"/"c1-pk1-b1-pk1"/0
-CPut /Table/84/2/NULL/"c1-pk1-b1-pk1"/0 -> /BYTES/ (expecting does not exist)
-Del /Table/84/2/"original"/"c1-pk2-b1-pk1"/0
-CPut /Table/84/2/NULL/"c1-pk2-b1-pk1"/0 -> /BYTES/ (expecting does not exist)
 executing cascade for constraint fk_update_set_null_ref_b1
-Del /Table/85/2/"original"/"c2-pk1-b1-pk1"/0
-CPut /Table/85/2/NULL/"c2-pk1-b1-pk1"/0 -> /BYTES/ (expecting does not exist)
-Del /Table/85/2/"original"/"c2-pk2-b1-pk1"/0
-CPut /Table/85/2/NULL/"c2-pk2-b1-pk1"/0 -> /BYTES/ (expecting does not exist)
 executing cascade for constraint fk_update_set_null_ref_b2
-Del /Table/86/2/"original"/"c3-pk1-b2-pk1"/0
-CPut /Table/86/2/NULL/"c3-pk1-b2-pk1"/0 -> /BYTES/ (expecting does not exist)
-Del /Table/86/2/"original"/"c3-pk2-b2-pk1"/0
-CPut /Table/86/2/NULL/"c3-pk2-b2-pk1"/0 -> /BYTES/ (expecting does not exist)
 
 # Clean up after the test.
 statement ok
@@ -596,12 +528,8 @@ WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
 Del /Table/87/1/"delete_me"/0
 executing cascade for constraint fk_delete_set_default_ref_a
 executing cascade for constraint fk_delete_set_default_ref_a
-Del /Table/89/2/"delete_me"/"b2-pk2"/0
 executing cascade for constraint fk_delete_set_default_ref_a
-Del /Table/90/2/"delete_me"/"b3-pk1"/0
 executing cascade for constraint fk_delete_set_default_ref_a
-Del /Table/91/2/"delete_me"/"b4-pk1"/0
-Del /Table/91/2/"delete_me"/"b4-pk2"/0
 
 # Clean up after the test.
 statement ok
@@ -677,30 +605,14 @@ WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
 ----
 Del /Table/92/1/"a-pk1"/0
 executing cascade for constraint fk_delete_cascade_ref_a
-Del /Table/93/2/"a-pk1"/"b1-pk1"/0
 Del /Table/93/1/"b1-pk1"/0
-Del /Table/93/2/"a-pk1"/"b1-pk2"/0
 Del /Table/93/1/"b1-pk2"/0
 executing cascade for constraint fk_delete_cascade_ref_a
-Del /Table/94/2/"a-pk1"/"b2-pk1"/0
 Del /Table/94/1/"b2-pk1"/0
-Del /Table/94/2/"a-pk1"/"b2-pk2"/0
 Del /Table/94/1/"b2-pk2"/0
 executing cascade for constraint fk_delete_set_default_ref_b1
-Del /Table/95/2/"b1-pk1"/"c1-pk1-b1-pk1"/0
-Del /Table/95/2/"b1-pk1"/"c1-pk2-b1-pk1"/0
-Del /Table/95/2/"b1-pk2"/"c1-pk3-b1-pk2"/0
-Del /Table/95/2/"b1-pk2"/"c1-pk4-b1-pk2"/0
 executing cascade for constraint fk_delete_set_default_ref_b1
-Del /Table/96/2/"b1-pk1"/"c2-pk1-b1-pk1"/0
-Del /Table/96/2/"b1-pk1"/"c2-pk2-b1-pk1"/0
-Del /Table/96/2/"b1-pk2"/"c2-pk3-b1-pk2"/0
-Del /Table/96/2/"b1-pk2"/"c2-pk4-b1-pk2"/0
 executing cascade for constraint fk_delete_set_default_ref_b2
-Del /Table/97/2/"b2-pk1"/"c3-pk1-b2-pk1"/0
-Del /Table/97/2/"b2-pk1"/"c3-pk2-b2-pk1"/0
-Del /Table/97/2/"b2-pk2"/"c3-pk3-b2-pk2"/0
-Del /Table/97/2/"b2-pk2"/"c3-pk4-b2-pk2"/0
 
 # Clean up after the test.
 statement ok
@@ -758,15 +670,7 @@ Del /Table/98/1/"original"/0
 CPut /Table/98/1/"updated"/0 -> /TUPLE/
 executing cascade for constraint fk_update_set_null_ref_a
 executing cascade for constraint fk_update_set_null_ref_a
-Del /Table/100/2/"original"/"b2-pk2"/0
-CPut /Table/100/2/"b2-default"/"b2-pk2"/0 -> /BYTES/ (expecting does not exist)
 executing cascade for constraint fk_update_set_null_ref_a
-Del /Table/101/2/"original"/"b3-pk1"/0
-CPut /Table/101/2/"b3-default"/"b3-pk1"/0 -> /BYTES/ (expecting does not exist)
-Del /Table/101/2/"original"/"b4-pk1"/0
-CPut /Table/101/2/"b3-default"/"b4-pk1"/0 -> /BYTES/ (expecting does not exist)
-Del /Table/101/2/"original"/"b4-pk2"/0
-CPut /Table/101/2/"b3-default"/"b4-pk2"/0 -> /BYTES/ (expecting does not exist)
 executing cascade for constraint fk_update_set_null_ref_a
 
 # Clean up after the test.
@@ -852,20 +756,8 @@ executing cascade for constraint fk_update_cascade_ref_a
 Del /Table/105/2/"original"/0
 CPut /Table/105/2/"updated"/0 -> /BYTES/0x1262322d706b310001 (expecting does not exist)
 executing cascade for constraint fk_update_set_null_ref_b1
-Del /Table/106/2/"original"/"c1-pk1-b1-pk1"/0
-CPut /Table/106/2/"b1-default"/"c1-pk1-b1-pk1"/0 -> /BYTES/ (expecting does not exist)
-Del /Table/106/2/"original"/"c1-pk2-b1-pk1"/0
-CPut /Table/106/2/"b1-default"/"c1-pk2-b1-pk1"/0 -> /BYTES/ (expecting does not exist)
 executing cascade for constraint fk_update_set_null_ref_b1
-Del /Table/107/2/"original"/"c2-pk1-b1-pk1"/0
-CPut /Table/107/2/"b1-default"/"c2-pk1-b1-pk1"/0 -> /BYTES/ (expecting does not exist)
-Del /Table/107/2/"original"/"c2-pk2-b1-pk1"/0
-CPut /Table/107/2/"b1-default"/"c2-pk2-b1-pk1"/0 -> /BYTES/ (expecting does not exist)
 executing cascade for constraint fk_update_set_null_ref_b2
-Del /Table/108/2/"original"/"c3-pk1-b2-pk1"/0
-CPut /Table/108/2/"b2-default"/"c3-pk1-b2-pk1"/0 -> /BYTES/ (expecting does not exist)
-Del /Table/108/2/"original"/"c3-pk2-b2-pk1"/0
-CPut /Table/108/2/"b2-default"/"c3-pk2-b2-pk1"/0 -> /BYTES/ (expecting does not exist)
 
 # Clean up after the test.
 statement ok
@@ -896,9 +788,5 @@ query T kvtrace(Del,FKScan)
 DELETE FROM parent WHERE x = 1
 ----
 Del /Table/109/1/1/0
-Del /Table/110/2/1/1/0
 Del /Table/110/1/1/0
-Del /Table/110/2/1/2/0
 Del /Table/110/1/2/0
-Del /Table/111/2/1/1/0
-Del /Table/111/2/1/2/0

--- a/pkg/sql/opt/exec/execbuilder/testdata/catalog
+++ b/pkg/sql/opt/exec/execbuilder/testdata/catalog
@@ -113,11 +113,6 @@ TABLE child
  ├── r int
  ├── INDEX primary
  │    └── c int not null
- ├── INDEX child_auto_index_fk
- │    ├── p int
- │    ├── q int
- │    ├── r int
- │    └── c int not null
  └── CONSTRAINT fk FOREIGN KEY child (p, q, r) REFERENCES parent (p, q, r)
 scan child
 
@@ -155,11 +150,6 @@ TABLE child2
  ├── q int
  ├── r int
  ├── INDEX primary
- │    └── c int not null
- ├── INDEX child2_auto_index_fk
- │    ├── p int
- │    ├── q int
- │    ├── r int
  │    └── c int not null
  └── CONSTRAINT fk FOREIGN KEY child2 (p, q, r) REFERENCES parent (p, q, r) MATCH FULL ON DELETE SET NULL
 scan child2

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -10,7 +10,7 @@ statement ok
 CREATE TABLE parent (p INT PRIMARY KEY, other INT UNIQUE, FAMILY (p, other))
 
 statement ok
-CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p), FAMILY (c, p))
+CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p), FAMILY (c, p), INDEX (p))
 
 query TTT
 EXPLAIN INSERT INTO child VALUES (1,1), (2,2)
@@ -71,7 +71,7 @@ root                                       ·                   ·
 ·                                          spans               FULL SCAN
 
 statement ok
-CREATE TABLE child_nullable (c INT PRIMARY KEY, p INT REFERENCES parent(p));
+CREATE TABLE child_nullable (c INT PRIMARY KEY, p INT REFERENCES parent(p), INDEX (p));
 
 # Because the input column can be NULL (in which case it requires no FK match),
 # we have to add an extra filter.
@@ -234,7 +234,7 @@ root                                       ·             ·
  ├── fk-check                              ·             ·
  │    └── error if rows                    ·             ·
  │         └── lookup-join                 ·             ·
- │              │                          table         child@child_auto_index_fk_p_ref_parent
+ │              │                          table         child@child_p_idx
  │              │                          type          semi
  │              │                          equality      (p) = (p)
  │              └── render                 ·             ·
@@ -243,7 +243,7 @@ root                                       ·             ·
  └── fk-check                              ·             ·
       └── error if rows                    ·             ·
            └── lookup-join                 ·             ·
-                │                          table         child_nullable@child_nullable_auto_index_fk_p_ref_parent
+                │                          table         child_nullable@child_nullable_p_idx
                 │                          type          semi
                 │                          equality      (p) = (p)
                 └── render                 ·             ·
@@ -251,7 +251,7 @@ root                                       ·             ·
 ·                                          label         buffer 1
 
 statement ok
-CREATE TABLE child2 (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(other))
+CREATE TABLE child2 (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(other), INDEX (p))
 
 query TTT
 EXPLAIN DELETE FROM parent WHERE p = 3
@@ -271,7 +271,7 @@ root                                       ·             ·
  ├── fk-check                              ·             ·
  │    └── error if rows                    ·             ·
  │         └── lookup-join                 ·             ·
- │              │                          table         child@child_auto_index_fk_p_ref_parent
+ │              │                          table         child@child_p_idx
  │              │                          type          semi
  │              │                          equality      (p) = (p)
  │              └── render                 ·             ·
@@ -280,7 +280,7 @@ root                                       ·             ·
  ├── fk-check                              ·             ·
  │    └── error if rows                    ·             ·
  │         └── lookup-join                 ·             ·
- │              │                          table         child_nullable@child_nullable_auto_index_fk_p_ref_parent
+ │              │                          table         child_nullable@child_nullable_p_idx
  │              │                          type          semi
  │              │                          equality      (p) = (p)
  │              └── render                 ·             ·
@@ -289,7 +289,7 @@ root                                       ·             ·
  └── fk-check                              ·             ·
       └── error if rows                    ·             ·
            └── lookup-join                 ·             ·
-                │                          table         child2@child2_auto_index_fk_p_ref_parent
+                │                          table         child2@child2_p_idx
                 │                          type          semi
                 │                          equality      (other) = (p)
                 └── render                 ·             ·
@@ -304,7 +304,8 @@ CREATE TABLE doublechild (
   c INT8 PRIMARY KEY,
   p1 INT8,
   p2 INT8,
-  FOREIGN KEY (p1, p2) REFERENCES doubleparent (p1, p2)
+  FOREIGN KEY (p1, p2) REFERENCES doubleparent (p1, p2),
+  INDEX (p1, p2)
 )
 
 query TTT
@@ -325,7 +326,7 @@ root                                  ·             ·
  └── fk-check                         ·             ·
       └── error if rows               ·             ·
            └── lookup-join            ·             ·
-                │                     table         doublechild@doublechild_auto_index_fk_p1_ref_doubleparent
+                │                     table         doublechild@doublechild_p1_p2_idx
                 │                     type          semi
                 │                     equality      (p1, p2) = (p1, p2)
                 └── scan buffer node  ·             ·
@@ -431,7 +432,7 @@ root                                                 ·                   ·
  │                        │                          distinct on         p
  │                        │                          order key           p
  │                        └── scan                   ·                   ·
- │                                                   table               child@child_auto_index_fk_p_ref_parent
+ │                                                   table               child@child_p_idx
  │                                                   spans               FULL SCAN
  └── fk-check                                        ·                   ·
       └── error if rows                              ·                   ·
@@ -452,7 +453,7 @@ root                                                 ·                   ·
                           │                          distinct on         p
                           │                          order key           p
                           └── scan                   ·                   ·
-·                                                    table               child_nullable@child_nullable_auto_index_fk_p_ref_parent
+·                                                    table               child_nullable@child_nullable_p_idx
 ·                                                    spans               FULL SCAN
 
 query TTT
@@ -476,7 +477,7 @@ root                                            ·                 ·
  ├── fk-check                                   ·                 ·
  │    └── error if rows                         ·                 ·
  │         └── lookup-join                      ·                 ·
- │              │                               table             child@child_auto_index_fk_p_ref_parent
+ │              │                               table             child@child_p_idx
  │              │                               type              semi
  │              │                               equality          (p) = (p)
  │              └── union                       ·                 ·
@@ -489,7 +490,7 @@ root                                            ·                 ·
  └── fk-check                                   ·                 ·
       └── error if rows                         ·                 ·
            └── lookup-join                      ·                 ·
-                │                               table             child_nullable@child_nullable_auto_index_fk_p_ref_parent
+                │                               table             child_nullable@child_nullable_p_idx
                 │                               type              semi
                 │                               equality          (p) = (p)
                 └── union                       ·                 ·
@@ -538,9 +539,8 @@ root                                                 ·                   ·
                      │                               label               buffer 1
                      └── distinct                    ·                   ·
                           │                          distinct on         c
-                          │                          order key           c
                           └── scan                   ·                   ·
-·                                                    table               grandchild@grandchild_auto_index_fk_c_ref_child
+·                                                    table               grandchild@primary
 ·                                                    spans               FULL SCAN
 
 # This update shouldn't emit checks for c, since it's unchanged.
@@ -653,9 +653,8 @@ root                                                 ·                   ·
                      │                               label               buffer 1
                      └── distinct                    ·                   ·
                           │                          distinct on         c
-                          │                          order key           c
                           └── scan                   ·                   ·
-·                                                    table               grandchild@grandchild_auto_index_fk_c_ref_child
+·                                                    table               grandchild@primary
 ·                                                    spans               FULL SCAN
 
 # Multiple grandchild tables
@@ -762,9 +761,8 @@ root                                                 ·                   ·
                      │                               label               buffer 1
                      └── distinct                    ·                   ·
                           │                          distinct on         y
-                          │                          order key           y
                           └── scan                   ·                   ·
-·                                                    table               self@self_auto_index_fk_y_ref_self
+·                                                    table               self@primary
 ·                                                    spans               FULL SCAN
 
 # Tests for the insert fast path.

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -432,7 +432,7 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
 
 # Ensure that left joins on non-null foreign keys turn into inner joins
 statement ok
-CREATE TABLE cards(id INT PRIMARY KEY, cust INT NOT NULL REFERENCES customers(id))
+CREATE TABLE cards(id INT PRIMARY KEY, cust INT NOT NULL REFERENCES customers(id), INDEX (cust))
 
 query TTT
 EXPLAIN SELECT * FROM cards LEFT OUTER JOIN customers ON customers.id = cards.cust
@@ -445,7 +445,7 @@ merge-join  ·                   ·
  │          right cols are key  ·
  │          mergeJoinOrder      +"(cust=id)"
  ├── scan   ·                   ·
- │          table               cards@cards_auto_index_fk_cust_ref_customers
+ │          table               cards@cards_cust_idx
  │          spans               FULL SCAN
  └── scan   ·                   ·
 ·           table               customers@primary

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -4002,7 +4002,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT, pi DECIMAL REFERENCES t.pi (d) DE
 		t.Fatal(err)
 	}
 
-	if err := checkTableKeyCount(ctx, kvDB, 2, maxValue); err != nil {
+	if err := checkTableKeyCount(ctx, kvDB, 1, maxValue); err != nil {
 		t.Fatal(err)
 	}
 	if err := sqlutils.RunScrub(sqlDB, "t", "test"); err != nil {
@@ -4036,7 +4036,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT, pi DECIMAL REFERENCES t.pi (d) DE
 		t.Fatal(err)
 	}
 
-	if err := checkTableKeyCount(ctx, kvDB, 2, maxValue); err != nil {
+	if err := checkTableKeyCount(ctx, kvDB, 1, maxValue); err != nil {
 		t.Fatal(err)
 	}
 	if err := sqlutils.RunScrub(sqlDB, "t", "test"); err != nil {

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -180,8 +180,6 @@ func TestShowCreateTable(t *testing.T) {
 	k INT8 NULL,
 	CONSTRAINT fk_i_ref_items FOREIGN KEY (i, j) REFERENCES items(a, b),
 	CONSTRAINT fk_k_ref_items FOREIGN KEY (k) REFERENCES items(c),
-	INDEX %[1]s_auto_index_fk_i_ref_items (i ASC, j ASC),
-	INDEX %[1]s_auto_index_fk_k_ref_items (k ASC),
 	FAMILY "primary" (i, j, k, rowid)
 )`,
 		},
@@ -200,8 +198,6 @@ func TestShowCreateTable(t *testing.T) {
 	k INT8 NULL,
 	CONSTRAINT fk_i_ref_items FOREIGN KEY (i, j) REFERENCES items(a, b) MATCH FULL,
 	CONSTRAINT fk_k_ref_items FOREIGN KEY (k) REFERENCES items(c) MATCH FULL,
-	INDEX %[1]s_auto_index_fk_i_ref_items (i ASC, j ASC),
-	INDEX %[1]s_auto_index_fk_k_ref_items (k ASC),
 	FAMILY "primary" (i, j, k, rowid)
 )`,
 		},
@@ -215,7 +211,6 @@ func TestShowCreateTable(t *testing.T) {
 			expect: `CREATE TABLE %s (
 	x INT8 NULL,
 	CONSTRAINT fk_ref FOREIGN KEY (x) REFERENCES o.public.foo(x),
-	INDEX %[1]s_auto_index_fk_ref (x ASC),
 	FAMILY "primary" (x, rowid)
 )`,
 		},
@@ -234,8 +229,6 @@ func TestShowCreateTable(t *testing.T) {
 	k INT8 NULL,
 	CONSTRAINT fk_i_ref_items FOREIGN KEY (i, j) REFERENCES items(a, b) ON DELETE SET DEFAULT,
 	CONSTRAINT fk_k_ref_items FOREIGN KEY (k) REFERENCES items(c) ON DELETE SET NULL,
-	INDEX %[1]s_auto_index_fk_i_ref_items (i ASC, j ASC),
-	INDEX %[1]s_auto_index_fk_k_ref_items (k ASC),
 	FAMILY "primary" (i, j, k, rowid)
 )`,
 		},
@@ -284,8 +277,6 @@ func TestShowCreateTable(t *testing.T) {
 	l INT8 NULL DEFAULT 4:::INT8,
 	CONSTRAINT fk_i_ref_items FOREIGN KEY (i, j) REFERENCES items(a, b) ON DELETE SET DEFAULT,
 	CONSTRAINT fk_k_ref_items FOREIGN KEY (k, l) REFERENCES items(a, b) MATCH FULL ON UPDATE CASCADE,
-	INDEX %[1]s_auto_index_fk_i_ref_items (i ASC, j ASC),
-	INDEX %[1]s_auto_index_fk_k_ref_items (k ASC, l ASC),
 	FAMILY "primary" (i, j, k, l, rowid)
 )`,
 		},


### PR DESCRIPTION
Release note (sql change): Indexes are no longer required on the origin
side of a foreign key relationship, and are no longer automatically
created.