### PR TITLE
bulkio: Support running BACKUP under transaction.

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -281,15 +280,6 @@ func backupPlanHook(
 		pwFn = fn
 	}
 
-	header := sqlbase.ResultColumns{
-		{Name: "job_id", Typ: types.Int},
-		{Name: "status", Typ: types.String},
-		{Name: "fraction_completed", Typ: types.Float},
-		{Name: "rows", Typ: types.Int},
-		{Name: "index_entries", Typ: types.Int},
-		{Name: "bytes", Typ: types.Int},
-	}
-
 	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
 		// TODO(dan): Move this span into sql.
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
@@ -305,8 +295,8 @@ func backupPlanHook(
 			return err
 		}
 
-		if !p.ExtendedEvalContext().TxnImplicit {
-			return errors.Errorf("BACKUP cannot be used inside a transaction")
+		if !(p.ExtendedEvalContext().TxnImplicit || backupStmt.Options.Detached) {
+			return errors.Errorf("BACKUP cannot be used inside a transaction without DETACHED option")
 		}
 
 		to, err := toFn()
@@ -667,40 +657,7 @@ func backupPlanHook(
 			backupDetails.ProtectedTimestampRecord = &protectedtsID
 		}
 
-		jr := jobs.Record{
-			Description: description,
-			Username:    p.User(),
-			DescriptorIDs: func() (sqlDescIDs []sqlbase.ID) {
-				for _, sqlDesc := range backupManifest.Descriptors {
-					sqlDescIDs = append(sqlDescIDs, sqlDesc.GetID())
-				}
-				return sqlDescIDs
-			}(),
-			Details:  backupDetails,
-			Progress: jobspb.BackupProgress{},
-		}
-		var sj *jobs.StartableJob
-		if err := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
-			sj, err = p.ExecCfg().JobRegistry.CreateStartableJobWithTxn(ctx, jr, txn, resultsCh)
-			if err != nil {
-				return err
-			}
-			if len(spans) > 0 {
-				tsToProtect := endTime
-				rec := jobsprotectedts.MakeRecord(*backupDetails.ProtectedTimestampRecord, *sj.ID(), tsToProtect, spans)
-				return p.ExecCfg().ProtectedTimestampProvider.Protect(ctx, txn, rec)
-			}
-			return nil
-		}); err != nil {
-			if sj != nil {
-				if cleanupErr := sj.CleanupOnRollback(ctx); cleanupErr != nil {
-					log.Warningf(ctx, "failed to cleanup StartableJob: %v", cleanupErr)
-				}
-			}
-		}
-
-		// Collect telemetry.
-		{
+		collectTelemetry := func() {
 			telemetry.Count("backup.total.started")
 			if startTime.IsEmpty() {
 				telemetry.Count("backup.span.full")
@@ -725,13 +682,62 @@ func backupPlanHook(
 			}
 		}
 
+		jr := jobs.Record{
+			Description: description,
+			Username:    p.User(),
+			DescriptorIDs: func() (sqlDescIDs []sqlbase.ID) {
+				for _, sqlDesc := range backupManifest.Descriptors {
+					sqlDescIDs = append(sqlDescIDs, sqlDesc.GetID())
+				}
+				return sqlDescIDs
+			}(),
+			Details:  backupDetails,
+			Progress: jobspb.BackupProgress{},
+		}
+
+		if backupStmt.Options.Detached {
+			// When running in detached mode, we simply create the job record.
+			// We do not wait for the job to finish.
+			if err := utilccl.StartAsyncJob(ctx, p, &jr, resultsCh); err != nil {
+				return err
+			}
+			collectTelemetry()
+			return nil
+		}
+
+		var sj *jobs.StartableJob
+		if err := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
+			sj, err = p.ExecCfg().JobRegistry.CreateStartableJobWithTxn(ctx, jr, txn, resultsCh)
+			if err != nil {
+				return err
+			}
+			if len(spans) > 0 {
+				tsToProtect := endTime
+				rec := jobsprotectedts.MakeRecord(*backupDetails.ProtectedTimestampRecord, *sj.ID(), tsToProtect, spans)
+				return p.ExecCfg().ProtectedTimestampProvider.Protect(ctx, txn, rec)
+			}
+			return nil
+		}); err != nil {
+			if sj != nil {
+				if cleanupErr := sj.CleanupOnRollback(ctx); cleanupErr != nil {
+					log.Warningf(ctx, "failed to cleanup StartableJob: %v", cleanupErr)
+				}
+			}
+		}
+
+		collectTelemetry()
+
 		errCh, err := sj.Start(ctx)
 		if err != nil {
 			return err
 		}
 		return <-errCh
 	}
