### PR TITLE
ui: add 30 minutes time range selector

### DIFF
--- a/pkg/ui/src/redux/timewindow.ts
+++ b/pkg/ui/src/redux/timewindow.ts
@@ -66,6 +66,11 @@ export let availableTimeScales: TimeScaleCollection = _.mapValues(
       windowValid: moment.duration(10, "seconds"),
       sampleSize: moment.duration(10, "seconds"),
     },
+    "Past 30 Minutes": {
+      windowSize: moment.duration(30, "minutes"),
+      windowValid: moment.duration(30, "seconds"),
+      sampleSize: moment.duration(30, "seconds"),
+    },
     "Past 1 Hour": {
       windowSize: moment.duration(1, "hour"),
       windowValid: moment.duration(1, "minute"),


### PR DESCRIPTION
Resolves #45440

Extends time range selector with 30 minutes option to provide more
granular predefined options.

Release note (admin ui change): Time range selector is extended with
30 minutes option (Metrics page)

<img width="883" alt="Screenshot 2020-06-30 at 10 01 51" src="https://user-images.githubusercontent.com/3106437/86096734-59b6ed80-babc-11ea-9ffe-19838b2d5afd.png">
