### PR TITLE
sql: don't allocate clientConnLock in LockCommunication

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -577,9 +577,7 @@ func (icc *internalClientComm) CreateSyncResult(pos CmdPos) SyncResult {
 
 // LockCommunication is part of the ClientComm interface.
 func (icc *internalClientComm) LockCommunication() ClientLock {
-	return &noopClientLock{
-		clientComm: icc,
-	}
+	return (*noopClientLock)(icc)
 }
 
 // Flush is part of the ClientComm interface.
@@ -624,26 +622,24 @@ func (icc *internalClientComm) CreateDrainResult(pos CmdPos) DrainResult {
 
 // noopClientLock is an implementation of ClientLock that says that no results
 // have been communicated to the client.
-type noopClientLock struct {
-	clientComm *internalClientComm
-}
+type noopClientLock internalClientComm
 
 // Close is part of the ClientLock interface.
 func (ncl *noopClientLock) Close() {}
 
 // ClientPos is part of the ClientLock interface.
 func (ncl *noopClientLock) ClientPos() CmdPos {
-	return ncl.clientComm.lastDelivered
+	return ncl.lastDelivered
 }
 
 // RTrim is part of the ClientLock interface.
 func (ncl *noopClientLock) RTrim(_ context.Context, pos CmdPos) {
 	var i int
 	var r resWithPos
-	for i, r = range ncl.clientComm.results {
+	for i, r = range ncl.results {
 		if r.pos >= pos {
 			break
 		}
 	}
-	ncl.clientComm.results = ncl.clientComm.results[:i]
+	ncl.results = ncl.results[:i]
 }

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1344,15 +1344,13 @@ func (c *conn) maybeFlush(pos sql.CmdPos) (bool, error) {
 // nothing to "lock" - communication is naturally blocked as the command
 // processor won't write any more results.
 func (c *conn) LockCommunication() sql.ClientLock {
-	return &clientConnLock{flushInfo: &c.writerState.fi}
+	return (*clientConnLock)(&c.writerState.fi)
 }
 
 // clientConnLock is the connection's implementation of sql.ClientLock. It lets
 // the sql module lock the flushing of results and find out what has already
 // been flushed.
-type clientConnLock struct {
-	*flushInfo
-}
+type clientConnLock flushInfo
 
 var _ sql.ClientLock = &clientConnLock{}
 


### PR DESCRIPTION
This allocation was showing up as **0.28%** of a CPU profile while running TPC-E. It's easy to avoid, so do so.

<img width="1679" alt="Screen Shot 2020-06-29 at 7 42 30 PM" src="https://user-images.githubusercontent.com/5438456/86068762-30f41100-ba46-11ea-864c-76d1b271992c.png">

While here, do the same thing for `noopClientLock`.