### PR TITLE
build/packer: Configure filebeat installation onto TeamCity agents

### DIFF
--- a/build/packer/filebeat/filebeat-agent.yml
+++ b/build/packer/filebeat/filebeat-agent.yml
@@ -1,0 +1,33 @@
+# Filebeat config file for the TeamCity agents
+
+# Whenever the 'filebeat-agent.yml' file is updated in the 
+# 'roachsiem' repo, the same edits need to be made here,
+# committed, and a new agent image built and deployed.
+
+filebeat.inputs:
+- type: log
+  paths:
+    - /home/agent/logs/teamcity-build.log
+  # Parses release events. All release logs begin with 'done building <package>: ' and end with a closing brace.
+  multiline:
+    pattern: '(.*(\d{4}\/(0[1-9]|1[012])\/(0[1-9]|[12][0-9]|3[01]))\s*([0-2][0-9]:[0-5][0-9]:[0-5][0-9])\s*(main.go:[0-9]+:\s*)?done\s*building\s*.*:\s*main\.opts{\s*)|(^Build .* \#[0-9]+, branch .*$)|(\[([0-2][0-9]:[0-5][0-9]:[0-5][0-9])\]([a-zA-Z|\s]:)?\s*\[Step\s[0-9]+\/[0-9]+\]\s*\++\s*docker push docker.io\/)' 
+    negate: true
+    match: after
+    flush_pattern: '(^\[([0-2][0-9]:[0-5][0-9]:[0-5][0-9])\]([a-zA-Z|\s]:)?\s*\[Step\s[0-9]+\/[0-9]+\]\s*}\s*$)|(\[([0-2][0-9]:[0-5][0-9]:[0-5][0-9])\][a-zA-Z|\s]:\s*\[Step\s[0-9]+\/[0-9]+\]\s*Process exited with code 0\s*$)|(([0-2][0-9]:[0-5][0-9]:[0-5][0-9]) main.go:[0-9]+: Uploading to s3:)|(^TeamCity server version is ([0-9]|\.)+ \(build [0-9]+\), server timezone: )|([A-Za-z0-9_\.-]+: digest: sha256:[a-z0-9]+ size: [0-9]+)'
+
+processors:
+# Add TeamCity identifier
+- add_fields:
+    target: ''
+    fields:
+      filebeat_source: 'teamcity_agent'
+# Add info about host machine & GCP metadata for TC project
+- add_host_metadata: ~
+- add_cloud_metadata: 
+    providers:
+      - gcp
+
+output.logstash:
+  enabled: true
+  timeout: 15
+  hosts: ["triptolemus.cockroachlabs.com:5044"]

--- a/build/packer/setup_filebeat_on_teamcity_agent.sh
+++ b/build/packer/setup_filebeat_on_teamcity_agent.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export FILEBEAT_CONFIG_PATH=/tmp/filebeat.yml
+
+# Download the Public Signing Key for the Beats APT repository
+wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add -
+
+# Install prerequisite package
+apt-get install apt-transport-https
+
+# Save APT repo to disk
+echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list
+
+# Install Filebeat via apt-get and run at startup
+echo "Installing filebeat..."
+apt-get update && apt-get install filebeat
+
+# Copy over config file 
+echo "Copying config..."
+cp $FILEBEAT_CONFIG_PATH /etc/filebeat/filebeat.yml
+# Filebeat requires that the core config file have root ownership
+chown root:root /etc/filebeat/filebeat.yml
+
+# Enable Filebeat service to run at startup
+systemctl enable filebeat
+
+# Restart Filebeat service
+echo "Restarting filebeat..."
+systemctl restart filebeat

--- a/build/packer/teamcity-agent.json
+++ b/build/packer/teamcity-agent.json
@@ -20,5 +20,14 @@
     "type": "shell",
     "script": "teamcity-agent.sh",
     "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+  },{
+    "type": "file",
+    "source": "filebeat/filebeat-agent.yml",
+    "destination": "/tmp/filebeat.yml"
+  },
+  {
+    "type": "shell",
+    "script": "setup_filebeat_on_teamcity_agent.sh",
+    "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
   }]
 }

--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -81,6 +81,11 @@ cd "$repo"
 git submodule update --init --recursive
 for branch in $(git branch --all --list --sort=-committerdate 'origin/release-*' | head -n1) master
 do
+  # Clean out all non-checked-in files. This is because of the check-in of
+  # the generated execgen files. Once we are no longer building 20.1 builds,
+  # the `git clean -dxf` line can be removed.
+  git clean -dxf
+
   git checkout "$branch"
   COCKROACH_BUILDER_CCACHE=1 build/builder.sh make test testrace TESTS=-
   # TODO(benesch): store the acceptanceversion somewhere more accessible.


### PR DESCRIPTION
Configures installation of [Filebeat](https://www.elastic.co/beats/filebeat) onto dynamically provisioned TeamCity agents for ease of log shipping.

The logs collected by Filebeat are sent to the internal IP of a GCE instance hosting the ELK stack for log parsing and analysis.