### PR TITLE
Makefile: fix vendor modvendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,7 +314,9 @@ $(call make-lazy,term-reset)
 # Force vendor directory to rebuild.
 .PHONY: vendor_rebuild
 vendor_rebuild: bin/.submodules-initialized
-	$(GO_INSTALL) -v github.com/goware/modvendor
+	# Use -mod=mod, as -mod=vendor will try install from the vendor directory
+	# which may be mismatching upon rebuild.
+	$(GO_INSTALL) -v -mod=mod github.com/goware/modvendor
 	./build/vendor_rebuild.sh
 
 # Tell Make to delete the target if its recipe fails. Otherwise, if a recipe


### PR DESCRIPTION
Since modvendor requires installation during vendor rebuilding, but a
dependency may have changed, `go mod` complains about inconsistent
versioning. To fix this, use -mod=mod when installing modvendor.

Release note: None