### PR TITLE
colexec: change the behavior of vectorize=experimental_always

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -265,7 +265,7 @@ func isSupported(mode sessiondata.VectorizeExecMode, spec *execinfrapb.Processor
 func (r opResult) createDiskBackedSort(
 	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
-	args colexec.NewColOperatorArgs,
+	args *colexec.NewColOperatorArgs,
 	input colexecbase.Operator,
 	inputTypes []*types.T,
 	ordering execinfrapb.Ordering,
@@ -403,36 +403,43 @@ func (r opResult) createDiskBackedSort(
 // it is a buffering processor). This is not a problem for memory accounting
 // because each processor does that on its own, so the used memory will be
 // accounted for.
+// - causeToWrap is an error that prompted us to wrap a processor core into the
+// vectorized plan (for example, it could be an unsupported processor core, an
+// unsupported function, etc).
 func (r opResult) createAndWrapRowSource(
 	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
+	args *colexec.NewColOperatorArgs,
 	inputs []colexecbase.Operator,
 	inputTypes [][]*types.T,
-	streamingMemAccount *mon.BoundAccount,
 	spec *execinfrapb.ProcessorSpec,
-	processorConstructor execinfra.ProcessorConstructor,
 	factory coldata.ColumnFactory,
+	causeToWrap error,
 ) error {
-	if processorConstructor == nil {
+	if args.ProcessorConstructor == nil {
 		return errors.New("processorConstructor is nil")
 	}
-	if flowCtx.EvalCtx.SessionData.VectorizeMode == sessiondata.Vectorize201Auto &&
-		spec.Core.JoinReader == nil {
-		return errors.New("rowexec processor wrapping for non-JoinReader core unsupported in vectorize=201auto mode")
+	if spec.Core.JoinReader == nil {
+		switch flowCtx.EvalCtx.SessionData.VectorizeMode {
+		case sessiondata.Vectorize201Auto:
+			return errors.New("rowexec processor wrapping for non-JoinReader core unsupported in vectorize=201auto mode")
+		case sessiondata.VectorizeExperimentalAlways:
+			return causeToWrap
+		}
 	}
 	c, err := wrapRowSources(
 		ctx,
 		flowCtx,
 		inputs,
 		inputTypes,
-		streamingMemAccount,
+		args.StreamingMemAccount,
 		spec.ProcessorID,
 		func(inputs []execinfra.RowSource) (execinfra.RowSource, error) {
 			// We provide a slice with a single nil as 'outputs' parameter because
 			// all processors expect a single output. Passing nil is ok here
 			// because when wrapping the processor, the materializer will be its
 			// output, and it will be set up in wrapRowSources.
-			proc, err := processorConstructor(
+			proc, err := args.ProcessorConstructor(
 				ctx, flowCtx, spec.ProcessorID, &spec.Core, &spec.Post, inputs,
 				[]execinfra.RowReceiver{nil}, /* outputs */
 				nil,                          /* localProcessors */
@@ -493,7 +500,7 @@ func (r opResult) createAndWrapRowSource(
 
 // NewColOperator creates a new columnar operator according to the given spec.
 func NewColOperator(
-	ctx context.Context, flowCtx *execinfra.FlowCtx, args colexec.NewColOperatorArgs,
+	ctx context.Context, flowCtx *execinfra.FlowCtx, args *colexec.NewColOperatorArgs,
 ) (r colexec.NewColOperatorResult, err error) {
 	result := opResult{NewColOperatorResult: &r}
 	// Make sure that we clean up memory monitoring infrastructure in case of an
@@ -521,7 +528,6 @@ func NewColOperator(
 	streamingMemAccount := args.StreamingMemAccount
 	streamingAllocator := colmem.NewAllocator(ctx, streamingMemAccount, factory)
 	useStreamingMemAccountForBuffering := args.TestingKnobs.UseStreamingMemAccountForBuffering
-	processorConstructor := args.ProcessorConstructor
 	if args.ExprHelper == nil {
 		args.ExprHelper = colexec.NewDefaultExprHelper()
 	}
@@ -575,8 +581,7 @@ func NewColOperator(
 			copy(inputTypes[inputIdx], input.ColumnTypes)
 		}
 
-		err = result.createAndWrapRowSource(ctx, flowCtx, inputs, inputTypes,
-			streamingMemAccount, spec, processorConstructor, factory)
+		err = result.createAndWrapRowSource(ctx, flowCtx, args, inputs, inputTypes, spec, factory, err)
 		// The wrapped processors need to be passed the post-process specs,
 		// since they inspect them to figure out information about needed
 		// columns. This means that we'll let those processors do any renders
@@ -817,7 +822,7 @@ func NewColOperator(
 							diskQueueCfg,
 							args.FDSemaphore,
 							func(input colexecbase.Operator, inputTypes []*types.T, orderingCols []execinfrapb.Ordering_Column, maxNumberPartitions int) (colexecbase.Operator, error) {
-								sortArgs := args
+								sortArgs := *args
 								if !args.TestingKnobs.DelegateFDAcquisitions {
 									// Set the FDSemaphore to nil. This indicates that no FDs
 									// should be acquired. The external hash joiner will do this
@@ -825,7 +830,7 @@ func NewColOperator(
 									sortArgs.FDSemaphore = nil
 								}
 								return result.createDiskBackedSort(
-									ctx, flowCtx, sortArgs, input, inputTypes,
+									ctx, flowCtx, &sortArgs, input, inputTypes,
 									execinfrapb.Ordering{Columns: orderingCols},
 									0 /* matchLen */, maxNumberPartitions, spec.ProcessorID,
 									&execinfrapb.PostProcessSpec{}, monitorNamePrefix+"-", factory)
@@ -851,7 +856,7 @@ func NewColOperator(
 			if !core.HashJoiner.OnExpr.Empty() && core.HashJoiner.Type == sqlbase.InnerJoin {
 				if err =
 					result.planAndMaybeWrapOnExprAsFilter(
-						ctx, flowCtx, core.HashJoiner.OnExpr, streamingMemAccount, processorConstructor, factory, args.ExprHelper,
+						ctx, flowCtx, args, core.HashJoiner.OnExpr, factory,
 					); err != nil {
 					return r, err
 				}
@@ -914,7 +919,7 @@ func NewColOperator(
 
 			if onExpr != nil {
 				if err = result.planAndMaybeWrapOnExprAsFilter(
-					ctx, flowCtx, *onExpr, streamingMemAccount, processorConstructor, factory, args.ExprHelper,
+					ctx, flowCtx, args, *onExpr, factory,
 				); err != nil {
 					return r, err
 				}
@@ -1069,7 +1074,7 @@ func NewColOperator(
 		Op:          result.Op,
 		ColumnTypes: result.ColumnTypes,
 	}
-	err = ppr.planPostProcessSpec(ctx, flowCtx, post, streamingMemAccount, factory, args.ExprHelper)
+	err = ppr.planPostProcessSpec(ctx, flowCtx, args, post, factory)
 	if err != nil {
 		log.VEventf(
 			ctx, 2,
@@ -1090,15 +1095,13 @@ func NewColOperator(
 				copy(inputTypes[inputIdx], input.ColumnTypes)
 			}
 			result.resetToState(ctx, resultPreSpecPlanningStateShallowCopy)
-			err = result.createAndWrapRowSource(
-				ctx, flowCtx, inputs, inputTypes, streamingMemAccount, spec, processorConstructor, factory,
-			)
+			err = result.createAndWrapRowSource(ctx, flowCtx, args, inputs, inputTypes, spec, factory, err)
 			if err != nil {
 				// There was an error wrapping the TableReader.
 				return r, err
 			}
 		} else {
-			err = result.wrapPostProcessSpec(ctx, flowCtx, post, streamingMemAccount, processorConstructor, factory)
+			err = result.wrapPostProcessSpec(ctx, flowCtx, args, post, factory, err)
 		}
 	} else {
 		// The result can be updated with the post process result.
@@ -1113,11 +1116,9 @@ func NewColOperator(
 func (r opResult) planAndMaybeWrapOnExprAsFilter(
 	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
+	args *colexec.NewColOperatorArgs,
 	onExpr execinfrapb.Expression,
-	streamingMemAccount *mon.BoundAccount,
-	processorConstructor execinfra.ProcessorConstructor,
 	factory coldata.ColumnFactory,
-	helper colexec.ExprHelper,
 ) error {
 	// We will plan other Operators on top of r.Op, so we need to account for the
 	// internal memory explicitly.
@@ -1129,7 +1130,7 @@ func (r opResult) planAndMaybeWrapOnExprAsFilter(
 		ColumnTypes: r.ColumnTypes,
 	}
 	if err := ppr.planFilterExpr(
-		ctx, flowCtx.NewEvalCtx(), onExpr, streamingMemAccount, factory, helper,
+		ctx, flowCtx.NewEvalCtx(), onExpr, args.StreamingMemAccount, factory, args.ExprHelper,
 	); err != nil {
 		// ON expression planning failed. Fall back to planning the filter
 		// using row execution.
@@ -1140,7 +1141,7 @@ func (r opResult) planAndMaybeWrapOnExprAsFilter(
 		)
 
 		onExprAsFilter := &execinfrapb.PostProcessSpec{Filter: onExpr}
-		return r.wrapPostProcessSpec(ctx, flowCtx, onExprAsFilter, streamingMemAccount, processorConstructor, factory)
+		return r.wrapPostProcessSpec(ctx, flowCtx, args, onExprAsFilter, factory, err)
 	}
 	r.updateWithPostProcessResult(ppr)
 	return nil
@@ -1154,10 +1155,10 @@ func (r opResult) planAndMaybeWrapOnExprAsFilter(
 func (r opResult) wrapPostProcessSpec(
 	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
+	args *colexec.NewColOperatorArgs,
 	post *execinfrapb.PostProcessSpec,
-	streamingMemAccount *mon.BoundAccount,
-	processorConstructor execinfra.ProcessorConstructor,
 	factory coldata.ColumnFactory,
+	causeToWrap error,
 ) error {
 	noopSpec := &execinfrapb.ProcessorSpec{
 		Core: execinfrapb.ProcessorCoreUnion{
@@ -1166,8 +1167,8 @@ func (r opResult) wrapPostProcessSpec(
 		Post: *post,
 	}
 	return r.createAndWrapRowSource(
-		ctx, flowCtx, []colexecbase.Operator{r.Op}, [][]*types.T{r.ColumnTypes},
-		streamingMemAccount, noopSpec, processorConstructor, factory,
+		ctx, flowCtx, args, []colexecbase.Operator{r.Op}, [][]*types.T{r.ColumnTypes},
+		noopSpec, factory, causeToWrap,
 	)
 }
 
@@ -1176,14 +1177,13 @@ func (r opResult) wrapPostProcessSpec(
 func (r *postProcessResult) planPostProcessSpec(
 	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
+	args *colexec.NewColOperatorArgs,
 	post *execinfrapb.PostProcessSpec,
-	streamingMemAccount *mon.BoundAccount,
 	factory coldata.ColumnFactory,
-	helper colexec.ExprHelper,
 ) error {
 	if !post.Filter.Empty() {
 		if err := r.planFilterExpr(
-			ctx, flowCtx.NewEvalCtx(), post.Filter, streamingMemAccount, factory, helper,
+			ctx, flowCtx.NewEvalCtx(), post.Filter, args.StreamingMemAccount, factory, args.ExprHelper,
 		); err != nil {
 			return err
 		}
@@ -1196,13 +1196,13 @@ func (r *postProcessResult) planPostProcessSpec(
 		var renderedCols []uint32
 		for _, renderExpr := range post.RenderExprs {
 			var renderInternalMem int
-			expr, err := helper.ProcessExpr(renderExpr, flowCtx.EvalCtx, r.ColumnTypes)
+			expr, err := args.ExprHelper.ProcessExpr(renderExpr, flowCtx.EvalCtx, r.ColumnTypes)
 			if err != nil {
 				return err
 			}
 			var outputIdx int
 			r.Op, outputIdx, r.ColumnTypes, renderInternalMem, err = planProjectionOperators(
-				ctx, flowCtx.NewEvalCtx(), expr, r.ColumnTypes, r.Op, streamingMemAccount, factory,
+				ctx, flowCtx.NewEvalCtx(), expr, r.ColumnTypes, r.Op, args.StreamingMemAccount, factory,
 			)
 			if err != nil {
 				return errors.Wrapf(err, "unable to columnarize render expression %q", expr)

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -304,7 +304,7 @@ func createDiskBackedHashJoiner(
 	delegateFDAcquisitions bool,
 	testingSemaphore semaphore.Semaphore,
 ) (colexecbase.Operator, []*mon.BoundAccount, []*mon.BytesMonitor, []IdempotentCloser, error) {
-	args := NewColOperatorArgs{
+	args := &NewColOperatorArgs{
 		Spec:                spec,
 		Inputs:              inputs,
 		StreamingMemAccount: testMemAcc,

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -335,7 +335,7 @@ func createDiskBackedSorter(
 			Limit: uint64(k),
 		},
 	}
-	args := NewColOperatorArgs{
+	args := &NewColOperatorArgs{
 		Spec:                spec,
 		Inputs:              input,
 		StreamingMemAccount: testMemAcc,

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -1003,7 +1003,7 @@ func TestHashJoiner(t *testing.T) {
 				for _, tc := range tc.mutateTypes() {
 					runHashJoinTestCase(t, tc, func(sources []colexecbase.Operator) (colexecbase.Operator, error) {
 						spec := createSpecForHashJoiner(tc)
-						args := NewColOperatorArgs{
+						args := &NewColOperatorArgs{
 							Spec:                spec,
 							Inputs:              sources,
 							StreamingMemAccount: testMemAcc,
@@ -1184,7 +1184,7 @@ func TestHashJoinerProjection(t *testing.T) {
 
 	leftSource := newOpTestInput(1, leftTuples, leftTypes)
 	rightSource := newOpTestInput(1, rightTuples, rightTypes)
-	args := NewColOperatorArgs{
+	args := &NewColOperatorArgs{
 		Spec:                spec,
 		Inputs:              []colexecbase.Operator{leftSource, rightSource},
 		StreamingMemAccount: testMemAcc,

--- a/pkg/sql/colexec/is_null_ops_test.go
+++ b/pkg/sql/colexec/is_null_ops_test.go
@@ -235,7 +235,7 @@ func TestIsNullSelOp(t *testing.T) {
 						Filter: execinfrapb.Expression{Expr: fmt.Sprintf("@1 %s", c.selExpr)},
 					},
 				}
-				args := NewColOperatorArgs{
+				args := &NewColOperatorArgs{
 					Spec:                spec,
 					Inputs:              input,
 					StreamingMemAccount: testMemAcc,

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1671,7 +1671,7 @@ func TestMergeJoiner(t *testing.T) {
 						tc.expected, mergeJoinVerifier,
 						func(input []colexecbase.Operator) (colexecbase.Operator, error) {
 							spec := createSpecForMergeJoiner(tc)
-							args := NewColOperatorArgs{
+							args := &NewColOperatorArgs{
 								Spec:                spec,
 								Inputs:              input,
 								StreamingMemAccount: testMemAcc,

--- a/pkg/sql/colexec/op_creation.go
+++ b/pkg/sql/colexec/op_creation.go
@@ -25,7 +25,7 @@ import (
 // TestNewColOperator is a test helper that's always aliased to builder.NewColOperator.
 // We inject this at test time, so tests can use NewColOperator from colexec
 // package.
-var TestNewColOperator func(ctx context.Context, flowCtx *execinfra.FlowCtx, args NewColOperatorArgs,
+var TestNewColOperator func(ctx context.Context, flowCtx *execinfra.FlowCtx, args *NewColOperatorArgs,
 ) (r NewColOperatorResult, err error)
 
 // NewColOperatorArgs is a helper struct that encompasses all of the input

--- a/pkg/sql/colexec/ordinality_test.go
+++ b/pkg/sql/colexec/ordinality_test.go
@@ -110,7 +110,7 @@ func createTestOrdinalityOperator(
 			Ordinality: &execinfrapb.OrdinalitySpec{},
 		},
 	}
-	args := NewColOperatorArgs{
+	args := &NewColOperatorArgs{
 		Spec:                spec,
 		Inputs:              []colexecbase.Operator{input},
 		StreamingMemAccount: testMemAcc,

--- a/pkg/sql/colexec/select_in_test.go
+++ b/pkg/sql/colexec/select_in_test.go
@@ -240,7 +240,7 @@ func TestProjectInInt64(t *testing.T) {
 							},
 						},
 					}
-					args := NewColOperatorArgs{
+					args := &NewColOperatorArgs{
 						Spec:                spec,
 						Inputs:              input,
 						StreamingMemAccount: testMemAcc,

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -1607,7 +1607,7 @@ func createTestProjectingOperator(
 			RenderExprs: renderExprs,
 		},
 	}
-	args := NewColOperatorArgs{
+	args := &NewColOperatorArgs{
 		Spec:                spec,
 		Inputs:              []colexecbase.Operator{input},
 		StreamingMemAccount: testMemAcc,

--- a/pkg/sql/colexec/window_functions_test.go
+++ b/pkg/sql/colexec/window_functions_test.go
@@ -295,7 +295,7 @@ func TestWindowFunctions(t *testing.T) {
 						},
 					}
 					sem := colexecbase.NewTestingSemaphore(maxNumberFDs)
-					args := NewColOperatorArgs{
+					args := &NewColOperatorArgs{
 						Spec:                spec,
 						Inputs:              inputs,
 						StreamingMemAccount: testMemAcc,

--- a/pkg/sql/colflow/colbatch_scan_test.go
+++ b/pkg/sql/colflow/colbatch_scan_test.go
@@ -82,7 +82,7 @@ func BenchmarkColBatchScan(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
-				args := colexec.NewColOperatorArgs{
+				args := &colexec.NewColOperatorArgs{
 					Spec:                &spec,
 					StreamingMemAccount: testMemAcc,
 				}

--- a/pkg/sql/colflow/vectorized_flow_space_test.go
+++ b/pkg/sql/colflow/vectorized_flow_space_test.go
@@ -96,7 +96,7 @@ func TestVectorizeInternalMemorySpaceError(t *testing.T) {
 				defer memMon.Stop(ctx)
 				acc := memMon.MakeBoundAccount()
 				defer acc.Close(ctx)
-				args := colexec.NewColOperatorArgs{
+				args := &colexec.NewColOperatorArgs{
 					Spec:                tc.spec,
 					Inputs:              inputs,
 					StreamingMemAccount: &acc,
@@ -223,7 +223,7 @@ func TestVectorizeAllocatorSpaceError(t *testing.T) {
 				defer memMon.Stop(ctx)
 				acc := memMon.MakeBoundAccount()
 				defer acc.Close(ctx)
-				args := colexec.NewColOperatorArgs{
+				args := &colexec.NewColOperatorArgs{
 					Spec:                tc.spec,
 					Inputs:              inputs,
 					StreamingMemAccount: &acc,

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -214,7 +214,10 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	f := &flowinfra.FlowBase{FlowCtx: execinfra.FlowCtx{EvalCtx: &evalCtx, NodeID: base.TestingIDContainer}}
 	var wg sync.WaitGroup
-	vfc := newVectorizedFlowCreator(&vectorizedFlowCreatorHelper{f: f}, componentCreator, false, &wg, &execinfra.RowChannel{}, nil, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{}, nil, false /* forceExprDeserialization */)
+	vfc := newVectorizedFlowCreator(
+		&vectorizedFlowCreatorHelper{f: f}, componentCreator, false, &wg, &execinfra.RowChannel{},
+		nil, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{}, nil, colexec.DefaultExprDeserialization,
+	)
 
 	_, err := vfc.setupFlow(ctx, &f.FlowCtx, procs, flowinfra.FuseNormally)
 	defer func() {

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -135,7 +135,7 @@ func verifyColOperator(args verifyColOperatorArgs) error {
 		columnarizers[i] = c
 	}
 
-	constructorArgs := colexec.NewColOperatorArgs{
+	constructorArgs := &colexec.NewColOperatorArgs{
 		Spec:                args.pspec,
 		Inputs:              columnarizers,
 		StreamingMemAccount: &acc,

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -159,6 +159,8 @@ func buildStatementBundle(
 	b.addStatement()
 	b.addOptPlans()
 	b.addExecPlan()
+	// TODO(yuzefovich): consider adding some variant of EXPLAIN (VEC) output
+	// of the query to the bundle.
 	b.addDistSQLDiagrams()
 	traceJSON := b.addTrace()
 	b.addEnv(ctx)

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -219,7 +219,9 @@ func populateExplain(
 			thisNodeID, _ := params.extendedEvalCtx.NodeID.OptionalNodeID()
 			for scheduledOnNodeID, flow := range flows {
 				scheduledOnRemoteNode := scheduledOnNodeID != thisNodeID
-				if _, err := colflow.SupportsVectorized(params.ctx, flowCtx, flow.Processors, !willDistribute, nil /* output */, scheduledOnRemoteNode); err != nil {
+				if _, err := colflow.SupportsVectorized(
+					params.ctx, flowCtx, flow.Processors, !willDistribute, nil /* output */, scheduledOnRemoteNode,
+				); err != nil {
 					willVectorize = false
 					break
 				}

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -102,7 +102,9 @@ func (n *explainVecNode) startExec(params runParams) error {
 	for _, flow := range sortedFlows {
 		node := root.Childf("Node %d", flow.nodeID)
 		scheduledOnRemoteNode := flow.nodeID != thisNodeID
-		opChains, err := colflow.SupportsVectorized(params.ctx, flowCtx, flow.flow.Processors, !willDistribute, nil /* output */, scheduledOnRemoteNode)
+		opChains, err := colflow.SupportsVectorized(
+			params.ctx, flowCtx, flow.flow.Processors, !willDistribute, nil /* output */, scheduledOnRemoteNode,
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1,4 +1,7 @@
-# LogicTest: local local-vec-auto fakedist fakedist-vec-auto-disk fakedist-disk
+# LogicTest: local fakedist fakedist-disk
+
+# Note that there is no much benefit from running this file with other logic
+# test configurations because we override vectorize setting.
 
 # Disable automatic stats.
 statement ok
@@ -182,12 +185,8 @@ SELECT a, b, (a + 1) * (b + 2) FROM a WHERE a < 3
 2  4  18
 2  5  21
 
-# Mismatched constant type in projection. Not handled yet but should fall back
-# gracefully.
-query I
+statement error .* unhandled cast decimal -> int
 SELECT (a + 1.0::DECIMAL)::INT FROM a LIMIT 1
-----
-1
 
 # Operations with constants on the left work.
 query I
@@ -213,18 +212,15 @@ SELECT * FROM bools WHERE b
 true 0
 true 2
 
-# Mismatched column types in projection. Not handled yet but should fall back
-# gracefully.
+# Mismatched column types in projection.
 statement ok
 RESET vectorize;
 CREATE TABLE intdecfloat (a INT, b DECIMAL, c INT4, d INT2, e FLOAT8);
 INSERT INTO intdecfloat VALUES (1, 2.0, 3, 4, 3.5);
 SET vectorize = experimental_always
 
-query I
+statement error .* unhandled cast decimal -> int
 SELECT (a + b)::INT FROM intdecfloat
-----
-3
 
 query BB
 SELECT b > a, e < b FROM intdecfloat
@@ -734,10 +730,8 @@ CREATE TABLE t39417 (x int8);
 INSERT INTO t39417 VALUES (10);
 SET vectorize = experimental_always
 
-query R
+statement error .* decimal casts with rounding unsupported
 select (x/1) from t39417
-----
-10
 
 # Regression tests for #39540, an issue caused by shallow copying decimals.
 # For now, we use the default vectorize setting for this query.
@@ -1065,11 +1059,9 @@ RESET vectorize;
 CREATE TABLE t44624(c0 STRING, c1 BOOL); INSERT INTO t44624(rowid, c0, c1) VALUES (0, '', true), (1, '', NULL);
 SET vectorize = experimental_always
 
-query TB rowsort
+# TODO(yuzefovich): #44700.
+statement error .* unsupported type string in CASE operator
 SELECT * FROM t44624 ORDER BY CASE WHEN c1 IS NULL THEN c0 WHEN true THEN c0 END
-----
-·  true
-·  NULL
 
 # Regression test for 44726 (unknown WHEN expression type).
 statement ok
@@ -1182,17 +1174,11 @@ SELECT b > now() - interval '1 day'  FROM mixed_type_a
 ----
 false
 
-# Merge join ON expressions also get wrapped.
-query ITITT
+statement error .* dates and timestamp\(tz\) not supported in mixed-type expressions in the vectorized engine
 SELECT * FROM mixed_type_a AS a INNER MERGE JOIN mixed_type_b AS b ON a.a = b.a AND a.b < (now() - b.b)
-----
-0  1970-01-01 00:00:00 +0000 UTC  0  00:00:00  1970-01-01 00:00:00 +0000 +0000
 
-# So do hash inner hash join ON expressions.
-query ITITT
+statement error .* dates and timestamp\(tz\) not supported in mixed-type expressions in the vectorized engine
 SELECT * FROM mixed_type_a AS a JOIN mixed_type_b AS b ON a.a = b.a AND a.b < (now() - b.b)
-----
-0  1970-01-01 00:00:00 +0000 UTC  0  00:00:00  1970-01-01 00:00:00 +0000 +0000
 
 # Regression for 46140.
 statement ok
@@ -1249,80 +1235,3 @@ query T
 SELECT c0 FROM t47715 ORDER by c1
 ----
 1819487610
-
-# Regression for flat bytes vector not being reset when it is reused by a
-# projecting operator. Interestingly, this query contains a subquery which is
-# handled as core.LocalPlanNode which we cannot wrap, so it cannot be run with
-# experimental_always setting. I'm not sure whether it serves the purpose with
-# which it was added, but we might as well keep the query.
-
-statement ok
-RESET vectorize
-
-query TTT
-WITH
-    with_194015 (col_1548014)
-        AS (
-            SELECT
-                *
-            FROM
-                (
-                    VALUES
-                        (('-28 years -2 mons -677 days -11:53:30.528699':::INTERVAL::INTERVAL + '11:55:41.419498':::TIME::TIME)::TIME + '1973-01-24':::DATE::DATE),
-                        ('1970-01-11 01:38:09.000155+00:00':::TIMESTAMP),
-                        ('1970-01-09 07:04:13.000247+00:00':::TIMESTAMP),
-                        ('1970-01-07 14:19:52.000951+00:00':::TIMESTAMP),
-                        (NULL)
-                )
-                    AS tab_240443 (col_1548014)
-        ),
-    with_194016 (col_1548015, col_1548016, col_1548017)
-        AS (
-            SELECT
-                *
-            FROM
-                (
-                    VALUES
-                        (
-                            '160.182.25.199/22':::INET::INET << 'c2af:30cb:5db8:bb79:4d11:2d0:1de8:bcea/59':::INET::INET,
-                            '09:14:05.761109':::TIME::TIME + '4 years 7 mons 345 days 23:43:13.325036':::INTERVAL::INTERVAL,
-                            B'0101010110101011101001111010100011001111001110001000101100011001101'
-                        ),
-                        (false, '14:36:41.282187':::TIME, B'011111111011001100000001101101011111110110010011110100110111100')
-                )
-                    AS tab_240444 (col_1548015, col_1548016, col_1548017)
-        ),
-    with_194017 (col_1548018)
-        AS (SELECT * FROM (VALUES ('43a30bc5-e412-426d-b99a-65783a7ed445':::UUID), (NULL), (crdb_internal.cluster_id()::UUID)) AS tab_240445 (col_1548018))
-SELECT
-    CASE
-    WHEN false THEN age('1970-01-09 08:48:24.000568+00:00':::TIMESTAMPTZ::TIMESTAMPTZ, '1970-01-07 08:40:45.000483+00:00':::TIMESTAMPTZ::TIMESTAMPTZ)::INTERVAL
-    ELSE (
-        (
-            (-0.02805450661234963150):::DECIMAL::DECIMAL
-            * array_position(
-                    (gen_random_uuid()::UUID::UUID || (NULL::UUID || NULL::UUID[])::UUID[])::UUID[],
-                    '5f29920d-7db1-4efc-b1cc-d1a7d0bcf145':::UUID::UUID
-                )::INT8::INT8
-        )::DECIMAL
-        * age('1970-01-04 07:17:45.000268+00:00':::TIMESTAMPTZ::TIMESTAMPTZ, NULL::TIMESTAMPTZ)::INTERVAL::INTERVAL
-    )
-    END::INTERVAL
-    + '-21 years -10 mons -289 days -13:27:05.205069':::INTERVAL::INTERVAL
-        AS col_1548019,
-    '1984-01-07':::DATE AS col_1548020,
-    'f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2':::UUID AS col_1548022
-FROM
-    with_194015
-ORDER BY
-    with_194015.col_1548014 DESC
-LIMIT
-    4:::INT8;
-----
-NULL  1984-01-07 00:00:00 +0000 +0000  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
-NULL  1984-01-07 00:00:00 +0000 +0000  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
-NULL  1984-01-07 00:00:00 +0000 +0000  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
-NULL  1984-01-07 00:00:00 +0000 +0000  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
-
-statement ok
-SET vectorize = experimental_always

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -189,3 +189,24 @@ query I
 SELECT _int2 * _int2 FROM ints WHERE _int4 + _int4 = _int8 + 2
 ----
 4
+
+# Check that joinReader core is wrapped into the plan when vectorize is set to
+# `experimental_always` - that core is the only exception to disabling of
+# wrapping.
+
+query T
+EXPLAIN (VEC) SELECT c.a FROM c JOIN d ON d.b = c.b
+----
+│
+└ Node 1
+  └ *rowexec.joinReader
+    └ *colfetcher.colBatchScan
+
+statement ok
+SET vectorize = experimental_always
+
+statement ok
+SELECT c.a FROM c JOIN d ON d.b = c.b
+
+statement ok
+RESET vectorize

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_unsupported
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_unsupported
@@ -1,0 +1,138 @@
+# LogicTest: local local-vec-auto fakedist fakedist-vec-auto-disk fakedist-disk
+
+statement ok
+CREATE TABLE a (a INT, b INT, c INT4, PRIMARY KEY (a, b));
+INSERT INTO a SELECT g//2, g, g FROM generate_series(0,2000) g(g)
+
+# Mismatched constant type in projection. Not handled yet but should fall back
+# gracefully.
+query I
+SELECT (a + 1.0::DECIMAL)::INT FROM a LIMIT 1
+----
+1
+
+# Mismatched column types in projection. Not handled yet but should fall back
+# gracefully.
+statement ok
+CREATE TABLE intdecfloat (a INT, b DECIMAL, c INT4, d INT2, e FLOAT8);
+INSERT INTO intdecfloat VALUES (1, 2.0, 3, 4, 3.5)
+
+query I
+SELECT (a + b)::INT FROM intdecfloat
+----
+3
+
+# Tests for #39417
+statement ok
+CREATE TABLE t39417 (x int8);
+INSERT INTO t39417 VALUES (10)
+
+query R
+select (x/1) from t39417
+----
+10
+
+# Regression test for CASE operator and flat bytes.
+statement ok
+CREATE TABLE t44624(c0 STRING, c1 BOOL); INSERT INTO t44624(rowid, c0, c1) VALUES (0, '', true), (1, '', NULL)
+
+query TB rowsort
+SELECT * FROM t44624 ORDER BY CASE WHEN c1 IS NULL THEN c0 WHEN true THEN c0 END
+----
+·  true
+·  NULL
+
+# Test that unsupported post process specs get wrapped in the vectorized engine.
+statement ok
+CREATE TABLE mixed_type_a (a INT, b TIMESTAMPTZ);
+CREATE TABLE mixed_type_b (a INT, b INTERVAL, c TIMESTAMP);
+INSERT INTO mixed_type_a VALUES (0, 0::TIMESTAMPTZ);
+INSERT INTO mixed_type_b VALUES (0, INTERVAL '0 days', 0::TIMESTAMP)
+
+query B
+SELECT b > now() - interval '1 day'  FROM mixed_type_a
+----
+false
+
+# Merge join ON expressions also get wrapped.
+query ITITT
+SELECT * FROM mixed_type_a AS a INNER MERGE JOIN mixed_type_b AS b ON a.a = b.a AND a.b < (now() - b.b)
+----
+0  1970-01-01 00:00:00 +0000 UTC  0  00:00:00  1970-01-01 00:00:00 +0000 +0000
+
+# So do hash inner hash join ON expressions.
+query ITITT
+SELECT * FROM mixed_type_a AS a JOIN mixed_type_b AS b ON a.a = b.a AND a.b < (now() - b.b)
+----
+0  1970-01-01 00:00:00 +0000 UTC  0  00:00:00  1970-01-01 00:00:00 +0000 +0000
+
+# Regression for flat bytes vector not being reset when it is reused by a
+# projecting operator. Interestingly, this query (originally placed in
+# 'vectorize' file) contains a subquery which is handled as core.LocalPlanNode
+# which we cannot wrap, so it cannot be run with experimental_always setting.
+# I'm not sure whether it serves the purpose with which it was added, but we
+# might as well keep the query.
+query TTT
+WITH
+    with_194015 (col_1548014)
+        AS (
+            SELECT
+                *
+            FROM
+                (
+                    VALUES
+                        (('-28 years -2 mons -677 days -11:53:30.528699':::INTERVAL::INTERVAL + '11:55:41.419498':::TIME::TIME)::TIME + '1973-01-24':::DATE::DATE),
+                        ('1970-01-11 01:38:09.000155+00:00':::TIMESTAMP),
+                        ('1970-01-09 07:04:13.000247+00:00':::TIMESTAMP),
+                        ('1970-01-07 14:19:52.000951+00:00':::TIMESTAMP),
+                        (NULL)
+                )
+                    AS tab_240443 (col_1548014)
+        ),
+    with_194016 (col_1548015, col_1548016, col_1548017)
+        AS (
+            SELECT
+                *
+            FROM
+                (
+                    VALUES
+                        (
+                            '160.182.25.199/22':::INET::INET << 'c2af:30cb:5db8:bb79:4d11:2d0:1de8:bcea/59':::INET::INET,
+                            '09:14:05.761109':::TIME::TIME + '4 years 7 mons 345 days 23:43:13.325036':::INTERVAL::INTERVAL,
+                            B'0101010110101011101001111010100011001111001110001000101100011001101'
+                        ),
+                        (false, '14:36:41.282187':::TIME, B'011111111011001100000001101101011111110110010011110100110111100')
+                )
+                    AS tab_240444 (col_1548015, col_1548016, col_1548017)
+        ),
+    with_194017 (col_1548018)
+        AS (SELECT * FROM (VALUES ('43a30bc5-e412-426d-b99a-65783a7ed445':::UUID), (NULL), (crdb_internal.cluster_id()::UUID)) AS tab_240445 (col_1548018))
+SELECT
+    CASE
+    WHEN false THEN age('1970-01-09 08:48:24.000568+00:00':::TIMESTAMPTZ::TIMESTAMPTZ, '1970-01-07 08:40:45.000483+00:00':::TIMESTAMPTZ::TIMESTAMPTZ)::INTERVAL
+    ELSE (
+        (
+            (-0.02805450661234963150):::DECIMAL::DECIMAL
+            * array_position(
+                    (gen_random_uuid()::UUID::UUID || (NULL::UUID || NULL::UUID[])::UUID[])::UUID[],
+                    '5f29920d-7db1-4efc-b1cc-d1a7d0bcf145':::UUID::UUID
+                )::INT8::INT8
+        )::DECIMAL
+        * age('1970-01-04 07:17:45.000268+00:00':::TIMESTAMPTZ::TIMESTAMPTZ, NULL::TIMESTAMPTZ)::INTERVAL::INTERVAL
+    )
+    END::INTERVAL
+    + '-21 years -10 mons -289 days -13:27:05.205069':::INTERVAL::INTERVAL
+        AS col_1548019,
+    '1984-01-07':::DATE AS col_1548020,
+    'f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2':::UUID AS col_1548022
+FROM
+    with_194015
+ORDER BY
+    with_194015.col_1548014 DESC
+LIMIT
+    4:::INT8;
+----
+NULL  1984-01-07 00:00:00 +0000 +0000  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
+NULL  1984-01-07 00:00:00 +0000 +0000  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
+NULL  1984-01-07 00:00:00 +0000 +0000  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
+NULL  1984-01-07 00:00:00 +0000 +0000  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -153,7 +153,7 @@ render                         ·             ·                                
 ·                              spans         FULL SCAN                                                                                                           ·                                                            ·
 
 query TTTTT
-EXPLAIN (TYPES,NONORMALIZE) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY k
+EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY k
 ----
 ·                    distribution  local                                                                                                             ·                                          ·
 ·                    vectorized    true                                                                                                              ·                                          ·

--- a/pkg/sql/sem/tree/eval_test/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test/eval_test.go
@@ -161,7 +161,7 @@ func TestEval(t *testing.T) {
 			inputTyps := []*types.T{types.Int}
 
 			batchesReturned := 0
-			args := colexec.NewColOperatorArgs{
+			args := &colexec.NewColOperatorArgs{
 				Spec: &execinfrapb.ProcessorSpec{
 					Input: []execinfrapb.InputSyncSpec{{
 						Type:        execinfrapb.InputSyncSpec_UNORDERED,


### PR DESCRIPTION
Depends on #50895.

**tree: minor clean up of explain**

NoNormalize explain option is not used anymore, so this commit removes
it. Additionally, we now treat `DEBUG` as a proper explain option.

Release note: None

**colexec: change the behavior of vectorize=experimental_always**

This commit changes the behavior of the planning when `vectorize` is set
to `experimental_always` - it now prohibits wrapping any processor cores
into the vectorized plan (with the only exception being
`core.JoinReader` for now since lookup and index joins are very popular
and have been the first ones to be wrapped).

There is no release note because the change is visible for the private
session variable value that we have mostly for internal purposes.

Release note: None