-	return fn, header, nil, false, nil
+
+	if backupStmt.Options.Detached {
+		return fn, utilccl.DetachedJobExecutionResultHeader, nil, false, nil
+	}
+	return fn, utilccl.BulkJobExecutionResultHeader, nil, false, nil
 }
 
 // checkForNewTables returns an error if any new tables were introduced with the

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -3471,51 +3471,56 @@ func TestFileIOLimits(t *testing.T) {
 	)
 }
 
-func TestBackupRestoreNotInTxn(t *testing.T) {
-	defer leaktest.AfterTest(t)()
+func waitForSuccessfulJob(t *testing.T, tc *testcluster.TestCluster, id int64) {
+	// Force newly created job to be adopted and verify it succeeds.
+	tc.Server(0).JobRegistry().(*jobs.Registry).TestingNudgeAdoptionQueue()
+	testutils.SucceedsSoon(t, func() error {
+		var unused int64
+		return tc.ServerConn(0).QueryRow(
+			"SELECT job_id FROM [SHOW JOBS] WHERE job_id = $1 AND status = $2",
+			id, jobs.StatusSucceeded).Scan(&unused)
+	})
+}
 
+func TestDetachedBackupRestore(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	const numAccounts = 1
-	_, _, sqlDB, _, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitNone)
+	_, tc, sqlDB, _, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitNone)
 	defer cleanupFn()
 
 	db := sqlDB.DB.(*gosql.DB)
