### PR TITLE
kv/kvserver: avoid unnecessary lock contention during application

### DIFF
--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -13,7 +13,6 @@ package kvserver
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -636,17 +635,3 @@ func (*raftLogQueue) timer(_ time.Duration) time.Duration {
 func (*raftLogQueue) purgatoryChan() <-chan time.Time {
 	return nil
 }
-
-var _ sort.Interface = uint64Slice(nil)
-
-// uint64Slice implements sort.Interface
-type uint64Slice []uint64
-
-// Len implements sort.Interface
-func (a uint64Slice) Len() int { return len(a) }
-
-// Swap implements sort.Interface
-func (a uint64Slice) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-
-// Less implements sort.Interface
-func (a uint64Slice) Less(i, j int) bool { return a[i] < a[j] }


### PR DESCRIPTION
This PR contains a mix of cleanup and a bit of perf optimization:

#### kv/kvserver: remove unused uint64Slice in raft_log_queue.go

This was just unused but being kept alive by the `sort.Interface` type assertion assignment.

#### kv/kvserver: remove stale TODO in replicaAppBatch.ApplyToStateMachine

The TODOs for tbg were correct – the bootstrap store no longer has nil split or merge queues, so the nil checks are not needed.

The other TODO was added in 63b1120 and addressed four days later in 2d25bf0 by throttling queue additions.

#### kv/kvserver: remove handleNoRaftLogDeltaResult

The `if cmd.replicatedResult().RaftLogDelta == 0 {` condition looked like a bug, but it was just a premature optimization to avoid potentially queueing on log truncation entries. We already throttle using `raftLogLastCheckSize`, so this doesn't seem worth the complexity.

Meanwhile, this call was incurring a Replica mutex lock on every proposal (not even on every application batch, because this was in ApplySideEffects), which is expensive. This commit merges this into the existing critical section in `ApplyToStateMachine`, which removes complexity and should remove lock contention.

#### kv/kvserver: accept *ReplicatedEvalResult in handleNonTrivialReplicatedEvalResult

The commit switches `replicaStateMachine.handleNonTrivialReplicatedEvalResult` to accept a `*ReplicatedEvalResult` instead of a `ReplicatedEvalResult`. Passing by value is already not stopping us from modifying it because the struct contains interior pointers. In fact, the method intends to modify the argument, so the pointer is just obscuring that fact. This now mirrors `clearTrivialReplicatedEvalResultFields`.

ReplicatedEvalResult is also 232 bytes large, so it generally shouldn't be passed around by value.