### PR TITLE
kv/kvserver: don't assert Replica state after lease transfer

### DIFF
--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -1120,9 +1120,19 @@ func (sm *replicaStateMachine) handleNonTrivialReplicatedEvalResult(
 	}
 
 	if rResult.State != nil {
+		if newLease := rResult.State.Lease; newLease != nil {
+			sm.r.handleLeaseResult(ctx, newLease)
+			rResult.State.Lease = nil
+		}
+
 		if rResult.State.TruncatedState != nil {
 			rResult.RaftLogDelta += sm.r.handleTruncatedStateResult(ctx, rResult.State.TruncatedState)
 			rResult.State.TruncatedState = nil
+		}
+
+		if newThresh := rResult.State.GCThreshold; newThresh != nil {
+			sm.r.handleGCThresholdResult(ctx, newThresh)
+			rResult.State.GCThreshold = nil
 		}
 
 		if (*rResult.State == kvserverpb.ReplicaState{}) {
@@ -1162,16 +1172,6 @@ func (sm *replicaStateMachine) handleNonTrivialReplicatedEvalResult(
 		if newDesc := rResult.State.Desc; newDesc != nil {
 			sm.r.handleDescResult(ctx, newDesc)
 			rResult.State.Desc = nil
-		}
-
-		if newLease := rResult.State.Lease; newLease != nil {
-			sm.r.handleLeaseResult(ctx, newLease)
-			rResult.State.Lease = nil
-		}
-
-		if newThresh := rResult.State.GCThreshold; newThresh != nil {
-			sm.r.handleGCThresholdResult(ctx, newThresh)
-			rResult.State.GCThreshold = nil
 		}
 
 		if rResult.State.UsingAppliedStateKey {


### PR DESCRIPTION
During a large IMPORT, I saw that **3.89%** of CPU on the hottest node in the cluster was being spent in `assertStateLocked`. `assertStateLocked` loads various pieces of information about the Replica from on-disk and compares it to in-memory state. The IMPORT creates a large amount of read-amplification (40-60x on this node), which makes these read operations extra expensive.

<img width="1668" alt="Screen Shot 2020-06-27 at 3 53 01 PM" src="https://user-images.githubusercontent.com/5438456/86042458-2d946180-ba15-11ea-842b-305049ef41d8.png">

The assertion is important for catching bugs, but I think we're calling it a little too often. Specifically, in this case, I think it's being called so often because we perform the assertion on lease transfers.

<img width="990" alt="Screen Shot 2020-06-27 at 3 51 42 PM" src="https://user-images.githubusercontent.com/5438456/86042478-384ef680-ba15-11ea-9aeb-5171cd820ddc.png">

Lease transfers have much less of a chance of causing bugs than operations like Splits and Merges, so this commit stops asserting after lease transfers. While here, it also gives the same treatment to bumps to the GCThreshold.