### PR TITLE
cli: SIGQUIT should only log stacks, not shut down.

### DIFF
--- a/pkg/cli/interactive_tests/test_dump_sig.tcl
+++ b/pkg/cli/interactive_tests/test_dump_sig.tcl
@@ -8,14 +8,18 @@ send "PS1='\\h:''/# '\r"
 eexpect ":/# "
 
 start_test "Check that the server emits a goroutine dump upon receiving signal"
-send "$argv start --insecure --pid-file=server_pid --log-dir=logs --logtostderr\r"
+send "$argv start --insecure --pid-file=server_pid --store=path=logs/db --logtostderr\r"
 eexpect "CockroachDB node starting"
 
 system "kill -QUIT `cat server_pid`"
-eexpect "received signal 'quit'"
 eexpect "\nI*stack traces:"
 eexpect "RunAsyncTask"
-eexpect "server drained and shutdown completed"
+
+system "kill -QUIT `cat server_pid`"
+eexpect "\nI*stack traces:"
+eexpect "RunAsyncTask"
+
+interrupt
 # Check that the server eventually terminates.
 eexpect ":/# "
 end_test
@@ -27,6 +31,7 @@ eexpect root@
 system "killall -QUIT `basename \$(realpath $argv)`"
 eexpect "SIGQUIT: quit"
 eexpect "RunAsyncTask"
+
 # Check that the client terminates.
 eexpect ":/# "
 end_test

--- a/pkg/cli/start_unix.go
+++ b/pkg/cli/start_unix.go
@@ -30,7 +30,7 @@ import (
 // If two drain signals are seen, the second drain signal will be reraised
 // without a signal handler. The default action of any signal listed here thus
 // must terminate the process.
-var drainSignals = []os.Signal{unix.SIGINT, unix.SIGTERM, unix.SIGQUIT}
+var drainSignals = []os.Signal{unix.SIGINT, unix.SIGTERM}
 
 // termSignal is the signal that causes an idempotent graceful
 // shutdown (i.e. second occurrence does not incur hard shutdown).


### PR DESCRIPTION
Previously, SIGQUIT would both log stack traces and initiate a
graceful shutdown (and since #50538, if received during a graceful
shutdown would log the stacks and then switch to a hard shutdown).
This dual purpose is generally not desirable; when SIGQUIT is used for
logging it does not need to be yet another signal that can shut down
the process.

This is also a slight simplification since SIGQUIT is only handled in
one place.

Release note (cli change): SIGQUIT now causes a cockroach server to
log its stack traces without shutting down.