### PR TITLE
sql: disallow creation of schemas with the "pg_" prefix

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -33,3 +33,6 @@ CREATE SCHEMA pg_catalog
 
 statement error schema .* already exists
 CREATE SCHEMA information_schema
+
+statement error pq: unacceptable schema name \"pg_temp\"
+CREATE SCHEMA pg_temp

--- a/pkg/sql/sessiondata/search_path.go
+++ b/pkg/sql/sessiondata/search_path.go
@@ -29,6 +29,10 @@ const InformationSchemaName = "information_schema"
 // CRDBInternalSchemaName is the name of the crdb_internal system schema.
 const CRDBInternalSchemaName = "crdb_internal"
 
+// PgSchemaPrefix is a prefix for Postgres system schemas. Users cannot
+// create schemas with this prefix.
+const PgSchemaPrefix = "pg_"
+
 // PgTempSchemaName is the alias for temporary schemas across sessions.
 const PgTempSchemaName = "pg_temp"
 


### PR DESCRIPTION
This is disallowed by Postgres, and will be useful when integrating user
defined schema resolution with the temporary schema (which isn't backed
by a descriptor).

Release note: None