+
+	// running backup under transaction requires DETACHED.
+	var jobID int64
 	tx, err := db.Begin()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := tx.Exec(`BACKUP DATABASE data TO 'blah'`); !testutils.IsError(err, "cannot be used inside a transaction") {
-		t.Fatal(err)
-	}
-	if err := tx.Rollback(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	err = tx.QueryRow(`BACKUP DATABASE data TO $1`, LocalFoo).Scan(&jobID)
+	require.True(t, testutils.IsError(err,
+		"BACKUP cannot be used inside a transaction without DETACHED option"))
+	require.NoError(t, tx.Rollback())
 
-	sqlDB.Exec(t, `BACKUP DATABASE data TO $1`, LocalFoo)
-	sqlDB.Exec(t, `DROP DATABASE data`)
-	sqlDB.Exec(t, `RESTORE DATABASE data FROM $1`, LocalFoo)
+	// Okay to run DETACHED backup, even w/out explicit transaction.
+	sqlDB.QueryRow(t, `BACKUP DATABASE data TO $1 WITH DETACHED`, LocalFoo).Scan(&jobID)
+	waitForSuccessfulJob(t, tc, jobID)
 
+	// Backup again, under explicit transaction.
 	tx, err = db.Begin()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := tx.Exec(`RESTORE DATABASE data FROM 'blah'`); !testutils.IsError(err, "cannot be used inside a transaction") {
-		t.Fatal(err)
-	}
-	if err := tx.Rollback(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	err = tx.QueryRow(`BACKUP DATABASE data TO $1 WITH DETACHED`, LocalFoo+"/1").Scan(&jobID)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	waitForSuccessfulJob(t, tc, jobID)
 
-	// TODO(dt): move to importccl.
+	// Backup again under transaction, but this time abort the transaction.
+	// No new jobs should have been created.
+	allJobsQuery := "SELECT job_id FROM [SHOW JOBS]"
+	allJobs := sqlDB.QueryStr(t, allJobsQuery)
 	tx, err = db.Begin()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := tx.Exec(`IMPORT TABLE t (id INT PRIMARY KEY) CSV DATA ('blah')`); !testutils.IsError(err, "cannot be used inside a transaction") {
-		t.Fatal(err)
-	}
-	if err := tx.Rollback(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	err = tx.QueryRow(`BACKUP DATABASE data TO $1 WITH DETACHED`, LocalFoo+"/2").Scan(&jobID)
+	require.NoError(t, err)
+	require.NoError(t, tx.Rollback())
+	sqlDB.CheckQueryResults(t, allJobsQuery, allJobs)
 }
 
 func TestBackupRestoreSequence(t *testing.T) {

--- a/pkg/ccl/utilccl/jobutils.go
+++ b/pkg/ccl/utilccl/jobutils.go
@@ -1,0 +1,51 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package utilccl
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
+
+// BulkJobExecutionResultHeader is the header for various job commands
+// (BACKUP, RESTORE, IMPORT, etc) stmt results.
+var BulkJobExecutionResultHeader = sqlbase.ResultColumns{
+	{Name: "job_id", Typ: types.Int},
+	{Name: "status", Typ: types.String},
+	{Name: "fraction_completed", Typ: types.Float},
+	{Name: "rows", Typ: types.Int},
+	{Name: "index_entries", Typ: types.Int},
+	{Name: "bytes", Typ: types.Int},
+}
+
+// DetachedJobExecutionResultHeader is a the header for various job commands when
+// job executes in detached mode (i.e. the caller doesn't wait for job completion).
+var DetachedJobExecutionResultHeader = sqlbase.ResultColumns{
+	{Name: "job_id", Typ: types.Int},
+}
+
+// StartAsyncJob starts running the job without blocking and waiting for job completion.
+func StartAsyncJob(
+	ctx context.Context, p sql.PlanHookState, jr *jobs.Record, resultsCh chan<- tree.Datums,
+) error {
+	// When running inside explicit transaction, we simply create the job record.
+	// We do not wait for the job to finish.
+	j, err := p.ExecCfg().JobRegistry.CreateAdoptableJobWithTxn(
+		ctx, *jr, p.ExtendedEvalContext().Txn)
+	if err != nil {
+		return err
+	}
+	resultsCh <- tree.Datums{tree.NewDInt(tree.DInt(*j.ID()))}
+	return nil
+}

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -367,11 +367,30 @@ func (r *Registry) NewJob(record Record) *Job {
 }
 
 // CreateJobWithTxn creates a job to be started later with StartJob.
-// It stores the job in the jobs table, marks it pending and gives the
+// It stores the job in the jobs table, marks it running and gives the
 // current node a lease.
 func (r *Registry) CreateJobWithTxn(ctx context.Context, record Record, txn *kv.Txn) (*Job, error) {
 	j := r.NewJob(record)
 	if err := j.WithTxn(txn).insert(ctx, r.makeJobID(), r.newLease()); err != nil {
+		return nil, err
+	}
+	return j, nil
+}
+
+const invalidNodeID = 0
+
+// CreateAdoptableJobWithTxn creates a job which will be adopted for execution
+// at a later time by some node in the cluster.
+func (r *Registry) CreateAdoptableJobWithTxn(
+	ctx context.Context, record Record, txn *kv.Txn,
+) (*Job, error) {
+	j := r.NewJob(record)
+
+	// We create a job record with an invalid lease to force the registry (on some node
+	// in the cluster) to adopt this job at a later time.
+	lease := &jobspb.Lease{NodeID: invalidNodeID}
+
+	if err := j.WithTxn(txn).insert(ctx, r.makeJobID(), lease); err != nil {
 		return nil, err
 	}
 	return j, nil
@@ -1015,9 +1034,9 @@ WHERE status IN ($1, $2, $3, $4, $5) ORDER BY created DESC`
 		isLive bool
 	}
 	nodeStatusMap := map[roachpb.NodeID]*nodeStatus{
-		// 0 is not a valid node ID, but we treat it as an always-dead node so that
+		// We treat invalidNodeID as an always-dead node so that
 		// the empty lease (Lease{}) is always considered expired.
-		0: {isLive: false},
+		invalidNodeID: {isLive: false},
 	}
 	// If no liveness is available, adopt all jobs. This is reasonable because this
 	// only affects SQL tenants, which have at most one SQL server running on their


### PR DESCRIPTION
Informs #47539

Allow execution of BACKUP statement under explicit transaction,
provided the "DETACHED" option is specified:

```
BACKUP TO <location_uri> ... WITH DETACHED
```

When backup runs in `detached` mode, we do not wait for the job
completion.  Instead, we return the job id to the caller, and
the job executes asynchronously.

Release notes (enterprise change): BACKUP can now run in "detached" mode.
That is, we do not wait for the BACKUP job to finish.  Instead, the
job ID is returned immediately, and the job itself runs in background.